### PR TITLE
fix(projects): CreateProjectDialog clips off iPhone viewport

### DIFF
--- a/desktop/src/apps/ProjectsApp/CreateProjectDialog.tsx
+++ b/desktop/src/apps/ProjectsApp/CreateProjectDialog.tsx
@@ -46,11 +46,11 @@ export function CreateProjectDialog({
       role="dialog"
       aria-modal="true"
       aria-label="Create project"
-      className="fixed inset-0 bg-black/50 flex items-center justify-center"
+      className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4"
     >
       <form
         onSubmit={onSubmit}
-        className="bg-zinc-900 p-4 rounded shadow w-96 space-y-3"
+        className="bg-zinc-900 p-4 rounded shadow w-full max-w-sm space-y-3"
       >
         <h3 className="text-lg font-semibold">New Project</h3>
         <label className="block text-sm">


### PR DESCRIPTION
## Summary

The New Project dialog uses `w-96` (fixed 384px) on the form. On a 390px iPhone viewport with no parent padding, the form clips off the right edge — the Slug / Description fields are unreachable, and the Cancel/Create buttons can't be tapped.

Fix: switch to `w-full max-w-sm` on the form and add `p-4` to the backdrop parent. Behavior:
- Mobile (390px): form is full-width minus 16px parent padding on each side ≈ 358px wide. Fully visible.
- Desktop (≥640px): form caps at 384px (max-w-sm) — identical to the old behavior.

Same pattern the mobile-shell PR used for `TaskCreateSheet`.

## Test plan

- [x] Vitest green (55 files, 220 tests)
- [x] TypeScript clean
- [ ] Manual: open the PWA on iPhone, tap "+ New" on Projects, verify all fields and buttons fit on screen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the project creation dialog with improved responsive layout and spacing. The form now adapts better to different screen sizes while maintaining optimal visual hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->