### PR TITLE
feat(catalog): pack 5 — vision-language models (paligemma-2, smolvlm)

### DIFF
--- a/app-catalog/models/paligemma-2/manifest.yaml
+++ b/app-catalog/models/paligemma-2/manifest.yaml
@@ -1,0 +1,31 @@
+id: paligemma-2
+name: PaliGemma 2 3B Mix
+type: model
+version: 2.0.0
+description: "Google's lightweight vision-language model — strong at image captioning, OCR, segmentation, visual Q&A. 3B params; 224/448/896 input resolutions."
+homepage: https://huggingface.co/google/paligemma2-3b-mix-224
+license: Gemma
+capabilities:
+- chat
+- vision
+context_window: 8192
+
+variants:
+  - id: safetensors-224
+    name: "Safetensors 224px (5.5GB)"
+    format: safetensors
+    size_mb: 5500
+    download_url: https://huggingface.co/google/paligemma2-3b-mix-224/resolve/main/model.safetensors
+    requires:
+      backends:
+        - id: transformers
+          targets: [apple-silicon, x86-cuda, x86-vulkan, arm-vulkan, cpu]
+          min_ram_mb: 6144
+
+hardware_tiers:
+  arm-npu-16gb: {recommended: safetensors-224}
+  arm-npu-32gb: {recommended: safetensors-224}
+  apple-silicon: {recommended: safetensors-224}
+  x86-cuda-12gb: {recommended: safetensors-224}
+  x86-vulkan-8gb: {recommended: safetensors-224}
+  cpu-only: {recommended: safetensors-224}

--- a/app-catalog/models/paligemma-2/manifest.yaml
+++ b/app-catalog/models/paligemma-2/manifest.yaml
@@ -8,7 +8,6 @@ license: Gemma
 capabilities:
 - chat
 - vision
-context_window: 8192
 
 variants:
   - id: safetensors-224
@@ -29,3 +28,4 @@ hardware_tiers:
   x86-cuda-12gb: {recommended: safetensors-224}
   x86-vulkan-8gb: {recommended: safetensors-224}
   cpu-only: {recommended: safetensors-224}
+context_window: 8192

--- a/app-catalog/models/smolvlm/manifest.yaml
+++ b/app-catalog/models/smolvlm/manifest.yaml
@@ -8,7 +8,6 @@ license: Apache-2.0
 capabilities:
 - chat
 - vision
-context_window: 16384
 
 variants:
   - id: safetensors
@@ -29,3 +28,4 @@ hardware_tiers:
   x86-cuda-12gb: {recommended: safetensors}
   x86-vulkan-8gb: {recommended: safetensors}
   cpu-only: {recommended: safetensors}
+context_window: 16384

--- a/app-catalog/models/smolvlm/manifest.yaml
+++ b/app-catalog/models/smolvlm/manifest.yaml
@@ -1,0 +1,31 @@
+id: smolvlm
+name: SmolVLM
+type: model
+version: 1.0.0
+description: "Hugging Face's compact VLM — 2B params, runs in 5 GB VRAM. Strong at chart understanding, document Q&A, and visual reasoning for the size."
+homepage: https://huggingface.co/HuggingFaceTB/SmolVLM-Instruct
+license: Apache-2.0
+capabilities:
+- chat
+- vision
+context_window: 16384
+
+variants:
+  - id: safetensors
+    name: "Safetensors (4.5GB)"
+    format: safetensors
+    size_mb: 4500
+    download_url: https://huggingface.co/HuggingFaceTB/SmolVLM-Instruct/resolve/main/model.safetensors
+    requires:
+      backends:
+        - id: transformers
+          targets: [apple-silicon, x86-cuda, x86-vulkan, arm-vulkan, cpu]
+          min_ram_mb: 5120
+
+hardware_tiers:
+  arm-npu-16gb: {recommended: safetensors}
+  arm-npu-32gb: {recommended: safetensors}
+  apple-silicon: {recommended: safetensors}
+  x86-cuda-12gb: {recommended: safetensors}
+  x86-vulkan-8gb: {recommended: safetensors}
+  cpu-only: {recommended: safetensors}


### PR DESCRIPTION
Pack 5 of the multimedia roadmap (#408). Adds paligemma-2 (Google 3B at 224 px) and smolvlm (HF 2B). moondream2 already in catalog so not re-added.

Both transformers-backend safetensors. `scripts/audit-manifests.py` clean.

---
_Jay is asleep right now so this PR was opened by Claude Opus 4.7._