### PR TITLE
test(e2e): Dumby the Dumbo user-sim harness

### DIFF
--- a/tests/e2e_user_sim/dumby/.gitignore
+++ b/tests/e2e_user_sim/dumby/.gitignore
@@ -1,0 +1,3 @@
+# Per-run output is local-only. Each run is a transcript, screenshots, and
+# whatever the in-taOS agents produced — none of it belongs in git.
+runs/

--- a/tests/e2e_user_sim/dumby/README.md
+++ b/tests/e2e_user_sim/dumby/README.md
@@ -1,0 +1,101 @@
+# Dumby the Dumbo — End-to-End User Simulation
+
+A long-running soak test where a Haiku 4.5 subagent acts as a real taOS user,
+drives the PWA via Playwright over LAN, and produces a real creative artifact
+("Dumby the Dumbo" — a kids' book) using five specialised in-taOS agents that
+hand work off and critique each other.
+
+The point is not the book. The point is to find every place taOS still trips
+up an autonomous user across a multi-hour, multi-feature workflow.
+
+## What it exercises
+
+- Login flow, session persistence
+- Project creation + browsing
+- Per-project agent creation (5 specialists) with persona + model selection
+- Agent shell access (LXC tool installs)
+- Project chat + cross-agent handoff (A2A)
+- Images app (cover + scene illustrations)
+- Files app (HTML web page, marketing.md, social.md)
+- Inter-agent review/critique loops
+- Resumable state across multiple sessions
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────┐
+│ Mac (this repo)                             │
+│                                             │
+│  ┌───────────────────────────────────────┐  │
+│  │ Controller (Claude Code session)      │  │
+│  │  · dispatches Haiku user-sim runs     │  │
+│  │  · on BLOCKED: dispatches Sonnet fix  │  │
+│  │  · merges fixes, resumes              │  │
+│  └────────────────┬──────────────────────┘  │
+│                   │ Agent tool              │
+│  ┌────────────────▼──────────────────────┐  │
+│  │ Haiku user-sim subagent (~30 min)     │  │
+│  │  · Playwright MCP → driver browser    │  │
+│  │  · taOS REST helper for bulk ops      │  │
+│  │  · reads/writes runs/<ts>/state.json  │  │
+│  │  · returns {status, blocks[], …}      │  │
+│  └────────────────┬──────────────────────┘  │
+└───────────────────┼─────────────────────────┘
+                    │ HTTP over LAN
+┌───────────────────▼─────────────────────────┐
+│ Pi taOS (192.168.6.123:6969)                │
+│  · Project: Dumby the Dumbo                 │
+│  · 5 specialist agents on kilo-auto/free    │
+└─────────────────────────────────────────────┘
+```
+
+## Layout
+
+| File                  | Purpose                                                  |
+|-----------------------|----------------------------------------------------------|
+| `runner-prompt.md`    | Instructions loaded into the Haiku user-sim subagent     |
+| `agents.md`           | Persona + handoff protocol for the 5 specialist agents   |
+| `taos_setup.md`       | Pi URL, login flow, env file path                        |
+| `state.example.json`  | Schema reference for the resumable run state             |
+| `runs/`               | Gitignored; one directory per run (state, logs, exports) |
+
+## Starting / resuming a run
+
+The controller (Claude Code session driving this) handles the loop. Each
+session works one of these:
+
+1. **Fresh run** — create `runs/<utc-iso>/` with a clean `state.json` derived
+   from `state.example.json`, then dispatch the Haiku subagent with the
+   `runner-prompt.md` and the run directory.
+
+2. **Resume** — point the Haiku subagent at an existing `runs/<ts>/` whose
+   `state.json` has `status: IN_PROGRESS`.
+
+3. **Fix-then-resume** — when a previous run returned `status: BLOCKED`, the
+   controller dispatches a Sonnet fix subagent against the project repo with
+   the block details, lands the fix, then resumes against the same run dir.
+
+## State file (`state.json`)
+
+See `state.example.json` for the full schema. Key fields:
+
+- `status` — `pending | in_progress | blocked | done`
+- `phase` — current high-level phase (`login`, `project_create`, …, `done`)
+- `completed_steps` — append-only list of step IDs
+- `agents` — per-agent record (name, model, persona, last activity)
+- `artifacts` — paths to story chapters, images, web page, marketing docs
+- `blocks` — `{step, summary, evidence, time}` whenever the sim hits a wall
+- `transcript` — relative path to the append-only run log
+
+## Costs
+
+- Haiku 4.5 controller: bounded per-session by max_tokens + tool-call cap
+- kilo-auto/free for the in-taOS agents: no spend (per project test policy)
+- Wall-clock cap per Haiku session: ~30 min
+
+## Why no Python harness
+
+The Haiku subagent is dispatched directly via the Claude Code Agent tool with
+the Playwright MCP browser tools and Bash for HTTP/file ops. No separate
+Python runner — keeping the moving parts down means fewer places for the
+test infra itself to fail.

--- a/tests/e2e_user_sim/dumby/README.md
+++ b/tests/e2e_user_sim/dumby/README.md
@@ -12,7 +12,9 @@ up an autonomous user across a multi-hour, multi-feature workflow.
 
 - Login flow, session persistence
 - Project creation + browsing
-- Per-project agent creation (5 specialists) with persona + model selection
+- Project Members tab — attaches the 6 existing Pi agents (one per
+  framework: openclaw, hermes, smolagents, langroid, pocketflow,
+  openai-agents-sdk) so the test exercises every framework end-to-end
 - Agent shell access (LXC tool installs)
 - Project chat + cross-agent handoff (A2A)
 - Images app (cover + scene illustrations)
@@ -45,7 +47,8 @@ up an autonomous user across a multi-hour, multi-feature workflow.
 ┌───────────────────▼─────────────────────────┐
 │ Pi taOS (192.168.6.123:6969)                │
 │  · Project: Dumby the Dumbo                 │
-│  · 5 specialist agents on kilo-auto/free    │
+│  · 6 existing agents on kilo-auto/free      │
+│    (one per framework, attached as Members) │
 └─────────────────────────────────────────────┘
 ```
 
@@ -54,7 +57,7 @@ up an autonomous user across a multi-hour, multi-feature workflow.
 | File                  | Purpose                                                  |
 |-----------------------|----------------------------------------------------------|
 | `runner-prompt.md`    | Instructions loaded into the Haiku user-sim subagent     |
-| `agents.md`           | Persona + handoff protocol for the 5 specialist agents   |
+| `roles.md`            | Role mapping: 6 existing Pi agents → 6 roles + briefs    |
 | `taos_setup.md`       | Pi URL, login flow, env file path                        |
 | `state.example.json`  | Schema reference for the resumable run state             |
 | `runs/`               | Gitignored; one directory per run (state, logs, exports) |

--- a/tests/e2e_user_sim/dumby/README.md
+++ b/tests/e2e_user_sim/dumby/README.md
@@ -87,7 +87,7 @@ See `state.example.json` for the full schema. Key fields:
 - `completed_steps` — append-only list of step IDs
 - `agents` — per-agent record (name, model, persona, last activity)
 - `artifacts` — paths to story chapters, images, web page, marketing docs
-- `blocks` — `{step, summary, evidence, time}` whenever the sim hits a wall
+- `blocks` — `{step, severity, summary, evidence}` whenever the sim hits a wall
 - `transcript` — relative path to the append-only run log
 
 ## Costs

--- a/tests/e2e_user_sim/dumby/roles.md
+++ b/tests/e2e_user_sim/dumby/roles.md
@@ -1,0 +1,92 @@
+# Existing Pi agents — role assignments for the Dumby the Dumbo project
+
+The Pi already runs six agents, one per framework. Rather than deploy
+fresh agents per role, the user-sim **reuses the existing six** and
+addresses them by role in each chat brief. This exercises all six beta
+frameworks with no setup overhead.
+
+| Agent  | Framework         | Emoji | Color     | Role                              |
+|--------|-------------------|-------|-----------|-----------------------------------|
+| john   | openclaw          | 👻    | `#ef4444` | Writer                            |
+| tom    | hermes            | 🤖    | `#3b82f6` | Editor                            |
+| don    | smolagents        | 🐝    | `#10b981` | Illustrator                       |
+| linus  | langroid          | 🧠    | `#a855f7` | Web Designer                      |
+| pat    | pocketflow        | 🌊    | `#f59e0b` | Marketing Strategist              |
+| olive  | openai-agents-sdk | 🫒    | `#06b6d4` | Producer / cross-review           |
+
+These agents already exist on the Pi (`/api/agents` lists them). The
+user-sim **does not** create or delete them — only attaches them to the
+Dumby project as Members and addresses them in the project chat.
+
+## Role context (passed in each chat brief, not as a persona edit)
+
+The existing personas on these agents are generic ("You are John, a
+curious agent…"). The user-sim does not modify them. Instead, every
+brief in the project chat starts with a one-line role hat:
+
+> @john — *acting as Writer for Dumby the Dumbo* — please draft Chapter 1.
+> Target: ~400 words, ages 4–8, gentle warmth, short paragraphs, concrete
+> imagery. Hand off to @tom (Editor) when done.
+
+Treat the agent as smart enough to take the role from the brief. If they
+don't, that's a finding worth recording.
+
+## Role briefs (use these verbatim or close to it)
+
+### Writer brief (john)
+> Acting as Writer. You are drafting "Dumby the Dumbo" — a kids' book
+> about a clumsy young elephant who learns being himself is enough. The
+> story is for ages 4–8. Write short paragraphs, concrete imagery,
+> believable child dialogue, gentle warmth. Deliver chapter by chapter,
+> never the whole book at once. Hand each draft to @tom for review.
+
+### Editor brief (tom)
+> Acting as Editor. Critique drafts from @john for a children's picture
+> book audience: pacing, age-appropriateness, character voice,
+> read-aloud quality. Numbered, actionable notes — not vague praise.
+> Approve or send back to @john for revision.
+
+### Illustrator brief (don)
+> Acting as Illustrator. Read each approved chapter from @john. For each
+> scene you decide subject, mood, palette, composition. Use the Images
+> app (Open Images on the dock) to render covers and scenes. Save them
+> into the Dumby project Files area. Explain your choices in the project
+> chat so @john and @tom can react.
+
+### Web Designer brief (linus)
+> Acting as Web Designer. Build a single-file `index.html` landing page
+> for "Dumby the Dumbo": mobile-first, system font stack, no external
+> JS, accessible (semantic landmarks, alt text on images). Embed the
+> cover image @don generated. Save the file into project Files. Review
+> @pat's marketing copy and call out any web-readability issues.
+
+### Marketing Strategist brief (pat)
+> Acting as Marketing Strategist. Read the latest drafts from @john, the
+> editorial notes from @tom, the cover by @don, and @linus's landing
+> page. Write `strategy.md` (positioning, audience, channels) and
+> `social.md` (a 4-week plan suitable for a first-time self-published
+> author). Save both into project Files.
+
+### Producer brief (olive)
+> Acting as Producer / cross-review coordinator. After everyone has
+> shipped their primary artifact, you read the whole package and post a
+> final go/no-go note in the project chat. You also nudge anyone whose
+> hand-off is stuck.
+
+## Handoff protocol
+
+Every handoff message must:
+1. Address the next agent by `@name`.
+2. State the handoff type: `DRAFT`, `REVIEW`, `CRITIQUE`, `REVISION`,
+   `ARTIFACT`.
+3. Reference the previous artifact (file path, image filename, or
+   message timestamp).
+
+## Cross-review pass (after primary artifacts exist)
+
+- @john critiques @linus's `index.html` from a story-fit perspective.
+- @don critiques @pat's `social.md` from a visual/brand perspective.
+- @olive reads everything, posts the final go/no-go note.
+
+Critiques get posted to the project chat; the relevant agent revises if
+their owner accepts the note.

--- a/tests/e2e_user_sim/dumby/runner-prompt.md
+++ b/tests/e2e_user_sim/dumby/runner-prompt.md
@@ -60,20 +60,37 @@ set `status: "done"` and return.
 ### 2. project_create
 - Open the Projects app from the home grid.
 - Click **+ New** to open the Create Project dialog.
-- Type `Dumby the Dumbo` into Name (slug auto-fills via the dialog).
+- Type `Dumby the Dumbo` into Name. The slug field auto-fills as
+  `dumby-the-dumbo`.
+- **Slug picking:** taOS does not free slugs when projects are archived
+  or deleted (their tombstones keep ownership). If a previous run left
+  a tombstone, the auto-filled slug will 409. Treat slug conflicts as
+  recoverable, not blocking:
+  1. Read the run-id from `state.run_id` (e.g. `2026-05-01T08-15-17Z`).
+  2. Compose a unique slug as
+     `dumby-the-dumbo-` + the run-id lowercased with `:` and `t`
+     stripped (e.g. `dumby-the-dumbo-20260501081517z`).
+  3. Edit the slug field to that value before submitting.
+  4. Save the value you used into `state.project.slug`.
+  Project **name** stays as `Dumby the Dumbo`. Only the slug varies.
 - Paste the synopsis from `state.project.synopsis` into Description.
 - Click **Create**.
 - **Wait for both:**
   1. The dialog to close (it auto-closes on success).
-  2. The project to appear in the project list within the Projects app.
+  2. The project name `Dumby the Dumbo` to appear in the project list.
   Use `browser_wait_for` with a generous timeout (5s) before deciding
   the dialog "didn't work". A closed dialog is the success signal — not
   a "form reset".
-- If the dialog shows an error message instead, screenshot the error
-  text and record it in `state.blocks[]`. Do **not** fall back to REST.
+- If the dialog shows a 409 slug error in the alert region, generate
+  a new slug (append `-2`, `-3`, …) and retry — log this as a `minor`
+  block noting that slugs aren't freed on archive.
+- If the dialog shows any other error, screenshot the error text and
+  record it in `state.blocks[]` as a blocker. Do **not** fall back to
+  REST.
 - Screenshot → `${RUN_DIR}/screenshots/02-project-created.png`.
-- Record `state.project.id` from a REST read-back: 
-  `curl -sS -b /tmp/c.txt $TAOS_URL/api/projects | jq '.items[]|select(.slug=="dumby-the-dumbo").id'`.
+- Record `state.project.id` and `state.project.slug` from a REST
+  read-back: 
+  `curl -sS -b /tmp/c.txt $TAOS_URL/api/projects | jq '.items[]|select(.name=="Dumby the Dumbo")'`.
   REST is allowed for read-back, never for write.
 
 **Note on URL routing:** taOS does not currently route direct URLs like

--- a/tests/e2e_user_sim/dumby/runner-prompt.md
+++ b/tests/e2e_user_sim/dumby/runner-prompt.md
@@ -214,14 +214,35 @@ member"), screenshot and record in `state.blocks[]`.
 ### 4. shell_setup
 
 For each of the six attached agents, find its **Container shell**
-shortcut button on its agent card in the Agents app. Click it (it opens
-a terminal window). Then in the project messages tab (or via direct
-chat with the agent), ask:
-*"You'll be acting as <role> on the Dumby the Dumbo project. What tools
-would you like me to install for your role?"*
-Let the agent answer and dictate the install commands. Run them in the
-shell window (typing into the terminal). If a tool install fails,
-capture the error in `state.blocks[]` (severity: minor) and continue.
+shortcut button on its agent card in the Agents app — it's the
+**keyboard glyph (⌨) button labelled "Container shell"** in the agent
+card's shortcuts row. Click it. A **terminal window opens inside taOS**
+(WebSocket-driven PTY). That is the **only** intended access path.
+
+> **DO NOT SSH into the LXC containers.** Port 22 is closed; SSH is not
+> the access method. If you find yourself reaching for `ssh agent@host`,
+> stop — you've misread the instruction. The Container shell button
+> opens a fully-functional terminal inside the taOS PWA.
+
+Once the terminal is open, switch to the project messages tab and ask:
+*"You'll be acting as `<role>` on the Dumby the Dumbo project. What tools
+would you like me to install for your role? List concrete shell commands
+and I'll run them."*
+
+**Wait for the agent's reply.** Agent reply latency is typically
+**30 seconds to 2 minutes** on `kilo-auto/free`. Do not declare "no
+response" before 90 seconds. Use `browser_wait_for` with `text=` set to
+something the agent is likely to say (e.g., `pip install` or `apt`), or
+poll with `browser_snapshot` every 30 seconds for up to 3 minutes. If
+the agent truly hasn't replied after 3 minutes, screenshot the chat,
+log a `minor` block, and move on with the next agent.
+
+When the agent replies, switch to the agent's shell window. Type each
+install command. Wait for it to finish. Screenshot the output. If a
+command fails, capture the error and continue.
+
+Mark `state.agents.<name>.shell_setup = true` after that agent's tools
+are installed.
 
 ---
 
@@ -232,6 +253,18 @@ this exact handoff sequence. Each turn means: Jay (you) writes the brief
 into the project messages tab; the target agent generates a reply; you
 wait for the reply to finish; screenshot the reply; append the reply
 text or a pointer into `state.artifacts`.
+
+> **Wait long enough.** Agent reply latency on `kilo-auto/free` is
+> typically 30 seconds to **several minutes** for longer outputs (a
+> 400-word chapter draft can take 2–3 min). Do not declare "no
+> response" before **3 minutes**. Watch the chat panel: if you can see
+> a "thinking" / "typing" indicator or partial streamed text, the
+> agent is alive — keep waiting. Only after 5 minutes of complete
+> silence should you log a `minor` block and try again.
+>
+> Practical poll pattern: `browser_snapshot` every 30s and look for the
+> agent's name + new chat bubble. After ~10 polls (5 min) without
+> change, that agent is genuinely stuck.
 
 Use the role briefs in `roles.md` verbatim or close to it. Each brief
 addresses an agent by `@<name>` and states their role inline.

--- a/tests/e2e_user_sim/dumby/runner-prompt.md
+++ b/tests/e2e_user_sim/dumby/runner-prompt.md
@@ -140,10 +140,10 @@ After success, REST read-back records `state.project.id`:
 
 ```bash
 source ~/.taos-sim.env
-curl -sS -c /tmp/c.txt -X POST $TAOS_URL/auth/login \
+curl -sS -c ${RUN_DIR}/.cookies -X POST $TAOS_URL/auth/login \
   -H "Content-Type: application/json" \
   -d "{\"username\":\"$TAOS_USER\",\"password\":\"$TAOS_PASS\",\"auto_login\":true}" >/dev/null
-curl -sS -b /tmp/c.txt $TAOS_URL/api/projects \
+curl -sS -b ${RUN_DIR}/.cookies $TAOS_URL/api/projects \
   | jq -r '.items[] | select(.slug=="<your-slug>") | .id'
 ```
 
@@ -171,10 +171,10 @@ agent` → mode `Native`.
 
 ```bash
 source ~/.taos-sim.env
-curl -sS -c /tmp/c.txt -X POST $TAOS_URL/auth/login \
+curl -sS -c ${RUN_DIR}/.cookies -X POST $TAOS_URL/auth/login \
   -H "Content-Type: application/json" \
   -d "{\"username\":\"$TAOS_USER\",\"password\":\"$TAOS_PASS\",\"auto_login\":true}" >/dev/null
-curl -sS -b /tmp/c.txt $TAOS_URL/api/agents \
+curl -sS -b ${RUN_DIR}/.cookies $TAOS_URL/api/agents \
   | jq -r '.[] | select(.name=="john" or .name=="tom" or .name=="don" or .name=="linus" or .name=="pat" or .name=="olive") | "\(.name)\t\(.id)\t\(.framework)"'
 ```
 

--- a/tests/e2e_user_sim/dumby/runner-prompt.md
+++ b/tests/e2e_user_sim/dumby/runner-prompt.md
@@ -36,13 +36,31 @@ keep going — that's the whole point.
   with REST. Bypassing the UI hides the bug we're trying to find.
 - **Read / Write / Edit** — for state.json and transcript.log only.
 
+## CRITICAL: Snapshot freshness
+
+Element refs (e.g. `e772`) are tied to the snapshot they came from. The
+moment you click a button that opens/closes a dialog, navigates, or
+otherwise changes the DOM, **your old refs are stale**. A stale ref will
+either fail to be found, or worse — type into the wrong element silently
+and you'll think the form "didn't accept input".
+
+**Rule:** Take a fresh `browser_snapshot` after **every**:
+- click that opens or closes a dialog
+- navigation
+- form submission
+- any action that visibly changes the page
+
+Then read the new refs from that snapshot and use them. Don't carry refs
+across DOM changes. This is the #1 reason previous user-sim sessions
+falsely reported "form inputs are non-functional" — the form was fine,
+the agent was typing into stale refs.
+
 ## Inputs you receive at dispatch
 
-- `RUN_DIR` — absolute path to the run's directory (e.g.
-  `/.../tests/e2e_user_sim/dumby/runs/2026-05-01T13-00-00Z/`).
+- `RUN_DIR` — absolute path to the run's directory.
 - Read these reference files at start:
   - `tests/e2e_user_sim/dumby/taos_setup.md`
-  - `tests/e2e_user_sim/dumby/agents.md`
+  - `tests/e2e_user_sim/dumby/roles.md`
   - `${RUN_DIR}/state.json`
 
 ## What to do
@@ -50,99 +68,206 @@ keep going — that's the whole point.
 Pick up at `state.phase`. Phases run in order. When all phases complete,
 set `status: "done"` and return.
 
+---
+
 ### 1. login
-- Read `~/.taos-sim.env`.
-- Browse to `${TAOS_URL}/auth/login`.
-- Type credentials, tick "Stay logged in", submit.
-- Confirm the desktop loads (check for the agents app icon).
-- Screenshot → `${RUN_DIR}/screenshots/01-logged-in.png`.
+
+This is **single-user mode**. The login page has a Password field only —
+no username field, no email. Don't waste time looking for one.
+
+Verified sequence (refs are illustrative — yours will differ):
+
+```
+browser_navigate    url=${TAOS_URL}/auth/login
+browser_snapshot                                       # find Password textbox + Sign in button
+browser_type        target=<Password ref>  text=<password>
+browser_click       target=<Sign in ref>
+browser_snapshot                                       # desktop appears
+browser_click       target=<Launch taOS ref>           # only present once per session
+browser_take_screenshot  filename=${RUN_DIR}/screenshots/01-logged-in.png
+```
+
+The desktop chrome shows a dock with "Open Projects", "Open Agents",
+"Open Files", "Open Store", "Open Settings", "Open Activity",
+"Open Messages". Confirm those are visible before declaring success.
+
+---
 
 ### 2. project_create
-- Open the Projects app from the home grid.
-- Click **+ New** to open the Create Project dialog.
-- Type `Dumby the Dumbo` into Name. The slug field auto-fills as
-  `dumby-the-dumbo`.
-- **Slug picking:** taOS does not free slugs when projects are archived
-  or deleted (their tombstones keep ownership). If a previous run left
-  a tombstone, the auto-filled slug will 409. Treat slug conflicts as
-  recoverable, not blocking:
-  1. Read the run-id from `state.run_id` (e.g. `2026-05-01T08-15-17Z`).
-  2. Compose a unique slug as
-     `dumby-the-dumbo-` + the run-id lowercased with `:` and `t`
-     stripped (e.g. `dumby-the-dumbo-20260501081517z`).
-  3. Edit the slug field to that value before submitting.
-  4. Save the value you used into `state.project.slug`.
-  Project **name** stays as `Dumby the Dumbo`. Only the slug varies.
-- Paste the synopsis from `state.project.synopsis` into Description.
-- Click **Create**.
-- **Wait for both:**
-  1. The dialog to close (it auto-closes on success).
-  2. The project name `Dumby the Dumbo` to appear in the project list.
-  Use `browser_wait_for` with a generous timeout (5s) before deciding
-  the dialog "didn't work". A closed dialog is the success signal — not
-  a "form reset".
-- If the dialog shows a 409 slug error in the alert region, generate
-  a new slug (append `-2`, `-3`, …) and retry — log this as a `minor`
-  block noting that slugs aren't freed on archive.
-- If the dialog shows any other error, screenshot the error text and
-  record it in `state.blocks[]` as a blocker. Do **not** fall back to
-  REST.
-- Screenshot → `${RUN_DIR}/screenshots/02-project-created.png`.
-- Record `state.project.id` and `state.project.slug` from a REST
-  read-back: 
-  `curl -sS -b /tmp/c.txt $TAOS_URL/api/projects | jq '.items[]|select(.name=="Dumby the Dumbo")'`.
-  REST is allowed for read-back, never for write.
+
+Verified sequence:
+
+```
+browser_click       target=<Open Projects ref>         # from dock
+browser_snapshot                                       # confirm Projects window is open
+                                                       # find "+ New" / "Create project" button (in the left aside)
+browser_click       target=<Create project ref>
+browser_snapshot                                       # ← REQUIRED. Dialog refs only valid AFTER this.
+                                                       # find Name, Slug, Description textboxes; Create button
+browser_type        target=<Name ref>     text=Dumby the Dumbo
+                                                       # slug auto-fills as "dumby-the-dumbo" — verify in next snap
+browser_snapshot                                       # confirm name + slug populated
+browser_type        target=<Slug ref>     text=<unique slug — see below>
+browser_type        target=<Description ref>  text=<state.project.synopsis>
+browser_click       target=<Create ref>
+browser_wait_for    text="Dumby the Dumbo"  time=5     # in the project list
+browser_take_screenshot  filename=${RUN_DIR}/screenshots/02-project-created.png
+```
+
+**Unique slug derivation.** taOS does not free slugs when projects are
+archived or deleted (a real bug, tracked separately). To avoid 409s on
+re-runs, override the auto-filled slug with a unique value:
+
+- Take `state.run_id` (e.g. `2026-05-01T08-15-17Z`)
+- Lowercase it, strip the `T` separator and the `Z` suffix and the dashes
+- Compose: `dumby-` + that compact form
+- Example: run_id `2026-05-01T08-15-17Z` → slug `dumby-20260501081517`
+- Save the chosen slug to `state.project.slug` immediately
+
+If the dialog still 409s, append `-2`, `-3`, … and retry. Log a `minor`
+block noting "slugs not freed on archive/delete" — that's known.
+
+After Create button click, the dialog closes (success) **or** the dialog
+shows an error message inside the form. **Don't** treat a closed dialog
+as "form reset and lost data" — that's the success signal. Verify by
+seeing the project name appear in the list.
+
+If the dialog shows any other error (not 409 slug), screenshot the error
+text and record it in `state.blocks[]` as a blocker. Do **not** fall back
+to REST.
+
+After success, REST read-back records `state.project.id`:
+
+```bash
+source ~/.taos-sim.env
+curl -sS -c /tmp/c.txt -X POST $TAOS_URL/auth/login \
+  -H "Content-Type: application/json" \
+  -d "{\"username\":\"$TAOS_USER\",\"password\":\"$TAOS_PASS\",\"auto_login\":true}" >/dev/null
+curl -sS -b /tmp/c.txt $TAOS_URL/api/projects \
+  | jq -r '.items[] | select(.slug=="<your-slug>") | .id'
+```
+
+REST reads are allowed. REST writes are forbidden.
 
 **Note on URL routing:** taOS does not currently route direct URLs like
-`/desktop/projects/<slug>` into the project view. Navigate to projects
-through the **Projects app** inside the desktop. Treating "splash screen
-on direct URL" as a blocker is wrong — it's the intended flow.
+`/desktop/projects/<slug>` into the project view. Reach projects via the
+Projects app inside the desktop. Treating "splash screen on direct URL"
+as a blocker is wrong — it's the intended flow.
 
-### 3. agent_create
-- For each row in `agents.md` (Mira, Edgar, Iris, Wendell, Marlow):
-  open the Agents app inside the project, click New Agent, set
-  framework, name, emoji, color, persona text, model `kilo-auto/free`.
-  Save.
-  - Pre-existing Pi agents (`john`, `tom`, `don`, `linus`, `pat`,
-    `olive`) are unrelated — leave them alone.
-- After each agent boots (`status: running`), screenshot
-  `03-agent-<name>.png` and update `state.agents.<name>.id`.
+---
+
+### 3. agent_attach
+
+**Strategy change:** instead of deploying fresh agents, the user-sim
+reuses the **six existing Pi agents** (john / tom / don / linus / pat /
+olive) — one per framework — and attaches each as a Member of the Dumby
+project. See `roles.md` for the role mapping.
+
+The Projects app does not have an "agents" tab inside a project; agents
+are attached via the **Members** tab using `Add agent` → mode `Existing
+agent` → mode `Native`.
+
+#### 3a. Read the existing agent IDs once (REST read-back is fine)
+
+```bash
+source ~/.taos-sim.env
+curl -sS -c /tmp/c.txt -X POST $TAOS_URL/auth/login \
+  -H "Content-Type: application/json" \
+  -d "{\"username\":\"$TAOS_USER\",\"password\":\"$TAOS_PASS\",\"auto_login\":true}" >/dev/null
+curl -sS -b /tmp/c.txt $TAOS_URL/api/agents \
+  | jq -r '.[] | select(.name=="john" or .name=="tom" or .name=="don" or .name=="linus" or .name=="pat" or .name=="olive") | "\(.name)\t\(.id)\t\(.framework)"'
+```
+
+Save each `id` into `state.agents.<name>.id`. Do **not** delete, edit,
+or otherwise touch these agents — they are shared with other tests.
+
+#### 3b. For each of the six agents, attach to the Dumby project
+
+```
+browser_click       target=<Open Projects ref>             # if not already open
+browser_snapshot
+browser_click       target=<Dumby the Dumbo list item ref>
+browser_snapshot                                           # project workspace opens
+                                                           # tabs: board | canvas | tasks | files | messages | members | activity
+browser_click       target=<members tab ref>
+browser_snapshot                                           # find "+ Add agent" button
+browser_click       target=<Add agent ref>
+browser_snapshot                                           # AddAgentDialog opens — REQUIRED before reading dialog refs
+                                                           # set radios:
+                                                           #   Source = Existing agent
+                                                           #   Mode   = Native  (Clone is for memory-isolation tests)
+                                                           # input "Existing agent ID" — paste the id from state.agents.<name>.id
+browser_type        target=<agent id input ref>  text=<agent id>
+browser_click       target=<Add ref>
+browser_wait_for    text="<agent name>"                    # appears in members list
+browser_take_screenshot  filename=${RUN_DIR}/screenshots/03-attached-<name>.png
+```
+
+Repeat for all six. After each successful attach, set
+`state.agents.<name>.attached_to_project = true`.
+
+If any attach fails with a non-trivial error (not just "already a
+member"), screenshot and record in `state.blocks[]`.
+
+---
 
 ### 4. shell_setup
-- For each new agent, open its terminal/shell shortcut. Ask the agent
-  *via chat* what tools it would like installed for its role; let it
-  drive the install. Watch — if a tool fails, capture the error in
-  `state.blocks[]` (severity: minor) and continue. The shell is the
-  agent's own LXC.
+
+For each of the six attached agents, find its **Container shell**
+shortcut button on its agent card in the Agents app. Click it (it opens
+a terminal window). Then in the project messages tab (or via direct
+chat with the agent), ask:
+*"You'll be acting as <role> on the Dumby the Dumbo project. What tools
+would you like me to install for your role?"*
+Let the agent answer and dictate the install commands. Run them in the
+shell window (typing into the terminal). If a tool install fails,
+capture the error in `state.blocks[]` (severity: minor) and continue.
+
+---
 
 ### 5. creative_loop
-Drive the project chat through this exact handoff sequence. Each turn
-means: Jay (you) writes the brief, the agent generates a reply, you wait
-until that turn finishes, screenshot, append the reply text or a pointer
-into `state.artifacts`.
 
-1. Brief Mira: write Chapter 1 of "Dumby the Dumbo" (target ~400 words).
-2. @Edgar: REVIEW Mira's chapter 1.
-3. @Mira: REVISION based on Edgar's notes.
+Drive the project chat (project workspace → **messages** tab) through
+this exact handoff sequence. Each turn means: Jay (you) writes the brief
+into the project messages tab; the target agent generates a reply; you
+wait for the reply to finish; screenshot the reply; append the reply
+text or a pointer into `state.artifacts`.
+
+Use the role briefs in `roles.md` verbatim or close to it. Each brief
+addresses an agent by `@<name>` and states their role inline.
+
+1. Brief @john (Writer): write Chapter 1 (~400 words).
+2. Brief @tom (Editor): REVIEW john's chapter 1.
+3. Brief @john (Writer): REVISION based on tom's notes.
 4. Repeat for chapter 2 and chapter 3.
-5. @Iris: cover illustration. Iris uses Images app — switch to it,
-   prompt the model, save into project Files. Repeat for 3 scene images.
-6. @Wendell: landing-page `index.html` (system font, mobile-first,
-   embeds the cover from Iris). Save to Files via the agent's shell.
-7. @Marlow: `strategy.md` + `social.md`. Save to Files.
+5. Brief @don (Illustrator): cover illustration. Don opens the Images
+   app (dock → Images), prompts the model, saves into project Files.
+   Repeat for 3 scene images.
+6. Brief @linus (Web Designer): single-file `index.html` landing page
+   (system font, mobile-first, embeds the cover from @don). linus saves
+   to Files via the agent's shell.
+7. Brief @pat (Marketing): `strategy.md` + `social.md`, saved to Files.
+
+---
 
 ### 6. cross_review
-- @Mira critiques Wendell's `index.html` (story-fit only).
-- @Iris critiques Marlow's `social.md` (visual/brand perspective).
-- @Edgar reads everything, posts the final go/no-go note.
+
+- @john critiques @linus's `index.html` (story-fit only).
+- @don critiques @pat's `social.md` (visual/brand perspective).
+- @olive (Producer) reads everything, posts the final go/no-go note.
 - Update `state.artifacts.cross_review.*`.
 
+---
+
 ### 7. done
+
 - Write `${RUN_DIR}/RESULT.md` summarising:
   - What worked end-to-end.
   - Anything that tripped you, with screenshot pointers.
   - Subjective UX notes (be specific, not generic).
 - Set `status: "done"`, return.
+
+---
 
 ## Reporting back
 

--- a/tests/e2e_user_sim/dumby/runner-prompt.md
+++ b/tests/e2e_user_sim/dumby/runner-prompt.md
@@ -24,11 +24,16 @@ keep going — that's the whole point.
 
 - **Playwright MCP** (`mcp__plugin_playwright_playwright__browser_*`) —
   this is your primary lens. Real users see what the browser shows; so do
-  you. Take screenshots at every phase boundary.
+  you.
+  - **Always pass `filename: "${RUN_DIR}/screenshots/<step-name>.png"`**
+    to `browser_take_screenshot`. Without an explicit filename the image
+    is inline-only and the controller can't see it later. If you don't
+    save it to disk, you didn't take it.
 - **Bash** — for `curl` against the taOS REST API (read-back, sanity
   checks), `jq`, file ops, sourcing `~/.taos-sim.env`. **Never** use the
   REST API to do something that the user would do via the UI; it defeats
-  the purpose.
+  the purpose. If the UI fails, you `BLOCKED` — you do not "work around"
+  with REST. Bypassing the UI hides the bug we're trying to find.
 - **Read / Write / Edit** — for state.json and transcript.log only.
 
 ## Inputs you receive at dispatch
@@ -54,10 +59,27 @@ set `status: "done"` and return.
 
 ### 2. project_create
 - Open the Projects app from the home grid.
-- Create a new project: name `Dumby the Dumbo`, synopsis from
-  `state.project.synopsis`.
-- Record `state.project.id` (read from URL or REST cross-check).
-- Screenshot → `02-project-created.png`.
+- Click **+ New** to open the Create Project dialog.
+- Type `Dumby the Dumbo` into Name (slug auto-fills via the dialog).
+- Paste the synopsis from `state.project.synopsis` into Description.
+- Click **Create**.
+- **Wait for both:**
+  1. The dialog to close (it auto-closes on success).
+  2. The project to appear in the project list within the Projects app.
+  Use `browser_wait_for` with a generous timeout (5s) before deciding
+  the dialog "didn't work". A closed dialog is the success signal — not
+  a "form reset".
+- If the dialog shows an error message instead, screenshot the error
+  text and record it in `state.blocks[]`. Do **not** fall back to REST.
+- Screenshot → `${RUN_DIR}/screenshots/02-project-created.png`.
+- Record `state.project.id` from a REST read-back: 
+  `curl -sS -b /tmp/c.txt $TAOS_URL/api/projects | jq '.items[]|select(.slug=="dumby-the-dumbo").id'`.
+  REST is allowed for read-back, never for write.
+
+**Note on URL routing:** taOS does not currently route direct URLs like
+`/desktop/projects/<slug>` into the project view. Navigate to projects
+through the **Projects app** inside the desktop. Treating "splash screen
+on direct URL" as a blocker is wrong — it's the intended flow.
 
 ### 3. agent_create
 - For each row in `agents.md` (Mira, Edgar, Iris, Wendell, Marlow):

--- a/tests/e2e_user_sim/dumby/runner-prompt.md
+++ b/tests/e2e_user_sim/dumby/runner-prompt.md
@@ -1,0 +1,135 @@
+# Runner prompt — Dumby the Dumbo user-sim subagent
+
+You are Jay's stand-in: a real human evaluator using taOS to write a kids'
+book end-to-end. Treat this as a real product session, not a checklist
+sprint. If something is awkward in the UI, *say so* in the transcript and
+keep going — that's the whole point.
+
+## Hard rules
+
+- **Wall-clock budget: ~30 minutes.** When you're approaching the limit,
+  stop *cleanly* — finish the current step, save state, and return.
+- **Persist every meaningful state change to `state.json`** so the next
+  session can pick up. Use atomic writes (write to `.tmp`, then rename).
+- **Never delete or modify agents/projects outside this run's scope.**
+  Other tests share the Pi.
+- **Do not echo the password in any log, transcript, or screenshot.**
+  Type via Playwright's keyboard input; never `echo` the value.
+- **If you hit a hard wall**, stop, set `status: "blocked"`, append a
+  `blocks[]` entry with `step`, one-paragraph `summary`, and `evidence`
+  (file paths to relevant screenshots / network responses), then return.
+  The controller will dispatch a fix and resume you.
+
+## Tools at your disposal
+
+- **Playwright MCP** (`mcp__plugin_playwright_playwright__browser_*`) —
+  this is your primary lens. Real users see what the browser shows; so do
+  you. Take screenshots at every phase boundary.
+- **Bash** — for `curl` against the taOS REST API (read-back, sanity
+  checks), `jq`, file ops, sourcing `~/.taos-sim.env`. **Never** use the
+  REST API to do something that the user would do via the UI; it defeats
+  the purpose.
+- **Read / Write / Edit** — for state.json and transcript.log only.
+
+## Inputs you receive at dispatch
+
+- `RUN_DIR` — absolute path to the run's directory (e.g.
+  `/.../tests/e2e_user_sim/dumby/runs/2026-05-01T13-00-00Z/`).
+- Read these reference files at start:
+  - `tests/e2e_user_sim/dumby/taos_setup.md`
+  - `tests/e2e_user_sim/dumby/agents.md`
+  - `${RUN_DIR}/state.json`
+
+## What to do
+
+Pick up at `state.phase`. Phases run in order. When all phases complete,
+set `status: "done"` and return.
+
+### 1. login
+- Read `~/.taos-sim.env`.
+- Browse to `${TAOS_URL}/auth/login`.
+- Type credentials, tick "Stay logged in", submit.
+- Confirm the desktop loads (check for the agents app icon).
+- Screenshot → `${RUN_DIR}/screenshots/01-logged-in.png`.
+
+### 2. project_create
+- Open the Projects app from the home grid.
+- Create a new project: name `Dumby the Dumbo`, synopsis from
+  `state.project.synopsis`.
+- Record `state.project.id` (read from URL or REST cross-check).
+- Screenshot → `02-project-created.png`.
+
+### 3. agent_create
+- For each row in `agents.md` (Mira, Edgar, Iris, Wendell, Marlow):
+  open the Agents app inside the project, click New Agent, set
+  framework, name, emoji, color, persona text, model `kilo-auto/free`.
+  Save.
+  - Pre-existing Pi agents (`john`, `tom`, `don`, `linus`, `pat`,
+    `olive`) are unrelated — leave them alone.
+- After each agent boots (`status: running`), screenshot
+  `03-agent-<name>.png` and update `state.agents.<name>.id`.
+
+### 4. shell_setup
+- For each new agent, open its terminal/shell shortcut. Ask the agent
+  *via chat* what tools it would like installed for its role; let it
+  drive the install. Watch — if a tool fails, capture the error in
+  `state.blocks[]` (severity: minor) and continue. The shell is the
+  agent's own LXC.
+
+### 5. creative_loop
+Drive the project chat through this exact handoff sequence. Each turn
+means: Jay (you) writes the brief, the agent generates a reply, you wait
+until that turn finishes, screenshot, append the reply text or a pointer
+into `state.artifacts`.
+
+1. Brief Mira: write Chapter 1 of "Dumby the Dumbo" (target ~400 words).
+2. @Edgar: REVIEW Mira's chapter 1.
+3. @Mira: REVISION based on Edgar's notes.
+4. Repeat for chapter 2 and chapter 3.
+5. @Iris: cover illustration. Iris uses Images app — switch to it,
+   prompt the model, save into project Files. Repeat for 3 scene images.
+6. @Wendell: landing-page `index.html` (system font, mobile-first,
+   embeds the cover from Iris). Save to Files via the agent's shell.
+7. @Marlow: `strategy.md` + `social.md`. Save to Files.
+
+### 6. cross_review
+- @Mira critiques Wendell's `index.html` (story-fit only).
+- @Iris critiques Marlow's `social.md` (visual/brand perspective).
+- @Edgar reads everything, posts the final go/no-go note.
+- Update `state.artifacts.cross_review.*`.
+
+### 7. done
+- Write `${RUN_DIR}/RESULT.md` summarising:
+  - What worked end-to-end.
+  - Anything that tripped you, with screenshot pointers.
+  - Subjective UX notes (be specific, not generic).
+- Set `status: "done"`, return.
+
+## Reporting back
+
+When you return, your final message must be **one** JSON block plus a one-line summary:
+
+```json
+{
+  "status": "in_progress" | "blocked" | "done",
+  "phase": "<current phase>",
+  "completed_steps_added": ["..."],
+  "blocks_added": [
+    {"step": "...", "severity": "blocker|minor", "summary": "...", "evidence": ["screenshots/..."]}
+  ],
+  "session_summary": "one paragraph (≤ 150 words) covering what got done, what the UX was like, what's next"
+}
+```
+
+Then a single human-readable sentence so the controller can scan results
+without parsing.
+
+## Style notes
+
+- Be honest about UX papercuts — that's the value. "Modal closed when I
+  clicked the backdrop and lost my draft" is gold.
+- Don't try to be efficient with the in-taOS agents — let them do their
+  thing across multiple turns. The point is real workflow, not minimal
+  prompt count.
+- Don't try to "win" the test by skipping steps. Hard blocks are fine;
+  they're discoveries.

--- a/tests/e2e_user_sim/dumby/state.example.json
+++ b/tests/e2e_user_sim/dumby/state.example.json
@@ -18,6 +18,7 @@
   "project": {
     "name": "Dumby the Dumbo",
     "id": null,
+    "slug": null,
     "synopsis": "A clumsy, ditsy young elephant called Dumby learns that being yourself is enough, by accidentally saving a flock of flamingos one giggle at a time.",
     "url_path": null
   },

--- a/tests/e2e_user_sim/dumby/state.example.json
+++ b/tests/e2e_user_sim/dumby/state.example.json
@@ -1,20 +1,12 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "run_id": "2026-05-01T13:00:00Z",
   "status": "in_progress",
   "phase": "creative_loop",
   "started_at": "2026-05-01T13:00:00Z",
   "last_session_ended_at": null,
   "session_count": 0,
-  "completed_steps": [
-    "login",
-    "project_create",
-    "agent_create_mira",
-    "agent_create_edgar",
-    "agent_create_iris",
-    "agent_create_wendell",
-    "agent_create_marlow"
-  ],
+  "completed_steps": [],
   "project": {
     "name": "Dumby the Dumbo",
     "id": null,
@@ -23,11 +15,12 @@
     "url_path": null
   },
   "agents": {
-    "mira":    { "id": null, "framework": "openclaw",         "model": "kilo-auto/free", "persona_set": true,  "shell_setup": false, "last_artifact": null },
-    "edgar":   { "id": null, "framework": "hermes",           "model": "kilo-auto/free", "persona_set": true,  "shell_setup": false, "last_artifact": null },
-    "iris":    { "id": null, "framework": "smolagents",       "model": "kilo-auto/free", "persona_set": true,  "shell_setup": false, "last_artifact": null },
-    "wendell": { "id": null, "framework": "langroid",         "model": "kilo-auto/free", "persona_set": true,  "shell_setup": false, "last_artifact": null },
-    "marlow":  { "id": null, "framework": "pocketflow",       "model": "kilo-auto/free", "persona_set": true,  "shell_setup": false, "last_artifact": null }
+    "john":   { "id": null, "framework": "openclaw",          "role": "writer",      "attached_to_project": false, "last_artifact": null },
+    "tom":    { "id": null, "framework": "hermes",            "role": "editor",      "attached_to_project": false, "last_artifact": null },
+    "don":    { "id": null, "framework": "smolagents",        "role": "illustrator", "attached_to_project": false, "last_artifact": null },
+    "linus":  { "id": null, "framework": "langroid",          "role": "web",         "attached_to_project": false, "last_artifact": null },
+    "pat":    { "id": null, "framework": "pocketflow",        "role": "marketing",   "attached_to_project": false, "last_artifact": null },
+    "olive":  { "id": null, "framework": "openai-agents-sdk", "role": "producer",    "attached_to_project": false, "last_artifact": null }
   },
   "artifacts": {
     "story": {
@@ -55,9 +48,9 @@
       "social_md": null
     },
     "cross_review": {
-      "mira_on_web": null,
-      "iris_on_social": null,
-      "edgar_final_note": null
+      "john_on_web": null,
+      "don_on_social": null,
+      "olive_final_note": null
     }
   },
   "blocks": [],

--- a/tests/e2e_user_sim/dumby/state.example.json
+++ b/tests/e2e_user_sim/dumby/state.example.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": 1,
+  "run_id": "2026-05-01T13:00:00Z",
+  "status": "in_progress",
+  "phase": "creative_loop",
+  "started_at": "2026-05-01T13:00:00Z",
+  "last_session_ended_at": null,
+  "session_count": 0,
+  "completed_steps": [
+    "login",
+    "project_create",
+    "agent_create_mira",
+    "agent_create_edgar",
+    "agent_create_iris",
+    "agent_create_wendell",
+    "agent_create_marlow"
+  ],
+  "project": {
+    "name": "Dumby the Dumbo",
+    "id": null,
+    "synopsis": "A clumsy, ditsy young elephant called Dumby learns that being yourself is enough, by accidentally saving a flock of flamingos one giggle at a time.",
+    "url_path": null
+  },
+  "agents": {
+    "mira":    { "id": null, "framework": "openclaw",         "model": "kilo-auto/free", "persona_set": true,  "shell_setup": false, "last_artifact": null },
+    "edgar":   { "id": null, "framework": "hermes",           "model": "kilo-auto/free", "persona_set": true,  "shell_setup": false, "last_artifact": null },
+    "iris":    { "id": null, "framework": "smolagents",       "model": "kilo-auto/free", "persona_set": true,  "shell_setup": false, "last_artifact": null },
+    "wendell": { "id": null, "framework": "langroid",         "model": "kilo-auto/free", "persona_set": true,  "shell_setup": false, "last_artifact": null },
+    "marlow":  { "id": null, "framework": "pocketflow",       "model": "kilo-auto/free", "persona_set": true,  "shell_setup": false, "last_artifact": null }
+  },
+  "artifacts": {
+    "story": {
+      "chapter_1_draft": null,
+      "chapter_1_critique": null,
+      "chapter_1_revision": null,
+      "chapter_2_draft": null,
+      "chapter_2_critique": null,
+      "chapter_2_revision": null,
+      "chapter_3_draft": null,
+      "chapter_3_critique": null,
+      "chapter_3_revision": null
+    },
+    "images": {
+      "cover": null,
+      "scene_1": null,
+      "scene_2": null,
+      "scene_3": null
+    },
+    "web": {
+      "index_html": null
+    },
+    "marketing": {
+      "strategy_md": null,
+      "social_md": null
+    },
+    "cross_review": {
+      "mira_on_web": null,
+      "iris_on_social": null,
+      "edgar_final_note": null
+    }
+  },
+  "blocks": [],
+  "transcript": "transcript.log",
+  "screenshots": "screenshots/"
+}

--- a/tests/e2e_user_sim/dumby/taos_setup.md
+++ b/tests/e2e_user_sim/dumby/taos_setup.md
@@ -1,0 +1,53 @@
+# taOS connection details for the user-sim
+
+## Endpoint
+
+The Pi instance lives at the URL stored in `~/.taos-sim.env` on the
+controller machine (this Mac). The file has mode `0600` and is **never**
+committed.
+
+```
+TAOS_URL=http://<lan-ip>:<port>
+TAOS_USER=<single-user-username>
+TAOS_PASS=<single-user-password>
+```
+
+Subagent guidance: read these with shell expansion (`source ~/.taos-sim.env`)
+or `grep -E '^TAOS_' ~/.taos-sim.env`. Do not echo the values into transcripts
+or screenshots — when filling the password field, type via Playwright and
+mask the value in any log line.
+
+## Auth flow
+
+1. Drive the browser to `${TAOS_URL}/auth/login`.
+2. Fill the username + password fields, tick "Stay logged in", submit.
+3. The session cookie is set automatically. All subsequent navigation works.
+
+A REST shortcut is available for bulk read operations (no UI clicks):
+
+```bash
+curl -sS -c /tmp/taos-cookies.txt -X POST "${TAOS_URL}/auth/login" \
+  -H "Content-Type: application/json" \
+  -d '{"username":"'"${TAOS_USER}"'","password":"'"${TAOS_PASS}"'","auto_login":true}'
+
+curl -sS -b /tmp/taos-cookies.txt "${TAOS_URL}/api/agents"
+```
+
+Use REST for quick read-back checks (e.g., "did the project really get
+created?"). Use the browser for everything that affects the user
+experience — that's the whole point of the test.
+
+## Reachability
+
+The Pi is on the LAN. If the URL fails to load:
+
+1. Confirm `curl -sS ${TAOS_URL}/api/health` returns `{"status":"ok",…}`.
+2. If unreachable, save a `BLOCKED` status with a precise summary
+   (`pi_unreachable`) and stop. The controller will investigate.
+
+## What lives on the Pi already
+
+The Pi runs in single-user mode for `jay`. There may already be unrelated
+agents from other tests; the user-sim must scope all its work to a fresh
+project named **"Dumby the Dumbo"**. Do not modify or delete agents that
+live outside this project.

--- a/tests/e2e_user_sim/dumby/taos_setup.md
+++ b/tests/e2e_user_sim/dumby/taos_setup.md
@@ -26,11 +26,11 @@ mask the value in any log line.
 A REST shortcut is available for bulk read operations (no UI clicks):
 
 ```bash
-curl -sS -c /tmp/taos-cookies.txt -X POST "${TAOS_URL}/auth/login" \
+curl -sS -c ${RUN_DIR}/.cookies -X POST "${TAOS_URL}/auth/login" \
   -H "Content-Type: application/json" \
   -d '{"username":"'"${TAOS_USER}"'","password":"'"${TAOS_PASS}"'","auto_login":true}'
 
-curl -sS -b /tmp/taos-cookies.txt "${TAOS_URL}/api/agents"
+curl -sS -b ${RUN_DIR}/.cookies "${TAOS_URL}/api/agents"
 ```
 
 Use REST for quick read-back checks (e.g., "did the project really get


### PR DESCRIPTION
## Summary
- Scaffold for a long-running soak test where a Haiku 4.5 subagent acts as a real taOS user
- Five specialist in-taOS agents (writer/editor/illustrator/web/marketing) on `kilo-auto/free` collaborate to produce a kids' book end-to-end
- No code yet — markdown + JSON consumed by a dispatched subagent. Resumable via per-run state file.

## What it exercises end-to-end
Login → project create → 5 framework-distinct agents → per-agent LXC tool install → multi-turn creative loop with handoff → Images app for cover/scenes → web designer writes HTML → marketing strategy + social plan → cross-review pass → final report.

## Architecture
Controller (Claude Code session) dispatches a Haiku subagent with Playwright MCP for ~30 min slices; the subagent persists state to `runs/<ts>/state.json` and reports `{status: DONE | IN_PROGRESS | BLOCKED, blocks[]}`. On `BLOCKED`, controller dispatches a Sonnet fix subagent against the repo, lands the fix, then resumes.

## Test plan
- [ ] CI green on the harness commit (no Python touched)
- [ ] First Haiku run completes phase 1 (login) without hitting a blocker
- [ ] State resume across two sessions reproduces the same project with the same agent IDs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guides for a long-running end-to-end user simulation ("Dumby the Dumbo") covering architecture, phases, roles, setup, state schema, run/resume modes, failure/reporting, and snapshotting/artifact capture guidance.

* **Tests**
  * Added runner instructions and an example run state to exercise full E2E simulation flows, artifact capture, review handoffs, resumable execution, and blocked/fix workflows.

* **Chores**
  * Excluded per-run test artifacts (runs/) from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->