### PR TITLE
feat(mobile): readable Agents + Cluster views at 390px wide

### DIFF
--- a/desktop/src/apps/AgentsApp.tsx
+++ b/desktop/src/apps/AgentsApp.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from "react";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import { Bot, Box, Plus, Trash2, ScrollText, Play, Server, X, ChevronRight, ChevronLeft, Check, Wrench, MessageSquare, PauseCircle, RotateCcw, Archive, HardDrive } from "lucide-react";
 import { fetchLatestFrameworks, LatestVersion } from "@/lib/framework-api";
 import { AgentSkillsPanel } from "./AgentSkillsPanel";
@@ -134,12 +135,145 @@ function AgentRow({
   onDelete: (name: string) => void;
   onResume: (name: string) => void;
 }) {
+  const isMobile = useIsMobile();
   const emoji = resolveAgentEmoji(agent.emoji, agent.framework);
   const latestForAgent = agent.framework ? latestByFramework[agent.framework] : undefined;
   const updateAvailable =
     agent.framework_version_sha &&
     latestForAgent &&
     latestForAgent.sha !== agent.framework_version_sha;
+
+  const btnCls = isMobile ? "h-11 w-11" : "h-8 w-8";
+
+  const actionButtons = (
+    <>
+      {agent.paused && (
+        <Button
+          variant="ghost"
+          size="icon"
+          className={`${btnCls} hover:bg-emerald-500/15 hover:text-emerald-400 text-amber-400`}
+          onClick={() => onResume(agent.name)}
+          aria-label={`Resume ${agent.name}`}
+          title="Resume agent"
+        >
+          <RotateCcw size={15} />
+        </Button>
+      )}
+      <Button
+        variant="ghost"
+        size="icon"
+        className={btnCls}
+        onClick={() => onViewLogs(agent.name)}
+        aria-label={`View logs for ${agent.name}`}
+        title="View Logs"
+      >
+        <ScrollText size={15} />
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon"
+        className={btnCls}
+        onClick={() => onViewSkills(agent.name)}
+        aria-label={`Manage skills for ${agent.name}`}
+        title="Skills"
+      >
+        <Wrench size={15} />
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon"
+        className={btnCls}
+        onClick={() => onViewMessages(agent.name)}
+        aria-label={`View messages for ${agent.name}`}
+        title="Messages"
+      >
+        <MessageSquare size={15} />
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon"
+        className={`${btnCls} hover:bg-red-500/15 hover:text-red-400`}
+        onClick={() => onDelete(agent.name)}
+        aria-label={`Delete ${agent.name}`}
+        title="Delete"
+      >
+        <Trash2 size={15} />
+      </Button>
+    </>
+  );
+
+  if (isMobile) {
+    return (
+      <Card className="px-3 py-2.5 hover:bg-shell-surface/50 transition-colors">
+        {/* Row 1: identity + status chip */}
+        <div className="flex items-center gap-2 min-w-0">
+          <span
+            className="w-2 h-2 rounded-full shrink-0"
+            style={{ backgroundColor: agent.color }}
+            aria-label={`Color: ${agent.color}`}
+          />
+          <span className="text-base leading-none shrink-0" aria-hidden="true">
+            {emoji}
+          </span>
+          <span className="font-medium text-sm truncate flex-1 min-w-0">
+            {agent.display_name || agent.name}
+          </span>
+          {updateAvailable && (
+            <span
+              aria-label="framework update available"
+              title="framework update available"
+              className="inline-block w-2 h-2 bg-yellow-400 rounded-full shrink-0"
+            />
+          )}
+          <span
+            className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium capitalize shrink-0 ${STATUS_STYLES[agent.status] ?? STATUS_STYLES.stopped}`}
+            aria-label={`Status: ${agent.status}`}
+          >
+            {agent.status}
+          </span>
+        </div>
+        {/* Row 2: host + vectors + optional chips */}
+        <div className="flex items-center gap-2 mt-1 min-w-0">
+          <Server size={11} className="text-shell-text-tertiary shrink-0" />
+          <span className="text-xs text-shell-text-secondary truncate flex-1 min-w-0">{agent.host}</span>
+          <span className="text-xs text-shell-text-tertiary tabular-nums shrink-0">
+            {agent.vectors.toLocaleString()} vectors
+          </span>
+        </div>
+        {(agent.paused || (diskState && diskState.state !== "ok")) && (
+          <div className="flex flex-wrap gap-1.5 mt-1.5">
+            {agent.paused && (
+              <span
+                className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] font-medium bg-amber-500/20 text-amber-400 border border-amber-500/20"
+                title="This agent is paused due to a worker failure"
+              >
+                <PauseCircle size={10} aria-hidden="true" />
+                paused
+              </span>
+            )}
+            {diskState && diskState.state !== "ok" && (
+              <span
+                className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] font-medium border ${
+                  diskState.state === "hard"
+                    ? "bg-red-500/20 text-red-400 border-red-500/20"
+                    : "bg-amber-500/20 text-amber-400 border-amber-500/20"
+                }`}
+                aria-label={`Disk usage: ${diskState.used_gib}/${diskState.quota_gib} GiB (${diskState.percent}%)`}
+              >
+                <HardDrive size={10} aria-hidden="true" />
+                {diskState.used_gib}/{diskState.quota_gib} GiB
+              </span>
+            )}
+          </div>
+        )}
+        {/* Row 3: action buttons */}
+        <div className="flex items-center gap-0 mt-1 -ml-1.5">
+          {actionButtons}
+        </div>
+      </Card>
+    );
+  }
+
   return (
     <Card className="flex items-center gap-4 px-4 py-3 hover:bg-shell-surface/50 transition-colors">
       <div className="flex items-center gap-2.5 flex-1 min-w-0">
@@ -204,58 +338,7 @@ function AgentRow({
         {agent.vectors.toLocaleString()}
       </span>
       <div className="flex items-center gap-1">
-        {agent.paused && (
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-8 w-8 hover:bg-emerald-500/15 hover:text-emerald-400 text-amber-400"
-            onClick={() => onResume(agent.name)}
-            aria-label={`Resume ${agent.name}`}
-            title="Resume agent"
-          >
-            <RotateCcw size={15} />
-          </Button>
-        )}
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-8 w-8"
-          onClick={() => onViewLogs(agent.name)}
-          aria-label={`View logs for ${agent.name}`}
-          title="View Logs"
-        >
-          <ScrollText size={15} />
-        </Button>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-8 w-8"
-          onClick={() => onViewSkills(agent.name)}
-          aria-label={`Manage skills for ${agent.name}`}
-          title="Skills"
-        >
-          <Wrench size={15} />
-        </Button>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-8 w-8"
-          onClick={() => onViewMessages(agent.name)}
-          aria-label={`View messages for ${agent.name}`}
-          title="Messages"
-        >
-          <MessageSquare size={15} />
-        </Button>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-8 w-8 hover:bg-red-500/15 hover:text-red-400"
-          onClick={() => onDelete(agent.name)}
-          aria-label={`Delete ${agent.name}`}
-          title="Delete"
-        >
-          <Trash2 size={15} />
-        </Button>
+        {actionButtons}
       </div>
     </Card>
   );
@@ -1800,18 +1883,18 @@ export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
   return (
     <div className="flex flex-col h-full min-h-0 overflow-hidden bg-shell-bg text-shell-text select-none relative">
       {/* Toolbar */}
-      <div className="flex items-center justify-between px-4 py-3 border-b border-white/5">
-        <div className="flex items-center gap-2">
-          <Bot size={18} className="text-accent" />
-          <h1 className="text-sm font-semibold">Agents</h1>
-          <span className="text-xs text-shell-text-tertiary">
+      <div className="flex items-center justify-between gap-2 px-4 py-3 border-b border-white/5">
+        <div className="flex items-center gap-2 min-w-0">
+          <Bot size={18} className="text-accent shrink-0" />
+          <h1 className="text-sm font-semibold shrink-0">Agents</h1>
+          <span className="text-xs text-shell-text-tertiary truncate">
             {agents.length} deployed
           </span>
         </div>
         <Button
           onClick={() => setWizardOpen(true)}
           size="sm"
-          className="text-white shadow-lg hover:shadow-xl hover:-translate-y-0.5 hover:brightness-110 border-0"
+          className="text-white shadow-lg hover:shadow-xl hover:-translate-y-0.5 hover:brightness-110 border-0 shrink-0"
           style={{ background: "linear-gradient(135deg, #8b92a3, #5b6170)" }}
           aria-label="Deploy new agent"
         >

--- a/desktop/src/apps/ClusterApp.tsx
+++ b/desktop/src/apps/ClusterApp.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { MobileSplitView } from "@/components/mobile/MobileSplitView";
 import {
   Network, RefreshCw, ExternalLink, Copy, Check, Trash2, Wand2,
@@ -532,6 +532,8 @@ export function ClusterApp({ windowId: _windowId }: { windowId: string }) {
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
+  // True after user explicitly hits "back"; suppresses auto-select on refresh.
+  const userNavigatedBack = useRef(false);
 
   const showToast = useCallback((msg: string) => {
     setToast(msg);
@@ -547,6 +549,7 @@ export function ClusterApp({ windowId: _windowId }: { windowId: string }) {
           setWorkers(json as ClusterWorker[]);
           setSelected((cur) => {
             if (cur && json.some((w: ClusterWorker) => w.name === cur)) return cur;
+            if (userNavigatedBack.current) return null;
             return json.length > 0 ? (json[0] as ClusterWorker).name : null;
           });
         }
@@ -674,7 +677,7 @@ export function ClusterApp({ windowId: _windowId }: { windowId: string }) {
           detailTitle={selectedWorker?.name ?? ""}
           listWidth={288}
           selectedId={selected}
-          onBack={() => setSelected(null)}
+          onBack={() => { userNavigatedBack.current = true; setSelected(null); }}
           list={
             <div className="p-3 space-y-2" aria-label="Cluster worker list">
               {loading ? (
@@ -700,7 +703,7 @@ export function ClusterApp({ windowId: _windowId }: { windowId: string }) {
                     key={w.name}
                     worker={w}
                     selected={selected === w.name}
-                    onSelect={() => setSelected(w.name)}
+                    onSelect={() => { userNavigatedBack.current = false; setSelected(w.name); }}
                   />
                 ))
               )}

--- a/desktop/src/apps/ClusterApp.tsx
+++ b/desktop/src/apps/ClusterApp.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { MobileSplitView } from "@/components/mobile/MobileSplitView";
 import {
   Network, RefreshCw, ExternalLink, Copy, Check, Trash2, Wand2,
   Cpu, MemoryStick, HardDrive, CircuitBoard, Zap, Server, Monitor,
@@ -202,10 +203,10 @@ function WorkerDetail({
   return (
     <div className="flex flex-col h-full min-h-0 overflow-hidden">
       {/* Header */}
-      <div className="flex items-start justify-between gap-3 px-4 py-3 border-b border-white/5 shrink-0">
-        <div className="min-w-0">
+      <div className="flex flex-wrap items-start justify-between gap-2 px-4 py-3 border-b border-white/5 shrink-0">
+        <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2 flex-wrap">
-            <h2 className="text-sm font-semibold text-shell-text truncate">{worker.name}</h2>
+            <h2 className="text-sm font-semibold text-shell-text">{worker.name}</h2>
             <StatusPill status={status} />
             {worker.tier_id && (
               <span
@@ -216,7 +217,7 @@ function WorkerDetail({
               </span>
             )}
           </div>
-          <p className="text-[11px] text-shell-text-tertiary mt-0.5 truncate">
+          <p className="text-[11px] text-shell-text-tertiary mt-0.5 break-all">
             {worker.url}
             {worker.last_heartbeat
               ? `  \u00b7  last seen ${formatRelativeSeconds(worker.last_heartbeat)}`
@@ -228,7 +229,7 @@ function WorkerDetail({
           href={worker.url}
           target="_blank"
           rel="noopener noreferrer"
-          className="shrink-0 inline-flex items-center gap-1.5 text-[11px] px-2.5 py-1.5 rounded-md bg-white/5 border border-white/10 text-shell-text-secondary hover:bg-white/10 transition-colors"
+          className="shrink-0 inline-flex items-center gap-1.5 text-[11px] px-2.5 py-1.5 rounded-md bg-white/5 border border-white/10 text-shell-text-secondary hover:bg-white/10 transition-colors min-h-[44px]"
           aria-label={`Open worker ${worker.name} UI in a new tab`}
         >
           <ExternalLink size={12} />
@@ -632,16 +633,16 @@ export function ClusterApp({ windowId: _windowId }: { windowId: string }) {
   return (
     <div className="flex flex-col h-full min-h-0 overflow-hidden bg-shell-bg text-shell-text select-none">
       {/* Toolbar */}
-      <div className="flex items-center justify-between px-4 py-3 border-b border-white/5 shrink-0">
-        <div className="flex items-center gap-2">
-          <Network size={18} className="text-accent" />
-          <h1 className="text-sm font-semibold">Cluster</h1>
-          <span className="text-xs text-shell-text-tertiary">
+      <div className="flex items-center justify-between gap-2 px-4 py-3 border-b border-white/5 shrink-0">
+        <div className="flex items-center gap-2 min-w-0">
+          <Network size={18} className="text-accent shrink-0" />
+          <h1 className="text-sm font-semibold shrink-0">Cluster</h1>
+          <span className="text-xs text-shell-text-tertiary truncate">
             {workers.length} worker{workers.length === 1 ? "" : "s"}
           </span>
         </div>
-        <div className="flex items-center gap-2">
-          <label htmlFor="cluster-sort" className="text-[11px] text-shell-text-tertiary">
+        <div className="flex items-center gap-1.5 shrink-0">
+          <label htmlFor="cluster-sort" className="sr-only">
             Sort by
           </label>
           <select
@@ -667,57 +668,60 @@ export function ClusterApp({ windowId: _windowId }: { windowId: string }) {
       </div>
 
       {/* Master-detail */}
-      <div className="flex-1 min-h-0 flex overflow-hidden">
-        {/* List */}
-        <aside
-          className="w-72 shrink-0 border-r border-white/5 overflow-y-auto p-3 space-y-2"
-          aria-label="Cluster worker list"
-        >
-          {loading ? (
-            <div className="text-[11px] text-shell-text-tertiary px-2 py-6 text-center">
-              Loading workers...
+      <div className="flex-1 min-h-0 overflow-hidden">
+        <MobileSplitView
+          listTitle="Cluster"
+          detailTitle={selectedWorker?.name ?? ""}
+          listWidth={288}
+          selectedId={selected}
+          onBack={() => setSelected(null)}
+          list={
+            <div className="p-3 space-y-2" aria-label="Cluster worker list">
+              {loading ? (
+                <div className="text-[11px] text-shell-text-tertiary px-2 py-6 text-center">
+                  Loading workers...
+                </div>
+              ) : sortedWorkers.length === 0 ? (
+                <div className="flex flex-col items-center gap-2 py-6 text-center">
+                  <p className="text-[11px] text-shell-text-tertiary">No workers registered yet.</p>
+                  <a
+                    href="https://github.com/jaylfc/tinyagentos#distributed-compute-cluster"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-[11px] px-3 py-1.5 rounded-md bg-white/5 border border-white/10 text-shell-text-secondary hover:bg-white/10 transition-colors"
+                    aria-label="How to add a worker (opens docs in new tab)"
+                  >
+                    How to add a worker
+                  </a>
+                </div>
+              ) : (
+                sortedWorkers.map((w) => (
+                  <WorkerListCard
+                    key={w.name}
+                    worker={w}
+                    selected={selected === w.name}
+                    onSelect={() => setSelected(w.name)}
+                  />
+                ))
+              )}
             </div>
-          ) : sortedWorkers.length === 0 ? (
-            <div className="flex flex-col items-center gap-2 py-6 text-center">
-              <p className="text-[11px] text-shell-text-tertiary">No workers registered yet.</p>
-              <a
-                href="https://github.com/jaylfc/tinyagentos#distributed-compute-cluster"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-[11px] px-3 py-1.5 rounded-md bg-white/5 border border-white/10 text-shell-text-secondary hover:bg-white/10 transition-colors"
-                aria-label="How to add a worker (opens docs in new tab)"
-              >
-                How to add a worker
-              </a>
-            </div>
-          ) : (
-            sortedWorkers.map((w) => (
-              <WorkerListCard
-                key={w.name}
-                worker={w}
-                selected={selected === w.name}
-                onSelect={() => setSelected(w.name)}
+          }
+          detail={
+            selectedWorker ? (
+              <WorkerDetail
+                worker={selectedWorker}
+                onRefresh={fetchWorkers}
+                onDeregister={handleDeregister}
+                onOptimise={handleOptimise}
+                busy={busy}
               />
-            ))
-          )}
-        </aside>
-
-        {/* Detail */}
-        <section className="flex-1 min-w-0 min-h-0 overflow-hidden" aria-label="Worker detail">
-          {selectedWorker ? (
-            <WorkerDetail
-              worker={selectedWorker}
-              onRefresh={fetchWorkers}
-              onDeregister={handleDeregister}
-              onOptimise={handleOptimise}
-              busy={busy}
-            />
-          ) : (
-            <div className="flex items-center justify-center h-full text-shell-text-tertiary text-sm">
-              {loading ? "Loading..." : "No worker selected"}
-            </div>
-          )}
-        </section>
+            ) : (
+              <div className="flex items-center justify-center h-full text-shell-text-tertiary text-sm">
+                {loading ? "Loading..." : "No worker selected"}
+              </div>
+            )
+          }
+        />
       </div>
 
       {/* Toast */}

--- a/desktop/src/apps/__tests__/AgentsApp.mobile.test.tsx
+++ b/desktop/src/apps/__tests__/AgentsApp.mobile.test.tsx
@@ -15,7 +15,7 @@ vi.mock("@/lib/models", () => ({
   CLOUD_PROVIDER_TYPES: [],
 }));
 vi.mock("@/lib/cluster", () => ({
-  availableKvQuantOptions: async () => ({ k: ["fp16"], v: ["fp16"], boundary: false, flat: ["fp16"] }),
+  availableKvQuantOptions: () => ({ k: ["fp16"], v: ["fp16"], boundary: false, flat: ["fp16"] }),
 }));
 vi.mock("@/lib/agent-emoji", () => ({ resolveAgentEmoji: () => "🤖" }));
 vi.mock("@/components/EmojiPicker", () => ({ EmojiPickerField: () => null }));

--- a/desktop/src/apps/__tests__/AgentsApp.mobile.test.tsx
+++ b/desktop/src/apps/__tests__/AgentsApp.mobile.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+// Mock useIsMobile to return true so we test the mobile layout branch
+vi.mock("@/hooks/use-is-mobile", () => ({
+  useIsMobile: () => true,
+}));
+
+// Minimal stubs for imports used by AgentsApp but not needed for this test
+vi.mock("@/lib/framework-api", () => ({ fetchLatestFrameworks: async () => ({}) }));
+vi.mock("@/lib/models", () => ({
+  fetchClusterWorkers: async () => [],
+  workersToAggregated: () => [],
+  HOST_BADGE_CLASS: "",
+  CLOUD_PROVIDER_TYPES: [],
+}));
+vi.mock("@/lib/cluster", () => ({
+  availableKvQuantOptions: async () => ({ k: ["fp16"], v: ["fp16"], boundary: false, flat: ["fp16"] }),
+}));
+vi.mock("@/lib/agent-emoji", () => ({ resolveAgentEmoji: () => "🤖" }));
+vi.mock("@/components/EmojiPicker", () => ({ EmojiPickerField: () => null }));
+vi.mock("@/components/ModelPickerFlow", () => ({ ModelPickerFlow: () => null }));
+vi.mock("@/components/ModelPickerModal", () => ({ ModelPickerModal: () => null }));
+vi.mock("@/components/persona-picker/PersonaPicker", () => ({ PersonaPicker: () => null }));
+vi.mock("@/lib/slug", () => ({
+  slugifyClient: (s: string) => s,
+  isValidSlug: () => true,
+  SLUG_REGEX: /^[a-z0-9][a-z0-9-]{0,62}$/,
+}));
+vi.mock("@/components/MigrationBanner", () => ({ MigrationBanner: () => null }));
+vi.mock("@/components/agent-settings/PersonaTab", () => ({ PersonaTab: () => null }));
+vi.mock("@/components/agent-settings/MemoryTab", () => ({ MemoryTab: () => null }));
+vi.mock("@/components/agent-settings/FrameworkTab", () => ({ FrameworkTab: () => null }));
+vi.mock("./AgentSkillsPanel", () => ({ AgentSkillsPanel: () => null }));
+vi.mock("./AgentMessagesPanel", () => ({ AgentMessagesPanel: () => null }));
+vi.mock("@/components/ui", () => ({
+  Button: ({ children, onClick, className, ...rest }: React.ButtonHTMLAttributes<HTMLButtonElement> & { children?: React.ReactNode }) => (
+    <button onClick={onClick} className={className} {...rest}>{children}</button>
+  ),
+  Card: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+  Label: ({ children }: { children: React.ReactNode }) => <label>{children}</label>,
+  Tabs: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsList: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsTrigger: ({ children }: { children: React.ReactNode }) => <button>{children}</button>,
+}));
+
+import React from "react";
+
+// Import after mocks are registered
+// We test by extracting just the mobile layout concern from AgentRow.
+// AgentRow is not exported, so we render the full AgentsApp with a mocked
+// fetch that returns one agent, then check the DOM.
+import { AgentsApp } from "../AgentsApp";
+
+const MOCK_AGENT = {
+  name: "my-agent",
+  display_name: "My Agent",
+  host: "localhost",
+  color: "#3b82f6",
+  status: "running",
+  vectors: 42,
+  framework: "smolagents",
+  paused: false,
+};
+
+describe("AgentsApp mobile layout (390px viewport)", () => {
+  beforeEach(() => {
+    // Simulate 390px viewport width
+    Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: 390 });
+
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url === "/api/agents") {
+        return Promise.resolve({
+          ok: true,
+          headers: { get: () => "application/json" },
+          json: () => Promise.resolve([MOCK_AGENT]),
+        } as unknown as Response);
+      }
+      if (url === "/api/agents/archived") {
+        return Promise.resolve({
+          ok: true,
+          headers: { get: () => "application/json" },
+          json: () => Promise.resolve([]),
+        } as unknown as Response);
+      }
+      return Promise.resolve({
+        ok: false,
+        headers: { get: () => "application/json" },
+        json: () => Promise.resolve({}),
+      } as unknown as Response);
+    });
+  });
+
+  it("renders agent name on its own line with status chip alongside it", async () => {
+    const { findByText } = render(<AgentsApp windowId="test" />);
+
+    // Agent name must be visible
+    const nameEl = await findByText("My Agent");
+    expect(nameEl).toBeTruthy();
+
+    // Status chip must be visible
+    const statusEl = await findByText("running");
+    expect(statusEl).toBeTruthy();
+
+    // Host must be visible on a second row
+    const hostEl = await findByText("localhost");
+    expect(hostEl).toBeTruthy();
+  });
+
+  it("renders all 4 action buttons with accessible labels", async () => {
+    render(<AgentsApp windowId="test" />);
+
+    // All four action buttons must have aria-labels
+    const logsBtn = await screen.findByRole("button", { name: /view logs for my-agent/i });
+    const skillsBtn = screen.getByRole("button", { name: /manage skills for my-agent/i });
+    const messagesBtn = screen.getByRole("button", { name: /view messages for my-agent/i });
+    const deleteBtn = screen.getByRole("button", { name: /delete my-agent/i });
+
+    expect(logsBtn).toBeTruthy();
+    expect(skillsBtn).toBeTruthy();
+    expect(messagesBtn).toBeTruthy();
+    expect(deleteBtn).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Two taOS mobile-PWA views were unreadable on narrow screens. Fixed without changing desktop layout.

### Agents view

The agent row packed the ID, status chip, and four icon actions into a single flex line — at 390px the name collapsed to "0.2..." and the actions fought the chip. Gated the single-row layout behind `useIsMobile`; on mobile the row now stacks:

1. dot + emoji + name + status chip
2. host (with server icon) + vectors count
3. paused/disk-warn chips (conditional)
4. action buttons at 44×44 for touch targets

Toolbar: `min-w-0` on the left group and `shrink-0` on Deploy Agent so the CTA never gets squeezed out.

### Cluster view

The fixed `w-72` aside next to the worker card forced the right-hand Hardware panel into a ~30px column on a 390px viewport, wrapping "x86_64" and breaking the CPU model one character per line.

Replaced the split with `MobileSplitView` (already used by `MessagesApp`). Mobile gets iOS-style one-pane-at-a-time slide nav; desktop keeps side-by-side layout. Worker detail header also flex-wraps now so "Open worker UI" drops below the name when cramped, URL uses `break-all`, and the "Sort by" label is `sr-only` to reclaim width.

## Changes

- `desktop/src/apps/AgentsApp.tsx` — mobile stacked row + toolbar flex fix.
- `desktop/src/apps/ClusterApp.tsx` — MobileSplitView, wrapping header, sr-only label.
- `desktop/src/apps/__tests__/AgentsApp.mobile.test.tsx` — 2 mobile-layout invariants.

## Style reference

Matched `MessagesApp` conventions: `useIsMobile` hook, `MobileSplitView` component, `shrink-0` / `min-w-0` flex discipline, `text-shell-text-*` tokens. No new design primitives.

## Test plan

- [x] Frontend suite — 304 passed / 3 pre-existing snap-zones failures unchanged.
- [x] Mobile-layout assertions: name + chip visible at 390px, all action buttons have `aria-label`.
- [x] TypeScript clean on changed files.
- [ ] Live visual check on device.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced mobile layouts for Agents and Cluster apps with improved responsiveness
  * Improved touch targets and optimized text handling for better mobile user experience
  * Redesigned agent display with mobile-friendly card layout

* **Tests**
  * Added mobile layout tests to verify responsive behavior on mobile devices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->