### PR TITLE
fix(store): /api/store/resolve 500 from registry.get_app typo

### DIFF
--- a/tests/routes/test_store_resolve.py
+++ b/tests/routes/test_store_resolve.py
@@ -28,7 +28,7 @@ def make_qwen_manifest():
 @pytest.fixture
 def fake_registry():
     reg = MagicMock()
-    reg.get_app = MagicMock(return_value=make_qwen_manifest())
+    reg.get = MagicMock(return_value=make_qwen_manifest())
     return reg
 
 

--- a/tests/test_routes_store.py
+++ b/tests/test_routes_store.py
@@ -97,6 +97,23 @@ class TestStoreAPI:
         assert "ram_mb" in data
         assert data["ram_mb"] >= 0
 
+    async def test_resolve_returns_200_not_500(self, store_client):
+        """Regression: registry.get_app -> registry.get typo caused 500 on every resolve."""
+        resp = await store_client.post(
+            "/api/store/resolve", json={"app_id": "test-model"}
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "result" in data
+        assert data["result"] in ("ok", "err")
+        assert "compat" in data
+
+    async def test_resolve_unknown_manifest_returns_404(self, store_client):
+        resp = await store_client.post(
+            "/api/store/resolve", json={"app_id": "does-not-exist"}
+        )
+        assert resp.status_code == 404
+
 
 @pytest.mark.asyncio
 class TestCategoryPassthrough:

--- a/tinyagentos/routes/store.py
+++ b/tinyagentos/routes/store.py
@@ -201,7 +201,7 @@ async def resolve_model(request: Request):
     force = bool(body.get("force", False))
 
     registry = request.app.state.registry
-    manifest = registry.get_app(manifest_id) if registry else None
+    manifest = registry.get(manifest_id) if registry else None
     if manifest is None:
         return JSONResponse({"error": f"manifest {manifest_id!r} not found"}, status_code=404)
 

--- a/tinyagentos/routes/store_install.py
+++ b/tinyagentos/routes/store_install.py
@@ -156,12 +156,8 @@ def _get_current_user(request: Request) -> dict | None:
 
 
 def _registry_get(registry, app_id: str):
-    """Look up a manifest by ID using whichever method the registry exposes."""
-    if hasattr(registry, "get_app"):
-        return registry.get_app(app_id)
-    if hasattr(registry, "get"):
-        return registry.get(app_id)
-    return None
+    """Look up a manifest by ID."""
+    return registry.get(app_id)
 
 
 async def _legacy_install(request: Request, body: dict, app_id: str | None, target_remote: str | None) -> JSONResponse:


### PR DESCRIPTION
Fixes #2 — reported by @redkjuegos.

## Problem

Every `POST /api/store/resolve` returned 500:

```
AttributeError: 'AppRegistry' object has no attribute 'get_app'
```

`AppRegistry` exposes `.get(app_id)` but two callsites were calling the non-existent `.get_app(...)`. This made every Store interaction that hits the resolve endpoint blow up — master-blocking.

## Fix

- `routes/store.py:204` — `registry.get_app(manifest_id)` → `registry.get(manifest_id)`
- `routes/store_install.py:158-164` — collapsed `_registry_get` helper: removed the dead `hasattr("get_app")` branch (always-false), now calls `registry.get(app_id)` directly

No alias added to `AppRegistry` — fixed at the callsites.

## Regression test

Added `test_resolve_returns_200_not_500` and `test_resolve_unknown_manifest_returns_404` to `tests/test_routes_store.py`. These exercise the happy path and 404 path of `POST /api/store/resolve` end-to-end so this class of typo is caught going forward. All 30 store + registry tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression tests for the `/api/store/resolve` endpoint to verify correct handling of valid manifest IDs (returning HTTP 200) and invalid manifest IDs (returning HTTP 404).

* **Refactor**
  * Standardized manifest retrieval mechanism across store operations for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->