### PR TITLE
fix(modals): portal sibling modals out of window transform

### DIFF
--- a/desktop/src/apps/ProjectsApp/AddAgentDialog.tsx
+++ b/desktop/src/apps/ProjectsApp/AddAgentDialog.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 import { projectsApi } from "@/lib/projects";
 
 type Mode = "new" | "existing";
@@ -56,7 +57,7 @@ export function AddAgentDialog({
     onClose();
   };
 
-  return (
+  return createPortal(
     <div role="dialog" aria-modal="true" aria-label="Add agent" className="fixed inset-0 bg-black/50 flex items-center justify-center">
       <form onSubmit={onSubmit} className="bg-zinc-900 p-4 rounded shadow w-[26rem] space-y-3">
         <h3 className="text-lg font-semibold">Add agent</h3>
@@ -142,6 +143,7 @@ export function AddAgentDialog({
           </button>
         </div>
       </form>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/desktop/src/apps/ProjectsApp/board/BoardToolbar.tsx
+++ b/desktop/src/apps/ProjectsApp/board/BoardToolbar.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from "react";
+import { createPortal } from "react-dom";
 import styles from "./BoardToolbar.module.css";
 import type { ViewMode, GroupBy, Filters } from "./types";
 import { BoardFilters } from "./BoardFilters";
@@ -45,7 +46,7 @@ export function BoardToolbar(p: BoardToolbarProps) {
             Filter / Group ▾
           </button>
         </div>
-        {sheetOpen && (
+        {sheetOpen && createPortal(
           <div
             role="dialog"
             aria-modal="true"
@@ -100,7 +101,8 @@ export function BoardToolbar(p: BoardToolbarProps) {
                 Done
               </button>
             </div>
-          </div>
+          </div>,
+          document.body,
         )}
       </>
     );

--- a/desktop/src/apps/ProjectsApp/board/TaskModal.tsx
+++ b/desktop/src/apps/ProjectsApp/board/TaskModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import styles from "./TaskModal.module.css";
 import { Hero } from "./modal/Hero";
 import { MetadataPane } from "./modal/MetadataPane";
@@ -76,7 +77,7 @@ export function TaskModal({ projectId, taskId, currentUserId, onClose, onPrev, o
 
   if (isMobile) {
     if (!task) {
-      return (
+      return createPortal(
         <div
           role="dialog"
           aria-modal="true"
@@ -94,7 +95,8 @@ export function TaskModal({ projectId, taskId, currentUserId, onClose, onPrev, o
             </button>
           </div>
           <div className="flex flex-1 items-center justify-center">Loading…</div>
-        </div>
+        </div>,
+        document.body,
       );
     }
     return (
@@ -124,7 +126,7 @@ export function TaskModal({ projectId, taskId, currentUserId, onClose, onPrev, o
     );
   }
 
-  return (
+  return createPortal(
     <div className={styles.scrim} role="dialog" aria-modal="true" aria-label={task?.title ?? "Task"}>
       <div className={styles.frame}>
         <header className={styles.bar}>
@@ -157,6 +159,7 @@ export function TaskModal({ projectId, taskId, currentUserId, onClose, onPrev, o
           ) : <p className={styles.loading}>Loading…</p>}
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/desktop/src/apps/ProjectsApp/mobile/MobileTaskModal.tsx
+++ b/desktop/src/apps/ProjectsApp/mobile/MobileTaskModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, type ReactNode, type TouchEvent } from "react";
+import { createPortal } from "react-dom";
 
 export interface MobileTaskModalTask {
   id: string;
@@ -93,7 +94,7 @@ export function MobileTaskModal({
     return () => window.clearTimeout(t);
   }, []);
 
-  return (
+  return createPortal(
     <div
       role="dialog"
       aria-modal="true"
@@ -218,7 +219,8 @@ export function MobileTaskModal({
           {action.label}
         </button>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }
 

--- a/desktop/src/apps/ProjectsApp/mobile/TaskCreateSheet.tsx
+++ b/desktop/src/apps/ProjectsApp/mobile/TaskCreateSheet.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 
 export interface TaskCreatePayload {
   title: string;
@@ -42,7 +43,7 @@ export function TaskCreateSheet({ open, onClose, onSubmit }: Props) {
     }
   };
 
-  return (
+  return createPortal(
     <div
       role="dialog"
       aria-modal="true"
@@ -97,6 +98,7 @@ export function TaskCreateSheet({ open, onClose, onSubmit }: Props) {
           </button>
         </div>
       </form>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/desktop/src/components/mobile/CardSwitcher.tsx
+++ b/desktop/src/components/mobile/CardSwitcher.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState, useCallback } from "react";
+import { createPortal } from "react-dom";
 import * as icons from "lucide-react";
 import { X, Plus } from "lucide-react";
 import { useProcessStore } from "@/stores/process-store";
@@ -66,7 +67,7 @@ export function CardSwitcher({ open, onClose, onSelectApp, onLaunchpad }: Props)
 
   if (!open) return null;
 
-  return (
+  return createPortal(
     <div
       className="fixed inset-0 flex flex-col backdrop-blur-sm"
       style={{ zIndex: 9000, backgroundColor: "rgba(0, 0, 0, 0.6)" }}
@@ -175,6 +176,7 @@ export function CardSwitcher({ open, onClose, onSelectApp, onLaunchpad }: Props)
           })}
         </div>
       )}
-    </div>
+    </div>,
+    document.body,
   );
 }


### PR DESCRIPTION
## Summary

Companion to PR #277. Same root cause (`react-rnd`'s `transform: translate` on the window wrapper scoping `position: fixed` to the window's bounds instead of the viewport), applied to all sibling modals that share the broken pattern.

## Files

- `desktop/src/apps/ProjectsApp/AddAgentDialog.tsx`
- `desktop/src/apps/ProjectsApp/board/TaskModal.tsx`
- `desktop/src/apps/ProjectsApp/board/BoardToolbar.tsx` (mobile filter sheet only)
- `desktop/src/apps/ProjectsApp/mobile/MobileTaskModal.tsx`
- `desktop/src/apps/ProjectsApp/mobile/TaskCreateSheet.tsx`
- `desktop/src/components/mobile/CardSwitcher.tsx`

Each return is wrapped in `createPortal(..., document.body)`.

## Test plan

- [x] Vitest green (245 tests, 62 files)
- [x] TypeScript clean
- [ ] Manual: open each modal on iPhone PWA, verify it covers the full screen and is centered/positioned correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced modal and dialog rendering across multiple application components to improve positioning, stacking behavior, and layout stability
  * Updated dialogs for project management workflows, task modal interactions, task creation sheets, and card switching interfaces
  * Improves visual consistency and reliability of modal overlays throughout the application

<!-- end of auto-generated comment: release notes by coderabbit.ai -->