### PR TITLE
fix(picker): show controller-hosted local providers in agent + assistant pickers

### DIFF
--- a/desktop/src/apps/AgentsApp.tsx
+++ b/desktop/src/apps/AgentsApp.tsx
@@ -1074,7 +1074,14 @@ function DeployWizard({
         // Network providers map onto the picker's 'worker' source tab
         // since that's what they conceptually are. Filed as #356 —
         // network providers were silently dropped before.
-        const providerByModelId = new Map<string, { name: string; kind: "cloud" | "worker" }>();
+        // Three lanes: cloud, worker (network-attached, source starts
+        // with "worker:"), and controller (everything else — backends
+        // configured directly on this controller, e.g. a local ollama
+        // or llama-cpp). Filed under #356 — johny reported (2026-05-08)
+        // that local-provider models were still being dropped after the
+        // network fix in #422. Surface them in the picker's local lane
+        // alongside catalog-installed models.
+        const providerByModelId = new Map<string, { name: string; kind: "cloud" | "worker" | "controller" }>();
         const cloudProviderNames = new Set<string>();
         try {
           const pct = providersRes.headers.get("content-type") ?? "";
@@ -1083,8 +1090,8 @@ function DeployWizard({
             for (const p of (Array.isArray(providers) ? providers : [])) {
               const isCloud = (CLOUD_PROVIDER_TYPES as readonly string[]).includes(p.type);
               const isNetwork = typeof p.source === "string" && p.source.startsWith("worker:");
-              if (!isCloud && !isNetwork) continue;
-              const kind: "cloud" | "worker" = isCloud ? "cloud" : "worker";
+              const kind: "cloud" | "worker" | "controller" =
+                isCloud ? "cloud" : isNetwork ? "worker" : "controller";
               const pname = p.name ?? p.type;
               if (kind === "cloud") cloudProviderNames.add(pname);
               const pModels: { id?: string; name?: string }[] = Array.isArray(p.models) ? p.models : [];
@@ -1110,11 +1117,17 @@ function DeployWizard({
             // defaults — they'd show up as a confusing "default" entry.
             if (mid === "default" || mid === "taos-embedding-default") continue;
             const provider = providerByModelId.get(mid);
-            if (!provider) continue; // not a cloud or network model
+            if (!provider) continue; // not a known provider — LiteLLM internal alias
             const key = `${provider.kind}:${provider.name}:${mid}`;
             if (seen.has(key)) continue;
             seen.add(key);
-            const target = provider.kind === "cloud" ? cloudModels : workerModels;
+            // Route into the lane that matches the provider's kind so the
+            // picker shows it under the right tab. Controller-hosted local
+            // providers go into localModels alongside catalog installs.
+            const target =
+              provider.kind === "cloud" ? cloudModels :
+              provider.kind === "worker" ? workerModels :
+              localModels;
             target.push({
               id: mid,
               name: `${mid} (${provider.name})`,

--- a/desktop/src/components/TaosAssistantSettings.tsx
+++ b/desktop/src/components/TaosAssistantSettings.tsx
@@ -6,6 +6,7 @@ import {
   fetchCloudProviders,
   workersToAggregated,
   cloudProvidersToAggregated,
+  localProvidersToAggregated,
 } from "@/lib/models";
 import { useTaosAgentStore } from "@/stores/taos-agent-store";
 
@@ -50,9 +51,15 @@ export function TaosAssistantSettings({ open, onClose }: Props) {
           }));
         const worker = workersToAggregated(workers);
         const cloud = cloudProvidersToAggregated(providers);
+        // Providers configured directly on the controller (a local ollama,
+        // a manually-added llama-cpp, etc.) are neither cloud nor a remote
+        // worker — they were silently dropped from the picker before #356
+        // surfaced the gap.
+        const localProviders = localProvidersToAggregated(providers);
 
         const all: AgentModel[] = [
           ...local,
+          ...localProviders.map((m: { id: string; name: string; host: string; hostKind: "controller" | "worker" | "cloud" }) => ({ id: m.id, name: m.name, host: m.host, hostKind: m.hostKind })),
           ...worker.map((m: { id: string; name: string; host: string; hostKind: "controller" | "worker" | "cloud" }) => ({ id: m.id, name: m.name, host: m.host, hostKind: m.hostKind })),
           ...cloud.map((m: { id: string; name: string; host: string; hostKind: "controller" | "worker" | "cloud" }) => ({ id: m.id, name: m.name, host: m.host, hostKind: m.hostKind })),
         ];

--- a/desktop/src/lib/__tests__/models-providers.test.ts
+++ b/desktop/src/lib/__tests__/models-providers.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests for the provider classifiers in src/lib/models.ts.
+ *
+ * #356 (johny-mnemonic) surfaced that controller-hosted local providers
+ * (a manually-added local ollama or llama.cpp endpoint) were silently
+ * dropped from the agent / assistant model picker — only cloud providers
+ * and worker-attached (`source: worker:*`) network providers survived
+ * the filter. localProvidersToAggregated picks up the residual.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  cloudProvidersToAggregated,
+  localProvidersToAggregated,
+  type CloudProvider,
+} from "../models";
+
+const cloudOpenAI: CloudProvider = {
+  name: "openai-prod",
+  type: "openai",
+  models: [{ id: "gpt-4o" }, { id: "gpt-4o-mini" }],
+};
+
+const networkOllama: CloudProvider = {
+  name: "remote-ollama",
+  type: "ollama",
+  source: "worker:fedora-worker",
+  models: [{ id: "llama3:8b" }],
+};
+
+const localOllama: CloudProvider = {
+  name: "local-ollama",
+  type: "ollama",
+  // no source, OR an explicit non-worker prefix
+  models: [{ id: "qwen2:7b" }],
+};
+
+const localLlamaCpp: CloudProvider = {
+  name: "local-llama-cpp",
+  type: "llama-cpp",
+  source: "local",
+  models: [{ id: "phi-3-mini" }],
+};
+
+const localCustomCompat: CloudProvider = {
+  name: "my-server",
+  type: "openai-compatible",  // IS in CLOUD_PROVIDER_TYPES — handled by cloudProvidersToAggregated, not local
+  models: [{ id: "custom-model" }],
+};
+
+
+describe("localProvidersToAggregated", () => {
+  it("includes ollama at controller (no worker: source)", () => {
+    const result = localProvidersToAggregated([localOllama]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: "qwen2:7b",
+      hostKind: "controller",
+      host: "local-ollama",
+      backend: "ollama",
+    });
+  });
+
+  it("includes llama-cpp with explicit local source", () => {
+    const result = localProvidersToAggregated([localLlamaCpp]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: "phi-3-mini",
+      hostKind: "controller",
+      backend: "llama-cpp",
+    });
+  });
+
+  it("excludes cloud providers (handled by cloudProvidersToAggregated)", () => {
+    const result = localProvidersToAggregated([cloudOpenAI]);
+    expect(result).toEqual([]);
+  });
+
+  it("excludes openai-compatible (it's a cloud type even when local)", () => {
+    // Edge case: openai-compatible is in CLOUD_PROVIDER_TYPES so the
+    // existing cloud helper handles it. localProvidersToAggregated
+    // skips it on purpose to avoid double-counting.
+    const result = localProvidersToAggregated([localCustomCompat]);
+    expect(result).toEqual([]);
+  });
+
+  it("excludes worker-attached network providers", () => {
+    const result = localProvidersToAggregated([networkOllama]);
+    expect(result).toEqual([]);
+  });
+
+  it("emits one entry per model", () => {
+    const multiModel: CloudProvider = {
+      name: "local",
+      type: "ollama",
+      models: [{ id: "a" }, { id: "b" }, { id: "c" }],
+    };
+    const result = localProvidersToAggregated([multiModel]);
+    expect(result.map((r) => r.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("emits a default entry when models list is empty", () => {
+    const noModels: CloudProvider = {
+      name: "empty-local",
+      type: "ollama",
+      // no models, no model
+    };
+    const result = localProvidersToAggregated([noModels]);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("default");
+  });
+
+  it("partitions cleanly with cloudProvidersToAggregated — no double counting", () => {
+    const all = [cloudOpenAI, networkOllama, localOllama, localLlamaCpp, localCustomCompat];
+    const cloud = cloudProvidersToAggregated(all);
+    const local = localProvidersToAggregated(all);
+    const cloudIds = cloud.map((m) => m.id);
+    const localIds = local.map((m) => m.id);
+    // Disjoint sets — no model surfaces in both
+    for (const id of cloudIds) {
+      expect(localIds).not.toContain(id);
+    }
+  });
+});

--- a/desktop/src/lib/models.ts
+++ b/desktop/src/lib/models.ts
@@ -114,6 +114,11 @@ export interface CloudProvider {
   type?: string;
   model?: string;
   models?: { id?: string; name?: string }[];
+  // Optional — set by /api/providers when the entry is sourced from a
+  // remote worker's heartbeat (e.g. ``worker:fedora-worker``). Used by
+  // the picker to keep network-attached and locally-configured local
+  // providers in different lanes.
+  source?: string;
 }
 
 export const CLOUD_PROVIDER_TYPES = ["openai", "anthropic", "openrouter", "kilocode", "openai-compatible"] as const;
@@ -145,6 +150,52 @@ export function cloudProvidersToAggregated(providers: CloudProvider[]): Aggregat
         name: m.name ?? id,
         host: providerName,
         hostKind: "cloud",
+        backend: p.type,
+      });
+    }
+  }
+  return out;
+}
+
+/** Flatten /api/providers entries that are NEITHER cloud nor worker-attached
+ *  — i.e. backends configured directly on the controller (a local ollama
+ *  on localhost, a manually-added llama-cpp endpoint, etc.). They show
+ *  alongside catalog-installed local models in the picker's controller
+ *  lane. johny-mnemonic surfaced this gap on #356.
+ *
+ *  Reuses the cloud filter rules in negative: skip anything in
+ *  CLOUD_PROVIDER_TYPES (handled by cloudProvidersToAggregated) and
+ *  anything whose source is ``worker:*`` (handled by workers). What's
+ *  left is "local controller-hosted".
+ */
+export function localProvidersToAggregated(providers: CloudProvider[]): AggregatedModel[] {
+  const out: AggregatedModel[] = [];
+  for (const p of providers ?? []) {
+    if (!p || !p.type) continue;
+    if ((CLOUD_PROVIDER_TYPES as readonly string[]).includes(p.type)) continue;
+    if (typeof p.source === "string" && p.source.startsWith("worker:")) continue;
+    const providerName = p.name ?? p.type;
+    const list = Array.isArray(p.models) ? p.models : [];
+    if (list.length === 0) {
+      const id = p.model ?? "default";
+      out.push({
+        key: `local:${providerName}:${id}`,
+        id,
+        name: `${providerName} default`,
+        host: providerName,
+        hostKind: "controller",
+        backend: p.type,
+      });
+      continue;
+    }
+    for (const m of list) {
+      const id = m.id ?? m.name ?? "unknown";
+      out.push({
+        key: `local:${providerName}:${id}`,
+        id,
+        name: m.name ?? id,
+        host: providerName,
+        hostKind: "controller",
         backend: p.type,
       });
     }


### PR DESCRIPTION
## Why
johny-mnemonic flagged on [#356](https://github.com/jaylfc/tinyagentos/issues/356#issuecomment-4407844837) that after the cloud + remote-LiteLLM fix in #422 worked, models from his **locally-configured** llama.cpp / ollama providers were still missing from the agent model picker.

The picker (\`AgentsApp.tsx:1077-1099\` and the shared \`cloudProvidersToAggregated\` helper in \`lib/models.ts\`) had two lanes for \`/api/providers\`:

| Lane | Filter |
|---|---|
| cloud | \`CLOUD_PROVIDER_TYPES.includes(p.type)\` |
| worker | \`p.source?.startsWith("worker:")\` (network-attached) |

Anything else hit \`if (!isCloud && !isNetwork) continue;\` and was silently dropped. johny's controller-hosted ollama / llama-cpp providers fall in that gap.

## Fix
Adds a third **controller** lane for non-cloud, non-worker providers so they surface alongside catalog-installed local models in the picker's local tab:

- New helper \`localProvidersToAggregated()\` in \`lib/models.ts\` that emits \`AggregatedModel\` entries with \`hostKind: "controller"\`. Disjoint with \`cloudProvidersToAggregated\` (no double-counting): excludes cloud types and \`worker:*\`-sourced providers.
- \`AgentsApp.tsx\` picker classifier extended: a provider that's neither cloud nor worker now gets \`kind: "controller"\` and its models push into \`localModels\` rather than being dropped.
- \`TaosAssistantSettings.tsx\` picker calls the new helper and unions controller-hosted providers into its local model list.

## Test plan
- [x] 8 new unit tests in \`models-providers.test.ts\` cover:
  - Local ollama / llama-cpp surface as \`hostKind: "controller"\`
  - Cloud and worker:* providers excluded
  - \`openai-compatible\` (a cloud type even when local) is handled by the cloud helper, not double-counted
  - Empty models list emits a single \`default\` entry
  - Disjoint partition invariant with \`cloudProvidersToAggregated\`
- [x] All 46 existing lib tests still pass; tsc --noEmit clean
- [ ] Live: johny re-tests after pulling master — his local llama.cpp models should appear in the agent wizard picker

---
_Routes against johny's [16:21 reply on #356](https://github.com/jaylfc/tinyagentos/issues/356#issuecomment-4407844837). Drafted at jay's request, not yet posted to johny._