### PR TITLE
fix(installer): broader RKNPU detection in install-server.sh

### DIFF
--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -258,13 +258,39 @@ detect_and_advise_accelerators() {
     fi
 
     # ── Rockchip RKNPU ──────────────────────────────────────────────
+    # Multi-signal detection: different RK3588 kernels expose the NPU at
+    # different paths. /dev/rknpu and /sys/class/devfreq/*.npu are the
+    # cleanest signals when present, but some kernel builds skip devfreq
+    # or expose only the debugfs entry, and on others the user-space
+    # device node is gated behind a module that isn't autoloaded. Fall
+    # back to the device-tree compatible string (the SoC's bootloader
+    # ID, always present on real RK35xx hardware) so we don't miss the
+    # NPU on those boards.  TAOS_FORCE_RKNPU=1 forces this branch on
+    # for testing or for kernels we don't yet recognise.
     local rknpu_present=0
-    if [[ -e /dev/rknpu ]]; then
+    local rknpu_signal=""
+    if [[ "${TAOS_FORCE_RKNPU:-}" == "1" || "${TAOS_FORCE_RKNPU:-}" == "true" ]]; then
         rknpu_present=1
+        rknpu_signal="TAOS_FORCE_RKNPU"
+    elif [[ -e /dev/rknpu ]]; then
+        rknpu_present=1
+        rknpu_signal="/dev/rknpu"
+    elif [[ -d /sys/kernel/debug/rknpu ]] || [[ -e /sys/kernel/debug/rknpu/load ]]; then
+        rknpu_present=1
+        rknpu_signal="/sys/kernel/debug/rknpu"
+    elif command -v lsmod >/dev/null 2>&1 && lsmod 2>/dev/null | awk '{print $1}' | grep -qx "rknpu"; then
+        rknpu_present=1
+        rknpu_signal="lsmod:rknpu"
+    elif [[ -r /proc/device-tree/compatible ]] && tr -d '\0' < /proc/device-tree/compatible 2>/dev/null | grep -qE "rockchip,rk(3588|3576|3568)"; then
+        rknpu_present=1
+        rknpu_signal="device-tree:rockchip-rk3xxx"
     else
         for _npu_devfreq in /sys/class/devfreq/*.npu; do
-            [[ -d "$_npu_devfreq" ]] && { rknpu_present=1; break; }
+            [[ -d "$_npu_devfreq" ]] && { rknpu_present=1; rknpu_signal="$_npu_devfreq"; break; }
         done
+    fi
+    if (( rknpu_present )); then
+        log "rknpu: detected via $rknpu_signal"
     fi
     if (( rknpu_present )); then
         found_any=1


### PR DESCRIPTION
## Summary

@redkjuegos reported in #2 that the RK3588 auto-install path didn't fire on first run — log ended at \`creating venv\` (the taOS venv, not rkllama). Original detection only checked \`/dev/rknpu\` and \`/sys/class/devfreq/*.npu\`. Both can be absent on real RK3588 boards where the kernel module is loaded but neither node gets exposed.

Adds four more detection signals tried in order:

1. \`/dev/rknpu\` (cleanest when present)
2. \`/sys/kernel/debug/rknpu/\` (debugfs entry, present whenever the \`rknpu\` module is loaded with \`CONFIG_DEBUG_FS\`)
3. \`lsmod | grep ^rknpu$\` (module loaded, no debugfs needed)
4. \`/proc/device-tree/compatible\` matching \`rockchip,rk(3588|3576|3568)\` — bootloader hardware ID, present even before the module loads
5. \`/sys/class/devfreq/*.npu\` (existing fallback)

\`TAOS_FORCE_RKNPU=1\` forces the path on for kernels we don't yet recognise. Logs the matching signal so users can tell which check fired.

## Test plan
- [x] \`bash -n scripts/install-server.sh\` — syntax clean
- [ ] CI green
- [ ] Real Pi: \`sudo bash scripts/install-server.sh\` shows \`rknpu: detected via …\` line; rkllama install chains correctly