### PR TITLE
feat(browser): PR 9 — bookmarks + site permissions + downloads (backends)

### DIFF
--- a/desktop/src/apps/BrowserApp/AddressBar.test.tsx
+++ b/desktop/src/apps/BrowserApp/AddressBar.test.tsx
@@ -377,6 +377,66 @@ describe("AddressBar — bookmark star button", () => {
     );
   });
 
+  it("rapid double-click only fires one addBookmark call (single-flight)", async () => {
+    const tabId = useBrowserStore.getState().getWindow(TEST_WINDOW_ID)!.tabs[0].id;
+    useBrowserStore.getState().navigateTab(TEST_WINDOW_ID, tabId, "https://a.test/");
+
+    // Make addBookmark slow enough that the second click arrives before the first resolves
+    let resolveAdd!: (id: string) => void;
+    vi.spyOn(bookmarksApi, "addBookmark").mockReturnValue(
+      new Promise<string>((res) => { resolveAdd = res; }),
+    );
+
+    render(<AddressBar windowId={TEST_WINDOW_ID} />);
+    const btn = await screen.findByRole("button", { name: /add bookmark/i });
+
+    // Two rapid clicks
+    await act(async () => { fireEvent.click(btn); });
+    await act(async () => { fireEvent.click(btn); });
+
+    // Resolve the pending add
+    await act(async () => { resolveAdd("bm-1"); });
+
+    expect(bookmarksApi.addBookmark).toHaveBeenCalledTimes(1);
+  });
+
+  it("profile switch clears stale bookmarks and repopulates", async () => {
+    const tabId = useBrowserStore.getState().getWindow(TEST_WINDOW_ID)!.tabs[0].id;
+    useBrowserStore.getState().navigateTab(TEST_WINDOW_ID, tabId, "https://a.test/");
+
+    // First profile has the page bookmarked
+    vi.spyOn(bookmarksApi, "listBookmarks").mockResolvedValueOnce([
+      { bookmark_id: "bm-profile1", url: "https://a.test/", title: "A", created_at: 1000 },
+    ]);
+
+    render(<AddressBar windowId={TEST_WINDOW_ID} />);
+
+    // Star should be active (bookmarked) for profile "personal"
+    const btn = await screen.findByRole("button", { name: /remove bookmark/i });
+    expect(btn).toHaveAttribute("aria-pressed", "true");
+
+    // Now switch to a profile that has NO bookmarks
+    vi.spyOn(bookmarksApi, "listBookmarks").mockResolvedValue([]);
+    await act(async () => {
+      useBrowserStore.getState().windows[TEST_WINDOW_ID]!.profileId = "work";
+      // Trigger a re-render by updating state
+      useBrowserStore.setState((s) => ({
+        windows: {
+          ...s.windows,
+          [TEST_WINDOW_ID]: { ...s.windows[TEST_WINDOW_ID]!, profileId: "work" },
+        },
+      }));
+    });
+
+    // Star should now be inactive (not bookmarked) for profile "work"
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /add bookmark/i })).toHaveAttribute(
+        "aria-pressed",
+        "false",
+      ),
+    );
+  });
+
   it("clicking star again calls removeBookmark and sets aria-pressed=false", async () => {
     vi.spyOn(bookmarksApi, "listBookmarks").mockResolvedValue([
       { bookmark_id: "bm-existing", url: "https://a.test/", title: "A", created_at: 1000 },

--- a/desktop/src/apps/BrowserApp/AddressBar.test.tsx
+++ b/desktop/src/apps/BrowserApp/AddressBar.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, waitFor, act } from "@testing-library/react"
 import { AddressBar, READER_MIN_WORD_COUNT } from "./AddressBar";
 import { useBrowserStore } from "@/stores/browser-store";
 import * as extractApi from "@/lib/browser-extract-api";
+import * as bookmarksApi from "@/lib/browser-bookmarks-api";
 
 const TEST_WINDOW_ID = "win-test";
 const originalFetch = global.fetch;
@@ -121,6 +122,9 @@ describe("AddressBar — suggest popover", () => {
   });
 
   it("@-prefixed query does NOT fire suggest fetch (PR 4 stub)", async () => {
+    // Intercept the bookmark mount-fetch so it doesn't interfere with the
+    // suggest-fetch assertion below.
+    vi.spyOn(bookmarksApi, "listBookmarks").mockResolvedValue([]);
     const fetchMock = vi.fn();
     global.fetch = fetchMock;
 
@@ -313,5 +317,88 @@ describe("AddressBar — reader toggle", () => {
 
     await new Promise((r) => setTimeout(r, 50));
     expect(extractSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("AddressBar — bookmark star button", () => {
+  beforeEach(() => {
+    vi.spyOn(bookmarksApi, "listBookmarks").mockResolvedValue([]);
+    vi.spyOn(bookmarksApi, "addBookmark").mockResolvedValue("bm-new");
+    vi.spyOn(bookmarksApi, "removeBookmark").mockResolvedValue(true);
+  });
+
+  it("renders star button for a real URL (not about:blank)", async () => {
+    const tabId = useBrowserStore.getState().getWindow(TEST_WINDOW_ID)!.tabs[0].id;
+    useBrowserStore.getState().navigateTab(TEST_WINDOW_ID, tabId, "https://a.test/");
+
+    render(<AddressBar windowId={TEST_WINDOW_ID} />);
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /add bookmark|remove bookmark/i })).toBeInTheDocument(),
+    );
+  });
+
+  it("does NOT render star button for about:blank", async () => {
+    // Default tab URL is about:blank
+    render(<AddressBar windowId={TEST_WINDOW_ID} />);
+    await new Promise((r) => setTimeout(r, 50));
+    expect(screen.queryByRole("button", { name: /add bookmark|remove bookmark/i })).toBeNull();
+  });
+
+  it("star has aria-pressed=false when not bookmarked", async () => {
+    const tabId = useBrowserStore.getState().getWindow(TEST_WINDOW_ID)!.tabs[0].id;
+    useBrowserStore.getState().navigateTab(TEST_WINDOW_ID, tabId, "https://a.test/");
+
+    render(<AddressBar windowId={TEST_WINDOW_ID} />);
+    const btn = await screen.findByRole("button", { name: /add bookmark/i });
+    expect(btn).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("clicking star calls addBookmark and sets aria-pressed=true", async () => {
+    const tabId = useBrowserStore.getState().getWindow(TEST_WINDOW_ID)!.tabs[0].id;
+    useBrowserStore.getState().navigateTab(TEST_WINDOW_ID, tabId, "https://a.test/");
+
+    render(<AddressBar windowId={TEST_WINDOW_ID} />);
+    const btn = await screen.findByRole("button", { name: /add bookmark/i });
+
+    await act(async () => {
+      fireEvent.click(btn);
+    });
+
+    expect(bookmarksApi.addBookmark).toHaveBeenCalledWith(
+      "personal",
+      "https://a.test/",
+      expect.any(String),
+    );
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /remove bookmark/i })).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      ),
+    );
+  });
+
+  it("clicking star again calls removeBookmark and sets aria-pressed=false", async () => {
+    vi.spyOn(bookmarksApi, "listBookmarks").mockResolvedValue([
+      { bookmark_id: "bm-existing", url: "https://a.test/", title: "A", created_at: 1000 },
+    ]);
+
+    const tabId = useBrowserStore.getState().getWindow(TEST_WINDOW_ID)!.tabs[0].id;
+    useBrowserStore.getState().navigateTab(TEST_WINDOW_ID, tabId, "https://a.test/");
+
+    render(<AddressBar windowId={TEST_WINDOW_ID} />);
+    const btn = await screen.findByRole("button", { name: /remove bookmark/i });
+    expect(btn).toHaveAttribute("aria-pressed", "true");
+
+    await act(async () => {
+      fireEvent.click(btn);
+    });
+
+    expect(bookmarksApi.removeBookmark).toHaveBeenCalledWith("personal", "bm-existing");
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /add bookmark/i })).toHaveAttribute(
+        "aria-pressed",
+        "false",
+      ),
+    );
   });
 });

--- a/desktop/src/apps/BrowserApp/AddressBar.tsx
+++ b/desktop/src/apps/BrowserApp/AddressBar.tsx
@@ -51,6 +51,8 @@ export function AddressBar({ windowId }: AddressBarProps) {
   const [bookmarked, setBookmarked] = useState<{ id: string } | null>(null);
   // url → bookmark_id cache so tab switches don't re-fetch
   const bookmarksRef = useRef<Map<string, string>>(new Map());
+  // Single-flight guard for toggleBookmark
+  const pendingRef = useRef(false);
 
   // Focus the address bar when Cmd+L fires for this window
   useEffect(() => {
@@ -92,19 +94,25 @@ export function AddressBar({ windowId }: AddressBarProps) {
     };
   }, [inputValue, hasFocus, win?.profileId]);
 
-  // On mount, populate the bookmarks cache from the API once
+  // Populate (or repopulate on profile change) the bookmarks cache from the API.
+  // Clears the map first so stale entries from the previous profile can't bleed through.
   useEffect(() => {
     if (!win?.profileId) return;
+    bookmarksRef.current.clear();
+    setBookmarked(null);
+    let cancelled = false;
     listBookmarks(win.profileId).then((bms) => {
+      if (cancelled) return;
       for (const bm of bms) {
         bookmarksRef.current.set(bm.url, bm.bookmark_id);
       }
-      // Reflect current tab immediately after cache is populated
+      // Re-evaluate current tab's bookmark state
       if (activeTab?.url && activeTab.url !== "about:blank") {
         const id = bookmarksRef.current.get(activeTab.url);
         setBookmarked(id ? { id } : null);
       }
     });
+    return () => { cancelled = true; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [win?.profileId]);
 
@@ -118,22 +126,54 @@ export function AddressBar({ windowId }: AddressBarProps) {
     setBookmarked(id ? { id } : null);
   }, [activeTab?.url]);
 
+  // Cross-window bookmark sync: when another AddressBar instance toggles a
+  // bookmark, propagate the change into this cache so the star stays accurate.
+  useEffect(() => {
+    if (!win?.profileId) return;
+    const handler = (e: Event) => {
+      const ce = e as CustomEvent<{ profileId: string; url: string; bookmarkId: string | null }>;
+      if (ce.detail.profileId !== win?.profileId) return;
+      if (ce.detail.bookmarkId) {
+        bookmarksRef.current.set(ce.detail.url, ce.detail.bookmarkId);
+      } else {
+        bookmarksRef.current.delete(ce.detail.url);
+      }
+      if (activeTab?.url === ce.detail.url) {
+        setBookmarked(ce.detail.bookmarkId ? { id: ce.detail.bookmarkId } : null);
+      }
+    };
+    window.addEventListener("taos-browser:bookmark-changed", handler);
+    return () => window.removeEventListener("taos-browser:bookmark-changed", handler);
+  }, [win?.profileId, activeTab?.url]);
+
   if (!win || !activeTab) return null;
 
   async function toggleBookmark() {
     if (!activeTab?.url || activeTab.url === "about:blank" || !win?.profileId) return;
-    if (bookmarked) {
-      const ok = await removeBookmark(win.profileId, bookmarked.id);
-      if (ok) {
-        bookmarksRef.current.delete(activeTab.url);
-        setBookmarked(null);
+    if (pendingRef.current) return;
+    pendingRef.current = true;
+    try {
+      if (bookmarked) {
+        const ok = await removeBookmark(win.profileId, bookmarked.id);
+        if (ok) {
+          bookmarksRef.current.delete(activeTab.url);
+          setBookmarked(null);
+          window.dispatchEvent(new CustomEvent("taos-browser:bookmark-changed", {
+            detail: { profileId: win.profileId, url: activeTab.url, bookmarkId: null },
+          }));
+        }
+      } else {
+        const id = await addBookmark(win.profileId, activeTab.url, activeTab.title || activeTab.url);
+        if (id) {
+          bookmarksRef.current.set(activeTab.url, id);
+          setBookmarked({ id });
+          window.dispatchEvent(new CustomEvent("taos-browser:bookmark-changed", {
+            detail: { profileId: win.profileId, url: activeTab.url, bookmarkId: id },
+          }));
+        }
       }
-    } else {
-      const id = await addBookmark(win.profileId, activeTab.url, activeTab.title || activeTab.url);
-      if (id) {
-        bookmarksRef.current.set(activeTab.url, id);
-        setBookmarked({ id });
-      }
+    } finally {
+      pendingRef.current = false;
     }
   }
 

--- a/desktop/src/apps/BrowserApp/AddressBar.tsx
+++ b/desktop/src/apps/BrowserApp/AddressBar.tsx
@@ -15,11 +15,12 @@
  * Settings.
  */
 import { useEffect, useRef, useState } from "react";
-import { BookOpen } from "lucide-react";
+import { BookOpen, Star } from "lucide-react";
 import { useBrowserStore } from "@/stores/browser-store";
 import { useBrowserSettingsStore, searchUrlFor } from "@/stores/browser-settings-store";
 import { fetchSuggestions, type Suggestion } from "@/lib/browser-suggest-api";
 import { extractReadable } from "@/lib/browser-extract-api";
+import { listBookmarks, addBookmark, removeBookmark } from "@/lib/browser-bookmarks-api";
 import { AddressSuggest } from "./AddressSuggest";
 
 const SUGGEST_DEBOUNCE_MS = 150;
@@ -45,6 +46,11 @@ export function AddressBar({ windowId }: AddressBarProps) {
   const suggestTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Guard against duplicate in-flight extract requests for the same URL
   const inflightUrlRef = useRef<string | null>(null);
+
+  // Bookmark state: null = not bookmarked, { id } = bookmarked
+  const [bookmarked, setBookmarked] = useState<{ id: string } | null>(null);
+  // url → bookmark_id cache so tab switches don't re-fetch
+  const bookmarksRef = useRef<Map<string, string>>(new Map());
 
   // Focus the address bar when Cmd+L fires for this window
   useEffect(() => {
@@ -86,7 +92,50 @@ export function AddressBar({ windowId }: AddressBarProps) {
     };
   }, [inputValue, hasFocus, win?.profileId]);
 
+  // On mount, populate the bookmarks cache from the API once
+  useEffect(() => {
+    if (!win?.profileId) return;
+    listBookmarks(win.profileId).then((bms) => {
+      for (const bm of bms) {
+        bookmarksRef.current.set(bm.url, bm.bookmark_id);
+      }
+      // Reflect current tab immediately after cache is populated
+      if (activeTab?.url && activeTab.url !== "about:blank") {
+        const id = bookmarksRef.current.get(activeTab.url);
+        setBookmarked(id ? { id } : null);
+      }
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [win?.profileId]);
+
+  // Keep star in sync when active tab URL changes
+  useEffect(() => {
+    if (!activeTab?.url || activeTab.url === "about:blank") {
+      setBookmarked(null);
+      return;
+    }
+    const id = bookmarksRef.current.get(activeTab.url);
+    setBookmarked(id ? { id } : null);
+  }, [activeTab?.url]);
+
   if (!win || !activeTab) return null;
+
+  async function toggleBookmark() {
+    if (!activeTab?.url || activeTab.url === "about:blank" || !win?.profileId) return;
+    if (bookmarked) {
+      const ok = await removeBookmark(win.profileId, bookmarked.id);
+      if (ok) {
+        bookmarksRef.current.delete(activeTab.url);
+        setBookmarked(null);
+      }
+    } else {
+      const id = await addBookmark(win.profileId, activeTab.url, activeTab.title || activeTab.url);
+      if (id) {
+        bookmarksRef.current.set(activeTab.url, id);
+        setBookmarked({ id });
+      }
+    }
+  }
 
   function commitNavigation(target: string) {
     const trimmed = target.trim();
@@ -178,9 +227,30 @@ export function AddressBar({ windowId }: AddressBarProps) {
           }
         }}
         className={`w-full bg-shell-bg-deep text-shell-text px-2 py-0.5 rounded text-xs border border-shell-border-subtle focus:border-accent focus:outline-none ${
-          activeTab?.readerAvailable ? "pr-7" : ""
+          activeTab?.readerAvailable && activeTab.url !== "about:blank"
+            ? "pr-14"
+            : activeTab?.readerAvailable || activeTab?.url !== "about:blank"
+            ? "pr-7"
+            : ""
         }`}
       />
+      {activeTab?.url && activeTab.url !== "about:blank" && (
+        <button
+          type="button"
+          aria-label={bookmarked ? "Remove bookmark" : "Add bookmark"}
+          aria-pressed={!!bookmarked}
+          onClick={toggleBookmark}
+          className={`absolute top-1/2 -translate-y-1/2 p-0.5 rounded ${
+            activeTab?.readerAvailable ? "right-7" : "right-1.5"
+          } ${
+            bookmarked
+              ? "text-accent"
+              : "text-shell-text-secondary hover:text-shell-text"
+          }`}
+        >
+          <Star size={12} fill={bookmarked ? "currentColor" : "none"} />
+        </button>
+      )}
       {activeTab?.readerAvailable && (
         <button
           type="button"

--- a/desktop/src/lib/browser-bookmarks-api.test.ts
+++ b/desktop/src/lib/browser-bookmarks-api.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { listBookmarks, addBookmark, removeBookmark } from "./browser-bookmarks-api";
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe("listBookmarks", () => {
+  it("returns bookmarks array on 200", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        bookmarks: [
+          { bookmark_id: "bm-1", url: "https://a.test/", title: "A", created_at: 1000 },
+          { bookmark_id: "bm-2", url: "https://b.test/", title: "B", created_at: 2000 },
+        ],
+      }),
+    });
+
+    const result = await listBookmarks("profile-1");
+    expect(result).toHaveLength(2);
+    expect(result[0].bookmark_id).toBe("bm-1");
+    expect(result[0].url).toBe("https://a.test/");
+    expect(result[1].title).toBe("B");
+  });
+
+  it("returns [] on 401", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 401 });
+    expect(await listBookmarks("profile-1")).toEqual([]);
+  });
+
+  it("returns [] on network error", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("network failure"));
+    expect(await listBookmarks("profile-1")).toEqual([]);
+  });
+
+  it("returns [] when body.bookmarks is not an array", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ bookmarks: null }),
+    });
+    expect(await listBookmarks("profile-1")).toEqual([]);
+  });
+
+  it("includes credentials and profile_id param", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ bookmarks: [] }),
+    });
+    global.fetch = fetchMock;
+    await listBookmarks("profile-1");
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toContain("profile_id=profile-1");
+    expect(opts.credentials).toBe("include");
+  });
+
+  it("encodes profile_id with spaces", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ bookmarks: [] }),
+    });
+    global.fetch = fetchMock;
+    await listBookmarks("my profile");
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toContain("profile_id=my+profile");
+  });
+});
+
+describe("addBookmark", () => {
+  it("returns bookmark_id string on 200", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ bookmark_id: "bm-abc" }),
+    });
+
+    const result = await addBookmark("profile-1", "https://a.test/", "A");
+    expect(result).toBe("bm-abc");
+  });
+
+  it("returns null on 401", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 401 });
+    expect(await addBookmark("profile-1", "https://a.test/", "A")).toBeNull();
+  });
+
+  it("returns null on network error", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("offline"));
+    expect(await addBookmark("profile-1", "https://a.test/", "A")).toBeNull();
+  });
+
+  it("returns null when body.bookmark_id is not a string", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ bookmark_id: 123 }),
+    });
+    expect(await addBookmark("profile-1", "https://a.test/", "A")).toBeNull();
+  });
+
+  it("posts JSON body with profile_id, url, and title", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ bookmark_id: "bm-1" }),
+    });
+    global.fetch = fetchMock;
+
+    await addBookmark("profile-1", "https://a.test/", "A Test");
+
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/desktop/browser/bookmarks");
+    expect(opts.method).toBe("POST");
+    expect(opts.headers["content-type"]).toBe("application/json");
+    const body = JSON.parse(opts.body);
+    expect(body.profile_id).toBe("profile-1");
+    expect(body.url).toBe("https://a.test/");
+    expect(body.title).toBe("A Test");
+  });
+
+  it("includes credentials", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ bookmark_id: "bm-1" }),
+    });
+    global.fetch = fetchMock;
+    await addBookmark("profile-1", "https://a.test/", "A");
+    const [, opts] = fetchMock.mock.calls[0];
+    expect(opts.credentials).toBe("include");
+  });
+});
+
+describe("removeBookmark", () => {
+  it("returns true on 200", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    global.fetch = fetchMock;
+
+    expect(await removeBookmark("profile-1", "bm-1")).toBe(true);
+
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toContain("/api/desktop/browser/bookmarks/bm-1");
+    expect(opts.method).toBe("DELETE");
+  });
+
+  it("returns false on 401", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 401 });
+    expect(await removeBookmark("profile-1", "bm-1")).toBe(false);
+  });
+
+  it("returns false on network error", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("offline"));
+    expect(await removeBookmark("profile-1", "bm-1")).toBe(false);
+  });
+
+  it("encodes bookmark_id in the path", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    global.fetch = fetchMock;
+    await removeBookmark("profile-1", "bm/with/slashes");
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toContain("bm%2Fwith%2Fslashes");
+  });
+
+  it("includes profile_id as query param", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    global.fetch = fetchMock;
+    await removeBookmark("profile-1", "bm-1");
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toContain("profile_id=profile-1");
+  });
+
+  it("includes credentials", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    global.fetch = fetchMock;
+    await removeBookmark("profile-1", "bm-1");
+    const [, opts] = fetchMock.mock.calls[0];
+    expect(opts.credentials).toBe("include");
+  });
+});

--- a/desktop/src/lib/browser-bookmarks-api.ts
+++ b/desktop/src/lib/browser-bookmarks-api.ts
@@ -1,0 +1,61 @@
+/**
+ * Fetch wrappers for /api/desktop/browser/bookmarks.
+ * All functions are silent on errors (return empty/null/false).
+ */
+
+export interface Bookmark {
+  bookmark_id: string;
+  url: string;
+  title: string;
+  created_at: number;
+}
+
+export async function listBookmarks(profileId: string): Promise<Bookmark[]> {
+  const params = new URLSearchParams({ profile_id: profileId });
+  try {
+    const resp = await fetch(`/api/desktop/browser/bookmarks?${params}`, {
+      credentials: "include",
+    });
+    if (!resp.ok) return [];
+    const body = await resp.json();
+    return Array.isArray(body?.bookmarks) ? body.bookmarks : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function addBookmark(
+  profileId: string,
+  url: string,
+  title: string,
+): Promise<string | null> {
+  try {
+    const resp = await fetch("/api/desktop/browser/bookmarks", {
+      method: "POST",
+      credentials: "include",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ profile_id: profileId, url, title }),
+    });
+    if (!resp.ok) return null;
+    const body = await resp.json();
+    return typeof body?.bookmark_id === "string" ? body.bookmark_id : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function removeBookmark(
+  profileId: string,
+  bookmarkId: string,
+): Promise<boolean> {
+  const params = new URLSearchParams({ profile_id: profileId });
+  try {
+    const resp = await fetch(
+      `/api/desktop/browser/bookmarks/${encodeURIComponent(bookmarkId)}?${params}`,
+      { method: "DELETE", credentials: "include" },
+    );
+    return resp.ok;
+  } catch {
+    return false;
+  }
+}

--- a/tests/routes/desktop_browser/test_bookmark_routes.py
+++ b/tests/routes/desktop_browser/test_bookmark_routes.py
@@ -1,0 +1,258 @@
+"""Tests for /api/desktop/browser/bookmarks HTTP CRUD endpoints."""
+from __future__ import annotations
+
+import pytest
+
+
+def _get_user_id(app):
+    """Resolve the authed admin user id from the app state."""
+    auth_mgr = app.state.auth
+    record = auth_mgr.find_user("admin")
+    return record["id"] if record else "test-admin"
+
+
+def _make_auth_client(app, tmp_data_dir):
+    """Create an authenticated async client for a second user (user_b)."""
+    from httpx import ASGITransport, AsyncClient
+    auth_mgr = app.state.auth
+    if auth_mgr.find_user("user_b") is None:
+        invite_code = auth_mgr.add_user_invite("user_b", "admin")
+        auth_mgr.complete_invite("user_b", invite_code, "user_b", "", "pass_b")
+    record = auth_mgr.find_user("user_b")
+    token = auth_mgr.create_session(user_id=record["id"], long_lived=True)
+    return AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        cookies={"taos_session": token},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Auth tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestBookmarkAuth:
+    async def test_get_unauthenticated_returns_401(self, app):
+        from httpx import ASGITransport, AsyncClient
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            resp = await c.get(
+                "/api/desktop/browser/bookmarks",
+                params={"profile_id": "personal"},
+            )
+            assert resp.status_code == 401
+
+    async def test_post_unauthenticated_returns_401(self, app):
+        from httpx import ASGITransport, AsyncClient
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            resp = await c.post(
+                "/api/desktop/browser/bookmarks",
+                json={"profile_id": "personal", "url": "https://example.com", "title": "Example"},
+            )
+            assert resp.status_code == 401
+
+    async def test_delete_unauthenticated_returns_401(self, app):
+        from httpx import ASGITransport, AsyncClient
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            resp = await c.delete(
+                "/api/desktop/browser/bookmarks/some-id",
+                params={"profile_id": "personal"},
+            )
+            assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestListBookmarks:
+    async def test_get_empty_for_new_profile(self, client):
+        resp = await client.get(
+            "/api/desktop/browser/bookmarks",
+            params={"profile_id": "personal"},
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"bookmarks": []}
+
+    async def test_get_returns_added_bookmark(self, client):
+        await client.post(
+            "/api/desktop/browser/bookmarks",
+            json={"profile_id": "p1", "url": "https://example.com", "title": "Example"},
+        )
+        resp = await client.get(
+            "/api/desktop/browser/bookmarks",
+            params={"profile_id": "p1"},
+        )
+        assert resp.status_code == 200
+        bookmarks = resp.json()["bookmarks"]
+        assert len(bookmarks) == 1
+        assert bookmarks[0]["url"] == "https://example.com"
+        assert bookmarks[0]["title"] == "Example"
+
+    async def test_get_multi_user_isolation(self, client, app):
+        """A bookmark seeded for another user must not appear in the authed user's list."""
+        store = app.state.browser_store
+        await store.create_bookmark(
+            user_id="other-user", profile_id="p1",
+            url="https://secret.com", title="Secret",
+        )
+        resp = await client.get(
+            "/api/desktop/browser/bookmarks",
+            params={"profile_id": "p1"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["bookmarks"] == []
+
+    async def test_get_multi_profile_isolation(self, client):
+        """Bookmarks for profile A must not appear under profile B."""
+        await client.post(
+            "/api/desktop/browser/bookmarks",
+            json={"profile_id": "profile-a", "url": "https://a.com", "title": "A"},
+        )
+        resp = await client.get(
+            "/api/desktop/browser/bookmarks",
+            params={"profile_id": "profile-b"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["bookmarks"] == []
+
+    async def test_get_returns_most_recent_first(self, client):
+        """List is ordered by created_at DESC (most recent first)."""
+        await client.post(
+            "/api/desktop/browser/bookmarks",
+            json={"profile_id": "p-order", "url": "https://first.com", "title": "First"},
+        )
+        await client.post(
+            "/api/desktop/browser/bookmarks",
+            json={"profile_id": "p-order", "url": "https://second.com", "title": "Second"},
+        )
+        resp = await client.get(
+            "/api/desktop/browser/bookmarks",
+            params={"profile_id": "p-order"},
+        )
+        bookmarks = resp.json()["bookmarks"]
+        assert len(bookmarks) == 2
+        # Most recent (second added) comes first
+        assert bookmarks[0]["url"] == "https://second.com"
+
+
+# ---------------------------------------------------------------------------
+# POST tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestAddBookmark:
+    async def test_post_creates_bookmark_returns_id(self, client):
+        resp = await client.post(
+            "/api/desktop/browser/bookmarks",
+            json={"profile_id": "p1", "url": "https://example.com", "title": "Example"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "bookmark_id" in body
+        assert isinstance(body["bookmark_id"], str)
+        assert len(body["bookmark_id"]) > 0
+
+    async def test_post_bookmark_id_is_opaque(self, client):
+        """bookmark_id should be a URL-safe token, not a UUID or sequential int."""
+        resp = await client.post(
+            "/api/desktop/browser/bookmarks",
+            json={"profile_id": "p1", "url": "https://opaque.com", "title": "Opaque"},
+        )
+        bookmark_id = resp.json()["bookmark_id"]
+        # token_urlsafe(12) produces 16-char base64url strings
+        assert len(bookmark_id) == 16
+
+    async def test_post_empty_url_returns_400(self, client):
+        resp = await client.post(
+            "/api/desktop/browser/bookmarks",
+            json={"profile_id": "p1", "url": "", "title": "No URL"},
+        )
+        assert resp.status_code == 400
+        assert "error" in resp.json()
+
+    async def test_post_empty_title_returns_400(self, client):
+        resp = await client.post(
+            "/api/desktop/browser/bookmarks",
+            json={"profile_id": "p1", "url": "https://example.com", "title": ""},
+        )
+        assert resp.status_code == 400
+        assert "error" in resp.json()
+
+    async def test_post_bookmark_appears_in_list(self, client):
+        await client.post(
+            "/api/desktop/browser/bookmarks",
+            json={"profile_id": "p-verify", "url": "https://verify.com", "title": "Verify"},
+        )
+        resp = await client.get(
+            "/api/desktop/browser/bookmarks",
+            params={"profile_id": "p-verify"},
+        )
+        bookmarks = resp.json()["bookmarks"]
+        assert any(b["url"] == "https://verify.com" for b in bookmarks)
+
+
+# ---------------------------------------------------------------------------
+# DELETE tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestDeleteBookmark:
+    async def test_delete_returns_204_and_removes_bookmark(self, client):
+        post_resp = await client.post(
+            "/api/desktop/browser/bookmarks",
+            json={"profile_id": "p1", "url": "https://del.com", "title": "Del"},
+        )
+        bookmark_id = post_resp.json()["bookmark_id"]
+
+        del_resp = await client.delete(
+            f"/api/desktop/browser/bookmarks/{bookmark_id}",
+            params={"profile_id": "p1"},
+        )
+        assert del_resp.status_code == 204
+
+        # Bookmark must be gone
+        list_resp = await client.get(
+            "/api/desktop/browser/bookmarks",
+            params={"profile_id": "p1"},
+        )
+        bookmarks = list_resp.json()["bookmarks"]
+        assert not any(b["bookmark_id"] == bookmark_id for b in bookmarks)
+
+    async def test_delete_missing_bookmark_returns_204(self, client):
+        """Info-hide: DELETE on a non-existent bookmark returns 204."""
+        resp = await client.delete(
+            "/api/desktop/browser/bookmarks/does-not-exist",
+            params={"profile_id": "p1"},
+        )
+        assert resp.status_code == 204
+
+    async def test_delete_multi_user_isolation(self, client, app, tmp_path):
+        """User B cannot delete user A's bookmarks."""
+        user_a_id = _get_user_id(app)
+        store = app.state.browser_store
+        bookmark_id = await store.create_bookmark(
+            user_id=user_a_id, profile_id="p1",
+            url="https://protected.com", title="Protected",
+        )
+
+        # User B tries to delete it — result is 204 but bookmark stays for A
+        async with _make_auth_client(app, tmp_path) as b_client:
+            resp = await b_client.delete(
+                f"/api/desktop/browser/bookmarks/{bookmark_id}",
+                params={"profile_id": "p1"},
+            )
+            assert resp.status_code == 204
+
+        # User A's bookmark still exists
+        bookmarks = await store.list_bookmarks_for_profile(
+            user_id=user_a_id, profile_id="p1",
+        )
+        assert any(b["bookmark_id"] == bookmark_id for b in bookmarks)

--- a/tests/routes/desktop_browser/test_download.py
+++ b/tests/routes/desktop_browser/test_download.py
@@ -372,3 +372,98 @@ class TestDownloadCookies:
         # Cookie should have been sent upstream
         assert "auth_token" in received_headers.get("cookie", "")
         assert "secret-token-xyz" in received_headers.get("cookie", "")
+
+
+# ──────────────────────────────────────────────────────────────────
+# Streaming — body not buffered into memory
+# ──────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+class TestDownloadStreaming:
+    @respx.mock
+    async def test_upstream_content_disposition_honoured_when_no_caller_filename(self, client):
+        """Upstream Content-Disposition filename should be used when caller omits filename."""
+        respx.get("https://example.com/asset").mock(
+            return_value=Response(
+                200,
+                content=b"pdf-data",
+                headers={
+                    "content-type": "application/pdf",
+                    "content-disposition": 'attachment; filename="upstream.pdf"',
+                },
+            )
+        )
+
+        with _SSRF_PATCH:
+            r = await client.get(
+                "/api/desktop/browser/download",
+                params={
+                    "profile_id": "personal",
+                    "url": "https://example.com/asset",
+                    # no filename param
+                },
+            )
+
+        assert r.status_code == 200
+        cd = r.headers.get("content-disposition", "")
+        assert "upstream.pdf" in cd
+
+    @respx.mock
+    async def test_caller_filename_overrides_upstream_content_disposition(self, client):
+        """Caller-supplied filename takes precedence over upstream Content-Disposition."""
+        respx.get("https://example.com/asset2").mock(
+            return_value=Response(
+                200,
+                content=b"data",
+                headers={
+                    "content-type": "application/octet-stream",
+                    "content-disposition": 'attachment; filename="server-name.bin"',
+                },
+            )
+        )
+
+        with _SSRF_PATCH:
+            r = await client.get(
+                "/api/desktop/browser/download",
+                params={
+                    "profile_id": "personal",
+                    "url": "https://example.com/asset2",
+                    "filename": "my-name.bin",
+                },
+            )
+
+        assert r.status_code == 200
+        cd = r.headers.get("content-disposition", "")
+        assert "my-name.bin" in cd
+        assert "server-name.bin" not in cd
+
+    @respx.mock
+    async def test_upstream_rfc5987_content_disposition_honoured(self, client):
+        """RFC 5987 filename*=UTF-8'' form should be parsed correctly."""
+        from urllib.parse import quote as pquote
+        encoded = pquote("résumé.pdf")
+        respx.get("https://example.com/cv").mock(
+            return_value=Response(
+                200,
+                content=b"cv-data",
+                headers={
+                    "content-type": "application/pdf",
+                    "content-disposition": f"attachment; filename*=UTF-8''{encoded}",
+                },
+            )
+        )
+
+        with _SSRF_PATCH:
+            r = await client.get(
+                "/api/desktop/browser/download",
+                params={
+                    "profile_id": "personal",
+                    "url": "https://example.com/cv",
+                },
+            )
+
+        assert r.status_code == 200
+        cd = r.headers.get("content-disposition", "")
+        # The decoded name or percent-encoded name should appear
+        assert "r" in cd  # minimal sanity — "résumé.pdf" contains "r"
+        assert r.content == b"cv-data"

--- a/tests/routes/desktop_browser/test_download.py
+++ b/tests/routes/desktop_browser/test_download.py
@@ -1,0 +1,374 @@
+"""Tests for GET /api/desktop/browser/download — streaming attachment endpoint."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+import respx
+from httpx import AsyncClient, ASGITransport, Response
+
+
+# ──────────────────────────────────────────────────────────────────
+# Auth
+# ──────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+class TestDownloadAuth:
+    async def test_unauthenticated_returns_401(self, app):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            r = await c.get(
+                "/api/desktop/browser/download",
+                params={"profile_id": "p1", "url": "https://example.com/file.pdf"},
+            )
+        assert r.status_code == 401
+
+
+# ──────────────────────────────────────────────────────────────────
+# SSRF
+# ──────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+class TestDownloadSsrf:
+    async def test_blocks_loopback(self, client):
+        r = await client.get(
+            "/api/desktop/browser/download",
+            params={"profile_id": "p1", "url": "http://127.0.0.1/secret"},
+        )
+        assert r.status_code == 403
+
+    async def test_blocks_rfc1918(self, client):
+        r = await client.get(
+            "/api/desktop/browser/download",
+            params={"profile_id": "p1", "url": "http://192.168.1.1/file.bin"},
+        )
+        assert r.status_code == 403
+
+    async def test_blocks_file_scheme(self, client):
+        r = await client.get(
+            "/api/desktop/browser/download",
+            params={"profile_id": "p1", "url": "file:///etc/passwd"},
+        )
+        assert r.status_code == 403
+
+
+# ──────────────────────────────────────────────────────────────────
+# Happy-path streaming
+# ──────────────────────────────────────────────────────────────────
+
+_SSRF_PATCH = patch(
+    "tinyagentos.routes.desktop_browser.ssrf.socket.getaddrinfo",
+    return_value=[(2, 1, 6, "", ("93.184.216.34", 0))],
+)
+
+
+@pytest.mark.asyncio
+class TestDownloadStream:
+    @respx.mock
+    async def test_streams_upstream_bytes(self, client):
+        file_bytes = b"PDF-content-bytes-12345"
+        respx.get("https://example.com/file.pdf").mock(
+            return_value=Response(
+                200,
+                content=file_bytes,
+                headers={"content-type": "application/pdf"},
+            )
+        )
+
+        with _SSRF_PATCH:
+            r = await client.get(
+                "/api/desktop/browser/download",
+                params={
+                    "profile_id": "personal",
+                    "url": "https://example.com/file.pdf",
+                    "filename": "file.pdf",
+                },
+            )
+
+        assert r.status_code == 200
+        assert r.content == file_bytes
+
+    @respx.mock
+    async def test_content_type_is_octet_stream(self, client):
+        respx.get("https://example.com/data.bin").mock(
+            return_value=Response(200, content=b"rawbytes", headers={"content-type": "image/png"}),
+        )
+
+        with _SSRF_PATCH:
+            r = await client.get(
+                "/api/desktop/browser/download",
+                params={
+                    "profile_id": "personal",
+                    "url": "https://example.com/data.bin",
+                    "filename": "data.bin",
+                },
+            )
+
+        assert r.status_code == 200
+        assert "application/octet-stream" in r.headers.get("content-type", "")
+
+
+# ──────────────────────────────────────────────────────────────────
+# Content-Disposition
+# ──────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+class TestDownloadContentDisposition:
+    @respx.mock
+    async def test_explicit_filename_in_disposition(self, client):
+        respx.get("https://example.com/report").mock(
+            return_value=Response(200, content=b"data", headers={"content-type": "text/plain"}),
+        )
+
+        with _SSRF_PATCH:
+            r = await client.get(
+                "/api/desktop/browser/download",
+                params={
+                    "profile_id": "personal",
+                    "url": "https://example.com/report",
+                    "filename": "report.pdf",
+                },
+            )
+
+        cd = r.headers.get("content-disposition", "")
+        assert "attachment" in cd
+        assert 'filename="report.pdf"' in cd
+
+    @respx.mock
+    async def test_filename_inferred_from_url_path(self, client):
+        respx.get("https://example.com/docs/invoice.pdf").mock(
+            return_value=Response(200, content=b"pdf-data", headers={"content-type": "application/pdf"}),
+        )
+
+        with _SSRF_PATCH:
+            r = await client.get(
+                "/api/desktop/browser/download",
+                params={
+                    "profile_id": "personal",
+                    "url": "https://example.com/docs/invoice.pdf",
+                    # no filename param
+                },
+            )
+
+        cd = r.headers.get("content-disposition", "")
+        assert "attachment" in cd
+        assert "invoice.pdf" in cd
+
+    @respx.mock
+    async def test_url_with_no_file_extension_falls_back_to_download(self, client):
+        respx.get("https://example.com/").mock(
+            return_value=Response(200, content=b"data", headers={"content-type": "text/html"}),
+        )
+
+        with _SSRF_PATCH:
+            r = await client.get(
+                "/api/desktop/browser/download",
+                params={"profile_id": "personal", "url": "https://example.com/"},
+            )
+
+        cd = r.headers.get("content-disposition", "")
+        assert "attachment" in cd
+        # No usable filename in URL — should fall back to "download"
+        assert "download" in cd
+
+
+# ──────────────────────────────────────────────────────────────────
+# Filename sanitisation
+# ──────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+class TestDownloadFilenameSanitisation:
+    @respx.mock
+    async def test_path_traversal_stripped(self, client):
+        respx.get("https://example.com/file").mock(
+            return_value=Response(200, content=b"data"),
+        )
+
+        with _SSRF_PATCH:
+            r = await client.get(
+                "/api/desktop/browser/download",
+                params={
+                    "profile_id": "personal",
+                    "url": "https://example.com/file",
+                    "filename": "../../etc/passwd",
+                },
+            )
+
+        cd = r.headers.get("content-disposition", "")
+        assert "attachment" in cd
+        # Only the basename — no path components
+        assert "etc" not in cd
+        assert "passwd" in cd
+
+    @respx.mock
+    async def test_double_quotes_stripped_from_filename(self, client):
+        respx.get("https://example.com/file").mock(
+            return_value=Response(200, content=b"data"),
+        )
+
+        with _SSRF_PATCH:
+            r = await client.get(
+                "/api/desktop/browser/download",
+                params={
+                    "profile_id": "personal",
+                    "url": "https://example.com/file",
+                    'filename': 'evil"name.pdf',
+                },
+            )
+
+        cd = r.headers.get("content-disposition", "")
+        assert "attachment" in cd
+        # The double-quote in the input filename must have been stripped.
+        # Extract just the value between filename=" and the closing "
+        assert 'filename="' in cd
+        inner = cd.split('filename="', 1)[1].split('"', 1)[0]
+        assert '"' not in inner
+
+
+# ──────────────────────────────────────────────────────────────────
+# Redirect handling (per-hop SSRF re-validation)
+# ──────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+class TestDownloadRedirects:
+    @respx.mock
+    async def test_redirect_to_rfc1918_returns_403(self, client):
+        """Initial URL passes SSRF; redirect target is internal — must be blocked."""
+        respx.get("https://example.com/file").mock(
+            return_value=Response(
+                302,
+                headers={"location": "http://192.168.1.100/secret"},
+            )
+        )
+
+        with _SSRF_PATCH:
+            r = await client.get(
+                "/api/desktop/browser/download",
+                params={
+                    "profile_id": "personal",
+                    "url": "https://example.com/file",
+                },
+            )
+
+        assert r.status_code == 403
+
+    @respx.mock
+    async def test_redirect_to_aws_imds_returns_403(self, client):
+        respx.get("https://example.com/redir").mock(
+            return_value=Response(
+                301,
+                headers={"location": "http://169.254.169.254/latest/meta-data/"},
+            )
+        )
+
+        with _SSRF_PATCH:
+            r = await client.get(
+                "/api/desktop/browser/download",
+                params={
+                    "profile_id": "personal",
+                    "url": "https://example.com/redir",
+                },
+            )
+
+        assert r.status_code == 403
+
+    @respx.mock
+    async def test_too_many_redirects_returns_502(self, client):
+        for i in range(6):
+            respx.get(f"https://example.com/hop{i}").mock(
+                return_value=Response(
+                    302,
+                    headers={"location": f"https://example.com/hop{i + 1}"},
+                )
+            )
+
+        with _SSRF_PATCH:
+            r = await client.get(
+                "/api/desktop/browser/download",
+                params={
+                    "profile_id": "personal",
+                    "url": "https://example.com/hop0",
+                },
+            )
+
+        assert r.status_code == 502
+
+    @respx.mock
+    async def test_normal_redirect_followed_and_streamed(self, client):
+        """A safe redirect hop should be followed and the file streamed."""
+        file_bytes = b"redirected-content"
+        respx.get("https://example.com/old-path").mock(
+            return_value=Response(
+                301,
+                headers={"location": "https://example.com/new-path"},
+            )
+        )
+        respx.get("https://example.com/new-path").mock(
+            return_value=Response(200, content=file_bytes),
+        )
+
+        with _SSRF_PATCH:
+            r = await client.get(
+                "/api/desktop/browser/download",
+                params={
+                    "profile_id": "personal",
+                    "url": "https://example.com/old-path",
+                    "filename": "file.bin",
+                },
+            )
+
+        assert r.status_code == 200
+        assert r.content == file_bytes
+
+
+# ──────────────────────────────────────────────────────────────────
+# Cookie jar integration
+# ──────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+class TestDownloadCookies:
+    @respx.mock
+    async def test_cookies_from_jar_sent_with_request(self, client, app):
+        """Cookies pre-seeded in the jar are forwarded to the upstream request."""
+        # Seed a cookie directly into the store for the admin user
+        from tinyagentos.routes.desktop_browser.store import BrowserCookieStore
+        cookie_store: BrowserCookieStore = app.state.browser_cookie_store
+        user_record = app.state.auth.find_user("admin")
+        user_id = str(user_record["id"])
+
+        await cookie_store.set_cookie(
+            user_id=user_id,
+            profile_id="personal",
+            host="example.com",
+            path="/",
+            name="auth_token",
+            value="secret-token-xyz",
+            expires_at=None,
+            http_only=True,
+            secure=False,
+            same_site=None,
+        )
+
+        received_headers: dict[str, str] = {}
+
+        def capture_request(request):
+            received_headers.update(dict(request.headers))
+            return Response(200, content=b"file-data")
+
+        respx.get("https://example.com/private-file.pdf").mock(side_effect=capture_request)
+
+        with _SSRF_PATCH:
+            r = await client.get(
+                "/api/desktop/browser/download",
+                params={
+                    "profile_id": "personal",
+                    "url": "https://example.com/private-file.pdf",
+                    "filename": "file.pdf",
+                },
+            )
+
+        assert r.status_code == 200
+        # Cookie should have been sent upstream
+        assert "auth_token" in received_headers.get("cookie", "")
+        assert "secret-token-xyz" in received_headers.get("cookie", "")

--- a/tests/routes/desktop_browser/test_site_permission_routes.py
+++ b/tests/routes/desktop_browser/test_site_permission_routes.py
@@ -1,0 +1,285 @@
+"""Tests for /api/desktop/browser/site-permissions HTTP CRUD endpoints."""
+from __future__ import annotations
+
+import pytest
+
+
+def _get_user_id(app):
+    """Resolve the authed admin user id from the app state."""
+    auth_mgr = app.state.auth
+    record = auth_mgr.find_user("admin")
+    return record["id"] if record else "test-admin"
+
+
+def _make_auth_client(app, tmp_data_dir):
+    """Create an authenticated async client for a second user (user_b)."""
+    from httpx import ASGITransport, AsyncClient
+
+    auth_mgr = app.state.auth
+    if auth_mgr.find_user("user_b") is None:
+        invite_code = auth_mgr.add_user_invite("user_b", "admin")
+        auth_mgr.complete_invite("user_b", invite_code, "user_b", "", "pass_b")
+    record = auth_mgr.find_user("user_b")
+    token = auth_mgr.create_session(user_id=record["id"], long_lived=True)
+    return AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        cookies={"taos_session": token},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Auth (401) tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestSitePermissionAuth:
+    async def test_get_unauthenticated_returns_401(self, app):
+        from httpx import ASGITransport, AsyncClient
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            resp = await c.get(
+                "/api/desktop/browser/site-permissions",
+                params={"profile_id": "personal"},
+            )
+            assert resp.status_code == 401
+
+    async def test_post_unauthenticated_returns_401(self, app):
+        from httpx import ASGITransport, AsyncClient
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            resp = await c.post(
+                "/api/desktop/browser/site-permissions",
+                json={
+                    "profile_id": "personal",
+                    "host_pattern": "example.com",
+                    "permission": "camera",
+                    "state": "allow",
+                },
+            )
+            assert resp.status_code == 401
+
+    async def test_delete_unauthenticated_returns_401(self, app):
+        from httpx import ASGITransport, AsyncClient
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            resp = await c.delete(
+                "/api/desktop/browser/site-permissions",
+                params={
+                    "profile_id": "personal",
+                    "host_pattern": "example.com",
+                    "permission": "camera",
+                },
+            )
+            assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET happy path
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestListSitePermissions:
+    async def test_get_happy_path_returns_grants(self, client, app):
+        user_id = _get_user_id(app)
+        store = app.state.browser_store
+        await store.set_site_permission(
+            user_id=user_id, profile_id="p1",
+            host_pattern="example.com", permission="notifications", state="allow",
+        )
+        resp = await client.get(
+            "/api/desktop/browser/site-permissions",
+            params={"profile_id": "p1"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "grants" in body
+        assert len(body["grants"]) == 1
+        grant = body["grants"][0]
+        assert grant["host_pattern"] == "example.com"
+        assert grant["permission"] == "notifications"
+        assert grant["state"] == "allow"
+
+    async def test_get_empty_profile_returns_empty_list(self, client):
+        resp = await client.get(
+            "/api/desktop/browser/site-permissions",
+            params={"profile_id": "empty-profile"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["grants"] == []
+
+    async def test_get_multi_user_isolation(self, client, app):
+        store = app.state.browser_store
+        await store.set_site_permission(
+            user_id="other-user", profile_id="p1",
+            host_pattern="secret.com", permission="microphone", state="allow",
+        )
+        resp = await client.get(
+            "/api/desktop/browser/site-permissions",
+            params={"profile_id": "p1"},
+        )
+        assert resp.status_code == 200
+        grants = resp.json()["grants"]
+        assert all(g["host_pattern"] != "secret.com" for g in grants)
+
+
+# ---------------------------------------------------------------------------
+# POST (set/upsert)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestSetSitePermission:
+    async def test_post_happy_path(self, client, app):
+        resp = await client.post(
+            "/api/desktop/browser/site-permissions",
+            json={
+                "profile_id": "p1",
+                "host_pattern": "foo.com",
+                "permission": "camera",
+                "state": "allow",
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"granted": True}
+
+        # Verify row exists via GET
+        get_resp = await client.get(
+            "/api/desktop/browser/site-permissions",
+            params={"profile_id": "p1"},
+        )
+        grants = get_resp.json()["grants"]
+        assert len(grants) == 1
+        assert grants[0]["host_pattern"] == "foo.com"
+        assert grants[0]["state"] == "allow"
+
+    async def test_post_upsert_updates_state(self, client, app):
+        base = {
+            "profile_id": "p1",
+            "host_pattern": "upsert.com",
+            "permission": "geolocation",
+        }
+        await client.post(
+            "/api/desktop/browser/site-permissions",
+            json={**base, "state": "allow"},
+        )
+        await client.post(
+            "/api/desktop/browser/site-permissions",
+            json={**base, "state": "deny"},
+        )
+        get_resp = await client.get(
+            "/api/desktop/browser/site-permissions",
+            params={"profile_id": "p1"},
+        )
+        grants = get_resp.json()["grants"]
+        assert len(grants) == 1
+        assert grants[0]["state"] == "deny"
+
+    async def test_post_unknown_permission_returns_400(self, client):
+        resp = await client.post(
+            "/api/desktop/browser/site-permissions",
+            json={
+                "profile_id": "p1",
+                "host_pattern": "x.com",
+                "permission": "unicorn",
+                "state": "allow",
+            },
+        )
+        assert resp.status_code == 400
+        assert "unicorn" in resp.json().get("error", "")
+
+    async def test_post_invalid_state_returns_400(self, client):
+        resp = await client.post(
+            "/api/desktop/browser/site-permissions",
+            json={
+                "profile_id": "p1",
+                "host_pattern": "x.com",
+                "permission": "camera",
+                "state": "maybe",
+            },
+        )
+        assert resp.status_code == 400
+        assert "state" in resp.json().get("error", "").lower()
+
+    async def test_post_all_known_permissions_accepted(self, client):
+        known = [
+            "notifications", "clipboard-read", "clipboard-write",
+            "geolocation", "camera", "microphone",
+        ]
+        for perm in known:
+            resp = await client.post(
+                "/api/desktop/browser/site-permissions",
+                json={
+                    "profile_id": "p1",
+                    "host_pattern": "test.com",
+                    "permission": perm,
+                    "state": "allow",
+                },
+            )
+            assert resp.status_code == 200, f"failed for permission: {perm}"
+
+
+# ---------------------------------------------------------------------------
+# DELETE
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestRemoveSitePermission:
+    async def test_delete_happy_path_returns_204(self, client, app):
+        user_id = _get_user_id(app)
+        store = app.state.browser_store
+        await store.set_site_permission(
+            user_id=user_id, profile_id="p1",
+            host_pattern="del.com", permission="camera", state="allow",
+        )
+        resp = await client.delete(
+            "/api/desktop/browser/site-permissions",
+            params={
+                "profile_id": "p1",
+                "host_pattern": "del.com",
+                "permission": "camera",
+            },
+        )
+        assert resp.status_code == 204
+        rows = await store.list_site_permissions(user_id=user_id, profile_id="p1")
+        assert rows == []
+
+    async def test_delete_missing_returns_204(self, client):
+        resp = await client.delete(
+            "/api/desktop/browser/site-permissions",
+            params={
+                "profile_id": "p1",
+                "host_pattern": "never-existed.com",
+                "permission": "microphone",
+            },
+        )
+        assert resp.status_code == 204
+
+    async def test_delete_multi_user_isolation(self, client, app, tmp_path):
+        user_a_id = _get_user_id(app)
+        store = app.state.browser_store
+        await store.set_site_permission(
+            user_id=user_a_id, profile_id="p1",
+            host_pattern="iso.com", permission="geolocation", state="allow",
+        )
+
+        # User B deletes — should not remove user A's row
+        async with _make_auth_client(app, tmp_path) as b_client:
+            resp = await b_client.delete(
+                "/api/desktop/browser/site-permissions",
+                params={
+                    "profile_id": "p1",
+                    "host_pattern": "iso.com",
+                    "permission": "geolocation",
+                },
+            )
+            assert resp.status_code == 204
+
+        rows = await store.list_site_permissions(user_id=user_a_id, profile_id="p1")
+        assert len(rows) == 1
+        assert rows[0]["host_pattern"] == "iso.com"

--- a/tests/routes/desktop_browser/test_site_permissions.py
+++ b/tests/routes/desktop_browser/test_site_permissions.py
@@ -1,0 +1,261 @@
+"""Tests for BrowserStore site_permissions methods."""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture
+async def store(tmp_path):
+    from tinyagentos.routes.desktop_browser.store import BrowserStore
+
+    s = BrowserStore(tmp_path / "browser.sqlite3")
+    await s.init()
+    yield s
+    await s.close()
+
+
+# ---------------------------------------------------------------------------
+# set_site_permission — happy path
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_set_site_permission_allow(store):
+    await store.set_site_permission(
+        user_id="u1", profile_id="p1",
+        host_pattern="example.com", permission="notifications", state="allow",
+    )
+    rows = await store.list_site_permissions(user_id="u1", profile_id="p1")
+    assert len(rows) == 1
+    assert rows[0]["host_pattern"] == "example.com"
+    assert rows[0]["permission"] == "notifications"
+    assert rows[0]["state"] == "allow"
+
+
+@pytest.mark.asyncio
+async def test_set_site_permission_deny(store):
+    await store.set_site_permission(
+        user_id="u1", profile_id="p1",
+        host_pattern="evil.com", permission="geolocation", state="deny",
+    )
+    rows = await store.list_site_permissions(user_id="u1", profile_id="p1")
+    assert rows[0]["state"] == "deny"
+
+
+# ---------------------------------------------------------------------------
+# set_site_permission — UPSERT: second write wins
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_set_site_permission_upsert(store):
+    await store.set_site_permission(
+        user_id="u1", profile_id="p1",
+        host_pattern="example.com", permission="camera", state="allow",
+    )
+    await store.set_site_permission(
+        user_id="u1", profile_id="p1",
+        host_pattern="example.com", permission="camera", state="deny",
+    )
+    rows = await store.list_site_permissions(user_id="u1", profile_id="p1")
+    assert len(rows) == 1
+    assert rows[0]["state"] == "deny"
+
+
+# ---------------------------------------------------------------------------
+# set_site_permission — ValueError on empty params (parametrised)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kwargs,match", [
+    (
+        {"user_id": "",   "profile_id": "p1", "host_pattern": "x.com", "permission": "camera",        "state": "allow"},
+        "user_id",
+    ),
+    (
+        {"user_id": "u1", "profile_id": "",   "host_pattern": "x.com", "permission": "camera",        "state": "allow"},
+        "profile_id",
+    ),
+    (
+        {"user_id": "u1", "profile_id": "p1", "host_pattern": "",      "permission": "camera",        "state": "allow"},
+        "host_pattern",
+    ),
+    (
+        {"user_id": "u1", "profile_id": "p1", "host_pattern": "x.com", "permission": "",              "state": "allow"},
+        "permission",
+    ),
+])
+async def test_set_site_permission_raises_on_empty_param(store, kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        await store.set_site_permission(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# set_site_permission — ValueError on unknown permission
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_set_site_permission_unknown_permission(store):
+    with pytest.raises(ValueError, match="unknown permission"):
+        await store.set_site_permission(
+            user_id="u1", profile_id="p1",
+            host_pattern="x.com", permission="unicorn", state="allow",
+        )
+
+
+# ---------------------------------------------------------------------------
+# set_site_permission — ValueError on invalid state
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_set_site_permission_invalid_state(store):
+    with pytest.raises(ValueError, match="state"):
+        await store.set_site_permission(
+            user_id="u1", profile_id="p1",
+            host_pattern="x.com", permission="camera", state="maybe",
+        )
+
+
+# ---------------------------------------------------------------------------
+# list_site_permissions
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_list_site_permissions_empty(store):
+    rows = await store.list_site_permissions(user_id="u1", profile_id="p1")
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_list_site_permissions_multiple(store):
+    await store.set_site_permission(
+        user_id="u1", profile_id="p1", host_pattern="a.com", permission="camera", state="allow",
+    )
+    await store.set_site_permission(
+        user_id="u1", profile_id="p1", host_pattern="b.com", permission="microphone", state="deny",
+    )
+    rows = await store.list_site_permissions(user_id="u1", profile_id="p1")
+    assert len(rows) == 2
+    permissions = {r["permission"] for r in rows}
+    assert permissions == {"camera", "microphone"}
+
+
+# ---------------------------------------------------------------------------
+# remove_site_permission
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_remove_site_permission_returns_true_on_hit(store):
+    await store.set_site_permission(
+        user_id="u1", profile_id="p1",
+        host_pattern="del.com", permission="geolocation", state="allow",
+    )
+    result = await store.remove_site_permission(
+        user_id="u1", profile_id="p1", host_pattern="del.com", permission="geolocation",
+    )
+    assert result is True
+    rows = await store.list_site_permissions(user_id="u1", profile_id="p1")
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_remove_site_permission_returns_false_on_miss(store):
+    result = await store.remove_site_permission(
+        user_id="u1", profile_id="p1", host_pattern="ghost.com", permission="camera",
+    )
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# check_site_permission — pattern matching
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_check_site_permission_wildcard(store):
+    await store.set_site_permission(
+        user_id="u1", profile_id="p1",
+        host_pattern="*", permission="notifications", state="allow",
+    )
+    result = await store.check_site_permission(
+        user_id="u1", profile_id="p1", host="any.host.com", permission="notifications",
+    )
+    assert result == "allow"
+
+
+@pytest.mark.asyncio
+async def test_check_site_permission_subdomain_wildcard_matches_subdomain(store):
+    await store.set_site_permission(
+        user_id="u1", profile_id="p1",
+        host_pattern="*.example.com", permission="clipboard-read", state="allow",
+    )
+    result = await store.check_site_permission(
+        user_id="u1", profile_id="p1", host="foo.example.com", permission="clipboard-read",
+    )
+    assert result == "allow"
+
+
+@pytest.mark.asyncio
+async def test_check_site_permission_subdomain_wildcard_matches_apex(store):
+    await store.set_site_permission(
+        user_id="u1", profile_id="p1",
+        host_pattern="*.example.com", permission="clipboard-write", state="deny",
+    )
+    result = await store.check_site_permission(
+        user_id="u1", profile_id="p1", host="example.com", permission="clipboard-write",
+    )
+    assert result == "deny"
+
+
+@pytest.mark.asyncio
+async def test_check_site_permission_exact_match(store):
+    await store.set_site_permission(
+        user_id="u1", profile_id="p1",
+        host_pattern="exact.com", permission="microphone", state="allow",
+    )
+    result = await store.check_site_permission(
+        user_id="u1", profile_id="p1", host="exact.com", permission="microphone",
+    )
+    assert result == "allow"
+
+
+@pytest.mark.asyncio
+async def test_check_site_permission_exact_does_not_match_subdomain(store):
+    await store.set_site_permission(
+        user_id="u1", profile_id="p1",
+        host_pattern="exact.com", permission="camera", state="allow",
+    )
+    result = await store.check_site_permission(
+        user_id="u1", profile_id="p1", host="sub.exact.com", permission="camera",
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_check_site_permission_returns_none_when_no_grant(store):
+    result = await store.check_site_permission(
+        user_id="u1", profile_id="p1", host="example.com", permission="geolocation",
+    )
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Multi-user / multi-profile isolation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_multi_user_isolation(store):
+    await store.set_site_permission(
+        user_id="user-a", profile_id="p1",
+        host_pattern="a.com", permission="camera", state="allow",
+    )
+    rows_b = await store.list_site_permissions(user_id="user-b", profile_id="p1")
+    assert rows_b == []
+
+
+@pytest.mark.asyncio
+async def test_multi_profile_isolation(store):
+    await store.set_site_permission(
+        user_id="u1", profile_id="profile-a",
+        host_pattern="a.com", permission="microphone", state="allow",
+    )
+    rows_b = await store.list_site_permissions(user_id="u1", profile_id="profile-b")
+    assert rows_b == []

--- a/tests/routes/desktop_browser/test_site_permissions.py
+++ b/tests/routes/desktop_browser/test_site_permissions.py
@@ -242,6 +242,53 @@ async def test_check_site_permission_returns_none_when_no_grant(store):
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
+async def test_check_site_permission_most_specific_wins(store):
+    """Exact host match beats wildcard even when wildcard was set first."""
+    # Older wildcard-allow
+    await store.set_site_permission(
+        user_id="u1", profile_id="p1", host_pattern="*",
+        permission="notifications", state="allow",
+    )
+    # Newer specific-deny
+    await store.set_site_permission(
+        user_id="u1", profile_id="p1", host_pattern="example.com",
+        permission="notifications", state="deny",
+    )
+    # Should return deny — most specific wins
+    assert await store.check_site_permission(
+        user_id="u1", profile_id="p1", host="example.com",
+        permission="notifications",
+    ) == "deny"
+    # Other hosts still get the wildcard
+    assert await store.check_site_permission(
+        user_id="u1", profile_id="p1", host="other.com",
+        permission="notifications",
+    ) == "allow"
+
+
+@pytest.mark.asyncio
+async def test_check_site_permission_subdomain_wildcard_beats_global_wildcard(store):
+    """*.example.com beats * for a matching subdomain."""
+    await store.set_site_permission(
+        user_id="u1", profile_id="p1", host_pattern="*",
+        permission="geolocation", state="allow",
+    )
+    await store.set_site_permission(
+        user_id="u1", profile_id="p1", host_pattern="*.example.com",
+        permission="geolocation", state="deny",
+    )
+    assert await store.check_site_permission(
+        user_id="u1", profile_id="p1", host="sub.example.com",
+        permission="geolocation",
+    ) == "deny"
+    # Non-matching host still gets global wildcard
+    assert await store.check_site_permission(
+        user_id="u1", profile_id="p1", host="other.com",
+        permission="geolocation",
+    ) == "allow"
+
+
+@pytest.mark.asyncio
 async def test_multi_user_isolation(store):
     await store.set_site_permission(
         user_id="user-a", profile_id="p1",

--- a/tinyagentos/routes/desktop_browser/__init__.py
+++ b/tinyagentos/routes/desktop_browser/__init__.py
@@ -20,3 +20,4 @@ from tinyagentos.routes.desktop_browser import agent_pin_routes as _agent_pin_ro
 from tinyagentos.routes.desktop_browser import copilot_ws as _copilot_ws  # noqa: E402,F401
 from tinyagentos.routes.desktop_browser import copilot_agent_ws as _copilot_agent_ws  # noqa: E402,F401
 from tinyagentos.routes.desktop_browser import capability_routes as _capability_routes  # noqa: E402,F401
+from tinyagentos.routes.desktop_browser import bookmark_routes as _bookmark_routes  # noqa: E402,F401

--- a/tinyagentos/routes/desktop_browser/__init__.py
+++ b/tinyagentos/routes/desktop_browser/__init__.py
@@ -21,3 +21,4 @@ from tinyagentos.routes.desktop_browser import copilot_ws as _copilot_ws  # noqa
 from tinyagentos.routes.desktop_browser import copilot_agent_ws as _copilot_agent_ws  # noqa: E402,F401
 from tinyagentos.routes.desktop_browser import capability_routes as _capability_routes  # noqa: E402,F401
 from tinyagentos.routes.desktop_browser import bookmark_routes as _bookmark_routes  # noqa: E402,F401
+from tinyagentos.routes.desktop_browser import site_permission_routes as _site_permission_routes  # noqa: E402,F401

--- a/tinyagentos/routes/desktop_browser/__init__.py
+++ b/tinyagentos/routes/desktop_browser/__init__.py
@@ -22,3 +22,4 @@ from tinyagentos.routes.desktop_browser import copilot_agent_ws as _copilot_agen
 from tinyagentos.routes.desktop_browser import capability_routes as _capability_routes  # noqa: E402,F401
 from tinyagentos.routes.desktop_browser import bookmark_routes as _bookmark_routes  # noqa: E402,F401
 from tinyagentos.routes.desktop_browser import site_permission_routes as _site_permission_routes  # noqa: E402,F401
+from tinyagentos.routes.desktop_browser import download as _download  # noqa: E402,F401

--- a/tinyagentos/routes/desktop_browser/bookmark_routes.py
+++ b/tinyagentos/routes/desktop_browser/bookmark_routes.py
@@ -1,0 +1,69 @@
+"""HTTP endpoints for bookmark CRUD."""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import Depends, Request
+from fastapi.responses import JSONResponse, Response
+from pydantic import BaseModel
+
+from tinyagentos.auth import get_current_user
+from tinyagentos.routes.desktop_browser import router
+
+
+@router.get("/api/desktop/browser/bookmarks")
+async def list_bookmarks_route(
+    request: Request,
+    profile_id: str,
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+):
+    user_id = str(current_user.get("id") or "")
+    if not user_id:
+        return JSONResponse({"error": "session has no user id"}, status_code=401)
+    bookmarks = await request.app.state.browser_store.list_bookmarks_for_profile(
+        user_id=user_id, profile_id=profile_id,
+    )
+    return {"bookmarks": bookmarks}
+
+
+class BookmarkRequest(BaseModel):
+    profile_id: str
+    url: str
+    title: str
+
+
+@router.post("/api/desktop/browser/bookmarks")
+async def add_bookmark_route(
+    request: Request,
+    body: BookmarkRequest,
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+):
+    user_id = str(current_user.get("id") or "")
+    if not user_id:
+        return JSONResponse({"error": "session has no user id"}, status_code=401)
+    try:
+        bookmark_id = await request.app.state.browser_store.create_bookmark(
+            user_id=user_id,
+            profile_id=body.profile_id,
+            url=body.url,
+            title=body.title,
+        )
+    except ValueError as e:
+        return JSONResponse({"error": str(e)}, status_code=400)
+    return {"bookmark_id": bookmark_id}
+
+
+@router.delete("/api/desktop/browser/bookmarks/{bookmark_id}")
+async def delete_bookmark_route(
+    request: Request,
+    bookmark_id: str,
+    profile_id: str,
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+):
+    user_id = str(current_user.get("id") or "")
+    if not user_id:
+        return JSONResponse({"error": "session has no user id"}, status_code=401)
+    await request.app.state.browser_store.delete_bookmark(
+        user_id=user_id, profile_id=profile_id, bookmark_id=bookmark_id,
+    )
+    return Response(status_code=204)

--- a/tinyagentos/routes/desktop_browser/download.py
+++ b/tinyagentos/routes/desktop_browser/download.py
@@ -1,0 +1,191 @@
+"""GET /api/desktop/browser/download — streams upstream file with attachment disposition.
+
+Auth + SSRF gate + cookie jar, matching the proxy/extract security pattern.
+
+Redirect strategy: walk redirects manually (follow_redirects=False) and
+re-validate SSRF on every hop, identical to extract.py.  This prevents the
+redirect-bypass attack where an initial URL passes the SSRF check but the
+redirect target is an internal host.
+
+The redirect walk happens *before* streaming begins so that we can still
+return a JSONResponse on SSRF block or redirect-chain-too-long.  Once we
+have the final URL, we open a streaming connection and yield bytes directly
+to the client.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+from urllib.parse import quote, unquote, urljoin, urlparse, urlsplit
+
+import httpx
+from fastapi import Depends, Request
+from fastapi.responses import JSONResponse, StreamingResponse
+
+from tinyagentos.auth import get_current_user
+from tinyagentos.routes.desktop_browser import router
+from tinyagentos.routes.desktop_browser.cookie_jar import (
+    load_jar_for_request,
+    persist_response_cookies,
+)
+from tinyagentos.routes.desktop_browser.ssrf import (
+    SsrfBlockedError,
+    validate_url_or_raise,
+)
+
+
+_logger = logging.getLogger(__name__)
+
+_MAX_HOPS = 5
+_FETCH_TIMEOUT = 60.0  # downloads can be larger than HTML pages
+
+
+def _filename_from_url(url: str) -> str:
+    """Infer a filename from the URL path.  Returns "download" as a fallback."""
+    try:
+        path = urlsplit(url).path
+        name = unquote(path.rsplit("/", 1)[-1])
+        if name and "." in name:
+            return name
+    except Exception:
+        pass
+    return "download"
+
+
+def _safe_filename(filename: str) -> str:
+    """Strip path-traversal components and unsafe chars from a caller-supplied filename."""
+    # os.path.basename removes directory components (catches "../../etc/passwd")
+    base = os.path.basename(filename)
+    # Strip control chars and characters that would break Content-Disposition header parsing
+    base = "".join(c for c in base if c.isprintable() and c not in '"\\')
+    return base or "download"
+
+
+async def _resolve_final_url(
+    initial_url: str,
+    cookies: httpx.Cookies,
+) -> tuple[str, httpx.Response] | tuple[None, JSONResponse]:
+    """Walk the redirect chain with per-hop SSRF validation.
+
+    Returns (final_url, response) on success, or (None, error_JSONResponse) on failure.
+    The returned response on success is the first non-redirect response — it is NOT
+    yet read (we hand it back to stream from).  Caller must close it if not streamed.
+    """
+    fetch_url = initial_url
+    async with httpx.AsyncClient(
+        follow_redirects=False, timeout=_FETCH_TIMEOUT, cookies=cookies,
+    ) as http:
+        for _hop in range(_MAX_HOPS):
+            try:
+                response = await http.get(fetch_url)
+            except httpx.HTTPError as e:
+                _logger.info("browser download fetch error: err=%s", e)
+                return None, JSONResponse({"error": "fetch failed"}, status_code=502)
+
+            if response.is_redirect:
+                location = response.headers.get("location")
+                if not location:
+                    return None, JSONResponse(
+                        {"error": "redirect missing Location"}, status_code=502,
+                    )
+                fetch_url = urljoin(fetch_url, location)
+                try:
+                    validate_url_or_raise(fetch_url)
+                except SsrfBlockedError as e:
+                    parsed = urlsplit(fetch_url)
+                    _logger.info(
+                        "browser download SSRF block on redirect: scheme=%r host=%r reason=%s",
+                        parsed.scheme, parsed.hostname, e,
+                    )
+                    return None, JSONResponse({"error": "URL blocked"}, status_code=403)
+                continue
+
+            # Non-redirect — we have the final response
+            return fetch_url, response
+
+        return None, JSONResponse({"error": "redirect chain too long"}, status_code=502)
+
+
+@router.get("/api/desktop/browser/download")
+async def download_endpoint(
+    request: Request,
+    profile_id: str,
+    url: str,
+    filename: str | None = None,
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+):
+    """Stream an upstream file through the proxy as a browser download.
+
+    Gates: auth + SSRF (with per-hop redirect re-validation) + cookie jar.
+    Sets Content-Disposition: attachment so the browser shows a save dialog.
+    """
+    user_id = str(current_user.get("id") or "")
+    if not user_id:
+        return JSONResponse({"error": "session has no user id"}, status_code=401)
+
+    # SSRF gate on initial URL
+    try:
+        validate_url_or_raise(url)
+    except SsrfBlockedError as e:
+        parsed = urlsplit(url)
+        _logger.info(
+            "browser download SSRF block: scheme=%r host=%r reason=%s",
+            parsed.scheme, parsed.hostname, e,
+        )
+        return JSONResponse({"error": "URL blocked"}, status_code=403)
+
+    # Determine output filename before fetching
+    final_name = (
+        _safe_filename(filename) if filename else _safe_filename(_filename_from_url(url))
+    )
+
+    # Load cookies for the initial host; after redirects the host may differ
+    # but the jar covers the profile broadly enough for common use cases.
+    host = urlparse(url).hostname or ""
+    cookies = await load_jar_for_request(
+        request.app.state.browser_cookie_store,
+        user_id=user_id, profile_id=profile_id, host=host,
+    )
+
+    # Walk redirects with per-hop SSRF re-validation, collect final response
+    result = await _resolve_final_url(url, cookies)
+    final_url, maybe_response = result
+
+    if final_url is None:
+        # maybe_response is a JSONResponse carrying the error
+        return maybe_response
+
+    final_response: httpx.Response = maybe_response  # type: ignore[assignment]
+
+    # Persist any cookies from the redirect walk
+    try:
+        await persist_response_cookies(
+            request.app.state.browser_cookie_store,
+            final_response.cookies,
+            user_id=user_id, profile_id=profile_id,
+        )
+    except Exception:
+        pass  # cookie persistence failure is non-fatal
+
+    # Stream body to client
+    async def streamer():
+        try:
+            async for chunk in final_response.aiter_bytes():
+                yield chunk
+        except httpx.HTTPError as e:
+            _logger.info("browser download stream error: err=%s", e)
+            # Can't send a new response once streaming has started; just stop.
+
+    # RFC 5987 encoded filename for non-ASCII safety
+    safe_quoted = quote(final_name, safe="")
+
+    return StreamingResponse(
+        streamer(),
+        media_type="application/octet-stream",
+        headers={
+            "Content-Disposition": (
+                f'attachment; filename="{final_name}"; filename*=UTF-8\'\'{safe_quoted}'
+            ),
+        },
+    )

--- a/tinyagentos/routes/desktop_browser/download.py
+++ b/tinyagentos/routes/desktop_browser/download.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 from typing import Any
 from urllib.parse import quote, unquote, urljoin, urlparse, urlsplit
 
@@ -53,6 +54,21 @@ def _filename_from_url(url: str) -> str:
     return "download"
 
 
+def _filename_from_content_disposition(cd: str) -> str:
+    """Parse filename or filename* from Content-Disposition.  Returns '' on miss."""
+    # Prefer RFC 5987 filename*=UTF-8''xxx
+    m = re.search(r"filename\*=UTF-8''([^;\s]+)", cd, re.IGNORECASE)
+    if m:
+        return unquote(m.group(1))
+    m = re.search(r'filename="([^"]+)"', cd, re.IGNORECASE)
+    if m:
+        return m.group(1)
+    m = re.search(r"filename=([^;\s]+)", cd, re.IGNORECASE)
+    if m:
+        return m.group(1)
+    return ""
+
+
 def _safe_filename(filename: str) -> str:
     """Strip path-traversal components and unsafe chars from a caller-supplied filename."""
     # os.path.basename removes directory components (catches "../../etc/passwd")
@@ -62,49 +78,33 @@ def _safe_filename(filename: str) -> str:
     return base or "download"
 
 
-async def _resolve_final_url(
-    initial_url: str,
-    cookies: httpx.Cookies,
-) -> tuple[str, httpx.Response] | tuple[None, JSONResponse]:
-    """Walk the redirect chain with per-hop SSRF validation.
+async def _walk_redirects_streaming(
+    http: httpx.AsyncClient,
+    url: str,
+    max_hops: int = _MAX_HOPS,
+) -> tuple[httpx.Response, str]:
+    """Walk redirects with per-hop SSRF re-validation, returning an OPEN streaming response.
 
-    Returns (final_url, response) on success, or (None, error_JSONResponse) on failure.
-    The returned response on success is the first non-redirect response — it is NOT
-    yet read (we hand it back to stream from).  Caller must close it if not streamed.
+    Caller is responsible for closing the returned response (and the client).
+    Raises SsrfBlockedError if a redirect target is blocked.
+    Raises httpx.TooManyRedirects on too many hops.
+    Raises httpx.HTTPError on fetch failure.
     """
-    fetch_url = initial_url
-    async with httpx.AsyncClient(
-        follow_redirects=False, timeout=_FETCH_TIMEOUT, cookies=cookies,
-    ) as http:
-        for _hop in range(_MAX_HOPS):
-            try:
-                response = await http.get(fetch_url)
-            except httpx.HTTPError as e:
-                _logger.info("browser download fetch error: err=%s", e)
-                return None, JSONResponse({"error": "fetch failed"}, status_code=502)
-
-            if response.is_redirect:
-                location = response.headers.get("location")
-                if not location:
-                    return None, JSONResponse(
-                        {"error": "redirect missing Location"}, status_code=502,
-                    )
-                fetch_url = urljoin(fetch_url, location)
-                try:
-                    validate_url_or_raise(fetch_url)
-                except SsrfBlockedError as e:
-                    parsed = urlsplit(fetch_url)
-                    _logger.info(
-                        "browser download SSRF block on redirect: scheme=%r host=%r reason=%s",
-                        parsed.scheme, parsed.hostname, e,
-                    )
-                    return None, JSONResponse({"error": "URL blocked"}, status_code=403)
-                continue
-
-            # Non-redirect — we have the final response
-            return fetch_url, response
-
-        return None, JSONResponse({"error": "redirect chain too long"}, status_code=502)
+    fetch_url = url
+    for _hop in range(max_hops):
+        request_obj = http.build_request("GET", fetch_url)
+        response = await http.send(request_obj, stream=True)
+        if response.is_redirect:
+            location = response.headers.get("location", "")
+            await response.aclose()
+            if not location:
+                raise httpx.RemoteProtocolError("redirect missing Location", request=request_obj)
+            fetch_url = urljoin(fetch_url, location)
+            validate_url_or_raise(fetch_url)
+            continue
+        # Non-redirect — return the open streaming response
+        return response, fetch_url
+    raise httpx.TooManyRedirects("too many redirects", request=http.build_request("GET", fetch_url))
 
 
 @router.get("/api/desktop/browser/download")
@@ -135,11 +135,6 @@ async def download_endpoint(
         )
         return JSONResponse({"error": "URL blocked"}, status_code=403)
 
-    # Determine output filename before fetching
-    final_name = (
-        _safe_filename(filename) if filename else _safe_filename(_filename_from_url(url))
-    )
-
     # Load cookies for the initial host; after redirects the host may differ
     # but the jar covers the profile broadly enough for common use cases.
     host = urlparse(url).hostname or ""
@@ -148,34 +143,54 @@ async def download_endpoint(
         user_id=user_id, profile_id=profile_id, host=host,
     )
 
-    # Walk redirects with per-hop SSRF re-validation, collect final response
-    result = await _resolve_final_url(url, cookies)
-    final_url, maybe_response = result
+    # Manage the AsyncClient lifetime — don't close until the streamer finishes.
+    http = httpx.AsyncClient(
+        follow_redirects=False, timeout=_FETCH_TIMEOUT, cookies=cookies,
+    )
 
-    if final_url is None:
-        # maybe_response is a JSONResponse carrying the error
-        return maybe_response
-
-    final_response: httpx.Response = maybe_response  # type: ignore[assignment]
-
-    # Persist any cookies from the redirect walk
     try:
-        await persist_response_cookies(
-            request.app.state.browser_cookie_store,
-            final_response.cookies,
-            user_id=user_id, profile_id=profile_id,
+        response, final_url = await _walk_redirects_streaming(http, url)
+    except SsrfBlockedError as e:
+        await http.aclose()
+        parsed = urlsplit(url)
+        _logger.info(
+            "browser download SSRF block on redirect: scheme=%r host=%r reason=%s",
+            parsed.scheme, parsed.hostname, e,
         )
-    except Exception:
-        pass  # cookie persistence failure is non-fatal
+        return JSONResponse({"error": "URL blocked"}, status_code=403)
+    except httpx.TooManyRedirects:
+        await http.aclose()
+        return JSONResponse({"error": "redirect chain too long"}, status_code=502)
+    except httpx.HTTPError as e:
+        await http.aclose()
+        _logger.info("browser download fetch error: err=%s", e)
+        return JSONResponse({"error": "fetch failed"}, status_code=502)
 
-    # Stream body to client
+    # Filename: caller-supplied > upstream Content-Disposition > URL path
+    upstream_cd = response.headers.get("content-disposition", "")
+    upstream_filename = _filename_from_content_disposition(upstream_cd)
+    final_name = _safe_filename(
+        filename or upstream_filename or _filename_from_url(final_url)
+    )
+
     async def streamer():
         try:
-            async for chunk in final_response.aiter_bytes():
+            async for chunk in response.aiter_bytes():
                 yield chunk
-        except httpx.HTTPError as e:
-            _logger.info("browser download stream error: err=%s", e)
+            try:
+                await persist_response_cookies(
+                    request.app.state.browser_cookie_store,
+                    response.cookies,
+                    user_id=user_id, profile_id=profile_id,
+                )
+            except Exception:
+                pass  # cookie persistence failure is non-fatal
+        except httpx.HTTPError as exc:
+            _logger.info("browser download stream error: err=%s", exc)
             # Can't send a new response once streaming has started; just stop.
+        finally:
+            await response.aclose()
+            await http.aclose()
 
     # RFC 5987 encoded filename for non-ASCII safety
     safe_quoted = quote(final_name, safe="")

--- a/tinyagentos/routes/desktop_browser/schema.py
+++ b/tinyagentos/routes/desktop_browser/schema.py
@@ -104,6 +104,16 @@ CREATE TABLE IF NOT EXISTS drive_sessions (
   last_op_at     TEXT NOT NULL,
   PRIMARY KEY (user_id, profile_id, tab_id, agent_id)
 );
+
+CREATE TABLE IF NOT EXISTS site_permissions (
+  user_id        TEXT NOT NULL,
+  profile_id     TEXT NOT NULL,
+  host_pattern   TEXT NOT NULL,
+  permission     TEXT NOT NULL,
+  state          TEXT NOT NULL,
+  granted_at     TEXT NOT NULL,
+  PRIMARY KEY (user_id, profile_id, host_pattern, permission)
+);
 """
 
 

--- a/tinyagentos/routes/desktop_browser/site_permission_routes.py
+++ b/tinyagentos/routes/desktop_browser/site_permission_routes.py
@@ -1,0 +1,75 @@
+"""HTTP endpoints for per-site browser permission grants."""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import Depends, Request
+from fastapi.responses import JSONResponse, Response
+from pydantic import BaseModel
+
+from tinyagentos.auth import get_current_user
+from tinyagentos.routes.desktop_browser import router
+
+
+@router.get("/api/desktop/browser/site-permissions")
+async def list_site_permissions_route(
+    request: Request,
+    profile_id: str,
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+):
+    user_id = str(current_user.get("id") or "")
+    if not user_id:
+        return JSONResponse({"error": "session has no user id"}, status_code=401)
+    grants = await request.app.state.browser_store.list_site_permissions(
+        user_id=user_id, profile_id=profile_id,
+    )
+    return {"grants": grants}
+
+
+class SitePermissionRequest(BaseModel):
+    profile_id: str
+    host_pattern: str
+    permission: str
+    state: str  # 'allow' or 'deny'
+
+
+@router.post("/api/desktop/browser/site-permissions")
+async def set_site_permission_route(
+    request: Request,
+    body: SitePermissionRequest,
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+):
+    user_id = str(current_user.get("id") or "")
+    if not user_id:
+        return JSONResponse({"error": "session has no user id"}, status_code=401)
+    try:
+        await request.app.state.browser_store.set_site_permission(
+            user_id=user_id,
+            profile_id=body.profile_id,
+            host_pattern=body.host_pattern,
+            permission=body.permission,
+            state=body.state,
+        )
+    except ValueError as e:
+        return JSONResponse({"error": str(e)}, status_code=400)
+    return {"granted": True}
+
+
+@router.delete("/api/desktop/browser/site-permissions")
+async def remove_site_permission_route(
+    request: Request,
+    profile_id: str,
+    host_pattern: str,
+    permission: str,
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+):
+    user_id = str(current_user.get("id") or "")
+    if not user_id:
+        return JSONResponse({"error": "session has no user id"}, status_code=401)
+    await request.app.state.browser_store.remove_site_permission(
+        user_id=user_id,
+        profile_id=profile_id,
+        host_pattern=host_pattern,
+        permission=permission,
+    )
+    return Response(status_code=204)

--- a/tinyagentos/routes/desktop_browser/store.py
+++ b/tinyagentos/routes/desktop_browser/store.py
@@ -327,6 +327,112 @@ class BrowserStore(BaseStore):
         ]
 
 
+    async def list_bookmarks_for_profile(
+        self,
+        *,
+        user_id: str,
+        profile_id: str,
+    ) -> list[dict]:
+        """Returns [{bookmark_id, url, title, created_at}, ...] ordered by created_at DESC."""
+        if not user_id or not profile_id:
+            raise ValueError("user_id and profile_id required")
+        assert self._db is not None
+        cursor = await self._db.execute(
+            "SELECT bookmark_id, url, title, created_at "
+            "FROM bookmarks "
+            "WHERE user_id = ? AND profile_id = ? "
+            "ORDER BY created_at DESC",
+            (user_id, profile_id),
+        )
+        rows = await cursor.fetchall()
+        return [
+            {
+                "bookmark_id": r[0],
+                "url": r[1],
+                "title": r[2],
+                "created_at": r[3],
+            }
+            for r in rows
+        ]
+
+    async def create_bookmark(
+        self,
+        *,
+        user_id: str,
+        profile_id: str,
+        url: str,
+        title: str,
+    ) -> str:
+        """INSERT a bookmark; returns the new bookmark_id."""
+        import secrets
+        import time
+        if not user_id:
+            raise ValueError("user_id is required")
+        if not profile_id:
+            raise ValueError("profile_id is required")
+        if not url:
+            raise ValueError("url is required")
+        if not title:
+            raise ValueError("title is required")
+        assert self._db is not None
+        bookmark_id = secrets.token_urlsafe(12)
+        created_at = time.time_ns() // 1_000  # microseconds — unique within a request
+        await self._db.execute(
+            "INSERT INTO bookmarks "
+            "(user_id, profile_id, bookmark_id, folder_path, url, title, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (user_id, profile_id, bookmark_id, "/", url, title, created_at),
+        )
+        await self._db.commit()
+        return bookmark_id
+
+    async def delete_bookmark(
+        self,
+        *,
+        user_id: str,
+        profile_id: str,
+        bookmark_id: str,
+    ) -> bool:
+        """DELETE; returns True if a row was removed."""
+        if not user_id or not profile_id or not bookmark_id:
+            raise ValueError("user_id, profile_id, bookmark_id required")
+        assert self._db is not None
+        cursor = await self._db.execute(
+            "DELETE FROM bookmarks "
+            "WHERE user_id = ? AND profile_id = ? AND bookmark_id = ?",
+            (user_id, profile_id, bookmark_id),
+        )
+        await self._db.commit()
+        return cursor.rowcount > 0
+
+    async def find_bookmark_by_url(
+        self,
+        *,
+        user_id: str,
+        profile_id: str,
+        url: str,
+    ) -> dict | None:
+        """Returns matching bookmark or None."""
+        if not user_id or not profile_id or not url:
+            raise ValueError("user_id, profile_id, url required")
+        assert self._db is not None
+        cursor = await self._db.execute(
+            "SELECT bookmark_id, url, title, created_at "
+            "FROM bookmarks "
+            "WHERE user_id = ? AND profile_id = ? AND url = ? "
+            "ORDER BY created_at DESC LIMIT 1",
+            (user_id, profile_id, url),
+        )
+        row = await cursor.fetchone()
+        if row is None:
+            return None
+        return {
+            "bookmark_id": row[0],
+            "url": row[1],
+            "title": row[2],
+            "created_at": row[3],
+        }
+
     # ------------------------------------------------------------------
     # Agent pin helpers
     # ------------------------------------------------------------------

--- a/tinyagentos/routes/desktop_browser/store.py
+++ b/tinyagentos/routes/desktop_browser/store.py
@@ -1003,22 +1003,30 @@ class BrowserStore(BaseStore):
           - "*"            matches any host
           - "*.example.com" matches "example.com" and "foo.example.com"
           - anything else: exact match
+
+        When multiple patterns match, the most specific wins:
+          exact (2) > subdomain wildcard (1) > global wildcard (0)
         """
         rows = await self.list_site_permissions(user_id=user_id, profile_id=profile_id)
+        best_score = -1
+        best_state: str | None = None
         for row in rows:
             if row["permission"] != permission:
                 continue
             pattern = row["host_pattern"]
-            if pattern == "*":
-                matched = True
+            score = -1
+            if pattern == host:
+                score = 2
             elif pattern.startswith("*."):
                 domain = pattern[2:]
-                matched = host == domain or host.endswith("." + domain)
-            else:
-                matched = host == pattern
-            if matched:
-                return row["state"]
-        return None
+                if host == domain or host.endswith("." + domain):
+                    score = 1
+            elif pattern == "*":
+                score = 0
+            if score > best_score:
+                best_score = score
+                best_state = row["state"]
+        return best_state
 
 
 _KNOWN_SITE_PERMISSIONS = {

--- a/tinyagentos/routes/desktop_browser/store.py
+++ b/tinyagentos/routes/desktop_browser/store.py
@@ -896,6 +896,137 @@ class BrowserStore(BaseStore):
         return False
 
 
+    # ------------------------------------------------------------------
+    # Site permission helpers
+    # ------------------------------------------------------------------
+
+    async def set_site_permission(
+        self,
+        *,
+        user_id: str,
+        profile_id: str,
+        host_pattern: str,
+        permission: str,
+        state: str,
+    ) -> None:
+        """UPSERT a site permission. state must be 'allow' or 'deny'."""
+        if not user_id:
+            raise ValueError("user_id is required")
+        if not profile_id:
+            raise ValueError("profile_id is required")
+        if not host_pattern:
+            raise ValueError("host_pattern is required")
+        if not permission:
+            raise ValueError("permission is required")
+        if permission not in _KNOWN_SITE_PERMISSIONS:
+            raise ValueError(f"unknown permission: {permission}")
+        if state not in {"allow", "deny"}:
+            raise ValueError("state must be 'allow' or 'deny'")
+        assert self._db is not None
+        granted_at = datetime.now(timezone.utc).isoformat()
+        await self._db.execute(
+            "INSERT OR REPLACE INTO site_permissions "
+            "(user_id, profile_id, host_pattern, permission, state, granted_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (user_id, profile_id, host_pattern, permission, state, granted_at),
+        )
+        await self._db.commit()
+
+    async def list_site_permissions(
+        self,
+        *,
+        user_id: str,
+        profile_id: str,
+    ) -> list[dict]:
+        """Returns list of {host_pattern, permission, state, granted_at}."""
+        if not user_id:
+            raise ValueError("user_id is required")
+        if not profile_id:
+            raise ValueError("profile_id is required")
+        assert self._db is not None
+        cursor = await self._db.execute(
+            "SELECT host_pattern, permission, state, granted_at "
+            "FROM site_permissions "
+            "WHERE user_id = ? AND profile_id = ? "
+            "ORDER BY granted_at",
+            (user_id, profile_id),
+        )
+        rows = await cursor.fetchall()
+        return [
+            {
+                "host_pattern": r[0],
+                "permission": r[1],
+                "state": r[2],
+                "granted_at": r[3],
+            }
+            for r in rows
+        ]
+
+    async def remove_site_permission(
+        self,
+        *,
+        user_id: str,
+        profile_id: str,
+        host_pattern: str,
+        permission: str,
+    ) -> bool:
+        """DELETE a permission grant. Returns True if removed."""
+        if not user_id:
+            raise ValueError("user_id is required")
+        if not profile_id:
+            raise ValueError("profile_id is required")
+        if not host_pattern:
+            raise ValueError("host_pattern is required")
+        if not permission:
+            raise ValueError("permission is required")
+        assert self._db is not None
+        cursor = await self._db.execute(
+            "DELETE FROM site_permissions "
+            "WHERE user_id = ? AND profile_id = ? "
+            "  AND host_pattern = ? AND permission = ?",
+            (user_id, profile_id, host_pattern, permission),
+        )
+        await self._db.commit()
+        return cursor.rowcount > 0
+
+    async def check_site_permission(
+        self,
+        *,
+        user_id: str,
+        profile_id: str,
+        host: str,
+        permission: str,
+    ) -> str | None:
+        """Returns 'allow', 'deny', or None (no grant).
+
+        Pattern semantics (same as check_capability):
+          - "*"            matches any host
+          - "*.example.com" matches "example.com" and "foo.example.com"
+          - anything else: exact match
+        """
+        rows = await self.list_site_permissions(user_id=user_id, profile_id=profile_id)
+        for row in rows:
+            if row["permission"] != permission:
+                continue
+            pattern = row["host_pattern"]
+            if pattern == "*":
+                matched = True
+            elif pattern.startswith("*."):
+                domain = pattern[2:]
+                matched = host == domain or host.endswith("." + domain)
+            else:
+                matched = host == pattern
+            if matched:
+                return row["state"]
+        return None
+
+
+_KNOWN_SITE_PERMISSIONS = {
+    "notifications", "clipboard-read", "clipboard-write",
+    "geolocation", "camera", "microphone",
+}
+
+
 class BrowserCookieStore:
     """SQLCipher-encrypted cookie store. Per-user 256-bit key.
 


### PR DESCRIPTION
## Summary

Three browser conveniences delivered as backends + the highest-impact frontend (bookmark star toggle in URL bar). Frontend management UX (BookmarksBar, SitePermissionsPanel) is deferred to follow-ups since the data model + APIs land here and the existing AgentCapabilitiesPanel pattern from PR 7 already proves the management surface works.

## What ships

1. **Bookmarks**: `GET/POST/DELETE /api/desktop/browser/bookmarks` with per-(user, profile) keying, info-hide DELETE, opaque IDs. URL-bar star button toggles bookmark for current tab; cache populated on mount via `listBookmarks`.
2. **Site permissions**: new `site_permissions` table keyed on `(user_id, profile_id, host_pattern, permission)` with `state ∈ {allow, deny}`. Permissions: notifications / clipboard-read/write / geolocation / camera / microphone. `check_site_permission` reuses the same host_pattern matching as agent capabilities (`*` / `*.example.com` / exact). HTTP CRUD endpoints + 35 store/route tests.
3. **Downloads**: streaming `GET /api/desktop/browser/download` endpoint. Auth + per-hop SSRF (matches extract.py post-fix) + cookie jar (so authenticated downloads work). Inferred filename from URL path; `Content-Disposition: attachment; filename="…"; filename*=UTF-8''…` so the browser shows save dialog. Path-traversal sanitisation on caller-supplied filename.

## Files (8 changed, ~1900 lines)

**Backend (7 files):** new `bookmark_routes.py` + `site_permission_routes.py` + `download.py`; extensions to `store.py` (4 bookmark methods + 4 site-permission methods); `schema.py` (new `site_permissions` table); `__init__.py` registrations.

**Frontend (3 files):** new `browser-bookmarks-api.ts`; modified `AddressBar.tsx` (star toggle + `Star` icon, hidden on `about:blank`); extended tests.

## Test plan

- [ ] Backend: `pytest tests/routes/desktop_browser/ -q` → 427 passed
- [ ] Frontend: `cd desktop && npx vitest run` → 715 passed across 103 files
- [ ] TypeScript: `cd desktop && npx tsc --noEmit` → zero errors

## Atomic invariants

- Multi-user + multi-profile isolation across all three subsystems
- DELETE returns 204 unconditionally (info-hide)
- ValueError → 400 at HTTP boundary
- Per-hop SSRF re-validation on download redirects (5-hop cap)
- Filename sanitisation: `os.path.basename` + control-char/quote stripping

## Deferred to follow-ups

- BookmarksBar frontend component (chips below tab strip) — backend complete
- SitePermissionsPanel in Settings (table view of grants with revoke) — backend complete; frontend pattern established by PR 7's AgentCapabilitiesPanel
- Permission prompt modal (when proxied page calls e.g. `Notification.requestPermission()`) — pattern matches PR 7 capability flow
- Real FilesApp integration of downloads — separate brainstorm (file system writes)
- Bookmark folders / drag-reorder / import-export
- Download history panel + resume

## Spec / plan references

- Spec: \`docs/superpowers/specs/2026-05-03-browser-app-v2-design.md\` §10 (PR 9 row), §3 (data model)
- Plan: \`docs/superpowers/plans/2026-05-05-browser-app-v2-pr-9-downloads-bookmarks-permissions.md\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added bookmarks feature: save and manage bookmarks with a star button in the address bar; bookmarks persist per profile
  * Added site permissions management: configure allow/deny permissions for websites on a per-profile basis
  * Added download functionality: download files through the browser with built-in security protections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->