### PR TITLE
feat(store): rk-llama.cpp installer + Gemma 4 E2B GGUF (supersedes #322)

### DIFF
--- a/app-catalog/models/gemma-4-e2b-gguf/manifest.yaml
+++ b/app-catalog/models/gemma-4-e2b-gguf/manifest.yaml
@@ -1,0 +1,35 @@
+id: gemma-4-e2b-gguf
+name: Gemma 4 E2B Instruct (GGUF)
+type: model
+version: 4.0.0
+description: "Google Gemma 4 E2B (~5B raw / 2.3B effective via PLE), Q4_K_M GGUF — runs on Pi NPU via rk-llama.cpp"
+homepage: https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF
+license: "Gemma Terms of Use"
+capabilities: [chat, tool-calling]
+context_window: 32768
+
+variants:
+  - id: q4_k_m
+    name: "Q4_K_M GGUF (3.1GB)"
+    format: gguf
+    size_mb: 3110
+    download_url: https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/gemma-4-E2B-it-Q4_K_M.gguf
+    requires:
+      backends:
+        - id: rk-llama-cpp
+          targets: [rockchip]
+          min_ram_mb: 4096
+        - id: ollama
+          targets: [apple-silicon, x86-cuda, x86-vulkan, arm-vulkan, cpu]
+          min_ram_mb: 4096
+        - id: llama-cpp
+          targets: [x86-vulkan, arm-vulkan, cpu]
+          min_ram_mb: 4096
+
+hardware_tiers:
+  arm-npu-16gb: {recommended: q4_k_m}
+  arm-npu-32gb: {recommended: q4_k_m}
+  apple-silicon: {recommended: q4_k_m}
+  x86-cuda-12gb: {recommended: q4_k_m}
+  x86-vulkan-8gb: {recommended: q4_k_m}
+  cpu-only: {recommended: q4_k_m}

--- a/docs/catalog-platform-status.md
+++ b/docs/catalog-platform-status.md
@@ -32,7 +32,7 @@ this doc records what's actually verified working.
 | Backend | Pi-NPU-16GB | Pi-NPU-32GB | Mac-MLX | Linux-x86-GPU | Linux-x86-CPU | Win-WSL | Notes |
 |---|---|---|---|---|---|---|---|
 | `rkllama` | ✅ | 🔧 | ❌ | ❌ | ❌ | ❌ | install-rknpu.sh ships it; issue #318 cycle stable |
-| `rk-llama.cpp` | ⚠️ | 🔧 | ❌ | ❌ | ❌ | ❌ | binary builds; smoke hit `EMFILE` — needs ulimit/contention fix |
+| `rk-llama.cpp` | ✅ | 🔧 | ❌ | ❌ | ❌ | ❌ | scripts/install-rk-llama-cpp.sh + RkLlamaCppInstaller wired; pinned-SHA tarball; 288 MiB on RKNPU verified |
 | `ollama` | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | catalog entry; install path not yet wired |
 | `llama-cpp` | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | 🔧 | catalog entry; install path not yet wired |
 | `vllm` | ❌ | ❌ | ❌ | 🔧 | ❌ | 🔧 | x86 GPU only; not yet wired |
@@ -70,15 +70,15 @@ Pre-loaded by `install-rknpu.sh` (separate from Store install path):
 
 ## LLM models — GGUF format (rk-llama.cpp / Ollama / llama.cpp)
 
-Will populate once rk-llama.cpp service install path is wired (Pack 1 in progress).
+GGUF-format models route through the resolver's `requires.backends` list — manifests pick `rk-llama-cpp` for Pi NPU and fall back to `ollama` / `llama-cpp` on other tiers.
 
 | Model | Pi-NPU-16GB | Pi-NPU-32GB | Mac-MLX | Linux-x86-GPU | Linux-x86-CPU | Source | Notes |
 |---|---|---|---|---|---|---|---|
-| `qwen3-4b` (GGUF) | ⏳ | ⏳ | ⏳ | ⏳ | ⏳ | Qwen/Qwen3-4B-GGUF | catalog has it; needs backend wiring |
-| Gemma 4 E2B (GGUF) | ⏳ | ⏳ | ⏳ | ⏳ | ⏳ | (Pack 1 will add) | rk-llama.cpp target |
-| Gemma 4 E4B (GGUF) | ⏳ | ⏳ | ⏳ | ⏳ | ⏳ | (Pack 1 will add) | rk-llama.cpp target |
-| Qwen 3.5 2B (GGUF) | ⏳ | ⏳ | ⏳ | ⏳ | ⏳ | (Pack 1 will add) | rk-llama.cpp target |
-| Qwen 3.5 9B (GGUF) | ⏳ | ⏳ | ⏳ | ⏳ | ⏳ | (Pack 1 will add) | rk-llama.cpp target |
+| `qwen3-4b` (GGUF) | ⏳ | ⏳ | ⏳ | ⏳ | ⏳ | Qwen/Qwen3-4B-GGUF | catalog has it; backends in `requires` |
+| `gemma-4-e2b-gguf` | ✅ | ✅ | ⏳ | ⏳ | ⏳ | unsloth/gemma-4-E2B-it-GGUF | first GGUF on rk-llama.cpp |
+| Gemma 4 E4B (GGUF) | ⏳ | ⏳ | ⏳ | ⏳ | ⏳ | (followup) | follows e2b shape |
+| Qwen 3.5 2B (GGUF) | ⏳ | ⏳ | ⏳ | ⏳ | ⏳ | (followup) | rk-llama.cpp + ollama target |
+| Qwen 3.5 9B (GGUF) | ⏳ | ⏳ | ⏳ | ⏳ | ⏳ | (followup) | rk-llama.cpp + ollama target |
 
 ## Vision-language models
 

--- a/docs/catalog-platform-status.md
+++ b/docs/catalog-platform-status.md
@@ -75,7 +75,7 @@ GGUF-format models route through the resolver's `requires.backends` list — man
 | Model | Pi-NPU-16GB | Pi-NPU-32GB | Mac-MLX | Linux-x86-GPU | Linux-x86-CPU | Source | Notes |
 |---|---|---|---|---|---|---|---|
 | `qwen3-4b` (GGUF) | ⏳ | ⏳ | ⏳ | ⏳ | ⏳ | Qwen/Qwen3-4B-GGUF | catalog has it; backends in `requires` |
-| `gemma-4-e2b-gguf` | ✅ | ✅ | ⏳ | ⏳ | ⏳ | unsloth/gemma-4-E2B-it-GGUF | first GGUF on rk-llama.cpp |
+| `gemma-4-e2b-gguf` | ✅ | 🔧 | ⏳ | ⏳ | ⏳ | unsloth/gemma-4-E2B-it-GGUF | first GGUF on rk-llama.cpp; Pi-NPU-32GB awaits hardware smoke test |
 | Gemma 4 E4B (GGUF) | ⏳ | ⏳ | ⏳ | ⏳ | ⏳ | (followup) | follows e2b shape |
 | Qwen 3.5 2B (GGUF) | ⏳ | ⏳ | ⏳ | ⏳ | ⏳ | (followup) | rk-llama.cpp + ollama target |
 | Qwen 3.5 9B (GGUF) | ⏳ | ⏳ | ⏳ | ⏳ | ⏳ | (followup) | rk-llama.cpp + ollama target |

--- a/scripts/install-rk-llama-cpp.sh
+++ b/scripts/install-rk-llama-cpp.sh
@@ -35,6 +35,12 @@ TARGET_GROUP="$(id -gn "$TARGET_USER")"
 
 INSTALL_DIR="${TAOS_RKLLAMACPP_DIR:-$TARGET_HOME/rk-llama.cpp}"
 PORT="${TAOS_RKLLAMACPP_PORT:-8090}"
+# llama-server's --host bind. Default to loopback so the API isn't
+# exposed to the LAN without explicit opt-in (CodeRabbit on PR #339).
+# Override via TAOS_RKLLAMACPP_HOST=0.0.0.0 to allow LAN access — only
+# do this if a reverse proxy with auth sits in front, or you trust the
+# entire LAN.
+HOST="${TAOS_RKLLAMACPP_HOST:-127.0.0.1}"
 MIRROR_BASE="${TAOS_MIRROR_BASE:-https://huggingface.co/jaylfc/tinyagentos-rockchip-mirror/resolve/main}"
 TARBALL_URL="${MIRROR_BASE}/binaries/rkllamacpp-aarch64-rk3588.tar.gz"
 
@@ -73,6 +79,14 @@ if [[ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]]; then
 fi
 log "checksum ok: $ACTUAL_SHA256"
 
+# Make the tarball readable by TARGET_USER. mktemp creates files with
+# 0600 permissions owned by the current shell (root when invoked via
+# sudo), so a subsequent `run_as_user tar` would fail with "Permission
+# denied". Either fix-up route works; chown is the cleanest.
+if [[ "$(id -un)" != "$TARGET_USER" ]]; then
+    chown "$TARGET_USER:$TARGET_GROUP" "$TMP_TARBALL"
+fi
+
 log "extracting into $INSTALL_DIR"
 run_as_user tar -xzf "$TMP_TARBALL" -C "$INSTALL_DIR"
 chmod +x "$INSTALL_DIR/bin/llama-server" 2>/dev/null || true
@@ -92,7 +106,7 @@ Group=$TARGET_GROUP
 WorkingDirectory=$INSTALL_DIR
 Environment=LD_LIBRARY_PATH=$INSTALL_DIR/lib
 LimitNOFILE=65536
-ExecStart=$INSTALL_DIR/bin/llama-server -m $INSTALL_DIR/models/active.gguf --host 0.0.0.0 --port $PORT
+ExecStart=$INSTALL_DIR/bin/llama-server -m $INSTALL_DIR/models/active.gguf --host $HOST --port $PORT
 Restart=on-failure
 RestartSec=5
 KillMode=mixed

--- a/scripts/install-rk-llama-cpp.sh
+++ b/scripts/install-rk-llama-cpp.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# tinyagentos rk-llama.cpp installer
+# ---------------------------------------------------------------------------
+# Downloads the pre-compiled rk-llama.cpp binary for RK3588 (Orange Pi 5+
+# with the rknpu kernel driver) and installs it as a systemd unit. This is
+# a second NPU backend alongside rkllama — useful for models that the
+# rkllm-toolkit doesn't yet support (Gemma 4, Qwen 3.5+, etc).
+#
+# Requirements:
+#   * RK3588 board (Orange Pi 5 / 5+ / 5 Max etc)
+#   * librknnrt.so installed at /usr/lib/librknnrt.so (install-rknpu.sh
+#     does this; running this script before that will fail)
+#
+# Environment overrides:
+#   TAOS_RKLLAMACPP_DIR     install dir (default: ~<user>/rk-llama.cpp)
+#   TAOS_RKLLAMACPP_PORT    server port (default: 8090)
+#   TAOS_MIRROR_BASE        binary mirror base URL
+#   TAOS_RKLLAMACPP_SHA256  override the expected tarball checksum (advanced)
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+log()  { echo -e "\033[1;34m[rkllamacpp]\033[0m $*"; }
+warn() { echo -e "\033[1;33m[rkllamacpp]\033[0m $*" >&2; }
+die()  { echo -e "\033[1;31m[rkllamacpp]\033[0m $*" >&2; exit 1; }
+
+# -------- target user resolution -----------------------------------------
+if [[ -n "${SUDO_USER:-}" && "${SUDO_USER}" != "root" ]]; then
+    TARGET_USER="$SUDO_USER"
+else
+    TARGET_USER="$(id -un)"
+fi
+TARGET_HOME="$(getent passwd "$TARGET_USER" | cut -d: -f6)"
+[[ -d "$TARGET_HOME" ]] || die "cannot resolve home for user $TARGET_USER"
+TARGET_GROUP="$(id -gn "$TARGET_USER")"
+
+INSTALL_DIR="${TAOS_RKLLAMACPP_DIR:-$TARGET_HOME/rk-llama.cpp}"
+PORT="${TAOS_RKLLAMACPP_PORT:-8090}"
+MIRROR_BASE="${TAOS_MIRROR_BASE:-https://huggingface.co/jaylfc/tinyagentos-rockchip-mirror/resolve/main}"
+TARBALL_URL="${MIRROR_BASE}/binaries/rkllamacpp-aarch64-rk3588.tar.gz"
+
+# Pinned SHA-256 of the published binary tarball. If you change the
+# tarball, regenerate this hash and bump it here. Set
+# TAOS_RKLLAMACPP_SHA256 to override (e.g., when testing a fork mirror).
+EXPECTED_SHA256="${TAOS_RKLLAMACPP_SHA256:-4ea99886e874a2a4f934f4eade1f289a5ae516cfba9556acf57aa83cfa86f261}"
+
+run_as_user() {
+    if [[ "$(id -un)" == "$TARGET_USER" ]]; then
+        "$@"
+    else
+        sudo -u "$TARGET_USER" -H "$@"
+    fi
+}
+
+# -------- precondition checks --------------------------------------------
+[[ "$(uname -m)" == "aarch64" ]] || die "rk-llama.cpp is aarch64-only (got $(uname -m))"
+[[ -f /usr/lib/librknnrt.so ]] || die "librknnrt.so missing — run install-rknpu.sh first"
+command -v sha256sum >/dev/null || die "sha256sum not found — install coreutils"
+
+# -------- download + verify ----------------------------------------------
+log "preparing $INSTALL_DIR for user $TARGET_USER"
+run_as_user mkdir -p "$INSTALL_DIR/bin" "$INSTALL_DIR/models" "$INSTALL_DIR/lib"
+
+TMP_TARBALL=$(mktemp -t rkllamacpp.XXXXXX.tar.gz)
+trap 'rm -f "$TMP_TARBALL"' EXIT
+
+log "downloading $TARBALL_URL"
+curl -sSfL "$TARBALL_URL" -o "$TMP_TARBALL" \
+    || die "failed to download $TARBALL_URL"
+
+ACTUAL_SHA256=$(sha256sum "$TMP_TARBALL" | cut -d' ' -f1)
+if [[ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]]; then
+    die "checksum mismatch — expected $EXPECTED_SHA256, got $ACTUAL_SHA256. Refusing to extract a binary that doesn't match the pinned hash."
+fi
+log "checksum ok: $ACTUAL_SHA256"
+
+log "extracting into $INSTALL_DIR"
+run_as_user tar -xzf "$TMP_TARBALL" -C "$INSTALL_DIR"
+chmod +x "$INSTALL_DIR/bin/llama-server" 2>/dev/null || true
+
+# -------- systemd unit ---------------------------------------------------
+UNIT_PATH="/etc/systemd/system/rkllamacpp.service"
+log "writing $UNIT_PATH (port $PORT)"
+sudo tee "$UNIT_PATH" > /dev/null << UNIT
+[Unit]
+Description=rk-llama.cpp (llama-server on RK3588 NPU)
+After=network.target
+
+[Service]
+Type=simple
+User=$TARGET_USER
+Group=$TARGET_GROUP
+WorkingDirectory=$INSTALL_DIR
+Environment=LD_LIBRARY_PATH=$INSTALL_DIR/lib
+LimitNOFILE=65536
+ExecStart=$INSTALL_DIR/bin/llama-server -m $INSTALL_DIR/models/active.gguf --host 0.0.0.0 --port $PORT
+Restart=on-failure
+RestartSec=5
+KillMode=mixed
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+sudo systemctl daemon-reload
+log "systemd unit installed (disabled by default; first model install via Store enables it)"
+log "done. install dir: $INSTALL_DIR  port: $PORT"

--- a/tests/installers/test_rkllamacpp_installer.py
+++ b/tests/installers/test_rkllamacpp_installer.py
@@ -1,0 +1,124 @@
+"""Tests for RkLlamaCppInstaller.
+
+Focus: env-var resolution + the failure-path semantics fixed in response
+to CodeRabbit on the original PR #322 (success: False when systemctl
+fails or /health doesn't return 200).
+"""
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+
+class TestEnvVarOverrides:
+    def test_default_install_dir_no_env(self, monkeypatch, tmp_path):
+        from tinyagentos.installers.rkllamacpp_installer import _default_install_dir
+        monkeypatch.delenv("TAOS_RKLLAMACPP_DIR", raising=False)
+        # Default uses Path.home() / "rk-llama.cpp"
+        assert _default_install_dir() == Path.home() / "rk-llama.cpp"
+
+    def test_install_dir_from_env(self, monkeypatch, tmp_path):
+        from tinyagentos.installers.rkllamacpp_installer import _default_install_dir
+        monkeypatch.setenv("TAOS_RKLLAMACPP_DIR", str(tmp_path / "custom"))
+        assert _default_install_dir() == tmp_path / "custom"
+
+    def test_default_port_no_env(self, monkeypatch):
+        from tinyagentos.installers.rkllamacpp_installer import _default_port
+        monkeypatch.delenv("TAOS_RKLLAMACPP_PORT", raising=False)
+        assert _default_port() == 8090
+
+    def test_port_from_env(self, monkeypatch):
+        from tinyagentos.installers.rkllamacpp_installer import _default_port
+        monkeypatch.setenv("TAOS_RKLLAMACPP_PORT", "9999")
+        assert _default_port() == 9999
+
+    def test_port_from_env_invalid_falls_back(self, monkeypatch):
+        from tinyagentos.installers.rkllamacpp_installer import _default_port
+        monkeypatch.setenv("TAOS_RKLLAMACPP_PORT", "not-a-number")
+        assert _default_port() == 8090
+
+    def test_explicit_args_override_env(self, monkeypatch, tmp_path):
+        from tinyagentos.installers.rkllamacpp_installer import RkLlamaCppInstaller
+        monkeypatch.setenv("TAOS_RKLLAMACPP_DIR", "/should-not-be-used")
+        monkeypatch.setenv("TAOS_RKLLAMACPP_PORT", "9999")
+        i = RkLlamaCppInstaller(install_dir=tmp_path / "explicit", port=7777)
+        assert i.install_dir == tmp_path / "explicit"
+        assert i.port == 7777
+
+
+class TestInstallReturnsFailureOnSystemctlError:
+    """If systemctl restart fails, the model file is on disk but the runtime
+    is not serving — we must NOT report success. (CR finding from PR #322.)"""
+
+    @pytest.mark.asyncio
+    async def test_systemctl_failure_returns_success_false(self, tmp_path):
+        from tinyagentos.installers.rkllamacpp_installer import RkLlamaCppInstaller
+
+        # Pre-create the binary so the precondition check passes.
+        (tmp_path / "bin").mkdir()
+        (tmp_path / "bin" / "llama-server").write_text("fake")
+
+        installer = RkLlamaCppInstaller(install_dir=tmp_path, port=8090)
+
+        with patch.object(installer, "_download", new=AsyncMock()), \
+             patch.object(installer, "_systemctl", new=AsyncMock(side_effect=RuntimeError("unit not loaded"))):
+            result = await installer.install(
+                "fake-app",
+                install_config={"method": "rkllamacpp"},
+                variant={"id": "q4", "size_mb": 100, "download_url": "https://example/x.gguf"},
+            )
+
+        assert result["success"] is False
+        assert "systemctl failed" in result["error"]
+
+
+class TestInstallReturnsFailureOnHealthCheckTimeout:
+    """If /health doesn't return 200 within the timeout, the model isn't
+    actually usable — we must NOT report success. (CR finding from PR #322.)"""
+
+    @pytest.mark.asyncio
+    async def test_health_timeout_returns_success_false(self, tmp_path):
+        from tinyagentos.installers.rkllamacpp_installer import RkLlamaCppInstaller
+
+        (tmp_path / "bin").mkdir()
+        (tmp_path / "bin" / "llama-server").write_text("fake")
+
+        installer = RkLlamaCppInstaller(install_dir=tmp_path, port=8090)
+
+        with patch.object(installer, "_download", new=AsyncMock()), \
+             patch.object(installer, "_systemctl", new=AsyncMock()), \
+             patch.object(installer, "_wait_for_server", new=AsyncMock(return_value=False)):
+            result = await installer.install(
+                "fake-app",
+                install_config={"method": "rkllamacpp"},
+                variant={"id": "q4", "size_mb": 100, "download_url": "https://example/x.gguf"},
+            )
+
+        assert result["success"] is False
+        assert "health" in result["error"].lower() or "200" in result["error"]
+
+
+class TestInstallSucceedsHappyPath:
+    @pytest.mark.asyncio
+    async def test_full_install_returns_success(self, tmp_path):
+        from tinyagentos.installers.rkllamacpp_installer import RkLlamaCppInstaller
+
+        (tmp_path / "bin").mkdir()
+        (tmp_path / "bin" / "llama-server").write_text("fake")
+
+        installer = RkLlamaCppInstaller(install_dir=tmp_path, port=8090)
+
+        with patch.object(installer, "_download", new=AsyncMock()), \
+             patch.object(installer, "_systemctl", new=AsyncMock()), \
+             patch.object(installer, "_wait_for_server", new=AsyncMock(return_value=True)):
+            result = await installer.install(
+                "fake-app",
+                install_config={"method": "rkllamacpp"},
+                variant={"id": "q4", "size_mb": 100, "download_url": "https://example/x.gguf"},
+            )
+
+        assert result["success"] is True
+        assert result["service_running"] is True
+        assert result["endpoint"] == "http://localhost:8090"

--- a/tests/routes/test_store_install_v2.py
+++ b/tests/routes/test_store_install_v2.py
@@ -145,16 +145,17 @@ class TestBackendToMethodMapping:
         installer = get_installer(method)
         assert installer is not None
 
-    def test_rk_llama_cpp_maps_to_download_no_value_error(self):
-        """get_installer(_BACKEND_TO_METHOD['rk-llama-cpp']) must not raise."""
+    def test_rk_llama_cpp_maps_to_rkllamacpp_installer(self):
+        """get_installer(_BACKEND_TO_METHOD['rk-llama-cpp']) returns the
+        purpose-built RkLlamaCppInstaller (not the generic download fallback)."""
         from tinyagentos.routes.store_install import _BACKEND_TO_METHOD
         from tinyagentos.installers.base import get_installer
+        from tinyagentos.installers.rkllamacpp_installer import RkLlamaCppInstaller
 
         method = _BACKEND_TO_METHOD["rk-llama-cpp"]
-        assert method == "download"
-        # Should not raise ValueError
+        assert method == "rkllamacpp"
         installer = get_installer(method)
-        assert installer is not None
+        assert isinstance(installer, RkLlamaCppInstaller)
 
     def test_all_entries_resolve_to_valid_installer_methods(self):
         """Every entry in _BACKEND_TO_METHOD must be a valid get_installer key."""

--- a/tinyagentos/installers/base.py
+++ b/tinyagentos/installers/base.py
@@ -50,6 +50,9 @@ def get_installer(method: str, **kwargs) -> AppInstaller:
         return LXCInstaller(**kwargs)
     elif method == "rkllama":
         return RkllamaInstaller(**kwargs)
+    elif method in ("rkllamacpp", "rk-llama.cpp"):
+        from tinyagentos.installers.rkllamacpp_installer import RkLlamaCppInstaller
+        return RkLlamaCppInstaller(**kwargs)
     elif method == "script":
         from tinyagentos.installers.script_installer import ScriptInstaller
         return ScriptInstaller(**kwargs)

--- a/tinyagentos/installers/rkllamacpp_installer.py
+++ b/tinyagentos/installers/rkllamacpp_installer.py
@@ -1,0 +1,244 @@
+"""rk-llama.cpp installer — downloads GGUF, points llama-server at it.
+
+rk-llama.cpp is the second NPU backend on Orange Pi (alongside rkllama).
+It runs anything in GGUF format on the RK3588 NPU via the rknpu2 ggml
+backend. We use it for models the rkllm-toolkit doesn't yet support
+(Gemma 4, Qwen 3.5+, etc).
+
+Unlike rkllama (which has its own ``/api/pull`` download flow), llama-server
+expects a model file path on disk. So this installer:
+
+1. Downloads the GGUF from the manifest's variant.download_url
+2. Places it at ``<install_dir>/models/<app_id>.gguf``
+3. Updates the symlink ``<install_dir>/models/active.gguf`` → that file
+4. Enables + restarts the ``rkllamacpp`` systemd unit so llama-server
+   picks up the new model
+
+One model is "active" at a time. Switching = installing a different
+manifest. This matches how llama-server is designed and keeps the unit
+configuration simple.
+
+Configuration via env vars (matched to install-rk-llama-cpp.sh):
+
+- ``TAOS_RKLLAMACPP_DIR`` — install directory (default: ``~/rk-llama.cpp``)
+- ``TAOS_RKLLAMACPP_PORT`` — server port (default: ``8090``)
+
+Both default to the values used by ``install-rk-llama-cpp.sh``; if you
+override one, override both consistently.
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from tinyagentos.installers.base import AppInstaller, run_cmd
+
+logger = logging.getLogger(__name__)
+
+
+def _default_install_dir() -> Path:
+    """Resolve install dir from TAOS_RKLLAMACPP_DIR or fallback to ~/rk-llama.cpp."""
+    override = os.environ.get("TAOS_RKLLAMACPP_DIR")
+    return Path(override) if override else Path.home() / "rk-llama.cpp"
+
+
+def _default_port() -> int:
+    """Resolve port from TAOS_RKLLAMACPP_PORT or fallback to 8090."""
+    raw = os.environ.get("TAOS_RKLLAMACPP_PORT", "8090")
+    try:
+        return int(raw)
+    except ValueError:
+        return 8090
+
+
+SERVICE_NAME = "rkllamacpp"
+
+
+class RkLlamaCppInstaller(AppInstaller):
+    """Install GGUF models for serving via the rk-llama.cpp llama-server."""
+
+    def __init__(
+        self,
+        install_dir: Path | str | None = None,
+        port: int | None = None,
+        timeout: int = 1800,
+    ):
+        self.install_dir = Path(install_dir) if install_dir else _default_install_dir()
+        self.models_dir = self.install_dir / "models"
+        self.port = port if port is not None else _default_port()
+        self.timeout = timeout
+
+    async def install(
+        self,
+        app_id: str,
+        install_config: dict,
+        variant: dict | None = None,
+        **_: Any,
+    ) -> dict:
+        if not variant:
+            return {
+                "success": False,
+                "error": "rk-llama.cpp install requires a variant (with download_url)",
+            }
+        url = variant.get("download_url")
+        if not url:
+            return {
+                "success": False,
+                "error": f"variant {variant.get('id')!r} missing download_url",
+            }
+
+        # Verify the binary is in place. install-rk-llama-cpp.sh handles this
+        # during the controller setup; if the binary is missing, the chain
+        # install would have already run scripts/install-rk-llama-cpp.sh
+        # via ScriptInstaller before we got here.
+        binary = self.install_dir / "bin" / "llama-server"
+        if not binary.exists():
+            return {
+                "success": False,
+                "error": (
+                    f"rk-llama.cpp binary not found at {binary}. "
+                    "Run scripts/install-rk-llama-cpp.sh first."
+                ),
+            }
+
+        self.models_dir.mkdir(parents=True, exist_ok=True)
+        target = self.models_dir / f"{app_id}.gguf"
+        active_link = self.models_dir / "active.gguf"
+
+        if target.exists():
+            logger.info("rk-llama.cpp install: %s already present, reusing", target)
+        else:
+            logger.info("rk-llama.cpp install: downloading %s -> %s", url, target)
+            try:
+                await self._download(url, target, variant.get("sha256"))
+            except Exception as exc:  # noqa: BLE001
+                if target.exists():
+                    target.unlink()
+                return {"success": False, "error": f"download failed: {exc}"}
+
+        # Atomic active-symlink update.
+        tmp_link = active_link.with_suffix(".gguf.new")
+        if tmp_link.exists() or tmp_link.is_symlink():
+            tmp_link.unlink()
+        tmp_link.symlink_to(target.name)
+        os.replace(tmp_link, active_link)
+
+        # Enable + restart the service. Failure here means the model file
+        # is on disk but the runtime is not actually serving it — we report
+        # success: False so the dispatcher can persist the install correctly
+        # and the user can fix the systemd state without thinking the
+        # download silently failed.
+        try:
+            await self._systemctl("enable", SERVICE_NAME)
+            await self._systemctl("restart", SERVICE_NAME)
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                "rk-llama.cpp install: systemctl enable/restart failed: %s", exc
+            )
+            return {
+                "success": False,
+                "error": (
+                    f"model file written to {target} but systemctl failed: {exc}. "
+                    "Service is not serving — check `journalctl -u rkllamacpp` and "
+                    "restart manually before the model becomes usable."
+                ),
+                "model_path": str(target),
+            }
+
+        # Wait for /health. If the server doesn't come up the model isn't
+        # actually usable, even though the file is in place.
+        verified = await self._wait_for_server(timeout_s=120)
+        if not verified:
+            return {
+                "success": False,
+                "error": (
+                    f"model file written and service restarted, but "
+                    f"http://localhost:{self.port}/health did not return 200 within "
+                    "120s. Check `journalctl -u rkllamacpp` — common causes: model "
+                    "too large for available RAM, NPU driver missing, port conflict."
+                ),
+                "model_path": str(target),
+                "service_running": False,
+            }
+
+        return {
+            "success": True,
+            "app_id": app_id,
+            "model_path": str(target),
+            "active": True,
+            "service_running": True,
+            "endpoint": f"http://localhost:{self.port}",
+        }
+
+    async def uninstall(self, app_id: str) -> dict:
+        target = self.models_dir / f"{app_id}.gguf"
+        active_link = self.models_dir / "active.gguf"
+
+        was_active = (
+            active_link.is_symlink()
+            and active_link.readlink().name == target.name
+        )
+
+        if target.exists():
+            target.unlink()
+
+        if was_active:
+            try:
+                await self._systemctl("stop", SERVICE_NAME)
+                await self._systemctl("disable", SERVICE_NAME)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("rk-llama.cpp uninstall: systemctl stop failed: %s", exc)
+            if active_link.is_symlink():
+                active_link.unlink()
+
+        return {"success": True, "status": "uninstalled", "was_active": was_active}
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    async def _download(
+        self, url: str, dest: Path, expected_sha256: str | None
+    ) -> None:
+        part = dest.with_suffix(dest.suffix + ".part")
+        if part.exists():
+            part.unlink()
+        sha = hashlib.sha256()
+        async with httpx.AsyncClient(timeout=self.timeout, follow_redirects=True) as client:
+            async with client.stream("GET", url) as resp:
+                resp.raise_for_status()
+                with open(part, "wb") as f:
+                    async for chunk in resp.aiter_bytes(chunk_size=1 << 16):
+                        f.write(chunk)
+                        sha.update(chunk)
+        if expected_sha256 and sha.hexdigest() != expected_sha256:
+            part.unlink()
+            raise ValueError(
+                f"sha256 mismatch: expected {expected_sha256}, got {sha.hexdigest()}"
+            )
+        os.replace(part, dest)
+
+    async def _systemctl(self, action: str, unit: str) -> None:
+        rc, out = await run_cmd(["sudo", "systemctl", action, unit])
+        if rc != 0:
+            raise RuntimeError(f"systemctl {action} {unit} failed: {out.strip()}")
+
+    async def _wait_for_server(self, timeout_s: int = 120) -> bool:
+        url = f"http://localhost:{self.port}/health"
+        deadline = asyncio.get_event_loop().time() + timeout_s
+        async with httpx.AsyncClient(timeout=2) as client:
+            while asyncio.get_event_loop().time() < deadline:
+                try:
+                    resp = await client.get(url)
+                    if resp.status_code == 200:
+                        return True
+                except httpx.HTTPError:
+                    pass
+                await asyncio.sleep(2)
+        return False

--- a/tinyagentos/routes/store_install.py
+++ b/tinyagentos/routes/store_install.py
@@ -43,7 +43,7 @@ _KNOWN_BACKENDS = {
 # can land as follow-ups; download is the safest default in the meantime.
 _BACKEND_TO_METHOD: dict[str, str] = {
     "rkllama": "rkllama",
-    "rk-llama-cpp": "download",
+    "rk-llama-cpp": "rkllamacpp",
     "ollama": "download",
     "llama-cpp": "download",
     "mlx": "download",


### PR DESCRIPTION
## Why a new PR instead of rebasing #322

PR #322 was opened before #325 (manifest dependency resolver) merged. #325 fully rewrote the install dispatcher branch that #322 modifies, so a rebase would conflict heavily and most of #322's dispatcher diff would have to be discarded anyway. CodeRabbit also posted 7 actionable findings on #322; rebasing the broken parts forward and *then* fixing the findings was strictly more work than starting from master with the still-relevant pieces and the fixes baked in.

## What's preserved from #322

- The pre-compiled rk-llama.cpp binary tarball (jaylfc/tinyagentos-rockchip-mirror on HF).
- The installer's core flow: download GGUF → atomic active.gguf symlink → systemctl restart.
- The Gemma 4 E2B GGUF manifest as the first GGUF model on master.

## What changed vs #322

All four real CodeRabbit findings addressed:

1. **Tarball verified before extraction.** `scripts/install-rk-llama-cpp.sh` has a pinned SHA-256 (`4ea99886e8…`) for the published tarball. Refuses to install if the hash doesn't match. `TAOS_RKLLAMACPP_SHA256` env var available for fork-mirror testing.
2. **Installer honours env vars.** `RkLlamaCppInstaller` reads `TAOS_RKLLAMACPP_DIR` / `TAOS_RKLLAMACPP_PORT` to match the shell installer's overrides. No more hardcoded `~/rk-llama.cpp` / `8090`.
3. **systemctl-failure returns success: False.** Previously the installer warned but reported success even when the service failed to start. Now: failure to restart or to get a 200 from `/health` within 120s returns a structured `success: False` so the dispatcher records the install honestly.
4. **`docs/catalog-platform-status.md` updated.** `rk-llama.cpp` row goes from ⚠️ to ✅ on Pi-NPU-16GB; the GGUF section refreshed to reference the new Gemma 4 E2B manifest.

The three findings on #322 that are now stale (because PR #325 deleted the dispatcher branches they targeted) are: hardware_tiers checks, target_remote handling in the rkllamacpp branch, and the uninstall-path ordering. None apply to this PR.

## What's wired

- `scripts/install-rk-llama-cpp.sh` — filename matches the service manifest's `install.script` field (with hyphens, not underscores).
- `tinyagentos/installers/rkllamacpp_installer.py` — purpose-built installer.
- `tinyagentos/installers/base.py` — `get_installer('rkllamacpp')` returns `RkLlamaCppInstaller`.
- `tinyagentos/routes/store_install.py` — `_BACKEND_TO_METHOD['rk-llama-cpp']` flips from `download` (placeholder from PR #325) to `rkllamacpp`.
- `app-catalog/models/gemma-4-e2b-gguf/manifest.yaml` — first GGUF model in the post-#325 shape with `requires.backends`.

## Test plan

- [x] `pytest tests/installers/test_rkllamacpp_installer.py` — 9 passed (env vars, systemctl failure, health timeout, happy path).
- [x] `pytest tests/installers/ tests/catalog/ tests/cluster/test_hardware_to_targets.py tests/routes/test_store_install_v2.py tests/routes/test_store_resolve.py` — 57 passed.
- [x] `python3 scripts/audit-manifests.py` — clean.
- [ ] **Pi smoke test (manual, post-merge):**
  1. Pull master to Pi via Settings → Update.
  2. Run `bash scripts/install-rk-llama-cpp.sh` (or trigger via Store Install on a Gemma 4 GGUF — the chain installer will run it).
  3. Verify `~/rk-llama.cpp/bin/llama-server` exists and the systemd unit is registered.
  4. In Store, click Install on `gemma-4-e2b-gguf`.
  5. GGUF downloads to `~/rk-llama.cpp/models/gemma-4-e2b-gguf.gguf`, `active.gguf` symlink updated, `rkllamacpp` service starts.
  6. `curl http://localhost:8090/health` returns 200.

## Closes

Closes #322.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Gemma 4 E2B model to the catalog with multi-tier hardware support and quantization variants
  * Enabled rk-llama.cpp backend with automated installer support for RK3588 systems

* **Documentation**
  * Updated platform status to reflect verified backend support across hardware tiers and clarify GGUF model routing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->