### PR TITLE
fix: snap RAM to canonical bucket (Pi shows 16GB, Store models match) + Install Update button spinner

### DIFF
--- a/app-catalog/models/gemma-4-e4b-gguf/manifest.yaml
+++ b/app-catalog/models/gemma-4-e4b-gguf/manifest.yaml
@@ -1,0 +1,36 @@
+id: gemma-4-e4b-gguf
+name: Gemma 4 E4B Instruct (GGUF)
+type: model
+version: 4.0.0
+description: "Google Gemma 4 E4B (~7.5B raw / 4B effective via PLE), Q4_K_M GGUF — bigger sibling of E2B for boards with more headroom"
+homepage: https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF
+license: "Gemma Terms of Use"
+capabilities: [chat, tool-calling]
+context_window: 32768
+
+variants:
+  - id: q4_k_m
+    name: "Q4_K_M GGUF (4.7GB)"
+    format: gguf
+    size_mb: 4746
+    download_url: https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF/resolve/main/gemma-4-E4B-it-Q4_K_M.gguf
+    requires:
+      backends:
+        - id: rk-llama-cpp
+          targets: [rockchip]
+          min_ram_mb: 6144
+        - id: ollama
+          targets: [apple-silicon, x86-cuda, x86-vulkan, arm-vulkan, cpu]
+          min_ram_mb: 6144
+        - id: llama-cpp
+          targets: [x86-vulkan, arm-vulkan, cpu]
+          min_ram_mb: 6144
+
+hardware_tiers:
+  arm-npu-16gb: {recommended: q4_k_m}
+  arm-npu-32gb: {recommended: q4_k_m}
+  apple-silicon: {recommended: q4_k_m}
+  x86-cuda-12gb: {recommended: q4_k_m}
+  x86-vulkan-8gb: {recommended: q4_k_m}
+  x86-vulkan-16gb: {recommended: q4_k_m}
+  cpu-only: {recommended: q4_k_m}

--- a/desktop/src/apps/SettingsApp.tsx
+++ b/desktop/src/apps/SettingsApp.tsx
@@ -785,6 +785,7 @@ function UpdatesSection() {
           </Button>
           {info?.has_updates ? (
             <Button size="sm" onClick={applyUpdate} disabled={applying}>
+              <RefreshCw size={14} className={applying ? "animate-spin" : ""} />
               {applying ? "Installing..." : "Install Update"}
             </Button>
           ) : null}

--- a/tinyagentos/hardware.py
+++ b/tinyagentos/hardware.py
@@ -49,6 +49,27 @@ class OsInfo:
     kernel: str = ""
 
 
+# Canonical RAM buckets covering the SBC / desktop / workstation range.
+# Boards reserve a slice for kernel/GPU so kernel-reported ram_mb is always
+# slightly below the marketed capacity (a "16 GB" Pi reports ~15.6 GB);
+# floor-dividing produced an `arm-npu-15gb` tier that didn't match any
+# catalog manifest using `arm-npu-16gb`. Snap to the closest bucket.
+_CANONICAL_RAM_GB: tuple[int, ...] = (
+    1, 2, 3, 4, 6, 8, 12, 16, 24, 32, 48, 64, 96, 128, 192, 256, 384, 512,
+)
+
+
+def _snap_ram_to_canonical_gb(ram_mb: int) -> int:
+    """Map kernel-reported MB to the closest canonical bucket in GB.
+
+    ``ram_mb=0`` returns 1 to keep `profile_id` parseable while signalling
+    "unknown" via everything else (`cpu`, `npu.type=="none"`, etc.)."""
+    if ram_mb <= 0:
+        return 1
+    actual_gb = ram_mb / 1024
+    return min(_CANONICAL_RAM_GB, key=lambda b: abs(b - actual_gb))
+
+
 @dataclass
 class HardwareProfile:
     cpu: CpuInfo = field(default_factory=CpuInfo)
@@ -71,7 +92,7 @@ class HardwareProfile:
             accel = "vulkan"
         else:
             accel = "cpu"
-        ram_gb = max(1, self.ram_mb // 1024)
+        ram_gb = _snap_ram_to_canonical_gb(self.ram_mb)
         return f"{arch}-{accel}-{ram_gb}gb"
 
     def save(self, path: Path) -> None:

--- a/tinyagentos/hardware.py
+++ b/tinyagentos/hardware.py
@@ -62,7 +62,7 @@ _CANONICAL_RAM_GB: tuple[int, ...] = (
 def _snap_ram_to_canonical_gb(ram_mb: int) -> int:
     """Map kernel-reported MB to the closest canonical bucket in GB.
 
-    ``ram_mb=0`` returns 1 to keep `profile_id` parseable while signalling
+    ``ram_mb <= 0`` returns 1 to keep `profile_id` parseable while signalling
     "unknown" via everything else (`cpu`, `npu.type=="none"`, etc.)."""
     if ram_mb <= 0:
         return 1


### PR DESCRIPTION
## Summary

Two issues from the Pi UI tonight:

### 1. Pi shows as 15GB, no models show as compatible

The Pi has 16 GB marketed but the kernel reports \`ram_mb=15958\` because the board reserves a slice for kernel + GPU. \`15958 // 1024 = 15\` produced \`arm-npu-15gb\`, but every catalog manifest writes its \`hardware_tiers\` as the marketed bucket (\`arm-npu-16gb\`, \`arm-cpu-8gb\`, etc.) — so nothing matched, every model showed as red.

Snap to the closest canonical bucket from \`{1,2,3,4,6,8,12,16,24,32,48,64,96,128,192,256,384,512}\`. Validated:
- 15958 MB → 16 GB ✓ (Pi)
- 8000 MB → 8 GB ✓
- 4096 MB → 4 GB ✓ (johny's N100)
- 31500 MB → 32 GB ✓
- 250000 MB → 256 GB ✓

After this lands the Pi resolves to \`arm-npu-16gb\` and the Store starts matching gemma-3-4b et al.

### 2. Install Update button visual artifact on mobile

Sibling buttons (Check Now, Rebuild Frontend) have \`RefreshCw\` icons; Install Update was the only one without — produced a thin visual mark in the mobile flex layout. Adding the icon (spinning during install) gives all three buttons consistent structure.

## Test plan
- [x] 14 bucket-snap test cases all return the marketed bucket
- [x] \`pytest tests/test_capabilities tests/test_registry tests/routes/test_store_install_v2 tests/test_routes_cluster tests/test_hardware\` (excl. pre-existing Mac arm64 failures unrelated to this change) — 73 passed
- [ ] On Pi after merge: \`profile_id\` flips to \`arm-npu-16gb\`, gemma-3-4b appears as green/amber in the Store
- [ ] On phone: Install Update button has the RefreshCw icon, no artifact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI/UX Improvements**
  * The "Install Update" button now displays an animated refresh icon during installation, providing clearer visual feedback while updates are being applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->