### PR TITLE
fix(install): Debian Incus + admin init + LiteLLM (#381 #382 #383)

### DIFF
--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -375,14 +375,36 @@ ensure_container_runtime() {
         return 0
     fi
 
-    log "no container runtime found — attempting to install Incus"
+    log "no container runtime found — installing Incus via Zabbly apt repo"
 
     local installed=0
     if command -v apt-get >/dev/null 2>&1; then
-        log "installing incus via apt"
-        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq incus \
-            && installed=1 \
-            || warn "apt install incus failed — continuing without container support"
+        # Incus is not in default Debian 12 / Ubuntu 22.04 repos — use Zabbly's
+        # stable apt repo which provides it on every supported Debian/Ubuntu release.
+        local codename=""
+        if command -v lsb_release >/dev/null 2>&1; then
+            codename=$(lsb_release -cs 2>/dev/null)
+        elif [[ -f /etc/os-release ]]; then
+            codename=$(. /etc/os-release && echo "${VERSION_CODENAME:-}")
+        fi
+
+        if [[ -z "$codename" ]]; then
+            warn "couldn't detect distro codename — Zabbly repo install skipped"
+            warn "  install Incus manually: https://github.com/zabbly/incus"
+        else
+            sudo install -d -m 0755 /etc/apt/keyrings
+            sudo curl -fsSL https://pkgs.zabbly.com/key.asc -o /etc/apt/keyrings/zabbly.asc \
+                || { warn "failed to fetch Zabbly key — skipping Incus install"; return 0; }
+            echo "deb [signed-by=/etc/apt/keyrings/zabbly.asc] https://pkgs.zabbly.com/incus/stable $codename main" \
+                | sudo tee /etc/apt/sources.list.d/zabbly-incus-stable.list > /dev/null
+            sudo DEBIAN_FRONTEND=noninteractive apt-get update -qq
+            if sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq incus; then
+                installed=1
+                log "container runtime: incus installed via Zabbly"
+            else
+                warn "Zabbly Incus install failed — see /var/log/apt/term.log"
+            fi
+        fi
     elif command -v dnf >/dev/null 2>&1; then
         log "installing incus via dnf"
         sudo dnf install -y -q incus \
@@ -407,6 +429,16 @@ ensure_container_runtime() {
             log "container runtime: incus installed successfully"
         else
             warn "incus install reported success but binary not found on PATH — check your PATH"
+        fi
+    fi
+
+    if (( installed )) && command -v incus >/dev/null 2>&1; then
+        log "initialising Incus with default storage + network"
+        if sudo incus admin init --auto >/dev/null 2>&1; then
+            log "container runtime: incus initialised"
+        else
+            warn "incus admin init --auto failed — you may need to configure storage manually"
+            warn "  see: https://linuxcontainers.org/incus/docs/main/howto/initialize/"
         fi
     fi
 }
@@ -442,9 +474,9 @@ if [[ ! -d .venv ]]; then
     fi
 fi
 
-log "installing controller python deps into .venv (pip install -e .)"
+log "installing controller python deps into .venv (pip install -e '.[proxy]')"
 ./.venv/bin/pip install --quiet --upgrade pip
-./.venv/bin/pip install --quiet -e .
+./.venv/bin/pip install --quiet -e ".[proxy]"
 
 # yt-dlp is needed for YouTube and X content ingestion (runs as subprocess)
 if ! command -v yt-dlp &>/dev/null; then


### PR DESCRIPTION
Surfaced by an end-to-end install test in a fresh Debian 12 LXC. Three gaps under the install-must-just-work bar (#370).

## Changes

**Fix 1 — Zabbly Incus repo for Debian/Ubuntu (#381)**

`incus` is absent from default repos on Debian 12 bookworm and Ubuntu 22.04 LTS. The previous `apt install -y -qq incus` failed silently (the `-q` + `|| warn` path), leaving taOS with no container backend and the user with no clue why. Now we detect the distro codename, add the Zabbly signed apt repo (`pkgs.zabbly.com/incus/stable`), and install from there — covering every supported Debian/Ubuntu release.

**Fix 2 — `incus admin init --auto` after install (#383)**

A freshly installed Incus daemon has no default storage pool or network; `incus launch` immediately fails with "No root device could be found". We now run `incus admin init --auto` immediately after install. The call is idempotent and gated on `command -v incus`, so re-running the installer is safe.

**Fix 3 — LiteLLM auto-install (#382)**

Fresh installs logged `LiteLLM not installed — proxy disabled` at startup because the install step was `pip install -e .` (core deps only). `pyproject.toml` already has a `proxy` optional-dep group containing `litellm[proxy]>=1.50.0`. Changed to `pip install -e ".[proxy]"` — no `pyproject.toml` changes needed.

## Files touched

- `scripts/install-server.sh`

## Test

`bash -n scripts/install-server.sh` passes (syntax clean).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced container runtime installation to use Zabbly's Incus stable repository for improved reliability on Debian/Ubuntu systems.
  * Added automatic Incus initialization with default storage and network configuration during installation.
  * Updated controller dependency installation to include enhanced proxy support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->