### PR TITLE
fix(asyncio): defensive timeouts + poll budget for #323 wedge

### DIFF
--- a/tests/test_health_poll_budget.py
+++ b/tests/test_health_poll_budget.py
@@ -1,0 +1,94 @@
+"""Tests that the health monitor's poll loop has a hard time budget.
+
+Issue #323: a single hung backend probe could lock the event loop. Each call
+already has its own timeout, but `_poll_once` runs many of them sequentially
+plus a qmd probe and metrics writes. The wait_for budget is the last line of
+defence.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tinyagentos.health import HealthMonitor
+
+
+class _CapturingHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.messages: list[str] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.messages.append(record.getMessage())
+
+
+def _make_monitor(poll_interval: int = 30) -> HealthMonitor:
+    config = MagicMock()
+    config.metrics = {"poll_interval": poll_interval}
+    config.backends = []
+    config.agents = []
+    metrics = MagicMock()
+    metrics.insert = AsyncMock()
+    metrics.cleanup = AsyncMock(return_value=0)
+    qmd = MagicMock()
+    qmd.health = AsyncMock(return_value={"status": "ok", "response_ms": 5})
+    return HealthMonitor(config, metrics, qmd, http_client=MagicMock())
+
+
+@pytest.mark.asyncio
+async def test_poll_loop_aborts_when_poll_once_hangs():
+    """A wedged _poll_once must not block the loop forever — wait_for kicks in."""
+    monitor = _make_monitor()
+    monitor._poll_budget_seconds = 0.05
+
+    async def hang_forever() -> None:
+        await asyncio.sleep(3600)
+
+    monitor._poll_once = hang_forever  # type: ignore[method-assign]
+
+    handler = _CapturingHandler()
+    health_logger = logging.getLogger("tinyagentos.health")
+    health_logger.addHandler(handler)
+    health_logger.setLevel(logging.DEBUG)
+    try:
+        task = asyncio.create_task(monitor._poll_loop())
+        await asyncio.sleep(0.2)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+    finally:
+        health_logger.removeHandler(handler)
+
+    assert any(
+        "Health poll exceeded" in m and "budget" in m for m in handler.messages
+    ), f"Expected timeout abort log; got: {handler.messages}"
+
+
+@pytest.mark.asyncio
+async def test_poll_loop_continues_after_timeout_abort():
+    """After a TimeoutError, the loop must keep running (not exit)."""
+    monitor = _make_monitor(poll_interval=0)  # no inter-cycle delay
+    monitor._poll_budget_seconds = 0.05
+    call_count = {"n": 0}
+
+    async def slow_then_ok() -> None:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            await asyncio.sleep(3600)
+
+    monitor._poll_once = slow_then_ok  # type: ignore[method-assign]
+
+    task = asyncio.create_task(monitor._poll_loop())
+    await asyncio.sleep(0.2)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+    assert call_count["n"] >= 2, "loop did not iterate past the timeout"

--- a/tinyagentos/__main__.py
+++ b/tinyagentos/__main__.py
@@ -34,7 +34,9 @@ def main() -> None:
         port = config.server.get("port", 6969)
 
     app = create_app(data_dir=data_dir)
-    uvicorn.run(app, host=host, port=port)
+    # backlog=128 — see issue #323. Keeps the kernel accept queue from
+    # silently growing into the thousands if the event loop ever wedges.
+    uvicorn.run(app, host=host, port=port, backlog=128)
 
 
 def _seed_data_dir(target: Path) -> None:

--- a/tinyagentos/agent_browsers.py
+++ b/tinyagentos/agent_browsers.py
@@ -163,7 +163,7 @@ class AgentBrowsersManager:
             return _MOCK_PNG
         try:
             import aiohttp  # optional dep
-            async with aiohttp.ClientSession() as session:
+            async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10)) as session:
                 async with session.get(
                     "http://localhost:9222/json", timeout=aiohttp.ClientTimeout(total=5)
                 ) as resp:
@@ -171,7 +171,7 @@ class AgentBrowsersManager:
                     if not tabs:
                         return None
                     ws_url = tabs[0].get("webSocketDebuggerUrl")
-                async with session.ws_connect(ws_url) as ws:
+                async with session.ws_connect(ws_url, timeout=10) as ws:
                     await ws.send_json({"id": 1, "method": "Page.captureScreenshot"})
                     async for msg in ws:
                         import json, base64

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -1167,7 +1167,12 @@ def main():
     import uvicorn
     config = load_config(PROJECT_DIR / "data" / "config.yaml")
     app = create_app()
-    uvicorn.run(app, host=config.server.get("host", "0.0.0.0"), port=config.server.get("port", 6969))
+    uvicorn.run(
+        app,
+        host=config.server.get("host", "0.0.0.0"),
+        port=config.server.get("port", 6969),
+        backlog=128,
+    )
 
 
 def gui():

--- a/tinyagentos/health.py
+++ b/tinyagentos/health.py
@@ -35,6 +35,7 @@ class HealthMonitor:
         self._poll_count = 0
         self._last_cleanup = 0
         self._backend_states: dict[str, str] = {}
+        self._poll_budget_seconds: float | None = None  # set in tests
 
     async def start(self) -> None:
         self._task = asyncio.create_task(self._poll_loop())
@@ -49,9 +50,15 @@ class HealthMonitor:
 
     async def _poll_loop(self) -> None:
         interval = self.config.metrics.get("poll_interval", 30)
+        # Hard ceiling so a wedged backend or hung qmd probe can't lock the
+        # event loop. Each individual call already has its own timeout, but
+        # this is a defense-in-depth guard against #323-style wedges.
+        poll_budget = self._poll_budget_seconds or max(60, interval * 2)
         while True:
             try:
-                await self._poll_once()
+                await asyncio.wait_for(self._poll_once(), timeout=poll_budget)
+            except asyncio.TimeoutError:
+                logger.error(f"Health poll exceeded {poll_budget}s budget — aborting cycle")
             except Exception as e:
                 logger.error(f"Health poll error: {e}")
             await asyncio.sleep(interval)

--- a/tinyagentos/lifecycle_manager.py
+++ b/tinyagentos/lifecycle_manager.py
@@ -150,7 +150,7 @@ class LifecycleManager:
         """Return True if the service at url responds to /health with status ok."""
         import httpx
         try:
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(5.0, connect=3.0)) as client:
                 resp = await client.get(f"{url.rstrip('/')}/health", timeout=3)
                 if resp.status_code == 200:
                     data = resp.json()


### PR DESCRIPTION
## Summary
- Audit of every `httpx.AsyncClient(...)` and `aiohttp.ClientSession(...)` against the wedge described in #323. Every httpx call already had at least a constructor- or per-call-level timeout; the gaps were a bare `AsyncClient()` in `lifecycle_manager._probe_health` and an `aiohttp.ClientSession()` with no overall timeout in `agent_browsers._cdp_screenshot`.
- Wraps `HealthMonitor._poll_once` in `asyncio.wait_for` with a budget of `max(60s, 2 * poll_interval)` — defense in depth, since a single cycle calls many backend probes plus qmd plus metric writes back-to-back.
- Raises uvicorn `--backlog` to 128 (in both `__main__.main` and `app.main`) so the kernel accept queue can't silently grow into the thousands.

## Files
- `tinyagentos/health.py` — adds `_poll_budget_seconds` (None → derived) and wraps `_poll_once` in `asyncio.wait_for`. On `TimeoutError` logs `"Health poll exceeded {N}s budget — aborting cycle"` and continues.
- `tinyagentos/lifecycle_manager.py` — `httpx.AsyncClient(timeout=httpx.Timeout(5.0, connect=3.0))`.
- `tinyagentos/agent_browsers.py` — `aiohttp.ClientSession(timeout=ClientTimeout(total=10))`, `ws_connect(..., timeout=10)`.
- `tinyagentos/__main__.py`, `tinyagentos/app.py` — `uvicorn.run(..., backlog=128)`.
- `tests/test_health_poll_budget.py` — two new tests: budget kicks in when `_poll_once` hangs, and the loop continues after a timeout abort.

## What was *not* changed
- `download_manager.py:160` keeps `timeout=None` — by design for large file downloads, body iteration is the slow path.
- All other httpx callers already had constructor- or per-call-level timeouts. Per-request defaults inherited from `app.py`'s shared `httpx.AsyncClient(timeout=30)` cover the injected-client callers (KnowledgeIngest/Monitor, BackendFallback, agent_templates, github_releases).

## Test plan
- [x] `PYTHONPATH=. pytest tests/test_health_poll_budget.py -v` — 2/2 pass
- [x] `PYTHONPATH=. pytest tests/ -k 'health or lifecycle or agent_browsers' --ignore=tests/e2e` — 100/100 pass
- [ ] CI green
- [ ] Pi smoke after merge: confirm uvicorn binds with backlog=128 and health log line shows up after 3 days uptime