### PR TITLE
fix(store): backend filter correctness — missing meta + category scope + install_method leak

### DIFF
--- a/desktop/src/apps/StoreApp/backends.test.ts
+++ b/desktop/src/apps/StoreApp/backends.test.ts
@@ -7,7 +7,7 @@ import { BACKEND_META } from "./backends";
 /**
  * Every backend id referenced from app-catalog/models/manifest files
  * must have a BACKEND_META entry. Falling through to the generic
- * fallback hid rk-llama-cpp / exo / onnxruntime / sd-webui /
+ * fallback hides rk-llama-cpp / exo / onnxruntime / sd-webui /
  * sentence-transformers / ezrknpu in the Store filter.
  *
  * Cheap regex parse: every backend reference under requires.backends

--- a/desktop/src/apps/StoreApp/backends.test.ts
+++ b/desktop/src/apps/StoreApp/backends.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { BACKEND_META } from "./backends";
+
+/**
+ * Every backend id referenced from app-catalog/models/manifest files
+ * must have a BACKEND_META entry. Falling through to the generic
+ * fallback hid rk-llama-cpp / exo / onnxruntime / sd-webui /
+ * sentence-transformers / ezrknpu in the Store filter.
+ *
+ * Cheap regex parse: every backend reference under requires.backends
+ * is on its own line as `- id: <name>` (audit-manifests.py enforces
+ * the schema). New backends added to a manifest must also land in
+ * BACKEND_META — otherwise the filter pill loses its label and colour.
+ */
+function collectCatalogBackends(catalogRoot: string): Set<string> {
+  const out = new Set<string>();
+  const idRe = /^\s*-\s*id:\s*([A-Za-z0-9_.-]+)/;
+  for (const entry of readdirSync(catalogRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const manifestPath = join(catalogRoot, entry.name, "manifest.yaml");
+    let raw: string;
+    try {
+      raw = readFileSync(manifestPath, "utf-8");
+    } catch {
+      continue;
+    }
+    // Walk lines tracking YAML indent. Only capture `- id: <name>`
+    // entries that sit under a `backends:` key. Variant ids live under
+    // a sibling `variants:` block which we deliberately ignore.
+    let underBackends = false;
+    let backendsIndent = -1;
+    for (const line of raw.split("\n")) {
+      const indent = line.length - line.trimStart().length;
+      const trimmed = line.trim();
+      if (trimmed === "" || trimmed.startsWith("#")) continue;
+      if (/^backends\s*:/.test(trimmed)) {
+        underBackends = true;
+        backendsIndent = indent;
+        continue;
+      }
+      if (underBackends && indent <= backendsIndent) {
+        underBackends = false;
+      }
+      if (underBackends) {
+        const m = idRe.exec(line);
+        if (m && m[1]) out.add(m[1]);
+      }
+    }
+  }
+  return out;
+}
+
+describe("BACKEND_META coverage", () => {
+  it("includes every backend id referenced from the model catalog", () => {
+    const catalogRoot = join(__dirname, "../../../../app-catalog/models");
+    const referenced = collectCatalogBackends(catalogRoot);
+    const missing = [...referenced].filter((id) => !(id in BACKEND_META)).sort();
+    expect(missing).toEqual([]);
+  });
+});

--- a/desktop/src/apps/StoreApp/backends.ts
+++ b/desktop/src/apps/StoreApp/backends.ts
@@ -23,12 +23,18 @@ export interface BackendMeta {
 
 export const BACKEND_META: Record<string, BackendMeta> = {
   rkllama: { label: "rkllama (NPU)", icon: "🧠", color: "purple", classes: "bg-purple-500/15 text-purple-300 border-purple-500/30" },
+  "rk-llama-cpp": { label: "rk-llama.cpp (NPU GGUF)", icon: "🧠", color: "violet", classes: "bg-violet-500/15 text-violet-300 border-violet-500/30" },
+  ezrknpu: { label: "ezrknpu", icon: "🧩", color: "purple", classes: "bg-purple-500/15 text-purple-300 border-purple-500/30" },
   ollama: { label: "Ollama", icon: "🦙", color: "blue", classes: "bg-blue-500/15 text-blue-300 border-blue-500/30" },
   "llama-cpp": { label: "llama.cpp", icon: "🦫", color: "amber", classes: "bg-amber-500/15 text-amber-300 border-amber-500/30" },
   vllm: { label: "vLLM", icon: "⚡", color: "yellow", classes: "bg-yellow-500/15 text-yellow-300 border-yellow-500/30" },
+  exo: { label: "exo", icon: "🌐", color: "cyan", classes: "bg-cyan-500/15 text-cyan-300 border-cyan-500/30" },
+  onnxruntime: { label: "ONNX Runtime", icon: "🟦", color: "blue", classes: "bg-blue-500/15 text-blue-300 border-blue-500/30" },
   transformers: { label: "Transformers", icon: "🤗", color: "rose", classes: "bg-rose-500/15 text-rose-300 border-rose-500/30" },
+  "sentence-transformers": { label: "Sentence Transformers", icon: "🤗", color: "rose", classes: "bg-rose-500/15 text-rose-300 border-rose-500/30" },
   diffusers: { label: "Diffusers", icon: "🎨", color: "fuchsia", classes: "bg-fuchsia-500/15 text-fuchsia-300 border-fuchsia-500/30" },
   comfyui: { label: "ComfyUI", icon: "🧩", color: "indigo", classes: "bg-indigo-500/15 text-indigo-300 border-indigo-500/30" },
+  "sd-webui": { label: "SD WebUI", icon: "🎨", color: "fuchsia", classes: "bg-fuchsia-500/15 text-fuchsia-300 border-fuchsia-500/30" },
   "stable-diffusion-cpp": { label: "stable-diffusion.cpp", icon: "🖼️", color: "pink", classes: "bg-pink-500/15 text-pink-300 border-pink-500/30" },
   "rknn-stable-diffusion": { label: "RKNN SD", icon: "🖼️", color: "purple", classes: "bg-purple-500/15 text-purple-300 border-purple-500/30" },
   fastsdcpu: { label: "FastSD CPU", icon: "🖌️", color: "teal", classes: "bg-teal-500/15 text-teal-300 border-teal-500/30" },

--- a/desktop/src/apps/StoreApp/index.tsx
+++ b/desktop/src/apps/StoreApp/index.tsx
@@ -766,7 +766,15 @@ export function StoreApp({ windowId: _windowId }: { windowId: string }) {
   }
 
   // Backends shown in the BackendPillBar are the union of variants[].backend
-  // across all manifests where any selected device's tier_id is supported.
+  // across manifests in the *current category* where any selected device's
+  // tier_id is supported. Two reasons this is category-scoped instead of
+  // catalog-wide:
+  //   1. On the Models view, runtime backends (rkllama, ollama, llama.cpp)
+  //      are meaningful filters; on the Agent Frameworks view they aren't.
+  //   2. install_method (docker, lxc, npm, pip) was leaking into the
+  //      backend pills via the no-variants fallback below — these are
+  //      deploy mechanisms, not runtime backends, and they don't belong
+  //      in this filter at all. Dropping the fallback closes that gap.
   const availableBackends = useMemo(() => {
     if (selectedDevices.length === 0) return [];
     const memoSelectedDevices = installTargets.filter((t) =>
@@ -775,8 +783,11 @@ export function StoreApp({ windowId: _windowId }: { windowId: string }) {
     const tiers = new Set(
       memoSelectedDevices.map((d) => d.tier_id).filter(Boolean) as string[]
     );
+    const sourceApps = activeCategory === "all" || !activeCat
+      ? apps
+      : apps.filter((a) => activeCat.types.includes(appGroup(a)));
     const out = new Set<string>();
-    for (const app of apps) {
+    for (const app of sourceApps) {
       if (!app.hardware_tiers) continue;
       const tierMatch = [...tiers].some(
         (t) =>
@@ -787,12 +798,9 @@ export function StoreApp({ windowId: _windowId }: { windowId: string }) {
       for (const v of app.variants ?? []) {
         for (const b of v.backend ?? []) out.add(b);
       }
-      if ((app.variants ?? []).length === 0 && app.install_method) {
-        out.add(app.install_method);
-      }
     }
     return Array.from(out).sort();
-  }, [selectedDevices, installTargets, apps]);
+  }, [selectedDevices, installTargets, apps, activeCategory, activeCat]);
 
   useEffect(() => {
     if (availableBackends.length === 0) {


### PR DESCRIPTION
## Summary

Three related bugs in the Store's backend filter, all surfaced when the user looked at the Models view on mobile:

### 1. \`install_method\` leaking into runtime backends

\`availableBackends\` had a fallback that added \`app.install_method\` (docker, lxc, npm, pip, script) when an app had no variants. \`install_method\` is a deploy mechanism, not a runtime backend — it doesn't belong in this filter at all. Removed.

### 2. Backend pills not scoped to current category

The set was computed from the full catalog, so on the Models view the pills picked up backends from agent frameworks and services. Now derives from category-filtered apps.

### 3. Missing entries in \`BACKEND_META\`

The catalog references 19 distinct backends across all manifests, but \`BACKEND_META\` (the lookup that gives each pill its label, icon, and colour) only had 13 — six fell through to the generic ⚙️ fallback with the raw id as the label:

- \`rk-llama-cpp\` (the new Pi-NPU GGUF runtime)
- \`exo\`
- \`ezrknpu\`
- \`onnxruntime\`
- \`sd-webui\`
- \`sentence-transformers\`

Added consistent metadata for all six. \`rk-llama.cpp\` uses the violet variant of the rkllama purple to distinguish them visually.

### Regression guard

New \`backends.test.ts\` walks \`app-catalog/models/*/manifest.yaml\`, collects every backend id under \`requires.backends\`, and asserts \`BACKEND_META\` has an entry for each. Future manifests adding a new backend without updating \`BACKEND_META\` will fail CI instead of falling through to the generic pill.

## Test plan
- [x] \`npx vitest run src/apps/StoreApp/backends.test.ts\` — 1 passed
- [x] tsc --noEmit clean
- [ ] Visual check on Pi after merge: Models tab shows only runtime backends, no docker/lxc/npm/pip pills, rk-llama.cpp pill renders with the violet branding