### PR TITLE
feat(catalog): pack 7 — music generation manifests

### DIFF
--- a/app-catalog/services/musicgen/manifest.yaml
+++ b/app-catalog/services/musicgen/manifest.yaml
@@ -9,6 +9,7 @@ license: MIT
 
 requires:
   ram_mb: 8192
+  disk_mb: 8000
   python: ">=3.9"
 
 install:

--- a/app-catalog/services/musicgen/manifest.yaml
+++ b/app-catalog/services/musicgen/manifest.yaml
@@ -1,0 +1,23 @@
+id: musicgen
+name: MusicGen
+type: service
+category: music
+version: 1.3.0
+description: "Meta's text-to-music — generates 30s clips from prompts. Multiple model sizes (small/medium/large/melody). Conditioning on melody supported."
+homepage: https://github.com/facebookresearch/audiocraft
+license: MIT
+
+requires:
+  ram_mb: 8192
+  python: ">=3.9"
+
+install:
+  method: pip
+  package: audiocraft
+
+hardware_tiers:
+  arm-npu-32gb: degraded
+  x86-cuda-12gb: full
+  x86-vulkan-8gb: degraded
+  cpu-only: degraded
+  apple-silicon: full

--- a/app-catalog/services/stable-audio-open/manifest.yaml
+++ b/app-catalog/services/stable-audio-open/manifest.yaml
@@ -9,6 +9,7 @@ license: "Stability AI Community License"
 
 requires:
   ram_mb: 8192
+  disk_mb: 8000
   python: ">=3.10"
 
 install:

--- a/app-catalog/services/stable-audio-open/manifest.yaml
+++ b/app-catalog/services/stable-audio-open/manifest.yaml
@@ -1,0 +1,23 @@
+id: stable-audio-open
+name: Stable Audio Open
+type: service
+category: music
+version: 1.0.0
+description: "Stability AI's open audio diffusion — generates up to 47s of music or sound effects from a prompt. Open weights under a community license."
+homepage: https://github.com/Stability-AI/stable-audio-tools
+license: "Stability AI Community License"
+
+requires:
+  ram_mb: 8192
+  python: ">=3.10"
+
+install:
+  method: pip
+  package: stable-audio-tools
+
+hardware_tiers:
+  arm-npu-32gb: degraded
+  x86-cuda-12gb: full
+  x86-vulkan-8gb: degraded
+  cpu-only: degraded
+  apple-silicon: full


### PR DESCRIPTION
Pack 7 of the multimedia roadmap (#408). 2 music-gen services: musicgen (Meta's audiocraft) + stable-audio-open (Stability AI). Audit clean.

---
_Jay is asleep right now so this PR was opened by Claude Opus 4.7._