### PR TITLE
fix(tests): isolate BEADS bridge test from 3.11 writer-loop race

### DIFF
--- a/tests/projects/test_routes_beads.py
+++ b/tests/projects/test_routes_beads.py
@@ -49,6 +49,12 @@ async def test_create_task_marks_project_dirty(app):
             project = r.json()
 
             bridge = app.state.beads_bridge
+            # Stop the background writer so it cannot drain _dirty between the
+            # POST and the assertion — the writer loop runs every 0.2 s and on
+            # slower event-loop implementations (e.g. CPython 3.11) it can fire
+            # during the awaits inside the HTTP round-trip, clearing the set
+            # before the assertion has a chance to read it.
+            await bridge.stop()
             bridge._dirty.clear()
 
             r = await c.post(


### PR DESCRIPTION
## Diagnosis

`test_create_task_marks_project_dirty` asserts that `project_id in bridge._dirty` immediately after a POST that creates a task. The `BeadsBridge` writer loop runs every 0.2 s in the background. On CPython 3.11 the event loop schedules the writer task during the `await` points inside the ASGI HTTP round-trip (HTTP framing + aiosqlite writes). The writer fires, does `pending = list(self._dirty); self._dirty.clear()`, and empties the set before the test assertion runs — leaving `_dirty` empty and the assertion failing. The same commit passes on 3.13 where timing differs.

## Fix

One line in the test: call `await bridge.stop()` before `bridge._dirty.clear()`. This tears down the background writer task so it cannot race the assertion. `mark_dirty()` is synchronous and still adds to `_dirty` normally; the only thing missing is the consumer that would clear it.

## Verification

- Ran `tests/projects/test_routes_beads.py::test_create_task_marks_project_dirty` 5× in a row on the local machine (Python 3.14): all green.
- Ran full `tests/projects/test_routes_beads.py` (7 tests): all 7 green.
- Fix is 6 lines, test file only, no production code touched.
- Python 3.11 not available locally; CI on this PR will confirm the fix across all matrix versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved timing in a test case to ensure accurate verification of project state changes during task creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->