### PR TITLE
fix(hardware): always re-probe on startup; add /api/system/hardware/refresh (#366)

### DIFF
--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -1,8 +1,10 @@
 # tests/test_hardware.py
 import json
 import pytest
-from unittest.mock import patch, mock_open
+from unittest.mock import patch
 from tinyagentos.hardware import detect_hardware, get_hardware_profile, HardwareProfile
+
+import pytest_asyncio
 
 
 class TestDetectHardware:
@@ -40,15 +42,94 @@ class TestDetectHardware:
 
 
 class TestGetHardwareProfile:
-    def test_returns_cached_if_exists(self, tmp_path):
-        profile = detect_hardware()
-        path = tmp_path / "hardware.json"
-        profile.save(path)
-        loaded = get_hardware_profile(path)
-        assert loaded.profile_id == profile.profile_id
+    def test_always_reprobes_on_startup(self, tmp_path, monkeypatch):
+        """Cache file with stale data is ignored; probe always runs first."""
+        # Write a stale cache with a clearly wrong ram_mb
+        stale = detect_hardware()
+        stale_path = tmp_path / "hardware.json"
+        stale.save(stale_path)
+        stale_data = json.loads(stale_path.read_text())
+        stale_data["ram_mb"] = 1  # sentinel value to detect stale read
+        stale_path.write_text(json.dumps(stale_data))
+
+        fresh = detect_hardware()
+        monkeypatch.setattr(
+            "tinyagentos.hardware.detect_hardware", lambda: fresh
+        )
+
+        result = get_hardware_profile(stale_path)
+        assert result.ram_mb == fresh.ram_mb
+        assert result.ram_mb != 1
+
+        # Cache file should now reflect the fresh probe
+        saved = json.loads(stale_path.read_text())
+        assert saved["ram_mb"] == fresh.ram_mb
+
+    def test_falls_back_to_cache_when_probe_raises(self, tmp_path, monkeypatch):
+        """When detect_hardware raises, the cached profile is returned."""
+        cached = detect_hardware()
+        cache_path = tmp_path / "hardware.json"
+        cached.save(cache_path)
+
+        monkeypatch.setattr(
+            "tinyagentos.hardware.detect_hardware",
+            lambda: (_ for _ in ()).throw(RuntimeError("test")),
+        )
+
+        result = get_hardware_profile(cache_path)
+        assert result.profile_id == cached.profile_id
+
+    def test_reraises_when_probe_raises_and_no_cache(self, tmp_path, monkeypatch):
+        """When detect_hardware raises and no cache exists, the exception propagates."""
+        cache_path = tmp_path / "hardware.json"
+
+        monkeypatch.setattr(
+            "tinyagentos.hardware.detect_hardware",
+            lambda: (_ for _ in ()).throw(RuntimeError("test")),
+        )
+
+        with pytest.raises(RuntimeError, match="test"):
+            get_hardware_profile(cache_path)
 
     def test_detects_if_no_cache(self, tmp_path):
         path = tmp_path / "hardware.json"
         profile = get_hardware_profile(path)
         assert profile.ram_mb > 0
         assert path.exists()  # auto-saved
+
+
+@pytest.mark.asyncio
+class TestHardwareRefreshEndpoint:
+    async def test_refresh_returns_fresh_profile(self, client):
+        """POST /api/system/hardware/refresh returns a valid hardware profile."""
+        resp = await client.post("/api/system/hardware/refresh")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "ram_mb" in data
+        assert data["ram_mb"] > 0
+        assert "profile_id" in data
+
+    async def test_refresh_updates_app_state(self, client):
+        """After refresh, GET /api/system reflects the new hardware values."""
+        post_resp = await client.post("/api/system/hardware/refresh")
+        assert post_resp.status_code == 200
+        fresh = post_resp.json()
+
+        get_resp = await client.get("/api/system")
+        assert get_resp.status_code == 200
+        hw = get_resp.json()["hardware"]
+        assert hw["ram_mb"] == fresh["ram_mb"]
+        assert hw["profile_id"] == fresh["profile_id"]
+
+    async def test_refresh_overwrites_cache_file(self, client):
+        """After refresh, the cache file reflects the fresh probe."""
+        data_dir = client._transport.app.state.data_dir
+        cache_path = data_dir / "hardware.json"
+
+        resp = await client.post("/api/system/hardware/refresh")
+        assert resp.status_code == 200
+        fresh = resp.json()
+
+        assert cache_path.exists()
+        saved = json.loads(cache_path.read_text())
+        assert saved["ram_mb"] == fresh["ram_mb"]

--- a/tinyagentos/hardware.py
+++ b/tinyagentos/hardware.py
@@ -507,16 +507,16 @@ def detect_hardware() -> HardwareProfile:
     )
 
 
-CACHE_TTL_SECONDS = 86400  # Re-detect after 24h (user might add accelerator card)
-
-
 def get_hardware_profile(cache_path: Path) -> HardwareProfile:
-    """Load cached hardware profile, or detect and cache if missing/stale."""
-    if cache_path.exists():
-        import time
-        age = time.time() - cache_path.stat().st_mtime
-        if age < CACHE_TTL_SECONDS:
+    """Detect hardware on every startup. Cache is a fallback for cases where
+    detection raises (broken /sys access, unsupported platform), not the
+    primary read path. Re-probing on startup means newly-installed
+    drivers/tooling are picked up without a manual cache delete."""
+    try:
+        profile = detect_hardware()
+    except Exception:
+        if cache_path.exists():
             return HardwareProfile.load(cache_path)
-    profile = detect_hardware()
+        raise
     profile.save(cache_path)
     return profile

--- a/tinyagentos/routes/system.py
+++ b/tinyagentos/routes/system.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import os
 import sys
+from dataclasses import asdict
 
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
@@ -116,6 +117,33 @@ async def _do_restart(app_state) -> None:
         os.execv(sys.executable, [sys.executable] + sys.argv)
     except Exception as exc:
         await _emit_fail(str(exc))
+
+
+@router.post("/api/system/hardware/refresh")
+async def hardware_refresh(request: Request):
+    """Re-probe hardware and update the cached profile.
+
+    Useful when the user has installed new drivers or hardware (e.g. vulkan-tools)
+    and wants taOS to pick up the change without a full restart. The new logic in
+    get_hardware_profile already re-probes on every startup; this endpoint provides
+    a self-service path between restarts.
+    """
+    from tinyagentos.hardware import get_hardware_profile
+
+    data_dir = getattr(request.app.state, "data_dir", None)
+    if data_dir is None:
+        return JSONResponse({"error": "data_dir not available"}, status_code=503)
+
+    cache_path = data_dir / "hardware.json"
+    if cache_path.exists():
+        cache_path.unlink()
+
+    profile = get_hardware_profile(cache_path)
+    request.app.state.hardware_profile = profile
+
+    data = asdict(profile)
+    data["profile_id"] = profile.profile_id
+    return data
 
 
 @router.get("/api/system/restart/status")


### PR DESCRIPTION
## Problem

Hardware profile was cached for 24h and only re-probed on cache miss or expiry. When johny installed `vulkan-tools` and restarted taOS, the stale `hardware.json` (with `vulkan: false`) was served from cache — the wrong tier persisted until he manually deleted `data/hardware.json`.

Bug thread: #312 (johny's case).

## Fix

**Half 1 — always re-probe on startup**

`get_hardware_profile` now calls `detect_hardware()` on every call. The cache file is a fallback only: if the probe raises (broken `/sys`, unsupported platform), the cached value is returned. If the probe raises and no cache exists, the exception propagates. The `CACHE_TTL_SECONDS` constant and its `import time` guard are removed.

The probe itself is ~100ms (a handful of subprocess calls), so always running it on startup has no meaningful cost.

**Half 2 — `POST /api/system/hardware/refresh` endpoint**

Added to `tinyagentos/routes/system.py`. Deletes the cache file, calls `get_hardware_profile`, updates `app.state.hardware_profile`, and returns the fresh profile JSON. Useful between restarts when a user installs new drivers.

Frontend "Refresh hardware" button in the System Info panel is a follow-up.

## Tests

- `test_always_reprobes_on_startup` — stale cache with sentinel `ram_mb=1` is not returned; fresh probe value is returned and written to cache.
- `test_falls_back_to_cache_when_probe_raises` — monkeypatched raise returns cached profile.
- `test_reraises_when_probe_raises_and_no_cache` — monkeypatched raise with no cache re-raises.
- `test_refresh_updates_app_state` — POST refresh, then GET `/api/system` reflects the new values.
- `test_refresh_overwrites_cache_file` — cache file matches fresh probe after endpoint call.

## Files changed

- `tinyagentos/hardware.py` — refactored `get_hardware_profile`, dropped `CACHE_TTL_SECONDS`
- `tinyagentos/routes/system.py` — added `POST /api/system/hardware/refresh`
- `tests/test_hardware.py` — replaced stale cache tests with the four cases above