### PR TITLE
feat(browser): PR 6 — agent presence (pill, picker, sticky pin, side panel)

### DIFF
--- a/desktop/src/apps/BrowserApp/AgentPanel.test.tsx
+++ b/desktop/src/apps/BrowserApp/AgentPanel.test.tsx
@@ -188,6 +188,52 @@ describe("AgentPanel", () => {
     );
   });
 
+  it("removes drag listeners on unmount during active drag (no leak)", () => {
+    openPanel("agent-1");
+    const setPanelWidthSpy = vi.spyOn(useBrowserAgentStore.getState(), "setPanelWidth");
+    const { unmount } = render(
+      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} pinnedAgentIds={PINNED} />,
+    );
+    const handle = screen.getByRole("separator");
+
+    // Start drag but do NOT fire mouseup
+    fireEvent.mouseDown(handle, { clientX: 1000 });
+
+    // Capture call count after mousedown (before mousemove)
+    const callsBefore = setPanelWidthSpy.mock.calls.length;
+
+    // Unmount mid-drag — listeners should be cleaned up
+    unmount();
+
+    // Fire a mousemove on window — should NOT trigger setPanelWidth
+    fireEvent.mouseMove(window, { clientX: 700 });
+
+    expect(setPanelWidthSpy.mock.calls.length).toBe(callsBefore);
+  });
+
+  it("two rapid Summarise clicks produce two distinct messages", () => {
+    openPanel("agent-1");
+    useBrowserAgentStore.getState().appendEvent(WINDOW_ID, TAB_ID, "agent-1", {
+      kind: "page-changed",
+      title: "Some Article",
+      url: "https://some.test/article",
+      timestamp: Date.now(),
+    });
+    render(
+      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} pinnedAgentIds={PINNED} />,
+    );
+    const btn = screen.getByText("Summarise this page");
+
+    // Click twice in the same render cycle
+    fireEvent.click(btn);
+    fireEvent.click(btn);
+
+    const msgs = useBrowserAgentStore.getState().messages["win-1:tab-1:agent-1"];
+    expect(msgs).toHaveLength(2);
+    // IDs must be distinct
+    expect(msgs[0].id).not.toBe(msgs[1].id);
+  });
+
   it("role='complementary' + aria-label='Agent panel'", () => {
     openPanel();
     render(

--- a/desktop/src/apps/BrowserApp/AgentPanel.test.tsx
+++ b/desktop/src/apps/BrowserApp/AgentPanel.test.tsx
@@ -1,0 +1,209 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { AgentPanel } from "./AgentPanel";
+import { useBrowserAgentStore } from "@/stores/browser-agent-store";
+import * as browserAgentApi from "@/lib/browser-agent-api";
+
+const WINDOW_ID = "win-1";
+const TAB_ID = "tab-1";
+const AGENTS = [
+  { id: "agent-1", name: "Alice", emoji: "🤖", framework: "openclaw" },
+  { id: "agent-2", name: "Bob", emoji: "🧪", framework: "smolagents" },
+];
+const PINNED = ["agent-1", "agent-2"];
+
+function openPanel(agentId = "agent-1") {
+  useBrowserAgentStore.getState().openPanel(WINDOW_ID, TAB_ID, agentId);
+}
+
+beforeEach(() => {
+  useBrowserAgentStore.setState({
+    panels: {},
+    lastEventAt: {},
+    messages: {},
+    recentEvents: {},
+  });
+  vi.spyOn(browserAgentApi, "listAgents").mockResolvedValue(AGENTS);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("AgentPanel", () => {
+  it("renders nothing when panel is closed", () => {
+    // Panel not open — store default has no entry
+    const { container } = render(
+      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} pinnedAgentIds={PINNED} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when pinnedAgentIds is empty", () => {
+    openPanel();
+    const { container } = render(
+      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} pinnedAgentIds={[]} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders panel when isOpen is true", () => {
+    openPanel();
+    render(
+      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} pinnedAgentIds={PINNED} />,
+    );
+    expect(screen.getByRole("complementary")).toBeInTheDocument();
+  });
+
+  it("renders one tab per pinned agent", () => {
+    openPanel();
+    render(
+      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} pinnedAgentIds={PINNED} />,
+    );
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs).toHaveLength(PINNED.length);
+  });
+
+  it("active tab highlighted with aria-selected=true", () => {
+    openPanel("agent-1");
+    render(
+      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} pinnedAgentIds={PINNED} />,
+    );
+    const tabs = screen.getAllByRole("tab");
+    // agent-1 is active
+    const activeTab = tabs.find((t) => t.getAttribute("aria-selected") === "true");
+    expect(activeTab).toBeTruthy();
+    const inactiveTabs = tabs.filter((t) => t.getAttribute("aria-selected") === "false");
+    expect(inactiveTabs.length).toBe(PINNED.length - 1);
+  });
+
+  it("clicking a tab calls setActiveAgent", () => {
+    openPanel("agent-1");
+    const setActiveAgentSpy = vi.spyOn(useBrowserAgentStore.getState(), "setActiveAgent");
+    render(
+      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} pinnedAgentIds={PINNED} />,
+    );
+    const tabs = screen.getAllByRole("tab");
+    // Click the second tab (agent-2)
+    fireEvent.click(tabs[1]);
+    expect(setActiveAgentSpy).toHaveBeenCalledWith(WINDOW_ID, TAB_ID, "agent-2");
+  });
+
+  it("close button calls closePanel", () => {
+    openPanel();
+    const closePanelSpy = vi.spyOn(useBrowserAgentStore.getState(), "closePanel");
+    render(
+      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} pinnedAgentIds={PINNED} />,
+    );
+    fireEvent.click(screen.getByLabelText("Close agent panel"));
+    expect(closePanelSpy).toHaveBeenCalledWith(WINDOW_ID, TAB_ID);
+  });
+
+  it("renders recent events from store", () => {
+    openPanel("agent-1");
+    useBrowserAgentStore.getState().appendEvent(WINDOW_ID, TAB_ID, "agent-1", {
+      kind: "page-changed",
+      title: "Example Page",
+      url: "https://example.com",
+      timestamp: Date.now(),
+    });
+    render(
+      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} pinnedAgentIds={PINNED} />,
+    );
+    expect(screen.getByText(/Example Page/)).toBeInTheDocument();
+  });
+
+  it("Summarise this page button appends a user message with the page extract", () => {
+    openPanel("agent-1");
+    const ts = Date.now();
+    useBrowserAgentStore.getState().appendEvent(WINDOW_ID, TAB_ID, "agent-1", {
+      kind: "page-changed",
+      title: "My Article",
+      url: "https://news.test/article",
+      timestamp: ts,
+    });
+    render(
+      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} pinnedAgentIds={PINNED} />,
+    );
+    fireEvent.click(screen.getByText("Summarise this page"));
+    const msgs = useBrowserAgentStore.getState().messages["win-1:tab-1:agent-1"];
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].author).toBe("user");
+    expect(msgs[0].content).toContain("summarise");
+    expect(msgs[0].content).toContain("My Article");
+  });
+
+  it("chat textarea Enter sends a user message; Shift+Enter inserts newline", () => {
+    openPanel("agent-1");
+    render(
+      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} pinnedAgentIds={PINNED} />,
+    );
+    const textarea = screen.getByRole("textbox");
+
+    // Type a message
+    fireEvent.change(textarea, { target: { value: "Hello agent" } });
+
+    // Shift+Enter should NOT send
+    fireEvent.keyDown(textarea, { key: "Enter", shiftKey: true });
+    expect(useBrowserAgentStore.getState().messages["win-1:tab-1:agent-1"] ?? []).toHaveLength(0);
+
+    // Enter should send
+    fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+    const msgs = useBrowserAgentStore.getState().messages["win-1:tab-1:agent-1"];
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].content).toBe("Hello agent");
+    expect(msgs[0].author).toBe("user");
+  });
+
+  it("sent message appears in the thread", () => {
+    openPanel("agent-1");
+    render(
+      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} pinnedAgentIds={PINNED} />,
+    );
+    const textarea = screen.getByRole("textbox");
+    fireEvent.change(textarea, { target: { value: "Visible message" } });
+    fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+    expect(screen.getByText("Visible message")).toBeInTheDocument();
+  });
+
+  it("drag handle updates setPanelWidth (mock mousemove)", () => {
+    openPanel("agent-1");
+    const setPanelWidthSpy = vi.spyOn(useBrowserAgentStore.getState(), "setPanelWidth");
+    render(
+      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} pinnedAgentIds={PINNED} />,
+    );
+    const handle = screen.getByRole("separator");
+
+    // Start drag
+    fireEvent.mouseDown(handle, { clientX: 1000 });
+    // Move left by 200px — panel width = window.innerWidth - clientX = 1024 - 800 = 224 (clamped to 240)
+    fireEvent.mouseMove(window, { clientX: 800 });
+    fireEvent.mouseUp(window);
+
+    // setPanelWidth should have been called with a number
+    expect(setPanelWidthSpy).toHaveBeenCalledWith(
+      WINDOW_ID,
+      TAB_ID,
+      expect.any(Number),
+    );
+  });
+
+  it("role='complementary' + aria-label='Agent panel'", () => {
+    openPanel();
+    render(
+      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} pinnedAgentIds={PINNED} />,
+    );
+    const panel = screen.getByRole("complementary");
+    expect(panel.getAttribute("aria-label")).toBe("Agent panel");
+  });
+
+  it("tablist + role='tab' + role='tabpanel' present", () => {
+    openPanel();
+    render(
+      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} pinnedAgentIds={PINNED} />,
+    );
+    expect(screen.getByRole("tablist")).toBeInTheDocument();
+    expect(screen.getAllByRole("tab").length).toBeGreaterThan(0);
+    expect(screen.getByRole("tabpanel")).toBeInTheDocument();
+  });
+});

--- a/desktop/src/apps/BrowserApp/AgentPanel.tsx
+++ b/desktop/src/apps/BrowserApp/AgentPanel.tsx
@@ -83,6 +83,17 @@ export function AgentPanel({ windowId, tabId, pinnedAgentIds }: AgentPanelProps)
 
   // Drag handle logic
   const isDraggingRef = useRef(false);
+  const onMoveRef = useRef<((ev: MouseEvent) => void) | null>(null);
+  const onUpRef = useRef<(() => void) | null>(null);
+
+  // Remove any lingering drag listeners on unmount (e.g. panel closed mid-drag)
+  useEffect(() => {
+    return () => {
+      isDraggingRef.current = false;
+      if (onMoveRef.current) window.removeEventListener("mousemove", onMoveRef.current);
+      if (onUpRef.current) window.removeEventListener("mouseup", onUpRef.current);
+    };
+  }, []);
 
   const handleDragStart = useCallback(
     (e: React.MouseEvent) => {
@@ -98,10 +109,14 @@ export function AgentPanel({ windowId, tabId, pinnedAgentIds }: AgentPanelProps)
 
       const onUp = () => {
         isDraggingRef.current = false;
-        window.removeEventListener("mousemove", onMove);
-        window.removeEventListener("mouseup", onUp);
+        if (onMoveRef.current) window.removeEventListener("mousemove", onMoveRef.current);
+        if (onUpRef.current) window.removeEventListener("mouseup", onUpRef.current);
+        onMoveRef.current = null;
+        onUpRef.current = null;
       };
 
+      onMoveRef.current = onMove;
+      onUpRef.current = onUp;
       window.addEventListener("mousemove", onMove);
       window.addEventListener("mouseup", onUp);
     },
@@ -154,7 +169,7 @@ export function AgentPanel({ windowId, tabId, pinnedAgentIds }: AgentPanelProps)
       ? ` (page: ${lastPageEvent.title ?? lastPageEvent.url ?? "unknown"})`
       : "";
     appendMessage(windowId, tabId, activeAgentId, {
-      id: `msg-${Date.now()}-summarise`,
+      id: `msg-${Date.now()}-${Math.random().toString(36).slice(2)}`,
       author: "user",
       content: `Please summarise this page${context}.`,
       timestamp: Date.now(),

--- a/desktop/src/apps/BrowserApp/AgentPanel.tsx
+++ b/desktop/src/apps/BrowserApp/AgentPanel.tsx
@@ -8,11 +8,14 @@
 import React, { useEffect, useRef, useState, useCallback, KeyboardEvent } from "react";
 import { useBrowserAgentStore } from "@/stores/browser-agent-store";
 import type { AgentMessage, AgentEvent } from "@/stores/browser-agent-store";
-import { listAgents, type AgentDto } from "@/lib/browser-agent-api";
+import { useBrowserStore } from "@/stores/browser-store";
+import { listAgents, unpinAgent, type AgentDto } from "@/lib/browser-agent-api";
 
 export interface AgentPanelProps {
   windowId: string;
   tabId: string;
+  /** Profile id needed for unpin requests. */
+  profileId: string;
   pinnedAgentIds: string[];
 }
 
@@ -40,7 +43,7 @@ function eventIcon(kind: AgentEvent["kind"]): string {
   return "↕";
 }
 
-export function AgentPanel({ windowId, tabId, pinnedAgentIds }: AgentPanelProps) {
+export function AgentPanel({ windowId, tabId, profileId, pinnedAgentIds }: AgentPanelProps) {
   const panelKey = `${windowId}:${tabId}`;
 
   const panel = useBrowserAgentStore((s) => s.panels[panelKey]);
@@ -141,6 +144,24 @@ export function AgentPanel({ windowId, tabId, pinnedAgentIds }: AgentPanelProps)
     closePanel(windowId, tabId);
   }
 
+  async function handleUnpin(agentId: string) {
+    const ok = await unpinAgent(profileId, tabId, agentId);
+    if (!ok) return;
+    useBrowserStore.getState().removePinnedAgent(windowId, tabId, agentId);
+    // If that was the last pinned agent, close the panel — there's nothing
+    // to show in the body.
+    const remaining = pinnedAgentIds.filter((a) => a !== agentId);
+    if (remaining.length === 0) {
+      closePanel(windowId, tabId);
+      return;
+    }
+    // If we just unpinned the active agent, switch to the first remaining.
+    const next = remaining[0];
+    if (agentId === activeAgentId && next) {
+      setActiveAgent(windowId, tabId, next);
+    }
+  }
+
   function sendMessage() {
     if (!inputValue.trim() || !activeAgentId) return;
     appendMessage(windowId, tabId, activeAgentId, {
@@ -209,27 +230,43 @@ export function AgentPanel({ windowId, tabId, pinnedAgentIds }: AgentPanelProps)
           const name = getAgentName(agentId);
           const tabId_ = `agent-tab-${windowId}-${tabId}-${agentId}`;
           return (
-            <button
+            <div
               key={agentId}
-              id={tabId_}
-              role="tab"
-              aria-selected={isActive}
-              onClick={() => handleTabClick(agentId)}
-              title={name}
               className={[
-                "flex items-center gap-1 px-2 py-1 rounded text-xs whitespace-nowrap transition-colors",
+                "group flex items-center gap-1 px-2 py-1 rounded text-xs whitespace-nowrap transition-colors",
                 isActive
                   ? "bg-shell-hover text-shell-text font-medium"
                   : "text-shell-text-secondary hover:bg-shell-hover hover:text-shell-text",
               ].join(" ")}
             >
-              <span
-                aria-hidden="true"
-                className="w-2 h-2 rounded-full flex-shrink-0"
-                style={{ backgroundColor: agentColor(agentId) }}
-              />
-              <span className="max-w-[80px] truncate">{name}</span>
-            </button>
+              <button
+                id={tabId_}
+                role="tab"
+                aria-selected={isActive}
+                onClick={() => handleTabClick(agentId)}
+                title={name}
+                className="flex items-center gap-1 outline-none"
+              >
+                <span
+                  aria-hidden="true"
+                  className="w-2 h-2 rounded-full flex-shrink-0"
+                  style={{ backgroundColor: agentColor(agentId) }}
+                />
+                <span className="max-w-[80px] truncate">{name}</span>
+              </button>
+              <button
+                type="button"
+                aria-label={`Unpin ${name}`}
+                title={`Unpin ${name}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleUnpin(agentId);
+                }}
+                className="opacity-0 group-hover:opacity-100 focus:opacity-100 ml-0.5 text-[0.65rem] leading-none rounded hover:bg-shell-bg-deep px-1 py-0.5 transition-opacity"
+              >
+                ✕
+              </button>
+            </div>
           );
         })}
       </div>

--- a/desktop/src/apps/BrowserApp/AgentPanel.tsx
+++ b/desktop/src/apps/BrowserApp/AgentPanel.tsx
@@ -1,0 +1,355 @@
+/**
+ * AgentPanel — slide-in side panel per (tab, agent).
+ *
+ * Shows a chat thread, recent page-change events, and suggested actions.
+ * Chat messages are stored locally in browser-agent-store for PR 6;
+ * PR 7 will wire real persistence and agent routing.
+ */
+import React, { useEffect, useRef, useState, useCallback, KeyboardEvent } from "react";
+import { useBrowserAgentStore } from "@/stores/browser-agent-store";
+import type { AgentMessage, AgentEvent } from "@/stores/browser-agent-store";
+import { listAgents, type AgentDto } from "@/lib/browser-agent-api";
+
+export interface AgentPanelProps {
+  windowId: string;
+  tabId: string;
+  pinnedAgentIds: string[];
+}
+
+// Stable empty arrays to avoid selector returning new references on every render
+const EMPTY_MESSAGES: AgentMessage[] = [];
+const EMPTY_EVENTS: AgentEvent[] = [];
+
+/** Deterministic hue from an agent id string — mirrors AgentPresencePill. */
+function agentColor(id: string): string {
+  let hash = 0;
+  for (let i = 0; i < id.length; i++) {
+    hash = (hash * 31 + id.charCodeAt(i)) >>> 0;
+  }
+  const hue = hash % 360;
+  return `hsl(${hue}, 55%, 45%)`;
+}
+
+function formatTime(ts: number): string {
+  return new Date(ts).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+function eventIcon(kind: AgentEvent["kind"]): string {
+  if (kind === "page-changed") return "🌐";
+  if (kind === "url-changed") return "🔗";
+  return "↕";
+}
+
+export function AgentPanel({ windowId, tabId, pinnedAgentIds }: AgentPanelProps) {
+  const panelKey = `${windowId}:${tabId}`;
+
+  const panel = useBrowserAgentStore((s) => s.panels[panelKey]);
+  const closePanel = useBrowserAgentStore((s) => s.closePanel);
+  const setActiveAgent = useBrowserAgentStore((s) => s.setActiveAgent);
+  const setPanelWidth = useBrowserAgentStore((s) => s.setPanelWidth);
+  const appendMessage = useBrowserAgentStore((s) => s.appendMessage);
+
+  const [agents, setAgents] = useState<AgentDto[]>([]);
+  const [inputValue, setInputValue] = useState("");
+  const chatEndRef = useRef<HTMLDivElement | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  // Load agent list once on mount
+  useEffect(() => {
+    let cancelled = false;
+    listAgents().then((list) => {
+      if (!cancelled) setAgents(list);
+    });
+    return () => { cancelled = true; };
+  }, []);
+
+  // Determine active agent id — fall back to first pinned if not set
+  const activeAgentId = panel?.activeAgentId ?? pinnedAgentIds[0] ?? null;
+  const agentKey = activeAgentId ? `${windowId}:${tabId}:${activeAgentId}` : null;
+
+  const messagesForKey = useBrowserAgentStore((s) =>
+    agentKey ? s.messages[agentKey] : undefined,
+  );
+  const recentEventsForKey = useBrowserAgentStore((s) =>
+    agentKey ? s.recentEvents[agentKey] : undefined,
+  );
+  const messages: AgentMessage[] = messagesForKey ?? EMPTY_MESSAGES;
+  const recentEvents: AgentEvent[] = recentEventsForKey ?? EMPTY_EVENTS;
+
+  // Scroll chat to bottom whenever messages change
+  useEffect(() => {
+    chatEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages.length]);
+
+  // Drag handle logic
+  const isDraggingRef = useRef(false);
+
+  const handleDragStart = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      isDraggingRef.current = true;
+
+      const onMove = (ev: MouseEvent) => {
+        if (!isDraggingRef.current) return;
+        // Panel is on the right; its width = viewport width - cursor X
+        const newWidth = window.innerWidth - ev.clientX;
+        setPanelWidth(windowId, tabId, newWidth);
+      };
+
+      const onUp = () => {
+        isDraggingRef.current = false;
+        window.removeEventListener("mousemove", onMove);
+        window.removeEventListener("mouseup", onUp);
+      };
+
+      window.addEventListener("mousemove", onMove);
+      window.addEventListener("mouseup", onUp);
+    },
+    [windowId, tabId, setPanelWidth],
+  );
+
+  // Don't render when there's nothing to show
+  if (pinnedAgentIds.length === 0) return null;
+  if (!panel?.isOpen) return null;
+
+  const panelWidth = panel.width;
+
+  function getAgentName(id: string): string {
+    return agents.find((a) => a.id === id)?.name ?? id;
+  }
+
+  function handleTabClick(agentId: string) {
+    setActiveAgent(windowId, tabId, agentId);
+  }
+
+  function handleClose() {
+    closePanel(windowId, tabId);
+  }
+
+  function sendMessage() {
+    if (!inputValue.trim() || !activeAgentId) return;
+    appendMessage(windowId, tabId, activeAgentId, {
+      id: `msg-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      author: "user",
+      content: inputValue.trim(),
+      timestamp: Date.now(),
+    });
+    setInputValue("");
+    textareaRef.current?.focus();
+  }
+
+  function handleKeyDown(e: KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      sendMessage();
+    }
+  }
+
+  function handleSummarisePage() {
+    if (!activeAgentId) return;
+    const lastPageEvent = [...recentEvents]
+      .reverse()
+      .find((ev) => ev.kind === "page-changed");
+    const context = lastPageEvent
+      ? ` (page: ${lastPageEvent.title ?? lastPageEvent.url ?? "unknown"})`
+      : "";
+    appendMessage(windowId, tabId, activeAgentId, {
+      id: `msg-${Date.now()}-summarise`,
+      author: "user",
+      content: `Please summarise this page${context}.`,
+      timestamp: Date.now(),
+    });
+  }
+
+  const activeAgentName = activeAgentId ? getAgentName(activeAgentId) : "Agent";
+
+  return (
+    <div
+      role="complementary"
+      aria-label="Agent panel"
+      style={{ width: panelWidth, minWidth: panelWidth, maxWidth: panelWidth }}
+      className="relative flex flex-col bg-shell-surface border-l border-shell-border-subtle h-full overflow-hidden flex-shrink-0"
+    >
+      {/* Drag handle */}
+      <div
+        role="separator"
+        aria-orientation="vertical"
+        aria-valuenow={panelWidth}
+        aria-valuemin={240}
+        aria-valuemax={480}
+        aria-label="Resize agent panel"
+        onMouseDown={handleDragStart}
+        className="absolute left-0 top-0 bottom-0 w-3 cursor-col-resize z-10 hover:bg-shell-border-subtle/30"
+        style={{ cursor: "col-resize" }}
+      />
+
+      {/* Tab bar */}
+      <div
+        role="tablist"
+        aria-label="Pinned agents"
+        className="flex items-center gap-1 px-3 pt-2 pb-1 border-b border-shell-border-subtle overflow-x-auto flex-shrink-0"
+      >
+        {pinnedAgentIds.map((agentId) => {
+          const isActive = agentId === activeAgentId;
+          const name = getAgentName(agentId);
+          const tabId_ = `agent-tab-${windowId}-${tabId}-${agentId}`;
+          return (
+            <button
+              key={agentId}
+              id={tabId_}
+              role="tab"
+              aria-selected={isActive}
+              onClick={() => handleTabClick(agentId)}
+              title={name}
+              className={[
+                "flex items-center gap-1 px-2 py-1 rounded text-xs whitespace-nowrap transition-colors",
+                isActive
+                  ? "bg-shell-hover text-shell-text font-medium"
+                  : "text-shell-text-secondary hover:bg-shell-hover hover:text-shell-text",
+              ].join(" ")}
+            >
+              <span
+                aria-hidden="true"
+                className="w-2 h-2 rounded-full flex-shrink-0"
+                style={{ backgroundColor: agentColor(agentId) }}
+              />
+              <span className="max-w-[80px] truncate">{name}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Header */}
+      <div className="flex items-center justify-between px-3 py-2 border-b border-shell-border-subtle flex-shrink-0">
+        <span className="text-xs font-medium text-shell-text truncate">{activeAgentName}</span>
+        <button
+          type="button"
+          aria-label="Close agent panel"
+          onClick={handleClose}
+          className="text-shell-text-secondary hover:text-shell-text hover:bg-shell-hover rounded p-0.5 text-xs leading-none flex-shrink-0"
+        >
+          ✕
+        </button>
+      </div>
+
+      {/* Tab panel body */}
+      <div
+        role="tabpanel"
+        aria-labelledby={
+          activeAgentId
+            ? `agent-tab-${windowId}-${tabId}-${activeAgentId}`
+            : undefined
+        }
+        className="flex flex-col flex-1 overflow-hidden"
+      >
+        {/* Recent events rail */}
+        {recentEvents.length > 0 && (
+          <div
+            aria-label="Recent page events"
+            className="flex gap-2 px-3 py-2 overflow-x-auto border-b border-shell-border-subtle flex-shrink-0"
+          >
+            {recentEvents.map((ev, i) => (
+              <div
+                key={i}
+                title={ev.title ?? ev.url ?? ev.kind}
+                className="flex items-center gap-1 bg-shell-bg-deep border border-shell-border-subtle rounded-full px-2 py-0.5 text-[10px] text-shell-text-secondary whitespace-nowrap flex-shrink-0"
+              >
+                <span aria-hidden="true">{eventIcon(ev.kind)}</span>
+                <span className="max-w-[100px] truncate">
+                  {ev.title ?? ev.url ?? ev.kind}
+                </span>
+                <span className="opacity-60 text-[9px]">{formatTime(ev.timestamp)}</span>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Suggested actions */}
+        <div className="flex flex-col gap-1 px-3 py-2 border-b border-shell-border-subtle flex-shrink-0">
+          <span className="text-[10px] uppercase tracking-wide text-shell-text-secondary mb-1">
+            Suggested
+          </span>
+          <button
+            type="button"
+            onClick={handleSummarisePage}
+            className="text-left text-xs px-2 py-1 rounded hover:bg-shell-hover text-shell-text-secondary hover:text-shell-text transition-colors"
+          >
+            Summarise this page
+          </button>
+          <button
+            type="button"
+            title="Coming in PR 7"
+            disabled
+            className="text-left text-xs px-2 py-1 rounded text-shell-text-secondary opacity-50 cursor-not-allowed"
+          >
+            Send to {activeAgentName}
+          </button>
+          <button
+            type="button"
+            title="Coming in PR 7"
+            disabled
+            className="text-left text-xs px-2 py-1 rounded text-shell-text-secondary opacity-50 cursor-not-allowed"
+          >
+            Pin to Memory
+          </button>
+        </div>
+
+        {/* Chat thread */}
+        <div
+          aria-label="Chat thread"
+          className="flex-1 overflow-y-auto px-3 py-2 flex flex-col gap-2"
+        >
+          {messages.length === 0 && (
+            <p className="text-[11px] text-shell-text-secondary italic text-center mt-4">
+              No messages yet. Start a conversation below.
+            </p>
+          )}
+          {messages.map((msg) => (
+            <div
+              key={msg.id}
+              className={[
+                "flex flex-col max-w-[85%] gap-0.5",
+                msg.author === "user" ? "self-end items-end" : "self-start items-start",
+              ].join(" ")}
+            >
+              <div
+                className={[
+                  "rounded-lg px-2.5 py-1.5 text-xs break-words",
+                  msg.author === "user"
+                    ? "bg-shell-hover text-shell-text"
+                    : "bg-shell-bg-deep text-shell-text border border-shell-border-subtle",
+                ].join(" ")}
+              >
+                {msg.content}
+              </div>
+              <span className="text-[9px] text-shell-text-secondary opacity-70">
+                {formatTime(msg.timestamp)}
+              </span>
+            </div>
+          ))}
+          <div ref={chatEndRef} />
+        </div>
+
+        {/* Chat input */}
+        <div className="flex-shrink-0 border-t border-shell-border-subtle px-3 py-2">
+          <label htmlFor={`agent-panel-input-${windowId}-${tabId}`} className="sr-only">
+            Message {activeAgentName}
+          </label>
+          <textarea
+            id={`agent-panel-input-${windowId}-${tabId}`}
+            ref={textareaRef}
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder={`Message ${activeAgentName}…`}
+            rows={2}
+            className="w-full bg-shell-bg-deep border border-shell-border-subtle rounded px-2 py-1.5 text-xs text-shell-text resize-none outline-none focus:border-accent placeholder:text-shell-text-secondary"
+          />
+          <div className="text-[9px] text-shell-text-secondary mt-0.5 opacity-60">
+            Enter to send · Shift+Enter for newline
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/apps/BrowserApp/AgentPickerPopover.test.tsx
+++ b/desktop/src/apps/BrowserApp/AgentPickerPopover.test.tsx
@@ -1,0 +1,257 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { AgentPickerPopover } from "./AgentPickerPopover";
+import { useBrowserStore } from "@/stores/browser-store";
+import { useBrowserAgentStore } from "@/stores/browser-agent-store";
+import * as browserAgentApi from "@/lib/browser-agent-api";
+
+const WINDOW_ID = "win-1";
+const TAB_ID = "tab-1";
+const PROFILE_ID = "personal";
+
+const AGENTS = [
+  { id: "agent-1", name: "Alpha", emoji: "🤖", framework: "openclaw" },
+  { id: "agent-2", name: "Beta", emoji: "🧪", framework: "smolagents" },
+  { id: "agent-3", name: "Gamma", emoji: "🔗", framework: "pocketflow" },
+  { id: "agent-4", name: "Delta", emoji: "🌳", framework: "langroid" },
+  { id: "agent-5", name: "Epsilon", emoji: "💬", framework: "openai-agents-sdk" },
+];
+
+function defaultProps(overrides?: Partial<Parameters<typeof AgentPickerPopover>[0]>) {
+  return {
+    windowId: WINDOW_ID,
+    tabId: TAB_ID,
+    profileId: PROFILE_ID,
+    pinnedAgentIds: [],
+    onClose: vi.fn(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  useBrowserStore.setState({ windows: {} });
+  useBrowserStore.getState().createWindow(WINDOW_ID, PROFILE_ID);
+  useBrowserAgentStore.setState({ panels: {}, lastEventAt: {} });
+
+  vi.spyOn(browserAgentApi, "listAgents").mockResolvedValue(AGENTS);
+  vi.spyOn(browserAgentApi, "pinAgent").mockResolvedValue({ pinned: true });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("AgentPickerPopover", () => {
+  it("renders the agent list from listAgents", async () => {
+    render(<AgentPickerPopover {...defaultProps()} />);
+    await waitFor(() => {
+      expect(screen.getByText("Alpha")).toBeTruthy();
+      expect(screen.getByText("Beta")).toBeTruthy();
+    });
+  });
+
+  it("shows X / 4 pinned count", async () => {
+    render(<AgentPickerPopover {...defaultProps({ pinnedAgentIds: ["agent-1"] })} />);
+    await waitFor(() => {
+      expect(screen.getByText(/1 \/ 4 pinned/i)).toBeTruthy();
+    });
+  });
+
+  it("disables already-pinned agents with aria-disabled and tooltip", async () => {
+    render(
+      <AgentPickerPopover
+        {...defaultProps({ pinnedAgentIds: ["agent-1"] })}
+      />,
+    );
+    await waitFor(() => {
+      const options = screen.getAllByRole("option");
+      const alphaRow = options.find((el) => el.textContent?.includes("Alpha"));
+      expect(alphaRow).toBeTruthy();
+      expect(alphaRow?.getAttribute("aria-disabled")).toBe("true");
+      expect(alphaRow?.getAttribute("title")).toBe("Already pinned");
+    });
+  });
+
+  it("filters as user types in the search box", async () => {
+    render(<AgentPickerPopover {...defaultProps()} />);
+    await waitFor(() => {
+      expect(screen.getByText("Alpha")).toBeTruthy();
+    });
+    const search = screen.getByRole("textbox");
+    fireEvent.change(search, { target: { value: "bet" } });
+    await waitFor(() => {
+      expect(screen.queryByText("Alpha")).toBeNull();
+      expect(screen.getByText("Beta")).toBeTruthy();
+    });
+  });
+
+  it("clicking an enabled row pins via pinAgent and closes on success", async () => {
+    const onClose = vi.fn();
+    render(<AgentPickerPopover {...defaultProps({ onClose })} />);
+    await waitFor(() => {
+      expect(screen.getByText("Beta")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByText("Beta"));
+    await waitFor(() => {
+      expect(browserAgentApi.pinAgent).toHaveBeenCalledWith(PROFILE_ID, TAB_ID, "agent-2");
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  it("on { pinned: true }, addPinnedAgent is called with the agent id", async () => {
+    vi.spyOn(browserAgentApi, "pinAgent").mockResolvedValue({ pinned: true });
+    const addSpy = vi.spyOn(useBrowserStore.getState(), "addPinnedAgent");
+    render(<AgentPickerPopover {...defaultProps()} />);
+    await waitFor(() => {
+      expect(screen.getByText("Alpha")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByText("Alpha"));
+    await waitFor(() => {
+      expect(addSpy).toHaveBeenCalledWith(WINDOW_ID, TAB_ID, "agent-1");
+    });
+  });
+
+  it("on { pinned: true }, openPanel is called with the agent id", async () => {
+    vi.spyOn(browserAgentApi, "pinAgent").mockResolvedValue({ pinned: true });
+    const openPanelSpy = vi.spyOn(useBrowserAgentStore.getState(), "openPanel");
+    render(<AgentPickerPopover {...defaultProps()} />);
+    await waitFor(() => {
+      expect(screen.getByText("Alpha")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByText("Alpha"));
+    await waitFor(() => {
+      expect(openPanelSpy).toHaveBeenCalledWith(WINDOW_ID, TAB_ID, "agent-1");
+    });
+  });
+
+  it("on { error }, error banner is shown and popover stays open", async () => {
+    vi.spyOn(browserAgentApi, "pinAgent").mockResolvedValue({ error: "agent not found" });
+    const onClose = vi.fn();
+    render(<AgentPickerPopover {...defaultProps({ onClose })} />);
+    await waitFor(() => {
+      expect(screen.getByText("Alpha")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByText("Alpha"));
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeTruthy();
+      expect(screen.getByText("agent not found")).toBeTruthy();
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  it("on null (network error), error banner is shown", async () => {
+    vi.spyOn(browserAgentApi, "pinAgent").mockResolvedValue(null);
+    const onClose = vi.fn();
+    render(<AgentPickerPopover {...defaultProps({ onClose })} />);
+    await waitFor(() => {
+      expect(screen.getByText("Alpha")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByText("Alpha"));
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeTruthy();
+      expect(screen.getByText(/network error/i)).toBeTruthy();
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  it("on { pinned: false } (idempotent race), addPinnedAgent still called and popover closes", async () => {
+    vi.spyOn(browserAgentApi, "pinAgent").mockResolvedValue({ pinned: false });
+    const addSpy = vi.spyOn(useBrowserStore.getState(), "addPinnedAgent");
+    const onClose = vi.fn();
+    render(<AgentPickerPopover {...defaultProps({ onClose })} />);
+    await waitFor(() => {
+      expect(screen.getByText("Alpha")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByText("Alpha"));
+    await waitFor(() => {
+      expect(addSpy).toHaveBeenCalledWith(WINDOW_ID, TAB_ID, "agent-1");
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  it("4 already-pinned agents shows 'Maximum agents reached' message + all rows disabled", async () => {
+    render(
+      <AgentPickerPopover
+        {...defaultProps({
+          pinnedAgentIds: ["agent-1", "agent-2", "agent-3", "agent-4"],
+        })}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText(/maximum agents reached/i)).toBeTruthy();
+      const options = screen.getAllByRole("option");
+      for (const opt of options) {
+        expect(opt.getAttribute("aria-disabled")).toBe("true");
+      }
+    });
+  });
+
+  it("Esc closes via onClose", async () => {
+    const onClose = vi.fn();
+    const { container } = render(<AgentPickerPopover {...defaultProps({ onClose })} />);
+    await waitFor(() => {
+      expect(screen.getByText("Alpha")).toBeTruthy();
+    });
+    fireEvent.keyDown(container.firstChild as HTMLElement, { key: "Escape" });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("click outside closes via onClose", async () => {
+    const onClose = vi.fn();
+    render(<AgentPickerPopover {...defaultProps({ onClose })} />);
+    await waitFor(() => {
+      expect(screen.getByText("Alpha")).toBeTruthy();
+    });
+    // The deferred handler is set via setTimeout(0), so we need to advance timers
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+    fireEvent.mouseDown(document.body);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("ArrowDown/Up navigate enabled rows only (skipping disabled)", async () => {
+    // Pin agent-1 so it's disabled; ArrowDown should advance from Beta (first enabled) to Gamma
+    const { container } = render(
+      <AgentPickerPopover
+        {...defaultProps({ pinnedAgentIds: ["agent-1"] })}
+      />,
+    );
+    // Wait for agents to load AND for the initial focus to settle on Beta
+    await waitFor(() => {
+      const options = screen.getAllByRole("option");
+      const focused = options.find((el) => el.getAttribute("aria-selected") === "true");
+      expect(focused?.textContent).toContain("Beta");
+    });
+    // fire keyDown on the popover root div (that's where onKeyDown lives)
+    const popover = container.firstChild as HTMLElement;
+    // ArrowDown from Beta (first enabled, index 1) → Gamma (index 2)
+    fireEvent.keyDown(popover, { key: "ArrowDown" });
+    await waitFor(() => {
+      const options = screen.getAllByRole("option");
+      const focused = options.find((el) => el.getAttribute("aria-selected") === "true");
+      expect(focused?.textContent).toContain("Gamma");
+    });
+  });
+
+  it("Enter pins the currently-focused row", async () => {
+    const onClose = vi.fn();
+    const { container } = render(<AgentPickerPopover {...defaultProps({ onClose })} />);
+    await waitFor(() => {
+      expect(screen.getByText("Alpha")).toBeTruthy();
+    });
+    fireEvent.keyDown(container.firstChild as HTMLElement, { key: "Enter" });
+    await waitFor(() => {
+      expect(browserAgentApi.pinAgent).toHaveBeenCalled();
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  it("listbox role + aria-label present", async () => {
+    render(<AgentPickerPopover {...defaultProps()} />);
+    await waitFor(() => {
+      const listbox = screen.getByRole("listbox", { name: /pick an agent/i });
+      expect(listbox).toBeTruthy();
+    });
+  });
+});

--- a/desktop/src/apps/BrowserApp/AgentPickerPopover.test.tsx
+++ b/desktop/src/apps/BrowserApp/AgentPickerPopover.test.tsx
@@ -247,6 +247,31 @@ describe("AgentPickerPopover", () => {
     });
   });
 
+  it("ignores a second pin click while the first is in flight", async () => {
+    let resolve!: (v: { pinned: boolean }) => void;
+    const deferred = new Promise<{ pinned: boolean }>((r) => { resolve = r; });
+    vi.spyOn(browserAgentApi, "pinAgent").mockReturnValueOnce(deferred);
+
+    const onClose = vi.fn();
+    render(<AgentPickerPopover {...defaultProps({ onClose })} />);
+    await waitFor(() => {
+      expect(screen.getByText("Alpha")).toBeTruthy();
+    });
+
+    // First click — starts in-flight pin
+    fireEvent.click(screen.getByText("Alpha"));
+    // Second click — should be ignored because pinningRef.current is true
+    fireEvent.click(screen.getByText("Alpha"));
+
+    // Resolve the deferred promise
+    await act(async () => { resolve({ pinned: true }); });
+
+    await waitFor(() => {
+      expect(browserAgentApi.pinAgent).toHaveBeenCalledTimes(1);
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it("listbox role + aria-label present", async () => {
     render(<AgentPickerPopover {...defaultProps()} />);
     await waitFor(() => {

--- a/desktop/src/apps/BrowserApp/AgentPickerPopover.tsx
+++ b/desktop/src/apps/BrowserApp/AgentPickerPopover.tsx
@@ -1,0 +1,236 @@
+/**
+ * AgentPickerPopover — lets the user search for and pin an agent to the active tab.
+ * Opened by clicking "+ agent" chip in Chrome or via Cmd+Shift+A.
+ */
+import { useEffect, useRef, useState } from "react";
+import { listAgents, pinAgent, type AgentDto } from "@/lib/browser-agent-api";
+import { resolveAgentEmoji } from "@/lib/agent-emoji";
+import { useBrowserStore } from "@/stores/browser-store";
+import { useBrowserAgentStore } from "@/stores/browser-agent-store";
+
+const MAX_PINS = 4;
+
+export interface AgentPickerPopoverProps {
+  windowId: string;
+  tabId: string;
+  profileId: string;
+  pinnedAgentIds: string[];
+  onClose: () => void;
+}
+
+export function AgentPickerPopover({
+  windowId,
+  tabId,
+  profileId,
+  pinnedAgentIds,
+  onClose,
+}: AgentPickerPopoverProps) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const searchRef = useRef<HTMLInputElement | null>(null);
+  const [agents, setAgents] = useState<AgentDto[] | null>(null);
+  const [query, setQuery] = useState("");
+  const [focusedIndex, setFocusedIndex] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+
+  // Load agents on mount
+  useEffect(() => {
+    let cancelled = false;
+    listAgents().then((list) => {
+      if (!cancelled) {
+        setAgents(list);
+      }
+    });
+    return () => { cancelled = true; };
+  }, []);
+
+  // Auto-focus search on mount
+  useEffect(() => {
+    searchRef.current?.focus();
+  }, []);
+
+  // Click-outside dismiss (deferred like ProfileSwitcher)
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (!ref.current?.contains(e.target as Node)) onClose();
+    };
+    const id = setTimeout(() => window.addEventListener("mousedown", handler), 0);
+    return () => {
+      clearTimeout(id);
+      window.removeEventListener("mousedown", handler);
+    };
+  }, [onClose]);
+
+  const pinnedCount = pinnedAgentIds.length;
+  const atMax = pinnedCount >= MAX_PINS;
+
+  const filtered = (agents ?? []).filter((a) =>
+    a.name.toLowerCase().includes(query.toLowerCase()),
+  );
+
+  // Build enabled/disabled list for keyboard navigation
+  const isDisabled = (a: AgentDto) => atMax || pinnedAgentIds.includes(a.id);
+  const enabledIndices = filtered.reduce<number[]>((acc, a, i) => {
+    if (!isDisabled(a)) acc.push(i);
+    return acc;
+  }, []);
+
+  async function handlePin(agent: AgentDto) {
+    if (isDisabled(agent)) return;
+    setError(null);
+    const result = await pinAgent(profileId, tabId, agent.id);
+    if (result === null) {
+      setError("Network error — please try again");
+      return;
+    }
+    if ("error" in result) {
+      setError(result.error);
+      return;
+    }
+    // { pinned: true } or { pinned: false } (race / already pinned) — both call addPinnedAgent
+    useBrowserStore.getState().addPinnedAgent(windowId, tabId, agent.id);
+    useBrowserAgentStore.getState().openPanel(windowId, tabId, agent.id);
+    onClose();
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Escape") {
+      onClose();
+      return;
+    }
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      if (enabledIndices.length === 0) return;
+      const currentPos = enabledIndices.indexOf(focusedIndex);
+      const next = enabledIndices[(currentPos + 1) % enabledIndices.length] ?? enabledIndices[0] ?? 0;
+      setFocusedIndex(next);
+      return;
+    }
+    if (e.key === "ArrowUp") {
+      e.preventDefault();
+      if (enabledIndices.length === 0) return;
+      const currentPos = enabledIndices.indexOf(focusedIndex);
+      const prev =
+        currentPos <= 0
+          ? (enabledIndices[enabledIndices.length - 1] ?? 0)
+          : (enabledIndices[currentPos - 1] ?? 0);
+      setFocusedIndex(prev);
+      return;
+    }
+    if (e.key === "Enter") {
+      const agent = filtered[focusedIndex];
+      if (agent && !isDisabled(agent)) {
+        handlePin(agent);
+      }
+    }
+  }
+
+  // Reset focus index when filtered list changes
+  useEffect(() => {
+    setFocusedIndex(enabledIndices[0] ?? 0);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query, agents?.length]);
+
+  return (
+    <div
+      ref={ref}
+      className="absolute z-[70] right-0 top-full mt-1 w-80 rounded-md bg-shell-surface border border-shell-border-subtle shadow-lg text-xs text-shell-text"
+      onKeyDown={handleKeyDown}
+    >
+      {/* Error banner */}
+      {error && (
+        <div
+          role="alert"
+          className="px-3 py-2 bg-red-500/10 text-red-400 border-b border-shell-border-subtle"
+        >
+          {error}
+        </div>
+      )}
+
+      {/* Header + count */}
+      <div className="flex items-center justify-between px-3 py-2 border-b border-shell-border-subtle">
+        <span className="text-shell-text-tertiary uppercase tracking-wide text-[10px]">
+          Pin an agent
+        </span>
+        <span className="text-shell-text-tertiary text-[10px]">
+          {pinnedCount} / {MAX_PINS} pinned
+        </span>
+      </div>
+
+      {/* Search */}
+      <div className="px-3 py-2 border-b border-shell-border-subtle">
+        <label htmlFor="agent-picker-search" className="sr-only">
+          Search agents
+        </label>
+        <input
+          id="agent-picker-search"
+          ref={searchRef}
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search…"
+          className="w-full bg-shell-bg-deep border border-shell-border-subtle rounded px-2 py-1 text-xs outline-none focus:border-accent"
+        />
+      </div>
+
+      {/* Agent list */}
+      <div
+        role="listbox"
+        aria-label="Pick an agent to pin"
+        className="max-h-64 overflow-y-auto"
+      >
+        {agents === null ? (
+          <div className="px-3 py-3 opacity-60 italic">Loading…</div>
+        ) : filtered.length === 0 ? (
+          <div className="px-3 py-3 opacity-60 italic">No agents found</div>
+        ) : (
+          filtered.map((agent, i) => {
+            const disabled = isDisabled(agent);
+            const alreadyPinned = pinnedAgentIds.includes(agent.id);
+            const focused = i === focusedIndex && !disabled;
+            const emoji = resolveAgentEmoji(
+              agent.emoji as string | undefined,
+              agent.framework as string | undefined,
+            );
+            return (
+              <div
+                key={agent.id}
+                role="option"
+                aria-selected={focused}
+                aria-disabled={disabled ? "true" : undefined}
+                title={alreadyPinned ? "Already pinned" : undefined}
+                onClick={() => !disabled && handlePin(agent)}
+                onMouseEnter={() => !disabled && setFocusedIndex(i)}
+                className={[
+                  "flex items-center gap-2 px-3 py-2 cursor-pointer select-none",
+                  disabled
+                    ? "opacity-50 cursor-not-allowed"
+                    : focused
+                    ? "bg-shell-hover"
+                    : "hover:bg-shell-hover",
+                ].join(" ")}
+              >
+                <span
+                  className="flex-shrink-0 w-6 h-6 rounded-full flex items-center justify-center text-sm bg-shell-bg-deep"
+                  aria-hidden="true"
+                >
+                  {emoji}
+                </span>
+                <span className="flex-1 truncate">{agent.name}</span>
+                {alreadyPinned && (
+                  <span className="text-shell-text-tertiary text-[10px]">pinned</span>
+                )}
+              </div>
+            );
+          })
+        )}
+      </div>
+
+      {/* Footer when at max */}
+      {atMax && (
+        <div className="px-3 py-2 text-center text-shell-text-tertiary border-t border-shell-border-subtle">
+          Maximum agents reached for this tab
+        </div>
+      )}
+    </div>
+  );
+}

--- a/desktop/src/apps/BrowserApp/AgentPickerPopover.tsx
+++ b/desktop/src/apps/BrowserApp/AgentPickerPopover.tsx
@@ -2,7 +2,7 @@
  * AgentPickerPopover — lets the user search for and pin an agent to the active tab.
  * Opened by clicking "+ agent" chip in Chrome or via Cmd+Shift+A.
  */
-import { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { listAgents, pinAgent, type AgentDto } from "@/lib/browser-agent-api";
 import { resolveAgentEmoji } from "@/lib/agent-emoji";
 import { useBrowserStore } from "@/stores/browser-store";
@@ -16,6 +16,7 @@ export interface AgentPickerPopoverProps {
   profileId: string;
   pinnedAgentIds: string[];
   onClose: () => void;
+  triggerRef?: React.RefObject<HTMLButtonElement | null>;
 }
 
 export function AgentPickerPopover({
@@ -24,9 +25,11 @@ export function AgentPickerPopover({
   profileId,
   pinnedAgentIds,
   onClose,
+  triggerRef,
 }: AgentPickerPopoverProps) {
   const ref = useRef<HTMLDivElement | null>(null);
   const searchRef = useRef<HTMLInputElement | null>(null);
+  const pinningRef = useRef(false);
   const [agents, setAgents] = useState<AgentDto[] | null>(null);
   const [query, setQuery] = useState("");
   const [focusedIndex, setFocusedIndex] = useState(0);
@@ -75,25 +78,31 @@ export function AgentPickerPopover({
   }, []);
 
   async function handlePin(agent: AgentDto) {
-    if (isDisabled(agent)) return;
+    if (isDisabled(agent) || pinningRef.current) return;
+    pinningRef.current = true;
     setError(null);
-    const result = await pinAgent(profileId, tabId, agent.id);
-    if (result === null) {
-      setError("Network error — please try again");
-      return;
+    try {
+      const result = await pinAgent(profileId, tabId, agent.id);
+      if (result === null) {
+        setError("Network error — please try again");
+        return;
+      }
+      if ("error" in result) {
+        setError(result.error);
+        return;
+      }
+      // { pinned: true } or { pinned: false } (race / already pinned) — both call addPinnedAgent
+      useBrowserStore.getState().addPinnedAgent(windowId, tabId, agent.id);
+      useBrowserAgentStore.getState().openPanel(windowId, tabId, agent.id);
+      onClose();
+    } finally {
+      pinningRef.current = false;
     }
-    if ("error" in result) {
-      setError(result.error);
-      return;
-    }
-    // { pinned: true } or { pinned: false } (race / already pinned) — both call addPinnedAgent
-    useBrowserStore.getState().addPinnedAgent(windowId, tabId, agent.id);
-    useBrowserAgentStore.getState().openPanel(windowId, tabId, agent.id);
-    onClose();
   }
 
   function handleKeyDown(e: React.KeyboardEvent) {
     if (e.key === "Escape") {
+      triggerRef?.current?.focus();
       onClose();
       return;
     }

--- a/desktop/src/apps/BrowserApp/AgentPresencePill.test.tsx
+++ b/desktop/src/apps/BrowserApp/AgentPresencePill.test.tsx
@@ -1,0 +1,250 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { AgentPresencePill } from "./AgentPresencePill";
+import { useBrowserAgentStore, WATCHING_DECAY_MS } from "@/stores/browser-agent-store";
+import * as browserAgentApi from "@/lib/browser-agent-api";
+
+const WINDOW_ID = "win-1";
+const TAB_ID = "tab-1";
+
+const AGENTS = [
+  { id: "agent-1", name: "Alice", emoji: "🤖", framework: "openclaw" },
+  { id: "agent-2", name: "Bob", emoji: "🧪", framework: "smolagents" },
+  { id: "agent-3", name: "Carol", emoji: "🔗", framework: "pocketflow" },
+  { id: "agent-4", name: "Dave", emoji: "🌳", framework: "langroid" },
+  { id: "agent-5", name: "Eve", emoji: "💬", framework: "openai-agents-sdk" },
+];
+
+beforeEach(() => {
+  useBrowserAgentStore.setState({ panels: {}, lastEventAt: {} });
+  vi.spyOn(browserAgentApi, "listAgents").mockResolvedValue(AGENTS);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe("AgentPresencePill", () => {
+  it("renders nothing when pinnedAgentIds is empty", () => {
+    render(
+      <AgentPresencePill
+        windowId={WINDOW_ID}
+        tabId={TAB_ID}
+        pinnedAgentIds={[]}
+      />,
+    );
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("renders one avatar when one agent pinned", async () => {
+    render(
+      <AgentPresencePill
+        windowId={WINDOW_ID}
+        tabId={TAB_ID}
+        pinnedAgentIds={["agent-1"]}
+      />,
+    );
+    await waitFor(() => {
+      const btn = screen.getByRole("button");
+      expect(btn).toBeTruthy();
+      // Should have exactly 1 avatar
+      const avatars = btn.querySelectorAll("[data-testid='agent-avatar']");
+      expect(avatars).toHaveLength(1);
+    });
+  });
+
+  it("renders four stacked avatars when four agents pinned", async () => {
+    render(
+      <AgentPresencePill
+        windowId={WINDOW_ID}
+        tabId={TAB_ID}
+        pinnedAgentIds={["agent-1", "agent-2", "agent-3", "agent-4"]}
+      />,
+    );
+    await waitFor(() => {
+      const btn = screen.getByRole("button");
+      const avatars = btn.querySelectorAll("[data-testid='agent-avatar']");
+      expect(avatars).toHaveLength(4);
+    });
+  });
+
+  it("displays at most 4 avatars even if more passed", async () => {
+    render(
+      <AgentPresencePill
+        windowId={WINDOW_ID}
+        tabId={TAB_ID}
+        pinnedAgentIds={["agent-1", "agent-2", "agent-3", "agent-4", "agent-5"]}
+      />,
+    );
+    await waitFor(() => {
+      const btn = screen.getByRole("button");
+      const avatars = btn.querySelectorAll("[data-testid='agent-avatar']");
+      expect(avatars).toHaveLength(4);
+    });
+  });
+
+  it("aria-label lists pinned agent names", async () => {
+    render(
+      <AgentPresencePill
+        windowId={WINDOW_ID}
+        tabId={TAB_ID}
+        pinnedAgentIds={["agent-1", "agent-2", "agent-3"]}
+      />,
+    );
+    await waitFor(() => {
+      const btn = screen.getByRole("button");
+      const label = btn.getAttribute("aria-label");
+      expect(label).toContain("3 agents pinned");
+      expect(label).toContain("Alice");
+      expect(label).toContain("Bob");
+      expect(label).toContain("Carol");
+    });
+  });
+
+  it("click toggles the panel via togglePanel store action", async () => {
+    const toggleSpy = vi.spyOn(useBrowserAgentStore.getState(), "togglePanel");
+    render(
+      <AgentPresencePill
+        windowId={WINDOW_ID}
+        tabId={TAB_ID}
+        pinnedAgentIds={["agent-1", "agent-2"]}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByRole("button")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByRole("button"));
+    expect(toggleSpy).toHaveBeenCalledWith(WINDOW_ID, TAB_ID, "agent-1");
+  });
+
+  it("shows the active background tint when panel is open", async () => {
+    useBrowserAgentStore.setState({
+      panels: {
+        [`${WINDOW_ID}:${TAB_ID}`]: { isOpen: true, activeAgentId: "agent-1", width: 280 },
+      },
+      lastEventAt: {},
+    });
+    render(
+      <AgentPresencePill
+        windowId={WINDOW_ID}
+        tabId={TAB_ID}
+        pinnedAgentIds={["agent-1"]}
+      />,
+    );
+    await waitFor(() => {
+      const btn = screen.getByRole("button");
+      expect(btn.className).toContain("bg-shell-hover");
+    });
+  });
+
+  it("shows the watching pulse when any pinned agent is in watching state", async () => {
+    // Bump an event for agent-2 so it's "watching"
+    useBrowserAgentStore.getState().bumpEventAt(WINDOW_ID, TAB_ID, "agent-2");
+    render(
+      <AgentPresencePill
+        windowId={WINDOW_ID}
+        tabId={TAB_ID}
+        pinnedAgentIds={["agent-1", "agent-2"]}
+      />,
+    );
+    await waitFor(() => {
+      const dot = screen.getByTestId("presence-dot");
+      expect(dot.className).toContain("animate-pulse");
+    });
+  });
+
+  it("does NOT show the pulse when no agent is watching", async () => {
+    render(
+      <AgentPresencePill
+        windowId={WINDOW_ID}
+        tabId={TAB_ID}
+        pinnedAgentIds={["agent-1"]}
+      />,
+    );
+    await waitFor(() => {
+      const dot = screen.getByTestId("presence-dot");
+      expect(dot.className).not.toContain("animate-pulse");
+    });
+  });
+
+  it("watching pulse decays after WATCHING_DECAY_MS", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: false });
+    const now = 1_000_000;
+    vi.setSystemTime(now);
+
+    useBrowserAgentStore.getState().bumpEventAt(WINDOW_ID, TAB_ID, "agent-1", now);
+
+    render(
+      <AgentPresencePill
+        windowId={WINDOW_ID}
+        tabId={TAB_ID}
+        pinnedAgentIds={["agent-1"]}
+      />,
+    );
+
+    // Let the async listAgents mock resolve and initial effects run
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const dot = screen.getByTestId("presence-dot");
+    expect(dot.className).toContain("animate-pulse");
+
+    // Advance system time past decay window and fire the decay timer
+    vi.setSystemTime(now + WATCHING_DECAY_MS + 100);
+    await act(async () => {
+      vi.runAllTimers();
+    });
+
+    const dotAfter = screen.getByTestId("presence-dot");
+    expect(dotAfter.className).not.toContain("animate-pulse");
+  });
+
+  it("aria-haspopup=dialog and aria-expanded reflects panel state", async () => {
+    render(
+      <AgentPresencePill
+        windowId={WINDOW_ID}
+        tabId={TAB_ID}
+        pinnedAgentIds={["agent-1"]}
+      />,
+    );
+    await waitFor(() => {
+      const btn = screen.getByRole("button");
+      expect(btn.getAttribute("aria-haspopup")).toBe("dialog");
+      expect(btn.getAttribute("aria-expanded")).toBe("false");
+    });
+
+    // Open the panel
+    act(() => {
+      useBrowserAgentStore.setState({
+        panels: {
+          [`${WINDOW_ID}:${TAB_ID}`]: { isOpen: true, activeAgentId: "agent-1", width: 280 },
+        },
+        lastEventAt: {},
+      });
+    });
+
+    await waitFor(() => {
+      const btn = screen.getByRole("button");
+      expect(btn.getAttribute("aria-expanded")).toBe("true");
+    });
+  });
+
+  it("falls back to placeholder rendering if listAgents returns []", async () => {
+    vi.spyOn(browserAgentApi, "listAgents").mockResolvedValue([]);
+    render(
+      <AgentPresencePill
+        windowId={WINDOW_ID}
+        tabId={TAB_ID}
+        pinnedAgentIds={["agent-1", "agent-2"]}
+      />,
+    );
+    await waitFor(() => {
+      const btn = screen.getByRole("button");
+      // Fallback: should still render 2 avatars (one per pinned id)
+      const avatars = btn.querySelectorAll("[data-testid='agent-avatar']");
+      expect(avatars).toHaveLength(2);
+    });
+  });
+});

--- a/desktop/src/apps/BrowserApp/AgentPresencePill.tsx
+++ b/desktop/src/apps/BrowserApp/AgentPresencePill.tsx
@@ -1,0 +1,161 @@
+/**
+ * AgentPresencePill — stacked agent avatars + idle/watching state indicator.
+ * Renders when at least one agent is pinned to the tab. Clicking it toggles
+ * the agent panel (Task 9 implements the panel itself).
+ */
+import React, { useEffect, useRef, useState } from "react";
+import { listAgents, type AgentDto } from "@/lib/browser-agent-api";
+import { useBrowserAgentStore, WATCHING_DECAY_MS } from "@/stores/browser-agent-store";
+
+const MAX_AVATARS = 4;
+
+/** Deterministic hue from an agent id string. */
+function agentColor(id: string): string {
+  let hash = 0;
+  for (let i = 0; i < id.length; i++) {
+    hash = (hash * 31 + id.charCodeAt(i)) >>> 0;
+  }
+  const hue = hash % 360;
+  return `hsl(${hue}, 55%, 45%)`;
+}
+
+export interface AgentPresencePillProps {
+  windowId: string;
+  tabId: string;
+  pinnedAgentIds: string[];
+  /** Optional ref so click-outside / focus restore upstream can target it */
+  triggerRef?: React.RefObject<HTMLButtonElement | null>;
+}
+
+export function AgentPresencePill({
+  windowId,
+  tabId,
+  pinnedAgentIds,
+  triggerRef,
+}: AgentPresencePillProps) {
+  const [agents, setAgents] = useState<AgentDto[]>([]);
+
+  // Subscribe to lastEventAt + panels so Zustand re-renders on changes
+  const lastEventAt = useBrowserAgentStore((s) => s.lastEventAt);
+  const panels = useBrowserAgentStore((s) => s.panels);
+  const togglePanel = useBrowserAgentStore((s) => s.togglePanel);
+  const isWatching = useBrowserAgentStore((s) => s.isWatching);
+
+  const panelKey = `${windowId}:${tabId}`;
+  const panelIsOpen = panels[panelKey]?.isOpen ?? false;
+
+  // Load agents once on mount
+  useEffect(() => {
+    let cancelled = false;
+    listAgents().then((list) => {
+      if (!cancelled) setAgents(list);
+    });
+    return () => { cancelled = true; };
+  }, []);
+
+  // Compute watching state from the subscribed lastEventAt
+  // (lastEventAt in the selector triggers re-render on each bumpEventAt call)
+  void lastEventAt; // ensure selector is referenced so Zustand tracks it
+  const anyWatching = pinnedAgentIds.some((id) => isWatching(windowId, tabId, id));
+
+  // Decay timer: when watching, schedule a re-render after WATCHING_DECAY_MS
+  // so the pulse disappears even without a new event.
+  const decayTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    if (!anyWatching) {
+      if (decayTimerRef.current) {
+        clearTimeout(decayTimerRef.current);
+        decayTimerRef.current = null;
+      }
+      return;
+    }
+    // Find the latest event ts for pinned agents to compute remaining decay time
+    const store = useBrowserAgentStore.getState();
+    const latestTs = pinnedAgentIds.reduce<number>((max, id) => {
+      const ts = store.lastEventAt[`${windowId}:${tabId}:${id}`] ?? 0;
+      return ts > max ? ts : max;
+    }, 0);
+    const elapsed = Date.now() - latestTs;
+    const remaining = Math.max(0, WATCHING_DECAY_MS - elapsed);
+
+    decayTimerRef.current = setTimeout(() => {
+      // Force re-render by bumping a dummy state change; we re-read isWatching in render
+      setAgents((prev) => [...prev]);
+    }, remaining + 50);
+
+    return () => {
+      if (decayTimerRef.current) {
+        clearTimeout(decayTimerRef.current);
+        decayTimerRef.current = null;
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [anyWatching]);
+
+  if (pinnedAgentIds.length === 0) return null;
+
+  // Build avatar data: limit to first 4 pinned ids
+  const displayIds = pinnedAgentIds.slice(0, MAX_AVATARS);
+
+  // Map ids to agent objects; fall back to placeholder if not found in loaded list
+  const displayAgents = displayIds.map((id) => {
+    const found = agents.find((a) => a.id === id);
+    return found ?? { id, name: id };
+  });
+
+  // Build label from resolved agent names
+  const resolvedNames = displayAgents.map((a) => a.name).join(", ");
+  const count = pinnedAgentIds.length;
+  const label = `${count} agent${count !== 1 ? "s" : ""} pinned: ${resolvedNames} — click to toggle agent panel`;
+
+  const firstAgentId = pinnedAgentIds[0] ?? "";
+
+  return (
+    <button
+      ref={triggerRef as React.RefObject<HTMLButtonElement> | undefined}
+      type="button"
+      aria-label={label}
+      title={label}
+      aria-haspopup="dialog"
+      aria-expanded={panelIsOpen}
+      onClick={() => togglePanel(windowId, tabId, firstAgentId)}
+      className={[
+        "flex items-center relative p-0.5 rounded-full border border-shell-border-subtle",
+        panelIsOpen ? "bg-shell-hover" : "bg-shell-bg-deep hover:bg-shell-hover",
+      ].join(" ")}
+    >
+      {/* Stacked avatars */}
+      <div className="flex items-center">
+        {displayAgents.map((agent, i) => (
+          <span
+            key={agent.id}
+            data-testid="agent-avatar"
+            aria-hidden="true"
+            className={[
+              "inline-flex items-center justify-center",
+              "w-4 h-4 rounded-full text-[9px] font-semibold text-white",
+              "ring-1 ring-shell-surface",
+              i > 0 ? "-ml-1" : "",
+            ].join(" ")}
+            style={{ backgroundColor: agentColor(agent.id), zIndex: MAX_AVATARS - i }}
+          >
+            {agent.name.charAt(0).toUpperCase()}
+          </span>
+        ))}
+      </div>
+
+      {/* Presence dot */}
+      <span
+        data-testid="presence-dot"
+        aria-hidden="true"
+        className={[
+          "absolute -top-0.5 -right-0.5",
+          "w-2 h-2 rounded-full ring-1 ring-shell-surface",
+          anyWatching
+            ? "bg-green-400 animate-pulse"
+            : "bg-green-600",
+        ].join(" ")}
+      />
+    </button>
+  );
+}

--- a/desktop/src/apps/BrowserApp/Chrome.tsx
+++ b/desktop/src/apps/BrowserApp/Chrome.tsx
@@ -15,6 +15,7 @@ import { listProfiles, type Profile } from "@/lib/browser-profile-api";
 import { ProfileSwitcher } from "./ProfileSwitcher";
 import { ProfileManager } from "./ProfileManager";
 import { SettingsPanel } from "./SettingsPanel";
+import { AgentPickerPopover } from "./AgentPickerPopover";
 
 interface ChromeProps {
   windowId: string;
@@ -29,6 +30,7 @@ export function Chrome({ windowId }: ChromeProps) {
   const [switcherOpen, setSwitcherOpen] = useState(false);
   const [managerOpen, setManagerOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [pickerOpen, setPickerOpen] = useState(false);
   const [profiles, setProfiles] = useState<Profile[] | null>(null);
 
   const currentProfileId = win?.profileId ?? "";
@@ -40,6 +42,20 @@ export function Chrome({ windowId }: ChromeProps) {
     });
     return () => { cancelled = true; };
   }, [currentProfileId]);
+
+  // Cmd+Shift+A keyboard shortcut → open agent picker
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const ce = e as CustomEvent<{ windowId: string }>;
+      if (ce.detail?.windowId !== windowId) return;
+      setSettingsOpen(false);
+      setSwitcherOpen(false);
+      setManagerOpen(false);
+      setPickerOpen(true);
+    };
+    window.addEventListener("taos-browser:open-agent-picker", handler);
+    return () => window.removeEventListener("taos-browser:open-agent-picker", handler);
+  }, [windowId]);
 
   if (!win) return null;
 
@@ -95,6 +111,38 @@ export function Chrome({ windowId }: ChromeProps) {
 
       {/* Spacer pushes the profile chip to the right */}
       <div className="flex-1" />
+
+      {/* Agent chip / picker */}
+      <div className="relative">
+        {activeTab.pinnedAgentIds.length === 0 ? (
+          <button
+            type="button"
+            aria-label="Add agent"
+            onClick={() => {
+              setSettingsOpen(false);
+              setSwitcherOpen(false);
+              setManagerOpen(false);
+              setPickerOpen((p) => !p);
+            }}
+            className="flex items-center gap-1 px-2 py-0.5 rounded-full bg-shell-bg-deep border border-shell-border-subtle text-xs hover:bg-shell-hover"
+          >
+            + agent
+          </button>
+        ) : (
+          <div aria-label={`${activeTab.pinnedAgentIds.length} agents pinned`} className="text-xs px-2 py-0.5 rounded-full bg-shell-bg-deep border border-shell-border-subtle">
+            {activeTab.pinnedAgentIds.length} agent{activeTab.pinnedAgentIds.length !== 1 ? "s" : ""}
+          </div>
+        )}
+        {pickerOpen && (
+          <AgentPickerPopover
+            windowId={windowId}
+            tabId={activeTab.id}
+            profileId={win.profileId}
+            pinnedAgentIds={activeTab.pinnedAgentIds}
+            onClose={() => setPickerOpen(false)}
+          />
+        )}
+      </div>
 
       {/* Settings button */}
       <div className="relative">

--- a/desktop/src/apps/BrowserApp/Chrome.tsx
+++ b/desktop/src/apps/BrowserApp/Chrome.tsx
@@ -8,7 +8,7 @@
  * `desktop/src/components/Window.tsx` — every window in taOS gets them
  * automatically. This component does NOT render its own traffic lights.
  */
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { ArrowLeft, ArrowRight, RotateCw, Settings } from "lucide-react";
 import { useBrowserStore } from "@/stores/browser-store";
 import { listProfiles, type Profile } from "@/lib/browser-profile-api";
@@ -32,6 +32,7 @@ export function Chrome({ windowId }: ChromeProps) {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [profiles, setProfiles] = useState<Profile[] | null>(null);
+  const agentChipRef = useRef<HTMLButtonElement>(null);
 
   const currentProfileId = win?.profileId ?? "";
 
@@ -116,8 +117,11 @@ export function Chrome({ windowId }: ChromeProps) {
       <div className="relative">
         {activeTab.pinnedAgentIds.length === 0 ? (
           <button
+            ref={agentChipRef}
             type="button"
             aria-label="Add agent"
+            aria-haspopup="listbox"
+            aria-expanded={pickerOpen}
             onClick={() => {
               setSettingsOpen(false);
               setSwitcherOpen(false);
@@ -140,6 +144,7 @@ export function Chrome({ windowId }: ChromeProps) {
             profileId={win.profileId}
             pinnedAgentIds={activeTab.pinnedAgentIds}
             onClose={() => setPickerOpen(false)}
+            triggerRef={agentChipRef}
           />
         )}
       </div>
@@ -155,6 +160,7 @@ export function Chrome({ windowId }: ChromeProps) {
           onClick={() => {
             setSwitcherOpen(false);
             setManagerOpen(false);
+            setPickerOpen(false);
             setSettingsOpen((s) => !s);
           }}
           className="p-1 rounded hover:bg-shell-hover"
@@ -178,6 +184,7 @@ export function Chrome({ windowId }: ChromeProps) {
               onClick={() => {
                 setSettingsOpen(false);
                 setManagerOpen(false);
+                setPickerOpen(false);
                 setSwitcherOpen((s) => !s);
               }}
               className="flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-shell-bg-deep border border-shell-border-subtle text-xs hover:bg-shell-hover"

--- a/desktop/src/apps/BrowserApp/Chrome.tsx
+++ b/desktop/src/apps/BrowserApp/Chrome.tsx
@@ -115,8 +115,18 @@ export function Chrome({ windowId }: ChromeProps) {
       <div className="flex-1" />
 
       {/* Agent chip / picker */}
-      <div className="relative">
-        {activeTab.pinnedAgentIds.length === 0 ? (
+      <div className="relative flex items-center gap-1">
+        {activeTab.pinnedAgentIds.length > 0 && (
+          <AgentPresencePill
+            windowId={windowId}
+            tabId={activeTab.id}
+            pinnedAgentIds={activeTab.pinnedAgentIds}
+            triggerRef={agentChipRef}
+          />
+        )}
+        {/* "+ agent" affordance — always visible (until at cap) so users can
+             add a 2nd/3rd/4th agent without remembering Cmd+Shift+A. */}
+        {activeTab.pinnedAgentIds.length < 4 && (
           <button
             ref={agentChipRef}
             type="button"
@@ -129,17 +139,15 @@ export function Chrome({ windowId }: ChromeProps) {
               setManagerOpen(false);
               setPickerOpen((p) => !p);
             }}
-            className="flex items-center gap-1 px-2 py-0.5 rounded-full bg-shell-bg-deep border border-shell-border-subtle text-xs hover:bg-shell-hover"
+            className={
+              activeTab.pinnedAgentIds.length === 0
+                ? "flex items-center gap-1 px-2 py-0.5 rounded-full bg-shell-bg-deep border border-shell-border-subtle text-xs hover:bg-shell-hover"
+                : "flex items-center justify-center w-5 h-5 rounded-full bg-shell-bg-deep border border-shell-border-subtle text-xs hover:bg-shell-hover"
+            }
+            title={activeTab.pinnedAgentIds.length === 0 ? undefined : "Add agent"}
           >
-            + agent
+            {activeTab.pinnedAgentIds.length === 0 ? "+ agent" : "+"}
           </button>
-        ) : (
-          <AgentPresencePill
-            windowId={windowId}
-            tabId={activeTab.id}
-            pinnedAgentIds={activeTab.pinnedAgentIds}
-            triggerRef={agentChipRef}
-          />
         )}
         {pickerOpen && (
           <AgentPickerPopover

--- a/desktop/src/apps/BrowserApp/Chrome.tsx
+++ b/desktop/src/apps/BrowserApp/Chrome.tsx
@@ -16,6 +16,7 @@ import { ProfileSwitcher } from "./ProfileSwitcher";
 import { ProfileManager } from "./ProfileManager";
 import { SettingsPanel } from "./SettingsPanel";
 import { AgentPickerPopover } from "./AgentPickerPopover";
+import { AgentPresencePill } from "./AgentPresencePill";
 
 interface ChromeProps {
   windowId: string;
@@ -133,9 +134,12 @@ export function Chrome({ windowId }: ChromeProps) {
             + agent
           </button>
         ) : (
-          <div aria-label={`${activeTab.pinnedAgentIds.length} agents pinned`} className="text-xs px-2 py-0.5 rounded-full bg-shell-bg-deep border border-shell-border-subtle">
-            {activeTab.pinnedAgentIds.length} agent{activeTab.pinnedAgentIds.length !== 1 ? "s" : ""}
-          </div>
+          <AgentPresencePill
+            windowId={windowId}
+            tabId={activeTab.id}
+            pinnedAgentIds={activeTab.pinnedAgentIds}
+            triggerRef={agentChipRef}
+          />
         )}
         {pickerOpen && (
           <AgentPickerPopover

--- a/desktop/src/apps/BrowserApp/PageContextMenu.test.tsx
+++ b/desktop/src/apps/BrowserApp/PageContextMenu.test.tsx
@@ -1,0 +1,254 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { PageContextMenu } from "./PageContextMenu";
+import * as browserAgentApi from "@/lib/browser-agent-api";
+import * as browserExtractApi from "@/lib/browser-extract-api";
+
+const AGENTS = [
+  { id: "agent-1", name: "Alpha", emoji: "🤖" },
+  { id: "agent-2", name: "Beta", emoji: "🧪" },
+];
+
+function defaultProps(overrides?: Partial<Parameters<typeof PageContextMenu>[0]>) {
+  return {
+    windowId: "win-1",
+    tabId: "tab-1",
+    url: "https://example.com/article",
+    title: "Test Article",
+    selection: null,
+    x: 200,
+    y: 150,
+    onClose: vi.fn(),
+    profileId: "personal",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.spyOn(browserAgentApi, "listAgents").mockResolvedValue(AGENTS);
+  vi.spyOn(browserExtractApi, "extractReadable").mockResolvedValue({
+    title: "Test Article",
+    text: "Extracted text content",
+    html: "<p>Extracted text content</p>",
+    word_count: 3,
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("PageContextMenu", () => {
+  it("renders one Send-to entry per agent", async () => {
+    render(<PageContextMenu {...defaultProps()} />);
+    await waitFor(() => {
+      expect(screen.getByText(/send to alpha/i)).toBeTruthy();
+      expect(screen.getByText(/send to beta/i)).toBeTruthy();
+    });
+  });
+
+  it("renders Pin to Memory entry", async () => {
+    render(<PageContextMenu {...defaultProps()} />);
+    await waitFor(() => {
+      expect(screen.getByText(/pin to memory/i)).toBeTruthy();
+    });
+  });
+
+  it("clicking 'Send to <Agent>' dispatches taos:open-messages with channelId + prefillCard", async () => {
+    const dispatched: CustomEvent[] = [];
+    const listener = (e: Event) => dispatched.push(e as CustomEvent);
+    window.addEventListener("taos:open-messages", listener);
+
+    render(<PageContextMenu {...defaultProps()} />);
+    await waitFor(() => {
+      expect(screen.getByText(/send to alpha/i)).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText(/send to alpha/i));
+    await waitFor(() => {
+      expect(dispatched.length).toBe(1);
+      expect(dispatched[0].detail.channelId).toBe("Alpha");
+      expect(dispatched[0].detail.prefillCard).toBeDefined();
+      expect(dispatched[0].detail.prefillCard.url).toBe("https://example.com/article");
+      expect(dispatched[0].detail.prefillCard.title).toBe("Test Article");
+    });
+
+    window.removeEventListener("taos:open-messages", listener);
+  });
+
+  it("the dispatched prefillCard contains the resolved extract.text", async () => {
+    const dispatched: CustomEvent[] = [];
+    const listener = (e: Event) => dispatched.push(e as CustomEvent);
+    window.addEventListener("taos:open-messages", listener);
+
+    render(<PageContextMenu {...defaultProps()} />);
+    await waitFor(() => {
+      expect(screen.getByText(/send to alpha/i)).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText(/send to alpha/i));
+    await waitFor(() => {
+      expect(dispatched.length).toBe(1);
+      expect(dispatched[0].detail.prefillCard.extract).toBe("Extracted text content");
+    });
+
+    window.removeEventListener("taos:open-messages", listener);
+  });
+
+  it("clicking 'Pin to Memory' dispatches taos:open-memory", async () => {
+    const dispatched: CustomEvent[] = [];
+    const listener = (e: Event) => dispatched.push(e as CustomEvent);
+    window.addEventListener("taos:open-memory", listener);
+
+    render(<PageContextMenu {...defaultProps()} />);
+    await waitFor(() => {
+      expect(screen.getByText(/pin to memory/i)).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText(/pin to memory/i));
+    await waitFor(() => {
+      expect(dispatched.length).toBe(1);
+      expect(dispatched[0].detail.prefillCard).toBeDefined();
+      expect(dispatched[0].detail.prefillCard.url).toBe("https://example.com/article");
+    });
+
+    window.removeEventListener("taos:open-memory", listener);
+  });
+
+  it("Esc closes via onClose", async () => {
+    const onClose = vi.fn();
+    const { container } = render(<PageContextMenu {...defaultProps({ onClose })} />);
+    await waitFor(() => {
+      expect(screen.getByRole("menu")).toBeTruthy();
+    });
+    fireEvent.keyDown(container.firstChild as HTMLElement, { key: "Escape" });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("click outside closes via onClose", async () => {
+    const onClose = vi.fn();
+    render(<PageContextMenu {...defaultProps({ onClose })} />);
+    await waitFor(() => {
+      expect(screen.getByRole("menu")).toBeTruthy();
+    });
+    // Deferred-add pattern — wait for setTimeout(0)
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+    fireEvent.mouseDown(document.body);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("ArrowDown/Up navigate between entries", async () => {
+    const { container } = render(<PageContextMenu {...defaultProps()} />);
+    await waitFor(() => {
+      expect(screen.getByText(/send to alpha/i)).toBeTruthy();
+    });
+
+    const menu = container.firstChild as HTMLElement;
+    // Initially Alpha should be focused (first item)
+    const items = screen.getAllByRole("menuitem");
+    expect(items[0].getAttribute("aria-selected")).toBe("true");
+
+    fireEvent.keyDown(menu, { key: "ArrowDown" });
+    await waitFor(() => {
+      const updated = screen.getAllByRole("menuitem");
+      expect(updated[1].getAttribute("aria-selected")).toBe("true");
+    });
+
+    fireEvent.keyDown(menu, { key: "ArrowUp" });
+    await waitFor(() => {
+      const updated = screen.getAllByRole("menuitem");
+      expect(updated[0].getAttribute("aria-selected")).toBe("true");
+    });
+  });
+
+  it("Enter triggers the focused entry", async () => {
+    const dispatched: CustomEvent[] = [];
+    const listener = (e: Event) => dispatched.push(e as CustomEvent);
+    window.addEventListener("taos:open-messages", listener);
+
+    const { container } = render(<PageContextMenu {...defaultProps()} />);
+    await waitFor(() => {
+      expect(screen.getByText(/send to alpha/i)).toBeTruthy();
+    });
+
+    const menu = container.firstChild as HTMLElement;
+    // First item is focused; Enter should trigger it
+    fireEvent.keyDown(menu, { key: "Enter" });
+    await waitFor(() => {
+      expect(dispatched.length).toBe(1);
+    });
+
+    window.removeEventListener("taos:open-messages", listener);
+  });
+
+  it("if extractReadable returns null, dispatches with empty extract", async () => {
+    vi.spyOn(browserExtractApi, "extractReadable").mockResolvedValue(null);
+    const dispatched: CustomEvent[] = [];
+    const listener = (e: Event) => dispatched.push(e as CustomEvent);
+    window.addEventListener("taos:open-messages", listener);
+
+    render(<PageContextMenu {...defaultProps()} />);
+    await waitFor(() => {
+      expect(screen.getByText(/send to alpha/i)).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText(/send to alpha/i));
+    await waitFor(() => {
+      expect(dispatched.length).toBe(1);
+      expect(dispatched[0].detail.prefillCard.extract).toBe("");
+    });
+
+    window.removeEventListener("taos:open-messages", listener);
+  });
+
+  it("role=menu + role=menuitem present", async () => {
+    render(<PageContextMenu {...defaultProps()} />);
+    await waitFor(() => {
+      expect(screen.getByRole("menu")).toBeTruthy();
+      const items = screen.getAllByRole("menuitem");
+      expect(items.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("position uses x/y props", async () => {
+    const { container } = render(
+      <PageContextMenu {...defaultProps({ x: 300, y: 400 })} />,
+    );
+    await waitFor(() => {
+      expect(screen.getByRole("menu")).toBeTruthy();
+    });
+    const menu = container.firstChild as HTMLElement;
+    // Should be positioned; check the style attribute references the coords
+    // (the component adjusts for overflow so exact values may shift, but
+    // the menu element uses position:fixed)
+    expect(menu.style.position).toBe("fixed");
+  });
+
+  it("menu closes after clicking 'Send to <Agent>'", async () => {
+    const onClose = vi.fn();
+    render(<PageContextMenu {...defaultProps({ onClose })} />);
+    await waitFor(() => {
+      expect(screen.getByText(/send to alpha/i)).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText(/send to alpha/i));
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  it("menu closes after clicking 'Pin to Memory'", async () => {
+    const onClose = vi.fn();
+    render(<PageContextMenu {...defaultProps({ onClose })} />);
+    await waitFor(() => {
+      expect(screen.getByText(/pin to memory/i)).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText(/pin to memory/i));
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+});

--- a/desktop/src/apps/BrowserApp/PageContextMenu.test.tsx
+++ b/desktop/src/apps/BrowserApp/PageContextMenu.test.tsx
@@ -148,18 +148,18 @@ describe("PageContextMenu", () => {
     const menu = container.firstChild as HTMLElement;
     // Initially Alpha should be focused (first item)
     const items = screen.getAllByRole("menuitem");
-    expect(items[0].getAttribute("aria-selected")).toBe("true");
+    expect(items[0].getAttribute("aria-current")).toBe("true");
 
     fireEvent.keyDown(menu, { key: "ArrowDown" });
     await waitFor(() => {
       const updated = screen.getAllByRole("menuitem");
-      expect(updated[1].getAttribute("aria-selected")).toBe("true");
+      expect(updated[1].getAttribute("aria-current")).toBe("true");
     });
 
     fireEvent.keyDown(menu, { key: "ArrowUp" });
     await waitFor(() => {
       const updated = screen.getAllByRole("menuitem");
-      expect(updated[0].getAttribute("aria-selected")).toBe("true");
+      expect(updated[0].getAttribute("aria-current")).toBe("true");
     });
   });
 
@@ -250,5 +250,31 @@ describe("PageContextMenu", () => {
     await waitFor(() => {
       expect(onClose).toHaveBeenCalled();
     });
+  });
+
+  it("suppresses dispatch when component unmounts during extractReadable", async () => {
+    let resolveExtract!: (v: null) => void;
+    vi.spyOn(browserExtractApi, "extractReadable").mockReturnValue(
+      new Promise<null>((resolve) => { resolveExtract = resolve; }),
+    );
+
+    const dispatched: Event[] = [];
+    const listener = (e: Event) => dispatched.push(e);
+    window.addEventListener("taos:open-messages", listener);
+
+    const { unmount } = render(<PageContextMenu {...defaultProps()} />);
+    await waitFor(() => {
+      expect(screen.getByText(/send to alpha/i)).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText(/send to alpha/i));
+    // Unmount before the extract resolves
+    unmount();
+    // Now resolve — the guard should swallow the dispatch
+    await act(async () => { resolveExtract(null); });
+
+    expect(dispatched.length).toBe(0);
+
+    window.removeEventListener("taos:open-messages", listener);
   });
 });

--- a/desktop/src/apps/BrowserApp/PageContextMenu.tsx
+++ b/desktop/src/apps/BrowserApp/PageContextMenu.tsx
@@ -1,0 +1,225 @@
+/**
+ * PageContextMenu — right-click context menu for the proxied browser page.
+ *
+ * Shows one "Send to <agentName>" entry per agent (via listAgents) and a
+ * "Pin to Memory" entry. Clicking an agent entry:
+ *   1. Calls extractReadable to get the Readability extract of the page.
+ *   2. Dispatches `taos:open-messages` with channelId + prefillCard so that
+ *      MessagesApp (PR 7) can open the chat pre-filled with the page card.
+ *
+ * Clicking "Pin to Memory" dispatches `taos:open-memory` similarly.
+ * Neither event has a receiving listener yet — that's PR 7 scope.
+ *
+ * PR 6 limitation: the menu is triggered by right-clicking the iframe wrapper,
+ * not the iframe content itself. The iframe is sandboxed (no allow-same-origin)
+ * so its own contextmenu events never reach the parent. PR 7 will add a
+ * copilot.js → parent postMessage forwarding so right-click anywhere on the
+ * page reaches the parent's onContextMenu handler.
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+import { listAgents, type AgentDto } from "@/lib/browser-agent-api";
+import { extractReadable } from "@/lib/browser-extract-api";
+
+export interface PageContextMenuProps {
+  windowId: string;
+  tabId: string;
+  /** Profile ID — needed for extractReadable */
+  profileId: string;
+  /** URL of the proxied page (from the active tab) */
+  url: string;
+  /** Page title from the tab */
+  title: string;
+  /**
+   * User's text selection if any. In PR 6 this is always null because the
+   * iframe is sandboxed and we cannot read iframe selection from the parent.
+   * PR 7 will forward the selection via copilot.js postMessage.
+   */
+  selection: string | null;
+  /** Coordinates where the menu opens (relative to viewport) */
+  x: number;
+  y: number;
+  onClose(): void;
+}
+
+export function PageContextMenu({
+  windowId: _windowId,
+  tabId: _tabId,
+  profileId,
+  url,
+  title,
+  selection: _selection,
+  x,
+  y,
+  onClose,
+}: PageContextMenuProps) {
+  const [agents, setAgents] = useState<AgentDto[]>([]);
+  const [focusedIdx, setFocusedIdx] = useState(0);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // Load agents on mount
+  useEffect(() => {
+    let cancelled = false;
+    listAgents().then((list) => {
+      if (!cancelled) setAgents(list);
+    });
+    return () => { cancelled = true; };
+  }, []);
+
+  // Reset focus when agents load
+  useEffect(() => {
+    setFocusedIdx(0);
+  }, [agents.length]);
+
+  // Click-outside to close (deferred so the triggering click doesn't close immediately)
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    const timer = setTimeout(() => {
+      document.addEventListener("mousedown", handler);
+    }, 0);
+    return () => {
+      clearTimeout(timer);
+      document.removeEventListener("mousedown", handler);
+    };
+  }, [onClose]);
+
+  // Build the item list: [Send to <agent>, ...] + [Pin to Memory]
+  const totalItems = agents.length + 1; // +1 for Pin to Memory
+  const PIN_IDX = agents.length;
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+        return;
+      }
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setFocusedIdx((i) => (i + 1) % totalItems);
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setFocusedIdx((i) => (i - 1 + totalItems) % totalItems);
+        return;
+      }
+      if (e.key === "Enter") {
+        e.preventDefault();
+        triggerItem(focusedIdx);
+        return;
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [focusedIdx, totalItems, agents],
+  );
+
+  async function triggerItem(idx: number) {
+    if (idx === PIN_IDX) {
+      await handlePinToMemory();
+    } else {
+      const agent = agents[idx];
+      if (agent) await handleSendToAgent(agent);
+    }
+  }
+
+  async function handleSendToAgent(agent: AgentDto) {
+    const result = await extractReadable(profileId, url);
+    window.dispatchEvent(
+      new CustomEvent("taos:open-messages", {
+        detail: {
+          channelId: agent.name,
+          prefillCard: {
+            title,
+            url,
+            extract: result?.text ?? "",
+          },
+        },
+      }),
+    );
+    onClose();
+  }
+
+  async function handlePinToMemory() {
+    const result = await extractReadable(profileId, url);
+    window.dispatchEvent(
+      new CustomEvent("taos:open-memory", {
+        detail: {
+          prefillCard: {
+            title,
+            url,
+            extract: result?.text ?? "",
+          },
+        },
+      }),
+    );
+    onClose();
+  }
+
+  // Clamp position to stay within viewport
+  const MENU_WIDTH = 220;
+  const MENU_ITEM_HEIGHT = 36;
+  const MENU_HEIGHT = (totalItems + 1) * MENU_ITEM_HEIGHT; // rough estimate
+  const left = Math.min(x, Math.max(0, window.innerWidth - MENU_WIDTH));
+  const top = Math.min(y, Math.max(0, window.innerHeight - MENU_HEIGHT));
+
+  return (
+    <div
+      ref={menuRef}
+      role="menu"
+      aria-label="Page actions"
+      tabIndex={-1}
+      onKeyDown={handleKeyDown}
+      style={{
+        position: "fixed",
+        left,
+        top,
+        width: MENU_WIDTH,
+        zIndex: 9999,
+      }}
+      className="bg-shell-surface border border-shell-border-subtle rounded-lg shadow-lg py-1 outline-none"
+    >
+      {agents.map((agent, idx) => (
+        <button
+          key={agent.id}
+          role="menuitem"
+          aria-selected={focusedIdx === idx}
+          type="button"
+          onClick={() => handleSendToAgent(agent)}
+          onMouseEnter={() => setFocusedIdx(idx)}
+          className={`w-full text-left px-3 py-2 text-sm flex items-center gap-2 cursor-pointer ${
+            focusedIdx === idx
+              ? "bg-shell-hover text-shell-text"
+              : "text-shell-text-secondary hover:bg-shell-hover hover:text-shell-text"
+          }`}
+        >
+          {agent.emoji && <span aria-hidden="true">{agent.emoji}</span>}
+          <span>Send to {agent.name}</span>
+        </button>
+      ))}
+
+      {/* Divider before Pin to Memory */}
+      {agents.length > 0 && (
+        <div className="border-t border-shell-border-subtle my-1" />
+      )}
+
+      <button
+        role="menuitem"
+        aria-selected={focusedIdx === PIN_IDX}
+        type="button"
+        onClick={() => handlePinToMemory()}
+        onMouseEnter={() => setFocusedIdx(PIN_IDX)}
+        className={`w-full text-left px-3 py-2 text-sm flex items-center gap-2 cursor-pointer ${
+          focusedIdx === PIN_IDX
+            ? "bg-shell-hover text-shell-text"
+            : "text-shell-text-secondary hover:bg-shell-hover hover:text-shell-text"
+        }`}
+      >
+        <span aria-hidden="true">📌</span>
+        <span>Pin to Memory</span>
+      </button>
+    </div>
+  );
+}

--- a/desktop/src/apps/BrowserApp/PageContextMenu.tsx
+++ b/desktop/src/apps/BrowserApp/PageContextMenu.tsx
@@ -55,6 +55,8 @@ export function PageContextMenu({
   const [agents, setAgents] = useState<AgentDto[]>([]);
   const [focusedIdx, setFocusedIdx] = useState(0);
   const menuRef = useRef<HTMLDivElement>(null);
+  const mountedRef = useRef(true);
+  useEffect(() => () => { mountedRef.current = false; }, []);
 
   // Load agents on mount
   useEffect(() => {
@@ -127,6 +129,7 @@ export function PageContextMenu({
 
   async function handleSendToAgent(agent: AgentDto) {
     const result = await extractReadable(profileId, url);
+    if (!mountedRef.current) return;
     window.dispatchEvent(
       new CustomEvent("taos:open-messages", {
         detail: {
@@ -144,6 +147,7 @@ export function PageContextMenu({
 
   async function handlePinToMemory() {
     const result = await extractReadable(profileId, url);
+    if (!mountedRef.current) return;
     window.dispatchEvent(
       new CustomEvent("taos:open-memory", {
         detail: {
@@ -185,7 +189,7 @@ export function PageContextMenu({
         <button
           key={agent.id}
           role="menuitem"
-          aria-selected={focusedIdx === idx}
+          aria-current={focusedIdx === idx ? "true" : undefined}
           type="button"
           onClick={() => handleSendToAgent(agent)}
           onMouseEnter={() => setFocusedIdx(idx)}
@@ -196,7 +200,7 @@ export function PageContextMenu({
           }`}
         >
           {agent.emoji && <span aria-hidden="true">{agent.emoji}</span>}
-          <span>Send to {agent.name}</span>
+          <span className="flex-1 min-w-0 truncate">Send to {agent.name}</span>
         </button>
       ))}
 
@@ -207,7 +211,7 @@ export function PageContextMenu({
 
       <button
         role="menuitem"
-        aria-selected={focusedIdx === PIN_IDX}
+        aria-current={focusedIdx === PIN_IDX ? "true" : undefined}
         type="button"
         onClick={() => handlePinToMemory()}
         onMouseEnter={() => setFocusedIdx(PIN_IDX)}

--- a/desktop/src/apps/BrowserApp/TabRenderer.tsx
+++ b/desktop/src/apps/BrowserApp/TabRenderer.tsx
@@ -40,7 +40,6 @@ interface TabRendererProps {
 
 export function TabRenderer({ windowId }: TabRendererProps) {
   const win = useBrowserStore((s) => s.windows[windowId]);
-  const markTabDiscarded = useBrowserStore((s) => s.markTabDiscarded);
   const markTabLive = useBrowserStore((s) => s.markTabLive);
 
   // Discard scheduler — ticks every 60s while the window is mounted.
@@ -93,10 +92,9 @@ export function TabRenderer({ windowId }: TabRendererProps) {
           )
           .sort((a, b) => a.lastActiveAt - b.lastActiveAt);
         for (let i = 0; i < overflowCount && i < candidates.length; i++) {
-          useBrowserStore.getState().markTabDiscarded(
-            windowId,
-            candidates[i].id,
-          );
+          const candidate = candidates[i];
+          if (!candidate) continue;
+          useBrowserStore.getState().markTabDiscarded(windowId, candidate.id);
         }
       }
     }, SCHEDULER_INTERVAL_MS);

--- a/desktop/src/apps/BrowserApp/TabRenderer.tsx
+++ b/desktop/src/apps/BrowserApp/TabRenderer.tsx
@@ -21,6 +21,9 @@ import { useEffect } from "react";
 import { useBrowserStore } from "@/stores/browser-store";
 import { useBrowserSettingsStore } from "@/stores/browser-settings-store";
 import { useBrowserAgentStore } from "@/stores/browser-agent-store";
+import { mintCopilotTicket } from "@/lib/browser-agent-api";
+import { openParentWs } from "./agent-ws-bridge";
+import type { AgentWsHandle } from "./agent-ws-bridge";
 import { detectLiveExclusion } from "./live-exclusion";
 import { ReaderMode } from "./ReaderMode";
 import { AgentPanel } from "./AgentPanel";
@@ -100,6 +103,82 @@ export function TabRenderer({ windowId }: TabRendererProps) {
     return () => clearInterval(interval);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [windowId, !!win]);
+
+  // WS lifecycle — for each pinned agent on the active tab:
+  //   1. Mint an iframe ticket and postMessage taos-copilot:open to the iframe.
+  //   2. Open the parent's own WS via openParentWs to receive page events and
+  //      bump AgentPresencePill's lastEventAt.
+  // Runs whenever the active tab, its pinned agents, or the profile changes.
+  // Cleanup closes all parent WS handles and posts taos-copilot:close to the
+  // iframe so copilot.js tears down the iframe-side WS.
+  const activeTabIdForEffect = win?.activeTabId;
+  const pinnedAgentIdsForEffect = win?.tabs.find((t) => t.id === win?.activeTabId)?.pinnedAgentIds ?? [];
+  const profileIdForEffect = win?.profileId;
+
+  useEffect(() => {
+    if (!activeTabIdForEffect || !profileIdForEffect) return;
+
+    const tabId = activeTabIdForEffect;
+    const profileId = profileIdForEffect;
+    const handles: AgentWsHandle[] = [];
+    let cancelled = false;
+
+    for (const agentId of pinnedAgentIdsForEffect) {
+      // 1. Mint a separate ticket for the iframe and post it
+      mintCopilotTicket(profileId, tabId, agentId).then((ticket) => {
+        if (cancelled || !ticket) return;
+        const iframe = document.querySelector(
+          `iframe[data-tab-id="${tabId}"]`,
+        ) as HTMLIFrameElement | null;
+        if (iframe?.contentWindow) {
+          iframe.contentWindow.postMessage(
+            { type: "taos-copilot:open", ticket: ticket.ticket, agentId },
+            "*",
+          );
+        }
+      });
+
+      // 2. Open the parent's own WS to receive page events
+      openParentWs({
+        windowId,
+        tabId,
+        agentId,
+        profileId,
+        onEvent: (event) => {
+          const store = useBrowserAgentStore.getState();
+          store.bumpEventAt(windowId, tabId, agentId);
+          store.appendEvent(windowId, tabId, agentId, event);
+        },
+      }).then((handle) => {
+        if (cancelled) {
+          handle.close();
+        } else {
+          handles.push(handle);
+        }
+      });
+    }
+
+    return () => {
+      cancelled = true;
+
+      // Close all parent WS handles
+      for (const handle of handles) handle.close();
+
+      // Tell the iframe-side copilot.js to close its WS for each agent
+      const iframe = document.querySelector(
+        `iframe[data-tab-id="${tabId}"]`,
+      ) as HTMLIFrameElement | null;
+      if (iframe?.contentWindow) {
+        for (const agentId of pinnedAgentIdsForEffect) {
+          iframe.contentWindow.postMessage(
+            { type: "taos-copilot:close", agentId },
+            "*",
+          );
+        }
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [windowId, activeTabIdForEffect, pinnedAgentIdsForEffect.join(","), profileIdForEffect]);
 
   // Subscribe to panel state so TabRenderer re-renders when panel opens/closes.
   // win?.activeTabId is safely undefined when win is undefined (hook must be

--- a/desktop/src/apps/BrowserApp/TabRenderer.tsx
+++ b/desktop/src/apps/BrowserApp/TabRenderer.tsx
@@ -101,9 +101,13 @@ export function TabRenderer({ windowId }: TabRendererProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [windowId, !!win]);
 
-  // Subscribe to panel state so TabRenderer re-renders when panel opens/closes
-  const panel = useBrowserAgentStore((s) => s.panels[`${windowId}:${win?.activeTabId}`]);
-  const panelIsOpen = panel?.isOpen ?? false;
+  // Subscribe to panel state so TabRenderer re-renders when panel opens/closes.
+  // win?.activeTabId is safely undefined when win is undefined (hook must be
+  // called unconditionally, so the guard comes after).
+  const panelIsOpen =
+    useBrowserAgentStore(
+      (s) => (win ? s.panels[`${windowId}:${win.activeTabId}`]?.isOpen : false),
+    ) ?? false;
 
   if (!win) return null;
 

--- a/desktop/src/apps/BrowserApp/TabRenderer.tsx
+++ b/desktop/src/apps/BrowserApp/TabRenderer.tsx
@@ -17,7 +17,7 @@
  * with playing audio/video, active form input, or in-flight upload
  * are exempt regardless of idle time. PR 4 ships the basic policy.
  */
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useBrowserStore } from "@/stores/browser-store";
 import { useBrowserSettingsStore } from "@/stores/browser-settings-store";
 import { useBrowserAgentStore } from "@/stores/browser-agent-store";
@@ -27,6 +27,7 @@ import type { AgentWsHandle } from "./agent-ws-bridge";
 import { detectLiveExclusion } from "./live-exclusion";
 import { ReaderMode } from "./ReaderMode";
 import { AgentPanel } from "./AgentPanel";
+import { PageContextMenu } from "./PageContextMenu";
 import type { Tab } from "./types";
 
 export const DISCARD_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
@@ -188,6 +189,13 @@ export function TabRenderer({ windowId }: TabRendererProps) {
       (s) => (win ? s.panels[`${windowId}:${win.activeTabId}`]?.isOpen : false),
     ) ?? false;
 
+  // Context menu state — position where the user right-clicked.
+  // PR 6 limitation: only fires when right-clicking on the iframe wrapper border,
+  // not on the iframe content itself (sandbox blocks contextmenu propagation to
+  // the parent). PR 7 will add copilot.js → parent postMessage forwarding so
+  // right-click anywhere on the page surface reaches this handler.
+  const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
+
   if (!win) return null;
 
   const activeTab = win.tabs.find((t) => t.id === win.activeTabId);
@@ -196,7 +204,16 @@ export function TabRenderer({ windowId }: TabRendererProps) {
   return (
     <div className="flex flex-1 overflow-hidden bg-shell-bg-deep">
       {/* Iframe pool — relative container so iframes can position absolutely */}
-      <div className="relative flex-1 overflow-hidden">
+      <div
+        className="relative flex-1 overflow-hidden"
+        onContextMenu={(e) => {
+          // Right-click on the iframe wrapper. See comment above for PR 6 limitation.
+          e.preventDefault();
+          if (activeTab) {
+            setContextMenu({ x: e.clientX, y: e.clientY });
+          }
+        }}
+      >
         {win.tabs.map((tab) => {
           const isActive = tab.id === win.activeTabId;
           if (tab.state === "discarded") {
@@ -245,6 +262,21 @@ export function TabRenderer({ windowId }: TabRendererProps) {
             </div>
           );
         })}
+
+        {/* Page context menu — shown when user right-clicks the iframe wrapper */}
+        {contextMenu && activeTab && (
+          <PageContextMenu
+            windowId={windowId}
+            tabId={activeTab.id}
+            profileId={win.profileId}
+            url={activeTab.url}
+            title={activeTab.title || activeTab.url || ""}
+            selection={null}
+            x={contextMenu.x}
+            y={contextMenu.y}
+            onClose={() => setContextMenu(null)}
+          />
+        )}
       </div>
 
       {/* Agent panel — renders to the right of the iframe; iframe squeezes via flex */}

--- a/desktop/src/apps/BrowserApp/TabRenderer.tsx
+++ b/desktop/src/apps/BrowserApp/TabRenderer.tsx
@@ -20,8 +20,10 @@
 import { useEffect } from "react";
 import { useBrowserStore } from "@/stores/browser-store";
 import { useBrowserSettingsStore } from "@/stores/browser-settings-store";
+import { useBrowserAgentStore } from "@/stores/browser-agent-store";
 import { detectLiveExclusion } from "./live-exclusion";
 import { ReaderMode } from "./ReaderMode";
+import { AgentPanel } from "./AgentPanel";
 import type { Tab } from "./types";
 
 export const DISCARD_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
@@ -99,58 +101,77 @@ export function TabRenderer({ windowId }: TabRendererProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [windowId, !!win]);
 
+  // Subscribe to panel state so TabRenderer re-renders when panel opens/closes
+  const panel = useBrowserAgentStore((s) => s.panels[`${windowId}:${win?.activeTabId}`]);
+  const panelIsOpen = panel?.isOpen ?? false;
+
   if (!win) return null;
 
+  const activeTab = win.tabs.find((t) => t.id === win.activeTabId);
+  const pinnedAgentIds = activeTab?.pinnedAgentIds ?? [];
+
   return (
-    <div className="relative flex-1 bg-shell-bg-deep overflow-hidden">
-      {win.tabs.map((tab) => {
-        const isActive = tab.id === win.activeTabId;
-        if (tab.state === "discarded") {
-          return isActive ? (
-            <DiscardedPlaceholder
+    <div className="flex flex-1 overflow-hidden bg-shell-bg-deep">
+      {/* Iframe pool — relative container so iframes can position absolutely */}
+      <div className="relative flex-1 overflow-hidden">
+        {win.tabs.map((tab) => {
+          const isActive = tab.id === win.activeTabId;
+          if (tab.state === "discarded") {
+            return isActive ? (
+              <DiscardedPlaceholder
+                key={tab.id}
+                tab={tab}
+                onReload={() => markTabLive(windowId, tab.id)}
+              />
+            ) : null;
+          }
+
+          const showReader = isActive && !!tab.readerActive && !!tab.readerExtract;
+
+          return (
+            <div
               key={tab.id}
-              tab={tab}
-              onReload={() => markTabLive(windowId, tab.id)}
-            />
-          ) : null;
-        }
+              style={{ display: isActive ? "contents" : "none" }}
+              data-window-tab={tab.id}
+            >
+              <iframe
+                title={tab.title || tab.url || "Browser tab"}
+                src={proxiedSrc(win.profileId, tab.url)}
+                data-tab-id={tab.id}
+                // sandbox: allow-same-origin intentionally OMITTED. The proxy
+                // serves on the same origin as the shell; combining
+                // allow-same-origin + allow-scripts would let proxied JS reach
+                // up into the parent and remove this attribute. The HTTPS+DNS
+                // Foundations brainstorm will land an isolated subdomain that
+                // makes allow-same-origin safe to add back.
+                sandbox="allow-scripts allow-forms allow-popups allow-downloads"
+                style={{
+                  display: isActive && !showReader ? "block" : "none",
+                  position: "absolute",
+                  inset: 0,
+                  width: "100%",
+                  height: "100%",
+                  border: "none",
+                  transform: tab.zoom !== 1 ? `scale(${tab.zoom})` : undefined,
+                  transformOrigin: "top left",
+                }}
+              />
+              {showReader && (
+                <ReaderMode tab={tab} windowId={windowId} />
+              )}
+            </div>
+          );
+        })}
+      </div>
 
-        const showReader = isActive && !!tab.readerActive && !!tab.readerExtract;
-
-        return (
-          <div
-            key={tab.id}
-            style={{ display: isActive ? "contents" : "none" }}
-            data-window-tab={tab.id}
-          >
-            <iframe
-              title={tab.title || tab.url || "Browser tab"}
-              src={proxiedSrc(win.profileId, tab.url)}
-              data-tab-id={tab.id}
-              // sandbox: allow-same-origin intentionally OMITTED. The proxy
-              // serves on the same origin as the shell; combining
-              // allow-same-origin + allow-scripts would let proxied JS reach
-              // up into the parent and remove this attribute. The HTTPS+DNS
-              // Foundations brainstorm will land an isolated subdomain that
-              // makes allow-same-origin safe to add back.
-              sandbox="allow-scripts allow-forms allow-popups allow-downloads"
-              style={{
-                display: isActive && !showReader ? "block" : "none",
-                position: "absolute",
-                inset: 0,
-                width: "100%",
-                height: "100%",
-                border: "none",
-                transform: tab.zoom !== 1 ? `scale(${tab.zoom})` : undefined,
-                transformOrigin: "top left",
-              }}
-            />
-            {showReader && (
-              <ReaderMode tab={tab} windowId={windowId} />
-            )}
-          </div>
-        );
-      })}
+      {/* Agent panel — renders to the right of the iframe; iframe squeezes via flex */}
+      {panelIsOpen && pinnedAgentIds.length > 0 && (
+        <AgentPanel
+          windowId={windowId}
+          tabId={win.activeTabId}
+          pinnedAgentIds={pinnedAgentIds}
+        />
+      )}
     </div>
   );
 }

--- a/desktop/src/apps/BrowserApp/TabRenderer.tsx
+++ b/desktop/src/apps/BrowserApp/TabRenderer.tsx
@@ -107,11 +107,12 @@ export function TabRenderer({ windowId }: TabRendererProps) {
 
   // WS lifecycle — for each pinned agent on the active tab:
   //   1. Mint an iframe ticket and postMessage taos-copilot:open to the iframe.
-  //   2. Open the parent's own WS via openParentWs to receive page events and
-  //      bump AgentPresencePill's lastEventAt.
-  // Runs whenever the active tab, its pinned agents, or the profile changes.
-  // Cleanup closes all parent WS handles and posts taos-copilot:close to the
-  // iframe so copilot.js tears down the iframe-side WS.
+  //      copilot.js opens the WS and forwards server events back to the parent
+  //      via postMessage.
+  //   2. Register a parent-side message listener via openParentWs so we
+  //      receive forwarded page-changed events and bump the presence pulse.
+  // We do NOT open a second parent WebSocket — both connections would register
+  // under the same hub key and clobber each other.
   const activeTabIdForEffect = win?.activeTabId;
   const pinnedAgentIdsForEffect = win?.tabs.find((t) => t.id === win?.activeTabId)?.pinnedAgentIds ?? [];
   const profileIdForEffect = win?.profileId;
@@ -121,17 +122,19 @@ export function TabRenderer({ windowId }: TabRendererProps) {
 
     const tabId = activeTabIdForEffect;
     const profileId = profileIdForEffect;
+    const iframe = document.querySelector(
+      `iframe[data-tab-id="${tabId}"]`,
+    ) as HTMLIFrameElement | null;
+    if (!iframe) return;
+
     const handles: AgentWsHandle[] = [];
     let cancelled = false;
 
     for (const agentId of pinnedAgentIdsForEffect) {
-      // 1. Mint a separate ticket for the iframe and post it
+      // 1. Mint a ticket for the iframe-side WS and post it.
       mintCopilotTicket(profileId, tabId, agentId).then((ticket) => {
         if (cancelled || !ticket) return;
-        const iframe = document.querySelector(
-          `iframe[data-tab-id="${tabId}"]`,
-        ) as HTMLIFrameElement | null;
-        if (iframe?.contentWindow) {
+        if (iframe.contentWindow) {
           iframe.contentWindow.postMessage(
             { type: "taos-copilot:open", ticket: ticket.ticket, agentId },
             "*",
@@ -139,37 +142,29 @@ export function TabRenderer({ windowId }: TabRendererProps) {
         }
       });
 
-      // 2. Open the parent's own WS to receive page events
-      openParentWs({
+      // 2. Register a parent-side listener for events forwarded by copilot.js.
+      const handle = openParentWs({
         windowId,
         tabId,
         agentId,
-        profileId,
+        iframe,
         onEvent: (event) => {
           const store = useBrowserAgentStore.getState();
           store.bumpEventAt(windowId, tabId, agentId);
           store.appendEvent(windowId, tabId, agentId, event);
         },
-      }).then((handle) => {
-        if (cancelled) {
-          handle.close();
-        } else {
-          handles.push(handle);
-        }
       });
+      handles.push(handle);
     }
 
     return () => {
       cancelled = true;
 
-      // Close all parent WS handles
+      // Close all parent-side listeners
       for (const handle of handles) handle.close();
 
       // Tell the iframe-side copilot.js to close its WS for each agent
-      const iframe = document.querySelector(
-        `iframe[data-tab-id="${tabId}"]`,
-      ) as HTMLIFrameElement | null;
-      if (iframe?.contentWindow) {
+      if (iframe.contentWindow) {
         for (const agentId of pinnedAgentIdsForEffect) {
           iframe.contentWindow.postMessage(
             { type: "taos-copilot:close", agentId },
@@ -236,7 +231,7 @@ export function TabRenderer({ windowId }: TabRendererProps) {
             >
               <iframe
                 title={tab.title || tab.url || "Browser tab"}
-                src={proxiedSrc(win.profileId, tab.url)}
+                src={proxiedSrc(win.profileId, tab.url, tab.id)}
                 data-tab-id={tab.id}
                 // sandbox: allow-same-origin intentionally OMITTED. The proxy
                 // serves on the same origin as the shell; combining
@@ -284,6 +279,7 @@ export function TabRenderer({ windowId }: TabRendererProps) {
         <AgentPanel
           windowId={windowId}
           tabId={win.activeTabId}
+          profileId={win.profileId}
           pinnedAgentIds={pinnedAgentIds}
         />
       )}
@@ -319,11 +315,18 @@ function DiscardedPlaceholder({ tab, onReload }: DiscardedPlaceholderProps) {
   );
 }
 
-/** Build the proxied iframe src. about:blank passes through unproxied. */
-function proxiedSrc(profileId: string, url: string): string {
+/** Build the proxied iframe src. about:blank passes through unproxied.
+ * tab_id is included so the proxy can fan out page-changed events to
+ * any agents pinned to the tab (see proxy.py + CopilotHub).
+ */
+function proxiedSrc(profileId: string, url: string, tabId: string): string {
   if (!url || url === "about:blank" || url.startsWith("about:")) {
     return "about:blank";
   }
-  const params = new URLSearchParams({ profile_id: profileId, url });
+  const params = new URLSearchParams({
+    profile_id: profileId,
+    url,
+    tab_id: tabId,
+  });
   return `/api/desktop/browser/proxy?${params.toString()}`;
 }

--- a/desktop/src/apps/BrowserApp/agent-ws-bridge.test.ts
+++ b/desktop/src/apps/BrowserApp/agent-ws-bridge.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { AgentWsBridgeOptions } from "./agent-ws-bridge";
+
+// vi.mock must be at module top-level (hoisted)
+vi.mock("@/lib/browser-agent-api", () => ({
+  mintCopilotTicket: vi.fn(),
+}));
+
+// Import after mock declaration
+import { openParentWs } from "./agent-ws-bridge";
+import * as browserAgentApi from "@/lib/browser-agent-api";
+
+// ─── Minimal WebSocket mock ───────────────────────────────────────────────────
+
+interface MockWsInstance {
+  url: string;
+  readyState: number;
+  listeners: Record<string, ((payload: unknown) => void)[]>;
+  addEventListener(type: string, fn: (payload: unknown) => void): void;
+  send: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+  /** Trigger registered listeners for a given event type. */
+  fire(type: string, payload?: unknown): void;
+}
+
+let mockWsInstances: MockWsInstance[];
+let MockWebSocket: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  mockWsInstances = [];
+
+  MockWebSocket = vi.fn().mockImplementation(function (this: MockWsInstance, url: string) {
+    this.url = url;
+    this.readyState = 0; // CONNECTING
+    this.listeners = {};
+    this.addEventListener = function (type: string, fn: (payload: unknown) => void) {
+      if (!this.listeners[type]) this.listeners[type] = [];
+      this.listeners[type].push(fn);
+    };
+    this.send = vi.fn();
+    this.close = vi.fn().mockImplementation(function (this: MockWsInstance) {
+      this.readyState = 3; // CLOSED
+      this.fire("close");
+    });
+    this.fire = function (type: string, payload?: unknown) {
+      (this.listeners[type] ?? []).forEach((fn) => fn(payload ?? {}));
+    };
+    mockWsInstances.push(this);
+  });
+
+  (global as unknown as Record<string, unknown>).WebSocket = MockWebSocket;
+
+  // Reset to the default "success" implementation before each test
+  vi.mocked(browserAgentApi.mintCopilotTicket).mockResolvedValue({
+    ticket: "fake-token",
+    ttl_seconds: 60,
+  });
+});
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeOpts(overrides?: Partial<AgentWsBridgeOptions>): AgentWsBridgeOptions {
+  return {
+    windowId: "win-1",
+    tabId: "tab-1",
+    agentId: "agent-1",
+    profileId: "profile-1",
+    onEvent: vi.fn(),
+    onOpen: vi.fn(),
+    onClose: vi.fn(),
+    ...overrides,
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("openParentWs", () => {
+  it("opens a WebSocket with the ticket in the URL", async () => {
+    const opts = makeOpts();
+    await openParentWs(opts);
+
+    expect(MockWebSocket).toHaveBeenCalledOnce();
+    const [url] = MockWebSocket.mock.calls[0] as [string];
+    expect(url).toContain("/api/desktop/browser/copilot");
+    expect(url).toContain("ticket=fake-token");
+    expect(url).toMatch(/^ws(s)?:\/\//);
+  });
+
+  it("calls onOpen when the WS open event fires", async () => {
+    const opts = makeOpts();
+    await openParentWs(opts);
+
+    const ws = mockWsInstances[0];
+    expect(opts.onOpen).not.toHaveBeenCalled();
+
+    ws.fire("open");
+    expect(opts.onOpen).toHaveBeenCalledOnce();
+  });
+
+  it("isOpen is true after onOpen fires, false before", async () => {
+    const opts = makeOpts();
+    const handle = await openParentWs(opts);
+
+    expect(handle.isOpen).toBe(false);
+    mockWsInstances[0].fire("open");
+    expect(handle.isOpen).toBe(true);
+  });
+
+  it("calls onEvent with transformed AgentEvent when server sends { event: 'page-changed' }", async () => {
+    const opts = makeOpts();
+    await openParentWs(opts);
+
+    const ws = mockWsInstances[0];
+    ws.fire("message", {
+      data: JSON.stringify({
+        event: "page-changed",
+        url: "https://example.com/",
+        title: "Example",
+        timestamp: 12345,
+      }),
+    });
+
+    expect(opts.onEvent).toHaveBeenCalledOnce();
+    const received = vi.mocked(opts.onEvent).mock.calls[0][0];
+    expect(received.kind).toBe("page-changed");
+    expect(received.url).toBe("https://example.com/");
+    expect(received.title).toBe("Example");
+    expect(received.timestamp).toBe(12345);
+    // Server's `event` field should not appear in the normalised event
+    expect((received as Record<string, unknown>).event).toBeUndefined();
+  });
+
+  it("transforms { event: 'url-changed' } and { event: 'scroll' } correctly", async () => {
+    const opts = makeOpts();
+    await openParentWs(opts);
+
+    const ws = mockWsInstances[0];
+
+    ws.fire("message", { data: JSON.stringify({ event: "url-changed", url: "https://a.com/" }) });
+    ws.fire("message", { data: JSON.stringify({ event: "scroll" }) });
+
+    const calls = vi.mocked(opts.onEvent).mock.calls;
+    expect(calls).toHaveLength(2);
+    expect(calls[0][0].kind).toBe("url-changed");
+    expect(calls[1][0].kind).toBe("scroll");
+  });
+
+  it("ignores messages with unknown event kinds", async () => {
+    const opts = makeOpts();
+    await openParentWs(opts);
+
+    const ws = mockWsInstances[0];
+    ws.fire("message", { data: JSON.stringify({ event: "totally-unknown-event" }) });
+
+    expect(opts.onEvent).not.toHaveBeenCalled();
+  });
+
+  it("ignores malformed messages (non-JSON, no event field)", async () => {
+    const opts = makeOpts();
+    await openParentWs(opts);
+
+    const ws = mockWsInstances[0];
+    ws.fire("message", { data: "not-json" });
+    ws.fire("message", { data: JSON.stringify({ noEventField: true }) });
+
+    expect(opts.onEvent).not.toHaveBeenCalled();
+  });
+
+  it("calls onClose when WS close fires", async () => {
+    const opts = makeOpts();
+    await openParentWs(opts);
+
+    expect(opts.onClose).not.toHaveBeenCalled();
+    mockWsInstances[0].fire("close");
+    expect(opts.onClose).toHaveBeenCalledOnce();
+  });
+
+  it("sets isOpen to false after close fires", async () => {
+    const opts = makeOpts();
+    const handle = await openParentWs(opts);
+
+    mockWsInstances[0].fire("open");
+    expect(handle.isOpen).toBe(true);
+
+    mockWsInstances[0].fire("close");
+    expect(handle.isOpen).toBe(false);
+  });
+
+  it("handle.close() shuts the underlying WebSocket", async () => {
+    const opts = makeOpts();
+    const handle = await openParentWs(opts);
+
+    handle.close();
+    expect(mockWsInstances[0].close).toHaveBeenCalled();
+  });
+
+  it("uses missing timestamp → Date.now() fallback when timestamp absent from server event", async () => {
+    const beforeTs = Date.now();
+    const opts = makeOpts();
+    await openParentWs(opts);
+
+    mockWsInstances[0].fire("message", {
+      data: JSON.stringify({ event: "scroll" }),
+    });
+
+    const afterTs = Date.now();
+    const received = vi.mocked(opts.onEvent).mock.calls[0][0];
+    expect(received.timestamp).toBeGreaterThanOrEqual(beforeTs);
+    expect(received.timestamp).toBeLessThanOrEqual(afterTs);
+  });
+
+  it("if mintCopilotTicket returns null, calls onClose immediately and isOpen stays false", async () => {
+    vi.mocked(browserAgentApi.mintCopilotTicket).mockResolvedValue(null);
+
+    const opts = makeOpts();
+    const handle = await openParentWs(opts);
+
+    expect(MockWebSocket).not.toHaveBeenCalled();
+    expect(opts.onClose).toHaveBeenCalledOnce();
+    expect(handle.isOpen).toBe(false);
+  });
+});

--- a/desktop/src/apps/BrowserApp/agent-ws-bridge.test.ts
+++ b/desktop/src/apps/BrowserApp/agent-ws-bridge.test.ts
@@ -1,70 +1,34 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import type { AgentWsBridgeOptions } from "./agent-ws-bridge";
+import { openParentWs, type AgentWsBridgeOptions } from "./agent-ws-bridge";
 
-// vi.mock must be at module top-level (hoisted)
-vi.mock("@/lib/browser-agent-api", () => ({
-  mintCopilotTicket: vi.fn(),
-}));
-
-// Import after mock declaration
-import { openParentWs } from "./agent-ws-bridge";
-import * as browserAgentApi from "@/lib/browser-agent-api";
-
-// ─── Minimal WebSocket mock ───────────────────────────────────────────────────
-
-interface MockWsInstance {
-  url: string;
-  readyState: number;
-  listeners: Record<string, ((payload: unknown) => void)[]>;
-  addEventListener(type: string, fn: (payload: unknown) => void): void;
-  send: ReturnType<typeof vi.fn>;
-  close: ReturnType<typeof vi.fn>;
-  /** Trigger registered listeners for a given event type. */
-  fire(type: string, payload?: unknown): void;
-}
-
-let mockWsInstances: MockWsInstance[];
-let MockWebSocket: ReturnType<typeof vi.fn>;
-
-beforeEach(() => {
-  mockWsInstances = [];
-
-  MockWebSocket = vi.fn().mockImplementation(function (this: MockWsInstance, url: string) {
-    this.url = url;
-    this.readyState = 0; // CONNECTING
-    this.listeners = {};
-    this.addEventListener = function (type: string, fn: (payload: unknown) => void) {
-      if (!this.listeners[type]) this.listeners[type] = [];
-      this.listeners[type].push(fn);
-    };
-    this.send = vi.fn();
-    this.close = vi.fn().mockImplementation(function (this: MockWsInstance) {
-      this.readyState = 3; // CLOSED
-      this.fire("close");
-    });
-    this.fire = function (type: string, payload?: unknown) {
-      (this.listeners[type] ?? []).forEach((fn) => fn(payload ?? {}));
-    };
-    mockWsInstances.push(this);
-  });
-
-  (global as unknown as Record<string, unknown>).WebSocket = MockWebSocket;
-
-  // Reset to the default "success" implementation before each test
-  vi.mocked(browserAgentApi.mintCopilotTicket).mockResolvedValue({
-    ticket: "fake-token",
-    ttl_seconds: 60,
-  });
-});
+/**
+ * In the new architecture (post-Opus whole-branch review), the parent does
+ * NOT open its own WebSocket. Instead, copilot.js (running in the iframe)
+ * forwards server events to the parent via postMessage as
+ *   { type: "taos-copilot:server-event", agentId, message }
+ *
+ * openParentWs registers a window message listener that filters by source
+ * iframe + agentId, normalises message.event → AgentEvent.kind, and calls
+ * the supplied onEvent callback.
+ */
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
+
+interface FakeIframe {
+  contentWindow: object;
+}
+
+function makeIframe(): HTMLIFrameElement {
+  const fakeWin = {};
+  return { contentWindow: fakeWin } as unknown as HTMLIFrameElement;
+}
 
 function makeOpts(overrides?: Partial<AgentWsBridgeOptions>): AgentWsBridgeOptions {
   return {
     windowId: "win-1",
     tabId: "tab-1",
     agentId: "agent-1",
-    profileId: "profile-1",
+    iframe: makeIframe(),
     onEvent: vi.fn(),
     onOpen: vi.fn(),
     onClose: vi.fn(),
@@ -72,52 +36,47 @@ function makeOpts(overrides?: Partial<AgentWsBridgeOptions>): AgentWsBridgeOptio
   };
 }
 
+/** Dispatch a message event with a chosen source. JSDOM's MessageEvent
+ * constructor doesn't honour the `source` option, so we override via
+ * Object.defineProperty before dispatch. */
+function dispatchMessageFrom(source: object | null, data: unknown): void {
+  const ev = new MessageEvent("message", { data });
+  Object.defineProperty(ev, "source", { value: source, configurable: true });
+  window.dispatchEvent(ev);
+}
+
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
-describe("openParentWs", () => {
-  it("opens a WebSocket with the ticket in the URL", async () => {
+describe("openParentWs (postMessage-based)", () => {
+  it("isOpen is true after creation (no async ticket round-trip)", () => {
     const opts = makeOpts();
-    await openParentWs(opts);
-
-    expect(MockWebSocket).toHaveBeenCalledOnce();
-    const [url] = MockWebSocket.mock.calls[0] as [string];
-    expect(url).toContain("/api/desktop/browser/copilot");
-    expect(url).toContain("ticket=fake-token");
-    expect(url).toMatch(/^ws(s)?:\/\//);
-  });
-
-  it("calls onOpen when the WS open event fires", async () => {
-    const opts = makeOpts();
-    await openParentWs(opts);
-
-    const ws = mockWsInstances[0];
-    expect(opts.onOpen).not.toHaveBeenCalled();
-
-    ws.fire("open");
-    expect(opts.onOpen).toHaveBeenCalledOnce();
-  });
-
-  it("isOpen is true after onOpen fires, false before", async () => {
-    const opts = makeOpts();
-    const handle = await openParentWs(opts);
-
-    expect(handle.isOpen).toBe(false);
-    mockWsInstances[0].fire("open");
+    const handle = openParentWs(opts);
     expect(handle.isOpen).toBe(true);
   });
 
-  it("calls onEvent with transformed AgentEvent when server sends { event: 'page-changed' }", async () => {
+  it("does NOT open a WebSocket (sanity: no fetch/WS APIs touched)", () => {
+    // The whole point of the new design is no WebSocket on the parent.
+    // If a WebSocket constructor gets called we'll see it via global mock.
+    const ctor = vi.fn();
+    (global as unknown as Record<string, unknown>).WebSocket = ctor;
     const opts = makeOpts();
-    await openParentWs(opts);
+    openParentWs(opts);
+    expect(ctor).not.toHaveBeenCalled();
+  });
 
-    const ws = mockWsInstances[0];
-    ws.fire("message", {
-      data: JSON.stringify({
+  it("calls onEvent when iframe forwards a page-changed event", () => {
+    const opts = makeOpts();
+    openParentWs(opts);
+
+    dispatchMessageFrom(opts.iframe.contentWindow, {
+      type: "taos-copilot:server-event",
+      agentId: "agent-1",
+      message: {
         event: "page-changed",
         url: "https://example.com/",
         title: "Example",
         timestamp: 12345,
-      }),
+      },
     });
 
     expect(opts.onEvent).toHaveBeenCalledOnce();
@@ -126,18 +85,22 @@ describe("openParentWs", () => {
     expect(received.url).toBe("https://example.com/");
     expect(received.title).toBe("Example");
     expect(received.timestamp).toBe(12345);
-    // Server's `event` field should not appear in the normalised event
-    expect((received as Record<string, unknown>).event).toBeUndefined();
   });
 
-  it("transforms { event: 'url-changed' } and { event: 'scroll' } correctly", async () => {
+  it("transforms url-changed and scroll kinds", () => {
     const opts = makeOpts();
-    await openParentWs(opts);
+    openParentWs(opts);
 
-    const ws = mockWsInstances[0];
-
-    ws.fire("message", { data: JSON.stringify({ event: "url-changed", url: "https://a.com/" }) });
-    ws.fire("message", { data: JSON.stringify({ event: "scroll" }) });
+    dispatchMessageFrom(opts.iframe.contentWindow, {
+      type: "taos-copilot:server-event",
+      agentId: "agent-1",
+      message: { event: "url-changed", url: "https://a.com/" },
+    });
+    dispatchMessageFrom(opts.iframe.contentWindow, {
+      type: "taos-copilot:server-event",
+      agentId: "agent-1",
+      message: { event: "scroll" },
+    });
 
     const calls = vi.mocked(opts.onEvent).mock.calls;
     expect(calls).toHaveLength(2);
@@ -145,62 +108,78 @@ describe("openParentWs", () => {
     expect(calls[1][0].kind).toBe("scroll");
   });
 
-  it("ignores messages with unknown event kinds", async () => {
+  it("rejects messages whose source is not the iframe (cross-frame protection)", () => {
     const opts = makeOpts();
-    await openParentWs(opts);
+    openParentWs(opts);
 
-    const ws = mockWsInstances[0];
-    ws.fire("message", { data: JSON.stringify({ event: "totally-unknown-event" }) });
+    // A message from a DIFFERENT window object — must be ignored
+    dispatchMessageFrom({}, {
+      type: "taos-copilot:server-event",
+      agentId: "agent-1",
+      message: { event: "page-changed", url: "https://attacker.example/" },
+    });
 
     expect(opts.onEvent).not.toHaveBeenCalled();
   });
 
-  it("ignores malformed messages (non-JSON, no event field)", async () => {
-    const opts = makeOpts();
-    await openParentWs(opts);
+  it("rejects messages with mismatched agentId (multi-pin isolation)", () => {
+    const opts = makeOpts({ agentId: "agent-1" });
+    openParentWs(opts);
 
-    const ws = mockWsInstances[0];
-    ws.fire("message", { data: "not-json" });
-    ws.fire("message", { data: JSON.stringify({ noEventField: true }) });
+    dispatchMessageFrom(opts.iframe.contentWindow, {
+      type: "taos-copilot:server-event",
+      agentId: "agent-2",
+      message: { event: "page-changed", url: "https://example.com/" },
+    });
 
     expect(opts.onEvent).not.toHaveBeenCalled();
   });
 
-  it("calls onClose when WS close fires", async () => {
+  it("ignores messages with unknown event kinds", () => {
     const opts = makeOpts();
-    await openParentWs(opts);
+    openParentWs(opts);
 
-    expect(opts.onClose).not.toHaveBeenCalled();
-    mockWsInstances[0].fire("close");
-    expect(opts.onClose).toHaveBeenCalledOnce();
+    dispatchMessageFrom(opts.iframe.contentWindow, {
+      type: "taos-copilot:server-event",
+      agentId: "agent-1",
+      message: { event: "totally-unknown" },
+    });
+
+    expect(opts.onEvent).not.toHaveBeenCalled();
   });
 
-  it("sets isOpen to false after close fires", async () => {
+  it("ignores messages without the expected type field", () => {
     const opts = makeOpts();
-    const handle = await openParentWs(opts);
+    openParentWs(opts);
 
-    mockWsInstances[0].fire("open");
-    expect(handle.isOpen).toBe(true);
+    dispatchMessageFrom(opts.iframe.contentWindow, {
+      type: "something-else",
+      agentId: "agent-1",
+      message: { event: "page-changed" },
+    });
 
-    mockWsInstances[0].fire("close");
-    expect(handle.isOpen).toBe(false);
+    expect(opts.onEvent).not.toHaveBeenCalled();
   });
 
-  it("handle.close() shuts the underlying WebSocket", async () => {
+  it("ignores malformed payloads (string data, missing message field)", () => {
     const opts = makeOpts();
-    const handle = await openParentWs(opts);
+    openParentWs(opts);
 
-    handle.close();
-    expect(mockWsInstances[0].close).toHaveBeenCalled();
+    dispatchMessageFrom(opts.iframe.contentWindow, "not-an-object");
+    dispatchMessageFrom(opts.iframe.contentWindow, { type: "taos-copilot:server-event", agentId: "agent-1" });
+
+    expect(opts.onEvent).not.toHaveBeenCalled();
   });
 
-  it("uses missing timestamp → Date.now() fallback when timestamp absent from server event", async () => {
+  it("falls back to Date.now() when server event has no timestamp", () => {
     const beforeTs = Date.now();
     const opts = makeOpts();
-    await openParentWs(opts);
+    openParentWs(opts);
 
-    mockWsInstances[0].fire("message", {
-      data: JSON.stringify({ event: "scroll" }),
+    dispatchMessageFrom(opts.iframe.contentWindow, {
+      type: "taos-copilot:server-event",
+      agentId: "agent-1",
+      message: { event: "scroll" },
     });
 
     const afterTs = Date.now();
@@ -209,14 +188,29 @@ describe("openParentWs", () => {
     expect(received.timestamp).toBeLessThanOrEqual(afterTs);
   });
 
-  it("if mintCopilotTicket returns null, calls onClose immediately and isOpen stays false", async () => {
-    vi.mocked(browserAgentApi.mintCopilotTicket).mockResolvedValue(null);
-
+  it("handle.close() removes the listener and fires onClose", () => {
     const opts = makeOpts();
-    const handle = await openParentWs(opts);
+    const handle = openParentWs(opts);
 
-    expect(MockWebSocket).not.toHaveBeenCalled();
-    expect(opts.onClose).toHaveBeenCalledOnce();
+    handle.close();
     expect(handle.isOpen).toBe(false);
+    expect(opts.onClose).toHaveBeenCalledOnce();
+
+    // Subsequent messages should be ignored
+    dispatchMessageFrom(opts.iframe.contentWindow, {
+      type: "taos-copilot:server-event",
+      agentId: "agent-1",
+      message: { event: "page-changed" },
+    });
+    expect(opts.onEvent).not.toHaveBeenCalled();
+  });
+
+  it("close() is idempotent — second call is a no-op", () => {
+    const opts = makeOpts();
+    const handle = openParentWs(opts);
+
+    handle.close();
+    handle.close();
+    expect(opts.onClose).toHaveBeenCalledOnce();
   });
 });

--- a/desktop/src/apps/BrowserApp/agent-ws-bridge.ts
+++ b/desktop/src/apps/BrowserApp/agent-ws-bridge.ts
@@ -1,0 +1,98 @@
+/**
+ * agent-ws-bridge — parent-side WebSocket for one (windowId, tabId, agentId).
+ *
+ * Mints a copilot ticket then opens a WS to /api/desktop/browser/copilot.
+ * Server events arrive as { event: "page-changed", ... }; the bridge
+ * normalises them to { kind: "page-changed", ... } to match AgentEvent in
+ * browser-agent-store.
+ *
+ * No reconnect logic in PR 6. WS closes → stays closed until next mount.
+ * PR 7 will add reconnect-with-backoff if UX warrants it.
+ */
+import { mintCopilotTicket } from "@/lib/browser-agent-api";
+import type { AgentEvent } from "@/stores/browser-agent-store";
+
+export interface AgentWsBridgeOptions {
+  windowId: string;
+  tabId: string;
+  agentId: string;
+  profileId: string;
+  /** Called when the WS receives an event. Caller dispatches to stores. */
+  onEvent: (event: AgentEvent) => void;
+  /** Called once when the WS opens, useful for tests. */
+  onOpen?: () => void;
+  /** Called when the WS closes (any reason). */
+  onClose?: () => void;
+}
+
+export interface AgentWsHandle {
+  close(): void;
+  /** True after onOpen fires; helpful for tests. */
+  readonly isOpen: boolean;
+}
+
+/** Mints a ticket then opens a WS to /api/desktop/browser/copilot.
+ * If ticket minting fails (null), the handle's onClose fires immediately
+ * and isOpen stays false — caller can decide whether to retry.
+ */
+export async function openParentWs(opts: AgentWsBridgeOptions): Promise<AgentWsHandle> {
+  const ticket = await mintCopilotTicket(opts.profileId, opts.tabId, opts.agentId);
+  let isOpen = false;
+  let ws: WebSocket | null = null;
+  let closed = false;
+
+  const handle: AgentWsHandle = {
+    get isOpen() { return isOpen; },
+    close() {
+      closed = true;
+      if (ws) {
+        try { ws.close(); } catch { /* ignore */ }
+      }
+    },
+  };
+
+  if (!ticket || closed) {
+    if (opts.onClose) opts.onClose();
+    return handle;
+  }
+
+  const proto = window.location.protocol === "https:" ? "wss" : "ws";
+  const url = `${proto}://${window.location.host}/api/desktop/browser/copilot?ticket=${encodeURIComponent(ticket.ticket)}`;
+  ws = new WebSocket(url);
+
+  ws.addEventListener("open", () => {
+    isOpen = true;
+    if (opts.onOpen) opts.onOpen();
+  });
+
+  ws.addEventListener("message", (ev) => {
+    let raw: Record<string, unknown>;
+    try { raw = JSON.parse(ev.data as string); } catch { return; }
+    if (!raw || typeof raw !== "object") return;
+
+    // Server sends { event: "page-changed", url?, title?, ... }
+    // Normalise to AgentEvent shape: { kind, url?, title?, timestamp }
+    const serverKind = typeof raw.event === "string" ? raw.event : null;
+    if (!serverKind) return;
+
+    const kind = serverKind as AgentEvent["kind"];
+    // Acceptable kinds — guard against unknown event types
+    if (kind !== "page-changed" && kind !== "url-changed" && kind !== "scroll") return;
+
+    const event: AgentEvent = {
+      kind,
+      url: typeof raw.url === "string" ? raw.url : undefined,
+      title: typeof raw.title === "string" ? raw.title : undefined,
+      timestamp: typeof raw.timestamp === "number" ? raw.timestamp : Date.now(),
+    };
+
+    opts.onEvent(event);
+  });
+
+  ws.addEventListener("close", () => {
+    isOpen = false;
+    if (opts.onClose) opts.onClose();
+  });
+
+  return handle;
+}

--- a/desktop/src/apps/BrowserApp/agent-ws-bridge.ts
+++ b/desktop/src/apps/BrowserApp/agent-ws-bridge.ts
@@ -1,98 +1,99 @@
 /**
- * agent-ws-bridge — parent-side WebSocket for one (windowId, tabId, agentId).
+ * agent-ws-bridge — parent-side listener for server events from copilot.js.
  *
- * Mints a copilot ticket then opens a WS to /api/desktop/browser/copilot.
- * Server events arrive as { event: "page-changed", ... }; the bridge
- * normalises them to { kind: "page-changed", ... } to match AgentEvent in
- * browser-agent-store.
+ * The iframe (via copilot.js) holds the actual WebSocket connection to
+ * /api/desktop/browser/copilot. Server events ({event: "page-changed"}, etc.)
+ * are forwarded by copilot.js to the parent shell via postMessage, so the
+ * parent doesn't need its own WebSocket.
  *
- * No reconnect logic in PR 6. WS closes → stays closed until next mount.
- * PR 7 will add reconnect-with-backoff if UX warrants it.
+ * Why no parent WS? Both connections would register in CopilotHub under the
+ * same (user, profile, tab, agent) key, and the hub deliberately closes the
+ * prior connection on key collision. The two would clobber each other.
+ * Forwarding via postMessage from copilot.js is cleaner and avoids the second
+ * ticket mint per pinned agent.
+ *
+ * postMessage shape (sent from copilot.js, see copilot.js openConnection):
+ *   { type: "taos-copilot:server-event", agentId, message }
+ *
+ * `message` is the raw server payload — { event: "page-changed", url, title, ... }
  */
-import { mintCopilotTicket } from "@/lib/browser-agent-api";
 import type { AgentEvent } from "@/stores/browser-agent-store";
 
 export interface AgentWsBridgeOptions {
   windowId: string;
   tabId: string;
   agentId: string;
-  profileId: string;
-  /** Called when the WS receives an event. Caller dispatches to stores. */
+  /** The iframe element. Used to verify e.source matches before accepting. */
+  iframe: HTMLIFrameElement;
+  /** Called when the iframe forwards a server event. */
   onEvent: (event: AgentEvent) => void;
-  /** Called once when the WS opens, useful for tests. */
+  /** Kept for API compatibility; never fires (no separate WS). */
   onOpen?: () => void;
-  /** Called when the WS closes (any reason). */
+  /** Called when the listener is removed via close(). */
   onClose?: () => void;
 }
 
 export interface AgentWsHandle {
   close(): void;
-  /** True after onOpen fires; helpful for tests. */
+  /** Always true while the listener is registered; false after close(). */
   readonly isOpen: boolean;
 }
 
-/** Mints a ticket then opens a WS to /api/desktop/browser/copilot.
- * If ticket minting fails (null), the handle's onClose fires immediately
- * and isOpen stays false — caller can decide whether to retry.
+const ALLOWED_EVENT_KINDS: ReadonlyArray<AgentEvent["kind"]> = [
+  "page-changed",
+  "url-changed",
+  "scroll",
+];
+
+/** Register a window-level postMessage listener filtered to events forwarded
+ * from this (windowId, tabId, agentId) iframe. Returns a handle whose close()
+ * removes the listener.
+ *
+ * Synchronous — no ticket round-trip needed. The iframe's own WebSocket is
+ * authenticated separately (see TabRenderer's iframe-side ticket flow).
  */
-export async function openParentWs(opts: AgentWsBridgeOptions): Promise<AgentWsHandle> {
-  const ticket = await mintCopilotTicket(opts.profileId, opts.tabId, opts.agentId);
-  let isOpen = false;
-  let ws: WebSocket | null = null;
-  let closed = false;
+export function openParentWs(opts: AgentWsBridgeOptions): AgentWsHandle {
+  let isOpen = true;
 
-  const handle: AgentWsHandle = {
-    get isOpen() { return isOpen; },
-    close() {
-      closed = true;
-      if (ws) {
-        try { ws.close(); } catch { /* ignore */ }
-      }
-    },
-  };
+  function handleMessage(e: MessageEvent) {
+    // SECURITY: only accept messages from this specific iframe. The iframe
+    // can't fake e.source; cross-frame messages from other origins won't
+    // pass this check.
+    if (e.source !== opts.iframe.contentWindow) return;
 
-  if (!ticket || closed) {
-    if (opts.onClose) opts.onClose();
-    return handle;
-  }
+    const data = e.data;
+    if (!data || typeof data !== "object") return;
+    if (data.type !== "taos-copilot:server-event") return;
+    if (data.agentId !== opts.agentId) return;
 
-  const proto = window.location.protocol === "https:" ? "wss" : "ws";
-  const url = `${proto}://${window.location.host}/api/desktop/browser/copilot?ticket=${encodeURIComponent(ticket.ticket)}`;
-  ws = new WebSocket(url);
+    const msg = data.message;
+    if (!msg || typeof msg !== "object") return;
 
-  ws.addEventListener("open", () => {
-    isOpen = true;
-    if (opts.onOpen) opts.onOpen();
-  });
-
-  ws.addEventListener("message", (ev) => {
-    let raw: Record<string, unknown>;
-    try { raw = JSON.parse(ev.data as string); } catch { return; }
-    if (!raw || typeof raw !== "object") return;
-
-    // Server sends { event: "page-changed", url?, title?, ... }
-    // Normalise to AgentEvent shape: { kind, url?, title?, timestamp }
-    const serverKind = typeof raw.event === "string" ? raw.event : null;
+    const serverKind = typeof msg.event === "string" ? msg.event : null;
     if (!serverKind) return;
 
     const kind = serverKind as AgentEvent["kind"];
-    // Acceptable kinds — guard against unknown event types
-    if (kind !== "page-changed" && kind !== "url-changed" && kind !== "scroll") return;
+    if (!ALLOWED_EVENT_KINDS.includes(kind)) return;
 
     const event: AgentEvent = {
       kind,
-      url: typeof raw.url === "string" ? raw.url : undefined,
-      title: typeof raw.title === "string" ? raw.title : undefined,
-      timestamp: typeof raw.timestamp === "number" ? raw.timestamp : Date.now(),
+      url: typeof msg.url === "string" ? msg.url : undefined,
+      title: typeof msg.title === "string" ? msg.title : undefined,
+      timestamp: typeof msg.timestamp === "number" ? msg.timestamp : Date.now(),
     };
 
     opts.onEvent(event);
-  });
+  }
 
-  ws.addEventListener("close", () => {
-    isOpen = false;
-    if (opts.onClose) opts.onClose();
-  });
+  window.addEventListener("message", handleMessage);
 
-  return handle;
+  return {
+    get isOpen() { return isOpen; },
+    close() {
+      if (!isOpen) return;
+      isOpen = false;
+      window.removeEventListener("message", handleMessage);
+      if (opts.onClose) opts.onClose();
+    },
+  };
 }

--- a/desktop/src/apps/BrowserApp/keyboard.test.ts
+++ b/desktop/src/apps/BrowserApp/keyboard.test.ts
@@ -127,4 +127,60 @@ describe("useBrowserKeyboardShortcuts", () => {
     act(() => window.dispatchEvent(event));
     expect(addSpy).not.toHaveBeenCalled();
   });
+
+  it("Cmd+Shift+A dispatches taos-browser:open-agent-picker with windowId", () => {
+    renderHook(() =>
+      useBrowserKeyboardShortcuts({
+        windowId: TEST_WINDOW_ID,
+        hasFocus: true,
+        onOpenFind: () => {},
+      }),
+    );
+    const received: CustomEvent[] = [];
+    const listener = (e: Event) => received.push(e as CustomEvent);
+    window.addEventListener("taos-browser:open-agent-picker", listener);
+
+    act(() => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "A",
+          shiftKey: true,
+          ctrlKey: true,
+        } as any),
+      );
+    });
+
+    window.removeEventListener("taos-browser:open-agent-picker", listener);
+    expect(received).toHaveLength(1);
+    expect(received[0].detail?.windowId).toBe(TEST_WINDOW_ID);
+  });
+
+  it("Cmd+Shift+A is preventDefault'd", () => {
+    renderHook(() =>
+      useBrowserKeyboardShortcuts({
+        windowId: TEST_WINDOW_ID,
+        hasFocus: true,
+        onOpenFind: () => {},
+      }),
+    );
+    let prevented = false;
+    act(() => {
+      const event = new KeyboardEvent("keydown", {
+        key: "A",
+        shiftKey: true,
+        ctrlKey: true,
+        cancelable: true,
+      } as any);
+      Object.defineProperty(event, "defaultPrevented", {
+        get: () => prevented,
+      });
+      const origPreventDefault = event.preventDefault.bind(event);
+      event.preventDefault = () => {
+        prevented = true;
+        origPreventDefault();
+      };
+      window.dispatchEvent(event);
+      expect(prevented).toBe(true);
+    });
+  });
 });

--- a/desktop/src/apps/BrowserApp/keyboard.test.ts
+++ b/desktop/src/apps/BrowserApp/keyboard.test.ts
@@ -155,6 +155,37 @@ describe("useBrowserKeyboardShortcuts", () => {
     expect(received[0].detail?.windowId).toBe(TEST_WINDOW_ID);
   });
 
+  it("Cmd+Shift+A is suppressed when an input element has focus", () => {
+    renderHook(() =>
+      useBrowserKeyboardShortcuts({
+        windowId: TEST_WINDOW_ID,
+        hasFocus: true,
+        onOpenFind: () => {},
+      }),
+    );
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+
+    const received: Event[] = [];
+    const listener = (e: Event) => received.push(e);
+    window.addEventListener("taos-browser:open-agent-picker", listener);
+
+    act(() => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "A",
+          shiftKey: true,
+          ctrlKey: true,
+        } as any),
+      );
+    });
+
+    window.removeEventListener("taos-browser:open-agent-picker", listener);
+    input.remove();
+    expect(received).toHaveLength(0);
+  });
+
   it("Cmd+Shift+A is preventDefault'd", () => {
     renderHook(() =>
       useBrowserKeyboardShortcuts({

--- a/desktop/src/apps/BrowserApp/keyboard.ts
+++ b/desktop/src/apps/BrowserApp/keyboard.ts
@@ -21,6 +21,19 @@ export interface KeyboardShortcutsOptions {
   onOpenFind: () => void;
 }
 
+/** True when a form control has keyboard focus (input, textarea, select, contenteditable). */
+function isInputFocused(): boolean {
+  const el = document.activeElement;
+  if (!el) return false;
+  const tag = (el as HTMLElement).tagName.toLowerCase();
+  return (
+    tag === "input" ||
+    tag === "textarea" ||
+    tag === "select" ||
+    (el as HTMLElement).isContentEditable
+  );
+}
+
 const ZOOM_STEP = 0.1;
 
 function isModifierMatch(e: KeyboardEvent): boolean {
@@ -40,6 +53,20 @@ export function useBrowserKeyboardShortcuts(opts: KeyboardShortcutsOptions) {
 
     const handler = (e: KeyboardEvent) => {
       if (!isModifierMatch(e)) return;
+
+      // Cmd+Shift+A — open agent picker (check before the switch so we can
+      // guard input focus independently of the other shortcuts)
+      if (e.shiftKey && e.key.toLowerCase() === "a") {
+        if (isInputFocused()) return;
+        e.preventDefault();
+        e.stopPropagation();
+        window.dispatchEvent(
+          new CustomEvent("taos-browser:open-agent-picker", {
+            detail: { windowId },
+          }),
+        );
+        return;
+      }
 
       const store = useBrowserStore.getState();
       const win = store.windows[windowId];

--- a/desktop/src/apps/BrowserApp/types.ts
+++ b/desktop/src/apps/BrowserApp/types.ts
@@ -35,12 +35,16 @@ export interface Tab {
   readerActive?: boolean;
   /** cached extract — avoids re-fetching when toggling */
   readerExtract?: ReaderExtract | null;
+  /** Agent IDs pinned to this tab — sticky across navigation and discard. */
+  pinnedAgentIds: string[];
 }
 
 export interface RecentlyClosedTab {
   url: string;
   title: string;
   closedAt: number;
+  /** Preserved so restore brings agents back. */
+  pinnedAgentIds?: string[];
 }
 
 export interface SavedProfileTabs {

--- a/desktop/src/lib/browser-agent-api.test.ts
+++ b/desktop/src/lib/browser-agent-api.test.ts
@@ -4,6 +4,7 @@ import {
   pinAgent,
   unpinAgent,
   mintCopilotTicket,
+  listAgents,
 } from "./browser-agent-api";
 
 const originalFetch = global.fetch;
@@ -155,6 +156,45 @@ describe("unpinAgent", () => {
   it("returns false on network error", async () => {
     global.fetch = vi.fn().mockRejectedValue(new Error("offline"));
     expect(await unpinAgent("profile-1", "tab-1", "agent-1")).toBe(false);
+  });
+});
+
+describe("listAgents", () => {
+  it("returns array on 200", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => [
+        { id: "agent-1", name: "Alpha" },
+        { id: "agent-2", name: "Beta" },
+      ],
+    });
+    const result = await listAgents();
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe("agent-1");
+    expect(result[0].name).toBe("Alpha");
+  });
+
+  it("returns [] on 401", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 401 });
+    expect(await listAgents()).toEqual([]);
+  });
+
+  it("returns [] on network error", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("offline"));
+    expect(await listAgents()).toEqual([]);
+  });
+
+  it("normalises shape to { id, name } from agent dicts that have only name", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => [{ name: "my-agent" }],
+    });
+    const result = await listAgents();
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("my-agent");
+    expect(result[0].name).toBe("my-agent");
   });
 });
 

--- a/desktop/src/lib/browser-agent-api.test.ts
+++ b/desktop/src/lib/browser-agent-api.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  listPins,
+  pinAgent,
+  unpinAgent,
+  mintCopilotTicket,
+} from "./browser-agent-api";
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe("listPins", () => {
+  it("returns pins on 200", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        pins: [
+          { agent_id: "agent-1", pinned_at: "2026-01-01T00:00:00Z" },
+          { agent_id: "agent-2", pinned_at: "2026-01-02T00:00:00Z" },
+        ],
+      }),
+    });
+
+    const pins = await listPins("profile-1", "tab-1");
+    expect(pins.length).toBe(2);
+    expect(pins[0].agent_id).toBe("agent-1");
+  });
+
+  it("returns [] on 401", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 401 });
+    expect(await listPins("profile-1", "tab-1")).toEqual([]);
+  });
+
+  it("returns [] on network error", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("network failure"));
+    expect(await listPins("profile-1", "tab-1")).toEqual([]);
+  });
+
+  it("includes credentials", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ pins: [] }),
+    });
+    global.fetch = fetchMock;
+    await listPins("profile-1", "tab-1");
+    const [, opts] = fetchMock.mock.calls[0];
+    expect(opts.credentials).toBe("include");
+  });
+
+  it("encodes URL params correctly", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ pins: [] }),
+    });
+    global.fetch = fetchMock;
+    await listPins("my profile", "tab/1");
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toContain("profile_id=my+profile");
+    expect(url).toContain("tab_id=tab%2F1");
+  });
+});
+
+describe("pinAgent", () => {
+  it("returns { pinned: true } on 200", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ pinned: true }),
+    });
+
+    const result = await pinAgent("profile-1", "tab-1", "agent-1");
+    expect(result).toEqual({ pinned: true });
+  });
+
+  it("returns { error } on 400 with body", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: "max pins reached" }),
+    });
+
+    const result = await pinAgent("profile-1", "tab-1", "agent-1");
+    expect(result).toEqual({ error: "max pins reached" });
+  });
+
+  it("returns { error } on 404", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({ error: "agent not found" }),
+    });
+
+    const result = await pinAgent("profile-1", "tab-1", "agent-unknown");
+    expect(result).toEqual({ error: "agent not found" });
+  });
+
+  it("returns null on 401", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({}),
+    });
+
+    const result = await pinAgent("profile-1", "tab-1", "agent-1");
+    expect(result).toBeNull();
+  });
+
+  it("returns null on network error", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("offline"));
+    expect(await pinAgent("profile-1", "tab-1", "agent-1")).toBeNull();
+  });
+
+  it("posts JSON body with all three fields", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ pinned: true }),
+    });
+    global.fetch = fetchMock;
+
+    await pinAgent("profile-1", "tab-1", "agent-1");
+
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/desktop/browser/pins");
+    expect(opts.method).toBe("POST");
+    expect(opts.headers["content-type"]).toBe("application/json");
+    const body = JSON.parse(opts.body);
+    expect(body.profile_id).toBe("profile-1");
+    expect(body.tab_id).toBe("tab-1");
+    expect(body.agent_id).toBe("agent-1");
+  });
+});
+
+describe("unpinAgent", () => {
+  it("returns true on 204", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 204 });
+    global.fetch = fetchMock;
+
+    expect(await unpinAgent("profile-1", "tab-1", "agent-1")).toBe(true);
+
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toContain("/api/desktop/browser/pins");
+    expect(opts.method).toBe("DELETE");
+  });
+
+  it("returns false on 401", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 401 });
+    expect(await unpinAgent("profile-1", "tab-1", "agent-1")).toBe(false);
+  });
+
+  it("returns false on network error", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("offline"));
+    expect(await unpinAgent("profile-1", "tab-1", "agent-1")).toBe(false);
+  });
+});
+
+describe("mintCopilotTicket", () => {
+  it("returns { ticket, ttl_seconds } on 200", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ ticket: "tok_abc123", ttl_seconds: 30 }),
+    });
+
+    const result = await mintCopilotTicket("profile-1", "tab-1", "agent-1");
+    expect(result).toEqual({ ticket: "tok_abc123", ttl_seconds: 30 });
+  });
+
+  it("returns null on 403", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 403 });
+    expect(await mintCopilotTicket("profile-1", "tab-1", "agent-1")).toBeNull();
+  });
+
+  it("returns null on 401", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 401 });
+    expect(await mintCopilotTicket("profile-1", "tab-1", "agent-1")).toBeNull();
+  });
+
+  it("returns null on network error", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("offline"));
+    expect(await mintCopilotTicket("profile-1", "tab-1", "agent-1")).toBeNull();
+  });
+});

--- a/desktop/src/lib/browser-agent-api.ts
+++ b/desktop/src/lib/browser-agent-api.ts
@@ -1,0 +1,102 @@
+/**
+ * Fetch wrappers for /api/desktop/browser/pins and copilot ticket minting.
+ * Silent on 401 (matches other browser-* api wrappers).
+ */
+
+export interface PinDto {
+  agent_id: string;
+  pinned_at: string;
+}
+
+export interface CopilotTicket {
+  ticket: string;
+  ttl_seconds: number;
+}
+
+export async function listPins(profileId: string, tabId: string): Promise<PinDto[]> {
+  const params = new URLSearchParams({ profile_id: profileId, tab_id: tabId });
+  try {
+    const resp = await fetch(`/api/desktop/browser/pins?${params}`, {
+      credentials: "include",
+    });
+    if (!resp.ok) return [];
+    const body = await resp.json();
+    return Array.isArray(body?.pins) ? body.pins : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Returns the boolean from the backend on success, an error string on 4xx, null on network/5xx. */
+export async function pinAgent(
+  profileId: string,
+  tabId: string,
+  agentId: string,
+): Promise<{ pinned: boolean } | { error: string } | null> {
+  try {
+    const resp = await fetch("/api/desktop/browser/pins", {
+      method: "POST",
+      credentials: "include",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        profile_id: profileId,
+        tab_id: tabId,
+        agent_id: agentId,
+      }),
+    });
+    if (resp.ok) {
+      return await resp.json(); // { pinned: boolean }
+    }
+    if (resp.status === 400 || resp.status === 404) {
+      const body = await resp.json().catch(() => ({}));
+      return { error: typeof body?.error === "string" ? body.error : `HTTP ${resp.status}` };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export async function unpinAgent(
+  profileId: string,
+  tabId: string,
+  agentId: string,
+): Promise<boolean> {
+  const params = new URLSearchParams({
+    profile_id: profileId,
+    tab_id: tabId,
+    agent_id: agentId,
+  });
+  try {
+    const resp = await fetch(`/api/desktop/browser/pins?${params}`, {
+      method: "DELETE",
+      credentials: "include",
+    });
+    return resp.ok;
+  } catch {
+    return false;
+  }
+}
+
+export async function mintCopilotTicket(
+  profileId: string,
+  tabId: string,
+  agentId: string,
+): Promise<CopilotTicket | null> {
+  try {
+    const resp = await fetch("/api/desktop/browser/copilot/ticket", {
+      method: "POST",
+      credentials: "include",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        profile_id: profileId,
+        tab_id: tabId,
+        agent_id: agentId,
+      }),
+    });
+    if (!resp.ok) return null;
+    return await resp.json();
+  } catch {
+    return null;
+  }
+}

--- a/desktop/src/lib/browser-agent-api.ts
+++ b/desktop/src/lib/browser-agent-api.ts
@@ -3,6 +3,37 @@
  * Silent on 401 (matches other browser-* api wrappers).
  */
 
+export interface AgentDto {
+  id: string;
+  name: string;
+  emoji?: string;
+  framework?: string;
+  [key: string]: unknown;
+}
+
+/** Returns the agent list from /api/agents. Returns [] on any error or auth failure. */
+export async function listAgents(): Promise<AgentDto[]> {
+  try {
+    const resp = await fetch("/api/agents", { credentials: "include" });
+    if (!resp.ok) return [];
+    const body = await resp.json();
+    const list: unknown[] = Array.isArray(body) ? body : [];
+    return list.map((item) => {
+      const agent = item as Record<string, unknown>;
+      const id =
+        typeof agent.id === "string" && agent.id
+          ? agent.id
+          : typeof agent.name === "string"
+          ? agent.name
+          : "";
+      const name = typeof agent.name === "string" ? agent.name : id;
+      return { ...agent, id, name } as AgentDto;
+    });
+  } catch {
+    return [];
+  }
+}
+
 export interface PinDto {
   agent_id: string;
   pinned_at: string;

--- a/desktop/src/stores/browser-agent-store.test.ts
+++ b/desktop/src/stores/browser-agent-store.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  useBrowserAgentStore,
+  MIN_PANEL_WIDTH,
+  MAX_PANEL_WIDTH,
+  DEFAULT_PANEL_WIDTH,
+  WATCHING_DECAY_MS,
+} from "./browser-agent-store";
+
+beforeEach(() => {
+  useBrowserAgentStore.setState({ panels: {}, lastEventAt: {} });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("browser-agent-store: openPanel", () => {
+  it("creates a new panel entry with default width when none exists", () => {
+    const s = useBrowserAgentStore.getState();
+    s.openPanel("win-1", "tab-1", "agent-a");
+
+    const panel = useBrowserAgentStore.getState().panels["win-1:tab-1"];
+    expect(panel).toBeDefined();
+    expect(panel.isOpen).toBe(true);
+    expect(panel.activeAgentId).toBe("agent-a");
+    expect(panel.width).toBe(DEFAULT_PANEL_WIDTH);
+  });
+
+  it("preserves existing width when re-opening", () => {
+    const s = useBrowserAgentStore.getState();
+    s.openPanel("win-1", "tab-1", "agent-a");
+    s.setPanelWidth("win-1", "tab-1", 350);
+    s.closePanel("win-1", "tab-1");
+    s.openPanel("win-1", "tab-1", "agent-b");
+
+    const panel = useBrowserAgentStore.getState().panels["win-1:tab-1"];
+    expect(panel.width).toBe(350);
+    expect(panel.isOpen).toBe(true);
+    expect(panel.activeAgentId).toBe("agent-b");
+  });
+});
+
+describe("browser-agent-store: closePanel", () => {
+  it("sets isOpen to false without removing the entry", () => {
+    const s = useBrowserAgentStore.getState();
+    s.openPanel("win-1", "tab-1", "agent-a");
+    s.closePanel("win-1", "tab-1");
+
+    const panel = useBrowserAgentStore.getState().panels["win-1:tab-1"];
+    expect(panel).toBeDefined();
+    expect(panel.isOpen).toBe(false);
+  });
+
+  it("is a no-op if panel doesn't exist", () => {
+    const s = useBrowserAgentStore.getState();
+    s.closePanel("win-1", "tab-missing");
+    expect(useBrowserAgentStore.getState().panels["win-1:tab-missing"]).toBeUndefined();
+  });
+});
+
+describe("browser-agent-store: setPanelWidth", () => {
+  it("clamps width below min to 240", () => {
+    const s = useBrowserAgentStore.getState();
+    s.openPanel("win-1", "tab-1", "agent-a");
+    s.setPanelWidth("win-1", "tab-1", 100);
+
+    const panel = useBrowserAgentStore.getState().panels["win-1:tab-1"];
+    expect(panel.width).toBe(MIN_PANEL_WIDTH);
+  });
+
+  it("clamps width above max to 480", () => {
+    const s = useBrowserAgentStore.getState();
+    s.openPanel("win-1", "tab-1", "agent-a");
+    s.setPanelWidth("win-1", "tab-1", 999);
+
+    const panel = useBrowserAgentStore.getState().panels["win-1:tab-1"];
+    expect(panel.width).toBe(MAX_PANEL_WIDTH);
+  });
+
+  it("accepts width within range", () => {
+    const s = useBrowserAgentStore.getState();
+    s.openPanel("win-1", "tab-1", "agent-a");
+    s.setPanelWidth("win-1", "tab-1", 320);
+
+    const panel = useBrowserAgentStore.getState().panels["win-1:tab-1"];
+    expect(panel.width).toBe(320);
+  });
+
+  it("is a no-op if panel doesn't exist (must be opened first)", () => {
+    const s = useBrowserAgentStore.getState();
+    s.setPanelWidth("win-1", "tab-missing", 300);
+    expect(useBrowserAgentStore.getState().panels["win-1:tab-missing"]).toBeUndefined();
+  });
+});
+
+describe("browser-agent-store: togglePanel", () => {
+  it("opens when closed", () => {
+    const s = useBrowserAgentStore.getState();
+    // Panel doesn't exist yet (treated as closed)
+    s.togglePanel("win-1", "tab-1", "agent-a");
+
+    const panel = useBrowserAgentStore.getState().panels["win-1:tab-1"];
+    expect(panel.isOpen).toBe(true);
+  });
+
+  it("closes when open", () => {
+    const s = useBrowserAgentStore.getState();
+    s.openPanel("win-1", "tab-1", "agent-a");
+    s.togglePanel("win-1", "tab-1", "agent-a");
+
+    const panel = useBrowserAgentStore.getState().panels["win-1:tab-1"];
+    expect(panel.isOpen).toBe(false);
+  });
+});
+
+describe("browser-agent-store: setActiveAgent", () => {
+  it("updates active agent when panel exists", () => {
+    const s = useBrowserAgentStore.getState();
+    s.openPanel("win-1", "tab-1", "agent-a");
+    s.setActiveAgent("win-1", "tab-1", "agent-b");
+
+    const panel = useBrowserAgentStore.getState().panels["win-1:tab-1"];
+    expect(panel.activeAgentId).toBe("agent-b");
+  });
+
+  it("is a no-op if panel doesn't exist", () => {
+    const s = useBrowserAgentStore.getState();
+    s.setActiveAgent("win-1", "tab-missing", "agent-a");
+    expect(useBrowserAgentStore.getState().panels["win-1:tab-missing"]).toBeUndefined();
+  });
+});
+
+describe("browser-agent-store: bumpEventAt + isWatching", () => {
+  it("isWatching returns true within WATCHING_DECAY_MS of bumpEventAt", () => {
+    vi.useFakeTimers();
+    const now = Date.now();
+    vi.setSystemTime(now);
+
+    const s = useBrowserAgentStore.getState();
+    s.bumpEventAt("win-1", "tab-1", "agent-a");
+
+    expect(useBrowserAgentStore.getState().isWatching("win-1", "tab-1", "agent-a")).toBe(true);
+  });
+
+  it("isWatching returns false after WATCHING_DECAY_MS expires (use vi.useFakeTimers)", () => {
+    vi.useFakeTimers();
+    const now = Date.now();
+    vi.setSystemTime(now);
+
+    const s = useBrowserAgentStore.getState();
+    s.bumpEventAt("win-1", "tab-1", "agent-a");
+
+    vi.setSystemTime(now + WATCHING_DECAY_MS + 1);
+    expect(useBrowserAgentStore.getState().isWatching("win-1", "tab-1", "agent-a")).toBe(false);
+  });
+
+  it("isWatching returns false when no event has been bumped", () => {
+    const s = useBrowserAgentStore.getState();
+    expect(s.isWatching("win-1", "tab-1", "agent-nobody")).toBe(false);
+  });
+
+  it("bumpEventAt accepts an explicit timestamp", () => {
+    vi.useFakeTimers();
+    const explicitTs = Date.now() - 1000; // 1 second ago
+
+    const s = useBrowserAgentStore.getState();
+    s.bumpEventAt("win-1", "tab-1", "agent-a", explicitTs);
+
+    const stored = useBrowserAgentStore.getState().lastEventAt["win-1:tab-1:agent-a"];
+    expect(stored).toBe(explicitTs);
+    // Should still be watching (1s < WATCHING_DECAY_MS=3s)
+    expect(useBrowserAgentStore.getState().isWatching("win-1", "tab-1", "agent-a")).toBe(true);
+  });
+});

--- a/desktop/src/stores/browser-agent-store.test.ts
+++ b/desktop/src/stores/browser-agent-store.test.ts
@@ -5,10 +5,16 @@ import {
   MAX_PANEL_WIDTH,
   DEFAULT_PANEL_WIDTH,
   WATCHING_DECAY_MS,
+  MAX_RECENT_EVENTS,
 } from "./browser-agent-store";
 
 beforeEach(() => {
-  useBrowserAgentStore.setState({ panels: {}, lastEventAt: {} });
+  useBrowserAgentStore.setState({
+    panels: {},
+    lastEventAt: {},
+    messages: {},
+    recentEvents: {},
+  });
 });
 
 afterEach(() => {
@@ -171,5 +177,92 @@ describe("browser-agent-store: bumpEventAt + isWatching", () => {
     expect(stored).toBe(explicitTs);
     // Should still be watching (1s < WATCHING_DECAY_MS=3s)
     expect(useBrowserAgentStore.getState().isWatching("win-1", "tab-1", "agent-a")).toBe(true);
+  });
+});
+
+describe("browser-agent-store: appendMessage", () => {
+  it("appends a message to an empty thread", () => {
+    const s = useBrowserAgentStore.getState();
+    s.appendMessage("win-1", "tab-1", "agent-a", {
+      id: "msg-1",
+      author: "user",
+      content: "Hello",
+      timestamp: 1000,
+    });
+
+    const msgs = useBrowserAgentStore.getState().messages["win-1:tab-1:agent-a"];
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].content).toBe("Hello");
+    expect(msgs[0].author).toBe("user");
+  });
+
+  it("appends multiple messages in order", () => {
+    const s = useBrowserAgentStore.getState();
+    s.appendMessage("win-1", "tab-1", "agent-a", { id: "1", author: "user", content: "First", timestamp: 1000 });
+    s.appendMessage("win-1", "tab-1", "agent-a", { id: "2", author: "agent", content: "Second", timestamp: 2000 });
+
+    const msgs = useBrowserAgentStore.getState().messages["win-1:tab-1:agent-a"];
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0].content).toBe("First");
+    expect(msgs[1].content).toBe("Second");
+  });
+
+  it("keeps threads for different (tab, agent) pairs separate", () => {
+    const s = useBrowserAgentStore.getState();
+    s.appendMessage("win-1", "tab-1", "agent-a", { id: "1", author: "user", content: "Tab1 A", timestamp: 1000 });
+    s.appendMessage("win-1", "tab-1", "agent-b", { id: "2", author: "user", content: "Tab1 B", timestamp: 1000 });
+
+    const msgsA = useBrowserAgentStore.getState().messages["win-1:tab-1:agent-a"];
+    const msgsB = useBrowserAgentStore.getState().messages["win-1:tab-1:agent-b"];
+    expect(msgsA).toHaveLength(1);
+    expect(msgsB).toHaveLength(1);
+    expect(msgsA[0].content).toBe("Tab1 A");
+    expect(msgsB[0].content).toBe("Tab1 B");
+  });
+});
+
+describe("browser-agent-store: appendEvent", () => {
+  it("appends an event to an empty list", () => {
+    const s = useBrowserAgentStore.getState();
+    s.appendEvent("win-1", "tab-1", "agent-a", {
+      kind: "page-changed",
+      title: "Example",
+      url: "https://example.com",
+      timestamp: 1000,
+    });
+
+    const events = useBrowserAgentStore.getState().recentEvents["win-1:tab-1:agent-a"];
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe("page-changed");
+    expect(events[0].title).toBe("Example");
+  });
+
+  it(`caps events at MAX_RECENT_EVENTS (${MAX_RECENT_EVENTS})`, () => {
+    const s = useBrowserAgentStore.getState();
+    for (let i = 0; i < MAX_RECENT_EVENTS + 2; i++) {
+      s.appendEvent("win-1", "tab-1", "agent-a", {
+        kind: "url-changed",
+        url: `https://example.com/${i}`,
+        timestamp: 1000 + i,
+      });
+    }
+
+    const events = useBrowserAgentStore.getState().recentEvents["win-1:tab-1:agent-a"];
+    expect(events).toHaveLength(MAX_RECENT_EVENTS);
+    // Should keep the most recent events (last MAX_RECENT_EVENTS)
+    expect(events[events.length - 1].url).toBe(`https://example.com/${MAX_RECENT_EVENTS + 1}`);
+  });
+
+  it("keeps events for different (tab, agent) pairs separate", () => {
+    const s = useBrowserAgentStore.getState();
+    s.appendEvent("win-1", "tab-1", "agent-a", { kind: "scroll", timestamp: 1000 });
+    s.appendEvent("win-1", "tab-1", "agent-b", { kind: "page-changed", title: "B", timestamp: 1000 });
+
+    const eventsA = useBrowserAgentStore.getState().recentEvents["win-1:tab-1:agent-a"];
+    const eventsB = useBrowserAgentStore.getState().recentEvents["win-1:tab-1:agent-b"];
+    expect(eventsA).toHaveLength(1);
+    expect(eventsB).toHaveLength(1);
+    expect(eventsA[0].kind).toBe("scroll");
+    expect(eventsB[0].kind).toBe("page-changed");
   });
 });

--- a/desktop/src/stores/browser-agent-store.ts
+++ b/desktop/src/stores/browser-agent-store.ts
@@ -1,0 +1,125 @@
+import { create } from "zustand";
+
+const MIN_PANEL_WIDTH = 240;
+const MAX_PANEL_WIDTH = 480;
+const DEFAULT_PANEL_WIDTH = 280;
+const WATCHING_DECAY_MS = 3000;
+
+export interface AgentPanelState {
+  isOpen: boolean;
+  activeAgentId: string | null;
+  width: number;
+}
+
+export interface BrowserAgentState {
+  /** Per-(windowId, tabId) panel state. Key: `${windowId}:${tabId}`. */
+  panels: Record<string, AgentPanelState>;
+
+  /** Per-(windowId, tabId, agentId) timestamp of the last WS event received.
+   * Used by AgentPresencePill to compute the "watching" pulse state.
+   * Key: `${windowId}:${tabId}:${agentId}`. */
+  lastEventAt: Record<string, number>;
+
+  openPanel(windowId: string, tabId: string, agentId: string): void;
+  closePanel(windowId: string, tabId: string): void;
+  togglePanel(windowId: string, tabId: string, agentId: string): void;
+  setActiveAgent(windowId: string, tabId: string, agentId: string): void;
+  setPanelWidth(windowId: string, tabId: string, width: number): void;
+  bumpEventAt(windowId: string, tabId: string, agentId: string, at?: number): void;
+
+  /** True if `lastEventAt` for this key is within WATCHING_DECAY_MS of now. */
+  isWatching(windowId: string, tabId: string, agentId: string): boolean;
+}
+
+export const useBrowserAgentStore = create<BrowserAgentState>((set, get) => ({
+  panels: {},
+  lastEventAt: {},
+
+  openPanel(windowId, tabId, agentId) {
+    set((state) => {
+      const key = `${windowId}:${tabId}`;
+      const existing = state.panels[key];
+      return {
+        panels: {
+          ...state.panels,
+          [key]: {
+            isOpen: true,
+            activeAgentId: agentId,
+            width: existing?.width ?? DEFAULT_PANEL_WIDTH,
+          },
+        },
+      };
+    });
+  },
+
+  closePanel(windowId, tabId) {
+    set((state) => {
+      const key = `${windowId}:${tabId}`;
+      const existing = state.panels[key];
+      if (!existing) return state;
+      return {
+        panels: {
+          ...state.panels,
+          [key]: { ...existing, isOpen: false },
+        },
+      };
+    });
+  },
+
+  togglePanel(windowId, tabId, agentId) {
+    const key = `${windowId}:${tabId}`;
+    const existing = get().panels[key];
+    if (existing?.isOpen) {
+      get().closePanel(windowId, tabId);
+    } else {
+      get().openPanel(windowId, tabId, agentId);
+    }
+  },
+
+  setActiveAgent(windowId, tabId, agentId) {
+    set((state) => {
+      const key = `${windowId}:${tabId}`;
+      const existing = state.panels[key];
+      if (!existing) return state;
+      return {
+        panels: {
+          ...state.panels,
+          [key]: { ...existing, activeAgentId: agentId },
+        },
+      };
+    });
+  },
+
+  setPanelWidth(windowId, tabId, width) {
+    const clamped = Math.max(MIN_PANEL_WIDTH, Math.min(MAX_PANEL_WIDTH, width));
+    set((state) => {
+      const key = `${windowId}:${tabId}`;
+      const existing = state.panels[key];
+      if (!existing) return state;
+      return {
+        panels: {
+          ...state.panels,
+          [key]: { ...existing, width: clamped },
+        },
+      };
+    });
+  },
+
+  bumpEventAt(windowId, tabId, agentId, at) {
+    set((state) => ({
+      lastEventAt: {
+        ...state.lastEventAt,
+        [`${windowId}:${tabId}:${agentId}`]: at ?? Date.now(),
+      },
+    }));
+  },
+
+  isWatching(windowId, tabId, agentId) {
+    const ts = get().lastEventAt[`${windowId}:${tabId}:${agentId}`];
+    if (!ts) return false;
+    return Date.now() - ts < WATCHING_DECAY_MS;
+  },
+}));
+
+// Re-export the constants for tests/callers
+export { MIN_PANEL_WIDTH, MAX_PANEL_WIDTH, DEFAULT_PANEL_WIDTH, WATCHING_DECAY_MS };

--- a/desktop/src/stores/browser-agent-store.ts
+++ b/desktop/src/stores/browser-agent-store.ts
@@ -11,6 +11,24 @@ export interface AgentPanelState {
   width: number;
 }
 
+/** A chat message in the local in-memory thread for a (tab, agent) pair. */
+export interface AgentMessage {
+  id: string;
+  author: "user" | "agent";
+  content: string;
+  timestamp: number;
+}
+
+/** A recent browser event recorded per (tab, agent). */
+export interface AgentEvent {
+  kind: "page-changed" | "url-changed" | "scroll";
+  url?: string;
+  title?: string;
+  timestamp: number;
+}
+
+const MAX_RECENT_EVENTS = 5;
+
 export interface BrowserAgentState {
   /** Per-(windowId, tabId) panel state. Key: `${windowId}:${tabId}`. */
   panels: Record<string, AgentPanelState>;
@@ -19,6 +37,12 @@ export interface BrowserAgentState {
    * Used by AgentPresencePill to compute the "watching" pulse state.
    * Key: `${windowId}:${tabId}:${agentId}`. */
   lastEventAt: Record<string, number>;
+
+  /** Chat thread per (tab, agent). Key: `${windowId}:${tabId}:${agentId}`. */
+  messages: Record<string, AgentMessage[]>;
+
+  /** Recent page events per (tab, agent). Key: same. Capped at last 5 per key. */
+  recentEvents: Record<string, AgentEvent[]>;
 
   openPanel(windowId: string, tabId: string, agentId: string): void;
   closePanel(windowId: string, tabId: string): void;
@@ -29,11 +53,16 @@ export interface BrowserAgentState {
 
   /** True if `lastEventAt` for this key is within WATCHING_DECAY_MS of now. */
   isWatching(windowId: string, tabId: string, agentId: string): boolean;
+
+  appendMessage(windowId: string, tabId: string, agentId: string, message: AgentMessage): void;
+  appendEvent(windowId: string, tabId: string, agentId: string, event: AgentEvent): void;
 }
 
 export const useBrowserAgentStore = create<BrowserAgentState>((set, get) => ({
   panels: {},
   lastEventAt: {},
+  messages: {},
+  recentEvents: {},
 
   openPanel(windowId, tabId, agentId) {
     set((state) => {
@@ -119,7 +148,34 @@ export const useBrowserAgentStore = create<BrowserAgentState>((set, get) => ({
     if (!ts) return false;
     return Date.now() - ts < WATCHING_DECAY_MS;
   },
+
+  appendMessage(windowId, tabId, agentId, message) {
+    set((state) => {
+      const key = `${windowId}:${tabId}:${agentId}`;
+      const existing = state.messages[key] ?? [];
+      return {
+        messages: {
+          ...state.messages,
+          [key]: [...existing, message],
+        },
+      };
+    });
+  },
+
+  appendEvent(windowId, tabId, agentId, event) {
+    set((state) => {
+      const key = `${windowId}:${tabId}:${agentId}`;
+      const existing = state.recentEvents[key] ?? [];
+      const updated = [...existing, event].slice(-MAX_RECENT_EVENTS);
+      return {
+        recentEvents: {
+          ...state.recentEvents,
+          [key]: updated,
+        },
+      };
+    });
+  },
 }));
 
-// Re-export the constants for tests/callers
-export { MIN_PANEL_WIDTH, MAX_PANEL_WIDTH, DEFAULT_PANEL_WIDTH, WATCHING_DECAY_MS };
+// Re-export constants for tests/callers
+export { MIN_PANEL_WIDTH, MAX_PANEL_WIDTH, DEFAULT_PANEL_WIDTH, WATCHING_DECAY_MS, MAX_RECENT_EVENTS };

--- a/desktop/src/stores/browser-store.test.ts
+++ b/desktop/src/stores/browser-store.test.ts
@@ -536,3 +536,105 @@ describe("browser-store: switchProfile snapshot/restore", () => {
     expect(win2?._savedTabsByProfile?.personal).toBeUndefined(); // Just restored
   });
 });
+
+describe("browser-store: pinnedAgentIds", () => {
+  beforeEach(async () => {
+    const mod = await import("./browser-store");
+    mod.useBrowserStore.setState({ windows: {} });
+  });
+
+  it("addTab initialises pinnedAgentIds as []", async () => {
+    const s = await freshStore();
+    s.createWindow("win-1", "personal");
+    const tabId = s.addTab("win-1", "https://example.test/");
+    const tab = s.getWindow("win-1")!.tabs.find((t) => t.id === tabId);
+    expect(tab?.pinnedAgentIds).toEqual([]);
+  });
+
+  it("addPinnedAgent appends an id", async () => {
+    const s = await freshStore();
+    s.createWindow("win-1", "personal");
+    const tabId = s.getWindow("win-1")!.tabs[0].id;
+
+    s.addPinnedAgent("win-1", tabId, "agent-1");
+    const tab = s.getWindow("win-1")!.tabs[0];
+    expect(tab.pinnedAgentIds).toEqual(["agent-1"]);
+  });
+
+  it("addPinnedAgent dedupes if already present", async () => {
+    const s = await freshStore();
+    s.createWindow("win-1", "personal");
+    const tabId = s.getWindow("win-1")!.tabs[0].id;
+
+    s.addPinnedAgent("win-1", tabId, "agent-1");
+    s.addPinnedAgent("win-1", tabId, "agent-1");
+    const tab = s.getWindow("win-1")!.tabs[0];
+    expect(tab.pinnedAgentIds).toEqual(["agent-1"]);
+  });
+
+  it("removePinnedAgent removes an id", async () => {
+    const s = await freshStore();
+    s.createWindow("win-1", "personal");
+    const tabId = s.getWindow("win-1")!.tabs[0].id;
+
+    s.addPinnedAgent("win-1", tabId, "agent-1");
+    s.addPinnedAgent("win-1", tabId, "agent-2");
+    s.removePinnedAgent("win-1", tabId, "agent-1");
+
+    const tab = s.getWindow("win-1")!.tabs[0];
+    expect(tab.pinnedAgentIds).toEqual(["agent-2"]);
+  });
+
+  it("navigateTab preserves pinnedAgentIds (sticky pin)", async () => {
+    const s = await freshStore();
+    s.createWindow("win-1", "personal");
+    const tabId = s.getWindow("win-1")!.tabs[0].id;
+
+    s.addPinnedAgent("win-1", tabId, "agent-1");
+    s.navigateTab("win-1", tabId, "https://new-page.test/");
+
+    const tab = s.getWindow("win-1")!.tabs[0];
+    expect(tab.pinnedAgentIds).toEqual(["agent-1"]);
+  });
+
+  it("markTabDiscarded preserves pinnedAgentIds", async () => {
+    const s = await freshStore();
+    s.createWindow("win-1", "personal");
+    const tabId = s.getWindow("win-1")!.tabs[0].id;
+
+    s.addPinnedAgent("win-1", tabId, "agent-1");
+    s.markTabDiscarded("win-1", tabId);
+
+    const tab = s.getWindow("win-1")!.tabs[0];
+    expect(tab.pinnedAgentIds).toEqual(["agent-1"]);
+  });
+
+  it("closeTab snapshot includes pinnedAgentIds in recentlyClosed", async () => {
+    const s = await freshStore();
+    s.createWindow("win-1", "personal");
+    const tabId = s.addTab("win-1", "https://pinned.test/");
+
+    s.addPinnedAgent("win-1", tabId, "agent-1");
+    s.closeTab("win-1", tabId);
+
+    const win = s.getWindow("win-1");
+    expect(win?.recentlyClosed[0].pinnedAgentIds).toEqual(["agent-1"]);
+  });
+
+  it("restoring a closed tab preserves pinnedAgentIds", async () => {
+    const s = await freshStore();
+    s.createWindow("win-1", "personal");
+    const tabId = s.addTab("win-1", "https://pinned.test/");
+
+    s.addPinnedAgent("win-1", tabId, "agent-1");
+    s.addPinnedAgent("win-1", tabId, "agent-2");
+    s.closeTab("win-1", tabId);
+
+    s.restoreClosedTab("win-1");
+
+    const win = s.getWindow("win-1");
+    const restored = win?.tabs.find((t) => t.url === "https://pinned.test/");
+    expect(restored).toBeDefined();
+    expect(restored?.pinnedAgentIds).toEqual(["agent-1", "agent-2"]);
+  });
+});

--- a/desktop/src/stores/browser-store.ts
+++ b/desktop/src/stores/browser-store.ts
@@ -37,6 +37,7 @@ function makeTab(url: string = NEW_TAB_URL): Tab {
     zoom: 1.0,
     state: "live",
     lastActiveAt: Date.now(),
+    pinnedAgentIds: [],
   };
 }
 
@@ -51,6 +52,7 @@ interface BrowserStore {
   // Tab lifecycle
   addTab: (windowId: string, url?: string) => string;
   closeTab: (windowId: string, tabId: string) => void;
+  restoreClosedTab: (windowId: string) => void;
   setActiveTab: (windowId: string, tabId: string) => void;
   pinTab: (windowId: string, tabId: string) => void;
   unpinTab: (windowId: string, tabId: string) => void;
@@ -88,6 +90,10 @@ interface BrowserStore {
     tabId: string,
     patch: Partial<Pick<Tab, "readerAvailable" | "readerActive" | "readerExtract">>,
   ) => void;
+
+  // Agent pin set — local state mutations; server calls happen via browser-agent-api.ts
+  addPinnedAgent: (windowId: string, tabId: string, agentId: string) => void;
+  removePinnedAgent: (windowId: string, tabId: string, agentId: string) => void;
 }
 
 export const useBrowserStore = create<BrowserStore>((set, get) => ({
@@ -150,6 +156,7 @@ export const useBrowserStore = create<BrowserStore>((set, get) => ({
         url: closing.url,
         title: closing.title,
         closedAt: Date.now(),
+        pinnedAgentIds: closing.pinnedAgentIds ?? [],
       };
 
       const remainingTabs = win.tabs.filter((_, i) => i !== closingIdx);
@@ -176,6 +183,30 @@ export const useBrowserStore = create<BrowserStore>((set, get) => ({
         tabs: tabsAfter,
         activeTabId: newActiveId,
         recentlyClosed: [closedEntry, ...win.recentlyClosed].slice(0, MAX_RECENTLY_CLOSED),
+      };
+      return { windows: { ...s.windows, [windowId]: updated } };
+    });
+  },
+
+  restoreClosedTab(windowId) {
+    set((s) => {
+      const win = s.windows[windowId];
+      if (!win || win.recentlyClosed.length === 0) return s;
+
+      const entry = win.recentlyClosed[0];
+      const remaining = win.recentlyClosed.slice(1);
+      if (!entry) return s;
+
+      const restored = makeTab(entry.url);
+      // Carry forward the pinned agents from the snapshot
+      restored.pinnedAgentIds = entry.pinnedAgentIds ?? [];
+      restored.title = entry.title;
+
+      const updated: BrowserWindowState = {
+        ...win,
+        tabs: [...win.tabs, restored],
+        activeTabId: restored.id,
+        recentlyClosed: remaining,
       };
       return { windows: { ...s.windows, [windowId]: updated } };
     });
@@ -326,6 +357,20 @@ export const useBrowserStore = create<BrowserStore>((set, get) => ({
   },
   setTabReader(windowId, tabId, patch) {
     set((s) => updateTab(s, windowId, tabId, (t) => ({ ...t, ...patch })));
+  },
+
+  addPinnedAgent(windowId, tabId, agentId) {
+    set((s) => updateTab(s, windowId, tabId, (t) => {
+      if (t.pinnedAgentIds.includes(agentId)) return t;
+      return { ...t, pinnedAgentIds: [...t.pinnedAgentIds, agentId] };
+    }));
+  },
+
+  removePinnedAgent(windowId, tabId, agentId) {
+    set((s) => updateTab(s, windowId, tabId, (t) => ({
+      ...t,
+      pinnedAgentIds: t.pinnedAgentIds.filter((id) => id !== agentId),
+    })));
   },
 
   switchProfile(windowId, newProfileId) {

--- a/desktop/src/stores/browser-store.ts
+++ b/desktop/src/stores/browser-store.ts
@@ -150,6 +150,7 @@ export const useBrowserStore = create<BrowserStore>((set, get) => ({
       if (closingIdx === -1) return s;
 
       const closing = win.tabs[closingIdx];
+      if (!closing) return s;
 
       // Capture into recently-closed
       const closedEntry: RecentlyClosedTab = {
@@ -168,13 +169,16 @@ export const useBrowserStore = create<BrowserStore>((set, get) => ({
       let newActiveId = win.activeTabId;
       if (win.activeTabId === tabId) {
         if (remainingTabs.length === 0) {
-          // tabsAfter has the fresh replacement
-          newActiveId = tabsAfter[0].id;
+          // tabsAfter has the fresh replacement; tabsAfter[0] is guaranteed
+          // present because we just constructed it with [makeTab()] above.
+          const fresh = tabsAfter[0];
+          if (fresh) newActiveId = fresh.id;
         } else {
           // Activate the tab to the LEFT (next-by-index when right-of removed
           // is also fine; pick by index clamped to remainingTabs)
           const newIdx = Math.min(closingIdx, remainingTabs.length - 1);
-          newActiveId = remainingTabs[newIdx].id;
+          const newActive = remainingTabs[newIdx];
+          if (newActive) newActiveId = newActive.id;
         }
       }
 
@@ -261,10 +265,12 @@ export const useBrowserStore = create<BrowserStore>((set, get) => ({
     set((s) => updateTab(s, windowId, tabId, (t) => {
       if (t.historyIndex <= 0) return t;
       const newIdx = t.historyIndex - 1;
+      const newUrl = t.history[newIdx];
+      if (newUrl === undefined) return t;
       return {
         ...t,
         historyIndex: newIdx,
-        url: t.history[newIdx],
+        url: newUrl,
         readerAvailable: undefined,
         readerActive: undefined,
         readerExtract: null,
@@ -276,10 +282,12 @@ export const useBrowserStore = create<BrowserStore>((set, get) => ({
     set((s) => updateTab(s, windowId, tabId, (t) => {
       if (t.historyIndex >= t.history.length - 1) return t;
       const newIdx = t.historyIndex + 1;
+      const newUrl = t.history[newIdx];
+      if (newUrl === undefined) return t;
       return {
         ...t,
         historyIndex: newIdx,
-        url: t.history[newIdx],
+        url: newUrl,
         readerAvailable: undefined,
         readerActive: undefined,
         readerExtract: null,
@@ -323,14 +331,17 @@ export const useBrowserStore = create<BrowserStore>((set, get) => ({
       const closingIdx = fromWin.tabs.findIndex((t) => t.id === tabId);
       const fromTabs = fromWin.tabs.filter((t) => t.id !== tabId);
       const replacementTab = fromTabs.length === 0 ? makeTab() : null;
+      let sourceActiveId = fromWin.activeTabId;
+      if (replacementTab) {
+        sourceActiveId = replacementTab.id;
+      } else if (fromWin.activeTabId === tabId) {
+        const fallback = fromTabs[Math.min(closingIdx, fromTabs.length - 1)];
+        if (fallback) sourceActiveId = fallback.id;
+      }
       const sourceAfter: BrowserWindowState = {
         ...fromWin,
         tabs: replacementTab ? [replacementTab] : fromTabs,
-        activeTabId: replacementTab
-          ? replacementTab.id
-          : (fromWin.activeTabId === tabId
-              ? fromTabs[Math.min(closingIdx, fromTabs.length - 1)].id
-              : fromWin.activeTabId),
+        activeTabId: sourceActiveId,
       };
 
       // Insert into destination at toIndex (or append if undefined)
@@ -393,8 +404,11 @@ export const useBrowserStore = create<BrowserStore>((set, get) => ({
       // otherwise initialise with a fresh new-tab page
       const restoredSnapshot = updatedSavedMap[newProfileId];
       const restoredTabs = restoredSnapshot?.tabs ?? [makeTab()];
+      // restoredTabs is guaranteed non-empty (snapshots store non-empty tab
+      // arrays; the fallback is [makeTab()]), so restoredTabs[0] is defined.
+      const firstRestored = restoredTabs[0];
       const restoredActiveId =
-        restoredSnapshot?.activeTabId ?? restoredTabs[0].id;
+        restoredSnapshot?.activeTabId ?? (firstRestored ? firstRestored.id : "");
 
       // Drop the new profile's snapshot from the saved map (it's now active)
       const { [newProfileId]: _consumed, ...remainingSnapshots } = updatedSavedMap;

--- a/tests/routes/desktop_browser/test_agent_pin.py
+++ b/tests/routes/desktop_browser/test_agent_pin.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import time
-from datetime import datetime, UTC, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 import pytest_asyncio
@@ -305,7 +305,7 @@ async def test_check_capability_star_matches_any_host(store):
 
 @pytest.mark.asyncio
 async def test_check_capability_expired_grant_returns_false(store):
-    past = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+    past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
     await store.add_capability(
         user_id="u1", profile_id="p1", agent_id="agent-a",
         host_pattern="*", permissions="read_dom", expires_at=past,
@@ -319,7 +319,7 @@ async def test_check_capability_expired_grant_returns_false(store):
 
 @pytest.mark.asyncio
 async def test_check_capability_future_expiry_returns_true(store):
-    future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+    future = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
     await store.add_capability(
         user_id="u1", profile_id="p1", agent_id="agent-a",
         host_pattern="*", permissions="read_dom", expires_at=future,

--- a/tests/routes/desktop_browser/test_agent_pin.py
+++ b/tests/routes/desktop_browser/test_agent_pin.py
@@ -1,0 +1,336 @@
+"""Tests for agent_pins + agent_capabilities store methods on BrowserStore."""
+from __future__ import annotations
+
+import time
+from datetime import datetime, UTC, timedelta
+
+import pytest
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture
+async def store(tmp_path):
+    from tinyagentos.routes.desktop_browser.store import BrowserStore
+
+    s = BrowserStore(tmp_path / "browser.sqlite3")
+    await s.init()
+    yield s
+    await s.close()
+
+
+# ---------------------------------------------------------------------------
+# add_pin
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_add_pin_returns_true_on_first_insert(store):
+    result = await store.add_pin(
+        user_id="u1", profile_id="p1", tab_id="t1", agent_id="agent-a",
+    )
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_add_pin_returns_false_on_duplicate(store):
+    await store.add_pin(user_id="u1", profile_id="p1", tab_id="t1", agent_id="agent-a")
+    result = await store.add_pin(
+        user_id="u1", profile_id="p1", tab_id="t1", agent_id="agent-a",
+    )
+    assert result is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kwargs,match", [
+    ({"user_id": "",   "profile_id": "p1", "tab_id": "t1", "agent_id": "a"}, "user_id"),
+    ({"user_id": "u1", "profile_id": "",   "tab_id": "t1", "agent_id": "a"}, "profile_id"),
+    ({"user_id": "u1", "profile_id": "p1", "tab_id": "",   "agent_id": "a"}, "tab_id"),
+    ({"user_id": "u1", "profile_id": "p1", "tab_id": "t1", "agent_id": ""}, "agent_id"),
+])
+async def test_add_pin_raises_on_empty_param(store, kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        await store.add_pin(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# list_pins_for_tab
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_list_pins_for_tab_returns_empty_for_unknown_tab(store):
+    result = await store.list_pins_for_tab(
+        user_id="u1", profile_id="p1", tab_id="nonexistent",
+    )
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_list_pins_for_tab_ordered_by_pinned_at_asc(store):
+    await store.add_pin(user_id="u1", profile_id="p1", tab_id="t1", agent_id="agent-first")
+    time.sleep(0.01)
+    await store.add_pin(user_id="u1", profile_id="p1", tab_id="t1", agent_id="agent-second")
+
+    pins = await store.list_pins_for_tab(user_id="u1", profile_id="p1", tab_id="t1")
+
+    assert len(pins) == 2
+    assert pins[0]["agent_id"] == "agent-first"
+    assert pins[1]["agent_id"] == "agent-second"
+    assert pins[0]["pinned_at"] <= pins[1]["pinned_at"]
+
+
+# ---------------------------------------------------------------------------
+# Multi-user + multi-profile isolation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_multi_user_isolation_list_pins_for_user(store):
+    await store.add_pin(user_id="a", profile_id="p1", tab_id="t1", agent_id="agent-x")
+
+    result = await store.list_pins_for_user(user_id="b")
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_multi_user_isolation_list_pins_for_tab(store):
+    await store.add_pin(user_id="a", profile_id="p1", tab_id="t1", agent_id="agent-x")
+
+    result = await store.list_pins_for_tab(user_id="b", profile_id="p1", tab_id="t1")
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_multi_profile_isolation_list_pins_for_tab(store):
+    await store.add_pin(user_id="u1", profile_id="profile-x", tab_id="t1", agent_id="agent-a")
+
+    result = await store.list_pins_for_tab(user_id="u1", profile_id="profile-y", tab_id="t1")
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# count_pins_for_tab
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_count_pins_for_tab_increments(store):
+    assert await store.count_pins_for_tab(user_id="u1", profile_id="p1", tab_id="t1") == 0
+
+    for i in range(5):
+        await store.add_pin(
+            user_id="u1", profile_id="p1", tab_id="t1", agent_id=f"agent-{i}",
+        )
+        assert await store.count_pins_for_tab(user_id="u1", profile_id="p1", tab_id="t1") == i + 1
+
+
+# ---------------------------------------------------------------------------
+# delete_pin
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_delete_pin_returns_true_on_hit(store):
+    await store.add_pin(user_id="u1", profile_id="p1", tab_id="t1", agent_id="agent-a")
+    result = await store.delete_pin(
+        user_id="u1", profile_id="p1", tab_id="t1", agent_id="agent-a",
+    )
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_delete_pin_returns_false_on_miss(store):
+    result = await store.delete_pin(
+        user_id="u1", profile_id="p1", tab_id="t1", agent_id="nonexistent",
+    )
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# add_capability + list_capabilities
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_add_capability_upserts_on_same_pk(store):
+    await store.add_capability(
+        user_id="u1", profile_id="p1", agent_id="agent-a",
+        host_pattern="example.com", permissions="read_dom",
+    )
+    # Second call with same PK, new permissions — should update
+    await store.add_capability(
+        user_id="u1", profile_id="p1", agent_id="agent-a",
+        host_pattern="example.com", permissions="read_dom,navigate",
+    )
+
+    caps = await store.list_capabilities(user_id="u1", profile_id="p1", agent_id="agent-a")
+    assert len(caps) == 1
+    assert caps[0]["permissions"] == "read_dom,navigate"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kwargs,match", [
+    ({"user_id": "",   "profile_id": "p1", "agent_id": "a", "host_pattern": "h", "permissions": "r"}, "user_id"),
+    ({"user_id": "u1", "profile_id": "",   "agent_id": "a", "host_pattern": "h", "permissions": "r"}, "profile_id"),
+    ({"user_id": "u1", "profile_id": "p1", "agent_id": "",  "host_pattern": "h", "permissions": "r"}, "agent_id"),
+    ({"user_id": "u1", "profile_id": "p1", "agent_id": "a", "host_pattern": "", "permissions": "r"}, "host_pattern"),
+    ({"user_id": "u1", "profile_id": "p1", "agent_id": "a", "host_pattern": "h", "permissions": ""}, "permissions"),
+])
+async def test_add_capability_raises_on_empty_param(store, kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        await store.add_capability(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# check_capability — pattern matching
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_check_capability_wildcard_subdomain_matches_subdomain(store):
+    await store.add_capability(
+        user_id="u1", profile_id="p1", agent_id="agent-a",
+        host_pattern="*.example.com", permissions="read_dom",
+    )
+    result = await store.check_capability(
+        user_id="u1", profile_id="p1", agent_id="agent-a",
+        host="foo.example.com", permission="read_dom",
+    )
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_check_capability_wildcard_subdomain_matches_root(store):
+    await store.add_capability(
+        user_id="u1", profile_id="p1", agent_id="agent-a",
+        host_pattern="*.example.com", permissions="read_dom",
+    )
+    result = await store.check_capability(
+        user_id="u1", profile_id="p1", agent_id="agent-a",
+        host="example.com", permission="read_dom",
+    )
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_check_capability_wildcard_subdomain_no_match_other(store):
+    await store.add_capability(
+        user_id="u1", profile_id="p1", agent_id="agent-a",
+        host_pattern="*.example.com", permissions="read_dom",
+    )
+    result = await store.check_capability(
+        user_id="u1", profile_id="p1", agent_id="agent-a",
+        host="other.com", permission="read_dom",
+    )
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_check_capability_star_matches_any_host(store):
+    await store.add_capability(
+        user_id="u1", profile_id="p1", agent_id="agent-a",
+        host_pattern="*", permissions="read_dom",
+    )
+    result = await store.check_capability(
+        user_id="u1", profile_id="p1", agent_id="agent-a",
+        host="anything.io", permission="read_dom",
+    )
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_check_capability_expired_grant_returns_false(store):
+    past = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+    await store.add_capability(
+        user_id="u1", profile_id="p1", agent_id="agent-a",
+        host_pattern="*", permissions="read_dom", expires_at=past,
+    )
+    result = await store.check_capability(
+        user_id="u1", profile_id="p1", agent_id="agent-a",
+        host="example.com", permission="read_dom",
+    )
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_check_capability_future_expiry_returns_true(store):
+    future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+    await store.add_capability(
+        user_id="u1", profile_id="p1", agent_id="agent-a",
+        host_pattern="*", permissions="read_dom", expires_at=future,
+    )
+    result = await store.check_capability(
+        user_id="u1", profile_id="p1", agent_id="agent-a",
+        host="example.com", permission="read_dom",
+    )
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_check_capability_permission_not_in_list_returns_false(store):
+    await store.add_capability(
+        user_id="u1", profile_id="p1", agent_id="agent-a",
+        host_pattern="*", permissions="read_dom",
+    )
+    result = await store.check_capability(
+        user_id="u1", profile_id="p1", agent_id="agent-a",
+        host="example.com", permission="drive",
+    )
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# revoke_capability
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_revoke_capability_returns_true_on_hit(store):
+    await store.add_capability(
+        user_id="u1", profile_id="p1", agent_id="agent-a",
+        host_pattern="example.com", permissions="read_dom",
+    )
+    result = await store.revoke_capability(
+        user_id="u1", profile_id="p1", agent_id="agent-a", host_pattern="example.com",
+    )
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_revoke_capability_returns_false_on_miss(store):
+    result = await store.revoke_capability(
+        user_id="u1", profile_id="p1", agent_id="agent-a", host_pattern="example.com",
+    )
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_revoke_capability_subsequent_check_returns_false(store):
+    await store.add_capability(
+        user_id="u1", profile_id="p1", agent_id="agent-a",
+        host_pattern="*", permissions="read_dom",
+    )
+    await store.revoke_capability(
+        user_id="u1", profile_id="p1", agent_id="agent-a", host_pattern="*",
+    )
+    result = await store.check_capability(
+        user_id="u1", profile_id="p1", agent_id="agent-a",
+        host="example.com", permission="read_dom",
+    )
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Multi-user / multi-profile isolation for capabilities
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_multi_user_isolation_capabilities(store):
+    await store.add_capability(
+        user_id="a", profile_id="p1", agent_id="agent-a",
+        host_pattern="*", permissions="read_dom",
+    )
+    caps = await store.list_capabilities(user_id="b", profile_id="p1")
+    assert caps == []
+
+
+@pytest.mark.asyncio
+async def test_multi_profile_isolation_capabilities(store):
+    await store.add_capability(
+        user_id="u1", profile_id="profile-x", agent_id="agent-a",
+        host_pattern="*", permissions="read_dom",
+    )
+    caps = await store.list_capabilities(user_id="u1", profile_id="profile-y")
+    assert caps == []

--- a/tests/routes/desktop_browser/test_agent_pin.py
+++ b/tests/routes/desktop_browser/test_agent_pin.py
@@ -121,6 +121,66 @@ async def test_count_pins_for_tab_increments(store):
 
 
 # ---------------------------------------------------------------------------
+# add_pin_if_under_cap (atomic count+insert)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_add_pin_if_under_cap_returns_added_on_first_insert(store):
+    result = await store.add_pin_if_under_cap(
+        user_id="u1", profile_id="p1", tab_id="t1", agent_id="a",
+        max_pins=4,
+    )
+    assert result == "added"
+
+
+@pytest.mark.asyncio
+async def test_add_pin_if_under_cap_returns_duplicate_on_existing_pin(store):
+    await store.add_pin(user_id="u1", profile_id="p1", tab_id="t1", agent_id="a")
+    result = await store.add_pin_if_under_cap(
+        user_id="u1", profile_id="p1", tab_id="t1", agent_id="a",
+        max_pins=4,
+    )
+    assert result == "duplicate"
+
+
+@pytest.mark.asyncio
+async def test_add_pin_if_under_cap_returns_at_cap_when_full(store):
+    for i in range(4):
+        await store.add_pin(
+            user_id="u1", profile_id="p1", tab_id="t1", agent_id=f"a{i}",
+        )
+    result = await store.add_pin_if_under_cap(
+        user_id="u1", profile_id="p1", tab_id="t1", agent_id="a-new",
+        max_pins=4,
+    )
+    assert result == "at_cap"
+    # Confirm the row was NOT inserted
+    pins = await store.list_pins_for_tab(user_id="u1", profile_id="p1", tab_id="t1")
+    assert len(pins) == 4
+    assert all(p["agent_id"] != "a-new" for p in pins)
+
+
+@pytest.mark.asyncio
+async def test_add_pin_if_under_cap_concurrent_does_not_exceed_cap(store):
+    """Fire 8 concurrent pins against a cap of 4 — at most 4 should succeed."""
+    import asyncio as _asyncio
+
+    results = await _asyncio.gather(*[
+        store.add_pin_if_under_cap(
+            user_id="u1", profile_id="p1", tab_id="t1", agent_id=f"a{i}",
+            max_pins=4,
+        )
+        for i in range(8)
+    ])
+    added = sum(1 for r in results if r == "added")
+    at_cap = sum(1 for r in results if r == "at_cap")
+    assert added <= 4
+    assert added + at_cap == 8
+    pins = await store.list_pins_for_tab(user_id="u1", profile_id="p1", tab_id="t1")
+    assert len(pins) <= 4
+
+
+# ---------------------------------------------------------------------------
 # delete_pin
 # ---------------------------------------------------------------------------
 

--- a/tests/routes/desktop_browser/test_agent_pin.py
+++ b/tests/routes/desktop_browser/test_agent_pin.py
@@ -141,6 +141,18 @@ async def test_delete_pin_returns_false_on_miss(store):
     assert result is False
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kwargs,match", [
+    ({"user_id": "",   "profile_id": "p1", "tab_id": "t1", "agent_id": "a"}, "user_id"),
+    ({"user_id": "u1", "profile_id": "",   "tab_id": "t1", "agent_id": "a"}, "profile_id"),
+    ({"user_id": "u1", "profile_id": "p1", "tab_id": "",   "agent_id": "a"}, "tab_id"),
+    ({"user_id": "u1", "profile_id": "p1", "tab_id": "t1", "agent_id": ""}, "agent_id"),
+])
+async def test_delete_pin_raises_on_empty_param(store, kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        await store.delete_pin(**kwargs)
+
+
 # ---------------------------------------------------------------------------
 # add_capability + list_capabilities
 # ---------------------------------------------------------------------------
@@ -334,3 +346,53 @@ async def test_multi_profile_isolation_capabilities(store):
     )
     caps = await store.list_capabilities(user_id="u1", profile_id="profile-y")
     assert caps == []
+
+
+# ---------------------------------------------------------------------------
+# revoke_capability — input validation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kwargs,match", [
+    ({"user_id": "",   "profile_id": "p1", "agent_id": "a", "host_pattern": "h"}, "user_id"),
+    ({"user_id": "u1", "profile_id": "",   "agent_id": "a", "host_pattern": "h"}, "profile_id"),
+    ({"user_id": "u1", "profile_id": "p1", "agent_id": "",  "host_pattern": "h"}, "agent_id"),
+    ({"user_id": "u1", "profile_id": "p1", "agent_id": "a", "host_pattern": ""}, "host_pattern"),
+])
+async def test_revoke_capability_raises_on_empty_param(store, kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        await store.revoke_capability(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# check_capability — suffix-attack rejection
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("host", ["evilexample.com", "xxxexample.com", "fooexample.com"])
+async def test_check_capability_wildcard_rejects_suffix_attack(store, host):
+    await store.add_capability(
+        user_id="u1", profile_id="p1", agent_id="agent-a",
+        host_pattern="*.example.com", permissions="read_dom",
+    )
+    result = await store.check_capability(
+        user_id="u1", profile_id="p1", agent_id="agent-a",
+        host=host, permission="read_dom",
+    )
+    assert result is False, f"{host!r} should not match *.example.com"
+
+
+# ---------------------------------------------------------------------------
+# check_capability — whitespace tolerance in stored permissions
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_check_capability_tolerates_whitespace_in_permissions(store):
+    await store.add_capability(
+        user_id="u1", profile_id="p1", agent_id="agent-a",
+        host_pattern="example.com", permissions="read_dom, navigate",  # space after comma
+    )
+    assert await store.check_capability(
+        user_id="u1", profile_id="p1", agent_id="agent-a",
+        host="example.com", permission="navigate",
+    ) is True

--- a/tests/routes/desktop_browser/test_agent_pin_routes.py
+++ b/tests/routes/desktop_browser/test_agent_pin_routes.py
@@ -1,0 +1,375 @@
+"""Tests for /api/desktop/browser/pins HTTP CRUD endpoints."""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock
+
+
+def _get_user_id(app):
+    """Resolve the authed admin user id from the app state."""
+    auth_mgr = app.state.auth
+    record = auth_mgr.find_user("admin")
+    return record["id"] if record else "test-admin"
+
+
+def _make_auth_client(app, tmp_data_dir):
+    """Create a second authenticated async client for multi-user isolation tests."""
+    from httpx import ASGITransport, AsyncClient
+    auth_mgr = app.state.auth
+    # Invite a second user
+    if auth_mgr.find_user("user_b") is None:
+        invite_code = auth_mgr.add_user_invite("user_b", "admin")
+        auth_mgr.complete_invite("user_b", invite_code, "user_b", "", "pass_b")
+    record = auth_mgr.find_user("user_b")
+    token = auth_mgr.create_session(user_id=record["id"], long_lived=True)
+    return AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        cookies={"taos_session": token},
+    )
+
+
+def _add_agent(app, agent_id: str):
+    """Inject a test agent into app.state.config.agents."""
+    app.state.config.agents.append({
+        "id": agent_id,
+        "name": agent_id,
+        "host": "127.0.0.1",
+        "qmd_index": "test",
+        "color": "#000000",
+    })
+
+
+# ---------------------------------------------------------------------------
+# Test 7: 401 on no auth (must come before authenticated tests)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestAgentPinAuth:
+    async def test_get_unauthenticated_returns_401(self, app):
+        from httpx import ASGITransport, AsyncClient
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            resp = await c.get(
+                "/api/desktop/browser/pins",
+                params={"profile_id": "personal", "tab_id": "t1"},
+            )
+            assert resp.status_code == 401
+
+    async def test_post_unauthenticated_returns_401(self, app):
+        from httpx import ASGITransport, AsyncClient
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            resp = await c.post(
+                "/api/desktop/browser/pins",
+                json={"profile_id": "personal", "tab_id": "t1", "agent_id": "a1"},
+            )
+            assert resp.status_code == 401
+
+    async def test_delete_unauthenticated_returns_401(self, app):
+        from httpx import ASGITransport, AsyncClient
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            resp = await c.delete(
+                "/api/desktop/browser/pins",
+                params={"profile_id": "personal", "tab_id": "t1", "agent_id": "a1"},
+            )
+            assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Test 1: GET happy path
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestListPins:
+    async def test_get_returns_empty_for_new_tab(self, client):
+        resp = await client.get(
+            "/api/desktop/browser/pins",
+            params={"profile_id": "personal", "tab_id": "t1"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body == {"pins": []}
+
+    async def test_get_returns_pinned_agents(self, client, app):
+        _add_agent(app, "agent-a")
+        await client.post(
+            "/api/desktop/browser/pins",
+            json={"profile_id": "p1", "tab_id": "t1", "agent_id": "agent-a"},
+        )
+        resp = await client.get(
+            "/api/desktop/browser/pins",
+            params={"profile_id": "p1", "tab_id": "t1"},
+        )
+        assert resp.status_code == 200
+        pins = resp.json()["pins"]
+        assert len(pins) == 1
+        assert pins[0]["agent_id"] == "agent-a"
+
+    # Test 2: GET multi-user isolation
+    async def test_get_multi_user_isolation(self, client, app, tmp_path):
+        # Seed a pin directly into the store for a different user
+        store = app.state.browser_store
+        await store.add_pin(
+            user_id="other-user", profile_id="p1", tab_id="t1", agent_id="agent-secret",
+        )
+
+        # Authed user (admin) should get empty list
+        resp = await client.get(
+            "/api/desktop/browser/pins",
+            params={"profile_id": "p1", "tab_id": "t1"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["pins"] == []
+
+
+# ---------------------------------------------------------------------------
+# Test 3: POST happy path
+# Test 4: POST idempotent
+# Test 5: POST 404 on unknown agent
+# Test 6: POST 400 on max-4
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestPinAgent:
+    async def test_post_pins_agent_returns_pinned_true(self, client, app):
+        _add_agent(app, "agent-1")
+        resp = await client.post(
+            "/api/desktop/browser/pins",
+            json={"profile_id": "p1", "tab_id": "t1", "agent_id": "agent-1"},
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"pinned": True}
+
+    async def test_post_happy_path_capability_grant_exists(self, client, app):
+        _add_agent(app, "agent-cap")
+        user_id = _get_user_id(app)
+        await client.post(
+            "/api/desktop/browser/pins",
+            json={"profile_id": "p1", "tab_id": "t1", "agent_id": "agent-cap"},
+        )
+        store = app.state.browser_store
+        has_cap = await store.check_capability(
+            user_id=user_id, profile_id="p1", agent_id="agent-cap",
+            host="anything.io", permission="read_dom",
+        )
+        assert has_cap is True
+
+    async def test_post_happy_path_list_shows_pin(self, client, app):
+        _add_agent(app, "agent-list")
+        await client.post(
+            "/api/desktop/browser/pins",
+            json={"profile_id": "p1", "tab_id": "t2", "agent_id": "agent-list"},
+        )
+        resp = await client.get(
+            "/api/desktop/browser/pins",
+            params={"profile_id": "p1", "tab_id": "t2"},
+        )
+        pins = resp.json()["pins"]
+        assert any(p["agent_id"] == "agent-list" for p in pins)
+
+    async def test_post_idempotent_returns_pinned_false(self, client, app):
+        _add_agent(app, "agent-idem")
+        await client.post(
+            "/api/desktop/browser/pins",
+            json={"profile_id": "p1", "tab_id": "t1", "agent_id": "agent-idem"},
+        )
+        resp = await client.post(
+            "/api/desktop/browser/pins",
+            json={"profile_id": "p1", "tab_id": "t1", "agent_id": "agent-idem"},
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"pinned": False}
+
+    async def test_post_unknown_agent_returns_404(self, client):
+        resp = await client.post(
+            "/api/desktop/browser/pins",
+            json={"profile_id": "p1", "tab_id": "t1", "agent_id": "no-such-agent"},
+        )
+        assert resp.status_code == 404
+        assert resp.json() == {"error": "agent not found"}
+
+    async def test_post_max_4_pins_per_tab(self, client, app):
+        for i in range(4):
+            aid = f"agent-max-{i}"
+            _add_agent(app, aid)
+            r = await client.post(
+                "/api/desktop/browser/pins",
+                json={"profile_id": "p1", "tab_id": "t-max", "agent_id": aid},
+            )
+            assert r.status_code == 200, f"pin {i} failed: {r.json()}"
+
+        # 5th agent: must fail
+        fifth = "agent-max-5th"
+        _add_agent(app, fifth)
+        resp = await client.post(
+            "/api/desktop/browser/pins",
+            json={"profile_id": "p1", "tab_id": "t-max", "agent_id": fifth},
+        )
+        assert resp.status_code == 400
+        body = resp.json()
+        assert "max 4" in body.get("error", "")
+
+
+# ---------------------------------------------------------------------------
+# Test 8: DELETE happy path
+# Test 9: DELETE on missing pin (204)
+# Test 10: DELETE multi-user isolation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestUnpinAgent:
+    async def test_delete_returns_204_and_removes_pin(self, client, app):
+        _add_agent(app, "agent-del")
+        await client.post(
+            "/api/desktop/browser/pins",
+            json={"profile_id": "p1", "tab_id": "t1", "agent_id": "agent-del"},
+        )
+        resp = await client.delete(
+            "/api/desktop/browser/pins",
+            params={"profile_id": "p1", "tab_id": "t1", "agent_id": "agent-del"},
+        )
+        assert resp.status_code == 204
+
+        # Subsequent GET should show the pin gone
+        list_resp = await client.get(
+            "/api/desktop/browser/pins",
+            params={"profile_id": "p1", "tab_id": "t1"},
+        )
+        pins = list_resp.json()["pins"]
+        assert not any(p["agent_id"] == "agent-del" for p in pins)
+
+    async def test_delete_missing_pin_returns_204(self, client):
+        resp = await client.delete(
+            "/api/desktop/browser/pins",
+            params={"profile_id": "p1", "tab_id": "t1", "agent_id": "never-pinned"},
+        )
+        assert resp.status_code == 204
+
+    async def test_delete_multi_user_isolation(self, client, app, tmp_path):
+        # Seed a pin for user A (the authed admin) via store directly
+        user_a_id = _get_user_id(app)
+        store = app.state.browser_store
+        await store.add_pin(
+            user_id=user_a_id, profile_id="p1", tab_id="t1", agent_id="agent-isolated",
+        )
+
+        # User B tries to delete it — result is 204 but pin must still be there for A
+        async with _make_auth_client(app, tmp_path) as b_client:
+            resp = await b_client.delete(
+                "/api/desktop/browser/pins",
+                params={"profile_id": "p1", "tab_id": "t1", "agent_id": "agent-isolated"},
+            )
+            assert resp.status_code == 204
+
+        # User A's pin still exists
+        pins = await store.list_pins_for_tab(
+            user_id=user_a_id, profile_id="p1", tab_id="t1",
+        )
+        assert any(p["agent_id"] == "agent-isolated" for p in pins)
+
+
+# ---------------------------------------------------------------------------
+# Test 11: pin_agent service layer — direct unit tests
+# ---------------------------------------------------------------------------
+
+class TestPinAgentService:
+    @pytest.mark.asyncio
+    async def test_agent_not_found_error_raised(self):
+        from tinyagentos.routes.desktop_browser.agent_pin import (
+            pin_agent, AgentNotFoundError,
+        )
+
+        store = AsyncMock()
+
+        async def agent_not_there(aid: str) -> bool:
+            return False
+
+        with pytest.raises(AgentNotFoundError):
+            await pin_agent(
+                store,
+                user_id="u1", profile_id="p1", tab_id="t1", agent_id="x",
+                agent_exists=agent_not_there,
+            )
+
+    @pytest.mark.asyncio
+    async def test_too_many_pins_error_raised(self):
+        from tinyagentos.routes.desktop_browser.agent_pin import (
+            pin_agent, TooManyPinsError, MAX_PINS_PER_TAB,
+        )
+
+        store = AsyncMock()
+        store.count_pins_for_tab.return_value = MAX_PINS_PER_TAB
+
+        async def agent_exists(aid: str) -> bool:
+            return True
+
+        with pytest.raises(TooManyPinsError):
+            await pin_agent(
+                store,
+                user_id="u1", profile_id="p1", tab_id="t1", agent_id="x",
+                agent_exists=agent_exists,
+            )
+
+    @pytest.mark.asyncio
+    async def test_pin_agent_auto_grants_read_dom(self):
+        from tinyagentos.routes.desktop_browser.agent_pin import pin_agent
+
+        store = AsyncMock()
+        store.count_pins_for_tab.return_value = 0
+        store.add_pin.return_value = True
+
+        async def agent_exists(aid: str) -> bool:
+            return True
+
+        result = await pin_agent(
+            store,
+            user_id="u1", profile_id="p1", tab_id="t1", agent_id="x",
+            agent_exists=agent_exists,
+        )
+
+        assert result is True
+        store.add_capability.assert_called_once_with(
+            user_id="u1", profile_id="p1", agent_id="x",
+            host_pattern="*", permissions="read_dom",
+        )
+
+    @pytest.mark.asyncio
+    async def test_pin_agent_idempotent_no_extra_capability_grant(self):
+        from tinyagentos.routes.desktop_browser.agent_pin import pin_agent
+
+        store = AsyncMock()
+        store.count_pins_for_tab.return_value = 0
+        store.add_pin.return_value = False  # already pinned
+
+        async def agent_exists(aid: str) -> bool:
+            return True
+
+        result = await pin_agent(
+            store,
+            user_id="u1", profile_id="p1", tab_id="t1", agent_id="x",
+            agent_exists=agent_exists,
+        )
+
+        assert result is False
+        store.add_capability.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unpin_agent_returns_true_on_hit(self):
+        from tinyagentos.routes.desktop_browser.agent_pin import unpin_agent
+
+        store = AsyncMock()
+        store.delete_pin.return_value = True
+
+        result = await unpin_agent(
+            store, user_id="u1", profile_id="p1", tab_id="t1", agent_id="x",
+        )
+
+        assert result is True
+        store.delete_pin.assert_called_once_with(
+            user_id="u1", profile_id="p1", tab_id="t1", agent_id="x",
+        )

--- a/tests/routes/desktop_browser/test_agent_pin_routes.py
+++ b/tests/routes/desktop_browser/test_agent_pin_routes.py
@@ -299,11 +299,11 @@ class TestPinAgentService:
     @pytest.mark.asyncio
     async def test_too_many_pins_error_raised(self):
         from tinyagentos.routes.desktop_browser.agent_pin import (
-            pin_agent, TooManyPinsError, MAX_PINS_PER_TAB,
+            pin_agent, TooManyPinsError,
         )
 
         store = AsyncMock()
-        store.count_pins_for_tab.return_value = MAX_PINS_PER_TAB
+        store.add_pin_if_under_cap.return_value = "at_cap"
 
         async def agent_exists(aid: str) -> bool:
             return True
@@ -320,8 +320,7 @@ class TestPinAgentService:
         from tinyagentos.routes.desktop_browser.agent_pin import pin_agent
 
         store = AsyncMock()
-        store.count_pins_for_tab.return_value = 0
-        store.add_pin.return_value = True
+        store.add_pin_if_under_cap.return_value = "added"
 
         async def agent_exists(aid: str) -> bool:
             return True
@@ -343,8 +342,7 @@ class TestPinAgentService:
         from tinyagentos.routes.desktop_browser.agent_pin import pin_agent
 
         store = AsyncMock()
-        store.count_pins_for_tab.return_value = 0
-        store.add_pin.return_value = False  # already pinned
+        store.add_pin_if_under_cap.return_value = "duplicate"
 
         async def agent_exists(aid: str) -> bool:
             return True

--- a/tests/routes/desktop_browser/test_copilot_js.py
+++ b/tests/routes/desktop_browser/test_copilot_js.py
@@ -1,0 +1,50 @@
+"""Tests for the /__taos/copilot.js static asset endpoint.
+
+Verifies Content-Type, Cache-Control, stable content, op-table presence,
+and the idempotent IIFE guard.  No auth required — the asset is public.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+class TestCopilotJsAsset:
+    """The /__taos/copilot.js asset is served with the right headers and is stable."""
+
+    @pytest.mark.asyncio
+    async def test_returns_javascript_content_type(self, client):
+        r = await client.get("/__taos/copilot.js")
+        assert r.status_code == 200
+        ct = r.headers["content-type"]
+        assert "application/javascript" in ct or "text/javascript" in ct
+
+    @pytest.mark.asyncio
+    async def test_caches_for_one_day(self, client):
+        r = await client.get("/__taos/copilot.js")
+        assert r.status_code == 200
+        cc = r.headers.get("cache-control", "")
+        assert "max-age=86400" in cc
+        assert "immutable" in cc
+
+    @pytest.mark.asyncio
+    async def test_serves_consistent_bytes(self, client):
+        """Two consecutive fetches return identical content (no per-request mutation)."""
+        a = await client.get("/__taos/copilot.js")
+        b = await client.get("/__taos/copilot.js")
+        assert a.status_code == 200 and b.status_code == 200
+        assert a.content == b.content
+
+    @pytest.mark.asyncio
+    async def test_contains_op_table_keys(self, client):
+        """Sanity check: the served file mentions all four read ops."""
+        r = await client.get("/__taos/copilot.js")
+        body = r.text
+        for op in ["extract", "screenshot", "scrollPosition", "findElement"]:
+            assert op in body
+
+    @pytest.mark.asyncio
+    async def test_idempotent_iife_guard(self, client):
+        """The IIFE has the __taosCopilot guard so re-running is a no-op."""
+        r = await client.get("/__taos/copilot.js")
+        body = r.text
+        assert "__taosCopilot" in body

--- a/tests/routes/desktop_browser/test_copilot_js.py
+++ b/tests/routes/desktop_browser/test_copilot_js.py
@@ -48,3 +48,27 @@ class TestCopilotJsAsset:
         r = await client.get("/__taos/copilot.js")
         body = r.text
         assert "__taosCopilot" in body
+
+    @pytest.mark.asyncio
+    async def test_uses_named_handlers_for_cleanup(self, client):
+        """The scroll and submit listeners must be named functions so the close
+        handler can remove them. Verify by content inspection."""
+        r = await client.get("/__taos/copilot.js")
+        body = r.text
+        # The cleanup pattern requires named functions or refs.
+        assert "function onScroll" in body
+        assert "function onSubmit" in body
+        assert "removeEventListener('scroll'" in body
+        assert "removeEventListener('submit'" in body
+
+    @pytest.mark.asyncio
+    async def test_uses_hasOwnProperty_guard_on_op_lookup(self, client):
+        r = await client.get("/__taos/copilot.js")
+        body = r.text
+        assert "hasOwnProperty.call" in body
+
+    @pytest.mark.asyncio
+    async def test_uses_css_escape_on_ids(self, client):
+        r = await client.get("/__taos/copilot.js")
+        body = r.text
+        assert "CSS.escape" in body or "CSS && CSS.escape" in body or "window.CSS.escape" in body

--- a/tests/routes/desktop_browser/test_copilot_ws.py
+++ b/tests/routes/desktop_browser/test_copilot_ws.py
@@ -291,6 +291,23 @@ class TestCopilotHub:
         # Must not raise
         await hub.push_event_to_pinned(user_id="u1", profile_id="p1", tab_id="t1", event=event)
 
+    @pytest.mark.asyncio
+    async def test_push_event_to_pinned_isolates_users(self):
+        """User A's push must not reach user B's iframe even when (profile, tab) IDs collide."""
+        hub = self._make_hub()
+        ws_user_a = AsyncMock()
+        ws_user_b = AsyncMock()
+
+        # Same profile/tab/agent IDs but different users — the keys differ on user_id only.
+        hub._iframe_conns[("user-a", "p1", "t1", "agent-x")] = ws_user_a
+        hub._iframe_conns[("user-b", "p1", "t1", "agent-x")] = ws_user_b
+
+        event = {"event": "page-changed", "url": "https://example.com"}
+        await hub.push_event_to_pinned(user_id="user-a", profile_id="p1", tab_id="t1", event=event)
+
+        ws_user_a.send_json.assert_awaited_once_with(event)
+        ws_user_b.send_json.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # Sync TestClient + browser_store fixture for WS endpoint tests

--- a/tests/routes/desktop_browser/test_copilot_ws.py
+++ b/tests/routes/desktop_browser/test_copilot_ws.py
@@ -1,8 +1,14 @@
-"""Tests for CopilotTicketStore and the /api/desktop/browser/copilot/ticket endpoint."""
+"""Tests for CopilotTicketStore, CopilotHub, and the copilot WebSocket endpoint."""
 from __future__ import annotations
 
+import asyncio
+from unittest.mock import AsyncMock
+
 import pytest
+import yaml
+from fastapi.testclient import TestClient
 from httpx import ASGITransport, AsyncClient
+from starlette.websockets import WebSocketDisconnect
 
 
 # ---------------------------------------------------------------------------
@@ -207,3 +213,249 @@ class TestMintTicketEndpoint:
         assert ticket is not None
         assert ticket.agent_id == "agent-consume"
         assert ticket.tab_id == "t1"
+
+
+# ---------------------------------------------------------------------------
+# CopilotHub unit tests
+# ---------------------------------------------------------------------------
+
+class TestCopilotHub:
+    def _make_hub(self):
+        from tinyagentos.routes.desktop_browser.copilot_ws import CopilotHub
+        return CopilotHub()
+
+    @pytest.mark.asyncio
+    async def test_add_iframe_replaces_prior_connection_for_same_key(self):
+        """Same key + new ws → old ws scheduled for close, new one is registered."""
+        hub = self._make_hub()
+        old_ws = AsyncMock()
+        new_ws = AsyncMock()
+
+        hub._iframe_conns[("u1", "p1", "t1", "agent-a")] = old_ws
+        hub.add_iframe(user_id="u1", profile_id="p1", tab_id="t1", agent_id="agent-a", ws=new_ws)
+
+        assert hub._iframe_conns[("u1", "p1", "t1", "agent-a")] is new_ws
+        assert ("u1", "p1", "t1", "agent-a") in hub._iframe_conns
+
+    def test_remove_iframe_is_noop_when_not_present(self):
+        hub = self._make_hub()
+        # Must not raise even if the key was never registered.
+        hub.remove_iframe(user_id="u1", profile_id="p1", tab_id="t1", agent_id="no-such")
+
+    @pytest.mark.asyncio
+    async def test_push_event_to_pinned_fans_out_to_all_agents_on_tab(self):
+        """Add 3 iframes for same (user, profile, tab) different agents.
+        push_event_to_pinned → all 3 receive the event."""
+        hub = self._make_hub()
+        ws_a = AsyncMock()
+        ws_b = AsyncMock()
+        ws_c = AsyncMock()
+
+        hub._iframe_conns[("u1", "p1", "t1", "agent-a")] = ws_a
+        hub._iframe_conns[("u1", "p1", "t1", "agent-b")] = ws_b
+        hub._iframe_conns[("u1", "p1", "t1", "agent-c")] = ws_c
+
+        event = {"event": "page-changed", "url": "https://example.com"}
+        await hub.push_event_to_pinned(user_id="u1", profile_id="p1", tab_id="t1", event=event)
+
+        ws_a.send_json.assert_awaited_once_with(event)
+        ws_b.send_json.assert_awaited_once_with(event)
+        ws_c.send_json.assert_awaited_once_with(event)
+
+    @pytest.mark.asyncio
+    async def test_push_event_to_pinned_skips_other_tabs(self):
+        """Add iframe for tab A and tab B. Push to tab A → only A's iframe gets the event."""
+        hub = self._make_hub()
+        ws_tab_a = AsyncMock()
+        ws_tab_b = AsyncMock()
+
+        hub._iframe_conns[("u1", "p1", "tab-a", "agent-a")] = ws_tab_a
+        hub._iframe_conns[("u1", "p1", "tab-b", "agent-a")] = ws_tab_b
+
+        event = {"event": "scroll", "x": 0, "y": 100}
+        await hub.push_event_to_pinned(user_id="u1", profile_id="p1", tab_id="tab-a", event=event)
+
+        ws_tab_a.send_json.assert_awaited_once_with(event)
+        ws_tab_b.send_json.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_push_event_to_pinned_swallows_send_failures(self):
+        """Fake WS whose send_json raises. push_event_to_pinned doesn't propagate."""
+        hub = self._make_hub()
+        ws_bad = AsyncMock()
+        ws_bad.send_json.side_effect = RuntimeError("connection lost")
+
+        hub._iframe_conns[("u1", "p1", "t1", "agent-a")] = ws_bad
+
+        event = {"event": "page-changed", "url": "https://example.com"}
+        # Must not raise
+        await hub.push_event_to_pinned(user_id="u1", profile_id="p1", tab_id="t1", event=event)
+
+
+# ---------------------------------------------------------------------------
+# Sync TestClient + browser_store fixture for WS endpoint tests
+# ---------------------------------------------------------------------------
+
+def _make_ws_app(tmp_path):
+    """Create a minimal app with browser_store initialized (sync-compatible)."""
+    from tinyagentos.app import create_app
+    from tinyagentos.routes.desktop_browser.store import BrowserStore
+
+    config = {
+        "server": {"host": "0.0.0.0", "port": 6969},
+        "backends": [],
+        "qmd": {"url": "http://localhost:7832"},
+        "agents": [],
+        "metrics": {"poll_interval": 30, "retention_days": 30},
+    }
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.dump(config))
+    (tmp_path / ".setup_complete").touch()
+
+    app = create_app(data_dir=tmp_path)
+
+    # Initialize the browser_store synchronously so the WS endpoint can call
+    # list_pins_for_tab without hitting an uninitialised store.
+    browser_store = BrowserStore(tmp_path / "browser.sqlite3")
+    asyncio.run(browser_store.init())
+    app.state.browser_store = browser_store
+
+    # Auth setup for the ticket-minting HTTP endpoint
+    app.state.auth.setup_user("admin", "Test Admin", "", "testpass")
+
+    return app
+
+
+@pytest.fixture
+def ws_app(tmp_path):
+    """App fixture with browser_store ready for WS tests."""
+    return _make_ws_app(tmp_path)
+
+
+@pytest.fixture
+def ws_client(ws_app):
+    """Sync TestClient for WS endpoint tests. Sets auth cookie."""
+    record = ws_app.state.auth.find_user("admin")
+    token = ws_app.state.auth.create_session(user_id=record["id"], long_lived=True)
+    with TestClient(ws_app, raise_server_exceptions=False) as c:
+        c.cookies.set("taos_session", token)
+        yield c
+
+
+def _add_agent_to(app, agent_id: str):
+    app.state.config.agents.append({
+        "id": agent_id,
+        "name": agent_id,
+        "host": "127.0.0.1",
+        "qmd_index": "test",
+        "color": "#000000",
+    })
+
+
+def _mint_ticket_via_http(client, app, profile_id, tab_id, agent_id):
+    """Pin agent then mint ticket via HTTP endpoint."""
+    _add_agent_to(app, agent_id)
+    client.post(
+        "/api/desktop/browser/pins",
+        json={"profile_id": profile_id, "tab_id": tab_id, "agent_id": agent_id},
+    )
+    resp = client.post(
+        "/api/desktop/browser/copilot/ticket",
+        json={"profile_id": profile_id, "tab_id": tab_id, "agent_id": agent_id},
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["ticket"]
+
+
+# ---------------------------------------------------------------------------
+# WebSocket endpoint tests
+# ---------------------------------------------------------------------------
+
+class TestCopilotWS:
+    def test_ws_4401_on_invalid_ticket(self, ws_client):
+        """Connect with random ticket → close code 4401."""
+        with pytest.raises(WebSocketDisconnect) as exc_info:
+            with ws_client.websocket_connect(
+                "/api/desktop/browser/copilot?ticket=totally-invalid-token"
+            ) as ws:
+                ws.receive_text()
+        assert exc_info.value.code == 4401
+
+    def test_ws_4401_on_consumed_ticket(self, ws_client, ws_app):
+        """Mint, consume in-process, then try to connect → close code 4401."""
+        ticket = _mint_ticket_via_http(ws_client, ws_app, "p1", "t1", "agent-consumed")
+        # Consume the ticket before connecting
+        ws_app.state.copilot_ticket_store.consume(ticket)
+
+        with pytest.raises(WebSocketDisconnect) as exc_info:
+            with ws_client.websocket_connect(
+                f"/api/desktop/browser/copilot?ticket={ticket}"
+            ) as ws:
+                ws.receive_text()
+        assert exc_info.value.code == 4401
+
+    def test_ws_4403_when_unpinned_after_mint(self, ws_client, ws_app):
+        """Pin agent, mint ticket, unpin, then connect → close code 4403."""
+        ticket = _mint_ticket_via_http(ws_client, ws_app, "p1", "t1", "agent-unpin")
+        # Unpin the agent
+        ws_client.delete(
+            "/api/desktop/browser/pins",
+            params={"profile_id": "p1", "tab_id": "t1", "agent_id": "agent-unpin"},
+        )
+
+        with pytest.raises(WebSocketDisconnect) as exc_info:
+            with ws_client.websocket_connect(
+                f"/api/desktop/browser/copilot?ticket={ticket}"
+            ) as ws:
+                ws.receive_text()
+        assert exc_info.value.code == 4403
+
+    def test_ws_happy_path_registers_iframe_in_hub(self, ws_client, ws_app):
+        """Pin, mint, connect. Inside the connection: hub has the iframe registered.
+        Disconnect: hub no longer has it."""
+        ticket = _mint_ticket_via_http(ws_client, ws_app, "p1", "t1", "agent-happy")
+
+        # Find the user_id for the admin user
+        record = ws_app.state.auth.find_user("admin")
+        user_id = record["id"]
+
+        with ws_client.websocket_connect(
+            f"/api/desktop/browser/copilot?ticket={ticket}"
+        ) as ws:
+            # While connected: hub must have the iframe registered
+            key = (user_id, "p1", "t1", "agent-happy")
+            assert key in ws_app.state.copilot_hub._iframe_conns
+
+        # After disconnect: hub must have removed the iframe
+        assert key not in ws_app.state.copilot_hub._iframe_conns
+
+    def test_ws_disconnect_cleans_up(self, ws_client, ws_app):
+        """Connect then close from client side. Hub entry removed."""
+        ticket = _mint_ticket_via_http(ws_client, ws_app, "p1", "t1", "agent-cleanup")
+        record = ws_app.state.auth.find_user("admin")
+        user_id = record["id"]
+
+        key = (user_id, "p1", "t1", "agent-cleanup")
+        with ws_client.websocket_connect(
+            f"/api/desktop/browser/copilot?ticket={ticket}"
+        ):
+            assert key in ws_app.state.copilot_hub._iframe_conns
+
+        assert key not in ws_app.state.copilot_hub._iframe_conns
+
+    def test_ws_drops_unknown_event_kinds(self, ws_client, ws_app):
+        """Connect, send unknown event kind and a known one — no crash."""
+        ticket = _mint_ticket_via_http(ws_client, ws_app, "p1", "t1", "agent-drop")
+
+        with ws_client.websocket_connect(
+            f"/api/desktop/browser/copilot?ticket={ticket}"
+        ) as ws:
+            # Unknown event — silently dropped
+            ws.send_json({"event": "definitely-not-real", "data": "x"})
+            # Known event — also silently accepted (not echoed back)
+            ws.send_json({"event": "scroll", "x": 0, "y": 100})
+            # Connection still alive — hub still has the entry
+            record = ws_app.state.auth.find_user("admin")
+            user_id = record["id"]
+            key = (user_id, "p1", "t1", "agent-drop")
+            assert key in ws_app.state.copilot_hub._iframe_conns

--- a/tests/routes/desktop_browser/test_copilot_ws.py
+++ b/tests/routes/desktop_browser/test_copilot_ws.py
@@ -76,6 +76,30 @@ class TestCopilotTicketStore:
         # A is gone — consume returns None and the internal dict doesn't hold it
         assert store.consume(token_a) is None
 
+    def test_mint_single_clock_read_no_self_eviction(self):
+        """Regression: mint() must capture `now` once so GC cannot evict the
+        freshly minted ticket when the clock jumps exactly TTL between calls."""
+        from tinyagentos.routes.desktop_browser.copilot_ws import CopilotTicketStore
+
+        # Clock returns 0.0 on first call, then 60.0 (exactly TTL) on every
+        # subsequent call — simulates the worst-case double-read scenario.
+        calls = iter([0.0, 60.0])
+        clock = lambda: next(calls)  # noqa: E731
+
+        store = CopilotTicketStore(clock=clock)
+        token = store.mint(user_id="u1", profile_id="p1", tab_id="t1", agent_id="a1")
+
+        # Token must still be present in the store — not evicted by its own mint.
+        assert token in store._tickets
+        # And must be consumable (using real time.time for consume, so patch
+        # issued_at to 0 is fine — consume's clock call will be >> 0 only if
+        # the ticket survived the GC sweep; here we pass a fixed consume clock).
+        consume_store = CopilotTicketStore(clock=lambda: 0.0)
+        consume_store._tickets = store._tickets
+        ticket = consume_store.consume(token)
+        assert ticket is not None
+        assert ticket.agent_id == "a1"
+
 
 # ---------------------------------------------------------------------------
 # HTTP endpoint tests
@@ -156,6 +180,14 @@ class TestMintTicketEndpoint:
                 json={"profile_id": "p1", "tab_id": "t1", "agent_id": "agent-iso"},
             )
             assert resp.status_code == 403
+
+    async def test_mint_ticket_422_on_missing_field(self, client):
+        """Pydantic returns 422 when a required body field is omitted."""
+        resp = await client.post(
+            "/api/desktop/browser/copilot/ticket",
+            json={"profile_id": "p1", "tab_id": "t1"},  # agent_id missing
+        )
+        assert resp.status_code == 422
 
     async def test_minted_ticket_can_be_consumed_via_app_state(self, client, app):
         _add_agent(app, "agent-consume")

--- a/tests/routes/desktop_browser/test_copilot_ws.py
+++ b/tests/routes/desktop_browser/test_copilot_ws.py
@@ -1,0 +1,177 @@
+"""Tests for CopilotTicketStore and the /api/desktop/browser/copilot/ticket endpoint."""
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+# ---------------------------------------------------------------------------
+# Store-only unit tests (no HTTP)
+# ---------------------------------------------------------------------------
+
+class TestCopilotTicketStore:
+    def _make_store(self, now: list[float] | None = None):
+        from tinyagentos.routes.desktop_browser.copilot_ws import CopilotTicketStore
+        if now is None:
+            return CopilotTicketStore()
+        return CopilotTicketStore(clock=lambda: now[0])
+
+    def test_mint_returns_url_safe_token(self):
+        store = self._make_store()
+        token = store.mint(user_id="u1", profile_id="p1", tab_id="t1", agent_id="a1")
+        assert token
+        # token_urlsafe(32) uses base64url — no +, /, or = characters
+        for bad_char in ("+", "/", "="):
+            assert bad_char not in token
+
+    @pytest.mark.parametrize("missing", ["user_id", "profile_id", "tab_id", "agent_id"])
+    def test_mint_rejects_empty_params(self, missing):
+        store = self._make_store()
+        kwargs = dict(user_id="u1", profile_id="p1", tab_id="t1", agent_id="a1")
+        kwargs[missing] = ""
+        with pytest.raises(ValueError):
+            store.mint(**kwargs)
+
+    def test_consume_returns_ticket_once(self):
+        now = [0.0]
+        store = self._make_store(now)
+        token = store.mint(user_id="u1", profile_id="p1", tab_id="t1", agent_id="a1")
+        ticket = store.consume(token)
+        assert ticket is not None
+        assert ticket.user_id == "u1"
+        assert ticket.profile_id == "p1"
+        assert ticket.tab_id == "t1"
+        assert ticket.agent_id == "a1"
+        # Second consume → None (single-use)
+        assert store.consume(token) is None
+
+    def test_consume_returns_none_for_unknown_token(self):
+        store = self._make_store()
+        assert store.consume("totally-unknown-token") is None
+
+    def test_consume_returns_none_for_expired_ticket(self):
+        now = [0.0]
+        store = self._make_store(now)
+        token = store.mint(user_id="u1", profile_id="p1", tab_id="t1", agent_id="a1")
+        # Advance clock past TTL
+        now[0] = 61.0
+        result = store.consume(token)
+        assert result is None
+        # Ticket must also be gone from the store after expiry consume
+        assert store.consume(token) is None
+
+    def test_mint_garbage_collects_expired(self):
+        from tinyagentos.routes.desktop_browser.copilot_ws import CopilotTicketStore
+
+        now = [0.0]
+        store = CopilotTicketStore(clock=lambda: now[0])
+
+        # Mint A at t=0
+        token_a = store.mint(user_id="u1", profile_id="p1", tab_id="t1", agent_id="a1")
+
+        # Advance past TTL and mint B → GC should sweep A out
+        now[0] = 120.0
+        store.mint(user_id="u1", profile_id="p1", tab_id="t1", agent_id="b1")
+
+        # A is gone — consume returns None and the internal dict doesn't hold it
+        assert store.consume(token_a) is None
+
+
+# ---------------------------------------------------------------------------
+# HTTP endpoint tests
+# ---------------------------------------------------------------------------
+
+def _add_agent(app, agent_id: str):
+    app.state.config.agents.append({
+        "id": agent_id,
+        "name": agent_id,
+        "host": "127.0.0.1",
+        "qmd_index": "test",
+        "color": "#000000",
+    })
+
+
+@pytest.mark.asyncio
+class TestMintTicketEndpoint:
+    async def test_mint_ticket_happy_path(self, client, app):
+        from tinyagentos.routes.desktop_browser.copilot_ws import CopilotTicketStore
+        _add_agent(app, "agent-tick-1")
+        # Pin the agent first
+        await client.post(
+            "/api/desktop/browser/pins",
+            json={"profile_id": "p1", "tab_id": "t1", "agent_id": "agent-tick-1"},
+        )
+        resp = await client.post(
+            "/api/desktop/browser/copilot/ticket",
+            json={"profile_id": "p1", "tab_id": "t1", "agent_id": "agent-tick-1"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "ticket" in body
+        assert body["ttl_seconds"] == CopilotTicketStore.TICKET_TTL_SECONDS
+
+    async def test_mint_ticket_403_when_not_pinned(self, client):
+        resp = await client.post(
+            "/api/desktop/browser/copilot/ticket",
+            json={"profile_id": "p1", "tab_id": "t1", "agent_id": "no-pin-agent"},
+        )
+        assert resp.status_code == 403
+        assert resp.json() == {"error": "agent not pinned to tab"}
+
+    async def test_mint_ticket_401_when_unauthenticated(self, app):
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as unauth_client:
+            resp = await unauth_client.post(
+                "/api/desktop/browser/copilot/ticket",
+                json={"profile_id": "p1", "tab_id": "t1", "agent_id": "a1"},
+            )
+            assert resp.status_code == 401
+
+    async def test_mint_ticket_multi_user_isolation(self, client, app, tmp_data_dir):
+        """User A pins an agent; user B cannot mint a ticket for it."""
+        _add_agent(app, "agent-iso")
+        # User A pins
+        await client.post(
+            "/api/desktop/browser/pins",
+            json={"profile_id": "p1", "tab_id": "t1", "agent_id": "agent-iso"},
+        )
+
+        # Set up user B
+        auth_mgr = app.state.auth
+        if auth_mgr.find_user("user_b") is None:
+            invite_code = auth_mgr.add_user_invite("user_b", "admin")
+            auth_mgr.complete_invite("user_b", invite_code, "user_b", "", "pass_b")
+        record = auth_mgr.find_user("user_b")
+        token_b = auth_mgr.create_session(user_id=record["id"], long_lived=True)
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            cookies={"taos_session": token_b},
+        ) as b_client:
+            resp = await b_client.post(
+                "/api/desktop/browser/copilot/ticket",
+                json={"profile_id": "p1", "tab_id": "t1", "agent_id": "agent-iso"},
+            )
+            assert resp.status_code == 403
+
+    async def test_minted_ticket_can_be_consumed_via_app_state(self, client, app):
+        _add_agent(app, "agent-consume")
+        await client.post(
+            "/api/desktop/browser/pins",
+            json={"profile_id": "p1", "tab_id": "t1", "agent_id": "agent-consume"},
+        )
+        resp = await client.post(
+            "/api/desktop/browser/copilot/ticket",
+            json={"profile_id": "p1", "tab_id": "t1", "agent_id": "agent-consume"},
+        )
+        assert resp.status_code == 200
+        token = resp.json()["ticket"]
+
+        # The ticket store must hold a consumable ticket for that token
+        ticket = app.state.copilot_ticket_store.consume(token)
+        assert ticket is not None
+        assert ticket.agent_id == "agent-consume"
+        assert ticket.tab_id == "t1"

--- a/tests/routes/desktop_browser/test_proxy_fetch.py
+++ b/tests/routes/desktop_browser/test_proxy_fetch.py
@@ -6,6 +6,7 @@ via respx (already in dev deps).
 """
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import patch
 
 import pytest
@@ -202,3 +203,198 @@ class TestResponseSizeCap:
         assert resp.status_code == 502
         body = resp.json()
         assert "too large" in body.get("error", "").lower()
+
+
+# ---------------------------------------------------------------------------
+# Helper shared across TestPageChangedBroadcast tests
+# ---------------------------------------------------------------------------
+
+_SSRF_PATCH = patch(
+    "tinyagentos.routes.desktop_browser.ssrf.socket.getaddrinfo",
+    return_value=[(2, 1, 6, "", ("93.184.216.34", 0))],
+)
+
+_EXAMPLE_HTML = b"<html><head><title>Example</title></head><body>Hello world</body></html>"
+
+
+@pytest.mark.asyncio
+class TestPageChangedBroadcast:
+    """The proxy emits a page-changed event to copilot_hub when tab_id is supplied."""
+
+    @respx.mock
+    async def test_broadcast_with_tab_id_and_html(self, client, app):
+        """Proxy with tab_id + HTML response → push_event_to_pinned called once."""
+        captured = []
+
+        async def fake_push(*, user_id, profile_id, tab_id, event):
+            captured.append(
+                {"user_id": user_id, "profile_id": profile_id, "tab_id": tab_id, "event": event}
+            )
+
+        app.state.copilot_hub.push_event_to_pinned = fake_push
+
+        respx.get("http://example.com/page").mock(
+            return_value=Response(
+                200,
+                content=_EXAMPLE_HTML,
+                headers={"content-type": "text/html"},
+            )
+        )
+
+        with _SSRF_PATCH:
+            await client.get(
+                "/api/desktop/browser/proxy",
+                params={
+                    "profile_id": "personal",
+                    "url": "http://example.com/page",
+                    "tab_id": "tab-abc",
+                },
+            )
+
+        # Allow the create_task'd broadcast to be scheduled and run.
+        await asyncio.sleep(0.05)
+
+        assert len(captured) == 1
+        ev = captured[0]["event"]
+        assert ev["event"] == "page-changed"
+        assert ev["url"] == "http://example.com/page"
+        assert "extract" in ev
+        assert "title" in ev
+        assert "timestamp" in ev
+        assert captured[0]["tab_id"] == "tab-abc"
+
+    @respx.mock
+    async def test_no_broadcast_without_tab_id(self, client, app):
+        """Proxy without tab_id → no broadcast."""
+        captured = []
+
+        async def fake_push(*, user_id, profile_id, tab_id, event):
+            captured.append(event)
+
+        app.state.copilot_hub.push_event_to_pinned = fake_push
+
+        respx.get("http://example.com/page").mock(
+            return_value=Response(
+                200,
+                content=_EXAMPLE_HTML,
+                headers={"content-type": "text/html"},
+            )
+        )
+
+        with _SSRF_PATCH:
+            await client.get(
+                "/api/desktop/browser/proxy",
+                params={"profile_id": "personal", "url": "http://example.com/page"},
+            )
+
+        await asyncio.sleep(0.05)
+        assert captured == []
+
+    @respx.mock
+    async def test_no_broadcast_for_non_html(self, client, app):
+        """Proxy with tab_id but non-HTML response (image) → no broadcast."""
+        captured = []
+
+        async def fake_push(*, user_id, profile_id, tab_id, event):
+            captured.append(event)
+
+        app.state.copilot_hub.push_event_to_pinned = fake_push
+
+        respx.get("http://example.com/img.png").mock(
+            return_value=Response(
+                200,
+                content=b"\x89PNG\r\n\x1a\n" + b"X" * 20,
+                headers={"content-type": "image/png"},
+            )
+        )
+
+        with _SSRF_PATCH:
+            await client.get(
+                "/api/desktop/browser/proxy",
+                params={
+                    "profile_id": "personal",
+                    "url": "http://example.com/img.png",
+                    "tab_id": "tab-abc",
+                },
+            )
+
+        await asyncio.sleep(0.05)
+        assert captured == []
+
+    @respx.mock
+    async def test_extract_failure_does_not_prevent_broadcast(self, client, app):
+        """If extract_readable raises, the page-changed event still fires."""
+        captured = []
+
+        async def fake_push(*, user_id, profile_id, tab_id, event):
+            captured.append(event)
+
+        app.state.copilot_hub.push_event_to_pinned = fake_push
+
+        respx.get("http://example.com/page").mock(
+            return_value=Response(
+                200,
+                content=_EXAMPLE_HTML,
+                headers={"content-type": "text/html"},
+            )
+        )
+
+        with _SSRF_PATCH:
+            with patch(
+                "tinyagentos.routes.desktop_browser.proxy.extract_readable",
+                side_effect=RuntimeError("extraction boom"),
+            ):
+                await client.get(
+                    "/api/desktop/browser/proxy",
+                    params={
+                        "profile_id": "personal",
+                        "url": "http://example.com/page",
+                        "tab_id": "tab-abc",
+                    },
+                )
+
+        await asyncio.sleep(0.05)
+
+        assert len(captured) == 1
+        assert captured[0]["event"] == "page-changed"
+        assert captured[0]["extract"] == ""
+        assert captured[0]["title"] == ""
+
+    @respx.mock
+    async def test_broadcast_extract_truncated_to_4000_chars(self, client, app):
+        """Long page → extract is capped at 4000 chars in the event."""
+        captured = []
+
+        async def fake_push(*, user_id, profile_id, tab_id, event):
+            captured.append(event)
+
+        app.state.copilot_hub.push_event_to_pinned = fake_push
+
+        respx.get("http://example.com/page").mock(
+            return_value=Response(
+                200,
+                content=_EXAMPLE_HTML,
+                headers={"content-type": "text/html"},
+            )
+        )
+
+        long_text = "A" * 8000
+
+        with _SSRF_PATCH:
+            with patch(
+                "tinyagentos.routes.desktop_browser.proxy.extract_readable",
+                return_value={"title": "Big Page", "text": long_text, "html": "", "word_count": 1},
+            ):
+                await client.get(
+                    "/api/desktop/browser/proxy",
+                    params={
+                        "profile_id": "personal",
+                        "url": "http://example.com/page",
+                        "tab_id": "tab-abc",
+                    },
+                )
+
+        await asyncio.sleep(0.05)
+
+        assert len(captured) == 1
+        assert len(captured[0]["extract"]) == 4000

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -355,6 +355,9 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await browser_cookie_store.init()
         app.state.browser_cookie_store = browser_cookie_store
 
+        from tinyagentos.routes.desktop_browser.copilot_ws import CopilotTicketStore
+        app.state.copilot_ticket_store = CopilotTicketStore()
+
         await benchmark_store.init()
         await scheduler_history_store.init()
         app.state.config = config
@@ -887,6 +890,9 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         chat_hub=chat_hub,
         archive=getattr(app.state, "archive", None),
     )
+
+    from tinyagentos.routes.desktop_browser.copilot_ws import CopilotTicketStore as _CopilotTicketStore
+    app.state.copilot_ticket_store = _CopilotTicketStore()
 
     # Detect and set container runtime (eager, so tests work without lifespan)
     try:

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -355,8 +355,9 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await browser_cookie_store.init()
         app.state.browser_cookie_store = browser_cookie_store
 
-        from tinyagentos.routes.desktop_browser.copilot_ws import CopilotTicketStore
+        from tinyagentos.routes.desktop_browser.copilot_ws import CopilotTicketStore, CopilotHub
         app.state.copilot_ticket_store = CopilotTicketStore()
+        app.state.copilot_hub = CopilotHub()
 
         await benchmark_store.init()
         await scheduler_history_store.init()
@@ -891,8 +892,9 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         archive=getattr(app.state, "archive", None),
     )
 
-    from tinyagentos.routes.desktop_browser.copilot_ws import CopilotTicketStore as _CopilotTicketStore
+    from tinyagentos.routes.desktop_browser.copilot_ws import CopilotTicketStore as _CopilotTicketStore, CopilotHub as _CopilotHub
     app.state.copilot_ticket_store = _CopilotTicketStore()
+    app.state.copilot_hub = _CopilotHub()
 
     # Detect and set container runtime (eager, so tests work without lifespan)
     try:

--- a/tinyagentos/routes/desktop_browser/__init__.py
+++ b/tinyagentos/routes/desktop_browser/__init__.py
@@ -16,3 +16,4 @@ from tinyagentos.routes.desktop_browser import windows as _windows  # noqa: E402
 from tinyagentos.routes.desktop_browser import suggest as _suggest  # noqa: E402,F401
 from tinyagentos.routes.desktop_browser import profile_routes as _profile_routes  # noqa: E402,F401
 from tinyagentos.routes.desktop_browser import extract as _extract  # noqa: E402,F401
+from tinyagentos.routes.desktop_browser import agent_pin_routes as _agent_pin_routes  # noqa: E402,F401

--- a/tinyagentos/routes/desktop_browser/__init__.py
+++ b/tinyagentos/routes/desktop_browser/__init__.py
@@ -17,3 +17,4 @@ from tinyagentos.routes.desktop_browser import suggest as _suggest  # noqa: E402
 from tinyagentos.routes.desktop_browser import profile_routes as _profile_routes  # noqa: E402,F401
 from tinyagentos.routes.desktop_browser import extract as _extract  # noqa: E402,F401
 from tinyagentos.routes.desktop_browser import agent_pin_routes as _agent_pin_routes  # noqa: E402,F401
+from tinyagentos.routes.desktop_browser import copilot_ws as _copilot_ws  # noqa: E402,F401

--- a/tinyagentos/routes/desktop_browser/agent_pin.py
+++ b/tinyagentos/routes/desktop_browser/agent_pin.py
@@ -1,0 +1,65 @@
+"""Service layer for agent pin operations."""
+from __future__ import annotations
+
+from typing import Awaitable, Callable
+
+from tinyagentos.routes.desktop_browser.store import BrowserStore
+
+
+MAX_PINS_PER_TAB = 4
+
+
+class TooManyPinsError(Exception):
+    """Raised when adding a 5th pin to a tab."""
+
+
+class AgentNotFoundError(Exception):
+    """Raised when pinning an agent_id that doesn't exist on the system."""
+
+
+async def pin_agent(
+    browser_store: BrowserStore,
+    *,
+    user_id: str,
+    profile_id: str,
+    tab_id: str,
+    agent_id: str,
+    agent_exists: Callable[[str], Awaitable[bool]],
+) -> bool:
+    """Pin an agent to a tab. Auto-grants read_dom for any host while pinned.
+
+    Returns True iff newly pinned. Raises TooManyPinsError if cap exceeded.
+    Raises AgentNotFoundError if agent_exists(agent_id) is False.
+    """
+    if not await agent_exists(agent_id):
+        raise AgentNotFoundError(agent_id)
+    count = await browser_store.count_pins_for_tab(
+        user_id=user_id, profile_id=profile_id, tab_id=tab_id,
+    )
+    if count >= MAX_PINS_PER_TAB:
+        raise TooManyPinsError(MAX_PINS_PER_TAB)
+    inserted = await browser_store.add_pin(
+        user_id=user_id, profile_id=profile_id, tab_id=tab_id, agent_id=agent_id,
+    )
+    if inserted:
+        # Auto-grant read_dom for any host. Drive/navigate/see_cookies are PR 7.
+        await browser_store.add_capability(
+            user_id=user_id, profile_id=profile_id, agent_id=agent_id,
+            host_pattern="*", permissions="read_dom",
+        )
+    return inserted
+
+
+async def unpin_agent(
+    browser_store: BrowserStore,
+    *,
+    user_id: str,
+    profile_id: str,
+    tab_id: str,
+    agent_id: str,
+) -> bool:
+    """Unpin. Returns True iff a row was deleted. Capability grants are NOT
+    revoked here — they persist across re-pins (intentional)."""
+    return await browser_store.delete_pin(
+        user_id=user_id, profile_id=profile_id, tab_id=tab_id, agent_id=agent_id,
+    )

--- a/tinyagentos/routes/desktop_browser/agent_pin.py
+++ b/tinyagentos/routes/desktop_browser/agent_pin.py
@@ -30,17 +30,22 @@ async def pin_agent(
 
     Returns True iff newly pinned. Raises TooManyPinsError if cap exceeded.
     Raises AgentNotFoundError if agent_exists(agent_id) is False.
+
+    The cap check is enforced atomically inside add_pin_if_under_cap — two
+    concurrent calls cannot both pass when the tab is at N=3.
     """
     if not await agent_exists(agent_id):
         raise AgentNotFoundError(agent_id)
-    count = await browser_store.count_pins_for_tab(
-        user_id=user_id, profile_id=profile_id, tab_id=tab_id,
+    result = await browser_store.add_pin_if_under_cap(
+        user_id=user_id,
+        profile_id=profile_id,
+        tab_id=tab_id,
+        agent_id=agent_id,
+        max_pins=MAX_PINS_PER_TAB,
     )
-    if count >= MAX_PINS_PER_TAB:
+    if result == "at_cap":
         raise TooManyPinsError(MAX_PINS_PER_TAB)
-    inserted = await browser_store.add_pin(
-        user_id=user_id, profile_id=profile_id, tab_id=tab_id, agent_id=agent_id,
-    )
+    inserted = (result == "added")
     if inserted:
         # Auto-grant read_dom for any host. Drive/navigate/see_cookies are PR 7.
         await browser_store.add_capability(

--- a/tinyagentos/routes/desktop_browser/agent_pin_routes.py
+++ b/tinyagentos/routes/desktop_browser/agent_pin_routes.py
@@ -1,0 +1,101 @@
+"""HTTP endpoints for agent pin CRUD."""
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable
+
+from fastapi import Depends, Request
+from fastapi.responses import JSONResponse, Response
+from pydantic import BaseModel
+
+from tinyagentos.auth import get_current_user
+from tinyagentos.routes.desktop_browser import router
+from tinyagentos.routes.desktop_browser.agent_pin import (
+    AgentNotFoundError,
+    TooManyPinsError,
+    pin_agent,
+    unpin_agent,
+)
+
+
+def _make_agent_exists(request: Request) -> Callable[[str], Awaitable[bool]]:
+    """Returns an agent-existence check that uses the app's agent registry.
+
+    Agents live in request.app.state.config.agents — a list of dicts with
+    'name' and optional 'id' keys. We treat the agent_id param as matching
+    either field so both slug-named and UUID-keyed agents work.
+    """
+    async def check(agent_id: str) -> bool:
+        agents = getattr(request.app.state.config, "agents", [])
+        for agent in agents:
+            if agent.get("id") == agent_id or agent.get("name") == agent_id:
+                return True
+        return False
+    return check
+
+
+@router.get("/api/desktop/browser/pins")
+async def list_pins_route(
+    request: Request,
+    profile_id: str,
+    tab_id: str,
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+) -> dict:
+    user_id = str(current_user.get("id") or "")
+    if not user_id:
+        return JSONResponse({"error": "session has no user id"}, status_code=401)
+    pins = await request.app.state.browser_store.list_pins_for_tab(
+        user_id=user_id, profile_id=profile_id, tab_id=tab_id,
+    )
+    return {"pins": pins}
+
+
+class PinRequest(BaseModel):
+    profile_id: str
+    tab_id: str
+    agent_id: str
+
+
+@router.post("/api/desktop/browser/pins")
+async def pin_agent_route(
+    request: Request,
+    body: PinRequest,
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+):
+    user_id = str(current_user.get("id") or "")
+    if not user_id:
+        return JSONResponse({"error": "session has no user id"}, status_code=401)
+    try:
+        inserted = await pin_agent(
+            request.app.state.browser_store,
+            user_id=user_id,
+            profile_id=body.profile_id,
+            tab_id=body.tab_id,
+            agent_id=body.agent_id,
+            agent_exists=_make_agent_exists(request),
+        )
+    except AgentNotFoundError:
+        return JSONResponse({"error": "agent not found"}, status_code=404)
+    except TooManyPinsError as e:
+        return JSONResponse(
+            {"error": f"max {e.args[0]} agents per tab"},
+            status_code=400,
+        )
+    return {"pinned": inserted}
+
+
+@router.delete("/api/desktop/browser/pins")
+async def unpin_agent_route(
+    request: Request,
+    profile_id: str,
+    tab_id: str,
+    agent_id: str,
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+):
+    user_id = str(current_user.get("id") or "")
+    if not user_id:
+        return JSONResponse({"error": "session has no user id"}, status_code=401)
+    await unpin_agent(
+        request.app.state.browser_store,
+        user_id=user_id, profile_id=profile_id, tab_id=tab_id, agent_id=agent_id,
+    )
+    return Response(status_code=204)  # info-hide: 204 even on miss

--- a/tinyagentos/routes/desktop_browser/copilot.js
+++ b/tinyagentos/routes/desktop_browser/copilot.js
@@ -1,27 +1,197 @@
-// taOS BrowserApp v2 — copilot.js (stub)
+// taOS BrowserApp v2 — copilot.js
 //
-// Full implementation (RPC bridge to copilot_ws, DOM extraction,
-// annotation rendering, drive ops) lands in PR 6.
+// Read-op implementation (PR 6).  Drive ops (scrollTo, click, type, navigate,
+// focus, highlight, arrow, sticky, cursor, clear) land in PR 7.
 //
-// PR 3 only needs this file to exist as a static asset so the
-// injector's <script src="/__taos/copilot.js"> reference resolves.
+// Injected into every proxied page by injector.py.  Runs same-origin with the
+// parent shell (the proxy serves both).
 
 (function () {
   'use strict';
 
-  if (window.__taos_copilot_loaded__) {
-    return;
+  // Idempotent guard — re-injection (e.g. turbo / PJAX frame swap) is a no-op.
+  if (window.__taosCopilot) return;
+  window.__taosCopilot = true;
+
+  var meta = document.querySelector('meta[name="taos-copilot-ws"]');
+  if (!meta) return; // injector didn't run; bail silently
+
+  // ---------------------------------------------------------------------------
+  // Op table — read-only ops in PR 6
+  // PR 7 will add: scrollTo, click, type, navigate, focus, highlight,
+  //                arrow, sticky, cursor, clear
+  // ---------------------------------------------------------------------------
+  var ops = {
+    extract: extractReadable,
+    screenshot: function () {
+      return { error: 'screenshot not implemented in PR 6' };
+    },
+    scrollPosition: function () {
+      return {
+        x: window.scrollX,
+        y: window.scrollY,
+        viewport: { w: window.innerWidth, h: window.innerHeight },
+      };
+    },
+    findElement: findElement,
+  };
+
+  function extractReadable(args) {
+    var mode = (args && args.mode) || 'readable';
+    if (mode === 'readable') {
+      var main = document.querySelector('main, article, [role="main"]') || document.body;
+      return { text: (main.innerText || '').slice(0, 8000) };
+    }
+    if (mode === 'dom') {
+      return { html: document.documentElement.outerHTML.slice(0, 200000) };
+    }
+    if (mode === 'a11y') {
+      var interactive = Array.from(document.querySelectorAll('a, button, input, [role]'));
+      return {
+        tree: interactive.slice(0, 200).map(function (el) {
+          return {
+            tag: el.tagName,
+            role: el.getAttribute('role'),
+            label: el.getAttribute('aria-label')
+                   || (el.textContent ? el.textContent.trim().slice(0, 80) : ''),
+          };
+        }),
+      };
+    }
+    return { error: 'unknown mode' };
   }
-  window.__taos_copilot_loaded__ = true;
 
-  const meta = document.querySelector('meta[name="taos-copilot-ws"]');
-  const wsUrl = meta ? meta.getAttribute('content') : null;
+  function findElement(args) {
+    if (args && args.selector) {
+      var el = document.querySelector(args.selector);
+      if (!el) return { error: 'not-found' };
+      var r = el.getBoundingClientRect();
+      return {
+        box: { x: r.x, y: r.y, w: r.width, h: r.height },
+        selector: args.selector,
+        text: el.textContent ? el.textContent.slice(0, 200) : '',
+      };
+    }
+    if (args && args.text) {
+      var all = document.querySelectorAll('a, button, h1, h2, h3, p, span');
+      for (var i = 0; i < all.length; i++) {
+        var candidate = all[i];
+        if (candidate.textContent && candidate.textContent.indexOf(args.text) !== -1) {
+          var rect = candidate.getBoundingClientRect();
+          return {
+            box: { x: rect.x, y: rect.y, w: rect.width, h: rect.height },
+            text: candidate.textContent.slice(0, 200),
+          };
+        }
+      }
+      return { error: 'not-found' };
+    }
+    return { error: 'missing selector or text' };
+  }
 
-  console.info('[taos-copilot] stub loaded', { wsUrl });
+  function cssPath(el) {
+    if (!(el instanceof Element)) return '';
+    var path = [];
+    while (el && el.nodeType === 1) {
+      var s = el.nodeName.toLowerCase();
+      if (el.id) {
+        s += '#' + el.id;
+        path.unshift(s);
+        break;
+      }
+      var sib = el.parentNode
+        ? Array.from(el.parentNode.children).filter(function (c) { return c.nodeName === el.nodeName; })
+        : [];
+      if (sib.length > 1) s += ':nth-of-type(' + (sib.indexOf(el) + 1) + ')';
+      path.unshift(s);
+      el = el.parentNode;
+    }
+    return path.join(' > ');
+  }
 
-  // PR 6 will:
-  //   - open ws connection to wsUrl
-  //   - register message handlers for {extract, drive.*, highlight, …}
-  //   - send page-loaded event
-  //   - render annotations via parent postMessage
+  // ---------------------------------------------------------------------------
+  // Connection management
+  // One WebSocket per (tab, agent).  Multiple agents → multiple connections.
+  // ---------------------------------------------------------------------------
+  var _connections = {}; // agentId -> WebSocket
+
+  // The parent shell mints a ticket per (tab, agent) and postMessages it into
+  // the iframe.  We open one WS per agentId.
+  window.addEventListener('message', function (e) {
+    // SECURITY: sandbox attribute is "allow-scripts allow-forms allow-popups
+    // allow-downloads" (no allow-same-origin), so accessing
+    // window.parent.location.origin would throw SecurityError.
+    // Instead we verify the message came from the direct parent window, which
+    // is equivalent and works in sandboxed contexts.
+    if (e.source !== window.parent) return;
+
+    var data = e.data || {};
+    if (data.type === 'taos-copilot:open' && data.ticket && data.agentId) {
+      openConnection(data.ticket, data.agentId);
+    } else if (data.type === 'taos-copilot:close' && data.agentId) {
+      closeConnection(data.agentId);
+    }
+  });
+
+  function openConnection(ticket, agentId) {
+    if (_connections[agentId]) return; // already open
+
+    var proto = location.protocol === 'https:' ? 'wss' : 'ws';
+    var url = proto + '://' + location.host
+            + '/api/desktop/browser/copilot?ticket=' + encodeURIComponent(ticket);
+    var ws = new WebSocket(url);
+    _connections[agentId] = ws;
+
+    ws.addEventListener('message', function (evt) {
+      var msg;
+      try { msg = JSON.parse(evt.data); } catch (_e) { return; }
+      if (msg && msg.op && ops[msg.op]) {
+        var result;
+        try {
+          result = ops[msg.op](msg.args || {});
+        } catch (err) {
+          result = { error: String(err) };
+        }
+        if (ws.readyState === 1) {
+          ws.send(JSON.stringify({ event: 'ack', op_id: msg.op_id, result: result }));
+        }
+      }
+    });
+
+    ws.addEventListener('close', function () {
+      delete _connections[agentId];
+    });
+
+    // Page lifecycle events forwarded to the server.
+    // Scroll is throttled to one event per animation frame.
+    var scrollPending = false;
+    window.addEventListener('scroll', function () {
+      if (scrollPending) return;
+      scrollPending = true;
+      requestAnimationFrame(function () {
+        scrollPending = false;
+        if (ws.readyState === 1) {
+          ws.send(JSON.stringify({ event: 'scroll', x: window.scrollX, y: window.scrollY }));
+        }
+      });
+    }, { passive: true });
+
+    document.addEventListener('submit', function (e) {
+      var form = e.target;
+      if (ws.readyState === 1) {
+        ws.send(JSON.stringify({
+          event: 'form-submit',
+          selector: cssPath(form),
+        }));
+      }
+    }, true);
+  }
+
+  function closeConnection(agentId) {
+    var ws = _connections[agentId];
+    if (ws) {
+      try { ws.close(); } catch (_e) {}
+      delete _connections[agentId];
+    }
+  }
 })();

--- a/tinyagentos/routes/desktop_browser/copilot.js
+++ b/tinyagentos/routes/desktop_browser/copilot.js
@@ -95,7 +95,7 @@
     while (el && el.nodeType === 1) {
       var s = el.nodeName.toLowerCase();
       if (el.id) {
-        s += '#' + el.id;
+        s += '#' + (window.CSS && window.CSS.escape ? window.CSS.escape(el.id) : el.id);
         path.unshift(s);
         break;
       }
@@ -145,7 +145,7 @@
     ws.addEventListener('message', function (evt) {
       var msg;
       try { msg = JSON.parse(evt.data); } catch (_e) { return; }
-      if (msg && msg.op && ops[msg.op]) {
+      if (msg && msg.op && Object.prototype.hasOwnProperty.call(ops, msg.op)) {
         var result;
         try {
           result = ops[msg.op](msg.args || {});
@@ -158,14 +158,10 @@
       }
     });
 
-    ws.addEventListener('close', function () {
-      delete _connections[agentId];
-    });
-
     // Page lifecycle events forwarded to the server.
     // Scroll is throttled to one event per animation frame.
     var scrollPending = false;
-    window.addEventListener('scroll', function () {
+    function onScroll() {
       if (scrollPending) return;
       scrollPending = true;
       requestAnimationFrame(function () {
@@ -174,17 +170,22 @@
           ws.send(JSON.stringify({ event: 'scroll', x: window.scrollX, y: window.scrollY }));
         }
       });
-    }, { passive: true });
+    }
 
-    document.addEventListener('submit', function (e) {
-      var form = e.target;
+    function onSubmit(e) {
       if (ws.readyState === 1) {
-        ws.send(JSON.stringify({
-          event: 'form-submit',
-          selector: cssPath(form),
-        }));
+        ws.send(JSON.stringify({ event: 'form-submit', selector: cssPath(e.target) }));
       }
-    }, true);
+    }
+
+    ws.addEventListener('close', function () {
+      window.removeEventListener('scroll', onScroll);
+      document.removeEventListener('submit', onSubmit, true);
+      delete _connections[agentId];
+    });
+
+    window.addEventListener('scroll', onScroll, { passive: true });
+    document.addEventListener('submit', onSubmit, true);
   }
 
   function closeConnection(agentId) {

--- a/tinyagentos/routes/desktop_browser/copilot.js
+++ b/tinyagentos/routes/desktop_browser/copilot.js
@@ -145,7 +145,27 @@
     ws.addEventListener('message', function (evt) {
       var msg;
       try { msg = JSON.parse(evt.data); } catch (_e) { return; }
-      if (msg && msg.op && Object.prototype.hasOwnProperty.call(ops, msg.op)) {
+      if (!msg) return;
+
+      // Forward server-emitted events (page-changed, url-changed, etc.) up
+      // to the parent shell via postMessage. The parent's agent-ws-bridge
+      // listens for these, so we don't need a second WebSocket from the
+      // parent (which would clobber this one in the server's hub registry).
+      if (msg.event && window.parent && window.parent !== window) {
+        try {
+          // Target origin "*" — sandboxed iframe can't query parent's origin
+          // without allow-same-origin. The parent's listener verifies
+          // e.source === iframe.contentWindow, which is the equivalent guard.
+          window.parent.postMessage({
+            type: 'taos-copilot:server-event',
+            agentId: agentId,
+            message: msg,
+          }, '*');
+        } catch (_e) { /* parent gone or hostile — ignore */ }
+      }
+
+      // Op dispatch (read ops; drive ops land in PR 7).
+      if (msg.op && Object.prototype.hasOwnProperty.call(ops, msg.op)) {
         var result;
         try {
           result = ops[msg.op](msg.args || {});

--- a/tinyagentos/routes/desktop_browser/copilot_ws.py
+++ b/tinyagentos/routes/desktop_browser/copilot_ws.py
@@ -1,0 +1,123 @@
+"""Copilot WebSocket ticket store and minting endpoint.
+
+Tickets are short-lived (60s) single-use tokens that let the copilot
+client authenticate a WebSocket upgrade without relying on cookies, which
+some browsers don't forward reliably on WS upgrades.
+"""
+from __future__ import annotations
+
+import secrets
+import time
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from fastapi import Depends, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from tinyagentos.auth import get_current_user
+from tinyagentos.routes.desktop_browser import router
+
+
+@dataclass(frozen=True)
+class CopilotTicket:
+    user_id: str
+    profile_id: str
+    tab_id: str
+    agent_id: str
+    issued_at: float
+
+
+class CopilotTicketStore:
+    """In-memory single-use ticket store. Tickets expire after 60s.
+
+    Tickets are minted by an authenticated HTTP endpoint after the server
+    confirms the (user, agent, tab) pin holds. The WebSocket upgrade then
+    consumes the ticket — single-use, expires fast.
+    """
+
+    TICKET_TTL_SECONDS = 60.0
+
+    def __init__(self, *, clock: Callable[[], float] | None = None) -> None:
+        # `clock` is injectable for tests (avoids monkey-patching time.time).
+        self._clock = clock or time.time
+        self._tickets: dict[str, CopilotTicket] = {}
+
+    def mint(
+        self,
+        *,
+        user_id: str,
+        profile_id: str,
+        tab_id: str,
+        agent_id: str,
+    ) -> str:
+        """Mint a single-use ticket. Returns the opaque token string."""
+        if not all([user_id, profile_id, tab_id, agent_id]):
+            raise ValueError("user_id, profile_id, tab_id, agent_id all required")
+        token = secrets.token_urlsafe(32)
+        self._tickets[token] = CopilotTicket(
+            user_id=user_id,
+            profile_id=profile_id,
+            tab_id=tab_id,
+            agent_id=agent_id,
+            issued_at=self._clock(),
+        )
+        # Opportunistic GC — sweep expired tickets to keep dict bounded.
+        now = self._clock()
+        self._tickets = {
+            k: v
+            for k, v in self._tickets.items()
+            if now - v.issued_at < self.TICKET_TTL_SECONDS
+        }
+        return token
+
+    def consume(self, token: str) -> CopilotTicket | None:
+        """Consume the ticket. Returns the ticket if valid and unexpired,
+        None otherwise. The ticket is removed regardless of validity."""
+        ticket = self._tickets.pop(token, None)
+        if ticket is None:
+            return None
+        if self._clock() - ticket.issued_at >= self.TICKET_TTL_SECONDS:
+            return None
+        return ticket
+
+
+# ---------------------------------------------------------------------------
+# HTTP endpoint
+# ---------------------------------------------------------------------------
+
+class TicketRequest(BaseModel):
+    profile_id: str
+    tab_id: str
+    agent_id: str
+
+
+@router.post("/api/desktop/browser/copilot/ticket")
+async def mint_copilot_ticket(
+    request: Request,
+    body: TicketRequest,
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+):
+    """Mint a single-use 60s ticket for a copilot WebSocket upgrade.
+
+    Verifies the user has the agent pinned to this tab before minting.
+    """
+    user_id = str(current_user.get("id") or "")
+    if not user_id:
+        return JSONResponse({"error": "session has no user id"}, status_code=401)
+
+    pinned = await request.app.state.browser_store.list_pins_for_tab(
+        user_id=user_id,
+        profile_id=body.profile_id,
+        tab_id=body.tab_id,
+    )
+    if not any(p["agent_id"] == body.agent_id for p in pinned):
+        return JSONResponse({"error": "agent not pinned to tab"}, status_code=403)
+
+    token = request.app.state.copilot_ticket_store.mint(
+        user_id=user_id,
+        profile_id=body.profile_id,
+        tab_id=body.tab_id,
+        agent_id=body.agent_id,
+    )
+    return {"ticket": token, "ttl_seconds": CopilotTicketStore.TICKET_TTL_SECONDS}

--- a/tinyagentos/routes/desktop_browser/copilot_ws.py
+++ b/tinyagentos/routes/desktop_browser/copilot_ws.py
@@ -6,17 +6,22 @@ some browsers don't forward reliably on WS upgrades.
 """
 from __future__ import annotations
 
+import asyncio
+import logging
 import secrets
 import time
 from dataclasses import dataclass
 from typing import Any, Callable
 
-from fastapi import Depends, Request
+from fastapi import Depends, Request, WebSocket
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
+from starlette.websockets import WebSocketDisconnect
 
 from tinyagentos.auth import get_current_user
 from tinyagentos.routes.desktop_browser import router
+
+_logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -121,3 +126,131 @@ async def mint_copilot_ticket(
         agent_id=body.agent_id,
     )
     return {"ticket": token, "ttl_seconds": CopilotTicketStore.TICKET_TTL_SECONDS}
+
+
+# ---------------------------------------------------------------------------
+# CopilotHub
+# ---------------------------------------------------------------------------
+
+async def _close_safely(ws: WebSocket) -> None:
+    """Close a WebSocket without raising if already closed."""
+    try:
+        await ws.close()
+    except Exception:
+        pass
+
+
+class CopilotHub:
+    """Routes messages between agents (server-side runtime, future PR 7)
+    and iframes (browser-side copilot.js).
+
+    PR 6 only registers iframe connections. The fan-out from proxy.py
+    (page-changed events, Task 5) iterates iframe connections by
+    (user, profile, tab) and pushes events.
+
+    Connection key: (user_id, profile_id, tab_id, agent_id) — one WS
+    per (tab, pinned-agent) pair. If a tab has 3 agents pinned, the
+    iframe opens 3 WS connections (one per agent).
+    """
+
+    def __init__(self) -> None:
+        self._iframe_conns: dict[tuple[str, str, str, str], WebSocket] = {}
+
+    def add_iframe(
+        self, *, user_id: str, profile_id: str, tab_id: str, agent_id: str,
+        ws: WebSocket,
+    ) -> None:
+        """Register an iframe WS. Replaces any prior connection for the same key
+        (refresh, reconnect — close the old one)."""
+        key = (user_id, profile_id, tab_id, agent_id)
+        old = self._iframe_conns.pop(key, None)
+        if old is not None:
+            asyncio.create_task(_close_safely(old))
+        self._iframe_conns[key] = ws
+
+    def remove_iframe(
+        self, *, user_id: str, profile_id: str, tab_id: str, agent_id: str,
+    ) -> None:
+        """Remove a registered iframe WS. No-op if not present."""
+        self._iframe_conns.pop((user_id, profile_id, tab_id, agent_id), None)
+
+    async def push_event_to_pinned(
+        self, *, user_id: str, profile_id: str, tab_id: str, event: dict,
+    ) -> None:
+        """Push an event to every iframe connection for every agent pinned
+        to this tab. Used by proxy.py when a tab navigates → page-changed
+        event. Failed sends are logged and ignored — the connection will be
+        cleaned up when its WS handler hits WebSocketDisconnect."""
+        targets = [
+            ws for (u, p, t, _a), ws in self._iframe_conns.items()
+            if u == user_id and p == profile_id and t == tab_id
+        ]
+        for ws in targets:
+            try:
+                await ws.send_json(event)
+            except Exception as e:
+                _logger.debug("copilot push failed: %s", e)
+
+
+# ---------------------------------------------------------------------------
+# WebSocket endpoint
+# ---------------------------------------------------------------------------
+
+# Allowed event kinds from iframe → server. Drive ack events come in PR 7.
+_ALLOWED_EVENT_KINDS = {
+    "page-changed", "url-changed", "scroll", "form-submit",
+    "download-started", "ack",
+}
+
+
+@router.websocket("/api/desktop/browser/copilot")
+async def copilot_ws(websocket: WebSocket, ticket: str):
+    """Iframe-side WebSocket for copilot.js. Authenticated by single-use ticket.
+
+    URL: ws://host/api/desktop/browser/copilot?ticket=<token>
+    """
+    # Consume the ticket BEFORE accepting the upgrade — invalid → close.
+    consumed = websocket.app.state.copilot_ticket_store.consume(ticket)
+    if consumed is None:
+        await websocket.close(code=4401, reason="invalid or expired ticket")
+        return
+
+    # Re-verify the pin still holds (user could have unpinned between
+    # mint and connect).
+    pinned = await websocket.app.state.browser_store.list_pins_for_tab(
+        user_id=consumed.user_id,
+        profile_id=consumed.profile_id,
+        tab_id=consumed.tab_id,
+    )
+    if not any(p["agent_id"] == consumed.agent_id for p in pinned):
+        await websocket.close(code=4403, reason="agent not pinned")
+        return
+
+    await websocket.accept()
+    hub = websocket.app.state.copilot_hub
+    hub.add_iframe(
+        user_id=consumed.user_id,
+        profile_id=consumed.profile_id,
+        tab_id=consumed.tab_id,
+        agent_id=consumed.agent_id,
+        ws=websocket,
+    )
+    try:
+        while True:
+            message = await websocket.receive_json()
+            event_kind = message.get("event")
+            if event_kind not in _ALLOWED_EVENT_KINDS:
+                # Don't crash on unknown events; just drop. PR 7 will route
+                # 'ack' events back to the agent connection.
+                continue
+            # PR 6: iframe → server events accepted but not routed.
+            # PR 7 wires 'ack' to the agent-side connection.
+    except WebSocketDisconnect:
+        pass
+    finally:
+        hub.remove_iframe(
+            user_id=consumed.user_id,
+            profile_id=consumed.profile_id,
+            tab_id=consumed.tab_id,
+            agent_id=consumed.agent_id,
+        )

--- a/tinyagentos/routes/desktop_browser/copilot_ws.py
+++ b/tinyagentos/routes/desktop_browser/copilot_ws.py
@@ -54,16 +54,16 @@ class CopilotTicketStore:
         """Mint a single-use ticket. Returns the opaque token string."""
         if not all([user_id, profile_id, tab_id, agent_id]):
             raise ValueError("user_id, profile_id, tab_id, agent_id all required")
+        now = self._clock()
         token = secrets.token_urlsafe(32)
         self._tickets[token] = CopilotTicket(
             user_id=user_id,
             profile_id=profile_id,
             tab_id=tab_id,
             agent_id=agent_id,
-            issued_at=self._clock(),
+            issued_at=now,
         )
         # Opportunistic GC — sweep expired tickets to keep dict bounded.
-        now = self._clock()
         self._tickets = {
             k: v
             for k, v in self._tickets.items()

--- a/tinyagentos/routes/desktop_browser/proxy.py
+++ b/tinyagentos/routes/desktop_browser/proxy.py
@@ -264,4 +264,8 @@ _COPILOT_JS = Path(__file__).parent / "copilot.js"
 
 @router.get("/__taos/copilot.js")
 async def copilot_js():
-    return FileResponse(_COPILOT_JS, media_type="application/javascript")
+    return FileResponse(
+        _COPILOT_JS,
+        media_type="application/javascript",
+        headers={"Cache-Control": "public, max-age=86400, immutable"},
+    )

--- a/tinyagentos/routes/desktop_browser/proxy.py
+++ b/tinyagentos/routes/desktop_browser/proxy.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from pathlib import Path
 from typing import Any
 from urllib.parse import quote, urljoin, urlparse, urlsplit
@@ -34,6 +35,7 @@ from tinyagentos.routes.desktop_browser.cookie_jar import (
     persist_response_cookies,
 )
 from tinyagentos.routes.desktop_browser.csp import proxied_response_csp
+from tinyagentos.routes.desktop_browser.extract import extract_readable
 from tinyagentos.routes.desktop_browser.injector import inject_into_head
 from tinyagentos.routes.desktop_browser.profile import (
     ProfileNotFoundError,
@@ -68,6 +70,7 @@ async def proxy_get(
     profile_id: str,
     url: str,
     request: Request,
+    tab_id: str | None = None,
     current_user: dict[str, Any] = Depends(get_current_user),
 ):
     """Real proxy fetch — replaces PR 2's 501 stub."""
@@ -209,6 +212,34 @@ async def proxy_get(
             f"?profile_id={quote(profile_id, safe='')}"
         )
         injected = inject_into_head(rewritten, ws_url=ws_url)
+
+        # Page-change broadcast for any agents pinned to this tab.
+        # Non-blocking — never delay the user's page load on agent fan-out.
+        if tab_id:
+            extract_text = ""
+            extract_title = ""
+            try:
+                extract_result = extract_readable(rewritten, url)
+                extract_text = (extract_result.get("text") or "")[:4000]
+                extract_title = extract_result.get("title", "")
+            except Exception:
+                # Extraction failure is non-fatal — page-changed still fires
+                pass
+
+            asyncio.create_task(
+                request.app.state.copilot_hub.push_event_to_pinned(
+                    user_id=user_id,
+                    profile_id=profile_id,
+                    tab_id=tab_id,
+                    event={
+                        "event": "page-changed",
+                        "url": url,
+                        "title": extract_title,
+                        "extract": extract_text,
+                        "timestamp": time.time(),
+                    },
+                )
+            )
 
         out_headers["content-security-policy"] = proxied_response_csp()
         return Response(

--- a/tinyagentos/routes/desktop_browser/proxy.py
+++ b/tinyagentos/routes/desktop_browser/proxy.py
@@ -219,7 +219,9 @@ async def proxy_get(
             extract_text = ""
             extract_title = ""
             try:
-                extract_result = extract_readable(rewritten, url)
+                # Extract from RAW upstream HTML, not the rewritten body — the
+                # agent's context should reference original URLs, not proxied ones.
+                extract_result = extract_readable(response.content, url)
                 extract_text = (extract_result.get("text") or "")[:4000]
                 extract_title = extract_result.get("title", "")
             except Exception:

--- a/tinyagentos/routes/desktop_browser/schema.py
+++ b/tinyagentos/routes/desktop_browser/schema.py
@@ -56,8 +56,9 @@ CREATE TABLE IF NOT EXISTS agent_capabilities (
   profile_id     TEXT NOT NULL,
   agent_id       TEXT NOT NULL,
   host_pattern   TEXT NOT NULL,
-  perms          TEXT NOT NULL,
-  granted_at     INTEGER NOT NULL,
+  permissions    TEXT NOT NULL,
+  granted_at     TEXT NOT NULL,
+  expires_at     TEXT,
   PRIMARY KEY (user_id, profile_id, agent_id, host_pattern)
 );
 
@@ -82,8 +83,45 @@ CREATE TABLE IF NOT EXISTS browser_windows (
   updated_at     INTEGER NOT NULL,
   PRIMARY KEY (user_id, window_id)
 );
+
+CREATE TABLE IF NOT EXISTS agent_pins (
+  user_id        TEXT NOT NULL,
+  profile_id     TEXT NOT NULL,
+  tab_id         TEXT NOT NULL,
+  agent_id       TEXT NOT NULL,
+  pinned_at      TEXT NOT NULL,
+  PRIMARY KEY (user_id, profile_id, tab_id, agent_id)
+);
+CREATE INDEX IF NOT EXISTS idx_agent_pins_lookup
+  ON agent_pins (user_id, profile_id, tab_id);
 """
 
+
+AGENT_PINS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS agent_pins (
+  user_id        TEXT NOT NULL,
+  profile_id     TEXT NOT NULL,
+  tab_id         TEXT NOT NULL,
+  agent_id       TEXT NOT NULL,
+  pinned_at      TEXT NOT NULL,
+  PRIMARY KEY (user_id, profile_id, tab_id, agent_id)
+);
+CREATE INDEX IF NOT EXISTS idx_agent_pins_lookup
+  ON agent_pins (user_id, profile_id, tab_id);
+"""
+
+AGENT_CAPABILITIES_SCHEMA = """
+CREATE TABLE IF NOT EXISTS agent_capabilities (
+  user_id        TEXT NOT NULL,
+  profile_id     TEXT NOT NULL,
+  agent_id       TEXT NOT NULL,
+  host_pattern   TEXT NOT NULL,
+  permissions    TEXT NOT NULL,
+  granted_at     TEXT NOT NULL,
+  expires_at     TEXT,
+  PRIMARY KEY (user_id, profile_id, agent_id, host_pattern)
+);
+"""
 
 COOKIE_SCHEMA = """
 CREATE TABLE IF NOT EXISTS cookies (

--- a/tinyagentos/routes/desktop_browser/schema.py
+++ b/tinyagentos/routes/desktop_browser/schema.py
@@ -97,32 +97,6 @@ CREATE INDEX IF NOT EXISTS idx_agent_pins_lookup
 """
 
 
-AGENT_PINS_SCHEMA = """
-CREATE TABLE IF NOT EXISTS agent_pins (
-  user_id        TEXT NOT NULL,
-  profile_id     TEXT NOT NULL,
-  tab_id         TEXT NOT NULL,
-  agent_id       TEXT NOT NULL,
-  pinned_at      TEXT NOT NULL,
-  PRIMARY KEY (user_id, profile_id, tab_id, agent_id)
-);
-CREATE INDEX IF NOT EXISTS idx_agent_pins_lookup
-  ON agent_pins (user_id, profile_id, tab_id);
-"""
-
-AGENT_CAPABILITIES_SCHEMA = """
-CREATE TABLE IF NOT EXISTS agent_capabilities (
-  user_id        TEXT NOT NULL,
-  profile_id     TEXT NOT NULL,
-  agent_id       TEXT NOT NULL,
-  host_pattern   TEXT NOT NULL,
-  permissions    TEXT NOT NULL,
-  granted_at     TEXT NOT NULL,
-  expires_at     TEXT,
-  PRIMARY KEY (user_id, profile_id, agent_id, host_pattern)
-);
-"""
-
 COOKIE_SCHEMA = """
 CREATE TABLE IF NOT EXISTS cookies (
   user_id        TEXT NOT NULL,

--- a/tinyagentos/routes/desktop_browser/store.py
+++ b/tinyagentos/routes/desktop_browser/store.py
@@ -8,6 +8,7 @@ The query helpers refuse to operate without a user_id argument.
 """
 from __future__ import annotations
 
+from datetime import datetime, UTC
 from pathlib import Path
 
 from tinyagentos.base_store import BaseStore
@@ -324,6 +325,247 @@ class BrowserStore(BaseStore):
             }
             for r in rows
         ]
+
+
+    # ------------------------------------------------------------------
+    # Agent pin helpers
+    # ------------------------------------------------------------------
+
+    async def add_pin(
+        self,
+        *,
+        user_id: str,
+        profile_id: str,
+        tab_id: str,
+        agent_id: str,
+    ) -> bool:
+        """INSERT OR IGNORE. Returns True if newly inserted, False if already existed."""
+        if not user_id:
+            raise ValueError("user_id is required")
+        if not profile_id:
+            raise ValueError("profile_id is required")
+        if not tab_id:
+            raise ValueError("tab_id is required")
+        if not agent_id:
+            raise ValueError("agent_id is required")
+        assert self._db is not None
+        pinned_at = datetime.now(UTC).isoformat()
+        cursor = await self._db.execute(
+            "INSERT OR IGNORE INTO agent_pins "
+            "(user_id, profile_id, tab_id, agent_id, pinned_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (user_id, profile_id, tab_id, agent_id, pinned_at),
+        )
+        await self._db.commit()
+        return cursor.rowcount > 0
+
+    async def list_pins_for_tab(
+        self,
+        *,
+        user_id: str,
+        profile_id: str,
+        tab_id: str,
+    ) -> list[dict]:
+        """Returns list of {agent_id, pinned_at} ordered by pinned_at ASC."""
+        assert self._db is not None
+        cursor = await self._db.execute(
+            "SELECT agent_id, pinned_at FROM agent_pins "
+            "WHERE user_id = ? AND profile_id = ? AND tab_id = ? "
+            "ORDER BY pinned_at ASC",
+            (user_id, profile_id, tab_id),
+        )
+        rows = await cursor.fetchall()
+        return [{"agent_id": r[0], "pinned_at": r[1]} for r in rows]
+
+    async def list_pins_for_user(self, *, user_id: str) -> list[dict]:
+        """Returns list of {profile_id, tab_id, agent_id, pinned_at}."""
+        assert self._db is not None
+        cursor = await self._db.execute(
+            "SELECT profile_id, tab_id, agent_id, pinned_at FROM agent_pins "
+            "WHERE user_id = ? ORDER BY pinned_at ASC",
+            (user_id,),
+        )
+        rows = await cursor.fetchall()
+        return [
+            {"profile_id": r[0], "tab_id": r[1], "agent_id": r[2], "pinned_at": r[3]}
+            for r in rows
+        ]
+
+    async def count_pins_for_tab(
+        self,
+        *,
+        user_id: str,
+        profile_id: str,
+        tab_id: str,
+    ) -> int:
+        """Returns the number of pins on the (user, profile, tab) tuple."""
+        assert self._db is not None
+        cursor = await self._db.execute(
+            "SELECT COUNT(*) FROM agent_pins "
+            "WHERE user_id = ? AND profile_id = ? AND tab_id = ?",
+            (user_id, profile_id, tab_id),
+        )
+        row = await cursor.fetchone()
+        return row[0] if row else 0
+
+    async def delete_pin(
+        self,
+        *,
+        user_id: str,
+        profile_id: str,
+        tab_id: str,
+        agent_id: str,
+    ) -> bool:
+        """DELETE. Returns True if a row was deleted, False if not present."""
+        assert self._db is not None
+        cursor = await self._db.execute(
+            "DELETE FROM agent_pins "
+            "WHERE user_id = ? AND profile_id = ? AND tab_id = ? AND agent_id = ?",
+            (user_id, profile_id, tab_id, agent_id),
+        )
+        await self._db.commit()
+        return cursor.rowcount > 0
+
+    # ------------------------------------------------------------------
+    # Agent capability helpers
+    # ------------------------------------------------------------------
+
+    async def add_capability(
+        self,
+        *,
+        user_id: str,
+        profile_id: str,
+        agent_id: str,
+        host_pattern: str,
+        permissions: str,
+        expires_at: str | None = None,
+    ) -> bool:
+        """UPSERT (INSERT OR REPLACE on the PK). Returns True on success."""
+        if not user_id:
+            raise ValueError("user_id is required")
+        if not profile_id:
+            raise ValueError("profile_id is required")
+        if not agent_id:
+            raise ValueError("agent_id is required")
+        if not host_pattern:
+            raise ValueError("host_pattern is required")
+        if not permissions:
+            raise ValueError("permissions is required")
+        assert self._db is not None
+        granted_at = datetime.now(UTC).isoformat()
+        await self._db.execute(
+            "INSERT OR REPLACE INTO agent_capabilities "
+            "(user_id, profile_id, agent_id, host_pattern, permissions, granted_at, expires_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (user_id, profile_id, agent_id, host_pattern, permissions, granted_at, expires_at),
+        )
+        await self._db.commit()
+        return True
+
+    async def list_capabilities(
+        self,
+        *,
+        user_id: str,
+        profile_id: str,
+        agent_id: str | None = None,
+    ) -> list[dict]:
+        """Returns all grants for (user, profile), optionally filtered by agent_id."""
+        assert self._db is not None
+        if agent_id is not None:
+            cursor = await self._db.execute(
+                "SELECT agent_id, host_pattern, permissions, granted_at, expires_at "
+                "FROM agent_capabilities "
+                "WHERE user_id = ? AND profile_id = ? AND agent_id = ?",
+                (user_id, profile_id, agent_id),
+            )
+        else:
+            cursor = await self._db.execute(
+                "SELECT agent_id, host_pattern, permissions, granted_at, expires_at "
+                "FROM agent_capabilities "
+                "WHERE user_id = ? AND profile_id = ?",
+                (user_id, profile_id),
+            )
+        rows = await cursor.fetchall()
+        return [
+            {
+                "agent_id": r[0],
+                "host_pattern": r[1],
+                "permissions": r[2],
+                "granted_at": r[3],
+                "expires_at": r[4],
+            }
+            for r in rows
+        ]
+
+    async def revoke_capability(
+        self,
+        *,
+        user_id: str,
+        profile_id: str,
+        agent_id: str,
+        host_pattern: str,
+    ) -> bool:
+        """DELETE matching grant. Returns True if a row was deleted."""
+        assert self._db is not None
+        cursor = await self._db.execute(
+            "DELETE FROM agent_capabilities "
+            "WHERE user_id = ? AND profile_id = ? AND agent_id = ? AND host_pattern = ?",
+            (user_id, profile_id, agent_id, host_pattern),
+        )
+        await self._db.commit()
+        return cursor.rowcount > 0
+
+    async def check_capability(
+        self,
+        *,
+        user_id: str,
+        profile_id: str,
+        agent_id: str,
+        host: str,
+        permission: str,
+    ) -> bool:
+        """Returns True if a non-expired grant for (user, profile, agent) matches
+        `host` against its host_pattern and contains `permission`.
+
+        Pattern semantics:
+          - "*" matches any host
+          - "*.example.com" matches "foo.example.com" and "example.com"
+          - anything else: exact match
+        """
+        rows = await self.list_capabilities(
+            user_id=user_id, profile_id=profile_id, agent_id=agent_id,
+        )
+        now = datetime.now(UTC)
+        for row in rows:
+            # Expiry check
+            expires = row["expires_at"]
+            if expires is not None:
+                try:
+                    exp_dt = datetime.fromisoformat(expires)
+                    if exp_dt <= now:
+                        continue
+                except ValueError:
+                    continue
+
+            # Pattern match
+            pattern = row["host_pattern"]
+            if pattern == "*":
+                matched = True
+            elif pattern.startswith("*."):
+                # "*.example.com" matches "example.com" and "foo.example.com"
+                domain = pattern[2:]  # e.g. "example.com"
+                matched = host == domain or host.endswith("." + domain)
+            else:
+                matched = host == pattern
+
+            if not matched:
+                continue
+
+            # Permission check
+            if permission in row["permissions"].split(","):
+                return True
+
+        return False
 
 
 class BrowserCookieStore:

--- a/tinyagentos/routes/desktop_browser/store.py
+++ b/tinyagentos/routes/desktop_browser/store.py
@@ -8,7 +8,7 @@ The query helpers refuse to operate without a user_id argument.
 """
 from __future__ import annotations
 
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 from pathlib import Path
 
 from tinyagentos.base_store import BaseStore
@@ -349,7 +349,7 @@ class BrowserStore(BaseStore):
         if not agent_id:
             raise ValueError("agent_id is required")
         assert self._db is not None
-        pinned_at = datetime.now(UTC).isoformat()
+        pinned_at = datetime.now(timezone.utc).isoformat()
         cursor = await self._db.execute(
             "INSERT OR IGNORE INTO agent_pins "
             "(user_id, profile_id, tab_id, agent_id, pinned_at) "
@@ -386,7 +386,7 @@ class BrowserStore(BaseStore):
         if not agent_id:
             raise ValueError("agent_id is required")
         assert self._db is not None
-        pinned_at = datetime.now(UTC).isoformat()
+        pinned_at = datetime.now(timezone.utc).isoformat()
         cursor = await self._db.execute(
             """
             INSERT OR IGNORE INTO agent_pins
@@ -516,7 +516,7 @@ class BrowserStore(BaseStore):
         if not permissions:
             raise ValueError("permissions is required")
         assert self._db is not None
-        granted_at = datetime.now(UTC).isoformat()
+        granted_at = datetime.now(timezone.utc).isoformat()
         await self._db.execute(
             "INSERT OR REPLACE INTO agent_capabilities "
             "(user_id, profile_id, agent_id, host_pattern, permissions, granted_at, expires_at) "
@@ -607,7 +607,7 @@ class BrowserStore(BaseStore):
         rows = await self.list_capabilities(
             user_id=user_id, profile_id=profile_id, agent_id=agent_id,
         )
-        now = datetime.now(UTC)
+        now = datetime.now(timezone.utc)
         for row in rows:
             # Expiry check
             expires = row["expires_at"]

--- a/tinyagentos/routes/desktop_browser/store.py
+++ b/tinyagentos/routes/desktop_browser/store.py
@@ -417,6 +417,14 @@ class BrowserStore(BaseStore):
         agent_id: str,
     ) -> bool:
         """DELETE. Returns True if a row was deleted, False if not present."""
+        if not user_id:
+            raise ValueError("user_id is required")
+        if not profile_id:
+            raise ValueError("profile_id is required")
+        if not tab_id:
+            raise ValueError("tab_id is required")
+        if not agent_id:
+            raise ValueError("agent_id is required")
         assert self._db is not None
         cursor = await self._db.execute(
             "DELETE FROM agent_pins "
@@ -506,6 +514,14 @@ class BrowserStore(BaseStore):
         host_pattern: str,
     ) -> bool:
         """DELETE matching grant. Returns True if a row was deleted."""
+        if not user_id:
+            raise ValueError("user_id is required")
+        if not profile_id:
+            raise ValueError("profile_id is required")
+        if not agent_id:
+            raise ValueError("agent_id is required")
+        if not host_pattern:
+            raise ValueError("host_pattern is required")
         assert self._db is not None
         cursor = await self._db.execute(
             "DELETE FROM agent_capabilities "
@@ -562,7 +578,8 @@ class BrowserStore(BaseStore):
                 continue
 
             # Permission check
-            if permission in row["permissions"].split(","):
+            permissions = [p.strip() for p in row["permissions"].split(",")]
+            if permission in permissions:
                 return True
 
         return False

--- a/tinyagentos/routes/desktop_browser/store.py
+++ b/tinyagentos/routes/desktop_browser/store.py
@@ -359,6 +359,62 @@ class BrowserStore(BaseStore):
         await self._db.commit()
         return cursor.rowcount > 0
 
+    async def add_pin_if_under_cap(
+        self,
+        *,
+        user_id: str,
+        profile_id: str,
+        tab_id: str,
+        agent_id: str,
+        max_pins: int,
+    ) -> str:
+        """Atomic INSERT-with-cap. Returns one of:
+          - "added"     — pin newly created
+          - "duplicate" — pin already existed for this tuple
+          - "at_cap"    — tab already at max_pins, cannot add new pin
+
+        The cap check and INSERT happen in one SQL statement so two concurrent
+        calls cannot both pass an N=3 check and produce N=5. Tested at
+        concurrency to lock the invariant in.
+        """
+        if not user_id:
+            raise ValueError("user_id is required")
+        if not profile_id:
+            raise ValueError("profile_id is required")
+        if not tab_id:
+            raise ValueError("tab_id is required")
+        if not agent_id:
+            raise ValueError("agent_id is required")
+        assert self._db is not None
+        pinned_at = datetime.now(UTC).isoformat()
+        cursor = await self._db.execute(
+            """
+            INSERT OR IGNORE INTO agent_pins
+                (user_id, profile_id, tab_id, agent_id, pinned_at)
+            SELECT ?, ?, ?, ?, ?
+            WHERE (
+                SELECT COUNT(*) FROM agent_pins
+                WHERE user_id = ? AND profile_id = ? AND tab_id = ?
+            ) < ?
+            """,
+            (
+                user_id, profile_id, tab_id, agent_id, pinned_at,
+                user_id, profile_id, tab_id, max_pins,
+            ),
+        )
+        await self._db.commit()
+        if cursor.rowcount > 0:
+            return "added"
+        # rowcount==0 — either duplicate (PK violation, swallowed by IGNORE)
+        # or at-cap (WHERE clause failed). Disambiguate with a single SELECT.
+        check = await self._db.execute(
+            "SELECT 1 FROM agent_pins "
+            "WHERE user_id = ? AND profile_id = ? AND tab_id = ? AND agent_id = ?",
+            (user_id, profile_id, tab_id, agent_id),
+        )
+        existing = await check.fetchone()
+        return "duplicate" if existing else "at_cap"
+
     async def list_pins_for_tab(
         self,
         *,


### PR DESCRIPTION
## Summary

The "read half" of agent integration. Pin agents to tabs, see their presence in the URL bar, open a per-(tab, agent) side panel with chat + recent events, and let copilot.js extract page context for them via a single-use ticket-authenticated WebSocket.

1. **Sticky pin model** — `agent_pins` table keyed by `(user_id, profile_id, tab_id, agent_id)`. Max 4 per tab, enforced atomically in SQL. Pins survive navigate / discard / restore. Pinning auto-grants `read_dom` for any host (`*`).
2. **WebSocket bridge** — `/api/desktop/browser/copilot?ticket=…`. Tickets are minted by an authenticated HTTP endpoint (60s TTL, single-use, in-memory store), bound to `(user, agent, tab)`, and re-validated on WS upgrade. The hub fans out `page-changed` events to every iframe pinned to the tab when the proxy serves a navigation.
3. **Real `copilot.js`** — read ops only (extract / screenshot / scrollPosition / findElement). Forwards page events (scroll, form-submit) to the server AND server events (page-changed, etc.) to the parent shell via postMessage, so the parent doesn't need a separate WS.
4. **Frontend** — `+ agent` chip + `AgentPickerPopover` (Cmd+Shift+A), `AgentPresencePill` (idle / watching pulse), `AgentPanel` (slide-in side panel, drag-resize 240–480, per-agent tab bar with ✕ unpin button, recent events rail, local chat thread), `PageContextMenu` (right-click → Send to chat / Pin to Memory).

## Files

- **Backend (8 files):** `agent_pin.py` + `agent_pin_routes.py` (service + HTTP), `copilot_ws.py` (ticket store, hub, WS endpoint), `proxy.py` (page-changed broadcast hook + `tab_id` query param), `store.py` (9 new methods incl. atomic `add_pin_if_under_cap`), `schema.py` (`agent_pins` + `agent_capabilities`), `copilot.js` (full implementation), `__init__.py` wiring, `app.py` lifespan
- **Frontend (10 files):** `browser-agent-store.ts` + api wrappers; `AgentPickerPopover` / `AgentPresencePill` / `AgentPanel` / `PageContextMenu`; `agent-ws-bridge.ts`; `Chrome.tsx` / `TabRenderer.tsx` / `keyboard.ts` integrations; `Tab` type extended with `pinnedAgentIds`

## Test plan

- [ ] Backend: `pytest tests/routes/desktop_browser/ -q` → 277 passed
- [ ] Frontend: `cd desktop && npx vitest run` → 613 passed across 97 files
- [ ] TypeScript: `cd desktop && npx tsc --noEmit` → zero errors
- [ ] Manual: pin agent via Cmd+Shift+A → pill appears with green dot. Navigate → pulse fires within ~1s. Recent events rail shows the URL.
- [ ] Manual: pin 4 agents → 5th attempt returns 400 with toast.
- [ ] Manual: click ✕ on a panel tab → backend DELETEs pin + frontend updates. Last unpin closes the panel.
- [ ] Manual: with ≥1 agent pinned, the small `+` chip stays visible alongside the pill (no need to remember Cmd+Shift+A to add a 2nd agent).
- [ ] Manual: discard a tab + reload → pinned agents survive (sticky invariant).

## Security model

- WS auth via single-use ticket (60s TTL, opportunistic GC). Pin is re-checked at WS upgrade.
- Multi-user isolation enforced at every store call + hub fan-out.
- Sandbox-safe: copilot.js uses `e.source === window.parent` (not location-based origin check) since proxy iframe runs without `allow-same-origin`.
- DOMPurify-equivalent: chat thread + recent events render text only (no `dangerouslySetInnerHTML`); Reader mode (PR 5) already covers HTML sanitisation.

## Atomic invariants

- **Max 4 pins per tab**: SQL `INSERT ... WHERE (SELECT COUNT(*) ...) < 4`. Tested under concurrent fire-of-8.
- **`read_dom` auto-grant on first pin only**: `add_pin_if_under_cap` returns `"added"` / `"duplicate"` / `"at_cap"`; capability grant runs only on `"added"`.
- **Sticky pin**: `pinnedAgentIds` lives on `Tab`, preserved by `navigateTab`, `markTabDiscarded`, `markTabLive`, `goBack`, `goForward`. Tested.

## Architecture decision

The plan called for two WebSockets per (tab, agent) — one in the iframe (copilot.js) and one in the parent (events for presence pulse). The whole-branch review caught that both registrations would collide in the hub under the same key. Final design: **single iframe-side WS**, `copilot.js` forwards server events to the parent via `postMessage`. Parent listens via `agent-ws-bridge.ts`'s `openParentWs(iframe, agentId, ...)`. Cleaner, fewer tickets, no architectural ambiguity.

## Deferred to PR 7

- Drive ops in `copilot.js` (scrollTo, click, type, navigate, focus)
- Annotation layer (highlight, sticky, arrow, cursor)
- Capability prompt modal (drive / navigate / see_cookies)
- Agent-side WebSocket (agent runtime → server → iframe op dispatch)
- Real chat-channel persistence for the AgentPanel thread (currently local-only in `browser-agent-store`)
- MessagesApp + MemoryApp listeners for `prefillCard` field on the existing `taos:open-messages` and new `taos:open-memory` events (events dispatch correctly; receiving side wires up in PR 7 or a small follow-up PR)
- Right-click on the iframe interior — currently wrapper-only; PR 7 will add `contextmenu` forwarding from copilot.js
- WS reconnect-with-backoff (PR 6 uses single-shot connect)

## Spec / plan references

- Spec: \`docs/superpowers/specs/2026-05-03-browser-app-v2-design.md\` §6
- Plan: \`docs/superpowers/plans/2026-05-04-browser-app-v2-pr-6-agent-presence.md\`