### PR TITLE
fix(agents): full-screen AgentDetailPanel + back button on mobile

### DIFF
--- a/desktop/src/apps/AgentsApp.tsx
+++ b/desktop/src/apps/AgentsApp.tsx
@@ -360,11 +360,13 @@ function AgentDetailPanel({
   initialTab,
   onClose,
   onAgentUpdated,
+  fullHeight = false,
 }: {
   agent: Agent;
   initialTab: DetailTab;
   onClose: () => void;
   onAgentUpdated: () => void;
+  fullHeight?: boolean;
 }) {
   const [tab, setTab] = useState<DetailTab>(initialTab);
   const [logs, setLogs] = useState<string>("Fetching logs...");
@@ -422,8 +424,8 @@ function AgentDetailPanel({
       <Tabs
       value={tab}
       onValueChange={(v) => setTab(v as DetailTab)}
-      className="border-t border-white/5 bg-shell-bg-deep flex flex-col"
-      style={{ height: "22rem" }}
+      className={fullHeight ? "border-t border-white/5 bg-shell-bg-deep flex flex-1 min-h-0 flex-col" : "border-t border-white/5 bg-shell-bg-deep flex flex-col"}
+      style={fullHeight ? undefined : { height: "22rem" }}
     >
       <div className="flex items-center justify-between px-4 py-2 border-b border-white/5 shrink-0">
         <div className="flex items-center gap-3">
@@ -2076,12 +2078,13 @@ export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
                 </div>
                 <span className="w-10" aria-hidden="true" />
               </div>
-              <div className="flex-1 overflow-y-auto">
+              <div className="flex flex-1 min-h-0 flex-col overflow-hidden">
                 <AgentDetailPanel
                   agent={agent}
                   initialTab={detail.tab}
                   onClose={() => setDetail(null)}
                   onAgentUpdated={fetchAgents}
+                  fullHeight
                 />
               </div>
             </div>,

--- a/desktop/src/apps/AgentsApp.tsx
+++ b/desktop/src/apps/AgentsApp.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from "react";
+import { createPortal } from "react-dom";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { Bot, Box, Plus, Trash2, ScrollText, Play, Server, X, ChevronRight, ChevronLeft, Check, Wrench, MessageSquare, PauseCircle, RotateCcw, Archive, HardDrive } from "lucide-react";
 import { fetchLatestFrameworks, LatestVersion } from "@/lib/framework-api";
@@ -1641,6 +1642,7 @@ export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
   const [diskStates, setDiskStates] = useState<Record<string, DiskState>>({});
   const [quotaErrors, setQuotaErrors] = useState<Record<string, string>>({});
   const [latestByFramework, setLatestByFramework] = useState<Record<string, LatestVersion>>({});
+  const isMobile = useIsMobile();
   const openWindow = useProcessStore((s) => s.openWindow);
 
   const fetchAgents = useCallback(async () => {
@@ -2049,6 +2051,43 @@ export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
       {detail && (() => {
         const agent = agents.find((a) => a.name === detail.name);
         if (!agent) return null;
+        if (isMobile) {
+          return createPortal(
+            <div
+              role="dialog"
+              aria-modal="true"
+              aria-label={`Agent details — ${agent.display_name || agent.name}`}
+              className="fixed inset-0 z-50 flex flex-col bg-zinc-950 text-zinc-200"
+            >
+              <div
+                className="flex items-center gap-2 border-b border-zinc-800 bg-zinc-900 px-3 py-2"
+                style={{ paddingTop: "calc(env(safe-area-inset-top, 0px) + 0.5rem)" }}
+              >
+                <button
+                  type="button"
+                  aria-label="Back to agents"
+                  onClick={() => setDetail(null)}
+                  className="rounded-lg px-2 py-1 text-sm text-zinc-300"
+                >
+                  ‹ Back
+                </button>
+                <div className="flex-1 truncate text-center text-sm font-medium text-zinc-200">
+                  {agent.display_name || agent.name}
+                </div>
+                <span className="w-10" aria-hidden="true" />
+              </div>
+              <div className="flex-1 overflow-y-auto">
+                <AgentDetailPanel
+                  agent={agent}
+                  initialTab={detail.tab}
+                  onClose={() => setDetail(null)}
+                  onAgentUpdated={fetchAgents}
+                />
+              </div>
+            </div>,
+            document.body,
+          );
+        }
         return (
           <AgentDetailPanel
             agent={agent}

--- a/desktop/src/apps/__tests__/AgentsApp.mobile.test.tsx
+++ b/desktop/src/apps/__tests__/AgentsApp.mobile.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 
 // Mock useIsMobile to return true so we test the mobile layout branch
 vi.mock("@/hooks/use-is-mobile", () => ({
@@ -33,6 +33,11 @@ vi.mock("@/components/agent-settings/MemoryTab", () => ({ MemoryTab: () => null 
 vi.mock("@/components/agent-settings/FrameworkTab", () => ({ FrameworkTab: () => null }));
 vi.mock("./AgentSkillsPanel", () => ({ AgentSkillsPanel: () => null }));
 vi.mock("./AgentMessagesPanel", () => ({ AgentMessagesPanel: () => null }));
+vi.mock("@/components/AgentShortcutRow", () => ({ AgentShortcutRow: () => null }));
+vi.mock("@/stores/process-store", () => ({
+  useProcessStore: (sel: (s: { openWindow: ReturnType<typeof vi.fn> }) => unknown) =>
+    sel({ openWindow: vi.fn() }),
+}));
 vi.mock("@/components/ui", () => ({
   Button: ({ children, onClick, className, ...rest }: React.ButtonHTMLAttributes<HTMLButtonElement> & { children?: React.ReactNode }) => (
     <button onClick={onClick} className={className} {...rest}>{children}</button>
@@ -124,5 +129,35 @@ describe("AgentsApp mobile layout (390px viewport)", () => {
     expect(skillsBtn).toBeTruthy();
     expect(messagesBtn).toBeTruthy();
     expect(deleteBtn).toBeTruthy();
+  });
+
+  it("renders a Back button in a full-screen dialog when the detail panel is opened on mobile", async () => {
+    render(<AgentsApp windowId="test" />);
+
+    // Wait for the agent list to load and click the skills button
+    const skillsBtn = await screen.findByRole("button", { name: /manage skills for my-agent/i });
+    fireEvent.click(skillsBtn);
+
+    // The full-screen overlay must render with a back button
+    const backBtn = screen.getByRole("button", { name: /back to agents/i });
+    expect(backBtn).toBeTruthy();
+
+    // The overlay must be a dialog with aria-modal
+    const dialog = screen.getByRole("dialog");
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+  });
+
+  it("closes the full-screen panel when the Back button is clicked", async () => {
+    render(<AgentsApp windowId="test" />);
+
+    const skillsBtn = await screen.findByRole("button", { name: /manage skills for my-agent/i });
+    fireEvent.click(skillsBtn);
+
+    const backBtn = screen.getByRole("button", { name: /back to agents/i });
+    fireEvent.click(backBtn);
+
+    // Panel must be gone
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(screen.queryByRole("button", { name: /back to agents/i })).toBeNull();
   });
 });

--- a/desktop/src/apps/__tests__/AgentsApp.test.tsx
+++ b/desktop/src/apps/__tests__/AgentsApp.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import React from "react";
 
 // Stub heavy deps first
@@ -128,5 +128,17 @@ describe("AgentsApp — AgentShortcutRow wiring (Task 27)", () => {
 
     const rowBeta = screen.getByTestId("shortcut-row-agent-beta");
     expect(rowBeta.getAttribute("data-has-launch")).toBe("true");
+  });
+
+  it("does NOT render a Back button or full-screen dialog when the detail panel is opened on desktop", async () => {
+    render(<AgentsApp windowId="test" />);
+
+    // Open the detail panel via the logs button on the first agent
+    const logsBtn = await screen.findByRole("button", { name: /view logs for agent-alpha/i });
+    fireEvent.click(logsBtn);
+
+    // No back button and no dialog wrapper on desktop
+    expect(screen.queryByRole("button", { name: /back to agents/i })).toBeNull();
+    expect(screen.queryByRole("dialog", { name: /agent details/i })).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- On mobile, tapping an agent card's skills/logs/messages icon rendered the detail panel inline below the agents list with no clear way to navigate back
- Refactors the render site to use a full-screen overlay with a `‹ Back` button + agent name header when `useIsMobile()` is true; desktop layout is completely unchanged
- Portals to `document.body` to escape react-rnd's window `transform: translate` (same pattern as #278)

## Test plan

- [x] Vitest: 248 tests pass (62 files)
- [x] TypeScript: clean (no errors)
- [ ] Manual: open AgentsApp on iPhone PWA, tap wrench/skills icon on any agent — full-screen panel with "‹ Back" header should appear; tap Back to return to the agent list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent details now open as a full-screen modal on mobile with a visible back button and improved accessibility for dialog screens; desktop experience remains unchanged.

* **Enhancements**
  * Mobile detail layout updated for full-height content and better tab behavior.

* **Tests**
  * Added mobile and desktop tests covering opening and dismissing the agent details view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->