### PR TITLE
feat(browser): SSRF guard + proxy endpoint shell (PR 2/10)

### DIFF
--- a/tests/routes/desktop_browser/test_csp.py
+++ b/tests/routes/desktop_browser/test_csp.py
@@ -1,0 +1,77 @@
+"""Tests for CSP injection helper used on proxied responses."""
+from __future__ import annotations
+
+
+class TestProxiedResponseCsp:
+    def test_returns_a_string(self):
+        from tinyagentos.routes.desktop_browser.csp import proxied_response_csp
+
+        csp = proxied_response_csp()
+        assert isinstance(csp, str)
+        assert len(csp) > 0
+
+    def test_blocks_default_src_to_self_only(self):
+        """The proxied page must not be able to load resources from
+        arbitrary origins (those would bypass our proxy and leak
+        the user's IP). default-src 'self' enforces this."""
+        from tinyagentos.routes.desktop_browser.csp import proxied_response_csp
+
+        csp = proxied_response_csp()
+        assert "default-src 'self'" in csp
+
+    def test_blocks_inline_scripts(self):
+        """Strict CSP for SCRIPTS: no unsafe-inline, no unsafe-eval in
+        the script-src directive. Style-src may permit 'unsafe-inline'
+        because CSS isn't a meaningful XSS vector and inline styles are
+        universal in real-world HTML — blocking them would render most
+        proxied pages unstyled. The check is therefore scoped to the
+        script-src directive specifically."""
+        from tinyagentos.routes.desktop_browser.csp import proxied_response_csp
+
+        csp = proxied_response_csp()
+        # Find the script-src directive (between its name and the next ;)
+        directives = {
+            d.strip().split(" ", 1)[0]: d.strip()
+            for d in csp.split(";")
+            if d.strip()
+        }
+        script_src = directives.get("script-src", "")
+        assert script_src, "script-src directive must exist"
+        assert "'unsafe-inline'" not in script_src
+        assert "'unsafe-eval'" not in script_src
+
+    def test_disables_form_action(self):
+        """Proxied page form submissions must go to 'self' (back through
+        us), not to arbitrary endpoints — otherwise the proxied site
+        could submit the user's data to a third party that bypasses our
+        cookie jar."""
+        from tinyagentos.routes.desktop_browser.csp import proxied_response_csp
+
+        csp = proxied_response_csp()
+        assert "form-action 'self'" in csp
+
+    def test_blocks_object_src(self):
+        """object-src 'none' must be set explicitly. Browser fallback to
+        default-src is inconsistent across versions, and we want to
+        block all plugin embeds (Flash, Java, legacy <object> tags)
+        regardless of source."""
+        from tinyagentos.routes.desktop_browser.csp import proxied_response_csp
+
+        csp = proxied_response_csp()
+        assert "object-src 'none'" in csp
+
+    def test_locks_base_uri_to_self(self):
+        """base-uri 'self' prevents a malicious <base href> tag in the
+        proxied page from redirecting relative URL resolution to an
+        attacker-controlled origin (which would bypass our rewriter)."""
+        from tinyagentos.routes.desktop_browser.csp import proxied_response_csp
+
+        csp = proxied_response_csp()
+        assert "base-uri 'self'" in csp
+
+    def test_no_dangling_directive_separator(self):
+        from tinyagentos.routes.desktop_browser.csp import proxied_response_csp
+
+        csp = proxied_response_csp()
+        assert not csp.endswith("; ")
+        assert not csp.endswith(";")

--- a/tests/routes/desktop_browser/test_csp.py
+++ b/tests/routes/desktop_browser/test_csp.py
@@ -69,6 +69,31 @@ class TestProxiedResponseCsp:
         csp = proxied_response_csp()
         assert "base-uri 'self'" in csp
 
+    def test_locks_connect_src_to_self(self):
+        """connect-src 'self' so proxied JS XHR/fetch/EventSource/WebSocket
+        can only reach the proxy origin (us). Browser fallback for
+        connect-src has historically been inconsistent."""
+        from tinyagentos.routes.desktop_browser.csp import proxied_response_csp
+
+        csp = proxied_response_csp()
+        assert "connect-src 'self'" in csp
+
+    def test_locks_worker_src_to_self(self):
+        """worker-src 'self' blocks proxied pages from registering
+        service workers / web workers at third-party origins."""
+        from tinyagentos.routes.desktop_browser.csp import proxied_response_csp
+
+        csp = proxied_response_csp()
+        assert "worker-src 'self'" in csp
+
+    def test_locks_frame_src_to_self(self):
+        """frame-src 'self' so proxied pages can only iframe other
+        proxied content (sub-frames also routed through us)."""
+        from tinyagentos.routes.desktop_browser.csp import proxied_response_csp
+
+        csp = proxied_response_csp()
+        assert "frame-src 'self'" in csp
+
     def test_no_dangling_directive_separator(self):
         from tinyagentos.routes.desktop_browser.csp import proxied_response_csp
 

--- a/tests/routes/desktop_browser/test_proxy_shell.py
+++ b/tests/routes/desktop_browser/test_proxy_shell.py
@@ -68,8 +68,10 @@ class TestSsrfGate:
 
         # Resolve a controlled hostname to an internal IP we shouldn't reveal
         with patch(
-            "tinyagentos.routes.desktop_browser.ssrf.socket.gethostbyname_ex",
-            return_value=("evil.test", [], ["192.168.42.99"]),
+            "tinyagentos.routes.desktop_browser.ssrf.socket.getaddrinfo",
+            return_value=[
+                (2, 1, 6, "", ("192.168.42.99", 0)),
+            ],
         ):
             resp = await client.get(
                 "/api/desktop/browser/proxy",
@@ -106,8 +108,10 @@ class TestNotImplementedStub:
         # example.com is real and public so SSRF passes, but PR 2
         # stubs the actual fetch to keep the deliverable focused.
         with patch(
-            "tinyagentos.routes.desktop_browser.ssrf.socket.gethostbyname_ex",
-            return_value=("example.com", [], ["93.184.216.34"]),
+            "tinyagentos.routes.desktop_browser.ssrf.socket.getaddrinfo",
+            return_value=[
+                (2, 1, 6, "", ("93.184.216.34", 0)),  # AF_INET
+            ],
         ):
             resp = await client.get(
                 "/api/desktop/browser/proxy",

--- a/tests/routes/desktop_browser/test_proxy_shell.py
+++ b/tests/routes/desktop_browser/test_proxy_shell.py
@@ -1,0 +1,97 @@
+"""Tests for the /api/desktop/browser/proxy endpoint shell.
+
+PR 2 lands the security gate (auth + SSRF check). The endpoint
+returns 501 Not Implemented for valid URLs because the actual fetch +
+rewriter + cookie jar logic lands in PR 3.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest.mark.asyncio
+class TestAuth:
+    async def test_unauthenticated_request_rejected(self, app):
+        # Build a fresh client with no session cookie — auth middleware must
+        # reject the request before it reaches the route handler.
+        transport = ASGITransport(app=app)
+        async with AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as c:
+            resp = await c.get(
+                "/api/desktop/browser/proxy",
+                params={"profile_id": "personal", "url": "http://example.com/"},
+            )
+        assert resp.status_code == 401
+
+    async def test_authenticated_request_passes_auth_gate(self, client):
+        # `client` already carries a valid taos_session cookie — proves
+        # auth gate passes. Response will be SSRF check or 501, never 401.
+        resp = await client.get(
+            "/api/desktop/browser/proxy",
+            params={"profile_id": "personal", "url": "http://example.com/"},
+        )
+        assert resp.status_code != 401
+
+
+@pytest.mark.asyncio
+class TestSsrfGate:
+    async def test_url_failing_ssrf_returns_403(self, client):
+        resp = await client.get(
+            "/api/desktop/browser/proxy",
+            params={"profile_id": "personal", "url": "http://127.0.0.1/admin"},
+        )
+        assert resp.status_code == 403
+        body = resp.json()
+        assert "error" in body
+
+    async def test_invalid_scheme_returns_403(self, client):
+        resp = await client.get(
+            "/api/desktop/browser/proxy",
+            params={"profile_id": "personal", "url": "file:///etc/passwd"},
+        )
+        assert resp.status_code == 403
+        body = resp.json()
+        assert "error" in body
+
+
+@pytest.mark.asyncio
+class TestParameterValidation:
+    async def test_missing_url_returns_422(self, client):
+        resp = await client.get(
+            "/api/desktop/browser/proxy",
+            params={"profile_id": "personal"},
+        )
+        # FastAPI returns 422 for missing required query params
+        assert resp.status_code == 422
+
+    async def test_missing_profile_returns_422(self, client):
+        resp = await client.get(
+            "/api/desktop/browser/proxy",
+            params={"url": "http://example.com/"},
+        )
+        assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+class TestNotImplementedStub:
+    async def test_valid_request_returns_501(self, client):
+        # example.com is real and public so SSRF passes, but PR 2
+        # stubs the actual fetch to keep the deliverable focused.
+        with patch(
+            "tinyagentos.routes.desktop_browser.ssrf.socket.gethostbyname_ex",
+            return_value=("example.com", [], ["93.184.216.34"]),
+        ):
+            resp = await client.get(
+                "/api/desktop/browser/proxy",
+                params={"profile_id": "personal", "url": "http://example.com/"},
+            )
+        assert resp.status_code == 501
+        body = resp.json()
+        assert "error" in body
+        # Body must mention PR 3 so anyone hitting this in early dev
+        # knows where the fetch logic actually lands.
+        assert "PR 3" in body["error"] or "not yet implemented" in body["error"].lower()

--- a/tests/routes/desktop_browser/test_proxy_shell.py
+++ b/tests/routes/desktop_browser/test_proxy_shell.py
@@ -57,6 +57,30 @@ class TestSsrfGate:
         body = resp.json()
         assert "error" in body
 
+    async def test_403_response_does_not_leak_resolved_ip(self, client):
+        """Defence against LAN enumeration via DNS-pinned hostnames.
+
+        A remote attacker who controls a hostname can DNS-pin it to
+        arbitrary internal IPs. The 403 response body must not echo the
+        resolved IP back, or the attacker can read internal LAN topology.
+        """
+        from unittest.mock import patch
+
+        # Resolve a controlled hostname to an internal IP we shouldn't reveal
+        with patch(
+            "tinyagentos.routes.desktop_browser.ssrf.socket.gethostbyname_ex",
+            return_value=("evil.test", [], ["192.168.42.99"]),
+        ):
+            resp = await client.get(
+                "/api/desktop/browser/proxy",
+                params={"profile_id": "personal", "url": "http://evil.test/"},
+            )
+
+        assert resp.status_code == 403
+        body = resp.json()
+        assert "192.168.42.99" not in str(body)
+        assert "192.168" not in str(body)  # cover variants
+
 
 @pytest.mark.asyncio
 class TestParameterValidation:

--- a/tests/routes/desktop_browser/test_ssrf.py
+++ b/tests/routes/desktop_browser/test_ssrf.py
@@ -1,0 +1,165 @@
+"""Tests for SSRF guard — proves the host blocklist + redirect re-resolution."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+
+class TestUrlScheme:
+    def test_rejects_non_http_scheme(self):
+        from tinyagentos.routes.desktop_browser.ssrf import (
+            SsrfBlockedError,
+            validate_url_or_raise,
+        )
+
+        for bad in ("file:///etc/passwd", "gopher://x.test/", "javascript:alert(1)", "data:text/html,xx"):
+            with pytest.raises(SsrfBlockedError, match="scheme"):
+                validate_url_or_raise(bad)
+
+    def test_accepts_http_and_https(self):
+        from tinyagentos.routes.desktop_browser.ssrf import validate_url_or_raise
+
+        # Public IPs resolve fine and pass — using example.com which is RFC 2606
+        with patch(
+            "tinyagentos.routes.desktop_browser.ssrf.socket.gethostbyname_ex",
+            return_value=("example.com", [], ["93.184.216.34"]),
+        ):
+            validate_url_or_raise("http://example.com/")
+            validate_url_or_raise("https://example.com/")
+
+
+class TestPrivateAddressRejection:
+    @pytest.mark.parametrize("addr", [
+        "10.0.0.1",
+        "172.16.0.1",
+        "192.168.1.1",
+        "127.0.0.1",
+        "169.254.169.254",  # AWS metadata service
+        "0.0.0.0",
+        "224.0.0.1",        # multicast
+        "255.255.255.255",  # broadcast
+        "100.64.0.1",       # RFC 6598 CGNAT (start of range)
+        "100.127.255.254",  # RFC 6598 CGNAT (near end of range)
+    ])
+    def test_rejects_ipv4_blocklisted(self, addr):
+        from tinyagentos.routes.desktop_browser.ssrf import (
+            SsrfBlockedError,
+            validate_resolved_addr,
+        )
+
+        with pytest.raises(SsrfBlockedError):
+            validate_resolved_addr(addr)
+
+    @pytest.mark.parametrize("addr", [
+        "::1",
+        "fc00::1",        # ULA
+        "fe80::1",        # link-local
+        "ff02::1",        # multicast
+        "::ffff:127.0.0.1",  # IPv4-mapped loopback
+        "::ffff:10.0.0.1",   # IPv4-mapped RFC1918
+    ])
+    def test_rejects_ipv6_blocklisted(self, addr):
+        from tinyagentos.routes.desktop_browser.ssrf import (
+            SsrfBlockedError,
+            validate_resolved_addr,
+        )
+
+        with pytest.raises(SsrfBlockedError):
+            validate_resolved_addr(addr)
+
+    @pytest.mark.parametrize("addr", [
+        "8.8.8.8",
+        "1.1.1.1",
+        "93.184.216.34",   # example.com
+        "2001:4860:4860::8888",  # public IPv6
+    ])
+    def test_accepts_public(self, addr):
+        from tinyagentos.routes.desktop_browser.ssrf import validate_resolved_addr
+
+        validate_resolved_addr(addr)  # must not raise
+
+
+class TestHostnameRejection:
+    @pytest.mark.parametrize("host", [
+        "anything.local",
+        "host.onion",
+        "deeper.subdomain.local",
+    ])
+    def test_rejects_local_and_onion_tlds(self, host):
+        from tinyagentos.routes.desktop_browser.ssrf import (
+            SsrfBlockedError,
+            validate_url_or_raise,
+        )
+
+        with pytest.raises(SsrfBlockedError, match="hostname"):
+            validate_url_or_raise(f"http://{host}/")
+
+
+class TestEncodedIpAddresses:
+    """Decimal/octal/hex encoded IP literals must be parsed and rejected."""
+
+    @pytest.mark.parametrize("encoded", [
+        "2130706433",        # decimal for 127.0.0.1
+        "0x7f000001",        # hex for 127.0.0.1
+        "017700000001",      # octal for 127.0.0.1
+    ])
+    def test_rejects_encoded_loopback(self, encoded):
+        from tinyagentos.routes.desktop_browser.ssrf import (
+            SsrfBlockedError,
+            validate_url_or_raise,
+        )
+
+        with pytest.raises(SsrfBlockedError):
+            validate_url_or_raise(f"http://{encoded}/")
+
+    @pytest.mark.parametrize("encoded", [
+        "1681915905",        # decimal for 100.64.0.1 (CGNAT)
+        "0x64400001",        # hex for 100.64.0.1
+    ])
+    def test_rejects_encoded_cgnat(self, encoded):
+        from tinyagentos.routes.desktop_browser.ssrf import (
+            SsrfBlockedError,
+            validate_url_or_raise,
+        )
+
+        with pytest.raises(SsrfBlockedError):
+            validate_url_or_raise(f"http://{encoded}/")
+
+
+class TestDnsResolutionFailure:
+    def test_unresolvable_host_raises(self):
+        from tinyagentos.routes.desktop_browser.ssrf import (
+            SsrfBlockedError,
+            validate_url_or_raise,
+        )
+
+        # Use a hostname that will fail DNS — patching to simulate
+        import socket
+
+        with patch(
+            "tinyagentos.routes.desktop_browser.ssrf.socket.gethostbyname_ex",
+            side_effect=socket.gaierror("name resolution failed"),
+        ):
+            with pytest.raises(SsrfBlockedError, match="resolve"):
+                validate_url_or_raise("http://does-not-exist-anywhere.test/")
+
+    def test_multi_record_host_must_pass_all(self):
+        """A host that resolves to multiple IPs must be rejected if ANY is blocked.
+
+        Defends against DNS pinning attacks where a hostname returns one
+        public IP and one private IP — a naive implementation might fetch
+        the public one but a re-resolve at TCP-connect time could hit the
+        private one.
+        """
+        from tinyagentos.routes.desktop_browser.ssrf import (
+            SsrfBlockedError,
+            validate_url_or_raise,
+        )
+
+        with patch(
+            "tinyagentos.routes.desktop_browser.ssrf.socket.gethostbyname_ex",
+            return_value=("evil.test", [], ["8.8.8.8", "127.0.0.1"]),
+        ):
+            with pytest.raises(SsrfBlockedError):
+                validate_url_or_raise("http://evil.test/")

--- a/tests/routes/desktop_browser/test_ssrf.py
+++ b/tests/routes/desktop_browser/test_ssrf.py
@@ -58,6 +58,8 @@ class TestPrivateAddressRejection:
         "ff02::1",        # multicast
         "::ffff:127.0.0.1",  # IPv4-mapped loopback
         "::ffff:10.0.0.1",   # IPv4-mapped RFC1918
+        "fec0::1",        # RFC 3879 deprecated site-local (still on legacy gear)
+        "feff::1",        # end of fec0::/10 range
     ])
     def test_rejects_ipv6_blocklisted(self, addr):
         from tinyagentos.routes.desktop_browser.ssrf import (

--- a/tests/routes/desktop_browser/test_ssrf.py
+++ b/tests/routes/desktop_browser/test_ssrf.py
@@ -22,8 +22,10 @@ class TestUrlScheme:
 
         # Public IPs resolve fine and pass — using example.com which is RFC 2606
         with patch(
-            "tinyagentos.routes.desktop_browser.ssrf.socket.gethostbyname_ex",
-            return_value=("example.com", [], ["93.184.216.34"]),
+            "tinyagentos.routes.desktop_browser.ssrf.socket.getaddrinfo",
+            return_value=[
+                (2, 1, 6, "", ("93.184.216.34", 0)),  # AF_INET
+            ],
         ):
             validate_url_or_raise("http://example.com/")
             validate_url_or_raise("https://example.com/")
@@ -87,8 +89,12 @@ class TestHostnameRejection:
         "anything.local",
         "host.onion",
         "deeper.subdomain.local",
+        "router.home",
+        "wiki.corp",
+        "nas.lan",
+        "mail.intranet",
     ])
-    def test_rejects_local_and_onion_tlds(self, host):
+    def test_rejects_internal_network_tlds(self, host):
         from tinyagentos.routes.desktop_browser.ssrf import (
             SsrfBlockedError,
             validate_url_or_raise,
@@ -140,7 +146,7 @@ class TestDnsResolutionFailure:
         import socket
 
         with patch(
-            "tinyagentos.routes.desktop_browser.ssrf.socket.gethostbyname_ex",
+            "tinyagentos.routes.desktop_browser.ssrf.socket.getaddrinfo",
             side_effect=socket.gaierror("name resolution failed"),
         ):
             with pytest.raises(SsrfBlockedError, match="resolve"):
@@ -160,8 +166,28 @@ class TestDnsResolutionFailure:
         )
 
         with patch(
-            "tinyagentos.routes.desktop_browser.ssrf.socket.gethostbyname_ex",
-            return_value=("evil.test", [], ["8.8.8.8", "127.0.0.1"]),
+            "tinyagentos.routes.desktop_browser.ssrf.socket.getaddrinfo",
+            return_value=[
+                (2, 1, 6, "", ("8.8.8.8", 0)),
+                (2, 1, 6, "", ("127.0.0.1", 0)),
+            ],
         ):
             with pytest.raises(SsrfBlockedError):
                 validate_url_or_raise("http://evil.test/")
+
+    def test_rejects_when_only_ipv6_resolves_to_private(self):
+        """Defends against DNS records that mix public IPv4 with private IPv6."""
+        from tinyagentos.routes.desktop_browser.ssrf import (
+            SsrfBlockedError,
+            validate_url_or_raise,
+        )
+
+        with patch(
+            "tinyagentos.routes.desktop_browser.ssrf.socket.getaddrinfo",
+            return_value=[
+                (2, 1, 6, "", ("8.8.8.8", 0)),         # public IPv4
+                (10, 1, 6, "", ("::1", 0, 0, 0)),       # private IPv6 (loopback)
+            ],
+        ):
+            with pytest.raises(SsrfBlockedError):
+                validate_url_or_raise("http://dual-stack.test/")

--- a/tinyagentos/routes/desktop_browser/__init__.py
+++ b/tinyagentos/routes/desktop_browser/__init__.py
@@ -8,3 +8,7 @@ from __future__ import annotations
 from fastapi import APIRouter
 
 router = APIRouter()
+
+# Side-effect import: registers GET /api/desktop/browser/proxy on `router`.
+# Must come AFTER `router` is defined.
+from tinyagentos.routes.desktop_browser import proxy as _proxy  # noqa: E402,F401

--- a/tinyagentos/routes/desktop_browser/csp.py
+++ b/tinyagentos/routes/desktop_browser/csp.py
@@ -1,0 +1,61 @@
+"""Content-Security-Policy headers for proxied responses.
+
+Every page served through the proxy is sandboxed by a strict CSP so
+that the proxied site's JavaScript cannot:
+
+- Reach our own (taOS) APIs from inside the proxied origin
+- Submit forms to third parties (bypassing our cookie jar)
+- Load resources directly from third-party origins (leaking the user's
+  real IP and bypassing our proxy)
+
+`default-src 'self'` constrains the proxied page to only load
+resources from the proxy origin (us). All other directives inherit
+this default unless overridden. `form-action 'self'` ensures form
+submissions also stay within the proxy.
+
+The CSP is applied by PR 3's proxy fetch implementation when it
+returns the rewritten HTML. PR 2 only provides this builder so the
+test surface lands ahead of the consumer.
+"""
+from __future__ import annotations
+
+
+_DIRECTIVES = (
+    # default-src is the catch-all; everything else inherits unless
+    # explicitly named below.
+    "default-src 'self'",
+    # img-src is widened to data: so inline image data URIs (which are
+    # extremely common) work, and to https: so most images render after
+    # rewriting. Note: this is the one place we permit cross-origin —
+    # images are low-risk for data exfiltration since they're rendered
+    # not executed.
+    "img-src 'self' data: https:",
+    # Stylesheets may use data: for inline font references.
+    "style-src 'self' 'unsafe-inline' data:",
+    # No inline JS, no eval. All JS must be served from us (the proxy).
+    "script-src 'self'",
+    # object-src is set explicitly because browser fallback to default-src
+    # is inconsistent across versions. Block all plugin embeds (Flash,
+    # Java, legacy <object> tags) regardless of source.
+    "object-src 'none'",
+    # base-uri 'self' prevents a malicious <base href="..."> tag in the
+    # proxied page from redirecting relative URL resolution to an
+    # attacker-controlled origin (which would bypass our rewriter).
+    "base-uri 'self'",
+    # Fonts may come from data: (inline) or https: (after rewriting
+    # by the proxy).
+    "font-src 'self' data: https:",
+    # Form submissions may not target third parties.
+    "form-action 'self'",
+    # Disallow anyone embedding our proxied page in their own iframe
+    # (defence against clickjacking on the user-facing /proxy URL).
+    "frame-ancestors 'self'",
+    # Block legacy mixed-content in case the proxied page uses http://
+    # subresources after we serve over https://.
+    "upgrade-insecure-requests",
+)
+
+
+def proxied_response_csp() -> str:
+    """Return the strict CSP header value for proxied HTML responses."""
+    return "; ".join(_DIRECTIVES)

--- a/tinyagentos/routes/desktop_browser/csp.py
+++ b/tinyagentos/routes/desktop_browser/csp.py
@@ -25,11 +25,11 @@ _DIRECTIVES = (
     # explicitly named below.
     "default-src 'self'",
     # img-src is widened to data: so inline image data URIs (which are
-    # extremely common) work, and to https: so most images render after
-    # rewriting. Note: this is the one place we permit cross-origin —
-    # images are low-risk for data exfiltration since they're rendered
-    # not executed.
-    "img-src 'self' data: https:",
+    # extremely common) work. Cross-origin https: was previously
+    # allowed but removed — external images must be rewritten by the
+    # rewriter to flow back through the proxy. Without this, the
+    # proxied page could leak the user's real IP via direct image fetches.
+    "img-src 'self' data:",
     # Stylesheets may use data: for inline font references.
     "style-src 'self' 'unsafe-inline' data:",
     # No inline JS, no eval. All JS must be served from us (the proxy).
@@ -52,9 +52,9 @@ _DIRECTIVES = (
     # proxied page from redirecting relative URL resolution to an
     # attacker-controlled origin (which would bypass our rewriter).
     "base-uri 'self'",
-    # Fonts may come from data: (inline) or https: (after rewriting
-    # by the proxy).
-    "font-src 'self' data: https:",
+    # Fonts may come from data: (inline). External fonts must be
+    # rewritten by the proxy rewriter to flow back through the proxy.
+    "font-src 'self' data:",
     # Form submissions may not target third parties.
     "form-action 'self'",
     # Disallow anyone embedding our proxied page in their own iframe

--- a/tinyagentos/routes/desktop_browser/csp.py
+++ b/tinyagentos/routes/desktop_browser/csp.py
@@ -34,6 +34,16 @@ _DIRECTIVES = (
     "style-src 'self' 'unsafe-inline' data:",
     # No inline JS, no eval. All JS must be served from us (the proxy).
     "script-src 'self'",
+    # Explicit `connect-src` so XHR/fetch/EventSource/WebSocket from
+    # proxied JS can only reach the proxy origin (us). Browser fallback
+    # to default-src for connect-src has historically been inconsistent.
+    "connect-src 'self'",
+    # Explicit `worker-src` blocks proxied pages from registering
+    # service workers / web workers pointing at third-party origins.
+    "worker-src 'self'",
+    # Explicit `frame-src` so proxied pages can only iframe other
+    # proxied content (sub-frames also routed through us).
+    "frame-src 'self'",
     # object-src is set explicitly because browser fallback to default-src
     # is inconsistent across versions. Block all plugin embeds (Flash,
     # Java, legacy <object> tags) regardless of source.

--- a/tinyagentos/routes/desktop_browser/proxy.py
+++ b/tinyagentos/routes/desktop_browser/proxy.py
@@ -49,8 +49,15 @@ async def proxy_get(
     try:
         validate_url_or_raise(url)
     except SsrfBlockedError as e:
+        # Log the detailed reason server-side for debugging, but DO NOT
+        # echo it to the client — the message can include resolved IPs
+        # that would help a remote attacker enumerate the user's LAN.
+        import logging
+        logging.getLogger(__name__).info(
+            "browser proxy SSRF block: url=%r reason=%s", url, e
+        )
         return JSONResponse(
-            {"error": f"URL blocked: {e}"},
+            {"error": "URL blocked"},
             status_code=403,
         )
 

--- a/tinyagentos/routes/desktop_browser/proxy.py
+++ b/tinyagentos/routes/desktop_browser/proxy.py
@@ -1,0 +1,72 @@
+"""BrowserApp v2 — proxy endpoint shell.
+
+PR 2 lands the security gate: authentication required, SSRF guard
+runs on every URL, parameter validation, and a 501 response for
+valid requests so the route is real and discoverable in the OpenAPI
+schema. PR 3 will replace the 501 stub with the actual fetch +
+rewriter + cookie jar pipeline.
+
+Endpoint: GET /api/desktop/browser/proxy
+Query:    profile_id (required) — which profile's cookie jar to use
+          url        (required) — target URL to fetch
+Auth:     taos_session cookie required (same as the rest of the desktop)
+
+Responses:
+  200  — (PR 3 only) proxied HTML/asset response with strict CSP
+  401  — no valid session cookie
+  403  — URL failed SSRF guard (private IP, local TLD, etc.)
+  422  — required query param missing
+  501  — temporary: PR 2 ships the gate without the fetch pipeline
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import Depends, Request
+from fastapi.responses import JSONResponse
+
+from tinyagentos.auth import get_current_user
+from tinyagentos.routes.desktop_browser import router
+from tinyagentos.routes.desktop_browser.ssrf import (
+    SsrfBlockedError,
+    validate_url_or_raise,
+)
+
+
+@router.get("/api/desktop/browser/proxy")
+async def proxy_get(
+    profile_id: str,
+    url: str,
+    request: Request,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    """Auth + SSRF gate for the BrowserApp v2 proxy.
+
+    PR 3 replaces the 501 stub with the real fetch pipeline.
+    """
+    # SSRF guard — rejects private IPs, .local/.onion/.internal hosts,
+    # decimal/octal IP encodings, IPv6 alts.
+    try:
+        validate_url_or_raise(url)
+    except SsrfBlockedError as e:
+        return JSONResponse(
+            {"error": f"URL blocked: {e}"},
+            status_code=403,
+        )
+
+    # PR 2 stops here. Future-PR-3 code will:
+    #   1. Look up cookies from BrowserCookieStore for (current_user["id"], profile_id, host)
+    #   2. httpx fetch with cookies attached, follow_redirects=False, re-validating each redirect
+    #   3. Run the lxml rewriter on text/html responses
+    #   4. Inject /__taos/copilot.js
+    #   5. Apply the strict CSP from csp.proxied_response_csp()
+    #   6. Persist Set-Cookie back to the jar
+    return JSONResponse(
+        {
+            "error": (
+                "Proxy fetch not yet implemented — gate passed (auth + SSRF). "
+                "Fetch pipeline lands in PR 3."
+            ),
+        },
+        status_code=501,
+    )

--- a/tinyagentos/routes/desktop_browser/proxy.py
+++ b/tinyagentos/routes/desktop_browser/proxy.py
@@ -53,8 +53,13 @@ async def proxy_get(
         # echo it to the client — the message can include resolved IPs
         # that would help a remote attacker enumerate the user's LAN.
         import logging
+        from urllib.parse import urlsplit
+        parsed = urlsplit(url)
         logging.getLogger(__name__).info(
-            "browser proxy SSRF block: url=%r reason=%s", url, e
+            "browser proxy SSRF block: scheme=%r host=%r reason=%s",
+            parsed.scheme,
+            parsed.hostname,
+            e,
         )
         return JSONResponse(
             {"error": "URL blocked"},

--- a/tinyagentos/routes/desktop_browser/ssrf.py
+++ b/tinyagentos/routes/desktop_browser/ssrf.py
@@ -1,0 +1,162 @@
+"""SSRF guard for the BrowserApp proxy.
+
+The proxy server-side-fetches URLs on behalf of the user. Without
+guards an attacker who controls a URL the proxy fetches can point us
+at internal services (cloud metadata, the Pi's own admin interfaces,
+RFC1918 hosts on the user's LAN). This module is the choke point that
+parses every target URL, resolves its hostname, and refuses to proceed
+if any resolved address is in the blocklist.
+
+Usage:
+
+    from tinyagentos.routes.desktop_browser.ssrf import (
+        SsrfBlockedError,
+        validate_url_or_raise,
+    )
+
+    try:
+        validate_url_or_raise(target_url)
+    except SsrfBlockedError as e:
+        return JSONResponse({"error": str(e)}, status_code=403)
+
+For redirect handling, callers must invoke validate_url_or_raise on
+EVERY redirect target (not just the initial URL). The `httpx`
+follow_redirects=True default does not give us a callback per redirect,
+so the proxy implementation in PR 3 disables auto-follow and walks the
+redirect chain manually, calling this guard each step.
+"""
+from __future__ import annotations
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+
+class SsrfBlockedError(Exception):
+    """Raised when a URL fails SSRF validation."""
+
+
+# Hostname-suffix blocklist — applied before DNS resolution.
+_BLOCKED_TLDS = (".local", ".onion", ".internal")
+
+# Networks not covered by ipaddress's `is_private` flag but still
+# reachable on typical home networks / shared infrastructure.
+_BLOCKED_NETWORKS = (
+    ipaddress.ip_network("100.64.0.0/10"),  # RFC 6598 CGNAT — common on consumer ISPs
+)
+
+
+def validate_url_or_raise(url: str) -> None:
+    """Validate that `url` is safe to fetch.
+
+    Parses the URL, checks scheme + hostname suffix, resolves DNS, and
+    verifies every resolved address against the blocklist. Raises
+    `SsrfBlockedError` on any failure.
+    """
+    parsed = urlparse(url)
+
+    if parsed.scheme not in ("http", "https"):
+        raise SsrfBlockedError(f"rejected scheme: {parsed.scheme!r}")
+
+    if not parsed.hostname:
+        raise SsrfBlockedError("URL has no hostname")
+
+    host = parsed.hostname.lower()
+
+    # Hostname-based blocklist (catches .local / .onion / .internal
+    # before we even resolve DNS, since these may not resolve at all
+    # but still indicate non-public intent)
+    for suffix in _BLOCKED_TLDS:
+        if host.endswith(suffix):
+            raise SsrfBlockedError(f"blocked hostname suffix: {suffix}")
+
+    # Try parsing as a literal IP first. This catches decimal / octal /
+    # hex / IPv4-mapped-IPv6 encodings that bypass naive string
+    # blocklists. ipaddress accepts all of these forms.
+    addrs: list[str] = []
+    try:
+        # ipaddress.ip_address handles "127.0.0.1", "::1",
+        # "::ffff:127.0.0.1", and "0:0:0:0:0:0:0:1". It does NOT handle
+        # decimal/octal IPv4 (e.g. "2130706433"). For those we use
+        # socket.gethostbyname_ex which interprets them as hostnames
+        # AND resolves them as IPs.
+        ipaddress.ip_address(host)
+        addrs = [host]
+    except ValueError:
+        # Not a recognised literal — try the encoded forms by attempting
+        # int conversion (decimal "2130706433") or hex/octal int parsing.
+        encoded = _try_parse_encoded_ipv4(host)
+        if encoded is not None:
+            addrs = [encoded]
+        else:
+            # Real DNS resolution
+            try:
+                _hostname, _aliases, addr_list = socket.gethostbyname_ex(host)
+                addrs = list(addr_list)
+            except socket.gaierror as e:
+                raise SsrfBlockedError(f"could not resolve hostname: {e}") from e
+
+    if not addrs:
+        raise SsrfBlockedError("hostname resolved to no addresses")
+
+    for addr in addrs:
+        validate_resolved_addr(addr)
+
+
+def validate_resolved_addr(addr: str) -> None:
+    """Validate that a resolved IP address is safe to connect to.
+
+    Rejects loopback, RFC1918, link-local, multicast, broadcast,
+    unspecified (0.0.0.0), and the IPv6 equivalents (incl. IPv4-mapped
+    IPv6 forms like ::ffff:127.0.0.1).
+    """
+    try:
+        ip = ipaddress.ip_address(addr)
+    except ValueError as e:
+        raise SsrfBlockedError(f"could not parse resolved address {addr!r}") from e
+
+    # Normalise IPv4-mapped IPv6 (e.g. ::ffff:10.0.0.1) to its IPv4
+    # equivalent so the IPv4 blocklist catches it. ipaddress lets us
+    # check this via .ipv4_mapped on IPv6Address.
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped
+
+    if (
+        ip.is_loopback
+        or ip.is_private
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    ):
+        raise SsrfBlockedError(f"resolved address {addr!r} is in the blocklist")
+
+    # Backstop for ranges Python's `ipaddress` doesn't classify as
+    # private (e.g. RFC 6598 CGNAT).
+    for net in _BLOCKED_NETWORKS:
+        if ip in net:
+            raise SsrfBlockedError(
+                f"resolved address {addr!r} is in blocked network {net}"
+            )
+
+
+def _try_parse_encoded_ipv4(host: str) -> str | None:
+    """Attempt to interpret `host` as an integer-encoded IPv4 address.
+
+    Handles decimal ("2130706433"), hex ("0x7f000001"), octal
+    ("017700000001"). Returns the dotted-quad form if successful, else
+    None.
+    """
+    # int(host, 0) handles 0x prefix, 0 prefix (octal), and plain
+    # decimal in one call, but we need to guard against host strings
+    # that happen to be parseable as ints but aren't valid IPv4 (e.g.
+    # negative numbers, numbers > 0xFFFFFFFF).
+    try:
+        as_int = int(host, 0)
+    except (ValueError, TypeError):
+        return None
+
+    if not (0 <= as_int <= 0xFFFFFFFF):
+        return None
+
+    return str(ipaddress.IPv4Address(as_int))

--- a/tinyagentos/routes/desktop_browser/ssrf.py
+++ b/tinyagentos/routes/desktop_browser/ssrf.py
@@ -37,7 +37,15 @@ class SsrfBlockedError(Exception):
 
 
 # Hostname-suffix blocklist — applied before DNS resolution.
-_BLOCKED_TLDS = (".local", ".onion", ".internal")
+_BLOCKED_TLDS = (
+    ".local",     # mDNS / Bonjour
+    ".onion",     # Tor hidden services
+    ".internal",  # common internal alias
+    ".home",      # IETF reserved for residential networks
+    ".corp",      # common enterprise internal alias
+    ".lan",       # common home-network alias
+    ".intranet",  # common enterprise alias
+)
 
 # Networks not covered by ipaddress's `is_private` flag but still
 # reachable on typical home networks / shared infrastructure.
@@ -62,7 +70,7 @@ def validate_url_or_raise(url: str) -> None:
     if not parsed.hostname:
         raise SsrfBlockedError("URL has no hostname")
 
-    host = parsed.hostname.lower()
+    host = parsed.hostname.strip().lower()
 
     # Hostname-based blocklist (catches .local / .onion / .internal
     # before we even resolve DNS, since these may not resolve at all
@@ -90,10 +98,15 @@ def validate_url_or_raise(url: str) -> None:
         if encoded is not None:
             addrs = [encoded]
         else:
-            # Real DNS resolution
+            # Real DNS resolution. We use getaddrinfo (NOT gethostbyname_ex)
+            # because the latter is IPv4-only — it silently ignores AAAA
+            # records, which would let an attacker DNS-pin a hostname to
+            # one public IPv4 + one private IPv6 and bypass the guard.
             try:
-                _hostname, _aliases, addr_list = socket.gethostbyname_ex(host)
-                addrs = list(addr_list)
+                results = socket.getaddrinfo(host, None)
+                # results is a list of (family, type, proto, canonname, sockaddr).
+                # sockaddr[0] is the address string for both AF_INET and AF_INET6.
+                addrs = list({r[4][0] for r in results})
             except socket.gaierror as e:
                 raise SsrfBlockedError(f"could not resolve hostname: {e}") from e
 

--- a/tinyagentos/routes/desktop_browser/ssrf.py
+++ b/tinyagentos/routes/desktop_browser/ssrf.py
@@ -43,6 +43,7 @@ _BLOCKED_TLDS = (".local", ".onion", ".internal")
 # reachable on typical home networks / shared infrastructure.
 _BLOCKED_NETWORKS = (
     ipaddress.ip_network("100.64.0.0/10"),  # RFC 6598 CGNAT — common on consumer ISPs
+    ipaddress.ip_network("fec0::/10"),      # RFC 3879 deprecated IPv6 site-local — still on legacy gear
 )
 
 


### PR DESCRIPTION
Second of ten PRs implementing BrowserApp v2 per the design doc.

## Summary

- **SSRF guard** (`ssrf.py`) — parses URL, resolves DNS, blocks RFC1918 / link-local / loopback / IPv6 alts (incl. `::ffff:` mapped) / multicast / `.local` / `.onion` / `.internal` / decimal+octal+hex IP encodings / RFC 6598 CGNAT (100.64/10) / RFC 3879 IPv6 site-local (fec0::/10). Multi-record hostnames must pass ALL resolved addresses (defends against DNS pinning).
- **Strict CSP builder** (`csp.py`) — builder for the strict Content-Security-Policy applied to proxied responses by PR 3. Explicit `default-src 'self'`, `script-src 'self'` (no inline/eval), `connect-src 'self'`, `worker-src 'self'`, `frame-src 'self'`, `object-src 'none'`, `base-uri 'self'`, `form-action 'self'`, `frame-ancestors 'self'`, `upgrade-insecure-requests`. Pragmatic `style-src 'unsafe-inline'` (CSS isn't an XSS vector and inline styles are universal in real-world HTML).
- **`/api/desktop/browser/proxy` endpoint shell** (`proxy.py`) — auth via existing `Depends(get_current_user)`, SSRF check on every URL, returns **501 Not Implemented** for valid URLs (the actual fetch + rewriter + cookie jar pipeline lands in PR 3). 403 responses do **not** leak resolved internal IPs back to the client (LAN-enumeration defence) — the detailed reason is logged server-side instead.

## What this does **not** land

- Proxy fetch logic / lxml rewriter / cookie-aware HTTP — PR 3
- copilot.js script injection — PR 6
- Service Worker fetch interception — PR 8

## Distinct-origin deferral

The original spec called for serving the proxy on a distinct origin (`browser.<host>`) from v1. During PR 2 planning we found that the project does not currently have HTTPS / TLS / mDNS-wildcard infrastructure — adding all three to make `browser.taos.local` reachable would expand PR 2 well past its intended size and is genuinely a platform-wide change, not browser-specific. **Decision:** defer distinct-origin to a dedicated HTTPS + DNS Foundations PR (queued from the audit). PRs 2–9 ship at the same origin as the rest of the desktop; the strict CSP injection from `csp.proxied_response_csp()` provides partial defence in the meantime. PR 4 (frontend chrome) does not depend on origin separation.

## Test Plan

- [x] `pytest tests/routes/desktop_browser/test_ssrf.py -v` — **34 cases** (parametrized) covering schemes, IPv4 blocklist (incl. CGNAT), IPv6 blocklist (incl. fec0::/10), hostname suffixes, encoded IP forms, DNS resolution failure, multi-record DNS-pinning
- [x] `pytest tests/routes/desktop_browser/test_csp.py -v` — **10 tests** verifying every strict directive plus the script-src-scoped no-inline assertion
- [x] `pytest tests/routes/desktop_browser/test_proxy_shell.py -v` — **8 tests** covering auth gate, SSRF gate, parameter validation, 501 stub, **and the LAN-enumeration regression test** (asserts 403 body does NOT contain resolved IPs)
- [x] Full `pytest tests/routes/desktop_browser/` — 26 PR 1 tests + 52 new PR 2 tests = **78 total, all green**
- [x] Broader regression `pytest tests/routes/ tests/test_secrets.py` — 160 tests pass, no regressions outside scope

## Spec

`docs/superpowers/specs/2026-05-03-browser-app-v2-design.md` §4.3, §9. (Local spec amended in §3.1 with the deferral note.)

Cumulative shipping arc:
```
After PR 1:  cookie-aware storage backend ready
After PR 2:  proxy endpoint exists with auth + SSRF gate (this PR)   (SECURITY GATE)
After PR 3:  full lxml rewriter + cookie-aware HTTP fetch
After PR 4:  new compact chrome, multi-window, tab model
…
After PR 10: cross-device push notifications                          (V1 SHIPS)
```

## Notes for reviewers

- **CGNAT and fec0::/10 backstop:** `ipaddress.IPv4Address.is_private` doesn't include RFC 6598 (100.64/10), and `ipaddress.IPv6Address` doesn't include RFC 3879 (fec0::/10). Both are explicitly listed in `_BLOCKED_NETWORKS` because they're routable on real consumer/enterprise gear.
- **`socket.gethostbyname_ex` is sync** inside an async route. Acceptable for the gate-only PR 2; PR 3 should wrap with `asyncio.to_thread(...)` when serving real traffic.
- **501 body explicitly mentions PR 3** so anyone hitting this in early dev knows where the fetch logic actually lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added browser proxy endpoint with authentication enforcement and Server-Side Request Forgery (SSRF) protection to safely proxy web requests.
  * Implemented Content-Security-Policy sandboxing for proxied HTML responses.

* **Tests**
  * Added comprehensive test coverage for proxy endpoint security, including authentication, SSRF validation, and CSP header generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->