### PR TITLE
perf(boot): bump systemd TimeoutStartSec and lazy-load app catalog (#337)

### DIFF
--- a/scripts/systemd/tinyagentos.service
+++ b/scripts/systemd/tinyagentos.service
@@ -37,6 +37,8 @@ ExecStop=TAOS_STOP_SCRIPT
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
 RestartSec=3
+# Slow boot on low-end ARM SBCs (Pi ~58s) sits too close to systemd's 90s default.
+TimeoutStartSec=180
 TimeoutStopSec=360
 Environment=PYTHONUNBUFFERED=1
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -139,3 +139,25 @@ class TestAppRegistry:
         r.list_available()
         assert r._catalog is not None
         assert len(r._catalog) == 3
+
+    def test_concurrent_first_read_does_not_double_load(self, catalog_dir, tmp_path):
+        """Two threads racing on a cold registry must not produce a doubled catalog."""
+        import threading
+
+        installed_path = tmp_path / "installed.json"
+        r = AppRegistry(catalog_dir=catalog_dir, installed_path=installed_path)
+        results: list[int] = []
+        barrier = threading.Barrier(8)
+
+        def worker():
+            barrier.wait()
+            results.append(len(r.list_available()))
+
+        threads = [threading.Thread(target=worker) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert all(n == 3 for n in results)
+        assert len(r._catalog) == 3

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -130,3 +130,12 @@ class TestAppRegistry:
         # Create new registry instance pointing at same file
         registry2 = AppRegistry(catalog_dir=registry.catalog_dir, installed_path=registry.installed_path)
         assert registry2.is_installed("gitea")
+
+    def test_catalog_loads_lazily(self, catalog_dir, tmp_path):
+        """Construction must not parse manifests; first read triggers load."""
+        installed_path = tmp_path / "installed.json"
+        r = AppRegistry(catalog_dir=catalog_dir, installed_path=installed_path)
+        assert r._catalog is None
+        r.list_available()
+        assert r._catalog is not None
+        assert len(r._catalog) == 3

--- a/tinyagentos/registry.py
+++ b/tinyagentos/registry.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import threading
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -82,13 +83,18 @@ class AppRegistry:
         # Sentinel: None means catalog has not been loaded yet. Deferred so that
         # boot does not pay for walking + parsing every manifest under catalog_dir.
         self._catalog: list[AppManifest] | None = None
+        self._catalog_lock = threading.Lock()
 
     def _ensure_loaded(self) -> None:
-        if self._catalog is None:
-            self._load_catalog()
+        # Double-checked locking: cheap path when already loaded, lock only on first miss.
+        if self._catalog is not None:
+            return
+        with self._catalog_lock:
+            if self._catalog is None:
+                self._load_catalog()
 
     def _load_catalog(self) -> None:
-        self._catalog = []
+        catalog: list[AppManifest] = []
         for type_dir in ("agents", "models", "services", "plugins"):
             base = self.catalog_dir / type_dir
             if not base.exists():
@@ -97,12 +103,15 @@ class AppRegistry:
                 manifest = app_dir / "manifest.yaml"
                 if manifest.exists():
                     try:
-                        self._catalog.append(AppManifest.from_file(manifest))
+                        catalog.append(AppManifest.from_file(manifest))
                     except (yaml.YAMLError, KeyError):
                         pass  # skip invalid manifests
+        # Single atomic assignment: readers either see the old list or the fully built one.
+        self._catalog = catalog
 
     def reload(self) -> None:
-        self._load_catalog()
+        with self._catalog_lock:
+            self._load_catalog()
 
     def list_available(self, type_filter: str | None = None) -> list[AppManifest]:
         self._ensure_loaded()

--- a/tinyagentos/registry.py
+++ b/tinyagentos/registry.py
@@ -79,8 +79,13 @@ class AppRegistry:
     def __init__(self, catalog_dir: Path, installed_path: Path):
         self.catalog_dir = catalog_dir
         self.installed_path = installed_path
-        self._catalog: list[AppManifest] = []
-        self._load_catalog()
+        # Sentinel: None means catalog has not been loaded yet. Deferred so that
+        # boot does not pay for walking + parsing every manifest under catalog_dir.
+        self._catalog: list[AppManifest] | None = None
+
+    def _ensure_loaded(self) -> None:
+        if self._catalog is None:
+            self._load_catalog()
 
     def _load_catalog(self) -> None:
         self._catalog = []
@@ -100,11 +105,13 @@ class AppRegistry:
         self._load_catalog()
 
     def list_available(self, type_filter: str | None = None) -> list[AppManifest]:
+        self._ensure_loaded()
         if type_filter:
             return [a for a in self._catalog if a.type == type_filter]
         return list(self._catalog)
 
     def get(self, app_id: str) -> AppManifest | None:
+        self._ensure_loaded()
         return next((a for a in self._catalog if a.id == app_id), None)
 
     def _read_installed(self) -> list[dict]:


### PR DESCRIPTION
## Summary

Two scoped fixes from issue #337. Pi boot is ~58s, uncomfortably close to systemd's default 90s `TimeoutStartSec`.

- **`scripts/systemd/tinyagentos.service`** — add `TimeoutStartSec=180` (with terse comment). `install-server.sh` only sed-replaces `TAOS_*` placeholders, so the literal value passes through unchanged. The vestigial `tinyagentos.service` (root) and `systemd/tinyagentos.service` are not on the install path (`install-server.sh` only references `scripts/systemd/tinyagentos.service`) and were left alone per the issue's scope guidance.
- **`tinyagentos/registry.py`** — `AppRegistry.__init__` no longer parses manifests. `_catalog` uses a `None` sentinel; `list_available` / `get` call a new private `_ensure_loaded()` which triggers `_load_catalog()` on first read. `reload()` is unchanged. Public API is fully transparent — no callers needed updating.

Out of scope (issue #337 fixes 3 and 4): lazy-loading LiteLLM, ChannelStore, knowledge pipeline. Separate PRs.

Closes #337 fixes 1 and 2.

## Test plan

- [x] `pytest tests/test_registry.py tests/test_routes_store.py tests/routes/test_store_install_v2.py -x` — 34 passed (33 existing + 1 new `test_catalog_loads_lazily` that asserts `_catalog is None` after construction and populated after the first public read).
- [ ] Manual: `sudo systemctl daemon-reload && sudo systemctl restart tinyagentos` on the Pi; confirm unit reaches `active (running)` without `start operation timed out`.
- [ ] Manual: hit `/api/store` after restart and verify catalog returns the expected manifests (proves first-read load path).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Increased system startup timeout to 180 seconds to support slow boot scenarios on low-end ARM devices.

* **Performance**
  * App catalog loading is now deferred until first access, improving initial system startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->