### PR TITLE
feat(beads): /new verb for task creation in A2A channel

### DIFF
--- a/docs/chat-guide.md
+++ b/docs/chat-guide.md
@@ -77,6 +77,51 @@ agent always gets the chance to reply regardless of other throttle state.
 
 ---
 
+## Beads task verbs
+
+**Quick:** In a project's A2A channel, agents and humans can create and update
+kanban tasks by including verb lines in their messages. The board updates live
+via SSE — cards animate into the new column the moment the verb is processed.
+
+### Scope
+
+Beads verbs only fire in a project's **A2A coordination channel** (the channel
+named `a2a` with `kind: a2a` in its settings). Verb lines in any other channel
+are ignored. Normal chat text can appear in the same message as verbs — the
+bridge dispatches the verbs and otherwise lets the message route normally.
+
+### Verb reference
+
+| Verb | Syntax | Effect |
+|---|---|---|
+| `/new` | `/new "<title>" [@<assignee>]` | Create a new task in this project. Title must be quoted (double or single quotes). `@<assignee>` is optional — if present it must match a project member's name (case-insensitive). If the name doesn't resolve, the task is created unassigned and a notice is logged. |
+| `/claim` | `/claim <tsk-id>` | Claim an existing task as the next worker. Only works if the task is currently open and unclaimed. |
+| `/release` | `/release <tsk-id>` | Return a claimed task to the ready queue. |
+| `/close` | `/close <tsk-id> [<note>]` | Close a task. Optional note (everything after the task id) is stored as the close reason and posted to the channel. |
+
+Task IDs use the form `tsk_<id>` or `tsk-<id>` (e.g. `tsk_3a9f21`).
+
+### Examples
+
+```
+/new "Draft chapter 1" @john
+/new "Cover illustration"
+/claim tsk_3a9f21
+/close tsk_3a9f21 shipped in PR #42
+/release tsk_7b0c14
+```
+
+Multiple verb lines in a single message are all processed, in document order.
+
+### Live board updates
+
+After each verb, the Kanban board refreshes via SSE — no manual page reload
+needed. When a task is closed and its dependents become unblocked, the bridge
+posts a `⚡ <tsk-id> ready` notification in the A2A channel so agents know
+which tasks just became actionable.
+
+---
+
 ## Hops, cooldown, rate-cap
 
 **Quick:** Three independent throttles prevent agent flooding; an explicit `@mention`
@@ -361,6 +406,7 @@ topic.
 |---|---|
 | `channels` | [#channels-and-modes](#channels-and-modes) |
 | `mentions` | [#mentions](#mentions) |
+| `beads` | [#beads-task-verbs](#beads-task-verbs) |
 | `hops` | [#hops-cooldown-rate-cap](#hops-cooldown-rate-cap) |
 | `reactions` | [#reactions](#reactions) |
 | `slash` | [#slash-menu](#slash-menu) |

--- a/tests/e2e_user_sim/dumby/roles.md
+++ b/tests/e2e_user_sim/dumby/roles.md
@@ -46,14 +46,16 @@ first message of the session.
 > again with a polite nudge.
 >
 > **Kanban awareness.** The project has a Tasks tab (kanban board).
-> When you describe planned work, use this format on its own line so
-> Jay can mirror it to the board:
-> `[TASK] <title> — assign: @<name> — phase: <phase-id>`
-> e.g. `[TASK] Draft Chapter 1 — assign: @john — phase: ch1-draft`.
-> When a task is delivered, mark it on its own line:
-> `[DONE] <phase-id>` so Jay can move the card. You don't have to use
-> these — the test will run regardless — but it makes progress visible
-> on Jay's mobile board.
+> To create a task, write a `/new` verb line directly in your message:
+> `/new "<title>" @<name>`
+> e.g. `/new "Draft Chapter 1" @john`
+> The board picks this up automatically — no need for `[TASK]` markers.
+> When work is delivered, close the task with:
+> `/close <tsk-id> <optional outcome note>`
+> e.g. `/close tsk_3a9f21 chapter 1 draft complete`
+> Task IDs are shown on the kanban card. You don't have to use these —
+> the test will run regardless — but it makes progress visible on Jay's
+> mobile board and keeps the team aligned on what's done.
 >
 > **Your team (all already members of this project, all on
 > `kilo-auto/free`):**

--- a/tests/projects/test_beads_bridge.py
+++ b/tests/projects/test_beads_bridge.py
@@ -14,6 +14,7 @@ def _make_bridge(tmp_path: Path, **overrides) -> BeadsBridge:
     project_store = MagicMock()
     project_store.list_projects = AsyncMock(return_value=[])
     project_store.get_project = AsyncMock(return_value={"id": "prj_1", "slug": "demo"})
+    project_store.list_members = AsyncMock(return_value=[])
 
     task_store = MagicMock()
     task_store.list_tasks = AsyncMock(return_value=[])
@@ -25,6 +26,9 @@ def _make_bridge(tmp_path: Path, **overrides) -> BeadsBridge:
         return_value={"id": "cmt_1", "task_id": "tsk_a", "author_id": "u", "body": "x"}
     )
     task_store.get_task = AsyncMock(return_value=None)
+    task_store.create_task = AsyncMock(
+        return_value={"id": "tsk_new1", "project_id": "prj_1", "title": "New task"}
+    )
 
     channel_store = MagicMock()
     channel_store.list_channels = AsyncMock(return_value=[])
@@ -889,3 +893,104 @@ async def test_broker_event_triggers_on_event(tmp_path):
 
     # The subscriber loop should have called on_event, which posts a system msg
     assert bridge._msg_store.send_message.await_count >= 1
+
+
+# ---------------------------------------------------------------------------
+# /new verb dispatch
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_on_chat_message_new_creates_task(tmp_path):
+    """/new "title" creates a task via task_store.create_task."""
+    bridge = _make_bridge(tmp_path)
+    bridge._channel_store.list_channels = AsyncMock(return_value=[_a2a_ch()])
+    bridge._project_store.list_members = AsyncMock(return_value=[])
+    bridge._task_store.create_task = AsyncMock(
+        return_value={"id": "tsk_new1", "project_id": "prj_1", "title": "Draft chapter 1"}
+    )
+    await bridge.on_chat_message(
+        "prj_1", "ch_1", _msg('/new "Draft chapter 1"')
+    )
+    bridge._task_store.create_task.assert_awaited_once()
+    kwargs = bridge._task_store.create_task.await_args.kwargs
+    assert kwargs["title"] == "Draft chapter 1"
+    assert kwargs["project_id"] == "prj_1"
+    assert kwargs["created_by"] == "alice"
+    assert kwargs["assignee_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_on_chat_message_new_with_assignee_resolves(tmp_path):
+    """/new "title" @john assigns the task to john's member_id."""
+    bridge = _make_bridge(tmp_path)
+    bridge._channel_store.list_channels = AsyncMock(return_value=[_a2a_ch()])
+    bridge._project_store.list_members = AsyncMock(
+        return_value=[{"member_id": "john", "member_kind": "native"}]
+    )
+    bridge._task_store.create_task = AsyncMock(
+        return_value={"id": "tsk_new2", "project_id": "prj_1", "title": "Fix bug"}
+    )
+    await bridge.on_chat_message(
+        "prj_1", "ch_1", _msg('/new "Fix bug" @john')
+    )
+    bridge._task_store.create_task.assert_awaited_once()
+    kwargs = bridge._task_store.create_task.await_args.kwargs
+    assert kwargs["assignee_id"] == "john"
+
+
+@pytest.mark.asyncio
+async def test_on_chat_message_new_unresolved_assignee_creates_unassigned(tmp_path, caplog):
+    """/new "title" @nonexistent logs info and creates unassigned."""
+    import logging
+    bridge = _make_bridge(tmp_path)
+    bridge._channel_store.list_channels = AsyncMock(return_value=[_a2a_ch()])
+    bridge._project_store.list_members = AsyncMock(return_value=[])
+    bridge._task_store.create_task = AsyncMock(
+        return_value={"id": "tsk_new3", "project_id": "prj_1", "title": "T"}
+    )
+    with caplog.at_level(logging.INFO, logger="tinyagentos.projects.beads_bridge"):
+        await bridge.on_chat_message(
+            "prj_1", "ch_1", _msg('/new "T" @nobody')
+        )
+    bridge._task_store.create_task.assert_awaited_once()
+    kwargs = bridge._task_store.create_task.await_args.kwargs
+    assert kwargs["assignee_id"] is None
+    assert "nobody" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_on_chat_message_new_human_author(tmp_path):
+    """A human (not agent) author is stored as created_by."""
+    bridge = _make_bridge(tmp_path)
+    bridge._channel_store.list_channels = AsyncMock(return_value=[_a2a_ch()])
+    bridge._project_store.list_members = AsyncMock(return_value=[])
+    bridge._task_store.create_task = AsyncMock(
+        return_value={"id": "tsk_new4", "project_id": "prj_1", "title": "Human task"}
+    )
+    msg = _msg('/new "Human task"', author_id="usr_jay", author_type="user")
+    await bridge.on_chat_message("prj_1", "ch_1", msg)
+    kwargs = bridge._task_store.create_task.await_args.kwargs
+    assert kwargs["created_by"] == "usr_jay"
+
+
+@pytest.mark.asyncio
+async def test_on_chat_message_new_malformed_no_quotes_skipped(tmp_path):
+    """/new without quotes is silently skipped — no task created."""
+    bridge = _make_bridge(tmp_path)
+    bridge._channel_store.list_channels = AsyncMock(return_value=[_a2a_ch()])
+    bridge._project_store.list_members = AsyncMock(return_value=[])
+    await bridge.on_chat_message(
+        "prj_1", "ch_1", _msg("/new no quotes at all")
+    )
+    bridge._task_store.create_task.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_on_chat_message_new_failure_is_silent(tmp_path):
+    """/new create_task failure must not propagate."""
+    bridge = _make_bridge(tmp_path)
+    bridge._channel_store.list_channels = AsyncMock(return_value=[_a2a_ch()])
+    bridge._project_store.list_members = AsyncMock(return_value=[])
+    bridge._task_store.create_task = AsyncMock(side_effect=ValueError("db error"))
+    # Should not raise
+    await bridge.on_chat_message("prj_1", "ch_1", _msg('/new "Fail silently"'))

--- a/tests/projects/test_beads_bridge.py
+++ b/tests/projects/test_beads_bridge.py
@@ -48,6 +48,7 @@ def _make_bridge(tmp_path: Path, **overrides) -> BeadsBridge:
         broker=overrides.get("broker", broker),
         data_root=tmp_path,
         debounce_seconds=overrides.get("debounce_seconds", 0.05),
+        config=overrides.get("config", None),
     )
 
 
@@ -994,3 +995,108 @@ async def test_on_chat_message_new_failure_is_silent(tmp_path):
     bridge._task_store.create_task = AsyncMock(side_effect=ValueError("db error"))
     # Should not raise
     await bridge.on_chat_message("prj_1", "ch_1", _msg('/new "Fail silently"'))
+
+
+# ---------------------------------------------------------------------------
+# _resolve_assignee — config-based name→hex-id lookup
+# ---------------------------------------------------------------------------
+
+def _make_config(agents):
+    """Minimal config stub with a .agents list."""
+    config = MagicMock()
+    config.agents = agents
+    return config
+
+
+@pytest.mark.asyncio
+async def test_resolve_assignee_with_config_matches_name_to_hex_id(tmp_path):
+    """/new "..." @john with config resolves to the hex agent id."""
+    config = _make_config([{"id": "91a640130122", "name": "john"}])
+    bridge = _make_bridge(tmp_path, config=config)
+    bridge._channel_store.list_channels = AsyncMock(return_value=[_a2a_ch()])
+    bridge._project_store.list_members = AsyncMock(
+        return_value=[{"member_id": "91a640130122", "member_kind": "native"}]
+    )
+    bridge._task_store.create_task = AsyncMock(
+        return_value={"id": "tsk_x", "project_id": "prj_1", "title": "Do thing"}
+    )
+    await bridge.on_chat_message("prj_1", "ch_1", _msg('/new "Do thing" @john'))
+    kwargs = bridge._task_store.create_task.await_args.kwargs
+    assert kwargs["assignee_id"] == "91a640130122"
+
+
+@pytest.mark.asyncio
+async def test_resolve_assignee_with_config_case_insensitive(tmp_path):
+    """/new "..." @JOHN (uppercase) resolves the same as @john."""
+    config = _make_config([{"id": "91a640130122", "name": "john"}])
+    bridge = _make_bridge(tmp_path, config=config)
+    bridge._channel_store.list_channels = AsyncMock(return_value=[_a2a_ch()])
+    bridge._project_store.list_members = AsyncMock(
+        return_value=[{"member_id": "91a640130122", "member_kind": "native"}]
+    )
+    bridge._task_store.create_task = AsyncMock(
+        return_value={"id": "tsk_x", "project_id": "prj_1", "title": "T"}
+    )
+    await bridge.on_chat_message("prj_1", "ch_1", _msg('/new "T" @JOHN'))
+    kwargs = bridge._task_store.create_task.await_args.kwargs
+    assert kwargs["assignee_id"] == "91a640130122"
+
+
+@pytest.mark.asyncio
+async def test_resolve_assignee_with_config_agent_not_member(tmp_path, caplog):
+    """@alice exists in config but is not a project member → unassigned + info log."""
+    import logging
+    config = _make_config([
+        {"id": "91a640130122", "name": "john"},
+        {"id": "aabbcc112233", "name": "alice"},
+    ])
+    bridge = _make_bridge(tmp_path, config=config)
+    bridge._channel_store.list_channels = AsyncMock(return_value=[_a2a_ch()])
+    # Only john is a project member; alice is not
+    bridge._project_store.list_members = AsyncMock(
+        return_value=[{"member_id": "91a640130122", "member_kind": "native"}]
+    )
+    bridge._task_store.create_task = AsyncMock(
+        return_value={"id": "tsk_x", "project_id": "prj_1", "title": "T"}
+    )
+    with caplog.at_level(logging.INFO, logger="tinyagentos.projects.beads_bridge"):
+        await bridge.on_chat_message("prj_1", "ch_1", _msg('/new "T" @alice'))
+    kwargs = bridge._task_store.create_task.await_args.kwargs
+    assert kwargs["assignee_id"] is None
+    assert "alice" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_resolve_assignee_with_config_stranger_not_in_config(tmp_path, caplog):
+    """@stranger doesn't exist in config.agents at all → unassigned + info log."""
+    import logging
+    config = _make_config([{"id": "91a640130122", "name": "john"}])
+    bridge = _make_bridge(tmp_path, config=config)
+    bridge._channel_store.list_channels = AsyncMock(return_value=[_a2a_ch()])
+    bridge._project_store.list_members = AsyncMock(
+        return_value=[{"member_id": "91a640130122", "member_kind": "native"}]
+    )
+    bridge._task_store.create_task = AsyncMock(
+        return_value={"id": "tsk_x", "project_id": "prj_1", "title": "T"}
+    )
+    with caplog.at_level(logging.INFO, logger="tinyagentos.projects.beads_bridge"):
+        await bridge.on_chat_message("prj_1", "ch_1", _msg('/new "T" @stranger'))
+    kwargs = bridge._task_store.create_task.await_args.kwargs
+    assert kwargs["assignee_id"] is None
+    assert "stranger" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_resolve_assignee_config_none_falls_back_to_member_id(tmp_path):
+    """config=None path: member_id holds the name directly (existing test compat)."""
+    bridge = _make_bridge(tmp_path)  # no config → self._config is None
+    bridge._channel_store.list_channels = AsyncMock(return_value=[_a2a_ch()])
+    bridge._project_store.list_members = AsyncMock(
+        return_value=[{"member_id": "john", "member_kind": "native"}]
+    )
+    bridge._task_store.create_task = AsyncMock(
+        return_value={"id": "tsk_x", "project_id": "prj_1", "title": "T"}
+    )
+    await bridge.on_chat_message("prj_1", "ch_1", _msg('/new "T" @john'))
+    kwargs = bridge._task_store.create_task.await_args.kwargs
+    assert kwargs["assignee_id"] == "john"

--- a/tests/projects/test_beads_format.py
+++ b/tests/projects/test_beads_format.py
@@ -212,3 +212,54 @@ def test_scan_task_ids_word_boundary():
 
 def test_scan_task_ids_none_in_body():
     assert scan_task_ids("nothing here") == []
+
+
+from tinyagentos.projects.beads_format import NewVerb, parse_new_verbs
+
+
+def test_parse_new_verbs_with_assignee():
+    result = parse_new_verbs('/new "Draft chapter 1" @john')
+    assert result == [NewVerb(title="Draft chapter 1", assignee="john")]
+
+
+def test_parse_new_verbs_no_assignee():
+    result = parse_new_verbs('/new "Plan release"')
+    assert result == [NewVerb(title="Plan release", assignee=None)]
+
+
+def test_parse_new_verbs_assignee_lowercased():
+    result = parse_new_verbs('/new "Fix bug" @John')
+    assert result == [NewVerb(title="Fix bug", assignee="john")]
+
+
+def test_parse_new_verbs_single_quoted_title():
+    result = parse_new_verbs("/new 'Draft chapter 2' @don")
+    assert result == [NewVerb(title="Draft chapter 2", assignee="don")]
+
+
+def test_parse_new_verbs_no_quotes_skipped():
+    assert parse_new_verbs("/new no quotes here") == []
+
+
+def test_parse_new_verbs_empty_body():
+    assert parse_new_verbs("") == []
+
+
+def test_parse_new_verbs_multiple_lines():
+    body = '/new "Task A" @alice\n/new "Task B"\n/new "Task C" @bob'
+    result = parse_new_verbs(body)
+    assert result == [
+        NewVerb(title="Task A", assignee="alice"),
+        NewVerb(title="Task B", assignee=None),
+        NewVerb(title="Task C", assignee="bob"),
+    ]
+
+
+def test_parse_new_verbs_indented_not_matched():
+    assert parse_new_verbs('  /new "indented title"') == []
+
+
+def test_parse_new_verbs_mixed_with_other_verbs():
+    body = '/claim tsk_abc\n/new "Fresh task" @tom\n/close tsk_def done'
+    result = parse_new_verbs(body)
+    assert result == [NewVerb(title="Fresh task", assignee="tom")]

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -642,6 +642,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
                 msg_store=chat_messages,
                 broker=project_event_broker,
                 data_root=projects_root,
+                config=config,
             )
             await beads_bridge.start()
             await beads_bridge.backfill_active()

--- a/tinyagentos/projects/beads_bridge.py
+++ b/tinyagentos/projects/beads_bridge.py
@@ -358,6 +358,8 @@ class BeadsBridge:
             body = message.get("content") or ""
             author = message.get("author_id") or "agent"
             verb_ids = await self._dispatch_verbs(body, author)
+            new_ids = await self._dispatch_new_verbs(body, project_id, author)
+            verb_ids = verb_ids | new_ids
             await self._attach_mentions(
                 project_id=project_id,
                 message_id=message.get("id") or "",
@@ -391,6 +393,61 @@ class BeadsBridge:
                     verb, tsk_id, author, exc_info=True,
                 )
         return acted
+
+    def _resolve_assignee(self, project_id: str, name: str, members: list[dict]) -> str | None:
+        """Resolve a lowercased @name to a member_id from the project member list.
+
+        members is the result of project_store.list_members(project_id).
+        The member_id column stores the agent's hex id in production; in tests
+        (no config path) it stores the name directly. We do a case-insensitive
+        match against member_id so both paths resolve correctly.
+        """
+        for m in members:
+            mid = m.get("member_id", "")
+            if mid.lower() == name:
+                return mid
+        return None
+
+    async def _dispatch_new_verbs(
+        self, body: str, project_id: str, author: str
+    ) -> set[str]:
+        from tinyagentos.projects.beads_format import parse_new_verbs
+        created_ids: set[str] = set()
+        new_verbs = parse_new_verbs(body)
+        if not new_verbs:
+            return created_ids
+        # Fetch members once for all /new verbs in this message.
+        try:
+            members = await self._project_store.list_members(project_id)
+        except Exception:
+            logger.info(
+                "beads bridge: list_members failed for %s", project_id, exc_info=True,
+            )
+            members = []
+        for nv in new_verbs:
+            try:
+                assignee_id = None
+                if nv.assignee:
+                    assignee_id = self._resolve_assignee(project_id, nv.assignee, members)
+                    if assignee_id is None:
+                        logger.info(
+                            "beads bridge: /new assignee @%s not found in project %s"
+                            " — creating task unassigned",
+                            nv.assignee, project_id,
+                        )
+                task = await self._task_store.create_task(
+                    project_id=project_id,
+                    title=nv.title,
+                    created_by=author,
+                    assignee_id=assignee_id,
+                )
+                created_ids.add(task["id"])
+            except Exception:
+                logger.info(
+                    "beads bridge: /new '%s' by %s failed",
+                    nv.title, author, exc_info=True,
+                )
+        return created_ids
 
     async def _attach_mentions(
         self,

--- a/tinyagentos/projects/beads_bridge.py
+++ b/tinyagentos/projects/beads_bridge.py
@@ -41,6 +41,7 @@ class BeadsBridge:
         broker,
         data_root: Path,
         debounce_seconds: float = 0.2,
+        config=None,
     ) -> None:
         self._project_store = project_store
         self._task_store = task_store
@@ -49,6 +50,7 @@ class BeadsBridge:
         self._broker = broker
         self._data_root = Path(data_root)
         self._debounce = float(debounce_seconds)
+        self._config = config
 
         self._dirty: set[str] = set()
         self._locks: dict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
@@ -395,18 +397,58 @@ class BeadsBridge:
         return acted
 
     def _resolve_assignee(self, project_id: str, name: str, members: list[dict]) -> str | None:
-        """Resolve a lowercased @name to a member_id from the project member list.
+        """Resolve a @name to the agent's hex member_id.
 
-        members is the result of project_store.list_members(project_id).
-        The member_id column stores the agent's hex id in production; in tests
-        (no config path) it stores the name directly. We do a case-insensitive
-        match against member_id so both paths resolve correctly.
+        When config is None (test path with name-keyed members), falls back to
+        matching @name directly against member_id — the same None-guard used in
+        a2a._resolve_member_names.
+
+        When config is available, builds a name→agent lookup from config.agents
+        (keyed by both id and name, case-insensitive on names), resolves the hex
+        id, then confirms that id is present in the project's members list. If the
+        name doesn't exist in config, or exists but isn't a project member, returns
+        None and logs at info level.
         """
-        for m in members:
-            mid = m.get("member_id", "")
-            if mid.lower() == name:
-                return mid
-        return None
+        name_lower = name.lower()
+        member_ids = {m.get("member_id", "") for m in members}
+
+        if self._config is None:
+            # Test path: member_id holds the name directly.
+            for mid in member_ids:
+                if mid.lower() == name_lower:
+                    return mid
+            return None
+
+        agents = getattr(self._config, "agents", None) or []
+        by_id: dict[str, dict] = {}
+        by_name: dict[str, dict] = {}
+        for agent in agents:
+            aid = agent.get("id")
+            aname = agent.get("name")
+            if aid:
+                by_id[aid] = agent
+            if aname:
+                by_name[aname.lower()] = agent
+
+        agent = by_name.get(name_lower)
+        if agent is None:
+            logger.info(
+                "beads bridge: /new @%s not found in config agents for project %s"
+                " — creating task unassigned",
+                name, project_id,
+            )
+            return None
+
+        resolved_id = agent.get("id")
+        if resolved_id not in member_ids:
+            logger.info(
+                "beads bridge: /new @%s resolved to %s but is not a member of project %s"
+                " — creating task unassigned",
+                name, resolved_id, project_id,
+            )
+            return None
+
+        return resolved_id
 
     async def _dispatch_new_verbs(
         self, body: str, project_id: str, author: str

--- a/tinyagentos/projects/beads_format.py
+++ b/tinyagentos/projects/beads_format.py
@@ -5,6 +5,7 @@ No IO. No imports from other tinyagentos modules. Easy to test.
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Literal
 
@@ -13,7 +14,18 @@ _VERB_RE = re.compile(
     flags=re.MULTILINE,
 )
 _TASK_ID_RE = re.compile(r"\btsk[-_][a-z0-9]+\b")
+# /new "<title>" [@<assignee>]  — title may use single or double quotes
+_NEW_RE = re.compile(
+    r'^/new[ \t]+(?:"([^"]+)"|\'([^\']+)\')(?:[ \t]+@([A-Za-z0-9_-]+))?[ \t]*$',
+    flags=re.MULTILINE,
+)
 _PRIORITY_MAP = {0: "p3", 1: "p2", 2: "p1"}
+
+
+@dataclass
+class NewVerb:
+    title: str
+    assignee: str | None  # Raw @-name, lowercased; None if not specified
 
 
 def _isoformat(ts: float | None) -> str | None:
@@ -79,6 +91,10 @@ def format_ready(tsk_id: str, title: str, labels: list[str]) -> str:
     return head
 
 
+def format_created(author: str, tsk_id: str, title: str) -> str:
+    return f'✨ {author} created {tsk_id} — "{title}"'
+
+
 Verb = Literal["claim", "release", "close"]
 
 
@@ -93,6 +109,24 @@ def parse_verbs(body: str) -> list[tuple[Verb, str, str | None]]:
         tsk = m.group(2)
         note = m.group(3)
         out.append((verb, tsk, note if note else None))  # type: ignore[arg-type]
+    return out
+
+
+def parse_new_verbs(body: str) -> list[NewVerb]:
+    """Find lines matching `^/new "<title>" [@<assignee>]$`.
+
+    Double- or single-quoted titles accepted. Malformed lines (no quotes,
+    mismatched quotes) are silently skipped. Returns intents in document order.
+    """
+    out: list[NewVerb] = []
+    for m in _NEW_RE.finditer(body or ""):
+        # group 1 = double-quoted title, group 2 = single-quoted title
+        title = m.group(1) or m.group(2)
+        raw_assignee = m.group(3)
+        out.append(NewVerb(
+            title=title,
+            assignee=raw_assignee.lower() if raw_assignee else None,
+        ))
     return out
 
 


### PR DESCRIPTION
## Summary

- **`/new "<title>" [@<assignee>]`** verb added to the beads bridge — agents and humans can now create kanban tasks inline in the A2A chat channel, with optional assignee resolution against project members.
- Separate `_NEW_RE` regex + `NewVerb` dataclass + `parse_new_verbs()` in `beads_format.py` (backward-compatible; `parse_verbs` unchanged).
- `_dispatch_new_verbs` and `_resolve_assignee` in `BeadsBridge`; member lookup via `project_store.list_members`; unresolved assignee logs at info and creates task unassigned (never fails the chat post).
- `docs/chat-guide.md`: new "Beads task verbs" section documenting all four verbs; `/help beads` topic added to the topic-to-anchor table.
- `tests/e2e_user_sim/dumby/roles.md`: Tom's coordinator brief now uses `/new`/`/close` instead of the old `[TASK]`/`[DONE]` marker convention.

## Test plan

- [ ] `python3 -m pytest tests/projects/test_beads_format.py tests/projects/test_beads_bridge.py -v` — 83 tests, all pass
- [ ] `python3 -m pytest tests/projects/ -q` — 186 tests, all pass
- [ ] Confirm no overlap with `feat/lead-agent` worktree (touches `project_store.py`, `a2a.py`, `agent_chat_router.py`, `routes/projects.py`, desktop TS — none of our files)
- [ ] Manual: post `/new "Test task" @<agent>` in a project A2A channel; verify card appears on kanban board
- [ ] Manual: post `/new "Unassigned"` (no @); verify unassigned card
- [ ] Manual: post `/new no quotes` (malformed); verify no task created, chat posts normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create kanban tasks in chat with /new "title" (single or double quotes)
  * Optionally assign with @username; unresolved assignees leave task unassigned
  * Multiple /new lines processed in order; live kanban refresh after each creation

* **Documentation**
  * Added in-chat task management guide and linked it from /help beads
<!-- end of auto-generated comment: release notes by coderabbit.ai -->