### PR TITLE
fix(assistant): bump panel opacity so error text is readable

### DIFF
--- a/desktop/src/components/TaosAssistantPanel.tsx
+++ b/desktop/src/components/TaosAssistantPanel.tsx
@@ -125,16 +125,24 @@ export function TaosAssistantPanel() {
         aria-hidden="true"
       />
 
-      {/* Slide-over panel */}
+      {/* Slide-over panel.
+          bg-shell-surface (4% white) is fine for inline cards layered
+          inside windows but is unreadable as a top-level slide-over
+          against the wallpaper. Use a heavy dark glass instead — solid
+          enough that error/log text reads cleanly, with a hint of
+          backdrop blur for the macOS-style sidebar feel. */}
       <div
         role="dialog"
         aria-label="taOS Assistant"
         aria-modal="true"
-        className="fixed right-0 z-[101] flex flex-col bg-shell-surface border-l border-white/10 shadow-2xl"
+        className="fixed right-0 z-[101] flex flex-col border-l border-white/10 shadow-2xl"
         style={{
           top: "var(--spacing-topbar-h)",
           bottom: "calc(var(--spacing-dock-h, 52px))",
           width: 400,
+          backgroundColor: "rgba(21, 22, 37, 0.92)",
+          backdropFilter: "blur(20px)",
+          WebkitBackdropFilter: "blur(20px)",
           animation: "taos-assistant-slidein 300ms ease-out",
         }}
         onClick={(e) => e.stopPropagation()}


### PR DESCRIPTION
The taOS Assistant slide-over used \`bg-shell-surface\` (4% white) which is fine for inline cards layered inside windows but unreadable as a top-level panel against the wallpaper — error / log text bled straight through to the background.

Switch to a heavy dark glass (\`rgba(21, 22, 37, 0.92)\` + \`20px\` \`backdrop-filter\`) which reads cleanly without losing the macOS-style sidebar feel.

## Test plan
- [x] Visual: panel now opaque enough to read error text against any wallpaper
- [ ] Live: jay's PWA reload — error bubble in the assistant should be legible

---
_Reported by jay via screenshot showing an LLM proxy 400 in the assistant pane against the wallpaper._