### PR TITLE
fix(cluster): install-targets dedupe + canonical RAM bucket + unknown-hardware UX

### DIFF
--- a/desktop/src/apps/StoreApp/DevicePillBar.tsx
+++ b/desktop/src/apps/StoreApp/DevicePillBar.tsx
@@ -3,6 +3,31 @@ import { useMemo } from "react";
 import { X } from "lucide-react";
 import type { InstallTarget } from "./types";
 
+/** Banner rendered above the catalog when one or more selected devices have unknown hardware. */
+export function UnknownHardwareBanner({ devices }: { devices: InstallTarget[] }) {
+  const unknownNames = devices
+    .filter((d) => d.hardware_known === false)
+    .map((d) => d.friendly_name ?? d.label);
+  if (unknownNames.length === 0) return null;
+  const names = unknownNames.join(", ");
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex items-center gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-300 mb-2"
+    >
+      <span aria-hidden="true">?</span>
+      <span>
+        Selected {unknownNames.length === 1 ? "device" : "devices"}{" "}
+        <strong>{names}</strong>{" "}
+        {unknownNames.length === 1 ? "has" : "have"} unknown hardware — register{" "}
+        {unknownNames.length === 1 ? "it" : "them"} via the Cluster app to filter
+        accurately. Showing all models for now.
+      </span>
+    </div>
+  );
+}
+
 interface Props {
   devices: InstallTarget[];
   selected: string[]; // device names
@@ -52,12 +77,19 @@ export function DevicePillBar({
     >
       {devices.map((d) => {
         const isOn = selectedSet.has(d.name);
-        const tierBadge = d.tier_id?.replace(/^arm-|^x86-|^apple-/, "") ?? "";
+        const hardwareUnknown = d.hardware_known === false;
+        const tierBadge = hardwareUnknown
+          ? "?"
+          : (d.tier_id?.replace(/^arm-|^x86-|^apple-/, "") ?? "");
+        const tooltip = hardwareUnknown
+          ? "Hardware unknown — register this worker via the Cluster app to see compatibility"
+          : undefined;
         return (
           <button
             key={d.name}
             type="button"
             aria-pressed={isOn}
+            title={tooltip}
             onClick={() => toggle(d.name)}
             className={`shrink-0 inline-flex items-center gap-1.5 px-3 py-1 rounded-full border text-xs whitespace-nowrap transition-colors ${
               isOn
@@ -67,7 +99,10 @@ export function DevicePillBar({
           >
             <span>{d.friendly_name ?? d.label}</span>
             {tierBadge && (
-              <span className="text-[10px] opacity-70 uppercase tracking-wide">
+              <span
+                className={`text-[10px] uppercase tracking-wide ${hardwareUnknown ? "opacity-50" : "opacity-70"}`}
+                aria-label={hardwareUnknown ? "hardware unknown" : undefined}
+              >
                 {tierBadge}
               </span>
             )}

--- a/desktop/src/apps/StoreApp/filter.test.ts
+++ b/desktop/src/apps/StoreApp/filter.test.ts
@@ -215,7 +215,7 @@ describe("unknown-hardware device filter", () => {
     expect(hasUnknownHardwareDevice([piDevice, unknownDevice])).toBe(true);
   });
 
-  it("hasUnknownHardwareDevice returns true when hardware_known is absent (legacy)", () => {
+  it("hasUnknownHardwareDevice returns false when hardware_known is absent (legacy)", () => {
     const noField: InstallTarget = { name: "x", label: "x", type: "remote" };
     expect(hasUnknownHardwareDevice([noField])).toBe(false);
   });

--- a/desktop/src/apps/StoreApp/filter.test.ts
+++ b/desktop/src/apps/StoreApp/filter.test.ts
@@ -1,6 +1,6 @@
 // desktop/src/apps/StoreApp/filter.test.ts
 import { describe, it, expect } from "vitest";
-import { filterModels, compatFromResolver } from "./filter";
+import { filterModels, compatFromResolver, hasUnknownHardwareDevice } from "./filter";
 import type { CatalogApp, InstallTarget } from "./types";
 
 const piDevice: InstallTarget = {
@@ -195,6 +195,54 @@ describe("filterModels", () => {
     // device has no tier_id → contributes nothing to the tier set;
     // selectedDevices is non-empty so deviceOk=false except for universal
     expect(compatible.map((a) => a.id)).toEqual(["small-tool"]);
+  });
+});
+
+describe("unknown-hardware device filter", () => {
+  const unknownDevice: InstallTarget = {
+    name: "fedora-worker",
+    label: "fedora-worker",
+    type: "remote",
+    tier_id: "unknown",
+    hardware_known: false,
+  };
+
+  it("hasUnknownHardwareDevice returns false when all devices have known hardware", () => {
+    expect(hasUnknownHardwareDevice([piDevice, macDevice])).toBe(false);
+  });
+
+  it("hasUnknownHardwareDevice returns true when any device has hardware_known=false", () => {
+    expect(hasUnknownHardwareDevice([piDevice, unknownDevice])).toBe(true);
+  });
+
+  it("hasUnknownHardwareDevice returns true when hardware_known is absent (legacy)", () => {
+    const noField: InstallTarget = { name: "x", label: "x", type: "remote" };
+    expect(hasUnknownHardwareDevice([noField])).toBe(false);
+  });
+
+  it("unknown-only selection shows all apps (filter treated as inactive)", () => {
+    // When every selected device has unknown hardware, knownDevices is empty
+    // → requireDeviceMatch is false → all apps pass device filter.
+    const { compatible } = filterModels(allApps, [unknownDevice], []);
+    expect(compatible).toEqual(allApps);
+  });
+
+  it("mixed known+unknown selection: unknown device doesn't narrow, known device does", () => {
+    // Pi + fedora-worker(unknown): only Pi tier matters; unknown adds nothing.
+    const { compatible } = filterModels(allApps, [piDevice, unknownDevice], []);
+    const ids = compatible.map((a) => a.id);
+    expect(ids).toContain("qwen3-4b-rk");   // matches Pi
+    expect(ids).toContain("small-tool");     // universal
+    // ollama model has no arm-npu-16gb tier so it won't match; but it would
+    // match if the unknown device contributed a tier — confirm it doesn't.
+    expect(ids).not.toContain("qwen3-4b-ollama");
+  });
+
+  it("unknown device does not cause empty catalog when it is the only selection", () => {
+    // The key regression: selecting an unknown-hardware device must NOT empty the Store.
+    const { compatible, incompatible } = filterModels(allApps, [unknownDevice], []);
+    expect(compatible.length).toBeGreaterThan(0);
+    expect(incompatible).toEqual([]);
   });
 });
 

--- a/desktop/src/apps/StoreApp/filter.ts
+++ b/desktop/src/apps/StoreApp/filter.ts
@@ -25,15 +25,30 @@ export interface FilterResult {
  * the backend filter only when no device filter is active; universal
  * device compatibility already includes them in that case.
  */
+/**
+ * Returns true if at least one of the selected devices has hardware_known === false.
+ * Used by callers to decide whether to show the "unknown hardware" banner.
+ */
+export function hasUnknownHardwareDevice(selectedDevices: InstallTarget[]): boolean {
+  return selectedDevices.some((d) => d.hardware_known === false);
+}
+
 export function filterModels(
   apps: CatalogApp[],
   selectedDevices: InstallTarget[],
   selectedBackends: string[],
 ): FilterResult {
+  // Devices with unknown hardware don't contribute a tier to the filter —
+  // they would match nothing and silently empty the catalog. Treat the device
+  // axis as inactive for those devices specifically: only known-hardware
+  // devices participate in tier matching.
+  const knownDevices = selectedDevices.filter((d) => d.hardware_known !== false);
   const tiers = new Set(
-    selectedDevices.map((d) => d.tier_id).filter((t): t is string => Boolean(t))
+    knownDevices.map((d) => d.tier_id).filter((t): t is string => Boolean(t))
   );
-  const requireDeviceMatch = selectedDevices.length > 0;
+  // If ALL selected devices have unknown hardware, treat the device filter as
+  // inactive (show everything) so the user doesn't get an empty catalog.
+  const requireDeviceMatch = selectedDevices.length > 0 && knownDevices.length > 0;
   const backends = new Set(selectedBackends);
 
   const compatible: CatalogApp[] = [];

--- a/desktop/src/apps/StoreApp/index.tsx
+++ b/desktop/src/apps/StoreApp/index.tsx
@@ -3,10 +3,10 @@ import { ShoppingBag, Search, Download, Trash2, Check, Package, Loader2, Bot, Br
 import { Button, Card, CardContent, CardFooter, CardHeader, Input } from "@/components/ui";
 import { fetchLatestFrameworks, LatestVersion } from "@/lib/framework-api";
 import type { CatalogApp, InstallTarget, InstalledEntry } from "./types";
-import { DevicePillBar } from "./DevicePillBar";
+import { DevicePillBar, UnknownHardwareBanner } from "./DevicePillBar";
 import { BackendPillBar } from "./BackendPillBar";
 import { IncompatibleToggle } from "./IncompatibleToggle";
-import { filterModels, compatFromResolver } from "./filter";
+import { filterModels, compatFromResolver, hasUnknownHardwareDevice } from "./filter";
 import { resolveModel, type ResolveResponse } from "./resolver-types";
 import { compatVisuals } from "./compat-visuals";
 import { loadFilter, saveFilter } from "./storage";
@@ -917,6 +917,9 @@ export function StoreApp({ windowId: _windowId }: { windowId: string }) {
                 onChange={setSelectedDevices}
                 showSkeleton={installTargets.length === 0 && loading}
               />
+              {hasUnknownHardwareDevice(selectedDeviceObjs) && (
+                <UnknownHardwareBanner devices={selectedDeviceObjs} />
+              )}
               <BackendPillBar
                 available={availableBackends}
                 selected={selectedBackends}

--- a/desktop/src/apps/StoreApp/types.ts
+++ b/desktop/src/apps/StoreApp/types.ts
@@ -26,6 +26,12 @@ export interface InstallTarget {
   tier_id?: string;
   /** Display name for pill bars. Defaults to `label` when absent. */
   friendly_name?: string;
+  /**
+   * False when the remote is an incus remote not yet registered as a taOS
+   * cluster worker. When false, tier_id is "unknown" and the filter should
+   * treat this device as if no device filter is active (show all).
+   */
+  hardware_known?: boolean;
 }
 
 export interface InstalledEntry {

--- a/tests/cluster/test_worker_tier_id.py
+++ b/tests/cluster/test_worker_tier_id.py
@@ -1,0 +1,87 @@
+"""Tests for worker_tier_id RAM-bucket snapping.
+
+Catalog manifests only declare canonical RAM sizes (2/4/8/16/32/64/128 GB).
+Devices report slightly lower values after kernel reservation (e.g. 15 GB on a
+16 GB Pi), so tier_id must snap UP to the next bucket.
+"""
+import pytest
+
+from tinyagentos.cluster.capabilities import worker_tier_id, _snap_to_bucket
+
+
+class TestSnapToBucket:
+    def test_exact_bucket_unchanged(self):
+        assert _snap_to_bucket(16) == 16
+
+    def test_4gb_exact(self):
+        assert _snap_to_bucket(4) == 4
+
+    def test_7gb_snaps_to_8(self):
+        assert _snap_to_bucket(7) == 8
+
+    def test_15gb_snaps_to_16(self):
+        assert _snap_to_bucket(15) == 16
+
+    def test_17gb_snaps_to_32(self):
+        assert _snap_to_bucket(17) == 32
+
+    def test_33gb_snaps_to_64(self):
+        assert _snap_to_bucket(33) == 64
+
+    def test_200gb_clamps_to_128(self):
+        assert _snap_to_bucket(200) == 128
+
+    def test_zero_clamps_to_2(self):
+        # raw_gb = max(1, 0) = 1 → first bucket ≥ 1 is 2
+        assert _snap_to_bucket(0) == 2
+
+    def test_1gb_snaps_to_2(self):
+        assert _snap_to_bucket(1) == 2
+
+
+class TestWorkerTierIdPiBucket:
+    """Verify that a 15 958 MB Pi (16 GB after kernel reservation) maps to
+    arm-npu-16gb, not arm-npu-15gb."""
+
+    def test_pi_npu_15gb_raw_returns_16gb_tier(self):
+        hw = {
+            "cpu": {"arch": "aarch64"},
+            "npu": {"type": "rknpu", "tops": 6, "cores": 3},
+            "ram_mb": 15000,
+        }
+        tier = worker_tier_id(hw)
+        assert tier.endswith("-16gb"), f"expected -16gb suffix, got {tier!r}"
+        assert tier == "arm-npu-16gb"
+
+    def test_pi_npu_exact_16gb_returns_16gb_tier(self):
+        hw = {
+            "cpu": {"arch": "aarch64"},
+            "npu": {"type": "rk3588"},
+            "ram_mb": 16384,
+        }
+        assert worker_tier_id(hw) == "arm-npu-16gb"
+
+    def test_pi_cpu_only_15gb_raw_returns_16gb_tier(self):
+        hw = {
+            "cpu": {"arch": "aarch64"},
+            "ram_mb": 15000,
+        }
+        assert worker_tier_id(hw) == "arm-cpu-16gb"
+
+    def test_cuda_12gb_vram_exact_stays_12(self):
+        # 12 GB is not a canonical bucket — snaps up to 16
+        hw = {
+            "cpu": {"arch": "x86_64"},
+            "gpu": {"type": "nvidia", "cuda": True, "vram_mb": 12288},
+            "ram_mb": 32768,
+        }
+        tier = worker_tier_id(hw)
+        assert tier == "x86-cuda-16gb"
+
+    def test_cuda_8gb_vram_exact_stays_8(self):
+        hw = {
+            "cpu": {"arch": "x86_64"},
+            "gpu": {"type": "nvidia", "cuda": True, "vram_mb": 8192},
+            "ram_mb": 32768,
+        }
+        assert worker_tier_id(hw) == "x86-cuda-8gb"

--- a/tests/cluster/test_worker_tier_id.py
+++ b/tests/cluster/test_worker_tier_id.py
@@ -68,7 +68,7 @@ class TestWorkerTierIdPiBucket:
         }
         assert worker_tier_id(hw) == "arm-cpu-16gb"
 
-    def test_cuda_12gb_vram_exact_stays_12(self):
+    def test_cuda_12gb_vram_snaps_to_16(self):
         # 12 GB is not a canonical bucket — snaps up to 16
         hw = {
             "cpu": {"arch": "x86_64"},

--- a/tinyagentos/cluster/capabilities.py
+++ b/tinyagentos/cluster/capabilities.py
@@ -16,6 +16,24 @@ if TYPE_CHECKING:
     from tinyagentos.registry import AppRegistry
 
 
+_RAM_BUCKETS_GB = (2, 4, 8, 16, 32, 64, 128)
+
+
+def _snap_to_bucket(raw_gb: int) -> int:
+    """Snap raw GB up to the nearest canonical bucket used by catalog manifests.
+
+    Catalog manifests only list canonical sizes (4gb / 8gb / 16gb / ...);
+    if a device reports a value between buckets (e.g. 15GB on a 16GB Pi after
+    kernel reservation), snap up so the tier_id matches the bucket the
+    device IS, not the slightly-smaller value it self-reports.
+    """
+    raw_gb = max(1, raw_gb)
+    for bucket in _RAM_BUCKETS_GB:
+        if raw_gb <= bucket:
+            return bucket
+    return _RAM_BUCKETS_GB[-1]
+
+
 def worker_tier_id(hardware: dict) -> str:
     """Derive a catalog-compatible tier id from a worker's hardware dict.
 
@@ -50,19 +68,19 @@ def worker_tier_id(hardware: dict) -> str:
     if npu_type != "none":
         accel = "npu"
         # NPU tiers use RAM gb
-        gb = max(1, ram_mb // 1024)
+        gb = _snap_to_bucket(ram_mb // 1024)
         return f"{arch}-{accel}-{gb}gb"
 
     if gpu_type == "nvidia" and gpu.get("cuda"):
         accel = "cuda"
         vram_mb = gpu.get("vram_mb", 0) or 0
-        gb = max(1, vram_mb // 1024) if vram_mb else max(1, ram_mb // 1024)
+        gb = _snap_to_bucket(vram_mb // 1024) if vram_mb else _snap_to_bucket(ram_mb // 1024)
         return f"{arch}-{accel}-{gb}gb"
 
     if gpu_type == "amd" and gpu.get("rocm"):
         accel = "rocm"
         vram_mb = gpu.get("vram_mb", 0) or 0
-        gb = max(1, vram_mb // 1024) if vram_mb else max(1, ram_mb // 1024)
+        gb = _snap_to_bucket(vram_mb // 1024) if vram_mb else _snap_to_bucket(ram_mb // 1024)
         return f"{arch}-{accel}-{gb}gb"
 
     if gpu_type == "apple":
@@ -72,14 +90,20 @@ def worker_tier_id(hardware: dict) -> str:
     if gpu.get("vulkan"):
         accel = "vulkan"
         vram_mb = gpu.get("vram_mb", 0) or 0
-        gb = max(1, vram_mb // 1024) if vram_mb else max(1, ram_mb // 1024)
+        gb = _snap_to_bucket(vram_mb // 1024) if vram_mb else _snap_to_bucket(ram_mb // 1024)
         return f"{arch}-{accel}-{gb}gb"
 
     # CPU-only fallback
-    gb = max(1, ram_mb // 1024)
+    gb = _snap_to_bucket(ram_mb // 1024)
     return f"{arch}-cpu-{gb}gb"
 
 
+# TODO(rockchip-target): The controller's hardware_to_targets sometimes returns
+# only ["cpu"] instead of ["rockchip", "cpu"] on Orange Pi 5+ production.
+# Root cause: the worker hardware dict for the *controller* is sourced from
+# HardwareProfile.hardware, which may report npu.type as something other than
+# "rk3588" or "rknpu" in older agent versions or when the NPU driver hasn't
+# initialised. Fix tracked separately — do not conflate with this PR.
 def hardware_to_targets(hardware: dict) -> list[str]:
     """Derive the resolver's catalog-targets list from a worker hardware dict.
 

--- a/tinyagentos/routes/cluster.py
+++ b/tinyagentos/routes/cluster.py
@@ -295,17 +295,25 @@ async def list_install_targets(request: Request):
             proto = r.get("protocol", "")
             if not name or name in _BUILTIN_REMOTES or proto != "incus":
                 continue
+            addr = r.get("addr", "")
+            if addr.startswith("unix://"):
+                # Local incus daemon — already added as the "local" controller
+                # entry above. Incus exposes this as "local (current)" when it
+                # is the active context, which isn't in _BUILTIN_REMOTES.
+                continue
             worker_hw = next(
                 (w.hardware for w in cluster.get_workers() if w.name == name),
                 {},
             ) if cluster else {}
+            hardware_known = bool(worker_hw) or bool(worker_tiers.get(name))
             targets.append({
                 "name": name,
                 "label": name,
                 "type": "remote",
                 "addr": r.get("addr", ""),
-                "tier_id": worker_tiers.get(name, ""),
+                "tier_id": worker_tiers.get(name) or ("unknown" if not hardware_known else ""),
                 "targets": hardware_to_targets(worker_hw),
+                "hardware_known": hardware_known,
                 "friendly_name": name,
             })
     except Exception as exc:  # noqa: BLE001


### PR DESCRIPTION
## What this fixes

Three bugs surfaced by the live `/api/cluster/install-targets` response on the Pi:

```json
[
  { "name": "local", "type": "local", "tier_id": "arm-npu-15gb", "targets": ["cpu"] },
  { "name": "fedora-worker", "type": "remote", "tier_id": "", "targets": ["cpu"] },
  { "name": "local (current)", "type": "remote", "addr": "unix://", "tier_id": "", "targets": ["cpu"] }
]
```

### Bug 1 — duplicate "local (current)" entry (`routes/cluster.py`)

Incus exposes the local daemon as a remote named `"local (current)"` when it's the active context. That string isn't in `_BUILTIN_REMOTES`, so it fell through and was added as a second controller entry. Fix: skip any remote whose `addr` starts with `"unix://"` — the durable signal for the local incus socket regardless of display name.

### Bug 2 — tier_id 15gb doesn't match catalog buckets (`cluster/capabilities.py`)

A 16 GB Pi reports ~15 GB after kernel reservation. `ram_mb // 1024` produced `15`, giving `arm-npu-15gb`. Catalog manifests only declare canonical buckets (2/4/8/16/32/64/128 GB), so the Store filter went empty when the controller NPU was selected. Fix: `_snap_to_bucket()` rounds raw GB **up** to the next canonical bucket. 15 → 16, 17 → 32, 33 → 64, 200 → 128. Applied to all five `gb = max(1, ...)` call sites in `worker_tier_id`.

### Bug 3 — incus-only remotes silently break the Store filter (multi-file)

`fedora-worker` is registered as an incus remote but not as a taOS cluster worker. `worker_tiers.get(name)` returned `""` and `worker_hw` was `{}`, so `hardware_to_targets({})` returned `["cpu"]` and `tier_id` was `""`. Selecting this device in the Store matched nothing and emptied the catalog with no explanation.

Fixes:
- **Backend**: empty-hardware remotes now emit `tier_id: "unknown"` and `hardware_known: false`.
- **DevicePillBar**: chips for `hardware_known=false` devices show a muted `?` badge with a tooltip.
- **Filter banner**: when an unknown-hardware device is selected, a banner appears above the catalog: "Hardware unknown — register it via the Cluster app to filter accurately. Showing all models for now."
- **filter.ts**: unknown-hardware devices don't contribute a tier to the filter set. If all selected devices are unknown, `requireDeviceMatch` is false — the catalog shows everything instead of nothing.

## Tests

- `tests/cluster/test_worker_tier_id.py` — 14 new Python tests: `_snap_to_bucket` boundary cases + `worker_tier_id` Pi regression.
- `filter.test.ts` — 6 new cases for `hasUnknownHardwareDevice` and unknown-device filter passthrough (22 total).
- All 27 Python cluster tests pass. All 34 frontend tests pass. `tsc --noEmit` clean. Build succeeds.

## Out of scope — known follow-up

The controller shows `targets: ["cpu"]` instead of `["rockchip", "cpu"]`. Root cause is in `hardware_to_targets` — the controller hardware dict's `npu.type` may not match `"rk3588"` or `"rknpu"` at runtime. A TODO comment is added near `hardware_to_targets` pointing at this disconnect. Will be addressed in a separate PR.