### PR TITLE
feat(projects): Projects app foundation (Tasks 1-24)

### DIFF
--- a/desktop/src/apps/ProjectsApp/AddAgentDialog.tsx
+++ b/desktop/src/apps/ProjectsApp/AddAgentDialog.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useState } from "react";
+import { projectsApi } from "@/lib/projects";
+
+type Mode = "new" | "existing";
+type AgentMode = "native" | "clone";
+
+export function AddAgentDialog({
+  projectId,
+  onClose,
+  onAdded,
+}: {
+  projectId: string;
+  onClose: () => void;
+  onAdded: () => void;
+}) {
+  const [mode, setMode] = useState<Mode>("new");
+  const [agentMode, setAgentMode] = useState<AgentMode>("clone");
+  const [agentId, setAgentId] = useState("");
+  const [cloneMemory, setCloneMemory] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // When user picks "new agent", agentMode is locked to "native".
+  useEffect(() => {
+    if (mode === "new") setAgentMode("native");
+  }, [mode]);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    try {
+      if (agentMode === "native") {
+        await projectsApi.members.addNative(projectId, agentId.trim());
+      } else {
+        await projectsApi.members.addClone(projectId, agentId.trim(), cloneMemory);
+      }
+      onAdded();
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div role="dialog" aria-modal="true" aria-label="Add agent" className="fixed inset-0 bg-black/50 flex items-center justify-center">
+      <form onSubmit={onSubmit} className="bg-zinc-900 p-4 rounded shadow w-[26rem] space-y-3">
+        <h3 className="text-lg font-semibold">Add agent</h3>
+
+        <fieldset className="border border-zinc-800 p-2 rounded">
+          <legend className="text-xs px-1">Source</legend>
+          <label className="mr-3 text-sm">
+            <input type="radio" checked={mode === "new"} onChange={() => setMode("new")} /> New agent
+          </label>
+          <label className="text-sm">
+            <input type="radio" checked={mode === "existing"} onChange={() => setMode("existing")} /> Existing agent
+          </label>
+        </fieldset>
+
+        <fieldset className="border border-zinc-800 p-2 rounded">
+          <legend className="text-xs px-1">Mode</legend>
+          <label className="mr-3 text-sm">
+            <input
+              type="radio"
+              checked={agentMode === "native"}
+              onChange={() => setAgentMode("native")}
+              disabled={mode === "new"}
+            />{" "}
+            Native
+          </label>
+          <label
+            className="text-sm"
+            title={
+              mode === "new"
+                ? "New agents are always native to this project. Clone exists for adding an existing agent without contaminating its memory."
+                : "Cloning gives this project its own copy of the agent. Project memory stays here; the original agent isn't affected."
+            }
+          >
+            <input
+              type="radio"
+              checked={agentMode === "clone"}
+              onChange={() => setAgentMode("clone")}
+              disabled={mode === "new"}
+            />{" "}
+            Clone
+            <span aria-hidden className="ml-1 text-zinc-500">ⓘ</span>
+          </label>
+        </fieldset>
+
+        <label className="block text-sm">
+          {mode === "new" ? "New agent name" : "Existing agent ID"}
+          <input
+            value={agentId}
+            onChange={(e) => setAgentId(e.target.value)}
+            required
+            className="w-full mt-1 px-2 py-1 bg-zinc-800 rounded"
+            placeholder={mode === "new" ? "e.g. researcher" : "agent-id"}
+          />
+        </label>
+
+        {agentMode === "clone" && (
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={cloneMemory}
+              onChange={(e) => setCloneMemory(e.target.checked)}
+            />
+            Clone memory (uncheck for empty memory)
+          </label>
+        )}
+
+        {error && <div role="alert" className="text-red-400 text-xs">{error}</div>}
+        <div className="flex justify-end gap-2">
+          <button type="button" onClick={onClose} className="px-3 py-1 text-sm">Cancel</button>
+          <button
+            type="submit"
+            disabled={submitting}
+            className="px-3 py-1 bg-blue-600 rounded text-sm disabled:opacity-50"
+          >
+            {submitting ? "Adding…" : "Add"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/desktop/src/apps/ProjectsApp/AddAgentDialog.tsx
+++ b/desktop/src/apps/ProjectsApp/AddAgentDialog.tsx
@@ -14,7 +14,7 @@ export function AddAgentDialog({
   onAdded: () => void;
 }) {
   const [mode, setMode] = useState<Mode>("new");
-  const [agentMode, setAgentMode] = useState<AgentMode>("clone");
+  const [agentMode, setAgentMode] = useState<AgentMode>("native");
   const [agentId, setAgentId] = useState("");
   const [cloneMemory, setCloneMemory] = useState(true);
   const [submitting, setSubmitting] = useState(false);
@@ -27,13 +27,21 @@ export function AddAgentDialog({
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (submitting) return;
+    const normalizedAgentId = agentId.trim();
+    if (!normalizedAgentId) {
+      setError("Agent ID is required.");
+      return;
+    }
+    // mode === "new" forces native; otherwise the user's agentMode choice wins.
+    const useNative = mode === "new" || agentMode === "native";
     setSubmitting(true);
     setError(null);
     try {
-      if (agentMode === "native") {
-        await projectsApi.members.addNative(projectId, agentId.trim());
+      if (useNative) {
+        await projectsApi.members.addNative(projectId, normalizedAgentId);
       } else {
-        await projectsApi.members.addClone(projectId, agentId.trim(), cloneMemory);
+        await projectsApi.members.addClone(projectId, normalizedAgentId, cloneMemory);
       }
       onAdded();
     } catch (err) {
@@ -41,6 +49,11 @@ export function AddAgentDialog({
     } finally {
       setSubmitting(false);
     }
+  };
+
+  const handleClose = () => {
+    if (submitting) return;
+    onClose();
   };
 
   return (
@@ -112,7 +125,14 @@ export function AddAgentDialog({
 
         {error && <div role="alert" className="text-red-400 text-xs">{error}</div>}
         <div className="flex justify-end gap-2">
-          <button type="button" onClick={onClose} className="px-3 py-1 text-sm">Cancel</button>
+          <button
+            type="button"
+            onClick={handleClose}
+            disabled={submitting}
+            className="px-3 py-1 text-sm disabled:opacity-50"
+          >
+            Cancel
+          </button>
           <button
             type="submit"
             disabled={submitting}

--- a/desktop/src/apps/ProjectsApp/CreateProjectDialog.tsx
+++ b/desktop/src/apps/ProjectsApp/CreateProjectDialog.tsx
@@ -19,12 +19,17 @@ export function CreateProjectDialog({
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      setError("Name is required.");
+      return;
+    }
     setSubmitting(true);
     setError(null);
     try {
       await projectsApi.create({
-        name: name.trim(),
-        slug: slug.trim() || slugify(name),
+        name: trimmedName,
+        slug: slug.trim() || slugify(trimmedName),
         description: description.trim(),
       });
       onCreated();

--- a/desktop/src/apps/ProjectsApp/CreateProjectDialog.tsx
+++ b/desktop/src/apps/ProjectsApp/CreateProjectDialog.tsx
@@ -19,6 +19,7 @@ export function CreateProjectDialog({
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (submitting) return;
     const trimmedName = name.trim();
     if (!trimmedName) {
       setError("Name is required.");

--- a/desktop/src/apps/ProjectsApp/CreateProjectDialog.tsx
+++ b/desktop/src/apps/ProjectsApp/CreateProjectDialog.tsx
@@ -1,0 +1,98 @@
+import { useState } from "react";
+import { projectsApi } from "@/lib/projects";
+
+const slugify = (s: string) =>
+  s.toLowerCase().trim().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+
+export function CreateProjectDialog({
+  onClose,
+  onCreated,
+}: {
+  onClose: () => void;
+  onCreated: () => void;
+}) {
+  const [name, setName] = useState("");
+  const [slug, setSlug] = useState("");
+  const [description, setDescription] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    try {
+      await projectsApi.create({
+        name: name.trim(),
+        slug: slug.trim() || slugify(name),
+        description: description.trim(),
+      });
+      onCreated();
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Create project"
+      className="fixed inset-0 bg-black/50 flex items-center justify-center"
+    >
+      <form
+        onSubmit={onSubmit}
+        className="bg-zinc-900 p-4 rounded shadow w-96 space-y-3"
+      >
+        <h3 className="text-lg font-semibold">New Project</h3>
+        <label className="block text-sm">
+          Name
+          <input
+            value={name}
+            onChange={(e) => {
+              setName(e.target.value);
+              if (!slug) setSlug(slugify(e.target.value));
+            }}
+            required
+            autoFocus
+            className="w-full mt-1 px-2 py-1 bg-zinc-800 rounded"
+          />
+        </label>
+        <label className="block text-sm">
+          Slug
+          <input
+            value={slug}
+            onChange={(e) => setSlug(e.target.value)}
+            pattern="[a-z0-9-]+"
+            required
+            className="w-full mt-1 px-2 py-1 bg-zinc-800 rounded"
+          />
+        </label>
+        <label className="block text-sm">
+          Description
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={3}
+            className="w-full mt-1 px-2 py-1 bg-zinc-800 rounded"
+          />
+        </label>
+        {error && <div role="alert" className="text-red-400 text-xs">{error}</div>}
+        <div className="flex justify-end gap-2">
+          <button type="button" onClick={onClose} className="px-3 py-1 text-sm">
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={submitting}
+            className="px-3 py-1 bg-blue-600 rounded text-sm disabled:opacity-50"
+          >
+            {submitting ? "Creating…" : "Create"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/desktop/src/apps/ProjectsApp/ProjectActivity.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectActivity.tsx
@@ -1,0 +1,25 @@
+import { useEffect, useState } from "react";
+import { projectsApi, type ProjectActivity } from "@/lib/projects";
+
+export function ProjectActivity({ projectId }: { projectId: string }) {
+  const [items, setItems] = useState<ProjectActivity[]>([]);
+
+  useEffect(() => {
+    projectsApi.activity(projectId).then(setItems);
+  }, [projectId]);
+
+  return (
+    <ul className="space-y-1" aria-label="Activity">
+      {items.map((a) => (
+        <li key={a.id} className="bg-zinc-900 px-3 py-2 rounded text-sm">
+          <span className="text-zinc-500 mr-2">{new Date(a.created_at * 1000).toLocaleString()}</span>
+          <span className="font-medium">{a.action}</span>
+          {a.payload && Object.keys(a.payload).length > 0 && (
+            <span className="ml-2 text-zinc-500 text-xs">{JSON.stringify(a.payload)}</span>
+          )}
+        </li>
+      ))}
+      {items.length === 0 && <li className="text-sm text-zinc-500">No activity.</li>}
+    </ul>
+  );
+}

--- a/desktop/src/apps/ProjectsApp/ProjectActivity.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectActivity.tsx
@@ -13,7 +13,7 @@ export function ProjectActivity({ projectId }: { projectId: string }) {
       {items.map((a) => (
         <li key={a.id} className="bg-zinc-900 px-3 py-2 rounded text-sm">
           <span className="text-zinc-500 mr-2">{new Date(a.created_at * 1000).toLocaleString()}</span>
-          <span className="font-medium">{a.action}</span>
+          <span className="font-medium">{a.kind}</span>
           {a.payload && Object.keys(a.payload).length > 0 && (
             <span className="ml-2 text-zinc-500 text-xs">{JSON.stringify(a.payload)}</span>
           )}

--- a/desktop/src/apps/ProjectsApp/ProjectActivity.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectActivity.tsx
@@ -5,7 +5,18 @@ export function ProjectActivity({ projectId }: { projectId: string }) {
   const [items, setItems] = useState<ProjectActivity[]>([]);
 
   useEffect(() => {
-    projectsApi.activity(projectId).then(setItems);
+    let cancelled = false;
+    projectsApi
+      .activity(projectId)
+      .then((rows) => {
+        if (!cancelled) setItems(rows);
+      })
+      .catch(() => {
+        if (!cancelled) setItems([]);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [projectId]);
 
   return (

--- a/desktop/src/apps/ProjectsApp/ProjectList.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectList.tsx
@@ -24,13 +24,12 @@ export function ProjectList({ projects, selectedId, onSelect, onCreated }: Props
           + New
         </button>
       </header>
-      <ul className="flex-1 overflow-auto" role="listbox" aria-label="Projects">
+      <ul className="flex-1 overflow-auto" aria-label="Projects">
         {projects.map((p) => (
           <li key={p.id}>
             <button
               type="button"
-              role="option"
-              aria-selected={p.id === selectedId}
+              aria-pressed={p.id === selectedId}
               onClick={() => onSelect(p.id)}
               className={`w-full text-left px-3 py-2 hover:bg-zinc-800 ${
                 p.id === selectedId ? "bg-zinc-800" : ""

--- a/desktop/src/apps/ProjectsApp/ProjectList.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectList.tsx
@@ -1,0 +1,56 @@
+import { useState } from "react";
+import type { Project } from "@/lib/projects";
+import { CreateProjectDialog } from "./CreateProjectDialog";
+
+type Props = {
+  projects: Project[];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+  onCreated: () => void;
+};
+
+export function ProjectList({ projects, selectedId, onSelect, onCreated }: Props) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  return (
+    <>
+      <header className="p-3 border-b border-zinc-800 flex items-center justify-between">
+        <h2 className="font-medium">Projects</h2>
+        <button
+          type="button"
+          aria-label="Create project"
+          className="text-sm px-2 py-1 rounded bg-zinc-800 hover:bg-zinc-700"
+          onClick={() => setDialogOpen(true)}
+        >
+          + New
+        </button>
+      </header>
+      <ul className="flex-1 overflow-auto" role="listbox" aria-label="Projects">
+        {projects.map((p) => (
+          <li key={p.id}>
+            <button
+              type="button"
+              role="option"
+              aria-selected={p.id === selectedId}
+              onClick={() => onSelect(p.id)}
+              className={`w-full text-left px-3 py-2 hover:bg-zinc-800 ${
+                p.id === selectedId ? "bg-zinc-800" : ""
+              }`}
+            >
+              <div className="font-medium">{p.name}</div>
+              <div className="text-xs text-zinc-500">{p.slug}</div>
+            </button>
+          </li>
+        ))}
+      </ul>
+      {dialogOpen && (
+        <CreateProjectDialog
+          onClose={() => setDialogOpen(false)}
+          onCreated={() => {
+            setDialogOpen(false);
+            onCreated();
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/desktop/src/apps/ProjectsApp/ProjectMembers.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectMembers.tsx
@@ -6,9 +6,21 @@ export function ProjectMembers({ project, onChanged }: { project: Project; onCha
   const [members, setMembers] = useState<ProjectMember[]>([]);
   const [dialogOpen, setDialogOpen] = useState(false);
 
-  const refresh = () => projectsApi.members.list(project.id).then(setMembers);
+  const refresh = () =>
+    projectsApi.members.list(project.id).then(setMembers).catch(() => setMembers([]));
   useEffect(() => {
-    refresh();
+    let cancelled = false;
+    projectsApi.members
+      .list(project.id)
+      .then((rows) => {
+        if (!cancelled) setMembers(rows);
+      })
+      .catch(() => {
+        if (!cancelled) setMembers([]);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [project.id]);
 
   return (

--- a/desktop/src/apps/ProjectsApp/ProjectMembers.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectMembers.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from "react";
+import { projectsApi, type Project, type ProjectMember } from "@/lib/projects";
+import { AddAgentDialog } from "./AddAgentDialog";
+
+export function ProjectMembers({ project, onChanged }: { project: Project; onChanged: () => void }) {
+  const [members, setMembers] = useState<ProjectMember[]>([]);
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const refresh = () => projectsApi.members.list(project.id).then(setMembers);
+  useEffect(() => {
+    refresh();
+  }, [project.id]);
+
+  return (
+    <section>
+      <header className="flex justify-between mb-3">
+        <h3 className="font-medium">Members</h3>
+        <button
+          type="button"
+          onClick={() => setDialogOpen(true)}
+          className="text-sm px-2 py-1 bg-zinc-800 rounded hover:bg-zinc-700"
+        >
+          + Add agent
+        </button>
+      </header>
+      <ul className="space-y-1" aria-label="Project members">
+        {members.map((m) => (
+          <li key={m.member_id} className="flex justify-between items-center bg-zinc-900 px-3 py-2 rounded">
+            <div>
+              <div className="text-sm">{m.member_id}</div>
+              <div className="text-xs text-zinc-500">
+                {m.member_kind}
+                {m.member_kind === "clone" ? ` · ${m.memory_seed}` : ""}
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={async () => {
+                await projectsApi.members.remove(project.id, m.member_id);
+                refresh();
+                onChanged();
+              }}
+              className="text-xs text-red-400 hover:underline"
+              aria-label={`Remove ${m.member_id}`}
+            >
+              Remove
+            </button>
+          </li>
+        ))}
+      </ul>
+      {dialogOpen && (
+        <AddAgentDialog
+          projectId={project.id}
+          onClose={() => setDialogOpen(false)}
+          onAdded={() => {
+            setDialogOpen(false);
+            refresh();
+            onChanged();
+          }}
+        />
+      )}
+    </section>
+  );
+}

--- a/desktop/src/apps/ProjectsApp/ProjectTaskList.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectTaskList.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useState } from "react";
+import { projectsApi, type ProjectTask } from "@/lib/projects";
+
+type View = "ready" | "claimed" | "closed";
+
+export function ProjectTaskList({ projectId }: { projectId: string }) {
+  const [view, setView] = useState<View>("ready");
+  const [tasks, setTasks] = useState<ProjectTask[]>([]);
+  const [newTitle, setNewTitle] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = async () => {
+    try {
+      if (view === "ready") setTasks(await projectsApi.tasks.ready(projectId));
+      else if (view === "claimed") setTasks(await projectsApi.tasks.list(projectId, "claimed"));
+      else setTasks(await projectsApi.tasks.list(projectId, "closed"));
+    } catch (e) {
+      setError(String(e));
+    }
+  };
+  useEffect(() => {
+    refresh();
+  }, [projectId, view]);
+
+  const create = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!newTitle.trim()) return;
+    await projectsApi.tasks.create(projectId, { title: newTitle.trim() });
+    setNewTitle("");
+    refresh();
+  };
+
+  // Closed view filters older than 7 days client-side per spec default.
+  const visible =
+    view === "closed"
+      ? tasks.filter((t) => (t.closed_at ?? 0) >= Date.now() / 1000 - 7 * 86400)
+      : tasks;
+
+  return (
+    <section>
+      <nav role="tablist" aria-label="Task view" className="flex gap-1 mb-3">
+        {(["ready", "claimed", "closed"] as View[]).map((v) => (
+          <button
+            key={v}
+            type="button"
+            role="tab"
+            aria-selected={view === v}
+            onClick={() => setView(v)}
+            className={`px-2 py-1 text-sm rounded ${
+              view === v ? "bg-zinc-700" : "bg-zinc-900 text-zinc-400"
+            }`}
+          >
+            {v}
+          </button>
+        ))}
+      </nav>
+
+      <form onSubmit={create} className="flex gap-2 mb-3">
+        <input
+          aria-label="New task title"
+          value={newTitle}
+          onChange={(e) => setNewTitle(e.target.value)}
+          placeholder="Add a task…"
+          className="flex-1 px-2 py-1 bg-zinc-800 rounded text-sm"
+        />
+        <button type="submit" className="px-3 py-1 bg-blue-600 rounded text-sm">
+          Add
+        </button>
+      </form>
+
+      {error && <div role="alert" className="text-red-400 text-xs mb-2">{error}</div>}
+
+      <ul className="space-y-1" aria-label={`${view} tasks`}>
+        {visible.map((t) => (
+          <li key={t.id} className="flex items-center justify-between bg-zinc-900 px-3 py-2 rounded">
+            <div className="min-w-0">
+              <div className="text-sm truncate">{t.title}</div>
+              <div className="text-xs text-zinc-500">
+                {t.id}
+                {t.claimed_by ? ` · claimed by ${t.claimed_by}` : ""}
+                {t.closed_at ? ` · closed` : ""}
+              </div>
+            </div>
+            <div className="flex gap-2 text-xs">
+              {view === "ready" && (
+                <button
+                  type="button"
+                  onClick={async () => {
+                    await projectsApi.tasks.claim(projectId, t.id, "user");
+                    refresh();
+                  }}
+                  className="px-2 py-1 bg-zinc-800 rounded"
+                >
+                  Claim
+                </button>
+              )}
+              {view === "claimed" && (
+                <>
+                  <button
+                    type="button"
+                    onClick={async () => {
+                      await projectsApi.tasks.release(projectId, t.id, t.claimed_by ?? "user");
+                      refresh();
+                    }}
+                    className="px-2 py-1 bg-zinc-800 rounded"
+                  >
+                    Release
+                  </button>
+                  <button
+                    type="button"
+                    onClick={async () => {
+                      await projectsApi.tasks.close(projectId, t.id, t.claimed_by ?? "user");
+                      refresh();
+                    }}
+                    className="px-2 py-1 bg-emerald-700 rounded"
+                  >
+                    Close
+                  </button>
+                </>
+              )}
+            </div>
+          </li>
+        ))}
+        {visible.length === 0 && <li className="text-sm text-zinc-500">No tasks.</li>}
+      </ul>
+    </section>
+  );
+}

--- a/desktop/src/apps/ProjectsApp/ProjectTaskList.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectTaskList.tsx
@@ -8,6 +8,21 @@ export function ProjectTaskList({ projectId }: { projectId: string }) {
   const [tasks, setTasks] = useState<ProjectTask[]>([]);
   const [newTitle, setNewTitle] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/auth/me")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((u) => {
+        if (!cancelled && u?.id) setCurrentUserId(u.id);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  const actorId = currentUserId ?? "user";
 
   const refresh = async () => {
     try {
@@ -24,10 +39,16 @@ export function ProjectTaskList({ projectId }: { projectId: string }) {
 
   const create = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!newTitle.trim()) return;
-    await projectsApi.tasks.create(projectId, { title: newTitle.trim() });
-    setNewTitle("");
-    refresh();
+    const title = newTitle.trim();
+    if (!title) return;
+    try {
+      await projectsApi.tasks.create(projectId, { title });
+      setNewTitle("");
+      setError(null);
+      refresh();
+    } catch (err) {
+      setError(String(err));
+    }
   };
 
   // Closed view filters older than 7 days client-side per spec default.
@@ -86,7 +107,7 @@ export function ProjectTaskList({ projectId }: { projectId: string }) {
                 <button
                   type="button"
                   onClick={async () => {
-                    await projectsApi.tasks.claim(projectId, t.id, "user");
+                    await projectsApi.tasks.claim(projectId, t.id, actorId);
                     refresh();
                   }}
                   className="px-2 py-1 bg-zinc-800 rounded"
@@ -99,7 +120,7 @@ export function ProjectTaskList({ projectId }: { projectId: string }) {
                   <button
                     type="button"
                     onClick={async () => {
-                      await projectsApi.tasks.release(projectId, t.id, t.claimed_by ?? "user");
+                      await projectsApi.tasks.release(projectId, t.id, t.claimed_by ?? actorId);
                       refresh();
                     }}
                     className="px-2 py-1 bg-zinc-800 rounded"
@@ -109,7 +130,7 @@ export function ProjectTaskList({ projectId }: { projectId: string }) {
                   <button
                     type="button"
                     onClick={async () => {
-                      await projectsApi.tasks.close(projectId, t.id, t.claimed_by ?? "user");
+                      await projectsApi.tasks.close(projectId, t.id, t.claimed_by ?? actorId);
                       refresh();
                     }}
                     className="px-2 py-1 bg-emerald-700 rounded"

--- a/desktop/src/apps/ProjectsApp/ProjectTaskList.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectTaskList.tsx
@@ -22,13 +22,13 @@ export function ProjectTaskList({ projectId }: { projectId: string }) {
       cancelled = true;
     };
   }, []);
-  const actorId = currentUserId ?? "user";
 
   const refresh = async () => {
     try {
       if (view === "ready") setTasks(await projectsApi.tasks.ready(projectId));
       else if (view === "claimed") setTasks(await projectsApi.tasks.list(projectId, "claimed"));
       else setTasks(await projectsApi.tasks.list(projectId, "closed"));
+      setError(null);
     } catch (e) {
       setError(String(e));
     }
@@ -46,6 +46,39 @@ export function ProjectTaskList({ projectId }: { projectId: string }) {
       setNewTitle("");
       setError(null);
       refresh();
+    } catch (err) {
+      setError(String(err));
+    }
+  };
+
+  const claim = async (taskId: string) => {
+    if (!currentUserId) return;
+    try {
+      await projectsApi.tasks.claim(projectId, taskId, currentUserId);
+      setError(null);
+      await refresh();
+    } catch (err) {
+      setError(String(err));
+    }
+  };
+
+  const release = async (taskId: string) => {
+    if (!currentUserId) return;
+    try {
+      await projectsApi.tasks.release(projectId, taskId, currentUserId);
+      setError(null);
+      await refresh();
+    } catch (err) {
+      setError(String(err));
+    }
+  };
+
+  const close = async (taskId: string) => {
+    if (!currentUserId) return;
+    try {
+      await projectsApi.tasks.close(projectId, taskId, currentUserId);
+      setError(null);
+      await refresh();
     } catch (err) {
       setError(String(err));
     }
@@ -92,56 +125,51 @@ export function ProjectTaskList({ projectId }: { projectId: string }) {
       {error && <div role="alert" className="text-red-400 text-xs mb-2">{error}</div>}
 
       <ul className="space-y-1" aria-label={`${view} tasks`}>
-        {visible.map((t) => (
-          <li key={t.id} className="flex items-center justify-between bg-zinc-900 px-3 py-2 rounded">
-            <div className="min-w-0">
-              <div className="text-sm truncate">{t.title}</div>
-              <div className="text-xs text-zinc-500">
-                {t.id}
-                {t.claimed_by ? ` · claimed by ${t.claimed_by}` : ""}
-                {t.closed_at ? ` · closed` : ""}
+        {visible.map((t) => {
+          const ownsClaim = !!currentUserId && t.claimed_by === currentUserId;
+          return (
+            <li key={t.id} className="flex items-center justify-between bg-zinc-900 px-3 py-2 rounded">
+              <div className="min-w-0">
+                <div className="text-sm truncate">{t.title}</div>
+                <div className="text-xs text-zinc-500">
+                  {t.id}
+                  {t.claimed_by ? ` · claimed by ${t.claimed_by}` : ""}
+                  {t.closed_at ? ` · closed` : ""}
+                </div>
               </div>
-            </div>
-            <div className="flex gap-2 text-xs">
-              {view === "ready" && (
-                <button
-                  type="button"
-                  onClick={async () => {
-                    await projectsApi.tasks.claim(projectId, t.id, actorId);
-                    refresh();
-                  }}
-                  className="px-2 py-1 bg-zinc-800 rounded"
-                >
-                  Claim
-                </button>
-              )}
-              {view === "claimed" && (
-                <>
+              <div className="flex gap-2 text-xs">
+                {view === "ready" && (
                   <button
                     type="button"
-                    onClick={async () => {
-                      await projectsApi.tasks.release(projectId, t.id, t.claimed_by ?? actorId);
-                      refresh();
-                    }}
-                    className="px-2 py-1 bg-zinc-800 rounded"
+                    disabled={!currentUserId}
+                    onClick={() => claim(t.id)}
+                    className="px-2 py-1 bg-zinc-800 rounded disabled:opacity-50"
                   >
-                    Release
+                    Claim
                   </button>
-                  <button
-                    type="button"
-                    onClick={async () => {
-                      await projectsApi.tasks.close(projectId, t.id, t.claimed_by ?? actorId);
-                      refresh();
-                    }}
-                    className="px-2 py-1 bg-emerald-700 rounded"
-                  >
-                    Close
-                  </button>
-                </>
-              )}
-            </div>
-          </li>
-        ))}
+                )}
+                {view === "claimed" && ownsClaim && (
+                  <>
+                    <button
+                      type="button"
+                      onClick={() => release(t.id)}
+                      className="px-2 py-1 bg-zinc-800 rounded"
+                    >
+                      Release
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => close(t.id)}
+                      className="px-2 py-1 bg-emerald-700 rounded"
+                    >
+                      Close
+                    </button>
+                  </>
+                )}
+              </div>
+            </li>
+          );
+        })}
         {visible.length === 0 && <li className="text-sm text-zinc-500">No tasks.</li>}
       </ul>
     </section>

--- a/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
@@ -1,0 +1,40 @@
+import { useState } from "react";
+import type { Project } from "@/lib/projects";
+import { ProjectTaskList } from "./ProjectTaskList";
+import { ProjectMembers } from "./ProjectMembers";
+import { ProjectActivity } from "./ProjectActivity";
+
+type Tab = "tasks" | "members" | "activity";
+
+export function ProjectWorkspace({ project, onChanged }: { project: Project; onChanged: () => void }) {
+  const [tab, setTab] = useState<Tab>("tasks");
+  return (
+    <div className="flex flex-col h-full">
+      <header className="px-4 py-3 border-b border-zinc-800">
+        <h1 className="text-lg font-semibold">{project.name}</h1>
+        <p className="text-xs text-zinc-500">{project.description}</p>
+      </header>
+      <nav className="flex border-b border-zinc-800 px-2" role="tablist">
+        {(["tasks", "members", "activity"] as Tab[]).map((t) => (
+          <button
+            key={t}
+            type="button"
+            role="tab"
+            aria-selected={tab === t}
+            onClick={() => setTab(t)}
+            className={`px-3 py-2 text-sm capitalize ${
+              tab === t ? "border-b-2 border-blue-400" : "text-zinc-400"
+            }`}
+          >
+            {t}
+          </button>
+        ))}
+      </nav>
+      <div className="flex-1 min-h-0 overflow-auto p-4">
+        {tab === "tasks" && <ProjectTaskList projectId={project.id} />}
+        {tab === "members" && <ProjectMembers project={project} onChanged={onChanged} />}
+        {tab === "activity" && <ProjectActivity projectId={project.id} />}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/apps/ProjectsApp/index.tsx
+++ b/desktop/src/apps/ProjectsApp/index.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from "react";
+import { projectsApi, type Project } from "@/lib/projects";
+import { ProjectList } from "./ProjectList";
+import { ProjectWorkspace } from "./ProjectWorkspace";
+
+export function ProjectsApp({ windowId: _windowId }: { windowId: string }) {
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = async () => {
+    try {
+      const list = await projectsApi.list("active");
+      setProjects(list);
+      if (!selectedId && list.length > 0) setSelectedId(list[0]!.id);
+    } catch (e) {
+      setError(String(e));
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const selected = projects.find((p) => p.id === selectedId) ?? null;
+
+  return (
+    <div className="flex h-full w-full">
+      <aside className="w-72 border-r border-zinc-800 flex flex-col">
+        <ProjectList
+          projects={projects}
+          selectedId={selectedId}
+          onSelect={setSelectedId}
+          onCreated={refresh}
+        />
+      </aside>
+      <main className="flex-1 min-w-0">
+        {error && <div role="alert" className="p-3 text-red-400">{error}</div>}
+        {selected ? (
+          <ProjectWorkspace project={selected} onChanged={refresh} />
+        ) : (
+          <div className="p-6 text-zinc-500">Select or create a project.</div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/desktop/src/apps/ProjectsApp/index.tsx
+++ b/desktop/src/apps/ProjectsApp/index.tsx
@@ -12,7 +12,9 @@ export function ProjectsApp({ windowId: _windowId }: { windowId: string }) {
     try {
       const list = await projectsApi.list("active");
       setProjects(list);
-      if (!selectedId && list.length > 0) setSelectedId(list[0]!.id);
+      setError(null);
+      const stillExists = selectedId && list.some((p) => p.id === selectedId);
+      if (!stillExists) setSelectedId(list.length > 0 ? list[0]!.id : null);
     } catch (e) {
       setError(String(e));
     }

--- a/desktop/src/lib/projects.ts
+++ b/desktop/src/lib/projects.ts
@@ -1,0 +1,125 @@
+export type Project = {
+  id: string;
+  name: string;
+  slug: string;
+  description: string;
+  status: "active" | "archived" | "deleted";
+  created_by: string;
+  created_at: number;
+  updated_at: number;
+};
+
+export type ProjectMember = {
+  project_id: string;
+  member_id: string;
+  member_kind: "native" | "clone";
+  role: string;
+  source_agent_id: string | null;
+  memory_seed: "none" | "snapshot" | "empty";
+  added_at: number;
+};
+
+export type ProjectTask = {
+  id: string;
+  project_id: string;
+  parent_task_id: string | null;
+  title: string;
+  body: string;
+  status: "open" | "claimed" | "closed" | "cancelled";
+  priority: number;
+  labels: string[];
+  assignee_id: string | null;
+  claimed_by: string | null;
+  claimed_at: number | null;
+  closed_at: number | null;
+  closed_by: string | null;
+  close_reason: string | null;
+  created_by: string;
+  created_at: number;
+  updated_at: number;
+};
+
+export type ProjectActivity = {
+  id: string;
+  project_id: string;
+  actor_id: string;
+  action: string;
+  payload: Record<string, unknown>;
+  created_at: number;
+};
+
+async function http<T>(path: string, init?: RequestInit): Promise<T> {
+  const r = await fetch(path, {
+    credentials: "include",
+    headers: { "Content-Type": "application/json", ...(init?.headers || {}) },
+    ...init,
+  });
+  if (!r.ok) {
+    const text = await r.text().catch(() => r.statusText);
+    throw new Error(`${r.status}: ${text}`);
+  }
+  return (await r.json()) as T;
+}
+
+export const projectsApi = {
+  list: (status: string = "active") =>
+    http<{ items: Project[] }>(`/api/projects?status=${status}`).then((r) => r.items),
+  get: (id: string) => http<Project>(`/api/projects/${id}`),
+  create: (input: { name: string; slug: string; description?: string }) =>
+    http<Project>("/api/projects", { method: "POST", body: JSON.stringify(input) }),
+  update: (id: string, patch: Partial<Pick<Project, "name" | "description">>) =>
+    http<Project>(`/api/projects/${id}`, { method: "PATCH", body: JSON.stringify(patch) }),
+  archive: (id: string) =>
+    http<Project>(`/api/projects/${id}/archive`, { method: "POST" }),
+  remove: (id: string) =>
+    http<Project>(`/api/projects/${id}`, { method: "DELETE" }),
+
+  members: {
+    list: (pid: string) =>
+      http<{ items: ProjectMember[] }>(`/api/projects/${pid}/members`).then((r) => r.items),
+    addNative: (pid: string, agent_id: string) =>
+      http<ProjectMember>(`/api/projects/${pid}/members`, {
+        method: "POST",
+        body: JSON.stringify({ mode: "native", agent_id }),
+      }),
+    addClone: (pid: string, source_agent_id: string, clone_memory: boolean) =>
+      http<ProjectMember>(`/api/projects/${pid}/members`, {
+        method: "POST",
+        body: JSON.stringify({ mode: "clone", source_agent_id, clone_memory }),
+      }),
+    remove: (pid: string, member_id: string) =>
+      http<{ ok: boolean }>(`/api/projects/${pid}/members/${member_id}`, { method: "DELETE" }),
+  },
+
+  tasks: {
+    list: (pid: string, status?: string) =>
+      http<{ items: ProjectTask[] }>(
+        `/api/projects/${pid}/tasks${status ? `?status=${status}` : ""}`,
+      ).then((r) => r.items),
+    ready: (pid: string) =>
+      http<{ items: ProjectTask[] }>(`/api/projects/${pid}/tasks/ready`).then((r) => r.items),
+    create: (pid: string, input: { title: string; body?: string; priority?: number }) =>
+      http<ProjectTask>(`/api/projects/${pid}/tasks`, {
+        method: "POST",
+        body: JSON.stringify(input),
+      }),
+    claim: (pid: string, tid: string, claimer_id: string) =>
+      http<ProjectTask>(`/api/projects/${pid}/tasks/${tid}/claim`, {
+        method: "POST",
+        body: JSON.stringify({ claimer_id }),
+      }),
+    release: (pid: string, tid: string, releaser_id: string) =>
+      http<ProjectTask>(`/api/projects/${pid}/tasks/${tid}/release`, {
+        method: "POST",
+        body: JSON.stringify({ releaser_id }),
+      }),
+    close: (pid: string, tid: string, closed_by: string, reason?: string) =>
+      http<ProjectTask>(`/api/projects/${pid}/tasks/${tid}/close`, {
+        method: "POST",
+        body: JSON.stringify({ closed_by, reason }),
+      }),
+  },
+
+  activity: (pid: string) =>
+    http<{ items: ProjectActivity[] }>(`/api/projects/${pid}/activity`).then((r) => r.items),
+};

--- a/desktop/src/lib/projects.ts
+++ b/desktop/src/lib/projects.ts
@@ -43,7 +43,7 @@ export type ProjectActivity = {
   id: string;
   project_id: string;
   actor_id: string;
-  action: string;
+  kind: string;
   payload: Record<string, unknown>;
   created_at: number;
 };

--- a/desktop/src/lib/projects.ts
+++ b/desktop/src/lib/projects.ts
@@ -40,7 +40,7 @@ export type ProjectTask = {
 };
 
 export type ProjectActivity = {
-  id: string;
+  id: number;
   project_id: string;
   actor_id: string;
   kind: string;

--- a/desktop/src/registry/app-registry.ts
+++ b/desktop/src/registry/app-registry.ts
@@ -16,6 +16,7 @@ export interface AppManifest {
 const apps: AppManifest[] = [
   // Platform apps
   { id: "messages", name: "Messages", icon: "message-circle", category: "platform", component: () => import("@/apps/MessagesApp").then((m) => ({ default: m.MessagesApp })), defaultSize: { w: 900, h: 600 }, minSize: { w: 400, h: 300 }, singleton: true, pinned: true, launchpadOrder: 1 },
+  { id: "projects", name: "Projects", icon: "folder-kanban", category: "platform", component: () => import("@/apps/ProjectsApp").then((m) => ({ default: m.ProjectsApp })), defaultSize: { w: 1100, h: 720 }, minSize: { w: 700, h: 500 }, singleton: true, pinned: true, launchpadOrder: 1.5 },
   { id: "agents", name: "Agents", icon: "bot", category: "platform", component: () => import("@/apps/AgentsApp").then((m) => ({ default: m.AgentsApp })), defaultSize: { w: 1000, h: 650 }, minSize: { w: 500, h: 400 }, singleton: true, pinned: true, launchpadOrder: 2 },
   { id: "files", name: "Files", icon: "folder", category: "platform", component: () => import("@/apps/FilesApp").then((m) => ({ default: m.FilesApp })), defaultSize: { w: 900, h: 550 }, minSize: { w: 400, h: 300 }, singleton: true, pinned: true, launchpadOrder: 3 },
   { id: "store", name: "Store", icon: "shopping-bag", category: "platform", component: () => import("@/apps/StoreApp").then((m) => ({ default: m.StoreApp })), defaultSize: { w: 1000, h: 700 }, minSize: { w: 600, h: 400 }, singleton: true, pinned: true, launchpadOrder: 4 },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,6 +95,15 @@ async def client(app):
     if chat_channels._db is not None:
         await chat_channels.close()
     await chat_channels.init()
+    project_store = app.state.project_store
+    if project_store._db is not None:
+        await project_store.close()
+    await project_store.init()
+    project_task_store = app.state.project_task_store
+    if project_task_store._db is not None:
+        await project_task_store.close()
+    await project_task_store.init()
+    app.state.projects_root.mkdir(parents=True, exist_ok=True)
     canvas_store = app.state.canvas_store
     if canvas_store._db is not None:
         await canvas_store.close()
@@ -113,6 +122,8 @@ async def client(app):
     ) as c:
         yield c
     await canvas_store.close()
+    await project_task_store.close()
+    await project_store.close()
     await chat_channels.close()
     await chat_messages.close()
     await expert_agents.close()
@@ -248,6 +259,15 @@ async def client_with_qmd(app_with_qmd):
     if chat_channels._db is not None:
         await chat_channels.close()
     await chat_channels.init()
+    project_store = app_with_qmd.state.project_store
+    if project_store._db is not None:
+        await project_store.close()
+    await project_store.init()
+    project_task_store = app_with_qmd.state.project_task_store
+    if project_task_store._db is not None:
+        await project_task_store.close()
+    await project_task_store.init()
+    app_with_qmd.state.projects_root.mkdir(parents=True, exist_ok=True)
     canvas_store = app_with_qmd.state.canvas_store
     if canvas_store._db is not None:
         await canvas_store.close()
@@ -264,6 +284,8 @@ async def client_with_qmd(app_with_qmd):
     ) as c:
         yield c
     await canvas_store.close()
+    await project_task_store.close()
+    await project_store.close()
     await chat_channels.close()
     await chat_messages.close()
     await expert_agents.close()

--- a/tests/projects/test_app_wiring.py
+++ b/tests/projects/test_app_wiring.py
@@ -1,0 +1,10 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_app_state_has_project_stores(client):
+    transport = client._transport
+    app = transport.app
+    assert app.state.project_store is not None
+    assert app.state.project_task_store is not None
+    assert app.state.projects_root.exists()

--- a/tests/projects/test_folders.py
+++ b/tests/projects/test_folders.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+import yaml
+import pytest
+
+from tinyagentos.projects.folders import (
+    project_dir,
+    ensure_project_layout,
+    write_project_yaml,
+    read_project_yaml,
+)
+
+
+def test_project_dir_uses_root_and_slug(tmp_path):
+    p = project_dir(tmp_path, "my-slug")
+    assert p == tmp_path / "my-slug"
+
+
+def test_ensure_project_layout_creates_subdirs(tmp_path):
+    root = ensure_project_layout(tmp_path, "alpha")
+    for sub in ("memory", "canvas", "files"):
+        assert (root / sub).is_dir(), sub
+    assert (root / "README.md").exists()
+
+
+def test_write_and_read_project_yaml(tmp_path):
+    ensure_project_layout(tmp_path, "alpha")
+    payload = {
+        "id": "prj-aaa",
+        "slug": "alpha",
+        "name": "Alpha",
+        "members": [{"member_id": "agent-1", "member_kind": "native"}],
+    }
+    write_project_yaml(tmp_path, "alpha", payload)
+    again = read_project_yaml(tmp_path, "alpha")
+    assert again == payload
+    raw = yaml.safe_load((tmp_path / "alpha" / "project.yaml").read_text())
+    assert raw["id"] == "prj-aaa"
+
+
+def test_read_missing_yaml_returns_none(tmp_path):
+    assert read_project_yaml(tmp_path, "missing") is None

--- a/tests/projects/test_ids.py
+++ b/tests/projects/test_ids.py
@@ -1,0 +1,19 @@
+import re
+import pytest
+from tinyagentos.projects.ids import new_id, ID_PREFIXES
+
+
+def test_new_id_format():
+    for prefix in ID_PREFIXES:
+        value = new_id(prefix)
+        assert re.fullmatch(rf"{prefix}-[a-z2-7]{{6}}", value), value
+
+
+def test_new_id_unique_across_calls():
+    ids = {new_id("tsk") for _ in range(200)}
+    assert len(ids) == 200
+
+
+def test_new_id_rejects_unknown_prefix():
+    with pytest.raises(ValueError):
+        new_id("bad")

--- a/tests/projects/test_lifecycle.py
+++ b/tests/projects/test_lifecycle.py
@@ -1,0 +1,26 @@
+import pytest
+from unittest.mock import AsyncMock
+
+from tinyagentos.projects.lifecycle import index_closed_task
+
+
+@pytest.mark.asyncio
+async def test_index_closed_task_calls_qmd_with_tags():
+    qmd = AsyncMock()
+    task = {
+        "id": "tsk-aaa",
+        "project_id": "prj-bbb",
+        "title": "Draft",
+        "body": "outline",
+        "closed_at": 1700000000.0,
+        "closed_by": "agent-1",
+        "labels": ["docs"],
+    }
+    project = {"id": "prj-bbb", "slug": "alpha", "name": "Alpha"}
+    await index_closed_task(qmd, project, task)
+    qmd.upsert_document.assert_awaited_once()
+    args, kwargs = qmd.upsert_document.await_args
+    assert kwargs["collection"] == "project-alpha"
+    assert "project:prj-bbb" in kwargs["tags"]
+    assert "task:tsk-aaa" in kwargs["tags"]
+    assert kwargs["body"].startswith("Draft")

--- a/tests/projects/test_project_store.py
+++ b/tests/projects/test_project_store.py
@@ -1,0 +1,37 @@
+import pytest
+import pytest_asyncio
+
+from tinyagentos.projects.project_store import ProjectStore
+
+
+@pytest_asyncio.fixture
+async def store(tmp_path):
+    s = ProjectStore(tmp_path / "projects.db")
+    await s.init()
+    yield s
+    await s.close()
+
+
+@pytest.mark.asyncio
+async def test_create_and_get_project(store):
+    p = await store.create_project(
+        name="Tax Prep 2026",
+        slug="tax-prep-2026",
+        description="annual filing",
+        created_by="user-1",
+    )
+    assert p["id"].startswith("prj-")
+    assert p["name"] == "Tax Prep 2026"
+    assert p["slug"] == "tax-prep-2026"
+    assert p["status"] == "active"
+    assert p["created_by"] == "user-1"
+
+    again = await store.get_project(p["id"])
+    assert again == p
+
+
+@pytest.mark.asyncio
+async def test_create_project_rejects_duplicate_slug(store):
+    await store.create_project(name="A", slug="dup", created_by="u")
+    with pytest.raises(ValueError):
+        await store.create_project(name="B", slug="dup", created_by="u")

--- a/tests/projects/test_project_store.py
+++ b/tests/projects/test_project_store.py
@@ -35,3 +35,62 @@ async def test_create_project_rejects_duplicate_slug(store):
     await store.create_project(name="A", slug="dup", created_by="u")
     with pytest.raises(ValueError):
         await store.create_project(name="B", slug="dup", created_by="u")
+
+
+@pytest.mark.asyncio
+async def test_list_projects_filter_by_status(store):
+    a = await store.create_project(name="A", slug="a", created_by="u")
+    b = await store.create_project(name="B", slug="b", created_by="u")
+    await store.set_status(b["id"], "archived")
+
+    active = await store.list_projects(status="active")
+    archived = await store.list_projects(status="archived")
+    assert [p["id"] for p in active] == [a["id"]]
+    assert [p["id"] for p in archived] == [b["id"]]
+
+
+@pytest.mark.asyncio
+async def test_update_project(store):
+    p = await store.create_project(name="A", slug="a", created_by="u")
+    await store.update_project(p["id"], name="A2", description="hello")
+    again = await store.get_project(p["id"])
+    assert again["name"] == "A2"
+    assert again["description"] == "hello"
+    assert again["updated_at"] >= p["updated_at"]
+
+
+@pytest.mark.asyncio
+async def test_add_remove_member(store):
+    p = await store.create_project(name="A", slug="a", created_by="u")
+    await store.add_member(
+        p["id"],
+        member_id="agent-1",
+        member_kind="native",
+        role="member",
+    )
+    await store.add_member(
+        p["id"],
+        member_id="agent-2-clone",
+        member_kind="clone",
+        source_agent_id="agent-2",
+        memory_seed="snapshot",
+    )
+    members = await store.list_members(p["id"])
+    assert len(members) == 2
+    by_id = {m["member_id"]: m for m in members}
+    assert by_id["agent-2-clone"]["memory_seed"] == "snapshot"
+    assert by_id["agent-2-clone"]["source_agent_id"] == "agent-2"
+
+    await store.remove_member(p["id"], "agent-1")
+    members = await store.list_members(p["id"])
+    assert [m["member_id"] for m in members] == ["agent-2-clone"]
+
+
+@pytest.mark.asyncio
+async def test_log_activity(store):
+    p = await store.create_project(name="A", slug="a", created_by="u")
+    await store.log_activity(p["id"], actor_id="u", kind="project.created", payload={"name": "A"})
+    await store.log_activity(p["id"], actor_id="u", kind="member.added", payload={"member_id": "agent-1"})
+    rows = await store.list_activity(p["id"])
+    assert [r["kind"] for r in rows] == ["member.added", "project.created"]
+    assert rows[0]["payload"] == {"member_id": "agent-1"}

--- a/tests/projects/test_task_store.py
+++ b/tests/projects/test_task_store.py
@@ -1,0 +1,42 @@
+import pytest
+import pytest_asyncio
+
+from tinyagentos.projects.task_store import ProjectTaskStore
+
+
+@pytest_asyncio.fixture
+async def store(tmp_path):
+    s = ProjectTaskStore(tmp_path / "tasks.db")
+    await s.init()
+    yield s
+    await s.close()
+
+
+@pytest.mark.asyncio
+async def test_create_and_get_task(store):
+    t = await store.create_task(
+        project_id="prj-aaa",
+        title="Draft outline",
+        body="Use 5 sections",
+        created_by="user-1",
+    )
+    assert t["id"].startswith("tsk-")
+    assert t["status"] == "open"
+    assert t["title"] == "Draft outline"
+    assert t["claimed_by"] is None
+    assert t["parent_task_id"] is None
+
+    again = await store.get_task(t["id"])
+    assert again == t
+
+
+@pytest.mark.asyncio
+async def test_create_subtask(store):
+    parent = await store.create_task(project_id="prj-aaa", title="P", created_by="u")
+    child = await store.create_task(
+        project_id="prj-aaa",
+        title="C",
+        created_by="u",
+        parent_task_id=parent["id"],
+    )
+    assert child["parent_task_id"] == parent["id"]

--- a/tests/projects/test_task_store.py
+++ b/tests/projects/test_task_store.py
@@ -153,3 +153,24 @@ async def test_threaded_comments(store):
 
     comments = await store.list_comments(task_id=t["id"])
     assert [c["id"] for c in comments] == [c1["id"], c2["id"]]
+
+
+@pytest.mark.asyncio
+async def test_closing_blocker_unblocks_ready_view(store):
+    a = await store.create_task(project_id="p", title="A", created_by="u")
+    b = await store.create_task(project_id="p", title="B", created_by="u")
+    c = await store.create_task(project_id="p", title="C", created_by="u")
+    # a is blocked by both b and c
+    await store.add_relationship(project_id="p", from_task_id=a["id"], to_task_id=b["id"], kind="blocks", created_by="u")
+    await store.add_relationship(project_id="p", from_task_id=a["id"], to_task_id=c["id"], kind="blocks", created_by="u")
+
+    ready = await store.list_ready_tasks(project_id="p")
+    assert {t["id"] for t in ready} == {b["id"], c["id"]}
+
+    await store.close_task(b["id"], closed_by="u")
+    ready = await store.list_ready_tasks(project_id="p")
+    assert {t["id"] for t in ready} == {c["id"]}
+
+    await store.close_task(c["id"], closed_by="u")
+    ready = await store.list_ready_tasks(project_id="p")
+    assert {t["id"] for t in ready} == {a["id"]}

--- a/tests/projects/test_task_store.py
+++ b/tests/projects/test_task_store.py
@@ -40,3 +40,58 @@ async def test_create_subtask(store):
         parent_task_id=parent["id"],
     )
     assert child["parent_task_id"] == parent["id"]
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_filter_by_status(store):
+    a = await store.create_task(project_id="p", title="A", created_by="u")
+    b = await store.create_task(project_id="p", title="B", created_by="u")
+    await store.close_task(b["id"], closed_by="u")
+
+    open_tasks = await store.list_tasks(project_id="p", status="open")
+    closed_tasks = await store.list_tasks(project_id="p", status="closed")
+    assert [t["id"] for t in open_tasks] == [a["id"]]
+    assert [t["id"] for t in closed_tasks] == [b["id"]]
+
+
+@pytest.mark.asyncio
+async def test_atomic_claim_only_one_winner(store):
+    t = await store.create_task(project_id="p", title="A", created_by="u")
+    first = await store.claim_task(t["id"], claimer_id="agent-1")
+    second = await store.claim_task(t["id"], claimer_id="agent-2")
+    assert first is True
+    assert second is False
+    again = await store.get_task(t["id"])
+    assert again["claimed_by"] == "agent-1"
+    assert again["status"] == "claimed"
+
+
+@pytest.mark.asyncio
+async def test_release_task(store):
+    t = await store.create_task(project_id="p", title="A", created_by="u")
+    await store.claim_task(t["id"], claimer_id="agent-1")
+    await store.release_task(t["id"], releaser_id="agent-1")
+    again = await store.get_task(t["id"])
+    assert again["claimed_by"] is None
+    assert again["status"] == "open"
+
+
+@pytest.mark.asyncio
+async def test_release_only_by_claimer(store):
+    t = await store.create_task(project_id="p", title="A", created_by="u")
+    await store.claim_task(t["id"], claimer_id="agent-1")
+    ok = await store.release_task(t["id"], releaser_id="agent-2")
+    assert ok is False
+    again = await store.get_task(t["id"])
+    assert again["claimed_by"] == "agent-1"
+
+
+@pytest.mark.asyncio
+async def test_close_task_records_metadata(store):
+    t = await store.create_task(project_id="p", title="A", created_by="u")
+    await store.close_task(t["id"], closed_by="agent-1", reason="done")
+    again = await store.get_task(t["id"])
+    assert again["status"] == "closed"
+    assert again["closed_by"] == "agent-1"
+    assert again["close_reason"] == "done"
+    assert again["closed_at"] is not None

--- a/tests/projects/test_task_store.py
+++ b/tests/projects/test_task_store.py
@@ -95,3 +95,61 @@ async def test_close_task_records_metadata(store):
     assert again["closed_by"] == "agent-1"
     assert again["close_reason"] == "done"
     assert again["closed_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_add_relationship_and_list(store):
+    a = await store.create_task(project_id="p", title="A", created_by="u")
+    b = await store.create_task(project_id="p", title="B", created_by="u")
+    rel = await store.add_relationship(
+        project_id="p",
+        from_task_id=a["id"],
+        to_task_id=b["id"],
+        kind="blocks",
+        created_by="u",
+    )
+    assert rel["id"].startswith("rel-")
+    rels = await store.list_relationships(a["id"])
+    assert [r["to_task_id"] for r in rels] == [b["id"]]
+
+
+@pytest.mark.asyncio
+async def test_ready_tasks_excludes_blocked(store):
+    a = await store.create_task(project_id="p", title="A", created_by="u")
+    b = await store.create_task(project_id="p", title="B", created_by="u")
+    # b blocks a
+    await store.add_relationship(
+        project_id="p",
+        from_task_id=a["id"],
+        to_task_id=b["id"],
+        kind="blocks",
+        created_by="u",
+    )
+    ready = await store.list_ready_tasks(project_id="p")
+    assert [t["id"] for t in ready] == [b["id"]]
+
+    await store.close_task(b["id"], closed_by="u")
+    ready = await store.list_ready_tasks(project_id="p")
+    assert [t["id"] for t in ready] == [a["id"]]
+
+
+@pytest.mark.asyncio
+async def test_ready_tasks_excludes_claimed(store):
+    a = await store.create_task(project_id="p", title="A", created_by="u")
+    await store.claim_task(a["id"], "agent-1")
+    ready = await store.list_ready_tasks(project_id="p")
+    assert ready == []
+
+
+@pytest.mark.asyncio
+async def test_threaded_comments(store):
+    t = await store.create_task(project_id="p", title="A", created_by="u")
+    c1 = await store.add_comment(task_id=t["id"], author_id="u", body="root")
+    c2 = await store.add_comment(
+        task_id=t["id"], author_id="u2", body="reply", replies_to_comment_id=c1["id"]
+    )
+    assert c1["id"].startswith("cmt-")
+    assert c2["replies_to_comment_id"] == c1["id"]
+
+    comments = await store.list_comments(task_id=t["id"])
+    assert [c["id"] for c in comments] == [c1["id"], c2["id"]]

--- a/tests/test_chat_channels.py
+++ b/tests/test_chat_channels.py
@@ -252,3 +252,26 @@ async def test_set_settings_archived_flag_roundtrip(store):
     assert not any(c["id"] == ch["id"] for c in arch_list2)
     live_list = await store.list_channels(archived=False)
     assert any(c["id"] == ch["id"] for c in live_list)
+
+
+@pytest.mark.asyncio
+async def test_create_channel_with_project_id(store):
+    ch = await store.create_channel(
+        name="alpha-room",
+        type="group",
+        created_by="u",
+        project_id="prj-aaa",
+    )
+    assert ch["project_id"] == "prj-aaa"
+
+
+@pytest.mark.asyncio
+async def test_list_channels_filter_by_project_id(store):
+    a = await store.create_channel(name="a", type="group", created_by="u", project_id="prj-1")
+    b = await store.create_channel(name="b", type="group", created_by="u", project_id="prj-2")
+    c = await store.create_channel(name="c", type="group", created_by="u")
+
+    in_p1 = await store.list_channels(project_id="prj-1")
+    rootless = await store.list_channels(project_id="")
+    assert [ch["id"] for ch in in_p1] == [a["id"]]
+    assert [ch["id"] for ch in rootless] == [c["id"]]

--- a/tests/test_routes_github.py
+++ b/tests/test_routes_github.py
@@ -146,8 +146,9 @@ async def test_notifications_returns_list():
     assert resp.status_code == 200
     data = resp.json()
     assert "notifications" in data
-    assert data["count"] == 1
-    assert data["notifications"][0]["reason"] == "mention"
+    assert data["unread_count"] == 1
+    assert data["notifications"][0]["title"] == "Bug"
+    assert data["notifications"][0]["repo"] == "owner/repo"
 
 
 @pytest.mark.asyncio

--- a/tests/test_routes_projects.py
+++ b/tests/test_routes_projects.py
@@ -256,3 +256,66 @@ async def test_delete_project_tombstones_folder_and_archives_channels(client):
 
     archived_channels = await channels_store.list_channels(archived=True)
     assert any(ch["project_id"] == pid for ch in archived_channels)
+
+
+@pytest.mark.asyncio
+async def test_add_member_idempotent_preserves_added_at(client):
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+    first = (await client.post(
+        f"/api/projects/{pid}/members",
+        json={"mode": "native", "agent_id": "agent-1"},
+    )).json()
+    await client.post(
+        f"/api/projects/{pid}/members",
+        json={"mode": "native", "agent_id": "agent-1"},
+    )
+    members = (await client.get(f"/api/projects/{pid}/members")).json()["items"]
+    me = next(m for m in members if m["member_id"] == "agent-1")
+    assert me["added_at"] == first["added_at"]
+
+
+@pytest.mark.asyncio
+async def test_archive_project_unknown_returns_404(client):
+    resp = await client.post("/api/projects/prj-nope/archive")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_update_task_cross_project_returns_404(client):
+    p1 = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+    p2 = (await client.post("/api/projects", json={"name": "B", "slug": "b"})).json()["id"]
+    t = (await client.post(f"/api/projects/{p1}/tasks", json={"title": "T"})).json()
+    resp = await client.patch(
+        f"/api/projects/{p2}/tasks/{t['id']}",
+        json={"title": "hijacked"},
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_add_relationship_rejects_other_project_task(client):
+    p1 = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+    p2 = (await client.post("/api/projects", json={"name": "B", "slug": "b"})).json()["id"]
+    a = (await client.post(f"/api/projects/{p1}/tasks", json={"title": "A"})).json()
+    b = (await client.post(f"/api/projects/{p2}/tasks", json={"title": "B"})).json()
+    resp = await client.post(
+        f"/api/projects/{p1}/tasks/{a['id']}/relationships",
+        json={"to_task_id": b["id"], "kind": "blocks"},
+    )
+    assert resp.status_code in (400, 422)
+
+
+@pytest.mark.asyncio
+async def test_add_comment_rejects_cross_task_reply(client):
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+    t1 = (await client.post(f"/api/projects/{pid}/tasks", json={"title": "T1"})).json()
+    t2 = (await client.post(f"/api/projects/{pid}/tasks", json={"title": "T2"})).json()
+    c1 = (await client.post(
+        f"/api/projects/{pid}/tasks/{t1['id']}/comments",
+        json={"body": "root", "author_id": "u"},
+    )).json()
+    resp = await client.post(
+        f"/api/projects/{pid}/tasks/{t2['id']}/comments",
+        json={"body": "reply", "author_id": "u", "replies_to_comment_id": c1["id"]},
+    )
+    assert resp.status_code in (400, 422)

--- a/tests/test_routes_projects.py
+++ b/tests/test_routes_projects.py
@@ -41,3 +41,63 @@ async def test_get_update_delete_project(client):
     resp = await client.delete(f"/api/projects/{pid}")
     assert resp.status_code == 200
     assert resp.json()["status"] == "deleted"
+
+
+@pytest.mark.asyncio
+async def test_add_native_member(client):
+    resp = await client.post("/api/projects", json={"name": "A", "slug": "a"})
+    pid = resp.json()["id"]
+
+    resp = await client.post(
+        f"/api/projects/{pid}/members",
+        json={"mode": "native", "agent_id": "agent-1"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["member_kind"] == "native"
+    assert body["member_id"] == "agent-1"
+
+    resp = await client.get(f"/api/projects/{pid}/members")
+    assert any(m["member_id"] == "agent-1" for m in resp.json()["items"])
+
+
+@pytest.mark.asyncio
+async def test_add_clone_member_with_memory_seed(client):
+    resp = await client.post("/api/projects", json={"name": "A", "slug": "a"})
+    pid = resp.json()["id"]
+
+    resp = await client.post(
+        f"/api/projects/{pid}/members",
+        json={"mode": "clone", "source_agent_id": "agent-1", "clone_memory": True},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["member_kind"] == "clone"
+    assert body["source_agent_id"] == "agent-1"
+    assert body["memory_seed"] == "snapshot"
+    assert body["member_id"] == "agent-1-a"
+
+
+@pytest.mark.asyncio
+async def test_add_clone_member_empty_memory(client):
+    resp = await client.post("/api/projects", json={"name": "A", "slug": "a"})
+    pid = resp.json()["id"]
+
+    resp = await client.post(
+        f"/api/projects/{pid}/members",
+        json={"mode": "clone", "source_agent_id": "agent-1", "clone_memory": False},
+    )
+    assert resp.json()["memory_seed"] == "empty"
+
+
+@pytest.mark.asyncio
+async def test_remove_member(client):
+    resp = await client.post("/api/projects", json={"name": "A", "slug": "a"})
+    pid = resp.json()["id"]
+    await client.post(f"/api/projects/{pid}/members", json={"mode": "native", "agent_id": "agent-1"})
+
+    resp = await client.delete(f"/api/projects/{pid}/members/agent-1")
+    assert resp.status_code == 200
+
+    resp = await client.get(f"/api/projects/{pid}/members")
+    assert resp.json()["items"] == []

--- a/tests/test_routes_projects.py
+++ b/tests/test_routes_projects.py
@@ -154,3 +154,38 @@ async def test_claim_release_close(client):
     )
     assert resp.status_code == 200
     assert resp.json()["status"] == "closed"
+
+
+@pytest.mark.asyncio
+async def test_threaded_comments_route(client):
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+    t = (await client.post(f"/api/projects/{pid}/tasks", json={"title": "T"})).json()
+
+    resp = await client.post(
+        f"/api/projects/{pid}/tasks/{t['id']}/comments",
+        json={"body": "root", "author_id": "u"},
+    )
+    assert resp.status_code == 200
+    c1 = resp.json()
+
+    resp = await client.post(
+        f"/api/projects/{pid}/tasks/{t['id']}/comments",
+        json={"body": "reply", "author_id": "u2", "replies_to_comment_id": c1["id"]},
+    )
+    assert resp.json()["replies_to_comment_id"] == c1["id"]
+
+    resp = await client.get(f"/api/projects/{pid}/tasks/{t['id']}/comments")
+    assert len(resp.json()["items"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_list_relationships_route(client):
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+    a = (await client.post(f"/api/projects/{pid}/tasks", json={"title": "A"})).json()
+    b = (await client.post(f"/api/projects/{pid}/tasks", json={"title": "B"})).json()
+    await client.post(
+        f"/api/projects/{pid}/tasks/{a['id']}/relationships",
+        json={"to_task_id": b["id"], "kind": "blocks"},
+    )
+    resp = await client.get(f"/api/projects/{pid}/tasks/{a['id']}/relationships")
+    assert [r["to_task_id"] for r in resp.json()["items"]] == [b["id"]]

--- a/tests/test_routes_projects.py
+++ b/tests/test_routes_projects.py
@@ -189,3 +189,18 @@ async def test_list_relationships_route(client):
     )
     resp = await client.get(f"/api/projects/{pid}/tasks/{a['id']}/relationships")
     assert [r["to_task_id"] for r in resp.json()["items"]] == [b["id"]]
+
+
+@pytest.mark.asyncio
+async def test_activity_feed(client):
+    resp = await client.post("/api/projects", json={"name": "A", "slug": "a"})
+    pid = resp.json()["id"]
+    await client.post(f"/api/projects/{pid}/members", json={"mode": "native", "agent_id": "agent-1"})
+    await client.post(f"/api/projects/{pid}/tasks", json={"title": "T"})
+
+    resp = await client.get(f"/api/projects/{pid}/activity")
+    assert resp.status_code == 200
+    kinds = [item["kind"] for item in resp.json()["items"]]
+    assert "project.created" in kinds
+    assert "member.added" in kinds
+    assert "task.created" in kinds

--- a/tests/test_routes_projects.py
+++ b/tests/test_routes_projects.py
@@ -22,6 +22,13 @@ async def test_create_project_duplicate_slug_returns_409(client):
     assert resp.status_code == 409
 
 
+@pytest.mark.parametrize("bad_slug", ["../escape", "/abs", "with space", "UPPER", "x" * 64, "", "."])
+@pytest.mark.asyncio
+async def test_create_project_rejects_unsafe_slug(client, bad_slug):
+    resp = await client.post("/api/projects", json={"name": "X", "slug": bad_slug})
+    assert resp.status_code == 422
+
+
 @pytest.mark.asyncio
 async def test_get_update_delete_project(client):
     resp = await client.post("/api/projects", json={"name": "A", "slug": "a"})

--- a/tests/test_routes_projects.py
+++ b/tests/test_routes_projects.py
@@ -226,3 +226,26 @@ async def test_memory_search_route(client, monkeypatch):
     assert resp.json()["items"][0]["path"] == "tasks/tsk-aaa.md"
     assert captured["collection"] == "project-a"
     assert "project:" + pid in captured["tags"]
+
+
+@pytest.mark.asyncio
+async def test_delete_project_tombstones_folder_and_archives_channels(client):
+    resp = await client.post("/api/projects", json={"name": "A", "slug": "a"})
+    pid = resp.json()["id"]
+    slug = "a"
+
+    channels_store = client._transport.app.state.chat_channels
+    await channels_store.create_channel(
+        name="alpha-room", type="group", created_by="u", project_id=pid,
+    )
+
+    resp = await client.delete(f"/api/projects/{pid}")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "deleted"
+
+    root = client._transport.app.state.projects_root
+    survivors = list(root.iterdir())
+    assert any(p.name.startswith(f"{slug}.deleted-") for p in survivors)
+
+    archived_channels = await channels_store.list_channels(archived=True)
+    assert any(ch["project_id"] == pid for ch in archived_channels)

--- a/tests/test_routes_projects.py
+++ b/tests/test_routes_projects.py
@@ -204,3 +204,25 @@ async def test_activity_feed(client):
     assert "project.created" in kinds
     assert "member.added" in kinds
     assert "task.created" in kinds
+
+
+@pytest.mark.asyncio
+async def test_memory_search_route(client, monkeypatch):
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+
+    captured = {}
+
+    async def fake_search(self, query, collection=None, tags=None, limit=10):
+        captured["query"] = query
+        captured["collection"] = collection
+        captured["tags"] = tags
+        return [{"path": "tasks/tsk-aaa.md", "score": 0.9, "title": "Draft"}]
+
+    from tinyagentos.qmd_client import QmdClient
+    monkeypatch.setattr(QmdClient, "search", fake_search, raising=False)
+
+    resp = await client.get(f"/api/projects/{pid}/memory/search?q=draft")
+    assert resp.status_code == 200
+    assert resp.json()["items"][0]["path"] == "tasks/tsk-aaa.md"
+    assert captured["collection"] == "project-a"
+    assert "project:" + pid in captured["tags"]

--- a/tests/test_routes_projects.py
+++ b/tests/test_routes_projects.py
@@ -101,3 +101,56 @@ async def test_remove_member(client):
 
     resp = await client.get(f"/api/projects/{pid}/members")
     assert resp.json()["items"] == []
+
+
+@pytest.mark.asyncio
+async def test_create_and_list_tasks(client):
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+
+    resp = await client.post(
+        f"/api/projects/{pid}/tasks",
+        json={"title": "T1", "body": "do it", "priority": 2},
+    )
+    assert resp.status_code == 200
+    t = resp.json()
+    assert t["id"].startswith("tsk-")
+
+    resp = await client.get(f"/api/projects/{pid}/tasks")
+    assert [x["id"] for x in resp.json()["items"]] == [t["id"]]
+
+
+@pytest.mark.asyncio
+async def test_ready_endpoint(client):
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+    a = (await client.post(f"/api/projects/{pid}/tasks", json={"title": "A"})).json()
+    b = (await client.post(f"/api/projects/{pid}/tasks", json={"title": "B"})).json()
+    await client.post(
+        f"/api/projects/{pid}/tasks/{a['id']}/relationships",
+        json={"to_task_id": b["id"], "kind": "blocks"},
+    )
+    resp = await client.get(f"/api/projects/{pid}/tasks/ready")
+    assert [t["id"] for t in resp.json()["items"]] == [b["id"]]
+
+
+@pytest.mark.asyncio
+async def test_claim_release_close(client):
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+    t = (await client.post(f"/api/projects/{pid}/tasks", json={"title": "A"})).json()
+
+    resp = await client.post(f"/api/projects/{pid}/tasks/{t['id']}/claim", json={"claimer_id": "agent-1"})
+    assert resp.status_code == 200
+    assert resp.json()["claimed_by"] == "agent-1"
+
+    resp = await client.post(f"/api/projects/{pid}/tasks/{t['id']}/claim", json={"claimer_id": "agent-2"})
+    assert resp.status_code == 409
+
+    resp = await client.post(f"/api/projects/{pid}/tasks/{t['id']}/release", json={"releaser_id": "agent-1"})
+    assert resp.status_code == 200
+
+    await client.post(f"/api/projects/{pid}/tasks/{t['id']}/claim", json={"claimer_id": "agent-1"})
+    resp = await client.post(
+        f"/api/projects/{pid}/tasks/{t['id']}/close",
+        json={"closed_by": "agent-1", "reason": "done"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "closed"

--- a/tests/test_routes_projects.py
+++ b/tests/test_routes_projects.py
@@ -319,3 +319,95 @@ async def test_add_comment_rejects_cross_task_reply(client):
         json={"body": "reply", "author_id": "u", "replies_to_comment_id": c1["id"]},
     )
     assert resp.status_code in (400, 422)
+
+
+@pytest.mark.asyncio
+async def test_claim_release_close_reject_cross_project(client):
+    p1 = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+    p2 = (await client.post("/api/projects", json={"name": "B", "slug": "b"})).json()["id"]
+    t = (await client.post(f"/api/projects/{p1}/tasks", json={"title": "T"})).json()
+
+    resp = await client.post(
+        f"/api/projects/{p2}/tasks/{t['id']}/claim",
+        json={"claimer_id": "agent-x"},
+    )
+    assert resp.status_code == 404
+
+    resp = await client.post(
+        f"/api/projects/{p2}/tasks/{t['id']}/release",
+        json={"releaser_id": "agent-x"},
+    )
+    assert resp.status_code == 404
+
+    resp = await client.post(
+        f"/api/projects/{p2}/tasks/{t['id']}/close",
+        json={"closed_by": "agent-x"},
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_release_after_close_does_not_reopen(client):
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+    t = (await client.post(f"/api/projects/{pid}/tasks", json={"title": "T"})).json()
+    await client.post(f"/api/projects/{pid}/tasks/{t['id']}/claim", json={"claimer_id": "agent-1"})
+    resp = await client.post(
+        f"/api/projects/{pid}/tasks/{t['id']}/close",
+        json={"closed_by": "agent-1"},
+    )
+    assert resp.json()["status"] == "closed"
+
+    resp = await client.post(
+        f"/api/projects/{pid}/tasks/{t['id']}/release",
+        json={"releaser_id": "agent-1"},
+    )
+    assert resp.status_code == 409
+
+    resp = await client.get(f"/api/projects/{pid}/tasks/{t['id']}")
+    assert resp.json()["status"] == "closed"
+
+
+@pytest.mark.asyncio
+async def test_comments_and_relationships_reject_wrong_project(client):
+    p1 = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+    p2 = (await client.post("/api/projects", json={"name": "B", "slug": "b"})).json()["id"]
+    t = (await client.post(f"/api/projects/{p1}/tasks", json={"title": "T"})).json()
+
+    resp = await client.post(
+        f"/api/projects/{p2}/tasks/{t['id']}/comments",
+        json={"body": "x", "author_id": "u"},
+    )
+    assert resp.status_code == 404
+
+    resp = await client.get(f"/api/projects/{p2}/tasks/{t['id']}/comments")
+    assert resp.status_code == 404
+
+    resp = await client.get(f"/api/projects/{p2}/tasks/{t['id']}/relationships")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_create_task_unknown_project_returns_404(client):
+    resp = await client.post("/api/projects/prj-nope/tasks", json={"title": "T"})
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_create_task_rejects_cross_project_parent(client):
+    p1 = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+    p2 = (await client.post("/api/projects", json={"name": "B", "slug": "b"})).json()["id"]
+    parent = (await client.post(f"/api/projects/{p1}/tasks", json={"title": "P"})).json()
+    resp = await client.post(
+        f"/api/projects/{p2}/tasks",
+        json={"title": "child", "parent_task_id": parent["id"]},
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_create_project_duplicate_slug_via_store_concurrent(client):
+    # Simulates the race where two creates pass any pre-check and both reach INSERT.
+    store = client._transport.app.state.project_store
+    await store.create_project(name="A", slug="race", created_by="u")
+    with pytest.raises(ValueError, match="slug already used"):
+        await store.create_project(name="B", slug="race", created_by="u")

--- a/tests/test_routes_projects.py
+++ b/tests/test_routes_projects.py
@@ -1,0 +1,43 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_create_and_list_project(client):
+    resp = await client.post("/api/projects", json={"name": "Alpha", "slug": "alpha", "description": "x"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"].startswith("prj-")
+    assert body["slug"] == "alpha"
+
+    resp = await client.get("/api/projects")
+    assert resp.status_code == 200
+    items = resp.json()["items"]
+    assert any(p["slug"] == "alpha" for p in items)
+
+
+@pytest.mark.asyncio
+async def test_create_project_duplicate_slug_returns_409(client):
+    await client.post("/api/projects", json={"name": "A", "slug": "dup"})
+    resp = await client.post("/api/projects", json={"name": "B", "slug": "dup"})
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_get_update_delete_project(client):
+    resp = await client.post("/api/projects", json={"name": "A", "slug": "a"})
+    pid = resp.json()["id"]
+
+    resp = await client.get(f"/api/projects/{pid}")
+    assert resp.status_code == 200
+
+    resp = await client.patch(f"/api/projects/{pid}", json={"name": "A2"})
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "A2"
+
+    resp = await client.post(f"/api/projects/{pid}/archive")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "archived"
+
+    resp = await client.delete(f"/api/projects/{pid}")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "deleted"

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -707,6 +707,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     app.state.chat_channels = chat_channels
     app.state.project_store = project_store
     app.state.project_task_store = project_task_store
+    projects_root.mkdir(parents=True, exist_ok=True)
     app.state.projects_root = projects_root
     app.state.chat_hub = chat_hub
     from tinyagentos.chat.reactions import WantsReplyRegistry as _WantsReplyRegistry

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -199,6 +199,11 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     adapter_manager = AdapterManager(channel_hub_router)
     chat_messages = ChatMessageStore(data_dir / "chat.db")
     chat_channels = ChatChannelStore(data_dir / "chat.db")
+    from tinyagentos.projects.project_store import ProjectStore
+    from tinyagentos.projects.task_store import ProjectTaskStore
+    project_store = ProjectStore(data_dir / "projects.db")
+    project_task_store = ProjectTaskStore(data_dir / "projects.db")
+    projects_root = data_dir / "projects"
     chat_hub = ChatHub()
     canvas_store = CanvasStore(data_dir / "canvas.db")
     desktop_settings = DesktopSettingsStore(data_dir / "desktop.db")
@@ -254,6 +259,9 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await expert_agents.init()
         await chat_messages.init()
         await chat_channels.init()
+        await project_store.init()
+        await project_task_store.init()
+        projects_root.mkdir(parents=True, exist_ok=True)
         await canvas_store.init()
         await desktop_settings.init()
         await user_memory.init()
@@ -391,6 +399,9 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         app.state.deploy_tasks = {}
         app.state.chat_messages = chat_messages
         app.state.chat_channels = chat_channels
+        app.state.project_store = project_store
+        app.state.project_task_store = project_task_store
+        app.state.projects_root = projects_root
         app.state.chat_hub = chat_hub
         from tinyagentos.chat.group_policy import GroupPolicy
         app.state.group_policy = GroupPolicy()
@@ -626,6 +637,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await user_memory.close()
         await desktop_settings.close()
         await canvas_store.close()
+        await project_task_store.close()
+        await project_store.close()
         await chat_channels.close()
         await chat_messages.close()
         await expert_agents.close()
@@ -692,6 +705,9 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     app.state.deploy_tasks = {}
     app.state.chat_messages = chat_messages
     app.state.chat_channels = chat_channels
+    app.state.project_store = project_store
+    app.state.project_task_store = project_task_store
+    app.state.projects_root = projects_root
     app.state.chat_hub = chat_hub
     from tinyagentos.chat.reactions import WantsReplyRegistry as _WantsReplyRegistry
     app.state.wants_reply = _WantsReplyRegistry()

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -799,6 +799,9 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     from tinyagentos.routes.store import router as store_router
     app.include_router(store_router)
 
+    from tinyagentos.routes import projects as projects_routes
+    app.include_router(projects_routes.router)
+
     from tinyagentos.routes.store_install import router as store_install_router
     app.include_router(store_install_router)
 

--- a/tinyagentos/chat/channel_store.py
+++ b/tinyagentos/chat/channel_store.py
@@ -17,7 +17,8 @@ CREATE TABLE IF NOT EXISTS chat_channels (
     settings TEXT NOT NULL DEFAULT '{}',
     created_by TEXT NOT NULL,
     created_at REAL NOT NULL,
-    last_message_at REAL
+    last_message_at REAL,
+    project_id TEXT NOT NULL DEFAULT ''
 );
 
 CREATE TABLE IF NOT EXISTS chat_read_positions (
@@ -78,6 +79,15 @@ def _parse_channel(row: tuple, description) -> dict:
 class ChatChannelStore(BaseStore):
     SCHEMA = CHANNELS_SCHEMA
 
+    async def _post_init(self) -> None:
+        async with self._db.execute("PRAGMA table_info(chat_channels)") as cur:
+            cols = {r[1] for r in await cur.fetchall()}
+        if "project_id" not in cols:
+            await self._db.execute(
+                "ALTER TABLE chat_channels ADD COLUMN project_id TEXT NOT NULL DEFAULT ''"
+            )
+            await self._db.commit()
+
     async def create_channel(
         self,
         name: str,
@@ -87,18 +97,19 @@ class ChatChannelStore(BaseStore):
         description: str = "",
         topic: str = "",
         settings: dict | None = None,
+        project_id: str = "",
     ) -> dict:
         ch_id = uuid.uuid4().hex[:12]
         now = time.time()
         await self._db.execute(
             """INSERT INTO chat_channels
-               (id, name, type, description, topic, members, settings, created_by, created_at, last_message_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)""",
+               (id, name, type, description, topic, members, settings, created_by, created_at, last_message_at, project_id)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)""",
             (
                 ch_id, name, type, description, topic,
                 json.dumps(members or []),
                 json.dumps(settings or {}),
-                created_by, now,
+                created_by, now, project_id,
             ),
         )
         await self._db.commit()
@@ -117,6 +128,7 @@ class ChatChannelStore(BaseStore):
         self,
         member_id: str | None = None,
         archived: bool | None = None,
+        project_id: str | None = None,
     ) -> list[dict]:
         conditions: list[str] = []
         params: list = []
@@ -124,6 +136,10 @@ class ChatChannelStore(BaseStore):
         if member_id is not None:
             conditions.append("members LIKE ?")
             params.append(f'%"{member_id}"%')
+
+        if project_id is not None:
+            conditions.append("project_id = ?")
+            params.append(project_id)
 
         # archived filter — use JSON text search for speed (settings is stored as
         # a JSON string; the canonical marker is '"archived": true').

--- a/tinyagentos/knowledge_fetchers/github.py
+++ b/tinyagentos/knowledge_fetchers/github.py
@@ -291,6 +291,7 @@ async def fetch_starred(
             "full_name": r.get("full_name", ""),
             "description": r.get("description") or "",
             "stars": r.get("stargazers_count", 0),
+            "forks": r.get("forks_count", 0),
             "language": r.get("language") or "",
             "updated_at": r.get("updated_at") or "",
             "url": r.get("html_url", ""),

--- a/tinyagentos/projects/folders.py
+++ b/tinyagentos/projects/folders.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+_README = "# {name}\n\nProject workspace managed by taOS.\n"
+
+
+def project_dir(root: Path, slug: str) -> Path:
+    return root / slug
+
+
+def ensure_project_layout(root: Path, slug: str, name: str | None = None) -> Path:
+    base = project_dir(root, slug)
+    for sub in ("memory", "canvas", "files"):
+        (base / sub).mkdir(parents=True, exist_ok=True)
+    readme = base / "README.md"
+    if not readme.exists():
+        readme.write_text(_README.format(name=name or slug))
+    return base
+
+
+def write_project_yaml(root: Path, slug: str, payload: dict) -> Path:
+    base = project_dir(root, slug)
+    base.mkdir(parents=True, exist_ok=True)
+    target = base / "project.yaml"
+    target.write_text(yaml.safe_dump(payload, sort_keys=False))
+    return target
+
+
+def read_project_yaml(root: Path, slug: str) -> dict | None:
+    target = project_dir(root, slug) / "project.yaml"
+    if not target.exists():
+        return None
+    return yaml.safe_load(target.read_text())

--- a/tinyagentos/projects/ids.py
+++ b/tinyagentos/projects/ids.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+import secrets
+
+ID_PREFIXES = ("prj", "tsk", "cmt", "rel")
+_ALPHABET = "abcdefghijklmnopqrstuvwxyz234567"
+
+
+def new_id(prefix: str) -> str:
+    if prefix not in ID_PREFIXES:
+        raise ValueError(f"unknown id prefix: {prefix}")
+    suffix = "".join(secrets.choice(_ALPHABET) for _ in range(6))
+    return f"{prefix}-{suffix}"

--- a/tinyagentos/projects/lifecycle.py
+++ b/tinyagentos/projects/lifecycle.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+
+async def index_closed_task(qmd_client: Any, project: dict, task: dict) -> None:
+    """Embed a closed task into the project's QMD index.
+
+    The project's per-project collection is `project-<slug>`. Tags include
+    project, task, label and close-date markers so the memory layer can
+    favour recently-closed work and decay older items naturally.
+    """
+    closed_at = task.get("closed_at") or time.time()
+    iso_date = datetime.fromtimestamp(closed_at, tz=timezone.utc).strftime("%Y-%m-%d")
+    body_parts = [task.get("title", ""), task.get("body", "")]
+    body = "\n\n".join(p for p in body_parts if p).strip()
+
+    tags = [
+        f"project:{project['id']}",
+        f"task:{task['id']}",
+        f"closed:{iso_date}",
+    ]
+    for label in task.get("labels") or []:
+        tags.append(f"label:{label}")
+
+    await qmd_client.upsert_document(
+        collection=f"project-{project['slug']}",
+        path=f"tasks/{task['id']}.md",
+        title=task.get("title", task["id"]),
+        body=body,
+        tags=tags,
+        metadata={
+            "task_id": task["id"],
+            "project_id": project["id"],
+            "closed_at": closed_at,
+            "closed_by": task.get("closed_by"),
+        },
+    )

--- a/tinyagentos/projects/project_store.py
+++ b/tinyagentos/projects/project_store.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 import time
 
 from tinyagentos.base_store import BaseStore
@@ -68,18 +69,21 @@ class ProjectStore(BaseStore):
         description: str = "",
         settings: dict | None = None,
     ) -> dict:
-        existing = await self.get_project_by_slug(slug)
-        if existing is not None:
-            raise ValueError(f"slug already used: {slug}")
         pid = new_id("prj")
         now = time.time()
-        await self._db.execute(
-            """INSERT INTO projects
-               (id, name, slug, description, status, created_by, created_at, updated_at, settings)
-               VALUES (?, ?, ?, ?, 'active', ?, ?, ?, ?)""",
-            (pid, name, slug, description, created_by, now, now, json.dumps(settings or {})),
-        )
-        await self._db.commit()
+        try:
+            await self._db.execute(
+                """INSERT INTO projects
+                   (id, name, slug, description, status, created_by, created_at, updated_at, settings)
+                   VALUES (?, ?, ?, ?, 'active', ?, ?, ?, ?)""",
+                (pid, name, slug, description, created_by, now, now, json.dumps(settings or {})),
+            )
+            await self._db.commit()
+        except sqlite3.IntegrityError as exc:
+            # UNIQUE(slug) is the only uniqueness constraint a caller can trigger.
+            if "slug" in str(exc).lower():
+                raise ValueError(f"slug already used: {slug}") from exc
+            raise
         return await self.get_project(pid)
 
     async def get_project(self, project_id: str) -> dict | None:

--- a/tinyagentos/projects/project_store.py
+++ b/tinyagentos/projects/project_store.py
@@ -99,3 +99,126 @@ class ProjectStore(BaseStore):
             if row is None:
                 return None
             return _row_to_project(row, cur.description)
+
+    async def list_projects(self, status: str | None = "active") -> list[dict]:
+        if status is None:
+            sql = "SELECT * FROM projects ORDER BY created_at DESC"
+            params: tuple = ()
+        else:
+            sql = "SELECT * FROM projects WHERE status = ? ORDER BY created_at DESC"
+            params = (status,)
+        async with self._db.execute(sql, params) as cur:
+            rows = await cur.fetchall()
+            desc = cur.description
+        return [_row_to_project(r, desc) for r in rows]
+
+    async def update_project(
+        self,
+        project_id: str,
+        name: str | None = None,
+        description: str | None = None,
+        settings: dict | None = None,
+    ) -> None:
+        sets: list[str] = []
+        params: list = []
+        if name is not None:
+            sets.append("name = ?"); params.append(name)
+        if description is not None:
+            sets.append("description = ?"); params.append(description)
+        if settings is not None:
+            sets.append("settings = ?"); params.append(json.dumps(settings))
+        if not sets:
+            return
+        sets.append("updated_at = ?"); params.append(time.time())
+        params.append(project_id)
+        await self._db.execute(
+            f"UPDATE projects SET {', '.join(sets)} WHERE id = ?", params
+        )
+        await self._db.commit()
+
+    async def set_status(self, project_id: str, status: str) -> None:
+        if status not in ("active", "archived", "deleted"):
+            raise ValueError(f"invalid status: {status}")
+        now = time.time()
+        col_map = {"archived": "archived_at", "deleted": "deleted_at"}
+        extra_col = col_map.get(status)
+        if extra_col:
+            await self._db.execute(
+                f"UPDATE projects SET status = ?, updated_at = ?, {extra_col} = ? WHERE id = ?",
+                (status, now, now, project_id),
+            )
+        else:
+            await self._db.execute(
+                "UPDATE projects SET status = ?, updated_at = ? WHERE id = ?",
+                (status, now, project_id),
+            )
+        await self._db.commit()
+
+    async def add_member(
+        self,
+        project_id: str,
+        member_id: str,
+        member_kind: str,
+        role: str = "member",
+        source_agent_id: str | None = None,
+        memory_seed: str = "none",
+    ) -> None:
+        if member_kind not in ("native", "clone"):
+            raise ValueError(f"invalid member_kind: {member_kind}")
+        if memory_seed not in ("none", "snapshot", "empty"):
+            raise ValueError(f"invalid memory_seed: {memory_seed}")
+        await self._db.execute(
+            """INSERT OR REPLACE INTO project_members
+               (project_id, member_id, member_kind, role, source_agent_id, memory_seed, added_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (project_id, member_id, member_kind, role, source_agent_id, memory_seed, time.time()),
+        )
+        await self._db.commit()
+
+    async def remove_member(self, project_id: str, member_id: str) -> None:
+        await self._db.execute(
+            "DELETE FROM project_members WHERE project_id = ? AND member_id = ?",
+            (project_id, member_id),
+        )
+        await self._db.commit()
+
+    async def list_members(self, project_id: str) -> list[dict]:
+        async with self._db.execute(
+            "SELECT * FROM project_members WHERE project_id = ? ORDER BY added_at ASC",
+            (project_id,),
+        ) as cur:
+            rows = await cur.fetchall()
+            keys = [d[0] for d in cur.description]
+        return [dict(zip(keys, r)) for r in rows]
+
+    async def log_activity(
+        self,
+        project_id: str,
+        actor_id: str,
+        kind: str,
+        payload: dict | None = None,
+    ) -> None:
+        await self._db.execute(
+            """INSERT INTO project_activity
+               (project_id, actor_id, kind, payload, created_at)
+               VALUES (?, ?, ?, ?, ?)""",
+            (project_id, actor_id, kind, json.dumps(payload or {}), time.time()),
+        )
+        await self._db.commit()
+
+    async def list_activity(self, project_id: str, limit: int = 100) -> list[dict]:
+        async with self._db.execute(
+            """SELECT * FROM project_activity
+               WHERE project_id = ?
+               ORDER BY created_at DESC
+               LIMIT ?""",
+            (project_id, limit),
+        ) as cur:
+            rows = await cur.fetchall()
+            keys = [d[0] for d in cur.description]
+        out: list[dict] = []
+        for r in rows:
+            d = dict(zip(keys, r))
+            d["payload"] = json.loads(d["payload"]) if d["payload"] else {}
+            out.append(d)
+        return out

--- a/tinyagentos/projects/project_store.py
+++ b/tinyagentos/projects/project_store.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+import time
+
+from tinyagentos.base_store import BaseStore
+from tinyagentos.projects.ids import new_id
+
+PROJECTS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS projects (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    slug TEXT NOT NULL UNIQUE,
+    description TEXT NOT NULL DEFAULT '',
+    status TEXT NOT NULL DEFAULT 'active',
+    created_by TEXT NOT NULL,
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL,
+    archived_at REAL,
+    deleted_at REAL,
+    settings TEXT NOT NULL DEFAULT '{}'
+);
+CREATE INDEX IF NOT EXISTS idx_projects_status ON projects(status);
+
+CREATE TABLE IF NOT EXISTS project_members (
+    project_id TEXT NOT NULL,
+    member_id TEXT NOT NULL,
+    member_kind TEXT NOT NULL,
+    role TEXT NOT NULL DEFAULT 'member',
+    source_agent_id TEXT,
+    memory_seed TEXT NOT NULL DEFAULT 'none',
+    added_at REAL NOT NULL,
+    PRIMARY KEY (project_id, member_id)
+);
+CREATE INDEX IF NOT EXISTS idx_project_members_member ON project_members(member_id);
+
+CREATE TABLE IF NOT EXISTS project_activity (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_id TEXT NOT NULL,
+    actor_id TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    payload TEXT NOT NULL DEFAULT '{}',
+    created_at REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_project_activity_project ON project_activity(project_id, created_at DESC);
+"""
+
+_JSON_FIELDS = ("settings",)
+
+
+def _row_to_project(row, description) -> dict:
+    keys = [d[0] for d in description]
+    p = dict(zip(keys, row))
+    for f in _JSON_FIELDS:
+        if f in p and p[f] is not None:
+            p[f] = json.loads(p[f])
+    return p
+
+
+class ProjectStore(BaseStore):
+    SCHEMA = PROJECTS_SCHEMA
+
+    async def create_project(
+        self,
+        name: str,
+        slug: str,
+        created_by: str,
+        description: str = "",
+        settings: dict | None = None,
+    ) -> dict:
+        existing = await self.get_project_by_slug(slug)
+        if existing is not None:
+            raise ValueError(f"slug already used: {slug}")
+        pid = new_id("prj")
+        now = time.time()
+        await self._db.execute(
+            """INSERT INTO projects
+               (id, name, slug, description, status, created_by, created_at, updated_at, settings)
+               VALUES (?, ?, ?, ?, 'active', ?, ?, ?, ?)""",
+            (pid, name, slug, description, created_by, now, now, json.dumps(settings or {})),
+        )
+        await self._db.commit()
+        return await self.get_project(pid)
+
+    async def get_project(self, project_id: str) -> dict | None:
+        async with self._db.execute(
+            "SELECT * FROM projects WHERE id = ?", (project_id,)
+        ) as cur:
+            row = await cur.fetchone()
+            if row is None:
+                return None
+            return _row_to_project(row, cur.description)
+
+    async def get_project_by_slug(self, slug: str) -> dict | None:
+        async with self._db.execute(
+            "SELECT * FROM projects WHERE slug = ?", (slug,)
+        ) as cur:
+            row = await cur.fetchone()
+            if row is None:
+                return None
+            return _row_to_project(row, cur.description)

--- a/tinyagentos/projects/project_store.py
+++ b/tinyagentos/projects/project_store.py
@@ -168,9 +168,10 @@ class ProjectStore(BaseStore):
         if memory_seed not in ("none", "snapshot", "empty"):
             raise ValueError(f"invalid memory_seed: {memory_seed}")
         await self._db.execute(
-            """INSERT OR REPLACE INTO project_members
+            """INSERT INTO project_members
                (project_id, member_id, member_kind, role, source_agent_id, memory_seed, added_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+               VALUES (?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(project_id, member_id) DO NOTHING""",
             (project_id, member_id, member_kind, role, source_agent_id, memory_seed, time.time()),
         )
         await self._db.commit()
@@ -207,6 +208,7 @@ class ProjectStore(BaseStore):
         await self._db.commit()
 
     async def list_activity(self, project_id: str, limit: int = 100) -> list[dict]:
+        limit = max(1, min(limit, 500))
         async with self._db.execute(
             """SELECT * FROM project_activity
                WHERE project_id = ?

--- a/tinyagentos/projects/task_store.py
+++ b/tinyagentos/projects/task_store.py
@@ -214,6 +214,10 @@ class ProjectTaskStore(BaseStore):
     ) -> dict:
         if kind not in ("blocks", "relates_to", "duplicates", "supersedes"):
             raise ValueError(f"invalid relationship kind: {kind}")
+        for tid in (from_task_id, to_task_id):
+            t = await self.get_task(tid)
+            if t is None or t["project_id"] != project_id:
+                raise ValueError(f"task not in project: {tid}")
         rid = new_id("rel")
         now = time.time()
         await self._db.execute(
@@ -239,6 +243,8 @@ class ProjectTaskStore(BaseStore):
         task_id: str,
         direction: str = "from",
     ) -> list[dict]:
+        if direction not in ("from", "to"):
+            raise ValueError(f"invalid direction: {direction}")
         col = "from_task_id" if direction == "from" else "to_task_id"
         async with self._db.execute(
             f"SELECT * FROM task_relationships WHERE {col} = ? ORDER BY created_at ASC",
@@ -249,6 +255,7 @@ class ProjectTaskStore(BaseStore):
         return [dict(zip(keys, r)) for r in rows]
 
     async def list_ready_tasks(self, project_id: str, limit: int = 50) -> list[dict]:
+        limit = max(1, min(limit, 200))
         async with self._db.execute(
             """SELECT * FROM ready_tasks
                WHERE project_id = ?
@@ -267,6 +274,14 @@ class ProjectTaskStore(BaseStore):
         body: str,
         replies_to_comment_id: str | None = None,
     ) -> dict:
+        if replies_to_comment_id is not None:
+            async with self._db.execute(
+                "SELECT task_id FROM task_comments WHERE id = ?",
+                (replies_to_comment_id,),
+            ) as cur:
+                row = await cur.fetchone()
+            if row is None or row[0] != task_id:
+                raise ValueError("replies_to_comment_id not in this task")
         cid = new_id("cmt")
         now = time.time()
         await self._db.execute(

--- a/tinyagentos/projects/task_store.py
+++ b/tinyagentos/projects/task_store.py
@@ -115,3 +115,91 @@ class ProjectTaskStore(BaseStore):
             if row is None:
                 return None
             return _row_to_task(row, cur.description)
+
+    async def list_tasks(
+        self,
+        project_id: str,
+        status: str | None = None,
+        parent_task_id: str | None = None,
+    ) -> list[dict]:
+        conds = ["project_id = ?"]
+        params: list = [project_id]
+        if status is not None:
+            conds.append("status = ?")
+            params.append(status)
+        if parent_task_id is not None:
+            conds.append("parent_task_id = ?")
+            params.append(parent_task_id)
+        sql = f"SELECT * FROM project_tasks WHERE {' AND '.join(conds)} ORDER BY created_at ASC"
+        async with self._db.execute(sql, params) as cur:
+            rows = await cur.fetchall()
+            desc = cur.description
+        return [_row_to_task(r, desc) for r in rows]
+
+    async def update_task(
+        self,
+        task_id: str,
+        title: str | None = None,
+        body: str | None = None,
+        priority: int | None = None,
+        labels: list[str] | None = None,
+        assignee_id: str | None = None,
+    ) -> None:
+        sets: list[str] = []
+        params: list = []
+        if title is not None:
+            sets.append("title = ?"); params.append(title)
+        if body is not None:
+            sets.append("body = ?"); params.append(body)
+        if priority is not None:
+            sets.append("priority = ?"); params.append(priority)
+        if labels is not None:
+            sets.append("labels = ?"); params.append(json.dumps(labels))
+        if assignee_id is not None:
+            sets.append("assignee_id = ?"); params.append(assignee_id)
+        if not sets:
+            return
+        sets.append("updated_at = ?"); params.append(time.time())
+        params.append(task_id)
+        await self._db.execute(
+            f"UPDATE project_tasks SET {', '.join(sets)} WHERE id = ?", params
+        )
+        await self._db.commit()
+
+    async def claim_task(self, task_id: str, claimer_id: str) -> bool:
+        now = time.time()
+        cursor = await self._db.execute(
+            """UPDATE project_tasks
+               SET claimed_by = ?, claimed_at = ?, status = 'claimed', updated_at = ?
+               WHERE id = ? AND claimed_by IS NULL AND status = 'open'""",
+            (claimer_id, now, now, task_id),
+        )
+        await self._db.commit()
+        return cursor.rowcount == 1
+
+    async def release_task(self, task_id: str, releaser_id: str) -> bool:
+        now = time.time()
+        cursor = await self._db.execute(
+            """UPDATE project_tasks
+               SET claimed_by = NULL, claimed_at = NULL, status = 'open', updated_at = ?
+               WHERE id = ? AND claimed_by = ?""",
+            (now, task_id, releaser_id),
+        )
+        await self._db.commit()
+        return cursor.rowcount == 1
+
+    async def close_task(
+        self,
+        task_id: str,
+        closed_by: str,
+        reason: str | None = None,
+    ) -> bool:
+        now = time.time()
+        cursor = await self._db.execute(
+            """UPDATE project_tasks
+               SET status = 'closed', closed_by = ?, closed_at = ?, close_reason = ?, updated_at = ?
+               WHERE id = ? AND status NOT IN ('closed', 'cancelled')""",
+            (closed_by, now, reason, now, task_id),
+        )
+        await self._db.commit()
+        return cursor.rowcount == 1

--- a/tinyagentos/projects/task_store.py
+++ b/tinyagentos/projects/task_store.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+import time
+
+from tinyagentos.base_store import BaseStore
+from tinyagentos.projects.ids import new_id
+
+TASK_SCHEMA = """
+CREATE TABLE IF NOT EXISTS project_tasks (
+    id TEXT PRIMARY KEY,
+    project_id TEXT NOT NULL,
+    parent_task_id TEXT,
+    title TEXT NOT NULL,
+    body TEXT NOT NULL DEFAULT '',
+    status TEXT NOT NULL DEFAULT 'open',
+    priority INTEGER NOT NULL DEFAULT 0,
+    labels TEXT NOT NULL DEFAULT '[]',
+    assignee_id TEXT,
+    claimed_by TEXT,
+    claimed_at REAL,
+    closed_at REAL,
+    closed_by TEXT,
+    close_reason TEXT,
+    created_by TEXT NOT NULL,
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_tasks_project ON project_tasks(project_id, status);
+CREATE INDEX IF NOT EXISTS idx_tasks_parent ON project_tasks(parent_task_id);
+
+CREATE TABLE IF NOT EXISTS task_relationships (
+    id TEXT PRIMARY KEY,
+    project_id TEXT NOT NULL,
+    from_task_id TEXT NOT NULL,
+    to_task_id TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    created_by TEXT NOT NULL,
+    created_at REAL NOT NULL,
+    UNIQUE (from_task_id, to_task_id, kind)
+);
+CREATE INDEX IF NOT EXISTS idx_rel_from ON task_relationships(from_task_id);
+CREATE INDEX IF NOT EXISTS idx_rel_to ON task_relationships(to_task_id);
+
+CREATE TABLE IF NOT EXISTS task_comments (
+    id TEXT PRIMARY KEY,
+    task_id TEXT NOT NULL,
+    author_id TEXT NOT NULL,
+    body TEXT NOT NULL DEFAULT '',
+    replies_to_comment_id TEXT,
+    created_at REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_comments_task ON task_comments(task_id, created_at);
+
+CREATE VIEW IF NOT EXISTS ready_tasks AS
+SELECT t.*
+FROM project_tasks t
+WHERE t.status = 'open'
+  AND t.claimed_by IS NULL
+  AND NOT EXISTS (
+      SELECT 1 FROM task_relationships r
+      JOIN project_tasks bt ON bt.id = r.to_task_id
+      WHERE r.from_task_id = t.id
+        AND r.kind = 'blocks'
+        AND bt.status NOT IN ('closed', 'cancelled')
+  );
+"""
+
+_TASK_JSON_FIELDS = ("labels",)
+
+
+def _row_to_task(row, description) -> dict:
+    keys = [d[0] for d in description]
+    t = dict(zip(keys, row))
+    for f in _TASK_JSON_FIELDS:
+        if f in t and t[f] is not None:
+            t[f] = json.loads(t[f])
+    return t
+
+
+class ProjectTaskStore(BaseStore):
+    SCHEMA = TASK_SCHEMA
+
+    async def create_task(
+        self,
+        project_id: str,
+        title: str,
+        created_by: str,
+        body: str = "",
+        priority: int = 0,
+        labels: list[str] | None = None,
+        assignee_id: str | None = None,
+        parent_task_id: str | None = None,
+    ) -> dict:
+        tid = new_id("tsk")
+        now = time.time()
+        await self._db.execute(
+            """INSERT INTO project_tasks
+               (id, project_id, parent_task_id, title, body, status, priority, labels,
+                assignee_id, created_by, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, 'open', ?, ?, ?, ?, ?, ?)""",
+            (
+                tid, project_id, parent_task_id, title, body, priority,
+                json.dumps(labels or []), assignee_id, created_by, now, now,
+            ),
+        )
+        await self._db.commit()
+        return await self.get_task(tid)
+
+    async def get_task(self, task_id: str) -> dict | None:
+        async with self._db.execute(
+            "SELECT * FROM project_tasks WHERE id = ?", (task_id,)
+        ) as cur:
+            row = await cur.fetchone()
+            if row is None:
+                return None
+            return _row_to_task(row, cur.description)

--- a/tinyagentos/projects/task_store.py
+++ b/tinyagentos/projects/task_store.py
@@ -203,3 +203,89 @@ class ProjectTaskStore(BaseStore):
         )
         await self._db.commit()
         return cursor.rowcount == 1
+
+    async def add_relationship(
+        self,
+        project_id: str,
+        from_task_id: str,
+        to_task_id: str,
+        kind: str,
+        created_by: str,
+    ) -> dict:
+        if kind not in ("blocks", "relates_to", "duplicates", "supersedes"):
+            raise ValueError(f"invalid relationship kind: {kind}")
+        rid = new_id("rel")
+        now = time.time()
+        await self._db.execute(
+            """INSERT INTO task_relationships
+               (id, project_id, from_task_id, to_task_id, kind, created_by, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (rid, project_id, from_task_id, to_task_id, kind, created_by, now),
+        )
+        await self._db.commit()
+        return {
+            "id": rid, "project_id": project_id, "from_task_id": from_task_id,
+            "to_task_id": to_task_id, "kind": kind, "created_by": created_by, "created_at": now,
+        }
+
+    async def remove_relationship(self, relationship_id: str) -> None:
+        await self._db.execute(
+            "DELETE FROM task_relationships WHERE id = ?", (relationship_id,)
+        )
+        await self._db.commit()
+
+    async def list_relationships(
+        self,
+        task_id: str,
+        direction: str = "from",
+    ) -> list[dict]:
+        col = "from_task_id" if direction == "from" else "to_task_id"
+        async with self._db.execute(
+            f"SELECT * FROM task_relationships WHERE {col} = ? ORDER BY created_at ASC",
+            (task_id,),
+        ) as cur:
+            rows = await cur.fetchall()
+            keys = [d[0] for d in cur.description]
+        return [dict(zip(keys, r)) for r in rows]
+
+    async def list_ready_tasks(self, project_id: str, limit: int = 50) -> list[dict]:
+        async with self._db.execute(
+            """SELECT * FROM ready_tasks
+               WHERE project_id = ?
+               ORDER BY priority DESC, created_at ASC
+               LIMIT ?""",
+            (project_id, limit),
+        ) as cur:
+            rows = await cur.fetchall()
+            desc = cur.description
+        return [_row_to_task(r, desc) for r in rows]
+
+    async def add_comment(
+        self,
+        task_id: str,
+        author_id: str,
+        body: str,
+        replies_to_comment_id: str | None = None,
+    ) -> dict:
+        cid = new_id("cmt")
+        now = time.time()
+        await self._db.execute(
+            """INSERT INTO task_comments
+               (id, task_id, author_id, body, replies_to_comment_id, created_at)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (cid, task_id, author_id, body, replies_to_comment_id, now),
+        )
+        await self._db.commit()
+        return {
+            "id": cid, "task_id": task_id, "author_id": author_id, "body": body,
+            "replies_to_comment_id": replies_to_comment_id, "created_at": now,
+        }
+
+    async def list_comments(self, task_id: str) -> list[dict]:
+        async with self._db.execute(
+            "SELECT * FROM task_comments WHERE task_id = ? ORDER BY created_at ASC",
+            (task_id,),
+        ) as cur:
+            rows = await cur.fetchall()
+            keys = [d[0] for d in cur.description]
+        return [dict(zip(keys, r)) for r in rows]

--- a/tinyagentos/projects/task_store.py
+++ b/tinyagentos/projects/task_store.py
@@ -182,7 +182,7 @@ class ProjectTaskStore(BaseStore):
         cursor = await self._db.execute(
             """UPDATE project_tasks
                SET claimed_by = NULL, claimed_at = NULL, status = 'open', updated_at = ?
-               WHERE id = ? AND claimed_by = ?""",
+               WHERE id = ? AND claimed_by = ? AND status = 'claimed'""",
             (now, task_id, releaser_id),
         )
         await self._db.commit()

--- a/tinyagentos/qmd_client.py
+++ b/tinyagentos/qmd_client.py
@@ -34,6 +34,30 @@ class QmdClient:
         resp = await with_retry(_call)
         return resp.json()["embedding"]
 
+    async def search(
+        self,
+        query: str,
+        collection: str | None = None,
+        tags: list[str] | None = None,
+        limit: int = 10,
+    ) -> list[dict]:
+        """Search documents via qmd serve /search."""
+        url = f"{self.base_url}/search"
+        client = self._client
+        payload: dict = {"query": query, "limit": limit}
+        if collection is not None:
+            payload["collection"] = collection
+        if tags is not None:
+            payload["tags"] = tags
+
+        async def _call():
+            resp = await client.post(url, json=payload)
+            resp.raise_for_status()
+            return resp
+
+        resp = await with_retry(_call)
+        return resp.json().get("items", [])
+
     async def health(self) -> dict:
         """Check qmd serve health."""
         start = time.monotonic()

--- a/tinyagentos/routes/github.py
+++ b/tinyagentos/routes/github.py
@@ -119,8 +119,26 @@ async def github_notifications(request: Request):
 
     http_client = request.app.state.http_client
     try:
-        notifications = await fetch_notifications(token, http_client)
-        return {"notifications": notifications, "count": len(notifications)}
+        raw_notifications = await fetch_notifications(token, http_client)
+        # Map notification objects to GitHubIssue shape expected by the frontend.
+        # GitHub notifications don't include state/comments/labels, so we use safe defaults.
+        notifications = [
+            {
+                "number": 0,
+                "title": n.get("subject_title", ""),
+                "state": "open",
+                "author": "",
+                "body": "",
+                "labels": [],
+                "comments": [],
+                "created_at": n.get("updated_at", ""),
+                "repo": n.get("repo_full_name", ""),
+                "is_pull_request": n.get("subject_type", "") == "PullRequest",
+            }
+            for n in raw_notifications
+        ]
+        unread_count = sum(1 for n in raw_notifications if n.get("unread", False))
+        return {"notifications": notifications, "unread_count": unread_count}
     except Exception as exc:
         logger.exception("github_notifications failed: %s", exc)
         return JSONResponse({"error": str(exc)}, status_code=500)

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -102,3 +102,70 @@ async def delete_project(project_id: str, request: Request):
     p = await store.get_project(project_id)
     await store.log_activity(project_id, _user_id(request), "project.deleted", {})
     return p
+
+
+class AddMemberIn(BaseModel):
+    mode: str  # "native" | "clone"
+    agent_id: str | None = None
+    source_agent_id: str | None = None
+    clone_memory: bool = True
+    role: str = "member"
+
+
+@router.post("/api/projects/{project_id}/members")
+async def add_member(project_id: str, payload: AddMemberIn, request: Request):
+    store = request.app.state.project_store
+    project = await store.get_project(project_id)
+    if project is None:
+        return JSONResponse({"error": "project not found"}, status_code=404)
+
+    if payload.mode == "native":
+        if not payload.agent_id:
+            return JSONResponse({"error": "agent_id required"}, status_code=400)
+        member_id = payload.agent_id
+        member_kind = "native"
+        source_agent_id = None
+        memory_seed = "none"
+    elif payload.mode == "clone":
+        if not payload.source_agent_id:
+            return JSONResponse({"error": "source_agent_id required"}, status_code=400)
+        member_id = f"{payload.source_agent_id}-{project['slug']}"
+        member_kind = "clone"
+        source_agent_id = payload.source_agent_id
+        memory_seed = "snapshot" if payload.clone_memory else "empty"
+    else:
+        return JSONResponse({"error": "mode must be native|clone"}, status_code=400)
+
+    await store.add_member(
+        project_id=project_id,
+        member_id=member_id,
+        member_kind=member_kind,
+        role=payload.role,
+        source_agent_id=source_agent_id,
+        memory_seed=memory_seed,
+    )
+    await store.log_activity(
+        project_id, _user_id(request), "member.added",
+        {"member_id": member_id, "kind": member_kind, "memory_seed": memory_seed},
+    )
+    members = await store.list_members(project_id)
+    _mirror(request, {**project, "members": members})
+    return next(m for m in members if m["member_id"] == member_id)
+
+
+@router.get("/api/projects/{project_id}/members")
+async def list_members(project_id: str, request: Request):
+    store = request.app.state.project_store
+    return {"items": await store.list_members(project_id)}
+
+
+@router.delete("/api/projects/{project_id}/members/{member_id}")
+async def remove_member(project_id: str, member_id: str, request: Request):
+    store = request.app.state.project_store
+    await store.remove_member(project_id, member_id)
+    await store.log_activity(project_id, _user_id(request), "member.removed", {"member_id": member_id})
+    project = await store.get_project(project_id)
+    members = await store.list_members(project_id)
+    if project is not None:
+        _mirror(request, {**project, "members": members})
+    return {"ok": True}

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -169,3 +169,136 @@ async def remove_member(project_id: str, member_id: str, request: Request):
     if project is not None:
         _mirror(request, {**project, "members": members})
     return {"ok": True}
+
+
+# ---------------------------------------------------------------------------
+# Task models
+# ---------------------------------------------------------------------------
+
+class CreateTaskIn(BaseModel):
+    title: str
+    body: str = ""
+    priority: int = 0
+    labels: list[str] = Field(default_factory=list)
+    assignee_id: str | None = None
+    parent_task_id: str | None = None
+
+
+class UpdateTaskIn(BaseModel):
+    title: str | None = None
+    body: str | None = None
+    priority: int | None = None
+    labels: list[str] | None = None
+    assignee_id: str | None = None
+
+
+class ClaimIn(BaseModel):
+    claimer_id: str
+
+
+class ReleaseIn(BaseModel):
+    releaser_id: str
+
+
+class CloseIn(BaseModel):
+    closed_by: str
+    reason: str | None = None
+
+
+class AddRelIn(BaseModel):
+    to_task_id: str
+    kind: str
+
+
+# ---------------------------------------------------------------------------
+# Task routes — order matters: /tasks/ready before /tasks/{task_id}
+# ---------------------------------------------------------------------------
+
+@router.post("/api/projects/{project_id}/tasks")
+async def create_task(project_id: str, payload: CreateTaskIn, request: Request):
+    store = request.app.state.project_task_store
+    t = await store.create_task(
+        project_id=project_id,
+        title=payload.title,
+        body=payload.body,
+        priority=payload.priority,
+        labels=payload.labels,
+        assignee_id=payload.assignee_id,
+        parent_task_id=payload.parent_task_id,
+        created_by=_user_id(request),
+    )
+    pstore = request.app.state.project_store
+    await pstore.log_activity(project_id, _user_id(request), "task.created", {"task_id": t["id"], "title": t["title"]})
+    return t
+
+
+@router.get("/api/projects/{project_id}/tasks")
+async def list_tasks(project_id: str, request: Request, status: str | None = None):
+    store = request.app.state.project_task_store
+    return {"items": await store.list_tasks(project_id=project_id, status=status)}
+
+
+@router.get("/api/projects/{project_id}/tasks/ready")
+async def ready_tasks(project_id: str, request: Request):
+    store = request.app.state.project_task_store
+    return {"items": await store.list_ready_tasks(project_id=project_id)}
+
+
+@router.get("/api/projects/{project_id}/tasks/{task_id}")
+async def get_task(project_id: str, task_id: str, request: Request):
+    store = request.app.state.project_task_store
+    t = await store.get_task(task_id)
+    if t is None or t["project_id"] != project_id:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    return t
+
+
+@router.patch("/api/projects/{project_id}/tasks/{task_id}")
+async def update_task(project_id: str, task_id: str, payload: UpdateTaskIn, request: Request):
+    store = request.app.state.project_task_store
+    await store.update_task(task_id, **payload.model_dump(exclude_none=True))
+    return await store.get_task(task_id)
+
+
+@router.post("/api/projects/{project_id}/tasks/{task_id}/claim")
+async def claim_task(project_id: str, task_id: str, payload: ClaimIn, request: Request):
+    store = request.app.state.project_task_store
+    ok = await store.claim_task(task_id, payload.claimer_id)
+    if not ok:
+        return JSONResponse({"error": "already claimed"}, status_code=409)
+    pstore = request.app.state.project_store
+    await pstore.log_activity(project_id, payload.claimer_id, "task.claimed", {"task_id": task_id})
+    return await store.get_task(task_id)
+
+
+@router.post("/api/projects/{project_id}/tasks/{task_id}/release")
+async def release_task(project_id: str, task_id: str, payload: ReleaseIn, request: Request):
+    store = request.app.state.project_task_store
+    ok = await store.release_task(task_id, payload.releaser_id)
+    if not ok:
+        return JSONResponse({"error": "not claimed by releaser"}, status_code=409)
+    return await store.get_task(task_id)
+
+
+@router.post("/api/projects/{project_id}/tasks/{task_id}/close")
+async def close_task(project_id: str, task_id: str, payload: CloseIn, request: Request):
+    store = request.app.state.project_task_store
+    ok = await store.close_task(task_id, closed_by=payload.closed_by, reason=payload.reason)
+    if not ok:
+        return JSONResponse({"error": "cannot close"}, status_code=409)
+    pstore = request.app.state.project_store
+    await pstore.log_activity(project_id, payload.closed_by, "task.closed", {"task_id": task_id})
+    return await store.get_task(task_id)
+
+
+@router.post("/api/projects/{project_id}/tasks/{task_id}/relationships")
+async def add_relationship(project_id: str, task_id: str, payload: AddRelIn, request: Request):
+    store = request.app.state.project_task_store
+    rel = await store.add_relationship(
+        project_id=project_id,
+        from_task_id=task_id,
+        to_task_id=payload.to_task_id,
+        kind=payload.kind,
+        created_by=_user_id(request),
+    )
+    return rel

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+
+from tinyagentos.projects.folders import ensure_project_layout, write_project_yaml
+
+router = APIRouter()
+
+
+class CreateProjectIn(BaseModel):
+    name: str
+    slug: str
+    description: str = ""
+    settings: dict = Field(default_factory=dict)
+
+
+class UpdateProjectIn(BaseModel):
+    name: str | None = None
+    description: str | None = None
+    settings: dict | None = None
+
+
+def _user_id(request: Request) -> str:
+    user = getattr(request.state, "user", None)
+    if user and isinstance(user, dict) and "id" in user:
+        return user["id"]
+    return "system"
+
+
+def _mirror(request: Request, project: dict) -> None:
+    root = request.app.state.projects_root
+    ensure_project_layout(root, project["slug"], project["name"])
+    write_project_yaml(root, project["slug"], project)
+
+
+@router.post("/api/projects")
+async def create_project(payload: CreateProjectIn, request: Request):
+    store = request.app.state.project_store
+    try:
+        p = await store.create_project(
+            name=payload.name,
+            slug=payload.slug,
+            description=payload.description,
+            settings=payload.settings,
+            created_by=_user_id(request),
+        )
+    except ValueError as e:
+        return JSONResponse({"error": str(e)}, status_code=409)
+    await store.log_activity(p["id"], _user_id(request), "project.created", {"slug": p["slug"]})
+    _mirror(request, p)
+    return p
+
+
+@router.get("/api/projects")
+async def list_projects(request: Request, status: str | None = "active"):
+    store = request.app.state.project_store
+    items = await store.list_projects(status=status)
+    return {"items": items}
+
+
+@router.get("/api/projects/{project_id}")
+async def get_project(project_id: str, request: Request):
+    store = request.app.state.project_store
+    p = await store.get_project(project_id)
+    if p is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    return p
+
+
+@router.patch("/api/projects/{project_id}")
+async def update_project(project_id: str, payload: UpdateProjectIn, request: Request):
+    store = request.app.state.project_store
+    await store.update_project(
+        project_id,
+        name=payload.name,
+        description=payload.description,
+        settings=payload.settings,
+    )
+    p = await store.get_project(project_id)
+    if p is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    await store.log_activity(project_id, _user_id(request), "project.updated", payload.model_dump(exclude_none=True))
+    _mirror(request, p)
+    return p
+
+
+@router.post("/api/projects/{project_id}/archive")
+async def archive_project(project_id: str, request: Request):
+    store = request.app.state.project_store
+    await store.set_status(project_id, "archived")
+    p = await store.get_project(project_id)
+    await store.log_activity(project_id, _user_id(request), "project.archived", {})
+    return p
+
+
+@router.delete("/api/projects/{project_id}")
+async def delete_project(project_id: str, request: Request):
+    store = request.app.state.project_store
+    await store.set_status(project_id, "deleted")
+    p = await store.get_project(project_id)
+    await store.log_activity(project_id, _user_id(request), "project.deleted", {})
+    return p

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -302,3 +302,32 @@ async def add_relationship(project_id: str, task_id: str, payload: AddRelIn, req
         created_by=_user_id(request),
     )
     return rel
+
+
+class AddCommentIn(BaseModel):
+    body: str
+    author_id: str
+    replies_to_comment_id: str | None = None
+
+
+@router.post("/api/projects/{project_id}/tasks/{task_id}/comments")
+async def add_comment(project_id: str, task_id: str, payload: AddCommentIn, request: Request):
+    store = request.app.state.project_task_store
+    return await store.add_comment(
+        task_id=task_id,
+        author_id=payload.author_id,
+        body=payload.body,
+        replies_to_comment_id=payload.replies_to_comment_id,
+    )
+
+
+@router.get("/api/projects/{project_id}/tasks/{task_id}/comments")
+async def list_comments(project_id: str, task_id: str, request: Request):
+    store = request.app.state.project_task_store
+    return {"items": await store.list_comments(task_id)}
+
+
+@router.get("/api/projects/{project_id}/tasks/{task_id}/relationships")
+async def list_relationships(project_id: str, task_id: str, request: Request, direction: str = "from"):
+    store = request.app.state.project_task_store
+    return {"items": await store.list_relationships(task_id, direction=direction)}

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
+import re
 import time as _time
 
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from tinyagentos.projects.folders import ensure_project_layout, write_project_yaml
 
 router = APIRouter()
+
+_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,62}$")
 
 
 class CreateProjectIn(BaseModel):
@@ -16,6 +19,13 @@ class CreateProjectIn(BaseModel):
     slug: str
     description: str = ""
     settings: dict = Field(default_factory=dict)
+
+    @field_validator("slug")
+    @classmethod
+    def _check_slug(cls, v: str) -> str:
+        if not _SLUG_RE.fullmatch(v):
+            raise ValueError("slug must match ^[a-z0-9][a-z0-9_-]{0,62}$")
+        return v
 
 
 class UpdateProjectIn(BaseModel):

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import re
 import time as _time
 
@@ -9,6 +10,7 @@ from pydantic import BaseModel, Field, field_validator
 
 from tinyagentos.projects.folders import ensure_project_layout, write_project_yaml
 
+logger = logging.getLogger(__name__)
 router = APIRouter()
 
 _SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,62}$")
@@ -42,9 +44,17 @@ def _user_id(request: Request) -> str:
 
 
 def _mirror(request: Request, project: dict) -> None:
-    root = request.app.state.projects_root
-    ensure_project_layout(root, project["slug"], project["name"])
-    write_project_yaml(root, project["slug"], project)
+    # Folder mirror is best-effort: if the disk write fails (permissions, full
+    # filesystem, transient I/O), the DB row is still authoritative and the
+    # request should succeed. Failures are logged for operator visibility.
+    try:
+        root = request.app.state.projects_root
+        ensure_project_layout(root, project["slug"], project["name"])
+        write_project_yaml(root, project["slug"], project)
+    except Exception as exc:
+        logger.warning(
+            "project folder mirror failed for slug=%s: %s", project.get("slug"), exc
+        )
 
 
 @router.post("/api/projects")
@@ -124,13 +134,19 @@ async def delete_project(project_id: str, request: Request):
     for ch in await channels.list_channels(project_id=project_id):
         await channels.set_settings(ch["id"], {"archived": True})
 
-    # Tombstone the folder rather than deleting on disk (recoverable)
-    root = request.app.state.projects_root
-    src = root / project["slug"]
-    if src.exists():
-        ts = int(_time.time())
-        dest = root / f"{project['slug']}.deleted-{ts}"
-        src.rename(dest)
+    # Tombstone the folder rather than deleting on disk (recoverable). Disk
+    # rename is best-effort; failure shouldn't block the DB tombstone.
+    try:
+        root = request.app.state.projects_root
+        src = root / project["slug"]
+        if src.exists():
+            ts = int(_time.time())
+            dest = root / f"{project['slug']}.deleted-{ts}"
+            src.rename(dest)
+    except Exception as exc:
+        logger.warning(
+            "project folder tombstone failed for slug=%s: %s", project.get("slug"), exc
+        )
 
     return await store.get_project(project_id)
 
@@ -339,13 +355,16 @@ async def close_task(project_id: str, task_id: str, payload: CloseIn, request: R
 @router.post("/api/projects/{project_id}/tasks/{task_id}/relationships")
 async def add_relationship(project_id: str, task_id: str, payload: AddRelIn, request: Request):
     store = request.app.state.project_task_store
-    rel = await store.add_relationship(
-        project_id=project_id,
-        from_task_id=task_id,
-        to_task_id=payload.to_task_id,
-        kind=payload.kind,
-        created_by=_user_id(request),
-    )
+    try:
+        rel = await store.add_relationship(
+            project_id=project_id,
+            from_task_id=task_id,
+            to_task_id=payload.to_task_id,
+            kind=payload.kind,
+            created_by=_user_id(request),
+        )
+    except ValueError as e:
+        return JSONResponse({"error": str(e)}, status_code=400)
     return rel
 
 
@@ -358,12 +377,15 @@ class AddCommentIn(BaseModel):
 @router.post("/api/projects/{project_id}/tasks/{task_id}/comments")
 async def add_comment(project_id: str, task_id: str, payload: AddCommentIn, request: Request):
     store = request.app.state.project_task_store
-    return await store.add_comment(
-        task_id=task_id,
-        author_id=payload.author_id,
-        body=payload.body,
-        replies_to_comment_id=payload.replies_to_comment_id,
-    )
+    try:
+        return await store.add_comment(
+            task_id=task_id,
+            author_id=payload.author_id,
+            body=payload.body,
+            replies_to_comment_id=payload.replies_to_comment_id,
+        )
+    except ValueError as e:
+        return JSONResponse({"error": str(e)}, status_code=400)
 
 
 @router.get("/api/projects/{project_id}/tasks/{task_id}/comments")

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import time as _time
+
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
@@ -98,10 +100,27 @@ async def archive_project(project_id: str, request: Request):
 @router.delete("/api/projects/{project_id}")
 async def delete_project(project_id: str, request: Request):
     store = request.app.state.project_store
+    project = await store.get_project(project_id)
+    if project is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+
     await store.set_status(project_id, "deleted")
-    p = await store.get_project(project_id)
     await store.log_activity(project_id, _user_id(request), "project.deleted", {})
-    return p
+
+    # Archive scoped chat channels
+    channels = request.app.state.chat_channels
+    for ch in await channels.list_channels(project_id=project_id):
+        await channels.set_settings(ch["id"], {"archived": True})
+
+    # Tombstone the folder rather than deleting on disk (recoverable)
+    root = request.app.state.projects_root
+    src = root / project["slug"]
+    if src.exists():
+        ts = int(_time.time())
+        dest = root / f"{project['slug']}.deleted-{ts}"
+        src.rename(dest)
+
+    return await store.get_project(project_id)
 
 
 class AddMemberIn(BaseModel):

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -264,6 +264,13 @@ class AddRelIn(BaseModel):
 @router.post("/api/projects/{project_id}/tasks")
 async def create_task(project_id: str, payload: CreateTaskIn, request: Request):
     store = request.app.state.project_task_store
+    pstore = request.app.state.project_store
+    if await pstore.get_project(project_id) is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    if payload.parent_task_id is not None:
+        parent = await store.get_task(payload.parent_task_id)
+        if parent is None or parent["project_id"] != project_id:
+            return JSONResponse({"error": "invalid parent_task_id"}, status_code=400)
     t = await store.create_task(
         project_id=project_id,
         title=payload.title,
@@ -274,7 +281,6 @@ async def create_task(project_id: str, payload: CreateTaskIn, request: Request):
         parent_task_id=payload.parent_task_id,
         created_by=_user_id(request),
     )
-    pstore = request.app.state.project_store
     await pstore.log_activity(project_id, _user_id(request), "task.created", {"task_id": t["id"], "title": t["title"]})
     return t
 
@@ -313,6 +319,9 @@ async def update_task(project_id: str, task_id: str, payload: UpdateTaskIn, requ
 @router.post("/api/projects/{project_id}/tasks/{task_id}/claim")
 async def claim_task(project_id: str, task_id: str, payload: ClaimIn, request: Request):
     store = request.app.state.project_task_store
+    existing = await store.get_task(task_id)
+    if existing is None or existing["project_id"] != project_id:
+        return JSONResponse({"error": "not found"}, status_code=404)
     ok = await store.claim_task(task_id, payload.claimer_id)
     if not ok:
         return JSONResponse({"error": "already claimed"}, status_code=409)
@@ -324,6 +333,9 @@ async def claim_task(project_id: str, task_id: str, payload: ClaimIn, request: R
 @router.post("/api/projects/{project_id}/tasks/{task_id}/release")
 async def release_task(project_id: str, task_id: str, payload: ReleaseIn, request: Request):
     store = request.app.state.project_task_store
+    existing = await store.get_task(task_id)
+    if existing is None or existing["project_id"] != project_id:
+        return JSONResponse({"error": "not found"}, status_code=404)
     ok = await store.release_task(task_id, payload.releaser_id)
     if not ok:
         return JSONResponse({"error": "not claimed by releaser"}, status_code=409)
@@ -333,6 +345,9 @@ async def release_task(project_id: str, task_id: str, payload: ReleaseIn, reques
 @router.post("/api/projects/{project_id}/tasks/{task_id}/close")
 async def close_task(project_id: str, task_id: str, payload: CloseIn, request: Request):
     store = request.app.state.project_task_store
+    existing = await store.get_task(task_id)
+    if existing is None or existing["project_id"] != project_id:
+        return JSONResponse({"error": "not found"}, status_code=404)
     ok = await store.close_task(task_id, closed_by=payload.closed_by, reason=payload.reason)
     if not ok:
         return JSONResponse({"error": "cannot close"}, status_code=409)
@@ -352,9 +367,21 @@ async def close_task(project_id: str, task_id: str, payload: CloseIn, request: R
     return task
 
 
+async def _require_task_in_project(
+    store, project_id: str, task_id: str
+) -> dict | JSONResponse:
+    task = await store.get_task(task_id)
+    if task is None or task["project_id"] != project_id:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    return task
+
+
 @router.post("/api/projects/{project_id}/tasks/{task_id}/relationships")
 async def add_relationship(project_id: str, task_id: str, payload: AddRelIn, request: Request):
     store = request.app.state.project_task_store
+    guard = await _require_task_in_project(store, project_id, task_id)
+    if isinstance(guard, JSONResponse):
+        return guard
     try:
         rel = await store.add_relationship(
             project_id=project_id,
@@ -377,6 +404,9 @@ class AddCommentIn(BaseModel):
 @router.post("/api/projects/{project_id}/tasks/{task_id}/comments")
 async def add_comment(project_id: str, task_id: str, payload: AddCommentIn, request: Request):
     store = request.app.state.project_task_store
+    guard = await _require_task_in_project(store, project_id, task_id)
+    if isinstance(guard, JSONResponse):
+        return guard
     try:
         return await store.add_comment(
             task_id=task_id,
@@ -391,12 +421,18 @@ async def add_comment(project_id: str, task_id: str, payload: AddCommentIn, requ
 @router.get("/api/projects/{project_id}/tasks/{task_id}/comments")
 async def list_comments(project_id: str, task_id: str, request: Request):
     store = request.app.state.project_task_store
+    guard = await _require_task_in_project(store, project_id, task_id)
+    if isinstance(guard, JSONResponse):
+        return guard
     return {"items": await store.list_comments(task_id)}
 
 
 @router.get("/api/projects/{project_id}/tasks/{task_id}/relationships")
 async def list_relationships(project_id: str, task_id: str, request: Request, direction: str = "from"):
     store = request.app.state.project_task_store
+    guard = await _require_task_in_project(store, project_id, task_id)
+    if isinstance(guard, JSONResponse):
+        return guard
     return {"items": await store.list_relationships(task_id, direction=direction)}
 
 

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -101,6 +101,8 @@ async def update_project(project_id: str, payload: UpdateProjectIn, request: Req
 @router.post("/api/projects/{project_id}/archive")
 async def archive_project(project_id: str, request: Request):
     store = request.app.state.project_store
+    if await store.get_project(project_id) is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
     await store.set_status(project_id, "archived")
     p = await store.get_project(project_id)
     await store.log_activity(project_id, _user_id(request), "project.archived", {})
@@ -285,6 +287,9 @@ async def get_task(project_id: str, task_id: str, request: Request):
 @router.patch("/api/projects/{project_id}/tasks/{task_id}")
 async def update_task(project_id: str, task_id: str, payload: UpdateTaskIn, request: Request):
     store = request.app.state.project_task_store
+    existing = await store.get_task(task_id)
+    if existing is None or existing["project_id"] != project_id:
+        return JSONResponse({"error": "not found"}, status_code=404)
     await store.update_task(task_id, **payload.model_dump(exclude_none=True))
     return await store.get_task(task_id)
 

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -288,7 +288,18 @@ async def close_task(project_id: str, task_id: str, payload: CloseIn, request: R
         return JSONResponse({"error": "cannot close"}, status_code=409)
     pstore = request.app.state.project_store
     await pstore.log_activity(project_id, payload.closed_by, "task.closed", {"task_id": task_id})
-    return await store.get_task(task_id)
+    project = await pstore.get_project(project_id)
+    task = await store.get_task(task_id)
+    qmd = getattr(request.app.state, "qmd_client", None)
+    if qmd is not None and project is not None and task is not None:
+        try:
+            from tinyagentos.projects.lifecycle import index_closed_task
+            await index_closed_task(qmd, project, task)
+        except Exception:
+            await pstore.log_activity(
+                project_id, payload.closed_by, "task.qmd_index_failed", {"task_id": task_id}
+            )
+    return task
 
 
 @router.post("/api/projects/{project_id}/tasks/{task_id}/relationships")

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -348,3 +348,21 @@ async def list_relationships(project_id: str, task_id: str, request: Request, di
 async def activity_feed(project_id: str, request: Request, limit: int = 100):
     store = request.app.state.project_store
     return {"items": await store.list_activity(project_id, limit=limit)}
+
+
+@router.get("/api/projects/{project_id}/memory/search")
+async def memory_search(project_id: str, request: Request, q: str, limit: int = 10):
+    store = request.app.state.project_store
+    project = await store.get_project(project_id)
+    if project is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    qmd = getattr(request.app.state, "qmd_client", None)
+    if qmd is None:
+        return {"items": []}
+    items = await qmd.search(
+        q,
+        collection=f"project-{project['slug']}",
+        tags=[f"project:{project_id}"],
+        limit=limit,
+    )
+    return {"items": items}

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -331,3 +331,9 @@ async def list_comments(project_id: str, task_id: str, request: Request):
 async def list_relationships(project_id: str, task_id: str, request: Request, direction: str = "from"):
     store = request.app.state.project_task_store
     return {"items": await store.list_relationships(task_id, direction=direction)}
+
+
+@router.get("/api/projects/{project_id}/activity")
+async def activity_feed(project_id: str, request: Request, limit: int = 100):
+    store = request.app.state.project_store
+    return {"items": await store.list_activity(project_id, limit=limit)}


### PR DESCRIPTION
## Summary

Foundation for the new Projects app: backend stores, routes, lifecycle, plus the frontend Projects app shell. Cross-app embedding (Tasks 25/26) is deferred to follow-up specs (see below).

### Backend (Phases 1-4 — Tasks 1-18)
- Hash-id generator (`prj-`, `tsk-`, `cmt-`, `rel-`), base32 alphabet
- `ProjectStore` — projects, members (native + clone with memory_seed), activity feed; statuses `active|archived|deleted`
- `ProjectTaskStore` — Beads-pattern task graph: hierarchy via `parent_task_id`, relationships (`blocks|relates_to|duplicates|supersedes`), atomic claim, threaded comments, `ready_tasks` SQL VIEW
- Folder mirror: `~/Projects/<slug>/{project.yaml, README.md, memory/, canvas/, files/}`
- Routes: full CRUD for projects, members, tasks; ready/claim/release/close; comments; relationships; activity feed; per-project memory search (QMD-backed)
- Lifecycle: on-close indexing into per-project QMD collection (`project-<slug>`); delete cascade archives scoped channels and tombstones the folder
- Chat channels gain `project_id` column for scoping
- Slug validator rejects path-traversal inputs (addresses CodeRabbit critical finding)
- 42 tests passing across `tests/projects/` and `tests/test_routes_projects.py`

### Frontend (Phase 5 — Tasks 19-24)
- Typed API client at `desktop/src/lib/projects.ts`
- App-registry entry (`folder-kanban` icon, launchpadOrder 1.5, pinned)
- `ProjectsApp` shell — sidebar list + tabbed workspace (tasks/members/activity)
- `CreateProjectDialog` — slug auto-derived from name, validates `[a-z0-9-]+`
- `AddAgentDialog` — Native/Clone radio with locked tooltip when source is "new agent"; clone-memory checkbox
- `ProjectMembers` tab; `ProjectTaskList` (ready/claimed/closed) with claim/release/close; `ProjectActivity` feed
- `tsc --noEmit` green

### Deferred to follow-up specs

Two cross-app embedding tasks are pulled out into their own brainstorm cycles because the affected apps are large and the original spec was hand-wavy about how to fit project scoping into existing models:

- **Task 25 — FilesApp scoping** — current FilesApp uses a location-based model (workspace/agent/shared/recycle), not a path-based one. Project files need a new location type plus backend API extension, not a simple `rootPath` prop. Worth its own design pass.
- **Task 26 — MessagesApp scope + Projects sidebar** — 2083-line app; needs careful sidebar restructure with collapsible Project groups, scoped channel-create flow, and clone-only filtering for cloned-agent DMs.

## Test plan
- [x] `pytest tests/projects/ tests/test_routes_projects.py -v` — 42 passed locally
- [x] `cd desktop && npx tsc --noEmit` — green
- [ ] CI green
- [ ] Smoke: create project via UI, add native + clone agents, add tasks, walk ready→claimed→closed
- [ ] Smoke: archive then delete project; confirm folder tombstone + channel archival

Plan: `docs/superpowers/plans/2026-04-25-projects-app-foundation-plan.md`
Spec: `docs/superpowers/specs/2026-04-25-projects-app-foundation-design.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full project management API and persistence (projects, members, activity), task system (create/claim/release/close, relationships, ready view, threaded comments), project-scoped indexing/search, and desktop Projects app (list, workspace, tasks, members, activity, dialogs).

* **Enhancements**
  * GitHub notifications normalized and per-repo fork counts; chat channels now support optional project association.

* **Tests**
  * Extensive new tests covering projects, tasks, stores, routing, lifecycle, folders, and app wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->