### PR TITLE
fix(catalog): declare minimum tier entries on every model manifest

### DIFF
--- a/app-catalog/models/4x-ultrasharp/manifest.yaml
+++ b/app-catalog/models/4x-ultrasharp/manifest.yaml
@@ -36,4 +36,6 @@ hardware_tiers:
     recommended: pth
   cpu-only:
     recommended: pth
+  x86-cuda-2gb:
+    recommended: pth
 context_window: 1

--- a/app-catalog/models/bge-large-en-v1.5/manifest.yaml
+++ b/app-catalog/models/bge-large-en-v1.5/manifest.yaml
@@ -39,4 +39,6 @@ hardware_tiers:
     recommended: q4_k_m
   cpu-only:
     recommended: q4_k_m
+  x86-vulkan-2gb:
+    recommended: q4_k_m
 context_window: 512

--- a/app-catalog/models/bge-m3/manifest.yaml
+++ b/app-catalog/models/bge-m3/manifest.yaml
@@ -56,4 +56,6 @@ hardware_tiers:
     recommended: pytorch
   cpu-only:
     recommended: q4_k_m
+  x86-cuda-2gb:
+    recommended: pytorch
 context_window: 8192

--- a/app-catalog/models/birefnet/manifest.yaml
+++ b/app-catalog/models/birefnet/manifest.yaml
@@ -33,4 +33,6 @@ hardware_tiers:
     recommended: safetensors
   cpu-only:
     recommended: safetensors
+  x86-cuda-2gb:
+    recommended: safetensors
 context_window: 1

--- a/app-catalog/models/codeformer/manifest.yaml
+++ b/app-catalog/models/codeformer/manifest.yaml
@@ -36,4 +36,6 @@ hardware_tiers:
     recommended: pth
   cpu-only:
     recommended: pth
+  x86-cuda-2gb:
+    recommended: pth
 context_window: 1

--- a/app-catalog/models/controlnet-canny/manifest.yaml
+++ b/app-catalog/models/controlnet-canny/manifest.yaml
@@ -40,4 +40,6 @@ hardware_tiers:
     recommended: safetensors
   cpu-only:
     recommended: safetensors
+  x86-cuda-2gb:
+    recommended: safetensors
 context_window: 77

--- a/app-catalog/models/controlnet-depth/manifest.yaml
+++ b/app-catalog/models/controlnet-depth/manifest.yaml
@@ -40,4 +40,6 @@ hardware_tiers:
     recommended: safetensors
   cpu-only:
     recommended: safetensors
+  x86-cuda-2gb:
+    recommended: safetensors
 context_window: 77

--- a/app-catalog/models/controlnet-openpose-sdxl/manifest.yaml
+++ b/app-catalog/models/controlnet-openpose-sdxl/manifest.yaml
@@ -37,4 +37,6 @@ hardware_tiers:
   x86-cuda-12gb:
     recommended: safetensors
   cpu-only: unsupported
+  x86-cuda-6gb:
+    recommended: safetensors
 context_window: 77

--- a/app-catalog/models/controlnet-openpose/manifest.yaml
+++ b/app-catalog/models/controlnet-openpose/manifest.yaml
@@ -40,4 +40,6 @@ hardware_tiers:
     recommended: safetensors
   cpu-only:
     recommended: safetensors
+  x86-cuda-2gb:
+    recommended: safetensors
 context_window: 77

--- a/app-catalog/models/dreamshaper-8-lcm/manifest.yaml
+++ b/app-catalog/models/dreamshaper-8-lcm/manifest.yaml
@@ -111,4 +111,10 @@ hardware_tiers:
   cpu-only:
     recommended: iq2_xs-gguf
     fallback: iq2_xs-gguf
+  x86-cuda-4gb:
+    recommended: lcm-safetensors
+    fallback: iq4_nl-gguf
+  x86-vulkan-4gb:
+    recommended: lcm-safetensors
+    fallback: iq4_nl-gguf
 context_window: 77

--- a/app-catalog/models/florence-2-base/manifest.yaml
+++ b/app-catalog/models/florence-2-base/manifest.yaml
@@ -34,4 +34,6 @@ hardware_tiers:
     recommended: pytorch
   cpu-only:
     recommended: pytorch
+  x86-cuda-2gb:
+    recommended: pytorch
 context_window: 1024

--- a/app-catalog/models/gemma-3-1b/manifest.yaml
+++ b/app-catalog/models/gemma-3-1b/manifest.yaml
@@ -40,4 +40,6 @@ hardware_tiers:
     recommended: q4_k_m
   cpu-only:
     recommended: q4_k_m
+  x86-vulkan-2gb:
+    recommended: q4_k_m
 context_window: 32768

--- a/app-catalog/models/gemma-3-4b/manifest.yaml
+++ b/app-catalog/models/gemma-3-4b/manifest.yaml
@@ -45,4 +45,6 @@ hardware_tiers:
     recommended: q4_k_m
   cpu-only:
     recommended: q4_k_m
+  x86-cuda-4gb:
+    recommended: q4_k_m
 context_window: 128000

--- a/app-catalog/models/gemma-4-e2b-gguf/manifest.yaml
+++ b/app-catalog/models/gemma-4-e2b-gguf/manifest.yaml
@@ -33,3 +33,6 @@ hardware_tiers:
   x86-cuda-12gb: {recommended: q4_k_m}
   x86-vulkan-8gb: {recommended: q4_k_m}
   cpu-only: {recommended: q4_k_m}
+  arm-npu-4gb: {recommended: q4_k_m}
+  x86-cuda-4gb: {recommended: q4_k_m}
+  x86-vulkan-4gb: {recommended: q4_k_m}

--- a/app-catalog/models/gemma-4-e4b-gguf/manifest.yaml
+++ b/app-catalog/models/gemma-4-e4b-gguf/manifest.yaml
@@ -34,3 +34,6 @@ hardware_tiers:
   x86-vulkan-8gb: {recommended: q4_k_m}
   x86-vulkan-16gb: {recommended: q4_k_m}
   cpu-only: {recommended: q4_k_m}
+  arm-npu-6gb: {recommended: q4_k_m}
+  x86-cuda-6gb: {recommended: q4_k_m}
+  x86-vulkan-6gb: {recommended: q4_k_m}

--- a/app-catalog/models/gfpgan-v1.4/manifest.yaml
+++ b/app-catalog/models/gfpgan-v1.4/manifest.yaml
@@ -35,4 +35,6 @@ hardware_tiers:
     recommended: pth
   cpu-only:
     recommended: pth
+  x86-cuda-2gb:
+    recommended: pth
 context_window: 1

--- a/app-catalog/models/granite-3.1-8b/manifest.yaml
+++ b/app-catalog/models/granite-3.1-8b/manifest.yaml
@@ -42,4 +42,6 @@ hardware_tiers:
     recommended: q4_k_m
   cpu-only:
     recommended: q4_k_m
+  x86-cuda-6gb:
+    recommended: q4_k_m
 context_window: 32768

--- a/app-catalog/models/lcm-dreamshaper-v7/manifest.yaml
+++ b/app-catalog/models/lcm-dreamshaper-v7/manifest.yaml
@@ -74,4 +74,6 @@ hardware_tiers:
   cpu-only:
     recommended: safetensors
     notes: Slow — consider SD 1.5 GGUF for CPU
+  x86-cuda-4gb:
+    recommended: safetensors
 context_window: 77

--- a/app-catalog/models/llama-3.1-8b/manifest.yaml
+++ b/app-catalog/models/llama-3.1-8b/manifest.yaml
@@ -51,4 +51,8 @@ hardware_tiers:
     recommended: q4_k_m
   cpu-only:
     recommended: q4_k_m
+  x86-cuda-6gb:
+    recommended: q4_k_m
+  x86-vulkan-6gb:
+    recommended: q4_k_m
 context_window: 131072

--- a/app-catalog/models/llama-3.2-1b/manifest.yaml
+++ b/app-catalog/models/llama-3.2-1b/manifest.yaml
@@ -39,4 +39,6 @@ hardware_tiers:
     recommended: q4_k_m
   cpu-only:
     recommended: q4_k_m
+  x86-vulkan-2gb:
+    recommended: q4_k_m
 context_window: 131072

--- a/app-catalog/models/llama-3.2-3b/manifest.yaml
+++ b/app-catalog/models/llama-3.2-3b/manifest.yaml
@@ -42,4 +42,6 @@ hardware_tiers:
     recommended: q4_k_m
   cpu-only:
     recommended: q4_k_m
+  x86-cuda-4gb:
+    recommended: q4_k_m
 context_window: 131072

--- a/app-catalog/models/ministral-3b/manifest.yaml
+++ b/app-catalog/models/ministral-3b/manifest.yaml
@@ -92,4 +92,6 @@ hardware_tiers:
     recommended: q4_k_m
   cpu-only:
     recommended: q4_k_m
+  x86-cuda-4gb:
+    recommended: q8_0
 context_window: 131072

--- a/app-catalog/models/mistral-7b-v0.3/manifest.yaml
+++ b/app-catalog/models/mistral-7b-v0.3/manifest.yaml
@@ -44,4 +44,8 @@ hardware_tiers:
     recommended: q4_k_m
   cpu-only:
     recommended: q4_k_m
+  x86-cuda-6gb:
+    recommended: q4_k_m
+  x86-vulkan-6gb:
+    recommended: q4_k_m
 context_window: 32768

--- a/app-catalog/models/moondream2/manifest.yaml
+++ b/app-catalog/models/moondream2/manifest.yaml
@@ -49,4 +49,6 @@ hardware_tiers:
     recommended: safetensors
   cpu-only:
     recommended: gguf-f16
+  x86-cuda-4gb:
+    recommended: safetensors
 context_window: 4096

--- a/app-catalog/models/mxbai-embed-large/manifest.yaml
+++ b/app-catalog/models/mxbai-embed-large/manifest.yaml
@@ -36,4 +36,6 @@ hardware_tiers:
     recommended: safetensors
   cpu-only:
     recommended: safetensors
+  x86-cuda-2gb:
+    recommended: safetensors
 context_window: 512

--- a/app-catalog/models/nemotron-mini-4b/manifest.yaml
+++ b/app-catalog/models/nemotron-mini-4b/manifest.yaml
@@ -40,4 +40,6 @@ hardware_tiers:
     recommended: q4_k_m
   cpu-only:
     recommended: q4_k_m
+  x86-cuda-4gb:
+    recommended: q4_k_m
 context_window: 4096

--- a/app-catalog/models/nomic-embed-text-v1.5/manifest.yaml
+++ b/app-catalog/models/nomic-embed-text-v1.5/manifest.yaml
@@ -62,4 +62,6 @@ hardware_tiers:
     recommended: q4_k_m
   cpu-only:
     recommended: q4_k_m
+  x86-vulkan-2gb:
+    recommended: q4_k_m
 context_window: 2048

--- a/app-catalog/models/paligemma-2/manifest.yaml
+++ b/app-catalog/models/paligemma-2/manifest.yaml
@@ -28,4 +28,6 @@ hardware_tiers:
   x86-cuda-12gb: {recommended: safetensors-224}
   x86-vulkan-8gb: {recommended: safetensors-224}
   cpu-only: {recommended: safetensors-224}
+  x86-cuda-6gb: {recommended: safetensors-224}
+  x86-vulkan-6gb: {recommended: safetensors-224}
 context_window: 8192

--- a/app-catalog/models/parakeet-tdt-0.6b/manifest.yaml
+++ b/app-catalog/models/parakeet-tdt-0.6b/manifest.yaml
@@ -34,4 +34,6 @@ hardware_tiers:
     recommended: nemo
   cpu-only:
     recommended: nemo
+  x86-cuda-2gb:
+    recommended: nemo
 context_window: 4096

--- a/app-catalog/models/pelochus-qwen-1.8b-rkllm/manifest.yaml
+++ b/app-catalog/models/pelochus-qwen-1.8b-rkllm/manifest.yaml
@@ -33,4 +33,6 @@ hardware_tiers:
     recommended: rkllm
   arm-npu-32gb:
     recommended: rkllm
+  arm-npu-2gb:
+    recommended: rkllm
 context_window: 32768

--- a/app-catalog/models/phi-3.5-mini/manifest.yaml
+++ b/app-catalog/models/phi-3.5-mini/manifest.yaml
@@ -44,4 +44,6 @@ hardware_tiers:
     recommended: q4_k_m
   cpu-only:
     recommended: q4_k_m
+  x86-cuda-4gb:
+    recommended: q4_k_m
 context_window: 131072

--- a/app-catalog/models/phi-4-mini/manifest.yaml
+++ b/app-catalog/models/phi-4-mini/manifest.yaml
@@ -43,4 +43,6 @@ hardware_tiers:
     recommended: q4_k_m
   cpu-only:
     recommended: q4_k_m
+  x86-cuda-4gb:
+    recommended: q4_k_m
 context_window: 131072

--- a/app-catalog/models/pixart-sigma-512/manifest.yaml
+++ b/app-catalog/models/pixart-sigma-512/manifest.yaml
@@ -51,4 +51,8 @@ hardware_tiers:
   cpu-only:
     recommended: fp16
     notes: Transformer only — requires T5 encoder separately
+  x86-cuda-4gb:
+    recommended: fp16
+  x86-vulkan-4gb:
+    recommended: fp16
 context_window: 300

--- a/app-catalog/models/qwen2.5-0.5b/manifest.yaml
+++ b/app-catalog/models/qwen2.5-0.5b/manifest.yaml
@@ -39,4 +39,6 @@ hardware_tiers:
     recommended: q4_k_m
   cpu-only:
     recommended: q4_k_m
+  x86-vulkan-2gb:
+    recommended: q4_k_m
 context_window: 32768

--- a/app-catalog/models/qwen2.5-1.5b-rkllm/manifest.yaml
+++ b/app-catalog/models/qwen2.5-1.5b-rkllm/manifest.yaml
@@ -30,4 +30,6 @@ hardware_tiers:
     recommended: w8a8
   arm-npu-32gb:
     recommended: w8a8
+  arm-npu-2gb:
+    recommended: w8a8
 context_window: 32768

--- a/app-catalog/models/qwen2.5-1.5b/manifest.yaml
+++ b/app-catalog/models/qwen2.5-1.5b/manifest.yaml
@@ -40,4 +40,6 @@ hardware_tiers:
     recommended: q4_k_m
   cpu-only:
     recommended: q4_k_m
+  x86-vulkan-2gb:
+    recommended: q4_k_m
 context_window: 32768

--- a/app-catalog/models/qwen2.5-14b-rkllm/manifest.yaml
+++ b/app-catalog/models/qwen2.5-14b-rkllm/manifest.yaml
@@ -31,4 +31,6 @@ variants:
 hardware_tiers:
   arm-npu-32gb:
     recommended: w8a8
+  arm-npu-2gb:
+    recommended: w8a8
 context_window: 32768

--- a/app-catalog/models/qwen2.5-3b-rkllm/manifest.yaml
+++ b/app-catalog/models/qwen2.5-3b-rkllm/manifest.yaml
@@ -32,4 +32,6 @@ hardware_tiers:
     recommended: w8a8
   arm-npu-32gb:
     recommended: w8a8
+  arm-npu-2gb:
+    recommended: w8a8
 context_window: 32768

--- a/app-catalog/models/qwen2.5-3b/manifest.yaml
+++ b/app-catalog/models/qwen2.5-3b/manifest.yaml
@@ -43,4 +43,6 @@ hardware_tiers:
     recommended: q4_k_m
   cpu-only:
     recommended: q4_k_m
+  x86-cuda-4gb:
+    recommended: q4_k_m
 context_window: 32768

--- a/app-catalog/models/qwen2.5-7b-rkllm/manifest.yaml
+++ b/app-catalog/models/qwen2.5-7b-rkllm/manifest.yaml
@@ -33,4 +33,6 @@ hardware_tiers:
     recommended: w8a8
   arm-npu-32gb:
     recommended: w8a8
+  arm-npu-2gb:
+    recommended: w8a8
 context_window: 32768

--- a/app-catalog/models/qwen2.5-7b/manifest.yaml
+++ b/app-catalog/models/qwen2.5-7b/manifest.yaml
@@ -44,4 +44,8 @@ hardware_tiers:
     recommended: q4_k_m
   cpu-only:
     recommended: q4_k_m
+  x86-cuda-6gb:
+    recommended: q4_k_m
+  x86-vulkan-6gb:
+    recommended: q4_k_m
 context_window: 32768

--- a/app-catalog/models/qwen2.5-coder-1.5b-rkllm/manifest.yaml
+++ b/app-catalog/models/qwen2.5-coder-1.5b-rkllm/manifest.yaml
@@ -32,4 +32,6 @@ hardware_tiers:
     recommended: w8a8
   arm-npu-32gb:
     recommended: w8a8
+  arm-npu-2gb:
+    recommended: w8a8
 context_window: 32768

--- a/app-catalog/models/qwen2.5-coder-14b-rkllm/manifest.yaml
+++ b/app-catalog/models/qwen2.5-coder-14b-rkllm/manifest.yaml
@@ -29,4 +29,6 @@ variants:
 hardware_tiers:
   arm-npu-32gb:
     recommended: w8a8
+  arm-npu-2gb:
+    recommended: w8a8
 context_window: 32768

--- a/app-catalog/models/qwen2.5-coder-7b-rkllm/manifest.yaml
+++ b/app-catalog/models/qwen2.5-coder-7b-rkllm/manifest.yaml
@@ -32,4 +32,6 @@ hardware_tiers:
     recommended: w8a8
   arm-npu-32gb:
     recommended: w8a8
+  arm-npu-2gb:
+    recommended: w8a8
 context_window: 32768

--- a/app-catalog/models/qwen2.5-coder-7b/manifest.yaml
+++ b/app-catalog/models/qwen2.5-coder-7b/manifest.yaml
@@ -44,4 +44,8 @@ hardware_tiers:
     recommended: q4_k_m
   cpu-only:
     recommended: q4_k_m
+  x86-cuda-6gb:
+    recommended: q4_k_m
+  x86-vulkan-6gb:
+    recommended: q4_k_m
 context_window: 32768

--- a/app-catalog/models/qwen2.5-math-1.5b-rkllm/manifest.yaml
+++ b/app-catalog/models/qwen2.5-math-1.5b-rkllm/manifest.yaml
@@ -32,4 +32,6 @@ hardware_tiers:
     recommended: w8a8
   arm-npu-32gb:
     recommended: w8a8
+  arm-npu-2gb:
+    recommended: w8a8
 context_window: 4096

--- a/app-catalog/models/qwen2.5-math-7b-rkllm/manifest.yaml
+++ b/app-catalog/models/qwen2.5-math-7b-rkllm/manifest.yaml
@@ -32,4 +32,6 @@ hardware_tiers:
     recommended: w8a8
   arm-npu-32gb:
     recommended: w8a8
+  arm-npu-2gb:
+    recommended: w8a8
 context_window: 4096

--- a/app-catalog/models/qwen3-1.7b-rkllm/manifest.yaml
+++ b/app-catalog/models/qwen3-1.7b-rkllm/manifest.yaml
@@ -31,4 +31,6 @@ hardware_tiers:
     recommended: w8a8
   arm-npu-32gb:
     recommended: w8a8
+  arm-npu-2gb:
+    recommended: w8a8
 context_window: 40960

--- a/app-catalog/models/qwen3-1.7b/manifest.yaml
+++ b/app-catalog/models/qwen3-1.7b/manifest.yaml
@@ -71,4 +71,8 @@ hardware_tiers:
     recommended: q4_k_m
   cpu-only:
     recommended: q4_k_m
+  x86-cuda-2gb:
+    recommended: q8_0
+  x86-vulkan-2gb:
+    recommended: q4_k_m
 context_window: 40960

--- a/app-catalog/models/qwen3-4b-rkllm/manifest.yaml
+++ b/app-catalog/models/qwen3-4b-rkllm/manifest.yaml
@@ -31,4 +31,6 @@ hardware_tiers:
     recommended: w8a8
   arm-npu-32gb:
     recommended: w8a8
+  arm-npu-2gb:
+    recommended: w8a8
 context_window: 32768

--- a/app-catalog/models/qwen3-4b/manifest.yaml
+++ b/app-catalog/models/qwen3-4b/manifest.yaml
@@ -74,4 +74,6 @@ hardware_tiers:
     recommended: q4_k_m
   cpu-only:
     recommended: q4_k_m
+  x86-cuda-4gb:
+    recommended: q4_k_m
 context_window: 32768

--- a/app-catalog/models/qwen3-8b/manifest.yaml
+++ b/app-catalog/models/qwen3-8b/manifest.yaml
@@ -78,4 +78,6 @@ hardware_tiers:
   cpu-only:
     recommended: q4_k_m
     notes: Slow but functional
+  x86-cuda-6gb:
+    recommended: q4_k_m
 context_window: 32768

--- a/app-catalog/models/qwen3-embedding-0.6b/manifest.yaml
+++ b/app-catalog/models/qwen3-embedding-0.6b/manifest.yaml
@@ -85,4 +85,9 @@ hardware_tiers:
     recommended: q8_0
   cpu-only:
     recommended: q8_0
+  x86-cuda-2gb:
+    recommended: f16
+    fallback: q8_0
+  x86-vulkan-2gb:
+    recommended: q8_0
 context_window: 32768

--- a/app-catalog/models/qwen3-reranker-0.6b/manifest.yaml
+++ b/app-catalog/models/qwen3-reranker-0.6b/manifest.yaml
@@ -51,4 +51,6 @@ hardware_tiers:
     recommended: q8_0
   cpu-only:
     recommended: q8_0
+  x86-vulkan-2gb:
+    recommended: q8_0
 context_window: 32768

--- a/app-catalog/models/qwen3-vl-2b-rkllm/manifest.yaml
+++ b/app-catalog/models/qwen3-vl-2b-rkllm/manifest.yaml
@@ -30,5 +30,7 @@ hardware_tiers:
     recommended: w8a8
   arm-npu-32gb:
     recommended: w8a8
+  arm-npu-2gb:
+    recommended: w8a8
 # context_window: rkllm quantizer cap; base Qwen3-VL-2B is 262144 (256K) but rkllm caps at 40960
 context_window: 40960

--- a/app-catalog/models/qwen3-vl-4b-rkllm/manifest.yaml
+++ b/app-catalog/models/qwen3-vl-4b-rkllm/manifest.yaml
@@ -30,5 +30,7 @@ hardware_tiers:
     recommended: w8a8
   arm-npu-32gb:
     recommended: w8a8
+  arm-npu-2gb:
+    recommended: w8a8
 # context_window: rkllm quantizer cap; base Qwen3-VL-4B is 262144 (256K) but rkllm caps at 40960
 context_window: 40960

--- a/app-catalog/models/real-esrgan-x4/manifest.yaml
+++ b/app-catalog/models/real-esrgan-x4/manifest.yaml
@@ -39,4 +39,6 @@ hardware_tiers:
     recommended: x4
   cpu-only:
     recommended: x4
+  x86-cuda-2gb:
+    recommended: x4
 context_window: 1

--- a/app-catalog/models/sd-v1.5-lcm/manifest.yaml
+++ b/app-catalog/models/sd-v1.5-lcm/manifest.yaml
@@ -101,4 +101,9 @@ hardware_tiers:
   cpu-only:
     recommended: q4_0
     notes: Slow — 1-3 minutes per image
+  x86-cuda-6gb:
+    recommended: safetensors
+    fallback: f16
+  x86-vulkan-6gb:
+    recommended: f16
 context_window: 77

--- a/app-catalog/models/sdxl-turbo/manifest.yaml
+++ b/app-catalog/models/sdxl-turbo/manifest.yaml
@@ -88,4 +88,9 @@ hardware_tiers:
   cpu-only:
     recommended: q4_0
     warning: Slow on CPU
+  x86-cuda-6gb:
+    recommended: q8_0
+    fallback: q4_0
+  x86-vulkan-6gb:
+    recommended: q4_0
 context_window: 77

--- a/app-catalog/models/smollm2/manifest.yaml
+++ b/app-catalog/models/smollm2/manifest.yaml
@@ -40,4 +40,6 @@ hardware_tiers:
     recommended: q4_k_m
   cpu-only:
     recommended: q4_k_m
+  x86-vulkan-2gb:
+    recommended: q4_k_m
 context_window: 8192

--- a/app-catalog/models/smolvlm/manifest.yaml
+++ b/app-catalog/models/smolvlm/manifest.yaml
@@ -28,4 +28,6 @@ hardware_tiers:
   x86-cuda-12gb: {recommended: safetensors}
   x86-vulkan-8gb: {recommended: safetensors}
   cpu-only: {recommended: safetensors}
+  x86-cuda-6gb: {recommended: safetensors}
+  x86-vulkan-6gb: {recommended: safetensors}
 context_window: 16384


### PR DESCRIPTION
The (A) audit pass that pairs with #435 (bucket coverage) and #436 (ladder match).

## Why
With #436's ladder logic in place, manifest authors only need to declare the **smallest** tier their model can run on per (arch, accel) — bigger machines inherit automatically. But many existing manifests skipped the smaller buckets entirely, so a 4 / 6 / 8 GB worker still saw nothing even though the model would happily run there.

## What changed
Walked every model manifest, parsed each variant's \`requires.backends[].min_ram_mb\`, and added the missing minimum-tier entry per (arch, accel) family. Existing entries untouched. New entries copy the \`recommended\` / \`fallback\` values from the smallest existing entry in the same family so resolver behaviour for the new tier mirrors what the bigger tiers already specified.

**77 new entries across 61 manifests.** Examples:

| Manifest | Was | Adds |
|---|---|---|
| \`gemma-4-e2b-gguf\` | floor \`x86-cuda-12gb\` | \`arm-npu-4gb\`, \`x86-cuda-4gb\`, \`x86-vulkan-4gb\` |
| \`llama-3.1-8b\` | floor \`x86-cuda-8gb\` | \`x86-cuda-6gb\`, \`x86-vulkan-6gb\` |
| \`dreamshaper-8-lcm\` | floor \`x86-cuda-8gb\` | \`x86-cuda-4gb\`, \`x86-vulkan-4gb\` |

## How
Surgical text inserts — no yaml round-trip. The audit tool detects each manifest's existing tier style (inline \`{...}\` vs block \`recommended: foo\`) and emits new entries in the same style, preserving every other byte of the manifest. Diffs are pure additions:

\`\`\`diff
 hardware_tiers:
   arm-npu-16gb: {recommended: q4_k_m}
   x86-cuda-12gb: {recommended: q4_k_m}
   cpu-only: {recommended: q4_k_m}
+  arm-npu-4gb: {recommended: q4_k_m}
+  x86-cuda-4gb: {recommended: q4_k_m}
+  x86-vulkan-4gb: {recommended: q4_k_m}
\`\`\`

## Test plan
- [x] All 61 changed files still parse with \`yaml.safe_load\`
- [x] Stat: 61 files changed, 149 insertions, 0 deletions — pure additions
- [ ] Live: cluster card on small-tier workers shows the latent capabilities they actually qualify for

---
_Closes the manifest-data half of the work jay scoped after I asked "(A) data audit or (B) ladder match?" and he said "do both". (B) shipped as #436; this is (A)._