### PR TITLE
ci: build SPA bundle before pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,23 @@ jobs:
       - name: Install dependencies
         run: pip install -e ".[dev]"
 
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: desktop/package-lock.json
+
+      - name: Build SPA bundle
+        # Several backend tests serve from static/desktop/* and 404 if the
+        # bundle isn't built (e.g. test_root_redirects_to_desktop). The bundle
+        # is gitignored (see #375) — generated, not source — so CI builds it
+        # before running pytest.
+        run: |
+          cd desktop
+          npm ci --silent
+          npm run build
+
       - name: Run tests
         run: pytest tests/ -v --tb=short --ignore=tests/e2e
 


### PR DESCRIPTION
After #375 (gitignore the SPA bundle), CI started failing because tests that hit `/desktop` or `/chat-pwa` routes expect `static/desktop/index.html` to exist. CI doesn't build the bundle, so those tests 404.

Concrete failure: `tests/test_routes_dashboard.py::TestDashboardPage::test_root_redirects_to_desktop` failed on PR #373's CI run with `assert 404 == 200`.

Fix: add `Set up Node` + `Build SPA bundle` steps before `Run tests`. `npm ci` for reproducible install, `npm run build` to emit the bundle into `static/desktop/`. Adds ~30-60s to each matrix job; cache-keyed on `package-lock.json` so most runs are mostly a no-op.

After this lands, the open PRs (#372, #373, #374) need a re-trigger to pick up the working CI.
