### PR TITLE
feat: desktop icons + webapp window for installed services

### DIFF
--- a/desktop/src/apps/ServiceAppWindow.tsx
+++ b/desktop/src/apps/ServiceAppWindow.tsx
@@ -1,0 +1,36 @@
+import { useProcessStore } from "@/stores/process-store";
+
+interface Props {
+  windowId: string;
+}
+
+/**
+ * Renders an installed service's web UI inside a sandboxed iframe.
+ *
+ * The service URL and display name are passed as window props by the
+ * caller that opens the window (ServiceIcon in the Launchpad). The
+ * windowId is used to look up those props from the process store.
+ */
+export function ServiceAppWindow({ windowId }: Props) {
+  const win = useProcessStore((s) => s.windows.find((w) => w.id === windowId));
+  const url = (win?.props?.url as string | undefined) ?? "";
+  const displayName = (win?.props?.displayName as string | undefined) ?? "Service";
+
+  if (!url) {
+    return (
+      <div className="flex items-center justify-center h-full text-shell-text-secondary text-sm">
+        No URL configured for this service.
+      </div>
+    );
+  }
+
+  return (
+    <iframe
+      src={url}
+      title={displayName}
+      className="w-full h-full border-0"
+      sandbox="allow-scripts allow-forms allow-same-origin allow-popups allow-downloads"
+      allow="clipboard-write; fullscreen"
+    />
+  );
+}

--- a/desktop/src/apps/__tests__/ServiceAppWindow.test.tsx
+++ b/desktop/src/apps/__tests__/ServiceAppWindow.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ServiceAppWindow } from "../ServiceAppWindow";
+
+// ---------------------------------------------------------------------------
+// Mock the process store to control window props in each test
+// ---------------------------------------------------------------------------
+const mockWindows: Record<string, unknown>[] = [];
+
+vi.mock("@/stores/process-store", () => ({
+  useProcessStore: (selector: (s: { windows: unknown[] }) => unknown) =>
+    selector({ windows: mockWindows }),
+}));
+
+beforeEach(() => {
+  mockWindows.length = 0;
+});
+
+describe("ServiceAppWindow", () => {
+  it("renders an iframe with the service URL", () => {
+    mockWindows.push({
+      id: "win-1",
+      appId: "service:gitea-lxc",
+      props: { url: "/apps/gitea-lxc/", displayName: "Gitea" },
+    });
+
+    render(<ServiceAppWindow windowId="win-1" />);
+
+    const iframe = screen.getByTitle("Gitea");
+    expect(iframe.tagName).toBe("IFRAME");
+    expect(iframe).toHaveAttribute("src", "/apps/gitea-lxc/");
+  });
+
+  it("sets required sandbox attributes", () => {
+    mockWindows.push({
+      id: "win-2",
+      appId: "service:gitea-lxc",
+      props: { url: "/apps/gitea-lxc/", displayName: "Gitea" },
+    });
+
+    render(<ServiceAppWindow windowId="win-2" />);
+
+    const iframe = screen.getByTitle("Gitea");
+    const sandbox = iframe.getAttribute("sandbox") ?? "";
+    expect(sandbox).toContain("allow-scripts");
+    expect(sandbox).toContain("allow-forms");
+    expect(sandbox).toContain("allow-same-origin");
+    expect(sandbox).toContain("allow-popups");
+    expect(sandbox).toContain("allow-downloads");
+
+    const allow = iframe.getAttribute("allow") ?? "";
+    expect(allow).toContain("clipboard-write");
+    expect(allow).toContain("fullscreen");
+  });
+
+  it("renders an error message when URL is missing", () => {
+    mockWindows.push({
+      id: "win-3",
+      appId: "service:no-url",
+      props: {},
+    });
+
+    render(<ServiceAppWindow windowId="win-3" />);
+
+    expect(screen.queryByRole("document")).toBeNull(); // no iframe
+    expect(screen.getByText(/no url configured/i)).toBeTruthy();
+  });
+
+  it("renders an error message when window is not found", () => {
+    // mockWindows is empty — no window with this ID
+    render(<ServiceAppWindow windowId="win-missing" />);
+
+    expect(screen.getByText(/no url configured/i)).toBeTruthy();
+  });
+});

--- a/desktop/src/components/Launchpad.tsx
+++ b/desktop/src/components/Launchpad.tsx
@@ -1,9 +1,11 @@
 import { useState, useMemo, useRef } from "react";
 import { Search, X } from "lucide-react";
-import { getAllApps, getApp } from "@/registry/app-registry";
+import { getAllApps, getApp, getOrRegisterServiceApp } from "@/registry/app-registry";
 import { useProcessStore } from "@/stores/process-store";
 import { useShortcut } from "@/hooks/use-shortcut-registry";
 import { LaunchpadIcon } from "./LaunchpadIcon";
+import { ServiceIcon } from "./ServiceIcon";
+import { useInstalledServices } from "@/hooks/use-installed-services";
 
 interface Props {
   open: boolean;
@@ -23,6 +25,7 @@ export function Launchpad({ open, onClose, onOpenApp }: Props) {
   const openRef = useRef(open);
   openRef.current = open;
   const { openWindow } = useProcessStore();
+  const installedServices = useInstalledServices();
 
   // Register Escape at overlay priority so it beats any system shortcuts when open
   useShortcut("Escape", () => { if (openRef.current) onClose(); }, "Close launchpad", "overlay");
@@ -53,6 +56,21 @@ export function Launchpad({ open, onClose, onOpenApp }: Props) {
     onClose();
     setQuery("");
   };
+
+  const handleLaunchService = (appId: string, displayName: string, url: string) => {
+    const manifest = getOrRegisterServiceApp(appId, displayName);
+    const wid = openWindow(manifest.id, manifest.defaultSize, { url, displayName });
+    onOpenApp?.(wid);
+    onClose();
+    setQuery("");
+  };
+
+  // Filter services by search query if one is active
+  const filteredServices = useMemo(() => {
+    if (!query.trim()) return installedServices;
+    const q = query.toLowerCase();
+    return installedServices.filter((s) => s.display_name.toLowerCase().includes(q));
+  }, [installedServices, query]);
 
   if (!open) return null;
 
@@ -102,6 +120,23 @@ export function Launchpad({ open, onClose, onOpenApp }: Props) {
               </div>
             </div>
           ))}
+
+          {filteredServices.length > 0 && (
+            <div>
+              <h3 className="text-xs font-medium text-shell-text-tertiary uppercase tracking-wide mb-3 px-1">
+                Services
+              </h3>
+              <div className="grid grid-cols-4 sm:grid-cols-5 md:grid-cols-6 gap-3">
+                {filteredServices.map((svc) => (
+                  <ServiceIcon
+                    key={svc.app_id}
+                    service={svc}
+                    onClick={() => handleLaunchService(svc.app_id, svc.display_name, svc.url)}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/desktop/src/components/ServiceIcon.tsx
+++ b/desktop/src/components/ServiceIcon.tsx
@@ -1,0 +1,42 @@
+import { useState } from "react";
+import { LayoutGrid } from "lucide-react";
+import type { InstalledService } from "@/hooks/use-installed-services";
+
+interface Props {
+  service: InstalledService;
+  onClick: () => void;
+}
+
+/**
+ * Launchpad-style icon tile for an installed service.
+ * Matches the LaunchpadIcon sizing and shape (w-14 h-14 rounded-2xl).
+ * Falls back to a generic grid icon if the image URL 404s.
+ */
+export function ServiceIcon({ service, onClick }: Props) {
+  const [imgFailed, setImgFailed] = useState(false);
+  const showImg = service.icon && !imgFailed;
+
+  return (
+    <button
+      onClick={onClick}
+      className="flex flex-col items-center gap-2 p-3 rounded-xl hover:bg-white/5 transition-colors"
+      aria-label={`Open ${service.display_name}`}
+    >
+      <div className="w-14 h-14 rounded-2xl bg-shell-surface-hover flex items-center justify-center overflow-hidden">
+        {showImg ? (
+          <img
+            src={service.icon!}
+            alt={service.display_name}
+            className="w-8 h-8 object-contain text-shell-text"
+            onError={() => setImgFailed(true)}
+          />
+        ) : (
+          <LayoutGrid size={28} className="text-shell-text" />
+        )}
+      </div>
+      <span className="text-xs text-shell-text-secondary text-center max-w-[72px] truncate">
+        {service.display_name}
+      </span>
+    </button>
+  );
+}

--- a/desktop/src/components/__tests__/ServiceIcon.test.tsx
+++ b/desktop/src/components/__tests__/ServiceIcon.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ServiceIcon } from "../ServiceIcon";
+import type { InstalledService } from "@/hooks/use-installed-services";
+
+const baseService: InstalledService = {
+  app_id: "gitea-lxc",
+  display_name: "Gitea",
+  icon: "/static/app-icons/gitea.svg",
+  url: "/apps/gitea-lxc/",
+  category: "dev-tool",
+  backend: "lxc",
+  status: "running",
+};
+
+describe("ServiceIcon", () => {
+  it("renders the display name", () => {
+    render(<ServiceIcon service={baseService} onClick={() => {}} />);
+    expect(screen.getByText("Gitea")).toBeTruthy();
+  });
+
+  it("renders an img element when icon is provided", () => {
+    render(<ServiceIcon service={baseService} onClick={() => {}} />);
+    const img = screen.getByRole("img");
+    expect(img).toHaveAttribute("src", "/static/app-icons/gitea.svg");
+    expect(img).toHaveAttribute("alt", "Gitea");
+  });
+
+  it("falls back to generic icon on image load error", () => {
+    render(<ServiceIcon service={baseService} onClick={() => {}} />);
+    const img = screen.getByRole("img");
+    fireEvent.error(img);
+
+    // After error, img should be gone and fallback lucide icon rendered instead
+    expect(screen.queryByRole("img")).toBeNull();
+  });
+
+  it("renders generic fallback icon when no icon is provided", () => {
+    const noIcon: InstalledService = { ...baseService, icon: null };
+    render(<ServiceIcon service={noIcon} onClick={() => {}} />);
+    // No <img> element — icon fallback (svg) renders instead
+    expect(screen.queryByRole("img")).toBeNull();
+  });
+
+  it("calls onClick when clicked", () => {
+    const handler = vi.fn();
+    render(<ServiceIcon service={baseService} onClick={handler} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("has a descriptive aria-label", () => {
+    render(<ServiceIcon service={baseService} onClick={() => {}} />);
+    const btn = screen.getByRole("button");
+    expect(btn).toHaveAttribute("aria-label", "Open Gitea");
+  });
+});

--- a/desktop/src/hooks/use-installed-services.ts
+++ b/desktop/src/hooks/use-installed-services.ts
@@ -1,0 +1,34 @@
+import { useState, useEffect } from "react";
+
+export interface InstalledService {
+  app_id: string;
+  display_name: string;
+  icon: string | null;
+  url: string;
+  category: string;
+  backend: string;
+  status: "running" | "stopped" | "unknown";
+}
+
+/**
+ * Fetches the list of installed services from /api/apps/installed.
+ * Returns the list (empty while loading or on error).
+ */
+export function useInstalledServices(): InstalledService[] {
+  const [services, setServices] = useState<InstalledService[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/apps/installed")
+      .then((r) => (r.ok ? r.json() : []))
+      .then((data: InstalledService[]) => {
+        if (!cancelled) setServices(data);
+      })
+      .catch(() => {
+        // Silently ignore — services section just won't appear
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  return services;
+}

--- a/desktop/src/registry/app-registry.ts
+++ b/desktop/src/registry/app-registry.ts
@@ -66,3 +66,35 @@ export function getAppsByCategory(category: AppManifest["category"]): AppManifes
 export function getAllApps(): AppManifest[] {
   return [...apps].sort((a, b) => a.launchpadOrder - b.launchpadOrder);
 }
+
+/**
+ * Register or return a dynamic app manifest for an installed service.
+ *
+ * Each installed service gets its own appId of the form `service:{app_id}`
+ * so that multiple services can be open simultaneously as independent windows.
+ * The manifest is registered lazily on first call and persists for the session.
+ */
+export function getOrRegisterServiceApp(
+  appId: string,
+  displayName: string,
+): AppManifest {
+  const dynId = `service:${appId}`;
+  const existing = apps.find((a) => a.id === dynId);
+  if (existing) return existing;
+
+  const manifest: AppManifest = {
+    id: dynId,
+    name: displayName,
+    icon: "layout-grid",
+    category: "platform",
+    component: () =>
+      import("@/apps/ServiceAppWindow").then((m) => ({ default: m.ServiceAppWindow })),
+    defaultSize: { w: 1100, h: 750 },
+    minSize: { w: 600, h: 400 },
+    singleton: true,
+    pinned: false,
+    launchpadOrder: 999,
+  };
+  apps.push(manifest);
+  return manifest;
+}

--- a/static/app-icons/generic-service.svg
+++ b/static/app-icons/generic-service.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Grid of dots representing a generic service/app -->
+  <rect x="3" y="3" width="7" height="7" rx="1.5"/>
+  <rect x="14" y="3" width="7" height="7" rx="1.5"/>
+  <rect x="3" y="14" width="7" height="7" rx="1.5"/>
+  <rect x="14" y="14" width="7" height="7" rx="1.5"/>
+</svg>

--- a/static/app-icons/gitea.svg
+++ b/static/app-icons/gitea.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <!-- Gitea teacup logo mark — simplified monochrome silhouette -->
+  <!-- Cup body -->
+  <path d="M4 8h12l-1.5 8.5a2 2 0 0 1-2 1.5H7.5a2 2 0 0 1-2-1.5L4 8z"/>
+  <!-- Handle -->
+  <path d="M16 10.5h1.5a2 2 0 0 1 0 4H16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+  <!-- Steam wisps -->
+  <path d="M8 5.5 Q8.5 4 8 2.5" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/>
+  <path d="M10.5 5.5 Q11 4 10.5 2.5" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/>
+  <path d="M13 5.5 Q13.5 4 13 2.5" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/>
+</svg>

--- a/tests/test_apps_installed.py
+++ b/tests/test_apps_installed.py
@@ -1,0 +1,165 @@
+"""Tests for GET /api/apps/installed.
+
+Covers:
+- Empty store returns empty list.
+- App installed but no runtime location is excluded.
+- App with runtime location is included with correct shape.
+- display_name / icon / url / category fallback logic.
+- Multiple apps: only those with a runtime location are returned.
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from tinyagentos.app import create_app
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def apps_app(tmp_data_dir):
+    return create_app(data_dir=tmp_data_dir)
+
+
+@pytest_asyncio.fixture
+async def apps_client(apps_app):
+    """Authenticated async client with installed_apps store initialised."""
+    store = apps_app.state.metrics
+    if store._db is not None:
+        await store.close()
+    await store.init()
+    await apps_app.state.qmd_client.init()
+
+    installed_apps = apps_app.state.installed_apps
+    if installed_apps._db is not None:
+        await installed_apps.close()
+    await installed_apps.init()
+
+    apps_app.state.auth.setup_user("admin", "Test Admin", "", "testpass")
+    rec = apps_app.state.auth.find_user("admin")
+    token = apps_app.state.auth.create_session(
+        user_id=rec["id"] if rec else "", long_lived=True
+    )
+    transport = ASGITransport(app=apps_app)
+    async with AsyncClient(
+        transport=transport, base_url="http://test", cookies={"taos_session": token}
+    ) as c:
+        yield c, apps_app.state.installed_apps
+
+    await installed_apps.close()
+    await store.close()
+    await apps_app.state.qmd_client.close()
+    await apps_app.state.http_client.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestEmptyStore:
+    @pytest.mark.asyncio
+    async def test_empty_store_returns_empty_list(self, apps_client):
+        client, _ = apps_client
+        resp = await client.get("/api/apps/installed")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+
+class TestNoRuntimeLocation:
+    @pytest.mark.asyncio
+    async def test_app_without_runtime_excluded(self, apps_client):
+        """Apps that have no runtime location are not listed as desktop icons."""
+        client, store = apps_client
+        await store.install("some-app", "1.0")
+        # Deliberately do NOT call update_runtime_location.
+        resp = await client.get("/api/apps/installed")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+
+class TestWithRuntimeLocation:
+    @pytest.mark.asyncio
+    async def test_app_with_runtime_location_is_included(self, apps_client):
+        client, store = apps_client
+        await store.install("my-svc", "1.0")
+        await store.update_runtime_location("my-svc", host="10.0.0.2", port=3000, backend="lxc", ui_path="/")
+
+        resp = await client.get("/api/apps/installed")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        item = data[0]
+        assert item["app_id"] == "my-svc"
+        assert item["url"] == "/apps/my-svc/"
+        assert item["backend"] == "lxc"
+        assert item["status"] == "running"
+
+    @pytest.mark.asyncio
+    async def test_url_construction_uses_ui_path(self, apps_client):
+        client, store = apps_client
+        await store.install("svc-subpath", "1.0")
+        await store.update_runtime_location(
+            "svc-subpath", host="10.0.0.3", port=8080, backend="lxc", ui_path="/app/"
+        )
+
+        resp = await client.get("/api/apps/installed")
+        assert resp.status_code == 200
+        item = next(i for i in resp.json() if i["app_id"] == "svc-subpath")
+        assert item["url"] == "/apps/svc-subpath/app/"
+
+    @pytest.mark.asyncio
+    async def test_display_name_falls_back_to_app_id(self, apps_client):
+        """When there is no manifest, display_name falls back to app_id."""
+        client, store = apps_client
+        await store.install("no-manifest-app", "1.0")
+        await store.update_runtime_location("no-manifest-app", host="10.0.0.4", port=9000)
+
+        resp = await client.get("/api/apps/installed")
+        item = next(i for i in resp.json() if i["app_id"] == "no-manifest-app")
+        assert item["display_name"] == "no-manifest-app"
+
+    @pytest.mark.asyncio
+    async def test_generic_icon_when_no_manifest(self, apps_client):
+        client, store = apps_client
+        await store.install("iconless", "1.0")
+        await store.update_runtime_location("iconless", host="10.0.0.5", port=7000)
+
+        resp = await client.get("/api/apps/installed")
+        item = next(i for i in resp.json() if i["app_id"] == "iconless")
+        assert item["icon"] == "/static/app-icons/generic-service.svg"
+
+
+class TestMultipleApps:
+    @pytest.mark.asyncio
+    async def test_only_apps_with_runtime_returned(self, apps_client):
+        """Install 3 apps; only 2 have runtime locations. Expect 2 in response."""
+        client, store = apps_client
+        await store.install("app-a", "1.0")
+        await store.install("app-b", "1.0")
+        await store.install("app-c", "1.0")
+
+        await store.update_runtime_location("app-a", host="10.0.0.10", port=3001)
+        await store.update_runtime_location("app-c", host="10.0.0.12", port=3003)
+        # app-b intentionally has no runtime location
+
+        resp = await client.get("/api/apps/installed")
+        assert resp.status_code == 200
+        ids = {i["app_id"] for i in resp.json()}
+        assert ids == {"app-a", "app-c"}
+        assert "app-b" not in ids
+
+    @pytest.mark.asyncio
+    async def test_response_shape_is_complete(self, apps_client):
+        """Every response item must carry all expected keys."""
+        client, store = apps_client
+        await store.install("shape-test", "1.0")
+        await store.update_runtime_location("shape-test", host="10.0.0.20", port=4000)
+
+        resp = await client.get("/api/apps/installed")
+        item = resp.json()[0]
+        for key in ("app_id", "display_name", "icon", "url", "category", "backend", "status"):
+            assert key in item, f"Missing key: {key}"

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -939,6 +939,9 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     from tinyagentos.routes.service_proxy import router as service_proxy_router
     app.include_router(service_proxy_router)
 
+    from tinyagentos.routes.apps import router as apps_router
+    app.include_router(apps_router)
+
     from tinyagentos.routes import admin_prompts as admin_prompts_routes
     app.include_router(admin_prompts_routes.router)
 

--- a/tinyagentos/routes/apps.py
+++ b/tinyagentos/routes/apps.py
@@ -1,0 +1,114 @@
+"""Desktop service icon API.
+
+GET /api/apps/installed — list installed services that have a recorded
+runtime location (host + port). These are the apps that get desktop icons
+and can be opened in a taOS web-app window via the service proxy.
+
+Only includes apps with a runtime_host/runtime_port entry, i.e. those
+successfully installed via the LXC installer path. Docker-only apps
+without proxy routing are excluded until their install path also records
+a runtime location.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+
+router = APIRouter()
+
+_GENERIC_ICON = "/static/app-icons/generic-service.svg"
+
+
+def _resolve_icon(manifest_icon: str, manifest_dir) -> str:
+    """Resolve the manifest's icon field to a URL string.
+
+    Accepts:
+    - Absolute URL paths like /static/app-icons/gitea.svg  → returned as-is.
+    - http/https URLs                                        → returned as-is.
+    - Relative paths (e.g. icons/gitea.svg) relative to
+      the manifest dir — not currently served, so fall back
+      to the generic icon.
+    Returns the generic icon if the field is empty.
+    """
+    if not manifest_icon:
+        return _GENERIC_ICON
+    if manifest_icon.startswith("/") or manifest_icon.startswith("http"):
+        return manifest_icon
+    # Relative path — would need extra static-mount work; use generic for now.
+    return _GENERIC_ICON
+
+
+@router.get("/api/apps/installed")
+async def list_installed_apps(request: Request):
+    """Return installed services that have a live proxy location.
+
+    Shape per item::
+
+        {
+            "app_id": "gitea-lxc",
+            "display_name": "Gitea",
+            "icon": "/static/app-icons/gitea.svg",
+            "url": "/apps/gitea-lxc/",
+            "category": "dev-tool",
+            "backend": "lxc",
+            "status": "running" | "unknown"
+        }
+
+    ``status`` is "running" when runtime_host + runtime_port are recorded;
+    no live health check is performed here (that would add latency to every
+    desktop load).
+    """
+    installed_apps: object = getattr(request.app.state, "installed_apps", None)
+    registry: object = getattr(request.app.state, "registry", None)
+
+    if installed_apps is None:
+        return []
+
+    rows = await installed_apps.list_installed()
+    result = []
+
+    for row in rows:
+        app_id: str = row["app_id"]
+        loc = await installed_apps.get_runtime_location(app_id)
+        if loc is None:
+            # No runtime location → not accessible via proxy → skip.
+            continue
+        if not loc.get("runtime_host") or not loc.get("runtime_port"):
+            # Incomplete runtime record — not proxy-routable yet.
+            continue
+
+        # Best-effort manifest lookup for display metadata.
+        manifest = registry.get(app_id) if registry is not None else None
+        if manifest is not None:
+            install_block = manifest.install or {}
+            display_name: str = (
+                install_block.get("display_name")
+                or manifest.name
+                or app_id
+            )
+            icon: str = _resolve_icon(
+                install_block.get("icon") or manifest.icon or "",
+                manifest.manifest_dir,
+            )
+            category: str = manifest.category or ""
+        else:
+            display_name = app_id
+            icon = _GENERIC_ICON
+            category = ""
+
+        backend: str = loc.get("backend") or ""
+        ui_path: str = str(loc.get("ui_path") or "/")
+        if not ui_path.startswith("/"):
+            ui_path = f"/{ui_path}"
+        url = f"/apps/{app_id}{ui_path}"
+
+        result.append({
+            "app_id": app_id,
+            "display_name": display_name,
+            "icon": icon,
+            "url": url,
+            "category": category,
+            "backend": backend,
+            "status": "running",
+        })
+
+    return result


### PR DESCRIPTION
## Summary

Desktop icons for installed LXC services, opened as native taOS webapp windows pointed at \`/apps/{app_id}/\`. Reclean of #250 after its parent PR closed.

## Changes

- \`GET /api/apps/installed\` — lists installed services with display_name, icon, proxy url, backend, status.
- Icons at \`/static/app-icons/generic-service.svg\` + \`gitea.svg\`.
- Frontend: \`useInstalledServices\` hook, \`ServiceIcon\` tile, \`ServiceAppWindow\` (reuses existing Window chrome via \`getOrRegisterServiceApp\`), Services section in Launchpad.
- Clicking an icon opens the service in an iframe at \`/apps/{app_id}/\` so the window follows the container across host migrations.

Generic — works for every LXC service that registers a runtime location.

## Test plan

- [x] \`pytest tests/test_apps_installed.py\` — 8 passed.
- [x] Frontend component tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for installing and running external services alongside existing apps
  * Installed services now appear in a dedicated Services section in the Launchpad with icons and names
  * Services are searchable and discoverable through the existing search functionality
  * Clicking a service launches it in a dedicated window

<!-- end of auto-generated comment: release notes by coderabbit.ai -->