### PR TITLE
fix(pwa): shell pre-login accessible so SW can actually precache it

### DIFF
--- a/docs/design/desktop-shell.md
+++ b/docs/design/desktop-shell.md
@@ -462,6 +462,8 @@ Import templates from a community marketplace or shared repository. This extends
 | API client | fetch / SWR | REST + WebSocket to FastAPI |
 | Icons | Lucide React | Clean, consistent icon set |
 | PWA | Service worker | Offline shell, installable |
+
+The service worker precaches the shell HTML (`/desktop`, `/desktop/index.html`, `/chat-pwa`) and all hashed JS/CSS assets on install. Caches are namespaced with `__TAOS_VERSION__` so the activate step evicts any stale cache from a previous build. When a new build is deployed the SW detects the version mismatch on next load and shows a toast prompting the user to reload — they never silently get stale assets. The shell HTML is intentionally pre-login accessible (no auth gate) so the SW can cache it on first visit; the SPA enforces auth client-side via `/auth/status` and redirects to `/auth/login` when there is no valid session.
 | Backend | FastAPI (unchanged) | Serves SPA bundle as static files |
 
 ## Migration Path

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -299,6 +299,8 @@ TinyAgentOS works as a fullscreen Progressive Web App (PWA) on phones and tablet
 
 The Messages app has its own dedicated PWA at `http://your-host:6969/chat-pwa` — install it the same way to get a private, agent-only messenger on your home screen (works like an internal Discord).
 
+> **Auth at install time:** The install itself does not require you to be logged in. The PWA shell is publicly accessible so the service worker can cache it immediately. The first time you open the installed app (or any time your session has expired) you will see the taOS login screen — that screen is part of the SPA itself, not a server redirect. Sign in once and the app resumes normally. This design also means the cached shell survives a backend restart: the app opens from cache while the backend comes back up, then reconnects automatically.
+
 ### Android
 
 1. Open the URL in **Chrome**.

--- a/tests/test_routes_desktop.py
+++ b/tests/test_routes_desktop.py
@@ -46,3 +46,61 @@ def test_sw_js_returns_404_when_not_built(client, monkeypatch, tmp_path):
     monkeypatch.setattr("tinyagentos.routes.desktop.SPA_DIR", tmp_path / "no-such-dir")
     r = client.get("/sw.js")
     assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# PWA shell pre-login accessibility
+# The service worker must be able to precache the shell HTML without a
+# session cookie. Auth is enforced client-side by the SPA itself.
+# ---------------------------------------------------------------------------
+
+
+def test_desktop_shell_accessible_without_auth(client, monkeypatch, tmp_path):
+    """/desktop returns 200 (or 404 if not built) without an auth cookie.
+    A 401 here would prevent the SW from precaching the shell."""
+    fake_dir = tmp_path / "spa"
+    fake_dir.mkdir()
+    (fake_dir / "index.html").write_text("<html>shell</html>")
+    monkeypatch.setattr("tinyagentos.routes.desktop.SPA_DIR", fake_dir)
+    r = client.get("/desktop")
+    assert r.status_code in (200, 404), (
+        f"Expected 200 or 404, got {r.status_code} — shell must not return 401"
+    )
+
+
+def test_desktop_shell_not_built_returns_404_without_auth(client, monkeypatch, tmp_path):
+    """/desktop returns 404 (not 401) when SPA is not built."""
+    monkeypatch.setattr("tinyagentos.routes.desktop.SPA_DIR", tmp_path / "no-such-dir")
+    r = client.get("/desktop")
+    assert r.status_code == 404
+
+
+def test_chat_pwa_accessible_without_auth(client, monkeypatch, tmp_path):
+    """/chat-pwa returns 200 (or 404 if not built) without an auth cookie."""
+    fake_dir = tmp_path / "spa"
+    fake_dir.mkdir()
+    (fake_dir / "chat.html").write_text("<html>chat pwa</html>")
+    monkeypatch.setattr("tinyagentos.routes.desktop.SPA_DIR", fake_dir)
+    r = client.get("/chat-pwa")
+    assert r.status_code in (200, 404), (
+        f"Expected 200 or 404, got {r.status_code} — chat PWA must not return 401"
+    )
+
+
+def test_chat_pwa_subpath_accessible_without_auth(client, monkeypatch, tmp_path):
+    """/chat-pwa/<subpath> falls back to chat.html without auth (SPA routing)."""
+    fake_dir = tmp_path / "spa"
+    fake_dir.mkdir()
+    (fake_dir / "chat.html").write_text("<html>chat pwa</html>")
+    monkeypatch.setattr("tinyagentos.routes.desktop.SPA_DIR", fake_dir)
+    r = client.get("/chat-pwa/some-thread")
+    assert r.status_code in (200, 404), (
+        f"Expected 200 or 404, got {r.status_code} — chat PWA subpaths must not return 401"
+    )
+
+
+def test_api_agents_still_requires_auth(client):
+    """Sanity check: opening the shell to auth-free access must not accidentally
+    expose real API endpoints. /api/agents must still return 401 without a cookie."""
+    r = client.get("/api/agents")
+    assert r.status_code == 401

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -5,15 +5,21 @@ from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import RedirectResponse
 
-EXEMPT_PATHS = {"/auth/login", "/auth/setup", "/auth/status", "/auth/me", "/auth/complete", "/auth/lock", "/api/health", "/api/version", "/api/cluster/workers", "/api/cluster/heartbeat", "/setup", "/setup/complete", "/redeem", "/api/desktop/browser/push/vapid-public-key", "/sw.js"}
-# Bundle assets must be reachable without auth so the SPA can paint the
-# login screen. The SPA shell itself (/desktop and /chat-pwa) goes
-# through the normal auth gate so an unauthenticated request hits a
-# server-side redirect instead of rendering whatever stale bundle the
-# browser cached.
+EXEMPT_PATHS = {"/auth/login", "/auth/setup", "/auth/status", "/auth/me", "/auth/complete", "/auth/lock", "/api/health", "/api/version", "/api/cluster/workers", "/api/cluster/heartbeat", "/setup", "/setup/complete", "/redeem", "/api/desktop/browser/push/vapid-public-key", "/sw.js", "/desktop", "/desktop/index.html", "/chat-pwa"}
+# Bundle assets and the SPA shell HTML must be reachable without auth so:
+#   1. The browser can install and cache the shell for offline / PWA use.
+#   2. After a backend restart the cached shell loads immediately without
+#      a round-trip that would return 401 and leave the user with a blank
+#      screen instead of the cached app.
+# Auth is enforced client-side: the SPA checks /auth/status on boot and
+# redirects to /auth/login if there is no valid session — so dropping the
+# server-side gate on the HTML does not reduce security.
+# Stale-bundle risk is mitigated by __TAOS_VERSION__-namespaced SW caches:
+# on activate the SW deletes any cache that does not match the current
+# build token, so stale index.html entries are evicted automatically.
 # /shortcut/ routes use their own taos_shortcut session cookie for auth;
 # they are intentionally excluded from the main session gate here.
-EXEMPT_PREFIXES = ("/static/", "/desktop/assets/", "/chat-pwa/assets/", "/ws/", "/shortcut/")
+EXEMPT_PREFIXES = ("/static/", "/desktop/", "/chat-pwa/", "/ws/", "/shortcut/")
 
 
 class AuthMiddleware(BaseHTTPMiddleware):


### PR DESCRIPTION
## Bug

The service worker added in #348 precaches `/desktop/`, `/desktop/index.html`, and `/chat-pwa` on install. All three URLs were auth-gated and returned 401 on a fresh visit without a session cookie. With `Promise.allSettled` the SW install didn't abort, but those entries silently never made it into the cache. When the backend goes down after an Install/Update click, the SW has no cached shell to serve, falls through to network, network is down, user sees the browser offline error. The whole point of the SW is defeated.

Observed on the Orange Pi (192.168.6.123) — fresh install sequence always ends with a blank offline screen after the backend restarts.

## Fix

Drop the auth gate on the SPA shell HTML. The SPA already enforces auth client-side: it calls `/auth/status` on boot and redirects to `/auth/login` if there is no valid session. Server-side 401 on the HTML is redundant.

**Stale-bundle trade-off:** the original gate comment cited stale-bundle risk. That risk is now mitigated by `__TAOS_VERSION__`-namespaced caches: the SW's activate step deletes any cache whose name doesn't match the current build token, so stale index.html entries are evicted automatically on every deploy.

### `auth_middleware.py`

- Added `/desktop`, `/desktop/index.html`, `/chat-pwa` to `EXEMPT_PATHS`.
- Widened `EXEMPT_PREFIXES` entry from `/desktop/assets/` → `/desktop/` and from `/chat-pwa/assets/` → `/chat-pwa/` so all SPA subpaths (client-side routes under `/desktop/*` and `/chat-pwa/*`) are reachable pre-login. The `serve_spa` and `serve_chat_pwa_assets` routes both fall back to `index.html` for unknown paths, so those subpaths serve the shell — they need to be exempt for the same reason as the root.
- Updated the misleading comment block to explain the new design.

### Tests (`test_routes_desktop.py`)

Five new tests:
- `/desktop` returns 200 or 404 (never 401) without a cookie.
- `/desktop` returns 404 (not 401) when not built.
- `/chat-pwa` returns 200 or 404 without a cookie.
- `/chat-pwa/<subpath>` returns 200 or 404 without a cookie.
- `/api/agents` still returns 401 without a cookie (sanity: we didn't open everything).

### Docs

- `docs/getting-started.md` — added a callout explaining the install-time auth flow: install works without being logged in, first launch shows the SPA login screen, shell survives backend restarts.
- `docs/design/desktop-shell.md` — expanded the one-line PWA table entry with a follow-up paragraph covering precache behaviour, version-namespaced cache eviction, and the version-mismatch toast.

## Test results

```
62 passed (test_routes_desktop.py + test_routes_auth.py + test_auth.py), 0 failures
```