### PR TITLE
feat(store): green/amber/red compatibility borders on model cards

### DIFF
--- a/desktop/src/apps/StoreApp/compat-visuals.test.ts
+++ b/desktop/src/apps/StoreApp/compat-visuals.test.ts
@@ -1,0 +1,105 @@
+// desktop/src/apps/StoreApp/compat-visuals.test.ts
+import { describe, it, expect } from "vitest";
+import { compatVisuals } from "./compat-visuals";
+import type { ResolveResponse } from "./resolver-types";
+
+describe("compatVisuals", () => {
+  it("returns no border when undefined (resolver hasn't classified)", () => {
+    const v = compatVisuals(undefined);
+    expect(v.borderClass).toBe("");
+    expect(v.tooltip).toBe("");
+  });
+
+  it("green + ok 'use' → emerald border + accelerated tooltip", () => {
+    const resp: ResolveResponse = {
+      result: "ok",
+      backend_id: "rk-llama-cpp",
+      variant_id: "q4_k_m",
+      action: "use",
+      compat: "green",
+    };
+    const v = compatVisuals(resp);
+    expect(v.borderClass).toContain("border-l-emerald");
+    expect(v.tooltip).toMatch(/accelerated/i);
+  });
+
+  it("green + install_chain → emerald border + install-first tooltip", () => {
+    const resp: ResolveResponse = {
+      result: "ok",
+      backend_id: "rk-llama-cpp",
+      variant_id: "q4_k_m",
+      action: "install_chain",
+      compat: "green",
+    };
+    const v = compatVisuals(resp);
+    expect(v.borderClass).toContain("border-l-emerald");
+    expect(v.tooltip).toMatch(/installed/i);
+  });
+
+  it("amber on err → amber border + reason from near_miss.blocked_by", () => {
+    const resp: ResolveResponse = {
+      result: "err",
+      reason: "no compatible variant",
+      near_miss: { variant: "q8", blocked_by: "ram", short_by_mb: 2048 },
+      suggestions: ["q4_k_m"],
+      compat: "amber",
+    };
+    const v = compatVisuals(resp);
+    expect(v.borderClass).toContain("border-l-amber");
+    expect(v.tooltip).toMatch(/RAM/);
+    expect(v.tooltip).toContain("2048 MB");
+  });
+
+  it("amber on ok → amber border + CPU-only tooltip", () => {
+    const resp: ResolveResponse = {
+      result: "ok",
+      backend_id: "llama-cpp",
+      variant_id: "q4_k_m",
+      action: "use",
+      compat: "amber",
+    };
+    const v = compatVisuals(resp);
+    expect(v.borderClass).toContain("border-l-amber");
+    expect(v.tooltip).toMatch(/CPU/);
+  });
+
+  it("red on err → red border + 'Won't run' tooltip with reason", () => {
+    const resp: ResolveResponse = {
+      result: "err",
+      reason: "no variant fits",
+      near_miss: { variant: "q4_k_m", blocked_by: "vram", short_by_mb: 4096 },
+      suggestions: [],
+      compat: "red",
+    };
+    const v = compatVisuals(resp);
+    expect(v.borderClass).toContain("border-l-red");
+    expect(v.tooltip).toMatch(/Won't run/);
+    expect(v.tooltip).toMatch(/VRAM/);
+    expect(v.tooltip).toContain("4096 MB");
+  });
+
+  it("red without short_by_mb → tooltip omits MB suffix", () => {
+    const resp: ResolveResponse = {
+      result: "err",
+      reason: "no compatible target",
+      near_miss: { blocked_by: "target" },
+      suggestions: [],
+      compat: "red",
+    };
+    const v = compatVisuals(resp);
+    expect(v.tooltip).toMatch(/Won't run/);
+    expect(v.tooltip).not.toMatch(/MB/);
+  });
+
+  it("falls back to reason text when blocked_by is missing", () => {
+    const resp: ResolveResponse = {
+      result: "err",
+      reason: "totally unique failure",
+      near_miss: {},
+      suggestions: [],
+      compat: "red",
+    };
+    const v = compatVisuals(resp);
+    expect(v.tooltip).toContain("totally unique failure");
+  });
+});

--- a/desktop/src/apps/StoreApp/compat-visuals.ts
+++ b/desktop/src/apps/StoreApp/compat-visuals.ts
@@ -1,0 +1,71 @@
+// desktop/src/apps/StoreApp/compat-visuals.ts
+import type { ResolveResponse } from "./resolver-types";
+
+export interface CompatVisuals {
+  /** Tailwind classes to append to the Card. Empty string when unclassified. */
+  borderClass: string;
+  /** Tooltip text shown on hover — explains *why* this colour was chosen. */
+  tooltip: string;
+}
+
+const REASON_LABELS: Record<string, string> = {
+  ram: "Not enough RAM",
+  vram: "Not enough VRAM",
+  disk: "Not enough disk space",
+  target: "No matching hardware target",
+  schema: "Variant has no requires.backends declaration",
+};
+
+/**
+ * Map a /api/store/resolve response to a card-border treatment.
+ *
+ * - **green** — at least one variant runs accelerated on the user's cluster.
+ * - **amber** — the model fits but only on CPU, or the backend isn't
+ *   installed yet (action="install_chain").
+ * - **red** — the model exceeds RAM/VRAM/disk on every available device, or
+ *   no compatible hardware target exists.
+ * - **undefined** — resolver hasn't classified this manifest yet (or it's
+ *   not a model). No border treatment is applied.
+ */
+export function compatVisuals(resp: ResolveResponse | undefined): CompatVisuals {
+  if (!resp || !("compat" in resp)) return { borderClass: "", tooltip: "" };
+
+  if (resp.compat === "green") {
+    const action = resp.result === "ok" ? resp.action : null;
+    const tip = action === "install_chain"
+      ? "Compatible — backend will be installed first"
+      : "Compatible — runs accelerated on this cluster";
+    return { borderClass: "border-l-4 border-l-emerald-400/70", tooltip: tip };
+  }
+
+  if (resp.compat === "amber") {
+    if (resp.result === "err") {
+      const why = REASON_LABELS[resp.near_miss.blocked_by ?? ""] ?? resp.reason;
+      const shortBy = resp.near_miss.short_by_mb;
+      const detail = shortBy ? ` (short by ${shortBy} MB)` : "";
+      return {
+        borderClass: "border-l-4 border-l-amber-400/70",
+        tooltip: `Partial: ${why}${detail}`,
+      };
+    }
+    return {
+      borderClass: "border-l-4 border-l-amber-400/70",
+      tooltip: "Runs CPU-only on this cluster",
+    };
+  }
+
+  // red
+  if (resp.result === "err") {
+    const why = REASON_LABELS[resp.near_miss.blocked_by ?? ""] ?? resp.reason;
+    const shortBy = resp.near_miss.short_by_mb;
+    const detail = shortBy ? ` (short by ${shortBy} MB)` : "";
+    return {
+      borderClass: "border-l-4 border-l-red-400/70",
+      tooltip: `Won't run: ${why}${detail}`,
+    };
+  }
+  return {
+    borderClass: "border-l-4 border-l-red-400/70",
+    tooltip: "Won't run on this cluster",
+  };
+}

--- a/desktop/src/apps/StoreApp/filter.ts
+++ b/desktop/src/apps/StoreApp/filter.ts
@@ -1,6 +1,6 @@
 // desktop/src/apps/StoreApp/filter.ts
 import type { CatalogApp, InstallTarget } from "./types";
-import type { Compat } from "./resolver-types";
+import type { Compat, ResolveResponse } from "./resolver-types";
 
 export interface FilterResult {
   compatible: CatalogApp[];
@@ -63,11 +63,12 @@ export function filterModels(
  */
 export function compatFromResolver(
   manifestId: string,
-  compatMap: Map<string, Compat>,
+  compatMap: Map<string, Compat | ResolveResponse>,
   showIncompatible: boolean,
 ): boolean {
-  const c = compatMap.get(manifestId);
-  if (c === undefined) return true;
+  const entry = compatMap.get(manifestId);
+  if (entry === undefined) return true;
+  const c = typeof entry === "string" ? entry : entry.compat;
   if (c === "red") return showIncompatible;
   return true;
 }

--- a/desktop/src/apps/StoreApp/index.tsx
+++ b/desktop/src/apps/StoreApp/index.tsx
@@ -7,7 +7,8 @@ import { DevicePillBar } from "./DevicePillBar";
 import { BackendPillBar } from "./BackendPillBar";
 import { IncompatibleToggle } from "./IncompatibleToggle";
 import { filterModels, compatFromResolver } from "./filter";
-import { resolveModel, type Compat } from "./resolver-types";
+import { resolveModel, type ResolveResponse } from "./resolver-types";
+import { compatVisuals } from "./compat-visuals";
 import { loadFilter, saveFilter } from "./storage";
 
 /* ------------------------------------------------------------------ */
@@ -410,7 +411,7 @@ function resolveIconUrl(appId: string): string | null {
 /*  AppCard                                                            */
 /* ------------------------------------------------------------------ */
 
-function AppCard({ app, affected, onInstall, onUninstall, installTargets, runtimeHost, defaultTargetRemote }: {
+function AppCard({ app, affected, onInstall, onUninstall, installTargets, runtimeHost, defaultTargetRemote, resolveResponse }: {
   app: CatalogApp;
   affected: number;
   onInstall: (id: string) => void;
@@ -418,6 +419,7 @@ function AppCard({ app, affected, onInstall, onUninstall, installTargets, runtim
   installTargets: InstallTarget[];
   runtimeHost: string | null;
   defaultTargetRemote?: string;
+  resolveResponse?: ResolveResponse;
 }) {
   const [busy, setBusy] = useState(false);
   const [iconFailed, setIconFailed] = useState(false);
@@ -472,8 +474,13 @@ function AppCard({ app, affected, onInstall, onUninstall, installTargets, runtim
     setBusy(false);
   };
 
+  const visuals = compatVisuals(resolveResponse);
+
   return (
-    <Card className="flex flex-col rounded-2xl hover:-translate-y-0.5 hover:shadow-2xl hover:border-white/[0.12] transition-all duration-200">
+    <Card
+      className={`flex flex-col rounded-2xl hover:-translate-y-0.5 hover:shadow-2xl hover:border-white/[0.12] transition-all duration-200 ${visuals.borderClass}`}
+      title={visuals.tooltip || undefined}
+    >
       <CardHeader className="p-5 pb-2">
         <div className="flex items-start justify-between">
           <div className="flex items-center gap-3">
@@ -580,7 +587,7 @@ export function StoreApp({ windowId: _windowId }: { windowId: string }) {
   const [runtimeHosts, setRuntimeHosts] = useState<Record<string, string | null>>({});
   const [selectedDevices, setSelectedDevices] = useState<string[]>([]);
   const [selectedBackends, setSelectedBackends] = useState<string[]>([]);
-  const [compatMap, setCompatMap] = useState<Map<string, Compat>>(new Map());
+  const [compatMap, setCompatMap] = useState<Map<string, ResolveResponse>>(new Map());
   // User identity for per-user filter persistence. Use an "anon" fallback
   // so single-user setups still work; profile defaults to "default".
   const userId = (typeof window !== "undefined"
@@ -656,7 +663,7 @@ export function StoreApp({ windowId: _windowId }: { windowId: string }) {
     let cancelled = false;
 
     const run = async () => {
-      const next = new Map<string, Compat>();
+      const next = new Map<string, ResolveResponse>();
       for (let i = 0; i < modelIds.length; i += 8) {
         if (cancelled) return;
         const batch = modelIds.slice(i, i + 8);
@@ -666,7 +673,7 @@ export function StoreApp({ windowId: _windowId }: { windowId: string }) {
         results.forEach((r, idx) => {
           const id = batch[idx];
           if (id && r.status === "fulfilled" && r.value && "compat" in r.value) {
-            next.set(id, r.value.compat);
+            next.set(id, r.value);
           }
         });
         if (!cancelled) setCompatMap(new Map(next));
@@ -956,6 +963,7 @@ export function StoreApp({ windowId: _windowId }: { windowId: string }) {
                     defaultTargetRemote={
                       isModels && selectedDevices.length === 1 ? selectedDevices[0] : undefined
                     }
+                    resolveResponse={compatMap.get(app.id)}
                   />
                 );
               })}
@@ -976,6 +984,7 @@ export function StoreApp({ windowId: _windowId }: { windowId: string }) {
                     defaultTargetRemote={
                       isModels && selectedDevices.length === 1 ? selectedDevices[0] : undefined
                     }
+                    resolveResponse={compatMap.get(app.id)}
                   />
                 ))}
               </div>


### PR DESCRIPTION
## Summary

Surfaces the resolver's classification visually on every model card. Closes #331.

- **Green** — emerald left-edge accent, *\"Compatible — runs accelerated\"* tooltip (or *\"backend will be installed first\"* for `install_chain`).
- **Amber** — amber left-edge accent, *\"Partial: <reason>\"* (with `short_by_mb` if applicable) or *\"Runs CPU-only on this cluster\"* tooltip.
- **Red** — red left-edge accent, *\"Won't run: <reason>\"* tooltip pulled from `near_miss.blocked_by`.

Reasons are derived from the resolver's structured `near_miss` field (ram / vram / disk / target / schema), so users see exactly why a variant was rejected instead of a generic compat dot.

## Files
- New: \`desktop/src/apps/StoreApp/compat-visuals.ts\` — pure helper mapping ResolveResponse → \`{ borderClass, tooltip }\`.
- New: \`desktop/src/apps/StoreApp/compat-visuals.test.ts\` — 8 tests covering green/amber/red, install_chain branch, and missing-blocked_by fallback.
- Modified: \`desktop/src/apps/StoreApp/filter.ts\` — \`compatFromResolver\` accepts both \`Compat\` and \`ResolveResponse\` shapes for backwards compat.
- Modified: \`desktop/src/apps/StoreApp/index.tsx\` — \`compatMap\` now stores full \`ResolveResponse\`; \`AppCard\` accepts \`resolveResponse\` prop and applies border via \`compatVisuals\`.

## Test plan
- [x] \`cd desktop && npx vitest run src/apps/StoreApp/\` — 28/28 pass (8 new compat-visuals + existing filter + BackendPillBar)
- [x] \`cd desktop && npx tsc --noEmit\` — clean
- [x] \`cd desktop && npx vitest run\` — 817/817 pass
- [ ] CI green
- [ ] Manual: open Store on Pi, confirm rkllama models show green left-edge, x86-cuda models show red, etc.

## Out of scope
Filter behaviour is unchanged — borders are visual surface only, per the issue.