### PR TITLE
fix(pwa): bust service-worker cache on every build via SHA-tagged version

### DIFF
--- a/desktop/scripts/read-version.mjs
+++ b/desktop/scripts/read-version.mjs
@@ -1,13 +1,14 @@
 // Reads __version__ from ../tinyagentos/__init__.py at Vite build time.
 // Single source of truth with the backend.
 import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const initPath = resolve(HERE, "..", "..", "tinyagentos", "__init__.py");
 
-export function readBackendVersion() {
+function readPackageVersion() {
   try {
     const src = readFileSync(initPath, "utf8");
     const m = src.match(/^\s*__version__\s*=\s*['"]([^'"]+)['"]/m);
@@ -15,4 +16,30 @@ export function readBackendVersion() {
   } catch {
     return "dev";
   }
+}
+
+function readBuildId() {
+  // Prefer the git short SHA so back-to-back builds on the same commit
+  // produce identical bundles. Fall back to an epoch-second timestamp
+  // when git isn't available (e.g. an sdist install).
+  try {
+    const sha = execFileSync("git", ["rev-parse", "--short", "HEAD"], {
+      cwd: HERE,
+      stdio: ["ignore", "pipe", "ignore"],
+    }).toString().trim();
+    if (sha) return sha;
+  } catch {
+    // git not available — fall through to timestamp
+  }
+  return Math.floor(Date.now() / 1000).toString(36);
+}
+
+// Service worker uses this string as its cache name (`taos-static-${VERSION}`).
+// If the string never changes between builds, the browser sees a byte-identical
+// SW on the next visit, never fires install/activate, never wipes the old
+// precache, and clients keep loading the previous bundle forever. Combining
+// the package version with the git SHA guarantees a fresh SW per build, so
+// stale-PWA recovery actually works after a controller upgrade.
+export function readBackendVersion() {
+  return `${readPackageVersion()}+${readBuildId()}`;
 }

--- a/desktop/scripts/read-version.mjs
+++ b/desktop/scripts/read-version.mjs
@@ -31,7 +31,12 @@ function readBuildId() {
   } catch {
     // git not available — fall through to timestamp
   }
-  return Math.floor(Date.now() / 1000).toString(36);
+  // Two distinct fields encoded in base36 so two builds within the same
+  // second still produce distinct ids (Date.now() is millisecond-resolution
+  // but high-res nanos disambiguate even sub-millisecond bursts).
+  const ms = Date.now().toString(36);
+  const hr = process.hrtime.bigint().toString(36);
+  return `${ms}-${hr.slice(-6)}`;
 }
 
 // Service worker uses this string as its cache name (`taos-static-${VERSION}`).

--- a/desktop/src/components/UpdateAvailableToast.tsx
+++ b/desktop/src/components/UpdateAvailableToast.tsx
@@ -20,6 +20,15 @@ import { useNotificationStore } from "@/stores/notification-store";
 
 const DEV_VERSION_PATTERN = /^(dev|0\.0\.0)/i;
 
+// Strip semver build metadata so a new SPA build (e.g. 0.1.0+a3bd632)
+// against the same backend version (0.1.0) doesn't trigger a spurious
+// "update available" toast. Build metadata is by spec not part of the
+// release identity.
+function strippedVersion(v: string): string {
+  const plus = v.indexOf("+");
+  return plus === -1 ? v : v.slice(0, plus);
+}
+
 interface Props {
   buildVersion: string;
 }
@@ -32,7 +41,7 @@ export function UpdateAvailableToast({ buildVersion }: Props) {
   useEffect(() => {
     if (DEV_VERSION_PATTERN.test(buildVersion)) return;
     if (!currentVersion) return;
-    if (currentVersion === buildVersion) return;
+    if (strippedVersion(currentVersion) === strippedVersion(buildVersion)) return;
     if (firedFor.current === currentVersion) return;
     firedFor.current = currentVersion;
     addNotification({

--- a/desktop/src/components/__tests__/UpdateAvailableToast.test.tsx
+++ b/desktop/src/components/__tests__/UpdateAvailableToast.test.tsx
@@ -63,4 +63,14 @@ describe("<UpdateAvailableToast />", () => {
     // The notification store has no actions[] — reload instruction is in the body.
     expect(call.body).toMatch(/reload/i);
   });
+
+  it("ignores semver build metadata when comparing", () => {
+    // Bundle version carries +sha for SW cache busting; backend version
+    // header is the raw 0.1.0. These should be treated as equal.
+    vi.mocked(useBackendStatus).mockReturnValue({
+      status: "up", currentVersion: "0.1.0", secondsReconnecting: 0,
+    });
+    render(<UpdateAvailableToast buildVersion="0.1.0+a3bd632" />);
+    expect(addNotification).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Why
The SW cache was named \`taos-static-\${VERSION}\` where \`VERSION\` came from \`__version__\` in \`tinyagentos/__init__.py\` — a string that almost never changes. Every controller upgrade therefore produced a byte-identical \`sw.js\`, the browser saw it as the same SW, never fired \`install\` / \`activate\`, never wiped the precache, and clients kept loading the previous SPA shell forever.

This is why jay's PWA didn't pick up the auth-guard from #426 even after multiple reopens — his cached old shell still referenced the old bundle hash, and the old bundle has no \`/api/*\` 401 handler.

## What changed
- \`desktop/scripts/read-version.mjs\` — appends a build id (git short SHA, falling back to a base36 epoch second when git isn't available) to the version it hands to \`vite.config.ts\`
- SW cache name becomes e.g. \`taos-static-0.1.0+a3bd632\` — different bytes per commit
- \`UpdateAvailableToast\` strips semver build metadata (everything after \`+\`) before comparing \`buildVersion\` against the backend's \`X-Taos-Version\` header, so the same release tagged with different SHAs doesn't fire spurious "update available" toasts

## Test plan
- [x] \`vitest\` — \`UpdateAvailableToast\` keeps existing 4 tests + new metadata-strip test (5 total, green)
- [x] \`tsc --noEmit -p desktop/\` clean
- [x] Local build emits \`f="0.1.0+a3bd632"\` inside the SW (was \`f="0.1.0"\`)
- [ ] Live: jay's PWA reopens, browser sees a new SW, activates, drops the old cache, loads the new bundle, and the auth-guard from #426 finally takes effect

---
_Jay is asleep right now so this PR was opened by Claude Opus 4.7. Surfaced when jay reported the previous fix wasn't reaching his PWA across multiple PWA reopens._