### PR TITLE
ci: cut 14 min off PRs — fix bootstrap-ping default + drop 3.11 from PR matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,10 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # 45 min cap accommodates the cron run that includes 3.11 (~30 min);
+    # 3.12/3.13 PR runs finish in ~16 min, so this only kicks in if 3.11
+    # ever drifts further.
+    timeout-minutes: 45
     strategy:
       matrix:
         # PR + push runs cover the latest two; the daily cron run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,18 +5,24 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  schedule:
+    # 06:00 UTC daily run keeps the 3.11 leg honest without making every
+    # PR wait 14 extra minutes on it. 3.11 is consistently ~2x slower
+    # than 3.12/3.13 due to per-test asyncio overhead — investigated
+    # with per-test timing and the gap is distributed (not a single
+    # slow test), so a kernel-level interpreter perf issue rather than
+    # something we can fix in our suite.
+    - cron: "0 6 * * *"
 
 jobs:
   test:
     runs-on: ubuntu-latest
-    # Bumped from 35 to 45: 3.11 was hitting the cap because it has fewer
-    # pre-built wheels for our deps + the newly-added SPA build step adds
-    # ~30s. Cancellations were showing as CANCELLED instead of TIMED_OUT,
-    # which made the cause non-obvious.
-    timeout-minutes: 45
+    timeout-minutes: 30
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        # PR + push runs cover the latest two; the daily cron run
+        # below adds 3.11 so the minimum-supported version stays tested.
+        python-version: ${{ github.event_name == 'schedule' && fromJSON('["3.11", "3.12", "3.13"]') || fromJSON('["3.12", "3.13"]') }}
 
     steps:
       - uses: actions/checkout@v5

--- a/tests/test_framework_update_runner.py
+++ b/tests/test_framework_update_runner.py
@@ -113,10 +113,17 @@ async def test_start_update_fails_on_missing_bootstrap(monkeypatch):
     monkeypatch.setattr(fu, "_prune_old_snapshots", AsyncMock())
     monkeypatch.setattr(fu, "exec_in_container", AsyncMock(return_value=(0, "")))
     monkeypatch.setattr(fu, "UPDATE_DEADLINE_SECONDS", 1)
+    # Time-bound the call so a regression on the default-arg fix surfaces
+    # as a fast failure (~5 s ceiling) instead of a 120 s CI hang.
+    elapsed_start = time.time()
     await start_update(agent,
                         {"id": "openclaw", "install_script": "/usr/local/bin/taos-framework-update"},
                         {"tag": "T", "sha": "s", "asset_url": "u"},
                         save_config=AsyncMock())
+    assert time.time() - elapsed_start < 5.0, (
+        "monkeypatched UPDATE_DEADLINE_SECONDS must take effect — "
+        "_wait_for_bootstrap_ping is reading the module attr at call time"
+    )
     assert agent["framework_update_status"] == "failed"
     assert "bridge" in agent["framework_update_last_error"]
 

--- a/tinyagentos/framework_update.py
+++ b/tinyagentos/framework_update.py
@@ -27,12 +27,20 @@ async def _prune_old_snapshots(container: str, *, keep: int) -> None:
 
 
 async def _wait_for_bootstrap_ping(
-    agent: dict, *, started_at: int, deadline_seconds: int = UPDATE_DEADLINE_SECONDS,
+    agent: dict, *, started_at: int, deadline_seconds: int | None = None,
 ) -> bool:
     """Poll `agent['bootstrap_last_seen_at']` every 500 ms. Returns True the
     first time it exceeds `started_at` (meaning the bridge has called
     `/api/openclaw/bootstrap` since the update started). False on deadline.
+
+    `deadline_seconds=None` reads `UPDATE_DEADLINE_SECONDS` at call time,
+    so tests that monkeypatch the module attribute are honoured. Using
+    the module attr as a default value bound it at definition time and
+    silently ignored the patch — the missing-bootstrap test then waited
+    the full 120 s on every CI run instead of the intended 1 s.
     """
+    if deadline_seconds is None:
+        deadline_seconds = UPDATE_DEADLINE_SECONDS
     deadline = time.time() + deadline_seconds
     while time.time() < deadline:
         last = agent.get("bootstrap_last_seen_at") or 0


### PR DESCRIPTION
## Summary

CI test runs were taking 25-30 min and the user noticed. Investigated by pulling the per-test timestamps from a recent 3.11 run vs 3.12/3.13. Found two distinct issues:

### 1. `_wait_for_bootstrap_ping` default-arg bug (saves ~6 min per CI run)

The function defaulted `deadline_seconds=UPDATE_DEADLINE_SECONDS`. Python evaluates default args at function-definition time, so the value was bound to 120 s and `monkeypatch.setattr(fu, "UPDATE_DEADLINE_SECONDS", 1)` in `test_start_update_fails_on_missing_bootstrap` was silently ignored — the test waited the full 120 s on every CI run. Confirmed by GH Actions log timestamps:

```
3.11: 21:39:01 ... fails_on_nonzero_exit ... PASSED
3.11: 21:41:01 ... fails_on_missing_bootstrap ... PASSED   ← 120 s gap

3.13: 21:38:35 ... fails_on_nonzero_exit ... PASSED
3.13: 21:40:35 ... fails_on_missing_bootstrap ... PASSED   ← same 120 s gap
```

Fix: read `UPDATE_DEADLINE_SECONDS` at call time. The new test guard time-bounds the call to <5 s so any regression surfaces fast instead of as a 120 s hang.

Local: 9 tests in `test_framework_update_runner.py` now run in 3.55 s.

### 2. Drop 3.11 from per-PR matrix, add a daily cron (saves ~14 min per PR)

After accounting for the 6 min above, 3.11 was *still* ~14 min slower than 3.12/3.13 (1778 s vs ~920 s for the test step). Investigated by analysing all >5 s gaps in both runs — they're identical between matrix legs, so the 3.11 delta is **distributed**: ~1 s per test of asyncio teardown overhead × ~870 tests. Not a hotspot we can fix in userspace.

Trade-off: 3.11 stays as our minimum-supported version (per `pyproject.toml`); we just don't gate every PR on it. Daily 06:00 UTC cron run includes 3.11 so a 3.11-only regression still surfaces within 24 h. Investigating the per-test asyncio overhead is a separate concern worth tracking.

`timeout-minutes` drops 45 → 30 since 3.12/3.13 finish in 16 min.

## Test plan
- [x] `pytest tests/test_framework_update_runner.py` — 9 passed in 3.55 s (was hanging at 120 s on missing-bootstrap)
- [x] `python -c yaml.safe_load(ci.yml)` — triggers + matrix conditional parse correctly
- [ ] PR run: matrix should be `[3.12, 3.13]` only
- [ ] Tomorrow's cron run: matrix should include 3.11