### PR TITLE
feat(projects): per-project A2A channel for agent handover

### DIFF
--- a/desktop/src/apps/MessagesApp.a2aSelection.ts
+++ b/desktop/src/apps/MessagesApp.a2aSelection.ts
@@ -1,0 +1,29 @@
+const KEY_PREFIX = "taos.projects.";
+const KEY_SUFFIX = ".lastChannel";
+
+export function projectChannelStorageKey(projectId: string): string {
+  return `${KEY_PREFIX}${projectId}${KEY_SUFFIX}`;
+}
+
+export function readLastChannel(projectId: string): string | null {
+  try {
+    return window.localStorage.getItem(projectChannelStorageKey(projectId));
+  } catch {
+    return null;
+  }
+}
+
+export function writeLastChannel(projectId: string, channelId: string): void {
+  try {
+    window.localStorage.setItem(projectChannelStorageKey(projectId), channelId);
+  } catch {
+    /* localStorage unavailable — ignore */
+  }
+}
+
+export function findA2aChannelId(channels: Array<{ id: string; settings?: { kind?: string } }>): string | null {
+  for (const c of channels) {
+    if (c.settings?.kind === "a2a") return c.id;
+  }
+  return null;
+}

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -533,21 +533,37 @@ export function MessagesApp({
     };
   }, [fetchChannels, fetchArchivedChannels, fetchAgentLists, connectWs]);
 
-  /* ---- default-select A2A channel on first project visit ---- */
+  /* ---- default-select A2A channel on first project visit ----
+   * Also runs when the project switches: if the previously selected channel
+   * is not in the new project's channel list, it's stale — fall back to
+   * the remembered/A2A channel for the new project, or clear the selection.
+   */
   useEffect(() => {
     if (!scope?.projectId) return;
-    if (selectedChannel) return;
     if (channels.length === 0) return;
+    const selectedStillVisible =
+      !!selectedChannel && channels.some((c) => c.id === selectedChannel);
+    if (selectedStillVisible) return;
     const remembered = readLastChannel(scope.projectId);
     if (remembered && channels.some((c) => c.id === remembered)) {
       setSelectedChannel(remembered);
       return;
     }
     const a2aId = findA2aChannelId(channels);
-    if (a2aId) {
-      setSelectedChannel(a2aId);
-    }
+    setSelectedChannel(a2aId ?? null);
   }, [scope?.projectId, channels, selectedChannel]);
+
+  /* ---- persist last-selected channel per project ----
+   * Split from the channel-join effect so we only write when we know the
+   * current selection actually belongs to the current project — prevents
+   * cross-project leakage when the user switches projects mid-flight.
+   */
+  useEffect(() => {
+    if (!scope?.projectId) return;
+    if (!selectedChannel) return;
+    if (!channels.some((c) => c.id === selectedChannel)) return;
+    writeLastChannel(scope.projectId, selectedChannel);
+  }, [scope?.projectId, selectedChannel, channels]);
 
   /* ---- fetch project list for sidebar grouping (standalone mode only) ---- */
   useEffect(() => {
@@ -630,12 +646,9 @@ export function MessagesApp({
     }
     fetchMessages(selectedChannel);
     markRead(selectedChannel);
-    if (scope?.projectId && selectedChannel) {
-      writeLastChannel(scope.projectId, selectedChannel);
-    }
     setTypingHumans([]);
     setTypingAgents([]);
-  }, [selectedChannel, fetchMessages, markRead, scope?.projectId]);
+  }, [selectedChannel, fetchMessages, markRead]);
 
   /* ---- deep-link scroll on ?msg=<id> — latch so it fires once per URL ---- */
   const deepLinkSeenRef = useRef<string | null>(null);

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -59,6 +59,11 @@ import {
   markUnread as apiMarkUnread,
 } from "@/lib/chat-messages-api";
 import { projectsApi, type Project } from "@/lib/projects";
+import {
+  findA2aChannelId,
+  readLastChannel,
+  writeLastChannel,
+} from "./MessagesApp.a2aSelection";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -93,6 +98,7 @@ interface Channel {
     archived_agent_id?: string;
     archived_agent_slug?: string;
     muted?: string[];
+    kind?: string;
   };
 }
 
@@ -527,6 +533,22 @@ export function MessagesApp({
     };
   }, [fetchChannels, fetchArchivedChannels, fetchAgentLists, connectWs]);
 
+  /* ---- default-select A2A channel on first project visit ---- */
+  useEffect(() => {
+    if (!scope?.projectId) return;
+    if (selectedChannel) return;
+    if (channels.length === 0) return;
+    const remembered = readLastChannel(scope.projectId);
+    if (remembered && channels.some((c) => c.id === remembered)) {
+      setSelectedChannel(remembered);
+      return;
+    }
+    const a2aId = findA2aChannelId(channels);
+    if (a2aId) {
+      setSelectedChannel(a2aId);
+    }
+  }, [scope?.projectId, channels, selectedChannel]);
+
   /* ---- fetch project list for sidebar grouping (standalone mode only) ---- */
   useEffect(() => {
     if (scope?.projectId) return;
@@ -608,9 +630,12 @@ export function MessagesApp({
     }
     fetchMessages(selectedChannel);
     markRead(selectedChannel);
+    if (scope?.projectId && selectedChannel) {
+      writeLastChannel(scope.projectId, selectedChannel);
+    }
     setTypingHumans([]);
     setTypingAgents([]);
-  }, [selectedChannel, fetchMessages, markRead]);
+  }, [selectedChannel, fetchMessages, markRead, scope?.projectId]);
 
   /* ---- deep-link scroll on ?msg=<id> — latch so it fires once per URL ---- */
   const deepLinkSeenRef = useRef<string | null>(null);

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -1830,6 +1830,23 @@ export function MessagesApp({
             }}
           />
 
+          {currentChannel?.settings?.kind === "a2a" && messages.length === 0 && (
+            <div
+              role="note"
+              style={{
+                padding: "10px 14px",
+                fontSize: 12,
+                color: "rgba(255,255,255,0.55)",
+                background: "rgba(255,255,255,0.03)",
+                border: "1px solid rgba(255,255,255,0.06)",
+                borderRadius: 12,
+                margin: "8px 12px",
+              }}
+            >
+              Agents coordinate here. Mention <code>@&lt;slug&gt;</code> to hand off a task to another agent.
+            </div>
+          )}
+
           {/* input area */}
           <div
             className="px-4 py-3 border-t border-white/[0.06] shrink-0"

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -1100,6 +1100,7 @@ export function MessagesApp({
                   type="button"
                   onClick={() => setSelectedChannel(ch.id)}
                   aria-label={`Channel ${ch.name}`}
+                  title={ch.settings?.kind === "a2a" ? "Agent coordination — mention @<slug> to hand off." : undefined}
                   style={{
                     display: "flex",
                     alignItems: "center",
@@ -1114,6 +1115,13 @@ export function MessagesApp({
                     textAlign: "left",
                   }}
                 >
+                  {ch.settings?.kind === "a2a" && (
+                    <Bot
+                      size={14}
+                      aria-hidden
+                      style={{ color: "rgba(255,255,255,0.6)", flexShrink: 0 }}
+                    />
+                  )}
                   <span style={{ flex: 1, fontSize: 15, fontWeight: 400, color: "rgba(255,255,255,0.9)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
                     {ch.name}
                   </span>
@@ -1166,6 +1174,7 @@ export function MessagesApp({
                           type="button"
                           onClick={() => setSelectedChannel(ch.id)}
                           aria-label={`Channel ${ch.name}`}
+                          title={ch.settings?.kind === "a2a" ? "Agent coordination — mention @<slug> to hand off." : undefined}
                           style={{
                             display: "flex",
                             alignItems: "center",
@@ -1180,6 +1189,13 @@ export function MessagesApp({
                             textAlign: "left",
                           }}
                         >
+                          {ch.settings?.kind === "a2a" && (
+                            <Bot
+                              size={14}
+                              aria-hidden
+                              style={{ color: "rgba(255,255,255,0.6)", flexShrink: 0 }}
+                            />
+                          )}
                           <span style={{ flex: 1, fontSize: 15, fontWeight: 400, color: "rgba(255,255,255,0.9)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
                             {ch.name}
                           </span>
@@ -1299,7 +1315,15 @@ export function MessagesApp({
                 onClick={() => setSelectedChannel(ch.id)}
                 className="w-full justify-start h-auto py-1.5 px-3 text-[13px] rounded-none font-normal"
                 aria-label={`Channel ${ch.name}`}
+                title={ch.settings?.kind === "a2a" ? "Agent coordination — mention @<slug> to hand off." : undefined}
               >
+                {ch.settings?.kind === "a2a" && (
+                  <Bot
+                    size={14}
+                    aria-hidden
+                    style={{ color: "rgba(255,255,255,0.6)", flexShrink: 0 }}
+                  />
+                )}
                 <span className="truncate flex-1 text-left">{ch.name}</span>
                 {(unread[ch.id] ?? 0) > 0 && (
                   <span className="shrink-0 bg-blue-500 text-white text-[10px] font-bold rounded-full min-w-[18px] h-[18px] flex items-center justify-center px-1">
@@ -1328,10 +1352,18 @@ export function MessagesApp({
                       onClick={() => setSelectedChannel(ch.id)}
                       aria-pressed={selectedChannel === ch.id}
                       aria-label={`Channel ${ch.name}`}
-                      className={`w-full text-left text-xs py-1 px-2 rounded ${
+                      title={ch.settings?.kind === "a2a" ? "Agent coordination — mention @<slug> to hand off." : undefined}
+                      className={`w-full text-left text-xs py-1 px-2 rounded flex items-center gap-1.5 ${
                         selectedChannel === ch.id ? "bg-white/10" : "hover:bg-white/5"
                       }`}
                     >
+                      {ch.settings?.kind === "a2a" && (
+                        <Bot
+                          size={12}
+                          aria-hidden
+                          style={{ color: "rgba(255,255,255,0.6)", flexShrink: 0 }}
+                        />
+                      )}
                       {ch.name}
                     </button>
                   ))}

--- a/desktop/tests/MessagesApp.a2a-default.test.ts
+++ b/desktop/tests/MessagesApp.a2a-default.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import {
+  findA2aChannelId,
+  projectChannelStorageKey,
+  readLastChannel,
+  writeLastChannel,
+} from "../src/apps/MessagesApp.a2aSelection";
+
+describe("a2a selection storage", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("storage key is project-scoped", () => {
+    expect(projectChannelStorageKey("p1")).toBe("taos.projects.p1.lastChannel");
+  });
+
+  it("readLastChannel returns null when unset", () => {
+    expect(readLastChannel("p1")).toBeNull();
+  });
+
+  it("writeLastChannel persists, readLastChannel returns it", () => {
+    writeLastChannel("p1", "ch1");
+    expect(readLastChannel("p1")).toBe("ch1");
+  });
+
+  it("read swallows localStorage errors", () => {
+    const spy = vi
+      .spyOn(window.localStorage, "getItem")
+      .mockImplementation(() => {
+        throw new Error("denied");
+      });
+    expect(readLastChannel("p1")).toBeNull();
+    spy.mockRestore();
+  });
+
+  it("findA2aChannelId picks the channel with settings.kind === 'a2a'", () => {
+    const channels = [
+      { id: "ch1", settings: { kind: undefined } },
+      { id: "ch2", settings: { kind: "a2a" } },
+      { id: "ch3", settings: { kind: "topic" } },
+    ];
+    expect(findA2aChannelId(channels)).toBe("ch2");
+  });
+
+  it("findA2aChannelId returns null when no A2A channel present", () => {
+    expect(findA2aChannelId([{ id: "ch1", settings: {} }])).toBeNull();
+  });
+});

--- a/tests/projects/test_a2a.py
+++ b/tests/projects/test_a2a.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+
+from tinyagentos.chat.channel_store import ChatChannelStore
+from tinyagentos.projects.a2a import (
+    A2A_KIND,
+    A2A_NAME,
+    A2A_TYPE,
+    backfill_all,
+    ensure_a2a_channel,
+)
+from tinyagentos.projects.project_store import ProjectStore
+
+
+@pytest_asyncio.fixture
+async def stores(tmp_path):
+    project_store = ProjectStore(tmp_path / "projects.db")
+    await project_store.init()
+    channel_store = ChatChannelStore(tmp_path / "chat.db")
+    await channel_store.init()
+    yield project_store, channel_store
+    await channel_store.close()
+    await project_store.close()
+
+
+@pytest.mark.asyncio
+async def test_ensure_creates_channel_when_missing(stores):
+    project_store, channel_store = stores
+    p = await project_store.create_project(name="Acme", slug="acme", created_by="u1")
+
+    ch = await ensure_a2a_channel(channel_store, project_store, p["id"])
+
+    assert ch["name"] == A2A_NAME
+    assert ch["type"] == A2A_TYPE
+    assert ch["project_id"] == p["id"]
+    assert ch["settings"].get("kind") == A2A_KIND
+    assert ch["members"] == []

--- a/tests/projects/test_a2a.py
+++ b/tests/projects/test_a2a.py
@@ -37,3 +37,17 @@ async def test_ensure_creates_channel_when_missing(stores):
     assert ch["project_id"] == p["id"]
     assert ch["settings"].get("kind") == A2A_KIND
     assert ch["members"] == []
+
+
+@pytest.mark.asyncio
+async def test_ensure_is_idempotent(stores):
+    project_store, channel_store = stores
+    p = await project_store.create_project(name="Acme", slug="acme2", created_by="u1")
+
+    ch1 = await ensure_a2a_channel(channel_store, project_store, p["id"])
+    ch2 = await ensure_a2a_channel(channel_store, project_store, p["id"])
+
+    assert ch1["id"] == ch2["id"]
+    all_channels = await channel_store.list_channels(project_id=p["id"])
+    a2a = [c for c in all_channels if (c.get("settings") or {}).get("kind") == "a2a"]
+    assert len(a2a) == 1

--- a/tests/projects/test_a2a.py
+++ b/tests/projects/test_a2a.py
@@ -51,3 +51,40 @@ async def test_ensure_is_idempotent(stores):
     all_channels = await channel_store.list_channels(project_id=p["id"])
     a2a = [c for c in all_channels if (c.get("settings") or {}).get("kind") == "a2a"]
     assert len(a2a) == 1
+
+
+@pytest.mark.asyncio
+async def test_ensure_syncs_members_added_after_creation(stores):
+    project_store, channel_store = stores
+    p = await project_store.create_project(name="P", slug="sync-add", created_by="u1")
+    await ensure_a2a_channel(channel_store, project_store, p["id"])
+
+    await project_store.add_member(p["id"], "agentA", member_kind="native")
+    await project_store.add_member(p["id"], "agentB", member_kind="native")
+    ch = await ensure_a2a_channel(channel_store, project_store, p["id"])
+
+    assert sorted(ch["members"]) == ["agentA", "agentB"]
+
+
+@pytest.mark.asyncio
+async def test_ensure_syncs_members_on_remove(stores):
+    project_store, channel_store = stores
+    p = await project_store.create_project(name="P", slug="sync-rm", created_by="u1")
+    await project_store.add_member(p["id"], "agentA", member_kind="native")
+    await project_store.add_member(p["id"], "agentB", member_kind="native")
+    await ensure_a2a_channel(channel_store, project_store, p["id"])
+
+    await project_store.remove_member(p["id"], "agentA")
+    ch = await ensure_a2a_channel(channel_store, project_store, p["id"])
+
+    assert ch["members"] == ["agentB"]
+
+
+@pytest.mark.asyncio
+async def test_ensure_no_op_when_members_match(stores):
+    project_store, channel_store = stores
+    p = await project_store.create_project(name="P", slug="sync-same", created_by="u1")
+    await project_store.add_member(p["id"], "agentA", member_kind="native")
+    ch1 = await ensure_a2a_channel(channel_store, project_store, p["id"])
+    ch2 = await ensure_a2a_channel(channel_store, project_store, p["id"])
+    assert ch1["members"] == ch2["members"] == ["agentA"]

--- a/tests/projects/test_a2a.py
+++ b/tests/projects/test_a2a.py
@@ -88,3 +88,24 @@ async def test_ensure_no_op_when_members_match(stores):
     ch1 = await ensure_a2a_channel(channel_store, project_store, p["id"])
     ch2 = await ensure_a2a_channel(channel_store, project_store, p["id"])
     assert ch1["members"] == ch2["members"] == ["agentA"]
+
+
+@pytest.mark.asyncio
+async def test_backfill_creates_channels_for_all_active_projects(stores):
+    project_store, channel_store = stores
+    p1 = await project_store.create_project(name="P1", slug="bf1", created_by="u1")
+    p2 = await project_store.create_project(name="P2", slug="bf2", created_by="u1")
+    p3 = await project_store.create_project(name="P3", slug="bf3", created_by="u1")
+    await project_store.set_status(p3["id"], "archived")
+
+    count = await backfill_all(channel_store, project_store)
+
+    assert count == 2
+    assert await _has_a2a(channel_store, p1["id"])
+    assert await _has_a2a(channel_store, p2["id"])
+    assert not await _has_a2a(channel_store, p3["id"])
+
+
+async def _has_a2a(channel_store, project_id: str) -> bool:
+    chans = await channel_store.list_channels(project_id=project_id)
+    return any((c.get("settings") or {}).get("kind") == "a2a" for c in chans)

--- a/tests/projects/test_a2a.py
+++ b/tests/projects/test_a2a.py
@@ -124,3 +124,31 @@ async def test_backfill_is_idempotent(stores):
     chans = await channel_store.list_channels(project_id=p["id"])
     a2a = [c for c in chans if (c.get("settings") or {}).get("kind") == "a2a"]
     assert len(a2a) == 1
+
+
+@pytest.mark.asyncio
+async def test_ensure_archives_duplicate_a2a_channels(stores):
+    """Defensive: if duplicate A2A channels exist (race / migration / manual
+    insert), the oldest is canonical and the rest are archived."""
+    project_store, channel_store = stores
+    p = await project_store.create_project(name="P", slug="dup", created_by="u1")
+
+    canonical = await ensure_a2a_channel(channel_store, project_store, p["id"])
+    duplicate = await channel_store.create_channel(
+        name=A2A_NAME,
+        type=A2A_TYPE,
+        created_by="u1",
+        members=[],
+        settings={"kind": A2A_KIND},
+        project_id=p["id"],
+    )
+
+    result = await ensure_a2a_channel(channel_store, project_store, p["id"])
+
+    assert result["id"] == canonical["id"]
+    dup_after = await channel_store.get_channel(duplicate["id"])
+    assert (dup_after.get("settings") or {}).get("archived") is True
+    active = await channel_store.list_channels(project_id=p["id"], archived=False)
+    a2a_active = [c for c in active if (c.get("settings") or {}).get("kind") == "a2a"]
+    assert len(a2a_active) == 1
+    assert a2a_active[0]["id"] == canonical["id"]

--- a/tests/projects/test_a2a.py
+++ b/tests/projects/test_a2a.py
@@ -109,3 +109,18 @@ async def test_backfill_creates_channels_for_all_active_projects(stores):
 async def _has_a2a(channel_store, project_id: str) -> bool:
     chans = await channel_store.list_channels(project_id=project_id)
     return any((c.get("settings") or {}).get("kind") == "a2a" for c in chans)
+
+
+@pytest.mark.asyncio
+async def test_backfill_is_idempotent(stores):
+    """Calling backfill twice is a no-op the second time."""
+    project_store, channel_store = stores
+    p = await project_store.create_project(name="P", slug="bf-idem", created_by="u1")
+
+    n1 = await backfill_all(channel_store, project_store)
+    n2 = await backfill_all(channel_store, project_store)
+
+    assert n1 == 1 and n2 == 1
+    chans = await channel_store.list_channels(project_id=p["id"])
+    a2a = [c for c in chans if (c.get("settings") or {}).get("kind") == "a2a"]
+    assert len(a2a) == 1

--- a/tests/projects/test_a2a.py
+++ b/tests/projects/test_a2a.py
@@ -152,3 +152,21 @@ async def test_ensure_archives_duplicate_a2a_channels(stores):
     a2a_active = [c for c in active if (c.get("settings") or {}).get("kind") == "a2a"]
     assert len(a2a_active) == 1
     assert a2a_active[0]["id"] == canonical["id"]
+
+
+@pytest.mark.asyncio
+async def test_ensure_provisions_new_when_only_archived_exists(stores):
+    """If the only A2A channel for a project is archived, ensure must
+    provision a fresh active one rather than re-electing the archived row."""
+    project_store, channel_store = stores
+    p = await project_store.create_project(name="P", slug="archived-only", created_by="u1")
+
+    first = await ensure_a2a_channel(channel_store, project_store, p["id"])
+    await channel_store.set_settings(first["id"], {"archived": True})
+
+    fresh = await ensure_a2a_channel(channel_store, project_store, p["id"])
+
+    assert fresh["id"] != first["id"]
+    assert (fresh.get("settings") or {}).get("archived") is not True
+    archived = await channel_store.get_channel(first["id"])
+    assert (archived.get("settings") or {}).get("archived") is True

--- a/tests/projects/test_a2a_handover.py
+++ b/tests/projects/test_a2a_handover.py
@@ -1,0 +1,62 @@
+"""End-to-end: posting `@<slug>` in an A2A channel routes through
+agent_chat_router to the addressed agent's bridge queue.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from tinyagentos.agent_chat_router import AgentChatRouter
+
+
+class _FakeBridge:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict]] = []
+
+    async def enqueue_user_message(self, agent_name: str, payload: dict) -> None:
+        self.calls.append((agent_name, payload))
+
+
+@pytest.mark.asyncio
+async def test_at_mention_in_a2a_channel_routes_to_agent_b():
+    bridge = _FakeBridge()
+    state = SimpleNamespace(
+        config=SimpleNamespace(
+            agents=[
+                {"name": "agentA", "status": "running"},
+                {"name": "agentB", "status": "running"},
+            ],
+        ),
+        bridge_sessions=bridge,
+        group_policy=None,
+    )
+
+    router = AgentChatRouter(state)
+
+    channel = {
+        "id": "ch_a2a",
+        "type": "group",
+        "members": ["agentA", "agentB"],
+        "settings": {"kind": "a2a", "max_hops": 3, "muted": []},
+        "project_id": "prj_1",
+    }
+    message = {
+        "id": "msg_1",
+        "channel_id": "ch_a2a",
+        "author_id": "agentA",
+        "content_type": "text",
+        "content": "@agentB please continue",
+        "metadata": {"hops_since_user": 0},
+        "created_at": 1.0,
+    }
+
+    await router._route_inner(message, channel)
+
+    assert len(bridge.calls) == 1
+    target, payload = bridge.calls[0]
+    assert target == "agentB"
+    assert payload["text"] == "@agentB please continue"
+    assert payload["channel_id"] == "ch_a2a"
+    assert payload["force_respond"] is True

--- a/tests/projects/test_routes_a2a.py
+++ b/tests/projects/test_routes_a2a.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import pytest
+
+
+async def _list_channels(client, project_id: str) -> list[dict]:
+    res = await client.get(f"/api/chat/channels?project_id={project_id}")
+    assert res.status_code == 200
+    return res.json().get("channels", [])
+
+
+def _a2a(channels: list[dict]) -> dict | None:
+    for c in channels:
+        if (c.get("settings") or {}).get("kind") == "a2a":
+            return c
+    return None
+
+
+@pytest.mark.asyncio
+async def test_create_project_creates_a2a_channel(client):
+    res = await client.post("/api/projects", json={"name": "P", "slug": "ra2a-1"})
+    assert res.status_code == 200
+    pid = res.json()["id"]
+
+    channels = await _list_channels(client, pid)
+    a2a = _a2a(channels)
+    assert a2a is not None
+    assert a2a["name"] == "a2a"
+    assert a2a["type"] == "group"
+    assert a2a["members"] == []

--- a/tests/projects/test_routes_a2a.py
+++ b/tests/projects/test_routes_a2a.py
@@ -61,3 +61,19 @@ async def test_remove_member_removes_from_a2a_channel(client):
     a2a = _a2a(channels)
     assert a2a is not None
     assert "agentA" not in a2a["members"]
+
+
+@pytest.mark.asyncio
+async def test_a2a_failure_does_not_break_project_create(client, monkeypatch, caplog):
+    import tinyagentos.projects.a2a as a2a_mod
+
+    async def boom(*args, **kwargs):
+        raise RuntimeError("simulated a2a failure")
+
+    monkeypatch.setattr(a2a_mod, "ensure_a2a_channel", boom)
+
+    with caplog.at_level("WARNING"):
+        res = await client.post("/api/projects", json={"name": "P", "slug": "ra2a-fail"})
+    assert res.status_code == 200
+    assert res.json()["slug"] == "ra2a-fail"
+    assert any("a2a ensure failed" in rec.message for rec in caplog.records)

--- a/tests/projects/test_routes_a2a.py
+++ b/tests/projects/test_routes_a2a.py
@@ -28,3 +28,36 @@ async def test_create_project_creates_a2a_channel(client):
     assert a2a["name"] == "a2a"
     assert a2a["type"] == "group"
     assert a2a["members"] == []
+
+
+@pytest.mark.asyncio
+async def test_add_member_adds_to_a2a_channel(client):
+    pid = (await client.post("/api/projects", json={"name": "P", "slug": "ra2a-2"})).json()["id"]
+
+    res = await client.post(
+        f"/api/projects/{pid}/members",
+        json={"mode": "native", "agent_id": "agentA"},
+    )
+    assert res.status_code == 200
+
+    channels = await _list_channels(client, pid)
+    a2a = _a2a(channels)
+    assert a2a is not None
+    assert "agentA" in a2a["members"]
+
+
+@pytest.mark.asyncio
+async def test_remove_member_removes_from_a2a_channel(client):
+    pid = (await client.post("/api/projects", json={"name": "P", "slug": "ra2a-3"})).json()["id"]
+    await client.post(
+        f"/api/projects/{pid}/members",
+        json={"mode": "native", "agent_id": "agentA"},
+    )
+
+    res = await client.delete(f"/api/projects/{pid}/members/agentA")
+    assert res.status_code == 200
+
+    channels = await _list_channels(client, pid)
+    a2a = _a2a(channels)
+    assert a2a is not None
+    assert "agentA" not in a2a["members"]

--- a/tests/projects/test_routes_a2a.py
+++ b/tests/projects/test_routes_a2a.py
@@ -77,3 +77,20 @@ async def test_a2a_failure_does_not_break_project_create(client, monkeypatch, ca
     assert res.status_code == 200
     assert res.json()["slug"] == "ra2a-fail"
     assert any("a2a ensure failed" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_project_delete_archives_a2a_channel(client):
+    pid = (await client.post("/api/projects", json={"name": "P", "slug": "ra2a-del"})).json()["id"]
+
+    pre = _a2a(await _list_channels(client, pid))
+    assert pre is not None and pre["settings"].get("archived") is not True
+
+    res = await client.delete(f"/api/projects/{pid}")
+    assert res.status_code == 200
+
+    archived_res = await client.get(
+        f"/api/chat/channels?archived=true&project_id={pid}"
+    )
+    archived = archived_res.json().get("channels", [])
+    assert _a2a(archived) is not None

--- a/tinyagentos/agent_chat_router.py
+++ b/tinyagentos/agent_chat_router.py
@@ -78,7 +78,7 @@ class AgentChatRouter:
                     force_by_slug[m] = True
                 recipients = list(candidates)
             elif mentions.explicit:
-                recipients = [m for m in candidates if m in mentions.explicit]
+                recipients = [m for m in candidates if m.lower() in mentions.explicit]
                 for m in recipients:
                     force_by_slug[m] = True
             elif channel_type == "dm":

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -607,6 +607,13 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
             logger.exception("disk quota monitor failed to initialise — disk routes will still work")
             app.state.disk_quota_monitor = None
 
+        try:
+            from tinyagentos.projects.a2a import backfill_all as _a2a_backfill_all
+            _n = await _a2a_backfill_all(chat_channels, project_store)
+            logger.info("a2a backfill: ensured channels for %d active projects", _n)
+        except Exception:
+            logger.exception("a2a backfill failed")
+
         yield
         # NOTE: controller restart/shutdown does NOT touch agent containers —
         # agents and LiteLLM keep running independently, so there's nothing to

--- a/tinyagentos/projects/a2a.py
+++ b/tinyagentos/projects/a2a.py
@@ -66,5 +66,16 @@ async def ensure_a2a_channel(channel_store, project_store, project_id: str) -> d
 
 
 async def backfill_all(channel_store, project_store) -> int:
-    """Stub — implemented in Task 4."""
-    return 0
+    """Call ensure_a2a_channel for every active project. Returns count synced.
+
+    Per-project failures are logged and do not stop the loop.
+    """
+    projects = await project_store.list_projects(status="active")
+    count = 0
+    for p in projects:
+        try:
+            await ensure_a2a_channel(channel_store, project_store, p["id"])
+            count += 1
+        except Exception:
+            logger.exception("a2a backfill failed for project %s", p.get("id"))
+    return count

--- a/tinyagentos/projects/a2a.py
+++ b/tinyagentos/projects/a2a.py
@@ -8,13 +8,21 @@ startup backfill.
 
 from __future__ import annotations
 
+import asyncio
 import logging
+from collections import defaultdict
 
 logger = logging.getLogger(__name__)
 
 A2A_NAME = "a2a"
 A2A_TYPE = "group"
 A2A_KIND = "a2a"
+
+# Per-project lock so concurrent ensure_a2a_channel calls (e.g. simultaneous
+# add_member requests during backfill) serialize on the read-modify-write of
+# channel members. Without this, two callers can each compute a stale member
+# diff and clobber each other's add/remove operations.
+_A2A_LOCKS: dict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
 
 
 async def _find_a2a_channel(channel_store, project_id: str) -> dict | None:
@@ -33,36 +41,38 @@ async def ensure_a2a_channel(channel_store, project_store, project_id: str) -> d
     """Create the A2A channel for project_id if missing, sync its members
     to the project's current native+clone members, return the channel row.
 
-    Idempotent.
+    Idempotent. Serialized per project_id via _A2A_LOCKS to prevent racing
+    member-sync diffs when multiple callers fire concurrently.
     """
-    project_members = await project_store.list_members(project_id)
-    expected = {m["member_id"] for m in project_members}
+    async with _A2A_LOCKS[project_id]:
+        project_members = await project_store.list_members(project_id)
+        expected = {m["member_id"] for m in project_members}
 
-    existing = await _find_a2a_channel(channel_store, project_id)
-    if existing is None:
-        project = await project_store.get_project(project_id)
-        created_by = project.get("created_by", "system") if project else "system"
-        return await channel_store.create_channel(
-            name=A2A_NAME,
-            type=A2A_TYPE,
-            created_by=created_by,
-            members=sorted(expected),
-            description="Agent coordination channel.",
-            settings={"kind": A2A_KIND},
-            project_id=project_id,
-        )
+        existing = await _find_a2a_channel(channel_store, project_id)
+        if existing is None:
+            project = await project_store.get_project(project_id)
+            created_by = project.get("created_by", "system") if project else "system"
+            return await channel_store.create_channel(
+                name=A2A_NAME,
+                type=A2A_TYPE,
+                created_by=created_by,
+                members=sorted(expected),
+                description="Agent coordination channel.",
+                settings={"kind": A2A_KIND},
+                project_id=project_id,
+            )
 
-    current = set(existing.get("members") or [])
-    if current == expected:
-        return existing
+        current = set(existing.get("members") or [])
+        if current == expected:
+            return existing
 
-    to_add = expected - current
-    to_remove = current - expected
-    for slug in sorted(to_add):
-        await channel_store.add_member(existing["id"], slug)
-    for slug in sorted(to_remove):
-        await channel_store.remove_member(existing["id"], slug)
-    return await channel_store.get_channel(existing["id"])
+        to_add = expected - current
+        to_remove = current - expected
+        for slug in sorted(to_add):
+            await channel_store.add_member(existing["id"], slug)
+        for slug in sorted(to_remove):
+            await channel_store.remove_member(existing["id"], slug)
+        return await channel_store.get_channel(existing["id"])
 
 
 async def backfill_all(channel_store, project_store) -> int:

--- a/tinyagentos/projects/a2a.py
+++ b/tinyagentos/projects/a2a.py
@@ -26,16 +26,28 @@ _A2A_LOCKS: dict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
 
 
 async def _find_a2a_channels(channel_store, project_id: str) -> list[dict]:
-    """Return all of the project's A2A channel rows, oldest-first.
+    """Return active, fully-identified A2A channel rows for a project, oldest-first.
 
-    Identification: project_id matches AND settings.kind == "a2a".
+    Identification requires all four conditions:
+    - project_id matches
+    - not archived
+    - name == A2A_NAME
+    - type == A2A_TYPE
+    - settings.kind == A2A_KIND
+
     The store already returns rows ordered by created_at ASC, so the first
-    element of the returned list is the canonical A2A channel.
+    element of the returned list is the canonical A2A channel. Archived rows
+    are excluded so a previously-archived duplicate can never be re-elected
+    as canonical.
     """
-    channels = await channel_store.list_channels(project_id=project_id)
+    channels = await channel_store.list_channels(
+        project_id=project_id, archived=False,
+    )
     return [
         ch for ch in channels
-        if (ch.get("settings") or {}).get("kind") == A2A_KIND
+        if ch.get("name") == A2A_NAME
+        and ch.get("type") == A2A_TYPE
+        and (ch.get("settings") or {}).get("kind") == A2A_KIND
     ]
 
 

--- a/tinyagentos/projects/a2a.py
+++ b/tinyagentos/projects/a2a.py
@@ -25,16 +25,18 @@ A2A_KIND = "a2a"
 _A2A_LOCKS: dict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
 
 
-async def _find_a2a_channel(channel_store, project_id: str) -> dict | None:
-    """Return the project's A2A channel row, or None.
+async def _find_a2a_channels(channel_store, project_id: str) -> list[dict]:
+    """Return all of the project's A2A channel rows, oldest-first.
 
     Identification: project_id matches AND settings.kind == "a2a".
+    The store already returns rows ordered by created_at ASC, so the first
+    element of the returned list is the canonical A2A channel.
     """
     channels = await channel_store.list_channels(project_id=project_id)
-    for ch in channels:
-        if (ch.get("settings") or {}).get("kind") == A2A_KIND:
-            return ch
-    return None
+    return [
+        ch for ch in channels
+        if (ch.get("settings") or {}).get("kind") == A2A_KIND
+    ]
 
 
 async def ensure_a2a_channel(channel_store, project_store, project_id: str) -> dict:
@@ -48,8 +50,8 @@ async def ensure_a2a_channel(channel_store, project_store, project_id: str) -> d
         project_members = await project_store.list_members(project_id)
         expected = {m["member_id"] for m in project_members}
 
-        existing = await _find_a2a_channel(channel_store, project_id)
-        if existing is None:
+        matches = await _find_a2a_channels(channel_store, project_id)
+        if not matches:
             project = await project_store.get_project(project_id)
             created_by = project.get("created_by", "system") if project else "system"
             return await channel_store.create_channel(
@@ -61,6 +63,17 @@ async def ensure_a2a_channel(channel_store, project_store, project_id: str) -> d
                 settings={"kind": A2A_KIND},
                 project_id=project_id,
             )
+
+        # Reconcile duplicates: oldest is canonical, archive the rest.
+        # Defensive: pre-lock data, manual DB tampering, or migrations could
+        # have produced more than one A2A channel for a project.
+        existing = matches[0]
+        for dup in matches[1:]:
+            logger.warning(
+                "a2a duplicate channel %s for project %s — archiving",
+                dup.get("id"), project_id,
+            )
+            await channel_store.set_settings(dup["id"], {"archived": True})
 
         current = set(existing.get("members") or [])
         if current == expected:

--- a/tinyagentos/projects/a2a.py
+++ b/tinyagentos/projects/a2a.py
@@ -1,0 +1,55 @@
+"""Per-project A2A (agent-to-agent) coordination channel.
+
+Owns the invariant that every active project has exactly one chat channel
+with `name="a2a"`, `type="group"`, `settings.kind="a2a"`. Single source of
+truth: `ensure_a2a_channel`. Called from project route hooks and from the
+startup backfill.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+A2A_NAME = "a2a"
+A2A_TYPE = "group"
+A2A_KIND = "a2a"
+
+
+async def _find_a2a_channel(channel_store, project_id: str) -> dict | None:
+    """Return the project's A2A channel row, or None.
+
+    Identification: project_id matches AND settings.kind == "a2a".
+    """
+    channels = await channel_store.list_channels(project_id=project_id)
+    for ch in channels:
+        if (ch.get("settings") or {}).get("kind") == A2A_KIND:
+            return ch
+    return None
+
+
+async def ensure_a2a_channel(channel_store, project_store, project_id: str) -> dict:
+    """Create the A2A channel for project_id if missing.
+
+    Idempotent: safe to call repeatedly. (Member sync added in Task 3.)
+    """
+    existing = await _find_a2a_channel(channel_store, project_id)
+    if existing is not None:
+        return existing
+    project = await project_store.get_project(project_id)
+    created_by = project.get("created_by", "system") if project else "system"
+    return await channel_store.create_channel(
+        name=A2A_NAME,
+        type=A2A_TYPE,
+        created_by=created_by,
+        members=[],
+        description="Agent coordination channel.",
+        settings={"kind": A2A_KIND},
+        project_id=project_id,
+    )
+
+
+async def backfill_all(channel_store, project_store) -> int:
+    """Stub — implemented in Task 4."""
+    return 0

--- a/tinyagentos/projects/a2a.py
+++ b/tinyagentos/projects/a2a.py
@@ -30,24 +30,39 @@ async def _find_a2a_channel(channel_store, project_id: str) -> dict | None:
 
 
 async def ensure_a2a_channel(channel_store, project_store, project_id: str) -> dict:
-    """Create the A2A channel for project_id if missing.
+    """Create the A2A channel for project_id if missing, sync its members
+    to the project's current native+clone members, return the channel row.
 
-    Idempotent: safe to call repeatedly. (Member sync added in Task 3.)
+    Idempotent.
     """
+    project_members = await project_store.list_members(project_id)
+    expected = {m["member_id"] for m in project_members}
+
     existing = await _find_a2a_channel(channel_store, project_id)
-    if existing is not None:
+    if existing is None:
+        project = await project_store.get_project(project_id)
+        created_by = project.get("created_by", "system") if project else "system"
+        return await channel_store.create_channel(
+            name=A2A_NAME,
+            type=A2A_TYPE,
+            created_by=created_by,
+            members=sorted(expected),
+            description="Agent coordination channel.",
+            settings={"kind": A2A_KIND},
+            project_id=project_id,
+        )
+
+    current = set(existing.get("members") or [])
+    if current == expected:
         return existing
-    project = await project_store.get_project(project_id)
-    created_by = project.get("created_by", "system") if project else "system"
-    return await channel_store.create_channel(
-        name=A2A_NAME,
-        type=A2A_TYPE,
-        created_by=created_by,
-        members=[],
-        description="Agent coordination channel.",
-        settings={"kind": A2A_KIND},
-        project_id=project_id,
-    )
+
+    to_add = expected - current
+    to_remove = current - expected
+    for slug in sorted(to_add):
+        await channel_store.add_member(existing["id"], slug)
+    for slug in sorted(to_remove):
+        await channel_store.remove_member(existing["id"], slug)
+    return await channel_store.get_channel(existing["id"])
 
 
 async def backfill_all(channel_store, project_store) -> int:

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -75,6 +75,15 @@ async def create_project(payload: CreateProjectIn, request: Request):
         return JSONResponse({"error": str(e)}, status_code=409)
     await store.log_activity(p["id"], _user_id(request), "project.created", {"slug": p["slug"]})
     _mirror(request, p)
+    try:
+        from tinyagentos.projects.a2a import ensure_a2a_channel
+        await ensure_a2a_channel(
+            request.app.state.chat_channels,
+            request.app.state.project_store,
+            p["id"],
+        )
+    except Exception:
+        logger.warning("a2a ensure failed for new project %s", p.get("id"), exc_info=True)
     return p
 
 

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -209,6 +209,15 @@ async def add_member(project_id: str, payload: AddMemberIn, request: Request):
     )
     members = await store.list_members(project_id)
     _mirror(request, {**project, "members": members})
+    try:
+        from tinyagentos.projects.a2a import ensure_a2a_channel
+        await ensure_a2a_channel(
+            request.app.state.chat_channels,
+            request.app.state.project_store,
+            project_id,
+        )
+    except Exception:
+        logger.warning("a2a ensure failed for project %s on add_member", project_id, exc_info=True)
     return next(m for m in members if m["member_id"] == member_id)
 
 
@@ -227,6 +236,15 @@ async def remove_member(project_id: str, member_id: str, request: Request):
     members = await store.list_members(project_id)
     if project is not None:
         _mirror(request, {**project, "members": members})
+    try:
+        from tinyagentos.projects.a2a import ensure_a2a_channel
+        await ensure_a2a_channel(
+            request.app.state.chat_channels,
+            request.app.state.project_store,
+            project_id,
+        )
+    except Exception:
+        logger.warning("a2a ensure failed for project %s on remove_member", project_id, exc_info=True)
     return {"ok": True}
 
 


### PR DESCRIPTION
## Summary

Auto-maintained chat channel per project for agent-to-agent coordination. The channel is a normal `chat_channels` row (`name="a2a"`, `type="group"`, `settings.kind="a2a"`, `project_id` set), kept in sync with `project_members` via three route hooks plus a startup backfill. Frontend default-selects it on first project visit, persists last-selected per project, decorates A2A channels with a Bot icon, and shows an empty-state hint above the composer.

No new database tables, no new API routes, no new chat types — piggybacks on the existing chat-channels infrastructure already shipped with the Projects foundation (#260, #264, #265).

## What changed

**Backend** (`tinyagentos/`)
- `projects/a2a.py` — new invariant module with `ensure_a2a_channel` (idempotent create + member sync) and `backfill_all` (startup sweep over active projects)
- `routes/projects.py` — try/except hooks in `create_project`, `add_member`, `remove_member` (failure logged, never blocks the route)
- `app.py` — startup backfill in lifespan (failure logged, never blocks boot)
- `agent_chat_router.py` — bug fix: lowercase the member name when matching against the lowercase `mentions.explicit` set, so `@agentB` actually routes to a member named `agentB`

**Frontend** (`desktop/`)
- `MessagesApp.a2aSelection.ts` — small helper module (storage key, read/write last-channel, find A2A by `settings.kind`)
- `MessagesApp.tsx` — default-select effect, persist on selection change, Bot icon in 4 sidebar variants, empty-state hint above composer

## Test plan

- [x] Backend: 55/55 tests pass in ` tests/projects/` (12 new across `test_a2a.py`, `test_routes_a2a.py`, `test_a2a_handover.py`)
- [x] Frontend: 6 new tests in `MessagesApp.a2a-default.test.ts`, all pass; `tsc --noEmit` clean
- [x] Pre-existing `tests/snap-zones.test.ts` failures verified to exist on master (unrelated)
- [ ] Smoke test in dev: create new project, confirm A2A channel auto-selected with Bot icon, post `@<slug>` to verify handover routing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-project A2A channel selection is persisted and restored across visits
  * Visual A2A indicators (icon + tooltip) added to channel lists and adjusted layout
  * Empty A2A channels show a guidance banner for handing off via @mention
  * App startup backfills and auto-provisions A2A channels; provisioning runs after project/member changes and reconciles members

* **Bug Fixes**
  * Agent @mentions are matched case-insensitively for reliable routing

* **Tests**
  * New tests cover A2A selection storage, provisioning/backfill, handover routing, and API behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->