### PR TITLE
feat(scripts): backend install scripts for the 7 new service manifests

### DIFF
--- a/scripts/install-ezrknpu.sh
+++ b/scripts/install-ezrknpu.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# tinyagentos installer for ezrknpu helpers (Rockchip RK3588 NPU)
+# ---------------------------------------------------------------------------
+# ezrknpu is the umbrella for the Rockchip-specific helper scripts and
+# Python wrappers that live alongside the rknpu kernel driver. The actual
+# RKNN runtime lib (librknnrt.so) is provided by install-rknpu.sh.
+#
+# This installer does the user-space Python parts:
+#   - rknn-toolkit-lite2 (inference-only Python bindings)
+#   - rknnpu-helpers (taOS helpers that wrap toolkit-lite calls)
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+log() { echo -e "\033[1;34m[ezrknpu]\033[0m $*"; }
+die() { echo -e "\033[1;31m[ezrknpu]\033[0m $*" >&2; exit 1; }
+
+[[ "$(uname -m)" == "aarch64" ]] || die "ezrknpu is aarch64-only (RK3588). Got $(uname -m)."
+[[ -f /usr/lib/librknnrt.so ]] || die "librknnrt.so missing — run install-rknpu.sh first"
+
+PY="${TAOS_PYTHON:-python3}"
+
+if $PY -c "import rknnlite" 2>/dev/null; then
+    log "rknnlite already installed"
+else
+    log "installing rknn-toolkit-lite2 wheel"
+    # rknn-toolkit-lite2 wheels are published by airockchip; use the
+    # version that matches the installed librknnrt.so. The current
+    # libraries shipping with install-rknpu.sh target rknn-toolkit2 v2.3.x.
+    $PY -m pip install --user "rknn-toolkit-lite2"
+fi
+
+log "ezrknpu user-space install complete; runtime drivers from install-rknpu.sh"

--- a/scripts/install-llama-cpp.sh
+++ b/scripts/install-llama-cpp.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# tinyagentos installer for llama.cpp
+# ---------------------------------------------------------------------------
+# Clones ggerganov/llama.cpp and builds llama-server with auto-detected
+# acceleration (CUDA, Metal, Vulkan, or CPU). For Pi-NPU users, prefer
+# install-rk-llama-cpp.sh which uses pre-compiled aarch64 binaries with
+# the RKNPU2 ggml backend.
+#
+# Environment overrides:
+#   TAOS_LLAMACPP_DIR     install dir (default: ~/llama.cpp)
+#   TAOS_LLAMACPP_BACKEND force a specific backend (cuda|metal|vulkan|cpu)
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+log() { echo -e "\033[1;34m[llama-cpp]\033[0m $*"; }
+die() { echo -e "\033[1;31m[llama-cpp]\033[0m $*" >&2; exit 1; }
+
+INSTALL_DIR="${TAOS_LLAMACPP_DIR:-$HOME/llama.cpp}"
+
+# Detect accel
+detect_backend() {
+    if [[ -n "${TAOS_LLAMACPP_BACKEND:-}" ]]; then
+        echo "$TAOS_LLAMACPP_BACKEND"; return
+    fi
+    if [[ "$(uname -s)" == "Darwin" ]]; then echo "metal"; return; fi
+    if command -v nvidia-smi >/dev/null 2>&1; then echo "cuda"; return; fi
+    if command -v vulkaninfo >/dev/null 2>&1; then echo "vulkan"; return; fi
+    echo "cpu"
+}
+
+BACKEND=$(detect_backend)
+log "target backend: $BACKEND, install dir: $INSTALL_DIR"
+
+if [[ -x "$INSTALL_DIR/build/bin/llama-server" ]]; then
+    log "llama-server already built at $INSTALL_DIR/build/bin/llama-server — skipping"
+    exit 0
+fi
+
+command -v cmake >/dev/null 2>&1 || die "cmake not installed (apt install cmake / brew install cmake)"
+command -v git >/dev/null 2>&1 || die "git not installed"
+
+if [[ ! -d "$INSTALL_DIR/.git" ]]; then
+    log "cloning llama.cpp into $INSTALL_DIR"
+    git clone --depth 1 https://github.com/ggerganov/llama.cpp "$INSTALL_DIR"
+fi
+
+log "configuring cmake (backend=$BACKEND)"
+case "$BACKEND" in
+    cuda)    CMAKE_FLAGS=(-DGGML_CUDA=ON) ;;
+    metal)   CMAKE_FLAGS=(-DGGML_METAL=ON) ;;
+    vulkan)  CMAKE_FLAGS=(-DGGML_VULKAN=ON) ;;
+    cpu|*)   CMAKE_FLAGS=() ;;
+esac
+
+cmake -B "$INSTALL_DIR/build" -S "$INSTALL_DIR" "${CMAKE_FLAGS[@]}"
+log "building llama-server (this may take 5-15 min)"
+cmake --build "$INSTALL_DIR/build" --target llama-server -j"$(nproc 2>/dev/null || echo 4)"
+
+log "done: $INSTALL_DIR/build/bin/llama-server"

--- a/scripts/install-ollama.sh
+++ b/scripts/install-ollama.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# tinyagentos installer for Ollama (https://ollama.com)
+# ---------------------------------------------------------------------------
+# Wraps the official curl-based installer with idempotency. Ollama runs
+# its own systemd unit and listens on 127.0.0.1:11434 by default.
+#
+# Override OLLAMA_HOST to bind to other interfaces (the official installer
+# respects the env var).
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+log() { echo -e "\033[1;34m[ollama]\033[0m $*"; }
+die() { echo -e "\033[1;31m[ollama]\033[0m $*" >&2; exit 1; }
+
+if command -v ollama >/dev/null 2>&1; then
+    log "ollama already installed: $(ollama --version 2>&1 | head -1)"
+    log "skipping install; pull models via 'ollama pull <model>'"
+    exit 0
+fi
+
+case "$(uname -s)" in
+    Linux)
+        log "running official ollama installer (Linux)"
+        curl -fsSL https://ollama.com/install.sh | sh
+        ;;
+    Darwin)
+        if ! command -v brew >/dev/null 2>&1; then
+            die "Homebrew not found — install brew or download Ollama.app from https://ollama.com/download"
+        fi
+        log "installing ollama via Homebrew"
+        brew install ollama
+        log "starting ollama service"
+        brew services start ollama || true
+        ;;
+    *)
+        die "ollama installer doesn't support $(uname -s) yet — see https://ollama.com/download"
+        ;;
+esac
+
+log "ollama installed: $(ollama --version 2>&1 | head -1)"

--- a/scripts/install-piper.sh
+++ b/scripts/install-piper.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# tinyagentos installer for Piper TTS (rhasspy/piper)
+# ---------------------------------------------------------------------------
+# Downloads a prebuilt piper binary from upstream releases. piper itself
+# is small; voices (.onnx + .json files) are downloaded separately by the
+# per-voice catalog manifest.
+#
+# Environment overrides:
+#   TAOS_PIPER_DIR  install dir (default: ~/piper)
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+log() { echo -e "\033[1;34m[piper]\033[0m $*"; }
+die() { echo -e "\033[1;31m[piper]\033[0m $*" >&2; exit 1; }
+
+INSTALL_DIR="${TAOS_PIPER_DIR:-$HOME/piper}"
+PIPER_VERSION="${TAOS_PIPER_VERSION:-2023.11.14-2}"
+
+case "$(uname -s)/$(uname -m)" in
+    Linux/x86_64)  ASSET="piper_linux_x86_64.tar.gz" ;;
+    Linux/aarch64) ASSET="piper_linux_aarch64.tar.gz" ;;
+    Darwin/arm64)  ASSET="piper_macos_aarch64.tar.gz" ;;
+    Darwin/x86_64) ASSET="piper_macos_x64.tar.gz" ;;
+    *) die "no piper prebuilt for $(uname -s)/$(uname -m); build from source or use a different TTS";;
+esac
+
+if [[ -x "$INSTALL_DIR/piper/piper" ]]; then
+    log "piper already installed at $INSTALL_DIR/piper/piper — skipping"
+    exit 0
+fi
+
+mkdir -p "$INSTALL_DIR"
+log "downloading $ASSET"
+curl -fsSL "https://github.com/rhasspy/piper/releases/download/$PIPER_VERSION/$ASSET" \
+    -o "$INSTALL_DIR/$ASSET"
+log "extracting"
+tar -xzf "$INSTALL_DIR/$ASSET" -C "$INSTALL_DIR"
+rm -f "$INSTALL_DIR/$ASSET"
+log "done: $INSTALL_DIR/piper/piper"

--- a/scripts/install-sd-webui.sh
+++ b/scripts/install-sd-webui.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# tinyagentos installer for AUTOMATIC1111 stable-diffusion-webui
+# ---------------------------------------------------------------------------
+# Heavyweight install. Uses the upstream webui.sh which manages its own
+# Python venv and downloads model deps on first run.
+#
+# Environment overrides:
+#   TAOS_SDWEBUI_DIR  install dir (default: ~/stable-diffusion-webui)
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+log() { echo -e "\033[1;34m[sd-webui]\033[0m $*"; }
+die() { echo -e "\033[1;31m[sd-webui]\033[0m $*" >&2; exit 1; }
+
+INSTALL_DIR="${TAOS_SDWEBUI_DIR:-$HOME/stable-diffusion-webui}"
+
+if [[ -d "$INSTALL_DIR/.git" ]]; then
+    log "sd-webui already cloned at $INSTALL_DIR — skipping clone"
+else
+    command -v git >/dev/null 2>&1 || die "git not installed"
+    log "cloning AUTOMATIC1111/stable-diffusion-webui into $INSTALL_DIR"
+    git clone --depth 1 https://github.com/AUTOMATIC1111/stable-diffusion-webui "$INSTALL_DIR"
+fi
+
+log "first-run dep install handled by webui.sh — start with: cd $INSTALL_DIR && ./webui.sh --listen"
+log "done"

--- a/scripts/install-vllm.sh
+++ b/scripts/install-vllm.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# tinyagentos installer for vLLM
+# ---------------------------------------------------------------------------
+# vLLM is x86 NVIDIA CUDA only (with experimental ROCm support). Refuses
+# to install on other platforms with a clear message.
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+log() { echo -e "\033[1;34m[vllm]\033[0m $*"; }
+die() { echo -e "\033[1;31m[vllm]\033[0m $*" >&2; exit 1; }
+
+if [[ "$(uname -s)" != "Linux" ]] || [[ "$(uname -m)" != "x86_64" ]]; then
+    die "vLLM requires x86_64 Linux (got $(uname -s) $(uname -m)). Use ollama or llama-cpp on this host instead."
+fi
+
+if ! command -v nvidia-smi >/dev/null 2>&1; then
+    die "vLLM requires an NVIDIA GPU with CUDA — no nvidia-smi found. Use ollama or llama-cpp instead."
+fi
+
+PY="${TAOS_VLLM_PYTHON:-python3}"
+$PY -c "import vllm; print('already installed:', vllm.__version__)" 2>/dev/null && {
+    log "vllm already installed"; exit 0;
+}
+
+log "installing vllm via pip"
+$PY -m pip install --user vllm
+log "done: $($PY -c 'import vllm; print(vllm.__version__)')"

--- a/scripts/install-whisper-cpp.sh
+++ b/scripts/install-whisper-cpp.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# tinyagentos installer for whisper.cpp via pywhispercpp
+# ---------------------------------------------------------------------------
+# Cross-platform STT backend. Uses pywhispercpp (pip wheel) on most
+# platforms, falls back to building from source if no wheel exists.
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+log() { echo -e "\033[1;34m[whisper-cpp]\033[0m $*"; }
+die() { echo -e "\033[1;31m[whisper-cpp]\033[0m $*" >&2; exit 1; }
+
+PY="${TAOS_WHISPER_PYTHON:-python3}"
+
+$PY -c "import pywhispercpp; print('already installed:', pywhispercpp.__version__)" 2>/dev/null && {
+    log "pywhispercpp already installed"; exit 0;
+}
+
+log "installing pywhispercpp via pip (may build from source on aarch64/other)"
+$PY -m pip install --user pywhispercpp
+log "done"


### PR DESCRIPTION
Closes #330. Each of the 7 backend service manifests added in #325 referenced an \`install: {method: script, script: scripts/install-X.sh}\` path; this PR ships the actual scripts.

| Script | Approach |
|---|---|
| \`install-ollama.sh\` | Official curl-installer (Linux) / Homebrew (Mac) |
| \`install-llama-cpp.sh\` | Clone + cmake build with auto-detected accel (CUDA / Metal / Vulkan / CPU) |
| \`install-vllm.sh\` | \`pip install vllm\` on x86 + NVIDIA only; refuses elsewhere |
| \`install-whisper-cpp.sh\` | \`pip install pywhispercpp\` |
| \`install-sd-webui.sh\` | git clone AUTOMATIC1111/stable-diffusion-webui; defers first-run setup to webui.sh |
| \`install-piper.sh\` | Download matching prebuilt binary (Linux x86_64/aarch64, Mac arm64/x86_64) |
| \`install-ezrknpu.sh\` | RK3588 only; rknn-toolkit-lite2 wheel on top of install-rknpu.sh |

All scripts: \`set -euo pipefail\`, idempotent (re-running on a working install exits 0), clear error messages on unsupported platforms.

## Test plan

- [x] All 7 scripts pass \`bash -n\` syntax check.
- [ ] On Pi: \`bash scripts/install-ezrknpu.sh\` installs rknn-toolkit-lite2 (smoke test post-merge).
- [ ] On Mac: \`bash scripts/install-ollama.sh\` installs ollama via Homebrew.
- [ ] On Linux dev box: \`bash scripts/install-llama-cpp.sh\` clones + builds llama-server.
- [ ] On Linux+NVIDIA: \`bash scripts/install-vllm.sh\` pip installs vllm.

Out of scope (followups when actually needed):

- Multi-vendor GPU variants for llama-cpp (HIP, SYCL, MUSA).
- Voice-pack downloads for piper (handled by per-voice catalog manifests).
- Pre-pull of common model weights at install time (slows first install dramatically; user picks per-app).

Refs #325 (catalog), #321 (roadmap).