### PR TITLE
feat(catalog): pack 2 — OCR / document parsing manifests

### DIFF
--- a/app-catalog/services/marker-pdf/manifest.yaml
+++ b/app-catalog/services/marker-pdf/manifest.yaml
@@ -1,0 +1,24 @@
+id: marker-pdf
+name: Marker
+type: service
+category: productivity
+version: 1.0.0
+description: "PDF → clean Markdown converter — preserves tables, equations, and structure. Fast and accurate, especially on academic papers."
+homepage: https://github.com/VikParuchuri/marker
+license: GPL-3.0
+
+requires:
+  ram_mb: 4096
+  python: ">=3.10"
+
+install:
+  method: pip
+  package: marker-pdf
+
+hardware_tiers:
+  arm-npu-16gb: degraded
+  arm-npu-32gb: full
+  x86-cuda-12gb: full
+  x86-vulkan-8gb: degraded
+  cpu-only: degraded
+  apple-silicon: full

--- a/app-catalog/services/mineru/manifest.yaml
+++ b/app-catalog/services/mineru/manifest.yaml
@@ -1,0 +1,25 @@
+id: mineru
+name: MinerU
+type: service
+category: productivity
+version: 1.0.0
+description: "PDF → structured Markdown / JSON with tables, formulas, and figures. Strong scientific and financial document parsing."
+homepage: https://github.com/opendatalab/MinerU
+license: AGPL-3.0
+
+requires:
+  ram_mb: 6144
+  disk_mb: 4000
+  python: ">=3.10"
+
+install:
+  method: pip
+  package: magic-pdf
+
+hardware_tiers:
+  arm-npu-16gb: degraded
+  arm-npu-32gb: full
+  x86-cuda-12gb: full
+  x86-vulkan-8gb: degraded
+  cpu-only: degraded
+  apple-silicon: full

--- a/app-catalog/services/paddleocr/manifest.yaml
+++ b/app-catalog/services/paddleocr/manifest.yaml
@@ -1,0 +1,24 @@
+id: paddleocr
+name: PaddleOCR
+type: service
+category: productivity
+version: 2.7.3
+description: "Baidu's deep-learning OCR — strong on layout-rich documents and CJK languages. Detection + recognition + table extraction in one pipeline."
+homepage: https://github.com/PaddlePaddle/PaddleOCR
+license: Apache-2.0
+
+requires:
+  ram_mb: 1024
+  python: ">=3.9"
+
+install:
+  method: pip
+  package: paddleocr
+
+hardware_tiers:
+  arm-npu-16gb: degraded
+  arm-npu-32gb: full
+  x86-cuda-12gb: full
+  x86-vulkan-8gb: degraded
+  cpu-only: degraded
+  apple-silicon: full

--- a/app-catalog/services/surya-ocr/manifest.yaml
+++ b/app-catalog/services/surya-ocr/manifest.yaml
@@ -1,0 +1,24 @@
+id: surya-ocr
+name: Surya OCR
+type: service
+category: productivity
+version: 0.6.0
+description: "Multilingual OCR with layout, reading-order, and table detection. Strong on 90+ languages including handwriting."
+homepage: https://github.com/VikParuchuri/surya
+license: GPL-3.0
+
+requires:
+  ram_mb: 4096
+  python: ">=3.10"
+
+install:
+  method: pip
+  package: surya-ocr
+
+hardware_tiers:
+  arm-npu-16gb: degraded
+  arm-npu-32gb: full
+  x86-cuda-12gb: full
+  x86-vulkan-8gb: degraded
+  cpu-only: degraded
+  apple-silicon: full

--- a/app-catalog/services/tesseract-ocr/manifest.yaml
+++ b/app-catalog/services/tesseract-ocr/manifest.yaml
@@ -1,0 +1,25 @@
+id: tesseract-ocr
+name: Tesseract OCR
+type: service
+category: productivity
+version: 5.3.4
+description: "Classic OCR engine — fast, lightweight, 100+ languages. The baseline for plain text extraction from images and scans."
+homepage: https://github.com/tesseract-ocr/tesseract
+license: Apache-2.0
+
+requires:
+  ram_mb: 256
+  disk_mb: 200
+
+install:
+  method: apt
+  package: tesseract-ocr
+
+hardware_tiers:
+  arm-npu-16gb: full
+  arm-npu-32gb: full
+  arm-cpu-8gb: full
+  x86-cuda-12gb: full
+  x86-vulkan-8gb: full
+  cpu-only: full
+  apple-silicon: full


### PR DESCRIPTION
## Summary

First slice of the multimedia-pack roadmap (#408 tracking issue). Adds the 5 OCR / document-parsing services from pack 2:

- \`tesseract-ocr\` — classic OCR engine, fast, 100+ languages, apt install
- \`paddleocr\` — Baidu's deep-learning OCR with table extraction, pip
- \`marker-pdf\` — PDF→Markdown with structure preservation, pip
- \`surya-ocr\` — multilingual OCR with layout + reading order, pip
- \`mineru\` — scientific PDF parsing with tables / formulas, pip

\`docling\` was already in catalog under productivity so it's not re-added.

## Hardware tiers

Tesseract is light enough to run anywhere (\`full\` on every tier). The deep-learning ones run on CPU but degraded; full on CUDA / Apple Silicon / 32 GB-class arm-npu.

## Test plan
- [x] \`scripts/audit-manifests.py\` clean
- [x] All 5 manifests parse as valid YAML
- [ ] Live install verification on Pi after merge — gated on the docker/service install path being healthy (#410)

Part of #408.

---
_Jay is asleep right now so this PR was opened by Claude Opus 4.7._