### PR TITLE
fix(store): promote IncompatibleToggle to empty-state CTA when nothing matches (closes #355)

### DIFF
--- a/desktop/src/apps/StoreApp/IncompatibleToggle.tsx
+++ b/desktop/src/apps/StoreApp/IncompatibleToggle.tsx
@@ -1,18 +1,58 @@
 // desktop/src/apps/StoreApp/IncompatibleToggle.tsx
 import { useState, type ReactNode } from "react";
-import { ChevronDown, ChevronUp } from "lucide-react";
+import { ChevronDown, ChevronUp, AlertCircle } from "lucide-react";
 
 interface Props {
   count: number;
+  /** Number of compatible items above this toggle. When 0, the toggle
+   *  promotes itself to a prominent empty-state CTA so users on
+   *  low-spec hardware know they CAN show the catalog anyway. Filed
+   *  as #355 — without this the user thought there was no filter at
+   *  all because their compatible-cards area was empty.
+   */
+  compatibleCount?: number;
   /** Render-prop for the dimmed grid of incompatible cards. */
   children: ReactNode;
 }
 
-export function IncompatibleToggle({ count, children }: Props) {
-  const [open, setOpen] = useState(false);
+export function IncompatibleToggle({ count, compatibleCount = 1, children }: Props) {
+  const [open, setOpen] = useState(compatibleCount === 0);
 
   if (count === 0) return null;
 
+  // Empty-state variant: nothing in the section is compatible.
+  // Promote the toggle to a yellow-card CTA + open-by-default so the
+  // user actually sees the dimmed list rather than an empty pane with
+  // a chevron at the bottom they didn't notice.
+  if (compatibleCount === 0) {
+    return (
+      <div className="mt-2 flex flex-col gap-3">
+        <div className="flex items-start gap-3 rounded-lg border border-amber-500/30 bg-amber-500/[0.06] px-4 py-3">
+          <AlertCircle size={16} className="text-amber-400 mt-0.5 shrink-0" aria-hidden="true" />
+          <div className="flex-1">
+            <div className="text-sm font-medium text-amber-100">
+              Nothing in this section matches the selected devices.
+            </div>
+            <div className="text-xs text-amber-200/70 mt-0.5">
+              Showing the {count} item{count === 1 ? "" : "s"} that won't run on this hardware below — pick a different device or accept the warning to install anyway.
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => setOpen((v) => !v)}
+            className="shrink-0 inline-flex items-center gap-1 rounded-md border border-amber-500/40 bg-amber-500/15 px-3 py-1 text-xs font-medium text-amber-100 hover:bg-amber-500/25 transition-colors"
+            aria-expanded={open}
+          >
+            {open ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
+            {open ? "Hide" : "Show"} all
+          </button>
+        </div>
+        {open && <div className="opacity-60">{children}</div>}
+      </div>
+    );
+  }
+
+  // Default: subtle bottom toggle when there ARE compatible items above.
   return (
     <div className="mt-6 border-t border-shell-border pt-4">
       <button

--- a/desktop/src/apps/StoreApp/index.tsx
+++ b/desktop/src/apps/StoreApp/index.tsx
@@ -1105,7 +1105,7 @@ export function StoreApp({ windowId: _windowId }: { windowId: string }) {
             </div>
           )}
           {incompatible.length > 0 && (
-            <IncompatibleToggle count={incompatible.length}>
+            <IncompatibleToggle count={incompatible.length} compatibleCount={filtered.length}>
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
                 {incompatible.map((app) => (
                   <AppCard


### PR DESCRIPTION
Closes #355 (johny on #312). When the compatible-cards section is empty, the previously-subtle IncompatibleToggle at the bottom of a blank pane was unfindable. Now it renders as a yellow alert card at the top with explanatory copy + opens the list by default, while preserving the subtle bottom-toggle behaviour when there ARE compatible items above. tsc -b clean.

---
_Jay is asleep right now so this PR was opened by Claude Opus 4.7._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* **Improved empty-state handling** – When a section has no matching items, users now see a clear empty-state message with an alert icon displaying the count of incompatible items
* **Toggle to show incompatible items** – New "Show all" button reveals the incompatible list, which opens by default when no matches exist in the section

<!-- end of auto-generated comment: release notes by coderabbit.ai -->