### PR TITLE
fix(chat): slash-command guardrail on WS path + release-actor attribution (#268)

### DIFF
--- a/tests/test_routes_chat_slash_guard.py
+++ b/tests/test_routes_chat_slash_guard.py
@@ -1,9 +1,18 @@
-"""Tests for the bare-slash guardrail in non-DM channels."""
+"""Tests for the bare-slash guardrail in non-DM channels.
+
+Covers both transports (HTTP and WS) — the safety must not be transport
+dependent. See #268.
+"""
+import asyncio
+import json
+
 import pytest
 import yaml
 
+from fastapi.testclient import TestClient
 from httpx import AsyncClient, ASGITransport
 from tinyagentos.app import create_app
+from tinyagentos.routes.chat import _validate_slash_target
 
 
 def _make_app(tmp_path):
@@ -125,3 +134,112 @@ async def test_non_slash_in_group_allowed(tmp_path):
                   "content_type": "text"},
         )
         assert r.status_code in (200, 201, 202)
+
+
+# ---------------------------------------------------------------------------
+# Pure-helper unit tests — guards the behavior independent of routing wiring.
+# ---------------------------------------------------------------------------
+
+
+class TestValidateSlashTargetHelper:
+    def test_non_slash_returns_none(self):
+        assert _validate_slash_target("hello", {"type": "group"}) is None
+
+    def test_no_channel_returns_none(self):
+        # Defensive: missing channel record cannot block delivery.
+        assert _validate_slash_target("/clear", None) is None
+
+    def test_dm_channel_allows_slash(self):
+        assert _validate_slash_target("/clear", {"type": "dm", "members": ["u", "v"]}) is None
+
+    def test_a2a_group_allows_slash(self):
+        ch = {"type": "group", "members": ["a"], "settings": {"kind": "a2a"}}
+        assert _validate_slash_target("/clear", ch) is None
+
+    def test_unaddressed_slash_in_group_returns_error(self):
+        ch = {"type": "group", "members": ["user", "tom"], "settings": {}}
+        msg = _validate_slash_target("/clear", ch)
+        assert msg is not None
+        assert "address an agent" in msg
+
+    def test_at_mention_allows_slash(self):
+        ch = {"type": "group", "members": ["user", "tom"], "settings": {}}
+        assert _validate_slash_target("@tom /help", ch) is None
+
+    def test_at_all_allows_slash(self):
+        ch = {"type": "group", "members": ["user", "tom"], "settings": {}}
+        assert _validate_slash_target("@all /help", ch) is None
+
+
+# ---------------------------------------------------------------------------
+# WS-path regression tests for #268 — guard must apply over the WebSocket too.
+# ---------------------------------------------------------------------------
+
+
+def _make_ws_app(tmp_path):
+    cfg = {
+        "server": {"host": "0.0.0.0", "port": 6969},
+        "backends": [],
+        "qmd": {"url": "http://localhost:7832"},
+        "agents": [],
+        "metrics": {"poll_interval": 30, "retention_days": 30},
+    }
+    (tmp_path / "config.yaml").write_text(yaml.dump(cfg))
+    (tmp_path / ".setup_complete").touch()
+    app = create_app(data_dir=tmp_path)
+    asyncio.run(app.state.chat_channels.init())
+    asyncio.run(app.state.chat_messages.init())
+    app.state.auth.setup_user("admin", "Test Admin", "", "testpass")
+    return app
+
+
+def test_ws_unaddressed_slash_in_group_returns_error_frame(tmp_path):
+    app = _make_ws_app(tmp_path)
+    ch = asyncio.run(app.state.chat_channels.create_channel(
+        name="g", type="group", description="", topic="",
+        members=["user", "tom", "don"], settings={}, created_by="user",
+    ))
+    ch_id = ch["id"] if isinstance(ch, dict) else ch
+
+    record = app.state.auth.find_user("admin")
+    token = app.state.auth.create_session(user_id=record["id"], long_lived=True)
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        client.cookies.set("taos_session", token)
+        with client.websocket_connect("/ws/chat") as ws:
+            ws.send_text(json.dumps({
+                "type": "message",
+                "channel_id": ch_id,
+                "content": "/clear",
+            }))
+            frame = json.loads(ws.receive_text())
+            assert frame["type"] == "error"
+            assert "address an agent" in frame["error"]
+
+
+def test_ws_addressed_slash_in_group_is_delivered(tmp_path):
+    """Sanity-check the happy WS path so the guard isn't blocking valid messages."""
+    app = _make_ws_app(tmp_path)
+    ch = asyncio.run(app.state.chat_channels.create_channel(
+        name="g", type="group", description="", topic="",
+        members=["user", "tom"], settings={}, created_by="user",
+    ))
+    ch_id = ch["id"] if isinstance(ch, dict) else ch
+
+    record = app.state.auth.find_user("admin")
+    token = app.state.auth.create_session(user_id=record["id"], long_lived=True)
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        client.cookies.set("taos_session", token)
+        with client.websocket_connect("/ws/chat") as ws:
+            ws.send_text(json.dumps({
+                "type": "join", "channel_id": ch_id,
+            }))
+            ws.send_text(json.dumps({
+                "type": "message",
+                "channel_id": ch_id,
+                "content": "@tom /help",
+            }))
+            # Expect a "message" broadcast frame, not an "error" one.
+            frame = json.loads(ws.receive_text())
+            assert frame["type"] != "error", f"Expected message frame, got {frame}"

--- a/tinyagentos/projects/beads_bridge.py
+++ b/tinyagentos/projects/beads_bridge.py
@@ -287,9 +287,14 @@ class BeadsBridge:
                     channel["id"], format_claimed(actor, tsk_id, title)
                 )
             elif kind == "task.released":
-                # The release event payload doesn't include releaser_id;
-                # use the actor we last knew about, or fall back to "agent".
-                actor = task.get("claimed_by") or "agent"
+                # release_task clears claimed_by before publishing the event,
+                # so prefer payload.releaser_id (the user/agent who released)
+                # over the now-NULL claimed_by column.
+                actor = (
+                    payload.get("releaser_id")
+                    or task.get("claimed_by")
+                    or "agent"
+                )
                 await self._post_system(
                     channel["id"], format_released(actor, tsk_id, title)
                 )

--- a/tinyagentos/projects/task_store.py
+++ b/tinyagentos/projects/task_store.py
@@ -219,7 +219,11 @@ class ProjectTaskStore(BaseStore):
         if changed:
             existing = await self.get_task(task_id)
             if existing is not None:
-                await self._publish(existing["project_id"], "task.released", {"id": task_id})
+                await self._publish(
+                    existing["project_id"],
+                    "task.released",
+                    {"id": task_id, "releaser_id": releaser_id},
+                )
         return changed
 
     async def close_task(

--- a/tinyagentos/routes/chat.py
+++ b/tinyagentos/routes/chat.py
@@ -16,6 +16,36 @@ from fastapi.responses import FileResponse, JSONResponse, Response
 from tinyagentos.chat.reactions import maybe_trigger_semantic
 
 router = APIRouter()
+
+
+_SLASH_GROUP_GUARD_ERROR = (
+    "slash commands in group channels must address an agent: "
+    "use @<agent> /<cmd> or @all /<cmd>"
+)
+
+
+def _validate_slash_target(content: str, channel: dict | None) -> str | None:
+    """Return an error message if a /cmd message is unaddressed in a non-DM,
+    non-A2A group channel; otherwise None.
+
+    Otherwise a framework slash command would broadcast to every agent in
+    the channel, producing N different /help outputs and (in some
+    frameworks) triggering destructive side effects like /clear on
+    unaddressed agents. Applies to HTTP /api/chat/messages and the
+    WS "message" branch — the safety must not be transport-dependent (#268).
+    """
+    if not content.lstrip().startswith("/"):
+        return None
+    if not channel or channel.get("type") == "dm":
+        return None
+    if ((channel.get("settings") or {}).get("kind")) == "a2a":
+        return None
+    from tinyagentos.chat.mentions import parse_mentions
+    members = list(channel.get("members") or [])
+    mentions = parse_mentions(content, members)
+    if mentions.explicit or mentions.all:
+        return None
+    return _SLASH_GROUP_GUARD_ERROR
 logger = logging.getLogger(__name__)
 
 _background_tasks: set[asyncio.Task] = set()
@@ -102,6 +132,14 @@ async def chat_ws(websocket: WebSocket):
                 msg_store = websocket.app.state.chat_messages
                 ch_store = websocket.app.state.chat_channels
                 _ws_channel = await ch_store.get_channel(data["channel_id"])
+                _ws_guard_err = _validate_slash_target(data.get("content", ""), _ws_channel)
+                if _ws_guard_err:
+                    await websocket.send_text(json.dumps({
+                        "type": "error",
+                        "channel_id": data["channel_id"],
+                        "error": _ws_guard_err,
+                    }))
+                    continue
                 _ws_ttl = None
                 if _ws_channel and _ws_channel.get("settings"):
                     _ws_ttl = _ws_channel["settings"].get("ephemeral_ttl_seconds")
@@ -256,24 +294,9 @@ async def post_message(request: Request):
             status_code=200,
         )
 
-    # Guardrail: in a non-DM channel, a / message must address at least one
-    # agent explicitly (@<slug> or @all). Otherwise a framework slash command
-    # would broadcast to every agent in the channel, producing N different
-    # /help outputs and (in some frameworks) triggering destructive side effects
-    # like /clear on unaddressed agents.
-    stripped = content.lstrip()
-    if stripped.startswith("/"):
-        channel = await ch_store.get_channel(channel_id)
-        _is_a2a = ((channel or {}).get("settings") or {}).get("kind") == "a2a"
-        if channel and channel.get("type") != "dm" and not _is_a2a:
-            from tinyagentos.chat.mentions import parse_mentions
-            members = list(channel.get("members") or [])
-            mentions = parse_mentions(content, members)
-            if not mentions.explicit and not mentions.all:
-                return JSONResponse(
-                    {"error": "slash commands in group channels must address an agent: use @<agent> /<cmd> or @all /<cmd>"},
-                    status_code=400,
-                )
+    err = _validate_slash_target(content, await ch_store.get_channel(channel_id))
+    if err:
+        return JSONResponse({"error": err}, status_code=400)
 
     attachments = (body or {}).get("attachments") or []
     if not isinstance(attachments, list):


### PR DESCRIPTION
## Summary
Two pre-existing inconsistencies surfaced in PR #267 review and tracked as #268.

1. The slash-command guardrail (rejects \`/cmd\` in non-DM, non-A2A group channels without an \`@<agent>\` or \`@all\` mention) ran only on the HTTP \`/api/chat/messages\` path. The WebSocket \`message\` branch in \`chat_ws\` accepted the same input — so the safety was transport-dependent. Extracted the validation into \`_validate_slash_target(content, channel)\` and applied it to both transports. The WS path sends back an \`{\"type\":\"error\",\"error\":...}\` frame and continues (matching the in-file pattern for non-fatal errors).

2. \`task.released\` event payload did not include \`releaser_id\`; \`release_task\` clears \`claimed_by\` before the event fires, so \`beads_bridge\` fell back to \`\"agent\"\` for the actor in the system message. Added \`releaser_id\` to the event payload and prefer it in the bridge.

## Files
- \`tinyagentos/routes/chat.py\` — new \`_validate_slash_target\` helper at module scope; wired into \`post_message\` (replaces inline block) and \`chat_ws\` \"message\" branch (sends error frame).
- \`tinyagentos/projects/task_store.py\` — \`release_task\` includes \`releaser_id\` in the published event payload.
- \`tinyagentos/projects/beads_bridge.py\` — release handler prefers \`payload.releaser_id\` over the now-NULL \`claimed_by\`.
- \`tests/test_routes_chat_slash_guard.py\` — 7 helper unit tests (DM allows, a2a allows, mention allows, etc.) + 2 WS integration tests (unaddressed → error frame; addressed → delivered).

## Test plan
- [x] \`PYTHONPATH=. pytest tests/test_routes_chat_slash_guard.py -v\` — 14/14 pass
- [x] \`PYTHONPATH=. pytest tests/ -k 'chat_slash or task_store or beads or chat_ws'\` — 121/121 pass
- [ ] CI green