### PR TITLE
feat(browser): PR 7 — co-pilot mode (driving, annotations, capability prompts)

### DIFF
--- a/desktop/src/apps/BrowserApp/AgentCapabilitiesPanel.test.tsx
+++ b/desktop/src/apps/BrowserApp/AgentCapabilitiesPanel.test.tsx
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
+import { AgentCapabilitiesPanel } from "./AgentCapabilitiesPanel";
+import * as capApi from "@/lib/browser-capability-api";
+import * as agentApi from "@/lib/browser-agent-api";
+
+vi.mock("@/lib/browser-capability-api");
+vi.mock("@/lib/browser-agent-api");
+
+const PROFILE_ID = "prof-1";
+
+const makeGrant = (
+  overrides: Partial<capApi.CapabilityGrant> = {},
+): capApi.CapabilityGrant => ({
+  agent_id: "agent-abc",
+  host_pattern: "*.example.com",
+  permissions: "read,navigate",
+  granted_at: new Date(Date.now() - 60_000).toISOString(),
+  expires_at: null,
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.mocked(capApi.listCapabilities).mockResolvedValue([]);
+  vi.mocked(capApi.revokeCapability).mockResolvedValue(true);
+  vi.mocked(agentApi.listAgents).mockResolvedValue([]);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("AgentCapabilitiesPanel", () => {
+  it("shows loading state initially", async () => {
+    // listCapabilities never resolves during this check
+    let resolve!: (v: capApi.CapabilityGrant[]) => void;
+    vi.mocked(capApi.listCapabilities).mockReturnValue(new Promise((r) => { resolve = r; }));
+
+    render(<AgentCapabilitiesPanel profileId={PROFILE_ID} onClose={vi.fn()} />);
+    expect(screen.getByText(/loading/i)).toBeTruthy();
+    resolve([]);
+  });
+
+  it("renders table with one row per grant after load", async () => {
+    vi.mocked(capApi.listCapabilities).mockResolvedValue([
+      makeGrant({ agent_id: "a1", host_pattern: "foo.com" }),
+      makeGrant({ agent_id: "a2", host_pattern: "bar.com" }),
+    ]);
+
+    render(<AgentCapabilitiesPanel profileId={PROFILE_ID} onClose={vi.fn()} />);
+    await waitFor(() => screen.getByText("foo.com"));
+    expect(screen.getByText("bar.com")).toBeTruthy();
+  });
+
+  it("empty state when no grants", async () => {
+    vi.mocked(capApi.listCapabilities).mockResolvedValue([]);
+
+    render(<AgentCapabilitiesPanel profileId={PROFILE_ID} onClose={vi.fn()} />);
+    await waitFor(() => screen.getByText(/no agent capabilities granted yet/i));
+  });
+
+  it("uses agent name from listAgents when available", async () => {
+    vi.mocked(capApi.listCapabilities).mockResolvedValue([
+      makeGrant({ agent_id: "agent-abc" }),
+    ]);
+    vi.mocked(agentApi.listAgents).mockResolvedValue([
+      { id: "agent-abc", name: "My Cool Agent" },
+    ]);
+
+    render(<AgentCapabilitiesPanel profileId={PROFILE_ID} onClose={vi.fn()} />);
+    await waitFor(() => screen.getByText("My Cool Agent"));
+  });
+
+  it("falls back to agent_id when agent name not found", async () => {
+    vi.mocked(capApi.listCapabilities).mockResolvedValue([
+      makeGrant({ agent_id: "unknown-agent" }),
+    ]);
+    vi.mocked(agentApi.listAgents).mockResolvedValue([]);
+
+    render(<AgentCapabilitiesPanel profileId={PROFILE_ID} onClose={vi.fn()} />);
+    await waitFor(() => screen.getByText("unknown-agent"));
+  });
+
+  it("formats expires_at as human-readable (In Xh / In X days)", async () => {
+    // Use 5 days (120h) so Math.floor(hours/24) is reliably >= 4 even with test overhead
+    const inFiveDays = new Date(Date.now() + 5 * 24 * 60 * 60 * 1000).toISOString();
+    vi.mocked(capApi.listCapabilities).mockResolvedValueOnce([
+      makeGrant({ expires_at: inFiveDays }),
+    ]);
+
+    render(<AgentCapabilitiesPanel profileId={PROFILE_ID} onClose={vi.fn()} />);
+    await waitFor(() => screen.getByText(/In [45] days/i));
+  });
+
+  it("expires_at null shows 'Never'", async () => {
+    vi.mocked(capApi.listCapabilities).mockResolvedValue([
+      makeGrant({ expires_at: null }),
+    ]);
+
+    render(<AgentCapabilitiesPanel profileId={PROFILE_ID} onClose={vi.fn()} />);
+    await waitFor(() => screen.getByText("Never"));
+  });
+
+  it("revoke click calls revokeCapability and refreshes list", async () => {
+    vi.mocked(capApi.listCapabilities).mockResolvedValue([
+      makeGrant({ agent_id: "agent-abc", host_pattern: "foo.com" }),
+    ]);
+    vi.mocked(capApi.revokeCapability).mockResolvedValue(true);
+    // After revoke, list returns empty
+    vi.mocked(capApi.listCapabilities)
+      .mockResolvedValueOnce([makeGrant({ agent_id: "agent-abc", host_pattern: "foo.com" })])
+      .mockResolvedValueOnce([]);
+
+    render(<AgentCapabilitiesPanel profileId={PROFILE_ID} onClose={vi.fn()} />);
+    await waitFor(() => screen.getByText("foo.com"));
+
+    const revokeBtn = screen.getByRole("button", { name: /revoke/i });
+    await act(async () => {
+      fireEvent.click(revokeBtn);
+    });
+
+    expect(capApi.revokeCapability).toHaveBeenCalledWith(PROFILE_ID, "agent-abc", "foo.com");
+    await waitFor(() => screen.getByText(/no agent capabilities granted yet/i));
+  });
+
+  it("revoke failure shows inline error", async () => {
+    vi.mocked(capApi.listCapabilities).mockResolvedValue([
+      makeGrant({ agent_id: "agent-abc", host_pattern: "foo.com" }),
+    ]);
+    vi.mocked(capApi.revokeCapability).mockResolvedValue(false);
+
+    render(<AgentCapabilitiesPanel profileId={PROFILE_ID} onClose={vi.fn()} />);
+    await waitFor(() => screen.getByText("foo.com"));
+
+    const revokeBtn = screen.getByRole("button", { name: /revoke/i });
+    await act(async () => {
+      fireEvent.click(revokeBtn);
+    });
+
+    await waitFor(() => screen.getByText(/failed to revoke/i));
+  });
+
+  it("Esc closes via onClose", async () => {
+    vi.mocked(capApi.listCapabilities).mockResolvedValue([]);
+    const onClose = vi.fn();
+
+    render(<AgentCapabilitiesPanel profileId={PROFILE_ID} onClose={onClose} />);
+    await waitFor(() => screen.getByRole("dialog"));
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("backdrop click closes via onClose", async () => {
+    vi.mocked(capApi.listCapabilities).mockResolvedValue([]);
+    const onClose = vi.fn();
+
+    render(<AgentCapabilitiesPanel profileId={PROFILE_ID} onClose={onClose} />);
+    const backdrop = await waitFor(() => screen.getByRole("dialog").parentElement!);
+
+    fireEvent.click(backdrop);
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("aria-modal + role=dialog present", async () => {
+    vi.mocked(capApi.listCapabilities).mockResolvedValue([]);
+
+    render(<AgentCapabilitiesPanel profileId={PROFILE_ID} onClose={vi.fn()} />);
+    const dialog = await waitFor(() => screen.getByRole("dialog"));
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+    expect(dialog.getAttribute("aria-label")).toMatch(/agent capabilities/i);
+  });
+});

--- a/desktop/src/apps/BrowserApp/AgentCapabilitiesPanel.tsx
+++ b/desktop/src/apps/BrowserApp/AgentCapabilitiesPanel.tsx
@@ -4,7 +4,7 @@
  *
  * Table columns: Agent | Host pattern | Permissions | Expires | Revoke
  */
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { X } from "lucide-react";
 import { listCapabilities, revokeCapability, type CapabilityGrant } from "@/lib/browser-capability-api";
 import { listAgents, type AgentDto } from "@/lib/browser-agent-api";
@@ -16,7 +16,9 @@ export interface AgentCapabilitiesPanelProps {
 
 function formatExpiry(iso: string | null): string {
   if (!iso) return "Never";
-  const ms = new Date(iso).getTime() - Date.now();
+  const parsed = new Date(iso).getTime();
+  if (Number.isNaN(parsed)) return "Invalid";
+  const ms = parsed - Date.now();
   if (ms < 0) return "Expired";
   const hours = Math.floor(ms / (60 * 60 * 1000));
   if (hours < 1) return "<1h";
@@ -29,14 +31,25 @@ export function AgentCapabilitiesPanel({ profileId, onClose }: AgentCapabilities
   const [grants, setGrants] = useState<CapabilityGrant[] | null>(null);
   const [agents, setAgents] = useState<AgentDto[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const loadSeqRef = useRef(0);
 
   async function load() {
-    const [fetchedGrants, fetchedAgents] = await Promise.all([
-      listCapabilities(profileId),
-      listAgents(),
-    ]);
-    setGrants(fetchedGrants);
-    setAgents(fetchedAgents);
+    const seq = ++loadSeqRef.current;
+    setError(null);
+    try {
+      const [fetchedGrants, fetchedAgents] = await Promise.all([
+        listCapabilities(profileId),
+        listAgents(),
+      ]);
+      if (seq !== loadSeqRef.current) return;
+      setGrants(fetchedGrants);
+      setAgents(fetchedAgents);
+    } catch {
+      if (seq !== loadSeqRef.current) return;
+      setError("Failed to load capabilities. Please try again.");
+      setGrants([]);
+      setAgents([]);
+    }
   }
 
   useEffect(() => {
@@ -53,14 +66,18 @@ export function AgentCapabilitiesPanel({ profileId, onClose }: AgentCapabilities
 
   async function handleRevoke(grant: CapabilityGrant) {
     setError(null);
-    const ok = await revokeCapability(profileId, grant.agent_id, grant.host_pattern);
-    if (!ok) {
+    try {
+      const ok = await revokeCapability(profileId, grant.agent_id, grant.host_pattern);
+      if (!ok) {
+        setError("Failed to revoke capability. Please try again.");
+        return;
+      }
+      // Refresh list
+      const fresh = await listCapabilities(profileId);
+      setGrants(fresh);
+    } catch {
       setError("Failed to revoke capability. Please try again.");
-      return;
     }
-    // Refresh list
-    const fresh = await listCapabilities(profileId);
-    setGrants(fresh);
   }
 
   function agentName(agentId: string): string {

--- a/desktop/src/apps/BrowserApp/AgentCapabilitiesPanel.tsx
+++ b/desktop/src/apps/BrowserApp/AgentCapabilitiesPanel.tsx
@@ -1,0 +1,166 @@
+/**
+ * Modal listing all agent capability grants for the current profile.
+ * User can revoke individual grants. Mounted from SettingsPanel.
+ *
+ * Table columns: Agent | Host pattern | Permissions | Expires | Revoke
+ */
+import { useEffect, useState } from "react";
+import { X } from "lucide-react";
+import { listCapabilities, revokeCapability, type CapabilityGrant } from "@/lib/browser-capability-api";
+import { listAgents, type AgentDto } from "@/lib/browser-agent-api";
+
+export interface AgentCapabilitiesPanelProps {
+  profileId: string;
+  onClose(): void;
+}
+
+function formatExpiry(iso: string | null): string {
+  if (!iso) return "Never";
+  const ms = new Date(iso).getTime() - Date.now();
+  if (ms < 0) return "Expired";
+  const hours = Math.floor(ms / (60 * 60 * 1000));
+  if (hours < 1) return "<1h";
+  if (hours < 24) return `In ${hours}h`;
+  const days = Math.floor(hours / 24);
+  return `In ${days} day${days === 1 ? "" : "s"}`;
+}
+
+export function AgentCapabilitiesPanel({ profileId, onClose }: AgentCapabilitiesPanelProps) {
+  const [grants, setGrants] = useState<CapabilityGrant[] | null>(null);
+  const [agents, setAgents] = useState<AgentDto[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  async function load() {
+    const [fetchedGrants, fetchedAgents] = await Promise.all([
+      listCapabilities(profileId),
+      listAgents(),
+    ]);
+    setGrants(fetchedGrants);
+    setAgents(fetchedAgents);
+  }
+
+  useEffect(() => {
+    load();
+  }, [profileId]);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [onClose]);
+
+  async function handleRevoke(grant: CapabilityGrant) {
+    setError(null);
+    const ok = await revokeCapability(profileId, grant.agent_id, grant.host_pattern);
+    if (!ok) {
+      setError("Failed to revoke capability. Please try again.");
+      return;
+    }
+    // Refresh list
+    const fresh = await listCapabilities(profileId);
+    setGrants(fresh);
+  }
+
+  function agentName(agentId: string): string {
+    const found = agents.find((a) => a.id === agentId);
+    return found ? found.name : agentId;
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-[70] flex items-center justify-center bg-black/40 p-4"
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Agent capabilities"
+        className="relative bg-shell-surface rounded-md shadow-xl border border-shell-border w-[600px] max-w-full max-h-[80vh] flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="flex items-center justify-between px-4 py-3 border-b border-shell-border-subtle">
+          <h2 className="text-sm font-medium">Agent capabilities</h2>
+          <button
+            type="button"
+            aria-label="Close agent capabilities"
+            onClick={onClose}
+            className="p-1 rounded hover:bg-shell-hover"
+          >
+            <X size={16} />
+          </button>
+        </header>
+
+        {error && (
+          <div className="mx-4 mt-3 px-3 py-2 rounded bg-red-500/10 border border-red-500/30 text-red-400 text-xs">
+            {error}
+          </div>
+        )}
+
+        <div className="flex-1 overflow-y-auto">
+          {grants === null ? (
+            <p className="px-4 py-4 text-xs opacity-60 italic">Loading…</p>
+          ) : grants.length === 0 ? (
+            <p className="px-4 py-4 text-xs opacity-60 italic">No agent capabilities granted yet</p>
+          ) : (
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="border-b border-shell-border-subtle text-shell-text-secondary">
+                  <th className="px-4 py-2 text-left font-medium">Agent</th>
+                  <th className="px-4 py-2 text-left font-medium">Host pattern</th>
+                  <th className="px-4 py-2 text-left font-medium">Permissions</th>
+                  <th className="px-4 py-2 text-left font-medium">Expires</th>
+                  <th className="px-4 py-2 text-left font-medium sr-only">Revoke</th>
+                </tr>
+              </thead>
+              <tbody>
+                {grants.map((grant) => (
+                  <tr
+                    key={`${grant.agent_id}::${grant.host_pattern}`}
+                    className="border-b border-shell-border-subtle/40 hover:bg-shell-hover"
+                  >
+                    <td className="px-4 py-2">{agentName(grant.agent_id)}</td>
+                    <td className="px-4 py-2">
+                      <span
+                        className="font-mono truncate max-w-[160px] block"
+                        title={grant.host_pattern}
+                      >
+                        {grant.host_pattern}
+                      </span>
+                    </td>
+                    <td className="px-4 py-2">
+                      <div className="flex flex-wrap gap-1">
+                        {grant.permissions.split(",").map((p) => (
+                          <span
+                            key={p}
+                            className="px-1.5 py-0.5 rounded bg-shell-bg-deep text-shell-text-secondary text-[10px]"
+                          >
+                            {p.trim()}
+                          </span>
+                        ))}
+                      </div>
+                    </td>
+                    <td className="px-4 py-2 whitespace-nowrap">
+                      {formatExpiry(grant.expires_at)}
+                    </td>
+                    <td className="px-4 py-2">
+                      <button
+                        type="button"
+                        aria-label={`Revoke ${grant.permissions} on ${grant.host_pattern}`}
+                        onClick={() => handleRevoke(grant)}
+                        className="p-1 rounded hover:bg-red-500/20 text-shell-text-secondary hover:text-red-400"
+                      >
+                        <X size={12} />
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/apps/BrowserApp/AgentPresencePill.tsx
+++ b/desktop/src/apps/BrowserApp/AgentPresencePill.tsx
@@ -41,6 +41,11 @@ export function AgentPresencePill({
   const togglePanel = useBrowserAgentStore((s) => s.togglePanel);
   const isWatching = useBrowserAgentStore((s) => s.isWatching);
 
+  // Subscribe to drivingState so the pill reflects driving visual
+  const isDriving = useBrowserAgentStore((s) =>
+    pinnedAgentIds.some((aid) => s.drivingState[`${windowId}:${tabId}:${aid}`] === "driving"),
+  );
+
   const panelKey = `${windowId}:${tabId}`;
   const panelIsOpen = panels[panelKey]?.isOpen ?? false;
 
@@ -144,14 +149,19 @@ export function AgentPresencePill({
         ))}
       </div>
 
-      {/* Presence dot */}
+      {/* Presence dot — three states:
+           driving: brighter green + faster pulse (animate-ping approximates fast)
+           watching: standard green + pulse
+           idle: dark green, static */}
       <span
         data-testid="presence-dot"
         aria-hidden="true"
         className={[
           "absolute -top-0.5 -right-0.5",
           "w-2 h-2 rounded-full ring-1 ring-shell-surface",
-          anyWatching
+          isDriving
+            ? "bg-green-400 animate-ping"
+            : anyWatching
             ? "bg-green-400 animate-pulse"
             : "bg-green-600",
         ].join(" ")}

--- a/desktop/src/apps/BrowserApp/AnnotationLayer.test.tsx
+++ b/desktop/src/apps/BrowserApp/AnnotationLayer.test.tsx
@@ -1,0 +1,210 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, act } from "@testing-library/react";
+import { AnnotationLayer } from "./AnnotationLayer";
+import { useBrowserAgentStore } from "@/stores/browser-agent-store";
+
+const WINDOW_ID = "win-1";
+const TAB_ID = "tab-1";
+
+beforeEach(() => {
+  useBrowserAgentStore.setState({
+    panels: {},
+    lastEventAt: {},
+    messages: {},
+    recentEvents: {},
+    annotations: {},
+  });
+});
+
+describe("AnnotationLayer", () => {
+  it("renders an empty SVG when no annotations", () => {
+    const { container } = render(
+      <AnnotationLayer windowId={WINDOW_ID} tabId={TAB_ID} />,
+    );
+    const svg = container.querySelector("svg");
+    expect(svg).toBeTruthy();
+    expect(container.querySelector("polygon")).toBeNull();
+    expect(container.querySelector("line")).toBeNull();
+  });
+
+  it("renders a cursor as a polygon at the right position", () => {
+    useBrowserAgentStore.getState().addAnnotation(WINDOW_ID, TAB_ID, {
+      kind: "cursor",
+      id: "c-1",
+      agentId: "agent-a",
+      x: 100,
+      y: 200,
+    });
+
+    const { container } = render(
+      <AnnotationLayer windowId={WINDOW_ID} tabId={TAB_ID} />,
+    );
+
+    const polygon = container.querySelector("polygon");
+    expect(polygon).toBeTruthy();
+    // The points attribute should encode the x,y origin
+    expect(polygon!.getAttribute("points")).toContain("100,200");
+  });
+
+  it("renders the cursor's label as text", () => {
+    useBrowserAgentStore.getState().addAnnotation(WINDOW_ID, TAB_ID, {
+      kind: "cursor",
+      id: "c-1",
+      agentId: "agent-a",
+      x: 50,
+      y: 80,
+      label: "Agent A",
+    });
+
+    const { container } = render(
+      <AnnotationLayer windowId={WINDOW_ID} tabId={TAB_ID} />,
+    );
+
+    const text = container.querySelector("text");
+    expect(text).toBeTruthy();
+    expect(text!.textContent).toBe("Agent A");
+  });
+
+  it("renders an arrow as a line between two points", () => {
+    useBrowserAgentStore.getState().addAnnotation(WINDOW_ID, TAB_ID, {
+      kind: "arrow",
+      id: "arr-1",
+      agentId: "agent-a",
+      from: { x: 10, y: 20 },
+      to: { x: 100, y: 200 },
+    });
+
+    const { container } = render(
+      <AnnotationLayer windowId={WINDOW_ID} tabId={TAB_ID} />,
+    );
+
+    const line = container.querySelector("line");
+    expect(line).toBeTruthy();
+    expect(line!.getAttribute("x1")).toBe("10");
+    expect(line!.getAttribute("y1")).toBe("20");
+    expect(line!.getAttribute("x2")).toBe("100");
+    expect(line!.getAttribute("y2")).toBe("200");
+  });
+
+  it("uses provided colors", () => {
+    useBrowserAgentStore.getState().addAnnotation(WINDOW_ID, TAB_ID, {
+      kind: "cursor",
+      id: "c-1",
+      agentId: "agent-a",
+      x: 10,
+      y: 10,
+      color: "#ff0000",
+    });
+
+    const { container } = render(
+      <AnnotationLayer windowId={WINDOW_ID} tabId={TAB_ID} />,
+    );
+
+    const polygon = container.querySelector("polygon");
+    expect(polygon!.getAttribute("fill")).toBe("#ff0000");
+  });
+
+  it("falls back to default color when not specified", () => {
+    useBrowserAgentStore.getState().addAnnotation(WINDOW_ID, TAB_ID, {
+      kind: "cursor",
+      id: "c-1",
+      agentId: "agent-a",
+      x: 10,
+      y: 10,
+    });
+
+    const { container } = render(
+      <AnnotationLayer windowId={WINDOW_ID} tabId={TAB_ID} />,
+    );
+
+    const polygon = container.querySelector("polygon");
+    expect(polygon!.getAttribute("fill")).toBe("#6c8df0");
+  });
+
+  it("uses pointer-events: none so it doesn't block iframe", () => {
+    const { container } = render(
+      <AnnotationLayer windowId={WINDOW_ID} tabId={TAB_ID} />,
+    );
+
+    const svg = container.querySelector("svg");
+    expect(svg!.style.pointerEvents).toBe("none");
+  });
+
+  it("re-renders when addAnnotation is called", () => {
+    const { container } = render(
+      <AnnotationLayer windowId={WINDOW_ID} tabId={TAB_ID} />,
+    );
+
+    expect(container.querySelector("polygon")).toBeNull();
+
+    act(() => {
+      useBrowserAgentStore.getState().addAnnotation(WINDOW_ID, TAB_ID, {
+        kind: "cursor",
+        id: "c-1",
+        agentId: "agent-a",
+        x: 50,
+        y: 50,
+      });
+    });
+
+    expect(container.querySelector("polygon")).toBeTruthy();
+  });
+
+  it("removes annotation when clearAnnotation is called", () => {
+    useBrowserAgentStore.getState().addAnnotation(WINDOW_ID, TAB_ID, {
+      kind: "cursor",
+      id: "c-1",
+      agentId: "agent-a",
+      x: 50,
+      y: 50,
+    });
+
+    const { container } = render(
+      <AnnotationLayer windowId={WINDOW_ID} tabId={TAB_ID} />,
+    );
+
+    expect(container.querySelector("polygon")).toBeTruthy();
+
+    act(() => {
+      useBrowserAgentStore.getState().clearAnnotation(WINDOW_ID, TAB_ID, "c-1");
+    });
+
+    expect(container.querySelector("polygon")).toBeNull();
+  });
+
+  it("clearAnnotations removes all for the (window, tab)", () => {
+    const s = useBrowserAgentStore.getState();
+    s.addAnnotation(WINDOW_ID, TAB_ID, { kind: "cursor", id: "c-1", agentId: "agent-a", x: 10, y: 10 });
+    s.addAnnotation(WINDOW_ID, TAB_ID, { kind: "cursor", id: "c-2", agentId: "agent-b", x: 20, y: 20 });
+
+    const { container } = render(
+      <AnnotationLayer windowId={WINDOW_ID} tabId={TAB_ID} />,
+    );
+
+    expect(container.querySelectorAll("polygon")).toHaveLength(2);
+
+    act(() => {
+      useBrowserAgentStore.getState().clearAnnotations(WINDOW_ID, TAB_ID);
+    });
+
+    expect(container.querySelectorAll("polygon")).toHaveLength(0);
+  });
+
+  it("clearAnnotations(agentId) removes only that agent's annotations", () => {
+    const s = useBrowserAgentStore.getState();
+    s.addAnnotation(WINDOW_ID, TAB_ID, { kind: "cursor", id: "c-1", agentId: "agent-a", x: 10, y: 10 });
+    s.addAnnotation(WINDOW_ID, TAB_ID, { kind: "cursor", id: "c-2", agentId: "agent-b", x: 20, y: 20 });
+
+    const { container } = render(
+      <AnnotationLayer windowId={WINDOW_ID} tabId={TAB_ID} />,
+    );
+
+    expect(container.querySelectorAll("polygon")).toHaveLength(2);
+
+    act(() => {
+      useBrowserAgentStore.getState().clearAnnotations(WINDOW_ID, TAB_ID, "agent-a");
+    });
+
+    expect(container.querySelectorAll("polygon")).toHaveLength(1);
+  });
+});

--- a/desktop/src/apps/BrowserApp/AnnotationLayer.tsx
+++ b/desktop/src/apps/BrowserApp/AnnotationLayer.tsx
@@ -10,9 +10,12 @@
 import { useBrowserAgentStore } from "@/stores/browser-agent-store";
 import type { Annotation, AnnotationCursor, AnnotationArrow } from "@/stores/browser-agent-store";
 
-const MARKER_ID = "annotation-arrowhead";
 const DEFAULT_COLOR = "#6c8df0";
 const EMPTY: Annotation[] = [];
+
+/** Stable marker id per color — avoids collisions between AnnotationLayer instances. */
+const markerIdFor = (color: string) =>
+  `annotation-arrowhead-${color.replace(/[^a-zA-Z0-9_-]/g, "_")}`;
 
 export interface AnnotationLayerProps {
   windowId: string;
@@ -43,16 +46,19 @@ export function AnnotationLayer({ windowId, tabId }: AnnotationLayerProps) {
     >
       {arrows.length > 0 && (
         <defs>
-          <marker
-            id={MARKER_ID}
-            markerWidth="8"
-            markerHeight="8"
-            refX="6"
-            refY="3"
-            orient="auto"
-          >
-            <path d="M0,0 L0,6 L8,3 z" fill={DEFAULT_COLOR} />
-          </marker>
+          {[...new Set(arrows.map((a) => a.color ?? DEFAULT_COLOR))].map((color) => (
+            <marker
+              key={color}
+              id={markerIdFor(color)}
+              markerWidth="8"
+              markerHeight="8"
+              refX="6"
+              refY="3"
+              orient="auto"
+            >
+              <path d="M0,0 L0,6 L8,3 z" fill={color} />
+            </marker>
+          ))}
         </defs>
       )}
 
@@ -100,7 +106,7 @@ export function AnnotationLayer({ windowId, tabId }: AnnotationLayerProps) {
             y2={arrow.to.y}
             stroke={color}
             strokeWidth={2}
-            markerEnd={`url(#${MARKER_ID})`}
+            markerEnd={`url(#${markerIdFor(color)})`}
           />
         );
       })}

--- a/desktop/src/apps/BrowserApp/AnnotationLayer.tsx
+++ b/desktop/src/apps/BrowserApp/AnnotationLayer.tsx
@@ -1,0 +1,109 @@
+/**
+ * Parent-overlay SVG for cursor + free-floating arrows.
+ *
+ * Positioned absolutely over the iframe (TabRenderer mounts it inside the
+ * iframe wrapper). Pointer-events none — must not block iframe interaction.
+ *
+ * Renders a cursor (filled triangle with optional label) and arrows
+ * (line + arrowhead at end).
+ */
+import { useBrowserAgentStore } from "@/stores/browser-agent-store";
+import type { Annotation, AnnotationCursor, AnnotationArrow } from "@/stores/browser-agent-store";
+
+const MARKER_ID = "annotation-arrowhead";
+const DEFAULT_COLOR = "#6c8df0";
+const EMPTY: Annotation[] = [];
+
+export interface AnnotationLayerProps {
+  windowId: string;
+  tabId: string;
+}
+
+export function AnnotationLayer({ windowId, tabId }: AnnotationLayerProps) {
+  const key = `${windowId}:${tabId}`;
+  // Select the specific array for this tab — falls back to the stable EMPTY
+  // constant so Zustand's Object.is comparison never sees a new reference
+  // when the key is absent (which would cause an infinite render loop).
+  const annotations = useBrowserAgentStore((s) => s.annotations[key] ?? EMPTY);
+
+  const cursors = annotations.filter((a): a is AnnotationCursor => a.kind === "cursor");
+  const arrows = annotations.filter((a): a is AnnotationArrow => a.kind === "arrow");
+
+  return (
+    <svg
+      aria-hidden="true"
+      style={{
+        position: "absolute",
+        inset: 0,
+        width: "100%",
+        height: "100%",
+        pointerEvents: "none",
+        overflow: "visible",
+      }}
+    >
+      {arrows.length > 0 && (
+        <defs>
+          <marker
+            id={MARKER_ID}
+            markerWidth="8"
+            markerHeight="8"
+            refX="6"
+            refY="3"
+            orient="auto"
+          >
+            <path d="M0,0 L0,6 L8,3 z" fill={DEFAULT_COLOR} />
+          </marker>
+        </defs>
+      )}
+
+      {cursors.map((cursor) => {
+        const color = cursor.color ?? DEFAULT_COLOR;
+        // Triangle pointing top-left: tip at (x, y), opening to bottom-right
+        const pts = `${cursor.x},${cursor.y} ${cursor.x + 10},${cursor.y + 16} ${cursor.x + 4},${cursor.y + 12}`;
+        return (
+          <g key={cursor.id}>
+            <polygon points={pts} fill={color} />
+            {cursor.label && (
+              <>
+                <rect
+                  x={cursor.x + 12}
+                  y={cursor.y - 1}
+                  width={cursor.label.length * 7 + 8}
+                  height={18}
+                  rx={3}
+                  fill={color}
+                  opacity={0.9}
+                />
+                <text
+                  x={cursor.x + 16}
+                  y={cursor.y + 12}
+                  fontSize={12}
+                  fill="#fff"
+                  fontFamily="sans-serif"
+                >
+                  {cursor.label}
+                </text>
+              </>
+            )}
+          </g>
+        );
+      })}
+
+      {arrows.map((arrow) => {
+        const color = arrow.color ?? DEFAULT_COLOR;
+        return (
+          <line
+            key={arrow.id}
+            x1={arrow.from.x}
+            y1={arrow.from.y}
+            x2={arrow.to.x}
+            y2={arrow.to.y}
+            stroke={color}
+            strokeWidth={2}
+            markerEnd={`url(#${MARKER_ID})`}
+          />
+        );
+      })}
+    </svg>
+  );
+}

--- a/desktop/src/apps/BrowserApp/BrowserApp.tsx
+++ b/desktop/src/apps/BrowserApp/BrowserApp.tsx
@@ -121,6 +121,7 @@ export function BrowserApp({ windowId }: BrowserAppProps) {
             <ListChecks size={14} />
           </button>
         </div>
+        <CapabilityPromptModal />
       </div>
     );
   }

--- a/desktop/src/apps/BrowserApp/BrowserApp.tsx
+++ b/desktop/src/apps/BrowserApp/BrowserApp.tsx
@@ -25,6 +25,7 @@ import { useBrowserKeyboardShortcuts } from "./keyboard";
 import { FindInPage } from "./FindInPage";
 import { TabOverview } from "./TabOverview";
 import { WindowChooser } from "./WindowChooser";
+import { CapabilityPromptModal } from "./CapabilityPromptModal";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { Layers, ListChecks } from "lucide-react";
 
@@ -138,6 +139,10 @@ export function BrowserApp({ windowId }: BrowserAppProps) {
           onClose={() => setFindOpen(false)}
         />
       )}
+      {/* Listens for `taos-browser:capability-prompt` window events from
+           agent-ws-bridge. Mounted at top of BrowserApp so any window's
+           agents can trigger it; the modal is global per shell. */}
+      <CapabilityPromptModal />
     </div>
   );
 }

--- a/desktop/src/apps/BrowserApp/CapabilityPromptModal.test.tsx
+++ b/desktop/src/apps/BrowserApp/CapabilityPromptModal.test.tsx
@@ -1,0 +1,188 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { CapabilityPromptModal } from "./CapabilityPromptModal";
+import * as capabilityApi from "@/lib/browser-capability-api";
+
+function dispatchPromptEvent(detail: object) {
+  window.dispatchEvent(
+    new CustomEvent("taos-browser:capability-prompt", { detail }),
+  );
+}
+
+const BASE_DETAIL = {
+  profileId: "profile-1",
+  agentId: "agent-42",
+  agentName: "TestAgent",
+  permission: "drive",
+  host: "example.com",
+  fullUrl: "https://example.com/page",
+};
+
+beforeEach(() => {
+  vi.spyOn(capabilityApi, "grantCapability").mockResolvedValue({ granted: true });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("CapabilityPromptModal", () => {
+  it("renders nothing when no event has fired", () => {
+    render(<CapabilityPromptModal />);
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("renders modal when taos-browser:capability-prompt event dispatched", async () => {
+    render(<CapabilityPromptModal />);
+    act(() => { dispatchPromptEvent(BASE_DETAIL); });
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeTruthy();
+    });
+  });
+
+  it("shows the agent name + permission + host", async () => {
+    render(<CapabilityPromptModal />);
+    act(() => { dispatchPromptEvent(BASE_DETAIL); });
+    await waitFor(() => {
+      const dialog = screen.getByRole("dialog");
+      expect(dialog.textContent).toContain("TestAgent");
+      expect(dialog.textContent).toContain("drive");
+      expect(dialog.textContent).toContain("example.com");
+    });
+  });
+
+  it("'This page only' calls grantCapability with full URL + ~1h expiry", async () => {
+    render(<CapabilityPromptModal />);
+    act(() => { dispatchPromptEvent(BASE_DETAIL); });
+    await waitFor(() => { expect(screen.getByRole("dialog")).toBeTruthy(); });
+
+    const expectedMs = Date.now() + 60 * 60 * 1000;
+    fireEvent.click(screen.getByText(/This page only/));
+    await waitFor(() => {
+      expect(capabilityApi.grantCapability).toHaveBeenCalledWith(
+        "profile-1",
+        "agent-42",
+        "https://example.com/page",
+        "drive",
+        expect.any(String),
+      );
+      const calls = (capabilityApi.grantCapability as ReturnType<typeof vi.fn>).mock.calls;
+      const expiresAt = calls[0][4] as string;
+      const actualMs = new Date(expiresAt).getTime();
+      expect(Math.abs(actualMs - expectedMs)).toBeLessThan(5000);
+    });
+  });
+
+  it("'This site (this session)' calls grantCapability with host + ~24h expiry", async () => {
+    render(<CapabilityPromptModal />);
+    act(() => { dispatchPromptEvent(BASE_DETAIL); });
+    await waitFor(() => { expect(screen.getByRole("dialog")).toBeTruthy(); });
+
+    const expectedMs = Date.now() + 24 * 60 * 60 * 1000;
+    fireEvent.click(screen.getByText(/This site \(this session\)/));
+    await waitFor(() => {
+      expect(capabilityApi.grantCapability).toHaveBeenCalledWith(
+        "profile-1",
+        "agent-42",
+        "example.com",
+        "drive",
+        expect.any(String),
+      );
+      const calls = (capabilityApi.grantCapability as ReturnType<typeof vi.fn>).mock.calls;
+      const expiresAt = calls[0][4] as string;
+      const actualMs = new Date(expiresAt).getTime();
+      expect(Math.abs(actualMs - expectedMs)).toBeLessThan(5000);
+    });
+  });
+
+  it("'This site (always)' calls grantCapability with host + null expiry", async () => {
+    render(<CapabilityPromptModal />);
+    act(() => { dispatchPromptEvent(BASE_DETAIL); });
+    await waitFor(() => { expect(screen.getByRole("dialog")).toBeTruthy(); });
+
+    fireEvent.click(screen.getByText(/This site \(always\)/));
+    await waitFor(() => {
+      expect(capabilityApi.grantCapability).toHaveBeenCalledWith(
+        "profile-1",
+        "agent-42",
+        "example.com",
+        "drive",
+        null,
+      );
+    });
+  });
+
+  it("'Deny' closes without calling grantCapability", async () => {
+    render(<CapabilityPromptModal />);
+    act(() => { dispatchPromptEvent(BASE_DETAIL); });
+    await waitFor(() => { expect(screen.getByRole("dialog")).toBeTruthy(); });
+
+    fireEvent.click(screen.getByText(/^Deny/));
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+    expect(capabilityApi.grantCapability).not.toHaveBeenCalled();
+  });
+
+  it("Esc closes without granting", async () => {
+    render(<CapabilityPromptModal />);
+    act(() => { dispatchPromptEvent(BASE_DETAIL); });
+    await waitFor(() => { expect(screen.getByRole("dialog")).toBeTruthy(); });
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+    expect(capabilityApi.grantCapability).not.toHaveBeenCalled();
+  });
+
+  it("click-outside backdrop closes without granting", async () => {
+    render(<CapabilityPromptModal />);
+    act(() => { dispatchPromptEvent(BASE_DETAIL); });
+    await waitFor(() => { expect(screen.getByRole("dialog")).toBeTruthy(); });
+
+    // Click on the backdrop (the dialog element itself, not its inner content)
+    const backdrop = screen.getByRole("dialog");
+    fireEvent.click(backdrop, { target: backdrop });
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+    expect(capabilityApi.grantCapability).not.toHaveBeenCalled();
+  });
+
+  it("error from grantCapability shows inline; modal stays open", async () => {
+    vi.spyOn(capabilityApi, "grantCapability").mockResolvedValue({
+      error: "host pattern rejected",
+    });
+    render(<CapabilityPromptModal />);
+    act(() => { dispatchPromptEvent(BASE_DETAIL); });
+    await waitFor(() => { expect(screen.getByRole("dialog")).toBeTruthy(); });
+
+    fireEvent.click(screen.getByText(/This page only/));
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeTruthy();
+      expect(screen.getByText("host pattern rejected")).toBeTruthy();
+      expect(screen.getByRole("dialog")).toBeTruthy();
+    });
+  });
+
+  it("grant success closes the modal", async () => {
+    render(<CapabilityPromptModal />);
+    act(() => { dispatchPromptEvent(BASE_DETAIL); });
+    await waitFor(() => { expect(screen.getByRole("dialog")).toBeTruthy(); });
+
+    fireEvent.click(screen.getByText(/This site \(always\)/));
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+  });
+
+  it("aria-modal + role=dialog present", async () => {
+    render(<CapabilityPromptModal />);
+    act(() => { dispatchPromptEvent(BASE_DETAIL); });
+    await waitFor(() => {
+      const dialog = screen.getByRole("dialog");
+      expect(dialog.getAttribute("aria-modal")).toBe("true");
+    });
+  });
+});

--- a/desktop/src/apps/BrowserApp/CapabilityPromptModal.tsx
+++ b/desktop/src/apps/BrowserApp/CapabilityPromptModal.tsx
@@ -1,0 +1,169 @@
+/**
+ * Modal popped on `capability-needed` event from an agent.
+ *
+ * The user picks a grant scope:
+ *   - This page only         → host_pattern = full URL, expires in 1h
+ *   - This site (this session) → host_pattern = hostname, expires in 24h
+ *   - This site (always)     → host_pattern = hostname, expires_at = null
+ *   - Deny                   → no grant; modal closes
+ *
+ * Triggered by a window event:
+ *   window.dispatchEvent(new CustomEvent("taos-browser:capability-prompt", {
+ *     detail: { profileId, agentId, agentName?, permission, host, fullUrl }
+ *   }));
+ *
+ * Mounted at top of BrowserApp (or globally) so it catches the event regardless
+ * of which window/tab triggered it.
+ */
+import { useEffect, useState } from "react";
+import { grantCapability } from "@/lib/browser-capability-api";
+
+export interface CapabilityPromptDetail {
+  profileId: string;
+  agentId: string;
+  agentName?: string;
+  permission: string;
+  host: string;
+  fullUrl: string;
+}
+
+export function CapabilityPromptModal() {
+  const [detail, setDetail] = useState<CapabilityPromptDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  useEffect(() => {
+    function handler(e: Event) {
+      const ce = e as CustomEvent<CapabilityPromptDetail>;
+      if (!ce.detail) return;
+      setDetail(ce.detail);
+      setError(null);
+    }
+    window.addEventListener("taos-browser:capability-prompt", handler);
+    return () => window.removeEventListener("taos-browser:capability-prompt", handler);
+  }, []);
+
+  // Esc closes (treats as Deny without grant)
+  useEffect(() => {
+    if (!detail) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setDetail(null);
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [detail]);
+
+  if (!detail) return null;
+
+  async function applyGrant(scope: "page" | "session" | "always") {
+    if (!detail) return;
+    setPending(true);
+    setError(null);
+    try {
+      let hostPattern: string;
+      let expiresAt: string | null;
+      if (scope === "page") {
+        hostPattern = detail.fullUrl;
+        expiresAt = isoOffset(60 * 60 * 1000); // 1h
+      } else if (scope === "session") {
+        hostPattern = detail.host;
+        expiresAt = isoOffset(24 * 60 * 60 * 1000); // 24h
+      } else {
+        hostPattern = detail.host;
+        expiresAt = null;
+      }
+      const result = await grantCapability(
+        detail.profileId,
+        detail.agentId,
+        hostPattern,
+        detail.permission,
+        expiresAt,
+      );
+      if (result && "error" in result) {
+        setError(result.error);
+        return;
+      }
+      if (!result) {
+        setError("Network error — please retry");
+        return;
+      }
+      setDetail(null);
+    } finally {
+      setPending(false);
+    }
+  }
+
+  function deny() { setDetail(null); }
+
+  const label = detail.agentName ?? detail.agentId;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="capability-prompt-title"
+      className="fixed inset-0 z-[80] flex items-center justify-center bg-black/40 p-4"
+      onClick={(e) => { if (e.target === e.currentTarget) deny(); }}
+    >
+      <div className="bg-shell-surface border border-shell-border-subtle rounded-md max-w-md w-full p-4 shadow-2xl">
+        <h2 id="capability-prompt-title" className="text-sm font-medium text-shell-text mb-1">
+          {label} is asking to {prettyPermission(detail.permission)} on {detail.host}.
+        </h2>
+        <p className="text-xs text-shell-text-secondary mb-4">
+          You can grant this permission for the current page, this site for the
+          current session, or always. You can revoke it later in Settings.
+        </p>
+        {error && (
+          <div role="alert" className="text-xs text-red-400 bg-red-500/10 border border-red-500/40 rounded px-2 py-1 mb-3">
+            {error}
+          </div>
+        )}
+        <div className="flex flex-col gap-2">
+          <button
+            type="button"
+            disabled={pending}
+            onClick={() => applyGrant("page")}
+            className="text-left text-xs px-3 py-2 rounded border border-shell-border-subtle hover:bg-shell-hover disabled:opacity-50"
+          >
+            <strong>This page only</strong> · expires in 1 hour
+          </button>
+          <button
+            type="button"
+            disabled={pending}
+            onClick={() => applyGrant("session")}
+            className="text-left text-xs px-3 py-2 rounded border border-shell-border-subtle hover:bg-shell-hover disabled:opacity-50"
+          >
+            <strong>This site (this session)</strong> · expires in 24 hours
+          </button>
+          <button
+            type="button"
+            disabled={pending}
+            onClick={() => applyGrant("always")}
+            className="text-left text-xs px-3 py-2 rounded border border-shell-border-subtle hover:bg-shell-hover disabled:opacity-50"
+          >
+            <strong>This site (always)</strong> · no expiry; revoke in Settings
+          </button>
+          <button
+            type="button"
+            disabled={pending}
+            onClick={deny}
+            className="text-left text-xs px-3 py-2 rounded border border-shell-border-subtle hover:bg-shell-hover disabled:opacity-50"
+          >
+            <strong>Deny</strong> · agent can ask again later
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function isoOffset(deltaMs: number): string {
+  return new Date(Date.now() + deltaMs).toISOString();
+}
+
+function prettyPermission(p: string): string {
+  if (p === "drive") return "drive (click, type, scroll, focus)";
+  if (p === "navigate") return "navigate";
+  if (p === "see_cookies") return "read raw cookies";
+  return p;
+}

--- a/desktop/src/apps/BrowserApp/Chrome.tsx
+++ b/desktop/src/apps/BrowserApp/Chrome.tsx
@@ -11,12 +11,14 @@
 import { useState, useEffect, useRef } from "react";
 import { ArrowLeft, ArrowRight, RotateCw, Settings } from "lucide-react";
 import { useBrowserStore } from "@/stores/browser-store";
+import { useBrowserAgentStore } from "@/stores/browser-agent-store";
 import { listProfiles, type Profile } from "@/lib/browser-profile-api";
 import { ProfileSwitcher } from "./ProfileSwitcher";
 import { ProfileManager } from "./ProfileManager";
 import { SettingsPanel } from "./SettingsPanel";
 import { AgentPickerPopover } from "./AgentPickerPopover";
 import { AgentPresencePill } from "./AgentPresencePill";
+import { CoPilotBanner } from "./CoPilotBanner";
 
 interface ChromeProps {
   windowId: string;
@@ -59,6 +61,13 @@ export function Chrome({ windowId }: ChromeProps) {
     return () => window.removeEventListener("taos-browser:open-agent-picker", handler);
   }, [windowId]);
 
+  // Subscribe to drivingState so the banner mounts/unmounts reactively.
+  const drivingAgentId = useBrowserAgentStore((s) => {
+    if (!win) return null;
+    const activeTabId = win.activeTabId;
+    return s.isAnyDriving(windowId, activeTabId);
+  });
+
   if (!win) return null;
 
   const activeTab = win.tabs.find((t) => t.id === win.activeTabId);
@@ -76,6 +85,15 @@ export function Chrome({ windowId }: ChromeProps) {
   };
 
   return (
+    <div className="flex flex-col">
+      {drivingAgentId && (
+        <CoPilotBanner
+          windowId={windowId}
+          tabId={activeTab.id}
+          profileId={win.profileId}
+          agentId={drivingAgentId}
+        />
+      )}
     <div
       className="flex items-center gap-2 px-2 py-1 bg-shell-surface border-b border-shell-border-subtle"
       role="toolbar"
@@ -230,6 +248,7 @@ export function Chrome({ windowId }: ChromeProps) {
           onClose={() => setManagerOpen(false)}
         />
       )}
+    </div>
     </div>
   );
 }

--- a/desktop/src/apps/BrowserApp/Chrome.tsx
+++ b/desktop/src/apps/BrowserApp/Chrome.tsx
@@ -180,7 +180,7 @@ export function Chrome({ windowId }: ChromeProps) {
           <Settings size={16} />
         </button>
         {settingsOpen && (
-          <SettingsPanel onClose={() => setSettingsOpen(false)} />
+          <SettingsPanel profileId={currentProfileId} onClose={() => setSettingsOpen(false)} />
         )}
       </div>
 

--- a/desktop/src/apps/BrowserApp/CoPilotBanner.test.tsx
+++ b/desktop/src/apps/BrowserApp/CoPilotBanner.test.tsx
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { CoPilotBanner } from "./CoPilotBanner";
+import { useBrowserAgentStore } from "@/stores/browser-agent-store";
+import * as capabilityApi from "@/lib/browser-capability-api";
+import * as agentApi from "@/lib/browser-agent-api";
+
+const WINDOW_ID = "win-1";
+const TAB_ID = "tab-1";
+const PROFILE_ID = "personal";
+const AGENT_ID = "agent-x";
+
+// Mock the browser-store module (imported dynamically inside handleTakeBack)
+vi.mock("@/stores/browser-store", () => ({
+  useBrowserStore: {
+    getState: vi.fn(() => ({
+      removePinnedAgent: vi.fn(),
+    })),
+  },
+}));
+
+beforeEach(() => {
+  useBrowserAgentStore.setState({
+    panels: {},
+    lastEventAt: {},
+    messages: {},
+    recentEvents: {},
+    annotations: {},
+    drivingState: {
+      [`${WINDOW_ID}:${TAB_ID}:${AGENT_ID}`]: "driving",
+    },
+  });
+
+  vi.spyOn(capabilityApi, "revokeCapability").mockResolvedValue(true);
+  vi.spyOn(agentApi, "unpinAgent").mockResolvedValue(true);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("CoPilotBanner", () => {
+  it("renders the agent name + co-piloting message", () => {
+    render(
+      <CoPilotBanner
+        windowId={WINDOW_ID}
+        tabId={TAB_ID}
+        profileId={PROFILE_ID}
+        agentId={AGENT_ID}
+        agentName="Aria"
+      />,
+    );
+    expect(screen.getByText(/co-piloting this tab/i)).toBeTruthy();
+    expect(screen.getByText("Aria")).toBeTruthy();
+  });
+
+  it("agent name falls back to agentId when name not provided", () => {
+    render(
+      <CoPilotBanner
+        windowId={WINDOW_ID}
+        tabId={TAB_ID}
+        profileId={PROFILE_ID}
+        agentId={AGENT_ID}
+      />,
+    );
+    expect(screen.getByText(AGENT_ID)).toBeTruthy();
+  });
+
+  it("Pause click flips drivingState to idle", () => {
+    render(
+      <CoPilotBanner
+        windowId={WINDOW_ID}
+        tabId={TAB_ID}
+        profileId={PROFILE_ID}
+        agentId={AGENT_ID}
+        agentName="Aria"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /pause/i }));
+
+    const state = useBrowserAgentStore.getState().drivingState[`${WINDOW_ID}:${TAB_ID}:${AGENT_ID}`];
+    expect(state).toBe("idle");
+  });
+
+  it("Take back click calls revokeCapability + unpinAgent", async () => {
+    render(
+      <CoPilotBanner
+        windowId={WINDOW_ID}
+        tabId={TAB_ID}
+        profileId={PROFILE_ID}
+        agentId={AGENT_ID}
+        agentName="Aria"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /take back/i }));
+
+    await waitFor(() => {
+      expect(capabilityApi.revokeCapability).toHaveBeenCalledWith(PROFILE_ID, AGENT_ID, "*");
+      expect(agentApi.unpinAgent).toHaveBeenCalledWith(PROFILE_ID, TAB_ID, AGENT_ID);
+    });
+  });
+
+  it("Take back click flips drivingState to idle", async () => {
+    render(
+      <CoPilotBanner
+        windowId={WINDOW_ID}
+        tabId={TAB_ID}
+        profileId={PROFILE_ID}
+        agentId={AGENT_ID}
+        agentName="Aria"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /take back/i }));
+
+    await waitFor(() => {
+      const state = useBrowserAgentStore.getState().drivingState[`${WINDOW_ID}:${TAB_ID}:${AGENT_ID}`];
+      expect(state).toBe("idle");
+    });
+  });
+
+  it("Take back click calls onTakeBack callback if supplied", async () => {
+    const onTakeBack = vi.fn();
+    render(
+      <CoPilotBanner
+        windowId={WINDOW_ID}
+        tabId={TAB_ID}
+        profileId={PROFILE_ID}
+        agentId={AGENT_ID}
+        agentName="Aria"
+        onTakeBack={onTakeBack}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /take back/i }));
+
+    await waitFor(() => {
+      expect(onTakeBack).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("aria-label on Pause button", () => {
+    render(
+      <CoPilotBanner
+        windowId={WINDOW_ID}
+        tabId={TAB_ID}
+        profileId={PROFILE_ID}
+        agentId={AGENT_ID}
+      />,
+    );
+    const pauseBtn = screen.getByRole("button", { name: /pause/i });
+    expect(pauseBtn.getAttribute("aria-label")).toBeTruthy();
+  });
+
+  it("aria-label on Take back button", () => {
+    render(
+      <CoPilotBanner
+        windowId={WINDOW_ID}
+        tabId={TAB_ID}
+        profileId={PROFILE_ID}
+        agentId={AGENT_ID}
+      />,
+    );
+    const takeBackBtn = screen.getByRole("button", { name: /take back/i });
+    expect(takeBackBtn.getAttribute("aria-label")).toBeTruthy();
+  });
+});

--- a/desktop/src/apps/BrowserApp/CoPilotBanner.test.tsx
+++ b/desktop/src/apps/BrowserApp/CoPilotBanner.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { CoPilotBanner } from "./CoPilotBanner";
 import { useBrowserAgentStore } from "@/stores/browser-agent-store";

--- a/desktop/src/apps/BrowserApp/CoPilotBanner.tsx
+++ b/desktop/src/apps/BrowserApp/CoPilotBanner.tsx
@@ -1,0 +1,85 @@
+/**
+ * CoPilotBanner — persistent banner shown while any pinned agent on the
+ * active tab is in the "driving" state.
+ *
+ * - Pause: flips drivingState → idle locally (server-side drive session decay
+ *   continues naturally; Task 10 will wire the server event).
+ * - Take back: revokes the drive capability grant, unpins the agent, and
+ *   resets the local driving state.
+ */
+import { revokeCapability } from "@/lib/browser-capability-api";
+import { unpinAgent } from "@/lib/browser-agent-api";
+import { useBrowserAgentStore } from "@/stores/browser-agent-store";
+
+export interface CoPilotBannerProps {
+  windowId: string;
+  tabId: string;
+  profileId: string;
+  agentId: string;
+  agentName?: string;
+  onTakeBack?(): void;
+}
+
+export function CoPilotBanner({
+  windowId,
+  tabId,
+  profileId,
+  agentId,
+  agentName,
+  onTakeBack,
+}: CoPilotBannerProps) {
+  const displayName = agentName ?? agentId;
+
+  const handlePause = () => {
+    useBrowserAgentStore.getState().setDrivingState(windowId, tabId, agentId, "idle");
+  };
+
+  const handleTakeBack = async () => {
+    // 1. Revoke drive capability (idempotent on both "*" and the host wildcard)
+    await revokeCapability(profileId, agentId, "*");
+
+    // 2. Unpin the agent from the tab
+    await unpinAgent(profileId, tabId, agentId);
+
+    // 3. Remove from local pin state
+    const browserStore = await import("@/stores/browser-store");
+    browserStore.useBrowserStore.getState().removePinnedAgent(windowId, tabId, agentId);
+
+    // 4. Flip driving state to idle locally
+    useBrowserAgentStore.getState().setDrivingState(windowId, tabId, agentId, "idle");
+
+    // 5. Notify parent
+    onTakeBack?.();
+  };
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex items-center gap-2 px-3 py-1 bg-green-500/15 text-green-200 border-b border-green-500/40 text-xs"
+    >
+      {/* Status text */}
+      <span className="flex-1">
+        <span className="font-semibold">{displayName}</span> is co-piloting this tab
+      </span>
+
+      {/* Actions */}
+      <button
+        type="button"
+        aria-label="Pause co-pilot"
+        onClick={handlePause}
+        className="px-2 py-0.5 rounded border border-green-500/50 hover:bg-green-500/20 text-green-200"
+      >
+        Pause
+      </button>
+      <button
+        type="button"
+        aria-label="Take back control"
+        onClick={handleTakeBack}
+        className="px-2 py-0.5 rounded border border-green-500/50 hover:bg-green-500/20 text-green-200"
+      >
+        Take back
+      </button>
+    </div>
+  );
+}

--- a/desktop/src/apps/BrowserApp/CoPilotBanner.tsx
+++ b/desktop/src/apps/BrowserApp/CoPilotBanner.tsx
@@ -35,21 +35,21 @@ export function CoPilotBanner({
   };
 
   const handleTakeBack = async () => {
-    // 1. Revoke drive capability (idempotent on both "*" and the host wildcard)
-    await revokeCapability(profileId, agentId, "*");
+    try {
+      // 1. Revoke drive capability (idempotent on both "*" and the host wildcard)
+      await revokeCapability(profileId, agentId, "*");
 
-    // 2. Unpin the agent from the tab
-    await unpinAgent(profileId, tabId, agentId);
+      // 2. Unpin the agent from the tab
+      await unpinAgent(profileId, tabId, agentId);
 
-    // 3. Remove from local pin state
-    const browserStore = await import("@/stores/browser-store");
-    browserStore.useBrowserStore.getState().removePinnedAgent(windowId, tabId, agentId);
-
-    // 4. Flip driving state to idle locally
-    useBrowserAgentStore.getState().setDrivingState(windowId, tabId, agentId, "idle");
-
-    // 5. Notify parent
-    onTakeBack?.();
+      // 3. Remove from local pin state
+      const browserStore = await import("@/stores/browser-store");
+      browserStore.useBrowserStore.getState().removePinnedAgent(windowId, tabId, agentId);
+    } finally {
+      // Always flip driving state and notify parent, even if the API calls fail.
+      useBrowserAgentStore.getState().setDrivingState(windowId, tabId, agentId, "idle");
+      onTakeBack?.();
+    }
   };
 
   return (

--- a/desktop/src/apps/BrowserApp/SettingsPanel.test.tsx
+++ b/desktop/src/apps/BrowserApp/SettingsPanel.test.tsx
@@ -21,19 +21,19 @@ afterEach(() => {
 
 describe("SettingsPanel — rendering", () => {
   it("renders with role=dialog and aria-label", () => {
-    render(<SettingsPanel onClose={() => {}} />);
+    render(<SettingsPanel profileId="prof-test" onClose={() => {}} />);
     const dialog = screen.getByRole("dialog");
     expect(dialog).toBeTruthy();
     expect(dialog.getAttribute("aria-label")).toMatch(/browser settings/i);
   });
 
   it("renders close button", () => {
-    render(<SettingsPanel onClose={() => {}} />);
+    render(<SettingsPanel profileId="prof-test" onClose={() => {}} />);
     expect(screen.getByRole("button", { name: /close/i })).toBeTruthy();
   });
 
   it("renders discard timeout slider with accessible label", () => {
-    render(<SettingsPanel onClose={() => {}} />);
+    render(<SettingsPanel profileId="prof-test" onClose={() => {}} />);
     const slider = screen.getByRole("slider");
     expect(slider).toBeTruthy();
     expect(slider.getAttribute("aria-label") ?? "").toMatch(/discard timeout/i);
@@ -42,13 +42,13 @@ describe("SettingsPanel — rendering", () => {
   });
 
   it("renders max live tabs number input", () => {
-    render(<SettingsPanel onClose={() => {}} />);
+    render(<SettingsPanel profileId="prof-test" onClose={() => {}} />);
     const input = screen.getByRole("spinbutton");
     expect(input).toBeTruthy();
   });
 
   it("renders search engine dropdown", () => {
-    render(<SettingsPanel onClose={() => {}} />);
+    render(<SettingsPanel profileId="prof-test" onClose={() => {}} />);
     const select = screen.getByRole("combobox");
     expect(select).toBeTruthy();
   });
@@ -56,7 +56,7 @@ describe("SettingsPanel — rendering", () => {
 
 describe("SettingsPanel — interactions", () => {
   it("moving slider updates discardTimeoutMs in the store", () => {
-    render(<SettingsPanel onClose={() => {}} />);
+    render(<SettingsPanel profileId="prof-test" onClose={() => {}} />);
     const slider = screen.getByRole("slider");
     // slider is in minutes (1–60); setting to 5 → 5*60*1000 ms
     fireEvent.change(slider, { target: { value: "5" } });
@@ -65,28 +65,28 @@ describe("SettingsPanel — interactions", () => {
 
   it("slider reflects current store value", () => {
     useBrowserSettingsStore.setState({ discardTimeoutMs: 3 * 60 * 1000 });
-    render(<SettingsPanel onClose={() => {}} />);
+    render(<SettingsPanel profileId="prof-test" onClose={() => {}} />);
     const slider = screen.getByRole("slider");
     expect(slider.getAttribute("aria-valuenow")).toBe("3");
     expect((slider as HTMLInputElement).value).toBe("3");
   });
 
   it("number input updates maxLiveTabs in the store", () => {
-    render(<SettingsPanel onClose={() => {}} />);
+    render(<SettingsPanel profileId="prof-test" onClose={() => {}} />);
     const input = screen.getByRole("spinbutton");
     fireEvent.change(input, { target: { value: "20" } });
     expect(useBrowserSettingsStore.getState().maxLiveTabs).toBe(20);
   });
 
   it("number input clamped via store setter: value > 50 becomes 50", () => {
-    render(<SettingsPanel onClose={() => {}} />);
+    render(<SettingsPanel profileId="prof-test" onClose={() => {}} />);
     const input = screen.getByRole("spinbutton");
     fireEvent.change(input, { target: { value: "99" } });
     expect(useBrowserSettingsStore.getState().maxLiveTabs).toBe(50);
   });
 
   it("dropdown updates searchEngine in the store", () => {
-    render(<SettingsPanel onClose={() => {}} />);
+    render(<SettingsPanel profileId="prof-test" onClose={() => {}} />);
     const select = screen.getByRole("combobox");
     fireEvent.change(select, { target: { value: "google" } });
     expect(useBrowserSettingsStore.getState().searchEngine).toBe("google");
@@ -94,7 +94,7 @@ describe("SettingsPanel — interactions", () => {
 
   it("close button calls onClose", () => {
     const onClose = vi.fn();
-    render(<SettingsPanel onClose={onClose} />);
+    render(<SettingsPanel profileId="prof-test" onClose={onClose} />);
     fireEvent.click(screen.getByRole("button", { name: /close/i }));
     expect(onClose).toHaveBeenCalledOnce();
   });

--- a/desktop/src/apps/BrowserApp/SettingsPanel.tsx
+++ b/desktop/src/apps/BrowserApp/SettingsPanel.tsx
@@ -5,22 +5,25 @@
  *  - Discard timeout (slider 1–60 minutes)
  *  - Hard cap of live tabs (number input 1–50)
  *  - Default search engine (dropdown)
+ *  - Agent capabilities (sub-modal)
  *
  * Settings are persisted via useBrowserSettingsStore (localStorage).
  */
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { X } from "lucide-react";
 import {
   useBrowserSettingsStore,
   SEARCH_ENGINES,
   type SearchEngine,
 } from "@/stores/browser-settings-store";
+import { AgentCapabilitiesPanel } from "./AgentCapabilitiesPanel";
 
 interface SettingsPanelProps {
+  profileId: string;
   onClose: () => void;
 }
 
-export function SettingsPanel({ onClose }: SettingsPanelProps) {
+export function SettingsPanel({ profileId, onClose }: SettingsPanelProps) {
   const discardTimeoutMs = useBrowserSettingsStore((s) => s.discardTimeoutMs);
   const maxLiveTabs = useBrowserSettingsStore((s) => s.maxLiveTabs);
   const searchEngine = useBrowserSettingsStore((s) => s.searchEngine);
@@ -28,6 +31,7 @@ export function SettingsPanel({ onClose }: SettingsPanelProps) {
   const setMaxLiveTabs = useBrowserSettingsStore((s) => s.setMaxLiveTabs);
   const setSearchEngine = useBrowserSettingsStore((s) => s.setSearchEngine);
   const ref = useRef<HTMLDivElement | null>(null);
+  const [capsOpen, setCapsOpen] = useState(false);
 
   const timeoutMinutes = Math.round(discardTimeoutMs / 60_000);
 
@@ -132,6 +136,25 @@ export function SettingsPanel({ onClose }: SettingsPanelProps) {
           ))}
         </select>
       </div>
+
+      {/* Agent capabilities */}
+      <div className="border-t border-shell-border-subtle pt-3">
+        <button
+          type="button"
+          onClick={() => setCapsOpen(true)}
+          className="w-full text-left text-xs text-shell-text hover:text-accent flex items-center justify-between"
+        >
+          <span>Agent capabilities</span>
+          <span className="text-shell-text-secondary">›</span>
+        </button>
+      </div>
+
+      {capsOpen && (
+        <AgentCapabilitiesPanel
+          profileId={profileId}
+          onClose={() => setCapsOpen(false)}
+        />
+      )}
     </div>
   );
 }

--- a/desktop/src/apps/BrowserApp/SettingsPanel.tsx
+++ b/desktop/src/apps/BrowserApp/SettingsPanel.tsx
@@ -47,14 +47,20 @@ export function SettingsPanel({ profileId, onClose }: SettingsPanelProps) {
     };
   }, [onClose]);
 
-  // Escape key dismiss
+  // Escape key dismiss — when the capabilities sub-modal is open, Escape
+  // should close it first; a second Escape then closes the settings panel.
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key !== "Escape") return;
+      if (capsOpen) {
+        setCapsOpen(false);
+        return;
+      }
+      onClose();
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [onClose]);
+  }, [onClose, capsOpen]);
 
   return (
     <div

--- a/desktop/src/apps/BrowserApp/TabRenderer.tsx
+++ b/desktop/src/apps/BrowserApp/TabRenderer.tsx
@@ -182,6 +182,11 @@ export function TabRenderer({ windowId }: TabRendererProps) {
       (s) => (win ? s.panels[`${windowId}:${win.activeTabId}`]?.isOpen : false),
     ) ?? false;
 
+  // Driving tint — show subtle green overlay on the iframe when an agent is driving.
+  const drivingAgentId = useBrowserAgentStore((s) =>
+    win ? s.isAnyDriving(windowId, win.activeTabId) : null,
+  );
+
   // Context menu state — position where the user right-clicked.
   // PR 6 limitation: only fires when right-clicking on the iframe wrapper border,
   // not on the iframe content itself (sandbox blocks contextmenu propagation to
@@ -255,6 +260,14 @@ export function TabRenderer({ windowId }: TabRendererProps) {
             </div>
           );
         })}
+
+        {/* Driving tint — semi-transparent green overlay when an agent is driving */}
+        {drivingAgentId && (
+          <div
+            className="absolute inset-0 bg-green-500/10 pointer-events-none"
+            aria-hidden="true"
+          />
+        )}
 
         {/* Page context menu — shown when user right-clicks the iframe wrapper */}
         {contextMenu && activeTab && (

--- a/desktop/src/apps/BrowserApp/TabStrip.tsx
+++ b/desktop/src/apps/BrowserApp/TabStrip.tsx
@@ -102,7 +102,7 @@ function TabItem({ windowId, tab, isActive, onActivate, onClose, onContextMenu }
 
   // Green underline when any pinned agent on this tab is in driving state
   const tabDriving = useBrowserAgentStore((s) => {
-    for (const aid of tab.pinnedAgentIds) {
+    for (const aid of tab.pinnedAgentIds ?? []) {
       if (s.drivingState[`${windowId}:${tab.id}:${aid}`] === "driving") return true;
     }
     return false;

--- a/desktop/src/apps/BrowserApp/TabStrip.tsx
+++ b/desktop/src/apps/BrowserApp/TabStrip.tsx
@@ -20,6 +20,7 @@
 import { useState } from "react";
 import { Plus, X, Globe } from "lucide-react";
 import { useBrowserStore } from "@/stores/browser-store";
+import { useBrowserAgentStore } from "@/stores/browser-agent-store";
 import { MoveTabMenu } from "./MoveTabMenu";
 import type { Tab } from "./types";
 
@@ -54,6 +55,7 @@ export function TabStrip({ windowId }: TabStripProps) {
       {ordered.map((tab) => (
         <TabItem
           key={tab.id}
+          windowId={windowId}
           tab={tab}
           isActive={tab.id === win.activeTabId}
           onActivate={() => setActiveTab(windowId, tab.id)}
@@ -87,6 +89,7 @@ export function TabStrip({ windowId }: TabStripProps) {
 }
 
 interface TabItemProps {
+  windowId: string;
   tab: Tab;
   isActive: boolean;
   onActivate: () => void;
@@ -94,8 +97,16 @@ interface TabItemProps {
   onContextMenu: (e: React.MouseEvent) => void;
 }
 
-function TabItem({ tab, isActive, onActivate, onClose, onContextMenu }: TabItemProps) {
+function TabItem({ windowId, tab, isActive, onActivate, onClose, onContextMenu }: TabItemProps) {
   const titleText = tab.title || tab.url || "New tab";
+
+  // Green underline when any pinned agent on this tab is in driving state
+  const tabDriving = useBrowserAgentStore((s) => {
+    for (const aid of tab.pinnedAgentIds) {
+      if (s.drivingState[`${windowId}:${tab.id}:${aid}`] === "driving") return true;
+    }
+    return false;
+  });
 
   // Width per Q8 layout A. Pinned: 32px (favicon-only). Inactive: 140px.
   // Active: 360px (will host the embedded AddressBar in Task 7).
@@ -121,6 +132,7 @@ function TabItem({ tab, isActive, onActivate, onClose, onContextMenu }: TabItemP
         isActive
           ? "bg-shell-surface text-shell-text"
           : "bg-shell-bg-deep text-shell-text-secondary hover:bg-shell-hover",
+        tabDriving ? "border-b-2 border-green-500" : "",
       ].join(" ")}
     >
       {/* Drag handle — Task 11 wires drag events on this child */}

--- a/desktop/src/apps/BrowserApp/agent-ws-bridge.test.ts
+++ b/desktop/src/apps/BrowserApp/agent-ws-bridge.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
-import { openParentWs, type AgentWsBridgeOptions } from "./agent-ws-bridge";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { openParentWs, DRIVING_DECAY_MS, type AgentWsBridgeOptions } from "./agent-ws-bridge";
+import { useBrowserAgentStore } from "@/stores/browser-agent-store";
 
 /**
  * In the new architecture (post-Opus whole-branch review), the parent does
@@ -212,5 +213,181 @@ describe("openParentWs (postMessage-based)", () => {
     handle.close();
     handle.close();
     expect(opts.onClose).toHaveBeenCalledOnce();
+  });
+});
+
+// ─── driving-state event ──────────────────────────────────────────────────────
+
+describe("driving-state event", () => {
+  beforeEach(() => {
+    // Reset the store's drivingState before each test.
+    useBrowserAgentStore.setState({ drivingState: {} });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("flips drivingState to driving when state=driving received", () => {
+    const opts = makeOpts();
+    openParentWs(opts);
+
+    dispatchMessageFrom(opts.iframe.contentWindow, {
+      type: "taos-copilot:server-event",
+      agentId: "agent-1",
+      message: { event: "driving-state", state: "driving" },
+    });
+
+    const key = "win-1:tab-1:agent-1";
+    expect(useBrowserAgentStore.getState().drivingState[key]).toBe("driving");
+  });
+
+  it("flips drivingState to idle when state=idle received", () => {
+    const opts = makeOpts();
+    // Pre-seed store with driving state.
+    useBrowserAgentStore.setState({
+      drivingState: { "win-1:tab-1:agent-1": "driving" },
+    });
+    openParentWs(opts);
+
+    dispatchMessageFrom(opts.iframe.contentWindow, {
+      type: "taos-copilot:server-event",
+      agentId: "agent-1",
+      message: { event: "driving-state", state: "idle" },
+    });
+
+    const key = "win-1:tab-1:agent-1";
+    expect(useBrowserAgentStore.getState().drivingState[key]).toBe("idle");
+  });
+
+  it("auto-decays back to idle after DRIVING_DECAY_MS", () => {
+    vi.useFakeTimers();
+    const opts = makeOpts();
+    openParentWs(opts);
+
+    dispatchMessageFrom(opts.iframe.contentWindow, {
+      type: "taos-copilot:server-event",
+      agentId: "agent-1",
+      message: { event: "driving-state", state: "driving" },
+    });
+
+    const key = "win-1:tab-1:agent-1";
+    expect(useBrowserAgentStore.getState().drivingState[key]).toBe("driving");
+
+    vi.advanceTimersByTime(DRIVING_DECAY_MS + 100);
+    expect(useBrowserAgentStore.getState().drivingState[key]).toBe("idle");
+  });
+
+  it("rapid successive driving events reset the decay timer", () => {
+    vi.useFakeTimers();
+    const opts = makeOpts();
+    openParentWs(opts);
+
+    const drivingMsg = {
+      type: "taos-copilot:server-event",
+      agentId: "agent-1",
+      message: { event: "driving-state", state: "driving" },
+    };
+
+    dispatchMessageFrom(opts.iframe.contentWindow, drivingMsg);
+    // Advance 25 000 ms (< 30 000 ms decay)
+    vi.advanceTimersByTime(25_000);
+    // Re-dispatch — resets the timer
+    dispatchMessageFrom(opts.iframe.contentWindow, drivingMsg);
+    // Advance another 10 000 ms (35 000 total but only 10 000 since last event)
+    vi.advanceTimersByTime(10_000);
+
+    const key = "win-1:tab-1:agent-1";
+    // Timer was reset at 25s, so 10s since last event < 30s → still driving
+    expect(useBrowserAgentStore.getState().drivingState[key]).toBe("driving");
+  });
+
+  it("close() cancels the decay timer — no setDrivingState after close", () => {
+    vi.useFakeTimers();
+    const opts = makeOpts();
+    const handle = openParentWs(opts);
+
+    dispatchMessageFrom(opts.iframe.contentWindow, {
+      type: "taos-copilot:server-event",
+      agentId: "agent-1",
+      message: { event: "driving-state", state: "driving" },
+    });
+
+    handle.close();
+
+    const key = "win-1:tab-1:agent-1";
+    const stateBeforeAdvance = useBrowserAgentStore.getState().drivingState[key];
+
+    vi.advanceTimersByTime(DRIVING_DECAY_MS + 100);
+
+    // State should not have been changed to idle after close
+    expect(useBrowserAgentStore.getState().drivingState[key]).toBe(stateBeforeAdvance);
+  });
+
+  it("does NOT call opts.onEvent for driving-state (handled separately)", () => {
+    const opts = makeOpts();
+    openParentWs(opts);
+
+    dispatchMessageFrom(opts.iframe.contentWindow, {
+      type: "taos-copilot:server-event",
+      agentId: "agent-1",
+      message: { event: "driving-state", state: "driving" },
+    });
+
+    expect(opts.onEvent).not.toHaveBeenCalled();
+  });
+});
+
+// ─── capability-needed event ──────────────────────────────────────────────────
+
+describe("capability-needed event", () => {
+  it("dispatches taos-browser:capability-prompt with the right detail", () => {
+    const opts = makeOpts();
+    openParentWs(opts);
+
+    let capturedEvent: CustomEvent | null = null;
+    const handler = (e: Event) => { capturedEvent = e as CustomEvent; };
+    window.addEventListener("taos-browser:capability-prompt", handler);
+
+    dispatchMessageFrom(opts.iframe.contentWindow, {
+      type: "taos-copilot:server-event",
+      agentId: "agent-1",
+      message: {
+        event: "capability-needed",
+        profile_id: "profile-42",
+        agent_name: "TestAgent",
+        permission: "clipboard-read",
+        host: "example.com",
+        full_url: "https://example.com/page",
+      },
+    });
+
+    window.removeEventListener("taos-browser:capability-prompt", handler);
+
+    expect(capturedEvent).not.toBeNull();
+    const detail = (capturedEvent as CustomEvent).detail;
+    expect(detail.profileId).toBe("profile-42");
+    expect(detail.agentId).toBe("agent-1");
+    expect(detail.agentName).toBe("TestAgent");
+    expect(detail.permission).toBe("clipboard-read");
+    expect(detail.host).toBe("example.com");
+    expect(detail.fullUrl).toBe("https://example.com/page");
+  });
+
+  it("does NOT call opts.onEvent for capability-needed (it's not an AgentEvent)", () => {
+    const opts = makeOpts();
+    openParentWs(opts);
+
+    dispatchMessageFrom(opts.iframe.contentWindow, {
+      type: "taos-copilot:server-event",
+      agentId: "agent-1",
+      message: {
+        event: "capability-needed",
+        permission: "camera",
+        host: "example.com",
+      },
+    });
+
+    expect(opts.onEvent).not.toHaveBeenCalled();
   });
 });

--- a/desktop/src/apps/BrowserApp/agent-ws-bridge.ts
+++ b/desktop/src/apps/BrowserApp/agent-ws-bridge.ts
@@ -18,6 +18,7 @@
  * `message` is the raw server payload — { event: "page-changed", url, title, ... }
  */
 import type { AgentEvent } from "@/stores/browser-agent-store";
+import { useBrowserAgentStore } from "@/stores/browser-agent-store";
 
 export interface AgentWsBridgeOptions {
   windowId: string;
@@ -39,10 +40,16 @@ export interface AgentWsHandle {
   readonly isOpen: boolean;
 }
 
-const ALLOWED_EVENT_KINDS: ReadonlyArray<AgentEvent["kind"]> = [
+/** Milliseconds before a "driving" state auto-decays to "idle" if no further
+ * driving-state event arrives. Matches the server-side drive_sessions TTL. */
+export const DRIVING_DECAY_MS = 30_000;
+
+const ALLOWED_EVENT_KINDS: ReadonlyArray<string> = [
   "page-changed",
   "url-changed",
   "scroll",
+  "driving-state",
+  "capability-needed",
 ];
 
 /** Register a window-level postMessage listener filtered to events forwarded
@@ -54,6 +61,7 @@ const ALLOWED_EVENT_KINDS: ReadonlyArray<AgentEvent["kind"]> = [
  */
 export function openParentWs(opts: AgentWsBridgeOptions): AgentWsHandle {
   let isOpen = true;
+  let drivingDecayTimer: ReturnType<typeof setTimeout> | null = null;
 
   function handleMessage(e: MessageEvent) {
     // SECURITY: only accept messages from this specific iframe. The iframe
@@ -70,19 +78,64 @@ export function openParentWs(opts: AgentWsBridgeOptions): AgentWsHandle {
     if (!msg || typeof msg !== "object") return;
 
     const serverKind = typeof msg.event === "string" ? msg.event : null;
-    if (!serverKind) return;
+    if (!serverKind || !ALLOWED_EVENT_KINDS.includes(serverKind)) return;
 
-    const kind = serverKind as AgentEvent["kind"];
-    if (!ALLOWED_EVENT_KINDS.includes(kind)) return;
+    if (serverKind === "driving-state") {
+      handleDrivingState(msg);
+      return;
+    }
 
+    if (serverKind === "capability-needed") {
+      handleCapabilityNeeded(msg);
+      return;
+    }
+
+    // The remaining kinds are AgentEvent shapes — forward to onEvent.
     const event: AgentEvent = {
-      kind,
+      kind: serverKind as AgentEvent["kind"],
       url: typeof msg.url === "string" ? msg.url : undefined,
       title: typeof msg.title === "string" ? msg.title : undefined,
       timestamp: typeof msg.timestamp === "number" ? msg.timestamp : Date.now(),
     };
 
     opts.onEvent(event);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function handleDrivingState(msg: any) {
+    const state = msg.state === "driving" ? "driving" : "idle";
+    useBrowserAgentStore.getState().setDrivingState(
+      opts.windowId, opts.tabId, opts.agentId, state,
+    );
+
+    if (drivingDecayTimer !== null) {
+      clearTimeout(drivingDecayTimer);
+      drivingDecayTimer = null;
+    }
+    if (state === "driving") {
+      // 30s idle decay — if no further driving event arrives within this
+      // window, flip back to idle. Mirrors server-side drive_sessions TTL.
+      drivingDecayTimer = setTimeout(() => {
+        drivingDecayTimer = null;
+        useBrowserAgentStore.getState().setDrivingState(
+          opts.windowId, opts.tabId, opts.agentId, "idle",
+        );
+      }, DRIVING_DECAY_MS);
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function handleCapabilityNeeded(msg: any) {
+    // Dispatch a window event for CapabilityPromptModal (Task 6) to consume.
+    const detail = {
+      profileId: typeof msg.profile_id === "string" ? msg.profile_id : "",
+      agentId: opts.agentId,
+      agentName: typeof msg.agent_name === "string" ? msg.agent_name : undefined,
+      permission: typeof msg.permission === "string" ? msg.permission : "",
+      host: typeof msg.host === "string" ? msg.host : "",
+      fullUrl: typeof msg.full_url === "string" ? msg.full_url : (typeof msg.url === "string" ? msg.url : ""),
+    };
+    window.dispatchEvent(new CustomEvent("taos-browser:capability-prompt", { detail }));
   }
 
   window.addEventListener("message", handleMessage);
@@ -92,6 +145,10 @@ export function openParentWs(opts: AgentWsBridgeOptions): AgentWsHandle {
     close() {
       if (!isOpen) return;
       isOpen = false;
+      if (drivingDecayTimer !== null) {
+        clearTimeout(drivingDecayTimer);
+        drivingDecayTimer = null;
+      }
       window.removeEventListener("message", handleMessage);
       if (opts.onClose) opts.onClose();
     },

--- a/desktop/src/lib/browser-capability-api.test.ts
+++ b/desktop/src/lib/browser-capability-api.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  listCapabilities,
+  grantCapability,
+  revokeCapability,
+} from "./browser-capability-api";
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe("browser-capability-api", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  describe("listCapabilities", () => {
+    it("returns grants array on 200", async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          grants: [
+            {
+              agent_id: "agent-1",
+              host_pattern: "example.com",
+              permissions: "drive",
+              granted_at: "2026-01-01T00:00:00Z",
+              expires_at: null,
+            },
+          ],
+        }),
+      });
+      const result = await listCapabilities("profile-1");
+      expect(result).toHaveLength(1);
+      expect(result[0].agent_id).toBe("agent-1");
+      expect(result[0].host_pattern).toBe("example.com");
+    });
+
+    it("returns [] on 401", async () => {
+      fetchMock.mockResolvedValue({ ok: false, status: 401 });
+      expect(await listCapabilities("profile-1")).toEqual([]);
+    });
+
+    it("returns [] on network error", async () => {
+      fetchMock.mockRejectedValue(new Error("network failure"));
+      expect(await listCapabilities("profile-1")).toEqual([]);
+    });
+
+    it("includes agent_id query param when supplied", async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({ grants: [] }),
+      });
+      await listCapabilities("profile-1", "agent-42");
+      const [url] = fetchMock.mock.calls[0];
+      expect(url).toContain("agent_id=agent-42");
+    });
+
+    it("includes credentials", async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({ grants: [] }),
+      });
+      await listCapabilities("profile-1");
+      const [, opts] = fetchMock.mock.calls[0];
+      expect(opts.credentials).toBe("include");
+    });
+  });
+
+  describe("grantCapability", () => {
+    it("returns { granted: true } on 200", async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ granted: true }),
+      });
+      const result = await grantCapability("profile-1", "agent-1", "example.com", "drive");
+      expect(result).toEqual({ granted: true });
+    });
+
+    it("returns { error } on 400", async () => {
+      fetchMock.mockResolvedValue({
+        ok: false,
+        status: 400,
+        json: async () => ({ error: "invalid host pattern" }),
+      });
+      const result = await grantCapability("profile-1", "agent-1", "bad pattern", "drive");
+      expect(result).toEqual({ error: "invalid host pattern" });
+    });
+
+    it("returns null on 401", async () => {
+      fetchMock.mockResolvedValue({
+        ok: false,
+        status: 401,
+        json: async () => ({}),
+      });
+      expect(await grantCapability("profile-1", "agent-1", "example.com", "drive")).toBeNull();
+    });
+
+    it("returns null on network error", async () => {
+      fetchMock.mockRejectedValue(new Error("offline"));
+      expect(await grantCapability("profile-1", "agent-1", "example.com", "drive")).toBeNull();
+    });
+
+    it("posts JSON body with all fields", async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({ granted: true }),
+      });
+      await grantCapability(
+        "profile-1",
+        "agent-1",
+        "example.com",
+        "drive",
+        "2026-12-31T00:00:00Z",
+      );
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toBe("/api/desktop/browser/capabilities");
+      expect(opts.method).toBe("POST");
+      expect(opts.headers["content-type"]).toBe("application/json");
+      const body = JSON.parse(opts.body);
+      expect(body.profile_id).toBe("profile-1");
+      expect(body.agent_id).toBe("agent-1");
+      expect(body.host_pattern).toBe("example.com");
+      expect(body.permissions).toBe("drive");
+      expect(body.expires_at).toBe("2026-12-31T00:00:00Z");
+    });
+
+    it("posts expires_at: null when expiresAt arg is null", async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({ granted: true }),
+      });
+      await grantCapability("profile-1", "agent-1", "example.com", "drive", null);
+      const [, opts] = fetchMock.mock.calls[0];
+      const body = JSON.parse(opts.body);
+      expect(body.expires_at).toBeNull();
+    });
+  });
+
+  describe("revokeCapability", () => {
+    it("returns true on 204", async () => {
+      fetchMock.mockResolvedValue({ ok: true, status: 204 });
+      const result = await revokeCapability("profile-1", "agent-1", "example.com");
+      expect(result).toBe(true);
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toContain("/api/desktop/browser/capabilities");
+      expect(opts.method).toBe("DELETE");
+    });
+
+    it("returns false on 401", async () => {
+      fetchMock.mockResolvedValue({ ok: false, status: 401 });
+      expect(await revokeCapability("profile-1", "agent-1", "example.com")).toBe(false);
+    });
+
+    it("returns false on network error", async () => {
+      fetchMock.mockRejectedValue(new Error("offline"));
+      expect(await revokeCapability("profile-1", "agent-1", "example.com")).toBe(false);
+    });
+
+    it("encodes URL params correctly", async () => {
+      fetchMock.mockResolvedValue({ ok: true, status: 204 });
+      await revokeCapability("my profile", "agent/1", "example.com");
+      const [url] = fetchMock.mock.calls[0];
+      expect(url).toContain("profile_id=my+profile");
+      expect(url).toContain("agent_id=agent%2F1");
+      expect(url).toContain("host_pattern=example.com");
+    });
+  });
+});

--- a/desktop/src/lib/browser-capability-api.ts
+++ b/desktop/src/lib/browser-capability-api.ts
@@ -1,0 +1,81 @@
+/**
+ * Fetch wrappers for /api/desktop/browser/capabilities.
+ * Silent on 401 (returns []/null/false to match other browser-* api wrappers).
+ */
+export interface CapabilityGrant {
+  agent_id: string;
+  host_pattern: string;
+  permissions: string;
+  granted_at: string;
+  expires_at: string | null;
+}
+
+export async function listCapabilities(
+  profileId: string,
+  agentId?: string,
+): Promise<CapabilityGrant[]> {
+  const params = new URLSearchParams({ profile_id: profileId });
+  if (agentId) params.set("agent_id", agentId);
+  try {
+    const resp = await fetch(`/api/desktop/browser/capabilities?${params}`, {
+      credentials: "include",
+    });
+    if (!resp.ok) return [];
+    const body = await resp.json();
+    return Array.isArray(body?.grants) ? body.grants : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function grantCapability(
+  profileId: string,
+  agentId: string,
+  hostPattern: string,
+  permissions: string,
+  expiresAt: string | null = null,
+): Promise<{ granted: boolean } | { error: string } | null> {
+  try {
+    const resp = await fetch("/api/desktop/browser/capabilities", {
+      method: "POST",
+      credentials: "include",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        profile_id: profileId,
+        agent_id: agentId,
+        host_pattern: hostPattern,
+        permissions,
+        expires_at: expiresAt,
+      }),
+    });
+    if (resp.ok) return await resp.json();
+    if (resp.status === 400) {
+      const body = await resp.json().catch(() => ({}));
+      return { error: typeof body?.error === "string" ? body.error : "Bad request" };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export async function revokeCapability(
+  profileId: string,
+  agentId: string,
+  hostPattern: string,
+): Promise<boolean> {
+  const params = new URLSearchParams({
+    profile_id: profileId,
+    agent_id: agentId,
+    host_pattern: hostPattern,
+  });
+  try {
+    const resp = await fetch(`/api/desktop/browser/capabilities?${params}`, {
+      method: "DELETE",
+      credentials: "include",
+    });
+    return resp.ok;
+  } catch {
+    return false;
+  }
+}

--- a/desktop/src/stores/browser-agent-store.test.ts
+++ b/desktop/src/stores/browser-agent-store.test.ts
@@ -405,7 +405,7 @@ describe("browser-agent-store: drivingState", () => {
     expect(useBrowserAgentStore.getState().isAnyDriving("win-2", "tab-2")).toBe("agent-b");
   });
 
-  it("isAnyDriving returns one of multiple driving agents", () => {
+  it("isAnyDriving picks the driving agent when others are idle", () => {
     const s = useBrowserAgentStore.getState();
     s.setDrivingState("win-1", "tab-1", "agent-a", "idle");
     s.setDrivingState("win-1", "tab-1", "agent-b", "driving");

--- a/desktop/src/stores/browser-agent-store.test.ts
+++ b/desktop/src/stores/browser-agent-store.test.ts
@@ -15,6 +15,7 @@ beforeEach(() => {
     messages: {},
     recentEvents: {},
     annotations: {},
+    drivingState: {},
   });
 });
 
@@ -354,5 +355,62 @@ describe("browser-agent-store: annotations", () => {
     expect(annsTab2).toHaveLength(1);
     expect(annsTab1[0].id).toBe("ann-1");
     expect(annsTab2[0].id).toBe("ann-2");
+  });
+});
+
+describe("browser-agent-store: drivingState", () => {
+  it("setDrivingState writes the right key", () => {
+    const s = useBrowserAgentStore.getState();
+    s.setDrivingState("win-1", "tab-1", "agent-a", "driving");
+
+    const state = useBrowserAgentStore.getState().drivingState;
+    expect(state["win-1:tab-1:agent-a"]).toBe("driving");
+  });
+
+  it("setDrivingState can flip back to idle", () => {
+    const s = useBrowserAgentStore.getState();
+    s.setDrivingState("win-1", "tab-1", "agent-a", "driving");
+    s.setDrivingState("win-1", "tab-1", "agent-a", "idle");
+
+    const state = useBrowserAgentStore.getState().drivingState;
+    expect(state["win-1:tab-1:agent-a"]).toBe("idle");
+  });
+
+  it("isAnyDriving returns the first driving agentId for the (window, tab)", () => {
+    const s = useBrowserAgentStore.getState();
+    s.setDrivingState("win-1", "tab-1", "agent-a", "driving");
+
+    expect(useBrowserAgentStore.getState().isAnyDriving("win-1", "tab-1")).toBe("agent-a");
+  });
+
+  it("isAnyDriving returns null when no agents driving", () => {
+    const s = useBrowserAgentStore.getState();
+    s.setDrivingState("win-1", "tab-1", "agent-a", "idle");
+
+    expect(useBrowserAgentStore.getState().isAnyDriving("win-1", "tab-1")).toBeNull();
+  });
+
+  it("isAnyDriving returns null when nothing set", () => {
+    expect(useBrowserAgentStore.getState().isAnyDriving("win-1", "tab-1")).toBeNull();
+  });
+
+  it("isAnyDriving is correctly scoped to (window, tab)", () => {
+    const s = useBrowserAgentStore.getState();
+    // Set driving on a different window+tab
+    s.setDrivingState("win-2", "tab-2", "agent-b", "driving");
+
+    // win-1:tab-1 should not report any driving
+    expect(useBrowserAgentStore.getState().isAnyDriving("win-1", "tab-1")).toBeNull();
+    // win-2:tab-2 should return agent-b
+    expect(useBrowserAgentStore.getState().isAnyDriving("win-2", "tab-2")).toBe("agent-b");
+  });
+
+  it("isAnyDriving returns one of multiple driving agents", () => {
+    const s = useBrowserAgentStore.getState();
+    s.setDrivingState("win-1", "tab-1", "agent-a", "idle");
+    s.setDrivingState("win-1", "tab-1", "agent-b", "driving");
+
+    const result = useBrowserAgentStore.getState().isAnyDriving("win-1", "tab-1");
+    expect(result).toBe("agent-b");
   });
 });

--- a/desktop/src/stores/browser-agent-store.test.ts
+++ b/desktop/src/stores/browser-agent-store.test.ts
@@ -14,6 +14,7 @@ beforeEach(() => {
     lastEventAt: {},
     messages: {},
     recentEvents: {},
+    annotations: {},
   });
 });
 
@@ -264,5 +265,94 @@ describe("browser-agent-store: appendEvent", () => {
     expect(eventsB).toHaveLength(1);
     expect(eventsA[0].kind).toBe("scroll");
     expect(eventsB[0].kind).toBe("page-changed");
+  });
+});
+
+describe("browser-agent-store: annotations", () => {
+  it("addAnnotation appends a new entry", () => {
+    const s = useBrowserAgentStore.getState();
+    s.addAnnotation("win-1", "tab-1", {
+      kind: "cursor",
+      id: "ann-1",
+      agentId: "agent-a",
+      x: 100,
+      y: 200,
+    });
+
+    const anns = useBrowserAgentStore.getState().annotations["win-1:tab-1"];
+    expect(anns).toHaveLength(1);
+    expect(anns[0].id).toBe("ann-1");
+  });
+
+  it("addAnnotation with same id replaces existing entry in place", () => {
+    const s = useBrowserAgentStore.getState();
+    s.addAnnotation("win-1", "tab-1", {
+      kind: "cursor",
+      id: "ann-1",
+      agentId: "agent-a",
+      x: 100,
+      y: 200,
+    });
+    s.addAnnotation("win-1", "tab-1", {
+      kind: "cursor",
+      id: "ann-1",
+      agentId: "agent-a",
+      x: 300,
+      y: 400,
+    });
+
+    const anns = useBrowserAgentStore.getState().annotations["win-1:tab-1"];
+    expect(anns).toHaveLength(1);
+    const cursor = anns[0];
+    expect(cursor.kind).toBe("cursor");
+    if (cursor.kind === "cursor") {
+      expect(cursor.x).toBe(300);
+      expect(cursor.y).toBe(400);
+    }
+  });
+
+  it("clearAnnotation removes by id", () => {
+    const s = useBrowserAgentStore.getState();
+    s.addAnnotation("win-1", "tab-1", { kind: "cursor", id: "ann-1", agentId: "agent-a", x: 10, y: 20 });
+    s.addAnnotation("win-1", "tab-1", { kind: "cursor", id: "ann-2", agentId: "agent-a", x: 30, y: 40 });
+    s.clearAnnotation("win-1", "tab-1", "ann-1");
+
+    const anns = useBrowserAgentStore.getState().annotations["win-1:tab-1"];
+    expect(anns).toHaveLength(1);
+    expect(anns[0].id).toBe("ann-2");
+  });
+
+  it("clearAnnotations clears all for (window, tab)", () => {
+    const s = useBrowserAgentStore.getState();
+    s.addAnnotation("win-1", "tab-1", { kind: "cursor", id: "ann-1", agentId: "agent-a", x: 10, y: 20 });
+    s.addAnnotation("win-1", "tab-1", { kind: "cursor", id: "ann-2", agentId: "agent-b", x: 30, y: 40 });
+    s.clearAnnotations("win-1", "tab-1");
+
+    const anns = useBrowserAgentStore.getState().annotations["win-1:tab-1"];
+    expect(anns).toHaveLength(0);
+  });
+
+  it("clearAnnotations(agentId) clears only that agent's annotations", () => {
+    const s = useBrowserAgentStore.getState();
+    s.addAnnotation("win-1", "tab-1", { kind: "cursor", id: "ann-1", agentId: "agent-a", x: 10, y: 20 });
+    s.addAnnotation("win-1", "tab-1", { kind: "cursor", id: "ann-2", agentId: "agent-b", x: 30, y: 40 });
+    s.clearAnnotations("win-1", "tab-1", "agent-a");
+
+    const anns = useBrowserAgentStore.getState().annotations["win-1:tab-1"];
+    expect(anns).toHaveLength(1);
+    expect(anns[0].agentId).toBe("agent-b");
+  });
+
+  it("annotations are scoped per (window, tab) key", () => {
+    const s = useBrowserAgentStore.getState();
+    s.addAnnotation("win-1", "tab-1", { kind: "cursor", id: "ann-1", agentId: "agent-a", x: 10, y: 20 });
+    s.addAnnotation("win-1", "tab-2", { kind: "cursor", id: "ann-2", agentId: "agent-a", x: 50, y: 60 });
+
+    const annsTab1 = useBrowserAgentStore.getState().annotations["win-1:tab-1"];
+    const annsTab2 = useBrowserAgentStore.getState().annotations["win-1:tab-2"];
+    expect(annsTab1).toHaveLength(1);
+    expect(annsTab2).toHaveLength(1);
+    expect(annsTab1[0].id).toBe("ann-1");
+    expect(annsTab2[0].id).toBe("ann-2");
   });
 });

--- a/desktop/src/stores/browser-agent-store.ts
+++ b/desktop/src/stores/browser-agent-store.ts
@@ -68,6 +68,9 @@ export interface BrowserAgentState {
   /** Per-(window, tab) annotation overlay. Key: `${windowId}:${tabId}` */
   annotations: Record<string, Annotation[]>;
 
+  /** Per-(window, tab, agent) driving state. Key: `${windowId}:${tabId}:${agentId}`. */
+  drivingState: Record<string, "idle" | "driving">;
+
   openPanel(windowId: string, tabId: string, agentId: string): void;
   closePanel(windowId: string, tabId: string): void;
   togglePanel(windowId: string, tabId: string, agentId: string): void;
@@ -84,6 +87,12 @@ export interface BrowserAgentState {
   addAnnotation(windowId: string, tabId: string, ann: Annotation): void;
   clearAnnotation(windowId: string, tabId: string, id: string): void;
   clearAnnotations(windowId: string, tabId: string, agentId?: string): void;
+
+  setDrivingState(windowId: string, tabId: string, agentId: string, state: "idle" | "driving"): void;
+
+  /** Returns the agent_id of the first driving agent for the (window, tab),
+   * or null if none. Used by chrome components to decide visual state. */
+  isAnyDriving(windowId: string, tabId: string): string | null;
 }
 
 export const useBrowserAgentStore = create<BrowserAgentState>((set, get) => ({
@@ -92,6 +101,7 @@ export const useBrowserAgentStore = create<BrowserAgentState>((set, get) => ({
   messages: {},
   recentEvents: {},
   annotations: {},
+  drivingState: {},
 
   openPanel(windowId, tabId, agentId) {
     set((state) => {
@@ -249,6 +259,26 @@ export const useBrowserAgentStore = create<BrowserAgentState>((set, get) => ({
         },
       };
     });
+  },
+
+  setDrivingState(windowId, tabId, agentId, state) {
+    set((s) => ({
+      drivingState: {
+        ...s.drivingState,
+        [`${windowId}:${tabId}:${agentId}`]: state,
+      },
+    }));
+  },
+
+  isAnyDriving(windowId, tabId) {
+    const ds = get().drivingState;
+    const prefix = `${windowId}:${tabId}:`;
+    for (const key of Object.keys(ds)) {
+      if (key.startsWith(prefix) && ds[key] === "driving") {
+        return key.slice(prefix.length);
+      }
+    }
+    return null;
   },
 }));
 

--- a/desktop/src/stores/browser-agent-store.ts
+++ b/desktop/src/stores/browser-agent-store.ts
@@ -5,6 +5,27 @@ const MAX_PANEL_WIDTH = 480;
 const DEFAULT_PANEL_WIDTH = 280;
 const WATCHING_DECAY_MS = 3000;
 
+export interface AnnotationCursor {
+  kind: "cursor";
+  id: string;
+  agentId: string;
+  x: number;
+  y: number;
+  label?: string;
+  color?: string;
+}
+
+export interface AnnotationArrow {
+  kind: "arrow";
+  id: string;
+  agentId: string;
+  from: { x: number; y: number };
+  to: { x: number; y: number };
+  color?: string;
+}
+
+export type Annotation = AnnotationCursor | AnnotationArrow;
+
 export interface AgentPanelState {
   isOpen: boolean;
   activeAgentId: string | null;
@@ -44,6 +65,9 @@ export interface BrowserAgentState {
   /** Recent page events per (tab, agent). Key: same. Capped at last 5 per key. */
   recentEvents: Record<string, AgentEvent[]>;
 
+  /** Per-(window, tab) annotation overlay. Key: `${windowId}:${tabId}` */
+  annotations: Record<string, Annotation[]>;
+
   openPanel(windowId: string, tabId: string, agentId: string): void;
   closePanel(windowId: string, tabId: string): void;
   togglePanel(windowId: string, tabId: string, agentId: string): void;
@@ -56,6 +80,10 @@ export interface BrowserAgentState {
 
   appendMessage(windowId: string, tabId: string, agentId: string, message: AgentMessage): void;
   appendEvent(windowId: string, tabId: string, agentId: string, event: AgentEvent): void;
+
+  addAnnotation(windowId: string, tabId: string, ann: Annotation): void;
+  clearAnnotation(windowId: string, tabId: string, id: string): void;
+  clearAnnotations(windowId: string, tabId: string, agentId?: string): void;
 }
 
 export const useBrowserAgentStore = create<BrowserAgentState>((set, get) => ({
@@ -63,6 +91,7 @@ export const useBrowserAgentStore = create<BrowserAgentState>((set, get) => ({
   lastEventAt: {},
   messages: {},
   recentEvents: {},
+  annotations: {},
 
   openPanel(windowId, tabId, agentId) {
     set((state) => {
@@ -170,6 +199,52 @@ export const useBrowserAgentStore = create<BrowserAgentState>((set, get) => ({
       return {
         recentEvents: {
           ...state.recentEvents,
+          [key]: updated,
+        },
+      };
+    });
+  },
+
+  addAnnotation(windowId, tabId, ann) {
+    set((state) => {
+      const key = `${windowId}:${tabId}`;
+      const existing = state.annotations[key] ?? [];
+      const idx = existing.findIndex((a) => a.id === ann.id);
+      const updated = idx >= 0
+        ? existing.map((a) => (a.id === ann.id ? ann : a))
+        : [...existing, ann];
+      return {
+        annotations: {
+          ...state.annotations,
+          [key]: updated,
+        },
+      };
+    });
+  },
+
+  clearAnnotation(windowId, tabId, id) {
+    set((state) => {
+      const key = `${windowId}:${tabId}`;
+      const existing = state.annotations[key] ?? [];
+      return {
+        annotations: {
+          ...state.annotations,
+          [key]: existing.filter((a) => a.id !== id),
+        },
+      };
+    });
+  },
+
+  clearAnnotations(windowId, tabId, agentId) {
+    set((state) => {
+      const key = `${windowId}:${tabId}`;
+      const existing = state.annotations[key] ?? [];
+      const updated = agentId
+        ? existing.filter((a) => a.agentId !== agentId)
+        : [];
+      return {
+        annotations: {
+          ...state.annotations,
           [key]: updated,
         },
       };

--- a/tests/routes/desktop_browser/test_capability_routes.py
+++ b/tests/routes/desktop_browser/test_capability_routes.py
@@ -1,0 +1,310 @@
+"""Tests for /api/desktop/browser/capabilities HTTP CRUD endpoints."""
+from __future__ import annotations
+
+import pytest
+
+
+def _get_user_id(app):
+    """Resolve the authed admin user id from the app state."""
+    auth_mgr = app.state.auth
+    record = auth_mgr.find_user("admin")
+    return record["id"] if record else "test-admin"
+
+
+def _make_auth_client(app, tmp_data_dir):
+    """Create a second authenticated async client for multi-user isolation tests."""
+    from httpx import ASGITransport, AsyncClient
+
+    auth_mgr = app.state.auth
+    if auth_mgr.find_user("user_b") is None:
+        invite_code = auth_mgr.add_user_invite("user_b", "admin")
+        auth_mgr.complete_invite("user_b", invite_code, "user_b", "", "pass_b")
+    record = auth_mgr.find_user("user_b")
+    token = auth_mgr.create_session(user_id=record["id"], long_lived=True)
+    return AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        cookies={"taos_session": token},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Auth (401) tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestCapabilityAuth:
+    async def test_get_unauthenticated_returns_401(self, app):
+        from httpx import ASGITransport, AsyncClient
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            resp = await c.get(
+                "/api/desktop/browser/capabilities",
+                params={"profile_id": "personal"},
+            )
+            assert resp.status_code == 401
+
+    async def test_post_unauthenticated_returns_401(self, app):
+        from httpx import ASGITransport, AsyncClient
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            resp = await c.post(
+                "/api/desktop/browser/capabilities",
+                json={
+                    "profile_id": "personal",
+                    "agent_id": "a1",
+                    "host_pattern": "example.com",
+                    "permissions": "read_dom",
+                },
+            )
+            assert resp.status_code == 401
+
+    async def test_delete_unauthenticated_returns_401(self, app):
+        from httpx import ASGITransport, AsyncClient
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            resp = await c.delete(
+                "/api/desktop/browser/capabilities",
+                params={
+                    "profile_id": "personal",
+                    "agent_id": "a1",
+                    "host_pattern": "example.com",
+                },
+            )
+            assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Test 1: GET happy path
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestListCapabilities:
+    async def test_get_happy_path_returns_grant(self, client, app):
+        user_id = _get_user_id(app)
+        store = app.state.browser_store
+        await store.add_capability(
+            user_id=user_id,
+            profile_id="p1",
+            agent_id="agent-a",
+            host_pattern="example.com",
+            permissions="read_dom,navigate",
+        )
+        resp = await client.get(
+            "/api/desktop/browser/capabilities",
+            params={"profile_id": "p1"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "grants" in body
+        assert len(body["grants"]) == 1
+        grant = body["grants"][0]
+        assert grant["agent_id"] == "agent-a"
+        assert grant["host_pattern"] == "example.com"
+        assert grant["permissions"] == "read_dom,navigate"
+
+    # Test 2: GET filter by agent_id
+    async def test_get_filter_by_agent_id(self, client, app):
+        user_id = _get_user_id(app)
+        store = app.state.browser_store
+        await store.add_capability(
+            user_id=user_id, profile_id="p1", agent_id="agent-x",
+            host_pattern="*.site.com", permissions="drive",
+        )
+        await store.add_capability(
+            user_id=user_id, profile_id="p1", agent_id="agent-y",
+            host_pattern="*.site.com", permissions="navigate",
+        )
+        resp = await client.get(
+            "/api/desktop/browser/capabilities",
+            params={"profile_id": "p1", "agent_id": "agent-x"},
+        )
+        assert resp.status_code == 200
+        grants = resp.json()["grants"]
+        assert len(grants) == 1
+        assert grants[0]["agent_id"] == "agent-x"
+
+    # Test 4: GET multi-user isolation
+    async def test_get_multi_user_isolation(self, client, app):
+        store = app.state.browser_store
+        await store.add_capability(
+            user_id="other-user", profile_id="p1", agent_id="secret-agent",
+            host_pattern="*", permissions="drive",
+        )
+        resp = await client.get(
+            "/api/desktop/browser/capabilities",
+            params={"profile_id": "p1"},
+        )
+        assert resp.status_code == 200
+        grants = resp.json()["grants"]
+        assert all(g["agent_id"] != "secret-agent" for g in grants)
+
+
+# ---------------------------------------------------------------------------
+# Test 5–10: POST (grant)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestGrantCapability:
+    async def test_post_happy_path(self, client, app):
+        resp = await client.post(
+            "/api/desktop/browser/capabilities",
+            json={
+                "profile_id": "p1",
+                "agent_id": "agent-g",
+                "host_pattern": "foo.com",
+                "permissions": "read_dom",
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"granted": True}
+
+        # GET shows the row
+        get_resp = await client.get(
+            "/api/desktop/browser/capabilities",
+            params={"profile_id": "p1", "agent_id": "agent-g"},
+        )
+        grants = get_resp.json()["grants"]
+        assert len(grants) == 1
+        assert grants[0]["host_pattern"] == "foo.com"
+        assert grants[0]["permissions"] == "read_dom"
+
+    # Test 6: UPSERT — same (agent, host_pattern), different permissions
+    async def test_post_upsert_updates_permissions(self, client, app):
+        base = {
+            "profile_id": "p1",
+            "agent_id": "agent-up",
+            "host_pattern": "bar.com",
+        }
+        await client.post(
+            "/api/desktop/browser/capabilities",
+            json={**base, "permissions": "read_dom"},
+        )
+        await client.post(
+            "/api/desktop/browser/capabilities",
+            json={**base, "permissions": "read_dom,drive"},
+        )
+        get_resp = await client.get(
+            "/api/desktop/browser/capabilities",
+            params={"profile_id": "p1", "agent_id": "agent-up"},
+        )
+        grants = get_resp.json()["grants"]
+        assert len(grants) == 1
+        assert grants[0]["permissions"] == "read_dom,drive"
+
+    # Test 7: 400 on empty permissions
+    async def test_post_empty_permissions_returns_400(self, client):
+        resp = await client.post(
+            "/api/desktop/browser/capabilities",
+            json={
+                "profile_id": "p1",
+                "agent_id": "a1",
+                "host_pattern": "x.com",
+                "permissions": "",
+            },
+        )
+        assert resp.status_code == 400
+        assert "permissions" in resp.json().get("error", "").lower()
+
+    # Test 8: 400 on unknown permission
+    async def test_post_unknown_permission_returns_400(self, client):
+        resp = await client.post(
+            "/api/desktop/browser/capabilities",
+            json={
+                "profile_id": "p1",
+                "agent_id": "a1",
+                "host_pattern": "x.com",
+                "permissions": "drive,unicorn",
+            },
+        )
+        assert resp.status_code == 400
+        assert "unicorn" in resp.json().get("error", "")
+
+    # Test 9: 400 on whitespace-only permissions
+    async def test_post_whitespace_permissions_returns_400(self, client):
+        resp = await client.post(
+            "/api/desktop/browser/capabilities",
+            json={
+                "profile_id": "p1",
+                "agent_id": "a1",
+                "host_pattern": "x.com",
+                "permissions": "   ",
+            },
+        )
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Test 11–14: DELETE (revoke)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestRevokeCapability:
+    async def test_delete_happy_path(self, client, app):
+        user_id = _get_user_id(app)
+        store = app.state.browser_store
+        await store.add_capability(
+            user_id=user_id, profile_id="p1", agent_id="agent-del",
+            host_pattern="del.com", permissions="navigate",
+        )
+        resp = await client.delete(
+            "/api/desktop/browser/capabilities",
+            params={
+                "profile_id": "p1",
+                "agent_id": "agent-del",
+                "host_pattern": "del.com",
+            },
+        )
+        assert resp.status_code == 204
+
+        get_resp = await client.get(
+            "/api/desktop/browser/capabilities",
+            params={"profile_id": "p1", "agent_id": "agent-del"},
+        )
+        assert get_resp.json()["grants"] == []
+
+    # Test 12: DELETE on missing returns 204 (info-hide)
+    async def test_delete_missing_returns_204(self, client):
+        resp = await client.delete(
+            "/api/desktop/browser/capabilities",
+            params={
+                "profile_id": "p1",
+                "agent_id": "never-existed",
+                "host_pattern": "ghost.com",
+            },
+        )
+        assert resp.status_code == 204
+
+    # Test 14: DELETE multi-user isolation
+    async def test_delete_multi_user_isolation(self, client, app, tmp_path):
+        user_a_id = _get_user_id(app)
+        store = app.state.browser_store
+        await store.add_capability(
+            user_id=user_a_id, profile_id="p1", agent_id="agent-iso",
+            host_pattern="iso.com", permissions="see_cookies",
+        )
+
+        # User B deletes — should not remove user A's row
+        async with _make_auth_client(app, tmp_path) as b_client:
+            resp = await b_client.delete(
+                "/api/desktop/browser/capabilities",
+                params={
+                    "profile_id": "p1",
+                    "agent_id": "agent-iso",
+                    "host_pattern": "iso.com",
+                },
+            )
+            assert resp.status_code == 204
+
+        # User A's grant still present
+        grants = await store.list_capabilities(
+            user_id=user_a_id, profile_id="p1", agent_id="agent-iso",
+        )
+        assert len(grants) == 1
+        assert grants[0]["host_pattern"] == "iso.com"

--- a/tests/routes/desktop_browser/test_copilot_agent_ws.py
+++ b/tests/routes/desktop_browser/test_copilot_agent_ws.py
@@ -217,6 +217,11 @@ class TestRoundTripOpAck:
         mock_iframe_ws = AsyncMock()
         iframe_key = (user_id, "p1", "t1", "agent-rt")
         ws_app.state.copilot_hub._iframe_conns[iframe_key] = mock_iframe_ws
+        # Trusted current URL for capability check (server-tracked, not agent-supplied)
+        ws_app.state.copilot_hub.set_tab_url(
+            user_id=user_id, profile_id="p1", tab_id="t1",
+            url="https://example.com/page",
+        )
 
         op_msg = {"op": "click", "selector": "#submit", "op_id": "op-1", "host": "example.com"}
 
@@ -260,6 +265,10 @@ class TestDriveOpBumpsSession:
         mock_iframe_ws = AsyncMock()
         iframe_key = (user_id, "p1", "t1", "agent-drive")
         ws_app.state.copilot_hub._iframe_conns[iframe_key] = mock_iframe_ws
+        ws_app.state.copilot_hub.set_tab_url(
+            user_id=user_id, profile_id="p1", tab_id="t1",
+            url="https://example.com/",
+        )
 
         with ws_client.websocket_connect(
             f"/api/desktop/browser/copilot-agent?ticket={ticket}"
@@ -340,6 +349,11 @@ class TestOpMissingIframe:
                 host_pattern="example.com",
                 permissions="drive",
             )
+        )
+        # Trusted current URL so capability check sees example.com (server-tracked)
+        ws_app.state.copilot_hub.set_tab_url(
+            user_id=user_id, profile_id="p1", tab_id="t1",
+            url="https://example.com/",
         )
 
         with ws_client.websocket_connect(
@@ -524,6 +538,11 @@ class TestCapabilityEnforcement:
         mock_iframe_ws = AsyncMock()
         iframe_key = (user_id, "p1", "t1", "agent-cap-deny")
         ws_app.state.copilot_hub._iframe_conns[iframe_key] = mock_iframe_ws
+        # Server-tracked URL — capability check uses this, NOT agent-supplied msg["host"]
+        ws_app.state.copilot_hub.set_tab_url(
+            user_id=user_id, profile_id="p1", tab_id="t1",
+            url="https://example.com/page",
+        )
 
         with ws_client.websocket_connect(
             f"/api/desktop/browser/copilot-agent?ticket={ticket}"
@@ -541,7 +560,7 @@ class TestCapabilityEnforcement:
         assert reply["reason"] == "capability-needed"
         assert reply["permission"] == "drive"
 
-        # iframe should have received capability-needed
+        # iframe should have received capability-needed (host from server-tracked URL)
         mock_iframe_ws.send_json.assert_awaited_once()
         sent = mock_iframe_ws.send_json.call_args[0][0]
         assert sent["event"] == "capability-needed"
@@ -562,6 +581,11 @@ class TestCapabilityEnforcement:
         mock_iframe_ws = AsyncMock()
         iframe_key = (user_id, "p1", "t1", "agent-cap-ok")
         ws_app.state.copilot_hub._iframe_conns[iframe_key] = mock_iframe_ws
+        # Server-tracked URL for capability check
+        ws_app.state.copilot_hub.set_tab_url(
+            user_id=user_id, profile_id="p1", tab_id="t1",
+            url="https://example.com/",
+        )
 
         op_msg = {"op": "click", "selector": "#submit", "op_id": "op-ok-1", "host": "example.com"}
 
@@ -652,3 +676,75 @@ class TestCapabilityEnforcement:
         assert reply["event"] == "denied"
         assert reply["reason"] == "capability-needed"
         assert reply["permission"] == "drive"
+
+
+# ---------------------------------------------------------------------------
+# Security: agent-supplied msg["host"] is NOT trusted for capability checks
+# ---------------------------------------------------------------------------
+
+class TestTrustedHostOnly:
+    def test_capability_uses_server_tracked_url_not_msg_host(self, ws_client, ws_app):
+        """Agent claims host=allowed-site.com but server-tracked URL is
+        actually-different.com. Capability check must use the server URL
+        (no grant for actually-different.com → denied)."""
+        ticket = _pin_and_mint(ws_client, ws_app, "p1", "t1", "agent-spoof")
+        record = ws_app.state.auth.find_user("admin")
+        user_id = record["id"]
+
+        # User granted drive ONLY for the actual server-tracked URL host
+        _grant_capability(ws_app, user_id, "p1", "agent-spoof", "trusted.com", "drive")
+
+        mock_iframe_ws = AsyncMock()
+        iframe_key = (user_id, "p1", "t1", "agent-spoof")
+        ws_app.state.copilot_hub._iframe_conns[iframe_key] = mock_iframe_ws
+        # Server says the iframe is on attacker.com, not trusted.com
+        ws_app.state.copilot_hub.set_tab_url(
+            user_id=user_id, profile_id="p1", tab_id="t1",
+            url="https://attacker.com/page",
+        )
+
+        with ws_client.websocket_connect(
+            f"/api/desktop/browser/copilot-agent?ticket={ticket}"
+        ) as ws:
+            # Agent LIES: claims host=trusted.com to try to bypass
+            ws.send_json({
+                "op": "click", "selector": "#x", "op_id": "spoof-1",
+                "host": "trusted.com",  # ← agent's claim, must be ignored
+            })
+            reply = ws.receive_json()
+
+        # Server should use the trusted URL (attacker.com → no grant) and deny
+        assert reply["event"] == "denied"
+        assert reply["reason"] == "capability-needed"
+        # The iframe was notified with the REAL host (attacker.com), not the spoof
+        sent = mock_iframe_ws.send_json.call_args[0][0]
+        assert sent["host"] == "attacker.com"
+
+        ws_app.state.copilot_hub._iframe_conns.pop(iframe_key, None)
+
+
+# ---------------------------------------------------------------------------
+# Security: per-op tab_id override re-checks pin
+# ---------------------------------------------------------------------------
+
+class TestPerOpTargetReauthorization:
+    def test_op_targeting_unpinned_tab_is_denied(self, ws_client, ws_app):
+        """Agent connects with ticket bound to (p1, t1) where it IS pinned,
+        then sends an op targeting tab t2 where it is NOT pinned. Server
+        must reject with 'agent not pinned for target tab'."""
+        ticket = _pin_and_mint(ws_client, ws_app, "p1", "t1", "agent-cross")
+        # Note: agent is pinned to t1 via _pin_and_mint, but NOT to t2
+
+        with ws_client.websocket_connect(
+            f"/api/desktop/browser/copilot-agent?ticket={ticket}"
+        ) as ws:
+            ws.send_json({
+                "op": "extract",     # non-privileged, so capability isn't the gate
+                "op_id": "cross-1",
+                "tab_id": "t2",      # ← target tab where agent is NOT pinned
+            })
+            reply = ws.receive_json()
+
+        assert reply["event"] == "denied"
+        assert reply["op_id"] == "cross-1"
+        assert "not pinned for target tab" in reply["reason"]

--- a/tests/routes/desktop_browser/test_copilot_agent_ws.py
+++ b/tests/routes/desktop_browser/test_copilot_agent_ws.py
@@ -202,12 +202,23 @@ class TestRoundTripOpAck:
         record = ws_app.state.auth.find_user("admin")
         user_id = record["id"]
 
+        # Grant drive capability so click op is not denied
+        asyncio.run(
+            ws_app.state.browser_store.add_capability(
+                user_id=user_id,
+                profile_id="p1",
+                agent_id="agent-rt",
+                host_pattern="example.com",
+                permissions="drive",
+            )
+        )
+
         # Register a fake iframe in the hub
         mock_iframe_ws = AsyncMock()
         iframe_key = (user_id, "p1", "t1", "agent-rt")
         ws_app.state.copilot_hub._iframe_conns[iframe_key] = mock_iframe_ws
 
-        op_msg = {"op": "click", "selector": "#submit", "op_id": "op-1"}
+        op_msg = {"op": "click", "selector": "#submit", "op_id": "op-1", "host": "example.com"}
 
         with ws_client.websocket_connect(
             f"/api/desktop/browser/copilot-agent?ticket={ticket}"
@@ -234,6 +245,17 @@ class TestDriveOpBumpsSession:
         record = ws_app.state.auth.find_user("admin")
         user_id = record["id"]
 
+        # Grant drive capability so click op is not denied
+        asyncio.run(
+            ws_app.state.browser_store.add_capability(
+                user_id=user_id,
+                profile_id="p1",
+                agent_id="agent-drive",
+                host_pattern="example.com",
+                permissions="drive",
+            )
+        )
+
         # Register a mock iframe so the op routes successfully
         mock_iframe_ws = AsyncMock()
         iframe_key = (user_id, "p1", "t1", "agent-drive")
@@ -242,7 +264,7 @@ class TestDriveOpBumpsSession:
         with ws_client.websocket_connect(
             f"/api/desktop/browser/copilot-agent?ticket={ticket}"
         ) as ws:
-            ws.send_json({"op": "click", "selector": "#btn", "op_id": "op-2"})
+            ws.send_json({"op": "click", "selector": "#btn", "op_id": "op-2", "host": "example.com"})
             import time
             time.sleep(0.05)
 
@@ -303,13 +325,27 @@ class TestNonDriveOpNoSession:
 
 class TestOpMissingIframe:
     def test_error_event_sent_to_agent_when_iframe_absent(self, ws_client, ws_app):
-        """Send an op when no iframe is connected → server replies event: error."""
+        """Send a privileged op with capability granted but no iframe connected →
+        server replies event: error (iframe not connected)."""
         ticket = _pin_and_mint(ws_client, ws_app, "p1", "t1", "agent-err")
+        record = ws_app.state.auth.find_user("admin")
+        user_id = record["id"]
+
+        # Grant drive so the capability check passes; then no iframe → error
+        asyncio.run(
+            ws_app.state.browser_store.add_capability(
+                user_id=user_id,
+                profile_id="p1",
+                agent_id="agent-err",
+                host_pattern="example.com",
+                permissions="drive",
+            )
+        )
 
         with ws_client.websocket_connect(
             f"/api/desktop/browser/copilot-agent?ticket={ticket}"
         ) as ws:
-            ws.send_json({"op": "click", "selector": "#x", "op_id": "op-err"})
+            ws.send_json({"op": "click", "selector": "#x", "op_id": "op-err", "host": "example.com"})
             reply = ws.receive_json()
 
         assert reply["event"] == "error"
@@ -399,3 +435,220 @@ class TestCopilotHubAgentMethods:
             op={"op": "click"},
         )
         assert result is False
+
+    # ------------------------------------------------------------------
+    # notify_capability_needed unit tests
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_notify_capability_needed_sends_event_to_iframe(self):
+        """notify_capability_needed pushes capability-needed payload to the iframe WS."""
+        hub = self._make_hub()
+        ws = AsyncMock()
+        hub._iframe_conns[("u1", "p1", "t1", "a1")] = ws
+        result = await hub.notify_capability_needed(
+            user_id="u1",
+            profile_id="p1",
+            tab_id="t1",
+            agent_id="a1",
+            permission="drive",
+            host="example.com",
+            full_url="https://example.com/page",
+        )
+        assert result is True
+        ws.send_json.assert_awaited_once_with({
+            "event": "capability-needed",
+            "profile_id": "p1",
+            "permission": "drive",
+            "host": "example.com",
+            "full_url": "https://example.com/page",
+        })
+
+    @pytest.mark.asyncio
+    async def test_notify_capability_needed_returns_false_when_no_iframe(self):
+        hub = self._make_hub()
+        result = await hub.notify_capability_needed(
+            user_id="u1",
+            profile_id="p1",
+            tab_id="t1",
+            agent_id="a1",
+            permission="drive",
+            host="example.com",
+        )
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_notify_capability_needed_swallows_send_failure(self):
+        hub = self._make_hub()
+        ws = AsyncMock()
+        ws.send_json.side_effect = RuntimeError("closed")
+        hub._iframe_conns[("u1", "p1", "t1", "a1")] = ws
+        result = await hub.notify_capability_needed(
+            user_id="u1",
+            profile_id="p1",
+            tab_id="t1",
+            agent_id="a1",
+            permission="drive",
+            host="example.com",
+        )
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Case 11: Capability enforcement — drive ops
+# ---------------------------------------------------------------------------
+
+def _grant_capability(app, user_id, profile_id, agent_id, host, permissions):
+    """Synchronously add a capability grant to the browser_store."""
+    import asyncio
+    asyncio.run(
+        app.state.browser_store.add_capability(
+            user_id=user_id,
+            profile_id=profile_id,
+            agent_id=agent_id,
+            host_pattern=host,
+            permissions=permissions,
+        )
+    )
+
+
+class TestCapabilityEnforcement:
+
+    def test_drive_op_without_capability_is_denied(self, ws_client, ws_app):
+        """Agent sends op:click without a drive grant → denied + iframe notified."""
+        ticket = _pin_and_mint(ws_client, ws_app, "p1", "t1", "agent-cap-deny")
+        record = ws_app.state.auth.find_user("admin")
+        user_id = record["id"]
+
+        # Register fake iframe
+        mock_iframe_ws = AsyncMock()
+        iframe_key = (user_id, "p1", "t1", "agent-cap-deny")
+        ws_app.state.copilot_hub._iframe_conns[iframe_key] = mock_iframe_ws
+
+        with ws_client.websocket_connect(
+            f"/api/desktop/browser/copilot-agent?ticket={ticket}"
+        ) as ws:
+            ws.send_json({
+                "op": "click",
+                "selector": "#btn",
+                "op_id": "op-deny-1",
+                "host": "example.com",
+            })
+            reply = ws.receive_json()
+
+        assert reply["event"] == "denied"
+        assert reply["op_id"] == "op-deny-1"
+        assert reply["reason"] == "capability-needed"
+        assert reply["permission"] == "drive"
+
+        # iframe should have received capability-needed
+        mock_iframe_ws.send_json.assert_awaited_once()
+        sent = mock_iframe_ws.send_json.call_args[0][0]
+        assert sent["event"] == "capability-needed"
+        assert sent["permission"] == "drive"
+        assert sent["host"] == "example.com"
+
+        ws_app.state.copilot_hub._iframe_conns.pop(iframe_key, None)
+
+    def test_drive_op_with_capability_proceeds(self, ws_client, ws_app):
+        """Agent sends op:click WITH a drive grant → routes through (no denial)."""
+        ticket = _pin_and_mint(ws_client, ws_app, "p1", "t1", "agent-cap-ok")
+        record = ws_app.state.auth.find_user("admin")
+        user_id = record["id"]
+
+        # Grant drive capability
+        _grant_capability(ws_app, user_id, "p1", "agent-cap-ok", "example.com", "drive")
+
+        mock_iframe_ws = AsyncMock()
+        iframe_key = (user_id, "p1", "t1", "agent-cap-ok")
+        ws_app.state.copilot_hub._iframe_conns[iframe_key] = mock_iframe_ws
+
+        op_msg = {"op": "click", "selector": "#submit", "op_id": "op-ok-1", "host": "example.com"}
+
+        with ws_client.websocket_connect(
+            f"/api/desktop/browser/copilot-agent?ticket={ticket}"
+        ) as ws:
+            ws.send_json(op_msg)
+            import time
+            time.sleep(0.05)
+
+        # The iframe should have received the op (not a denial)
+        mock_iframe_ws.send_json.assert_awaited_once_with(op_msg)
+
+        ws_app.state.copilot_hub._iframe_conns.pop(iframe_key, None)
+
+    def test_navigate_op_requires_navigate_capability(self, ws_client, ws_app):
+        """op:navigate is gated by 'navigate' permission — 'drive' grant is NOT enough."""
+        ticket = _pin_and_mint(ws_client, ws_app, "p1", "t1", "agent-cap-nav")
+        record = ws_app.state.auth.find_user("admin")
+        user_id = record["id"]
+
+        # Grant only drive, NOT navigate
+        _grant_capability(ws_app, user_id, "p1", "agent-cap-nav", "example.com", "drive")
+
+        mock_iframe_ws = AsyncMock()
+        iframe_key = (user_id, "p1", "t1", "agent-cap-nav")
+        ws_app.state.copilot_hub._iframe_conns[iframe_key] = mock_iframe_ws
+
+        with ws_client.websocket_connect(
+            f"/api/desktop/browser/copilot-agent?ticket={ticket}"
+        ) as ws:
+            ws.send_json({
+                "op": "navigate",
+                "url": "https://example.com/other",
+                "op_id": "op-nav-1",
+                "host": "example.com",
+            })
+            reply = ws.receive_json()
+
+        assert reply["event"] == "denied"
+        assert reply["permission"] == "navigate"
+
+        ws_app.state.copilot_hub._iframe_conns.pop(iframe_key, None)
+
+    def test_non_privileged_op_passes_through(self, ws_client, ws_app):
+        """op:extract (read-only) goes through without any capability check."""
+        ticket = _pin_and_mint(ws_client, ws_app, "p1", "t1", "agent-cap-extract")
+        record = ws_app.state.auth.find_user("admin")
+        user_id = record["id"]
+
+        # No capability granted — extract should still route
+        mock_iframe_ws = AsyncMock()
+        iframe_key = (user_id, "p1", "t1", "agent-cap-extract")
+        ws_app.state.copilot_hub._iframe_conns[iframe_key] = mock_iframe_ws
+
+        op_msg = {"op": "extract", "selector": "article", "op_id": "op-ext-1"}
+
+        with ws_client.websocket_connect(
+            f"/api/desktop/browser/copilot-agent?ticket={ticket}"
+        ) as ws:
+            ws.send_json(op_msg)
+            import time
+            time.sleep(0.05)
+
+        # Iframe should have received the extract op
+        mock_iframe_ws.send_json.assert_awaited_once_with(op_msg)
+
+        ws_app.state.copilot_hub._iframe_conns.pop(iframe_key, None)
+
+    def test_capability_needed_with_no_iframe_still_denies_agent(
+        self, ws_client, ws_app
+    ):
+        """When iframe is not connected, agent still gets the denial."""
+        ticket = _pin_and_mint(ws_client, ws_app, "p1", "t1", "agent-cap-noframe")
+
+        # No iframe registered, no capability granted
+        with ws_client.websocket_connect(
+            f"/api/desktop/browser/copilot-agent?ticket={ticket}"
+        ) as ws:
+            ws.send_json({
+                "op": "click",
+                "selector": "#x",
+                "op_id": "op-noframe-1",
+                "host": "example.com",
+            })
+            reply = ws.receive_json()
+
+        assert reply["event"] == "denied"
+        assert reply["reason"] == "capability-needed"
+        assert reply["permission"] == "drive"

--- a/tests/routes/desktop_browser/test_copilot_agent_ws.py
+++ b/tests/routes/desktop_browser/test_copilot_agent_ws.py
@@ -1,0 +1,401 @@
+"""Tests for the agent-side copilot WebSocket endpoint and CopilotHub agent methods."""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import yaml
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — reuse _make_ws_app pattern from test_copilot_ws.py
+# ---------------------------------------------------------------------------
+
+def _make_ws_app(tmp_path):
+    """Create a minimal app with browser_store initialized (sync-compatible)."""
+    from tinyagentos.app import create_app
+    from tinyagentos.routes.desktop_browser.store import BrowserStore
+
+    config = {
+        "server": {"host": "0.0.0.0", "port": 6969},
+        "backends": [],
+        "qmd": {"url": "http://localhost:7832"},
+        "agents": [],
+        "metrics": {"poll_interval": 30, "retention_days": 30},
+    }
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.dump(config))
+    (tmp_path / ".setup_complete").touch()
+
+    app = create_app(data_dir=tmp_path)
+
+    browser_store = BrowserStore(tmp_path / "browser.sqlite3")
+    asyncio.run(browser_store.init())
+    app.state.browser_store = browser_store
+
+    app.state.auth.setup_user("admin", "Test Admin", "", "testpass")
+
+    return app
+
+
+@pytest.fixture
+def ws_app(tmp_path):
+    return _make_ws_app(tmp_path)
+
+
+@pytest.fixture
+def ws_client(ws_app):
+    record = ws_app.state.auth.find_user("admin")
+    token = ws_app.state.auth.create_session(user_id=record["id"], long_lived=True)
+    with TestClient(ws_app, raise_server_exceptions=False) as c:
+        c.cookies.set("taos_session", token)
+        yield c
+
+
+def _add_agent_to(app, agent_id: str):
+    app.state.config.agents.append({
+        "id": agent_id,
+        "name": agent_id,
+        "host": "127.0.0.1",
+        "qmd_index": "test",
+        "color": "#000000",
+    })
+
+
+def _pin_and_mint(client, app, profile_id, tab_id, agent_id):
+    """Pin agent and mint a ticket. Returns the ticket token."""
+    _add_agent_to(app, agent_id)
+    client.post(
+        "/api/desktop/browser/pins",
+        json={"profile_id": profile_id, "tab_id": tab_id, "agent_id": agent_id},
+    )
+    resp = client.post(
+        "/api/desktop/browser/copilot/ticket",
+        json={"profile_id": profile_id, "tab_id": tab_id, "agent_id": agent_id},
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["ticket"]
+
+
+# ---------------------------------------------------------------------------
+# Case 1: 4401 on invalid ticket
+# ---------------------------------------------------------------------------
+
+class TestAgentWS4401InvalidTicket:
+    def test_4401_on_random_ticket(self, ws_client):
+        with pytest.raises(WebSocketDisconnect) as exc_info:
+            with ws_client.websocket_connect(
+                "/api/desktop/browser/copilot-agent?ticket=totally-invalid-token"
+            ) as ws:
+                ws.receive_text()
+        assert exc_info.value.code == 4401
+
+
+# ---------------------------------------------------------------------------
+# Case 2: 4401 on already-consumed ticket
+# ---------------------------------------------------------------------------
+
+class TestAgentWS4401ConsumedTicket:
+    def test_4401_on_consumed_ticket(self, ws_client, ws_app):
+        ticket = _pin_and_mint(ws_client, ws_app, "p1", "t1", "agent-consumed")
+        ws_app.state.copilot_ticket_store.consume(ticket)
+
+        with pytest.raises(WebSocketDisconnect) as exc_info:
+            with ws_client.websocket_connect(
+                f"/api/desktop/browser/copilot-agent?ticket={ticket}"
+            ) as ws:
+                ws.receive_text()
+        assert exc_info.value.code == 4401
+
+
+# ---------------------------------------------------------------------------
+# Case 3: 4403 on unpinned agent
+# ---------------------------------------------------------------------------
+
+class TestAgentWS4403Unpinned:
+    def test_4403_when_unpinned_after_mint(self, ws_client, ws_app):
+        ticket = _pin_and_mint(ws_client, ws_app, "p1", "t1", "agent-unpin")
+        ws_client.delete(
+            "/api/desktop/browser/pins",
+            params={"profile_id": "p1", "tab_id": "t1", "agent_id": "agent-unpin"},
+        )
+
+        with pytest.raises(WebSocketDisconnect) as exc_info:
+            with ws_client.websocket_connect(
+                f"/api/desktop/browser/copilot-agent?ticket={ticket}"
+            ) as ws:
+                ws.receive_text()
+        assert exc_info.value.code == 4403
+
+
+# ---------------------------------------------------------------------------
+# Case 4: Successful upgrade adds agent to hub
+# ---------------------------------------------------------------------------
+
+class TestAgentWSRegistersInHub:
+    def test_agent_registered_in_hub_during_connection(self, ws_client, ws_app):
+        ticket = _pin_and_mint(ws_client, ws_app, "p1", "t1", "agent-hub")
+        record = ws_app.state.auth.find_user("admin")
+        user_id = record["id"]
+
+        with ws_client.websocket_connect(
+            f"/api/desktop/browser/copilot-agent?ticket={ticket}"
+        ):
+            key = (user_id, "agent-hub")
+            assert key in ws_app.state.copilot_hub._agent_conns
+
+        # After disconnect, still need to check removal in case 5 below.
+
+
+# ---------------------------------------------------------------------------
+# Case 5: Disconnect cleans up agent from hub
+# ---------------------------------------------------------------------------
+
+class TestAgentWSCleanupOnDisconnect:
+    def test_hub_key_removed_after_disconnect(self, ws_client, ws_app):
+        ticket = _pin_and_mint(ws_client, ws_app, "p1", "t1", "agent-cleanup")
+        record = ws_app.state.auth.find_user("admin")
+        user_id = record["id"]
+        key = (user_id, "agent-cleanup")
+
+        with ws_client.websocket_connect(
+            f"/api/desktop/browser/copilot-agent?ticket={ticket}"
+        ):
+            assert key in ws_app.state.copilot_hub._agent_conns
+
+        assert key not in ws_app.state.copilot_hub._agent_conns
+
+
+# ---------------------------------------------------------------------------
+# Case 6: route_op_to_iframe returns False when no iframe registered
+# ---------------------------------------------------------------------------
+
+class TestRouteOpToIframeNoIframe:
+    @pytest.mark.asyncio
+    async def test_returns_false_when_iframe_not_connected(self):
+        from tinyagentos.routes.desktop_browser.copilot_ws import CopilotHub
+        hub = CopilotHub()
+        result = await hub.route_op_to_iframe(
+            user_id="u1",
+            profile_id="p1",
+            tab_id="t1",
+            agent_id="agent-x",
+            op={"op": "click", "selector": "#btn"},
+        )
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Case 7: Round-trip: agent op → iframe receive → ack → agent receive
+# ---------------------------------------------------------------------------
+
+class TestRoundTripOpAck:
+    def test_op_forwarded_to_iframe_and_ack_forwarded_to_agent(
+        self, ws_client, ws_app
+    ):
+        """Register a mock iframe, connect agent, send op, verify iframe gets it,
+        then send ack from iframe WS, verify agent receives it."""
+        ticket = _pin_and_mint(ws_client, ws_app, "p1", "t1", "agent-rt")
+        record = ws_app.state.auth.find_user("admin")
+        user_id = record["id"]
+
+        # Register a fake iframe in the hub
+        mock_iframe_ws = AsyncMock()
+        iframe_key = (user_id, "p1", "t1", "agent-rt")
+        ws_app.state.copilot_hub._iframe_conns[iframe_key] = mock_iframe_ws
+
+        op_msg = {"op": "click", "selector": "#submit", "op_id": "op-1"}
+
+        with ws_client.websocket_connect(
+            f"/api/desktop/browser/copilot-agent?ticket={ticket}"
+        ) as ws:
+            ws.send_json(op_msg)
+            # Give the async loop a moment to process
+            import time
+            time.sleep(0.05)
+
+        # The iframe mock should have received the op
+        mock_iframe_ws.send_json.assert_awaited_once_with(op_msg)
+
+        # Clean up
+        ws_app.state.copilot_hub._iframe_conns.pop(iframe_key, None)
+
+
+# ---------------------------------------------------------------------------
+# Case 8: Drive op bumps drive_session
+# ---------------------------------------------------------------------------
+
+class TestDriveOpBumpsSession:
+    def test_click_op_creates_drive_session(self, ws_client, ws_app):
+        ticket = _pin_and_mint(ws_client, ws_app, "p1", "t1", "agent-drive")
+        record = ws_app.state.auth.find_user("admin")
+        user_id = record["id"]
+
+        # Register a mock iframe so the op routes successfully
+        mock_iframe_ws = AsyncMock()
+        iframe_key = (user_id, "p1", "t1", "agent-drive")
+        ws_app.state.copilot_hub._iframe_conns[iframe_key] = mock_iframe_ws
+
+        with ws_client.websocket_connect(
+            f"/api/desktop/browser/copilot-agent?ticket={ticket}"
+        ) as ws:
+            ws.send_json({"op": "click", "selector": "#btn", "op_id": "op-2"})
+            import time
+            time.sleep(0.05)
+
+        # Verify drive session exists
+        result = asyncio.run(
+            ws_app.state.browser_store.is_driving(
+                user_id=user_id,
+                profile_id="p1",
+                tab_id="t1",
+                agent_id="agent-drive",
+            )
+        )
+        assert result is True
+
+        # Clean up
+        ws_app.state.copilot_hub._iframe_conns.pop(iframe_key, None)
+
+
+# ---------------------------------------------------------------------------
+# Case 9: Non-drive op does NOT bump drive_session
+# ---------------------------------------------------------------------------
+
+class TestNonDriveOpNoSession:
+    def test_extract_op_does_not_create_drive_session(self, ws_client, ws_app):
+        ticket = _pin_and_mint(ws_client, ws_app, "p1", "t1", "agent-nodrive")
+        record = ws_app.state.auth.find_user("admin")
+        user_id = record["id"]
+
+        # Register a mock iframe so the op routes successfully
+        mock_iframe_ws = AsyncMock()
+        iframe_key = (user_id, "p1", "t1", "agent-nodrive")
+        ws_app.state.copilot_hub._iframe_conns[iframe_key] = mock_iframe_ws
+
+        with ws_client.websocket_connect(
+            f"/api/desktop/browser/copilot-agent?ticket={ticket}"
+        ) as ws:
+            ws.send_json({"op": "extract", "selector": "article", "op_id": "op-3"})
+            import time
+            time.sleep(0.05)
+
+        result = asyncio.run(
+            ws_app.state.browser_store.is_driving(
+                user_id=user_id,
+                profile_id="p1",
+                tab_id="t1",
+                agent_id="agent-nodrive",
+            )
+        )
+        assert result is False
+
+        # Clean up
+        ws_app.state.copilot_hub._iframe_conns.pop(iframe_key, None)
+
+
+# ---------------------------------------------------------------------------
+# Case 10: Op with missing iframe → agent receives event: "error"
+# ---------------------------------------------------------------------------
+
+class TestOpMissingIframe:
+    def test_error_event_sent_to_agent_when_iframe_absent(self, ws_client, ws_app):
+        """Send an op when no iframe is connected → server replies event: error."""
+        ticket = _pin_and_mint(ws_client, ws_app, "p1", "t1", "agent-err")
+
+        with ws_client.websocket_connect(
+            f"/api/desktop/browser/copilot-agent?ticket={ticket}"
+        ) as ws:
+            ws.send_json({"op": "click", "selector": "#x", "op_id": "op-err"})
+            reply = ws.receive_json()
+
+        assert reply["event"] == "error"
+        assert reply["op_id"] == "op-err"
+        assert "iframe not connected" in reply["reason"]
+
+
+# ---------------------------------------------------------------------------
+# Additional CopilotHub agent-method unit tests
+# ---------------------------------------------------------------------------
+
+class TestCopilotHubAgentMethods:
+    def _make_hub(self):
+        from tinyagentos.routes.desktop_browser.copilot_ws import CopilotHub
+        return CopilotHub()
+
+    def test_add_agent_registers_ws(self):
+        hub = self._make_hub()
+        ws = AsyncMock()
+        hub.add_agent(user_id="u1", agent_id="a1", ws=ws)
+        assert hub._agent_conns[("u1", "a1")] is ws
+
+    def test_remove_agent_is_noop_when_not_present(self):
+        hub = self._make_hub()
+        hub.remove_agent(user_id="u1", agent_id="no-such")  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_add_agent_replaces_prior_connection(self):
+        hub = self._make_hub()
+        old_ws = AsyncMock()
+        new_ws = AsyncMock()
+        hub._agent_conns[("u1", "a1")] = old_ws
+        hub.add_agent(user_id="u1", agent_id="a1", ws=new_ws)
+        assert hub._agent_conns[("u1", "a1")] is new_ws
+
+    @pytest.mark.asyncio
+    async def test_route_ack_to_agent_returns_true_on_success(self):
+        hub = self._make_hub()
+        ws = AsyncMock()
+        hub._agent_conns[("u1", "a1")] = ws
+        ack = {"event": "ack", "op_id": "op-1", "status": "ok"}
+        result = await hub.route_ack_to_agent(user_id="u1", agent_id="a1", ack=ack)
+        assert result is True
+        ws.send_json.assert_awaited_once_with(ack)
+
+    @pytest.mark.asyncio
+    async def test_route_ack_to_agent_returns_false_when_no_agent(self):
+        hub = self._make_hub()
+        result = await hub.route_ack_to_agent(
+            user_id="u1", agent_id="no-such",
+            ack={"event": "ack", "op_id": "x"},
+        )
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_route_ack_to_agent_swallows_send_failure(self):
+        hub = self._make_hub()
+        ws = AsyncMock()
+        ws.send_json.side_effect = RuntimeError("connection reset")
+        hub._agent_conns[("u1", "a1")] = ws
+        result = await hub.route_ack_to_agent(
+            user_id="u1", agent_id="a1",
+            ack={"event": "ack", "op_id": "x"},
+        )
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_route_op_to_iframe_returns_true_on_success(self):
+        hub = self._make_hub()
+        ws = AsyncMock()
+        hub._iframe_conns[("u1", "p1", "t1", "a1")] = ws
+        op = {"op": "navigate", "url": "https://example.com"}
+        result = await hub.route_op_to_iframe(
+            user_id="u1", profile_id="p1", tab_id="t1", agent_id="a1", op=op,
+        )
+        assert result is True
+        ws.send_json.assert_awaited_once_with(op)
+
+    @pytest.mark.asyncio
+    async def test_route_op_to_iframe_swallows_send_failure(self):
+        hub = self._make_hub()
+        ws = AsyncMock()
+        ws.send_json.side_effect = RuntimeError("disconnected")
+        hub._iframe_conns[("u1", "p1", "t1", "a1")] = ws
+        result = await hub.route_op_to_iframe(
+            user_id="u1", profile_id="p1", tab_id="t1", agent_id="a1",
+            op={"op": "click"},
+        )
+        assert result is False

--- a/tests/routes/desktop_browser/test_copilot_js.py
+++ b/tests/routes/desktop_browser/test_copilot_js.py
@@ -96,3 +96,27 @@ class TestCopilotJsAsset:
         body = r.text
         assert "new Event('input'" in body
         assert "new Event('change'" in body
+
+    @pytest.mark.asyncio
+    async def test_annotation_ops_present(self, client):
+        """All annotation ops appear in the served file."""
+        r = await client.get("/__taos/copilot.js")
+        body = r.text
+        for op in ["highlight", "sticky", "arrow", "cursor", "clear"]:
+            assert op in body, f"missing op {op}"
+
+    @pytest.mark.asyncio
+    async def test_arrow_and_cursor_return_parent_overlay_sentinel(self, client):
+        """Arrow + cursor in copilot.js return the use-parent-overlay sentinel
+        so the agent knows to re-issue via AnnotationLayer."""
+        r = await client.get("/__taos/copilot.js")
+        body = r.text
+        assert "use-parent-overlay" in body
+
+    @pytest.mark.asyncio
+    async def test_annotations_use_data_attribute_for_tracking(self, client):
+        """clear op needs data-taos-annotation-id to find/remove specific annotations."""
+        r = await client.get("/__taos/copilot.js")
+        body = r.text
+        assert "taosAnnotationId" in body
+        assert "taosAnnotation" in body

--- a/tests/routes/desktop_browser/test_copilot_js.py
+++ b/tests/routes/desktop_browser/test_copilot_js.py
@@ -72,3 +72,27 @@ class TestCopilotJsAsset:
         r = await client.get("/__taos/copilot.js")
         body = r.text
         assert "CSS.escape" in body or "CSS && CSS.escape" in body or "window.CSS.escape" in body
+
+    @pytest.mark.asyncio
+    async def test_drive_ops_present(self, client):
+        """All five drive ops appear in the served file."""
+        r = await client.get("/__taos/copilot.js")
+        body = r.text
+        for op in ["scrollTo", "click", "type", "navigate", "focus"]:
+            assert op in body, f"missing op {op}"
+
+    @pytest.mark.asyncio
+    async def test_drive_ops_table_includes_DRIVE_OPS(self, client):
+        """DRIVE_OPS map exists for the driving-state postMessage trigger."""
+        r = await client.get("/__taos/copilot.js")
+        body = r.text
+        assert "DRIVE_OPS" in body
+        assert "driving-state" in body
+
+    @pytest.mark.asyncio
+    async def test_input_dispatch_fires_input_and_change_events(self, client):
+        """type op fires both input and change events for React controlled inputs."""
+        r = await client.get("/__taos/copilot.js")
+        body = r.text
+        assert "new Event('input'" in body
+        assert "new Event('change'" in body

--- a/tests/routes/desktop_browser/test_drive_sessions.py
+++ b/tests/routes/desktop_browser/test_drive_sessions.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 import pytest_asyncio

--- a/tests/routes/desktop_browser/test_drive_sessions.py
+++ b/tests/routes/desktop_browser/test_drive_sessions.py
@@ -177,26 +177,24 @@ async def test_is_driving_false_when_no_row(store):
 
 @pytest.mark.asyncio
 async def test_prune_expired_removes_only_expired(store):
-    # Start a "fresh" session for user u1
-    await store.start_drive_session(
-        user_id="u1", profile_id="p1", tab_id="t1", agent_id="fresh-agent",
-    )
-    # Start a session for user u2, then let it "expire"
+    # Start a session that we'll let expire
     await store.start_drive_session(
         user_id="u2", profile_id="p1", tab_id="t1", agent_id="stale-agent",
     )
 
-    # Wait for the stale one to actually expire under the tiny timeout
-    await asyncio.sleep(0.1)
+    # Wait long enough that stale-agent is well past the 0.5s timeout below.
+    # Using 0.6s so the test isn't flaky under heavy CI load (where the Python
+    # interpreter can pause for hundreds of ms between awaits — a tighter
+    # boundary would let the "fresh" session also slip past the cutoff).
+    await asyncio.sleep(0.6)
 
-    # Prune with tiny timeout — u2 session is expired; u1 is not (we just bumped
-    # the "fresh" session's last_op_at by starting it after the sleep, but
-    # actually both were started before the sleep). Use fresh bump to keep u1 alive.
-    await store.bump_drive_session(
+    # Now create the fresh session AFTER the sleep so its last_op_at is
+    # guaranteed within the timeout window when we prune.
+    await store.start_drive_session(
         user_id="u1", profile_id="p1", tab_id="t1", agent_id="fresh-agent",
     )
 
-    removed = await store.prune_expired_drive_sessions(idle_timeout_s=0.05)
+    removed = await store.prune_expired_drive_sessions(idle_timeout_s=0.5)
     assert removed == 1  # Only the stale one
 
     rows = await store._db.execute_fetchall(

--- a/tests/routes/desktop_browser/test_drive_sessions.py
+++ b/tests/routes/desktop_browser/test_drive_sessions.py
@@ -1,0 +1,309 @@
+"""Tests for drive_sessions store methods + capability-check wrappers."""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
+import pytest
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture
+async def store(tmp_path):
+    from tinyagentos.routes.desktop_browser.store import BrowserStore
+
+    s = BrowserStore(tmp_path / "browser.sqlite3")
+    await s.init()
+    yield s
+    await s.close()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+BASE = dict(user_id="u1", profile_id="p1", tab_id="t1", agent_id="agent-a")
+
+
+# ---------------------------------------------------------------------------
+# start_drive_session
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_start_drive_session_creates_row(store):
+    before = datetime.now(timezone.utc)
+    await store.start_drive_session(**BASE)
+    rows = await store._db.execute_fetchall(
+        "SELECT started_at, last_op_at FROM drive_sessions "
+        "WHERE user_id=? AND profile_id=? AND tab_id=? AND agent_id=?",
+        (BASE["user_id"], BASE["profile_id"], BASE["tab_id"], BASE["agent_id"]),
+    )
+    assert len(rows) == 1
+    started = datetime.fromisoformat(rows[0][0])
+    last_op = datetime.fromisoformat(rows[0][1])
+    after = datetime.now(timezone.utc)
+    assert before <= started <= after
+    assert before <= last_op <= after
+
+
+@pytest.mark.asyncio
+async def test_start_drive_session_upsert_resets_timestamps(store):
+    await store.start_drive_session(**BASE)
+    rows_first = await store._db.execute_fetchall(
+        "SELECT started_at FROM drive_sessions "
+        "WHERE user_id=? AND profile_id=? AND tab_id=? AND agent_id=?",
+        (BASE["user_id"], BASE["profile_id"], BASE["tab_id"], BASE["agent_id"]),
+    )
+    first_started = rows_first[0][0]
+
+    # Brief sleep so timestamps differ
+    await asyncio.sleep(0.02)
+    await store.start_drive_session(**BASE)
+
+    rows_second = await store._db.execute_fetchall(
+        "SELECT started_at FROM drive_sessions "
+        "WHERE user_id=? AND profile_id=? AND tab_id=? AND agent_id=?",
+        (BASE["user_id"], BASE["profile_id"], BASE["tab_id"], BASE["agent_id"]),
+    )
+    # Only one row (UPSERT, not duplicate insert)
+    assert len(rows_second) == 1
+    # started_at should be refreshed (>= first value)
+    assert rows_second[0][0] >= first_started
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kwargs,match", [
+    ({"user_id": "",   "profile_id": "p1", "tab_id": "t1", "agent_id": "a"}, "user_id"),
+    ({"user_id": "u1", "profile_id": "",   "tab_id": "t1", "agent_id": "a"}, "profile_id"),
+    ({"user_id": "u1", "profile_id": "p1", "tab_id": "",   "agent_id": "a"}, "tab_id"),
+    ({"user_id": "u1", "profile_id": "p1", "tab_id": "t1", "agent_id": ""}, "agent_id"),
+])
+async def test_start_drive_session_raises_on_empty_param(store, kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        await store.start_drive_session(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# bump_drive_session
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_bump_drive_session_returns_true_on_hit(store):
+    await store.start_drive_session(**BASE)
+    result = await store.bump_drive_session(**BASE)
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_bump_drive_session_returns_false_on_miss(store):
+    result = await store.bump_drive_session(**BASE)
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_bump_drive_session_updates_last_op_at_not_started_at(store):
+    await store.start_drive_session(**BASE)
+    rows_before = await store._db.execute_fetchall(
+        "SELECT started_at, last_op_at FROM drive_sessions "
+        "WHERE user_id=? AND profile_id=? AND tab_id=? AND agent_id=?",
+        (BASE["user_id"], BASE["profile_id"], BASE["tab_id"], BASE["agent_id"]),
+    )
+    started_before = rows_before[0][0]
+    last_op_before = rows_before[0][1]
+
+    await asyncio.sleep(0.02)
+    await store.bump_drive_session(**BASE)
+
+    rows_after = await store._db.execute_fetchall(
+        "SELECT started_at, last_op_at FROM drive_sessions "
+        "WHERE user_id=? AND profile_id=? AND tab_id=? AND agent_id=?",
+        (BASE["user_id"], BASE["profile_id"], BASE["tab_id"], BASE["agent_id"]),
+    )
+    started_after = rows_after[0][0]
+    last_op_after = rows_after[0][1]
+
+    # started_at unchanged
+    assert started_after == started_before
+    # last_op_at moved forward
+    assert last_op_after >= last_op_before
+
+
+# ---------------------------------------------------------------------------
+# end_drive_session
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_end_drive_session_returns_true_on_hit(store):
+    await store.start_drive_session(**BASE)
+    result = await store.end_drive_session(**BASE)
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_end_drive_session_returns_false_on_miss(store):
+    result = await store.end_drive_session(**BASE)
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# is_driving
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_is_driving_true_within_timeout(store):
+    await store.start_drive_session(**BASE)
+    result = await store.is_driving(**BASE, idle_timeout_s=30.0)
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_is_driving_false_after_timeout(store):
+    await store.start_drive_session(**BASE)
+    # Use a very short timeout and let it expire
+    await asyncio.sleep(0.1)
+    result = await store.is_driving(**BASE, idle_timeout_s=0.05)
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_is_driving_false_when_no_row(store):
+    result = await store.is_driving(**BASE)
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# prune_expired_drive_sessions
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_prune_expired_removes_only_expired(store):
+    # Start a "fresh" session for user u1
+    await store.start_drive_session(
+        user_id="u1", profile_id="p1", tab_id="t1", agent_id="fresh-agent",
+    )
+    # Start a session for user u2, then let it "expire"
+    await store.start_drive_session(
+        user_id="u2", profile_id="p1", tab_id="t1", agent_id="stale-agent",
+    )
+
+    # Wait for the stale one to actually expire under the tiny timeout
+    await asyncio.sleep(0.1)
+
+    # Prune with tiny timeout — u2 session is expired; u1 is not (we just bumped
+    # the "fresh" session's last_op_at by starting it after the sleep, but
+    # actually both were started before the sleep). Use fresh bump to keep u1 alive.
+    await store.bump_drive_session(
+        user_id="u1", profile_id="p1", tab_id="t1", agent_id="fresh-agent",
+    )
+
+    removed = await store.prune_expired_drive_sessions(idle_timeout_s=0.05)
+    assert removed == 1  # Only the stale one
+
+    rows = await store._db.execute_fetchall(
+        "SELECT agent_id FROM drive_sessions", ()
+    )
+    agent_ids = [r[0] for r in rows]
+    assert "stale-agent" not in agent_ids
+    assert "fresh-agent" in agent_ids
+
+
+# ---------------------------------------------------------------------------
+# Multi-user + multi-profile isolation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_multi_user_isolation_drive_sessions(store):
+    await store.start_drive_session(
+        user_id="user-a", profile_id="p1", tab_id="t1", agent_id="agent-x",
+    )
+    result = await store.is_driving(
+        user_id="user-b", profile_id="p1", tab_id="t1", agent_id="agent-x",
+    )
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_multi_profile_isolation_drive_sessions(store):
+    await store.start_drive_session(
+        user_id="u1", profile_id="profile-x", tab_id="t1", agent_id="agent-a",
+    )
+    result = await store.is_driving(
+        user_id="u1", profile_id="profile-y", tab_id="t1", agent_id="agent-a",
+    )
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# check_drive_capability / check_navigate_capability / check_see_cookies_capability
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_check_drive_capability_returns_true_when_granted(store):
+    await store.add_capability(
+        user_id="u1", profile_id="p1", agent_id="agent-a",
+        host_pattern="example.com", permissions="drive",
+    )
+    result = await store.check_drive_capability(
+        user_id="u1", profile_id="p1", agent_id="agent-a", host="example.com",
+    )
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_check_drive_capability_returns_false_for_other_permission(store):
+    await store.add_capability(
+        user_id="u1", profile_id="p1", agent_id="agent-a",
+        host_pattern="example.com", permissions="navigate",
+    )
+    result = await store.check_drive_capability(
+        user_id="u1", profile_id="p1", agent_id="agent-a", host="example.com",
+    )
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_check_navigate_capability_returns_true_when_granted(store):
+    await store.add_capability(
+        user_id="u1", profile_id="p1", agent_id="agent-a",
+        host_pattern="example.com", permissions="navigate",
+    )
+    result = await store.check_navigate_capability(
+        user_id="u1", profile_id="p1", agent_id="agent-a", host="example.com",
+    )
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_check_navigate_capability_returns_false_for_other_permission(store):
+    await store.add_capability(
+        user_id="u1", profile_id="p1", agent_id="agent-a",
+        host_pattern="example.com", permissions="drive",
+    )
+    result = await store.check_navigate_capability(
+        user_id="u1", profile_id="p1", agent_id="agent-a", host="example.com",
+    )
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_check_see_cookies_capability_returns_true_when_granted(store):
+    await store.add_capability(
+        user_id="u1", profile_id="p1", agent_id="agent-a",
+        host_pattern="example.com", permissions="see_cookies",
+    )
+    result = await store.check_see_cookies_capability(
+        user_id="u1", profile_id="p1", agent_id="agent-a", host="example.com",
+    )
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_check_see_cookies_capability_returns_false_for_other_permission(store):
+    await store.add_capability(
+        user_id="u1", profile_id="p1", agent_id="agent-a",
+        host_pattern="example.com", permissions="drive",
+    )
+    result = await store.check_see_cookies_capability(
+        user_id="u1", profile_id="p1", agent_id="agent-a", host="example.com",
+    )
+    assert result is False

--- a/tests/routes/desktop_browser/test_drive_sessions.py
+++ b/tests/routes/desktop_browser/test_drive_sessions.py
@@ -177,24 +177,25 @@ async def test_is_driving_false_when_no_row(store):
 
 @pytest.mark.asyncio
 async def test_prune_expired_removes_only_expired(store):
-    # Start a session that we'll let expire
-    await store.start_drive_session(
-        user_id="u2", profile_id="p1", tab_id="t1", agent_id="stale-agent",
+    # Insert a "stale" row directly with a hand-rolled timestamp 100s in the past.
+    # This sidesteps wall-clock flakiness on slow CI runners where any sleep-based
+    # timing test has a non-trivial chance of slipping out of its window.
+    stale_ts = (datetime.now(timezone.utc) - timedelta(seconds=100)).isoformat()
+    await store._db.execute(
+        "INSERT INTO drive_sessions "
+        "(user_id, profile_id, tab_id, agent_id, started_at, last_op_at) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        ("u2", "p1", "t1", "stale-agent", stale_ts, stale_ts),
     )
+    await store._db.commit()
 
-    # Wait long enough that stale-agent is well past the 0.5s timeout below.
-    # Using 0.6s so the test isn't flaky under heavy CI load (where the Python
-    # interpreter can pause for hundreds of ms between awaits — a tighter
-    # boundary would let the "fresh" session also slip past the cutoff).
-    await asyncio.sleep(0.6)
-
-    # Now create the fresh session AFTER the sleep so its last_op_at is
-    # guaranteed within the timeout window when we prune.
+    # Fresh session created normally — last_op_at = now.
     await store.start_drive_session(
         user_id="u1", profile_id="p1", tab_id="t1", agent_id="fresh-agent",
     )
 
-    removed = await store.prune_expired_drive_sessions(idle_timeout_s=0.5)
+    # Use the production default timeout (30s) so the boundary is wide.
+    removed = await store.prune_expired_drive_sessions(idle_timeout_s=30.0)
     assert removed == 1  # Only the stale one
 
     rows = await store._db.execute_fetchall(

--- a/tinyagentos/routes/desktop_browser/__init__.py
+++ b/tinyagentos/routes/desktop_browser/__init__.py
@@ -18,3 +18,4 @@ from tinyagentos.routes.desktop_browser import profile_routes as _profile_routes
 from tinyagentos.routes.desktop_browser import extract as _extract  # noqa: E402,F401
 from tinyagentos.routes.desktop_browser import agent_pin_routes as _agent_pin_routes  # noqa: E402,F401
 from tinyagentos.routes.desktop_browser import copilot_ws as _copilot_ws  # noqa: E402,F401
+from tinyagentos.routes.desktop_browser import copilot_agent_ws as _copilot_agent_ws  # noqa: E402,F401

--- a/tinyagentos/routes/desktop_browser/__init__.py
+++ b/tinyagentos/routes/desktop_browser/__init__.py
@@ -19,3 +19,4 @@ from tinyagentos.routes.desktop_browser import extract as _extract  # noqa: E402
 from tinyagentos.routes.desktop_browser import agent_pin_routes as _agent_pin_routes  # noqa: E402,F401
 from tinyagentos.routes.desktop_browser import copilot_ws as _copilot_ws  # noqa: E402,F401
 from tinyagentos.routes.desktop_browser import copilot_agent_ws as _copilot_agent_ws  # noqa: E402,F401
+from tinyagentos.routes.desktop_browser import capability_routes as _capability_routes  # noqa: E402,F401

--- a/tinyagentos/routes/desktop_browser/capability_routes.py
+++ b/tinyagentos/routes/desktop_browser/capability_routes.py
@@ -1,6 +1,7 @@
 """HTTP endpoints for agent capability grant/revoke."""
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any
 
 from fastapi import Depends, Request
@@ -60,6 +61,8 @@ async def grant_capability_route(
         return JSONResponse({"error": "session has no user id"}, status_code=401)
     try:
         _validate_permissions(body.permissions)
+        if body.expires_at is not None:
+            datetime.fromisoformat(body.expires_at)
     except ValueError as e:
         return JSONResponse({"error": str(e)}, status_code=400)
     try:

--- a/tinyagentos/routes/desktop_browser/capability_routes.py
+++ b/tinyagentos/routes/desktop_browser/capability_routes.py
@@ -1,0 +1,96 @@
+"""HTTP endpoints for agent capability grant/revoke."""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import Depends, Request
+from fastapi.responses import JSONResponse, Response
+from pydantic import BaseModel
+
+from tinyagentos.auth import get_current_user
+from tinyagentos.routes.desktop_browser import router
+
+_KNOWN_PERMISSIONS = {"read_dom", "navigate", "drive", "see_cookies"}
+
+
+def _validate_permissions(permissions: str) -> None:
+    if not permissions or not permissions.strip():
+        raise ValueError("permissions must not be empty")
+    tokens = [t.strip() for t in permissions.split(",")]
+    if not tokens or any(not t for t in tokens):
+        raise ValueError("permissions must be a non-empty comma-separated list")
+    bad = [t for t in tokens if t not in _KNOWN_PERMISSIONS]
+    if bad:
+        raise ValueError(f"unknown permissions: {','.join(bad)}")
+
+
+@router.get("/api/desktop/browser/capabilities")
+async def list_capabilities_route(
+    request: Request,
+    profile_id: str,
+    agent_id: str | None = None,
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+):
+    """Returns { grants: [{agent_id, host_pattern, permissions, granted_at, expires_at}, ...] }"""
+    user_id = str(current_user.get("id") or "")
+    if not user_id:
+        return JSONResponse({"error": "session has no user id"}, status_code=401)
+    grants = await request.app.state.browser_store.list_capabilities(
+        user_id=user_id, profile_id=profile_id, agent_id=agent_id,
+    )
+    return {"grants": grants}
+
+
+class GrantRequest(BaseModel):
+    profile_id: str
+    agent_id: str
+    host_pattern: str
+    permissions: str
+    expires_at: str | None = None
+
+
+@router.post("/api/desktop/browser/capabilities")
+async def grant_capability_route(
+    request: Request,
+    body: GrantRequest,
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+):
+    user_id = str(current_user.get("id") or "")
+    if not user_id:
+        return JSONResponse({"error": "session has no user id"}, status_code=401)
+    try:
+        _validate_permissions(body.permissions)
+    except ValueError as e:
+        return JSONResponse({"error": str(e)}, status_code=400)
+    try:
+        await request.app.state.browser_store.add_capability(
+            user_id=user_id,
+            profile_id=body.profile_id,
+            agent_id=body.agent_id,
+            host_pattern=body.host_pattern,
+            permissions=body.permissions,
+            expires_at=body.expires_at,
+        )
+    except ValueError as e:
+        return JSONResponse({"error": str(e)}, status_code=400)
+    return {"granted": True}
+
+
+@router.delete("/api/desktop/browser/capabilities")
+async def revoke_capability_route(
+    request: Request,
+    profile_id: str,
+    agent_id: str,
+    host_pattern: str,
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+):
+    user_id = str(current_user.get("id") or "")
+    if not user_id:
+        return JSONResponse({"error": "session has no user id"}, status_code=401)
+    await request.app.state.browser_store.revoke_capability(
+        user_id=user_id,
+        profile_id=profile_id,
+        agent_id=agent_id,
+        host_pattern=host_pattern,
+    )
+    return Response(status_code=204)

--- a/tinyagentos/routes/desktop_browser/copilot.js
+++ b/tinyagentos/routes/desktop_browser/copilot.js
@@ -86,11 +86,20 @@
       if (!args || typeof args.url !== 'string' || !args.url) {
         return { error: 'missing url' };
       }
+      var parsed;
+      try {
+        parsed = new URL(args.url, location.href);
+      } catch (_e) {
+        return { error: 'invalid url' };
+      }
+      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+        return { error: 'unsupported scheme' };
+      }
       // The proxied iframe is sandboxed; setting location.href triggers a
       // navigation through the proxy (the rewriter has already prefixed
       // anchor hrefs but a synthetic navigate uses the raw URL — the browser
       // shell picks this up via the navigation event).
-      location.href = args.url;
+      location.href = parsed.href;
       return { ok: true };
     },
 

--- a/tinyagentos/routes/desktop_browser/copilot.js
+++ b/tinyagentos/routes/desktop_browser/copilot.js
@@ -102,6 +102,100 @@
       el.focus();
       return { ok: true };
     },
+
+    // ─── Annotation ops ────────────────────────────────────────────────────────
+    // In-iframe annotations drawn directly into the proxied DOM. Anchored
+    // elements survive iframe scroll natively. Free-floating cursor + arrows
+    // are drawn by the parent's AnnotationLayer.tsx (this op returns a
+    // sentinel so the parent knows to draw them).
+    //
+    // Annotations are tagged with data-taos-annotation-id so 'clear' can
+    // remove them by id.
+
+    highlight: function (args) {
+      if (!args || !args.selector) return { error: 'missing selector' };
+      var el = document.querySelector(args.selector);
+      if (!el) return { error: 'not-found' };
+      var color = args.color || 'yellow';
+      var id = 'h-' + Date.now() + '-' + Math.floor(Math.random() * 100000);
+      // Stash original background so 'clear' can restore it
+      el.dataset.taosAnnotationOrigBg = el.style.background || '';
+      el.style.background = color;
+      el.dataset.taosAnnotation = 'highlight';
+      el.dataset.taosAnnotationId = id;
+      return { ok: true, annotationId: id };
+    },
+
+    sticky: function (args) {
+      if (!args || !args.anchorSelector) return { error: 'missing anchorSelector' };
+      var anchor = document.querySelector(args.anchorSelector);
+      if (!anchor) return { error: 'not-found' };
+      var id = 'sticky-' + Date.now() + '-' + Math.floor(Math.random() * 100000);
+      var note = document.createElement('div');
+      note.textContent = (args.text !== undefined && args.text !== null) ? String(args.text) : '';
+      note.dataset.taosAnnotation = 'sticky';
+      note.dataset.taosAnnotationId = id;
+      note.style.cssText = 'position:absolute;'
+        + 'background:' + (args.color || '#fff8b0') + ';'
+        + 'border:1px solid #999;'
+        + 'padding:6px;'
+        + 'font:13px sans-serif;'
+        + 'border-radius:4px;'
+        + 'z-index:2147483647;'
+        + 'max-width:240px;'
+        + 'box-shadow:0 2px 8px rgba(0,0,0,0.15);';
+      // Position below the anchor in document coordinates
+      var rect = anchor.getBoundingClientRect();
+      note.style.top = (window.scrollY + rect.bottom + 4) + 'px';
+      note.style.left = (window.scrollX + rect.left) + 'px';
+      document.body.appendChild(note);
+      return { ok: true, annotationId: id };
+    },
+
+    arrow: function (args) {
+      // Parent-overlay path — see AnnotationLayer.tsx (PR 7 Task 8). The agent
+      // sees this sentinel and re-issues via the parent's annotation channel.
+      return { error: 'use-parent-overlay' };
+    },
+
+    cursor: function (args) {
+      // Same: parent-overlay only. The cursor follows mouse coords from the
+      // parent's perspective and the iframe doesn't have those.
+      return { error: 'use-parent-overlay' };
+    },
+
+    clear: function (args) {
+      if (args && args.annotationId) {
+        var el = document.querySelector(
+          '[data-taos-annotation-id="' + args.annotationId + '"]'
+        );
+        if (el) {
+          if (el.dataset.taosAnnotation === 'highlight') {
+            el.style.background = el.dataset.taosAnnotationOrigBg || '';
+            delete el.dataset.taosAnnotation;
+            delete el.dataset.taosAnnotationId;
+            delete el.dataset.taosAnnotationOrigBg;
+          } else {
+            el.parentNode && el.parentNode.removeChild(el);
+          }
+        }
+        return { ok: true };
+      }
+      // Clear all annotations
+      var all = document.querySelectorAll('[data-taos-annotation]');
+      for (var i = 0; i < all.length; i++) {
+        var a = all[i];
+        if (a.dataset.taosAnnotation === 'highlight') {
+          a.style.background = a.dataset.taosAnnotationOrigBg || '';
+          delete a.dataset.taosAnnotation;
+          delete a.dataset.taosAnnotationId;
+          delete a.dataset.taosAnnotationOrigBg;
+        } else if (a.parentNode) {
+          a.parentNode.removeChild(a);
+        }
+      }
+      return { ok: true };
+    },
   };
 
   function extractReadable(args) {

--- a/tinyagentos/routes/desktop_browser/copilot.js
+++ b/tinyagentos/routes/desktop_browser/copilot.js
@@ -34,6 +34,74 @@
       };
     },
     findElement: findElement,
+
+    // ─── Drive ops ─────────────────────────────────────────────────────────────
+    // These require server-side capability check (server enforces in Task 11).
+    // copilot.js runs them unconditionally — server is responsible for not
+    // dispatching them without a grant.
+
+    scrollTo: function (args) {
+      if (args && args.selector) {
+        var el = document.querySelector(args.selector);
+        if (!el) return { error: 'not-found' };
+        el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        return { ok: true };
+      }
+      if (args && typeof args.y === 'number') {
+        window.scrollTo({ top: args.y, behavior: 'smooth' });
+        return { ok: true };
+      }
+      return { error: 'missing selector or y' };
+    },
+
+    click: function (args) {
+      if (!args || !args.selector) return { error: 'missing selector' };
+      var el = document.querySelector(args.selector);
+      if (!el) return { error: 'not-found' };
+      // Synthetic click works for buttons/links and bubbles like a user click.
+      el.click();
+      return { ok: true };
+    },
+
+    type: function (args) {
+      if (!args || !args.selector) return { error: 'missing selector' };
+      var el = document.querySelector(args.selector);
+      if (!el) return { error: 'not-found' };
+      if (!('value' in el)) return { error: 'not-input' };
+      el.value = (args.value !== undefined && args.value !== null) ? String(args.value) : '';
+      // Fire input + change so React/Vue/etc. controlled inputs notice
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+      el.dispatchEvent(new Event('change', { bubbles: true }));
+      if (args.submit && el.form) {
+        if (typeof el.form.requestSubmit === 'function') {
+          el.form.requestSubmit();
+        } else {
+          el.form.submit();
+        }
+      }
+      return { ok: true };
+    },
+
+    navigate: function (args) {
+      if (!args || typeof args.url !== 'string' || !args.url) {
+        return { error: 'missing url' };
+      }
+      // The proxied iframe is sandboxed; setting location.href triggers a
+      // navigation through the proxy (the rewriter has already prefixed
+      // anchor hrefs but a synthetic navigate uses the raw URL — the browser
+      // shell picks this up via the navigation event).
+      location.href = args.url;
+      return { ok: true };
+    },
+
+    focus: function (args) {
+      if (!args || !args.selector) return { error: 'missing selector' };
+      var el = document.querySelector(args.selector);
+      if (!el) return { error: 'not-found' };
+      if (typeof el.focus !== 'function') return { error: 'not-focusable' };
+      el.focus();
+      return { ok: true };
+    },
   };
 
   function extractReadable(args) {
@@ -171,6 +239,17 @@
           result = ops[msg.op](msg.args || {});
         } catch (err) {
           result = { error: String(err) };
+        }
+        // Drive ops flip the chrome to "driving" — tell the parent
+        var DRIVE_OPS = { scrollTo: 1, click: 1, type: 1, navigate: 1, focus: 1 };
+        if (DRIVE_OPS[msg.op] && window.parent && window.parent !== window) {
+          try {
+            window.parent.postMessage({
+              type: 'taos-copilot:server-event',
+              agentId: agentId,
+              message: { event: 'driving-state', state: 'driving', timestamp: Date.now() / 1000 },
+            }, '*');
+          } catch (_e) { /* parent gone — ignore */ }
         }
         if (ws.readyState === 1) {
           ws.send(JSON.stringify({ event: 'ack', op_id: msg.op_id, result: result }));

--- a/tinyagentos/routes/desktop_browser/copilot_agent_ws.py
+++ b/tinyagentos/routes/desktop_browser/copilot_agent_ws.py
@@ -38,19 +38,16 @@ def _required_permission(op: str) -> str | None:
     return OP_TO_PERMISSION.get(op)
 
 
-def _extract_host(msg: dict) -> str:
-    """Extract the host the agent claims to operate on. Falls back to
-    parsing the url field if no explicit host."""
-    host = msg.get("host")
-    if isinstance(host, str) and host:
-        return host
-    url = msg.get("url")
-    if isinstance(url, str) and url:
-        try:
-            return urlparse(url).hostname or ""
-        except Exception:
-            return ""
-    return ""
+def _trusted_host(server_url: str | None) -> str:
+    """Derive the host from an authoritative server-tracked URL. Returns
+    empty string if the URL is missing or unparseable. Never trust
+    agent-supplied msg["host"] for authorization."""
+    if not server_url:
+        return ""
+    try:
+        return urlparse(server_url).hostname or ""
+    except Exception:
+        return ""
 
 
 @router.websocket("/api/desktop/browser/copilot-agent")
@@ -88,10 +85,35 @@ async def copilot_agent_ws(websocket: WebSocket, ticket: str):
             target_profile = msg.get("profile_id", consumed.profile_id)
             target_tab = msg.get("tab_id", consumed.tab_id)
 
-            # Capability check for privileged ops
+            # If the agent overrides the target tab/profile, re-verify the pin.
+            # The connect-time check only proves the ticket-bound (profile, tab) is pinned.
+            if target_profile != consumed.profile_id or target_tab != consumed.tab_id:
+                target_pinned = await store.list_pins_for_tab(
+                    user_id=consumed.user_id,
+                    profile_id=target_profile,
+                    tab_id=target_tab,
+                )
+                if not any(p["agent_id"] == consumed.agent_id for p in target_pinned):
+                    await websocket.send_json({
+                        "event": "denied",
+                        "op_id": msg.get("op_id"),
+                        "reason": "agent not pinned for target tab",
+                    })
+                    continue
+
+            # Capability check for privileged ops. The host comes from the
+            # SERVER-tracked current URL for this tab (set by proxy.py on every
+            # successful HTML fetch). Agent-supplied msg["host"] is NOT trusted —
+            # otherwise a malicious agent could claim it's operating on an allowed
+            # host while actually driving on a different one.
             required = _required_permission(op)
             if required is not None:
-                host = _extract_host(msg)
+                trusted_url = hub.get_tab_url(
+                    user_id=consumed.user_id,
+                    profile_id=target_profile,
+                    tab_id=target_tab,
+                )
+                host = _trusted_host(trusted_url)
                 granted = await store.check_capability(
                     user_id=consumed.user_id,
                     profile_id=target_profile,
@@ -108,7 +130,7 @@ async def copilot_agent_ws(websocket: WebSocket, ticket: str):
                         agent_id=consumed.agent_id,
                         permission=required,
                         host=host,
-                        full_url=msg.get("url", ""),
+                        full_url=trusted_url or "",
                     )
                     # Tell agent the op was denied
                     await websocket.send_json({

--- a/tinyagentos/routes/desktop_browser/copilot_agent_ws.py
+++ b/tinyagentos/routes/desktop_browser/copilot_agent_ws.py
@@ -1,0 +1,90 @@
+"""Copilot agent-side WebSocket — agent runtime sends ops, receives acks.
+
+The agent runtime obtains a ticket via /api/desktop/browser/copilot/ticket
+(same endpoint as the iframe side). The ticket is bound to (user, agent, tab),
+but the agent connection is keyed only by (user, agent) — an agent has one WS
+regardless of how many tabs it's pinned to. The ticket's tab_id determines the
+*default* iframe target for op routing.
+"""
+from __future__ import annotations
+
+import logging
+
+from fastapi import WebSocket
+from starlette.websockets import WebSocketDisconnect
+
+from tinyagentos.routes.desktop_browser import router
+
+_logger = logging.getLogger(__name__)
+
+_DRIVE_OPS = {"scrollTo", "click", "type", "navigate", "focus"}
+
+
+@router.websocket("/api/desktop/browser/copilot-agent")
+async def copilot_agent_ws(websocket: WebSocket, ticket: str):
+    """Agent runtime → server WebSocket."""
+    consumed = websocket.app.state.copilot_ticket_store.consume(ticket)
+    if consumed is None:
+        await websocket.close(code=4401, reason="invalid or expired ticket")
+        return
+
+    pinned = await websocket.app.state.browser_store.list_pins_for_tab(
+        user_id=consumed.user_id,
+        profile_id=consumed.profile_id,
+        tab_id=consumed.tab_id,
+    )
+    if not any(p["agent_id"] == consumed.agent_id for p in pinned):
+        await websocket.close(code=4403, reason="agent not pinned")
+        return
+
+    await websocket.accept()
+    hub = websocket.app.state.copilot_hub
+    store = websocket.app.state.browser_store
+    hub.add_agent(user_id=consumed.user_id, agent_id=consumed.agent_id, ws=websocket)
+
+    try:
+        while True:
+            msg = await websocket.receive_json()
+            op = msg.get("op")
+            if not isinstance(op, str):
+                continue
+
+            # Allow the agent to target a specific (profile, tab) per op via msg fields,
+            # falling back to the ticket-bound (profile, tab). For PR 7 the typical agent
+            # only operates on the ticket's tab; cross-tab ops are out of scope.
+            target_profile = msg.get("profile_id", consumed.profile_id)
+            target_tab = msg.get("tab_id", consumed.tab_id)
+
+            ok = await hub.route_op_to_iframe(
+                user_id=consumed.user_id,
+                profile_id=target_profile,
+                tab_id=target_tab,
+                agent_id=consumed.agent_id,
+                op=msg,
+            )
+            if not ok:
+                await websocket.send_json({
+                    "event": "error",
+                    "op_id": msg.get("op_id"),
+                    "reason": "iframe not connected",
+                })
+                continue
+
+            if op in _DRIVE_OPS:
+                bumped = await store.bump_drive_session(
+                    user_id=consumed.user_id,
+                    profile_id=target_profile,
+                    tab_id=target_tab,
+                    agent_id=consumed.agent_id,
+                )
+                if not bumped:
+                    await store.start_drive_session(
+                        user_id=consumed.user_id,
+                        profile_id=target_profile,
+                        tab_id=target_tab,
+                        agent_id=consumed.agent_id,
+                    )
+    except WebSocketDisconnect:
+        pass
+    finally:
+        hub.remove_agent(user_id=consumed.user_id, agent_id=consumed.agent_id)

--- a/tinyagentos/routes/desktop_browser/copilot_agent_ws.py
+++ b/tinyagentos/routes/desktop_browser/copilot_agent_ws.py
@@ -9,6 +9,7 @@ regardless of how many tabs it's pinned to. The ticket's tab_id determines the
 from __future__ import annotations
 
 import logging
+from urllib.parse import urlparse
 
 from fastapi import WebSocket
 from starlette.websockets import WebSocketDisconnect
@@ -18,6 +19,38 @@ from tinyagentos.routes.desktop_browser import router
 _logger = logging.getLogger(__name__)
 
 _DRIVE_OPS = {"scrollTo", "click", "type", "navigate", "focus"}
+
+# Privileged ops and the permission required to execute them.
+PRIVILEGED_OPS = {
+    "drive": {"scrollTo", "click", "type", "focus"},
+    "navigate": {"navigate"},
+    "see_cookies": set(),  # see_cookies is for raw cookie reads — not used by current ops
+}
+
+# Reverse lookup: op name → required permission
+OP_TO_PERMISSION: dict[str, str] = {}
+for _perm, _ops in PRIVILEGED_OPS.items():
+    for _op_name in _ops:
+        OP_TO_PERMISSION[_op_name] = _perm
+
+
+def _required_permission(op: str) -> str | None:
+    return OP_TO_PERMISSION.get(op)
+
+
+def _extract_host(msg: dict) -> str:
+    """Extract the host the agent claims to operate on. Falls back to
+    parsing the url field if no explicit host."""
+    host = msg.get("host")
+    if isinstance(host, str) and host:
+        return host
+    url = msg.get("url")
+    if isinstance(url, str) and url:
+        try:
+            return urlparse(url).hostname or ""
+        except Exception:
+            return ""
+    return ""
 
 
 @router.websocket("/api/desktop/browser/copilot-agent")
@@ -54,6 +87,37 @@ async def copilot_agent_ws(websocket: WebSocket, ticket: str):
             # only operates on the ticket's tab; cross-tab ops are out of scope.
             target_profile = msg.get("profile_id", consumed.profile_id)
             target_tab = msg.get("tab_id", consumed.tab_id)
+
+            # Capability check for privileged ops
+            required = _required_permission(op)
+            if required is not None:
+                host = _extract_host(msg)
+                granted = await store.check_capability(
+                    user_id=consumed.user_id,
+                    profile_id=target_profile,
+                    agent_id=consumed.agent_id,
+                    host=host,
+                    permission=required,
+                )
+                if not granted:
+                    # Notify iframe so the modal can pop
+                    await hub.notify_capability_needed(
+                        user_id=consumed.user_id,
+                        profile_id=target_profile,
+                        tab_id=target_tab,
+                        agent_id=consumed.agent_id,
+                        permission=required,
+                        host=host,
+                        full_url=msg.get("url", ""),
+                    )
+                    # Tell agent the op was denied
+                    await websocket.send_json({
+                        "event": "denied",
+                        "op_id": msg.get("op_id"),
+                        "reason": "capability-needed",
+                        "permission": required,
+                    })
+                    continue
 
             ok = await hub.route_op_to_iframe(
                 user_id=consumed.user_id,

--- a/tinyagentos/routes/desktop_browser/copilot_ws.py
+++ b/tinyagentos/routes/desktop_browser/copilot_ws.py
@@ -159,6 +159,24 @@ class CopilotHub:
         # talks to the server through this single WS regardless of how many tabs
         # it's pinned to.
         self._agent_conns: dict[tuple[str, str], WebSocket] = {}
+        # Authoritative current URL per (user_id, profile_id, tab_id) — written
+        # by proxy.py on every successful HTML fetch, read by capability checks
+        # in copilot_agent_ws.py. The agent-supplied msg["host"] is NOT trusted
+        # for authorization; this tracker is the source of truth.
+        self._tab_urls: dict[tuple[str, str, str], str] = {}
+
+    def set_tab_url(
+        self, *, user_id: str, profile_id: str, tab_id: str, url: str,
+    ) -> None:
+        """Record the current URL the iframe is serving for this tab.
+        Called from proxy.py on every successful HTML fetch."""
+        self._tab_urls[(user_id, profile_id, tab_id)] = url
+
+    def get_tab_url(
+        self, *, user_id: str, profile_id: str, tab_id: str,
+    ) -> str | None:
+        """Return the last recorded URL for this tab, or None if unknown."""
+        return self._tab_urls.get((user_id, profile_id, tab_id))
 
     def add_iframe(
         self, *, user_id: str, profile_id: str, tab_id: str, agent_id: str,

--- a/tinyagentos/routes/desktop_browser/copilot_ws.py
+++ b/tinyagentos/routes/desktop_browser/copilot_ws.py
@@ -296,7 +296,7 @@ class CopilotHub:
 # WebSocket endpoint
 # ---------------------------------------------------------------------------
 
-# Allowed event kinds from iframe → server. Drive ack events come in PR 7.
+# Allowed event kinds from iframe → server. 'ack' is routed back to the agent runtime.
 _ALLOWED_EVENT_KINDS = {
     "page-changed", "url-changed", "scroll", "form-submit",
     "download-started", "ack",

--- a/tinyagentos/routes/desktop_browser/copilot_ws.py
+++ b/tinyagentos/routes/desktop_browser/copilot_ws.py
@@ -155,6 +155,10 @@ class CopilotHub:
 
     def __init__(self) -> None:
         self._iframe_conns: dict[tuple[str, str, str, str], WebSocket] = {}
+        # Agent connections: one per (user_id, agent_id) tuple. An agent's runtime
+        # talks to the server through this single WS regardless of how many tabs
+        # it's pinned to.
+        self._agent_conns: dict[tuple[str, str], WebSocket] = {}
 
     def add_iframe(
         self, *, user_id: str, profile_id: str, tab_id: str, agent_id: str,
@@ -173,6 +177,47 @@ class CopilotHub:
     ) -> None:
         """Remove a registered iframe WS. No-op if not present."""
         self._iframe_conns.pop((user_id, profile_id, tab_id, agent_id), None)
+
+    def add_agent(self, *, user_id: str, agent_id: str, ws: WebSocket) -> None:
+        """Register agent connection. Replaces prior connection for the same key
+        (closes the old one async-style, mirrors add_iframe pattern)."""
+        key = (user_id, agent_id)
+        old = self._agent_conns.pop(key, None)
+        if old is not None:
+            asyncio.create_task(_close_safely(old))
+        self._agent_conns[key] = ws
+
+    def remove_agent(self, *, user_id: str, agent_id: str) -> None:
+        self._agent_conns.pop((user_id, agent_id), None)
+
+    async def route_op_to_iframe(
+        self, *, user_id: str, profile_id: str, tab_id: str, agent_id: str, op: dict,
+    ) -> bool:
+        """Forward an op to the iframe-side WS. Returns True iff the iframe was reachable."""
+        key = (user_id, profile_id, tab_id, agent_id)
+        ws = self._iframe_conns.get(key)
+        if ws is None:
+            return False
+        try:
+            await ws.send_json(op)
+            return True
+        except Exception as e:
+            _logger.debug("copilot route_op_to_iframe failed: %s", e)
+            return False
+
+    async def route_ack_to_agent(
+        self, *, user_id: str, agent_id: str, ack: dict,
+    ) -> bool:
+        """Forward an ack from iframe → agent. Returns True iff the agent was reachable."""
+        ws = self._agent_conns.get((user_id, agent_id))
+        if ws is None:
+            return False
+        try:
+            await ws.send_json(ack)
+            return True
+        except Exception as e:
+            _logger.debug("copilot route_ack_to_agent failed: %s", e)
+            return False
 
     async def push_event_to_pinned(
         self, *, user_id: str, profile_id: str, tab_id: str, event: dict,
@@ -240,11 +285,16 @@ async def copilot_ws(websocket: WebSocket, ticket: str):
             message = await websocket.receive_json()
             event_kind = message.get("event")
             if event_kind not in _ALLOWED_EVENT_KINDS:
-                # Don't crash on unknown events; just drop. PR 7 will route
-                # 'ack' events back to the agent connection.
+                # Don't crash on unknown events; just drop.
                 continue
-            # PR 6: iframe → server events accepted but not routed.
-            # PR 7 wires 'ack' to the agent-side connection.
+            # Iframe → server events. 'ack' messages get routed to the agent runtime.
+            # Other events (page-changed etc.) are broadcast by proxy.py via push_event_to_pinned.
+            if event_kind == "ack":
+                await hub.route_ack_to_agent(
+                    user_id=consumed.user_id,
+                    agent_id=consumed.agent_id,
+                    ack=message,
+                )
     except WebSocketDisconnect:
         pass
     finally:

--- a/tinyagentos/routes/desktop_browser/copilot_ws.py
+++ b/tinyagentos/routes/desktop_browser/copilot_ws.py
@@ -219,6 +219,43 @@ class CopilotHub:
             _logger.debug("copilot route_ack_to_agent failed: %s", e)
             return False
 
+    async def notify_capability_needed(
+        self,
+        *,
+        user_id: str,
+        profile_id: str,
+        tab_id: str,
+        agent_id: str,
+        permission: str,
+        host: str,
+        full_url: str = "",
+    ) -> bool:
+        """Push a capability-needed event to the iframe-side WS for the
+        (user, profile, tab, agent) tuple. The iframe's copilot.js forwards
+        it to the parent via postMessage; the parent's agent-ws-bridge
+        catches it and dispatches taos-browser:capability-prompt for the
+        CapabilityPromptModal.
+
+        Returns True iff the iframe was reachable.
+        """
+        key = (user_id, profile_id, tab_id, agent_id)
+        ws = self._iframe_conns.get(key)
+        if ws is None:
+            return False
+        payload = {
+            "event": "capability-needed",
+            "profile_id": profile_id,
+            "permission": permission,
+            "host": host,
+            "full_url": full_url,
+        }
+        try:
+            await ws.send_json(payload)
+            return True
+        except Exception as e:
+            _logger.debug("notify_capability_needed failed: %s", e)
+            return False
+
     async def push_event_to_pinned(
         self, *, user_id: str, profile_id: str, tab_id: str, event: dict,
     ) -> None:

--- a/tinyagentos/routes/desktop_browser/proxy.py
+++ b/tinyagentos/routes/desktop_browser/proxy.py
@@ -216,6 +216,11 @@ async def proxy_get(
         # Page-change broadcast for any agents pinned to this tab.
         # Non-blocking — never delay the user's page load on agent fan-out.
         if tab_id:
+            # Record authoritative current URL for this tab. Agent-side capability
+            # checks read from this rather than trusting agent-supplied msg["host"].
+            request.app.state.copilot_hub.set_tab_url(
+                user_id=user_id, profile_id=profile_id, tab_id=tab_id, url=url,
+            )
             extract_text = ""
             extract_title = ""
             try:

--- a/tinyagentos/routes/desktop_browser/proxy.py
+++ b/tinyagentos/routes/desktop_browser/proxy.py
@@ -216,10 +216,13 @@ async def proxy_get(
         # Page-change broadcast for any agents pinned to this tab.
         # Non-blocking — never delay the user's page load on agent fan-out.
         if tab_id:
-            # Record authoritative current URL for this tab. Agent-side capability
-            # checks read from this rather than trusting agent-supplied msg["host"].
+            # Record authoritative current URL for this tab. Use the FINAL URL
+            # after redirects (`response.url`), not the requested URL — the
+            # iframe is showing whatever the redirects landed on, and capability
+            # checks against the wrong host would mis-authorize ops.
+            final_url = str(response.url)
             request.app.state.copilot_hub.set_tab_url(
-                user_id=user_id, profile_id=profile_id, tab_id=tab_id, url=url,
+                user_id=user_id, profile_id=profile_id, tab_id=tab_id, url=final_url,
             )
             extract_text = ""
             extract_title = ""

--- a/tinyagentos/routes/desktop_browser/schema.py
+++ b/tinyagentos/routes/desktop_browser/schema.py
@@ -94,6 +94,16 @@ CREATE TABLE IF NOT EXISTS agent_pins (
 );
 CREATE INDEX IF NOT EXISTS idx_agent_pins_lookup
   ON agent_pins (user_id, profile_id, tab_id);
+
+CREATE TABLE IF NOT EXISTS drive_sessions (
+  user_id        TEXT NOT NULL,
+  profile_id     TEXT NOT NULL,
+  tab_id         TEXT NOT NULL,
+  agent_id       TEXT NOT NULL,
+  started_at     TEXT NOT NULL,
+  last_op_at     TEXT NOT NULL,
+  PRIMARY KEY (user_id, profile_id, tab_id, agent_id)
+);
 """
 
 

--- a/tinyagentos/routes/desktop_browser/store.py
+++ b/tinyagentos/routes/desktop_browser/store.py
@@ -8,7 +8,7 @@ The query helpers refuse to operate without a user_id argument.
 """
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from tinyagentos.base_store import BaseStore
@@ -683,28 +683,15 @@ class BrowserStore(BaseStore):
         *,
         idle_timeout_s: float = 30.0,
     ) -> int:
-        """DELETE all rows where (now - last_op_at) >= idle_timeout_s. Returns rowcount."""
+        """Atomically delete rows idle for >= idle_timeout_s. Returns rowcount."""
         assert self._db is not None
-        now = datetime.now(timezone.utc)
+        cutoff = (datetime.now(timezone.utc) - timedelta(seconds=idle_timeout_s)).isoformat()
         cursor = await self._db.execute(
-            "SELECT user_id, profile_id, tab_id, agent_id, last_op_at FROM drive_sessions",
+            "DELETE FROM drive_sessions WHERE last_op_at <= ?",
+            (cutoff,),
         )
-        rows = await cursor.fetchall()
-        expired = [
-            (r[0], r[1], r[2], r[3])
-            for r in rows
-            if (now - datetime.fromisoformat(r[4])).total_seconds() >= idle_timeout_s
-        ]
-        if not expired:
-            return 0
-        for (uid, pid, tid, aid) in expired:
-            await self._db.execute(
-                "DELETE FROM drive_sessions "
-                "WHERE user_id = ? AND profile_id = ? AND tab_id = ? AND agent_id = ?",
-                (uid, pid, tid, aid),
-            )
         await self._db.commit()
-        return len(expired)
+        return cursor.rowcount or 0
 
     # ------------------------------------------------------------------
     # Capability-check wrappers

--- a/tinyagentos/routes/desktop_browser/store.py
+++ b/tinyagentos/routes/desktop_browser/store.py
@@ -587,6 +587,168 @@ class BrowserStore(BaseStore):
         await self._db.commit()
         return cursor.rowcount > 0
 
+    # ------------------------------------------------------------------
+    # Drive session helpers
+    # ------------------------------------------------------------------
+
+    async def start_drive_session(
+        self,
+        *,
+        user_id: str,
+        profile_id: str,
+        tab_id: str,
+        agent_id: str,
+    ) -> None:
+        """UPSERT a drive session. Resets started_at + last_op_at to now."""
+        if not user_id:
+            raise ValueError("user_id is required")
+        if not profile_id:
+            raise ValueError("profile_id is required")
+        if not tab_id:
+            raise ValueError("tab_id is required")
+        if not agent_id:
+            raise ValueError("agent_id is required")
+        assert self._db is not None
+        now = datetime.now(timezone.utc).isoformat()
+        await self._db.execute(
+            "INSERT OR REPLACE INTO drive_sessions "
+            "(user_id, profile_id, tab_id, agent_id, started_at, last_op_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (user_id, profile_id, tab_id, agent_id, now, now),
+        )
+        await self._db.commit()
+
+    async def bump_drive_session(
+        self,
+        *,
+        user_id: str,
+        profile_id: str,
+        tab_id: str,
+        agent_id: str,
+    ) -> bool:
+        """UPDATE last_op_at = now. Returns True iff a row was updated."""
+        assert self._db is not None
+        now = datetime.now(timezone.utc).isoformat()
+        cursor = await self._db.execute(
+            "UPDATE drive_sessions SET last_op_at = ? "
+            "WHERE user_id = ? AND profile_id = ? AND tab_id = ? AND agent_id = ?",
+            (now, user_id, profile_id, tab_id, agent_id),
+        )
+        await self._db.commit()
+        return cursor.rowcount > 0
+
+    async def end_drive_session(
+        self,
+        *,
+        user_id: str,
+        profile_id: str,
+        tab_id: str,
+        agent_id: str,
+    ) -> bool:
+        """DELETE the session. Returns True iff a row was removed."""
+        assert self._db is not None
+        cursor = await self._db.execute(
+            "DELETE FROM drive_sessions "
+            "WHERE user_id = ? AND profile_id = ? AND tab_id = ? AND agent_id = ?",
+            (user_id, profile_id, tab_id, agent_id),
+        )
+        await self._db.commit()
+        return cursor.rowcount > 0
+
+    async def is_driving(
+        self,
+        *,
+        user_id: str,
+        profile_id: str,
+        tab_id: str,
+        agent_id: str,
+        idle_timeout_s: float = 30.0,
+    ) -> bool:
+        """True iff a row exists AND (now - last_op_at) < idle_timeout_s."""
+        assert self._db is not None
+        cursor = await self._db.execute(
+            "SELECT last_op_at FROM drive_sessions "
+            "WHERE user_id = ? AND profile_id = ? AND tab_id = ? AND agent_id = ?",
+            (user_id, profile_id, tab_id, agent_id),
+        )
+        row = await cursor.fetchone()
+        if row is None:
+            return False
+        last_op = datetime.fromisoformat(row[0])
+        elapsed = (datetime.now(timezone.utc) - last_op).total_seconds()
+        return elapsed < idle_timeout_s
+
+    async def prune_expired_drive_sessions(
+        self,
+        *,
+        idle_timeout_s: float = 30.0,
+    ) -> int:
+        """DELETE all rows where (now - last_op_at) >= idle_timeout_s. Returns rowcount."""
+        assert self._db is not None
+        now = datetime.now(timezone.utc)
+        cursor = await self._db.execute(
+            "SELECT user_id, profile_id, tab_id, agent_id, last_op_at FROM drive_sessions",
+        )
+        rows = await cursor.fetchall()
+        expired = [
+            (r[0], r[1], r[2], r[3])
+            for r in rows
+            if (now - datetime.fromisoformat(r[4])).total_seconds() >= idle_timeout_s
+        ]
+        if not expired:
+            return 0
+        for (uid, pid, tid, aid) in expired:
+            await self._db.execute(
+                "DELETE FROM drive_sessions "
+                "WHERE user_id = ? AND profile_id = ? AND tab_id = ? AND agent_id = ?",
+                (uid, pid, tid, aid),
+            )
+        await self._db.commit()
+        return len(expired)
+
+    # ------------------------------------------------------------------
+    # Capability-check wrappers
+    # ------------------------------------------------------------------
+
+    async def check_drive_capability(
+        self,
+        *,
+        user_id: str,
+        profile_id: str,
+        agent_id: str,
+        host: str,
+    ) -> bool:
+        return await self.check_capability(
+            user_id=user_id, profile_id=profile_id, agent_id=agent_id,
+            host=host, permission="drive",
+        )
+
+    async def check_navigate_capability(
+        self,
+        *,
+        user_id: str,
+        profile_id: str,
+        agent_id: str,
+        host: str,
+    ) -> bool:
+        return await self.check_capability(
+            user_id=user_id, profile_id=profile_id, agent_id=agent_id,
+            host=host, permission="navigate",
+        )
+
+    async def check_see_cookies_capability(
+        self,
+        *,
+        user_id: str,
+        profile_id: str,
+        agent_id: str,
+        host: str,
+    ) -> bool:
+        return await self.check_capability(
+            user_id=user_id, profile_id=profile_id, agent_id=agent_id,
+            host=host, permission="see_cookies",
+        )
+
     async def check_capability(
         self,
         *,


### PR DESCRIPTION
## Summary

The "write half" of agent integration on top of PR 6's read half. Agents can now drive (scrollTo / click / type / focus / navigate) and annotate (highlight, sticky, parent-overlay cursor + arrows). Privileged ops (drive / navigate / see_cookies) require explicit user grant via a modal that pops on first use; grants are revocable in Settings. The driving state has obvious chrome — green banner with Pause/Take back, tinted iframe, tab-strip wash, brighter pulsing presence pill.

## Architecture

- **Agent-side WS** at `/api/desktop/browser/copilot-agent?ticket=…` — agent runtime connects, sends ops, receives acks. Same ticket store as the iframe side.
- **CopilotHub** extended with `_agent_conns` registry + `route_op_to_iframe` (server→iframe) + `route_ack_to_agent` (iframe→agent) + `notify_capability_needed` (server→iframe→parent).
- **Capability enforcement** in the agent-side receive loop: privileged ops checked against `check_capability(host, permission)`; on miss → deny agent + notify iframe so the modal pops.
- **drive_sessions table** tracks active driving with `last_op_at` for the 30s idle timeout. `is_driving` is the source of truth for "is this agent currently driving on this tab".
- **Frontend driving state**: copilot.js forwards `driving-state` via postMessage; agent-ws-bridge sets local `drivingState` + arms a 30s decay timer. Chrome reads from store: CoPilotBanner, iframe tint, tab-strip wash, pill pulse-faster.
- **Annotations**: in-iframe (highlight, sticky) drawn by copilot.js with `data-taos-annotation-id` for `clear` to find/remove. Parent-overlay (cursor, arrows) drawn by `<AnnotationLayer />` SVG with `pointer-events: none`.

## Files (24 changed, ~3500 lines)

**Backend:** `drive_sessions` schema + 5 store methods + 3 capability wrappers, `copilot_agent_ws.py`, `capability_routes.py` (GET/POST/DELETE), CopilotHub extensions, `copilot.js` (5 drive ops + 5 annotation ops + driving-state forwarding).

**Frontend:** `CapabilityPromptModal`, `AgentCapabilitiesPanel`, `AnnotationLayer`, `CoPilotBanner`, `browser-capability-api.ts`. Agent store extensions: `drivingState` + `isAnyDriving` + annotation actions. agent-ws-bridge handles `driving-state` and `capability-needed` events with 30s decay. Chrome / TabRenderer / TabStrip / AgentPresencePill render the new chrome states.

## Test plan

- [ ] Backend: `pytest tests/routes/desktop_browser/ -q` → 346 passed
- [ ] Frontend: `cd desktop && npx vitest run` → 692 passed across 102 files
- [ ] TypeScript: `cd desktop && npx tsc --noEmit` → zero errors
- [ ] Manual: pin agent → simulate drive op (via WS test client) → modal pops → grant "this site (always)" → driving banner shows, iframe tints, tab-strip green wash, pill pulses faster → Pause flips to idle → 30s decay flips back to idle from server side → Take back revokes grant + unpins
- [ ] Manual: Settings → Agent capabilities → revoke entry → next drive attempt re-prompts

## Atomic invariants

- **Capability check is server-side** — copilot.js executes ops unconditionally; the server gates which ops reach the iframe.
- **30s idle decay enforced both server-side** (`drive_sessions.last_op_at` + `is_driving`) **and client-side** (`agent-ws-bridge` setTimeout). Server is source of truth.
- **Agent ↔ iframe routing via `(user, agent_id)` agent connections** + `(user, profile, tab, agent)` iframe connections in the same hub. PR 6's no-clobber design preserved.

## Deferred to follow-up brainstorms

- AgentsApp aggregated capabilities tab (cross-app — separate brainstorm per spec §12)
- Real chat persistence in AgentPanel (still local-only — small follow-up PR)
- Cursor follows user mouse during co-pilot (UX brainstorm)
- Multi-step plan replay (agent runtime concern)

## Spec / plan references

- Spec: \`docs/superpowers/specs/2026-05-03-browser-app-v2-design.md\` §6.3 / §6.4 / §6.5 / §6.6
- Plan: \`docs/superpowers/plans/2026-05-05-browser-app-v2-pr-7-copilot-driving.md\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent capability management: view and revoke agent permissions in Settings
  * Co-pilot driving mode with visual indicators on tabs and browser area
  * Capability permission prompts allowing users to grant agent access with scope options (page, site session, always)
  * Annotation overlay system displaying agent cursors and arrows in real-time
  * Co-pilot banner showing active driving status with Pause and Take Back actions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->