### PR TITLE
feat(projects): lead agent — bypass quiet filter for coordinators

### DIFF
--- a/desktop/src/apps/ProjectsApp/ProjectMembers.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectMembers.tsx
@@ -92,6 +92,14 @@ export function ProjectMembers({ project, onChanged }: { project: Project; onCha
                 <div className="truncate text-sm flex items-center gap-1" title={hint || m.member_id}>
                   {emoji && <span aria-hidden>{emoji}</span>}
                   <span>{label}</span>
+                  {!!m.is_lead && (
+                    <span
+                      className="ml-1 text-xs text-yellow-400 font-medium"
+                      aria-label="Lead agent"
+                    >
+                      ★ Lead
+                    </span>
+                  )}
                 </div>
                 <div className="text-xs text-zinc-500">
                   {m.member_kind}
@@ -114,6 +122,24 @@ export function ProjectMembers({ project, onChanged }: { project: Project; onCha
                       }}
                     />
                     <span className="text-xs">Can edit canvas</span>
+                  </label>
+                )}
+                {(m.member_kind === "native" || m.member_kind === "clone") && (
+                  <label
+                    style={{ display: "inline-flex", alignItems: "center", gap: 6 }}
+                    title="Lead agents see all messages in the project channel, even without being @mentioned."
+                  >
+                    <input
+                      type="checkbox"
+                      checked={!!m.is_lead}
+                      aria-label={`Toggle lead for ${label}`}
+                      onChange={async (e) => {
+                        await projectsApi.members.setLead(project.id, m.member_id, e.target.checked);
+                        refresh();
+                        onChanged();
+                      }}
+                    />
+                    <span className="text-xs">Lead</span>
                   </label>
                 )}
                 <button

--- a/desktop/src/lib/projects.ts
+++ b/desktop/src/lib/projects.ts
@@ -18,6 +18,7 @@ export type ProjectMember = {
   memory_seed: "none" | "snapshot" | "empty";
   added_at: number;
   can_edit_canvas?: boolean;
+  is_lead?: number;
 };
 
 export type ProjectTask = {
@@ -115,6 +116,11 @@ export const projectsApi = {
       }),
     remove: (pid: string, member_id: string) =>
       http<{ ok: boolean }>(`/api/projects/${pid}/members/${member_id}`, { method: "DELETE" }),
+    setLead: (pid: string, member_id: string, is_lead: boolean) =>
+      http<{ ok: boolean; is_lead: boolean }>(
+        `/api/projects/${pid}/members/${member_id}/lead`,
+        { method: "PATCH", body: JSON.stringify({ is_lead }) },
+      ),
   },
 
   tasks: {

--- a/tests/projects/test_a2a.py
+++ b/tests/projects/test_a2a.py
@@ -367,3 +367,109 @@ async def test_mention_routes_to_agent_in_a2a_channel():
     slug, enqueued = bridge.calls[0]
     assert slug == "john"
     assert enqueued["force_respond"] is True
+
+
+# ---------------------------------------------------------------------------
+# Lead agent — ensure_a2a_channel syncs settings.leads
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ensure_populates_leads_from_is_lead_flag(stores):
+    """When a member has is_lead=1, their name appears in settings.leads."""
+    project_store, channel_store = stores
+    p = await project_store.create_project(name="P", slug="lead-basic", created_by="u1")
+
+    coord_id = "aaaa11111111"
+    worker_id = "bbbb22222222"
+    config = _config(_agent("coord", coord_id), _agent("worker", worker_id))
+
+    await project_store.add_member(p["id"], coord_id, member_kind="native")
+    await project_store.add_member(p["id"], worker_id, member_kind="native")
+    await project_store.set_member_lead(p["id"], coord_id, True)
+
+    ch = await ensure_a2a_channel(channel_store, project_store, p["id"], config=config)
+
+    assert ch["settings"]["leads"] == ["coord"]
+    assert sorted(ch["members"]) == ["coord", "worker"]
+
+
+@pytest.mark.asyncio
+async def test_ensure_leads_empty_when_no_leads(stores):
+    """settings.leads is an empty list when no member is marked as lead."""
+    project_store, channel_store = stores
+    p = await project_store.create_project(name="P", slug="no-leads", created_by="u1")
+
+    agent_id = "cccc33333333"
+    config = _config(_agent("alice", agent_id))
+    await project_store.add_member(p["id"], agent_id, member_kind="native")
+
+    ch = await ensure_a2a_channel(channel_store, project_store, p["id"], config=config)
+
+    assert ch["settings"]["leads"] == []
+
+
+@pytest.mark.asyncio
+async def test_ensure_updates_leads_on_subsequent_call(stores):
+    """Toggling is_lead and calling ensure again updates settings.leads."""
+    project_store, channel_store = stores
+    p = await project_store.create_project(name="P", slug="lead-update", created_by="u1")
+
+    coord_id = "dddd44444444"
+    config = _config(_agent("coord", coord_id))
+    await project_store.add_member(p["id"], coord_id, member_kind="native")
+
+    ch1 = await ensure_a2a_channel(channel_store, project_store, p["id"], config=config)
+    assert ch1["settings"]["leads"] == []
+
+    await project_store.set_member_lead(p["id"], coord_id, True)
+    ch2 = await ensure_a2a_channel(channel_store, project_store, p["id"], config=config)
+    assert ch2["settings"]["leads"] == ["coord"]
+
+    await project_store.set_member_lead(p["id"], coord_id, False)
+    ch3 = await ensure_a2a_channel(channel_store, project_store, p["id"], config=config)
+    assert ch3["settings"]["leads"] == []
+
+
+@pytest.mark.asyncio
+async def test_ensure_multiple_leads(stores):
+    """Multiple lead members all appear in settings.leads, sorted."""
+    project_store, channel_store = stores
+    p = await project_store.create_project(name="P", slug="multi-lead", created_by="u1")
+
+    alpha_id = "eeee55555555"
+    beta_id = "ffff66666666"
+    config = _config(_agent("alpha", alpha_id), _agent("beta", beta_id))
+
+    await project_store.add_member(p["id"], alpha_id, member_kind="native")
+    await project_store.add_member(p["id"], beta_id, member_kind="native")
+    await project_store.set_member_lead(p["id"], alpha_id, True)
+    await project_store.set_member_lead(p["id"], beta_id, True)
+
+    ch = await ensure_a2a_channel(channel_store, project_store, p["id"], config=config)
+
+    assert ch["settings"]["leads"] == ["alpha", "beta"]
+
+
+@pytest.mark.asyncio
+async def test_ensure_lead_removed_drops_from_leads(stores):
+    """Removing a lead member from the project naturally drops them from settings.leads."""
+    project_store, channel_store = stores
+    p = await project_store.create_project(name="P", slug="lead-drop", created_by="u1")
+
+    coord_id = "gggg77777777"
+    worker_id = "hhhh88888888"
+    config = _config(_agent("coord", coord_id), _agent("worker", worker_id))
+
+    await project_store.add_member(p["id"], coord_id, member_kind="native")
+    await project_store.add_member(p["id"], worker_id, member_kind="native")
+    await project_store.set_member_lead(p["id"], coord_id, True)
+
+    ch1 = await ensure_a2a_channel(channel_store, project_store, p["id"], config=config)
+    assert ch1["settings"]["leads"] == ["coord"]
+
+    # Remove the lead from the project
+    await project_store.remove_member(p["id"], coord_id)
+    ch2 = await ensure_a2a_channel(channel_store, project_store, p["id"], config=config)
+    assert ch2["settings"]["leads"] == []
+    assert ch2["members"] == ["worker"]

--- a/tests/projects/test_routes_a2a.py
+++ b/tests/projects/test_routes_a2a.py
@@ -107,3 +107,62 @@ async def test_project_delete_archives_a2a_channel(client):
     )
     archived = archived_res.json().get("channels", [])
     assert _a2a(archived) is not None
+
+
+# ---------------------------------------------------------------------------
+# Lead endpoint — PATCH /api/projects/{pid}/members/{mid}/lead
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_lead_updates_channel_settings(client):
+    """PATCHing the lead flag resynchronises settings.leads in the A2A channel."""
+    agent_id, agent_name = await _test_agent_id(client)
+    pid = (await client.post("/api/projects", json={"name": "P", "slug": "ra2a-lead1"})).json()["id"]
+    await client.post(f"/api/projects/{pid}/members", json={"mode": "native", "agent_id": agent_id})
+
+    # Verify leads starts empty
+    a2a_before = _a2a(await _list_channels(client, pid))
+    assert a2a_before is not None
+    assert a2a_before["settings"].get("leads") == []
+
+    # Promote to lead
+    res = await client.patch(
+        f"/api/projects/{pid}/members/{agent_id}/lead",
+        json={"is_lead": True},
+    )
+    assert res.status_code == 200
+    assert res.json()["is_lead"] is True
+
+    a2a_after = _a2a(await _list_channels(client, pid))
+    assert a2a_after is not None
+    assert agent_name in (a2a_after["settings"].get("leads") or [])
+
+
+@pytest.mark.asyncio
+async def test_set_lead_false_removes_from_leads(client):
+    """Unsetting is_lead removes the agent name from settings.leads."""
+    agent_id, agent_name = await _test_agent_id(client)
+    pid = (await client.post("/api/projects", json={"name": "P", "slug": "ra2a-lead2"})).json()["id"]
+    await client.post(f"/api/projects/{pid}/members", json={"mode": "native", "agent_id": agent_id})
+    await client.patch(f"/api/projects/{pid}/members/{agent_id}/lead", json={"is_lead": True})
+
+    res = await client.patch(
+        f"/api/projects/{pid}/members/{agent_id}/lead",
+        json={"is_lead": False},
+    )
+    assert res.status_code == 200
+
+    a2a = _a2a(await _list_channels(client, pid))
+    assert a2a is not None
+    assert agent_name not in (a2a["settings"].get("leads") or [])
+
+
+@pytest.mark.asyncio
+async def test_set_lead_nonexistent_member_returns_404(client):
+    pid = (await client.post("/api/projects", json={"name": "P", "slug": "ra2a-lead3"})).json()["id"]
+    res = await client.patch(
+        f"/api/projects/{pid}/members/nonexistent-id/lead",
+        json={"is_lead": True},
+    )
+    assert res.status_code == 404

--- a/tests/test_agent_chat_router.py
+++ b/tests/test_agent_chat_router.py
@@ -389,3 +389,136 @@ async def test_router_thread_policy_key_is_scoped():
     await router._route(msg2, _channel(["user", "tom"], "lively"))
     # Expect 2 bridge calls total (one per message), since policy keys are independent.
     assert len(bridge.calls) == 2
+
+
+# ---------------------------------------------------------------------------
+# Lead agent routing
+# ---------------------------------------------------------------------------
+
+def _channel_with_leads(members, leads, mode="quiet", muted=None, ctype="group"):
+    return {
+        "id": "c1",
+        "type": ctype,
+        "members": members,
+        "settings": {
+            "response_mode": mode,
+            "leads": leads,
+            "max_hops": 3,
+            "cooldown_seconds": 5,
+            "rate_cap_per_minute": 20,
+            "muted": muted or [],
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_lead_receives_quiet_message_not_mentioning_them():
+    """A lead agent receives messages in quiet mode even without an @mention."""
+    bridge = _FakeBridge()
+    state = _state_for({"name": "coord", "status": "running"}, bridge=bridge)
+    state.config.agents = [
+        {"name": "coord", "status": "running"},
+        {"name": "worker", "status": "running"},
+    ]
+    from tinyagentos.chat.group_policy import GroupPolicy
+    state.group_policy = GroupPolicy()
+    router = AgentChatRouter(state)
+
+    msg = {"id": "m1", "author_id": "user", "author_type": "user",
+           "content": "just an update", "metadata": {"hops_since_user": 0}}
+    ch = _channel_with_leads(["user", "coord", "worker"], leads=["coord"], mode="quiet")
+    await router._route(msg, ch)
+
+    slugs = [c[0] for c in bridge.calls]
+    assert "coord" in slugs
+    assert "worker" not in slugs
+
+
+@pytest.mark.asyncio
+async def test_non_lead_skipped_in_quiet_with_no_mention():
+    """Non-lead agents are still silent in quiet mode when not mentioned."""
+    bridge = _FakeBridge()
+    state = _state_for({"name": "coord", "status": "running"}, bridge=bridge)
+    state.config.agents = [
+        {"name": "coord", "status": "running"},
+        {"name": "worker", "status": "running"},
+    ]
+    from tinyagentos.chat.group_policy import GroupPolicy
+    state.group_policy = GroupPolicy()
+    router = AgentChatRouter(state)
+
+    msg = {"id": "m1", "author_id": "user", "author_type": "user",
+           "content": "just an update", "metadata": {"hops_since_user": 0}}
+    ch = _channel_with_leads(["user", "coord", "worker"], leads=["coord"], mode="quiet")
+    await router._route(msg, ch)
+
+    slugs = [c[0] for c in bridge.calls]
+    assert "worker" not in slugs
+
+
+@pytest.mark.asyncio
+async def test_multiple_leads_both_receive():
+    """All leads receive a quiet message not mentioning either of them."""
+    bridge = _FakeBridge()
+    state = _state_for({"name": "alpha", "status": "running"}, bridge=bridge)
+    state.config.agents = [
+        {"name": "alpha", "status": "running"},
+        {"name": "beta", "status": "running"},
+        {"name": "worker", "status": "running"},
+    ]
+    from tinyagentos.chat.group_policy import GroupPolicy
+    state.group_policy = GroupPolicy()
+    router = AgentChatRouter(state)
+
+    msg = {"id": "m1", "author_id": "user", "author_type": "user",
+           "content": "status update", "metadata": {"hops_since_user": 0}}
+    ch = _channel_with_leads(["user", "alpha", "beta", "worker"],
+                              leads=["alpha", "beta"], mode="quiet")
+    await router._route(msg, ch)
+
+    slugs = sorted(c[0] for c in bridge.calls)
+    assert slugs == ["alpha", "beta"]
+
+
+@pytest.mark.asyncio
+async def test_lead_not_double_added_when_mentioned():
+    """Lead @mentioned explicitly: they appear exactly once in recipients."""
+    bridge = _FakeBridge()
+    state = _state_for({"name": "coord", "status": "running"}, bridge=bridge)
+    state.config.agents = [
+        {"name": "coord", "status": "running"},
+        {"name": "worker", "status": "running"},
+    ]
+    from tinyagentos.chat.group_policy import GroupPolicy
+    state.group_policy = GroupPolicy()
+    router = AgentChatRouter(state)
+
+    msg = {"id": "m1", "author_id": "user", "author_type": "user",
+           "content": "@coord check this", "metadata": {"hops_since_user": 0}}
+    ch = _channel_with_leads(["user", "coord", "worker"], leads=["coord"], mode="quiet")
+    await router._route(msg, ch)
+
+    slugs = [c[0] for c in bridge.calls]
+    assert slugs.count("coord") == 1
+
+
+@pytest.mark.asyncio
+async def test_lead_who_is_author_does_not_receive_own_message():
+    """A lead who authored the message does not receive it."""
+    bridge = _FakeBridge()
+    state = _state_for({"name": "coord", "status": "running"}, bridge=bridge)
+    state.config.agents = [
+        {"name": "coord", "status": "running"},
+        {"name": "worker", "status": "running"},
+    ]
+    from tinyagentos.chat.group_policy import GroupPolicy
+    state.group_policy = GroupPolicy()
+    router = AgentChatRouter(state)
+
+    msg = {"id": "m1", "author_id": "coord", "author_type": "agent",
+           "content": "progress report", "metadata": {"hops_since_user": 1}}
+    ch = _channel_with_leads(["user", "coord", "worker"], leads=["coord"], mode="quiet")
+    await router._route(msg, ch)
+
+    slugs = [c[0] for c in bridge.calls]
+    assert "coord" not in slugs

--- a/tinyagentos/agent_chat_router.py
+++ b/tinyagentos/agent_chat_router.py
@@ -72,6 +72,14 @@ class AgentChatRouter:
             if not candidates:
                 return
 
+            # Leads bypass the quiet filter: they see every message in the
+            # channel except their own. They are always added to recipients
+            # after the normal routing decision, de-duplicating if already present.
+            leads = [
+                m for m in (settings.get("leads") or [])
+                if m and m != author and m not in muted
+            ]
+
             force_by_slug: dict[str, bool] = {}
             if mentions.all:
                 for m in candidates:
@@ -89,6 +97,12 @@ class AgentChatRouter:
                 recipients = []
             else:
                 recipients = list(candidates)
+
+            # Always loop leads in regardless of mode/mentions (except author
+            # already excluded above, and muted already excluded from leads).
+            for lead in leads:
+                if lead not in recipients:
+                    recipients.append(lead)
 
             if not recipients:
                 return

--- a/tinyagentos/projects/a2a.py
+++ b/tinyagentos/projects/a2a.py
@@ -51,6 +51,23 @@ async def _find_a2a_channels(channel_store, project_id: str) -> list[dict]:
     ]
 
 
+def _build_agent_lookups(config):
+    """Return (by_id, by_name) dicts from config.agents, or (None, None) when config is None."""
+    if config is None:
+        return None, None
+    agents = getattr(config, "agents", None) or []
+    by_id: dict[str, dict] = {}
+    by_name: dict[str, dict] = {}
+    for agent in agents:
+        aid = agent.get("id")
+        name = agent.get("name")
+        if aid:
+            by_id[aid] = agent
+        if name:
+            by_name[name] = agent
+    return by_id, by_name
+
+
 def _resolve_member_names(member_rows: list[dict], config) -> set[str]:
     """Convert project_members rows to agent names for channel membership.
 
@@ -68,19 +85,9 @@ def _resolve_member_names(member_rows: list[dict], config) -> set[str]:
     If config is None (test path), member_id is returned as-is so that tests
     that already store names in project_members continue to work unmodified.
     """
-    if config is None:
+    by_id, by_name = _build_agent_lookups(config)
+    if by_id is None:
         return {m["member_id"] for m in member_rows}
-
-    agents = getattr(config, "agents", None) or []
-    by_id: dict[str, dict] = {}
-    by_name: dict[str, dict] = {}
-    for agent in agents:
-        aid = agent.get("id")
-        name = agent.get("name")
-        if aid:
-            by_id[aid] = agent
-        if name:
-            by_name[name] = agent
 
     resolved: set[str] = set()
     for m in member_rows:
@@ -97,6 +104,33 @@ def _resolve_member_names(member_rows: list[dict], config) -> set[str]:
     return resolved
 
 
+def _resolve_lead_names(member_rows: list[dict], config) -> list[str]:
+    """Return sorted list of resolved agent names for members where is_lead = 1.
+
+    Uses the same config-lookup strategy as _resolve_member_names. Returns
+    names in sorted order for deterministic storage.
+    """
+    leads = [m for m in member_rows if m.get("is_lead")]
+    if not leads:
+        return []
+    by_id, by_name = _build_agent_lookups(config)
+    result: list[str] = []
+    for m in leads:
+        mid = m["member_id"]
+        if by_id is None:
+            # No config (test path): use member_id as name directly.
+            result.append(mid)
+            continue
+        agent = by_id.get(mid) or by_name.get(mid)
+        if agent is None:
+            logger.debug("a2a: lead member_id %r not found in config — skipping", mid)
+            continue
+        name = agent.get("name")
+        if name:
+            result.append(name)
+    return sorted(set(result))
+
+
 async def ensure_a2a_channel(
     channel_store, project_store, project_id: str, *, config=None
 ) -> dict:
@@ -109,12 +143,17 @@ async def ensure_a2a_channel(
     router both operate on names. When None (test path with name-keyed members),
     member_ids are used as-is.
 
+    Also syncs settings.leads from project members where is_lead = 1 so that
+    the router can give leads visibility into all channel messages regardless
+    of response_mode.
+
     Idempotent. Serialized per project_id via _A2A_LOCKS to prevent racing
     member-sync diffs when multiple callers fire concurrently.
     """
     async with _A2A_LOCKS[project_id]:
         project_members = await project_store.list_members(project_id)
         expected = _resolve_member_names(project_members, config)
+        expected_leads = _resolve_lead_names(project_members, config)
 
         matches = await _find_a2a_channels(channel_store, project_id)
         if not matches:
@@ -126,7 +165,7 @@ async def ensure_a2a_channel(
                 created_by=created_by,
                 members=sorted(expected),
                 description="Agent coordination channel.",
-                settings={"kind": A2A_KIND},
+                settings={"kind": A2A_KIND, "leads": expected_leads},
                 project_id=project_id,
             )
 
@@ -141,16 +180,26 @@ async def ensure_a2a_channel(
             )
             await channel_store.set_settings(dup["id"], {"archived": True})
 
+        # Sync members.
         current = set(existing.get("members") or [])
-        if current == expected:
-            return existing
-
         to_add = expected - current
         to_remove = current - expected
         for slug in sorted(to_add):
             await channel_store.add_member(existing["id"], slug)
         for slug in sorted(to_remove):
             await channel_store.remove_member(existing["id"], slug)
+
+        # Sync settings.leads — always write so the field stays current even if
+        # the member set didn't change (e.g. is_lead toggled without add/remove).
+        current_settings = dict(existing.get("settings") or {})
+        leads_changed = current_settings.get("leads") != expected_leads
+        if leads_changed:
+            current_settings["leads"] = expected_leads
+            await channel_store.set_settings(existing["id"], current_settings)
+
+        if not to_add and not to_remove and not leads_changed:
+            return existing
+
         return await channel_store.get_channel(existing["id"])
 
 

--- a/tinyagentos/projects/project_store.py
+++ b/tinyagentos/projects/project_store.py
@@ -31,6 +31,7 @@ CREATE TABLE IF NOT EXISTS project_members (
     source_agent_id TEXT,
     memory_seed TEXT NOT NULL DEFAULT 'none',
     can_edit_canvas INTEGER NOT NULL DEFAULT 0,
+    is_lead INTEGER NOT NULL DEFAULT 0,
     added_at REAL NOT NULL,
     PRIMARY KEY (project_id, member_id)
 );
@@ -63,14 +64,26 @@ class ProjectStore(BaseStore):
     SCHEMA = PROJECTS_SCHEMA
 
     async def _post_init(self) -> None:
-        try:
-            await self._db.execute(
-                "ALTER TABLE project_members ADD COLUMN can_edit_canvas INTEGER NOT NULL DEFAULT 0"
-            )
-            await self._db.commit()
-        except Exception:
-            # Column already exists on fresh installs (created by SCHEMA).
-            pass
+        for col_def in (
+            "ALTER TABLE project_members ADD COLUMN can_edit_canvas INTEGER NOT NULL DEFAULT 0",
+            "ALTER TABLE project_members ADD COLUMN is_lead INTEGER NOT NULL DEFAULT 0",
+        ):
+            try:
+                await self._db.execute(col_def)
+                await self._db.commit()
+            except Exception:
+                # Column already exists on fresh installs (created by SCHEMA).
+                pass
+
+    async def set_member_lead(self, project_id: str, member_id: str, is_lead: bool) -> None:
+        val = 1 if is_lead else 0
+        cur = await self._db.execute(
+            "UPDATE project_members SET is_lead = ? WHERE project_id = ? AND member_id = ?",
+            (val, project_id, member_id),
+        )
+        await self._db.commit()
+        if cur.rowcount == 0:
+            raise KeyError(f"member {member_id!r} not in project {project_id!r}")
 
     async def create_project(
         self,

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -242,6 +242,30 @@ async def list_members(project_id: str, request: Request):
     return {"items": await store.list_members(project_id)}
 
 
+class LeadIn(BaseModel):
+    is_lead: bool
+
+
+@router.patch("/api/projects/{project_id}/members/{member_id}/lead")
+async def set_lead(project_id: str, member_id: str, body: LeadIn, request: Request):
+    store = request.app.state.project_store
+    try:
+        await store.set_member_lead(project_id, member_id, body.is_lead)
+    except KeyError as e:
+        return JSONResponse({"error": str(e)}, status_code=404)
+    try:
+        from tinyagentos.projects.a2a import ensure_a2a_channel
+        await ensure_a2a_channel(
+            request.app.state.chat_channels,
+            store,
+            project_id,
+            config=getattr(request.app.state, "config", None),
+        )
+    except Exception:
+        logger.warning("a2a ensure failed for project %s on set_lead", project_id, exc_info=True)
+    return {"ok": True, "is_lead": body.is_lead}
+
+
 @router.delete("/api/projects/{project_id}/members/{member_id}")
 async def remove_member(project_id: str, member_id: str, request: Request):
     store = request.app.state.project_store


### PR DESCRIPTION
## Summary

- Adds `is_lead` flag to `project_members` (schema + ALTER TABLE migration)
- `ensure_a2a_channel` now writes `settings.leads` — a sorted list of resolved names for members with `is_lead = 1` — and keeps it in sync on every reconcile call
- `AgentChatRouter` appends leads to recipients after normal routing, so leads see every message in the project's A2A channel regardless of `response_mode`, except their own
- `PATCH /api/projects/{pid}/members/{mid}/lead` sets the flag and resyncs the channel immediately
- Frontend: `ProjectMember` type gains `is_lead`; `projectsApi.members.setLead` helper; Lead checkbox + ★ Lead badge in `ProjectMembers` UI

## Motivation

Coordinator workflows were stalling: a coordinator briefs the team, a teammate replies without @-tagging anyone, nobody sees the reply. The quiet default is appropriate for non-leads but coordinators need visibility into all traffic.

## Test Plan

- [ ] `tests/projects/test_a2a.py` — 5 new tests: leads populated on create, empty when none, updated on toggle, multiple leads, dropped when member removed
- [ ] `tests/test_agent_chat_router.py` — 5 new tests: lead receives quiet msg not mentioning them; non-lead still silent; multiple leads both receive; lead not double-added when @mentioned; lead-author excluded from recipients
- [ ] `tests/projects/test_routes_a2a.py` — 3 new integration tests: PATCH sets leads in channel, PATCH false removes, 404 on unknown member
- [ ] `npm run build` passes (verified)
- [ ] `npm test` — 250/250 tests pass (verified)
- [ ] `pytest tests/projects/test_a2a.py tests/projects/test_routes_a2a.py tests/test_agent_chat_router.py` — all pass (verified)
- [ ] Full suite: 261 pass, 1 pre-existing environment error (disk full on test host, unrelated)

## Edge cases covered

- Multiple leads: both receive (tested)
- Lead @mentioned: not double-added (tested)
- Lead removed from project: auto-dropped from `settings.leads` on next reconcile (tested)
- Lead is message author: excluded (tested)
- No leads: `settings.leads = []` (tested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added the ability to designate project members as leads with visual indicators in the member list.
  * Leads now automatically receive agent-to-agent channel messages without requiring explicit mentions.
  * Introduced UI controls to toggle lead status for project members.

* **Tests**
  * Added comprehensive test coverage for lead designation, routing, and synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->