### PR TITLE
ci: bump test timeout 35→45 to stop 3.11 false cancellations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,11 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    # Bumped from 35 to 45: 3.11 was hitting the cap because it has fewer
+    # pre-built wheels for our deps + the newly-added SPA build step adds
+    # ~30s. Cancellations were showing as CANCELLED instead of TIMED_OUT,
+    # which made the cause non-obvious.
+    timeout-minutes: 45
     strategy:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]


### PR DESCRIPTION
Python 3.11 jobs were hitting the 35-minute timeout because:

- 3.11 has fewer pre-built wheels for our deps so pip install is slower
- The newly-added SPA build step (#376) adds another ~30s

When the timeout hit, GitHub displayed the job as `CANCELLED` rather than `TIMED_OUT`, which made the cause non-obvious — looked like a fail-fast cascade.

Bumping to 45 keeps coverage on 3.11 (still in pyproject's `requires-python = ">=3.11"`) without dropping it from the matrix.
