### PR TITLE
feat(store): variant chooser + target chooser on every install card

### DIFF
--- a/desktop/src/apps/StoreApp/index.tsx
+++ b/desktop/src/apps/StoreApp/index.tsx
@@ -426,13 +426,22 @@ function AppCard({ app, affected, onInstall, onUninstall, installTargets, runtim
   const [selectedTarget, setSelectedTarget] = useState<string>(
     defaultTargetRemote ?? "local"
   );
+  // "auto" defers variant choice to the resolver — same default the
+  // backend uses when the field is absent. Users can override via the
+  // dropdown when the manifest exposes >1 variant.
+  const [selectedVariant, setSelectedVariant] = useState<string>("auto");
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (defaultTargetRemote !== undefined) setSelectedTarget(defaultTargetRemote);
   }, [defaultTargetRemote]);
   const iconUrl = resolveIconUrl(app.id);
-  const isLxc = app.install_method === "lxc";
+  const variantOptions = app.variants ?? [];
+  const showVariantPicker = !app.installed && variantOptions.length > 1;
+  // Show the target chooser whenever multiple targets exist — used to
+  // be gated to LXC apps only, but model installs also route to the
+  // selected worker so cluster users want the same pick on every card.
+  const showTargetPicker = !app.installed && installTargets.length > 1;
 
   const handleAction = async () => {
     setBusy(true);
@@ -454,6 +463,9 @@ function AppCard({ app, affected, onInstall, onUninstall, installTargets, runtim
         onUninstall(app.id);
       } else {
         const body: Record<string, unknown> = { app_id: app.id, target_remote: selectedTarget };
+        if (selectedVariant !== "auto") {
+          body.variant_id = selectedVariant;
+        }
         const res = await fetch("/api/store/install-v2", {
           method: "POST",
           headers: { "Content-Type": "application/json", Accept: "application/json" },
@@ -531,7 +543,7 @@ function AppCard({ app, affected, onInstall, onUninstall, installTargets, runtim
             {error}
           </div>
         )}
-        {isLxc && !app.installed && installTargets.length > 1 && (
+        {showTargetPicker && (
           <div className="flex items-center gap-2">
             <label htmlFor={`target-${app.id}`} className="text-[11px] text-shell-text-tertiary whitespace-nowrap">
               Install on
@@ -545,6 +557,25 @@ function AppCard({ app, affected, onInstall, onUninstall, installTargets, runtim
             >
               {installTargets.map((t) => (
                 <option key={t.name} value={t.name}>{t.label}</option>
+              ))}
+            </select>
+          </div>
+        )}
+        {showVariantPicker && (
+          <div className="flex items-center gap-2">
+            <label htmlFor={`variant-${app.id}`} className="text-[11px] text-shell-text-tertiary whitespace-nowrap">
+              Variant
+            </label>
+            <select
+              id={`variant-${app.id}`}
+              value={selectedVariant}
+              onChange={(e) => setSelectedVariant(e.target.value)}
+              className="flex-1 h-7 rounded-md border border-white/10 bg-shell-bg-deep px-2 text-[11px] text-shell-text focus-visible:outline-none focus-visible:border-accent/40 focus-visible:ring-2 focus-visible:ring-accent/20 transition-colors"
+              aria-label="Variant"
+            >
+              <option value="auto">Auto (recommended)</option>
+              {variantOptions.map((v) => (
+                <option key={v.id} value={v.id}>{v.name}</option>
               ))}
             </select>
           </div>

--- a/tinyagentos/routes/store.py
+++ b/tinyagentos/routes/store.py
@@ -69,6 +69,26 @@ async def list_catalog(request: Request, type: str | None = None):
     registry = request.app.state.registry
     installation = getattr(request.app.state, "installation_state", None)
     apps = registry.list_available(type_filter=type)
+    def _slim_variants(manifest_app) -> list[dict]:
+        """Return id/name/size for each variant. Models with multiple
+        variants need this so the Store can render a chooser instead of
+        forcing the resolver's auto-pick."""
+        if manifest_app.type != "model":
+            return []
+        out: list[dict] = []
+        for v in (manifest_app.variants or []):
+            if not isinstance(v, dict):
+                continue
+            vid = v.get("id")
+            if not vid:
+                continue
+            out.append({
+                "id": vid,
+                "name": v.get("name") or vid,
+                "size_mb": v.get("size_mb") or 0,
+            })
+        return out
+
     return [
         {
             "id": a.id, "name": a.name, "type": a.type, "category": a.category,
@@ -78,6 +98,7 @@ async def list_catalog(request: Request, type: str | None = None):
             "install_method": (a.install.get("method") or a.install.get("backend") or "") if isinstance(a.install, dict) else "",
             "installed": (installation.is_installed(a.id) if installation else registry.is_installed(a.id)),
             "state": (installation.state(a.id) if installation else ("installed" if registry.is_installed(a.id) else "not_installed")),
+            "variants": _slim_variants(a),
         }
         for a in apps
     ]


### PR DESCRIPTION
## Summary

Two small Store UX gaps the user flagged:

1. **No variant choice on models.** \`/api/store/install-v2\` already accepted \`variant_id\`, but the frontend never sent one — every install used the resolver's \"auto\" pick. Now models with >1 variant get a dropdown defaulting to \"Auto (recommended)\".
2. **Target machine chooser was LXC-only.** The \"Install on\" select was gated behind \`app.install_method === \"lxc\"\`. Cluster users want the same pick on model and other install types too — both flows route through the selected worker.

## Changes

**Backend** (\`tinyagentos/routes/store.py\`)
- \`/api/store/catalog\` now serialises a slim \`variants\` array on each \`type=model\` entry (\`id\`, \`name\`, \`size_mb\`). Non-models stay variant-free so the payload doesn't bloat.

**Frontend** (\`StoreApp/index.tsx\`)
- New \`Variant\` dropdown rendered when \`variants.length > 1\` (most multi-quant models). \"Auto (recommended)\" is the first option and sends no \`variant_id\` — preserves prior behaviour for users who don't touch it.
- Target picker visibility flipped: \`isLxc && installTargets.length > 1\` → \`installTargets.length > 1\` (any cluster).
- Install POST now includes \`variant_id\` when the user picks something other than auto.

## Test plan
- [x] \`pytest tests/test_routes_store.py\` — 15 passed
- [x] \`tsc --noEmit -p desktop/\` clean
- [ ] Live on Pi after merge: pick a non-auto variant, confirm install actually downloads that one
- [ ] Live on Pi after merge: target dropdown appears on a model card when fedora-worker is also registered