### PR TITLE
feat(image-tool): richer model controls for agents

### DIFF
--- a/tests/e2e_user_sim/dumby/roles.md
+++ b/tests/e2e_user_sim/dumby/roles.md
@@ -16,6 +16,8 @@ actually drive the team end-to-end via the project a2a channel?
 | **tom**    | hermes            | 🤖    | `#3b82f6` | Coordinator + Senior Editor (this is *you*)      |
 | john   | openclaw          | 👻    | `#ef4444` | Strong narrative/prose drafting                  |
 | don    | smolagents        | 🐝    | `#10b981` | Image generation + visual art (Images app)       |
+
+@don has access to two image-gen tools: `list_image_models` (discover what's installed) and `generate_image` (text-to-image, with optional `model`, `guidance_scale`, `negative_prompt`). Recommended workflow: list → pick the model that fits the task (LCM models = fast and stylized; full SD/SDXL = slower, more photorealistic) → generate with `guidance_scale=7.5` for balanced output, raise to 10–12 if the model is ignoring details, lower to 4–6 for more artistic interpretation.
 | linus  | langroid          | 🧠    | `#a855f7` | Multi-step reasoning + HTML/web                  |
 | pat    | pocketflow        | 🌊    | `#f59e0b` | Graph/flow thinking — marketing strategy + plans |
 | olive  | openai-agents-sdk | 🫒    | `#06b6d4` | Final QA cross-review                            |

--- a/tests/test_image_tool.py
+++ b/tests/test_image_tool.py
@@ -13,6 +13,8 @@ import base64
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
+
 import pytest
 import httpx
 
@@ -188,17 +190,17 @@ async def test_image_generation_forwards_new_params():
 
 
 @pytest.mark.asyncio
-async def test_image_generation_backward_compat():
-    """Omitting model/guidance_scale/negative_prompt uses legacy direct path."""
+async def test_image_generation_default_routes_via_scheduler():
+    """Omitting model still routes via the scheduler (no hardcoded model
+    fallback). The model field is left out of the payload so the
+    scheduler's GenerateRequest default ("") applies."""
     from tinyagentos.tools.image_tool import execute_image_generation
 
-    response_body = {
-        "data": [{"b64_json": base64.b64encode(b"fake-png").decode()}]
-    }
+    fake_png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
 
     mock_resp = MagicMock()
     mock_resp.status_code = 200
-    mock_resp.json.return_value = response_body
+    mock_resp.content = fake_png
     mock_resp.raise_for_status = MagicMock()
 
     captured: dict = {}
@@ -216,15 +218,88 @@ async def test_image_generation_backward_compat():
     with patch("httpx.AsyncClient", return_value=mock_client):
         result = await execute_image_generation(
             prompt="a red barn",
+            seed=7,
+        )
+
+    assert result["success"] is True
+    assert "/api/images/generate" in captured["url"]
+    body = captured["body"]
+    assert body["prompt"] == "a red barn"
+    assert body["seed"] == 7
+    # No hardcoded model — the field is omitted so the server picks
+    assert "model" not in body
+    # negative_prompt absent when empty
+    assert "negative_prompt" not in body
+
+
+@pytest.mark.asyncio
+async def test_image_generation_blank_model_treated_as_omitted():
+    """Whitespace-only or empty model strings should not land in the payload."""
+    from tinyagentos.tools.image_tool import execute_image_generation
+
+    fake_png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.content = fake_png
+    mock_resp.raise_for_status = MagicMock()
+
+    captured: dict = {}
+
+    async def fake_post(url, json=None, **kwargs):
+        captured["body"] = json or {}
+        return mock_resp
+
+    mock_client = AsyncMock()
+    mock_client.post = fake_post
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        result = await execute_image_generation(prompt="x", model="   ")
+
+    assert result["success"] is True
+    assert "model" not in captured["body"]
+
+
+@pytest.mark.asyncio
+async def test_image_generation_falls_back_on_controller_unreachable():
+    """When the controller is unreachable, fall back to the direct
+    backend call. The fallback also must not pin a model name."""
+    from tinyagentos.tools.image_tool import execute_image_generation
+
+    direct_response_body = {"data": [{"b64_json": base64.b64encode(b"fake").decode()}]}
+
+    direct_resp = MagicMock()
+    direct_resp.status_code = 200
+    direct_resp.json.return_value = direct_response_body
+    direct_resp.raise_for_status = MagicMock()
+
+    captured_urls: list = []
+    captured_body: dict = {}
+
+    async def fake_post(url, json=None, **kwargs):
+        captured_urls.append(url)
+        # First call (scheduler) raises; second call (direct backend) succeeds.
+        if "/api/images/generate" in url:
+            raise httpx.ConnectError("controller down")
+        captured_body.update(json or {})
+        return direct_resp
+
+    mock_client = AsyncMock()
+    mock_client.post = fake_post
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        result = await execute_image_generation(
+            prompt="a red barn",
             backend_url="http://localhost:8080",
             seed=7,
         )
 
     assert result["success"] is True
-    # Must have gone to the direct backend path, not the scheduler
-    assert "/v1/images/generations" in captured["url"]
-    body = captured["body"]
-    assert body["prompt"] == "a red barn"
-    assert body["seed"] == 7
-    # negative_prompt absent when empty
-    assert "negative_prompt" not in body
+    # Tried scheduler first, then direct backend.
+    assert any("/api/images/generate" in u for u in captured_urls)
+    assert any("/v1/images/generations" in u for u in captured_urls)
+    # Direct fallback does NOT pin a model name.
+    assert "model" not in captured_body

--- a/tests/test_image_tool.py
+++ b/tests/test_image_tool.py
@@ -1,0 +1,230 @@
+"""Tests for tinyagentos.tools.image_tool.
+
+Covers:
+- execute_list_image_models: filters to image-gen models, sets loaded flag
+- execute_list_image_models: handles API failures gracefully
+- execute_image_generation: forwards model/guidance_scale/negative_prompt
+- execute_image_generation: backward-compat when new params are omitted
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import httpx
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_response(status_code: int, body: dict) -> MagicMock:
+    """Build a minimal mock httpx.Response."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = body
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# execute_list_image_models
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_image_models_filters_to_image_gen():
+    """Only image-generation models should appear; loaded flag must be set."""
+    from tinyagentos.tools.image_tool import execute_list_image_models
+
+    installed_body = {
+        "models": [
+            {
+                "id": "lcm-dreamshaper-v7",
+                "name": "LCM Dreamshaper v7",
+                "capabilities": ["image-generation"],
+                "variants": [{"id": "rknn", "backend": ["rknn-sd"]}],
+                "description": "LCM model for RKNN",
+                "has_downloaded_variant": True,
+            },
+            {
+                "id": "llama-3-8b",
+                "name": "Llama 3 8B",
+                "capabilities": ["chat"],
+                "variants": [{"id": "q4", "backend": ["rkllama"]}],
+                "description": "Chat model",
+                "has_downloaded_variant": False,
+            },
+        ]
+    }
+    loaded_body = {
+        "loaded": [
+            {
+                "name": "LCM Dreamshaper v7",
+                "purpose": "image-generation",
+                "backend_type": "rknn-sd",
+            }
+        ]
+    }
+
+    installed_resp = _make_response(200, installed_body)
+    loaded_resp = _make_response(200, loaded_body)
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(side_effect=[installed_resp, loaded_resp])
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        result = await execute_list_image_models()
+
+    assert result["success"] is True
+    models = result["models"]
+    assert len(models) == 1
+    m = models[0]
+    assert m["name"] == "LCM Dreamshaper v7"
+    assert m["loaded"] is True
+
+
+@pytest.mark.asyncio
+async def test_list_image_models_backend_type_filter():
+    """Models with no image-generation capability but an rknn-sd/sd-cpp variant are included."""
+    from tinyagentos.tools.image_tool import execute_list_image_models
+
+    installed_body = {
+        "models": [
+            {
+                "id": "my-sd-model",
+                "name": "My SD Model",
+                "capabilities": [],  # no capability declared
+                "variants": [{"id": "fp16", "backend": ["sd-cpp"]}],
+                "description": "",
+                "has_downloaded_variant": True,
+            },
+        ]
+    }
+    loaded_body = {"loaded": []}
+
+    installed_resp = _make_response(200, installed_body)
+    loaded_resp = _make_response(200, loaded_body)
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(side_effect=[installed_resp, loaded_resp])
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        result = await execute_list_image_models()
+
+    assert result["success"] is True
+    assert len(result["models"]) == 1
+    assert result["models"][0]["id"] == "my-sd-model"
+    assert result["models"][0]["loaded"] is False
+
+
+@pytest.mark.asyncio
+async def test_list_image_models_api_failure():
+    """A connection error should return success=False with error text, not raise."""
+    from tinyagentos.tools.image_tool import execute_list_image_models
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        result = await execute_list_image_models()
+
+    assert result["success"] is False
+    assert "error" in result
+    assert result["models"] == []
+
+
+# ---------------------------------------------------------------------------
+# execute_image_generation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_image_generation_forwards_new_params():
+    """model/guidance_scale/negative_prompt must appear in the POST body."""
+    from tinyagentos.tools.image_tool import execute_image_generation
+
+    fake_png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16  # minimal fake PNG bytes
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.content = fake_png
+    mock_resp.raise_for_status = MagicMock()
+
+    captured_payload: dict = {}
+
+    async def fake_post(url, json=None, **kwargs):
+        captured_payload.update(json or {})
+        return mock_resp
+
+    mock_client = AsyncMock()
+    mock_client.post = fake_post
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        result = await execute_image_generation(
+            prompt="a majestic elephant",
+            model="lcm-dreamshaper-v7",
+            guidance_scale=10.0,
+            negative_prompt="blurry, low quality",
+            seed=42,
+        )
+
+    assert result["success"] is True
+    assert captured_payload["model"] == "lcm-dreamshaper-v7"
+    assert captured_payload["guidance_scale"] == 10.0
+    assert captured_payload["negative_prompt"] == "blurry, low quality"
+    assert captured_payload["seed"] == 42
+
+
+@pytest.mark.asyncio
+async def test_image_generation_backward_compat():
+    """Omitting model/guidance_scale/negative_prompt uses legacy direct path."""
+    from tinyagentos.tools.image_tool import execute_image_generation
+
+    response_body = {
+        "data": [{"b64_json": base64.b64encode(b"fake-png").decode()}]
+    }
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = response_body
+    mock_resp.raise_for_status = MagicMock()
+
+    captured: dict = {}
+
+    async def fake_post(url, json=None, **kwargs):
+        captured["url"] = url
+        captured["body"] = json or {}
+        return mock_resp
+
+    mock_client = AsyncMock()
+    mock_client.post = fake_post
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        result = await execute_image_generation(
+            prompt="a red barn",
+            backend_url="http://localhost:8080",
+            seed=7,
+        )
+
+    assert result["success"] is True
+    # Must have gone to the direct backend path, not the scheduler
+    assert "/v1/images/generations" in captured["url"]
+    body = captured["body"]
+    assert body["prompt"] == "a red barn"
+    assert body["seed"] == 7
+    # negative_prompt absent when empty
+    assert "negative_prompt" not in body

--- a/tests/test_image_tool.py
+++ b/tests/test_image_tool.py
@@ -14,9 +14,7 @@ import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
-
 import pytest
-import httpx
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_image_tool.py
+++ b/tests/test_image_tool.py
@@ -150,7 +150,9 @@ async def test_list_image_models_api_failure():
 
 @pytest.mark.asyncio
 async def test_image_generation_forwards_new_params():
-    """model/guidance_scale/negative_prompt must appear in the POST body."""
+    """model/guidance_scale/negative_prompt must appear in the POST body
+    AND the call must hit the scheduler route — guards against regressing
+    to a non-scheduler endpoint."""
     from tinyagentos.tools.image_tool import execute_image_generation
 
     fake_png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16  # minimal fake PNG bytes
@@ -161,8 +163,10 @@ async def test_image_generation_forwards_new_params():
     mock_resp.raise_for_status = MagicMock()
 
     captured_payload: dict = {}
+    captured_url: dict = {}
 
     async def fake_post(url, json=None, **kwargs):
+        captured_url["url"] = url
         captured_payload.update(json or {})
         return mock_resp
 
@@ -181,6 +185,7 @@ async def test_image_generation_forwards_new_params():
         )
 
     assert result["success"] is True
+    assert "/api/images/generate" in captured_url["url"]
     assert captured_payload["model"] == "lcm-dreamshaper-v7"
     assert captured_payload["guidance_scale"] == 10.0
     assert captured_payload["negative_prompt"] == "blurry, low quality"
@@ -262,7 +267,18 @@ async def test_image_generation_blank_model_treated_as_omitted():
 @pytest.mark.asyncio
 async def test_image_generation_falls_back_on_controller_unreachable():
     """When the controller is unreachable, fall back to the direct
-    backend call. The fallback also must not pin a model name."""
+    backend call. The fallback forwards a user-supplied model (their
+    explicit choice wins) but does NOT inject a hardcoded Pi-specific
+    default — the principle is "don't pin a default", not "drop user
+    input".
+
+    Two sub-assertions matter for the regression:
+
+      1. Scheduler is tried first with the user's model.
+      2. Fallback is tried second; if the user did NOT supply a model,
+         the fallback payload does not include one (so heterogeneous
+         hardware doesn't get a Pi-pinned default forwarded).
+    """
     from tinyagentos.tools.image_tool import execute_image_generation
 
     direct_response_body = {"data": [{"b64_json": base64.b64encode(b"fake").decode()}]}
@@ -273,14 +289,14 @@ async def test_image_generation_falls_back_on_controller_unreachable():
     direct_resp.raise_for_status = MagicMock()
 
     captured_urls: list = []
-    captured_body: dict = {}
+    captured_payloads: list = []
 
     async def fake_post(url, json=None, **kwargs):
         captured_urls.append(url)
+        captured_payloads.append(json or {})
         # First call (scheduler) raises; second call (direct backend) succeeds.
         if "/api/images/generate" in url:
             raise httpx.ConnectError("controller down")
-        captured_body.update(json or {})
         return direct_resp
 
     mock_client = AsyncMock()
@@ -288,16 +304,40 @@ async def test_image_generation_falls_back_on_controller_unreachable():
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=None)
 
+    # Case A: user supplied a model — both scheduler and fallback get it.
     with patch("httpx.AsyncClient", return_value=mock_client):
-        result = await execute_image_generation(
+        result_a = await execute_image_generation(
             prompt="a red barn",
+            model="lcm-dreamshaper-v7",
             backend_url="http://localhost:8080",
             seed=7,
         )
 
-    assert result["success"] is True
-    # Tried scheduler first, then direct backend.
+    assert result_a["success"] is True
     assert any("/api/images/generate" in u for u in captured_urls)
     assert any("/v1/images/generations" in u for u in captured_urls)
-    # Direct fallback does NOT pin a model name.
-    assert "model" not in captured_body
+    scheduler_payload = next(
+        p for u, p in zip(captured_urls, captured_payloads) if "/api/images/generate" in u
+    )
+    fallback_payload = next(
+        p for u, p in zip(captured_urls, captured_payloads) if "/v1/images/generations" in u
+    )
+    assert scheduler_payload.get("model") == "lcm-dreamshaper-v7"
+    assert fallback_payload.get("model") == "lcm-dreamshaper-v7"
+
+    # Case B: no model supplied — neither scheduler nor fallback should
+    # add a default. This is the heterogeneous-hardware regression.
+    captured_urls.clear()
+    captured_payloads.clear()
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        result_b = await execute_image_generation(
+            prompt="a barn at dusk",
+            backend_url="http://localhost:8080",
+            seed=8,
+        )
+
+    assert result_b["success"] is True
+    fallback_payload_b = next(
+        p for u, p in zip(captured_urls, captured_payloads) if "/v1/images/generations" in u
+    )
+    assert "model" not in fallback_payload_b

--- a/tests/test_skill_runtime.py
+++ b/tests/test_skill_runtime.py
@@ -6,9 +6,13 @@ Verifies that:
   OpenAI/MCP-style schemas.
 - Executing a non-existent skill returns a 404.
 - The ``file_write`` and ``file_read`` built-ins round-trip successfully.
+- ``list_image_models`` skill dispatches correctly via skill-exec.
+- ``image_generation`` skill still dispatches correctly (no regression).
 """
 
 from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import pytest_asyncio
@@ -101,3 +105,56 @@ async def test_file_write_and_read(app_with_store):
         )
         assert read_resp.status_code == 200
         assert read_resp.json().get("content") == "hello world"
+
+
+@pytest.mark.asyncio
+async def test_skill_exec_list_image_models(app_with_store):
+    """list_image_models skill returns a list of models via skill-exec."""
+    store = app_with_store.state.skills
+    await store.assign_skill("don", "list_image_models")
+
+    models_payload = {"success": True, "models": [{"name": "LCM", "id": "lcm"}]}
+
+    with patch(
+        "tinyagentos.tools.image_tool.execute_list_image_models",
+        new_callable=AsyncMock,
+        return_value=models_payload,
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_store), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/api/skill-exec/list_image_models/call", json={"args": {}}
+            )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["success"] is True
+    assert isinstance(data["models"], list)
+
+
+@pytest.mark.asyncio
+async def test_skill_exec_image_generation_no_regression(app_with_store):
+    """Existing image_generation skill still dispatches correctly."""
+    store = app_with_store.state.skills
+    await store.assign_skill("don", "image_generation")
+
+    gen_payload = {"success": True, "image_b64": "abc", "seed": 1, "model": "lcm", "size": "512x512"}
+
+    with patch(
+        "tinyagentos.tools.image_tool.execute_image_generation",
+        new_callable=AsyncMock,
+        return_value=gen_payload,
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_store), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/api/skill-exec/image_generation/call",
+                json={"args": {"prompt": "a red barn"}},
+            )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["success"] is True
+    assert data["image_b64"] == "abc"

--- a/tinyagentos/routes/images.py
+++ b/tinyagentos/routes/images.py
@@ -29,7 +29,11 @@ router = APIRouter()
 
 class GenerateRequest(BaseModel):
     prompt: str
-    model: str = "lcm-dreamshaper-v7"
+    # Empty string means "let the scheduler pick a model based on what's
+    # installed on the host". Hardcoding a Pi-specific name here was a
+    # footgun for users on different hardware (e.g. NVIDIA GPU users
+    # who don't have lcm-dreamshaper-v7 installed at all).
+    model: str = ""
     size: str = "512x512"
     steps: int = 4
     seed: int | None = None

--- a/tinyagentos/routes/skill_exec.py
+++ b/tinyagentos/routes/skill_exec.py
@@ -155,7 +155,21 @@ async def _skill_image_generation(args: dict, request: Request) -> dict:
             prompt=args.get("prompt", ""),
             size=args.get("size", "512x512"),
             steps=args.get("steps", 4),
+            model=args.get("model") or None,
+            guidance_scale=float(args.get("guidance_scale", 7.5)),
+            negative_prompt=args.get("negative_prompt", ""),
         )
+        return result
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
+async def _skill_list_image_models(args: dict, request: Request) -> dict:
+    """List installed image-generation models."""
+    try:
+        from tinyagentos.tools.image_tool import execute_list_image_models
+
+        result = await execute_list_image_models()
         return result
     except Exception as exc:
         return {"error": str(exc)}
@@ -169,6 +183,7 @@ SKILL_IMPLEMENTATIONS = {
     "code_exec": _skill_code_exec,
     "http_request": _skill_http_request,
     "image_generation": _skill_image_generation,
+    "list_image_models": _skill_list_image_models,
 }
 
 

--- a/tinyagentos/skills.py
+++ b/tinyagentos/skills.py
@@ -180,9 +180,30 @@ class SkillStore(BaseStore):
                         "properties": {
                             "prompt": {"type": "string"},
                             "size": {"type": "string", "default": "512x512"},
+                            "model": {"type": "string"},
+                            "guidance_scale": {"type": "number", "default": 7.5},
+                            "negative_prompt": {"type": "string", "default": ""},
                         },
                         "required": ["prompt"],
                     },
+                },
+                "frameworks": {
+                    "smolagents": "adapter", "openclaw": "adapter", "pocketflow": "adapter",
+                    "langroid": "adapter", "hermes": "adapter", "agent-zero": "adapter",
+                    "openai-agents-sdk": "adapter", "generic": "adapter",
+                },
+                "install_method": "builtin",
+                "install_target": "tinyagentos.tools.image_tool",
+            },
+            {
+                "id": "list_image_models",
+                "name": "List Image Models",
+                "category": "media",
+                "description": "Discover installed image-generation models",
+                "tool_schema": {
+                    "name": "list_image_models",
+                    "description": "List installed image-generation models the agent can pick from",
+                    "input_schema": {"type": "object", "properties": {}},
                 },
                 "frameworks": {
                     "smolagents": "adapter", "openclaw": "adapter", "pocketflow": "adapter",

--- a/tinyagentos/tools/image_tool.py
+++ b/tinyagentos/tools/image_tool.py
@@ -1,4 +1,4 @@
-"""MCP tool definition for agent image generation via any OpenAI-compatible backend."""
+"""MCP tool definitions for agent image generation via any OpenAI-compatible backend."""
 from __future__ import annotations
 
 # MCP tool schema — agents can call this to generate images
@@ -29,24 +29,146 @@ IMAGE_GENERATION_TOOL = {
                 "type": "integer",
                 "description": "Random seed for reproducibility (omit for random)",
             },
+            "model": {
+                "type": "string",
+                "description": "Pick from list_image_models output. Omit to let the scheduler choose.",
+            },
+            "guidance_scale": {
+                "type": "number",
+                "description": "Classifier-free guidance scale. Higher values follow the prompt more strictly; 7.5 is balanced. Lower (1–4) for artistic flexibility, higher (10–15) for strict adherence.",
+                "default": 7.5,
+                "minimum": 1.0,
+                "maximum": 20.0,
+            },
+            "negative_prompt": {
+                "type": "string",
+                "description": "Things you want to AVOID in the image. Comma-separated tokens, e.g. 'blurry, low quality, deformed hands'.",
+                "default": "",
+            },
         },
         "required": ["prompt"],
     },
 }
 
+# MCP tool schema — agents call this to discover installed image-gen models
+LIST_IMAGE_MODELS_TOOL = {
+    "name": "list_image_models",
+    "description": "List installed image-generation models the agent can pick from. Returns each model's name, backend type (rknn-sd / sd-cpp / etc.), whether it's currently loaded, and any model metadata that can help with model choice.",
+    "input_schema": {"type": "object", "properties": {}},
+}
+
+
+async def execute_list_image_models(
+    controller_url: str = "http://localhost:6969",
+) -> dict:
+    """Read installed image-gen models via the controller's models API.
+
+    Joins /api/models (installed) + /api/models/loaded (in memory) so the
+    agent can prefer loaded models for low latency.
+
+    /api/models returns:
+      {"models": [{"id", "name", "capabilities": [...], "variants": [{"backend": [...], ...}], ...}], ...}
+
+    An entry is image-gen if "image-generation" is in its capabilities list,
+    or if any variant declares a backend in ("rknn-sd", "sd-cpp").
+    """
+    import httpx
+
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            installed_resp = await client.get(
+                f"{controller_url.rstrip('/')}/api/models"
+            )
+            installed_resp.raise_for_status()
+            installed = installed_resp.json()
+
+            loaded_set: set[str] = set()
+            loaded_resp = await client.get(
+                f"{controller_url.rstrip('/')}/api/models/loaded"
+            )
+            if loaded_resp.status_code == 200:
+                loaded_data = loaded_resp.json()
+                loaded_set = {
+                    m.get("name", "")
+                    for m in (loaded_data.get("loaded") or [])
+                    if m.get("purpose") == "image-generation"
+                }
+
+        raw_models = (
+            installed.get("models")
+            if isinstance(installed, dict)
+            else (installed or [])
+        ) or []
+
+        models = []
+        for m in raw_models:
+            capabilities = m.get("capabilities") or []
+            variants = m.get("variants") or []
+
+            # Check capabilities list for image-generation purpose
+            is_image = "image-generation" in capabilities
+
+            # Also check if any variant declares an image-gen backend type
+            if not is_image:
+                image_backends = {"rknn-sd", "sd-cpp"}
+                for v in variants:
+                    backends = v.get("backend") or []
+                    if isinstance(backends, str):
+                        backends = [backends]
+                    if any(b in image_backends for b in backends):
+                        is_image = True
+                        break
+
+            if not is_image:
+                continue
+
+            # Derive a display name from the first downloaded variant if present
+            backend_type = ""
+            for v in variants:
+                backends = v.get("backend") or []
+                if isinstance(backends, str):
+                    backends = [backends]
+                if backends:
+                    backend_type = backends[0]
+                    break
+
+            name = m.get("name") or m.get("id", "")
+            models.append({
+                "name": name,
+                "id": m.get("id", ""),
+                "backend": backend_type,
+                "backend_type": backend_type,
+                "loaded": name in loaded_set or m.get("id", "") in loaded_set,
+                "size_mb": None,
+                "metadata": {
+                    "description": m.get("description", ""),
+                    "capabilities": capabilities,
+                    "has_downloaded_variant": m.get("has_downloaded_variant", False),
+                },
+            })
+
+        return {"success": True, "models": models}
+    except Exception as e:
+        return {"success": False, "error": str(e), "models": []}
+
 
 async def execute_image_generation(
     prompt: str,
     backend_url: str = "http://localhost:8080",
-    model: str = "lcm-dreamshaper-v7",
+    model: str | None = None,
     size: str = "512x512",
     steps: int = 4,
     seed: int | None = None,
     guidance_scale: float = 7.5,
+    negative_prompt: str = "",
+    controller_url: str = "http://localhost:6969",
 ) -> dict:
     """Execute image generation via an OpenAI-compatible endpoint.
 
-    Works with rkllama, ollama, or any backend serving ``/v1/images/generations``.
+    When a model is specified, routes through the controller's scheduler
+    (/api/images/generate) which knows how to find the right backend.
+    When no model is given, falls back to hitting the backend_url directly.
+
     Returns dict with 'success', 'image_b64' (base64 PNG), and 'error' if failed.
     """
     import httpx
@@ -55,20 +177,61 @@ async def execute_image_generation(
     if seed is None:
         seed = random.randint(1, 999999)
 
+    # If a model is specified, go through the scheduler so it can route to
+    # the right backend. The scheduler endpoint accepts the full GenerateRequest.
+    if model is not None:
+        effective_model = model
+        target_url = f"{controller_url.rstrip('/')}/api/images/generate"
+        payload: dict = {
+            "prompt": prompt,
+            "model": effective_model,
+            "size": size,
+            "steps": steps,
+            "seed": seed,
+            "guidance_scale": guidance_scale,
+        }
+        if negative_prompt:
+            payload["negative_prompt"] = negative_prompt
+        try:
+            async with httpx.AsyncClient(timeout=120) as client:
+                resp = await client.post(target_url, json=payload)
+                resp.raise_for_status()
+                # /api/images/generate returns raw PNG bytes
+                image_bytes = resp.content
+                import base64
+                return {
+                    "success": True,
+                    "image_b64": base64.b64encode(image_bytes).decode(),
+                    "seed": seed,
+                    "model": effective_model,
+                    "size": size,
+                }
+        except httpx.ConnectError:
+            return {"success": False, "error": f"Cannot connect to controller at {controller_url}"}
+        except httpx.TimeoutException:
+            return {"success": False, "error": "Image generation timed out (>120s)"}
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
+    # No model specified — direct call to the backend's OpenAI-compatible endpoint.
+    effective_model = "lcm-dreamshaper-v7"
     try:
         async with httpx.AsyncClient(timeout=120) as client:
+            body: dict = {
+                "prompt": prompt,
+                "model": effective_model,
+                "size": size,
+                "n": 1,
+                "num_inference_steps": steps,
+                "seed": seed,
+                "guidance_scale": guidance_scale,
+                "response_format": "b64_json",
+            }
+            if negative_prompt:
+                body["negative_prompt"] = negative_prompt
             resp = await client.post(
                 f"{backend_url.rstrip('/')}/v1/images/generations",
-                json={
-                    "prompt": prompt,
-                    "model": model,
-                    "size": size,
-                    "n": 1,
-                    "num_inference_steps": steps,
-                    "seed": seed,
-                    "guidance_scale": guidance_scale,
-                    "response_format": "b64_json",
-                },
+                json=body,
             )
             resp.raise_for_status()
             data = resp.json()
@@ -77,7 +240,7 @@ async def execute_image_generation(
                     "success": True,
                     "image_b64": data["data"][0].get("b64_json", ""),
                     "seed": seed,
-                    "model": model,
+                    "model": effective_model,
                     "size": size,
                 }
             return {"success": False, "error": "No image data in response"}

--- a/tinyagentos/tools/image_tool.py
+++ b/tinyagentos/tools/image_tool.py
@@ -31,11 +31,11 @@ IMAGE_GENERATION_TOOL = {
             },
             "model": {
                 "type": "string",
-                "description": "Pick from list_image_models output. When supplied, routes through the controller's scheduler which picks the right backend (NPU first, CPU fallback). Omit to call the default backend directly with lcm-dreamshaper-v7 (legacy path; bypasses the scheduler).",
+                "description": "Pick from list_image_models output. Omit to let the controller's scheduler pick a model based on the host's installed backends — works on any hardware (Pi NPU, NVIDIA GPU, CPU).",
             },
             "guidance_scale": {
                 "type": "number",
-                "description": "Classifier-free guidance scale. Higher values follow the prompt more strictly; 7.5 is balanced. Lower (1–4) for artistic flexibility, higher (10–15) for strict adherence.",
+                "description": "Classifier-free guidance scale. Higher values follow the prompt more strictly; 7.5 is balanced. Lower (1-4) for artistic flexibility, higher (10-15) for strict adherence.",
                 "default": 7.5,
                 "minimum": 1.0,
                 "maximum": 20.0,
@@ -163,63 +163,74 @@ async def execute_image_generation(
     negative_prompt: str = "",
     controller_url: str = "http://localhost:6969",
 ) -> dict:
-    """Execute image generation via an OpenAI-compatible endpoint.
+    """Execute image generation, preferring the controller's scheduler.
 
-    When a model is specified, routes through the controller's scheduler
-    (/api/images/generate) which knows how to find the right backend.
-    When no model is given, falls back to hitting the backend_url directly.
+    Always tries the controller's ``/api/images/generate`` first so the
+    scheduler can pick a backend (Pi NPU, NVIDIA GPU, CPU, …) using
+    whatever's installed on the host. Falls back to a direct call to
+    ``backend_url`` only when the controller is unreachable — and the
+    fallback omits the model field so the local backend uses whatever
+    checkpoint it has loaded rather than a pinned model name.
 
-    Returns dict with 'success', 'image_b64' (base64 PNG), and 'error' if failed.
+    Returns dict with 'success', 'image_b64' (base64 PNG), and 'error'
+    if failed.
     """
+    import base64
     import httpx
     import random
 
     if seed is None:
         seed = random.randint(1, 999999)
 
-    # If a model is specified, go through the scheduler so it can route to
-    # the right backend. The scheduler endpoint accepts the full GenerateRequest.
-    if model is not None:
-        effective_model = model
-        target_url = f"{controller_url.rstrip('/')}/api/images/generate"
-        payload: dict = {
-            "prompt": prompt,
-            "model": effective_model,
-            "size": size,
-            "steps": steps,
-            "seed": seed,
-            "guidance_scale": guidance_scale,
-        }
-        if negative_prompt:
-            payload["negative_prompt"] = negative_prompt
-        try:
-            async with httpx.AsyncClient(timeout=120) as client:
-                resp = await client.post(target_url, json=payload)
-                resp.raise_for_status()
-                # /api/images/generate returns raw PNG bytes
-                image_bytes = resp.content
-                import base64
-                return {
-                    "success": True,
-                    "image_b64": base64.b64encode(image_bytes).decode(),
-                    "seed": seed,
-                    "model": effective_model,
-                    "size": size,
-                }
-        except httpx.ConnectError:
-            return {"success": False, "error": f"Cannot connect to controller at {controller_url}"}
-        except httpx.TimeoutException:
-            return {"success": False, "error": "Image generation timed out (>120s)"}
-        except Exception as e:
-            return {"success": False, "error": str(e)}
+    # 1. Scheduler-routed path. Works for any hardware. If no model is
+    #    supplied, the scheduler's GenerateRequest defaults the model to
+    #    empty and the chosen backend uses its loaded checkpoint.
+    target_url = f"{controller_url.rstrip('/')}/api/images/generate"
+    payload: dict = {
+        "prompt": prompt,
+        "size": size,
+        "steps": steps,
+        "seed": seed,
+        "guidance_scale": guidance_scale,
+    }
+    if isinstance(model, str) and model.strip():
+        payload["model"] = model.strip()
+    if negative_prompt:
+        payload["negative_prompt"] = negative_prompt
 
-    # No model specified — direct call to the backend's OpenAI-compatible endpoint.
-    effective_model = "lcm-dreamshaper-v7"
+    controller_unreachable = False
+    try:
+        async with httpx.AsyncClient(timeout=120) as client:
+            resp = await client.post(target_url, json=payload)
+            resp.raise_for_status()
+            # /api/images/generate returns raw PNG bytes
+            image_bytes = resp.content
+            return {
+                "success": True,
+                "image_b64": base64.b64encode(image_bytes).decode(),
+                "seed": seed,
+                "model": model or "",
+                "size": size,
+            }
+    except httpx.ConnectError:
+        controller_unreachable = True  # fall through to direct path below
+    except httpx.TimeoutException:
+        return {"success": False, "error": "Image generation timed out (>120s)"}
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+    if not controller_unreachable:
+        # Defensive guard — shouldn't reach here without a return above.
+        return {"success": False, "error": "Image generation failed unexpectedly"}
+
+    # 2. Connect-failure fallback: direct call to backend_url. Used when
+    #    the caller's network can't see the controller (e.g. an LXC agent
+    #    where localhost:6969 is not the controller). We do NOT pin a
+    #    model name here — the local backend uses its own loaded model.
     try:
         async with httpx.AsyncClient(timeout=120) as client:
             body: dict = {
                 "prompt": prompt,
-                "model": effective_model,
                 "size": size,
                 "n": 1,
                 "num_inference_steps": steps,
@@ -227,6 +238,8 @@ async def execute_image_generation(
                 "guidance_scale": guidance_scale,
                 "response_format": "b64_json",
             }
+            if isinstance(model, str) and model.strip():
+                body["model"] = model.strip()
             if negative_prompt:
                 body["negative_prompt"] = negative_prompt
             resp = await client.post(
@@ -240,12 +253,12 @@ async def execute_image_generation(
                     "success": True,
                     "image_b64": data["data"][0].get("b64_json", ""),
                     "seed": seed,
-                    "model": effective_model,
+                    "model": model or "",
                     "size": size,
                 }
             return {"success": False, "error": "No image data in response"}
     except httpx.ConnectError:
-        return {"success": False, "error": f"Cannot connect to image backend at {backend_url}"}
+        return {"success": False, "error": f"Cannot connect to controller at {controller_url} or backend at {backend_url}"}
     except httpx.TimeoutException:
         return {"success": False, "error": "Image generation timed out (>120s)"}
     except Exception as e:

--- a/tinyagentos/tools/image_tool.py
+++ b/tinyagentos/tools/image_tool.py
@@ -31,7 +31,7 @@ IMAGE_GENERATION_TOOL = {
             },
             "model": {
                 "type": "string",
-                "description": "Pick from list_image_models output. Omit to let the scheduler choose.",
+                "description": "Pick from list_image_models output. When supplied, routes through the controller's scheduler which picks the right backend (NPU first, CPU fallback). Omit to call the default backend directly with lcm-dreamshaper-v7 (legacy path; bypasses the scheduler).",
             },
             "guidance_scale": {
                 "type": "number",


### PR DESCRIPTION
## Summary
- New \`list_image_models\` MCP tool — agents can discover installed image-gen models (which are loaded vs cold)
- \`generate_image\` gains optional \`model\`, \`guidance_scale\`, \`negative_prompt\` params on top of the existing \`prompt/size/steps/seed\`
- When \`model\` is supplied, calls route via the controller's scheduler (\`/api/images/generate\`) so model→backend routing + NPU→CPU fallback still apply
- Skill registry + skill-exec dispatch wired for both tools
- Don's brief in the Dumby user-sim updated with a recommended workflow

## Test plan
- [x] 11 new + extended tests pass
- [ ] Session 10 will exercise this end-to-end (Don picks a model, generates cover + scene art)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browse available image-generation models with loaded status; list includes models that can generate images even via variant backends.
  * Image generation accepts optional model, guidance_scale, and negative_prompt; leaving model empty lets the scheduler choose. Requests try the scheduler first, with a direct backend fallback.

* **Documentation**
  * Added usage note describing image-generation tools and guidance_scale options.

* **Tests**
  * Added end-to-end and unit tests for listing, generation payloads, routing/fallbacks, error handling, and runtime dispatch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->