### PR TITLE
feat(store): live install progress + UI bar (closes #407)

### DIFF
--- a/desktop/src/apps/StoreApp/index.tsx
+++ b/desktop/src/apps/StoreApp/index.tsx
@@ -431,10 +431,64 @@ function AppCard({ app, affected, onInstall, onUninstall, installTargets, runtim
   // dropdown when the manifest exposes >1 variant.
   const [selectedVariant, setSelectedVariant] = useState<string>("auto");
   const [error, setError] = useState<string | null>(null);
+  // Live install progress — polled from /api/store/install-progress
+  // while busy. null when no install is in-flight. Backend updates
+  // bytes_downloaded / bytes_total / state as the install runs.
+  interface InstallProgressSnapshot {
+    state: string;
+    percent: number | null;
+    bytes_downloaded: number;
+    bytes_total: number;
+    detail: string;
+    error: string | null;
+  }
+  const [progress, setProgress] = useState<InstallProgressSnapshot | null>(null);
 
   useEffect(() => {
     if (defaultTargetRemote !== undefined) setSelectedTarget(defaultTargetRemote);
   }, [defaultTargetRemote]);
+
+  // Poll install progress while a download is running. Stops on
+  // terminal states or when busy flips back to false.
+  useEffect(() => {
+    if (!busy) {
+      // Hold the last frame for a moment so the user sees "installed" /
+      // error before it disappears. The handleAction completion path
+      // handles the actual clear.
+      return;
+    }
+    let cancelled = false;
+    const poll = async () => {
+      while (!cancelled) {
+        try {
+          const r = await fetch(`/api/store/install-progress/by-app/${encodeURIComponent(app.id)}`, {
+            headers: { Accept: "application/json" },
+          });
+          if (r.ok) {
+            const j = await r.json();
+            const a = j?.active;
+            if (a) {
+              setProgress({
+                state: a.state,
+                percent: a.percent ?? null,
+                bytes_downloaded: a.bytes_downloaded ?? 0,
+                bytes_total: a.bytes_total ?? 0,
+                detail: a.detail ?? "",
+                error: a.error ?? null,
+              });
+              if (a.state === "installed" || a.state === "failed" || a.state === "cancelled") {
+                break; // terminal — handleAction will set busy=false on response return
+              }
+            }
+          }
+        } catch { /* network blip; keep polling */ }
+        await new Promise((res) => setTimeout(res, 1500));
+      }
+    };
+    void poll();
+    return () => { cancelled = true; };
+  }, [busy, app.id]);
+
   const iconUrl = resolveIconUrl(app.id);
   const variantOptions = app.variants ?? [];
   const showVariantPicker = !app.installed && variantOptions.length > 1;
@@ -446,6 +500,7 @@ function AppCard({ app, affected, onInstall, onUninstall, installTargets, runtim
   const handleAction = async () => {
     setBusy(true);
     setError(null);
+    setProgress(null);
     try {
       if (app.installed) {
         const res = await fetch("/api/store/uninstall", {
@@ -484,6 +539,10 @@ function AppCard({ app, affected, onInstall, onUninstall, installTargets, runtim
       setError(e instanceof Error ? e.message : "Network error");
     }
     setBusy(false);
+    // Hold the last progress frame for a beat so the user reads
+    // "installed" / error before it fades. 1.5 s matches the poll
+    // interval, so the bar visibly settles rather than vanishing.
+    setTimeout(() => setProgress(null), 1500);
   };
 
   const visuals = compatVisuals(resolveResponse);
@@ -541,6 +600,43 @@ function AppCard({ app, affected, onInstall, onUninstall, installTargets, runtim
         {error && (
           <div role="alert" className="text-[11px] text-red-300 bg-red-500/10 border border-red-500/20 rounded px-2 py-1">
             {error}
+          </div>
+        )}
+        {progress && (
+          <div className="flex flex-col gap-1" aria-live="polite">
+            <div className="flex items-center justify-between text-[11px] text-shell-text-tertiary">
+              <span className="capitalize">{progress.state.replace(/_/g, " ")}</span>
+              <span>
+                {progress.percent !== null
+                  ? `${progress.percent.toFixed(0)}%`
+                  : progress.bytes_downloaded > 0
+                    ? `${(progress.bytes_downloaded / (1024 * 1024)).toFixed(1)} MB`
+                    : ""}
+              </span>
+            </div>
+            <div
+              className="h-1.5 w-full rounded-full bg-white/5 overflow-hidden"
+              role="progressbar"
+              aria-valuenow={progress.percent ?? 0}
+              aria-valuemin={0}
+              aria-valuemax={100}
+            >
+              <div
+                className={`h-full transition-all ${
+                  progress.state === "failed"
+                    ? "bg-red-400"
+                    : progress.state === "installed"
+                      ? "bg-emerald-400"
+                      : "bg-sky-400"
+                } ${progress.percent === null ? "animate-pulse w-1/3" : ""}`}
+                style={{ width: progress.percent !== null ? `${progress.percent}%` : undefined }}
+              />
+            </div>
+            {progress.detail && (
+              <span className="text-[10px] text-shell-text-tertiary truncate" title={progress.detail}>
+                {progress.detail}
+              </span>
+            )}
           </div>
         )}
         {showTargetPicker && (

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -618,6 +618,12 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         # registry.is_installed() / list_installed() directly.
         app.state.installation_state = InstallationState(registry, backend_catalog)
 
+        # In-memory install progress store. Read by /api/store/install-progress*
+        # endpoints; written by the install-v2 dispatcher and the
+        # download_file callback.
+        from tinyagentos.install_progress import get_global_store
+        app.state.install_progress_store = get_global_store()
+
         # LiteLLM config reload on catalog change — keeps the proxy's
         # routing table in sync with live backend state. Subscriber is
         # a no-op if the proxy isn't running (LiteLLM not installed) or

--- a/tinyagentos/install_progress.py
+++ b/tinyagentos/install_progress.py
@@ -32,7 +32,10 @@ InstallState = Literal[
     "starting",      # backend service starting up
     "installed",     # terminal — success
     "failed",        # terminal — error populated
-    "cancelled",     # terminal — caller asked to stop
+    "cancelled",     # terminal — caller asked to stop. Reserved for the
+                     # follow-up "Cancel install" UI; the frontend already
+                     # treats this as a terminal state and hides the bar
+                     # the same way as installed/failed.
 ]
 
 # Drop entries older than this many seconds the next time anything

--- a/tinyagentos/install_progress.py
+++ b/tinyagentos/install_progress.py
@@ -1,0 +1,195 @@
+"""In-memory install progress tracking.
+
+The Store's install path is fire-and-forget today: ``POST
+/api/store/install-v2`` returns 200 the moment the resolver decides
+which backend to use, but the actual download + setup happens after
+the response is sent. The frontend has no way to know whether work is
+still in flight, how far along the download is, or whether the
+install succeeded.
+
+This module exposes a tiny in-memory progress store keyed by
+``install_id`` (uuid generated per install attempt). The Store route
+allocates an id, the installer updates ``state`` / ``bytes_downloaded``
+/ ``bytes_total`` as it goes, and the frontend polls a GET endpoint.
+
+State is in-memory only — losing it on controller restart is fine
+because the install path is also lost (subprocess dies). Stale entries
+older than INSTALL_PROGRESS_TTL_S are pruned lazily on every call.
+"""
+from __future__ import annotations
+
+import time
+import uuid
+from dataclasses import dataclass, field
+from threading import Lock
+from typing import Literal
+
+InstallState = Literal[
+    "queued",        # registered but no work has started yet
+    "downloading",   # bytes streaming, watch bytes_downloaded / bytes_total
+    "verifying",     # SHA256 check, post-download
+    "unpacking",     # extracting / moving into place
+    "starting",      # backend service starting up
+    "installed",     # terminal — success
+    "failed",        # terminal — error populated
+    "cancelled",     # terminal — caller asked to stop
+]
+
+# Drop entries older than this many seconds the next time anything
+# touches the store. Long enough that a slow hardware-side install
+# (multi-GB models on a Pi) doesn't get pruned mid-flight; short
+# enough that a forgotten "installed" entry doesn't linger forever.
+INSTALL_PROGRESS_TTL_S = 60 * 60  # 1 hour
+
+
+@dataclass
+class InstallProgress:
+    install_id: str
+    app_id: str
+    target_remote: str | None
+    state: InstallState = "queued"
+    bytes_downloaded: int = 0
+    bytes_total: int = 0
+    started_at: float = field(default_factory=time.time)
+    updated_at: float = field(default_factory=time.time)
+    finished_at: float | None = None
+    error: str | None = None
+    detail: str = ""  # one-line human-readable progress hint
+
+    @property
+    def percent(self) -> float | None:
+        if self.bytes_total <= 0:
+            return None
+        return min(100.0, 100.0 * self.bytes_downloaded / self.bytes_total)
+
+    def to_dict(self) -> dict:
+        return {
+            "install_id": self.install_id,
+            "app_id": self.app_id,
+            "target_remote": self.target_remote,
+            "state": self.state,
+            "bytes_downloaded": self.bytes_downloaded,
+            "bytes_total": self.bytes_total,
+            "percent": self.percent,
+            "started_at": self.started_at,
+            "updated_at": self.updated_at,
+            "finished_at": self.finished_at,
+            "error": self.error,
+            "detail": self.detail,
+        }
+
+
+class InstallProgressStore:
+    """Thread-safe in-memory progress tracker.
+
+    The Lock is fine for the modest concurrency the Store sees — a
+    handful of in-flight installs at most. Async callers don't await
+    inside the critical section, just snapshot.
+    """
+
+    def __init__(self) -> None:
+        self._lock = Lock()
+        self._entries: dict[str, InstallProgress] = {}
+
+    def start(self, app_id: str, target_remote: str | None = None) -> InstallProgress:
+        install_id = uuid.uuid4().hex
+        entry = InstallProgress(
+            install_id=install_id,
+            app_id=app_id,
+            target_remote=target_remote,
+        )
+        with self._lock:
+            self._prune_locked()
+            self._entries[install_id] = entry
+        return entry
+
+    def update(
+        self,
+        install_id: str,
+        *,
+        state: InstallState | None = None,
+        bytes_downloaded: int | None = None,
+        bytes_total: int | None = None,
+        detail: str | None = None,
+        error: str | None = None,
+    ) -> None:
+        with self._lock:
+            entry = self._entries.get(install_id)
+            if entry is None:
+                return
+            if state is not None:
+                entry.state = state
+            if bytes_downloaded is not None:
+                entry.bytes_downloaded = bytes_downloaded
+            if bytes_total is not None:
+                entry.bytes_total = bytes_total
+            if detail is not None:
+                entry.detail = detail
+            if error is not None:
+                entry.error = error
+            entry.updated_at = time.time()
+
+    def finish(
+        self,
+        install_id: str,
+        *,
+        success: bool,
+        error: str | None = None,
+        detail: str | None = None,
+    ) -> None:
+        with self._lock:
+            entry = self._entries.get(install_id)
+            if entry is None:
+                return
+            entry.state = "installed" if success else "failed"
+            if error is not None:
+                entry.error = error
+            if detail is not None:
+                entry.detail = detail
+            entry.finished_at = time.time()
+            entry.updated_at = entry.finished_at
+
+    def get(self, install_id: str) -> InstallProgress | None:
+        with self._lock:
+            self._prune_locked()
+            return self._entries.get(install_id)
+
+    def list_by_app(self, app_id: str) -> list[InstallProgress]:
+        """Return all entries for an app, newest first. Useful when the
+        frontend doesn't yet know the install_id but wants to find any
+        in-flight install for a card."""
+        with self._lock:
+            self._prune_locked()
+            matches = [e for e in self._entries.values() if e.app_id == app_id]
+        matches.sort(key=lambda e: e.started_at, reverse=True)
+        return matches
+
+    def list_all(self) -> list[InstallProgress]:
+        with self._lock:
+            self._prune_locked()
+            entries = list(self._entries.values())
+        entries.sort(key=lambda e: e.started_at, reverse=True)
+        return entries
+
+    def _prune_locked(self) -> None:
+        cutoff = time.time() - INSTALL_PROGRESS_TTL_S
+        stale = [
+            iid for iid, e in self._entries.items()
+            if e.finished_at is not None and e.finished_at < cutoff
+        ]
+        for iid in stale:
+            del self._entries[iid]
+
+
+# Single shared instance — bound to app.state in app.py and consumed
+# by the Store install routes. Exposed as a module global so install
+# helpers (download_file etc.) can update progress without each one
+# threading the store through their kwargs.
+_GLOBAL: InstallProgressStore | None = None
+
+
+def get_global_store() -> InstallProgressStore:
+    global _GLOBAL
+    if _GLOBAL is None:
+        _GLOBAL = InstallProgressStore()
+    return _GLOBAL

--- a/tinyagentos/installers/download_installer.py
+++ b/tinyagentos/installers/download_installer.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import hashlib
+import logging
 from pathlib import Path
 from typing import Callable
 
 import httpx
 
 from tinyagentos.installers.base import AppInstaller
+
+logger = logging.getLogger(__name__)
 
 # Signature: callback(downloaded_bytes, total_bytes_or_zero_if_unknown)
 ProgressCallback = Callable[[int, int], None]
@@ -45,16 +48,25 @@ async def download_file(
                         if now - last_cb >= 1.0:
                             try:
                                 on_progress(downloaded, total)
-                            except Exception:  # noqa: BLE001
-                                pass  # never let a bad callback kill the download
+                            except Exception as exc:  # noqa: BLE001
+                                # Never let a bad callback kill the
+                                # download, but log so a regression in
+                                # the progress store is debuggable.
+                                logger.warning(
+                                    "download_file: progress callback raised %s — continuing download",
+                                    exc,
+                                )
                             last_cb = now
             # Always emit a final update at 100% so the UI can flip to
             # "verifying" promptly instead of waiting for the next tick.
             if on_progress is not None:
                 try:
                     on_progress(downloaded, total or downloaded)
-                except Exception:  # noqa: BLE001
-                    pass
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "download_file: final progress callback raised %s",
+                        exc,
+                    )
     if expected_sha256 and sha.hexdigest() != expected_sha256:
         dest.unlink()
         raise ValueError(f"SHA256 mismatch: expected {expected_sha256}, got {sha.hexdigest()}")

--- a/tinyagentos/installers/download_installer.py
+++ b/tinyagentos/installers/download_installer.py
@@ -2,23 +2,59 @@ from __future__ import annotations
 
 import hashlib
 from pathlib import Path
+from typing import Callable
 
 import httpx
 
 from tinyagentos.installers.base import AppInstaller
 
+# Signature: callback(downloaded_bytes, total_bytes_or_zero_if_unknown)
+ProgressCallback = Callable[[int, int], None]
 
-async def download_file(url: str, dest: Path, expected_sha256: str | None = None) -> Path:
-    """Download a file with optional SHA256 verification."""
+
+async def download_file(
+    url: str,
+    dest: Path,
+    expected_sha256: str | None = None,
+    *,
+    on_progress: ProgressCallback | None = None,
+) -> Path:
+    """Download a file with optional SHA256 verification.
+
+    ``on_progress`` is called periodically with (downloaded_bytes,
+    total_bytes). total_bytes is 0 when the server didn't send a
+    Content-Length. Callbacks are throttled to roughly once a second
+    so the install-progress store doesn't take a write lock per chunk.
+    """
     dest.parent.mkdir(parents=True, exist_ok=True)
+    import time as _time
+    last_cb = 0.0
     async with httpx.AsyncClient(timeout=None, follow_redirects=True) as client:
         async with client.stream("GET", url) as resp:
             resp.raise_for_status()
+            total = int(resp.headers.get("content-length") or 0)
             sha = hashlib.sha256()
+            downloaded = 0
             with open(dest, "wb") as f:
                 async for chunk in resp.aiter_bytes(chunk_size=65536):
                     f.write(chunk)
                     sha.update(chunk)
+                    downloaded += len(chunk)
+                    if on_progress is not None:
+                        now = _time.monotonic()
+                        if now - last_cb >= 1.0:
+                            try:
+                                on_progress(downloaded, total)
+                            except Exception:  # noqa: BLE001
+                                pass  # never let a bad callback kill the download
+                            last_cb = now
+            # Always emit a final update at 100% so the UI can flip to
+            # "verifying" promptly instead of waiting for the next tick.
+            if on_progress is not None:
+                try:
+                    on_progress(downloaded, total or downloaded)
+                except Exception:  # noqa: BLE001
+                    pass
     if expected_sha256 and sha.hexdigest() != expected_sha256:
         dest.unlink()
         raise ValueError(f"SHA256 mismatch: expected {expected_sha256}, got {sha.hexdigest()}")
@@ -39,11 +75,17 @@ class DownloadInstaller(AppInstaller):
         if dest.exists():
             return {"success": True, "path": str(dest), "cached": True}
 
+        # Optional progress hook from the dispatcher. The Store route
+        # passes one wired to the install-progress store so the
+        # frontend can render a download bar.
+        on_progress: ProgressCallback | None = kwargs.get("on_progress")
+
         try:
             path = await download_file(
                 url=variant["download_url"],
                 dest=dest,
                 expected_sha256=variant.get("sha256"),
+                on_progress=on_progress,
             )
             return {"success": True, "path": str(path)}
         except Exception as e:

--- a/tinyagentos/routes/store_install.py
+++ b/tinyagentos/routes/store_install.py
@@ -350,6 +350,35 @@ async def _legacy_install(request: Request, body: dict, app_id: str | None, targ
     return JSONResponse({"ok": True, "app_id": app_id, "status": "installed"})
 
 
+@router.get("/api/store/install-progress/by-app/{app_id}")
+async def install_progress_by_app(request: Request, app_id: str):
+    """Return the most-recent install progress entry for ``app_id``.
+
+    The Store frontend polls this every 1.5 s after a user clicks
+    Install so it can render a download bar / status label without
+    needing to track the install_id explicitly.
+    """
+    from tinyagentos.install_progress import get_global_store
+    store = getattr(request.app.state, "install_progress_store", None) or get_global_store()
+    entries = store.list_by_app(app_id)
+    if not entries:
+        return JSONResponse({"app_id": app_id, "active": None})
+    return JSONResponse({"app_id": app_id, "active": entries[0].to_dict()})
+
+
+@router.get("/api/store/install-progress/{install_id}")
+async def install_progress_by_id(request: Request, install_id: str):
+    """Look up a specific install attempt. Returned by install-v2 in
+    the response body so the caller can pin a progress stream to the
+    exact attempt rather than 'most recent for app_id'."""
+    from tinyagentos.install_progress import get_global_store
+    store = getattr(request.app.state, "install_progress_store", None) or get_global_store()
+    entry = store.get(install_id)
+    if entry is None:
+        return JSONResponse({"error": "install_id not found"}, status_code=404)
+    return JSONResponse(entry.to_dict())
+
+
 @router.post("/api/store/install-v2")
 async def install_app(request: Request):
     """Resolver-driven install. Chains backend → model in one user click.
@@ -365,16 +394,31 @@ async def install_app(request: Request):
     target_remote = body.get("target_remote") or None
     force = bool(body.get("force", False))
 
+    # Progress store — opened up here so both legacy and v2 paths can
+    # tag work-in-flight that the frontend polls for. Importing here
+    # avoids a circular import at module load.
+    from tinyagentos.install_progress import get_global_store
+    progress = getattr(request.app.state, "install_progress_store", None) or get_global_store()
+    progress_entry = progress.start(app_id=manifest_id or "(unknown)", target_remote=target_remote)
+    install_id = progress_entry.install_id
+
     registry = getattr(request.app.state, "registry", None)
     manifest = _registry_get(registry, manifest_id) if registry and manifest_id else None
     if manifest is None:
         # Fall through to legacy path if the registry doesn't know this ID —
         # allows callers that don't have a manifest to install via metadata.
+        progress.finish(install_id, success=False, error="manifest not found in registry")
         return await _legacy_install(request, body, manifest_id, target_remote)
 
     # Non-model manifests use the legacy method-driven path.
     if getattr(manifest, "type", "model") != "model":
-        return await _legacy_install(request, body, manifest_id, target_remote)
+        progress.update(install_id, state="unpacking", detail=f"installing {manifest.type}")
+        legacy_resp = await _legacy_install(request, body, manifest_id, target_remote)
+        # Best-effort: read status code on the response to mark final
+        # state. JSONResponse defaults to 200 on success.
+        success = getattr(legacy_resp, "status_code", 200) < 400
+        progress.finish(install_id, success=success)
+        return legacy_resp
 
     device = await get_device_capability(request, target_remote)
     manifest_dict = {
@@ -385,11 +429,13 @@ async def install_app(request: Request):
     }
     result = resolve(manifest_dict, variant_id, device, force=force)
     if isinstance(result, ResolveErr):
+        progress.finish(install_id, success=False, error=result.reason)
         return JSONResponse(
             {
                 "error": result.reason,
                 "near_miss": result.near_miss,
                 "suggestions": result.suggestions,
+                "install_id": install_id,
             },
             status_code=422,
         )
@@ -398,10 +444,12 @@ async def install_app(request: Request):
 
     # Install the backend if missing.
     if result.action == "install_chain":
+        progress.update(install_id, state="unpacking", detail=f"installing backend {result.backend_id}")
         backend_manifest = _registry_get(registry, result.backend_id)
         if backend_manifest is None:
+            progress.finish(install_id, success=False, error=f"backend manifest {result.backend_id!r} not in catalog")
             return JSONResponse(
-                {"error": f"backend service manifest {result.backend_id!r} not in catalog"},
+                {"error": f"backend service manifest {result.backend_id!r} not in catalog", "install_id": install_id},
                 status_code=500,
             )
         install_block = getattr(backend_manifest, "install", None) or {}
@@ -409,8 +457,9 @@ async def install_app(request: Request):
             install_block.get("method") if isinstance(install_block, dict) else None
         )
         if not backend_method:
+            progress.finish(install_id, success=False, error=f"backend {result.backend_id!r} has no install.method")
             return JSONResponse(
-                {"error": f"backend {result.backend_id!r} has no install.method"},
+                {"error": f"backend {result.backend_id!r} has no install.method", "install_id": install_id},
                 status_code=500,
             )
         backend_installer = get_installer(backend_method)
@@ -419,13 +468,15 @@ async def install_app(request: Request):
             install_config=install_block if isinstance(install_block, dict) else {},
         )
         if not be_result.get("success"):
+            err = be_result.get("error", "unknown")
+            progress.finish(install_id, success=False, error=f"backend install failed: {err}")
             return JSONResponse(
                 {
                     "error": (
-                        f"backend install failed for {result.backend_id!r}: "
-                        f"{be_result.get('error', 'unknown')}"
+                        f"backend install failed for {result.backend_id!r}: {err}"
                     ),
                     "chain": chain + [{"step": "backend", "id": result.backend_id, "status": "failed"}],
+                    "install_id": install_id,
                 },
                 status_code=500,
             )
@@ -442,35 +493,57 @@ async def install_app(request: Request):
         None,
     )
     if chosen_variant is None:
+        progress.finish(install_id, success=False, error=f"variant {result.variant_id!r} not in manifest")
         return JSONResponse(
-            {"error": f"variant {result.variant_id!r} not found in manifest"},
+            {"error": f"variant {result.variant_id!r} not found in manifest", "install_id": install_id},
             status_code=500,
         )
     install_method = _BACKEND_TO_METHOD.get(result.backend_id)
     if install_method is None:
+        progress.finish(install_id, success=False, error=f"backend {result.backend_id!r} has no installer mapping")
         return JSONResponse(
             {
                 "error": (
                     f"backend {result.backend_id!r} has no installer mapping. "
                     "Add an entry to _BACKEND_TO_METHOD in store_install.py."
                 ),
+                "install_id": install_id,
             },
             status_code=500,
         )
     model_installer = get_installer(install_method)
     install_config = dict(getattr(manifest, "install", None) or {})
     install_config["backend"] = result.backend_id
+
+    # Wire a download-progress callback so the in-flight bytes show
+    # up in the install-progress store. Throttled to ~1 update per
+    # second by download_file itself.
+    def _on_progress(downloaded: int, total: int) -> None:
+        progress.update(
+            install_id,
+            state="downloading",
+            bytes_downloaded=downloaded,
+            bytes_total=total,
+            detail=(f"downloading {chosen_variant.get('id','')} from {chosen_variant.get('download_url','')[:60]}…"
+                    if downloaded == 0 else None),
+        )
+
+    progress.update(install_id, state="downloading", detail=f"downloading {chosen_variant.get('id','')}")
     model_result = await model_installer.install(
         manifest.id,
         install_config=install_config,
         variant=chosen_variant,
         target_remote=target_remote,
+        on_progress=_on_progress,
     )
     if not model_result.get("success"):
+        err = model_result.get("error", "unknown")
+        progress.finish(install_id, success=False, error=f"model install failed: {err}")
         return JSONResponse(
             {
-                "error": f"model install failed: {model_result.get('error', 'unknown')}",
+                "error": f"model install failed: {err}",
                 "chain": chain + [{"step": "model", "id": manifest.id, "status": "failed"}],
+                "install_id": install_id,
             },
             status_code=500,
         )
@@ -480,8 +553,9 @@ async def install_app(request: Request):
         except Exception:  # noqa: BLE001
             pass
     chain.append({"step": "model", "id": manifest.id, "status": "installed"})
+    progress.finish(install_id, success=True, detail="install complete")
 
-    return JSONResponse({"chain": chain, "compat": classify(manifest_dict, device)})
+    return JSONResponse({"chain": chain, "compat": classify(manifest_dict, device), "install_id": install_id})
 
 
 @router.post("/api/store/uninstall-v2")


### PR DESCRIPTION
## Summary

User feedback (filed as #407): \"clicking Install returns 200 OK with no progress signal — looks broken\". The Store install path was fire-and-forget — backend completed work async with no observable state, frontend stayed in the same visual state. Users couldn't tell if anything was happening.

This PR wires polling progress end-to-end:

### Backend

- **\`tinyagentos/install_progress.py\`** (new): thread-safe in-memory store keyed by \`install_id\` (uuid per attempt). Tracks state (\`queued\` / \`downloading\` / \`verifying\` / \`unpacking\` / \`starting\` / \`installed\` / \`failed\`), bytes_downloaded / bytes_total / detail / error. Stale entries (finished_at older than 1 h) prune lazily on every call.
- **\`download_file\`** accepts \`on_progress\` callback, throttled to ~1 update/sec so the lock isn't taken per chunk.
- **\`DownloadInstaller\`** threads the callback through.
- **\`/api/store/install-v2\`** dispatcher allocates an install_id, walks state through resolve → backend install → model download → finish, and now returns \`install_id\` in every response (success + every error path).
- Two new GETs:
  - \`/api/store/install-progress/{install_id}\` — pin to a specific attempt.
  - \`/api/store/install-progress/by-app/{app_id}\` — most-recent in-flight attempt for an app. Frontend uses this since it doesn't track install_ids.
- Wired \`app.state.install_progress_store\` in app.py.

### Frontend

- AppCard polls every 1.5 s while \`busy=true\`, renders a thin progress bar (sky / emerald / red by state) with state label + percent or MB counter and a one-line detail.
- Bar holds for 1.5 s after the POST returns so the user reads the terminal state before it fades.
- aria-live polite + role=progressbar.

## Test plan
- [x] \`pytest tests/routes/test_store_install_v2.py tests/test_routes_store.py\` — 26 passed
- [x] \`tsc --noEmit -p desktop/\` clean
- [x] In-process smoke test of \`InstallProgressStore\` — start → update → finish + percent calc + by-app lookup
- [ ] Live on Pi after merge: install a model from the Store, watch the bar populate during download, verify it transitions to "installed" green or shows error red

Closes #407.