### PR TITLE
feat(store): rkllama installer + 14 Qwen rkllm models for Orange Pi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ data/agent-workspaces/
 benchmarks/data/longmemeval_s_cleaned.json
 benchmarks/data/*.json
 models/minilm-onnx/minilm-l6-rk3588.rknn
-models/
+/models/
+!app-catalog/models/
 screenshots.zip
 data/.auth_user.json

--- a/app-catalog/models/pelochus-qwen-1.8b-rkllm/manifest.yaml
+++ b/app-catalog/models/pelochus-qwen-1.8b-rkllm/manifest.yaml
@@ -6,6 +6,7 @@ description: "Pelochus' original Qwen 1.8B rkllm port for RK3588 — the classic
 homepage: https://huggingface.co/Pelochus/qwen-1_8B-rk3588
 license: "Tongyi Qianwen License"
 capabilities: [chat]
+install: {method: rkllama}
 
 variants:
   - id: rkllm

--- a/app-catalog/models/qwen2.5-1.5b-rkllm/manifest.yaml
+++ b/app-catalog/models/qwen2.5-1.5b-rkllm/manifest.yaml
@@ -6,6 +6,7 @@ description: "RK3588 NPU-accelerated Qwen 2.5 1.5B — runs on Orange Pi 5 NPU v
 homepage: https://huggingface.co/c01zaut/Qwen2.5-1.5B-Instruct-rk3588-1.1.1
 license: Apache-2.0
 capabilities: [chat, tool-calling]
+install: {method: rkllama}
 
 variants:
   - id: w8a8

--- a/app-catalog/models/qwen2.5-14b-rkllm/manifest.yaml
+++ b/app-catalog/models/qwen2.5-14b-rkllm/manifest.yaml
@@ -6,6 +6,7 @@ description: "RK3588 NPU-accelerated Qwen 2.5 14B — high-capability model for 
 homepage: https://huggingface.co/c01zaut/Qwen2.5-14B-Instruct-rk3588-1.1.1
 license: Apache-2.0
 capabilities: [chat, tool-calling, code, reasoning]
+install: {method: rkllama}
 
 variants:
   - id: w8a8

--- a/app-catalog/models/qwen2.5-3b-rkllm/manifest.yaml
+++ b/app-catalog/models/qwen2.5-3b-rkllm/manifest.yaml
@@ -6,6 +6,7 @@ description: "RK3588 NPU-accelerated Qwen 2.5 3B — strong tool calling on Oran
 homepage: https://huggingface.co/c01zaut/Qwen2.5-3B-Instruct-rk3588-1.1.1
 license: "Qwen Research License"
 capabilities: [chat, tool-calling, code]
+install: {method: rkllama}
 
 variants:
   - id: w8a8

--- a/app-catalog/models/qwen2.5-7b-rkllm/manifest.yaml
+++ b/app-catalog/models/qwen2.5-7b-rkllm/manifest.yaml
@@ -6,6 +6,7 @@ description: "RK3588 NPU-accelerated Qwen 2.5 7B — full-capability model on Or
 homepage: https://huggingface.co/c01zaut/Qwen2.5-7B-Instruct-rk3588-v1.1.0
 license: Apache-2.0
 capabilities: [chat, tool-calling, code, reasoning]
+install: {method: rkllama}
 
 variants:
   - id: w8a8

--- a/app-catalog/models/qwen2.5-coder-1.5b-rkllm/manifest.yaml
+++ b/app-catalog/models/qwen2.5-coder-1.5b-rkllm/manifest.yaml
@@ -1,0 +1,24 @@
+id: qwen2.5-coder-1.5b-rkllm
+name: Qwen 2.5 Coder 1.5B Instruct (RKLLM)
+type: model
+version: 2.5.0
+description: "RK3588 NPU-accelerated Qwen 2.5 Coder 1.5B — fast, small code-focused model for Orange Pi NPU"
+homepage: https://huggingface.co/c01zaut/Qwen2.5-Coder-1.5B-Instruct-RK3588-1.1.4
+license: "Qwen Research License"
+capabilities: [chat, tool-calling, code]
+install: {method: rkllama}
+
+variants:
+  - id: w8a8
+    name: "W8A8 RKLLM (2GB, NPU)"
+    format: rkllm
+    size_mb: 2048
+    min_ram_mb: 0
+    download_url: https://huggingface.co/c01zaut/Qwen2.5-Coder-1.5B-Instruct-RK3588-1.1.4/resolve/main/Qwen2.5-Coder-1.5B-Instruct-rk3588-w8a8-opt-1-hybrid-ratio-1.0.rkllm
+    backend: [rkllama]
+    requires_npu: [rk3588, rk3576]
+    quality: good
+
+hardware_tiers:
+  arm-npu-16gb: {recommended: w8a8}
+  arm-npu-32gb: {recommended: w8a8}

--- a/app-catalog/models/qwen2.5-coder-14b-rkllm/manifest.yaml
+++ b/app-catalog/models/qwen2.5-coder-14b-rkllm/manifest.yaml
@@ -1,0 +1,23 @@
+id: qwen2.5-coder-14b-rkllm
+name: Qwen 2.5 Coder 14B Instruct (RKLLM)
+type: model
+version: 2.5.0
+description: "RK3588 NPU-accelerated Qwen 2.5 Coder 14B — large code-focused model; needs 32GB Pi (very tight on 16GB)"
+homepage: https://huggingface.co/c01zaut/Qwen2.5-Coder-14B-Instruct-RK3588-1.1.4
+license: "Qwen Research License"
+capabilities: [chat, tool-calling, code]
+install: {method: rkllama}
+
+variants:
+  - id: w8a8
+    name: "W8A8 RKLLM (15.6GB, NPU)"
+    format: rkllm
+    size_mb: 15600
+    min_ram_mb: 0
+    download_url: https://huggingface.co/c01zaut/Qwen2.5-Coder-14B-Instruct-RK3588-1.1.4/resolve/main/Qwen2.5-Coder-14B-Instruct-rk3588-w8a8-opt-1-hybrid-ratio-1.0.rkllm
+    backend: [rkllama]
+    requires_npu: [rk3588]
+    quality: good
+
+hardware_tiers:
+  arm-npu-32gb: {recommended: w8a8}

--- a/app-catalog/models/qwen2.5-coder-7b-rkllm/manifest.yaml
+++ b/app-catalog/models/qwen2.5-coder-7b-rkllm/manifest.yaml
@@ -1,0 +1,24 @@
+id: qwen2.5-coder-7b-rkllm
+name: Qwen 2.5 Coder 7B Instruct (RKLLM)
+type: model
+version: 2.5.0
+description: "RK3588 NPU-accelerated Qwen 2.5 Coder 7B — code-focused chat model for Orange Pi NPU"
+homepage: https://huggingface.co/c01zaut/Qwen2.5-Coder-7B-Instruct-rk3588-1.1.2
+license: "Qwen Research License"
+capabilities: [chat, tool-calling, code]
+install: {method: rkllama}
+
+variants:
+  - id: w8a8
+    name: "W8A8 RKLLM (8.2GB, NPU)"
+    format: rkllm
+    size_mb: 8190
+    min_ram_mb: 0
+    download_url: https://huggingface.co/c01zaut/Qwen2.5-Coder-7B-Instruct-rk3588-1.1.2/resolve/main/Qwen2.5-Coder-7B-Instruct-rk3588-w8a8-opt-1-hybrid-ratio-1.0.rkllm
+    backend: [rkllama]
+    requires_npu: [rk3588, rk3576]
+    quality: good
+
+hardware_tiers:
+  arm-npu-16gb: {recommended: w8a8}
+  arm-npu-32gb: {recommended: w8a8}

--- a/app-catalog/models/qwen2.5-math-1.5b-rkllm/manifest.yaml
+++ b/app-catalog/models/qwen2.5-math-1.5b-rkllm/manifest.yaml
@@ -1,0 +1,24 @@
+id: qwen2.5-math-1.5b-rkllm
+name: Qwen 2.5 Math 1.5B Instruct (RKLLM)
+type: model
+version: 2.5.0
+description: "RK3588 NPU-accelerated Qwen 2.5 Math 1.5B — fast math/reasoning model for Orange Pi NPU"
+homepage: https://huggingface.co/c01zaut/Qwen2.5-Math-1.5B-Instruct-RK3588-1.1.4
+license: "Qwen Research License"
+capabilities: [chat, math, reasoning]
+install: {method: rkllama}
+
+variants:
+  - id: w8a8
+    name: "W8A8 RKLLM (2GB, NPU)"
+    format: rkllm
+    size_mb: 2048
+    min_ram_mb: 0
+    download_url: https://huggingface.co/c01zaut/Qwen2.5-Math-1.5B-Instruct-RK3588-1.1.4/resolve/main/Qwen2.5-Math-1.5B-Instruct-rk3588-w8a8-opt-1-hybrid-ratio-1.0.rkllm
+    backend: [rkllama]
+    requires_npu: [rk3588, rk3576]
+    quality: good
+
+hardware_tiers:
+  arm-npu-16gb: {recommended: w8a8}
+  arm-npu-32gb: {recommended: w8a8}

--- a/app-catalog/models/qwen2.5-math-7b-rkllm/manifest.yaml
+++ b/app-catalog/models/qwen2.5-math-7b-rkllm/manifest.yaml
@@ -1,0 +1,24 @@
+id: qwen2.5-math-7b-rkllm
+name: Qwen 2.5 Math 7B Instruct (RKLLM)
+type: model
+version: 2.5.0
+description: "RK3588 NPU-accelerated Qwen 2.5 Math 7B — strong math/reasoning for Orange Pi NPU"
+homepage: https://huggingface.co/c01zaut/Qwen2.5-Math-7B-Instruct-RK3588-1.1.4
+license: "Qwen Research License"
+capabilities: [chat, math, reasoning]
+install: {method: rkllama}
+
+variants:
+  - id: w8a8
+    name: "W8A8 RKLLM (8.2GB, NPU)"
+    format: rkllm
+    size_mb: 8190
+    min_ram_mb: 0
+    download_url: https://huggingface.co/c01zaut/Qwen2.5-Math-7B-Instruct-RK3588-1.1.4/resolve/main/Qwen2.5-Math-7B-Instruct-rk3588-w8a8-opt-1-hybrid-ratio-1.0.rkllm
+    backend: [rkllama]
+    requires_npu: [rk3588, rk3576]
+    quality: good
+
+hardware_tiers:
+  arm-npu-16gb: {recommended: w8a8}
+  arm-npu-32gb: {recommended: w8a8}

--- a/app-catalog/models/qwen3-1.7b-rkllm/manifest.yaml
+++ b/app-catalog/models/qwen3-1.7b-rkllm/manifest.yaml
@@ -1,0 +1,24 @@
+id: qwen3-1.7b-rkllm
+name: Qwen 3 1.7B (RKLLM)
+type: model
+version: 3.0.0
+description: "RK3588 NPU-accelerated Qwen 3 1.7B — small, fast chat model for Orange Pi NPU"
+homepage: https://huggingface.co/GatekeeperZA/Qwen3-1.7B-RKLLM-v1.2.3
+license: Apache-2.0
+capabilities: [chat, tool-calling]
+install: {method: rkllama}
+
+variants:
+  - id: w8a8
+    name: "W8A8 RKLLM (2.4GB, NPU)"
+    format: rkllm
+    size_mb: 2380
+    min_ram_mb: 0
+    download_url: https://huggingface.co/GatekeeperZA/Qwen3-1.7B-RKLLM-v1.2.3/resolve/main/Qwen3-1.7B-w8a8-rk3588.rkllm
+    backend: [rkllama]
+    requires_npu: [rk3588, rk3576]
+    quality: good
+
+hardware_tiers:
+  arm-npu-16gb: {recommended: w8a8}
+  arm-npu-32gb: {recommended: w8a8}

--- a/app-catalog/models/qwen3-4b-rkllm/manifest.yaml
+++ b/app-catalog/models/qwen3-4b-rkllm/manifest.yaml
@@ -1,0 +1,24 @@
+id: qwen3-4b-rkllm
+name: Qwen 3 4B Instruct (RKLLM)
+type: model
+version: 3.0.0
+description: "RK3588 NPU-accelerated Qwen 3 4B (Instruct-2507) — strong general-purpose chat model for Orange Pi NPU"
+homepage: https://huggingface.co/thanhtantran/Qwen3-4B-Instruct-2507-RKLLM
+license: Apache-2.0
+capabilities: [chat, tool-calling, code]
+install: {method: rkllama}
+
+variants:
+  - id: w8a8
+    name: "W8A8 RKLLM (4.9GB, NPU)"
+    format: rkllm
+    size_mb: 4850
+    min_ram_mb: 0
+    download_url: https://huggingface.co/thanhtantran/Qwen3-4B-Instruct-2507-RKLLM/resolve/main/qwen3-4b-instruct-2507_w8a8_rk3588.rkllm
+    backend: [rkllama]
+    requires_npu: [rk3588]
+    quality: good
+
+hardware_tiers:
+  arm-npu-16gb: {recommended: w8a8}
+  arm-npu-32gb: {recommended: w8a8}

--- a/app-catalog/models/qwen3-vl-2b-rkllm/manifest.yaml
+++ b/app-catalog/models/qwen3-vl-2b-rkllm/manifest.yaml
@@ -1,0 +1,24 @@
+id: qwen3-vl-2b-rkllm
+name: Qwen 3 VL 2B Instruct (RKLLM)
+type: model
+version: 3.0.0
+description: "RK3588 NPU-accelerated Qwen 3 VL 2B — vision-language multimodal model for Orange Pi NPU"
+homepage: https://huggingface.co/GatekeeperZA/Qwen3-VL-2B-Instruct-RKLLM-v1.2.3
+license: Apache-2.0
+capabilities: [chat, vision]
+install: {method: rkllama}
+
+variants:
+  - id: w8a8
+    name: "W8A8 RKLLM (2.4GB, NPU)"
+    format: rkllm
+    size_mb: 2380
+    min_ram_mb: 0
+    download_url: https://huggingface.co/GatekeeperZA/Qwen3-VL-2B-Instruct-RKLLM-v1.2.3/resolve/main/qwen3-vl-2b-instruct_w8a8_rk3588.rkllm
+    backend: [rkllama]
+    requires_npu: [rk3588]
+    quality: good
+
+hardware_tiers:
+  arm-npu-16gb: {recommended: w8a8}
+  arm-npu-32gb: {recommended: w8a8}

--- a/app-catalog/models/qwen3-vl-4b-rkllm/manifest.yaml
+++ b/app-catalog/models/qwen3-vl-4b-rkllm/manifest.yaml
@@ -1,0 +1,24 @@
+id: qwen3-vl-4b-rkllm
+name: Qwen 3 VL 4B Instruct (RKLLM)
+type: model
+version: 3.0.0
+description: "RK3588 NPU-accelerated Qwen 3 VL 4B — vision-language multimodal model with stronger capability for Orange Pi NPU"
+homepage: https://huggingface.co/reponislam/Qwen3-VL-4B-Instruct-w8a8-RK3588-rkllm
+license: Apache-2.0
+capabilities: [chat, vision]
+install: {method: rkllama}
+
+variants:
+  - id: w8a8
+    name: "W8A8 RKLLM (4.9GB, NPU)"
+    format: rkllm
+    size_mb: 4850
+    min_ram_mb: 0
+    download_url: https://huggingface.co/reponislam/Qwen3-VL-4B-Instruct-w8a8-RK3588-rkllm/resolve/main/qwen3-vl-4b-instruct_w8a8_rk3588.rkllm
+    backend: [rkllama]
+    requires_npu: [rk3588]
+    quality: good
+
+hardware_tiers:
+  arm-npu-16gb: {recommended: w8a8}
+  arm-npu-32gb: {recommended: w8a8}

--- a/tests/test_rkllama_installer.py
+++ b/tests/test_rkllama_installer.py
@@ -1,0 +1,83 @@
+"""Tests for the rkllama installer.
+
+Most coverage is around the HF URL parser since that's where install
+failures will manifest if a manifest URL changes shape. The actual HTTP
+roundtrip to /api/pull is exercised manually on the Pi (see PR description).
+"""
+from __future__ import annotations
+
+import pytest
+
+from tinyagentos.installers.rkllama_installer import (
+    parse_hf_resolve_url,
+    resolve_rkllama_url,
+)
+
+
+class TestParseHfResolveUrl:
+    def test_standard_main_branch(self):
+        url = (
+            "https://huggingface.co/c01zaut/Qwen2.5-3B-Instruct-rk3588-1.1.1/"
+            "resolve/main/Qwen2.5-3B-Instruct-rk3588-w8a8-opt-1-hybrid-ratio-1.0.rkllm"
+        )
+        user, repo, filename = parse_hf_resolve_url(url)
+        assert user == "c01zaut"
+        assert repo == "Qwen2.5-3B-Instruct-rk3588-1.1.1"
+        assert filename == "Qwen2.5-3B-Instruct-rk3588-w8a8-opt-1-hybrid-ratio-1.0.rkllm"
+
+    def test_non_main_branch(self):
+        url = (
+            "https://huggingface.co/user/repo-name/resolve/v2/model.rkllm"
+        )
+        user, repo, filename = parse_hf_resolve_url(url)
+        assert user == "user"
+        assert repo == "repo-name"
+        assert filename == "model.rkllm"
+
+    def test_http_scheme_accepted(self):
+        url = "http://huggingface.co/u/r/resolve/main/f.rkllm"
+        user, repo, filename = parse_hf_resolve_url(url)
+        assert (user, repo, filename) == ("u", "r", "f.rkllm")
+
+    def test_filename_with_dashes_and_underscores(self):
+        url = (
+            "https://huggingface.co/GatekeeperZA/Qwen3-1.7B-RKLLM-v1.2.3/"
+            "resolve/main/Qwen3-1.7B-w8a8-rk3588.rkllm"
+        )
+        _, _, filename = parse_hf_resolve_url(url)
+        assert filename == "Qwen3-1.7B-w8a8-rk3588.rkllm"
+
+    def test_non_huggingface_url_raises(self):
+        with pytest.raises(ValueError, match="HuggingFace"):
+            parse_hf_resolve_url("https://example.com/foo/bar/baz.rkllm")
+
+    def test_missing_resolve_segment_raises(self):
+        # Direct file URL without /resolve/<branch>/ — common malformed case.
+        with pytest.raises(ValueError, match="HuggingFace"):
+            parse_hf_resolve_url("https://huggingface.co/user/repo/main/file.rkllm")
+
+    def test_query_string_or_fragment_rejected(self):
+        # The model field that gets POSTed to rkllama can't contain ? or #
+        # since rkllama splits on / and uses parts directly. Any URL with
+        # those should fail validation up front.
+        with pytest.raises(ValueError):
+            parse_hf_resolve_url(
+                "https://huggingface.co/u/r/resolve/main/f.rkllm?x=1"
+            )
+
+
+class TestResolveRkllamaUrl:
+    def test_none_returns_loopback(self):
+        assert resolve_rkllama_url(None) == "http://localhost:8080"
+
+    def test_empty_returns_loopback(self):
+        assert resolve_rkllama_url("") == "http://localhost:8080"
+
+    def test_local_returns_loopback(self):
+        assert resolve_rkllama_url("local") == "http://localhost:8080"
+
+    def test_remote_name_becomes_url(self):
+        assert resolve_rkllama_url("orange-pi") == "http://orange-pi:8080"
+
+    def test_ip_address(self):
+        assert resolve_rkllama_url("192.168.1.10") == "http://192.168.1.10:8080"

--- a/tinyagentos/installers/base.py
+++ b/tinyagentos/installers/base.py
@@ -38,6 +38,7 @@ def get_installer(method: str, **kwargs) -> AppInstaller:
     from tinyagentos.installers.docker_installer import DockerInstaller
     from tinyagentos.installers.download_installer import DownloadInstaller
     from tinyagentos.installers.lxc_installer import LXCInstaller
+    from tinyagentos.installers.rkllama_installer import RkllamaInstaller
 
     if method == "pip":
         return PipInstaller(**kwargs)
@@ -47,5 +48,7 @@ def get_installer(method: str, **kwargs) -> AppInstaller:
         return DownloadInstaller(**kwargs)
     elif method == "lxc":
         return LXCInstaller(**kwargs)
+    elif method == "rkllama":
+        return RkllamaInstaller(**kwargs)
     else:
         raise ValueError(f"Unknown install method: '{method}'")

--- a/tinyagentos/installers/rkllama_installer.py
+++ b/tinyagentos/installers/rkllama_installer.py
@@ -1,0 +1,173 @@
+"""rkllama installer — pulls .rkllm models via rkllama's own /api/pull endpoint.
+
+rkllama is a local NPU model server (already running on Orange Pi via
+``install-rknpu.sh``). It exposes an Ollama-compatible HTTP API including
+``POST /api/pull`` which downloads a model from HuggingFace, places the
+``.rkllm`` weight in its models directory, and writes a ``Modelfile``
+alongside it. This installer just calls that endpoint — no file pushing
+from the controller, no remote SSH, no Modelfile generation on our side.
+
+The endpoint expects the model identifier in three slash-separated parts:
+``<hf_user>/<hf_repo>/<filename>.rkllm``. We derive that from the catalog
+manifest's variant ``download_url`` (a full HuggingFace ``/resolve/main/``
+URL), so we don't need any extra fields on the manifest.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+
+from tinyagentos.installers.base import AppInstaller
+
+logger = logging.getLogger(__name__)
+
+
+# Match a full HF resolve URL and capture (user, repo, filename).
+# Example: https://huggingface.co/c01zaut/Qwen2.5-3B-Instruct-rk3588-1.1.4/resolve/main/foo.rkllm
+_HF_RESOLVE_RE = re.compile(
+    r"^https?://huggingface\.co/(?P<user>[^/]+)/(?P<repo>[^/]+)/resolve/[^/]+/(?P<filename>[^/?#]+)$"
+)
+
+
+def parse_hf_resolve_url(url: str) -> tuple[str, str, str]:
+    """Return (user, repo, filename) for an HF resolve URL.
+
+    Raises ValueError if the URL doesn't look like a HuggingFace resolve URL.
+    """
+    m = _HF_RESOLVE_RE.match(url)
+    if not m:
+        raise ValueError(
+            f"download_url is not a HuggingFace resolve URL: {url!r}. "
+            "Expected shape: https://huggingface.co/<user>/<repo>/resolve/<branch>/<file>"
+        )
+    return m.group("user"), m.group("repo"), m.group("filename")
+
+
+class RkllamaInstaller(AppInstaller):
+    """Install ``.rkllm`` models by calling the rkllama ``/api/pull`` endpoint.
+
+    By default the installer talks to ``http://localhost:8080`` — the
+    controller-local rkllama. When a remote worker hosts rkllama, callers
+    pass ``rkllama_url`` (e.g. ``http://192.168.6.123:8080``).
+    """
+
+    def __init__(self, rkllama_url: str | None = None, timeout: int = 1800):
+        # rkllama install can take many minutes for multi-GB weights — give it
+        # half an hour by default. Caller may override.
+        self.rkllama_url = (rkllama_url or "http://localhost:8080").rstrip("/")
+        self.timeout = timeout
+
+    async def install(
+        self,
+        app_id: str,
+        install_config: dict,
+        variant: dict | None = None,
+        **_: Any,
+    ) -> dict:
+        if not variant:
+            return {
+                "success": False,
+                "error": "rkllama install requires a variant (with download_url)",
+            }
+        url = variant.get("download_url")
+        if not url:
+            return {
+                "success": False,
+                "error": f"variant {variant.get('id')!r} missing download_url",
+            }
+
+        try:
+            user, repo, filename = parse_hf_resolve_url(url)
+        except ValueError as exc:
+            return {"success": False, "error": str(exc)}
+
+        # rkllama's pull handler splits on '/' and expects exactly three parts.
+        model_spec = f"{user}/{repo}/{filename}"
+        # Stable model name in rkllama: the catalog app_id, not the auto-derived
+        # filename. Lets agents reference "qwen2.5-3b-rkllm" instead of the
+        # quant-suffixed filename.
+        body = {"model": model_spec, "model_name": app_id}
+
+        endpoint = f"{self.rkllama_url}/api/pull"
+        logger.info("rkllama install: POST %s body=%r", endpoint, body)
+
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                # /api/pull streams ndjson progress; we drain the stream until
+                # close. Any non-2xx status is an install failure.
+                async with client.stream("POST", endpoint, json=body) as resp:
+                    if resp.status_code >= 400:
+                        text = (await resp.aread()).decode("utf-8", errors="replace")
+                        return {
+                            "success": False,
+                            "error": f"rkllama /api/pull returned {resp.status_code}: {text[:500]}",
+                        }
+                    last_line = ""
+                    async for line in resp.aiter_lines():
+                        if line:
+                            last_line = line
+                    logger.info(
+                        "rkllama install: pull complete for %s (last line: %s)",
+                        app_id, last_line[:200],
+                    )
+        except httpx.HTTPError as exc:
+            return {
+                "success": False,
+                "error": f"rkllama /api/pull failed: {exc}",
+            }
+
+        # Verify the model now appears in /api/tags so we know rkllama
+        # successfully registered it.
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                tags = await client.get(f"{self.rkllama_url}/api/tags")
+                tags.raise_for_status()
+                names = {m.get("name") for m in tags.json().get("models", [])}
+                if app_id not in names:
+                    return {
+                        "success": False,
+                        "error": (
+                            f"rkllama pull returned 200 but {app_id!r} is not in "
+                            f"/api/tags. Known models: {sorted(names)[:5]}"
+                        ),
+                    }
+        except httpx.HTTPError as exc:
+            logger.warning(
+                "rkllama install: /api/tags verification failed: %s", exc
+            )
+            # Non-fatal — pull succeeded; verification problem is likely transient.
+
+        return {"success": True, "app_id": app_id, "model_name": app_id}
+
+    async def uninstall(self, app_id: str) -> dict:
+        endpoint = f"{self.rkllama_url}/api/delete"
+        try:
+            async with httpx.AsyncClient(timeout=30) as client:
+                resp = await client.request(
+                    "DELETE", endpoint, json={"name": app_id}
+                )
+                if resp.status_code == 404:
+                    return {"success": True, "status": "not_installed"}
+                resp.raise_for_status()
+        except httpx.HTTPError as exc:
+            return {"success": False, "error": f"rkllama /api/delete failed: {exc}"}
+        return {"success": True, "status": "uninstalled"}
+
+
+def resolve_rkllama_url(target_remote: str | None) -> str:
+    """Resolve which rkllama instance to talk to.
+
+    - ``None`` / empty / "local" → controller's own rkllama on loopback.
+    - Anything else → the remote worker's hostname on port 8080.
+
+    rkllama always serves on 8080; that's hard-coded by ``install-rknpu.sh``
+    and the systemd unit. If we ever make the port configurable per worker
+    we'll need a registry lookup here.
+    """
+    if not target_remote or target_remote == "local":
+        return "http://localhost:8080"
+    return f"http://{target_remote}:8080"

--- a/tinyagentos/routes/store_install.py
+++ b/tinyagentos/routes/store_install.py
@@ -92,6 +92,77 @@ async def install_app(request: Request):
                 status_code=400,
             )
 
+    if backend == "rkllama":
+        # Models served by rkllama are pulled by rkllama itself via its
+        # /api/pull endpoint — no file transfer from the controller. We
+        # need to know which device is hosting rkllama; default is the
+        # controller, override via target_remote.
+        from tinyagentos.installers.rkllama_installer import (
+            RkllamaInstaller,
+            resolve_rkllama_url,
+        )
+
+        raw_remote = body.get("target_remote") or install_config.get("target_remote") or ""
+        target_remote: str | None = raw_remote if raw_remote and raw_remote != "local" else None
+        rkllama_url = resolve_rkllama_url(target_remote)
+
+        # Pick the right variant: explicit body override → manifest's
+        # recommended for this hardware tier → first variant.
+        variant_id = body.get("variant_id")
+        variants = list(getattr(manifest, "variants", []) or [])
+        chosen_variant: dict | None = None
+        if variant_id:
+            chosen_variant = next(
+                (v for v in variants if v.get("id") == variant_id), None
+            )
+        if chosen_variant is None and variants:
+            chosen_variant = variants[0]
+        if chosen_variant is None:
+            return JSONResponse(
+                {"error": f"manifest for {app_id!r} declares method=rkllama but has no variants"},
+                status_code=400,
+            )
+
+        installer = RkllamaInstaller(rkllama_url=rkllama_url)
+        try:
+            result = await installer.install(
+                app_id, install_config, variant=chosen_variant
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("rkllama install failed for %s", app_id)
+            return JSONResponse({"error": str(exc)}, status_code=500)
+
+        if not result.get("success"):
+            return JSONResponse(
+                {"error": result.get("error", "rkllama install failed")},
+                status_code=500,
+            )
+
+        # Persist install state.
+        store = getattr(request.app.state, "installed_apps", None)
+        if store is not None:
+            await store.install(app_id, body.get("version", ""), meta)
+            # rkllama always serves on 8080; the runtime location is the
+            # rkllama host itself — that's where the model lives.
+            await store.update_runtime_location(
+                app_id,
+                host=urlparse(rkllama_url).hostname or "localhost",
+                port=urlparse(rkllama_url).port or 8080,
+                backend="rkllama",
+                ui_path="/",
+            )
+        if registry is not None:
+            version = body.get("version") or (getattr(manifest, "version", "") if manifest else "")
+            registry.mark_installed(app_id, version)
+
+        return JSONResponse({
+            "ok": True,
+            "app_id": app_id,
+            "status": "installed",
+            "rkllama_url": rkllama_url,
+            **result,
+        })
+
     if backend == "lxc":
         # LXC installs require admin_password.
         admin_password = body.get("admin_password", "")


### PR DESCRIPTION
## Summary

Makes the Store install button actually work for rkllama-backed models on Orange Pi (it didn't before — the default install-v2 branch just recorded metadata, no `.rkllm` weight ever moved). Adds an `RkllamaInstaller` that calls rkllama's own `/api/pull` endpoint, which downloads the weight directly onto the Pi from HuggingFace and auto-creates the rkllama Modelfile.

## Catalog

The Store now lists **14 rkllm Qwen models** for Orange Pi 5 / 5+ users:

**Existing (5)** — got `install: {method: rkllama}` plumbing:
- `pelochus-qwen-1.8b-rkllm` · `qwen2.5-1.5b-rkllm` · `qwen2.5-3b-rkllm` · `qwen2.5-7b-rkllm` · `qwen2.5-14b-rkllm`

**New chat (3):**
- `qwen3-1.7b-rkllm` (GatekeeperZA, 2.4 GB)
- `qwen3-4b-rkllm` (thanhtantran 2507 tune, 4.9 GB)
- `qwen2.5-coder-7b-rkllm` (c01zaut, 8 GB)

**New code (2):**
- `qwen2.5-coder-1.5b-rkllm` (2 GB) · `qwen2.5-coder-14b-rkllm` (15.6 GB, 32GB Pi only)

**New math/reasoning (2):**
- `qwen2.5-math-1.5b-rkllm` (2 GB) · `qwen2.5-math-7b-rkllm` (8.2 GB)

**New vision-language (2):**
- `qwen3-vl-2b-rkllm` (2.4 GB) · `qwen3-vl-4b-rkllm` (4.9 GB)

## Wiring

- `RkllamaInstaller` in `tinyagentos/installers/rkllama_installer.py` — POSTs `<user>/<repo>/<file>` to rkllama's `/api/pull`, drains the streamed progress, verifies the model appears in `/api/tags`, falls back to controller-loopback when no `target_remote` is specified.
- `get_installer("rkllama")` in `installers/base.py` returns the new installer.
- `/api/store/install-v2` dispatches to a new rkllama branch when the manifest declares `method: rkllama`. Picks the right rkllama URL (loopback for controller; `http://<remote>:8080` for a worker), runs install, persists `runtime_location` pointing at the rkllama host.
- 12 unit tests for the HF URL parser + URL resolver.

## End-to-end test

Real pull verified on Pi (192.168.6.123):
```
POST /api/pull {"model": "GatekeeperZA/Qwen3-1.7B-RKLLM-v1.2.3/Qwen3-1.7B-w8a8-rk3588.rkllm", "model_name": "qwen3-1.7b-rkllm-test"}
→ 99% → 100% in ~2 min for 2.4 GB
→ qwen3-1.7b-rkllm-test appears in /api/tags ✓
→ Modelfile written to ~/rkllama/models/qwen3-1.7b-rkllm-test/ ✓
```

## Skipped

- **Qwen3-ASR-1.7B** (happyme531) — model file is in a subfolder; rkllama's `/api/pull` only supports flat `<user>/<repo>/<file>` paths today. Follow-up to extend the parser.
- **AgentDoG-Qwen2.5-7B** — file is 15.3 GB for a "7B" model, indicates non-standard quant; skipped pending sanity check.
- Alternate uploaders (workholic7228, akmaldira, CreamSys) — duplicates of established ones already shipped.

## Test Plan
- [x] `pytest tests/test_rkllama_installer.py` — 12/12 pass
- [x] Real `/api/pull` against Pi for Qwen3-1.7B — succeeded in ~2 min
- [ ] Click Install on Qwen3-1.7B from the Store UI on the Pi — manual smoke

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added rkllama installation method for deploying language models on rkllama-supported hardware.
  * Introduced 12 new Qwen model variants including Qwen 2.5 Coder, Math, and Qwen 3 series models.

* **Tests**
  * Added tests for rkllama installer functionality.

* **Chores**
  * Updated gitignore to preserve model catalog tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->