### PR TITLE
fix(review): Gitea ROOT_URL, manifest normalisation, token parse error handling

### DIFF
--- a/tests/test_lxc_installer.py
+++ b/tests/test_lxc_installer.py
@@ -617,11 +617,13 @@ class TestInstallRouteBackendSelection:
             )
 
         assert resp.status_code == 200
-        instance.uninstall.assert_awaited_once_with("gitea-lxc")
+        instance.uninstall.assert_awaited_once_with("gitea-lxc", target_remote=None)
 
-    async def test_lxc_uninstall_container_error_still_unregisters(self, lxc_client):
-        """If container destroy fails, store uninstall still proceeds and error is surfaced."""
-        # First register the app so store.uninstall returns True.
+    async def test_lxc_uninstall_container_error_blocks_store_removal(self, lxc_client):
+        """If container destroy fails, return 500 and keep the store record so
+        the user doesn't end up with an orphan container that taOS no longer
+        tracks. Addresses the CodeRabbit finding that let migrated containers
+        live on while the app_id was marked uninstalled."""
         with patch(
             "tinyagentos.routes.store_install.LXCInstaller",
         ) as MockInstaller:
@@ -633,7 +635,7 @@ class TestInstallRouteBackendSelection:
                 json={"app_id": "gitea-lxc", "metadata": {"method": "lxc"}},
             )
 
-        assert resp.status_code == 200
+        assert resp.status_code == 500
         data = resp.json()
         assert "container_error" in data
         assert "container gone" in data["container_error"]

--- a/tinyagentos/containers/__init__.py
+++ b/tinyagentos/containers/__init__.py
@@ -408,13 +408,37 @@ async def remote_generate_token(
     code, output = await _run(cmd)
     if code != 0:
         return {"success": False, "token": "", "output": output}
-    # The token is the last non-empty line of the output.
+    # The token is the last non-empty line of the output. incus formats trust
+    # tokens as base64url-encoded JSON; reject anything that clearly isn't one
+    # so a broken / changed incus output format doesn't silently return "".
     token = ""
     for line in reversed(output.strip().splitlines()):
         line = line.strip()
         if line:
             token = line
             break
+    if not token:
+        return {
+            "success": False,
+            "token": "",
+            "output": (
+                "`incus config trust add` succeeded but produced no token. "
+                f"Raw output: {output!r}"
+            ),
+        }
+    # Real incus trust tokens are long base64url-encoded blobs with no
+    # whitespace. Embedded spaces would mean we grabbed a help/status line
+    # instead of the token payload.
+    if " " in token or "\t" in token:
+        return {
+            "success": False,
+            "token": "",
+            "output": (
+                f"`incus config trust add` returned unexpected output; last "
+                f"line {token!r} does not look like a trust token. "
+                f"Full output: {output!r}"
+            ),
+        }
     return {"success": True, "token": token, "output": output}
 
 

--- a/tinyagentos/installers/lxc_installer.py
+++ b/tinyagentos/installers/lxc_installer.py
@@ -35,7 +35,7 @@ WantedBy=multi-user.target
 _APP_INI_TEMPLATE = """\
 [server]
 HTTP_PORT = 3000
-ROOT_URL = http://localhost:3000/
+ROOT_URL = {root_url}
 SSH_PORT = 2222
 
 [database]
@@ -52,10 +52,21 @@ DISABLE_REGISTRATION = true
 """
 
 
-def _render_app_ini() -> str:
+def _render_app_ini(app_id: str = "gitea-lxc") -> str:
+    """Render app.ini with proxy-aware ROOT_URL.
+
+    Gitea uses ROOT_URL to build absolute URLs for avatars, clone URLs, and
+    redirect targets. Hardcoding http://localhost:3000/ breaks any request
+    routed through the controller proxy at /apps/{app_id}/ — the browser
+    would be sent back to localhost:3000 which isn't reachable.
+
+    Setting ROOT_URL to /apps/{app_id}/ makes Gitea emit relative-to-root
+    URLs that the controller proxy will correctly re-route to the container.
+    """
     return _APP_INI_TEMPLATE.format(
         secret_key=secrets.token_hex(32),
         internal_token=secrets.token_hex(32),
+        root_url=f"/apps/{app_id}/",
     )
 
 
@@ -238,7 +249,7 @@ class LXCInstaller(AppInstaller):
                 if code != 0:
                     raise RuntimeError(f"Failed to create /etc/gitea: {output}")
 
-                app_ini = _render_app_ini()
+                app_ini = _render_app_ini(app_id=app_id)
                 code, output = await containers.exec_in_container(
                     incus_name,
                     ["bash", "-c",

--- a/tinyagentos/routes/apps.py
+++ b/tinyagentos/routes/apps.py
@@ -79,7 +79,9 @@ async def list_installed_apps(request: Request):
         # Best-effort manifest lookup for display metadata.
         manifest = registry.get(app_id) if registry is not None else None
         if manifest is not None:
-            install_block = manifest.install or {}
+            install_block = getattr(manifest, "install", None) or {}
+            if not isinstance(install_block, dict):
+                install_block = {}
             display_name: str = (
                 install_block.get("display_name")
                 or manifest.name

--- a/tinyagentos/routes/cluster_migrate.py
+++ b/tinyagentos/routes/cluster_migrate.py
@@ -16,6 +16,21 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+def _install_dict(manifest) -> dict:
+    """Return manifest.install normalised to a dict.
+
+    AppManifest.install is typed as ``dict`` but older catalog entries, broken
+    YAML, or future manifest shapes could surface it as None, a list, or an
+    object with ``.get`` but no mapping semantics. Calling ``.get(...)`` on
+    those blows up with AttributeError — callers should go through this helper
+    instead of touching ``manifest.install`` directly.
+    """
+    install = getattr(manifest, "install", None)
+    if isinstance(install, dict):
+        return install
+    return {}
+
+
 class RemoteAddBody(BaseModel):
     name: str
     url: str
@@ -122,7 +137,8 @@ async def migrate_service_route(request: Request, body: MigrateServiceBody):
             {"error": f"App '{body.app_id}' not found in catalog"}, status_code=404
         )
 
-    state_paths: list[str] = manifest.install.get("state_paths", [])
+    install = _install_dict(manifest)
+    state_paths: list[str] = install.get("state_paths", [])
     if not state_paths:
         # Fall back to top-level manifest field for manifests that declare it there.
         import yaml as _yaml
@@ -138,7 +154,7 @@ async def migrate_service_route(request: Request, body: MigrateServiceBody):
             status_code=400,
         )
 
-    service_name: str = manifest.install.get("service_name", "")
+    service_name: str = install.get("service_name", "")
     if not service_name and manifest.manifest_dir is not None:
         import yaml as _yaml
         lxc_manifest_path = manifest.manifest_dir / "manifest-lxc.yaml"
@@ -153,7 +169,7 @@ async def migrate_service_route(request: Request, body: MigrateServiceBody):
         result = await migrate_service(
             body.app_id,
             body.target_remote,
-            install_config=manifest.install,
+            install_config=install,
             state_paths=state_paths,
             service_name=service_name,
             keep_source=body.keep_source,
@@ -184,7 +200,7 @@ async def migrate_service_route(request: Request, body: MigrateServiceBody):
                     target_remote_norm,
                 )
                 return result
-            ui_path = manifest.install.get("ui_path", "/") if isinstance(manifest.install, dict) else "/"
+            ui_path = _install_dict(manifest).get("ui_path", "/")
             try:
                 await installed_apps.update_runtime_location(
                     body.app_id,


### PR DESCRIPTION
Three follow-ups from CodeRabbit's review pass. See commit for details. All 100 affected tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Enhanced error reporting for container operations during uninstall procedures
  * Stricter validation of configuration tokens with whitespace rejection to improve token quality
  * Added robustness when handling malformed manifest installation configurations to prevent downstream processing errors

* **New Features**
  * Applications now install with proxy-aware path configuration ensuring proper URL routing through the application controller

<!-- end of auto-generated comment: release notes by coderabbit.ai -->