### PR TITLE
feat(worker): forward storage-backup marker → workspace file + notification

### DIFF
--- a/tinyagentos/routes/cluster.py
+++ b/tinyagentos/routes/cluster.py
@@ -174,11 +174,25 @@ async def _surface_storage_backup(app, worker_name: str, marker: dict) -> None:
     if data_dir is None:
         return
     try:
+        import re as _re
         from pathlib import Path as _Path
-        inbox = _Path(data_dir) / "workspace" / "inbox"
+        inbox = (_Path(data_dir) / "workspace" / "inbox").resolve()
         inbox.mkdir(parents=True, exist_ok=True)
-        # Filename sortable by timestamp; safe ASCII only.
-        fname = f"worker-storage-backup-{worker_name}-{timestamp or 'unknown'}.txt"
+        # Sanitise both interpolated components — worker_name and the
+        # marker timestamp arrive over the wire and can carry slashes,
+        # NULs, or other path-traversal characters. Strip everything
+        # outside [A-Za-z0-9._-] and cap length so a hostile or weird
+        # worker can't escape the inbox via crafted filename pieces.
+        safe_re = _re.compile(r"[^A-Za-z0-9._-]+")
+        safe_worker = safe_re.sub("-", worker_name)[:64] or "worker"
+        safe_ts = safe_re.sub("-", timestamp)[:32] if timestamp else "unknown"
+        fname = f"worker-storage-backup-{safe_worker}-{safe_ts}.txt"
+        target = (inbox / fname).resolve()
+        # Belt-and-braces — even after sanitisation, refuse to write
+        # outside the inbox directory.
+        if not str(target).startswith(str(inbox) + "/") and target != inbox:
+            logger.warning("storage-backup notify: refusing write outside inbox (%s)", target)
+            return
         body_lines = [
             f"Worker storage pool backed up — {worker_name}",
             "",
@@ -200,7 +214,7 @@ async def _surface_storage_backup(app, worker_name: str, marker: dict) -> None:
             "Discard the backup once you're sure you don't need it:",
             f"  incus storage delete {backed_up}",
         ]
-        (inbox / fname).write_text("\n".join(body_lines) + "\n")
+        target.write_text("\n".join(body_lines) + "\n")
     except Exception:  # noqa: BLE001
         logger.warning("storage-backup notify: failed to write workspace inbox file")
 

--- a/tinyagentos/routes/cluster.py
+++ b/tinyagentos/routes/cluster.py
@@ -38,6 +38,12 @@ class WorkerRegister(BaseModel):
     storage_used_bytes: int = 0
     bytes_deduped_total: int = 0
     worker_lxc_image_version: str | None = None
+    # One-shot marker delivered by install-worker.sh when it backed up
+    # an existing taos-worker-pool. Controller materialises it as a
+    # workspace text file + notification so the user knows old data was
+    # preserved under the renamed pool. Worker deletes its local marker
+    # after a successful registration so this never repeats.
+    pending_storage_backup: dict | None = None
 
 
 class HeartbeatBody(BaseModel):
@@ -133,7 +139,70 @@ async def register_worker(request: Request, body: WorkerRegister):
         worker_lxc_image_version=body.worker_lxc_image_version,
     )
     await cluster.register_worker(info)
+    if body.pending_storage_backup:
+        await _surface_storage_backup(request.app, body.name, body.pending_storage_backup)
     return {"status": "registered", "name": body.name}
+
+
+async def _surface_storage_backup(app, worker_name: str, marker: dict) -> None:
+    """Materialise an install-worker storage-backup marker as both a
+    notification and a workspace text file so the user finds out about
+    the rename without needing to inspect the worker box.
+
+    Failures are swallowed — registration must succeed even if the
+    surfacing path is broken (e.g. workspace dir missing in tests).
+    """
+    backed_up = marker.get("backed_up_pool", "?")
+    original = marker.get("original_name", "taos-worker-pool")
+    timestamp = marker.get("timestamp_utc", "")
+    reason = marker.get("reason", "")
+
+    title = f"Worker '{worker_name}': storage pool backed up"
+    short_msg = (
+        f"The installer found an existing '{original}' on this worker and "
+        f"renamed it to '{backed_up}' before creating a fresh pool. "
+        f"No data was deleted — see your workspace inbox for the full note."
+    )
+    notif = getattr(app.state, "notif_store", None)
+    if notif is not None:
+        try:
+            await notif.add(title, short_msg, level="warning", source=f"worker:{worker_name}")
+        except Exception:  # noqa: BLE001
+            logger.warning("storage-backup notify: failed to add notification")
+
+    data_dir = getattr(app.state, "data_dir", None)
+    if data_dir is None:
+        return
+    try:
+        from pathlib import Path as _Path
+        inbox = _Path(data_dir) / "workspace" / "inbox"
+        inbox.mkdir(parents=True, exist_ok=True)
+        # Filename sortable by timestamp; safe ASCII only.
+        fname = f"worker-storage-backup-{worker_name}-{timestamp or 'unknown'}.txt"
+        body_lines = [
+            f"Worker storage pool backed up — {worker_name}",
+            "",
+            f"When: {timestamp or 'unknown'} (UTC)",
+            f"Reason: {reason or 'unspecified'}",
+            f"Original pool: {original}",
+            f"Renamed to:   {backed_up}",
+            "",
+            "What this means:",
+            f"  The installer detected an existing '{original}' storage pool",
+            "  on this worker and renamed it for safety before creating a",
+            "  fresh pool. Nothing was deleted. Any LXCs from the previous",
+            f"  install are still attached to '{backed_up}'.",
+            "",
+            "Recovery on the worker box:",
+            f"  incus storage list                # confirm '{backed_up}' is present",
+            f"  incus storage info {backed_up}    # check what's stored there",
+            "",
+            "Discard the backup once you're sure you don't need it:",
+            f"  incus storage delete {backed_up}",
+        ]
+        (inbox / fname).write_text("\n".join(body_lines) + "\n")
+    except Exception:  # noqa: BLE001
+        logger.warning("storage-backup notify: failed to write workspace inbox file")
 
 
 @router.post("/api/cluster/heartbeat")

--- a/tinyagentos/worker/agent.py
+++ b/tinyagentos/worker/agent.py
@@ -1,14 +1,44 @@
 from __future__ import annotations
 import asyncio
+import json
 import logging
+import os
 import platform
 import socket
 import time
+from pathlib import Path
 from urllib.parse import urlparse
 import httpx
 import psutil
 
 logger = logging.getLogger(__name__)
+
+
+# Marker dropped by install-worker.sh when it backs up an existing
+# taos-worker-pool. The worker forwards it to the controller once on
+# registration; controller materialises a notification + a workspace
+# text file. Worker deletes the marker after a successful POST so it
+# doesn't repeat the alert on every reconnect.
+_STORAGE_BACKUP_MARKER = Path("/var/lib/tinyagentos-worker/storage-backup.json")
+
+
+def _read_storage_backup_marker() -> dict | None:
+    """Return the parsed storage-backup marker if present, else None.
+    Errors swallowed — the marker is best-effort plumbing and must not
+    break worker registration."""
+    try:
+        if not _STORAGE_BACKUP_MARKER.exists():
+            return None
+        return json.loads(_STORAGE_BACKUP_MARKER.read_text())
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _delete_storage_backup_marker() -> None:
+    try:
+        _STORAGE_BACKUP_MARKER.unlink(missing_ok=True)
+    except Exception:  # noqa: BLE001
+        pass
 
 
 def _detect_lan_ip(controller_url: str) -> str | None:
@@ -330,6 +360,12 @@ class WorkerAgent:
             "kv_cache_quant_v_support": kv_quant.get("v", ["fp16"]),
             "kv_cache_quant_boundary_layer_protect": bool(kv_quant.get("boundary", False)),
         }
+        # Forward the storage-backup marker once. Controller materialises
+        # a workspace text file + a notification so the user sees the
+        # rename next time they open taOS.
+        backup = _read_storage_backup_marker()
+        if backup:
+            payload["pending_storage_backup"] = backup
 
         try:
             async with httpx.AsyncClient(timeout=10) as client:
@@ -337,6 +373,8 @@ class WorkerAgent:
                 resp.raise_for_status()
                 self._registered = True
                 logger.info(f"Registered with controller as '{self.name}'")
+                if backup:
+                    _delete_storage_backup_marker()
                 return True
         except Exception as e:
             logger.error(f"Failed to register: {e}")


### PR DESCRIPTION
## Summary

Pairs with #403 (install-worker.sh backup-or-delete prompt). When the installer renames an existing \`taos-worker-pool\`, it drops a marker JSON at \`/var/lib/tinyagentos-worker/storage-backup.json\`. Without this PR the marker just sits there — the user has no in-product signal that the rename happened.

### Worker side (\`tinyagentos/worker/agent.py\`)

- Reads the marker on registration; if present, attaches it as \`pending_storage_backup\` on the payload.
- After a successful POST, deletes the marker so the alert never repeats on heartbeat reconnects.

### Controller side (\`tinyagentos/routes/cluster.py\`)

- \`WorkerRegister\` model accepts the new optional \`pending_storage_backup\` dict.
- New \`_surface_storage_backup\` helper does two things on receipt:
  1. Fires a notification via \`app.state.notif_store\` with the worker name, the renamed pool, and a one-line summary.
  2. Writes a human-readable text file to \`data_dir/workspace/inbox/\` explaining what happened, why, and the exact incus commands to inspect or discard the backup pool.

Both paths swallow errors so a missing notif store or workspace dir doesn't break worker registration.

### Workspace file shape

\`\`\`
worker-storage-backup-fedora-worker-20260508-001234.txt

Worker storage pool backed up — fedora-worker

When: 20260508-001234 (UTC)
Reason: install-worker re-run found an existing pool; renamed for safety
Original pool: taos-worker-pool
Renamed to:   taos-worker-pool-backup-20260508-001234

What this means:
  ...
Recovery on the worker box:
  incus storage list                # confirm 'taos-worker-pool-backup-...' is present
  incus storage info taos-worker-pool-backup-...
Discard the backup once you're sure you don't need it:
  incus storage delete taos-worker-pool-backup-...
\`\`\`

## Test plan
- [x] Smoke test of \`_surface_storage_backup\` — notification fires + file appears at \`workspace/inbox/\` with correct content
- [x] \`pytest tests/test_routes_cluster.py\` — 18 passed
- [ ] After both #403 + this PR merge, run install-worker.sh on a worker that already has the pool — confirm rename happens, marker delivered, notification appears in taOS, file appears in user workspace

Stacked behind #403 (no merge conflict expected — different files).