### PR TITLE
ci: bump test timeout to 35min, drop Python 3.10 matrix entry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 35
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "tinyagentos"
 version = "0.1.0"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { text = "AGPL-3.0-or-later" }
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.30.0",
@@ -62,4 +62,12 @@ taos-worker-ctl = "tinyagentos.cli.worker:main"
 markers = [
     "e2e: End-to-end browser tests (require running server)",
     "slow: Tests requiring a live stack (skipped in local CI; run with pytest -m slow)",
+]
+filterwarnings = [
+    # Silence noisy "Event loop is closed" RuntimeError emitted from
+    # asyncio finalisers (httpx clients, aiosqlite connections) during
+    # interpreter shutdown. Harmless — the tests have already passed by
+    # the time these fire — but they trip GitHub Actions log parser into
+    # marking the step as having errors. Filter at the warning level.
+    "ignore::pytest.PytestUnraisableExceptionWarning",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,10 +64,13 @@ markers = [
     "slow: Tests requiring a live stack (skipped in local CI; run with pytest -m slow)",
 ]
 filterwarnings = [
-    # Silence noisy "Event loop is closed" RuntimeError emitted from
-    # asyncio finalisers (httpx clients, aiosqlite connections) during
-    # interpreter shutdown. Harmless — the tests have already passed by
-    # the time these fire — but they trip GitHub Actions log parser into
-    # marking the step as having errors. Filter at the warning level.
-    "ignore::pytest.PytestUnraisableExceptionWarning",
+    # Asyncio teardown emits unraisable RuntimeError("Event loop is closed")
+    # warnings when finalisers (httpx clients, aiosqlite connections) fire
+    # during interpreter shutdown after the loop is gone. Harmless — tests
+    # have already passed — but trips GitHub Actions log parser into
+    # ##[error] annotations. Narrow filter: only matches the well-known
+    # "Exception ignored in:" prefix that pytest uses for these, so
+    # genuine unraisable exceptions in __del__ or forgotten awaitables
+    # still surface as test failures.
+    "ignore:Exception ignored in:pytest.PytestUnraisableExceptionWarning",
 ]


### PR DESCRIPTION
## Why

CI on PR #325 (and #324 yesterday) hit a flake where:

\`\`\`
========== 3239 passed, 14 skipped, 82 warnings in 1457.40s (0:24:17) ==========
##[error]The operation was canceled.
\`\`\`

pytest finished cleanly inside the 25-minute timeout, then teardown noise burned the last 30 seconds and GitHub Actions cancelled the job at 25:00 wall-clock. \`test (3.10)\` is consistently 4-5 minutes slower than \`test (3.13)\` on this suite — CPython interpreter improvements in 3.11+ are real.

## What this PR does

- **Bumps \`timeout-minutes\` 25 → 35** so future suite growth doesn't ride the wall.
- **Drops Python 3.10 from the matrix** (still tested on 3.11, 3.12, 3.13). Python 3.10 is in security-only support upstream and was the consistent matrix flake source.
- **Bumps \`requires-python\` to >=3.11** to match the new floor.
- **Adds a \`filterwarnings\` rule** for \`PytestUnraisableExceptionWarning\` so late-finaliser "Event loop is closed" warnings don't trip the GitHub Actions log parser into \`##[error]\` annotations on otherwise-passing runs.

## Test plan

- [x] Local: \`pytest tests/test_routes_settings.py\` — 16 passed
- [ ] CI: this PR's own run is the test; the change should land green on 3.11/3.12/3.13 and the job-cancel pattern should not recur on PR #325 once it rebases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Python version requirement to 3.11 (Python 3.10 no longer supported).
  * Updated CI workflow to test against Python 3.11, 3.12, and 3.13.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->