### PR TITLE
feat(hermes): AGENTS.md injection — extends OpenClaw pattern from #380

### DIFF
--- a/tests/test_deployer.py
+++ b/tests/test_deployer.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from tinyagentos.deployer import deploy_agent, undeploy_agent, DeployRequest, _splice_taosmd_block
+from tinyagentos.deployer import deploy_agent, undeploy_agent, DeployRequest, _splice_taosmd_block, AGENTS_MD_PATHS
 
 
 def _req(**overrides) -> DeployRequest:
@@ -667,6 +667,88 @@ class TestDeployAgent:
         assert "<your-agent-name>" not in content, "placeholder not replaced"
         assert "<!-- taosmd:rules-begin -->" in content, "missing begin sentinel"
         assert "<!-- taosmd:rules-end -->" in content, "missing end sentinel"
+
+    @pytest.mark.asyncio
+    async def test_hermes_deploy_pushes_agents_md_with_taosmd_rules(self, tmp_path):
+        """When framework=hermes and no existing AGENTS.md, deploy pushes a
+        sentinel-wrapped file to /root/.hermes/AGENTS.md with taosmd agent_rules
+        and the agent name substituted."""
+        pushed: list[tuple[str, str]] = []
+
+        async def fake_push_file(container, src, dst):
+            try:
+                with open(src) as fh:
+                    pushed.append((dst, fh.read()))
+            except FileNotFoundError:
+                pushed.append((dst, ""))
+            return 0, ""
+
+        async def mock_exec_fn(name, cmd, **kwargs):
+            cmd_str = " ".join(cmd)
+            if "hostname -I" in cmd_str:
+                return (0, "10.0.0.98")
+            if "cat" in cmd_str and "AGENTS.md" in cmd_str:
+                return (1, "")
+            return (0, "ok")
+
+        fake_rules = "Hermes agent protocol.\nAgent: <your-agent-name>"
+
+        with patch("tinyagentos.deployer.create_container", new_callable=AsyncMock) as mock_create, \
+             patch("tinyagentos.deployer.exec_in_container", side_effect=mock_exec_fn), \
+             patch("tinyagentos.deployer.push_file", side_effect=fake_push_file), \
+             patch("tinyagentos.deployer.add_proxy_device", new_callable=AsyncMock, return_value={"success": True, "output": ""}), \
+             patch("tinyagentos.deployer.is_image_present", new_callable=AsyncMock, return_value=False):
+            mock_create.return_value = {"success": True, "name": "taos-agent-hermestest"}
+
+            import types
+            fake_taosmd = types.ModuleType("taosmd")
+            fake_taosmd.agent_rules = lambda: fake_rules
+
+            import sys
+            sys.modules["taosmd"] = fake_taosmd
+            try:
+                req = _req(name="hermestest", framework="hermes", data_dir=tmp_path)
+                result = await deploy_agent(req)
+            finally:
+                sys.modules.pop("taosmd", None)
+
+        assert result["success"] is True
+        agents_md_entries = [(dst, content) for dst, content in pushed if dst == "/root/.hermes/AGENTS.md"]
+        assert agents_md_entries, "AGENTS.md was not pushed to /root/.hermes/AGENTS.md"
+        _dst, content = agents_md_entries[0]
+        assert "hermestest" in content, "agent slug not substituted in AGENTS.md"
+        assert "Hermes agent protocol" in content, "expected taosmd rules phrase in AGENTS.md"
+        assert "<your-agent-name>" not in content, "placeholder not replaced"
+        assert "<!-- taosmd:rules-begin -->" in content, "missing begin sentinel"
+        assert "<!-- taosmd:rules-end -->" in content, "missing end sentinel"
+
+    @pytest.mark.asyncio
+    async def test_unknown_framework_does_not_push_agents_md(self, tmp_path):
+        """A framework not in AGENTS_MD_PATHS must not trigger AGENTS.md injection."""
+        pushed_dsts: list[str] = []
+
+        async def fake_push_file(container, src, dst):
+            pushed_dsts.append(dst)
+            return 0, ""
+
+        async def mock_exec_fn(name, cmd, **kwargs):
+            cmd_str = " ".join(cmd)
+            if "hostname -I" in cmd_str:
+                return (0, "10.0.0.97")
+            return (0, "ok")
+
+        with patch("tinyagentos.deployer.create_container", new_callable=AsyncMock) as mock_create, \
+             patch("tinyagentos.deployer.exec_in_container", side_effect=mock_exec_fn), \
+             patch("tinyagentos.deployer.push_file", side_effect=fake_push_file), \
+             patch("tinyagentos.deployer.add_proxy_device", new_callable=AsyncMock, return_value={"success": True, "output": ""}):
+            mock_create.return_value = {"success": True, "name": "taos-agent-unknown-fw"}
+            req = _req(name="unknown-fw", framework="hermes_typo", data_dir=tmp_path)
+            result = await deploy_agent(req)
+
+        assert result["success"] is True
+        assert "hermes_typo" not in AGENTS_MD_PATHS
+        agents_md_pushes = [d for d in pushed_dsts if "AGENTS.md" in d]
+        assert not agents_md_pushes, f"AGENTS.md should not be pushed for unknown framework, got: {agents_md_pushes}"
 
     @pytest.mark.asyncio
     async def test_bridge_url_injected_into_env(self, tmp_path):

--- a/tinyagentos/deployer.py
+++ b/tinyagentos/deployer.py
@@ -31,6 +31,14 @@ logger = logging.getLogger(__name__)
 _TAOSMD_BEGIN = "<!-- taosmd:rules-begin -->"
 _TAOSMD_END = "<!-- taosmd:rules-end -->"
 
+# Per-framework AGENTS.md path inside the agent's container.
+# Frameworks read this file on every turn to pick up agent rules
+# (per the taosmd contract — see issue #378).
+AGENTS_MD_PATHS: dict[str, str] = {
+    "openclaw": "/root/.openclaw/AGENTS.md",
+    "hermes": "/root/.hermes/AGENTS.md",
+}
+
 
 def _splice_taosmd_block(existing: str, new_rules: str) -> str:
     """Insert or replace the taosmd-rules sentinel block in *existing*,
@@ -355,16 +363,17 @@ async def deploy_agent(req: DeployRequest) -> dict:
 
             steps.append("framework_installed")
 
-        # OpenClaw: inject taosmd agent rules into AGENTS.md so the framework
-        # picks them up on every turn (per taosmd contract — see issue #378).
-        # Non-fatal: the runtime system-prompt prepend in prompt_assembly.py
-        # remains as a backstop until all frameworks are wired.
+        # Inject taosmd agent rules into AGENTS.md for supported frameworks so
+        # the framework picks them up on every turn (per taosmd contract —
+        # see issue #378).  Non-fatal: the runtime system-prompt prepend in
+        # prompt_assembly.py remains as a backstop until all frameworks are wired.
         #
         # Sentinel-aware write: we wrap the taosmd block between HTML comment
         # sentinels so it never conflicts with a user-supplied template.  If
         # the file already exists (from the Store or hand-crafted), we splice
         # only our block in; everything outside the sentinels is preserved.
-        if req.framework == "openclaw":
+        if req.framework in AGENTS_MD_PATHS:
+            target_path = AGENTS_MD_PATHS[req.framework]
             try:
                 import taosmd as _taosmd
                 _agent_rules_fn = getattr(_taosmd, "agent_rules", None)
@@ -372,32 +381,31 @@ async def deploy_agent(req: DeployRequest) -> dict:
                     _rules = _agent_rules_fn().replace("<your-agent-name>", req.name)
                     import tempfile
                     import os as _os
-                    _agents_md_path = "/root/.openclaw/AGENTS.md"
                     # Read existing file from the container; treat any error as absent.
                     _read_rc, _existing = await exec_in_container(
-                        container_name, ["cat", _agents_md_path]
+                        container_name, ["cat", target_path]
                     )
                     _existing_content = _existing if _read_rc == 0 else ""
                     _new_content = _splice_taosmd_block(_existing_content, _rules)
                     with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as _tf:
                         _tf.write(_new_content)
                         _tmp_path = _tf.name
-                    _push_rc, _push_out = await push_file(container_name, _tmp_path, _agents_md_path)
+                    _push_rc, _push_out = await push_file(container_name, _tmp_path, target_path)
                     _os.unlink(_tmp_path)
                     if _push_rc != 0:
                         logger.warning(
-                            "openclaw: failed to push AGENTS.md (rc=%s): %s",
-                            _push_rc, _push_out[-200:],
+                            "%s: failed to push AGENTS.md (rc=%s): %s",
+                            req.framework, _push_rc, _push_out[-200:],
                         )
                     else:
                         logger.info(
-                            "openclaw: pushed AGENTS.md (taosmd rules) to %s",
-                            _agents_md_path,
+                            "%s: pushed AGENTS.md (taosmd rules) to %s",
+                            req.framework, target_path,
                         )
             except ImportError:
-                logger.warning("openclaw: taosmd not installed — skipping AGENTS.md injection")
+                logger.warning("%s: taosmd not installed — skipping AGENTS.md injection", req.framework)
             except Exception:
-                logger.exception("openclaw: AGENTS.md injection failed")
+                logger.exception("%s: AGENTS.md injection failed", req.framework)
 
         # Step 5: Get container IP
         code, output = await exec_in_container(container_name, ["hostname", "-I"])


### PR DESCRIPTION
## Summary

- Extracts a `AGENTS_MD_PATHS` dict (module-level constant in `deployer.py`) mapping framework names to their per-container AGENTS.md path
- Changes the injection guard from `if req.framework == "openclaw":` to `if req.framework in AGENTS_MD_PATHS:`, with `target_path` substituted throughout
- Adds `hermes` at `/root/.hermes/AGENTS.md` — best-guess from Hermes convention of reading config from `~/.hermes/`; update the dict entry if testing reveals a different path
- Log messages now include `req.framework` instead of hardcoded `"openclaw"`

## Tests

- `test_openclaw_deploy_pushes_agents_md_with_taosmd_rules` — unchanged, still passes
- `test_hermes_deploy_pushes_agents_md_with_taosmd_rules` — parallel test: framework=hermes, asserts push to `/root/.hermes/AGENTS.md`, sentinels present, slug substituted
- `test_unknown_framework_does_not_push_agents_md` — confirms framework not in `AGENTS_MD_PATHS` (e.g. `hermes_typo`) does not trigger any AGENTS.md push

All 39 tests pass.

## Note on Hermes path

`/root/.hermes/AGENTS.md` mirrors the shape of OpenClaw's `/root/.openclaw/AGENTS.md`. If live testing shows Hermes reads from a different location (working dir, home root, etc.), update the `AGENTS_MD_PATHS` entry — no other code needs to change.

Closes part of #378.