### PR TITLE
feat(deploy): rebuild desktop frontend on update

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,16 +429,40 @@ rm -rf ~/.local/share/tinyagentos-worker
 
 ### Upgrading a long-running install
 
+**Controller (recommended):** use the one-shot update script:
+
 ```bash
-cd ~/.local/share/tinyagentos-worker  # or ~/tinyagentos for the controller
+cd ~/tinyagentos
+bin/update.sh
+```
+
+This pulls the latest, rebuilds the desktop frontend bundle if the source has moved (skips it when nothing changed), then restarts the service. The frontend rebuild takes ~50s when it fires; it is a no-op otherwise.
+
+**Manual equivalent:**
+
+```bash
+cd ~/tinyagentos
 git pull
 # Clear stale Python bytecode after upgrades (git pull preserves source mtimes
 # which can confuse Python's .pyc cache invalidation on some setups)
 find . -name __pycache__ -type d -exec rm -rf {} + 2>/dev/null || true
-sudo systemctl restart tinyagentos-worker  # or tinyagentos for the controller
+# Rebuild frontend if desktop source changed (omit if you didn't pull any desktop/ changes)
+cd desktop && npm install && npm run build && cd ..
+sudo systemctl restart tinyagentos
 ```
 
-The bytecode cleanup line is belt-and-braces, Python's mtime-based invalidation usually works, but on long-running boxes that have survived many upgrades it occasionally doesn't, and a stale `.pyc` is easy to mistake for a code bug.
+The systemd unit also runs a conditional rebuild as an `ExecStartPre` step — if you skip the manual `npm run build`, the next service restart detects the stale bundle and rebuilds it automatically (~50s startup overhead when it fires).
+
+**Worker:**
+
+```bash
+cd ~/.local/share/tinyagentos-worker
+git pull
+find . -name __pycache__ -type d -exec rm -rf {} + 2>/dev/null || true
+sudo systemctl restart tinyagentos-worker
+```
+
+The bytecode cleanup line is belt-and-braces; Python's mtime-based invalidation usually works, but on long-running boxes that have survived many upgrades it occasionally doesn't, and a stale `.pyc` is easy to mistake for a code bug.
 
 ## Service Management
 

--- a/bin/update.sh
+++ b/bin/update.sh
@@ -10,7 +10,7 @@ cd "$REPO_ROOT"
 echo "==> Pulling latest..."
 git pull --ff-only
 
-if [ -d desktop ] && { [ ! -f static/desktop/index.html ] || [ desktop/src -nt static/desktop/index.html ]; }; then
+if [ -d desktop ] && { [ ! -f static/desktop/index.html ] || [ -n "$(find desktop/src -type f -newer static/desktop/index.html -print -quit 2>/dev/null)" ]; }; then
   echo "==> Frontend source moved since last build — rebuilding..."
   cd desktop
   npm install --silent

--- a/bin/update.sh
+++ b/bin/update.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# bin/update.sh — pull latest, rebuild frontend if stale, restart taOS service.
+# Usage: bin/update.sh
+# Idempotent: skips rebuild when the static bundle is already current.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "==> Pulling latest..."
+git pull --ff-only origin master
+
+if [ -d desktop ] && [ desktop/src -nt static/desktop/index.html ]; then
+  echo "==> Frontend source moved since last build — rebuilding..."
+  cd desktop
+  npm install --silent
+  npm run build
+  cd "$REPO_ROOT"
+else
+  echo "==> Frontend bundle is current — skipping rebuild."
+fi
+
+echo "==> Restarting tinyagentos service..."
+sudo systemctl restart tinyagentos
+
+echo "==> Done. Service status:"
+systemctl status tinyagentos --no-pager | head -5

--- a/bin/update.sh
+++ b/bin/update.sh
@@ -8,9 +8,9 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
 echo "==> Pulling latest..."
-git pull --ff-only origin master
+git pull --ff-only
 
-if [ -d desktop ] && [ desktop/src -nt static/desktop/index.html ]; then
+if [ -d desktop ] && { [ ! -f static/desktop/index.html ] || [ desktop/src -nt static/desktop/index.html ]; }; then
   echo "==> Frontend source moved since last build — rebuilding..."
   cd desktop
   npm install --silent

--- a/scripts/systemd/tinyagentos.service
+++ b/scripts/systemd/tinyagentos.service
@@ -21,6 +21,15 @@ ExecStartPre=+/bin/sh -c '\
   chmod o+r /sys/kernel/debug/rkrga/load 2>/dev/null || true; \
   chmod o+rx /sys/kernel/debug/mali0 2>/dev/null || true; \
   chmod o+r /sys/kernel/debug/mali0/dvfs_utilization 2>/dev/null || true'
+# Rebuild the desktop bundle if desktop/src is newer than the last build output.
+# Catches the case where `git pull` landed new frontend source but `npm run build`
+# was not run before restarting the service. ~0s when current, ~50s when stale.
+ExecStartPre=/bin/sh -c '\
+  cd TAOS_INSTALL_DIR && \
+  if [ -d desktop ] && [ desktop/src -nt static/desktop/index.html ]; then \
+    echo "[taos] desktop source newer than bundle — rebuilding..." && \
+    cd desktop && npm install --silent && npm run build; \
+  fi'
 ExecStart=TAOS_PYTHON -m uvicorn tinyagentos.app:create_app --factory --host 0.0.0.0 --port TAOS_PORT
 ExecStop=TAOS_STOP_SCRIPT
 # Reload sends SIGHUP to the main process, causing uvicorn to re-exec in-place.

--- a/scripts/systemd/tinyagentos.service
+++ b/scripts/systemd/tinyagentos.service
@@ -26,7 +26,7 @@ ExecStartPre=+/bin/sh -c '\
 # was not run before restarting the service. ~0s when current, ~50s when stale.
 ExecStartPre=/bin/sh -c '\
   cd TAOS_INSTALL_DIR && \
-  if [ -d desktop ] && { [ ! -f static/desktop/index.html ] || [ desktop/src -nt static/desktop/index.html ]; }; then \
+  if [ -d desktop ] && { [ ! -f static/desktop/index.html ] || [ -n "$(find desktop/src -type f -newer static/desktop/index.html -print -quit 2>/dev/null)" ]; }; then \
     echo "[taos] desktop source newer than bundle — rebuilding..." && \
     cd desktop && npm install --silent && npm run build; \
   fi'

--- a/scripts/systemd/tinyagentos.service
+++ b/scripts/systemd/tinyagentos.service
@@ -26,7 +26,7 @@ ExecStartPre=+/bin/sh -c '\
 # was not run before restarting the service. ~0s when current, ~50s when stale.
 ExecStartPre=/bin/sh -c '\
   cd TAOS_INSTALL_DIR && \
-  if [ -d desktop ] && [ desktop/src -nt static/desktop/index.html ]; then \
+  if [ -d desktop ] && { [ ! -f static/desktop/index.html ] || [ desktop/src -nt static/desktop/index.html ]; }; then \
     echo "[taos] desktop source newer than bundle — rebuilding..." && \
     cd desktop && npm install --silent && npm run build; \
   fi'

--- a/tests/test_desktop_rebuild.py
+++ b/tests/test_desktop_rebuild.py
@@ -1,0 +1,203 @@
+import asyncio
+import os
+import time
+
+import pytest
+
+from tinyagentos.desktop_rebuild import _is_bundle_stale, rebuild_desktop_bundle_if_stale
+
+
+# ---------------------------------------------------------------------------
+# _is_bundle_stale
+# ---------------------------------------------------------------------------
+
+
+def test_is_bundle_stale_returns_true_when_no_bundle(tmp_path):
+    """No index.html means stale (never built)."""
+    (tmp_path / "desktop" / "src").mkdir(parents=True)
+    (tmp_path / "desktop" / "src" / "App.tsx").write_text("// app")
+    assert _is_bundle_stale(tmp_path) is True
+
+
+def test_is_bundle_stale_returns_false_when_no_desktop_dir(tmp_path):
+    """Backend-only deploys with no desktop/ are not considered stale."""
+    assert _is_bundle_stale(tmp_path) is False
+
+
+def test_is_bundle_stale_returns_false_when_bundle_newer(tmp_path):
+    """Bundle newer than all source files → not stale."""
+    src_dir = tmp_path / "desktop" / "src"
+    src_dir.mkdir(parents=True)
+    (src_dir / "App.tsx").write_text("// app")
+    static_dir = tmp_path / "static" / "desktop"
+    static_dir.mkdir(parents=True)
+    bundle = static_dir / "index.html"
+    bundle.write_text("<html />")
+    # Make bundle 60 s newer than source
+    os.utime(bundle, (time.time() + 60, time.time() + 60))
+    assert _is_bundle_stale(tmp_path) is False
+
+
+def test_is_bundle_stale_returns_true_when_source_newer(tmp_path):
+    """Any source file newer than bundle → stale."""
+    src_dir = tmp_path / "desktop" / "src"
+    src_dir.mkdir(parents=True)
+    static_dir = tmp_path / "static" / "desktop"
+    static_dir.mkdir(parents=True)
+    bundle = static_dir / "index.html"
+    bundle.write_text("<html />")
+    src_file = src_dir / "App.tsx"
+    src_file.write_text("// edit")
+    os.utime(src_file, (time.time() + 60, time.time() + 60))
+    assert _is_bundle_stale(tmp_path) is True
+
+
+def test_is_bundle_stale_returns_false_when_no_src_dir(tmp_path):
+    """desktop/ exists but no src/ → nothing to compare; not stale."""
+    (tmp_path / "desktop").mkdir()
+    static_dir = tmp_path / "static" / "desktop"
+    static_dir.mkdir(parents=True)
+    (static_dir / "index.html").write_text("<html />")
+    assert _is_bundle_stale(tmp_path) is False
+
+
+# ---------------------------------------------------------------------------
+# rebuild_desktop_bundle_if_stale
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rebuild_skips_when_bundle_current(tmp_path, monkeypatch):
+    """If bundle is current, no subprocess is spawned."""
+    src_dir = tmp_path / "desktop" / "src"
+    src_dir.mkdir(parents=True)
+    static_dir = tmp_path / "static" / "desktop"
+    static_dir.mkdir(parents=True)
+    bundle = static_dir / "index.html"
+    bundle.write_text("<html />")
+    os.utime(bundle, (time.time() + 60, time.time() + 60))
+
+    called = []
+
+    async def fake_exec(*args, **kwargs):
+        called.append(args)
+        raise AssertionError("subprocess should NOT be called when bundle is current")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+    rebuilt, msg = await rebuild_desktop_bundle_if_stale(tmp_path)
+    assert rebuilt is False
+    assert called == []
+
+
+@pytest.mark.asyncio
+async def test_rebuild_skips_when_no_package_json(tmp_path):
+    """desktop/src exists (stale) but no package.json → skip without error."""
+    src_dir = tmp_path / "desktop" / "src"
+    src_dir.mkdir(parents=True)
+    (src_dir / "App.tsx").write_text("// stale source")
+    # Deliberately no package.json
+    rebuilt, msg = await rebuild_desktop_bundle_if_stale(tmp_path)
+    assert rebuilt is False
+    assert "package.json" in msg.lower() or "skipping" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_rebuild_handles_npm_missing(tmp_path, monkeypatch):
+    """If npm not on PATH, return graceful (False, msg) — don't crash."""
+    src_dir = tmp_path / "desktop" / "src"
+    src_dir.mkdir(parents=True)
+    (src_dir / "App.tsx").write_text("// stale")
+    (tmp_path / "desktop" / "package.json").write_text('{"name":"x"}')
+
+    async def fake_exec(*args, **kwargs):
+        raise FileNotFoundError("npm not found")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+    rebuilt, msg = await rebuild_desktop_bundle_if_stale(tmp_path)
+    assert rebuilt is False
+    assert "npm" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_rebuild_returns_true_on_npm_install_failure(tmp_path, monkeypatch):
+    """If npm install exits non-zero, return (True, error_msg)."""
+    src_dir = tmp_path / "desktop" / "src"
+    src_dir.mkdir(parents=True)
+    (src_dir / "App.tsx").write_text("// stale")
+    (tmp_path / "desktop" / "package.json").write_text('{"name":"x"}')
+
+    class FakeProc:
+        returncode = 1
+
+        async def communicate(self):
+            return b"", b"install error"
+
+    async def fake_exec(*args, **kwargs):
+        return FakeProc()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+    rebuilt, msg = await rebuild_desktop_bundle_if_stale(tmp_path)
+    assert rebuilt is True
+    assert "npm install failed" in msg
+
+
+@pytest.mark.asyncio
+async def test_rebuild_returns_true_on_npm_build_failure(tmp_path, monkeypatch):
+    """If npm install succeeds but npm run build fails, return (True, error_msg)."""
+    src_dir = tmp_path / "desktop" / "src"
+    src_dir.mkdir(parents=True)
+    (src_dir / "App.tsx").write_text("// stale")
+    (tmp_path / "desktop" / "package.json").write_text('{"name":"x"}')
+
+    call_count = [0]
+
+    class InstallProc:
+        returncode = 0
+
+        async def communicate(self):
+            return b"", b""
+
+    class BuildProc:
+        returncode = 1
+
+        async def communicate(self):
+            return b"", b"build error"
+
+    async def fake_exec(*args, **kwargs):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return InstallProc()
+        return BuildProc()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+    rebuilt, msg = await rebuild_desktop_bundle_if_stale(tmp_path)
+    assert rebuilt is True
+    assert "npm run build failed" in msg
+
+
+@pytest.mark.asyncio
+async def test_rebuild_success(tmp_path, monkeypatch):
+    """Happy path: both npm commands succeed → (True, 'rebuilt successfully')."""
+    src_dir = tmp_path / "desktop" / "src"
+    src_dir.mkdir(parents=True)
+    (src_dir / "App.tsx").write_text("// stale")
+    (tmp_path / "desktop" / "package.json").write_text('{"name":"x"}')
+
+    class OkProc:
+        returncode = 0
+
+        async def communicate(self):
+            return b"", b""
+
+    async def fake_exec(*args, **kwargs):
+        return OkProc()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+    rebuilt, msg = await rebuild_desktop_bundle_if_stale(tmp_path)
+    assert rebuilt is True
+    assert "successfully" in msg.lower()

--- a/tinyagentos/auto_update.py
+++ b/tinyagentos/auto_update.py
@@ -224,6 +224,12 @@ class AutoUpdateService:
         pip_cmd = str(Path(sys.executable).parent / "pip")
         await _run([pip_cmd, "install", "-e", ".", "-q"], self._project_dir)
 
+        # Rebuild the desktop bundle if source moved (covers non-systemd hosts).
+        from tinyagentos.desktop_rebuild import rebuild_desktop_bundle_if_stale
+        _rebuilt, _rebuild_msg = await rebuild_desktop_bundle_if_stale(self._project_dir)
+        if _rebuilt:
+            logger.info("Desktop rebuild: %s", _rebuild_msg)
+
         from tinyagentos.restart_orchestrator import write_pending_restart
         write_pending_restart(new_commit)
 

--- a/tinyagentos/desktop_rebuild.py
+++ b/tinyagentos/desktop_rebuild.py
@@ -1,0 +1,104 @@
+"""Rebuild the desktop frontend bundle if source has moved ahead of the bundle.
+
+Used by both the in-app Install Update handler and the background auto-update
+service.  Mirrors the intent of ExecStartPre in the systemd unit and
+bin/update.sh — so all update paths converge on the same conditional rebuild
+regardless of platform (systemd/Pi, Docker, Mac .app, dev host).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def _is_bundle_stale(project_root: Path) -> bool:
+    """Return True if any file under desktop/src is newer than the built bundle."""
+    desktop_dir = project_root / "desktop"
+    if not desktop_dir.is_dir():
+        return False  # nothing to build
+    index_html = project_root / "static" / "desktop" / "index.html"
+    if not index_html.is_file():
+        return True  # never built
+    bundle_mtime = index_html.stat().st_mtime
+    src_dir = desktop_dir / "src"
+    if not src_dir.is_dir():
+        return False
+    for path in src_dir.rglob("*"):
+        if path.is_file() and path.stat().st_mtime > bundle_mtime:
+            return True
+    return False
+
+
+async def rebuild_desktop_bundle_if_stale(
+    project_root: Path,
+    *,
+    timeout_seconds: int = 600,
+) -> tuple[bool, str]:
+    """Run npm install + npm run build if the bundle is stale.
+
+    Returns ``(rebuilt, message)``.  ``rebuilt=False`` means skipped (bundle is
+    current or npm unavailable).  ``rebuilt=True`` means a rebuild was attempted;
+    ``message`` describes the outcome.
+
+    On hosts where npm/node aren't installed the rebuild fails gracefully with a
+    clear log message.  The caller can decide whether to surface it to the user.
+    """
+    if not _is_bundle_stale(project_root):
+        return False, "Desktop bundle is current — skipping rebuild."
+
+    desktop_dir = project_root / "desktop"
+    if not (desktop_dir / "package.json").is_file():
+        return False, "No desktop/package.json found — skipping rebuild."
+
+    logger.info("Desktop source is ahead of bundle — rebuilding...")
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "npm", "install", "--silent",
+            cwd=str(desktop_dir),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        _, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout_seconds)
+        if proc.returncode != 0:
+            msg = f"npm install failed (rc={proc.returncode}): {stderr.decode(errors='replace')[-500:]}"
+            logger.error(msg)
+            return True, msg
+
+        proc = await asyncio.create_subprocess_exec(
+            "npm", "run", "build",
+            cwd=str(desktop_dir),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        _, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout_seconds)
+        if proc.returncode != 0:
+            msg = f"npm run build failed (rc={proc.returncode}): {stderr.decode(errors='replace')[-500:]}"
+            logger.error(msg)
+            return True, msg
+
+        logger.info("Desktop bundle rebuilt successfully.")
+        return True, "Desktop bundle rebuilt successfully."
+
+    except asyncio.TimeoutError:
+        try:
+            proc.terminate()
+        except Exception:
+            pass
+        msg = f"Desktop rebuild timed out after {timeout_seconds}s."
+        logger.error(msg)
+        return True, msg
+
+    except FileNotFoundError as exc:
+        # npm not on PATH — e.g. minimal Docker image, dev box without Node
+        msg = f"npm not available — skipping desktop rebuild: {exc}"
+        logger.warning(msg)
+        return False, msg
+
+    except Exception as exc:
+        msg = f"Desktop rebuild error: {exc!r}"
+        logger.error(msg)
+        return True, msg

--- a/tinyagentos/routes/settings.py
+++ b/tinyagentos/routes/settings.py
@@ -568,6 +568,13 @@ async def apply_update(request: Request):
     )
     await proc2.communicate()
 
+    # Rebuild the desktop bundle if new source files landed (belt-and-braces on
+    # non-systemd hosts where ExecStartPre doesn't run: Mac .app, Docker, dev).
+    from tinyagentos.desktop_rebuild import rebuild_desktop_bundle_if_stale
+    _rebuilt, _rebuild_msg = await rebuild_desktop_bundle_if_stale(project_dir)
+    if _rebuilt:
+        logger.info("Desktop rebuild: %s", _rebuild_msg)
+
     # Record the new SHA so the restart modal can confirm the update was applied
     # and the Updates section can show the pending-restart banner.
     sha_proc = await asyncio.create_subprocess_exec(


### PR DESCRIPTION
## Summary

Closes a deployment gap: `git pull` + service restart was leaving the desktop frontend bundle stale because nothing in the update path ran `npm run build`. The PWA-projects bug was a recent example — source had the fix, deployed bundle didn't.

Two complementary mitigations:

- **`bin/update.sh`** — explicit one-shot: pull → rebuild (if stale) → restart. The recommended path.
- **`scripts/systemd/tinyagentos.service` ExecStartPre** — conditional rebuild fires on every service start when `desktop/src` is newer than `static/desktop/index.html`. Belt-and-braces: catches users who skip the script.

The conditional check (`[ A -nt B ]`) costs ~0s when the bundle is current. Only rebuilds when it's actually stale (~50s).

## Test plan

- [ ] `bin/update.sh` runs end-to-end on the Pi: pulls, conditionally rebuilds, restarts service
- [ ] Stale-bundle scenario: touch `desktop/src/App.tsx`, restart service — observe rebuild in journalctl, fresh assets in `static/desktop/`
- [ ] Current-bundle scenario: restart service immediately after — observe no rebuild, fast startup

## Why both, not just the script?

The script is the right path but the user who hit this bug had already run their normal update flow without realising `npm run build` was missing. The `ExecStartPre` net catches that case automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a recommended one-shot update script to pull changes, conditionally rebuild the frontend, and restart the service.
  * Controller startup and auto-update flow now perform a conditional frontend rebuild when the bundle is stale.

* **Tests**
  * Added tests covering bundle staleness detection and conditional rebuild behavior.

* **Documentation**
  * Restructured upgrade docs to separate controller vs worker procedures and added a manual equivalent to the one-shot script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->