### PR TITLE
fix(mobile-home): home grid from registry — Projects + others missing in PWA

### DIFF
--- a/desktop/src/stores/mobile-home-store.test.ts
+++ b/desktop/src/stores/mobile-home-store.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { useMobileHomeStore } from "./mobile-home-store";
+import { getAllApps } from "@/registry/app-registry";
+
+describe("mobile-home-store", () => {
+  it("home grid includes every registered app", () => {
+    const { pages } = useMobileHomeStore.getState();
+    const allIdsInPages = new Set(
+      pages.flatMap((p) =>
+        p.items
+          .filter((i) => i.type === "app")
+          .map((i) => (i as { type: "app"; appId: string }).appId),
+      ),
+    );
+    const registryIds = getAllApps().map((a) => a.id);
+    for (const id of registryIds) {
+      expect(allIdsInPages.has(id), `missing app "${id}" in home grid`).toBe(true);
+    }
+  });
+
+  it("home grid contains only valid registry IDs", () => {
+    const { pages } = useMobileHomeStore.getState();
+    const registryIds = new Set(getAllApps().map((a) => a.id));
+    const appIdsInPages = pages.flatMap((p) =>
+      p.items
+        .filter((i) => i.type === "app")
+        .map((i) => (i as { type: "app"; appId: string }).appId),
+    );
+    for (const id of appIdsInPages) {
+      expect(registryIds.has(id), `dead app ID "${id}" in home grid`).toBe(true);
+    }
+  });
+});

--- a/desktop/src/stores/mobile-home-store.ts
+++ b/desktop/src/stores/mobile-home-store.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { getAllApps } from "@/registry/app-registry";
 
 type WidgetItem = { type: "widget"; widgetType: string };
 type AppItem = { type: "app"; appId: string };
@@ -7,13 +8,6 @@ export type HomeItem = WidgetItem | AppItem;
 export interface HomePage {
   items: HomeItem[];
 }
-
-const ALL_APP_IDS = [
-  "messages", "agents", "files", "store", "settings", "models", "providers",
-  "activity", "cluster", "memory", "channels", "secrets", "tasks", "import",
-  "images", "library", "reddit", "youtube", "github", "x-monitor",
-  "agent-browsers", "calculator", "calendar", "contacts",
-];
 
 const DEFAULT_DOCK: string[] = ["messages", "agents", "files", "store"];
 
@@ -27,7 +21,7 @@ const DEFAULT_PAGES: HomePage[] = [
     ],
   },
   {
-    items: ALL_APP_IDS.map((appId) => ({ type: "app", appId }) as AppItem),
+    items: getAllApps().map((a) => ({ type: "app", appId: a.id }) as AppItem),
   },
 ];
 


### PR DESCRIPTION
## Summary

The mobile home grid (`MobileHomePages`) in PWA / mobile viewport reads from `mobile-home-store.ts`, which maintained a hardcoded `ALL_APP_IDS` list that had drifted from the app registry. Three classes of bug rolled up:

1. **Projects missing** — the recently-shipped Projects app was never added to the hardcoded list. PWA users couldn't see it on the home grid (Launchpad still worked).
2. **Other missing apps** — 9 other apps were also missing: `mcp`, `browser`, `media-player`, `text-editor`, `image-viewer`, `terminal`, `chess`, `wordle`, `crosswords`.
3. **Dead-link IDs** — the list contained `"youtube"` and `"github"`, but the registry IDs are `"youtube-library"` and `"github-browser"`. These tiles were dead.

## Fix

Replace the hardcoded list with `getAllApps().map(a => a.id)` from `@/registry/app-registry`. The home grid now stays in sync with the registry by construction; future apps appear automatically.

## Side effects

- Existing PWA users see new ordering and the additional tiles on next reload. There is no persisted user-customization in the store, so no data loss.
- The dock and pinned-defaults are unchanged; this PR only touches the "all apps" grid.

## Test plan

- [x] New regression test in `src/stores/mobile-home-store.test.ts` asserts the home grid contains every registered app and no dead IDs
- [x] Vitest green — 55 test files, 220 tests passed
- [x] TypeScript clean
- [ ] Manual: open the PWA on iPhone or Chrome installed-app — Projects tile should appear

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added tests to verify app list consistency and accuracy.

* **Refactor**
  * Updated app list generation to use dynamic registry instead of hard-coded values, ensuring the list stays current automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->