### PR TITLE
fix(pwa): self-unregister legacy SW, add cache headers on /static

### DIFF
--- a/static/sw.js
+++ b/static/sw.js
@@ -20,8 +20,6 @@ self.addEventListener('activate', (event) => {
         await Promise.all(keys.map((k) => caches.delete(k)));
         await self.registration.unregister();
         const clients = await self.clients.matchAll({ includeUncontrolled: true });
-        for (const client of clients) {
-            client.navigate(client.url);
-        }
+        await Promise.all(clients.map((client) => client.navigate(client.url)));
     })());
 });

--- a/static/sw.js
+++ b/static/sw.js
@@ -1,56 +1,27 @@
-const CACHE_NAME = 'taos-v3-onboarding';
-const OFFLINE_URL = '/offline';
-
-// Assets to pre-cache
-const PRE_CACHE = [
-    '/offline',
-    '/static/app.css',
-    'https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css',
-    'https://unpkg.com/htmx.org@2.0.4',
-];
-
-self.addEventListener('install', (event) => {
-    event.waitUntil(
-        caches.open(CACHE_NAME).then((cache) => cache.addAll(PRE_CACHE))
-    );
+// Legacy self-unregistering service worker.
+//
+// An earlier taOS release (HTMX/Jinja2 era, removed in 95651bd) registered
+// this service worker with a cache-first strategy for /static/*. The new
+// React SPA does not register a service worker, but browsers that visited
+// the old app still have this SW active — silently intercepting requests
+// and serving pinned cache entries long after the code on disk has moved on.
+//
+// This replacement body tears itself down: it deletes every cache it owns
+// and unregisters itself on next install/activate. After one PWA launch
+// against this script, the browser is back to plain HTTP caching and picks
+// up fresh content normally.
+self.addEventListener('install', () => {
     self.skipWaiting();
 });
 
 self.addEventListener('activate', (event) => {
-    event.waitUntil(
-        caches.keys().then((keys) =>
-            Promise.all(keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k)))
-        )
-    );
-    self.clients.claim();
-});
-
-self.addEventListener('fetch', (event) => {
-    // Only handle GET requests
-    if (event.request.method !== 'GET') return;
-
-    // For navigation requests, try network first, fall back to offline page
-    if (event.request.mode === 'navigate') {
-        event.respondWith(
-            fetch(event.request).catch(() => caches.match(OFFLINE_URL))
-        );
-        return;
-    }
-
-    // For static assets, try cache first, then network
-    if (event.request.url.includes('/static/') || event.request.url.includes('cdn.jsdelivr') || event.request.url.includes('unpkg.com')) {
-        event.respondWith(
-            caches.match(event.request).then((cached) => {
-                return cached || fetch(event.request).then((response) => {
-                    const clone = response.clone();
-                    caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
-                    return response;
-                });
-            })
-        );
-        return;
-    }
-
-    // For API requests, always try network
-    event.respondWith(fetch(event.request));
+    event.waitUntil((async () => {
+        const keys = await caches.keys();
+        await Promise.all(keys.map((k) => caches.delete(k)));
+        await self.registration.unregister();
+        const clients = await self.clients.matchAll({ includeUncontrolled: true });
+        for (const client of clients) {
+            client.navigate(client.url);
+        }
+    })());
 });

--- a/tests/test_static_cache_headers.py
+++ b/tests/test_static_cache_headers.py
@@ -16,6 +16,10 @@ def static_app(tmp_path):
     (tmp_path / "sw.js").write_text("// stub")
     (tmp_path / "icon-192.png").write_bytes(b"\x89PNG\r\n\x1a\n")
 
+    unrelated = tmp_path / "store-icons"
+    unrelated.mkdir()
+    (unrelated / "app-with-manifest-in-name.json").write_text("{}")
+
     app = FastAPI()
     app.mount("/static", _CacheAwareStaticFiles(directory=str(tmp_path)), name="static")
     return TestClient(app)
@@ -45,3 +49,11 @@ def test_icon_cacheable(static_app):
     assert r.status_code == 200
     assert "public" in r.headers["cache-control"]
     assert "max-age" in r.headers["cache-control"]
+
+
+def test_unrelated_json_with_manifest_in_path_is_cacheable(static_app):
+    # A JSON file whose filename doesn't start with "manifest" should not
+    # be no-cache'd just because "manifest" appears elsewhere.
+    r = static_app.get("/static/store-icons/app-with-manifest-in-name.json")
+    assert r.status_code == 200
+    assert "no-cache" not in r.headers["cache-control"]

--- a/tests/test_static_cache_headers.py
+++ b/tests/test_static_cache_headers.py
@@ -1,0 +1,47 @@
+"""Tests for _CacheAwareStaticFiles — ensures index.html, manifests, and
+sw.js never cache, so installed PWAs pick up rebuilds."""
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tinyagentos.app import _CacheAwareStaticFiles
+
+
+@pytest.fixture
+def static_app(tmp_path):
+    (tmp_path / "index.html").write_text("<html></html>")
+    (tmp_path / "manifest-desktop.json").write_text("{}")
+    (tmp_path / "sw.js").write_text("// stub")
+    (tmp_path / "icon-192.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    app = FastAPI()
+    app.mount("/static", _CacheAwareStaticFiles(directory=str(tmp_path)), name="static")
+    return TestClient(app)
+
+
+def test_html_never_cached(static_app):
+    r = static_app.get("/static/index.html")
+    assert r.status_code == 200
+    assert "no-cache" in r.headers["cache-control"]
+    assert "no-store" in r.headers["cache-control"]
+
+
+def test_manifest_never_cached(static_app):
+    r = static_app.get("/static/manifest-desktop.json")
+    assert r.status_code == 200
+    assert "no-cache" in r.headers["cache-control"]
+
+
+def test_sw_never_cached(static_app):
+    r = static_app.get("/static/sw.js")
+    assert r.status_code == 200
+    assert "no-cache" in r.headers["cache-control"]
+
+
+def test_icon_cacheable(static_app):
+    r = static_app.get("/static/icon-192.png")
+    assert r.status_code == 200
+    assert "public" in r.headers["cache-control"]
+    assert "max-age" in r.headers["cache-control"]

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -23,10 +23,14 @@ class _CacheAwareStaticFiles(StaticFiles):
 
     async def get_response(self, path, scope):
         response = await super().get_response(path, scope)
-        lowered = path.lower()
+        filename = path.rsplit("/", 1)[-1].lower()
+        is_manifest_json = (
+            filename.startswith("manifest") and filename.endswith(".json")
+        )
         if (
-            lowered.endswith((".html", ".webmanifest", "sw.js"))
-            or ("manifest" in lowered and lowered.endswith(".json"))
+            filename.endswith((".html", ".webmanifest"))
+            or filename == "sw.js"
+            or is_manifest_json
         ):
             response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
         else:

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -12,6 +12,29 @@ from fastapi import FastAPI
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.staticfiles import StaticFiles
 
+
+class _CacheAwareStaticFiles(StaticFiles):
+    """StaticFiles that sets Cache-Control by file type.
+
+    index.html / manifests / the legacy sw.js must always revalidate so
+    PWAs pick up rebuilds; everything else under /static/ is fingerprinted
+    or static-forever (icons, wallpaper) and is safe to cache a long time.
+    """
+
+    async def get_response(self, path, scope):
+        response = await super().get_response(path, scope)
+        lowered = path.lower()
+        if (
+            lowered.endswith((".html", ".webmanifest", "sw.js"))
+            or ("manifest" in lowered and lowered.endswith(".json"))
+        ):
+            response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
+        else:
+            response.headers.setdefault(
+                "Cache-Control", "public, max-age=86400"
+            )
+        return response
+
 from tinyagentos.auth import AuthManager
 from tinyagentos.backend_fallback import BackendFallback
 from tinyagentos.capabilities import CapabilityChecker
@@ -620,7 +643,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     # Mount static files
     static_dir = PROJECT_DIR / "static"
     if static_dir.exists():
-        app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
+        app.mount("/static", _CacheAwareStaticFiles(directory=str(static_dir)), name="static")
 
     # Mount workspace for serving generated images and other workspace files
     workspace_dir = data_dir / "workspace"


### PR DESCRIPTION
Follow-up: Jay's installed PWA kept showing pre-#229 UI even after the Pi was updated.

## Root cause
Two gaps:
1. **Orphan service worker.** `static/sw.js` was registered by the HTMX/Jinja2 app (removed in commit 95651bd) with a cache-first strategy on `/static/*`. Any browser that visited the old app still has it active, intercepting requests forever.
2. **No Cache-Control on /static mount.** `tinyagentos/app.py` mounted `/static` with vanilla `StaticFiles`, so `index.html`, `manifest-*.json`, and `sw.js` itself were served with only `ETag`/`Last-Modified` — heuristic caching kicked in.

## Fix
- `static/sw.js` → self-unregister stub: deletes every cache, `self.registration.unregister()`, navigates controlled clients to reload cleanly.
- `tinyagentos/app.py` → `_CacheAwareStaticFiles` wrapper: `no-cache, no-store, must-revalidate` for HTML/manifests/sw.js; `public, max-age=86400` for everything else (icons, wallpapers).
- `tests/test_static_cache_headers.py` verifies both behaviours.

## One-time action for existing users
After this lands, PWAs still running the old SW will self-heal on next launch (SW activate → clears caches → unregisters → reload). If you've killed the PWA before that chance, uninstall + reinstall.

## Test plan
- [x] `pytest tests/test_static_cache_headers.py` → 4/4 pass
- [x] Import smoke test