### PR TITLE
feat(browser): PR 10 — Web Push (browser-scope v1)

### DIFF
--- a/desktop/src/apps/BrowserApp/AgentPanel.notifications.test.tsx
+++ b/desktop/src/apps/BrowserApp/AgentPanel.notifications.test.tsx
@@ -170,6 +170,30 @@ describe("AgentPanel — Notifications section", () => {
     expect((checkboxes[0] as HTMLInputElement).checked).toBe(true);
   });
 
+  it("reverts optimistic update when setPushMute fails", async () => {
+    vi.spyOn(pushApi, "listPushMutes").mockResolvedValue([]);
+    vi.spyOn(pushApi, "setPushMute").mockRejectedValue(new Error("500"));
+    openPanel();
+    render(
+      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} profileId="personal" pinnedAgentIds={PINNED} />,
+    );
+    await waitFor(() => expect(screen.queryByText("Loading…")).toBeNull());
+
+    const chatToggle = screen.getByLabelText("Chat messages notifications for Alice");
+    // Starts checked (not muted)
+    expect((chatToggle as HTMLInputElement).checked).toBe(true);
+
+    await act(async () => {
+      fireEvent.click(chatToggle);
+    });
+
+    // The optimistic update flipped it to unchecked, but the API rejected,
+    // so the revert path should restore it to checked.
+    await waitFor(() =>
+      expect((screen.getByLabelText("Chat messages notifications for Alice") as HTMLInputElement).checked).toBe(true),
+    );
+  });
+
   it("renders single pinned agent without agent name header", async () => {
     vi.spyOn(pushApi, "listPushMutes").mockResolvedValue([]);
     openPanel();

--- a/desktop/src/apps/BrowserApp/AgentPanel.notifications.test.tsx
+++ b/desktop/src/apps/BrowserApp/AgentPanel.notifications.test.tsx
@@ -1,0 +1,190 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { AgentPanel } from "./AgentPanel";
+import { useBrowserAgentStore } from "@/stores/browser-agent-store";
+import * as browserAgentApi from "@/lib/browser-agent-api";
+import * as pushApi from "@/lib/browser-push-api";
+
+const WINDOW_ID = "win-notif";
+const TAB_ID = "tab-notif";
+const AGENTS = [
+  { id: "agent-1", name: "Alice", emoji: "🤖", framework: "openclaw" },
+  { id: "agent-2", name: "Bob", emoji: "🧪", framework: "smolagents" },
+];
+const PINNED = ["agent-1", "agent-2"];
+
+function openPanel(agentId = "agent-1") {
+  useBrowserAgentStore.getState().openPanel(WINDOW_ID, TAB_ID, agentId);
+}
+
+beforeEach(() => {
+  useBrowserAgentStore.setState({
+    panels: {},
+    lastEventAt: {},
+    messages: {},
+    recentEvents: {},
+  });
+  vi.spyOn(browserAgentApi, "listAgents").mockResolvedValue(AGENTS);
+  vi.spyOn(pushApi, "listPushMutes").mockResolvedValue([]);
+  vi.spyOn(pushApi, "setPushMute").mockResolvedValue({ ok: true });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("AgentPanel — Notifications section", () => {
+  it("renders three toggles per pinned agent", async () => {
+    openPanel();
+    render(
+      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} profileId="personal" pinnedAgentIds={PINNED} />,
+    );
+
+    // Wait for mutes to load (loading indicator disappears)
+    await waitFor(() => expect(screen.queryByText("Loading…")).toBeNull());
+
+    // 3 toggles per agent × 2 agents = 6 checkboxes
+    const checkboxes = screen.getAllByRole("checkbox");
+    expect(checkboxes).toHaveLength(6);
+  });
+
+  it("all toggles are checked (not muted) when listPushMutes returns empty", async () => {
+    vi.spyOn(pushApi, "listPushMutes").mockResolvedValue([]);
+    openPanel();
+    render(
+      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} profileId="personal" pinnedAgentIds={PINNED} />,
+    );
+    await waitFor(() => expect(screen.queryByText("Loading…")).toBeNull());
+
+    const checkboxes = screen.getAllByRole("checkbox") as HTMLInputElement[];
+    expect(checkboxes.every((cb) => cb.checked)).toBe(true);
+  });
+
+  it("initial state reflects listPushMutes response — muted kind is unchecked", async () => {
+    vi.spyOn(pushApi, "listPushMutes").mockResolvedValue([
+      { agent_id: "agent-1", kind: "chat", muted_at: 1000 },
+    ]);
+    openPanel();
+    render(
+      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} profileId="personal" pinnedAgentIds={PINNED} />,
+    );
+    await waitFor(() => expect(screen.queryByText("Loading…")).toBeNull());
+
+    // The "Chat messages" toggle for agent-1 should be UNCHECKED (muted)
+    const chatToggleForAgent1 = screen.getByLabelText("Chat messages notifications for Alice");
+    expect((chatToggleForAgent1 as HTMLInputElement).checked).toBe(false);
+
+    // The "Started driving" toggle for agent-1 should be CHECKED (not muted)
+    const driveToggle = screen.getByLabelText("Started driving notifications for Alice");
+    expect((driveToggle as HTMLInputElement).checked).toBe(true);
+  });
+
+  it("toggling a checked toggle fires setPushMute with muted: true", async () => {
+    vi.spyOn(pushApi, "listPushMutes").mockResolvedValue([]);
+    openPanel();
+    render(
+      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} profileId="personal" pinnedAgentIds={PINNED} />,
+    );
+    await waitFor(() => expect(screen.queryByText("Loading…")).toBeNull());
+
+    const chatToggle = screen.getByLabelText("Chat messages notifications for Alice");
+    expect((chatToggle as HTMLInputElement).checked).toBe(true);
+
+    await act(async () => {
+      fireEvent.click(chatToggle);
+    });
+
+    expect(pushApi.setPushMute).toHaveBeenCalledWith({
+      agent_id: "agent-1",
+      kind: "chat",
+      muted: true,
+    });
+  });
+
+  it("toggling an unchecked toggle fires setPushMute with muted: false", async () => {
+    vi.spyOn(pushApi, "listPushMutes").mockResolvedValue([
+      { agent_id: "agent-1", kind: "chat", muted_at: 1000 },
+    ]);
+    openPanel();
+    render(
+      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} profileId="personal" pinnedAgentIds={PINNED} />,
+    );
+    await waitFor(() => expect(screen.queryByText("Loading…")).toBeNull());
+
+    const chatToggle = screen.getByLabelText("Chat messages notifications for Alice");
+    expect((chatToggle as HTMLInputElement).checked).toBe(false);
+
+    await act(async () => {
+      fireEvent.click(chatToggle);
+    });
+
+    expect(pushApi.setPushMute).toHaveBeenCalledWith({
+      agent_id: "agent-1",
+      kind: "chat",
+      muted: false,
+    });
+  });
+
+  it("after toggling, UI reflects new state (optimistic update)", async () => {
+    vi.spyOn(pushApi, "listPushMutes").mockResolvedValue([]);
+    openPanel();
+    render(
+      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} profileId="personal" pinnedAgentIds={PINNED} />,
+    );
+    await waitFor(() => expect(screen.queryByText("Loading…")).toBeNull());
+
+    const chatToggle = screen.getByLabelText("Chat messages notifications for Alice");
+    expect((chatToggle as HTMLInputElement).checked).toBe(true);
+
+    await act(async () => {
+      fireEvent.click(chatToggle);
+    });
+
+    // After clicking (muting), the toggle should be unchecked
+    await waitFor(() =>
+      expect((screen.getByLabelText("Chat messages notifications for Alice") as HTMLInputElement).checked).toBe(false),
+    );
+  });
+
+  it("shows loading indicator while mutes are being fetched", () => {
+    // Return a promise that never resolves to keep loading state
+    vi.spyOn(pushApi, "listPushMutes").mockReturnValue(new Promise(() => {}));
+    openPanel();
+    render(
+      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} profileId="personal" pinnedAgentIds={PINNED} />,
+    );
+    expect(screen.getByText("Loading…")).toBeInTheDocument();
+  });
+
+  it("renders toggles even when listPushMutes fails (default unchecked state)", async () => {
+    vi.spyOn(pushApi, "listPushMutes").mockRejectedValue(new Error("network error"));
+    openPanel();
+    render(
+      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} profileId="personal" pinnedAgentIds={PINNED} />,
+    );
+    await waitFor(() => expect(screen.queryByText("Loading…")).toBeNull());
+
+    // Should still render 6 checkboxes, all checked (default not-muted)
+    const checkboxes = screen.getAllByRole("checkbox");
+    expect(checkboxes).toHaveLength(6);
+    expect((checkboxes[0] as HTMLInputElement).checked).toBe(true);
+  });
+
+  it("renders single pinned agent without agent name header", async () => {
+    vi.spyOn(pushApi, "listPushMutes").mockResolvedValue([]);
+    openPanel();
+    render(
+      <AgentPanel
+        windowId={WINDOW_ID}
+        tabId={TAB_ID}
+        profileId="personal"
+        pinnedAgentIds={["agent-1"]}
+      />,
+    );
+    await waitFor(() => expect(screen.queryByText("Loading…")).toBeNull());
+
+    // Only 3 toggles for single agent
+    const checkboxes = screen.getAllByRole("checkbox");
+    expect(checkboxes).toHaveLength(3);
+  });
+});

--- a/desktop/src/apps/BrowserApp/AgentPanel.test.tsx
+++ b/desktop/src/apps/BrowserApp/AgentPanel.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, act } from "@testing-library/react";
 import { AgentPanel } from "./AgentPanel";
 import { useBrowserAgentStore } from "@/stores/browser-agent-store";
 import * as browserAgentApi from "@/lib/browser-agent-api";
+import * as pushApi from "@/lib/browser-push-api";
 
 const WINDOW_ID = "win-1";
 const TAB_ID = "tab-1";
@@ -24,6 +25,8 @@ beforeEach(() => {
     recentEvents: {},
   });
   vi.spyOn(browserAgentApi, "listAgents").mockResolvedValue(AGENTS);
+  vi.spyOn(pushApi, "listPushMutes").mockResolvedValue([]);
+  vi.spyOn(pushApi, "setPushMute").mockResolvedValue({ ok: true });
 });
 
 afterEach(() => {
@@ -34,7 +37,7 @@ describe("AgentPanel", () => {
   it("renders nothing when panel is closed", () => {
     // Panel not open — store default has no entry
     const { container } = render(
-      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} pinnedAgentIds={PINNED} />,
+      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} profileId="personal" pinnedAgentIds={PINNED} />,
     );
     expect(container.firstChild).toBeNull();
   });
@@ -42,7 +45,7 @@ describe("AgentPanel", () => {
   it("renders nothing when pinnedAgentIds is empty", () => {
     openPanel();
     const { container } = render(
-      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} pinnedAgentIds={[]} />,
+      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} profileId="personal" pinnedAgentIds={[]} />,
     );
     expect(container.firstChild).toBeNull();
   });
@@ -50,7 +53,7 @@ describe("AgentPanel", () => {
   it("renders panel when isOpen is true", () => {
     openPanel();
     render(
-      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} pinnedAgentIds={PINNED} />,
+      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} profileId="personal" pinnedAgentIds={PINNED} />,
     );
     expect(screen.getByRole("complementary")).toBeInTheDocument();
   });
@@ -58,7 +61,7 @@ describe("AgentPanel", () => {
   it("renders one tab per pinned agent", () => {
     openPanel();
     render(
-      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} pinnedAgentIds={PINNED} />,
+      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} profileId="personal" pinnedAgentIds={PINNED} />,
     );
     const tabs = screen.getAllByRole("tab");
     expect(tabs).toHaveLength(PINNED.length);
@@ -67,7 +70,7 @@ describe("AgentPanel", () => {
   it("active tab highlighted with aria-selected=true", () => {
     openPanel("agent-1");
     render(
-      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} pinnedAgentIds={PINNED} />,
+      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} profileId="personal" pinnedAgentIds={PINNED} />,
     );
     const tabs = screen.getAllByRole("tab");
     // agent-1 is active
@@ -81,7 +84,7 @@ describe("AgentPanel", () => {
     openPanel("agent-1");
     const setActiveAgentSpy = vi.spyOn(useBrowserAgentStore.getState(), "setActiveAgent");
     render(
-      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} pinnedAgentIds={PINNED} />,
+      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} profileId="personal" pinnedAgentIds={PINNED} />,
     );
     const tabs = screen.getAllByRole("tab");
     // Click the second tab (agent-2)
@@ -93,7 +96,7 @@ describe("AgentPanel", () => {
     openPanel();
     const closePanelSpy = vi.spyOn(useBrowserAgentStore.getState(), "closePanel");
     render(
-      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} pinnedAgentIds={PINNED} />,
+      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} profileId="personal" pinnedAgentIds={PINNED} />,
     );
     fireEvent.click(screen.getByLabelText("Close agent panel"));
     expect(closePanelSpy).toHaveBeenCalledWith(WINDOW_ID, TAB_ID);
@@ -108,7 +111,7 @@ describe("AgentPanel", () => {
       timestamp: Date.now(),
     });
     render(
-      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} pinnedAgentIds={PINNED} />,
+      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} profileId="personal" pinnedAgentIds={PINNED} />,
     );
     expect(screen.getByText(/Example Page/)).toBeInTheDocument();
   });
@@ -123,7 +126,7 @@ describe("AgentPanel", () => {
       timestamp: ts,
     });
     render(
-      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} pinnedAgentIds={PINNED} />,
+      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} profileId="personal" pinnedAgentIds={PINNED} />,
     );
     fireEvent.click(screen.getByText("Summarise this page"));
     const msgs = useBrowserAgentStore.getState().messages["win-1:tab-1:agent-1"];
@@ -136,7 +139,7 @@ describe("AgentPanel", () => {
   it("chat textarea Enter sends a user message; Shift+Enter inserts newline", () => {
     openPanel("agent-1");
     render(
-      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} pinnedAgentIds={PINNED} />,
+      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} profileId="personal" pinnedAgentIds={PINNED} />,
     );
     const textarea = screen.getByRole("textbox");
 
@@ -158,7 +161,7 @@ describe("AgentPanel", () => {
   it("sent message appears in the thread", () => {
     openPanel("agent-1");
     render(
-      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} pinnedAgentIds={PINNED} />,
+      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} profileId="personal" pinnedAgentIds={PINNED} />,
     );
     const textarea = screen.getByRole("textbox");
     fireEvent.change(textarea, { target: { value: "Visible message" } });
@@ -170,7 +173,7 @@ describe("AgentPanel", () => {
     openPanel("agent-1");
     const setPanelWidthSpy = vi.spyOn(useBrowserAgentStore.getState(), "setPanelWidth");
     render(
-      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} pinnedAgentIds={PINNED} />,
+      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} profileId="personal" pinnedAgentIds={PINNED} />,
     );
     const handle = screen.getByRole("separator");
 
@@ -192,7 +195,7 @@ describe("AgentPanel", () => {
     openPanel("agent-1");
     const setPanelWidthSpy = vi.spyOn(useBrowserAgentStore.getState(), "setPanelWidth");
     const { unmount } = render(
-      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} pinnedAgentIds={PINNED} />,
+      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} profileId="personal" pinnedAgentIds={PINNED} />,
     );
     const handle = screen.getByRole("separator");
 
@@ -220,7 +223,7 @@ describe("AgentPanel", () => {
       timestamp: Date.now(),
     });
     render(
-      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} pinnedAgentIds={PINNED} />,
+      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} profileId="personal" pinnedAgentIds={PINNED} />,
     );
     const btn = screen.getByText("Summarise this page");
 
@@ -237,7 +240,7 @@ describe("AgentPanel", () => {
   it("role='complementary' + aria-label='Agent panel'", () => {
     openPanel();
     render(
-      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} pinnedAgentIds={PINNED} />,
+      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} profileId="personal" pinnedAgentIds={PINNED} />,
     );
     const panel = screen.getByRole("complementary");
     expect(panel.getAttribute("aria-label")).toBe("Agent panel");
@@ -246,7 +249,7 @@ describe("AgentPanel", () => {
   it("tablist + role='tab' + role='tabpanel' present", () => {
     openPanel();
     render(
-      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} pinnedAgentIds={PINNED} />,
+      <AgentPanel windowId={WINDOW_ID} tabId={TAB_ID} profileId="personal" pinnedAgentIds={PINNED} />,
     );
     expect(screen.getByRole("tablist")).toBeInTheDocument();
     expect(screen.getAllByRole("tab").length).toBeGreaterThan(0);

--- a/desktop/src/apps/BrowserApp/AgentPanel.tsx
+++ b/desktop/src/apps/BrowserApp/AgentPanel.tsx
@@ -69,7 +69,7 @@ export function AgentPanel({ windowId, tabId, profileId, pinnedAgentIds }: Agent
     return () => { cancelled = true; };
   }, []);
 
-  // Load mutes once when panel opens
+  // Load mutes once on mount.
   useEffect(() => {
     let cancelled = false;
     setMutesLoading(true);

--- a/desktop/src/apps/BrowserApp/AgentPanel.tsx
+++ b/desktop/src/apps/BrowserApp/AgentPanel.tsx
@@ -10,6 +10,7 @@ import { useBrowserAgentStore } from "@/stores/browser-agent-store";
 import type { AgentMessage, AgentEvent } from "@/stores/browser-agent-store";
 import { useBrowserStore } from "@/stores/browser-store";
 import { listAgents, unpinAgent, type AgentDto } from "@/lib/browser-agent-api";
+import { listPushMutes, setPushMute, type PushMute } from "@/lib/browser-push-api";
 
 export interface AgentPanelProps {
   windowId: string;
@@ -54,6 +55,8 @@ export function AgentPanel({ windowId, tabId, profileId, pinnedAgentIds }: Agent
 
   const [agents, setAgents] = useState<AgentDto[]>([]);
   const [inputValue, setInputValue] = useState("");
+  const [mutes, setMutes] = useState<PushMute[]>([]);
+  const [mutesLoading, setMutesLoading] = useState(true);
   const chatEndRef = useRef<HTMLDivElement | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 
@@ -62,6 +65,21 @@ export function AgentPanel({ windowId, tabId, profileId, pinnedAgentIds }: Agent
     let cancelled = false;
     listAgents().then((list) => {
       if (!cancelled) setAgents(list);
+    });
+    return () => { cancelled = true; };
+  }, []);
+
+  // Load mutes once when panel opens
+  useEffect(() => {
+    let cancelled = false;
+    setMutesLoading(true);
+    listPushMutes().then((list) => {
+      if (!cancelled) {
+        setMutes(list);
+        setMutesLoading(false);
+      }
+    }).catch(() => {
+      if (!cancelled) setMutesLoading(false);
     });
     return () => { cancelled = true; };
   }, []);
@@ -198,6 +216,41 @@ export function AgentPanel({ windowId, tabId, profileId, pinnedAgentIds }: Agent
   }
 
   const activeAgentName = activeAgentId ? getAgentName(activeAgentId) : "Agent";
+
+  const MUTE_KINDS: Array<{ kind: PushMute["kind"]; label: string }> = [
+    { kind: "chat", label: "Chat messages" },
+    { kind: "drive-started", label: "Started driving" },
+    { kind: "download-finished", label: "Download finished" },
+  ];
+
+  function isMuted(agentId: string, kind: PushMute["kind"]): boolean {
+    return mutes.some((m) => m.agent_id === agentId && m.kind === kind);
+  }
+
+  async function handleToggleMute(agentId: string, kind: PushMute["kind"]) {
+    const currentlyMuted = isMuted(agentId, kind);
+    const nextMuted = !currentlyMuted;
+    // Optimistic update
+    setMutes((prev) => {
+      const without = prev.filter((m) => !(m.agent_id === agentId && m.kind === kind));
+      if (nextMuted) {
+        return [...without, { agent_id: agentId, kind, muted_at: Date.now() }];
+      }
+      return without;
+    });
+    try {
+      await setPushMute({ agent_id: agentId, kind, muted: nextMuted });
+    } catch {
+      // Revert on failure
+      setMutes((prev) => {
+        const without = prev.filter((m) => !(m.agent_id === agentId && m.kind === kind));
+        if (currentlyMuted) {
+          return [...without, { agent_id: agentId, kind, muted_at: Date.now() }];
+        }
+        return without;
+      });
+    }
+  }
 
   return (
     <div
@@ -344,6 +397,47 @@ export function AgentPanel({ windowId, tabId, profileId, pinnedAgentIds }: Agent
           >
             Pin to Memory
           </button>
+        </div>
+
+        {/* Notifications section */}
+        <div className="flex flex-col gap-1 px-3 py-2 border-b border-shell-border-subtle flex-shrink-0">
+          <span className="text-[10px] uppercase tracking-wide text-shell-text-secondary mb-1">
+            Notifications
+          </span>
+          {mutesLoading ? (
+            <span className="text-[10px] text-shell-text-secondary italic">Loading…</span>
+          ) : (
+            pinnedAgentIds.map((agentId) => (
+              <div key={agentId} className="flex flex-col gap-1">
+                {pinnedAgentIds.length > 1 && (
+                  <span className="text-[10px] font-medium text-shell-text-secondary truncate">
+                    {getAgentName(agentId)}
+                  </span>
+                )}
+                {MUTE_KINDS.map(({ kind, label }) => {
+                  const checked = !isMuted(agentId, kind);
+                  const toggleId = `notif-${windowId}-${tabId}-${agentId}-${kind}`;
+                  return (
+                    <label
+                      key={kind}
+                      htmlFor={toggleId}
+                      className="flex items-center gap-2 cursor-pointer text-xs text-shell-text-secondary hover:text-shell-text"
+                    >
+                      <input
+                        id={toggleId}
+                        type="checkbox"
+                        checked={checked}
+                        onChange={() => handleToggleMute(agentId, kind)}
+                        className="accent-accent"
+                        aria-label={`${label} notifications for ${getAgentName(agentId)}`}
+                      />
+                      <span>{label}</span>
+                    </label>
+                  );
+                })}
+              </div>
+            ))
+          )}
         </div>
 
         {/* Chat thread */}

--- a/desktop/src/apps/BrowserApp/BrowserApp.tsx
+++ b/desktop/src/apps/BrowserApp/BrowserApp.tsx
@@ -28,6 +28,7 @@ import { WindowChooser } from "./WindowChooser";
 import { CapabilityPromptModal } from "./CapabilityPromptModal";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { Layers, ListChecks } from "lucide-react";
+import { bootstrapPushSubscription } from "../../lib/browser-push-bootstrap";
 
 const DEFAULT_PROFILE_ID = "personal";
 
@@ -64,6 +65,7 @@ export function BrowserApp({ windowId }: BrowserAppProps) {
     navigator.serviceWorker.register("/__taos/sw.js", { scope: "/" }).catch(() => {
       // SW registration can fail in test/HTTP contexts — ignore
     });
+    bootstrapPushSubscription().catch(() => { /* swallow — non-fatal */ });
   }, []);
 
   // Cleanup on unmount: remove the window from browser-store + delete server row

--- a/desktop/src/apps/BrowserApp/SettingsPanel.test.tsx
+++ b/desktop/src/apps/BrowserApp/SettingsPanel.test.tsx
@@ -4,6 +4,7 @@ import { SettingsPanel } from "./SettingsPanel";
 import { TabRenderer, DISCARD_TIMEOUT_MS } from "./TabRenderer";
 import { useBrowserSettingsStore } from "@/stores/browser-settings-store";
 import { useBrowserStore } from "@/stores/browser-store";
+import * as pushBootstrap from "../../lib/browser-push-bootstrap";
 
 const TEST_WINDOW_ID = "win-settings-test";
 
@@ -97,6 +98,73 @@ describe("SettingsPanel — interactions", () => {
     render(<SettingsPanel profileId="prof-test" onClose={onClose} />);
     fireEvent.click(screen.getByRole("button", { name: /close/i }));
     expect(onClose).toHaveBeenCalledOnce();
+  });
+});
+
+describe("SettingsPanel — Notifications button", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shows 'Enable browser notifications' when permission is default", () => {
+    vi.stubGlobal("Notification", { permission: "default", requestPermission: vi.fn() });
+    render(<SettingsPanel profileId="prof-test" onClose={() => {}} />);
+    const btn = screen.getByRole("button", { name: /enable browser notifications/i });
+    expect(btn).toBeInTheDocument();
+    expect((btn as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("shows 'Notifications enabled' and disabled when permission is granted", () => {
+    vi.stubGlobal("Notification", { permission: "granted", requestPermission: vi.fn() });
+    render(<SettingsPanel profileId="prof-test" onClose={() => {}} />);
+    const btn = screen.getByRole("button", { name: /notifications enabled/i });
+    expect(btn).toBeInTheDocument();
+    expect((btn as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("shows 'Blocked in browser settings' and disabled when permission is denied", () => {
+    vi.stubGlobal("Notification", { permission: "denied", requestPermission: vi.fn() });
+    render(<SettingsPanel profileId="prof-test" onClose={() => {}} />);
+    const btn = screen.getByRole("button", { name: /blocked in browser settings/i });
+    expect(btn).toBeInTheDocument();
+    expect((btn as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("clicking enable button calls requestPermission and bootstrapPushSubscription when granted", async () => {
+    const requestPermission = vi.fn().mockResolvedValue("granted");
+    vi.stubGlobal("Notification", { permission: "default", requestPermission });
+    vi.spyOn(pushBootstrap, "bootstrapPushSubscription").mockResolvedValue({
+      status: "subscribed",
+      device_id: "dev-1",
+    });
+
+    render(<SettingsPanel profileId="prof-test" onClose={() => {}} />);
+    const btn = screen.getByRole("button", { name: /enable browser notifications/i });
+
+    await act(async () => {
+      fireEvent.click(btn);
+    });
+
+    expect(requestPermission).toHaveBeenCalledOnce();
+    expect(pushBootstrap.bootstrapPushSubscription).toHaveBeenCalledOnce();
+  });
+
+  it("does NOT call bootstrapPushSubscription when requestPermission resolves denied", async () => {
+    const requestPermission = vi.fn().mockResolvedValue("denied");
+    vi.stubGlobal("Notification", { permission: "default", requestPermission });
+    vi.spyOn(pushBootstrap, "bootstrapPushSubscription").mockResolvedValue({
+      status: "subscribed",
+      device_id: "dev-1",
+    });
+
+    render(<SettingsPanel profileId="prof-test" onClose={() => {}} />);
+    const btn = screen.getByRole("button", { name: /enable browser notifications/i });
+
+    await act(async () => {
+      fireEvent.click(btn);
+    });
+
+    expect(pushBootstrap.bootstrapPushSubscription).not.toHaveBeenCalled();
   });
 });
 

--- a/desktop/src/apps/BrowserApp/SettingsPanel.tsx
+++ b/desktop/src/apps/BrowserApp/SettingsPanel.tsx
@@ -9,7 +9,7 @@
  *
  * Settings are persisted via useBrowserSettingsStore (localStorage).
  */
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { X } from "lucide-react";
 import {
   useBrowserSettingsStore,
@@ -17,6 +17,7 @@ import {
   type SearchEngine,
 } from "@/stores/browser-settings-store";
 import { AgentCapabilitiesPanel } from "./AgentCapabilitiesPanel";
+import { bootstrapPushSubscription } from "../../lib/browser-push-bootstrap";
 
 interface SettingsPanelProps {
   profileId: string;
@@ -32,8 +33,26 @@ export function SettingsPanel({ profileId, onClose }: SettingsPanelProps) {
   const setSearchEngine = useBrowserSettingsStore((s) => s.setSearchEngine);
   const ref = useRef<HTMLDivElement | null>(null);
   const [capsOpen, setCapsOpen] = useState(false);
+  const [notifPermission, setNotifPermission] = useState<NotificationPermission>(
+    typeof Notification !== "undefined" ? Notification.permission : "default",
+  );
+  const [notifBusy, setNotifBusy] = useState(false);
 
   const timeoutMinutes = Math.round(discardTimeoutMs / 60_000);
+
+  const handleEnableNotifications = useCallback(async () => {
+    if (typeof Notification === "undefined") return;
+    setNotifBusy(true);
+    try {
+      const result = await Notification.requestPermission();
+      setNotifPermission(result);
+      if (result === "granted") {
+        bootstrapPushSubscription().catch(() => { /* non-fatal */ });
+      }
+    } finally {
+      setNotifBusy(false);
+    }
+  }, []);
 
   // Click-outside dismiss
   useEffect(() => {
@@ -161,6 +180,30 @@ export function SettingsPanel({ profileId, onClose }: SettingsPanelProps) {
           onClose={() => setCapsOpen(false)}
         />
       )}
+
+      {/* Notifications */}
+      <div className="border-t border-shell-border-subtle pt-3 flex flex-col gap-2">
+        <span className="text-xs text-shell-text-secondary">Notifications</span>
+        <button
+          type="button"
+          disabled={notifPermission !== "default" || notifBusy}
+          onClick={handleEnableNotifications}
+          className={[
+            "w-full text-left text-xs px-2 py-1.5 rounded border transition-colors",
+            notifPermission === "granted"
+              ? "border-shell-border-subtle text-shell-text-secondary cursor-default"
+              : notifPermission === "denied"
+              ? "border-shell-border-subtle text-shell-text-secondary cursor-default opacity-60"
+              : "border-accent text-accent hover:bg-accent/10 cursor-pointer",
+          ].join(" ")}
+        >
+          {notifPermission === "granted"
+            ? "Notifications enabled"
+            : notifPermission === "denied"
+            ? "Blocked in browser settings"
+            : "Enable browser notifications"}
+        </button>
+      </div>
     </div>
   );
 }

--- a/desktop/src/apps/BrowserApp/TabRenderer.test.tsx
+++ b/desktop/src/apps/BrowserApp/TabRenderer.test.tsx
@@ -331,9 +331,6 @@ describe("TabRenderer — tab-focus postMessage", () => {
       "https://b.test/",
     );
     // tabB is now active. Render while capturing postMessages.
-    const messages: any[] = [];
-    const origPostMessage = window.postMessage.bind(window);
-
     const { container } = render(<TabRenderer windowId={TEST_WINDOW_ID} />);
 
     // Attach a spy to each iframe's contentWindow.postMessage.

--- a/desktop/src/apps/BrowserApp/TabRenderer.test.tsx
+++ b/desktop/src/apps/BrowserApp/TabRenderer.test.tsx
@@ -320,3 +320,61 @@ describe("TabRenderer — live exclusion exempts discard", () => {
     expect(tab?.liveExclusion).toBe("video");
   });
 });
+
+describe("TabRenderer — tab-focus postMessage", () => {
+  it("postMessages taos-copilot:tab-focus to iframes when active tab changes", () => {
+    // Add a second tab and switch to it — the postMessage should fire for both
+    // iframes: focused:true for the new active tab, focused:false for the old.
+    const tabA = useBrowserStore.getState().getWindow(TEST_WINDOW_ID)!.tabs[0].id;
+    const tabB = useBrowserStore.getState().addTab(
+      TEST_WINDOW_ID,
+      "https://b.test/",
+    );
+    // tabB is now active. Render while capturing postMessages.
+    const messages: any[] = [];
+    const origPostMessage = window.postMessage.bind(window);
+
+    const { container } = render(<TabRenderer windowId={TEST_WINDOW_ID} />);
+
+    // Attach a spy to each iframe's contentWindow.postMessage.
+    const iframes = Array.from(
+      container.querySelectorAll("iframe"),
+    ) as HTMLIFrameElement[];
+    const spies = iframes.map((iframe) => {
+      const spy = vi.fn();
+      // jsdom iframes don't have a real contentWindow; polyfill for this test.
+      if (!iframe.contentWindow) {
+        Object.defineProperty(iframe, "contentWindow", {
+          value: { postMessage: spy },
+          configurable: true,
+        });
+      } else {
+        vi.spyOn(iframe.contentWindow, "postMessage").mockImplementation(spy);
+      }
+      return spy;
+    });
+
+    // Now switch to tabA — triggers the activeTabId change.
+    act(() => {
+      useBrowserStore.getState().setActiveTab(TEST_WINDOW_ID, tabA);
+    });
+
+    // At least one iframe should have received a taos-copilot:tab-focus message.
+    const allCalls = spies.flatMap((spy) => spy.mock.calls);
+    const focusCalls = allCalls.filter(
+      (args) => args[0]?.type === "taos-copilot:tab-focus",
+    );
+    expect(focusCalls.length).toBeGreaterThan(0);
+
+    // The active tab's iframe should have received focused:true.
+    const activeFocusCalls = focusCalls.filter(
+      (args) => args[0]?.tab_id === tabA && args[0]?.focused === true,
+    );
+    expect(activeFocusCalls.length).toBeGreaterThan(0);
+
+    // window_id must be present on every tab-focus message.
+    for (const args of focusCalls) {
+      expect(args[0].window_id).toBe(TEST_WINDOW_ID);
+    }
+  });
+});

--- a/desktop/src/apps/BrowserApp/TabRenderer.tsx
+++ b/desktop/src/apps/BrowserApp/TabRenderer.tsx
@@ -174,6 +174,32 @@ export function TabRenderer({ windowId }: TabRendererProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [windowId, activeTabIdForEffect, pinnedAgentIdsForEffect.join(","), profileIdForEffect]);
 
+  // Tab-focus postMessage — keep copilot.js informed of which tab is active
+  // so it can forward tab-focus events to the server. Fires whenever the
+  // active tab changes, not on every render (effect deps are stable).
+  useEffect(() => {
+    if (!win) return;
+    const tabs = win.tabs;
+    const activeId = win.activeTabId;
+    for (const tab of tabs) {
+      const iframe = document.querySelector(
+        `iframe[data-tab-id="${tab.id}"]`,
+      ) as HTMLIFrameElement | null;
+      if (!iframe?.contentWindow) continue;
+      const focused = tab.id === activeId;
+      iframe.contentWindow.postMessage(
+        {
+          type: "taos-copilot:tab-focus",
+          window_id: windowId,
+          tab_id: tab.id,
+          focused,
+        },
+        "*",
+      );
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [windowId, activeTabIdForEffect]);
+
   // Prime the Service Worker with the active tab's page base URL + profile ID
   // so it can rewrite relative SPA fetch calls through the proxy.
   // Registration moved to BrowserApp.tsx (parent shell) since copilot.js runs

--- a/desktop/src/lib/browser-push-api.test.ts
+++ b/desktop/src/lib/browser-push-api.test.ts
@@ -1,0 +1,322 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getVapidPublicKey,
+  subscribePush,
+  listPushSubscriptions,
+  unsubscribePush,
+  listPushMutes,
+  setPushMute,
+} from "./browser-push-api";
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe("browser-push-api", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  // ---------------------------------------------------------------------------
+  // getVapidPublicKey
+  // ---------------------------------------------------------------------------
+  describe("getVapidPublicKey", () => {
+    it("extracts public_key from response body on 200", async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ public_key: "BFoo123" }),
+      });
+      const key = await getVapidPublicKey();
+      expect(key).toBe("BFoo123");
+    });
+
+    it("hits the correct URL with credentials", async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({ public_key: "BFoo123" }),
+      });
+      await getVapidPublicKey();
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toBe("/api/desktop/browser/push/vapid-public-key");
+      expect(opts.credentials).toBe("include");
+    });
+
+    it("throws on 401", async () => {
+      fetchMock.mockResolvedValue({ ok: false, status: 401 });
+      await expect(getVapidPublicKey()).rejects.toThrow("HTTP 401");
+    });
+
+    it("throws when public_key is missing", async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({ other: "stuff" }),
+      });
+      await expect(getVapidPublicKey()).rejects.toThrow(/Missing public_key/);
+    });
+
+    it("throws on network error", async () => {
+      fetchMock.mockRejectedValue(new Error("offline"));
+      await expect(getVapidPublicKey()).rejects.toThrow("offline");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // subscribePush
+  // ---------------------------------------------------------------------------
+  describe("subscribePush", () => {
+    const ARGS = {
+      device_id: "dev-1",
+      endpoint: "https://push.example.com/1",
+      p256dh_key: "p256dhKey==",
+      auth_key: "authKey==",
+      user_agent: "TestBrowser/1.0",
+    };
+
+    it("returns { ok: true } on 200", async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true }),
+      });
+      const result = await subscribePush(ARGS);
+      expect(result).toEqual({ ok: true });
+    });
+
+    it("posts to correct URL with JSON body and credentials", async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({ ok: true }),
+      });
+      await subscribePush(ARGS);
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toBe("/api/desktop/browser/push/subscribe");
+      expect(opts.method).toBe("POST");
+      expect(opts.credentials).toBe("include");
+      expect(opts.headers["content-type"]).toBe("application/json");
+      const body = JSON.parse(opts.body);
+      expect(body.device_id).toBe("dev-1");
+      expect(body.endpoint).toBe("https://push.example.com/1");
+      expect(body.p256dh_key).toBe("p256dhKey==");
+      expect(body.auth_key).toBe("authKey==");
+    });
+
+    it("throws on 401", async () => {
+      fetchMock.mockResolvedValue({ ok: false, status: 401 });
+      await expect(subscribePush(ARGS)).rejects.toThrow("HTTP 401");
+    });
+
+    it("throws on 400", async () => {
+      fetchMock.mockResolvedValue({ ok: false, status: 400 });
+      await expect(subscribePush(ARGS)).rejects.toThrow("HTTP 400");
+    });
+
+    it("throws on network error", async () => {
+      fetchMock.mockRejectedValue(new Error("offline"));
+      await expect(subscribePush(ARGS)).rejects.toThrow("offline");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // listPushSubscriptions
+  // ---------------------------------------------------------------------------
+  describe("listPushSubscriptions", () => {
+    it("returns subscriptions array from subscriptions key on 200", async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          subscriptions: [
+            {
+              device_id: "dev-1",
+              endpoint: "https://push.example.com/1",
+              user_agent: "Mozilla/5.0",
+              created_at: 1000,
+              last_seen_at: 2000,
+            },
+          ],
+        }),
+      });
+      const result = await listPushSubscriptions();
+      expect(result).toHaveLength(1);
+      expect(result[0].device_id).toBe("dev-1");
+      expect(result[0].endpoint).toBe("https://push.example.com/1");
+      expect(result[0].last_seen_at).toBe(2000);
+    });
+
+    it("returns [] on 401", async () => {
+      fetchMock.mockResolvedValue({ ok: false, status: 401 });
+      expect(await listPushSubscriptions()).toEqual([]);
+    });
+
+    it("returns [] on network error", async () => {
+      fetchMock.mockRejectedValue(new Error("offline"));
+      expect(await listPushSubscriptions()).toEqual([]);
+    });
+
+    it("returns [] when subscriptions key is not an array", async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({ subscriptions: null }),
+      });
+      expect(await listPushSubscriptions()).toEqual([]);
+    });
+
+    it("uses credentials", async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({ subscriptions: [] }),
+      });
+      await listPushSubscriptions();
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toBe("/api/desktop/browser/push/subscriptions");
+      expect(opts.credentials).toBe("include");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // unsubscribePush
+  // ---------------------------------------------------------------------------
+  describe("unsubscribePush", () => {
+    it("returns { ok: true } on 200", async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true }),
+      });
+      expect(await unsubscribePush("dev-1")).toEqual({ ok: true });
+    });
+
+    it("encodes device_id in the URL path", async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({ ok: true }),
+      });
+      await unsubscribePush("dev/with/slashes");
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toContain("dev%2Fwith%2Fslashes");
+      expect(opts.method).toBe("DELETE");
+    });
+
+    it("returns { ok: false } on 401", async () => {
+      fetchMock.mockResolvedValue({ ok: false, status: 401 });
+      expect(await unsubscribePush("dev-1")).toEqual({ ok: false });
+    });
+
+    it("returns { ok: false } on network error", async () => {
+      fetchMock.mockRejectedValue(new Error("offline"));
+      expect(await unsubscribePush("dev-1")).toEqual({ ok: false });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // listPushMutes
+  // ---------------------------------------------------------------------------
+  describe("listPushMutes", () => {
+    it("returns mutes array from mutes key on 200", async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          mutes: [
+            { agent_id: "agent-1", kind: "chat", muted_at: 1000 },
+            { agent_id: "agent-1", kind: "drive-started", muted_at: 2000 },
+          ],
+        }),
+      });
+      const result = await listPushMutes();
+      expect(result).toHaveLength(2);
+      expect(result[0].agent_id).toBe("agent-1");
+      expect(result[0].kind).toBe("chat");
+      expect(result[1].kind).toBe("drive-started");
+    });
+
+    it("returns [] on 401", async () => {
+      fetchMock.mockResolvedValue({ ok: false, status: 401 });
+      expect(await listPushMutes()).toEqual([]);
+    });
+
+    it("returns [] on network error", async () => {
+      fetchMock.mockRejectedValue(new Error("offline"));
+      expect(await listPushMutes()).toEqual([]);
+    });
+
+    it("returns [] when mutes key is not an array", async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({ mutes: null }),
+      });
+      expect(await listPushMutes()).toEqual([]);
+    });
+
+    it("uses credentials", async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({ mutes: [] }),
+      });
+      await listPushMutes();
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toBe("/api/desktop/browser/push/mutes");
+      expect(opts.credentials).toBe("include");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // setPushMute
+  // ---------------------------------------------------------------------------
+  describe("setPushMute", () => {
+    it("returns { ok: true } on 200", async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true }),
+      });
+      const result = await setPushMute({ agent_id: "agent-1", kind: "chat", muted: true });
+      expect(result).toEqual({ ok: true });
+    });
+
+    it("sends PUT to correct URL with JSON body", async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({ ok: true }),
+      });
+      await setPushMute({ agent_id: "agent-1", kind: "drive-started", muted: false });
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toBe("/api/desktop/browser/push/mutes");
+      expect(opts.method).toBe("PUT");
+      expect(opts.credentials).toBe("include");
+      expect(opts.headers["content-type"]).toBe("application/json");
+      const body = JSON.parse(opts.body);
+      expect(body.agent_id).toBe("agent-1");
+      expect(body.kind).toBe("drive-started");
+      expect(body.muted).toBe(false);
+    });
+
+    it("throws on 401", async () => {
+      fetchMock.mockResolvedValue({ ok: false, status: 401 });
+      await expect(
+        setPushMute({ agent_id: "agent-1", kind: "chat", muted: true }),
+      ).rejects.toThrow("HTTP 401");
+    });
+
+    it("throws on 400", async () => {
+      fetchMock.mockResolvedValue({ ok: false, status: 400 });
+      await expect(
+        setPushMute({ agent_id: "agent-1", kind: "chat", muted: true }),
+      ).rejects.toThrow("HTTP 400");
+    });
+
+    it("throws on network error", async () => {
+      fetchMock.mockRejectedValue(new Error("offline"));
+      await expect(
+        setPushMute({ agent_id: "agent-1", kind: "chat", muted: true }),
+      ).rejects.toThrow("offline");
+    });
+  });
+});

--- a/desktop/src/lib/browser-push-api.ts
+++ b/desktop/src/lib/browser-push-api.ts
@@ -1,6 +1,6 @@
 /**
  * Fetch wrappers for /api/desktop/browser/push/*.
- * Silent on errors (returns sensible defaults) to match other browser-* api wrappers.
+ * Read operations return empty/false on error; write operations throw.
  */
 
 export interface PushSubscriptionInfo {

--- a/desktop/src/lib/browser-push-api.ts
+++ b/desktop/src/lib/browser-push-api.ts
@@ -1,0 +1,100 @@
+/**
+ * Fetch wrappers for /api/desktop/browser/push/*.
+ * Silent on errors (returns sensible defaults) to match other browser-* api wrappers.
+ */
+
+export interface PushSubscriptionInfo {
+  device_id: string;
+  endpoint: string;
+  user_agent: string | null;
+  created_at: number;
+  last_seen_at: number;
+}
+
+export interface PushMute {
+  agent_id: string;
+  kind: "chat" | "drive-started" | "download-finished";
+  muted_at: number;
+}
+
+export async function getVapidPublicKey(): Promise<string> {
+  const resp = await fetch("/api/desktop/browser/push/vapid-public-key", {
+    credentials: "include",
+  });
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  const body = await resp.json();
+  if (typeof body?.public_key !== "string") throw new Error("Missing public_key in response");
+  return body.public_key;
+}
+
+export async function subscribePush(args: {
+  device_id: string;
+  endpoint: string;
+  p256dh_key: string;
+  auth_key: string;
+  user_agent?: string | null;
+}): Promise<{ ok: true }> {
+  const resp = await fetch("/api/desktop/browser/push/subscribe", {
+    method: "POST",
+    credentials: "include",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(args),
+  });
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  return { ok: true };
+}
+
+export async function listPushSubscriptions(): Promise<PushSubscriptionInfo[]> {
+  try {
+    const resp = await fetch("/api/desktop/browser/push/subscriptions", {
+      credentials: "include",
+    });
+    if (!resp.ok) return [];
+    const body = await resp.json();
+    return Array.isArray(body?.subscriptions) ? body.subscriptions : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function unsubscribePush(device_id: string): Promise<{ ok: boolean }> {
+  try {
+    const resp = await fetch(
+      `/api/desktop/browser/push/subscriptions/${encodeURIComponent(device_id)}`,
+      { method: "DELETE", credentials: "include" },
+    );
+    if (!resp.ok) return { ok: false };
+    const body = await resp.json();
+    return { ok: typeof body?.ok === "boolean" ? body.ok : resp.ok };
+  } catch {
+    return { ok: false };
+  }
+}
+
+export async function listPushMutes(): Promise<PushMute[]> {
+  try {
+    const resp = await fetch("/api/desktop/browser/push/mutes", {
+      credentials: "include",
+    });
+    if (!resp.ok) return [];
+    const body = await resp.json();
+    return Array.isArray(body?.mutes) ? body.mutes : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function setPushMute(args: {
+  agent_id: string;
+  kind: "chat" | "drive-started" | "download-finished";
+  muted: boolean;
+}): Promise<{ ok: true }> {
+  const resp = await fetch("/api/desktop/browser/push/mutes", {
+    method: "PUT",
+    credentials: "include",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(args),
+  });
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  return { ok: true };
+}

--- a/desktop/src/lib/browser-push-bootstrap.test.ts
+++ b/desktop/src/lib/browser-push-bootstrap.test.ts
@@ -1,0 +1,288 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { bootstrapPushSubscription } from "./browser-push-bootstrap";
+import * as pushApi from "./browser-push-api";
+
+const DEVICE_ID_KEY = "taos-browser:push-device-id";
+
+// ---------------------------------------------------------------------------
+// Helpers to build mock push subscriptions
+// ---------------------------------------------------------------------------
+
+function makeMockSubscription(opts: { endpoint?: string } = {}) {
+  const endpoint = opts.endpoint ?? "https://push.example.com/endpoint-1";
+  return {
+    endpoint,
+    getKey: vi.fn((name: string) => {
+      if (name === "p256dh") return new Uint8Array([1, 2, 3]).buffer;
+      if (name === "auth") return new Uint8Array([4, 5, 6]).buffer;
+      return null;
+    }),
+  };
+}
+
+function makePushManager(existingSubscription: unknown = null) {
+  return {
+    getSubscription: vi.fn().mockResolvedValue(existingSubscription),
+    subscribe: vi.fn().mockResolvedValue(makeMockSubscription()),
+  };
+}
+
+function makeServiceWorkerRegistration(pushManager: ReturnType<typeof makePushManager>) {
+  return { pushManager };
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+  global.fetch = originalFetch;
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Utility: set up navigator + Notification mocks
+// ---------------------------------------------------------------------------
+
+function stubSupported(permission: NotificationPermission, existingSubscription: unknown = null) {
+  const pushManager = makePushManager(existingSubscription);
+  const registration = makeServiceWorkerRegistration(pushManager);
+
+  // Stub serviceWorker
+  Object.defineProperty(navigator, "serviceWorker", {
+    configurable: true,
+    value: {
+      ready: Promise.resolve(registration),
+      register: vi.fn().mockResolvedValue(registration),
+    },
+  });
+
+  // Stub PushManager in window
+  vi.stubGlobal("PushManager", class PushManager {});
+
+  // Stub Notification
+  vi.stubGlobal("Notification", {
+    permission,
+    requestPermission: vi.fn().mockResolvedValue(permission),
+  });
+
+  return { pushManager, registration };
+}
+
+function stubUnsupported() {
+  // Remove serviceWorker from navigator
+  Object.defineProperty(navigator, "serviceWorker", {
+    configurable: true,
+    value: undefined,
+  });
+  // Remove PushManager
+  vi.stubGlobal("PushManager", undefined);
+}
+
+// ---------------------------------------------------------------------------
+// Tests — unsupported
+// ---------------------------------------------------------------------------
+
+describe("bootstrapPushSubscription — unsupported", () => {
+  it("returns unsupported when serviceWorker is absent", async () => {
+    stubUnsupported();
+    const result = await bootstrapPushSubscription();
+    expect(result).toEqual({ status: "unsupported" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — no permission
+// ---------------------------------------------------------------------------
+
+describe("bootstrapPushSubscription — no permission", () => {
+  it("returns no-permission with reason=default when permission is 'default'", async () => {
+    stubSupported("default");
+    const result = await bootstrapPushSubscription();
+    expect(result).toEqual({ status: "no-permission", reason: "default" });
+  });
+
+  it("makes no network calls when permission is 'default'", async () => {
+    stubSupported("default");
+    const fetchMock = vi.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    await bootstrapPushSubscription();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns no-permission with reason=denied when permission is 'denied'", async () => {
+    stubSupported("denied");
+    const result = await bootstrapPushSubscription();
+    expect(result).toEqual({ status: "no-permission", reason: "denied" });
+  });
+
+  it("makes no network calls when permission is 'denied'", async () => {
+    stubSupported("denied");
+    const fetchMock = vi.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    await bootstrapPushSubscription();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — granted + no existing subscription
+// ---------------------------------------------------------------------------
+
+describe("bootstrapPushSubscription — granted, no existing subscription", () => {
+  it("calls pushManager.subscribe and POSTs to /push/subscribe, returns subscribed", async () => {
+    const { pushManager } = stubSupported("granted", null);
+    const subscribePushSpy = vi.spyOn(pushApi, "subscribePush").mockResolvedValue({ ok: true });
+    vi.spyOn(pushApi, "getVapidPublicKey").mockResolvedValue("BValidVapidKey==");
+
+    const result = await bootstrapPushSubscription();
+
+    expect(pushManager.subscribe).toHaveBeenCalledOnce();
+    expect(pushManager.subscribe).toHaveBeenCalledWith({
+      userVisibleOnly: true,
+      applicationServerKey: expect.any(Uint8Array),
+    });
+    expect(subscribePushSpy).toHaveBeenCalledOnce();
+    const callArgs = subscribePushSpy.mock.calls[0][0];
+    expect(callArgs.endpoint).toBe("https://push.example.com/endpoint-1");
+    expect(typeof callArgs.device_id).toBe("string");
+    expect(callArgs.device_id).toBeTruthy();
+    expect(result.status).toBe("subscribed");
+    if (result.status === "subscribed") {
+      expect(typeof result.device_id).toBe("string");
+    }
+  });
+
+  it("generates and stores a new device_id in localStorage on first call", async () => {
+    stubSupported("granted", null);
+    vi.spyOn(pushApi, "subscribePush").mockResolvedValue({ ok: true });
+    vi.spyOn(pushApi, "getVapidPublicKey").mockResolvedValue("BValidVapidKey==");
+
+    expect(localStorage.getItem(DEVICE_ID_KEY)).toBeNull();
+    const result = await bootstrapPushSubscription();
+
+    const stored = localStorage.getItem(DEVICE_ID_KEY);
+    expect(stored).toBeTruthy();
+    if (result.status === "subscribed") {
+      expect(result.device_id).toBe(stored);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — granted + existing subscription (re-POST path)
+// ---------------------------------------------------------------------------
+
+describe("bootstrapPushSubscription — granted, existing subscription", () => {
+  it("does NOT call pushManager.subscribe again when subscription already exists", async () => {
+    const existing = makeMockSubscription({ endpoint: "https://push.example.com/existing" });
+    const { pushManager } = stubSupported("granted", existing);
+    const subscribePushSpy = vi.spyOn(pushApi, "subscribePush").mockResolvedValue({ ok: true });
+    vi.spyOn(pushApi, "getVapidPublicKey").mockResolvedValue("BValidVapidKey==");
+
+    const result = await bootstrapPushSubscription();
+
+    expect(pushManager.subscribe).not.toHaveBeenCalled();
+    expect(subscribePushSpy).toHaveBeenCalledOnce();
+    const callArgs = subscribePushSpy.mock.calls[0][0];
+    expect(callArgs.endpoint).toBe("https://push.example.com/existing");
+    expect(result.status).toBe("subscribed");
+  });
+
+  it("re-POSTs with the existing subscription's endpoint to refresh last_seen_at", async () => {
+    const existing = makeMockSubscription({ endpoint: "https://push.example.com/existing" });
+    stubSupported("granted", existing);
+    const subscribePushSpy = vi.spyOn(pushApi, "subscribePush").mockResolvedValue({ ok: true });
+
+    await bootstrapPushSubscription();
+
+    expect(subscribePushSpy).toHaveBeenCalledOnce();
+    expect(subscribePushSpy.mock.calls[0][0].endpoint).toBe(
+      "https://push.example.com/existing",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — device_id persistence
+// ---------------------------------------------------------------------------
+
+describe("bootstrapPushSubscription — device_id persistence", () => {
+  it("reuses the existing device_id from localStorage on subsequent calls", async () => {
+    const stored_id = "my-stable-device-uuid";
+    localStorage.setItem(DEVICE_ID_KEY, stored_id);
+
+    stubSupported("granted", null);
+    const subscribePushSpy = vi.spyOn(pushApi, "subscribePush").mockResolvedValue({ ok: true });
+    vi.spyOn(pushApi, "getVapidPublicKey").mockResolvedValue("BValidVapidKey==");
+
+    const result = await bootstrapPushSubscription();
+
+    expect(subscribePushSpy.mock.calls[0][0].device_id).toBe(stored_id);
+    if (result.status === "subscribed") {
+      expect(result.device_id).toBe(stored_id);
+    }
+    // localStorage should still have the same id (not regenerated)
+    expect(localStorage.getItem(DEVICE_ID_KEY)).toBe(stored_id);
+  });
+
+  it("generates different device_ids for two fresh starts", async () => {
+    stubSupported("granted", null);
+    vi.spyOn(pushApi, "subscribePush").mockResolvedValue({ ok: true });
+    vi.spyOn(pushApi, "getVapidPublicKey").mockResolvedValue("BValidVapidKey==");
+
+    // First call
+    await bootstrapPushSubscription();
+    const firstId = localStorage.getItem(DEVICE_ID_KEY);
+
+    // Reset localStorage to simulate a new first-time run
+    localStorage.clear();
+
+    // Re-stub because vi.restoreAllMocks clears previous stubs inline
+    const { pushManager: pm2 } = stubSupported("granted", null);
+    pm2.getSubscription.mockResolvedValue(null);
+    vi.spyOn(pushApi, "subscribePush").mockResolvedValue({ ok: true });
+    vi.spyOn(pushApi, "getVapidPublicKey").mockResolvedValue("BValidVapidKey==");
+
+    await bootstrapPushSubscription();
+    const secondId = localStorage.getItem(DEVICE_ID_KEY);
+
+    expect(firstId).toBeTruthy();
+    expect(secondId).toBeTruthy();
+    expect(firstId).not.toBe(secondId);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — error path
+// ---------------------------------------------------------------------------
+
+describe("bootstrapPushSubscription — error handling", () => {
+  it("returns { status: 'error' } rather than throwing when subscribePush fails", async () => {
+    stubSupported("granted", null);
+    vi.spyOn(pushApi, "getVapidPublicKey").mockResolvedValue("BValidVapidKey==");
+    vi.spyOn(pushApi, "subscribePush").mockRejectedValue(new Error("subscribe failed"));
+
+    const result = await bootstrapPushSubscription();
+    expect(result.status).toBe("error");
+    if (result.status === "error") {
+      expect(result.error.message).toContain("subscribe failed");
+    }
+  });
+
+  it("returns { status: 'error' } when getVapidPublicKey fails", async () => {
+    stubSupported("granted", null);
+    vi.spyOn(pushApi, "getVapidPublicKey").mockRejectedValue(new Error("vapid error"));
+
+    const result = await bootstrapPushSubscription();
+    expect(result.status).toBe("error");
+  });
+});

--- a/desktop/src/lib/browser-push-bootstrap.ts
+++ b/desktop/src/lib/browser-push-bootstrap.ts
@@ -1,0 +1,107 @@
+/**
+ * Bootstrap a push subscription if Notification.permission is 'granted'.
+ * Idempotent — safe to call on every page load. Caches a stable device_id
+ * in localStorage. No-ops on 'default' (caller decides when to prompt) or
+ * 'denied'.
+ */
+
+import { getVapidPublicKey, subscribePush } from "./browser-push-api";
+
+const DEVICE_ID_KEY = "taos-browser:push-device-id";
+
+function urlBase64ToUint8Array(b64url: string): Uint8Array {
+  const padding = "=".repeat((4 - (b64url.length % 4)) % 4);
+  const base64 = (b64url + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const raw = atob(base64);
+  return Uint8Array.from(raw, (c) => c.charCodeAt(0));
+}
+
+function arrayBufferToBase64Url(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i]!);
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+}
+
+export async function bootstrapPushSubscription(): Promise<
+  | { status: "subscribed"; device_id: string }
+  | { status: "no-permission"; reason: "default" | "denied" }
+  | { status: "unsupported" }
+  | { status: "error"; error: Error }
+> {
+  try {
+    // 1. Check browser support
+    if (
+      !("serviceWorker" in navigator) ||
+      !navigator.serviceWorker ||
+      !("PushManager" in window) ||
+      !(window as unknown as Record<string, unknown>)["PushManager"]
+    ) {
+      return { status: "unsupported" };
+    }
+
+    // 2. Get or create stable device_id
+    let device_id = localStorage.getItem(DEVICE_ID_KEY);
+    if (!device_id) {
+      device_id = crypto.randomUUID();
+      localStorage.setItem(DEVICE_ID_KEY, device_id);
+    }
+
+    // 3. Check notification permission — do NOT prompt here
+    if (typeof Notification === "undefined") {
+      return { status: "unsupported" };
+    }
+    const permission = Notification.permission;
+    if (permission === "default") {
+      return { status: "no-permission", reason: "default" };
+    }
+    if (permission === "denied") {
+      return { status: "no-permission", reason: "denied" };
+    }
+
+    // 4. Wait for service worker registration
+    const registration = await navigator.serviceWorker.ready;
+
+    // 5. Check for existing subscription
+    const existing = await registration.pushManager.getSubscription();
+    if (existing) {
+      // Re-POST to keep last_seen_at fresh (idempotent upsert)
+      const p256dhKey = existing.getKey("p256dh");
+      const authKey = existing.getKey("auth");
+      await subscribePush({
+        device_id,
+        endpoint: existing.endpoint,
+        p256dh_key: p256dhKey ? arrayBufferToBase64Url(p256dhKey) : "",
+        auth_key: authKey ? arrayBufferToBase64Url(authKey) : "",
+        user_agent: navigator.userAgent,
+      });
+      return { status: "subscribed", device_id };
+    }
+
+    // 6. Subscribe — fetch VAPID key and call pushManager.subscribe
+    const vapidPublicKey = await getVapidPublicKey();
+    const applicationServerKey = urlBase64ToUint8Array(vapidPublicKey);
+    const subscription = await registration.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: applicationServerKey as unknown as BufferSource,
+    });
+
+    // 7. Extract keys and POST subscription
+    const p256dhBuffer = subscription.getKey("p256dh");
+    const authBuffer = subscription.getKey("auth");
+    await subscribePush({
+      device_id,
+      endpoint: subscription.endpoint,
+      p256dh_key: p256dhBuffer ? arrayBufferToBase64Url(p256dhBuffer) : "",
+      auth_key: authBuffer ? arrayBufferToBase64Url(authBuffer) : "",
+      user_agent: navigator.userAgent,
+    });
+
+    // 8. Return success
+    return { status: "subscribed", device_id };
+  } catch (err) {
+    return { status: "error", error: err instanceof Error ? err : new Error(String(err)) };
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ dependencies = [
     "taosmd @ git+https://github.com/jaylfc/taosmd.git@master",
     # WebSocket client for dashboard proxy (shortcut_proxy.py)
     "websockets>=12.0",
+    # Web Push VAPID signing — pulls in cryptography, http-ece, py-vapid
+    "pywebpush>=1.14",
 ]
 
 [project.optional-dependencies]

--- a/tests/routes/desktop_browser/test_push_mutes.py
+++ b/tests/routes/desktop_browser/test_push_mutes.py
@@ -1,0 +1,199 @@
+"""Tests for push_mutes table, store methods, and HTTP API."""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+
+# ---------------------------------------------------------------------------
+# Store-level fixture (no app needed)
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def store(tmp_path):
+    from tinyagentos.routes.desktop_browser.store import BrowserStore
+
+    s = BrowserStore(tmp_path / "browser.sqlite3")
+    await s.init()
+    yield s
+    await s.close()
+
+
+# ---------------------------------------------------------------------------
+# HTTP helper: create an authenticated client for a second user
+# ---------------------------------------------------------------------------
+
+
+def _make_user_b_client(app):
+    auth_mgr = app.state.auth
+    if auth_mgr.find_user("user_b") is None:
+        invite_code = auth_mgr.add_user_invite("user_b", "admin")
+        auth_mgr.complete_invite("user_b", invite_code, "user_b", "", "pass_b")
+    record = auth_mgr.find_user("user_b")
+    token = auth_mgr.create_session(user_id=record["id"], long_lived=True)
+    return AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        cookies={"taos_session": token},
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Set then list
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_then_list(client):
+    resp = await client.put(
+        "/api/desktop/browser/push/mutes",
+        json={"agent_id": "agent-A", "kind": "chat", "muted": True},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+
+    list_resp = await client.get("/api/desktop/browser/push/mutes")
+    assert list_resp.status_code == 200
+    mutes = list_resp.json()["mutes"]
+    assert len(mutes) == 1
+    assert mutes[0]["agent_id"] == "agent-A"
+    assert mutes[0]["kind"] == "chat"
+    assert isinstance(mutes[0]["muted_at"], int)
+
+
+# ---------------------------------------------------------------------------
+# 2. Unmute
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unmute(client):
+    await client.put(
+        "/api/desktop/browser/push/mutes",
+        json={"agent_id": "agent-A", "kind": "chat", "muted": True},
+    )
+    resp = await client.put(
+        "/api/desktop/browser/push/mutes",
+        json={"agent_id": "agent-A", "kind": "chat", "muted": False},
+    )
+    assert resp.status_code == 200
+
+    list_resp = await client.get("/api/desktop/browser/push/mutes")
+    assert list_resp.json()["mutes"] == []
+
+
+# ---------------------------------------------------------------------------
+# 3. Multi-user isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_multi_user_isolation(client, app):
+    # User A (current client) sets a mute
+    await client.put(
+        "/api/desktop/browser/push/mutes",
+        json={"agent_id": "agent-A", "kind": "chat", "muted": True},
+    )
+
+    # User B's GET must be empty
+    async with _make_user_b_client(app) as b_client:
+        resp_b = await b_client.get("/api/desktop/browser/push/mutes")
+        assert resp_b.status_code == 200
+        assert resp_b.json()["mutes"] == []
+
+        # User B sets their own mute
+        await b_client.put(
+            "/api/desktop/browser/push/mutes",
+            json={"agent_id": "agent-B", "kind": "drive-started", "muted": True},
+        )
+
+    # User A's list must not contain user B's mute
+    list_resp_a = await client.get("/api/desktop/browser/push/mutes")
+    mutes_a = list_resp_a.json()["mutes"]
+    assert all(m["agent_id"] != "agent-B" for m in mutes_a)
+    assert len(mutes_a) == 1
+
+
+# ---------------------------------------------------------------------------
+# 4. Invalid kind → 422
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invalid_kind_returns_422(client):
+    resp = await client.put(
+        "/api/desktop/browser/push/mutes",
+        json={"agent_id": "agent-A", "kind": "explosion", "muted": True},
+    )
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# 5. Auth required on GET and PUT
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_mutes_unauthenticated_returns_401(app):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        resp = await c.get("/api/desktop/browser/push/mutes")
+        assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_put_mutes_unauthenticated_returns_401(app):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        resp = await c.put(
+            "/api/desktop/browser/push/mutes",
+            json={"agent_id": "agent-A", "kind": "chat", "muted": True},
+        )
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# 6. is_push_muted direct store check
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_is_push_muted_store(store):
+    # Initially not muted
+    assert await store.is_push_muted("user_a", "agent-X", "chat") is False
+
+    # Set mute
+    await store.set_push_mute("user_a", "agent-X", "chat", True)
+    assert await store.is_push_muted("user_a", "agent-X", "chat") is True
+
+    # Different kind for same agent → False
+    assert await store.is_push_muted("user_a", "agent-X", "drive-started") is False
+
+    # Unset mute
+    await store.set_push_mute("user_a", "agent-X", "chat", False)
+    assert await store.is_push_muted("user_a", "agent-X", "chat") is False
+
+
+# ---------------------------------------------------------------------------
+# 7. Replace on duplicate set (PRIMARY KEY enforced)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_replace_on_duplicate_set(client):
+    await client.put(
+        "/api/desktop/browser/push/mutes",
+        json={"agent_id": "agent-A", "kind": "chat", "muted": True},
+    )
+    await client.put(
+        "/api/desktop/browser/push/mutes",
+        json={"agent_id": "agent-A", "kind": "chat", "muted": True},
+    )
+
+    list_resp = await client.get("/api/desktop/browser/push/mutes")
+    mutes = list_resp.json()["mutes"]
+    assert len(mutes) == 1

--- a/tests/routes/desktop_browser/test_push_routes.py
+++ b/tests/routes/desktop_browser/test_push_routes.py
@@ -1,0 +1,270 @@
+"""Tests for /api/desktop/browser/push HTTP endpoints."""
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrors bookmark/site_permission tests)
+# ---------------------------------------------------------------------------
+
+
+def _get_user_id(app):
+    """Resolve the authed admin user id from the app state."""
+    auth_mgr = app.state.auth
+    record = auth_mgr.find_user("admin")
+    return record["id"] if record else "test-admin"
+
+
+def _make_auth_client(app, tmp_data_dir):
+    """Create an authenticated async client for a second user (user_b)."""
+    from httpx import ASGITransport, AsyncClient
+
+    auth_mgr = app.state.auth
+    if auth_mgr.find_user("user_b") is None:
+        invite_code = auth_mgr.add_user_invite("user_b", "admin")
+        auth_mgr.complete_invite("user_b", invite_code, "user_b", "", "pass_b")
+    record = auth_mgr.find_user("user_b")
+    token = auth_mgr.create_session(user_id=record["id"], long_lived=True)
+    return AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        cookies={"taos_session": token},
+    )
+
+
+_VALID_SUB = {
+    "device_id": "device-abc",
+    "endpoint": "https://push.example.com/send/abc123",
+    "p256dh_key": "BNcRdreALRFXTkOOUHK1EtK2wtwe5HJnRKJE4NVe5kU",
+    "auth_key": "tBHItJI5svbpez7KI4CCXg",
+    "user_agent": "Mozilla/5.0",
+}
+
+
+# ---------------------------------------------------------------------------
+# GET /vapid-public-key — public, no auth
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestVapidPublicKey:
+    async def test_returns_200_without_auth(self, app):
+        """vapid-public-key must be reachable with no session cookie."""
+        from httpx import ASGITransport, AsyncClient
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            resp = await c.get("/api/desktop/browser/push/vapid-public-key")
+            assert resp.status_code == 200
+            body = resp.json()
+            assert "public_key" in body
+            # Verify it's valid uncompressed P-256 point: 65 bytes when decoded
+            pub_bytes = base64.urlsafe_b64decode(
+                body["public_key"] + "=" * (-len(body["public_key"]) % 4)
+            )
+            assert len(pub_bytes) == 65
+
+    async def test_same_key_on_second_call(self, app):
+        """Cache test: both calls return the identical public key."""
+        from httpx import ASGITransport, AsyncClient
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            r1 = await c.get("/api/desktop/browser/push/vapid-public-key")
+            r2 = await c.get("/api/desktop/browser/push/vapid-public-key")
+        assert r1.json()["public_key"] == r2.json()["public_key"]
+
+
+# ---------------------------------------------------------------------------
+# Auth (401) tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestPushAuth:
+    async def test_subscribe_unauthenticated_returns_401(self, app):
+        from httpx import ASGITransport, AsyncClient
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            resp = await c.post("/api/desktop/browser/push/subscribe", json=_VALID_SUB)
+            assert resp.status_code == 401
+
+    async def test_list_subscriptions_unauthenticated_returns_401(self, app):
+        from httpx import ASGITransport, AsyncClient
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            resp = await c.get("/api/desktop/browser/push/subscriptions")
+            assert resp.status_code == 401
+
+    async def test_delete_subscription_unauthenticated_returns_401(self, app):
+        from httpx import ASGITransport, AsyncClient
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            resp = await c.delete(
+                "/api/desktop/browser/push/subscriptions/some-device"
+            )
+            assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# POST /subscribe
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestSubscribePush:
+    async def test_subscribe_happy_path(self, client):
+        resp = await client.post(
+            "/api/desktop/browser/push/subscribe", json=_VALID_SUB
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True}
+
+    async def test_subscribe_appears_in_list(self, client):
+        await client.post(
+            "/api/desktop/browser/push/subscribe", json=_VALID_SUB
+        )
+        list_resp = await client.get("/api/desktop/browser/push/subscriptions")
+        assert list_resp.status_code == 200
+        subs = list_resp.json()["subscriptions"]
+        assert len(subs) == 1
+        assert subs[0]["device_id"] == _VALID_SUB["device_id"]
+        assert subs[0]["endpoint"] == _VALID_SUB["endpoint"]
+
+    async def test_subscribe_missing_required_field_returns_422(self, client):
+        # Missing p256dh_key
+        bad = {k: v for k, v in _VALID_SUB.items() if k != "p256dh_key"}
+        resp = await client.post("/api/desktop/browser/push/subscribe", json=bad)
+        assert resp.status_code == 422
+
+    async def test_subscribe_empty_device_id_returns_422(self, client):
+        bad = {**_VALID_SUB, "device_id": ""}
+        resp = await client.post("/api/desktop/browser/push/subscribe", json=bad)
+        assert resp.status_code == 422
+
+    async def test_subscribe_non_https_endpoint_returns_422(self, client):
+        bad = {**_VALID_SUB, "endpoint": "http://push.example.com/send/abc"}
+        resp = await client.post("/api/desktop/browser/push/subscribe", json=bad)
+        assert resp.status_code == 422
+
+    async def test_subscribe_javascript_uri_endpoint_returns_422(self, client):
+        bad = {**_VALID_SUB, "endpoint": "javascript:alert(1)"}
+        resp = await client.post("/api/desktop/browser/push/subscribe", json=bad)
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /subscriptions — secrets must be stripped
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestListPushSubscriptions:
+    async def test_list_empty_initially(self, client):
+        resp = await client.get("/api/desktop/browser/push/subscriptions")
+        assert resp.status_code == 200
+        assert resp.json() == {"subscriptions": []}
+
+    async def test_list_does_not_include_p256dh_key(self, client):
+        await client.post("/api/desktop/browser/push/subscribe", json=_VALID_SUB)
+        resp = await client.get("/api/desktop/browser/push/subscriptions")
+        subs = resp.json()["subscriptions"]
+        assert len(subs) == 1
+        assert "p256dh_key" not in subs[0], "p256dh_key must never be returned"
+
+    async def test_list_does_not_include_auth_key(self, client):
+        await client.post("/api/desktop/browser/push/subscribe", json=_VALID_SUB)
+        resp = await client.get("/api/desktop/browser/push/subscriptions")
+        subs = resp.json()["subscriptions"]
+        assert len(subs) == 1
+        assert "auth_key" not in subs[0], "auth_key must never be returned"
+
+    async def test_list_includes_expected_safe_fields(self, client):
+        await client.post("/api/desktop/browser/push/subscribe", json=_VALID_SUB)
+        resp = await client.get("/api/desktop/browser/push/subscriptions")
+        sub = resp.json()["subscriptions"][0]
+        assert "device_id" in sub
+        assert "endpoint" in sub
+        assert "user_agent" in sub
+        assert "created_at" in sub
+        assert "last_seen_at" in sub
+
+    async def test_list_multi_user_isolation(self, client, app):
+        """User A's subscription must not appear in the current user's list."""
+        store = app.state.browser_store
+        await store.upsert_push_subscription(
+            user_id="other-user",
+            device_id="other-device",
+            endpoint="https://push.example.com/other",
+            p256dh_key="otherkey",
+            auth_key="otherauth",
+        )
+        resp = await client.get("/api/desktop/browser/push/subscriptions")
+        assert resp.status_code == 200
+        subs = resp.json()["subscriptions"]
+        assert all(s["device_id"] != "other-device" for s in subs)
+
+
+# ---------------------------------------------------------------------------
+# DELETE /subscriptions/{device_id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestDeletePushSubscription:
+    async def test_delete_happy_path(self, client):
+        await client.post("/api/desktop/browser/push/subscribe", json=_VALID_SUB)
+        resp = await client.delete(
+            f"/api/desktop/browser/push/subscriptions/{_VALID_SUB['device_id']}"
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True}
+
+    async def test_delete_removes_from_list(self, client):
+        await client.post("/api/desktop/browser/push/subscribe", json=_VALID_SUB)
+        await client.delete(
+            f"/api/desktop/browser/push/subscriptions/{_VALID_SUB['device_id']}"
+        )
+        list_resp = await client.get("/api/desktop/browser/push/subscriptions")
+        assert list_resp.json()["subscriptions"] == []
+
+    async def test_delete_non_existent_returns_ok_false(self, client):
+        resp = await client.delete(
+            "/api/desktop/browser/push/subscriptions/does-not-exist"
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": False}
+
+    async def test_delete_multi_user_isolation(self, client, app, tmp_path):
+        """User B deleting device_id 'X' must not remove user A's 'X'."""
+        user_a_id = _get_user_id(app)
+        store = app.state.browser_store
+        await store.upsert_push_subscription(
+            user_id=user_a_id,
+            device_id="shared-device-id",
+            endpoint="https://push.example.com/a",
+            p256dh_key="akey",
+            auth_key="aauth",
+        )
+
+        # User B deletes the same device_id — should not affect user A
+        async with _make_auth_client(app, tmp_path) as b_client:
+            resp = await b_client.delete(
+                "/api/desktop/browser/push/subscriptions/shared-device-id"
+            )
+            assert resp.status_code == 200
+
+        # User A's subscription must still exist
+        remaining = await store.list_push_subscriptions(user_id=user_a_id)
+        assert any(s["device_id"] == "shared-device-id" for s in remaining)

--- a/tests/routes/desktop_browser/test_push_routes.py
+++ b/tests/routes/desktop_browser/test_push_routes.py
@@ -4,14 +4,6 @@ from __future__ import annotations
 import base64
 
 import pytest
-from tinyagentos.routes.desktop_browser import push_routes
-
-
-@pytest.fixture(autouse=True)
-def reset_vapid_cache():
-    push_routes._vapid_cache = None
-    yield
-    push_routes._vapid_cache = None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/routes/desktop_browser/test_push_routes.py
+++ b/tests/routes/desktop_browser/test_push_routes.py
@@ -4,6 +4,14 @@ from __future__ import annotations
 import base64
 
 import pytest
+from tinyagentos.routes.desktop_browser import push_routes
+
+
+@pytest.fixture(autouse=True)
+def reset_vapid_cache():
+    push_routes._vapid_cache = None
+    yield
+    push_routes._vapid_cache = None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/routes/desktop_browser/test_push_send.py
+++ b/tests/routes/desktop_browser/test_push_send.py
@@ -1,0 +1,290 @@
+"""Tests for tinyagentos.routes.desktop_browser.push.send()."""
+from __future__ import annotations
+
+import asyncio
+import requests
+from unittest.mock import patch, MagicMock
+
+import pytest
+import pytest_asyncio
+
+from tinyagentos.routes.desktop_browser import push as push_module
+from tinyagentos.routes.desktop_browser.push import _RateLimiter, send
+from tinyagentos.routes.desktop_browser.vapid import load_or_create_vapid_keypair
+from tinyagentos.routes.desktop_browser.store import BrowserStore
+from pywebpush import WebPushException
+
+
+# ---------------------------------------------------------------------------
+# Module-level: generate a real VAPID keypair once for all tests.
+# We need a real PEM because pywebpush parses the private key; only the PEM
+# is actually used by push.send() (public key isn't passed to pywebpush).
+# ---------------------------------------------------------------------------
+
+import pathlib
+import tempfile
+
+_VAPID_TMPDIR = tempfile.mkdtemp()
+_vapid_pub, _vapid_priv = load_or_create_vapid_keypair(pathlib.Path(_VAPID_TMPDIR))
+FAKE_VAPID = (_vapid_pub, _vapid_priv)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_ENDPOINT_A = "https://push.example.com/sub/device_a"
+_ENDPOINT_B = "https://push.example.com/sub/device_b"
+_PAYLOAD = {"title": "Test", "body": "Hello"}
+
+
+def _make_response(status_code: int) -> requests.Response:
+    """Construct a requests.Response with the given status code."""
+    r = requests.Response()
+    r.status_code = status_code
+    r.reason = str(status_code)
+    return r
+
+
+def _raise_410(subscription_info, data, vapid_private_key, vapid_claims, timeout=None):
+    r = _make_response(410)
+    raise WebPushException("Push failed: 410", response=r)
+
+
+def _raise_429(subscription_info, data, vapid_private_key, vapid_claims, timeout=None):
+    r = _make_response(429)
+    raise WebPushException("Push failed: 429", response=r)
+
+
+def _raise_503(subscription_info, data, vapid_private_key, vapid_claims, timeout=None):
+    r = _make_response(503)
+    raise WebPushException("Push failed: 503", response=r)
+
+
+def _return_ok(subscription_info, data, vapid_private_key, vapid_claims, timeout=None):
+    return _make_response(201)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture
+async def store(tmp_path):
+    s = BrowserStore(tmp_path / "browser.sqlite3")
+    await s.init()
+    yield s
+    await s.close()
+
+
+@pytest.fixture(autouse=True)
+def reset_rate_limiter():
+    """Reset the module-level rate limiter before and after every test."""
+    push_module._rate_limiter = _RateLimiter()
+    yield
+    push_module._rate_limiter = _RateLimiter()
+
+
+# ---------------------------------------------------------------------------
+# 1. Happy path: 201 → sent
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_happy_path_201_sent(store):
+    await store.upsert_push_subscription(
+        "user1", "device_a",
+        endpoint=_ENDPOINT_A,
+        p256dh_key="p256dh_fake",
+        auth_key="auth_fake",
+    )
+
+    with patch("tinyagentos.routes.desktop_browser.push._sync_send", side_effect=_return_ok):
+        result = await send("user1", _PAYLOAD, store=store, vapid=FAKE_VAPID)
+
+    assert result == {"sent": 1, "failed": 0, "removed": 0}
+
+    # Subscription must still exist
+    subs = await store.list_push_subscriptions("user1")
+    assert len(subs) == 1
+
+
+# ---------------------------------------------------------------------------
+# 2. 410 Gone: subscription deleted
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_410_gone_subscription_deleted(store):
+    await store.upsert_push_subscription(
+        "user1", "device_a",
+        endpoint=_ENDPOINT_A,
+        p256dh_key="p256dh_fake",
+        auth_key="auth_fake",
+    )
+
+    with patch("tinyagentos.routes.desktop_browser.push._sync_send", side_effect=_raise_410):
+        result = await send("user1", _PAYLOAD, store=store, vapid=FAKE_VAPID)
+
+    assert result == {"sent": 0, "failed": 0, "removed": 1}
+
+    # Subscription must be gone
+    subs = await store.list_push_subscriptions("user1")
+    assert subs == []
+
+
+# ---------------------------------------------------------------------------
+# 3. 429: counted as failed, subscription kept
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_429_counted_as_failed_sub_kept(store):
+    await store.upsert_push_subscription(
+        "user1", "device_a",
+        endpoint=_ENDPOINT_A,
+        p256dh_key="p256dh_fake",
+        auth_key="auth_fake",
+    )
+
+    with patch("tinyagentos.routes.desktop_browser.push._sync_send", side_effect=_raise_429):
+        result = await send("user1", _PAYLOAD, store=store, vapid=FAKE_VAPID)
+
+    assert result == {"sent": 0, "failed": 1, "removed": 0}
+
+    # Subscription must still be present
+    subs = await store.list_push_subscriptions("user1")
+    assert len(subs) == 1
+
+
+# ---------------------------------------------------------------------------
+# 4. 5xx: counted as failed, subscription kept
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_503_counted_as_failed_sub_kept(store):
+    await store.upsert_push_subscription(
+        "user1", "device_a",
+        endpoint=_ENDPOINT_A,
+        p256dh_key="p256dh_fake",
+        auth_key="auth_fake",
+    )
+
+    with patch("tinyagentos.routes.desktop_browser.push._sync_send", side_effect=_raise_503):
+        result = await send("user1", _PAYLOAD, store=store, vapid=FAKE_VAPID)
+
+    assert result == {"sent": 0, "failed": 1, "removed": 0}
+
+    subs = await store.list_push_subscriptions("user1")
+    assert len(subs) == 1
+
+
+# ---------------------------------------------------------------------------
+# 5. Rate limit kicks in
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_rate_limit_kicks_in(store):
+    await store.upsert_push_subscription(
+        "user1", "device_a",
+        endpoint=_ENDPOINT_A,
+        p256dh_key="p256dh_fake",
+        auth_key="auth_fake",
+    )
+
+    # Install a tight limiter: 2 per window
+    push_module._rate_limiter = _RateLimiter(limit=2, window_seconds=60)
+
+    call_count = 0
+
+    def _ok_and_count(subscription_info, data, vapid_private_key, vapid_claims, timeout=None):
+        nonlocal call_count
+        call_count += 1
+        return _make_response(201)
+
+    with patch("tinyagentos.routes.desktop_browser.push._sync_send", side_effect=_ok_and_count):
+        r1 = await send("user1", _PAYLOAD, store=store, vapid=FAKE_VAPID)
+        r2 = await send("user1", _PAYLOAD, store=store, vapid=FAKE_VAPID)
+        r3 = await send("user1", _PAYLOAD, store=store, vapid=FAKE_VAPID)
+
+    assert r1 == {"sent": 1, "failed": 0, "removed": 0}
+    assert r2 == {"sent": 1, "failed": 0, "removed": 0}
+    # Third call must be denied by rate limiter; no upstream call
+    assert r3 == {"sent": 0, "failed": 1, "removed": 0}
+    assert call_count == 2, f"Expected exactly 2 upstream calls, got {call_count}"
+
+
+# ---------------------------------------------------------------------------
+# 6. Device filter
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_device_filter(store):
+    await store.upsert_push_subscription(
+        "user1", "device_a",
+        endpoint=_ENDPOINT_A,
+        p256dh_key="p256dh_a",
+        auth_key="auth_a",
+    )
+    await store.upsert_push_subscription(
+        "user1", "device_b",
+        endpoint=_ENDPOINT_B,
+        p256dh_key="p256dh_b",
+        auth_key="auth_b",
+    )
+
+    call_count = 0
+
+    def _ok_and_count(subscription_info, data, vapid_private_key, vapid_claims, timeout=None):
+        nonlocal call_count
+        call_count += 1
+        return _make_response(201)
+
+    with patch("tinyagentos.routes.desktop_browser.push._sync_send", side_effect=_ok_and_count):
+        result = await send(
+            "user1", _PAYLOAD,
+            devices=["device_a"],
+            store=store,
+            vapid=FAKE_VAPID,
+        )
+
+    assert result == {"sent": 1, "failed": 0, "removed": 0}
+    assert call_count == 1, f"Expected exactly 1 upstream call (device filter), got {call_count}"
+
+
+# ---------------------------------------------------------------------------
+# 7. Multi-sub partial failure
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_multi_sub_partial_failure(store):
+    await store.upsert_push_subscription(
+        "user1", "device_a",
+        endpoint=_ENDPOINT_A,
+        p256dh_key="p256dh_a",
+        auth_key="auth_a",
+    )
+    await store.upsert_push_subscription(
+        "user1", "device_b",
+        endpoint=_ENDPOINT_B,
+        p256dh_key="p256dh_b",
+        auth_key="auth_b",
+    )
+
+    def _dispatch(subscription_info, data, vapid_private_key, vapid_claims, timeout=None):
+        endpoint = subscription_info["endpoint"]
+        if endpoint == _ENDPOINT_A:
+            return _make_response(201)
+        # _ENDPOINT_B → 410
+        r = _make_response(410)
+        raise WebPushException("Push failed: 410", response=r)
+
+    with patch("tinyagentos.routes.desktop_browser.push._sync_send", side_effect=_dispatch):
+        result = await send("user1", _PAYLOAD, store=store, vapid=FAKE_VAPID)
+
+    assert result == {"sent": 1, "failed": 0, "removed": 1}
+
+    # 410 sub (device_b / _ENDPOINT_B) must be gone
+    subs = await store.list_push_subscriptions("user1")
+    assert len(subs) == 1
+    assert subs[0]["device_id"] == "device_a"
+
+    # 201 sub (device_a) must still be present
+    assert subs[0]["endpoint"] == _ENDPOINT_A

--- a/tests/routes/desktop_browser/test_push_send.py
+++ b/tests/routes/desktop_browser/test_push_send.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import requests
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import pytest
 import pytest_asyncio
@@ -288,3 +288,22 @@ async def test_multi_sub_partial_failure(store):
 
     # 201 sub (device_a) must still be present
     assert subs[0]["endpoint"] == _ENDPOINT_A
+
+
+# ---------------------------------------------------------------------------
+# 8. Timeout: counted as failed, subscription kept
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_timeout_counted_as_failed(store):
+    await store.upsert_push_subscription("user_a", "device_a", "https://example.com/push", "p", "a")
+
+    # Patch _send_one's executor call site by patching _sync_send to raise
+    # — wait_for catches the exception type and increments failed.
+    with patch.object(push_module, "_sync_send", side_effect=asyncio.TimeoutError()):
+        result = await send(
+            "user_a", {"title": "x"}, store=store, vapid=FAKE_VAPID,
+        )
+    assert result == {"sent": 0, "failed": 1, "removed": 0}
+    rows = await store.list_push_subscriptions("user_a")
+    assert len(rows) == 1  # not deleted on timeout

--- a/tests/routes/desktop_browser/test_push_subscriptions.py
+++ b/tests/routes/desktop_browser/test_push_subscriptions.py
@@ -1,0 +1,219 @@
+"""Tests for BrowserStore push_subscriptions methods."""
+from __future__ import annotations
+
+import time
+
+import pytest
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture
+async def store(tmp_path):
+    from tinyagentos.routes.desktop_browser.store import BrowserStore
+
+    s = BrowserStore(tmp_path / "browser.sqlite3")
+    await s.init()
+    yield s
+    await s.close()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_sub(endpoint="https://push.example.com/sub1", p256dh="key1", auth="auth1"):
+    return dict(endpoint=endpoint, p256dh_key=p256dh, auth_key=auth)
+
+
+# ---------------------------------------------------------------------------
+# 1. Upsert insert
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_upsert_insert_basic(store):
+    """Insert a fresh subscription and verify all fields are returned."""
+    before = int(time.time())
+    await store.upsert_push_subscription(
+        "user_a", "device_1",
+        endpoint="https://push.example.com/sub1",
+        p256dh_key="p256dhkey==",
+        auth_key="authkey==",
+        user_agent="Mozilla/5.0",
+    )
+    after = int(time.time())
+
+    rows = await store.list_push_subscriptions("user_a")
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["device_id"] == "device_1"
+    assert row["endpoint"] == "https://push.example.com/sub1"
+    assert row["p256dh_key"] == "p256dhkey=="
+    assert row["auth_key"] == "authkey=="
+    assert row["user_agent"] == "Mozilla/5.0"
+    assert before <= row["created_at"] <= after
+    assert before <= row["last_seen_at"] <= after
+
+
+# ---------------------------------------------------------------------------
+# 2. Upsert replace preserves created_at
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_upsert_replace_preserves_created_at(store):
+    """Re-upserting same (user, device) updates endpoint/last_seen_at but keeps created_at."""
+    await store.upsert_push_subscription(
+        "user_a", "device_1",
+        endpoint="https://push.example.com/old",
+        p256dh_key="k1",
+        auth_key="a1",
+    )
+    rows = await store.list_push_subscriptions("user_a")
+    original_created_at = rows[0]["created_at"]
+    original_last_seen = rows[0]["last_seen_at"]
+
+    # Advance wall clock by at least 1 second so last_seen_at changes
+    time.sleep(1)
+
+    await store.upsert_push_subscription(
+        "user_a", "device_1",
+        endpoint="https://push.example.com/new",
+        p256dh_key="k2",
+        auth_key="a2",
+    )
+
+    rows = await store.list_push_subscriptions("user_a")
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["created_at"] == original_created_at, "created_at must not change on upsert"
+    assert row["last_seen_at"] > original_last_seen, "last_seen_at must advance"
+    assert row["endpoint"] == "https://push.example.com/new"
+
+
+# ---------------------------------------------------------------------------
+# 3. Multi-user isolation on list
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_list_isolation_by_user(store):
+    """list_push_subscriptions returns only the requesting user's rows."""
+    await store.upsert_push_subscription(
+        "user_a", "device_x",
+        endpoint="https://push.example.com/a",
+        p256dh_key="ka",
+        auth_key="aa",
+    )
+    await store.upsert_push_subscription(
+        "user_b", "device_x",
+        endpoint="https://push.example.com/b",
+        p256dh_key="kb",
+        auth_key="ab",
+    )
+
+    rows_a = await store.list_push_subscriptions("user_a")
+    assert len(rows_a) == 1
+    assert rows_a[0]["endpoint"] == "https://push.example.com/a"
+
+    rows_b = await store.list_push_subscriptions("user_b")
+    assert len(rows_b) == 1
+    assert rows_b[0]["endpoint"] == "https://push.example.com/b"
+
+
+# ---------------------------------------------------------------------------
+# 4. Multi-user isolation on delete
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_delete_isolation_by_user(store):
+    """delete_push_subscription for user_a must not touch user_b's identical device_id."""
+    await store.upsert_push_subscription(
+        "user_a", "device_x",
+        endpoint="https://push.example.com/a",
+        p256dh_key="ka",
+        auth_key="aa",
+    )
+    await store.upsert_push_subscription(
+        "user_b", "device_x",
+        endpoint="https://push.example.com/b",
+        p256dh_key="kb",
+        auth_key="ab",
+    )
+
+    deleted = await store.delete_push_subscription("user_a", "device_x")
+    assert deleted is True
+
+    # user_a's row is gone
+    assert await store.list_push_subscriptions("user_a") == []
+    # user_b's row is untouched
+    rows_b = await store.list_push_subscriptions("user_b")
+    assert len(rows_b) == 1
+    assert rows_b[0]["device_id"] == "device_x"
+
+
+# ---------------------------------------------------------------------------
+# 5. Delete returns False when no row matched
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_delete_returns_false_on_miss(store):
+    result = await store.delete_push_subscription("user_a", "nonexistent_device")
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# 6. Delete by endpoint cleans across users
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_delete_by_endpoint_cross_user(store):
+    """delete_push_subscription_by_endpoint removes matching rows for all users."""
+    shared_endpoint = "https://push.example.com/shared"
+
+    await store.upsert_push_subscription(
+        "user_a", "device_a",
+        endpoint=shared_endpoint,
+        p256dh_key="ka",
+        auth_key="aa",
+    )
+    await store.upsert_push_subscription(
+        "user_b", "device_b",
+        endpoint=shared_endpoint,
+        p256dh_key="kb",
+        auth_key="ab",
+    )
+
+    deleted = await store.delete_push_subscription_by_endpoint(shared_endpoint)
+    assert deleted == 2
+
+    # Both users' rows are gone
+    assert await store.list_push_subscriptions("user_a") == []
+    assert await store.list_push_subscriptions("user_b") == []
+
+
+# ---------------------------------------------------------------------------
+# 7. List ordering — most recent last_seen_at first
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_list_ordering_by_last_seen_at_desc(store):
+    """list_push_subscriptions returns rows newest-first by last_seen_at."""
+    await store.upsert_push_subscription(
+        "user_a", "device_old",
+        endpoint="https://push.example.com/old",
+        p256dh_key="ko",
+        auth_key="ao",
+    )
+
+    time.sleep(1)
+
+    await store.upsert_push_subscription(
+        "user_a", "device_new",
+        endpoint="https://push.example.com/new",
+        p256dh_key="kn",
+        auth_key="an",
+    )
+
+    rows = await store.list_push_subscriptions("user_a")
+    assert len(rows) == 2
+    assert rows[0]["device_id"] == "device_new", "most recently seen device must be first"
+    assert rows[1]["device_id"] == "device_old"
+    assert rows[0]["last_seen_at"] >= rows[1]["last_seen_at"]

--- a/tests/routes/desktop_browser/test_push_subscriptions.py
+++ b/tests/routes/desktop_browser/test_push_subscriptions.py
@@ -217,3 +217,72 @@ async def test_list_ordering_by_last_seen_at_desc(store):
     assert rows[0]["device_id"] == "device_new", "most recently seen device must be first"
     assert rows[1]["device_id"] == "device_old"
     assert rows[0]["last_seen_at"] >= rows[1]["last_seen_at"]
+
+
+# ---------------------------------------------------------------------------
+# 8. Endpoint dedup — same endpoint, different device_id, same user
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_endpoint_dedup_same_user(store):
+    """Re-subscribing with a new device_id but the same endpoint removes the old row."""
+    shared_endpoint = "https://push.example.com/dedup-test"
+
+    # First subscription: device_x with endpoint E.
+    await store.upsert_push_subscription(
+        "user_a", "device_x",
+        endpoint=shared_endpoint,
+        p256dh_key="k1",
+        auth_key="a1",
+    )
+
+    # Second subscription: device_y with same endpoint E — old row must be removed.
+    await store.upsert_push_subscription(
+        "user_a", "device_y",
+        endpoint=shared_endpoint,
+        p256dh_key="k2",
+        auth_key="a2",
+    )
+
+    rows = await store.list_push_subscriptions("user_a")
+    assert len(rows) == 1, "duplicate endpoint rows must be removed"
+    assert rows[0]["device_id"] == "device_y"
+    assert rows[0]["endpoint"] == shared_endpoint
+
+
+@pytest.mark.asyncio
+async def test_endpoint_dedup_does_not_affect_other_users(store):
+    """Dedup within user_a must not remove user_b's row with the same endpoint."""
+    shared_endpoint = "https://push.example.com/cross-user-dedup"
+
+    # user_b subscribes with device_b.
+    await store.upsert_push_subscription(
+        "user_b", "device_b",
+        endpoint=shared_endpoint,
+        p256dh_key="kb",
+        auth_key="ab",
+    )
+
+    # user_a subscribes with device_x, then device_y (same endpoint).
+    await store.upsert_push_subscription(
+        "user_a", "device_x",
+        endpoint=shared_endpoint,
+        p256dh_key="k1",
+        auth_key="a1",
+    )
+    await store.upsert_push_subscription(
+        "user_a", "device_y",
+        endpoint=shared_endpoint,
+        p256dh_key="k2",
+        auth_key="a2",
+    )
+
+    # user_a ends up with exactly one row (device_y).
+    rows_a = await store.list_push_subscriptions("user_a")
+    assert len(rows_a) == 1
+    assert rows_a[0]["device_id"] == "device_y"
+
+    # user_b's row is untouched.
+    rows_b = await store.list_push_subscriptions("user_b")
+    assert len(rows_b) == 1
+    assert rows_b[0]["device_id"] == "device_b"

--- a/tests/routes/desktop_browser/test_push_triggers.py
+++ b/tests/routes/desktop_browser/test_push_triggers.py
@@ -176,6 +176,56 @@ class TestChatPushTrigger:
         mock_send.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_suppressed_by_tab_id_when_window_id_empty(self, store):
+        """Chat push suppressed when window_id is empty but tab_id matches focused tab."""
+        from tinyagentos.routes.desktop_browser.copilot_ws import _maybe_send_chat_push
+
+        hub = _make_hub()
+        # Focused tab is known with full (window_id, tab_id)
+        hub.set_focused_tab("user_a", "real-window", "tab-X")
+
+        with _patch_push_send() as mock_send:
+            # window_id="" but tab_id matches focused tab's tab_id — should suppress
+            await _maybe_send_chat_push(
+                user_id="user_a",
+                agent_id="agent-1",
+                agent_name="Agent",
+                msg_text="hello",
+                window_id="",
+                tab_id="tab-X",
+                store=store,
+                hub=hub,
+                vapid=FAKE_VAPID,
+            )
+
+        mock_send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_fires_when_window_id_empty_and_tab_id_no_match(self, store):
+        """Chat push fires when window_id is empty and tab_id does NOT match focused tab."""
+        from tinyagentos.routes.desktop_browser.copilot_ws import _maybe_send_chat_push
+
+        hub = _make_hub()
+        # Focused tab has tab_id "tab-X"; agent is on a different tab "tab-Y"
+        hub.set_focused_tab("user_a", "real-window", "tab-X")
+
+        with _patch_push_send() as mock_send:
+            mock_send.return_value = {"sent": 1, "failed": 0, "removed": 0}
+            await _maybe_send_chat_push(
+                user_id="user_a",
+                agent_id="agent-1",
+                agent_name="Agent",
+                msg_text="hello",
+                window_id="",
+                tab_id="tab-Y",
+                store=store,
+                hub=hub,
+                vapid=FAKE_VAPID,
+            )
+
+        mock_send.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_body_truncated_to_200_chars(self, store):
         """Long messages are truncated to 200 chars in the push body."""
         from tinyagentos.routes.desktop_browser.copilot_ws import _maybe_send_chat_push

--- a/tests/routes/desktop_browser/test_push_triggers.py
+++ b/tests/routes/desktop_browser/test_push_triggers.py
@@ -543,7 +543,7 @@ class TestNonBlockingPushTriggers:
             task.cancel()
             try:
                 await task
-            except (asyncio.CancelledError, Exception):
+            except asyncio.CancelledError:
                 pass
 
     @pytest.mark.asyncio
@@ -579,7 +579,7 @@ class TestNonBlockingPushTriggers:
             task.cancel()
             try:
                 await task
-            except (asyncio.CancelledError, Exception):
+            except asyncio.CancelledError:
                 pass
 
 

--- a/tests/routes/desktop_browser/test_push_triggers.py
+++ b/tests/routes/desktop_browser/test_push_triggers.py
@@ -1,0 +1,508 @@
+"""Tests for push notification triggers: chat, drive-started, download-finished.
+
+Tests are unit-level — they call the trigger helpers directly with mocked
+push.send so no real push service is contacted.
+
+Subtask F coverage:
+ 1. Chat push fires when user not focused on the agent's pinned tab
+ 2. Chat push suppressed when user IS focused
+ 3. Chat push suppressed when muted
+ 4. Drive push fires on transition into driving
+ 5. Drive push suppressed when focused
+ 6. Drive push suppressed when muted
+ 7. Download push fires on completion
+ 8. Download push suppressed when muted
+ 9. Triggers use asyncio.create_task and do not block the critical path
+"""
+from __future__ import annotations
+
+import asyncio
+import pathlib
+import tempfile
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+
+from tinyagentos.routes.desktop_browser.store import BrowserStore
+from tinyagentos.routes.desktop_browser.vapid import load_or_create_vapid_keypair
+
+
+# ---------------------------------------------------------------------------
+# Shared VAPID keypair for all tests
+# ---------------------------------------------------------------------------
+
+_VAPID_TMPDIR = tempfile.mkdtemp()
+FAKE_VAPID = load_or_create_vapid_keypair(pathlib.Path(_VAPID_TMPDIR))
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture
+async def store(tmp_path):
+    s = BrowserStore(tmp_path / "browser.sqlite3")
+    await s.init()
+    yield s
+    await s.close()
+
+
+def _make_hub():
+    from tinyagentos.routes.desktop_browser.copilot_ws import CopilotHub
+    return CopilotHub()
+
+
+# ---------------------------------------------------------------------------
+# Helper: patch push.send with an AsyncMock
+# ---------------------------------------------------------------------------
+
+def _patch_push_send():
+    """Return a context manager that replaces push.send with an AsyncMock."""
+    return patch(
+        "tinyagentos.routes.desktop_browser.push.send",
+        new_callable=AsyncMock,
+    )
+
+
+# ===========================================================================
+# Subtask C — chat push trigger
+# ===========================================================================
+
+class TestChatPushTrigger:
+
+    @pytest.mark.asyncio
+    async def test_fires_when_user_not_focused_on_agent_tab(self, store):
+        """Chat push fires when focused tab differs from agent's tab."""
+        from tinyagentos.routes.desktop_browser.copilot_ws import _maybe_send_chat_push
+
+        hub = _make_hub()
+        # User is focused on a DIFFERENT (window, tab) pair
+        hub.set_focused_tab("user1", "win-A", "tab-other")
+
+        with _patch_push_send() as mock_send:
+            mock_send.return_value = {"sent": 1, "failed": 0, "removed": 0}
+            await _maybe_send_chat_push(
+                user_id="user1",
+                agent_id="agent-alpha",
+                agent_name="Alpha",
+                msg_text="Hello from agent",
+                window_id="win-A",
+                tab_id="tab-agent",
+                store=store,
+                hub=hub,
+                vapid=FAKE_VAPID,
+            )
+
+        mock_send.assert_awaited_once()
+        call_kwargs = mock_send.call_args
+        payload = call_kwargs.args[1]
+        assert payload["title"] == "Alpha"
+        assert "Hello from agent" in payload["body"]
+        assert payload["tag"] == "chat:agent-alpha"
+        assert payload["data"]["agent_id"] == "agent-alpha"
+
+    @pytest.mark.asyncio
+    async def test_suppressed_when_user_is_focused_on_tab(self, store):
+        """Chat push suppressed when user is focused on the agent's exact tab."""
+        from tinyagentos.routes.desktop_browser.copilot_ws import _maybe_send_chat_push
+
+        hub = _make_hub()
+        # User IS focused on the agent's tab
+        hub.set_focused_tab("user1", "win-A", "tab-agent")
+
+        with _patch_push_send() as mock_send:
+            await _maybe_send_chat_push(
+                user_id="user1",
+                agent_id="agent-alpha",
+                agent_name="Alpha",
+                msg_text="You can see this already",
+                window_id="win-A",
+                tab_id="tab-agent",
+                store=store,
+                hub=hub,
+                vapid=FAKE_VAPID,
+            )
+
+        mock_send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_suppressed_when_muted(self, store):
+        """Chat push suppressed when the user has muted chat for this agent."""
+        from tinyagentos.routes.desktop_browser.copilot_ws import _maybe_send_chat_push
+
+        hub = _make_hub()
+        # User is NOT focused, but has muted chat for this agent
+        hub.set_focused_tab("user1", "win-A", "tab-other")
+        await store.set_push_mute("user1", "agent-alpha", "chat", True)
+
+        with _patch_push_send() as mock_send:
+            await _maybe_send_chat_push(
+                user_id="user1",
+                agent_id="agent-alpha",
+                agent_name="Alpha",
+                msg_text="This should be muted",
+                window_id="win-A",
+                tab_id="tab-agent",
+                store=store,
+                hub=hub,
+                vapid=FAKE_VAPID,
+            )
+
+        mock_send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_fires_when_no_focused_tab_known(self, store):
+        """Chat push fires when no focused tab has been recorded (None)."""
+        from tinyagentos.routes.desktop_browser.copilot_ws import _maybe_send_chat_push
+
+        hub = _make_hub()
+        # No set_focused_tab call → hub returns None
+
+        with _patch_push_send() as mock_send:
+            mock_send.return_value = {"sent": 0, "failed": 0, "removed": 0}
+            await _maybe_send_chat_push(
+                user_id="user1",
+                agent_id="agent-alpha",
+                agent_name="Alpha",
+                msg_text="Ping",
+                window_id="win-A",
+                tab_id="tab-agent",
+                store=store,
+                hub=hub,
+                vapid=FAKE_VAPID,
+            )
+
+        mock_send.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_body_truncated_to_200_chars(self, store):
+        """Long messages are truncated to 200 chars in the push body."""
+        from tinyagentos.routes.desktop_browser.copilot_ws import _maybe_send_chat_push
+
+        hub = _make_hub()
+
+        with _patch_push_send() as mock_send:
+            mock_send.return_value = {"sent": 1, "failed": 0, "removed": 0}
+            await _maybe_send_chat_push(
+                user_id="user1",
+                agent_id="agent-alpha",
+                agent_name="Alpha",
+                msg_text="x" * 500,
+                window_id="win-A",
+                tab_id="tab-agent",
+                store=store,
+                hub=hub,
+                vapid=FAKE_VAPID,
+            )
+
+        payload = mock_send.call_args.args[1]
+        assert len(payload["body"]) == 200
+
+
+# ===========================================================================
+# Subtask A — CopilotHub focused-tab tracking
+# ===========================================================================
+
+class TestCopilotHubFocusedTab:
+
+    def test_set_and_get_focused_tab(self):
+        hub = _make_hub()
+        assert hub.get_focused_tab("user1") is None
+        hub.set_focused_tab("user1", "win-1", "tab-42")
+        assert hub.get_focused_tab("user1") == ("win-1", "tab-42")
+
+    def test_focused_tab_isolated_per_user(self):
+        hub = _make_hub()
+        hub.set_focused_tab("user-a", "win-1", "tab-1")
+        hub.set_focused_tab("user-b", "win-2", "tab-2")
+        assert hub.get_focused_tab("user-a") == ("win-1", "tab-1")
+        assert hub.get_focused_tab("user-b") == ("win-2", "tab-2")
+
+    def test_get_focused_tab_unknown_user_returns_none(self):
+        hub = _make_hub()
+        assert hub.get_focused_tab("nobody") is None
+
+    def test_set_focused_tab_overwrites_previous(self):
+        hub = _make_hub()
+        hub.set_focused_tab("user1", "win-1", "old-tab")
+        hub.set_focused_tab("user1", "win-1", "new-tab")
+        assert hub.get_focused_tab("user1") == ("win-1", "new-tab")
+
+
+# ===========================================================================
+# Subtask D — drive-started push trigger
+# ===========================================================================
+
+class TestDrivePushTrigger:
+
+    @pytest.mark.asyncio
+    async def test_fires_on_drive_start_when_not_focused(self, store):
+        """Drive push fires on the first drive op when user is not focused."""
+        from tinyagentos.routes.desktop_browser.copilot_agent_ws import _maybe_send_drive_push
+
+        hub = _make_hub()
+        hub.set_focused_tab("user1", "win-A", "tab-other")
+
+        with _patch_push_send() as mock_send:
+            mock_send.return_value = {"sent": 1, "failed": 0, "removed": 0}
+            await _maybe_send_drive_push(
+                user_id="user1",
+                agent_id="agent-beta",
+                agent_name="Beta",
+                target_url="https://github.com/org/repo/issues/1",
+                window_id="win-A",
+                tab_id="tab-agent",
+                store=store,
+                hub=hub,
+                vapid=FAKE_VAPID,
+            )
+
+        mock_send.assert_awaited_once()
+        payload = mock_send.call_args.args[1]
+        assert "started driving" in payload["title"]
+        assert "github.com" in payload["body"]
+        assert payload["tag"].startswith("drive:agent-beta:")
+
+    @pytest.mark.asyncio
+    async def test_suppressed_when_focused_on_drive_tab(self, store):
+        """Drive push suppressed when user is looking at the agent's tab."""
+        from tinyagentos.routes.desktop_browser.copilot_agent_ws import _maybe_send_drive_push
+
+        hub = _make_hub()
+        hub.set_focused_tab("user1", "win-A", "tab-agent")
+
+        with _patch_push_send() as mock_send:
+            await _maybe_send_drive_push(
+                user_id="user1",
+                agent_id="agent-beta",
+                agent_name="Beta",
+                target_url="https://example.com/",
+                window_id="win-A",
+                tab_id="tab-agent",
+                store=store,
+                hub=hub,
+                vapid=FAKE_VAPID,
+            )
+
+        mock_send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_suppressed_when_drive_started_muted(self, store):
+        """Drive push suppressed when the user has muted drive-started for this agent."""
+        from tinyagentos.routes.desktop_browser.copilot_agent_ws import _maybe_send_drive_push
+
+        hub = _make_hub()
+        hub.set_focused_tab("user1", "win-A", "tab-other")
+        await store.set_push_mute("user1", "agent-beta", "drive-started", True)
+
+        with _patch_push_send() as mock_send:
+            await _maybe_send_drive_push(
+                user_id="user1",
+                agent_id="agent-beta",
+                agent_name="Beta",
+                target_url="https://example.com/",
+                window_id="win-A",
+                tab_id="tab-agent",
+                store=store,
+                hub=hub,
+                vapid=FAKE_VAPID,
+            )
+
+        mock_send.assert_not_awaited()
+
+
+# ===========================================================================
+# Subtask E — download-finished push trigger
+# ===========================================================================
+
+class TestDownloadPushTrigger:
+
+    @pytest.mark.asyncio
+    async def test_fires_on_successful_download(self, store):
+        """download push fires after a successful stream completes."""
+        # We test the trigger logic directly via the module-level imports,
+        # exercising _store.is_push_muted and push.send call in streamer().
+        # We simulate by calling the helper logic with a mocked push.send.
+
+        with _patch_push_send() as mock_send:
+            mock_send.return_value = {"sent": 1, "failed": 0, "removed": 0}
+
+            # Simulate what streamer() does on success
+            user_id = "user1"
+            final_name = "report.pdf"
+            download_id = "abc12345"
+
+            if not await store.is_push_muted(user_id, "system", "download-finished"):
+                import tinyagentos.routes.desktop_browser.push as push_mod
+                payload = {
+                    "title": "Download finished",
+                    "body": final_name,
+                    "tag": f"download:{download_id}",
+                    "data": {"window_id": "", "tab_id": ""},
+                }
+                await push_mod.send(user_id, payload, store=store, vapid=FAKE_VAPID)
+
+        mock_send.assert_awaited_once()
+        call_payload = mock_send.call_args.args[1]
+        assert call_payload["title"] == "Download finished"
+        assert call_payload["body"] == "report.pdf"
+        assert "download:" in call_payload["tag"]
+
+    @pytest.mark.asyncio
+    async def test_suppressed_when_download_finished_muted(self, store):
+        """Download push suppressed when the user has muted download-finished."""
+        await store.set_push_mute("user1", "system", "download-finished", True)
+
+        with _patch_push_send() as mock_send:
+            # Simulate what streamer() does — checks mute first
+            user_id = "user1"
+            if not await store.is_push_muted(user_id, "system", "download-finished"):
+                import tinyagentos.routes.desktop_browser.push as push_mod
+                await push_mod.send(
+                    user_id,
+                    {"title": "Download finished", "body": "file.zip"},
+                    store=store,
+                    vapid=FAKE_VAPID,
+                )
+
+        mock_send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_uses_system_agent_id_for_mute_key(self, store):
+        """Download mute is keyed on (user, 'system', 'download-finished')."""
+        # Mute for a specific agent should NOT suppress the download push
+        await store.set_push_mute("user1", "some-agent", "download-finished", True)
+
+        with _patch_push_send() as mock_send:
+            mock_send.return_value = {"sent": 0, "failed": 0, "removed": 0}
+            user_id = "user1"
+            # "system" mute is NOT set — push should fire
+            if not await store.is_push_muted(user_id, "system", "download-finished"):
+                import tinyagentos.routes.desktop_browser.push as push_mod
+                await push_mod.send(
+                    user_id,
+                    {"title": "Download finished", "body": "file.zip",
+                     "tag": "download:abc", "data": {}},
+                    store=store,
+                    vapid=FAKE_VAPID,
+                )
+
+        mock_send.assert_awaited_once()
+
+
+# ===========================================================================
+# Test 9 — Non-blocking: create_task doesn't block critical path
+# ===========================================================================
+
+class TestNonBlockingPushTriggers:
+
+    @pytest.mark.asyncio
+    async def test_chat_push_does_not_block_when_push_is_slow(self, store):
+        """If push.send is slow, the asyncio.create_task wrapper means the
+        caller completes before push.send finishes."""
+        from tinyagentos.routes.desktop_browser.copilot_ws import _maybe_send_chat_push
+
+        hub = _make_hub()
+        send_started = asyncio.Event()
+        send_finished = asyncio.Event()
+
+        async def slow_send(*args, **kwargs):
+            send_started.set()
+            # Simulate a push that takes a long time
+            await asyncio.sleep(0.5)
+            send_finished.set()
+            return {"sent": 1, "failed": 0, "removed": 0}
+
+        with patch(
+            "tinyagentos.routes.desktop_browser.push.send",
+            side_effect=slow_send,
+        ):
+            # Wrap the call in a task the same way the real code does
+            task = asyncio.create_task(_maybe_send_chat_push(
+                user_id="user1",
+                agent_id="agent-slow",
+                agent_name="Slow",
+                msg_text="ping",
+                window_id="win-A",
+                tab_id="tab-x",
+                store=store,
+                hub=hub,
+                vapid=FAKE_VAPID,
+            ))
+            # The task starts but we don't await it — caller can proceed immediately
+            # Give event loop a chance to start the task
+            await asyncio.sleep(0)
+            # At this point, the critical path (chat broadcast) would have already
+            # returned. The push may or may not have started yet depending on
+            # scheduling, but the task is queued.
+            assert not send_finished.is_set(), (
+                "push.send should not have completed yet — it takes 0.5s"
+            )
+            # Clean up by cancelling
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):
+                pass
+
+    @pytest.mark.asyncio
+    async def test_drive_push_does_not_block_when_push_is_slow(self, store):
+        """Same non-blocking property for drive push via create_task."""
+        from tinyagentos.routes.desktop_browser.copilot_agent_ws import _maybe_send_drive_push
+
+        hub = _make_hub()
+        send_finished = asyncio.Event()
+
+        async def slow_send(*args, **kwargs):
+            await asyncio.sleep(0.5)
+            send_finished.set()
+            return {"sent": 1, "failed": 0, "removed": 0}
+
+        with patch(
+            "tinyagentos.routes.desktop_browser.push.send",
+            side_effect=slow_send,
+        ):
+            task = asyncio.create_task(_maybe_send_drive_push(
+                user_id="user1",
+                agent_id="agent-slow-drive",
+                agent_name="SlowDrive",
+                target_url="https://example.com/",
+                window_id="win-A",
+                tab_id="tab-y",
+                store=store,
+                hub=hub,
+                vapid=FAKE_VAPID,
+            ))
+            await asyncio.sleep(0)
+            assert not send_finished.is_set()
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):
+                pass
+
+
+# ===========================================================================
+# _short_url helper
+# ===========================================================================
+
+class TestShortUrl:
+    def test_truncates_long_path(self):
+        from tinyagentos.routes.desktop_browser.copilot_agent_ws import _short_url
+        result = _short_url("https://github.com/org/repo/issues/123")
+        assert result == "github.com/org/repo/..."
+
+    def test_short_path_not_truncated(self):
+        from tinyagentos.routes.desktop_browser.copilot_agent_ws import _short_url
+        result = _short_url("https://example.com/foo")
+        assert result == "example.com/foo"
+
+    def test_empty_string_returned_as_is(self):
+        from tinyagentos.routes.desktop_browser.copilot_agent_ws import _short_url
+        assert _short_url("") == ""
+
+    def test_root_path(self):
+        from tinyagentos.routes.desktop_browser.copilot_agent_ws import _short_url
+        result = _short_url("https://github.com/")
+        assert result.startswith("github.com")

--- a/tests/routes/desktop_browser/test_push_triggers.py
+++ b/tests/routes/desktop_browser/test_push_triggers.py
@@ -288,6 +288,56 @@ class TestDrivePushTrigger:
         mock_send.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_suppressed_by_tab_id_when_window_id_empty(self, store):
+        """Drive push suppressed when window_id is empty but tab_id matches focused tab."""
+        from tinyagentos.routes.desktop_browser.copilot_agent_ws import _maybe_send_drive_push
+
+        hub = _make_hub()
+        # Focused tab is known with full (window_id, tab_id)
+        hub.set_focused_tab("user1", "real-window", "tab-X")
+
+        with _patch_push_send() as mock_send:
+            # window_id="" but tab_id matches focused tab's tab_id — should suppress
+            await _maybe_send_drive_push(
+                user_id="user1",
+                agent_id="agent-beta",
+                agent_name="Beta",
+                target_url="https://example.com/",
+                window_id="",
+                tab_id="tab-X",
+                store=store,
+                hub=hub,
+                vapid=FAKE_VAPID,
+            )
+
+        mock_send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_fires_when_window_id_empty_and_tab_id_no_match(self, store):
+        """Drive push fires when window_id is empty and tab_id does NOT match focused tab."""
+        from tinyagentos.routes.desktop_browser.copilot_agent_ws import _maybe_send_drive_push
+
+        hub = _make_hub()
+        # Focused tab has tab_id "tab-X"; agent is on a different tab "tab-Y"
+        hub.set_focused_tab("user1", "real-window", "tab-X")
+
+        with _patch_push_send() as mock_send:
+            mock_send.return_value = {"sent": 1, "failed": 0, "removed": 0}
+            await _maybe_send_drive_push(
+                user_id="user1",
+                agent_id="agent-beta",
+                agent_name="Beta",
+                target_url="https://example.com/",
+                window_id="",
+                tab_id="tab-Y",
+                store=store,
+                hub=hub,
+                vapid=FAKE_VAPID,
+            )
+
+        mock_send.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_suppressed_when_drive_started_muted(self, store):
         """Drive push suppressed when the user has muted drive-started for this agent."""
         from tinyagentos.routes.desktop_browser.copilot_agent_ws import _maybe_send_drive_push

--- a/tests/routes/desktop_browser/test_vapid.py
+++ b/tests/routes/desktop_browser/test_vapid.py
@@ -1,0 +1,51 @@
+"""Tests for VAPID keypair bootstrap."""
+from __future__ import annotations
+
+import base64
+import os
+import time
+
+import pytest
+
+
+class TestLoadOrCreateVapidKeypair:
+    def test_first_call_generates_and_persists(self, tmp_path):
+        from tinyagentos.routes.desktop_browser.vapid import load_or_create_vapid_keypair
+
+        pub, priv = load_or_create_vapid_keypair(tmp_path)
+
+        pem_path = tmp_path / "vapid.pem"
+        assert pem_path.exists()
+        assert isinstance(pub, str)
+        assert isinstance(priv, str)
+
+        # Uncompressed P-256 point: 0x04 prefix + 32 bytes X + 32 bytes Y = 65 bytes.
+        # base64url without padding → 87 chars; decode must yield exactly 65 bytes.
+        decoded = base64.urlsafe_b64decode(pub + "==")  # pad generously before decode
+        assert len(decoded) == 65
+        assert decoded[0] == 0x04
+
+    def test_second_call_returns_same_keys(self, tmp_path):
+        from tinyagentos.routes.desktop_browser.vapid import load_or_create_vapid_keypair
+
+        pub1, priv1 = load_or_create_vapid_keypair(tmp_path)
+
+        pem_path = tmp_path / "vapid.pem"
+        mtime_before = pem_path.stat().st_mtime
+
+        time.sleep(0.01)
+
+        pub2, priv2 = load_or_create_vapid_keypair(tmp_path)
+
+        assert pub2 == pub1
+        assert priv2 == priv1
+        assert pem_path.stat().st_mtime == mtime_before
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX file modes not applicable on Windows")
+    def test_file_mode_is_0600(self, tmp_path):
+        from tinyagentos.routes.desktop_browser.vapid import load_or_create_vapid_keypair
+
+        load_or_create_vapid_keypair(tmp_path)
+
+        pem_path = tmp_path / "vapid.pem"
+        assert os.stat(pem_path).st_mode & 0o777 == 0o600

--- a/tests/routes/desktop_browser/test_vapid.py
+++ b/tests/routes/desktop_browser/test_vapid.py
@@ -49,3 +49,17 @@ class TestLoadOrCreateVapidKeypair:
 
         pem_path = tmp_path / "vapid.pem"
         assert os.stat(pem_path).st_mode & 0o777 == 0o600
+
+    def test_creates_missing_data_dir(self, tmp_path):
+        """data_dir that does not yet exist is created automatically."""
+        from tinyagentos.routes.desktop_browser.vapid import load_or_create_vapid_keypair
+
+        subdir = tmp_path / "subdir"
+        assert not subdir.exists()
+
+        pub, priv = load_or_create_vapid_keypair(subdir)
+
+        assert subdir.exists()
+        assert (subdir / "vapid.pem").exists()
+        assert isinstance(pub, str)
+        assert isinstance(priv, str)

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -899,6 +899,9 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     app.state.copilot_ticket_store = _CopilotTicketStore()
     app.state.copilot_hub = _CopilotHub()
 
+    from tinyagentos.routes.desktop_browser.vapid import load_or_create_vapid_keypair as _load_vapid
+    app.state.vapid_keypair = _load_vapid(data_dir)
+
     # Detect and set container runtime (eager, so tests work without lifespan)
     try:
         from tinyagentos.containers.backend import detect_runtime, set_backend

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -359,6 +359,9 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         app.state.copilot_ticket_store = CopilotTicketStore()
         app.state.copilot_hub = CopilotHub()
 
+        from tinyagentos.routes.desktop_browser.vapid import load_or_create_vapid_keypair
+        app.state.vapid_keypair = load_or_create_vapid_keypair(data_dir)
+
         await benchmark_store.init()
         await scheduler_history_store.init()
         app.state.config = config

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -5,7 +5,7 @@ from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import RedirectResponse
 
-EXEMPT_PATHS = {"/auth/login", "/auth/setup", "/auth/status", "/auth/me", "/auth/complete", "/auth/lock", "/api/health", "/api/cluster/workers", "/api/cluster/heartbeat", "/setup", "/setup/complete", "/redeem"}
+EXEMPT_PATHS = {"/auth/login", "/auth/setup", "/auth/status", "/auth/me", "/auth/complete", "/auth/lock", "/api/health", "/api/cluster/workers", "/api/cluster/heartbeat", "/setup", "/setup/complete", "/redeem", "/api/desktop/browser/push/vapid-public-key"}
 # Bundle assets must be reachable without auth so the SPA can paint the
 # login screen. The SPA shell itself (/desktop and /chat-pwa) goes
 # through the normal auth gate so an unauthenticated request hits a

--- a/tinyagentos/routes/desktop_browser/__init__.py
+++ b/tinyagentos/routes/desktop_browser/__init__.py
@@ -22,4 +22,5 @@ from tinyagentos.routes.desktop_browser import copilot_agent_ws as _copilot_agen
 from tinyagentos.routes.desktop_browser import capability_routes as _capability_routes  # noqa: E402,F401
 from tinyagentos.routes.desktop_browser import bookmark_routes as _bookmark_routes  # noqa: E402,F401
 from tinyagentos.routes.desktop_browser import site_permission_routes as _site_permission_routes  # noqa: E402,F401
+from tinyagentos.routes.desktop_browser import push_routes as _push_routes  # noqa: E402,F401
 from tinyagentos.routes.desktop_browser import download as _download  # noqa: E402,F401

--- a/tinyagentos/routes/desktop_browser/copilot.js
+++ b/tinyagentos/routes/desktop_browser/copilot.js
@@ -321,6 +321,42 @@
 
   // The parent shell mints a ticket per (tab, agent) and postMessages it into
   // the iframe.  We open one WS per agentId.
+  // ─── Tab focus context ──────────────────────────────────────────────────────
+  // window_id and tab_id are not available inside the sandboxed iframe directly.
+  // The parent shell (TabRenderer.tsx or BrowserApp.tsx) sends them via
+  // postMessage of type 'taos-copilot:tab-focus' whenever the active tab changes.
+  // We cache them here and forward via WS when the iframe receives focus.
+  var _focusWindowId = '';
+  var _focusTabId = '';
+
+  function _sendTabFocusToAll() {
+    if (!_focusWindowId || !_focusTabId) return;
+    var msg = JSON.stringify({
+      event: 'tab-focus',
+      window_id: _focusWindowId,
+      tab_id: _focusTabId,
+    });
+    var ids = Object.keys(_connections);
+    for (var i = 0; i < ids.length; i++) {
+      var ws = _connections[ids[i]];
+      if (ws && ws.readyState === 1) {
+        ws.send(msg);
+      }
+    }
+  }
+
+  // When the iframe window itself gains focus (user clicks into it)
+  window.addEventListener('focus', function () {
+    _sendTabFocusToAll();
+  });
+
+  // When the iframe becomes visible (tab switch back to this tab)
+  document.addEventListener('visibilitychange', function () {
+    if (document.visibilityState === 'visible') {
+      _sendTabFocusToAll();
+    }
+  });
+
   window.addEventListener('message', function (e) {
     // SECURITY: sandbox attribute is "allow-scripts allow-forms allow-popups
     // allow-downloads" (no allow-same-origin), so accessing
@@ -334,6 +370,15 @@
       openConnection(data.ticket, data.agentId);
     } else if (data.type === 'taos-copilot:close' && data.agentId) {
       closeConnection(data.agentId);
+    } else if (data.type === 'taos-copilot:tab-focus' && data.window_id && data.tab_id) {
+      // Parent shell tells us which tab is currently focused (and whether it's
+      // this iframe's tab). We always update and forward — the server checks
+      // whether the stored (window_id, tab_id) matches the agent's pinned tab.
+      _focusWindowId = data.window_id;
+      _focusTabId = data.tab_id;
+      if (data.focused) {
+        _sendTabFocusToAll();
+      }
     }
   });
 

--- a/tinyagentos/routes/desktop_browser/copilot_agent_ws.py
+++ b/tinyagentos/routes/desktop_browser/copilot_agent_ws.py
@@ -21,6 +21,19 @@ from tinyagentos.routes.desktop_browser.copilot_ws import _maybe_send_chat_push
 
 _logger = logging.getLogger(__name__)
 
+# Strong references to fire-and-forget background tasks. Without this, CPython
+# may GC a task before it completes; exceptions would also be silently swallowed.
+_BACKGROUND_TASKS: set[asyncio.Task] = set()
+
+
+def _log_task_exception(task: asyncio.Task) -> None:
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        _logger.warning("background push task failed: %s", exc)
+
+
 _DRIVE_OPS = {"scrollTo", "click", "type", "navigate", "focus"}
 
 # Privileged ops and the permission required to execute them.
@@ -223,7 +236,7 @@ async def copilot_agent_ws(websocket: WebSocket, ticket: str):
                 vapid = getattr(websocket.app.state, "vapid_keypair", None)
                 if vapid is not None:
                     try:
-                        asyncio.create_task(_maybe_send_chat_push(
+                        _task = asyncio.create_task(_maybe_send_chat_push(
                             user_id=consumed.user_id,
                             agent_id=consumed.agent_id,
                             agent_name=consumed.agent_id,
@@ -234,6 +247,9 @@ async def copilot_agent_ws(websocket: WebSocket, ticket: str):
                             hub=hub,
                             vapid=vapid,
                         ))
+                        _BACKGROUND_TASKS.add(_task)
+                        _task.add_done_callback(_BACKGROUND_TASKS.discard)
+                        _task.add_done_callback(_log_task_exception)
                     except Exception:
                         _logger.warning(
                             "chat push trigger setup failed", exc_info=True
@@ -264,7 +280,7 @@ async def copilot_agent_ws(websocket: WebSocket, ticket: str):
                     vapid = getattr(websocket.app.state, "vapid_keypair", None)
                     if vapid is not None:
                         try:
-                            asyncio.create_task(_maybe_send_drive_push(
+                            _task = asyncio.create_task(_maybe_send_drive_push(
                                 user_id=consumed.user_id,
                                 agent_id=consumed.agent_id,
                                 agent_name=agent_name,
@@ -275,6 +291,9 @@ async def copilot_agent_ws(websocket: WebSocket, ticket: str):
                                 hub=hub,
                                 vapid=vapid,
                             ))
+                            _BACKGROUND_TASKS.add(_task)
+                            _task.add_done_callback(_BACKGROUND_TASKS.discard)
+                            _task.add_done_callback(_log_task_exception)
                         except Exception:
                             _logger.warning(
                                 "drive push trigger setup failed", exc_info=True

--- a/tinyagentos/routes/desktop_browser/copilot_agent_ws.py
+++ b/tinyagentos/routes/desktop_browser/copilot_agent_ws.py
@@ -8,13 +8,15 @@ regardless of how many tabs it's pinned to. The ticket's tab_id determines the
 """
 from __future__ import annotations
 
+import asyncio
 import logging
+from typing import Any
 from urllib.parse import urlparse
 
 from fastapi import WebSocket
 from starlette.websockets import WebSocketDisconnect
 
-from tinyagentos.routes.desktop_browser import router
+from tinyagentos.routes.desktop_browser import push, router
 
 _logger = logging.getLogger(__name__)
 
@@ -36,6 +38,58 @@ for _perm, _ops in PRIVILEGED_OPS.items():
 
 def _required_permission(op: str) -> str | None:
     return OP_TO_PERMISSION.get(op)
+
+
+def _short_url(url: str) -> str:
+    """Return host + truncated path for display in push notifications.
+
+    e.g. 'https://github.com/foo/bar/baz/qux' → 'github.com/foo/bar/...'
+    """
+    if not url:
+        return url
+    try:
+        parsed = urlparse(url)
+        host = parsed.hostname or ""
+        path = parsed.path or ""
+        # Truncate path to first 2 segments for brevity
+        parts = [p for p in path.split("/") if p]
+        if len(parts) > 2:
+            short_path = "/" + "/".join(parts[:2]) + "/..."
+        else:
+            short_path = path
+        return host + short_path
+    except Exception:
+        return url[:60]
+
+
+async def _maybe_send_drive_push(
+    user_id: str,
+    agent_id: str,
+    agent_name: str,
+    target_url: str,
+    window_id: str,
+    tab_id: str,
+    store: Any,
+    hub: Any,
+    vapid: tuple[str, str],
+) -> None:
+    """Send a push notification when the agent starts driving a tab, unless
+    the user is already focused on that tab or has muted drive-started alerts."""
+    from tinyagentos.routes.desktop_browser.store import BrowserStore
+    if not isinstance(store, BrowserStore):
+        return
+    if await store.is_push_muted(user_id, agent_id, "drive-started"):
+        return
+    focused = hub.get_focused_tab(user_id)
+    if focused == (window_id, tab_id):
+        return
+    payload = {
+        "title": f"{agent_name or 'Agent'} started driving",
+        "body": _short_url(target_url),
+        "tag": f"drive:{agent_id}:{tab_id}",
+        "data": {"window_id": window_id, "tab_id": tab_id, "agent_id": agent_id},
+    }
+    await push.send(user_id, payload, store=store, vapid=vapid)
 
 
 def _trusted_host(server_url: str | None) -> str:
@@ -164,12 +218,38 @@ async def copilot_agent_ws(websocket: WebSocket, ticket: str):
                     agent_id=consumed.agent_id,
                 )
                 if not bumped:
+                    # First drive op of this session — start the session and
+                    # fire a push notification (non-blocking).
                     await store.start_drive_session(
                         user_id=consumed.user_id,
                         profile_id=target_profile,
                         tab_id=target_tab,
                         agent_id=consumed.agent_id,
                     )
+                    target_url = hub.get_tab_url(
+                        user_id=consumed.user_id,
+                        profile_id=target_profile,
+                        tab_id=target_tab,
+                    ) or ""
+                    agent_name = consumed.agent_id  # best available identifier
+                    vapid = getattr(websocket.app.state, "vapid_keypair", None)
+                    if vapid is not None:
+                        try:
+                            asyncio.create_task(_maybe_send_drive_push(
+                                user_id=consumed.user_id,
+                                agent_id=consumed.agent_id,
+                                agent_name=agent_name,
+                                target_url=target_url,
+                                window_id="",
+                                tab_id=target_tab,
+                                store=store,
+                                hub=hub,
+                                vapid=vapid,
+                            ))
+                        except Exception:
+                            _logger.warning(
+                                "drive push trigger setup failed", exc_info=True
+                            )
     except WebSocketDisconnect:
         pass
     finally:

--- a/tinyagentos/routes/desktop_browser/copilot_agent_ws.py
+++ b/tinyagentos/routes/desktop_browser/copilot_agent_ws.py
@@ -17,6 +17,7 @@ from fastapi import WebSocket
 from starlette.websockets import WebSocketDisconnect
 
 from tinyagentos.routes.desktop_browser import push, router
+from tinyagentos.routes.desktop_browser.copilot_ws import _maybe_send_chat_push
 
 _logger = logging.getLogger(__name__)
 
@@ -81,8 +82,14 @@ async def _maybe_send_drive_push(
     if await store.is_push_muted(user_id, agent_id, "drive-started"):
         return
     focused = hub.get_focused_tab(user_id)
-    if focused == (window_id, tab_id):
-        return
+    if focused is not None:
+        if window_id:
+            if focused == (window_id, tab_id):
+                return
+        else:
+            # window_id unknown at the agent WS — fall back to tab_id match.
+            if focused[1] == tab_id:
+                return
     payload = {
         "title": f"{agent_name or 'Agent'} started driving",
         "body": _short_url(target_url),
@@ -209,6 +216,28 @@ async def copilot_agent_ws(websocket: WebSocket, ticket: str):
                     "reason": "iframe not connected",
                 })
                 continue
+
+            # Chat push trigger — fire for chat-message ops (non-blocking).
+            if op == "chat-message":
+                msg_text = str(msg.get("text") or "")
+                vapid = getattr(websocket.app.state, "vapid_keypair", None)
+                if vapid is not None:
+                    try:
+                        asyncio.create_task(_maybe_send_chat_push(
+                            user_id=consumed.user_id,
+                            agent_id=consumed.agent_id,
+                            agent_name=consumed.agent_id,
+                            msg_text=msg_text,
+                            window_id="",
+                            tab_id=target_tab,
+                            store=store,
+                            hub=hub,
+                            vapid=vapid,
+                        ))
+                    except Exception:
+                        _logger.warning(
+                            "chat push trigger setup failed", exc_info=True
+                        )
 
             if op in _DRIVE_OPS:
                 bumped = await store.bump_drive_session(

--- a/tinyagentos/routes/desktop_browser/copilot_ws.py
+++ b/tinyagentos/routes/desktop_browser/copilot_ws.py
@@ -180,6 +180,15 @@ class CopilotHub:
         """Return (window_id, tab_id) of the user's focused tab, or None if unknown."""
         return self._focused_tabs.get(user_id)
 
+    def clear_focused_tab_if_matches(
+        self, user_id: str, window_id: str, tab_id: str,
+    ) -> None:
+        """Clear focused-tab cache if it matches the disconnecting tab. Prevents
+        stale focus state from suppressing pushes after a tab/window closes."""
+        current = self._focused_tabs.get(user_id)
+        if current == (window_id, tab_id):
+            del self._focused_tabs[user_id]
+
     def set_tab_url(
         self, *, user_id: str, profile_id: str, tab_id: str, url: str,
     ) -> None:
@@ -389,6 +398,9 @@ async def copilot_ws(websocket: WebSocket, ticket: str):
         agent_id=consumed.agent_id,
         ws=websocket,
     )
+    # Track the (window_id, tab_id) this connection last reported as focused,
+    # so we can clear stale focus state when this connection closes.
+    _last_focus: tuple[str, str] | None = None
     try:
         while True:
             message = await websocket.receive_json()
@@ -409,6 +421,7 @@ async def copilot_ws(websocket: WebSocket, ticket: str):
                 tab_id = message.get("tab_id", "")
                 if window_id and tab_id:
                     hub.set_focused_tab(consumed.user_id, window_id, tab_id)
+                    _last_focus = (window_id, tab_id)
     except WebSocketDisconnect:
         pass
     finally:
@@ -418,3 +431,7 @@ async def copilot_ws(websocket: WebSocket, ticket: str):
             tab_id=consumed.tab_id,
             agent_id=consumed.agent_id,
         )
+        if _last_focus is not None:
+            hub.clear_focused_tab_if_matches(
+                consumed.user_id, _last_focus[0], _last_focus[1],
+            )

--- a/tinyagentos/routes/desktop_browser/copilot_ws.py
+++ b/tinyagentos/routes/desktop_browser/copilot_ws.py
@@ -340,8 +340,14 @@ async def _maybe_send_chat_push(
         return
     # Check focus
     focused = hub.get_focused_tab(user_id)
-    if focused == (window_id, tab_id):
-        return  # User is looking right at this tab — don't push
+    if focused is not None:
+        if window_id:
+            if focused == (window_id, tab_id):
+                return
+        else:
+            # window_id unknown at the agent WS — fall back to tab_id match.
+            if focused[1] == tab_id:
+                return
     payload = {
         "title": agent_name or "Agent",
         "body": msg_text[:200],

--- a/tinyagentos/routes/desktop_browser/copilot_ws.py
+++ b/tinyagentos/routes/desktop_browser/copilot_ws.py
@@ -20,6 +20,7 @@ from starlette.websockets import WebSocketDisconnect
 
 from tinyagentos.auth import get_current_user
 from tinyagentos.routes.desktop_browser import router
+from tinyagentos.routes.desktop_browser import push
 
 _logger = logging.getLogger(__name__)
 
@@ -164,6 +165,20 @@ class CopilotHub:
         # in copilot_agent_ws.py. The agent-supplied msg["host"] is NOT trusted
         # for authorization; this tracker is the source of truth.
         self._tab_urls: dict[tuple[str, str, str], str] = {}
+        # Focused tab tracker: user_id → (window_id, tab_id) of the tab the user
+        # is currently looking at. Updated via 'tab-focus' WS messages from the
+        # iframe. Used by push triggers to suppress notifications when the user is
+        # already looking at the relevant tab.
+        self._focused_tabs: dict[str, tuple[str, str]] = {}
+
+    def set_focused_tab(self, user_id: str, window_id: str, tab_id: str) -> None:
+        """Track which tab the user is currently focused on. Called from the
+        iframe-side WS message router when a 'tab-focus' event arrives."""
+        self._focused_tabs[user_id] = (window_id, tab_id)
+
+    def get_focused_tab(self, user_id: str) -> tuple[str, str] | None:
+        """Return (window_id, tab_id) of the user's focused tab, or None if unknown."""
+        return self._focused_tabs.get(user_id)
 
     def set_tab_url(
         self, *, user_id: str, profile_id: str, tab_id: str, url: str,
@@ -299,8 +314,41 @@ class CopilotHub:
 # Allowed event kinds from iframe → server. 'ack' is routed back to the agent runtime.
 _ALLOWED_EVENT_KINDS = {
     "page-changed", "url-changed", "scroll", "form-submit",
-    "download-started", "ack",
+    "download-started", "ack", "tab-focus",
 }
+
+
+async def _maybe_send_chat_push(
+    user_id: str,
+    agent_id: str,
+    agent_name: str,
+    msg_text: str,
+    window_id: str,
+    tab_id: str,
+    store: Any,
+    hub: "CopilotHub",
+    vapid: tuple[str, str],
+) -> None:
+    """Send a push notification for an agent chat message if the user is not
+    currently focused on the agent's pinned tab and they haven't muted chat
+    notifications for this agent."""
+    from tinyagentos.routes.desktop_browser.store import BrowserStore
+    if not isinstance(store, BrowserStore):
+        return
+    # Check mute
+    if await store.is_push_muted(user_id, agent_id, "chat"):
+        return
+    # Check focus
+    focused = hub.get_focused_tab(user_id)
+    if focused == (window_id, tab_id):
+        return  # User is looking right at this tab — don't push
+    payload = {
+        "title": agent_name or "Agent",
+        "body": msg_text[:200],
+        "tag": f"chat:{agent_id}",
+        "data": {"window_id": window_id, "tab_id": tab_id, "agent_id": agent_id},
+    }
+    await push.send(user_id, payload, store=store, vapid=vapid)
 
 
 @router.websocket("/api/desktop/browser/copilot")
@@ -350,6 +398,11 @@ async def copilot_ws(websocket: WebSocket, ticket: str):
                     agent_id=consumed.agent_id,
                     ack=message,
                 )
+            elif event_kind == "tab-focus":
+                window_id = message.get("window_id", "")
+                tab_id = message.get("tab_id", "")
+                if window_id and tab_id:
+                    hub.set_focused_tab(consumed.user_id, window_id, tab_id)
     except WebSocketDisconnect:
         pass
     finally:

--- a/tinyagentos/routes/desktop_browser/download.py
+++ b/tinyagentos/routes/desktop_browser/download.py
@@ -28,6 +28,10 @@ from fastapi.responses import JSONResponse, StreamingResponse
 
 from tinyagentos.auth import get_current_user
 from tinyagentos.routes.desktop_browser import push, router
+from tinyagentos.routes.desktop_browser.copilot_agent_ws import (
+    _BACKGROUND_TASKS,
+    _log_task_exception,
+)
 from tinyagentos.routes.desktop_browser.cookie_jar import (
     load_jar_for_request,
     persist_response_cookies,
@@ -213,9 +217,12 @@ async def download_endpoint(
                                 "tab_id": tab_id or "",
                             },
                         }
-                        asyncio.create_task(
+                        _task = asyncio.create_task(
                             push.send(user_id, payload, store=_store, vapid=_vapid)
                         )
+                        _BACKGROUND_TASKS.add(_task)
+                        _task.add_done_callback(_BACKGROUND_TASKS.discard)
+                        _task.add_done_callback(_log_task_exception)
                 except Exception:
                     _logger.warning("download push trigger failed", exc_info=True)
 

--- a/tinyagentos/routes/desktop_browser/download.py
+++ b/tinyagentos/routes/desktop_browser/download.py
@@ -14,9 +14,11 @@ to the client.
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import re
+import uuid
 from typing import Any
 from urllib.parse import quote, unquote, urljoin, urlparse, urlsplit
 
@@ -25,7 +27,7 @@ from fastapi import Depends, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 
 from tinyagentos.auth import get_current_user
-from tinyagentos.routes.desktop_browser import router
+from tinyagentos.routes.desktop_browser import push, router
 from tinyagentos.routes.desktop_browser.cookie_jar import (
     load_jar_for_request,
     persist_response_cookies,
@@ -113,6 +115,8 @@ async def download_endpoint(
     profile_id: str,
     url: str,
     filename: str | None = None,
+    window_id: str | None = None,
+    tab_id: str | None = None,
     current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
 ):
     """Stream an upstream file through the proxy as a browser download.
@@ -173,10 +177,16 @@ async def download_endpoint(
         filename or upstream_filename or _filename_from_url(final_url)
     )
 
+    download_id = uuid.uuid4().hex[:8]
+    _store = getattr(request.app.state, "browser_store", None)
+    _vapid = getattr(request.app.state, "vapid_keypair", None)
+
     async def streamer():
+        _stream_ok = False
         try:
             async for chunk in response.aiter_bytes():
                 yield chunk
+            _stream_ok = True
             try:
                 await persist_response_cookies(
                     request.app.state.browser_cookie_store,
@@ -191,6 +201,23 @@ async def download_endpoint(
         finally:
             await response.aclose()
             await http.aclose()
+            if _stream_ok and _store is not None and _vapid is not None:
+                try:
+                    if not await _store.is_push_muted(user_id, "system", "download-finished"):
+                        payload = {
+                            "title": "Download finished",
+                            "body": final_name,
+                            "tag": f"download:{download_id}",
+                            "data": {
+                                "window_id": window_id or "",
+                                "tab_id": tab_id or "",
+                            },
+                        }
+                        asyncio.create_task(
+                            push.send(user_id, payload, store=_store, vapid=_vapid)
+                        )
+                except Exception:
+                    _logger.warning("download push trigger failed", exc_info=True)
 
     # RFC 5987 encoded filename for non-ASCII safety
     safe_quoted = quote(final_name, safe="")

--- a/tinyagentos/routes/desktop_browser/push.py
+++ b/tinyagentos/routes/desktop_browser/push.py
@@ -1,0 +1,217 @@
+"""Web Push send helper for taOS BrowserApp.
+
+Exposes one public coroutine — ``send()`` — that delivers a push notification
+to every (or a filtered subset of) push subscriptions for a user.
+
+Design notes
+------------
+* pywebpush.webpush() is synchronous (uses requests).  We run it in the
+  default asyncio thread executor so the event loop is never blocked.
+* VAPID keys are NOT instantiated here — the caller (Task 8 triggers) passes
+  the (public_key_b64url, private_key_pem_str) tuple through.  This keeps
+  push.py testable without a filesystem dependency.
+* Rate limiting is a simple in-memory sliding-window (30 calls/min/user).
+  It is per send() invocation, not per subscription.
+* 410 Gone from the push service means the subscription is permanently
+  invalid — we delete it from the store.  Other 4xx/5xx are transient
+  failures; we count them and move on.
+* Secrets (auth_key, p256dh_key, private PEM) are never logged.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from collections import defaultdict, deque
+from urllib.parse import urlsplit
+
+import pywebpush
+from pywebpush import WebPushException
+
+from tinyagentos.routes.desktop_browser.store import BrowserStore
+
+_log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_VAPID_SUB = "mailto:admin@taos.local"
+_SEND_TIMEOUT = 5.0  # seconds per upstream push-service call
+
+
+# ---------------------------------------------------------------------------
+# In-memory sliding-window rate limiter (30 sends/min/user, single-process)
+# ---------------------------------------------------------------------------
+
+
+class _RateLimiter:
+    """30 sends/min/user, sliding window.  In-memory, single-process."""
+
+    def __init__(self, limit: int = 30, window_seconds: int = 60) -> None:
+        self._limit = limit
+        self._window = window_seconds
+        self._timestamps: dict[str, deque[float]] = defaultdict(deque)
+        self._lock = asyncio.Lock()
+
+    async def acquire(self, user_id: str) -> bool:
+        """True if under limit, False if denied."""
+        async with self._lock:
+            now = time.monotonic()
+            q = self._timestamps[user_id]
+            while q and q[0] < now - self._window:
+                q.popleft()
+            if len(q) >= self._limit:
+                return False
+            q.append(now)
+            return True
+
+
+_rate_limiter = _RateLimiter()
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def send(
+    user_id: str,
+    payload: dict,
+    *,
+    devices: list[str] | None = None,
+    store: BrowserStore,
+    vapid: tuple[str, str],  # (public_key_b64url, private_key_pem_str)
+) -> dict:
+    """Send a push notification to all subscriptions of a user.
+
+    ``payload`` is JSON-serialized to a UTF-8 string before sending.
+    ``devices`` filters to specific device_ids (default = all).
+    Returns ``{"sent": int, "failed": int, "removed": int}``.
+
+    On 410 Gone: the subscription is removed from the store.
+    On other 4xx/5xx or 429: counted as failed, subscription kept.
+    On rate-limit hit (30/min/user): all subs in the rejected slice are
+    counted as failed and no upstream calls are made.
+    """
+    _, private_pem = vapid
+    data_str = json.dumps(payload)
+
+    # Fetch subscriptions for this user.
+    all_subs = await store.list_push_subscriptions(user_id)
+    if devices is not None:
+        subs = [s for s in all_subs if s["device_id"] in devices]
+    else:
+        subs = all_subs
+
+    # Rate-limit check — ONCE per send() invocation, not per device.
+    allowed = await _rate_limiter.acquire(user_id)
+    if not allowed:
+        _log.warning("push: rate limit exceeded for user %r (%d subs dropped)", user_id, len(subs))
+        return {"sent": 0, "failed": len(subs), "removed": 0}
+
+    if not subs:
+        return {"sent": 0, "failed": 0, "removed": 0}
+
+    loop = asyncio.get_running_loop()
+    results = await asyncio.gather(
+        *[_send_one(sub, data_str, private_pem, store, loop) for sub in subs],
+        return_exceptions=True,
+    )
+
+    sent = failed = removed = 0
+    for r in results:
+        if isinstance(r, Exception):
+            # gather(return_exceptions=True) surfaces unexpected exceptions here.
+            _log.warning("push: unexpected error sending to a subscription: %s", r)
+            failed += 1
+        elif r == "sent":
+            sent += 1
+        elif r == "removed":
+            removed += 1
+        else:
+            failed += 1
+
+    return {"sent": sent, "failed": failed, "removed": removed}
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+async def _send_one(
+    sub: dict,
+    data_str: str,
+    private_pem: str,
+    store: BrowserStore,
+    loop: asyncio.AbstractEventLoop,
+) -> str:
+    """Send to one subscription.  Returns "sent", "failed", or "removed"."""
+    endpoint = sub["endpoint"]
+    parsed = urlsplit(endpoint)
+    aud = f"{parsed.scheme}://{parsed.netloc}"
+
+    subscription_info = {
+        "endpoint": endpoint,
+        "keys": {
+            "p256dh": sub["p256dh_key"],
+            "auth": sub["auth_key"],
+        },
+    }
+    vapid_claims = {
+        "sub": _VAPID_SUB,
+        "aud": aud,
+    }
+
+    try:
+        await asyncio.wait_for(
+            loop.run_in_executor(
+                None,
+                _sync_send,
+                subscription_info,
+                data_str,
+                private_pem,
+                vapid_claims,
+            ),
+            timeout=_SEND_TIMEOUT,
+        )
+        return "sent"
+    except WebPushException as exc:
+        response = exc.response
+        status = getattr(response, "status_code", None)
+        ep_hash = hash(endpoint) & 0xFFFFFFFF
+        if status == 410:
+            _log.info("push: endpoint gone (hash=%08x), removing subscription", ep_hash)
+            await store.delete_push_subscription_by_endpoint(endpoint)
+            return "removed"
+        _log.warning(
+            "push: delivery failed for endpoint hash=%08x status=%s: %s",
+            ep_hash, status, exc.message,
+        )
+        return "failed"
+    except asyncio.TimeoutError:
+        ep_hash = hash(endpoint) & 0xFFFFFFFF
+        _log.warning("push: send timed out for endpoint hash=%08x", ep_hash)
+        return "failed"
+    except Exception as exc:
+        ep_hash = hash(endpoint) & 0xFFFFFFFF
+        _log.warning("push: unexpected error for endpoint hash=%08x: %s", ep_hash, exc)
+        return "failed"
+
+
+def _sync_send(
+    subscription_info: dict,
+    data: str,
+    private_pem: str,
+    vapid_claims: dict,
+) -> None:
+    """Blocking pywebpush call — run in executor."""
+    pywebpush.webpush(
+        subscription_info=subscription_info,
+        data=data,
+        vapid_private_key=private_pem,
+        vapid_claims=vapid_claims,
+        timeout=_SEND_TIMEOUT,
+    )

--- a/tinyagentos/routes/desktop_browser/push.py
+++ b/tinyagentos/routes/desktop_browser/push.py
@@ -39,6 +39,8 @@ _log = logging.getLogger(__name__)
 
 _VAPID_SUB = "mailto:admin@taos.local"
 _SEND_TIMEOUT = 5.0  # seconds per upstream push-service call
+_RATE_LIMIT_PER_MIN = 30
+_WINDOW_SECONDS = 60
 
 
 # ---------------------------------------------------------------------------
@@ -68,7 +70,7 @@ class _RateLimiter:
             return True
 
 
-_rate_limiter = _RateLimiter()
+_rate_limiter = _RateLimiter(limit=_RATE_LIMIT_PER_MIN, window_seconds=_WINDOW_SECONDS)
 
 
 # ---------------------------------------------------------------------------
@@ -105,14 +107,14 @@ async def send(
     else:
         subs = all_subs
 
+    if not subs:
+        return {"sent": 0, "failed": 0, "removed": 0}
+
     # Rate-limit check — ONCE per send() invocation, not per device.
     allowed = await _rate_limiter.acquire(user_id)
     if not allowed:
         _log.warning("push: rate limit exceeded for user %r (%d subs dropped)", user_id, len(subs))
         return {"sent": 0, "failed": len(subs), "removed": 0}
-
-    if not subs:
-        return {"sent": 0, "failed": 0, "removed": 0}
 
     loop = asyncio.get_running_loop()
     results = await asyncio.gather(

--- a/tinyagentos/routes/desktop_browser/push_routes.py
+++ b/tinyagentos/routes/desktop_browser/push_routes.py
@@ -1,7 +1,6 @@
 """HTTP endpoints for Web Push subscription CRUD and mute management."""
 from __future__ import annotations
 
-import pathlib
 from typing import Any, Literal
 
 from fastapi import Depends, Request
@@ -10,20 +9,6 @@ from pydantic import BaseModel, field_validator
 
 from tinyagentos.auth import get_current_user
 from tinyagentos.routes.desktop_browser import router
-from tinyagentos.routes.desktop_browser.vapid import load_or_create_vapid_keypair
-
-# ---------------------------------------------------------------------------
-# Module-level VAPID cache — loaded once, never re-read from disk per request.
-# ---------------------------------------------------------------------------
-
-_vapid_cache: tuple[str, str] | None = None
-
-
-def _get_vapid(data_dir: pathlib.Path) -> tuple[str, str]:
-    global _vapid_cache
-    if _vapid_cache is None:
-        _vapid_cache = load_or_create_vapid_keypair(data_dir)
-    return _vapid_cache
 
 
 # ---------------------------------------------------------------------------
@@ -32,10 +17,9 @@ def _get_vapid(data_dir: pathlib.Path) -> tuple[str, str]:
 
 
 @router.get("/api/desktop/browser/push/vapid-public-key")
-async def get_vapid_public_key(request: Request):
+async def get_vapid_public_key(request: Request) -> dict[str, str]:
     """Return the server's VAPID public key for use in PushManager.subscribe()."""
-    data_dir: pathlib.Path = request.app.state.data_dir
-    public_key, _ = _get_vapid(data_dir)
+    public_key, _ = request.app.state.vapid_keypair
     return {"public_key": public_key}
 
 

--- a/tinyagentos/routes/desktop_browser/push_routes.py
+++ b/tinyagentos/routes/desktop_browser/push_routes.py
@@ -1,8 +1,8 @@
-"""HTTP endpoints for Web Push subscription CRUD."""
+"""HTTP endpoints for Web Push subscription CRUD and mute management."""
 from __future__ import annotations
 
 import pathlib
-from typing import Any
+from typing import Any, Literal
 
 from fastapi import Depends, Request
 from fastapi.responses import JSONResponse
@@ -132,3 +132,46 @@ async def delete_push_subscription(
         user_id=user_id, device_id=device_id,
     )
     return {"ok": deleted}
+
+
+# ---------------------------------------------------------------------------
+# GET /mutes
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/desktop/browser/push/mutes")
+async def list_push_mutes(
+    request: Request,
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+):
+    user_id = str(current_user.get("id") or "")
+    if not user_id:
+        return JSONResponse({"error": "session has no user id"}, status_code=401)
+    mutes = await request.app.state.browser_store.list_push_mutes(user_id)
+    return {"mutes": mutes}
+
+
+# ---------------------------------------------------------------------------
+# PUT /mutes
+# ---------------------------------------------------------------------------
+
+
+class SetMuteRequest(BaseModel):
+    agent_id: str
+    kind: Literal["chat", "drive-started", "download-finished"]
+    muted: bool
+
+
+@router.put("/api/desktop/browser/push/mutes")
+async def set_push_mute(
+    request: Request,
+    body: SetMuteRequest,
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+):
+    user_id = str(current_user.get("id") or "")
+    if not user_id:
+        return JSONResponse({"error": "session has no user id"}, status_code=401)
+    await request.app.state.browser_store.set_push_mute(
+        user_id, body.agent_id, body.kind, body.muted
+    )
+    return {"ok": True}

--- a/tinyagentos/routes/desktop_browser/push_routes.py
+++ b/tinyagentos/routes/desktop_browser/push_routes.py
@@ -1,0 +1,134 @@
+"""HTTP endpoints for Web Push subscription CRUD."""
+from __future__ import annotations
+
+import pathlib
+from typing import Any
+
+from fastapi import Depends, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, field_validator
+
+from tinyagentos.auth import get_current_user
+from tinyagentos.routes.desktop_browser import router
+from tinyagentos.routes.desktop_browser.vapid import load_or_create_vapid_keypair
+
+# ---------------------------------------------------------------------------
+# Module-level VAPID cache — loaded once, never re-read from disk per request.
+# ---------------------------------------------------------------------------
+
+_vapid_cache: tuple[str, str] | None = None
+
+
+def _get_vapid(data_dir: pathlib.Path) -> tuple[str, str]:
+    global _vapid_cache
+    if _vapid_cache is None:
+        _vapid_cache = load_or_create_vapid_keypair(data_dir)
+    return _vapid_cache
+
+
+# ---------------------------------------------------------------------------
+# Public endpoint — NO auth required.
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/desktop/browser/push/vapid-public-key")
+async def get_vapid_public_key(request: Request):
+    """Return the server's VAPID public key for use in PushManager.subscribe()."""
+    data_dir: pathlib.Path = request.app.state.data_dir
+    public_key, _ = _get_vapid(data_dir)
+    return {"public_key": public_key}
+
+
+# ---------------------------------------------------------------------------
+# POST /subscribe
+# ---------------------------------------------------------------------------
+
+
+class SubscribeRequest(BaseModel):
+    device_id: str
+    endpoint: str
+    p256dh_key: str
+    auth_key: str
+    user_agent: str | None = None
+
+    @field_validator("device_id", "endpoint", "p256dh_key", "auth_key")
+    @classmethod
+    def must_be_non_empty(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("field must not be empty")
+        return v
+
+    @field_validator("endpoint")
+    @classmethod
+    def endpoint_must_be_https(cls, v: str) -> str:
+        if not v.startswith("https://"):
+            raise ValueError("endpoint must start with https://")
+        return v
+
+
+@router.post("/api/desktop/browser/push/subscribe")
+async def subscribe_push(
+    request: Request,
+    body: SubscribeRequest,
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+):
+    user_id = str(current_user.get("id") or "")
+    if not user_id:
+        return JSONResponse({"error": "session has no user id"}, status_code=401)
+    await request.app.state.browser_store.upsert_push_subscription(
+        user_id=user_id,
+        device_id=body.device_id,
+        endpoint=body.endpoint,
+        p256dh_key=body.p256dh_key,
+        auth_key=body.auth_key,
+        user_agent=body.user_agent,
+    )
+    return {"ok": True}
+
+
+# ---------------------------------------------------------------------------
+# GET /subscriptions
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/desktop/browser/push/subscriptions")
+async def list_push_subscriptions(
+    request: Request,
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+):
+    user_id = str(current_user.get("id") or "")
+    if not user_id:
+        return JSONResponse({"error": "session has no user id"}, status_code=401)
+    rows = await request.app.state.browser_store.list_push_subscriptions(user_id=user_id)
+    # Strip p256dh_key and auth_key — they are E2E encryption secrets.
+    safe = [
+        {
+            "device_id": r["device_id"],
+            "endpoint": r["endpoint"],
+            "user_agent": r["user_agent"],
+            "created_at": r["created_at"],
+            "last_seen_at": r["last_seen_at"],
+        }
+        for r in rows
+    ]
+    return {"subscriptions": safe}
+
+
+# ---------------------------------------------------------------------------
+# DELETE /subscriptions/{device_id}
+# ---------------------------------------------------------------------------
+
+
+@router.delete("/api/desktop/browser/push/subscriptions/{device_id}")
+async def delete_push_subscription(
+    request: Request,
+    device_id: str,
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+):
+    user_id = str(current_user.get("id") or "")
+    if not user_id:
+        return JSONResponse({"error": "session has no user id"}, status_code=401)
+    deleted = await request.app.state.browser_store.delete_push_subscription(
+        user_id=user_id, device_id=device_id,
+    )
+    return {"ok": deleted}

--- a/tinyagentos/routes/desktop_browser/schema.py
+++ b/tinyagentos/routes/desktop_browser/schema.py
@@ -74,6 +74,14 @@ CREATE TABLE IF NOT EXISTS push_subscriptions (
   PRIMARY KEY (user_id, device_id)
 );
 
+CREATE TABLE IF NOT EXISTS push_mutes (
+  user_id   TEXT NOT NULL,
+  agent_id  TEXT NOT NULL,
+  kind      TEXT NOT NULL,
+  muted_at  INTEGER NOT NULL,
+  PRIMARY KEY (user_id, agent_id, kind)
+);
+
 CREATE TABLE IF NOT EXISTS browser_windows (
   user_id        TEXT NOT NULL,
   window_id      TEXT NOT NULL,

--- a/tinyagentos/routes/desktop_browser/store.py
+++ b/tinyagentos/routes/desktop_browser/store.py
@@ -1029,6 +1029,105 @@ class BrowserStore(BaseStore):
         return best_state
 
 
+    # ------------------------------------------------------------------
+    # Push subscription helpers
+    # ------------------------------------------------------------------
+
+    async def upsert_push_subscription(
+        self,
+        user_id: str,
+        device_id: str,
+        endpoint: str,
+        p256dh_key: str,
+        auth_key: str,
+        user_agent: str | None = None,
+    ) -> None:
+        """Insert-or-replace a push subscription. Updates last_seen_at to now.
+
+        created_at is set on first insert and NOT touched on conflict.
+        """
+        if not user_id:
+            raise ValueError("user_id is required")
+        if not device_id:
+            raise ValueError("device_id is required")
+        import time
+        assert self._db is not None
+        now = int(time.time())
+        await self._db.execute(
+            "INSERT INTO push_subscriptions "
+            "(user_id, device_id, endpoint, p256dh_key, auth_key, user_agent, created_at, last_seen_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?) "
+            "ON CONFLICT(user_id, device_id) DO UPDATE SET "
+            "  endpoint = excluded.endpoint, "
+            "  p256dh_key = excluded.p256dh_key, "
+            "  auth_key = excluded.auth_key, "
+            "  user_agent = excluded.user_agent, "
+            "  last_seen_at = excluded.last_seen_at",
+            (user_id, device_id, endpoint, p256dh_key, auth_key, user_agent, now, now),
+        )
+        await self._db.commit()
+
+    async def list_push_subscriptions(self, user_id: str) -> list[dict]:
+        """All push subscriptions for a user, ordered by last_seen_at DESC.
+
+        Each dict has keys: device_id, endpoint, p256dh_key, auth_key,
+        user_agent, created_at, last_seen_at.
+        """
+        if not user_id:
+            raise ValueError("user_id is required")
+        assert self._db is not None
+        cursor = await self._db.execute(
+            "SELECT device_id, endpoint, p256dh_key, auth_key, user_agent, created_at, last_seen_at "
+            "FROM push_subscriptions "
+            "WHERE user_id = ? "
+            "ORDER BY last_seen_at DESC",
+            (user_id,),
+        )
+        rows = await cursor.fetchall()
+        return [
+            {
+                "device_id": r[0],
+                "endpoint": r[1],
+                "p256dh_key": r[2],
+                "auth_key": r[3],
+                "user_agent": r[4],
+                "created_at": r[5],
+                "last_seen_at": r[6],
+            }
+            for r in rows
+        ]
+
+    async def delete_push_subscription(self, user_id: str, device_id: str) -> bool:
+        """Remove a single subscription. Returns True if a row was deleted."""
+        if not user_id:
+            raise ValueError("user_id is required")
+        if not device_id:
+            raise ValueError("device_id is required")
+        assert self._db is not None
+        cursor = await self._db.execute(
+            "DELETE FROM push_subscriptions WHERE user_id = ? AND device_id = ?",
+            (user_id, device_id),
+        )
+        await self._db.commit()
+        return cursor.rowcount > 0
+
+    async def delete_push_subscription_by_endpoint(self, endpoint: str) -> int:
+        """Delete every subscription with this exact endpoint, across all users.
+
+        Returns the number of rows deleted. Used by the 410-Gone cleanup path
+        in push.send().
+        """
+        if not endpoint:
+            raise ValueError("endpoint is required")
+        assert self._db is not None
+        cursor = await self._db.execute(
+            "DELETE FROM push_subscriptions WHERE endpoint = ?",
+            (endpoint,),
+        )
+        await self._db.commit()
+        return cursor.rowcount or 0
+
+
 _KNOWN_SITE_PERMISSIONS = {
     "notifications", "clipboard-read", "clipboard-write",
     "geolocation", "camera", "microphone",

--- a/tinyagentos/routes/desktop_browser/store.py
+++ b/tinyagentos/routes/desktop_browser/store.py
@@ -1045,6 +1045,11 @@ class BrowserStore(BaseStore):
         """Insert-or-replace a push subscription. Updates last_seen_at to now.
 
         created_at is set on first insert and NOT touched on conflict.
+
+        Deduplicates by endpoint within the same user: if an existing row for
+        this user has the same endpoint but a different device_id (e.g. the
+        browser regenerated its device_id), the old row is removed before the
+        upsert so the user doesn't accumulate duplicate notification targets.
         """
         if not user_id:
             raise ValueError("user_id is required")
@@ -1053,6 +1058,12 @@ class BrowserStore(BaseStore):
         import time
         assert self._db is not None
         now = int(time.time())
+        # Remove stale rows for the same (user, endpoint) with a different device_id.
+        await self._db.execute(
+            "DELETE FROM push_subscriptions "
+            "WHERE user_id = ? AND endpoint = ? AND device_id != ?",
+            (user_id, endpoint, device_id),
+        )
         await self._db.execute(
             "INSERT INTO push_subscriptions "
             "(user_id, device_id, endpoint, p256dh_key, auth_key, user_agent, created_at, last_seen_at) "

--- a/tinyagentos/routes/desktop_browser/store.py
+++ b/tinyagentos/routes/desktop_browser/store.py
@@ -1127,11 +1127,68 @@ class BrowserStore(BaseStore):
         await self._db.commit()
         return cursor.rowcount or 0
 
+    # ------------------------------------------------------------------
+    # Push mute helpers
+    # ------------------------------------------------------------------
+
+    async def set_push_mute(
+        self, user_id: str, agent_id: str, kind: str, muted: bool
+    ) -> None:
+        """Set or clear a per-(agent, kind) mute.
+
+        muted=True inserts (or replaces), muted=False deletes.
+        Raises ValueError if kind is not in _PUSH_MUTE_KINDS.
+        """
+        if kind not in _PUSH_MUTE_KINDS:
+            raise ValueError(f"invalid kind: {kind}")
+        assert self._db is not None
+        if muted:
+            import time
+            now = int(time.time())
+            await self._db.execute(
+                "INSERT OR REPLACE INTO push_mutes (user_id, agent_id, kind, muted_at) "
+                "VALUES (?, ?, ?, ?)",
+                (user_id, agent_id, kind, now),
+            )
+        else:
+            await self._db.execute(
+                "DELETE FROM push_mutes WHERE user_id = ? AND agent_id = ? AND kind = ?",
+                (user_id, agent_id, kind),
+            )
+        await self._db.commit()
+
+    async def list_push_mutes(self, user_id: str) -> list[dict]:
+        """All mutes for the user. Each dict: {agent_id, kind, muted_at}."""
+        if not user_id:
+            raise ValueError("user_id is required")
+        assert self._db is not None
+        cursor = await self._db.execute(
+            "SELECT agent_id, kind, muted_at FROM push_mutes "
+            "WHERE user_id = ? ORDER BY muted_at",
+            (user_id,),
+        )
+        rows = await cursor.fetchall()
+        return [{"agent_id": r[0], "kind": r[1], "muted_at": r[2]} for r in rows]
+
+    async def is_push_muted(
+        self, user_id: str, agent_id: str, kind: str
+    ) -> bool:
+        """Single-row existence check used by send-side gating."""
+        assert self._db is not None
+        cursor = await self._db.execute(
+            "SELECT 1 FROM push_mutes WHERE user_id = ? AND agent_id = ? AND kind = ?",
+            (user_id, agent_id, kind),
+        )
+        row = await cursor.fetchone()
+        return row is not None
+
 
 _KNOWN_SITE_PERMISSIONS = {
     "notifications", "clipboard-read", "clipboard-write",
     "geolocation", "camera", "microphone",
 }
+
+_PUSH_MUTE_KINDS = frozenset({"chat", "drive-started", "download-finished"})
 
 
 class BrowserCookieStore:

--- a/tinyagentos/routes/desktop_browser/sw.js
+++ b/tinyagentos/routes/desktop_browser/sw.js
@@ -71,3 +71,51 @@ self.addEventListener('message', function (event) {
     self.__taosProfileId = data.profileId;
   }
 });
+
+self.addEventListener('push', function (event) {
+  // Server pushes a JSON payload {title, body, tag?, icon?, data?}.
+  // We forward to showNotification, falling back to a generic message
+  // if parsing fails or the push has no payload.
+  var payload;
+  try {
+    payload = event.data ? event.data.json() : null;
+  } catch (_e) {
+    payload = null;
+  }
+  if (!payload || typeof payload !== 'object') {
+    payload = { title: 'taOS', body: 'New activity' };
+  }
+  var title = (typeof payload.title === 'string') ? payload.title : 'taOS';
+  var options = {
+    body: (typeof payload.body === 'string') ? payload.body : '',
+    tag: (typeof payload.tag === 'string') ? payload.tag : undefined,
+    icon: (typeof payload.icon === 'string') ? payload.icon : undefined,
+    data: (payload.data && typeof payload.data === 'object') ? payload.data : {},
+  };
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener('notificationclick', function (event) {
+  // Close the notification, then either focus an existing same-origin
+  // taOS window (postMessage so the shell can route to the right tab)
+  // or open a new one.
+  event.notification.close();
+  var data = event.notification.data || {};
+  event.waitUntil(
+    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then(function (clientsList) {
+      for (var i = 0; i < clientsList.length; i++) {
+        var client = clientsList[i];
+        if (client.url && new URL(client.url).origin === self.location.origin) {
+          // Found a same-origin client — focus it and forward the click data.
+          client.postMessage({ type: 'taos-push:click', data: data });
+          return client.focus();
+        }
+      }
+      // No matching window — open a new one at root.
+      if (self.clients.openWindow) {
+        return self.clients.openWindow('/');
+      }
+      return null;
+    })
+  );
+});

--- a/tinyagentos/routes/desktop_browser/vapid.py
+++ b/tinyagentos/routes/desktop_browser/vapid.py
@@ -1,0 +1,53 @@
+"""VAPID keypair bootstrap for Web Push.
+
+One P-256 keypair per host install. The private key is persisted to
+``<data_dir>/vapid.pem`` on first call (mode 0600) and reloaded on
+subsequent calls. Idempotent — repeated calls return the same keys.
+
+The public key is returned in the uncompressed-point base64url-without-
+padding form that the browser's PushManager.subscribe() expects as its
+``applicationServerKey``.
+"""
+from __future__ import annotations
+
+import base64
+import os
+import pathlib
+
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+from py_vapid import Vapid01
+
+_VAPID_FILENAME = "vapid.pem"
+
+
+def load_or_create_vapid_keypair(data_dir: pathlib.Path) -> tuple[str, str]:
+    """Return (public_key_b64url, private_key_pem_str).
+
+    Loads from <data_dir>/vapid.pem if present; otherwise generates a fresh
+    P-256 keypair, persists the private key PEM to disk with mode 0600, and
+    returns both keys. Idempotent — second call returns same keys.
+
+    The public key is returned in uncompressed-point base64url-without-padding
+    form (the format applicationServerKey expects in PushManager.subscribe).
+    """
+    pem_path = data_dir / _VAPID_FILENAME
+
+    if pem_path.exists():
+        vapid = Vapid01.from_pem(pem_path.read_bytes())
+    else:
+        vapid = Vapid01()
+        vapid.generate_keys()
+        pem_bytes = vapid.private_pem()
+        # Write with mode 0600 atomically using os.open so no window exists
+        # where the file is readable by other users.
+        fd = os.open(str(pem_path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        try:
+            os.write(fd, pem_bytes)
+        finally:
+            os.close(fd)
+
+    pub_bytes = vapid.public_key.public_bytes(Encoding.X962, PublicFormat.UncompressedPoint)
+    public_key_b64url = base64.urlsafe_b64encode(pub_bytes).rstrip(b"=").decode("ascii")
+    private_key_pem_str = pem_path.read_text()
+
+    return public_key_b64url, private_key_pem_str

--- a/tinyagentos/routes/desktop_browser/vapid.py
+++ b/tinyagentos/routes/desktop_browser/vapid.py
@@ -41,11 +41,16 @@ def load_or_create_vapid_keypair(data_dir: pathlib.Path) -> tuple[str, str]:
         pem_bytes = vapid.private_pem()
         # Write with mode 0600 atomically using os.open so no window exists
         # where the file is readable by other users.
-        fd = os.open(str(pem_path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
         try:
-            os.write(fd, pem_bytes)
-        finally:
-            os.close(fd)
+            fd = os.open(str(pem_path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            try:
+                os.write(fd, pem_bytes)
+            finally:
+                os.close(fd)
+        except FileExistsError:
+            # Lost the race with a concurrent process — load the file that the
+            # winner wrote instead of using the in-memory keypair.
+            vapid = Vapid01.from_pem(pem_path.read_bytes())
 
     pub_bytes = vapid.public_key.public_bytes(Encoding.X962, PublicFormat.UncompressedPoint)
     public_key_b64url = base64.urlsafe_b64encode(pub_bytes).rstrip(b"=").decode("ascii")

--- a/tinyagentos/routes/desktop_browser/vapid.py
+++ b/tinyagentos/routes/desktop_browser/vapid.py
@@ -30,6 +30,7 @@ def load_or_create_vapid_keypair(data_dir: pathlib.Path) -> tuple[str, str]:
     The public key is returned in uncompressed-point base64url-without-padding
     form (the format applicationServerKey expects in PushManager.subscribe).
     """
+    data_dir.mkdir(parents=True, exist_ok=True)
     pem_path = data_dir / _VAPID_FILENAME
 
     if pem_path.exists():


### PR DESCRIPTION
## Summary

Closes the BrowserApp v2 epic by laying the Web Push platform primitive scoped to BrowserApp v1 triggers. After this PR: cross-device push works for the three v1 trigger sites (chat / drive-started / download-finished), and the primitive is reusable for the cross-app aggregator follow-up.

## What landed

**Backend**
- `pywebpush` dependency + VAPID keypair bootstrap (`vapid.py`, persisted to `data/vapid.pem` mode 0600, lazy idempotent generation)
- `push_subscriptions` store methods (upsert/list/delete/delete-by-endpoint with multi-user isolation)
- HTTP CRUD: `GET /push/vapid-public-key` (public), `POST /push/subscribe`, `GET /push/subscriptions` (strips p256dh/auth keys), `DELETE /push/subscriptions/{device_id}`, `GET/PUT /push/mutes`
- `push.send(user_id, payload, *, devices, store, vapid)` with 30/min/user sliding-window rate limit, 410-Gone subscription cleanup, per-endpoint VAPID claims, 5s send timeout
- `push_mutes` table keyed on `(user_id, agent_id, kind)` where kind ∈ `{chat, drive-started, download-finished}`
- VAPID singleton wired at app startup (`app.state.vapid_keypair`)

**Service Worker** (extends `sw.js` from PR 8 — no second SW)
- `push` handler: parse JSON payload, fall back to generic title/body, `event.waitUntil(showNotification(...))`
- `notificationclick` handler: focus matching same-origin window + postMessage `taos-push:click`, fallback `openWindow('/')`

**Frontend**
- `browser-push-api.ts` — six wrappers
- `browser-push-bootstrap.ts` — idempotent subscription flow (gated by `Notification.permission`, persistent `device_id` in localStorage, re-POSTs existing subscriptions to refresh `last_seen_at`)
- `BrowserApp.tsx` calls bootstrap after SW registration (fire-and-forget)
- `AgentPanel.tsx` notifications section with three toggles per pinned agent, optimistic update + revert on failure
- `SettingsPanel.tsx` tri-state Enable Notifications button (granted / denied / default)
- `TabRenderer.tsx` postMessages `taos-copilot:tab-focus` to iframes on active-tab change

**Triggers (v1)**
- Chat: agent chat-message broadcast in `copilot_agent_ws.py` → `_maybe_send_chat_push` (mute + tab-focus gated)
- Drive-started: first drive op of a session in `copilot_agent_ws.py` → `_maybe_send_drive_push`
- Download-finished: successful stream completion in `download.py` → push.send via `asyncio.create_task`
- Tab-focus tracking via `CopilotHub.set_focused_tab` / `get_focused_tab`, `tab-focus` WS event, parent-shell postMessage from `TabRenderer.tsx`

## Out of scope (deferred)

- Cross-app push aggregator (`notifications.py`) — Foundations brainstorm
- DND mode + channel categories
- Native iOS/Android wrapper integration
- Cluster-wide rate limiting (currently single-process in-memory)
- VAPID key rotation UX

## Test Plan

- [x] Backend: `pytest tests/routes/desktop_browser/` → 504/504 passing
- [x] Frontend: `npm test -- --run` → 775/775 passing, `tsc --noEmit` clean
- [x] Multi-user isolation: every endpoint and trigger derives `user_id` from session; never from request body
- [x] p256dh/auth_key NEVER returned from list endpoint; NEVER logged
- [x] VAPID private key file mode 0600, atomic via `O_EXCL`
- [x] 410-Gone cleanup verified
- [x] Rate limit verified (30/min/user, FIFO denial counted as failed without upstream calls)
- [x] Service Worker: no `clients.claim()` (preserves PR 8 invariant)
- [x] Focus suppression: tab-id fallback when window_id unavailable at the agent WS

## After this PR

This closes the BrowserApp v2 epic per spec §10:

```
After PR 10:  cross-device push (agent pings your phone).    (FOUNDATIONS PRIMITIVE)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enable browser notifications in Settings to receive push notifications for chat messages, drive operations, and download completions.
  * Mute notifications per-agent and per-notification type directly in the Agent Panel.
  * Smart notification suppression: notifications won't fire when you're actively viewing the relevant browser tab.

* **Tests**
  * Added comprehensive test coverage for push notification endpoints, subscriptions, mutes, and delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->