### PR TITLE
fix(a2a): resolve member hex IDs to names in project channels

### DIFF
--- a/tests/projects/test_a2a.py
+++ b/tests/projects/test_a2a.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 import pytest_asyncio
 
@@ -12,6 +14,15 @@ from tinyagentos.projects.a2a import (
     ensure_a2a_channel,
 )
 from tinyagentos.projects.project_store import ProjectStore
+
+
+def _config(*agents):
+    """Build a minimal config-like object with the given agent dicts."""
+    return SimpleNamespace(agents=list(agents))
+
+
+def _agent(name: str, agent_id: str) -> dict:
+    return {"id": agent_id, "name": name, "status": "running"}
 
 
 @pytest_asyncio.fixture
@@ -170,3 +181,189 @@ async def test_ensure_provisions_new_when_only_archived_exists(stores):
     assert (fresh.get("settings") or {}).get("archived") is not True
     archived = await channel_store.get_channel(first["id"])
     assert (archived.get("settings") or {}).get("archived") is True
+
+
+# ---------------------------------------------------------------------------
+# ID → name resolution tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ensure_populates_members_as_names_when_config_provided(stores):
+    """ensure_a2a_channel stores agent names, not hex IDs, in channel members."""
+    project_store, channel_store = stores
+    p = await project_store.create_project(name="P", slug="id-to-name", created_by="u1")
+
+    john_id = "91a640130122"
+    tom_id = "ec4ac43c99c1"
+    config = _config(_agent("john", john_id), _agent("tom", tom_id))
+
+    # project_members stores hex IDs (the real runtime behaviour)
+    await project_store.add_member(p["id"], john_id, member_kind="native")
+    await project_store.add_member(p["id"], tom_id, member_kind="native")
+
+    ch = await ensure_a2a_channel(channel_store, project_store, p["id"], config=config)
+
+    assert sorted(ch["members"]) == ["john", "tom"]
+
+
+@pytest.mark.asyncio
+async def test_ensure_backfill_converts_hex_ids_to_names(stores):
+    """backfill_all with config converts an existing channel whose members are
+    stored as hex IDs into one whose members are stored as names. Member count
+    is preserved; only the identifier form changes."""
+    project_store, channel_store = stores
+    p = await project_store.create_project(name="P", slug="backfill-names", created_by="u1")
+
+    john_id = "aabbcc001122"
+    tom_id = "ddeeff334455"
+
+    # Create channel with hex IDs as members (simulates pre-fix state)
+    await channel_store.create_channel(
+        name=A2A_NAME,
+        type=A2A_TYPE,
+        created_by="u1",
+        members=[john_id, tom_id],
+        settings={"kind": A2A_KIND},
+        project_id=p["id"],
+    )
+    await project_store.add_member(p["id"], john_id, member_kind="native")
+    await project_store.add_member(p["id"], tom_id, member_kind="native")
+
+    config = _config(_agent("john", john_id), _agent("tom", tom_id))
+    await backfill_all(channel_store, project_store, config=config)
+
+    chans = await channel_store.list_channels(project_id=p["id"])
+    a2a = next(c for c in chans if (c.get("settings") or {}).get("kind") == "a2a")
+    assert sorted(a2a["members"]) == ["john", "tom"]
+    assert len(a2a["members"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_ensure_drops_unknown_member_ids_silently(stores):
+    """Members whose IDs don't resolve in config (deleted agents) are dropped
+    without raising an exception."""
+    project_store, channel_store = stores
+    p = await project_store.create_project(name="P", slug="unknown-drop", created_by="u1")
+
+    known_id = "111111111111"
+    ghost_id = "deadbeefcafe"  # not in config
+    config = _config(_agent("alice", known_id))
+
+    await project_store.add_member(p["id"], known_id, member_kind="native")
+    await project_store.add_member(p["id"], ghost_id, member_kind="native")
+
+    ch = await ensure_a2a_channel(channel_store, project_store, p["id"], config=config)
+
+    assert ch["members"] == ["alice"]
+
+
+@pytest.mark.asyncio
+async def test_ensure_diff_computed_in_name_space(stores):
+    """When a project gains a new member, the diff is computed in name-space so
+    there is no spurious add/remove of the hex ID that was previously in the
+    channel."""
+    project_store, channel_store = stores
+    p = await project_store.create_project(name="P", slug="diff-namespace", created_by="u1")
+
+    john_id = "aaaa00000001"
+    don_id = "bbbb00000002"
+    config = _config(_agent("john", john_id), _agent("don", don_id))
+
+    # First call: john only
+    await project_store.add_member(p["id"], john_id, member_kind="native")
+    ch = await ensure_a2a_channel(channel_store, project_store, p["id"], config=config)
+    assert ch["members"] == ["john"]
+
+    # Second call: add don
+    await project_store.add_member(p["id"], don_id, member_kind="native")
+    ch2 = await ensure_a2a_channel(channel_store, project_store, p["id"], config=config)
+    assert sorted(ch2["members"]) == ["don", "john"]
+
+
+@pytest.mark.asyncio
+async def test_ensure_name_collision_both_kept(stores):
+    """Two agents with the same name (possible if config has duplicates) — both
+    resolve to the same string so the set deduplicates to one entry. Documents
+    the expected behaviour: the name appears once in members."""
+    project_store, channel_store = stores
+    p = await project_store.create_project(name="P", slug="collision", created_by="u1")
+
+    id1 = "cccc00000001"
+    id2 = "cccc00000002"
+    # Both agents have name "twin" — unusual config but must not crash
+    config = _config(_agent("twin", id1), _agent("twin", id2))
+
+    await project_store.add_member(p["id"], id1, member_kind="native")
+    await project_store.add_member(p["id"], id2, member_kind="native")
+
+    ch = await ensure_a2a_channel(channel_store, project_store, p["id"], config=config)
+
+    # set deduplication: only one "twin" in members
+    assert ch["members"] == ["twin"]
+
+
+# ---------------------------------------------------------------------------
+# End-to-end mention routing through a2a channel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mention_routes_to_agent_in_a2a_channel():
+    """@<name> in a project a2a channel routes to the matching agent.
+
+    This is the primary regression test for the bug: before the fix, channel
+    members were hex IDs so parse_mentions found no match and the router fell
+    through to quiet mode (no dispatch). With the fix, members are names so
+    the mention resolves and the agent is enqueued.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+    from tinyagentos.agent_chat_router import AgentChatRouter
+    from tinyagentos.chat.group_policy import GroupPolicy
+
+    class _FakeBridge:
+        def __init__(self):
+            self.calls: list[tuple[str, dict]] = []
+        async def enqueue_user_message(self, slug: str, msg: dict) -> None:
+            self.calls.append((slug, msg))
+
+    bridge = _FakeBridge()
+    state = MagicMock()
+    state.config = MagicMock()
+    state.config.agents = [{"name": "john", "id": "91a640130122", "status": "running"}]
+    state.chat_messages = MagicMock()
+    state.chat_messages.send_message = AsyncMock(return_value={
+        "id": "m1", "channel_id": "c1",
+        "author_id": "john", "author_type": "agent",
+        "content": "", "created_at": 1.0,
+    })
+    state.chat_messages.get_messages = AsyncMock(return_value=[])
+    state.chat_channels = MagicMock()
+    state.chat_channels.update_last_message_at = AsyncMock()
+    state.chat_hub = MagicMock()
+    state.chat_hub.broadcast = AsyncMock()
+    state.chat_hub.next_seq = MagicMock(return_value=1)
+    state.bridge_sessions = bridge
+    state.group_policy = GroupPolicy()
+
+    router = AgentChatRouter(state)
+
+    # A2A channel with name-resolved members (post-fix)
+    channel = {
+        "id": "c-a2a",
+        "type": "group",
+        "members": ["user", "john"],  # names, not hex IDs
+        "settings": {"kind": "a2a", "response_mode": "quiet", "max_hops": 3,
+                     "cooldown_seconds": 5, "rate_cap_per_minute": 20, "muted": []},
+    }
+    message = {
+        "id": "m1", "channel_id": "c-a2a", "author_id": "user",
+        "author_type": "user", "content": "@john draft chapter 1",
+        "metadata": {"hops_since_user": 0},
+    }
+    await router._route(message, channel)
+
+    assert len(bridge.calls) == 1
+    slug, enqueued = bridge.calls[0]
+    assert slug == "john"
+    assert enqueued["force_respond"] is True

--- a/tests/projects/test_routes_a2a.py
+++ b/tests/projects/test_routes_a2a.py
@@ -16,6 +16,16 @@ def _a2a(channels: list[dict]) -> dict | None:
     return None
 
 
+async def _test_agent_id(client) -> tuple[str, str]:
+    """Return (agent_id, agent_name) for the test-agent in config."""
+    res = await client.get("/api/agents")
+    assert res.status_code == 200
+    data = res.json()
+    agents = data if isinstance(data, list) else data.get("agents", [])
+    ta = next(a for a in agents if a["name"] == "test-agent")
+    return ta["id"], ta["name"]
+
+
 @pytest.mark.asyncio
 async def test_create_project_creates_a2a_channel(client):
     res = await client.post("/api/projects", json={"name": "P", "slug": "ra2a-1"})
@@ -32,35 +42,38 @@ async def test_create_project_creates_a2a_channel(client):
 
 @pytest.mark.asyncio
 async def test_add_member_adds_to_a2a_channel(client):
+    agent_id, agent_name = await _test_agent_id(client)
     pid = (await client.post("/api/projects", json={"name": "P", "slug": "ra2a-2"})).json()["id"]
 
     res = await client.post(
         f"/api/projects/{pid}/members",
-        json={"mode": "native", "agent_id": "agentA"},
+        json={"mode": "native", "agent_id": agent_id},
     )
     assert res.status_code == 200
 
     channels = await _list_channels(client, pid)
     a2a = _a2a(channels)
     assert a2a is not None
-    assert "agentA" in a2a["members"]
+    # Channel members are agent names (not hex IDs)
+    assert agent_name in a2a["members"]
 
 
 @pytest.mark.asyncio
 async def test_remove_member_removes_from_a2a_channel(client):
+    agent_id, agent_name = await _test_agent_id(client)
     pid = (await client.post("/api/projects", json={"name": "P", "slug": "ra2a-3"})).json()["id"]
     await client.post(
         f"/api/projects/{pid}/members",
-        json={"mode": "native", "agent_id": "agentA"},
+        json={"mode": "native", "agent_id": agent_id},
     )
 
-    res = await client.delete(f"/api/projects/{pid}/members/agentA")
+    res = await client.delete(f"/api/projects/{pid}/members/{agent_id}")
     assert res.status_code == 200
 
     channels = await _list_channels(client, pid)
     a2a = _a2a(channels)
     assert a2a is not None
-    assert "agentA" not in a2a["members"]
+    assert agent_name not in a2a["members"]
 
 
 @pytest.mark.asyncio

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -624,7 +624,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
 
         try:
             from tinyagentos.projects.a2a import backfill_all as _a2a_backfill_all
-            _n = await _a2a_backfill_all(chat_channels, project_store)
+            _n = await _a2a_backfill_all(chat_channels, project_store, config=config)
             logger.info("a2a backfill: ensured channels for %d active projects", _n)
         except Exception:
             logger.exception("a2a backfill failed")

--- a/tinyagentos/projects/a2a.py
+++ b/tinyagentos/projects/a2a.py
@@ -51,16 +51,70 @@ async def _find_a2a_channels(channel_store, project_id: str) -> list[dict]:
     ]
 
 
-async def ensure_a2a_channel(channel_store, project_store, project_id: str) -> dict:
+def _resolve_member_names(member_rows: list[dict], config) -> set[str]:
+    """Convert project_members rows to agent names for channel membership.
+
+    project_members.member_id stores an agent's hex id (e.g. "91a640130122")
+    for native members, or a clone slug like "<source_id>-<project_slug>" for
+    clones. Both need resolving to a name before being stored in the channel's
+    members list, which the @mention parser and router expect.
+
+    Resolution strategy:
+    - Build a lookup: id -> agent, name -> agent from config.agents.
+    - For each member_id, try id match first then name match (handles the case
+      where names are already stored for older rows that used names as member_id).
+    - Members with no match in config (deleted agents) are dropped with a debug log.
+
+    If config is None (test path), member_id is returned as-is so that tests
+    that already store names in project_members continue to work unmodified.
+    """
+    if config is None:
+        return {m["member_id"] for m in member_rows}
+
+    agents = getattr(config, "agents", None) or []
+    by_id: dict[str, dict] = {}
+    by_name: dict[str, dict] = {}
+    for agent in agents:
+        aid = agent.get("id")
+        name = agent.get("name")
+        if aid:
+            by_id[aid] = agent
+        if name:
+            by_name[name] = agent
+
+    resolved: set[str] = set()
+    for m in member_rows:
+        mid = m["member_id"]
+        agent = by_id.get(mid) or by_name.get(mid)
+        if agent is None:
+            logger.debug(
+                "a2a: member_id %r not found in config agents — skipping", mid
+            )
+            continue
+        name = agent.get("name")
+        if name:
+            resolved.add(name)
+    return resolved
+
+
+async def ensure_a2a_channel(
+    channel_store, project_store, project_id: str, *, config=None
+) -> dict:
     """Create the A2A channel for project_id if missing, sync its members
     to the project's current native+clone members, return the channel row.
+
+    config: the app's AppConfig (or any object with a .agents list of dicts
+    with "id" and "name" keys). When provided, project member IDs are resolved
+    to agent names before being stored in the channel — the @mention parser and
+    router both operate on names. When None (test path with name-keyed members),
+    member_ids are used as-is.
 
     Idempotent. Serialized per project_id via _A2A_LOCKS to prevent racing
     member-sync diffs when multiple callers fire concurrently.
     """
     async with _A2A_LOCKS[project_id]:
         project_members = await project_store.list_members(project_id)
-        expected = {m["member_id"] for m in project_members}
+        expected = _resolve_member_names(project_members, config)
 
         matches = await _find_a2a_channels(channel_store, project_id)
         if not matches:
@@ -100,7 +154,7 @@ async def ensure_a2a_channel(channel_store, project_store, project_id: str) -> d
         return await channel_store.get_channel(existing["id"])
 
 
-async def backfill_all(channel_store, project_store) -> int:
+async def backfill_all(channel_store, project_store, *, config=None) -> int:
     """Call ensure_a2a_channel for every active project. Returns count synced.
 
     Per-project failures are logged and do not stop the loop.
@@ -109,7 +163,9 @@ async def backfill_all(channel_store, project_store) -> int:
     count = 0
     for p in projects:
         try:
-            await ensure_a2a_channel(channel_store, project_store, p["id"])
+            await ensure_a2a_channel(
+                channel_store, project_store, p["id"], config=config
+            )
             count += 1
         except Exception:
             logger.exception("a2a backfill failed for project %s", p.get("id"))

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -94,6 +94,7 @@ async def create_project(payload: CreateProjectIn, request: Request):
             request.app.state.chat_channels,
             request.app.state.project_store,
             p["id"],
+            config=getattr(request.app.state, "config", None),
         )
     except Exception:
         logger.warning("a2a ensure failed for new project %s", p.get("id"), exc_info=True)
@@ -228,6 +229,7 @@ async def add_member(project_id: str, payload: AddMemberIn, request: Request):
             request.app.state.chat_channels,
             request.app.state.project_store,
             project_id,
+            config=getattr(request.app.state, "config", None),
         )
     except Exception:
         logger.warning("a2a ensure failed for project %s on add_member", project_id, exc_info=True)
@@ -255,6 +257,7 @@ async def remove_member(project_id: str, member_id: str, request: Request):
             request.app.state.chat_channels,
             request.app.state.project_store,
             project_id,
+            config=getattr(request.app.state, "config", None),
         )
     except Exception:
         logger.warning("a2a ensure failed for project %s on remove_member", project_id, exc_info=True)


### PR DESCRIPTION
## Summary

- Project a2a channels stored hex agent IDs (e.g. `91a640130122`) in their `members` list, but `parse_mentions` and `agent_chat_router` both work with agent names. Any `@john` mention in project chat found zero channel-member matches, fell through to `quiet` mode, and was silently dropped — no agent ever saw it.
- Root cause: `ensure_a2a_channel` took `member_id` straight from `project_members` rows without resolving to names. DM channels were unaffected because they always stored names.
- Fix is at the source: `ensure_a2a_channel` now accepts an optional `config` kwarg and calls `_resolve_member_names` to map each `member_id` (hex id or backwards-compat name) to the agent's name before storing in the channel. Members with no config match (deleted agents) are silently dropped with a debug log.
- The startup `backfill_all` now passes `config=config`, so all existing project channels are repaired on next boot without any migration script.
- `routes/projects.py` passes `config=getattr(request.app.state, "config", None)` at all three `ensure_a2a_channel` call sites.
- No changes to `mentions.py` or `agent_chat_router.py` — the routing layer is correct once members are names.

## Test plan

- `pytest -xvs tests/projects/test_a2a.py` — 15 tests (9 pre-existing + 6 new):
  - `test_ensure_populates_members_as_names_when_config_provided` — core regression: hex IDs → names on create
  - `test_ensure_backfill_converts_hex_ids_to_names` — existing channel with hex IDs is repaired by backfill
  - `test_ensure_drops_unknown_member_ids_silently` — deleted agent member doesn't crash
  - `test_ensure_diff_computed_in_name_space` — incremental member adds stay in name-space
  - `test_ensure_name_collision_both_kept` — two agents sharing a name collapse to one entry (documented behaviour)
  - `test_mention_routes_to_agent_in_a2a_channel` — end-to-end: `@john` in a project channel with name-resolved members enqueues to john's bridge
- `pytest tests/projects/test_routes_a2a.py` — 5 integration tests updated to look up real agent hex ID via `/api/agents` before posting as `agent_id`, verifying channel members resolve to names
- All existing tests pass (conftest unchanged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * A2A channel members now resolve to configured agent names for improved identification
  * Agent mentions now properly route to matching agents in A2A channels
  * Automatic migration of existing channels to name-based member identification during startup

* **Tests**
  * Added comprehensive test coverage for A2A channel member resolution and end-to-end mention routing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->