### PR TITLE
feat(routing): auto-route every locally-installed model through LiteLLM

### DIFF
--- a/app-catalog/services/rk-llama-cpp/manifest.yaml
+++ b/app-catalog/services/rk-llama-cpp/manifest.yaml
@@ -10,11 +10,24 @@ license: MIT
 requires:
   ram_mb: 512
   disk_mb: 1000
-  ports: [8080]
+  # llama-server inside rk-llama.cpp listens on 8090 by default (see
+  # scripts/install-rk-llama-cpp.sh — TAOS_RKLLAMACPP_PORT). Bound to
+  # 127.0.0.1 so it isn't exposed off-host.
+  ports: [8090]
 
 install:
   method: script
   script: scripts/install-rk-llama-cpp.sh
+
+lifecycle:
+  # Auto-register as a backend so the LiteLLM proxy gets a route to
+  # the local llama-server. llama-server speaks OpenAI-compatible
+  # /v1/chat/completions; without this block the service runs but no
+  # agent / assistant call ever finds it.
+  backend_type: openai-compatible
+  default_url: http://localhost:8090
+  auto_manage: false
+  keep_alive_minutes: 0  # always-on while a model is active
 
 hardware_tiers:
   arm-npu-16gb: full

--- a/scripts/install-rk-llama-cpp.sh
+++ b/scripts/install-rk-llama-cpp.sh
@@ -91,6 +91,18 @@ log "extracting into $INSTALL_DIR"
 run_as_user tar -xzf "$TMP_TARBALL" -C "$INSTALL_DIR"
 chmod +x "$INSTALL_DIR/bin/llama-server" 2>/dev/null || true
 
+# Default active.alias — rkllamacpp installer rewrites this file every
+# time a model becomes active so /v1/models advertises the manifest id
+# (e.g. gemma-4-e2b-gguf) instead of the generic "active.gguf". The
+# systemd unit reads it via EnvironmentFile= and passes the value as
+# --alias. Pre-create with a sentinel so the unit starts cleanly even
+# before the first model install (llama-server will refuse to load
+# without -m, which is fine — the unit is disabled until the store
+# install activates it anyway).
+sudo -u "$TARGET_USER" tee "$INSTALL_DIR/active.alias" > /dev/null <<'ALIAS'
+TAOS_ACTIVE_ALIAS=active.gguf
+ALIAS
+
 # -------- systemd unit ---------------------------------------------------
 UNIT_PATH="/etc/systemd/system/rkllamacpp.service"
 log "writing $UNIT_PATH (port $PORT)"
@@ -105,8 +117,9 @@ User=$TARGET_USER
 Group=$TARGET_GROUP
 WorkingDirectory=$INSTALL_DIR
 Environment=LD_LIBRARY_PATH=$INSTALL_DIR/lib
+EnvironmentFile=$INSTALL_DIR/active.alias
 LimitNOFILE=65536
-ExecStart=$INSTALL_DIR/bin/llama-server -m $INSTALL_DIR/active.gguf --host $HOST --port $PORT
+ExecStart=$INSTALL_DIR/bin/llama-server -m $INSTALL_DIR/active.gguf --alias \${TAOS_ACTIVE_ALIAS} --host $HOST --port $PORT
 Restart=on-failure
 RestartSec=5
 KillMode=mixed

--- a/tests/test_llm_proxy_local_models.py
+++ b/tests/test_llm_proxy_local_models.py
@@ -1,0 +1,140 @@
+"""Tests for the local-installed-model registration path in
+generate_litellm_config — the fix that lets the agent picker actually
+chat with locally-installed models like gemma-4-e2b-gguf."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from tinyagentos.llm_proxy import generate_litellm_config
+
+
+def _fake_registry(manifests: list[dict], installed_ids: list[str]):
+    """Build a stub object exposing the AppRegistry surface that
+    generate_litellm_config uses (list_installed + get).
+    """
+    by_id = {m["id"]: SimpleNamespace(**m) for m in manifests}
+
+    def _get(app_id):
+        return by_id.get(app_id)
+
+    return SimpleNamespace(
+        list_installed=lambda: [{"id": i} for i in installed_ids],
+        get=_get,
+    )
+
+
+def _gemma_manifest(app_id: str, backend_id: str) -> dict:
+    return {
+        "id": app_id,
+        "name": app_id,
+        "type": "model",
+        "variants": [
+            {
+                "id": "q4_k_m",
+                "format": "gguf",
+                "download_url": f"https://example.com/{app_id}.gguf",
+                "requires": {"backends": [{"id": backend_id}]},
+            }
+        ],
+        "context_window": 32768,
+    }
+
+
+def _local_backend(name="local-rk-llama-cpp", url="http://localhost:8090"):
+    return {
+        "name": name,
+        "type": "openai-compatible",
+        "url": url,
+        "priority": 99,
+        "enabled": True,
+    }
+
+
+class TestLocalInstalledModelRegistration:
+    def test_installed_model_registered_under_manifest_id(self):
+        """The whole point: chatting with the agent picker's selected
+        model name must reach a configured LiteLLM model_name."""
+        registry = _fake_registry(
+            manifests=[_gemma_manifest("gemma-4-e2b-gguf", "rk-llama-cpp")],
+            installed_ids=["gemma-4-e2b-gguf"],
+        )
+
+        config = generate_litellm_config([_local_backend()], registry=registry)
+        names = [e["model_name"] for e in config["model_list"]]
+        assert "gemma-4-e2b-gguf" in names, names
+
+        entry = next(e for e in config["model_list"] if e["model_name"] == "gemma-4-e2b-gguf")
+        assert entry["litellm_params"]["api_base"] == "http://localhost:8090"
+        assert entry["litellm_params"]["model"] == "openai/gemma-4-e2b-gguf"
+        assert entry["metadata"]["source"] == "local-installed"
+
+    def test_only_compatible_models_register(self):
+        """A model whose variants don't list this backend's id must not
+        be registered against this backend — wrong route would 400."""
+        registry = _fake_registry(
+            manifests=[
+                _gemma_manifest("gemma-4-e2b-gguf", "rk-llama-cpp"),
+                # This one targets a different backend (ollama) — must be skipped
+                _gemma_manifest("ollama-only-model", "ollama"),
+            ],
+            installed_ids=["gemma-4-e2b-gguf", "ollama-only-model"],
+        )
+
+        config = generate_litellm_config([_local_backend()], registry=registry)
+        names = [e["model_name"] for e in config["model_list"]]
+        assert "gemma-4-e2b-gguf" in names
+        assert "ollama-only-model" not in names
+
+    def test_no_registry_no_local_entries(self):
+        """Existing behaviour without the registry must be preserved —
+        no installed-model entries when the caller doesn't pass it."""
+        config = generate_litellm_config([_local_backend()])
+        names = [e["model_name"] for e in config["model_list"]]
+        # "default" alias should still be there for the openai-compatible backend
+        assert "default" in names
+        # No per-installed-model entries because no registry was supplied
+        assert all(not n.startswith("gemma") for n in names)
+
+    def test_non_local_named_backend_skipped(self):
+        """Cloud backends (name doesn't start with 'local-') must be
+        unaffected — the per-installed-model branch only runs for
+        backends auto-registered from local service manifests."""
+        cloud = {
+            "name": "openai-prod",  # not 'local-...'
+            "type": "openai",
+            "url": "https://api.openai.com/v1",
+            "priority": 1,
+            "models": [{"id": "gpt-4o"}],
+        }
+        registry = _fake_registry(
+            manifests=[_gemma_manifest("gemma-4-e2b-gguf", "rk-llama-cpp")],
+            installed_ids=["gemma-4-e2b-gguf"],
+        )
+        config = generate_litellm_config([cloud], registry=registry)
+        names = [e["model_name"] for e in config["model_list"]]
+        # Cloud per-model entries still present
+        assert "gpt-4o" in names
+        # Local manifest never registers under the cloud backend
+        assert "gemma-4-e2b-gguf" not in names
+
+    def test_no_duplicate_when_cloud_loop_already_added_name(self):
+        """If a cloud-style backend.models[] entry already registered the
+        manifest id, the local-installed branch must not double-register."""
+        backend = {
+            "name": "local-rk-llama-cpp",
+            "type": "openai-compatible",
+            "url": "http://localhost:8090",
+            "priority": 1,
+            # Pre-declared models[] (unlikely for local, but the dedupe
+            # logic must hold even if a future caller adds one)
+            "models": [{"id": "gemma-4-e2b-gguf"}],
+        }
+        registry = _fake_registry(
+            manifests=[_gemma_manifest("gemma-4-e2b-gguf", "rk-llama-cpp")],
+            installed_ids=["gemma-4-e2b-gguf"],
+        )
+        config = generate_litellm_config([backend], registry=registry)
+        gemma_entries = [e for e in config["model_list"] if e["model_name"] == "gemma-4-e2b-gguf"]
+        assert len(gemma_entries) == 1

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -233,7 +233,17 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     # back to /api/trace and the 401s fill the log instead of trace rows.
     local_token_path = data_dir / ".auth_local_token"
     local_token = local_token_path.read_text().strip() if local_token_path.exists() else None
-    llm_proxy = LLMProxy(port=4000, database_url=db_url, local_token=local_token)
+    llm_proxy = LLMProxy(
+        port=4000,
+        database_url=db_url,
+        local_token=local_token,
+        # registry lets generate_litellm_config register installed local
+        # models (e.g. gemma-4-e2b-gguf) as LiteLLM model_name aliases
+        # routing through the matching backend's URL. Without it, the
+        # agent picker can show a local model but chatting with it 400s
+        # at the proxy because no alias exists for that model_name.
+        registry=registry,
+    )
     channel_hub_router = MessageRouter()
     adapter_manager = AdapterManager(channel_hub_router)
     chat_messages = ChatMessageStore(data_dir / "chat.db")

--- a/tinyagentos/installers/rkllamacpp_installer.py
+++ b/tinyagentos/installers/rkllamacpp_installer.py
@@ -153,6 +153,14 @@ class RkLlamaCppInstaller(AppInstaller):
         tmp_link.symlink_to(target)
         os.replace(tmp_link, active_link)
 
+        # Tell llama-server which manifest id is now active so its
+        # /v1/models endpoint advertises the right name. The systemd
+        # unit reads this file via EnvironmentFile= and passes it to
+        # llama-server as --alias. Reading via a sidecar file means
+        # we never rewrite the unit at runtime — install-time only.
+        active_alias_path = self.install_dir / "active.alias"
+        active_alias_path.write_text(f"TAOS_ACTIVE_ALIAS={app_id}\n")
+
         # Enable + restart the service. Failure here means the model file
         # is on disk but the runtime is not actually serving it — we report
         # success: False so the dispatcher can persist the install correctly

--- a/tinyagentos/llm_proxy.py
+++ b/tinyagentos/llm_proxy.py
@@ -147,7 +147,62 @@ def _discover_ollama_models(url: str, timeout: float = 2.0) -> list[str]:
         return []
 
 
-def generate_litellm_config(backends: list[dict], default_model: str = "default") -> dict:
+def _local_backend_models_from_registry(
+    backend: dict, registry
+) -> list[str]:
+    """Find every installed model that can run on this local backend.
+
+    auto_register_from_manifest names backends ``local-<service-id>`` (e.g.
+    ``local-rk-llama-cpp`` for the rk-llama.cpp service). Each model
+    manifest declares ``variants[].requires.backends[].id`` listing the
+    runtime ids it supports. Cross-reference the two: every installed
+    model whose variants point at this backend's service id is a model
+    we can route requests to via this backend's URL.
+
+    Returns a deduplicated list of manifest ids — the LiteLLM model_name
+    aliases we want to create per local backend.
+    """
+    if registry is None:
+        return []
+
+    name = backend.get("name", "")
+    if not name.startswith("local-"):
+        return []
+    service_id = name[len("local-"):]
+    if not service_id:
+        return []
+
+    try:
+        installed_rows = registry.list_installed()
+    except Exception:  # noqa: BLE001
+        return []
+    installed_ids = {row.get("id") for row in installed_rows if row.get("id")}
+
+    matched: list[str] = []
+    for manifest_id in sorted(installed_ids):
+        manifest = registry.get(manifest_id) if hasattr(registry, "get") else None
+        if not manifest or getattr(manifest, "type", None) != "model":
+            continue
+        variants = getattr(manifest, "variants", None) or []
+        for v in variants:
+            if not isinstance(v, dict):
+                continue
+            for req in (v.get("requires", {}) or {}).get("backends", []) or []:
+                if isinstance(req, dict) and req.get("id") == service_id:
+                    matched.append(manifest_id)
+                    break
+            else:
+                continue
+            break
+    return matched
+
+
+def generate_litellm_config(
+    backends: list[dict],
+    default_model: str = "default",
+    *,
+    registry=None,
+) -> dict:
     """Generate LiteLLM config from TinyAgentOS backend list.
 
     Emits two kinds of model_list entries:
@@ -243,6 +298,39 @@ def generate_litellm_config(backends: list[dict], default_model: str = "default"
             },
         })
 
+        # For local backends (name "local-<service-id>" from
+        # auto_register_from_manifest), also register every installed
+        # model that targets this backend as its own LiteLLM model_name.
+        # Independent of cloud/non-cloud: openai-compatible is in
+        # CLOUD_BACKEND_TYPES even when it's actually a local llama-server
+        # (e.g. rk-llama.cpp). Without this, an agent picker that says
+        # "use gemma-4-e2b-gguf" → LiteLLM call with that model_name →
+        # 400 because no such alias is registered.
+        backend_name = backend.get("name", "")
+        if backend_name.startswith("local-") and url:
+            for manifest_id in _local_backend_models_from_registry(backend, registry):
+                # Skip if already added (e.g. cloud per-model loop above
+                # already registered it under the same name).
+                if any(e.get("model_name") == manifest_id for e in model_list):
+                    continue
+                per_model_params: dict = {
+                    "model": f"{prefix}/{manifest_id}",
+                    "api_base": url,
+                }
+                if backend.get("api_key_secret"):
+                    per_model_params["api_key"] = f"os.environ/{backend['api_key_secret']}"
+                elif backend.get("api_key"):
+                    per_model_params["api_key"] = backend["api_key"]
+                model_list.append({
+                    "model_name": manifest_id,
+                    "litellm_params": per_model_params,
+                    "metadata": {
+                        "priority": backend.get("priority", 99),
+                        "backend_name": backend_name,
+                        "source": "local-installed",
+                    },
+                })
+
         # Auto-discover embedding models on ollama-compatible backends and
         # register each as its own LiteLLM entry. The first embedding model
         # found across all backends also claims the stable
@@ -319,6 +407,7 @@ class LLMProxy:
         config_dir: Path | None = None,
         database_url: str | None = None,
         local_token: str | None = None,
+        registry=None,
     ):
         self.port = port
         self.config_dir = config_dir or Path("/tmp/taos-litellm")
@@ -329,6 +418,12 @@ class LLMProxy:
         # the taOS bridge — without it, every llm_call event lands a 401
         # and trace rows never get ``llm_call`` entries.
         self.local_token = local_token
+        # AppRegistry — when provided, generate_litellm_config can register
+        # every installed model that targets a local backend as its own
+        # model_name alias. Without this, an agent picker that says "use
+        # gemma-4-e2b-gguf" would 400 on the proxy because the alias was
+        # never created.
+        self._registry = registry
         self._process: subprocess.Popen | None = None
 
     @property
@@ -356,7 +451,7 @@ class LLMProxy:
         callback code in one place.
         """
         self.config_dir.mkdir(parents=True, exist_ok=True)
-        config = generate_litellm_config(backends)
+        config = generate_litellm_config(backends, registry=self._registry)
         config_path = self.config_dir / "litellm_config.yaml"
 
         import yaml


### PR DESCRIPTION
The agent picker has shown locally-installed models since #429, but chatting with them 400'd at the LiteLLM proxy because no \`model_name\` alias was ever registered for the manifest id. This fixes the flow end-to-end so installing a model from the Store and picking it in the Assistant / Agent wizard "just works" — **no manual config, no shell scripts, no SSH**.

## Three layers, one cohesive PR

### 1. Service manifest
\`app-catalog/services/rk-llama-cpp/manifest.yaml\` gains a \`lifecycle:\` block:

\`\`\`yaml
lifecycle:
  backend_type: openai-compatible
  default_url: http://localhost:8090
\`\`\`

\`auto_register_from_manifest\` now writes a \`local-rk-llama-cpp\` entry into \`config.backends\` at controller startup — same path every other catalog service follows.

### 2. LiteLLM config generation
\`generate_litellm_config\` now accepts a \`registry\` parameter and, for any backend whose name starts with \`local-\` (the auto-register naming convention), enumerates \`registry.list_installed()\` models whose \`variants[].requires.backends[].id\` matches the backend's service id and registers each as its own \`model_name\` alias routing through the backend's URL. Mirrors the per-model registration the cloud path already does, but driven by the install registry instead of manual \`backend.models\` config.

### 3. llama-server \`--alias\`
\`install-rk-llama-cpp.sh\` now writes an \`active.alias\` \`EnvironmentFile\` next to the binary, and the systemd unit's \`ExecStart\` passes \`\${TAOS_ACTIVE_ALIAS}\` to llama-server's \`--alias\`. The \`rkllamacpp\` installer rewrites that file at install time (one line, atomic) so \`/v1/models\` advertises the manifest id rather than the generic \`active.gguf\`. **No runtime systemd surgery and no scripts to run by hand.**

## Net effect for the user

1. Install rk-llama.cpp service (it's pre-installed via \`curl | bash\` on Pi anyway)
2. Install Gemma 4 (or any model) from the Store
3. Pick it in the Agent / Assistant picker
4. Chat just works — LiteLLM routes by manifest id to \`localhost:8090\`

## Test plan
- [x] 5 new tests in \`test_llm_proxy_local_models.py\`:
  - Registry path registers manifest id under correct alias
  - Backend-id filter — incompatible models stay unregistered
  - Registry absent → backwards compatible (no-op)
  - Cloud backend (no \`local-\` prefix) untouched
  - De-dupe when cloud-style \`models[]\` pre-declaration overlaps registry path
- [ ] Live: wipe Pi, fresh install via \`curl | bash\`, install Gemma 4 from Store, chat from Assistant — round-trip succeeds

## What this does NOT cover (filing separately if needed)
- Worker ollama models — already routed via \`/api/cluster/backends\`, separate path
- The "only one model active at a time on rk-llama.cpp" UX — installing a second model swaps which one is active; the picker doesn't yet surface this
- mlc-llm and other download_installer-served local backends — they get \`local-\` names from #431, so this code path applies to them too once their manifests have the \`lifecycle.backend_type\` block

---
_Surfaced when jay reported "I picked Gemma 4 and chatting 400s." Per jay's "no scripts and quickfixes — test it like a user," the install path now does all the wiring; verification is a fresh Pi install via the UI._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Installed local models are now automatically registered and discoverable by the LLM proxy system
  * Local model backend auto-configures with the LiteLLM proxy as an OpenAI-compatible endpoint

* **Updates**
  * Llama-cpp service port changed from 8080 to 8090
  * Enhanced local model discovery and routing for seamless agent integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->