### PR TITLE
fix(store): use asdict(HardwareProfile) — every model showed as red

### DIFF
--- a/tests/routes/test_store_install_v2.py
+++ b/tests/routes/test_store_install_v2.py
@@ -263,11 +263,26 @@ class TestGetDeviceCapabilityDisk:
     """Unit tests for the free-disk probe in get_device_capability."""
 
     def _make_request(self, hw: dict, data_dir=None):
-        """Build a minimal mock request with a hardware_profile and optional data_dir."""
-        from unittest.mock import MagicMock
+        """Build a minimal mock request with a hardware_profile and optional data_dir.
 
-        hp = MagicMock()
-        hp.hardware = hw
+        ``hw`` is the same nested {ram_mb, disk, gpu, ...} shape that
+        ``asdict(HardwareProfile)`` produces — get_device_capability now
+        calls asdict() on the profile, so the fixture builds a real
+        dataclass instance from the test dict.
+        """
+        from unittest.mock import MagicMock
+        from tinyagentos.hardware import (
+            HardwareProfile, CpuInfo, NpuInfo, GpuInfo, DiskInfo, OsInfo,
+        )
+
+        hp = HardwareProfile(
+            cpu=CpuInfo(**(hw.get("cpu") or {})),
+            ram_mb=int(hw.get("ram_mb", 0) or 0),
+            npu=NpuInfo(**(hw.get("npu") or {})),
+            gpu=GpuInfo(**(hw.get("gpu") or {})),
+            disk=DiskInfo(**(hw.get("disk") or {})),
+            os=OsInfo(**(hw.get("os") or {})),
+        )
 
         state = MagicMock()
         state.hardware_profile = hp
@@ -334,3 +349,21 @@ class TestGetDeviceCapabilityDisk:
             assert cap.free_disk_mb == 0
         finally:
             _shutil_mod.disk_usage = original
+
+    @pytest.mark.asyncio
+    async def test_total_ram_and_vram_propagate_from_hardware_profile(self):
+        """Regression: get_device_capability previously read hp.hardware
+        (an attribute that doesn't exist on HardwareProfile), so
+        total_ram_mb came back as 0 and every model's min_ram_mb check
+        failed in the Store. Confirm ram_mb + vram_mb come through now."""
+        from tinyagentos.routes.store_install import get_device_capability
+
+        hw = {
+            "ram_mb": 15958,
+            "gpu": {"type": "nvidia", "vram_mb": 24576, "cuda": True},
+            "disk": {"free_gb": 100, "total_gb": 500},
+        }
+        req = self._make_request(hw)
+        cap = await get_device_capability(req, None)
+        assert cap.total_ram_mb == 15958
+        assert cap.total_vram_mb == 24576

--- a/tinyagentos/routes/cluster.py
+++ b/tinyagentos/routes/cluster.py
@@ -264,7 +264,10 @@ async def list_install_targets(request: Request):
     for display.
     """
     hp = getattr(request.app.state, "hardware_profile", None)
-    local_hw = getattr(hp, "hardware", {}) if hp else {}
+    # HardwareProfile is a flat dataclass (ram_mb / cpu / gpu / npu / disk
+    # / os) — no .hardware attribute. asdict() produces the same nested
+    # shape that hardware_to_targets and the Store filter expect.
+    local_hw = asdict(hp) if hp is not None else {}
     targets: list[dict] = [
         {
             "name": "local",

--- a/tinyagentos/routes/store_install.py
+++ b/tinyagentos/routes/store_install.py
@@ -10,6 +10,7 @@ script).
 from __future__ import annotations
 
 import logging
+from dataclasses import asdict
 from urllib.parse import urlparse
 
 from fastapi import APIRouter, Request
@@ -65,7 +66,11 @@ async def get_device_capability(request: Request, target_remote: str | None) -> 
     """Build a DeviceCapability snapshot for the (local | remote) target."""
     if not target_remote or target_remote == "local":
         hp = getattr(request.app.state, "hardware_profile", None)
-        hw = getattr(hp, "hardware", {}) if hp else {}
+        # HardwareProfile is a flat dataclass — there is no .hardware
+        # attribute on it. asdict() yields {ram_mb, cpu, gpu, npu, disk,
+        # os}, which is the shape hardware_to_targets and the resolver
+        # both expect.
+        hw = asdict(hp) if hp is not None else {}
         targets = tuple(hardware_to_targets(hw))
         ram_mb = int(hw.get("ram_mb", 0) or 0)
         vram_mb = int((hw.get("gpu") or {}).get("vram_mb", 0) or 0)


### PR DESCRIPTION
## Summary

User on the Pi reports no models show as compatible in the Store. Reproduced live: `POST /api/store/resolve` for any model with `min_ram_mb > 0` returned `near_miss.short_by_mb` equal to the model's full `min_ram_mb` — meaning the resolver thought `device.total_ram_mb = 0` even though `/api/hardware` correctly returned `ram_mb: 15958`.

Root cause: `get_device_capability` (in `routes/store_install.py`) and `list_install_targets` (in `routes/cluster.py`) both did:

```python
hp = request.app.state.hardware_profile
hw = getattr(hp, "hardware", {})  # always returns {}
ram_mb = int(hw.get("ram_mb", 0) or 0)  # always 0
```

`HardwareProfile` is a flat dataclass with `ram_mb` / `cpu` / `gpu` / `npu` / `disk` / `os` as direct fields — there's no `.hardware` attribute on it, so the getattr fell back to `{}`. Every model in the Store got classified red on the Pi because of this. PR #344's compatibility borders surfaced the symptom; the bug itself has been there since the resolver started reading from `app.state.hardware_profile`.

`asdict(hp)` returns the nested `{ram_mb, gpu: {...}, disk: {...}}` shape that `hardware_to_targets` and the resolver actually expect — identical to what `/api/hardware` already serves.

## What this doesn't fix

The Fedora "unknown hardware" entry in install-targets is a different bug: the user's incus remote name (`fedora-worker`) doesn't match the cluster worker name (`fedora-host`), so `worker_tiers.get(name)` fails to find the registered hardware. Will file separately — likely needs name-or-addr matching in `list_install_targets`.

## Test plan
- [x] Existing test fixture for `get_device_capability` mirrored the bug (`MagicMock().hardware = hw`); updated to build a real `HardwareProfile` dataclass
- [x] New `test_total_ram_and_vram_propagate_from_hardware_profile` asserts ram_mb + vram_mb propagate (would have caught the regression)
- [x] `pytest tests/routes/test_store_install_v2.py tests/test_routes_cluster.py` — 28 passed
- [ ] Live Pi verification after merge — every model card on the Store should re-classify