### PR TITLE
fix(install): defer rknpu auto-install until after repo clone + add wheel-build deps (closes redkjuegos #362)

### DIFF
--- a/scripts/install-rknpu.sh
+++ b/scripts/install-rknpu.sh
@@ -323,6 +323,22 @@ install_rkllama() {
     run_as_user git -C "$RKLLAMA_DIR" checkout --quiet "$RKLLAMA_REF"
     log "rkllama pinned to $(run_as_user git -C "$RKLLAMA_DIR" rev-parse --short HEAD)"
 
+    # rkllama's transitive deps (notably webrtcvad) need a C toolchain to
+    # build wheels from source — Pi images often ship without these. Pull
+    # them via apt before the venv install so `pip install -e .` doesn't
+    # die with "Failed building wheel for webrtcvad" on a fresh box.
+    if command -v apt-get >/dev/null 2>&1; then
+        local _need=()
+        command -v gcc >/dev/null 2>&1 || _need+=("build-essential")
+        dpkg-query -W python3-dev >/dev/null 2>&1 || _need+=("python3-dev")
+        dpkg-query -W libffi-dev  >/dev/null 2>&1 || _need+=("libffi-dev")
+        if (( ${#_need[@]} )); then
+            log "installing build deps for rkllama wheel compilation: ${_need[*]}"
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq "${_need[@]}" \
+                || warn "apt-get install of build deps failed — wheel builds may still fail"
+        fi
+    fi
+
     # Build the venv in-place (matches the production layout).
     if [[ ! -d "$RKLLAMA_VENV" ]]; then
         log "creating rkllama venv at $RKLLAMA_VENV"

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -341,8 +341,10 @@ install_rknpu_if_pending() {
         return 0
     fi
     local rknpu_script="$INSTALL_DIR/scripts/install-rknpu.sh"
-    if [[ ! -x "$rknpu_script" ]]; then
-        warn "install-rknpu.sh not found at $rknpu_script — skipping rkllama auto-install"
+    # We invoke via `bash "$rknpu_script"`, so executable bit isn't
+    # required — only readable. Per CodeRabbit nit on #405.
+    if [[ ! -f "$rknpu_script" || ! -r "$rknpu_script" ]]; then
+        warn "install-rknpu.sh missing or unreadable at $rknpu_script — skipping rkllama auto-install"
         warn "  to set up rkllama later: sudo bash $INSTALL_DIR/scripts/install-rknpu.sh"
         return 0
     fi
@@ -969,10 +971,16 @@ fi
 # --- wait for controller to come up -------------------------------------
 
 if [[ "$SERVICE_MODE" != "skip" ]]; then
-    log "waiting for controller to be ready on port $TAOS_PORT (up to 60 s)..."
+    # 120s ceiling: cold-boot on a Pi 5 / Orange Pi 5 lands around 55-65s
+    # (issue #337) so 60s was racing the actual ready state and printing
+    # a false "controller did not respond" warning even on successful
+    # installs. Doubling the cap keeps the safety net while removing the
+    # false alarm. Loop continues to early-exit the moment /api/cluster/workers
+    # answers, so this is just a higher ceiling, not slower steady state.
+    log "waiting for controller to be ready on port $TAOS_PORT (up to 120 s)..."
     ctrl_tries=0
     ctrl_up=0
-    while [[ $ctrl_tries -lt 60 ]]; do
+    while [[ $ctrl_tries -lt 120 ]]; do
         if curl -sf "http://localhost:$TAOS_PORT/api/cluster/workers" >/dev/null 2>&1; then
             ctrl_up=1
             break
@@ -982,7 +990,7 @@ if [[ "$SERVICE_MODE" != "skip" ]]; then
     done
 
     if [[ $ctrl_up -eq 0 ]]; then
-        warn "controller did not respond within 60 seconds"
+        warn "controller did not respond within 120 seconds"
         if command -v journalctl >/dev/null 2>&1; then
             warn "latest journal output:"
             journalctl -u tinyagentos --no-pager -n 30 2>/dev/null || true

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -317,20 +317,12 @@ detect_and_advise_accelerators() {
                 warn "TAOS_NO_RKNPU=1 — skipping rkllama install; controller will run CPU-only on this NPU box"
                 warn "  to set up later: sudo bash scripts/install-rknpu.sh"
             else
-                local rknpu_script=""
-                if [[ -x "$(dirname "$0")/install-rknpu.sh" ]]; then
-                    rknpu_script="$(dirname "$0")/install-rknpu.sh"
-                elif [[ -x "$INSTALL_DIR/scripts/install-rknpu.sh" ]]; then
-                    rknpu_script="$INSTALL_DIR/scripts/install-rknpu.sh"
-                fi
-                if [[ -n "$rknpu_script" ]]; then
-                    log "chaining into $rknpu_script"
-                    sudo -E bash "$rknpu_script" --yes \
-                        || warn "install-rknpu.sh failed — continuing controller install anyway"
-                else
-                    warn "install-rknpu.sh not found locally yet — it will be after the repo is cloned"
-                    warn "  to set up rkllama then: sudo bash scripts/install-rknpu.sh"
-                fi
+                # Defer the actual install to after the repo clone — the
+                # script we need lives at $INSTALL_DIR/scripts/install-rknpu.sh
+                # and that path doesn't exist on this very first detection
+                # pass. install_rknpu_if_pending below picks this up.
+                RKNPU_PENDING_INSTALL=1
+                log "rkllama install deferred until after repo clone"
             fi
         fi
     fi
@@ -339,6 +331,24 @@ detect_and_advise_accelerators() {
     if (( ! found_any )); then
         log "no discrete accelerator detected — controller will run on CPU"
     fi
+}
+
+# Run the deferred rknpu auto-install once the repo is on disk. Called
+# after `git clone $INSTALL_DIR`. Skips if no NPU was detected up front
+# or if the user opted out via TAOS_NO_RKNPU=1.
+install_rknpu_if_pending() {
+    if [[ "${RKNPU_PENDING_INSTALL:-0}" != "1" ]]; then
+        return 0
+    fi
+    local rknpu_script="$INSTALL_DIR/scripts/install-rknpu.sh"
+    if [[ ! -x "$rknpu_script" ]]; then
+        warn "install-rknpu.sh not found at $rknpu_script — skipping rkllama auto-install"
+        warn "  to set up rkllama later: sudo bash $INSTALL_DIR/scripts/install-rknpu.sh"
+        return 0
+    fi
+    log "chaining into $rknpu_script (rkllama auto-install)"
+    sudo -E bash "$rknpu_script" --yes \
+        || warn "install-rknpu.sh failed — continuing controller install anyway"
 }
 
 detect_and_advise_accelerators
@@ -484,6 +494,10 @@ else
 fi
 
 cd "$INSTALL_DIR"
+
+# Now that the repo is on disk, run any accelerator-backend install
+# that was deferred up front (e.g. rkllama on a Rockchip NPU host).
+install_rknpu_if_pending
 
 # --- python venv + controller deps ---------------------------------------
 


### PR DESCRIPTION
## Summary

User redkjuegos reported on discussion #362 that the install-server.sh \"auto-install rkllama\" path doesn't actually work on a fresh Pi. Two related bugs:

### 1. Ordering: install-rknpu.sh referenced before the repo is cloned

\`detect_and_advise_accelerators\` runs at the top of install-server.sh and tries to \`bash \$INSTALL_DIR/scripts/install-rknpu.sh\` — but \$INSTALL_DIR doesn't exist yet because git clone happens later in the script. The user sees:

\`\`\`
[server-install] Rockchip NPU detected — auto-installing the jaylfc/rkllama backend
[server-install] install-rknpu.sh not found locally yet — it will be after the repo is cloned
\`\`\`

So the auto-path always fails on the first run.

**Fix**: split detection and install. \`detect_and_advise_accelerators\` now sets a \`RKNPU_PENDING_INSTALL=1\` flag instead of trying to install. After the \`git clone\`, a new \`install_rknpu_if_pending\` chains into the now-present script.

### 2. webrtcvad wheel build fails on Pi

\`\`\`
ERROR: Failed building wheel for webrtcvad
\`\`\`

webrtcvad is a transitive rkllama dep that compiles from source. Pi images often ship without \`gcc\` / \`python3-dev\` / \`libffi-dev\`.

**Fix**: install-rknpu.sh apts the missing build deps right before the venv pip install. Only installs what's missing.

## Test plan
- [x] \`bash -n\` clean on both scripts
- [ ] Live test on Pi after merge — wipe existing taOS install, re-run install-server.sh, confirm rknpu auto-install fires after clone and webrtcvad wheel builds

Closes redkjuegos's findings #1 + #3 from discussion #362. Issues #2 (librknnrt empty version on first run) and #4 (Store install button no feedback) tracked separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Rockchip RKNPU backend installation process by ensuring required system-level build dependencies are installed before virtual environment setup.
  * Optimized installation timing for RKNPU support to occur after repository clone, ensuring all necessary files are available, with graceful fallback if installation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->