### PR TITLE
fix(cluster): worker default name + addr-based remote↔worker matching

### DIFF
--- a/scripts/install-worker.ps1
+++ b/scripts/install-worker.ps1
@@ -36,7 +36,16 @@ if (-not $ControllerUrl) {
     exit 2
 }
 
-if (-not $WorkerName) { $WorkerName = $env:COMPUTERNAME }
+if (-not $WorkerName) {
+    # Default appends "-worker" so the cluster UI distinguishes the worker
+    # entry from the underlying machine. Skip if the host already contains
+    # "worker" to avoid "rig-worker-worker".
+    if ($env:COMPUTERNAME -like '*worker*') {
+        $WorkerName = $env:COMPUTERNAME
+    } else {
+        $WorkerName = "$($env:COMPUTERNAME)-worker"
+    }
+}
 if (-not $InstallDir) { $InstallDir = Join-Path $env:LOCALAPPDATA 'tinyagentos-worker' }
 if (-not $Branch) { $Branch = 'master' }
 if (-not $Repo) { $Repo = 'https://github.com/jaylfc/tinyagentos' }

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -43,7 +43,20 @@ if [[ -z "$CONTROLLER_URL" ]]; then
     exit 2
 fi
 
-WORKER_NAME="${TAOS_WORKER_NAME:-$(hostname -s)}"
+# Default appends "-worker" to the host's short name so the cluster UI
+# distinguishes the worker entry from the underlying machine (e.g.
+# "fedora-host" becomes "fedora-worker"). Skip the suffix if the hostname
+# already contains "worker" so we don't end up with "rig-worker-worker".
+_default_worker_name() {
+    local h
+    h="$(hostname -s)"
+    if [[ "$h" == *worker* ]]; then
+        printf '%s' "$h"
+    else
+        printf '%s-worker' "$h"
+    fi
+}
+WORKER_NAME="${TAOS_WORKER_NAME:-$(_default_worker_name)}"
 INSTALL_DIR="${TAOS_INSTALL_DIR:-$HOME/.local/share/tinyagentos-worker}"
 BRANCH="${TAOS_BRANCH:-master}"
 REPO="${TAOS_REPO:-https://github.com/jaylfc/tinyagentos}"

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -48,9 +48,14 @@ fi
 # "fedora-host" becomes "fedora-worker"). Skip the suffix if the hostname
 # already contains "worker" so we don't end up with "rig-worker-worker".
 _default_worker_name() {
-    local h
+    local h h_lower
     h="$(hostname -s)"
-    if [[ "$h" == *worker* ]]; then
+    # Case-insensitive match so this stays consistent with the PowerShell
+    # installer's -like '*worker*' (which is case-insensitive). Otherwise
+    # a host called "WORKER1" would skip the suffix on Windows but get
+    # "-worker" appended on Linux.
+    h_lower="${h,,}"
+    if [[ "$h_lower" == *worker* ]]; then
         printf '%s' "$h"
     else
         printf '%s-worker' "$h"

--- a/tests/test_routes_cluster.py
+++ b/tests/test_routes_cluster.py
@@ -312,3 +312,38 @@ async def test_install_targets_remote_includes_tier_id(app, client, monkeypatch)
     assert "tier_id" in pi
     assert isinstance(pi["tier_id"], str) and pi["tier_id"]
     assert pi["friendly_name"] == "orange-pi"
+
+
+@pytest.mark.asyncio
+async def test_install_targets_matches_remote_to_worker_by_url_host(app, client, monkeypatch):
+    """When the incus remote name (e.g. 'fedora-worker') doesn't equal the
+    cluster worker name (e.g. 'fedora-host'), the install-target lookup
+    must still link them via URL hostname so the box doesn't show as
+    'unknown hardware'."""
+    from tinyagentos.cluster.worker_protocol import WorkerInfo
+    cluster = app.state.cluster_manager
+    cluster._workers["fedora-host"] = WorkerInfo(  # noqa: SLF001
+        name="fedora-host",
+        url="https://192.168.6.108:8443",
+        hardware={
+            "ram_mb": 65536,
+            "cpu": {"arch": "x86_64"},
+            "gpu": {"type": "nvidia", "vram_mb": 16384, "cuda": True},
+        },
+        status="online",
+    )
+
+    async def fake_remote_list():
+        return [{"name": "fedora-worker", "addr": "https://192.168.6.108:8443",
+                 "protocol": "incus"}]
+    monkeypatch.setattr(
+        "tinyagentos.containers.remote_list", fake_remote_list
+    )
+
+    resp = await client.get("/api/cluster/install-targets")
+    assert resp.status_code == 200
+    data = resp.json()
+    fedora = next((t for t in data if t["name"] == "fedora-worker"), None)
+    assert fedora is not None
+    assert fedora["hardware_known"] is True, fedora
+    assert fedora["tier_id"] not in ("", "unknown"), fedora

--- a/tinyagentos/routes/cluster.py
+++ b/tinyagentos/routes/cluster.py
@@ -279,13 +279,13 @@ async def list_install_targets(request: Request):
     # Also map URL-hostname → tier_id so an incus remote whose name doesn't
     # match the worker registration name (e.g. remote "fedora-worker" vs
     # worker "fedora-host") still resolves the same physical hardware.
+    from urllib.parse import urlparse as _urlparse
     cluster = getattr(request.app.state, "cluster_manager", None)
     registry = getattr(request.app.state, "registry", None)
     worker_tiers: dict[str, str] = {}
     worker_tiers_by_host: dict[str, str] = {}
     workers_by_host: dict[str, "WorkerInfo"] = {}
     if cluster is not None and registry is not None:
-        from urllib.parse import urlparse as _urlparse
         for w in cluster.get_workers():
             try:
                 tier_id, _caps = _potential_capabilities(w.hardware, registry)
@@ -302,7 +302,6 @@ async def list_install_targets(request: Request):
 
     try:
         import tinyagentos.containers as containers
-        from urllib.parse import urlparse as _urlparse
         remotes = await containers.remote_list()
         for r in remotes:
             name = r.get("name", "")

--- a/tinyagentos/routes/cluster.py
+++ b/tinyagentos/routes/cluster.py
@@ -276,19 +276,33 @@ async def list_install_targets(request: Request):
         }
     ]
     # Map worker name → tier_id by reusing the existing capability resolver.
+    # Also map URL-hostname → tier_id so an incus remote whose name doesn't
+    # match the worker registration name (e.g. remote "fedora-worker" vs
+    # worker "fedora-host") still resolves the same physical hardware.
     cluster = getattr(request.app.state, "cluster_manager", None)
     registry = getattr(request.app.state, "registry", None)
     worker_tiers: dict[str, str] = {}
+    worker_tiers_by_host: dict[str, str] = {}
+    workers_by_host: dict[str, "WorkerInfo"] = {}
     if cluster is not None and registry is not None:
+        from urllib.parse import urlparse as _urlparse
         for w in cluster.get_workers():
             try:
                 tier_id, _caps = _potential_capabilities(w.hardware, registry)
-                worker_tiers[w.name] = tier_id
             except Exception:  # noqa: BLE001
-                worker_tiers[w.name] = ""
+                tier_id = ""
+            worker_tiers[w.name] = tier_id
+            try:
+                host = _urlparse(getattr(w, "url", "") or "").hostname or ""
+            except Exception:  # noqa: BLE001
+                host = ""
+            if host:
+                worker_tiers_by_host[host] = tier_id
+                workers_by_host[host] = w
 
     try:
         import tinyagentos.containers as containers
+        from urllib.parse import urlparse as _urlparse
         remotes = await containers.remote_list()
         for r in remotes:
             name = r.get("name", "")
@@ -301,17 +315,30 @@ async def list_install_targets(request: Request):
                 # entry above. Incus exposes this as "local (current)" when it
                 # is the active context, which isn't in _BUILTIN_REMOTES.
                 continue
-            worker_hw = next(
-                (w.hardware for w in cluster.get_workers() if w.name == name),
-                {},
-            ) if cluster else {}
-            hardware_known = bool(worker_hw) or bool(worker_tiers.get(name))
+            # Look up the matching worker: by name first, then by URL host.
+            worker_hw: dict = {}
+            tier_id = ""
+            if cluster is not None:
+                worker_hw = next(
+                    (w.hardware for w in cluster.get_workers() if w.name == name),
+                    {},
+                )
+                tier_id = worker_tiers.get(name, "")
+                if not worker_hw:
+                    try:
+                        remote_host = _urlparse(addr).hostname or ""
+                    except Exception:  # noqa: BLE001
+                        remote_host = ""
+                    if remote_host and remote_host in workers_by_host:
+                        worker_hw = workers_by_host[remote_host].hardware
+                        tier_id = worker_tiers_by_host.get(remote_host, tier_id)
+            hardware_known = bool(worker_hw) or bool(tier_id)
             targets.append({
                 "name": name,
                 "label": name,
                 "type": "remote",
-                "addr": r.get("addr", ""),
-                "tier_id": worker_tiers.get(name) or ("unknown" if not hardware_known else ""),
+                "addr": addr,
+                "tier_id": tier_id or ("unknown" if not hardware_known else ""),
                 "targets": hardware_to_targets(worker_hw),
                 "hardware_known": hardware_known,
                 "friendly_name": name,


### PR DESCRIPTION
## Summary

Address the \"fedora-host vs fedora-worker\" mismatch the user hit on the Pi: incus remote was named \`fedora-worker\` but the worker registered with the controller as \`fedora-host\`, so the install-targets endpoint surfaced it as \"unknown hardware\" even though hardware was fully detected.

Two complementary fixes:

1. **install-worker.sh / install-worker.ps1** — default name is now \`<hostname>-worker\` instead of \`<hostname>\`. Skips the suffix when the hostname already contains \"worker\" so we don't get \"rig-worker-worker\". Aligns fresh installs with the \"<box>-worker\" convention used for incus remotes.

2. **/api/cluster/install-targets** — match an incus remote to a registered worker by URL hostname when names don't equal. Now \`fedora-worker\` pointing at \`https://192.168.6.108:8443\` correctly resolves the worker registered as \`fedora-host\` at the same addr.

## Test plan
- [x] New \`test_install_targets_matches_remote_to_worker_by_url_host\` exercises the fallback path
- [x] \`pytest tests/test_routes_cluster.py\` — 18 passed
- [x] \`bash -n install-worker.sh\` clean
- [ ] Live verification on Pi after merge: fedora-worker entry should flip from \"unknown\" to its actual tier_id
- [ ] User's existing fedora install can be renamed via env: \`TAOS_WORKER_NAME=fedora-worker\` re-run of install-worker.sh, OR a one-liner systemd unit edit

Stacked behind #389 (which fixes the broader hardware-profile attribute access bug). Either order works since they touch different code paths inside \`list_install_targets\`.