### PR TITLE
feat(catalog): qdrant, ltx-video, openllm — fill pack 2/8/9 gaps

### DIFF
--- a/app-catalog/models/jina-embeddings-v3/manifest.yaml
+++ b/app-catalog/models/jina-embeddings-v3/manifest.yaml
@@ -1,0 +1,34 @@
+id: jina-embeddings-v3
+name: Jina Embeddings v3
+type: model
+version: 3.0.0
+description: "Multilingual embedding model — 89 languages, 8192 token context, task-specific LoRA adapters. 570M params, 1024 dim."
+homepage: https://huggingface.co/jinaai/jina-embeddings-v3
+license: CC-BY-NC-4.0
+capabilities:
+- embedding
+- multilingual
+
+variants:
+- id: pytorch
+  name: PyTorch (570M params, 2.3GB)
+  format: pytorch
+  size_mb: 2300
+  download_url: https://huggingface.co/jinaai/jina-embeddings-v3/resolve/main/model.safetensors
+  requires:
+    backends:
+    - id: sentence-transformers
+      targets: [apple-silicon, x86-cuda, x86-vulkan, arm-vulkan, cpu]
+      min_ram_mb: 3072
+    - id: transformers
+      targets: [apple-silicon, x86-cuda, x86-vulkan, arm-vulkan, cpu]
+      min_ram_mb: 3072
+
+hardware_tiers:
+  apple-silicon: {recommended: pytorch}
+  x86-cuda-4gb: {recommended: pytorch}
+  x86-vulkan-4gb: {recommended: pytorch}
+  arm-vulkan-4gb: {recommended: pytorch}
+  cpu-only: {recommended: pytorch}
+
+context_window: 8192

--- a/app-catalog/models/ltx-video/manifest.yaml
+++ b/app-catalog/models/ltx-video/manifest.yaml
@@ -1,0 +1,32 @@
+id: ltx-video
+name: LTX-Video
+type: model
+version: 0.9.5
+description: "Lightricks open video gen — 2B params, real-time generation on H100, 24 fps, 768×512. Apache-2.0 weights, fastest open video model in its class."
+homepage: https://huggingface.co/Lightricks/LTX-Video
+license: Apache-2.0
+capabilities:
+- video-generation
+- image-to-video
+
+variants:
+- id: bf16-safetensors
+  name: bf16 safetensors (~9GB)
+  format: safetensors
+  size_mb: 9000
+  download_url: https://huggingface.co/Lightricks/LTX-Video/resolve/main/ltx-video-2b-v0.9.5.safetensors
+  requires:
+    backends:
+    - id: diffusers
+      targets: [apple-silicon, x86-cuda, x86-vulkan]
+      min_ram_mb: 12288
+    - id: comfyui
+      targets: [apple-silicon, x86-cuda, x86-vulkan]
+      min_ram_mb: 12288
+
+hardware_tiers:
+  apple-silicon: {recommended: bf16-safetensors}
+  x86-cuda-12gb: {recommended: bf16-safetensors}
+  x86-cuda-16gb: {recommended: bf16-safetensors}
+  x86-cuda-24gb: {recommended: bf16-safetensors}
+  x86-vulkan-16gb: {recommended: bf16-safetensors}

--- a/app-catalog/services/openllm/manifest.yaml
+++ b/app-catalog/services/openllm/manifest.yaml
@@ -1,0 +1,35 @@
+id: openllm
+name: OpenLLM
+type: service
+category: llm-runtime
+version: 0.6.0
+description: "BentoML's production LLM serving framework — OpenAI-compatible API, vLLM under the hood, model packaging, K8s deploy. Bridge between local dev and production inference."
+homepage: https://github.com/bentoml/OpenLLM
+license: Apache-2.0
+
+requires:
+  ram_mb: 8192
+  disk_mb: 4000
+  python: ">=3.9"
+  ports: [3000]
+
+install:
+  method: pip
+  package: openllm
+
+lifecycle:
+  # OpenLLM exposes an OpenAI-compatible /v1 API on its bento server.
+  backend_type: openai-compatible
+  default_url: http://localhost:3000
+  auto_manage: false
+  keep_alive_minutes: 10
+
+hardware_tiers:
+  x86-cuda-8gb: full
+  x86-cuda-12gb: full
+  x86-cuda-16gb: full
+  x86-cuda-24gb: full
+  x86-vulkan-8gb: degraded
+  apple-silicon: full
+  cpu-only: degraded
+  arm-npu-32gb: unsupported

--- a/app-catalog/services/qdrant/manifest.yaml
+++ b/app-catalog/services/qdrant/manifest.yaml
@@ -1,0 +1,37 @@
+id: qdrant
+name: Qdrant
+type: service
+category: vector-db
+version: 1.13.0
+description: "High-performance vector database — Rust core, gRPC + REST APIs, payload filtering, hybrid search. Production-grade for RAG."
+homepage: https://qdrant.tech
+license: Apache-2.0
+
+requires:
+  ram_mb: 1024
+  disk_mb: 2000
+  ports: [6333, 6334]
+
+install:
+  method: docker
+  image: qdrant/qdrant:v1.13.0
+  ports:
+    - "6333:6333"
+    - "6334:6334"
+  volumes:
+    - qdrant-storage:/qdrant/storage
+
+lifecycle:
+  # Pure storage service — no LLM backend type, just a port the agent
+  # frameworks talk to. Doesn't auto-register as a backend.
+  auto_manage: false
+  keep_alive_minutes: 0  # always-on while installed
+
+hardware_tiers:
+  arm-npu-4gb: full
+  arm-npu-16gb: full
+  arm-npu-32gb: full
+  apple-silicon: full
+  x86-cuda-4gb: full
+  x86-vulkan-4gb: full
+  cpu-only: full


### PR DESCRIPTION
Three of the five apps still missing from packs 2-9 per #321:

| Pack | App | Install method | Why now |
|---|---|---|---|
| 2 Doc/RAG | **qdrant** | docker | official \`qdrant/qdrant:v1.13.0\` image, no extra setup |
| 8 Video | **ltx-video** | download | single-file safetensors → existing \`download_installer\` + diffusers / comfyui backends |
| 9 LLM runtime | **openllm** | pip | clean PyPI wheel, OpenAI-compatible \`/v1\` API → ladder routes through \`openai-compatible\` adapter automatically |

## Two NOT in this PR (intentional)

Both have install-path issues that would silently fail if shipped:

- **ktransformers** — PyPI wheel exists but installation often requires building against a specific CUDA toolkit. Needs a source-build install method or CUDA preflight before the manifest is honest.
- **lmstudio-cli** — would need a new \`scripts/install-lmstudio-cli.sh\` that fetches the platform-appropriate binary from lmstudio.ai.

Filing those as follow-ups rather than shipping aspirational manifests that 400 at install time.

## Test plan
- [x] All 3 manifests parse with \`yaml.safe_load\`
- [ ] Live: qdrant installs via Docker on a fresh worker; ltx-video appears as available video-gen model in store; openllm registers as \`local-openllm\` backend after install

---
_jay confirmed "yes keep adding them, I'll do the test later". Per his "no aspirational manifests" rule (the MLC-format conversation earlier), trimming the two that need install-path work first._