### PR TITLE
fix(auto-register): gate on hardware tier compatibility (closes johny's rk-llama.cpp-on-x86 issue)

### DIFF
--- a/tests/test_config_auto_register.py
+++ b/tests/test_config_auto_register.py
@@ -159,3 +159,140 @@ default_url: http://localhost:9999
         added = auto_register_from_manifest(manifest, config)
     assert added is False
     assert config.backends == []
+
+
+class _FakeHardwareProfile:
+    """Test stub mirroring the HardwareProfile API the gate uses."""
+
+    def __init__(self, hardware: dict):
+        self.hardware = hardware
+
+
+def test_auto_register_skips_when_hardware_only_lists_unsupported_tiers(tmp_path: Path, caplog):
+    """rk-llama.cpp on x86: every CUDA / vulkan tier that matches the
+    controller's tier_id is marked ``unsupported``, so the entry must be
+    skipped rather than registered. johny saw rk-llama.cpp showing as
+    installed on his x86 cluster — exactly this gap."""
+    import logging
+
+    manifest = tmp_path / "rk-llama-cpp.yaml"
+    manifest.write_text("""
+id: rk-llama-cpp
+name: rk-llama.cpp
+type: service
+lifecycle:
+  backend_type: openai-compatible
+  default_url: http://localhost:8090
+hardware_tiers:
+  arm-npu-16gb: full
+  arm-npu-32gb: full
+  x86-cuda-12gb: unsupported
+  x86-vulkan-8gb: unsupported
+  cpu-only: unsupported
+""")
+    # x86 controller with a 12 GB CUDA card — tier_id = x86-cuda-12gb,
+    # which IS in the manifest but as "unsupported". Skip.
+    hw = _FakeHardwareProfile({
+        "cpu": {"arch": "x86_64"},
+        "gpu": {"type": "nvidia", "cuda": True, "vram_mb": 12 * 1024},
+    })
+    config = AppConfig()
+    with caplog.at_level(logging.INFO):
+        added = auto_register_from_manifest(manifest, config, hardware_profile=hw)
+    assert added is False
+    assert config.backends == []
+    assert any(
+        "doesn't match" in rec.message.lower() or "incompatible" in rec.message.lower()
+        for rec in caplog.records
+    )
+
+
+def test_auto_register_accepts_when_compatible_tier_present(tmp_path: Path):
+    """rk-llama.cpp on a Pi: arm-npu-16gb is declared ``full`` and matches
+    the controller's tier_id, so the entry registers."""
+    manifest = tmp_path / "rk-llama-cpp.yaml"
+    manifest.write_text("""
+id: rk-llama-cpp
+name: rk-llama.cpp
+type: service
+lifecycle:
+  backend_type: openai-compatible
+  default_url: http://localhost:8090
+hardware_tiers:
+  arm-npu-16gb: full
+  arm-npu-32gb: full
+  x86-cuda-12gb: unsupported
+  cpu-only: unsupported
+""")
+    hw = _FakeHardwareProfile({
+        "cpu": {"arch": "aarch64"},
+        "npu": {"type": "rk3588", "tops": 6, "cores": 3},
+        "ram_mb": 16 * 1024,
+    })
+    config = AppConfig()
+    added = auto_register_from_manifest(manifest, config, hardware_profile=hw)
+    assert added is True
+    assert len(config.backends) == 1
+    assert config.backends[0]["name"] == "local-rk-llama-cpp"
+
+
+def test_auto_register_accepts_via_ladder_match(tmp_path: Path):
+    """Bigger worker inherits smaller minimum tier (per #436's tier ladder).
+    A manifest declaring only ``x86-cuda-8gb: full`` should register on
+    a 16 GB CUDA worker."""
+    manifest = tmp_path / "fake-svc.yaml"
+    manifest.write_text("""
+id: fake-svc
+name: Fake Service
+type: service
+lifecycle:
+  backend_type: openai-compatible
+  default_url: http://localhost:9000
+hardware_tiers:
+  x86-cuda-8gb: full
+""")
+    hw = _FakeHardwareProfile({
+        "cpu": {"arch": "x86_64"},
+        "gpu": {"type": "nvidia", "cuda": True, "vram_mb": 16 * 1024},
+    })
+    config = AppConfig()
+    added = auto_register_from_manifest(manifest, config, hardware_profile=hw)
+    assert added is True
+
+
+def test_auto_register_no_hardware_tiers_block_still_registers(tmp_path: Path):
+    """Manifests without a hardware_tiers block (some infrastructure
+    services) shouldn't be gated — the check is opt-in. Backwards
+    compatible with existing manifests."""
+    manifest = tmp_path / "infra-svc.yaml"
+    manifest.write_text("""
+id: infra-svc
+name: Infra Service
+type: service
+lifecycle:
+  backend_type: openai-compatible
+  default_url: http://localhost:7000
+""")
+    hw = _FakeHardwareProfile({
+        "cpu": {"arch": "x86_64"},
+        "gpu": {"type": "nvidia", "cuda": True, "vram_mb": 12 * 1024},
+    })
+    config = AppConfig()
+    added = auto_register_from_manifest(manifest, config, hardware_profile=hw)
+    assert added is True
+
+
+def test_auto_register_without_hardware_profile_works_unchanged(tmp_path: Path):
+    """Existing callers that don't pass hardware_profile must still work
+    (no gate applied) — keeps the function backwards-compatible for
+    tests and any non-controller call sites."""
+    manifest = tmp_path / "rkllama.yaml"
+    manifest.write_text("""
+id: rkllama
+name: rkllama
+type: rkllama
+default_url: http://localhost:8080
+""")
+    config = AppConfig()
+    added = auto_register_from_manifest(manifest, config)  # no hardware_profile kwarg
+    assert added is True

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -147,6 +147,14 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
             shutil.copy2(example, config_path)
     config = load_config(config_path)
 
+    # Hardware profile drives auto-registration: a service whose manifest
+    # declares e.g. ``arm-npu-*: full`` and ``x86-cuda-*: unsupported``
+    # shouldn't be added as a backend on an x86 controller (rk-llama.cpp
+    # was registering everywhere before this). Load it BEFORE the
+    # auto-register loop so the gate is informed.
+    hardware_path = data_dir / "hardware.json"
+    hardware_profile = get_hardware_profile(hardware_path)
+
     # Auto-register any taOS-managed services that have a lifecycle block
     # in their app-catalog manifest but are not yet in config.backends.
     # This runs synchronously at create_app time (before the lifespan starts)
@@ -156,7 +164,9 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         _any_added = False
         for _manifest in _services_dir.glob("*/manifest.yaml"):
             try:
-                added = auto_register_from_manifest(_manifest, config)
+                added = auto_register_from_manifest(
+                    _manifest, config, hardware_profile=hardware_profile,
+                )
                 if added:
                     logger.info("auto-registered backend from manifest: %s", _manifest)
                     _any_added = True
@@ -178,8 +188,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
             # Do NOT raise — legacy manifests can still run agents; only update paths are disabled.
 
     catalog_dir = catalog_dir or PROJECT_DIR / "app-catalog"
-    hardware_path = data_dir / "hardware.json"
-    hardware_profile = get_hardware_profile(hardware_path)
+    # hardware_path / hardware_profile already loaded above before the
+    # auto-register loop; don't re-probe.
     installed_path = data_dir / "installed.json"
     registry = AppRegistry(catalog_dir=catalog_dir, installed_path=installed_path)
 

--- a/tinyagentos/config.py
+++ b/tinyagentos/config.py
@@ -213,15 +213,27 @@ async def save_config_locked(config: AppConfig, path: Path) -> None:
     async with _config_lock:
         save_config(config, path)
 
-def auto_register_from_manifest(manifest_path: Path, config: "AppConfig") -> bool:
+def auto_register_from_manifest(
+    manifest_path: Path,
+    config: "AppConfig",
+    *,
+    hardware_profile: object | None = None,
+) -> bool:
     """Read a service manifest and add a backend entry to config if not already present.
 
-    Returns True if a new entry was added, False if already registered.
+    Returns True if a new entry was added, False if already registered or skipped.
 
     Supports two manifest formats:
     - Flat format: top-level ``type`` is the backend type, ``default_url`` is the URL.
     - Catalog format: ``type: service`` with ``lifecycle.backend_type`` and
       ``lifecycle.default_url`` (used by existing app-catalog manifests).
+
+    When ``hardware_profile`` is supplied, the manifest's ``hardware_tiers``
+    block is checked: if every declared tier is ``unsupported`` (or no
+    matching tier survives the ladder match in
+    :func:`tinyagentos.cluster.capabilities.tier_compatible`), the entry
+    is **skipped** rather than registered. Stops e.g. rk-llama.cpp from
+    auto-registering on x86 hardware.
     """
     data = yaml.safe_load(manifest_path.read_text())
     lifecycle = data.get("lifecycle", {})
@@ -253,6 +265,44 @@ def auto_register_from_manifest(manifest_path: Path, config: "AppConfig") -> boo
             name, backend_type, sorted(VALID_BACKEND_TYPES),
         )
         return False
+
+    # Hardware compat check: skip the entry if the manifest declares
+    # hardware_tiers and none are compatible with this controller's tier.
+    # Reuses the ladder logic from tier_compatible() — bigger workers
+    # inherit smaller-tier compatibility, so a 16gb CUDA worker matches
+    # a manifest declaring ``x86-cuda-12gb: full``. Manifests with no
+    # hardware_tiers block (rare for service manifests, common for
+    # generic infra) are accepted as-is — opt-in gating only.
+    if hardware_profile is not None:
+        tiers = data.get("hardware_tiers") or {}
+        if isinstance(tiers, dict) and tiers:
+            from tinyagentos.cluster.capabilities import (
+                tier_compatible,
+                worker_tier_id,
+            )
+            hw_dict = getattr(hardware_profile, "hardware", None) or {}
+            controller_tier = worker_tier_id(hw_dict)
+            any_compatible = False
+            for manifest_tier, tier_val in tiers.items():
+                if not tier_compatible(controller_tier, manifest_tier):
+                    continue
+                # Treat 'unsupported' as a hard no even if the tier matches.
+                if isinstance(tier_val, str) and tier_val == "unsupported":
+                    continue
+                if isinstance(tier_val, dict) and tier_val.get("unsupported") is True:
+                    continue
+                any_compatible = True
+                break
+            if not any_compatible:
+                import logging
+                logging.getLogger(__name__).info(
+                    "auto_register_from_manifest: skipping %s — controller tier %s "
+                    "doesn't match any compatible entry in %s. Hardware-incompatible "
+                    "manifests stay un-registered so the Providers list and Store "
+                    "don't show services that can't actually run here.",
+                    name, controller_tier, sorted(tiers.keys()),
+                )
+                return False
 
     if any(b.get("name") == name for b in config.backends):
         return False


### PR DESCRIPTION
johny saw rk-llama.cpp showing as **"installed"** on his x86 cluster even though it's a Rockchip-NPU-only service ([#312 reply 2026-05-08 16:21](https://github.com/jaylfc/tinyagentos/discussions/312#discussioncomment-16854745)). The cause: \`auto_register_from_manifest\` only checked backend_type validity, not whether the controller's hardware could run the service.

## Fix

\`auto_register_from_manifest\` now takes an optional \`hardware_profile\` and checks the manifest's \`hardware_tiers\` block:

- If the controller's tier_id has **no compatible entry** (using the same \`tier_compatible()\` ladder match from #436), skip + log
- \`unsupported\` entries are explicitly excluded even when the tier matches
- Manifests with **no \`hardware_tiers\` block** are accepted as-is — opt-in gating keeps existing infra-service manifests working

\`create_app()\` was reshuffled to load \`hardware_profile\` before the auto-register loop runs (it was after) so the gate has the data it needs.

## Backwards compatibility

\`hardware_profile\` is keyword-only and defaults to \`None\`. Existing call sites that don't pass it (tests, non-controller code) keep working exactly as before — the gate is skipped without it.

## Test plan
- [x] 5 new tests in \`test_config_auto_register.py\`:
  - rk-llama.cpp on x86 cluster (cuda) → skipped + log emitted
  - rk-llama.cpp on Pi (arm-npu-16gb \`full\`) → registers
  - Manifest declaring only \`x86-cuda-8gb\` on a 16 GB worker → registers via tier ladder
  - Manifest with no \`hardware_tiers\` block → still registers (opt-in)
  - No hardware_profile kwarg → backwards compatible
- [x] Existing 6 tests in the file still pass (verified via sanity script)
- [ ] Live: johny re-tests after pulling master — rk-llama.cpp no longer appears as installed on his x86 cluster

---
_First of four follow-ups from johny's 2026-05-08 16:21 reply on #312. Memory-step / store-stale / dup-providers fixes coming as separate PRs._