### PR TITLE
fix(shortcuts): route accepts agent name OR id (was: id only)

### DIFF
--- a/tests/routes/test_shortcuts_list.py
+++ b/tests/routes/test_shortcuts_list.py
@@ -83,3 +83,22 @@ def test_unauthenticated_returns_401(test_client, agent_with_shortcuts):
     agent_id = agent_with_shortcuts["id"]
     resp = test_client.get(f"/api/agents/{agent_id}/shortcuts")
     assert resp.status_code == 401
+
+
+def test_get_shortcuts_by_name(test_client, admin_auth_headers, agent_with_shortcuts):
+    """Frontend passes agent.name; route must find the agent."""
+    agent_name = agent_with_shortcuts["name"]
+    resp = test_client.get(
+        f"/api/agents/{agent_name}/shortcuts", headers=admin_auth_headers
+    )
+    assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
+    assert isinstance(resp.json(), list)
+
+
+def test_get_shortcuts_by_id(test_client, admin_auth_headers, agent_with_shortcuts):
+    """Backwards-compat: lookup by id should also work."""
+    agent_id = agent_with_shortcuts["id"]
+    resp = test_client.get(
+        f"/api/agents/{agent_id}/shortcuts", headers=admin_auth_headers
+    )
+    assert resp.status_code == 200

--- a/tinyagentos/routes/shortcuts.py
+++ b/tinyagentos/routes/shortcuts.py
@@ -14,10 +14,19 @@ router = APIRouter()
 
 
 def _get_agent_by_name_or_id(request: Request, agent_ref: str) -> dict[str, Any]:
-    """Return the agent dict for *agent_ref* (matched by name or id) or raise 404."""
+    """Return the agent dict for *agent_ref* (matched by name first, then id) or raise 404.
+
+    Two-pass lookup: match by name first across all agents, fall back to id only if
+    no name match exists. Single-pass `name or id` is order-dependent — an agent
+    with `id="tom"` could win over a different agent with `name="tom"` depending
+    on list order.
+    """
     agents = request.app.state.config.agents
     for agent in agents:
-        if agent.get("name") == agent_ref or agent.get("id") == agent_ref:
+        if agent.get("name") == agent_ref:
+            return agent
+    for agent in agents:
+        if agent.get("id") == agent_ref:
             return agent
     raise HTTPException(status_code=404, detail="Agent not found")
 

--- a/tinyagentos/routes/shortcuts.py
+++ b/tinyagentos/routes/shortcuts.py
@@ -13,11 +13,11 @@ from tinyagentos.cluster.worker_registry import get_local_worker
 router = APIRouter()
 
 
-def _get_agent_by_id(request: Request, agent_id: str) -> dict[str, Any]:
-    """Return the agent dict for *agent_id* or raise 404."""
+def _get_agent_by_name_or_id(request: Request, agent_ref: str) -> dict[str, Any]:
+    """Return the agent dict for *agent_ref* (matched by name or id) or raise 404."""
     agents = request.app.state.config.agents
     for agent in agents:
-        if agent.get("id") == agent_id:
+        if agent.get("name") == agent_ref or agent.get("id") == agent_ref:
             return agent
     raise HTTPException(status_code=404, detail="Agent not found")
 
@@ -41,7 +41,7 @@ async def list_shortcuts(
     Each entry includes idx, kind, label, and icon.
     requires_capability is not exposed to the frontend.
     """
-    agent = _get_agent_by_id(request, agent_id)
+    agent = _get_agent_by_name_or_id(request, agent_id)
     all_shortcuts = _get_framework_shortcuts(agent)
 
     result = []
@@ -72,7 +72,7 @@ async def launch_shortcut(
     403 if the user lacks the required capability.
     404 if agent or shortcut idx not found.
     """
-    agent = _get_agent_by_id(request, agent_id)
+    agent = _get_agent_by_name_or_id(request, agent_id)
     all_shortcuts = _get_framework_shortcuts(agent)
 
     if idx < 0 or idx >= len(all_shortcuts):


### PR DESCRIPTION
## Summary

\`AgentsApp\` passes \`agent.name\` ("john") to \`/api/agents/{ref}/shortcuts\`, but the route's \`_get_agent_by_id\` helper only matched \`agent.id\` (a hex hash). Result: 404 → \`shortcuts=[]\` → \`AgentShortcutRow\` rendered null → no shortcut buttons in AgentsApp.

This was the actual reason agent shortcuts weren't showing in the iOS PWA — not a cache problem.

The fix renames the helper to \`_get_agent_by_name_or_id\` and tries the name first (matching the convention used by \`/api/agents/{name}/logs\` and similar existing routes), falling through to id. Both callers (\`list_shortcuts\`, \`launch_shortcut\`) updated.

\`shortcut_proxy.py\` was checked — its \`_resolve_container_ip\` and \`_get_shortcuts_for_agent\` already matched by both \`id\` and \`name\`, so no change needed there.

## Test plan

- [x] New tests verify both name and id paths return 200
- [x] Existing list/launch/proxy tests still pass (52 total)
- [ ] Manual: open AgentsApp on iPhone — agents with shortcuts (john, tom, don) should show a second row of buttons

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shortcut-list endpoint now accepts agent identifiers by name as well as by ID, making agent lookup more flexible and user-friendly.

* **Tests**
  * Added route tests to verify agent lookup by name and by ID, ensuring the endpoint returns successful JSON responses and maintains backward compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->