### PR TITLE
feat(cluster): tier ladder — bigger workers match smaller minimum tiers

### DIFF
--- a/tests/cluster/test_tier_compatible.py
+++ b/tests/cluster/test_tier_compatible.py
@@ -1,0 +1,131 @@
+"""Tier-ladder matching tests.
+
+A worker on a bigger numeric tier (e.g. ``x86-cuda-16gb``) should match
+manifests that only declare a smaller minimum tier of the same arch and
+accelerator (e.g. ``x86-cuda-12gb``). This stops manifest authors having
+to repeat themselves across every bucket size — declare the minimum,
+bigger machines inherit.
+"""
+from __future__ import annotations
+
+import pytest
+
+from tinyagentos.cluster.capabilities import (
+    _parse_numeric_tier,
+    tier_compatible,
+)
+
+
+class TestParseNumericTier:
+    def test_x86_cuda(self):
+        assert _parse_numeric_tier("x86-cuda-12gb") == ("x86", "cuda", 12)
+
+    def test_arm_npu(self):
+        assert _parse_numeric_tier("arm-npu-16gb") == ("arm", "npu", 16)
+
+    def test_x86_vulkan(self):
+        assert _parse_numeric_tier("x86-vulkan-8gb") == ("x86", "vulkan", 8)
+
+    def test_apple_silicon_is_flat(self):
+        assert _parse_numeric_tier("apple-silicon") is None
+
+    def test_cpu_only_is_flat(self):
+        assert _parse_numeric_tier("cpu-only") is None
+
+    def test_garbage_returns_none(self):
+        assert _parse_numeric_tier("") is None
+        assert _parse_numeric_tier("not-a-tier") is None
+        assert _parse_numeric_tier("x86-cuda-NOTANUMBERgb") is None
+
+
+class TestTierCompatible:
+    """Worker on the LEFT, manifest declaration on the RIGHT."""
+
+    def test_exact_match(self):
+        assert tier_compatible("x86-cuda-16gb", "x86-cuda-16gb")
+
+    def test_bigger_worker_matches_smaller_manifest(self):
+        # The point of the ladder: manifests declare minimums, bigger
+        # workers inherit.
+        assert tier_compatible("x86-cuda-16gb", "x86-cuda-12gb")
+        assert tier_compatible("x86-cuda-24gb", "x86-cuda-12gb")
+        assert tier_compatible("arm-npu-32gb", "arm-npu-16gb")
+
+    def test_smaller_worker_does_not_match_bigger_manifest(self):
+        # A 12 GB card cannot run a model that needs 24 GB.
+        assert not tier_compatible("x86-cuda-12gb", "x86-cuda-24gb")
+        assert not tier_compatible("arm-npu-16gb", "arm-npu-32gb")
+
+    def test_different_arch_never_matches(self):
+        # ARM and x86 builds are distinct artefacts even with same accel.
+        assert not tier_compatible("x86-cuda-16gb", "arm-cuda-16gb")
+        assert not tier_compatible("arm-vulkan-16gb", "x86-vulkan-16gb")
+
+    def test_different_accel_never_matches(self):
+        # Same card, different driver — runtime artefacts differ.
+        assert not tier_compatible("x86-cuda-16gb", "x86-vulkan-16gb")
+        assert not tier_compatible("x86-cuda-16gb", "x86-rocm-16gb")
+        assert not tier_compatible("x86-cuda-16gb", "x86-cpu-16gb")
+
+    def test_apple_silicon_only_matches_apple_silicon(self):
+        # Flat tiers don't ladder.
+        assert tier_compatible("apple-silicon", "apple-silicon")
+        assert not tier_compatible("apple-silicon", "x86-cuda-16gb")
+        assert not tier_compatible("x86-cuda-16gb", "apple-silicon")
+
+    def test_cpu_only_only_matches_cpu_only(self):
+        assert tier_compatible("cpu-only", "cpu-only")
+        assert not tier_compatible("cpu-only", "x86-cuda-12gb")
+        assert not tier_compatible("x86-cuda-16gb", "cpu-only")
+
+    def test_unknown_tier_strings_only_exact_match(self):
+        assert tier_compatible("garbage", "garbage")
+        assert not tier_compatible("garbage", "x86-cuda-12gb")
+
+
+class TestPotentialCapabilitiesLadder:
+    """End-to-end via potential_capabilities() — the function the cluster
+    UI calls. Build a fake registry with manifests at varying minimum
+    tiers and check the tier ladder picks them up."""
+
+    def _make_manifest(self, tier_id: str, capabilities: list[str]):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            type="model",
+            hardware_tiers={tier_id: {"recommended": "default"}},
+            capabilities=capabilities,
+        )
+
+    def _registry(self, manifests: list):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            list_available=lambda type_filter=None: [
+                m for m in manifests if type_filter is None or m.type == type_filter
+            ],
+        )
+
+    def test_x86_cuda_16gb_picks_up_12gb_manifest(self):
+        from tinyagentos.cluster.capabilities import potential_capabilities
+
+        registry = self._registry(
+            [
+                self._make_manifest("x86-cuda-12gb", ["chat", "code"]),
+                self._make_manifest("x86-cuda-24gb", ["vision"]),
+            ]
+        )
+        # Fedora-style hardware: 12 GB RTX 3060 → x86-cuda-12gb after
+        # the bucket fix in #435 lands; or x86-cuda-16gb pre-merge.
+        # Either way the 12gb manifest has to come along for the ride.
+        # Use a 16gb tier explicitly here to verify the ladder path
+        # independently of bucket coverage.
+        hw = {
+            "cpu": {"arch": "x86_64"},
+            "gpu": {"type": "nvidia", "cuda": True, "vram_mb": 16 * 1024},
+        }
+        tier_id, caps = potential_capabilities(hw, registry)
+        assert tier_id == "x86-cuda-16gb"
+        # 12gb manifest qualifies (smaller minimum); 24gb does not.
+        assert "chat" in caps and "code" in caps
+        assert "vision" not in caps

--- a/tinyagentos/cluster/capabilities.py
+++ b/tinyagentos/cluster/capabilities.py
@@ -150,12 +150,73 @@ def hardware_to_targets(hardware: dict) -> list[str]:
     return targets
 
 
+def _parse_numeric_tier(tier_id: str) -> tuple[str, str, int] | None:
+    """Decompose a numeric tier id like ``x86-cuda-12gb`` into
+    ``(arch, accel, gb)``. Non-numeric tiers (``apple-silicon``,
+    ``cpu-only``) return ``None`` — they only ever match exactly.
+    """
+    parts = tier_id.split("-")
+    if len(parts) < 3 or not parts[-1].endswith("gb"):
+        return None
+    try:
+        gb = int(parts[-1][:-2])
+    except ValueError:
+        return None
+    arch = parts[0]
+    accel = "-".join(parts[1:-1])
+    if not arch or not accel:
+        return None
+    return arch, accel, gb
+
+
+def tier_compatible(worker_tier: str, manifest_tier: str) -> bool:
+    """A manifest tier is compatible with a worker tier when either:
+
+    - The two strings are equal (existing exact-match behaviour), OR
+    - Both are numeric tiers (``<arch>-<accel>-<N>gb``) with matching arch
+      and accel, and the manifest's required gb is at most the worker's gb.
+
+    Bigger machines inherit smaller-tier compatibility — a worker on
+    ``x86-cuda-16gb`` qualifies for any manifest declaring
+    ``x86-cuda-12gb`` or ``x86-cuda-8gb``, since the larger card has
+    enough VRAM by definition. This means manifest authors only need to
+    declare the *minimum* tier per arch/accel; bigger workers pick it up
+    automatically. Same machine never inherits across arches or
+    accelerator types (CUDA ≠ Vulkan ≠ ROCm even on the same card).
+
+    Apple Silicon and ``cpu-only`` are flat tiers, so they only match
+    exactly — there's no ladder to walk.
+    """
+    if worker_tier == manifest_tier:
+        return True
+    w = _parse_numeric_tier(worker_tier)
+    m = _parse_numeric_tier(manifest_tier)
+    if w is None or m is None:
+        return False
+    return w[0] == m[0] and w[1] == m[1] and m[2] <= w[2]
+
+
+def _tier_value_compatible(tier_val: object) -> bool:
+    """A hardware_tiers entry counts as compatible iff it's a non-empty
+    declaration that isn't the explicit ``"unsupported"`` sentinel.
+    """
+    if isinstance(tier_val, str):
+        return tier_val != "unsupported"
+    if isinstance(tier_val, dict):
+        return (
+            tier_val.get("recommended") is not None
+            or tier_val.get("fallback") is not None
+        )
+    return False
+
+
 def potential_capabilities(hardware: dict, registry: "AppRegistry") -> tuple[str, list[str]]:
     """Return the tier id and list of capabilities the hardware *could* support.
 
     Walks every model in the catalog and collects the distinct capability
-    strings from any manifest that declares the worker's tier as compatible
-    (i.e. has a non-``unsupported`` / non-null entry for that tier).
+    strings from any manifest with at least one ``hardware_tiers`` entry
+    that's compatible with the worker's tier (per :func:`tier_compatible`
+    — exact match or same-arch-accel ladder match).
 
     Parameters
     ----------
@@ -175,18 +236,12 @@ def potential_capabilities(hardware: dict, registry: "AppRegistry") -> tuple[str
 
     for manifest in registry.list_available(type_filter="model"):
         tiers = manifest.hardware_tiers or {}
-        tier_val = tiers.get(tier_id)
-        if tier_val is None:
-            continue
-        compatible = False
-        if isinstance(tier_val, str):
-            compatible = tier_val != "unsupported"
-        elif isinstance(tier_val, dict):
-            compatible = (
-                tier_val.get("recommended") is not None
-                or tier_val.get("fallback") is not None
-            )
-        if compatible:
+        for manifest_tier, tier_val in tiers.items():
+            if not tier_compatible(tier_id, manifest_tier):
+                continue
+            if not _tier_value_compatible(tier_val):
+                continue
             caps.update(manifest.capabilities or [])
+            break  # one matching tier is enough
 
     return tier_id, sorted(caps)


### PR DESCRIPTION
Pairs with #435 (bucket coverage). Two parts of the same problem:

| | #435 (already up) | This PR |
|---|---|---|
| Layer | Worker → tier id | Tier id → manifest match |
| Fix | Add 6/12/24gb buckets so workers land on the tier the catalog uses | A worker on a bigger numeric tier qualifies for any manifest minimum at the same arch+accel ≤ its own gb |

Either fix alone closes part of the gap; together a 16 GB / 24 GB / 32 GB worker now matches every \`x86-cuda-12gb\` model in the catalog instead of the 3 that happened to declare \`x86-cuda-16gb\`.

## Compatibility rule
- exact tier match — always matches (existing behaviour)
- same \`arch\`, same \`accel\`, manifest \`gb\` ≤ worker \`gb\` — matches
- anything else — does not match (no cross-arch, no cross-accel)

Flat tiers (\`apple-silicon\`, \`cpu-only\`) only match exactly — there's no ladder to walk.

## Concrete impact for fedora-worker
Once both PRs merge:
- 12 GB RTX 3060 → \`x86-cuda-12gb\` (#435) → ladder picks up \`x86-cuda-8gb\` and below if any (this PR)
- 24 GB RTX 4090 → \`x86-cuda-24gb\` (#435) → ladder picks up \`x86-cuda-12gb\`, \`-16gb\` (this PR)

End result: the cluster card stops surprising users with low capability counts on capable hardware.

## Test plan
- [x] 14 new tests in \`test_tier_compatible.py\`:
  - Parser handles numeric and flat tier strings
  - Worker → manifest direction (bigger inherits smaller)
  - Smaller worker → bigger manifest blocked
  - Arch and accel isolation (no x86 ↔ arm, no cuda ↔ vulkan)
  - Apple Silicon and cpu-only exact-only
  - End-to-end via \`potential_capabilities()\` with a synthetic registry
- [ ] Live: jay's fedora-worker card shows the full set of CUDA-capable model capabilities, not just the 3 manifests that happened to declare \`-16gb\`

---
_Continuation of jay's "show potential" steer. Decision was: do both manifest data + ladder logic — this is the ladder half._