### PR TITLE
feat(catalog): add jina-embeddings-v3 (closes pack 6)

### DIFF
--- a/app-catalog/models/jina-embeddings-v3/manifest.yaml
+++ b/app-catalog/models/jina-embeddings-v3/manifest.yaml
@@ -1,0 +1,34 @@
+id: jina-embeddings-v3
+name: Jina Embeddings v3
+type: model
+version: 3.0.0
+description: "Multilingual embedding model — 89 languages, 8192 token context, task-specific LoRA adapters. 570M params, 1024 dim."
+homepage: https://huggingface.co/jinaai/jina-embeddings-v3
+license: CC-BY-NC-4.0
+capabilities:
+- embedding
+- multilingual
+
+variants:
+- id: pytorch
+  name: PyTorch (570M params, 2.3GB)
+  format: pytorch
+  size_mb: 2300
+  download_url: https://huggingface.co/jinaai/jina-embeddings-v3/resolve/main/model.safetensors
+  requires:
+    backends:
+    - id: sentence-transformers
+      targets: [apple-silicon, x86-cuda, x86-vulkan, arm-vulkan, cpu]
+      min_ram_mb: 3072
+    - id: transformers
+      targets: [apple-silicon, x86-cuda, x86-vulkan, arm-vulkan, cpu]
+      min_ram_mb: 3072
+
+hardware_tiers:
+  apple-silicon: {recommended: pytorch}
+  x86-cuda-4gb: {recommended: pytorch}
+  x86-vulkan-4gb: {recommended: pytorch}
+  arm-vulkan-4gb: {recommended: pytorch}
+  cpu-only: {recommended: pytorch}
+
+context_window: 8192


### PR DESCRIPTION
## Pack 6 audit

#321 listed three Pack 6 (Embedding / Reranking) models. Found two already in the catalog from earlier sessions, one genuinely missing:

| Model | Status |
|---|---|
| nomic-embed-text-v1.5 | already in catalog |
| jina-embeddings-v3 | **adds in this PR** |
| mxbai-embed-large | already in catalog |

Manifest declares the pytorch / safetensors variant (570M params, 1024-dim, 8192-token context, 89 languages) targeting \`sentence-transformers\` / \`transformers\` backends on every accelerator tier from \`cpu-only\` up.

License is CC-BY-NC-4.0 (research-only, no commercial use) — flagged in the manifest \`license\` field; consumers can decide.

## Pack 9 MLC variants — NOT in this PR (intentional)

jay asked for MLC-format variants too, but \`download_installer\` is single-file only and MLC models are multi-file HF repos (weights + tokenizer + config). Shipping aspirational MLC manifests would silently fail at install. Two follow-up paths to discuss:

1. Add multi-file HF download to \`download_installer\` (or a new \`mlc_installer\`) — proper fix
2. Wrap \`mlc_chat\`'s compile-from-HF CLI behind a new install method

I'll wait for jay's steer before touching either.

## Test plan
- [x] \`yaml.safe_load\` parses cleanly
- [ ] Live: jina-embeddings-v3 appears in Models app on a freshly-pulled controller; resolver can install it on a worker via sentence-transformers backend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Jina Embeddings v3 model for text embedding with multilingual support and 8192-token context window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->