### PR TITLE
feat(openclaw): inject taosmd agent_rules into AGENTS.md at deploy (#378)

### DIFF
--- a/tests/test_deployer.py
+++ b/tests/test_deployer.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from tinyagentos.deployer import deploy_agent, undeploy_agent, DeployRequest
+from tinyagentos.deployer import deploy_agent, undeploy_agent, DeployRequest, _splice_taosmd_block
 
 
 def _req(**overrides) -> DeployRequest:
@@ -616,8 +616,8 @@ class TestDeployAgent:
 
     @pytest.mark.asyncio
     async def test_openclaw_deploy_pushes_agents_md_with_taosmd_rules(self, tmp_path):
-        """When framework=openclaw, deploy pushes AGENTS.md containing taosmd
-        agent_rules with the agent's name substituted in."""
+        """When framework=openclaw and no existing AGENTS.md, deploy pushes a
+        sentinel-wrapped file with taosmd agent_rules and the agent name substituted."""
         pushed: list[tuple[str, str]] = []
 
         async def fake_push_file(container, src, dst):
@@ -625,13 +625,16 @@ class TestDeployAgent:
                 with open(src) as fh:
                     pushed.append((dst, fh.read()))
             except FileNotFoundError:
-                # tmp file already unlinked — content capture not needed for error path
                 pushed.append((dst, ""))
             return 0, ""
 
         async def mock_exec_fn(name, cmd, **kwargs):
-            if "hostname -I" in " ".join(cmd):
+            cmd_str = " ".join(cmd)
+            if "hostname -I" in cmd_str:
                 return (0, "10.0.0.99")
+            if "cat" in cmd_str and "AGENTS.md" in cmd_str:
+                # Simulate no existing file
+                return (1, "")
             return (0, "ok")
 
         fake_rules = "Follow the taosmd librarian protocol.\nAgent: <your-agent-name>"
@@ -662,6 +665,8 @@ class TestDeployAgent:
         assert "octest" in content, "agent slug not substituted in AGENTS.md"
         assert "librarian" in content, "expected taosmd rules phrase in AGENTS.md"
         assert "<your-agent-name>" not in content, "placeholder not replaced"
+        assert "<!-- taosmd:rules-begin -->" in content, "missing begin sentinel"
+        assert "<!-- taosmd:rules-end -->" in content, "missing end sentinel"
 
     @pytest.mark.asyncio
     async def test_bridge_url_injected_into_env(self, tmp_path):
@@ -681,6 +686,160 @@ class TestDeployAgent:
             await deploy_agent(req)
             env = mock_create.call_args.kwargs["env"]
             assert env["TAOS_BRIDGE_URL"] == "http://127.0.0.1:6969"
+
+
+class TestSpliceTaosmdBlock:
+    """Unit tests for the _splice_taosmd_block helper — no I/O involved."""
+
+    BEGIN = "<!-- taosmd:rules-begin -->"
+    END = "<!-- taosmd:rules-end -->"
+
+    def test_no_existing_file_produces_sentinel_only(self):
+        result = _splice_taosmd_block("", "my rules")
+        assert result == f"{self.BEGIN}\nmy rules\n{self.END}\n"
+
+    def test_existing_with_sentinels_replaces_block_preserves_surroundings(self):
+        existing = (
+            "# My Agent\n\nSome user content.\n\n"
+            f"{self.BEGIN}\nold rules\n{self.END}\n\n"
+            "User content below.\n"
+        )
+        result = _splice_taosmd_block(existing, "new rules")
+        assert "Some user content." in result
+        assert "User content below." in result
+        assert "old rules" not in result
+        assert "new rules" in result
+        assert result.count(self.BEGIN) == 1
+        assert result.count(self.END) == 1
+
+    def test_existing_without_sentinels_appends_block(self):
+        existing = "# My Agent\n\nHand-crafted user content.\n"
+        result = _splice_taosmd_block(existing, "appended rules")
+        assert result.startswith("# My Agent")
+        assert "Hand-crafted user content." in result
+        assert "appended rules" in result
+        assert self.BEGIN in result
+        assert self.END in result
+        # User content comes before the sentinels
+        user_pos = result.index("Hand-crafted")
+        sentinel_pos = result.index(self.BEGIN)
+        assert user_pos < sentinel_pos
+
+    def test_redeploy_updates_only_block_content(self):
+        rules_v1 = "rules version 1"
+        rules_v2 = "rules version 2"
+        user_header = "# My Agent\n\nUser stuff.\n"
+        user_footer = "\nUser footer.\n"
+        after_first = _splice_taosmd_block("", rules_v1)
+        # Simulate user editing the file around the block
+        with_user = user_header + after_first + user_footer
+        result = _splice_taosmd_block(with_user, rules_v2)
+        assert "User stuff." in result
+        assert "User footer." in result
+        assert rules_v1 not in result
+        assert rules_v2 in result
+        assert result.count(self.BEGIN) == 1
+
+
+class TestOpenClawSpliceDeploy:
+    """Integration-level tests for sentinel-aware AGENTS.md push via deploy_agent."""
+
+    @pytest.mark.asyncio
+    async def test_existing_file_with_sentinels_preserves_user_content(self, tmp_path):
+        """When the container already has AGENTS.md with sentinels, user content
+        outside the block is kept and only the taosmd block is updated."""
+        import types, sys
+
+        pushed: list[tuple[str, str]] = []
+        existing_file = (
+            "# Agent rules\n\nMy custom rules.\n\n"
+            "<!-- taosmd:rules-begin -->\nstale rules\n<!-- taosmd:rules-end -->\n\n"
+            "Footer content.\n"
+        )
+
+        async def fake_push_file(container, src, dst):
+            with open(src) as fh:
+                pushed.append((dst, fh.read()))
+            return 0, ""
+
+        async def mock_exec_fn(name, cmd, **kwargs):
+            cmd_str = " ".join(cmd)
+            if "hostname -I" in cmd_str:
+                return (0, "10.0.0.100")
+            if "cat" in cmd_str and "AGENTS.md" in cmd_str:
+                return (0, existing_file)
+            return (0, "ok")
+
+        fake_taosmd = types.ModuleType("taosmd")
+        fake_taosmd.agent_rules = lambda: "fresh rules for <your-agent-name>"
+
+        with patch("tinyagentos.deployer.create_container", new_callable=AsyncMock) as mock_create, \
+             patch("tinyagentos.deployer.exec_in_container", side_effect=mock_exec_fn), \
+             patch("tinyagentos.deployer.push_file", side_effect=fake_push_file), \
+             patch("tinyagentos.deployer.add_proxy_device", new_callable=AsyncMock, return_value={"success": True, "output": ""}), \
+             patch("tinyagentos.deployer.is_image_present", new_callable=AsyncMock, return_value=False):
+            mock_create.return_value = {"success": True, "name": "taos-agent-splice-test"}
+            sys.modules["taosmd"] = fake_taosmd
+            try:
+                req = _req(name="splice-test", framework="openclaw", data_dir=tmp_path)
+                result = await deploy_agent(req)
+            finally:
+                sys.modules.pop("taosmd", None)
+
+        assert result["success"] is True
+        agents_pushed = [(dst, c) for dst, c in pushed if dst == "/root/.openclaw/AGENTS.md"]
+        assert agents_pushed
+        content = agents_pushed[0][1]
+        assert "My custom rules." in content
+        assert "Footer content." in content
+        assert "stale rules" not in content
+        assert "fresh rules for splice-test" in content
+
+    @pytest.mark.asyncio
+    async def test_existing_file_without_sentinels_preserves_and_appends(self, tmp_path):
+        """When the container AGENTS.md has no sentinels (user template), we
+        append the block at the end without touching user content."""
+        import types, sys
+
+        pushed: list[tuple[str, str]] = []
+        existing_file = "# My handcrafted template\n\nDo not overwrite me.\n"
+
+        async def fake_push_file(container, src, dst):
+            with open(src) as fh:
+                pushed.append((dst, fh.read()))
+            return 0, ""
+
+        async def mock_exec_fn(name, cmd, **kwargs):
+            cmd_str = " ".join(cmd)
+            if "hostname -I" in cmd_str:
+                return (0, "10.0.0.101")
+            if "cat" in cmd_str and "AGENTS.md" in cmd_str:
+                return (0, existing_file)
+            return (0, "ok")
+
+        fake_taosmd = types.ModuleType("taosmd")
+        fake_taosmd.agent_rules = lambda: "appended rules <your-agent-name>"
+
+        with patch("tinyagentos.deployer.create_container", new_callable=AsyncMock) as mock_create, \
+             patch("tinyagentos.deployer.exec_in_container", side_effect=mock_exec_fn), \
+             patch("tinyagentos.deployer.push_file", side_effect=fake_push_file), \
+             patch("tinyagentos.deployer.add_proxy_device", new_callable=AsyncMock, return_value={"success": True, "output": ""}), \
+             patch("tinyagentos.deployer.is_image_present", new_callable=AsyncMock, return_value=False):
+            mock_create.return_value = {"success": True, "name": "taos-agent-append-test"}
+            sys.modules["taosmd"] = fake_taosmd
+            try:
+                req = _req(name="append-test", framework="openclaw", data_dir=tmp_path)
+                result = await deploy_agent(req)
+            finally:
+                sys.modules.pop("taosmd", None)
+
+        assert result["success"] is True
+        agents_pushed = [(dst, c) for dst, c in pushed if dst == "/root/.openclaw/AGENTS.md"]
+        assert agents_pushed
+        content = agents_pushed[0][1]
+        assert "Do not overwrite me." in content
+        assert "appended rules append-test" in content
+        assert content.index("Do not overwrite me.") < content.index("<!-- taosmd:rules-begin -->")
 
 
 class TestBackgroundDeploy:

--- a/tests/test_deployer.py
+++ b/tests/test_deployer.py
@@ -467,7 +467,12 @@ class TestDeployAgent:
             mock_push.return_value = (0, "")
             result = await deploy_agent(req)
             assert result["success"] is True
-            mock_push.assert_called_once()
+            # At least one push_file call must be for the install script
+            install_pushes = [
+                c for c in mock_push.call_args_list
+                if c.args[2] == "/tmp/install.sh"
+            ]
+            assert install_pushes, "install.sh was not pushed"
             assert any("bash /tmp/install.sh" in c for c in recorded_execs)
 
     @pytest.mark.asyncio
@@ -608,6 +613,55 @@ class TestDeployAgent:
             env = mock_create.call_args.kwargs["env"]
             assert "TAOS_BASE_IMAGE_PRESENT" not in env
             assert "deps_installed" in result["steps"]
+
+    @pytest.mark.asyncio
+    async def test_openclaw_deploy_pushes_agents_md_with_taosmd_rules(self, tmp_path):
+        """When framework=openclaw, deploy pushes AGENTS.md containing taosmd
+        agent_rules with the agent's name substituted in."""
+        pushed: list[tuple[str, str]] = []
+
+        async def fake_push_file(container, src, dst):
+            try:
+                with open(src) as fh:
+                    pushed.append((dst, fh.read()))
+            except FileNotFoundError:
+                # tmp file already unlinked — content capture not needed for error path
+                pushed.append((dst, ""))
+            return 0, ""
+
+        async def mock_exec_fn(name, cmd, **kwargs):
+            if "hostname -I" in " ".join(cmd):
+                return (0, "10.0.0.99")
+            return (0, "ok")
+
+        fake_rules = "Follow the taosmd librarian protocol.\nAgent: <your-agent-name>"
+
+        with patch("tinyagentos.deployer.create_container", new_callable=AsyncMock) as mock_create, \
+             patch("tinyagentos.deployer.exec_in_container", side_effect=mock_exec_fn), \
+             patch("tinyagentos.deployer.push_file", side_effect=fake_push_file), \
+             patch("tinyagentos.deployer.add_proxy_device", new_callable=AsyncMock, return_value={"success": True, "output": ""}), \
+             patch("tinyagentos.deployer.is_image_present", new_callable=AsyncMock, return_value=False):
+            mock_create.return_value = {"success": True, "name": "taos-agent-octest"}
+
+            import types
+            fake_taosmd = types.ModuleType("taosmd")
+            fake_taosmd.agent_rules = lambda: fake_rules
+
+            import sys
+            sys.modules["taosmd"] = fake_taosmd
+            try:
+                req = _req(name="octest", framework="openclaw", data_dir=tmp_path)
+                result = await deploy_agent(req)
+            finally:
+                sys.modules.pop("taosmd", None)
+
+        assert result["success"] is True
+        agents_md_entries = [(dst, content) for dst, content in pushed if dst == "/root/.openclaw/AGENTS.md"]
+        assert agents_md_entries, "AGENTS.md was not pushed to /root/.openclaw/AGENTS.md"
+        _dst, content = agents_md_entries[0]
+        assert "octest" in content, "agent slug not substituted in AGENTS.md"
+        assert "librarian" in content, "expected taosmd rules phrase in AGENTS.md"
+        assert "<your-agent-name>" not in content, "placeholder not replaced"
 
     @pytest.mark.asyncio
     async def test_bridge_url_injected_into_env(self, tmp_path):

--- a/tinyagentos/deployer.py
+++ b/tinyagentos/deployer.py
@@ -328,6 +328,39 @@ async def deploy_agent(req: DeployRequest) -> dict:
 
             steps.append("framework_installed")
 
+        # OpenClaw: inject taosmd agent rules into AGENTS.md so the framework
+        # picks them up on every turn (per taosmd contract — see issue #378).
+        # Non-fatal: the runtime system-prompt prepend in prompt_assembly.py
+        # remains as a backstop until all frameworks are wired.
+        if req.framework == "openclaw":
+            try:
+                import taosmd as _taosmd
+                _agent_rules_fn = getattr(_taosmd, "agent_rules", None)
+                if callable(_agent_rules_fn):
+                    _rules = _agent_rules_fn().replace("<your-agent-name>", req.name)
+                    import tempfile
+                    import os as _os
+                    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as _tf:
+                        _tf.write(_rules)
+                        _tmp_path = _tf.name
+                    _agents_md_path = "/root/.openclaw/AGENTS.md"
+                    _push_rc, _push_out = await push_file(container_name, _tmp_path, _agents_md_path)
+                    _os.unlink(_tmp_path)
+                    if _push_rc != 0:
+                        logger.warning(
+                            "openclaw: failed to push AGENTS.md (rc=%s): %s",
+                            _push_rc, _push_out[-200:],
+                        )
+                    else:
+                        logger.info(
+                            "openclaw: pushed AGENTS.md (taosmd rules) to %s",
+                            _agents_md_path,
+                        )
+            except ImportError:
+                logger.warning("openclaw: taosmd not installed — skipping AGENTS.md injection")
+            except Exception:
+                logger.exception("openclaw: AGENTS.md injection failed")
+
         # Step 5: Get container IP
         code, output = await exec_in_container(container_name, ["hostname", "-I"])
         container_ip = output.strip().split()[0] if code == 0 and output.strip() else None

--- a/tinyagentos/deployer.py
+++ b/tinyagentos/deployer.py
@@ -28,6 +28,33 @@ from tinyagentos.containers import (
 
 logger = logging.getLogger(__name__)
 
+_TAOSMD_BEGIN = "<!-- taosmd:rules-begin -->"
+_TAOSMD_END = "<!-- taosmd:rules-end -->"
+
+
+def _splice_taosmd_block(existing: str, new_rules: str) -> str:
+    """Insert or replace the taosmd-rules sentinel block in *existing*,
+    preserving any user content outside the sentinels.
+
+    Sentinels are HTML comments so they're invisible in rendered Markdown
+    but trivial to find in raw text.  The pattern follows tools like
+    pre-commit, direnv and nvm that manage a section inside user-editable
+    files without silently blowing away the rest.
+
+    Three cases:
+      1. Sentinels present  → replace only the content between them.
+      2. File empty/absent  → return only the sentinel-wrapped block.
+      3. File exists, no sentinels → append block with a blank separator.
+    """
+    block = f"{_TAOSMD_BEGIN}\n{new_rules.rstrip()}\n{_TAOSMD_END}"
+    if _TAOSMD_BEGIN in existing and _TAOSMD_END in existing:
+        before, _, rest = existing.partition(_TAOSMD_BEGIN)
+        _, _, after = rest.partition(_TAOSMD_END)
+        return f"{before}{block}{after}"
+    if not existing.strip():
+        return block + "\n"
+    return existing.rstrip() + "\n\n" + block + "\n"
+
 
 @dataclass
 class DeployRequest:
@@ -332,6 +359,11 @@ async def deploy_agent(req: DeployRequest) -> dict:
         # picks them up on every turn (per taosmd contract — see issue #378).
         # Non-fatal: the runtime system-prompt prepend in prompt_assembly.py
         # remains as a backstop until all frameworks are wired.
+        #
+        # Sentinel-aware write: we wrap the taosmd block between HTML comment
+        # sentinels so it never conflicts with a user-supplied template.  If
+        # the file already exists (from the Store or hand-crafted), we splice
+        # only our block in; everything outside the sentinels is preserved.
         if req.framework == "openclaw":
             try:
                 import taosmd as _taosmd
@@ -340,10 +372,16 @@ async def deploy_agent(req: DeployRequest) -> dict:
                     _rules = _agent_rules_fn().replace("<your-agent-name>", req.name)
                     import tempfile
                     import os as _os
-                    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as _tf:
-                        _tf.write(_rules)
-                        _tmp_path = _tf.name
                     _agents_md_path = "/root/.openclaw/AGENTS.md"
+                    # Read existing file from the container; treat any error as absent.
+                    _read_rc, _existing = await exec_in_container(
+                        container_name, ["cat", _agents_md_path]
+                    )
+                    _existing_content = _existing if _read_rc == 0 else ""
+                    _new_content = _splice_taosmd_block(_existing_content, _rules)
+                    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as _tf:
+                        _tf.write(_new_content)
+                        _tmp_path = _tf.name
                     _push_rc, _push_out = await push_file(container_name, _tmp_path, _agents_md_path)
                     _os.unlink(_tmp_path)
                     if _push_rc != 0:


### PR DESCRIPTION
## Summary

Per the taosmd contract, `agent_rules()` must land in the framework's instruction file (AGENTS.md, CLAUDE.md, etc.) at deploy time — not in the runtime system prompt. This PR wires that for OpenClaw.

- After the framework install step succeeds, the deployer calls `taosmd.agent_rules()`, substitutes the agent's slug for `<your-agent-name>`, and pushes the result to `/root/.openclaw/AGENTS.md` inside the container via `push_file`.
- Failure is non-fatal: a warning is logged and the runtime system-prompt prepend in `prompt_assembly.py` stays as a backstop until all frameworks are wired.
- `test_manifest_script_install` assertion updated: now checks that the install script push occurred (rather than asserting exactly one `push_file` call), since openclaw deploys now make a second call for AGENTS.md.

## Per-framework status (closes part of #378)

- ✅ OpenClaw — file injection wired in this PR (writes to `/root/.openclaw/AGENTS.md`)
- ⏭️ Hermes — keep runtime prompt-prepend (Hermes is an LLM API proxy, not an instruction-file framework)
- 🔲 IronClaw, MicroClaw, NanoClaw, MoltisClaw — follow same pattern as OpenClaw
- 🔲 AgentZero, Langroid — framework-specific instruction file path to be identified
- 🔲 Once all frameworks injected, remove runtime prepend in `prompt_assembly.py:62`

## Test plan

- [ ] `PYTHONPATH=. pytest tests/test_deployer.py -v` — 31 passed
- [ ] `test_openclaw_deploy_pushes_agents_md_with_taosmd_rules` asserts: path is `/root/.openclaw/AGENTS.md`, slug is substituted, placeholder is gone