### PR TITLE
test(trace): bump close()-drain wait to unflake test_late_event on 3.11

### DIFF
--- a/tests/test_trace_store.py
+++ b/tests/test_trace_store.py
@@ -411,10 +411,10 @@ async def test_late_event_writes_late_jsonl_not_db(tmp_path):
         mock_time.time.return_value = old_ts
         await store.record("lifecycle", created_at=old_ts, payload={"event": "old"})
     await store.close()
-    # aiosqlite's worker thread on Python 3.10 can return from close() before
-    # the underlying SQLite connection FD is fully released; yield once to let
-    # the worker finish draining so our chmod below takes effect on every FD.
-    await asyncio.sleep(0.05)
+    # aiosqlite's worker thread can return from close() before the underlying
+    # SQLite connection FD is fully released; yield long enough for the worker
+    # to drain so the chmod below takes effect on every FD across CI runners.
+    await asyncio.sleep(0.5)
 
     db_path = _bucket_db_path(tmp_path, "agent-seal-c", old_bucket)
     late_path = _bucket_late_jsonl_path(tmp_path, "agent-seal-c", old_bucket)


### PR DESCRIPTION
## Summary
- Same race the b3fd137 sleep was meant to fix, now hitting Python 3.11 in CI: aiosqlite's worker can return from `close()` before the SQLite FD is released, so the test's chmod-based bucket seal misses an open FD and the next event lands in `.db` instead of `.late.jsonl`
- Bumps the post-close yield from 0.05s to 0.5s so the worker has enough time to drain on every matrix entry; still effectively instant in test time

## Test plan
- [ ] CI green on this PR (3.10/3.11/3.12/3.13)