### PR TITLE
fix(update): robust git update handles diverged, dirty, non-master state

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -37,7 +37,49 @@ echo "Python version: $PYTHON_VERSION"
 if [ -d "$INSTALL_DIR/.git" ]; then
     echo "Updating TinyAgentOS..."
     cd "$INSTALL_DIR"
-    git pull --ff-only
+    # Robust update — handles non-master branch, dirty tree, diverged history.
+    # Every destructive step preceded by a recovery tag so nothing is lost silently.
+    if ! git fetch origin master; then
+        echo "WARNING: git fetch failed — cannot reach remote. Skipping update to avoid destroying local state."
+    else
+        _taos_ts=$(date +%s)
+        _taos_branch=$(git rev-parse --abbrev-ref HEAD)
+
+        # If on a non-master branch, tag and switch
+        if [ "$_taos_branch" != "master" ]; then
+            _taos_safe_branch=$(echo "$_taos_branch" | tr '/' '-')
+            _taos_branch_tag="taos-pre-update-${_taos_safe_branch}-${_taos_ts}"
+            git tag "$_taos_branch_tag" HEAD
+            echo "Tagged non-master branch tip as: $_taos_branch_tag"
+            git checkout master
+        fi
+
+        # Stash any dirty working tree (including untracked files)
+        _taos_stashed=0
+        if [ -n "$(git status --porcelain -u)" ]; then
+            _taos_stash_msg="taos-update-${_taos_ts}"
+            git stash push -u -m "$_taos_stash_msg"
+            _taos_stashed=1
+        fi
+
+        # Attempt fast-forward; on failure tag and hard-reset
+        if ! git merge --ff-only origin/master; then
+            _taos_short=$(git rev-parse --short HEAD)
+            _taos_recovery_tag="taos-pre-update-${_taos_short}-${_taos_ts}"
+            git tag "$_taos_recovery_tag" HEAD
+            echo "Diverged history detected. Local commits saved as tag: $_taos_recovery_tag"
+            git reset --hard origin/master
+        fi
+
+        # Restore stash if we saved one
+        if [ "$_taos_stashed" = "1" ]; then
+            if ! git stash pop; then
+                echo "WARNING: stash restore had conflicts. Your local changes are preserved in stash."
+                echo "  Use 'git stash list' to find them (look for message: $_taos_stash_msg)."
+                echo "  Apply manually with 'git stash pop' when ready."
+            fi
+        fi
+    fi
 else
     echo "Installing TinyAgentOS to $INSTALL_DIR..."
     git clone "$CATALOG_REPO" "$INSTALL_DIR"

--- a/tests/test_update_runner.py
+++ b/tests/test_update_runner.py
@@ -1,0 +1,220 @@
+"""Tests for tinyagentos.update_runner.
+
+Uses real git repos in tmpdir — no mocking of git itself.
+Each test builds an upstream bare repo + a local clone so origin is real.
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+# Skip the whole module if git is not available.
+if not shutil.which("git"):
+    pytest.skip("git not on PATH", allow_module_level=True)
+
+from tinyagentos.update_runner import update_to_master
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _git(args: list[str], cwd: Path, check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git"] + args,
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=check,
+    )
+
+
+def _configure_repo(repo: Path) -> None:
+    """Set user.name and user.email so commits don't fail in CI."""
+    _git(["config", "user.name", "Test User"], repo)
+    _git(["config", "user.email", "test@example.com"], repo)
+
+
+def _make_repos(tmp_path: Path) -> tuple[Path, Path]:
+    """Create a bare upstream and a local clone. Return (upstream, local)."""
+    upstream = tmp_path / "upstream.git"
+    upstream.mkdir()
+    # Force master as the default branch regardless of git global config.
+    _git(["init", "--bare", "-b", "master", str(upstream)], tmp_path)
+
+    # Seed upstream with an initial commit via a temp working tree
+    seed = tmp_path / "seed"
+    seed.mkdir()
+    _git(["clone", str(upstream), str(seed)], tmp_path)
+    _configure_repo(seed)
+    # Ensure we're on master (older git may still need explicit branch).
+    _git(["checkout", "-B", "master"], seed)
+    (seed / "README.md").write_text("initial\n")
+    _git(["add", "README.md"], seed)
+    _git(["commit", "-m", "init"], seed)
+    _git(["push", "-u", "origin", "master"], seed)
+
+    # Clone for the test subject
+    local = tmp_path / "local"
+    _git(["clone", str(upstream), str(local)], tmp_path)
+    _configure_repo(local)
+
+    return upstream, local
+
+
+def _add_remote_commit(upstream: Path, tmp_path: Path, filename: str = "remote.txt", content: str = "remote\n") -> None:
+    """Push a new commit to the bare upstream."""
+    helper = tmp_path / "helper"
+    if not helper.exists():
+        _git(["clone", str(upstream), str(helper)], tmp_path)
+        _configure_repo(helper)
+    else:
+        _git(["pull", "--ff-only"], helper)
+    (helper / filename).write_text(content)
+    _git(["add", filename], helper)
+    _git(["commit", "-m", f"add {filename}"], helper)
+    _git(["push", "origin", "master"], helper)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_clean_fast_forward(tmp_path: Path):
+    """Remote has 1 commit ahead, local on master clean — should FF cleanly."""
+    upstream, local = _make_repos(tmp_path)
+    _add_remote_commit(upstream, tmp_path)
+
+    result = await update_to_master(local)
+
+    expected_sha = subprocess.run(
+        ["git", "rev-parse", "origin/master"],
+        cwd=str(local), capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+    assert result.new_sha == expected_sha
+    assert result.recovery_tag is None
+    assert result.stash_ref is None
+    assert result.stash_restored is False
+    assert result.branch_tag is None
+    assert "Updated" in result.message
+
+
+@pytest.mark.asyncio
+async def test_non_master_branch(tmp_path: Path):
+    """Local on feature/foo, remote ahead — should tag branch and switch to master."""
+    upstream, local = _make_repos(tmp_path)
+
+    # Create and switch to a feature branch
+    _git(["checkout", "-b", "feature/foo"], local)
+    _add_remote_commit(upstream, tmp_path)
+
+    result = await update_to_master(local)
+
+    # Should have created a branch tag matching the pattern
+    assert result.branch_tag is not None
+    assert result.branch_tag.startswith("taos-pre-update-feature-foo-")
+
+    # HEAD should now be on master at origin/master
+    branch_out = subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        cwd=str(local), capture_output=True, text=True, check=True
+    ).stdout.strip()
+    assert branch_out == "master"
+
+    expected_sha = subprocess.run(
+        ["git", "rev-parse", "origin/master"],
+        cwd=str(local), capture_output=True, text=True, check=True
+    ).stdout.strip()
+    assert result.new_sha == expected_sha
+
+    # Tag must exist in the repo
+    tags = subprocess.run(
+        ["git", "tag", "-l", result.branch_tag],
+        cwd=str(local), capture_output=True, text=True, check=True
+    ).stdout.strip()
+    assert tags == result.branch_tag
+
+
+@pytest.mark.asyncio
+async def test_dirty_working_tree(tmp_path: Path):
+    """Dirty tracked file — should stash, FF, then restore the change."""
+    upstream, local = _make_repos(tmp_path)
+    _add_remote_commit(upstream, tmp_path, filename="other.txt")
+
+    # Dirty the working tree (different file from remote commit)
+    (local / "README.md").write_text("local tweak\n")
+
+    result = await update_to_master(local)
+
+    assert result.stash_ref is not None
+    assert result.stash_restored is True
+    assert result.recovery_tag is None
+    # The local edit should be back on disk
+    assert (local / "README.md").read_text() == "local tweak\n"
+    assert "Local changes restored from stash" in result.message
+
+
+@pytest.mark.asyncio
+async def test_diverged_history(tmp_path: Path):
+    """Local has an extra commit, remote also has a different commit — should tag and hard-reset."""
+    upstream, local = _make_repos(tmp_path)
+
+    # Local commit (diverge)
+    (local / "local_only.txt").write_text("local commit\n")
+    _git(["add", "local_only.txt"], local)
+    _git(["commit", "-m", "local diverge"], local)
+    local_diverged_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=str(local), capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+    # Remote commit (different history)
+    _add_remote_commit(upstream, tmp_path, filename="remote_only.txt")
+
+    result = await update_to_master(local)
+
+    assert result.recovery_tag is not None
+    assert result.recovery_tag.startswith("taos-pre-update-")
+
+    # HEAD should be at origin/master
+    expected_sha = subprocess.run(
+        ["git", "rev-parse", "origin/master"],
+        cwd=str(local), capture_output=True, text=True, check=True
+    ).stdout.strip()
+    assert result.new_sha == expected_sha
+
+    # The recovery tag must point to the old local sha
+    tag_sha = subprocess.run(
+        ["git", "rev-parse", result.recovery_tag],
+        cwd=str(local), capture_output=True, text=True, check=True
+    ).stdout.strip()
+    assert tag_sha == local_diverged_sha
+
+
+@pytest.mark.asyncio
+async def test_stash_restore_conflict(tmp_path: Path):
+    """Local edit conflicts with incoming change — stash pop should fail gracefully."""
+    upstream, local = _make_repos(tmp_path)
+
+    # Both local and remote edit the same lines of README.md
+    (local / "README.md").write_text("local version\n")
+    _add_remote_commit(upstream, tmp_path, filename="README.md", content="remote version\n")
+
+    result = await update_to_master(local)
+
+    # Stash pop should have failed — stash preserved, not restored
+    assert result.stash_ref is not None
+    assert result.stash_restored is False
+    assert "stash" in result.message.lower()
+
+    # Stash must still be listed
+    stash_list = subprocess.run(
+        ["git", "stash", "list"],
+        cwd=str(local), capture_output=True, text=True, check=True
+    ).stdout
+    assert "taos-update-" in stash_list

--- a/tinyagentos/auto_update.py
+++ b/tinyagentos/auto_update.py
@@ -170,13 +170,22 @@ class AutoUpdateService:
 
     async def _auto_apply(self, new_commit: str) -> None:
         """Pull + install + notify restart needed."""
+        from tinyagentos.update_runner import update_to_master
+
         logger.info("Auto-applying update to %s", new_commit[:7])
 
-        rc, out = await _run(
-            ["git", "pull", "--ff-only", "origin", "master"], self._project_dir
-        )
-        if rc != 0:
-            logger.error("auto-update pull failed: %s", out[:500])
+        result = await update_to_master(self._project_dir)
+
+        # If fetch failed, new_sha will be empty and previous_sha will also be
+        # empty — surface the error and bail without running pip.
+        if not result.new_sha:
+            logger.error("auto-update failed: %s", result.message)
+            await self._notif.emit_event(
+                event_type="system.update",
+                title="taOS update failed",
+                message=result.message,
+                level="error",
+            )
             return
 
         pip_cmd = str(Path(sys.executable).parent / "pip")
@@ -194,7 +203,7 @@ class AutoUpdateService:
             await self._notif.emit_event(
                 event_type="system.update",
                 title="taOS updated automatically",
-                message=f"Pulled {new_commit[:7]}. Restart the server to finish applying.",
+                message=result.message,
                 level="info",
             )
 

--- a/tinyagentos/update_runner.py
+++ b/tinyagentos/update_runner.py
@@ -1,0 +1,157 @@
+"""Robust git update helper for taOS.
+
+Replaces a bare ``git pull --ff-only`` with a sequence that handles the four
+real-world failure modes without silently discarding local work:
+
+1. HEAD not on master  — tags the branch tip and checks out master first.
+2. Dirty working tree  — stashes (including untracked files) before merging,
+   then attempts to restore after.
+3. Diverged history    — tags local HEAD, hard-resets to origin/master.
+4. Network failure     — returns early before any destructive action.
+
+Every destructive step is preceded by a recovery tag so the user can always
+``git checkout taos-pre-update-…`` to recover.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class UpdateResult:
+    previous_sha: str
+    new_sha: str
+    recovery_tag: Optional[str] = None
+    stash_ref: Optional[str] = None
+    stash_restored: bool = False
+    branch_tag: Optional[str] = None
+    message: str = ""
+
+
+async def _run(args: list[str], cwd: Path) -> tuple[int, str]:
+    """Run a subprocess safely (no shell) and return (returncode, output)."""
+    proc = await asyncio.create_subprocess_exec(
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+        cwd=str(cwd),
+    )
+    stdout, _ = await proc.communicate()
+    return proc.returncode or 0, (stdout.decode() if stdout else "")
+
+
+async def update_to_master(project_dir: Path) -> UpdateResult:
+    """Pull origin/master robustly, handling dirty trees, branches, and divergence.
+
+    Returns an UpdateResult describing what happened. On network failure the
+    result carries a descriptive message and no destructive action has been taken.
+    """
+    ts = int(time.time())
+
+    # 1. Fetch — bail early if unreachable so we never destroy local state
+    logger.info("update_runner: fetching origin/master")
+    rc, out = await _run(["git", "fetch", "origin", "master"], project_dir)
+    if rc != 0:
+        logger.warning("update_runner: fetch failed: %s", out[:500])
+        return UpdateResult(
+            previous_sha="",
+            new_sha="",
+            message=f"Fetch failed — no changes applied. ({out.strip()[:200]})",
+        )
+
+    # 2. Probe current state
+    _, branch_out = await _run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"], project_dir
+    )
+    branch = branch_out.strip()
+
+    _, sha_out = await _run(["git", "rev-parse", "HEAD"], project_dir)
+    current_sha = sha_out.strip()
+    short_sha = current_sha[:7]
+
+    # Use -u so untracked files also trigger a stash (matches git stash -u).
+    _, status_out = await _run(
+        ["git", "status", "--porcelain", "-u"], project_dir
+    )
+    dirty = bool(status_out.strip())
+
+    result = UpdateResult(previous_sha=current_sha, new_sha=current_sha)
+
+    # 3. Switch to master if on another branch
+    if branch != "master":
+        safe_branch = branch.replace("/", "-")
+        branch_tag = f"taos-pre-update-{safe_branch}-{ts}"
+        logger.info("update_runner: not on master (%s); tagging as %s", branch, branch_tag)
+        await _run(["git", "tag", branch_tag, "HEAD"], project_dir)
+        await _run(["git", "checkout", "master"], project_dir)
+        result.branch_tag = branch_tag
+
+    # 4. Stash dirty working tree
+    stash_msg = f"taos-update-{ts}"
+    if dirty:
+        logger.info("update_runner: stashing dirty working tree as '%s'", stash_msg)
+        await _run(
+            ["git", "stash", "push", "-u", "-m", stash_msg], project_dir
+        )
+        result.stash_ref = "stash@{0}"
+
+    # 5. Attempt fast-forward merge
+    logger.info("update_runner: attempting ff-only merge")
+    rc_merge, merge_out = await _run(
+        ["git", "merge", "--ff-only", "origin/master"], project_dir
+    )
+
+    # 6. Diverged — tag local HEAD then hard-reset
+    if rc_merge != 0:
+        recovery_tag = f"taos-pre-update-{short_sha}-{ts}"
+        logger.info(
+            "update_runner: diverged; tagging %s as %s then hard-resetting",
+            short_sha,
+            recovery_tag,
+        )
+        await _run(["git", "tag", recovery_tag, "HEAD"], project_dir)
+        await _run(["git", "reset", "--hard", "origin/master"], project_dir)
+        result.recovery_tag = recovery_tag
+
+    # 7. Stash restore (best-effort)
+    if result.stash_ref:
+        logger.info("update_runner: restoring stash")
+        rc_pop, pop_out = await _run(["git", "stash", "pop"], project_dir)
+        if rc_pop == 0:
+            result.stash_restored = True
+        else:
+            logger.warning(
+                "update_runner: stash pop had conflicts — leaving stash in place. %s",
+                pop_out[:300],
+            )
+            # Do NOT drop the stash on conflict.
+
+    # 8. Record new sha and build human-readable summary
+    _, new_sha_out = await _run(["git", "rev-parse", "HEAD"], project_dir)
+    result.new_sha = new_sha_out.strip()
+
+    parts: list[str] = [
+        f"Updated {result.previous_sha[:7]} -> {result.new_sha[:7]}."
+    ]
+    if result.branch_tag:
+        parts.append(f"Previous branch tip saved as tag '{result.branch_tag}'.")
+    if result.recovery_tag:
+        parts.append(f"Diverged commits saved as tag '{result.recovery_tag}'.")
+    if result.stash_ref and not result.stash_restored:
+        parts.append(
+            f"Your local changes are preserved in stash (use `git stash list` to find it,"
+            f" message: '{stash_msg}')."
+        )
+    elif result.stash_ref and result.stash_restored:
+        parts.append("Local changes restored from stash.")
+
+    result.message = " ".join(parts)
+    logger.info("update_runner: done — %s", result.message)
+    return result


### PR DESCRIPTION
Closes #228.

## Summary
- New `tinyagentos/update_runner.py` with `update_to_master()` — fetches, tags HEAD before every destructive step, stashes dirty trees, switches off non-master branches, and hard-resets on divergence.
- `auto_update.py` `_auto_apply` now uses it and surfaces the recovery tag / stash message in the success/failure notification.
- `install.sh` has an inline shell equivalent for the curl-install update path.
- `tests/test_update_runner.py` covers clean FF, non-master branch, dirty tree, diverged history, and stash-pop conflict using real git repos in tmpdir.

## Test plan
- [x] `pytest tests/test_update_runner.py -v` → 5/5 pass
- [x] `bash -n install.sh` → syntax ok
- [x] Import smoke test for `AutoUpdateService` + `update_to_master`

## Recovery behaviour
Every destructive step is preceded by a `taos-pre-update-…` tag. On stash-pop conflict the stash is left in place and the user is told exactly which stash to pop.