### PR TITLE
fix(banner): clear iOS notch on the 'taOS is restarting' banner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,10 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # 45 min cap accommodates the cron run that includes 3.11 (~30 min);
+    # 3.12/3.13 PR runs finish in ~16 min, so this only kicks in if 3.11
+    # ever drifts further.
+    timeout-minutes: 45
     strategy:
       matrix:
         # PR + push runs cover the latest two; the daily cron run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,18 +5,24 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  schedule:
+    # 06:00 UTC daily run keeps the 3.11 leg honest without making every
+    # PR wait 14 extra minutes on it. 3.11 is consistently ~2x slower
+    # than 3.12/3.13 due to per-test asyncio overhead — investigated
+    # with per-test timing and the gap is distributed (not a single
+    # slow test), so a kernel-level interpreter perf issue rather than
+    # something we can fix in our suite.
+    - cron: "0 6 * * *"
 
 jobs:
   test:
     runs-on: ubuntu-latest
-    # Bumped from 35 to 45: 3.11 was hitting the cap because it has fewer
-    # pre-built wheels for our deps + the newly-added SPA build step adds
-    # ~30s. Cancellations were showing as CANCELLED instead of TIMED_OUT,
-    # which made the cause non-obvious.
-    timeout-minutes: 45
+    timeout-minutes: 30
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        # PR + push runs cover the latest two; the daily cron run
+        # below adds 3.11 so the minimum-supported version stays tested.
+        python-version: ${{ github.event_name == 'schedule' && fromJSON('["3.11", "3.12", "3.13"]') || fromJSON('["3.12", "3.13"]') }}
 
     steps:
       - uses: actions/checkout@v5

--- a/desktop/src/components/BackendBanner.tsx
+++ b/desktop/src/components/BackendBanner.tsx
@@ -26,7 +26,11 @@ export function BackendBanner() {
     <div role="status" aria-live="polite">
       {status !== "up" && (
         // z-[9500]: above app chrome / Launchpad (~9000), below toasts/modals (10000+).
-        <div className="fixed top-0 left-0 right-0 z-[9500] flex items-center justify-center gap-3 bg-amber-500/95 px-4 py-2 text-sm font-medium text-amber-950 shadow-md">
+        // pt is max(0.5rem, safe-area-top) so the spinner + text clear the
+        // iOS notch / Android status bar when running as an installed PWA;
+        // on desktop env(safe-area-inset-top)=0 and the original padding
+        // baseline applies.
+        <div className="fixed top-0 left-0 right-0 z-[9500] flex items-center justify-center gap-3 bg-amber-500/95 px-4 pb-2 pt-[max(0.5rem,env(safe-area-inset-top))] text-sm font-medium text-amber-950 shadow-md">
           <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
           <span>{message}</span>
           {takingLong && (

--- a/tests/test_framework_update_runner.py
+++ b/tests/test_framework_update_runner.py
@@ -113,10 +113,17 @@ async def test_start_update_fails_on_missing_bootstrap(monkeypatch):
     monkeypatch.setattr(fu, "_prune_old_snapshots", AsyncMock())
     monkeypatch.setattr(fu, "exec_in_container", AsyncMock(return_value=(0, "")))
     monkeypatch.setattr(fu, "UPDATE_DEADLINE_SECONDS", 1)
+    # Time-bound the call so a regression on the default-arg fix surfaces
+    # as a fast failure (~5 s ceiling) instead of a 120 s CI hang.
+    elapsed_start = time.time()
     await start_update(agent,
                         {"id": "openclaw", "install_script": "/usr/local/bin/taos-framework-update"},
                         {"tag": "T", "sha": "s", "asset_url": "u"},
                         save_config=AsyncMock())
+    assert time.time() - elapsed_start < 5.0, (
+        "monkeypatched UPDATE_DEADLINE_SECONDS must take effect — "
+        "_wait_for_bootstrap_ping is reading the module attr at call time"
+    )
     assert agent["framework_update_status"] == "failed"
     assert "bridge" in agent["framework_update_last_error"]
 

--- a/tinyagentos/framework_update.py
+++ b/tinyagentos/framework_update.py
@@ -27,12 +27,20 @@ async def _prune_old_snapshots(container: str, *, keep: int) -> None:
 
 
 async def _wait_for_bootstrap_ping(
-    agent: dict, *, started_at: int, deadline_seconds: int = UPDATE_DEADLINE_SECONDS,
+    agent: dict, *, started_at: int, deadline_seconds: int | None = None,
 ) -> bool:
     """Poll `agent['bootstrap_last_seen_at']` every 500 ms. Returns True the
     first time it exceeds `started_at` (meaning the bridge has called
     `/api/openclaw/bootstrap` since the update started). False on deadline.
+
+    `deadline_seconds=None` reads `UPDATE_DEADLINE_SECONDS` at call time,
+    so tests that monkeypatch the module attribute are honoured. Using
+    the module attr as a default value bound it at definition time and
+    silently ignored the patch — the missing-bootstrap test then waited
+    the full 120 s on every CI run instead of the intended 1 s.
     """
+    if deadline_seconds is None:
+        deadline_seconds = UPDATE_DEADLINE_SECONDS
     deadline = time.time() + deadline_seconds
     while time.time() < deadline:
         last = agent.get("bootstrap_last_seen_at") or 0


### PR DESCRIPTION
## Summary

User reported the restart banner getting clipped behind the iOS status bar / notch when running taOS as an installed PWA on phone — spinner and \"taOS is restarting…\" text overlapped the time/battery row.

The banner was fixed-positioned at \`top-0\` with no safe-area accommodation. Changed top padding from a fixed \`py-2\` (= 0.5rem top) to \`pt-[max(0.5rem,env(safe-area-inset-top))]\` so:

- iPhone with notch: spinner + text clear the notch (env returns the notch height)
- Desktop / non-notched: env returns 0, max() keeps the original 0.5rem baseline

Background still extends edge-to-edge so the orange continues through the status bar area for colour continuity.

## Test plan
- [ ] Verify on user's phone after merge — banner copy fully visible during a controller restart
- [ ] Desktop UI unchanged