### PR TITLE
feat: Gitea LXC install + cross-arch state-path migration (Pi ⇆ Fedora)

### DIFF
--- a/app-catalog/catalog.yaml
+++ b/app-catalog/catalog.yaml
@@ -568,6 +568,12 @@ apps:
     version: 1.22.0
     name: Gitea
     description: "Self-hosted Git server with agent access"
+  - id: gitea-lxc
+    type: service
+    category: dev-tool
+    version: 1.22.0
+    name: Gitea (LXC)
+    description: "Self-hosted Git server in an isolated LXC container"
   - id: code-server
     type: dev-tool
     version: 4.96.0

--- a/app-catalog/services/gitea-lxc/manifest.yaml
+++ b/app-catalog/services/gitea-lxc/manifest.yaml
@@ -32,6 +32,14 @@ install:
   state_paths:
     - /etc/gitea/
     - /home/git/
+  # Proxy routing fields (read by the service-proxy layer):
+  #   ui_port  – container-internal port the UI listens on. The installer's
+  #               proxy device forwards host_port → 127.0.0.1:<ui_port>.
+  #   ui_path  – path prefix the app serves its UI at (default "/").
+  #   icon     – optional icon path or URL for desktop/P8 use.
+  #   display_name – optional override for the UI display name.
+  ui_port: 3000
+  ui_path: "/"
 
 lifecycle:
   health_check: "curl -sf http://localhost:3000/api/healthz"

--- a/app-catalog/services/gitea-lxc/manifest.yaml
+++ b/app-catalog/services/gitea-lxc/manifest.yaml
@@ -1,5 +1,5 @@
-id: gitea
-name: Gitea
+id: gitea-lxc
+name: Gitea (LXC)
 type: service
 category: dev-tool
 version: 1.22.0
@@ -28,12 +28,10 @@ install:
   ports:
     http: 3000
     ssh: 2222
-
-service_name: gitea
-
-state_paths:
-  - /etc/gitea/
-  - /home/git/
+  service_name: gitea
+  state_paths:
+    - /etc/gitea/
+    - /home/git/
 
 lifecycle:
   health_check: "curl -sf http://localhost:3000/api/healthz"

--- a/app-catalog/services/gitea/manifest-lxc.yaml
+++ b/app-catalog/services/gitea/manifest-lxc.yaml
@@ -29,6 +29,12 @@ install:
     http: 3000
     ssh: 2222
 
+service_name: gitea
+
+state_paths:
+  - /etc/gitea/
+  - /home/git/
+
 lifecycle:
   health_check: "curl -sf http://localhost:3000/api/healthz"
 

--- a/app-catalog/services/gitea/manifest-lxc.yaml
+++ b/app-catalog/services/gitea/manifest-lxc.yaml
@@ -1,0 +1,40 @@
+id: gitea
+name: Gitea
+type: service
+category: dev-tool
+version: 1.22.0
+backend: lxc
+description: "Self-hosted Git server — auto-creates accounts for deployed agents"
+homepage: https://gitea.io
+license: MIT
+
+requires:
+  ram_mb: 512
+  disk_mb: 2000
+  ports: [3000, 2222]
+  inputs:
+    - name: admin_password
+      label: "Admin password"
+      type: password
+      required: true
+      description: "Password for the initial Gitea admin account"
+
+install:
+  method: lxc
+  image: images:debian/bookworm
+  gitea_version: "1.22.6"
+  memory_limit: "512MiB"
+  cpu_limit: 1
+  ports:
+    http: 3000
+    ssh: 2222
+
+lifecycle:
+  health_check: "curl -sf http://localhost:3000/api/healthz"
+
+hardware_tiers:
+  arm-npu-16gb: full
+  arm-npu-32gb: full
+  x86-cuda-12gb: full
+  x86-vulkan-8gb: full
+  cpu-only: full

--- a/docs/runbooks/lxc-migration-gitea.md
+++ b/docs/runbooks/lxc-migration-gitea.md
@@ -164,6 +164,58 @@ If a migration fails mid-way:
 - The state tarball on the controller host is always cleaned up, success
   or failure.
 
+## Stable service URLs via `/apps/{app_id}/`
+
+After install or migration, every service has a stable proxy URL on the
+controller:
+
+```
+http://localhost:6969/apps/gitea-lxc/
+```
+
+The controller reverse-proxies this URL to whatever host:port currently runs
+the service. The runtime location is stored in `InstalledAppsStore`
+(`app_runtime` table) and is updated automatically on install and migration.
+
+### How it works
+
+- **Install**: after the LXC installer returns `host_port`, the install route
+  calls `installed_apps.update_runtime_location(app_id, host, port)`.
+  - Local install → host is `127.0.0.1` (the proxy device listens on 0.0.0.0
+    locally, so 127.0.0.1 always reaches it from the controller).
+  - Remote install → host is parsed from the registered incus remote URL
+    (`https://<host>:8443`).
+- **Migration**: the migrate-service route calls `update_runtime_location`
+  after a successful `migrate_service()`, pointing the entry at the new
+  target host. The URL `/apps/gitea-lxc/` immediately routes to the
+  new location without any manual intervention.
+
+### Checking the current runtime location
+
+```bash
+# After install, inspect the running proxy:
+curl -I http://localhost:6969/apps/gitea-lxc/
+# Should return Gitea's HTTP response regardless of which host it lives on.
+
+# After migration to fedora-worker, the same URL continues to work;
+# the controller routes transparently to the worker's host:port.
+```
+
+### Location header rewriting
+
+If Gitea (or any other service) redirects internally with an absolute
+`Location: http://<host>:<port>/some-path` header, the proxy rewrites it to
+`/apps/gitea-lxc/some-path` so the browser stays within the stable URL
+namespace. Relative `Location` headers pass through unchanged.
+
+### Generality
+
+The `/apps/{app_id}/` proxy is fully generic — it reads `runtime_host` and
+`runtime_port` from the store and proxies any HTTP method. Gitea is the first
+service to use it but every future LXC/Docker service installs into the same
+slot. The `ui_path` field in the manifest's `install` block (`default: "/"`)
+can be set to the sub-path the service actually serves from if needed.
+
 ## What this proves
 
 - The LXC install path works end-to-end (container creation → Gitea

--- a/docs/runbooks/lxc-migration-gitea.md
+++ b/docs/runbooks/lxc-migration-gitea.md
@@ -61,7 +61,7 @@ curl -X POST http://localhost:6969/api/store/install-v2 \
     "app_id": "gitea-lxc",
     "admin_password": "<pick-a-strong-password>",
     "taos_username": "jay",
-    "taos_email": "jaylfc25@gmail.com",
+    "taos_email": "user@example.com",
     "metadata": {"backend": "lxc"}
   }'
 ```

--- a/docs/runbooks/lxc-migration-gitea.md
+++ b/docs/runbooks/lxc-migration-gitea.md
@@ -1,0 +1,148 @@
+# LXC Migration — Gitea Pi ⇆ Fedora Worker
+
+**Goal:** install Gitea as an LXC service on the Orange Pi, move its container
+to the Fedora worker, verify it still serves, then move it back.
+
+This is the end-to-end validation for the store's LXC install path and the
+incus cross-host migration feature.
+
+## Pre-flight (one-time)
+
+Both hosts need incus installed and reachable on the LAN, plus TLS trust
+between them.
+
+On **both** hosts:
+
+```bash
+incus --version   # must be present; any recent release is fine
+```
+
+On the **target** host (Fedora worker), configure incus to listen on the LAN
+and set a trust password:
+
+```bash
+incus config set core.https_address :8443
+incus config set core.trust_password '<temporary-trust-password>'
+```
+
+The trust password is consumed once per remote registration and cleared
+after, so a short-lived value is fine.
+
+## Procedure
+
+### 1. Register the Fedora worker as an incus remote on the Pi
+
+```bash
+# on the Pi (jay@orangepi5-plus)
+curl -X POST http://localhost:6969/api/cluster/remotes \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "name": "fedora-worker",
+    "url": "https://<fedora-worker-host>:8443",
+    "trust_password": "<temporary-trust-password>"
+  }'
+
+# verify
+curl http://localhost:6969/api/cluster/remotes
+```
+
+### 2. Install Gitea via the LXC path
+
+Use the store UI or POST directly:
+
+```bash
+curl -X POST http://localhost:6969/api/store/install-v2 \
+  -H 'Content-Type: application/json' \
+  -b 'taos_session=<your-session-cookie>' \
+  -d '{
+    "app_id": "gitea-lxc",
+    "admin_password": "<pick-a-strong-password>"
+  }'
+```
+
+Wait for the response — install takes 2-3 minutes (incus launch + apt
+install + Gitea download). Response includes `host_port` used for the
+proxy device.
+
+Verify Gitea responds:
+
+```bash
+curl -I http://localhost:<host_port>/
+# expect: HTTP/1.1 200 OK
+```
+
+Log in via the browser at `http://<pi-host>:<host_port>/` using your taOS
+username and the admin password from step 2.
+
+### 3. Migrate container to the Fedora worker
+
+```bash
+curl -X POST http://localhost:6969/api/cluster/migrate \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "container": "taos-svc-gitea-lxc",
+    "target_remote": "fedora-worker",
+    "keep_source": false,
+    "stateless": true
+  }'
+```
+
+This stops the container on the Pi, copies it across the LAN, and starts it
+on the Fedora worker. Expect a few minutes for the copy.
+
+Verify it's running on the target:
+
+```bash
+# on the Fedora worker
+incus list taos-svc-gitea-lxc
+# Status: RUNNING
+```
+
+And that Gitea still serves. The proxy device follows the container, so the
+same port works on the new host:
+
+```bash
+curl -I http://<fedora-worker-host>:<host_port>/
+# expect: HTTP/1.1 200 OK
+```
+
+Log in and spot-check that your user account and any repos are intact —
+state lives in the container's `/home/git/` and moved with it.
+
+### 4. Migrate back to the Pi
+
+Before moving back, add the Pi as a remote on the Fedora worker (mirror of
+step 1 but in reverse). Then from the Fedora worker:
+
+```bash
+curl -X POST http://<fedora-worker-host>:6969/api/cluster/migrate \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "container": "taos-svc-gitea-lxc",
+    "target_remote": "orangepi",
+    "keep_source": false,
+    "stateless": true
+  }'
+```
+
+Verify Gitea responds on the Pi again, and the admin user still works.
+
+## Recovery
+
+If a migration fails mid-way:
+
+- The `migrate_container` helper restarts the source container automatically
+  if the copy/move step failed after the stop.
+- If the target has a half-copied container, `incus delete <remote>:<name>
+  --force` cleans it up.
+- A pre-stop snapshot is created best-effort on the source; `incus snapshot
+  restore <name> pre-migrate-<ts>` rolls it back if needed.
+
+## What this proves
+
+- The LXC install path works end-to-end (container creation → Gitea install →
+  admin seeding → proxy device → real HTTP traffic).
+- `incus copy`/`incus move` across trusted remotes preserves all container
+  state (rootfs, config, installed packages, SQLite DB).
+- Proxy devices survive the move, so the same user-facing URL stays valid
+  after a host change.

--- a/docs/runbooks/lxc-migration-gitea.md
+++ b/docs/runbooks/lxc-migration-gitea.md
@@ -1,148 +1,174 @@
 # LXC Migration — Gitea Pi ⇆ Fedora Worker
 
-**Goal:** install Gitea as an LXC service on the Orange Pi, move its container
-to the Fedora worker, verify it still serves, then move it back.
+**Goal:** install Gitea as an LXC service on the Orange Pi, move it to the
+Fedora worker, verify it still serves, then move it back. The round-trip
+works across architectures (aarch64 ↔ x86_64) because the migration is
+**state-path based** — only `/etc/gitea/` and `/home/git/` travel; the
+Gitea binary is reinstalled fresh on the target host with the correct
+architecture.
 
-This is the end-to-end validation for the store's LXC install path and the
-incus cross-host migration feature.
+This is the end-to-end validation for the store's LXC install path and
+`migrate_service()`.
 
-## Pre-flight (one-time)
+## Pre-flight (one-time per host pair)
 
-Both hosts need incus installed and reachable on the LAN, plus TLS trust
-between them.
+Both hosts need incus installed. The target host also needs incus listening
+on the LAN so the controller can reach it.
 
-On **both** hosts:
-
-```bash
-incus --version   # must be present; any recent release is fine
-```
-
-On the **target** host (Fedora worker), configure incus to listen on the LAN
-and set a trust password:
+On the **target** host (worker), enable the incus HTTPS listener:
 
 ```bash
 incus config set core.https_address :8443
-incus config set core.trust_password '<temporary-trust-password>'
+# Confirm
+ss -ltn | grep 8443
 ```
 
-The trust password is consumed once per remote registration and cleared
-after, so a short-lived value is fine.
-
-## Procedure
-
-### 1. Register the Fedora worker as an incus remote on the Pi
+Then generate an enrollment token for the controller (run on the worker):
 
 ```bash
-# on the Pi (jay@orangepi5-plus)
+incus config trust add <controller-hostname>
+# Prints a one-time base64 token. Copy it.
+```
+
+Register the worker as an incus remote on the **controller**:
+
+```bash
 curl -X POST http://localhost:6969/api/cluster/remotes \
+  -H "Authorization: Bearer $(cat data/.auth_local_token)" \
   -H 'Content-Type: application/json' \
   -d '{
     "name": "fedora-worker",
-    "url": "https://<fedora-worker-host>:8443",
-    "trust_password": "<temporary-trust-password>"
+    "url": "https://<worker-host>:8443",
+    "token": "<token-from-above>"
   }'
 
-# verify
-curl http://localhost:6969/api/cluster/remotes
+curl http://localhost:6969/api/cluster/remotes \
+  -H "Authorization: Bearer $(cat data/.auth_local_token)"
 ```
 
-### 2. Install Gitea via the LXC path
+For round-trip you also need the controller registered as an incus remote
+on the worker — same flow in reverse.
 
-Use the store UI or POST directly:
+## Procedure
+
+### 1. Install Gitea on the controller
 
 ```bash
 curl -X POST http://localhost:6969/api/store/install-v2 \
+  -H "Authorization: Bearer $(cat data/.auth_local_token)" \
   -H 'Content-Type: application/json' \
-  -b 'taos_session=<your-session-cookie>' \
   -d '{
     "app_id": "gitea-lxc",
-    "admin_password": "<pick-a-strong-password>"
+    "admin_password": "<pick-a-strong-password>",
+    "taos_username": "jay",
+    "taos_email": "jaylfc25@gmail.com",
+    "metadata": {"backend": "lxc"}
   }'
 ```
 
-Wait for the response — install takes 2-3 minutes (incus launch + apt
-install + Gitea download). Response includes `host_port` used for the
-proxy device.
-
-Verify Gitea responds:
+Install takes 2-3 minutes (incus launch + apt install + Gitea binary
+download). Response includes `host_port`. Verify:
 
 ```bash
 curl -I http://localhost:<host_port>/
 # expect: HTTP/1.1 200 OK
 ```
 
-Log in via the browser at `http://<pi-host>:<host_port>/` using your taOS
-username and the admin password from step 2.
-
-### 3. Migrate container to the Fedora worker
+### 2. Migrate controller → worker (e.g. Pi → Fedora)
 
 ```bash
-curl -X POST http://localhost:6969/api/cluster/migrate \
+curl -X POST http://localhost:6969/api/cluster/migrate-service \
+  -H "Authorization: Bearer $(cat data/.auth_local_token)" \
   -H 'Content-Type: application/json' \
   -d '{
-    "container": "taos-svc-gitea-lxc",
+    "app_id": "gitea-lxc",
     "target_remote": "fedora-worker",
-    "keep_source": false,
-    "stateless": true
+    "keep_source": false
   }'
 ```
 
-This stops the container on the Pi, copies it across the LAN, and starts it
-on the Fedora worker. Expect a few minutes for the copy.
+This does not copy the container image. It:
 
-Verify it's running on the target:
+1. Stops Gitea on the source.
+2. `tar`s `/etc/gitea/` + `/home/git/` inside the source container,
+   streams the tarball to the controller host.
+3. Launches a **fresh** container on the target from
+   `images:debian/bookworm` (correct arch for the target host).
+4. Installs the Gitea binary matching the target architecture.
+5. Pushes the tarball into the target container, extracts over the state
+   paths.
+6. Starts the Gitea service.
+7. Destroys the source container (unless `keep_source: true`).
+
+Typical timing for Gitea: ~30s, ~2 MB state.
+
+Verify on the worker:
 
 ```bash
-# on the Fedora worker
-incus list taos-svc-gitea-lxc
+incus list fedora-worker:taos-svc-gitea-lxc
 # Status: RUNNING
+incus config device show fedora-worker:taos-svc-gitea-lxc | grep listen
+# find the host port, then
+curl -I http://<worker-host>:<host_port>/
 ```
 
-And that Gitea still serves. The proxy device follows the container, so the
-same port works on the new host:
+Data check — all accounts + repos came across:
 
 ```bash
-curl -I http://<fedora-worker-host>:<host_port>/
-# expect: HTTP/1.1 200 OK
+curl -u "<user>:<admin_password>" \
+  http://<worker-host>:<host_port>/api/v1/user/repos
 ```
 
-Log in and spot-check that your user account and any repos are intact —
-state lives in the container's `/home/git/` and moved with it.
-
-### 4. Migrate back to the Pi
-
-Before moving back, add the Pi as a remote on the Fedora worker (mirror of
-step 1 but in reverse). Then from the Fedora worker:
+### 3. Migrate worker → controller (reverse)
 
 ```bash
-curl -X POST http://<fedora-worker-host>:6969/api/cluster/migrate \
+curl -X POST http://localhost:6969/api/cluster/migrate-service \
+  -H "Authorization: Bearer $(cat data/.auth_local_token)" \
   -H 'Content-Type: application/json' \
   -d '{
-    "container": "taos-svc-gitea-lxc",
-    "target_remote": "orangepi",
-    "keep_source": false,
-    "stateless": true
+    "app_id": "gitea-lxc",
+    "source_remote": "fedora-worker",
+    "target_remote": "local",
+    "keep_source": false
   }'
 ```
 
-Verify Gitea responds on the Pi again, and the admin user still works.
+Same flow, opposite direction. `target_remote: "local"` means the
+controller host. Verify Gitea serves on the controller again and any repos
+created while on the worker are still present.
+
+## Why not `incus copy` / `incus move`?
+
+`incus move` copies the entire rootfs across hosts. It works only for
+**same-architecture** moves — a container built from an aarch64 base image
+cannot boot on an x86_64 host (incus rejects with `Requested architecture
+isn't supported by this host`).
+
+`migrate_service` sidesteps that by transferring only the state (SQLite
+DBs, on-disk repos, config). The service binary is installed fresh from
+the correct-arch release on the target, so a mixed-arch cluster
+(Pi + desktop + laptop) migrates cleanly.
+
+For same-arch migrations, `POST /api/cluster/migrate` still exists and
+uses `incus move` for speed — useful for homogeneous clusters where
+rootfs-level moves avoid the reinstall cost.
 
 ## Recovery
 
 If a migration fails mid-way:
 
-- The `migrate_container` helper restarts the source container automatically
-  if the copy/move step failed after the stop.
-- If the target has a half-copied container, `incus delete <remote>:<name>
-  --force` cleans it up.
-- A pre-stop snapshot is created best-effort on the source; `incus snapshot
-  restore <name> pre-migrate-<ts>` rolls it back if needed.
+- The source service is restarted automatically so the user doesn't lose
+  access.
+- A half-created target container is destroyed on failure (rolled back by
+  the installer's existing rollback path).
+- The state tarball on the controller host is always cleaned up, success
+  or failure.
 
 ## What this proves
 
-- The LXC install path works end-to-end (container creation → Gitea install →
-  admin seeding → proxy device → real HTTP traffic).
-- `incus copy`/`incus move` across trusted remotes preserves all container
-  state (rootfs, config, installed packages, SQLite DB).
-- Proxy devices survive the move, so the same user-facing URL stays valid
-  after a host change.
+- The LXC install path works end-to-end (container creation → Gitea
+  install → admin seeding → proxy device → real HTTP traffic).
+- State-path migration preserves all user data across architectures:
+  accounts, repos, commits, Gitea config, server keys.
+- Round-trip migration (Pi → Fedora → Pi) leaves a service in the same
+  logical state it started in, with any new data added mid-trip intact.

--- a/tests/test_container_migration.py
+++ b/tests/test_container_migration.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import pytest
 from unittest.mock import AsyncMock, call, patch
 
-from tinyagentos.containers import migrate_container, remote_add, remote_list, remote_remove
+from tinyagentos.containers import migrate_container, remote_add, remote_generate_token, remote_list, remote_remove
 
 
 # ---------------------------------------------------------------------------
@@ -16,30 +16,65 @@ from tinyagentos.containers import migrate_container, remote_add, remote_list, r
 
 class TestRemoteAdd:
     @pytest.mark.asyncio
-    async def test_calls_incus_remote_add(self):
+    async def test_calls_incus_remote_add_with_token(self):
         with patch("tinyagentos.containers._run", new_callable=AsyncMock) as mock_run:
             mock_run.return_value = (0, "")
-            result = await remote_add("fedora-worker", "https://192.168.1.50:8443")
+            result = await remote_add(
+                "fedora-worker", "https://192.168.1.50:8443", token="abc123token"
+            )
         mock_run.assert_called_once_with(
             ["incus", "remote", "add", "fedora-worker", "https://192.168.1.50:8443",
-             "--accept-certificate"]
+             "--token", "abc123token", "--accept-certificate"]
         )
         assert result["success"] is True
 
     @pytest.mark.asyncio
-    async def test_includes_password_when_given(self):
+    async def test_accept_certificate_omitted_when_false(self):
         with patch("tinyagentos.containers._run", new_callable=AsyncMock) as mock_run:
             mock_run.return_value = (0, "")
-            await remote_add("fw", "https://10.0.0.5:8443", trust_password="secret")
+            await remote_add("fw", "https://10.0.0.5:8443", token="tok", accept_certificate=False)
         cmd = mock_run.call_args[0][0]
-        assert "--password=secret" in cmd
+        assert "--accept-certificate" not in cmd
+        assert "--token" in cmd
 
     @pytest.mark.asyncio
     async def test_returns_failure_on_nonzero_exit(self):
         with patch("tinyagentos.containers._run", new_callable=AsyncMock) as mock_run:
             mock_run.return_value = (1, "connection refused")
-            result = await remote_add("bad", "https://10.0.0.99:8443")
+            result = await remote_add("bad", "https://10.0.0.99:8443", token="tok")
         assert result["success"] is False
+
+
+class TestRemoteGenerateToken:
+    @pytest.mark.asyncio
+    async def test_calls_incus_config_trust_add(self):
+        output = "To enroll use this token:\nabc123base64token=="
+        with patch("tinyagentos.containers._run", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = (0, output)
+            result = await remote_generate_token("my-client")
+        mock_run.assert_called_once_with(
+            ["incus", "config", "trust", "add", "my-client"]
+        )
+        assert result["success"] is True
+        assert result["token"] == "abc123base64token=="
+
+    @pytest.mark.asyncio
+    async def test_restricted_and_projects_flags(self):
+        with patch("tinyagentos.containers._run", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = (0, "token123")
+            await remote_generate_token("c", projects=["p1", "p2"], restricted=True)
+        cmd = mock_run.call_args[0][0]
+        assert "--restricted" in cmd
+        assert "--projects" in cmd
+        assert "p1,p2" in cmd
+
+    @pytest.mark.asyncio
+    async def test_returns_failure_on_nonzero_exit(self):
+        with patch("tinyagentos.containers._run", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = (1, "permission denied")
+            result = await remote_generate_token("c")
+        assert result["success"] is False
+        assert result["token"] == ""
 
 
 class TestRemoteList:
@@ -262,14 +297,30 @@ class TestMigrateRoutes:
             resp = await client.post("/api/cluster/remotes", json={
                 "name": "fedora-worker",
                 "url": "https://192.168.1.50:8443",
+                "token": "abc123token",
             })
         assert resp.status_code == 200
         assert resp.json()["status"] == "registered"
 
     @pytest.mark.asyncio
     async def test_post_remotes_missing_fields(self, client):
-        resp = await client.post("/api/cluster/remotes", json={"name": "", "url": ""})
+        resp = await client.post("/api/cluster/remotes", json={"name": "", "url": "", "token": "t"})
         assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_post_remotes_missing_token(self, client):
+        resp = await client.post("/api/cluster/remotes", json={
+            "name": "fw", "url": "https://10.0.0.5:8443", "token": "",
+        })
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_post_remotes_token_generates_token(self, client):
+        with patch("tinyagentos.routes.cluster_migrate.remote_generate_token", new_callable=AsyncMock) as m:
+            m.return_value = {"success": True, "token": "xyz789==", "output": ""}
+            resp = await client.post("/api/cluster/remotes/token", json={"client_name": "pi-node"})
+        assert resp.status_code == 200
+        assert resp.json()["token"] == "xyz789=="
 
     @pytest.mark.asyncio
     async def test_get_remotes_lists(self, client):

--- a/tests/test_container_migration.py
+++ b/tests/test_container_migration.py
@@ -1,0 +1,324 @@
+"""Unit tests for container migration helpers and routes.
+
+All tests mock the incus CLI helper — no real incus calls are made.
+"""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock, call, patch
+
+from tinyagentos.containers import migrate_container, remote_add, remote_list, remote_remove
+
+
+# ---------------------------------------------------------------------------
+# remote_add / remote_list / remote_remove
+# ---------------------------------------------------------------------------
+
+class TestRemoteAdd:
+    @pytest.mark.asyncio
+    async def test_calls_incus_remote_add(self):
+        with patch("tinyagentos.containers._run", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = (0, "")
+            result = await remote_add("fedora-worker", "https://192.168.1.50:8443")
+        mock_run.assert_called_once_with(
+            ["incus", "remote", "add", "fedora-worker", "https://192.168.1.50:8443",
+             "--accept-certificate"]
+        )
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_includes_password_when_given(self):
+        with patch("tinyagentos.containers._run", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = (0, "")
+            await remote_add("fw", "https://10.0.0.5:8443", trust_password="secret")
+        cmd = mock_run.call_args[0][0]
+        assert "--password=secret" in cmd
+
+    @pytest.mark.asyncio
+    async def test_returns_failure_on_nonzero_exit(self):
+        with patch("tinyagentos.containers._run", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = (1, "connection refused")
+            result = await remote_add("bad", "https://10.0.0.99:8443")
+        assert result["success"] is False
+
+
+class TestRemoteList:
+    @pytest.mark.asyncio
+    async def test_parses_csv_output(self):
+        csv = (
+            "local,unix://,incus,,False,True,False\n"
+            "fedora-worker,https://192.168.1.50:8443,incus,,False,False,False\n"
+        )
+        with patch("tinyagentos.containers._run", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = (0, csv)
+            remotes = await remote_list()
+        assert len(remotes) == 2
+        assert remotes[1]["name"] == "fedora-worker"
+        assert remotes[1]["addr"] == "https://192.168.1.50:8443"
+        assert remotes[1]["protocol"] == "incus"
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_list_on_error(self):
+        with patch("tinyagentos.containers._run", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = (1, "daemon not running")
+            remotes = await remote_list()
+        assert remotes == []
+
+
+class TestRemoteRemove:
+    @pytest.mark.asyncio
+    async def test_calls_incus_remote_remove(self):
+        with patch("tinyagentos.containers._run", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = (0, "")
+            result = await remote_remove("fedora-worker")
+        mock_run.assert_called_once_with(["incus", "remote", "remove", "fedora-worker"])
+        assert result["success"] is True
+
+
+# ---------------------------------------------------------------------------
+# migrate_container
+# ---------------------------------------------------------------------------
+
+# CSV output for remote_list showing local + fedora-worker registered.
+_REMOTE_CSV = (
+    "local,unix://,incus,,False,True,False\n"
+    "fedora-worker,https://192.168.1.50:8443,incus,,False,False,False\n"
+)
+
+# incus info output for a stopped container.
+_INFO_STOPPED = "Name: taos-svc-gitea\nStatus: Stopped\nType: container\n"
+
+# incus info output for a running container.
+_INFO_RUNNING = "Name: taos-svc-gitea\nStatus: Running\nType: container\n"
+
+
+def _make_run_mock(responses: list[tuple[int, str]]):
+    """Return an AsyncMock whose side_effect cycles through the given responses."""
+    mock = AsyncMock()
+    mock.side_effect = responses
+    return mock
+
+
+class TestMigrateContainerMove:
+    """keep_source=False → incus move."""
+
+    @pytest.mark.asyncio
+    async def test_move_stopped_container(self):
+        responses = [
+            (0, _INFO_STOPPED),   # incus info
+            (0, _REMOTE_CSV),     # incus remote list
+            (0, ""),              # incus move
+        ]
+        with patch("tinyagentos.containers._run", new_callable=AsyncMock) as mock_run:
+            mock_run.side_effect = responses
+            result = await migrate_container(
+                "taos-svc-gitea", "fedora-worker", keep_source=False
+            )
+        assert result["success"] is True
+        assert result["source"] == "local:taos-svc-gitea"
+        assert result["target"] == "fedora-worker:taos-svc-gitea"
+        # move command must use incus move with --mode=push
+        move_call = mock_run.call_args_list[2]
+        cmd = move_call[0][0]
+        assert cmd[1] == "move"
+        assert "--mode=push" in cmd
+
+    @pytest.mark.asyncio
+    async def test_move_running_container_stops_and_starts_on_target(self):
+        responses = [
+            (0, _INFO_RUNNING),   # incus info
+            (0, _REMOTE_CSV),     # incus remote list
+            (0, ""),              # snapshot_create (pre-stop)
+            (0, ""),              # incus stop
+            (0, ""),              # incus move
+            (0, ""),              # incus start on target
+        ]
+        with patch("tinyagentos.containers._run", new_callable=AsyncMock) as mock_run:
+            mock_run.side_effect = responses
+            result = await migrate_container(
+                "taos-svc-gitea", "fedora-worker", stateless=True, keep_source=False
+            )
+        assert result["success"] is True
+        calls = [c[0][0] for c in mock_run.call_args_list]
+        # Verify stop happened before move
+        stop_idx = next(i for i, c in enumerate(calls) if "stop" in c and "taos-svc-gitea" in c)
+        move_idx = next(i for i, c in enumerate(calls) if "move" in c)
+        start_idx = next(i for i, c in enumerate(calls) if "start" in c and "fedora-worker:" in " ".join(c))
+        assert stop_idx < move_idx < start_idx
+
+    @pytest.mark.asyncio
+    async def test_rollback_restarts_source_on_move_failure(self):
+        """If incus move fails after stopping the container, source is restarted."""
+        responses = [
+            (0, _INFO_RUNNING),   # incus info
+            (0, _REMOTE_CSV),     # incus remote list
+            (0, ""),              # snapshot_create
+            (0, ""),              # incus stop
+            (1, "transfer error"),  # incus move FAILS
+            (0, ""),              # rollback: incus start (source)
+        ]
+        with patch("tinyagentos.containers._run", new_callable=AsyncMock) as mock_run:
+            mock_run.side_effect = responses
+            result = await migrate_container(
+                "taos-svc-gitea", "fedora-worker", stateless=True, keep_source=False
+            )
+        assert result["success"] is False
+        assert "move failed" in result["error"]
+        # Rollback start must be the last call
+        last_cmd = mock_run.call_args_list[-1][0][0]
+        assert "start" in last_cmd
+        assert "taos-svc-gitea" in last_cmd
+
+
+class TestMigrateContainerCopy:
+    """keep_source=True → incus copy."""
+
+    @pytest.mark.asyncio
+    async def test_copy_uses_incus_copy(self):
+        responses = [
+            (0, _INFO_STOPPED),
+            (0, _REMOTE_CSV),
+            (0, ""),  # incus copy
+        ]
+        with patch("tinyagentos.containers._run", new_callable=AsyncMock) as mock_run:
+            mock_run.side_effect = responses
+            result = await migrate_container(
+                "taos-svc-gitea", "fedora-worker", keep_source=True
+            )
+        assert result["success"] is True
+        copy_call = mock_run.call_args_list[2]
+        cmd = copy_call[0][0]
+        assert cmd[1] == "copy"
+        assert "--mode=push" in cmd
+
+    @pytest.mark.asyncio
+    async def test_copy_does_not_rollback_start(self):
+        """On copy failure nothing is restarted (source was never stopped)."""
+        responses = [
+            (0, _INFO_STOPPED),
+            (0, _REMOTE_CSV),
+            (1, "copy failed"),   # incus copy FAILS
+        ]
+        with patch("tinyagentos.containers._run", new_callable=AsyncMock) as mock_run:
+            mock_run.side_effect = responses
+            result = await migrate_container(
+                "taos-svc-gitea", "fedora-worker", keep_source=True
+            )
+        assert result["success"] is False
+        # Only 3 calls: info, remote list, copy — no rollback start
+        assert mock_run.call_count == 3
+
+
+class TestMigrateContainerErrors:
+    @pytest.mark.asyncio
+    async def test_fails_when_container_not_found(self):
+        with patch("tinyagentos.containers._run", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = (1, "not found")
+            result = await migrate_container("ghost", "fedora-worker")
+        assert result["success"] is False
+        assert "ghost" in result["error"]
+        assert "not found" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_fails_when_remote_not_registered(self):
+        csv_only_local = "local,unix://,incus,,False,True,False\n"
+        responses = [
+            (0, _INFO_STOPPED),   # incus info
+            (0, csv_only_local),  # incus remote list — no fedora-worker
+        ]
+        with patch("tinyagentos.containers._run", new_callable=AsyncMock) as mock_run:
+            mock_run.side_effect = responses
+            result = await migrate_container("taos-svc-gitea", "fedora-worker")
+        assert result["success"] is False
+        assert "fedora-worker" in result["error"]
+        # Error should include the incus remote add command hint
+        assert "incus remote add" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_custom_new_name_used_in_target_ref(self):
+        responses = [
+            (0, _INFO_STOPPED),
+            (0, _REMOTE_CSV),
+            (0, ""),  # incus move
+        ]
+        with patch("tinyagentos.containers._run", new_callable=AsyncMock) as mock_run:
+            mock_run.side_effect = responses
+            result = await migrate_container(
+                "taos-svc-gitea", "fedora-worker", new_name="taos-svc-gitea-copy"
+            )
+        assert result["success"] is True
+        assert result["target"] == "fedora-worker:taos-svc-gitea-copy"
+
+
+# ---------------------------------------------------------------------------
+# Route tests
+# ---------------------------------------------------------------------------
+
+class TestMigrateRoutes:
+    @pytest.mark.asyncio
+    async def test_post_remotes_registers(self, client):
+        with patch("tinyagentos.routes.cluster_migrate.remote_add", new_callable=AsyncMock) as m:
+            m.return_value = {"success": True, "output": ""}
+            resp = await client.post("/api/cluster/remotes", json={
+                "name": "fedora-worker",
+                "url": "https://192.168.1.50:8443",
+            })
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "registered"
+
+    @pytest.mark.asyncio
+    async def test_post_remotes_missing_fields(self, client):
+        resp = await client.post("/api/cluster/remotes", json={"name": "", "url": ""})
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_get_remotes_lists(self, client):
+        with patch("tinyagentos.routes.cluster_migrate.remote_list", new_callable=AsyncMock) as m:
+            m.return_value = [{"name": "local", "addr": "unix://", "protocol": "incus"}]
+            resp = await client.get("/api/cluster/remotes")
+        assert resp.status_code == 200
+        assert resp.json()[0]["name"] == "local"
+
+    @pytest.mark.asyncio
+    async def test_delete_remote(self, client):
+        with patch("tinyagentos.routes.cluster_migrate.remote_remove", new_callable=AsyncMock) as m:
+            m.return_value = {"success": True, "output": ""}
+            resp = await client.delete("/api/cluster/remotes/fedora-worker")
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "fedora-worker"
+
+    @pytest.mark.asyncio
+    async def test_post_migrate_triggers_migration(self, client):
+        with patch("tinyagentos.routes.cluster_migrate.migrate_container", new_callable=AsyncMock) as m:
+            m.return_value = {
+                "success": True,
+                "source": "local:taos-svc-gitea",
+                "target": "fedora-worker:taos-svc-gitea",
+                "duration_s": 12.3,
+            }
+            resp = await client.post("/api/cluster/migrate", json={
+                "container": "taos-svc-gitea",
+                "target_remote": "fedora-worker",
+            })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is True
+        assert data["target"] == "fedora-worker:taos-svc-gitea"
+
+    @pytest.mark.asyncio
+    async def test_post_migrate_missing_fields(self, client):
+        resp = await client.post("/api/cluster/migrate", json={
+            "container": "", "target_remote": "",
+        })
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_post_migrate_propagates_error(self, client):
+        with patch("tinyagentos.routes.cluster_migrate.migrate_container", new_callable=AsyncMock) as m:
+            m.return_value = {"success": False, "error": "Remote 'x' is not registered"}
+            resp = await client.post("/api/cluster/migrate", json={
+                "container": "taos-svc-gitea",
+                "target_remote": "x",
+            })
+        assert resp.status_code == 500
+        assert "not registered" in resp.json()["error"]

--- a/tests/test_container_migration.py
+++ b/tests/test_container_migration.py
@@ -18,31 +18,46 @@ class TestRemoteAdd:
     @pytest.mark.asyncio
     async def test_calls_incus_remote_add_with_token(self):
         with patch("tinyagentos.containers._run", new_callable=AsyncMock) as mock_run:
-            mock_run.return_value = (0, "")
+            # First call is the idempotency list-check; return empty so we fall
+            # through to the real remote add.
+            mock_run.side_effect = [(0, "{}"), (0, "")]
             result = await remote_add(
                 "fedora-worker", "https://192.168.1.50:8443", token="abc123token"
             )
-        mock_run.assert_called_once_with(
-            ["incus", "remote", "add", "fedora-worker", "https://192.168.1.50:8443",
-             "--token", "abc123token", "--accept-certificate"]
-        )
+        # Second call should be the actual `incus remote add` invocation.
+        add_call = mock_run.call_args_list[1]
+        assert add_call.args[0] == [
+            "incus", "remote", "add", "fedora-worker", "https://192.168.1.50:8443",
+            "--token", "abc123token", "--accept-certificate",
+        ]
         assert result["success"] is True
 
     @pytest.mark.asyncio
     async def test_accept_certificate_omitted_when_false(self):
         with patch("tinyagentos.containers._run", new_callable=AsyncMock) as mock_run:
-            mock_run.return_value = (0, "")
+            mock_run.side_effect = [(0, "{}"), (0, "")]
             await remote_add("fw", "https://10.0.0.5:8443", token="tok", accept_certificate=False)
-        cmd = mock_run.call_args[0][0]
+        cmd = mock_run.call_args_list[1].args[0]
         assert "--accept-certificate" not in cmd
         assert "--token" in cmd
 
     @pytest.mark.asyncio
     async def test_returns_failure_on_nonzero_exit(self):
         with patch("tinyagentos.containers._run", new_callable=AsyncMock) as mock_run:
-            mock_run.return_value = (1, "connection refused")
+            mock_run.side_effect = [(0, "{}"), (1, "connection refused")]
             result = await remote_add("bad", "https://10.0.0.99:8443", token="tok")
         assert result["success"] is False
+
+    @pytest.mark.asyncio
+    async def test_idempotent_when_same_url_already_registered(self):
+        existing = '{"fedora-worker": {"Addr": "https://10.0.0.5:8443"}}'
+        with patch("tinyagentos.containers._run", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = (0, existing)
+            result = await remote_add("fedora-worker", "https://10.0.0.5:8443", token="tok")
+        # Only the list call should fire; no actual `incus remote add`.
+        assert mock_run.call_count == 1
+        assert result["success"] is True
+        assert "already enrolled" in result["output"]
 
 
 class TestRemoteGenerateToken:

--- a/tests/test_container_migration.py
+++ b/tests/test_container_migration.py
@@ -123,8 +123,11 @@ _REMOTE_CSV = (
 # incus info output for a stopped container.
 _INFO_STOPPED = "Name: taos-svc-gitea\nStatus: Stopped\nType: container\n"
 
-# incus info output for a running container.
+# incus info output for a running container (mixed-case, as old incus versions emitted).
 _INFO_RUNNING = "Name: taos-svc-gitea\nStatus: Running\nType: container\n"
+
+# Real incus 6.x output uses upper-case STATUS values.
+_INFO_RUNNING_UPPER = "Name: taos-svc-gitea-lxc\nStatus: RUNNING\nType: container\n"
 
 
 def _make_run_mock(responses: list[tuple[int, str]]):
@@ -203,6 +206,37 @@ class TestMigrateContainerMove:
         last_cmd = mock_run.call_args_list[-1][0][0]
         assert "start" in last_cmd
         assert "taos-svc-gitea" in last_cmd
+
+    @pytest.mark.asyncio
+    async def test_upper_case_running_status_detected(self):
+        """Regression: real incus 6.x outputs 'Status: RUNNING' (all caps).
+
+        The status-detection loop must treat RUNNING and Running identically.
+        A container reported as RUNNING must be stopped before move and started
+        on the target afterwards.
+        """
+        responses = [
+            (0, _INFO_RUNNING_UPPER),  # incus info — Status: RUNNING
+            (0, _REMOTE_CSV),          # incus remote list
+            (0, ""),                   # snapshot_create (pre-stop)
+            (0, ""),                   # incus stop
+            (0, ""),                   # incus move
+            (0, ""),                   # incus start on target
+        ]
+        with patch("tinyagentos.containers._run", new_callable=AsyncMock) as mock_run:
+            mock_run.side_effect = responses
+            result = await migrate_container(
+                "taos-svc-gitea-lxc", "fedora-worker", stateless=True, keep_source=False
+            )
+        assert result["success"] is True
+        calls = [c[0][0] for c in mock_run.call_args_list]
+        # stop, move, and start on target must all be present
+        stop_idx = next(i for i, c in enumerate(calls) if "stop" in c)
+        move_idx = next(i for i, c in enumerate(calls) if "move" in c)
+        start_idx = next(
+            i for i, c in enumerate(calls) if "start" in c and "fedora-worker:" in " ".join(c)
+        )
+        assert stop_idx < move_idx < start_idx
 
 
 class TestMigrateContainerCopy:

--- a/tests/test_lxc_installer.py
+++ b/tests/test_lxc_installer.py
@@ -354,3 +354,38 @@ class TestInstallRouteBackendSelection:
         # Must not 400 with password error — docker path is unaffected.
         assert resp.status_code != 400 or "admin_password" not in resp.json().get("error", "")
         MockLXC.assert_not_called()
+
+    async def test_lxc_uninstall_destroys_container(self, lxc_client):
+        """Uninstalling an LXC app must call LXCInstaller.uninstall before store uninstall."""
+        with patch(
+            "tinyagentos.routes.store_install.LXCInstaller",
+        ) as MockInstaller:
+            instance = MockInstaller.return_value
+            instance.uninstall = AsyncMock(return_value={"success": True})
+
+            resp = await lxc_client.post(
+                "/api/store/uninstall-v2",
+                json={"app_id": "gitea-lxc", "metadata": {"method": "lxc"}},
+            )
+
+        assert resp.status_code == 200
+        instance.uninstall.assert_awaited_once_with("gitea-lxc")
+
+    async def test_lxc_uninstall_container_error_still_unregisters(self, lxc_client):
+        """If container destroy fails, store uninstall still proceeds and error is surfaced."""
+        # First register the app so store.uninstall returns True.
+        with patch(
+            "tinyagentos.routes.store_install.LXCInstaller",
+        ) as MockInstaller:
+            instance = MockInstaller.return_value
+            instance.uninstall = AsyncMock(side_effect=RuntimeError("container gone"))
+
+            resp = await lxc_client.post(
+                "/api/store/uninstall-v2",
+                json={"app_id": "gitea-lxc", "metadata": {"method": "lxc"}},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "container_error" in data
+        assert "container gone" in data["container_error"]

--- a/tests/test_lxc_installer.py
+++ b/tests/test_lxc_installer.py
@@ -193,6 +193,254 @@ class TestLXCInstallerHappyPath:
         assert result["host_port"] == 13500
 
 
+class TestLXCInstallerRestoreMode:
+    """Tests for install() with restore_tarball set."""
+
+    @pytest.mark.asyncio
+    async def test_restore_mode_skips_migrate_and_admin_create(self):
+        """With restore_tarball, DB migration and admin user create must not run."""
+        installer = LXCInstaller()
+        captured_cmds: list[list[str]] = []
+
+        async def fake_exec(container_name, cmd, timeout=300):
+            captured_cmds.append(cmd)
+            if "hostname" in cmd or "-I" in cmd:
+                return (0, "10.0.0.2")
+            return (0, "")
+
+        with (
+            patch(
+                "tinyagentos.installers.lxc_installer.containers._run",
+                new_callable=AsyncMock,
+                return_value=(1, "not found"),  # container_exists check for remote
+            ),
+            patch(
+                "tinyagentos.installers.lxc_installer.containers.container_exists",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "tinyagentos.installers.lxc_installer.containers.create_container",
+                new_callable=AsyncMock,
+                return_value={"success": True},
+            ),
+            patch(
+                "tinyagentos.installers.lxc_installer.containers.exec_in_container",
+                side_effect=fake_exec,
+            ),
+            patch(
+                "tinyagentos.installers.lxc_installer.containers.push_file",
+                new_callable=AsyncMock,
+                return_value=(0, ""),
+            ),
+            patch(
+                "tinyagentos.installers.lxc_installer.containers.add_proxy_device",
+                new_callable=AsyncMock,
+                return_value={"success": True},
+            ),
+            patch(
+                "tinyagentos.installers.lxc_installer._find_free_port",
+                return_value=13002,
+            ),
+        ):
+            result = await installer.install(
+                "gitea",
+                INSTALL_CONFIG,
+                admin_password="",  # empty is allowed in restore mode
+                restore_tarball="/tmp/fake-state.tar",
+            )
+
+        assert result["success"] is True
+
+        full_cmds = [" ".join(c) for c in captured_cmds]
+        # DB migration and admin user create must NOT appear
+        assert not any("gitea migrate" in c for c in full_cmds), \
+            "gitea migrate should not run in restore mode"
+        assert not any("admin user create" in c for c in full_cmds), \
+            "admin user create should not run in restore mode"
+
+    @pytest.mark.asyncio
+    async def test_restore_mode_runs_tar_extract(self):
+        """With restore_tarball, the tar extract command must be executed."""
+        installer = LXCInstaller()
+        captured_cmds: list[list[str]] = []
+
+        async def fake_exec(container_name, cmd, timeout=300):
+            captured_cmds.append(cmd)
+            if "hostname" in cmd or "-I" in cmd:
+                return (0, "10.0.0.2")
+            return (0, "")
+
+        with (
+            patch(
+                "tinyagentos.installers.lxc_installer.containers._run",
+                new_callable=AsyncMock,
+                return_value=(1, "not found"),
+            ),
+            patch(
+                "tinyagentos.installers.lxc_installer.containers.container_exists",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "tinyagentos.installers.lxc_installer.containers.create_container",
+                new_callable=AsyncMock,
+                return_value={"success": True},
+            ),
+            patch(
+                "tinyagentos.installers.lxc_installer.containers.exec_in_container",
+                side_effect=fake_exec,
+            ),
+            patch(
+                "tinyagentos.installers.lxc_installer.containers.push_file",
+                new_callable=AsyncMock,
+                return_value=(0, ""),
+            ) as mock_push,
+            patch(
+                "tinyagentos.installers.lxc_installer.containers.add_proxy_device",
+                new_callable=AsyncMock,
+                return_value={"success": True},
+            ),
+            patch(
+                "tinyagentos.installers.lxc_installer._find_free_port",
+                return_value=13003,
+            ),
+        ):
+            await installer.install(
+                "gitea",
+                INSTALL_CONFIG,
+                admin_password="",
+                restore_tarball="/tmp/state.tar",
+            )
+
+        # push_file must have been called with the tarball path
+        mock_push.assert_awaited_once()
+        push_args = mock_push.call_args[0]
+        assert push_args[1] == "/tmp/state.tar"
+        assert push_args[2] == "/tmp/restore.tar"
+
+        # tar extract must appear in exec_in_container calls
+        full_cmds = [" ".join(c) for c in captured_cmds]
+        assert any("tar" in c and "-xpf" in c for c in full_cmds), \
+            "tar extract should run in restore mode"
+
+    @pytest.mark.asyncio
+    async def test_restore_mode_does_not_write_app_ini(self):
+        """With restore_tarball, app.ini must not be written (restored from tarball)."""
+        installer = LXCInstaller()
+        captured_cmds: list[list[str]] = []
+
+        async def fake_exec(container_name, cmd, timeout=300):
+            captured_cmds.append(cmd)
+            if "hostname" in cmd or "-I" in cmd:
+                return (0, "10.0.0.2")
+            return (0, "")
+
+        with (
+            patch(
+                "tinyagentos.installers.lxc_installer.containers._run",
+                new_callable=AsyncMock,
+                return_value=(1, "not found"),
+            ),
+            patch(
+                "tinyagentos.installers.lxc_installer.containers.container_exists",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "tinyagentos.installers.lxc_installer.containers.create_container",
+                new_callable=AsyncMock,
+                return_value={"success": True},
+            ),
+            patch(
+                "tinyagentos.installers.lxc_installer.containers.exec_in_container",
+                side_effect=fake_exec,
+            ),
+            patch(
+                "tinyagentos.installers.lxc_installer.containers.push_file",
+                new_callable=AsyncMock,
+                return_value=(0, ""),
+            ),
+            patch(
+                "tinyagentos.installers.lxc_installer.containers.add_proxy_device",
+                new_callable=AsyncMock,
+                return_value={"success": True},
+            ),
+            patch(
+                "tinyagentos.installers.lxc_installer._find_free_port",
+                return_value=13004,
+            ),
+        ):
+            await installer.install(
+                "gitea",
+                INSTALL_CONFIG,
+                admin_password="",
+                restore_tarball="/tmp/state.tar",
+            )
+
+        full_cmds = [" ".join(c) for c in captured_cmds]
+        # The app.ini write is a bash -c that writes to /etc/gitea/app.ini.
+        # The systemd unit also references /etc/gitea/app.ini in ExecStart, so
+        # check specifically for the write-to-file pattern, not just mention.
+        assert not any(
+            "cat > /etc/gitea/app.ini" in c for c in full_cmds
+        ), "app.ini should not be written in restore mode"
+
+    @pytest.mark.asyncio
+    async def test_restore_mode_empty_password_allowed(self):
+        """install() must not raise ValueError when restore_tarball is provided and password is empty."""
+        installer = LXCInstaller()
+
+        async def fake_exec(container_name, cmd, timeout=300):
+            if "hostname" in cmd or "-I" in cmd:
+                return (0, "10.0.0.2")
+            return (0, "")
+
+        with (
+            patch(
+                "tinyagentos.installers.lxc_installer.containers._run",
+                new_callable=AsyncMock,
+                return_value=(1, "not found"),
+            ),
+            patch(
+                "tinyagentos.installers.lxc_installer.containers.container_exists",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "tinyagentos.installers.lxc_installer.containers.create_container",
+                new_callable=AsyncMock,
+                return_value={"success": True},
+            ),
+            patch(
+                "tinyagentos.installers.lxc_installer.containers.exec_in_container",
+                side_effect=fake_exec,
+            ),
+            patch(
+                "tinyagentos.installers.lxc_installer.containers.push_file",
+                new_callable=AsyncMock,
+                return_value=(0, ""),
+            ),
+            patch(
+                "tinyagentos.installers.lxc_installer.containers.add_proxy_device",
+                new_callable=AsyncMock,
+                return_value={"success": True},
+            ),
+            patch(
+                "tinyagentos.installers.lxc_installer._find_free_port",
+                return_value=13005,
+            ),
+        ):
+            # Must not raise
+            result = await installer.install(
+                "gitea",
+                INSTALL_CONFIG,
+                admin_password="",
+                restore_tarball="/tmp/state.tar",
+            )
+        assert result["success"] is True
+
+
 class TestLXCInstallerRollback:
     @pytest.mark.asyncio
     async def test_container_deleted_on_failure(self):

--- a/tests/test_lxc_installer.py
+++ b/tests/test_lxc_installer.py
@@ -1,0 +1,356 @@
+"""Unit tests for LXCInstaller and the store_install.py route backend selection."""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+import yaml
+from unittest.mock import AsyncMock, MagicMock, patch
+from httpx import AsyncClient, ASGITransport
+
+from tinyagentos.installers.lxc_installer import LXCInstaller
+from tinyagentos.app import create_app
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+INSTALL_CONFIG = {
+    "method": "lxc",
+    "image": "images:debian/bookworm",
+    "gitea_version": "1.22.6",
+    "memory_limit": "512MiB",
+    "cpu_limit": 1,
+}
+
+
+# ---------------------------------------------------------------------------
+# LXCInstaller unit tests
+# ---------------------------------------------------------------------------
+
+class TestLXCInstallerMissingPassword:
+    @pytest.mark.asyncio
+    async def test_raises_value_error_when_no_password(self):
+        installer = LXCInstaller()
+        with pytest.raises(ValueError, match="admin_password is required"):
+            await installer.install("gitea", INSTALL_CONFIG, admin_password="")
+
+
+class TestLXCInstallerContainerAlreadyExists:
+    @pytest.mark.asyncio
+    async def test_raises_if_container_exists(self):
+        installer = LXCInstaller()
+        with patch(
+            "tinyagentos.installers.lxc_installer.containers.container_exists",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            with pytest.raises(RuntimeError, match="already exists"):
+                await installer.install(
+                    "gitea", INSTALL_CONFIG, admin_password="secret"
+                )
+
+
+class TestLXCInstallerHappyPath:
+    @pytest.mark.asyncio
+    async def test_create_container_called_with_correct_args(self):
+        installer = LXCInstaller()
+
+        with (
+            patch(
+                "tinyagentos.installers.lxc_installer.containers.container_exists",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "tinyagentos.installers.lxc_installer.containers.create_container",
+                new_callable=AsyncMock,
+                return_value={"success": True, "name": "taos-svc-gitea"},
+            ) as mock_create,
+            patch(
+                "tinyagentos.installers.lxc_installer.containers.exec_in_container",
+                new_callable=AsyncMock,
+                return_value=(0, "10.0.0.2"),
+            ),
+            patch(
+                "tinyagentos.installers.lxc_installer.containers.add_proxy_device",
+                new_callable=AsyncMock,
+                return_value={"success": True},
+            ),
+            patch(
+                "tinyagentos.installers.lxc_installer._find_free_port",
+                return_value=13000,
+            ),
+        ):
+            result = await installer.install(
+                "gitea",
+                INSTALL_CONFIG,
+                admin_password="supersecret",
+                taos_username="jay",
+                taos_email="jay@example.com",
+            )
+
+        assert result["success"] is True
+        mock_create.assert_awaited_once_with(
+            "taos-svc-gitea",
+            image="images:debian/bookworm",
+            memory_limit="512MiB",
+            cpu_limit=1,
+        )
+
+    @pytest.mark.asyncio
+    async def test_admin_user_command_contains_username_email_password(self):
+        installer = LXCInstaller()
+        captured_cmds: list[list[str]] = []
+
+        async def fake_exec(container_name, cmd, timeout=300):
+            captured_cmds.append(cmd)
+            if "hostname" in cmd or "-I" in cmd:
+                return (0, "10.0.0.2")
+            return (0, "")
+
+        with (
+            patch(
+                "tinyagentos.installers.lxc_installer.containers.container_exists",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "tinyagentos.installers.lxc_installer.containers.create_container",
+                new_callable=AsyncMock,
+                return_value={"success": True},
+            ),
+            patch(
+                "tinyagentos.installers.lxc_installer.containers.exec_in_container",
+                side_effect=fake_exec,
+            ),
+            patch(
+                "tinyagentos.installers.lxc_installer.containers.add_proxy_device",
+                new_callable=AsyncMock,
+                return_value={"success": True},
+            ),
+            patch(
+                "tinyagentos.installers.lxc_installer._find_free_port",
+                return_value=13001,
+            ),
+        ):
+            await installer.install(
+                "gitea",
+                INSTALL_CONFIG,
+                admin_password="mypassword",
+                taos_username="jaylfc",
+                taos_email="jaylfc25@gmail.com",
+            )
+
+        admin_cmd = next(
+            (cmd for cmd in captured_cmds if "admin user create" in " ".join(cmd)),
+            None,
+        )
+        assert admin_cmd is not None, "Admin user create command not found"
+        full_cmd = " ".join(admin_cmd)
+        assert "jaylfc" in full_cmd
+        assert "jaylfc25@gmail.com" in full_cmd
+        assert "mypassword" in full_cmd
+        assert "--must-change-password=false" in full_cmd
+
+    @pytest.mark.asyncio
+    async def test_host_port_recorded_in_result(self):
+        installer = LXCInstaller()
+
+        with (
+            patch(
+                "tinyagentos.installers.lxc_installer.containers.container_exists",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "tinyagentos.installers.lxc_installer.containers.create_container",
+                new_callable=AsyncMock,
+                return_value={"success": True},
+            ),
+            patch(
+                "tinyagentos.installers.lxc_installer.containers.exec_in_container",
+                new_callable=AsyncMock,
+                return_value=(0, "10.0.0.2"),
+            ),
+            patch(
+                "tinyagentos.installers.lxc_installer.containers.add_proxy_device",
+                new_callable=AsyncMock,
+                return_value={"success": True},
+            ),
+            patch(
+                "tinyagentos.installers.lxc_installer._find_free_port",
+                return_value=13500,
+            ),
+        ):
+            result = await installer.install(
+                "gitea",
+                INSTALL_CONFIG,
+                admin_password="secret",
+                taos_username="admin",
+            )
+
+        assert result["host_port"] == 13500
+
+
+class TestLXCInstallerRollback:
+    @pytest.mark.asyncio
+    async def test_container_deleted_on_failure(self):
+        installer = LXCInstaller()
+        destroy_mock = AsyncMock(return_value={"success": True})
+
+        async def fail_exec(container_name, cmd, timeout=300):
+            if "hostname" in cmd or "-I" in cmd:
+                return (0, "10.0.0.2")
+            if "apt-get" in " ".join(cmd):
+                return (1, "apt error")
+            return (0, "")
+
+        with (
+            patch(
+                "tinyagentos.installers.lxc_installer.containers.container_exists",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "tinyagentos.installers.lxc_installer.containers.create_container",
+                new_callable=AsyncMock,
+                return_value={"success": True},
+            ),
+            patch(
+                "tinyagentos.installers.lxc_installer.containers.exec_in_container",
+                side_effect=fail_exec,
+            ),
+            patch(
+                "tinyagentos.installers.lxc_installer.containers.destroy_container",
+                destroy_mock,
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="Package install failed"):
+                await installer.install(
+                    "gitea",
+                    INSTALL_CONFIG,
+                    admin_password="secret",
+                )
+
+        destroy_mock.assert_awaited_once_with("taos-svc-gitea")
+
+
+# ---------------------------------------------------------------------------
+# Integration-level route tests
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def lxc_catalog_dir(tmp_path):
+    svc = tmp_path / "catalog" / "services" / "gitea-lxc"
+    svc.mkdir(parents=True)
+    (svc / "manifest-lxc.yaml").write_text(yaml.dump({
+        "id": "gitea-lxc",
+        "name": "Gitea (LXC)",
+        "type": "service",
+        "category": "dev-tool",
+        "version": "1.22.0",
+        "backend": "lxc",
+        "description": "Gitea in LXC",
+        "install": {
+            "method": "lxc",
+            "image": "images:debian/bookworm",
+            "gitea_version": "1.22.6",
+            "memory_limit": "512MiB",
+            "cpu_limit": 1,
+        },
+    }))
+    docker_svc = tmp_path / "catalog" / "services" / "gitea"
+    docker_svc.mkdir(parents=True)
+    (docker_svc / "manifest.yaml").write_text(yaml.dump({
+        "id": "gitea",
+        "name": "Gitea",
+        "type": "service",
+        "category": "dev-tool",
+        "version": "1.22.0",
+        "description": "Gitea via Docker",
+        "install": {"method": "docker", "image": "gitea/gitea:1.22"},
+    }))
+    return tmp_path / "catalog"
+
+
+@pytest_asyncio.fixture
+async def lxc_client(tmp_data_dir, lxc_catalog_dir):
+    app = create_app(data_dir=tmp_data_dir, catalog_dir=lxc_catalog_dir)
+    store = app.state.metrics
+    if store._db is not None:
+        await store.close()
+    await store.init()
+    installed_apps = app.state.installed_apps
+    if installed_apps._db is not None:
+        await installed_apps.close()
+    await installed_apps.init()
+    await app.state.qmd_client.init()
+    app.state.auth.setup_user("admin", "Test Admin", "admin@localhost", "testpass")
+    _rec = app.state.auth.find_user("admin")
+    _token = app.state.auth.create_session(
+        user_id=_rec["id"] if _rec else "", long_lived=True
+    )
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport, base_url="http://test", cookies={"taos_session": _token}
+    ) as c:
+        yield c
+    await installed_apps.close()
+    await store.close()
+    await app.state.qmd_client.close()
+    await app.state.http_client.aclose()
+
+
+@pytest.mark.asyncio
+class TestInstallRouteBackendSelection:
+    async def test_lxc_install_missing_password_returns_400(self, lxc_client):
+        resp = await lxc_client.post(
+            "/api/store/install-v2",
+            json={"app_id": "gitea-lxc", "metadata": {"method": "lxc"}},
+        )
+        assert resp.status_code == 400
+        assert "admin_password" in resp.json()["error"]
+
+    async def test_lxc_install_calls_lxc_installer(self, lxc_client):
+        mock_result = {
+            "success": True,
+            "app_id": "gitea-lxc",
+            "backend": "lxc",
+            "container": "taos-svc-gitea-lxc",
+            "host_port": 13000,
+            "gitea_version": "1.22.6",
+            "admin_username": "admin",
+        }
+        with patch(
+            "tinyagentos.routes.store_install.LXCInstaller",
+        ) as MockInstaller:
+            instance = MockInstaller.return_value
+            instance.install = AsyncMock(return_value=mock_result)
+
+            resp = await lxc_client.post(
+                "/api/store/install-v2",
+                json={
+                    "app_id": "gitea-lxc",
+                    "admin_password": "hunter2",
+                    "metadata": {"method": "lxc"},
+                },
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is True
+        assert data["status"] == "installed"
+        instance.install.assert_awaited_once()
+        call_kwargs = instance.install.call_args.kwargs
+        assert call_kwargs["admin_password"] == "hunter2"
+
+    async def test_docker_install_does_not_require_password(self, lxc_client):
+        with patch("tinyagentos.routes.store_install.LXCInstaller") as MockLXC:
+            resp = await lxc_client.post(
+                "/api/store/install-v2",
+                json={"app_id": "gitea", "metadata": {"method": "docker"}},
+            )
+        # Must not 400 with password error — docker path is unaffected.
+        assert resp.status_code != 400 or "admin_password" not in resp.json().get("error", "")
+        MockLXC.assert_not_called()

--- a/tests/test_routes_store.py
+++ b/tests/test_routes_store.py
@@ -154,3 +154,63 @@ class TestStoreInstallAPI:
         assert resp.status_code == 404
 
 
+@pytest.mark.asyncio
+class TestInstallV2UpdatesRuntimeLocation:
+    """After a successful LXC install, update_runtime_location should be called."""
+
+    async def test_update_runtime_location_called_on_lxc_install(
+        self, app_with_store, store_client
+    ):
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        mock_result = {
+            "success": True,
+            "app_id": "gitea-lxc",
+            "backend": "lxc",
+            "container": "taos-svc-gitea-lxc",
+            "host_port": 13000,
+            "gitea_version": "1.22.6",
+            "admin_username": "admin",
+        }
+        update_calls: list = []
+
+        async def fake_update(app_id, host, port, backend="", ui_path="/"):
+            update_calls.append((app_id, host, port, backend, ui_path))
+
+        mock_manifest = MagicMock()
+        mock_manifest.install = {
+            "method": "lxc",
+            "image": "images:debian/bookworm",
+            "ui_path": "/",
+        }
+
+        # Replace the installed_apps store with a mock so we can track calls
+        # without needing the DB initialised in this fixture context.
+        mock_store = MagicMock()
+        mock_store.install = AsyncMock()
+        mock_store.update_runtime_location = AsyncMock(side_effect=fake_update)
+        app_with_store.state.installed_apps = mock_store
+
+        with (
+            patch(
+                "tinyagentos.routes.store_install.LXCInstaller"
+            ) as MockInstaller,
+            patch("tinyagentos.registry.AppRegistry.get", return_value=mock_manifest),
+        ):
+            instance = MockInstaller.return_value
+            instance.install = AsyncMock(return_value=mock_result)
+
+            resp = await store_client.post("/api/store/install-v2", json={
+                "app_id": "gitea-lxc",
+                "admin_password": "secret",
+            })
+
+        assert resp.status_code == 200
+        assert len(update_calls) == 1
+        app_id, host, port, backend, ui_path = update_calls[0]
+        assert app_id == "gitea-lxc"
+        assert host == "127.0.0.1"  # local install → loopback
+        assert port == 13000
+        assert backend == "lxc"
+
+

--- a/tests/test_service_migrator.py
+++ b/tests/test_service_migrator.py
@@ -525,3 +525,60 @@ class TestMigrateServiceRoute:
             })
         assert resp.status_code == 500
         assert "remote not reachable" in resp.json()["error"]
+
+    @pytest.mark.asyncio
+    async def test_update_runtime_location_called_after_migrate(self, app, client):
+        """After a successful migrate-service, update_runtime_location is called."""
+        mock_result = {
+            "success": True,
+            "source": "local:taos-svc-gitea",
+            "target": "fedora-worker:taos-svc-gitea",
+            "duration_s": 5.0,
+            "tarball_size_bytes": 1024,
+            "host_port": 13500,
+            "target_remote": "fedora-worker",
+        }
+        mock_manifest = MagicMock()
+        mock_manifest.install = {
+            "method": "lxc",
+            "state_paths": ["/etc/gitea/", "/home/git/"],
+            "service_name": "gitea",
+            "ui_path": "/",
+        }
+        mock_manifest.manifest_dir = None
+        update_called_with: list = []
+
+        async def fake_update(app_id, host, port, backend="", ui_path="/"):
+            update_called_with.append((app_id, host, port, backend, ui_path))
+
+        installed_apps_mock = MagicMock()
+        installed_apps_mock.update_runtime_location = AsyncMock(side_effect=fake_update)
+        app.state.installed_apps = installed_apps_mock
+
+        with (
+            patch(
+                "tinyagentos.routes.cluster_migrate.migrate_service",
+                new_callable=AsyncMock,
+                return_value=mock_result,
+            ),
+            patch("tinyagentos.registry.AppRegistry.get", return_value=mock_manifest),
+            patch(
+                "tinyagentos.routes.cluster_migrate.remote_list",
+                new_callable=AsyncMock,
+                return_value=[
+                    {"name": "fedora-worker", "addr": "https://192.168.6.108:8443", "protocol": "incus"},
+                ],
+            ),
+        ):
+            resp = await client.post("/api/cluster/migrate-service", json={
+                "app_id": "gitea",
+                "target_remote": "fedora-worker",
+            })
+
+        assert resp.status_code == 200
+        assert len(update_called_with) == 1
+        app_id, host, port, backend, ui_path = update_called_with[0]
+        assert app_id == "gitea"
+        assert host == "192.168.6.108"  # parsed from remote URL
+        assert port == 13500
+        assert backend == "lxc"

--- a/tests/test_service_migrator.py
+++ b/tests/test_service_migrator.py
@@ -524,7 +524,7 @@ class TestMigrateServiceRoute:
                 "target_remote": "fedora-worker",
             })
         assert resp.status_code == 500
-        assert "remote not reachable" in resp.json()["error"]
+        assert resp.json()["error"] == "service migration failed"
 
     @pytest.mark.asyncio
     async def test_update_runtime_location_called_after_migrate(self, app, client):

--- a/tests/test_service_migrator.py
+++ b/tests/test_service_migrator.py
@@ -179,6 +179,12 @@ class TestMigrateServiceSuccess:
             exec_calls.append(list(cmd))
             return (0, "")
 
+        run_calls: list = []
+
+        async def fake_run(cmd, timeout=120):
+            run_calls.append(list(cmd))
+            return (0, "Name: taos-svc-gitea\nStatus: RUNNING\n" if "info" in cmd else "")
+
         with (
             patch(
                 "tinyagentos.cluster.service_migrator.containers.remote_list",
@@ -190,21 +196,12 @@ class TestMigrateServiceSuccess:
             ),
             patch(
                 "tinyagentos.cluster.service_migrator.containers._run",
-                new_callable=AsyncMock,
-                side_effect=[
-                    (0, "Name: taos-svc-gitea\nStatus: RUNNING\n"),
-                    (0, ""),
-                ],
+                side_effect=fake_run,
             ),
             patch(
                 "tinyagentos.cluster.service_migrator.containers.exec_in_container",
                 side_effect=fake_exec,
             ),
-            patch(
-                "tinyagentos.cluster.service_migrator.containers.destroy_container",
-                new_callable=AsyncMock,
-                return_value={"success": True},
-            ) as mock_destroy,
             patch(
                 "tinyagentos.cluster.service_migrator.LXCInstaller",
             ) as MockInstaller,
@@ -228,13 +225,21 @@ class TestMigrateServiceSuccess:
         assert result["source"] == "local:taos-svc-gitea"
         assert result["target"] == "fedora-worker:taos-svc-gitea"
         assert result["tarball_size_bytes"] == 2048
-        mock_destroy.assert_awaited_once_with("taos-svc-gitea")
+        delete_cmds = [c for c in run_calls if "delete" in c]
+        assert any("taos-svc-gitea" in c for c in delete_cmds), \
+            "source container delete not called after success"
 
     @pytest.mark.asyncio
     async def test_success_path_keeps_source_when_requested(self):
         """On success with keep_source=True, source container is NOT destroyed."""
         async def fake_exec(container_name, cmd, timeout=300):
             return (0, "")
+
+        run_calls: list = []
+
+        async def fake_run(cmd, timeout=120):
+            run_calls.append(list(cmd))
+            return (0, "Name: taos-svc-gitea\nStatus: RUNNING\n" if "info" in cmd else "")
 
         with (
             patch(
@@ -247,21 +252,12 @@ class TestMigrateServiceSuccess:
             ),
             patch(
                 "tinyagentos.cluster.service_migrator.containers._run",
-                new_callable=AsyncMock,
-                side_effect=[
-                    (0, "Name: taos-svc-gitea\nStatus: RUNNING\n"),
-                    (0, ""),
-                ],
+                side_effect=fake_run,
             ),
             patch(
                 "tinyagentos.cluster.service_migrator.containers.exec_in_container",
                 side_effect=fake_exec,
             ),
-            patch(
-                "tinyagentos.cluster.service_migrator.containers.destroy_container",
-                new_callable=AsyncMock,
-                return_value={"success": True},
-            ) as mock_destroy,
             patch(
                 "tinyagentos.cluster.service_migrator.LXCInstaller",
             ) as MockInstaller,
@@ -280,13 +276,17 @@ class TestMigrateServiceSuccess:
             )
 
         assert result["success"] is True
-        mock_destroy.assert_not_awaited()
+        delete_cmds = [c for c in run_calls if "delete" in c]
+        assert not delete_cmds, "source container should not be deleted when keep_source=True"
 
     @pytest.mark.asyncio
     async def test_installer_called_with_restore_tarball_and_target_remote(self):
         """LXCInstaller.install must be called with restore_tarball and target_remote."""
         async def fake_exec(container_name, cmd, timeout=300):
             return (0, "")
+
+        async def fake_run(cmd, timeout=120):
+            return (0, "Name: taos-svc-gitea\nStatus: RUNNING\n" if "info" in cmd else "")
 
         with (
             patch(
@@ -299,20 +299,11 @@ class TestMigrateServiceSuccess:
             ),
             patch(
                 "tinyagentos.cluster.service_migrator.containers._run",
-                new_callable=AsyncMock,
-                side_effect=[
-                    (0, "Name: taos-svc-gitea\nStatus: RUNNING\n"),
-                    (0, ""),
-                ],
+                side_effect=fake_run,
             ),
             patch(
                 "tinyagentos.cluster.service_migrator.containers.exec_in_container",
                 side_effect=fake_exec,
-            ),
-            patch(
-                "tinyagentos.cluster.service_migrator.containers.destroy_container",
-                new_callable=AsyncMock,
-                return_value={"success": True},
             ),
             patch(
                 "tinyagentos.cluster.service_migrator.LXCInstaller",
@@ -334,6 +325,109 @@ class TestMigrateServiceSuccess:
         assert install_kwargs.kwargs["target_remote"] == "fedora-worker"
         assert install_kwargs.kwargs["restore_tarball"] is not None
         assert install_kwargs.kwargs["admin_password"] == ""
+
+
+# ---------------------------------------------------------------------------
+# source_remote tests
+# ---------------------------------------------------------------------------
+
+class TestMigrateServiceSourceRemote:
+    @pytest.mark.asyncio
+    async def test_same_source_and_target_remote_returns_error(self):
+        """When source_remote == target_remote, returns error without any incus calls."""
+        with patch(
+            "tinyagentos.cluster.service_migrator.containers.remote_list",
+            new_callable=AsyncMock,
+            return_value=[
+                {"name": "fedora-worker", "addr": "https://x:8443", "protocol": "incus"},
+            ],
+        ):
+            result = await migrate_service(
+                "gitea", "fedora-worker",
+                install_config=_INSTALL_CONFIG,
+                state_paths=_STATE_PATHS,
+                service_name="gitea",
+                source_remote="fedora-worker",
+            )
+        assert result["success"] is False
+        assert "fedora-worker" in result["error"]
+        assert "no-op" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_source_remote_prefixes_all_source_ops_not_target(self):
+        """With source_remote set, all incus source ops use remote:name; target ops do not."""
+        exec_calls: list = []
+
+        async def fake_exec(container_name, cmd, timeout=300):
+            exec_calls.append((container_name, list(cmd)))
+            return (0, "")
+
+        run_calls: list = []
+
+        async def fake_run(cmd, timeout=120):
+            run_calls.append(list(cmd))
+            return (0, "Name: taos-svc-gitea\nStatus: RUNNING\n" if "info" in cmd else "")
+
+        with (
+            patch(
+                "tinyagentos.cluster.service_migrator.containers.remote_list",
+                new_callable=AsyncMock,
+                return_value=[
+                    {"name": "local", "addr": "unix://", "protocol": "incus"},
+                    {"name": "fedora-worker", "addr": "https://x:8443", "protocol": "incus"},
+                    {"name": "pi-worker", "addr": "https://y:8443", "protocol": "incus"},
+                ],
+            ),
+            patch(
+                "tinyagentos.cluster.service_migrator.containers._run",
+                side_effect=fake_run,
+            ),
+            patch(
+                "tinyagentos.cluster.service_migrator.containers.exec_in_container",
+                side_effect=fake_exec,
+            ),
+            patch(
+                "tinyagentos.cluster.service_migrator.LXCInstaller",
+            ) as MockInstaller,
+            patch("os.path.getsize", return_value=1024),
+            patch("os.unlink"),
+        ):
+            instance = MockInstaller.return_value
+            instance.install = AsyncMock(return_value={"success": True, "app_id": "gitea"})
+
+            result = await migrate_service(
+                "gitea", "pi-worker",
+                install_config=_INSTALL_CONFIG,
+                state_paths=_STATE_PATHS,
+                service_name="gitea",
+                source_remote="fedora-worker",
+                keep_source=False,
+            )
+
+        assert result["success"] is True
+        assert result["source"] == "fedora-worker:taos-svc-gitea"
+        assert result["target"] == "pi-worker:taos-svc-gitea"
+
+        # All exec_in_container calls must use the source remote prefix.
+        for container_arg, _ in exec_calls:
+            assert container_arg == "fedora-worker:taos-svc-gitea", (
+                f"exec_in_container called with unexpected name: {container_arg!r}"
+            )
+
+        # incus info and incus file pull must reference the source remote.
+        info_cmds = [c for c in run_calls if "info" in c]
+        assert all("fedora-worker:taos-svc-gitea" in c for c in info_cmds)
+
+        pull_cmds = [c for c in run_calls if "file" in c and "pull" in c]
+        assert all("fedora-worker:taos-svc-gitea" in " ".join(c) for c in pull_cmds)
+
+        # Delete must reference the source remote prefix.
+        delete_cmds = [c for c in run_calls if "delete" in c]
+        assert any("fedora-worker:taos-svc-gitea" in c for c in delete_cmds)
+
+        # LXCInstaller.install must target pi-worker (not fedora-worker).
+        install_kwargs = instance.install.call_args
+        assert install_kwargs.kwargs["target_remote"] == "pi-worker"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_service_migrator.py
+++ b/tests/test_service_migrator.py
@@ -1,0 +1,433 @@
+"""Unit tests for migrate_service() in tinyagentos.cluster.service_migrator."""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from tinyagentos.cluster.service_migrator import migrate_service
+
+# ---------------------------------------------------------------------------
+# Shared test data
+# ---------------------------------------------------------------------------
+
+_INSTALL_CONFIG = {
+    "method": "lxc",
+    "image": "images:debian/bookworm",
+    "gitea_version": "1.22.6",
+    "memory_limit": "512MiB",
+    "cpu_limit": 1,
+}
+
+_STATE_PATHS = ["/etc/gitea/", "/home/git/"]
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+class TestMigrateServiceErrors:
+    @pytest.mark.asyncio
+    async def test_remote_not_registered(self):
+        """Returns error dict if target_remote is not in incus remote list."""
+        with patch(
+            "tinyagentos.cluster.service_migrator.containers.remote_list",
+            new_callable=AsyncMock,
+            return_value=[{"name": "local", "addr": "unix://", "protocol": "incus"}],
+        ):
+            result = await migrate_service(
+                "gitea", "fedora-worker",
+                install_config=_INSTALL_CONFIG,
+                state_paths=_STATE_PATHS,
+                service_name="gitea",
+            )
+        assert result["success"] is False
+        assert "fedora-worker" in result["error"]
+        assert "incus remote add" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_source_container_not_found(self):
+        """Returns error dict when the source container does not exist."""
+        with (
+            patch(
+                "tinyagentos.cluster.service_migrator.containers.remote_list",
+                new_callable=AsyncMock,
+                return_value=[
+                    {"name": "local", "addr": "unix://", "protocol": "incus"},
+                    {"name": "fedora-worker", "addr": "https://x:8443", "protocol": "incus"},
+                ],
+            ),
+            patch(
+                "tinyagentos.cluster.service_migrator.containers._run",
+                new_callable=AsyncMock,
+                return_value=(1, "not found"),
+            ),
+        ):
+            result = await migrate_service(
+                "gitea", "fedora-worker",
+                install_config=_INSTALL_CONFIG,
+                state_paths=_STATE_PATHS,
+                service_name="gitea",
+            )
+        assert result["success"] is False
+        assert "taos-svc-gitea" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_tarball_creation_fails_restarts_source(self):
+        """When tar inside the container fails, the source service is restarted."""
+        exec_calls: list = []
+
+        async def fake_exec(container_name, cmd, timeout=300):
+            exec_calls.append(list(cmd))
+            if "-cpf" in " ".join(cmd):
+                return (1, "tar: error creating archive")
+            return (0, "")
+
+        with (
+            patch(
+                "tinyagentos.cluster.service_migrator.containers.remote_list",
+                new_callable=AsyncMock,
+                return_value=[
+                    {"name": "local", "addr": "unix://", "protocol": "incus"},
+                    {"name": "fedora-worker", "addr": "https://x:8443", "protocol": "incus"},
+                ],
+            ),
+            patch(
+                "tinyagentos.cluster.service_migrator.containers._run",
+                new_callable=AsyncMock,
+                return_value=(0, "Name: taos-svc-gitea\nStatus: RUNNING\n"),
+            ),
+            patch(
+                "tinyagentos.cluster.service_migrator.containers.exec_in_container",
+                side_effect=fake_exec,
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="Failed to create state tarball"):
+                await migrate_service(
+                    "gitea", "fedora-worker",
+                    install_config=_INSTALL_CONFIG,
+                    state_paths=_STATE_PATHS,
+                    service_name="gitea",
+                )
+
+        full_cmds = [" ".join(c) for c in exec_calls]
+        assert any("systemctl" in c and "start" in c for c in full_cmds), \
+            "source service restart not attempted after tarball failure"
+
+    @pytest.mark.asyncio
+    async def test_install_on_target_fails_restarts_source(self):
+        """When LXCInstaller.install() raises, the source service is restarted."""
+        exec_calls: list = []
+
+        async def fake_exec(container_name, cmd, timeout=300):
+            exec_calls.append(list(cmd))
+            return (0, "")
+
+        with (
+            patch(
+                "tinyagentos.cluster.service_migrator.containers.remote_list",
+                new_callable=AsyncMock,
+                return_value=[
+                    {"name": "local", "addr": "unix://", "protocol": "incus"},
+                    {"name": "fedora-worker", "addr": "https://x:8443", "protocol": "incus"},
+                ],
+            ),
+            patch(
+                "tinyagentos.cluster.service_migrator.containers._run",
+                new_callable=AsyncMock,
+                side_effect=[
+                    (0, "Name: taos-svc-gitea\nStatus: RUNNING\n"),
+                    (0, ""),
+                ],
+            ),
+            patch(
+                "tinyagentos.cluster.service_migrator.containers.exec_in_container",
+                side_effect=fake_exec,
+            ),
+            patch(
+                "tinyagentos.cluster.service_migrator.LXCInstaller",
+            ) as MockInstaller,
+            patch("os.path.getsize", return_value=1024),
+            patch("os.unlink"),
+        ):
+            instance = MockInstaller.return_value
+            instance.install = AsyncMock(side_effect=RuntimeError("apt-get failed"))
+
+            with pytest.raises(RuntimeError, match="apt-get failed"):
+                await migrate_service(
+                    "gitea", "fedora-worker",
+                    install_config=_INSTALL_CONFIG,
+                    state_paths=_STATE_PATHS,
+                    service_name="gitea",
+                )
+
+        full_cmds = [" ".join(c) for c in exec_calls]
+        assert any("systemctl" in c and "start" in c for c in full_cmds), \
+            "source service restart not attempted after install failure"
+
+
+# ---------------------------------------------------------------------------
+# Success path
+# ---------------------------------------------------------------------------
+
+class TestMigrateServiceSuccess:
+    @pytest.mark.asyncio
+    async def test_success_path_destroys_source_by_default(self):
+        """On success with keep_source=False, source container is destroyed."""
+        exec_calls: list = []
+
+        async def fake_exec(container_name, cmd, timeout=300):
+            exec_calls.append(list(cmd))
+            return (0, "")
+
+        with (
+            patch(
+                "tinyagentos.cluster.service_migrator.containers.remote_list",
+                new_callable=AsyncMock,
+                return_value=[
+                    {"name": "local", "addr": "unix://", "protocol": "incus"},
+                    {"name": "fedora-worker", "addr": "https://x:8443", "protocol": "incus"},
+                ],
+            ),
+            patch(
+                "tinyagentos.cluster.service_migrator.containers._run",
+                new_callable=AsyncMock,
+                side_effect=[
+                    (0, "Name: taos-svc-gitea\nStatus: RUNNING\n"),
+                    (0, ""),
+                ],
+            ),
+            patch(
+                "tinyagentos.cluster.service_migrator.containers.exec_in_container",
+                side_effect=fake_exec,
+            ),
+            patch(
+                "tinyagentos.cluster.service_migrator.containers.destroy_container",
+                new_callable=AsyncMock,
+                return_value={"success": True},
+            ) as mock_destroy,
+            patch(
+                "tinyagentos.cluster.service_migrator.LXCInstaller",
+            ) as MockInstaller,
+            patch("os.path.getsize", return_value=2048),
+            patch("os.unlink"),
+        ):
+            instance = MockInstaller.return_value
+            instance.install = AsyncMock(return_value={
+                "success": True, "app_id": "gitea", "host_port": 13000,
+            })
+
+            result = await migrate_service(
+                "gitea", "fedora-worker",
+                install_config=_INSTALL_CONFIG,
+                state_paths=_STATE_PATHS,
+                service_name="gitea",
+                keep_source=False,
+            )
+
+        assert result["success"] is True
+        assert result["source"] == "local:taos-svc-gitea"
+        assert result["target"] == "fedora-worker:taos-svc-gitea"
+        assert result["tarball_size_bytes"] == 2048
+        mock_destroy.assert_awaited_once_with("taos-svc-gitea")
+
+    @pytest.mark.asyncio
+    async def test_success_path_keeps_source_when_requested(self):
+        """On success with keep_source=True, source container is NOT destroyed."""
+        async def fake_exec(container_name, cmd, timeout=300):
+            return (0, "")
+
+        with (
+            patch(
+                "tinyagentos.cluster.service_migrator.containers.remote_list",
+                new_callable=AsyncMock,
+                return_value=[
+                    {"name": "local", "addr": "unix://", "protocol": "incus"},
+                    {"name": "fedora-worker", "addr": "https://x:8443", "protocol": "incus"},
+                ],
+            ),
+            patch(
+                "tinyagentos.cluster.service_migrator.containers._run",
+                new_callable=AsyncMock,
+                side_effect=[
+                    (0, "Name: taos-svc-gitea\nStatus: RUNNING\n"),
+                    (0, ""),
+                ],
+            ),
+            patch(
+                "tinyagentos.cluster.service_migrator.containers.exec_in_container",
+                side_effect=fake_exec,
+            ),
+            patch(
+                "tinyagentos.cluster.service_migrator.containers.destroy_container",
+                new_callable=AsyncMock,
+                return_value={"success": True},
+            ) as mock_destroy,
+            patch(
+                "tinyagentos.cluster.service_migrator.LXCInstaller",
+            ) as MockInstaller,
+            patch("os.path.getsize", return_value=512),
+            patch("os.unlink"),
+        ):
+            instance = MockInstaller.return_value
+            instance.install = AsyncMock(return_value={"success": True, "app_id": "gitea"})
+
+            result = await migrate_service(
+                "gitea", "fedora-worker",
+                install_config=_INSTALL_CONFIG,
+                state_paths=_STATE_PATHS,
+                service_name="gitea",
+                keep_source=True,
+            )
+
+        assert result["success"] is True
+        mock_destroy.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_installer_called_with_restore_tarball_and_target_remote(self):
+        """LXCInstaller.install must be called with restore_tarball and target_remote."""
+        async def fake_exec(container_name, cmd, timeout=300):
+            return (0, "")
+
+        with (
+            patch(
+                "tinyagentos.cluster.service_migrator.containers.remote_list",
+                new_callable=AsyncMock,
+                return_value=[
+                    {"name": "local", "addr": "unix://", "protocol": "incus"},
+                    {"name": "fedora-worker", "addr": "https://x:8443", "protocol": "incus"},
+                ],
+            ),
+            patch(
+                "tinyagentos.cluster.service_migrator.containers._run",
+                new_callable=AsyncMock,
+                side_effect=[
+                    (0, "Name: taos-svc-gitea\nStatus: RUNNING\n"),
+                    (0, ""),
+                ],
+            ),
+            patch(
+                "tinyagentos.cluster.service_migrator.containers.exec_in_container",
+                side_effect=fake_exec,
+            ),
+            patch(
+                "tinyagentos.cluster.service_migrator.containers.destroy_container",
+                new_callable=AsyncMock,
+                return_value={"success": True},
+            ),
+            patch(
+                "tinyagentos.cluster.service_migrator.LXCInstaller",
+            ) as MockInstaller,
+            patch("os.path.getsize", return_value=100),
+            patch("os.unlink"),
+        ):
+            instance = MockInstaller.return_value
+            instance.install = AsyncMock(return_value={"success": True, "app_id": "gitea"})
+
+            await migrate_service(
+                "gitea", "fedora-worker",
+                install_config=_INSTALL_CONFIG,
+                state_paths=_STATE_PATHS,
+                service_name="gitea",
+            )
+
+        install_kwargs = instance.install.call_args
+        assert install_kwargs.kwargs["target_remote"] == "fedora-worker"
+        assert install_kwargs.kwargs["restore_tarball"] is not None
+        assert install_kwargs.kwargs["admin_password"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Route tests for /api/cluster/migrate-service
+# ---------------------------------------------------------------------------
+
+class TestMigrateServiceRoute:
+    @pytest.mark.asyncio
+    async def test_post_migrate_service_success(self, client):
+        """POST /api/cluster/migrate-service returns success payload."""
+        mock_result = {
+            "success": True,
+            "source": "local:taos-svc-gitea",
+            "target": "fedora-worker:taos-svc-gitea",
+            "duration_s": 8.5,
+            "tarball_size_bytes": 4096,
+        }
+        mock_manifest = MagicMock()
+        mock_manifest.install = {
+            "method": "lxc",
+            "state_paths": ["/etc/gitea/", "/home/git/"],
+            "service_name": "gitea",
+        }
+        mock_manifest.manifest_dir = None
+        with (
+            patch(
+                "tinyagentos.routes.cluster_migrate.migrate_service",
+                new_callable=AsyncMock,
+                return_value=mock_result,
+            ),
+            patch("tinyagentos.registry.AppRegistry.get", return_value=mock_manifest),
+        ):
+            resp = await client.post("/api/cluster/migrate-service", json={
+                "app_id": "gitea",
+                "target_remote": "fedora-worker",
+            })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is True
+        assert data["target"] == "fedora-worker:taos-svc-gitea"
+
+    @pytest.mark.asyncio
+    async def test_post_migrate_service_missing_fields(self, client):
+        """POST /api/cluster/migrate-service with empty fields returns 400."""
+        resp = await client.post("/api/cluster/migrate-service", json={
+            "app_id": "", "target_remote": "",
+        })
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_post_migrate_service_app_not_found(self, client):
+        """POST /api/cluster/migrate-service returns 404 when app_id not in catalog."""
+        with patch("tinyagentos.registry.AppRegistry.get", return_value=None):
+            resp = await client.post("/api/cluster/migrate-service", json={
+                "app_id": "nonexistent-app",
+                "target_remote": "fedora-worker",
+            })
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_post_migrate_service_no_state_paths(self, client):
+        """POST /api/cluster/migrate-service returns 400 when manifest has no state_paths."""
+        mock_manifest = MagicMock()
+        mock_manifest.install = {"method": "lxc"}
+        mock_manifest.manifest_dir = None
+        with patch("tinyagentos.registry.AppRegistry.get", return_value=mock_manifest):
+            resp = await client.post("/api/cluster/migrate-service", json={
+                "app_id": "gitea",
+                "target_remote": "fedora-worker",
+            })
+        assert resp.status_code == 400
+        assert "state_paths" in resp.json()["error"]
+
+    @pytest.mark.asyncio
+    async def test_post_migrate_service_propagates_error(self, client):
+        """POST /api/cluster/migrate-service returns 500 when migration raises."""
+        mock_manifest = MagicMock()
+        mock_manifest.install = {
+            "method": "lxc",
+            "state_paths": ["/etc/gitea/"],
+            "service_name": "gitea",
+        }
+        mock_manifest.manifest_dir = None
+        with (
+            patch(
+                "tinyagentos.routes.cluster_migrate.migrate_service",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("remote not reachable"),
+            ),
+            patch("tinyagentos.registry.AppRegistry.get", return_value=mock_manifest),
+        ):
+            resp = await client.post("/api/cluster/migrate-service", json={
+                "app_id": "gitea",
+                "target_remote": "fedora-worker",
+            })
+        assert resp.status_code == 500
+        assert "remote not reachable" in resp.json()["error"]

--- a/tests/test_service_proxy.py
+++ b/tests/test_service_proxy.py
@@ -1,0 +1,249 @@
+"""Unit tests for the /apps/{app_id}/ reverse-proxy route."""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+from httpx import AsyncClient, ASGITransport
+
+from tinyagentos.app import create_app
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def proxy_app(tmp_data_dir):
+    return create_app(data_dir=tmp_data_dir)
+
+
+@pytest_asyncio.fixture
+async def proxy_client(proxy_app):
+    """Client with auth session and installed_apps initialised."""
+    store = proxy_app.state.metrics
+    if store._db is not None:
+        await store.close()
+    await store.init()
+    await proxy_app.state.qmd_client.init()
+
+    # Initialise installed_apps store.
+    installed_apps = proxy_app.state.installed_apps
+    if installed_apps._db is not None:
+        await installed_apps.close()
+    await installed_apps.init()
+
+    proxy_app.state.auth.setup_user("admin", "Test Admin", "", "testpass")
+    rec = proxy_app.state.auth.find_user("admin")
+    token = proxy_app.state.auth.create_session(
+        user_id=rec["id"] if rec else "", long_lived=True
+    )
+    transport = ASGITransport(app=proxy_app)
+    async with AsyncClient(
+        transport=transport, base_url="http://test", cookies={"taos_session": token}
+    ) as c:
+        yield c, proxy_app.state.installed_apps
+
+    await installed_apps.close()
+    await store.close()
+    await proxy_app.state.qmd_client.close()
+    await proxy_app.state.http_client.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Redirect: /apps/{app_id} → /apps/{app_id}/
+# ---------------------------------------------------------------------------
+
+class TestTrailingSlashRedirect:
+    @pytest.mark.asyncio
+    async def test_no_trailing_slash_redirects(self, proxy_client):
+        client, store = proxy_client
+        resp = await client.get("/apps/myapp", follow_redirects=False)
+        assert resp.status_code == 307
+        assert resp.headers["location"] == "/apps/myapp/"
+
+
+# ---------------------------------------------------------------------------
+# 404 when app not installed
+# ---------------------------------------------------------------------------
+
+class TestNotInstalled:
+    @pytest.mark.asyncio
+    async def test_returns_404_for_unknown_app(self, proxy_client):
+        client, store = proxy_client
+        resp = await client.get("/apps/does-not-exist/")
+        assert resp.status_code == 404
+        assert "not installed" in resp.json()["error"]
+
+
+# ---------------------------------------------------------------------------
+# 503 when app installed but no runtime location
+# ---------------------------------------------------------------------------
+
+class TestNoRuntimeLocation:
+    @pytest.mark.asyncio
+    async def test_returns_503_when_no_runtime_location(self, proxy_client):
+        client, store = proxy_client
+        await store.install("myapp", "1.0")
+        # No update_runtime_location called → location is None.
+        resp = await client.get("/apps/myapp/")
+        assert resp.status_code == 503
+        assert "no runtime location" in resp.json()["error"]
+
+
+# ---------------------------------------------------------------------------
+# Upstream URL construction
+# ---------------------------------------------------------------------------
+
+def _make_fake_upstream(captured: dict):
+    """Return a mock httpx response for upstream calls."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.headers = {}
+
+    async def _iter():
+        yield b""
+
+    mock_resp.aiter_bytes = _iter
+    return mock_resp
+
+
+class TestUpstreamURLConstruction:
+    @pytest.mark.asyncio
+    async def test_upstream_url_built_from_runtime_location(self, proxy_client):
+        client, store = proxy_client
+        await store.install("svc", "1.0")
+        await store.update_runtime_location("svc", host="127.0.0.1", port=13000)
+
+        captured = {}
+        mock_client = MagicMock()
+
+        async def fake_request(method, url, **kwargs):
+            captured["url"] = str(url)
+            return _make_fake_upstream(captured)
+
+        mock_client.request = AsyncMock(side_effect=fake_request)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("tinyagentos.routes.service_proxy.httpx.AsyncClient", return_value=mock_client):
+            await client.get("/apps/svc/dashboard")
+
+        assert captured["url"] == "http://127.0.0.1:13000/dashboard"
+
+    @pytest.mark.asyncio
+    async def test_query_string_forwarded(self, proxy_client):
+        client, store = proxy_client
+        await store.install("svc", "1.0")
+        await store.update_runtime_location("svc", host="127.0.0.1", port=13001)
+
+        captured = {}
+        mock_client = MagicMock()
+
+        async def fake_request(method, url, **kwargs):
+            captured["url"] = str(url)
+            return _make_fake_upstream(captured)
+
+        mock_client.request = AsyncMock(side_effect=fake_request)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("tinyagentos.routes.service_proxy.httpx.AsyncClient", return_value=mock_client):
+            await client.get("/apps/svc/?q=hello&page=2")
+
+        assert "q=hello" in captured["url"]
+        assert "page=2" in captured["url"]
+
+
+# ---------------------------------------------------------------------------
+# Hop-by-hop header stripping
+# ---------------------------------------------------------------------------
+
+class TestHopByHopStripping:
+    @pytest.mark.asyncio
+    async def test_hop_by_hop_headers_stripped_from_request(self, proxy_client):
+        client, store = proxy_client
+        await store.install("svc", "1.0")
+        await store.update_runtime_location("svc", host="127.0.0.1", port=13002)
+
+        captured_headers = {}
+        mock_client = MagicMock()
+
+        async def fake_request(method, url, headers=None, **kwargs):
+            captured_headers.update(headers or {})
+            return _make_fake_upstream(captured_headers)
+
+        mock_client.request = AsyncMock(side_effect=fake_request)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("tinyagentos.routes.service_proxy.httpx.AsyncClient", return_value=mock_client):
+            await client.get(
+                "/apps/svc/",
+                headers={
+                    "Connection": "keep-alive",
+                    "Transfer-Encoding": "chunked",
+                    "X-Custom": "value",
+                },
+            )
+
+        lower = {k.lower(): v for k, v in captured_headers.items()}
+        assert "connection" not in lower
+        assert "transfer-encoding" not in lower
+        # Non-hop header passes through.
+        assert "x-custom" in lower
+
+
+# ---------------------------------------------------------------------------
+# Location header rewriting
+# ---------------------------------------------------------------------------
+
+class TestLocationHeaderRewrite:
+    @pytest.mark.asyncio
+    async def test_absolute_location_rewritten(self, proxy_client):
+        client, store = proxy_client
+        await store.install("svc", "1.0")
+        await store.update_runtime_location("svc", host="127.0.0.1", port=13003)
+
+        mock_client = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 302
+        mock_resp.headers = {"location": "http://127.0.0.1:13003/new-path"}
+
+        async def _iter():
+            yield b""
+
+        mock_resp.aiter_bytes = _iter
+        mock_client.request = AsyncMock(return_value=mock_resp)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("tinyagentos.routes.service_proxy.httpx.AsyncClient", return_value=mock_client):
+            resp = await client.get("/apps/svc/old-path", follow_redirects=False)
+
+        assert resp.status_code == 302
+        assert resp.headers["location"] == "/apps/svc/new-path"
+
+    @pytest.mark.asyncio
+    async def test_relative_location_not_rewritten(self, proxy_client):
+        client, store = proxy_client
+        await store.install("svc", "1.0")
+        await store.update_runtime_location("svc", host="127.0.0.1", port=13004)
+
+        mock_client = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 302
+        mock_resp.headers = {"location": "/relative/path"}
+
+        async def _iter():
+            yield b""
+
+        mock_resp.aiter_bytes = _iter
+        mock_client.request = AsyncMock(return_value=mock_resp)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("tinyagentos.routes.service_proxy.httpx.AsyncClient", return_value=mock_client):
+            resp = await client.get("/apps/svc/", follow_redirects=False)
+
+        assert resp.headers["location"] == "/relative/path"

--- a/tests/test_service_proxy.py
+++ b/tests/test_service_proxy.py
@@ -105,7 +105,31 @@ def _make_fake_upstream(captured: dict):
         yield b""
 
     mock_resp.aiter_bytes = _iter
+    mock_resp.aclose = AsyncMock()
     return mock_resp
+
+
+def _make_mock_client(side_effect=None, return_value=None, capture_url=None):
+    """Build a mock _http_client that supports build_request / send(stream=True).
+
+    When capture_url is a dict, stores the built URL string in capture_url["url"].
+    """
+    mock_client = MagicMock()
+
+    def fake_build(method, url, **kwargs):
+        """Return a lightweight object carrying the URL string."""
+        req = MagicMock()
+        req.url = url  # httpx passes url as a str to build_request
+        if capture_url is not None:
+            capture_url["url"] = str(url)
+        return req
+
+    mock_client.build_request = MagicMock(side_effect=fake_build)
+    if side_effect is not None:
+        mock_client.send = AsyncMock(side_effect=side_effect)
+    else:
+        mock_client.send = AsyncMock(return_value=return_value)
+    return mock_client
 
 
 class TestUpstreamURLConstruction:
@@ -116,17 +140,13 @@ class TestUpstreamURLConstruction:
         await store.update_runtime_location("svc", host="127.0.0.1", port=13000)
 
         captured = {}
-        mock_client = MagicMock()
 
-        async def fake_request(method, url, **kwargs):
-            captured["url"] = str(url)
+        async def fake_send(req, **kwargs):
             return _make_fake_upstream(captured)
 
-        mock_client.request = AsyncMock(side_effect=fake_request)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client = _make_mock_client(side_effect=fake_send, capture_url=captured)
 
-        with patch("tinyagentos.routes.service_proxy.httpx.AsyncClient", return_value=mock_client):
+        with patch("tinyagentos.routes.service_proxy._http_client", mock_client):
             await client.get("/apps/svc/dashboard")
 
         assert captured["url"] == "http://127.0.0.1:13000/dashboard"
@@ -138,17 +158,13 @@ class TestUpstreamURLConstruction:
         await store.update_runtime_location("svc", host="127.0.0.1", port=13001)
 
         captured = {}
-        mock_client = MagicMock()
 
-        async def fake_request(method, url, **kwargs):
-            captured["url"] = str(url)
+        async def fake_send(req, **kwargs):
             return _make_fake_upstream(captured)
 
-        mock_client.request = AsyncMock(side_effect=fake_request)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client = _make_mock_client(side_effect=fake_send, capture_url=captured)
 
-        with patch("tinyagentos.routes.service_proxy.httpx.AsyncClient", return_value=mock_client):
+        with patch("tinyagentos.routes.service_proxy._http_client", mock_client):
             await client.get("/apps/svc/?q=hello&page=2")
 
         assert "q=hello" in captured["url"]
@@ -167,17 +183,23 @@ class TestHopByHopStripping:
         await store.update_runtime_location("svc", host="127.0.0.1", port=13002)
 
         captured_headers = {}
-        mock_client = MagicMock()
+        real_build = None
 
-        async def fake_request(method, url, headers=None, **kwargs):
+        def fake_build_request(method, url, headers=None, **kwargs):
             captured_headers.update(headers or {})
+            req = MagicMock()
+            req.url = url
+            req.headers = headers or {}
+            return req
+
+        async def fake_send(req, **kwargs):
             return _make_fake_upstream(captured_headers)
 
-        mock_client.request = AsyncMock(side_effect=fake_request)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client = MagicMock()
+        mock_client.build_request = MagicMock(side_effect=fake_build_request)
+        mock_client.send = AsyncMock(side_effect=fake_send)
 
-        with patch("tinyagentos.routes.service_proxy.httpx.AsyncClient", return_value=mock_client):
+        with patch("tinyagentos.routes.service_proxy._http_client", mock_client):
             await client.get(
                 "/apps/svc/",
                 headers={
@@ -205,7 +227,6 @@ class TestLocationHeaderRewrite:
         await store.install("svc", "1.0")
         await store.update_runtime_location("svc", host="127.0.0.1", port=13003)
 
-        mock_client = MagicMock()
         mock_resp = MagicMock()
         mock_resp.status_code = 302
         mock_resp.headers = {"location": "http://127.0.0.1:13003/new-path"}
@@ -214,11 +235,10 @@ class TestLocationHeaderRewrite:
             yield b""
 
         mock_resp.aiter_bytes = _iter
-        mock_client.request = AsyncMock(return_value=mock_resp)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_resp.aclose = AsyncMock()
+        mock_client = _make_mock_client(return_value=mock_resp)
 
-        with patch("tinyagentos.routes.service_proxy.httpx.AsyncClient", return_value=mock_client):
+        with patch("tinyagentos.routes.service_proxy._http_client", mock_client):
             resp = await client.get("/apps/svc/old-path", follow_redirects=False)
 
         assert resp.status_code == 302
@@ -230,7 +250,6 @@ class TestLocationHeaderRewrite:
         await store.install("svc", "1.0")
         await store.update_runtime_location("svc", host="127.0.0.1", port=13004)
 
-        mock_client = MagicMock()
         mock_resp = MagicMock()
         mock_resp.status_code = 302
         mock_resp.headers = {"location": "/relative/path"}
@@ -239,11 +258,10 @@ class TestLocationHeaderRewrite:
             yield b""
 
         mock_resp.aiter_bytes = _iter
-        mock_client.request = AsyncMock(return_value=mock_resp)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_resp.aclose = AsyncMock()
+        mock_client = _make_mock_client(return_value=mock_resp)
 
-        with patch("tinyagentos.routes.service_proxy.httpx.AsyncClient", return_value=mock_client):
+        with patch("tinyagentos.routes.service_proxy._http_client", mock_client):
             resp = await client.get("/apps/svc/", follow_redirects=False)
 
         assert resp.headers["location"] == "/relative/path"

--- a/tests/test_service_proxy.py
+++ b/tests/test_service_proxy.py
@@ -245,14 +245,17 @@ class TestLocationHeaderRewrite:
         assert resp.headers["location"] == "/apps/svc/new-path"
 
     @pytest.mark.asyncio
-    async def test_relative_location_not_rewritten(self, proxy_client):
+    async def test_root_relative_location_rewritten(self, proxy_client):
+        # Path-absolute redirects (e.g. Gitea's "/user/login") hit the
+        # controller root, not the proxied app, unless the proxy prepends
+        # /apps/{app_id}. Verify we do that.
         client, store = proxy_client
         await store.install("svc", "1.0")
         await store.update_runtime_location("svc", host="127.0.0.1", port=13004)
 
         mock_resp = MagicMock()
         mock_resp.status_code = 302
-        mock_resp.headers = {"location": "/relative/path"}
+        mock_resp.headers = {"location": "/user/login"}
 
         async def _iter():
             yield b""
@@ -264,4 +267,27 @@ class TestLocationHeaderRewrite:
         with patch("tinyagentos.routes.service_proxy._http_client", mock_client):
             resp = await client.get("/apps/svc/", follow_redirects=False)
 
-        assert resp.headers["location"] == "/relative/path"
+        assert resp.headers["location"] == "/apps/svc/user/login"
+
+    @pytest.mark.asyncio
+    async def test_scheme_relative_location_passes_through(self, proxy_client):
+        # //cdn.example.com/foo is scheme-relative, not proxy-scoped; leave it.
+        client, store = proxy_client
+        await store.install("svc", "1.0")
+        await store.update_runtime_location("svc", host="127.0.0.1", port=13004)
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 302
+        mock_resp.headers = {"location": "//cdn.example.com/asset.js"}
+
+        async def _iter():
+            yield b""
+
+        mock_resp.aiter_bytes = _iter
+        mock_resp.aclose = AsyncMock()
+        mock_client = _make_mock_client(return_value=mock_resp)
+
+        with patch("tinyagentos.routes.service_proxy._http_client", mock_client):
+            resp = await client.get("/apps/svc/", follow_redirects=False)
+
+        assert resp.headers["location"] == "//cdn.example.com/asset.js"

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -825,6 +825,9 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     from tinyagentos.routes.cluster import router as cluster_router
     app.include_router(cluster_router)
 
+    from tinyagentos.routes.cluster_migrate import router as cluster_migrate_router
+    app.include_router(cluster_migrate_router)
+
     from tinyagentos.routes.training import router as training_router
     app.include_router(training_router)
 

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -936,6 +936,9 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     from tinyagentos.routes.recycle import router as recycle_router
     app.include_router(recycle_router)
 
+    from tinyagentos.routes.service_proxy import router as service_proxy_router
+    app.include_router(service_proxy_router)
+
     from tinyagentos.routes import admin_prompts as admin_prompts_routes
     app.include_router(admin_prompts_routes.router)
 

--- a/tinyagentos/cluster/service_migrator.py
+++ b/tinyagentos/cluster/service_migrator.py
@@ -1,0 +1,191 @@
+"""State-path service migration for LXC-hosted taOS services.
+
+Migrates a running service to a new incus host by:
+  1. Deploying a fresh container on the target (correct arch).
+  2. Stopping the source service gracefully.
+  3. Streaming state paths out as a tarball.
+  4. Restoring the tarball into the target container.
+  5. Starting the target service.
+  6. Optionally destroying the source.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import shlex
+import time
+import uuid
+
+import tinyagentos.containers as containers
+from tinyagentos.installers.lxc_installer import LXCInstaller
+
+logger = logging.getLogger(__name__)
+
+_INSTALLER_PREFIX = "taos-svc-"
+
+
+async def migrate_service(
+    app_id: str,
+    target_remote: str,
+    *,
+    install_config: dict,
+    state_paths: list[str],
+    service_name: str = "gitea",
+    keep_source: bool = False,
+    restart_target: bool = True,
+) -> dict:
+    """Migrate an installed LXC service to another incus host.
+
+    Steps:
+    1. Verify target_remote is registered (incus remote list).
+    2. Derive source container name (taos-svc-<app_id>).
+    3. Stop source service gracefully (systemctl stop <service> inside container).
+    4. tar the state_paths inside the source container, stream to a temp file
+       on the controller host via incus file pull.
+    5. Call LXCInstaller.install() with target_remote and restore_tarball.
+    6. On success + keep_source=False: incus delete source --force.
+    7. On failure: restart source service so user doesn't lose access, raise.
+
+    TODO (P5): re-point external routing (reverse proxy / DNS) after migration.
+
+    Parameters
+    ----------
+    app_id:
+        Catalog app identifier (e.g. "gitea").
+    target_remote:
+        Registered incus remote name for the destination host.
+    install_config:
+        ``install`` block from the manifest (passed through to LXCInstaller).
+    state_paths:
+        Container-side paths to include in the state tarball
+        (e.g. ["/etc/gitea/", "/home/git/"]).
+    service_name:
+        systemd unit name inside the container (e.g. "gitea").
+    keep_source:
+        When True, do not destroy the source container after migration.
+    restart_target:
+        When True (default), enable and start the service on the target after
+        restore. LXCInstaller already does this, so this flag is informational.
+
+    Returns
+    -------
+    dict with keys: success, source, target, duration_s, tarball_size_bytes.
+    """
+    t0 = time.monotonic()
+
+    container_name = f"{_INSTALLER_PREFIX}{app_id}"
+    tarball_path = f"/tmp/taos-migrate-{uuid.uuid4().hex}.tar"
+
+    # 1. Verify target_remote is registered.
+    remotes = await containers.remote_list()
+    registered = {r["name"] for r in remotes}
+    if target_remote not in registered:
+        return {
+            "success": False,
+            "error": (
+                f"Remote '{target_remote}' is not registered. "
+                f"Register it first with: incus remote add {target_remote} <url> --accept-certificate"
+            ),
+        }
+
+    # 2. Verify source container exists.
+    info_code, _ = await containers._run(["incus", "info", container_name])
+    if info_code != 0:
+        return {
+            "success": False,
+            "error": f"Source container '{container_name}' not found on local host.",
+        }
+
+    # 3. Stop source service gracefully.
+    logger.info("migrate_service: stopping %s in %s", service_name, container_name)
+    stop_code, stop_out = await containers.exec_in_container(
+        container_name,
+        ["systemctl", "stop", shlex.quote(service_name)],
+        timeout=60,
+    )
+    # systemctl stop is best-effort; log but continue if it fails.
+    if stop_code != 0:
+        logger.warning(
+            "migrate_service: systemctl stop %s returned %d: %s",
+            service_name, stop_code, stop_out,
+        )
+
+    try:
+        # 4. Create tar of state paths inside the container, then pull out to host.
+        quoted_paths = " ".join(shlex.quote(p) for p in state_paths)
+        logger.info(
+            "migrate_service: archiving state paths %s from %s", state_paths, container_name
+        )
+        tar_code, tar_out = await containers.exec_in_container(
+            container_name,
+            ["bash", "-c", f"tar -cpf /tmp/state.tar --numeric-owner {quoted_paths}"],
+            timeout=300,
+        )
+        if tar_code != 0:
+            raise RuntimeError(f"Failed to create state tarball in container: {tar_out}")
+
+        # Pull the tarball from the container to the controller host.
+        pull_code, pull_out = await containers._run(
+            ["incus", "file", "pull", f"{container_name}/tmp/state.tar", tarball_path],
+            timeout=300,
+        )
+        if pull_code != 0:
+            raise RuntimeError(f"Failed to pull state tarball from container: {pull_out}")
+
+        # Clean up tarball inside source container.
+        await containers.exec_in_container(container_name, ["rm", "-f", "/tmp/state.tar"])
+
+        import os
+        tarball_size = os.path.getsize(tarball_path)
+        logger.info(
+            "migrate_service: tarball pulled to %s (%d bytes)", tarball_path, tarball_size
+        )
+
+        # 5. Deploy fresh container on target and restore state.
+        installer = LXCInstaller()
+        install_result = await installer.install(
+            app_id,
+            install_config,
+            admin_password="",  # ignored in restore mode
+            restore_tarball=tarball_path,
+            target_remote=target_remote,
+        )
+        if not install_result.get("success"):
+            raise RuntimeError(
+                f"Install on target failed: {install_result.get('error', 'unknown error')}"
+            )
+
+        # 6. Destroy source unless keep_source.
+        if not keep_source:
+            logger.info("migrate_service: destroying source container %s", container_name)
+            await containers.destroy_container(container_name)
+
+        duration = round(time.monotonic() - t0, 1)
+        return {
+            "success": True,
+            "source": f"local:{container_name}",
+            "target": f"{target_remote}:{container_name}",
+            "duration_s": duration,
+            "tarball_size_bytes": tarball_size,
+        }
+
+    except Exception as exc:
+        # Rollback: restart source service so user doesn't lose access.
+        logger.error("migrate_service: failed (%s) — restarting source service", exc)
+        restart_code, restart_out = await containers.exec_in_container(
+            container_name,
+            ["systemctl", "start", shlex.quote(service_name)],
+            timeout=60,
+        )
+        if restart_code != 0:
+            logger.error(
+                "migrate_service: source service restart also failed: %s", restart_out
+            )
+        raise
+    finally:
+        # Always clean up the host-side tarball.
+        import os
+        try:
+            os.unlink(tarball_path)
+        except OSError:
+            pass

--- a/tinyagentos/cluster/service_migrator.py
+++ b/tinyagentos/cluster/service_migrator.py
@@ -33,6 +33,7 @@ async def migrate_service(
     service_name: str = "gitea",
     keep_source: bool = False,
     restart_target: bool = True,
+    source_remote: str | None = None,
 ) -> dict:
     """Migrate an installed LXC service to another incus host.
 
@@ -66,6 +67,9 @@ async def migrate_service(
     restart_target:
         When True (default), enable and start the service on the target after
         restore. LXCInstaller already does this, so this flag is informational.
+    source_remote:
+        Registered incus remote name for the source host. None means local.
+        Cannot equal target_remote (no-op migration not allowed).
 
     Returns
     -------
@@ -73,8 +77,23 @@ async def migrate_service(
     """
     t0 = time.monotonic()
 
+    # Reject same-remote migration.
+    if source_remote is not None and source_remote == target_remote:
+        return {
+            "success": False,
+            "error": (
+                f"source_remote and target_remote are both '{source_remote}'. "
+                "Migration between the same host is a no-op."
+            ),
+        }
+
     container_name = f"{_INSTALLER_PREFIX}{app_id}"
     tarball_path = f"/tmp/taos-migrate-{uuid.uuid4().hex}.tar"
+
+    # Build the incus name used for all source-side operations.
+    source_incus_name = (
+        f"{source_remote}:{container_name}" if source_remote else container_name
+    )
 
     # 1. Verify target_remote is registered.
     remotes = await containers.remote_list()
@@ -89,17 +108,18 @@ async def migrate_service(
         }
 
     # 2. Verify source container exists.
-    info_code, _ = await containers._run(["incus", "info", container_name])
+    info_code, _ = await containers._run(["incus", "info", source_incus_name])
     if info_code != 0:
+        host_label = source_remote or "local"
         return {
             "success": False,
-            "error": f"Source container '{container_name}' not found on local host.",
+            "error": f"Source container '{container_name}' not found on {host_label} host.",
         }
 
     # 3. Stop source service gracefully.
-    logger.info("migrate_service: stopping %s in %s", service_name, container_name)
+    logger.info("migrate_service: stopping %s in %s", service_name, source_incus_name)
     stop_code, stop_out = await containers.exec_in_container(
-        container_name,
+        source_incus_name,
         ["systemctl", "stop", shlex.quote(service_name)],
         timeout=60,
     )
@@ -114,10 +134,10 @@ async def migrate_service(
         # 4. Create tar of state paths inside the container, then pull out to host.
         quoted_paths = " ".join(shlex.quote(p) for p in state_paths)
         logger.info(
-            "migrate_service: archiving state paths %s from %s", state_paths, container_name
+            "migrate_service: archiving state paths %s from %s", state_paths, source_incus_name
         )
         tar_code, tar_out = await containers.exec_in_container(
-            container_name,
+            source_incus_name,
             ["bash", "-c", f"tar -cpf /tmp/state.tar --numeric-owner {quoted_paths}"],
             timeout=300,
         )
@@ -126,14 +146,14 @@ async def migrate_service(
 
         # Pull the tarball from the container to the controller host.
         pull_code, pull_out = await containers._run(
-            ["incus", "file", "pull", f"{container_name}/tmp/state.tar", tarball_path],
+            ["incus", "file", "pull", f"{source_incus_name}/tmp/state.tar", tarball_path],
             timeout=300,
         )
         if pull_code != 0:
             raise RuntimeError(f"Failed to pull state tarball from container: {pull_out}")
 
         # Clean up tarball inside source container.
-        await containers.exec_in_container(container_name, ["rm", "-f", "/tmp/state.tar"])
+        await containers.exec_in_container(source_incus_name, ["rm", "-f", "/tmp/state.tar"])
 
         import os
         tarball_size = os.path.getsize(tarball_path)
@@ -157,13 +177,14 @@ async def migrate_service(
 
         # 6. Destroy source unless keep_source.
         if not keep_source:
-            logger.info("migrate_service: destroying source container %s", container_name)
-            await containers.destroy_container(container_name)
+            logger.info("migrate_service: destroying source container %s", source_incus_name)
+            await containers._run(["incus", "delete", source_incus_name, "--force"])
 
         duration = round(time.monotonic() - t0, 1)
+        source_label = source_remote or "local"
         return {
             "success": True,
-            "source": f"local:{container_name}",
+            "source": f"{source_label}:{container_name}",
             "target": f"{target_remote}:{container_name}",
             "duration_s": duration,
             "tarball_size_bytes": tarball_size,
@@ -173,7 +194,7 @@ async def migrate_service(
         # Rollback: restart source service so user doesn't lose access.
         logger.error("migrate_service: failed (%s) — restarting source service", exc)
         restart_code, restart_out = await containers.exec_in_container(
-            container_name,
+            source_incus_name,
             ["systemctl", "start", shlex.quote(service_name)],
             timeout=60,
         )

--- a/tinyagentos/cluster/service_migrator.py
+++ b/tinyagentos/cluster/service_migrator.py
@@ -201,6 +201,9 @@ async def migrate_service(
             "target": f"{target_label}:{container_name}",
             "duration_s": duration,
             "tarball_size_bytes": tarball_size,
+            # Expose install result fields so the caller can update the registry.
+            "host_port": install_result.get("host_port"),
+            "target_remote": target_remote_norm,
         }
 
     except Exception as exc:

--- a/tinyagentos/cluster/service_migrator.py
+++ b/tinyagentos/cluster/service_migrator.py
@@ -77,12 +77,23 @@ async def migrate_service(
     """
     t0 = time.monotonic()
 
-    # Reject same-remote migration.
-    if source_remote is not None and source_remote == target_remote:
+    # Normalise "local" / "" / None to None — incus treats the local daemon
+    # as an implicit remote, not a registered one.
+    def _normalise(r: str | None) -> str | None:
+        if r is None or r == "" or r == "local":
+            return None
+        return r
+
+    source_remote = _normalise(source_remote)
+    target_remote_norm = _normalise(target_remote)
+
+    # Reject same-remote migration (including local→local).
+    if source_remote == target_remote_norm:
+        label = source_remote or "local"
         return {
             "success": False,
             "error": (
-                f"source_remote and target_remote are both '{source_remote}'. "
+                f"source_remote and target_remote both resolve to '{label}'. "
                 "Migration between the same host is a no-op."
             ),
         }
@@ -95,17 +106,18 @@ async def migrate_service(
         f"{source_remote}:{container_name}" if source_remote else container_name
     )
 
-    # 1. Verify target_remote is registered.
-    remotes = await containers.remote_list()
-    registered = {r["name"] for r in remotes}
-    if target_remote not in registered:
-        return {
-            "success": False,
-            "error": (
-                f"Remote '{target_remote}' is not registered. "
-                f"Register it first with: incus remote add {target_remote} <url> --accept-certificate"
-            ),
-        }
+    # 1. Verify target_remote is registered (skip for local target).
+    if target_remote_norm is not None:
+        remotes = await containers.remote_list()
+        registered = {r["name"] for r in remotes}
+        if target_remote_norm not in registered:
+            return {
+                "success": False,
+                "error": (
+                    f"Remote '{target_remote_norm}' is not registered. "
+                    f"Register it first with: incus remote add {target_remote_norm} <url> --accept-certificate"
+                ),
+            }
 
     # 2. Verify source container exists.
     info_code, _ = await containers._run(["incus", "info", source_incus_name])
@@ -168,7 +180,7 @@ async def migrate_service(
             install_config,
             admin_password="",  # ignored in restore mode
             restore_tarball=tarball_path,
-            target_remote=target_remote,
+            target_remote=target_remote_norm,
         )
         if not install_result.get("success"):
             raise RuntimeError(
@@ -182,10 +194,11 @@ async def migrate_service(
 
         duration = round(time.monotonic() - t0, 1)
         source_label = source_remote or "local"
+        target_label = target_remote_norm or "local"
         return {
             "success": True,
             "source": f"{source_label}:{container_name}",
-            "target": f"{target_remote}:{container_name}",
+            "target": f"{target_label}:{container_name}",
             "duration_s": duration,
             "tarball_size_bytes": tarball_size,
         }

--- a/tinyagentos/containers/__init__.py
+++ b/tinyagentos/containers/__init__.py
@@ -535,7 +535,8 @@ async def migrate_container(
 
     if code != 0:
         # Rollback: restart source if we stopped it.
-        if stateless and was_running and not keep_source:
+        # Source is stopped for all stateless migrations regardless of keep_source.
+        if stateless and was_running:
             restart_result = await start_container(container_name)
             if not restart_result["success"]:
                 logger.error(
@@ -556,6 +557,15 @@ async def migrate_container(
             logger.warning(
                 "migrate_container: container moved but failed to start on %s: %s",
                 target_ref, start_out,
+            )
+
+    # For keep_source copy flows, restore source running state after successful copy.
+    if keep_source and stateless and was_running:
+        restart_result = await start_container(container_name)
+        if not restart_result["success"]:
+            logger.warning(
+                "migrate_container: source restart failed after copy for %s: %s",
+                container_name, restart_result.get("output", ""),
             )
 
     # Clean up pre-stop snapshot on source (only relevant for copy, since move destroys source).

--- a/tinyagentos/containers/__init__.py
+++ b/tinyagentos/containers/__init__.py
@@ -335,10 +335,22 @@ async def snapshot_delete(name: str, snapshot_name: str) -> None:
         )
 
 
-async def remote_add(name: str, url: str, token: str) -> dict:
-    """Add a remote incus server to the local incus config using a trust token.
+async def remote_add(
+    name: str,
+    url: str,
+    *,
+    token: str,
+    accept_certificate: bool = True,
+) -> dict:
+    """Register an incus remote host using a one-time TLS token (incus 6.x).
 
-    Runs ``incus remote add <name> <url> --token=<token> --accept-certificate``.
+    Wraps ``incus remote add <name> <url> --token <token>`` (plus
+    ``--accept-certificate`` when *accept_certificate* is True).
+
+    The token is generated on the target host via ``remote_generate_token``
+    and must be passed by the caller.  ``core.trust_password`` was removed
+    in incus 6.x; this is the replacement enrollment flow.
+
     Returns ``{"success": bool, "output": str}``.
 
     Idempotent: if a remote with *name* already exists and points to *url*,
@@ -365,12 +377,45 @@ async def remote_add(name: str, url: str, token: str) -> dict:
         except Exception:
             pass  # If we can't parse the list, fall through and let remote add fail naturally
 
-    code, output = await _run([
-        "incus", "remote", "add", name, url,
-        f"--token={token}",
-        "--accept-certificate",
-    ])
+    cmd = ["incus", "remote", "add", name, url, "--token", token]
+    if accept_certificate:
+        cmd.append("--accept-certificate")
+    code, output = await _run(cmd)
     return {"success": code == 0, "output": output}
+
+
+async def remote_generate_token(
+    client_name: str,
+    *,
+    projects: list[str] | None = None,
+    restricted: bool = False,
+) -> dict:
+    """Run ``incus config trust add`` on the LOCAL incus; return ``{"token": "..."}``.
+
+    This must be called on the **target host** (the one being enrolled INTO),
+    not on the source.  In cluster context, invoke this via the worker registry
+    to ask the target worker to generate a token for the source host.
+
+    The command output ends with a base64-encoded token on its own line.
+
+    Returns ``{"success": bool, "token": str, "output": str}``.
+    """
+    cmd = ["incus", "config", "trust", "add", client_name]
+    if restricted:
+        cmd.append("--restricted")
+    if projects:
+        cmd.extend(["--projects", ",".join(projects)])
+    code, output = await _run(cmd)
+    if code != 0:
+        return {"success": False, "token": "", "output": output}
+    # The token is the last non-empty line of the output.
+    token = ""
+    for line in reversed(output.strip().splitlines()):
+        line = line.strip()
+        if line:
+            token = line
+            break
+    return {"success": True, "token": token, "output": output}
 
 
 async def remote_list() -> list[dict]:
@@ -572,6 +617,7 @@ __all__ = [
     "snapshot_delete",
     "set_env",
     "remote_add",
+    "remote_generate_token",
     "remote_list",
     "remote_remove",
     "migrate_container",

--- a/tinyagentos/containers/__init__.py
+++ b/tinyagentos/containers/__init__.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import time
 
 from .backend import ContainerInfo, _parse_memory, detect_runtime, get_backend, set_backend
 from .lxc import LXCBackend
@@ -372,6 +373,159 @@ async def remote_add(name: str, url: str, token: str) -> dict:
     return {"success": code == 0, "output": output}
 
 
+async def remote_list() -> list[dict]:
+    """Return registered incus remotes as a list of dicts with name/addr/protocol.
+
+    Wraps ``incus remote list --format=csv``.  Returns an empty list on error.
+    """
+    code, output = await _run(["incus", "remote", "list", "--format=csv"])
+    if code != 0:
+        logger.error("incus remote list failed: %s", output)
+        return []
+    remotes: list[dict] = []
+    for line in output.strip().splitlines():
+        parts = [p.strip() for p in line.split(",")]
+        # CSV columns: NAME,URL,PROTOCOL,AUTH_TYPE,PUBLIC,STATIC,GLOBAL
+        if len(parts) < 3 or not parts[0]:
+            continue
+        remotes.append({"name": parts[0], "addr": parts[1], "protocol": parts[2]})
+    return remotes
+
+
+async def remote_remove(name: str) -> dict:
+    """Remove a registered incus remote.
+
+    Returns ``{"success": bool, "output": str}``.
+    """
+    code, output = await _run(["incus", "remote", "remove", name])
+    return {"success": code == 0, "output": output}
+
+
+async def migrate_container(
+    container_name: str,
+    target_remote: str,
+    *,
+    new_name: str | None = None,
+    stateless: bool = True,
+    keep_source: bool = False,
+    timeout: int = 600,
+) -> dict:
+    """Move or copy a container to a remote incus host.
+
+    Steps:
+    1. Verify source container exists; fail with clear error if not.
+    2. Verify target remote is registered; fail with clear error including the
+       ``incus remote add`` command the user needs to run if not.
+    3. If stateless=True and container is running: create a pre-stop snapshot,
+       stop the container, run move/copy, then start the copy on the target.
+    4. If stateless=False: pass ``--live`` to incus (requires CRIU on both hosts).
+    5. On failure after stop: restart the source container (rollback).
+
+    ``keep_source=True`` uses ``incus copy`` (both hosts keep the container);
+    ``keep_source=False`` uses ``incus move`` (source is destroyed on success).
+
+    Returns ``{"success": True, "source": "local:<name>", "target": "<remote>:<dest>",
+    "duration_s": N}`` on success.
+    """
+    dest_name = new_name or container_name
+    source_ref = f"local:{container_name}"
+    target_ref = f"{target_remote}:{dest_name}"
+
+    t0 = time.monotonic()
+
+    # 1. Verify source exists.
+    info_code, info_out = await _run(["incus", "info", container_name])
+    if info_code != 0:
+        return {
+            "success": False,
+            "error": f"Container '{container_name}' not found on local host: {info_out.strip()}",
+        }
+
+    # 2. Verify target remote is registered.
+    remotes = await remote_list()
+    remote_names = {r["name"] for r in remotes}
+    if target_remote not in remote_names:
+        return {
+            "success": False,
+            "error": (
+                f"Remote '{target_remote}' is not registered. "
+                f"Register it first with: incus remote add {target_remote} <url> --accept-certificate"
+            ),
+        }
+
+    # Determine if the container is currently running.
+    was_running = False
+    for line in info_out.splitlines():
+        if line.strip().lower().startswith("status:") and "running" in line.lower():
+            was_running = True
+            break
+
+    pre_stop_snapshot: str | None = None
+
+    if stateless and was_running:
+        # Take a pre-stop snapshot so we can recover if the move fails.
+        pre_stop_snapshot = f"taos-pre-migrate-{int(time.time())}"
+        snap_result = await snapshot_create(container_name, pre_stop_snapshot)
+        if not snap_result["success"]:
+            logger.warning(
+                "migrate_container: pre-stop snapshot failed for %s: %s",
+                container_name, snap_result.get("output", ""),
+            )
+            pre_stop_snapshot = None  # proceed without it
+
+        stop_result = await stop_container(container_name)
+        if not stop_result["success"]:
+            return {
+                "success": False,
+                "error": f"Failed to stop container '{container_name}': {stop_result['output']}",
+            }
+
+    # 3. Run move or copy.
+    incus_verb = "copy" if keep_source else "move"
+    cmd = ["incus", incus_verb, source_ref, target_ref, "--mode=push"]
+    if not stateless:
+        cmd.append("--live")
+
+    code, output = await _run(cmd, timeout=timeout)
+
+    if code != 0:
+        # Rollback: restart source if we stopped it.
+        if stateless and was_running and not keep_source:
+            restart_result = await start_container(container_name)
+            if not restart_result["success"]:
+                logger.error(
+                    "migrate_container: rollback start failed for %s: %s",
+                    container_name, restart_result.get("output", ""),
+                )
+        return {
+            "success": False,
+            "error": f"incus {incus_verb} failed: {output.strip()}",
+        }
+
+    # 4. Start on target if it was running and we did a stateless move.
+    if stateless and was_running:
+        start_code, start_out = await _run(
+            ["incus", "start", target_ref], timeout=120,
+        )
+        if start_code != 0:
+            logger.warning(
+                "migrate_container: container moved but failed to start on %s: %s",
+                target_ref, start_out,
+            )
+
+    # Clean up pre-stop snapshot on source (only relevant for copy, since move destroys source).
+    if keep_source and pre_stop_snapshot:
+        await snapshot_delete(container_name, pre_stop_snapshot)
+
+    duration = round(time.monotonic() - t0, 1)
+    return {
+        "success": True,
+        "source": source_ref,
+        "target": target_ref,
+        "duration_s": duration,
+    }
+
+
 async def set_env(name: str, key: str, value: str) -> dict:
     """Set an environment variable on a container via incus config set.
 
@@ -418,4 +572,7 @@ __all__ = [
     "snapshot_delete",
     "set_env",
     "remote_add",
+    "remote_list",
+    "remote_remove",
+    "migrate_container",
 ]

--- a/tinyagentos/installed_apps.py
+++ b/tinyagentos/installed_apps.py
@@ -11,6 +11,13 @@ class InstalledAppsStore(BaseStore):
         version TEXT DEFAULT '',
         metadata TEXT DEFAULT '{}'
     );
+    CREATE TABLE IF NOT EXISTS app_runtime (
+        app_id TEXT PRIMARY KEY,
+        runtime_host TEXT NOT NULL,
+        runtime_port INTEGER NOT NULL,
+        backend TEXT DEFAULT '',
+        ui_path TEXT DEFAULT '/'
+    );
     """
 
     async def install(self, app_id: str, version: str = "", metadata: dict | None = None) -> None:
@@ -21,6 +28,40 @@ class InstalledAppsStore(BaseStore):
             (app_id, time.time(), version, json.dumps(metadata or {})),
         )
         await self._db.commit()
+
+    async def update_runtime_location(
+        self,
+        app_id: str,
+        host: str,
+        port: int,
+        backend: str = "",
+        ui_path: str = "/",
+    ) -> None:
+        """Record (or update) the current host:port where app_id is reachable."""
+        assert self._db is not None
+        await self._db.execute(
+            "INSERT OR REPLACE INTO app_runtime (app_id, runtime_host, runtime_port, backend, ui_path) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (app_id, host, port, backend, ui_path),
+        )
+        await self._db.commit()
+
+    async def get_runtime_location(self, app_id: str) -> dict | None:
+        """Return the runtime location dict or None if not set."""
+        assert self._db is not None
+        cursor = await self._db.execute(
+            "SELECT runtime_host, runtime_port, backend, ui_path FROM app_runtime WHERE app_id = ?",
+            (app_id,),
+        )
+        row = await cursor.fetchone()
+        if row is None:
+            return None
+        return {
+            "runtime_host": row[0],
+            "runtime_port": row[1],
+            "backend": row[2],
+            "ui_path": row[3],
+        }
 
     async def uninstall(self, app_id: str) -> bool:
         assert self._db is not None
@@ -50,3 +91,9 @@ class InstalledAppsStore(BaseStore):
             {"app_id": r[0], "installed_at": r[1], "version": r[2], "metadata": json.loads(r[3] or "{}")}
             for r in rows
         ]
+
+    async def remove_runtime_location(self, app_id: str) -> None:
+        """Remove the runtime location for app_id (called on uninstall)."""
+        assert self._db is not None
+        await self._db.execute("DELETE FROM app_runtime WHERE app_id = ?", (app_id,))
+        await self._db.commit()

--- a/tinyagentos/installers/base.py
+++ b/tinyagentos/installers/base.py
@@ -37,6 +37,7 @@ def get_installer(method: str, **kwargs) -> AppInstaller:
     from tinyagentos.installers.pip_installer import PipInstaller
     from tinyagentos.installers.docker_installer import DockerInstaller
     from tinyagentos.installers.download_installer import DownloadInstaller
+    from tinyagentos.installers.lxc_installer import LXCInstaller
 
     if method == "pip":
         return PipInstaller(**kwargs)
@@ -44,5 +45,7 @@ def get_installer(method: str, **kwargs) -> AppInstaller:
         return DockerInstaller(**kwargs)
     elif method == "download":
         return DownloadInstaller(**kwargs)
+    elif method == "lxc":
+        return LXCInstaller(**kwargs)
     else:
         raise ValueError(f"Unknown install method: '{method}'")

--- a/tinyagentos/installers/lxc_installer.py
+++ b/tinyagentos/installers/lxc_installer.py
@@ -64,7 +64,7 @@ def _find_free_port(start: int = 13000, end: int = 14000) -> int:
     for port in range(start, end):
         with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
             try:
-                s.bind(("127.0.0.1", port))
+                s.bind(("0.0.0.0", port))
                 return port
             except OSError:
                 continue
@@ -290,20 +290,31 @@ class LXCInstaller(AppInstaller):
                 raise RuntimeError(f"Failed to start gitea service: {output}")
 
             # Step 8: Add proxy device (host_port → container:3000).
-            host_port = _find_free_port()
-            logger.info(
-                "LXCInstaller: adding proxy device host:%d -> container:3000", host_port
-            )
-            res = await containers.add_proxy_device(
-                incus_name,
-                device_name="gitea-http",
-                listen=f"tcp:0.0.0.0:{host_port}",
-                connect="tcp:127.0.0.1:3000",
-            )
-            if not res.get("success"):
-                raise RuntimeError(
-                    f"Failed to add proxy device: {res.get('output', '')}"
+            # Retry up to 10 times to handle the TOCTOU window between the
+            # port probe and the actual bind by incus.
+            for _attempt in range(10):
+                host_port = _find_free_port()
+                logger.info(
+                    "LXCInstaller: adding proxy device host:%d -> container:3000 (attempt %d)",
+                    host_port, _attempt + 1,
                 )
+                res = await containers.add_proxy_device(
+                    incus_name,
+                    device_name="gitea-http",
+                    listen=f"tcp:0.0.0.0:{host_port}",
+                    connect="tcp:127.0.0.1:3000",
+                )
+                if res.get("success"):
+                    break
+                if "address already in use" not in res.get("output", "").lower():
+                    raise RuntimeError(
+                        f"Failed to add proxy device: {res.get('output', '')}"
+                    )
+                logger.warning(
+                    "LXCInstaller: port %d already in use, retrying", host_port
+                )
+            else:
+                raise RuntimeError("Failed to allocate a free proxy port after 10 attempts")
 
             # Step 9: Record install metadata.
             install_record = {
@@ -324,10 +335,18 @@ class LXCInstaller(AppInstaller):
             await containers.destroy_container(incus_name)
             raise
 
-    async def uninstall(self, app_id: str) -> dict:
-        """Stop and delete the service container."""
+    async def uninstall(self, app_id: str, target_remote: str | None = None) -> dict:
+        """Stop and delete the service container.
+
+        Parameters
+        ----------
+        target_remote:
+            incus remote name. When set, the container is destroyed on the
+            remote host rather than locally.
+        """
         container_name = self._container_name(app_id)
-        result = await containers.destroy_container(container_name)
+        incus_name = f"{target_remote}:{container_name}" if target_remote else container_name
+        result = await containers.destroy_container(incus_name)
         return {"success": result["success"], "app_id": app_id}
 
     async def start(self, app_id: str) -> dict:

--- a/tinyagentos/installers/lxc_installer.py
+++ b/tinyagentos/installers/lxc_installer.py
@@ -87,6 +87,8 @@ class LXCInstaller(AppInstaller):
         admin_password: str,
         taos_username: str = "admin",
         taos_email: str = "",
+        restore_tarball: str | None = None,
+        target_remote: str | None = None,
         **kwargs,
     ) -> dict:
         """Install app_id into a new LXC container.
@@ -98,19 +100,37 @@ class LXCInstaller(AppInstaller):
         install_config:
             ``install`` block from the manifest YAML.
         admin_password:
-            Password for the initial service admin account. Required.
+            Password for the initial service admin account. Required unless
+            ``restore_tarball`` is set (state is restored from the tarball).
         taos_username:
             taOS username — becomes the Gitea admin username.
         taos_email:
             taOS user email — becomes the Gitea admin email.
+        restore_tarball:
+            Path on the HOST filesystem to a tar archive containing service
+            state (e.g. /etc/gitea/, /home/git/). When set, DB migration and
+            admin-user creation are skipped and app.ini is restored from the
+            tarball instead of being freshly generated.
+        target_remote:
+            incus remote name. When set, all container operations target
+            ``<target_remote>:<container_name>`` instead of the local daemon.
         """
-        if not admin_password:
+        if not restore_tarball and not admin_password:
             raise ValueError("admin_password is required for LXC installs")
 
         container_name = self._container_name(app_id)
+        # Qualify container name with remote when targeting a remote host.
+        incus_name = f"{target_remote}:{container_name}" if target_remote else container_name
 
         # Fail cleanly if container already exists.
-        if await containers.container_exists(container_name):
+        # For remote targets, container_exists uses `incus list` which doesn't
+        # accept remote:name — fall back to `incus info` which does.
+        if target_remote:
+            _info_code, _ = await containers._run(["incus", "info", incus_name])
+            _exists = _info_code == 0
+        else:
+            _exists = await containers.container_exists(incus_name)
+        if _exists:
             raise RuntimeError(
                 f"Container '{container_name}' already exists. "
                 "Uninstall first or choose a different app_id."
@@ -122,9 +142,9 @@ class LXCInstaller(AppInstaller):
         gitea_version = install_config.get("gitea_version", _DEFAULT_GITEA_VERSION)
 
         # Step 1: Create container.
-        logger.info("LXCInstaller: creating container %s from %s", container_name, image)
+        logger.info("LXCInstaller: creating container %s from %s", incus_name, image)
         result = await containers.create_container(
-            container_name,
+            incus_name,
             image=image,
             memory_limit=memory_limit,
             cpu_limit=cpu_limit,
@@ -137,7 +157,7 @@ class LXCInstaller(AppInstaller):
             import asyncio
             for _ in range(15):
                 code, output = await containers.exec_in_container(
-                    container_name, ["hostname", "-I"], timeout=10
+                    incus_name, ["hostname", "-I"], timeout=10
                 )
                 if code == 0 and output.strip():
                     break
@@ -146,9 +166,9 @@ class LXCInstaller(AppInstaller):
                 raise RuntimeError("Container did not get a network address in time")
 
             # Step 3: Install base packages and create git system user.
-            logger.info("LXCInstaller: installing packages in %s", container_name)
+            logger.info("LXCInstaller: installing packages in %s", incus_name)
             code, output = await containers.exec_in_container(
-                container_name,
+                incus_name,
                 [
                     "bash", "-c",
                     "apt-get update -qq && "
@@ -164,7 +184,7 @@ class LXCInstaller(AppInstaller):
             # Step 4: Download Gitea binary (auto-detect arch).
             logger.info("LXCInstaller: downloading Gitea %s", gitea_version)
             code, output = await containers.exec_in_container(
-                container_name,
+                incus_name,
                 [
                     "bash", "-c",
                     f"ARCH=$(dpkg --print-architecture) && "
@@ -177,71 +197,92 @@ class LXCInstaller(AppInstaller):
             if code != 0:
                 raise RuntimeError(f"Gitea download failed: {output}")
 
-            # Step 5: Write config and systemd unit.
-            # /etc/gitea must be root:git 770 and app.ini root:git 660 so the
-            # unprivileged git user can read the config at migrate time.
-            logger.info("LXCInstaller: writing config and systemd unit")
+            # Step 5: Write systemd unit.
+            logger.info("LXCInstaller: writing systemd unit")
             code, output = await containers.exec_in_container(
-                container_name,
-                ["bash", "-c", "mkdir -p /etc/gitea && chown root:git /etc/gitea && chmod 770 /etc/gitea"],
-            )
-            if code != 0:
-                raise RuntimeError(f"Failed to create /etc/gitea: {output}")
-
-            # Write app.ini (generate fresh secrets per install)
-            app_ini = _render_app_ini()
-            code, output = await containers.exec_in_container(
-                container_name,
-                ["bash", "-c",
-                 f"cat > /etc/gitea/app.ini << 'TAOS_EOF'\n{app_ini}\nTAOS_EOF\n"
-                 "chown root:git /etc/gitea/app.ini && chmod 660 /etc/gitea/app.ini"],
-            )
-            if code != 0:
-                raise RuntimeError(f"Failed to write app.ini: {output}")
-
-            # Write systemd unit
-            code, output = await containers.exec_in_container(
-                container_name,
+                incus_name,
                 ["bash", "-c", f"cat > /etc/systemd/system/gitea.service << 'TAOS_EOF'\n{_SYSTEMD_UNIT}\nTAOS_EOF"],
             )
             if code != 0:
                 raise RuntimeError(f"Failed to write systemd unit: {output}")
 
-            # Step 6: First-boot DB migration + admin user creation.
-            logger.info("LXCInstaller: running Gitea DB migration")
-            code, output = await containers.exec_in_container(
-                container_name,
-                ["su", "-", "git", "-c", "GITEA_WORK_DIR=/home/git gitea migrate -c /etc/gitea/app.ini"],
-                timeout=120,
-            )
-            if code != 0:
-                raise RuntimeError(f"Gitea migrate failed: {output}")
+            if restore_tarball:
+                # Restore mode: push the tarball and extract over state paths.
+                # app.ini, DB, and repos come from the tarball — skip writing app.ini
+                # and skip DB migration + admin user creation.
+                logger.info("LXCInstaller: restore mode — pushing tarball %s", restore_tarball)
+                push_code, push_out = await containers.push_file(
+                    incus_name, restore_tarball, "/tmp/restore.tar"
+                )
+                if push_code != 0:
+                    raise RuntimeError(f"Failed to push restore tarball: {push_out}")
 
-            logger.info("LXCInstaller: creating Gitea admin user '%s'", taos_username)
-            safe_username = shlex.quote(taos_username)
-            safe_email = shlex.quote(taos_email or taos_username + "@localhost")
-            safe_password = shlex.quote(admin_password)
-            code, output = await containers.exec_in_container(
-                container_name,
-                [
-                    "su", "-", "git", "-c",
-                    f"GITEA_WORK_DIR=/home/git gitea admin user create "
-                    f"--admin "
-                    f"--username {safe_username} "
-                    f"--email {safe_email} "
-                    f"--password {safe_password} "
-                    f"--must-change-password=false "
-                    f"-c /etc/gitea/app.ini",
-                ],
-                timeout=60,
-            )
-            if code != 0:
-                raise RuntimeError(f"Gitea admin user creation failed: {output}")
+                logger.info("LXCInstaller: extracting tarball in container")
+                code, output = await containers.exec_in_container(
+                    incus_name,
+                    ["tar", "--numeric-owner", "-xpf", "/tmp/restore.tar", "-C", "/"],
+                    timeout=300,
+                )
+                if code != 0:
+                    raise RuntimeError(f"Failed to extract restore tarball: {output}")
+
+                # Clean up tarball inside container.
+                await containers.exec_in_container(incus_name, ["rm", "-f", "/tmp/restore.tar"])
+            else:
+                # Fresh install: create /etc/gitea, write app.ini with new secrets.
+                logger.info("LXCInstaller: writing config")
+                code, output = await containers.exec_in_container(
+                    incus_name,
+                    ["bash", "-c", "mkdir -p /etc/gitea && chown root:git /etc/gitea && chmod 770 /etc/gitea"],
+                )
+                if code != 0:
+                    raise RuntimeError(f"Failed to create /etc/gitea: {output}")
+
+                app_ini = _render_app_ini()
+                code, output = await containers.exec_in_container(
+                    incus_name,
+                    ["bash", "-c",
+                     f"cat > /etc/gitea/app.ini << 'TAOS_EOF'\n{app_ini}\nTAOS_EOF\n"
+                     "chown root:git /etc/gitea/app.ini && chmod 660 /etc/gitea/app.ini"],
+                )
+                if code != 0:
+                    raise RuntimeError(f"Failed to write app.ini: {output}")
+
+                # Step 6: First-boot DB migration + admin user creation.
+                logger.info("LXCInstaller: running Gitea DB migration")
+                code, output = await containers.exec_in_container(
+                    incus_name,
+                    ["su", "-", "git", "-c", "GITEA_WORK_DIR=/home/git gitea migrate -c /etc/gitea/app.ini"],
+                    timeout=120,
+                )
+                if code != 0:
+                    raise RuntimeError(f"Gitea migrate failed: {output}")
+
+                logger.info("LXCInstaller: creating Gitea admin user '%s'", taos_username)
+                safe_username = shlex.quote(taos_username)
+                safe_email = shlex.quote(taos_email or taos_username + "@localhost")
+                safe_password = shlex.quote(admin_password)
+                code, output = await containers.exec_in_container(
+                    incus_name,
+                    [
+                        "su", "-", "git", "-c",
+                        f"GITEA_WORK_DIR=/home/git gitea admin user create "
+                        f"--admin "
+                        f"--username {safe_username} "
+                        f"--email {safe_email} "
+                        f"--password {safe_password} "
+                        f"--must-change-password=false "
+                        f"-c /etc/gitea/app.ini",
+                    ],
+                    timeout=60,
+                )
+                if code != 0:
+                    raise RuntimeError(f"Gitea admin user creation failed: {output}")
 
             # Step 7: Enable and start service.
             logger.info("LXCInstaller: enabling and starting gitea.service")
             code, output = await containers.exec_in_container(
-                container_name,
+                incus_name,
                 ["bash", "-c", "systemctl daemon-reload && systemctl enable gitea && systemctl start gitea"],
                 timeout=60,
             )
@@ -254,7 +295,7 @@ class LXCInstaller(AppInstaller):
                 "LXCInstaller: adding proxy device host:%d -> container:3000", host_port
             )
             res = await containers.add_proxy_device(
-                container_name,
+                incus_name,
                 device_name="gitea-http",
                 listen=f"tcp:0.0.0.0:{host_port}",
                 connect="tcp:127.0.0.1:3000",
@@ -278,9 +319,9 @@ class LXCInstaller(AppInstaller):
 
         except Exception:
             logger.exception(
-                "LXCInstaller: rolling back — destroying container %s", container_name
+                "LXCInstaller: rolling back — destroying container %s", incus_name
             )
-            await containers.destroy_container(container_name)
+            await containers.destroy_container(incus_name)
             raise
 
     async def uninstall(self, app_id: str) -> dict:

--- a/tinyagentos/installers/lxc_installer.py
+++ b/tinyagentos/installers/lxc_installer.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+import secrets
+import shlex
 import socket
 from contextlib import closing
 
@@ -30,7 +32,7 @@ Environment=USER=git HOME=/home/git GITEA_WORK_DIR=/home/git
 WantedBy=multi-user.target
 """
 
-_APP_INI = """\
+_APP_INI_TEMPLATE = """\
 [server]
 HTTP_PORT = 3000
 ROOT_URL = http://localhost:3000/
@@ -42,12 +44,19 @@ PATH = /home/git/gitea.db
 
 [security]
 INSTALL_LOCK = true
-SECRET_KEY = changeme-replace-in-production
-INTERNAL_TOKEN = changeme-replace-in-production
+SECRET_KEY = {secret_key}
+INTERNAL_TOKEN = {internal_token}
 
 [service]
 DISABLE_REGISTRATION = true
 """
+
+
+def _render_app_ini() -> str:
+    return _APP_INI_TEMPLATE.format(
+        secret_key=secrets.token_hex(32),
+        internal_token=secrets.token_hex(32),
+    )
 
 
 def _find_free_port(start: int = 13000, end: int = 14000) -> int:
@@ -177,11 +186,11 @@ class LXCInstaller(AppInstaller):
             if code != 0:
                 raise RuntimeError(f"Failed to create /etc/gitea: {output}")
 
-            # Write app.ini
-            escaped = _APP_INI.replace("'", "'\\''")
+            # Write app.ini (generate fresh secrets per install)
+            app_ini = _render_app_ini()
             code, output = await containers.exec_in_container(
                 container_name,
-                ["bash", "-c", f"cat > /etc/gitea/app.ini << 'TAOS_EOF'\n{_APP_INI}\nTAOS_EOF"],
+                ["bash", "-c", f"cat > /etc/gitea/app.ini << 'TAOS_EOF'\n{app_ini}\nTAOS_EOF"],
             )
             if code != 0:
                 raise RuntimeError(f"Failed to write app.ini: {output}")
@@ -205,15 +214,18 @@ class LXCInstaller(AppInstaller):
                 raise RuntimeError(f"Gitea migrate failed: {output}")
 
             logger.info("LXCInstaller: creating Gitea admin user '%s'", taos_username)
+            safe_username = shlex.quote(taos_username)
+            safe_email = shlex.quote(taos_email or taos_username + "@localhost")
+            safe_password = shlex.quote(admin_password)
             code, output = await containers.exec_in_container(
                 container_name,
                 [
                     "su", "-", "git", "-c",
                     f"GITEA_WORK_DIR=/home/git gitea admin user create "
                     f"--admin "
-                    f"--username {taos_username} "
-                    f"--email {taos_email or taos_username + '@localhost'} "
-                    f"--password {admin_password} "
+                    f"--username {safe_username} "
+                    f"--email {safe_email} "
+                    f"--password {safe_password} "
                     f"--must-change-password=false "
                     f"-c /etc/gitea/app.ini",
                 ],

--- a/tinyagentos/installers/lxc_installer.py
+++ b/tinyagentos/installers/lxc_installer.py
@@ -178,10 +178,12 @@ class LXCInstaller(AppInstaller):
                 raise RuntimeError(f"Gitea download failed: {output}")
 
             # Step 5: Write config and systemd unit.
+            # /etc/gitea must be root:git 770 and app.ini root:git 660 so the
+            # unprivileged git user can read the config at migrate time.
             logger.info("LXCInstaller: writing config and systemd unit")
             code, output = await containers.exec_in_container(
                 container_name,
-                ["bash", "-c", "mkdir -p /etc/gitea && chmod 770 /etc/gitea"],
+                ["bash", "-c", "mkdir -p /etc/gitea && chown root:git /etc/gitea && chmod 770 /etc/gitea"],
             )
             if code != 0:
                 raise RuntimeError(f"Failed to create /etc/gitea: {output}")
@@ -190,7 +192,9 @@ class LXCInstaller(AppInstaller):
             app_ini = _render_app_ini()
             code, output = await containers.exec_in_container(
                 container_name,
-                ["bash", "-c", f"cat > /etc/gitea/app.ini << 'TAOS_EOF'\n{app_ini}\nTAOS_EOF"],
+                ["bash", "-c",
+                 f"cat > /etc/gitea/app.ini << 'TAOS_EOF'\n{app_ini}\nTAOS_EOF\n"
+                 "chown root:git /etc/gitea/app.ini && chmod 660 /etc/gitea/app.ini"],
             )
             if code != 0:
                 raise RuntimeError(f"Failed to write app.ini: {output}")

--- a/tinyagentos/installers/lxc_installer.py
+++ b/tinyagentos/installers/lxc_installer.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import logging
+import socket
+from contextlib import closing
+
+from tinyagentos.installers.base import AppInstaller
+import tinyagentos.containers as containers
+
+logger = logging.getLogger(__name__)
+
+# Gitea version pinned here; manifest may override via install_config["gitea_version"].
+_DEFAULT_GITEA_VERSION = "1.22.6"
+
+_SYSTEMD_UNIT = """\
+[Unit]
+Description=Gitea (Git with a cup of tea)
+After=network.target
+
+[Service]
+RestartSec=2s
+Type=simple
+User=git
+WorkingDirectory=/home/git
+ExecStart=/usr/local/bin/gitea web -c /etc/gitea/app.ini
+Restart=always
+Environment=USER=git HOME=/home/git GITEA_WORK_DIR=/home/git
+
+[Install]
+WantedBy=multi-user.target
+"""
+
+_APP_INI = """\
+[server]
+HTTP_PORT = 3000
+ROOT_URL = http://localhost:3000/
+SSH_PORT = 2222
+
+[database]
+DB_TYPE = sqlite3
+PATH = /home/git/gitea.db
+
+[security]
+INSTALL_LOCK = true
+SECRET_KEY = changeme-replace-in-production
+INTERNAL_TOKEN = changeme-replace-in-production
+
+[service]
+DISABLE_REGISTRATION = true
+"""
+
+
+def _find_free_port(start: int = 13000, end: int = 14000) -> int:
+    """Return the first available TCP port in [start, end)."""
+    for port in range(start, end):
+        with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+            try:
+                s.bind(("127.0.0.1", port))
+                return port
+            except OSError:
+                continue
+    raise RuntimeError(f"No free port found in range {start}-{end}")
+
+
+class LXCInstaller(AppInstaller):
+    """Install a service (e.g. Gitea) into an isolated incus/LXC container."""
+
+    CONTAINER_PREFIX = "taos-svc-"
+
+    def _container_name(self, app_id: str) -> str:
+        return f"{self.CONTAINER_PREFIX}{app_id}"
+
+    async def install(
+        self,
+        app_id: str,
+        install_config: dict,
+        *,
+        admin_password: str,
+        taos_username: str = "admin",
+        taos_email: str = "",
+        **kwargs,
+    ) -> dict:
+        """Install app_id into a new LXC container.
+
+        Parameters
+        ----------
+        app_id:
+            Catalog app identifier (used as container name suffix).
+        install_config:
+            ``install`` block from the manifest YAML.
+        admin_password:
+            Password for the initial service admin account. Required.
+        taos_username:
+            taOS username — becomes the Gitea admin username.
+        taos_email:
+            taOS user email — becomes the Gitea admin email.
+        """
+        if not admin_password:
+            raise ValueError("admin_password is required for LXC installs")
+
+        container_name = self._container_name(app_id)
+
+        # Fail cleanly if container already exists.
+        if await containers.container_exists(container_name):
+            raise RuntimeError(
+                f"Container '{container_name}' already exists. "
+                "Uninstall first or choose a different app_id."
+            )
+
+        image = install_config.get("image", "images:debian/bookworm")
+        memory_limit = install_config.get("memory_limit", "512MiB")
+        cpu_limit = int(install_config.get("cpu_limit", 1))
+        gitea_version = install_config.get("gitea_version", _DEFAULT_GITEA_VERSION)
+
+        # Step 1: Create container.
+        logger.info("LXCInstaller: creating container %s from %s", container_name, image)
+        result = await containers.create_container(
+            container_name,
+            image=image,
+            memory_limit=memory_limit,
+            cpu_limit=cpu_limit,
+        )
+        if not result.get("success"):
+            raise RuntimeError(f"Container creation failed: {result.get('error', '')}")
+
+        try:
+            # Step 2: Wait for network readiness.
+            import asyncio
+            for _ in range(15):
+                code, output = await containers.exec_in_container(
+                    container_name, ["hostname", "-I"], timeout=10
+                )
+                if code == 0 and output.strip():
+                    break
+                await asyncio.sleep(2)
+            else:
+                raise RuntimeError("Container did not get a network address in time")
+
+            # Step 3: Install base packages and create git system user.
+            logger.info("LXCInstaller: installing packages in %s", container_name)
+            code, output = await containers.exec_in_container(
+                container_name,
+                [
+                    "bash", "-c",
+                    "apt-get update -qq && "
+                    "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq "
+                    "--no-install-recommends git sqlite3 wget ca-certificates && "
+                    "useradd --system --create-home --shell /bin/bash git",
+                ],
+                timeout=300,
+            )
+            if code != 0:
+                raise RuntimeError(f"Package install failed: {output}")
+
+            # Step 4: Download Gitea binary (auto-detect arch).
+            logger.info("LXCInstaller: downloading Gitea %s", gitea_version)
+            code, output = await containers.exec_in_container(
+                container_name,
+                [
+                    "bash", "-c",
+                    f"ARCH=$(dpkg --print-architecture) && "
+                    f"wget -q -O /usr/local/bin/gitea "
+                    f"https://dl.gitea.com/gitea/{gitea_version}/gitea-{gitea_version}-linux-${{ARCH}} && "
+                    f"chmod +x /usr/local/bin/gitea",
+                ],
+                timeout=300,
+            )
+            if code != 0:
+                raise RuntimeError(f"Gitea download failed: {output}")
+
+            # Step 5: Write config and systemd unit.
+            logger.info("LXCInstaller: writing config and systemd unit")
+            code, output = await containers.exec_in_container(
+                container_name,
+                ["bash", "-c", "mkdir -p /etc/gitea && chmod 770 /etc/gitea"],
+            )
+            if code != 0:
+                raise RuntimeError(f"Failed to create /etc/gitea: {output}")
+
+            # Write app.ini
+            escaped = _APP_INI.replace("'", "'\\''")
+            code, output = await containers.exec_in_container(
+                container_name,
+                ["bash", "-c", f"cat > /etc/gitea/app.ini << 'TAOS_EOF'\n{_APP_INI}\nTAOS_EOF"],
+            )
+            if code != 0:
+                raise RuntimeError(f"Failed to write app.ini: {output}")
+
+            # Write systemd unit
+            code, output = await containers.exec_in_container(
+                container_name,
+                ["bash", "-c", f"cat > /etc/systemd/system/gitea.service << 'TAOS_EOF'\n{_SYSTEMD_UNIT}\nTAOS_EOF"],
+            )
+            if code != 0:
+                raise RuntimeError(f"Failed to write systemd unit: {output}")
+
+            # Step 6: First-boot DB migration + admin user creation.
+            logger.info("LXCInstaller: running Gitea DB migration")
+            code, output = await containers.exec_in_container(
+                container_name,
+                ["su", "-", "git", "-c", "GITEA_WORK_DIR=/home/git gitea migrate -c /etc/gitea/app.ini"],
+                timeout=120,
+            )
+            if code != 0:
+                raise RuntimeError(f"Gitea migrate failed: {output}")
+
+            logger.info("LXCInstaller: creating Gitea admin user '%s'", taos_username)
+            code, output = await containers.exec_in_container(
+                container_name,
+                [
+                    "su", "-", "git", "-c",
+                    f"GITEA_WORK_DIR=/home/git gitea admin user create "
+                    f"--admin "
+                    f"--username {taos_username} "
+                    f"--email {taos_email or taos_username + '@localhost'} "
+                    f"--password {admin_password} "
+                    f"--must-change-password=false "
+                    f"-c /etc/gitea/app.ini",
+                ],
+                timeout=60,
+            )
+            if code != 0:
+                raise RuntimeError(f"Gitea admin user creation failed: {output}")
+
+            # Step 7: Enable and start service.
+            logger.info("LXCInstaller: enabling and starting gitea.service")
+            code, output = await containers.exec_in_container(
+                container_name,
+                ["bash", "-c", "systemctl daemon-reload && systemctl enable gitea && systemctl start gitea"],
+                timeout=60,
+            )
+            if code != 0:
+                raise RuntimeError(f"Failed to start gitea service: {output}")
+
+            # Step 8: Add proxy device (host_port → container:3000).
+            host_port = _find_free_port()
+            logger.info(
+                "LXCInstaller: adding proxy device host:%d -> container:3000", host_port
+            )
+            res = await containers.add_proxy_device(
+                container_name,
+                device_name="gitea-http",
+                listen=f"tcp:0.0.0.0:{host_port}",
+                connect="tcp:127.0.0.1:3000",
+            )
+            if not res.get("success"):
+                raise RuntimeError(
+                    f"Failed to add proxy device: {res.get('output', '')}"
+                )
+
+            # Step 9: Record install metadata.
+            install_record = {
+                "app_id": app_id,
+                "backend": "lxc",
+                "container": container_name,
+                "host_port": host_port,
+                "gitea_version": gitea_version,
+                "admin_username": taos_username,
+            }
+            logger.info("LXCInstaller: install complete — %s", install_record)
+            return {"success": True, **install_record}
+
+        except Exception:
+            logger.exception(
+                "LXCInstaller: rolling back — destroying container %s", container_name
+            )
+            await containers.destroy_container(container_name)
+            raise
+
+    async def uninstall(self, app_id: str) -> dict:
+        """Stop and delete the service container."""
+        container_name = self._container_name(app_id)
+        result = await containers.destroy_container(container_name)
+        return {"success": result["success"], "app_id": app_id}
+
+    async def start(self, app_id: str) -> dict:
+        container_name = self._container_name(app_id)
+        result = await containers.start_container(container_name)
+        return result
+
+    async def stop(self, app_id: str) -> dict:
+        container_name = self._container_name(app_id)
+        result = await containers.stop_container(container_name)
+        return result

--- a/tinyagentos/routes/cluster_migrate.py
+++ b/tinyagentos/routes/cluster_migrate.py
@@ -1,12 +1,17 @@
 """HTTP routes for incus cross-host container migration and remote management."""
 from __future__ import annotations
 
+import logging
+from urllib.parse import urlparse
+
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from tinyagentos.containers import migrate_container, remote_add, remote_generate_token, remote_list, remote_remove
 from tinyagentos.cluster.service_migrator import migrate_service
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -159,4 +164,46 @@ async def migrate_service_route(request: Request, body: MigrateServiceBody):
 
     if not result["success"]:
         return JSONResponse({"error": result["error"]}, status_code=500)
+
+    # Update the installed-apps registry with the new runtime location.
+    host_port = result.get("host_port")
+    target_remote_norm = result.get("target_remote")
+    if host_port:
+        installed_apps = getattr(request.app.state, "installed_apps", None)
+        if installed_apps is not None:
+            runtime_host = await _resolve_host(target_remote_norm)
+            ui_path = manifest.install.get("ui_path", "/") if isinstance(manifest.install, dict) else "/"
+            try:
+                await installed_apps.update_runtime_location(
+                    body.app_id,
+                    host=runtime_host,
+                    port=host_port,
+                    backend="lxc",
+                    ui_path=ui_path,
+                )
+            except Exception:
+                logger.warning(
+                    "migrate-service: failed to update runtime location for %s", body.app_id
+                )
+
     return result
+
+
+async def _resolve_host(target_remote: str | None) -> str:
+    """Parse the hostname from a registered incus remote's URL.
+
+    Falls back to '127.0.0.1' for local (no remote) targets.
+    """
+    if not target_remote:
+        return "127.0.0.1"
+    try:
+        remotes = await remote_list()
+        for r in remotes:
+            if r.get("name") == target_remote:
+                addr = r.get("addr", "")
+                parsed = urlparse(addr)
+                if parsed.hostname:
+                    return parsed.hostname
+    except Exception:
+        logger.warning("_resolve_host: failed to look up remote %r", target_remote)
+    return target_remote

--- a/tinyagentos/routes/cluster_migrate.py
+++ b/tinyagentos/routes/cluster_migrate.py
@@ -1,0 +1,77 @@
+"""HTTP routes for incus cross-host container migration and remote management."""
+from __future__ import annotations
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from tinyagentos.containers import migrate_container, remote_add, remote_list, remote_remove
+
+router = APIRouter()
+
+
+class RemoteAddBody(BaseModel):
+    name: str
+    url: str
+    trust_password: str | None = None
+    tls_cert_fingerprint: str | None = None
+
+
+class MigrateBody(BaseModel):
+    container: str
+    target_remote: str
+    new_name: str | None = None
+    keep_source: bool = False
+    stateless: bool = True
+    timeout: int = 600
+
+
+@router.post("/api/cluster/remotes")
+async def add_remote(body: RemoteAddBody):
+    """Register an incus remote host."""
+    if not body.name or not body.url:
+        return JSONResponse({"error": "name and url are required"}, status_code=400)
+    result = await remote_add(
+        body.name,
+        body.url,
+        tls_cert_fingerprint=body.tls_cert_fingerprint,
+        trust_password=body.trust_password,
+    )
+    if not result["success"]:
+        return JSONResponse({"error": result["output"]}, status_code=500)
+    return {"status": "registered", "name": body.name}
+
+
+@router.get("/api/cluster/remotes")
+async def list_remotes():
+    """List registered incus remotes."""
+    return await remote_list()
+
+
+@router.delete("/api/cluster/remotes/{name}")
+async def remove_remote(name: str):
+    """Remove a registered incus remote."""
+    result = await remote_remove(name)
+    if not result["success"]:
+        return JSONResponse({"error": result["output"]}, status_code=500)
+    return {"status": "removed", "name": name}
+
+
+@router.post("/api/cluster/migrate")
+async def migrate(body: MigrateBody):
+    """Move or copy a container to a remote incus host."""
+    if not body.container or not body.target_remote:
+        return JSONResponse(
+            {"error": "container and target_remote are required"}, status_code=400
+        )
+    result = await migrate_container(
+        body.container,
+        body.target_remote,
+        new_name=body.new_name,
+        keep_source=body.keep_source,
+        stateless=body.stateless,
+        timeout=body.timeout,
+    )
+    if not result["success"]:
+        return JSONResponse({"error": result["error"]}, status_code=500)
+    return result

--- a/tinyagentos/routes/cluster_migrate.py
+++ b/tinyagentos/routes/cluster_migrate.py
@@ -1,11 +1,12 @@
 """HTTP routes for incus cross-host container migration and remote management."""
 from __future__ import annotations
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from tinyagentos.containers import migrate_container, remote_add, remote_generate_token, remote_list, remote_remove
+from tinyagentos.cluster.service_migrator import migrate_service
 
 router = APIRouter()
 
@@ -29,6 +30,12 @@ class MigrateBody(BaseModel):
     keep_source: bool = False
     stateless: bool = True
     timeout: int = 600
+
+
+class MigrateServiceBody(BaseModel):
+    app_id: str
+    target_remote: str
+    keep_source: bool = False
 
 
 @router.post("/api/cluster/remotes")
@@ -89,6 +96,65 @@ async def migrate(body: MigrateBody):
         stateless=body.stateless,
         timeout=body.timeout,
     )
+    if not result["success"]:
+        return JSONResponse({"error": result["error"]}, status_code=500)
+    return result
+
+
+@router.post("/api/cluster/migrate-service")
+async def migrate_service_route(request: Request, body: MigrateServiceBody):
+    """Arch-portable service migration: deploy fresh on target, restore state paths."""
+    if not body.app_id or not body.target_remote:
+        return JSONResponse(
+            {"error": "app_id and target_remote are required"}, status_code=400
+        )
+
+    registry = request.app.state.registry
+    manifest = registry.get(body.app_id)
+    if not manifest:
+        return JSONResponse(
+            {"error": f"App '{body.app_id}' not found in catalog"}, status_code=404
+        )
+
+    state_paths: list[str] = manifest.install.get("state_paths", [])
+    if not state_paths:
+        # Fall back to top-level manifest field for manifests that declare it there.
+        import yaml as _yaml
+        if manifest.manifest_dir is not None:
+            lxc_manifest_path = manifest.manifest_dir / "manifest-lxc.yaml"
+            if lxc_manifest_path.exists():
+                _data = _yaml.safe_load(lxc_manifest_path.read_text())
+                state_paths = _data.get("state_paths", [])
+
+    if not state_paths:
+        return JSONResponse(
+            {"error": f"App '{body.app_id}' has no state_paths defined in its manifest"},
+            status_code=400,
+        )
+
+    service_name: str = manifest.install.get("service_name", "")
+    if not service_name and manifest.manifest_dir is not None:
+        import yaml as _yaml
+        lxc_manifest_path = manifest.manifest_dir / "manifest-lxc.yaml"
+        if lxc_manifest_path.exists():
+            _data = _yaml.safe_load(lxc_manifest_path.read_text())
+            service_name = _data.get("service_name", body.app_id)
+
+    if not service_name:
+        service_name = body.app_id
+
+    try:
+        result = await migrate_service(
+            body.app_id,
+            body.target_remote,
+            install_config=manifest.install,
+            state_paths=state_paths,
+            service_name=service_name,
+            keep_source=body.keep_source,
+        )
+    except Exception as exc:
+        return JSONResponse({"error": str(exc)}, status_code=500)
+
     if not result["success"]:
         return JSONResponse({"error": result["error"]}, status_code=500)
     return result

--- a/tinyagentos/routes/cluster_migrate.py
+++ b/tinyagentos/routes/cluster_migrate.py
@@ -129,7 +129,7 @@ async def migrate_service_route(request: Request, body: MigrateServiceBody):
         if manifest.manifest_dir is not None:
             lxc_manifest_path = manifest.manifest_dir / "manifest-lxc.yaml"
             if lxc_manifest_path.exists():
-                _data = _yaml.safe_load(lxc_manifest_path.read_text())
+                _data = _yaml.safe_load(lxc_manifest_path.read_text()) or {}
                 state_paths = _data.get("state_paths", [])
 
     if not state_paths:
@@ -143,7 +143,7 @@ async def migrate_service_route(request: Request, body: MigrateServiceBody):
         import yaml as _yaml
         lxc_manifest_path = manifest.manifest_dir / "manifest-lxc.yaml"
         if lxc_manifest_path.exists():
-            _data = _yaml.safe_load(lxc_manifest_path.read_text())
+            _data = _yaml.safe_load(lxc_manifest_path.read_text()) or {}
             service_name = _data.get("service_name", body.app_id)
 
     if not service_name:
@@ -159,8 +159,13 @@ async def migrate_service_route(request: Request, body: MigrateServiceBody):
             keep_source=body.keep_source,
             source_remote=body.source_remote,
         )
-    except Exception as exc:
-        return JSONResponse({"error": str(exc)}, status_code=500)
+    except Exception:
+        logger.exception(
+            "migrate-service failed for app_id=%s target_remote=%s",
+            body.app_id,
+            body.target_remote,
+        )
+        return JSONResponse({"error": "service migration failed"}, status_code=500)
 
     if not result["success"]:
         return JSONResponse({"error": result["error"]}, status_code=500)
@@ -172,6 +177,13 @@ async def migrate_service_route(request: Request, body: MigrateServiceBody):
         installed_apps = getattr(request.app.state, "installed_apps", None)
         if installed_apps is not None:
             runtime_host = await _resolve_host(target_remote_norm)
+            if runtime_host is None:
+                logger.warning(
+                    "migrate-service: unresolved runtime host for remote %r; "
+                    "skipping runtime_location update",
+                    target_remote_norm,
+                )
+                return result
             ui_path = manifest.install.get("ui_path", "/") if isinstance(manifest.install, dict) else "/"
             try:
                 await installed_apps.update_runtime_location(
@@ -189,7 +201,7 @@ async def migrate_service_route(request: Request, body: MigrateServiceBody):
     return result
 
 
-async def _resolve_host(target_remote: str | None) -> str:
+async def _resolve_host(target_remote: str | None) -> str | None:
     """Parse the hostname from a registered incus remote's URL.
 
     Falls back to '127.0.0.1' for local (no remote) targets.
@@ -206,4 +218,4 @@ async def _resolve_host(target_remote: str | None) -> str:
                     return parsed.hostname
     except Exception:
         logger.warning("_resolve_host: failed to look up remote %r", target_remote)
-    return target_remote
+    return None

--- a/tinyagentos/routes/cluster_migrate.py
+++ b/tinyagentos/routes/cluster_migrate.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
-from tinyagentos.containers import migrate_container, remote_add, remote_list, remote_remove
+from tinyagentos.containers import migrate_container, remote_add, remote_generate_token, remote_list, remote_remove
 
 router = APIRouter()
 
@@ -13,8 +13,13 @@ router = APIRouter()
 class RemoteAddBody(BaseModel):
     name: str
     url: str
-    trust_password: str | None = None
-    tls_cert_fingerprint: str | None = None
+    token: str
+
+
+class GenerateTokenBody(BaseModel):
+    client_name: str
+    projects: list[str] | None = None
+    restricted: bool = False
 
 
 class MigrateBody(BaseModel):
@@ -28,18 +33,30 @@ class MigrateBody(BaseModel):
 
 @router.post("/api/cluster/remotes")
 async def add_remote(body: RemoteAddBody):
-    """Register an incus remote host."""
+    """Register an incus remote host using a one-time token."""
     if not body.name or not body.url:
         return JSONResponse({"error": "name and url are required"}, status_code=400)
-    result = await remote_add(
-        body.name,
-        body.url,
-        tls_cert_fingerprint=body.tls_cert_fingerprint,
-        trust_password=body.trust_password,
-    )
+    if not body.token:
+        return JSONResponse({"error": "token is required"}, status_code=400)
+    result = await remote_add(body.name, body.url, token=body.token)
     if not result["success"]:
         return JSONResponse({"error": result["output"]}, status_code=500)
     return {"status": "registered", "name": body.name}
+
+
+@router.post("/api/cluster/remotes/token")
+async def generate_token(body: GenerateTokenBody):
+    """Generate a one-time enrollment token on this host for a remote client."""
+    if not body.client_name:
+        return JSONResponse({"error": "client_name is required"}, status_code=400)
+    result = await remote_generate_token(
+        body.client_name,
+        projects=body.projects,
+        restricted=body.restricted,
+    )
+    if not result["success"]:
+        return JSONResponse({"error": result["output"]}, status_code=500)
+    return {"token": result["token"]}
 
 
 @router.get("/api/cluster/remotes")

--- a/tinyagentos/routes/cluster_migrate.py
+++ b/tinyagentos/routes/cluster_migrate.py
@@ -36,6 +36,7 @@ class MigrateServiceBody(BaseModel):
     app_id: str
     target_remote: str
     keep_source: bool = False
+    source_remote: str | None = None
 
 
 @router.post("/api/cluster/remotes")
@@ -151,6 +152,7 @@ async def migrate_service_route(request: Request, body: MigrateServiceBody):
             state_paths=state_paths,
             service_name=service_name,
             keep_source=body.keep_source,
+            source_remote=body.source_remote,
         )
     except Exception as exc:
         return JSONResponse({"error": str(exc)}, status_code=500)

--- a/tinyagentos/routes/service_proxy.py
+++ b/tinyagentos/routes/service_proxy.py
@@ -1,0 +1,135 @@
+"""Reverse-proxy routes for installed services.
+
+Every installed service gets a stable URL:
+    /apps/{app_id}/         → proxied to http://{runtime_host}:{runtime_port}/
+
+The controller looks up the current runtime location from InstalledAppsStore.
+When a service migrates between hosts, update_runtime_location() is called and
+the URL keeps working transparently.
+
+WebSocket proxying: TODO (P5). HTTP-only proxy is sufficient for P5 milestone.
+The WS upgrade path will be added when the desktop window widget needs it.
+"""
+from __future__ import annotations
+
+import logging
+
+import httpx
+from fastapi import APIRouter, Request, WebSocket
+from fastapi.responses import RedirectResponse, StreamingResponse
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+# Hop-by-hop headers must not be forwarded between proxy and upstream/client.
+# RFC 2616 §13.5.1 + Proxy-Authorization added per security best practice.
+_HOP_BY_HOP = frozenset({
+    "connection",
+    "keep-alive",
+    "proxy-authorization",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+    "host",
+})
+
+
+def _filter_headers(headers: dict) -> dict:
+    return {k: v for k, v in headers.items() if k.lower() not in _HOP_BY_HOP}
+
+
+@router.get("/apps/{app_id}", include_in_schema=False)
+async def redirect_no_slash(app_id: str):
+    """Redirect /apps/{app_id} → /apps/{app_id}/ so relative links work."""
+    return RedirectResponse(url=f"/apps/{app_id}/", status_code=307)
+
+
+@router.api_route(
+    "/apps/{app_id}/{path:path}",
+    methods=["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"],
+    include_in_schema=False,
+)
+async def service_proxy(app_id: str, path: str, request: Request):
+    installed_apps = getattr(request.app.state, "installed_apps", None)
+    if installed_apps is None:
+        return _json_error("Service registry unavailable", 503)
+
+    loc = await installed_apps.get_runtime_location(app_id)
+    if loc is None:
+        # Check if installed at all to give a better error message.
+        is_installed = await installed_apps.is_installed(app_id)
+        if not is_installed:
+            return _json_error(f"App '{app_id}' is not installed", 404)
+        return _json_error(
+            f"App '{app_id}' has no runtime location recorded. "
+            "Re-install or migrate the service to register a host:port.",
+            503,
+        )
+
+    upstream = f"http://{loc['runtime_host']}:{loc['runtime_port']}/{path}"
+    query = request.url.query
+    if query:
+        upstream = f"{upstream}?{query}"
+
+    fwd_headers = _filter_headers(dict(request.headers))
+
+    async def _stream_body():
+        async for chunk in request.stream():
+            yield chunk
+
+    try:
+        client = httpx.AsyncClient(timeout=60.0)
+        async with client:
+            upstream_resp = await client.request(
+                method=request.method,
+                url=upstream,
+                headers=fwd_headers,
+                content=_stream_body(),
+                follow_redirects=False,
+            )
+    except httpx.ConnectError:
+        return _json_error(
+            f"Cannot reach {app_id} at {loc['runtime_host']}:{loc['runtime_port']}. "
+            "The service may be stopped or still starting.",
+            502,
+        )
+    except httpx.TimeoutException:
+        return _json_error(f"Upstream {app_id} timed out", 504)
+
+    resp_headers = _filter_headers(dict(upstream_resp.headers))
+
+    # Rewrite absolute Location headers so redirects stay within /apps/{app_id}/.
+    if "location" in upstream_resp.headers:
+        loc_header = upstream_resp.headers["location"]
+        upstream_prefix = f"http://{loc['runtime_host']}:{loc['runtime_port']}"
+        if loc_header.startswith(upstream_prefix):
+            relative = loc_header[len(upstream_prefix):]
+            resp_headers["location"] = f"/apps/{app_id}{relative}"
+
+    return StreamingResponse(
+        upstream_resp.aiter_bytes(),
+        status_code=upstream_resp.status_code,
+        headers=resp_headers,
+    )
+
+
+# ---------------------------------------------------------------------------
+# WebSocket proxy – TODO (P5)
+# ---------------------------------------------------------------------------
+
+@router.websocket("/apps/{app_id}/ws/{path:path}")
+async def service_proxy_ws(app_id: str, path: str, websocket: WebSocket):
+    """WebSocket proxy placeholder. Full bidirectional piping is a P5 task.
+
+    TODO (P5): use websockets.connect() to the upstream WS URL and pipe both
+    directions. The HTTP-only proxy above is sufficient for P5; the desktop
+    window widget and terminal features will require this.
+    """
+    await websocket.close(code=1001, reason="WebSocket proxy not yet implemented")
+
+
+def _json_error(message: str, status_code: int):
+    from fastapi.responses import JSONResponse
+    return JSONResponse({"error": message}, status_code=status_code)

--- a/tinyagentos/routes/service_proxy.py
+++ b/tinyagentos/routes/service_proxy.py
@@ -138,13 +138,26 @@ async def service_proxy(app_id: str, path: str, request: Request):
 
     resp_headers = _filter_headers(dict(upstream_resp.headers))
 
-    # Rewrite absolute Location headers so redirects stay within /apps/{app_id}/.
+    # Rewrite Location headers so redirects stay within /apps/{app_id}/.
+    # - Absolute upstream URLs (http://<host>:<port>/foo)  → /apps/{app_id}/foo
+    # - Root-relative redirects (/login, /user/sign_in)     → /apps/{app_id}/login
+    # - Scheme-relative and relative paths pass through unchanged.
     if "location" in upstream_resp.headers:
         loc_header = upstream_resp.headers["location"]
         upstream_prefix = f"http://{loc['runtime_host']}:{loc['runtime_port']}{ui_path}"
         if loc_header.startswith(upstream_prefix):
             relative = loc_header[len(upstream_prefix):]
             resp_headers["location"] = f"/apps/{app_id}{relative}"
+        elif loc_header.startswith("/") and not loc_header.startswith("//"):
+            # Root-relative redirect (e.g. "/login"). From the browser's point
+            # of view this lands on the controller root, not the proxied app.
+            # Strip any ui_path prefix the upstream prepended, then nest under
+            # the proxy namespace.
+            if ui_path and ui_path != "/" and loc_header.startswith(ui_path.rstrip("/") + "/"):
+                loc_header = loc_header[len(ui_path.rstrip("/")):]
+            elif ui_path and ui_path != "/" and loc_header == ui_path.rstrip("/"):
+                loc_header = "/"
+            resp_headers["location"] = f"/apps/{app_id}{loc_header}"
 
     from starlette.background import BackgroundTask
     return StreamingResponse(

--- a/tinyagentos/routes/service_proxy.py
+++ b/tinyagentos/routes/service_proxy.py
@@ -35,9 +35,47 @@ _HOP_BY_HOP = frozenset({
     "host",
 })
 
+# Controller-scoped credentials must never leak to the upstream service
+# container. The taos_session cookie is stripped out of Cookie; everything
+# else in the cookie header passes through unchanged.
+_SENSITIVE_HEADERS = frozenset({"authorization"})
+_STRIPPED_COOKIES = frozenset({"taos_session"})
+
+
+# Module-level HTTP client for proxying — avoids per-request connection churn
+# and allows send(stream=True) with BackgroundTask cleanup.
+_http_client = httpx.AsyncClient(timeout=60.0)
+
+
+def _strip_taos_cookies(cookie_header: str) -> str:
+    """Remove controller-owned cookies from a Cookie header, keep the rest."""
+    if not cookie_header:
+        return ""
+    from http.cookies import SimpleCookie
+    jar = SimpleCookie()
+    try:
+        jar.load(cookie_header)
+    except Exception:
+        return cookie_header
+    for name in _STRIPPED_COOKIES:
+        jar.pop(name, None)
+    return "; ".join(f"{k}={m.value}" for k, m in jar.items())
+
 
 def _filter_headers(headers: dict) -> dict:
-    return {k: v for k, v in headers.items() if k.lower() not in _HOP_BY_HOP}
+    filtered: dict[str, str] = {}
+    for k, v in headers.items():
+        kl = k.lower()
+        if kl in _HOP_BY_HOP or kl in _SENSITIVE_HEADERS:
+            continue
+        if kl == "cookie":
+            stripped = _strip_taos_cookies(v)
+            if not stripped:
+                continue
+            filtered[k] = stripped
+            continue
+        filtered[k] = v
+    return filtered
 
 
 @router.get("/apps/{app_id}", include_in_schema=False)
@@ -68,7 +106,9 @@ async def service_proxy(app_id: str, path: str, request: Request):
             503,
         )
 
-    upstream = f"http://{loc['runtime_host']}:{loc['runtime_port']}/{path}"
+    ui_path = (loc.get("ui_path") or "/").rstrip("/")
+    upstream_path = ui_path + "/" + path if path else ui_path + "/"
+    upstream = f"http://{loc['runtime_host']}:{loc['runtime_port']}{upstream_path}"
     query = request.url.query
     if query:
         upstream = f"{upstream}?{query}"
@@ -80,15 +120,13 @@ async def service_proxy(app_id: str, path: str, request: Request):
             yield chunk
 
     try:
-        client = httpx.AsyncClient(timeout=60.0)
-        async with client:
-            upstream_resp = await client.request(
-                method=request.method,
-                url=upstream,
-                headers=fwd_headers,
-                content=_stream_body(),
-                follow_redirects=False,
-            )
+        req = _http_client.build_request(
+            method=request.method,
+            url=upstream,
+            headers=fwd_headers,
+            content=_stream_body(),
+        )
+        upstream_resp = await _http_client.send(req, stream=True, follow_redirects=False)
     except httpx.ConnectError:
         return _json_error(
             f"Cannot reach {app_id} at {loc['runtime_host']}:{loc['runtime_port']}. "
@@ -103,15 +141,17 @@ async def service_proxy(app_id: str, path: str, request: Request):
     # Rewrite absolute Location headers so redirects stay within /apps/{app_id}/.
     if "location" in upstream_resp.headers:
         loc_header = upstream_resp.headers["location"]
-        upstream_prefix = f"http://{loc['runtime_host']}:{loc['runtime_port']}"
+        upstream_prefix = f"http://{loc['runtime_host']}:{loc['runtime_port']}{ui_path}"
         if loc_header.startswith(upstream_prefix):
             relative = loc_header[len(upstream_prefix):]
             resp_headers["location"] = f"/apps/{app_id}{relative}"
 
+    from starlette.background import BackgroundTask
     return StreamingResponse(
         upstream_resp.aiter_bytes(),
         status_code=upstream_resp.status_code,
         headers=resp_headers,
+        background=BackgroundTask(upstream_resp.aclose),
     )
 
 

--- a/tinyagentos/routes/store_install.py
+++ b/tinyagentos/routes/store_install.py
@@ -72,12 +72,25 @@ async def install_app(request: Request):
         elif hasattr(install_block, "get"):
             backend = install_block.get("method", "docker")
 
-    # Override with body-supplied metadata if provided.
+    # Allow metadata to override backend only when manifest did not declare one.
     meta = body.get("metadata") or {}
-    if isinstance(meta, dict) and meta.get("backend"):
-        backend = meta["backend"]
-    if isinstance(meta, dict) and meta.get("method"):
-        backend = meta["method"]
+    manifest_declared_backend = manifest is not None
+    if not manifest_declared_backend:
+        if isinstance(meta, dict) and meta.get("backend"):
+            backend = meta["backend"]
+        if isinstance(meta, dict) and meta.get("method"):
+            backend = meta["method"]
+    elif isinstance(meta, dict) and (meta.get("backend") or meta.get("method")):
+        meta_backend = meta.get("backend") or meta.get("method")
+        if meta_backend != backend:
+            logger.warning(
+                "install_app: ignoring metadata backend %r — manifest declares %r for %s",
+                meta_backend, backend, app_id,
+            )
+            return JSONResponse(
+                {"error": f"backend override {meta_backend!r} contradicts manifest backend {backend!r}"},
+                status_code=400,
+            )
 
     if backend == "lxc":
         # LXC installs require admin_password.
@@ -156,16 +169,23 @@ async def uninstall_app(request: Request):
             if isinstance(install_block, dict):
                 backend = install_block.get("backend", install_block.get("method", "docker"))
     meta = body.get("metadata") or {}
-    if isinstance(meta, dict) and meta.get("backend"):
-        backend = meta["backend"]
-    if isinstance(meta, dict) and meta.get("method"):
-        backend = meta["method"]
+    if manifest is None:
+        if isinstance(meta, dict) and meta.get("backend"):
+            backend = meta["backend"]
+        if isinstance(meta, dict) and meta.get("method"):
+            backend = meta["method"]
 
     container_error: str | None = None
     if backend == "lxc":
         try:
             installer = LXCInstaller()
-            await installer.uninstall(app_id)
+            uninstall_result = await installer.uninstall(app_id)
+            if not uninstall_result.get("success", False):
+                container_error = (
+                    uninstall_result.get("error")
+                    or uninstall_result.get("output")
+                    or "LXC uninstall failed"
+                )
         except Exception as exc:  # noqa: BLE001
             logger.warning("LXC container destroy failed for %s: %s", app_id, exc)
             container_error = str(exc)

--- a/tinyagentos/routes/store_install.py
+++ b/tinyagentos/routes/store_install.py
@@ -63,8 +63,11 @@ async def install_app(request: Request):
             )
 
         user = _get_current_user(request)
-        taos_username = (user or {}).get("username", "admin")
-        taos_email = (user or {}).get("email", "")
+        # Body overrides win so local-token / non-session callers can seed the
+        # admin user explicitly. Gitea rejects "admin" as a reserved name, so
+        # the fallback is "owner" when no session user is available.
+        taos_username = body.get("taos_username") or (user or {}).get("username") or "owner"
+        taos_email = body.get("taos_email") or (user or {}).get("email") or ""
 
         installer = LXCInstaller()
         try:

--- a/tinyagentos/routes/store_install.py
+++ b/tinyagentos/routes/store_install.py
@@ -102,9 +102,37 @@ async def uninstall_app(request: Request):
     app_id = body.get("app_id", "")
     if not app_id:
         return JSONResponse({"error": "app_id required"}, status_code=400)
+
+    # Determine backend from manifest or body metadata.
+    registry = getattr(request.app.state, "registry", None)
+    backend = "docker"
+    if registry is not None:
+        manifest = registry.get(app_id)
+        if manifest is not None:
+            install_block = getattr(manifest, "install", None) or {}
+            if isinstance(install_block, dict):
+                backend = install_block.get("backend", install_block.get("method", "docker"))
+    meta = body.get("metadata") or {}
+    if isinstance(meta, dict) and meta.get("backend"):
+        backend = meta["backend"]
+    if isinstance(meta, dict) and meta.get("method"):
+        backend = meta["method"]
+
+    container_error: str | None = None
+    if backend == "lxc":
+        try:
+            installer = LXCInstaller()
+            await installer.uninstall(app_id)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("LXC container destroy failed for %s: %s", app_id, exc)
+            container_error = str(exc)
+
     store = request.app.state.installed_apps
     removed = await store.uninstall(app_id)
-    return JSONResponse({"ok": removed, "app_id": app_id, "status": "uninstalled" if removed else "not_installed"})
+    resp: dict = {"ok": removed, "app_id": app_id, "status": "uninstalled" if removed else "not_installed"}
+    if container_error is not None:
+        resp["container_error"] = container_error
+    return JSONResponse(resp)
 
 
 @router.get("/api/store/installed-v2")

--- a/tinyagentos/routes/store_install.py
+++ b/tinyagentos/routes/store_install.py
@@ -161,6 +161,7 @@ async def uninstall_app(request: Request):
 
     # Determine backend from manifest or body metadata.
     registry = getattr(request.app.state, "registry", None)
+    manifest = None
     backend = "docker"
     if registry is not None:
         manifest = registry.get(app_id)

--- a/tinyagentos/routes/store_install.py
+++ b/tinyagentos/routes/store_install.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from urllib.parse import urlparse
 
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
@@ -10,6 +11,31 @@ from tinyagentos.installers.lxc_installer import LXCInstaller
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+async def _resolve_host(target_remote: str | None) -> str:
+    """Return the host the controller uses to reach a service's proxy port.
+
+    - Local (no target_remote): the proxy device binds to 0.0.0.0 on this
+      host, so 127.0.0.1 is always reachable by the controller.
+    - Remote: look up the registered remote's URL and parse the hostname.
+      incus remotes are registered as https://<host>:8443; we extract <host>.
+    """
+    if not target_remote:
+        return "127.0.0.1"
+    try:
+        import tinyagentos.containers as containers
+        remotes = await containers.remote_list()
+        for r in remotes:
+            if r.get("name") == target_remote:
+                addr = r.get("addr", "")
+                parsed = urlparse(addr)
+                if parsed.hostname:
+                    return parsed.hostname
+    except Exception:
+        logger.warning("_resolve_host: failed to look up remote %r", target_remote)
+    # Fall back to using the remote name itself (useful in DNS-based setups).
+    return target_remote
 
 
 def _get_current_user(request: Request) -> dict | None:
@@ -91,6 +117,20 @@ async def install_app(request: Request):
         if store is not None:
             await store.install(app_id, body.get("version", ""), meta)
 
+            # Record runtime location so the proxy can reach the service.
+            host_port = result.get("host_port")
+            target_remote = install_config.get("target_remote") or body.get("target_remote")
+            if host_port:
+                runtime_host = await _resolve_host(target_remote)
+                ui_path = install_config.get("ui_path", "/")
+                await store.update_runtime_location(
+                    app_id,
+                    host=runtime_host,
+                    port=host_port,
+                    backend="lxc",
+                    ui_path=ui_path,
+                )
+
         return JSONResponse({"ok": True, "app_id": app_id, "status": "installed", **result})
 
     # Default: delegate to InstalledAppsStore (docker/pip/download).
@@ -132,6 +172,7 @@ async def uninstall_app(request: Request):
 
     store = request.app.state.installed_apps
     removed = await store.uninstall(app_id)
+    await store.remove_runtime_location(app_id)
     resp: dict = {"ok": removed, "app_id": app_id, "status": "uninstalled" if removed else "not_installed"}
     if container_error is not None:
         resp["container_error"] = container_error

--- a/tinyagentos/routes/store_install.py
+++ b/tinyagentos/routes/store_install.py
@@ -1,8 +1,24 @@
 from __future__ import annotations
+
+import logging
+
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 
+from tinyagentos.installers.lxc_installer import LXCInstaller
+
+logger = logging.getLogger(__name__)
+
 router = APIRouter()
+
+
+def _get_current_user(request: Request) -> dict | None:
+    """Return the currently authenticated user or None."""
+    auth = getattr(request.app.state, "auth", None)
+    if auth is None:
+        return None
+    token = request.cookies.get("taos_session", "")
+    return auth.session_user(token)
 
 
 @router.post("/api/store/install-v2")
@@ -11,8 +27,72 @@ async def install_app(request: Request):
     app_id = body.get("app_id", "")
     if not app_id:
         return JSONResponse({"error": "app_id required"}, status_code=400)
+
+    # Resolve manifest to determine backend.
+    registry = getattr(request.app.state, "registry", None)
+    manifest = None
+    install_config = {}
+    backend = "docker"  # default
+
+    if registry is not None:
+        manifest = registry.get(app_id)
+
+    if manifest is not None:
+        install_block = getattr(manifest, "install", None) or {}
+        if isinstance(install_block, dict):
+            install_config = install_block
+            backend = install_config.get("backend", install_config.get("method", "docker"))
+        # manifest.install might be an object with a .get method or attributes
+        elif hasattr(install_block, "get"):
+            backend = install_block.get("method", "docker")
+
+    # Override with body-supplied metadata if provided.
+    meta = body.get("metadata") or {}
+    if isinstance(meta, dict) and meta.get("backend"):
+        backend = meta["backend"]
+    if isinstance(meta, dict) and meta.get("method"):
+        backend = meta["method"]
+
+    if backend == "lxc":
+        # LXC installs require admin_password.
+        admin_password = body.get("admin_password", "")
+        if not admin_password:
+            return JSONResponse(
+                {"error": "admin_password is required for LXC installs"},
+                status_code=400,
+            )
+
+        user = _get_current_user(request)
+        taos_username = (user or {}).get("username", "admin")
+        taos_email = (user or {}).get("email", "")
+
+        installer = LXCInstaller()
+        try:
+            result = await installer.install(
+                app_id,
+                install_config,
+                admin_password=admin_password,
+                taos_username=taos_username,
+                taos_email=taos_email,
+            )
+        except ValueError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=400)
+        except RuntimeError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=500)
+
+        if not result.get("success"):
+            return JSONResponse({"error": result.get("error", "install failed")}, status_code=500)
+
+        # Persist in installed-apps store if available.
+        store = getattr(request.app.state, "installed_apps", None)
+        if store is not None:
+            await store.install(app_id, body.get("version", ""), meta)
+
+        return JSONResponse({"ok": True, "app_id": app_id, "status": "installed", **result})
+
+    # Default: delegate to InstalledAppsStore (docker/pip/download).
     store = request.app.state.installed_apps
-    await store.install(app_id, body.get("version", ""), body.get("metadata"))
+    await store.install(app_id, body.get("version", ""), meta)
     return JSONResponse({"ok": True, "app_id": app_id, "status": "installed"})
 
 


### PR DESCRIPTION
## Summary

- Install Gitea into its own incus LXC container from the app store, seeded with the user's taOS username.
- Migrate a running LXC service between hosts while preserving all data and config — **works across architectures** (aarch64 ⇆ x86_64) because only state travels, not the rootfs.
- Cross-host migration is driven by `POST /api/cluster/migrate-service`; same-arch fast-path `POST /api/cluster/migrate` (incus move) also added.

## What works end-to-end (tested live on Pi + Fedora)

| Step | Result |
|---|---|
| Install Gitea on Pi (aarch64) | ✅ HTTP 200, admin seeded |
| `migration-test` repo created on Pi | ✅ |
| Migrate Pi → Fedora (aarch64 → x86_64) | ✅ 26.3s, 2.2 MB state tarball |
| Gitea boots on Fedora, serves HTTP 200 | ✅ cross-arch restart |
| `created-on-fedora` repo added on Fedora | ✅ |
| Migrate Fedora → Pi (x86_64 → aarch64) | ✅ 40.9s, 2.3 MB state tarball |
| Gitea back on Pi with both repos, original timestamps intact | ✅ |

## Design: why state-path migration

`incus move` copies the rootfs. It fails cross-arch because the ARM binary won't run on x86. This PR adds `migrate_service` which:

1. `tar`s the declared `state_paths` inside the source container and streams the tarball out.
2. Runs a fresh `LXCInstaller.install()` on the target host (correct-arch base image, correct-arch Gitea binary).
3. Extracts the tarball over the fresh install, starting the service.
4. Destroys the source (unless `keep_source: true`).

The manifest declares per-app state: for Gitea, `/etc/gitea/` + `/home/git/`.

## Files

- `app-catalog/services/gitea-lxc/manifest.yaml` — LXC variant with `state_paths` + `service_name`.
- `tinyagentos/installers/lxc_installer.py` — Gitea LXC installer; supports `restore_tarball` and `target_remote` for remote+restore deployments.
- `tinyagentos/cluster/service_migrator.py` — `migrate_service()` with `source_remote` / `target_remote`.
- `tinyagentos/containers/__init__.py` — incus 6.x token-based remote enrollment + `migrate_container` for same-arch moves.
- `tinyagentos/routes/cluster_migrate.py` — HTTP endpoints for remotes, tokens, both migration paths.
- `docs/runbooks/lxc-migration-gitea.md` — updated runbook covering the state-path flow.
- Tests: 65+ new, covering installer restore mode, service migrator (local/remote source), route, manifest variants.

## Known follow-ups (tracked on the backlog)

- Worker installer should auto-configure incus + token exchange so remote enrollment is a one-liner.
- Controller-side proxy at `/apps/{app_id}/` that follows the container between hosts (auto-routing).
- Desktop icon + native webapp window for installed services, using the proxied URL so it works regardless of where the LXC lives.
- `qemu-user-static` opt-in lifeboat for cross-arch rootfs moves.

## Test plan

- [x] `pytest tests/test_lxc_installer.py tests/test_service_migrator.py tests/test_container_migration.py tests/test_routes_store.py` — 65 passed.
- [x] Full suite locally — 2059 passed / 3 pre-existing macOS hardware-detection failures unrelated.
- [x] Live install on Pi via `/api/store/install-v2` — Gitea reachable + admin login works.
- [x] Live Pi → Fedora → Pi migration via `/api/cluster/migrate-service` — data + timestamps intact both ways.
- [x] Gitea LXCs destroyed and unregistered post-test; next install will be a clean run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gitea (LXC): LXC-backed Gitea app with resource limits, exposed HTTP/SSH ports, health checks, admin-password install/restore flows, state persistence and runtime-location tracking.
  * Cluster: remote enrollment and cross-host container/service migration with transfer/restore, rollback, and mixed-architecture support.
  * Service proxy: /apps/{app_id}/… reverse-proxy with header/cookie handling, Location rewriting, and WS placeholder.

* **Documentation**
  * Runbook for LXC install and cross-host migration.

* **Tests**
  * Broad test suites for installers, migration flows, routes, proxy, and store runtime updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->