### PR TITLE
ci: auto-add new issues + PRs to project board

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -37,7 +37,7 @@ jobs:
           fi
       - name: Add to Project
         if: steps.cfg.outputs.skip != 'true'
-        uses: actions/add-to-project@v1
+        uses: actions/add-to-project@v2
         with:
           project-url: ${{ vars.PROJECT_URL }}
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,43 @@
+name: Add to Project Board
+
+on:
+  issues:
+    types: [opened, reopened]
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+# This workflow adds every new issue and PR to the repo's GitHub Project (v2)
+# board so feature work shows up on the kanban automatically.
+#
+# Setup required (one-off):
+#
+# 1. Create a fine-grained PAT with `project:write` scope.
+# 2. Store it as a repo secret named ADD_TO_PROJECT_PAT.
+# 3. Add a repo variable named PROJECT_URL with the full project URL,
+#    e.g. https://github.com/users/jaylfc/projects/1
+#
+# If either is missing, the workflow logs a one-line skip note and exits 0
+# so issue creation isn't blocked by missing config.
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip if not configured
+        id: cfg
+        env:
+          PROJECT_URL: ${{ vars.PROJECT_URL }}
+          PAT: ${{ secrets.ADD_TO_PROJECT_PAT }}
+        run: |
+          if [ -z "$PROJECT_URL" ] || [ -z "$PAT" ]; then
+            echo "::notice::add-to-project workflow not configured (PROJECT_URL var or ADD_TO_PROJECT_PAT secret missing). Skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Add to Project
+        if: steps.cfg.outputs.skip != 'true'
+        uses: actions/add-to-project@v1
+        with:
+          project-url: ${{ vars.PROJECT_URL }}
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
## Why

Feature issues filed during recent sessions weren't showing up on the project board because there was no automation to add them. \`has_projects: true\` on the repo, but no workflow doing the auto-add.

## What this PR does

Adds \`.github/workflows/add-to-project.yml\` using \`actions/add-to-project@v1\`. Triggers on:

- \`issues: [opened, reopened]\`
- \`pull_request: [opened, reopened, ready_for_review]\`

The workflow no-ops cleanly if the PAT secret or PROJECT_URL var are missing — safe to merge before configuration.

## Activation steps (after merge)

1. **Fine-grained PAT** with \`projects:write\` (and read on this repo for issues): https://github.com/settings/tokens?type=beta
2. **Repo secret** \`ADD_TO_PROJECT_PAT\` = that token
3. **Repo variable** \`PROJECT_URL\` = the full project URL, e.g. \`https://github.com/users/jaylfc/projects/1\`

## Backfill

Issues #323, #327, #328-#337 (and any other recently-filed) won't auto-add retroactively. Two options:

- Manually add them via the project UI ("Add items" → search by number).
- Once the workflow is live, re-open then re-close each issue to trigger the \`reopened\` event.

I can do the latter via gh CLI if you want a one-shot batch backfill — just say the word once the secret + var are configured.