### PR TITLE
fix(pwa): restore LoginGate on mobile/PWA so expired sessions hit the form

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -247,10 +247,14 @@ export function App() {
     );
   }
 
-  // Mobile/Tablet layout — no login gate, no fullscreen button (PWA is already fullscreen)
+  // Mobile/Tablet layout — wrap in LoginGate so a stale or missing
+  // session prompts the user to sign in instead of rendering apps with
+  // empty data. The LoginScreen splash is intentionally still skipped
+  // (mobile auto-launches), but the auth check itself is required.
   return (
     <ShortcutProvider>
       <SystemShortcuts toggleSearch={toggleSearch} toggleLaunchpad={toggleLaunchpad} toggleAssistant={toggleAssistant} />
+      <LoginGate>
     <div className="taos-wallpaper h-screen w-screen flex flex-col text-shell-text" style={{ backgroundColor: wallpaperFallback, ["--wallpaper-desktop" as never]: wallpaperImage, ["--wallpaper-mobile" as never]: wallpaperMobileImage }}>
       <div className={`flex-1 flex flex-col overflow-hidden transition-all duration-500 ${launched ? "opacity-100 scale-100" : "opacity-0 scale-95"}`}>
         <MobileTopBar
@@ -297,6 +301,7 @@ export function App() {
       <NotificationToasts />
       <NotificationCentre />
     </div>
+      </LoginGate>
     </ShortcutProvider>
   );
 }


### PR DESCRIPTION
## Why
Found while debugging why jay's PWA still rendered empty apps after the auth-guard fix in #426 and the SW cache versioning fix in #427. Neither helped because the underlying issue is more direct:

Commit \`ccdccdd\` back in April removed \`<LoginGate>\` from the mobile/tablet branch of \`App.tsx\` entirely. The intent was to skip the \`LoginScreen\` launcher splash on touch devices (mobile auto-launches), but the side effect was that the **auth gate itself** got removed too. The PWA renders the desktop straight out of the unauthenticated state — \`taos-session-expired\` from #426 had no listener, and \`refreshStatus()\` never ran on mount. Users with an expired session saw apps with empty data and no path to sign in.

## Fix
Wrap the mobile branch in \`<LoginGate>\`:
- Logged in → renders children unchanged (LoginGate is transparent)
- Not authenticated → renders the existing sign-in form
- The \`LoginScreen\` splash is still skipped — mobile keeps auto-launching via the \`isPwa\`/\`isTouchDevice\` check at the top of the component

## Test plan
- [x] \`vitest\` — 24 tests across components + auth-guard pass
- [x] \`tsc --noEmit\` clean
- [ ] Live: jay's PWA reloads, \`/auth/status\` returns \`authenticated:false\`, sign-in form renders, sign-in succeeds, widgets and Activity populate again

---
_Jay is asleep right now so this PR was opened by Claude Opus 4.7 — surfaced when jay reported "still not redirected to login" after 5 PWA reloads. The earlier fixes were correct but addressed a different layer; this is the one that closes the gap on touch devices._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mobile and tablet users now require authentication before accessing the app interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->