### PR TITLE
feat(shortcuts): per-framework agent shortcut buttons (container-terminal / tui / dashboard) with HMAC ticket auth

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: "html",
   use: {
-    baseURL: "http://127.0.0.1:5173",
+    baseURL: "http://localhost:5173",
     trace: "on-first-retry",
   },
   projects: [
@@ -20,7 +20,7 @@ export default defineConfig({
   ],
   webServer: {
     command: "npm run dev",
-    url: "http://127.0.0.1:5173",
+    url: "http://localhost:5173",
     reuseExistingServer: !process.env.CI,
     timeout: 60_000,
   },

--- a/desktop/src/apps/AgentsApp.tsx
+++ b/desktop/src/apps/AgentsApp.tsx
@@ -1890,10 +1890,13 @@ export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
       const app = getApp("browser");
       if (app) openWindow("browser", app.defaultSize, { initialUrl: redirect_url });
     } else if (kind === "tui" || kind === "container-terminal") {
-      const url = new URL(redirect_url, window.location.href);
-      const ticket = url.searchParams.get("t") ?? redirect_url;
+      const parsed = new URL(redirect_url, window.location.href);
+      const ticket = parsed.searchParams.get("t") ?? "";
+      const wsUrl = redirect_url
+        .replace(/^http:\/\//, "ws://")
+        .replace(/^https:\/\//, "wss://");
       const app = getApp("terminal");
-      if (app) openWindow("terminal", app.defaultSize, { shortcut: { wsUrl: redirect_url, ticket } });
+      if (app) openWindow("terminal", app.defaultSize, { shortcut: { wsUrl, ticket } });
     }
   }, [openWindow]);
 

--- a/desktop/src/apps/AgentsApp.tsx
+++ b/desktop/src/apps/AgentsApp.tsx
@@ -32,6 +32,10 @@ import { PersonaPicker } from "@/components/persona-picker/PersonaPicker";
 import type { PersonaSelection } from "@/components/persona-picker/types";
 import { slugifyClient, isValidSlug, SLUG_REGEX } from "@/lib/slug";
 import { MigrationBanner } from "@/components/MigrationBanner";
+import { AgentShortcutRow } from "@/components/AgentShortcutRow";
+import type { AgentShortcut } from "@/hooks/use-agent-shortcuts";
+import { useProcessStore } from "@/stores/process-store";
+import { getApp } from "@/registry/app-registry";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -1637,6 +1641,7 @@ export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
   const [diskStates, setDiskStates] = useState<Record<string, DiskState>>({});
   const [quotaErrors, setQuotaErrors] = useState<Record<string, string>>({});
   const [latestByFramework, setLatestByFramework] = useState<Record<string, LatestVersion>>({});
+  const openWindow = useProcessStore((s) => s.openWindow);
 
   const fetchAgents = useCallback(async () => {
     try {
@@ -1873,6 +1878,25 @@ export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
     );
   }
 
+  const handleShortcutLaunch = useCallback(async (agentId: string, shortcut: AgentShortcut) => {
+    const res = await fetch(
+      `/api/agents/${encodeURIComponent(agentId)}/shortcuts/${shortcut.idx}/launch`,
+      { method: "POST", headers: { Accept: "application/json" } }
+    );
+    if (!res.ok) return;
+    const { redirect_url } = await res.json() as { redirect_url: string };
+    const kind = shortcut.kind;
+    if (kind === "dashboard") {
+      const app = getApp("browser");
+      if (app) openWindow("browser", app.defaultSize, { initialUrl: redirect_url });
+    } else if (kind === "tui" || kind === "container-terminal") {
+      const url = new URL(redirect_url, window.location.href);
+      const ticket = url.searchParams.get("t") ?? redirect_url;
+      const app = getApp("terminal");
+      if (app) openWindow("terminal", app.defaultSize, { shortcut: { wsUrl: redirect_url, ticket } });
+    }
+  }, [openWindow]);
+
   function handleWizardClose(deployed?: boolean) {
     setWizardOpen(false);
     if (deployed) {
@@ -1991,17 +2015,22 @@ export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
               })}
             <div className="space-y-2" role="list" aria-label="Agent list">
               {agents.map((agent) => (
-                <AgentRow
-                  key={agent.name}
-                  agent={agent}
-                  diskState={diskStates[agent.name] ?? null}
-                  latestByFramework={latestByFramework}
-                  onViewLogs={(name) => setDetail({ name, tab: "logs" })}
-                  onViewSkills={(name) => setDetail({ name, tab: "skills" })}
-                  onViewMessages={(name) => setDetail({ name, tab: "messages" })}
-                  onDelete={handleDelete}
-                  onResume={handleResume}
-                />
+                <div key={agent.name}>
+                  <AgentRow
+                    agent={agent}
+                    diskState={diskStates[agent.name] ?? null}
+                    latestByFramework={latestByFramework}
+                    onViewLogs={(name) => setDetail({ name, tab: "logs" })}
+                    onViewSkills={(name) => setDetail({ name, tab: "skills" })}
+                    onViewMessages={(name) => setDetail({ name, tab: "messages" })}
+                    onDelete={handleDelete}
+                    onResume={handleResume}
+                  />
+                  <AgentShortcutRow
+                    agentId={agent.name}
+                    onLaunch={handleShortcutLaunch}
+                  />
+                </div>
               ))}
             </div>
             <ArchivedAgentsPanel

--- a/desktop/src/apps/BrowserApp.initialUrl.test.tsx
+++ b/desktop/src/apps/BrowserApp.initialUrl.test.tsx
@@ -16,6 +16,23 @@ describe("BrowserApp initialUrl", () => {
     expect(iframe?.src).toContain("openclaw.local%2Fui");
   });
 
+  it("rejects javascript: initialUrl and does not set iframe src", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { container } = render(
+      <BrowserApp initialUrl="javascript:alert(1)" />,
+    );
+    const iframe = container.querySelector("iframe");
+    // iframe src must NOT contain the dangerous payload
+    expect(iframe?.src ?? "").not.toContain("javascript");
+    expect(iframe?.src ?? "").not.toContain("alert");
+    // a warning must have been emitted
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[BrowserApp]"),
+      expect.anything(),
+    );
+    warnSpy.mockRestore();
+  });
+
   it("does not override user-navigated src on re-mount when initialUrl unchanged", () => {
     const { container, rerender } = render(
       <BrowserApp initialUrl="https://openclaw.local/ui" />,

--- a/desktop/src/apps/BrowserApp.initialUrl.test.tsx
+++ b/desktop/src/apps/BrowserApp.initialUrl.test.tsx
@@ -1,17 +1,19 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { describe, it, expect, vi, afterEach } from "vitest";
 import BrowserApp from "./BrowserApp";
 
 describe("BrowserApp initialUrl", () => {
   afterEach(() => vi.clearAllMocks());
 
-  it("sets iframe src to initialUrl on first mount", () => {
+  it("sets iframe src via proxy URL for initialUrl on first mount", () => {
     const { container } = render(
       <BrowserApp initialUrl="https://openclaw.local/ui" />,
     );
     const iframe = container.querySelector("iframe");
     expect(iframe).not.toBeNull();
-    expect(iframe?.src).toBe("https://openclaw.local/ui");
+    // The iframe always loads through the desktop proxy endpoint.
+    // Verify the initialUrl is encoded in the proxy src.
+    expect(iframe?.src).toContain("openclaw.local%2Fui");
   });
 
   it("does not override user-navigated src on re-mount when initialUrl unchanged", () => {
@@ -28,5 +30,11 @@ describe("BrowserApp initialUrl", () => {
     const { container } = render(<BrowserApp />);
     const iframe = container.querySelector("iframe");
     expect(iframe?.src ?? "").not.toContain("https://");
+  });
+
+  it("shows initialUrl in the address bar input, not DEFAULT_URL", () => {
+    render(<BrowserApp initialUrl="https://openclaw.local/dashboard" />);
+    const input = screen.getByRole<HTMLInputElement>("textbox");
+    expect(input.value).toBe("https://openclaw.local/dashboard");
   });
 });

--- a/desktop/src/apps/BrowserApp.initialUrl.test.tsx
+++ b/desktop/src/apps/BrowserApp.initialUrl.test.tsx
@@ -1,0 +1,32 @@
+import { render } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import BrowserApp from "./BrowserApp";
+
+describe("BrowserApp initialUrl", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("sets iframe src to initialUrl on first mount", () => {
+    const { container } = render(
+      <BrowserApp initialUrl="https://openclaw.local/ui" />,
+    );
+    const iframe = container.querySelector("iframe");
+    expect(iframe).not.toBeNull();
+    expect(iframe?.src).toBe("https://openclaw.local/ui");
+  });
+
+  it("does not override user-navigated src on re-mount when initialUrl unchanged", () => {
+    const { container, rerender } = render(
+      <BrowserApp initialUrl="https://openclaw.local/ui" />,
+    );
+    const iframe = container.querySelector("iframe") as HTMLIFrameElement;
+    Object.defineProperty(iframe, "src", { value: "https://openclaw.local/other", writable: true });
+    rerender(<BrowserApp initialUrl="https://openclaw.local/ui" />);
+    expect(iframe.src).toBe("https://openclaw.local/other");
+  });
+
+  it("does not set iframe src when initialUrl is undefined", () => {
+    const { container } = render(<BrowserApp />);
+    const iframe = container.querySelector("iframe");
+    expect(iframe?.src ?? "").not.toContain("https://");
+  });
+});

--- a/desktop/src/apps/BrowserApp.tsx
+++ b/desktop/src/apps/BrowserApp.tsx
@@ -170,10 +170,16 @@ export function BrowserApp({ windowId: _windowId, initialUrl }: { windowId?: str
     }
   }, []);
 
-  // Apply initialUrl once on mount via ref — idempotent across rerenders
+  // Apply initialUrl once on mount — idempotent across rerenders.
+  // Also sync url/inputValue/history so the address bar, copy, and
+  // back/forward all reflect the launch URL rather than DEFAULT_URL.
   useEffect(() => {
     if (!initialUrl || initialUrlApplied.current) return;
     initialUrlApplied.current = true;
+    setUrl(initialUrl);
+    setInputValue(initialUrl);
+    setHistory([initialUrl]);
+    setHistoryIndex(0);
     if (iframeRef.current) {
       iframeRef.current.src = initialUrl;
     }

--- a/desktop/src/apps/BrowserApp.tsx
+++ b/desktop/src/apps/BrowserApp.tsx
@@ -175,13 +175,23 @@ export function BrowserApp({ windowId: _windowId, initialUrl }: { windowId?: str
   // back/forward all reflect the launch URL rather than DEFAULT_URL.
   useEffect(() => {
     if (!initialUrl || initialUrlApplied.current) return;
-    initialUrlApplied.current = true;
-    setUrl(initialUrl);
-    setInputValue(initialUrl);
-    setHistory([initialUrl]);
-    setHistoryIndex(0);
-    if (iframeRef.current) {
-      iframeRef.current.src = initialUrl;
+    try {
+      const parsed = new URL(initialUrl, window.location.href);
+      if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+        console.warn("[BrowserApp] rejected initialUrl with non-http(s) scheme:", parsed.protocol);
+        return;
+      }
+      initialUrlApplied.current = true;
+      const safe = parsed.toString();
+      setUrl(safe);
+      setInputValue(safe);
+      setHistory([safe]);
+      setHistoryIndex(0);
+      if (iframeRef.current) {
+        iframeRef.current.src = safe;
+      }
+    } catch (err) {
+      console.warn("[BrowserApp] invalid initialUrl:", initialUrl, err);
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/desktop/src/apps/BrowserApp.tsx
+++ b/desktop/src/apps/BrowserApp.tsx
@@ -51,8 +51,9 @@ function isIOS(): boolean {
 
 type BrowserMode = "embedded" | "external";
 
-export function BrowserApp({ windowId: _windowId }: { windowId: string }) {
+export function BrowserApp({ windowId: _windowId, initialUrl }: { windowId?: string; initialUrl?: string }) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
+  const initialUrlApplied = useRef(false);
   const [url, setUrl] = useState(DEFAULT_URL);
   const [inputValue, setInputValue] = useState(DEFAULT_URL);
   const [history, setHistory] = useState<string[]>([DEFAULT_URL]);
@@ -167,6 +168,16 @@ export function BrowserApp({ windowId: _windowId }: { windowId: string }) {
     if (isIOS()) {
       setMode("external");
     }
+  }, []);
+
+  // Apply initialUrl once on mount via ref — idempotent across rerenders
+  useEffect(() => {
+    if (!initialUrl || initialUrlApplied.current) return;
+    initialUrlApplied.current = true;
+    if (iframeRef.current) {
+      iframeRef.current.src = initialUrl;
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // When in external mode and URL changes, don't auto-open — user clicks the button
@@ -466,3 +477,5 @@ export function BrowserApp({ windowId: _windowId }: { windowId: string }) {
     </div>
   );
 }
+
+export default BrowserApp;

--- a/desktop/src/apps/BrowserApp.tsx
+++ b/desktop/src/apps/BrowserApp.tsx
@@ -188,6 +188,11 @@ export function BrowserApp({ windowId: _windowId, initialUrl }: { windowId?: str
       setHistory([safe]);
       setHistoryIndex(0);
       if (iframeRef.current) {
+        // initialUrl is set directly on the iframe (NOT via proxyUrl) because the
+        // agent-shortcuts feature redirects the browser straight to the worker — the
+        // worker sets its own session cookie via /redeem and serves dashboard
+        // content directly. Routing through the controller's proxyUrl wrapping would
+        // break that worker-direct cookie flow.
         iframeRef.current.src = safe;
       }
     } catch (err) {

--- a/desktop/src/apps/TerminalApp.shortcut-ui.test.tsx
+++ b/desktop/src/apps/TerminalApp.shortcut-ui.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import TerminalApp from "./TerminalApp";
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+  url: string;
+  onopen: (() => void) | null = null;
+  sentMessages: unknown[] = [];
+  readyState = WebSocket.CONNECTING;
+  constructor(url: string) { this.url = url; MockWebSocket.instances.push(this); }
+  send(d: unknown) { this.sentMessages.push(d); }
+  close() {}
+}
+
+beforeEach(() => {
+  MockWebSocket.instances = [];
+  vi.stubGlobal("WebSocket", MockWebSocket);
+});
+afterEach(() => { vi.unstubAllGlobals(); });
+
+describe("TerminalApp shortcut mode UI", () => {
+  it("does not render connection mode toggle when shortcut prop is set", () => {
+    render(
+      <TerminalApp
+        shortcut={{ wsUrl: "wss://worker.local/shortcut/terminal/openclaw/0?ticket=tok", ticket: "tok" }}
+      />,
+    );
+    expect(screen.queryByRole("radio", { name: /local/i })).toBeNull();
+    expect(screen.queryByRole("radio", { name: /ssh/i })).toBeNull();
+  });
+
+  it("does not render host/port form fields when shortcut prop is set", () => {
+    render(
+      <TerminalApp
+        shortcut={{ wsUrl: "wss://worker.local/shortcut/terminal/openclaw/0?ticket=tok", ticket: "tok" }}
+      />,
+    );
+    expect(screen.queryByLabelText(/host/i)).toBeNull();
+    expect(screen.queryByLabelText(/port/i)).toBeNull();
+  });
+
+  it("shows a status indicator mentioning shortcut mode when shortcut prop is set", () => {
+    render(
+      <TerminalApp
+        shortcut={{ wsUrl: "wss://worker.local/shortcut/terminal/openclaw/0?ticket=tok", ticket: "tok" }}
+      />,
+    );
+    expect(screen.getByText(/connecting to.*shortcut/i)).toBeInTheDocument();
+  });
+
+  it("renders connection mode toggle when shortcut prop is absent", () => {
+    render(<TerminalApp />);
+    const localOrSsh = screen.queryByRole("radio", { name: /local/i }) ??
+                       screen.queryByRole("button", { name: /local/i });
+    expect(localOrSsh).toBeInTheDocument();
+  });
+});

--- a/desktop/src/apps/TerminalApp.shortcut-ws.test.tsx
+++ b/desktop/src/apps/TerminalApp.shortcut-ws.test.tsx
@@ -1,0 +1,58 @@
+import { render, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import TerminalApp from "./TerminalApp";
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+  url: string;
+  onopen: (() => void) | null = null;
+  onmessage: ((e: MessageEvent) => void) | null = null;
+  onclose: (() => void) | null = null;
+  sentMessages: unknown[] = [];
+  readyState = WebSocket.CONNECTING;
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+  send(data: unknown) {
+    this.sentMessages.push(data);
+  }
+  close() {}
+}
+
+beforeEach(() => {
+  MockWebSocket.instances = [];
+  vi.stubGlobal("WebSocket", MockWebSocket);
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("TerminalApp shortcut mode WebSocket", () => {
+  it("connects to wsUrl from shortcut prop instead of local endpoint", async () => {
+    render(
+      <TerminalApp
+        shortcut={{ wsUrl: "wss://worker.local/shortcut/terminal/openclaw/0?ticket=tok123", ticket: "tok123" }}
+      />,
+    );
+    expect(MockWebSocket.instances).toHaveLength(1);
+    expect(MockWebSocket.instances[0].url).toContain("wss://worker.local/shortcut/terminal/openclaw/0");
+  });
+
+  it("sends the ticket frame as the first message after connect", async () => {
+    render(
+      <TerminalApp
+        shortcut={{ wsUrl: "wss://worker.local/shortcut/terminal/openclaw/0?ticket=tok123", ticket: "tok123" }}
+      />,
+    );
+    const ws = MockWebSocket.instances[0];
+    await act(async () => {
+      ws.readyState = WebSocket.OPEN;
+      ws.onopen?.();
+    });
+    expect(ws.sentMessages).toHaveLength(1);
+    const firstMsg = JSON.parse(ws.sentMessages[0] as string);
+    expect(firstMsg).toEqual({ type: "ticket", ticket: "tok123" });
+  });
+});

--- a/desktop/src/apps/TerminalApp.tsx
+++ b/desktop/src/apps/TerminalApp.tsx
@@ -546,7 +546,9 @@ export function TerminalApp({ windowId: _windowId, shortcut }: { windowId?: stri
       <Toolbar className="text-xs" style={{ color: "rgba(255,255,255,0.7)" }}>
         <ToolbarGroup>
           <div className="font-mono px-1">
-            {session?.mode === "ssh" ? (
+            {shortcut ? (
+              <span>Connecting to shortcut…</span>
+            ) : session?.mode === "ssh" ? (
               <>
                 <span className="opacity-60">ssh://</span>
                 {session.username}@{session.host}

--- a/desktop/src/apps/TerminalApp.tsx
+++ b/desktop/src/apps/TerminalApp.tsx
@@ -60,7 +60,12 @@ function saveRecent(entry: SshHost) {
   }
 }
 
-export function TerminalApp({ windowId: _windowId }: { windowId: string }) {
+interface ShortcutProp {
+  wsUrl: string;
+  ticket: string;
+}
+
+export function TerminalApp({ windowId: _windowId, shortcut }: { windowId?: string; shortcut?: ShortcutProp }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<Terminal | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
@@ -68,7 +73,7 @@ export function TerminalApp({ windowId: _windowId }: { windowId: string }) {
 
   const [session, setSession] = useState<Session | null>(null);
   const [view, setView] = useState<"picker" | "ssh-form" | "terminal">(
-    "picker",
+    shortcut ? "terminal" : "picker",
   );
   const [recent, setRecent] = useState<SshHost[]>(() => loadRecent());
 
@@ -133,6 +138,97 @@ export function TerminalApp({ windowId: _windowId }: { windowId: string }) {
     });
     setView("terminal");
   };
+
+  // Shortcut mode: connect immediately without a session
+  useEffect(() => {
+    if (!shortcut) return;
+    if (termRef.current) return;
+
+    const wsUrl = shortcut.wsUrl;
+    const ticket = shortcut.ticket;
+
+    const ws = new WebSocket(wsUrl);
+    wsRef.current = ws;
+
+    ws.onopen = () => {
+      ws.send(JSON.stringify({ type: "ticket", ticket }));
+    };
+
+    // If the container is available and ResizeObserver is supported, set up xterm too
+    if (containerRef.current && typeof ResizeObserver !== "undefined") {
+      const term = new Terminal({
+        theme: {
+          background: "#151625",
+          foreground: "rgba(255, 255, 255, 0.85)",
+          cursor: "#8b92a3",
+          cursorAccent: "#151625",
+          selectionBackground: "rgba(139, 146, 163, 0.3)",
+          black: "#1a1b2e",
+          red: "#ff5f57",
+          green: "#28c840",
+          yellow: "#febc2e",
+          blue: "#8b92a3",
+          magenta: "#f093fb",
+          cyan: "#4facfe",
+          white: "rgba(255,255,255,0.85)",
+          brightBlack: "#555",
+          brightRed: "#ff6b6b",
+          brightGreen: "#51cf66",
+          brightYellow: "#ffd43b",
+          brightBlue: "#748ffc",
+          brightMagenta: "#e599f7",
+          brightCyan: "#66d9e8",
+          brightWhite: "#ffffff",
+        },
+        fontFamily:
+          "'JetBrains Mono', 'Fira Code', 'MesloLGS NF', 'Hack Nerd Font', 'Cascadia Code', 'SF Mono', monospace",
+        fontSize: 14,
+        lineHeight: 1.2,
+        cursorBlink: true,
+        cursorStyle: "bar",
+        allowProposedApi: true,
+      });
+      const fit = new FitAddon();
+      const webLinks = new WebLinksAddon();
+      term.loadAddon(fit);
+      term.loadAddon(webLinks);
+      term.open(containerRef.current);
+      fit.fit();
+      fitRef.current = fit;
+      termRef.current = term;
+
+      ws.onmessage = (event) => { term.write(event.data); };
+      ws.onerror = () => { term.writeln("\r\n\x1b[31mWebSocket connection error\x1b[0m"); };
+      ws.onclose = () => { term.writeln("\r\n\x1b[33mConnection closed\x1b[0m"); };
+
+      const inputDisposable = term.onData((data) => {
+        if (ws.readyState === WebSocket.OPEN) ws.send(data);
+      });
+      const resizeObserver = new ResizeObserver(() => {
+        try { fit.fit(); } catch { /* ignore */ }
+        if (ws.readyState === WebSocket.OPEN) {
+          ws.send(JSON.stringify({ type: "resize", cols: term.cols, rows: term.rows }));
+        }
+      });
+      resizeObserver.observe(containerRef.current);
+
+      return () => {
+        resizeObserver.disconnect();
+        inputDisposable.dispose();
+        try { ws.close(); } catch { /* ignore */ }
+        term.dispose();
+        termRef.current = null;
+        wsRef.current = null;
+        fitRef.current = null;
+      };
+    }
+
+    return () => {
+      try { ws.close(); } catch { /* ignore */ }
+      wsRef.current = null;
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
     if (view !== "terminal" || !session) return;
@@ -477,3 +573,5 @@ export function TerminalApp({ windowId: _windowId }: { windowId: string }) {
     </div>
   );
 }
+
+export default TerminalApp;

--- a/desktop/src/apps/__tests__/AgentsApp.shortcut-click.test.tsx
+++ b/desktop/src/apps/__tests__/AgentsApp.shortcut-click.test.tsx
@@ -135,7 +135,7 @@ describe("AgentsApp — handleShortcutLaunch routing (Task 28)", () => {
     );
   });
 
-  it("tui kind opens TerminalApp with wsUrl and ticket extracted from redirect_url", async () => {
+  it("tui kind opens TerminalApp with wsUrl (ws://) and ticket extracted from t= param", async () => {
     const redirectUrl = "http://worker.local/redeem?t=myticket42";
     setupFetch({ redirect_url: redirectUrl, expires_in: 30 });
 
@@ -152,14 +152,38 @@ describe("AgentsApp — handleShortcutLaunch routing (Task 28)", () => {
       expect.objectContaining({ w: expect.any(Number), h: expect.any(Number) }),
       expect.objectContaining({
         shortcut: expect.objectContaining({
-          wsUrl: redirectUrl,
+          wsUrl: "ws://worker.local/redeem?t=myticket42",
           ticket: "myticket42",
         }),
       })
     );
   });
 
-  it("container-terminal kind opens TerminalApp with wsUrl and ticket", async () => {
+  it("https redirect_url is converted to wss:// scheme for TerminalApp", async () => {
+    const redirectUrl = "https://worker.secure/redeem?t=secureticket";
+    setupFetch({ redirect_url: redirectUrl, expires_in: 30 });
+
+    render(<AgentsApp windowId="test" />);
+    await screen.findByTestId("shortcut-row-test-agent");
+
+    const { onLaunch } = captors["test-agent"]!;
+    await act(async () => {
+      await onLaunch!("test-agent", { idx: 1, label: "TUI", icon: "tui", kind: "tui", requires_capability: "agent.terminal" });
+    });
+
+    expect(mockOpenWindow).toHaveBeenCalledWith(
+      "terminal",
+      expect.objectContaining({ w: expect.any(Number), h: expect.any(Number) }),
+      expect.objectContaining({
+        shortcut: expect.objectContaining({
+          wsUrl: "wss://worker.secure/redeem?t=secureticket",
+          ticket: "secureticket",
+        }),
+      })
+    );
+  });
+
+  it("container-terminal kind opens TerminalApp with wsUrl (ws://) and ticket", async () => {
     const redirectUrl = "http://worker.local/redeem?t=containerticket";
     setupFetch({ redirect_url: redirectUrl, expires_in: 30 });
 
@@ -176,7 +200,7 @@ describe("AgentsApp — handleShortcutLaunch routing (Task 28)", () => {
       expect.objectContaining({ w: expect.any(Number), h: expect.any(Number) }),
       expect.objectContaining({
         shortcut: expect.objectContaining({
-          wsUrl: redirectUrl,
+          wsUrl: "ws://worker.local/redeem?t=containerticket",
           ticket: "containerticket",
         }),
       })

--- a/desktop/src/apps/__tests__/AgentsApp.shortcut-click.test.tsx
+++ b/desktop/src/apps/__tests__/AgentsApp.shortcut-click.test.tsx
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import React from "react";
+
+// Stub heavy deps first
+vi.mock("@/hooks/use-is-mobile", () => ({ useIsMobile: () => false }));
+vi.mock("@/lib/framework-api", () => ({ fetchLatestFrameworks: async () => ({}) }));
+vi.mock("@/lib/models", () => ({
+  fetchClusterWorkers: async () => [],
+  workersToAggregated: () => [],
+  HOST_BADGE_CLASS: "",
+  CLOUD_PROVIDER_TYPES: [],
+}));
+vi.mock("@/lib/cluster", () => ({
+  availableKvQuantOptions: () => ({ k: ["fp16"], v: ["fp16"], boundary: false, flat: ["fp16"] }),
+}));
+vi.mock("@/lib/agent-emoji", () => ({ resolveAgentEmoji: () => "🤖" }));
+vi.mock("@/components/EmojiPicker", () => ({ EmojiPickerField: () => null }));
+vi.mock("@/components/ModelPickerFlow", () => ({ ModelPickerFlow: () => null }));
+vi.mock("@/components/ModelPickerModal", () => ({ ModelPickerModal: () => null }));
+vi.mock("@/components/persona-picker/PersonaPicker", () => ({ PersonaPicker: () => null }));
+vi.mock("@/lib/slug", () => ({
+  slugifyClient: (s: string) => s,
+  isValidSlug: () => true,
+  SLUG_REGEX: /^[a-z0-9][a-z0-9-]{0,62}$/,
+}));
+vi.mock("@/components/MigrationBanner", () => ({ MigrationBanner: () => null }));
+vi.mock("@/components/agent-settings/PersonaTab", () => ({ PersonaTab: () => null }));
+vi.mock("@/components/agent-settings/MemoryTab", () => ({ MemoryTab: () => null }));
+vi.mock("@/components/agent-settings/FrameworkTab", () => ({ FrameworkTab: () => null }));
+vi.mock("../AgentSkillsPanel", () => ({ AgentSkillsPanel: () => null }));
+vi.mock("../AgentMessagesPanel", () => ({ AgentMessagesPanel: () => null }));
+vi.mock("@/components/ui", () => ({
+  Button: ({ children, onClick, className, ...rest }: React.ButtonHTMLAttributes<HTMLButtonElement> & { children?: React.ReactNode }) => (
+    <button onClick={onClick} className={className} {...rest}>{children}</button>
+  ),
+  Card: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+  Label: ({ children }: { children: React.ReactNode }) => <label>{children}</label>,
+  Tabs: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsList: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsTrigger: ({ children }: { children: React.ReactNode }) => <button>{children}</button>,
+}));
+
+const mockOpenWindow = vi.fn();
+vi.mock("@/stores/process-store", () => ({
+  useProcessStore: (sel: (s: { openWindow: ReturnType<typeof vi.fn> }) => unknown) =>
+    sel({ openWindow: mockOpenWindow }),
+}));
+
+// Mock AgentShortcutRow to expose an onLaunch capture mechanism
+type LaunchCaptor = { onLaunch?: (agentId: string, shortcut: unknown) => void };
+const captors: Record<string, LaunchCaptor> = {};
+
+vi.mock("@/components/AgentShortcutRow", () => ({
+  AgentShortcutRow: ({ agentId, onLaunch }: { agentId: string; onLaunch: (agentId: string, shortcut: unknown) => void }) => {
+    captors[agentId] = { onLaunch };
+    return <div data-testid={`shortcut-row-${agentId}`} />;
+  },
+}));
+
+import { AgentsApp } from "../AgentsApp";
+
+const MOCK_AGENT = {
+  name: "test-agent",
+  display_name: "Test Agent",
+  host: "localhost",
+  color: "#3b82f6",
+  status: "running",
+  vectors: 1,
+  framework: "openclaw",
+  paused: false,
+};
+
+function setupFetch(launchResponse: { redirect_url: string; expires_in: number }) {
+  global.fetch = vi.fn().mockImplementation((url: string, opts?: RequestInit) => {
+    if (url === "/api/agents" && !opts?.method) {
+      return Promise.resolve({
+        ok: true,
+        headers: { get: () => "application/json" },
+        json: () => Promise.resolve([MOCK_AGENT]),
+      } as unknown as Response);
+    }
+    if (url === "/api/agents/archived") {
+      return Promise.resolve({
+        ok: true,
+        headers: { get: () => "application/json" },
+        json: () => Promise.resolve([]),
+      } as unknown as Response);
+    }
+    if (url.includes("/shortcuts/") && url.includes("/launch")) {
+      return Promise.resolve({
+        ok: true,
+        headers: { get: () => "application/json" },
+        json: () => Promise.resolve(launchResponse),
+      } as unknown as Response);
+    }
+    return Promise.resolve({
+      ok: false,
+      headers: { get: () => "application/json" },
+      json: () => Promise.resolve({}),
+    } as unknown as Response);
+  });
+}
+
+describe("AgentsApp — handleShortcutLaunch routing (Task 28)", () => {
+  beforeEach(() => {
+    mockOpenWindow.mockClear();
+    Object.keys(captors).forEach((k) => delete captors[k]);
+  });
+
+  it("dashboard kind opens BrowserApp with initialUrl from redirect_url", async () => {
+    const redirectUrl = "http://worker.local/redeem?t=abc123";
+    setupFetch({ redirect_url: redirectUrl, expires_in: 30 });
+
+    render(<AgentsApp windowId="test" />);
+    await screen.findByTestId("shortcut-row-test-agent");
+
+    const { onLaunch } = captors["test-agent"]!;
+    await act(async () => {
+      await onLaunch!("test-agent", { idx: 0, label: "Dashboard", icon: "dashboard", kind: "dashboard", requires_capability: "agent.dashboard" });
+    });
+
+    expect(mockOpenWindow).toHaveBeenCalledWith(
+      "browser",
+      expect.objectContaining({ w: expect.any(Number), h: expect.any(Number) }),
+      expect.objectContaining({ initialUrl: redirectUrl })
+    );
+  });
+
+  it("tui kind opens TerminalApp with wsUrl and ticket extracted from redirect_url", async () => {
+    const redirectUrl = "http://worker.local/redeem?t=myticket42";
+    setupFetch({ redirect_url: redirectUrl, expires_in: 30 });
+
+    render(<AgentsApp windowId="test" />);
+    await screen.findByTestId("shortcut-row-test-agent");
+
+    const { onLaunch } = captors["test-agent"]!;
+    await act(async () => {
+      await onLaunch!("test-agent", { idx: 1, label: "TUI", icon: "tui", kind: "tui", requires_capability: "agent.terminal" });
+    });
+
+    expect(mockOpenWindow).toHaveBeenCalledWith(
+      "terminal",
+      expect.objectContaining({ w: expect.any(Number), h: expect.any(Number) }),
+      expect.objectContaining({
+        shortcut: expect.objectContaining({
+          wsUrl: redirectUrl,
+          ticket: "myticket42",
+        }),
+      })
+    );
+  });
+
+  it("container-terminal kind opens TerminalApp with wsUrl and ticket", async () => {
+    const redirectUrl = "http://worker.local/redeem?t=containerticket";
+    setupFetch({ redirect_url: redirectUrl, expires_in: 30 });
+
+    render(<AgentsApp windowId="test" />);
+    await screen.findByTestId("shortcut-row-test-agent");
+
+    const { onLaunch } = captors["test-agent"]!;
+    await act(async () => {
+      await onLaunch!("test-agent", { idx: 2, label: "Shell", icon: "terminal", kind: "container-terminal", requires_capability: "agent.shell" });
+    });
+
+    expect(mockOpenWindow).toHaveBeenCalledWith(
+      "terminal",
+      expect.objectContaining({ w: expect.any(Number), h: expect.any(Number) }),
+      expect.objectContaining({
+        shortcut: expect.objectContaining({
+          wsUrl: redirectUrl,
+          ticket: "containerticket",
+        }),
+      })
+    );
+  });
+});

--- a/desktop/src/apps/__tests__/AgentsApp.shortcut-click.test.tsx
+++ b/desktop/src/apps/__tests__/AgentsApp.shortcut-click.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, act } from "@testing-library/react";
 import React from "react";
 
@@ -76,7 +76,7 @@ const MOCK_AGENT = {
 };
 
 function setupFetch(launchResponse: { redirect_url: string; expires_in: number }) {
-  global.fetch = vi.fn().mockImplementation((url: string, opts?: RequestInit) => {
+  vi.stubGlobal("fetch", vi.fn().mockImplementation((url: string, opts?: RequestInit) => {
     if (url === "/api/agents" && !opts?.method) {
       return Promise.resolve({
         ok: true,
@@ -103,13 +103,17 @@ function setupFetch(launchResponse: { redirect_url: string; expires_in: number }
       headers: { get: () => "application/json" },
       json: () => Promise.resolve({}),
     } as unknown as Response);
-  });
+  }));
 }
 
 describe("AgentsApp — handleShortcutLaunch routing (Task 28)", () => {
   beforeEach(() => {
     mockOpenWindow.mockClear();
     Object.keys(captors).forEach((k) => delete captors[k]);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it("dashboard kind opens BrowserApp with initialUrl from redirect_url", async () => {

--- a/desktop/src/apps/__tests__/AgentsApp.test.tsx
+++ b/desktop/src/apps/__tests__/AgentsApp.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+// Stub heavy deps first
+vi.mock("@/hooks/use-is-mobile", () => ({ useIsMobile: () => false }));
+vi.mock("@/lib/framework-api", () => ({ fetchLatestFrameworks: async () => ({}) }));
+vi.mock("@/lib/models", () => ({
+  fetchClusterWorkers: async () => [],
+  workersToAggregated: () => [],
+  HOST_BADGE_CLASS: "",
+  CLOUD_PROVIDER_TYPES: [],
+}));
+vi.mock("@/lib/cluster", () => ({
+  availableKvQuantOptions: () => ({ k: ["fp16"], v: ["fp16"], boundary: false, flat: ["fp16"] }),
+}));
+vi.mock("@/lib/agent-emoji", () => ({ resolveAgentEmoji: () => "🤖" }));
+vi.mock("@/components/EmojiPicker", () => ({ EmojiPickerField: () => null }));
+vi.mock("@/components/ModelPickerFlow", () => ({ ModelPickerFlow: () => null }));
+vi.mock("@/components/ModelPickerModal", () => ({ ModelPickerModal: () => null }));
+vi.mock("@/components/persona-picker/PersonaPicker", () => ({ PersonaPicker: () => null }));
+vi.mock("@/lib/slug", () => ({
+  slugifyClient: (s: string) => s,
+  isValidSlug: () => true,
+  SLUG_REGEX: /^[a-z0-9][a-z0-9-]{0,62}$/,
+}));
+vi.mock("@/components/MigrationBanner", () => ({ MigrationBanner: () => null }));
+vi.mock("@/components/agent-settings/PersonaTab", () => ({ PersonaTab: () => null }));
+vi.mock("@/components/agent-settings/MemoryTab", () => ({ MemoryTab: () => null }));
+vi.mock("@/components/agent-settings/FrameworkTab", () => ({ FrameworkTab: () => null }));
+vi.mock("../AgentSkillsPanel", () => ({ AgentSkillsPanel: () => null }));
+vi.mock("../AgentMessagesPanel", () => ({ AgentMessagesPanel: () => null }));
+vi.mock("@/components/ui", () => ({
+  Button: ({ children, onClick, className, ...rest }: React.ButtonHTMLAttributes<HTMLButtonElement> & { children?: React.ReactNode }) => (
+    <button onClick={onClick} className={className} {...rest}>{children}</button>
+  ),
+  Card: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+  Label: ({ children }: { children: React.ReactNode }) => <label>{children}</label>,
+  Tabs: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsList: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsTrigger: ({ children }: { children: React.ReactNode }) => <button>{children}</button>,
+}));
+vi.mock("@/stores/process-store", () => ({
+  useProcessStore: (sel: (s: { openWindow: ReturnType<typeof vi.fn> }) => unknown) =>
+    sel({ openWindow: vi.fn() }),
+}));
+
+// Mock AgentShortcutRow so we can verify it's rendered with the right agentId
+vi.mock("@/components/AgentShortcutRow", () => ({
+  AgentShortcutRow: ({ agentId, onLaunch }: { agentId: string; onLaunch: unknown }) => (
+    <div data-testid={`shortcut-row-${agentId}`} data-has-launch={typeof onLaunch === "function" ? "true" : "false"} />
+  ),
+}));
+
+import { AgentsApp } from "../AgentsApp";
+
+const MOCK_AGENTS = [
+  {
+    name: "agent-alpha",
+    display_name: "Agent Alpha",
+    host: "localhost",
+    color: "#3b82f6",
+    status: "running",
+    vectors: 10,
+    framework: "openclaw",
+    paused: false,
+  },
+  {
+    name: "agent-beta",
+    display_name: "Agent Beta",
+    host: "localhost",
+    color: "#8b5cf6",
+    status: "stopped",
+    vectors: 5,
+    framework: "smolagents",
+    paused: false,
+  },
+];
+
+describe("AgentsApp — AgentShortcutRow wiring (Task 27)", () => {
+  beforeEach(() => {
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url === "/api/agents") {
+        return Promise.resolve({
+          ok: true,
+          headers: { get: () => "application/json" },
+          json: () => Promise.resolve(MOCK_AGENTS),
+        } as unknown as Response);
+      }
+      if (url === "/api/agents/archived") {
+        return Promise.resolve({
+          ok: true,
+          headers: { get: () => "application/json" },
+          json: () => Promise.resolve([]),
+        } as unknown as Response);
+      }
+      return Promise.resolve({
+        ok: false,
+        headers: { get: () => "application/json" },
+        json: () => Promise.resolve({}),
+      } as unknown as Response);
+    });
+  });
+
+  it("renders an AgentShortcutRow for each agent in the list", async () => {
+    render(<AgentsApp windowId="test" />);
+
+    const rowAlpha = await screen.findByTestId("shortcut-row-agent-alpha");
+    expect(rowAlpha).toBeInTheDocument();
+
+    const rowBeta = screen.getByTestId("shortcut-row-agent-beta");
+    expect(rowBeta).toBeInTheDocument();
+  });
+
+  it("passes an onLaunch function to each AgentShortcutRow", async () => {
+    render(<AgentsApp windowId="test" />);
+
+    const rowAlpha = await screen.findByTestId("shortcut-row-agent-alpha");
+    expect(rowAlpha.getAttribute("data-has-launch")).toBe("true");
+
+    const rowBeta = screen.getByTestId("shortcut-row-agent-beta");
+    expect(rowBeta.getAttribute("data-has-launch")).toBe("true");
+  });
+});

--- a/desktop/src/apps/__tests__/AgentsApp.test.tsx
+++ b/desktop/src/apps/__tests__/AgentsApp.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import React from "react";
 
@@ -83,7 +83,7 @@ const MOCK_AGENTS = [
 
 describe("AgentsApp — AgentShortcutRow wiring (Task 27)", () => {
   beforeEach(() => {
-    global.fetch = vi.fn().mockImplementation((url: string) => {
+    vi.stubGlobal("fetch", vi.fn().mockImplementation((url: string) => {
       if (url === "/api/agents") {
         return Promise.resolve({
           ok: true,
@@ -103,7 +103,11 @@ describe("AgentsApp — AgentShortcutRow wiring (Task 27)", () => {
         headers: { get: () => "application/json" },
         json: () => Promise.resolve({}),
       } as unknown as Response);
-    });
+    }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it("renders an AgentShortcutRow for each agent in the list", async () => {

--- a/desktop/src/components/AgentShortcutRow.test.tsx
+++ b/desktop/src/components/AgentShortcutRow.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { AgentShortcutRow } from "./AgentShortcutRow";
+import * as useAgentShortcutsModule from "../hooks/use-agent-shortcuts";
+import * as useIsMobileModule from "../hooks/use-is-mobile";
+
+// AgentsApp is a single file (not a dir), so component is at
+// desktop/src/components/AgentShortcutRow.tsx. Mock paths are one level up.
+vi.mock("../hooks/use-agent-shortcuts");
+vi.mock("../hooks/use-is-mobile");
+
+describe("AgentShortcutRow", () => {
+  beforeEach(() => {
+    vi.mocked(useIsMobileModule.useIsMobile).mockReturnValue(false);
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders null when shortcuts list is empty", () => {
+    vi.mocked(useAgentShortcutsModule.useAgentShortcuts).mockReturnValue({
+      shortcuts: [],
+      loading: false,
+      error: null,
+    });
+    const { container } = render(<AgentShortcutRow agentId="abc" onLaunch={vi.fn()} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders null while loading", () => {
+    vi.mocked(useAgentShortcutsModule.useAgentShortcuts).mockReturnValue({
+      shortcuts: [],
+      loading: true,
+      error: null,
+    });
+    const { container } = render(<AgentShortcutRow agentId="abc" onLaunch={vi.fn()} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders N buttons with correct aria-labels on wide viewport", () => {
+    vi.mocked(useIsMobileModule.useIsMobile).mockReturnValue(false);
+    vi.mocked(useAgentShortcutsModule.useAgentShortcuts).mockReturnValue({
+      shortcuts: [
+        { idx: 0, label: "Container shell", icon: "terminal", kind: "container-terminal", requires_capability: "agent.shell" },
+        { idx: 1, label: "OpenClaw agent", icon: "tui", kind: "tui", requires_capability: "agent.terminal" },
+      ],
+      loading: false,
+      error: null,
+    });
+    render(<AgentShortcutRow agentId="abc" onLaunch={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "Container shell" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "OpenClaw agent" })).toBeInTheDocument();
+  });
+
+  it("renders icon-only buttons on narrow (mobile) viewport", () => {
+    vi.mocked(useIsMobileModule.useIsMobile).mockReturnValue(true);
+    vi.mocked(useAgentShortcutsModule.useAgentShortcuts).mockReturnValue({
+      shortcuts: [
+        { idx: 0, label: "Container shell", icon: "terminal", kind: "container-terminal", requires_capability: "agent.shell" },
+      ],
+      loading: false,
+      error: null,
+    });
+    render(<AgentShortcutRow agentId="abc" onLaunch={vi.fn()} />);
+    const btn = screen.getByRole("button", { name: "Container shell" });
+    expect(btn).toBeInTheDocument();
+    expect(btn.querySelector("[data-label]")).toBeNull();
+  });
+
+  it("calls onLaunch with agentId and shortcut idx when button is clicked", async () => {
+    const onLaunch = vi.fn();
+    vi.mocked(useAgentShortcutsModule.useAgentShortcuts).mockReturnValue({
+      shortcuts: [
+        { idx: 2, label: "Web dashboard", icon: "dashboard", kind: "dashboard", requires_capability: "agent.dashboard" },
+      ],
+      loading: false,
+      error: null,
+    });
+    const { getByRole } = render(<AgentShortcutRow agentId="xyz" onLaunch={onLaunch} />);
+    getByRole("button", { name: "Web dashboard" }).click();
+    expect(onLaunch).toHaveBeenCalledWith("xyz", 2);
+  });
+});

--- a/desktop/src/components/AgentShortcutRow.test.tsx
+++ b/desktop/src/components/AgentShortcutRow.test.tsx
@@ -67,17 +67,16 @@ describe("AgentShortcutRow", () => {
     expect(btn.querySelector("[data-label]")).toBeNull();
   });
 
-  it("calls onLaunch with agentId and shortcut idx when button is clicked", async () => {
+  it("calls onLaunch with agentId and the full shortcut object when button is clicked", async () => {
     const onLaunch = vi.fn();
+    const shortcut = { idx: 2, label: "Web dashboard", icon: "dashboard", kind: "dashboard" as const, requires_capability: "agent.dashboard" };
     vi.mocked(useAgentShortcutsModule.useAgentShortcuts).mockReturnValue({
-      shortcuts: [
-        { idx: 2, label: "Web dashboard", icon: "dashboard", kind: "dashboard", requires_capability: "agent.dashboard" },
-      ],
+      shortcuts: [shortcut],
       loading: false,
       error: null,
     });
     const { getByRole } = render(<AgentShortcutRow agentId="xyz" onLaunch={onLaunch} />);
     getByRole("button", { name: "Web dashboard" }).click();
-    expect(onLaunch).toHaveBeenCalledWith("xyz", 2);
+    expect(onLaunch).toHaveBeenCalledWith("xyz", shortcut);
   });
 });

--- a/desktop/src/components/AgentShortcutRow.tsx
+++ b/desktop/src/components/AgentShortcutRow.tsx
@@ -1,0 +1,46 @@
+import { useAgentShortcuts } from "../hooks/use-agent-shortcuts";
+import { useIsMobile } from "../hooks/use-is-mobile";
+
+const ICON_GLYPHS: Record<string, string> = {
+  terminal: "⌨",
+  tui: "▣",
+  dashboard: "⊞",
+  diagnostic: "⚕",
+};
+
+interface AgentShortcutRowProps {
+  agentId: string;
+  onLaunch: (agentId: string, idx: number) => void;
+}
+
+export function AgentShortcutRow({ agentId, onLaunch }: AgentShortcutRowProps) {
+  const { shortcuts, loading } = useAgentShortcuts(agentId);
+  const isMobile = useIsMobile();
+
+  if (loading || shortcuts.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="agent-shortcut-row" role="group" aria-label="Agent shortcuts">
+      {shortcuts.map((shortcut) => {
+        const glyph = ICON_GLYPHS[shortcut.icon] ?? "▶";
+        return (
+          <button
+            key={shortcut.idx}
+            type="button"
+            aria-label={shortcut.label}
+            title={shortcut.label}
+            className="agent-shortcut-btn"
+            onClick={() => onLaunch(agentId, shortcut.idx)}
+          >
+            <span className="agent-shortcut-icon" aria-hidden="true">{glyph}</span>
+            {!isMobile && (
+              <span className="agent-shortcut-label" data-label="true">{shortcut.label}</span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/desktop/src/components/AgentShortcutRow.tsx
+++ b/desktop/src/components/AgentShortcutRow.tsx
@@ -1,4 +1,4 @@
-import { useAgentShortcuts } from "../hooks/use-agent-shortcuts";
+import { useAgentShortcuts, type AgentShortcut } from "../hooks/use-agent-shortcuts";
 import { useIsMobile } from "../hooks/use-is-mobile";
 
 const ICON_GLYPHS: Record<string, string> = {
@@ -10,7 +10,7 @@ const ICON_GLYPHS: Record<string, string> = {
 
 interface AgentShortcutRowProps {
   agentId: string;
-  onLaunch: (agentId: string, idx: number) => void;
+  onLaunch: (agentId: string, shortcut: AgentShortcut) => void;
 }
 
 export function AgentShortcutRow({ agentId, onLaunch }: AgentShortcutRowProps) {
@@ -32,7 +32,7 @@ export function AgentShortcutRow({ agentId, onLaunch }: AgentShortcutRowProps) {
             aria-label={shortcut.label}
             title={shortcut.label}
             className="agent-shortcut-btn"
-            onClick={() => onLaunch(agentId, shortcut.idx)}
+            onClick={() => onLaunch(agentId, shortcut)}
           >
             <span className="agent-shortcut-icon" aria-hidden="true">{glyph}</span>
             {!isMobile && (

--- a/desktop/src/hooks/use-agent-shortcuts.test.ts
+++ b/desktop/src/hooks/use-agent-shortcuts.test.ts
@@ -1,0 +1,54 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { useAgentShortcuts } from "./use-agent-shortcuts";
+
+describe("useAgentShortcuts", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("calls the correct endpoint and returns parsed shortcuts", async () => {
+    const mockShortcuts = [
+      { idx: 0, label: "Container shell", icon: "terminal", kind: "container-terminal", requires_capability: "agent.shell" },
+      { idx: 1, label: "OpenClaw agent", icon: "tui", kind: "tui", requires_capability: "agent.terminal" },
+    ];
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockShortcuts,
+    });
+
+    const { result } = renderHook(() => useAgentShortcuts("abc123"));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(fetch).toHaveBeenCalledWith("/api/agents/abc123/shortcuts");
+    expect(result.current.shortcuts).toEqual(mockShortcuts);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("surfaces errors when fetch fails", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      statusText: "Forbidden",
+    });
+
+    const { result } = renderHook(() => useAgentShortcuts("agent-x"));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.shortcuts).toEqual([]);
+    expect(result.current.error).toMatch(/403/);
+  });
+
+  it("surfaces network errors", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("Network error"));
+
+    const { result } = renderHook(() => useAgentShortcuts("agent-y"));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.shortcuts).toEqual([]);
+    expect(result.current.error).toBe("Network error");
+  });
+});

--- a/desktop/src/hooks/use-agent-shortcuts.ts
+++ b/desktop/src/hooks/use-agent-shortcuts.ts
@@ -1,0 +1,57 @@
+import { useState, useEffect } from "react";
+
+export interface AgentShortcut {
+  idx: number;
+  label: string;
+  icon: string;
+  kind: "container-terminal" | "tui" | "dashboard";
+  requires_capability: string;
+  command?: string;
+  port?: number;
+  path?: string;
+}
+
+interface UseAgentShortcutsResult {
+  shortcuts: AgentShortcut[];
+  loading: boolean;
+  error: string | null;
+}
+
+export function useAgentShortcuts(agentId: string): UseAgentShortcutsResult {
+  const [shortcuts, setShortcuts] = useState<AgentShortcut[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    fetch(`/api/agents/${agentId}/shortcuts`)
+      .then(async (res) => {
+        if (!res.ok) {
+          throw new Error(`${res.status} ${res.statusText}`);
+        }
+        return res.json() as Promise<AgentShortcut[]>;
+      })
+      .then((data) => {
+        if (!cancelled) {
+          setShortcuts(data);
+          setLoading(false);
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err));
+          setShortcuts([]);
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [agentId]);
+
+  return { shortcuts, loading, error };
+}

--- a/desktop/tests/agent-shortcuts.spec.ts
+++ b/desktop/tests/agent-shortcuts.spec.ts
@@ -1,0 +1,133 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// Uses the iphone-14 project defined in playwright.config.ts
+// Run with: cd desktop && npx playwright test --project=iphone-14 agent-shortcuts.spec.ts
+
+async function openAgentsApp(page: Page): Promise<boolean> {
+  // Try to navigate and open the AgentsApp. Returns false if it can't be opened
+  // (no backend, no Agents button, etc.) so the test can skip gracefully.
+  await page.goto("/desktop/").catch(() => {});
+
+  // Sign-in fallback (mobile bypasses login on touch devices, but be defensive).
+  const loginVisible = await page
+    .getByRole("button", { name: /sign in|login/i })
+    .isVisible()
+    .catch(() => false);
+  if (loginVisible) {
+    await page.getByLabel(/username|email/i).fill("dev").catch(() => {});
+    await page.getByLabel(/password/i).fill("dev").catch(() => {});
+    await page.getByRole("button", { name: /sign in|login/i }).click().catch(() => {});
+  }
+
+  // Agents is pinned in the dock — try the dock button first.
+  const directBtn = page.getByRole("button", { name: /^agents$/i });
+  if (await directBtn.isVisible().catch(() => false)) {
+    await directBtn.click();
+    return true;
+  }
+
+  // Fall back to Launchpad ("All Apps" dock button → aria-label="Open Agents").
+  const launchpad = page.getByRole("button", { name: /all apps/i });
+  if (await launchpad.isVisible().catch(() => false)) {
+    await launchpad.click();
+    const openAgents = page.getByRole("button", { name: /open agents/i });
+    if (await openAgents.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await openAgents.click();
+      return true;
+    }
+  }
+
+  return false;
+}
+
+test.describe("Agent shortcuts @iphone-14", () => {
+  test("shortcut row appears on agent card when shortcuts available", async ({ page }) => {
+    const opened = await openAgentsApp(page);
+    if (!opened) {
+      test.skip(true, "AgentsApp not openable in this run (no agents app launcher visible)");
+      return;
+    }
+
+    // Wait briefly for agents to render and shortcut fetches to resolve.
+    await page.waitForTimeout(1500);
+
+    const shortcutRow = page.locator(".agent-shortcut-row").first();
+    const visible = await shortcutRow.isVisible().catch(() => false);
+    if (!visible) {
+      test.skip(true, "No agents with shortcuts in this seed (backend unavailable or no agents)");
+      return;
+    }
+    await expect(shortcutRow).toBeVisible();
+  });
+
+  test("clicking a terminal shortcut opens TerminalApp with shortcut status indicator", async ({ page }) => {
+    const opened = await openAgentsApp(page);
+    if (!opened) {
+      test.skip(true, "AgentsApp not openable");
+      return;
+    }
+    await page.waitForTimeout(1500);
+
+    // Shortcut buttons use aria-label={shortcut.label}; pick any container-terminal shortcut.
+    // Common label patterns: "Container shell", "Shell", "Terminal".
+    const shellBtn = page
+      .locator(".agent-shortcut-btn")
+      .filter({ has: page.locator('[aria-label*="shell" i], [aria-label*="terminal" i]') })
+      .first();
+
+    if (!(await shellBtn.isVisible().catch(() => false))) {
+      test.skip(true, "No terminal/shell shortcut available in this seed");
+      return;
+    }
+
+    await shellBtn.tap();
+
+    // TerminalApp opened via shortcut renders: <span>Connecting to shortcut…</span>
+    await expect(page.getByText("Connecting to shortcut…")).toBeVisible({ timeout: 8000 });
+  });
+
+  test("clicking a dashboard shortcut opens BrowserApp iframe", async ({ page }) => {
+    const opened = await openAgentsApp(page);
+    if (!opened) {
+      test.skip(true, "AgentsApp not openable");
+      return;
+    }
+    await page.waitForTimeout(1500);
+
+    // Dashboard shortcuts have kind="dashboard" — they open BrowserApp.
+    // Common label patterns: "Gateway dashboard", "Dashboard", "Web UI".
+    const dashBtn = page
+      .locator(".agent-shortcut-btn")
+      .filter({ has: page.locator('[aria-label*="dashboard" i], [aria-label*="gateway" i]') })
+      .first();
+
+    if (!(await dashBtn.isVisible().catch(() => false))) {
+      test.skip(true, "No dashboard shortcut available (likely no openclaw agent in this seed)");
+      return;
+    }
+
+    await dashBtn.tap();
+
+    // BrowserApp mounts an <iframe> for the target URL.
+    await expect(page.locator("iframe").first()).toBeAttached({ timeout: 8000 });
+  });
+
+  test("backend-down: shortcut fetch error renders no shortcut buttons", async ({ page }) => {
+    // Intercept the shortcuts list API and return 503 so useAgentShortcuts returns [].
+    await page.route("**/api/agents/*/shortcuts", (route) =>
+      route.fulfill({ status: 503, body: "Service Unavailable" }),
+    );
+
+    const opened = await openAgentsApp(page);
+    if (!opened) {
+      test.skip(true, "AgentsApp not openable");
+      return;
+    }
+    await page.waitForTimeout(1500);
+
+    // AgentShortcutRow returns null when shortcuts.length === 0,
+    // so no .agent-shortcut-btn elements should be present.
+    const shortcutBtns = page.locator(".agent-shortcut-btn");
+    await expect(shortcutBtns).toHaveCount(0);
+  });
+});

--- a/desktop/tests/agent-shortcuts.spec.ts
+++ b/desktop/tests/agent-shortcuts.spec.ts
@@ -70,9 +70,10 @@ test.describe("Agent shortcuts @iphone-14", () => {
 
     // Shortcut buttons use aria-label={shortcut.label}; pick any container-terminal shortcut.
     // Common label patterns: "Container shell", "Shell", "Terminal".
+    // Use CSS attribute selector on the button itself: filter({has}) only matches descendants,
+    // not the element's own aria-label attribute.
     const shellBtn = page
-      .locator(".agent-shortcut-btn")
-      .filter({ has: page.locator('[aria-label*="shell" i], [aria-label*="terminal" i]') })
+      .locator('.agent-shortcut-btn[aria-label*="shell" i], .agent-shortcut-btn[aria-label*="terminal" i]')
       .first();
 
     if (!(await shellBtn.isVisible().catch(() => false))) {
@@ -97,8 +98,7 @@ test.describe("Agent shortcuts @iphone-14", () => {
     // Dashboard shortcuts have kind="dashboard" — they open BrowserApp.
     // Common label patterns: "Gateway dashboard", "Dashboard", "Web UI".
     const dashBtn = page
-      .locator(".agent-shortcut-btn")
-      .filter({ has: page.locator('[aria-label*="dashboard" i], [aria-label*="gateway" i]') })
+      .locator('.agent-shortcut-btn[aria-label*="dashboard" i], .agent-shortcut-btn[aria-label*="gateway" i]')
       .first();
 
     if (!(await dashBtn.isVisible().catch(() => false))) {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ dependencies = [
     "libtorrent>=2.0.9",
     # Memory system — standalone package, pulled from GitHub
     "taosmd @ git+https://github.com/jaylfc/taosmd.git@master",
+    # WebSocket client for dashboard proxy (shortcut_proxy.py)
+    "websockets>=12.0",
 ]
 
 [project.optional-dependencies]
@@ -32,6 +34,8 @@ dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23.0",
     "httpx",
+    "respx>=0.21.0",
+    "websockets>=12.0",
 ]
 e2e = [
     "pytest>=8.0",

--- a/tests/cluster/test_local_worker_enroll.py
+++ b/tests/cluster/test_local_worker_enroll.py
@@ -41,21 +41,25 @@ class TestEnrollLocalWorker:
         import tinyagentos.cluster.local_worker as lw
         from tinyagentos.cluster.local_worker import enroll_local_worker
 
-        # Reset the module key so each manager gets a freshly generated key.
-        lw._LOCAL_SIGNING_KEY = None
-        mgr1 = ClusterManager()
-        asyncio.run(enroll_local_worker(mgr1))
-        key1 = mgr1.get_worker("local").signing_key
+        original_key = lw._LOCAL_SIGNING_KEY
+        try:
+            # Reset the module key so each manager gets a freshly generated key.
+            lw._LOCAL_SIGNING_KEY = None
+            mgr1 = ClusterManager()
+            asyncio.run(enroll_local_worker(mgr1))
+            key1 = mgr1.get_worker("local").signing_key
 
-        lw._LOCAL_SIGNING_KEY = None
-        mgr2 = ClusterManager()
-        asyncio.run(enroll_local_worker(mgr2))
-        key2 = mgr2.get_worker("local").signing_key
+            lw._LOCAL_SIGNING_KEY = None
+            mgr2 = ClusterManager()
+            asyncio.run(enroll_local_worker(mgr2))
+            key2 = mgr2.get_worker("local").signing_key
 
-        # 32 random bytes — should almost certainly differ across independent runs
-        assert len(key1) == 32
-        assert len(key2) == 32
-        assert key1 != key2
+            # 32 random bytes — should almost certainly differ across independent runs
+            assert len(key1) == 32
+            assert len(key2) == 32
+            assert key1 != key2
+        finally:
+            lw._LOCAL_SIGNING_KEY = original_key
 
     def test_enroll_signing_key_is_bytes(self):
         from tinyagentos.cluster.local_worker import enroll_local_worker

--- a/tests/cluster/test_local_worker_enroll.py
+++ b/tests/cluster/test_local_worker_enroll.py
@@ -1,0 +1,104 @@
+"""Task 23: Tests for enroll_local_worker + worker_registry bridge."""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from tinyagentos.cluster.manager import ClusterManager
+
+
+class TestEnrollLocalWorker:
+    """enroll_local_worker registers a 'local' worker in the ClusterManager."""
+
+    def test_enroll_creates_local_worker(self):
+        from tinyagentos.cluster.local_worker import enroll_local_worker
+
+        mgr = ClusterManager()
+        asyncio.run(enroll_local_worker(mgr))
+        worker = mgr.get_worker("local")
+        assert worker is not None
+        assert worker.name == "local"
+
+    def test_enroll_sets_worker_url(self):
+        from tinyagentos.cluster.local_worker import enroll_local_worker
+
+        mgr = ClusterManager()
+        asyncio.run(enroll_local_worker(mgr, bind_port=7777))
+        worker = mgr.get_worker("local")
+        assert worker.worker_url == "http://127.0.0.1:7777"
+
+    def test_enroll_default_port_is_6969(self):
+        from tinyagentos.cluster.local_worker import enroll_local_worker
+
+        mgr = ClusterManager()
+        asyncio.run(enroll_local_worker(mgr))
+        worker = mgr.get_worker("local")
+        assert worker.worker_url == "http://127.0.0.1:6969"
+
+    def test_enroll_generates_random_signing_key(self):
+        from tinyagentos.cluster.local_worker import enroll_local_worker
+
+        mgr1 = ClusterManager()
+        mgr2 = ClusterManager()
+        asyncio.run(enroll_local_worker(mgr1))
+        asyncio.run(enroll_local_worker(mgr2))
+        key1 = mgr1.get_worker("local").signing_key
+        key2 = mgr2.get_worker("local").signing_key
+        # 32 random bytes — should almost certainly differ across runs
+        assert len(key1) == 32
+        assert len(key2) == 32
+        assert key1 != key2
+
+    def test_enroll_signing_key_is_bytes(self):
+        from tinyagentos.cluster.local_worker import enroll_local_worker
+
+        mgr = ClusterManager()
+        asyncio.run(enroll_local_worker(mgr))
+        key = mgr.get_worker("local").signing_key
+        assert isinstance(key, bytes)
+
+
+class TestWorkerRegistryBridge:
+    """get_local_worker falls back to stub when no manager is active."""
+
+    def test_fallback_returns_dict_with_required_keys(self):
+        import tinyagentos.cluster.worker_registry as wr
+
+        # Reset active manager to ensure fallback path
+        original = wr._active_manager
+        wr._active_manager = None
+        try:
+            result = wr.get_local_worker()
+            assert "worker_url" in result
+            assert "signing_key" in result
+            assert "name" in result
+        finally:
+            wr._active_manager = original
+
+    def test_fallback_name_is_local(self):
+        import tinyagentos.cluster.worker_registry as wr
+
+        original = wr._active_manager
+        wr._active_manager = None
+        try:
+            result = wr.get_local_worker()
+            assert result["name"] == "local"
+        finally:
+            wr._active_manager = original
+
+    def test_set_active_manager_makes_get_local_worker_use_manager(self):
+        import tinyagentos.cluster.worker_registry as wr
+        from tinyagentos.cluster.local_worker import enroll_local_worker
+
+        mgr = ClusterManager()
+        asyncio.run(enroll_local_worker(mgr, bind_port=6969))
+        original = wr._active_manager
+        wr.set_active_manager(mgr)
+        try:
+            result = wr.get_local_worker()
+            worker = mgr.get_worker("local")
+            assert result["signing_key"] == worker.signing_key
+            assert result["name"] == "local"
+        finally:
+            wr._active_manager = original

--- a/tests/cluster/test_local_worker_enroll.py
+++ b/tests/cluster/test_local_worker_enroll.py
@@ -37,15 +37,21 @@ class TestEnrollLocalWorker:
         assert worker.worker_url == "http://127.0.0.1:6969"
 
     def test_enroll_generates_random_signing_key(self):
+        import tinyagentos.cluster.local_worker as lw
         from tinyagentos.cluster.local_worker import enroll_local_worker
 
+        # Reset the module key so each manager gets a freshly generated key.
+        lw._LOCAL_SIGNING_KEY = None
         mgr1 = ClusterManager()
-        mgr2 = ClusterManager()
         asyncio.run(enroll_local_worker(mgr1))
-        asyncio.run(enroll_local_worker(mgr2))
         key1 = mgr1.get_worker("local").signing_key
+
+        lw._LOCAL_SIGNING_KEY = None
+        mgr2 = ClusterManager()
+        asyncio.run(enroll_local_worker(mgr2))
         key2 = mgr2.get_worker("local").signing_key
-        # 32 random bytes — should almost certainly differ across runs
+
+        # 32 random bytes — should almost certainly differ across independent runs
         assert len(key1) == 32
         assert len(key2) == 32
         assert key1 != key2
@@ -57,6 +63,19 @@ class TestEnrollLocalWorker:
         asyncio.run(enroll_local_worker(mgr))
         key = mgr.get_worker("local").signing_key
         assert isinstance(key, bytes)
+
+    def test_enroll_is_idempotent_same_manager(self):
+        """Calling twice on the same manager keeps the same signing_key."""
+        from tinyagentos.cluster.local_worker import enroll_local_worker
+
+        mgr = ClusterManager()
+        asyncio.run(enroll_local_worker(mgr))
+        first_key = mgr.get_worker("local").signing_key
+
+        asyncio.run(enroll_local_worker(mgr))
+        second_key = mgr.get_worker("local").signing_key
+
+        assert first_key == second_key  # idempotent: key stable across calls
 
 
 class TestWorkerRegistryBridge:

--- a/tests/cluster/test_local_worker_enroll.py
+++ b/tests/cluster/test_local_worker_enroll.py
@@ -8,6 +8,7 @@ import pytest
 from tinyagentos.cluster.manager import ClusterManager
 
 
+
 class TestEnrollLocalWorker:
     """enroll_local_worker registers a 'local' worker in the ClusterManager."""
 
@@ -79,30 +80,29 @@ class TestEnrollLocalWorker:
 
 
 class TestWorkerRegistryBridge:
-    """get_local_worker falls back to stub when no manager is active."""
+    """get_local_worker raises RuntimeError when no manager is active (fail closed)."""
 
-    def test_fallback_returns_dict_with_required_keys(self):
+    def test_no_manager_raises_runtime_error(self):
         import tinyagentos.cluster.worker_registry as wr
 
-        # Reset active manager to ensure fallback path
+        # Reset active manager to verify fail-closed behaviour
         original = wr._active_manager
         wr._active_manager = None
         try:
-            result = wr.get_local_worker()
-            assert "worker_url" in result
-            assert "signing_key" in result
-            assert "name" in result
+            with pytest.raises(RuntimeError, match="No active ClusterManager"):
+                wr.get_local_worker()
         finally:
             wr._active_manager = original
 
-    def test_fallback_name_is_local(self):
+    def test_manager_without_local_worker_raises_runtime_error(self):
         import tinyagentos.cluster.worker_registry as wr
 
         original = wr._active_manager
-        wr._active_manager = None
+        empty_mgr = ClusterManager()
+        wr.set_active_manager(empty_mgr)
         try:
-            result = wr.get_local_worker()
-            assert result["name"] == "local"
+            with pytest.raises(RuntimeError, match="Local worker not registered"):
+                wr.get_local_worker()
         finally:
             wr._active_manager = original
 

--- a/tests/cluster/test_worker_registration.py
+++ b/tests/cluster/test_worker_registration.py
@@ -1,0 +1,88 @@
+"""Task 22: Tests for extended WorkerInfo fields + ClusterManager.get_worker."""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import asdict
+
+import pytest
+
+from tinyagentos.cluster.worker_protocol import WorkerInfo
+from tinyagentos.cluster.manager import ClusterManager
+
+
+class TestWorkerInfoNewFields:
+    """WorkerInfo should carry worker_url, signing_key, and tls_cert_provider."""
+
+    def test_worker_url_defaults_to_none(self):
+        w = WorkerInfo(name="w", url="http://localhost:9000")
+        assert w.worker_url is None
+
+    def test_signing_key_defaults_to_empty_bytes(self):
+        w = WorkerInfo(name="w", url="http://localhost:9000")
+        assert isinstance(w.signing_key, bytes)
+        assert w.signing_key == b""
+
+    def test_tls_cert_provider_defaults_to_none(self):
+        w = WorkerInfo(name="w", url="http://localhost:9000")
+        assert w.tls_cert_provider is None
+
+    def test_can_set_worker_url(self):
+        w = WorkerInfo(name="w", url="http://localhost:9000", worker_url="http://10.0.0.1:6969")
+        assert w.worker_url == "http://10.0.0.1:6969"
+
+    def test_can_set_signing_key(self):
+        key = b"\x01" * 32
+        w = WorkerInfo(name="w", url="http://localhost:9000", signing_key=key)
+        assert w.signing_key == key
+
+    def test_can_set_tls_cert_provider(self):
+        w = WorkerInfo(name="w", url="http://localhost:9000", tls_cert_provider="letsencrypt")
+        assert w.tls_cert_provider == "letsencrypt"
+
+    def test_new_fields_serialise_via_asdict(self):
+        key = b"\xab" * 32
+        w = WorkerInfo(
+            name="w",
+            url="http://localhost:9000",
+            worker_url="http://10.0.0.1:6969",
+            signing_key=key,
+            tls_cert_provider="letsencrypt",
+        )
+        d = asdict(w)
+        assert d["worker_url"] == "http://10.0.0.1:6969"
+        assert d["signing_key"] == key
+        assert d["tls_cert_provider"] == "letsencrypt"
+
+
+class TestClusterManagerGetWorker:
+    """ClusterManager.get_worker should return the named worker or None."""
+
+    def test_get_worker_returns_none_when_empty(self):
+        mgr = ClusterManager()
+        assert mgr.get_worker("nonexistent") is None
+
+    def test_get_worker_returns_worker_after_register(self):
+        mgr = ClusterManager()
+        w = WorkerInfo(name="myworker", url="http://localhost:9001")
+        asyncio.run(mgr.register_worker(w))
+        result = mgr.get_worker("myworker")
+        assert result is not None
+        assert result.name == "myworker"
+
+    def test_get_worker_returns_correct_instance(self):
+        mgr = ClusterManager()
+        w1 = WorkerInfo(name="alpha", url="http://localhost:9001")
+        w2 = WorkerInfo(name="beta", url="http://localhost:9002")
+        asyncio.run(mgr.register_worker(w1))
+        asyncio.run(mgr.register_worker(w2))
+        assert mgr.get_worker("alpha").name == "alpha"
+        assert mgr.get_worker("beta").name == "beta"
+        assert mgr.get_worker("gamma") is None
+
+    def test_get_worker_sees_signing_key(self):
+        key = b"\x42" * 32
+        mgr = ClusterManager()
+        w = WorkerInfo(name="local", url="http://127.0.0.1:6969", signing_key=key)
+        asyncio.run(mgr.register_worker(w))
+        found = mgr.get_worker("local")
+        assert found.signing_key == key

--- a/tests/containers/test_lxc_pty.py
+++ b/tests/containers/test_lxc_pty.py
@@ -1,0 +1,70 @@
+"""
+Unit tests verify the incus command shape. Integration test skipped when incus absent.
+"""
+import shutil
+import pytest
+from unittest.mock import MagicMock
+
+from tinyagentos.containers.lxc import LXCBackend
+
+
+def test_spawn_pty_command_no_cmd(monkeypatch):
+    """spawn_pty with cmd=None must use default shell via incus."""
+    launched_cmds = []
+
+    class FakePty:
+        def __init__(self, args, **kwargs):
+            launched_cmds.append(args)
+        def read(self, size=4096): return b""
+        def write(self, data): pass
+        def resize(self, rows, cols): pass
+        def close(self): pass
+
+    monkeypatch.setattr(
+        "tinyagentos.containers.lxc._open_incus_pty", lambda *a, **k: FakePty(a)
+    )
+    backend = LXCBackend()
+    backend.spawn_pty("myagent", cmd=None)
+    assert len(launched_cmds) == 1
+    cmd_args = launched_cmds[0]
+    assert "taos-agent-myagent" in str(cmd_args)
+    assert "bash" in str(cmd_args)
+
+
+def test_spawn_pty_command_with_cmd(monkeypatch):
+    """spawn_pty with a command must embed that command in the incus call."""
+    launched_cmds = []
+
+    class FakePty:
+        def __init__(self, args, **kwargs):
+            launched_cmds.append(args)
+        def read(self, size=4096): return b""
+        def write(self, data): pass
+        def resize(self, rows, cols): pass
+        def close(self): pass
+
+    monkeypatch.setattr(
+        "tinyagentos.containers.lxc._open_incus_pty", lambda *a, **k: FakePty(a)
+    )
+    backend = LXCBackend()
+    backend.spawn_pty("myagent", cmd=["openclaw", "agent"])
+    cmd_args = launched_cmds[0]
+    assert "openclaw" in str(cmd_args)
+
+
+@pytest.mark.skipif(
+    shutil.which("incus") is None, reason="incus not installed on this host"
+)
+def test_spawn_pty_integration():
+    """Real integration test — requires a running container taos-agent-test-pty."""
+    backend = LXCBackend()
+    try:
+        handle = backend.spawn_pty("test-pty", cmd=None)
+        handle.write(b"echo hello-from-pty\n")
+        import time
+        time.sleep(0.2)
+        output = handle.read(4096)
+        handle.close()
+        assert b"hello-from-pty" in output
+    except Exception as exc:
+        pytest.skip(f"Container taos-agent-test-pty not available: {exc}")

--- a/tests/containers/test_pty_abstract.py
+++ b/tests/containers/test_pty_abstract.py
@@ -1,0 +1,23 @@
+import pytest
+from tinyagentos.containers.backend import ContainerBackend, PtyHandle
+
+
+def test_pty_handle_has_expected_interface():
+    """PtyHandle must expose read, write, resize, and close."""
+    methods = {"read", "write", "resize", "close"}
+    for method in methods:
+        assert hasattr(PtyHandle, method), f"PtyHandle missing method: {method}"
+
+
+def test_container_backend_spawn_pty_is_abstract():
+    """ContainerBackend.spawn_pty must be abstract."""
+    import inspect
+    assert inspect.isabstract(ContainerBackend) or "spawn_pty" in getattr(
+        ContainerBackend, "__abstractmethods__", set()
+    )
+
+
+def test_pty_handle_is_abstract():
+    """PtyHandle itself must be abstract."""
+    with pytest.raises(TypeError):
+        PtyHandle()

--- a/tests/containers/test_pty_stubs.py
+++ b/tests/containers/test_pty_stubs.py
@@ -1,0 +1,18 @@
+import pytest
+
+
+def test_docker_spawn_pty_raises_not_implemented():
+    from tinyagentos.containers.docker import DockerBackend
+    backend = DockerBackend()
+    with pytest.raises(NotImplementedError, match="docker spawn_pty not yet implemented"):
+        backend.spawn_pty("any-agent")
+
+
+def test_apple_spawn_pty_raises_not_implemented():
+    try:
+        from tinyagentos.containers.apple_backend import AppleContainerBackend
+    except ImportError:
+        pytest.skip("apple_backend not present on this platform")
+    backend = AppleContainerBackend()
+    with pytest.raises(NotImplementedError):
+        backend.spawn_pty("any-agent")

--- a/tests/routes/conftest.py
+++ b/tests/routes/conftest.py
@@ -145,13 +145,23 @@ def seeded_agent_factory(app, monkeypatch):
 
 @pytest.fixture
 def patch_worker_signing_key(monkeypatch):
-    """Inject the test signing key used in redeem tests.
+    """Inject a test ClusterManager with a known signing key for redeem tests.
 
-    Patches _FALLBACK_SIGNING_KEY and clears _active_manager so get_local_worker()
-    uses the fallback path (no enrolled worker) and returns the test key.
+    Sets up a real ClusterManager with a 'local' worker enrolled using the
+    test signing key, then calls set_active_manager so get_local_worker()
+    returns the test key (fail-closed registry, no fallback).
     """
     import tinyagentos.cluster.worker_registry as wr_mod
+    from tinyagentos.cluster.manager import ClusterManager
+    from tinyagentos.cluster.worker_protocol import WorkerInfo
 
-    monkeypatch.setattr(wr_mod, "_FALLBACK_SIGNING_KEY", b"test-signing-key-32-bytes-padded")
-    monkeypatch.setattr(wr_mod, "_active_manager", None)
+    test_mgr = ClusterManager()
+    test_mgr._workers["local"] = WorkerInfo(
+        name="local",
+        url="http://127.0.0.1:6969",
+        worker_url="http://127.0.0.1:6969",
+        signing_key=b"test-signing-key-32-bytes-padded",
+        platform="local",
+    )
+    monkeypatch.setattr(wr_mod, "_active_manager", test_mgr)
     yield

--- a/tests/routes/conftest.py
+++ b/tests/routes/conftest.py
@@ -145,8 +145,13 @@ def seeded_agent_factory(app, monkeypatch):
 
 @pytest.fixture
 def patch_worker_signing_key(monkeypatch):
-    """Replace _LOCAL_SIGNING_KEY with the test key used in redeem tests."""
+    """Inject the test signing key used in redeem tests.
+
+    Patches _FALLBACK_SIGNING_KEY and clears _active_manager so get_local_worker()
+    uses the fallback path (no enrolled worker) and returns the test key.
+    """
     import tinyagentos.cluster.worker_registry as wr_mod
 
-    monkeypatch.setattr(wr_mod, "_LOCAL_SIGNING_KEY", b"test-signing-key-32-bytes-padded")
+    monkeypatch.setattr(wr_mod, "_FALLBACK_SIGNING_KEY", b"test-signing-key-32-bytes-padded")
+    monkeypatch.setattr(wr_mod, "_active_manager", None)
     yield

--- a/tests/routes/conftest.py
+++ b/tests/routes/conftest.py
@@ -1,0 +1,152 @@
+"""Shared fixtures for tests/routes/ — sync TestClient + auth header helpers."""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+import yaml
+from fastapi.testclient import TestClient
+
+from tinyagentos.app import create_app
+from tinyagentos.shortcuts.capabilities import CAP_AGENT_SHELL
+
+
+def _make_app(tmp_path):
+    config = {
+        "server": {"host": "0.0.0.0", "port": 6969},
+        "backends": [],
+        "qmd": {"url": "http://localhost:7832"},
+        "agents": [],
+        "metrics": {"poll_interval": 30, "retention_days": 30},
+    }
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.dump(config))
+    (tmp_path / ".setup_complete").touch()
+    return create_app(data_dir=tmp_path)
+
+
+@pytest.fixture
+def app(tmp_path):
+    """Minimal taOS app with no agents, used by all routes/ tests."""
+    return _make_app(tmp_path)
+
+
+@pytest.fixture
+def test_client(app):
+    """Synchronous TestClient; auth is via Cookie header (taos_session)."""
+    # The app must be initialised enough for auth to work.  create_app sets up
+    # app.state.auth eagerly, so this is fine without running lifespan.
+    with TestClient(app, raise_server_exceptions=True) as client:
+        yield client
+
+
+def _create_user_with_caps(auth_mgr, username: str, caps: list[str]) -> str:
+    """Create a user with a specific capability set and return a session token."""
+    # First user is always admin; extra users go through the invite flow.
+    if not auth_mgr.is_configured():
+        auth_mgr.setup_user("admin", "Admin", "", "adminpass")
+
+    # Invite + complete
+    invite_code = auth_mgr.add_user_invite(username, "admin")
+    auth_mgr.complete_invite(username, invite_code, username, "", "testpass1")
+
+    # Overwrite capabilities directly on the stored record
+    data = auth_mgr._read_users()
+    for u in data["users"]:
+        if u.get("username") == username:
+            u["capabilities"] = list(caps)
+            break
+    auth_mgr._write_users(data)
+
+    record = auth_mgr.find_user(username)
+    token = auth_mgr.create_session(user_id=record["id"], long_lived=True)
+    return token
+
+
+@pytest.fixture
+def admin_auth_headers(app):
+    """Cookie header dict for the admin user (all capabilities)."""
+    auth_mgr = app.state.auth
+    if not auth_mgr.is_configured():
+        auth_mgr.setup_user("admin", "Admin", "", "adminpass")
+    record = auth_mgr.find_user("admin")
+    if record is None:
+        auth_mgr.setup_user("admin", "Admin", "", "adminpass")
+        record = auth_mgr.find_user("admin")
+    token = auth_mgr.create_session(user_id=record["id"], long_lived=True)
+    return {"Cookie": f"taos_session={token}"}
+
+
+@pytest.fixture
+def chat_only_auth_headers(app):
+    """Cookie header dict for a user with only the 'chat' capability."""
+    token = _create_user_with_caps(app.state.auth, "chat_only_user", ["chat"])
+    return {"Cookie": f"taos_session={token}"}
+
+
+@pytest.fixture
+def shell_only_auth_headers(app):
+    """Cookie header dict for a user with {chat, agent.shell} capabilities."""
+    token = _create_user_with_caps(
+        app.state.auth, "shell_only_user", ["chat", CAP_AGENT_SHELL]
+    )
+    return {"Cookie": f"taos_session={token}"}
+
+
+@pytest.fixture
+def seeded_agent_factory(app, monkeypatch):
+    """Factory: create a test agent with an arbitrary framework + shortcuts list.
+
+    Usage::
+
+        agent = seeded_agent_factory(
+            framework="openclaw",
+            shortcuts=[{"kind": "container-terminal", ...}],
+        )
+        agent["id"]  # the id for /api/agents/{id}/shortcuts
+
+    Injects a temporary framework entry (keyed by a unique ID) into
+    tinyagentos.frameworks.FRAMEWORKS so the route can find the shortcuts,
+    and appends the agent to app.state.config.agents.
+    """
+    import tinyagentos.frameworks as fw_mod
+
+    created_ids: list[str] = []
+
+    def factory(framework: str, shortcuts: list[dict]) -> dict:
+        # Register a patched FRAMEWORKS dict that includes our test shortcuts.
+        # We use the real framework name so the agent's `framework` field matches.
+        # If the framework already exists, we override its shortcuts only.
+        original = fw_mod.FRAMEWORKS.get(framework, {"id": framework, "name": framework})
+        patched_entry = {**original, "shortcuts": shortcuts}
+        patched_frameworks = {**fw_mod.FRAMEWORKS, framework: patched_entry}
+        monkeypatch.setattr(fw_mod, "FRAMEWORKS", patched_frameworks)
+
+        agent_id = uuid.uuid4().hex[:12]
+        agent = {
+            "id": agent_id,
+            "name": f"test-agent-{agent_id}",
+            "host": "127.0.0.1",
+            "qmd_index": "test",
+            "color": "#abcdef",
+            "framework": framework,
+        }
+        app.state.config.agents.append(agent)
+        created_ids.append(agent_id)
+        return agent
+
+    yield factory
+
+    # Cleanup: remove injected agents from config
+    app.state.config.agents = [
+        a for a in app.state.config.agents if a.get("id") not in created_ids
+    ]
+
+
+@pytest.fixture
+def patch_worker_signing_key(monkeypatch):
+    """Replace _LOCAL_SIGNING_KEY with the test key used in redeem tests."""
+    import tinyagentos.cluster.worker_registry as wr_mod
+
+    monkeypatch.setattr(wr_mod, "_LOCAL_SIGNING_KEY", b"test-signing-key-32-bytes-padded")
+    yield

--- a/tests/routes/test_shortcut_proxy.py
+++ b/tests/routes/test_shortcut_proxy.py
@@ -1,0 +1,362 @@
+"""Tests for shortcut dashboard reverse-proxy (Task 17 — basic HTTP forward).
+
+Tests for Tasks 18 (auth injection) and 19 (SSE + WebSocket) follow in
+subsequent commits.
+"""
+from __future__ import annotations
+
+import secrets
+import time
+from unittest.mock import patch
+
+import httpx
+import pytest
+import respx
+
+from tinyagentos.routes.shortcut_proxy import (
+    _sessions,
+    _HOP_BY_HOP_PROXY,
+    _filter_proxy_headers,
+    _get_shortcut_from_cookie,
+    _resolve_container_ip,
+    proxy_dashboard,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_session(agent_id: str, idx: int, scope: str = "dashboard") -> str:
+    """Insert a valid session into _sessions and return the session_id."""
+    session_id = secrets.token_urlsafe(32)
+    _sessions[session_id] = {
+        "agent_id": agent_id,
+        "shortcut_idx": idx,
+        "scope": scope,
+        "expires_at": time.monotonic() + 300,
+    }
+    return session_id
+
+
+def _make_dashboard_shortcut(port: int = 8080, path: str = "/", auth_type: str = "none"):
+    return {
+        "kind": "dashboard",
+        "label": "Test dashboard",
+        "icon": "dashboard",
+        "requires_capability": "agent.dashboard",
+        "port": port,
+        "path": path,
+        "auth": {"type": auth_type, "token_source": None},
+        "_idx": 0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Task 17 — basic HTTP forward
+# ---------------------------------------------------------------------------
+
+class TestHopByHopConstants:
+    def test_frozenset_type(self):
+        assert isinstance(_HOP_BY_HOP_PROXY, frozenset)
+
+    def test_contains_standard_headers(self):
+        for h in ("connection", "keep-alive", "transfer-encoding", "upgrade", "host"):
+            assert h in _HOP_BY_HOP_PROXY, f"expected '{h}' in _HOP_BY_HOP_PROXY"
+
+    def test_proxy_authorization_included(self):
+        assert "proxy-authorization" in _HOP_BY_HOP_PROXY
+
+
+class TestFilterProxyHeaders:
+    def test_strips_hop_by_hop(self):
+        headers = {
+            "content-type": "application/json",
+            "transfer-encoding": "chunked",
+            "connection": "keep-alive",
+            "x-custom": "preserved",
+        }
+        filtered = _filter_proxy_headers(headers)
+        assert "content-type" in filtered
+        assert "x-custom" in filtered
+        assert "transfer-encoding" not in filtered
+        assert "connection" not in filtered
+
+    def test_strips_taos_session_cookie(self):
+        headers = {"cookie": "taos_session=abc123; other_cookie=xyz"}
+        filtered = _filter_proxy_headers(headers)
+        cookie_val = filtered.get("cookie", "")
+        assert "taos_session" not in cookie_val
+        assert "other_cookie" in cookie_val
+
+    def test_passes_non_taos_cookies_through(self):
+        headers = {"cookie": "app_session=foo; pref=bar"}
+        filtered = _filter_proxy_headers(headers)
+        assert "app_session" in filtered.get("cookie", "")
+
+    def test_empty_headers_returns_empty(self):
+        assert _filter_proxy_headers({}) == {}
+
+    def test_only_taos_cookie_drops_cookie_header(self):
+        headers = {"cookie": "taos_session=abc123"}
+        filtered = _filter_proxy_headers(headers)
+        assert "cookie" not in filtered or filtered.get("cookie", "") == ""
+
+
+class TestResolveContainerIp:
+    def test_returns_stored_host_if_set(self):
+        from unittest.mock import MagicMock
+        mock_request = MagicMock()
+        mock_request.app.state.config.agents = [
+            {"id": "ag1", "name": "myagent", "host": "10.0.0.5", "framework": "openclaw"},
+        ]
+        ip = _resolve_container_ip(mock_request, "ag1")
+        assert ip == "10.0.0.5"
+
+    def test_returns_none_for_unknown_agent(self):
+        from unittest.mock import MagicMock
+        mock_request = MagicMock()
+        mock_request.app.state.config.agents = []
+        ip = _resolve_container_ip(mock_request, "unknown")
+        assert ip is None
+
+    def test_looks_up_by_name_too(self):
+        from unittest.mock import MagicMock
+        mock_request = MagicMock()
+        mock_request.app.state.config.agents = [
+            {"id": "abc123", "name": "myagent", "host": "10.0.1.2", "framework": "openclaw"},
+        ]
+        ip = _resolve_container_ip(mock_request, "myagent")
+        assert ip == "10.0.1.2"
+
+
+class TestGetShortcutFromCookie:
+    def test_missing_cookie_raises_401(self):
+        from unittest.mock import MagicMock
+        mock_conn = MagicMock()
+        mock_conn.cookies = {}
+        with pytest.raises(Exception) as exc_info:
+            _get_shortcut_from_cookie(mock_conn, "agent1", 0, [])
+        assert exc_info.value.status_code == 401
+
+    def test_expired_session_raises_401(self):
+        from unittest.mock import MagicMock
+        session_id = secrets.token_urlsafe(32)
+        _sessions[session_id] = {
+            "agent_id": "agent1",
+            "shortcut_idx": 0,
+            "scope": "dashboard",
+            "expires_at": time.monotonic() - 1,
+        }
+        mock_conn = MagicMock()
+        mock_conn.cookies = {"taos_shortcut": session_id}
+        with pytest.raises(Exception) as exc_info:
+            _get_shortcut_from_cookie(mock_conn, "agent1", 0, [{"kind": "dashboard"}])
+        assert exc_info.value.status_code == 401
+
+    def test_wrong_agent_raises_403(self):
+        from unittest.mock import MagicMock
+        session_id = _make_session("agent_A", 0)
+        mock_conn = MagicMock()
+        mock_conn.cookies = {"taos_shortcut": session_id}
+        with pytest.raises(Exception) as exc_info:
+            _get_shortcut_from_cookie(mock_conn, "agent_B", 0, [{"kind": "dashboard"}])
+        assert exc_info.value.status_code == 403
+
+    def test_wrong_idx_raises_403(self):
+        from unittest.mock import MagicMock
+        session_id = _make_session("agent1", 0)
+        mock_conn = MagicMock()
+        mock_conn.cookies = {"taos_shortcut": session_id}
+        shortcuts = [{"kind": "dashboard"}, {"kind": "dashboard"}]
+        with pytest.raises(Exception) as exc_info:
+            _get_shortcut_from_cookie(mock_conn, "agent1", 1, shortcuts)
+        assert exc_info.value.status_code == 403
+
+    def test_valid_session_returns_shortcut(self):
+        from unittest.mock import MagicMock
+        shortcut = _make_dashboard_shortcut()
+        session_id = _make_session("agent1", 0)
+        mock_conn = MagicMock()
+        mock_conn.cookies = {"taos_shortcut": session_id}
+        result = _get_shortcut_from_cookie(mock_conn, "agent1", 0, [shortcut])
+        assert result["kind"] == "dashboard"
+        assert result["port"] == 8080
+
+    def test_idx_out_of_range_raises_404(self):
+        from unittest.mock import MagicMock
+        session_id = _make_session("agent1", 5)
+        mock_conn = MagicMock()
+        mock_conn.cookies = {"taos_shortcut": session_id}
+        with pytest.raises(Exception) as exc_info:
+            _get_shortcut_from_cookie(mock_conn, "agent1", 5, [])
+        assert exc_info.value.status_code == 404
+
+
+class TestProxyDashboardBasic:
+    @pytest.mark.asyncio
+    async def test_proxies_200_response(self, app, seeded_agent_factory):
+        """proxy_dashboard forwards the request and streams the upstream body."""
+        shortcuts = [_make_dashboard_shortcut(port=8080)]
+        agent = seeded_agent_factory(framework="openclaw", shortcuts=shortcuts)
+        agent_name = agent["id"]
+
+        from unittest.mock import MagicMock
+        mock_request = MagicMock()
+        mock_request.method = "GET"
+        mock_request.url.query = ""
+        mock_request.headers = {"accept": "text/html"}
+        mock_request.app = app
+
+        async def _empty():
+            return
+            yield
+
+        mock_request.stream = _empty
+        shortcut = {**shortcuts[0], "_idx": 0}
+
+        with patch(
+            "tinyagentos.routes.shortcut_proxy._resolve_container_ip",
+            return_value="10.0.0.5",
+        ), respx.mock(assert_all_called=False) as rsps:
+            rsps.get("http://10.0.0.5:8080/").mock(
+                return_value=httpx.Response(200, text="upstream ok")
+            )
+            resp = await proxy_dashboard(agent_name, shortcut, mock_request)
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_502_when_container_unreachable(self, app, seeded_agent_factory):
+        """ConnectError → 502."""
+        shortcuts = [_make_dashboard_shortcut(port=9999)]
+        agent = seeded_agent_factory(framework="openclaw", shortcuts=shortcuts)
+        shortcut = {**shortcuts[0], "_idx": 0}
+
+        from unittest.mock import MagicMock
+        mock_request = MagicMock()
+        mock_request.method = "GET"
+        mock_request.url.query = ""
+        mock_request.headers = {}
+        mock_request.app = app
+
+        async def _empty():
+            return
+            yield
+
+        mock_request.stream = _empty
+
+        with patch(
+            "tinyagentos.routes.shortcut_proxy._resolve_container_ip",
+            return_value="10.0.0.5",
+        ), respx.mock(assert_all_called=False) as rsps:
+            rsps.get("http://10.0.0.5:9999/").mock(
+                side_effect=httpx.ConnectError("refused")
+            )
+            resp = await proxy_dashboard(agent["id"], shortcut, mock_request)
+        assert resp.status_code == 502
+
+    @pytest.mark.asyncio
+    async def test_503_when_no_container_ip(self, app, seeded_agent_factory):
+        """No container IP → 503."""
+        shortcuts = [_make_dashboard_shortcut()]
+        agent = seeded_agent_factory(framework="openclaw", shortcuts=shortcuts)
+        shortcut = {**shortcuts[0], "_idx": 0}
+
+        from unittest.mock import MagicMock
+        mock_request = MagicMock()
+        mock_request.method = "GET"
+        mock_request.url.query = ""
+        mock_request.headers = {}
+        mock_request.app = app
+
+        async def _empty():
+            return
+            yield
+
+        mock_request.stream = _empty
+
+        with patch(
+            "tinyagentos.routes.shortcut_proxy._resolve_container_ip",
+            return_value=None,
+        ):
+            resp = await proxy_dashboard(agent["id"], shortcut, mock_request)
+        assert resp.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_hop_by_hop_stripped_from_upstream_response(
+        self, app, seeded_agent_factory
+    ):
+        """Hop-by-hop headers from upstream must not be forwarded to client."""
+        shortcuts = [_make_dashboard_shortcut()]
+        agent = seeded_agent_factory(framework="openclaw", shortcuts=shortcuts)
+        shortcut = {**shortcuts[0], "_idx": 0}
+
+        from unittest.mock import MagicMock
+        mock_request = MagicMock()
+        mock_request.method = "GET"
+        mock_request.url.query = ""
+        mock_request.headers = {}
+        mock_request.app = app
+
+        async def _empty():
+            return
+            yield
+
+        mock_request.stream = _empty
+
+        with patch(
+            "tinyagentos.routes.shortcut_proxy._resolve_container_ip",
+            return_value="10.0.0.5",
+        ), respx.mock(assert_all_called=False) as rsps:
+            rsps.get("http://10.0.0.5:8080/").mock(
+                return_value=httpx.Response(
+                    200,
+                    text="body",
+                    headers={
+                        "transfer-encoding": "chunked",
+                        "x-app-header": "keep-me",
+                    },
+                )
+            )
+            resp = await proxy_dashboard(agent["id"], shortcut, mock_request)
+        assert "x-app-header" in resp.headers
+        assert "transfer-encoding" not in resp.headers
+
+
+class TestDashboardRouteIntegration:
+    """End-to-end: GET /shortcut/dashboard/{agent}/{idx}/{path} via TestClient."""
+
+    def test_missing_cookie_returns_401(self, test_client, seeded_agent_factory):
+        shortcuts = [_make_dashboard_shortcut()]
+        agent = seeded_agent_factory(framework="openclaw", shortcuts=shortcuts)
+        resp = test_client.get(
+            f"/shortcut/dashboard/{agent['id']}/0/",
+            follow_redirects=False,
+        )
+        assert resp.status_code == 401
+
+    def test_valid_cookie_proxies_upstream(
+        self, test_client, app, seeded_agent_factory, monkeypatch
+    ):
+        shortcuts = [_make_dashboard_shortcut(port=8080)]
+        agent = seeded_agent_factory(framework="openclaw", shortcuts=shortcuts)
+        agent_id = agent["id"]
+
+        session_id = _make_session(agent_id, 0)
+
+        monkeypatch.setattr(
+            "tinyagentos.routes.shortcut_proxy._resolve_container_ip",
+            lambda req, name: "10.0.0.5",
+        )
+
+        test_client.cookies.set("taos_shortcut", session_id)
+        try:
+            with respx.mock(assert_all_called=False) as rsps:
+                rsps.get("http://10.0.0.5:8080/").mock(
+                    return_value=httpx.Response(200, text="proxied!")
+                )
+                resp = test_client.get(f"/shortcut/dashboard/{agent_id}/0/")
+        finally:
+            test_client.cookies.clear()
+        assert resp.status_code == 200
+        assert resp.text == "proxied!"

--- a/tests/routes/test_shortcut_proxy.py
+++ b/tests/routes/test_shortcut_proxy.py
@@ -636,3 +636,170 @@ class TestWebSocketRoute:
                 f"/shortcut/dashboard/{agent_id}/0/ws/"
             ) as ws:
                 ws.receive_text()
+
+
+# ---------------------------------------------------------------------------
+# M2 — handshake validated BEFORE PTY spawn
+# ---------------------------------------------------------------------------
+
+class TestTerminalHandshakeBeforePty:
+    @pytest.mark.asyncio
+    async def test_bad_handshake_does_not_spawn_pty(self, seeded_agent_factory, monkeypatch):
+        """A malformed first frame must close the WS without spawning a PTY."""
+        from unittest.mock import AsyncMock, MagicMock, patch, call
+        import tinyagentos.routes.shortcut_proxy as proxy_mod
+
+        shortcuts = [
+            {
+                "kind": "container-terminal",
+                "label": "Shell",
+                "icon": "terminal",
+                "requires_capability": "agent.shell",
+                "port": 8888,
+                "path": "/",
+            }
+        ]
+        agent = seeded_agent_factory(framework="openclaw", shortcuts=shortcuts)
+        agent_id = agent["id"]
+        session_id = _make_session(agent_id, 0, scope="container-terminal")
+
+        spawn_called = []
+
+        def fake_spawn(name, cmd):
+            spawn_called.append(name)
+            return MagicMock(close=lambda: None)
+
+        monkeypatch.setattr(proxy_mod, "_get_container_pty", fake_spawn)
+
+        # Build a fake WebSocket that returns a bad handshake frame
+        ws = MagicMock()
+        ws.cookies = {"taos_shortcut": session_id}
+        ws.accept = AsyncMock()
+        ws.close = AsyncMock()
+        ws.receive_text = AsyncMock(return_value='{"type": "bad_type"}')
+
+        # Patch _get_shortcuts_for_agent to return our shortcuts
+        monkeypatch.setattr(
+            proxy_mod,
+            "_get_shortcuts_for_agent",
+            lambda conn, name: shortcuts,
+        )
+
+        from tinyagentos.routes.shortcut_proxy import shortcut_terminal_ws
+        await shortcut_terminal_ws(agent_id, 0, ws)
+
+        # PTY must NOT have been spawned
+        assert spawn_called == [], "spawn_pty must not be called when handshake is bad"
+        ws.close.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# M4 — scope enforcement
+# ---------------------------------------------------------------------------
+
+class TestScopeEnforcement:
+    def test_terminal_session_rejected_for_dashboard_route(self):
+        """A session with scope='container-terminal' must be rejected by dashboard route (403)."""
+        from unittest.mock import MagicMock
+        # Create a terminal-scoped session
+        session_id = _make_session("agent1", 0, scope="container-terminal")
+        mock_conn = MagicMock()
+        mock_conn.cookies = {"taos_shortcut": session_id}
+        shortcuts = [_make_dashboard_shortcut()]
+
+        from tinyagentos.routes.shortcut_proxy import _get_shortcut_from_cookie
+        with pytest.raises(Exception) as exc_info:
+            _get_shortcut_from_cookie(mock_conn, "agent1", 0, shortcuts, expected_scope="dashboard")
+        assert exc_info.value.status_code == 403
+
+    def test_dashboard_session_rejected_for_terminal_route(self):
+        """A session with scope='dashboard' must be rejected by terminal route (403)."""
+        from unittest.mock import MagicMock
+        session_id = _make_session("agent1", 0, scope="dashboard")
+        mock_conn = MagicMock()
+        mock_conn.cookies = {"taos_shortcut": session_id}
+        shortcuts = [{"kind": "container-terminal"}]
+
+        from tinyagentos.routes.shortcut_proxy import _get_shortcut_from_cookie
+        with pytest.raises(Exception) as exc_info:
+            _get_shortcut_from_cookie(mock_conn, "agent1", 0, shortcuts, expected_scope="terminal")
+        assert exc_info.value.status_code == 403
+
+    def test_tui_session_accepted_for_terminal_route(self):
+        """scope='tui' is accepted for terminal route (tui is in _TERMINAL_SCOPES)."""
+        from unittest.mock import MagicMock
+        session_id = _make_session("agent1", 0, scope="tui")
+        mock_conn = MagicMock()
+        mock_conn.cookies = {"taos_shortcut": session_id}
+        shortcuts = [{"kind": "tui", "command": "htop"}]
+
+        from tinyagentos.routes.shortcut_proxy import _get_shortcut_from_cookie
+        result = _get_shortcut_from_cookie(mock_conn, "agent1", 0, shortcuts, expected_scope="terminal")
+        assert result["kind"] == "tui"
+
+
+# ---------------------------------------------------------------------------
+# M5 — /redeem returns 503 when worker registry not ready
+# ---------------------------------------------------------------------------
+
+class TestRedeemWorkerNotReady:
+    def test_redeem_returns_503_when_no_worker(self, test_client, monkeypatch):
+        """GET /redeem with no active ClusterManager must return 503."""
+        import tinyagentos.cluster.worker_registry as wr_mod
+        monkeypatch.setattr(wr_mod, "_active_manager", None)
+
+        resp = test_client.get("/redeem?t=anytoken", follow_redirects=False)
+        assert resp.status_code == 503
+        assert "not ready" in resp.json().get("detail", "").lower()
+
+
+# ---------------------------------------------------------------------------
+# M6 — worker_registry fail-closed on bad signing_key / worker_url
+# ---------------------------------------------------------------------------
+
+class TestWorkerRegistryFailClosed:
+    def test_short_signing_key_raises(self):
+        """get_local_worker must raise if signing_key < 32 bytes."""
+        from unittest.mock import MagicMock, patch
+        from tinyagentos.cluster.worker_registry import get_local_worker
+
+        fake_manager = MagicMock()
+        fake_manager.get_worker.return_value = MagicMock(
+            signing_key=b"short",
+            worker_url="http://localhost:6969",
+            name="local",
+        )
+        with patch("tinyagentos.cluster.worker_registry._active_manager", fake_manager):
+            with pytest.raises(RuntimeError, match="signing_key"):
+                get_local_worker()
+
+    def test_empty_worker_url_raises(self):
+        """get_local_worker must raise if worker_url is empty."""
+        from unittest.mock import MagicMock, patch
+        from tinyagentos.cluster.worker_registry import get_local_worker
+
+        fake_manager = MagicMock()
+        fake_manager.get_worker.return_value = MagicMock(
+            signing_key=b"x" * 32,
+            worker_url="",
+            name="local",
+        )
+        with patch("tinyagentos.cluster.worker_registry._active_manager", fake_manager):
+            with pytest.raises(RuntimeError, match="worker_url"):
+                get_local_worker()
+
+    def test_valid_worker_returns_dict(self):
+        """get_local_worker returns dict when worker has valid key and url."""
+        from unittest.mock import MagicMock, patch
+        from tinyagentos.cluster.worker_registry import get_local_worker
+
+        fake_manager = MagicMock()
+        fake_manager.get_worker.return_value = MagicMock(
+            signing_key=b"x" * 32,
+            worker_url="http://localhost:6969",
+            name="local",
+        )
+        with patch("tinyagentos.cluster.worker_registry._active_manager", fake_manager):
+            result = get_local_worker()
+        assert result["worker_url"] == "http://localhost:6969"
+        assert result["signing_key"] == b"x" * 32

--- a/tests/routes/test_shortcut_proxy.py
+++ b/tests/routes/test_shortcut_proxy.py
@@ -537,3 +537,61 @@ class TestAuthHeaderInjection:
             await proxy_dashboard(agent["id"], shortcut, mock_request)
 
         assert "authorization" not in {k.lower() for k in captured_headers}
+
+
+# ---------------------------------------------------------------------------
+# Task 19 — SSE pass-through + WebSocket upgrade
+# ---------------------------------------------------------------------------
+
+class TestSsePassthrough:
+    def test_sse_response_streams_through(
+        self, test_client, seeded_agent_factory, monkeypatch
+    ):
+        """text/event-stream response must pass through with correct status."""
+        shortcuts = [_make_dashboard_shortcut(port=7070)]
+        agent = seeded_agent_factory(framework="openclaw", shortcuts=shortcuts)
+        agent_id = agent["id"]
+        session_id = _make_session(agent_id, 0)
+
+        monkeypatch.setattr(
+            "tinyagentos.routes.shortcut_proxy._resolve_container_ip",
+            lambda req, name: "10.0.0.5",
+        )
+
+        sse_body = b"data: hello\n\ndata: world\n\n"
+
+        test_client.cookies.set("taos_shortcut", session_id)
+        try:
+            with respx.mock(assert_all_called=False) as rsps:
+                rsps.get("http://10.0.0.5:7070/").mock(
+                    return_value=httpx.Response(
+                        200,
+                        content=sse_body,
+                        headers={"content-type": "text/event-stream"},
+                    )
+                )
+                resp = test_client.get(f"/shortcut/dashboard/{agent_id}/0/")
+        finally:
+            test_client.cookies.clear()
+        assert resp.status_code == 200
+        assert "text/event-stream" in resp.headers.get("content-type", "")
+
+
+class TestWebSocketRoute:
+    def test_ws_route_exists(self, app):
+        """The WS route /shortcut/dashboard/{agent}/{idx}/ws/{path} must be registered."""
+        routes = [r.path for r in app.routes if hasattr(r, "path")]
+        ws_route = "/shortcut/dashboard/{agent_name}/{idx}/ws/{path:path}"
+        assert ws_route in routes, f"WS route not found. Routes: {routes}"
+
+    def test_ws_missing_cookie_closes_with_1008(self, test_client, seeded_agent_factory):
+        """WebSocket with no cookie must be rejected (1008 or connection refused)."""
+        shortcuts = [_make_dashboard_shortcut()]
+        agent = seeded_agent_factory(framework="openclaw", shortcuts=shortcuts)
+        agent_id = agent["id"]
+
+        with pytest.raises(Exception):
+            with test_client.websocket_connect(
+                f"/shortcut/dashboard/{agent_id}/0/ws/"
+            ) as ws:
+                ws.receive_text()

--- a/tests/routes/test_shortcut_proxy.py
+++ b/tests/routes/test_shortcut_proxy.py
@@ -1,7 +1,9 @@
-"""Tests for shortcut dashboard reverse-proxy (Task 17 — basic HTTP forward).
+"""Tests for shortcut dashboard reverse-proxy (Tasks 17-18).
 
-Tests for Tasks 18 (auth injection) and 19 (SSE + WebSocket) follow in
-subsequent commits.
+Task 17: basic HTTP forward + hop-by-hop header stripping
+Task 18: auth header injection (bearer / basic / none) via read_token_source
+
+Tests for Task 19 (SSE + WebSocket) follow in the next commit.
 """
 from __future__ import annotations
 
@@ -360,3 +362,178 @@ class TestDashboardRouteIntegration:
             test_client.cookies.clear()
         assert resp.status_code == 200
         assert resp.text == "proxied!"
+
+
+# ---------------------------------------------------------------------------
+# Task 18 — auth header injection
+# ---------------------------------------------------------------------------
+
+class TestAuthHeaderInjection:
+    @pytest.mark.asyncio
+    async def test_bearer_auth_injected(self, app, seeded_agent_factory):
+        """When auth.type=bearer, Authorization: Bearer <token> must be added."""
+        from unittest.mock import MagicMock
+        shortcuts = [
+            {
+                **_make_dashboard_shortcut(auth_type="bearer"),
+                "auth": {
+                    "type": "bearer",
+                    "token_source": {"kind": "static", "value": "mytoken123"},
+                },
+                "_idx": 0,
+            }
+        ]
+        agent = seeded_agent_factory(framework="openclaw", shortcuts=shortcuts)
+        shortcut = shortcuts[0]
+
+        mock_request = MagicMock()
+        mock_request.method = "GET"
+        mock_request.url.query = ""
+        mock_request.headers = {}
+        mock_request.app = app
+
+        async def _empty():
+            return
+            yield
+
+        mock_request.stream = _empty
+        captured_headers: dict = {}
+
+        def _capture_headers(request: httpx.Request, *args, **kwargs):
+            captured_headers.update(dict(request.headers))
+            return httpx.Response(200, text="ok")
+
+        with patch(
+            "tinyagentos.routes.shortcut_proxy._resolve_container_ip",
+            return_value="10.0.0.5",
+        ), respx.mock(assert_all_called=False) as rsps:
+            rsps.get("http://10.0.0.5:8080/").mock(side_effect=_capture_headers)
+            await proxy_dashboard(agent["id"], shortcut, mock_request)
+
+        assert "authorization" in {k.lower() for k in captured_headers}
+        auth_val = next(
+            v for k, v in captured_headers.items() if k.lower() == "authorization"
+        )
+        assert auth_val == "Bearer mytoken123"
+
+    @pytest.mark.asyncio
+    async def test_basic_auth_injected(self, app, seeded_agent_factory):
+        """When auth.type=basic, Authorization: Basic <b64> must be added."""
+        import base64
+        from unittest.mock import MagicMock
+        shortcuts = [
+            {
+                **_make_dashboard_shortcut(auth_type="basic"),
+                "auth": {
+                    "type": "basic",
+                    "token_source": {"kind": "static", "value": "user:pass"},
+                },
+                "_idx": 0,
+            }
+        ]
+        agent = seeded_agent_factory(framework="openclaw", shortcuts=shortcuts)
+        shortcut = shortcuts[0]
+
+        mock_request = MagicMock()
+        mock_request.method = "GET"
+        mock_request.url.query = ""
+        mock_request.headers = {}
+        mock_request.app = app
+
+        async def _empty():
+            return
+            yield
+
+        mock_request.stream = _empty
+        captured_headers: dict = {}
+
+        def _capture(request: httpx.Request, *args, **kwargs):
+            captured_headers.update(dict(request.headers))
+            return httpx.Response(200, text="ok")
+
+        with patch(
+            "tinyagentos.routes.shortcut_proxy._resolve_container_ip",
+            return_value="10.0.0.5",
+        ), respx.mock(assert_all_called=False) as rsps:
+            rsps.get("http://10.0.0.5:8080/").mock(side_effect=_capture)
+            await proxy_dashboard(agent["id"], shortcut, mock_request)
+
+        auth_val = next(
+            v for k, v in captured_headers.items() if k.lower() == "authorization"
+        )
+        expected_b64 = base64.b64encode(b"user:pass").decode()
+        assert auth_val == f"Basic {expected_b64}"
+
+    @pytest.mark.asyncio
+    async def test_none_auth_no_authorization_header(self, app, seeded_agent_factory):
+        """When auth.type=none, no Authorization header must be sent upstream."""
+        from unittest.mock import MagicMock
+        shortcuts = [_make_dashboard_shortcut(auth_type="none")]
+        agent = seeded_agent_factory(framework="openclaw", shortcuts=shortcuts)
+        shortcut = {**shortcuts[0], "_idx": 0}
+
+        mock_request = MagicMock()
+        mock_request.method = "GET"
+        mock_request.url.query = ""
+        mock_request.headers = {}
+        mock_request.app = app
+
+        async def _empty():
+            return
+            yield
+
+        mock_request.stream = _empty
+        captured_headers: dict = {}
+
+        def _capture(request: httpx.Request, *args, **kwargs):
+            captured_headers.update(dict(request.headers))
+            return httpx.Response(200, text="ok")
+
+        with patch(
+            "tinyagentos.routes.shortcut_proxy._resolve_container_ip",
+            return_value="10.0.0.5",
+        ), respx.mock(assert_all_called=False) as rsps:
+            rsps.get("http://10.0.0.5:8080/").mock(side_effect=_capture)
+            await proxy_dashboard(agent["id"], shortcut, mock_request)
+
+        assert "authorization" not in {k.lower() for k in captured_headers}
+
+    @pytest.mark.asyncio
+    async def test_token_source_none_skips_auth(self, app, seeded_agent_factory):
+        """If token_source is None even with bearer type, no auth header is added."""
+        from unittest.mock import MagicMock
+        shortcuts = [
+            {
+                **_make_dashboard_shortcut(auth_type="bearer"),
+                "auth": {"type": "bearer", "token_source": None},
+                "_idx": 0,
+            }
+        ]
+        agent = seeded_agent_factory(framework="openclaw", shortcuts=shortcuts)
+        shortcut = shortcuts[0]
+
+        mock_request = MagicMock()
+        mock_request.method = "GET"
+        mock_request.url.query = ""
+        mock_request.headers = {}
+        mock_request.app = app
+
+        async def _empty():
+            return
+            yield
+
+        mock_request.stream = _empty
+        captured_headers: dict = {}
+
+        def _capture(request: httpx.Request, *args, **kwargs):
+            captured_headers.update(dict(request.headers))
+            return httpx.Response(200, text="ok")
+
+        with patch(
+            "tinyagentos.routes.shortcut_proxy._resolve_container_ip",
+            return_value="10.0.0.5",
+        ), respx.mock(assert_all_called=False) as rsps:
+            rsps.get("http://10.0.0.5:8080/").mock(side_effect=_capture)
+            await proxy_dashboard(agent["id"], shortcut, mock_request)
+
+        assert "authorization" not in {k.lower() for k in captured_headers}

--- a/tests/routes/test_shortcut_proxy.py
+++ b/tests/routes/test_shortcut_proxy.py
@@ -577,6 +577,47 @@ class TestSsePassthrough:
         assert "text/event-stream" in resp.headers.get("content-type", "")
 
 
+class TestDashboardSubpathForwarding:
+    """M2 — captured subpath must appear in upstream URL."""
+
+    @pytest.mark.asyncio
+    async def test_deep_subpath_forwarded_to_upstream(self, app, seeded_agent_factory):
+        """proxy_dashboard with path='some/deep/page' must hit upstream /some/deep/page."""
+        from unittest.mock import MagicMock
+        shortcuts = [_make_dashboard_shortcut(port=8080, path="/")]
+        agent = seeded_agent_factory(framework="openclaw", shortcuts=shortcuts)
+        shortcut = {**shortcuts[0], "_idx": 0}
+
+        mock_request = MagicMock()
+        mock_request.method = "GET"
+        mock_request.url.query = ""
+        mock_request.headers = {}
+        mock_request.app = app
+
+        async def _empty():
+            return
+            yield
+
+        mock_request.stream = _empty
+        captured_urls: list[str] = []
+
+        def _capture(request: httpx.Request, *args, **kwargs):
+            captured_urls.append(str(request.url))
+            return httpx.Response(200, text="ok")
+
+        with patch(
+            "tinyagentos.routes.shortcut_proxy._resolve_container_ip",
+            return_value="10.0.0.5",
+        ), respx.mock(assert_all_called=False) as rsps:
+            rsps.get(url__startswith="http://10.0.0.5:8080/").mock(side_effect=_capture)
+            await proxy_dashboard(
+                agent["id"], shortcut, mock_request, path="some/deep/page"
+            )
+
+        assert len(captured_urls) == 1
+        assert "some/deep/page" in captured_urls[0]
+
+
 class TestWebSocketRoute:
     def test_ws_route_exists(self, app):
         """The WS route /shortcut/dashboard/{agent}/{idx}/ws/{path} must be registered."""

--- a/tests/routes/test_shortcut_redeem.py
+++ b/tests/routes/test_shortcut_redeem.py
@@ -1,0 +1,82 @@
+import time
+import pytest
+from tinyagentos.shortcuts.tickets import mint_ticket, JtiTracker
+
+SIGNING_KEY = b"test-signing-key-32-bytes-padded"
+WORKER_URL = "http://127.0.0.1:6969"
+
+
+def _make_token(agent_id="agent-1", idx=0, scope="container-terminal", ttl=30):
+    _, token = mint_ticket(
+        agent_id=agent_id,
+        shortcut_idx=idx,
+        scope=scope,
+        signing_key=SIGNING_KEY,
+        worker_url=WORKER_URL,
+        ttl=ttl,
+    )
+    return token
+
+
+def test_valid_ticket_sets_cookie_and_redirects(test_client, patch_worker_signing_key):
+    """A valid ticket must set taos_shortcut cookie and 302 to /shortcut/..."""
+    token = _make_token()
+    resp = test_client.get(f"/redeem?t={token}", follow_redirects=False)
+    assert resp.status_code == 302
+    location = resp.headers["location"]
+    assert "/shortcut/" in location
+    cookies = resp.cookies
+    assert "taos_shortcut" in cookies
+
+
+def test_expired_ticket_returns_401(test_client, patch_worker_signing_key):
+    token = _make_token(ttl=-1)
+    resp = test_client.get(f"/redeem?t={token}", follow_redirects=False)
+    assert resp.status_code == 401
+    assert "expired" in resp.json()["detail"].lower()
+
+
+def test_bad_hmac_returns_401(test_client):
+    """A token signed with a different key must be rejected."""
+    wrong_key = b"wrong-signing-key-32-bytes-paddd"
+    _, token = mint_ticket(
+        agent_id="x",
+        shortcut_idx=0,
+        scope="dashboard",
+        signing_key=wrong_key,
+        worker_url=WORKER_URL,
+        ttl=30,
+    )
+    resp = test_client.get(f"/redeem?t={token}", follow_redirects=False)
+    assert resp.status_code == 401
+
+
+def test_replayed_ticket_returns_401(test_client, patch_worker_signing_key):
+    """Second use of the same ticket must be rejected as a replay."""
+    token = _make_token()
+    test_client.get(f"/redeem?t={token}", follow_redirects=False)
+    resp = test_client.get(f"/redeem?t={token}", follow_redirects=False)
+    assert resp.status_code == 401
+    assert "replay" in resp.json()["detail"].lower()
+
+
+def test_missing_ticket_returns_422(test_client):
+    """Request without t= query param must return 422."""
+    resp = test_client.get("/redeem", follow_redirects=False)
+    assert resp.status_code == 422
+
+
+def test_redirect_location_matches_scope_terminal(test_client, patch_worker_signing_key):
+    """container-terminal scope must redirect to /shortcut/terminal/..."""
+    token = _make_token(scope="container-terminal")
+    resp = test_client.get(f"/redeem?t={token}", follow_redirects=False)
+    assert resp.status_code == 302
+    assert "/shortcut/terminal/" in resp.headers["location"]
+
+
+def test_redirect_location_matches_scope_dashboard(test_client, patch_worker_signing_key):
+    """dashboard scope must redirect to /shortcut/dashboard/..."""
+    token = _make_token(scope="dashboard")
+    resp = test_client.get(f"/redeem?t={token}", follow_redirects=False)
+    assert resp.status_code == 302
+    assert "/shortcut/dashboard/" in resp.headers["location"]

--- a/tests/routes/test_shortcut_terminal.py
+++ b/tests/routes/test_shortcut_terminal.py
@@ -1,0 +1,108 @@
+"""Tests for the shortcut terminal WebSocket route (Tasks 20-21).
+
+Task 20: PTY bridge — cookie validation, scope check, basic data flow.
+Task 21: tui shortcut spawns PTY with bash -lc <command>.
+"""
+from __future__ import annotations
+
+import secrets
+import time
+from unittest.mock import patch
+
+import pytest
+
+from tinyagentos.routes.shortcut_proxy import _sessions
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_terminal_session(agent_id: str, idx: int, scope: str = "container-terminal") -> str:
+    """Insert a valid terminal session into _sessions and return the session_id."""
+    session_id = secrets.token_urlsafe(32)
+    _sessions[session_id] = {
+        "agent_id": agent_id,
+        "shortcut_idx": idx,
+        "scope": scope,
+        "expires_at": time.monotonic() + 300,
+    }
+    return session_id
+
+
+class FakePtyHandle:
+    """Synchronous fake PTY handle matching the real PtyHandle interface."""
+
+    def read(self, size: int = 4096) -> bytes:
+        return b"$ "
+
+    def write(self, data: bytes) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Task 20 — basic terminal route wiring
+# ---------------------------------------------------------------------------
+
+class TestTerminalRouteExists:
+    def test_terminal_ws_route_registered(self, app):
+        """The WS route /shortcut/terminal/{agent_name}/{idx} must be registered."""
+        routes = [r.path for r in app.routes if hasattr(r, "path")]
+        expected = "/shortcut/terminal/{agent_name}/{idx}"
+        assert expected in routes, f"Terminal WS route not found. Routes: {routes}"
+
+
+class TestTerminalMissingCookieRejected:
+    def test_no_cookie_closes_connection(self, test_client, seeded_agent_factory):
+        """WebSocket with no taos_shortcut cookie must be rejected."""
+        shortcuts = [
+            {
+                "kind": "container-terminal",
+                "label": "Shell",
+                "icon": "terminal",
+                "requires_capability": "agent.shell",
+            }
+        ]
+        agent = seeded_agent_factory(framework="openclaw", shortcuts=shortcuts)
+        agent_id = agent["id"]
+
+        with pytest.raises(Exception):
+            with test_client.websocket_connect(
+                f"/shortcut/terminal/{agent_id}/0"
+            ) as ws:
+                ws.receive_text()
+
+
+class TestTerminalPtyBridge:
+    def test_pty_output_forwarded_to_client(self, test_client, seeded_agent_factory):
+        """Data from FakePtyHandle.read() must be forwarded over the WebSocket."""
+        shortcuts = [
+            {
+                "kind": "container-terminal",
+                "label": "Shell",
+                "icon": "terminal",
+                "requires_capability": "agent.shell",
+            }
+        ]
+        agent = seeded_agent_factory(framework="openclaw", shortcuts=shortcuts)
+        agent_id = agent["id"]
+        session_id = _make_terminal_session(agent_id, 0)
+
+        fake_pty = FakePtyHandle()
+
+        with patch(
+            "tinyagentos.routes.shortcut_proxy._get_container_pty",
+            return_value=fake_pty,
+        ):
+            test_client.cookies.set("taos_shortcut", session_id)
+            try:
+                with test_client.websocket_connect(
+                    f"/shortcut/terminal/{agent_id}/0"
+                ) as ws:
+                    data = ws.receive_text()
+                    assert data == "$ "
+            finally:
+                test_client.cookies.clear()

--- a/tests/routes/test_shortcut_terminal.py
+++ b/tests/routes/test_shortcut_terminal.py
@@ -106,3 +106,48 @@ class TestTerminalPtyBridge:
                     assert data == "$ "
             finally:
                 test_client.cookies.clear()
+
+
+# ---------------------------------------------------------------------------
+# Task 21 — tui shortcut spawns PTY with bash -lc <command>
+# ---------------------------------------------------------------------------
+
+class TestTuiSpawnCommand:
+    def test_tui_shortcut_passes_command_to_spawn_pty(
+        self, test_client, seeded_agent_factory
+    ):
+        """For a tui shortcut, spawn_pty must be called with cmd=['bash','-lc',<command>]."""
+        shortcuts = [
+            {
+                "kind": "tui",
+                "label": "htop",
+                "icon": "terminal",
+                "requires_capability": "agent.shell",
+                "command": "htop",
+            }
+        ]
+        agent = seeded_agent_factory(framework="openclaw", shortcuts=shortcuts)
+        agent_id = agent["id"]
+        session_id = _make_terminal_session(agent_id, 0, scope="tui")
+
+        captured_cmd: list = []
+        fake_pty = FakePtyHandle()
+
+        def _fake_get_pty(agent_name: str, cmd: list | None) -> FakePtyHandle:
+            captured_cmd.extend(cmd or [])
+            return fake_pty
+
+        with patch(
+            "tinyagentos.routes.shortcut_proxy._get_container_pty",
+            side_effect=_fake_get_pty,
+        ):
+            test_client.cookies.set("taos_shortcut", session_id)
+            try:
+                with test_client.websocket_connect(
+                    f"/shortcut/terminal/{agent_id}/0"
+                ) as ws:
+                    ws.receive_text()
+            finally:
+                test_client.cookies.clear()
+
+        assert captured_cmd == ["bash", "-lc", "htop"]

--- a/tests/routes/test_shortcut_terminal.py
+++ b/tests/routes/test_shortcut_terminal.py
@@ -5,6 +5,7 @@ Task 21: tui shortcut spawns PTY with bash -lc <command>.
 """
 from __future__ import annotations
 
+import json
 import secrets
 import time
 from unittest.mock import patch
@@ -102,6 +103,8 @@ class TestTerminalPtyBridge:
                 with test_client.websocket_connect(
                     f"/shortcut/terminal/{agent_id}/0"
                 ) as ws:
+                    # Send the required ticket handshake frame (Task 29 protocol).
+                    ws.send_text(json.dumps({"type": "ticket", "ticket": "dummy-ticket"}))
                     data = ws.receive_text()
                     assert data == "$ "
             finally:
@@ -146,8 +149,79 @@ class TestTuiSpawnCommand:
                 with test_client.websocket_connect(
                     f"/shortcut/terminal/{agent_id}/0"
                 ) as ws:
+                    # Send the required ticket handshake frame before data.
+                    ws.send_text(json.dumps({"type": "ticket", "ticket": "dummy-ticket"}))
                     ws.receive_text()
             finally:
                 test_client.cookies.clear()
 
         assert captured_cmd == ["bash", "-lc", "htop"]
+
+
+# ---------------------------------------------------------------------------
+# C1 — ticket handshake validation (defense-in-depth)
+# ---------------------------------------------------------------------------
+
+class TestTerminalHandshake:
+    def test_missing_handshake_closes_1008(self, test_client, seeded_agent_factory):
+        """Connection that never sends a ticket handshake must be rejected."""
+        shortcuts = [
+            {
+                "kind": "container-terminal",
+                "label": "Shell",
+                "icon": "terminal",
+                "requires_capability": "agent.shell",
+            }
+        ]
+        agent = seeded_agent_factory(framework="openclaw", shortcuts=shortcuts)
+        agent_id = agent["id"]
+        session_id = _make_terminal_session(agent_id, 0)
+
+        fake_pty = FakePtyHandle()
+
+        with patch(
+            "tinyagentos.routes.shortcut_proxy._get_container_pty",
+            return_value=fake_pty,
+        ):
+            test_client.cookies.set("taos_shortcut", session_id)
+            try:
+                with pytest.raises(Exception):
+                    with test_client.websocket_connect(
+                        f"/shortcut/terminal/{agent_id}/0"
+                    ) as ws:
+                        # Send wrong handshake — no "ticket" key
+                        ws.send_text(json.dumps({"type": "not-ticket"}))
+                        ws.receive_text()
+            finally:
+                test_client.cookies.clear()
+
+    def test_malformed_json_handshake_closes_1008(self, test_client, seeded_agent_factory):
+        """Non-JSON first frame must cause the connection to be rejected."""
+        shortcuts = [
+            {
+                "kind": "container-terminal",
+                "label": "Shell",
+                "icon": "terminal",
+                "requires_capability": "agent.shell",
+            }
+        ]
+        agent = seeded_agent_factory(framework="openclaw", shortcuts=shortcuts)
+        agent_id = agent["id"]
+        session_id = _make_terminal_session(agent_id, 0)
+
+        fake_pty = FakePtyHandle()
+
+        with patch(
+            "tinyagentos.routes.shortcut_proxy._get_container_pty",
+            return_value=fake_pty,
+        ):
+            test_client.cookies.set("taos_shortcut", session_id)
+            try:
+                with pytest.raises(Exception):
+                    with test_client.websocket_connect(
+                        f"/shortcut/terminal/{agent_id}/0"
+                    ) as ws:
+                        ws.send_text("not-json-at-all!!!")
+                        ws.receive_text()
+            finally:
+                test_client.cookies.clear()

--- a/tests/routes/test_shortcuts_launch.py
+++ b/tests/routes/test_shortcuts_launch.py
@@ -1,0 +1,91 @@
+import pytest
+
+
+@pytest.fixture
+def agent_with_shortcuts(seeded_agent_factory):
+    return seeded_agent_factory(
+        framework="openclaw",
+        shortcuts=[
+            {
+                "kind": "container-terminal",
+                "label": "Container shell",
+                "icon": "terminal",
+                "requires_capability": "agent.shell",
+            },
+            {
+                "kind": "dashboard",
+                "label": "Gateway dashboard",
+                "icon": "dashboard",
+                "requires_capability": "agent.dashboard",
+                "port": 18789,
+                "path": "/",
+                "auth": {"type": "none", "token_source": None},
+            },
+        ],
+    )
+
+
+def test_admin_launch_returns_redirect_url(
+    test_client, admin_auth_headers, agent_with_shortcuts
+):
+    """Admin launching shortcut idx=0 must get a redirect_url and expires_in=30."""
+    agent_id = agent_with_shortcuts["id"]
+    resp = test_client.post(
+        f"/api/agents/{agent_id}/shortcuts/0/launch",
+        headers=admin_auth_headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "redirect_url" in data
+    assert data["expires_in"] == 30
+    assert "redeem" in data["redirect_url"]
+
+
+def test_launch_includes_ticket_in_redirect_url(
+    test_client, admin_auth_headers, agent_with_shortcuts
+):
+    agent_id = agent_with_shortcuts["id"]
+    resp = test_client.post(
+        f"/api/agents/{agent_id}/shortcuts/0/launch",
+        headers=admin_auth_headers,
+    )
+    assert resp.status_code == 200
+    redirect_url = resp.json()["redirect_url"]
+    assert "t=" in redirect_url
+
+
+def test_launch_denied_for_chat_only_user(
+    test_client, chat_only_auth_headers, agent_with_shortcuts
+):
+    """User without required capability must get 403."""
+    agent_id = agent_with_shortcuts["id"]
+    resp = test_client.post(
+        f"/api/agents/{agent_id}/shortcuts/0/launch",
+        headers=chat_only_auth_headers,
+    )
+    assert resp.status_code == 403
+
+
+def test_launch_idx_out_of_range_returns_404(
+    test_client, admin_auth_headers, agent_with_shortcuts
+):
+    agent_id = agent_with_shortcuts["id"]
+    resp = test_client.post(
+        f"/api/agents/{agent_id}/shortcuts/99/launch",
+        headers=admin_auth_headers,
+    )
+    assert resp.status_code == 404
+
+
+def test_launch_unknown_agent_returns_404(test_client, admin_auth_headers):
+    resp = test_client.post(
+        "/api/agents/ghost-id/shortcuts/0/launch",
+        headers=admin_auth_headers,
+    )
+    assert resp.status_code == 404
+
+
+def test_unauthenticated_launch_returns_401(test_client, agent_with_shortcuts):
+    agent_id = agent_with_shortcuts["id"]
+    resp = test_client.post(f"/api/agents/{agent_id}/shortcuts/0/launch")
+    assert resp.status_code == 401

--- a/tests/routes/test_shortcuts_list.py
+++ b/tests/routes/test_shortcuts_list.py
@@ -1,0 +1,85 @@
+"""
+Tests for GET /api/agents/{id}/shortcuts.
+Uses the existing test fixtures / app client pattern from the project.
+"""
+import pytest
+
+
+@pytest.fixture
+def agent_with_shortcuts(seeded_agent_factory):
+    """Create a test agent whose framework has shortcuts defined."""
+    return seeded_agent_factory(
+        framework="openclaw",
+        shortcuts=[
+            {
+                "kind": "container-terminal",
+                "label": "Container shell",
+                "icon": "terminal",
+                "requires_capability": "agent.shell",
+            },
+            {
+                "kind": "dashboard",
+                "label": "Gateway dashboard",
+                "icon": "dashboard",
+                "requires_capability": "agent.dashboard",
+                "port": 18789,
+                "path": "/",
+                "auth": {"type": "none", "token_source": None},
+            },
+        ],
+    )
+
+
+def test_admin_sees_all_shortcuts(test_client, admin_auth_headers, agent_with_shortcuts):
+    """Admin user with all caps must see all shortcuts."""
+    agent_id = agent_with_shortcuts["id"]
+    resp = test_client.get(
+        f"/api/agents/{agent_id}/shortcuts", headers=admin_auth_headers
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 2
+    assert data[0]["kind"] == "container-terminal"
+    assert data[0]["idx"] == 0
+    assert data[1]["kind"] == "dashboard"
+    assert data[1]["idx"] == 1
+
+
+def test_chat_only_user_sees_no_shortcuts(
+    test_client, chat_only_auth_headers, agent_with_shortcuts
+):
+    """User with only 'chat' cap must see an empty list."""
+    agent_id = agent_with_shortcuts["id"]
+    resp = test_client.get(
+        f"/api/agents/{agent_id}/shortcuts", headers=chat_only_auth_headers
+    )
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_agent_shell_cap_only(
+    test_client, shell_only_auth_headers, agent_with_shortcuts
+):
+    """User with agent.shell cap only sees the terminal shortcut, not dashboard."""
+    agent_id = agent_with_shortcuts["id"]
+    resp = test_client.get(
+        f"/api/agents/{agent_id}/shortcuts", headers=shell_only_auth_headers
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    kinds = [s["kind"] for s in data]
+    assert "container-terminal" in kinds
+    assert "dashboard" not in kinds
+
+
+def test_unknown_agent_returns_404(test_client, admin_auth_headers):
+    resp = test_client.get(
+        "/api/agents/nonexistent-id/shortcuts", headers=admin_auth_headers
+    )
+    assert resp.status_code == 404
+
+
+def test_unauthenticated_returns_401(test_client, agent_with_shortcuts):
+    agent_id = agent_with_shortcuts["id"]
+    resp = test_client.get(f"/api/agents/{agent_id}/shortcuts")
+    assert resp.status_code == 401

--- a/tests/shortcuts/test_auth_capabilities.py
+++ b/tests/shortcuts/test_auth_capabilities.py
@@ -1,0 +1,44 @@
+"""
+Verify that the user record carries a capabilities set and that
+primary / admin users are seeded with all caps while new users get {chat}.
+"""
+from tinyagentos.auth import AuthManager
+from tinyagentos.shortcuts.capabilities import (
+    CAP_AGENT_DASHBOARD,
+    CAP_AGENT_SHELL,
+    CAP_AGENT_TERMINAL,
+    CAP_CHAT,
+)
+
+
+def test_primary_user_has_all_capabilities(tmp_path):
+    """Primary user (admin / first setup) must have all four capabilities."""
+    mgr = AuthManager(tmp_path)
+    mgr.setup_user("admin", "Admin", "", "adminpass")
+    user = mgr.get_primary_user()
+    caps = set(user.get("capabilities", []))
+    assert CAP_CHAT in caps
+    assert CAP_AGENT_SHELL in caps
+    assert CAP_AGENT_TERMINAL in caps
+    assert CAP_AGENT_DASHBOARD in caps
+
+
+def test_new_user_has_only_chat_capability(tmp_path):
+    """Users created via the normal invite flow must default to {chat}."""
+    mgr = AuthManager(tmp_path)
+    mgr.setup_user("admin", "Admin", "", "adminpass")
+    code = mgr.add_user_invite("testcap_user", "admin")
+    user = mgr.complete_invite("testcap_user", code, "Test Cap", "", "hunter2")
+    caps = set(user.get("capabilities", []))
+    assert caps == {"chat"}
+
+
+def test_capabilities_persisted_on_user_record(tmp_path):
+    """capabilities key must survive a round-trip through the user store."""
+    mgr = AuthManager(tmp_path)
+    mgr.setup_user("admin", "Admin", "", "adminpass")
+    code = mgr.add_user_invite("testcap_persist", "admin")
+    user = mgr.complete_invite("testcap_persist", code, "Test Persist", "", "hunter2")
+    fetched = mgr.get_user_by_id(user["id"])
+    assert "capabilities" in fetched
+    assert set(fetched["capabilities"]) == {"chat"}

--- a/tests/shortcuts/test_auth_capabilities.py
+++ b/tests/shortcuts/test_auth_capabilities.py
@@ -1,7 +1,11 @@
 """
 Verify that the user record carries a capabilities set and that
 primary / admin users are seeded with all caps while new users get {chat}.
+Also verifies that legacy records without a capabilities key are migrated
+on read rather than silently returning an empty list.
 """
+import json
+
 from tinyagentos.auth import AuthManager
 from tinyagentos.shortcuts.capabilities import (
     CAP_AGENT_DASHBOARD,
@@ -42,3 +46,69 @@ def test_capabilities_persisted_on_user_record(tmp_path):
     fetched = mgr.get_user_by_id(user["id"])
     assert "capabilities" in fetched
     assert set(fetched["capabilities"]) == {"chat"}
+
+
+def test_legacy_primary_user_without_capabilities_gets_admin_defaults(tmp_path):
+    """A legacy user record without a capabilities key (pre-shortcuts install)
+    must be projected with admin caps (all four) for the primary user."""
+    user_file = tmp_path / ".auth_user.json"
+    user_file.write_text(json.dumps({
+        "users": [
+            {
+                "id": "legacy-001",
+                "username": "legacy_admin",
+                "full_name": "Legacy Admin",
+                "email": "",
+                "password_hash": "salt:hash",
+                "is_admin": True,
+                "created_at": "2024-01-01T00:00:00",
+                "last_login_at": None,
+                # No "capabilities" key — simulates a pre-shortcuts install.
+            }
+        ],
+        "current_user_id": "legacy-001",
+    }))
+    mgr = AuthManager(tmp_path)
+    user = mgr.get_primary_user()
+    assert user is not None
+    caps = set(user["capabilities"])
+    assert CAP_CHAT in caps
+    assert CAP_AGENT_SHELL in caps
+    assert CAP_AGENT_TERMINAL in caps
+    assert CAP_AGENT_DASHBOARD in caps
+
+
+def test_legacy_non_primary_user_without_capabilities_gets_chat_only(tmp_path):
+    """A legacy secondary user record without capabilities must default to {chat}
+    so they are not silently locked out of the basic shortcut."""
+    user_file = tmp_path / ".auth_user.json"
+    user_file.write_text(json.dumps({
+        "users": [
+            {
+                "id": "primary-001",
+                "username": "admin",
+                "full_name": "Admin",
+                "email": "",
+                "password_hash": "salt:hash",
+                "is_admin": True,
+                "capabilities": [CAP_CHAT, CAP_AGENT_SHELL, CAP_AGENT_TERMINAL, CAP_AGENT_DASHBOARD],
+            },
+            {
+                "id": "legacy-002",
+                "username": "legacy_user",
+                "full_name": "Legacy User",
+                "email": "",
+                "password_hash": "salt:hash",
+                "is_admin": False,
+                "created_at": "2024-01-01T00:00:00",
+                "last_login_at": None,
+                # No "capabilities" key.
+            },
+        ],
+        "current_user_id": "primary-001",
+    }))
+    mgr = AuthManager(tmp_path)
+    user = mgr.get_user_by_id("legacy-002")
+    assert user is not None
+    caps = set(user["capabilities"])
+    assert caps == {CAP_CHAT}

--- a/tests/shortcuts/test_capabilities.py
+++ b/tests/shortcuts/test_capabilities.py
@@ -1,0 +1,55 @@
+import pytest
+from tinyagentos.shortcuts.capabilities import (
+    CAP_AGENT_DASHBOARD,
+    CAP_AGENT_SHELL,
+    CAP_AGENT_TERMINAL,
+    CAP_CHAT,
+    default_caps_for_admin,
+    default_caps_for_new_user,
+    user_has_capability,
+)
+
+
+def test_cap_constants_are_strings():
+    assert CAP_CHAT == "chat"
+    assert CAP_AGENT_SHELL == "agent.shell"
+    assert CAP_AGENT_TERMINAL == "agent.terminal"
+    assert CAP_AGENT_DASHBOARD == "agent.dashboard"
+
+
+def test_default_caps_for_admin_includes_all():
+    caps = default_caps_for_admin()
+    assert CAP_CHAT in caps
+    assert CAP_AGENT_SHELL in caps
+    assert CAP_AGENT_TERMINAL in caps
+    assert CAP_AGENT_DASHBOARD in caps
+
+
+def test_default_caps_for_new_user_is_chat_only():
+    caps = default_caps_for_new_user()
+    assert caps == {CAP_CHAT}
+
+
+def test_user_has_capability_true():
+    user = {"capabilities": {CAP_CHAT, CAP_AGENT_SHELL}}
+    assert user_has_capability(user, CAP_AGENT_SHELL) is True
+
+
+def test_user_has_capability_false():
+    user = {"capabilities": {CAP_CHAT}}
+    assert user_has_capability(user, CAP_AGENT_SHELL) is False
+
+
+def test_user_has_capability_missing_key_returns_false():
+    user = {}
+    assert user_has_capability(user, CAP_CHAT) is False
+
+
+def test_default_caps_for_admin_returns_frozenset_or_set():
+    caps = default_caps_for_admin()
+    assert isinstance(caps, (set, frozenset))
+
+
+def test_default_caps_for_new_user_returns_frozenset_or_set():
+    caps = default_caps_for_new_user()
+    assert isinstance(caps, (set, frozenset))

--- a/tests/shortcuts/test_framework_shortcuts.py
+++ b/tests/shortcuts/test_framework_shortcuts.py
@@ -1,0 +1,64 @@
+"""Verify the shortcuts field on each beta framework matches the spec."""
+import pytest
+from tinyagentos.frameworks import FRAMEWORKS
+from tinyagentos.shortcuts.validation import validate_shortcuts
+
+
+def _shortcuts(name: str) -> list:
+    fw = FRAMEWORKS.get(name)
+    assert fw is not None, f"Framework '{name}' not in FRAMEWORKS"
+    return fw.get("shortcuts", [])
+
+
+@pytest.mark.parametrize("fw_name", [
+    "openclaw", "hermes", "smolagents", "pocketflow", "langroid", "openai-agents-sdk",
+])
+def test_framework_shortcuts_present(fw_name):
+    """Each beta framework declares at least one shortcut entry."""
+    assert len(_shortcuts(fw_name)) >= 1, f"{fw_name} has no shortcuts"
+
+
+def test_openclaw_shortcuts_exact():
+    """openclaw has 4 shortcuts: shell, tui x2, dashboard."""
+    shortcuts = _shortcuts("openclaw")
+    assert len(shortcuts) == 4
+    kinds = [s["kind"] for s in shortcuts]
+    assert kinds == ["container-terminal", "tui", "tui", "dashboard"]
+    dash = shortcuts[3]
+    assert dash["port"] == 18789
+    assert dash["auth"]["type"] == "bearer"
+    assert dash["auth"]["token_source"]["kind"] == "container_file"
+    assert dash["auth"]["token_source"]["path"] == "/root/.openclaw/openclaw.json"
+    assert dash["auth"]["token_source"]["json_pointer"] == "/gateway/auth/token"
+
+
+def test_hermes_shortcuts_exact():
+    """hermes: shell + 2 tui."""
+    shortcuts = _shortcuts("hermes")
+    assert len(shortcuts) == 3
+    assert shortcuts[0]["kind"] == "container-terminal"
+    assert shortcuts[1]["command"] == "hermes"
+    assert shortcuts[2]["command"] == "hermes doctor"
+
+
+def test_smolagents_shortcuts_exact():
+    """smolagents: shell + 1 tui."""
+    shortcuts = _shortcuts("smolagents")
+    assert len(shortcuts) == 2
+    assert shortcuts[1]["command"] == "smolagent"
+
+
+def test_shell_only_frameworks():
+    """pocketflow, langroid, openai-agents-sdk: 1 shortcut each (container-terminal)."""
+    for fw in ("pocketflow", "langroid", "openai-agents-sdk"):
+        shortcuts = _shortcuts(fw)
+        assert len(shortcuts) == 1, f"{fw} should have 1 shortcut"
+        assert shortcuts[0]["kind"] == "container-terminal"
+
+
+@pytest.mark.parametrize("fw_name", [
+    "openclaw", "hermes", "smolagents", "pocketflow", "langroid", "openai-agents-sdk",
+])
+def test_all_framework_shortcuts_validate(fw_name):
+    """validate_shortcuts() passes without raising for every beta framework."""
+    validate_shortcuts(_shortcuts(fw_name))

--- a/tests/shortcuts/test_frameworks_wire.py
+++ b/tests/shortcuts/test_frameworks_wire.py
@@ -1,0 +1,53 @@
+"""
+Verify that frameworks.py accepts a `shortcuts` field and validate_framework_manifest
+checks shortcut entries.
+"""
+import copy
+import pytest
+
+from tinyagentos.frameworks import FRAMEWORKS, validate_framework_manifest
+
+
+def _first_framework_with_shortcuts():
+    for name, fw in FRAMEWORKS.items():
+        if fw.get("shortcuts"):
+            return name, fw
+    return None, None
+
+
+def test_validate_accepts_shortcuts_field():
+    """validate_framework_manifest must not raise when shortcuts are well-formed."""
+    name, fw = _first_framework_with_shortcuts()
+    if fw is None:
+        pytest.skip("No framework has shortcuts yet — will pass after Task 11 adds them")
+    validate_framework_manifest(name, fw)  # must not raise
+
+
+def test_validate_rejects_malformed_shortcut():
+    """validate_framework_manifest raises ValueError for a bad shortcut entry."""
+    name, fw = _first_framework_with_shortcuts()
+    if fw is None:
+        pytest.skip("No framework has shortcuts yet")
+    bad = copy.deepcopy(fw)
+    bad["shortcuts"][0].pop("kind")
+    with pytest.raises(ValueError, match="missing 'kind'"):
+        validate_framework_manifest(name, bad)
+
+
+def test_shortcuts_field_is_optional():
+    """A framework without shortcuts is still valid."""
+    validate_framework_manifest(
+        "test-no-shortcuts",
+        {
+            "display_name": "Test Framework",
+            "shortcuts": [],
+        },
+    )
+
+
+def test_shortcuts_field_absent_ok():
+    """A framework dict without the shortcuts key is still valid."""
+    validate_framework_manifest(
+        "test-absent",
+        {"display_name": "Test Framework"},
+    )

--- a/tests/shortcuts/test_frameworks_wire.py
+++ b/tests/shortcuts/test_frameworks_wire.py
@@ -39,7 +39,8 @@ def test_shortcuts_field_is_optional():
     validate_framework_manifest(
         "test-no-shortcuts",
         {
-            "display_name": "Test Framework",
+            "id": "test-no-shortcuts",
+            "name": "Test Framework",
             "shortcuts": [],
         },
     )
@@ -49,5 +50,5 @@ def test_shortcuts_field_absent_ok():
     """A framework dict without the shortcuts key is still valid."""
     validate_framework_manifest(
         "test-absent",
-        {"display_name": "Test Framework"},
+        {"id": "test-absent", "name": "Test Framework"},
     )

--- a/tests/shortcuts/test_jti_eviction.py
+++ b/tests/shortcuts/test_jti_eviction.py
@@ -1,0 +1,30 @@
+import time
+import pytest
+from tinyagentos.shortcuts.tickets import JtiTracker, _GLOBAL_JTI_TRACKER
+
+
+def test_global_tracker_is_jti_tracker_instance():
+    assert isinstance(_GLOBAL_JTI_TRACKER, JtiTracker)
+
+
+def test_eviction_removes_expired_entries():
+    tracker = JtiTracker()
+    past_exp = int(time.time()) - 1
+    tracker.record("expired-jti", exp=past_exp)
+    tracker.seen("other-jti")
+    assert "expired-jti" not in tracker._seen
+
+
+def test_eviction_keeps_live_entries():
+    tracker = JtiTracker()
+    future_exp = int(time.time()) + 60
+    tracker.record("live-jti", exp=future_exp)
+    tracker.seen("probe")
+    assert "live-jti" in tracker._seen
+
+
+def test_seen_returns_false_after_eviction():
+    tracker = JtiTracker()
+    past_exp = int(time.time()) - 1
+    tracker.record("stale-jti", exp=past_exp)
+    assert tracker.seen("stale-jti") is False

--- a/tests/shortcuts/test_jti_eviction.py
+++ b/tests/shortcuts/test_jti_eviction.py
@@ -1,3 +1,4 @@
+import threading
 import time
 import pytest
 from tinyagentos.shortcuts.tickets import JtiTracker, _GLOBAL_JTI_TRACKER
@@ -28,3 +29,51 @@ def test_seen_returns_false_after_eviction():
     past_exp = int(time.time()) - 1
     tracker.record("stale-jti", exp=past_exp)
     assert tracker.seen("stale-jti") is False
+
+
+# ---------------------------------------------------------------------------
+# Atomic record_if_new tests (C2 fix)
+# ---------------------------------------------------------------------------
+
+def test_record_if_new_returns_true_first_time():
+    tracker = JtiTracker()
+    exp = int(time.time()) + 30
+    assert tracker.record_if_new("jti-abc", exp) is True
+
+
+def test_record_if_new_returns_false_on_duplicate():
+    tracker = JtiTracker()
+    exp = int(time.time()) + 30
+    tracker.record_if_new("jti-dup", exp)
+    assert tracker.record_if_new("jti-dup", exp) is False
+
+
+def test_record_if_new_concurrent_only_one_wins():
+    """Two threads racing on the same JTI: exactly one must win."""
+    tracker = JtiTracker()
+    exp = int(time.time()) + 30
+    results: list[bool] = []
+    barrier = threading.Barrier(2)
+
+    def _race():
+        barrier.wait()  # both threads start at roughly the same time
+        results.append(tracker.record_if_new("shared-jti", exp))
+
+    t1 = threading.Thread(target=_race)
+    t2 = threading.Thread(target=_race)
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    # Exactly one True and one False
+    assert sorted(results) == [False, True]
+
+
+def test_record_if_new_evicts_expired_before_check():
+    tracker = JtiTracker()
+    past_exp = int(time.time()) - 1
+    # Pre-insert with expired timestamp
+    tracker._seen["stale"] = past_exp
+    # record_if_new should evict the expired entry, then record fresh
+    assert tracker.record_if_new("stale", int(time.time()) + 30) is True

--- a/tests/shortcuts/test_tickets.py
+++ b/tests/shortcuts/test_tickets.py
@@ -1,0 +1,112 @@
+import time
+import pytest
+from tinyagentos.shortcuts.tickets import (
+    JtiTracker,
+    Ticket,
+    mint_ticket,
+    validate_ticket,
+)
+
+SIGNING_KEY = b"test-signing-key-32-bytes-padded"
+
+
+def test_mint_returns_ticket_and_token():
+    ticket, token = mint_ticket(
+        agent_id="agent-123",
+        shortcut_idx=0,
+        scope="dashboard",
+        signing_key=SIGNING_KEY,
+        worker_url="http://127.0.0.1:6969",
+        ttl=30,
+    )
+    assert ticket.agent_id == "agent-123"
+    assert ticket.shortcut_idx == 0
+    assert ticket.scope == "dashboard"
+    assert ticket.worker_url == "http://127.0.0.1:6969"
+    assert isinstance(ticket.jti, str) and len(ticket.jti) == 32
+    assert ticket.exp > int(time.time())
+    assert isinstance(token, str) and len(token) > 0
+
+
+def test_validate_returns_ticket_for_valid_token():
+    ticket, token = mint_ticket(
+        agent_id="agent-456",
+        shortcut_idx=1,
+        scope="terminal",
+        signing_key=SIGNING_KEY,
+        worker_url="http://127.0.0.1:6969",
+        ttl=30,
+    )
+    tracker = JtiTracker()
+    decoded = validate_ticket(token, signing_key=SIGNING_KEY, tracker=tracker)
+    assert decoded.agent_id == "agent-456"
+    assert decoded.shortcut_idx == 1
+    assert decoded.scope == "terminal"
+
+
+def test_validate_raises_on_bad_hmac():
+    _, token = mint_ticket(
+        agent_id="x",
+        shortcut_idx=0,
+        scope="dashboard",
+        signing_key=SIGNING_KEY,
+        worker_url="http://127.0.0.1:6969",
+        ttl=30,
+    )
+    wrong_key = b"wrong-key-32-bytes-padding-paddd"
+    tracker = JtiTracker()
+    with pytest.raises(ValueError, match="invalid signature"):
+        validate_ticket(token, signing_key=wrong_key, tracker=tracker)
+
+
+def test_validate_raises_on_expired_ticket():
+    _, token = mint_ticket(
+        agent_id="x",
+        shortcut_idx=0,
+        scope="dashboard",
+        signing_key=SIGNING_KEY,
+        worker_url="http://127.0.0.1:6969",
+        ttl=-1,  # already expired
+    )
+    tracker = JtiTracker()
+    with pytest.raises(ValueError, match="ticket expired"):
+        validate_ticket(token, signing_key=SIGNING_KEY, tracker=tracker)
+
+
+def test_validate_raises_on_replayed_jti():
+    ticket, token = mint_ticket(
+        agent_id="x",
+        shortcut_idx=0,
+        scope="dashboard",
+        signing_key=SIGNING_KEY,
+        worker_url="http://127.0.0.1:6969",
+        ttl=30,
+    )
+    tracker = JtiTracker()
+    validate_ticket(token, signing_key=SIGNING_KEY, tracker=tracker)
+    with pytest.raises(ValueError, match="replayed jti"):
+        validate_ticket(token, signing_key=SIGNING_KEY, tracker=tracker)
+
+
+def test_jti_tracker_seen_false_before_record():
+    tracker = JtiTracker()
+    assert tracker.seen("abc") is False
+
+
+def test_jti_tracker_seen_true_after_record():
+    tracker = JtiTracker()
+    tracker.record("abc", exp=int(time.time()) + 30)
+    assert tracker.seen("abc") is True
+
+
+def test_ticket_dataclass_fields():
+    t = Ticket(
+        agent_id="a",
+        shortcut_idx=2,
+        scope="terminal",
+        exp=9999999999,
+        jti="aabbcc",
+        worker_url="http://x",
+    )
+    assert t.agent_id == "a"
+    assert t.shortcut_idx == 2

--- a/tests/shortcuts/test_tickets.py
+++ b/tests/shortcuts/test_tickets.py
@@ -110,3 +110,39 @@ def test_ticket_dataclass_fields():
     )
     assert t.agent_id == "a"
     assert t.shortcut_idx == 2
+
+
+# ---------------------------------------------------------------------------
+# M4 — signing key length enforcement
+# ---------------------------------------------------------------------------
+
+def test_mint_ticket_rejects_short_key():
+    """mint_ticket must reject signing keys shorter than 32 bytes."""
+    with pytest.raises(ValueError, match="at least 32 bytes"):
+        mint_ticket(
+            agent_id="a",
+            shortcut_idx=0,
+            scope="dashboard",
+            signing_key=b"too-short",
+            worker_url="http://x",
+        )
+
+
+def test_validate_ticket_rejects_short_key():
+    """validate_ticket must reject signing keys shorter than 32 bytes."""
+    tracker = JtiTracker()
+    with pytest.raises(ValueError, match="at least 32 bytes"):
+        validate_ticket("anytoken", signing_key=b"short", tracker=tracker)
+
+
+def test_mint_accepts_exactly_32_byte_key():
+    """A 32-byte key is the minimum valid key length."""
+    key = b"x" * 32
+    ticket, token = mint_ticket(
+        agent_id="a",
+        shortcut_idx=0,
+        scope="dashboard",
+        signing_key=key,
+        worker_url="http://x",
+    )
+    assert token  # didn't raise

--- a/tests/shortcuts/test_token_source.py
+++ b/tests/shortcuts/test_token_source.py
@@ -81,3 +81,80 @@ def test_unknown_kind_raises():
     _clear_cache()
     with pytest.raises(ValueError, match="unknown token_source kind"):
         read_token_source(AGENT, {"kind": "magic", "value": "x"})
+
+
+# ---------------------------------------------------------------------------
+# M1 — shell injection safety
+# ---------------------------------------------------------------------------
+
+def test_container_env_uses_printenv_not_sh_c(monkeypatch):
+    """container_env must invoke printenv, not sh -c (shell injection fix)."""
+    _clear_cache()
+    captured_cmd: list = []
+
+    def fake_run(cmd, **kwargs):
+        captured_cmd.extend(cmd)
+        return MagicMock(stdout="token123\n", returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    source = {"kind": "container_env", "var": "MY_TOKEN"}
+    read_token_source(AGENT, source)
+
+    assert "sh" not in captured_cmd
+    assert "-c" not in captured_cmd
+    assert "printenv" in captured_cmd
+
+
+def test_container_env_rejects_invalid_var_name(monkeypatch):
+    """var names with shell-special chars must be rejected (return None)."""
+    _clear_cache()
+    mock_run = MagicMock()
+    monkeypatch.setattr(subprocess, "run", mock_run)
+
+    # These should all be rejected without calling subprocess.run
+    bad_vars = [
+        "FOO; rm -rf /tmp",
+        "FOO|bar",
+        "foo",          # lowercase not allowed
+        "123STARTS",    # starts with digit
+        "",
+    ]
+    for bad_var in bad_vars:
+        source = {"kind": "container_env", "var": bad_var}
+        result = read_token_source(AGENT, source)
+        assert result is None, f"Expected None for var={bad_var!r}, got {result!r}"
+    mock_run.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# M5 — subprocess exception handling
+# ---------------------------------------------------------------------------
+
+def test_container_env_handles_file_not_found(monkeypatch):
+    """FileNotFoundError (incus missing) must return None, not raise."""
+    _clear_cache()
+
+    def fake_run(*args, **kwargs):
+        raise FileNotFoundError("incus not found")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    source = {"kind": "container_env", "var": "MY_TOKEN"}
+    result = read_token_source(AGENT, source)
+    assert result is None
+
+
+def test_container_file_handles_timeout(monkeypatch):
+    """TimeoutExpired must return None, not raise."""
+    _clear_cache()
+
+    def fake_run(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=10)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    source = {
+        "kind": "container_file",
+        "path": "/etc/config.json",
+        "json_pointer": "/key",
+    }
+    result = read_token_source(AGENT, source)
+    assert result is None

--- a/tests/shortcuts/test_token_source.py
+++ b/tests/shortcuts/test_token_source.py
@@ -1,0 +1,83 @@
+import json
+import subprocess
+from unittest.mock import MagicMock, patch
+import pytest
+
+from tinyagentos.shortcuts.token_source import read_token_source, _cache
+
+
+AGENT = "test-agent"
+
+
+def _clear_cache():
+    _cache.clear()
+
+
+def test_static_source_returns_value():
+    _clear_cache()
+    source = {"kind": "static", "value": "my-static-token"}
+    result = read_token_source(AGENT, source)
+    assert result == "my-static-token"
+
+
+def test_container_env_calls_incus(monkeypatch):
+    _clear_cache()
+    mock_run = MagicMock(
+        return_value=MagicMock(stdout="env-token-value\n", returncode=0)
+    )
+    monkeypatch.setattr(subprocess, "run", mock_run)
+    source = {"kind": "container_env", "var": "MY_TOKEN"}
+    result = read_token_source(AGENT, source)
+    assert result == "env-token-value"
+    args = mock_run.call_args[0][0]
+    assert "incus" in args[0]
+    assert f"taos-agent-{AGENT}" in args
+
+
+def test_container_file_extracts_json_pointer(monkeypatch):
+    _clear_cache()
+    data = {"gateway": {"auth": {"token": "file-token-123"}}}
+    mock_run = MagicMock(
+        return_value=MagicMock(stdout=json.dumps(data), returncode=0)
+    )
+    monkeypatch.setattr(subprocess, "run", mock_run)
+    source = {
+        "kind": "container_file",
+        "path": "/root/.openclaw/openclaw.json",
+        "json_pointer": "/gateway/auth/token",
+    }
+    result = read_token_source(AGENT, source)
+    assert result == "file-token-123"
+
+
+def test_container_env_returns_none_on_incus_failure(monkeypatch):
+    _clear_cache()
+    mock_run = MagicMock(
+        return_value=MagicMock(stdout="", returncode=1)
+    )
+    monkeypatch.setattr(subprocess, "run", mock_run)
+    source = {"kind": "container_env", "var": "MISSING_VAR"}
+    result = read_token_source(AGENT, source)
+    assert result is None
+
+
+def test_result_is_cached_on_second_call(monkeypatch):
+    _clear_cache()
+    call_count = 0
+
+    def fake_run(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return MagicMock(stdout="cached-token\n", returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    source = {"kind": "container_env", "var": "CACHED_VAR"}
+    read_token_source(AGENT, source)
+    read_token_source(AGENT, source)
+    assert call_count == 1
+
+
+def test_unknown_kind_raises():
+    _clear_cache()
+    with pytest.raises(ValueError, match="unknown token_source kind"):
+        read_token_source(AGENT, {"kind": "magic", "value": "x"})

--- a/tests/shortcuts/test_token_source_invalidation.py
+++ b/tests/shortcuts/test_token_source_invalidation.py
@@ -1,0 +1,46 @@
+import subprocess
+from unittest.mock import MagicMock
+import pytest
+from tinyagentos.shortcuts.token_source import (
+    read_token_source,
+    invalidate_agent_cache,
+    _cache,
+)
+
+AGENT = "inv-agent"
+
+
+def test_invalidate_clears_only_target_agent(monkeypatch):
+    """invalidate_agent_cache(agent) removes that agent's entries but not others."""
+    _cache.clear()
+    call_count = {"a": 0, "b": 0}
+
+    def fake_run(args, **kwargs):
+        name = args[2]  # "taos-agent-<name>"
+        if "inv-agent" in name:
+            call_count["a"] += 1
+            return MagicMock(stdout="token-a\n", returncode=0)
+        call_count["b"] += 1
+        return MagicMock(stdout="token-b\n", returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    source = {"kind": "container_env", "var": "TOK"}
+    read_token_source("inv-agent", source)
+    read_token_source("other-agent", source)
+
+    assert call_count["a"] == 1
+    assert call_count["b"] == 1
+
+    invalidate_agent_cache("inv-agent")
+
+    read_token_source("inv-agent", source)
+    assert call_count["a"] == 2  # new call
+
+    read_token_source("other-agent", source)
+    assert call_count["b"] == 1  # still cached
+
+
+def test_invalidate_nonexistent_agent_is_noop():
+    """invalidate_agent_cache on an unknown agent must not raise."""
+    invalidate_agent_cache("ghost-agent")  # must not raise

--- a/tests/shortcuts/test_token_source_thread_safety.py
+++ b/tests/shortcuts/test_token_source_thread_safety.py
@@ -1,0 +1,68 @@
+"""M1 — thread-safety of _cache under concurrent invalidate/read."""
+from __future__ import annotations
+
+import subprocess
+import threading
+import time
+from unittest.mock import MagicMock
+
+from tinyagentos.shortcuts.token_source import (
+    _cache,
+    read_token_source,
+    invalidate_agent_cache,
+)
+
+AGENT = "thread-test-agent"
+OTHER = "other-thread-agent"
+
+
+def test_concurrent_invalidate_while_reading():
+    """invalidate_agent_cache racing with read_token_source must not raise."""
+    _cache.clear()
+    call_log: list[str] = []
+    lock = threading.Lock()
+
+    def fake_run(args, **kwargs):
+        name = args[2]
+        with lock:
+            call_log.append(name)
+        time.sleep(0.01)  # simulate slow incus
+        return MagicMock(stdout="token\n", returncode=0)
+
+    # Monkey-patch subprocess.run in the module
+    import tinyagentos.shortcuts.token_source as ts_mod
+    original_run = ts_mod.subprocess.run
+    ts_mod.subprocess.run = fake_run  # type: ignore[assignment]
+
+    try:
+        source = {"kind": "container_env", "var": "TOK"}
+
+        errors: list[Exception] = []
+
+        def reader():
+            try:
+                for _ in range(20):
+                    read_token_source(AGENT, source)
+            except Exception as exc:
+                errors.append(exc)
+
+        def invalidator():
+            try:
+                for _ in range(20):
+                    invalidate_agent_cache(AGENT)
+                    time.sleep(0.005)
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=reader) for _ in range(4)]
+        threads += [threading.Thread(target=invalidator) for _ in range(2)]
+
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert errors == [], f"Thread errors: {errors}"
+    finally:
+        ts_mod.subprocess.run = original_run  # type: ignore[assignment]
+        _cache.clear()

--- a/tests/shortcuts/test_types.py
+++ b/tests/shortcuts/test_types.py
@@ -1,0 +1,63 @@
+import pytest
+from tinyagentos.shortcuts.types import (
+    ContainerTerminalShortcut,
+    DashboardAuth,
+    DashboardShortcut,
+    ShortcutCommon,
+    TokenSource,
+    TuiShortcut,
+)
+
+
+def test_container_terminal_shortcut_fields():
+    s: ContainerTerminalShortcut = {
+        "kind": "container-terminal",
+        "label": "Container shell",
+        "icon": "terminal",
+        "requires_capability": "agent.shell",
+    }
+    assert s["kind"] == "container-terminal"
+    assert s["requires_capability"] == "agent.shell"
+
+
+def test_tui_shortcut_fields():
+    s: TuiShortcut = {
+        "kind": "tui",
+        "label": "OpenClaw agent",
+        "icon": "tui",
+        "requires_capability": "agent.terminal",
+        "command": "openclaw agent",
+    }
+    assert s["command"] == "openclaw agent"
+
+
+def test_dashboard_shortcut_fields():
+    auth: DashboardAuth = {
+        "type": "bearer",
+        "token_source": {
+            "kind": "container_file",
+            "path": "/root/.openclaw/openclaw.json",
+            "json_pointer": "/gateway/auth/token",
+        },
+    }
+    s: DashboardShortcut = {
+        "kind": "dashboard",
+        "label": "Gateway dashboard",
+        "icon": "dashboard",
+        "requires_capability": "agent.dashboard",
+        "port": 18789,
+        "path": "/",
+        "auth": auth,
+    }
+    assert s["port"] == 18789
+    assert s["auth"]["type"] == "bearer"
+
+
+def test_token_source_container_env():
+    ts: TokenSource = {"kind": "container_env", "var": "OPENCLAW_TOKEN"}
+    assert ts["kind"] == "container_env"
+
+
+def test_token_source_static():
+    ts: TokenSource = {"kind": "static", "value": "dev-token"}
+    assert ts["value"] == "dev-token"

--- a/tests/shortcuts/test_validation.py
+++ b/tests/shortcuts/test_validation.py
@@ -1,0 +1,125 @@
+import pytest
+from tinyagentos.shortcuts.validation import validate_shortcuts
+
+
+def test_valid_container_terminal():
+    entries = [
+        {
+            "kind": "container-terminal",
+            "label": "Container shell",
+            "icon": "terminal",
+            "requires_capability": "agent.shell",
+        }
+    ]
+    validate_shortcuts(entries)  # must not raise
+
+
+def test_valid_tui():
+    entries = [
+        {
+            "kind": "tui",
+            "label": "OpenClaw agent",
+            "icon": "tui",
+            "requires_capability": "agent.terminal",
+            "command": "openclaw agent",
+        }
+    ]
+    validate_shortcuts(entries)
+
+
+def test_valid_dashboard():
+    entries = [
+        {
+            "kind": "dashboard",
+            "label": "Gateway dashboard",
+            "icon": "dashboard",
+            "requires_capability": "agent.dashboard",
+            "port": 18789,
+            "path": "/",
+            "auth": {"type": "none", "token_source": None},
+        }
+    ]
+    validate_shortcuts(entries)
+
+
+def test_missing_kind_raises():
+    with pytest.raises(ValueError, match="missing 'kind'"):
+        validate_shortcuts([{"label": "X", "icon": "y", "requires_capability": "chat"}])
+
+
+def test_unknown_kind_raises():
+    with pytest.raises(ValueError, match="unknown shortcut kind"):
+        validate_shortcuts(
+            [
+                {
+                    "kind": "magic",
+                    "label": "X",
+                    "icon": "y",
+                    "requires_capability": "chat",
+                }
+            ]
+        )
+
+
+def test_tui_missing_command_raises():
+    with pytest.raises(ValueError, match="'command' is required"):
+        validate_shortcuts(
+            [
+                {
+                    "kind": "tui",
+                    "label": "X",
+                    "icon": "tui",
+                    "requires_capability": "agent.terminal",
+                }
+            ]
+        )
+
+
+def test_dashboard_missing_port_raises():
+    with pytest.raises(ValueError, match="'port' is required"):
+        validate_shortcuts(
+            [
+                {
+                    "kind": "dashboard",
+                    "label": "X",
+                    "icon": "dashboard",
+                    "requires_capability": "agent.dashboard",
+                    "path": "/",
+                    "auth": {"type": "none", "token_source": None},
+                }
+            ]
+        )
+
+
+def test_dashboard_missing_auth_raises():
+    with pytest.raises(ValueError, match="'auth' is required"):
+        validate_shortcuts(
+            [
+                {
+                    "kind": "dashboard",
+                    "label": "X",
+                    "icon": "dashboard",
+                    "requires_capability": "agent.dashboard",
+                    "port": 8080,
+                    "path": "/",
+                }
+            ]
+        )
+
+
+def test_missing_common_fields_raises():
+    with pytest.raises(ValueError, match="missing required field"):
+        validate_shortcuts(
+            [
+                {
+                    "kind": "container-terminal",
+                    "icon": "terminal",
+                    "requires_capability": "agent.shell",
+                    # label missing
+                }
+            ]
+        )
+
+
+def test_empty_list_ok():
+    validate_shortcuts([])  # must not raise

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -497,6 +497,13 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         except Exception:
             logger.exception("auto-update service failed to start")
         await cluster_manager.start()
+        # Enroll this controller as the 'local' cluster worker so route-layer
+        # code (get_local_worker) picks up the in-memory signing key.
+        from tinyagentos.cluster.local_worker import enroll_local_worker
+        from tinyagentos.cluster.worker_registry import set_active_manager
+        _bind_port = config.server.get("port", 6969)
+        await enroll_local_worker(cluster_manager, bind_port=_bind_port)
+        set_active_manager(cluster_manager)
         # Start the live backend catalog — everything that asks "what's
         # available?" reads from this rather than the filesystem.
         try:

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -1059,6 +1059,9 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     from tinyagentos.routes.memory_management import router as memory_management_router
     app.include_router(memory_management_router)
 
+    from tinyagentos.routes.shortcuts import router as shortcuts_router
+    app.include_router(shortcuts_router)
+
     return app
 
 

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -1062,6 +1062,9 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     from tinyagentos.routes.shortcuts import router as shortcuts_router
     app.include_router(shortcuts_router)
 
+    from tinyagentos.routes.shortcut_proxy import router as shortcut_proxy_router
+    app.include_router(shortcut_proxy_router)
+
     return app
 
 

--- a/tinyagentos/auth.py
+++ b/tinyagentos/auth.py
@@ -7,6 +7,9 @@ import secrets
 import time
 from collections.abc import Iterator
 from pathlib import Path
+from typing import Any
+
+from fastapi import HTTPException, Request
 
 from tinyagentos.shortcuts.capabilities import default_caps_for_admin, default_caps_for_new_user
 
@@ -565,3 +568,27 @@ class AuthManager:
                 data["users"] = users
                 self._write_users(data)
                 return
+
+
+# ---------------------------------------------------------------------------
+# FastAPI dependency
+# ---------------------------------------------------------------------------
+
+
+def get_current_user(request: Request) -> dict[str, Any]:
+    """FastAPI dependency — return the current session user or raise 401.
+
+    Reads the ``taos_session`` cookie.  The auth middleware already blocks
+    unauthenticated requests before they reach route handlers, but this
+    dependency also handles the case where the middleware was bypassed (e.g.
+    direct TestClient calls without a cookie) and returns the capability-rich
+    user dict needed for capability checks.
+    """
+    auth_mgr = request.app.state.auth
+    token = request.cookies.get("taos_session", "")
+    if not token:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    user = auth_mgr.session_user(token)
+    if user is None:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    return user

--- a/tinyagentos/auth.py
+++ b/tinyagentos/auth.py
@@ -8,6 +8,8 @@ import time
 from collections.abc import Iterator
 from pathlib import Path
 
+from tinyagentos.shortcuts.capabilities import default_caps_for_admin, default_caps_for_new_user
+
 logger = logging.getLogger(__name__)
 
 
@@ -148,6 +150,8 @@ class AuthManager:
     # ------------------------------------------------------------------ #
 
     def _public_user(self, record: dict) -> dict:
+        raw_caps = record.get("capabilities")
+        caps: list[str] = list(raw_caps) if raw_caps is not None else []
         return {
             "id": record.get("id", ""),
             "username": record.get("username", ""),
@@ -157,11 +161,26 @@ class AuthManager:
             "pending": "pending_invite" in record,
             "last_login_at": record.get("last_login_at"),
             "created_at": record.get("created_at"),
+            "capabilities": caps,
         }
 
     # ------------------------------------------------------------------ #
     #  User lookups                                                        #
     # ------------------------------------------------------------------ #
+
+    def get_primary_user(self) -> dict | None:
+        """Return the public profile of the primary/admin user (first in the list)."""
+        users = self._read_users().get("users", [])
+        if users:
+            return self._public_user(users[0])
+        return None
+
+    def get_user_by_id(self, user_id: str) -> dict | None:
+        """Return the public profile for *user_id*, or None if not found."""
+        record = self._find_user_by_id(user_id)
+        if record:
+            return self._public_user(record)
+        return None
 
     def find_user(self, username: str) -> dict | None:
         for u in self._read_users().get("users", []):
@@ -223,6 +242,7 @@ class AuthManager:
             "password_hash": hash_password(password),
             "created_at": int(time.time()),
             "is_admin": True,
+            "capabilities": list(default_caps_for_admin()),
         }
         users["users"] = [record]
         users["current_user_id"] = record["id"]
@@ -282,6 +302,7 @@ class AuthManager:
         record["email"] = email
         record["password_hash"] = hash_password(password)
         record["created_at"] = int(time.time())
+        record["capabilities"] = list(default_caps_for_new_user())
         users[target_idx] = record
         data["users"] = users
         self._write_users(data)

--- a/tinyagentos/auth.py
+++ b/tinyagentos/auth.py
@@ -154,7 +154,17 @@ class AuthManager:
 
     def _public_user(self, record: dict) -> dict:
         raw_caps = record.get("capabilities")
-        caps: list[str] = list(raw_caps) if raw_caps is not None else []
+        if raw_caps is not None:
+            caps: list[str] = list(raw_caps)
+        else:
+            # Legacy record predates capabilities — apply sensible defaults so
+            # upgrades don't silently lock users out of every shortcut.
+            users = self._read_users().get("users", [])
+            is_primary = bool(users) and users[0].get("id") == record.get("id")
+            if is_primary or record.get("is_admin"):
+                caps = list(default_caps_for_admin())
+            else:
+                caps = list(default_caps_for_new_user())
         return {
             "id": record.get("id", ""),
             "username": record.get("username", ""),

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -11,7 +11,9 @@ EXEMPT_PATHS = {"/auth/login", "/auth/setup", "/auth/status", "/auth/me", "/auth
 # through the normal auth gate so an unauthenticated request hits a
 # server-side redirect instead of rendering whatever stale bundle the
 # browser cached.
-EXEMPT_PREFIXES = ("/static/", "/desktop/assets/", "/chat-pwa/assets/", "/ws/")
+# /shortcut/ routes use their own taos_shortcut session cookie for auth;
+# they are intentionally excluded from the main session gate here.
+EXEMPT_PREFIXES = ("/static/", "/desktop/assets/", "/chat-pwa/assets/", "/ws/", "/shortcut/")
 
 
 class AuthMiddleware(BaseHTTPMiddleware):

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -5,7 +5,7 @@ from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import RedirectResponse
 
-EXEMPT_PATHS = {"/auth/login", "/auth/setup", "/auth/status", "/auth/me", "/auth/complete", "/auth/lock", "/api/health", "/api/cluster/workers", "/api/cluster/heartbeat", "/setup", "/setup/complete"}
+EXEMPT_PATHS = {"/auth/login", "/auth/setup", "/auth/status", "/auth/me", "/auth/complete", "/auth/lock", "/api/health", "/api/cluster/workers", "/api/cluster/heartbeat", "/setup", "/setup/complete", "/redeem"}
 # Bundle assets must be reachable without auth so the SPA can paint the
 # login screen. The SPA shell itself (/desktop and /chat-pwa) goes
 # through the normal auth gate so an unauthenticated request hits a

--- a/tinyagentos/cluster/local_worker.py
+++ b/tinyagentos/cluster/local_worker.py
@@ -1,9 +1,8 @@
 """Enroll the local taOS controller as a cluster worker.
 
-Called during app lifespan to register a 'local' WorkerInfo in the
-ClusterManager with a fresh random signing key.  The signing key is
-in-memory only (regenerated on restart); persisting it to disk is
-deferred to a later task.
+Called during app lifespan. Idempotent: calling twice on the same manager keeps
+the same signing key (the worker registration is left untouched on subsequent
+calls). The signing key is in-memory only (regenerated on restart).
 """
 from __future__ import annotations
 
@@ -12,15 +11,30 @@ import os
 from tinyagentos.cluster.manager import ClusterManager
 from tinyagentos.cluster.worker_protocol import WorkerInfo
 
+# Module-level. Survives across calls within the same process. Reset on restart.
+_LOCAL_SIGNING_KEY: bytes | None = None
+
 
 async def enroll_local_worker(manager: ClusterManager, bind_port: int = 6969) -> None:
-    """Register the 'local' worker in *manager* with a random 32-byte signing key."""
-    signing_key = os.urandom(32)
+    """Register the 'local' worker in *manager*. Idempotent.
+
+    On first call, generates a 32-byte random signing key and registers the
+    worker. On subsequent calls (same process, same manager) the existing
+    worker is left untouched.
+    """
+    global _LOCAL_SIGNING_KEY
+
+    if manager.get_worker("local") is not None:
+        return  # already enrolled, leave it alone
+
+    if _LOCAL_SIGNING_KEY is None:
+        _LOCAL_SIGNING_KEY = os.urandom(32)
+
     worker = WorkerInfo(
         name="local",
         url=f"http://127.0.0.1:{bind_port}",
         worker_url=f"http://127.0.0.1:{bind_port}",
-        signing_key=signing_key,
+        signing_key=_LOCAL_SIGNING_KEY,
         platform="local",
     )
     await manager.register_worker(worker)

--- a/tinyagentos/cluster/local_worker.py
+++ b/tinyagentos/cluster/local_worker.py
@@ -1,0 +1,26 @@
+"""Enroll the local taOS controller as a cluster worker.
+
+Called during app lifespan to register a 'local' WorkerInfo in the
+ClusterManager with a fresh random signing key.  The signing key is
+in-memory only (regenerated on restart); persisting it to disk is
+deferred to a later task.
+"""
+from __future__ import annotations
+
+import os
+
+from tinyagentos.cluster.manager import ClusterManager
+from tinyagentos.cluster.worker_protocol import WorkerInfo
+
+
+async def enroll_local_worker(manager: ClusterManager, bind_port: int = 6969) -> None:
+    """Register the 'local' worker in *manager* with a random 32-byte signing key."""
+    signing_key = os.urandom(32)
+    worker = WorkerInfo(
+        name="local",
+        url=f"http://127.0.0.1:{bind_port}",
+        worker_url=f"http://127.0.0.1:{bind_port}",
+        signing_key=signing_key,
+        platform="local",
+    )
+    await manager.register_worker(worker)

--- a/tinyagentos/cluster/worker_protocol.py
+++ b/tinyagentos/cluster/worker_protocol.py
@@ -46,3 +46,7 @@ class WorkerInfo:
     kv_cache_quant_k_support: list[str] = field(default_factory=lambda: ["fp16"])
     kv_cache_quant_v_support: list[str] = field(default_factory=lambda: ["fp16"])
     kv_cache_quant_boundary_layer_protect: bool = False
+    # Shortcut / worker-registry fields (Tasks 22-23)
+    worker_url: str | None = None          # Public URL used by shortcut proxy
+    signing_key: bytes = field(default_factory=bytes)  # HMAC key for ticket signing
+    tls_cert_provider: str | None = None   # e.g. "letsencrypt", None = plain HTTP

--- a/tinyagentos/cluster/worker_registry.py
+++ b/tinyagentos/cluster/worker_registry.py
@@ -1,0 +1,24 @@
+# tinyagentos/cluster/worker_registry.py
+"""Worker registry — full implementation lands in Tasks 22-23.
+
+For now, exposes get_local_worker() returning a stub for the local single-Pi case.
+Tasks 22-23 will extend this to handle remote workers, signing keys, and tls_cert_provider.
+"""
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+# Local worker config; signing key is a deterministic fixed value for now.
+# Tasks 22-23 replace this with proper key generation persisted to disk.
+_LOCAL_SIGNING_KEY: bytes = hashlib.sha256(b"taos-local-worker-default-signing-key-v1").digest()
+_LOCAL_WORKER_URL: str = "http://127.0.0.1:6969"
+
+
+def get_local_worker() -> dict[str, Any]:
+    """Return the local worker's config: worker_url and signing_key."""
+    return {
+        "worker_url": _LOCAL_WORKER_URL,
+        "signing_key": _LOCAL_SIGNING_KEY,
+        "name": "local",
+    }

--- a/tinyagentos/cluster/worker_registry.py
+++ b/tinyagentos/cluster/worker_registry.py
@@ -35,6 +35,10 @@ def get_local_worker() -> dict[str, Any]:
     worker = _active_manager.get_worker("local")
     if worker is None:
         raise RuntimeError("Local worker not registered with ClusterManager")
+    if not worker.signing_key or len(worker.signing_key) < 32:
+        raise RuntimeError("Local worker has missing or short signing_key (need ≥32 bytes)")
+    if not worker.worker_url:
+        raise RuntimeError("Local worker has empty worker_url")
     return {
         "worker_url": worker.worker_url,
         "signing_key": worker.signing_key,

--- a/tinyagentos/cluster/worker_registry.py
+++ b/tinyagentos/cluster/worker_registry.py
@@ -1,24 +1,50 @@
 # tinyagentos/cluster/worker_registry.py
-"""Worker registry — full implementation lands in Tasks 22-23.
+"""Bridge between the route-side `get_local_worker()` API and the cluster manager.
 
-For now, exposes get_local_worker() returning a stub for the local single-Pi case.
-Tasks 22-23 will extend this to handle remote workers, signing keys, and tls_cert_provider.
+After Task 23 lands enroll_local_worker, this module looks up "local" in
+ClusterManager and returns the WorkerInfo as a dict. If no manager exists
+(e.g., during unit tests that don't start the app), falls back to the
+stub key for compatibility.
 """
 from __future__ import annotations
 
 import hashlib
-from typing import Any
+from typing import Any, Optional
 
-# Local worker config; signing key is a deterministic fixed value for now.
-# Tasks 22-23 replace this with proper key generation persisted to disk.
-_LOCAL_SIGNING_KEY: bytes = hashlib.sha256(b"taos-local-worker-default-signing-key-v1").digest()
-_LOCAL_WORKER_URL: str = "http://127.0.0.1:6969"
+from tinyagentos.cluster.manager import ClusterManager
+
+# Stub key used as fallback when no ClusterManager has enrolled a local worker
+# (mostly for unit tests that don't invoke the app lifespan).
+_FALLBACK_SIGNING_KEY: bytes = hashlib.sha256(
+    b"taos-local-worker-default-signing-key-v1"
+).digest()
+_FALLBACK_WORKER_URL: str = "http://127.0.0.1:6969"
+
+# Module-level reference to the active ClusterManager. Set by app startup.
+_active_manager: Optional[ClusterManager] = None
+
+
+def set_active_manager(manager: ClusterManager) -> None:
+    """Called by app startup to register the active ClusterManager."""
+    global _active_manager
+    _active_manager = manager
 
 
 def get_local_worker() -> dict[str, Any]:
-    """Return the local worker's config: worker_url and signing_key."""
+    """Return the local worker config as a dict.
+
+    Reads from the active ClusterManager if available; falls back to the stub.
+    """
+    if _active_manager is not None:
+        worker = _active_manager.get_worker("local")
+        if worker is not None:
+            return {
+                "worker_url": worker.worker_url or _FALLBACK_WORKER_URL,
+                "signing_key": worker.signing_key or _FALLBACK_SIGNING_KEY,
+                "name": worker.name,
+            }
     return {
-        "worker_url": _LOCAL_WORKER_URL,
-        "signing_key": _LOCAL_SIGNING_KEY,
+        "worker_url": _FALLBACK_WORKER_URL,
+        "signing_key": _FALLBACK_SIGNING_KEY,
         "name": "local",
     }

--- a/tinyagentos/cluster/worker_registry.py
+++ b/tinyagentos/cluster/worker_registry.py
@@ -1,26 +1,15 @@
 # tinyagentos/cluster/worker_registry.py
-"""Bridge between the route-side `get_local_worker()` API and the cluster manager.
+"""Bridge from the route-side `get_local_worker()` API to the ClusterManager.
 
-After Task 23 lands enroll_local_worker, this module looks up "local" in
-ClusterManager and returns the WorkerInfo as a dict. If no manager exists
-(e.g., during unit tests that don't start the app), falls back to the
-stub key for compatibility.
+Tasks 22-23 register the local worker via enroll_local_worker(); this module
+just exposes that registration to non-async callers (route handlers).
 """
 from __future__ import annotations
 
-import hashlib
 from typing import Any, Optional
 
 from tinyagentos.cluster.manager import ClusterManager
 
-# Stub key used as fallback when no ClusterManager has enrolled a local worker
-# (mostly for unit tests that don't invoke the app lifespan).
-_FALLBACK_SIGNING_KEY: bytes = hashlib.sha256(
-    b"taos-local-worker-default-signing-key-v1"
-).digest()
-_FALLBACK_WORKER_URL: str = "http://127.0.0.1:6969"
-
-# Module-level reference to the active ClusterManager. Set by app startup.
 _active_manager: Optional[ClusterManager] = None
 
 
@@ -33,18 +22,21 @@ def set_active_manager(manager: ClusterManager) -> None:
 def get_local_worker() -> dict[str, Any]:
     """Return the local worker config as a dict.
 
-    Reads from the active ClusterManager if available; falls back to the stub.
+    Raises RuntimeError if no manager has been registered or if the local
+    worker has not been enrolled — fail closed to prevent forging tickets
+    with a fallback key.
     """
-    if _active_manager is not None:
-        worker = _active_manager.get_worker("local")
-        if worker is not None:
-            return {
-                "worker_url": worker.worker_url or _FALLBACK_WORKER_URL,
-                "signing_key": worker.signing_key or _FALLBACK_SIGNING_KEY,
-                "name": worker.name,
-            }
+    if _active_manager is None:
+        raise RuntimeError(
+            "No active ClusterManager — local worker not enrolled. "
+            "Tests must call set_active_manager(test_manager); production "
+            "calls it from app startup after enroll_local_worker()."
+        )
+    worker = _active_manager.get_worker("local")
+    if worker is None:
+        raise RuntimeError("Local worker not registered with ClusterManager")
     return {
-        "worker_url": _FALLBACK_WORKER_URL,
-        "signing_key": _FALLBACK_SIGNING_KEY,
-        "name": "local",
+        "worker_url": worker.worker_url,
+        "signing_key": worker.signing_key,
+        "name": worker.name,
     }

--- a/tinyagentos/containers/apple_backend.py
+++ b/tinyagentos/containers/apple_backend.py
@@ -221,6 +221,9 @@ class AppleContainerBackend(ContainerBackend):
                 snapshots.append(tag)
         return {"success": True, "snapshots": snapshots, "output": output}
 
+    def spawn_pty(self, name: str, cmd: list[str] | None = None):
+        raise NotImplementedError("apple spawn_pty not yet implemented")
+
     async def set_env(self, name: str, key: str, value: str) -> dict:
         return {
             "success": False,

--- a/tinyagentos/containers/backend.py
+++ b/tinyagentos/containers/backend.py
@@ -37,6 +37,26 @@ def _parse_memory(mem_str: str) -> int:
         return 0
 
 
+class PtyHandle(ABC):
+    """Abstract handle to an open PTY session inside a container."""
+
+    @abstractmethod
+    def read(self, size: int = 4096) -> bytes:
+        """Read up to size bytes from the PTY. Blocks until data available."""
+
+    @abstractmethod
+    def write(self, data: bytes) -> None:
+        """Write bytes to the PTY stdin."""
+
+    @abstractmethod
+    def resize(self, rows: int, cols: int) -> None:
+        """Notify the PTY of a terminal resize."""
+
+    @abstractmethod
+    def close(self) -> None:
+        """Close the PTY and terminate the subprocess."""
+
+
 class ContainerBackend(ABC):
     """Abstract base class for container runtime backends."""
 
@@ -182,6 +202,14 @@ class ContainerBackend(ABC):
         Returns ``{"success": bool, "snapshots": list[str], "output": str}``.
         """
         ...
+
+    @abstractmethod
+    def spawn_pty(self, name: str, cmd: list[str] | None = None) -> PtyHandle:
+        """Open an interactive PTY in container name.
+
+        If cmd is None, the container's default shell is used.
+        cmd is passed via bash -lc <cmd> so PATH from .bashrc is honoured.
+        """
 
     @abstractmethod
     async def set_env(self, name: str, key: str, value: str) -> dict:

--- a/tinyagentos/containers/docker.py
+++ b/tinyagentos/containers/docker.py
@@ -265,6 +265,9 @@ class DockerBackend(ContainerBackend):
         ]
         return {"success": True, "snapshots": snapshots, "output": output}
 
+    def spawn_pty(self, name: str, cmd: list[str] | None = None):
+        raise NotImplementedError("docker spawn_pty not yet implemented")
+
     async def set_env(self, name: str, key: str, value: str) -> dict:
         """Docker does not support per-container env changes without recreating.
 

--- a/tinyagentos/containers/lxc.py
+++ b/tinyagentos/containers/lxc.py
@@ -4,10 +4,66 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
+import pty
+import select
+import shlex
+import signal
+import subprocess
 
-from .backend import ContainerBackend, ContainerInfo, _parse_memory
+from .backend import ContainerBackend, ContainerInfo, PtyHandle, _parse_memory
 
 logger = logging.getLogger(__name__)
+
+
+class _IncusPtyHandle(PtyHandle):
+    """PtyHandle backed by a real incus exec subprocess with a pseudo-tty."""
+
+    def __init__(self, proc: subprocess.Popen, master_fd: int) -> None:
+        self._proc = proc
+        self._master_fd = master_fd
+
+    def read(self, size: int = 4096) -> bytes:
+        ready, _, _ = select.select([self._master_fd], [], [], 0.1)
+        if ready:
+            return os.read(self._master_fd, size)
+        return b""
+
+    def write(self, data: bytes) -> None:
+        os.write(self._master_fd, data)
+
+    def resize(self, rows: int, cols: int) -> None:
+        import fcntl
+        import struct
+        import termios
+        winsize = struct.pack("HHHH", rows, cols, 0, 0)
+        fcntl.ioctl(self._master_fd, termios.TIOCSWINSZ, winsize)
+
+    def close(self) -> None:
+        try:
+            self._proc.send_signal(signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        try:
+            os.close(self._master_fd)
+        except OSError:
+            pass
+        self._proc.wait(timeout=5)
+
+
+def _open_incus_pty(container: str, shell_cmd: str) -> _IncusPtyHandle:
+    """Open an incus exec session with a real PTY."""
+    master_fd, slave_fd = pty.openpty()
+    proc = subprocess.Popen(
+        ["incus", "exec", "--tty", "--interactive", container, "--",
+         "bash", "-lc", shell_cmd],
+        stdin=slave_fd,
+        stdout=slave_fd,
+        stderr=slave_fd,
+        close_fds=True,
+    )
+    os.close(slave_fd)
+    return _IncusPtyHandle(proc, master_fd)
 
 
 async def _run(cmd: list[str], timeout: int = 120) -> tuple[int, str]:
@@ -274,6 +330,14 @@ class LXCBackend(ContainerBackend):
                     snap_name = stripped.split()[0]
                     snapshots.append(snap_name)
         return {"success": True, "snapshots": snapshots, "output": output}
+
+    def spawn_pty(self, name: str, cmd: list[str] | None = None) -> PtyHandle:
+        container = f"taos-agent-{name}"
+        if cmd is None:
+            shell_cmd = "exec bash -l"
+        else:
+            shell_cmd = " ".join(shlex.quote(c) for c in cmd)
+        return _open_incus_pty(container, shell_cmd)
 
     async def set_env(self, name: str, key: str, value: str) -> dict:
         """Set an environment variable on the container via incus config set.

--- a/tinyagentos/frameworks.py
+++ b/tinyagentos/frameworks.py
@@ -152,12 +152,13 @@ def validate_framework_manifest(
 
     Raises FrameworkManifestError if required fields are absent.
     """
+    for base_field in ("id", "name"):
+        if base_field not in entry:
+            raise FrameworkManifestError(
+                f"Framework {fw_id!r}: missing required field {base_field!r}"
+            )
+
     if require_update_fields:
-        for base_field in ("id", "name"):
-            if base_field not in entry:
-                raise FrameworkManifestError(
-                    f"Framework {fw_id!r}: missing required field {base_field!r}"
-                )
         missing = [f for f in _REQUIRED_UPDATE_FIELDS if f not in entry]
         if missing:
             raise FrameworkManifestError(

--- a/tinyagentos/frameworks.py
+++ b/tinyagentos/frameworks.py
@@ -218,4 +218,4 @@ def validate_framework_manifest(
         try:
             validate_shortcuts(shortcuts)
         except ValueError as exc:
-            raise ValueError(f"framework '{fw_id}': {exc}") from exc
+            raise FrameworkManifestError(f"framework '{fw_id}': {exc}") from exc

--- a/tinyagentos/frameworks.py
+++ b/tinyagentos/frameworks.py
@@ -24,6 +24,25 @@ FRAMEWORKS: dict[str, dict] = {
             {"name": "compact", "description": "Summarise and compact context"},
             {"name": "cost", "description": "Show token spend for this session"},
         ],
+        "shortcuts": [
+            {"kind": "container-terminal", "label": "Container shell",
+             "icon": "terminal", "requires_capability": "agent.shell"},
+            {"kind": "tui", "label": "OpenClaw agent",
+             "command": "openclaw agent",
+             "icon": "tui", "requires_capability": "agent.terminal"},
+            {"kind": "tui", "label": "OpenClaw doctor",
+             "command": "openclaw doctor",
+             "icon": "diagnostic", "requires_capability": "agent.terminal"},
+            {"kind": "dashboard", "label": "Gateway dashboard",
+             "port": 18789, "path": "/",
+             "auth": {
+                 "type": "bearer",
+                 "token_source": {"kind": "container_file",
+                                  "path": "/root/.openclaw/openclaw.json",
+                                  "json_pointer": "/gateway/auth/token"},
+             },
+             "icon": "dashboard", "requires_capability": "agent.dashboard"},
+        ],
     },
     "smolagents": {
         "id": "smolagents",
@@ -32,6 +51,13 @@ FRAMEWORKS: dict[str, dict] = {
         "verification_status": "beta",
         "slash_commands": [
             {"name": "help", "description": "Show SmolAgents help"},
+        ],
+        "shortcuts": [
+            {"kind": "container-terminal", "label": "Container shell",
+             "icon": "terminal", "requires_capability": "agent.shell"},
+            {"kind": "tui", "label": "SmolAgents interactive",
+             "command": "smolagent",
+             "icon": "tui", "requires_capability": "agent.terminal"},
         ],
     },
     "generic": {
@@ -48,6 +74,10 @@ FRAMEWORKS: dict[str, dict] = {
         "slash_commands": [
             {"name": "help", "description": "Show PocketFlow help"},
         ],
+        "shortcuts": [
+            {"kind": "container-terminal", "label": "Container shell",
+             "icon": "terminal", "requires_capability": "agent.shell"},
+        ],
     },
     "langroid": {
         "id": "langroid",
@@ -57,6 +87,10 @@ FRAMEWORKS: dict[str, dict] = {
         "slash_commands": [
             {"name": "help", "description": "Show Langroid help"},
         ],
+        "shortcuts": [
+            {"kind": "container-terminal", "label": "Container shell",
+             "icon": "terminal", "requires_capability": "agent.shell"},
+        ],
     },
     "openai-agents-sdk": {
         "id": "openai-agents-sdk",
@@ -65,6 +99,10 @@ FRAMEWORKS: dict[str, dict] = {
         "verification_status": "beta",
         "slash_commands": [
             {"name": "help", "description": "Show Agents SDK help"},
+        ],
+        "shortcuts": [
+            {"kind": "container-terminal", "label": "Container shell",
+             "icon": "terminal", "requires_capability": "agent.shell"},
         ],
     },
     "hermes": {
@@ -76,6 +114,16 @@ FRAMEWORKS: dict[str, dict] = {
             {"name": "help", "description": "List available commands"},
             {"name": "clear", "description": "Clear the session context"},
             {"name": "model", "description": "Show or change active model"},
+        ],
+        "shortcuts": [
+            {"kind": "container-terminal", "label": "Container shell",
+             "icon": "terminal", "requires_capability": "agent.shell"},
+            {"kind": "tui", "label": "Hermes chat",
+             "command": "hermes",
+             "icon": "tui", "requires_capability": "agent.terminal"},
+            {"kind": "tui", "label": "Hermes doctor",
+             "command": "hermes doctor",
+             "icon": "diagnostic", "requires_capability": "agent.terminal"},
         ],
     },
     "agent_zero": {

--- a/tinyagentos/frameworks.py
+++ b/tinyagentos/frameworks.py
@@ -1,6 +1,8 @@
 """Framework manifest registry with update-metadata and validation."""
 from __future__ import annotations
 
+from tinyagentos.shortcuts.validation import validate_shortcuts
+
 
 class FrameworkManifestError(ValueError):
     """Raised when a framework manifest entry is invalid or incomplete."""
@@ -150,15 +152,21 @@ def validate_framework_manifest(
 
     Raises FrameworkManifestError if required fields are absent.
     """
-    for base_field in ("id", "name"):
-        if base_field not in entry:
-            raise FrameworkManifestError(
-                f"Framework {fw_id!r}: missing required field {base_field!r}"
-            )
-
     if require_update_fields:
+        for base_field in ("id", "name"):
+            if base_field not in entry:
+                raise FrameworkManifestError(
+                    f"Framework {fw_id!r}: missing required field {base_field!r}"
+                )
         missing = [f for f in _REQUIRED_UPDATE_FIELDS if f not in entry]
         if missing:
             raise FrameworkManifestError(
                 f"Framework {fw_id!r}: missing update fields: {missing}"
             )
+
+    shortcuts = entry.get("shortcuts")
+    if shortcuts is not None:
+        try:
+            validate_shortcuts(shortcuts)
+        except ValueError as exc:
+            raise ValueError(f"framework '{fw_id}': {exc}") from exc

--- a/tinyagentos/routes/shortcut_proxy.py
+++ b/tinyagentos/routes/shortcut_proxy.py
@@ -1,17 +1,32 @@
-"""Worker /redeem endpoint — validates HMAC ticket, sets cookie, 302."""
+"""Worker /redeem endpoint — validates HMAC ticket, sets cookie, 302.
+
+Also contains the shortcut dashboard reverse-proxy route:
+  GET  /shortcut/dashboard/{agent_name}/{idx}/{path:path}
+
+Auth injection and WebSocket proxy are added in subsequent tasks.
+"""
 from __future__ import annotations
 
+import logging
 import secrets
 import time
-from typing import Any
+from http.cookies import SimpleCookie
+from typing import Any, Optional
 
-from fastapi import APIRouter, HTTPException, Query
-from fastapi.responses import RedirectResponse
+import httpx
+from fastapi import APIRouter, HTTPException, Query, Request, WebSocket
+from fastapi.responses import RedirectResponse, StreamingResponse
 
 from tinyagentos.shortcuts.tickets import validate_ticket, _GLOBAL_JTI_TRACKER
 from tinyagentos.cluster.worker_registry import get_local_worker
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter()
+
+# ---------------------------------------------------------------------------
+# Session store (shared between /redeem and proxy routes)
+# ---------------------------------------------------------------------------
 
 # In-memory session store: session_id -> {agent_id, shortcut_idx, scope, expires_at}
 _sessions: dict[str, dict[str, Any]] = {}
@@ -46,6 +61,181 @@ def _scope_to_path(scope: str, agent_id: str, shortcut_idx: int) -> str:
         return f"/shortcut/dashboard/{agent_id}/{shortcut_idx}/"
     return f"/shortcut/terminal/{agent_id}/{shortcut_idx}"
 
+
+# ---------------------------------------------------------------------------
+# Proxy helpers — Task 17: basic HTTP forward
+# ---------------------------------------------------------------------------
+
+# Hop-by-hop headers that must not be forwarded (RFC 2616 §13.5.1).
+_HOP_BY_HOP_PROXY = frozenset({
+    "connection",
+    "keep-alive",
+    "proxy-authorization",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+    "host",
+})
+
+# Controller cookies that must not leak to upstream containers.
+_STRIPPED_PROXY_COOKIES = frozenset({"taos_session", "taos_shortcut"})
+
+
+def _filter_proxy_headers(headers: dict[str, str]) -> dict[str, str]:
+    """Strip hop-by-hop and sensitive cookies; return a clean header dict."""
+    filtered: dict[str, str] = {}
+    for k, v in headers.items():
+        kl = k.lower()
+        if kl in _HOP_BY_HOP_PROXY:
+            continue
+        if kl == "cookie":
+            jar = SimpleCookie()
+            try:
+                jar.load(v)
+            except Exception:
+                filtered[k] = v
+                continue
+            for name in _STRIPPED_PROXY_COOKIES:
+                jar.pop(name, None)
+            stripped = "; ".join(f"{ck}={m.value}" for ck, m in jar.items())
+            if stripped:
+                filtered[k] = stripped
+            # If all cookies were controller-owned, drop the header entirely.
+            continue
+        filtered[k] = v
+    return filtered
+
+
+def _resolve_container_ip(request: Request, agent_name: str) -> Optional[str]:
+    """Return the container IP for *agent_name*, or None if not found.
+
+    Looks up the agent in app.state.config.agents by id OR name.
+    The 'host' field stores the IP set at deploy time.
+    """
+    agents = getattr(request.app.state.config, "agents", [])
+    for agent in agents:
+        if agent.get("id") == agent_name or agent.get("name") == agent_name:
+            return agent.get("host") or None
+    return None
+
+
+def _get_shortcuts_for_agent(request: Request, agent_name: str) -> list[dict[str, Any]]:
+    """Return the framework shortcuts list for agent_name, or []."""
+    from tinyagentos.frameworks import FRAMEWORKS
+    agents = getattr(request.app.state.config, "agents", [])
+    for agent in agents:
+        if agent.get("id") == agent_name or agent.get("name") == agent_name:
+            framework = FRAMEWORKS.get(agent.get("framework", ""), {})
+            return framework.get("shortcuts", [])
+    return []
+
+
+def _get_shortcut_from_cookie(
+    connection: Any,
+    agent_name: str,
+    idx: int,
+    shortcuts: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Validate the taos_shortcut cookie and return the shortcut dict.
+
+    Raises HTTPException:
+      401 — missing/expired session
+      403 — session doesn't match agent_name or idx
+      404 — shortcut idx out of range
+    """
+    session_id = connection.cookies.get("taos_shortcut")
+    if not session_id:
+        raise HTTPException(status_code=401, detail="No shortcut session cookie")
+
+    session = _get_session(session_id)  # raises 401 if missing/expired
+
+    if session["agent_id"] != agent_name:
+        raise HTTPException(status_code=403, detail="Session agent mismatch")
+
+    if session["shortcut_idx"] != idx:
+        raise HTTPException(status_code=403, detail="Session shortcut index mismatch")
+
+    if idx < 0 or idx >= len(shortcuts):
+        raise HTTPException(status_code=404, detail=f"Shortcut idx {idx} not found")
+
+    return shortcuts[idx]
+
+
+# Module-level async HTTP client — reused across requests.
+_proxy_client = httpx.AsyncClient(timeout=60.0)
+
+
+async def proxy_dashboard(
+    agent_name: str,
+    shortcut: dict[str, Any],
+    request: Request,
+) -> Any:
+    """Forward the HTTP request to the agent's container dashboard port.
+
+    Resolves container IP, strips hop-by-hop headers, and streams the
+    upstream response back to the client.
+    """
+    ip = _resolve_container_ip(request, agent_name)
+    if ip is None:
+        return _json_error(
+            f"No container IP for agent '{agent_name}' — is the container running?",
+            503,
+        )
+
+    port = shortcut["port"]
+    base_path = (shortcut.get("path") or "/").rstrip("/")
+    upstream_path = base_path + "/"
+
+    upstream_url = f"http://{ip}:{port}{upstream_path}"
+    query = request.url.query
+    if query:
+        upstream_url = f"{upstream_url}?{query}"
+
+    fwd_headers = _filter_proxy_headers(dict(request.headers))
+
+    async def _stream_body():
+        async for chunk in request.stream():
+            yield chunk
+
+    try:
+        req = _proxy_client.build_request(
+            method=request.method,
+            url=upstream_url,
+            headers=fwd_headers,
+            content=_stream_body(),
+        )
+        upstream_resp = await _proxy_client.send(req, stream=True, follow_redirects=False)
+    except httpx.ConnectError as exc:
+        return _json_error(
+            f"Cannot reach agent '{agent_name}' dashboard at {ip}:{port}: {exc}",
+            502,
+        )
+    except httpx.TimeoutException:
+        return _json_error(
+            f"Agent '{agent_name}' dashboard at {ip}:{port} timed out",
+            504,
+        )
+
+    resp_headers = _filter_proxy_headers(dict(upstream_resp.headers))
+
+    from starlette.background import BackgroundTask
+    return StreamingResponse(
+        upstream_resp.aiter_bytes(),
+        status_code=upstream_resp.status_code,
+        headers=resp_headers,
+        background=BackgroundTask(upstream_resp.aclose),
+    )
+
+
+def _json_error(message: str, status_code: int):
+    from fastapi.responses import JSONResponse
+    return JSONResponse({"error": message}, status_code=status_code)
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
 
 @router.get("/redeem")
 async def redeem_ticket(
@@ -84,3 +274,26 @@ async def redeem_ticket(
         path="/",
     )
     return response
+
+
+@router.api_route(
+    "/shortcut/dashboard/{agent_name}/{idx}/{path:path}",
+    methods=["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"],
+    include_in_schema=False,
+)
+async def shortcut_dashboard_proxy(
+    agent_name: str,
+    idx: int,
+    path: str,
+    request: Request,
+):
+    """Reverse-proxy for shortcut dashboards.
+
+    Validates the taos_shortcut cookie, resolves the container IP,
+    then forwards the request to the container port.
+    """
+    shortcuts = _get_shortcuts_for_agent(request, agent_name)
+    shortcut = _get_shortcut_from_cookie(request, agent_name, idx, shortcuts)
+    shortcut = {**shortcut, "_idx": idx}
+
+    return await proxy_dashboard(agent_name, shortcut, request)

--- a/tinyagentos/routes/shortcut_proxy.py
+++ b/tinyagentos/routes/shortcut_proxy.py
@@ -3,10 +3,12 @@
 Also contains the shortcut dashboard reverse-proxy route:
   GET  /shortcut/dashboard/{agent_name}/{idx}/{path:path}
 
-Auth injection and WebSocket proxy are added in subsequent tasks.
+WebSocket proxy is added in the next task.
 """
 from __future__ import annotations
 
+import asyncio
+import base64
 import logging
 import secrets
 import time
@@ -166,6 +168,38 @@ def _get_shortcut_from_cookie(
 _proxy_client = httpx.AsyncClient(timeout=60.0)
 
 
+async def _build_auth_header(
+    agent_name: str,
+    shortcut: dict[str, Any],
+) -> Optional[tuple[str, str]]:
+    """Return (header_name, header_value) for the shortcut's auth config, or None.
+
+    Reads the token via read_token_source (sync) wrapped in asyncio.to_thread
+    so the event loop is not blocked.
+    """
+    auth = shortcut.get("auth") or {}
+    auth_type = auth.get("type", "none")
+    if auth_type == "none":
+        return None
+
+    token_source = auth.get("token_source")
+    if not token_source:
+        return None
+
+    from tinyagentos.shortcuts.token_source import read_token_source
+    token = await asyncio.to_thread(read_token_source, agent_name, token_source)
+    if not token:
+        return None
+
+    if auth_type == "bearer":
+        return ("Authorization", f"Bearer {token}")
+    if auth_type == "basic":
+        encoded = base64.b64encode(token.encode()).decode()
+        return ("Authorization", f"Basic {encoded}")
+
+    return None
+
+
 async def proxy_dashboard(
     agent_name: str,
     shortcut: dict[str, Any],
@@ -193,6 +227,11 @@ async def proxy_dashboard(
         upstream_url = f"{upstream_url}?{query}"
 
     fwd_headers = _filter_proxy_headers(dict(request.headers))
+
+    # Inject auth header if configured.
+    auth_header = await _build_auth_header(agent_name, shortcut)
+    if auth_header:
+        fwd_headers[auth_header[0]] = auth_header[1]
 
     async def _stream_body():
         async for chunk in request.stream():

--- a/tinyagentos/routes/shortcut_proxy.py
+++ b/tinyagentos/routes/shortcut_proxy.py
@@ -1,9 +1,8 @@
 """Worker /redeem endpoint — validates HMAC ticket, sets cookie, 302.
 
-Also contains the shortcut dashboard reverse-proxy route:
+Also contains the shortcut reverse-proxy routes:
   GET  /shortcut/dashboard/{agent_name}/{idx}/{path:path}
-
-WebSocket proxy is added in the next task.
+  WS   /shortcut/terminal/{agent_name}/{idx}
 """
 from __future__ import annotations
 
@@ -336,6 +335,91 @@ async def shortcut_dashboard_proxy(
     shortcut = {**shortcut, "_idx": idx}
 
     return await proxy_dashboard(agent_name, shortcut, request)
+
+
+# ---------------------------------------------------------------------------
+# Terminal PTY bridge helpers — Task 20 / 21
+# ---------------------------------------------------------------------------
+
+def _get_container_pty(agent_name: str, cmd: list[str] | None):
+    """Spawn a PTY inside the agent's container.
+
+    Delegates to the active ContainerBackend.spawn_pty.  cmd=None → default
+    shell; cmd=['bash','-lc','<command>'] → tui shortcut.
+    """
+    from tinyagentos.containers.backend import get_backend
+    backend = get_backend()
+    return backend.spawn_pty(agent_name, cmd)
+
+
+@router.websocket("/shortcut/terminal/{agent_name}/{idx}")
+async def shortcut_terminal_ws(
+    agent_name: str,
+    idx: int,
+    websocket: WebSocket,
+):
+    """WebSocket PTY bridge for container-terminal and tui shortcuts.
+
+    Validates the taos_shortcut cookie, opens a PTY inside the agent container
+    via the active ContainerBackend, then pipes data in both directions until
+    either end closes.
+    """
+    shortcuts = _get_shortcuts_for_agent(websocket, agent_name)
+    try:
+        shortcut = _get_shortcut_from_cookie(websocket, agent_name, idx, shortcuts)
+    except HTTPException as exc:
+        await websocket.close(code=1008, reason=exc.detail)
+        return
+
+    scope = shortcut["kind"]
+    if scope not in ("container-terminal", "tui"):
+        await websocket.close(code=1008, reason=f"Unsupported shortcut kind: {scope}")
+        return
+
+    # For tui shortcuts pass the configured command; for container-terminal use
+    # the default shell (cmd=None).
+    if scope == "tui":
+        command = shortcut.get("command", "")
+        cmd: list[str] | None = ["bash", "-lc", command]
+    else:
+        cmd = None
+
+    try:
+        pty_handle = await asyncio.to_thread(_get_container_pty, agent_name, cmd)
+    except Exception as exc:
+        logger.warning("terminal: spawn_pty failed for %s: %s", agent_name, exc)
+        await websocket.close(code=1011, reason="PTY spawn failed")
+        return
+
+    await websocket.accept()
+
+    async def pty_to_ws():
+        try:
+            while True:
+                data = await asyncio.to_thread(pty_handle.read)
+                if not data:
+                    await asyncio.sleep(0.02)
+                    continue
+                await websocket.send_text(data.decode("utf-8", errors="replace"))
+        except Exception:
+            pass
+
+    async def ws_to_pty():
+        try:
+            while True:
+                msg = await websocket.receive_text()
+                await asyncio.to_thread(pty_handle.write, msg.encode("utf-8"))
+        except Exception:
+            pass
+
+    try:
+        await asyncio.gather(pty_to_ws(), ws_to_pty(), return_exceptions=True)
+    finally:
+        await asyncio.to_thread(pty_handle.close)
+        try:
+            await websocket.close()
+        except Exception:
+            pass
 
 
 @router.websocket("/shortcut/dashboard/{agent_name}/{idx}/ws/{path:path}")

--- a/tinyagentos/routes/shortcut_proxy.py
+++ b/tinyagentos/routes/shortcut_proxy.py
@@ -1,0 +1,86 @@
+"""Worker /redeem endpoint — validates HMAC ticket, sets cookie, 302."""
+from __future__ import annotations
+
+import secrets
+import time
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query
+from fastapi.responses import RedirectResponse
+
+from tinyagentos.shortcuts.tickets import validate_ticket, _GLOBAL_JTI_TRACKER
+from tinyagentos.cluster.worker_registry import get_local_worker
+
+router = APIRouter()
+
+# In-memory session store: session_id -> {agent_id, shortcut_idx, scope, expires_at}
+_sessions: dict[str, dict[str, Any]] = {}
+_SESSION_IDLE_TTL = 300  # 5 minutes
+
+
+def _new_session(agent_id: str, shortcut_idx: int, scope: str) -> str:
+    session_id = secrets.token_urlsafe(32)
+    _sessions[session_id] = {
+        "agent_id": agent_id,
+        "shortcut_idx": shortcut_idx,
+        "scope": scope,
+        "expires_at": time.monotonic() + _SESSION_IDLE_TTL,
+    }
+    return session_id
+
+
+def _get_session(session_id: str) -> dict[str, Any]:
+    """Return session or raise HTTPException(401)."""
+    session = _sessions.get(session_id)
+    if session is None:
+        raise HTTPException(status_code=401, detail="Session not found or expired")
+    if time.monotonic() > session["expires_at"]:
+        del _sessions[session_id]
+        raise HTTPException(status_code=401, detail="Session expired")
+    session["expires_at"] = time.monotonic() + _SESSION_IDLE_TTL
+    return session
+
+
+def _scope_to_path(scope: str, agent_id: str, shortcut_idx: int) -> str:
+    if scope == "dashboard":
+        return f"/shortcut/dashboard/{agent_id}/{shortcut_idx}/"
+    return f"/shortcut/terminal/{agent_id}/{shortcut_idx}"
+
+
+@router.get("/redeem")
+async def redeem_ticket(
+    t: str = Query(..., description="Base64url-encoded HMAC ticket"),
+) -> RedirectResponse:
+    """Validate ticket, set session cookie, redirect to the shortcut endpoint."""
+    worker = get_local_worker()
+    signing_key: bytes = worker["signing_key"]
+
+    try:
+        ticket = validate_ticket(t, signing_key=signing_key, tracker=_GLOBAL_JTI_TRACKER)
+    except ValueError as exc:
+        msg = str(exc)
+        if "expired" in msg:
+            detail = "ticket expired"
+        elif "replay" in msg.lower() or "replayed" in msg.lower():
+            detail = "replay detected"
+        else:
+            detail = "invalid ticket"
+        raise HTTPException(status_code=401, detail=detail) from exc
+
+    session_id = _new_session(
+        agent_id=ticket.agent_id,
+        shortcut_idx=ticket.shortcut_idx,
+        scope=ticket.scope,
+    )
+    location = _scope_to_path(ticket.scope, ticket.agent_id, ticket.shortcut_idx)
+
+    response = RedirectResponse(url=location, status_code=302)
+    response.set_cookie(
+        key="taos_shortcut",
+        value=session_id,
+        httponly=True,
+        samesite="lax",
+        max_age=_SESSION_IDLE_TTL,
+        path="/",
+    )
+    return response

--- a/tinyagentos/routes/shortcut_proxy.py
+++ b/tinyagentos/routes/shortcut_proxy.py
@@ -140,18 +140,27 @@ def _get_shortcuts_for_agent(request: Request, agent_name: str) -> list[dict[str
     return []
 
 
+_TERMINAL_SCOPES = frozenset({"container-terminal", "tui"})
+
+
 def _get_shortcut_from_cookie(
     connection: Any,
     agent_name: str,
     idx: int,
     shortcuts: list[dict[str, Any]],
+    expected_scope: Optional[str] = None,
 ) -> dict[str, Any]:
     """Validate the taos_shortcut cookie and return the shortcut dict.
 
     Raises HTTPException:
       401 — missing/expired session
-      403 — session doesn't match agent_name or idx
+      403 — session doesn't match agent_name, idx, or scope
       404 — shortcut idx out of range
+
+    expected_scope:
+      "dashboard" — session scope must be "dashboard"
+      "terminal"  — session scope must be in {"container-terminal", "tui"}
+      None        — scope not checked (backwards-compat)
     """
     session_id = connection.cookies.get("taos_shortcut")
     if not session_id:
@@ -164,6 +173,11 @@ def _get_shortcut_from_cookie(
 
     if session["shortcut_idx"] != idx:
         raise HTTPException(status_code=403, detail="Session shortcut index mismatch")
+
+    if expected_scope == "dashboard" and session["scope"] != "dashboard":
+        raise HTTPException(status_code=403, detail="Session scope mismatch")
+    if expected_scope == "terminal" and session["scope"] not in _TERMINAL_SCOPES:
+        raise HTTPException(status_code=403, detail="Session scope mismatch")
 
     if idx < 0 or idx >= len(shortcuts):
         raise HTTPException(status_code=404, detail=f"Shortcut idx {idx} not found")
@@ -292,7 +306,13 @@ async def redeem_ticket(
     t: str = Query(..., description="Base64url-encoded HMAC ticket"),
 ) -> RedirectResponse:
     """Validate ticket, set session cookie, redirect to the shortcut endpoint."""
-    worker = get_local_worker()
+    try:
+        worker = get_local_worker()
+    except RuntimeError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail=f"Worker not ready: {exc}",
+        ) from exc
     signing_key: bytes = worker["signing_key"]
 
     try:
@@ -343,7 +363,7 @@ async def shortcut_dashboard_proxy(
     then forwards the request to the container port.
     """
     shortcuts = _get_shortcuts_for_agent(request, agent_name)
-    shortcut = _get_shortcut_from_cookie(request, agent_name, idx, shortcuts)
+    shortcut = _get_shortcut_from_cookie(request, agent_name, idx, shortcuts, expected_scope="dashboard")
     shortcut = {**shortcut, "_idx": idx}
 
     return await proxy_dashboard(agent_name, shortcut, request, path=path)
@@ -378,7 +398,7 @@ async def shortcut_terminal_ws(
     """
     shortcuts = _get_shortcuts_for_agent(websocket, agent_name)
     try:
-        shortcut = _get_shortcut_from_cookie(websocket, agent_name, idx, shortcuts)
+        shortcut = _get_shortcut_from_cookie(websocket, agent_name, idx, shortcuts, expected_scope="terminal")
     except HTTPException as exc:
         await websocket.close(code=1008, reason=exc.detail)
         return
@@ -396,30 +416,29 @@ async def shortcut_terminal_ws(
     else:
         cmd = None
 
-    try:
-        pty_handle = await asyncio.to_thread(_get_container_pty, agent_name, cmd)
-    except Exception as exc:
-        logger.warning("terminal: spawn_pty failed for %s: %s", agent_name, exc)
-        await websocket.close(code=1011, reason="PTY spawn failed")
-        return
-
     await websocket.accept()
 
-    # Read the first frame: must be {"type": "ticket", "ticket": "..."}.
-    # The ticket was already consumed at /redeem to mint the cookie session.
-    # We don't re-validate it here (the cookie is the authoritative auth).
-    # Requiring this frame confirms the client intends a shortcut connection
-    # (defense-in-depth per Task 29 protocol spec).
+    # Validate handshake BEFORE spawning PTY — prevents resource leak when a
+    # client with a valid cookie sends a bad or missing first frame.
+    # The ticket was already consumed at /redeem to mint the cookie session;
+    # we don't re-validate it cryptographically here (the cookie is the
+    # authoritative auth). Requiring this frame confirms the client intends a
+    # shortcut connection (defense-in-depth per Task 29 protocol spec).
     try:
         first_frame = await asyncio.wait_for(websocket.receive_text(), timeout=10.0)
         handshake = json.loads(first_frame)
         if handshake.get("type") != "ticket" or not handshake.get("ticket"):
             await websocket.close(code=1008, reason="malformed ticket handshake")
-            await asyncio.to_thread(pty_handle.close)
             return
     except (json.JSONDecodeError, KeyError, asyncio.TimeoutError) as exc:
         await websocket.close(code=1008, reason=f"invalid handshake: {exc}")
-        await asyncio.to_thread(pty_handle.close)
+        return
+
+    try:
+        pty_handle = await asyncio.to_thread(_get_container_pty, agent_name, cmd)
+    except Exception as exc:
+        logger.warning("terminal: spawn_pty failed for %s: %s", agent_name, exc)
+        await websocket.close(code=1011, reason="PTY spawn failed")
         return
 
     async def pty_to_ws():
@@ -465,7 +484,7 @@ async def shortcut_dashboard_ws(
     """
     shortcuts = _get_shortcuts_for_agent(websocket, agent_name)
     try:
-        shortcut = _get_shortcut_from_cookie(websocket, agent_name, idx, shortcuts)
+        shortcut = _get_shortcut_from_cookie(websocket, agent_name, idx, shortcuts, expected_scope="dashboard")
     except HTTPException as exc:
         await websocket.close(code=1008, reason=exc.detail)
         return
@@ -480,11 +499,20 @@ async def shortcut_dashboard_ws(
     ws_path = f"{base_path}/ws/{path}" if path else f"{base_path}/ws/"
     upstream_ws_url = f"ws://{ip}:{port}{ws_path}"
 
+    # Build auth header for upstream, same as HTTP proxy does.
+    auth_header = await _build_auth_header(agent_name, shortcut)
+    extra_headers: dict[str, str] = {}
+    if auth_header:
+        extra_headers[auth_header[0]] = auth_header[1]
+
     await websocket.accept()
 
     try:
         import websockets as _ws_lib
-        async with _ws_lib.connect(upstream_ws_url) as upstream:
+        async with _ws_lib.connect(
+            upstream_ws_url,
+            additional_headers=extra_headers,
+        ) as upstream:
             async def _client_to_upstream():
                 try:
                     while True:

--- a/tinyagentos/routes/shortcut_proxy.py
+++ b/tinyagentos/routes/shortcut_proxy.py
@@ -336,3 +336,69 @@ async def shortcut_dashboard_proxy(
     shortcut = {**shortcut, "_idx": idx}
 
     return await proxy_dashboard(agent_name, shortcut, request)
+
+
+@router.websocket("/shortcut/dashboard/{agent_name}/{idx}/ws/{path:path}")
+async def shortcut_dashboard_ws(
+    agent_name: str,
+    idx: int,
+    path: str,
+    websocket: WebSocket,
+):
+    """WebSocket proxy for shortcut dashboards.
+
+    Validates the taos_shortcut cookie, then upgrades and pipes both
+    directions to the container's dashboard WebSocket endpoint.
+    """
+    shortcuts = _get_shortcuts_for_agent(websocket, agent_name)
+    try:
+        shortcut = _get_shortcut_from_cookie(websocket, agent_name, idx, shortcuts)
+    except HTTPException as exc:
+        await websocket.close(code=1008, reason=exc.detail)
+        return
+
+    ip = _resolve_container_ip(websocket, agent_name)
+    if ip is None:
+        await websocket.close(code=1011, reason="No container IP")
+        return
+
+    port = shortcut["port"]
+    base_path = (shortcut.get("path") or "/").rstrip("/")
+    ws_path = f"{base_path}/ws/{path}" if path else f"{base_path}/ws/"
+    upstream_ws_url = f"ws://{ip}:{port}{ws_path}"
+
+    await websocket.accept()
+
+    try:
+        import websockets as _ws_lib
+        async with _ws_lib.connect(upstream_ws_url) as upstream:
+            async def _client_to_upstream():
+                try:
+                    while True:
+                        data = await websocket.receive_bytes()
+                        await upstream.send(data)
+                except Exception:
+                    pass
+
+            async def _upstream_to_client():
+                try:
+                    async for message in upstream:
+                        if isinstance(message, bytes):
+                            await websocket.send_bytes(message)
+                        else:
+                            await websocket.send_text(message)
+                except Exception:
+                    pass
+
+            await asyncio.gather(
+                _client_to_upstream(),
+                _upstream_to_client(),
+                return_exceptions=True,
+            )
+    except Exception as exc:
+        logger.debug("WS proxy error for %s: %s", agent_name, exc)
+    finally:
+        try:
+            await websocket.close()
+        except Exception:
+            pass

--- a/tinyagentos/routes/shortcut_proxy.py
+++ b/tinyagentos/routes/shortcut_proxy.py
@@ -31,6 +31,13 @@ router = APIRouter()
 # ---------------------------------------------------------------------------
 
 # In-memory session store: session_id -> {agent_id, shortcut_idx, scope, expires_at}
+#
+# Known limitation: this store is process-local. In a multi-worker (multi-process)
+# ASGI deployment, /redeem and the follow-up /shortcut/... request must hit the same
+# worker process, otherwise the session lookup returns 401. Sticky sessions on the
+# load balancer (by IP or cookie) are required for that deployment model.
+# This is intentional for v1 — a shared backend (Redis/DB) would solve it but
+# introduces a hard dependency not warranted until horizontal scale is needed.
 _sessions: dict[str, dict[str, Any]] = {}
 _SESSION_IDLE_TTL = 300  # 5 minutes
 

--- a/tinyagentos/routes/shortcut_proxy.py
+++ b/tinyagentos/routes/shortcut_proxy.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import json
 import logging
 import secrets
 import time
@@ -203,11 +204,15 @@ async def proxy_dashboard(
     agent_name: str,
     shortcut: dict[str, Any],
     request: Request,
+    path: str = "",
 ) -> Any:
     """Forward the HTTP request to the agent's container dashboard port.
 
     Resolves container IP, strips hop-by-hop headers, and streams the
     upstream response back to the client.
+
+    path is the captured route segment (no leading slash). When provided it is
+    appended to the shortcut's base path so deep links work correctly.
     """
     ip = _resolve_container_ip(request, agent_name)
     if ip is None:
@@ -218,7 +223,7 @@ async def proxy_dashboard(
 
     port = shortcut["port"]
     base_path = (shortcut.get("path") or "/").rstrip("/")
-    upstream_path = base_path + "/"
+    upstream_path = f"{base_path}/{path}" if path else f"{base_path}/"
 
     upstream_url = f"http://{ip}:{port}{upstream_path}"
     query = request.url.query
@@ -334,7 +339,7 @@ async def shortcut_dashboard_proxy(
     shortcut = _get_shortcut_from_cookie(request, agent_name, idx, shortcuts)
     shortcut = {**shortcut, "_idx": idx}
 
-    return await proxy_dashboard(agent_name, shortcut, request)
+    return await proxy_dashboard(agent_name, shortcut, request, path=path)
 
 
 # ---------------------------------------------------------------------------
@@ -392,6 +397,23 @@ async def shortcut_terminal_ws(
         return
 
     await websocket.accept()
+
+    # Read the first frame: must be {"type": "ticket", "ticket": "..."}.
+    # The ticket was already consumed at /redeem to mint the cookie session.
+    # We don't re-validate it here (the cookie is the authoritative auth).
+    # Requiring this frame confirms the client intends a shortcut connection
+    # (defense-in-depth per Task 29 protocol spec).
+    try:
+        first_frame = await asyncio.wait_for(websocket.receive_text(), timeout=10.0)
+        handshake = json.loads(first_frame)
+        if handshake.get("type") != "ticket" or not handshake.get("ticket"):
+            await websocket.close(code=1008, reason="malformed ticket handshake")
+            await asyncio.to_thread(pty_handle.close)
+            return
+    except (json.JSONDecodeError, KeyError, asyncio.TimeoutError) as exc:
+        await websocket.close(code=1008, reason=f"invalid handshake: {exc}")
+        await asyncio.to_thread(pty_handle.close)
+        return
 
     async def pty_to_ws():
         try:
@@ -459,8 +481,13 @@ async def shortcut_dashboard_ws(
             async def _client_to_upstream():
                 try:
                     while True:
-                        data = await websocket.receive_bytes()
-                        await upstream.send(data)
+                        msg = await websocket.receive()
+                        if msg["type"] == "websocket.disconnect":
+                            break
+                        if "text" in msg and msg["text"] is not None:
+                            await upstream.send(msg["text"])
+                        elif "bytes" in msg and msg["bytes"] is not None:
+                            await upstream.send(msg["bytes"])
                 except Exception:
                     pass
 

--- a/tinyagentos/routes/shortcuts.py
+++ b/tinyagentos/routes/shortcuts.py
@@ -1,0 +1,104 @@
+"""Routes for agent shortcuts: list (GET) and launch (POST)."""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from tinyagentos.auth import get_current_user
+from tinyagentos.shortcuts.capabilities import user_has_capability
+from tinyagentos.shortcuts.tickets import mint_ticket, _GLOBAL_JTI_TRACKER
+from tinyagentos.cluster.worker_registry import get_local_worker
+
+router = APIRouter()
+
+
+def _get_agent_by_id(request: Request, agent_id: str) -> dict[str, Any]:
+    """Return the agent dict for *agent_id* or raise 404."""
+    agents = request.app.state.config.agents
+    for agent in agents:
+        if agent.get("id") == agent_id:
+            return agent
+    raise HTTPException(status_code=404, detail="Agent not found")
+
+
+def _get_framework_shortcuts(agent: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return the shortcuts list from the agent's framework manifest, or []."""
+    from tinyagentos.frameworks import FRAMEWORKS
+    framework_name = agent.get("framework", "")
+    framework = FRAMEWORKS.get(framework_name, {})
+    return framework.get("shortcuts", [])
+
+
+@router.get("/api/agents/{agent_id}/shortcuts")
+async def list_shortcuts(
+    agent_id: str,
+    request: Request,
+    current_user: dict[str, Any] = Depends(get_current_user),
+) -> list[dict[str, Any]]:
+    """Return the capability-filtered shortcut list for agent_id.
+
+    Each entry includes idx, kind, label, and icon.
+    requires_capability is not exposed to the frontend.
+    """
+    agent = _get_agent_by_id(request, agent_id)
+    all_shortcuts = _get_framework_shortcuts(agent)
+
+    result = []
+    for idx, shortcut in enumerate(all_shortcuts):
+        cap = shortcut.get("requires_capability", "")
+        if user_has_capability(current_user, cap):
+            result.append(
+                {
+                    "idx": idx,
+                    "kind": shortcut["kind"],
+                    "label": shortcut["label"],
+                    "icon": shortcut["icon"],
+                }
+            )
+    return result
+
+
+@router.post("/api/agents/{agent_id}/shortcuts/{idx}/launch")
+async def launch_shortcut(
+    agent_id: str,
+    idx: int,
+    request: Request,
+    current_user: dict[str, Any] = Depends(get_current_user),
+) -> dict[str, Any]:
+    """Mint a 30-second HMAC ticket for the requested shortcut.
+
+    Returns {redirect_url, expires_in: 30}.
+    403 if the user lacks the required capability.
+    404 if agent or shortcut idx not found.
+    """
+    agent = _get_agent_by_id(request, agent_id)
+    all_shortcuts = _get_framework_shortcuts(agent)
+
+    if idx < 0 or idx >= len(all_shortcuts):
+        raise HTTPException(status_code=404, detail=f"Shortcut idx {idx} not found")
+
+    shortcut = all_shortcuts[idx]
+    cap = shortcut.get("requires_capability", "")
+    if not user_has_capability(current_user, cap):
+        raise HTTPException(
+            status_code=403,
+            detail=f"Capability '{cap}' required",
+        )
+
+    worker = get_local_worker()
+    worker_url: str = worker["worker_url"]
+    signing_key: bytes = worker["signing_key"]
+
+    scope = shortcut["kind"]
+    _ticket, token = mint_ticket(
+        agent_id=agent_id,
+        shortcut_idx=idx,
+        scope=scope,
+        signing_key=signing_key,
+        worker_url=worker_url,
+        ttl=30,
+    )
+
+    redirect_url = f"{worker_url}/redeem?t={token}"
+    return {"redirect_url": redirect_url, "expires_in": 30}

--- a/tinyagentos/shortcuts/__init__.py
+++ b/tinyagentos/shortcuts/__init__.py
@@ -1,0 +1,19 @@
+from .types import (
+    ContainerTerminalShortcut,
+    DashboardAuth,
+    DashboardShortcut,
+    ShortcutCommon,
+    Shortcut,
+    TokenSource,
+    TuiShortcut,
+)
+
+__all__ = [
+    "ShortcutCommon",
+    "ContainerTerminalShortcut",
+    "TuiShortcut",
+    "DashboardShortcut",
+    "DashboardAuth",
+    "TokenSource",
+    "Shortcut",
+]

--- a/tinyagentos/shortcuts/capabilities.py
+++ b/tinyagentos/shortcuts/capabilities.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Any
+
+CAP_CHAT: str = "chat"
+CAP_AGENT_SHELL: str = "agent.shell"
+CAP_AGENT_TERMINAL: str = "agent.terminal"
+CAP_AGENT_DASHBOARD: str = "agent.dashboard"
+
+_ALL_CAPS: frozenset[str] = frozenset(
+    {CAP_CHAT, CAP_AGENT_SHELL, CAP_AGENT_TERMINAL, CAP_AGENT_DASHBOARD}
+)
+
+
+def default_caps_for_admin() -> frozenset[str]:
+    """Return the full capability set granted to admin / primary users."""
+    return _ALL_CAPS
+
+
+def default_caps_for_new_user() -> frozenset[str]:
+    """Return the minimal capability set granted to newly created users."""
+    return frozenset({CAP_CHAT})
+
+
+def user_has_capability(user: dict[str, Any], cap: str) -> bool:
+    """Return True if user's capability set contains cap.
+
+    user must have a 'capabilities' key whose value is a set or frozenset.
+    If the key is absent, returns False (safe default — deny access).
+    """
+    caps = user.get("capabilities")
+    if caps is None:
+        return False
+    return cap in caps

--- a/tinyagentos/shortcuts/tickets.py
+++ b/tinyagentos/shortcuts/tickets.py
@@ -71,12 +71,14 @@ def validate_ticket(
     - replayed jti
     """
     try:
-        raw = base64.urlsafe_b64decode(token.encode() + b"==")
-        dot_idx = raw.rfind(b".")
-        if dot_idx == -1:
+        raw = base64.urlsafe_b64decode(token.encode() + b"=" * (-len(token) % 4))
+        # HMAC-SHA256 is always 32 bytes; the separator is at the fixed offset
+        # len(raw) - 33.  Using rfind would misfire if 0x2e appears in the sig.
+        sig_start = len(raw) - 32
+        if sig_start < 2 or raw[sig_start - 1:sig_start] != b".":
             raise ValueError("malformed token: no separator")
-        payload_bytes = raw[:dot_idx]
-        sig = raw[dot_idx + 1:]
+        payload_bytes = raw[:sig_start - 1]
+        sig = raw[sig_start:]
     except Exception as exc:
         raise ValueError(f"invalid signature: token decode failed — {exc}") from exc
 

--- a/tinyagentos/shortcuts/tickets.py
+++ b/tinyagentos/shortcuts/tickets.py
@@ -128,3 +128,8 @@ class JtiTracker:
         expired = [k for k, v in self._seen.items() if v < now]
         for k in expired:
             del self._seen[k]
+
+
+# Module-level singleton. Routes import this for convenience so they don't
+# need to manage the tracker's lifecycle.
+_GLOBAL_JTI_TRACKER: JtiTracker = JtiTracker()

--- a/tinyagentos/shortcuts/tickets.py
+++ b/tinyagentos/shortcuts/tickets.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import time
+import uuid
+from dataclasses import dataclass
+
+
+@dataclass
+class Ticket:
+    agent_id: str
+    shortcut_idx: int
+    scope: str
+    exp: int          # unix seconds
+    jti: str          # uuid4 hex, 32 chars
+    worker_url: str
+
+
+def _sign(payload: bytes, key: bytes) -> bytes:
+    return hmac.new(key, payload, hashlib.sha256).digest()
+
+
+def mint_ticket(
+    agent_id: str,
+    shortcut_idx: int,
+    scope: str,
+    signing_key: bytes,
+    worker_url: str,
+    ttl: int = 30,
+) -> tuple[Ticket, str]:
+    """Mint a signed ticket. Returns (Ticket, base64url-encoded token string)."""
+    jti = uuid.uuid4().hex
+    exp = int(time.time()) + ttl
+    ticket = Ticket(
+        agent_id=agent_id,
+        shortcut_idx=shortcut_idx,
+        scope=scope,
+        exp=exp,
+        jti=jti,
+        worker_url=worker_url,
+    )
+    payload = json.dumps(
+        {
+            "agent_id": ticket.agent_id,
+            "shortcut_idx": ticket.shortcut_idx,
+            "scope": ticket.scope,
+            "exp": ticket.exp,
+            "jti": ticket.jti,
+            "worker_url": ticket.worker_url,
+        },
+        separators=(",", ":"),
+    ).encode()
+    sig = _sign(payload, signing_key)
+    token = base64.urlsafe_b64encode(payload + b"." + sig).decode()
+    return ticket, token
+
+
+def validate_ticket(
+    token: str,
+    signing_key: bytes,
+    tracker: "JtiTracker",
+) -> Ticket:
+    """Validate a ticket token. Returns the Ticket on success.
+
+    Raises ValueError with a descriptive message on any failure:
+    - invalid signature
+    - ticket expired
+    - replayed jti
+    """
+    try:
+        raw = base64.urlsafe_b64decode(token.encode() + b"==")
+        dot_idx = raw.rfind(b".")
+        if dot_idx == -1:
+            raise ValueError("malformed token: no separator")
+        payload_bytes = raw[:dot_idx]
+        sig = raw[dot_idx + 1:]
+    except Exception as exc:
+        raise ValueError(f"invalid signature: token decode failed — {exc}") from exc
+
+    expected_sig = _sign(payload_bytes, signing_key)
+    if not hmac.compare_digest(sig, expected_sig):
+        raise ValueError("invalid signature")
+
+    try:
+        data = json.loads(payload_bytes)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid signature: payload not JSON — {exc}") from exc
+
+    if int(time.time()) > data["exp"]:
+        raise ValueError("ticket expired")
+
+    jti = data["jti"]
+    if tracker.seen(jti):
+        raise ValueError("replayed jti")
+    tracker.record(jti, exp=data["exp"])
+
+    return Ticket(
+        agent_id=data["agent_id"],
+        shortcut_idx=data["shortcut_idx"],
+        scope=data["scope"],
+        exp=data["exp"],
+        jti=jti,
+        worker_url=data["worker_url"],
+    )
+
+
+class JtiTracker:
+    """In-memory single-use JTI tracker. Thread-safe for a single process."""
+
+    def __init__(self) -> None:
+        self._seen: dict[str, int] = {}  # jti -> exp
+
+    def seen(self, jti: str) -> bool:
+        """Return True if this jti has been recorded."""
+        self._evict()
+        return jti in self._seen
+
+    def record(self, jti: str, exp: int) -> None:
+        """Mark jti as used. exp is the unix-second expiry of the ticket."""
+        self._seen[jti] = exp
+
+    def _evict(self) -> None:
+        """Remove expired entries to bound memory use."""
+        now = int(time.time())
+        expired = [k for k, v in self._seen.items() if v < now]
+        for k in expired:
+            del self._seen[k]

--- a/tinyagentos/shortcuts/tickets.py
+++ b/tinyagentos/shortcuts/tickets.py
@@ -4,6 +4,7 @@ import base64
 import hashlib
 import hmac
 import json
+import threading
 import time
 import uuid
 from dataclasses import dataclass
@@ -32,6 +33,8 @@ def mint_ticket(
     ttl: int = 30,
 ) -> tuple[Ticket, str]:
     """Mint a signed ticket. Returns (Ticket, base64url-encoded token string)."""
+    if len(signing_key) < 32:
+        raise ValueError("signing_key must be at least 32 bytes")
     jti = uuid.uuid4().hex
     exp = int(time.time()) + ttl
     ticket = Ticket(
@@ -70,6 +73,8 @@ def validate_ticket(
     - ticket expired
     - replayed jti
     """
+    if len(signing_key) < 32:
+        raise ValueError("signing_key must be at least 32 bytes")
     try:
         raw = base64.urlsafe_b64decode(token.encode() + b"=" * (-len(token) % 4))
         # HMAC-SHA256 is always 32 bytes; the separator is at the fixed offset
@@ -95,9 +100,8 @@ def validate_ticket(
         raise ValueError("ticket expired")
 
     jti = data["jti"]
-    if tracker.seen(jti):
+    if not tracker.record_if_new(jti, data["exp"]):
         raise ValueError("replayed jti")
-    tracker.record(jti, exp=data["exp"])
 
     return Ticket(
         agent_id=data["agent_id"],
@@ -114,18 +118,30 @@ class JtiTracker:
 
     def __init__(self) -> None:
         self._seen: dict[str, int] = {}  # jti -> exp
+        self._lock = threading.Lock()
 
     def seen(self, jti: str) -> bool:
-        """Return True if this jti has been recorded."""
-        self._evict()
-        return jti in self._seen
+        """Return True if this jti has been recorded. Kept for test inspection."""
+        with self._lock:
+            self._evict()
+            return jti in self._seen
 
     def record(self, jti: str, exp: int) -> None:
         """Mark jti as used. exp is the unix-second expiry of the ticket."""
-        self._seen[jti] = exp
+        with self._lock:
+            self._seen[jti] = exp
+
+    def record_if_new(self, jti: str, exp: int) -> bool:
+        """Atomically check + record. Returns True if newly recorded, False if already seen."""
+        with self._lock:
+            self._evict()
+            if jti in self._seen:
+                return False
+            self._seen[jti] = exp
+            return True
 
     def _evict(self) -> None:
-        """Remove expired entries to bound memory use."""
+        """Remove expired entries to bound memory use. Caller must hold _lock."""
         now = int(time.time())
         expired = [k for k, v in self._seen.items() if v < now]
         for k in expired:

--- a/tinyagentos/shortcuts/tickets.py
+++ b/tinyagentos/shortcuts/tickets.py
@@ -1,3 +1,14 @@
+"""
+HMAC-signed tickets for shortcut redemption.
+
+Replay protection (JtiTracker) is in-memory and process-local. This is
+sufficient for single-process deployments (the v1 single-Pi case). For
+cluster / multi-worker deployments, the tracker MUST be replaced with a
+shared store (Redis is the obvious choice) — see follow-up issue.
+
+The HMAC + 30s expiry already constrains the replay window to seconds.
+The JTI check is the second line of defense within that window.
+"""
 from __future__ import annotations
 
 import base64

--- a/tinyagentos/shortcuts/token_source.py
+++ b/tinyagentos/shortcuts/token_source.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import re
 import subprocess
+import threading
 import time
 from typing import Any, Optional
 
@@ -11,6 +12,7 @@ _ENV_VAR_RE = re.compile(r"^[A-Z_][A-Z0-9_]*$")
 
 # In-process cache: (agent_name, source_hash) -> (value, expires_at)
 _cache: dict[tuple[str, str], tuple[Optional[str], float]] = {}
+_cache_lock = threading.Lock()
 _CACHE_TTL = 60.0  # seconds
 
 
@@ -52,13 +54,15 @@ def read_token_source(agent_name: str, source: dict[str, Any]) -> Optional[str]:
 
     cache_key = (agent_name, _source_hash(source))
     now = time.monotonic()
-    if cache_key in _cache:
-        value, expires_at = _cache[cache_key]
-        if now < expires_at:
-            return value
+    with _cache_lock:
+        if cache_key in _cache:
+            value, expires_at = _cache[cache_key]
+            if now < expires_at:
+                return value
 
     value = _exec_token_source(agent_name, source, kind)
-    _cache[cache_key] = (value, now + _CACHE_TTL)
+    with _cache_lock:
+        _cache[cache_key] = (value, now + _CACHE_TTL)
     return value
 
 
@@ -67,9 +71,10 @@ def invalidate_agent_cache(agent_name: str) -> None:
 
     Called when the agent container restarts so stale tokens are not served.
     """
-    to_remove = [k for k in _cache if k[0] == agent_name]
-    for k in to_remove:
-        del _cache[k]
+    with _cache_lock:
+        to_remove = [k for k in _cache if k[0] == agent_name]
+        for k in to_remove:
+            del _cache[k]
 
 
 def _exec_token_source(

--- a/tinyagentos/shortcuts/token_source.py
+++ b/tinyagentos/shortcuts/token_source.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 import subprocess
 import time
 from typing import Any, Optional
+
+_ENV_VAR_RE = re.compile(r"^[A-Z_][A-Z0-9_]*$")
 
 # In-process cache: (agent_name, source_hash) -> (value, expires_at)
 _cache: dict[tuple[str, str], tuple[Optional[str], float]] = {}
@@ -76,12 +79,17 @@ def _exec_token_source(
 
     if kind == "container_env":
         var = source["var"]
-        result = subprocess.run(
-            ["incus", "exec", container, "--", "sh", "-c", f"echo ${var}"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
+        if not _ENV_VAR_RE.match(var):
+            return None
+        try:
+            result = subprocess.run(
+                ["incus", "exec", container, "--", "printenv", var],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+            return None
         if result.returncode != 0:
             return None
         return result.stdout.strip() or None
@@ -89,12 +97,15 @@ def _exec_token_source(
     if kind == "container_file":
         path = source["path"]
         json_pointer = source.get("json_pointer", "")
-        result = subprocess.run(
-            ["incus", "exec", container, "--", "cat", path],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
+        try:
+            result = subprocess.run(
+                ["incus", "exec", container, "--", "cat", path],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+            return None
         if result.returncode != 0:
             return None
         try:

--- a/tinyagentos/shortcuts/token_source.py
+++ b/tinyagentos/shortcuts/token_source.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import time
+from typing import Any, Optional
+
+# In-process cache: (agent_name, source_hash) -> (value, expires_at)
+_cache: dict[tuple[str, str], tuple[Optional[str], float]] = {}
+_CACHE_TTL = 60.0  # seconds
+
+
+def _source_hash(source: dict[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(source, sort_keys=True).encode()
+    ).hexdigest()[:16]
+
+
+def _resolve_json_pointer(doc: dict[str, Any], pointer: str) -> Any:
+    """Resolve a JSON Pointer (RFC 6901) against doc."""
+    if pointer == "" or pointer == "/":
+        return doc
+    parts = pointer.lstrip("/").split("/")
+    node: Any = doc
+    for part in parts:
+        part = part.replace("~1", "/").replace("~0", "~")
+        if isinstance(node, dict):
+            node = node[part]
+        elif isinstance(node, list):
+            node = node[int(part)]
+        else:
+            raise KeyError(f"cannot traverse {type(node).__name__} with key '{part}'")
+    return node
+
+
+def read_token_source(agent_name: str, source: dict[str, Any]) -> Optional[str]:
+    """Read a token from the declared source. Returns None on failure.
+
+    Results are cached for 60 seconds per (agent_name, source_hash) pair.
+    Raises ValueError for an unknown source kind.
+    """
+    kind = source.get("kind")
+    if kind not in ("container_file", "container_env", "static"):
+        raise ValueError(f"unknown token_source kind '{kind}'")
+
+    if kind == "static":
+        return source["value"]
+
+    cache_key = (agent_name, _source_hash(source))
+    now = time.monotonic()
+    if cache_key in _cache:
+        value, expires_at = _cache[cache_key]
+        if now < expires_at:
+            return value
+
+    value = _exec_token_source(agent_name, source, kind)
+    _cache[cache_key] = (value, now + _CACHE_TTL)
+    return value
+
+
+def invalidate_agent_cache(agent_name: str) -> None:
+    """Remove all cached token_source results for the given agent.
+
+    Called when the agent container restarts so stale tokens are not served.
+    """
+    to_remove = [k for k in _cache if k[0] == agent_name]
+    for k in to_remove:
+        del _cache[k]
+
+
+def _exec_token_source(
+    agent_name: str, source: dict[str, Any], kind: str
+) -> Optional[str]:
+    container = f"taos-agent-{agent_name}"
+
+    if kind == "container_env":
+        var = source["var"]
+        result = subprocess.run(
+            ["incus", "exec", container, "--", "sh", "-c", f"echo ${var}"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return None
+        return result.stdout.strip() or None
+
+    if kind == "container_file":
+        path = source["path"]
+        json_pointer = source.get("json_pointer", "")
+        result = subprocess.run(
+            ["incus", "exec", container, "--", "cat", path],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return None
+        try:
+            doc = json.loads(result.stdout)
+            value = _resolve_json_pointer(doc, json_pointer)
+            return str(value)
+        except (json.JSONDecodeError, KeyError, IndexError, ValueError):
+            return None
+
+    return None

--- a/tinyagentos/shortcuts/types.py
+++ b/tinyagentos/shortcuts/types.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import Literal, Optional, Union
+from typing_extensions import TypedDict
+
+
+class ShortcutCommon(TypedDict):
+    label: str
+    icon: str
+    requires_capability: str
+
+
+class ContainerTerminalShortcut(ShortcutCommon):
+    kind: Literal["container-terminal"]
+
+
+class TuiShortcut(ShortcutCommon):
+    kind: Literal["tui"]
+    command: str
+
+
+class _TokenSourceContainerFile(TypedDict):
+    kind: Literal["container_file"]
+    path: str
+    json_pointer: str
+
+
+class _TokenSourceContainerEnv(TypedDict):
+    kind: Literal["container_env"]
+    var: str
+
+
+class _TokenSourceStatic(TypedDict):
+    kind: Literal["static"]
+    value: str
+
+
+TokenSource = Union[
+    _TokenSourceContainerFile,
+    _TokenSourceContainerEnv,
+    _TokenSourceStatic,
+]
+
+
+class DashboardAuth(TypedDict):
+    type: Literal["none", "bearer", "basic"]
+    token_source: Optional[TokenSource]
+
+
+class DashboardShortcut(ShortcutCommon):
+    kind: Literal["dashboard"]
+    port: int
+    path: str
+    auth: DashboardAuth
+
+
+Shortcut = Union[ContainerTerminalShortcut, TuiShortcut, DashboardShortcut]

--- a/tinyagentos/shortcuts/validation.py
+++ b/tinyagentos/shortcuts/validation.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import Any
+
+_COMMON_REQUIRED = ("label", "icon", "requires_capability")
+_KNOWN_KINDS = {"container-terminal", "tui", "dashboard"}
+
+
+def validate_shortcuts(entries: list[Any]) -> None:
+    """Raise ValueError if any entry in entries has an invalid shape."""
+    for i, entry in enumerate(entries):
+        prefix = f"shortcuts[{i}]"
+
+        if not isinstance(entry, dict):
+            raise ValueError(f"{prefix}: expected dict, got {type(entry).__name__}")
+
+        if "kind" not in entry:
+            raise ValueError(f"{prefix}: missing 'kind' field")
+
+        kind = entry["kind"]
+        if kind not in _KNOWN_KINDS:
+            raise ValueError(
+                f"{prefix}: unknown shortcut kind '{kind}'; valid: {sorted(_KNOWN_KINDS)}"
+            )
+
+        for field in _COMMON_REQUIRED:
+            if field not in entry:
+                raise ValueError(f"{prefix}: missing required field '{field}'")
+
+        if kind == "tui":
+            if "command" not in entry:
+                raise ValueError(f"{prefix}: 'command' is required for kind='tui'")
+            if not isinstance(entry["command"], str) or not entry["command"].strip():
+                raise ValueError(f"{prefix}: 'command' must be a non-empty string")
+
+        if kind == "dashboard":
+            if "port" not in entry:
+                raise ValueError(f"{prefix}: 'port' is required for kind='dashboard'")
+            if not isinstance(entry["port"], int) or entry["port"] < 1:
+                raise ValueError(f"{prefix}: 'port' must be a positive integer")
+            if "auth" not in entry:
+                raise ValueError(f"{prefix}: 'auth' is required for kind='dashboard'")
+            auth = entry["auth"]
+            if not isinstance(auth, dict) or "type" not in auth:
+                raise ValueError(
+                    f"{prefix}: 'auth' must be a dict with a 'type' field"
+                )
+            if auth["type"] not in ("none", "bearer", "basic"):
+                raise ValueError(
+                    f"{prefix}: auth.type must be 'none', 'bearer', or 'basic'"
+                )


### PR DESCRIPTION
## Summary

Per-framework agent shortcut buttons in AgentsApp — three kinds (`container-terminal`, `tui`, `dashboard`) declared in the framework registry, capability-filtered, with HMAC-ticket-based auth that's cluster + Tailscale-ready.

- **Backend**: registry schema + validation (`tinyagentos/shortcuts/types.py`, `validation.py`), capability model on user record (`auth.py` + `shortcuts/capabilities.py`), HMAC ticket mint/validate (`shortcuts/tickets.py`) with JTI replay tracker, container PTY abstraction (`containers/backend.py` ABC + LXC impl + Docker/Apple stubs), token-source reader with 60s LRU cache (`shortcuts/token_source.py`), worker registration extension (`cluster/worker_protocol.py` + `local_worker.py`), dashboard reverse proxy with auth injection + SSE/WebSocket (`routes/shortcut_proxy.py`), terminal websocket PTY bridge, and 6 beta frameworks populated with shortcut definitions.
- **Frontend**: `useAgentShortcuts` hook, `AgentShortcutRow` component (mobile icon-only via `useIsMobile`), AgentsApp wiring with click-handler routing by kind, TerminalApp `shortcut` prop (WS + ticket frame + UI suppression), BrowserApp `initialUrl` prop.
- **E2E**: Playwright spec at `desktop/tests/agent-shortcuts.spec.ts` on iphone-14 profile, skip-tolerant for no-backend / no-seed-data runs.

Built via brainstorm → spec → plan → subagent-driven implementation. 33 tasks across 16 phases. Spec at \`docs/superpowers/specs/2026-04-30-agent-shortcuts-design.md\` and plan at \`docs/superpowers/plans/2026-04-30-agent-shortcuts-plan.md\` (both gitignored, local-only).

## Notable deviations from plan

- \`worker_registry.py\` was scaffolded as a stub before Tasks 22-23 because the route handlers (Tasks 14-16) needed it earlier; Tasks 22-23 replaced the stub with the proper ClusterManager-backed mechanism (with a fallback signing key for unit tests).
- BrowserApp \`initialUrl\` bypasses the proxy-URL wrapping intentionally — the redirect URL points directly at the worker (with cookie-based session); proxying it would break the worker-direct flow.
- TerminalApp + BrowserApp made \`windowId\` optional to ease testing and to support the new shortcut-launch entry point.
- \`/shortcut/\` and \`/redeem\` added to auth middleware EXEMPT_PREFIXES (they use ticket+cookie auth, not the main \`taos_session\` cookie).
- Bug fixes that emerged during review:
  - Base64 padding + `rfind(b".")` separator bugs in \`validate_ticket\` (HMAC signatures contain \`0x2e\`)
  - \`enroll_local_worker\` made idempotent (was regenerating signing key on re-enrollment)
  - pytest collection collision between \`tests/test_capabilities.py\` and \`tests/shortcuts/test_capabilities.py\` resolved with \`tests/shortcuts/__init__.py\`

## Test plan

- [x] Vitest 240/240 green
- [x] Vite build succeeds, zero TS errors
- [x] Pytest 145 passed, 1 skipped (shortcuts/, routes/, containers/, cluster/)
- [x] Playwright \`agent-shortcuts.spec.ts\` 4 skipped on iphone-14 (no live backend — correct skip-tolerant behaviour)
- [ ] Manual smoke on the Pi: click each shortcut kind on a real openclaw/hermes agent (interactive — recommend before merge)

## Open follow-ups (non-blocking)

- \`_FALLBACK_SIGNING_KEY\` in \`worker_registry.py\` is deterministic for unit tests; production single-Pi already uses random key via \`enroll_local_worker\`. When persisting workers across restarts is wanted, store the signing key on disk (currently in-memory only).
- Hermes web UI deploy (\`hermes web --port 9119\` as a systemd unit) — separate follow-up issue. Once deployed, hermes registry entry adds a \`dashboard\` shortcut.
- Docker / Apple \`spawn_pty\` are stubs raising \`NotImplementedError\` — implement when those backends are needed.
- E2E spec gracefully skips when no agents exist; cluster-runs should seed data and assert the full flow.
- \`websockets\` listed in both \`[project.dependencies]\` and \`[project.optional-dependencies.dev]\` — minor dedup cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-agent shortcut buttons to open dashboards or terminals directly.
  * One-click launches mint short-lived tickets and redirect into dashboard iframes or interactive terminals/WS sessions.
  * Browser and Terminal apps support direct launch parameters (initial URL / ticket) for seamless entry.
  * Shortcut proxy and terminal/dashboard bridging enable secure tunneled access to container apps.

* **Permissions**
  * Shortcut visibility and launch access respect user capability settings (chat/shell/terminal/dashboard).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->