### PR TITLE
fix(models): mark registry-installed models as downloaded in /api/models

### DIFF
--- a/tests/test_routes_models.py
+++ b/tests/test_routes_models.py
@@ -130,6 +130,28 @@ class TestModelsAPI:
         for m in data["models"]:
             assert m["has_downloaded_variant"] is False
 
+    async def test_registry_installed_marks_downloaded(self, models_client, models_app):
+        """Backend-installed models (e.g. rk-llama.cpp GGUFs at
+        ~/rk-llama.cpp/models/) leave nothing in data/models and don't show
+        up in any live BackendCatalog entry, so /api/models needs to fall
+        back to the install registry to know they're present.
+        """
+        registry = models_app.state.registry
+        registry.mark_installed("test-model", "1.0.0")
+
+        resp = await models_client.get("/api/models")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        installed = next(m for m in data["models"] if m["id"] == "test-model")
+        assert installed["has_downloaded_variant"] is True
+        assert all(v["downloaded"] is True for v in installed["variants"])
+
+        # Other manifests not in the registry must remain not-downloaded so
+        # we don't blanket-mark every model.
+        not_installed = next(m for m in data["models"] if m["id"] == "another-model")
+        assert not_installed["has_downloaded_variant"] is False
+
 
 @pytest.mark.asyncio
 class TestModelsDelete:

--- a/tinyagentos/routes/models.py
+++ b/tinyagentos/routes/models.py
@@ -149,6 +149,8 @@ def _model_to_dict(
     hardware_profile,
     downloaded_files: list[dict],
     live_models: list[dict] | None = None,
+    *,
+    registry_installed: bool = False,
 ) -> dict:
     """Convert an AppManifest to a model dict with compatibility info.
 
@@ -158,6 +160,16 @@ def _model_to_dict(
     for models that have been pulled to ``data/models`` but no backend has
     loaded yet — though this is a transitional state; the long-term answer is
     always the live catalog.
+
+    ``registry_installed`` is the install-registry's verdict for this manifest
+    id. Some installers (e.g. rk-llama.cpp) write GGUFs to a backend-specific
+    directory outside ``data/models`` and the resulting llama-server reports
+    the model under a generic name like ``active.gguf``. Neither the on-disk
+    scan nor the live-backend match can detect those, so the registry's
+    "this app was installed" record is the only honest signal we have. Set
+    on the manifest level (variant-level install-tracking doesn't exist yet),
+    so every variant gets the same flag — coarse but accurate enough for the
+    agent picker, which filters on any-variant-downloaded.
     """
     downloaded_filenames = {d["filename"] for d in downloaded_files}
     live_models = live_models or []
@@ -169,6 +181,7 @@ def _model_to_dict(
             _matches_live_backend(manifest.id, v, live_models)
             or expected_filename in downloaded_filenames
             or _is_service_installed(v)
+            or registry_installed
         )
         compat = _variant_compatibility(v, hardware_profile)
         variants.append({
@@ -211,10 +224,23 @@ async def list_models(request: Request):
     models = registry.list_available(type_filter="model")
     downloaded = get_downloaded_models(models_dir)
     live_models = catalog.all_models() if catalog is not None else []
+    # Build {app_id: True} from the install registry so backend-installed
+    # models (e.g. rk-llama.cpp GGUFs at ~/rk-llama.cpp/models/) still show
+    # up as downloaded in /api/models even though they're not under data/.
+    try:
+        installed_ids = {row["id"] for row in registry.list_installed() if "id" in row}
+    except Exception:  # noqa: BLE001 — registry is best-effort, never break /api/models
+        installed_ids = set()
 
     return {
         "models": [
-            _model_to_dict(m, hardware_profile, downloaded, live_models)
+            _model_to_dict(
+                m,
+                hardware_profile,
+                downloaded,
+                live_models,
+                registry_installed=(m.id in installed_ids),
+            )
             for m in models
         ],
         "downloaded_files": downloaded,


### PR DESCRIPTION
## Why
jay reported "downloaded Gemma 4 from the store, agent picker doesn't show it." Tracing on the live Pi found:

- \`installed.json\` says \`state: installed\` for both \`gemma-4-e2b-gguf\` and \`gemma-4-e4b-gguf\`
- \`rkllamacpp\` systemd service running, \`/v1/models\` reports model loaded
- \`/root/rk-llama.cpp/models/{e2b,e4b}.gguf\` both on disk
- ❌ \`/api/models\` still returns \`has_downloaded_variant: false\`

Three existing signals that should have flipped the flag, and why each missed:

| Signal | Status | Why it missed |
|---|---|---|
| \`data/models/\` scan | empty | rkllamacpp installer writes to \`~/rk-llama.cpp/models/\`, not \`data/models/\` |
| Live BackendCatalog match | empty list | local rk-llama.cpp isn't registered as a controller backend, and llama-server reports the model name as \`active.gguf\` anyway |
| \`_is_service_installed\` | false | only matches the rknn-stable-diffusion layout, not GGUF backends |

Result: agent picker (\`AgentsApp.tsx:1015\`) filters on \`has_downloaded_variant === true\`, so both gemmas get dropped despite serving traffic.

## Fix
Fall back to the install registry. \`registry.list_installed()\` already records every successful install. If a manifest id appears there, set \`registry_installed=True\` on every variant in \`_model_to_dict\`.

Coarse — no per-variant install tracking exists today, so every variant of a marked-installed model gets the flag. The picker only checks "any variant downloaded," so coarse is exactly right for this surface.

This **does not** address the deeper question of how the agent-deploy wizard routes to a controller-local backend that isn't in BackendCatalog — filing that separately. This PR closes the visibility gap.

## Test plan
- [x] New test \`test_registry_installed_marks_downloaded\` — registry-mark a model and assert \`/api/models\` flips both \`has_downloaded_variant\` and per-variant \`downloaded\` to True
- [x] Asserts a sibling unmarked model stays \`has_downloaded_variant: false\` — no blanket-marking
- [ ] Live: jay's PWA reloads \`/api/models\`, gemma-4-e2b-gguf and gemma-4-e4b-gguf appear in the agent-deploy picker

---
_Jay is asleep right now so this PR was opened by Claude Opus 4.7 — surfaced when jay reported "downloaded Gemma 4, doesn't show in agent picker"._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added test to verify proper detection of registry-installed models.

* **New Features**
  * Enhanced model status detection to recognize installed models from registry sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->