### PR TITLE
feat(projects): kanban / swimlane board views

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist/
 build/
 *.db
 .superpowers/
+.worktrees/
 
 # User config — never commit (contains IPs, backend URLs, agent definitions)
 data/config.yaml

--- a/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
@@ -27,14 +27,15 @@ function setTaskParam(taskId: string | null) {
 export function ProjectWorkspace({ project, onChanged }: { project: Project; onChanged: () => void }) {
   const [tab, setTab] = useState<Tab>("tasks");
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+  const [authResolved, setAuthResolved] = useState(false);
   const [openTaskId, setOpenTaskId] = useState<string | null>(() => readTaskParam());
 
   useEffect(() => {
     let cancelled = false;
     fetch("/api/auth/me")
       .then((r) => (r.ok ? r.json() : null))
-      .then((u) => { if (!cancelled && u?.id) setCurrentUserId(u.id); })
-      .catch(() => {});
+      .then((u) => { if (!cancelled) { if (u?.id) setCurrentUserId(u.id); setAuthResolved(true); } })
+      .catch(() => { if (!cancelled) setAuthResolved(true); });
     return () => { cancelled = true; };
   }, []);
 
@@ -72,21 +73,25 @@ export function ProjectWorkspace({ project, onChanged }: { project: Project; onC
       <div className="flex-1 min-h-0 overflow-auto p-4">
         {tab === "board" && (
           <>
-            {currentUserId ? (
+            {!authResolved ? (
+              <div className="text-sm text-zinc-500">Loading board…</div>
+            ) : currentUserId ? (
               <ProjectBoard
                 projectId={project.id}
                 currentUserId={currentUserId}
                 onOpenTask={openTask}
               />
             ) : (
-              <div className="text-sm text-zinc-500">Loading board…</div>
+              <div className="text-sm text-zinc-500">Sign in required to view the board.</div>
             )}
-            <TaskModal
-              projectId={project.id}
-              taskId={openTaskId}
-              currentUserId={currentUserId ?? ""}
-              onClose={closeTask}
-            />
+            {currentUserId && (
+              <TaskModal
+                projectId={project.id}
+                taskId={openTaskId}
+                currentUserId={currentUserId}
+                onClose={closeTask}
+              />
+            )}
           </>
         )}
         {tab === "tasks" && <ProjectTaskList projectId={project.id} />}

--- a/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
@@ -34,7 +34,7 @@ export function ProjectWorkspace({ project, onChanged }: { project: Project; onC
     let cancelled = false;
     fetch("/api/auth/me")
       .then((r) => (r.ok ? r.json() : null))
-      .then((u) => { if (!cancelled) { if (u?.id) setCurrentUserId(u.id); setAuthResolved(true); } })
+      .then((u) => { if (!cancelled) { if (u?.user?.id) setCurrentUserId(u.user.id); setAuthResolved(true); } })
       .catch(() => { if (!cancelled) setAuthResolved(true); });
     return () => { cancelled = true; };
   }, []);

--- a/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
@@ -1,15 +1,52 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { Project } from "@/lib/projects";
 import { ProjectTaskList } from "./ProjectTaskList";
 import { ProjectMembers } from "./ProjectMembers";
 import { ProjectActivity } from "./ProjectActivity";
+import { ProjectBoard } from "./board/ProjectBoard";
+import { TaskModal } from "./board/TaskModal";
 import { FilesApp } from "@/apps/FilesApp";
 import { MessagesApp } from "@/apps/MessagesApp";
 
-type Tab = "tasks" | "files" | "messages" | "members" | "activity";
+type Tab = "board" | "tasks" | "files" | "messages" | "members" | "activity";
+const TABS: Tab[] = ["board", "tasks", "files", "messages", "members", "activity"];
+
+function readTaskParam(): string | null {
+  if (typeof window === "undefined") return null;
+  return new URLSearchParams(window.location.search).get("task");
+}
+
+function setTaskParam(taskId: string | null) {
+  if (typeof window === "undefined") return;
+  const url = new URL(window.location.href);
+  if (taskId) url.searchParams.set("task", taskId);
+  else url.searchParams.delete("task");
+  window.history.pushState({}, "", url);
+}
 
 export function ProjectWorkspace({ project, onChanged }: { project: Project; onChanged: () => void }) {
   const [tab, setTab] = useState<Tab>("tasks");
+  const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+  const [openTaskId, setOpenTaskId] = useState<string | null>(() => readTaskParam());
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/auth/me")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((u) => { if (!cancelled && u?.id) setCurrentUserId(u.id); })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, []);
+
+  useEffect(() => {
+    const onPop = () => setOpenTaskId(readTaskParam());
+    window.addEventListener("popstate", onPop);
+    return () => window.removeEventListener("popstate", onPop);
+  }, []);
+
+  const openTask = (id: string) => { setTaskParam(id); setOpenTaskId(id); };
+  const closeTask = () => { setTaskParam(null); setOpenTaskId(null); };
+
   return (
     <div className="flex flex-col h-full">
       <header className="px-4 py-3 border-b border-zinc-800">
@@ -17,7 +54,7 @@ export function ProjectWorkspace({ project, onChanged }: { project: Project; onC
         <p className="text-xs text-zinc-500">{project.description}</p>
       </header>
       <nav className="flex border-b border-zinc-800 px-2" role="tablist">
-        {(["tasks", "files", "messages", "members", "activity"] as Tab[]).map((t) => (
+        {TABS.map((t) => (
           <button
             key={t}
             type="button"
@@ -33,6 +70,25 @@ export function ProjectWorkspace({ project, onChanged }: { project: Project; onC
         ))}
       </nav>
       <div className="flex-1 min-h-0 overflow-auto p-4">
+        {tab === "board" && (
+          <>
+            {currentUserId ? (
+              <ProjectBoard
+                projectId={project.id}
+                currentUserId={currentUserId}
+                onOpenTask={openTask}
+              />
+            ) : (
+              <div className="text-sm text-zinc-500">Loading board…</div>
+            )}
+            <TaskModal
+              projectId={project.id}
+              taskId={openTaskId}
+              currentUserId={currentUserId ?? ""}
+              onClose={closeTask}
+            />
+          </>
+        )}
         {tab === "tasks" && <ProjectTaskList projectId={project.id} />}
         {tab === "files" && (
           <FilesApp

--- a/desktop/src/apps/ProjectsApp/board/BoardColumn.module.css
+++ b/desktop/src/apps/ProjectsApp/board/BoardColumn.module.css
@@ -1,0 +1,7 @@
+.col { background: linear-gradient(180deg, rgba(255,255,255,.025), rgba(255,255,255,.01)); border: 1px solid var(--board-hair); border-radius: 12px; padding: 12px; display: flex; flex-direction: column; gap: 10px; min-height: 600px; }
+.head { display: flex; align-items: center; gap: 8px; padding: 2px 4px 8px; border-bottom: 1px solid var(--board-hair); }
+.name { font: 600 12.5px -apple-system; }
+.count { margin-left: auto; font: 600 11px -apple-system; background: rgba(255,255,255,.07); padding: 2px 8px; border-radius: 8px; color: #d2d2d7; }
+.body { display: flex; flex-direction: column; gap: 10px; }
+.showMore { background: transparent; border: 1px dashed var(--board-hair); color: #86868b; padding: 6px; border-radius: 8px; cursor: pointer; font: 11px -apple-system; }
+.ready, .claimed, .closed {} /* status modifiers reserved for future glow */

--- a/desktop/src/apps/ProjectsApp/board/BoardColumn.tsx
+++ b/desktop/src/apps/ProjectsApp/board/BoardColumn.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from "react";
+import styles from "./BoardColumn.module.css";
+
+export interface BoardColumnProps {
+  status: "ready" | "claimed" | "closed";
+  count: number;
+  showAllClosed?: boolean;
+  onShowAllClosed?: () => void;
+  onDropTask: (taskId: string) => void;
+  children: ReactNode;
+}
+
+const NAME = { ready: "Ready", claimed: "Claimed", closed: "Closed · 7d" } as const;
+
+export function BoardColumn(p: BoardColumnProps) {
+  return (
+    <section
+      role="region"
+      aria-label={NAME[p.status]}
+      className={`${styles.col} ${styles[p.status]}`}
+      onDragOver={(e) => { e.preventDefault(); }}
+      onDrop={(e) => {
+        e.preventDefault();
+        const id = e.dataTransfer.getData("text/plain");
+        if (id) p.onDropTask(id);
+      }}
+    >
+      <header className={styles.head}>
+        <span className={styles.name}>{NAME[p.status]}</span>
+        <span className={styles.count}>{p.count}</span>
+      </header>
+      <div className={styles.body}>{p.children}</div>
+      {p.status === "closed" && p.onShowAllClosed && (
+        <button type="button" className={styles.showMore} onClick={p.onShowAllClosed}>
+          {p.showAllClosed ? "Show recent only" : "Show all closed"}
+        </button>
+      )}
+    </section>
+  );
+}

--- a/desktop/src/apps/ProjectsApp/board/BoardFilters.tsx
+++ b/desktop/src/apps/ProjectsApp/board/BoardFilters.tsx
@@ -1,0 +1,58 @@
+import { useState } from "react";
+import styles from "./BoardToolbar.module.css";
+import type { Filters } from "./types";
+
+export interface BoardFiltersProps {
+  value: Filters;
+  onChange: (f: Filters) => void;
+}
+
+const PRIORITY_OPTIONS = [0, 1, 2, 3];
+
+export function BoardFilters({ value, onChange }: BoardFiltersProps) {
+  const [open, setOpen] = useState(false);
+  const togglePriority = (p: number) => {
+    const next = value.priorities.includes(p)
+      ? value.priorities.filter(x => x !== p)
+      : [...value.priorities, p];
+    onChange({ ...value, priorities: next });
+  };
+  return (
+    <div className={styles.filterWrap}>
+      <button type="button" className={styles.pill} onClick={() => setOpen(o => !o)}>+ Filter</button>
+      {open && (
+        <div role="dialog" aria-label="Filters" className={styles.popover}>
+          <label className={styles.popRow}>
+            <input
+              type="checkbox"
+              checked={value.hideClosed}
+              onChange={(e) => onChange({ ...value, hideClosed: e.target.checked })}
+            />
+            Hide closed
+          </label>
+          <label className={styles.popRow}>
+            <input
+              type="checkbox"
+              checked={value.hasAttachments}
+              onChange={(e) => onChange({ ...value, hasAttachments: e.target.checked })}
+            />
+            Has attachments
+          </label>
+          <div className={styles.chipRow}>
+            {PRIORITY_OPTIONS.map(p => (
+              <button
+                key={p}
+                type="button"
+                aria-pressed={value.priorities.includes(p)}
+                className={`${styles.chip} ${value.priorities.includes(p) ? styles.chipOn : ""}`}
+                onClick={() => togglePriority(p)}
+              >
+                P{p}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/desktop/src/apps/ProjectsApp/board/BoardLane.module.css
+++ b/desktop/src/apps/ProjectsApp/board/BoardLane.module.css
@@ -1,0 +1,7 @@
+.row { display: grid; grid-template-columns: 200px 1fr 1fr 1fr; gap: 10px; padding: 12px 0; border-top: 1px solid var(--board-hair); }
+.row:first-child { border-top: 0; }
+.head { display: flex; align-items: center; gap: 10px; padding: 4px 8px; }
+.av { width: 32px; height: 32px; border-radius: 50%; background: linear-gradient(135deg,#0891b2,#06b6d4); display: flex; align-items: center; justify-content: center; color: white; font: 600 13px -apple-system; }
+.name { font: 600 12.5px -apple-system; }
+.sub { font: 10px -apple-system; color: #86868b; margin-top: 2px; }
+.cell { display: flex; flex-direction: column; gap: 8px; min-height: 80px; }

--- a/desktop/src/apps/ProjectsApp/board/BoardLane.module.css
+++ b/desktop/src/apps/ProjectsApp/board/BoardLane.module.css
@@ -4,4 +4,5 @@
 .av { width: 32px; height: 32px; border-radius: 50%; background: linear-gradient(135deg,#0891b2,#06b6d4); display: flex; align-items: center; justify-content: center; color: white; font: 600 13px -apple-system; }
 .name { font: 600 12.5px -apple-system; }
 .sub { font: 10px -apple-system; color: #86868b; margin-top: 2px; }
-.cell { display: flex; flex-direction: column; gap: 8px; min-height: 80px; }
+.cell { display: flex; flex-direction: column; gap: 8px; min-height: 80px; position: relative; }
+.cell:empty::after { content: "Drop here to claim or assign"; position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; color: #5a5a60; font: 10.5px -apple-system; border: 1px dashed var(--board-hair); border-radius: 8px; pointer-events: none; }

--- a/desktop/src/apps/ProjectsApp/board/BoardLane.tsx
+++ b/desktop/src/apps/ProjectsApp/board/BoardLane.tsx
@@ -1,0 +1,35 @@
+import type { DragEvent, ReactNode } from "react";
+import styles from "./BoardLane.module.css";
+import type { LaneHeader } from "./types";
+
+type CellStatus = "ready" | "claimed" | "closed";
+
+export interface BoardLaneProps {
+  header: LaneHeader;
+  cells: { ready: ReactNode; claimed: ReactNode; closed: ReactNode };
+  onDropTask: (taskId: string, status: CellStatus, laneKey: string) => void;
+}
+
+export function BoardLane({ header, cells, onDropTask }: BoardLaneProps) {
+  const onCellDrop = (status: CellStatus) => (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const id = e.dataTransfer.getData("text/plain");
+    if (id) onDropTask(id, status, header.key);
+  };
+  const dragOver = (e: DragEvent<HTMLDivElement>) => e.preventDefault();
+  const initial = header.title.charAt(0).toUpperCase() || "?";
+  return (
+    <div className={styles.row}>
+      <div className={styles.head}>
+        <div className={styles.av} aria-hidden>{initial}</div>
+        <div>
+          <div className={styles.name}>{header.title}</div>
+          {header.subtitle && <div className={styles.sub}>{header.subtitle}</div>}
+        </div>
+      </div>
+      <div data-testid="lane-cell-ready" className={styles.cell} onDragOver={dragOver} onDrop={onCellDrop("ready")}>{cells.ready}</div>
+      <div data-testid="lane-cell-claimed" className={styles.cell} onDragOver={dragOver} onDrop={onCellDrop("claimed")}>{cells.claimed}</div>
+      <div data-testid="lane-cell-closed" className={styles.cell} onDragOver={dragOver} onDrop={onCellDrop("closed")}>{cells.closed}</div>
+    </div>
+  );
+}

--- a/desktop/src/apps/ProjectsApp/board/BoardToolbar.module.css
+++ b/desktop/src/apps/ProjectsApp/board/BoardToolbar.module.css
@@ -1,0 +1,21 @@
+.bar { display: flex; align-items: center; gap: 10px; padding: 10px 14px; background: linear-gradient(180deg, rgba(255,255,255,.025), rgba(255,255,255,.005)); border-bottom: 1px solid var(--board-hair); }
+.crumb { font: 600 12.5px -apple-system; color: #d2d2d7; }
+.grow { flex: 1; }
+.seg { display: inline-flex; gap: 0; background: rgba(255,255,255,.05); border: 1px solid var(--board-hair); border-radius: 8px; padding: 2px; }
+.seg button { background: transparent; border: 0; padding: 4px 10px; border-radius: 6px; color: #86868b; font: 600 11.5px -apple-system; cursor: pointer; }
+.seg button:disabled { opacity: .4; cursor: not-allowed; }
+.seg button.on { background: rgba(167,139,250,.18); color: #fff; box-shadow: 0 0 0 1px rgba(167,139,250,.3); }
+.pill { display: inline-flex; align-items: center; gap: 6px; padding: 4px 10px; background: rgba(255,255,255,.05); border: 1px solid var(--board-hair); border-radius: 8px; color: #d2d2d7; font: 600 11.5px -apple-system; cursor: pointer; }
+.pill select { background: transparent; color: inherit; border: 0; font: inherit; outline: none; }
+.live { color: #5fdb84; }
+.live::before, .dead::before { content: "● "; }
+.dead { color: #86868b; }
+.search { background: rgba(255,255,255,.05); border: 1px solid var(--board-hair); border-radius: 8px; color: #f5f5f7; padding: 5px 10px; font: 11.5px -apple-system; min-width: 220px; outline: none; }
+.search:focus { border-color: rgba(167,139,250,.5); }
+.add { background: var(--board-accent-violet); border: 0; color: #1a1a1c; padding: 5px 12px; border-radius: 8px; font: 700 11.5px -apple-system; cursor: pointer; }
+.filterWrap { position: relative; }
+.popover { position: absolute; top: calc(100% + 6px); right: 0; background: #1f1f22; border: 1px solid var(--board-hair); padding: 10px; border-radius: 10px; min-width: 200px; box-shadow: 0 10px 30px rgba(0,0,0,.4); z-index: 10; display: flex; flex-direction: column; gap: 8px; }
+.popRow { display: flex; gap: 8px; align-items: center; font: 12px -apple-system; color: #d2d2d7; }
+.chipRow { display: flex; gap: 4px; }
+.chip { background: rgba(255,255,255,.05); border: 1px solid var(--board-hair); border-radius: 6px; padding: 3px 8px; color: #86868b; font: 600 10.5px -apple-system; cursor: pointer; }
+.chipOn { background: rgba(167,139,250,.18); color: #fff; border-color: rgba(167,139,250,.4); }

--- a/desktop/src/apps/ProjectsApp/board/BoardToolbar.tsx
+++ b/desktop/src/apps/ProjectsApp/board/BoardToolbar.tsx
@@ -1,0 +1,71 @@
+import styles from "./BoardToolbar.module.css";
+import type { ViewMode, GroupBy, Filters } from "./types";
+import { BoardFilters } from "./BoardFilters";
+
+export interface BoardToolbarProps {
+  viewMode: ViewMode;
+  groupBy: GroupBy;
+  filters: Filters;
+  live: boolean;
+  onChangeView: (m: ViewMode) => void;
+  onChangeGroup: (g: GroupBy) => void;
+  onChangeFilters: (f: Filters) => void;
+  onAddTask?: () => void;
+}
+
+const VIEWS: ViewMode[] = ["lanes", "kanban", "timeline"];
+const VIEW_LABEL: Record<ViewMode, string> = {
+  lanes: "▦ Lanes",
+  kanban: "▤ Kanban",
+  timeline: "⇆ Timeline",
+};
+
+export function BoardToolbar(p: BoardToolbarProps) {
+  return (
+    <div className={styles.bar}>
+      <div className={styles.crumb}>Board</div>
+      <div className={styles.grow} />
+      <div className={styles.seg} role="tablist" aria-label="Board view">
+        {VIEWS.map(m => (
+          <button
+            key={m}
+            type="button"
+            role="tab"
+            aria-selected={p.viewMode === m}
+            disabled={m === "timeline"}
+            onClick={() => p.onChangeView(m)}
+            className={p.viewMode === m ? styles.on : ""}
+          >
+            {VIEW_LABEL[m]}
+          </button>
+        ))}
+      </div>
+      {p.viewMode === "lanes" && (
+        <label className={styles.pill} aria-label="Group by">
+          Group:
+          <select
+            value={p.groupBy}
+            onChange={(e) => p.onChangeGroup(e.target.value as GroupBy)}
+          >
+            <option value="assignee">Assignee</option>
+            <option value="parent">Parent</option>
+            <option value="label">Label</option>
+            <option value="priority">Priority</option>
+          </select>
+        </label>
+      )}
+      <input
+        className={styles.search}
+        placeholder="Search tasks…"
+        value={p.filters.search}
+        onChange={(e) => p.onChangeFilters({ ...p.filters, search: e.target.value })}
+        aria-label="Search tasks"
+      />
+      <BoardFilters value={p.filters} onChange={p.onChangeFilters} />
+      <span className={`${styles.pill} ${p.live ? styles.live : styles.dead}`}>● Live</span>
+      {p.onAddTask && (
+        <button type="button" className={styles.add} onClick={p.onAddTask}>＋ Task</button>
+      )}
+    </div>
+  );
+}

--- a/desktop/src/apps/ProjectsApp/board/ProjectBoard.module.css
+++ b/desktop/src/apps/ProjectsApp/board/ProjectBoard.module.css
@@ -2,3 +2,8 @@
 .cols { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 14px; padding: 16px; }
 .lanes { padding: 0 16px 16px; }
 .colsHeader { display: grid; grid-template-columns: 200px 1fr 1fr 1fr; padding: 10px 4px; color: #86868b; font: 600 10.5px -apple-system; text-transform: uppercase; letter-spacing: .5px; }
+.sr { position: absolute; left: -10000px; width: 1px; height: 1px; overflow: hidden; }
+.movePop { position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); background: #1f1f22; border: 1px solid var(--board-hair-strong); border-radius: 12px; padding: 16px; min-width: 240px; box-shadow: 0 20px 60px rgba(0,0,0,.5); z-index: 60; display: flex; flex-direction: column; gap: 8px; }
+.movePop p { margin: 0 0 4px; color: #d2d2d7; font: 600 12px -apple-system; }
+.movePop button { background: rgba(255,255,255,.05); border: 1px solid var(--board-hair); border-radius: 8px; color: #f5f5f7; padding: 6px 10px; font: 12px -apple-system; cursor: pointer; text-transform: capitalize; }
+.movePop button:hover { background: rgba(255,255,255,.08); border-color: var(--board-hair-strong); }

--- a/desktop/src/apps/ProjectsApp/board/ProjectBoard.module.css
+++ b/desktop/src/apps/ProjectsApp/board/ProjectBoard.module.css
@@ -1,0 +1,4 @@
+.frame { background: var(--board-bg); border-radius: 14px; border: 1px solid var(--board-hair); overflow: hidden; }
+.cols { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 14px; padding: 16px; }
+.lanes { padding: 0 16px 16px; }
+.colsHeader { display: grid; grid-template-columns: 200px 1fr 1fr 1fr; padding: 10px 4px; color: #86868b; font: 600 10.5px -apple-system; text-transform: uppercase; letter-spacing: .5px; }

--- a/desktop/src/apps/ProjectsApp/board/ProjectBoard.tsx
+++ b/desktop/src/apps/ProjectsApp/board/ProjectBoard.tsx
@@ -22,7 +22,9 @@ export interface ProjectBoardProps {
 }
 
 const PERSIST_KEY = (pid: string) => `taos.projects.${pid}.board`;
-const VALID_VIEWS: ViewMode[] = ["lanes", "kanban", "timeline"];
+// "timeline" is reserved in the toolbar but not implemented; only persist
+// modes that actually render to avoid `lanes!` blowing up on rehydrate.
+const VALID_VIEWS: ViewMode[] = ["lanes", "kanban"];
 const VALID_GROUPS: GroupBy[] = ["assignee", "parent", "label", "priority"];
 type ColStatus = "ready" | "claimed" | "closed";
 

--- a/desktop/src/apps/ProjectsApp/board/ProjectBoard.tsx
+++ b/desktop/src/apps/ProjectsApp/board/ProjectBoard.tsx
@@ -22,6 +22,8 @@ export interface ProjectBoardProps {
 }
 
 const PERSIST_KEY = (pid: string) => `taos.projects.${pid}.board`;
+const VALID_VIEWS: ViewMode[] = ["lanes", "kanban", "timeline"];
+const VALID_GROUPS: GroupBy[] = ["assignee", "parent", "label", "priority"];
 type ColStatus = "ready" | "claimed" | "closed";
 
 export function ProjectBoard({ projectId, currentUserId, onOpenTask }: ProjectBoardProps) {
@@ -36,9 +38,9 @@ export function ProjectBoard({ projectId, currentUserId, onOpenTask }: ProjectBo
     try {
       const raw = localStorage.getItem(PERSIST_KEY(projectId));
       if (raw) {
-        const p = JSON.parse(raw) as { viewMode?: ViewMode; groupBy?: GroupBy };
-        if (p.viewMode) setViewMode(p.viewMode);
-        if (p.groupBy) setGroupBy(p.groupBy);
+        const p = JSON.parse(raw) as { viewMode?: string; groupBy?: string };
+        if (p.viewMode && VALID_VIEWS.includes(p.viewMode as ViewMode)) setViewMode(p.viewMode as ViewMode);
+        if (p.groupBy && VALID_GROUPS.includes(p.groupBy as GroupBy)) setGroupBy(p.groupBy as GroupBy);
       }
     } catch { /* ignore */ }
   }, [projectId]);

--- a/desktop/src/apps/ProjectsApp/board/ProjectBoard.tsx
+++ b/desktop/src/apps/ProjectsApp/board/ProjectBoard.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useMemo, useState } from "react";
+import type { DragEvent } from "react";
+import styles from "./ProjectBoard.module.css";
+import { BoardToolbar } from "./BoardToolbar";
+import { BoardColumn } from "./BoardColumn";
+import { BoardLane } from "./BoardLane";
+import { TaskCard } from "./TaskCard";
+import { useBoardData } from "./useBoardData";
+import { useBoardLive } from "./useBoardLive";
+import { applyFilters } from "./boardFiltering";
+import { groupByAssignee, groupByLabel, groupByParent, groupByPriority } from "./boardGrouping";
+import { dndAction } from "./boardDnd";
+import { EMPTY_FILTERS } from "./types";
+import type { Filters, GroupBy, Task, ViewMode } from "./types";
+import { projectsApi } from "../../../lib/projects";
+import type { ProjectTask } from "../../../lib/projects";
+
+export interface ProjectBoardProps {
+  projectId: string;
+  currentUserId: string;
+  onOpenTask?: (id: string) => void;
+}
+
+const PERSIST_KEY = (pid: string) => `taos.projects.${pid}.board`;
+type ColStatus = "ready" | "claimed" | "closed";
+
+export function ProjectBoard({ projectId, currentUserId, onOpenTask }: ProjectBoardProps) {
+  const [viewMode, setViewMode] = useState<ViewMode>("lanes");
+  const [groupBy, setGroupBy] = useState<GroupBy>("assignee");
+  const [filters, setFilters] = useState<Filters>(EMPTY_FILTERS);
+  const [justClaimed, setJustClaimed] = useState<string | null>(null);
+
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(PERSIST_KEY(projectId));
+      if (raw) {
+        const p = JSON.parse(raw) as { viewMode?: ViewMode; groupBy?: GroupBy };
+        if (p.viewMode) setViewMode(p.viewMode);
+        if (p.groupBy) setGroupBy(p.groupBy);
+      }
+    } catch { /* ignore */ }
+  }, [projectId]);
+
+  useEffect(() => {
+    localStorage.setItem(PERSIST_KEY(projectId), JSON.stringify({ viewMode, groupBy }));
+  }, [projectId, viewMode, groupBy]);
+
+  const { tasks, applyEvent, setTasks } = useBoardData(projectId);
+  const { connected } = useBoardLive(projectId, (e) => {
+    if (e.kind === "task.claimed") {
+      const id = String((e.payload as { id?: string }).id ?? "");
+      if (id) {
+        setJustClaimed(id);
+        setTimeout(() => setJustClaimed(null), 1500);
+      }
+    }
+    applyEvent(e);
+  });
+
+  const filtered = useMemo(() => applyFilters(tasks, filters), [tasks, filters]);
+
+  const lanes = useMemo(() => {
+    if (viewMode !== "lanes") return null;
+    const fn = { assignee: groupByAssignee, parent: groupByParent, label: groupByLabel, priority: groupByPriority }[groupBy];
+    return fn(filtered);
+  }, [viewMode, groupBy, filtered]);
+
+  const counts = useMemo(() => ({
+    ready: filtered.filter(t => t.status === "open").length,
+    claimed: filtered.filter(t => t.status === "claimed").length,
+    closed: filtered.filter(t => t.status === "closed").length,
+  }), [filtered]);
+
+  const onCardDragStart = (e: DragEvent<HTMLButtonElement>, task: Task) => {
+    e.dataTransfer.setData("text/plain", task.id);
+  };
+
+  const dispatchDnd = async (taskId: string, columnStatus: ColStatus, laneKey?: string) => {
+    const task = tasks.find(t => t.id === taskId);
+    if (!task) return;
+    const result = dndAction({
+      task,
+      target: { columnStatus, laneKey, groupBy: viewMode === "lanes" ? groupBy : undefined },
+      viewMode,
+      currentUserId,
+    });
+    if ("blocked" in result) {
+      window.alert(result.blocked);
+      return;
+    }
+    const snapshot = tasks;
+    for (const c of result.calls) {
+      try {
+        switch (c.kind) {
+          case "claim": await projectsApi.tasks.claim(projectId, c.taskId, c.claimerId); break;
+          case "release": await projectsApi.tasks.release(projectId, c.taskId, c.releaserId); break;
+          case "close": await projectsApi.tasks.close(projectId, c.taskId, c.closedBy); break;
+          case "update": await projectsApi.tasks.update(projectId, c.taskId, c.patch as Partial<ProjectTask>); break;
+        }
+      } catch (err) {
+        console.error("DnD call failed", err);
+        setTasks(snapshot);
+        window.alert("Could not move card — reverted.");
+        return;
+      }
+    }
+  };
+
+  const renderCard = (t: Task, drag = true) => (
+    <TaskCard
+      key={t.id}
+      task={t}
+      onOpen={(id) => onOpenTask?.(id)}
+      justClaimed={justClaimed === t.id}
+      draggable={drag}
+      onDragStart={drag ? onCardDragStart : undefined}
+    />
+  );
+
+  return (
+    <div className={styles.frame}>
+      <BoardToolbar
+        viewMode={viewMode}
+        groupBy={groupBy}
+        filters={filters}
+        live={connected}
+        onChangeView={setViewMode}
+        onChangeGroup={setGroupBy}
+        onChangeFilters={setFilters}
+      />
+      {viewMode === "kanban" ? (
+        <div className={styles.cols}>
+          {(["ready", "claimed", "closed"] as ColStatus[]).map(s => {
+            const dataStatus = s === "ready" ? "open" : s;
+            const cards = filtered.filter(t => t.status === dataStatus);
+            return (
+              <BoardColumn key={s} status={s} count={cards.length} onDropTask={(id) => dispatchDnd(id, s)}>
+                {cards.map(t => renderCard(t))}
+              </BoardColumn>
+            );
+          })}
+        </div>
+      ) : (
+        <div className={styles.lanes}>
+          <div className={styles.colsHeader}>
+            <span />
+            <span>Ready · {counts.ready}</span>
+            <span>Claimed · {counts.claimed}</span>
+            <span>Closed · {counts.closed}</span>
+          </div>
+          {lanes!.map(lane => (
+            <BoardLane
+              key={lane.header.key}
+              header={lane.header}
+              cells={{
+                ready: lane.cards.filter(t => t.status === "open").map(t => renderCard(t)),
+                claimed: lane.cards.filter(t => t.status === "claimed").map(t => renderCard(t)),
+                closed: lane.cards.filter(t => t.status === "closed").map(t => renderCard(t, false)),
+              }}
+              onDropTask={(id, status, laneKey) => dispatchDnd(id, status, laneKey)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/desktop/src/apps/ProjectsApp/board/ProjectBoard.tsx
+++ b/desktop/src/apps/ProjectsApp/board/ProjectBoard.tsx
@@ -29,6 +29,8 @@ export function ProjectBoard({ projectId, currentUserId, onOpenTask }: ProjectBo
   const [groupBy, setGroupBy] = useState<GroupBy>("assignee");
   const [filters, setFilters] = useState<Filters>(EMPTY_FILTERS);
   const [justClaimed, setJustClaimed] = useState<string | null>(null);
+  const [movePopover, setMovePopover] = useState<string | null>(null);
+  const [announcement, setAnnouncement] = useState("");
 
   useEffect(() => {
     try {
@@ -104,6 +106,8 @@ export function ProjectBoard({ projectId, currentUserId, onOpenTask }: ProjectBo
         return;
       }
     }
+    const moved = tasks.find(t => t.id === taskId);
+    if (moved) setAnnouncement(`Moved ${moved.title} to ${columnStatus}`);
   };
 
   const renderCard = (t: Task, drag = true) => (
@@ -111,6 +115,7 @@ export function ProjectBoard({ projectId, currentUserId, onOpenTask }: ProjectBo
       key={t.id}
       task={t}
       onOpen={(id) => onOpenTask?.(id)}
+      onMove={(id) => setMovePopover(id)}
       justClaimed={justClaimed === t.id}
       draggable={drag}
       onDragStart={drag ? onCardDragStart : undefined}
@@ -119,6 +124,7 @@ export function ProjectBoard({ projectId, currentUserId, onOpenTask }: ProjectBo
 
   return (
     <div className={styles.frame}>
+      <div role="status" aria-live="polite" className={styles.sr}>{announcement}</div>
       <BoardToolbar
         viewMode={viewMode}
         groupBy={groupBy}
@@ -160,6 +166,25 @@ export function ProjectBoard({ projectId, currentUserId, onOpenTask }: ProjectBo
               onDropTask={(id, status, laneKey) => dispatchDnd(id, status, laneKey)}
             />
           ))}
+        </div>
+      )}
+      {movePopover && (
+        <div role="dialog" aria-label="Move task" className={styles.movePop}>
+          <p>Move to:</p>
+          {(["ready", "claimed", "closed"] as ColStatus[]).map(s => (
+            <button
+              key={s}
+              type="button"
+              onClick={() => {
+                const id = movePopover;
+                setMovePopover(null);
+                void dispatchDnd(id, s);
+              }}
+            >
+              {s}
+            </button>
+          ))}
+          <button type="button" onClick={() => setMovePopover(null)}>Cancel</button>
         </div>
       )}
     </div>

--- a/desktop/src/apps/ProjectsApp/board/TaskCard.module.css
+++ b/desktop/src/apps/ProjectsApp/board/TaskCard.module.css
@@ -1,0 +1,25 @@
+.card { width: 100%; text-align: left; padding: 0; background: var(--board-card-bg); border: 1px solid var(--board-hair); border-radius: 11px; cursor: pointer; transition: transform .18s, box-shadow .18s, border-color .18s; position: relative; overflow: hidden; color: var(--ink-1, #f5f5f7); }
+.card:hover { transform: translateY(-2px); border-color: var(--board-hair-strong); box-shadow: 0 14px 30px rgba(0,0,0,.4), 0 0 0 1px rgba(167,139,250,.18); }
+.priEdge { position: absolute; left: 0; top: 0; bottom: 0; width: 3px; }
+.p0 .priEdge { background: linear-gradient(180deg, var(--board-p0), #c70015); }
+.p1 .priEdge { background: linear-gradient(180deg, var(--board-p1), #c97e15); }
+.p2 .priEdge { background: var(--board-p2); opacity: .5; }
+.justClaimed { animation: justClaimed 1.4s ease-out 1; border-color: rgba(245,158,11,.4); }
+@keyframes justClaimed {
+  0% { box-shadow: 0 0 0 0 rgba(245,158,11,.5); }
+  50% { box-shadow: 0 0 0 8px rgba(245,158,11,0); transform: translateY(-3px) scale(1.02); }
+  100% { box-shadow: 0 0 0 0 rgba(245,158,11,0); transform: translateY(0) scale(1); }
+}
+.body { padding: 11px 13px 12px; }
+.idRow { display: flex; gap: 6px; font: 9.5px ui-monospace, monospace; color: #86868b; margin-bottom: 5px; }
+.parent { background: rgba(255,255,255,.05); padding: 1px 6px; border-radius: 3px; color: #d2d2d7; }
+.title { font: 600 13px -apple-system; line-height: 1.35; margin-bottom: 8px; letter-spacing: -.01em; }
+.labels { display: flex; gap: 5px; flex-wrap: wrap; margin-bottom: 9px; }
+.lbl { font: 600 9.5px -apple-system; padding: 2px 7px; border-radius: 4px; }
+.lbl_feature { background: rgba(100,210,255,.16); color: #64d2ff; }
+.lbl_bug { background: rgba(255,69,58,.16); color: #ff7a73; }
+.lbl_infra { background: rgba(48,209,88,.16); color: #5fdb84; }
+.lbl_docs { background: rgba(255,214,10,.16); color: #ffe35a; }
+.lbl_review { background: rgba(191,90,242,.18); color: #d397ff; }
+.foot { display: flex; gap: 8px; font: 10.5px -apple-system; color: #86868b; }
+.grow { flex: 1; }

--- a/desktop/src/apps/ProjectsApp/board/TaskCard.tsx
+++ b/desktop/src/apps/ProjectsApp/board/TaskCard.tsx
@@ -1,4 +1,4 @@
-import type { DragEvent } from "react";
+import type { DragEvent, KeyboardEvent } from "react";
 import styles from "./TaskCard.module.css";
 import { TaskCardCover, inferCoverKind } from "./TaskCardCover";
 import type { Task } from "./types";
@@ -6,20 +6,31 @@ import type { Task } from "./types";
 export interface TaskCardProps {
   task: Task;
   onOpen: (id: string) => void;
+  onMove?: (id: string) => void;
   justClaimed?: boolean;
   draggable?: boolean;
   onDragStart?: (e: DragEvent<HTMLButtonElement>, t: Task) => void;
 }
 
-export function TaskCard({ task, onOpen, justClaimed, draggable, onDragStart }: TaskCardProps) {
+export function TaskCard({ task, onOpen, onMove, justClaimed, draggable, onDragStart }: TaskCardProps) {
   const cover = inferCoverKind(task);
   const pri = task.priority === 0 ? "p0" : task.priority === 1 ? "p1" : "p2";
+  const onKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      onOpen(task.id);
+    } else if ((e.key === "m" || e.key === "M") && onMove) {
+      e.preventDefault();
+      onMove(task.id);
+    }
+  };
   return (
     <button
       data-testid="task-card"
       type="button"
       className={`${styles.card} ${styles[pri as keyof typeof styles] ?? ""} ${justClaimed ? styles.justClaimed : ""}`}
       onClick={() => onOpen(task.id)}
+      onKeyDown={onKeyDown}
       draggable={draggable}
       onDragStart={(e) => onDragStart?.(e, task)}
       aria-label={task.title}

--- a/desktop/src/apps/ProjectsApp/board/TaskCard.tsx
+++ b/desktop/src/apps/ProjectsApp/board/TaskCard.tsx
@@ -1,0 +1,61 @@
+import type { DragEvent } from "react";
+import styles from "./TaskCard.module.css";
+import { TaskCardCover, inferCoverKind } from "./TaskCardCover";
+import type { Task } from "./types";
+
+export interface TaskCardProps {
+  task: Task;
+  onOpen: (id: string) => void;
+  justClaimed?: boolean;
+  draggable?: boolean;
+  onDragStart?: (e: DragEvent<HTMLButtonElement>, t: Task) => void;
+}
+
+export function TaskCard({ task, onOpen, justClaimed, draggable, onDragStart }: TaskCardProps) {
+  const cover = inferCoverKind(task);
+  const pri = task.priority === 0 ? "p0" : task.priority === 1 ? "p1" : "p2";
+  return (
+    <button
+      data-testid="task-card"
+      type="button"
+      className={`${styles.card} ${styles[pri as keyof typeof styles] ?? ""} ${justClaimed ? styles.justClaimed : ""}`}
+      onClick={() => onOpen(task.id)}
+      draggable={draggable}
+      onDragStart={(e) => onDragStart?.(e, task)}
+      aria-label={task.title}
+    >
+      <span className={styles.priEdge} aria-hidden />
+      <TaskCardCover kind={cover} />
+      <div className={styles.body}>
+        <div className={styles.idRow}>
+          <span>{task.id}</span>
+          {task.parent_task_id && <span className={styles.parent}>↳</span>}
+        </div>
+        <div className={styles.title}>{task.title}</div>
+        {task.labels.length > 0 && (
+          <div className={styles.labels}>
+            {task.labels.filter(l => !l.startsWith("cover:")).map(l => (
+              <span key={l} className={`${styles.lbl} ${(styles as Record<string, string | undefined>)[`lbl_${l}`] ?? ""}`}>{l}</span>
+            ))}
+          </div>
+        )}
+        <div className={styles.foot}>
+          {task.claimed_by && <span>{task.claimed_by}</span>}
+          <span className={styles.grow} />
+          <span>{relativeTime(task.updated_at)}</span>
+        </div>
+      </div>
+    </button>
+  );
+}
+
+function relativeTime(iso: string): string {
+  const d = new Date(iso).getTime();
+  const diff = Date.now() - d;
+  const min = Math.round(diff / 60_000);
+  if (min < 1) return "now";
+  if (min < 60) return `${min}m`;
+  const hrs = Math.round(min / 60);
+  if (hrs < 24) return `${hrs}h`;
+  return `${Math.round(hrs / 24)}d`;
+}

--- a/desktop/src/apps/ProjectsApp/board/TaskCardCover.module.css
+++ b/desktop/src/apps/ProjectsApp/board/TaskCardCover.module.css
@@ -1,0 +1,7 @@
+.gradient { height: 110px; background: linear-gradient(135deg, #5b21b6 0%, #1e3a8a 50%, #0c4a6e 100%); border-bottom: 1px solid var(--board-hair); position: relative; }
+.code { height: 110px; margin: 0; padding: 9px 11px; background: #0d0d10; font: 10.5px/1.5 ui-monospace, "SF Mono", Menlo, monospace; color: #d2d2d7; overflow: hidden; border-bottom: 1px solid var(--board-hair); position: relative; }
+.terminal { height: 110px; padding: 9px 11px; background: #0d0d10; font: 10px/1.55 ui-monospace, monospace; color: #82aaff; overflow: hidden; border-bottom: 1px solid var(--board-hair); position: relative; }
+.screenshot { height: 110px; background: linear-gradient(135deg, #1e3a8a 0%, #312e81 50%, #1e1b4b 100%); border-bottom: 1px solid var(--board-hair); position: relative; }
+.badge { position: absolute; top: 8px; right: 8px; background: rgba(0,0,0,0.55); color: #f5f5f7; font: 600 9.5px/1 -apple-system, sans-serif; padding: 3px 8px; border-radius: 5px; border: 1px solid rgba(255,255,255,0.12); text-transform: uppercase; letter-spacing: 0.5px; }
+.cursor { display: inline-block; width: 6px; height: 11px; background: var(--board-accent-violet); animation: blink 1.1s steps(2) infinite; }
+@keyframes blink { 0%, 50% { opacity: 1; } 50.01%, 100% { opacity: 0; } }

--- a/desktop/src/apps/ProjectsApp/board/TaskCardCover.tsx
+++ b/desktop/src/apps/ProjectsApp/board/TaskCardCover.tsx
@@ -1,0 +1,57 @@
+import styles from "./TaskCardCover.module.css";
+
+export type CoverKind = "gradient" | "code" | "terminal" | "screenshot" | "none";
+
+export interface TaskCardCoverProps {
+  kind: CoverKind;
+  data?: {
+    snippet?: string;
+    language?: string;
+    lines?: string[];
+    badge?: string;
+  };
+}
+
+export function TaskCardCover({ kind, data }: TaskCardCoverProps) {
+  if (kind === "none") return null;
+  if (kind === "gradient") {
+    return (
+      <div data-testid="cover-gradient" className={styles.gradient}>
+        {data?.badge && <span className={styles.badge}>{data.badge}</span>}
+      </div>
+    );
+  }
+  if (kind === "code") {
+    return (
+      <pre data-testid="cover-code" className={styles.code}>
+        {data?.badge && <span className={styles.badge}>{data.badge}</span>}
+        <code>{data?.snippet ?? ""}</code>
+      </pre>
+    );
+  }
+  if (kind === "terminal") {
+    return (
+      <div data-testid="cover-terminal" className={styles.terminal}>
+        {data?.badge && <span className={styles.badge}>{data.badge}</span>}
+        {(data?.lines ?? []).map((l, i) => <div key={i}>{l}</div>)}
+        <span className={styles.cursor} aria-hidden />
+      </div>
+    );
+  }
+  return (
+    <div data-testid="cover-screenshot" className={styles.screenshot}>
+      {data?.badge && <span className={styles.badge}>{data.badge}</span>}
+    </div>
+  );
+}
+
+// Heuristic: derive cover kind from labels + priority + (future) attachments
+export function inferCoverKind(task: { labels: string[]; priority: number }): CoverKind {
+  const lbl = task.labels.find(l => l.startsWith("cover:"));
+  if (lbl) {
+    const k = lbl.slice("cover:".length) as CoverKind;
+    if (["gradient", "code", "terminal", "screenshot", "none"].includes(k)) return k;
+  }
+  if (task.priority <= 1) return "gradient";
+  return "none";
+}

--- a/desktop/src/apps/ProjectsApp/board/TaskModal.module.css
+++ b/desktop/src/apps/ProjectsApp/board/TaskModal.module.css
@@ -10,3 +10,11 @@
 .title { font: 700 22px -apple-system; letter-spacing: -.02em; margin: 0 0 14px; color: #f5f5f7; }
 .bodyText { font: 13.5px -apple-system; line-height: 1.6; margin: 0; }
 .loading { color: #86868b; font: 12px -apple-system; }
+.layout { display: grid; grid-template-columns: 1fr 260px; gap: 24px; align-items: start; }
+.main { min-width: 0; }
+.layout > aside { background: rgba(255,255,255,.025); border: 1px solid var(--board-hair); border-radius: 10px; padding: 14px; display: flex; flex-direction: column; gap: 12px; font: 12px -apple-system; color: #d2d2d7; }
+.layout > aside h4 { font: 600 10.5px -apple-system; color: #86868b; margin: 0 0 4px; text-transform: uppercase; letter-spacing: .5px; }
+.layout > aside input { background: rgba(255,255,255,.05); border: 1px solid var(--board-hair); color: #f5f5f7; border-radius: 6px; padding: 4px 8px; font: 12px -apple-system; width: 100%; outline: none; }
+.layout > aside input:focus { border-color: rgba(167,139,250,.5); }
+.layout > aside [role="button"] { cursor: pointer; }
+.layout > aside [role="button"]:hover { color: #fff; }

--- a/desktop/src/apps/ProjectsApp/board/TaskModal.module.css
+++ b/desktop/src/apps/ProjectsApp/board/TaskModal.module.css
@@ -1,0 +1,12 @@
+.scrim { position: fixed; inset: 0; background: rgba(10,10,12,.6); backdrop-filter: blur(14px); display: flex; align-items: stretch; z-index: 50; }
+.frame { flex: 1; background: var(--board-bg); display: flex; flex-direction: column; }
+.bar { display: flex; align-items: center; gap: 8px; padding: 11px 16px; border-bottom: 1px solid var(--board-hair); }
+.bar button { background: transparent; border: 1px solid var(--board-hair); color: #d2d2d7; width: 28px; height: 28px; border-radius: 7px; cursor: pointer; font: 12px -apple-system; }
+.bar button:hover { background: rgba(255,255,255,.06); border-color: var(--board-hair-strong); }
+.crumb { color: #86868b; font: 11.5px -apple-system; }
+.crumb b { color: #d2d2d7; font-weight: 600; }
+.grow { flex: 1; }
+.body { padding: 22px 28px; overflow-y: auto; flex: 1; color: #d2d2d7; }
+.title { font: 700 22px -apple-system; letter-spacing: -.02em; margin: 0 0 14px; color: #f5f5f7; }
+.bodyText { font: 13.5px -apple-system; line-height: 1.6; margin: 0; }
+.loading { color: #86868b; font: 12px -apple-system; }

--- a/desktop/src/apps/ProjectsApp/board/TaskModal.tsx
+++ b/desktop/src/apps/ProjectsApp/board/TaskModal.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import styles from "./TaskModal.module.css";
 import { Hero } from "./modal/Hero";
+import { SubTasks } from "./modal/SubTasks";
+import { Relationships } from "./modal/Relationships";
 import { projectsApi } from "../../../lib/projects";
 import type { Task } from "./types";
 
@@ -13,15 +15,17 @@ export interface TaskModalProps {
 }
 
 export function TaskModal({ projectId, taskId, onClose, onPrev, onNext }: TaskModalProps) {
+  const [allTasks, setAllTasks] = useState<Task[]>([]);
   const [task, setTask] = useState<Task | null>(null);
 
   useEffect(() => {
     if (!taskId) { setTask(null); return; }
     let cancelled = false;
     (async () => {
-      const all = await projectsApi.tasks.list(projectId);
-      const found = all.find(t => t.id === taskId);
-      if (!cancelled) setTask((found ?? null) as unknown as Task | null);
+      const all = (await projectsApi.tasks.list(projectId)) as unknown as Task[];
+      if (cancelled) return;
+      setAllTasks(all);
+      setTask(all.find(t => t.id === taskId) ?? null);
     })();
     return () => { cancelled = true; };
   }, [projectId, taskId]);
@@ -54,6 +58,8 @@ export function TaskModal({ projectId, taskId, onClose, onPrev, onNext }: TaskMo
             <>
               <h1 className={styles.title}>{task.title}</h1>
               {task.body && <p className={styles.bodyText}>{task.body}</p>}
+              <SubTasks all={allTasks} parentId={task.id} />
+              <Relationships projectId={projectId} taskId={task.id} />
             </>
           ) : <p className={styles.loading}>Loading…</p>}
         </div>

--- a/desktop/src/apps/ProjectsApp/board/TaskModal.tsx
+++ b/desktop/src/apps/ProjectsApp/board/TaskModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import styles from "./TaskModal.module.css";
 import { Hero } from "./modal/Hero";
+import { MetadataPane } from "./modal/MetadataPane";
 import { SubTasks } from "./modal/SubTasks";
 import { Relationships } from "./modal/Relationships";
 import { Activity } from "./modal/Activity";
@@ -57,13 +58,23 @@ export function TaskModal({ projectId, taskId, currentUserId, onClose, onPrev, o
         {task && <Hero task={task} />}
         <div className={styles.body}>
           {task ? (
-            <>
-              <h1 className={styles.title}>{task.title}</h1>
-              {task.body && <p className={styles.bodyText}>{task.body}</p>}
-              <SubTasks all={allTasks} parentId={task.id} />
-              <Relationships projectId={projectId} taskId={task.id} />
-              <Activity projectId={projectId} taskId={task.id} currentUserId={currentUserId} />
-            </>
+            <div className={styles.layout}>
+              <main className={styles.main}>
+                <h1 className={styles.title}>{task.title}</h1>
+                {task.body && <p className={styles.bodyText}>{task.body}</p>}
+                <SubTasks all={allTasks} parentId={task.id} />
+                <Relationships projectId={projectId} taskId={task.id} />
+                <Activity projectId={projectId} taskId={task.id} currentUserId={currentUserId} />
+              </main>
+              <MetadataPane
+                projectId={projectId}
+                task={task}
+                onUpdated={(t) => {
+                  setTask(t);
+                  setAllTasks(prev => prev.map(x => x.id === t.id ? t : x));
+                }}
+              />
+            </div>
           ) : <p className={styles.loading}>Loading…</p>}
         </div>
       </div>

--- a/desktop/src/apps/ProjectsApp/board/TaskModal.tsx
+++ b/desktop/src/apps/ProjectsApp/board/TaskModal.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from "react";
+import styles from "./TaskModal.module.css";
+import { Hero } from "./modal/Hero";
+import { projectsApi } from "../../../lib/projects";
+import type { Task } from "./types";
+
+export interface TaskModalProps {
+  projectId: string;
+  taskId: string | null;
+  onClose: () => void;
+  onPrev?: () => void;
+  onNext?: () => void;
+}
+
+export function TaskModal({ projectId, taskId, onClose, onPrev, onNext }: TaskModalProps) {
+  const [task, setTask] = useState<Task | null>(null);
+
+  useEffect(() => {
+    if (!taskId) { setTask(null); return; }
+    let cancelled = false;
+    (async () => {
+      const all = await projectsApi.tasks.list(projectId);
+      const found = all.find(t => t.id === taskId);
+      if (!cancelled) setTask((found ?? null) as unknown as Task | null);
+    })();
+    return () => { cancelled = true; };
+  }, [projectId, taskId]);
+
+  useEffect(() => {
+    if (!taskId) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+      else if (e.key === "ArrowDown") onNext?.();
+      else if (e.key === "ArrowUp") onPrev?.();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [taskId, onClose, onNext, onPrev]);
+
+  if (!taskId) return null;
+  return (
+    <div className={styles.scrim} role="dialog" aria-modal="true" aria-label={task?.title ?? "Task"}>
+      <div className={styles.frame}>
+        <header className={styles.bar}>
+          <span className={styles.crumb}>Board / <b>{task?.id ?? taskId}</b></span>
+          <span className={styles.grow} />
+          <button type="button" onClick={onPrev} aria-label="Previous task">↑</button>
+          <button type="button" onClick={onNext} aria-label="Next task">↓</button>
+          <button type="button" onClick={onClose} aria-label="Close">✕</button>
+        </header>
+        {task && <Hero task={task} />}
+        <div className={styles.body}>
+          {task ? (
+            <>
+              <h1 className={styles.title}>{task.title}</h1>
+              {task.body && <p className={styles.bodyText}>{task.body}</p>}
+            </>
+          ) : <p className={styles.loading}>Loading…</p>}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/apps/ProjectsApp/board/TaskModal.tsx
+++ b/desktop/src/apps/ProjectsApp/board/TaskModal.tsx
@@ -36,9 +36,12 @@ export function TaskModal({ projectId, taskId, currentUserId, onClose, onPrev, o
   useEffect(() => {
     if (!taskId) return;
     const onKey = (e: KeyboardEvent) => {
+      const el = e.target as HTMLElement | null;
+      const tag = el?.tagName;
+      const editable = tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || el?.isContentEditable === true;
       if (e.key === "Escape") onClose();
-      else if (e.key === "ArrowDown") onNext?.();
-      else if (e.key === "ArrowUp") onPrev?.();
+      else if (!editable && e.key === "ArrowDown") onNext?.();
+      else if (!editable && e.key === "ArrowUp") onPrev?.();
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);

--- a/desktop/src/apps/ProjectsApp/board/TaskModal.tsx
+++ b/desktop/src/apps/ProjectsApp/board/TaskModal.tsx
@@ -3,18 +3,20 @@ import styles from "./TaskModal.module.css";
 import { Hero } from "./modal/Hero";
 import { SubTasks } from "./modal/SubTasks";
 import { Relationships } from "./modal/Relationships";
+import { Activity } from "./modal/Activity";
 import { projectsApi } from "../../../lib/projects";
 import type { Task } from "./types";
 
 export interface TaskModalProps {
   projectId: string;
   taskId: string | null;
+  currentUserId: string;
   onClose: () => void;
   onPrev?: () => void;
   onNext?: () => void;
 }
 
-export function TaskModal({ projectId, taskId, onClose, onPrev, onNext }: TaskModalProps) {
+export function TaskModal({ projectId, taskId, currentUserId, onClose, onPrev, onNext }: TaskModalProps) {
   const [allTasks, setAllTasks] = useState<Task[]>([]);
   const [task, setTask] = useState<Task | null>(null);
 
@@ -60,6 +62,7 @@ export function TaskModal({ projectId, taskId, onClose, onPrev, onNext }: TaskMo
               {task.body && <p className={styles.bodyText}>{task.body}</p>}
               <SubTasks all={allTasks} parentId={task.id} />
               <Relationships projectId={projectId} taskId={task.id} />
+              <Activity projectId={projectId} taskId={task.id} currentUserId={currentUserId} />
             </>
           ) : <p className={styles.loading}>Loading…</p>}
         </div>

--- a/desktop/src/apps/ProjectsApp/board/__tests__/BoardColumn.test.tsx
+++ b/desktop/src/apps/ProjectsApp/board/__tests__/BoardColumn.test.tsx
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { BoardColumn } from "../BoardColumn";
+
+describe("BoardColumn", () => {
+  it("renders header with name + count", () => {
+    render(<BoardColumn status="ready" count={3} onDropTask={() => {}}>{null}</BoardColumn>);
+    expect(screen.getByText(/Ready/)).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("calls onDropTask when a task is dropped", () => {
+    const onDrop = vi.fn();
+    render(<BoardColumn status="claimed" count={0} onDropTask={onDrop}>{null}</BoardColumn>);
+    const region = screen.getByRole("region", { name: /Claimed/ });
+    fireEvent.dragOver(region);
+    fireEvent.drop(region, { dataTransfer: { getData: () => "t1" } });
+    expect(onDrop).toHaveBeenCalledWith("t1");
+  });
+});

--- a/desktop/src/apps/ProjectsApp/board/__tests__/BoardLane.test.tsx
+++ b/desktop/src/apps/ProjectsApp/board/__tests__/BoardLane.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { BoardLane } from "../BoardLane";
+
+describe("BoardLane", () => {
+  it("renders lane header (title + subtitle)", () => {
+    render(
+      <BoardLane
+        header={{ key: "alice", kind: "assignee", title: "alice", subtitle: "2 active" }}
+        cells={{ ready: <></>, claimed: <></>, closed: <></> }}
+        onDropTask={() => {}}
+      />,
+    );
+    expect(screen.getByText("alice")).toBeInTheDocument();
+    expect(screen.getByText("2 active")).toBeInTheDocument();
+  });
+
+  it("emits onDropTask with cell info on drop", () => {
+    const onDrop = vi.fn();
+    render(
+      <BoardLane
+        header={{ key: "alice", kind: "assignee", title: "alice" }}
+        cells={{ ready: <div data-testid="r" />, claimed: <></>, closed: <></> }}
+        onDropTask={onDrop}
+      />,
+    );
+    const cell = screen.getByTestId("lane-cell-ready");
+    fireEvent.dragOver(cell);
+    fireEvent.drop(cell, { dataTransfer: { getData: () => "t1" } });
+    expect(onDrop).toHaveBeenCalledWith("t1", "ready", "alice");
+  });
+});

--- a/desktop/src/apps/ProjectsApp/board/__tests__/BoardToolbar.test.tsx
+++ b/desktop/src/apps/ProjectsApp/board/__tests__/BoardToolbar.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { BoardToolbar } from "../BoardToolbar";
+import { EMPTY_FILTERS } from "../types";
+
+describe("BoardToolbar", () => {
+  it("hides Group by selector in Kanban mode", () => {
+    render(
+      <BoardToolbar
+        viewMode="kanban"
+        groupBy="assignee"
+        filters={EMPTY_FILTERS}
+        live
+        onChangeView={() => {}}
+        onChangeGroup={() => {}}
+        onChangeFilters={() => {}}
+      />,
+    );
+    expect(screen.queryByLabelText(/Group by/)).not.toBeInTheDocument();
+  });
+
+  it("shows Group by selector in Lanes mode", () => {
+    render(
+      <BoardToolbar
+        viewMode="lanes"
+        groupBy="assignee"
+        filters={EMPTY_FILTERS}
+        live
+        onChangeView={() => {}}
+        onChangeGroup={() => {}}
+        onChangeFilters={() => {}}
+      />,
+    );
+    expect(screen.getByLabelText(/Group by/)).toBeInTheDocument();
+  });
+
+  it("emits onChangeView when a segment is clicked", () => {
+    const fn = vi.fn();
+    render(
+      <BoardToolbar
+        viewMode="lanes"
+        groupBy="assignee"
+        filters={EMPTY_FILTERS}
+        live
+        onChangeView={fn}
+        onChangeGroup={() => {}}
+        onChangeFilters={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("tab", { name: /Kanban/ }));
+    expect(fn).toHaveBeenCalledWith("kanban");
+  });
+});

--- a/desktop/src/apps/ProjectsApp/board/__tests__/ProjectBoard.test.tsx
+++ b/desktop/src/apps/ProjectsApp/board/__tests__/ProjectBoard.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ProjectBoard } from "../ProjectBoard";
+import { projectsApi } from "../../../../lib/projects";
+
+beforeEach(() => {
+  vi.spyOn(projectsApi.tasks, "list").mockResolvedValue([]);
+  vi.spyOn(projectsApi, "subscribeEvents").mockReturnValue(() => {});
+});
+
+describe("ProjectBoard", () => {
+  it("renders three columns (Ready / Claimed / Closed) in Kanban mode", async () => {
+    render(<ProjectBoard projectId="p1" currentUserId="u1" />);
+    fireEvent.click(await screen.findByRole("tab", { name: /Kanban/ }));
+    await waitFor(() => {
+      expect(screen.getByRole("region", { name: /Ready/ })).toBeInTheDocument();
+      expect(screen.getByRole("region", { name: /Claimed/ })).toBeInTheDocument();
+      expect(screen.getByRole("region", { name: /Closed/ })).toBeInTheDocument();
+    });
+  });
+
+  it("toggles between Lanes and Kanban modes", async () => {
+    render(<ProjectBoard projectId="p1" currentUserId="u1" />);
+    fireEvent.click(await screen.findByRole("tab", { name: /Kanban/ }));
+    expect(screen.getByRole("tab", { name: /Kanban/ })).toHaveAttribute("aria-selected", "true");
+  });
+});

--- a/desktop/src/apps/ProjectsApp/board/__tests__/TaskCard.test.tsx
+++ b/desktop/src/apps/ProjectsApp/board/__tests__/TaskCard.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { TaskCard } from "../TaskCard";
+import type { Task } from "../types";
+
+const t: Task = {
+  id: "t1", project_id: "p1", parent_task_id: null, title: "Wire up auth",
+  body: "", status: "claimed", priority: 1, labels: ["feature"], assignee_id: "alice",
+  claimed_by: "alice", claimed_at: "2026-04-26T00:00:00Z", closed_at: null, closed_by: null,
+  created_by: "u", created_at: "2026-04-26T00:00:00Z", updated_at: "2026-04-26T00:00:00Z",
+};
+
+describe("TaskCard", () => {
+  it("renders title, id, labels, priority bar", () => {
+    render(<TaskCard task={t} onOpen={() => {}} />);
+    expect(screen.getByText("Wire up auth")).toBeInTheDocument();
+    expect(screen.getByText("t1")).toBeInTheDocument();
+    expect(screen.getByText("feature")).toBeInTheDocument();
+  });
+
+  it("calls onOpen when clicked", () => {
+    const open = vi.fn();
+    render(<TaskCard task={t} onOpen={open} />);
+    fireEvent.click(screen.getByRole("button", { name: /Wire up auth/ }));
+    expect(open).toHaveBeenCalledWith("t1");
+  });
+
+  it("shows just-claimed marker when justClaimed is true", () => {
+    render(<TaskCard task={t} onOpen={() => {}} justClaimed />);
+    expect(screen.getByTestId("task-card")).toHaveClass(/just-?claimed/i);
+  });
+});

--- a/desktop/src/apps/ProjectsApp/board/__tests__/TaskCard.test.tsx
+++ b/desktop/src/apps/ProjectsApp/board/__tests__/TaskCard.test.tsx
@@ -29,4 +29,13 @@ describe("TaskCard", () => {
     render(<TaskCard task={t} onOpen={() => {}} justClaimed />);
     expect(screen.getByTestId("task-card")).toHaveClass(/just-?claimed/i);
   });
+
+  it("calls onMove when M is pressed while focused", () => {
+    const move = vi.fn();
+    render(<TaskCard task={t} onOpen={() => {}} onMove={move} />);
+    const card = screen.getByRole("button");
+    card.focus();
+    fireEvent.keyDown(card, { key: "M" });
+    expect(move).toHaveBeenCalledWith("t1");
+  });
 });

--- a/desktop/src/apps/ProjectsApp/board/__tests__/TaskCardCover.test.tsx
+++ b/desktop/src/apps/ProjectsApp/board/__tests__/TaskCardCover.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TaskCardCover } from "../TaskCardCover";
+
+describe("TaskCardCover", () => {
+  it("renders nothing when kind is none", () => {
+    const { container } = render(<TaskCardCover kind="none" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders gradient variant", () => {
+    render(<TaskCardCover kind="gradient" />);
+    expect(screen.getByTestId("cover-gradient")).toBeInTheDocument();
+  });
+
+  it("renders code variant with the snippet", () => {
+    render(<TaskCardCover kind="code" data={{ snippet: "let x = 1;", language: "ts" }} />);
+    expect(screen.getByTestId("cover-code").textContent).toContain("let x = 1;");
+  });
+
+  it("renders terminal variant with lines", () => {
+    render(<TaskCardCover kind="terminal" data={{ lines: ["WARN slow", "INFO ok"] }} />);
+    expect(screen.getByTestId("cover-terminal").textContent).toContain("WARN slow");
+  });
+
+  it("renders screenshot variant placeholder", () => {
+    render(<TaskCardCover kind="screenshot" />);
+    expect(screen.getByTestId("cover-screenshot")).toBeInTheDocument();
+  });
+});

--- a/desktop/src/apps/ProjectsApp/board/__tests__/TaskModal.test.tsx
+++ b/desktop/src/apps/ProjectsApp/board/__tests__/TaskModal.test.tsx
@@ -15,17 +15,18 @@ const sampleTask: ProjectTask = {
 beforeEach(() => {
   vi.spyOn(projectsApi.tasks, "list").mockResolvedValue([]);
   vi.spyOn(projectsApi.tasks, "listRelationships").mockResolvedValue([]);
+  vi.spyOn(projectsApi.tasks, "listComments").mockResolvedValue([]);
 });
 
 describe("TaskModal", () => {
   it("renders nothing when taskId is null", () => {
-    const { container } = render(<TaskModal projectId="p1" taskId={null} onClose={() => {}} />);
+    const { container } = render(<TaskModal projectId="p1" taskId={null} currentUserId="u1" onClose={() => {}} />);
     expect(container.firstChild).toBeNull();
   });
 
   it("renders title + close button when taskId is set", async () => {
     vi.spyOn(projectsApi.tasks, "list").mockResolvedValue([sampleTask]);
-    render(<TaskModal projectId="p1" taskId="t1" onClose={() => {}} />);
+    render(<TaskModal projectId="p1" taskId="t1" currentUserId="u1" onClose={() => {}} />);
     await waitFor(() => expect(screen.getByText("Spec the kanban")).toBeInTheDocument());
     expect(screen.getByRole("button", { name: /Close/i })).toBeInTheDocument();
   });
@@ -33,7 +34,7 @@ describe("TaskModal", () => {
   it("calls onClose when Escape is pressed", async () => {
     const onClose = vi.fn();
     vi.spyOn(projectsApi.tasks, "list").mockResolvedValue([sampleTask]);
-    render(<TaskModal projectId="p1" taskId="t1" onClose={onClose} />);
+    render(<TaskModal projectId="p1" taskId="t1" currentUserId="u1" onClose={onClose} />);
     await waitFor(() => expect(screen.getByText("Spec the kanban")).toBeInTheDocument());
     window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
     expect(onClose).toHaveBeenCalled();

--- a/desktop/src/apps/ProjectsApp/board/__tests__/TaskModal.test.tsx
+++ b/desktop/src/apps/ProjectsApp/board/__tests__/TaskModal.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { TaskModal } from "../TaskModal";
+import { projectsApi } from "../../../../lib/projects";
+import type { ProjectTask } from "../../../../lib/projects";
+
+const sampleTask: ProjectTask = {
+  id: "t1", project_id: "p1", parent_task_id: null,
+  title: "Spec the kanban", body: "Body text",
+  status: "open", priority: 0, labels: [], assignee_id: null,
+  claimed_by: null, claimed_at: null, closed_at: null, closed_by: null, close_reason: null,
+  created_by: "u", created_at: 0, updated_at: 0,
+};
+
+beforeEach(() => {
+  vi.spyOn(projectsApi.tasks, "list").mockResolvedValue([]);
+});
+
+describe("TaskModal", () => {
+  it("renders nothing when taskId is null", () => {
+    const { container } = render(<TaskModal projectId="p1" taskId={null} onClose={() => {}} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders title + close button when taskId is set", async () => {
+    vi.spyOn(projectsApi.tasks, "list").mockResolvedValue([sampleTask]);
+    render(<TaskModal projectId="p1" taskId="t1" onClose={() => {}} />);
+    await waitFor(() => expect(screen.getByText("Spec the kanban")).toBeInTheDocument());
+    expect(screen.getByRole("button", { name: /Close/i })).toBeInTheDocument();
+  });
+
+  it("calls onClose when Escape is pressed", async () => {
+    const onClose = vi.fn();
+    vi.spyOn(projectsApi.tasks, "list").mockResolvedValue([sampleTask]);
+    render(<TaskModal projectId="p1" taskId="t1" onClose={onClose} />);
+    await waitFor(() => expect(screen.getByText("Spec the kanban")).toBeInTheDocument());
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/desktop/src/apps/ProjectsApp/board/__tests__/TaskModal.test.tsx
+++ b/desktop/src/apps/ProjectsApp/board/__tests__/TaskModal.test.tsx
@@ -14,6 +14,7 @@ const sampleTask: ProjectTask = {
 
 beforeEach(() => {
   vi.spyOn(projectsApi.tasks, "list").mockResolvedValue([]);
+  vi.spyOn(projectsApi.tasks, "listRelationships").mockResolvedValue([]);
 });
 
 describe("TaskModal", () => {

--- a/desktop/src/apps/ProjectsApp/board/__tests__/boardDnd.test.ts
+++ b/desktop/src/apps/ProjectsApp/board/__tests__/boardDnd.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { dndAction } from "../boardDnd";
+import type { Task } from "../types";
+
+const t = (over: Partial<Task>): Task => ({
+  id: "t1", project_id: "p1", parent_task_id: null, title: "T", body: "",
+  status: "open", priority: 2, labels: [], assignee_id: null,
+  claimed_by: null, claimed_at: null, closed_at: null, closed_by: null,
+  created_by: "u", created_at: "2026-01-01", updated_at: "2026-01-01",
+  ...over,
+});
+
+describe("dndAction — kanban view", () => {
+  it("ready→claimed produces a claim call", () => {
+    const r = dndAction({
+      task: t({ status: "open" }),
+      target: { columnStatus: "claimed" },
+      viewMode: "kanban",
+      currentUserId: "u1",
+    });
+    expect(r).toEqual({ calls: [{ kind: "claim", taskId: "t1", claimerId: "u1" }] });
+  });
+
+  it("claimed→ready produces a release call", () => {
+    const r = dndAction({
+      task: t({ status: "claimed", claimed_by: "u1" }),
+      target: { columnStatus: "ready" },
+      viewMode: "kanban",
+      currentUserId: "u1",
+    });
+    expect(r).toEqual({ calls: [{ kind: "release", taskId: "t1", releaserId: "u1" }] });
+  });
+
+  it("any→closed produces a close call", () => {
+    expect(dndAction({
+      task: t({ status: "claimed", claimed_by: "u1" }),
+      target: { columnStatus: "closed" },
+      viewMode: "kanban",
+      currentUserId: "u1",
+    })).toEqual({ calls: [{ kind: "close", taskId: "t1", closedBy: "u1" }] });
+  });
+
+  it("closed→ready is blocked", () => {
+    expect(dndAction({
+      task: t({ status: "closed" }),
+      target: { columnStatus: "ready" },
+      viewMode: "kanban",
+      currentUserId: "u1",
+    })).toEqual({ blocked: "Re-open by creating a follow-up task" });
+  });
+});
+
+describe("dndAction — lanes view", () => {
+  it("change lane (assignee) emits PATCH then column action", () => {
+    expect(dndAction({
+      task: t({ status: "open", assignee_id: "alice" }),
+      target: { columnStatus: "claimed", laneKey: "bob", groupBy: "assignee" },
+      viewMode: "lanes",
+      currentUserId: "u1",
+    })).toEqual({
+      calls: [
+        { kind: "update", taskId: "t1", patch: { assignee_id: "bob" } },
+        { kind: "claim", taskId: "t1", claimerId: "u1" },
+      ],
+    });
+  });
+
+  it("change lane (priority) emits PATCH on priority", () => {
+    expect(dndAction({
+      task: t({ status: "open", priority: 2 }),
+      target: { columnStatus: "ready", laneKey: "p0", groupBy: "priority" },
+      viewMode: "lanes",
+      currentUserId: "u1",
+    })).toEqual({
+      calls: [{ kind: "update", taskId: "t1", patch: { priority: 0 } }],
+    });
+  });
+});

--- a/desktop/src/apps/ProjectsApp/board/__tests__/boardFiltering.test.ts
+++ b/desktop/src/apps/ProjectsApp/board/__tests__/boardFiltering.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { applyFilters } from "../boardFiltering";
+import { EMPTY_FILTERS } from "../types";
+import type { Task } from "../types";
+
+const t = (over: Partial<Task>): Task => ({
+  id: "t1", project_id: "p1", parent_task_id: null, title: "T", body: "",
+  status: "open", priority: 2, labels: [], assignee_id: null,
+  claimed_by: null, claimed_at: null, closed_at: null, closed_by: null,
+  created_by: "u", created_at: "2026-01-01", updated_at: "2026-01-01",
+  ...over,
+});
+
+describe("applyFilters", () => {
+  const tasks = [
+    t({ id: "a", assignee_id: "alice", labels: ["bug"], priority: 0, title: "Auth break" }),
+    t({ id: "b", assignee_id: "bob", labels: ["feature"], priority: 1, title: "New feature" }),
+    t({ id: "c", assignee_id: "alice", labels: [], priority: 2, status: "closed", title: "Old work" }),
+  ];
+
+  it("returns all tasks with empty filters", () => {
+    expect(applyFilters(tasks, EMPTY_FILTERS).map(t => t.id).sort()).toEqual(["a", "b", "c"]);
+  });
+
+  it("filters by assignee", () => {
+    expect(applyFilters(tasks, { ...EMPTY_FILTERS, assignees: ["alice"] }).map(t => t.id).sort())
+      .toEqual(["a", "c"]);
+  });
+
+  it("filters by label", () => {
+    expect(applyFilters(tasks, { ...EMPTY_FILTERS, labels: ["bug"] }).map(t => t.id))
+      .toEqual(["a"]);
+  });
+
+  it("filters by priority", () => {
+    expect(applyFilters(tasks, { ...EMPTY_FILTERS, priorities: [0, 1] }).map(t => t.id).sort())
+      .toEqual(["a", "b"]);
+  });
+
+  it("hideClosed removes closed tasks", () => {
+    expect(applyFilters(tasks, { ...EMPTY_FILTERS, hideClosed: true }).map(t => t.id).sort())
+      .toEqual(["a", "b"]);
+  });
+
+  it("search matches title (case-insensitive)", () => {
+    expect(applyFilters(tasks, { ...EMPTY_FILTERS, search: "auth" }).map(t => t.id))
+      .toEqual(["a"]);
+  });
+
+  it("AND-combines filters", () => {
+    const result = applyFilters(tasks, { ...EMPTY_FILTERS, assignees: ["alice"], labels: ["bug"] });
+    expect(result.map(t => t.id)).toEqual(["a"]);
+  });
+});

--- a/desktop/src/apps/ProjectsApp/board/__tests__/boardGrouping.test.ts
+++ b/desktop/src/apps/ProjectsApp/board/__tests__/boardGrouping.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import {
+  groupByAssignee, groupByParent, groupByLabel, groupByPriority,
+} from "../boardGrouping";
+import type { Task } from "../types";
+
+const t = (over: Partial<Task>): Task => ({
+  id: "t1", project_id: "p1", parent_task_id: null, title: "T", body: "",
+  status: "open", priority: 2, labels: [], assignee_id: null,
+  claimed_by: null, claimed_at: null, closed_at: null, closed_by: null,
+  created_by: "u", created_at: "2026-01-01", updated_at: "2026-01-01",
+  ...over,
+});
+
+describe("groupByAssignee", () => {
+  it("groups by assignee_id, with unassigned bucket", () => {
+    const lanes = groupByAssignee([
+      t({ id: "a", assignee_id: "alice" }),
+      t({ id: "b", assignee_id: "bob" }),
+      t({ id: "c", assignee_id: null }),
+      t({ id: "d", assignee_id: "alice" }),
+    ]);
+    const keys = lanes.map(l => l.header.key);
+    expect(keys).toContain("alice");
+    expect(keys).toContain("bob");
+    expect(keys).toContain("__unassigned__");
+    const alice = lanes.find(l => l.header.key === "alice")!;
+    expect(alice.cards.map(c => c.id).sort()).toEqual(["a", "d"]);
+  });
+
+  it("returns empty when no tasks", () => {
+    expect(groupByAssignee([])).toEqual([]);
+  });
+});
+
+describe("groupByParent", () => {
+  it("buckets children under their parent and orphans separately", () => {
+    const lanes = groupByParent([
+      t({ id: "p1", parent_task_id: null }),
+      t({ id: "c1", parent_task_id: "p1" }),
+      t({ id: "c2", parent_task_id: "p1" }),
+      t({ id: "o1", parent_task_id: null }),
+    ]);
+    const p = lanes.find(l => l.header.key === "p1")!;
+    expect(p.cards.map(c => c.id).sort()).toEqual(["c1", "c2"]);
+    const orphans = lanes.find(l => l.header.key === "__orphans__")!;
+    expect(orphans.cards.map(c => c.id)).toEqual(["o1"]);
+  });
+});
+
+describe("groupByLabel", () => {
+  it("renders multi-label tasks in each matching lane", () => {
+    const lanes = groupByLabel([
+      t({ id: "a", labels: ["bug", "auth"] }),
+      t({ id: "b", labels: ["bug"] }),
+      t({ id: "c", labels: [] }),
+    ]);
+    const bug = lanes.find(l => l.header.key === "bug")!;
+    expect(bug.cards.map(c => c.id).sort()).toEqual(["a", "b"]);
+    const auth = lanes.find(l => l.header.key === "auth")!;
+    expect(auth.cards.map(c => c.id)).toEqual(["a"]);
+    const unlabeled = lanes.find(l => l.header.key === "__unlabeled__")!;
+    expect(unlabeled.cards.map(c => c.id)).toEqual(["c"]);
+  });
+});
+
+describe("groupByPriority", () => {
+  it("buckets into P0/P1/P2/backlog", () => {
+    const lanes = groupByPriority([
+      t({ id: "a", priority: 0 }),
+      t({ id: "b", priority: 1 }),
+      t({ id: "c", priority: 2 }),
+      t({ id: "d", priority: 5 }),
+    ]);
+    expect(lanes.find(l => l.header.key === "p0")!.cards[0].id).toBe("a");
+    expect(lanes.find(l => l.header.key === "p1")!.cards[0].id).toBe("b");
+    expect(lanes.find(l => l.header.key === "p2")!.cards[0].id).toBe("c");
+    expect(lanes.find(l => l.header.key === "backlog")!.cards[0].id).toBe("d");
+  });
+});

--- a/desktop/src/apps/ProjectsApp/board/__tests__/useBoardData.test.tsx
+++ b/desktop/src/apps/ProjectsApp/board/__tests__/useBoardData.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useBoardData } from "../useBoardData";
+import { projectsApi } from "../../../../lib/projects";
+
+beforeEach(() => vi.restoreAllMocks());
+
+const seed = (over: Record<string, unknown>) => ({
+  id: "t1", title: "T", status: "open", priority: 2, labels: [],
+  project_id: "p1", parent_task_id: null, body: "",
+  assignee_id: null, claimed_by: null, claimed_at: null,
+  closed_at: null, closed_by: null, close_reason: null,
+  created_by: "u", created_at: 0, updated_at: 0,
+  ...over,
+}) as any;
+
+describe("useBoardData", () => {
+  it("loads the initial task list", async () => {
+    vi.spyOn(projectsApi.tasks, "list").mockResolvedValue([seed({})]);
+    const { result } = renderHook(() => useBoardData("p1"));
+    await waitFor(() => expect(result.current.tasks.length).toBe(1));
+  });
+
+  it("applies a task.updated event", async () => {
+    vi.spyOn(projectsApi.tasks, "list").mockImplementation(async (_pid, status) => {
+      return status === "open" ? [seed({})] : [];
+    });
+    const { result } = renderHook(() => useBoardData("p1"));
+    await waitFor(() => expect(result.current.tasks.length).toBe(1));
+    act(() => result.current.applyEvent({ kind: "task.updated", payload: { id: "t1", patch: { title: "Renamed" } }, ts: 0 }));
+    expect(result.current.tasks[0].title).toBe("Renamed");
+  });
+});

--- a/desktop/src/apps/ProjectsApp/board/__tests__/useBoardLive.test.tsx
+++ b/desktop/src/apps/ProjectsApp/board/__tests__/useBoardLive.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useBoardLive } from "../useBoardLive";
+import { projectsApi } from "../../../../lib/projects";
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useBoardLive", () => {
+  it("subscribes via projectsApi and forwards events", () => {
+    let captured: ((e: any) => void) | null = null;
+    const unsub = vi.fn();
+    vi.spyOn(projectsApi, "subscribeEvents").mockImplementation((_pid, cb) => {
+      captured = cb;
+      return unsub;
+    });
+    const onEvent = vi.fn();
+    const { unmount } = renderHook(() => useBoardLive("p1", onEvent));
+    act(() => captured?.({ kind: "task.created", payload: { id: "t1" }, ts: 0 }));
+    expect(onEvent).toHaveBeenCalledWith(expect.objectContaining({ kind: "task.created" }));
+    unmount();
+    expect(unsub).toHaveBeenCalled();
+  });
+
+  it("exposes connected status (true after subscribe)", () => {
+    vi.spyOn(projectsApi, "subscribeEvents").mockReturnValue(() => {});
+    const { result } = renderHook(() => useBoardLive("p1", () => {}));
+    expect(result.current.connected).toBe(true);
+  });
+});

--- a/desktop/src/apps/ProjectsApp/board/boardDnd.ts
+++ b/desktop/src/apps/ProjectsApp/board/boardDnd.ts
@@ -1,0 +1,76 @@
+import type { Task, ViewMode, GroupBy, TaskStatus } from "./types";
+
+export type ApiCall =
+  | { kind: "claim"; taskId: string; claimerId: string }
+  | { kind: "release"; taskId: string; releaserId: string }
+  | { kind: "close"; taskId: string; closedBy: string }
+  | { kind: "update"; taskId: string; patch: Partial<Task> };
+
+export type DndResult = { calls: ApiCall[] } | { blocked: string };
+
+export interface DndInput {
+  task: Task;
+  target: {
+    columnStatus: "ready" | "claimed" | "closed";
+    laneKey?: string;
+    groupBy?: GroupBy;
+  };
+  viewMode: ViewMode;
+  currentUserId: string;
+}
+
+export function dndAction(input: DndInput): DndResult {
+  const { task, target, viewMode, currentUserId } = input;
+  const calls: ApiCall[] = [];
+
+  // 1) Lane change first (Lanes mode only)
+  if (viewMode === "lanes" && target.laneKey && target.groupBy) {
+    const patch = lanePatch(task, target.laneKey, target.groupBy);
+    if (patch) calls.push({ kind: "update", taskId: task.id, patch });
+  }
+
+  // 2) Column status change
+  const fromStatus = mapStatus(task.status);
+  if (fromStatus !== target.columnStatus) {
+    if (fromStatus === "closed") {
+      return { blocked: "Re-open by creating a follow-up task" };
+    }
+    if (target.columnStatus === "claimed") {
+      calls.push({ kind: "claim", taskId: task.id, claimerId: currentUserId });
+    } else if (target.columnStatus === "ready") {
+      calls.push({ kind: "release", taskId: task.id, releaserId: currentUserId });
+    } else if (target.columnStatus === "closed") {
+      calls.push({ kind: "close", taskId: task.id, closedBy: currentUserId });
+    }
+  }
+
+  return { calls };
+}
+
+function mapStatus(s: TaskStatus): "ready" | "claimed" | "closed" {
+  return s === "open" ? "ready" : s === "claimed" ? "claimed" : "closed";
+}
+
+function lanePatch(task: Task, laneKey: string, groupBy: GroupBy): Partial<Task> | null {
+  switch (groupBy) {
+    case "assignee":
+      if (laneKey === "__unassigned__") return { assignee_id: null };
+      if (task.assignee_id === laneKey) return null;
+      return { assignee_id: laneKey };
+    case "parent":
+      if (laneKey === "__orphans__") return { parent_task_id: null };
+      if (task.parent_task_id === laneKey) return null;
+      return { parent_task_id: laneKey };
+    case "priority": {
+      const p = laneKey === "p0" ? 0 : laneKey === "p1" ? 1 : laneKey === "p2" ? 2 : 3;
+      if (task.priority === p) return null;
+      return { priority: p };
+    }
+    case "label": {
+      const targetLbl = laneKey === "__unlabeled__" ? null : laneKey;
+      if (targetLbl && task.labels.includes(targetLbl)) return null;
+      const next = targetLbl ? [...task.labels, targetLbl] : [];
+      return { labels: next };
+    }
+  }
+}

--- a/desktop/src/apps/ProjectsApp/board/boardDnd.ts
+++ b/desktop/src/apps/ProjectsApp/board/boardDnd.ts
@@ -51,6 +51,12 @@ function mapStatus(s: TaskStatus): "ready" | "claimed" | "closed" {
   return s === "open" ? "ready" : s === "claimed" ? "claimed" : "closed";
 }
 
+function sameMembers(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const sa = new Set(a);
+  return b.every(x => sa.has(x));
+}
+
 function lanePatch(task: Task, laneKey: string, groupBy: GroupBy): Partial<Task> | null {
   switch (groupBy) {
     case "assignee":
@@ -67,9 +73,12 @@ function lanePatch(task: Task, laneKey: string, groupBy: GroupBy): Partial<Task>
       return { priority: p };
     }
     case "label": {
+      // Replace category labels with target; preserve cover:* markers.
+      // __unlabeled__ removes all category labels but keeps cover:* labels.
+      const covers = task.labels.filter(l => l.startsWith("cover:"));
       const targetLbl = laneKey === "__unlabeled__" ? null : laneKey;
-      if (targetLbl && task.labels.includes(targetLbl)) return null;
-      const next = targetLbl ? [...task.labels, targetLbl] : [];
+      const next = targetLbl ? [...covers, targetLbl] : covers;
+      if (sameMembers(task.labels, next)) return null;
       return { labels: next };
     }
   }

--- a/desktop/src/apps/ProjectsApp/board/boardFiltering.ts
+++ b/desktop/src/apps/ProjectsApp/board/boardFiltering.ts
@@ -1,0 +1,18 @@
+import type { Task, Filters } from "./types";
+
+export function applyFilters(tasks: Task[], f: Filters): Task[] {
+  const search = f.search.trim().toLowerCase();
+  return tasks.filter(t => {
+    if (f.assignees.length && !f.assignees.includes(t.assignee_id ?? "")) return false;
+    if (f.labels.length && !f.labels.some(l => t.labels.includes(l))) return false;
+    if (f.priorities.length && !f.priorities.includes(t.priority)) return false;
+    if (f.parentTaskId && t.parent_task_id !== f.parentTaskId) return false;
+    if (f.hideClosed && t.status === "closed") return false;
+    if (search) {
+      const hay = `${t.title} ${t.body} ${t.id}`.toLowerCase();
+      if (!hay.includes(search)) return false;
+    }
+    // hasAttachments: not modeled yet — pass-through. When attachments land, check t.attachments.length > 0.
+    return true;
+  });
+}

--- a/desktop/src/apps/ProjectsApp/board/boardGrouping.ts
+++ b/desktop/src/apps/ProjectsApp/board/boardGrouping.ts
@@ -1,0 +1,104 @@
+import type { Task, Lane } from "./types";
+
+export function groupByAssignee(tasks: Task[]): Lane[] {
+  const buckets = new Map<string, Task[]>();
+  for (const t of tasks) {
+    const k = t.assignee_id ?? "__unassigned__";
+    if (!buckets.has(k)) buckets.set(k, []);
+    buckets.get(k)!.push(t);
+  }
+  return [...buckets.entries()].map(([key, cards]) => ({
+    header: {
+      key,
+      kind: "assignee",
+      title: key === "__unassigned__" ? "Unassigned" : key,
+      subtitle: `${cards.length} task${cards.length === 1 ? "" : "s"}`,
+      avatarSeed: key,
+    },
+    cards,
+  }));
+}
+
+export function groupByParent(tasks: Task[]): Lane[] {
+  const byId = new Map(tasks.map(t => [t.id, t]));
+  const buckets = new Map<string, Task[]>();
+  for (const t of tasks) {
+    const parent = t.parent_task_id;
+    if (parent && byId.has(parent)) {
+      if (!buckets.has(parent)) buckets.set(parent, []);
+      buckets.get(parent)!.push(t);
+    }
+  }
+  const lanes: Lane[] = [];
+  for (const [parentId, cards] of buckets) {
+    const parent = byId.get(parentId)!;
+    lanes.push({
+      header: {
+        key: parentId,
+        kind: "parent",
+        title: parent.title,
+        subtitle: `${cards.length} sub-task${cards.length === 1 ? "" : "s"}`,
+      },
+      cards,
+    });
+  }
+  // Orphan lane: tasks with no parent and no children
+  const childIds = new Set([...buckets.values()].flat().map(t => t.id));
+  const parentIds = new Set(buckets.keys());
+  const orphans = tasks.filter(t => !childIds.has(t.id) && !parentIds.has(t.id));
+  if (orphans.length > 0) {
+    lanes.push({
+      header: { key: "__orphans__", kind: "parent", title: "Standalone", subtitle: `${orphans.length}` },
+      cards: orphans,
+    });
+  }
+  return lanes;
+}
+
+export function groupByLabel(tasks: Task[]): Lane[] {
+  const buckets = new Map<string, Task[]>();
+  for (const t of tasks) {
+    if (t.labels.length === 0) {
+      const k = "__unlabeled__";
+      if (!buckets.has(k)) buckets.set(k, []);
+      buckets.get(k)!.push(t);
+    } else {
+      for (const lbl of t.labels) {
+        if (!buckets.has(lbl)) buckets.set(lbl, []);
+        buckets.get(lbl)!.push(t);
+      }
+    }
+  }
+  return [...buckets.entries()].map(([key, cards]) => ({
+    header: {
+      key,
+      kind: "label",
+      title: key === "__unlabeled__" ? "Unlabeled" : key,
+      subtitle: `${cards.length}`,
+    },
+    cards,
+  }));
+}
+
+export function groupByPriority(tasks: Task[]): Lane[] {
+  const buckets = new Map<string, { title: string; cards: Task[] }>([
+    ["p0", { title: "P0 — urgent", cards: [] }],
+    ["p1", { title: "P1 — high", cards: [] }],
+    ["p2", { title: "P2 — normal", cards: [] }],
+    ["backlog", { title: "Backlog", cards: [] }],
+  ]);
+  for (const t of tasks) {
+    const k = t.priority === 0 ? "p0" : t.priority === 1 ? "p1" : t.priority === 2 ? "p2" : "backlog";
+    buckets.get(k)!.cards.push(t);
+  }
+  const lanes: Lane[] = [];
+  for (const [k, { title, cards }] of buckets) {
+    if (cards.length > 0) {
+      lanes.push({
+        header: { key: k, kind: "priority", title, subtitle: `${cards.length}` },
+        cards,
+      });
+    }
+  }
+  return lanes;
+}

--- a/desktop/src/apps/ProjectsApp/board/modal/Activity.tsx
+++ b/desktop/src/apps/ProjectsApp/board/modal/Activity.tsx
@@ -23,7 +23,7 @@ export function Activity({ projectId, taskId, currentUserId }: ActivityProps) {
 
   const submit = async () => {
     const body = draft.trim();
-    if (!body) return;
+    if (!body || !currentUserId) return;
     const c = await projectsApi.tasks.addComment(projectId, taskId, { body, author_id: currentUserId });
     setComments(prev => [...prev, c]);
     setDraft("");
@@ -44,7 +44,7 @@ export function Activity({ projectId, taskId, currentUserId }: ActivityProps) {
           placeholder="Comment…"
           aria-label="Comment composer"
         />
-        <button type="submit">↵ Send</button>
+        <button type="submit" disabled={!currentUserId || !draft.trim()}>↵ Send</button>
       </form>
     </section>
   );

--- a/desktop/src/apps/ProjectsApp/board/modal/Activity.tsx
+++ b/desktop/src/apps/ProjectsApp/board/modal/Activity.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from "react";
+import { projectsApi } from "../../../../lib/projects";
+import type { ProjectComment } from "../../../../lib/projects";
+
+export interface ActivityProps {
+  projectId: string;
+  taskId: string;
+  currentUserId: string;
+}
+
+export function Activity({ projectId, taskId, currentUserId }: ActivityProps) {
+  const [comments, setComments] = useState<ProjectComment[]>([]);
+  const [draft, setDraft] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const items = await projectsApi.tasks.listComments(projectId, taskId);
+      if (!cancelled) setComments(items);
+    })();
+    return () => { cancelled = true; };
+  }, [projectId, taskId]);
+
+  const submit = async () => {
+    const body = draft.trim();
+    if (!body) return;
+    const c = await projectsApi.tasks.addComment(projectId, taskId, { body, author_id: currentUserId });
+    setComments(prev => [...prev, c]);
+    setDraft("");
+  };
+
+  return (
+    <section className="board-section">
+      <h3>Activity</h3>
+      <ul>
+        {comments.map(c => (
+          <li key={c.id}><b>{c.author_id}</b>: {c.body}</li>
+        ))}
+      </ul>
+      <form onSubmit={(e) => { e.preventDefault(); void submit(); }}>
+        <input
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          placeholder="Comment…"
+          aria-label="Comment composer"
+        />
+        <button type="submit">↵ Send</button>
+      </form>
+    </section>
+  );
+}

--- a/desktop/src/apps/ProjectsApp/board/modal/Hero.tsx
+++ b/desktop/src/apps/ProjectsApp/board/modal/Hero.tsx
@@ -1,0 +1,12 @@
+import { TaskCardCover, inferCoverKind } from "../TaskCardCover";
+import type { Task } from "../types";
+
+export function Hero({ task }: { task: Task }) {
+  const kind = inferCoverKind(task);
+  if (kind === "none") return null;
+  return (
+    <div style={{ height: 160, position: "relative", overflow: "hidden" }}>
+      <TaskCardCover kind={kind} />
+    </div>
+  );
+}

--- a/desktop/src/apps/ProjectsApp/board/modal/MetadataPane.tsx
+++ b/desktop/src/apps/ProjectsApp/board/modal/MetadataPane.tsx
@@ -1,0 +1,92 @@
+import { useState } from "react";
+import { projectsApi } from "../../../../lib/projects";
+import type { ProjectTask } from "../../../../lib/projects";
+import type { Task } from "../types";
+
+export interface MetadataPaneProps {
+  projectId: string;
+  task: Task;
+  onUpdated: (t: Task) => void;
+}
+
+type FieldKey = "priority" | "assignee" | "labels";
+
+export function MetadataPane({ projectId, task, onUpdated }: MetadataPaneProps) {
+  const [editing, setEditing] = useState<FieldKey | null>(null);
+
+  const save = async (patch: Partial<ProjectTask>) => {
+    const updated = await projectsApi.tasks.update(projectId, task.id, patch);
+    onUpdated(updated as unknown as Task);
+    setEditing(null);
+  };
+
+  return (
+    <aside className="board-meta">
+      <Field label="Status" value={task.status} />
+      <Field
+        label="Priority"
+        value={String(task.priority)}
+        editing={editing === "priority"}
+        onEdit={() => setEditing("priority")}
+        onCancel={() => setEditing(null)}
+        onSave={(v) => save({ priority: Number(v) })}
+      />
+      <Field
+        label="Assignee"
+        value={task.assignee_id ?? "—"}
+        editing={editing === "assignee"}
+        onEdit={() => setEditing("assignee")}
+        onCancel={() => setEditing(null)}
+        onSave={(v) => save({ assignee_id: v.trim() || null })}
+      />
+      <Field
+        label="Labels"
+        value={task.labels.join(", ")}
+        editing={editing === "labels"}
+        onEdit={() => setEditing("labels")}
+        onCancel={() => setEditing(null)}
+        onSave={(v) => save({ labels: v.split(",").map(s => s.trim()).filter(Boolean) })}
+      />
+    </aside>
+  );
+}
+
+interface FieldProps {
+  label: string;
+  value: string;
+  editing?: boolean;
+  onEdit?: () => void;
+  onCancel?: () => void;
+  onSave?: (v: string) => void;
+}
+
+function Field({ label, value, editing, onEdit, onCancel, onSave }: FieldProps) {
+  const [draft, setDraft] = useState(value);
+  return (
+    <div>
+      <h4>{label}</h4>
+      {editing ? (
+        <input
+          autoFocus
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={() => onSave?.(draft)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") onSave?.(draft);
+            else if (e.key === "Escape") { setDraft(value); onCancel?.(); }
+          }}
+          aria-label={label}
+        />
+      ) : (
+        <span
+          role={onEdit ? "button" : undefined}
+          tabIndex={onEdit ? 0 : undefined}
+          onClick={onEdit}
+          onKeyDown={(e) => { if (onEdit && (e.key === "Enter" || e.key === " ")) { e.preventDefault(); onEdit(); } }}
+        >
+          {value}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/desktop/src/apps/ProjectsApp/board/modal/MetadataPane.tsx
+++ b/desktop/src/apps/ProjectsApp/board/modal/MetadataPane.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { projectsApi } from "../../../../lib/projects";
 import type { ProjectTask } from "../../../../lib/projects";
 import type { Task } from "../types";
@@ -29,7 +29,11 @@ export function MetadataPane({ projectId, task, onUpdated }: MetadataPaneProps) 
         editing={editing === "priority"}
         onEdit={() => setEditing("priority")}
         onCancel={() => setEditing(null)}
-        onSave={(v) => save({ priority: Number(v) })}
+        onSave={(v) => {
+          const n = Number(v);
+          if (!Number.isFinite(n) || n < 0 || n > 3) { setEditing(null); return; }
+          void save({ priority: n });
+        }}
       />
       <Field
         label="Assignee"
@@ -62,6 +66,9 @@ interface FieldProps {
 
 function Field({ label, value, editing, onEdit, onCancel, onSave }: FieldProps) {
   const [draft, setDraft] = useState(value);
+  const committedRef = useRef(false);
+  useEffect(() => { setDraft(value); }, [value]);
+  useEffect(() => { if (editing) committedRef.current = false; }, [editing]);
   return (
     <div>
       <h4>{label}</h4>
@@ -70,10 +77,10 @@ function Field({ label, value, editing, onEdit, onCancel, onSave }: FieldProps) 
           autoFocus
           value={draft}
           onChange={(e) => setDraft(e.target.value)}
-          onBlur={() => onSave?.(draft)}
+          onBlur={() => { if (committedRef.current) return; committedRef.current = true; onSave?.(draft); }}
           onKeyDown={(e) => {
-            if (e.key === "Enter") onSave?.(draft);
-            else if (e.key === "Escape") { setDraft(value); onCancel?.(); }
+            if (e.key === "Enter") { committedRef.current = true; onSave?.(draft); }
+            else if (e.key === "Escape") { committedRef.current = true; setDraft(value); onCancel?.(); }
           }}
           aria-label={label}
         />

--- a/desktop/src/apps/ProjectsApp/board/modal/Relationships.tsx
+++ b/desktop/src/apps/ProjectsApp/board/modal/Relationships.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+import { projectsApi } from "../../../../lib/projects";
+import type { ProjectRelationship } from "../../../../lib/projects";
+
+export function Relationships({ projectId, taskId }: { projectId: string; taskId: string }) {
+  const [rels, setRels] = useState<ProjectRelationship[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const [from, to] = await Promise.all([
+        projectsApi.tasks.listRelationships(projectId, taskId, "from"),
+        projectsApi.tasks.listRelationships(projectId, taskId, "to"),
+      ]);
+      if (!cancelled) setRels([...from, ...to]);
+    })();
+    return () => { cancelled = true; };
+  }, [projectId, taskId]);
+  if (rels.length === 0) return null;
+  return (
+    <section className="board-section">
+      <h3>Relationships</h3>
+      <ul>
+        {rels.map(r => (
+          <li key={r.id}>
+            <b>{r.kind}</b>{" "}
+            {r.from_task_id === taskId ? "→" : "←"}{" "}
+            {r.from_task_id === taskId ? r.to_task_id : r.from_task_id}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/desktop/src/apps/ProjectsApp/board/modal/SubTasks.tsx
+++ b/desktop/src/apps/ProjectsApp/board/modal/SubTasks.tsx
@@ -1,0 +1,20 @@
+import type { Task } from "../types";
+
+export function SubTasks({ all, parentId }: { all: Task[]; parentId: string }) {
+  const children = all.filter(t => t.parent_task_id === parentId);
+  if (children.length === 0) return null;
+  const done = children.filter(c => c.status === "closed").length;
+  return (
+    <section className="board-section">
+      <h3>Sub-tasks · {done} / {children.length}</h3>
+      <ul>
+        {children.map(c => (
+          <li key={c.id}>
+            <input type="checkbox" checked={c.status === "closed"} readOnly aria-label={c.title} />
+            <span>{c.title}</span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/desktop/src/apps/ProjectsApp/board/types.ts
+++ b/desktop/src/apps/ProjectsApp/board/types.ts
@@ -1,0 +1,51 @@
+export type TaskStatus = "open" | "claimed" | "closed";
+
+export interface Task {
+  id: string;
+  project_id: string;
+  parent_task_id: string | null;
+  title: string;
+  body: string;
+  status: TaskStatus;
+  priority: number;
+  labels: string[];
+  assignee_id: string | null;
+  claimed_by: string | null;
+  claimed_at: string | null;
+  closed_at: string | null;
+  closed_by: string | null;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export type ViewMode = "lanes" | "kanban" | "timeline";
+export type GroupBy = "assignee" | "parent" | "label" | "priority";
+
+export interface LaneHeader {
+  key: string;            // stable key for React
+  kind: GroupBy;
+  title: string;
+  subtitle?: string;
+  avatarSeed?: string;    // for color hashing
+}
+
+export interface Lane {
+  header: LaneHeader;
+  cards: Task[];
+}
+
+export interface Filters {
+  assignees: string[];
+  labels: string[];
+  priorities: number[];
+  parentTaskId: string | null;
+  hasAttachments: boolean;
+  hideClosed: boolean;
+  search: string;
+}
+
+export const EMPTY_FILTERS: Filters = {
+  assignees: [], labels: [], priorities: [], parentTaskId: null,
+  hasAttachments: false, hideClosed: false, search: "",
+};

--- a/desktop/src/apps/ProjectsApp/board/useBoardData.ts
+++ b/desktop/src/apps/ProjectsApp/board/useBoardData.ts
@@ -1,0 +1,57 @@
+import { useCallback, useEffect, useState } from "react";
+import { projectsApi } from "../../../lib/projects";
+import type { Task } from "./types";
+import type { BoardLiveEvent } from "./useBoardLive";
+
+export function useBoardData(projectId: string) {
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    (async () => {
+      const [open, claimed, closed] = await Promise.all([
+        projectsApi.tasks.list(projectId, "open"),
+        projectsApi.tasks.list(projectId, "claimed"),
+        projectsApi.tasks.list(projectId, "closed"),
+      ]);
+      if (!cancelled) {
+        const seen = new Set<string>();
+        const all = [...open, ...claimed, ...closed].filter(t => {
+          if (seen.has(t.id)) return false;
+          seen.add(t.id);
+          return true;
+        });
+        setTasks(all as unknown as Task[]);
+        setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [projectId]);
+
+  const applyEvent = useCallback((e: BoardLiveEvent) => {
+    setTasks(prev => {
+      const p = e.payload as Record<string, any>;
+      switch (e.kind) {
+        case "task.created":
+          if (prev.find(t => t.id === p.id)) return prev;
+          return [...prev, p.task as Task];
+        case "task.updated":
+          return prev.map(t => t.id === p.id ? { ...t, ...(p.patch as Partial<Task>) } : t);
+        case "task.claimed":
+          return prev.map(t => t.id === p.id ? { ...t, status: "claimed", claimed_by: p.claimed_by ?? null } : t);
+        case "task.released":
+          return prev.map(t => t.id === p.id ? { ...t, status: "open", claimed_by: null } : t);
+        case "task.closed":
+          return prev.map(t => t.id === p.id ? { ...t, status: "closed", closed_by: p.closed_by ?? null } : t);
+        case "task.deleted":
+          return prev.filter(t => t.id !== p.id);
+        default:
+          return prev;
+      }
+    });
+  }, []);
+
+  return { tasks, loading, setTasks, applyEvent };
+}

--- a/desktop/src/apps/ProjectsApp/board/useBoardLive.ts
+++ b/desktop/src/apps/ProjectsApp/board/useBoardLive.ts
@@ -1,0 +1,25 @@
+import { useEffect, useRef, useState } from "react";
+import { projectsApi, type ProjectEvent } from "../../../lib/projects";
+
+export type BoardLiveEvent = ProjectEvent;
+
+export function useBoardLive(projectId: string, onEvent: (e: BoardLiveEvent) => void) {
+  const [connected, setConnected] = useState(false);
+  const onEventRef = useRef(onEvent);
+  onEventRef.current = onEvent;
+
+  useEffect(() => {
+    let active = true;
+    const off = projectsApi.subscribeEvents(projectId, (e) => {
+      if (active) onEventRef.current(e);
+    });
+    setConnected(true);
+    return () => {
+      active = false;
+      setConnected(false);
+      off();
+    };
+  }, [projectId]);
+
+  return { connected };
+}

--- a/desktop/src/lib/__tests__/projects-tasks.test.ts
+++ b/desktop/src/lib/__tests__/projects-tasks.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { projectsApi } from "../projects";
+
+const fetchMock = vi.fn();
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+function ok(data: unknown) {
+  return { ok: true, status: 200, json: async () => data };
+}
+
+describe("projectsApi.tasks (extended)", () => {
+  it("update PATCHes the task", async () => {
+    fetchMock.mockResolvedValueOnce(ok({ id: "t1", title: "renamed" }));
+    const r = await projectsApi.tasks.update("p1", "t1", { title: "renamed" });
+    expect(fetchMock.mock.calls[0][0]).toMatch("/api/projects/p1/tasks/t1");
+    expect(fetchMock.mock.calls[0][1].method).toBe("PATCH");
+    expect(r.title).toBe("renamed");
+  });
+
+  it("listComments fetches comment list", async () => {
+    fetchMock.mockResolvedValueOnce(ok({ items: [{ id: "c1" }] }));
+    const r = await projectsApi.tasks.listComments("p1", "t1");
+    expect(fetchMock.mock.calls[0][0]).toMatch("/api/projects/p1/tasks/t1/comments");
+    expect(r).toEqual([{ id: "c1" }]);
+  });
+
+  it("addComment posts a comment", async () => {
+    fetchMock.mockResolvedValueOnce(ok({ id: "c1" }));
+    await projectsApi.tasks.addComment("p1", "t1", { body: "hi", author_id: "u" });
+    expect(fetchMock.mock.calls[0][1].method).toBe("POST");
+  });
+
+  it("addRelationship posts an edge", async () => {
+    fetchMock.mockResolvedValueOnce(ok({ from_task_id: "a", to_task_id: "b", kind: "blocks" }));
+    await projectsApi.tasks.addRelationship("p1", "a", { to_task_id: "b", kind: "blocks", created_by: "u" });
+    expect(fetchMock.mock.calls[0][1].method).toBe("POST");
+  });
+
+  it("listRelationships fetches edges", async () => {
+    fetchMock.mockResolvedValueOnce(ok({ items: [] }));
+    await projectsApi.tasks.listRelationships("p1", "t1", "from");
+    expect(fetchMock.mock.calls[0][0]).toMatch("/relationships?direction=from");
+  });
+});
+
+describe("projectsApi.subscribeEvents", () => {
+  it("opens an EventSource for the project events endpoint", () => {
+    const closeSpy = vi.fn();
+    const eventSourceMock = vi.fn(() => ({ close: closeSpy, onmessage: null as ((e: MessageEvent) => void) | null }));
+    vi.stubGlobal("EventSource", eventSourceMock);
+    const off = projectsApi.subscribeEvents("p1", () => {});
+    expect(eventSourceMock).toHaveBeenCalledWith(expect.stringMatching("/api/projects/p1/events"));
+    off();
+    expect(closeSpy).toHaveBeenCalled();
+  });
+});

--- a/desktop/src/lib/projects.ts
+++ b/desktop/src/lib/projects.ts
@@ -48,6 +48,31 @@ export type ProjectActivity = {
   created_at: number;
 };
 
+export type ProjectComment = {
+  id: string;
+  task_id: string;
+  author_id: string;
+  body: string;
+  replies_to_comment_id: string | null;
+  created_at: number;
+};
+
+export type ProjectRelationship = {
+  id: string;
+  project_id: string;
+  from_task_id: string;
+  to_task_id: string;
+  kind: string;
+  created_by: string;
+  created_at: number;
+};
+
+export type ProjectEvent = {
+  kind: string;
+  payload: Record<string, unknown>;
+  ts: number;
+};
+
 async function http<T>(path: string, init?: RequestInit): Promise<T> {
   const r = await fetch(path, {
     credentials: "include",
@@ -118,8 +143,45 @@ export const projectsApi = {
         method: "POST",
         body: JSON.stringify({ closed_by, reason }),
       }),
+    update: (pid: string, tid: string, patch: Partial<ProjectTask>) =>
+      http<ProjectTask>(`/api/projects/${pid}/tasks/${tid}`, {
+        method: "PATCH",
+        body: JSON.stringify(patch),
+      }),
+    listComments: (pid: string, tid: string) =>
+      http<{ items: ProjectComment[] }>(`/api/projects/${pid}/tasks/${tid}/comments`).then((r) => r.items),
+    addComment: (
+      pid: string,
+      tid: string,
+      input: { body: string; author_id: string; replies_to_comment_id?: string },
+    ) =>
+      http<ProjectComment>(`/api/projects/${pid}/tasks/${tid}/comments`, {
+        method: "POST",
+        body: JSON.stringify(input),
+      }),
+    listRelationships: (pid: string, tid: string, direction: "from" | "to" = "from") =>
+      http<{ items: ProjectRelationship[] }>(
+        `/api/projects/${pid}/tasks/${tid}/relationships?direction=${direction}`,
+      ).then((r) => r.items),
+    addRelationship: (
+      pid: string,
+      tid: string,
+      input: { to_task_id: string; kind: string; created_by: string },
+    ) =>
+      http<ProjectRelationship>(`/api/projects/${pid}/tasks/${tid}/relationships`, {
+        method: "POST",
+        body: JSON.stringify(input),
+      }),
   },
 
   activity: (pid: string) =>
     http<{ items: ProjectActivity[] }>(`/api/projects/${pid}/activity`).then((r) => r.items),
+
+  subscribeEvents(projectId: string, onEvent: (ev: ProjectEvent) => void): () => void {
+    const es = new EventSource(`/api/projects/${projectId}/events`);
+    es.onmessage = (e) => {
+      try { onEvent(JSON.parse(e.data) as ProjectEvent); } catch { /* heartbeat / malformed — skip */ }
+    };
+    return () => es.close();
+  },
 };

--- a/desktop/src/theme/tokens.css
+++ b/desktop/src/theme/tokens.css
@@ -91,3 +91,19 @@
   outline-offset: 2px;
   transition: outline 0.2s ease-out;
 }
+
+/* Projects board — Apple-grade chrome (Pass B Kanban) */
+:root {
+  --board-accent-violet: #a78bfa;
+  --board-accent-violet-soft: rgba(167, 139, 250, 0.14);
+  --board-hair: rgba(255, 255, 255, 0.07);
+  --board-hair-strong: rgba(255, 255, 255, 0.12);
+  --board-card-bg: linear-gradient(180deg, #26262b, #1f1f22);
+  --board-bg: linear-gradient(180deg, #1a1a1c, #131316);
+  --board-p0: #ff453a;
+  --board-p1: #ffb340;
+  --board-p2: #8e8e93;
+  --board-status-ready: #64d2ff;
+  --board-status-claimed: #ffb340;
+  --board-status-closed: #30d158;
+}

--- a/desktop/src/types/css-modules.d.ts
+++ b/desktop/src/types/css-modules.d.ts
@@ -1,0 +1,4 @@
+declare module "*.module.css" {
+  const classes: Record<string, string>;
+  export default classes;
+}

--- a/tests/e2e/test_projects_board.py
+++ b/tests/e2e/test_projects_board.py
@@ -14,6 +14,8 @@ dev environment having an authenticated session. They will fail loudly if
 the server is unauthenticated; that is expected — run them locally only.
 """
 import os
+import re
+import uuid
 import pytest
 from playwright.sync_api import Page, BrowserContext, expect
 
@@ -26,6 +28,10 @@ pytestmark = [
 ]
 
 _URL = os.environ.get("TAOS_E2E_URL", "")
+
+
+def _uniq(prefix: str) -> str:
+    return f"{prefix}-{uuid.uuid4().hex[:8]}"
 
 
 def _create_project_and_tasks(page: Page, slug: str, n_tasks: int = 0) -> str:
@@ -80,16 +86,16 @@ def _open_board(page: Page, pid: str) -> None:
 
 
 def test_board_renders_three_columns_in_kanban(page: Page):
-    pid = _create_project_and_tasks(page, "board-e2e-1")
+    pid = _create_project_and_tasks(page, _uniq("board-e2e"))
     _open_board(page, pid)
     page.get_by_role("tab", name="Kanban").click()
     expect(page.get_by_role("region", name="Ready")).to_be_visible()
     expect(page.get_by_role("region", name="Claimed")).to_be_visible()
-    expect(page.get_by_role("region", name=lambda n: "Closed" in (n or ""))).to_be_visible()
+    expect(page.get_by_role("region", name=re.compile("Closed"))).to_be_visible()
 
 
 def test_drag_card_ready_to_claimed(page: Page):
-    pid = _create_project_and_tasks(page, "board-e2e-2", n_tasks=1)
+    pid = _create_project_and_tasks(page, _uniq("board-e2e"), n_tasks=1)
     _open_board(page, pid)
     page.get_by_role("tab", name="Kanban").click()
 
@@ -101,7 +107,7 @@ def test_drag_card_ready_to_claimed(page: Page):
 
 
 def test_modal_open_via_card_click_and_keyboard_nav(page: Page):
-    pid = _create_project_and_tasks(page, "board-e2e-4", n_tasks=3)
+    pid = _create_project_and_tasks(page, _uniq("board-e2e"), n_tasks=3)
     _open_board(page, pid)
 
     page.get_by_role("button", name="Test card 1").click()
@@ -119,7 +125,7 @@ def test_sse_live_update_across_contexts(browser):
     try:
         page_a = ctx_a.new_page()
         page_b = ctx_b.new_page()
-        pid = _create_project_and_tasks(page_a, "board-e2e-3", n_tasks=1)
+        pid = _create_project_and_tasks(page_a, _uniq("board-e2e"), n_tasks=1)
         _open_board(page_a, pid)
         _open_board(page_b, pid)
         page_a.get_by_role("tab", name="Kanban").click()

--- a/tests/e2e/test_projects_board.py
+++ b/tests/e2e/test_projects_board.py
@@ -1,0 +1,137 @@
+"""End-to-end tests for the Projects board UI (Kanban / swimlane).
+
+Skipped unless TAOS_E2E_URL is set; matches the pattern used by
+test_chat_phase2a.py and other e2e tests in this directory. The board UI
+lives inside the desktop SPA at the "board" tab of a project workspace.
+
+Required server-side setup before running:
+  1. uvicorn tinyagentos.app:create_app --factory --port 6969
+  2. A signed-in browser session (cookies preserved by Playwright)
+  3. At least one project named "board-e2e" exists (or fixture creates one)
+
+These tests are scaffolds — they exercise the UI surface but rely on the
+dev environment having an authenticated session. They will fail loudly if
+the server is unauthenticated; that is expected — run them locally only.
+"""
+import os
+import pytest
+from playwright.sync_api import Page, BrowserContext, expect
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.skipif(
+        not os.environ.get("TAOS_E2E_URL"),
+        reason="TAOS_E2E_URL required",
+    ),
+]
+
+_URL = os.environ.get("TAOS_E2E_URL", "")
+
+
+def _create_project_and_tasks(page: Page, slug: str, n_tasks: int = 0) -> str:
+    """Create a project and N open tasks via the JSON API.
+
+    Uses page.evaluate so we inherit the browser session cookie. Returns
+    the project id.
+    """
+    project = page.evaluate(
+        """async ({ slug }) => {
+            const r = await fetch('/api/projects', {
+                method: 'POST',
+                credentials: 'include',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ name: slug, slug }),
+            });
+            if (!r.ok) throw new Error('create project: ' + r.status);
+            return r.json();
+        }""",
+        {"slug": slug},
+    )
+    pid = project["id"]
+    for i in range(n_tasks):
+        page.evaluate(
+            """async ({ pid, title }) => {
+                const r = await fetch(`/api/projects/${pid}/tasks`, {
+                    method: 'POST',
+                    credentials: 'include',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ title }),
+                });
+                if (!r.ok) throw new Error('create task: ' + r.status);
+                return r.json();
+            }""",
+            {"pid": pid, "title": f"Test card {i + 1}"},
+        )
+    return pid
+
+
+def _open_board(page: Page, pid: str) -> None:
+    """Open the project workspace at the board tab.
+
+    The desktop SPA opens projects via the Projects app. We click into the
+    project by id once it appears in the projects list.
+    """
+    page.goto(_URL)
+    page.get_by_role("button", name="Projects").click()
+    # Project tiles include the project id as data-project-id; fallback to
+    # text match if attribute selectors aren't present.
+    page.locator(f'[data-project-id="{pid}"]').first.click()
+    page.get_by_role("tab", name="board").click()
+
+
+def test_board_renders_three_columns_in_kanban(page: Page):
+    pid = _create_project_and_tasks(page, "board-e2e-1")
+    _open_board(page, pid)
+    page.get_by_role("tab", name="Kanban").click()
+    expect(page.get_by_role("region", name="Ready")).to_be_visible()
+    expect(page.get_by_role("region", name="Claimed")).to_be_visible()
+    expect(page.get_by_role("region", name=lambda n: "Closed" in (n or ""))).to_be_visible()
+
+
+def test_drag_card_ready_to_claimed(page: Page):
+    pid = _create_project_and_tasks(page, "board-e2e-2", n_tasks=1)
+    _open_board(page, pid)
+    page.get_by_role("tab", name="Kanban").click()
+
+    card = page.get_by_role("button", name="Test card 1")
+    target = page.get_by_role("region", name="Claimed")
+    card.drag_to(target)
+
+    expect(target.get_by_text("Test card 1")).to_be_visible()
+
+
+def test_modal_open_via_card_click_and_keyboard_nav(page: Page):
+    pid = _create_project_and_tasks(page, "board-e2e-4", n_tasks=3)
+    _open_board(page, pid)
+
+    page.get_by_role("button", name="Test card 1").click()
+    expect(page.get_by_role("dialog")).to_be_visible()
+    expect(page.get_by_text("Test card 1")).to_be_visible()
+
+    page.keyboard.press("Escape")
+    expect(page.get_by_role("dialog")).not_to_be_visible()
+
+
+def test_sse_live_update_across_contexts(browser):
+    """Two browser contexts on the same project — claim in A appears in B."""
+    ctx_a: BrowserContext = browser.new_context()
+    ctx_b: BrowserContext = browser.new_context()
+    try:
+        page_a = ctx_a.new_page()
+        page_b = ctx_b.new_page()
+        pid = _create_project_and_tasks(page_a, "board-e2e-3", n_tasks=1)
+        _open_board(page_a, pid)
+        _open_board(page_b, pid)
+        page_a.get_by_role("tab", name="Kanban").click()
+        page_b.get_by_role("tab", name="Kanban").click()
+
+        card = page_a.get_by_role("button", name="Test card 1")
+        target = page_a.get_by_role("region", name="Claimed")
+        card.drag_to(target)
+
+        # SSE should propagate within ~2s; Playwright auto-waits up to 5s.
+        b_target = page_b.get_by_role("region", name="Claimed")
+        expect(b_target.get_by_text("Test card 1")).to_be_visible(timeout=5000)
+    finally:
+        ctx_a.close()
+        ctx_b.close()

--- a/tests/projects/test_event_broker.py
+++ b/tests/projects/test_event_broker.py
@@ -1,0 +1,62 @@
+import asyncio
+import pytest
+from tinyagentos.projects.events import ProjectEventBroker, ProjectEvent
+
+
+@pytest.mark.asyncio
+async def test_publish_then_subscribe_replays_recent():
+    broker = ProjectEventBroker(replay_size=4)
+    await broker.publish("p1", ProjectEvent(kind="task.created", payload={"id": "t1"}))
+    await broker.publish("p1", ProjectEvent(kind="task.claimed", payload={"id": "t1"}))
+
+    queue = await broker.subscribe("p1")
+    first = await asyncio.wait_for(queue.get(), timeout=0.5)
+    second = await asyncio.wait_for(queue.get(), timeout=0.5)
+    assert first.kind == "task.created"
+    assert second.kind == "task.claimed"
+
+
+@pytest.mark.asyncio
+async def test_publish_fans_out_to_all_subscribers():
+    broker = ProjectEventBroker()
+    a = await broker.subscribe("p1")
+    b = await broker.subscribe("p1")
+    await broker.publish("p1", ProjectEvent(kind="task.updated", payload={"id": "t1"}))
+    ev_a = await asyncio.wait_for(a.get(), timeout=0.5)
+    ev_b = await asyncio.wait_for(b.get(), timeout=0.5)
+    assert ev_a.kind == "task.updated"
+    assert ev_b.kind == "task.updated"
+
+
+@pytest.mark.asyncio
+async def test_publish_isolated_per_project():
+    broker = ProjectEventBroker()
+    a = await broker.subscribe("p1")
+    b = await broker.subscribe("p2")
+    await broker.publish("p1", ProjectEvent(kind="task.created", payload={"id": "t1"}))
+    ev_a = await asyncio.wait_for(a.get(), timeout=0.5)
+    assert ev_a.kind == "task.created"
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(b.get(), timeout=0.1)
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe_removes_queue():
+    broker = ProjectEventBroker()
+    queue = await broker.subscribe("p1")
+    await broker.unsubscribe("p1", queue)
+    await broker.publish("p1", ProjectEvent(kind="task.created", payload={"id": "t1"}))
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(queue.get(), timeout=0.1)
+
+
+@pytest.mark.asyncio
+async def test_replay_buffer_respects_size():
+    broker = ProjectEventBroker(replay_size=2)
+    for i in range(5):
+        await broker.publish("p1", ProjectEvent(kind="task.created", payload={"id": f"t{i}"}))
+    queue = await broker.subscribe("p1")
+    items = []
+    for _ in range(2):
+        items.append(await asyncio.wait_for(queue.get(), timeout=0.5))
+    assert [e.payload["id"] for e in items] == ["t3", "t4"]

--- a/tests/projects/test_event_broker_integration.py
+++ b/tests/projects/test_event_broker_integration.py
@@ -1,0 +1,74 @@
+import asyncio
+import pytest
+import pytest_asyncio
+from tinyagentos.projects.task_store import ProjectTaskStore
+from tinyagentos.projects.events import ProjectEventBroker
+
+
+@pytest_asyncio.fixture
+async def store_with_broker(tmp_path):
+    broker = ProjectEventBroker()
+    store = ProjectTaskStore(tmp_path / "tasks.db", broker=broker)
+    await store.init()
+    yield store, broker
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_create_task_emits_event(store_with_broker):
+    store, broker = store_with_broker
+    queue = await broker.subscribe("p1")
+    t = await store.create_task(project_id="p1", title="t", created_by="u1")
+    ev = await asyncio.wait_for(queue.get(), timeout=0.5)
+    assert ev.kind == "task.created"
+    assert ev.payload["id"] == t["id"]
+
+
+@pytest.mark.asyncio
+async def test_claim_release_close_emit_events(store_with_broker):
+    store, broker = store_with_broker
+    t = await store.create_task(project_id="p1", title="t", created_by="u1")
+    queue = await broker.subscribe("p1")
+    # drain replay (the create event)
+    await queue.get()
+
+    await store.claim_task(t["id"], "agent")
+    ev = await asyncio.wait_for(queue.get(), timeout=0.5)
+    assert ev.kind == "task.claimed"
+
+    await store.release_task(t["id"], "agent")
+    ev = await asyncio.wait_for(queue.get(), timeout=0.5)
+    assert ev.kind == "task.released"
+
+    await store.close_task(t["id"], "agent", reason="done")
+    ev = await asyncio.wait_for(queue.get(), timeout=0.5)
+    assert ev.kind == "task.closed"
+
+
+@pytest.mark.asyncio
+async def test_update_task_emits_event(store_with_broker):
+    store, broker = store_with_broker
+    t = await store.create_task(project_id="p1", title="t", created_by="u1")
+    queue = await broker.subscribe("p1")
+    await queue.get()  # drain
+    await store.update_task(t["id"], title="renamed")
+    ev = await asyncio.wait_for(queue.get(), timeout=0.5)
+    assert ev.kind == "task.updated"
+
+
+@pytest.mark.asyncio
+async def test_relationship_and_comment_events(store_with_broker):
+    store, broker = store_with_broker
+    a = await store.create_task(project_id="p1", title="a", created_by="u1")
+    b = await store.create_task(project_id="p1", title="b", created_by="u1")
+    queue = await broker.subscribe("p1")
+    while not queue.empty():
+        await queue.get()  # drain replay
+
+    await store.add_relationship("p1", a["id"], b["id"], "blocks", "u1")
+    ev = await asyncio.wait_for(queue.get(), timeout=0.5)
+    assert ev.kind == "relationship.added"
+
+    await store.add_comment(a["id"], "u1", "hi")
+    ev = await asyncio.wait_for(queue.get(), timeout=0.5)
+    assert ev.kind == "comment.added"

--- a/tests/projects/test_events_route.py
+++ b/tests/projects/test_events_route.py
@@ -1,0 +1,105 @@
+"""Tests for GET /api/projects/{id}/events SSE route."""
+import asyncio
+import json
+import pytest
+from tinyagentos.projects.events import ProjectEvent
+
+
+async def _collect_sse_lines(app, path, cookies, n_lines, timeout=5.0):
+    """
+    Drive an ASGI SSE endpoint, collect the first n_lines non-empty lines,
+    then cancel the request task.
+
+    Returns the collected lines.
+    """
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "GET",
+        "headers": [
+            (b"cookie", "; ".join(f"{k}={v}" for k, v in cookies.items()).encode()),
+            (b"accept", b"text/event-stream"),
+        ],
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": b"",
+        "server": ("testserver", 80),
+        "client": ("127.0.0.1", 1234),
+        "root_path": "",
+    }
+
+    lines: list[str] = []
+    response_started = asyncio.Event()
+    done = asyncio.Event()
+
+    async def receive():
+        await done.wait()
+        return {"type": "http.disconnect"}
+
+    async def send(message):
+        if message["type"] == "http.response.start":
+            response_started.set()
+        elif message["type"] == "http.response.body":
+            body = message.get("body", b"")
+            if body:
+                chunk = body.decode()
+                for line in chunk.split("\n"):
+                    stripped = line.rstrip("\r")
+                    if stripped:
+                        lines.append(stripped)
+                        if len(lines) >= n_lines:
+                            done.set()
+
+    task = asyncio.create_task(app(scope, receive, send))
+    try:
+        await asyncio.wait_for(asyncio.shield(done.wait()), timeout=timeout)
+    except asyncio.TimeoutError:
+        pass
+    finally:
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):
+            pass
+
+    return lines
+
+
+@pytest.mark.asyncio
+async def test_sse_emits_task_event(app, client):
+    pid = (await client.post("/api/projects", json={"name": "P", "slug": "p"})).json()["id"]
+
+    # Publish before subscribing so the broker replay buffer delivers it
+    # immediately to the new subscriber.
+    await app.state.project_event_broker.publish(
+        pid, ProjectEvent(kind="task.created", payload={"id": "t1"})
+    )
+
+    cookies = {"taos_session": client.cookies.get("taos_session", "")}
+    lines = await _collect_sse_lines(
+        app, f"/api/projects/{pid}/events", cookies, n_lines=1, timeout=5.0
+    )
+
+    data_lines = [l for l in lines if l.startswith("data:")]
+    assert data_lines, f"No data: lines received; got: {lines}"
+    evt = json.loads(data_lines[0][5:].strip())
+    assert evt["kind"] == "task.created"
+    assert evt["payload"]["id"] == "t1"
+
+
+@pytest.mark.asyncio
+async def test_sse_heartbeat(app, client):
+    """Heartbeat comment lines arrive after the 15 s queue timeout."""
+    pid = (await client.post("/api/projects", json={"name": "P", "slug": "ph"})).json()["id"]
+    cookies = {"taos_session": client.cookies.get("taos_session", "")}
+
+    # Wait for a heartbeat line (starts with ':'). The route yields one after
+    # 15 s with no events; give it 16 s to arrive.
+    lines = await _collect_sse_lines(
+        app, f"/api/projects/{pid}/events", cookies, n_lines=1, timeout=16.0
+    )
+
+    heartbeat_lines = [l for l in lines if l.startswith(":")]
+    assert heartbeat_lines, f"No heartbeat lines received; got: {lines}"

--- a/tests/projects/test_routes_update_parent.py
+++ b/tests/projects/test_routes_update_parent.py
@@ -1,0 +1,68 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_patch_accepts_parent_task_id(client):
+    pid = (await client.post("/api/projects", json={"name": "P", "slug": "p1"})).json()["id"]
+    parent = (await client.post(f"/api/projects/{pid}/tasks", json={"title": "Parent"})).json()
+    child = (await client.post(f"/api/projects/{pid}/tasks", json={"title": "Child"})).json()
+
+    resp = await client.patch(
+        f"/api/projects/{pid}/tasks/{child['id']}",
+        json={"parent_task_id": parent["id"]},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["parent_task_id"] == parent["id"]
+
+
+@pytest.mark.asyncio
+async def test_patch_rejects_self_parent(client):
+    pid = (await client.post("/api/projects", json={"name": "P", "slug": "p2"})).json()["id"]
+    t = (await client.post(f"/api/projects/{pid}/tasks", json={"title": "T"})).json()
+
+    resp = await client.patch(
+        f"/api/projects/{pid}/tasks/{t['id']}",
+        json={"parent_task_id": t["id"]},
+    )
+    assert resp.status_code == 400
+    body = resp.json()
+    assert "cycle" in body.get("error", "").lower() or "self" in body.get("error", "").lower()
+
+
+@pytest.mark.asyncio
+async def test_patch_rejects_cross_project_parent(client):
+    p1 = (await client.post("/api/projects", json={"name": "P1", "slug": "cp1"})).json()["id"]
+    p2 = (await client.post("/api/projects", json={"name": "P2", "slug": "cp2"})).json()["id"]
+    t1 = (await client.post(f"/api/projects/{p1}/tasks", json={"title": "T1"})).json()
+    t2 = (await client.post(f"/api/projects/{p2}/tasks", json={"title": "T2"})).json()
+
+    resp = await client.patch(
+        f"/api/projects/{p1}/tasks/{t1['id']}",
+        json={"parent_task_id": t2["id"]},
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_patch_rejects_indirect_cycle(client):
+    pid = (await client.post("/api/projects", json={"name": "P", "slug": "ic1"})).json()["id"]
+    a = (await client.post(f"/api/projects/{pid}/tasks", json={"title": "A"})).json()
+    b = (await client.post(f"/api/projects/{pid}/tasks", json={"title": "B"})).json()
+    c = (await client.post(f"/api/projects/{pid}/tasks", json={"title": "C"})).json()
+
+    # chain: A -> B -> C
+    await client.patch(
+        f"/api/projects/{pid}/tasks/{a['id']}",
+        json={"parent_task_id": b["id"]},
+    )
+    await client.patch(
+        f"/api/projects/{pid}/tasks/{b['id']}",
+        json={"parent_task_id": c["id"]},
+    )
+
+    # now try to set C's parent to A — would create a cycle
+    resp = await client.patch(
+        f"/api/projects/{pid}/tasks/{c['id']}",
+        json={"parent_task_id": a["id"]},
+    )
+    assert resp.status_code == 400

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -201,8 +201,10 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     chat_channels = ChatChannelStore(data_dir / "chat.db")
     from tinyagentos.projects.project_store import ProjectStore
     from tinyagentos.projects.task_store import ProjectTaskStore
+    from tinyagentos.projects.events import ProjectEventBroker
     project_store = ProjectStore(data_dir / "projects.db")
-    project_task_store = ProjectTaskStore(data_dir / "projects.db")
+    project_event_broker = ProjectEventBroker()
+    project_task_store = ProjectTaskStore(data_dir / "projects.db", broker=project_event_broker)
     projects_root = data_dir / "projects"
     chat_hub = ChatHub()
     canvas_store = CanvasStore(data_dir / "canvas.db")
@@ -401,6 +403,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         app.state.chat_channels = chat_channels
         app.state.project_store = project_store
         app.state.project_task_store = project_task_store
+        app.state.project_event_broker = project_event_broker
         app.state.projects_root = projects_root
         app.state.chat_hub = chat_hub
         from tinyagentos.chat.group_policy import GroupPolicy
@@ -707,6 +710,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     app.state.chat_channels = chat_channels
     app.state.project_store = project_store
     app.state.project_task_store = project_task_store
+    app.state.project_event_broker = project_event_broker
     projects_root.mkdir(parents=True, exist_ok=True)
     app.state.projects_root = projects_root
     app.state.chat_hub = chat_hub

--- a/tinyagentos/projects/events.py
+++ b/tinyagentos/projects/events.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+import asyncio
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class ProjectEvent:
+    kind: str
+    payload: dict[str, Any]
+    ts: float = field(default_factory=time.time)
+
+
+class ProjectEventBroker:
+    """In-memory pub/sub. One channel per project_id.
+
+    Single-worker assumption: all subscribers and publishers share one process.
+    See spec §4 — multi-worker is out of scope.
+    """
+
+    def __init__(self, replay_size: int = 32) -> None:
+        self._replay_size = replay_size
+        self._queues: dict[str, list[asyncio.Queue[ProjectEvent]]] = {}
+        self._replay: dict[str, deque[ProjectEvent]] = {}
+        self._lock = asyncio.Lock()
+
+    async def subscribe(self, project_id: str) -> asyncio.Queue[ProjectEvent]:
+        queue: asyncio.Queue[ProjectEvent] = asyncio.Queue()
+        async with self._lock:
+            self._queues.setdefault(project_id, []).append(queue)
+            for ev in self._replay.get(project_id, ()):
+                queue.put_nowait(ev)
+        return queue
+
+    async def unsubscribe(self, project_id: str, queue: asyncio.Queue[ProjectEvent]) -> None:
+        async with self._lock:
+            qs = self._queues.get(project_id, [])
+            if queue in qs:
+                qs.remove(queue)
+
+    async def publish(self, project_id: str, event: ProjectEvent) -> None:
+        async with self._lock:
+            buf = self._replay.setdefault(project_id, deque(maxlen=self._replay_size))
+            buf.append(event)
+            for q in list(self._queues.get(project_id, [])):
+                q.put_nowait(event)

--- a/tinyagentos/projects/task_store.py
+++ b/tinyagentos/projects/task_store.py
@@ -3,8 +3,13 @@ from __future__ import annotations
 import json
 import time
 
+from typing import TYPE_CHECKING
+
 from tinyagentos.base_store import BaseStore
 from tinyagentos.projects.ids import new_id
+
+if TYPE_CHECKING:
+    from tinyagentos.projects.events import ProjectEventBroker
 
 TASK_SCHEMA = """
 CREATE TABLE IF NOT EXISTS project_tasks (
@@ -81,6 +86,15 @@ def _row_to_task(row, description) -> dict:
 class ProjectTaskStore(BaseStore):
     SCHEMA = TASK_SCHEMA
 
+    def __init__(self, db_path, *, broker: "ProjectEventBroker | None" = None) -> None:
+        super().__init__(db_path)
+        self._broker = broker
+
+    async def _publish(self, project_id: str, kind: str, payload: dict) -> None:
+        if self._broker is not None:
+            from tinyagentos.projects.events import ProjectEvent
+            await self._broker.publish(project_id, ProjectEvent(kind=kind, payload=payload))
+
     async def create_task(
         self,
         project_id: str,
@@ -105,7 +119,9 @@ class ProjectTaskStore(BaseStore):
             ),
         )
         await self._db.commit()
-        return await self.get_task(tid)
+        new_task = await self.get_task(tid)
+        await self._publish(project_id, "task.created", {"id": new_task["id"], "task": new_task})
+        return new_task
 
     async def get_task(self, task_id: str) -> dict | None:
         async with self._db.execute(
@@ -159,12 +175,26 @@ class ProjectTaskStore(BaseStore):
             sets.append("assignee_id = ?"); params.append(assignee_id)
         if not sets:
             return
+        patch: dict = {}
+        if title is not None:
+            patch["title"] = title
+        if body is not None:
+            patch["body"] = body
+        if priority is not None:
+            patch["priority"] = priority
+        if labels is not None:
+            patch["labels"] = labels
+        if assignee_id is not None:
+            patch["assignee_id"] = assignee_id
         sets.append("updated_at = ?"); params.append(time.time())
         params.append(task_id)
         await self._db.execute(
             f"UPDATE project_tasks SET {', '.join(sets)} WHERE id = ?", params
         )
         await self._db.commit()
+        existing = await self.get_task(task_id)
+        if existing is not None:
+            await self._publish(existing["project_id"], "task.updated", {"id": task_id, "patch": patch})
 
     async def claim_task(self, task_id: str, claimer_id: str) -> bool:
         now = time.time()
@@ -175,7 +205,12 @@ class ProjectTaskStore(BaseStore):
             (claimer_id, now, now, task_id),
         )
         await self._db.commit()
-        return cursor.rowcount == 1
+        changed = cursor.rowcount == 1
+        if changed:
+            existing = await self.get_task(task_id)
+            if existing is not None:
+                await self._publish(existing["project_id"], "task.claimed", {"id": task_id, "claimed_by": claimer_id})
+        return changed
 
     async def release_task(self, task_id: str, releaser_id: str) -> bool:
         now = time.time()
@@ -186,7 +221,12 @@ class ProjectTaskStore(BaseStore):
             (now, task_id, releaser_id),
         )
         await self._db.commit()
-        return cursor.rowcount == 1
+        changed = cursor.rowcount == 1
+        if changed:
+            existing = await self.get_task(task_id)
+            if existing is not None:
+                await self._publish(existing["project_id"], "task.released", {"id": task_id})
+        return changed
 
     async def close_task(
         self,
@@ -202,7 +242,12 @@ class ProjectTaskStore(BaseStore):
             (closed_by, now, reason, now, task_id),
         )
         await self._db.commit()
-        return cursor.rowcount == 1
+        changed = cursor.rowcount == 1
+        if changed:
+            existing = await self.get_task(task_id)
+            if existing is not None:
+                await self._publish(existing["project_id"], "task.closed", {"id": task_id, "closed_by": closed_by})
+        return changed
 
     async def add_relationship(
         self,
@@ -227,6 +272,7 @@ class ProjectTaskStore(BaseStore):
             (rid, project_id, from_task_id, to_task_id, kind, created_by, now),
         )
         await self._db.commit()
+        await self._publish(project_id, "relationship.added", {"from": from_task_id, "to": to_task_id, "kind": kind})
         return {
             "id": rid, "project_id": project_id, "from_task_id": from_task_id,
             "to_task_id": to_task_id, "kind": kind, "created_by": created_by, "created_at": now,
@@ -291,10 +337,14 @@ class ProjectTaskStore(BaseStore):
             (cid, task_id, author_id, body, replies_to_comment_id, now),
         )
         await self._db.commit()
-        return {
+        new_comment = {
             "id": cid, "task_id": task_id, "author_id": author_id, "body": body,
             "replies_to_comment_id": replies_to_comment_id, "created_at": now,
         }
+        existing = await self.get_task(task_id)
+        if existing is not None:
+            await self._publish(existing["project_id"], "comment.added", {"task_id": task_id, "comment": new_comment})
+        return new_comment
 
     async def list_comments(self, task_id: str) -> list[dict]:
         async with self._db.execute(

--- a/tinyagentos/projects/task_store.py
+++ b/tinyagentos/projects/task_store.py
@@ -160,32 +160,26 @@ class ProjectTaskStore(BaseStore):
         priority: int | None = None,
         labels: list[str] | None = None,
         assignee_id: str | None = None,
+        parent_task_id: str | None = None,
     ) -> None:
+        candidates = [
+            ("title", title, title),
+            ("body", body, body),
+            ("priority", priority, priority),
+            ("labels", labels, json.dumps(labels) if labels is not None else None),
+            ("assignee_id", assignee_id, assignee_id),
+            ("parent_task_id", parent_task_id, parent_task_id),
+        ]
         sets: list[str] = []
         params: list = []
-        if title is not None:
-            sets.append("title = ?"); params.append(title)
-        if body is not None:
-            sets.append("body = ?"); params.append(body)
-        if priority is not None:
-            sets.append("priority = ?"); params.append(priority)
-        if labels is not None:
-            sets.append("labels = ?"); params.append(json.dumps(labels))
-        if assignee_id is not None:
-            sets.append("assignee_id = ?"); params.append(assignee_id)
+        patch: dict = {}
+        for col, raw, serialised in candidates:
+            if raw is not None:
+                sets.append(f"{col} = ?")
+                params.append(serialised)
+                patch[col] = raw
         if not sets:
             return
-        patch: dict = {}
-        if title is not None:
-            patch["title"] = title
-        if body is not None:
-            patch["body"] = body
-        if priority is not None:
-            patch["priority"] = priority
-        if labels is not None:
-            patch["labels"] = labels
-        if assignee_id is not None:
-            patch["assignee_id"] = assignee_id
         sets.append("updated_at = ?"); params.append(time.time())
         params.append(task_id)
         await self._db.execute(

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -4,8 +4,11 @@ import logging
 import re
 import time as _time
 
+import asyncio as _asyncio
+import json as _json
+
 from fastapi import APIRouter, Request
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, Field, field_validator
 
 from tinyagentos.projects.folders import ensure_project_layout, write_project_yaml
@@ -475,3 +478,29 @@ async def memory_search(project_id: str, request: Request, q: str, limit: int = 
         limit=limit,
     )
     return {"items": items}
+
+
+@router.get("/api/projects/{project_id}/events")
+async def project_events(project_id: str, request: Request):
+    broker = request.app.state.project_event_broker
+    queue = await broker.subscribe(project_id)
+
+    async def event_stream():
+        try:
+            while True:
+                if await request.is_disconnected():
+                    break
+                try:
+                    ev = await _asyncio.wait_for(queue.get(), timeout=15.0)
+                    payload = {"kind": ev.kind, "payload": ev.payload, "ts": ev.ts}
+                    yield f"data: {_json.dumps(payload)}\n\n"
+                except _asyncio.TimeoutError:
+                    yield ": heartbeat\n\n"
+        finally:
+            await broker.unsubscribe(project_id, queue)
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -237,6 +237,7 @@ class UpdateTaskIn(BaseModel):
     priority: int | None = None
     labels: list[str] | None = None
     assignee_id: str | None = None
+    parent_task_id: str | None = None
 
 
 class ClaimIn(BaseModel):
@@ -312,6 +313,22 @@ async def update_task(project_id: str, task_id: str, payload: UpdateTaskIn, requ
     existing = await store.get_task(task_id)
     if existing is None or existing["project_id"] != project_id:
         return JSONResponse({"error": "not found"}, status_code=404)
+
+    if payload.parent_task_id is not None:
+        if payload.parent_task_id == task_id:
+            return JSONResponse({"error": "cycle: cannot self-parent"}, status_code=400)
+        parent = await store.get_task(payload.parent_task_id)
+        if parent is None or parent["project_id"] != project_id:
+            return JSONResponse({"error": "parent not in this project"}, status_code=400)
+        # walk ancestors to detect indirect cycles (parent's chain must not reach task_id)
+        seen = {task_id}
+        cur = parent
+        while cur is not None and cur.get("parent_task_id"):
+            if cur["parent_task_id"] in seen:
+                return JSONResponse({"error": "cycle in parent chain"}, status_code=400)
+            seen.add(cur["parent_task_id"])
+            cur = await store.get_task(cur["parent_task_id"])
+
     await store.update_task(task_id, **payload.model_dump(exclude_none=True))
     return await store.get_task(task_id)
 

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -321,7 +321,7 @@ async def update_task(project_id: str, task_id: str, payload: UpdateTaskIn, requ
         if parent is None or parent["project_id"] != project_id:
             return JSONResponse({"error": "parent not in this project"}, status_code=400)
         # walk ancestors to detect indirect cycles (parent's chain must not reach task_id)
-        seen = {task_id}
+        seen = {task_id, parent["id"]}
         cur = parent
         while cur is not None and cur.get("parent_task_id"):
             if cur["parent_task_id"] in seen:


### PR DESCRIPTION
## Summary

Pass B item #1 from the Projects roadmap: rich kanban / swimlane board views inside a single project workspace. Foundation (PRs #260, #264) already on master.

This is a **draft** — only the backend live-event spine is in place so far (5 of 25 tasks). Pushed early so CI + CodeRabbit can run on partial work.

## Progress

- [x] Task 1 — `ProjectEventBroker` pub/sub primitive (`projects/events.py`)
- [x] Task 2 — Emit broker events from `task_store` mutations (post-commit, conditional on `rowcount`)
- [x] Task 3 — `PATCH /tasks` accepts `parent_task_id` with self/cross-project/indirect-cycle guards
- [x] Task 4 — SSE `GET /api/projects/{id}/events` with 15s heartbeat
- [ ] Tasks 5-25 — board grouping/filtering/DnD, theme tokens, card+modal+column UI, board tab routing, E2E + a11y polish

No schema changes — three-state lifecycle (`open|claimed|closed`) and existing relationship table are sufficient.

## Test plan

- [x] `tests/projects/test_event_broker.py` — 5 unit tests (replay, fan-out, isolation, unsubscribe, replay-cap)
- [x] `tests/projects/test_event_broker_integration.py` — 4 integration tests through `task_store`
- [x] `tests/projects/test_routes_update_parent.py` — 4 tests (accept, self-cycle, cross-project, indirect cycle)
- [x] `tests/projects/test_events_route.py` — 2 tests (drives ASGI directly; httpx `ASGITransport` buffers full body and deadlocks on infinite SSE streams, so a custom `_collect_sse_lines()` helper is used)
- [ ] Frontend board UI tests (Tasks 5+)
- [ ] E2E pytest-playwright board flow (Task 24)
- [ ] axe a11y sweep (Task 25)

## Notes for reviewers

- All commits scoped under `feat(projects-board):` / `refactor(projects-board):`
- Single-worker assumption for the broker is documented in `events.py` and tracked in spec §4 (multi-worker out of scope)
- httpx 0.28 `ASGITransport` deviation in Task 4 tests is intentional — see `tests/projects/test_events_route.py` docstring

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New "Board" tab: Kanban and lanes views, grouping, search, filters, toolbar with live indicator, per-project view/filter persistence.
  * Task cards with visual covers, priority badges, keyboard/drag-and-drop support, and a details modal including comments, relationships, subtasks, and editable metadata.
  * Real-time sync across sessions (live updates/SSE).

* **Bug Fixes**
  * Parent-task updates now validate and prevent invalid or cyclic parent relationships.

* **Tests**
  * Extensive unit, integration, and e2e tests added for board UI, DnD, filtering, grouping, live events, and APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->