### PR TITLE
fix(projects): portal CreateProjectDialog out of window transform

### DIFF
--- a/desktop/src/apps/ProjectsApp/CreateProjectDialog.tsx
+++ b/desktop/src/apps/ProjectsApp/CreateProjectDialog.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { createPortal } from "react-dom";
 import { projectsApi } from "@/lib/projects";
 
 const slugify = (s: string) =>
@@ -41,7 +42,7 @@ export function CreateProjectDialog({
     }
   };
 
-  return (
+  return createPortal(
     <div
       role="dialog"
       aria-modal="true"
@@ -99,6 +100,7 @@ export function CreateProjectDialog({
           </button>
         </div>
       </form>
-    </div>
+    </div>,
+    document.body,
   );
 }


### PR DESCRIPTION
## Summary

The earlier PR #276 fixed the dialog's width (`w-96` → `w-full max-w-sm`) but didn't address why the modal was clipped/right-aligned on iPhone in the first place: `react-rnd` (used by `Window.tsx`) applies a CSS `transform: translate(...)` to window wrappers. Per CSS spec, `position: fixed` resolves relative to the nearest transformed ancestor — so `inset-0` was covering the window's bounds, not the viewport.

Render the dialog via `createPortal(..., document.body)` so it escapes the transformed parent and `position: fixed` actually means viewport.

## Test plan

- [x] Vitest green (245 tests, 62 files)
- [x] TypeScript clean
- [ ] Manual: open the PWA on iPhone, tap "+ New" on Projects — dialog should be centered on the screen, full-width minus 16px padding, fully visible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the create-project dialog rendering approach for improved stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->