### PR TITLE
fix(store): variant.backend missing from catalog response (regression from #397)

### DIFF
--- a/tinyagentos/routes/store.py
+++ b/tinyagentos/routes/store.py
@@ -70,9 +70,12 @@ async def list_catalog(request: Request, type: str | None = None):
     installation = getattr(request.app.state, "installation_state", None)
     apps = registry.list_available(type_filter=type)
     def _slim_variants(manifest_app) -> list[dict]:
-        """Return id/name/size for each variant. Models with multiple
-        variants need this so the Store can render a chooser instead of
-        forcing the resolver's auto-pick."""
+        """Return id/name/size/backend for each variant. Models with
+        multiple variants need this so the Store can render a chooser
+        instead of forcing the resolver's auto-pick. ``backend`` is the
+        list of backend ids the variant declares under
+        ``requires.backends`` — the Store's BackendPillBar uses it to
+        derive which backend filters apply to which model."""
         if manifest_app.type != "model":
             return []
         out: list[dict] = []
@@ -82,10 +85,17 @@ async def list_catalog(request: Request, type: str | None = None):
             vid = v.get("id")
             if not vid:
                 continue
+            backend_ids: list[str] = []
+            for b in (v.get("requires", {}) or {}).get("backends", []) or []:
+                if isinstance(b, dict) and b.get("id"):
+                    backend_ids.append(b["id"])
+                elif isinstance(b, str):
+                    backend_ids.append(b)
             out.append({
                 "id": vid,
                 "name": v.get("name") or vid,
                 "size_mb": v.get("size_mb") or 0,
+                "backend": backend_ids,
             })
         return out
 


### PR DESCRIPTION
## Summary

Regression I introduced in #397. When I slimmed \`variants\` in the catalog response to \`{id, name, size_mb}\` for the variant chooser, I dropped the \`backend\` field that BackendPillBar reads:

\`\`\`ts
for (const v of app.variants ?? [])
  for (const b of v.backend ?? []) out.add(b);
\`\`\`

Combined with #396 removing the install_method fallback for apps without variants, the result was an **empty backend pill bar on the Models view** (user-reported screenshot from the Pi).

Restore by extracting backend ids from \`variant.requires.backends\` and including them as a top-level \`backend: string[]\` on each slim variant — matches the field name BackendPillBar already consumes.

## Test plan
- [x] \`pytest tests/test_routes_store.py\` — 15 passed
- [ ] Live on Pi after merge: backend pills reappear under Models with rkllama / rk-llama.cpp / ollama / llama.cpp / sentence-transformers, etc.