### PR TITLE
feat(catalog): pack 4 — TTS / voice cloning manifests

### DIFF
--- a/app-catalog/services/bark-tts/manifest.yaml
+++ b/app-catalog/services/bark-tts/manifest.yaml
@@ -1,0 +1,24 @@
+id: bark-tts
+name: Bark TTS
+type: service
+category: voice
+version: 1.0.0
+description: "Suno's transformer-based TTS with non-verbal sounds (laughs, sighs), multilingual prosody, and emotive speech."
+homepage: https://github.com/suno-ai/bark
+license: MIT
+
+requires:
+  ram_mb: 6144
+  python: ">=3.10"
+
+install:
+  method: pip
+  package: suno-bark
+
+hardware_tiers:
+  arm-npu-16gb: degraded
+  arm-npu-32gb: full
+  x86-cuda-12gb: full
+  x86-vulkan-8gb: degraded
+  cpu-only: degraded
+  apple-silicon: full

--- a/app-catalog/services/coqui-tts/manifest.yaml
+++ b/app-catalog/services/coqui-tts/manifest.yaml
@@ -1,0 +1,24 @@
+id: coqui-tts
+name: Coqui TTS
+type: service
+category: voice
+version: 0.22.0
+description: "Mozilla TTS fork — multi-speaker, multi-lingual, voice cloning. 1100+ pretrained models. The community baseline for self-hosted TTS."
+homepage: https://github.com/coqui-ai/TTS
+license: MPL-2.0
+
+requires:
+  ram_mb: 2048
+  python: ">=3.9,<3.12"
+
+install:
+  method: pip
+  package: TTS
+
+hardware_tiers:
+  arm-npu-16gb: degraded
+  arm-npu-32gb: full
+  x86-cuda-12gb: full
+  x86-vulkan-8gb: degraded
+  cpu-only: degraded
+  apple-silicon: full

--- a/app-catalog/services/f5-tts/manifest.yaml
+++ b/app-catalog/services/f5-tts/manifest.yaml
@@ -1,0 +1,24 @@
+id: f5-tts
+name: F5-TTS
+type: service
+category: voice
+version: 1.0.0
+description: "Flow-matching TTS with strong zero-shot voice cloning from short references. Multilingual, low-latency, MIT licensed."
+homepage: https://github.com/SWivid/F5-TTS
+license: MIT
+
+requires:
+  ram_mb: 4096
+  python: ">=3.10"
+
+install:
+  method: pip
+  package: f5-tts
+
+hardware_tiers:
+  arm-npu-16gb: degraded
+  arm-npu-32gb: full
+  x86-cuda-12gb: full
+  x86-vulkan-8gb: degraded
+  cpu-only: degraded
+  apple-silicon: full

--- a/app-catalog/services/openvoice/manifest.yaml
+++ b/app-catalog/services/openvoice/manifest.yaml
@@ -1,0 +1,24 @@
+id: openvoice
+name: OpenVoice
+type: service
+category: voice
+version: 2.0.0
+description: "MyShell's instant voice cloning — clones speaker identity from a single reference, then generates in any language with controllable style."
+homepage: https://github.com/myshell-ai/OpenVoice
+license: MIT
+
+requires:
+  ram_mb: 4096
+  python: ">=3.9"
+
+install:
+  method: pip
+  package: MyShell-OpenVoice
+
+hardware_tiers:
+  arm-npu-16gb: degraded
+  arm-npu-32gb: full
+  x86-cuda-12gb: full
+  x86-vulkan-8gb: degraded
+  cpu-only: degraded
+  apple-silicon: full

--- a/app-catalog/services/style-tts-2/manifest.yaml
+++ b/app-catalog/services/style-tts-2/manifest.yaml
@@ -1,0 +1,24 @@
+id: style-tts-2
+name: StyleTTS 2
+type: service
+category: voice
+version: 0.0.1
+description: "Diffusion + adversarial TTS — human-level quality on LibriTTS, fast inference. Strong English voice cloning from a few seconds of reference audio."
+homepage: https://github.com/yl4579/StyleTTS2
+license: MIT
+
+requires:
+  ram_mb: 4096
+  python: ">=3.10"
+
+install:
+  method: pip
+  package: styletts2
+
+hardware_tiers:
+  arm-npu-16gb: degraded
+  arm-npu-32gb: full
+  x86-cuda-12gb: full
+  x86-vulkan-8gb: degraded
+  cpu-only: degraded
+  apple-silicon: full


### PR DESCRIPTION
Pack 4 of the multimedia roadmap (#408). 5 TTS / voice-cloning services: coqui-tts, style-tts-2, f5-tts, openvoice, bark-tts. (kokoro-tts and chatterbox-tts already exist.) All pip-install. Audit clean.

---
_Jay is asleep right now so this PR was opened by Claude Opus 4.7._