### PR TITLE
fix(install): Postgres for LiteLLM virtual keys + openai-compatible cloud type + skip /key/generate without DB

### DIFF
--- a/desktop/src/lib/models.ts
+++ b/desktop/src/lib/models.ts
@@ -116,7 +116,7 @@ export interface CloudProvider {
   models?: { id?: string; name?: string }[];
 }
 
-export const CLOUD_PROVIDER_TYPES = ["openai", "anthropic", "openrouter", "kilocode"] as const;
+export const CLOUD_PROVIDER_TYPES = ["openai", "anthropic", "openrouter", "kilocode", "openai-compatible"] as const;
 
 /** Flatten /api/providers cloud providers into AggregatedModel entries. */
 export function cloudProvidersToAggregated(providers: CloudProvider[]): AggregatedModel[] {

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -543,6 +543,14 @@ ensure_litellm_postgres() {
         elif command -v pacman >/dev/null 2>&1; then
             sudo pacman -S --noconfirm postgresql \
                 || { warn "pacman -S postgresql failed — skipping virtual key setup"; return 0; }
+            # Arch ships postgresql binaries without an initialised data
+            # directory; systemd refuses to start until initdb has run.
+            if [[ ! -d /var/lib/postgres/data/base ]]; then
+                sudo mkdir -p /var/lib/postgres/data
+                sudo chown postgres:postgres /var/lib/postgres/data
+                sudo -u postgres initdb --locale=C.UTF-8 --encoding=UTF8 \
+                    -D /var/lib/postgres/data >/dev/null 2>&1 || true
+            fi
         else
             warn "litellm postgres: unrecognised package manager — install postgresql manually then re-run"
             return 0
@@ -567,21 +575,32 @@ ensure_litellm_postgres() {
         return 0
     fi
 
+    # Pipe the password via stdin instead of -c "...PASSWORD '...'" so it
+    # never appears in /proc/<pid>/cmdline. Quoting nuance: psql's :'var'
+    # interpolation produces a properly-escaped SQL string literal.
+    local role_sql
     if ! sudo -u postgres psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='litellm'" 2>/dev/null | grep -q 1; then
-        sudo -u postgres psql -c "CREATE ROLE litellm WITH LOGIN PASSWORD '${pw}';" >/dev/null \
-            || { warn "litellm postgres: CREATE ROLE failed — skipping"; return 0; }
+        role_sql="CREATE ROLE litellm WITH LOGIN PASSWORD :'pw';"
     else
-        sudo -u postgres psql -c "ALTER ROLE litellm WITH LOGIN PASSWORD '${pw}';" >/dev/null \
-            || { warn "litellm postgres: ALTER ROLE failed — skipping"; return 0; }
+        role_sql="ALTER ROLE litellm WITH LOGIN PASSWORD :'pw';"
+    fi
+    if ! printf '%s\n' "$role_sql" \
+            | sudo -u postgres psql -v ON_ERROR_STOP=1 -v "pw=${pw}" >/dev/null 2>&1; then
+        warn "litellm postgres: role create/alter failed — skipping"
+        return 0
     fi
 
     if ! sudo -u postgres psql -tAc "SELECT 1 FROM pg_database WHERE datname='litellm'" 2>/dev/null | grep -q 1; then
-        sudo -u postgres psql -c "CREATE DATABASE litellm OWNER litellm;" >/dev/null \
+        printf 'CREATE DATABASE litellm OWNER litellm;\n' \
+            | sudo -u postgres psql -v ON_ERROR_STOP=1 >/dev/null 2>&1 \
             || { warn "litellm postgres: CREATE DATABASE failed — skipping"; return 0; }
     fi
 
-    umask 077
-    printf 'postgresql://litellm:%s@127.0.0.1:5432/litellm\n' "$pw" > data/.litellm_db_url
+    # Subshell scopes umask so we don't leak 077 into the rest of the
+    # install script (the SPA build below relies on the calling shell's
+    # default umask for npm-managed files). chmod is belt-and-braces.
+    ( umask 077 && \
+        printf 'postgresql://litellm:%s@127.0.0.1:5432/litellm\n' "$pw" > data/.litellm_db_url )
     chmod 600 data/.litellm_db_url
     log "litellm postgres: data/.litellm_db_url written — virtual keys enabled"
 }

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -504,6 +504,90 @@ if [[ -f data/config.yaml.example && ! -f data/config.yaml ]]; then
     cp data/config.yaml.example data/config.yaml
 fi
 
+# --- LiteLLM virtual-key store (Postgres) --------------------------------
+#
+# LiteLLM uses a Postgres-backed key store to mint per-agent virtual keys
+# via /key/generate. Without it, agent deploys log a "DB not connected"
+# error and fall back to a shared master key (functional, but every agent
+# in this controller authenticates as the same identity). We install a
+# small local Postgres and write data/.litellm_db_url so the controller
+# picks it up on next start. Idempotent: re-runs leave the existing URL
+# in place — bumping the password would invalidate any keys already
+# minted against it.
+
+ensure_litellm_postgres() {
+    if [[ -f data/.litellm_db_url && -s data/.litellm_db_url ]]; then
+        log "litellm postgres: data/.litellm_db_url present — skipping setup"
+        return 0
+    fi
+
+    if ! command -v sudo >/dev/null 2>&1 && [[ "$(id -u)" != "0" ]]; then
+        warn "litellm postgres: sudo not available and not running as root — skipping"
+        warn "  per-agent virtual keys will not work; deployer will use the shared master key"
+        return 0
+    fi
+
+    if ! command -v psql >/dev/null 2>&1; then
+        log "installing postgresql for LiteLLM virtual keys"
+        if command -v apt-get >/dev/null 2>&1; then
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq postgresql \
+                || { warn "apt install postgresql failed — skipping virtual key setup"; return 0; }
+        elif command -v dnf >/dev/null 2>&1; then
+            sudo dnf install -y -q postgresql postgresql-server \
+                || { warn "dnf install postgresql failed — skipping virtual key setup"; return 0; }
+            # Fedora/RHEL ship Postgres uninitialised — set up the data
+            # cluster before systemd can start it.
+            if [[ ! -d /var/lib/pgsql/data/base ]]; then
+                sudo postgresql-setup --initdb >/dev/null 2>&1 || true
+            fi
+        elif command -v pacman >/dev/null 2>&1; then
+            sudo pacman -S --noconfirm postgresql \
+                || { warn "pacman -S postgresql failed — skipping virtual key setup"; return 0; }
+        else
+            warn "litellm postgres: unrecognised package manager — install postgresql manually then re-run"
+            return 0
+        fi
+    fi
+
+    if command -v systemctl >/dev/null 2>&1; then
+        sudo systemctl enable --now postgresql >/dev/null 2>&1 \
+            || { warn "litellm postgres: could not start postgresql service — skipping"; return 0; }
+    fi
+
+    # Wait for Postgres to accept connections (cold start can take a few seconds).
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
+        sudo -u postgres psql -tAc 'SELECT 1' >/dev/null 2>&1 && break
+        sleep 1
+    done
+
+    local pw
+    pw=$(openssl rand -hex 24 2>/dev/null || head -c 32 /dev/urandom | base64 | tr -dc 'A-Za-z0-9' | head -c 32)
+    if [[ -z "$pw" ]]; then
+        warn "litellm postgres: could not generate password — skipping"
+        return 0
+    fi
+
+    if ! sudo -u postgres psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='litellm'" 2>/dev/null | grep -q 1; then
+        sudo -u postgres psql -c "CREATE ROLE litellm WITH LOGIN PASSWORD '${pw}';" >/dev/null \
+            || { warn "litellm postgres: CREATE ROLE failed — skipping"; return 0; }
+    else
+        sudo -u postgres psql -c "ALTER ROLE litellm WITH LOGIN PASSWORD '${pw}';" >/dev/null \
+            || { warn "litellm postgres: ALTER ROLE failed — skipping"; return 0; }
+    fi
+
+    if ! sudo -u postgres psql -tAc "SELECT 1 FROM pg_database WHERE datname='litellm'" 2>/dev/null | grep -q 1; then
+        sudo -u postgres psql -c "CREATE DATABASE litellm OWNER litellm;" >/dev/null \
+            || { warn "litellm postgres: CREATE DATABASE failed — skipping"; return 0; }
+    fi
+
+    umask 077
+    printf 'postgresql://litellm:%s@127.0.0.1:5432/litellm\n' "$pw" > data/.litellm_db_url
+    chmod 600 data/.litellm_db_url
+    log "litellm postgres: data/.litellm_db_url written — virtual keys enabled"
+}
+
+ensure_litellm_postgres
+
 # --- desktop SPA bundle --------------------------------------------------
 # Build the frontend unconditionally on every install / upgrade. The bundle
 # is not committed to git (static/desktop/ is gitignored) so this is the

--- a/tests/test_llm_proxy.py
+++ b/tests/test_llm_proxy.py
@@ -418,7 +418,10 @@ class TestLLMProxyOwnership:
 
         monkeypatch.setattr(mod.httpx, "AsyncClient", _FakeClient)
 
-        p = mod.LLMProxy(port=4000)
+        # database_url required so create_agent_key actually hits the
+        # endpoint — without it the routing-only short-circuit returns
+        # None before any HTTP call.
+        p = mod.LLMProxy(port=4000, database_url="postgres://x:y@h/litellm")
 
         # Bypass is_running(): pretend we own a live subprocess.
         class _FakeProc:
@@ -433,3 +436,33 @@ class TestLLMProxyOwnership:
             "/key/generate" in rec.getMessage() and "401" in rec.getMessage()
             for rec in caplog.records
         ), [rec.getMessage() for rec in caplog.records]
+
+    @pytest.mark.asyncio
+    async def test_create_agent_key_skips_call_when_no_database_url(self, monkeypatch):
+        """In routing-only mode (no Postgres), create_agent_key must
+        return None without hitting /key/generate — otherwise LiteLLM
+        emits a confusing 500 'DB not connected' on every deploy."""
+        import tinyagentos.llm_proxy as mod
+
+        called = False
+
+        class _FakeClient:
+            def __init__(self, *a, **kw): pass
+            async def __aenter__(self): return self
+            async def __aexit__(self, *exc): return False
+            async def post(self, *a, **kw):
+                nonlocal called
+                called = True
+                raise AssertionError("/key/generate should not be called when database_url is None")
+
+        monkeypatch.setattr(mod.httpx, "AsyncClient", _FakeClient)
+
+        p = mod.LLMProxy(port=4000)  # no database_url
+
+        class _FakeProc:
+            def poll(self): return None
+        p._process = _FakeProc()
+
+        key = await p.create_agent_key("routing-only")
+        assert key is None
+        assert called is False

--- a/tinyagentos/llm_proxy.py
+++ b/tinyagentos/llm_proxy.py
@@ -558,6 +558,12 @@ class LLMProxy:
         """Create a per-agent virtual key via LiteLLM API."""
         if not self.is_running():
             return None
+        # LiteLLM virtual keys require a Postgres DB. Without one,
+        # /key/generate returns a 500 "DB not connected" error that looks
+        # alarming in logs even though the deployer's master-key fallback
+        # handles it fine. Skip the round-trip in routing-only mode.
+        if not self.database_url:
+            return None
         try:
             async with httpx.AsyncClient(timeout=10) as client:
                 body = {


### PR DESCRIPTION
## Summary

Three install/runtime fixes found during a clean Debian 12 LXC E2E:

- **install: Postgres for LiteLLM virtual keys.** LiteLLM is now a hard dep (PR #385 added it via the `[proxy]` extra) and uses Postgres for `/key/generate`. Without it, the deployer falls back to a shared master key for every agent — functional, but no per-agent isolation, and every deploy logs a confusing 500 `DB not connected`. Adds `ensure_litellm_postgres` to `install-server.sh`: installs postgresql via apt/dnf/pacman, creates a `litellm` role + database with a randomized password, writes a chmod-600 `data/.litellm_db_url`. Idempotent — re-runs leave the existing URL in place so we don't invalidate keys already minted.

- **frontend: `openai-compatible` cloud type missing from wizard.** Backend has it everywhere (`config.py`, `llm_proxy.py`, `routes/providers.py`); frontend's `CLOUD_PROVIDER_TYPES` was missed when PR #353 added the type. Result: users with only a custom OpenAI-compatible endpoint saw an empty Cloud bucket in the deploy wizard.

- **runtime: skip `/key/generate` when no `database_url`.** Belt-and-braces guard for installs that intentionally skip Postgres (test envs, embedded). The deployer's master-key fallback path is unchanged; this just keeps the warning out of the log.

## Test plan
- [x] `pytest tests/test_llm_proxy.py tests/test_deployer.py` — 68 passed
- [x] Updated existing 401-logging test to pass `database_url` so the path is still exercised
- [x] New test asserts `/key/generate` is not called in routing-only mode
- [x] `bash -n` clean on `install-server.sh`; idempotency proven by the early-return on `.litellm_db_url`
- [ ] Live install verification on Debian 12 LXC after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for OpenAI-compatible cloud providers to the model filtering system
  * Optional PostgreSQL database setup during initial server installation for enhanced virtual key management
  * System now gracefully handles routing-only mode without requiring database configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->