### PR TITLE
fix(update): clean dirty bundle state before pull

### DIFF
--- a/bin/update.sh
+++ b/bin/update.sh
@@ -7,6 +7,15 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
+# The systemd ExecStartPre rebuild produces new content-hashed bundle files
+# in static/desktop/assets/ and modifies desktop/tsconfig.tsbuildinfo, leaving
+# the working tree dirty after every restart. git pull --ff-only refuses to
+# overwrite that, so the user can never update. Wipe build outputs first;
+# they're regenerated below if needed and otherwise come down with the pull.
+echo "==> Resetting build outputs before pull..."
+git checkout -- desktop/tsconfig.tsbuildinfo static/desktop 2>/dev/null || true
+git clean -fd static/desktop/assets 2>/dev/null || true
+
 echo "==> Pulling latest..."
 git pull --ff-only
 

--- a/tinyagentos/routes/settings.py
+++ b/tinyagentos/routes/settings.py
@@ -542,6 +542,25 @@ async def apply_update(request: Request):
     from tinyagentos.restart_orchestrator import write_pending_restart
     project_dir = Path(__file__).parent.parent.parent
 
+    # systemd ExecStartPre rebuilds produce new content-hashed files in
+    # static/desktop/assets/ and modify desktop/tsconfig.tsbuildinfo on each
+    # restart, leaving the tree dirty. git pull --ff-only then refuses to
+    # overwrite the locals and the Install Update button always 500s. Wipe
+    # build outputs first — git pull restores them or the rebuild below
+    # regenerates them.
+    reset_proc = await asyncio.create_subprocess_exec(
+        "git", "checkout", "--", "desktop/tsconfig.tsbuildinfo", "static/desktop",
+        stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL,
+        cwd=str(project_dir),
+    )
+    await reset_proc.communicate()
+    clean_proc = await asyncio.create_subprocess_exec(
+        "git", "clean", "-fd", "static/desktop/assets",
+        stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL,
+        cwd=str(project_dir),
+    )
+    await clean_proc.communicate()
+
     # Git pull
     proc = await asyncio.create_subprocess_exec(
         "git", "pull", "--ff-only", "origin", "master",


### PR DESCRIPTION
## Summary
- Both \`bin/update.sh\` and \`POST /api/settings/update\` reliably fail on the Pi after the first restart because the systemd \`ExecStartPre\` rebuild leaves the tree dirty (new content-hashed files in \`static/desktop/assets/\`, modified \`desktop/tsconfig.tsbuildinfo\`). \`git pull --ff-only\` refuses to overwrite the locals.
- Reset + git-clean build outputs before the pull. Scoped to \`desktop/tsconfig.tsbuildinfo\` and \`static/desktop\` so user code edits elsewhere are untouched. Idempotent on a clean tree.

## Repro on Pi
1. Service running with bundle rebuilt by ExecStartPre (default state)
2. Click Settings → Install Update
3. 500: \`error: Your local changes to the following files would be overwritten by merge: desktop/tsconfig.tsbuildinfo, static/desktop/chat.html, static/desktop/index.html\`

## Test plan
- [x] Lint clean
- [x] Pi: manual repro confirmed before fix
- [ ] Pi: with this fix landed + bundle rebuilt by ExecStartPre, Settings → Install Update completes successfully (verify after merge)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update process reliability by ensuring build artifacts are cleaned up before applying updates, preventing update failures due to dirty working directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->