### PR TITLE
fix(backends): make /api/backends resilient + migrate-model-layout robustness

### DIFF
--- a/app-catalog/services/mlc-llm/manifest.yaml
+++ b/app-catalog/services/mlc-llm/manifest.yaml
@@ -1,6 +1,6 @@
 id: mlc-llm
 name: MLC LLM
-type: llm-runtime
+type: service
 category: llm-runtime
 version: 0.1.0
 description: "TVM-compiled LLM serving — runs Llama / Mistral / Qwen / Phi on Vulkan, ROCm, Metal, CUDA, and even WebGPU. Strong on consumer GPUs and edge accelerators where llama.cpp underperforms."
@@ -16,6 +16,16 @@ requires:
 install:
   method: pip
   package: mlc-llm
+
+lifecycle:
+  # mlc-llm exposes an OpenAI-compatible HTTP API on /v1, so the
+  # controller talks to it via the openai-compatible adapter rather
+  # than registering a bespoke "llm-runtime" backend type that no
+  # adapter handles.
+  backend_type: openai-compatible
+  default_url: http://localhost:8000
+  auto_manage: false
+  keep_alive_minutes: 10
 
 hardware_tiers:
   arm-npu-16gb: degraded

--- a/scripts/migrate-model-layout.sh
+++ b/scripts/migrate-model-layout.sh
@@ -22,17 +22,44 @@ log()  { echo -e "\033[1;34m[migrate-models]\033[0m $*"; }
 warn() { echo -e "\033[1;33m[migrate-models]\033[0m $*" >&2; }
 die()  { echo -e "\033[1;31m[migrate-models]\033[0m $*" >&2; exit 1; }
 
-# Resolve target user — controller installs as root or jay; pick the owner
-# of the running unit's WorkingDirectory rather than guess from $HOME.
-TARGET_USER="${SUDO_USER:-$(id -un)}"
-TARGET_HOME=$(getent passwd "$TARGET_USER" | cut -d: -f6)
-[[ -d "$TARGET_HOME" ]] || die "could not resolve home for $TARGET_USER"
+# Resolve the rk-llama.cpp install dir from the live systemd unit so we
+# migrate the directory that's actually serving traffic. Falls back to
+# $SUDO_USER's home only if no unit is installed (fresh Pi, no service
+# yet) — otherwise picking the wrong tree can leave the unit pointing
+# at a non-existent active.gguf and the service refuses to start.
+UNIT_PATH="/etc/systemd/system/rkllamacpp.service"
+RKDIR=""
+if [[ -f "$UNIT_PATH" ]]; then
+    # ExecStart line lists the binary path — strip the "bin/llama-server …" tail
+    # to get the install dir.
+    binary=$(awk -F= '/^ExecStart=/{ split($2,a," "); print a[1] }' "$UNIT_PATH" | head -1)
+    if [[ -n "$binary" && "$binary" == */bin/llama-server ]]; then
+        RKDIR="${binary%/bin/llama-server}"
+    fi
+fi
+if [[ -z "$RKDIR" ]]; then
+    # Fall back: $SUDO_USER home, then $HOME. Only used when no unit
+    # exists yet (this script ran before install-rk-llama-cpp.sh).
+    fallback_user="${SUDO_USER:-$(id -un)}"
+    fallback_home=$(getent passwd "$fallback_user" | cut -d: -f6)
+    [[ -d "$fallback_home" ]] || die "could not resolve home for $fallback_user"
+    RKDIR="$fallback_home/rk-llama.cpp"
+fi
 
-NEW_ROOT="${TAOS_MODELS_ROOT:-$TARGET_HOME/models}"
-log "target user: $TARGET_USER  new root: $NEW_ROOT"
+# Owner of the install dir drives chown — the service runs as that user.
+if [[ -d "$RKDIR" ]]; then
+    install_owner=$(stat -c '%U' "$RKDIR")
+else
+    install_owner="${SUDO_USER:-$(id -un)}"
+fi
+install_home=$(getent passwd "$install_owner" | cut -d: -f6)
+[[ -d "$install_home" ]] || die "could not resolve home for install owner $install_owner"
+
+NEW_ROOT="${TAOS_MODELS_ROOT:-$install_home/models}"
+log "rk-llama.cpp install dir: $RKDIR  owner: $install_owner  new models root: $NEW_ROOT"
 
 mkdir -p "$NEW_ROOT"
-chown "$TARGET_USER:$TARGET_USER" "$NEW_ROOT"
+chown "$install_owner:$install_owner" "$NEW_ROOT" 2>/dev/null || true
 
 # Pure-bash family extractor — first dash-separated token of the id,
 # lowercased. Matches model_paths.family_from_manifest's fallback path.
@@ -44,10 +71,19 @@ family_of() {
 }
 
 # --- rk-llama.cpp -----------------------------------------------------
-RKDIR="$TARGET_HOME/rk-llama.cpp"
 RK_OLD_MODELS="$RKDIR/models"
 RK_NEW_BACKEND="$NEW_ROOT/rk-llama.cpp"
 moved=0
+
+# Skip rk-llama.cpp's own bundled vocab test fixtures — they're build
+# artefacts in the source tree, not user-installed models. Detect them
+# by filename pattern so we don't accidentally migrate them and then
+# expose them in /api/models as fake installed models.
+is_vocab_fixture() {
+    local name="$1"
+    [[ "$name" == ggml-vocab-* ]]
+}
+
 if [[ -d "$RK_OLD_MODELS" ]]; then
     log "scanning $RK_OLD_MODELS"
     mkdir -p "$RK_NEW_BACKEND"
@@ -56,6 +92,10 @@ if [[ -d "$RK_OLD_MODELS" ]]; then
         # Skip the active.gguf symlink — re-pointed below.
         if [[ -L "$src" ]]; then continue; fi
         base=$(basename "$src")
+        if is_vocab_fixture "$base"; then
+            log "  skip $base (rk-llama.cpp vocab test fixture, not a real model)"
+            continue
+        fi
         # Old naming was "<app_id>.gguf"; recover app_id and family from it.
         manifest_id="${base%.gguf}"
         family=$(family_of "$manifest_id")
@@ -68,7 +108,7 @@ if [[ -d "$RK_OLD_MODELS" ]]; then
         mkdir -p "$target_dir"
         log "  moving $base -> $family/$manifest_id/"
         mv "$src" "$target"
-        chown -R "$TARGET_USER:$TARGET_USER" "$target_dir"
+        chown -R "$install_owner:$install_owner" "$target_dir" 2>/dev/null || true
         moved=$((moved+1))
     done
 fi
@@ -86,7 +126,7 @@ if [[ -L "$ACTIVE_OLD" ]]; then
     new_target="$RK_NEW_BACKEND/$family/$manifest_id/$target_name"
     if [[ -f "$new_target" ]]; then
         ln -sfn "$new_target" "$ACTIVE_NEW"
-        chown -h "$TARGET_USER:$TARGET_USER" "$ACTIVE_NEW"
+        chown -h "$install_owner:$install_owner" "$ACTIVE_NEW" 2>/dev/null || true
         rm -f "$ACTIVE_OLD"
         log "  active.gguf -> $new_target"
     else

--- a/tests/test_backend_adapters.py
+++ b/tests/test_backend_adapters.py
@@ -19,6 +19,51 @@ class TestGetAdapter:
         with pytest.raises(ValueError, match="Unknown backend type"):
             get_adapter("unknown")
 
+
+class TestCheckBackendHealthResilience:
+    """A misconfigured backend (unknown type, raising adapter) must not
+    take the whole /api/backends endpoint with it. check_backend_health
+    must always return a structured dict.
+    """
+
+    @pytest.mark.asyncio
+    async def test_unknown_type_returns_unsupported_envelope(self):
+        client = AsyncMock(spec=httpx.AsyncClient)
+        backend = {"name": "local-mlc-llm", "type": "llm-runtime", "url": "http://x"}
+        result = await check_backend_health(client, backend)
+        assert result["healthy"] is False
+        assert result["status"] == "unsupported"
+        assert "Unknown backend type" in result["error"]
+        assert result["name"] == "local-mlc-llm"
+        assert result["type"] == "llm-runtime"
+        assert result["models"] == []
+
+    @pytest.mark.asyncio
+    async def test_adapter_exception_returns_error_envelope(self):
+        client = AsyncMock(spec=httpx.AsyncClient)
+        # Use a real type whose adapter we'll make raise — patch the
+        # registered adapter's health method.
+        from tinyagentos.backend_adapters import _ADAPTERS
+        original = _ADAPTERS["ollama"].health
+        async def boom(*_a, **_kw):
+            raise RuntimeError("network on fire")
+        _ADAPTERS["ollama"].health = boom  # type: ignore[method-assign]
+        try:
+            result = await check_backend_health(client, {"name": "x", "type": "ollama", "url": "http://x"})
+        finally:
+            _ADAPTERS["ollama"].health = original  # type: ignore[method-assign]
+        assert result["healthy"] is False
+        assert result["status"] == "error"
+        assert "network on fire" in result["error"]
+        assert result["models"] == []
+
+    @pytest.mark.asyncio
+    async def test_missing_name_does_not_crash(self):
+        client = AsyncMock(spec=httpx.AsyncClient)
+        result = await check_backend_health(client, {"type": "totally-bogus", "url": "http://x"})
+        assert result["healthy"] is False
+        assert result["name"] == ""
+
 class TestRkLlamaAdapter:
     @pytest.mark.asyncio
     async def test_parse_health_response(self):

--- a/tests/test_config_auto_register.py
+++ b/tests/test_config_auto_register.py
@@ -107,3 +107,55 @@ lifecycle:
     auto_register_from_manifest(manifest, config)
     b = config.backends[0]
     assert b["keep_alive_minutes"] == 0, "0 means always-on; must not fall back to 10"
+
+
+def test_auto_register_skips_unknown_backend_type(tmp_path: Path, caplog):
+    """A manifest with a backend_type the controller doesn't have an
+    adapter for must NOT register the backend — otherwise every health
+    check round raises ValueError and /api/backends 500s. The fix is
+    to skip + log loudly at registration time.
+    """
+    import logging
+
+    # Catalog-format manifest with an invented backend type.
+    manifest = tmp_path / "bogus.yaml"
+    manifest.write_text("""
+id: bogus-runtime
+name: Bogus Runtime
+type: service
+lifecycle:
+  backend_type: not-a-real-adapter
+  default_url: http://localhost:9999
+""")
+    config = AppConfig()
+    with caplog.at_level(logging.WARNING):
+        added = auto_register_from_manifest(manifest, config)
+
+    assert added is False
+    assert config.backends == []
+    # The warning has to be loud enough to be noticed in the controller
+    # log — the user shouldn't have to grep the source to understand why
+    # their service isn't registering.
+    assert any(
+        "not-a-real-adapter" in rec.message and "VALID_BACKEND_TYPES" in rec.message
+        for rec in caplog.records
+    ), f"expected loud warning; got: {[r.message for r in caplog.records]}"
+
+
+def test_auto_register_flat_format_unknown_type_skipped(tmp_path: Path, caplog):
+    """Same skip behaviour for flat-format manifests (top-level type is
+    the backend type)."""
+    import logging
+
+    manifest = tmp_path / "flat-bogus.yaml"
+    manifest.write_text("""
+id: flat-bogus
+name: Flat Bogus
+type: not-a-real-adapter
+default_url: http://localhost:9999
+""")
+    config = AppConfig()
+    with caplog.at_level(logging.WARNING):
+        added = auto_register_from_manifest(manifest, config)
+    assert added is False
+    assert config.backends == []

--- a/tinyagentos/backend_adapters.py
+++ b/tinyagentos/backend_adapters.py
@@ -197,6 +197,37 @@ def get_adapter(backend_type: str) -> BackendAdapter:
 
 
 async def check_backend_health(client: httpx.AsyncClient, backend: dict) -> dict:
-    adapter = get_adapter(backend["type"])
-    result = await adapter.health(client, backend["url"])
-    return {**result, "name": backend["name"], "type": backend["type"], "priority": backend.get("priority", 99)}
+    """Health-check a single backend, never raising.
+
+    A misconfigured backend (unknown type, missing url, adapter that
+    raises) must not be allowed to take down the entire /api/backends
+    response. Return a structured error envelope so the caller can
+    aggregate and the UI can show the bad entry as offline with a
+    reason rather than 500-ing the whole endpoint.
+    """
+    backend_type = backend.get("type", "")
+    try:
+        adapter = get_adapter(backend_type)
+    except ValueError as exc:
+        return {
+            "healthy": False,
+            "status": "unsupported",
+            "error": str(exc),
+            "name": backend.get("name", ""),
+            "type": backend_type,
+            "priority": backend.get("priority", 99),
+            "models": [],
+        }
+    try:
+        result = await adapter.health(client, backend["url"])
+    except Exception as exc:  # noqa: BLE001 — adapter integrity is best-effort
+        return {
+            "healthy": False,
+            "status": "error",
+            "error": str(exc),
+            "name": backend.get("name", ""),
+            "type": backend_type,
+            "priority": backend.get("priority", 99),
+            "models": [],
+        }
+    return {**result, "name": backend.get("name", ""), "type": backend_type, "priority": backend.get("priority", 99)}

--- a/tinyagentos/config.py
+++ b/tinyagentos/config.py
@@ -239,6 +239,21 @@ def auto_register_from_manifest(manifest_path: Path, config: "AppConfig") -> boo
     if not backend_type:
         return False
 
+    # Reject backend types we don't have an adapter for. Otherwise the
+    # entry survives in config.backends and every health-check round
+    # raises ValueError in get_adapter() — a single bad manifest takes
+    # the /api/backends endpoint with it. Better to surface this loudly
+    # at startup than to limp along with a 500-ing endpoint.
+    if backend_type not in VALID_BACKEND_TYPES:
+        import logging
+        logging.getLogger(__name__).warning(
+            "auto_register_from_manifest: skipping %s — backend_type %r is not "
+            "in VALID_BACKEND_TYPES %s. Update the manifest's lifecycle.backend_type "
+            "or register an adapter in backend_adapters.py.",
+            name, backend_type, sorted(VALID_BACKEND_TYPES),
+        )
+        return False
+
     if any(b.get("name") == name for b in config.backends):
         return False
 


### PR DESCRIPTION
Three layers fixed together because they're the same bug surfacing at different points, plus a follow-up to the migration script that exposed itself when run live on the Pi.

## 1. Manifest layer
\`mlc-llm\` declared top-level \`type: llm-runtime\` which \`auto_register_from_manifest\` read as the backend type. Now follows the pattern every other catalog service uses:

| Field | Before | After |
|---|---|---|
| top-level \`type\` | \`llm-runtime\` | \`service\` |
| \`category\` | \`llm-runtime\` | \`llm-runtime\` (kept — UX grouping) |
| \`lifecycle.backend_type\` | _missing_ | \`openai-compatible\` |
| \`lifecycle.default_url\` | _missing_ | \`http://localhost:8000\` |

## 2. Registration layer
\`auto_register_from_manifest\` used to write ANY string into \`config.backends\`. One bad manifest meant every health-check loop hit \`ValueError\`. Now validates against \`VALID_BACKEND_TYPES\` at registration time, logs a loud warning with the offending name + type + the allowed set, and skips the entry. Loud failure beats limp-along.

## 3. Read layer
Even if a bad backend somehow ended up in config (old data file from before #2 lands, manual edit), \`check_backend_health\` used to raise \`ValueError\` up through the FastAPI handler and 500 the whole \`/api/backends\` response. Now returns a structured envelope:

\`\`\`json
{ "healthy": false, "status": "unsupported", "error": "...", "models": [] }
\`\`\`

…so the dashboard renders the bad entry as offline-with-reason instead of taking down the entire endpoint. Same envelope for adapter exceptions during \`health()\` calls.

## 4. Migration script (follow-up from live Pi run)
The script in #430 picked the install dir from \`$SUDO_USER\`'s \`$HOME\`, but the real production install on the Pi is under \`/root/rk-llama.cpp/\` (the systemd unit runs as \`User=jay\` even though the binary lives in /root). Result: it scanned \`/home/jay/rk-llama.cpp/models/\` (a build dir holding only \`ggml-vocab-*\` test fixtures), migrated those, and re-pointed an \`active.gguf\` to a path that didn't exist — service refused to start.

Now the script:
- Reads the \`ExecStart\` line of \`/etc/systemd/system/rkllamacpp.service\` to find the **actual** install dir (\`/root/rk-llama.cpp\` or \`~/rk-llama.cpp\`)
- Uses the install dir's filesystem owner for chown, not \`SUDO_USER\`
- Skips \`ggml-vocab-*\` filenames (rk-llama.cpp's bundled test fixtures, not user-installed models)

## Net effect
- ✅ Master CI goes green again — \`test_routes_dashboard.py::test_backends_api\` had been failing for the past 4+ PRs (#427-#430) on this exact \`llm-runtime\` warning the live controller logged every 30s
- ✅ \`/api/backends\` never 500s because of one bad backend
- ✅ Future malformed manifests fail loudly at startup instead of silently poisoning every health-check round
- ✅ Migration script robust to dual rk-llama.cpp install dirs (production at /root, source build at ~/, etc.)

## Test plan
- [x] 3 new tests in \`test_backend_adapters.py\` — unknown type returns unsupported envelope, raising adapter returns error envelope, missing name doesn't crash
- [x] 2 new tests in \`test_config_auto_register.py\` — catalog-format manifest with unknown backend_type is skipped + warning logged; flat-format ditto
- [x] Live: ran updated migration logic by hand on the Pi — moved \`/root/rk-llama.cpp/models/{e2b,e4b}.gguf\` → \`/root/models/rk-llama.cpp/gemma/...\`, re-pointed active.gguf, restarted rkllamacpp, /v1/models reports model loaded
- [ ] Master CI green after merge

---
_Surfaced while debugging \`test (3.13)\` failure on PR #430. Jay said "fix it properly no workarounds" — the manifest fix alone would patch the symptom; the registration + read layers are the actual fragility. Migration-script bug surfaced in live testing._