### PR TITLE
feat: install LXC services directly to a worker from the store

### DIFF
--- a/desktop/src/apps/StoreApp.tsx
+++ b/desktop/src/apps/StoreApp.tsx
@@ -16,6 +16,21 @@ interface CatalogApp {
   installed: boolean;
   compat: "green" | "yellow" | "red";
   category?: string;
+  install_method?: string;
+}
+
+interface InstallTarget {
+  name: string;
+  label: string;
+  type: "local" | "remote";
+  addr?: string;
+}
+
+interface InstalledEntry {
+  app_id: string;
+  runtime_host: string | null;
+  runtime_port: number | null;
+  runtime_backend: string | null;
 }
 
 /* ------------------------------------------------------------------ */
@@ -418,35 +433,56 @@ function resolveIconUrl(appId: string): string | null {
 /*  AppCard                                                            */
 /* ------------------------------------------------------------------ */
 
-function AppCard({ app, affected, onInstall, onUninstall }: { app: CatalogApp; affected: number; onInstall: (id: string) => void; onUninstall: (id: string) => void }) {
+function AppCard({ app, affected, onInstall, onUninstall, installTargets, runtimeHost }: {
+  app: CatalogApp;
+  affected: number;
+  onInstall: (id: string) => void;
+  onUninstall: (id: string) => void;
+  installTargets: InstallTarget[];
+  runtimeHost: string | null;
+}) {
   const [busy, setBusy] = useState(false);
   const [iconFailed, setIconFailed] = useState(false);
-
+  const [selectedTarget, setSelectedTarget] = useState("local");
   const [error, setError] = useState<string | null>(null);
   const iconUrl = resolveIconUrl(app.id);
+  const isLxc = app.install_method === "lxc";
 
   const handleAction = async () => {
     setBusy(true);
     setError(null);
     try {
-      const url = app.installed ? "/api/store/uninstall" : "/api/store/install";
-      const res = await fetch(url, {
-        method: "POST",
-        headers: { "Content-Type": "application/json", Accept: "application/json" },
-        body: JSON.stringify({ app_id: app.id }),
-      });
-      if (!res.ok) {
-        let msg = `${app.installed ? "Uninstall" : "Install"} failed (${res.status})`;
-        try {
-          const err = await res.json();
-          if (err?.error) msg = String(err.error);
-        } catch { /* ignore */ }
-        setError(msg);
-        setBusy(false);
-        return;
+      if (app.installed) {
+        const res = await fetch("/api/store/uninstall", {
+          method: "POST",
+          headers: { "Content-Type": "application/json", Accept: "application/json" },
+          body: JSON.stringify({ app_id: app.id }),
+        });
+        if (!res.ok) {
+          let msg = `Uninstall failed (${res.status})`;
+          try { const err = await res.json(); if (err?.error) msg = String(err.error); } catch { /* ignore */ }
+          setError(msg);
+          setBusy(false);
+          return;
+        }
+        onUninstall(app.id);
+      } else {
+        const body: Record<string, unknown> = { app_id: app.id };
+        if (isLxc) body.target_remote = selectedTarget;
+        const res = await fetch("/api/store/install-v2", {
+          method: "POST",
+          headers: { "Content-Type": "application/json", Accept: "application/json" },
+          body: JSON.stringify(body),
+        });
+        if (!res.ok) {
+          let msg = `Install failed (${res.status})`;
+          try { const err = await res.json(); if (err?.error) msg = String(err.error); } catch { /* ignore */ }
+          setError(msg);
+          setBusy(false);
+          return;
+        }
+        onInstall(app.id);
       }
-      if (app.installed) onUninstall(app.id);
-      else onInstall(app.id);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Network error");
     }
@@ -505,12 +541,37 @@ function AppCard({ app, affected, onInstall, onUninstall }: { app: CatalogApp; a
             {error}
           </div>
         )}
+        {isLxc && !app.installed && installTargets.length > 1 && (
+          <div className="flex items-center gap-2">
+            <label htmlFor={`target-${app.id}`} className="text-[11px] text-shell-text-tertiary whitespace-nowrap">
+              Install on
+            </label>
+            <select
+              id={`target-${app.id}`}
+              value={selectedTarget}
+              onChange={(e) => setSelectedTarget(e.target.value)}
+              className="flex-1 h-7 rounded-md border border-white/10 bg-shell-bg-deep px-2 text-[11px] text-shell-text focus-visible:outline-none focus-visible:border-accent/40 focus-visible:ring-2 focus-visible:ring-accent/20 transition-colors"
+              aria-label="Install target host"
+            >
+              {installTargets.map((t) => (
+                <option key={t.name} value={t.name}>{t.label}</option>
+              ))}
+            </select>
+          </div>
+        )}
+        {app.installed && runtimeHost && (
+          <p className="text-[10px] text-shell-text-tertiary flex items-center gap-1">
+            <Server className="w-3 h-3 shrink-0" />
+            {runtimeHost === "127.0.0.1" ? "on controller" : `on ${runtimeHost}`}
+          </p>
+        )}
         <Button
           variant={app.installed ? "destructive" : "default"}
           size="sm"
           className="w-full"
           onClick={handleAction}
           disabled={busy}
+          aria-label={app.installed ? `Uninstall ${app.name}` : `Install ${app.name}`}
         >
           {busy ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : app.installed ? <><Trash2 className="w-3.5 h-3.5" /> Uninstall</> : <><Download className="w-3.5 h-3.5" /> Install</>}
         </Button>
@@ -530,6 +591,23 @@ export function StoreApp({ windowId: _windowId }: { windowId: string }) {
   const [loading, setLoading] = useState(true);
   const [latest, setLatest] = useState<Record<string, LatestVersion>>({});
   const [agentList, setAgentList] = useState<any[]>([]);
+  const [installTargets, setInstallTargets] = useState<InstallTarget[]>([
+    { name: "local", label: "This controller", type: "local" },
+  ]);
+  const [runtimeHosts, setRuntimeHosts] = useState<Record<string, string | null>>({});
+
+  const refreshInstalled = useCallback(() => {
+    fetch("/api/store/installed-v2", { headers: { Accept: "application/json" } })
+      .then((r) => r.ok ? r.json() : null)
+      .then((data) => {
+        const hosts: Record<string, string | null> = {};
+        for (const entry of (data?.installed ?? []) as InstalledEntry[]) {
+          hosts[entry.app_id] = entry.runtime_host ?? null;
+        }
+        setRuntimeHosts(hosts);
+      })
+      .catch(() => {});
+  }, []);
 
   const fetchCatalog = useCallback(async () => {
     try {
@@ -549,6 +627,7 @@ export function StoreApp({ windowId: _windowId }: { windowId: string }) {
             description: String(a.description ?? ""),
             installed: Boolean(a.installed),
             compat: (a.compat as CatalogApp["compat"]) ?? "green",
+            install_method: a.install_method ? String(a.install_method) : undefined,
           }));
           setApps(normalized);
           setLoading(false);
@@ -580,7 +659,12 @@ export function StoreApp({ windowId: _windowId }: { windowId: string }) {
       .then((r) => r.ok ? r.json() : [])
       .then((j) => setAgentList(Array.isArray(j) ? j : (j?.agents ?? [])))
       .catch(() => {});
-  }, []);
+    fetch("/api/cluster/install-targets", { headers: { Accept: "application/json" } })
+      .then((r) => r.ok ? r.json() : null)
+      .then((data) => { if (Array.isArray(data)) setInstallTargets(data); })
+      .catch(() => {});
+    refreshInstalled();
+  }, [refreshInstalled]);
 
   const activeCat = CATEGORIES.find((c) => c.id === activeCategory);
 
@@ -597,11 +681,13 @@ export function StoreApp({ windowId: _windowId }: { windowId: string }) {
 
   const handleInstall = useCallback((id: string) => {
     setApps((prev) => prev.map((a) => (a.id === id ? { ...a, installed: true } : a)));
-  }, []);
+    refreshInstalled();
+  }, [refreshInstalled]);
 
   const handleUninstall = useCallback((id: string) => {
     setApps((prev) => prev.map((a) => (a.id === id ? { ...a, installed: false } : a)));
-  }, []);
+    refreshInstalled();
+  }, [refreshInstalled]);
 
   // Count per category
   const counts: Record<string, number> = {};
@@ -714,7 +800,15 @@ export function StoreApp({ windowId: _windowId }: { windowId: string }) {
                     ).length
                   : 0;
                 return (
-                  <AppCard key={app.id} app={app} affected={affected} onInstall={handleInstall} onUninstall={handleUninstall} />
+                  <AppCard
+                    key={app.id}
+                    app={app}
+                    affected={affected}
+                    onInstall={handleInstall}
+                    onUninstall={handleUninstall}
+                    installTargets={installTargets}
+                    runtimeHost={runtimeHosts[app.id] ?? null}
+                  />
                 );
               })}
             </div>

--- a/docs/runbooks/lxc-migration-gitea.md
+++ b/docs/runbooks/lxc-migration-gitea.md
@@ -51,7 +51,13 @@ on the worker — same flow in reverse.
 
 ## Procedure
 
-### 1. Install Gitea on the controller
+### 1. Install Gitea on the controller (or a worker)
+
+You can install directly to a registered worker by adding `"target_remote"` to
+the request body. Omit it (or set it to `""` or `"local"`) to install on the
+controller — the API normalizes all three to a local install.
+
+**Install on the controller (default):**
 
 ```bash
 curl -X POST http://localhost:6969/api/store/install-v2 \
@@ -65,6 +71,29 @@ curl -X POST http://localhost:6969/api/store/install-v2 \
     "metadata": {"backend": "lxc"}
   }'
 ```
+
+**Install directly on a worker** (skips the migrate step if you know where you
+want it from the start):
+
+```bash
+curl -X POST http://localhost:6969/api/store/install-v2 \
+  -H "Authorization: Bearer $(cat data/.auth_local_token)" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "app_id": "gitea-lxc",
+    "admin_password": "<pick-a-strong-password>",
+    "taos_username": "jay",
+    "taos_email": "jaylfc25@gmail.com",
+    "metadata": {"backend": "lxc"},
+    "target_remote": "fedora-worker"
+  }'
+```
+
+`target_remote` must match a remote already registered via
+`POST /api/cluster/remotes`. Use `GET /api/cluster/install-targets` to list
+valid names. Omitting the field, passing `""`, or passing `"local"` all install
+on the controller. In the taOS Store UI, an "Install on" dropdown appears
+automatically on LXC apps when workers are registered.
 
 Install takes 2-3 minutes (incus launch + apt install + Gitea binary
 download). Response includes `host_port`. Verify:
@@ -169,7 +198,7 @@ If a migration fails mid-way:
 After install or migration, every service has a stable proxy URL on the
 controller:
 
-```
+```text
 http://localhost:6969/apps/gitea-lxc/
 ```
 

--- a/tinyagentos/routes/cluster.py
+++ b/tinyagentos/routes/cluster.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import logging
 from dataclasses import asdict
 
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
 
 from tinyagentos.cluster.capabilities import potential_capabilities as _potential_capabilities
 from tinyagentos.cluster.optimiser import ClusterOptimiser
@@ -213,6 +216,36 @@ async def optimise_cluster(request: Request):
     cluster = request.app.state.cluster_manager
     optimiser = ClusterOptimiser(cluster)
     return optimiser.analyse()
+
+
+_BUILTIN_REMOTES = {"images", "ubuntu", "ubuntu-daily", "local"}
+
+
+@router.get("/api/cluster/install-targets")
+async def list_install_targets():
+    """Return the ordered list of hosts available for LXC service installs.
+
+    Always includes the controller first ("local"), then any registered incus
+    remotes whose protocol is "incus" (filters out the read-only image servers).
+    """
+    targets: list[dict] = [{"name": "local", "label": "This controller", "type": "local"}]
+    try:
+        import tinyagentos.containers as containers
+        remotes = await containers.remote_list()
+        for r in remotes:
+            name = r.get("name", "")
+            proto = r.get("protocol", "")
+            if not name or name in _BUILTIN_REMOTES or proto != "incus":
+                continue
+            targets.append({
+                "name": name,
+                "label": name,
+                "type": "remote",
+                "addr": r.get("addr", ""),
+            })
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("list_install_targets: remote_list failed: %s", exc)
+    return targets
 
 
 @router.post("/api/cluster/move")

--- a/tinyagentos/routes/store.py
+++ b/tinyagentos/routes/store.py
@@ -68,6 +68,7 @@ async def list_catalog(request: Request, type: str | None = None):
             "version": a.version,
             "description": a.description, "icon": a.icon,
             "requires": a.requires, "hardware_tiers": a.hardware_tiers,
+            "install_method": (a.install.get("method") or a.install.get("backend") or "") if isinstance(a.install, dict) else "",
             "installed": (installation.is_installed(a.id) if installation else registry.is_installed(a.id)),
             "state": (installation.state(a.id) if installation else ("installed" if registry.is_installed(a.id) else "not_installed")),
         }

--- a/tinyagentos/routes/store_install.py
+++ b/tinyagentos/routes/store_install.py
@@ -101,6 +101,26 @@ async def install_app(request: Request):
                 status_code=400,
             )
 
+        # Resolve target_remote: body field takes precedence over manifest.
+        # Normalise empty string / "local" to None (= install on controller).
+        raw_remote = body.get("target_remote") or install_config.get("target_remote") or ""
+        target_remote: str | None = raw_remote if raw_remote and raw_remote != "local" else None
+
+        # Validate that the requested remote is registered.
+        if target_remote:
+            try:
+                import tinyagentos.containers as containers
+                registered = await containers.remote_list()
+                known = {r.get("name") for r in registered}
+                if target_remote not in known:
+                    return JSONResponse(
+                        {"error": f"incus remote '{target_remote}' is not registered. "
+                         f"Register it first via POST /api/cluster/remotes."},
+                        status_code=400,
+                    )
+            except Exception as exc:
+                logger.warning("install-v2: could not verify remote %r: %s", target_remote, exc)
+
         user = _get_current_user(request)
         # Body overrides win so local-token / non-session callers can seed the
         # admin user explicitly. Gitea rejects "admin" as a reserved name, so
@@ -116,6 +136,7 @@ async def install_app(request: Request):
                 admin_password=admin_password,
                 taos_username=taos_username,
                 taos_email=taos_email,
+                target_remote=target_remote,
             )
         except ValueError as exc:
             return JSONResponse({"error": str(exc)}, status_code=400)
@@ -132,7 +153,6 @@ async def install_app(request: Request):
 
             # Record runtime location so the proxy can reach the service.
             host_port = result.get("host_port")
-            target_remote = install_config.get("target_remote") or body.get("target_remote")
             if host_port:
                 runtime_host = await _resolve_host(target_remote)
                 ui_path = install_config.get("ui_path", "/")
@@ -144,7 +164,9 @@ async def install_app(request: Request):
                     ui_path=ui_path,
                 )
 
-        return JSONResponse({"ok": True, "app_id": app_id, "status": "installed", **result})
+        resp_target = target_remote or "local"
+        return JSONResponse({"ok": True, "app_id": app_id, "status": "installed",
+                             "target_remote": resp_target, **result})
 
     # Default: delegate to InstalledAppsStore (docker/pip/download).
     store = request.app.state.installed_apps
@@ -161,7 +183,6 @@ async def uninstall_app(request: Request):
 
     # Determine backend from manifest or body metadata.
     registry = getattr(request.app.state, "registry", None)
-    manifest = None
     backend = "docker"
     if registry is not None:
         manifest = registry.get(app_id)
@@ -176,11 +197,24 @@ async def uninstall_app(request: Request):
         if isinstance(meta, dict) and meta.get("method"):
             backend = meta["method"]
 
+    # Retrieve the runtime location before touching the store so we know
+    # whether the container lives on a remote host.
+    _store_for_loc = getattr(request.app.state, "installed_apps", None)
+    _runtime_loc = None
+    if _store_for_loc is not None:
+        _runtime_loc = await _store_for_loc.get_runtime_location(app_id)
+
     container_error: str | None = None
     if backend == "lxc":
+        target_remote: str | None = None
+        if _runtime_loc is not None:
+            _runtime_host = _runtime_loc.get("runtime_host", "")
+            # 127.0.0.1 means local; anything else is a remote host name.
+            if _runtime_host and _runtime_host != "127.0.0.1":
+                target_remote = _runtime_host
         try:
             installer = LXCInstaller()
-            uninstall_result = await installer.uninstall(app_id)
+            uninstall_result = await installer.uninstall(app_id, target_remote=target_remote)
             if not uninstall_result.get("success", False):
                 container_error = (
                     uninstall_result.get("error")
@@ -191,12 +225,18 @@ async def uninstall_app(request: Request):
             logger.warning("LXC container destroy failed for %s: %s", app_id, exc)
             container_error = str(exc)
 
+    if container_error is not None:
+        # Container removal failed; do not clear the store record so the
+        # orphaned container can be retried or manually cleaned up.
+        return JSONResponse(
+            {"ok": False, "app_id": app_id, "container_error": container_error},
+            status_code=500,
+        )
+
     store = request.app.state.installed_apps
     removed = await store.uninstall(app_id)
     await store.remove_runtime_location(app_id)
     resp: dict = {"ok": removed, "app_id": app_id, "status": "uninstalled" if removed else "not_installed"}
-    if container_error is not None:
-        resp["container_error"] = container_error
     return JSONResponse(resp)
 
 
@@ -204,4 +244,16 @@ async def uninstall_app(request: Request):
 async def list_installed(request: Request):
     store = request.app.state.installed_apps
     items = await store.list_installed()
+    # Annotate each item with its runtime location so the UI can show which
+    # host each app currently lives on.
+    for item in items:
+        loc = await store.get_runtime_location(item["app_id"])
+        if loc:
+            item["runtime_host"] = loc["runtime_host"]
+            item["runtime_port"] = loc["runtime_port"]
+            item["runtime_backend"] = loc["backend"]
+        else:
+            item["runtime_host"] = None
+            item["runtime_port"] = None
+            item["runtime_backend"] = None
     return JSONResponse({"installed": items})


### PR DESCRIPTION
Reclean of #253 on new master. Store install dropdown to pick worker; `install-targets` endpoint; installed-apps list shows runtime host. See commit for details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for installing apps to multiple installation targets (e.g., remote workers)
  * Enhanced app installation UI with target selection for compatible apps
  * Displays runtime host information for installed applications
  * New endpoint to retrieve available installation targets

* **Documentation**
  * Updated migration guide with examples for installing apps to registered remote workers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->