### PR TITLE
feat(catalog): direct-chat UIs (anything-llm, librechat, jan, farfalle)

### DIFF
--- a/app-catalog/services/anything-llm/manifest.yaml
+++ b/app-catalog/services/anything-llm/manifest.yaml
@@ -1,0 +1,30 @@
+id: anything-llm
+name: AnythingLLM
+type: service
+category: ai-app
+version: 1.7.0
+description: "Self-hosted ChatGPT for any LLM + any document — privacy-first, multi-user, agent skills, runs against any OpenAI-compatible API or local model."
+homepage: https://github.com/Mintplex-Labs/anything-llm
+license: MIT
+
+requires:
+  ram_mb: 1024
+  disk_mb: 3000
+  ports: [3001]
+
+install:
+  method: docker
+  image: mintplexlabs/anythingllm:latest
+  volumes:
+    - storage:/app/server/storage
+  ports: [3001]
+  env:
+    STORAGE_DIR: "/app/server/storage"
+
+hardware_tiers:
+  arm-npu-16gb: full
+  arm-npu-32gb: full
+  x86-cuda-12gb: full
+  x86-vulkan-8gb: full
+  cpu-only: full
+  apple-silicon: full

--- a/app-catalog/services/farfalle/manifest.yaml
+++ b/app-catalog/services/farfalle/manifest.yaml
@@ -1,0 +1,26 @@
+id: farfalle
+name: Farfalle
+type: service
+category: ai-app
+version: 1.0.0
+description: "Self-hosted Perplexity clone — answers questions with web-search + citations. Plays well with local models via Ollama or any OpenAI-compatible API."
+homepage: https://github.com/rashadphz/farfalle
+license: Apache-2.0
+
+requires:
+  ram_mb: 1024
+  disk_mb: 1500
+  ports: [3002]
+
+install:
+  method: docker
+  image: ghcr.io/rashadphz/farfalle:latest
+  ports: [3002]
+
+hardware_tiers:
+  arm-npu-16gb: full
+  arm-npu-32gb: full
+  x86-cuda-12gb: full
+  x86-vulkan-8gb: full
+  cpu-only: full
+  apple-silicon: full

--- a/app-catalog/services/jan/manifest.yaml
+++ b/app-catalog/services/jan/manifest.yaml
@@ -1,0 +1,26 @@
+id: jan
+name: Jan
+type: service
+category: ai-app
+version: 0.5.14
+description: "Jan as a server — local-first ChatGPT alternative with built-in inference engine. Self-hosted, runs against any OpenAI-compatible API."
+homepage: https://github.com/janhq/jan
+license: AGPL-3.0
+
+requires:
+  ram_mb: 2048
+  disk_mb: 4000
+  ports: [1337]
+
+install:
+  method: docker
+  image: ghcr.io/janhq/jan-server:latest
+  ports: [1337]
+
+hardware_tiers:
+  arm-npu-16gb: full
+  arm-npu-32gb: full
+  x86-cuda-12gb: full
+  x86-vulkan-8gb: full
+  cpu-only: full
+  apple-silicon: full

--- a/app-catalog/services/librechat/manifest.yaml
+++ b/app-catalog/services/librechat/manifest.yaml
@@ -1,0 +1,28 @@
+id: librechat
+name: LibreChat
+type: service
+category: ai-app
+version: 0.7.6
+description: "All-in-one open-source ChatGPT alternative — multi-user accounts, plugins, agents, multi-modal, RAG. Connects to any OpenAI-compatible API."
+homepage: https://github.com/danny-avila/LibreChat
+license: MIT
+
+requires:
+  ram_mb: 1024
+  disk_mb: 4000
+  ports: [3080]
+
+install:
+  method: docker
+  image: ghcr.io/danny-avila/librechat-dev:latest
+  ports: [3080]
+  env:
+    HOST: "0.0.0.0"
+
+hardware_tiers:
+  arm-npu-16gb: full
+  arm-npu-32gb: full
+  x86-cuda-12gb: full
+  x86-vulkan-8gb: full
+  cpu-only: full
+  apple-silicon: full


### PR DESCRIPTION
Adds 4 chat-frontend services for users who want to talk to models without agents. Pairs with the existing open-webui + perplexica.

- `anything-llm` — Mintplex ChatGPT-for-any-LLM with multi-user + RAG
- `librechat` — ChatGPT alternative, plugins, agents, multi-modal
- `jan` — Jan as a server, local-first
- `farfalle` — self-hosted Perplexity clone with web search + citations

All docker-method. Audit clean. Part of #408.

(Note: docker-method service installs are tracked as broken in #410 — these manifests are still useful and become installable once that's fixed.)

---
_Jay is asleep right now so this PR was opened by Claude Opus 4.7._