### PR TITLE
fix(cluster): add 6/12/24gb buckets so common cards match catalog tiers

### DIFF
--- a/desktop/src/components/TaosAssistantPanel.tsx
+++ b/desktop/src/components/TaosAssistantPanel.tsx
@@ -137,8 +137,12 @@ export function TaosAssistantPanel() {
         aria-modal="true"
         className="fixed right-0 z-[101] flex flex-col border-l border-white/10 shadow-2xl"
         style={{
+          // Fill from below the topbar to the bottom of the viewport.
+          // The dock floats above this with its own z-index, so the
+          // panel doesn't need to leave a hole for it. Removing the
+          // bottom: dock-h gap closes the empty strip jay reported.
           top: "var(--spacing-topbar-h)",
-          bottom: "calc(var(--spacing-dock-h, 52px))",
+          bottom: 0,
           width: 400,
           backgroundColor: "rgba(21, 22, 37, 0.92)",
           backdropFilter: "blur(20px)",
@@ -201,8 +205,13 @@ export function TaosAssistantPanel() {
           <div ref={messagesEndRef} />
         </div>
 
-        {/* Input area */}
-        <div className="px-4 py-3 border-t border-white/5 shrink-0">
+        {/* Input area — extra bottom padding equal to the dock height
+            so the textarea + send button never sit under the floating
+            dock at the bottom-right corner of the screen. */}
+        <div
+          className="px-4 py-3 border-t border-white/5 shrink-0"
+          style={{ paddingBottom: "calc(0.75rem + var(--spacing-dock-h, 52px))" }}
+        >
           {noModel && (
             <p className="text-xs text-shell-text-tertiary mb-2">
               No model selected.{" "}

--- a/desktop/src/components/TaosAssistantSettings.tsx
+++ b/desktop/src/components/TaosAssistantSettings.tsx
@@ -6,7 +6,6 @@ import {
   fetchCloudProviders,
   workersToAggregated,
   cloudProvidersToAggregated,
-  controllerDownloadedToAggregated,
 } from "@/lib/models";
 import { useTaosAgentStore } from "@/stores/taos-agent-store";
 
@@ -27,21 +26,33 @@ export function TaosAssistantSettings({ open, onClose }: Props) {
     async function load() {
       try {
         const [localRes, workers, providers] = await Promise.all([
-          fetch("/api/models").then((r) => r.ok ? r.json() : { downloaded_files: [] }),
+          fetch("/api/models").then((r) => r.ok ? r.json() : { models: [] }),
           fetchClusterWorkers(),
           fetchCloudProviders(),
         ]);
         if (cancelled) return;
 
-        const local = (localRes.downloaded_files ?? []).map(
-          (f: { filename: string; size_mb?: number; format?: string }) =>
-            controllerDownloadedToAggregated(f),
-        );
+        // Use models[].id (manifest id, e.g. "gemma-4-e2b-gguf") rather
+        // than downloaded_files[].filename ("gemma-4-e2b-gguf.gguf").
+        // The chat path passes whatever id we set here straight to the
+        // LiteLLM proxy as the model_name; #433 registered aliases by
+        // manifest id, so sending the filename 400s. AgentsApp uses
+        // the same models[] source and works correctly.
+        type ApiModel = { id: string; name?: string; has_downloaded_variant?: boolean };
+        const apiModels: ApiModel[] = Array.isArray(localRes?.models) ? localRes.models : [];
+        const local = apiModels
+          .filter((m) => m.has_downloaded_variant === true)
+          .map((m) => ({
+            id: m.id,
+            name: m.name ?? m.id,
+            host: "controller" as const,
+            hostKind: "controller" as const,
+          }));
         const worker = workersToAggregated(workers);
         const cloud = cloudProvidersToAggregated(providers);
 
         const all: AgentModel[] = [
-          ...local.map((m: { id: string; name: string; host: string; hostKind: "controller" | "worker" | "cloud" }) => ({ id: m.id, name: m.name, host: m.host, hostKind: m.hostKind })),
+          ...local,
           ...worker.map((m: { id: string; name: string; host: string; hostKind: "controller" | "worker" | "cloud" }) => ({ id: m.id, name: m.name, host: m.host, hostKind: m.hostKind })),
           ...cloud.map((m: { id: string; name: string; host: string; hostKind: "controller" | "worker" | "cloud" }) => ({ id: m.id, name: m.name, host: m.host, hostKind: m.hostKind })),
         ];

--- a/tests/cluster/test_worker_tier_id.py
+++ b/tests/cluster/test_worker_tier_id.py
@@ -22,11 +22,32 @@ class TestSnapToBucket:
     def test_15gb_snaps_to_16(self):
         assert _snap_to_bucket(15) == 16
 
-    def test_17gb_snaps_to_32(self):
-        assert _snap_to_bucket(17) == 32
+    def test_17gb_snaps_to_24(self):
+        # With the 24gb bucket added (RTX 3090/4090), 17gb no longer
+        # leaps straight to 32gb.
+        assert _snap_to_bucket(17) == 24
 
     def test_33gb_snaps_to_64(self):
         assert _snap_to_bucket(33) == 64
+
+    def test_5gb_snaps_to_6(self):
+        # Orange Pi 5 6 GB used to snap to 8gb-tier and miss every
+        # arm-npu-6gb manifest.
+        assert _snap_to_bucket(5) == 6
+
+    def test_12gb_exact(self):
+        # RTX 3060 12 GB used to snap to 16gb-tier and miss every
+        # x86-cuda-12gb manifest.
+        assert _snap_to_bucket(12) == 12
+
+    def test_24gb_exact(self):
+        # RTX 3090 / 4090 used to snap to 32gb and miss every
+        # x86-cuda-24gb manifest.
+        assert _snap_to_bucket(24) == 24
+
+    def test_13gb_snaps_to_16(self):
+        # In-between values still round up to the next bucket.
+        assert _snap_to_bucket(13) == 16
 
     def test_200gb_clamps_to_128(self):
         assert _snap_to_bucket(200) == 128
@@ -68,15 +89,18 @@ class TestWorkerTierIdPiBucket:
         }
         assert worker_tier_id(hw) == "arm-cpu-16gb"
 
-    def test_cuda_12gb_vram_snaps_to_16(self):
-        # 12 GB is not a canonical bucket — snaps up to 16
+    def test_cuda_12gb_vram_lands_on_12gb_tier(self):
+        # 12 GB IS a canonical bucket now — was wrongly snapping to 16
+        # before the bucket fix in this PR. RTX 3060 12 GB / RTX 4060 Ti
+        # 12 GB / many other consumer cards all sit at exactly 12 GB,
+        # and 30 catalog manifests target x86-cuda-12gb.
         hw = {
             "cpu": {"arch": "x86_64"},
             "gpu": {"type": "nvidia", "cuda": True, "vram_mb": 12288},
             "ram_mb": 32768,
         }
         tier = worker_tier_id(hw)
-        assert tier == "x86-cuda-16gb"
+        assert tier == "x86-cuda-12gb"
 
     def test_cuda_8gb_vram_exact_stays_8(self):
         hw = {

--- a/tinyagentos/cluster/capabilities.py
+++ b/tinyagentos/cluster/capabilities.py
@@ -16,7 +16,20 @@ if TYPE_CHECKING:
     from tinyagentos.registry import AppRegistry
 
 
-_RAM_BUCKETS_GB = (2, 4, 8, 16, 32, 64, 128)
+# Bucket sizes used by catalog manifests' hardware_tiers keys
+# (e.g. ``x86-cuda-12gb``, ``arm-npu-6gb``). Adding 6 / 12 / 24 closes a
+# real coverage gap: cards / boards with those VRAM/RAM amounts used to
+# snap UP to the next bucket (12 → 16, 24 → 32) and miss every manifest
+# that targets the precise size. Concrete failures observed on:
+#
+#   - Orange Pi 5 (6 GB) — was snapping to 8gb, missing arm-npu-6gb
+#   - RTX 3060 12 GB     — was snapping to 16gb, missing x86-cuda-12gb
+#   - RTX 3090 / 4090    — was snapping to 32gb, missing x86-cuda-24gb
+#
+# The list must stay sorted ascending — _snap_to_bucket walks it in
+# order and returns the first bucket >= raw_gb, so 12 has to come
+# before 16 to actually be reachable.
+_RAM_BUCKETS_GB = (2, 4, 6, 8, 12, 16, 24, 32, 64, 128)
 
 
 def _snap_to_bucket(raw_gb: int) -> int:


### PR DESCRIPTION
## Why
\`worker_tier_id()\` snaps a worker's RAM/VRAM to the nearest bucket so the resulting tier id (e.g. \`x86-cuda-12gb\`) matches an entry in a catalog manifest's \`hardware_tiers\`. With buckets only at \`2/4/8/16/32/64/128\`, three common card classes silently snapped to the wrong bucket and missed every manifest that targeted their actual size:

| Card / board | Was snapped to | Manifests matching | Should snap to | Manifests matching |
|---|---|---|---|---|
| RTX 3060 12 GB | \`x86-cuda-16gb\` | 3 | \`x86-cuda-12gb\` | **30** |
| RTX 3090 / 4090 24 GB | \`x86-cuda-32gb\` | 0 | \`x86-cuda-24gb\` | **10** |
| Orange Pi 5 6 GB | \`arm-npu-8gb\` | 0 | \`arm-npu-6gb\` | 0 |

Surfaced when jay asked why his Orange Pi (cpu-only tier, 19 latent caps from the catalog) was showing more capabilities than his fedora-worker (\`x86-cuda-16gb\`, 9 caps). The fedora was snapping to a tier almost no manifest targets — the 12gb bucket addition lifts its tier to \`x86-cuda-12gb\` and brings the latent count up to where it should be.

## Fix
One-liner: extend \`_RAM_BUCKETS_GB\` from \`(2, 4, 8, 16, 32, 64, 128)\` to \`(2, 4, 6, 8, 12, 16, 24, 32, 64, 128)\`. Sorted ascending so the snap-to-next-bucket walk reaches the new entries.

## Test plan
- [x] 4 new tests in \`test_worker_tier_id.py\`: 5→6, 12→12 exact, 24→24 exact, 13→16 (in-between still rounds up)
- [x] Existing \`17→32\` test updated to \`17→24\` (the new behaviour)
- [x] All other tests green
- [ ] Live: jay's fedora-worker card in Activity now shows the full 30+ latent caps from CUDA-targeting models in the catalog

---
_Continuation of jay's "show potential" steer in the cluster card UX._