### PR TITLE
fix(store): stale registry entries no longer show as installed

### DIFF
--- a/tests/test_routes_models.py
+++ b/tests/test_routes_models.py
@@ -135,14 +135,25 @@ class TestModelsAPI:
         for m in data["models"]:
             assert m["has_downloaded_variant"] is False
 
-    async def test_registry_installed_marks_downloaded(self, models_client, models_app):
+    async def test_registry_installed_with_disk_evidence_marks_downloaded(
+        self, models_client, models_app, tmp_path
+    ):
         """Backend-installed models (e.g. rk-llama.cpp GGUFs at
-        ~/rk-llama.cpp/models/) leave nothing in data/models and don't show
-        up in any live BackendCatalog entry, so /api/models needs to fall
-        back to the install registry to know they're present.
+        ~/models/rk-llama.cpp/<family>/<manifest_id>/) leave nothing in
+        data/models and don't show up in the live BackendCatalog, so
+        /api/models needs to fall back to the install registry —
+        provided there's at least one corroborating signal that the
+        install really happened.
         """
         registry = models_app.state.registry
         registry.mark_installed("test-model", "1.0.0")
+
+        # Drop a file under the new shared layout that the rglob scan
+        # picks up — its path contains the manifest id.
+        shared = models_app.state.models_root
+        target_dir = shared / "rk-llama.cpp" / "test" / "test-model"
+        target_dir.mkdir(parents=True, exist_ok=True)
+        (target_dir / "test-model-q4_k_m.gguf").write_bytes(b"x" * 100)
 
         resp = await models_client.get("/api/models")
         assert resp.status_code == 200
@@ -150,12 +161,30 @@ class TestModelsAPI:
 
         installed = next(m for m in data["models"] if m["id"] == "test-model")
         assert installed["has_downloaded_variant"] is True
-        assert all(v["downloaded"] is True for v in installed["variants"])
 
-        # Other manifests not in the registry must remain not-downloaded so
-        # we don't blanket-mark every model.
+        # Other manifests untouched.
         not_installed = next(m for m in data["models"] if m["id"] == "another-model")
         assert not_installed["has_downloaded_variant"] is False
+
+    async def test_registry_installed_without_evidence_is_not_downloaded(
+        self, models_client, models_app
+    ):
+        """Stale registry entry with no disk file and no live backend
+        match should NOT count as downloaded. johny saw the catalog
+        showing models as installed when nothing was actually on disk —
+        registry breadcrumbs from earlier sessions leaking through. This
+        is the bypass the corroboration check closes.
+        """
+        registry = models_app.state.registry
+        registry.mark_installed("test-model", "1.0.0")
+        # No file written, no live backend — registry breadcrumb only.
+
+        resp = await models_client.get("/api/models")
+        data = resp.json()
+        installed = next(m for m in data["models"] if m["id"] == "test-model")
+        assert installed["has_downloaded_variant"] is False, (
+            f"stale registry entry should not mark downloaded: {installed}"
+        )
 
 
 @pytest.mark.asyncio

--- a/tinyagentos/routes/models.py
+++ b/tinyagentos/routes/models.py
@@ -211,17 +211,37 @@ def _model_to_dict(
     always the live catalog.
 
     ``registry_installed`` is the install-registry's verdict for this manifest
-    id. Some installers (e.g. rk-llama.cpp) write GGUFs to a backend-specific
-    directory outside ``data/models`` and the resulting llama-server reports
-    the model under a generic name like ``active.gguf``. Neither the on-disk
-    scan nor the live-backend match can detect those, so the registry's
-    "this app was installed" record is the only honest signal we have. Set
-    on the manifest level (variant-level install-tracking doesn't exist yet),
-    so every variant gets the same flag — coarse but accurate enough for the
-    agent picker, which filters on any-variant-downloaded.
+    id, but only counts when corroborated by at least one of:
+
+    - a file under ``downloaded_files`` whose path contains this manifest id
+      (the new shared layout from #430 puts files at
+      ``~/models/<backend>/<family>/<manifest_id>/`` — any file there is
+      strong evidence the install really happened)
+    - a live backend that advertises this manifest id
+
+    Pure registry breadcrumbs without disk or live-backend evidence are
+    treated as stale and NOT marked downloaded. johny saw a bunch of
+    models showing as installed on a fresh install because the registry
+    had stale entries from earlier sessions; that bypass is closed here.
     """
     downloaded_filenames = {d["filename"] for d in downloaded_files}
     live_models = live_models or []
+
+    # Corroboration check for registry_installed — does this manifest have
+    # at least one file on disk or one live-backend hit somewhere? Used
+    # below in place of an unconditional registry_installed OR.
+    manifest_id_lower = (manifest.id or "").lower()
+    has_disk_evidence = any(
+        manifest_id_lower in (d.get("relative_path", d.get("filename", "")) or "").lower()
+        for d in downloaded_files
+    )
+    has_live_evidence = any(
+        manifest_id_lower in ((m.get("name") or m.get("id") or "").lower().replace("_", "-"))
+        for m in live_models
+    )
+    registry_corroborated = bool(
+        registry_installed and (has_disk_evidence or has_live_evidence)
+    )
 
     variants = []
     for v in manifest.variants:
@@ -230,7 +250,7 @@ def _model_to_dict(
             _matches_live_backend(manifest.id, v, live_models)
             or expected_filename in downloaded_filenames
             or _is_service_installed(v)
-            or registry_installed
+            or registry_corroborated
         )
         compat = _variant_compatibility(v, hardware_profile)
         variants.append({

--- a/tinyagentos/routes/store.py
+++ b/tinyagentos/routes/store.py
@@ -35,10 +35,27 @@ def _build_app_items(registry, profile_id: str, type_filter: str | None = None, 
     registry cache with the live BackendCatalog; callers that pass it
     get accurate 'installed' state for services and models. Passing
     ``None`` falls back to the registry cache only (tests and early
-    startup paths)."""
+    startup paths).
+
+    "Installed" here means actually-usable-right-now or in-cache-with-no-
+    probe-surface (agents/plugins). ``stale`` cache entries — services
+    whose backends are unreachable, models whose files no longer exist —
+    are deliberately excluded from the installed set so the user sees
+    them as installable rather than as a permanent "Installed (broken)"
+    state with no working uninstall. johny flagged this on #312/#356:
+    Ollama / Open WebUI / rk-llama.cpp etc were showing as installed
+    when he hadn't actually installed them, blocking him from installing
+    them legitimately.
+    """
     apps = registry.list_available(type_filter=type_filter or None)
     if installation is not None:
-        installed_ids = {entry["id"] for entry in installation.list_installed()}
+        # Filter out stale entries — only entries the live probe says are
+        # running, or no-probe-surface types (agent/plugin) that the cache
+        # alone is authoritative for.
+        installed_ids = {
+            entry["id"] for entry in installation.list_installed()
+            if entry.get("state") in ("running", "installed")
+        }
     else:
         installed_ids = {a["id"] for a in registry.list_installed()}
     items = []
@@ -99,6 +116,15 @@ async def list_catalog(request: Request, type: str | None = None):
             })
         return out
 
+    def _installed_flag(app_id: str) -> bool:
+        # Match _build_app_items semantics: stale entries should NOT
+        # count as installed for the user-facing flag, otherwise the
+        # Store shows them as installed with a non-functional Uninstall
+        # button (johny's #312 complaint).
+        if installation is None:
+            return registry.is_installed(app_id)
+        return installation.state(app_id) in ("running", "installed")
+
     return [
         {
             "id": a.id, "name": a.name, "type": a.type, "category": a.category,
@@ -106,7 +132,7 @@ async def list_catalog(request: Request, type: str | None = None):
             "description": a.description, "icon": a.icon,
             "requires": a.requires, "hardware_tiers": a.hardware_tiers,
             "install_method": (a.install.get("method") or a.install.get("backend") or "") if isinstance(a.install, dict) else "",
-            "installed": (installation.is_installed(a.id) if installation else registry.is_installed(a.id)),
+            "installed": _installed_flag(a.id),
             "state": (installation.state(a.id) if installation else ("installed" if registry.is_installed(a.id) else "not_installed")),
             "variants": _slim_variants(a),
         }
@@ -265,9 +291,24 @@ async def resolve_model(request: Request):
 
 @router.post("/api/store/uninstall")
 async def uninstall_app(request: Request, body: UninstallRequest):
-    """Uninstall an installed app."""
+    """Uninstall an installed app.
+
+    Accepts either an actually-installed app (live or cached) OR a stale
+    cache entry. johny saw the catalog show items as installed (via the
+    joined live+cache view) and then the uninstall route reject them as
+    "not installed" (cache-only check). Use the same joined view here so
+    the two endpoints agree, AND fall through to mark_uninstalled even
+    when the live probe says the service is gone — cleaning the
+    breadcrumb is exactly what the user wants in that case.
+    """
     registry = request.app.state.registry
-    if not registry.is_installed(body.app_id):
+    installation = getattr(request.app.state, "installation_state", None)
+    is_known = (
+        installation.is_installed(body.app_id)
+        if installation is not None
+        else registry.is_installed(body.app_id)
+    )
+    if not is_known:
         return JSONResponse({"error": f"App '{body.app_id}' not installed"}, status_code=404)
 
     manifest = registry.get(body.app_id)


### PR DESCRIPTION
johny on [#312 reply 16:21](https://github.com/jaylfc/tinyagentos/discussions/312#discussioncomment-16854745) (and related [#356](https://github.com/jaylfc/tinyagentos/issues/356#issuecomment-4407844837)) reported that **Ollama, Open WebUI, rk-llama.cpp, and various models he'd never installed** were showing as "Installed" in the Store. Clicking Uninstall returned "not installed".

## Root cause: three sources of truth disagreeing

| # | Endpoint | Bug |
|---|---|---|
| 1 | \`/api/store/catalog\` (\`_build_app_items\`) | Set \`installed: true\` for any entry the joined live+cache view returned — including \`stale\` entries (cache says installed but live probe can't reach the service). The Uninstall button rendered for those. |
| 2 | \`/api/store/uninstall\` | Only consulted the registry cache (\`registry.is_installed\`), not the joined view — so its check disagreed with what the catalog reported. Different sources of truth → 404 mismatches. |
| 3 | \`/api/models\` (regression from #429) | Honored \`registry_installed\` unconditionally. A manifest in \`installed.json\` with no disk file and no live backend serving it still got \`has_downloaded_variant: true\`. Stale models leaked through the same way. |

## Fix

| Layer | Change |
|---|---|
| \`_build_app_items\` + inline catalog | \`installed\` is computed from state. \`stale\` → not installed. \`running\` and \`installed\` (no-probe-surface types) → installed. State field still emitted so the UI can later render "Installed (offline)" explicitly. |
| \`/api/store/uninstall\` | Uses the joined view to decide whether to proceed; falls through to \`mark_uninstalled\` even when the live probe says the service is gone. No more 404 mismatches. |
| \`/api/models\` | Adds a corroboration check: \`registry_installed\` only counts when there's at least one file on disk whose path contains the manifest id OR a live backend that names it. Pure breadcrumbs without evidence are skipped. |

## Test plan
- [x] Existing \`test_registry_installed_marks_downloaded\` split into two: one providing disk evidence (keeps the gemma-4-on-Pi flow working), one asserting pure-breadcrumb-only is no longer enough.
- [x] All other tests in \`test_routes_models.py\` and \`test_config_auto_register.py\` pass.
- [ ] Live: johny pulls master, restarts, opens the Store. Ollama / Open WebUI etc no longer show as installed; Install buttons reappear.

---
_Closes one of four issues from johny's #312 reply. Memory step ollama-only default + duplicate provider entries are next._