### PR TITLE
feat(browser): PR 5 — profile switcher, discard policy, Reader mode

### DIFF
--- a/desktop/src/apps/BrowserApp/AddressBar.test.tsx
+++ b/desktop/src/apps/BrowserApp/AddressBar.test.tsx
@@ -1,7 +1,8 @@
 import { describe, expect, it, beforeEach, vi, afterEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import { AddressBar } from "./AddressBar";
 import { useBrowserStore } from "@/stores/browser-store";
+import * as extractApi from "@/lib/browser-extract-api";
 
 const TEST_WINDOW_ID = "win-test";
 const originalFetch = global.fetch;
@@ -171,5 +172,105 @@ describe("AddressBar — focus event", () => {
 
     await new Promise((r) => setTimeout(r, 0));
     expect(document.activeElement).not.toBe(input);
+  });
+});
+
+describe("AddressBar — reader toggle", () => {
+  it("does NOT render reader toggle when readerAvailable is not true", () => {
+    const tabId = useBrowserStore.getState().getWindow(TEST_WINDOW_ID)!.tabs[0].id;
+    useBrowserStore.getState().navigateTab(TEST_WINDOW_ID, tabId, "https://a.test/");
+    // readerAvailable is undefined by default after navigateTab
+
+    render(<AddressBar windowId={TEST_WINDOW_ID} />);
+    expect(
+      screen.queryByRole("button", { name: /toggle reader mode/i }),
+    ).toBeNull();
+  });
+
+  it("renders reader toggle when readerAvailable is true", () => {
+    const tabId = useBrowserStore.getState().getWindow(TEST_WINDOW_ID)!.tabs[0].id;
+    useBrowserStore.getState().navigateTab(TEST_WINDOW_ID, tabId, "https://a.test/");
+    useBrowserStore.getState().setTabReader(TEST_WINDOW_ID, tabId, {
+      readerAvailable: true,
+      readerExtract: {
+        title: "Test",
+        text: "content",
+        html: "<p>content</p>",
+        word_count: 300,
+      },
+    });
+
+    render(<AddressBar windowId={TEST_WINDOW_ID} />);
+    expect(
+      screen.getByRole("button", { name: /toggle reader mode/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("clicking the reader toggle flips readerActive in the store", () => {
+    const tabId = useBrowserStore.getState().getWindow(TEST_WINDOW_ID)!.tabs[0].id;
+    useBrowserStore.getState().navigateTab(TEST_WINDOW_ID, tabId, "https://a.test/");
+    useBrowserStore.getState().setTabReader(TEST_WINDOW_ID, tabId, {
+      readerAvailable: true,
+      readerActive: false,
+      readerExtract: {
+        title: "Test",
+        text: "content",
+        html: "<p>content</p>",
+        word_count: 300,
+      },
+    });
+
+    const setTabReaderSpy = vi.spyOn(useBrowserStore.getState(), "setTabReader");
+    render(<AddressBar windowId={TEST_WINDOW_ID} />);
+    fireEvent.click(screen.getByRole("button", { name: /toggle reader mode/i }));
+
+    expect(setTabReaderSpy).toHaveBeenCalledWith(
+      TEST_WINDOW_ID,
+      tabId,
+      { readerActive: true },
+    );
+  });
+
+  it("focusing address bar with readerAvailable=undefined triggers extractReadable", async () => {
+    const tabId = useBrowserStore.getState().getWindow(TEST_WINDOW_ID)!.tabs[0].id;
+    useBrowserStore.getState().navigateTab(TEST_WINDOW_ID, tabId, "https://a.test/");
+
+    const extractSpy = vi.spyOn(extractApi, "extractReadable").mockResolvedValue({
+      title: "Article",
+      text: "some content",
+      html: "<p>some content</p>",
+      word_count: 250,
+    });
+
+    render(<AddressBar windowId={TEST_WINDOW_ID} />);
+    const input = screen.getByLabelText("Address") as HTMLInputElement;
+    await act(async () => {
+      fireEvent.focus(input);
+    });
+
+    expect(extractSpy).toHaveBeenCalledWith("personal", "https://a.test/");
+  });
+
+  it("focusing address bar with readerAvailable already set does NOT re-trigger extractReadable", async () => {
+    const tabId = useBrowserStore.getState().getWindow(TEST_WINDOW_ID)!.tabs[0].id;
+    useBrowserStore.getState().navigateTab(TEST_WINDOW_ID, tabId, "https://a.test/");
+    useBrowserStore.getState().setTabReader(TEST_WINDOW_ID, tabId, {
+      readerAvailable: true,
+      readerExtract: {
+        title: "Article",
+        text: "content",
+        html: "<p>content</p>",
+        word_count: 300,
+      },
+    });
+
+    const extractSpy = vi.spyOn(extractApi, "extractReadable").mockResolvedValue(null);
+
+    render(<AddressBar windowId={TEST_WINDOW_ID} />);
+    const input = screen.getByLabelText("Address") as HTMLInputElement;
+    fireEvent.focus(input);
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(extractSpy).not.toHaveBeenCalled();
   });
 });

--- a/desktop/src/apps/BrowserApp/AddressBar.test.tsx
+++ b/desktop/src/apps/BrowserApp/AddressBar.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it, beforeEach, vi, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
-import { AddressBar } from "./AddressBar";
+import { AddressBar, READER_MIN_WORD_COUNT } from "./AddressBar";
 import { useBrowserStore } from "@/stores/browser-store";
 import * as extractApi from "@/lib/browser-extract-api";
 
@@ -249,6 +249,47 @@ describe("AddressBar — reader toggle", () => {
     });
 
     expect(extractSpy).toHaveBeenCalledWith("personal", "https://a.test/");
+  });
+
+  it("stale extract result is discarded when URL changes before the fetch resolves", async () => {
+    const tabId = useBrowserStore.getState().getWindow(TEST_WINDOW_ID)!.tabs[0].id;
+    useBrowserStore.getState().navigateTab(TEST_WINDOW_ID, tabId, "https://original.test/");
+
+    // Deferred promise — we control when it resolves
+    let resolveExtract!: (v: Awaited<ReturnType<typeof extractApi.extractReadable>>) => void;
+    const deferredPromise = new Promise<Awaited<ReturnType<typeof extractApi.extractReadable>>>(
+      (res) => { resolveExtract = res; },
+    );
+    vi.spyOn(extractApi, "extractReadable").mockReturnValue(deferredPromise);
+
+    render(<AddressBar windowId={TEST_WINDOW_ID} />);
+    const input = screen.getByLabelText("Address") as HTMLInputElement;
+
+    // Focus triggers the fetch for https://original.test/
+    await act(async () => {
+      fireEvent.focus(input);
+    });
+
+    // Navigate to a different URL before the fetch resolves
+    await act(async () => {
+      useBrowserStore.getState().navigateTab(TEST_WINDOW_ID, tabId, "https://new.test/");
+    });
+
+    // Now resolve the extract with data for the OLD url
+    await act(async () => {
+      resolveExtract({
+        title: "Stale Article",
+        text: "stale content",
+        html: "<p>stale content</p>",
+        word_count: READER_MIN_WORD_COUNT + 50,
+      });
+    });
+
+    // The tab should NOT have readerExtract set (stale write discarded)
+    const tab = useBrowserStore.getState().windows[TEST_WINDOW_ID]?.tabs.find(
+      (t) => t.id === tabId,
+    );
+    expect(tab?.readerExtract).toBeFalsy();
   });
 
   it("focusing address bar with readerAvailable already set does NOT re-trigger extractReadable", async () => {

--- a/desktop/src/apps/BrowserApp/AddressBar.tsx
+++ b/desktop/src/apps/BrowserApp/AddressBar.tsx
@@ -15,9 +15,11 @@
  * Settings.
  */
 import { useEffect, useRef, useState } from "react";
+import { BookOpen } from "lucide-react";
 import { useBrowserStore } from "@/stores/browser-store";
 import { useBrowserSettingsStore, searchUrlFor } from "@/stores/browser-settings-store";
 import { fetchSuggestions, type Suggestion } from "@/lib/browser-suggest-api";
+import { extractReadable } from "@/lib/browser-extract-api";
 import { AddressSuggest } from "./AddressSuggest";
 
 const SUGGEST_DEBOUNCE_MS = 150;
@@ -32,12 +34,16 @@ export function AddressBar({ windowId }: AddressBarProps) {
 
   const activeTab = win?.tabs.find((t) => t.id === win?.activeTabId);
 
+  const setTabReader = useBrowserStore((s) => s.setTabReader);
+
   const [inputValue, setInputValue] = useState(activeTab?.url ?? "");
   const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
   const [selectedIndex, setSelectedIndex] = useState(-1);
   const [hasFocus, setHasFocus] = useState(false);
   const inputRef = useRef<HTMLInputElement | null>(null);
   const suggestTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Guard against duplicate in-flight extract requests for the same URL
+  const inflightUrlRef = useRef<string | null>(null);
 
   // Focus the address bar when Cmd+L fires for this window
   useEffect(() => {
@@ -107,6 +113,31 @@ export function AddressBar({ windowId }: AddressBarProps) {
           setHasFocus(true);
           // Select all on focus (Safari / Chrome behavior)
           e.currentTarget.select();
+          // Lazy reader extract — fire once per URL when the address bar is opened
+          if (
+            activeTab &&
+            activeTab.readerAvailable === undefined &&
+            !activeTab.readerExtract &&
+            /^https?:\/\//i.test(activeTab.url) &&
+            inflightUrlRef.current !== activeTab.url
+          ) {
+            const targetUrl = activeTab.url;
+            inflightUrlRef.current = targetUrl;
+            extractReadable(win.profileId, targetUrl)
+              .then((result) => {
+                if (result) {
+                  setTabReader(windowId, activeTab.id, {
+                    readerAvailable: result.word_count > 200,
+                    readerExtract: result,
+                  });
+                } else {
+                  setTabReader(windowId, activeTab.id, { readerAvailable: false });
+                }
+              })
+              .finally(() => {
+                inflightUrlRef.current = null;
+              });
+          }
         }}
         onBlur={() => {
           setHasFocus(false);
@@ -135,8 +166,30 @@ export function AddressBar({ windowId }: AddressBarProps) {
             setSelectedIndex((i) => Math.max(i - 1, -1));
           }
         }}
-        className="w-full bg-shell-bg-deep text-shell-text px-2 py-0.5 rounded text-xs border border-shell-border-subtle focus:border-accent focus:outline-none"
+        className={`w-full bg-shell-bg-deep text-shell-text px-2 py-0.5 rounded text-xs border border-shell-border-subtle focus:border-accent focus:outline-none ${
+          activeTab?.readerAvailable ? "pr-7" : ""
+        }`}
       />
+      {activeTab?.readerAvailable && (
+        <button
+          type="button"
+          aria-label="Toggle Reader mode"
+          aria-pressed={!!activeTab?.readerActive}
+          onClick={() => {
+            if (!activeTab) return;
+            setTabReader(windowId, activeTab.id, {
+              readerActive: !activeTab.readerActive,
+            });
+          }}
+          className={`absolute right-1.5 top-1/2 -translate-y-1/2 p-0.5 rounded ${
+            activeTab?.readerActive
+              ? "text-accent"
+              : "text-shell-text-secondary hover:text-shell-text"
+          }`}
+        >
+          <BookOpen size={12} />
+        </button>
+      )}
       {hasFocus && (
         <AddressSuggest
           suggestions={suggestions}

--- a/desktop/src/apps/BrowserApp/AddressBar.tsx
+++ b/desktop/src/apps/BrowserApp/AddressBar.tsx
@@ -16,11 +16,11 @@
  */
 import { useEffect, useRef, useState } from "react";
 import { useBrowserStore } from "@/stores/browser-store";
+import { useBrowserSettingsStore, searchUrlFor } from "@/stores/browser-settings-store";
 import { fetchSuggestions, type Suggestion } from "@/lib/browser-suggest-api";
 import { AddressSuggest } from "./AddressSuggest";
 
 const SUGGEST_DEBOUNCE_MS = 150;
-const DEFAULT_SEARCH_URL = "https://duckduckgo.com/?q=";
 
 interface AddressBarProps {
   windowId: string;
@@ -166,5 +166,5 @@ function resolveFinalUrl(input: string): string {
   if (input.includes(".") && !input.includes(" ")) {
     return `https://${input}`;
   }
-  return `${DEFAULT_SEARCH_URL}${encodeURIComponent(input)}`;
+  return searchUrlFor(useBrowserSettingsStore.getState().searchEngine, input);
 }

--- a/desktop/src/apps/BrowserApp/AddressBar.tsx
+++ b/desktop/src/apps/BrowserApp/AddressBar.tsx
@@ -23,6 +23,7 @@ import { extractReadable } from "@/lib/browser-extract-api";
 import { AddressSuggest } from "./AddressSuggest";
 
 const SUGGEST_DEBOUNCE_MS = 150;
+export const READER_MIN_WORD_COUNT = 200;
 
 interface AddressBarProps {
   windowId: string;
@@ -125,17 +126,27 @@ export function AddressBar({ windowId }: AddressBarProps) {
             inflightUrlRef.current = targetUrl;
             extractReadable(win.profileId, targetUrl)
               .then((result) => {
+                const currentTab = useBrowserStore
+                  .getState()
+                  .windows[windowId]
+                  ?.tabs.find((t) => t.id === activeTab.id);
+                if (!currentTab || currentTab.url !== targetUrl) return;
                 if (result) {
                   setTabReader(windowId, activeTab.id, {
-                    readerAvailable: result.word_count > 200,
+                    readerAvailable: result.word_count > READER_MIN_WORD_COUNT,
                     readerExtract: result,
                   });
                 } else {
                   setTabReader(windowId, activeTab.id, { readerAvailable: false });
                 }
               })
+              .catch(() => {
+                // Silent — match other browser-* api wrappers
+              })
               .finally(() => {
-                inflightUrlRef.current = null;
+                if (inflightUrlRef.current === targetUrl) {
+                  inflightUrlRef.current = null;
+                }
               });
           }
         }}

--- a/desktop/src/apps/BrowserApp/Chrome.test.tsx
+++ b/desktop/src/apps/BrowserApp/Chrome.test.tsx
@@ -89,10 +89,10 @@ describe("Chrome — profile chip", () => {
 
     // Wait for the async listProfiles call to resolve and the color dot to appear
     await waitFor(() => {
-      const dot = document.querySelector(
-        "[aria-label='Profile: personal'] span[aria-hidden='true']",
-      ) as HTMLElement | null;
-      expect(dot?.style.backgroundColor).toBe("rgb(171, 205, 239)"); // #abcdef in rgb
+      const chip = screen.getByLabelText(/profile: personal/i);
+      const dot = chip.querySelector("span[aria-hidden='true']") as HTMLElement | null;
+      expect(dot).not.toBeNull();
+      expect(dot!.style.backgroundColor).toBe("rgb(171, 205, 239)"); // #abcdef in rgb
     });
   });
 });

--- a/desktop/src/apps/BrowserApp/Chrome.test.tsx
+++ b/desktop/src/apps/BrowserApp/Chrome.test.tsx
@@ -1,7 +1,14 @@
 import { describe, expect, it, beforeEach, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { Chrome } from "./Chrome";
 import { useBrowserStore } from "@/stores/browser-store";
+
+vi.mock("@/lib/browser-profile-api", () => ({
+  listProfiles: vi.fn().mockResolvedValue([
+    { profile_id: "personal", name: "Personal", color: "#6c8df0", created_at: 0 },
+    { profile_id: "work",     name: "Work",     color: "#f5b86b", created_at: 1 },
+  ]),
+}));
 
 const TEST_WINDOW_ID = "win-test";
 
@@ -70,6 +77,23 @@ describe("Chrome — profile chip", () => {
     const chip = screen.getByLabelText(/profile|personal/i);
     expect(chip).toBeTruthy();
     expect(chip.textContent?.toLowerCase()).toContain("personal");
+  });
+
+  it("shows the custom color from the loaded profiles list on the chip dot", async () => {
+    const { listProfiles } = await import("@/lib/browser-profile-api");
+    (listProfiles as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      { profile_id: "personal", name: "Personal", color: "#abcdef", created_at: 0 },
+    ]);
+
+    render(<Chrome windowId={TEST_WINDOW_ID} />);
+
+    // Wait for the async listProfiles call to resolve and the color dot to appear
+    await waitFor(() => {
+      const dot = document.querySelector(
+        "[aria-label='Profile: personal'] span[aria-hidden='true']",
+      ) as HTMLElement | null;
+      expect(dot?.style.backgroundColor).toBe("rgb(171, 205, 239)"); // #abcdef in rgb
+    });
   });
 });
 

--- a/desktop/src/apps/BrowserApp/Chrome.tsx
+++ b/desktop/src/apps/BrowserApp/Chrome.tsx
@@ -94,6 +94,7 @@ export function Chrome({ windowId }: ChromeProps) {
           aria-expanded={settingsOpen}
           onClick={() => {
             setSwitcherOpen(false);
+            setManagerOpen(false);
             setSettingsOpen((s) => !s);
           }}
           className="p-1 rounded hover:bg-shell-hover"
@@ -111,6 +112,7 @@ export function Chrome({ windowId }: ChromeProps) {
           type="button"
           onClick={() => {
             setSettingsOpen(false);
+            setManagerOpen(false);
             setSwitcherOpen((s) => !s);
           }}
           className="flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-shell-bg-deep border border-shell-border-subtle text-xs hover:bg-shell-hover"

--- a/desktop/src/apps/BrowserApp/Chrome.tsx
+++ b/desktop/src/apps/BrowserApp/Chrome.tsx
@@ -90,7 +90,12 @@ export function Chrome({ windowId }: ChromeProps) {
           type="button"
           aria-label="Settings"
           title="Settings"
-          onClick={() => setSettingsOpen((s) => !s)}
+          aria-haspopup="dialog"
+          aria-expanded={settingsOpen}
+          onClick={() => {
+            setSwitcherOpen(false);
+            setSettingsOpen((s) => !s);
+          }}
           className="p-1 rounded hover:bg-shell-hover"
         >
           <Settings size={16} />
@@ -104,7 +109,10 @@ export function Chrome({ windowId }: ChromeProps) {
       <div className="relative">
         <button
           type="button"
-          onClick={() => setSwitcherOpen((s) => !s)}
+          onClick={() => {
+            setSettingsOpen(false);
+            setSwitcherOpen((s) => !s);
+          }}
           className="flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-shell-bg-deep border border-shell-border-subtle text-xs hover:bg-shell-hover"
           aria-label={`Profile: ${win.profileId}`}
           aria-haspopup="menu"

--- a/desktop/src/apps/BrowserApp/Chrome.tsx
+++ b/desktop/src/apps/BrowserApp/Chrome.tsx
@@ -7,12 +7,11 @@
  * NOTE: The OS-level traffic lights (close / minimize / maximize) live in
  * `desktop/src/components/Window.tsx` — every window in taOS gets them
  * automatically. This component does NOT render its own traffic lights.
- *
- * For PR 4 the profile chip is display-only; PR 5's ProfileSwitcher will
- * wire the click-to-open-dropdown behavior.
  */
+import { useState } from "react";
 import { ArrowLeft, ArrowRight, RotateCw } from "lucide-react";
 import { useBrowserStore } from "@/stores/browser-store";
+import { ProfileSwitcher } from "./ProfileSwitcher";
 
 interface ChromeProps {
   windowId: string;
@@ -24,6 +23,7 @@ export function Chrome({ windowId }: ChromeProps) {
   const goBack = useBrowserStore((s) => s.goBack);
   const goForward = useBrowserStore((s) => s.goForward);
   const navigateTab = useBrowserStore((s) => s.navigateTab);
+  const [switcherOpen, setSwitcherOpen] = useState(false);
 
   if (!win) return null;
 
@@ -80,17 +80,30 @@ export function Chrome({ windowId }: ChromeProps) {
       {/* Spacer pushes the profile chip to the right */}
       <div className="flex-1" />
 
-      {/* Profile chip — display-only for PR 4; PR 5 wires the dropdown */}
-      <div
-        className="flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-shell-bg-deep border border-shell-border-subtle text-xs"
-        aria-label={`Profile: ${win.profileId}`}
-      >
-        <span
-          className="inline-block w-2 h-2 rounded-full"
-          style={{ backgroundColor: profileColor(win.profileId) }}
-          aria-hidden="true"
-        />
-        <span className="capitalize">{win.profileId}</span>
+      {/* Profile chip — clicking opens the ProfileSwitcher dropdown */}
+      <div className="relative">
+        <button
+          type="button"
+          onClick={() => setSwitcherOpen((s) => !s)}
+          className="flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-shell-bg-deep border border-shell-border-subtle text-xs hover:bg-shell-hover"
+          aria-label={`Profile: ${win.profileId}`}
+          aria-haspopup="menu"
+          aria-expanded={switcherOpen}
+        >
+          <span
+            className="inline-block w-2 h-2 rounded-full"
+            style={{ backgroundColor: profileColor(win.profileId) }}
+            aria-hidden="true"
+          />
+          <span className="capitalize">{win.profileId}</span>
+        </button>
+        {switcherOpen && (
+          <ProfileSwitcher
+            windowId={windowId}
+            onClose={() => setSwitcherOpen(false)}
+            // PR 5 Task 5 will wire onManage to open ProfileManager
+          />
+        )}
       </div>
     </div>
   );

--- a/desktop/src/apps/BrowserApp/Chrome.tsx
+++ b/desktop/src/apps/BrowserApp/Chrome.tsx
@@ -9,10 +9,11 @@
  * automatically. This component does NOT render its own traffic lights.
  */
 import { useState } from "react";
-import { ArrowLeft, ArrowRight, RotateCw } from "lucide-react";
+import { ArrowLeft, ArrowRight, RotateCw, Settings } from "lucide-react";
 import { useBrowserStore } from "@/stores/browser-store";
 import { ProfileSwitcher } from "./ProfileSwitcher";
 import { ProfileManager } from "./ProfileManager";
+import { SettingsPanel } from "./SettingsPanel";
 
 interface ChromeProps {
   windowId: string;
@@ -26,6 +27,7 @@ export function Chrome({ windowId }: ChromeProps) {
   const navigateTab = useBrowserStore((s) => s.navigateTab);
   const [switcherOpen, setSwitcherOpen] = useState(false);
   const [managerOpen, setManagerOpen] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
 
   if (!win) return null;
 
@@ -81,6 +83,22 @@ export function Chrome({ windowId }: ChromeProps) {
 
       {/* Spacer pushes the profile chip to the right */}
       <div className="flex-1" />
+
+      {/* Settings button */}
+      <div className="relative">
+        <button
+          type="button"
+          aria-label="Settings"
+          title="Settings"
+          onClick={() => setSettingsOpen((s) => !s)}
+          className="p-1 rounded hover:bg-shell-hover"
+        >
+          <Settings size={16} />
+        </button>
+        {settingsOpen && (
+          <SettingsPanel onClose={() => setSettingsOpen(false)} />
+        )}
+      </div>
 
       {/* Profile chip — clicking opens the ProfileSwitcher dropdown */}
       <div className="relative">

--- a/desktop/src/apps/BrowserApp/Chrome.tsx
+++ b/desktop/src/apps/BrowserApp/Chrome.tsx
@@ -8,9 +8,10 @@
  * `desktop/src/components/Window.tsx` — every window in taOS gets them
  * automatically. This component does NOT render its own traffic lights.
  */
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { ArrowLeft, ArrowRight, RotateCw, Settings } from "lucide-react";
 import { useBrowserStore } from "@/stores/browser-store";
+import { listProfiles, type Profile } from "@/lib/browser-profile-api";
 import { ProfileSwitcher } from "./ProfileSwitcher";
 import { ProfileManager } from "./ProfileManager";
 import { SettingsPanel } from "./SettingsPanel";
@@ -28,6 +29,17 @@ export function Chrome({ windowId }: ChromeProps) {
   const [switcherOpen, setSwitcherOpen] = useState(false);
   const [managerOpen, setManagerOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [profiles, setProfiles] = useState<Profile[] | null>(null);
+
+  const currentProfileId = win?.profileId ?? "";
+
+  useEffect(() => {
+    let cancelled = false;
+    listProfiles().then((list) => {
+      if (!cancelled) setProfiles(list);
+    });
+    return () => { cancelled = true; };
+  }, [currentProfileId]);
 
   if (!win) return null;
 
@@ -108,25 +120,32 @@ export function Chrome({ windowId }: ChromeProps) {
 
       {/* Profile chip — clicking opens the ProfileSwitcher dropdown */}
       <div className="relative">
-        <button
-          type="button"
-          onClick={() => {
-            setSettingsOpen(false);
-            setManagerOpen(false);
-            setSwitcherOpen((s) => !s);
-          }}
-          className="flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-shell-bg-deep border border-shell-border-subtle text-xs hover:bg-shell-hover"
-          aria-label={`Profile: ${win.profileId}`}
-          aria-haspopup="menu"
-          aria-expanded={switcherOpen}
-        >
-          <span
-            className="inline-block w-2 h-2 rounded-full"
-            style={{ backgroundColor: profileColor(win.profileId) }}
-            aria-hidden="true"
-          />
-          <span className="capitalize">{win.profileId}</span>
-        </button>
+        {(() => {
+          const activeProfile = profiles?.find((p) => p.profile_id === win.profileId);
+          const chipColor = activeProfile?.color ?? "#8b92a3";
+          const chipName = activeProfile?.name ?? win.profileId;
+          return (
+            <button
+              type="button"
+              onClick={() => {
+                setSettingsOpen(false);
+                setManagerOpen(false);
+                setSwitcherOpen((s) => !s);
+              }}
+              className="flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-shell-bg-deep border border-shell-border-subtle text-xs hover:bg-shell-hover"
+              aria-label={`Profile: ${win.profileId}`}
+              aria-haspopup="menu"
+              aria-expanded={switcherOpen}
+            >
+              <span
+                className="inline-block w-2 h-2 rounded-full"
+                style={{ backgroundColor: chipColor }}
+                aria-hidden="true"
+              />
+              <span className="capitalize">{chipName}</span>
+            </button>
+          );
+        })()}
         {switcherOpen && (
           <ProfileSwitcher
             windowId={windowId}
@@ -148,15 +167,3 @@ export function Chrome({ windowId }: ChromeProps) {
   );
 }
 
-// Default colors for the two seeded profiles. PR 5's ProfileSwitcher will
-// fetch real per-profile colors from the backend.
-function profileColor(profileId: string): string {
-  switch (profileId) {
-    case "personal":
-      return "#6c8df0";
-    case "work":
-      return "#f5b86b";
-    default:
-      return "#8b92a3";
-  }
-}

--- a/desktop/src/apps/BrowserApp/Chrome.tsx
+++ b/desktop/src/apps/BrowserApp/Chrome.tsx
@@ -12,6 +12,7 @@ import { useState } from "react";
 import { ArrowLeft, ArrowRight, RotateCw } from "lucide-react";
 import { useBrowserStore } from "@/stores/browser-store";
 import { ProfileSwitcher } from "./ProfileSwitcher";
+import { ProfileManager } from "./ProfileManager";
 
 interface ChromeProps {
   windowId: string;
@@ -24,6 +25,7 @@ export function Chrome({ windowId }: ChromeProps) {
   const goForward = useBrowserStore((s) => s.goForward);
   const navigateTab = useBrowserStore((s) => s.navigateTab);
   const [switcherOpen, setSwitcherOpen] = useState(false);
+  const [managerOpen, setManagerOpen] = useState(false);
 
   if (!win) return null;
 
@@ -101,10 +103,19 @@ export function Chrome({ windowId }: ChromeProps) {
           <ProfileSwitcher
             windowId={windowId}
             onClose={() => setSwitcherOpen(false)}
-            // PR 5 Task 5 will wire onManage to open ProfileManager
+            onManage={() => {
+              setSwitcherOpen(false);
+              setManagerOpen(true);
+            }}
           />
         )}
       </div>
+      {managerOpen && (
+        <ProfileManager
+          activeProfileId={win.profileId}
+          onClose={() => setManagerOpen(false)}
+        />
+      )}
     </div>
   );
 }

--- a/desktop/src/apps/BrowserApp/ProfileManager.test.tsx
+++ b/desktop/src/apps/BrowserApp/ProfileManager.test.tsx
@@ -193,6 +193,94 @@ describe("ProfileManager — close", () => {
   });
 });
 
+describe("ProfileManager — rename double-fire prevention", () => {
+  it("pressing Enter calls renameProfile exactly once, not twice", async () => {
+    let patchCount = 0;
+    // First GET returns original names; PATCH increments counter; subsequent GETs return renamed
+    global.fetch = vi.fn()
+      .mockImplementationOnce(() =>
+        Promise.resolve(mockListResponse([
+          { profile_id: "personal", name: "Personal", color: "#6c8df0", created_at: 0 },
+          { profile_id: "work", name: "Work", color: "#f5b86b", created_at: 0 },
+        ])),
+      )
+      .mockImplementation((url: string, opts: any) => {
+        if (opts?.method === "PATCH") {
+          patchCount++;
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              profile_id: "work",
+              name: "Work Renamed",
+              color: "#f5b86b",
+              created_at: 0,
+            }),
+          });
+        }
+        return Promise.resolve(mockListResponse([
+          { profile_id: "personal", name: "Personal", color: "#6c8df0", created_at: 0 },
+          { profile_id: "work", name: "Work Renamed", color: "#f5b86b", created_at: 0 },
+        ]));
+      });
+
+    render(
+      <ProfileManager
+        activeProfileId="personal"
+        onClose={() => {}}
+      />,
+    );
+    await waitFor(() => screen.getByText("Work"));
+
+    // Click rename on Work
+    const renameBtns = screen.getAllByLabelText(/rename work/i);
+    fireEvent.click(renameBtns[0]);
+
+    // Type new name and press Enter
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "Work Renamed" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    // Wait for the rename to complete — patchCount must be exactly 1
+    await waitFor(() => {
+      expect(patchCount).toBe(1);
+    });
+  });
+});
+
+describe("ProfileManager — network error handling", () => {
+  it("shows error banner when delete throws a network error", async () => {
+    global.fetch = vi.fn().mockImplementation((url: string, opts: any) => {
+      if (opts?.method === "DELETE") {
+        return Promise.reject(new Error("Network failure"));
+      }
+      return Promise.resolve(mockListResponse([
+        { profile_id: "personal", name: "Personal", color: "#6c8df0", created_at: 0 },
+        { profile_id: "work", name: "Work", color: "#f5b86b", created_at: 0 },
+      ]));
+    });
+
+    render(
+      <ProfileManager
+        activeProfileId="personal"
+        onClose={() => {}}
+      />,
+    );
+    await waitFor(() => screen.getByText("Work"));
+
+    // Click delete on Work
+    const deleteBtns = screen.getAllByLabelText(/delete profile work/i);
+    fireEvent.click(deleteBtns[0]);
+
+    await waitFor(() => screen.getByText(/this also clears all saved cookies/i));
+    fireEvent.click(screen.getByLabelText(/confirm delete/i));
+
+    // Error banner must appear
+    await waitFor(() => {
+      expect(screen.getByText(/network error/i)).toBeTruthy();
+    });
+  });
+});
+
 describe("ProfileManager — orphan recovery", () => {
   beforeEach(() => {
     // Reset browser store to a clean slate before each test

--- a/desktop/src/apps/BrowserApp/ProfileManager.test.tsx
+++ b/desktop/src/apps/BrowserApp/ProfileManager.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, beforeEach, vi, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { ProfileManager } from "./ProfileManager";
+import { useBrowserStore } from "@/stores/browser-store";
 
 const originalFetch = global.fetch;
 
@@ -189,5 +190,167 @@ describe("ProfileManager — close", () => {
     await waitFor(() => screen.getByText("Personal"));
     fireEvent.click(screen.getByLabelText(/close manager/i));
     expect(onClose).toHaveBeenCalled();
+  });
+});
+
+describe("ProfileManager — orphan recovery", () => {
+  beforeEach(() => {
+    // Reset browser store to a clean slate before each test
+    useBrowserStore.setState({ windows: {} });
+  });
+
+  it("Test A: recovers orphan windows in other windows after delete", async () => {
+    // Set up two windows: window-a on personal, window-b on work
+    useBrowserStore.getState().createWindow("window-a", "personal");
+    useBrowserStore.getState().createWindow("window-b", "work");
+
+    // Mock: DELETE succeeds, then GET list returns only personal (work was removed)
+    global.fetch = vi.fn().mockImplementation((url: string, opts: any) => {
+      if (opts?.method === "DELETE") {
+        return Promise.resolve({ ok: true, status: 204 });
+      }
+      // GET /profiles — return only personal after delete
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          profiles: [
+            { profile_id: "personal", name: "Personal", color: "#6c8df0", created_at: 0 },
+          ],
+        }),
+      });
+    });
+
+    // Render ProfileManager as if the user in window-a opened it (active = personal)
+    render(
+      <ProfileManager
+        activeProfileId="personal"
+        onClose={() => {}}
+      />,
+    );
+
+    // Wait for the initial profile list (which initially has personal + work)
+    // But we've already set up fetch to return only personal, so wait for Work to appear
+    // via the initial load mock — we need to override the initial load too.
+    // Let's wait for the list to settle: the first GET returns personal only (no work).
+    // Because the fetch is mocked to return personal-only for ALL GETs, the list
+    // will show only Personal. We won't see Work in the UI.
+    // To properly test the flow, we need Work in the initial list.
+    // Re-mock: first GET returns both, DELETE succeeds, second GET returns only personal.
+    global.fetch = vi.fn()
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            profiles: [
+              { profile_id: "personal", name: "Personal", color: "#6c8df0", created_at: 0 },
+              { profile_id: "work", name: "Work", color: "#f5b86b", created_at: 0 },
+            ],
+          }),
+        }),
+      )
+      .mockImplementationOnce(() =>
+        Promise.resolve({ ok: true, status: 204 }),
+      )
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            profiles: [
+              { profile_id: "personal", name: "Personal", color: "#6c8df0", created_at: 0 },
+            ],
+          }),
+        }),
+      );
+
+    // Re-render with correct mock sequence
+    const { unmount } = render(
+      <ProfileManager
+        activeProfileId="personal"
+        onClose={() => {}}
+      />,
+    );
+
+    await waitFor(() => screen.getAllByText("Work")[0]);
+
+    // Click delete on Work
+    const deleteBtns = screen.getAllByLabelText(/delete profile work/i);
+    fireEvent.click(deleteBtns[deleteBtns.length - 1]);
+
+    // Confirm the deletion
+    await waitFor(() => screen.getAllByText(/this also clears all saved cookies/i)[0]);
+    const confirmBtns = screen.getAllByLabelText(/confirm delete/i);
+    fireEvent.click(confirmBtns[confirmBtns.length - 1]);
+
+    // After delete completes, window-b should have been switched to personal
+    await waitFor(() => {
+      const windowB = useBrowserStore.getState().windows["window-b"];
+      expect(windowB?.profileId).toBe("personal");
+    });
+
+    unmount();
+  });
+
+  it("Test B: no switchProfile called when deleted profile is not in any window", async () => {
+    // Set up a single window on personal; work profile is not in any window
+    useBrowserStore.getState().createWindow("window-a", "personal");
+
+    // Spy on switchProfile
+    const switchProfileSpy = vi.spyOn(useBrowserStore.getState(), "switchProfile");
+
+    global.fetch = vi.fn()
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            profiles: [
+              { profile_id: "personal", name: "Personal", color: "#6c8df0", created_at: 0 },
+              { profile_id: "work", name: "Work", color: "#f5b86b", created_at: 0 },
+            ],
+          }),
+        }),
+      )
+      .mockImplementationOnce(() =>
+        Promise.resolve({ ok: true, status: 204 }),
+      )
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            profiles: [
+              { profile_id: "personal", name: "Personal", color: "#6c8df0", created_at: 0 },
+            ],
+          }),
+        }),
+      );
+
+    render(
+      <ProfileManager
+        activeProfileId="personal"
+        onClose={() => {}}
+      />,
+    );
+
+    await waitFor(() => screen.getByText("Work"));
+
+    // Click delete on Work
+    const deleteBtns = screen.getAllByLabelText(/delete profile work/i);
+    fireEvent.click(deleteBtns[0]);
+
+    await waitFor(() => screen.getByText(/this also clears all saved cookies/i));
+    fireEvent.click(screen.getByLabelText(/confirm delete/i));
+
+    // After delete, window-a should still be on personal (no switch needed)
+    await waitFor(() => {
+      const windowA = useBrowserStore.getState().windows["window-a"];
+      expect(windowA?.profileId).toBe("personal");
+    });
+
+    // switchProfile should NOT have been called (no window was on work)
+    expect(switchProfileSpy).not.toHaveBeenCalled();
   });
 });

--- a/desktop/src/apps/BrowserApp/ProfileManager.test.tsx
+++ b/desktop/src/apps/BrowserApp/ProfileManager.test.tsx
@@ -1,0 +1,193 @@
+import { describe, expect, it, beforeEach, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ProfileManager } from "./ProfileManager";
+
+const originalFetch = global.fetch;
+
+function mockListResponse(profiles: any[]) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({ profiles }),
+  };
+}
+
+beforeEach(() => {
+  global.fetch = vi.fn().mockResolvedValue(
+    mockListResponse([
+      { profile_id: "personal", name: "Personal", color: "#6c8df0", created_at: 0 },
+      { profile_id: "work", name: "Work", color: "#f5b86b", created_at: 0 },
+    ]),
+  );
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe("ProfileManager — list view", () => {
+  it("renders all profiles after loading", async () => {
+    render(
+      <ProfileManager
+        activeProfileId="personal"
+        onClose={() => {}}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText("Personal")).toBeTruthy();
+      expect(screen.getByText("Work")).toBeTruthy();
+    });
+  });
+
+  it("each profile row has rename + delete buttons", async () => {
+    render(
+      <ProfileManager
+        activeProfileId="personal"
+        onClose={() => {}}
+      />,
+    );
+    await waitFor(() => {
+      const rename = screen.getAllByLabelText(/rename/i);
+      expect(rename.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  it("delete button on the active profile is disabled", async () => {
+    render(
+      <ProfileManager
+        activeProfileId="personal"
+        onClose={() => {}}
+      />,
+    );
+    await waitFor(() => screen.getByText("Personal"));
+
+    const deleteBtns = screen.getAllByLabelText(/delete profile/i);
+    // Find the one inside the Personal row
+    const personalRow = screen.getByText("Personal").closest('[role="listitem"], li, div');
+    const deleteBtn = deleteBtns.find((b) => personalRow?.contains(b)) as HTMLButtonElement;
+    expect(deleteBtn?.disabled).toBe(true);
+  });
+});
+
+describe("ProfileManager — create flow", () => {
+  it("Add profile form takes name + color, posts to backend", async () => {
+    let postBody: any = null;
+    global.fetch = vi.fn().mockImplementation((url, opts) => {
+      if (opts?.method === "POST") {
+        postBody = JSON.parse(opts.body as string);
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            profile_id: "research",
+            name: postBody.name,
+            color: postBody.color,
+            created_at: 0,
+          }),
+        });
+      }
+      // Default: list returns initial 2 profiles
+      return Promise.resolve(mockListResponse([
+        { profile_id: "personal", name: "Personal", color: "#6c8df0", created_at: 0 },
+        { profile_id: "work", name: "Work", color: "#f5b86b", created_at: 0 },
+      ]));
+    });
+
+    render(
+      <ProfileManager
+        activeProfileId="personal"
+        onClose={() => {}}
+      />,
+    );
+    await waitFor(() => screen.getByText("Personal"));
+
+    // Open the add form
+    fireEvent.click(screen.getByLabelText(/add profile/i));
+    const nameInput = screen.getByLabelText(/profile name/i);
+    fireEvent.change(nameInput, { target: { value: "Research" } });
+
+    // Pick a color swatch (any one)
+    const swatches = screen.getAllByLabelText(/color/i);
+    if (swatches.length > 0) fireEvent.click(swatches[0]);
+
+    fireEvent.click(screen.getByLabelText(/^create$/i));
+
+    await waitFor(() => {
+      expect(postBody).not.toBeNull();
+      expect(postBody.name).toBe("Research");
+    });
+  });
+});
+
+describe("ProfileManager — delete flow", () => {
+  it("delete button shows confirmation with cookie-cascade warning", async () => {
+    render(
+      <ProfileManager
+        activeProfileId="personal"
+        onClose={() => {}}
+      />,
+    );
+    await waitFor(() => screen.getByText("Work"));
+
+    // Click delete on Work (not active)
+    const deleteBtns = screen.getAllByLabelText(/delete profile/i);
+    const workRow = screen.getByText("Work").closest('[role="listitem"], li, div');
+    const workDelete = deleteBtns.find((b) => workRow?.contains(b)) as HTMLButtonElement;
+    fireEvent.click(workDelete);
+
+    // Confirmation should appear
+    await waitFor(() => {
+      expect(screen.getByText(/this also clears all saved cookies/i)).toBeTruthy();
+    });
+  });
+
+  it("confirming delete sends DELETE request", async () => {
+    let deleteUrl: string | null = null;
+    global.fetch = vi.fn().mockImplementation((url, opts) => {
+      if (opts?.method === "DELETE") {
+        deleteUrl = url as string;
+        return Promise.resolve({ ok: true, status: 204 });
+      }
+      return Promise.resolve(mockListResponse([
+        { profile_id: "personal", name: "Personal", color: "#6c8df0", created_at: 0 },
+        { profile_id: "work", name: "Work", color: "#f5b86b", created_at: 0 },
+      ]));
+    });
+
+    render(
+      <ProfileManager
+        activeProfileId="personal"
+        onClose={() => {}}
+      />,
+    );
+    await waitFor(() => screen.getByText("Work"));
+
+    const deleteBtns = screen.getAllByLabelText(/delete profile/i);
+    const workRow = screen.getByText("Work").closest('[role="listitem"], li, div');
+    const workDelete = deleteBtns.find((b) => workRow?.contains(b)) as HTMLButtonElement;
+    fireEvent.click(workDelete);
+
+    await waitFor(() => screen.getByText(/this also clears all saved cookies/i));
+
+    fireEvent.click(screen.getByLabelText(/confirm delete/i));
+
+    await waitFor(() => {
+      expect(deleteUrl).toContain("/api/desktop/browser/profiles/work");
+    });
+  });
+});
+
+describe("ProfileManager — close", () => {
+  it("close button calls onClose", async () => {
+    const onClose = vi.fn();
+    render(
+      <ProfileManager
+        activeProfileId="personal"
+        onClose={onClose}
+      />,
+    );
+    await waitFor(() => screen.getByText("Personal"));
+    fireEvent.click(screen.getByLabelText(/close manager/i));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/desktop/src/apps/BrowserApp/ProfileManager.test.tsx
+++ b/desktop/src/apps/BrowserApp/ProfileManager.test.tsx
@@ -292,39 +292,7 @@ describe("ProfileManager — orphan recovery", () => {
     useBrowserStore.getState().createWindow("window-a", "personal");
     useBrowserStore.getState().createWindow("window-b", "work");
 
-    // Mock: DELETE succeeds, then GET list returns only personal (work was removed)
-    global.fetch = vi.fn().mockImplementation((url: string, opts: any) => {
-      if (opts?.method === "DELETE") {
-        return Promise.resolve({ ok: true, status: 204 });
-      }
-      // GET /profiles — return only personal after delete
-      return Promise.resolve({
-        ok: true,
-        status: 200,
-        json: async () => ({
-          profiles: [
-            { profile_id: "personal", name: "Personal", color: "#6c8df0", created_at: 0 },
-          ],
-        }),
-      });
-    });
-
-    // Render ProfileManager as if the user in window-a opened it (active = personal)
-    render(
-      <ProfileManager
-        activeProfileId="personal"
-        onClose={() => {}}
-      />,
-    );
-
-    // Wait for the initial profile list (which initially has personal + work)
-    // But we've already set up fetch to return only personal, so wait for Work to appear
-    // via the initial load mock — we need to override the initial load too.
-    // Let's wait for the list to settle: the first GET returns personal only (no work).
-    // Because the fetch is mocked to return personal-only for ALL GETs, the list
-    // will show only Personal. We won't see Work in the UI.
-    // To properly test the flow, we need Work in the initial list.
-    // Re-mock: first GET returns both, DELETE succeeds, second GET returns only personal.
+    // First GET returns both profiles; DELETE succeeds; second GET returns only personal.
     global.fetch = vi.fn()
       .mockImplementationOnce(() =>
         Promise.resolve({
@@ -353,32 +321,28 @@ describe("ProfileManager — orphan recovery", () => {
         }),
       );
 
-    // Re-render with correct mock sequence
-    const { unmount } = render(
+    render(
       <ProfileManager
         activeProfileId="personal"
         onClose={() => {}}
       />,
     );
 
-    await waitFor(() => screen.getAllByText("Work")[0]);
+    await waitFor(() => screen.getByText("Work"));
 
     // Click delete on Work
-    const deleteBtns = screen.getAllByLabelText(/delete profile work/i);
-    fireEvent.click(deleteBtns[deleteBtns.length - 1]);
+    const deleteBtn = screen.getByLabelText(/delete profile work/i);
+    fireEvent.click(deleteBtn);
 
     // Confirm the deletion
-    await waitFor(() => screen.getAllByText(/this also clears all saved cookies/i)[0]);
-    const confirmBtns = screen.getAllByLabelText(/confirm delete/i);
-    fireEvent.click(confirmBtns[confirmBtns.length - 1]);
+    await waitFor(() => screen.getByText(/this also clears all saved cookies/i));
+    fireEvent.click(screen.getByLabelText(/confirm delete/i));
 
     // After delete completes, window-b should have been switched to personal
     await waitFor(() => {
       const windowB = useBrowserStore.getState().windows["window-b"];
       expect(windowB?.profileId).toBe("personal");
     });
-
-    unmount();
   });
 
   it("Test B: no switchProfile called when deleted profile is not in any window", async () => {

--- a/desktop/src/apps/BrowserApp/ProfileManager.tsx
+++ b/desktop/src/apps/BrowserApp/ProfileManager.tsx
@@ -8,7 +8,7 @@
  * - Delete confirmation includes explicit cookie-cascade warning
  * - Create form has 8 preset color swatches matching the chrome palette
  */
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Trash2, Edit2, Plus, X, Check } from "lucide-react";
 import {
   listProfiles,
@@ -44,6 +44,11 @@ export function ProfileManager({ activeProfileId, onClose }: ProfileManagerProps
   const [newName, setNewName] = useState("");
   const [newColor, setNewColor] = useState(COLOR_SWATCHES[0]);
   const [error, setError] = useState<string | null>(null);
+  // Tracks the profile currently being renamed to prevent double-fire:
+  // pressing Enter triggers handleRename → setEditingId(null) → input unmounts
+  // → native blur fires → onBlur calls handleRename again. The ref guard
+  // makes the second call a no-op.
+  const renamingRef = useRef<string | null>(null);
 
   async function reload() {
     const fresh = await listProfiles();
@@ -55,69 +60,87 @@ export function ProfileManager({ activeProfileId, onClose }: ProfileManagerProps
   }, []);
 
   async function handleRename(id: string) {
+    if (renamingRef.current === id) return;
+    setError(null);
     if (!editName.trim()) {
       setEditingId(null);
       return;
     }
-    const updated = await renameProfile(id, { name: editName.trim() });
-    if (updated) {
-      await reload();
-    } else {
-      setError("Rename failed");
+    renamingRef.current = id;
+    try {
+      const updated = await renameProfile(id, { name: editName.trim() });
+      if (updated) {
+        await reload();
+      } else {
+        setError("Rename failed");
+      }
+    } catch {
+      setError("Network error — could not rename profile");
+    } finally {
+      renamingRef.current = null;
+      setEditingId(null);
     }
-    setEditingId(null);
   }
 
   async function handleDelete(id: string) {
-    const ok = await deleteProfile(id);
-    if (!ok) {
-      setError("Delete failed (cannot delete last profile)");
-      setConfirmDeleteId(null);
-      return;
-    }
+    setError(null);
+    setConfirmDeleteId(null);
+    try {
+      const ok = await deleteProfile(id);
+      if (!ok) {
+        setError("Delete failed (cannot delete last profile)");
+        return;
+      }
 
-    // Re-read profiles from server (UI list update + fallback computation)
-    const fresh = await listProfiles();
-    setProfiles(fresh);
+      // Re-read profiles from server (UI list update + fallback computation)
+      const fresh = await listProfiles();
+      setProfiles(fresh);
 
-    // Recover any windows that were pointing at the just-deleted profile.
-    // Without this, those windows would orphan onto a non-existent profile_id
-    // and the proxy + profile chip would silently break.
-    const fallback = fresh?.[0]?.profile_id;
-    if (fallback) {
-      const windows = useBrowserStore.getState().windows;
-      for (const win of Object.values(windows)) {
-        if (win.profileId === id) {
-          useBrowserStore.getState().switchProfile(win.windowId, fallback);
+      // Recover any windows that were pointing at the just-deleted profile.
+      // Without this, those windows would orphan onto a non-existent profile_id
+      // and the proxy + profile chip would silently break.
+      const fallback = fresh?.[0]?.profile_id;
+      if (fallback) {
+        const windows = useBrowserStore.getState().windows;
+        for (const win of Object.values(windows)) {
+          if (win.profileId === id) {
+            useBrowserStore.getState().switchProfile(win.windowId, fallback);
+          }
         }
       }
+    } catch {
+      setError("Network error — could not delete profile");
     }
-
-    setConfirmDeleteId(null);
   }
 
   async function handleCreate() {
+    setError(null);
     if (!newName.trim()) return;
-    const created = await createProfile({ name: newName.trim(), color: newColor });
-    if (created) {
-      setNewName("");
-      setNewColor(COLOR_SWATCHES[0]);
-      setAdding(false);
-      await reload();
-    } else {
-      setError("Create failed");
+    try {
+      const created = await createProfile({ name: newName.trim(), color: newColor });
+      if (created) {
+        setNewName("");
+        setNewColor(COLOR_SWATCHES[0]);
+        setAdding(false);
+        await reload();
+      } else {
+        setError("Create failed");
+      }
+    } catch {
+      setError("Network error — could not create profile");
     }
   }
 
   return (
     <div
       role="dialog"
+      aria-modal="true"
       aria-label="Manage profiles"
       className="fixed inset-0 z-[70] flex items-center justify-center bg-black/40 p-4"
       onClick={onClose}
     >
       <div
-        className="bg-shell-surface rounded-md shadow-xl border border-shell-border w-[420px] max-w-full max-h-[80vh] flex flex-col"
+        className="relative bg-shell-surface rounded-md shadow-xl border border-shell-border w-[420px] max-w-full max-h-[80vh] flex flex-col"
         onClick={(e) => e.stopPropagation()}
       >
         <header className="flex items-center justify-between px-4 py-3 border-b border-shell-border-subtle">

--- a/desktop/src/apps/BrowserApp/ProfileManager.tsx
+++ b/desktop/src/apps/BrowserApp/ProfileManager.tsx
@@ -17,6 +17,7 @@ import {
   deleteProfile,
   type Profile,
 } from "@/lib/browser-profile-api";
+import { useBrowserStore } from "@/stores/browser-store";
 
 const COLOR_SWATCHES = [
   "#6c8df0",
@@ -69,11 +70,29 @@ export function ProfileManager({ activeProfileId, onClose }: ProfileManagerProps
 
   async function handleDelete(id: string) {
     const ok = await deleteProfile(id);
-    if (ok) {
-      await reload();
-    } else {
+    if (!ok) {
       setError("Delete failed (cannot delete last profile)");
+      setConfirmDeleteId(null);
+      return;
     }
+
+    // Re-read profiles from server (UI list update + fallback computation)
+    const fresh = await listProfiles();
+    setProfiles(fresh);
+
+    // Recover any windows that were pointing at the just-deleted profile.
+    // Without this, those windows would orphan onto a non-existent profile_id
+    // and the proxy + profile chip would silently break.
+    const fallback = fresh?.[0]?.profile_id;
+    if (fallback) {
+      const windows = useBrowserStore.getState().windows;
+      for (const win of Object.values(windows)) {
+        if (win.profileId === id) {
+          useBrowserStore.getState().switchProfile(win.windowId, fallback);
+        }
+      }
+    }
+
     setConfirmDeleteId(null);
   }
 

--- a/desktop/src/apps/BrowserApp/ProfileManager.tsx
+++ b/desktop/src/apps/BrowserApp/ProfileManager.tsx
@@ -1,0 +1,290 @@
+/**
+ * Modal for full profile CRUD: rename + delete + create.
+ *
+ * Opened from ProfileSwitcher's "Manage profiles…" footer.
+ *
+ * - Active profile: delete button disabled (with tooltip)
+ * - Last profile delete: backend rejects with 400; UI surfaces an error
+ * - Delete confirmation includes explicit cookie-cascade warning
+ * - Create form has 8 preset color swatches matching the chrome palette
+ */
+import { useEffect, useState } from "react";
+import { Trash2, Edit2, Plus, X, Check } from "lucide-react";
+import {
+  listProfiles,
+  createProfile,
+  renameProfile,
+  deleteProfile,
+  type Profile,
+} from "@/lib/browser-profile-api";
+
+const COLOR_SWATCHES = [
+  "#6c8df0",
+  "#f5b86b",
+  "#88aa44",
+  "#cc6644",
+  "#9966cc",
+  "#44aabb",
+  "#cc44aa",
+  "#888888",
+];
+
+interface ProfileManagerProps {
+  activeProfileId: string;
+  onClose: () => void;
+}
+
+export function ProfileManager({ activeProfileId, onClose }: ProfileManagerProps) {
+  const [profiles, setProfiles] = useState<Profile[] | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editName, setEditName] = useState("");
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  const [adding, setAdding] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [newColor, setNewColor] = useState(COLOR_SWATCHES[0]);
+  const [error, setError] = useState<string | null>(null);
+
+  async function reload() {
+    const fresh = await listProfiles();
+    setProfiles(fresh);
+  }
+
+  useEffect(() => {
+    reload();
+  }, []);
+
+  async function handleRename(id: string) {
+    if (!editName.trim()) {
+      setEditingId(null);
+      return;
+    }
+    const updated = await renameProfile(id, { name: editName.trim() });
+    if (updated) {
+      await reload();
+    } else {
+      setError("Rename failed");
+    }
+    setEditingId(null);
+  }
+
+  async function handleDelete(id: string) {
+    const ok = await deleteProfile(id);
+    if (ok) {
+      await reload();
+    } else {
+      setError("Delete failed (cannot delete last profile)");
+    }
+    setConfirmDeleteId(null);
+  }
+
+  async function handleCreate() {
+    if (!newName.trim()) return;
+    const created = await createProfile({ name: newName.trim(), color: newColor });
+    if (created) {
+      setNewName("");
+      setNewColor(COLOR_SWATCHES[0]);
+      setAdding(false);
+      await reload();
+    } else {
+      setError("Create failed");
+    }
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Manage profiles"
+      className="fixed inset-0 z-[70] flex items-center justify-center bg-black/40 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-shell-surface rounded-md shadow-xl border border-shell-border w-[420px] max-w-full max-h-[80vh] flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="flex items-center justify-between px-4 py-3 border-b border-shell-border-subtle">
+          <h2 className="text-sm font-medium">Manage profiles</h2>
+          <button
+            type="button"
+            aria-label="Close manager"
+            onClick={onClose}
+            className="p-1 rounded hover:bg-shell-hover"
+          >
+            <X size={16} />
+          </button>
+        </header>
+
+        {error && (
+          <div className="mx-4 mt-3 px-3 py-2 rounded bg-red-500/10 border border-red-500/30 text-red-400 text-xs">
+            {error}
+          </div>
+        )}
+
+        <ul role="list" className="flex-1 overflow-y-auto py-2 px-2">
+          {profiles === null ? (
+            <li className="px-2 py-2 text-xs opacity-60 italic">Loading…</li>
+          ) : profiles.length === 0 ? (
+            <li className="px-2 py-2 text-xs opacity-60 italic">No profiles</li>
+          ) : (
+            profiles.map((p) => {
+              const isActive = p.profile_id === activeProfileId;
+              return (
+                <li
+                  key={p.profile_id}
+                  role="listitem"
+                  className="flex items-center gap-2 px-2 py-2 hover:bg-shell-hover rounded"
+                >
+                  <span
+                    className="inline-block w-3 h-3 rounded-full shrink-0"
+                    style={{ backgroundColor: p.color ?? "#8b92a3" }}
+                    aria-hidden="true"
+                  />
+                  {editingId === p.profile_id ? (
+                    <input
+                      type="text"
+                      autoFocus
+                      value={editName}
+                      onChange={(e) => setEditName(e.target.value)}
+                      onBlur={() => handleRename(p.profile_id)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") handleRename(p.profile_id);
+                        if (e.key === "Escape") setEditingId(null);
+                      }}
+                      className="flex-1 bg-shell-bg-deep border border-shell-border-subtle rounded px-1.5 py-0.5 text-xs outline-none focus:border-accent"
+                    />
+                  ) : (
+                    <span className="flex-1 text-sm">{p.name}</span>
+                  )}
+                  <button
+                    type="button"
+                    aria-label={`Rename ${p.name}`}
+                    onClick={() => {
+                      setEditingId(p.profile_id);
+                      setEditName(p.name);
+                    }}
+                    className="p-1 rounded hover:bg-shell-hover"
+                  >
+                    <Edit2 size={12} />
+                  </button>
+                  <button
+                    type="button"
+                    aria-label={`Delete profile ${p.name}`}
+                    disabled={isActive}
+                    title={isActive ? "Cannot delete the active profile" : "Delete"}
+                    onClick={() => setConfirmDeleteId(p.profile_id)}
+                    className="p-1 rounded hover:bg-shell-hover disabled:opacity-30 disabled:cursor-not-allowed"
+                  >
+                    <Trash2 size={12} />
+                  </button>
+                </li>
+              );
+            })
+          )}
+        </ul>
+
+        {/* Add profile section */}
+        <div className="border-t border-shell-border-subtle p-2">
+          {adding ? (
+            <div className="space-y-2 px-2 py-1">
+              <input
+                type="text"
+                aria-label="Profile name"
+                autoFocus
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                placeholder="Profile name"
+                className="w-full bg-shell-bg-deep border border-shell-border-subtle rounded px-2 py-1 text-xs outline-none focus:border-accent"
+              />
+              <div className="flex gap-1.5 items-center" role="radiogroup" aria-label="Profile color">
+                {COLOR_SWATCHES.map((c) => (
+                  <button
+                    key={c}
+                    type="button"
+                    role="radio"
+                    aria-label={`Color ${c}`}
+                    aria-checked={newColor === c}
+                    onClick={() => setNewColor(c)}
+                    className={[
+                      "w-5 h-5 rounded-full border-2",
+                      newColor === c ? "border-accent" : "border-transparent",
+                    ].join(" ")}
+                    style={{ backgroundColor: c }}
+                  />
+                ))}
+              </div>
+              <div className="flex gap-1 justify-end">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setAdding(false);
+                    setNewName("");
+                    setNewColor(COLOR_SWATCHES[0]);
+                  }}
+                  className="px-2 py-1 rounded hover:bg-shell-hover text-xs"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  aria-label="Create"
+                  onClick={handleCreate}
+                  className="px-2 py-1 rounded bg-accent text-shell-bg text-xs"
+                >
+                  Create
+                </button>
+              </div>
+            </div>
+          ) : (
+            <button
+              type="button"
+              aria-label="Add profile"
+              onClick={() => setAdding(true)}
+              className="w-full text-left px-2 py-1.5 hover:bg-shell-hover flex items-center gap-1.5 text-xs"
+            >
+              <Plus size={12} />
+              Add profile
+            </button>
+          )}
+        </div>
+
+        {/* Delete confirmation */}
+        {confirmDeleteId && (
+          <div
+            role="alertdialog"
+            aria-label="Delete profile confirmation"
+            className="absolute inset-0 z-10 flex items-center justify-center bg-black/30 rounded-md"
+          >
+            <div className="bg-shell-surface border border-shell-border rounded shadow-xl p-4 max-w-[320px] w-full mx-3">
+              <p className="text-sm mb-1">
+                Delete profile{" "}
+                <strong>
+                  {profiles?.find((p) => p.profile_id === confirmDeleteId)?.name ?? confirmDeleteId}
+                </strong>?
+              </p>
+              <p className="text-xs text-shell-text-secondary mb-3">
+                This also clears all saved cookies for this profile.
+              </p>
+              <div className="flex gap-2 justify-end">
+                <button
+                  type="button"
+                  onClick={() => setConfirmDeleteId(null)}
+                  className="px-3 py-1 rounded hover:bg-shell-hover text-xs"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  aria-label="Confirm delete"
+                  onClick={() => handleDelete(confirmDeleteId)}
+                  className="px-3 py-1 rounded bg-red-500 text-white text-xs flex items-center gap-1"
+                >
+                  <Check size={12} />
+                  Delete
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/apps/BrowserApp/ProfileManager.tsx
+++ b/desktop/src/apps/BrowserApp/ProfileManager.tsx
@@ -88,7 +88,7 @@ export function ProfileManager({ activeProfileId, onClose }: ProfileManagerProps
     try {
       const ok = await deleteProfile(id);
       if (!ok) {
-        setError("Delete failed (cannot delete last profile)");
+        setError("Delete failed");
         return;
       }
 

--- a/desktop/src/apps/BrowserApp/ProfileSwitcher.test.tsx
+++ b/desktop/src/apps/BrowserApp/ProfileSwitcher.test.tsx
@@ -1,0 +1,109 @@
+import { describe, expect, it, beforeEach, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ProfileSwitcher } from "./ProfileSwitcher";
+import { useBrowserStore } from "@/stores/browser-store";
+
+const TEST_WINDOW_ID = "win-test";
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  useBrowserStore.setState({ windows: {} });
+  useBrowserStore.getState().createWindow(TEST_WINDOW_ID, "personal");
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      profiles: [
+        { profile_id: "personal", name: "Personal", color: "#6c8df0", created_at: 0 },
+        { profile_id: "work", name: "Work", color: "#f5b86b", created_at: 0 },
+      ],
+    }),
+  });
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe("ProfileSwitcher", () => {
+  it("renders profiles after loading", async () => {
+    render(
+      <ProfileSwitcher windowId={TEST_WINDOW_ID} onClose={() => {}} />,
+    );
+    await waitFor(() => {
+      const items = screen.getAllByRole("menuitem");
+      // 2 profiles + "New profile" button = 3 menuitems minimum
+      expect(items.length).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  it("marks the active profile with aria-current", async () => {
+    render(
+      <ProfileSwitcher windowId={TEST_WINDOW_ID} onClose={() => {}} />,
+    );
+    await waitFor(() => {
+      const items = screen.getAllByRole("menuitem");
+      const active = items.find(
+        (i) => i.getAttribute("aria-current") === "true",
+      );
+      expect(active?.textContent?.toLowerCase()).toContain("personal");
+    });
+  });
+
+  it("clicking a different profile calls switchProfile + onClose", async () => {
+    const switchSpy = vi.spyOn(useBrowserStore.getState(), "switchProfile");
+    const onClose = vi.fn();
+    render(
+      <ProfileSwitcher windowId={TEST_WINDOW_ID} onClose={onClose} />,
+    );
+    await waitFor(() => screen.getAllByRole("menuitem"));
+
+    const items = screen.getAllByRole("menuitem");
+    const workBtn = items.find((i) =>
+      i.textContent?.toLowerCase().includes("work"),
+    );
+    fireEvent.click(workBtn!);
+    expect(switchSpy).toHaveBeenCalledWith(TEST_WINDOW_ID, "work");
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("clicking the active profile does NOT call switchProfile but does close", async () => {
+    const switchSpy = vi.spyOn(useBrowserStore.getState(), "switchProfile");
+    const onClose = vi.fn();
+    render(
+      <ProfileSwitcher windowId={TEST_WINDOW_ID} onClose={onClose} />,
+    );
+    await waitFor(() => screen.getAllByRole("menuitem"));
+
+    const items = screen.getAllByRole("menuitem");
+    const personalBtn = items.find((i) =>
+      i.getAttribute("aria-current") === "true",
+    );
+    fireEvent.click(personalBtn!);
+    expect(switchSpy).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("renders Manage footer when onManage prop provided", async () => {
+    const onManage = vi.fn();
+    render(
+      <ProfileSwitcher
+        windowId={TEST_WINDOW_ID}
+        onClose={() => {}}
+        onManage={onManage}
+      />,
+    );
+    await waitFor(() => screen.getAllByRole("menuitem"));
+    const manageBtn = screen.getByText(/manage profiles/i).closest("button");
+    expect(manageBtn).toBeTruthy();
+  });
+
+  it("does NOT render Manage footer when onManage prop omitted", async () => {
+    render(
+      <ProfileSwitcher windowId={TEST_WINDOW_ID} onClose={() => {}} />,
+    );
+    await waitFor(() => screen.getAllByRole("menuitem"));
+    expect(screen.queryByText(/manage profiles/i)).toBeNull();
+  });
+});

--- a/desktop/src/apps/BrowserApp/ProfileSwitcher.tsx
+++ b/desktop/src/apps/BrowserApp/ProfileSwitcher.tsx
@@ -1,0 +1,155 @@
+/**
+ * Profile dropdown. Anchored to the profile chip in Chrome.tsx.
+ * Lists user's profiles + check-mark on active + Manage footer.
+ *
+ * Manage footer calls the `onManage` callback supplied by the parent
+ * (Chrome.tsx). PR 5 Task 5 will wire that to open the ProfileManager
+ * modal; for Task 4 the parent provides a no-op placeholder.
+ */
+import { useEffect, useRef, useState } from "react";
+import { Check, Plus, Settings } from "lucide-react";
+import { useBrowserStore } from "@/stores/browser-store";
+import { listProfiles, type Profile } from "@/lib/browser-profile-api";
+
+interface ProfileSwitcherProps {
+  windowId: string;
+  onClose: () => void;
+  onManage?: () => void;
+}
+
+export function ProfileSwitcher({
+  windowId,
+  onClose,
+  onManage,
+}: ProfileSwitcherProps) {
+  const win = useBrowserStore((s) => s.windows[windowId]);
+  const switchProfile = useBrowserStore((s) => s.switchProfile);
+  const [profiles, setProfiles] = useState<Profile[] | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [newName, setNewName] = useState("");
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  // Load profiles on mount
+  useEffect(() => {
+    listProfiles().then(setProfiles);
+  }, []);
+
+  // Click-outside dismiss
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (!ref.current?.contains(e.target as Node)) onClose();
+    };
+    const id = setTimeout(() => window.addEventListener("mousedown", handler), 0);
+    return () => {
+      clearTimeout(id);
+      window.removeEventListener("mousedown", handler);
+    };
+  }, [onClose]);
+
+  if (!win) return null;
+
+  async function handleCreate() {
+    if (!newName.trim()) return;
+    const { createProfile } = await import("@/lib/browser-profile-api");
+    const created = await createProfile({ name: newName.trim() });
+    if (created) {
+      setProfiles((prev) => (prev ? [...prev, created] : [created]));
+      switchProfile(windowId, created.profile_id);
+      onClose();
+    }
+  }
+
+  return (
+    <div
+      ref={ref}
+      role="menu"
+      aria-label="Switch profile"
+      className="absolute z-[60] min-w-[220px] rounded-md bg-shell-surface border border-shell-border shadow-lg py-1 text-xs"
+    >
+      <div className="px-2 py-1 text-shell-text-tertiary uppercase tracking-wide text-[10px]">
+        Profiles
+      </div>
+
+      {profiles === null ? (
+        <div className="px-2 py-1 opacity-60 italic">Loading…</div>
+      ) : profiles.length === 0 ? (
+        <div className="px-2 py-1 opacity-60 italic">No profiles</div>
+      ) : (
+        profiles.map((p) => {
+          const isActive = p.profile_id === win.profileId;
+          return (
+            <button
+              key={p.profile_id}
+              type="button"
+              role="menuitem"
+              aria-current={isActive ? "true" : undefined}
+              onClick={() => {
+                if (!isActive) switchProfile(windowId, p.profile_id);
+                onClose();
+              }}
+              className="w-full text-left px-2 py-1 hover:bg-shell-hover flex items-center gap-2"
+            >
+              <span
+                className="inline-block w-2 h-2 rounded-full shrink-0"
+                style={{ backgroundColor: p.color ?? "#8b92a3" }}
+                aria-hidden="true"
+              />
+              <span className="capitalize flex-1">{p.name}</span>
+              {isActive && (
+                <Check size={12} className="opacity-70" aria-label="Active" />
+              )}
+            </button>
+          );
+        })
+      )}
+
+      <div className="border-t border-shell-border-subtle my-1" />
+
+      {creating ? (
+        <div className="px-2 py-1 flex gap-1">
+          <input
+            type="text"
+            aria-label="New profile name"
+            autoFocus
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleCreate();
+              if (e.key === "Escape") {
+                setCreating(false);
+                setNewName("");
+              }
+            }}
+            placeholder="Profile name"
+            className="flex-1 bg-shell-bg-deep border border-shell-border-subtle rounded px-1.5 py-0.5 text-xs outline-none focus:border-accent"
+          />
+        </div>
+      ) : (
+        <button
+          type="button"
+          role="menuitem"
+          onClick={() => setCreating(true)}
+          className="w-full text-left px-2 py-1 hover:bg-shell-hover flex items-center gap-1.5"
+        >
+          <Plus size={12} />
+          New profile
+        </button>
+      )}
+
+      {onManage && (
+        <button
+          type="button"
+          role="menuitem"
+          onClick={() => {
+            onManage();
+            onClose();
+          }}
+          className="w-full text-left px-2 py-1 hover:bg-shell-hover flex items-center gap-1.5"
+        >
+          <Settings size={12} />
+          Manage profiles…
+        </button>
+      )}
+    </div>
+  );
+}

--- a/desktop/src/apps/BrowserApp/ReaderMode.test.tsx
+++ b/desktop/src/apps/BrowserApp/ReaderMode.test.tsx
@@ -1,0 +1,138 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ReaderMode } from "./ReaderMode";
+import { useBrowserStore } from "@/stores/browser-store";
+import type { Tab } from "./types";
+
+const TEST_WINDOW_ID = "win-test";
+
+function makeTab(overrides: Partial<Tab> = {}): Tab {
+  return {
+    id: "tab-1",
+    url: "https://example.com/article",
+    title: "Test Tab",
+    pinned: false,
+    history: ["https://example.com/article"],
+    historyIndex: 0,
+    scrollY: 0,
+    zoom: 1,
+    state: "live",
+    lastActiveAt: Date.now(),
+    readerAvailable: true,
+    readerActive: true,
+    readerExtract: {
+      title: "Test Article Title",
+      text: "Some article text content here",
+      html: "<p>Some article text content here</p>",
+      word_count: 300,
+    },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  useBrowserStore.setState({ windows: {} });
+  useBrowserStore.getState().createWindow(TEST_WINDOW_ID, "personal");
+});
+
+describe("ReaderMode — rendering", () => {
+  it("renders the article title", () => {
+    const tab = makeTab();
+    render(<ReaderMode tab={tab} windowId={TEST_WINDOW_ID} />);
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "Test Article Title",
+    );
+  });
+
+  it("renders the source domain from tab URL", () => {
+    const tab = makeTab();
+    render(<ReaderMode tab={tab} windowId={TEST_WINDOW_ID} />);
+    expect(screen.getByText("example.com")).toBeInTheDocument();
+  });
+
+  it("renders sanitised HTML body", () => {
+    const tab = makeTab({
+      readerExtract: {
+        title: "Article",
+        text: "Real content",
+        html: "<p>Real content</p>",
+        word_count: 300,
+      },
+    });
+    render(<ReaderMode tab={tab} windowId={TEST_WINDOW_ID} />);
+    const body = screen.getByTestId("reader-body");
+    expect(body.querySelector("p")).toBeInTheDocument();
+    expect(body.textContent).toContain("Real content");
+  });
+
+  it("strips <script> tags from extract HTML before render (XSS safety)", () => {
+    const tab = makeTab({
+      readerExtract: {
+        title: "Article",
+        text: "real content",
+        html: "<script>alert(1)</script><p>real content</p>",
+        word_count: 300,
+      },
+    });
+    render(<ReaderMode tab={tab} windowId={TEST_WINDOW_ID} />);
+    const body = screen.getByTestId("reader-body");
+    expect(body.querySelector("script")).toBeNull();
+    expect(body.textContent).toContain("real content");
+  });
+
+  it("returns null when readerExtract is absent", () => {
+    const tab = makeTab({ readerExtract: null });
+    const { container } = render(<ReaderMode tab={tab} windowId={TEST_WINDOW_ID} />);
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+describe("ReaderMode — font controls", () => {
+  it("font size buttons change the aria-pressed state", () => {
+    const tab = makeTab();
+    render(<ReaderMode tab={tab} windowId={TEST_WINDOW_ID} />);
+
+    const smallBtn = screen.getByRole("button", { name: /font size small/i });
+    const mediumBtn = screen.getByRole("button", { name: /font size medium/i });
+
+    // Default is medium
+    expect(mediumBtn).toHaveAttribute("aria-pressed", "true");
+    expect(smallBtn).toHaveAttribute("aria-pressed", "false");
+
+    fireEvent.click(smallBtn);
+
+    expect(smallBtn).toHaveAttribute("aria-pressed", "true");
+    expect(mediumBtn).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("font family buttons toggle aria-pressed", () => {
+    const tab = makeTab();
+    render(<ReaderMode tab={tab} windowId={TEST_WINDOW_ID} />);
+
+    const serifBtn = screen.getByRole("button", { name: /font family serif/i });
+    const sansBtn = screen.getByRole("button", { name: /font family sans-serif/i });
+
+    // Default is serif
+    expect(serifBtn).toHaveAttribute("aria-pressed", "true");
+
+    fireEvent.click(sansBtn);
+    expect(sansBtn).toHaveAttribute("aria-pressed", "true");
+    expect(serifBtn).toHaveAttribute("aria-pressed", "false");
+  });
+});
+
+describe("ReaderMode — exit button", () => {
+  it("Exit Reader button calls setTabReader with readerActive: false", () => {
+    const setTabReaderSpy = vi.spyOn(useBrowserStore.getState(), "setTabReader");
+    const tab = makeTab();
+    render(<ReaderMode tab={tab} windowId={TEST_WINDOW_ID} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /exit reader mode/i }));
+
+    expect(setTabReaderSpy).toHaveBeenCalledWith(
+      TEST_WINDOW_ID,
+      "tab-1",
+      { readerActive: false },
+    );
+  });
+});

--- a/desktop/src/apps/BrowserApp/ReaderMode.test.tsx
+++ b/desktop/src/apps/BrowserApp/ReaderMode.test.tsx
@@ -80,6 +80,13 @@ describe("ReaderMode — rendering", () => {
     expect(body.textContent).toContain("real content");
   });
 
+  it("wraps content in an <article> element with aria-label", () => {
+    const tab = makeTab();
+    render(<ReaderMode tab={tab} windowId={TEST_WINDOW_ID} />);
+    expect(screen.getByRole("article")).toBeInTheDocument();
+    expect(screen.getByRole("article")).toHaveAttribute("aria-label", "Test Article Title");
+  });
+
   it("returns null when readerExtract is absent", () => {
     const tab = makeTab({ readerExtract: null });
     const { container } = render(<ReaderMode tab={tab} windowId={TEST_WINDOW_ID} />);

--- a/desktop/src/apps/BrowserApp/ReaderMode.tsx
+++ b/desktop/src/apps/BrowserApp/ReaderMode.tsx
@@ -1,0 +1,141 @@
+/**
+ * ReaderMode — replaces the active tab's iframe with a styled article view.
+ *
+ * The raw Readability HTML is sanitised through DOMPurify before rendering
+ * (XSS prevention). Font size and family are local component state.
+ */
+import { useState } from "react";
+import DOMPurify from "dompurify";
+import { useBrowserStore } from "@/stores/browser-store";
+import type { Tab } from "./types";
+
+type FontSize = "small" | "medium" | "large";
+type FontFamily = "serif" | "sans-serif";
+
+const FONT_SIZE_CLASS: Record<FontSize, string> = {
+  small: "text-sm leading-relaxed",
+  medium: "text-base leading-relaxed",
+  large: "text-lg leading-relaxed",
+};
+
+interface ReaderModeProps {
+  tab: Tab;
+  windowId: string;
+}
+
+export function ReaderMode({ tab, windowId }: ReaderModeProps) {
+  const setTabReader = useBrowserStore((s) => s.setTabReader);
+  const [fontSize, setFontSize] = useState<FontSize>("medium");
+  const [fontFamily, setFontFamily] = useState<FontFamily>("serif");
+
+  const extract = tab.readerExtract;
+  if (!extract) return null;
+
+  const sanitisedHtml = DOMPurify.sanitize(extract.html, {
+    USE_PROFILES: { html: true },
+  });
+
+  let sourceDomain = "";
+  try {
+    sourceDomain = new URL(tab.url).hostname;
+  } catch {
+    sourceDomain = tab.url;
+  }
+
+  const fontFamilyStyle =
+    fontFamily === "serif" ? "font-serif" : "font-sans";
+
+  return (
+    <div
+      data-testid="reader-mode"
+      className="absolute inset-0 overflow-y-auto bg-shell-surface text-shell-text"
+    >
+      <div className="mx-auto max-w-[700px] px-6 py-8">
+        {/* Toolbar */}
+        <div className="flex items-center justify-between mb-6 gap-4">
+          {/* Font size controls */}
+          <div
+            role="group"
+            aria-label="Font size"
+            className="flex items-center gap-1"
+          >
+            {(["small", "medium", "large"] as FontSize[]).map((size) => (
+              <button
+                key={size}
+                type="button"
+                aria-label={`Font size ${size}`}
+                aria-pressed={fontSize === size}
+                onClick={() => setFontSize(size)}
+                className={`px-2 py-1 rounded text-xs border ${
+                  fontSize === size
+                    ? "bg-accent text-white border-accent"
+                    : "border-shell-border-subtle hover:bg-shell-hover"
+                }`}
+              >
+                {size === "small" ? "Aˢ" : size === "medium" ? "A" : "Aᴷ"}
+                <span className="sr-only">{size}</span>
+              </button>
+            ))}
+          </div>
+
+          {/* Font family toggle */}
+          <div
+            role="group"
+            aria-label="Font family"
+            className="flex items-center gap-1"
+          >
+            {(["serif", "sans-serif"] as FontFamily[]).map((family) => (
+              <button
+                key={family}
+                type="button"
+                aria-label={`Font family ${family}`}
+                aria-pressed={fontFamily === family}
+                onClick={() => setFontFamily(family)}
+                className={`px-2 py-1 rounded text-xs border ${
+                  fontFamily === family
+                    ? "bg-accent text-white border-accent"
+                    : "border-shell-border-subtle hover:bg-shell-hover"
+                } ${family === "serif" ? "font-serif" : "font-sans"}`}
+              >
+                {family === "serif" ? "Serif" : "Sans"}
+              </button>
+            ))}
+          </div>
+
+          {/* Exit button */}
+          <button
+            type="button"
+            aria-label="Exit Reader mode"
+            onClick={() => setTabReader(windowId, tab.id, { readerActive: false })}
+            className="ml-auto px-3 py-1 rounded text-xs border border-shell-border-subtle hover:bg-shell-hover"
+          >
+            Exit Reader
+          </button>
+        </div>
+
+        {/* Article header */}
+        <h1
+          className={`font-bold mb-2 ${fontFamilyStyle} ${
+            fontSize === "small"
+              ? "text-xl"
+              : fontSize === "medium"
+                ? "text-2xl"
+                : "text-3xl"
+          }`}
+        >
+          {extract.title || tab.title || "Untitled"}
+        </h1>
+        {sourceDomain && (
+          <p className="text-shell-text-secondary text-xs mb-6">{sourceDomain}</p>
+        )}
+
+        {/* Article body — sanitisedHtml passed through DOMPurify above */}
+        <div
+          data-testid="reader-body"
+          className={`prose max-w-none ${fontFamilyStyle} ${FONT_SIZE_CLASS[fontSize]}`}
+          dangerouslySetInnerHTML={{ __html: sanitisedHtml }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/apps/BrowserApp/ReaderMode.tsx
+++ b/desktop/src/apps/BrowserApp/ReaderMode.tsx
@@ -4,7 +4,7 @@
  * The raw Readability HTML is sanitised through DOMPurify before rendering
  * (XSS prevention). Font size and family are local component state.
  */
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import DOMPurify from "dompurify";
 import { useBrowserStore } from "@/stores/browser-store";
 import type { Tab } from "./types";
@@ -29,11 +29,13 @@ export function ReaderMode({ tab, windowId }: ReaderModeProps) {
   const [fontFamily, setFontFamily] = useState<FontFamily>("serif");
 
   const extract = tab.readerExtract;
-  if (!extract) return null;
 
-  const sanitisedHtml = DOMPurify.sanitize(extract.html, {
-    USE_PROFILES: { html: true },
-  });
+  const sanitisedHtml = useMemo(
+    () => DOMPurify.sanitize(extract?.html ?? "", { USE_PROFILES: { html: true } }),
+    [extract?.html],
+  );
+
+  if (!extract) return null;
 
   let sourceDomain = "";
   try {
@@ -113,28 +115,30 @@ export function ReaderMode({ tab, windowId }: ReaderModeProps) {
           </button>
         </div>
 
-        {/* Article header */}
-        <h1
-          className={`font-bold mb-2 ${fontFamilyStyle} ${
-            fontSize === "small"
-              ? "text-xl"
-              : fontSize === "medium"
-                ? "text-2xl"
-                : "text-3xl"
-          }`}
-        >
-          {extract.title || tab.title || "Untitled"}
-        </h1>
-        {sourceDomain && (
-          <p className="text-shell-text-secondary text-xs mb-6">{sourceDomain}</p>
-        )}
+        {/* Article content */}
+        <article aria-label={extract.title || "Article"}>
+          <h1
+            className={`font-bold mb-2 ${fontFamilyStyle} ${
+              fontSize === "small"
+                ? "text-xl"
+                : fontSize === "medium"
+                  ? "text-2xl"
+                  : "text-3xl"
+            }`}
+          >
+            {extract.title || tab.title || "Untitled"}
+          </h1>
+          {sourceDomain && (
+            <p className="text-shell-text-secondary text-xs mb-6">{sourceDomain}</p>
+          )}
 
-        {/* Article body — sanitisedHtml passed through DOMPurify above */}
-        <div
-          data-testid="reader-body"
-          className={`prose max-w-none ${fontFamilyStyle} ${FONT_SIZE_CLASS[fontSize]}`}
-          dangerouslySetInnerHTML={{ __html: sanitisedHtml }}
-        />
+          {/* Article body — sanitisedHtml passed through DOMPurify above */}
+          <div
+            data-testid="reader-body"
+            className={`prose max-w-none ${fontFamilyStyle} ${FONT_SIZE_CLASS[fontSize]}`}
+            dangerouslySetInnerHTML={{ __html: sanitisedHtml }}
+          />
+        </article>
       </div>
     </div>
   );

--- a/desktop/src/apps/BrowserApp/SettingsPanel.test.tsx
+++ b/desktop/src/apps/BrowserApp/SettingsPanel.test.tsx
@@ -113,7 +113,7 @@ describe("SettingsPanel — TabRenderer wire-through (discard scheduler reads fr
     useBrowserSettingsStore.setState({ discardTimeoutMs: customTimeoutMs });
 
     const tabA = useBrowserStore.getState().getWindow(TEST_WINDOW_ID)!.tabs[0].id;
-    const tabB = useBrowserStore.getState().addTab(TEST_WINDOW_ID, "https://b.test/");
+    useBrowserStore.getState().addTab(TEST_WINDOW_ID, "https://b.test/");
 
     // tabA idle past the custom timeout but NOT past the default (10 min)
     // This proves TabRenderer reads from the store, not the DISCARD_TIMEOUT_MS constant
@@ -146,7 +146,7 @@ describe("SettingsPanel — TabRenderer wire-through (discard scheduler reads fr
     useBrowserSettingsStore.setState({ discardTimeoutMs: 30 * 60 * 1000 });
 
     const tabA = useBrowserStore.getState().getWindow(TEST_WINDOW_ID)!.tabs[0].id;
-    const tabB = useBrowserStore.getState().addTab(TEST_WINDOW_ID, "https://b.test/");
+    useBrowserStore.getState().addTab(TEST_WINDOW_ID, "https://b.test/");
 
     // tabA idle for only 11 minutes — past default (10 min) but within new 30 min timeout
     useBrowserStore.setState((s) => {

--- a/desktop/src/apps/BrowserApp/SettingsPanel.test.tsx
+++ b/desktop/src/apps/BrowserApp/SettingsPanel.test.tsx
@@ -1,0 +1,174 @@
+import { describe, expect, it, beforeEach, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { SettingsPanel } from "./SettingsPanel";
+import { TabRenderer, DISCARD_TIMEOUT_MS } from "./TabRenderer";
+import { useBrowserSettingsStore } from "@/stores/browser-settings-store";
+import { useBrowserStore } from "@/stores/browser-store";
+
+const TEST_WINDOW_ID = "win-settings-test";
+
+beforeEach(() => {
+  useBrowserSettingsStore.setState({
+    discardTimeoutMs: 10 * 60 * 1000,
+    maxLiveTabs: 12,
+    searchEngine: "duckduckgo",
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("SettingsPanel — rendering", () => {
+  it("renders with role=dialog and aria-label", () => {
+    render(<SettingsPanel onClose={() => {}} />);
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toBeTruthy();
+    expect(dialog.getAttribute("aria-label")).toMatch(/browser settings/i);
+  });
+
+  it("renders close button", () => {
+    render(<SettingsPanel onClose={() => {}} />);
+    expect(screen.getByRole("button", { name: /close/i })).toBeTruthy();
+  });
+
+  it("renders discard timeout slider with accessible label", () => {
+    render(<SettingsPanel onClose={() => {}} />);
+    const slider = screen.getByRole("slider");
+    expect(slider).toBeTruthy();
+    expect(slider.getAttribute("aria-label") ?? "").toMatch(/discard timeout/i);
+    expect(slider.getAttribute("aria-valuemin")).toBe("1");
+    expect(slider.getAttribute("aria-valuemax")).toBe("60");
+  });
+
+  it("renders max live tabs number input", () => {
+    render(<SettingsPanel onClose={() => {}} />);
+    const input = screen.getByRole("spinbutton");
+    expect(input).toBeTruthy();
+  });
+
+  it("renders search engine dropdown", () => {
+    render(<SettingsPanel onClose={() => {}} />);
+    const select = screen.getByRole("combobox");
+    expect(select).toBeTruthy();
+  });
+});
+
+describe("SettingsPanel — interactions", () => {
+  it("moving slider updates discardTimeoutMs in the store", () => {
+    render(<SettingsPanel onClose={() => {}} />);
+    const slider = screen.getByRole("slider");
+    // slider is in minutes (1–60); setting to 5 → 5*60*1000 ms
+    fireEvent.change(slider, { target: { value: "5" } });
+    expect(useBrowserSettingsStore.getState().discardTimeoutMs).toBe(5 * 60 * 1000);
+  });
+
+  it("slider reflects current store value", () => {
+    useBrowserSettingsStore.setState({ discardTimeoutMs: 3 * 60 * 1000 });
+    render(<SettingsPanel onClose={() => {}} />);
+    const slider = screen.getByRole("slider");
+    expect(slider.getAttribute("aria-valuenow")).toBe("3");
+    expect((slider as HTMLInputElement).value).toBe("3");
+  });
+
+  it("number input updates maxLiveTabs in the store", () => {
+    render(<SettingsPanel onClose={() => {}} />);
+    const input = screen.getByRole("spinbutton");
+    fireEvent.change(input, { target: { value: "20" } });
+    expect(useBrowserSettingsStore.getState().maxLiveTabs).toBe(20);
+  });
+
+  it("number input clamped via store setter: value > 50 becomes 50", () => {
+    render(<SettingsPanel onClose={() => {}} />);
+    const input = screen.getByRole("spinbutton");
+    fireEvent.change(input, { target: { value: "99" } });
+    expect(useBrowserSettingsStore.getState().maxLiveTabs).toBe(50);
+  });
+
+  it("dropdown updates searchEngine in the store", () => {
+    render(<SettingsPanel onClose={() => {}} />);
+    const select = screen.getByRole("combobox");
+    fireEvent.change(select, { target: { value: "google" } });
+    expect(useBrowserSettingsStore.getState().searchEngine).toBe("google");
+  });
+
+  it("close button calls onClose", () => {
+    const onClose = vi.fn();
+    render(<SettingsPanel onClose={onClose} />);
+    fireEvent.click(screen.getByRole("button", { name: /close/i }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});
+
+describe("SettingsPanel — TabRenderer wire-through (discard scheduler reads from store)", () => {
+  beforeEach(() => {
+    useBrowserStore.setState({ windows: {} });
+    useBrowserStore.getState().createWindow(TEST_WINDOW_ID, "personal");
+    vi.useFakeTimers();
+  });
+
+  it("discards a tab idle past the CUSTOM timeout (shorter than default)", () => {
+    // Set a 2-minute custom timeout
+    const customTimeoutMs = 2 * 60 * 1000;
+    useBrowserSettingsStore.setState({ discardTimeoutMs: customTimeoutMs });
+
+    const tabA = useBrowserStore.getState().getWindow(TEST_WINDOW_ID)!.tabs[0].id;
+    const tabB = useBrowserStore.getState().addTab(TEST_WINDOW_ID, "https://b.test/");
+
+    // tabA idle past the custom timeout but NOT past the default (10 min)
+    // This proves TabRenderer reads from the store, not the DISCARD_TIMEOUT_MS constant
+    const idleTime = customTimeoutMs + 1000; // older than custom, newer than default
+    expect(idleTime).toBeLessThan(DISCARD_TIMEOUT_MS); // sanity check
+    useBrowserStore.setState((s) => {
+      const win = s.windows[TEST_WINDOW_ID];
+      const tabs = win.tabs.map((t) =>
+        t.id === tabA
+          ? { ...t, lastActiveAt: Date.now() - idleTime }
+          : t,
+      );
+      return { windows: { ...s.windows, [TEST_WINDOW_ID]: { ...win, tabs } } };
+    });
+
+    render(<TabRenderer windowId={TEST_WINDOW_ID} />);
+
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+
+    const tab = useBrowserStore.getState().getWindow(TEST_WINDOW_ID)!.tabs.find(
+      (t) => t.id === tabA,
+    );
+    expect(tab?.state).toBe("discarded");
+  });
+
+  it("does NOT discard tab idle past custom timeout when custom timeout is longer than idle time", () => {
+    // Set a very long custom timeout (30 minutes)
+    useBrowserSettingsStore.setState({ discardTimeoutMs: 30 * 60 * 1000 });
+
+    const tabA = useBrowserStore.getState().getWindow(TEST_WINDOW_ID)!.tabs[0].id;
+    const tabB = useBrowserStore.getState().addTab(TEST_WINDOW_ID, "https://b.test/");
+
+    // tabA idle for only 11 minutes — past default (10 min) but within new 30 min timeout
+    useBrowserStore.setState((s) => {
+      const win = s.windows[TEST_WINDOW_ID];
+      const tabs = win.tabs.map((t) =>
+        t.id === tabA
+          ? { ...t, lastActiveAt: Date.now() - 11 * 60 * 1000 }
+          : t,
+      );
+      return { windows: { ...s.windows, [TEST_WINDOW_ID]: { ...win, tabs } } };
+    });
+
+    render(<TabRenderer windowId={TEST_WINDOW_ID} />);
+
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+
+    const tab = useBrowserStore.getState().getWindow(TEST_WINDOW_ID)!.tabs.find(
+      (t) => t.id === tabA,
+    );
+    // Should NOT be discarded yet — only 11 min idle, 30 min timeout
+    expect(tab?.state).toBe("live");
+  });
+});

--- a/desktop/src/apps/BrowserApp/SettingsPanel.tsx
+++ b/desktop/src/apps/BrowserApp/SettingsPanel.tsx
@@ -8,6 +8,7 @@
  *
  * Settings are persisted via useBrowserSettingsStore (localStorage).
  */
+import { useEffect, useRef } from "react";
 import { X } from "lucide-react";
 import {
   useBrowserSettingsStore,
@@ -26,15 +27,37 @@ export function SettingsPanel({ onClose }: SettingsPanelProps) {
   const setDiscardTimeoutMs = useBrowserSettingsStore((s) => s.setDiscardTimeoutMs);
   const setMaxLiveTabs = useBrowserSettingsStore((s) => s.setMaxLiveTabs);
   const setSearchEngine = useBrowserSettingsStore((s) => s.setSearchEngine);
+  const ref = useRef<HTMLDivElement | null>(null);
 
   const timeoutMinutes = Math.round(discardTimeoutMs / 60_000);
 
+  // Click-outside dismiss
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (!ref.current?.contains(e.target as Node)) onClose();
+    };
+    const id = setTimeout(() => window.addEventListener("mousedown", handler), 0);
+    return () => {
+      clearTimeout(id);
+      window.removeEventListener("mousedown", handler);
+    };
+  }, [onClose]);
+
+  // Escape key dismiss
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [onClose]);
+
   return (
     <div
+      ref={ref}
       role="dialog"
       aria-label="Browser settings"
-      aria-modal="true"
-      className="absolute right-0 top-full mt-1 z-50 w-72 rounded-lg border border-shell-border-subtle bg-shell-surface shadow-xl p-4 flex flex-col gap-4"
+      className="absolute right-0 top-full mt-1 z-[60] w-72 rounded-lg border border-shell-border-subtle bg-shell-surface shadow-xl p-4 flex flex-col gap-4"
     >
       {/* Header */}
       <div className="flex items-center justify-between">
@@ -99,7 +122,7 @@ export function SettingsPanel({ onClose }: SettingsPanelProps) {
         <select
           id="search-engine-select"
           value={searchEngine}
-          onChange={(e) => setSearchEngine(e.target.value as SearchEngine)}
+          onChange={(e) => setSearchEngine(e.target.value)}
           className="bg-shell-bg-deep text-shell-text text-xs px-2 py-1 rounded border border-shell-border-subtle focus:border-accent focus:outline-none"
         >
           {(Object.keys(SEARCH_ENGINES) as SearchEngine[]).map((engine) => (

--- a/desktop/src/apps/BrowserApp/SettingsPanel.tsx
+++ b/desktop/src/apps/BrowserApp/SettingsPanel.tsx
@@ -1,0 +1,120 @@
+/**
+ * BrowserApp v2 — SettingsPanel.
+ *
+ * Popover panel for browser-specific settings:
+ *  - Discard timeout (slider 1–60 minutes)
+ *  - Hard cap of live tabs (number input 1–50)
+ *  - Default search engine (dropdown)
+ *
+ * Settings are persisted via useBrowserSettingsStore (localStorage).
+ */
+import { X } from "lucide-react";
+import {
+  useBrowserSettingsStore,
+  SEARCH_ENGINES,
+  type SearchEngine,
+} from "@/stores/browser-settings-store";
+
+interface SettingsPanelProps {
+  onClose: () => void;
+}
+
+export function SettingsPanel({ onClose }: SettingsPanelProps) {
+  const discardTimeoutMs = useBrowserSettingsStore((s) => s.discardTimeoutMs);
+  const maxLiveTabs = useBrowserSettingsStore((s) => s.maxLiveTabs);
+  const searchEngine = useBrowserSettingsStore((s) => s.searchEngine);
+  const setDiscardTimeoutMs = useBrowserSettingsStore((s) => s.setDiscardTimeoutMs);
+  const setMaxLiveTabs = useBrowserSettingsStore((s) => s.setMaxLiveTabs);
+  const setSearchEngine = useBrowserSettingsStore((s) => s.setSearchEngine);
+
+  const timeoutMinutes = Math.round(discardTimeoutMs / 60_000);
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Browser settings"
+      aria-modal="true"
+      className="absolute right-0 top-full mt-1 z-50 w-72 rounded-lg border border-shell-border-subtle bg-shell-surface shadow-xl p-4 flex flex-col gap-4"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium text-shell-text">Browser Settings</span>
+        <button
+          type="button"
+          aria-label="Close settings"
+          onClick={onClose}
+          className="p-1 rounded hover:bg-shell-hover text-shell-text-secondary"
+        >
+          <X size={14} />
+        </button>
+      </div>
+
+      {/* Discard timeout slider */}
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="discard-timeout-slider" className="text-xs text-shell-text-secondary">
+          Tab discard timeout
+        </label>
+        <div className="flex items-center gap-2">
+          <input
+            id="discard-timeout-slider"
+            type="range"
+            min={1}
+            max={60}
+            step={1}
+            value={timeoutMinutes}
+            aria-label="Discard timeout"
+            aria-valuemin={1}
+            aria-valuemax={60}
+            aria-valuenow={timeoutMinutes}
+            onChange={(e) => setDiscardTimeoutMs(Number(e.target.value) * 60_000)}
+            className="flex-1 accent-accent"
+          />
+          <span className="text-xs text-shell-text w-16 text-right">
+            {timeoutMinutes} {timeoutMinutes === 1 ? "minute" : "minutes"}
+          </span>
+        </div>
+      </div>
+
+      {/* Max live tabs number input */}
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="max-live-tabs-input" className="text-xs text-shell-text-secondary">
+          Max live tabs
+        </label>
+        <input
+          id="max-live-tabs-input"
+          type="number"
+          min={1}
+          max={50}
+          value={maxLiveTabs}
+          onChange={(e) => setMaxLiveTabs(Number(e.target.value))}
+          className="bg-shell-bg-deep text-shell-text text-xs px-2 py-1 rounded border border-shell-border-subtle focus:border-accent focus:outline-none w-20"
+        />
+      </div>
+
+      {/* Search engine dropdown */}
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="search-engine-select" className="text-xs text-shell-text-secondary">
+          Default search engine
+        </label>
+        <select
+          id="search-engine-select"
+          value={searchEngine}
+          onChange={(e) => setSearchEngine(e.target.value as SearchEngine)}
+          className="bg-shell-bg-deep text-shell-text text-xs px-2 py-1 rounded border border-shell-border-subtle focus:border-accent focus:outline-none"
+        >
+          {(Object.keys(SEARCH_ENGINES) as SearchEngine[]).map((engine) => (
+            <option key={engine} value={engine}>
+              {ENGINE_LABELS[engine]}
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
+  );
+}
+
+const ENGINE_LABELS: Record<SearchEngine, string> = {
+  duckduckgo: "DuckDuckGo",
+  google: "Google",
+  bing: "Bing",
+};

--- a/desktop/src/apps/BrowserApp/TabRenderer.test.tsx
+++ b/desktop/src/apps/BrowserApp/TabRenderer.test.tsx
@@ -197,3 +197,49 @@ describe("TabRenderer — graceful handling", () => {
     expect(container.querySelector("iframe")).toBeNull();
   });
 });
+
+describe("TabRenderer — live exclusion exempts discard", () => {
+  it("does NOT discard a tab whose iframe has a playing video", () => {
+    const tabA = useBrowserStore.getState().getWindow(TEST_WINDOW_ID)!.tabs[0].id;
+    const tabB = useBrowserStore.getState().addTab(
+      TEST_WINDOW_ID,
+      "https://b.test/",
+    );
+
+    // Make tabA idle (long past discard timeout)
+    useBrowserStore.setState((s) => {
+      const win = s.windows[TEST_WINDOW_ID];
+      const tabs = win.tabs.map((t) =>
+        t.id === tabA
+          ? { ...t, lastActiveAt: Date.now() - DISCARD_TIMEOUT_MS - 1000 }
+          : t,
+      );
+      return { windows: { ...s.windows, [TEST_WINDOW_ID]: { ...win, tabs } } };
+    });
+
+    const { container } = render(<TabRenderer windowId={TEST_WINDOW_ID} />);
+
+    // Plant a "playing video" in tabA's iframe
+    const iframe = container.querySelector(
+      `iframe[data-tab-id="${tabA}"]`,
+    ) as HTMLIFrameElement | null;
+    if (iframe?.contentDocument) {
+      const video = iframe.contentDocument.createElement("video");
+      iframe.contentDocument.body.appendChild(video);
+      Object.defineProperty(video, "paused", { value: false, configurable: true });
+      Object.defineProperty(video, "ended", { value: false, configurable: true });
+    }
+
+    // Tick the scheduler
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+
+    const tab = useBrowserStore.getState().getWindow(TEST_WINDOW_ID)!.tabs.find(
+      (t) => t.id === tabA,
+    );
+    // Should remain live + have the exclusion reason set
+    expect(tab?.state).toBe("live");
+    expect(tab?.liveExclusion).toBe("video");
+  });
+});

--- a/desktop/src/apps/BrowserApp/TabRenderer.test.tsx
+++ b/desktop/src/apps/BrowserApp/TabRenderer.test.tsx
@@ -198,6 +198,83 @@ describe("TabRenderer — graceful handling", () => {
   });
 });
 
+describe("TabRenderer — reader mode", () => {
+  it("renders ReaderMode for active tab when readerActive is true", () => {
+    const tabId = useBrowserStore.getState().getWindow(TEST_WINDOW_ID)!.activeTabId;
+    useBrowserStore.getState().navigateTab(
+      TEST_WINDOW_ID,
+      tabId,
+      "https://article.test/story",
+    );
+    useBrowserStore.getState().setTabReader(TEST_WINDOW_ID, tabId, {
+      readerAvailable: true,
+      readerActive: true,
+      readerExtract: {
+        title: "Amazing Article",
+        text: "content",
+        html: "<p>content</p>",
+        word_count: 500,
+      },
+    });
+
+    render(<TabRenderer windowId={TEST_WINDOW_ID} />);
+    expect(screen.getByTestId("reader-mode")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "Amazing Article",
+    );
+  });
+
+  it("renders iframe normally when readerActive is false", () => {
+    const tabId = useBrowserStore.getState().getWindow(TEST_WINDOW_ID)!.activeTabId;
+    useBrowserStore.getState().navigateTab(
+      TEST_WINDOW_ID,
+      tabId,
+      "https://article.test/story",
+    );
+    useBrowserStore.getState().setTabReader(TEST_WINDOW_ID, tabId, {
+      readerAvailable: true,
+      readerActive: false,
+      readerExtract: {
+        title: "Amazing Article",
+        text: "content",
+        html: "<p>content</p>",
+        word_count: 500,
+      },
+    });
+
+    const { container } = render(<TabRenderer windowId={TEST_WINDOW_ID} />);
+    expect(screen.queryByTestId("reader-mode")).toBeNull();
+    const iframe = container.querySelector("iframe");
+    expect(iframe).toBeTruthy();
+    expect((iframe as HTMLIFrameElement).style.display).toBe("block");
+  });
+
+  it("iframe stays in DOM when reader mode is active (toggling off preserves iframe state)", () => {
+    const tabId = useBrowserStore.getState().getWindow(TEST_WINDOW_ID)!.activeTabId;
+    useBrowserStore.getState().navigateTab(
+      TEST_WINDOW_ID,
+      tabId,
+      "https://article.test/story",
+    );
+    useBrowserStore.getState().setTabReader(TEST_WINDOW_ID, tabId, {
+      readerAvailable: true,
+      readerActive: true,
+      readerExtract: {
+        title: "Amazing Article",
+        text: "content",
+        html: "<p>content</p>",
+        word_count: 500,
+      },
+    });
+
+    const { container } = render(<TabRenderer windowId={TEST_WINDOW_ID} />);
+    // iframe should still be in DOM even with reader active (display:none)
+    const iframe = container.querySelector("iframe");
+    expect(iframe).toBeTruthy();
+    expect((iframe as HTMLIFrameElement).style.display).toBe("none");
+  });
+});
+
 describe("TabRenderer — live exclusion exempts discard", () => {
   it("does NOT discard a tab whose iframe has a playing video", () => {
     const tabA = useBrowserStore.getState().getWindow(TEST_WINDOW_ID)!.tabs[0].id;

--- a/desktop/src/apps/BrowserApp/TabRenderer.tsx
+++ b/desktop/src/apps/BrowserApp/TabRenderer.tsx
@@ -18,6 +18,7 @@
  */
 import { useEffect } from "react";
 import { useBrowserStore } from "@/stores/browser-store";
+import { detectLiveExclusion } from "./live-exclusion";
 import type { Tab } from "./types";
 
 export const DISCARD_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
@@ -43,10 +44,24 @@ export function TabRenderer({ windowId }: TabRendererProps) {
       const now = Date.now();
       const liveTabs = current.tabs.filter((t) => t.state === "live");
 
-      // Pass 1: idle-based discard
+      // Pass 1: idle-based discard with live-exclusion respect
       for (const tab of liveTabs) {
         if (tab.id === current.activeTabId) continue;
-        if (tab.pinned) continue;
+        // Detect any live activity in the iframe — playing media, active
+        // form input, in-flight upload — and exempt those tabs.
+        const iframe = document.querySelector(
+          `iframe[data-tab-id="${tab.id}"]`,
+        ) as HTMLIFrameElement | null;
+        const exclusion = iframe
+          ? detectLiveExclusion(iframe, tab.pinned)
+          : (tab.pinned ? "pinned" : undefined);
+        // Update the tab so the UI can surface "kept alive: video"
+        if (exclusion !== tab.liveExclusion) {
+          useBrowserStore.getState().setTabLiveExclusion(
+            windowId, tab.id, exclusion,
+          );
+        }
+        if (exclusion) continue; // exempt
         if (now - tab.lastActiveAt > DISCARD_TIMEOUT_MS) {
           useBrowserStore.getState().markTabDiscarded(windowId, tab.id);
         }
@@ -60,7 +75,11 @@ export function TabRenderer({ windowId }: TabRendererProps) {
       if (overflowCount > 0) {
         // Discard oldest non-pinned non-active until at cap
         const candidates = stillLive
-          .filter((t) => !t.pinned && t.id !== refreshed.activeTabId)
+          .filter((t) =>
+            !t.pinned
+            && t.id !== refreshed.activeTabId
+            && !t.liveExclusion
+          )
           .sort((a, b) => a.lastActiveAt - b.lastActiveAt);
         for (let i = 0; i < overflowCount && i < candidates.length; i++) {
           useBrowserStore.getState().markTabDiscarded(

--- a/desktop/src/apps/BrowserApp/TabRenderer.tsx
+++ b/desktop/src/apps/BrowserApp/TabRenderer.tsx
@@ -21,6 +21,7 @@ import { useEffect } from "react";
 import { useBrowserStore } from "@/stores/browser-store";
 import { useBrowserSettingsStore } from "@/stores/browser-settings-store";
 import { detectLiveExclusion } from "./live-exclusion";
+import { ReaderMode } from "./ReaderMode";
 import type { Tab } from "./types";
 
 export const DISCARD_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
@@ -114,30 +115,40 @@ export function TabRenderer({ windowId }: TabRendererProps) {
           ) : null;
         }
 
+        const showReader = isActive && !!tab.readerActive && !!tab.readerExtract;
+
         return (
-          <iframe
+          <div
             key={tab.id}
-            title={tab.title || tab.url || "Browser tab"}
-            src={proxiedSrc(win.profileId, tab.url)}
-            data-tab-id={tab.id}
-            // sandbox: allow-same-origin intentionally OMITTED. The proxy
-            // serves on the same origin as the shell; combining
-            // allow-same-origin + allow-scripts would let proxied JS reach
-            // up into the parent and remove this attribute. The HTTPS+DNS
-            // Foundations brainstorm will land an isolated subdomain that
-            // makes allow-same-origin safe to add back.
-            sandbox="allow-scripts allow-forms allow-popups allow-downloads"
-            style={{
-              display: isActive ? "block" : "none",
-              position: "absolute",
-              inset: 0,
-              width: "100%",
-              height: "100%",
-              border: "none",
-              transform: tab.zoom !== 1 ? `scale(${tab.zoom})` : undefined,
-              transformOrigin: "top left",
-            }}
-          />
+            style={{ display: isActive ? "contents" : "none" }}
+            data-window-tab={tab.id}
+          >
+            <iframe
+              title={tab.title || tab.url || "Browser tab"}
+              src={proxiedSrc(win.profileId, tab.url)}
+              data-tab-id={tab.id}
+              // sandbox: allow-same-origin intentionally OMITTED. The proxy
+              // serves on the same origin as the shell; combining
+              // allow-same-origin + allow-scripts would let proxied JS reach
+              // up into the parent and remove this attribute. The HTTPS+DNS
+              // Foundations brainstorm will land an isolated subdomain that
+              // makes allow-same-origin safe to add back.
+              sandbox="allow-scripts allow-forms allow-popups allow-downloads"
+              style={{
+                display: showReader ? "none" : isActive ? "block" : "none",
+                position: "absolute",
+                inset: 0,
+                width: "100%",
+                height: "100%",
+                border: "none",
+                transform: tab.zoom !== 1 ? `scale(${tab.zoom})` : undefined,
+                transformOrigin: "top left",
+              }}
+            />
+            {showReader && (
+              <ReaderMode tab={tab} windowId={windowId} />
+            )}
+          </div>
         );
       })}
     </div>

--- a/desktop/src/apps/BrowserApp/TabRenderer.tsx
+++ b/desktop/src/apps/BrowserApp/TabRenderer.tsx
@@ -8,9 +8,10 @@
  *
  * The discard scheduler runs every 60s and:
  *  - Discards non-pinned, non-active tabs whose lastActiveAt is older
- *    than DISCARD_TIMEOUT_MS.
+ *    than DISCARD_TIMEOUT_MS (default; runtime value from useBrowserSettingsStore).
  *  - Enforces a hard cap of MAX_LIVE_TABS live tabs by discarding the
- *    oldest live tab (by lastActiveAt) if the cap is exceeded.
+ *    oldest live tab (by lastActiveAt) if the cap is exceeded (default;
+ *    runtime value from useBrowserSettingsStore).
  *
  * PR 5 (live exclusion) will further refine the discard rule — tabs
  * with playing audio/video, active form input, or in-flight upload

--- a/desktop/src/apps/BrowserApp/TabRenderer.tsx
+++ b/desktop/src/apps/BrowserApp/TabRenderer.tsx
@@ -18,6 +18,7 @@
  */
 import { useEffect } from "react";
 import { useBrowserStore } from "@/stores/browser-store";
+import { useBrowserSettingsStore } from "@/stores/browser-settings-store";
 import { detectLiveExclusion } from "./live-exclusion";
 import type { Tab } from "./types";
 
@@ -62,7 +63,8 @@ export function TabRenderer({ windowId }: TabRendererProps) {
           );
         }
         if (exclusion) continue; // exempt
-        if (now - tab.lastActiveAt > DISCARD_TIMEOUT_MS) {
+        const { discardTimeoutMs } = useBrowserSettingsStore.getState();
+        if (now - tab.lastActiveAt > discardTimeoutMs) {
           useBrowserStore.getState().markTabDiscarded(windowId, tab.id);
         }
       }
@@ -71,7 +73,8 @@ export function TabRenderer({ windowId }: TabRendererProps) {
       const refreshed = useBrowserStore.getState().windows[windowId];
       if (!refreshed) return;
       const stillLive = refreshed.tabs.filter((t) => t.state === "live");
-      const overflowCount = stillLive.length - MAX_LIVE_TABS;
+      const { maxLiveTabs } = useBrowserSettingsStore.getState();
+      const overflowCount = stillLive.length - maxLiveTabs;
       if (overflowCount > 0) {
         // Discard oldest non-pinned non-active until at cap
         const candidates = stillLive

--- a/desktop/src/apps/BrowserApp/TabRenderer.tsx
+++ b/desktop/src/apps/BrowserApp/TabRenderer.tsx
@@ -135,7 +135,7 @@ export function TabRenderer({ windowId }: TabRendererProps) {
               // makes allow-same-origin safe to add back.
               sandbox="allow-scripts allow-forms allow-popups allow-downloads"
               style={{
-                display: showReader ? "none" : isActive ? "block" : "none",
+                display: isActive && !showReader ? "block" : "none",
                 position: "absolute",
                 inset: 0,
                 width: "100%",

--- a/desktop/src/apps/BrowserApp/live-exclusion.test.ts
+++ b/desktop/src/apps/BrowserApp/live-exclusion.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { detectLiveExclusion } from "./live-exclusion";
+
+/**
+ * Helper: build an iframe whose contentDocument is set up via JSDOM
+ * by writing HTML directly. JSDOM iframes default to about:blank with
+ * a same-origin contentDocument.
+ */
+function makeIframe(bodyHtml: string): HTMLIFrameElement {
+  const iframe = document.createElement("iframe");
+  document.body.appendChild(iframe);
+  const doc = iframe.contentDocument!;
+  doc.body.innerHTML = bodyHtml;
+  return iframe;
+}
+
+describe("detectLiveExclusion — pinned exemption", () => {
+  it("returns 'pinned' when isPinned=true regardless of content", () => {
+    const iframe = makeIframe("<p>hello</p>");
+    expect(detectLiveExclusion(iframe, true)).toBe("pinned");
+  });
+});
+
+describe("detectLiveExclusion — audio/video", () => {
+  it("returns undefined when no media", () => {
+    const iframe = makeIframe("<p>just text</p>");
+    expect(detectLiveExclusion(iframe, false)).toBeUndefined();
+  });
+
+  it("returns undefined when video is paused", () => {
+    const iframe = makeIframe("<video></video>");
+    // JSDOM HTMLMediaElement.paused defaults to true
+    expect(detectLiveExclusion(iframe, false)).toBeUndefined();
+  });
+
+  it("returns 'video' when a video is playing (paused=false)", () => {
+    const iframe = makeIframe("<video></video>");
+    const video = iframe.contentDocument!.querySelector("video") as HTMLVideoElement;
+    Object.defineProperty(video, "paused", { value: false, configurable: true });
+    Object.defineProperty(video, "ended", { value: false, configurable: true });
+    expect(detectLiveExclusion(iframe, false)).toBe("video");
+  });
+
+  it("returns 'audio' when an audio element is playing", () => {
+    const iframe = makeIframe("<audio></audio>");
+    const audio = iframe.contentDocument!.querySelector("audio") as HTMLAudioElement;
+    Object.defineProperty(audio, "paused", { value: false, configurable: true });
+    Object.defineProperty(audio, "ended", { value: false, configurable: true });
+    expect(detectLiveExclusion(iframe, false)).toBe("audio");
+  });
+});
+
+describe("detectLiveExclusion — active form input", () => {
+  it("returns 'form-active' when an input has non-empty value AND is focused", () => {
+    const iframe = makeIframe('<input type="text">');
+    const input = iframe.contentDocument!.querySelector("input") as HTMLInputElement;
+    input.value = "some text";
+    input.focus();
+    expect(detectLiveExclusion(iframe, false)).toBe("form-active");
+  });
+
+  it("returns undefined when input is focused but empty", () => {
+    const iframe = makeIframe('<input type="text">');
+    const input = iframe.contentDocument!.querySelector("input") as HTMLInputElement;
+    input.focus();
+    expect(detectLiveExclusion(iframe, false)).toBeUndefined();
+  });
+
+  it("returns 'form-active' for focused textarea with content", () => {
+    const iframe = makeIframe("<textarea></textarea>");
+    const ta = iframe.contentDocument!.querySelector("textarea") as HTMLTextAreaElement;
+    ta.value = "draft email";
+    ta.focus();
+    expect(detectLiveExclusion(iframe, false)).toBe("form-active");
+  });
+});
+
+describe("detectLiveExclusion — upload in progress", () => {
+  it("returns 'upload' when a file input has selected files", () => {
+    const iframe = makeIframe('<input type="file">');
+    const input = iframe.contentDocument!.querySelector("input") as HTMLInputElement;
+    // Mock files property — JSDOM's FileList is read-only
+    Object.defineProperty(input, "files", {
+      value: [new File(["x"], "test.txt")],
+      configurable: true,
+    });
+    expect(detectLiveExclusion(iframe, false)).toBe("upload");
+  });
+
+  it("returns undefined when file input has no selected files", () => {
+    const iframe = makeIframe('<input type="file">');
+    expect(detectLiveExclusion(iframe, false)).toBeUndefined();
+  });
+});
+
+describe("detectLiveExclusion — graceful fallback", () => {
+  it("returns undefined when contentDocument is null", () => {
+    const iframe = document.createElement("iframe");
+    // No appendChild — contentDocument may be null
+    Object.defineProperty(iframe, "contentDocument", {
+      value: null,
+      configurable: true,
+    });
+    expect(detectLiveExclusion(iframe, false)).toBeUndefined();
+  });
+});

--- a/desktop/src/apps/BrowserApp/live-exclusion.ts
+++ b/desktop/src/apps/BrowserApp/live-exclusion.ts
@@ -1,0 +1,53 @@
+/**
+ * Live-exclusion detection — keeps the discard scheduler from snoozing
+ * tabs the user is actively using.
+ *
+ * Runs from the PARENT window by inspecting iframe.contentDocument.
+ * Same-origin since the proxy serves on our origin (PR 3 baked the cookie
+ * jar into the proxy fetch). PR 6 may refactor to push events from
+ * copilot.js, but the polling implementation works without it and is the
+ * cleaner v1 — no extra protocol surface.
+ *
+ * Order matters: pinned > video > audio > form-active > upload. The first
+ * match wins. Returns undefined when nothing applies.
+ */
+import type { LiveExclusion } from "./types";
+
+export function detectLiveExclusion(
+  iframe: HTMLIFrameElement,
+  isPinned: boolean,
+): LiveExclusion | undefined {
+  if (isPinned) return "pinned";
+
+  const doc = iframe.contentDocument;
+  if (!doc) return undefined; // navigation in progress, or cross-origin
+
+  // Audio / video playing
+  for (const media of Array.from(doc.querySelectorAll("video, audio"))) {
+    const m = media as HTMLMediaElement;
+    if (!m.paused && !m.ended) {
+      // Differentiate: HTMLVideoElement has `videoWidth` property, audio doesn't
+      if ((media as HTMLVideoElement).videoWidth !== undefined) {
+        return "video";
+      }
+      return "audio";
+    }
+  }
+
+  // Active form input with non-empty value
+  const active = doc.activeElement as HTMLInputElement | HTMLTextAreaElement | null;
+  if (active && (active.tagName === "INPUT" || active.tagName === "TEXTAREA")) {
+    if ((active.value ?? "").length > 0) return "form-active";
+  }
+
+  // Upload in progress — heuristic: an <input type="file"> with selected files.
+  // The actual upload may or may not have started; the user is mid-flow either way.
+  const fileInputs = doc.querySelectorAll(
+    'input[type="file"]',
+  ) as NodeListOf<HTMLInputElement>;
+  for (const f of Array.from(fileInputs)) {
+    if (f.files && f.files.length > 0) return "upload";
+  }
+
+  return undefined;
+}

--- a/desktop/src/apps/BrowserApp/live-exclusion.ts
+++ b/desktop/src/apps/BrowserApp/live-exclusion.ts
@@ -23,11 +23,14 @@ export function detectLiveExclusion(
   if (!doc) return undefined; // navigation in progress, or cross-origin
 
   // Audio / video playing
+  // Use the iframe's own HTMLVideoElement for instanceof — this works for
+  // same-origin iframes in both real browsers and JSDOM.
+  const iframeWin = iframe.contentWindow as (Window & { HTMLVideoElement?: typeof HTMLVideoElement }) | null;
+  const VideoElement = iframeWin?.HTMLVideoElement ?? HTMLVideoElement;
   for (const media of Array.from(doc.querySelectorAll("video, audio"))) {
     const m = media as HTMLMediaElement;
     if (!m.paused && !m.ended) {
-      // Differentiate: HTMLVideoElement has `videoWidth` property, audio doesn't
-      if ((media as HTMLVideoElement).videoWidth !== undefined) {
+      if (media instanceof VideoElement) {
         return "video";
       }
       return "audio";

--- a/desktop/src/apps/BrowserApp/types.ts
+++ b/desktop/src/apps/BrowserApp/types.ts
@@ -8,6 +8,13 @@
 
 export type LiveExclusion = "audio" | "video" | "form-active" | "upload" | "pinned";
 
+export interface ReaderExtract {
+  title: string;
+  text: string;
+  html: string;
+  word_count: number;
+}
+
 export interface Tab {
   id: string;
   url: string;
@@ -21,6 +28,12 @@ export interface Tab {
   state: "live" | "discarded";
   lastActiveAt: number;
   liveExclusion?: LiveExclusion;
+  /** true when the last extract returned word_count > 200 */
+  readerAvailable?: boolean;
+  /** true when the user has toggled reader mode on */
+  readerActive?: boolean;
+  /** cached extract — avoids re-fetching when toggling */
+  readerExtract?: ReaderExtract | null;
 }
 
 export interface RecentlyClosedTab {

--- a/desktop/src/apps/BrowserApp/types.ts
+++ b/desktop/src/apps/BrowserApp/types.ts
@@ -29,10 +29,22 @@ export interface RecentlyClosedTab {
   closedAt: number;
 }
 
+export interface SavedProfileTabs {
+  tabs: Tab[];
+  activeTabId: string;
+}
+
 export interface BrowserWindowState {
   windowId: string;
   profileId: string;
   tabs: Tab[];
   activeTabId: string;
   recentlyClosed: RecentlyClosedTab[];
+  /**
+   * Per-(window, profile) snapshot of tabs + activeTabId.
+   * switchProfile snapshots the current state under the OLD profileId
+   * before swapping; restores from this map on switch back.
+   * Keyed by profile_id.
+   */
+  _savedTabsByProfile?: Record<string, SavedProfileTabs>;
 }

--- a/desktop/src/apps/BrowserApp/types.ts
+++ b/desktop/src/apps/BrowserApp/types.ts
@@ -13,6 +13,7 @@ export interface ReaderExtract {
   text: string;
   html: string;
   word_count: number;
+  note?: string;
 }
 
 export interface Tab {

--- a/desktop/src/lib/browser-extract-api.test.ts
+++ b/desktop/src/lib/browser-extract-api.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { extractReadable } from "./browser-extract-api";
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe("extractReadable", () => {
+  it("calls the correct URL with profile_id and url params", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        title: "Test Article",
+        text: "Some text",
+        html: "<p>Some text</p>",
+        word_count: 250,
+      }),
+    });
+    global.fetch = fetchMock;
+
+    await extractReadable("personal", "https://example.com/article");
+
+    const [calledUrl] = fetchMock.mock.calls[0];
+    expect(calledUrl).toContain("/api/desktop/browser/extract");
+    expect(calledUrl).toContain("profile_id=personal");
+    expect(calledUrl).toContain("url=");
+    expect(calledUrl).toContain("example.com");
+  });
+
+  it("returns parsed JSON on 200", async () => {
+    const expected = {
+      title: "Article Title",
+      text: "The text",
+      html: "<p>The text</p>",
+      word_count: 350,
+    };
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => expected,
+    });
+
+    const result = await extractReadable("personal", "https://example.com/");
+    expect(result).toEqual(expected);
+  });
+
+  it("returns null on non-ok response (e.g. 401)", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 401 });
+    const result = await extractReadable("personal", "https://example.com/");
+    expect(result).toBeNull();
+  });
+
+  it("returns null on non-ok 403 response", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 403 });
+    const result = await extractReadable("personal", "https://blocked.com/");
+    expect(result).toBeNull();
+  });
+
+  it("returns null on network error", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("Network error"));
+    const result = await extractReadable("personal", "https://example.com/");
+    expect(result).toBeNull();
+  });
+
+  it("passes credentials: include", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ title: "", text: "", html: "", word_count: 0 }),
+    });
+    global.fetch = fetchMock;
+
+    await extractReadable("work", "https://example.com/");
+
+    const [, options] = fetchMock.mock.calls[0];
+    expect(options?.credentials).toBe("include");
+  });
+});

--- a/desktop/src/lib/browser-extract-api.ts
+++ b/desktop/src/lib/browser-extract-api.ts
@@ -1,0 +1,30 @@
+/**
+ * Fetch wrapper for /api/desktop/browser/extract.
+ * Runs Mozilla Readability on the backend and returns structured article data.
+ * Returns null on any non-2xx response (silent on 401, matching other browser-* wrappers).
+ */
+
+export interface ExtractResult {
+  title: string;
+  text: string;
+  html: string;
+  word_count: number;
+  note?: string;
+}
+
+export async function extractReadable(
+  profileId: string,
+  url: string,
+): Promise<ExtractResult | null> {
+  const params = new URLSearchParams({ profile_id: profileId, url });
+  try {
+    const resp = await fetch(
+      `/api/desktop/browser/extract?${params.toString()}`,
+      { credentials: "include" },
+    );
+    if (!resp.ok) return null;
+    return (await resp.json()) as ExtractResult;
+  } catch {
+    return null;
+  }
+}

--- a/desktop/src/lib/browser-profile-api.test.ts
+++ b/desktop/src/lib/browser-profile-api.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  listProfiles,
+  createProfile,
+  renameProfile,
+  deleteProfile,
+} from "./browser-profile-api";
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe("listProfiles", () => {
+  it("returns the profiles array on 200", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        profiles: [
+          { profile_id: "personal", name: "Personal", color: "#6c8df0", created_at: 0 },
+        ],
+      }),
+    });
+    const out = await listProfiles();
+    expect(out.length).toBe(1);
+    expect(out[0].profile_id).toBe("personal");
+  });
+
+  it("returns [] on 401 silently", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 401 });
+    expect(await listProfiles()).toEqual([]);
+  });
+});
+
+describe("createProfile", () => {
+  it("POSTs name + color and returns the new profile", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ profile_id: "research", name: "Research", color: "#abc123", created_at: 1 }),
+    });
+    global.fetch = fetchMock;
+
+    const out = await createProfile({ name: "Research", color: "#abc123" });
+    expect(out?.profile_id).toBe("research");
+
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/desktop/browser/profiles");
+    expect(opts.method).toBe("POST");
+    const body = JSON.parse(opts.body);
+    expect(body.name).toBe("Research");
+    expect(body.color).toBe("#abc123");
+  });
+
+  it("returns null on non-ok", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 400 });
+    expect(await createProfile({ name: "" })).toBeNull();
+  });
+});
+
+describe("renameProfile", () => {
+  it("PATCHes name + color to the keyed URL", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ profile_id: "personal", name: "New Name", color: null, created_at: 0 }),
+    });
+    global.fetch = fetchMock;
+
+    await renameProfile("personal", { name: "New Name" });
+
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/desktop/browser/profiles/personal");
+    expect(opts.method).toBe("PATCH");
+    expect(JSON.parse(opts.body)).toEqual({ name: "New Name" });
+  });
+
+  it("URL-encodes the profileId", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+    global.fetch = fetchMock;
+    await renameProfile("with space", { name: "x" });
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/desktop/browser/profiles/with%20space");
+  });
+});
+
+describe("deleteProfile", () => {
+  it("issues DELETE and returns true on 204", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 204 });
+    global.fetch = fetchMock;
+    expect(await deleteProfile("temp")).toBe(true);
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/desktop/browser/profiles/temp");
+    expect(opts.method).toBe("DELETE");
+  });
+
+  it("returns false on non-ok", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 400 });
+    expect(await deleteProfile("personal")).toBe(false);
+  });
+});

--- a/desktop/src/lib/browser-profile-api.ts
+++ b/desktop/src/lib/browser-profile-api.ts
@@ -1,0 +1,66 @@
+/**
+ * Fetch wrappers for /api/desktop/browser/profiles CRUD.
+ *
+ * 401 returns empty array / null silently (the user isn't logged in yet).
+ * Other errors throw — callers should handle them.
+ */
+
+export interface Profile {
+  profile_id: string;
+  name: string;
+  color: string | null;
+  created_at: number;
+}
+
+const ENDPOINT = "/api/desktop/browser/profiles";
+
+export async function listProfiles(): Promise<Profile[]> {
+  try {
+    const resp = await fetch(ENDPOINT, { credentials: "include" });
+    if (resp.status === 401) return [];
+    if (!resp.ok) return [];
+    const body = await resp.json();
+    return Array.isArray(body?.profiles) ? body.profiles : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function createProfile(args: {
+  name: string;
+  color?: string;
+}): Promise<Profile | null> {
+  const resp = await fetch(ENDPOINT, {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name: args.name, color: args.color ?? null }),
+  });
+  if (!resp.ok) return null;
+  return resp.json();
+}
+
+export async function renameProfile(
+  profileId: string,
+  args: { name?: string; color?: string },
+): Promise<Profile | null> {
+  const resp = await fetch(
+    `${ENDPOINT}/${encodeURIComponent(profileId)}`,
+    {
+      method: "PATCH",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(args),
+    },
+  );
+  if (!resp.ok) return null;
+  return resp.json();
+}
+
+export async function deleteProfile(profileId: string): Promise<boolean> {
+  const resp = await fetch(
+    `${ENDPOINT}/${encodeURIComponent(profileId)}`,
+    { method: "DELETE", credentials: "include" },
+  );
+  return resp.ok;
+}

--- a/desktop/src/stores/browser-settings-store.test.ts
+++ b/desktop/src/stores/browser-settings-store.test.ts
@@ -3,6 +3,7 @@ import {
   useBrowserSettingsStore,
   searchUrlFor,
   SEARCH_ENGINES,
+  type SearchEngine,
 } from "./browser-settings-store";
 
 beforeEach(() => {

--- a/desktop/src/stores/browser-settings-store.test.ts
+++ b/desktop/src/stores/browser-settings-store.test.ts
@@ -67,6 +67,11 @@ describe("browser-settings-store — setters", () => {
     useBrowserSettingsStore.getState().setSearchEngine("bing");
     expect(useBrowserSettingsStore.getState().searchEngine).toBe("bing");
   });
+
+  it("setSearchEngine ignores invalid engine values", () => {
+    useBrowserSettingsStore.getState().setSearchEngine("yahoo" as SearchEngine);
+    expect(useBrowserSettingsStore.getState().searchEngine).toBe("duckduckgo");
+  });
 });
 
 describe("searchUrlFor", () => {

--- a/desktop/src/stores/browser-settings-store.test.ts
+++ b/desktop/src/stores/browser-settings-store.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import {
+  useBrowserSettingsStore,
+  searchUrlFor,
+  SEARCH_ENGINES,
+} from "./browser-settings-store";
+
+beforeEach(() => {
+  useBrowserSettingsStore.setState({
+    discardTimeoutMs: 10 * 60 * 1000,
+    maxLiveTabs: 12,
+    searchEngine: "duckduckgo",
+  });
+});
+
+describe("browser-settings-store — defaults", () => {
+  it("discardTimeoutMs defaults to 10 minutes", () => {
+    expect(useBrowserSettingsStore.getState().discardTimeoutMs).toBe(10 * 60 * 1000);
+  });
+
+  it("maxLiveTabs defaults to 12", () => {
+    expect(useBrowserSettingsStore.getState().maxLiveTabs).toBe(12);
+  });
+
+  it("searchEngine defaults to duckduckgo", () => {
+    expect(useBrowserSettingsStore.getState().searchEngine).toBe("duckduckgo");
+  });
+});
+
+describe("browser-settings-store — setters", () => {
+  it("setDiscardTimeoutMs updates the value", () => {
+    useBrowserSettingsStore.getState().setDiscardTimeoutMs(5 * 60 * 1000);
+    expect(useBrowserSettingsStore.getState().discardTimeoutMs).toBe(5 * 60 * 1000);
+  });
+
+  it("setDiscardTimeoutMs clamps to minimum 1 minute", () => {
+    useBrowserSettingsStore.getState().setDiscardTimeoutMs(0);
+    expect(useBrowserSettingsStore.getState().discardTimeoutMs).toBe(60_000);
+  });
+
+  it("setDiscardTimeoutMs clamps to maximum 60 minutes", () => {
+    useBrowserSettingsStore.getState().setDiscardTimeoutMs(999 * 60 * 1000);
+    expect(useBrowserSettingsStore.getState().discardTimeoutMs).toBe(60 * 60 * 1000);
+  });
+
+  it("setMaxLiveTabs updates the value", () => {
+    useBrowserSettingsStore.getState().setMaxLiveTabs(20);
+    expect(useBrowserSettingsStore.getState().maxLiveTabs).toBe(20);
+  });
+
+  it("setMaxLiveTabs clamps to minimum 1", () => {
+    useBrowserSettingsStore.getState().setMaxLiveTabs(0);
+    expect(useBrowserSettingsStore.getState().maxLiveTabs).toBe(1);
+  });
+
+  it("setMaxLiveTabs clamps to maximum 50", () => {
+    useBrowserSettingsStore.getState().setMaxLiveTabs(100);
+    expect(useBrowserSettingsStore.getState().maxLiveTabs).toBe(50);
+  });
+
+  it("setSearchEngine updates to google", () => {
+    useBrowserSettingsStore.getState().setSearchEngine("google");
+    expect(useBrowserSettingsStore.getState().searchEngine).toBe("google");
+  });
+
+  it("setSearchEngine updates to bing", () => {
+    useBrowserSettingsStore.getState().setSearchEngine("bing");
+    expect(useBrowserSettingsStore.getState().searchEngine).toBe("bing");
+  });
+});
+
+describe("searchUrlFor", () => {
+  it("returns DuckDuckGo URL with encoded query", () => {
+    const url = searchUrlFor("duckduckgo", "hello world");
+    expect(url).toBe(`${SEARCH_ENGINES.duckduckgo}${encodeURIComponent("hello world")}`);
+  });
+
+  it("returns Google URL with encoded query", () => {
+    const url = searchUrlFor("google", "typescript tutorial");
+    expect(url).toBe(`${SEARCH_ENGINES.google}${encodeURIComponent("typescript tutorial")}`);
+  });
+
+  it("returns Bing URL with encoded query", () => {
+    const url = searchUrlFor("bing", "open source");
+    expect(url).toBe(`${SEARCH_ENGINES.bing}${encodeURIComponent("open source")}`);
+  });
+
+  it("encodes special characters in query", () => {
+    const url = searchUrlFor("duckduckgo", "what is 2+2?");
+    expect(url).toContain(encodeURIComponent("what is 2+2?"));
+  });
+});

--- a/desktop/src/stores/browser-settings-store.ts
+++ b/desktop/src/stores/browser-settings-store.ts
@@ -20,7 +20,7 @@ interface BrowserSettingsState {
   searchEngine: SearchEngine;
   setDiscardTimeoutMs: (ms: number) => void;
   setMaxLiveTabs: (n: number) => void;
-  setSearchEngine: (e: SearchEngine) => void;
+  setSearchEngine: (e: string) => void;
 }
 
 export const useBrowserSettingsStore = create<BrowserSettingsState>()(
@@ -28,7 +28,7 @@ export const useBrowserSettingsStore = create<BrowserSettingsState>()(
     (set) => ({
       discardTimeoutMs: 10 * 60 * 1000,
       maxLiveTabs: 12,
-      searchEngine: "duckduckgo" as SearchEngine,
+      searchEngine: "duckduckgo",
 
       setDiscardTimeoutMs(ms) {
         const clamped = Math.max(60_000, Math.min(60 * 60 * 1000, ms));
@@ -41,7 +41,7 @@ export const useBrowserSettingsStore = create<BrowserSettingsState>()(
       },
 
       setSearchEngine(e) {
-        set({ searchEngine: e });
+        if (e in SEARCH_ENGINES) set({ searchEngine: e as SearchEngine });
       },
     }),
     { name: "taos-browser-settings" },

--- a/desktop/src/stores/browser-settings-store.ts
+++ b/desktop/src/stores/browser-settings-store.ts
@@ -1,0 +1,49 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export const SEARCH_ENGINES = {
+  duckduckgo: "https://duckduckgo.com/?q=",
+  google: "https://www.google.com/search?q=",
+  bing: "https://www.bing.com/search?q=",
+} as const;
+
+export type SearchEngine = keyof typeof SEARCH_ENGINES;
+
+/** Returns the full search URL for a given engine and query. */
+export function searchUrlFor(engine: SearchEngine, query: string): string {
+  return `${SEARCH_ENGINES[engine]}${encodeURIComponent(query)}`;
+}
+
+interface BrowserSettingsState {
+  discardTimeoutMs: number;
+  maxLiveTabs: number;
+  searchEngine: SearchEngine;
+  setDiscardTimeoutMs: (ms: number) => void;
+  setMaxLiveTabs: (n: number) => void;
+  setSearchEngine: (e: SearchEngine) => void;
+}
+
+export const useBrowserSettingsStore = create<BrowserSettingsState>()(
+  persist(
+    (set) => ({
+      discardTimeoutMs: 10 * 60 * 1000,
+      maxLiveTabs: 12,
+      searchEngine: "duckduckgo" as SearchEngine,
+
+      setDiscardTimeoutMs(ms) {
+        const clamped = Math.max(60_000, Math.min(60 * 60 * 1000, ms));
+        set({ discardTimeoutMs: clamped });
+      },
+
+      setMaxLiveTabs(n) {
+        const clamped = Math.max(1, Math.min(50, n));
+        set({ maxLiveTabs: clamped });
+      },
+
+      setSearchEngine(e) {
+        set({ searchEngine: e });
+      },
+    }),
+    { name: "taos-browser-settings" },
+  ),
+);

--- a/desktop/src/stores/browser-store.test.ts
+++ b/desktop/src/stores/browser-store.test.ts
@@ -285,6 +285,79 @@ describe("browser-store: zoom", () => {
   });
 });
 
+describe("browser-store: setTabReader", () => {
+  beforeEach(async () => {
+    const mod = await import("./browser-store");
+    mod.useBrowserStore.setState({ windows: {} });
+  });
+
+  it("patches reader fields onto the tab", async () => {
+    const s = await freshStore();
+    s.createWindow("win-1", "personal");
+    const tabId = s.getWindow("win-1")!.tabs[0].id;
+
+    s.setTabReader("win-1", tabId, {
+      readerAvailable: true,
+      readerActive: false,
+      readerExtract: {
+        title: "Article",
+        text: "content",
+        html: "<p>content</p>",
+        word_count: 300,
+      },
+    });
+
+    const tab = s.getWindow("win-1")?.tabs[0];
+    expect(tab?.readerAvailable).toBe(true);
+    expect(tab?.readerActive).toBe(false);
+    expect(tab?.readerExtract?.title).toBe("Article");
+  });
+
+  it("partial patch only updates specified fields", async () => {
+    const s = await freshStore();
+    s.createWindow("win-1", "personal");
+    const tabId = s.getWindow("win-1")!.tabs[0].id;
+
+    s.setTabReader("win-1", tabId, { readerAvailable: true });
+    s.setTabReader("win-1", tabId, { readerActive: true });
+
+    const tab = s.getWindow("win-1")?.tabs[0];
+    expect(tab?.readerAvailable).toBe(true);
+    expect(tab?.readerActive).toBe(true);
+  });
+});
+
+describe("browser-store: navigateTab reader reset", () => {
+  beforeEach(async () => {
+    const mod = await import("./browser-store");
+    mod.useBrowserStore.setState({ windows: {} });
+  });
+
+  it("resets reader fields when navigating to a new URL", async () => {
+    const s = await freshStore();
+    s.createWindow("win-1", "personal");
+    const tabId = s.getWindow("win-1")!.tabs[0].id;
+
+    s.setTabReader("win-1", tabId, {
+      readerAvailable: true,
+      readerActive: true,
+      readerExtract: {
+        title: "Old article",
+        text: "old",
+        html: "<p>old</p>",
+        word_count: 500,
+      },
+    });
+
+    s.navigateTab("win-1", tabId, "https://new-page.test/");
+
+    const tab = s.getWindow("win-1")?.tabs[0];
+    expect(tab?.readerAvailable).toBeUndefined();
+    expect(tab?.readerActive).toBeUndefined();
+    expect(tab?.readerExtract).toBeNull();
+  });
+});
+
 describe("browser-store: switchProfile", () => {
   beforeEach(async () => {
     const mod = await import("./browser-store");

--- a/desktop/src/stores/browser-store.test.ts
+++ b/desktop/src/stores/browser-store.test.ts
@@ -306,3 +306,97 @@ describe("browser-store: switchProfile", () => {
     expect(s.getWindow("missing")).toBeUndefined();
   });
 });
+
+describe("browser-store: switchProfile snapshot/restore", () => {
+  beforeEach(async () => {
+    const mod = await import("./browser-store");
+    mod.useBrowserStore.setState({ windows: {} });
+  });
+
+  it("snapshots current tabs under the old profileId on switch", async () => {
+    const s = await freshStore();
+    s.createWindow("win-1", "personal");
+    const tabA = s.addTab("win-1", "https://a.test/");
+    const tabB = s.addTab("win-1", "https://b.test/");
+    expect(s.getWindow("win-1")?.tabs.length).toBe(3);
+
+    s.switchProfile("win-1", "work");
+
+    // After switch: profileId is "work", tabs reset to one fresh new-tab,
+    // and the old "personal" tabs are saved under _savedTabsByProfile
+    const win = s.getWindow("win-1");
+    expect(win?.profileId).toBe("work");
+    expect(win?.tabs.length).toBe(1);
+    expect(win?._savedTabsByProfile?.personal).toBeDefined();
+    expect(win?._savedTabsByProfile?.personal.tabs.length).toBe(3);
+  });
+
+  it("restores tabs from the snapshot on switch back", async () => {
+    const s = await freshStore();
+    s.createWindow("win-1", "personal");
+    const tabA = s.addTab("win-1", "https://a.test/");
+    const tabB = s.addTab("win-1", "https://b.test/");
+
+    s.switchProfile("win-1", "work");
+    expect(s.getWindow("win-1")?.tabs.length).toBe(1); // Fresh new-tab for "work"
+
+    s.switchProfile("win-1", "personal");
+
+    const win = s.getWindow("win-1");
+    expect(win?.profileId).toBe("personal");
+    expect(win?.tabs.length).toBe(3);
+    // The original tabs are restored
+    expect(win?.tabs.find((t) => t.id === tabA)).toBeDefined();
+    expect(win?.tabs.find((t) => t.id === tabB)).toBeDefined();
+  });
+
+  it("creates fresh new-tab when destination profile has no snapshot", async () => {
+    const s = await freshStore();
+    s.createWindow("win-1", "personal");
+    s.switchProfile("win-1", "work");
+
+    // Work has no prior snapshot — should init with one fresh new-tab
+    const win = s.getWindow("win-1");
+    expect(win?.tabs.length).toBe(1);
+    expect(win?.profileId).toBe("work");
+  });
+
+  it("noop when switching to the already-active profile", async () => {
+    const s = await freshStore();
+    s.createWindow("win-1", "personal");
+    const tabA = s.addTab("win-1", "https://a.test/");
+    const before = s.getWindow("win-1");
+
+    s.switchProfile("win-1", "personal");
+
+    const after = s.getWindow("win-1");
+    expect(after?.tabs.length).toBe(before?.tabs.length);
+    expect(after?._savedTabsByProfile).toBeUndefined();
+  });
+
+  it("preserves snapshots for OTHER profiles when switching between two", async () => {
+    const s = await freshStore();
+    s.createWindow("win-1", "personal");
+    s.addTab("win-1", "https://personal-a.test/");
+
+    s.switchProfile("win-1", "work");
+    s.addTab("win-1", "https://work-a.test/");
+
+    s.switchProfile("win-1", "research");
+    s.addTab("win-1", "https://research-a.test/");
+
+    // Now both personal AND work snapshots should be in the saved map
+    const win = s.getWindow("win-1");
+    expect(win?.profileId).toBe("research");
+    expect(win?._savedTabsByProfile?.personal).toBeDefined();
+    expect(win?._savedTabsByProfile?.work).toBeDefined();
+    expect(win?._savedTabsByProfile?.research).toBeUndefined(); // Active
+
+    // Switch back to personal — work snapshot should still be preserved
+    s.switchProfile("win-1", "personal");
+    const win2 = s.getWindow("win-1");
+    expect(win2?._savedTabsByProfile?.work).toBeDefined();
+    expect(win2?._savedTabsByProfile?.research).toBeDefined(); // Just snapshotted
+    expect(win2?._savedTabsByProfile?.personal).toBeUndefined(); // Just restored
+  });
+});

--- a/desktop/src/stores/browser-store.test.ts
+++ b/desktop/src/stores/browser-store.test.ts
@@ -358,6 +358,69 @@ describe("browser-store: navigateTab reader reset", () => {
   });
 });
 
+describe("browser-store: goBack/goForward reader reset", () => {
+  beforeEach(async () => {
+    const mod = await import("./browser-store");
+    mod.useBrowserStore.setState({ windows: {} });
+  });
+
+  it("goBack clears all three reader fields", async () => {
+    const s = await freshStore();
+    s.createWindow("win-1", "personal");
+    const tabId = s.getWindow("win-1")!.tabs[0].id;
+
+    s.navigateTab("win-1", tabId, "https://a.test/");
+    s.navigateTab("win-1", tabId, "https://b.test/");
+    s.setTabReader("win-1", tabId, {
+      readerAvailable: true,
+      readerActive: true,
+      readerExtract: {
+        title: "Article",
+        text: "content",
+        html: "<p>content</p>",
+        word_count: 300,
+      },
+    });
+
+    s.goBack("win-1", tabId);
+
+    const tab = s.getWindow("win-1")?.tabs[0];
+    expect(tab?.url).toBe("https://a.test/");
+    expect(tab?.readerAvailable).toBeUndefined();
+    expect(tab?.readerActive).toBeUndefined();
+    expect(tab?.readerExtract).toBeNull();
+  });
+
+  it("goForward clears all three reader fields", async () => {
+    const s = await freshStore();
+    s.createWindow("win-1", "personal");
+    const tabId = s.getWindow("win-1")!.tabs[0].id;
+
+    s.navigateTab("win-1", tabId, "https://a.test/");
+    s.navigateTab("win-1", tabId, "https://b.test/");
+    s.goBack("win-1", tabId);
+    // Now set reader state at https://a.test/
+    s.setTabReader("win-1", tabId, {
+      readerAvailable: true,
+      readerActive: true,
+      readerExtract: {
+        title: "Article A",
+        text: "content a",
+        html: "<p>content a</p>",
+        word_count: 300,
+      },
+    });
+
+    s.goForward("win-1", tabId);
+
+    const tab = s.getWindow("win-1")?.tabs[0];
+    expect(tab?.url).toBe("https://b.test/");
+    expect(tab?.readerAvailable).toBeUndefined();
+    expect(tab?.readerActive).toBeUndefined();
+    expect(tab?.readerExtract).toBeNull();
+  });
+});
+
 describe("browser-store: switchProfile", () => {
   beforeEach(async () => {
     const mod = await import("./browser-store");

--- a/desktop/src/stores/browser-store.test.ts
+++ b/desktop/src/stores/browser-store.test.ts
@@ -284,3 +284,25 @@ describe("browser-store: zoom", () => {
     expect(s.getWindow("win-1")?.tabs[0].zoom).toBeCloseTo(0.5);
   });
 });
+
+describe("browser-store: switchProfile", () => {
+  beforeEach(async () => {
+    const mod = await import("./browser-store");
+    mod.useBrowserStore.setState({ windows: {} });
+  });
+
+  it("updates the window's profileId (basic — Task 6 adds tab snapshot)", async () => {
+    const s = await freshStore();
+    s.createWindow("win-1", "personal");
+    expect(s.getWindow("win-1")?.profileId).toBe("personal");
+
+    s.switchProfile("win-1", "work");
+    expect(s.getWindow("win-1")?.profileId).toBe("work");
+  });
+
+  it("noop when window doesn't exist", async () => {
+    const s = await freshStore();
+    s.switchProfile("missing", "work");
+    expect(s.getWindow("missing")).toBeUndefined();
+  });
+});

--- a/desktop/src/stores/browser-store.ts
+++ b/desktop/src/stores/browser-store.ts
@@ -288,12 +288,38 @@ export const useBrowserStore = create<BrowserStore>((set, get) => ({
     set((s) => {
       const win = s.windows[windowId];
       if (!win) return s;
-      // PR 5 Task 4: minimal — just update profileId. Task 6 will
-      // enhance to snapshot/restore tabs per (window, profile).
+      if (win.profileId === newProfileId) return s; // No-op if already active
+
+      // Snapshot current state under the OLD profileId
+      const savedMap = win._savedTabsByProfile ?? {};
+      const updatedSavedMap = {
+        ...savedMap,
+        [win.profileId]: {
+          tabs: win.tabs,
+          activeTabId: win.activeTabId,
+        },
+      };
+
+      // Restore from snapshot if one exists for the new profile,
+      // otherwise initialise with a fresh new-tab page
+      const restoredSnapshot = updatedSavedMap[newProfileId];
+      const restoredTabs = restoredSnapshot?.tabs ?? [makeTab()];
+      const restoredActiveId =
+        restoredSnapshot?.activeTabId ?? restoredTabs[0].id;
+
+      // Drop the new profile's snapshot from the saved map (it's now active)
+      const { [newProfileId]: _consumed, ...remainingSnapshots } = updatedSavedMap;
+
       return {
         windows: {
           ...s.windows,
-          [windowId]: { ...win, profileId: newProfileId },
+          [windowId]: {
+            ...win,
+            profileId: newProfileId,
+            tabs: restoredTabs,
+            activeTabId: restoredActiveId,
+            _savedTabsByProfile: remainingSnapshots,
+          },
         },
       };
     });

--- a/desktop/src/stores/browser-store.ts
+++ b/desktop/src/stores/browser-store.ts
@@ -12,6 +12,7 @@ import { create } from "zustand";
 import type {
   BrowserWindowState,
   LiveExclusion,
+  ReaderExtract,
   RecentlyClosedTab,
   Tab,
 } from "@/apps/BrowserApp/types";
@@ -81,6 +82,13 @@ interface BrowserStore {
   // Profile switching — Task 4: minimal (updates profileId only).
   // Task 6 will enhance to snapshot/restore tabs per (window, profile).
   switchProfile: (windowId: string, newProfileId: string) => void;
+
+  // Reader mode
+  setTabReader: (
+    windowId: string,
+    tabId: string,
+    patch: Partial<Pick<Tab, "readerAvailable" | "readerActive" | "readerExtract">>,
+  ) => void;
 }
 
 export const useBrowserStore = create<BrowserStore>((set, get) => ({
@@ -211,6 +219,10 @@ export const useBrowserStore = create<BrowserStore>((set, get) => ({
         historyIndex: newHistory.length - 1,
         state: "live",
         lastActiveAt: Date.now(),
+        // Reset reader state on navigation — new URL invalidates the extract
+        readerAvailable: undefined,
+        readerActive: undefined,
+        readerExtract: null,
       };
     }));
   },
@@ -299,6 +311,10 @@ export const useBrowserStore = create<BrowserStore>((set, get) => ({
       };
     });
   },
+  setTabReader(windowId, tabId, patch) {
+    set((s) => updateTab(s, windowId, tabId, (t) => ({ ...t, ...patch })));
+  },
+
   switchProfile(windowId, newProfileId) {
     set((s) => {
       const win = s.windows[windowId];

--- a/desktop/src/stores/browser-store.ts
+++ b/desktop/src/stores/browser-store.ts
@@ -11,6 +11,7 @@
 import { create } from "zustand";
 import type {
   BrowserWindowState,
+  LiveExclusion,
   RecentlyClosedTab,
   Tab,
 } from "@/apps/BrowserApp/types";
@@ -65,6 +66,13 @@ interface BrowserStore {
 
   // Per-tab zoom
   setTabZoom: (windowId: string, tabId: string, zoom: number) => void;
+
+  // Live-exclusion tracking
+  setTabLiveExclusion: (
+    windowId: string,
+    tabId: string,
+    exclusion: LiveExclusion | undefined,
+  ) => void;
 
   // Cross-window tab move (PR 4: menu-driven; native drag-and-drop with
   // DOM-portal iframe preservation is deferred to a future enhancement)
@@ -236,6 +244,13 @@ export const useBrowserStore = create<BrowserStore>((set, get) => ({
   setTabZoom(windowId, tabId, zoom) {
     const clamped = Math.max(0.5, Math.min(3.0, zoom));
     set((s) => updateTab(s, windowId, tabId, (t) => ({ ...t, zoom: clamped })));
+  },
+
+  setTabLiveExclusion(windowId, tabId, exclusion) {
+    set((s) => updateTab(s, windowId, tabId, (t) => ({
+      ...t,
+      liveExclusion: exclusion,
+    })));
   },
 
   moveTab(fromWindowId, tabId, toWindowId, toIndex) {

--- a/desktop/src/stores/browser-store.ts
+++ b/desktop/src/stores/browser-store.ts
@@ -69,6 +69,10 @@ interface BrowserStore {
   // Cross-window tab move (PR 4: menu-driven; native drag-and-drop with
   // DOM-portal iframe preservation is deferred to a future enhancement)
   moveTab: (fromWindowId: string, tabId: string, toWindowId: string, toIndex?: number) => void;
+
+  // Profile switching — Task 4: minimal (updates profileId only).
+  // Task 6 will enhance to snapshot/restore tabs per (window, profile).
+  switchProfile: (windowId: string, newProfileId: string) => void;
 }
 
 export const useBrowserStore = create<BrowserStore>((set, get) => ({
@@ -276,6 +280,20 @@ export const useBrowserStore = create<BrowserStore>((set, get) => ({
           ...s.windows,
           [fromWindowId]: sourceAfter,
           [toWindowId]: destAfter,
+        },
+      };
+    });
+  },
+  switchProfile(windowId, newProfileId) {
+    set((s) => {
+      const win = s.windows[windowId];
+      if (!win) return s;
+      // PR 5 Task 4: minimal — just update profileId. Task 6 will
+      // enhance to snapshot/restore tabs per (window, profile).
+      return {
+        windows: {
+          ...s.windows,
+          [windowId]: { ...win, profileId: newProfileId },
         },
       };
     });

--- a/desktop/src/stores/browser-store.ts
+++ b/desktop/src/stores/browser-store.ts
@@ -12,7 +12,6 @@ import { create } from "zustand";
 import type {
   BrowserWindowState,
   LiveExclusion,
-  ReaderExtract,
   RecentlyClosedTab,
   Tab,
 } from "@/apps/BrowserApp/types";
@@ -231,7 +230,14 @@ export const useBrowserStore = create<BrowserStore>((set, get) => ({
     set((s) => updateTab(s, windowId, tabId, (t) => {
       if (t.historyIndex <= 0) return t;
       const newIdx = t.historyIndex - 1;
-      return { ...t, historyIndex: newIdx, url: t.history[newIdx] };
+      return {
+        ...t,
+        historyIndex: newIdx,
+        url: t.history[newIdx],
+        readerAvailable: undefined,
+        readerActive: undefined,
+        readerExtract: null,
+      };
     }));
   },
 
@@ -239,7 +245,14 @@ export const useBrowserStore = create<BrowserStore>((set, get) => ({
     set((s) => updateTab(s, windowId, tabId, (t) => {
       if (t.historyIndex >= t.history.length - 1) return t;
       const newIdx = t.historyIndex + 1;
-      return { ...t, historyIndex: newIdx, url: t.history[newIdx] };
+      return {
+        ...t,
+        historyIndex: newIdx,
+        url: t.history[newIdx],
+        readerAvailable: undefined,
+        readerActive: undefined,
+        readerExtract: null,
+      };
     }));
   },
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     # libtorrent-rasterbar as a prerequisite on each platform.
     "libtorrent>=2.0.9",
     "lxml>=5.0.0",
+    "readability-lxml>=0.8.1",
     # Memory system — standalone package, pulled from GitHub
     "taosmd @ git+https://github.com/jaylfc/taosmd.git@master",
     # WebSocket client for dashboard proxy (shortcut_proxy.py)

--- a/tests/routes/desktop_browser/test_extract.py
+++ b/tests/routes/desktop_browser/test_extract.py
@@ -152,3 +152,102 @@ class TestExtractEndpointFetch:
         # 500 with non-HTML content, word_count will just be 0)
         # Verify the endpoint doesn't crash
         assert resp.status_code in (200, 502)
+
+
+@pytest.mark.asyncio
+class TestExtractEndpointRedirectSsrf:
+    """Regression tests: SSRF re-validation on each redirect hop."""
+
+    @respx.mock
+    async def test_redirect_to_rfc1918_returns_403(self, client):
+        # Initial URL passes SSRF; redirect lands on RFC1918 — must be blocked.
+        respx.get("http://example.com/go").mock(
+            return_value=Response(
+                302,
+                headers={"location": "http://192.168.1.1/"},
+            )
+        )
+
+        with patch(
+            "tinyagentos.routes.desktop_browser.ssrf.socket.getaddrinfo",
+            return_value=[(2, 1, 6, "", ("93.184.216.34", 0))],
+        ):
+            resp = await client.get(
+                "/api/desktop/browser/extract",
+                params={"profile_id": "personal", "url": "http://example.com/go"},
+            )
+
+        assert resp.status_code == 403
+
+    @respx.mock
+    async def test_redirect_to_aws_imds_returns_403(self, client):
+        # Redirect to AWS IMDS (169.254.169.254) is link-local — blocked.
+        respx.get("http://example.com/redir").mock(
+            return_value=Response(
+                301,
+                headers={"location": "http://169.254.169.254/latest/meta-data/"},
+            )
+        )
+
+        with patch(
+            "tinyagentos.routes.desktop_browser.ssrf.socket.getaddrinfo",
+            return_value=[(2, 1, 6, "", ("93.184.216.34", 0))],
+        ):
+            resp = await client.get(
+                "/api/desktop/browser/extract",
+                params={"profile_id": "personal", "url": "http://example.com/redir"},
+            )
+
+        assert resp.status_code == 403
+
+    @respx.mock
+    async def test_redirect_chain_too_long_returns_502(self, client):
+        # 5-hop cycle: example.com/hop0 → /hop1 → … — exhausts the cap.
+        for i in range(5):
+            respx.get(f"http://example.com/hop{i}").mock(
+                return_value=Response(
+                    302,
+                    headers={"location": f"http://example.com/hop{i + 1}"},
+                )
+            )
+
+        with patch(
+            "tinyagentos.routes.desktop_browser.ssrf.socket.getaddrinfo",
+            return_value=[(2, 1, 6, "", ("93.184.216.34", 0))],
+        ):
+            resp = await client.get(
+                "/api/desktop/browser/extract",
+                params={"profile_id": "personal", "url": "http://example.com/hop0"},
+            )
+
+        assert resp.status_code == 502
+
+    @respx.mock
+    async def test_normal_redirect_followed_and_extracted(self, client):
+        # http → final response on the same public host — should succeed.
+        respx.get("http://example.com/article").mock(
+            return_value=Response(
+                301,
+                headers={"location": "http://example.com/article-final"},
+            )
+        )
+        respx.get("http://example.com/article-final").mock(
+            return_value=Response(
+                200,
+                content=ARTICLE_HTML,
+                headers={"content-type": "text/html"},
+            )
+        )
+
+        with patch(
+            "tinyagentos.routes.desktop_browser.ssrf.socket.getaddrinfo",
+            return_value=[(2, 1, 6, "", ("93.184.216.34", 0))],
+        ):
+            resp = await client.get(
+                "/api/desktop/browser/extract",
+                params={"profile_id": "personal", "url": "http://example.com/article"},
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["word_count"] > 100

--- a/tests/routes/desktop_browser/test_extract.py
+++ b/tests/routes/desktop_browser/test_extract.py
@@ -1,0 +1,154 @@
+"""Tests for /api/desktop/browser/extract — Readability port."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+import respx
+from httpx import Response
+
+
+# A representative article HTML — enough words that Readability finds content
+ARTICLE_HTML = b"""
+<!doctype html>
+<html>
+<head><title>How HTTP cookies work</title></head>
+<body>
+<header><nav>Site nav | Login | Account</nav></header>
+<article>
+<h1>How HTTP cookies work</h1>
+<p>HTTP cookies are small pieces of data that a server sends to a user's web
+browser. The browser may store the cookie and send it back to the same server
+with later requests. Typically, an HTTP cookie is used to tell if two requests
+come from the same browser - keeping a user logged in, for example. It remembers
+stateful information for the stateless HTTP protocol.</p>
+<p>Cookies are mainly used for three purposes: session management, personalization,
+and tracking. Cookies were once used for general client-side storage. While this
+was legitimate when they were the only way to store data on the client, it is
+recommended to use modern storage APIs today. Cookies are sent with every
+request, so they can worsen performance, especially for mobile data connections.</p>
+<p>Modern APIs for client storage are the Web Storage API (localStorage and
+sessionStorage) and IndexedDB. There is also the Cache API for storing
+responses to specific requests, useful when working with the Service Worker API.
+These APIs let you store data on the client without sending it on every request,
+and they are not limited in size.</p>
+</article>
+<footer>Copyright 2026</footer>
+</body>
+</html>
+"""
+
+
+# Boilerplate-heavy HTML — list of links, no real article body
+BOILERPLATE_HTML = b"""
+<!doctype html>
+<html><body>
+<nav><a href="/">Home</a> <a href="/about">About</a> <a href="/contact">Contact</a></nav>
+<ul><li>Item 1</li><li>Item 2</li><li>Item 3</li></ul>
+</body></html>
+"""
+
+
+class TestExtractReadable:
+    def test_extracts_title_and_text_from_article(self):
+        from tinyagentos.routes.desktop_browser.extract import extract_readable
+
+        out = extract_readable(ARTICLE_HTML, "https://example.com/cookies")
+        assert "title" in out
+        assert "text" in out
+        assert "html" in out
+        assert "word_count" in out
+        assert isinstance(out["word_count"], int)
+        assert "cookie" in out["text"].lower()
+        assert out["word_count"] > 100
+
+    def test_boilerplate_produces_low_word_count(self):
+        from tinyagentos.routes.desktop_browser.extract import extract_readable
+
+        out = extract_readable(BOILERPLATE_HTML, "https://example.com/")
+        # Reader UI hides the toggle when word_count <= 200
+        assert out["word_count"] < 200
+
+    def test_empty_input_returns_empty_dict(self):
+        from tinyagentos.routes.desktop_browser.extract import extract_readable
+
+        out = extract_readable(b"", "https://example.com/")
+        assert out["word_count"] == 0
+        assert out["text"] == ""
+
+
+@pytest.mark.asyncio
+class TestExtractEndpointAuth:
+    async def test_unauthenticated_returns_401(self, app):
+        from httpx import ASGITransport, AsyncClient
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.get(
+                "/api/desktop/browser/extract",
+                params={"profile_id": "personal", "url": "http://example.com/"},
+            )
+            assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+class TestExtractEndpointSsrf:
+    async def test_blocks_private_ip(self, client):
+        resp = await client.get(
+            "/api/desktop/browser/extract",
+            params={"profile_id": "personal", "url": "http://127.0.0.1/admin"},
+        )
+        assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+class TestExtractEndpointFetch:
+    @respx.mock
+    async def test_fetches_and_extracts(self, client):
+        respx.get("http://example.com/cookies").mock(
+            return_value=Response(
+                200,
+                content=ARTICLE_HTML,
+                headers={"content-type": "text/html"},
+            )
+        )
+
+        with patch(
+            "tinyagentos.routes.desktop_browser.ssrf.socket.getaddrinfo",
+            return_value=[(2, 1, 6, "", ("93.184.216.34", 0))],
+        ):
+            resp = await client.get(
+                "/api/desktop/browser/extract",
+                params={
+                    "profile_id": "personal",
+                    "url": "http://example.com/cookies",
+                },
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "title" in body
+        assert "text" in body
+        assert body["word_count"] > 100
+        assert "cookie" in body["text"].lower()
+
+    @respx.mock
+    async def test_fetch_failure_returns_502(self, client):
+        respx.get("http://example.com/").mock(
+            return_value=Response(500, content=b"server error"),
+        )
+
+        with patch(
+            "tinyagentos.routes.desktop_browser.ssrf.socket.getaddrinfo",
+            return_value=[(2, 1, 6, "", ("93.184.216.34", 0))],
+        ):
+            resp = await client.get(
+                "/api/desktop/browser/extract",
+                params={"profile_id": "personal", "url": "http://example.com/"},
+            )
+
+        # Upstream 500 is propagated as part of the response
+        # (the endpoint doesn't error — it extracts what it can; for a
+        # 500 with non-HTML content, word_count will just be 0)
+        # Verify the endpoint doesn't crash
+        assert resp.status_code in (200, 502)

--- a/tests/routes/desktop_browser/test_profile_routes.py
+++ b/tests/routes/desktop_browser/test_profile_routes.py
@@ -84,6 +84,19 @@ class TestPatchProfile:
         )
         assert resp.status_code == 404
 
+    async def test_patch_blank_name_returns_400(self, client):
+        """Blank/whitespace-only name is rejected; existing name unchanged."""
+        resp = await client.patch(
+            "/api/desktop/browser/profiles/personal",
+            json={"name": "   "},
+        )
+        assert resp.status_code == 400
+
+        # Profile name must not have changed
+        list_resp = await client.get("/api/desktop/browser/profiles")
+        profiles = {p["profile_id"]: p for p in list_resp.json()["profiles"]}
+        assert profiles["personal"]["name"] == "Personal"
+
 
 @pytest.mark.asyncio
 class TestDeleteProfile:

--- a/tests/routes/desktop_browser/test_profile_routes.py
+++ b/tests/routes/desktop_browser/test_profile_routes.py
@@ -1,0 +1,163 @@
+"""Tests for /api/desktop/browser/profiles full CRUD."""
+from __future__ import annotations
+
+import pytest
+
+
+def _user_id_from_app(app):
+    """Resolve the conftest-authed user id for direct store seeding."""
+    auth_mgr = app.state.auth
+    users = auth_mgr._read_users().get("users", []) if hasattr(auth_mgr, "_read_users") else []
+    return users[0]["id"] if users else "test-admin"
+
+
+@pytest.mark.asyncio
+class TestProfilesAuth:
+    async def test_get_unauthenticated_returns_401(self, app):
+        from httpx import ASGITransport, AsyncClient
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.get("/api/desktop/browser/profiles")
+            assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+class TestListProfiles:
+    async def test_list_returns_default_profiles_after_first_call(self, client, app):
+        # Trigger ensure_default_profiles by hitting any auth-bound endpoint
+        # that calls it (the proxy does); for this test we hit profiles
+        # directly — endpoint must auto-bootstrap on first GET.
+        resp = await client.get("/api/desktop/browser/profiles")
+        assert resp.status_code == 200
+        body = resp.json()
+        names = {p["name"] for p in body["profiles"]}
+        assert names == {"Personal", "Work"}
+
+
+@pytest.mark.asyncio
+class TestCreateProfile:
+    async def test_post_creates_profile(self, client):
+        resp = await client.post(
+            "/api/desktop/browser/profiles",
+            json={"name": "Research", "color": "#88aa44"},
+        )
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["name"] == "Research"
+        assert body["color"] == "#88aa44"
+        assert body["profile_id"] == "research"
+
+    async def test_post_appends_suffix_on_collision(self, client):
+        await client.post(
+            "/api/desktop/browser/profiles", json={"name": "Personal", "color": "#000000"},
+        )
+        body = (await client.post(
+            "/api/desktop/browser/profiles", json={"name": "Personal", "color": "#111111"},
+        )).json()
+        # Original "personal" exists from defaults; first POST gets "personal-2"
+        assert body["profile_id"] in {"personal-2", "personal-3"}
+
+
+@pytest.mark.asyncio
+class TestPatchProfile:
+    async def test_patch_renames_profile(self, client):
+        resp = await client.patch(
+            "/api/desktop/browser/profiles/personal",
+            json={"name": "My Profile"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "My Profile"
+
+    async def test_patch_changes_color(self, client):
+        resp = await client.patch(
+            "/api/desktop/browser/profiles/personal",
+            json={"color": "#abcdef"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["color"] == "#abcdef"
+
+    async def test_patch_missing_returns_404(self, client):
+        resp = await client.patch(
+            "/api/desktop/browser/profiles/nonexistent",
+            json={"name": "X"},
+        )
+        assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestDeleteProfile:
+    async def test_delete_returns_204_and_removes(self, client):
+        # Create a fresh deletable profile (the defaults can't be deleted
+        # if they're the last two — see refuses-last-profile test below)
+        await client.post(
+            "/api/desktop/browser/profiles",
+            json={"name": "Temp", "color": "#999999"},
+        )
+
+        resp = await client.delete("/api/desktop/browser/profiles/temp")
+        assert resp.status_code == 204
+
+        # List shouldn't include it anymore
+        list_resp = await client.get("/api/desktop/browser/profiles")
+        ids = {p["profile_id"] for p in list_resp.json()["profiles"]}
+        assert "temp" not in ids
+
+    async def test_delete_cascades_cookies(self, client, app):
+        await client.post(
+            "/api/desktop/browser/profiles",
+            json={"name": "Cookie Test", "color": "#cc0000"},
+        )
+
+        # Seed a cookie under that profile via the store directly
+        cookie_store = app.state.browser_cookie_store
+        user_id = _user_id_from_app(app)
+        await cookie_store.set_cookie(
+            user_id=user_id, profile_id="cookie-test",
+            host="example.com", path="/", name="sid", value="xyz",
+            expires_at=None, http_only=False, secure=False, same_site=None,
+        )
+        before = await cookie_store.get_cookies(
+            user_id=user_id, profile_id="cookie-test", host="example.com",
+        )
+        assert len(before) == 1
+
+        # Delete the profile
+        resp = await client.delete("/api/desktop/browser/profiles/cookie-test")
+        assert resp.status_code == 204
+
+        # Cookies for that profile must be gone
+        after = await cookie_store.get_cookies(
+            user_id=user_id, profile_id="cookie-test", host="example.com",
+        )
+        assert after == []
+
+    async def test_delete_missing_returns_404(self, client):
+        resp = await client.delete("/api/desktop/browser/profiles/never-existed")
+        assert resp.status_code == 404
+
+    async def test_delete_refuses_last_profile(self, client):
+        # First delete one of the two defaults
+        await client.delete("/api/desktop/browser/profiles/work")
+        # Trying to delete the only remaining profile must 400
+        resp = await client.delete("/api/desktop/browser/profiles/personal")
+        assert resp.status_code == 400
+        assert "last" in resp.json().get("error", "").lower()
+
+
+@pytest.mark.asyncio
+class TestMultiUserIsolation:
+    async def test_patch_other_users_profile_returns_404(self, client, app):
+        # Seed a profile for a DIFFERENT user
+        store = app.state.browser_store
+        import time
+        await store.add_profile(
+            user_id="other-user", profile_id="secret",
+            name="Secret", color="#000", created_at=int(time.time()),
+        )
+
+        # Authed user should NOT see / be able to patch other-user's profile
+        resp = await client.patch(
+            "/api/desktop/browser/profiles/secret", json={"name": "X"},
+        )
+        assert resp.status_code == 404

--- a/tests/routes/desktop_browser/test_profile_routes.py
+++ b/tests/routes/desktop_browser/test_profile_routes.py
@@ -1,6 +1,8 @@
 """Tests for /api/desktop/browser/profiles full CRUD."""
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
 
 
@@ -57,6 +59,37 @@ class TestCreateProfile:
         )).json()
         # Original "personal" exists from defaults; first POST gets "personal-2"
         assert body["profile_id"] in {"personal-2", "personal-3"}
+
+    async def test_create_retries_on_concurrent_slug_collision(self):
+        """Simulate a race: add_profile returns False on first call (slug taken by a
+        concurrent request), True on second. create_profile must retry and return
+        the suffixed slug rather than silently returning a ghost profile_id."""
+        from unittest.mock import AsyncMock
+        from tinyagentos.routes.desktop_browser.profile import create_profile
+
+        # Build a minimal mock store
+        store = AsyncMock()
+        store.list_profiles.return_value = []  # no existing profiles
+
+        add_calls: list[str] = []
+
+        async def fake_add_profile(*, user_id, profile_id, name, color, created_at):
+            add_calls.append(profile_id)
+            # First call always fails (simulate race)
+            return len(add_calls) > 1
+
+        store.add_profile.side_effect = fake_add_profile
+
+        result = await create_profile(
+            store, user_id="u1", name="Race", color="#112233",
+        )
+
+        # Must have retried (2 calls) and returned a valid profile_id
+        assert len(add_calls) == 2
+        assert result["profile_id"] is not None
+        # Both attempts were for the same base slug (list returned empty both times)
+        assert add_calls[0] == "race"
+        assert add_calls[1] == "race"
 
 
 @pytest.mark.asyncio

--- a/tinyagentos/routes/desktop_browser/__init__.py
+++ b/tinyagentos/routes/desktop_browser/__init__.py
@@ -14,3 +14,4 @@ router = APIRouter()
 from tinyagentos.routes.desktop_browser import proxy as _proxy  # noqa: E402,F401
 from tinyagentos.routes.desktop_browser import windows as _windows  # noqa: E402,F401
 from tinyagentos.routes.desktop_browser import suggest as _suggest  # noqa: E402,F401
+from tinyagentos.routes.desktop_browser import profile_routes as _profile_routes  # noqa: E402,F401

--- a/tinyagentos/routes/desktop_browser/__init__.py
+++ b/tinyagentos/routes/desktop_browser/__init__.py
@@ -15,3 +15,4 @@ from tinyagentos.routes.desktop_browser import proxy as _proxy  # noqa: E402,F40
 from tinyagentos.routes.desktop_browser import windows as _windows  # noqa: E402,F401
 from tinyagentos.routes.desktop_browser import suggest as _suggest  # noqa: E402,F401
 from tinyagentos.routes.desktop_browser import profile_routes as _profile_routes  # noqa: E402,F401
+from tinyagentos.routes.desktop_browser import extract as _extract  # noqa: E402,F401

--- a/tinyagentos/routes/desktop_browser/extract.py
+++ b/tinyagentos/routes/desktop_browser/extract.py
@@ -1,0 +1,120 @@
+"""BrowserApp v2 — Readability extract endpoint.
+
+Single function `extract_readable(html_bytes, url) -> dict` runs Mozilla's
+Readability algorithm (via `readability-lxml`) over the raw HTML and returns
+title + text + html + word_count. Used by:
+
+  - Reader mode UI (PR 5 Task 9) — replaces iframe with styled article view
+  - Agent context (PR 6) — same extraction, fed into agent runtime as
+    "page changed" tool-result events for pinned-agent shared context
+
+The HTTP endpoint at `/api/desktop/browser/extract` does the same auth +
+SSRF gate as the proxy, then performs a fresh httpx fetch (no rewriter, no
+injection — we want the raw upstream HTML) and runs the extractor.
+
+For PR 5 the endpoint duplicates a thin slice of the proxy fetch loop
+(auth + SSRF + httpx GET). A future refactor can extract a shared
+`_fetcher.py` helper if both paths grow more in common.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+from urllib.parse import urlparse, urlsplit
+
+import httpx
+from fastapi import Depends, Request
+from fastapi.responses import JSONResponse
+from lxml import html as lxml_html
+from readability import Document
+
+from tinyagentos.auth import get_current_user
+from tinyagentos.routes.desktop_browser import router
+from tinyagentos.routes.desktop_browser.ssrf import (
+    SsrfBlockedError,
+    validate_url_or_raise,
+)
+
+
+_logger = logging.getLogger(__name__)
+_FETCH_TIMEOUT = 15.0
+
+
+def extract_readable(html_bytes: bytes, url: str) -> dict[str, Any]:
+    """Run Readability over `html_bytes` and return title/text/html/word_count.
+
+    Returns an empty-ish dict on parse failure; never raises.
+    """
+    if not html_bytes:
+        return {"title": "", "text": "", "html": "", "word_count": 0}
+
+    try:
+        decoded = html_bytes.decode("utf-8", errors="replace")
+        doc = Document(decoded)
+        title = (doc.short_title() or doc.title() or "").strip()
+        summary_html = doc.summary(html_partial=True)
+    except Exception as e:
+        _logger.info("readability extract failed: %s", e)
+        return {"title": "", "text": "", "html": "", "word_count": 0}
+
+    text = ""
+    try:
+        text = lxml_html.fromstring(summary_html).text_content().strip()
+    except Exception:
+        # Empty / malformed summary — fall through with empty text
+        pass
+
+    word_count = len([w for w in text.split() if w.strip()])
+
+    return {
+        "title": title,
+        "text": text,
+        "html": summary_html,
+        "word_count": word_count,
+    }
+
+
+@router.get("/api/desktop/browser/extract")
+async def extract_endpoint(
+    profile_id: str,
+    url: str,
+    request: Request,
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+):
+    """Auth + SSRF gate + fetch + Readability extract."""
+    user_id = str(current_user.get("id") or "")
+    if not user_id:
+        return JSONResponse({"error": "session has no user id"}, status_code=401)
+
+    # SSRF gate
+    try:
+        validate_url_or_raise(url)
+    except SsrfBlockedError as e:
+        parsed = urlsplit(url)
+        _logger.info(
+            "browser extract SSRF block: scheme=%r host=%r reason=%s",
+            parsed.scheme, parsed.hostname, e,
+        )
+        return JSONResponse({"error": "URL blocked"}, status_code=403)
+
+    # Fetch (no rewriter / no injection — we want raw upstream HTML for extraction)
+    async with httpx.AsyncClient(
+        follow_redirects=True, timeout=_FETCH_TIMEOUT,
+    ) as http:
+        try:
+            response = await http.get(url)
+        except httpx.HTTPError as e:
+            _logger.info("browser extract fetch error: err=%s", e)
+            return JSONResponse({"error": "fetch failed"}, status_code=502)
+
+    content_type = response.headers.get("content-type", "")
+    if "text/html" not in content_type.lower():
+        return {
+            "title": "",
+            "text": "",
+            "html": "",
+            "word_count": 0,
+            "note": f"non-HTML content-type: {content_type}",
+        }
+
+    return extract_readable(response.content, url)

--- a/tinyagentos/routes/desktop_browser/extract.py
+++ b/tinyagentos/routes/desktop_browser/extract.py
@@ -76,12 +76,18 @@ def extract_readable(html_bytes: bytes, url: str) -> dict[str, Any]:
 
 @router.get("/api/desktop/browser/extract")
 async def extract_endpoint(
-    profile_id: str,
+    profile_id: str,  # reserved for future per-profile caching; not yet used
     url: str,
     request: Request,
     current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
 ):
-    """Auth + SSRF gate + fetch + Readability extract."""
+    """Auth + SSRF gate + fetch + Readability extract.
+
+    Note: profile_id is currently unused — extracts run against raw upstream
+    HTML (no cookie injection) so the result is profile-independent. The
+    parameter is reserved for future per-profile extract caching.
+    """
+    _ = profile_id
     user_id = str(current_user.get("id") or "")
     if not user_id:
         return JSONResponse({"error": "session has no user id"}, status_code=401)

--- a/tinyagentos/routes/desktop_browser/extract.py
+++ b/tinyagentos/routes/desktop_browser/extract.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import logging
 from typing import Any
-from urllib.parse import urlparse, urlsplit
+from urllib.parse import urljoin, urlparse, urlsplit
 
 import httpx
 from fastapi import Depends, Request
@@ -50,7 +50,9 @@ def extract_readable(html_bytes: bytes, url: str) -> dict[str, Any]:
 
     try:
         decoded = html_bytes.decode("utf-8", errors="replace")
-        doc = Document(decoded)
+        # Pass url so readability-lxml can absolutize relative href/src via
+        # make_links_absolute — without it, Reader mode renders broken links.
+        doc = Document(decoded, url=url)
         title = (doc.short_title() or doc.title() or "").strip()
         summary_html = doc.summary(html_partial=True)
     except Exception as e:
@@ -61,8 +63,7 @@ def extract_readable(html_bytes: bytes, url: str) -> dict[str, Any]:
     try:
         text = lxml_html.fromstring(summary_html).text_content().strip()
     except Exception:
-        # Empty / malformed summary — fall through with empty text
-        pass
+        _logger.debug("lxml text_content failed for extracted summary; returning empty text")
 
     word_count = len([w for w in text.split() if w.strip()])
 
@@ -103,15 +104,39 @@ async def extract_endpoint(
         )
         return JSONResponse({"error": "URL blocked"}, status_code=403)
 
-    # Fetch (no rewriter / no injection — we want raw upstream HTML for extraction)
-    async with httpx.AsyncClient(
-        follow_redirects=True, timeout=_FETCH_TIMEOUT,
-    ) as http:
-        try:
-            response = await http.get(url)
-        except httpx.HTTPError as e:
-            _logger.info("browser extract fetch error: err=%s", e)
-            return JSONResponse({"error": "fetch failed"}, status_code=502)
+    # Fetch (no rewriter / no injection — we want raw upstream HTML for extraction).
+    # Walk redirects manually so we can re-check SSRF on each hop, mirroring
+    # the pattern in proxy.py. follow_redirects=False prevents httpx from silently
+    # following a redirect to an internal address after the initial SSRF gate passes.
+    _MAX_HOPS = 5
+    response: httpx.Response | None = None
+    async with httpx.AsyncClient(follow_redirects=False, timeout=_FETCH_TIMEOUT) as http:
+        fetch_url = url
+        for _hop in range(_MAX_HOPS):
+            try:
+                response = await http.get(fetch_url)
+            except httpx.HTTPError as e:
+                _logger.info("browser extract fetch error: err=%s", e)
+                return JSONResponse({"error": "fetch failed"}, status_code=502)
+            if response.is_redirect:
+                location = response.headers.get("location")
+                if not location:
+                    return JSONResponse({"error": "redirect missing Location"}, status_code=502)
+                fetch_url = urljoin(fetch_url, location)
+                try:
+                    validate_url_or_raise(fetch_url)
+                except SsrfBlockedError as e:
+                    parsed = urlsplit(fetch_url)
+                    _logger.info(
+                        "browser extract SSRF block on redirect: scheme=%r host=%r reason=%s",
+                        parsed.scheme, parsed.hostname, e,
+                    )
+                    return JSONResponse({"error": "URL blocked"}, status_code=403)
+                continue
+            break
+        else:
+            return JSONResponse({"error": "redirect chain too long"}, status_code=502)
+    assert response is not None
 
     content_type = response.headers.get("content-type", "")
     if "text/html" not in content_type.lower():

--- a/tinyagentos/routes/desktop_browser/profile.py
+++ b/tinyagentos/routes/desktop_browser/profile.py
@@ -34,17 +34,25 @@ class ProfileNotFoundError(Exception):
 
 
 async def ensure_default_profiles(store: BrowserStore, *, user_id: str) -> None:
-    """Idempotent bootstrap: create Personal + Work for the user if absent."""
+    """Idempotent bootstrap: create Personal + Work for the user on first call only.
+
+    Uses a profile_init table to record that defaults were seeded — subsequent
+    calls are a no-op even if the user later deletes those default profiles.
+    """
     if not user_id:
         raise ValueError("user_id is required")
 
-    existing = await store.list_profiles(user_id=user_id)
-    have_ids = {p["profile_id"] for p in existing}
-    now = int(time.time())
+    assert store._db is not None
+    cursor = await store._db.execute(
+        "SELECT initialized_at FROM profile_init WHERE user_id = ?",
+        (user_id,),
+    )
+    row = await cursor.fetchone()
+    if row is not None:
+        return  # Already bootstrapped; respect any deletions the user made.
 
+    now = int(time.time())
     for default in _DEFAULTS:
-        if default["profile_id"] in have_ids:
-            continue
         await store.add_profile(
             user_id=user_id,
             profile_id=default["profile_id"],
@@ -52,6 +60,11 @@ async def ensure_default_profiles(store: BrowserStore, *, user_id: str) -> None:
             color=default["color"],
             created_at=now,
         )
+    await store._db.execute(
+        "INSERT OR IGNORE INTO profile_init (user_id, initialized_at) VALUES (?, ?)",
+        (user_id, now),
+    )
+    await store._db.commit()
 
 
 async def get_profile_or_404(
@@ -75,3 +88,130 @@ async def get_profile_or_404(
     raise ProfileNotFoundError(
         f"profile {profile_id!r} not found for user {user_id!r}"
     )
+
+
+import re
+
+from tinyagentos.routes.desktop_browser.store import BrowserCookieStore
+
+
+def _slugify(name: str) -> str:
+    """Convert a profile name to a URL-safe slug."""
+    slug = re.sub(r"[^\w\s-]", "", name.lower())
+    slug = re.sub(r"[\s_-]+", "-", slug).strip("-")
+    return slug or "profile"
+
+
+async def create_profile(
+    store: BrowserStore,
+    *,
+    user_id: str,
+    name: str,
+    color: str | None = None,
+) -> dict:
+    """Create a new profile with auto-slugified ID; appends -2/-3 on collision."""
+    if not user_id:
+        raise ValueError("user_id is required")
+    name = name.strip()
+    if not name:
+        raise ValueError("name is required")
+
+    base_slug = _slugify(name)
+    existing = await store.list_profiles(user_id=user_id)
+    have_ids = {p["profile_id"] for p in existing}
+
+    candidate = base_slug
+    suffix = 2
+    while candidate in have_ids:
+        candidate = f"{base_slug}-{suffix}"
+        suffix += 1
+
+    now = int(time.time())
+    await store.add_profile(
+        user_id=user_id,
+        profile_id=candidate,
+        name=name,
+        color=color,
+        created_at=now,
+    )
+    return {
+        "profile_id": candidate,
+        "name": name,
+        "color": color,
+        "created_at": now,
+    }
+
+
+async def rename_profile(
+    store: BrowserStore,
+    *,
+    user_id: str,
+    profile_id: str,
+    name: str | None = None,
+    color: str | None = None,
+) -> dict:
+    """Update an existing profile's name/color. Raises ProfileNotFoundError if missing."""
+    if not user_id:
+        raise ValueError("user_id is required")
+    if not profile_id:
+        raise ValueError("profile_id is required")
+
+    updated = await store.update_profile(
+        user_id=user_id, profile_id=profile_id, name=name, color=color,
+    )
+    if not updated:
+        # Either the row doesn't exist OR no fields were provided
+        # — distinguish by re-reading
+        existing = await store.list_profiles(user_id=user_id)
+        for p in existing:
+            if p["profile_id"] == profile_id:
+                return p  # No-op update on existing — return current state
+        raise ProfileNotFoundError(
+            f"profile {profile_id!r} not found for user {user_id!r}"
+        )
+
+    # Re-read to return the updated row
+    return await get_profile_or_404(
+        store, user_id=user_id, profile_id=profile_id,
+    )
+
+
+class LastProfileError(Exception):
+    """Raised when attempting to delete the user's last profile."""
+
+
+async def delete_profile_cascade(
+    browser_store: BrowserStore,
+    cookie_store: BrowserCookieStore,
+    *,
+    user_id: str,
+    profile_id: str,
+) -> bool:
+    """Delete a profile + cascade-delete its cookies.
+
+    Refuses to delete the user's last profile (raises LastProfileError).
+    Returns True if the profile was deleted, False if it didn't exist.
+    """
+    if not user_id:
+        raise ValueError("user_id is required")
+    if not profile_id:
+        raise ValueError("profile_id is required")
+
+    profiles = await browser_store.list_profiles(user_id=user_id)
+    # Check if the profile being deleted actually exists
+    profile_exists = any(p["profile_id"] == profile_id for p in profiles)
+    if not profile_exists:
+        return False
+    if len(profiles) <= 1:
+        raise LastProfileError(
+            "cannot delete the last profile — every user needs at least one"
+        )
+
+    deleted = await browser_store.delete_profile(
+        user_id=user_id, profile_id=profile_id,
+    )
+    if deleted:
+        await cookie_store.delete_profile_cookies(
+            user_id=user_id, profile_id=profile_id,
+        )
+    return deleted

--- a/tinyagentos/routes/desktop_browser/profile.py
+++ b/tinyagentos/routes/desktop_browser/profile.py
@@ -38,18 +38,15 @@ async def ensure_default_profiles(store: BrowserStore, *, user_id: str) -> None:
 
     Uses a profile_init table to record that defaults were seeded — subsequent
     calls are a no-op even if the user later deletes those default profiles.
+    The INSERT OR IGNORE on the PRIMARY KEY (user_id) column makes the claim
+    atomic: two concurrent first requests both attempt the insert; only one
+    succeeds (rowcount == 1) and that caller seeds the defaults.
     """
     if not user_id:
         raise ValueError("user_id is required")
 
-    assert store._db is not None
-    cursor = await store._db.execute(
-        "SELECT initialized_at FROM profile_init WHERE user_id = ?",
-        (user_id,),
-    )
-    row = await cursor.fetchone()
-    if row is not None:
-        return  # Already bootstrapped; respect any deletions the user made.
+    if not await store.claim_profile_init(user_id=user_id):
+        return  # Another caller already seeded defaults.
 
     now = int(time.time())
     for default in _DEFAULTS:
@@ -60,11 +57,6 @@ async def ensure_default_profiles(store: BrowserStore, *, user_id: str) -> None:
             color=default["color"],
             created_at=now,
         )
-    await store._db.execute(
-        "INSERT OR IGNORE INTO profile_init (user_id, initialized_at) VALUES (?, ?)",
-        (user_id, now),
-    )
-    await store._db.commit()
 
 
 async def get_profile_or_404(
@@ -155,6 +147,11 @@ async def rename_profile(
         raise ValueError("user_id is required")
     if not profile_id:
         raise ValueError("profile_id is required")
+    if name is not None:
+        normalized = name.strip()
+        if not normalized:
+            raise ValueError("name must not be blank")
+        name = normalized
 
     updated = await store.update_profile(
         user_id=user_id, profile_id=profile_id, name=name, color=color,
@@ -191,27 +188,30 @@ async def delete_profile_cascade(
 
     Refuses to delete the user's last profile (raises LastProfileError).
     Returns True if the profile was deleted, False if it didn't exist.
+
+    The last-profile check is performed atomically inside delete_profile via
+    a single SQL statement, so two concurrent deletes cannot both pass the
+    guard.
     """
     if not user_id:
         raise ValueError("user_id is required")
     if not profile_id:
         raise ValueError("profile_id is required")
 
-    profiles = await browser_store.list_profiles(user_id=user_id)
-    # Check if the profile being deleted actually exists
-    profile_exists = any(p["profile_id"] == profile_id for p in profiles)
-    if not profile_exists:
-        return False
-    if len(profiles) <= 1:
-        raise LastProfileError(
-            "cannot delete the last profile — every user needs at least one"
-        )
-
     deleted = await browser_store.delete_profile(
         user_id=user_id, profile_id=profile_id,
     )
-    if deleted:
-        await cookie_store.delete_profile_cookies(
-            user_id=user_id, profile_id=profile_id,
-        )
-    return deleted
+    if not deleted:
+        # Either the profile didn't exist, or it was the last one.
+        # Distinguish by checking whether the profile_id still appears in the list.
+        profiles = await browser_store.list_profiles(user_id=user_id)
+        if any(p["profile_id"] == profile_id for p in profiles):
+            raise LastProfileError(
+                "cannot delete the last profile — every user needs at least one"
+            )
+        return False  # didn't exist
+
+    await cookie_store.delete_profile_cookies(
+        user_id=user_id, profile_id=profile_id,
+    )
+    return True

--- a/tinyagentos/routes/desktop_browser/profile.py
+++ b/tinyagentos/routes/desktop_browser/profile.py
@@ -101,7 +101,13 @@ async def create_profile(
     name: str,
     color: str | None = None,
 ) -> dict:
-    """Create a new profile with auto-slugified ID; appends -2/-3 on collision."""
+    """Create a new profile with auto-slugified ID; appends -2/-3 on collision.
+
+    Uses INSERT OR IGNORE as the authoritative collision guard — the
+    pre-check via list_profiles is a fast path only. If a concurrent
+    request took the slug between list_profiles and add_profile, the
+    INSERT returns False and we increment the suffix and retry.
+    """
     if not user_id:
         raise ValueError("user_id is required")
     name = name.strip()
@@ -109,29 +115,38 @@ async def create_profile(
         raise ValueError("name is required")
 
     base_slug = _slugify(name)
-    existing = await store.list_profiles(user_id=user_id)
-    have_ids = {p["profile_id"] for p in existing}
+    max_attempts = 100
+    for attempt in range(max_attempts):
+        # Fast-path: skip slugs that are already visible in the list.
+        existing = await store.list_profiles(user_id=user_id)
+        have_ids = {p["profile_id"] for p in existing}
+        candidate = base_slug
+        n = 2
+        while candidate in have_ids:
+            candidate = f"{base_slug}-{n}"
+            n += 1
 
-    candidate = base_slug
-    suffix = 2
-    while candidate in have_ids:
-        candidate = f"{base_slug}-{suffix}"
-        suffix += 1
+        now = int(time.time())
+        inserted = await store.add_profile(
+            user_id=user_id,
+            profile_id=candidate,
+            name=name,
+            color=color,
+            created_at=now,
+        )
+        if inserted:
+            return {
+                "profile_id": candidate,
+                "name": name,
+                "color": color,
+                "created_at": now,
+            }
+        # Race: a concurrent request took this slug between list_profiles and
+        # add_profile. Loop again — the next list_profiles call will see it.
 
-    now = int(time.time())
-    await store.add_profile(
-        user_id=user_id,
-        profile_id=candidate,
-        name=name,
-        color=color,
-        created_at=now,
+    raise RuntimeError(
+        f"could not allocate slug for name={name!r} after {max_attempts} attempts"
     )
-    return {
-        "profile_id": candidate,
-        "name": name,
-        "color": color,
-        "created_at": now,
-    }
 
 
 async def rename_profile(

--- a/tinyagentos/routes/desktop_browser/profile.py
+++ b/tinyagentos/routes/desktop_browser/profile.py
@@ -15,9 +15,10 @@ in the chrome) lands in PR 5. PR 3 only needs:
 """
 from __future__ import annotations
 
+import re
 import time
 
-from tinyagentos.routes.desktop_browser.store import BrowserStore
+from tinyagentos.routes.desktop_browser.store import BrowserCookieStore, BrowserStore
 
 
 # Defaults bootstrapped per user. profile_id is the URL-safe identifier;
@@ -82,11 +83,6 @@ async def get_profile_or_404(
     )
 
 
-import re
-
-from tinyagentos.routes.desktop_browser.store import BrowserCookieStore
-
-
 def _slugify(name: str) -> str:
     """Convert a profile name to a URL-safe slug."""
     slug = re.sub(r"[^\w\s-]", "", name.lower())
@@ -116,7 +112,7 @@ async def create_profile(
 
     base_slug = _slugify(name)
     max_attempts = 100
-    for attempt in range(max_attempts):
+    for _attempt in range(max_attempts):
         # Fast-path: skip slugs that are already visible in the list.
         existing = await store.list_profiles(user_id=user_id)
         have_ids = {p["profile_id"] for p in existing}

--- a/tinyagentos/routes/desktop_browser/profile_routes.py
+++ b/tinyagentos/routes/desktop_browser/profile_routes.py
@@ -1,0 +1,121 @@
+"""HTTP endpoints for profile CRUD."""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import Depends, Request
+from fastapi.responses import JSONResponse, Response
+from pydantic import BaseModel
+
+from tinyagentos.auth import get_current_user
+from tinyagentos.routes.desktop_browser import router
+from tinyagentos.routes.desktop_browser.profile import (
+    LastProfileError,
+    ProfileNotFoundError,
+    create_profile,
+    delete_profile_cascade,
+    ensure_default_profiles,
+    rename_profile,
+)
+
+
+class ProfileCreateBody(BaseModel):
+    name: str
+    color: str | None = None
+
+
+class ProfilePatchBody(BaseModel):
+    name: str | None = None
+    color: str | None = None
+
+
+@router.get("/api/desktop/browser/profiles")
+async def list_profiles_route(
+    request: Request,
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+) -> dict:
+    user_id = str(current_user.get("id") or "")
+    if not user_id:
+        return JSONResponse({"error": "session has no user id"}, status_code=401)
+
+    store = request.app.state.browser_store
+    await ensure_default_profiles(store, user_id=user_id)
+    profiles = await store.list_profiles(user_id=user_id)
+    return {"profiles": profiles}
+
+
+@router.post("/api/desktop/browser/profiles")
+async def create_profile_route(
+    body: ProfileCreateBody,
+    request: Request,
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+):
+    user_id = str(current_user.get("id") or "")
+    if not user_id:
+        return JSONResponse({"error": "session has no user id"}, status_code=401)
+
+    store = request.app.state.browser_store
+    await ensure_default_profiles(store, user_id=user_id)
+    try:
+        created = await create_profile(
+            store, user_id=user_id, name=body.name, color=body.color,
+        )
+    except ValueError as e:
+        return JSONResponse({"error": str(e)}, status_code=400)
+
+    return JSONResponse(created, status_code=201)
+
+
+@router.patch("/api/desktop/browser/profiles/{profile_id}")
+async def patch_profile_route(
+    profile_id: str,
+    body: ProfilePatchBody,
+    request: Request,
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+):
+    user_id = str(current_user.get("id") or "")
+    if not user_id:
+        return JSONResponse({"error": "session has no user id"}, status_code=401)
+
+    store = request.app.state.browser_store
+    await ensure_default_profiles(store, user_id=user_id)
+    try:
+        updated = await rename_profile(
+            store,
+            user_id=user_id,
+            profile_id=profile_id,
+            name=body.name,
+            color=body.color,
+        )
+    except ProfileNotFoundError:
+        return JSONResponse({"error": "profile not found"}, status_code=404)
+
+    return updated
+
+
+@router.delete("/api/desktop/browser/profiles/{profile_id}")
+async def delete_profile_route(
+    profile_id: str,
+    request: Request,
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+):
+    user_id = str(current_user.get("id") or "")
+    if not user_id:
+        return JSONResponse({"error": "session has no user id"}, status_code=401)
+
+    browser_store = request.app.state.browser_store
+    cookie_store = request.app.state.browser_cookie_store
+    await ensure_default_profiles(browser_store, user_id=user_id)
+
+    try:
+        deleted = await delete_profile_cascade(
+            browser_store, cookie_store,
+            user_id=user_id, profile_id=profile_id,
+        )
+    except LastProfileError as e:
+        return JSONResponse({"error": str(e)}, status_code=400)
+
+    if not deleted:
+        return JSONResponse({"error": "profile not found"}, status_code=404)
+
+    return Response(status_code=204)

--- a/tinyagentos/routes/desktop_browser/profile_routes.py
+++ b/tinyagentos/routes/desktop_browser/profile_routes.py
@@ -87,6 +87,8 @@ async def patch_profile_route(
             name=body.name,
             color=body.color,
         )
+    except ValueError as e:
+        return JSONResponse({"error": str(e)}, status_code=400)
     except ProfileNotFoundError:
         return JSONResponse({"error": "profile not found"}, status_code=404)
 

--- a/tinyagentos/routes/desktop_browser/schema.py
+++ b/tinyagentos/routes/desktop_browser/schema.py
@@ -24,6 +24,11 @@ CREATE TABLE IF NOT EXISTS profiles (
   PRIMARY KEY (user_id, profile_id)
 );
 
+CREATE TABLE IF NOT EXISTS profile_init (
+  user_id        TEXT NOT NULL PRIMARY KEY,
+  initialized_at INTEGER NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS history (
   user_id        TEXT NOT NULL,
   profile_id     TEXT NOT NULL,

--- a/tinyagentos/routes/desktop_browser/store.py
+++ b/tinyagentos/routes/desktop_browser/store.py
@@ -171,16 +171,45 @@ class BrowserStore(BaseStore):
         await self._db.commit()
         return cursor.rowcount > 0
 
+    async def claim_profile_init(self, *, user_id: str) -> bool:
+        """Try to claim the init marker; return True iff this caller won the race.
+
+        profile_init has PRIMARY KEY (user_id), so INSERT OR IGNORE is atomic:
+        exactly one concurrent caller gets rowcount == 1 and proceeds to seed
+        defaults; all others get rowcount == 0 and skip.
+        """
+        if not user_id:
+            raise ValueError("user_id is required")
+        import time as _time
+        assert self._db is not None
+        cursor = await self._db.execute(
+            "INSERT OR IGNORE INTO profile_init (user_id, initialized_at) VALUES (?, ?)",
+            (user_id, int(_time.time())),
+        )
+        await self._db.commit()
+        return cursor.rowcount > 0
+
     async def delete_profile(self, *, user_id: str, profile_id: str) -> bool:
-        """Delete a profile. Returns True if a row was deleted."""
+        """Atomically delete the profile if it is not the user's last.
+
+        Returns True iff the profile was actually deleted.
+        Returns False if the profile doesn't exist OR is the last one for the user.
+
+        The COUNT subquery and DELETE execute as a single SQL statement, so two
+        concurrent deletes cannot both pass the last-profile guard.
+        """
         if not user_id:
             raise ValueError("user_id is required")
         if not profile_id:
             raise ValueError("profile_id is required")
         assert self._db is not None
         cursor = await self._db.execute(
-            "DELETE FROM profiles WHERE user_id = ? AND profile_id = ?",
-            (user_id, profile_id),
+            """
+            DELETE FROM profiles
+            WHERE user_id = ? AND profile_id = ?
+              AND (SELECT COUNT(*) FROM profiles WHERE user_id = ?) > 1
+            """,
+            (user_id, profile_id, user_id),
         )
         await self._db.commit()
         return cursor.rowcount > 0

--- a/tinyagentos/routes/desktop_browser/store.py
+++ b/tinyagentos/routes/desktop_browser/store.py
@@ -137,6 +137,54 @@ class BrowserStore(BaseStore):
         await self._db.commit()
         return cursor.rowcount > 0
 
+    async def update_profile(
+        self,
+        *,
+        user_id: str,
+        profile_id: str,
+        name: str | None = None,
+        color: str | None = None,
+    ) -> bool:
+        """Patch an existing profile's name/color. Returns True if a row was updated."""
+        if not user_id:
+            raise ValueError("user_id is required")
+        if not profile_id:
+            raise ValueError("profile_id is required")
+        if name is None and color is None:
+            return False
+        assert self._db is not None
+        # Build dynamic SET clause
+        sets: list[str] = []
+        params: list[object] = []
+        if name is not None:
+            sets.append("name = ?")
+            params.append(name)
+        if color is not None:
+            sets.append("color = ?")
+            params.append(color)
+        params.extend([user_id, profile_id])
+        cursor = await self._db.execute(
+            f"UPDATE profiles SET {', '.join(sets)} "
+            f"WHERE user_id = ? AND profile_id = ?",
+            params,
+        )
+        await self._db.commit()
+        return cursor.rowcount > 0
+
+    async def delete_profile(self, *, user_id: str, profile_id: str) -> bool:
+        """Delete a profile. Returns True if a row was deleted."""
+        if not user_id:
+            raise ValueError("user_id is required")
+        if not profile_id:
+            raise ValueError("profile_id is required")
+        assert self._db is not None
+        cursor = await self._db.execute(
+            "DELETE FROM profiles WHERE user_id = ? AND profile_id = ?",
+            (user_id, profile_id),
+        )
+        await self._db.commit()
+        return cursor.rowcount > 0
+
     async def add_history(
         self,
         *,
@@ -416,3 +464,28 @@ class BrowserCookieStore:
                 conn.close()
 
         await asyncio.get_running_loop().run_in_executor(None, _do)
+
+    async def delete_profile_cookies(
+        self, *, user_id: str, profile_id: str,
+    ) -> int:
+        """Delete all cookies for a (user, profile). Returns row count."""
+        if not user_id:
+            raise ValueError("user_id is required")
+        if not profile_id:
+            raise ValueError("profile_id is required")
+
+        import asyncio
+
+        def _do() -> int:
+            conn = self._connect()
+            try:
+                cursor = conn.execute(
+                    "DELETE FROM cookies WHERE user_id = ? AND profile_id = ?",
+                    (user_id, profile_id),
+                )
+                conn.commit()
+                return cursor.rowcount or 0
+            finally:
+                conn.close()
+
+        return await asyncio.get_running_loop().run_in_executor(None, _do)

--- a/tinyagentos/routes/desktop_browser/store.py
+++ b/tinyagentos/routes/desktop_browser/store.py
@@ -33,18 +33,19 @@ class BrowserStore(BaseStore):
         name: str,
         color: str | None = None,
         created_at: int,
-    ) -> None:
+    ) -> bool:
         if not user_id:
             raise ValueError("user_id is required")
         if not profile_id:
             raise ValueError("profile_id is required")
         assert self._db is not None
-        await self._db.execute(
+        cursor = await self._db.execute(
             "INSERT OR IGNORE INTO profiles (user_id, profile_id, name, color, created_at) "
             "VALUES (?, ?, ?, ?, ?)",
             (user_id, profile_id, name, color, created_at),
         )
         await self._db.commit()
+        return cursor.rowcount > 0  # False = slug already taken
 
     async def list_profiles(self, *, user_id: str) -> list[dict]:
         if not user_id:


### PR DESCRIPTION
## Summary

Three quality-of-life upgrades that turn PR 4's working browser into a daily driver:

1. **Profile switcher + manager** — dropdown chip in chrome to switch active profile per window, modal for create/rename/delete with cookie-cascade warning. Active-profile delete is disabled in-window; if a profile is deleted while another window is using it, that window auto-recovers to the first remaining profile.
2. **Discard policy with live-exclusion** — the existing PR 4 idle/cap discard scheduler now exempts tabs that are playing audio/video, have active form input with non-empty value, or have selected files in an upload input. In-app settings panel exposes the discard timeout (1–60 min, default 10), live-tab cap (1–50, default 12), and default search engine (DDG / Google / Bing).
3. **Reader mode** — Readability extract endpoint (`/api/desktop/browser/extract`) plus a URL-bar toggle that appears when an article has >200 words. Article view renders DOMPurify-sanitised HTML with font-size and serif/sans-serif controls. Lazy: extract fires on address-bar focus, not on every navigation. Stale-fetch guard discards a result if the user navigated away mid-fetch.

Per-(window, profile) tab snapshots ride along: switching profiles saves the current tab set under the old profile and restores any prior snapshot for the new profile.

## Files

- Backend: profile CRUD routes + cascade delete (`profile.py`, `profile_routes.py`, `store.py`), Readability extract endpoint (`extract.py`).
- Frontend: `ProfileSwitcher.tsx`, `ProfileManager.tsx`, `SettingsPanel.tsx`, `ReaderMode.tsx`, `live-exclusion.ts`, `browser-settings-store.ts`, plus `browser-extract-api.ts` and `browser-profile-api.ts` clients.
- Modifies: `Chrome.tsx` (gear icon + chip), `AddressBar.tsx` (Reader toggle + lazy extract + search-engine wired through), `TabRenderer.tsx` (live-exclusion in scheduler, ReaderMode renders over hidden iframe), `browser-store.ts` (`switchProfile`, `setTabReader`, reader-state reset on `navigateTab` / `goBack` / `goForward`), Tab type extensions.

## Test plan

- [ ] Backend: \`pytest tests/routes/desktop_browser/ -q\` → 162 passed
- [ ] Frontend: \`cd desktop && npx vitest run\` → 483 passed across 90 files
- [ ] Manual: switch profile chip → tabs change → switch back → original tabs restored
- [ ] Manual: delete a profile → cookies for that profile gone, any other window on that profile auto-switches to fallback
- [ ] Manual: open a video tab, switch away, wait past discard timeout → video tab stays live (excluded)
- [ ] Manual: long-form article (Wikipedia) → Reader toggle appears, click → sanitised article view; toggling off restores iframe with scroll position intact
- [ ] Manual: list-heavy homepage → Reader toggle absent
- [ ] Manual: SettingsPanel slider change → next scheduler tick uses new discard timeout

## Deferred (follow-ups)

- **Multi-window profile-delete server push** — current fix is client-side scan inside ProfileManager; a proper fix wants the server to broadcast \`profile.deleted\` to all sessions for the user.
- **Stricter DOMPurify allowlist** — current config (\`USE_PROFILES: { html: true }\`) closes the XSS surface but still permits \`<form>\`, \`<input>\`, \`<iframe>\` etc. Article-only allowlist would be tighter.
- **Snapshot reader-extract eviction** — \`switchProfile\` snapshots include cached \`readerExtract.html\`; large articles × many profiles could grow in-memory state. Consider stripping \`readerExtract\` on snapshot and re-extracting on demand after restore.

## Spec / plan references

- Spec: \`docs/superpowers/specs/2026-05-03-browser-app-v2-design.md\`
- Plan: \`docs/superpowers/plans/2026-05-03-browser-app-v2-pr-5-profile-switcher-discard-reader.md\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reader mode: one-click reader view with sanitized article rendering, font controls, and lazy per-URL extraction
  * Profiles: create/rename/delete profiles with colors, plus profile switching that preserves/restores per-profile tabs
  * Settings panel: configure discard timeout, max live tabs, and default search engine (searches respect chosen engine)
  * Smart tab preservation: detect playing media, active forms, uploads to keep tabs live

* **Tests**
  * Expanded test coverage across reader, profiles, settings, extraction, live-exclusion, and tab rendering features
<!-- end of auto-generated comment: release notes by coderabbit.ai -->