### PR TITLE
feat(catalog): pack 3 — speech-to-text manifests

### DIFF
--- a/app-catalog/services/distil-whisper/manifest.yaml
+++ b/app-catalog/services/distil-whisper/manifest.yaml
@@ -2,7 +2,7 @@ id: distil-whisper
 name: Distil-Whisper
 type: service
 category: voice
-version: 0.0.0
+version: 1.0.0
 description: "Hugging Face's distilled Whisper — 6× faster than whisper-large-v3 at within 1% WER. Drop-in via transformers."
 homepage: https://github.com/huggingface/distil-whisper
 license: MIT

--- a/app-catalog/services/distil-whisper/manifest.yaml
+++ b/app-catalog/services/distil-whisper/manifest.yaml
@@ -1,0 +1,24 @@
+id: distil-whisper
+name: Distil-Whisper
+type: service
+category: voice
+version: 0.0.0
+description: "Hugging Face's distilled Whisper — 6× faster than whisper-large-v3 at within 1% WER. Drop-in via transformers."
+homepage: https://github.com/huggingface/distil-whisper
+license: MIT
+
+requires:
+  ram_mb: 3072
+  python: ">=3.9"
+
+install:
+  method: pip
+  package: transformers
+
+hardware_tiers:
+  arm-npu-16gb: degraded
+  arm-npu-32gb: full
+  x86-cuda-12gb: full
+  x86-vulkan-8gb: degraded
+  cpu-only: degraded
+  apple-silicon: full

--- a/app-catalog/services/faster-whisper/manifest.yaml
+++ b/app-catalog/services/faster-whisper/manifest.yaml
@@ -1,0 +1,25 @@
+id: faster-whisper
+name: faster-whisper
+type: service
+category: voice
+version: 1.0.3
+description: "CTranslate2-backed Whisper — 4-8× faster than openai/whisper at the same accuracy. Streaming and batched inference, runs on CPU + CUDA + Apple Silicon."
+homepage: https://github.com/SYSTRAN/faster-whisper
+license: MIT
+
+requires:
+  ram_mb: 2048
+  python: ">=3.9"
+
+install:
+  method: pip
+  package: faster-whisper
+
+hardware_tiers:
+  arm-npu-16gb: full
+  arm-npu-32gb: full
+  arm-cpu-8gb: degraded
+  x86-cuda-12gb: full
+  x86-vulkan-8gb: degraded
+  cpu-only: degraded
+  apple-silicon: full

--- a/app-catalog/services/parakeet-nemo/manifest.yaml
+++ b/app-catalog/services/parakeet-nemo/manifest.yaml
@@ -1,0 +1,24 @@
+id: parakeet-nemo
+name: NVIDIA Parakeet (NeMo)
+type: service
+category: voice
+version: 1.23.0
+description: "NVIDIA's RNN-T / TDT ASR family — sub-real-time on CUDA, strong on long-form. NeMo runtime."
+homepage: https://github.com/NVIDIA/NeMo
+license: Apache-2.0
+
+requires:
+  ram_mb: 6144
+  python: ">=3.10"
+
+install:
+  method: pip
+  package: nemo_toolkit[asr]
+
+hardware_tiers:
+  arm-npu-16gb: degraded
+  arm-npu-32gb: degraded
+  x86-cuda-12gb: full
+  x86-vulkan-8gb: degraded
+  cpu-only: degraded
+  apple-silicon: degraded

--- a/app-catalog/services/sense-voice/manifest.yaml
+++ b/app-catalog/services/sense-voice/manifest.yaml
@@ -1,0 +1,24 @@
+id: sense-voice
+name: SenseVoice
+type: service
+category: voice
+version: 0.5.0
+description: "Multilingual ASR from FunASR with emotion + audio-event detection. Strong on Chinese, Japanese, Korean, English."
+homepage: https://github.com/FunAudioLLM/SenseVoice
+license: Apache-2.0
+
+requires:
+  ram_mb: 4096
+  python: ">=3.10"
+
+install:
+  method: pip
+  package: funasr
+
+hardware_tiers:
+  arm-npu-16gb: degraded
+  arm-npu-32gb: full
+  x86-cuda-12gb: full
+  x86-vulkan-8gb: degraded
+  cpu-only: degraded
+  apple-silicon: full

--- a/app-catalog/services/whisperx/manifest.yaml
+++ b/app-catalog/services/whisperx/manifest.yaml
@@ -1,0 +1,24 @@
+id: whisperx
+name: WhisperX
+type: service
+category: voice
+version: 3.3.4
+description: "Whisper + word-level timestamps + speaker diarization. Built on faster-whisper plus pyannote for speaker labels and forced alignment."
+homepage: https://github.com/m-bain/whisperX
+license: BSD-2-Clause
+
+requires:
+  ram_mb: 4096
+  python: ">=3.10"
+
+install:
+  method: pip
+  package: whisperx
+
+hardware_tiers:
+  arm-npu-16gb: degraded
+  arm-npu-32gb: full
+  x86-cuda-12gb: full
+  x86-vulkan-8gb: degraded
+  cpu-only: degraded
+  apple-silicon: full


### PR DESCRIPTION
Pack 3 of the multimedia roadmap (#408). 5 ASR runtimes:

- \`faster-whisper\` — CTranslate2-backed Whisper, 4-8× faster
- \`whisperx\` — adds word-level timestamps + speaker diarization
- \`distil-whisper\` — HF's distilled Whisper, 6× faster within 1 % WER
- \`parakeet-nemo\` — NVIDIA's RNN-T / TDT family, NeMo runtime
- \`sense-voice\` — FunASR multilingual + emotion / audio-event detection

All pip-install. Hardware tiers reflect realistic GPU dependence: \`full\` on CUDA / Apple Silicon / 32 GB-class arm-npu, \`degraded\` elsewhere.

\`scripts/audit-manifests.py\` clean. Part of #408.

---
_Jay is asleep right now so this PR was opened by Claude Opus 4.7._