### PR TITLE
fix(cluster): link incus remote to worker by host_lan_ip (fixes fedora 'unknown hardware')

### DIFF
--- a/tinyagentos/routes/cluster.py
+++ b/tinyagentos/routes/cluster.py
@@ -295,13 +295,24 @@ async def list_install_targets(request: Request):
             except Exception:  # noqa: BLE001
                 tier_id = ""
             worker_tiers[w.name] = tier_id
+            # Index by every plausible host signal — URL hostname AND
+            # host_lan_ip — so an incus remote at https://192.168.x.y:8443
+            # can match a worker whose `url` field points at its local
+            # Ollama (e.g. http://localhost:11434) but who registered with
+            # the LAN IP it would use to reach the controller.
+            host_keys: set[str] = set()
             try:
                 host = _urlparse(getattr(w, "url", "") or "").hostname or ""
             except Exception:  # noqa: BLE001
                 host = ""
-            if host:
-                worker_tiers_by_host[host] = tier_id
-                workers_by_host[host] = w
+            if host and host not in ("localhost", "127.0.0.1", "::1"):
+                host_keys.add(host)
+            lan_ip = getattr(w, "host_lan_ip", None) or ""
+            if lan_ip:
+                host_keys.add(lan_ip)
+            for k in host_keys:
+                worker_tiers_by_host[k] = tier_id
+                workers_by_host[k] = w
 
     try:
         import tinyagentos.containers as containers

--- a/tinyagentos/worker/agent.py
+++ b/tinyagentos/worker/agent.py
@@ -4,10 +4,35 @@ import logging
 import platform
 import socket
 import time
+from urllib.parse import urlparse
 import httpx
 import psutil
 
 logger = logging.getLogger(__name__)
+
+
+def _detect_lan_ip(controller_url: str) -> str | None:
+    """Return the local IPv4 address the worker would use to reach the
+    controller — same address the controller sees the registration POST
+    coming from. Used to populate `host_lan_ip` on registration so the
+    install-targets matcher can link an incus remote to its worker even
+    when the worker's `url` field points at an unrelated backend (e.g.
+    the local Ollama on 127.0.0.1).
+
+    Connectionless UDP: opening a socket and calling ``connect`` makes
+    the kernel pick the outbound interface, but no packet is sent — we
+    just read ``getsockname()`` and close. Falls back to ``None`` if
+    the controller URL can't be parsed.
+    """
+    try:
+        host = urlparse(controller_url).hostname
+        if not host:
+            return None
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            s.connect((host, 9))  # UDP discard port; never delivered
+            return s.getsockname()[0]
+    except Exception:  # noqa: BLE001
+        return None
 
 
 class WorkerAgent:
@@ -294,6 +319,7 @@ class WorkerAgent:
         payload = {
             "name": self.name,
             "url": worker_url,
+            "host_lan_ip": _detect_lan_ip(self.controller_url),
             "hardware": asdict(hw),
             "backends": backends,
             "capabilities": caps,


### PR DESCRIPTION
## Summary

User reported the Store showing **\"fedora-worker has unknown hardware\"** even though a Fedora worker (registered as \`fedora-host\`) is online with full hardware data and has been used to host moved agents. The cluster manager already knew about the box; the install-targets endpoint just couldn't link the two names.

Two parts to the fix:

### Worker (\`tinyagentos/worker/agent.py\`)

The registration payload never included \`host_lan_ip\`. Added \`_detect_lan_ip(controller_url)\`:

- Opens a connectionless UDP socket toward the controller
- Kernel picks the outbound interface
- \`getsockname()\` returns the address the controller would see the registration POST coming from
- No packet is actually sent

That value goes into the registration as \`host_lan_ip\`.

### Controller (\`tinyagentos/routes/cluster.py\`)

\`list_install_targets\` now indexes workers by **both** URL hostname AND \`host_lan_ip\` when building the matcher. Loopback URL hostnames (\`localhost\`, \`127.0.0.1\`, \`::1\`) are skipped so a worker that reports \`url=http://localhost:11434\` (its local Ollama backend) doesn't pollute the lookup.

Result: an incus remote at \`https://192.168.x.y:8443\` now matches a worker that registered with \`host_lan_ip=192.168.x.y\` regardless of what it called itself or what URL it advertised.

### Existing fedora install

The current \`fedora-host\` worker was installed before this change shipped, so it has \`host_lan_ip=None\` cached on the controller. Re-running install-worker.sh on the Fedora box (or restarting the worker daemon after this PR ships) will re-register with the LAN IP and the link will form. No manual UI step on the controller.

## Test plan
- [x] \`pytest tests/test_routes_cluster.py\` — 18 passed
- [ ] Live verification on Pi after merge: re-register fedora worker, confirm Store install-targets shows fedora-worker with its real tier_id (\`x86-cuda-16gb\`-class) instead of \`unknown\`