### PR TITLE
feat(installers): HFMultiInstaller — multi-file HuggingFace repo download

### DIFF
--- a/tests/installers/test_hf_multi_installer.py
+++ b/tests/installers/test_hf_multi_installer.py
@@ -1,0 +1,319 @@
+"""Tests for HFMultiInstaller — covers happy path, exclude patterns,
+existing-file skip, single-file fallback, and error envelopes.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from tinyagentos.installers.hf_multi_installer import (
+    HFMultiInstaller,
+    _file_excluded,
+    _safe_relative_path,
+    list_hf_repo_files,
+)
+
+
+class TestSafeRelativePath:
+    """Path-traversal guard. HF rfilenames must always be repo-relative."""
+
+    def test_normal_relative_path_ok(self):
+        assert _safe_relative_path("config.json") == Path("config.json")
+        assert _safe_relative_path("subdir/model.safetensors") == Path("subdir/model.safetensors")
+
+    def test_absolute_path_rejected(self):
+        assert _safe_relative_path("/etc/passwd") is None
+        # Windows-style drive letters survive Path() but are still absolute.
+        # We don't claim to handle that — just that the leading slash check fires.
+
+    def test_dotdot_traversal_rejected(self):
+        assert _safe_relative_path("../etc/passwd") is None
+        assert _safe_relative_path("a/../b") is None
+        assert _safe_relative_path("a/b/../../c") is None
+
+    def test_empty_rejected(self):
+        assert _safe_relative_path("") is None
+
+
+class TestFileExcluded:
+    def test_md_glob_matches_root(self):
+        assert _file_excluded("README.md", ["*.md"])
+
+    def test_md_glob_matches_nested(self):
+        assert _file_excluded("docs/foo.md", ["*.md"])
+
+    def test_does_not_match_unrelated(self):
+        assert not _file_excluded("model.bin", ["*.md"])
+
+    def test_matches_basename(self):
+        # ``.gitattributes`` at the root or anywhere in the tree.
+        assert _file_excluded(".gitattributes", [".gitattributes"])
+        assert _file_excluded("subdir/.gitattributes", [".gitattributes"])
+
+
+@pytest.fixture
+def fake_repo_listing():
+    """Return a stub HF API response covering the file shapes we care
+    about: tiny config + tokenizer, larger weights file, an LFS-marked
+    safetensors shard."""
+    return {
+        "siblings": [
+            {"rfilename": "config.json", "size": 1234},
+            {"rfilename": "tokenizer.json", "size": 5678},
+            {"rfilename": "model.safetensors", "size": 1024 * 1024, "lfs": True},
+            {"rfilename": "README.md", "size": 100},
+            {"rfilename": ".gitattributes", "size": 50},
+        ]
+    }
+
+
+def _stub_listing_client(files: dict):
+    class _Stub:
+        async def __aenter__(self): return self
+        async def __aexit__(self, *exc): return False
+        async def get(self, *a, **kw):
+            class _Resp:
+                def raise_for_status(self): return None
+                def json(self): return files
+            return _Resp()
+        async def aclose(self): return None
+    return _Stub()
+
+
+class TestHFMultiInstallerHappyPath:
+    @pytest.mark.asyncio
+    async def test_downloads_filtered_files(self, tmp_path, monkeypatch, fake_repo_listing):
+        monkeypatch.setenv("TAOS_MODELS_ROOT", str(tmp_path / "models"))
+        installer = HFMultiInstaller()
+
+        downloaded: list[Path] = []
+
+        async def fake_download(url, dest, expected_sha256=None, on_progress=None):
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(b"fake")
+            downloaded.append(dest)
+            if on_progress:
+                on_progress(len(b"fake"), len(b"fake"))
+
+        with patch("tinyagentos.installers.hf_multi_installer.httpx.AsyncClient",
+                   return_value=_stub_listing_client(fake_repo_listing)), \
+             patch("tinyagentos.installers.hf_multi_installer.download_file",
+                   side_effect=fake_download):
+            result = await installer.install(
+                "llama-3-8b-mlc",
+                install_config={"backend": "mlc-llm"},
+                variant={
+                    "id": "q4f16",
+                    "hf_repo": "mlc-ai/Llama-3-8B-Instruct-q4f16_1-MLC",
+                    "multi_file": True,
+                },
+            )
+
+        assert result["success"] is True
+        # README.md and .gitattributes are excluded by default
+        names = sorted(p.name for p in downloaded)
+        assert names == ["config.json", "model.safetensors", "tokenizer.json"]
+        assert result["files_downloaded"] == 3
+
+    @pytest.mark.asyncio
+    async def test_skips_already_downloaded_files(self, tmp_path, monkeypatch, fake_repo_listing):
+        monkeypatch.setenv("TAOS_MODELS_ROOT", str(tmp_path / "models"))
+        installer = HFMultiInstaller()
+
+        # Pre-create config.json so the installer should skip it.
+        target = tmp_path / "models" / "mlc-llm" / "llama" / "llama-3-8b-mlc"
+        target.mkdir(parents=True)
+        (target / "config.json").write_bytes(b"already here")
+
+        downloaded: list[Path] = []
+
+        async def fake_download(url, dest, expected_sha256=None, on_progress=None):
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(b"fake")
+            downloaded.append(dest)
+
+        with patch("tinyagentos.installers.hf_multi_installer.httpx.AsyncClient",
+                   return_value=_stub_listing_client(fake_repo_listing)), \
+             patch("tinyagentos.installers.hf_multi_installer.download_file",
+                   side_effect=fake_download):
+            result = await installer.install(
+                "llama-3-8b-mlc",
+                install_config={"backend": "mlc-llm"},
+                variant={"id": "q4f16", "hf_repo": "mlc-ai/X", "multi_file": True},
+            )
+
+        assert result["success"] is True
+        # Only the un-existing files (tokenizer.json + model.safetensors) re-download
+        names = sorted(p.name for p in downloaded)
+        assert "config.json" not in names
+        assert "tokenizer.json" in names
+        assert "model.safetensors" in names
+
+
+class TestHFMultiInstallerErrors:
+    @pytest.mark.asyncio
+    async def test_missing_variant_returns_error(self):
+        result = await HFMultiInstaller().install("x", {}, variant=None)
+        assert result["success"] is False
+        assert "variant required" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_no_hf_repo_falls_back_to_download_installer(self, tmp_path, monkeypatch):
+        """A variant with download_url but no hf_repo should be handled by
+        the existing single-file DownloadInstaller — the multi-file path
+        is opt-in.
+        """
+        monkeypatch.setenv("TAOS_MODELS_ROOT", str(tmp_path / "models"))
+
+        called = {}
+
+        class _StubDownload:
+            async def install(self, app_id, install_config, variant=None, **kw):
+                called["app_id"] = app_id
+                called["variant"] = variant
+                return {"success": True, "path": "fake"}
+
+        with patch(
+            "tinyagentos.installers.download_installer.DownloadInstaller",
+            return_value=_StubDownload(),
+        ):
+            result = await HFMultiInstaller().install(
+                "single-file-model",
+                {"backend": "llama-cpp"},
+                variant={"id": "q4", "download_url": "https://x/y.gguf"},
+            )
+        assert result["success"] is True
+        assert called["app_id"] == "single-file-model"
+
+    @pytest.mark.asyncio
+    async def test_hf_api_failure_returns_error_envelope(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TAOS_MODELS_ROOT", str(tmp_path / "models"))
+
+        class _ErrClient:
+            async def __aenter__(self): return self
+            async def __aexit__(self, *exc): return False
+            async def get(self, *a, **kw):
+                raise httpx.ConnectError("network down")
+            async def aclose(self): return None
+
+        with patch(
+            "tinyagentos.installers.hf_multi_installer.httpx.AsyncClient",
+            return_value=_ErrClient(),
+        ):
+            result = await HFMultiInstaller().install(
+                "x", {"backend": "mlc-llm"},
+                variant={"id": "q4f16", "hf_repo": "mlc-ai/Z", "multi_file": True},
+            )
+
+        assert result["success"] is False
+        assert "failed to list files" in result["error"]
+
+
+class TestPathTraversalGuard:
+    @pytest.mark.asyncio
+    async def test_traversal_rfilename_skipped_not_downloaded(
+        self, tmp_path, monkeypatch
+    ):
+        """If the HF API response contains an rfilename that resolves outside
+        target_dir, the installer must skip it (not download)."""
+        monkeypatch.setenv("TAOS_MODELS_ROOT", str(tmp_path / "models"))
+        downloaded: list[Path] = []
+
+        async def fake_download(url, dest, expected_sha256=None, on_progress=None):
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(b"x")
+            downloaded.append(dest)
+
+        bad_listing = {
+            "siblings": [
+                {"rfilename": "../../../../etc/passwd", "size": 100},
+                {"rfilename": "/etc/shadow", "size": 100},
+                {"rfilename": "config.json", "size": 100},  # legit
+            ]
+        }
+        with patch("tinyagentos.installers.hf_multi_installer.httpx.AsyncClient",
+                   return_value=_stub_listing_client(bad_listing)), \
+             patch("tinyagentos.installers.hf_multi_installer.download_file",
+                   side_effect=fake_download):
+            await HFMultiInstaller().install(
+                "x", {"backend": "mlc-llm"},
+                variant={"id": "q4", "hf_repo": "a/b", "multi_file": True},
+            )
+
+        # Only the legit file got through.
+        names = sorted(p.name for p in downloaded)
+        assert names == ["config.json"]
+
+
+class TestUninstallResilience:
+    @pytest.mark.asyncio
+    async def test_locked_file_does_not_fail_whole_uninstall(self, tmp_path, monkeypatch):
+        """A locked / un-deletable file should be reported in `failed` but
+        the rest of the manifest dir should still get cleaned."""
+        monkeypatch.setenv("TAOS_MODELS_ROOT", str(tmp_path / "models"))
+        target = tmp_path / "models" / "mlc-llm" / "test" / "test-model"
+        target.mkdir(parents=True)
+        good = target / "config.json"
+        bad = target / "model.safetensors"
+        good.write_bytes(b"a")
+        bad.write_bytes(b"b")
+
+        original_unlink = Path.unlink
+
+        def conditional_unlink(self, *args, **kwargs):
+            if self.name == "model.safetensors":
+                raise OSError(16, "Device or resource busy")
+            return original_unlink(self, *args, **kwargs)
+
+        with patch.object(Path, "unlink", conditional_unlink):
+            result = await HFMultiInstaller().uninstall("test-model")
+
+        assert result["success"] is False  # there was a failure...
+        assert "config.json" in result["deleted"]  # ...but the good file still went
+        assert any("model.safetensors" in f["path"] for f in result["failed"])
+
+
+class TestProgressAggregation:
+    @pytest.mark.asyncio
+    async def test_progress_is_cumulative_across_files(
+        self, tmp_path, monkeypatch, fake_repo_listing
+    ):
+        """The installer's on_progress must report cumulative bytes across
+        the whole repo, not per-file. Otherwise the install-progress bar
+        resets every time a new file starts and looks broken to the user.
+        """
+        monkeypatch.setenv("TAOS_MODELS_ROOT", str(tmp_path / "models"))
+        progress_seen: list[tuple[int, int]] = []
+
+        def cb(done, total):
+            progress_seen.append((done, total))
+
+        async def fake_download(url, dest, expected_sha256=None, on_progress=None):
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(b"x" * 100)
+            if on_progress:
+                # Simulate streaming 100 bytes in two halves
+                on_progress(50, 100)
+                on_progress(100, 100)
+
+        with patch("tinyagentos.installers.hf_multi_installer.httpx.AsyncClient",
+                   return_value=_stub_listing_client(fake_repo_listing)), \
+             patch("tinyagentos.installers.hf_multi_installer.download_file",
+                   side_effect=fake_download):
+            await HFMultiInstaller().install(
+                "x", {"backend": "mlc-llm"},
+                variant={"id": "q4", "hf_repo": "a/b", "multi_file": True},
+                on_progress=cb,
+            )
+
+        # Cumulative bytes must be monotonically non-decreasing
+        cumulative = [done for done, _ in progress_seen]
+        assert cumulative == sorted(cumulative), (
+            f"progress went backwards: {cumulative}"
+        )
+        # Final value should be at least the sum of the per-file totals
+        # (100 bytes × 3 included files = 300)
+        assert max(cumulative) >= 300

--- a/tinyagentos/installers/base.py
+++ b/tinyagentos/installers/base.py
@@ -59,5 +59,8 @@ def get_installer(method: str, **kwargs) -> AppInstaller:
     elif method == "script":
         from tinyagentos.installers.script_installer import ScriptInstaller
         return ScriptInstaller(**kwargs)
+    elif method in ("huggingface", "hf-multi"):
+        from tinyagentos.installers.hf_multi_installer import HFMultiInstaller
+        return HFMultiInstaller(**kwargs)
     else:
         raise ValueError(f"Unknown install method: '{method}'")

--- a/tinyagentos/installers/hf_multi_installer.py
+++ b/tinyagentos/installers/hf_multi_installer.py
@@ -1,0 +1,356 @@
+"""HuggingFace multi-file repo installer.
+
+For backends that ship a model as a directory of files rather than a single
+download (MLC-LLM compiled artefacts, multi-file diffusers / transformers
+checkpoints, etc.) this installer:
+
+1. Lists every file in the HF repo via the public API (no auth required for
+   public repos; gated repos would need a token, surfaced separately).
+2. Downloads each one to ``~/models/<backend>/<family>/<manifest_id>/<rel_path>``
+   preserving the repo's directory structure so consumers like ``mlc_chat``
+   or ``transformers.from_pretrained()`` find the files in the layout they
+   expect.
+3. Reports progress as bytes-downloaded across the whole repo so the UI's
+   install bar moves smoothly instead of resetting per file.
+
+Manifest variant fields:
+
+    hf_repo: mlc-ai/Llama-3-8B-Instruct-q4f16_1-MLC   # required
+    hf_revision: main                                 # optional, default "main"
+    multi_file: true                                  # required marker
+    exclude_patterns: ["*.md", ".gitattributes"]      # optional glob blocklist
+
+Single-file fallback: a variant with ``download_url`` and no ``hf_repo`` is
+delegated back to the regular DownloadInstaller so callers don't have to
+care which path applies.
+"""
+from __future__ import annotations
+
+import fnmatch
+import logging
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from tinyagentos.installers.base import AppInstaller
+from tinyagentos.installers.download_installer import download_file
+from tinyagentos.installers.model_paths import (
+    backend_model_dir,
+    family_from_manifest,
+    models_root,
+)
+
+logger = logging.getLogger(__name__)
+
+HF_API = "https://huggingface.co/api/models/{repo}"
+HF_FILE = "https://huggingface.co/{repo}/resolve/{rev}/{path}"
+
+DEFAULT_EXCLUDE_PATTERNS = (
+    ".gitattributes",
+    "README.md",
+    "LICENSE",
+    "*.md",
+    ".gitignore",
+)
+
+
+async def list_hf_repo_files(
+    repo: str, revision: str = "main", *, client: httpx.AsyncClient | None = None
+) -> list[dict]:
+    """Fetch the file manifest for an HF repo.
+
+    Returns a list of ``{rfilename, size, lfs}`` dicts. ``size`` is bytes
+    when known; ``lfs`` indicates whether the file is stored via Git LFS
+    (large file).
+    """
+    own_client = client is None
+    c = client or httpx.AsyncClient(timeout=30, follow_redirects=True)
+    try:
+        params = {"revision": revision} if revision and revision != "main" else None
+        resp = await c.get(HF_API.format(repo=repo), params=params)
+        resp.raise_for_status()
+        data = resp.json()
+    finally:
+        if own_client:
+            await c.aclose()
+    siblings = data.get("siblings") or []
+    out: list[dict] = []
+    for s in siblings:
+        if not isinstance(s, dict):
+            continue
+        rfilename = s.get("rfilename")
+        if not rfilename:
+            continue
+        # Some HF entries return size as None, missing, or a string. Coerce
+        # defensively — failing the whole listing because one sibling has a
+        # weird size field would be a poor reason to abort an install.
+        raw_size = s.get("size", 0)
+        try:
+            size = int(raw_size) if raw_size is not None else 0
+        except (TypeError, ValueError):
+            size = 0
+        out.append({
+            "rfilename": rfilename,
+            "size": size,
+            "lfs": bool(s.get("lfs")) if "lfs" in s else False,
+        })
+    return out
+
+
+def _safe_relative_path(rfilename: str) -> Path | None:
+    """Reject any HF rfilename that would resolve outside the target dir.
+
+    HF repos shouldn't ever contain absolute paths or ``..`` segments, but
+    a malicious / corrupted manifest could. We always join the rfilename
+    onto ``target_dir`` and verify the resolved path is still inside; if
+    not, return None so the caller can skip and log.
+    """
+    if not rfilename or rfilename.startswith("/"):
+        return None
+    p = Path(rfilename)
+    if p.is_absolute():
+        return None
+    # Reject any segment that's literal '..' — Path.parts after Path()
+    # construction preserves these for traversal-detection purposes.
+    if any(part == ".." for part in p.parts):
+        return None
+    return p
+
+
+def _file_excluded(rfilename: str, patterns: list[str]) -> bool:
+    name = rfilename.lstrip("/")
+    for pat in patterns:
+        if fnmatch.fnmatch(name, pat) or fnmatch.fnmatch(Path(name).name, pat):
+            return True
+    return False
+
+
+class HFMultiInstaller(AppInstaller):
+    """Install a multi-file HuggingFace repo into the shared model layout."""
+
+    def __init__(self, *, _root_override: Path | None = None):
+        # Tests can pass a tmp_path here so the installer doesn't write into
+        # the real ~/models. Production callers leave it None and the path
+        # comes from model_paths.models_root() (TAOS_MODELS_ROOT env override).
+        self._root_override = Path(_root_override) if _root_override else None
+
+    def _backend_id(self, install_config: dict) -> str:
+        backend = install_config.get("backend") if install_config else None
+        return str(backend) if backend else "huggingface"
+
+    def _target_dir(self, backend_id: str, app_id: str) -> Path:
+        if self._root_override is not None:
+            return self._root_override / backend_id / family_from_manifest(app_id) / app_id
+        return backend_model_dir(backend_id, app_id)
+
+    async def install(
+        self,
+        app_id: str,
+        install_config: dict,
+        variant: dict | None = None,
+        **kwargs: Any,
+    ) -> dict:
+        if not variant:
+            return {"success": False, "error": "variant required"}
+
+        repo = variant.get("hf_repo")
+        if not repo:
+            # Single-file fallback for variants that came through the
+            # huggingface route by accident — delegate.
+            from tinyagentos.installers.download_installer import DownloadInstaller
+            return await DownloadInstaller().install(
+                app_id, install_config, variant=variant, **kwargs
+            )
+
+        revision = variant.get("hf_revision", "main")
+        backend_id = self._backend_id(install_config or {})
+        target_dir = self._target_dir(backend_id, app_id)
+        target_dir.mkdir(parents=True, exist_ok=True)
+
+        on_progress = kwargs.get("on_progress")
+        # Be defensive about caller-supplied filter lists: a manifest author
+        # could write ``exclude_patterns: "*.bak"`` (a string) instead of a
+        # list. ``list.extend(str)`` would then add individual chars to the
+        # blocklist rather than treating it as a single pattern.
+        excludes: list[str] = list(DEFAULT_EXCLUDE_PATTERNS)
+        raw_excludes = variant.get("exclude_patterns") or []
+        if isinstance(raw_excludes, str):
+            raw_excludes = [raw_excludes]
+        if isinstance(raw_excludes, list):
+            excludes.extend(p for p in raw_excludes if isinstance(p, str))
+        raw_includes = variant.get("include_patterns") or []
+        if isinstance(raw_includes, str):
+            raw_includes = [raw_includes]
+        includes: list[str] = (
+            [p for p in raw_includes if isinstance(p, str)]
+            if isinstance(raw_includes, list)
+            else []
+        )
+
+        try:
+            async with httpx.AsyncClient(timeout=30, follow_redirects=True) as api:
+                files = await list_hf_repo_files(repo, revision, client=api)
+        except httpx.HTTPError as exc:
+            return {
+                "success": False,
+                "error": f"failed to list files for {repo!r}: {exc}",
+            }
+
+        # Filter
+        selected: list[dict] = []
+        for f in files:
+            if _file_excluded(f["rfilename"], excludes):
+                continue
+            if includes and not any(fnmatch.fnmatch(f["rfilename"], p) for p in includes):
+                continue
+            selected.append(f)
+
+        if not selected:
+            return {
+                "success": False,
+                "error": f"no files matched after filtering for {repo!r}",
+            }
+
+        total_bytes = sum(f["size"] for f in selected) or 0
+        downloaded_bytes = 0
+
+        # Per-file callback aggregates into the cross-repo total so the UI
+        # bar progresses linearly rather than resetting on each file. Track
+        # per-file last value and add deltas to the cumulative count.
+        per_file_prev: dict[str, int] = {}
+
+        def _make_cb(rfilename: str):
+            def _cb(local_done: int, local_total: int) -> None:
+                nonlocal downloaded_bytes
+                prev = per_file_prev.get(rfilename, 0)
+                if local_done < prev:
+                    return  # never go backwards
+                downloaded_bytes += local_done - prev
+                per_file_prev[rfilename] = local_done
+                if on_progress is not None:
+                    try:
+                        on_progress(downloaded_bytes, total_bytes)
+                    except Exception as exc:  # noqa: BLE001
+                        logger.warning(
+                            "hf-multi: on_progress raised %s, continuing", exc,
+                        )
+            return _cb
+
+        # Resolve target_dir once for boundary checks below.
+        target_resolved = target_dir.resolve()
+
+        for f in selected:
+            rfilename = f["rfilename"]
+            file_size = f["size"]
+
+            # Path traversal guard: HF rfilenames should always be repo-
+            # relative, but a hostile API response (or a corrupted cache)
+            # could include "/etc/passwd" or "../etc/passwd". Reject any
+            # rfilename that's absolute, contains '..' segments, or
+            # resolves outside target_dir after joining.
+            safe_rel = _safe_relative_path(rfilename)
+            if safe_rel is None:
+                logger.warning(
+                    "hf-multi: skipping unsafe rfilename %r in repo %r",
+                    rfilename, repo,
+                )
+                continue
+            local = (target_dir / safe_rel)
+            try:
+                if not local.resolve().is_relative_to(target_resolved):
+                    logger.warning(
+                        "hf-multi: %r resolves outside %s — skipping",
+                        rfilename, target_resolved,
+                    )
+                    continue
+            except (OSError, ValueError):
+                # is_relative_to is 3.9+; fall back to string-prefix check
+                if not str(local.resolve()).startswith(str(target_resolved)):
+                    continue
+
+            url = HF_FILE.format(repo=repo, rev=revision, path=rfilename)
+            if local.exists():
+                # Skip files we've already downloaded — sha verification
+                # not in this iteration; HF resolve URLs are immutable per
+                # revision so a present file is a present file. Surface
+                # the byte count anyway so the aggregate progress is right.
+                downloaded_bytes += file_size
+                per_file_prev[rfilename] = file_size
+                if on_progress is not None:
+                    try:
+                        on_progress(downloaded_bytes, total_bytes)
+                    except Exception:  # noqa: BLE001
+                        pass
+                continue
+
+            try:
+                await download_file(
+                    url,
+                    local,
+                    expected_sha256=None,
+                    on_progress=_make_cb(rfilename),
+                )
+            except Exception as exc:  # noqa: BLE001
+                # Leave partially downloaded files alone — caller can
+                # retry. Single bad file aborts the whole install.
+                return {
+                    "success": False,
+                    "error": f"download failed for {repo}/{rfilename}: {exc}",
+                    "downloaded_bytes": downloaded_bytes,
+                    "target_dir": str(target_dir),
+                }
+
+        return {
+            "success": True,
+            "app_id": app_id,
+            "target_dir": str(target_dir),
+            "files_downloaded": len(selected),
+            "bytes_downloaded": downloaded_bytes,
+        }
+
+    async def uninstall(self, app_id: str, variant_id: str | None = None, **kwargs) -> dict:
+        # Walk every backend root for this app's manifest dir. Each unlink
+        # is wrapped — a single locked file (e.g. mmap'd by a running
+        # llama-server) shouldn't fail the whole uninstall and leave the
+        # registry inconsistent. Surface failures in the result so the
+        # caller can decide whether to retry or escalate.
+        family = family_from_manifest(app_id)
+        root = self._root_override if self._root_override is not None else models_root()
+        if not root.exists():
+            return {"success": True, "deleted": [], "failed": []}
+
+        deleted: list[str] = []
+        failed: list[dict] = []
+        for backend_dir in sorted(root.iterdir()):
+            if not backend_dir.is_dir():
+                continue
+            manifest_dir = backend_dir / family / app_id
+            if not manifest_dir.exists():
+                continue
+            for f in sorted(manifest_dir.rglob("*")):
+                if not f.is_file():
+                    continue
+                rel = str(f.relative_to(manifest_dir))
+                try:
+                    f.unlink()
+                    deleted.append(rel)
+                except OSError as exc:
+                    failed.append({"path": rel, "error": str(exc)})
+            # Remove empty dirs (deepest first). Best-effort.
+            for d in sorted(manifest_dir.rglob("*"), reverse=True):
+                if d.is_dir():
+                    try:
+                        d.rmdir()
+                    except OSError:
+                        pass
+            try:
+                manifest_dir.rmdir()
+            except OSError:
+                pass
+
+        return {
+            "success": not failed,
+            "deleted": deleted,
+            "failed": failed,
+        }

--- a/tinyagentos/routes/store_install.py
+++ b/tinyagentos/routes/store_install.py
@@ -50,9 +50,16 @@ _BACKEND_TO_METHOD: dict[str, str] = {
     "mlx": "download",
     "vllm": "download",
     "comfyui": "download",
-    "transformers": "download",
-    "diffusers": "download",
-    "sentence-transformers": "download",
+    # Multi-file backends — model weights ship as an HF directory (config,
+    # tokenizer, sharded safetensors / .bin chunks). The huggingface
+    # installer downloads the whole repo into the shared layout. Single-
+    # file variants on these backends still work because the installer
+    # delegates back to DownloadInstaller when a variant has no hf_repo.
+    "transformers": "huggingface",
+    "diffusers": "huggingface",
+    "sentence-transformers": "huggingface",
+    "mlc-llm": "huggingface",
+    "mlc": "huggingface",
     "whisper-cpp": "download",
     "piper": "download",
     "onnxruntime": "download",


### PR DESCRIPTION
The (3) item from the "what needs finishing" list — the multi-file HF download path that unblocks MLC model variants and reusable across diffusers / transformers / sentence-transformers checkpoints.

## Why
Pack 9's MLC-format models plus most diffusers / transformers / sentence-transformers checkpoints ship as a **directory** of files (config + tokenizer + sharded safetensors / .bin chunks), not a single download. The existing \`DownloadInstaller\` is single-file only — manifests declaring an HF repo layout silently failed at install. Per "no aspirational manifests" rule, MLC variants couldn't ship until this landed.

## What
New install method \`huggingface\` (alias \`hf-multi\`):

| Behaviour | Detail |
|---|---|
| File listing | HF public API (\`/api/models/{repo}\`) → file manifest with size + LFS flag |
| Layout | Writes to \`~/models/<backend>/<family>/<manifest_id>/<rel_path>\` (#430's shared tree), preserving repo directory structure so \`mlc_chat\` / \`transformers.from_pretrained()\` find what they expect |
| Default excludes | \`.gitattributes\`, \`README.md\`, \`*.md\`, \`LICENSE\`, \`.gitignore\` — caller can override per-variant |
| Custom filters | \`variant.exclude_patterns\` (extra blocks) and \`variant.include_patterns\` (allowlist) |
| Progress | Aggregates per-file progress into one cumulative number so the install bar moves linearly across the whole repo, not resets per file |
| Idempotence | Skips files already present — HF resolve URLs are immutable per revision, so a present file is a present file. Re-runs are no-ops |
| Single-file fallback | Variants without \`hf_repo\` delegate back to \`DownloadInstaller\` so single-file vs multi-file is variant-driven, not method-driven |

## Manifest schema for multi-file variants

\`\`\`yaml
variants:
  - id: mlc-q4f16
    hf_repo: mlc-ai/Llama-3-8B-Instruct-q4f16_1-MLC
    hf_revision: main           # optional, default "main"
    multi_file: true
    exclude_patterns: ["*.bak"]  # optional
\`\`\`

\`_BACKEND_TO_METHOD\` updated: \`transformers\` / \`diffusers\` / \`sentence-transformers\` / \`mlc-llm\` / \`mlc\` now route to \`huggingface\`. Their existing single-file manifests still work because the fallback path runs DownloadInstaller when \`hf_repo\` is absent.

## Test plan
- [x] 8 new tests in \`test_hf_multi_installer.py\` covering:
  - File-pattern excludes (root + nested + basename match)
  - Happy path — downloads all non-excluded files
  - Skip already-downloaded files
  - Missing variant returns error
  - No \`hf_repo\` falls back to DownloadInstaller
  - HF API failure returns structured error envelope
  - Cumulative progress is monotonically non-decreasing across files
- [x] Dispatcher registration: \`get_installer('huggingface')\` → HFMultiInstaller
- [ ] Live: post-merge, MLC manifests for Llama-3-8B / Phi-3-mini / Qwen2-7B can ship and install end-to-end (next PR)

## What this does NOT cover (filing if needed)
- **Gated HF repos** (e.g. Llama 3 originals before access granted) — would need an HF token plumbed via secrets. Public mirrors like \`mlc-ai/*\` work without auth.
- **SHA256 verification per file** — HF's API doesn't expose per-file sha256 reliably; could be added later via the LFS pointer files for LFS-tracked weights specifically.

---
_Per jay's "yes do 3 for now" steer. Pure backend code, no UI changes; nothing breaks if it sits behind master while jay runs the gemma-4 chat test._