### PR TITLE
fix(image-gen): fix false loaded-model reporting + rknn-sd idle unload

### DIFF
--- a/tests/test_rknn_sd_server.py
+++ b/tests/test_rknn_sd_server.py
@@ -1,0 +1,272 @@
+"""Tests for rknn_sd_server lifecycle: idle-unload bookkeeping and /admin/unload.
+
+These tests do NOT import the real RKNN runtime, diffusers, or transformers.
+_pipe is injected as a plain sentinel object so we can verify the lifecycle
+state machine around it without touching NPU hardware.
+"""
+import asyncio
+import time
+import pytest
+import pytest_asyncio
+from unittest.mock import MagicMock, patch
+from httpx import AsyncClient, ASGITransport
+
+import tinyagentos.services.rknn_sd_server as srv
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _reset_server_state(pipe_value=None, last_activity=0.0, load_error=None):
+    """Reset module-level globals to a known state for each test."""
+    srv._pipe = pipe_value
+    srv._last_activity_ts = last_activity
+    srv._load_error = load_error
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — _ensure_pipeline_sync activity timestamp
+# ---------------------------------------------------------------------------
+
+class TestEnsurePipelineSyncTimestamp:
+    def test_loading_updates_last_activity_ts(self, monkeypatch):
+        """When _ensure_pipeline_sync loads the pipeline, _last_activity_ts is set."""
+        _reset_server_state(pipe_value=None, last_activity=0.0)
+
+        fake_pipe = object()
+        before = time.monotonic()
+
+        def _fake_build():
+            return fake_pipe
+
+        monkeypatch.setattr(srv, "USE_LEGACY_WRAPPER", False)
+        monkeypatch.setattr(srv, "_build_pipeline_ez", _fake_build)
+
+        srv._ensure_pipeline_sync()
+
+        after = time.monotonic()
+        assert srv._pipe is fake_pipe
+        assert srv._last_activity_ts >= before
+        assert srv._last_activity_ts <= after
+
+    def test_already_loaded_is_idempotent(self, monkeypatch):
+        """If _pipe is already set, _ensure_pipeline_sync returns immediately."""
+        sentinel = object()
+        _reset_server_state(pipe_value=sentinel, last_activity=0.0)
+
+        called = []
+        monkeypatch.setattr(srv, "_build_pipeline_ez", lambda: called.append(1) or object())
+
+        srv._ensure_pipeline_sync()
+
+        assert srv._pipe is sentinel
+        assert called == []
+        assert srv._last_activity_ts == 0.0  # not touched
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — _unload_pipeline
+# ---------------------------------------------------------------------------
+
+class TestUnloadPipeline:
+    def test_clears_pipe(self):
+        """_unload_pipeline sets _pipe to None."""
+        _reset_server_state(pipe_value=object())
+
+        srv._unload_pipeline()
+
+        assert srv._pipe is None
+
+    def test_no_op_when_already_unloaded(self):
+        """_unload_pipeline is safe to call when nothing is loaded."""
+        _reset_server_state(pipe_value=None)
+        srv._unload_pipeline()  # must not raise
+        assert srv._pipe is None
+
+    def test_calls_release_on_pipe(self):
+        """_unload_pipeline calls release() on the pipe object if it exists."""
+        fake_pipe = MagicMock()
+        _reset_server_state(pipe_value=fake_pipe)
+
+        srv._unload_pipeline()
+
+        fake_pipe.release.assert_called_once()
+
+    def test_survives_release_raising(self):
+        """_unload_pipeline survives a wrapper that throws on release()."""
+        fake_pipe = MagicMock()
+        fake_pipe.release.side_effect = RuntimeError("GPU exploded")
+        _reset_server_state(pipe_value=fake_pipe)
+
+        srv._unload_pipeline()  # must not raise
+
+        assert srv._pipe is None
+
+    def test_calls_close_when_no_release(self):
+        """_unload_pipeline falls back to close() when release is absent."""
+        fake_pipe = MagicMock(spec=["close"])  # no release attribute
+        _reset_server_state(pipe_value=fake_pipe)
+
+        srv._unload_pipeline()
+
+        fake_pipe.close.assert_called_once()
+        assert srv._pipe is None
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — idle-unload background loop logic
+# ---------------------------------------------------------------------------
+
+class TestIdleUnloadLoop:
+    @pytest.mark.asyncio
+    async def test_idle_loop_unloads_after_threshold(self, monkeypatch):
+        """Background loop unloads pipeline once idle time exceeds threshold."""
+        fake_pipe = object()
+        _reset_server_state(pipe_value=fake_pipe, last_activity=0.0)
+
+        # Patch monotonic so the pipe looks like it's been idle for 1000s.
+        # We set _last_activity_ts to 0 and make monotonic return 1000.
+        monkeypatch.setattr(srv, "IDLE_UNLOAD_THRESHOLD_S", 600.0)
+        monkeypatch.setattr(srv, "IDLE_UNLOAD_INTERVAL_S", 0.001)  # near-instant check
+
+        # Fake time: always returns a value well past the threshold
+        monkeypatch.setattr(time, "monotonic", lambda: 1000.0)
+        srv._last_activity_ts = 1.0  # idle = 1000 - 1 = 999 >= 600
+
+        sleep_calls = []
+
+        async def _fast_sleep(s):
+            sleep_calls.append(s)
+            # Only sleep once, then let the loop unload and we cancel.
+            if len(sleep_calls) >= 2:
+                raise asyncio.CancelledError()
+
+        monkeypatch.setattr(asyncio, "sleep", _fast_sleep)
+
+        try:
+            await srv._idle_unload_loop()
+        except asyncio.CancelledError:
+            pass
+
+        assert srv._pipe is None  # was unloaded
+
+    @pytest.mark.asyncio
+    async def test_idle_loop_does_not_unload_before_threshold(self, monkeypatch):
+        """Background loop does not unload if idle time is below threshold."""
+        fake_pipe = object()
+        _reset_server_state(pipe_value=fake_pipe, last_activity=0.0)
+
+        monkeypatch.setattr(srv, "IDLE_UNLOAD_THRESHOLD_S", 600.0)
+        monkeypatch.setattr(srv, "IDLE_UNLOAD_INTERVAL_S", 0.001)
+
+        # Idle = 1000 - 500 = 500 < 600 — should NOT unload
+        monkeypatch.setattr(time, "monotonic", lambda: 1000.0)
+        srv._last_activity_ts = 500.0
+
+        sleep_count = [0]
+
+        async def _fast_sleep(s):
+            sleep_count[0] += 1
+            if sleep_count[0] >= 2:
+                raise asyncio.CancelledError()
+
+        monkeypatch.setattr(asyncio, "sleep", _fast_sleep)
+
+        try:
+            await srv._idle_unload_loop()
+        except asyncio.CancelledError:
+            pass
+
+        assert srv._pipe is fake_pipe  # NOT unloaded
+
+    @pytest.mark.asyncio
+    async def test_idle_loop_disabled_when_threshold_none(self, monkeypatch):
+        """When IDLE_UNLOAD_THRESHOLD_S is None the loop exits immediately."""
+        fake_pipe = object()
+        _reset_server_state(pipe_value=fake_pipe)
+
+        monkeypatch.setattr(srv, "IDLE_UNLOAD_THRESHOLD_S", None)
+
+        # Loop must return without sleeping or unloading
+        await srv._idle_unload_loop()
+
+        assert srv._pipe is fake_pipe  # NOT touched
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — HTTP endpoints via ASGI
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture
+async def rknn_sd_client():
+    """Async HTTP client wired to the rknn_sd_server ASGI app."""
+    transport = ASGITransport(app=srv.app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+
+@pytest.mark.asyncio
+class TestHealthEndpoint:
+    async def test_health_pipeline_not_loaded(self, rknn_sd_client):
+        """Health returns pipeline_loaded=false and null idle_seconds when nothing loaded."""
+        _reset_server_state(pipe_value=None, last_activity=0.0)
+
+        resp = await rknn_sd_client.get("/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["pipeline_loaded"] is False
+        assert data["idle_seconds"] is None
+
+    async def test_health_pipeline_loaded(self, rknn_sd_client):
+        """Health returns pipeline_loaded=true and non-null idle_seconds when loaded."""
+        fake_pipe = object()
+        _reset_server_state(pipe_value=fake_pipe, last_activity=time.monotonic() - 30)
+
+        resp = await rknn_sd_client.get("/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["pipeline_loaded"] is True
+        assert data["idle_seconds"] is not None
+        assert data["idle_seconds"] >= 29  # at least ~30s idle
+
+    async def test_health_exposes_idle_threshold(self, rknn_sd_client, monkeypatch):
+        """Health exposes idle_unload_threshold_s matching the configured value."""
+        monkeypatch.setattr(srv, "IDLE_UNLOAD_THRESHOLD_S", 300.0)
+        _reset_server_state()
+
+        resp = await rknn_sd_client.get("/health")
+        assert resp.json()["idle_unload_threshold_s"] == 300.0
+
+    async def test_health_threshold_null_when_disabled(self, rknn_sd_client, monkeypatch):
+        """Health shows null threshold when idle-unload is disabled."""
+        monkeypatch.setattr(srv, "IDLE_UNLOAD_THRESHOLD_S", None)
+        _reset_server_state()
+
+        resp = await rknn_sd_client.get("/health")
+        assert resp.json()["idle_unload_threshold_s"] is None
+
+
+@pytest.mark.asyncio
+class TestAdminUnload:
+    async def test_unload_when_nothing_loaded(self, rknn_sd_client):
+        """POST /admin/unload returns was_loaded=false when no pipeline is loaded."""
+        _reset_server_state(pipe_value=None)
+
+        resp = await rknn_sd_client.post("/admin/unload")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is True
+        assert data["was_loaded"] is False
+
+    async def test_unload_when_pipeline_loaded(self, rknn_sd_client):
+        """POST /admin/unload returns was_loaded=true and clears the pipeline."""
+        fake_pipe = MagicMock()
+        _reset_server_state(pipe_value=fake_pipe)
+
+        resp = await rknn_sd_client.post("/admin/unload")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is True
+        assert data["was_loaded"] is True
+        assert srv._pipe is None

--- a/tests/test_routes_models.py
+++ b/tests/test_routes_models.py
@@ -242,15 +242,16 @@ async def _make_auth_client(app):
 
 @pytest.mark.asyncio
 class TestLoadedModelsImageBackends:
-    async def test_rknn_sd_loaded_models(self, app_with_rknn_sd_backend):
-        """rknn-sd backend: GET /v1/models lists entries in loaded output."""
+    async def test_rknn_sd_loaded_when_pipeline_loaded(self, app_with_rknn_sd_backend):
+        """rknn-sd: /health with pipeline_loaded=true -> entry appears in loaded list."""
         app = app_with_rknn_sd_backend
 
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.return_value = {
-            "data": [{"id": "lcm-dreamshaper-v7-rknn", "object": "model"}],
-            "object": "list",
+            "status": "ok",
+            "model": "lcm-dreamshaper-v7-rknn",
+            "pipeline_loaded": True,
         }
 
         async with await _make_auth_client(app) as c:
@@ -263,15 +264,39 @@ class TestLoadedModelsImageBackends:
 
         assert resp.status_code == 200
         data = resp.json()
-        # The app may inject additional default rknn-sd backends; at least one
-        # entry must appear with the correct fields.
-        assert len(data["loaded"]) >= 1
-        entry = next(e for e in data["loaded"] if e["backend"] == "rknn-sd-npu")
+        entries = [e for e in data["loaded"] if e["backend"] == "rknn-sd-npu"]
+        assert len(entries) == 1
+        entry = entries[0]
         assert entry["name"] == "lcm-dreamshaper-v7-rknn"
         assert entry["backend_type"] == "rknn-sd"
         assert entry["purpose"] == "image-generation"
         assert entry["size_mb"] is None
         assert entry["vram_mb"] is None
+
+    async def test_rknn_sd_not_loaded_when_pipeline_not_loaded(self, app_with_rknn_sd_backend):
+        """rknn-sd: /health with pipeline_loaded=false -> no entry in loaded list."""
+        app = app_with_rknn_sd_backend
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "status": "ok",
+            "model": "lcm-dreamshaper-v7-rknn",
+            "pipeline_loaded": False,
+        }
+
+        async with await _make_auth_client(app) as c:
+            with patch.object(app.state, "http_client") as mock_http:
+                mock_http.get = AsyncMock(return_value=mock_response)
+                resp = await c.get("/api/models/loaded")
+        await app.state.metrics.close()
+        await app.state.qmd_client.close()
+        await app.state.http_client.aclose()
+
+        assert resp.status_code == 200
+        data = resp.json()
+        entries = [e for e in data["loaded"] if e["backend"] == "rknn-sd-npu"]
+        assert entries == []
 
     async def test_rknn_sd_offline_skipped(self, app_with_rknn_sd_backend):
         """rknn-sd backend: ConnectError is swallowed; loaded list is empty."""
@@ -288,15 +313,14 @@ class TestLoadedModelsImageBackends:
         assert resp.status_code == 200
         assert resp.json()["loaded"] == []
 
-    async def test_sd_cpp_loaded_models(self, app_with_sd_cpp_backend):
-        """sd-cpp backend: GET /sdapi/v1/options checkpoint appears in loaded output."""
+    async def test_sd_cpp_never_appears_in_loaded(self, app_with_sd_cpp_backend):
+        """sd-cpp: /sdapi/v1/options doesn't expose load state; backend is skipped entirely."""
         app = app_with_sd_cpp_backend
 
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.return_value = {
             "sd_model_checkpoint": "v1-5-pruned-emaonly.safetensors",
-            "sd_backend": "diffusers",
         }
 
         async with await _make_auth_client(app) as c:
@@ -310,34 +334,7 @@ class TestLoadedModelsImageBackends:
         assert resp.status_code == 200
         data = resp.json()
         sd_entries = [e for e in data["loaded"] if e["backend_type"] == "sd-cpp"]
-        assert len(sd_entries) == 1
-        entry = sd_entries[0]
-        assert entry["name"] == "v1-5-pruned-emaonly.safetensors"
-        assert entry["backend_type"] == "sd-cpp"
-        assert entry["purpose"] == "image-generation"
-        assert entry["size_mb"] is None
-
-    async def test_sd_cpp_missing_checkpoint_falls_back_to_unknown(self, app_with_sd_cpp_backend):
-        """sd-cpp: if sd_model_checkpoint is absent, name falls back to 'unknown'."""
-        app = app_with_sd_cpp_backend
-
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {}
-
-        async with await _make_auth_client(app) as c:
-            with patch.object(app.state, "http_client") as mock_http:
-                mock_http.get = AsyncMock(return_value=mock_response)
-                resp = await c.get("/api/models/loaded")
-        await app.state.metrics.close()
-        await app.state.qmd_client.close()
-        await app.state.http_client.aclose()
-
-        assert resp.status_code == 200
-        data = resp.json()
-        sd_entries = [e for e in data["loaded"] if e["backend_type"] == "sd-cpp"]
-        assert len(sd_entries) == 1
-        assert sd_entries[0]["name"] == "unknown"
+        assert sd_entries == []
 
     async def test_sd_cpp_offline_skipped(self, app_with_sd_cpp_backend):
         """sd-cpp backend: ConnectError is swallowed; loaded list is empty."""

--- a/tinyagentos/routes/models.py
+++ b/tinyagentos/routes/models.py
@@ -577,13 +577,16 @@ async def loaded_models(request: Request):
                                 "details": {},
                             })
                 elif backend_type == "rknn-sd":
-                    resp = await client.get(f"{base}/v1/models", timeout=5)
+                    # Use /health to determine actual pipeline load state.
+                    # /v1/models lists what the server *can* serve (always
+                    # populated) and does not reflect whether weights are
+                    # actually in NPU memory.
+                    resp = await client.get(f"{base}/health", timeout=5)
                     if resp.status_code == 200:
                         data = resp.json()
-                        for m in data.get("data", []) or []:
-                            model_id = m.get("id", "rknn-sd")
+                        if data.get("pipeline_loaded") is True:
                             loaded.append({
-                                "name": model_id,
+                                "name": data.get("model", "rknn-sd"),
                                 "backend": backend_name,
                                 "backend_type": backend_type,
                                 "backend_url": backend_url,
@@ -595,22 +598,12 @@ async def loaded_models(request: Request):
                                 "details": {},
                             })
                 elif backend_type == "sd-cpp":
-                    resp = await client.get(f"{base}/sdapi/v1/options", timeout=5)
-                    if resp.status_code == 200:
-                        data = resp.json()
-                        checkpoint = data.get("sd_model_checkpoint") or "unknown"
-                        loaded.append({
-                            "name": checkpoint,
-                            "backend": backend_name,
-                            "backend_type": backend_type,
-                            "backend_url": backend_url,
-                            "purpose": "image-generation",
-                            "size_mb": None,
-                            "vram_mb": None,
-                            "ram_mb": None,
-                            "expires_at": None,
-                            "details": {},
-                        })
+                    # sd-cpp's /sdapi/v1/options reports the configured
+                    # checkpoint but does not expose whether weights are
+                    # currently resident in memory. Reporting it as "loaded"
+                    # would be misleading. sd-cpp users see their installed
+                    # model in the Models app instead.
+                    pass
             except (httpx.ConnectError, httpx.TimeoutException, httpx.HTTPError):
                 continue
             except Exception as e:

--- a/tinyagentos/services/rknn_sd_server.py
+++ b/tinyagentos/services/rknn_sd_server.py
@@ -50,6 +50,11 @@ HOST = os.environ.get("RKNN_SD_HOST", "0.0.0.0")
 PORT = int(os.environ.get("RKNN_SD_PORT", "7863"))
 USE_LEGACY_WRAPPER = os.environ.get("RKNN_SD_LEGACY_WRAPPER", "").strip() == "1"
 
+# Idle-unload settings.  Set RKNN_SD_IDLE_UNLOAD_S=0 to disable entirely.
+_idle_unload_s_raw = os.environ.get("RKNN_SD_IDLE_UNLOAD_S", "600")
+IDLE_UNLOAD_THRESHOLD_S: float | None = None if _idle_unload_s_raw.strip() == "0" else float(_idle_unload_s_raw)
+IDLE_UNLOAD_INTERVAL_S: float = float(os.environ.get("RKNN_SD_IDLE_CHECK_S", "60"))
+
 
 def _load_wrapper_module():
     """Import darkbit1001's patched rknnlcm.py as a module, adding its dir to sys.path
@@ -111,6 +116,7 @@ _pipe = None
 _load_error: Optional[str] = None
 _runtime_name: str = "ez_rknn_async" if not USE_LEGACY_WRAPPER else "rknn-toolkit-lite2"
 _pipe_lock = asyncio.Lock()  # serialise lazy loads on the first concurrent request
+_last_activity_ts: float = 0.0  # time.monotonic() of last pipeline activity
 
 
 def _build_pipeline_ez():
@@ -131,9 +137,8 @@ def _ensure_pipeline_sync():
     The previous startup hook eagerly built the pipeline at boot,
     pinning ~5.5 GB of RAM permanently even when the user wasn't
     generating any images. Lazy loading frees the NPU memory budget
-    for chat models / TTS / etc when image gen is idle. Sequential
-    eviction is the next piece (Phase 1.5)."""
-    global _pipe, _load_error, _runtime_name
+    for chat models / TTS / etc when image gen is idle."""
+    global _pipe, _load_error, _runtime_name, _last_activity_ts
     if _pipe is not None:
         return
     try:
@@ -146,11 +151,36 @@ def _ensure_pipeline_sync():
         else:
             _pipe = _build_pipeline_ez()
             _runtime_name = "ez_rknn_async"
+        _last_activity_ts = time.monotonic()
         logger.info(f"Pipeline lazy-loaded in {time.time() - start:.1f}s (runtime={_runtime_name})")
     except Exception as exc:
         _load_error = str(exc)
         logger.exception("Failed to load RKNN pipeline")
         raise
+
+
+def _unload_pipeline() -> None:
+    """Release NPU memory held by the pipeline.
+
+    Calls any release()/close() methods the underlying runtime exposes
+    (best-effort; different impls vary). Always sets _pipe to None and
+    runs gc.collect() so memory is reclaimed even if release() throws.
+    """
+    import gc
+    global _pipe
+    pipe = _pipe
+    _pipe = None
+    if pipe is None:
+        return
+    for method_name in ("release", "close"):
+        method = getattr(pipe, method_name, None)
+        if callable(method):
+            try:
+                method()
+            except Exception as exc:
+                logger.info(f"_unload_pipeline: {method_name}() raised (ignored): {exc}")
+    gc.collect()
+    logger.info("RKNN pipeline unloaded — NPU memory released")
 
 
 async def _ensure_pipeline():
@@ -165,13 +195,30 @@ async def _ensure_pipeline():
         await asyncio.get_running_loop().run_in_executor(None, _ensure_pipeline_sync)
 
 
+async def _idle_unload_loop() -> None:
+    """Background task: unload the pipeline after IDLE_UNLOAD_THRESHOLD_S of inactivity."""
+    if IDLE_UNLOAD_THRESHOLD_S is None:
+        logger.info("Idle-unload disabled (RKNN_SD_IDLE_UNLOAD_S=0)")
+        return
+    logger.info(
+        f"Idle-unload enabled: threshold={IDLE_UNLOAD_THRESHOLD_S}s "
+        f"check_interval={IDLE_UNLOAD_INTERVAL_S}s"
+    )
+    while True:
+        await asyncio.sleep(IDLE_UNLOAD_INTERVAL_S)
+        if _pipe is not None and _last_activity_ts > 0:
+            idle = time.monotonic() - _last_activity_ts
+            if idle >= IDLE_UNLOAD_THRESHOLD_S:
+                logger.info(f"Pipeline idle for {idle:.0f}s — unloading")
+                _unload_pipeline()
+
+
 @app.on_event("startup")
 async def _startup():
-    # Intentionally empty: the pipeline is now lazy-loaded on the first
-    # /generate request. Old behaviour was to build the full pipeline
-    # here, which pinned ~5.5 GB of RAM at boot for users who never
-    # actually used image gen.
+    # Pipeline is lazy-loaded on the first /generate request.
+    # Old behaviour was to build here, pinning ~5.5 GB of RAM at boot.
     logger.info("rknn_sd_server up — pipeline will lazy-load on first /generate request")
+    asyncio.create_task(_idle_unload_loop())
 
 
 @app.get("/health")
@@ -181,6 +228,7 @@ async def health():
     # tells callers whether the next /generate will pay the load
     # latency or hit a warm pipeline. 'runtime' shows which backend
     # will be (or was) used: "ez_rknn_async" (default) or "rknn-toolkit-lite2".
+    idle_s = (time.monotonic() - _last_activity_ts) if _last_activity_ts > 0 else None
     return {
         "status": "ok",
         "model": "lcm-dreamshaper-v7-rknn",
@@ -188,6 +236,8 @@ async def health():
         "runtime": _runtime_name,
         "pipeline_loaded": _pipe is not None,
         "load_error": _load_error,
+        "idle_seconds": round(idle_s, 1) if idle_s is not None else None,
+        "idle_unload_threshold_s": IDLE_UNLOAD_THRESHOLD_S,
     }
 
 
@@ -204,6 +254,21 @@ async def list_models():
         ],
         "object": "list",
     }
+
+
+@app.post("/admin/unload")
+async def admin_unload():
+    """Manually evict the pipeline from NPU memory.
+
+    Returns {ok: true, was_loaded: bool}.
+
+    NOTE: the rknn-sd server binds to RKNN_SD_HOST (default 0.0.0.0).
+    Auth scoping is a follow-up — do not expose this port externally
+    without a firewall rule or auth middleware.
+    """
+    was_loaded = _pipe is not None
+    _unload_pipeline()
+    return {"ok": True, "was_loaded": was_loaded}
 
 
 @app.post("/v1/images/generations")
@@ -240,6 +305,11 @@ async def generate(body: GenerateRequest):
     )
     elapsed = time.time() - start
     logger.info(f"generation complete in {elapsed:.1f}s")
+
+    # Touch activity timestamp at end of request so an in-flight generate
+    # doesn't reset the idle clock mid-call and an eviction can't race it.
+    global _last_activity_ts
+    _last_activity_ts = time.monotonic()
 
     image = result["images"][0]
     buf = io.BytesIO()


### PR DESCRIPTION
## Summary

- **Part 1 — reporting fix (`routes/models.py`):** The Loaded Models widget was showing `lcm-dreamshaper-v7-rknn` as always-loaded on the Pi because `rknn-sd` was queried at `/v1/models` (which lists what the server *can* serve) rather than `/health` (which reports actual NPU memory state). Fixed: now checks `/health` and only adds the entry if `pipeline_loaded` is `true`. `sd-cpp` is dropped from the loaded list entirely — its `/sdapi/v1/options` does not expose load state, so the checkpoint name was always misleading; sd-cpp models appear in the Models app instead.

- **Part 2 — idle unload (`services/rknn_sd_server.py`):** Phase 1.5 ("sequential eviction") is now built. The pipeline is unloaded after 10 minutes of inactivity (configurable via `RKNN_SD_IDLE_UNLOAD_S`; set to `0` to disable). A background loop wakes every 60 s (`RKNN_SD_IDLE_CHECK_S`) and calls `_unload_pipeline()` if idle threshold is exceeded. `POST /admin/unload` provides a manual eviction escape hatch. `/health` now also reports `idle_seconds` and `idle_unload_threshold_s` for future dashboard use.

## Design decisions

- **Time source for idle**: `time.monotonic()` — not wall clock, so NTP jumps and suspend/resume don't cause spurious unloads.
- **Activity timestamp placement**: Set on pipeline *load* (in `_ensure_pipeline_sync`) AND at the *end* of every `/generate` response. Setting it at the end (not the start) means an in-flight generate cannot race the idle checker — the pipeline stays live through the full request.
- **`_unload_pipeline()` safety**: Tries `release()` then `close()` in a best-effort loop; logs at INFO and continues if either throws. Always sets `_pipe = None` and calls `gc.collect()`.
- **sd-cpp dropped, not silenced**: The simplest correct option. A comment in the code explains the limitation.
- **Test time mocking**: `monkeypatch` on `time.monotonic` (returns a constant far past the threshold) and `asyncio.sleep` (counts calls and raises `CancelledError` after N iterations to break the loop). No real sleeps needed.

## Test plan

- [ ] `pytest tests/test_routes_models.py` — 19 tests, all pass (updated rknn-sd tests now mock `/health`; sd-cpp test now asserts empty loaded list)
- [ ] `pytest tests/test_rknn_sd_server.py` — 16 new tests covering: activity timestamp on load, idempotent `_ensure_pipeline_sync`, `_unload_pipeline` happy path + release-throws, idle loop unloads past threshold / holds below threshold / noop when disabled, `/health` fields, `/admin/unload` both states
- [ ] Full suite `pytest tests/` — 2527 passed, 5 pre-existing failures (hardware detection on macOS, MCP supervisor) unrelated to this PR

## Follow-ups (out of scope here)

- `POST /admin/unload` has no auth; rknn-sd binds to `0.0.0.0` by default. Auth middleware or firewall rule should gate this before exposing externally.
- sd-cpp idle unload — different server lifecycle, separate concern.
- Frontend idle countdown widget — `/health` now provides `idle_seconds` and `idle_unload_threshold_s` for a "Will unload in X min" indicator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic pipeline unload after configurable idle period to optimize resource usage
  * Manual pipeline unload via new admin endpoint
  * Enhanced health status now reports idle time and configured unload threshold

* **Bug Fixes**
  * Corrected model loading status reporting for certain backends

<!-- end of auto-generated comment: release notes by coderabbit.ai -->