### PR TITLE
feat(installers): shared model layout ~/models/<backend>/<family>/<id>/

### DIFF
--- a/scripts/install-rk-llama-cpp.sh
+++ b/scripts/install-rk-llama-cpp.sh
@@ -106,7 +106,7 @@ Group=$TARGET_GROUP
 WorkingDirectory=$INSTALL_DIR
 Environment=LD_LIBRARY_PATH=$INSTALL_DIR/lib
 LimitNOFILE=65536
-ExecStart=$INSTALL_DIR/bin/llama-server -m $INSTALL_DIR/models/active.gguf --host $HOST --port $PORT
+ExecStart=$INSTALL_DIR/bin/llama-server -m $INSTALL_DIR/active.gguf --host $HOST --port $PORT
 Restart=on-failure
 RestartSec=5
 KillMode=mixed

--- a/scripts/migrate-model-layout.sh
+++ b/scripts/migrate-model-layout.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# One-shot migration to the shared model layout.
+#
+# Before this script: each backend wrote model files to its own dir
+#   ~/rk-llama.cpp/models/<app_id>.gguf
+#   /opt/tinyagentos/models/<app_id>-<variant>.<ext>
+#
+# After: every backend writes to a single tree
+#   ~/models/<backend>/<family>/<manifest_id>/<filename>
+#
+# This script moves files into the new layout in place and updates the
+# rk-llama.cpp service-state symlink + systemd unit so the running
+# llama-server keeps serving from the new path.
+#
+# Idempotent: re-running on an already-migrated tree is a no-op.
+# Conservative: never deletes a file it can't account for; logs a warning
+# instead.
+
+set -euo pipefail
+
+log()  { echo -e "\033[1;34m[migrate-models]\033[0m $*"; }
+warn() { echo -e "\033[1;33m[migrate-models]\033[0m $*" >&2; }
+die()  { echo -e "\033[1;31m[migrate-models]\033[0m $*" >&2; exit 1; }
+
+# Resolve target user — controller installs as root or jay; pick the owner
+# of the running unit's WorkingDirectory rather than guess from $HOME.
+TARGET_USER="${SUDO_USER:-$(id -un)}"
+TARGET_HOME=$(getent passwd "$TARGET_USER" | cut -d: -f6)
+[[ -d "$TARGET_HOME" ]] || die "could not resolve home for $TARGET_USER"
+
+NEW_ROOT="${TAOS_MODELS_ROOT:-$TARGET_HOME/models}"
+log "target user: $TARGET_USER  new root: $NEW_ROOT"
+
+mkdir -p "$NEW_ROOT"
+chown "$TARGET_USER:$TARGET_USER" "$NEW_ROOT"
+
+# Pure-bash family extractor — first dash-separated token of the id,
+# lowercased. Matches model_paths.family_from_manifest's fallback path.
+# Manifests with an explicit family: field don't pass through here
+# (they got installed via the new code path already).
+family_of() {
+    local id="$1"
+    echo "${id%%-*}" | tr '[:upper:]' '[:lower:]'
+}
+
+# --- rk-llama.cpp -----------------------------------------------------
+RKDIR="$TARGET_HOME/rk-llama.cpp"
+RK_OLD_MODELS="$RKDIR/models"
+RK_NEW_BACKEND="$NEW_ROOT/rk-llama.cpp"
+moved=0
+if [[ -d "$RK_OLD_MODELS" ]]; then
+    log "scanning $RK_OLD_MODELS"
+    mkdir -p "$RK_NEW_BACKEND"
+    for src in "$RK_OLD_MODELS"/*.gguf; do
+        [[ -e "$src" ]] || continue
+        # Skip the active.gguf symlink — re-pointed below.
+        if [[ -L "$src" ]]; then continue; fi
+        base=$(basename "$src")
+        # Old naming was "<app_id>.gguf"; recover app_id and family from it.
+        manifest_id="${base%.gguf}"
+        family=$(family_of "$manifest_id")
+        target_dir="$RK_NEW_BACKEND/$family/$manifest_id"
+        target="$target_dir/$base"
+        if [[ -e "$target" ]]; then
+            log "  $base already migrated, skipping"
+            continue
+        fi
+        mkdir -p "$target_dir"
+        log "  moving $base -> $family/$manifest_id/"
+        mv "$src" "$target"
+        chown -R "$TARGET_USER:$TARGET_USER" "$target_dir"
+        moved=$((moved+1))
+    done
+fi
+
+# Re-point the active.gguf symlink. The old pattern was
+# <install_dir>/models/active.gguf -> <name>.gguf (relative). The new
+# pattern is <install_dir>/active.gguf -> <absolute path under NEW_ROOT>.
+ACTIVE_OLD="$RK_OLD_MODELS/active.gguf"
+ACTIVE_NEW="$RKDIR/active.gguf"
+if [[ -L "$ACTIVE_OLD" ]]; then
+    target_name=$(readlink "$ACTIVE_OLD")
+    # target_name is bare basename like "gemma-4-e2b-gguf.gguf"
+    manifest_id="${target_name%.gguf}"
+    family=$(family_of "$manifest_id")
+    new_target="$RK_NEW_BACKEND/$family/$manifest_id/$target_name"
+    if [[ -f "$new_target" ]]; then
+        ln -sfn "$new_target" "$ACTIVE_NEW"
+        chown -h "$TARGET_USER:$TARGET_USER" "$ACTIVE_NEW"
+        rm -f "$ACTIVE_OLD"
+        log "  active.gguf -> $new_target"
+    else
+        warn "  active.gguf points to $target_name but $new_target missing — leaving symlink alone for human review"
+    fi
+fi
+
+# Restart the rkllamacpp service so llama-server picks up the new -m
+# argument from the updated unit. The unit file is rewritten by
+# install-rk-llama-cpp.sh on the next controller upgrade; for now we
+# rewrite it inline if it still has the old path.
+UNIT="/etc/systemd/system/rkllamacpp.service"
+if [[ -f "$UNIT" ]] && grep -q "models/active.gguf" "$UNIT"; then
+    log "rewriting unit $UNIT to use new active.gguf path"
+    sed -i 's|/models/active.gguf|/active.gguf|g' "$UNIT"
+    systemctl daemon-reload
+fi
+if systemctl is-enabled rkllamacpp >/dev/null 2>&1; then
+    log "restarting rkllamacpp"
+    systemctl restart rkllamacpp || warn "rkllamacpp restart failed — check journalctl -u rkllamacpp"
+fi
+
+# --- legacy /opt/tinyagentos/models -----------------------------------
+# Older download_installer dropped flat files at /opt/tinyagentos/models.
+# We can't always recover the (backend, manifest_id) split from a flat
+# filename like "qwen3.5-9b-q4_k_m.gguf", so DON'T move these. Just log
+# their presence so the user can decide whether to leave or hand-migrate.
+LEGACY="/opt/tinyagentos/models"
+if [[ -d "$LEGACY" ]]; then
+    legacy_files=$(find "$LEGACY" -maxdepth 1 -type f 2>/dev/null | wc -l)
+    if [[ "$legacy_files" -gt 0 ]]; then
+        warn "found $legacy_files legacy file(s) at $LEGACY — left in place; uninstall + reinstall to migrate them cleanly"
+    fi
+fi
+
+log "done. moved $moved file(s) into $NEW_ROOT"

--- a/tests/installers/test_model_paths.py
+++ b/tests/installers/test_model_paths.py
@@ -1,0 +1,106 @@
+"""Tests for the shared model-layout path helpers."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tinyagentos.installers.model_paths import (
+    backend_model_dir,
+    family_from_manifest,
+    filename_from_url,
+    models_root,
+)
+
+
+class TestFamilyFromManifest:
+    def test_string_id_takes_first_dash_token(self):
+        assert family_from_manifest("gemma-4-e2b-gguf") == "gemma"
+        assert family_from_manifest("llama-3.2-1b") == "llama"
+        assert family_from_manifest("bge-m3") == "bge"
+
+    def test_no_dash_keeps_whole_id(self):
+        # qwen3.5-9b -> "qwen3.5"; qwen35 with no dash -> "qwen35"
+        assert family_from_manifest("qwen3.5-9b") == "qwen3.5"
+        assert family_from_manifest("singletoken") == "singletoken"
+
+    def test_lowercases_token(self):
+        assert family_from_manifest("Gemma-4-E2B-GGUF") == "gemma"
+
+    def test_explicit_family_wins(self):
+        class Manifest:
+            id = "paligemma-2"
+            family = "gemma"
+
+        assert family_from_manifest(Manifest()) == "gemma"
+
+    def test_explicit_family_from_dict(self):
+        assert family_from_manifest({"id": "anything", "family": "Custom"}) == "custom"
+
+    def test_dict_without_family_falls_back_to_id(self):
+        assert family_from_manifest({"id": "qwen3.5-9b"}) == "qwen3.5"
+
+    def test_object_with_id_attr(self):
+        class Manifest:
+            id = "gemma-4-e2b-gguf"
+
+        assert family_from_manifest(Manifest()) == "gemma"
+
+    def test_empty_id_falls_back_to_uncategorised(self):
+        assert family_from_manifest("") == "uncategorised"
+
+
+class TestBackendModelDir:
+    def test_builds_full_path(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TAOS_MODELS_ROOT", str(tmp_path))
+        result = backend_model_dir("rk-llama.cpp", "gemma-4-e2b-gguf")
+        assert result == tmp_path / "rk-llama.cpp" / "gemma" / "gemma-4-e2b-gguf"
+
+    def test_uses_explicit_family(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TAOS_MODELS_ROOT", str(tmp_path))
+        result = backend_model_dir("ollama", {"id": "paligemma-2", "family": "gemma"})
+        assert result == tmp_path / "ollama" / "gemma" / "paligemma-2"
+
+    def test_pure_path_builder_no_mkdir(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TAOS_MODELS_ROOT", str(tmp_path))
+        result = backend_model_dir("download", "test-model")
+        assert not result.exists()  # builder doesn't touch the filesystem
+
+    def test_raises_on_empty_id(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TAOS_MODELS_ROOT", str(tmp_path))
+        with pytest.raises(ValueError):
+            backend_model_dir("rk-llama.cpp", "")
+
+
+class TestModelsRoot:
+    def test_env_override(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TAOS_MODELS_ROOT", str(tmp_path / "alt"))
+        assert models_root() == tmp_path / "alt"
+
+    def test_default_is_home_models(self, monkeypatch):
+        monkeypatch.delenv("TAOS_MODELS_ROOT", raising=False)
+        # Just assert the relationship to home; absolute path varies per CI
+        assert models_root() == Path.home() / "models"
+
+
+class TestFilenameFromUrl:
+    def test_extracts_basename(self):
+        url = "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/gemma-4-E2B-it-Q4_K_M.gguf"
+        assert filename_from_url(url, "fallback.bin") == "gemma-4-E2B-it-Q4_K_M.gguf"
+
+    def test_falls_back_for_no_extension(self):
+        # An opaque CDN URL with no clean extension hits the fallback.
+        assert filename_from_url("https://example.com/redirect/abc123", "model.gguf") == "model.gguf"
+
+    def test_empty_url_uses_fallback(self):
+        assert filename_from_url("", "fallback.gguf") == "fallback.gguf"
+
+    def test_sanitises_unsafe_chars(self):
+        url = "https://example.com/path/weird name!.gguf"
+        out = filename_from_url(url, "fallback.bin")
+        # Spaces and ! get replaced with underscores
+        assert " " not in out
+        assert "!" not in out
+        assert out.endswith(".gguf")

--- a/tests/installers/test_rkllamacpp_installer.py
+++ b/tests/installers/test_rkllamacpp_installer.py
@@ -48,12 +48,23 @@ class TestEnvVarOverrides:
         assert i.port == 7777
 
 
+@pytest.fixture
+def sandboxed_models_root(tmp_path, monkeypatch):
+    """Point TAOS_MODELS_ROOT at tmp_path so the installer creates the
+    new shared layout (~/models/<backend>/<family>/<id>/) inside the
+    test sandbox instead of the real home directory.
+    """
+    root = tmp_path / "models"
+    monkeypatch.setenv("TAOS_MODELS_ROOT", str(root))
+    return root
+
+
 class TestInstallReturnsFailureOnSystemctlError:
     """If systemctl restart fails, the model file is on disk but the runtime
     is not serving — we must NOT report success. (CR finding from PR #322.)"""
 
     @pytest.mark.asyncio
-    async def test_systemctl_failure_returns_success_false(self, tmp_path):
+    async def test_systemctl_failure_returns_success_false(self, tmp_path, sandboxed_models_root):
         from tinyagentos.installers.rkllamacpp_installer import RkLlamaCppInstaller
 
         # Pre-create the binary so the precondition check passes.
@@ -79,7 +90,7 @@ class TestInstallReturnsFailureOnHealthCheckTimeout:
     actually usable — we must NOT report success. (CR finding from PR #322.)"""
 
     @pytest.mark.asyncio
-    async def test_health_timeout_returns_success_false(self, tmp_path):
+    async def test_health_timeout_returns_success_false(self, tmp_path, sandboxed_models_root):
         from tinyagentos.installers.rkllamacpp_installer import RkLlamaCppInstaller
 
         (tmp_path / "bin").mkdir()
@@ -102,7 +113,7 @@ class TestInstallReturnsFailureOnHealthCheckTimeout:
 
 class TestInstallSucceedsHappyPath:
     @pytest.mark.asyncio
-    async def test_full_install_returns_success(self, tmp_path):
+    async def test_full_install_returns_success(self, tmp_path, sandboxed_models_root):
         from tinyagentos.installers.rkllamacpp_installer import RkLlamaCppInstaller
 
         (tmp_path / "bin").mkdir()
@@ -122,3 +133,54 @@ class TestInstallSucceedsHappyPath:
         assert result["success"] is True
         assert result["service_running"] is True
         assert result["endpoint"] == "http://localhost:8090"
+
+
+class TestInstallUsesSharedLayout:
+    """The installer writes to ~/models/<backend>/<family>/<manifest_id>/
+    (per the layout decision in #430), not the legacy install_dir/models/."""
+
+    @pytest.mark.asyncio
+    async def test_target_path_under_shared_root(self, tmp_path, sandboxed_models_root):
+        from tinyagentos.installers.rkllamacpp_installer import (
+            BACKEND_ID,
+            RkLlamaCppInstaller,
+        )
+
+        (tmp_path / "bin").mkdir()
+        (tmp_path / "bin" / "llama-server").write_text("fake")
+
+        installer = RkLlamaCppInstaller(install_dir=tmp_path, port=8090)
+        captured: dict = {}
+
+        async def fake_download(url, dest, expected_sha256):
+            captured["dest"] = dest
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_text("fake gguf bytes")
+
+        with patch.object(installer, "_download", side_effect=fake_download), \
+             patch.object(installer, "_systemctl", new=AsyncMock()), \
+             patch.object(installer, "_wait_for_server", new=AsyncMock(return_value=True)):
+            result = await installer.install(
+                "gemma-4-e2b-gguf",
+                install_config={"method": "rkllamacpp"},
+                variant={
+                    "id": "q4_k_m",
+                    "size_mb": 100,
+                    "download_url": "https://hf.co/x/y/resolve/main/gemma-4-E2B-it-Q4_K_M.gguf",
+                },
+            )
+
+        assert result["success"] is True
+        # Lands at <root>/<backend>/<family>/<id>/<original-filename>
+        expected = (
+            sandboxed_models_root
+            / BACKEND_ID
+            / "gemma"
+            / "gemma-4-e2b-gguf"
+            / "gemma-4-E2B-it-Q4_K_M.gguf"
+        )
+        assert captured["dest"] == expected
+        # active.gguf is in install_dir, points at the file in the new tree
+        active = tmp_path / "active.gguf"
+        assert active.is_symlink()
+        assert active.resolve() == expected.resolve()

--- a/tests/test_model_sources.py
+++ b/tests/test_model_sources.py
@@ -295,11 +295,14 @@ def catalog_with_models(tmp_path):
 
 
 @pytest.fixture
-def search_app(tmp_data_dir, catalog_with_models, tmp_path):
+def search_app(tmp_data_dir, catalog_with_models, tmp_path, monkeypatch):
     models_dir = tmp_path / "models"
     models_dir.mkdir()
+    shared_root = tmp_path / "models-shared"
+    monkeypatch.setenv("TAOS_MODELS_ROOT", str(shared_root))
     app = create_app(data_dir=tmp_data_dir, catalog_dir=catalog_with_models)
     app.state.models_dir = models_dir
+    app.state.models_root = shared_root
     return app
 
 

--- a/tests/test_routes_models.py
+++ b/tests/test_routes_models.py
@@ -47,11 +47,16 @@ def catalog_with_models(tmp_path):
 
 
 @pytest.fixture
-def models_app(tmp_data_dir, catalog_with_models, tmp_path):
+def models_app(tmp_data_dir, catalog_with_models, tmp_path, monkeypatch):
     models_dir = tmp_path / "models"
     models_dir.mkdir()
+    # Sandbox the new shared layout root so scans don't pick up files
+    # in the test runner's real home directory.
+    shared_root = tmp_path / "models-shared"
+    monkeypatch.setenv("TAOS_MODELS_ROOT", str(shared_root))
     app = create_app(data_dir=tmp_data_dir, catalog_dir=catalog_with_models)
     app.state.models_dir = models_dir
+    app.state.models_root = shared_root
     return app
 
 

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -440,6 +440,13 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         app.state.agent_memory_dir.mkdir(parents=True, exist_ok=True)
         app.state.models_dir = data_dir / "models"
         app.state.models_dir.mkdir(parents=True, exist_ok=True)
+        # Shared model layout root (~/models/<backend>/<family>/<id>/...)
+        # — the new home for everything backend installers download.
+        # Kept distinct from the legacy data/models scan target so old
+        # files there still get discovered.
+        from tinyagentos.installers.model_paths import models_root
+        app.state.models_root = models_root()
+        app.state.models_root.mkdir(parents=True, exist_ok=True)
         app.state.metrics = metrics_store
         app.state.notifications = notif_store
         app.state.qmd_client = qmd_client

--- a/tinyagentos/installers/download_installer.py
+++ b/tinyagentos/installers/download_installer.py
@@ -74,15 +74,56 @@ async def download_file(
 
 
 class DownloadInstaller(AppInstaller):
+    """Generic file-download installer for backends that just need bytes
+    on disk (llama-cpp, mlx, vllm, transformers, diffusers,
+    sentence-transformers, whisper-cpp, piper, onnxruntime, nemo, sd-webui).
+
+    Files land in the shared layout at
+    ``~/models/<backend>/<family>/<manifest_id>/<filename>`` so the user
+    has one place to inspect everything and workers can rsync a manifest
+    dir across the cluster.
+
+    The ``models_dir`` constructor arg is kept for tests that want a
+    sandboxed root, but production code should leave it ``None`` and let
+    ``model_paths.models_root()`` decide (driven by
+    ``TAOS_MODELS_ROOT`` when set).
+    """
+
     def __init__(self, models_dir: Path | None = None):
-        self.models_dir = models_dir or Path("/opt/tinyagentos/models")
+        # If a caller passes models_dir, treat it as an alternate root —
+        # the per-(backend, family, id) sub-tree is appended below.
+        # Production callers leave this None.
+        self._root_override = Path(models_dir) if models_dir else None
+
+    def _backend_id(self, install_config: dict) -> str:
+        # The store-install dispatcher injects "backend" into install_config
+        # before calling us — same field that drives _BACKEND_TO_METHOD.
+        backend = install_config.get("backend") if install_config else None
+        return str(backend) if backend else "download"
+
+    def _target_dir(self, backend_id: str, app_id: str) -> Path:
+        from tinyagentos.installers.model_paths import (
+            backend_model_dir,
+            family_from_manifest,
+        )
+        if self._root_override is not None:
+            return self._root_override / backend_id / family_from_manifest(app_id) / app_id
+        return backend_model_dir(backend_id, app_id)
 
     async def install(self, app_id: str, install_config: dict, variant: dict | None = None, **kwargs) -> dict:
         if not variant:
             return {"success": False, "error": "variant required for model download"}
 
-        filename = f"{app_id}-{variant['id']}.{variant.get('format', 'bin')}"
-        dest = self.models_dir / filename
+        from tinyagentos.installers.model_paths import filename_from_url
+
+        backend_id = self._backend_id(install_config or {})
+        target_dir = self._target_dir(backend_id, app_id)
+        target_dir.mkdir(parents=True, exist_ok=True)
+
+        url = variant.get("download_url", "")
+        fallback = f"{app_id}-{variant['id']}.{variant.get('format', 'bin')}"
+        filename = filename_from_url(url, fallback)
+        dest = target_dir / filename
 
         if dest.exists():
             return {"success": True, "path": str(dest), "cached": True}
@@ -94,7 +135,7 @@ class DownloadInstaller(AppInstaller):
 
         try:
             path = await download_file(
-                url=variant["download_url"],
+                url=url,
                 dest=dest,
                 expected_sha256=variant.get("sha256"),
                 on_progress=on_progress,
@@ -104,11 +145,39 @@ class DownloadInstaller(AppInstaller):
             return {"success": False, "error": str(e)}
 
     async def uninstall(self, app_id: str, variant_id: str | None = None, **kwargs) -> dict:
-        # Delete matching model files
-        deleted = []
-        for f in self.models_dir.glob(f"{app_id}*"):
-            if variant_id and variant_id not in f.name:
+        # Locate the manifest dir under whichever backend it's recorded
+        # against. We don't know the backend here for sure (uninstall is
+        # called with just the app_id), so scan every backend root for a
+        # matching manifest dir.
+        from tinyagentos.installers.model_paths import (
+            family_from_manifest,
+            models_root,
+        )
+
+        deleted: list[str] = []
+        family = family_from_manifest(app_id)
+        # Walk one level deep under models_root to find every backend.
+        root = self._root_override if self._root_override is not None else models_root()
+        if not root.exists():
+            return {"success": True, "deleted": deleted}
+
+        for backend_dir in sorted(root.iterdir()):
+            if not backend_dir.is_dir():
                 continue
-            f.unlink()
-            deleted.append(f.name)
+            manifest_dir = backend_dir / family / app_id
+            if not manifest_dir.exists():
+                continue
+            for f in sorted(manifest_dir.glob("*")):
+                if not f.is_file():
+                    continue
+                if variant_id and variant_id not in f.name:
+                    continue
+                f.unlink()
+                deleted.append(f"{backend_dir.name}/{family}/{app_id}/{f.name}")
+            # Best-effort cleanup — only rmdir an empty dir.
+            try:
+                manifest_dir.rmdir()
+            except OSError:
+                pass
+
         return {"success": True, "deleted": deleted}

--- a/tinyagentos/installers/model_paths.py
+++ b/tinyagentos/installers/model_paths.py
@@ -1,0 +1,114 @@
+"""Shared on-disk layout for installed models.
+
+All backend installers write into one tree:
+
+    ~/models/<backend>/<family>/<manifest_id>/<filename>
+
+Examples:
+    ~/models/rk-llama.cpp/gemma/gemma-4-e2b-gguf/gemma-4-E2B-it-Q4_K_M.gguf
+    ~/models/llama-cpp/qwen3.5/qwen3.5-9b/qwen3.5-9b-Q4_K_M.gguf
+
+Why a single tree:
+- The user can browse one place and see everything they have.
+- Workers can rsync a manifest dir directly across the cluster and the
+  receiving end mounts the exact same path layout.
+- The Models app can group by family and surface size/cleanup actions
+  uniformly without each backend reinventing its layout.
+
+Ollama is intentionally not migrated here — it manages its own blob
+store (~/.ollama/models) and reading from a foreign tree is a separate
+discoverability concern handled in routes/models.py.
+"""
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from urllib.parse import urlparse
+
+
+def models_root() -> Path:
+    """Single root for the layout. Override with TAOS_MODELS_ROOT for tests
+    or alternate filesystems (network share, dedicated SSD, etc.).
+    """
+    override = os.environ.get("TAOS_MODELS_ROOT")
+    return Path(override) if override else Path.home() / "models"
+
+
+_FAMILY_FALLBACK = "uncategorised"
+
+
+def family_from_manifest(manifest_or_id: object) -> str:
+    """Pick the family directory name for a manifest.
+
+    Resolution order:
+
+    1. Explicit ``family`` field on the manifest (preferred — gives
+       maintainers full control for cases like ``paligemma-2`` that
+       should arguably nest under ``gemma``).
+    2. First dash-separated token of the manifest id, lowercased. We
+       deliberately keep version numbers as part of the family token
+       (``qwen3.5-9b`` -> ``qwen3.5``, ``llama-3.2-1b`` -> ``llama``)
+       because the literal first token is deterministic and easy to
+       reason about — set ``family:`` explicitly when you want to merge
+       e.g. qwen / qwen2 / qwen3 under one bucket.
+    3. ``uncategorised`` if everything else falls through (defensive —
+       shouldn't happen with well-formed manifest ids).
+    """
+    explicit = None
+    manifest_id = ""
+    if isinstance(manifest_or_id, str):
+        manifest_id = manifest_or_id
+    else:
+        explicit = getattr(manifest_or_id, "family", None) or (
+            manifest_or_id.get("family") if isinstance(manifest_or_id, dict) else None
+        )
+        manifest_id = (
+            getattr(manifest_or_id, "id", None)
+            or (manifest_or_id.get("id") if isinstance(manifest_or_id, dict) else "")
+            or ""
+        )
+    if explicit:
+        return str(explicit).lower()
+    first_token = (manifest_id or "").split("-", 1)[0].strip().lower()
+    return first_token or _FAMILY_FALLBACK
+
+
+def backend_model_dir(backend_id: str, manifest_or_id: object) -> Path:
+    """Resolved directory for a specific (backend, manifest) install.
+
+    Caller is responsible for mkdir-ing this — the helper is a pure path
+    builder so tests don't need a real filesystem.
+    """
+    family = family_from_manifest(manifest_or_id)
+    manifest_id = (
+        manifest_or_id
+        if isinstance(manifest_or_id, str)
+        else (
+            getattr(manifest_or_id, "id", None)
+            or (manifest_or_id.get("id") if isinstance(manifest_or_id, dict) else "")
+            or ""
+        )
+    )
+    if not manifest_id:
+        raise ValueError("backend_model_dir: manifest_or_id has no id")
+    return models_root() / backend_id / family / manifest_id
+
+
+_FILENAME_BAD = re.compile(r"[^A-Za-z0-9._+\-]")
+
+
+def filename_from_url(url: str, fallback: str) -> str:
+    """Pull the basename from a download URL, falling back when the URL
+    is opaque (query strings, redirects to opaque CDN paths, etc.).
+    """
+    if url:
+        try:
+            path = urlparse(url).path
+            base = path.rsplit("/", 1)[-1]
+            base = _FILENAME_BAD.sub("_", base)
+            if base and "." in base:
+                return base
+        except Exception:  # noqa: BLE001 — pure best-effort parse
+            pass
+    return fallback

--- a/tinyagentos/installers/rkllamacpp_installer.py
+++ b/tinyagentos/installers/rkllamacpp_installer.py
@@ -9,22 +9,25 @@ Unlike rkllama (which has its own ``/api/pull`` download flow), llama-server
 expects a model file path on disk. So this installer:
 
 1. Downloads the GGUF from the manifest's variant.download_url
-2. Places it at ``<install_dir>/models/<app_id>.gguf``
-3. Updates the symlink ``<install_dir>/models/active.gguf`` → that file
+2. Places it under the shared layout at
+   ``~/models/rk-llama.cpp/<family>/<manifest_id>/<filename>``
+3. Updates the symlink ``<install_dir>/active.gguf`` to point at that file
 4. Enables + restarts the ``rkllamacpp`` systemd unit so llama-server
    picks up the new model
 
-One model is "active" at a time. Switching = installing a different
-manifest. This matches how llama-server is designed and keeps the unit
-configuration simple.
+One model is "active" at a time on this backend. Switching = installing
+a different manifest. This matches how llama-server is designed and
+keeps the unit configuration simple. ``active.gguf`` lives outside the
+shared models tree because it's a service-state pointer, not a model.
 
 Configuration via env vars (matched to install-rk-llama-cpp.sh):
 
-- ``TAOS_RKLLAMACPP_DIR`` — install directory (default: ``~/rk-llama.cpp``)
+- ``TAOS_RKLLAMACPP_DIR`` — service install directory for binary +
+  active symlink (default: ``~/rk-llama.cpp``). Distinct from the
+  shared models root.
+- ``TAOS_MODELS_ROOT`` — shared model tree root (default: ``~/models``).
+  Honoured via ``model_paths.models_root()``.
 - ``TAOS_RKLLAMACPP_PORT`` — server port (default: ``8090``)
-
-Both default to the values used by ``install-rk-llama-cpp.sh``; if you
-override one, override both consistently.
 """
 from __future__ import annotations
 
@@ -38,6 +41,13 @@ from typing import Any
 import httpx
 
 from tinyagentos.installers.base import AppInstaller, run_cmd
+from tinyagentos.installers.model_paths import (
+    backend_model_dir,
+    filename_from_url,
+)
+
+
+BACKEND_ID = "rk-llama.cpp"
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +80,9 @@ class RkLlamaCppInstaller(AppInstaller):
         timeout: int = 1800,
     ):
         self.install_dir = Path(install_dir) if install_dir else _default_install_dir()
-        self.models_dir = self.install_dir / "models"
+        # Model files live in the shared layout (~/models/<backend>/<family>/<id>),
+        # not under install_dir/models. Keep the install_dir for the binary,
+        # the libs, and the active.gguf symlink — that's all service state.
         self.port = port if port is not None else _default_port()
         self.timeout = timeout
 
@@ -107,9 +119,19 @@ class RkLlamaCppInstaller(AppInstaller):
                 ),
             }
 
-        self.models_dir.mkdir(parents=True, exist_ok=True)
-        target = self.models_dir / f"{app_id}.gguf"
-        active_link = self.models_dir / "active.gguf"
+        # Resolve the per-(backend, family, manifest) directory and the
+        # original filename from the URL — preserves what the user
+        # actually got from HF and lets a manifest dir hold multiple
+        # variants over time.
+        target_dir = backend_model_dir(BACKEND_ID, app_id)
+        target_dir.mkdir(parents=True, exist_ok=True)
+        fallback = f"{app_id}-{variant.get('id', 'model')}.gguf"
+        filename = filename_from_url(url, fallback)
+        target = target_dir / filename
+        # active.gguf is a service-state pointer, not a model artefact —
+        # keep it next to the binary in install_dir, never inside the
+        # shared models tree.
+        active_link = self.install_dir / "active.gguf"
 
         if target.exists():
             logger.info("rk-llama.cpp install: %s already present, reusing", target)
@@ -122,11 +144,13 @@ class RkLlamaCppInstaller(AppInstaller):
                     target.unlink()
                 return {"success": False, "error": f"download failed: {exc}"}
 
-        # Atomic active-symlink update.
+        # Atomic active-symlink update. Use absolute target so the
+        # symlink works regardless of working directory and cross-tree
+        # (active.gguf in install_dir, target in models_root).
         tmp_link = active_link.with_suffix(".gguf.new")
         if tmp_link.exists() or tmp_link.is_symlink():
             tmp_link.unlink()
-        tmp_link.symlink_to(target.name)
+        tmp_link.symlink_to(target)
         os.replace(tmp_link, active_link)
 
         # Enable + restart the service. Failure here means the model file
@@ -177,16 +201,32 @@ class RkLlamaCppInstaller(AppInstaller):
         }
 
     async def uninstall(self, app_id: str) -> dict:
-        target = self.models_dir / f"{app_id}.gguf"
-        active_link = self.models_dir / "active.gguf"
+        target_dir = backend_model_dir(BACKEND_ID, app_id)
+        active_link = self.install_dir / "active.gguf"
 
-        was_active = (
-            active_link.is_symlink()
-            and active_link.readlink().name == target.name
-        )
+        was_active = False
+        if active_link.is_symlink():
+            try:
+                active_target = active_link.resolve(strict=False)
+                # Active points inside this manifest's dir → it's serving
+                # one of this manifest's variants right now.
+                was_active = target_dir in active_target.parents
+            except OSError:
+                was_active = False
 
-        if target.exists():
-            target.unlink()
+        deleted: list[str] = []
+        if target_dir.exists():
+            for f in sorted(target_dir.glob("*")):
+                if f.is_file():
+                    f.unlink()
+                    deleted.append(f.name)
+            try:
+                target_dir.rmdir()
+            except OSError:
+                # Directory not empty (e.g. partial dir from an aborted
+                # install), leave it for human inspection rather than
+                # nuking unknown contents.
+                pass
 
         if was_active:
             try:
@@ -197,7 +237,12 @@ class RkLlamaCppInstaller(AppInstaller):
             if active_link.is_symlink():
                 active_link.unlink()
 
-        return {"success": True, "status": "uninstalled", "was_active": was_active}
+        return {
+            "success": True,
+            "status": "uninstalled",
+            "was_active": was_active,
+            "deleted": deleted,
+        }
 
     # ------------------------------------------------------------------
     # Helpers

--- a/tinyagentos/routes/models.py
+++ b/tinyagentos/routes/models.py
@@ -39,24 +39,73 @@ router = APIRouter()
 DEFAULT_MODELS_DIR = Path("/opt/tinyagentos/models")
 
 
+_MODEL_FILE_SUFFIXES = (".gguf", ".rkllm", ".bin", ".safetensors", ".onnx")
+
+
 def get_downloaded_models(models_dir: Path) -> list[dict]:
-    """Scan models directory and return list of downloaded model files."""
+    """Scan model directories and return downloaded model files.
+
+    Walks ``models_dir`` recursively (not just the top level) so the
+    shared layout at ``~/models/<backend>/<family>/<id>/<file>`` is
+    discovered alongside any legacy flat ``data/models/<file>`` files.
+    Each entry carries the relative path so the UI can show backend +
+    family grouping without re-deriving them.
+    """
     if not models_dir.exists():
         return []
     results = []
-    for f in sorted(models_dir.glob("*")):
-        if f.is_file() and f.suffix in (".gguf", ".rkllm", ".bin"):
-            results.append({
-                "filename": f.name,
-                "size_mb": f.stat().st_size // (1024 * 1024),
-                "format": f.suffix.lstrip("."),
-                "path": str(f),
-            })
+    for f in sorted(models_dir.rglob("*")):
+        if not f.is_file():
+            continue
+        if f.suffix.lower() not in _MODEL_FILE_SUFFIXES:
+            continue
+        try:
+            rel = str(f.relative_to(models_dir))
+        except ValueError:
+            rel = f.name
+        results.append({
+            "filename": f.name,
+            "relative_path": rel,
+            "size_mb": f.stat().st_size // (1024 * 1024),
+            "format": f.suffix.lstrip(".").lower(),
+            "path": str(f),
+        })
     return results
 
 
 def _models_dir(request: Request) -> Path:
     return getattr(request.app.state, "models_dir", DEFAULT_MODELS_DIR)
+
+
+def _scan_roots(request: Request) -> list[Path]:
+    """Roots to scan for downloaded model files.
+
+    Legacy ``data/models`` plus the new shared layout root
+    (~/models/<backend>/<family>/<id>/...). Both get walked so files
+    placed by older installers still surface alongside the new tree.
+    """
+    primary = _models_dir(request)
+    extra = getattr(request.app.state, "models_root", None)
+    roots = [primary]
+    if extra is not None and Path(extra) != primary:
+        roots.append(Path(extra))
+    return roots
+
+
+def _scan_all_roots(roots: list[Path]) -> list[dict]:
+    """Run get_downloaded_models against each root and merge, de-duped
+    by absolute path so a single file never appears twice even if a
+    legacy directory is symlinked into the new layout.
+    """
+    seen: set[str] = set()
+    merged: list[dict] = []
+    for r in roots:
+        for entry in get_downloaded_models(r):
+            if entry["path"] in seen:
+                continue
+            seen.add(entry["path"])
+            merged.append(entry)
+    return merged
 
 
 def _is_service_installed(variant: dict) -> bool:
@@ -218,11 +267,10 @@ async def list_models(request: Request):
     """
     registry = request.app.state.registry
     hardware_profile = request.app.state.hardware_profile
-    models_dir = _models_dir(request)
     catalog = getattr(request.app.state, "backend_catalog", None)
 
     models = registry.list_available(type_filter="model")
-    downloaded = get_downloaded_models(models_dir)
+    downloaded = _scan_all_roots(_scan_roots(request))
     live_models = catalog.all_models() if catalog is not None else []
     # Build {app_id: True} from the install registry so backend-installed
     # models (e.g. rk-llama.cpp GGUFs at ~/rk-llama.cpp/models/) still show


### PR DESCRIPTION
## Why
Each backend installer used to drop files in its own private dir (\`rk-llama.cpp/models/\`, \`/opt/tinyagentos/models/\`, etc.). The user couldn't see everything they had in one place. Workers couldn't rsync a manifest cleanly across the cluster. The Models app had no way to surface backend-installed files because each backend's layout was different.

## What
Consolidates all backend installs under one tree:

\`\`\`
~/models/<backend>/<family>/<manifest_id>/<original_filename>
\`\`\`

Examples:
- \`~/models/rk-llama.cpp/gemma/gemma-4-e2b-gguf/gemma-4-E2B-it-Q4_K_M.gguf\`
- \`~/models/llama-cpp/qwen3.5/qwen3.5-9b/qwen3.5-9b-Q4_K_M.gguf\`

### New: \`tinyagentos/installers/model_paths.py\`
| Function | Behaviour |
|---|---|
| \`models_root()\` | \`TAOS_MODELS_ROOT\` override, defaults to \`~/models\` |
| \`family_from_manifest()\` | explicit \`family:\` field wins → else first dash-separated token of the id (\`gemma-4-e2b-gguf\` → \`gemma\`, \`qwen3.5-9b\` → \`qwen3.5\`) → else \`uncategorised\` |
| \`backend_model_dir()\` | pure path builder, doesn't touch the filesystem |
| \`filename_from_url()\` | preserves the HF basename so the user sees the file they actually got; falls back to \`<id>-<variant>.<format>\` for opaque URLs |

### Touched
- \`rkllamacpp_installer.py\` — writes to shared layout; \`active.gguf\` symlink moved out of \`<install_dir>/models/\` to \`<install_dir>/active.gguf\` (service-state, not model artefact)
- \`download_installer.py\` — covers llama-cpp / mlx / vllm / transformers / diffusers / sentence-transformers / whisper-cpp / piper / onnxruntime / nemo / sd-webui
- \`scripts/install-rk-llama-cpp.sh\` — systemd unit's \`-m\` path follows
- \`routes/models.py\` — scan walks recursively (rglob) and scans both legacy \`data/models\` and the new shared root; entries carry \`relative_path\` for future grouping
- \`app.py\` — \`app.state.models_root\` added alongside \`app.state.models_dir\`

### Migration: \`scripts/migrate-model-layout.sh\`
Moves existing \`rk-llama.cpp/models/\` files into the new tree, re-points the active symlink, rewrites the systemd unit if it still has the old path, and restarts rkllamacpp. Idempotent. Legacy \`/opt/tinyagentos/models\` files are flagged but not auto-moved because filename ambiguity makes inferring \`(backend, manifest_id)\` from a flat name unsafe.

### Out of scope (filing separately)
- Ollama discovery — ollama owns its own blob store under \`~/.ollama/models\`; surfacing those in the Models app is the next chunk
- Per-variant download tracking — the registry still tracks per-manifest, so \`has_downloaded_variant\` is still coarse

## Test plan
- [x] 16 new tests in \`test_model_paths.py\` covering family extraction (literal first token, explicit override, dict/object inputs, lowercase normalisation, fallback), root resolution (env override, default), and filename sanitisation
- [x] New test \`TestInstallUsesSharedLayout\` in \`test_rkllamacpp_installer.py\` proves the installer writes under \`<root>/<backend>/<family>/<id>/\` and \`active.gguf\` resolves correctly
- [x] Updated existing tests to sandbox \`TAOS_MODELS_ROOT\` so they don't pollute the test runner's \`~/models\`
- [ ] Live: run \`scripts/migrate-model-layout.sh\` on the Pi, verify gemma-4-e2b-gguf moves cleanly, llama-server keeps serving on port 8090

---
_Surfaced when jay reported the agent picker not showing his store-installed Gemma 4 — #429 closed the visibility gap; this is the layout reorg jay asked for as the structural follow-up._