### PR TITLE
fix(projects): slug auto-tracks name + dialog color polish

### DIFF
--- a/desktop/src/apps/ProjectsApp/CreateProjectDialog.test.tsx
+++ b/desktop/src/apps/ProjectsApp/CreateProjectDialog.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { CreateProjectDialog } from "./CreateProjectDialog";
+
+vi.mock("@/lib/projects", () => ({
+  projectsApi: { create: vi.fn() },
+}));
+
+describe("CreateProjectDialog slug auto-tracking", () => {
+  it("auto-fills slug from name on every keystroke until user edits slug", () => {
+    render(<CreateProjectDialog onClose={vi.fn()} onCreated={vi.fn()} />);
+    const nameInput = screen.getByRole("textbox", { name: /name/i });
+    const slugInput = screen.getByRole("textbox", { name: /slug/i });
+
+    fireEvent.change(nameInput, { target: { value: "H" } });
+    expect((slugInput as HTMLInputElement).value).toBe("h");
+
+    fireEvent.change(nameInput, { target: { value: "Hello" } });
+    expect((slugInput as HTMLInputElement).value).toBe("hello");
+
+    fireEvent.change(nameInput, { target: { value: "Hello World" } });
+    expect((slugInput as HTMLInputElement).value).toBe("hello-world");
+  });
+
+  it("stops auto-tracking once user manually edits the slug", () => {
+    render(<CreateProjectDialog onClose={vi.fn()} onCreated={vi.fn()} />);
+    const nameInput = screen.getByRole("textbox", { name: /name/i });
+    const slugInput = screen.getByRole("textbox", { name: /slug/i });
+
+    fireEvent.change(nameInput, { target: { value: "Hello" } });
+    expect((slugInput as HTMLInputElement).value).toBe("hello");
+
+    // User edits slug manually
+    fireEvent.change(slugInput, { target: { value: "my-project" } });
+    expect((slugInput as HTMLInputElement).value).toBe("my-project");
+
+    // Further name edits should NOT overwrite the user's slug
+    fireEvent.change(nameInput, { target: { value: "Hello World" } });
+    expect((slugInput as HTMLInputElement).value).toBe("my-project");
+  });
+});

--- a/desktop/src/apps/ProjectsApp/CreateProjectDialog.tsx
+++ b/desktop/src/apps/ProjectsApp/CreateProjectDialog.tsx
@@ -14,6 +14,7 @@ export function CreateProjectDialog({
 }) {
   const [name, setName] = useState("");
   const [slug, setSlug] = useState("");
+  const [slugTouched, setSlugTouched] = useState(false);
   const [description, setDescription] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -51,50 +52,53 @@ export function CreateProjectDialog({
     >
       <form
         onSubmit={onSubmit}
-        className="bg-zinc-900 p-4 rounded shadow w-full max-w-sm space-y-3"
+        className="bg-zinc-900 text-zinc-200 p-4 rounded shadow w-full max-w-sm space-y-3"
       >
-        <h3 className="text-lg font-semibold">New Project</h3>
-        <label className="block text-sm">
+        <h3 className="text-lg font-semibold text-zinc-200">New Project</h3>
+        <label className="block text-sm text-zinc-400">
           Name
           <input
             value={name}
             onChange={(e) => {
               setName(e.target.value);
-              if (!slug) setSlug(slugify(e.target.value));
+              if (!slugTouched) setSlug(slugify(e.target.value));
             }}
             required
             autoFocus
-            className="w-full mt-1 px-2 py-1 bg-zinc-800 rounded"
+            className="w-full mt-1 px-2 py-1 bg-zinc-800 text-zinc-100 placeholder-zinc-500 rounded outline-none focus:ring-2 focus:ring-zinc-600"
           />
         </label>
-        <label className="block text-sm">
+        <label className="block text-sm text-zinc-400">
           Slug
           <input
             value={slug}
-            onChange={(e) => setSlug(e.target.value)}
+            onChange={(e) => {
+              setSlug(e.target.value);
+              setSlugTouched(true);
+            }}
             pattern="[a-z0-9-]+"
             required
-            className="w-full mt-1 px-2 py-1 bg-zinc-800 rounded"
+            className="w-full mt-1 px-2 py-1 bg-zinc-800 text-zinc-100 placeholder-zinc-500 rounded outline-none focus:ring-2 focus:ring-zinc-600"
           />
         </label>
-        <label className="block text-sm">
+        <label className="block text-sm text-zinc-400">
           Description
           <textarea
             value={description}
             onChange={(e) => setDescription(e.target.value)}
             rows={3}
-            className="w-full mt-1 px-2 py-1 bg-zinc-800 rounded"
+            className="w-full mt-1 px-2 py-1 bg-zinc-800 text-zinc-100 placeholder-zinc-500 rounded outline-none focus:ring-2 focus:ring-zinc-600"
           />
         </label>
-        {error && <div role="alert" className="text-red-400 text-xs">{error}</div>}
+        {error && <div role="alert" className="mt-2 text-sm text-red-400">{error}</div>}
         <div className="flex justify-end gap-2">
-          <button type="button" onClick={onClose} className="px-3 py-1 text-sm">
+          <button type="button" onClick={onClose} className="px-3 py-1 text-sm text-zinc-300 hover:text-zinc-100 disabled:opacity-50">
             Cancel
           </button>
           <button
             type="submit"
             disabled={submitting}
-            className="px-3 py-1 bg-blue-600 rounded text-sm disabled:opacity-50"
+            className="px-3 py-1 bg-blue-600 hover:bg-blue-500 rounded text-sm font-medium text-white disabled:opacity-50"
           >
             {submitting ? "Creating…" : "Create"}
           </button>


### PR DESCRIPTION
## Summary

Two small fixes to `CreateProjectDialog`:

1. **Slug auto-tracking** — `if (!slug) setSlug(slugify(name))` only fired while `slug` was empty (true on the first keystroke only), so slugs stayed stuck on the first character of the name. Switched to a `slugTouched` flag that flips when the user manually edits the slug field. Auto-track until then; preserve the user's value after.

2. **Color polish** — the form had no explicit text colors. Cancel was `text-zinc-400` (low contrast), Create was missing `text-white`, inputs had no placeholder/focus styling. Applied the same palette as the mobile-shell modals (zinc-200 form text, zinc-100 input text, zinc-300 Cancel, blue-600 Create with hover, focus rings on inputs).

## Test plan

- [x] New tests cover the slug auto-tracking behavior (single char + manual edit)
- [x] Vitest green
- [x] TypeScript clean
- [ ] Manual: type into Name and verify Slug fills with the full kebab-cased name; edit slug and verify further name edits don't override

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the slug field to preserve user-edited values and prevent automatic regeneration from overwriting manual changes when the project name is updated.

* **Style**
  * Improved the Create Project dialog's visual appearance with enhanced styling, including updated input field colors, refined focus indicators, improved button hover behavior, and better-formatted error messages for increased visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->