### PR TITLE
fix(assistant): use manifest id (not filename) + fill panel vertically

### DIFF
--- a/desktop/src/components/TaosAssistantPanel.tsx
+++ b/desktop/src/components/TaosAssistantPanel.tsx
@@ -137,8 +137,12 @@ export function TaosAssistantPanel() {
         aria-modal="true"
         className="fixed right-0 z-[101] flex flex-col border-l border-white/10 shadow-2xl"
         style={{
+          // Fill from below the topbar to the bottom of the viewport.
+          // The dock floats above this with its own z-index, so the
+          // panel doesn't need to leave a hole for it. Removing the
+          // bottom: dock-h gap closes the empty strip jay reported.
           top: "var(--spacing-topbar-h)",
-          bottom: "calc(var(--spacing-dock-h, 52px))",
+          bottom: 0,
           width: 400,
           backgroundColor: "rgba(21, 22, 37, 0.92)",
           backdropFilter: "blur(20px)",
@@ -201,8 +205,13 @@ export function TaosAssistantPanel() {
           <div ref={messagesEndRef} />
         </div>
 
-        {/* Input area */}
-        <div className="px-4 py-3 border-t border-white/5 shrink-0">
+        {/* Input area — extra bottom padding equal to the dock height
+            so the textarea + send button never sit under the floating
+            dock at the bottom-right corner of the screen. */}
+        <div
+          className="px-4 py-3 border-t border-white/5 shrink-0"
+          style={{ paddingBottom: "calc(0.75rem + var(--spacing-dock-h, 52px))" }}
+        >
           {noModel && (
             <p className="text-xs text-shell-text-tertiary mb-2">
               No model selected.{" "}

--- a/desktop/src/components/TaosAssistantSettings.tsx
+++ b/desktop/src/components/TaosAssistantSettings.tsx
@@ -6,7 +6,6 @@ import {
   fetchCloudProviders,
   workersToAggregated,
   cloudProvidersToAggregated,
-  controllerDownloadedToAggregated,
 } from "@/lib/models";
 import { useTaosAgentStore } from "@/stores/taos-agent-store";
 
@@ -27,21 +26,33 @@ export function TaosAssistantSettings({ open, onClose }: Props) {
     async function load() {
       try {
         const [localRes, workers, providers] = await Promise.all([
-          fetch("/api/models").then((r) => r.ok ? r.json() : { downloaded_files: [] }),
+          fetch("/api/models").then((r) => r.ok ? r.json() : { models: [] }),
           fetchClusterWorkers(),
           fetchCloudProviders(),
         ]);
         if (cancelled) return;
 
-        const local = (localRes.downloaded_files ?? []).map(
-          (f: { filename: string; size_mb?: number; format?: string }) =>
-            controllerDownloadedToAggregated(f),
-        );
+        // Use models[].id (manifest id, e.g. "gemma-4-e2b-gguf") rather
+        // than downloaded_files[].filename ("gemma-4-e2b-gguf.gguf").
+        // The chat path passes whatever id we set here straight to the
+        // LiteLLM proxy as the model_name; #433 registered aliases by
+        // manifest id, so sending the filename 400s. AgentsApp uses
+        // the same models[] source and works correctly.
+        type ApiModel = { id: string; name?: string; has_downloaded_variant?: boolean };
+        const apiModels: ApiModel[] = Array.isArray(localRes?.models) ? localRes.models : [];
+        const local = apiModels
+          .filter((m) => m.has_downloaded_variant === true)
+          .map((m) => ({
+            id: m.id,
+            name: m.name ?? m.id,
+            host: "controller" as const,
+            hostKind: "controller" as const,
+          }));
         const worker = workersToAggregated(workers);
         const cloud = cloudProvidersToAggregated(providers);
 
         const all: AgentModel[] = [
-          ...local.map((m: { id: string; name: string; host: string; hostKind: "controller" | "worker" | "cloud" }) => ({ id: m.id, name: m.name, host: m.host, hostKind: m.hostKind })),
+          ...local,
           ...worker.map((m: { id: string; name: string; host: string; hostKind: "controller" | "worker" | "cloud" }) => ({ id: m.id, name: m.name, host: m.host, hostKind: m.hostKind })),
           ...cloud.map((m: { id: string; name: string; host: string; hostKind: "controller" | "worker" | "cloud" }) => ({ id: m.id, name: m.name, host: m.host, hostKind: m.hostKind })),
         ];


### PR DESCRIPTION
Two issues from the same jay screenshot:

## 1. Chat 400: \`Invalid model name passed in model=gemma-4-e4b-gguf.gguf\`

\`TaosAssistantSettings\` was mapping \`/api/models\`' \`downloaded_files\` entries (filenames like \`gemma-4-e4b-gguf.gguf\`) into the picker. When the user picked one, the chat path passed that filename straight to the LiteLLM proxy as \`model_name\`. #433 registered aliases by **manifest id** (\`gemma-4-e4b-gguf\`, no \`.gguf\` suffix), so LiteLLM 400'd.

Switch the source to \`localRes.models[]\` filtered by \`has_downloaded_variant === true\` — same pattern \`AgentsApp\` already uses. Each entry's \`id\` is now the manifest id that LiteLLM has an alias for, so chat round-trips cleanly.

## 2. Bottom gap in the Assistant slide-over

\`bottom: calc(var(--spacing-dock-h, 52px))\` left an empty strip below the input area. Set \`bottom: 0\` so the panel fills to the viewport bottom; bump the input region's \`padding-bottom\` to the dock height so the textarea and send button never sit under the floating dock.

## Test plan
- [x] All 43 frontend tests still pass (\`vitest run src/components/\`)
- [x] \`tsc --noEmit\` clean
- [ ] Live: jay's PWA reloads, picks Gemma 4 in Assistant settings, sends a message — round-trip succeeds
- [ ] Live: panel visually fills to bottom of viewport, input area not occluded by dock

---
_Surfaced by jay's screenshot showing the same 400 the routing fix in #433 was supposed to address. The routing fix was correct; the picker was sending the wrong identifier._