### PR TITLE
fix(container): install-server.sh auto-installs Incus; app logs actionable warning when no runtime (#369)

### DIFF
--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -343,6 +343,76 @@ detect_and_advise_accelerators() {
 
 detect_and_advise_accelerators
 
+# --- container runtime — install Incus if nothing is present -------------
+#
+# taOS uses a container runtime (Incus, Docker, or Podman) to deploy
+# worker containers. On macOS, the Apple Containerization framework
+# (bundled with macOS 26) is used instead — no install needed here.
+# On Linux, if no runtime is found, we install Incus via the system
+# package manager on Debian/Ubuntu/Fedora. On Arch/Alpine we log a
+# manual-install notice and continue — those distros have it in the
+# repos but the AUR/apk setup varies too much to auto-invoke here.
+# A failed Incus install is non-fatal: taOS still starts; cluster and
+# worker-container features are simply unavailable until one is added.
+
+ensure_container_runtime() {
+    if [[ "$os_name" == "Darwin" ]]; then
+        log "container runtime: macOS — Apple Containerization framework (macOS 26+) will be used"
+        return 0
+    fi
+
+    # Check if any supported runtime is already present
+    if command -v incus >/dev/null 2>&1; then
+        log "container runtime: incus $(incus --version 2>/dev/null | head -1) — ok"
+        return 0
+    fi
+    if command -v docker >/dev/null 2>&1; then
+        log "container runtime: docker $(docker --version 2>/dev/null | head -1) — ok"
+        return 0
+    fi
+    if command -v podman >/dev/null 2>&1; then
+        log "container runtime: podman $(podman --version 2>/dev/null | head -1) — ok"
+        return 0
+    fi
+
+    log "no container runtime found — attempting to install Incus"
+
+    local installed=0
+    if command -v apt-get >/dev/null 2>&1; then
+        log "installing incus via apt"
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq incus \
+            && installed=1 \
+            || warn "apt install incus failed — continuing without container support"
+    elif command -v dnf >/dev/null 2>&1; then
+        log "installing incus via dnf"
+        sudo dnf install -y -q incus \
+            && installed=1 \
+            || warn "dnf install incus failed — continuing without container support"
+    elif command -v pacman >/dev/null 2>&1; then
+        warn "container runtime: Arch detected — install Incus manually with:"
+        warn "  sudo pacman -S incus"
+        warn "  (or install Docker/Podman if you prefer)"
+        warn "  worker containers will be unavailable until a runtime is installed"
+    elif command -v apk >/dev/null 2>&1; then
+        warn "container runtime: Alpine detected — install Incus manually with:"
+        warn "  sudo apk add incus"
+        warn "  worker containers will be unavailable until a runtime is installed"
+    else
+        warn "container runtime: unrecognised package manager — install Incus or Docker manually"
+        warn "  worker containers will be unavailable until a runtime is installed"
+    fi
+
+    if (( installed )); then
+        if command -v incus >/dev/null 2>&1; then
+            log "container runtime: incus installed successfully"
+        else
+            warn "incus install reported success but binary not found on PATH — check your PATH"
+        fi
+    fi
+}
+
+ensure_container_runtime
+
 # --- clone / update the repo ---------------------------------------------
 
 if [[ ! -d "$INSTALL_DIR/.git" ]]; then

--- a/tests/test_container_detection.py
+++ b/tests/test_container_detection.py
@@ -2,7 +2,7 @@ import os
 import sys
 import pytest
 from unittest.mock import patch
-from tinyagentos.containers.backend import detect_runtime
+from tinyagentos.containers.backend import detect_runtime, get_backend, set_backend, _active_backend
 
 
 class TestDetectRuntime:
@@ -65,3 +65,49 @@ class TestDetectRuntimeApple:
              patch.dict(os.environ, {"TAOS_CONTAINER_BIN": "/x/container"}, clear=False), \
              patch("shutil.which", side_effect=lambda x: "/usr/bin/incus" if x == "incus" else None):
             assert detect_runtime() == "apple"
+
+
+class TestGetBackendError:
+    def test_get_backend_raises_actionable_error_when_not_set(self):
+        import tinyagentos.containers.backend as _be
+        original = _be._active_backend
+        try:
+            _be._active_backend = None
+            with pytest.raises(RuntimeError) as exc_info:
+                get_backend()
+            msg = str(exc_info.value)
+            assert "Install" in msg
+            assert "Incus or Docker" in msg
+        finally:
+            _be._active_backend = original
+
+    def test_detect_runtime_returns_none_when_nothing_installed(self, monkeypatch):
+        monkeypatch.delenv("TAOS_CONTAINER_BIN", raising=False)
+        with patch("shutil.which", return_value=None):
+            assert detect_runtime() == "none"
+
+    def test_detect_runtime_returns_lxc_when_incus_present(self, monkeypatch):
+        monkeypatch.delenv("TAOS_CONTAINER_BIN", raising=False)
+        with patch("shutil.which", side_effect=lambda x: "/usr/bin/incus" if x == "incus" else None):
+            assert detect_runtime() == "lxc"
+
+
+class TestAppStartupNoRuntime:
+    def test_app_starts_with_no_runtime_logs_warning(self, tmp_path, caplog):
+        import logging
+        import tinyagentos.containers.backend as _be
+
+        original = _be._active_backend
+        try:
+            _be._active_backend = None
+            with patch("tinyagentos.containers.backend.detect_runtime", return_value="none"), \
+                 caplog.at_level(logging.WARNING, logger="tinyagentos.app"):
+                from tinyagentos.app import create_app
+                app = create_app(data_dir=tmp_path)
+                # App created without error; warning should be logged
+                assert any(
+                    "No container backend detected" in r.message
+                    for r in caplog.records
+                ), "Expected actionable container warning in logs"
+        finally:
+            _be._active_backend = original

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -682,6 +682,13 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
             set_backend(LXCBackend())
         elif runtime in ("docker", "podman"):
             set_backend(DockerBackend(binary=runtime))
+        else:
+            logger.warning(
+                "No container backend detected (Incus / Docker / Podman / Apple). "
+                "Cluster features and worker containers will be disabled. "
+                "Install one (e.g. 'sudo apt install incus' on Ubuntu/Debian, "
+                "'sudo dnf install incus' on Fedora) and restart taOS."
+            )
 
         # Disk quota monitor — build and attach to app state so the route
         # handler can reuse the same instance (preserves in-memory last_state).
@@ -920,8 +927,15 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
             set_backend(LXCBackend())
         elif _runtime in ("docker", "podman"):
             set_backend(DockerBackend(binary=_runtime))
+        else:
+            logger.warning(
+                "No container backend detected (Incus / Docker / Podman / Apple). "
+                "Cluster features and worker containers will be disabled. "
+                "Install one (e.g. 'sudo apt install incus' on Ubuntu/Debian, "
+                "'sudo dnf install incus' on Fedora) and restart taOS."
+            )
     except Exception:
-        pass  # Container runtime detection is non-fatal
+        logger.exception("container backend auto-init failed")
 
     # Mount static files
     static_dir = PROJECT_DIR / "static"

--- a/tinyagentos/containers/backend.py
+++ b/tinyagentos/containers/backend.py
@@ -275,7 +275,9 @@ def get_backend() -> ContainerBackend:
     """
     if _active_backend is None:
         raise RuntimeError(
-            "No container backend configured. Call set_backend() first."
+            "No container backend detected on this host. taOS needs Incus or Docker to run "
+            "worker containers. Install one (e.g. 'sudo apt install incus' on Ubuntu/Debian, "
+            "'sudo dnf install incus' on Fedora) and restart taOS."
         )
     return _active_backend
 


### PR DESCRIPTION
## Summary

- **install-server.sh**: adds `ensure_container_runtime()` block (after the GPU/NPU detection step) that installs Incus via `apt` on Debian/Ubuntu or `dnf` on Fedora if no runtime (Incus/Docker/Podman) is on PATH. Arch and Alpine get an advisory log. macOS logs the Apple Containerization path. A failed install is non-fatal; taOS continues and cluster features are disabled.
- **app.py**: both the lifespan block and the eager `create_app` block now log a clear `logger.warning` when `detect_runtime()` returns `"none"`, telling the user exactly which packages to install. Previously the `"none"` branch fell through silently and the disk-quota-monitor `get_backend()` call raised an internal error swallowed by its `except Exception`.
- **backend.py**: `get_backend()` `RuntimeError` message now says "Install one (e.g. 'sudo apt install incus' on Ubuntu/Debian…) and restart taOS" instead of "Call set_backend() first."

## Relation to #368

Fixing #369 means the disk-quota-monitor stop-failing-to-init problem is resolved at its root (a runtime gets installed or a clear warning is logged). #368's fallback is the belt-and-braces for the case where a runtime is installed but the quota call itself fails.

## Tests

4 new tests in `tests/test_container_detection.py`:
- `test_detect_runtime_returns_none_when_nothing_installed` — monkeypatches `shutil.which` to `None`
- `test_detect_runtime_returns_lxc_when_incus_present` — asserts lxc priority
- `test_get_backend_raises_actionable_error_when_not_set` — asserts "Install" and "Incus or Docker" in the error
- `test_app_starts_with_no_runtime_logs_warning` — `create_app` with patched `detect_runtime → "none"` checks the warning is emitted

All 278 existing backend/container/runtime tests still pass; `test_routes_settings.py` (21 tests) clean.