### PR TITLE
fix(settings): update-flow hardening — fail-loud + manual Rebuild Frontend

### DIFF
--- a/desktop/src/apps/SettingsApp.tsx
+++ b/desktop/src/apps/SettingsApp.tsx
@@ -633,6 +633,7 @@ function RestartProgressModal({
 function UpdatesSection() {
   const [checking, setChecking] = useState(false);
   const [applying, setApplying] = useState(false);
+  const [rebuilding, setRebuilding] = useState(false);
   const [info, setInfo] = useState<UpdateInfo | null>(null);
   const [status, setStatus] = useState<string | null>(null);
   const [prefs, setPrefs] = useState<AutoUpdatePrefs>({ check_enabled: true, auto_apply: false, auto_restart: false });
@@ -724,6 +725,23 @@ function UpdatesSection() {
     setApplying(false);
   };
 
+  const rebuildFrontend = async () => {
+    setRebuilding(true);
+    setStatus(null);
+    try {
+      const res = await fetch("/api/settings/rebuild-frontend", { method: "POST" });
+      const data = (await res.json().catch(() => ({}))) as { message?: string; error?: string };
+      if (res.ok) {
+        setStatus(data.message ?? "Frontend rebuilt — hard-refresh the browser to see changes.");
+      } else {
+        setStatus(data.error ?? "Frontend rebuild failed.");
+      }
+    } catch {
+      setStatus("Could not reach rebuild endpoint.");
+    }
+    setRebuilding(false);
+  };
+
   const triggerRestart = async () => {
     setShowRestartModal(true);
     try {
@@ -792,6 +810,17 @@ function UpdatesSection() {
               {applying ? "Installing..." : "Install Update"}
             </Button>
           ) : null}
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={rebuildFrontend}
+            disabled={rebuilding}
+            aria-label="Force rebuild of the desktop frontend bundle"
+            title="Rebuild the desktop bundle from source. Use after a source-only update or when the UI looks stale."
+          >
+            <RefreshCw size={14} className={rebuilding ? "animate-spin" : ""} />
+            {rebuilding ? "Rebuilding..." : "Rebuild Frontend"}
+          </Button>
         </div>
 
         {status && (

--- a/tests/test_routes_settings.py
+++ b/tests/test_routes_settings.py
@@ -137,3 +137,28 @@ class TestSettingsRoutes:
         resp = await client.delete("/api/settings/webhooks/0")
         assert resp.status_code == 200
         assert resp.json()["status"] == "removed"
+
+
+class TestRunCaptureHelper:
+    """Helper used by /api/settings/update to surface pip + smoke-test output.
+
+    The previous implementation piped pip output to DEVNULL, so a failed
+    install left no breadcrumbs and users grey-screened on next restart.
+    These tests pin the helper's contract.
+    """
+
+    @pytest.mark.asyncio
+    async def test_captures_stdout_and_returncode_on_success(self):
+        from tinyagentos.routes.settings import _run_capture
+
+        rc, out = await _run_capture(["sh", "-c", "echo hello-from-helper"])
+        assert rc == 0
+        assert "hello-from-helper" in out
+
+    @pytest.mark.asyncio
+    async def test_captures_stderr_and_returncode_on_failure(self):
+        from tinyagentos.routes.settings import _run_capture
+
+        rc, out = await _run_capture(["sh", "-c", "echo boom-on-stderr 1>&2; exit 7"])
+        assert rc == 7
+        assert "boom-on-stderr" in out

--- a/tinyagentos/desktop_rebuild.py
+++ b/tinyagentos/desktop_rebuild.py
@@ -36,8 +36,9 @@ async def rebuild_desktop_bundle_if_stale(
     project_root: Path,
     *,
     timeout_seconds: int = 600,
+    force: bool = False,
 ) -> tuple[bool, str]:
-    """Run npm install + npm run build if the bundle is stale.
+    """Run npm install + npm run build if the bundle is stale (or always, if force=True).
 
     Returns ``(rebuilt, message)``.  ``rebuilt=False`` means skipped (bundle is
     current or npm unavailable).  ``rebuilt=True`` means a rebuild was attempted;
@@ -45,8 +46,13 @@ async def rebuild_desktop_bundle_if_stale(
 
     On hosts where npm/node aren't installed the rebuild fails gracefully with a
     clear log message.  The caller can decide whether to surface it to the user.
+
+    Use ``force=True`` for explicit user-initiated rebuilds (e.g. the
+    ``/api/settings/rebuild-frontend`` endpoint or applied updates) where the
+    staleness heuristic isn't trustworthy — committed bundles can lie about
+    their freshness when a PR landed source-only.
     """
-    if not _is_bundle_stale(project_root):
+    if not force and not _is_bundle_stale(project_root):
         return False, "Desktop bundle is current — skipping rebuild."
 
     desktop_dir = project_root / "desktop"

--- a/tinyagentos/routes/settings.py
+++ b/tinyagentos/routes/settings.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
+import asyncio
 import datetime
 import io
+import logging
 import tarfile
 import time
 from pathlib import Path
@@ -11,7 +13,25 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel
 from tinyagentos.config import AppConfig, save_config_locked, validate_config
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter()
+
+
+async def _run_capture(cmd: list[str], cwd: str | None = None) -> tuple[int, str]:
+    """Run a subprocess capturing combined stdout+stderr.
+
+    Wraps asyncio.create_subprocess_exec so callers don't have to plumb the
+    PIPE/communicate dance themselves. Returns (returncode, decoded_output).
+    """
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+        cwd=cwd,
+    )
+    out, _ = await proc.communicate()
+    return proc.returncode or 0, out.decode() if out else ""
 
 
 class ConfigUpdate(BaseModel):
@@ -573,19 +593,58 @@ async def apply_update(request: Request):
     if proc.returncode != 0:
         return JSONResponse({"error": f"Update failed: {output}"}, status_code=500)
 
-    # Pip install to pick up new deps — prefer .venv then venv, fall back to system pip
+    # Pip install to pick up new deps. Capture output and surface failures —
+    # silently swallowing a failed install lands users on a grey-screen the
+    # next time they restart, because the new code imports a module that's
+    # not on disk. See issue #323's sibling failure mode.
+    venv_python: Path | None = None
     for candidate in (project_dir / ".venv" / "bin" / "pip", project_dir / "venv" / "bin" / "pip"):
         if candidate.exists():
             pip_cmd = str(candidate)
+            venv_python = candidate.parent / "python"
             break
     else:
         pip_cmd = "pip"
-    proc2 = await asyncio.create_subprocess_exec(
-        pip_cmd, "install", "-e", ".", "-q",
-        stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL,
+    pip_returncode, pip_output = await _run_capture(
+        [pip_cmd, "install", "-e", "."],
         cwd=str(project_dir),
     )
-    await proc2.communicate()
+    if pip_returncode != 0:
+        return JSONResponse(
+            {
+                "error": "Dependency install failed — update aborted to avoid grey-screen on restart.",
+                "git_output": output.strip(),
+                "pip_output": pip_output.strip()[-2000:],
+            },
+            status_code=500,
+        )
+
+    # Import smoke test in a fresh interpreter — verifies the new code can
+    # actually load with the freshly installed deps. Without this a partial
+    # pip install (returncode 0 but a wheel quietly skipped) still grey-screens
+    # the user on restart.
+    if venv_python is not None and venv_python.exists():
+        smoke_returncode, smoke_output = await _run_capture(
+            [
+                str(venv_python), "-c",
+                "import tinyagentos.app; "
+                "from tinyagentos.routes.desktop_browser import proxy, copilot_ws, vapid, store",
+            ],
+            cwd=str(project_dir),
+        )
+        if smoke_returncode != 0:
+            return JSONResponse(
+                {
+                    "error": (
+                        "Update applied to disk but post-install import test failed "
+                        "— restart would grey-screen. Fix the import error before restarting."
+                    ),
+                    "git_output": output.strip(),
+                    "pip_output": pip_output.strip()[-2000:],
+                    "import_error": smoke_output.strip()[-2000:],
+                },
+                status_code=500,
+            )
 
     # Rebuild the desktop bundle if new source files landed (belt-and-braces on
     # non-systemd hosts where ExecStartPre doesn't run: Mac .app, Docker, dev).

--- a/tinyagentos/routes/settings.py
+++ b/tinyagentos/routes/settings.py
@@ -646,10 +646,14 @@ async def apply_update(request: Request):
                 status_code=500,
             )
 
-    # Rebuild the desktop bundle if new source files landed (belt-and-braces on
-    # non-systemd hosts where ExecStartPre doesn't run: Mac .app, Docker, dev).
+    # Force a desktop bundle rebuild on every applied update. The mtime-based
+    # staleness check in rebuild_desktop_bundle_if_stale is unreliable when
+    # static/desktop/ is committed and a PR lands source-only (no rebuilt
+    # bundle in the commit) — git pull touches both source and bundle in the
+    # same instant and the heuristic can pick the wrong winner. Force-rebuilding
+    # is the only reliable path; the cost is one ~30s npm build on Update click.
     from tinyagentos.desktop_rebuild import rebuild_desktop_bundle_if_stale
-    _rebuilt, _rebuild_msg = await rebuild_desktop_bundle_if_stale(project_dir)
+    _rebuilt, _rebuild_msg = await rebuild_desktop_bundle_if_stale(project_dir, force=True)
     if _rebuilt:
         logger.info("Desktop rebuild: %s", _rebuild_msg)
 
@@ -698,4 +702,28 @@ async def apply_update(request: Request):
         "status": "updated",
         "output": output.strip(),
         "message": "Update pulled. Restart TinyAgentOS to apply changes.",
+    }
+
+
+@router.post("/api/settings/rebuild-frontend")
+async def rebuild_frontend(request: Request):
+    """Force a fresh `npm install` + `npm run build` of the desktop bundle.
+
+    The auto-rebuild during `/api/settings/update` uses an mtime heuristic that
+    can miss source-only PRs (where committed bundle and new source files end
+    up with identical mtimes after `git pull`). This endpoint is a manual
+    escape hatch — always rebuilds, regardless of staleness.
+    """
+    project_dir = Path(__file__).parent.parent.parent
+    from tinyagentos.desktop_rebuild import rebuild_desktop_bundle_if_stale
+
+    rebuilt, message = await rebuild_desktop_bundle_if_stale(project_dir, force=True)
+    if not rebuilt:
+        return JSONResponse({"error": message}, status_code=500)
+    if "failed" in message.lower() or "error" in message.lower() or "timed out" in message.lower():
+        return JSONResponse({"error": message}, status_code=500)
+
+    return {
+        "status": "rebuilt",
+        "message": "Desktop bundle rebuilt. Hard-refresh the browser to see new components.",
     }


### PR DESCRIPTION
## Why

Two real failure modes hit my Pi today and would hit any user updating from Settings:

**1. Silent dep install failures.** `POST /api/settings/update` ran `pip install -e .` with stdout+stderr piped to `DEVNULL` and never checked the return code. A failed pip install (network blip, missing system lib for a wheel that needs to build, partial venv state) left no breadcrumbs and the endpoint still returned `status: \"updated\"`. User clicks Restart, service tries to import new code, hits ModuleNotFoundError, crashes — grey screen.

**2. Stale frontend bundle after source-only PRs.** `static/desktop/assets/*` is committed to the repo. When a PR lands source-only (e.g. PR #319 added the Store filter components but didn't include the rebuilt bundle), `git pull` ends up with new source AND old committed bundle touched at roughly the same instant. The mtime-based staleness check in `rebuild_desktop_bundle_if_stale` picks the wrong winner and skips the rebuild — user restarts into old UI without the new components.

Both bit me on the production Pi today.

## What this PR does

**Fail-loud on dep install:**
- Captures pip stdout/stderr into the response. On non-zero exit, returns 500 with the captured output and aborts the update.
- Adds a post-install **import smoke test** in a fresh interpreter that imports `tinyagentos.app` plus the desktop_browser modules pulling in BrowserApp v2 deps (lxml, sqlcipher, argon2, py_vapid, pywebpush, cryptography). Catches the partial-install case where pip exits 0 but a wheel was quietly skipped.
- Both failure modes return structured output (`git_output`, `pip_output`, `import_error`).
- Extracts a small `_run_capture` helper for subprocess calls, with two unit tests.

**Force rebuild on Update + manual button:**
- `apply_update` now calls `rebuild_desktop_bundle_if_stale(..., force=True)`. The cost is one ~30s npm build per Update click; the benefit is the bundle is always current.
- New `POST /api/settings/rebuild-frontend` endpoint that always rebuilds unconditionally.
- Updates section in SettingsApp grows a **Rebuild Frontend** button — manual escape hatch when the UI looks stale.

## Out of scope

The asyncio-loop wedge that caused my Pi's accept queue to fill (independent of update flow) is tracked separately as #323 — different root cause (uncancelled outbound httpx call), separate audit pass.

## Test plan

- [x] `pytest tests/test_routes_settings.py` — 16 passed
- [ ] On Pi: click Install Update — verify rebuild happens, logs visible
- [ ] On Pi: click Rebuild Frontend after a source-only state — verify bundle rebuilt, hard-refresh shows new components
- [ ] On Pi: simulate failed pip install (typo in pyproject.toml) → /api/settings/update should return 500 with pip_output

Refs #323