### PR TITLE
fix(providers): re-probe /models with API key when auth-less call returns empty (#356)

### DIFF
--- a/tinyagentos/routes/providers.py
+++ b/tinyagentos/routes/providers.py
@@ -277,6 +277,23 @@ async def list_providers(request: Request):
             models = result.get("models", [])
         except Exception:
             status = "error"
+        # Cloud / openai-compatible adapters call /models without auth.
+        # That returns 401 for any auth-required endpoint (LiteLLM proxy,
+        # private OpenAI gateway, etc.) and we end up with an empty
+        # models list even though the user gave us a valid key. Re-probe
+        # with the resolved api_key when the auth-less path returned
+        # nothing — issue #356 (johny: 'LiteLLM provider connects but
+        # picker shows 0 models').
+        if (
+            status == "ok"
+            and not models
+            and backend.get("type") in ("openai", "anthropic", "openrouter", "kilocode", "openai-compatible")
+        ):
+            api_key = await _resolve_api_key_for_backend(request.app.state, backend)
+            if api_key:
+                discovered = await _discover_provider_models(backend["url"], api_key)
+                if discovered:
+                    models = [{"name": m.get("id", ""), "size_mb": 0} for m in discovered]
         lifecycle_state = catalog.get_lifecycle_state(backend["name"]) if catalog else "running"
         entry = {
             **backend,


### PR DESCRIPTION
Reported by @johny-mnemonic on issue #356 (\"LiteLLM provider connects but picker shows 0 models, Open WebUI works against the same URL + key\").

\`CloudAPIAdapter.health\` probes \`GET /models\` without auth. For LiteLLM (or any auth-required gateway) that returns 401, the auth-less path skips populating \`models\`, and the picker has nothing to show even though the user gave us a valid key.

Fix lives in \`list_providers\`: after the adapter returns \`status=ok\` with an empty models list AND the backend type is in {openai, anthropic, openrouter, kilocode, openai-compatible}, re-probe via \`_discover_provider_models\` which already sends \`Authorization: Bearer <key>\`. Merge the result.

Adapter signatures unchanged — minimal blast radius.

## Test plan
- [x] \`pytest tests/test_routes_providers.py\` — 15 passed
- [ ] After merge: johny's LiteLLM provider should populate its models list and the cloud tab in the agent picker should show entries

Closes nothing automatically — leaving #356 open until johny confirms it works on his stack.

---
_Jay is asleep right now so this PR was opened by Claude Opus 4.7._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced provider discovery to automatically retrieve available models for cloud and OpenAI-compatible providers when the initial probe succeeds but returns an empty model list, improving accuracy of displayed provider capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->