### PR TITLE
fix(ci): ignore unfixed pip CVE-2026-3219 in dependency-audit

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,4 +26,6 @@ jobs:
         run: pip install -e ".[dev]"
 
       - name: Check for known vulnerabilities
-        run: pip install pip-audit && pip-audit
+        # CVE-2026-3219 affects pip itself with no fix released yet; revisit once
+        # a patched pip is available on PyPI.
+        run: pip install pip-audit && pip-audit --ignore-vuln CVE-2026-3219


### PR DESCRIPTION
## Summary
- `pip-audit` flags `pip 26.0.1` itself for CVE-2026-3219, but the advisory has no fix versions published yet — the runner is already on the latest pip
- Pass `--ignore-vuln CVE-2026-3219` so the audit job tracks vulnerabilities in our own dependency tree instead of staying red on something we can't act on
- Remove the ignore once a patched pip lands on PyPI

## Test plan
- [ ] Security workflow on this PR shows `dependency-audit` green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted dependency vulnerability scanning: temporarily exempt a known pip-related finding so automated audits complete reliably; will resume full checks once a patched package is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->