### PR TITLE
fix(store): compat filter applies to all sections (LLM Runtime, MCP, Services, etc.)

### DIFF
--- a/desktop/src/apps/StoreApp/filter.test.ts
+++ b/desktop/src/apps/StoreApp/filter.test.ts
@@ -1,6 +1,6 @@
 // desktop/src/apps/StoreApp/filter.test.ts
 import { describe, it, expect } from "vitest";
-import { filterModels, compatFromResolver } from "./filter";
+import { filterCatalog, compatFromResolver } from "./filter";
 import type { CatalogApp, InstallTarget } from "./types";
 
 const piDevice: InstallTarget = {
@@ -22,6 +22,13 @@ const controllerDevice: InstallTarget = {
   label: "Controller",
   type: "local",
   tier_id: "x86-cpu-only",
+};
+
+const x86VulkanDevice: InstallTarget = {
+  name: "x86-gpu",
+  label: "x86 GPU",
+  type: "remote",
+  tier_id: "x86-vulkan-8gb",
 };
 
 const rkllamaModel: CatalogApp = {
@@ -97,15 +104,15 @@ const allApps = [
   fallbackInstallMethod,
 ];
 
-describe("filterModels", () => {
+describe("filterCatalog", () => {
   it("returns all apps as compatible when no filters are applied", () => {
-    const { compatible, incompatible } = filterModels(allApps, [], []);
+    const { compatible, incompatible } = filterCatalog(allApps, [], []);
     expect(compatible).toEqual(allApps);
     expect(incompatible).toEqual([]);
   });
 
   it("filters to a single device's compatible models", () => {
-    const { compatible } = filterModels(allApps, [piDevice], []);
+    const { compatible } = filterCatalog(allApps, [piDevice], []);
     const ids = compatible.map((a) => a.id);
     expect(ids).toContain("qwen3-4b-rk");
     expect(ids).toContain("small-tool"); // no hardware_tiers → universal
@@ -113,13 +120,13 @@ describe("filterModels", () => {
   });
 
   it("excludes models with explicit 'unsupported' tier", () => {
-    const { compatible, incompatible } = filterModels(allApps, [piDevice], []);
+    const { compatible, incompatible } = filterCatalog(allApps, [piDevice], []);
     expect(compatible.find((a) => a.id === "huge-model")).toBeUndefined();
     expect(incompatible.find((a) => a.id === "huge-model")).toBeDefined();
   });
 
   it("union semantics across multiple devices", () => {
-    const { compatible } = filterModels(allApps, [piDevice, macDevice], []);
+    const { compatible } = filterCatalog(allApps, [piDevice, macDevice], []);
     const ids = compatible.map((a) => a.id);
     expect(ids).toContain("qwen3-4b-rk"); // matches Pi
     expect(ids).toContain("qwen3-4b-ollama"); // matches Mac
@@ -127,7 +134,7 @@ describe("filterModels", () => {
   });
 
   it("backend filter narrows further (intersection with device match)", () => {
-    const { compatible } = filterModels(
+    const { compatible } = filterCatalog(
       allApps,
       [piDevice, macDevice],
       ["rkllama"]
@@ -138,7 +145,7 @@ describe("filterModels", () => {
   });
 
   it("falls back to install_method when variants[].backend is absent", () => {
-    const { compatible } = filterModels(
+    const { compatible } = filterCatalog(
       [fallbackInstallMethod],
       [macDevice],
       ["ollama"]
@@ -147,7 +154,7 @@ describe("filterModels", () => {
   });
 
   it("model with no hardware_tiers and no variants passes any device filter", () => {
-    const { compatible } = filterModels(
+    const { compatible } = filterCatalog(
       [universalModel],
       [piDevice],
       []
@@ -156,7 +163,7 @@ describe("filterModels", () => {
   });
 
   it("model with no backend constraint passes any backend filter", () => {
-    const { compatible } = filterModels(
+    const { compatible } = filterCatalog(
       [universalModel],
       [],
       ["rkllama"]
@@ -165,7 +172,7 @@ describe("filterModels", () => {
   });
 
   it("controller-only filter excludes Pi-only models into incompatible", () => {
-    const { compatible, incompatible } = filterModels(
+    const { compatible, incompatible } = filterCatalog(
       allApps,
       [controllerDevice],
       []
@@ -177,7 +184,7 @@ describe("filterModels", () => {
   });
 
   it("device + backend together require BOTH to match", () => {
-    const { compatible } = filterModels(
+    const { compatible } = filterCatalog(
       allApps,
       [macDevice],
       ["rkllama"]
@@ -191,10 +198,133 @@ describe("filterModels", () => {
       label: "weird",
       type: "remote",
     };
-    const { compatible } = filterModels(allApps, [noTierDevice], []);
+    const { compatible } = filterCatalog(allApps, [noTierDevice], []);
     // device has no tier_id → contributes nothing to the tier set;
     // selectedDevices is non-empty so deviceOk=false except for universal
     expect(compatible.map((a) => a.id)).toEqual(["small-tool"]);
+  });
+
+  // --- Non-model app type tests ---
+
+  it("service with hardware_tiers is correctly filtered by device", () => {
+    const armService: CatalogApp = {
+      id: "arm-inference-svc",
+      name: "ARM Inference Service",
+      type: "service",
+      version: "1",
+      description: "",
+      installed: false,
+      compat: "green",
+      hardware_tiers: { "arm-npu-16gb": { recommended: "default" } },
+      variants: [{ id: "default", backend: ["rkllama"] }],
+    };
+    const { compatible, incompatible } = filterCatalog([armService], [controllerDevice], []);
+    expect(compatible.find((a) => a.id === "arm-inference-svc")).toBeUndefined();
+    expect(incompatible.find((a) => a.id === "arm-inference-svc")).toBeDefined();
+  });
+
+  it("agent-framework with hardware_tiers is filtered when tier doesn't match", () => {
+    const npuFramework: CatalogApp = {
+      id: "npu-agent-fw",
+      name: "NPU Agent Framework",
+      type: "agent-framework",
+      version: "1",
+      description: "",
+      installed: false,
+      compat: "green",
+      hardware_tiers: {
+        "arm-npu-16gb": { recommended: "default" },
+        "arm-npu-8gb": { recommended: "default" },
+      },
+      variants: [{ id: "default", backend: ["rkllama"] }],
+    };
+    const { compatible, incompatible } = filterCatalog([npuFramework], [macDevice], []);
+    expect(compatible.find((a) => a.id === "npu-agent-fw")).toBeUndefined();
+    expect(incompatible.find((a) => a.id === "npu-agent-fw")).toBeDefined();
+  });
+
+  it("mcp server with hardware_tiers is filtered when tier doesn't match", () => {
+    const armMcp: CatalogApp = {
+      id: "arm-mcp-server",
+      name: "ARM MCP Server",
+      type: "mcp",
+      version: "1",
+      description: "",
+      installed: false,
+      compat: "green",
+      hardware_tiers: { "arm-npu-16gb": { recommended: "default" } },
+    };
+    const { compatible, incompatible } = filterCatalog([armMcp], [x86VulkanDevice], []);
+    expect(compatible.find((a) => a.id === "arm-mcp-server")).toBeUndefined();
+    expect(incompatible.find((a) => a.id === "arm-mcp-server")).toBeDefined();
+  });
+
+  it("service without hardware_tiers is universally compatible (passes any device filter)", () => {
+    const universalService: CatalogApp = {
+      id: "universal-svc",
+      name: "Universal Service",
+      type: "service",
+      version: "1",
+      description: "",
+      installed: false,
+      compat: "green",
+      // no hardware_tiers → runs anywhere
+    };
+    const { compatible } = filterCatalog([universalService], [piDevice], []);
+    expect(compatible.map((a) => a.id)).toEqual(["universal-svc"]);
+  });
+
+  it("agent-framework without hardware_tiers passes any device filter", () => {
+    const universalFw: CatalogApp = {
+      id: "universal-fw",
+      name: "Universal Framework",
+      type: "agent-framework",
+      version: "1",
+      description: "",
+      installed: false,
+      compat: "green",
+    };
+    const { compatible } = filterCatalog([universalFw], [x86VulkanDevice], []);
+    expect(compatible.map((a) => a.id)).toEqual(["universal-fw"]);
+  });
+
+  it("mcp server without hardware_tiers passes any device filter", () => {
+    const universalMcp: CatalogApp = {
+      id: "universal-mcp",
+      name: "Universal MCP",
+      type: "mcp",
+      version: "1",
+      description: "",
+      installed: false,
+      compat: "green",
+    };
+    const { compatible } = filterCatalog([universalMcp], [controllerDevice], []);
+    expect(compatible.map((a) => a.id)).toEqual(["universal-mcp"]);
+  });
+
+  // --- LLM Runtime specific test (johny / N100 case from #312) ---
+
+  it("LLM runtime restricted to arm-npu tiers is incompatible on x86-vulkan", () => {
+    // This is the exact case from #312: johny on an N100 (x86-vulkan-*) was
+    // able to install rk-llama-cpp because the runtime tab had no filter.
+    const rkLlamaCpp: CatalogApp = {
+      id: "rk-llama-cpp",
+      name: "rk-llama-cpp Runtime",
+      type: "llm-runtime",
+      version: "1",
+      description: "",
+      installed: false,
+      compat: "green",
+      hardware_tiers: {
+        "arm-npu-16gb": { recommended: "default" },
+        "arm-npu-8gb": { recommended: "default" },
+        "cpu-only": { recommended: "default" },
+      },
+      variants: [{ id: "default", backend: ["rk-llama-cpp"] }],
+    };
+    const { compatible, incompatible } = filterCatalog([rkLlamaCpp], [x86VulkanDevice], []);
+    expect(compatible.find((a) => a.id === "rk-llama-cpp")).toBeUndefined();
+    expect(incompatible.find((a) => a.id === "rk-llama-cpp")).toBeDefined();
   });
 });
 

--- a/desktop/src/apps/StoreApp/filter.ts
+++ b/desktop/src/apps/StoreApp/filter.ts
@@ -14,18 +14,21 @@ export interface FilterResult {
  * within an axis (any selected device matches; any selected backend
  * matches), intersection across axes (must satisfy both).
  *
- * A model passes the device filter if at least one of its declared
+ * An app passes the device filter if at least one of its declared
  * hardware_tiers matches one of the selected devices' tier_ids and
- * is not explicitly "unsupported". Models with no hardware_tiers are
- * treated as universally compatible.
+ * is not explicitly "unsupported". Apps with no hardware_tiers are
+ * treated as universally compatible (runs anywhere).
  *
- * A model passes the backend filter if any of its variants advertise
+ * An app passes the backend filter if any of its variants advertise
  * one of the selected backends. Falls back to install_method when
- * variants[].backend is empty. Models with no declared backend pass
+ * variants[].backend is empty. Apps with no declared backend pass
  * the backend filter only when no device filter is active; universal
  * device compatibility already includes them in that case.
+ *
+ * Works for all catalog item types: models, runtimes, services, agents,
+ * MCP servers, etc.
  */
-export function filterModels(
+export function filterCatalog(
   apps: CatalogApp[],
   selectedDevices: InstallTarget[],
   selectedBackends: string[],

--- a/desktop/src/apps/StoreApp/index.tsx
+++ b/desktop/src/apps/StoreApp/index.tsx
@@ -795,7 +795,12 @@ export function StoreApp({ windowId: _windowId }: { windowId: string }) {
   }, [selectedDevices, installTargets, apps]);
 
   useEffect(() => {
-    if (availableBackends.length === 0) return; // bar is hidden, leave state alone
+    if (availableBackends.length === 0) {
+      // Bar is hidden; clear any stale backend filter so it doesn't
+      // silently apply behind invisible UI.
+      if (selectedBackends.length > 0) setSelectedBackends([]);
+      return;
+    }
     const availSet = new Set(availableBackends);
     const dropped = selectedBackends.filter((b) => !availSet.has(b));
     if (dropped.length > 0) {

--- a/desktop/src/apps/StoreApp/index.tsx
+++ b/desktop/src/apps/StoreApp/index.tsx
@@ -6,7 +6,7 @@ import type { CatalogApp, InstallTarget, InstalledEntry } from "./types";
 import { DevicePillBar } from "./DevicePillBar";
 import { BackendPillBar } from "./BackendPillBar";
 import { IncompatibleToggle } from "./IncompatibleToggle";
-import { filterModels, compatFromResolver } from "./filter";
+import { filterCatalog, compatFromResolver } from "./filter";
 import { resolveModel, type ResolveResponse } from "./resolver-types";
 import { compatVisuals } from "./compat-visuals";
 import { loadFilter, saveFilter } from "./storage";
@@ -746,15 +746,10 @@ export function StoreApp({ windowId: _windowId }: { windowId: string }) {
     return true;
   });
 
-  // Device + backend filter only applies when the user is in the Models
-  // category. Other categories use the existing list as-is.
-  const isModels = activeCategory === "models";
   const selectedDeviceObjs = installTargets.filter((t) =>
     selectedDevices.includes(t.name)
   );
-  const tierFilterResult = isModels
-    ? filterModels(categoryFiltered, selectedDeviceObjs, selectedBackends)
-    : { compatible: categoryFiltered, incompatible: [] };
+  const tierFilterResult = filterCatalog(categoryFiltered, selectedDeviceObjs, selectedBackends);
 
   // Apply resolver compat as a second pass: any model the resolver classifies
   // as "red" moves from compatible → incompatible, regardless of tier match.
@@ -773,7 +768,7 @@ export function StoreApp({ windowId: _windowId }: { windowId: string }) {
   // Backends shown in the BackendPillBar are the union of variants[].backend
   // across all manifests where any selected device's tier_id is supported.
   const availableBackends = useMemo(() => {
-    if (!isModels || selectedDevices.length === 0) return [];
+    if (selectedDevices.length === 0) return [];
     const memoSelectedDevices = installTargets.filter((t) =>
       selectedDevices.includes(t.name)
     );
@@ -797,10 +792,9 @@ export function StoreApp({ windowId: _windowId }: { windowId: string }) {
       }
     }
     return Array.from(out).sort();
-  }, [isModels, selectedDevices, installTargets, apps]);
+  }, [selectedDevices, installTargets, apps]);
 
   useEffect(() => {
-    if (!isModels) return;
     if (availableBackends.length === 0) return; // bar is hidden, leave state alone
     const availSet = new Set(availableBackends);
     const dropped = selectedBackends.filter((b) => !availSet.has(b));
@@ -813,7 +807,7 @@ export function StoreApp({ windowId: _windowId }: { windowId: string }) {
         `[store-filter] auto-deselected backend(s): ${dropped.join(", ")}`
       );
     }
-  }, [availableBackends, isModels, selectedBackends]);
+  }, [availableBackends, selectedBackends]);
 
   const handleInstall = useCallback((id: string) => {
     setApps((prev) => prev.map((a) => (a.id === id ? { ...a, installed: true } : a)));
@@ -909,22 +903,20 @@ export function StoreApp({ windowId: _windowId }: { windowId: string }) {
 
         {/* Grid */}
         <div className="flex-1 overflow-y-auto px-5 py-4">
-          {isModels && (
-            <>
-              <DevicePillBar
-                devices={installTargets}
-                selected={selectedDevices}
-                onChange={setSelectedDevices}
-                showSkeleton={installTargets.length === 0 && loading}
-              />
-              <BackendPillBar
-                available={availableBackends}
-                selected={selectedBackends}
-                onChange={setSelectedBackends}
-                disabled={selectedDevices.length === 0}
-              />
-            </>
-          )}
+          <>
+            <DevicePillBar
+              devices={installTargets}
+              selected={selectedDevices}
+              onChange={setSelectedDevices}
+              showSkeleton={installTargets.length === 0 && loading}
+            />
+            <BackendPillBar
+              available={availableBackends}
+              selected={selectedBackends}
+              onChange={setSelectedBackends}
+              disabled={selectedDevices.length === 0}
+            />
+          </>
           {loading ? (
             <div className="flex items-center justify-center h-40">
               <Loader2 className="w-6 h-6 text-shell-text-tertiary animate-spin" />
@@ -961,7 +953,7 @@ export function StoreApp({ windowId: _windowId }: { windowId: string }) {
                     installTargets={installTargets}
                     runtimeHost={runtimeHosts[app.id] ?? null}
                     defaultTargetRemote={
-                      isModels && selectedDevices.length === 1 ? selectedDevices[0] : undefined
+                      selectedDevices.length === 1 ? selectedDevices[0] : undefined
                     }
                     resolveResponse={compatMap.get(app.id)}
                   />
@@ -969,7 +961,7 @@ export function StoreApp({ windowId: _windowId }: { windowId: string }) {
               })}
             </div>
           )}
-          {isModels && (
+          {incompatible.length > 0 && (
             <IncompatibleToggle count={incompatible.length}>
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
                 {incompatible.map((app) => (
@@ -982,7 +974,7 @@ export function StoreApp({ windowId: _windowId }: { windowId: string }) {
                     installTargets={installTargets}
                     runtimeHost={runtimeHosts[app.id] ?? null}
                     defaultTargetRemote={
-                      isModels && selectedDevices.length === 1 ? selectedDevices[0] : undefined
+                      selectedDevices.length === 1 ? selectedDevices[0] : undefined
                     }
                     resolveResponse={compatMap.get(app.id)}
                   />


### PR DESCRIPTION
## Problem

The device/backend compatibility filter (DevicePillBar + BackendPillBar + IncompatibleToggle) was gated to the Models category only. Every other section — LLM Runtime, Services, MCP, Agent Frameworks — used the raw catalog list with no filtering.

Concrete case from #312: johny on an N100 box (x86-vulkan tier) was able to install `rk-llama-cpp` from the LLM Runtime tab even though the resolver classified it as incompatible with his hardware. The filter didn't run on that tab, so nothing stopped him. Model installs against it then failed.

## Fix

- Removed the `isModels` gate from the three filter-logic sites in `index.tsx`:
  - `tierFilterResult` — now always calls `filterCatalog` (was conditional)
  - `availableBackends` useMemo — now computes for any active device selection
  - autodeselect-removed-backends effect — now always runs
- Also removed the `isModels` gate from the DevicePillBar/BackendPillBar/IncompatibleToggle UI rendering so the controls are visible in all sections.
- Renamed `filterModels` → `filterCatalog` in `filter.ts` since the function is generic and now used across all catalog types.

## Tests

- Updated import in `filter.test.ts` to `filterCatalog`.
- Added tests for `type: "service"`, `type: "agent-framework"`, `type: "mcp"` apps with `hardware_tiers` — assert correctly filtered when tier doesn't match.
- Added tests for non-model apps without `hardware_tiers` — assert universal compat preserved.
- Added specific test for the johny/#312 LLM runtime case: `rk-llama-cpp` with only `arm-npu-*` and `cpu-only` tiers is incompatible on `x86-vulkan-8gb`.

All 35 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified filtering now applies to all catalog items, not just specific types.
  * Device and backend selection controls are always available in the UI.

* **Bug Fixes**
  * Improved device compatibility checking with more comprehensive coverage of hardware tier matching scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->