### PR TITLE
feat(catalog): pack 8 — video generation manifests

### DIFF
--- a/app-catalog/services/cogvideox/manifest.yaml
+++ b/app-catalog/services/cogvideox/manifest.yaml
@@ -8,8 +8,11 @@ homepage: https://github.com/THUDM/CogVideo
 license: Apache-2.0
 
 requires:
+  disk_mb: 30000
   ram_mb: 16384
   python: ">=3.10"
+
+  ports: [7860]
 
 install:
   method: pip

--- a/app-catalog/services/cogvideox/manifest.yaml
+++ b/app-catalog/services/cogvideox/manifest.yaml
@@ -1,0 +1,23 @@
+id: cogvideox
+name: CogVideoX
+type: service
+category: video-gen
+version: 1.5.0
+description: "Tsinghua's CogVideo line — text-to-video, image-to-video, multiple sizes (2B / 5B). Strong prompt adherence, Apache-2.0 weights."
+homepage: https://github.com/THUDM/CogVideo
+license: Apache-2.0
+
+requires:
+  ram_mb: 16384
+  python: ">=3.10"
+
+install:
+  method: pip
+  package: diffusers
+
+hardware_tiers:
+  arm-npu-32gb: degraded
+  x86-cuda-12gb: full
+  x86-vulkan-8gb: degraded
+  cpu-only: unsupported
+  apple-silicon: degraded

--- a/app-catalog/services/hunyuanvideo/manifest.yaml
+++ b/app-catalog/services/hunyuanvideo/manifest.yaml
@@ -1,0 +1,23 @@
+id: hunyuanvideo
+name: HunyuanVideo
+type: service
+category: video-gen
+version: 1.0.0
+description: "Tencent's 13B-param open video model — high-quality text-to-video, 720p, prompt adherence on par with closed offerings."
+homepage: https://github.com/Tencent/HunyuanVideo
+license: "Tencent HunyuanVideo Community License"
+
+requires:
+  ram_mb: 24576
+  python: ">=3.10"
+
+install:
+  method: pip
+  package: hyvideo
+
+hardware_tiers:
+  arm-npu-32gb: unsupported
+  x86-cuda-12gb: degraded
+  x86-vulkan-8gb: unsupported
+  cpu-only: unsupported
+  apple-silicon: degraded

--- a/app-catalog/services/hunyuanvideo/manifest.yaml
+++ b/app-catalog/services/hunyuanvideo/manifest.yaml
@@ -8,8 +8,11 @@ homepage: https://github.com/Tencent/HunyuanVideo
 license: "Tencent HunyuanVideo Community License"
 
 requires:
+  disk_mb: 80000
   ram_mb: 24576
   python: ">=3.10"
+
+  ports: [7860]
 
 install:
   method: pip

--- a/app-catalog/services/mochi-1/manifest.yaml
+++ b/app-catalog/services/mochi-1/manifest.yaml
@@ -1,0 +1,23 @@
+id: mochi-1
+name: Mochi 1
+type: service
+category: video-gen
+version: 1.0.0
+description: "Genmo's open video model — 480p text-to-video at 30 fps with strong motion fidelity. 10B params; Apache-2.0 weights."
+homepage: https://github.com/genmoai/models
+license: Apache-2.0
+
+requires:
+  ram_mb: 24576
+  python: ">=3.10"
+
+install:
+  method: pip
+  package: genmo-mochi-1
+
+hardware_tiers:
+  arm-npu-32gb: unsupported
+  x86-cuda-12gb: degraded
+  x86-vulkan-8gb: unsupported
+  cpu-only: unsupported
+  apple-silicon: degraded

--- a/app-catalog/services/mochi-1/manifest.yaml
+++ b/app-catalog/services/mochi-1/manifest.yaml
@@ -8,8 +8,11 @@ homepage: https://github.com/genmoai/models
 license: Apache-2.0
 
 requires:
+  disk_mb: 60000
   ram_mb: 24576
   python: ">=3.10"
+
+  ports: [7860]
 
 install:
   method: pip

--- a/app-catalog/services/wan-2-1/manifest.yaml
+++ b/app-catalog/services/wan-2-1/manifest.yaml
@@ -1,0 +1,23 @@
+id: wan-2-1
+name: Wan 2.1
+type: service
+category: video-gen
+version: 2.1.0
+description: "Alibaba's open video model — text-to-video and image-to-video at 480p / 720p, 5-10s clips. State-of-the-art open-weights video gen."
+homepage: https://github.com/Wan-Video/Wan2.1
+license: Apache-2.0
+
+requires:
+  ram_mb: 16384
+  python: ">=3.10"
+
+install:
+  method: pip
+  package: wan2_1
+
+hardware_tiers:
+  arm-npu-32gb: degraded
+  x86-cuda-12gb: full
+  x86-vulkan-8gb: degraded
+  cpu-only: unsupported
+  apple-silicon: degraded

--- a/app-catalog/services/wan-2-1/manifest.yaml
+++ b/app-catalog/services/wan-2-1/manifest.yaml
@@ -8,8 +8,11 @@ homepage: https://github.com/Wan-Video/Wan2.1
 license: Apache-2.0
 
 requires:
+  disk_mb: 35000
   ram_mb: 16384
   python: ">=3.10"
+
+  ports: [7860]
 
 install:
   method: pip


### PR DESCRIPTION
Pack 8 of the multimedia roadmap (#408). 4 video-gen services (ltx-video already in catalog): wan-2-1, hunyuanvideo, cogvideox, mochi-1. Hardware tiers reflect actual VRAM needs — cpu-only unsupported across the board.

---
_Jay is asleep right now so this PR was opened by Claude Opus 4.7._