### PR TITLE
feat(installers): OllamaInstaller — pulls models via /api/pull

### DIFF
--- a/tests/installers/test_ollama_installer.py
+++ b/tests/installers/test_ollama_installer.py
@@ -1,0 +1,187 @@
+"""Tests for OllamaInstaller — Ollama daemon model puller.
+
+Mocks httpx at the boundary so tests don't actually hit a daemon.
+"""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+
+class _MockStreamCtx:
+    """Mock async context manager for httpx's client.stream() return value.
+
+    httpx's stream() returns a context manager directly (not a coroutine).
+    AsyncMock can't be used here because Python's `async with` doesn't await
+    the call itself, only the __aenter__/__aexit__ methods.
+    """
+    def __init__(self, response):
+        self._response = response
+
+    async def __aenter__(self):
+        return self._response
+
+    async def __aexit__(self, *_args):
+        return None
+
+
+def _make_pull_response(events):
+    """Build a mock streaming response that yields the given JSON events."""
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+
+    async def _aiter_lines():
+        for line in events:
+            yield line
+
+    resp.aiter_lines = _aiter_lines
+    return resp
+
+
+class TestDefaultHostResolution:
+    def test_default_no_env(self, monkeypatch):
+        monkeypatch.delenv("OLLAMA_HOST", raising=False)
+        from tinyagentos.installers.ollama_installer import _default_host
+        assert _default_host() == "http://localhost:11434"
+
+    def test_explicit_url_from_env(self, monkeypatch):
+        monkeypatch.setenv("OLLAMA_HOST", "http://10.0.0.5:11434")
+        from tinyagentos.installers.ollama_installer import _default_host
+        assert _default_host() == "http://10.0.0.5:11434"
+
+    def test_bare_host_port_gets_scheme(self, monkeypatch):
+        """OLLAMA_HOST sometimes has no scheme; we add http:// rather than failing."""
+        monkeypatch.setenv("OLLAMA_HOST", "10.0.0.5:11434")
+        from tinyagentos.installers.ollama_installer import _default_host
+        assert _default_host() == "http://10.0.0.5:11434"
+
+    def test_explicit_host_overrides_env(self, monkeypatch):
+        monkeypatch.setenv("OLLAMA_HOST", "http://from-env:11434")
+        from tinyagentos.installers.ollama_installer import OllamaInstaller
+        i = OllamaInstaller(host="http://explicit:11434")
+        assert i.host == "http://explicit:11434"
+
+
+class TestModelNameResolution:
+    """variant.ollama_name overrides app_id; falls back to app_id if missing."""
+
+    @pytest.mark.asyncio
+    async def test_uses_variant_ollama_name_when_set(self):
+        from tinyagentos.installers.ollama_installer import OllamaInstaller
+
+        i = OllamaInstaller(host="http://localhost:11434")
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = client
+            client.get.return_value = MagicMock(raise_for_status=MagicMock(), status_code=200)
+
+            stream_resp = _make_pull_response([
+                '{"status": "downloading"}',
+                '{"status": "success"}',
+            ])
+            client.stream = MagicMock(return_value=_MockStreamCtx(stream_resp))
+
+            result = await i.install(
+                "mymodel",
+                install_config={},
+                variant={"ollama_name": "qwen2.5:3b"},
+            )
+
+        assert result["success"] is True
+        assert client.stream.call_args.kwargs["json"]["name"] == "qwen2.5:3b"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_app_id(self):
+        from tinyagentos.installers.ollama_installer import OllamaInstaller
+
+        i = OllamaInstaller(host="http://localhost:11434")
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = client
+            client.get.return_value = MagicMock(raise_for_status=MagicMock(), status_code=200)
+
+            stream_resp = _make_pull_response(['{"status": "success"}'])
+            client.stream = MagicMock(return_value=_MockStreamCtx(stream_resp))
+
+            result = await i.install("qwen2.5:3b", install_config={}, variant=None)
+
+        assert result["success"] is True
+        assert client.stream.call_args.kwargs["json"]["name"] == "qwen2.5:3b"
+
+
+class TestDaemonNotReachable:
+    @pytest.mark.asyncio
+    async def test_returns_helpful_error_when_daemon_down(self):
+        from tinyagentos.installers.ollama_installer import OllamaInstaller
+
+        i = OllamaInstaller(host="http://localhost:11434")
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = client
+            client.get.side_effect = httpx.ConnectError("connection refused")
+
+            result = await i.install("qwen2.5:3b", install_config={}, variant=None)
+
+        assert result["success"] is False
+        assert "not reachable" in result["error"].lower()
+        assert "install-ollama.sh" in result["error"]
+
+
+class TestPullErrorPropagation:
+    @pytest.mark.asyncio
+    async def test_pull_error_event_returns_failure(self):
+        from tinyagentos.installers.ollama_installer import OllamaInstaller
+
+        i = OllamaInstaller(host="http://localhost:11434")
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = client
+            client.get.return_value = MagicMock(raise_for_status=MagicMock(), status_code=200)
+
+            stream_resp = _make_pull_response([
+                '{"status": "downloading"}',
+                '{"error": "model not found in library"}',
+            ])
+            client.stream = MagicMock(return_value=_MockStreamCtx(stream_resp))
+
+            result = await i.install("nope", install_config={}, variant=None)
+
+        assert result["success"] is False
+        assert "model not found" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_no_success_event_returns_failure(self):
+        """If the stream ends without a {status: success} event, the pull
+        didn't actually finish — we shouldn't claim success."""
+        from tinyagentos.installers.ollama_installer import OllamaInstaller
+
+        i = OllamaInstaller(host="http://localhost:11434")
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = client
+            client.get.return_value = MagicMock(raise_for_status=MagicMock(), status_code=200)
+
+            stream_resp = _make_pull_response([
+                '{"status": "downloading"}',
+                '{"status": "verifying"}',
+            ])
+            client.stream = MagicMock(return_value=_MockStreamCtx(stream_resp))
+
+            result = await i.install("incomplete", install_config={}, variant=None)
+
+        assert result["success"] is False
+        assert "verifying" in result["error"]
+
+
+class TestGetInstallerWiring:
+    def test_get_installer_returns_ollama_installer(self):
+        from tinyagentos.installers.base import get_installer
+        from tinyagentos.installers.ollama_installer import OllamaInstaller
+
+        i = get_installer("ollama")
+        assert isinstance(i, OllamaInstaller)

--- a/tests/routes/test_store_install_v2.py
+++ b/tests/routes/test_store_install_v2.py
@@ -134,13 +134,17 @@ class TestBackendToMethodMapping:
     The underlying installers' .install() methods are mocked to avoid I/O.
     """
 
-    def test_ollama_maps_to_download_no_value_error(self):
-        """get_installer(_BACKEND_TO_METHOD['ollama']) must not raise."""
+    def test_ollama_maps_to_ollama_installer_no_value_error(self):
+        """get_installer(_BACKEND_TO_METHOD['ollama']) must not raise.
+
+        Originally pointed at the generic DownloadInstaller; now uses the
+        dedicated OllamaInstaller which streams /api/pull (#329 / #342).
+        """
         from tinyagentos.routes.store_install import _BACKEND_TO_METHOD
         from tinyagentos.installers.base import get_installer
 
         method = _BACKEND_TO_METHOD["ollama"]
-        assert method == "download"
+        assert method == "ollama"
         # Should not raise ValueError
         installer = get_installer(method)
         assert installer is not None

--- a/tinyagentos/installers/base.py
+++ b/tinyagentos/installers/base.py
@@ -53,6 +53,9 @@ def get_installer(method: str, **kwargs) -> AppInstaller:
     elif method in ("rkllamacpp", "rk-llama.cpp"):
         from tinyagentos.installers.rkllamacpp_installer import RkLlamaCppInstaller
         return RkLlamaCppInstaller(**kwargs)
+    elif method == "ollama":
+        from tinyagentos.installers.ollama_installer import OllamaInstaller
+        return OllamaInstaller(**kwargs)
     elif method == "script":
         from tinyagentos.installers.script_installer import ScriptInstaller
         return ScriptInstaller(**kwargs)

--- a/tinyagentos/installers/ollama_installer.py
+++ b/tinyagentos/installers/ollama_installer.py
@@ -1,0 +1,165 @@
+"""Ollama installer — pulls models via `ollama pull` over HTTP.
+
+Ollama runs its own daemon on port 11434 with an OllamaCompatible API,
+including ``POST /api/pull`` (the same shape as rkllama, conveniently).
+This installer just calls that endpoint — Ollama owns the model files
+on disk; we don't push anything from the controller.
+
+Variants in catalog manifests can declare an explicit ``ollama_name``
+field with the Ollama library identifier (e.g. ``qwen2.5:3b``,
+``llama3.2:1b-q8_0``). When absent, we fall back to the manifest's ID
+verbatim — works for any model whose catalog ID matches its Ollama
+library entry, fails clearly otherwise so the user can fix the manifest.
+
+Configuration via env var (matching scripts/install-ollama.sh):
+
+- ``OLLAMA_HOST`` — daemon URL (default: ``http://localhost:11434``)
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any
+
+import httpx
+
+from tinyagentos.installers.base import AppInstaller
+
+logger = logging.getLogger(__name__)
+
+
+def _default_host() -> str:
+    """Resolve daemon URL from OLLAMA_HOST or fallback to localhost:11434."""
+    raw = os.environ.get("OLLAMA_HOST", "").strip()
+    if not raw:
+        return "http://localhost:11434"
+    # OLLAMA_HOST sometimes carries just `host:port` without scheme — normalize.
+    if "://" not in raw:
+        raw = f"http://{raw}"
+    return raw.rstrip("/")
+
+
+class OllamaInstaller(AppInstaller):
+    """Install models for serving via the Ollama daemon."""
+
+    def __init__(self, host: str | None = None, timeout: int = 3600):
+        self.host = host.rstrip("/") if host else _default_host()
+        # Pulls can take a long time (multi-GB layers, slow mirrors).
+        # 60 minutes is a generous default; callers can override.
+        self.timeout = timeout
+
+    async def install(
+        self,
+        app_id: str,
+        install_config: dict,
+        variant: dict | None = None,
+        **_: Any,
+    ) -> dict:
+        # Resolve the ollama model name. Variant's explicit field wins; fall
+        # back to manifest_id (passed as app_id by the dispatcher).
+        model_name: str = ""
+        if variant and isinstance(variant, dict):
+            model_name = str(variant.get("ollama_name", "") or "").strip()
+        if not model_name:
+            model_name = app_id
+
+        if not model_name:
+            return {
+                "success": False,
+                "error": "no ollama model name to pull (variant.ollama_name or app_id required)",
+            }
+
+        # Verify the daemon is reachable before kicking off a long pull.
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                resp = await client.get(f"{self.host}/api/tags")
+                resp.raise_for_status()
+        except Exception as exc:  # noqa: BLE001
+            return {
+                "success": False,
+                "error": (
+                    f"ollama daemon not reachable at {self.host}: {exc}. "
+                    "Run scripts/install-ollama.sh first."
+                ),
+            }
+
+        # Pull via the streaming /api/pull endpoint. Status events flow as
+        # NDJSON; a final {"status": "success"} indicates completion.
+        last_status = ""
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                async with client.stream(
+                    "POST",
+                    f"{self.host}/api/pull",
+                    json={"name": model_name, "stream": True},
+                ) as resp:
+                    resp.raise_for_status()
+                    async for line in resp.aiter_lines():
+                        if not line:
+                            continue
+                        try:
+                            data = json.loads(line)
+                        except json.JSONDecodeError:
+                            continue
+                        if data.get("error"):
+                            return {
+                                "success": False,
+                                "error": f"ollama pull failed: {data['error']}",
+                                "ollama_model": model_name,
+                            }
+                        last_status = data.get("status", last_status)
+        except httpx.HTTPError as exc:
+            return {
+                "success": False,
+                "error": f"ollama pull HTTP error: {exc}",
+                "ollama_model": model_name,
+            }
+
+        if last_status != "success":
+            return {
+                "success": False,
+                "error": (
+                    f"ollama pull ended with status {last_status!r} (expected 'success'). "
+                    "Check the daemon logs for details."
+                ),
+                "ollama_model": model_name,
+            }
+
+        return {
+            "success": True,
+            "app_id": app_id,
+            "ollama_model": model_name,
+            "endpoint": self.host,
+            "runtime_location": {
+                "host": self.host.replace("http://", "").replace("https://", "").split(":")[0],
+                "port": int(self.host.rsplit(":", 1)[-1]) if ":" in self.host.replace("://", "") else 11434,
+                "backend": "ollama",
+            },
+        }
+
+    async def uninstall(self, app_id: str) -> dict:
+        """Best-effort uninstall via DELETE /api/delete.
+
+        The ollama model name needs to come from caller-supplied metadata
+        (the dispatcher's registry knows what was pulled). Without it we
+        fall back to the app_id itself.
+        """
+        try:
+            async with httpx.AsyncClient(timeout=30) as client:
+                resp = await client.request(
+                    "DELETE",
+                    f"{self.host}/api/delete",
+                    json={"name": app_id},
+                )
+                if resp.status_code == 200:
+                    return {"success": True, "status": "uninstalled", "ollama_model": app_id}
+                # 404 means already gone — that's fine for uninstall.
+                if resp.status_code == 404:
+                    return {"success": True, "status": "not-installed", "ollama_model": app_id}
+                return {
+                    "success": False,
+                    "error": f"ollama delete returned {resp.status_code}: {resp.text[:200]}",
+                }
+        except httpx.HTTPError as exc:
+            return {"success": False, "error": f"ollama delete HTTP error: {exc}"}

--- a/tinyagentos/routes/store_install.py
+++ b/tinyagentos/routes/store_install.py
@@ -44,7 +44,7 @@ _KNOWN_BACKENDS = {
 _BACKEND_TO_METHOD: dict[str, str] = {
     "rkllama": "rkllama",
     "rk-llama-cpp": "rkllamacpp",
-    "ollama": "download",
+    "ollama": "ollama",
     "llama-cpp": "download",
     "mlx": "download",
     "vllm": "download",


### PR DESCRIPTION
First purpose-built per-backend installer from #329. Replaces the \`download\` fallback for the \`ollama\` entry in \`_BACKEND_TO_METHOD\` with a real pull flow.

## What it does

- Talks to the Ollama daemon over HTTP (default \`localhost:11434\`, override via \`OLLAMA_HOST\` env var to match \`scripts/install-ollama.sh\`).
- Verifies the daemon is reachable **before** kicking off a long pull. Clear error pointing at \`install-ollama.sh\` if not.
- Streams \`/api/pull\` NDJSON events; bubbles up any \`{error: ...}\` event immediately. Won't claim success unless the stream ends with \`{status: "success"}\`.
- Resolves the model name from \`variant.ollama_name\` (preferred) with a fallback to \`app_id\` verbatim — works for any catalog ID that matches an Ollama library entry.

## Test plan

- [x] 10 unit tests pass: env var resolution (4), model-name fallback (2), daemon-down clear error (1), mid-pull error events (1), no-success-event failure (1), get_installer wiring (1).

## Out of scope

The other download-fallback backends (vllm, mlx, llama-cpp, comfyui, transformers, diffusers, etc.) — same pattern, future PRs.

Refs #329.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added dedicated Ollama installer for pulling models via the Ollama daemon API.
  * Automatic host resolution from `OLLAMA_HOST` environment variable with intelligent URL scheme handling.
  * Model selection via variant configuration with fallback to app identifier.

* **Tests**
  * Comprehensive test suite for Ollama installer functionality, error handling, and integration paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->