### PR TITLE
fix(settings): timeouts + RebuildResult dataclass + dynamic smoke test

### DIFF
--- a/tests/test_desktop_rebuild.py
+++ b/tests/test_desktop_rebuild.py
@@ -85,8 +85,8 @@ async def test_rebuild_skips_when_bundle_current(tmp_path, monkeypatch):
 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
 
-    rebuilt, msg = await rebuild_desktop_bundle_if_stale(tmp_path)
-    assert rebuilt is False
+    result = await rebuild_desktop_bundle_if_stale(tmp_path)
+    assert result.rebuilt is False
     assert called == []
 
 
@@ -97,9 +97,9 @@ async def test_rebuild_skips_when_no_package_json(tmp_path):
     src_dir.mkdir(parents=True)
     (src_dir / "App.tsx").write_text("// stale source")
     # Deliberately no package.json
-    rebuilt, msg = await rebuild_desktop_bundle_if_stale(tmp_path)
-    assert rebuilt is False
-    assert "package.json" in msg.lower() or "skipping" in msg.lower()
+    result = await rebuild_desktop_bundle_if_stale(tmp_path)
+    assert result.rebuilt is False
+    assert "package.json" in result.message.lower() or "skipping" in result.message.lower()
 
 
 @pytest.mark.asyncio
@@ -115,9 +115,9 @@ async def test_rebuild_handles_npm_missing(tmp_path, monkeypatch):
 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
 
-    rebuilt, msg = await rebuild_desktop_bundle_if_stale(tmp_path)
-    assert rebuilt is False
-    assert "npm" in msg.lower()
+    result = await rebuild_desktop_bundle_if_stale(tmp_path)
+    assert result.rebuilt is False
+    assert "npm" in result.message.lower()
 
 
 @pytest.mark.asyncio
@@ -139,9 +139,10 @@ async def test_rebuild_returns_true_on_npm_install_failure(tmp_path, monkeypatch
 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
 
-    rebuilt, msg = await rebuild_desktop_bundle_if_stale(tmp_path)
-    assert rebuilt is True
-    assert "npm install failed" in msg
+    result = await rebuild_desktop_bundle_if_stale(tmp_path)
+    assert result.rebuilt is True
+    assert result.success is False
+    assert "npm install failed" in result.message
 
 
 @pytest.mark.asyncio
@@ -174,9 +175,10 @@ async def test_rebuild_returns_true_on_npm_build_failure(tmp_path, monkeypatch):
 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
 
-    rebuilt, msg = await rebuild_desktop_bundle_if_stale(tmp_path)
-    assert rebuilt is True
-    assert "npm run build failed" in msg
+    result = await rebuild_desktop_bundle_if_stale(tmp_path)
+    assert result.rebuilt is True
+    assert result.success is False
+    assert "npm run build failed" in result.message
 
 
 @pytest.mark.asyncio
@@ -198,6 +200,7 @@ async def test_rebuild_success(tmp_path, monkeypatch):
 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
 
-    rebuilt, msg = await rebuild_desktop_bundle_if_stale(tmp_path)
-    assert rebuilt is True
-    assert "successfully" in msg.lower()
+    result = await rebuild_desktop_bundle_if_stale(tmp_path)
+    assert result.rebuilt is True
+    assert result.success is True
+    assert "successfully" in result.message.lower()

--- a/tests/test_routes_settings.py
+++ b/tests/test_routes_settings.py
@@ -162,3 +162,75 @@ class TestRunCaptureHelper:
         rc, out = await _run_capture(["sh", "-c", "echo boom-on-stderr 1>&2; exit 7"])
         assert rc == 7
         assert "boom-on-stderr" in out
+
+
+class TestRunCaptureTimeout:
+    """The timeout fix for #327. Without it, pip / npm / smoke test could
+    hang the /api/settings/update route forever on a slow mirror."""
+
+    @pytest.mark.asyncio
+    async def test_command_within_timeout_succeeds(self):
+        from tinyagentos.routes.settings import _run_capture
+
+        rc, out = await _run_capture(
+            ["sh", "-c", "echo fast"], timeout=5.0,
+        )
+        assert rc == 0
+        assert "fast" in out
+
+    @pytest.mark.asyncio
+    async def test_command_exceeding_timeout_returns_marker(self):
+        from tinyagentos.routes.settings import _run_capture
+
+        rc, out = await _run_capture(
+            ["sh", "-c", "sleep 5"], timeout=0.5,
+        )
+        assert rc == -1
+        assert "TIMEOUT" in out
+
+    @pytest.mark.asyncio
+    async def test_timeout_kills_subprocess_no_orphan(self):
+        """After timeout, the subprocess must be terminated — not leaked."""
+        import time
+
+        from tinyagentos.routes.settings import _run_capture
+
+        # Long sleep that would pin the subprocess open if not killed.
+        start = time.monotonic()
+        rc, _out = await _run_capture(
+            ["sh", "-c", "sleep 30"], timeout=0.3,
+        )
+        elapsed = time.monotonic() - start
+        assert rc == -1
+        # Should return promptly after timeout, not after the full sleep.
+        assert elapsed < 5.0, (
+            f"_run_capture took {elapsed:.1f}s — subprocess wasn't killed cleanly"
+        )
+
+
+class TestRebuildResultStructured:
+    """Issue #327: rebuild_desktop_bundle_if_stale returns a structured
+    RebuildResult so callers don't have to string-match the message field."""
+
+    @pytest.mark.asyncio
+    async def test_skip_returns_success_true(self, tmp_path):
+        """When there's no desktop/, the rebuild is a successful no-op."""
+        from tinyagentos.desktop_rebuild import rebuild_desktop_bundle_if_stale
+
+        result = await rebuild_desktop_bundle_if_stale(tmp_path, force=True)
+        assert result.rebuilt is False
+        # No desktop dir → nothing to do; that's a successful skip, not a failure.
+        # (force=True makes it skip the staleness check; it still skips because
+        # there's no package.json.)
+        assert result.success is True
+        assert "package.json" in result.message or "current" in result.message.lower()
+
+    @pytest.mark.asyncio
+    async def test_result_fields_present(self, tmp_path):
+        """Sanity-check the dataclass surface so future refactors don't drift."""
+        from tinyagentos.desktop_rebuild import RebuildResult
+
+        r = RebuildResult(rebuilt=True, success=False, message="x")
+        assert r.rebuilt is True
+        assert r.success is False
+        assert r.message == "x"

--- a/tinyagentos/desktop_rebuild.py
+++ b/tinyagentos/desktop_rebuild.py
@@ -9,9 +9,27 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RebuildResult:
+    """Outcome of a rebuild attempt.
+
+    ``rebuilt`` indicates whether a rebuild was attempted at all (False when
+    the staleness check skipped it or npm wasn't available).  ``success``
+    indicates whether the result is healthy (False on npm failure or
+    timeout).  ``message`` is human-readable for log/error surfaces.
+
+    Callers can branch on ``success`` directly rather than string-matching
+    the message — see issue #327.
+    """
+    rebuilt: bool
+    success: bool
+    message: str
 
 
 def _is_bundle_stale(project_root: Path) -> bool:
@@ -37,15 +55,15 @@ async def rebuild_desktop_bundle_if_stale(
     *,
     timeout_seconds: int = 600,
     force: bool = False,
-) -> tuple[bool, str]:
+) -> RebuildResult:
     """Run npm install + npm run build if the bundle is stale (or always, if force=True).
 
-    Returns ``(rebuilt, message)``.  ``rebuilt=False`` means skipped (bundle is
-    current or npm unavailable).  ``rebuilt=True`` means a rebuild was attempted;
-    ``message`` describes the outcome.
+    Returns a :class:`RebuildResult` with ``rebuilt`` (was a build attempted?),
+    ``success`` (did it succeed?), and ``message`` (human-readable detail).
 
-    On hosts where npm/node aren't installed the rebuild fails gracefully with a
-    clear log message.  The caller can decide whether to surface it to the user.
+    On hosts where npm/node aren't installed the rebuild reports
+    ``rebuilt=False, success=True`` (the skip is a successful no-op for the
+    caller — it's not the rebuild's job to install npm).
 
     Use ``force=True`` for explicit user-initiated rebuilds (e.g. the
     ``/api/settings/rebuild-frontend`` endpoint or applied updates) where the
@@ -53,11 +71,19 @@ async def rebuild_desktop_bundle_if_stale(
     their freshness when a PR landed source-only.
     """
     if not force and not _is_bundle_stale(project_root):
-        return False, "Desktop bundle is current — skipping rebuild."
+        return RebuildResult(
+            rebuilt=False,
+            success=True,
+            message="Desktop bundle is current — skipping rebuild.",
+        )
 
     desktop_dir = project_root / "desktop"
     if not (desktop_dir / "package.json").is_file():
-        return False, "No desktop/package.json found — skipping rebuild."
+        return RebuildResult(
+            rebuilt=False,
+            success=True,
+            message="No desktop/package.json found — skipping rebuild.",
+        )
 
     logger.info("Desktop source is ahead of bundle — rebuilding...")
 
@@ -72,7 +98,7 @@ async def rebuild_desktop_bundle_if_stale(
         if proc.returncode != 0:
             msg = f"npm install failed (rc={proc.returncode}): {stderr.decode(errors='replace')[-500:]}"
             logger.error(msg)
-            return True, msg
+            return RebuildResult(rebuilt=True, success=False, message=msg)
 
         proc = await asyncio.create_subprocess_exec(
             "npm", "run", "build",
@@ -84,10 +110,10 @@ async def rebuild_desktop_bundle_if_stale(
         if proc.returncode != 0:
             msg = f"npm run build failed (rc={proc.returncode}): {stderr.decode(errors='replace')[-500:]}"
             logger.error(msg)
-            return True, msg
+            return RebuildResult(rebuilt=True, success=False, message=msg)
 
         logger.info("Desktop bundle rebuilt successfully.")
-        return True, "Desktop bundle rebuilt successfully."
+        return RebuildResult(rebuilt=True, success=True, message="Desktop bundle rebuilt successfully.")
 
     except asyncio.TimeoutError:
         try:
@@ -96,15 +122,16 @@ async def rebuild_desktop_bundle_if_stale(
             pass
         msg = f"Desktop rebuild timed out after {timeout_seconds}s."
         logger.error(msg)
-        return True, msg
+        return RebuildResult(rebuilt=True, success=False, message=msg)
 
     except FileNotFoundError as exc:
-        # npm not on PATH — e.g. minimal Docker image, dev box without Node
+        # npm not on PATH — e.g. minimal Docker image, dev box without Node.
+        # This is a benign skip from the caller's perspective.
         msg = f"npm not available — skipping desktop rebuild: {exc}"
         logger.warning(msg)
-        return False, msg
+        return RebuildResult(rebuilt=False, success=True, message=msg)
 
     except Exception as exc:
         msg = f"Desktop rebuild error: {exc!r}"
         logger.error(msg)
-        return True, msg
+        return RebuildResult(rebuilt=True, success=False, message=msg)

--- a/tinyagentos/routes/settings.py
+++ b/tinyagentos/routes/settings.py
@@ -18,11 +18,34 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-async def _run_capture(cmd: list[str], cwd: str | None = None) -> tuple[int, str]:
-    """Run a subprocess capturing combined stdout+stderr.
+async def _run_capture(
+    cmd: list[str],
+    cwd: str | None = None,
+    timeout: float | None = 600.0,
+) -> tuple[int, str]:
+    """Run a subprocess capturing combined stdout+stderr, with timeout.
 
-    Wraps asyncio.create_subprocess_exec so callers don't have to plumb the
-    PIPE/communicate dance themselves. Returns (returncode, decoded_output).
+    Wraps ``asyncio.create_subprocess_exec`` so callers don't have to plumb
+    the PIPE/communicate dance themselves.
+
+    Parameters
+    ----------
+    cmd:
+        Command list (no shell — argv-style).
+    cwd:
+        Working directory.
+    timeout:
+        Wall-clock seconds. Default 10 minutes — long enough for pip
+        wheels on a Pi but short enough to fail loud rather than hang
+        the user's session indefinitely (issue #327).  Pass ``None`` to
+        disable the timeout (rare; only for trusted long-running calls).
+
+    Returns
+    -------
+    tuple[int, str]
+        ``(returncode, combined_output)``.  On timeout, returncode is
+        ``-1`` and the output ends with a clear ``[TIMEOUT after Ns]``
+        marker so callers can include it in the error surface.
     """
     proc = await asyncio.create_subprocess_exec(
         *cmd,
@@ -30,8 +53,19 @@ async def _run_capture(cmd: list[str], cwd: str | None = None) -> tuple[int, str
         stderr=asyncio.subprocess.STDOUT,
         cwd=cwd,
     )
-    out, _ = await proc.communicate()
-    return proc.returncode or 0, out.decode() if out else ""
+    try:
+        out, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        return proc.returncode or 0, out.decode() if out else ""
+    except asyncio.TimeoutError:
+        # Kill the subprocess so it doesn't leak; communicate() may have
+        # buffered some output before we hit the timeout, but we can't
+        # safely retrieve it without potentially blocking again.
+        try:
+            proc.kill()
+            await proc.wait()
+        except Exception:  # noqa: BLE001
+            pass
+        return -1, f"[TIMEOUT after {timeout}s] cmd: {' '.join(cmd[:3])}..."
 
 
 class ConfigUpdate(BaseModel):
@@ -623,14 +657,35 @@ async def apply_update(request: Request):
     # actually load with the freshly installed deps. Without this a partial
     # pip install (returncode 0 but a wheel quietly skipped) still grey-screens
     # the user on restart.
+    #
+    # Walk the package tree dynamically (issue #327) so new modules added in
+    # later PRs are validated automatically without anyone remembering to
+    # update a hardcoded import list. Errors during walk_packages or import
+    # bubble up via the smoke proc's exit code.
     if venv_python is not None and venv_python.exists():
+        smoke_script = (
+            "import importlib, pkgutil, sys, traceback\n"
+            "import tinyagentos\n"
+            "errors = []\n"
+            "for m in pkgutil.walk_packages(tinyagentos.__path__, prefix='tinyagentos.'):\n"
+            "    name = m.name\n"
+            "    # Skip optional dev/test scaffolding; stay on production code paths.\n"
+            "    if any(part in name for part in ('test', '_pycache_', '.scripts.')):\n"
+            "        continue\n"
+            "    try:\n"
+            "        importlib.import_module(name)\n"
+            "    except Exception:\n"
+            "        errors.append(name + ':\\n' + traceback.format_exc())\n"
+            "if errors:\n"
+            "    print('Import smoke FAILED for', len(errors), 'modules:\\n')\n"
+            "    print('\\n---\\n'.join(errors[:10]))\n"
+            "    sys.exit(1)\n"
+            "print('Import smoke OK')\n"
+        )
         smoke_returncode, smoke_output = await _run_capture(
-            [
-                str(venv_python), "-c",
-                "import tinyagentos.app; "
-                "from tinyagentos.routes.desktop_browser import proxy, copilot_ws, vapid, store",
-            ],
+            [str(venv_python), "-c", smoke_script],
             cwd=str(project_dir),
+            timeout=60.0,  # imports should be fast; 60s is generous
         )
         if smoke_returncode != 0:
             return JSONResponse(
@@ -653,9 +708,16 @@ async def apply_update(request: Request):
     # same instant and the heuristic can pick the wrong winner. Force-rebuilding
     # is the only reliable path; the cost is one ~30s npm build on Update click.
     from tinyagentos.desktop_rebuild import rebuild_desktop_bundle_if_stale
-    _rebuilt, _rebuild_msg = await rebuild_desktop_bundle_if_stale(project_dir, force=True)
-    if _rebuilt:
-        logger.info("Desktop rebuild: %s", _rebuild_msg)
+    rebuild_result = await rebuild_desktop_bundle_if_stale(project_dir, force=True)
+    if rebuild_result.rebuilt:
+        logger.info("Desktop rebuild: %s", rebuild_result.message)
+    if not rebuild_result.success:
+        # Update is still applied to disk, but the frontend won't be in sync
+        # until the rebuild succeeds. Surface this clearly rather than
+        # silently leaving the user with a stale UI.
+        logger.warning(
+            "Update pulled but desktop rebuild failed: %s", rebuild_result.message
+        )
 
     # Record the new SHA so the restart modal can confirm the update was applied
     # and the Updates section can show the pending-restart banner.
@@ -717,11 +779,16 @@ async def rebuild_frontend(request: Request):
     project_dir = Path(__file__).parent.parent.parent
     from tinyagentos.desktop_rebuild import rebuild_desktop_bundle_if_stale
 
-    rebuilt, message = await rebuild_desktop_bundle_if_stale(project_dir, force=True)
-    if not rebuilt:
-        return JSONResponse({"error": message}, status_code=500)
-    if "failed" in message.lower() or "error" in message.lower() or "timed out" in message.lower():
-        return JSONResponse({"error": message}, status_code=500)
+    result = await rebuild_desktop_bundle_if_stale(project_dir, force=True)
+    if not result.success:
+        # Structured success bool — no more string-matching the message
+        # field for "failed"/"error"/"timed out". Issue #327.
+        return JSONResponse({"error": result.message}, status_code=500)
+    if not result.rebuilt:
+        # Force=True should always rebuild unless something is fundamentally
+        # missing (no package.json, npm not on PATH). Surface the reason
+        # rather than claiming success — the user clicked Rebuild.
+        return JSONResponse({"error": result.message}, status_code=500)
 
     return {
         "status": "rebuilt",

--- a/tinyagentos/routes/settings.py
+++ b/tinyagentos/routes/settings.py
@@ -57,13 +57,20 @@ async def _run_capture(
         out, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout)
         return proc.returncode or 0, out.decode() if out else ""
     except asyncio.TimeoutError:
-        # Kill the subprocess so it doesn't leak; communicate() may have
-        # buffered some output before we hit the timeout, but we can't
-        # safely retrieve it without potentially blocking again.
+        # Kill the subprocess so it doesn't leak. communicate() may have
+        # buffered some output before we hit the timeout but we can't
+        # safely retrieve it without potentially blocking again.  Don't
+        # rely on proc.wait() unbounded — on some Linux kernels the
+        # asyncio subprocess transport can hold a pipe FD open after
+        # SIGKILL, leaving wait() pending until manual reap (#323/#327
+        # CI flake).  So bound it.
         try:
             proc.kill()
-            await proc.wait()
-        except Exception:  # noqa: BLE001
+        except (ProcessLookupError, Exception):  # noqa: BLE001
+            pass
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=2.0)
+        except (asyncio.TimeoutError, Exception):  # noqa: BLE001
             pass
         return -1, f"[TIMEOUT after {timeout}s] cmd: {' '.join(cmd[:3])}..."
 


### PR DESCRIPTION
Closes #327. Addresses all three findings from the post-#324 manual audit.

## Changes

### 1. \`_run_capture\` now has a timeout (default 600s)

The helper used to call \`proc.communicate()\` without a timeout. Same class of bug as #323 — if pip, npm, or the smoke test hung on a slow mirror, \`/api/settings/update\` would hang the user's session forever.

Now wraps \`communicate()\` in \`asyncio.wait_for\` and kills the subprocess on timeout. Returns \`(-1, "[TIMEOUT after Ns] cmd: ...")\` so callers can include the marker in error surfaces. The pip-install call uses the 600s default; the smoke test uses 60s (imports should be fast).

### 2. \`rebuild_desktop_bundle_if_stale\` returns a structured \`RebuildResult\`

Previously \`(rebuilt: bool, message: str)\`. \`/api/settings/rebuild-frontend\` had to string-match \`"failed"/"error"/"timed out"\` against the message — fragile coupling that would break silently if the helper's wording changed. Now: \`@dataclass(frozen=True) RebuildResult(rebuilt, success, message)\`. Callers branch on \`result.success\` directly.

### 3. Smoke test walks the package tree

The hardcoded import list was \`tinyagentos.app\` + four \`desktop_browser\` submodules. New routes added later wouldn't be validated. Replaced with \`pkgutil.walk_packages(tinyagentos.__path__)\` so every production module is exercised, with any \`ModuleNotFoundError\` surfacing before restart.

## Test plan

- [x] 21 tests pass in \`tests/test_routes_settings.py\` (16 existing + 5 new).
- [x] New tests cover: timeout returns marker, timeout doesn't leak subprocess, RebuildResult skip-success path, dataclass fields.