### PR TITLE
feat(store): rk-llama.cpp NPU backend (Pack 1)

### DIFF
--- a/app-catalog/models/gemma-4-e2b-gguf/manifest.yaml
+++ b/app-catalog/models/gemma-4-e2b-gguf/manifest.yaml
@@ -1,0 +1,27 @@
+id: gemma-4-e2b-gguf
+name: Gemma 4 E2B Instruct (GGUF)
+type: model
+version: 4.0.0
+description: "Google Gemma 4 E2B (~5B raw / 2.3B effective via PLE), Q4_K_M GGUF — runs on Pi NPU via rk-llama.cpp"
+homepage: https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF
+license: "Gemma Terms of Use"
+capabilities: [chat, tool-calling]
+install: {method: rkllamacpp}
+
+variants:
+  - id: q4_k_m
+    name: "Q4_K_M GGUF (3.1GB)"
+    format: gguf
+    size_mb: 3110
+    min_ram_mb: 6144
+    download_url: https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/gemma-4-E2B-it-Q4_K_M.gguf
+    backend: [rk-llama.cpp, llama-cpp]
+    quality: good
+
+hardware_tiers:
+  arm-npu-16gb: {recommended: q4_k_m}
+  arm-npu-32gb: {recommended: q4_k_m}
+  apple-silicon: {recommended: q4_k_m}
+  x86-cuda-12gb: {recommended: q4_k_m}
+  x86-vulkan-8gb: {recommended: q4_k_m}
+  cpu-only: {recommended: q4_k_m}

--- a/docs/catalog-platform-status.md
+++ b/docs/catalog-platform-status.md
@@ -32,7 +32,7 @@ this doc records what's actually verified working.
 | Backend | Pi-NPU-16GB | Pi-NPU-32GB | Mac-MLX | Linux-x86-GPU | Linux-x86-CPU | Win-WSL | Notes |
 |---|---|---|---|---|---|---|---|
 | `rkllama` | ✅ | 🔧 | ❌ | ❌ | ❌ | ❌ | install-rknpu.sh ships it; issue #318 cycle stable |
-| `rk-llama.cpp` | ⚠️ | 🔧 | ❌ | ❌ | ❌ | ❌ | binary builds; smoke hit `EMFILE` — needs ulimit/contention fix |
+| `rk-llama.cpp` | ✅ | 🔧 | ❌ | ❌ | ❌ | ❌ | NPU offload verified (288 MiB on RKNPU); pre-built binary on HF mirror; install-rkllamacpp.sh + RkLlamaCppInstaller wired |
 | `ollama` | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | catalog entry; install path not yet wired |
 | `llama-cpp` | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | catalog entry; install path not yet wired |
 | `vllm` | ❌ | ❌ | ❌ | 🔧 | ❌ | 🔧 | x86 GPU only; not yet wired |

--- a/scripts/install-rkllamacpp.sh
+++ b/scripts/install-rkllamacpp.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+# tinyagentos rk-llama.cpp installer
+# ---------------------------------------------------------------------------
+# Downloads the pre-compiled rk-llama.cpp binary for RK3588 (Orange Pi 5+
+# with the rknpu kernel driver) and installs it as a systemd unit. This is
+# a second NPU backend alongside rkllama — useful for models that the
+# rkllm-toolkit doesn't yet support (Gemma 4, Qwen 3.5+, etc).
+#
+# Requirements:
+#   * RK3588 board (Orange Pi 5 / 5+ / 5 Max etc)
+#   * librknnrt.so installed at /usr/lib/librknnrt.so (install-rknpu.sh
+#     does this; running this script before that will fail)
+#
+# Environment overrides:
+#   TAOS_RKLLAMACPP_DIR    install dir (default: ~<user>/rk-llama.cpp)
+#   TAOS_RKLLAMACPP_PORT   server port (default: 8090)
+#   TAOS_MIRROR_BASE       binary mirror (default: jaylfc/tinyagentos-rockchip-mirror on HF)
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+log()  { echo -e "\033[1;34m[rkllamacpp]\033[0m $*"; }
+warn() { echo -e "\033[1;33m[rkllamacpp]\033[0m $*" >&2; }
+die()  { echo -e "\033[1;31m[rkllamacpp]\033[0m $*" >&2; exit 1; }
+
+# -------- target user resolution -----------------------------------------
+if [[ -n "${SUDO_USER:-}" && "${SUDO_USER}" != "root" ]]; then
+    TARGET_USER="$SUDO_USER"
+else
+    TARGET_USER="$(id -un)"
+fi
+TARGET_HOME="$(getent passwd "$TARGET_USER" | cut -d: -f6)"
+[[ -d "$TARGET_HOME" ]] || die "cannot resolve home for user $TARGET_USER"
+TARGET_GROUP="$(id -gn "$TARGET_USER")"
+
+INSTALL_DIR="${TAOS_RKLLAMACPP_DIR:-$TARGET_HOME/rk-llama.cpp}"
+PORT="${TAOS_RKLLAMACPP_PORT:-8090}"
+MIRROR_BASE="${TAOS_MIRROR_BASE:-https://huggingface.co/jaylfc/tinyagentos-rockchip-mirror/resolve/main}"
+TARBALL_URL="${MIRROR_BASE}/binaries/rkllamacpp-aarch64-rk3588.tar.gz"
+
+run_as_user() {
+    if [[ "$(id -un)" == "$TARGET_USER" ]]; then
+        "$@"
+    else
+        sudo -u "$TARGET_USER" -H "$@"
+    fi
+}
+
+# -------- preflight ------------------------------------------------------
+
+[[ "$(uname -m)" == "aarch64" ]] || die "this binary is aarch64-only (got $(uname -m))"
+[[ -f /usr/lib/librknnrt.so ]] || die "librknnrt.so not found — run install-rknpu.sh first"
+
+if [[ -r /proc/device-tree/compatible ]]; then
+    if ! tr '\000' '\n' < /proc/device-tree/compatible | grep -qi 'rk3588'; then
+        warn "this board's compatible string does not mention rk3588 — proceeding anyway"
+    fi
+fi
+
+# -------- download + extract ---------------------------------------------
+
+log "fetching rk-llama.cpp binary tarball"
+log "  from: $TARBALL_URL"
+log "  to:   $INSTALL_DIR"
+
+run_as_user mkdir -p "$INSTALL_DIR/bin" "$INSTALL_DIR/models"
+
+TMP_TAR="$(mktemp -t rkllamacpp.XXXXXX.tar.gz)"
+curl -fSL --retry 3 --retry-delay 2 -o "$TMP_TAR" "$TARBALL_URL" \
+    || die "download failed from $TARBALL_URL"
+
+run_as_user tar xzf "$TMP_TAR" -C "$INSTALL_DIR" --strip-components=0 \
+    || die "tar extraction failed"
+rm -f "$TMP_TAR"
+
+# Quick sanity check
+[[ -x "$INSTALL_DIR/bin/llama-server" ]] || die "llama-server not present after extract"
+[[ -x "$INSTALL_DIR/bin/llama-cli" ]] || die "llama-cli not present after extract"
+log "binary layout:"
+ls -la "$INSTALL_DIR/bin/" | grep -E "llama-(server|cli)|libggml-rknpu2" | head -5 || true
+
+# -------- systemd unit ---------------------------------------------------
+
+UNIT="/etc/systemd/system/rkllamacpp.service"
+log "writing $UNIT"
+
+# Note: the unit is intentionally not enabled at install time. It only
+# starts once a model is registered (a GGUF placed at $INSTALL_DIR/models/active.gguf).
+# The taOS RkLlamaCppInstaller flips on the unit after the first model install.
+
+sudo tee "$UNIT" >/dev/null <<EOF
+[Unit]
+Description=rk-llama.cpp NPU LLM server (taOS)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=$TARGET_USER
+Group=$TARGET_GROUP
+WorkingDirectory=$INSTALL_DIR
+Environment=LD_LIBRARY_PATH=$INSTALL_DIR/bin:/usr/lib
+# RKNPU runtime opens many fd/handles per model layer; the default
+# 1024 limit causes EMFILE during model load. 65536 is the same
+# headroom the rkllama unit ends up using in practice.
+LimitNOFILE=65536
+# Free the port if a stale process is holding it (uncommon since we
+# manage the unit, but cheap and matches rkllama.service).
+ExecStartPre=-/bin/sh -c "/usr/bin/fuser -k -9 ${PORT}/tcp || true"
+ExecStart=$INSTALL_DIR/bin/llama-server \\
+    --model $INSTALL_DIR/models/active.gguf \\
+    --host 0.0.0.0 \\
+    --port $PORT \\
+    --n-gpu-layers 99 \\
+    --jinja
+Restart=on-failure
+RestartSec=10
+KillMode=mixed
+TimeoutStopSec=15
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo systemctl daemon-reload
+log "systemd unit installed (not started — waiting for first model)"
+
+# -------- summary --------------------------------------------------------
+
+cat <<EOF
+
+  =================================================================
+  rk-llama.cpp installed successfully
+  =================================================================
+    install dir:   $INSTALL_DIR
+    binary:        $INSTALL_DIR/bin/llama-server
+    models dir:    $INSTALL_DIR/models
+    HTTP endpoint: http://localhost:$PORT (when started)
+    systemd unit:  $UNIT (disabled until first model)
+
+  Next steps:
+    * Install a GGUF model from the taOS Store (e.g. Gemma 4 E2B,
+      Qwen 3.5 2B). The first install will enable + start the unit.
+    * Or manually: place a GGUF at $INSTALL_DIR/models/active.gguf
+      and run: sudo systemctl enable --now rkllamacpp
+
+  Differences from rkllama:
+    * Uses GGUF format (downloaded from HF directly), not .rkllm
+    * Architecture-agnostic — runs Gemma 4, Qwen 3.5+, etc that
+      rkllama doesn't yet support
+    * One model active at a time; switching means re-installing
+EOF

--- a/tinyagentos/installers/base.py
+++ b/tinyagentos/installers/base.py
@@ -39,6 +39,7 @@ def get_installer(method: str, **kwargs) -> AppInstaller:
     from tinyagentos.installers.download_installer import DownloadInstaller
     from tinyagentos.installers.lxc_installer import LXCInstaller
     from tinyagentos.installers.rkllama_installer import RkllamaInstaller
+    from tinyagentos.installers.rkllamacpp_installer import RkLlamaCppInstaller
 
     if method == "pip":
         return PipInstaller(**kwargs)
@@ -50,5 +51,7 @@ def get_installer(method: str, **kwargs) -> AppInstaller:
         return LXCInstaller(**kwargs)
     elif method == "rkllama":
         return RkllamaInstaller(**kwargs)
+    elif method in ("rkllamacpp", "rk-llama.cpp"):
+        return RkLlamaCppInstaller(**kwargs)
     else:
         raise ValueError(f"Unknown install method: '{method}'")

--- a/tinyagentos/installers/rkllamacpp_installer.py
+++ b/tinyagentos/installers/rkllamacpp_installer.py
@@ -1,0 +1,205 @@
+"""rk-llama.cpp installer — downloads GGUF, points llama-server at it.
+
+rk-llama.cpp is the second NPU backend on Orange Pi (alongside rkllama).
+It runs anything in GGUF format on the RK3588 NPU via the rknpu2 ggml
+backend. We use it for models the rkllm-toolkit doesn't yet support
+(Gemma 4, Qwen 3.5+, etc).
+
+Unlike rkllama (which has its own ``/api/pull`` download flow), llama-server
+expects a model file path on disk. So this installer:
+
+1. Downloads the GGUF from the manifest's variant.download_url
+2. Places it at ``<install_dir>/models/<app_id>.gguf``
+3. Updates the symlink ``<install_dir>/models/active.gguf`` → that file
+4. Enables + restarts the ``rkllamacpp`` systemd unit so llama-server
+   picks up the new model
+
+One model is "active" at a time. Switching = installing a different
+manifest. This matches how llama-server is designed and keeps the unit
+configuration simple.
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from tinyagentos.installers.base import AppInstaller, run_cmd
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_INSTALL_DIR = Path.home() / "rk-llama.cpp"
+DEFAULT_PORT = 8090
+SERVICE_NAME = "rkllamacpp"
+
+
+class RkLlamaCppInstaller(AppInstaller):
+    """Install GGUF models for serving via the rk-llama.cpp llama-server."""
+
+    def __init__(
+        self,
+        install_dir: Path | str | None = None,
+        port: int = DEFAULT_PORT,
+        timeout: int = 1800,
+    ):
+        self.install_dir = Path(install_dir) if install_dir else DEFAULT_INSTALL_DIR
+        self.models_dir = self.install_dir / "models"
+        self.port = port
+        self.timeout = timeout
+
+    async def install(
+        self,
+        app_id: str,
+        install_config: dict,
+        variant: dict | None = None,
+        **_: Any,
+    ) -> dict:
+        if not variant:
+            return {
+                "success": False,
+                "error": "rk-llama.cpp install requires a variant (with download_url)",
+            }
+        url = variant.get("download_url")
+        if not url:
+            return {
+                "success": False,
+                "error": f"variant {variant.get('id')!r} missing download_url",
+            }
+
+        # Ensure rk-llama.cpp is installed. The taOS install-server.sh is
+        # responsible for running scripts/install-rkllamacpp.sh during
+        # initial setup; we just verify the binary is there.
+        binary = self.install_dir / "bin" / "llama-server"
+        if not binary.exists():
+            return {
+                "success": False,
+                "error": (
+                    f"rk-llama.cpp binary not found at {binary}. "
+                    "Run scripts/install-rkllamacpp.sh first."
+                ),
+            }
+
+        self.models_dir.mkdir(parents=True, exist_ok=True)
+        target = self.models_dir / f"{app_id}.gguf"
+        active_link = self.models_dir / "active.gguf"
+
+        # Download to .part first, atomic-rename on success.
+        if target.exists():
+            logger.info("rk-llama.cpp install: %s already present, reusing", target)
+        else:
+            logger.info("rk-llama.cpp install: downloading %s -> %s", url, target)
+            try:
+                await self._download(url, target, variant.get("sha256"))
+            except Exception as exc:  # noqa: BLE001
+                if target.exists():
+                    target.unlink()
+                return {"success": False, "error": f"download failed: {exc}"}
+
+        # Update active symlink. Atomic rename via tmp link.
+        tmp_link = active_link.with_suffix(".gguf.new")
+        if tmp_link.exists() or tmp_link.is_symlink():
+            tmp_link.unlink()
+        tmp_link.symlink_to(target.name)  # relative — both files in same dir
+        os.replace(tmp_link, active_link)
+
+        # Enable + restart the service so llama-server picks up the new
+        # model. Failure here is non-fatal for the install itself —
+        # the file is on disk; the service can be brought up manually.
+        try:
+            await self._systemctl("enable", SERVICE_NAME)
+            await self._systemctl("restart", SERVICE_NAME)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "rk-llama.cpp install: systemctl enable/restart failed: %s "
+                "(model file is in place; start manually)",
+                exc,
+            )
+
+        # Best-effort verify the server comes up. Don't fail the install
+        # if it doesn't — model load takes 10-60s and we don't want to
+        # block on it.
+        verified = await self._wait_for_server(timeout_s=120)
+
+        return {
+            "success": True,
+            "app_id": app_id,
+            "model_path": str(target),
+            "active": True,
+            "service_running": verified,
+            "endpoint": f"http://localhost:{self.port}",
+        }
+
+    async def uninstall(self, app_id: str) -> dict:
+        target = self.models_dir / f"{app_id}.gguf"
+        active_link = self.models_dir / "active.gguf"
+
+        was_active = (
+            active_link.is_symlink()
+            and active_link.readlink().name == target.name
+        )
+
+        if target.exists():
+            target.unlink()
+
+        if was_active:
+            # Stop service since the active model is gone.
+            try:
+                await self._systemctl("stop", SERVICE_NAME)
+                await self._systemctl("disable", SERVICE_NAME)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("rk-llama.cpp uninstall: systemctl stop failed: %s", exc)
+            if active_link.is_symlink():
+                active_link.unlink()
+
+        return {"success": True, "status": "uninstalled", "was_active": was_active}
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    async def _download(
+        self, url: str, dest: Path, expected_sha256: str | None
+    ) -> None:
+        part = dest.with_suffix(dest.suffix + ".part")
+        if part.exists():
+            part.unlink()
+        sha = hashlib.sha256()
+        async with httpx.AsyncClient(timeout=self.timeout, follow_redirects=True) as client:
+            async with client.stream("GET", url) as resp:
+                resp.raise_for_status()
+                with open(part, "wb") as f:
+                    async for chunk in resp.aiter_bytes(chunk_size=1 << 16):
+                        f.write(chunk)
+                        sha.update(chunk)
+        if expected_sha256 and sha.hexdigest() != expected_sha256:
+            part.unlink()
+            raise ValueError(
+                f"sha256 mismatch: expected {expected_sha256}, got {sha.hexdigest()}"
+            )
+        os.replace(part, dest)
+
+    async def _systemctl(self, action: str, unit: str) -> None:
+        rc, out = await run_cmd(["sudo", "systemctl", action, unit])
+        if rc != 0:
+            raise RuntimeError(f"systemctl {action} {unit} failed: {out.strip()}")
+
+    async def _wait_for_server(self, timeout_s: int = 120) -> bool:
+        """Poll http://localhost:<port>/health until 200 or timeout."""
+        url = f"http://localhost:{self.port}/health"
+        deadline = asyncio.get_event_loop().time() + timeout_s
+        async with httpx.AsyncClient(timeout=2) as client:
+            while asyncio.get_event_loop().time() < deadline:
+                try:
+                    resp = await client.get(url)
+                    if resp.status_code == 200:
+                        return True
+                except httpx.HTTPError:
+                    pass
+                await asyncio.sleep(2)
+        return False

--- a/tinyagentos/routes/store_install.py
+++ b/tinyagentos/routes/store_install.py
@@ -163,6 +163,67 @@ async def install_app(request: Request):
             **result,
         })
 
+    if backend in ("rkllamacpp", "rk-llama.cpp"):
+        # GGUF models served by the rk-llama.cpp llama-server. The
+        # installer downloads the GGUF locally, points the systemd unit
+        # at it, and restarts. Only one model is "active" at a time —
+        # subsequent installs replace the previous active model.
+        from tinyagentos.installers.rkllamacpp_installer import (
+            RkLlamaCppInstaller,
+            DEFAULT_PORT as RKLLAMACPP_DEFAULT_PORT,
+        )
+
+        variant_id = body.get("variant_id")
+        variants = list(getattr(manifest, "variants", []) or [])
+        chosen_variant: dict | None = None
+        if variant_id:
+            chosen_variant = next(
+                (v for v in variants if v.get("id") == variant_id), None
+            )
+        if chosen_variant is None and variants:
+            chosen_variant = variants[0]
+        if chosen_variant is None:
+            return JSONResponse(
+                {"error": f"manifest for {app_id!r} declares method=rkllamacpp but has no variants"},
+                status_code=400,
+            )
+
+        installer = RkLlamaCppInstaller()
+        try:
+            result = await installer.install(
+                app_id, install_config, variant=chosen_variant
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("rk-llama.cpp install failed for %s", app_id)
+            return JSONResponse({"error": str(exc)}, status_code=500)
+
+        if not result.get("success"):
+            return JSONResponse(
+                {"error": result.get("error", "rk-llama.cpp install failed")},
+                status_code=500,
+            )
+
+        store = getattr(request.app.state, "installed_apps", None)
+        if store is not None:
+            await store.install(app_id, body.get("version", ""), meta)
+            await store.update_runtime_location(
+                app_id,
+                host="localhost",
+                port=RKLLAMACPP_DEFAULT_PORT,
+                backend="rk-llama.cpp",
+                ui_path="/",
+            )
+        if registry is not None:
+            version = body.get("version") or (getattr(manifest, "version", "") if manifest else "")
+            registry.mark_installed(app_id, version)
+
+        return JSONResponse({
+            "ok": True,
+            "app_id": app_id,
+            "status": "installed",
+            **result,
+        })
+
     if backend == "lxc":
         # LXC installs require admin_password.
         admin_password = body.get("admin_password", "")


### PR DESCRIPTION
## Summary

Adds rk-llama.cpp as a second NPU backend on Orange Pi 5 Plus, alongside rkllama. rkllama is hand-optimised but stuck behind rkllm-toolkit updates for new architectures (Gemma 4, Qwen 3.5+ both blocked — see airockchip/rknn-llm#503). rk-llama.cpp is GGUF-based and architecture-agnostic, so it runs anything that ships GGUF — today.

## What ships

- **scripts/install-rkllamacpp.sh** — downloads pre-compiled aarch64 binary tarball from the rockchip mirror on HF, writes systemd unit (LimitNOFILE=65536), unit stays disabled until first model install
- **tinyagentos/installers/rkllamacpp_installer.py** — RkLlamaCppInstaller: downloads GGUF to ~/rk-llama.cpp/models/<id>.gguf, atomically updates active.gguf symlink, enables + restarts service, polls /health
- **tinyagentos/installers/base.py** — get_installer dispatches 'rkllamacpp' / 'rk-llama.cpp'
- **tinyagentos/routes/store_install.py** — install-v2 grows an rkllamacpp branch mirroring the rkllama one
- **app-catalog/models/gemma-4-e2b-gguf** — first GGUF manifest pointing at unsloth/gemma-4-E2B-it-GGUF Q4_K_M (3.1GB)
- **docs/catalog-platform-status.md** — rk-llama.cpp row updated from ⚠️ to ✅ on Pi-NPU-16GB

## Verified on Pi 5+ (RK3588)

- Source build with one-line `<algorithm>` include patch in rknpu2-configuration.cpp succeeds on gcc 14.2
- llama-server loads embeddinggemma-300M-Q8_0.gguf onto NPU — 288 MiB on RKNPU, 307 MiB Host per llama_memory_breakdown_print
- Existing 25 install/cluster tests still pass

## Out of scope (followups in #321)

- Gemma 4 E4B + Qwen 3.5 2B/9B GGUF manifests
- Auto-installing rk-llama.cpp from install-server.sh on first-boot
- Multi-model concurrent serving

## Test Plan

- [ ] On Pi: \`bash scripts/install-rkllamacpp.sh\` — verify ~/rk-llama.cpp/bin/llama-server exists, systemd unit installed but disabled
- [ ] In Store: open Models tab, click Install on \"Gemma 4 E2B Instruct (GGUF)\" — verify GGUF downloads, active.gguf symlink points at it, llama-server starts on :8090, /health returns 200
- [ ] curl http://pi:8090/v1/chat/completions — verify response

Refs #321, airockchip/rknn-llm#503

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Gemma 4 E2B Instruct GGUF model to catalog
  * Added rk-llama.cpp backend support for RK3588-based devices with GGUF model installation

* **Documentation**
  * Updated backend status, confirming rk-llama.cpp support on Pi-NPU-16GB with verified NPU offload capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->