### PR TITLE
feat(projects): mobile shell — responsive layout, swipe board, mobile task modal

### DIFF
--- a/desktop/.gitignore
+++ b/desktop/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 dist/
+playwright-report/
+test-results/

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -50,6 +50,7 @@
         "zustand": "^5.0.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/vite": "^4.0.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -2089,6 +2090,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ocavue"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -8147,6 +8164,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/plyr": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@codemirror/lang-markdown": "^6.5.0",
@@ -53,6 +54,7 @@
     "zustand": "^5.0.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/vite": "^4.0.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests",
+  testMatch: "**/*.spec.ts",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "html",
+  use: {
+    baseURL: "http://127.0.0.1:5173",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "iphone-14",
+      use: { ...devices["iPhone 14"] },
+    },
+  ],
+  webServer: {
+    command: "npm run dev",
+    url: "http://127.0.0.1:5173",
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+});

--- a/desktop/src/apps/ProjectsApp/ProjectActivity.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectActivity.tsx
@@ -24,16 +24,16 @@ export function ProjectActivity({ projectId }: { projectId: string }) {
       {items.map((a) => (
         <li
           key={a.id}
-          className="bg-zinc-900 px-3 py-2 rounded text-sm flex flex-col-reverse gap-1 md:block md:gap-0"
+          className="bg-zinc-900 px-3 py-2 rounded text-sm flex flex-col gap-1 md:flex-row-reverse md:items-baseline md:justify-end md:gap-2"
         >
-          <span className="text-zinc-500 md:mr-2 text-xs md:text-sm md:tabular-nums">
-            {new Date(a.created_at * 1000).toLocaleString()}
-          </span>
-          <span>
+          <div className="md:contents">
             <span className="font-medium">{a.kind}</span>
             {a.payload && Object.keys(a.payload).length > 0 && (
               <span className="ml-2 text-zinc-500 text-xs">{JSON.stringify(a.payload)}</span>
             )}
+          </div>
+          <span className="text-zinc-500 text-xs md:text-sm md:tabular-nums">
+            {new Date(a.created_at * 1000).toLocaleString()}
           </span>
         </li>
       ))}

--- a/desktop/src/apps/ProjectsApp/ProjectActivity.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectActivity.tsx
@@ -22,12 +22,19 @@ export function ProjectActivity({ projectId }: { projectId: string }) {
   return (
     <ul className="space-y-1" aria-label="Activity">
       {items.map((a) => (
-        <li key={a.id} className="bg-zinc-900 px-3 py-2 rounded text-sm">
-          <span className="text-zinc-500 mr-2">{new Date(a.created_at * 1000).toLocaleString()}</span>
-          <span className="font-medium">{a.kind}</span>
-          {a.payload && Object.keys(a.payload).length > 0 && (
-            <span className="ml-2 text-zinc-500 text-xs">{JSON.stringify(a.payload)}</span>
-          )}
+        <li
+          key={a.id}
+          className="bg-zinc-900 px-3 py-2 rounded text-sm flex flex-col-reverse gap-1 md:block md:gap-0"
+        >
+          <span className="text-zinc-500 md:mr-2 text-xs md:text-sm md:tabular-nums">
+            {new Date(a.created_at * 1000).toLocaleString()}
+          </span>
+          <span>
+            <span className="font-medium">{a.kind}</span>
+            {a.payload && Object.keys(a.payload).length > 0 && (
+              <span className="ml-2 text-zinc-500 text-xs">{JSON.stringify(a.payload)}</span>
+            )}
+          </span>
         </li>
       ))}
       {items.length === 0 && <li className="text-sm text-zinc-500">No activity.</li>}

--- a/desktop/src/apps/ProjectsApp/ProjectMembers.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectMembers.tsx
@@ -38,15 +38,15 @@ export function ProjectMembers({ project, onChanged }: { project: Project; onCha
       </header>
       <ul className="space-y-1" aria-label="Project members">
         {members.map((m) => (
-          <li key={m.member_id} className="flex justify-between items-center bg-zinc-900 px-3 py-2 rounded">
-            <div>
-              <div className="text-sm">{m.member_id}</div>
+          <li key={m.member_id} className="flex flex-col gap-2 bg-zinc-900 px-3 py-3 rounded md:flex-row md:items-center md:justify-between md:gap-4 md:py-2">
+            <div className="min-w-0">
+              <div className="truncate text-sm" title={m.member_id}>{m.member_id}</div>
               <div className="text-xs text-zinc-500">
                 {m.member_kind}
                 {m.member_kind === "clone" ? ` · ${m.memory_seed}` : ""}
               </div>
             </div>
-            <div className="flex items-center gap-2">
+            <div className="flex flex-wrap items-center gap-2 md:flex-nowrap">
               {(m.member_kind === "native" || m.member_kind === "clone") && (
                 <label
                   style={{ display: "inline-flex", alignItems: "center", gap: 6 }}

--- a/desktop/src/apps/ProjectsApp/ProjectTaskList.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectTaskList.tsx
@@ -109,15 +109,15 @@ export function ProjectTaskList({ projectId }: { projectId: string }) {
         ))}
       </nav>
 
-      <form onSubmit={create} className="flex gap-2 mb-3">
+      <form onSubmit={create} className="flex flex-col gap-2 mb-3 md:flex-row md:items-center md:gap-2">
         <input
           aria-label="New task title"
           value={newTitle}
           onChange={(e) => setNewTitle(e.target.value)}
           placeholder="Add a task…"
-          className="flex-1 px-2 py-1 bg-zinc-800 rounded text-sm"
+          className="w-full px-3 py-2 bg-zinc-800 rounded text-sm md:flex-1 md:px-2 md:py-1"
         />
-        <button type="submit" className="px-3 py-1 bg-blue-600 rounded text-sm">
+        <button type="submit" className="px-4 py-2 bg-blue-600 rounded text-sm md:w-auto md:px-3 md:py-1">
           Add
         </button>
       </form>
@@ -128,16 +128,16 @@ export function ProjectTaskList({ projectId }: { projectId: string }) {
         {visible.map((t) => {
           const ownsClaim = !!currentUserId && t.claimed_by === currentUserId;
           return (
-            <li key={t.id} className="flex items-center justify-between bg-zinc-900 px-3 py-2 rounded">
-              <div className="min-w-0">
-                <div className="text-sm truncate">{t.title}</div>
-                <div className="text-xs text-zinc-500">
+            <li key={t.id} className="flex flex-col gap-2 bg-zinc-900 px-3 py-2 rounded md:flex-row md:items-center md:justify-between md:gap-4">
+              <div className="min-w-0 flex-1">
+                <div className="text-sm truncate" title={t.title}>{t.title}</div>
+                <div className="text-xs text-zinc-500 truncate">
                   {t.id}
                   {t.claimed_by ? ` · claimed by ${t.claimed_by}` : ""}
                   {t.closed_at ? ` · closed` : ""}
                 </div>
               </div>
-              <div className="flex gap-2 text-xs">
+              <div className="flex flex-wrap gap-2 text-xs md:flex-nowrap">
                 {view === "ready" && (
                   <button
                     type="button"

--- a/desktop/src/apps/ProjectsApp/ProjectTaskList.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectTaskList.tsx
@@ -37,6 +37,15 @@ export function ProjectTaskList({ projectId }: { projectId: string }) {
     refresh();
   }, [projectId, view]);
 
+  useEffect(() => {
+    const onRefresh = (e: Event) => {
+      const detail = (e as CustomEvent).detail;
+      if (detail?.projectId === projectId) refresh();
+    };
+    window.addEventListener("projects:tasks-refresh", onRefresh);
+    return () => window.removeEventListener("projects:tasks-refresh", onRefresh);
+  }, [projectId, view]);
+
   const create = async (e: React.FormEvent) => {
     e.preventDefault();
     const title = newTitle.trim();

--- a/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import type { Project } from "@/lib/projects";
+import { projectsApi, type Project } from "@/lib/projects";
 import { ProjectTaskList } from "./ProjectTaskList";
 import { ProjectMembers } from "./ProjectMembers";
 import { ProjectActivity } from "./ProjectActivity";
@@ -10,6 +10,8 @@ import { MessagesApp } from "@/apps/MessagesApp";
 import { CanvasView } from "./canvas/CanvasView";
 import { useIsMobile } from "../../hooks/use-is-mobile";
 import { WorkspaceTabPills } from "../../components/mobile/WorkspaceTabPills";
+import { ProjectFab } from "./mobile/ProjectFab";
+import { TaskCreateSheet } from "./mobile/TaskCreateSheet";
 
 type Tab = "board" | "canvas" | "tasks" | "files" | "messages" | "members" | "activity";
 const TABS: Tab[] = ["board", "canvas", "tasks", "files", "messages", "members", "activity"];
@@ -33,6 +35,14 @@ export function ProjectWorkspace({ project, onChanged }: { project: Project; onC
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
   const [authResolved, setAuthResolved] = useState(false);
   const [openTaskId, setOpenTaskId] = useState<string | null>(() => readTaskParam());
+  const [createSheetOpen, setCreateSheetOpen] = useState(false);
+
+  const handleCreateTask = async ({ title }: { title: string }) => {
+    await projectsApi.tasks.create(project.id, { title });
+    window.dispatchEvent(
+      new CustomEvent("projects:tasks-refresh", { detail: { projectId: project.id } }),
+    );
+  };
 
   const tabPills = TABS.map((t) => ({
     id: t,
@@ -134,6 +144,16 @@ export function ProjectWorkspace({ project, onChanged }: { project: Project; onC
         {tab === "members" && <ProjectMembers project={project} onChanged={onChanged} />}
         {tab === "activity" && <ProjectActivity projectId={project.id} />}
       </div>
+      {isMobile && (tab === "tasks" || tab === "board") && (
+        <>
+          <ProjectFab onClick={() => setCreateSheetOpen(true)} />
+          <TaskCreateSheet
+            open={createSheetOpen}
+            onClose={() => setCreateSheetOpen(false)}
+            onSubmit={handleCreateTask}
+          />
+        </>
+      )}
     </div>
   );
 }

--- a/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
@@ -90,7 +90,9 @@ export function ProjectWorkspace({ project, onChanged }: { project: Project; onC
               key={t}
               type="button"
               role="tab"
+              id={`workspace-tab-${t}`}
               aria-selected={tab === t}
+              aria-controls={`workspace-tabpanel-${t}`}
               onClick={() => setTab(t)}
               className={`px-3 py-2 text-sm capitalize ${
                 tab === t ? "border-b-2 border-blue-400" : "text-zinc-400"
@@ -101,7 +103,12 @@ export function ProjectWorkspace({ project, onChanged }: { project: Project; onC
           ))}
         </nav>
       )}
-      <div className="flex-1 min-h-0 overflow-auto p-4">
+      <div
+        className="flex-1 min-h-0 overflow-auto p-4"
+        role="tabpanel"
+        id={`workspace-tabpanel-${tab}`}
+        aria-labelledby={`workspace-tab-${tab}`}
+      >
         {tab === "board" && (
           <>
             {!authResolved ? (

--- a/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
@@ -59,9 +59,11 @@ export function ProjectWorkspace({ project, onChanged }: { project: Project; onC
 
   return (
     <div className="flex flex-col h-full">
-      <header className="px-4 py-3 border-b border-zinc-800">
-        <h1 className="text-lg font-semibold">{project.name}</h1>
-        <p className="text-xs text-zinc-500">{project.description}</p>
+      <header className="flex flex-col gap-3 px-4 py-3 border-b border-zinc-800 md:flex-row md:items-center md:justify-between md:px-6 md:py-4">
+        <div className="min-w-0">
+          <h1 className="truncate text-lg font-semibold md:text-xl">{project.name}</h1>
+          <p className="mt-1 line-clamp-2 text-xs text-zinc-500 md:line-clamp-none">{project.description}</p>
+        </div>
       </header>
       {isMobile ? (
         <WorkspaceTabPills

--- a/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
@@ -61,8 +61,10 @@ export function ProjectWorkspace({ project, onChanged }: { project: Project; onC
     <div className="flex flex-col h-full">
       <header className="flex flex-col gap-3 px-4 py-3 border-b border-zinc-800 md:flex-row md:items-center md:justify-between md:px-6 md:py-4">
         <div className="min-w-0">
-          <h1 className="truncate text-lg font-semibold md:text-xl">{project.name}</h1>
-          <p className="mt-1 line-clamp-2 text-xs text-zinc-500 md:line-clamp-none">{project.description}</p>
+          <h1 className="truncate text-lg font-semibold md:text-xl" title={project.name}>{project.name}</h1>
+          {project.description && (
+            <p className="mt-1 line-clamp-2 text-xs text-zinc-500 md:line-clamp-none" title={project.description}>{project.description}</p>
+          )}
         </div>
       </header>
       {isMobile ? (

--- a/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
@@ -8,6 +8,8 @@ import { TaskModal } from "./board/TaskModal";
 import { FilesApp } from "@/apps/FilesApp";
 import { MessagesApp } from "@/apps/MessagesApp";
 import { CanvasView } from "./canvas/CanvasView";
+import { useIsMobile } from "../../hooks/use-is-mobile";
+import { WorkspaceTabPills } from "../../components/mobile/WorkspaceTabPills";
 
 type Tab = "board" | "canvas" | "tasks" | "files" | "messages" | "members" | "activity";
 const TABS: Tab[] = ["board", "canvas", "tasks", "files", "messages", "members", "activity"];
@@ -26,10 +28,16 @@ function setTaskParam(taskId: string | null) {
 }
 
 export function ProjectWorkspace({ project, onChanged }: { project: Project; onChanged: () => void }) {
+  const isMobile = useIsMobile();
   const [tab, setTab] = useState<Tab>("tasks");
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
   const [authResolved, setAuthResolved] = useState(false);
   const [openTaskId, setOpenTaskId] = useState<string | null>(() => readTaskParam());
+
+  const tabPills = TABS.map((t) => ({
+    id: t,
+    label: t.charAt(0).toUpperCase() + t.slice(1),
+  }));
 
   useEffect(() => {
     let cancelled = false;
@@ -55,22 +63,30 @@ export function ProjectWorkspace({ project, onChanged }: { project: Project; onC
         <h1 className="text-lg font-semibold">{project.name}</h1>
         <p className="text-xs text-zinc-500">{project.description}</p>
       </header>
-      <nav className="flex border-b border-zinc-800 px-2" role="tablist">
-        {TABS.map((t) => (
-          <button
-            key={t}
-            type="button"
-            role="tab"
-            aria-selected={tab === t}
-            onClick={() => setTab(t)}
-            className={`px-3 py-2 text-sm capitalize ${
-              tab === t ? "border-b-2 border-blue-400" : "text-zinc-400"
-            }`}
-          >
-            {t}
-          </button>
-        ))}
-      </nav>
+      {isMobile ? (
+        <WorkspaceTabPills
+          tabs={tabPills}
+          active={tab}
+          onSelect={(id) => setTab(id as Tab)}
+        />
+      ) : (
+        <nav className="flex border-b border-zinc-800 px-2" role="tablist">
+          {TABS.map((t) => (
+            <button
+              key={t}
+              type="button"
+              role="tab"
+              aria-selected={tab === t}
+              onClick={() => setTab(t)}
+              className={`px-3 py-2 text-sm capitalize ${
+                tab === t ? "border-b-2 border-blue-400" : "text-zinc-400"
+              }`}
+            >
+              {t}
+            </button>
+          ))}
+        </nav>
+      )}
       <div className="flex-1 min-h-0 overflow-auto p-4">
         {tab === "board" && (
           <>

--- a/desktop/src/apps/ProjectsApp/__tests__/ProjectWorkspace.mobile.test.tsx
+++ b/desktop/src/apps/ProjectsApp/__tests__/ProjectWorkspace.mobile.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import type { Project } from "@/lib/projects";
+import { ProjectWorkspace } from "../ProjectWorkspace";
+
+vi.mock("../../../hooks/use-is-mobile", () => ({
+  useIsMobile: vi.fn(),
+}));
+import { useIsMobile } from "../../../hooks/use-is-mobile";
+
+// Mock heavy children — we only care about the tab strip switch here.
+vi.mock("../board/ProjectBoard", () => ({ ProjectBoard: () => <div /> }));
+vi.mock("../board/TaskModal", () => ({ TaskModal: () => <div /> }));
+vi.mock("../canvas/CanvasView", () => ({ CanvasView: () => <div /> }));
+vi.mock("../ProjectTaskList", () => ({ ProjectTaskList: () => <div /> }));
+vi.mock("../ProjectMembers", () => ({ ProjectMembers: () => <div /> }));
+vi.mock("../ProjectActivity", () => ({ ProjectActivity: () => <div /> }));
+vi.mock("@/apps/FilesApp", () => ({ FilesApp: () => <div /> }));
+vi.mock("@/apps/MessagesApp", () => ({ MessagesApp: () => <div /> }));
+
+const fakeProject: Project = {
+  id: "p1",
+  slug: "p1",
+  name: "P1",
+  description: "",
+  status: "active",
+  created_by: "u1",
+  created_at: 0,
+  updated_at: 0,
+};
+
+describe("ProjectWorkspace tab strip", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    // ProjectWorkspace fires `fetch("/api/auth/me")` on mount. Stub it so the
+    // test doesn't depend on jsdom's network or auth state.
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ user: { id: "u1" } }),
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("renders WorkspaceTabPills on mobile", async () => {
+    (useIsMobile as ReturnType<typeof vi.fn>).mockReturnValue(true);
+    await act(async () => {
+      render(<ProjectWorkspace project={fakeProject} onChanged={() => {}} />);
+    });
+    expect(screen.getByTestId("workspace-tab-pills-scroller")).toBeInTheDocument();
+  });
+
+  it("renders the desktop button strip on desktop", async () => {
+    (useIsMobile as ReturnType<typeof vi.fn>).mockReturnValue(false);
+    await act(async () => {
+      render(<ProjectWorkspace project={fakeProject} onChanged={() => {}} />);
+    });
+    expect(screen.queryByTestId("workspace-tab-pills-scroller")).not.toBeInTheDocument();
+  });
+});

--- a/desktop/src/apps/ProjectsApp/__tests__/ProjectWorkspace.mobile.test.tsx
+++ b/desktop/src/apps/ProjectsApp/__tests__/ProjectWorkspace.mobile.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { act, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import type { Project } from "@/lib/projects";
 import { ProjectWorkspace } from "../ProjectWorkspace";
 
@@ -60,5 +60,33 @@ describe("ProjectWorkspace tab strip", () => {
       render(<ProjectWorkspace project={fakeProject} onChanged={() => {}} />);
     });
     expect(screen.queryByTestId("workspace-tab-pills-scroller")).not.toBeInTheDocument();
+  });
+
+  it("renders the FAB on mobile when the Tasks tab is active", async () => {
+    (useIsMobile as ReturnType<typeof vi.fn>).mockReturnValue(true);
+    await act(async () => {
+      render(<ProjectWorkspace project={fakeProject} onChanged={() => {}} />);
+    });
+    expect(screen.getByLabelText("Create task")).toBeInTheDocument();
+  });
+
+  it("does not render the FAB on desktop", async () => {
+    (useIsMobile as ReturnType<typeof vi.fn>).mockReturnValue(false);
+    await act(async () => {
+      render(<ProjectWorkspace project={fakeProject} onChanged={() => {}} />);
+    });
+    expect(screen.queryByLabelText("Create task")).not.toBeInTheDocument();
+  });
+
+  it("hides the FAB when a non-task tab is active on mobile", async () => {
+    (useIsMobile as ReturnType<typeof vi.fn>).mockReturnValue(true);
+    await act(async () => {
+      render(<ProjectWorkspace project={fakeProject} onChanged={() => {}} />);
+    });
+    // Switch to Files tab via the mobile pill button.
+    await act(async () => {
+      fireEvent.click(screen.getByRole("tab", { name: "Files" }));
+    });
+    expect(screen.queryByLabelText("Create task")).not.toBeInTheDocument();
   });
 });

--- a/desktop/src/apps/ProjectsApp/__tests__/ProjectsApp.mobile.test.tsx
+++ b/desktop/src/apps/ProjectsApp/__tests__/ProjectsApp.mobile.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from "vitest";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { ProjectsApp } from "../index";
+
+vi.mock("../../../hooks/use-is-mobile", () => ({
+  useIsMobile: vi.fn(),
+}));
+import { useIsMobile } from "../../../hooks/use-is-mobile";
+
+vi.mock("@/lib/projects", () => ({
+  projectsApi: {
+    list: vi.fn().mockResolvedValue([]),
+    activity: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+// Stub out heavy child components so the test only cares about layout structure
+vi.mock("../ProjectList", () => ({
+  ProjectList: () => <div data-testid="project-list" />,
+}));
+
+vi.mock("../ProjectWorkspace", () => ({
+  ProjectWorkspace: () => <div data-testid="project-workspace" />,
+}));
+
+// Stub MobileSplitView so it renders without needing window.matchMedia
+vi.mock("../../../components/mobile/MobileSplitView", () => ({
+  MobileSplitView: ({ list }: { list: React.ReactNode }) => (
+    <div data-testid="mobile-split-view">{list}</div>
+  ),
+}));
+
+describe("ProjectsApp mobile shell", () => {
+  it("renders MobileSplitView when useIsMobile is true", () => {
+    (useIsMobile as ReturnType<typeof vi.fn>).mockReturnValue(true);
+    render(<ProjectsApp windowId="test-window" />);
+    expect(screen.getByTestId("mobile-split-view")).toBeInTheDocument();
+  });
+
+  it("renders side-by-side flex layout when useIsMobile is false", () => {
+    (useIsMobile as ReturnType<typeof vi.fn>).mockReturnValue(false);
+    render(<ProjectsApp windowId="test-window" />);
+    expect(screen.queryByTestId("mobile-split-view")).not.toBeInTheDocument();
+    expect(document.querySelector("aside.w-72")).toBeInTheDocument();
+  });
+});

--- a/desktop/src/apps/ProjectsApp/__tests__/ProjectsApp.mobile.test.tsx
+++ b/desktop/src/apps/ProjectsApp/__tests__/ProjectsApp.mobile.test.tsx
@@ -24,10 +24,13 @@ vi.mock("../ProjectWorkspace", () => ({
   ProjectWorkspace: () => <div data-testid="project-workspace" />,
 }));
 
-// Stub MobileSplitView so it renders without needing window.matchMedia
+// Stub MobileSplitView so it renders without needing window.matchMedia.
+// Surface listTitle as a data attribute so the test can verify the production
+// code actually routed through this component with the expected props,
+// rather than a desktop-branch element happening to wear the same testid.
 vi.mock("../../../components/mobile/MobileSplitView", () => ({
-  MobileSplitView: ({ list }: { list: React.ReactNode }) => (
-    <div data-testid="mobile-split-view">{list}</div>
+  MobileSplitView: ({ list, listTitle }: { list: React.ReactNode; listTitle?: string }) => (
+    <div data-testid="mobile-split-view" data-list-title={listTitle}>{list}</div>
   ),
 }));
 
@@ -36,6 +39,7 @@ describe("ProjectsApp mobile shell", () => {
     (useIsMobile as ReturnType<typeof vi.fn>).mockReturnValue(true);
     render(<ProjectsApp windowId="test-window" />);
     expect(screen.getByTestId("mobile-split-view")).toBeInTheDocument();
+    expect(screen.getByTestId("mobile-split-view")).toHaveAttribute("data-list-title", "Projects");
   });
 
   it("renders side-by-side flex layout when useIsMobile is false", () => {

--- a/desktop/src/apps/ProjectsApp/board/BoardToolbar.tsx
+++ b/desktop/src/apps/ProjectsApp/board/BoardToolbar.tsx
@@ -1,6 +1,8 @@
+import { useState } from "react";
 import styles from "./BoardToolbar.module.css";
 import type { ViewMode, GroupBy, Filters } from "./types";
 import { BoardFilters } from "./BoardFilters";
+import { useIsMobile } from "../../../hooks/use-is-mobile";
 
 export interface BoardToolbarProps {
   viewMode: ViewMode;
@@ -21,6 +23,80 @@ const VIEW_LABEL: Record<ViewMode, string> = {
 };
 
 export function BoardToolbar(p: BoardToolbarProps) {
+  const isMobile = useIsMobile();
+  const [sheetOpen, setSheetOpen] = useState(false);
+
+  if (isMobile) {
+    return (
+      <>
+        <div className="flex items-center justify-between border-b border-zinc-800 px-3 py-2">
+          <button
+            type="button"
+            onClick={() => setSheetOpen(true)}
+            className="rounded-full bg-zinc-800 px-3 py-1.5 text-sm text-zinc-200"
+          >
+            Filter / Group ▾
+          </button>
+        </div>
+        {sheetOpen && (
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-label="Filter and group"
+            className="fixed inset-0 z-40 flex items-end"
+          >
+            <button
+              type="button"
+              aria-label="Dismiss"
+              className="absolute inset-0 bg-black/60"
+              onClick={() => setSheetOpen(false)}
+            />
+            <div
+              className="relative z-10 w-full rounded-t-2xl bg-zinc-900 p-4 text-zinc-100"
+              style={{ paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 1rem)" }}
+            >
+              <div className="mx-auto mb-3 h-1 w-10 rounded-full bg-zinc-700" />
+              <h2 className="mb-3 text-base font-semibold">Filter & group</h2>
+
+              <label className="mb-3 flex items-center gap-2 text-sm">
+                <span className="text-zinc-300">Group by</span>
+                <select
+                  value={p.groupBy}
+                  onChange={(e) => p.onChangeGroup(e.target.value as GroupBy)}
+                  className="flex-1 rounded bg-zinc-800 px-2 py-1 text-sm text-zinc-100"
+                >
+                  <option value="assignee">Assignee</option>
+                  <option value="parent">Parent</option>
+                  <option value="label">Label</option>
+                  <option value="priority">Priority</option>
+                </select>
+              </label>
+
+              <input
+                type="search"
+                className="mb-3 w-full rounded bg-zinc-800 px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-500"
+                placeholder="Search tasks…"
+                value={p.filters.search}
+                onChange={(e) => p.onChangeFilters({ ...p.filters, search: e.target.value })}
+                aria-label="Search tasks"
+              />
+
+              <BoardFilters value={p.filters} onChange={p.onChangeFilters} />
+
+              <button
+                type="button"
+                onClick={() => setSheetOpen(false)}
+                className="mt-4 w-full rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white"
+              >
+                Done
+              </button>
+            </div>
+          </div>
+        )}
+      </>
+    );
+  }
+
   return (
     <div className={styles.bar}>
       <div className={styles.crumb}>Board</div>

--- a/desktop/src/apps/ProjectsApp/board/BoardToolbar.tsx
+++ b/desktop/src/apps/ProjectsApp/board/BoardToolbar.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import styles from "./BoardToolbar.module.css";
 import type { ViewMode, GroupBy, Filters } from "./types";
 import { BoardFilters } from "./BoardFilters";
@@ -25,6 +25,13 @@ const VIEW_LABEL: Record<ViewMode, string> = {
 export function BoardToolbar(p: BoardToolbarProps) {
   const isMobile = useIsMobile();
   const [sheetOpen, setSheetOpen] = useState(false);
+  const groupSelectRef = useRef<HTMLSelectElement>(null);
+
+  useEffect(() => {
+    if (!sheetOpen) return;
+    const t = window.setTimeout(() => groupSelectRef.current?.focus(), 50);
+    return () => window.clearTimeout(t);
+  }, [sheetOpen]);
 
   if (isMobile) {
     return (
@@ -58,9 +65,11 @@ export function BoardToolbar(p: BoardToolbarProps) {
               <div className="mx-auto mb-3 h-1 w-10 rounded-full bg-zinc-700" />
               <h2 className="mb-3 text-base font-semibold">Filter & group</h2>
 
+              {/* On mobile we always show group-by; the carousel applies it regardless of viewMode. */}
               <label className="mb-3 flex items-center gap-2 text-sm">
                 <span className="text-zinc-300">Group by</span>
                 <select
+                  ref={groupSelectRef}
                   value={p.groupBy}
                   onChange={(e) => p.onChangeGroup(e.target.value as GroupBy)}
                   className="flex-1 rounded bg-zinc-800 px-2 py-1 text-sm text-zinc-100"

--- a/desktop/src/apps/ProjectsApp/board/ProjectBoard.tsx
+++ b/desktop/src/apps/ProjectsApp/board/ProjectBoard.tsx
@@ -29,6 +29,11 @@ const PERSIST_KEY = (pid: string) => `taos.projects.${pid}.board`;
 // modes that actually render to avoid `lanes!` blowing up on rehydrate.
 const VALID_VIEWS: ViewMode[] = ["lanes", "kanban"];
 const VALID_GROUPS: GroupBy[] = ["assignee", "parent", "label", "priority"];
+const MOBILE_COLUMNS: ReadonlyArray<MobileBoardColumn> = [
+  { id: "ready", label: "Ready" },
+  { id: "claimed", label: "Claimed" },
+  { id: "closed", label: "Closed" },
+];
 type ColStatus = "ready" | "claimed" | "closed";
 
 export function ProjectBoard({ projectId, currentUserId, onOpenTask }: ProjectBoardProps) {
@@ -69,12 +74,6 @@ export function ProjectBoard({ projectId, currentUserId, onOpenTask }: ProjectBo
   const filtered = useMemo(() => applyFilters(tasks, filters), [tasks, filters]);
 
   const isMobile = useIsMobile();
-
-  const mobileColumns: ReadonlyArray<MobileBoardColumn> = [
-    { id: "ready", label: "Ready" },
-    { id: "claimed", label: "Claimed" },
-    { id: "closed", label: "Closed" },
-  ];
 
   const tasksByColumn = useMemo<Record<string, BoardTask[]>>(() => ({
     ready: filtered.filter((t) => t.status === "open"),
@@ -145,14 +144,12 @@ export function ProjectBoard({ projectId, currentUserId, onOpenTask }: ProjectBo
 
   if (isMobile) {
     return (
-      <div className="flex h-full flex-col">
-        <MobileBoardCarousel
-          columns={mobileColumns}
-          tasksByColumn={tasksByColumn}
-          groupBy={groupBy}
-          onOpenTask={(id) => onOpenTask?.(id)}
-        />
-      </div>
+      <MobileBoardCarousel
+        columns={MOBILE_COLUMNS}
+        tasksByColumn={tasksByColumn}
+        groupBy={groupBy}
+        onOpenTask={(id) => onOpenTask?.(id)}
+      />
     );
   }
 

--- a/desktop/src/apps/ProjectsApp/board/ProjectBoard.tsx
+++ b/desktop/src/apps/ProjectsApp/board/ProjectBoard.tsx
@@ -14,6 +14,9 @@ import { EMPTY_FILTERS } from "./types";
 import type { Filters, GroupBy, Task, ViewMode } from "./types";
 import { projectsApi } from "../../../lib/projects";
 import type { ProjectTask } from "../../../lib/projects";
+import { useIsMobile } from "../../../hooks/use-is-mobile";
+import { MobileBoardCarousel } from "../mobile/MobileBoardCarousel";
+import type { BoardColumn as MobileBoardColumn, BoardTask } from "../mobile/MobileBoardCarousel";
 
 export interface ProjectBoardProps {
   projectId: string;
@@ -64,6 +67,20 @@ export function ProjectBoard({ projectId, currentUserId, onOpenTask }: ProjectBo
   });
 
   const filtered = useMemo(() => applyFilters(tasks, filters), [tasks, filters]);
+
+  const isMobile = useIsMobile();
+
+  const mobileColumns: ReadonlyArray<MobileBoardColumn> = [
+    { id: "ready", label: "Ready" },
+    { id: "claimed", label: "Claimed" },
+    { id: "closed", label: "Closed" },
+  ];
+
+  const tasksByColumn = useMemo<Record<string, BoardTask[]>>(() => ({
+    ready: filtered.filter((t) => t.status === "open"),
+    claimed: filtered.filter((t) => t.status === "claimed"),
+    closed: filtered.filter((t) => t.status === "closed"),
+  }), [filtered]);
 
   const lanes = useMemo(() => {
     if (viewMode !== "lanes") return null;
@@ -125,6 +142,19 @@ export function ProjectBoard({ projectId, currentUserId, onOpenTask }: ProjectBo
       onDragStart={drag ? onCardDragStart : undefined}
     />
   );
+
+  if (isMobile) {
+    return (
+      <div className="flex h-full flex-col">
+        <MobileBoardCarousel
+          columns={mobileColumns}
+          tasksByColumn={tasksByColumn}
+          groupBy={groupBy}
+          onOpenTask={(id) => onOpenTask?.(id)}
+        />
+      </div>
+    );
+  }
 
   return (
     <div className={styles.frame}>

--- a/desktop/src/apps/ProjectsApp/board/ProjectBoard.tsx
+++ b/desktop/src/apps/ProjectsApp/board/ProjectBoard.tsx
@@ -144,12 +144,23 @@ export function ProjectBoard({ projectId, currentUserId, onOpenTask }: ProjectBo
 
   if (isMobile) {
     return (
-      <MobileBoardCarousel
-        columns={MOBILE_COLUMNS}
-        tasksByColumn={tasksByColumn}
-        groupBy={groupBy}
-        onOpenTask={(id) => onOpenTask?.(id)}
-      />
+      <div className={styles.frame}>
+        <BoardToolbar
+          viewMode={viewMode}
+          groupBy={groupBy}
+          filters={filters}
+          live={connected}
+          onChangeView={setViewMode}
+          onChangeGroup={setGroupBy}
+          onChangeFilters={setFilters}
+        />
+        <MobileBoardCarousel
+          columns={MOBILE_COLUMNS}
+          tasksByColumn={tasksByColumn}
+          groupBy={groupBy}
+          onOpenTask={(id) => onOpenTask?.(id)}
+        />
+      </div>
     );
   }
 

--- a/desktop/src/apps/ProjectsApp/board/TaskModal.tsx
+++ b/desktop/src/apps/ProjectsApp/board/TaskModal.tsx
@@ -81,9 +81,19 @@ export function TaskModal({ projectId, taskId, currentUserId, onClose, onPrev, o
           role="dialog"
           aria-modal="true"
           aria-label="Loading task"
-          className="fixed inset-0 z-50 flex items-center justify-center bg-zinc-950 text-zinc-400"
+          className="fixed inset-0 z-50 flex flex-col bg-zinc-950 text-zinc-400"
         >
-          Loading…
+          <div className="flex justify-end p-3" style={{ paddingTop: "calc(env(safe-area-inset-top, 0px) + 0.5rem)" }}>
+            <button
+              type="button"
+              aria-label="Close"
+              onClick={onClose}
+              className="rounded-lg px-2 py-1 text-sm text-zinc-300"
+            >
+              ✕
+            </button>
+          </div>
+          <div className="flex flex-1 items-center justify-center">Loading…</div>
         </div>
       );
     }

--- a/desktop/src/apps/ProjectsApp/board/TaskModal.tsx
+++ b/desktop/src/apps/ProjectsApp/board/TaskModal.tsx
@@ -7,6 +7,8 @@ import { Relationships } from "./modal/Relationships";
 import { Activity } from "./modal/Activity";
 import { projectsApi } from "../../../lib/projects";
 import type { Task } from "./types";
+import { useIsMobile } from "../../../hooks/use-is-mobile";
+import { MobileTaskModal } from "../mobile/MobileTaskModal";
 
 export interface TaskModalProps {
   projectId: string;
@@ -47,7 +49,65 @@ export function TaskModal({ projectId, taskId, currentUserId, onClose, onPrev, o
     return () => window.removeEventListener("keydown", onKey);
   }, [taskId, onClose, onNext, onPrev]);
 
+  const isMobile = useIsMobile();
+
+  const onChangeStatus = async (newStatus: string) => {
+    if (!task) return;
+    try {
+      if (newStatus === "claimed") await projectsApi.tasks.claim(projectId, task.id, currentUserId);
+      else if (newStatus === "closed") await projectsApi.tasks.close(projectId, task.id, currentUserId);
+      else if (newStatus === "open") await projectsApi.tasks.release(projectId, task.id, currentUserId);
+      else return;
+      const all = (await projectsApi.tasks.list(projectId)) as unknown as Task[];
+      setAllTasks(all);
+      setTask(all.find((t) => t.id === task.id) ?? null);
+    } catch (err) {
+      console.error("Mobile status change failed", err);
+    }
+  };
+
   if (!taskId) return null;
+
+  if (isMobile) {
+    if (!task) {
+      return (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="Loading task"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-zinc-950 text-zinc-400"
+        >
+          Loading…
+        </div>
+      );
+    }
+    return (
+      <MobileTaskModal
+        task={task}
+        onClose={onClose}
+        onPrev={() => onPrev?.()}
+        onNext={() => onNext?.()}
+        hasPrev={!!onPrev}
+        hasNext={!!onNext}
+        onChangeStatus={onChangeStatus}
+        heroSlot={<Hero task={task} />}
+        metadataSlot={
+          <MetadataPane
+            projectId={projectId}
+            task={task}
+            onUpdated={(t) => {
+              setTask(t);
+              setAllTasks(prev => prev.map(x => x.id === t.id ? t : x));
+            }}
+          />
+        }
+        subtasksSlot={<SubTasks all={allTasks} parentId={task.id} />}
+        relationshipsSlot={<Relationships projectId={projectId} taskId={task.id} />}
+        activitySlot={<Activity projectId={projectId} taskId={task.id} currentUserId={currentUserId} />}
+      />
+    );
+  }
+
   return (
     <div className={styles.scrim} role="dialog" aria-modal="true" aria-label={task?.title ?? "Task"}>
       <div className={styles.frame}>

--- a/desktop/src/apps/ProjectsApp/board/TaskModal.tsx
+++ b/desktop/src/apps/ProjectsApp/board/TaskModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import styles from "./TaskModal.module.css";
 import { Hero } from "./modal/Hero";
 import { MetadataPane } from "./modal/MetadataPane";
@@ -22,6 +22,7 @@ export interface TaskModalProps {
 export function TaskModal({ projectId, taskId, currentUserId, onClose, onPrev, onNext }: TaskModalProps) {
   const [allTasks, setAllTasks] = useState<Task[]>([]);
   const [task, setTask] = useState<Task | null>(null);
+  const statusChangeInFlightRef = useRef(false);
 
   useEffect(() => {
     if (!taskId) { setTask(null); return; }
@@ -53,6 +54,8 @@ export function TaskModal({ projectId, taskId, currentUserId, onClose, onPrev, o
 
   const onChangeStatus = async (newStatus: string) => {
     if (!task) return;
+    if (statusChangeInFlightRef.current) return;
+    statusChangeInFlightRef.current = true;
     try {
       if (newStatus === "claimed") await projectsApi.tasks.claim(projectId, task.id, currentUserId);
       else if (newStatus === "closed") await projectsApi.tasks.close(projectId, task.id, currentUserId);
@@ -63,6 +66,9 @@ export function TaskModal({ projectId, taskId, currentUserId, onClose, onPrev, o
       setTask(all.find((t) => t.id === task.id) ?? null);
     } catch (err) {
       console.error("Mobile status change failed", err);
+      window.alert("Could not change status — please retry.");
+    } finally {
+      statusChangeInFlightRef.current = false;
     }
   };
 

--- a/desktop/src/apps/ProjectsApp/canvas/CanvasBoard.tsx
+++ b/desktop/src/apps/ProjectsApp/canvas/CanvasBoard.tsx
@@ -8,6 +8,7 @@ import { subscribeCanvasStream } from "./canvas-sse";
 import { TaosNoteShapeUtil } from "./shapes/NoteShape";
 import { TaosLinkShapeUtil } from "./shapes/LinkShape";
 import { TaosImageShapeUtil } from "./shapes/ImageShape";
+import { useIsMobile } from "../../../hooks/use-is-mobile";
 
 interface CanvasBoardProps {
   projectId: string;
@@ -17,6 +18,7 @@ interface CanvasBoardProps {
 const CUSTOM_SHAPE_UTILS = [TaosNoteShapeUtil, TaosLinkShapeUtil, TaosImageShapeUtil];
 
 export function CanvasBoard({ projectId, projectSlug }: CanvasBoardProps) {
+  const isMobile = useIsMobile();
   const cacheRef = useRef(createCanvasStore());
   const editorRef = useRef<Editor | null>(null);
 
@@ -50,6 +52,11 @@ export function CanvasBoard({ projectId, projectSlug }: CanvasBoardProps) {
     return unsub;
   }, [projectSlug]);
 
+  // Keep readonly state in sync if isMobile changes after mount (e.g. window resize)
+  useEffect(() => {
+    editorRef.current?.updateInstanceState({ isReadonly: isMobile });
+  }, [isMobile]);
+
   return (
     <div style={{ position: "relative", width: "100%", height: "100%" }}>
       <Tldraw
@@ -57,6 +64,7 @@ export function CanvasBoard({ projectId, projectSlug }: CanvasBoardProps) {
         shapeUtils={[...defaultShapeUtils, ...CUSTOM_SHAPE_UTILS] as any}
         onMount={(editor) => {
           editorRef.current = editor;
+          editor.updateInstanceState({ isReadonly: isMobile });
           // Send local user edits to backend
           editor.store.listen(
             (entry) => {

--- a/desktop/src/apps/ProjectsApp/index.tsx
+++ b/desktop/src/apps/ProjectsApp/index.tsx
@@ -29,7 +29,7 @@ export function ProjectsApp({ windowId: _windowId }: { windowId: string }) {
   const isMobile = useIsMobile();
   const selected = projects.find((p) => p.id === selectedId) ?? null;
 
-  const list = (
+  const listPane = (
     <ProjectList
       projects={projects}
       selectedId={selectedId}
@@ -38,7 +38,7 @@ export function ProjectsApp({ windowId: _windowId }: { windowId: string }) {
     />
   );
 
-  const detail = (
+  const detailPane = (
     <>
       {error && <div role="alert" className="p-3 text-red-400">{error}</div>}
       {selected ? (
@@ -52,8 +52,8 @@ export function ProjectsApp({ windowId: _windowId }: { windowId: string }) {
   if (isMobile) {
     return (
       <MobileSplitView
-        list={list}
-        detail={detail}
+        list={listPane}
+        detail={detailPane}
         selectedId={selectedId}
         onBack={() => setSelectedId(null)}
         listTitle="Projects"
@@ -65,10 +65,10 @@ export function ProjectsApp({ windowId: _windowId }: { windowId: string }) {
   return (
     <div className="flex h-full w-full">
       <aside className="w-72 border-r border-zinc-800 flex flex-col">
-        {list}
+        {listPane}
       </aside>
       <main className="flex-1 min-w-0">
-        {detail}
+        {detailPane}
       </main>
     </div>
   );

--- a/desktop/src/apps/ProjectsApp/index.tsx
+++ b/desktop/src/apps/ProjectsApp/index.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
 import { projectsApi, type Project } from "@/lib/projects";
+import { useIsMobile } from "../../hooks/use-is-mobile";
+import { MobileSplitView } from "../../components/mobile/MobileSplitView";
 import { ProjectList } from "./ProjectList";
 import { ProjectWorkspace } from "./ProjectWorkspace";
 
@@ -24,25 +26,49 @@ export function ProjectsApp({ windowId: _windowId }: { windowId: string }) {
     refresh();
   }, []);
 
+  const isMobile = useIsMobile();
   const selected = projects.find((p) => p.id === selectedId) ?? null;
 
+  const list = (
+    <ProjectList
+      projects={projects}
+      selectedId={selectedId}
+      onSelect={setSelectedId}
+      onCreated={refresh}
+    />
+  );
+
+  const detail = (
+    <>
+      {error && <div role="alert" className="p-3 text-red-400">{error}</div>}
+      {selected ? (
+        <ProjectWorkspace project={selected} onChanged={refresh} />
+      ) : (
+        <div className="p-6 text-zinc-500">Select or create a project.</div>
+      )}
+    </>
+  );
+
+  if (isMobile) {
+    return (
+      <MobileSplitView
+        list={list}
+        detail={detail}
+        selectedId={selectedId}
+        onBack={() => setSelectedId(null)}
+        listTitle="Projects"
+      />
+    );
+  }
+
+  // Desktop branch — byte-identical layout preserved
   return (
     <div className="flex h-full w-full">
       <aside className="w-72 border-r border-zinc-800 flex flex-col">
-        <ProjectList
-          projects={projects}
-          selectedId={selectedId}
-          onSelect={setSelectedId}
-          onCreated={refresh}
-        />
+        {list}
       </aside>
       <main className="flex-1 min-w-0">
-        {error && <div role="alert" className="p-3 text-red-400">{error}</div>}
-        {selected ? (
-          <ProjectWorkspace project={selected} onChanged={refresh} />
-        ) : (
-          <div className="p-6 text-zinc-500">Select or create a project.</div>
-        )}
+        {detail}
       </main>
     </div>
   );

--- a/desktop/src/apps/ProjectsApp/mobile/MobileBoardCarousel.tsx
+++ b/desktop/src/apps/ProjectsApp/mobile/MobileBoardCarousel.tsx
@@ -26,7 +26,7 @@ interface Props {
 
 /**
  * Mobile board shell — sticky pill strip + horizontally paged columns.
- * Section-header swimlanes (when `groupBy` is set) come in Task 14.
+ * When `groupBy` is set, each column renders collapsible swimlane sections.
  */
 export function MobileBoardCarousel({ columns, tasksByColumn, groupBy, onOpenTask }: Props) {
   const [activeIdx, setActiveIdx] = useState(0);
@@ -125,30 +125,113 @@ function EmptyColumn({ label }: { label: string }) {
 
 function ColumnContent({
   tasks,
-  groupBy: _groupBy,
+  groupBy,
   onOpenTask,
 }: {
   tasks: BoardTask[];
   groupBy: GroupBy;
   onOpenTask: (id: string) => void;
 }) {
-  // Section-header swimlanes come in Task 14. For now, render a flat list.
+  const groups = groupTasks(tasks, groupBy);
+  const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
+
+  if (groups.length === 1 && groups[0]?.key === "_all") {
+    return (
+      <ul className="flex flex-col gap-2 p-3">
+        {tasks.map((t) => (
+          <TaskListItem key={t.id} task={t} onOpen={onOpenTask} />
+        ))}
+      </ul>
+    );
+  }
+
   return (
-    <ul className="flex flex-col gap-2 p-3">
-      {tasks.map((t) => (
-        <li key={t.id}>
-          <button
-            type="button"
-            onClick={() => onOpenTask(t.id)}
-            className="w-full rounded-lg border border-zinc-800 bg-zinc-900 p-3 text-left text-sm hover:bg-zinc-800"
-          >
-            <div className="truncate font-medium">{t.title}</div>
-            {t.assignee && (
-              <div className="mt-1 text-xs text-zinc-500">{t.assignee}</div>
+    <div className="flex flex-col">
+      {groups.map((g) => {
+        const isCollapsed = collapsed[g.key] ?? false;
+        return (
+          <section key={g.key}>
+            <button
+              type="button"
+              onClick={() =>
+                setCollapsed((c) => ({ ...c, [g.key]: !isCollapsed }))
+              }
+              className="sticky top-0 z-[1] flex w-full items-center justify-between bg-zinc-900/95 px-3 py-2 text-left text-sm font-medium text-zinc-200 backdrop-blur"
+            >
+              <span>
+                {isCollapsed ? "▸" : "▾"} {g.label} ({g.tasks.length})
+              </span>
+            </button>
+            {!isCollapsed && (
+              <ul className="flex flex-col gap-2 p-3">
+                {g.tasks.map((t) => (
+                  <TaskListItem key={t.id} task={t} onOpen={onOpenTask} />
+                ))}
+              </ul>
             )}
-          </button>
-        </li>
-      ))}
-    </ul>
+          </section>
+        );
+      })}
+    </div>
   );
+}
+
+function TaskListItem({
+  task,
+  onOpen,
+}: {
+  task: BoardTask;
+  onOpen: (id: string) => void;
+}) {
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={() => onOpen(task.id)}
+        className="w-full rounded-lg border border-zinc-800 bg-zinc-900 p-3 text-left text-sm hover:bg-zinc-800"
+      >
+        <div className="truncate font-medium">{task.title}</div>
+        {task.assignee && (
+          <div className="mt-1 text-xs text-zinc-500">{task.assignee}</div>
+        )}
+      </button>
+    </li>
+  );
+}
+
+function groupTasks(
+  tasks: BoardTask[],
+  groupBy: GroupBy
+): Array<{ key: string; label: string; tasks: BoardTask[] }> {
+  if (!groupBy) return [{ key: "_all", label: "", tasks }];
+  const buckets = new Map<string, { label: string; tasks: BoardTask[] }>();
+  for (const t of tasks) {
+    let key: string;
+    let label: string;
+    switch (groupBy) {
+      case "assignee":
+        key = t.assignee ?? "_unassigned";
+        label = t.assignee ?? "Unassigned";
+        break;
+      case "parent":
+        key = t.parent_id ?? "_root";
+        label = t.parent_id ?? "(no parent)";
+        break;
+      case "label":
+        key = t.labels?.[0] ?? "_unlabeled";
+        label = t.labels?.[0] ?? "(no label)";
+        break;
+      case "priority":
+        key = String(t.priority ?? "_none");
+        label = t.priority != null ? `P${t.priority}` : "(no priority)";
+        break;
+    }
+    if (!buckets.has(key)) buckets.set(key, { label, tasks: [] });
+    buckets.get(key)!.tasks.push(t);
+  }
+  return Array.from(buckets.entries()).map(([key, { label, tasks }]) => ({
+    key,
+    label,
+    tasks,
+  }));
 }

--- a/desktop/src/apps/ProjectsApp/mobile/MobileBoardCarousel.tsx
+++ b/desktop/src/apps/ProjectsApp/mobile/MobileBoardCarousel.tsx
@@ -9,8 +9,8 @@ export interface BoardTask {
   id: string;
   title: string;
   status: string;
-  assignee?: string | null;
-  parent_id?: string | null;
+  assignee_id?: string | null;
+  parent_task_id?: string | null;
   labels?: string[];
   priority?: number | null;
 }
@@ -192,8 +192,8 @@ function TaskListItem({
         className="w-full rounded-lg border border-zinc-800 bg-zinc-900 p-3 text-left text-sm hover:bg-zinc-800"
       >
         <div className="truncate font-medium">{task.title}</div>
-        {task.assignee && (
-          <div className="mt-1 text-xs text-zinc-500">{task.assignee}</div>
+        {task.assignee_id && (
+          <div className="mt-1 text-xs text-zinc-500">{task.assignee_id}</div>
         )}
       </button>
     </li>
@@ -211,12 +211,12 @@ function groupTasks(
     let label: string;
     switch (groupBy) {
       case "assignee":
-        key = t.assignee ?? "_unassigned";
-        label = t.assignee ?? "Unassigned";
+        key = t.assignee_id ?? "_unassigned";
+        label = t.assignee_id ?? "Unassigned";
         break;
       case "parent":
-        key = t.parent_id ?? "_root";
-        label = t.parent_id ?? "(no parent)";
+        key = t.parent_task_id ?? "_root";
+        label = t.parent_task_id ?? "(no parent)";
         break;
       case "label":
         key = t.labels?.[0] ?? "_unlabeled";

--- a/desktop/src/apps/ProjectsApp/mobile/MobileBoardCarousel.tsx
+++ b/desktop/src/apps/ProjectsApp/mobile/MobileBoardCarousel.tsx
@@ -188,6 +188,7 @@ function TaskListItem({
     <li>
       <button
         type="button"
+        data-testid="task-card"
         onClick={() => onOpen(task.id)}
         className="w-full rounded-lg border border-zinc-800 bg-zinc-900 p-3 text-left text-sm hover:bg-zinc-800"
       >

--- a/desktop/src/apps/ProjectsApp/mobile/MobileBoardCarousel.tsx
+++ b/desktop/src/apps/ProjectsApp/mobile/MobileBoardCarousel.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useRef, useState } from "react";
+
+export interface BoardColumn {
+  id: string;
+  label: string;
+}
+
+export interface BoardTask {
+  id: string;
+  title: string;
+  status: string;
+  assignee?: string | null;
+  parent_id?: string | null;
+  labels?: string[];
+  priority?: number | null;
+}
+
+export type GroupBy = "assignee" | "parent" | "label" | "priority" | null;
+
+interface Props {
+  columns: ReadonlyArray<BoardColumn>;
+  tasksByColumn: Record<string, BoardTask[]>;
+  groupBy: GroupBy;
+  onOpenTask: (id: string) => void;
+}
+
+/**
+ * Mobile board shell — sticky pill strip + horizontally paged columns.
+ * Section-header swimlanes (when `groupBy` is set) come in Task 14.
+ */
+export function MobileBoardCarousel({ columns, tasksByColumn, groupBy, onOpenTask }: Props) {
+  const [activeIdx, setActiveIdx] = useState(0);
+  const scrollerRef = useRef<HTMLDivElement>(null);
+  const paneRefs = useRef<Array<HTMLDivElement | null>>([]);
+
+  useEffect(() => {
+    const scroller = scrollerRef.current;
+    if (!scroller) return;
+    const onScroll = () => {
+      const w = scroller.clientWidth;
+      if (w === 0) return;
+      const idx = Math.round(scroller.scrollLeft / w);
+      setActiveIdx(idx);
+    };
+    scroller.addEventListener("scroll", onScroll, { passive: true });
+    return () => scroller.removeEventListener("scroll", onScroll);
+  }, []);
+
+  const goToColumn = (idx: number) => {
+    paneRefs.current[idx]?.scrollIntoView({
+      behavior: "smooth",
+      block: "nearest",
+      inline: "start",
+    });
+    setActiveIdx(idx);
+  };
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Sticky column pill strip — role=tablist */}
+      <div
+        role="tablist"
+        className="sticky top-0 z-10 flex gap-2 overflow-x-auto bg-zinc-900/95 px-3 py-2 backdrop-blur"
+      >
+        {columns.map((c, i) => {
+          const count = (tasksByColumn[c.id] ?? []).length;
+          const isActive = i === activeIdx;
+          return (
+            <button
+              key={c.id}
+              role="tab"
+              aria-selected={isActive}
+              onClick={() => goToColumn(i)}
+              className={
+                "shrink-0 rounded-full px-3 py-1.5 text-sm transition-colors " +
+                (isActive
+                  ? "bg-blue-600 text-white"
+                  : "bg-zinc-800 text-zinc-300 hover:bg-zinc-700")
+              }
+            >
+              {c.label} ({count})
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Scroll-snap paged columns */}
+      <div
+        ref={scrollerRef}
+        data-testid="mobile-board-scroller"
+        className="flex flex-1 overflow-x-auto overflow-y-hidden"
+        style={{ scrollSnapType: "x mandatory", WebkitOverflowScrolling: "touch" }}
+      >
+        {columns.map((c, i) => {
+          const tasks = tasksByColumn[c.id] ?? [];
+          return (
+            <div
+              key={c.id}
+              ref={(el) => {
+                paneRefs.current[i] = el;
+              }}
+              className="h-full w-screen shrink-0 overflow-y-auto"
+              style={{ scrollSnapAlign: "start" }}
+            >
+              {tasks.length === 0 ? (
+                <EmptyColumn label={c.label} />
+              ) : (
+                <ColumnContent tasks={tasks} groupBy={groupBy} onOpenTask={onOpenTask} />
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function EmptyColumn({ label }: { label: string }) {
+  return (
+    <div className="flex h-full items-center justify-center p-6 text-center text-sm text-zinc-500">
+      No {label.toLowerCase()} tasks
+    </div>
+  );
+}
+
+function ColumnContent({
+  tasks,
+  groupBy: _groupBy,
+  onOpenTask,
+}: {
+  tasks: BoardTask[];
+  groupBy: GroupBy;
+  onOpenTask: (id: string) => void;
+}) {
+  // Section-header swimlanes come in Task 14. For now, render a flat list.
+  return (
+    <ul className="flex flex-col gap-2 p-3">
+      {tasks.map((t) => (
+        <li key={t.id}>
+          <button
+            type="button"
+            onClick={() => onOpenTask(t.id)}
+            className="w-full rounded-lg border border-zinc-800 bg-zinc-900 p-3 text-left text-sm hover:bg-zinc-800"
+          >
+            <div className="truncate font-medium">{t.title}</div>
+            {t.assignee && (
+              <div className="mt-1 text-xs text-zinc-500">{t.assignee}</div>
+            )}
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/desktop/src/apps/ProjectsApp/mobile/MobileBoardCarousel.tsx
+++ b/desktop/src/apps/ProjectsApp/mobile/MobileBoardCarousel.tsx
@@ -153,6 +153,7 @@ function ColumnContent({
           <section key={g.key}>
             <button
               type="button"
+              aria-expanded={!isCollapsed}
               onClick={() =>
                 setCollapsed((c) => ({ ...c, [g.key]: !isCollapsed }))
               }

--- a/desktop/src/apps/ProjectsApp/mobile/MobileTaskModal.tsx
+++ b/desktop/src/apps/ProjectsApp/mobile/MobileTaskModal.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { useEffect, useRef, type ReactNode } from "react";
 
 export interface MobileTaskModalTask {
   id: string;
@@ -64,6 +64,12 @@ export function MobileTaskModal({
   activitySlot,
 }: Props) {
   const action = primaryActionFor(task.status);
+  const closeBtnRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    const t = window.setTimeout(() => closeBtnRef.current?.focus(), 50);
+    return () => window.clearTimeout(t);
+  }, []);
 
   return (
     <div
@@ -99,8 +105,9 @@ export function MobileTaskModal({
           ›
         </button>
         <button
+          ref={closeBtnRef}
           type="button"
-          aria-label="Close"
+          aria-label="Close modal"
           onClick={onClose}
           className="rounded-lg px-2 py-1 text-sm text-zinc-300"
         >
@@ -135,28 +142,28 @@ export function MobileTaskModal({
 
         <Section label="Metadata" defaultOpen>
           {metadataSlot ?? (
-            <div className="grid grid-cols-2 gap-x-3 gap-y-2 text-sm">
-              <div className="text-zinc-500">Assignee</div>
-              <div className="text-zinc-300">
+            <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-2 text-sm">
+              <dt className="text-zinc-500">Assignee</dt>
+              <dd className="text-zinc-300">
                 {task.assignee_id ?? <Empty>Unassigned</Empty>}
-              </div>
-              <div className="text-zinc-500">Priority</div>
-              <div className="text-zinc-300">
+              </dd>
+              <dt className="text-zinc-500">Priority</dt>
+              <dd className="text-zinc-300">
                 {task.priority != null ? `P${task.priority}` : <Empty>—</Empty>}
-              </div>
-              <div className="text-zinc-500">Labels</div>
-              <div className="text-zinc-300">
+              </dd>
+              <dt className="text-zinc-500">Labels</dt>
+              <dd className="text-zinc-300">
                 {task.labels && task.labels.length > 0 ? (
                   task.labels.join(", ")
                 ) : (
                   <Empty>None</Empty>
                 )}
-              </div>
-              <div className="text-zinc-500">Parent</div>
-              <div className="text-zinc-300">
+              </dd>
+              <dt className="text-zinc-500">Parent</dt>
+              <dd className="text-zinc-300">
                 {task.parent_task_id ?? <Empty>None</Empty>}
-              </div>
-            </div>
+              </dd>
+            </dl>
           )}
         </Section>
 
@@ -200,14 +207,14 @@ function Section({
   children: ReactNode;
 }) {
   return (
-    <div role="group" aria-label={label} className="border-b border-zinc-800">
-      <details role="presentation" open={defaultOpen}>
+    <section aria-label={label} className="border-b border-zinc-800">
+      <details open={defaultOpen}>
         <summary className="cursor-pointer list-none px-3 py-3 text-sm font-medium text-zinc-300">
           {label}
         </summary>
         <div className="px-3 pb-3">{children}</div>
       </details>
-    </div>
+    </section>
   );
 }
 

--- a/desktop/src/apps/ProjectsApp/mobile/MobileTaskModal.tsx
+++ b/desktop/src/apps/ProjectsApp/mobile/MobileTaskModal.tsx
@@ -1,0 +1,216 @@
+import type { ReactNode } from "react";
+
+export interface MobileTaskModalTask {
+  id: string;
+  title: string;
+  description?: string | null;
+  status: string;
+  priority?: number | null;
+  assignee_id?: string | null;
+  labels?: string[];
+  parent_task_id?: string | null;
+}
+
+interface Props {
+  task: MobileTaskModalTask;
+  onClose: () => void;
+  onPrev: () => void;
+  onNext: () => void;
+  onChangeStatus: (next: string) => void;
+  hasPrev: boolean;
+  hasNext: boolean;
+  heroSlot?: ReactNode;
+  metadataSlot?: ReactNode;
+  subtasksSlot?: ReactNode;
+  relationshipsSlot?: ReactNode;
+  activitySlot?: ReactNode;
+}
+
+function primaryActionFor(status: string): { label: string; next: string } {
+  switch (status) {
+    case "open":
+      return { label: "Claim", next: "claimed" };
+    case "claimed":
+      return { label: "Close", next: "closed" };
+    case "closed":
+      return { label: "Reopen", next: "open" };
+    default:
+      return { label: "Update", next: status };
+  }
+}
+
+/**
+ * Full-screen mobile task modal shell.
+ *
+ * Top bar (prev / title / next / close), five collapsible sections
+ * (Hero, Metadata, SubTasks, Relationships, Activity — Activity collapsed by
+ * default), and a sticky bottom action bar whose label depends on task status.
+ *
+ * Each section accepts an optional slot to override the default content; the
+ * defaults render directly from the `task` prop.
+ */
+export function MobileTaskModal({
+  task,
+  onClose,
+  onPrev,
+  onNext,
+  onChangeStatus,
+  hasPrev,
+  hasNext,
+  heroSlot,
+  metadataSlot,
+  subtasksSlot,
+  relationshipsSlot,
+  activitySlot,
+}: Props) {
+  const action = primaryActionFor(task.status);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Task details"
+      className="fixed inset-0 z-50 flex flex-col bg-zinc-950 text-zinc-200"
+    >
+      {/* Top bar */}
+      <div
+        className="flex items-center gap-2 border-b border-zinc-800 bg-zinc-900 px-3 py-2"
+        style={{ paddingTop: "calc(env(safe-area-inset-top, 0px) + 0.5rem)" }}
+      >
+        <button
+          type="button"
+          aria-label="Previous task"
+          onClick={onPrev}
+          disabled={!hasPrev}
+          className="rounded-lg px-2 py-1 text-sm text-zinc-300 disabled:opacity-30"
+        >
+          ‹
+        </button>
+        <div className="flex-1 truncate text-center text-sm font-medium text-zinc-200">
+          {task.title}
+        </div>
+        <button
+          type="button"
+          aria-label="Next task"
+          onClick={onNext}
+          disabled={!hasNext}
+          className="rounded-lg px-2 py-1 text-sm text-zinc-300 disabled:opacity-30"
+        >
+          ›
+        </button>
+        <button
+          type="button"
+          aria-label="Close"
+          onClick={onClose}
+          className="rounded-lg px-2 py-1 text-sm text-zinc-300"
+        >
+          ✕
+        </button>
+      </div>
+
+      {/* Scrollable body */}
+      <div className="flex-1 overflow-y-auto">
+        <Section label="Hero" defaultOpen>
+          {heroSlot ?? (
+            <div className="space-y-2">
+              <div className="text-base font-semibold text-zinc-200">
+                {task.title}
+              </div>
+              <div className="flex items-center gap-2 text-xs">
+                <span className="rounded-full bg-zinc-800 px-2 py-0.5 text-zinc-200">
+                  {task.status}
+                </span>
+                {task.priority != null && (
+                  <span className="text-zinc-500">P{task.priority}</span>
+                )}
+              </div>
+              {task.description ? (
+                <p className="text-sm text-zinc-300">{task.description}</p>
+              ) : (
+                <Empty>No description</Empty>
+              )}
+            </div>
+          )}
+        </Section>
+
+        <Section label="Metadata" defaultOpen>
+          {metadataSlot ?? (
+            <div className="grid grid-cols-2 gap-x-3 gap-y-2 text-sm">
+              <div className="text-zinc-500">Assignee</div>
+              <div className="text-zinc-300">
+                {task.assignee_id ?? <Empty>Unassigned</Empty>}
+              </div>
+              <div className="text-zinc-500">Priority</div>
+              <div className="text-zinc-300">
+                {task.priority != null ? `P${task.priority}` : <Empty>—</Empty>}
+              </div>
+              <div className="text-zinc-500">Labels</div>
+              <div className="text-zinc-300">
+                {task.labels && task.labels.length > 0 ? (
+                  task.labels.join(", ")
+                ) : (
+                  <Empty>None</Empty>
+                )}
+              </div>
+              <div className="text-zinc-500">Parent</div>
+              <div className="text-zinc-300">
+                {task.parent_task_id ?? <Empty>None</Empty>}
+              </div>
+            </div>
+          )}
+        </Section>
+
+        <Section label="SubTasks" defaultOpen>
+          {subtasksSlot ?? <Empty>No subtasks</Empty>}
+        </Section>
+
+        <Section label="Relationships" defaultOpen>
+          {relationshipsSlot ?? <Empty>No relationships</Empty>}
+        </Section>
+
+        <Section label="Activity" defaultOpen={false}>
+          {activitySlot ?? <Empty>No activity yet</Empty>}
+        </Section>
+      </div>
+
+      {/* Sticky bottom action bar */}
+      <div
+        className="border-t border-zinc-800 bg-zinc-900 px-3 py-2"
+        style={{ paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 0.5rem)" }}
+      >
+        <button
+          type="button"
+          onClick={() => onChangeStatus(action.next)}
+          className="w-full rounded-lg bg-blue-600 px-4 py-3 text-sm font-medium text-white"
+        >
+          {action.label}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function Section({
+  label,
+  defaultOpen,
+  children,
+}: {
+  label: string;
+  defaultOpen: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <div role="group" aria-label={label} className="border-b border-zinc-800">
+      <details role="presentation" open={defaultOpen}>
+        <summary className="cursor-pointer list-none px-3 py-3 text-sm font-medium text-zinc-300">
+          {label}
+        </summary>
+        <div className="px-3 pb-3">{children}</div>
+      </details>
+    </div>
+  );
+}
+
+function Empty({ children }: { children: ReactNode }) {
+  return <span className="text-zinc-500">{children}</span>;
+}

--- a/desktop/src/apps/ProjectsApp/mobile/MobileTaskModal.tsx
+++ b/desktop/src/apps/ProjectsApp/mobile/MobileTaskModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type ReactNode } from "react";
+import { useEffect, useRef, type ReactNode, type TouchEvent } from "react";
 
 export interface MobileTaskModalTask {
   id: string;
@@ -25,6 +25,8 @@ interface Props {
   relationshipsSlot?: ReactNode;
   activitySlot?: ReactNode;
 }
+
+const SWIPE_THRESHOLD_PX = 60;
 
 function primaryActionFor(status: string): { label: string; next: string } {
   switch (status) {
@@ -65,6 +67,25 @@ export function MobileTaskModal({
 }: Props) {
   const action = primaryActionFor(task.status);
   const closeBtnRef = useRef<HTMLButtonElement>(null);
+  const touchStartRef = useRef<{ x: number; y: number } | null>(null);
+
+  const onTouchStart = (e: TouchEvent) => {
+    const t = e.touches[0];
+    if (!t) return;
+    touchStartRef.current = { x: t.clientX, y: t.clientY };
+  };
+  const onTouchEnd = (e: TouchEvent) => {
+    const start = touchStartRef.current;
+    touchStartRef.current = null;
+    if (!start) return;
+    const t = e.changedTouches[0];
+    if (!t) return;
+    const dx = t.clientX - start.x;
+    const dy = Math.abs(t.clientY - start.y);
+    if (Math.abs(dx) < SWIPE_THRESHOLD_PX || dy > Math.abs(dx)) return;
+    if (dx < 0 && hasNext) onNext();
+    if (dx > 0 && hasPrev) onPrev();
+  };
 
   useEffect(() => {
     const t = window.setTimeout(() => closeBtnRef.current?.focus(), 50);
@@ -76,7 +97,10 @@ export function MobileTaskModal({
       role="dialog"
       aria-modal="true"
       aria-label="Task details"
+      data-testid="mobile-task-modal"
       className="fixed inset-0 z-50 flex flex-col bg-zinc-950 text-zinc-200"
+      onTouchStart={onTouchStart}
+      onTouchEnd={onTouchEnd}
     >
       {/* Top bar */}
       <div

--- a/desktop/src/apps/ProjectsApp/mobile/MobileTaskModal.tsx
+++ b/desktop/src/apps/ProjectsApp/mobile/MobileTaskModal.tsx
@@ -70,6 +70,7 @@ export function MobileTaskModal({
   const touchStartRef = useRef<{ x: number; y: number } | null>(null);
 
   const onTouchStart = (e: TouchEvent) => {
+    if (e.touches.length !== 1) return;
     const t = e.touches[0];
     if (!t) return;
     touchStartRef.current = { x: t.clientX, y: t.clientY };

--- a/desktop/src/apps/ProjectsApp/mobile/ProjectFab.tsx
+++ b/desktop/src/apps/ProjectsApp/mobile/ProjectFab.tsx
@@ -1,0 +1,19 @@
+interface Props {
+  onClick: () => void;
+}
+
+export function ProjectFab({ onClick }: Props) {
+  return (
+    <button
+      type="button"
+      aria-label="Create task"
+      onClick={onClick}
+      className="fixed right-4 z-40 flex h-14 w-14 items-center justify-center
+                 rounded-full bg-blue-600 text-2xl font-light text-white shadow-lg
+                 active:scale-95 transition-transform"
+      style={{ bottom: "calc(env(safe-area-inset-bottom, 0px) + 1rem)" }}
+    >
+      +
+    </button>
+  );
+}

--- a/desktop/src/apps/ProjectsApp/mobile/TaskCreateSheet.tsx
+++ b/desktop/src/apps/ProjectsApp/mobile/TaskCreateSheet.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useRef, useState } from "react";
+
+export interface TaskCreatePayload {
+  title: string;
+}
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (payload: TaskCreatePayload) => Promise<void>;
+}
+
+export function TaskCreateSheet({ open, onClose, onSubmit }: Props) {
+  const [title, setTitle] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (open) {
+      setTitle("");
+      setError(null);
+      const t = setTimeout(() => inputRef.current?.focus(), 50);
+      return () => clearTimeout(t);
+    }
+  }, [open]);
+
+  if (!open) return null;
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim() || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onSubmit({ title: title.trim() });
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create task");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="New task"
+      data-testid="task-create-sheet"
+      className="fixed inset-0 z-50 flex items-end"
+    >
+      <button
+        type="button"
+        aria-label="Dismiss"
+        className="absolute inset-0 bg-black/50"
+        onClick={onClose}
+      />
+      <form
+        onSubmit={submit}
+        className="relative z-10 w-full rounded-t-2xl bg-zinc-900 p-4 shadow-xl border-t border-zinc-800"
+        style={{ paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 1rem)" }}
+      >
+        <div className="mx-auto mb-3 h-1 w-10 rounded-full bg-zinc-700" />
+        <h2 className="mb-3 text-base font-semibold">New task</h2>
+        <input
+          ref={inputRef}
+          type="text"
+          placeholder="Task title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          className="w-full rounded-lg bg-zinc-800 px-3 py-3 text-base outline-none focus:ring-2 focus:ring-zinc-600"
+          disabled={submitting}
+        />
+        {error && (
+          <div role="alert" className="mt-2 text-sm text-red-400">
+            {error}
+          </div>
+        )}
+        <div className="mt-3 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg px-4 py-2 text-sm text-zinc-400 disabled:opacity-50"
+            disabled={submitting}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
+            disabled={!title.trim() || submitting}
+          >
+            {submitting ? "Creating…" : "Create"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/desktop/src/apps/ProjectsApp/mobile/TaskCreateSheet.tsx
+++ b/desktop/src/apps/ProjectsApp/mobile/TaskCreateSheet.tsx
@@ -53,8 +53,9 @@ export function TaskCreateSheet({ open, onClose, onSubmit }: Props) {
       <button
         type="button"
         aria-label="Dismiss"
-        className="absolute inset-0 bg-black/50"
+        className="absolute inset-0 bg-black/50 disabled:cursor-not-allowed"
         onClick={onClose}
+        disabled={submitting}
       />
       <form
         onSubmit={submit}
@@ -66,6 +67,7 @@ export function TaskCreateSheet({ open, onClose, onSubmit }: Props) {
         <input
           ref={inputRef}
           type="text"
+          aria-label="Task title"
           placeholder="Task title"
           value={title}
           onChange={(e) => setTitle(e.target.value)}

--- a/desktop/src/apps/ProjectsApp/mobile/__tests__/MobileBoardCarousel.test.tsx
+++ b/desktop/src/apps/ProjectsApp/mobile/__tests__/MobileBoardCarousel.test.tsx
@@ -61,17 +61,22 @@ describe("MobileBoardCarousel — shell", () => {
   });
 
   it("scrolls to a column when its pill is tapped", () => {
+    const original = Element.prototype.scrollIntoView;
     const scrollIntoView = vi.fn();
     Element.prototype.scrollIntoView = scrollIntoView;
-    render(
-      <MobileBoardCarousel
-        columns={columns}
-        tasksByColumn={tasksByColumn}
-        groupBy={null}
-        onOpenTask={() => {}}
-      />
-    );
-    fireEvent.click(screen.getByRole("tab", { name: /claimed/i }));
-    expect(scrollIntoView).toHaveBeenCalled();
+    try {
+      render(
+        <MobileBoardCarousel
+          columns={columns}
+          tasksByColumn={tasksByColumn}
+          groupBy={null}
+          onOpenTask={() => {}}
+        />
+      );
+      fireEvent.click(screen.getByRole("tab", { name: /claimed/i }));
+      expect(scrollIntoView).toHaveBeenCalled();
+    } finally {
+      Element.prototype.scrollIntoView = original;
+    }
   });
 });

--- a/desktop/src/apps/ProjectsApp/mobile/__tests__/MobileBoardCarousel.test.tsx
+++ b/desktop/src/apps/ProjectsApp/mobile/__tests__/MobileBoardCarousel.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MobileBoardCarousel } from "../MobileBoardCarousel";
+
+const columns = [
+  { id: "open", label: "Open" },
+  { id: "claimed", label: "Claimed" },
+  { id: "closed", label: "Closed" },
+];
+
+const tasksByColumn = {
+  open: [
+    { id: "t1", title: "First", status: "open", assignee: "alice" },
+    { id: "t2", title: "Second", status: "open", assignee: "alice" },
+  ],
+  claimed: [
+    { id: "t3", title: "Claimed", status: "claimed", assignee: "bob" },
+  ],
+  closed: [],
+};
+
+describe("MobileBoardCarousel — shell", () => {
+  it("renders one pill per column with task counts", () => {
+    render(
+      <MobileBoardCarousel
+        columns={columns}
+        tasksByColumn={tasksByColumn}
+        groupBy={null}
+        onOpenTask={() => {}}
+      />
+    );
+    expect(screen.getByRole("tab", { name: /open \(2\)/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /claimed \(1\)/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /closed \(0\)/i })).toBeInTheDocument();
+  });
+
+  it("renders an empty-state pane for empty columns", () => {
+    render(
+      <MobileBoardCarousel
+        columns={columns}
+        tasksByColumn={tasksByColumn}
+        groupBy={null}
+        onOpenTask={() => {}}
+      />
+    );
+    expect(screen.getByText(/no closed tasks/i)).toBeInTheDocument();
+  });
+
+  it("calls onOpenTask when a card is tapped", () => {
+    const onOpenTask = vi.fn();
+    render(
+      <MobileBoardCarousel
+        columns={columns}
+        tasksByColumn={tasksByColumn}
+        groupBy={null}
+        onOpenTask={onOpenTask}
+      />
+    );
+    fireEvent.click(screen.getByText("First"));
+    expect(onOpenTask).toHaveBeenCalledWith("t1");
+  });
+
+  it("scrolls to a column when its pill is tapped", () => {
+    const scrollIntoView = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoView;
+    render(
+      <MobileBoardCarousel
+        columns={columns}
+        tasksByColumn={tasksByColumn}
+        groupBy={null}
+        onOpenTask={() => {}}
+      />
+    );
+    fireEvent.click(screen.getByRole("tab", { name: /claimed/i }));
+    expect(scrollIntoView).toHaveBeenCalled();
+  });
+});

--- a/desktop/src/apps/ProjectsApp/mobile/__tests__/MobileBoardCarousel.test.tsx
+++ b/desktop/src/apps/ProjectsApp/mobile/__tests__/MobileBoardCarousel.test.tsx
@@ -10,11 +10,11 @@ const columns = [
 
 const tasksByColumn = {
   open: [
-    { id: "t1", title: "First", status: "open", assignee: "alice" },
-    { id: "t2", title: "Second", status: "open", assignee: "alice" },
+    { id: "t1", title: "First", status: "open", assignee_id: "alice" },
+    { id: "t2", title: "Second", status: "open", assignee_id: "alice" },
   ],
   claimed: [
-    { id: "t3", title: "Claimed", status: "claimed", assignee: "bob" },
+    { id: "t3", title: "Claimed", status: "claimed", assignee_id: "bob" },
   ],
   closed: [],
 };
@@ -87,9 +87,9 @@ describe2("MobileBoardCarousel — swimlane section headers", () => {
   it("renders a section header per assignee when groupBy='assignee'", () => {
     const tbc = {
       open: [
-        { id: "a1", title: "Alice 1", status: "open", assignee: "alice" },
-        { id: "a2", title: "Alice 2", status: "open", assignee: "alice" },
-        { id: "b1", title: "Bob 1", status: "open", assignee: "bob" },
+        { id: "a1", title: "Alice 1", status: "open", assignee_id: "alice" },
+        { id: "a2", title: "Alice 2", status: "open", assignee_id: "alice" },
+        { id: "b1", title: "Bob 1", status: "open", assignee_id: "bob" },
       ],
       claimed: [],
       closed: [],
@@ -109,7 +109,7 @@ describe2("MobileBoardCarousel — swimlane section headers", () => {
   it("collapses a section when its header is tapped", () => {
     const tbc = {
       open: [
-        { id: "a1", title: "Alice One", status: "open", assignee: "alice" },
+        { id: "a1", title: "Alice One", status: "open", assignee_id: "alice" },
       ],
       claimed: [],
       closed: [],

--- a/desktop/src/apps/ProjectsApp/mobile/__tests__/MobileBoardCarousel.test.tsx
+++ b/desktop/src/apps/ProjectsApp/mobile/__tests__/MobileBoardCarousel.test.tsx
@@ -80,3 +80,50 @@ describe("MobileBoardCarousel — shell", () => {
     }
   });
 });
+
+import { describe as describe2 } from "vitest";
+
+describe2("MobileBoardCarousel — swimlane section headers", () => {
+  it("renders a section header per assignee when groupBy='assignee'", () => {
+    const tbc = {
+      open: [
+        { id: "a1", title: "Alice 1", status: "open", assignee: "alice" },
+        { id: "a2", title: "Alice 2", status: "open", assignee: "alice" },
+        { id: "b1", title: "Bob 1", status: "open", assignee: "bob" },
+      ],
+      claimed: [],
+      closed: [],
+    };
+    render(
+      <MobileBoardCarousel
+        columns={columns}
+        tasksByColumn={tbc}
+        groupBy="assignee"
+        onOpenTask={() => {}}
+      />
+    );
+    expect(screen.getByText(/alice \(2\)/i)).toBeInTheDocument();
+    expect(screen.getByText(/bob \(1\)/i)).toBeInTheDocument();
+  });
+
+  it("collapses a section when its header is tapped", () => {
+    const tbc = {
+      open: [
+        { id: "a1", title: "Alice One", status: "open", assignee: "alice" },
+      ],
+      claimed: [],
+      closed: [],
+    };
+    render(
+      <MobileBoardCarousel
+        columns={columns}
+        tasksByColumn={tbc}
+        groupBy="assignee"
+        onOpenTask={() => {}}
+      />
+    );
+    expect(screen.getByText("Alice One")).toBeInTheDocument();
+    fireEvent.click(screen.getByText(/alice \(1\)/i));
+    expect(screen.queryByText("Alice One")).not.toBeInTheDocument();
+  });
+});

--- a/desktop/src/apps/ProjectsApp/mobile/__tests__/MobileTaskModal.test.tsx
+++ b/desktop/src/apps/ProjectsApp/mobile/__tests__/MobileTaskModal.test.tsx
@@ -66,3 +66,32 @@ describe("MobileTaskModal", () => {
     expect(onChangeStatus).toHaveBeenCalledWith(next);
   });
 });
+
+describe("MobileTaskModal — swipe gestures", () => {
+  it("calls onNext when the user swipes left", () => {
+    const onNext = vi.fn();
+    render(<MobileTaskModal task={baseTask} {...noopHandlers} hasNext onNext={onNext} />);
+    const dialog = screen.getByTestId("mobile-task-modal");
+    fireEvent.touchStart(dialog, { touches: [{ clientX: 300, clientY: 100 }] });
+    fireEvent.touchEnd(dialog, { changedTouches: [{ clientX: 80, clientY: 100 }] });
+    expect(onNext).toHaveBeenCalledOnce();
+  });
+
+  it("calls onPrev when the user swipes right", () => {
+    const onPrev = vi.fn();
+    render(<MobileTaskModal task={baseTask} {...noopHandlers} hasPrev onPrev={onPrev} />);
+    const dialog = screen.getByTestId("mobile-task-modal");
+    fireEvent.touchStart(dialog, { touches: [{ clientX: 80, clientY: 100 }] });
+    fireEvent.touchEnd(dialog, { changedTouches: [{ clientX: 300, clientY: 100 }] });
+    expect(onPrev).toHaveBeenCalledOnce();
+  });
+
+  it("ignores small touches (< 60px threshold)", () => {
+    const onNext = vi.fn();
+    render(<MobileTaskModal task={baseTask} {...noopHandlers} hasNext onNext={onNext} />);
+    const dialog = screen.getByTestId("mobile-task-modal");
+    fireEvent.touchStart(dialog, { touches: [{ clientX: 100, clientY: 100 }] });
+    fireEvent.touchEnd(dialog, { changedTouches: [{ clientX: 90, clientY: 100 }] });
+    expect(onNext).not.toHaveBeenCalled();
+  });
+});

--- a/desktop/src/apps/ProjectsApp/mobile/__tests__/MobileTaskModal.test.tsx
+++ b/desktop/src/apps/ProjectsApp/mobile/__tests__/MobileTaskModal.test.tsx
@@ -94,4 +94,30 @@ describe("MobileTaskModal — swipe gestures", () => {
     fireEvent.touchEnd(dialog, { changedTouches: [{ clientX: 90, clientY: 100 }] });
     expect(onNext).not.toHaveBeenCalled();
   });
+
+  it("ignores vertical-dominant swipes", () => {
+    const onNext = vi.fn();
+    render(<MobileTaskModal task={baseTask} {...noopHandlers} hasNext onNext={onNext} />);
+    const dialog = screen.getByTestId("mobile-task-modal");
+    // |dx|=80 (clears threshold), |dy|=160 (dy > |dx| → vertical-dominant guard fires)
+    fireEvent.touchStart(dialog, { touches: [{ clientX: 150, clientY: 100 }] });
+    fireEvent.touchEnd(dialog, { changedTouches: [{ clientX: 230, clientY: 260 }] });
+    expect(onNext).not.toHaveBeenCalled();
+  });
+
+  it("ignores multi-touch (pinch) gestures", () => {
+    const onNext = vi.fn();
+    render(<MobileTaskModal task={baseTask} {...noopHandlers} hasNext onNext={onNext} />);
+    const dialog = screen.getByTestId("mobile-task-modal");
+    // touchstart with TWO fingers — first one near left, second near right
+    fireEvent.touchStart(dialog, {
+      touches: [
+        { clientX: 100, clientY: 100 },
+        { clientX: 300, clientY: 100 },
+      ],
+    });
+    // first finger lifts after sliding right (large dx if guard absent)
+    fireEvent.touchEnd(dialog, { changedTouches: [{ clientX: 300, clientY: 100 }] });
+    expect(onNext).not.toHaveBeenCalled();
+  });
 });

--- a/desktop/src/apps/ProjectsApp/mobile/__tests__/MobileTaskModal.test.tsx
+++ b/desktop/src/apps/ProjectsApp/mobile/__tests__/MobileTaskModal.test.tsx
@@ -25,7 +25,7 @@ const noopHandlers = {
 describe("MobileTaskModal", () => {
   it("renders all five sections in order", () => {
     render(<MobileTaskModal task={baseTask} {...noopHandlers} />);
-    const sections = screen.getAllByRole("group");
+    const sections = screen.getAllByRole("region");
     const labels = sections.map((s) => s.getAttribute("aria-label"));
     expect(labels).toEqual(["Hero", "Metadata", "SubTasks", "Relationships", "Activity"]);
   });
@@ -44,7 +44,25 @@ describe("MobileTaskModal", () => {
 
   it("the Activity section is collapsed by default", () => {
     render(<MobileTaskModal task={baseTask} {...noopHandlers} />);
-    const activity = screen.getByRole("group", { name: "Activity" });
+    const activity = screen.getByRole("region", { name: "Activity" });
     expect(activity.querySelector("details")).not.toHaveAttribute("open");
+  });
+
+  it.each([
+    ["open" as const, /^Claim$/, "claimed"],
+    ["claimed" as const, /^Close$/, "closed"],
+    ["closed" as const, /^Reopen$/, "open"],
+    ["blocked" as const, /^Update$/, "blocked"],
+  ])("status %s shows %s and emits %s", (status, label, next) => {
+    const onChangeStatus = vi.fn();
+    render(
+      <MobileTaskModal
+        task={{ ...baseTask, status }}
+        {...noopHandlers}
+        onChangeStatus={onChangeStatus}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: label }));
+    expect(onChangeStatus).toHaveBeenCalledWith(next);
   });
 });

--- a/desktop/src/apps/ProjectsApp/mobile/__tests__/MobileTaskModal.test.tsx
+++ b/desktop/src/apps/ProjectsApp/mobile/__tests__/MobileTaskModal.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MobileTaskModal } from "../MobileTaskModal";
+
+const baseTask = {
+  id: "t1",
+  title: "Ship it",
+  description: "Test description",
+  status: "open",
+  priority: 2,
+  assignee_id: null,
+  labels: [],
+  parent_task_id: null,
+};
+
+const noopHandlers = {
+  onClose: vi.fn(),
+  onPrev: vi.fn(),
+  onNext: vi.fn(),
+  onChangeStatus: vi.fn(),
+  hasPrev: false,
+  hasNext: false,
+};
+
+describe("MobileTaskModal", () => {
+  it("renders all five sections in order", () => {
+    render(<MobileTaskModal task={baseTask} {...noopHandlers} />);
+    const sections = screen.getAllByRole("group");
+    const labels = sections.map((s) => s.getAttribute("aria-label"));
+    expect(labels).toEqual(["Hero", "Metadata", "SubTasks", "Relationships", "Activity"]);
+  });
+
+  it("calls onClose when the close button is tapped", () => {
+    const onClose = vi.fn();
+    render(<MobileTaskModal task={baseTask} {...noopHandlers} onClose={onClose} />);
+    fireEvent.click(screen.getByRole("button", { name: /close/i }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("shows a sticky action button for status change", () => {
+    render(<MobileTaskModal task={baseTask} {...noopHandlers} />);
+    expect(screen.getByRole("button", { name: /claim/i })).toBeInTheDocument();
+  });
+
+  it("the Activity section is collapsed by default", () => {
+    render(<MobileTaskModal task={baseTask} {...noopHandlers} />);
+    const activity = screen.getByRole("group", { name: "Activity" });
+    expect(activity.querySelector("details")).not.toHaveAttribute("open");
+  });
+});

--- a/desktop/src/apps/ProjectsApp/mobile/__tests__/ProjectFab.test.tsx
+++ b/desktop/src/apps/ProjectsApp/mobile/__tests__/ProjectFab.test.tsx
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ProjectFab } from "../ProjectFab";
+
+describe("ProjectFab", () => {
+  it("renders a single round '+' button", () => {
+    render(<ProjectFab onClick={() => {}} />);
+    expect(screen.getByRole("button", { name: /create task/i })).toBeInTheDocument();
+  });
+
+  it("calls onClick when tapped", () => {
+    const onClick = vi.fn();
+    render(<ProjectFab onClick={onClick} />);
+    fireEvent.click(screen.getByRole("button", { name: /create task/i }));
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it("uses safe-area-inset for bottom positioning", () => {
+    render(<ProjectFab onClick={() => {}} />);
+    const btn = screen.getByRole("button", { name: /create task/i });
+    expect(btn.getAttribute("style") ?? "").toMatch(/safe-area-inset-bottom/);
+  });
+});

--- a/desktop/src/apps/ProjectsApp/mobile/__tests__/TaskCreateSheet.test.tsx
+++ b/desktop/src/apps/ProjectsApp/mobile/__tests__/TaskCreateSheet.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { TaskCreateSheet } from "../TaskCreateSheet";
+
+describe("TaskCreateSheet", () => {
+  it("renders title input and submit button", () => {
+    render(<TaskCreateSheet open onClose={() => {}} onSubmit={() => Promise.resolve()} />);
+    expect(screen.getByPlaceholderText(/task title/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /create/i })).toBeInTheDocument();
+  });
+
+  it("does not render when closed", () => {
+    render(<TaskCreateSheet open={false} onClose={() => {}} onSubmit={() => Promise.resolve()} />);
+    expect(screen.queryByPlaceholderText(/task title/i)).not.toBeInTheDocument();
+  });
+
+  it("calls onSubmit with the entered title and then onClose", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const onClose = vi.fn();
+    render(<TaskCreateSheet open onSubmit={onSubmit} onClose={onClose} />);
+    fireEvent.change(screen.getByPlaceholderText(/task title/i), { target: { value: "ship it" } });
+    fireEvent.click(screen.getByRole("button", { name: /create/i }));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(onSubmit).toHaveBeenCalledWith({ title: "ship it" });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("disables submit when title is empty", () => {
+    render(<TaskCreateSheet open onClose={() => {}} onSubmit={() => Promise.resolve()} />);
+    expect(screen.getByRole("button", { name: /create/i })).toBeDisabled();
+  });
+});

--- a/desktop/src/components/mobile/MobileSplitView.tsx
+++ b/desktop/src/components/mobile/MobileSplitView.tsx
@@ -82,7 +82,7 @@ export function MobileSplitView({
   // Mobile: single-pane with slide transition
   const showingDetail = selectedId !== null;
   return (
-    <div style={{ position: "relative", height: "100%", width: "100%", overflow: "hidden" }}>
+    <div data-testid="mobile-split-view" style={{ position: "relative", height: "100%", width: "100%", overflow: "hidden" }}>
       {/* Slider track — two panes each 100%, translated by view state */}
       <div
         style={{

--- a/desktop/src/components/mobile/WorkspaceTabPills.tsx
+++ b/desktop/src/components/mobile/WorkspaceTabPills.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useRef } from "react";
+
+export interface PillTab {
+  id: string;
+  label: string;
+}
+
+interface Props {
+  tabs: ReadonlyArray<PillTab>;
+  active: string;
+  onSelect: (id: string) => void;
+}
+
+/**
+ * Horizontal-scrolling pill tab strip for the project workspace on mobile.
+ * Distinct from the global PillBar (which is the iOS home-indicator widget).
+ */
+export function WorkspaceTabPills({ tabs, active, onSelect }: Props) {
+  const scrollerRef = useRef<HTMLDivElement>(null);
+  const activeRef = useRef<HTMLButtonElement>(null);
+
+  // Keep the active pill in view when it changes (e.g. via URL state).
+  useEffect(() => {
+    activeRef.current?.scrollIntoView({ behavior: "smooth", block: "nearest", inline: "center" });
+  }, [active]);
+
+  return (
+    <div
+      role="tablist"
+      data-testid="workspace-tab-pills-scroller"
+      ref={scrollerRef}
+      className="flex gap-2 overflow-x-auto px-3 py-2 border-b border-white/10
+                 [scrollbar-width:none] [-ms-overflow-style:none]
+                 [&::-webkit-scrollbar]:hidden"
+      style={{
+        WebkitOverflowScrolling: "touch",
+      }}
+    >
+      {tabs.map((t) => {
+        const isActive = t.id === active;
+        return (
+          <button
+            key={t.id}
+            ref={isActive ? activeRef : undefined}
+            role="tab"
+            aria-selected={isActive}
+            onClick={() => onSelect(t.id)}
+            className={
+              "shrink-0 rounded-full px-3 py-1.5 text-sm transition-colors " +
+              (isActive
+                ? "bg-white text-black"
+                : "bg-white/10 text-white/80 hover:bg-white/20")
+            }
+          >
+            {t.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/desktop/src/components/mobile/WorkspaceTabPills.tsx
+++ b/desktop/src/components/mobile/WorkspaceTabPills.tsx
@@ -16,7 +16,6 @@ interface Props {
  * Distinct from the global PillBar (which is the iOS home-indicator widget).
  */
 export function WorkspaceTabPills({ tabs, active, onSelect }: Props) {
-  const scrollerRef = useRef<HTMLDivElement>(null);
   const activeRef = useRef<HTMLButtonElement>(null);
 
   // Keep the active pill in view when it changes (e.g. via URL state).
@@ -28,7 +27,6 @@ export function WorkspaceTabPills({ tabs, active, onSelect }: Props) {
     <div
       role="tablist"
       data-testid="workspace-tab-pills-scroller"
-      ref={scrollerRef}
       className="flex gap-2 overflow-x-auto px-3 py-2 border-b border-white/10
                  [scrollbar-width:none] [-ms-overflow-style:none]
                  [&::-webkit-scrollbar]:hidden"

--- a/desktop/src/components/mobile/WorkspaceTabPills.tsx
+++ b/desktop/src/components/mobile/WorkspaceTabPills.tsx
@@ -40,8 +40,11 @@ export function WorkspaceTabPills({ tabs, active, onSelect }: Props) {
           <button
             key={t.id}
             ref={isActive ? activeRef : undefined}
+            type="button"
             role="tab"
+            id={`workspace-tab-${t.id}`}
             aria-selected={isActive}
+            aria-controls={`workspace-tabpanel-${t.id}`}
             onClick={() => onSelect(t.id)}
             className={
               "shrink-0 rounded-full px-3 py-1.5 text-sm transition-colors " +

--- a/desktop/src/components/mobile/__tests__/WorkspaceTabPills.test.tsx
+++ b/desktop/src/components/mobile/__tests__/WorkspaceTabPills.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { WorkspaceTabPills } from "../WorkspaceTabPills";
+
+const tabs = [
+  { id: "tasks", label: "Tasks" },
+  { id: "board", label: "Board" },
+  { id: "files", label: "Files" },
+] as const;
+
+describe("WorkspaceTabPills", () => {
+  it("renders one pill per tab", () => {
+    render(<WorkspaceTabPills tabs={tabs} active="tasks" onSelect={() => {}} />);
+    for (const t of tabs) {
+      expect(screen.getByRole("tab", { name: t.label })).toBeInTheDocument();
+    }
+  });
+
+  it("marks the active tab with aria-selected=true", () => {
+    render(<WorkspaceTabPills tabs={tabs} active="board" onSelect={() => {}} />);
+    expect(screen.getByRole("tab", { name: "Board" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("tab", { name: "Tasks" })).toHaveAttribute("aria-selected", "false");
+  });
+
+  it("calls onSelect with the tab id when clicked", () => {
+    const onSelect = vi.fn();
+    render(<WorkspaceTabPills tabs={tabs} active="tasks" onSelect={onSelect} />);
+    fireEvent.click(screen.getByRole("tab", { name: "Files" }));
+    expect(onSelect).toHaveBeenCalledWith("files");
+  });
+
+  it("renders a horizontal-scroll container", () => {
+    const { container } = render(
+      <WorkspaceTabPills tabs={tabs} active="tasks" onSelect={() => {}} />
+    );
+    const scroller = container.querySelector("[data-testid='workspace-tab-pills-scroller']");
+    expect(scroller).toBeInTheDocument();
+    expect(scroller).toHaveClass("overflow-x-auto");
+  });
+});

--- a/desktop/tests/projects-mobile.spec.ts
+++ b/desktop/tests/projects-mobile.spec.ts
@@ -1,0 +1,132 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("projects mobile shell @iphone-14", () => {
+  test("end-to-end mobile flow: list → workspace → tabs → board → modal → canvas", async ({ page }) => {
+    await page.goto("/desktop/");
+
+    // Sign in if required (skip if dev mode auto-auths).
+    // On iPhone 14 emulation, isTouchDevice = true so launched=true and no login screen.
+    const loginVisible = await page
+      .getByRole("button", { name: /sign in|login/i })
+      .isVisible()
+      .catch(() => false);
+    if (loginVisible) {
+      await page.getByLabel(/username|email/i).fill("dev");
+      await page.getByLabel(/password/i).fill("dev");
+      await page.getByRole("button", { name: /sign in|login/i }).click();
+    }
+
+    // Open Projects via the Launchpad ("All Apps" button in the dock).
+    // Projects is not on the home screen by default — it lives in the Launchpad.
+    await page.getByRole("button", { name: /all apps/i }).click();
+
+    // Launchpad is open — Projects icon has aria-label="Open Projects".
+    await expect(page.getByRole("button", { name: /open projects/i })).toBeVisible({ timeout: 5000 });
+    await page.getByRole("button", { name: /open projects/i }).click();
+
+    // Projects app window is now active.
+    // The MobileSplitView list pane shows a "Projects" heading.
+    await expect(page.getByRole("heading", { name: /^projects$/i })).toBeVisible({ timeout: 5000 });
+
+    // ── Core assertion: Projects list is mounted ────────────────────────────
+    // The list <ul> is in the DOM (may be off-screen via translate in MobileSplitView).
+    // We verify via the heading we already checked, and wait for the list to be attached.
+    const projectList = page.getByRole("list", { name: /projects/i });
+    await projectList.waitFor({ state: "attached", timeout: 5000 });
+
+    // Attempt to open a project for the workspace / tab / board sub-flow.
+    // This requires at least one project to exist (needs a live backend).
+    const projectButtons = projectList.getByRole("button");
+    const projectCount = await projectButtons.count().catch(() => 0);
+
+    if (projectCount === 0) {
+      // No projects (no backend or empty dataset).
+      // Try to create one; if the API is unavailable, cancel and skip the workspace sub-flow.
+      await page.getByRole("button", { name: /create project/i }).click();
+      await expect(page.getByRole("dialog")).toBeVisible({ timeout: 3000 });
+
+      const nameInput = page.getByRole("dialog").locator("input").first();
+      await nameInput.fill("e2e Mobile Test Project");
+      await page.getByRole("dialog").getByRole("button", { name: /^create$/i }).click();
+
+      // Give the API 3 s to succeed; if it doesn't, cancel and skip workspace tests.
+      const dialogGone = await page
+        .getByRole("dialog")
+        .waitFor({ state: "hidden", timeout: 3000 })
+        .then(() => true)
+        .catch(() => false);
+
+      if (!dialogGone) {
+        // API unavailable — dismiss dialog, skip project-detail sub-flow.
+        await page.getByRole("dialog").getByRole("button", { name: /cancel/i }).click();
+        // Core assertion already passed (list is visible), test ends here.
+        return;
+      }
+    }
+
+    // At least one project exists — tap it to open the workspace.
+    await projectList.getByRole("button").first().click();
+
+    // Detail pane slid in — back button visible (aria-label="Back to Projects").
+    await expect(page.getByRole("button", { name: /back to/i })).toBeVisible({ timeout: 3000 });
+
+    // Switch through workspace tabs via WorkspaceTabPills.
+    // On mobile, ProjectWorkspace renders WorkspaceTabPills (role=tablist, role=tab buttons).
+    for (const tabName of ["tasks", "board", "files", "messages"]) {
+      await page.getByRole("tab", { name: new RegExp(tabName, "i") }).click();
+      // Each tab should at least mount without throwing.
+      await expect(page.locator("body")).toBeVisible();
+    }
+
+    // Tasks tab — tap FAB → sheet opens → create a task.
+    await page.getByRole("tab", { name: /tasks/i }).click();
+    // ProjectFab has aria-label="Create task".
+    await page.getByRole("button", { name: /create task/i }).click();
+    await expect(page.getByTestId("task-create-sheet")).toBeVisible({ timeout: 3000 });
+    // Input placeholder is "Task title".
+    await page.getByPlaceholder(/task title/i).fill(`mobile e2e ${Date.now()}`);
+    // Submit button text is "Create".
+    await page.getByRole("button", { name: /^create$/i }).click();
+    // Sheet closes after submit; network may fail so use soft assert.
+    await expect
+      .soft(page.getByTestId("task-create-sheet"))
+      .not.toBeVisible({ timeout: 5000 });
+    // Dismiss if still open (API failure).
+    if (await page.getByTestId("task-create-sheet").isVisible().catch(() => false)) {
+      await page.getByRole("button", { name: /cancel/i }).click();
+    }
+
+    // Board tab — navigate and verify carousel mounted.
+    await page.getByRole("tab", { name: /board/i }).click();
+    const scroller = page.getByTestId("mobile-board-scroller");
+    await expect(scroller).toBeVisible({ timeout: 5000 });
+
+    // Attempt swipe gesture on carousel (best-effort; board still passes if no tasks).
+    const box = await scroller.boundingBox();
+    if (box) {
+      await page.mouse.move(box.x + box.width - 20, box.y + box.height / 2);
+      await page.mouse.down();
+      await page.mouse.move(box.x + 20, box.y + box.height / 2, { steps: 10 });
+      await page.mouse.up();
+    }
+
+    // Tap first task card in scroller → MobileTaskModal opens (conditional on tasks existing).
+    const firstCard = scroller.locator("button").first();
+    if (await firstCard.isVisible().catch(() => false)) {
+      await firstCard.click();
+      const modal = page.getByTestId("mobile-task-modal");
+      if (await modal.isVisible({ timeout: 2000 }).catch(() => false)) {
+        await expect(modal).toBeVisible();
+        // Close button has aria-label="Close modal".
+        await page.getByRole("button", { name: /close modal/i }).click();
+        await expect(modal).not.toBeVisible({ timeout: 3000 });
+      }
+    }
+
+    // Navigate back to project list via in-app back button.
+    // (MobileSplitView uses internal state, not browser history, so goBack() won't work.)
+    await page.getByRole("button", { name: /back to/i }).click();
+    // Back on list pane — "Projects" heading visible again.
+    await expect(page.getByRole("heading", { name: /^projects$/i })).toBeVisible({ timeout: 3000 });
+  });
+});

--- a/desktop/tests/projects-mobile.spec.ts
+++ b/desktop/tests/projects-mobile.spec.ts
@@ -87,13 +87,18 @@ test.describe("projects mobile shell @iphone-14", () => {
     await page.getByPlaceholder(/task title/i).fill(`mobile e2e ${Date.now()}`);
     // Submit button text is "Create".
     await page.getByRole("button", { name: /^create$/i }).click();
-    // Sheet closes after submit; network may fail so use soft assert.
-    await expect
-      .soft(page.getByTestId("task-create-sheet"))
-      .not.toBeVisible({ timeout: 5000 });
-    // Dismiss if still open (API failure).
-    if (await page.getByTestId("task-create-sheet").isVisible().catch(() => false)) {
+    // Wait for the sheet to auto-close after submit. If it doesn't (network failure
+    // or actual regression), dismiss it manually and fail the test loudly.
+    const sheetClosed = await page
+      .getByTestId("task-create-sheet")
+      .waitFor({ state: "hidden", timeout: 5000 })
+      .then(() => true)
+      .catch(() => false);
+    if (!sheetClosed) {
       await page.getByRole("button", { name: /cancel/i }).click();
+      throw new Error(
+        "TaskCreateSheet did not auto-close after submit — likely a network failure or a regression in TaskCreateSheet's onSubmit handler.",
+      );
     }
 
     // Board tab — navigate and verify carousel mounted.
@@ -111,7 +116,7 @@ test.describe("projects mobile shell @iphone-14", () => {
     }
 
     // Tap first task card in scroller → MobileTaskModal opens (conditional on tasks existing).
-    const firstCard = scroller.locator("button").first();
+    const firstCard = scroller.getByTestId("task-card").first();
     if (await firstCard.isVisible().catch(() => false)) {
       await firstCard.click();
       const modal = page.getByTestId("mobile-task-modal");

--- a/desktop/tests/projects-mobile.spec.ts
+++ b/desktop/tests/projects-mobile.spec.ts
@@ -57,10 +57,9 @@ test.describe("projects mobile shell @iphone-14", () => {
         .catch(() => false);
 
       if (!dialogGone) {
-        // API unavailable — dismiss dialog, skip project-detail sub-flow.
+        // Dismiss the still-open dialog before skipping (Playwright will fail on an open dialog otherwise).
         await page.getByRole("dialog").getByRole("button", { name: /cancel/i }).click();
-        // Core assertion already passed (list is visible), test ends here.
-        return;
+        test.skip(true, "Workspace sub-flow requires a backend for project creation; backend not available in this run.");
       }
     }
 

--- a/desktop/vitest.setup.ts
+++ b/desktop/vitest.setup.ts
@@ -24,3 +24,23 @@ if (typeof localStorage === "undefined" || typeof localStorage.clear !== "functi
 if (typeof Element !== "undefined" && typeof Element.prototype.scrollIntoView !== "function") {
   Element.prototype.scrollIntoView = function () {};
 }
+
+// JSDOM does not implement window.matchMedia. Hooks like useIsMobile call it
+// in a useEffect, which would otherwise crash any test that mounts them.
+// Default to "no match" (desktop). Individual tests can override per-suite.
+if (typeof window !== "undefined" && typeof window.matchMedia !== "function") {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}

--- a/desktop/vitest.setup.ts
+++ b/desktop/vitest.setup.ts
@@ -17,3 +17,10 @@ if (typeof localStorage === "undefined" || typeof localStorage.clear !== "functi
   Object.defineProperty(globalThis, "localStorage", { value: impl, configurable: true, writable: true });
   Object.defineProperty(globalThis, "sessionStorage", { value: { ...impl, clear() { store.clear(); } }, configurable: true, writable: true });
 }
+
+// JSDOM does not implement Element.prototype.scrollIntoView. Components that
+// scroll an active item into view (e.g. WorkspaceTabPills) call it during
+// useEffect, which would otherwise crash every test that mounts them.
+if (typeof Element !== "undefined" && typeof Element.prototype.scrollIntoView !== "function") {
+  Element.prototype.scrollIntoView = function () {};
+}


### PR DESCRIPTION
## Summary

Phone-targeted UX for ProjectsApp: surgical `useIsMobile()` branches plus a small `desktop/src/apps/ProjectsApp/mobile/` subtree. Zero backend changes.

- **Outer shell:** `MobileSplitView` wraps ProjectList + ProjectWorkspace; `WorkspaceTabPills` replaces the tab strip on phone.
- **Tasks:** `ProjectFab` + `TaskCreateSheet` bottom-sheet. Tasks/Members/Activity rows stack via Tailwind responsive classes.
- **Board:** `MobileBoardCarousel` — sticky column pills + swipe-paged columns with section-header swimlanes. No DnD on mobile (status changes via the modal).
- **Task modal:** `MobileTaskModal` — full-screen, slot-based (Hero/Metadata/SubTasks/Relationships/Activity). Sticky action bar (Claim/Close/Reopen). Swipe-left/right for sibling nav (60px threshold, vertical-dominance + pinch guards). Re-entrancy guard + `window.alert` on status-change failure.
- **BoardToolbar:** collapses to a filter sheet (group-by select + search + filters); viewMode tabs / live indicator / +Task button hidden on mobile.
- **Canvas:** read-only on mobile via `editor.updateInstanceState({ isReadonly })` (tldraw v4 API; the prop-based `readOnly` doesn't exist on this version).
- **PWA:** verified — `viewport-fit=cover`, Apple meta tags, manifest, icons, standalone detection all already in place.
- **Tests:** 218 vitest (54 files, +new tests for every new component), 1 Playwright e2e (\`projects-mobile.spec.ts\` on \`iphone-14\` profile).

## Notable deviations from the plan
1. tldraw v4 has no `<Tldraw readOnly>` prop — used the editor API.
2. e2e spec adapted to actual app: Launchpad path (not home screen), aria-label `"Back to Projects"`, modal close `aria-label="Close modal"` (disambiguated from the "Close" action button).
3. ARIA: used `<section aria-label>` (maps to `region`) rather than `<div role="group">`; verified `<details>` and `<dl>` carry no implicit role.
4. Added `data-testid="task-card"` to `TaskListItem` so the e2e selector targets task cards, not swimlane toggles.

## Test plan
- [ ] Vitest green (218/218 verified locally)
- [ ] Vite build succeeds, zero TS errors (verified locally)
- [ ] Playwright `projects-mobile.spec.ts` passes on `iphone-14` profile (verified locally)
- [ ] Manual sweep at iPhone 14 emulation in Chrome devtools:
  - [ ] Project list pane → tap project → workspace slides in, back button visible
  - [ ] Tab pills scroll horizontally; each tab mounts (tasks / board / files / messages / members / activity / canvas)
  - [ ] Tasks tab — FAB → sheet → create → task appears
  - [ ] Board tab — column pills sticky-top, swipe between columns, swimlane group-by visible (open Filter sheet → choose Assignee)
  - [ ] Tap card → MobileTaskModal full-screen → Claim button changes status → swipe right → previous task → Close
  - [ ] Canvas tab — tldraw read-only, pan/zoom work, no shape creation
  - [ ] Switch back to desktop viewport — visuals unchanged from pre-plan baseline

## Open follow-ups (non-blocking)
- `tablist`/`tab` lacks `tabpanel` wiring on the workspace tabs (visual UX clear; SR users would benefit).
- `MobileBoardCarousel` panes use `w-screen` rather than `w-full` — fine for full-width windows, will overflow if the projects window is ever embedded narrow.
- e2e test creates state ("e2e Mobile Test Project") — future cleanup hook desirable.
- Pre-existing `canvas-e2e.spec.ts` skeleton needs `@backend-required` tag or deletion (it fails without backend).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full mobile support: responsive layouts, mobile-specific navigation, touch-optimized board carousel, and a mobile task modal with swipe navigation
  * Mobile task creation: floating action button and a task creation sheet
  * Mobile tab pills and workspace split-view for improved phone UX
  * Added end-to-end test runner and CI-friendly test configuration

* **Tests**
  * Comprehensive unit and E2E tests covering mobile workflows and components

* **Chores**
  * Updated test-related ignores and test environment polyfills
<!-- end of auto-generated comment: release notes by coderabbit.ai -->