### PR TITLE
feat(projects): cross-app embedding — Files + Messages in ProjectWorkspace

### DIFF
--- a/desktop/src/apps/FilesApp.tsx
+++ b/desktop/src/apps/FilesApp.tsx
@@ -135,6 +135,16 @@ function agentSlug(location: string): string {
   return location.slice(AGENT_LOCATION_PREFIX.length);
 }
 
+const PROJECT_LOCATION_PREFIX = "project:";
+
+function isProjectLocation(loc: string): boolean {
+  return loc.startsWith(PROJECT_LOCATION_PREFIX);
+}
+
+function projectSlug(loc: string): string {
+  return loc.slice(PROJECT_LOCATION_PREFIX.length);
+}
+
 function fileUrl(location: "workspace" | string, path: string): string {
   const encoded = encodeURIComponent(path);
   if (location === "workspace") {
@@ -142,6 +152,9 @@ function fileUrl(location: "workspace" | string, path: string): string {
   }
   if (isAgentLocation(location)) {
     return `/api/agents/${encodeURIComponent(agentSlug(location))}/workspace/files/${encoded}`;
+  }
+  if (isProjectLocation(location)) {
+    return `/api/projects/${encodeURIComponent(projectSlug(location))}/files/${encoded}`;
   }
   return `/api/shared-folders/${encodeURIComponent(location)}/files/${encoded}`;
 }
@@ -159,6 +172,9 @@ function workspaceListUrl(location: "workspace" | string, path: string): string 
   if (isAgentLocation(location)) {
     return `/api/agents/${encodeURIComponent(agentSlug(location))}/workspace/files${qs}`;
   }
+  if (isProjectLocation(location)) {
+    return `/api/projects/${encodeURIComponent(projectSlug(location))}/files${qs}`;
+  }
   return `/api/shared-folders/${encodeURIComponent(location)}/files`;
 }
 
@@ -167,6 +183,9 @@ function workspaceWatchUrl(location: "workspace" | string, path: string): string
   if (location === "workspace") return `/api/workspace/files/watch${qs}`;
   if (isAgentLocation(location)) {
     return `/api/agents/${encodeURIComponent(agentSlug(location))}/workspace/files/watch${qs}`;
+  }
+  if (isProjectLocation(location)) {
+    return `/api/projects/${encodeURIComponent(projectSlug(location))}/files/watch${qs}`;
   }
   return null;
 }
@@ -177,6 +196,9 @@ function workspaceUploadUrl(location: "workspace" | string, path: string): strin
   if (isAgentLocation(location)) {
     return `/api/agents/${encodeURIComponent(agentSlug(location))}/workspace/files/upload${qs}`;
   }
+  if (isProjectLocation(location)) {
+    return `/api/projects/${encodeURIComponent(projectSlug(location))}/files/upload${qs}`;
+  }
   return `/api/shared-folders/${encodeURIComponent(location)}/upload`;
 }
 
@@ -184,6 +206,9 @@ function workspaceMkdirUrl(location: "workspace" | string): string | null {
   if (location === "workspace") return `/api/workspace/mkdir`;
   if (isAgentLocation(location)) {
     return `/api/agents/${encodeURIComponent(agentSlug(location))}/workspace/mkdir`;
+  }
+  if (isProjectLocation(location)) {
+    return `/api/projects/${encodeURIComponent(projectSlug(location))}/mkdir`;
   }
   return null;
 }
@@ -194,6 +219,9 @@ function workspaceDeleteUrl(location: "workspace" | string, path: string): strin
   if (isAgentLocation(location)) {
     return `/api/agents/${encodeURIComponent(agentSlug(location))}/workspace/files/${encoded}`;
   }
+  if (isProjectLocation(location)) {
+    return `/api/projects/${encodeURIComponent(projectSlug(location))}/files/${encoded}`;
+  }
   return null;
 }
 
@@ -201,6 +229,9 @@ function workspaceStatsUrl(location: "workspace" | string): string | null {
   if (location === "workspace") return `/api/workspace/stats`;
   if (isAgentLocation(location)) {
     return `/api/agents/${encodeURIComponent(agentSlug(location))}/workspace/stats`;
+  }
+  if (isProjectLocation(location)) {
+    return `/api/projects/${encodeURIComponent(projectSlug(location))}/stats`;
   }
   return null;
 }
@@ -364,11 +395,14 @@ function FileRow({
 /*  Component                                                          */
 /* ------------------------------------------------------------------ */
 
-export function FilesApp({ windowId: _windowId }: { windowId: string }) {
+export function FilesApp({
+  windowId: _windowId,
+  rootPath,
+}: { windowId: string; rootPath?: string }) {
   const isMobile = useIsMobile();
 
   const [currentPath, setCurrentPath] = useState("");
-  const [location, setLocation] = useState<"workspace" | string>("workspace");
+  const [location, setLocation] = useState<"workspace" | string>(() => rootPath ?? "workspace");
   const [files, setFiles] = useState<FileEntry[]>([]);
   const [sharedFolders, setSharedFolders] = useState<SharedFolder[]>([]);
   const [agents, setAgents] = useState<AgentSummary[] | null>(null);
@@ -393,9 +427,9 @@ export function FilesApp({ windowId: _windowId }: { windowId: string }) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const dragCounter = useRef(0);
 
-  // Workspace locations (user + per-agent) allow mutations and the stats
+  // Workspace locations (user + per-agent + project) allow mutations and the stats
   // endpoint. Shared folders and the recycle bin are read-only here.
-  const isWritable = location === "workspace" || isAgentLocation(location);
+  const isWritable = location === "workspace" || isAgentLocation(location) || isProjectLocation(location);
   const locationTitle =
     location === "recycle"
       ? "Recycle Bin"
@@ -403,7 +437,9 @@ export function FilesApp({ windowId: _windowId }: { windowId: string }) {
         ? "Workspace"
         : isAgentLocation(location)
           ? agents?.find((a) => a.name === agentSlug(location))?.display_name ?? agentSlug(location)
-          : location;
+          : isProjectLocation(location)
+            ? projectSlug(location)
+            : location;
 
   /* ---- Fetch files ---- */
   const fetchFiles = useCallback(async (path = "") => {

--- a/desktop/src/apps/FilesApp.tsx
+++ b/desktop/src/apps/FilesApp.tsx
@@ -416,7 +416,7 @@ export function FilesApp({
   const [sharedExpanded, setSharedExpanded] = useState(true);
   const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null);
   // null = showing sidebar (list pane); non-null = showing file browser (detail pane)
-  const [selectedLocation, setSelectedLocation] = useState<string | null>(null);
+  const [selectedLocation, setSelectedLocation] = useState<string | null>(rootPath ?? null);
 
   // Recycle bin
   const [recycleItems, setRecycleItems] = useState<RecycleItem[]>([]);

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -58,6 +58,7 @@ import {
   editMessage as apiEditMessage, deleteMessage as apiDeleteMessage,
   markUnread as apiMarkUnread,
 } from "@/lib/chat-messages-api";
+import { projectsApi, type Project } from "@/lib/projects";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -85,6 +86,7 @@ interface Channel {
   created_at?: string;
   last_message_at?: string;
   lastPreview?: string;
+  project_id?: string;
   settings?: {
     archived?: boolean;
     archived_at?: string;
@@ -206,7 +208,15 @@ const EMOJI_PICKER = ["👍", "❤️", "😂", "🎉", "🤔", "👀", "🚀", 
 /*  MessagesApp                                                        */
 /* ------------------------------------------------------------------ */
 
-export function MessagesApp({ windowId: _windowId, title }: { windowId: string; title?: string }) {
+export function MessagesApp({
+  windowId: _windowId,
+  title,
+  scope,
+}: {
+  windowId: string;
+  title?: string;
+  scope?: { projectId?: string };
+}) {
   const isMobile = useIsMobile();
   const { keyboardInset } = useVisualViewport();
 
@@ -266,6 +276,7 @@ export function MessagesApp({ windowId: _windowId, title }: { windowId: string; 
   const [pinnedPopoverOpen, setPinnedPopoverOpen] = useState(false);
   const [pinnedMessages, setPinnedMessages] = useState<PinnedMessage[]>([]);
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+  const [projects, setProjects] = useState<Project[]>([]);
   const { openThread, openThreadFor, closeThread } = useThreadPanel();
 
   const wsRef = useRef<WebSocket | null>(null);
@@ -281,8 +292,9 @@ export function MessagesApp({ windowId: _windowId, title }: { windowId: string; 
   /* ---- fetch channels + unread ---- */
   const fetchChannels = useCallback(async () => {
     try {
+      const qs = scope?.projectId ? `?project_id=${encodeURIComponent(scope.projectId)}` : "";
       const [chRes, unRes] = await Promise.all([
-        fetch("/api/chat/channels"),
+        fetch(`/api/chat/channels${qs}`),
         fetch("/api/chat/unread"),
       ]);
       if (chRes.ok) {
@@ -296,12 +308,15 @@ export function MessagesApp({ windowId: _windowId, title }: { windowId: string; 
     } catch {
       /* offline */
     }
-  }, []);
+  }, [scope?.projectId]);
 
   /* ---- fetch archived channels ---- */
   const fetchArchivedChannels = useCallback(async () => {
     try {
-      const res = await fetch("/api/chat/channels?archived=true");
+      const url = scope?.projectId
+        ? `/api/chat/channels?archived=true&project_id=${encodeURIComponent(scope.projectId)}`
+        : "/api/chat/channels?archived=true";
+      const res = await fetch(url);
       if (res.ok) {
         const data = await res.json();
         setArchivedChannels(data.channels ?? []);
@@ -309,7 +324,7 @@ export function MessagesApp({ windowId: _windowId, title }: { windowId: string; 
     } catch {
       /* offline */
     }
-  }, []);
+  }, [scope?.projectId]);
 
   /* ---- fetch agent lists for author resolution ---- */
   const fetchAgentLists = useCallback(async () => {
@@ -509,6 +524,14 @@ export function MessagesApp({ windowId: _windowId, title }: { windowId: string; 
       }
     };
   }, [fetchChannels, fetchArchivedChannels, fetchAgentLists, connectWs]);
+
+  /* ---- fetch project list for sidebar grouping (standalone mode only) ---- */
+  useEffect(() => {
+    if (scope?.projectId) return;
+    let cancelled = false;
+    projectsApi.list("active").then((p) => { if (!cancelled) setProjects(p); }).catch(() => {});
+    return () => { cancelled = true; };
+  }, [scope?.projectId]);
 
   /* ---- fetch current user ---- */
   useEffect(() => {
@@ -839,6 +862,7 @@ export function MessagesApp({ windowId: _windowId, title }: { windowId: string; 
           name: newChannel.name.trim(),
           type: newChannel.type,
           description: newChannel.description.trim() || undefined,
+          ...(scope?.projectId ? { project_id: scope.projectId } : {}),
         }),
       });
       if (res.ok) {
@@ -971,15 +995,32 @@ export function MessagesApp({ windowId: _windowId, title }: { windowId: string; 
   };
 
   /* ---- group channels by type ---- */
+  const isRoot = (c: Channel) => !c.project_id;
   const grouped = {
-    dm: channels.filter((c) => c.type === "dm"),
-    topic: channels.filter((c) => c.type === "topic"),
-    group: channels.filter((c) => c.type === "group"),
+    dm: channels.filter((c) => c.type === "dm" && isRoot(c)),
+    topic: channels.filter((c) => c.type === "topic" && isRoot(c)),
+    group: channels.filter((c) => c.type === "group" && isRoot(c)),
   };
 
   const allChannels = [...channels, ...archivedChannels];
   const currentChannel = allChannels.find((c) => c.id === selectedChannel);
   const isCurrentArchived = currentChannel?.settings?.archived === true;
+
+  /* ---- project-grouped channels for sidebar (standalone mode) ---- */
+  const projectGroups = (() => {
+    const projectChannels = channels.filter((c) => c.project_id);
+    if (!projectChannels.length) return [];
+    const byId = new Map<string, { id: string; name: string; channels: Channel[] }>();
+    for (const ch of projectChannels) {
+      const pid = ch.project_id!;
+      if (!byId.has(pid)) {
+        const proj = projects.find((p) => p.id === pid);
+        byId.set(pid, { id: pid, name: proj ? proj.name : pid, channels: [] });
+      }
+      byId.get(pid)!.channels.push(ch);
+    }
+    return Array.from(byId.values());
+  })();
 
   /* ---------------------------------------------------------------- */
   /*  Sections definition (shared between mobile + desktop lists)     */
@@ -1061,6 +1102,53 @@ export function MessagesApp({ windowId: _windowId, title }: { windowId: string; 
           )}
         </div>
       ))}
+
+      {/* Projects section — mobile (standalone mode only) */}
+      {!scope?.projectId && projectGroups.length > 0 && (
+        <div style={{ marginBottom: 20 }}>
+          <div style={{ fontSize: 12, textTransform: "uppercase", letterSpacing: 0.5, color: "rgba(255,255,255,0.45)", padding: "0 20px 6px", fontWeight: 600 }}>
+            Projects
+          </div>
+          {projectGroups.map((g) => (
+            <div key={g.id} style={{ marginBottom: 12 }}>
+              <div style={{ fontSize: 11, color: "rgba(255,255,255,0.5)", padding: "0 20px 4px", fontWeight: 600 }}>{g.name}</div>
+              <div style={{ margin: "0 12px", borderRadius: 16, background: "rgba(255,255,255,0.05)", border: "1px solid rgba(255,255,255,0.08)", overflow: "hidden" }}>
+                {g.channels.map((ch, idx, arr) => (
+                  <button
+                    key={ch.id}
+                    type="button"
+                    onClick={() => setSelectedChannel(ch.id)}
+                    aria-label={`Channel ${ch.name}`}
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 10,
+                      width: "100%",
+                      padding: "14px 16px",
+                      background: selectedChannel === ch.id ? "rgba(59,130,246,0.15)" : "none",
+                      border: "none",
+                      borderBottom: idx === arr.length - 1 ? "none" : "1px solid rgba(255,255,255,0.06)",
+                      cursor: "pointer",
+                      color: "inherit",
+                      textAlign: "left",
+                    }}
+                  >
+                    <span style={{ flex: 1, fontSize: 15, fontWeight: 400, color: "rgba(255,255,255,0.9)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                      {ch.name}
+                    </span>
+                    {(unread[ch.id] ?? 0) > 0 && (
+                      <span style={{ background: "#3b82f6", color: "#fff", fontSize: 10, fontWeight: 700, borderRadius: 9999, minWidth: 18, height: 18, display: "flex", alignItems: "center", justifyContent: "center", padding: "0 4px" }}>
+                        {unread[ch.id]}
+                      </span>
+                    )}
+                    <ChevronRight size={16} style={{ color: "rgba(255,255,255,0.25)", flexShrink: 0 }} />
+                  </button>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
 
       {/* Archived channels section — mobile */}
       {archivedChannels.length > 0 && (
@@ -1172,6 +1260,35 @@ export function MessagesApp({ windowId: _windowId, title }: { windowId: string; 
             ))}
           </div>
         ))}
+
+        {/* Projects section — desktop (standalone mode only) */}
+        {!scope?.projectId && projectGroups.length > 0 && (
+          <details className="px-3 mt-2">
+            <summary className="cursor-pointer text-[10px] font-semibold uppercase tracking-wider text-white/30 py-1">
+              Projects
+            </summary>
+            {projectGroups.map((g) => (
+              <details key={g.id} className="ml-2 mt-1">
+                <summary className="cursor-pointer text-xs text-white/60 py-1">{g.name}</summary>
+                <div className="ml-2 mt-0.5">
+                  {g.channels.map((ch) => (
+                    <button
+                      key={ch.id}
+                      type="button"
+                      onClick={() => setSelectedChannel(ch.id)}
+                      aria-pressed={selectedChannel === ch.id}
+                      className={`w-full text-left text-xs py-1 px-2 rounded ${
+                        selectedChannel === ch.id ? "bg-white/10" : "hover:bg-white/5"
+                      }`}
+                    >
+                      {ch.name}
+                    </button>
+                  ))}
+                </div>
+              </details>
+            ))}
+          </details>
+        )}
 
         {/* Archived channels section — desktop */}
         {archivedChannels.length > 0 && (

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -248,6 +248,8 @@ export function MessagesApp({
   });
   const [archivedChannels, setArchivedChannels] = useState<Channel[]>([]);
   const [archivedExpanded, setArchivedExpanded] = useState(false);
+  const [projectsExpanded, setProjectsExpanded] = useState(true);
+  const [projectChannelExpanded, setProjectChannelExpanded] = useState<Record<string, boolean>>({});
   const [liveAgents, setLiveAgents] = useState<LiveAgent[]>([]);
   const [archivedAgents, setArchivedAgents] = useState<ArchivedAgentEntry[]>([]);
   const [selectedChannel, setSelectedChannel] = useState<string | null>(null);
@@ -1106,47 +1108,70 @@ export function MessagesApp({
       {/* Projects section — mobile (standalone mode only) */}
       {!scope?.projectId && projectGroups.length > 0 && (
         <div style={{ marginBottom: 20 }}>
-          <div style={{ fontSize: 12, textTransform: "uppercase", letterSpacing: 0.5, color: "rgba(255,255,255,0.45)", padding: "0 20px 6px", fontWeight: 600 }}>
-            Projects
-          </div>
-          {projectGroups.map((g) => (
-            <div key={g.id} style={{ marginBottom: 12 }}>
-              <div style={{ fontSize: 11, color: "rgba(255,255,255,0.5)", padding: "0 20px 4px", fontWeight: 600 }}>{g.name}</div>
-              <div style={{ margin: "0 12px", borderRadius: 16, background: "rgba(255,255,255,0.05)", border: "1px solid rgba(255,255,255,0.08)", overflow: "hidden" }}>
-                {g.channels.map((ch, idx, arr) => (
+          <button
+            type="button"
+            onClick={() => setProjectsExpanded((v) => !v)}
+            aria-expanded={projectsExpanded}
+            aria-controls="projects-section-mobile"
+            style={{ fontSize: 12, textTransform: "uppercase" as const, letterSpacing: 0.5, color: "rgba(255,255,255,0.45)", padding: "0 20px 6px", fontWeight: 600, display: "flex", alignItems: "center", gap: 6, background: "none", border: "none", cursor: "pointer", width: "100%" }}
+          >
+            <ChevronRight size={12} style={{ transition: "transform 0.15s", transform: projectsExpanded ? "rotate(90deg)" : "none", color: "rgba(255,255,255,0.3)" }} aria-hidden="true" />
+            Projects ({projectGroups.length})
+          </button>
+          <div id="projects-section-mobile" style={{ display: projectsExpanded ? "block" : "none" }}>
+            {projectGroups.map((g) => {
+              const isOpen = projectChannelExpanded[g.id] !== false;
+              return (
+                <div key={g.id} style={{ marginBottom: 12 }}>
                   <button
-                    key={ch.id}
                     type="button"
-                    onClick={() => setSelectedChannel(ch.id)}
-                    aria-label={`Channel ${ch.name}`}
-                    style={{
-                      display: "flex",
-                      alignItems: "center",
-                      gap: 10,
-                      width: "100%",
-                      padding: "14px 16px",
-                      background: selectedChannel === ch.id ? "rgba(59,130,246,0.15)" : "none",
-                      border: "none",
-                      borderBottom: idx === arr.length - 1 ? "none" : "1px solid rgba(255,255,255,0.06)",
-                      cursor: "pointer",
-                      color: "inherit",
-                      textAlign: "left",
-                    }}
+                    onClick={() => setProjectChannelExpanded((prev) => ({ ...prev, [g.id]: !isOpen }))}
+                    aria-expanded={isOpen}
+                    aria-controls={`project-section-mobile-${g.id}`}
+                    style={{ fontSize: 11, color: "rgba(255,255,255,0.5)", padding: "0 20px 4px", fontWeight: 600, display: "flex", alignItems: "center", gap: 6, background: "none", border: "none", cursor: "pointer", width: "100%" }}
                   >
-                    <span style={{ flex: 1, fontSize: 15, fontWeight: 400, color: "rgba(255,255,255,0.9)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                      {ch.name}
-                    </span>
-                    {(unread[ch.id] ?? 0) > 0 && (
-                      <span style={{ background: "#3b82f6", color: "#fff", fontSize: 10, fontWeight: 700, borderRadius: 9999, minWidth: 18, height: 18, display: "flex", alignItems: "center", justifyContent: "center", padding: "0 4px" }}>
-                        {unread[ch.id]}
-                      </span>
-                    )}
-                    <ChevronRight size={16} style={{ color: "rgba(255,255,255,0.25)", flexShrink: 0 }} />
+                    <ChevronRight size={10} style={{ transition: "transform 0.15s", transform: isOpen ? "rotate(90deg)" : "none", color: "rgba(255,255,255,0.3)" }} aria-hidden="true" />
+                    {g.name}
                   </button>
-                ))}
-              </div>
-            </div>
-          ))}
+                  <div id={`project-section-mobile-${g.id}`} style={{ display: isOpen ? "block" : "none" }}>
+                    <div style={{ margin: "0 12px", borderRadius: 16, background: "rgba(255,255,255,0.05)", border: "1px solid rgba(255,255,255,0.08)", overflow: "hidden" }}>
+                      {g.channels.map((ch, idx, arr) => (
+                        <button
+                          key={ch.id}
+                          type="button"
+                          onClick={() => setSelectedChannel(ch.id)}
+                          aria-label={`Channel ${ch.name}`}
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 10,
+                            width: "100%",
+                            padding: "14px 16px",
+                            background: selectedChannel === ch.id ? "rgba(59,130,246,0.15)" : "none",
+                            border: "none",
+                            borderBottom: idx === arr.length - 1 ? "none" : "1px solid rgba(255,255,255,0.06)",
+                            cursor: "pointer",
+                            color: "inherit",
+                            textAlign: "left",
+                          }}
+                        >
+                          <span style={{ flex: 1, fontSize: 15, fontWeight: 400, color: "rgba(255,255,255,0.9)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                            {ch.name}
+                          </span>
+                          {(unread[ch.id] ?? 0) > 0 && (
+                            <span style={{ background: "#3b82f6", color: "#fff", fontSize: 10, fontWeight: 700, borderRadius: 9999, minWidth: 18, height: 18, display: "flex", alignItems: "center", justifyContent: "center", padding: "0 4px" }}>
+                              {unread[ch.id]}
+                            </span>
+                          )}
+                          <ChevronRight size={16} style={{ color: "rgba(255,255,255,0.25)", flexShrink: 0 }} />
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
         </div>
       )}
 
@@ -1277,6 +1302,7 @@ export function MessagesApp({
                       type="button"
                       onClick={() => setSelectedChannel(ch.id)}
                       aria-pressed={selectedChannel === ch.id}
+                      aria-label={`Channel ${ch.name}`}
                       className={`w-full text-left text-xs py-1 px-2 rounded ${
                         selectedChannel === ch.id ? "bg-white/10" : "hover:bg-white/5"
                       }`}

--- a/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
@@ -4,8 +4,9 @@ import { ProjectTaskList } from "./ProjectTaskList";
 import { ProjectMembers } from "./ProjectMembers";
 import { ProjectActivity } from "./ProjectActivity";
 import { FilesApp } from "@/apps/FilesApp";
+import { MessagesApp } from "@/apps/MessagesApp";
 
-type Tab = "tasks" | "files" | "members" | "activity";
+type Tab = "tasks" | "files" | "messages" | "members" | "activity";
 
 export function ProjectWorkspace({ project, onChanged }: { project: Project; onChanged: () => void }) {
   const [tab, setTab] = useState<Tab>("tasks");
@@ -16,7 +17,7 @@ export function ProjectWorkspace({ project, onChanged }: { project: Project; onC
         <p className="text-xs text-zinc-500">{project.description}</p>
       </header>
       <nav className="flex border-b border-zinc-800 px-2" role="tablist">
-        {(["tasks", "files", "members", "activity"] as Tab[]).map((t) => (
+        {(["tasks", "files", "messages", "members", "activity"] as Tab[]).map((t) => (
           <button
             key={t}
             type="button"
@@ -38,6 +39,13 @@ export function ProjectWorkspace({ project, onChanged }: { project: Project; onC
             key={project.id}
             windowId={`project-files-${project.id}`}
             rootPath={`project:${project.slug}`}
+          />
+        )}
+        {tab === "messages" && (
+          <MessagesApp
+            key={project.id}
+            windowId={`project-messages-${project.id}`}
+            scope={{ projectId: project.id }}
           />
         )}
         {tab === "members" && <ProjectMembers project={project} onChanged={onChanged} />}

--- a/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
@@ -3,8 +3,9 @@ import type { Project } from "@/lib/projects";
 import { ProjectTaskList } from "./ProjectTaskList";
 import { ProjectMembers } from "./ProjectMembers";
 import { ProjectActivity } from "./ProjectActivity";
+import { FilesApp } from "@/apps/FilesApp";
 
-type Tab = "tasks" | "members" | "activity";
+type Tab = "tasks" | "files" | "members" | "activity";
 
 export function ProjectWorkspace({ project, onChanged }: { project: Project; onChanged: () => void }) {
   const [tab, setTab] = useState<Tab>("tasks");
@@ -15,7 +16,7 @@ export function ProjectWorkspace({ project, onChanged }: { project: Project; onC
         <p className="text-xs text-zinc-500">{project.description}</p>
       </header>
       <nav className="flex border-b border-zinc-800 px-2" role="tablist">
-        {(["tasks", "members", "activity"] as Tab[]).map((t) => (
+        {(["tasks", "files", "members", "activity"] as Tab[]).map((t) => (
           <button
             key={t}
             type="button"
@@ -32,6 +33,7 @@ export function ProjectWorkspace({ project, onChanged }: { project: Project; onC
       </nav>
       <div className="flex-1 min-h-0 overflow-auto p-4">
         {tab === "tasks" && <ProjectTaskList projectId={project.id} />}
+        {tab === "files" && <FilesApp windowId={`project-files-${project.id}`} rootPath={`project:${project.slug}`} />}
         {tab === "members" && <ProjectMembers project={project} onChanged={onChanged} />}
         {tab === "activity" && <ProjectActivity projectId={project.id} />}
       </div>

--- a/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
@@ -33,7 +33,13 @@ export function ProjectWorkspace({ project, onChanged }: { project: Project; onC
       </nav>
       <div className="flex-1 min-h-0 overflow-auto p-4">
         {tab === "tasks" && <ProjectTaskList projectId={project.id} />}
-        {tab === "files" && <FilesApp windowId={`project-files-${project.id}`} rootPath={`project:${project.slug}`} />}
+        {tab === "files" && (
+          <FilesApp
+            key={project.id}
+            windowId={`project-files-${project.id}`}
+            rootPath={`project:${project.slug}`}
+          />
+        )}
         {tab === "members" && <ProjectMembers project={project} onChanged={onChanged} />}
         {tab === "activity" && <ProjectActivity projectId={project.id} />}
       </div>

--- a/tests/test_routes_chat_channels.py
+++ b/tests/test_routes_chat_channels.py
@@ -1,0 +1,39 @@
+"""Route-level tests for chat channel project_id filtering."""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_get_channels_filter_by_project_id(client):
+    """GET /api/chat/channels?project_id=... returns only matching channels."""
+    # Create three channels with different project scopes
+    await client.post("/api/chat/channels", json={"name": "root-ch", "type": "topic"})
+    await client.post("/api/chat/channels", json={"name": "prj-x-ch", "type": "topic", "project_id": "prj-X"})
+    await client.post("/api/chat/channels", json={"name": "prj-y-ch", "type": "topic", "project_id": "prj-Y"})
+
+    resp = await client.get("/api/chat/channels?project_id=prj-X")
+    assert resp.status_code == 200
+    channels = resp.json()["channels"]
+    names = {c["name"] for c in channels}
+    assert "prj-x-ch" in names
+    assert "prj-y-ch" not in names
+    assert "root-ch" not in names
+
+
+@pytest.mark.asyncio
+async def test_post_channel_with_project_id_then_filter(client):
+    """POST with project_id body field; GET filter returns it."""
+    resp = await client.post(
+        "/api/chat/channels",
+        json={"name": "zeta-room", "type": "group", "project_id": "prj-Z"},
+    )
+    assert resp.status_code == 200
+    created = resp.json()
+    assert created["project_id"] == "prj-Z"
+
+    resp = await client.get("/api/chat/channels?project_id=prj-Z")
+    assert resp.status_code == 200
+    channels = resp.json()["channels"]
+    ids = {c["id"] for c in channels}
+    assert created["id"] in ids

--- a/tests/test_routes_project_files.py
+++ b/tests/test_routes_project_files.py
@@ -1,0 +1,117 @@
+import io
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_list_unknown_slug_returns_empty(client):
+    """Unknown slug auto-creates an empty folder and returns []."""
+    resp = await client.get("/api/projects/unknown-slug/files")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.asyncio
+async def test_mkdir_then_list(client):
+    """mkdir creates a folder that then appears in listing."""
+    resp = await client.post("/api/projects/myproject/mkdir", json={"path": "docs"})
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "created"
+
+    resp = await client.get("/api/projects/myproject/files")
+    assert resp.status_code == 200
+    names = [e["name"] for e in resp.json()]
+    assert "docs" in names
+
+
+@pytest.mark.asyncio
+async def test_upload_then_list(client):
+    """Uploaded file appears in listing with correct size."""
+    content = b"hello project"
+    resp = await client.post(
+        "/api/projects/proj1/files/upload",
+        files={"file": ("hello.txt", io.BytesIO(content), "text/plain")},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["name"] == "hello.txt"
+    assert body["size"] == len(content)
+
+    resp = await client.get("/api/projects/proj1/files")
+    assert resp.status_code == 200
+    entries = resp.json()
+    names = [e["name"] for e in entries]
+    assert "hello.txt" in names
+    entry = next(e for e in entries if e["name"] == "hello.txt")
+    assert entry["size"] == len(content)
+
+
+@pytest.mark.asyncio
+async def test_get_file_streams_bytes(client):
+    """GET file returns the uploaded bytes."""
+    content = b"stream me"
+    await client.post(
+        "/api/projects/proj2/files/upload",
+        files={"file": ("data.bin", io.BytesIO(content), "application/octet-stream")},
+    )
+    resp = await client.get("/api/projects/proj2/files/data.bin")
+    assert resp.status_code == 200
+    assert resp.content == content
+
+
+@pytest.mark.asyncio
+async def test_delete_removes_file(client):
+    """Delete removes the file; listing is empty afterwards."""
+    content = b"delete me"
+    await client.post(
+        "/api/projects/proj3/files/upload",
+        files={"file": ("todelete.txt", io.BytesIO(content), "text/plain")},
+    )
+
+    resp = await client.delete("/api/projects/proj3/files/todelete.txt")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "deleted"
+
+    resp = await client.get("/api/projects/proj3/files")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.parametrize("bad_slug", ["", "a/b", "..", "."])
+@pytest.mark.asyncio
+async def test_invalid_slug_returns_4xx(client, bad_slug):
+    """Empty or path-traversal slugs are rejected (400 from our handler, or 404/422 at routing layer)."""
+    resp = await client.get(f"/api/projects/{bad_slug}/files")
+    assert resp.status_code in (400, 404, 422)
+
+
+@pytest.mark.asyncio
+async def test_path_traversal_returns_400(client):
+    """?path=../../etc/passwd is rejected by _resolve_safe."""
+    resp = await client.get("/api/projects/safe-proj/files?path=../../etc/passwd")
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_stats_empty_project(client):
+    """Stats for a brand-new project folder returns 0 files and 0 bytes."""
+    resp = await client.get("/api/projects/empty-proj/stats")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total_files"] == 0
+    assert body["total_size"] == 0
+
+
+@pytest.mark.asyncio
+async def test_stats_after_upload(client):
+    """Stats reflect uploaded files."""
+    content = b"x" * 100
+    await client.post(
+        "/api/projects/stats-proj/files/upload",
+        files={"file": ("a.txt", io.BytesIO(content), "text/plain")},
+    )
+    resp = await client.get("/api/projects/stats-proj/stats")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total_files"] == 1
+    assert body["total_size"] == 100

--- a/tests/test_routes_project_files.py
+++ b/tests/test_routes_project_files.py
@@ -103,6 +103,40 @@ async def test_stats_empty_project(client):
 
 
 @pytest.mark.asyncio
+async def test_upload_to_existing_file_path_returns_400(client):
+    """Uploading with a path= that points to an existing file returns 400."""
+    content = b"i am a file"
+    # First upload creates the file at the root
+    await client.post(
+        "/api/projects/collision-proj/files/upload",
+        files={"file": ("blocker.txt", io.BytesIO(content), "text/plain")},
+    )
+    # Now try to upload into that file as if it were a directory
+    resp = await client.post(
+        "/api/projects/collision-proj/files/upload?path=blocker.txt",
+        files={"file": ("inner.txt", io.BytesIO(b"x"), "text/plain")},
+    )
+    assert resp.status_code == 400
+    assert "conflict" in resp.json()["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_mkdir_at_existing_file_path_returns_400(client):
+    """mkdir at a path that already holds a file returns 400."""
+    content = b"i am a file"
+    await client.post(
+        "/api/projects/mkdir-collision/files/upload",
+        files={"file": ("blocker.txt", io.BytesIO(content), "text/plain")},
+    )
+    resp = await client.post(
+        "/api/projects/mkdir-collision/mkdir",
+        json={"path": "blocker.txt"},
+    )
+    assert resp.status_code == 400
+    assert "conflict" in resp.json()["error"].lower()
+
+
+@pytest.mark.asyncio
 async def test_stats_after_upload(client):
     """Stats reflect uploaded files."""
     content = b"x" * 100

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -863,6 +863,9 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     from tinyagentos.routes.agent_workspace import router as agent_workspace_router
     app.include_router(agent_workspace_router)
 
+    from tinyagentos.routes.project_files import router as project_files_router
+    app.include_router(project_files_router)
+
     from tinyagentos.routes.shared_folders import router as shared_folders_router
     app.include_router(shared_folders_router)
 

--- a/tinyagentos/routes/chat.py
+++ b/tinyagentos/routes/chat.py
@@ -382,9 +382,10 @@ async def list_channels(
     request: Request,
     member: str | None = None,
     archived: bool | None = None,
+    project_id: str | None = None,
 ):
     ch_store = request.app.state.chat_channels
-    channels = await ch_store.list_channels(member_id=member, archived=archived)
+    channels = await ch_store.list_channels(member_id=member, archived=archived, project_id=project_id)
     return {"channels": channels}
 
 
@@ -399,6 +400,7 @@ async def create_channel(request: Request):
         members=body.get("members"),
         description=body.get("description", ""),
         topic=body.get("topic", ""),
+        project_id=body.get("project_id", ""),
     )
     return channel
 

--- a/tinyagentos/routes/project_files.py
+++ b/tinyagentos/routes/project_files.py
@@ -63,7 +63,7 @@ def _list_dir(workspace: Path, path: str) -> list[dict] | tuple[int, dict]:
 
 
 def _dir_signature(entries: list[dict]) -> str:
-    parts = [f"{e['name']}:{int(e['modified'])}:{e['size']}" for e in entries]
+    parts = [f"{e['name']}:{e['modified']}:{e['size']}" for e in entries]
     return "|".join(parts)
 
 
@@ -129,6 +129,8 @@ async def api_project_upload_file(request: Request, slug: str, path: str = "", f
         target_dir = _resolve_safe(workspace, path)
         if target_dir is None:
             return JSONResponse({"error": "Invalid path"}, status_code=400)
+        if target_dir.exists() and not target_dir.is_dir():
+            return JSONResponse({"error": "Path conflicts with an existing file"}, status_code=400)
         target_dir.mkdir(parents=True, exist_ok=True)
     else:
         target_dir = workspace
@@ -155,6 +157,8 @@ async def api_project_mkdir(request: Request, slug: str, body: MkdirRequest):
     if target is None:
         return JSONResponse({"error": "Invalid path"}, status_code=400)
 
+    if target.exists() and not target.is_dir():
+        return JSONResponse({"error": "Path conflicts with an existing file"}, status_code=400)
     target.mkdir(parents=True, exist_ok=True)
     rel = target.relative_to(workspace)
     return {"path": str(rel), "status": "created"}

--- a/tinyagentos/routes/project_files.py
+++ b/tinyagentos/routes/project_files.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+from pathlib import Path
+
+from fastapi import APIRouter, Request, UploadFile, File
+from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
+from pydantic import BaseModel
+
+router = APIRouter()
+
+
+def _get_project_files_root(request: Request, slug: str) -> Path | None:
+    """Return <projects_root>/<slug>/files, creating it on first access.
+    Returns None if slug is empty / contains path separators."""
+    if not slug or "/" in slug or "\\" in slug or slug in (".", ".."):
+        return None
+    root = request.app.state.projects_root / slug / "files"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _resolve_safe(workspace: Path, subpath: str) -> Path | None:
+    """Resolve subpath relative to workspace, returning None if outside workspace."""
+    try:
+        resolved = (workspace / subpath).resolve()
+        if resolved.is_relative_to(workspace.resolve()):
+            return resolved
+        return None
+    except Exception:
+        return None
+
+
+class MkdirRequest(BaseModel):
+    path: str
+
+
+def _list_dir(workspace: Path, path: str) -> list[dict] | tuple[int, dict]:
+    """Shared listing logic. Returns entries list on success, or (status, error) on failure."""
+    if path:
+        target = _resolve_safe(workspace, path)
+        if target is None:
+            return (400, {"error": "Invalid path"})
+        if not target.exists() or not target.is_dir():
+            return (404, {"error": "Directory not found"})
+    else:
+        target = workspace
+
+    entries = []
+    for item in sorted(target.iterdir(), key=lambda x: (not x.is_dir(), x.name.lower())):
+        stat = item.stat()
+        rel = item.relative_to(workspace)
+        entries.append({
+            "name": item.name,
+            "path": str(rel),
+            "is_dir": item.is_dir(),
+            "size": stat.st_size if item.is_file() else 0,
+            "modified": stat.st_mtime,
+        })
+    return entries
+
+
+def _dir_signature(entries: list[dict]) -> str:
+    parts = [f"{e['name']}:{int(e['modified'])}:{e['size']}" for e in entries]
+    return "|".join(parts)
+
+
+@router.get("/api/projects/{slug}/files")
+async def api_project_list_files(request: Request, slug: str, path: str = ""):
+    """List files in the project's files folder."""
+    workspace = _get_project_files_root(request, slug)
+    if workspace is None:
+        return JSONResponse({"error": "Invalid slug"}, status_code=400)
+    result = _list_dir(workspace, path)
+    if isinstance(result, tuple):
+        status, body = result
+        return JSONResponse(body, status_code=status)
+    return result
+
+
+@router.get("/api/projects/{slug}/files/watch")
+async def api_project_watch_files(request: Request, slug: str, path: str = "", interval: float = 1.0):
+    """SSE watch stream for the project's files folder."""
+    workspace = _get_project_files_root(request, slug)
+    if workspace is None:
+        return JSONResponse({"error": "Invalid slug"}, status_code=400)
+    interval = max(0.25, min(interval, 10.0))
+
+    async def event_stream():
+        last_signature: str | None = None
+        try:
+            while True:
+                if await request.is_disconnected():
+                    break
+                result = _list_dir(workspace, path)
+                if isinstance(result, tuple):
+                    status, body = result
+                    yield f"event: error\ndata: {json.dumps(body)}\n\n"
+                    break
+                entries = result
+                signature = _dir_signature(entries)
+                if signature != last_signature:
+                    last_signature = signature
+                    yield f"data: {json.dumps(entries)}\n\n"
+                await asyncio.sleep(interval)
+        except asyncio.CancelledError:
+            raise
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+@router.post("/api/projects/{slug}/files/upload")
+async def api_project_upload_file(request: Request, slug: str, path: str = "", file: UploadFile = File(...)):
+    """Upload a file to the project's files folder."""
+    workspace = _get_project_files_root(request, slug)
+    if workspace is None:
+        return JSONResponse({"error": "Invalid slug"}, status_code=400)
+
+    if path:
+        target_dir = _resolve_safe(workspace, path)
+        if target_dir is None:
+            return JSONResponse({"error": "Invalid path"}, status_code=400)
+        target_dir.mkdir(parents=True, exist_ok=True)
+    else:
+        target_dir = workspace
+
+    filename = Path(file.filename).name
+    dest = target_dir / filename
+    content = await file.read()
+    dest.write_bytes(content)
+    rel = dest.relative_to(workspace)
+    return {"name": filename, "path": str(rel), "size": len(content), "status": "uploaded"}
+
+
+@router.post("/api/projects/{slug}/mkdir")
+async def api_project_mkdir(request: Request, slug: str, body: MkdirRequest):
+    """Create a directory in the project's files folder."""
+    workspace = _get_project_files_root(request, slug)
+    if workspace is None:
+        return JSONResponse({"error": "Invalid slug"}, status_code=400)
+
+    if not body.path or not body.path.strip():
+        return JSONResponse({"error": "path is required"}, status_code=400)
+
+    target = _resolve_safe(workspace, body.path.strip())
+    if target is None:
+        return JSONResponse({"error": "Invalid path"}, status_code=400)
+
+    target.mkdir(parents=True, exist_ok=True)
+    rel = target.relative_to(workspace)
+    return {"path": str(rel), "status": "created"}
+
+
+@router.get("/api/projects/{slug}/files/{file_path:path}")
+async def api_project_get_file(request: Request, slug: str, file_path: str):
+    """Stream a single file from the project's files folder."""
+    workspace = _get_project_files_root(request, slug)
+    if workspace is None:
+        return JSONResponse({"error": "Invalid slug"}, status_code=400)
+    target = _resolve_safe(workspace, file_path)
+    if target is None:
+        return JSONResponse({"error": "Invalid path"}, status_code=400)
+    if not target.exists() or not target.is_file():
+        return JSONResponse({"error": f"'{file_path}' not found"}, status_code=404)
+    return FileResponse(target, filename=target.name)
+
+
+@router.delete("/api/projects/{slug}/files/{file_path:path}")
+async def api_project_delete_file(request: Request, slug: str, file_path: str):
+    """Delete a file or directory from the project's files folder."""
+    workspace = _get_project_files_root(request, slug)
+    if workspace is None:
+        return JSONResponse({"error": "Invalid slug"}, status_code=400)
+
+    target = _resolve_safe(workspace, file_path)
+    if target is None:
+        return JSONResponse({"error": "Invalid path"}, status_code=400)
+
+    if not target.exists():
+        return JSONResponse({"error": f"'{file_path}' not found"}, status_code=404)
+
+    if target.is_dir():
+        shutil.rmtree(target)
+    else:
+        target.unlink()
+
+    return {"path": file_path, "status": "deleted"}
+
+
+@router.get("/api/projects/{slug}/stats")
+async def api_project_stats(request: Request, slug: str):
+    """Return total file count and total size for the project's files folder."""
+    workspace = _get_project_files_root(request, slug)
+    if workspace is None:
+        return JSONResponse({"error": "Invalid slug"}, status_code=400)
+
+    total_files = 0
+    total_size = 0
+    for item in workspace.rglob("*"):
+        if item.is_file():
+            total_files += 1
+            total_size += item.stat().st_size
+
+    return {"total_files": total_files, "total_size": total_size}


### PR DESCRIPTION
## Summary

Tasks 25 and 26 from the Projects-app foundation plan — embed FilesApp and MessagesApp inside `ProjectWorkspace`, with backend route family for project-scoped files and `project_id`-aware chat channel filtering.

- **FilesApp** accepts a `rootPath` prop (`"project:<slug>"`); standalone-mode UI unchanged. Backend exposes `/api/projects/{slug}/files*` mirroring user-workspace routes, rooted at `<projects_root>/<slug>/files`. 12 new route tests.
- **MessagesApp** accepts a `scope?: { projectId?: string }` prop. When scoped, fetches and creates channels filter by `project_id` server-side; when standalone, root sidebar sections (DM/topic/group) strictly exclude project-tagged channels and a new collapsible "Projects" section nests them. Cloned-agent channels appear only inside Projects (naturally — they carry the owning `project_id`). 2 new route tests.
- **ProjectWorkspace** gains "Files" and "Messages" tabs. Both embeds use `key={project.id}` to remount on project change (avoids stale state from lazy `useState` initialisers).
- **Mobile sidebar a11y** — Projects section uses keyboard-accessible expand/collapse mirroring the existing Archived pattern (`button` + `aria-expanded` + `aria-controls`).

## Test plan

- [x] `pytest tests/projects tests/test_routes_projects.py tests/test_chat_channels.py tests/test_routes_chat_channels.py tests/test_routes_project_files.py` — 94 passed
- [x] `npx tsc -b --noEmit` (desktop) — clean
- [ ] Manual smoke: open standalone Messages → Projects collapsible group works on desktop and mobile, root sections do not leak project channels
- [ ] Manual smoke: open a Project → Messages tab shows only that project's channels, channel-create posts the right `project_id`
- [ ] Manual smoke: open a Project → Files tab browses `~/Projects/<slug>/files`, upload/mkdir/delete work, switching projects shows the new project's tree (no stale state)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Files and Messages tabs in project workspaces.
  * Project-scoped file management: list, watch (live updates), upload, download, mkdir, delete, and stats.
  * Project-scoped chat channels: create channels with project association and filter channel lists by project.
* **Tests**
  * New end-to-end tests covering project file operations, stats, validations, and project-scoped channel APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->