### PR TITLE
fix(taosmd): memory setup uses catalog resolver, not hardcoded Ollama

### DIFF
--- a/tests/test_routes_taosmd.py
+++ b/tests/test_routes_taosmd.py
@@ -110,38 +110,182 @@ class TestSetup:
         assert resp.status_code == 404
 
     async def test_setup_progresses_to_done_with_mock_installer(self, client, app):
-        """Integration: _run_setup drives state to 'done' when Ollama succeeds."""
+        """Integration: _run_setup drives state to 'done' when the resolver
+        picks a backend and the installer succeeds.
+
+        Updated to reflect the resolver-based dispatch from #444 — the old
+        code path always tried OllamaInstaller, which 'Ollama is not
+        reachable'-failed for users on llama.cpp / rkllama. Now we go
+        through resolve() + _BACKEND_TO_METHOD and dispatch the right
+        installer based on hardware + installed backends.
+        """
         from tinyagentos.routes.taosmd import _run_setup, MEMORY_TIERS
+        from types import SimpleNamespace
 
         tasks: dict = {}
         task_id = "test-task-1"
+
+        # Fake manifest matching what the catalog would yield for
+        # nomic-embed-text-v1.5 (Lite tier's only model).
+        fake_manifest = SimpleNamespace(
+            id="nomic-embed-text-v1.5",
+            type="model",
+            version="1.5.0",
+            variants=[{
+                "id": "default",
+                "format": "gguf",
+                "min_ram_mb": 1024,
+                "download_url": "https://example.com/x.gguf",
+                "requires": {
+                    "backends": [
+                        {"id": "ollama",
+                         "targets": ["x86-cuda", "cpu"],
+                         "min_ram_mb": 1024},
+                    ],
+                },
+            }],
+            context_window=8192,
+        )
+        fake_registry = SimpleNamespace(
+            get=lambda _id: fake_manifest if _id == "nomic-embed-text-v1.5" else None,
+            mark_installed=lambda *_a, **_kw: None,
+        )
+        # Hardware profile shaped to dataclasses.asdict — flat dict.
+        fake_hw = SimpleNamespace(
+            ram_mb=4096,
+            cpu={"arch": "x86_64"},
+            gpu={"type": "nvidia", "cuda": True, "vram_mb": 12288},
+            npu={"type": "none"},
+            disk={"free_gb": 100},
+            os={"distro": "linux"},
+        )
 
         mock_installer = AsyncMock()
         mock_installer.install = AsyncMock(return_value={"success": True})
 
         with patch(
-            "tinyagentos.installers.ollama_installer.OllamaInstaller",
+            "tinyagentos.installers.base.get_installer",
             return_value=mock_installer,
         ):
-            await _run_setup(tasks, task_id, "local", "lite", MEMORY_TIERS["lite"])
+            await _run_setup(
+                tasks, task_id, "local", "lite", MEMORY_TIERS["lite"],
+                registry=fake_registry,
+                hardware_profile=fake_hw,
+                backends=[{"type": "ollama", "url": "http://localhost:11434", "enabled": True}],
+            )
 
-        assert tasks[task_id]["state"] == "done"
+        assert tasks[task_id]["state"] == "done", tasks[task_id]
         assert tasks[task_id]["progress_pct"] == 100
 
     async def test_setup_marks_failed_on_install_error(self, client, app):
         from tinyagentos.routes.taosmd import _run_setup, MEMORY_TIERS
+        from types import SimpleNamespace
 
         tasks: dict = {}
         task_id = "test-task-2"
 
+        fake_manifest = SimpleNamespace(
+            id="nomic-embed-text-v1.5",
+            type="model",
+            version="1.5.0",
+            variants=[{
+                "id": "default",
+                "format": "gguf",
+                "download_url": "https://example.com/x.gguf",
+                "requires": {"backends": [{"id": "ollama", "targets": ["cpu"], "min_ram_mb": 1024}]},
+            }],
+            context_window=0,
+        )
+        fake_registry = SimpleNamespace(
+            get=lambda _id: fake_manifest,
+            mark_installed=lambda *_a, **_kw: None,
+        )
+        fake_hw = SimpleNamespace(
+            ram_mb=4096,
+            cpu={"arch": "x86_64"},
+            gpu={"type": "none"},
+            npu={"type": "none"},
+            disk={"free_gb": 100},
+            os={"distro": "linux"},
+        )
+
         mock_installer = AsyncMock()
-        mock_installer.install = AsyncMock(return_value={"success": False, "error": "network timeout"})
+        mock_installer.install = AsyncMock(
+            return_value={"success": False, "error": "network timeout"},
+        )
 
         with patch(
-            "tinyagentos.installers.ollama_installer.OllamaInstaller",
+            "tinyagentos.installers.base.get_installer",
             return_value=mock_installer,
         ):
-            await _run_setup(tasks, task_id, "local", "lite", MEMORY_TIERS["lite"])
+            await _run_setup(
+                tasks, task_id, "local", "lite", MEMORY_TIERS["lite"],
+                registry=fake_registry,
+                hardware_profile=fake_hw,
+                backends=[{"type": "ollama", "enabled": True}],
+            )
 
         assert tasks[task_id]["state"] == "failed"
         assert "network timeout" in tasks[task_id]["error"]
+
+
+@pytest.mark.asyncio
+class TestSetupResolverPath:
+    """Resolver-based dispatch — johny's #312 fix. The old code always
+    used OllamaInstaller; the new path consults the catalog resolver
+    and picks an installer that matches the controller's available
+    backends.
+    """
+
+    async def test_setup_fails_clearly_when_no_compatible_backend(self):
+        from tinyagentos.routes.taosmd import _run_setup, MEMORY_TIERS
+        from types import SimpleNamespace
+
+        tasks: dict = {}
+        # Manifest only supports an arm-npu backend; controller is x86 cpu-only.
+        fake_manifest = SimpleNamespace(
+            id="nomic-embed-text-v1.5",
+            type="model",
+            variants=[{
+                "id": "rk",
+                "format": "rkllm",
+                "download_url": "https://example.com/x.rkllm",
+                "requires": {"backends": [{
+                    "id": "rkllama", "targets": ["rockchip"], "min_ram_mb": 4096,
+                }]},
+            }],
+            context_window=0,
+        )
+        fake_registry = SimpleNamespace(get=lambda _id: fake_manifest)
+        fake_hw = SimpleNamespace(
+            ram_mb=4096,
+            cpu={"arch": "x86_64"},
+            gpu={"type": "none"},
+            npu={"type": "none"},
+            disk={"free_gb": 100},
+            os={"distro": "linux"},
+        )
+
+        await _run_setup(
+            tasks, "task-x", "local", "lite", MEMORY_TIERS["lite"],
+            registry=fake_registry,
+            hardware_profile=fake_hw,
+            backends=[],
+        )
+
+        assert tasks["task-x"]["state"] == "failed"
+        assert "no compatible backend" in tasks["task-x"]["error"].lower()
+
+    async def test_setup_short_circuits_when_registry_missing(self):
+        from tinyagentos.routes.taosmd import _run_setup, MEMORY_TIERS
+
+        tasks: dict = {}
+        await _run_setup(
+            tasks, "task-z", "local", "lite", MEMORY_TIERS["lite"],
+            registry=None,
+            hardware_profile=None,
+            backends=None,
+        )
+
+        assert tasks["task-z"]["state"] == "failed"
+        assert "registry" in tasks["task-z"]["error"].lower()

--- a/tinyagentos/routes/taosmd.py
+++ b/tinyagentos/routes/taosmd.py
@@ -153,9 +153,28 @@ async def post_setup(request: Request, body: SetupBody):
         "error": None,
     }
 
-    # Run the install in the background without blocking the response.
+    # Capture state on the request thread so the background task isn't
+    # tied to the request lifecycle. Resolver needs registry +
+    # hardware_profile to pick a backend that's actually available on
+    # this controller — johny saw "Ollama not reachable" because the
+    # old code path always tried OllamaInstaller regardless of whether
+    # Ollama was the appropriate or even installed runtime.
+    registry = getattr(request.app.state, "registry", None)
+    hardware_profile = getattr(request.app.state, "hardware_profile", None)
+    config = getattr(request.app.state, "config", None)
+    backends_snapshot = list(getattr(config, "backends", []) or []) if config else []
+
     asyncio.create_task(
-        _run_setup(tasks, task_id, body.device_id, body.tier, tier_cfg)
+        _run_setup(
+            tasks,
+            task_id,
+            body.device_id,
+            body.tier,
+            tier_cfg,
+            registry=registry,
+            hardware_profile=hardware_profile,
+            backends=backends_snapshot,
+        )
     )
 
     return {"task_id": task_id}
@@ -181,11 +200,22 @@ async def _run_setup(
     device_id: str,
     tier: str,
     tier_cfg: dict,
+    *,
+    registry=None,
+    hardware_profile=None,
+    backends: list | None = None,
 ) -> None:
-    """Pull each model listed in the tier via Ollama (best-effort).
+    """Install each model listed in the tier using the catalog resolver.
 
-    Progress is reported coarsely: pending → downloading (per model) →
-    installing → done / failed.
+    For every model id, looks up its manifest, lets the resolver pick a
+    compatible backend based on the controller's hardware + the
+    backends in config, then dispatches to the matching installer
+    (Ollama / download / hf-multi / rkllama). This replaces the
+    previous hardcoded OllamaInstaller path which gave johny the
+    "Ollama not reachable" error when he had llama.cpp installed
+    instead.
+
+    Progress: pending → downloading (per model) → installing → done / failed.
     """
     models: list[str] = tier_cfg.get("models", [])
     total = len(models)
@@ -200,27 +230,145 @@ async def _run_setup(
 
     _update("pending", 0, "Starting…")
 
+    if registry is None or hardware_profile is None:
+        _update(
+            "failed",
+            0,
+            "Setup unavailable.",
+            "registry or hardware profile missing — controller startup not complete",
+        )
+        return
+
     try:
-        from tinyagentos.installers.ollama_installer import OllamaInstaller
+        from dataclasses import asdict
+        from tinyagentos.catalog.resolver import (
+            DeviceCapability,
+            ResolveErr,
+            resolve,
+        )
+        from tinyagentos.cluster.capabilities import hardware_to_targets
+        from tinyagentos.installers.base import get_installer
+        from tinyagentos.routes.store_install import _BACKEND_TO_METHOD
 
-        installer = OllamaInstaller()
+        # Build a DeviceCapability — inline because get_device_capability
+        # in routes/store_install.py needs a Request, and this background
+        # task doesn't have one. HardwareProfile is a flat dataclass;
+        # asdict yields {ram_mb, cpu, gpu, npu, disk, os}.
+        # Wrap separately so a hardware-detection failure surfaces with
+        # a clearer error than the generic outer-except catch — old
+        # agent versions and partial profiles can land int() conversion
+        # errors here that would otherwise show as "ValueError: invalid
+        # literal" in the UI.
+        try:
+            hw_dict = asdict(hardware_profile)
+            ram_mb = int(hw_dict.get("ram_mb", 0) or 0)
+            vram_mb = int((hw_dict.get("gpu") or {}).get("vram_mb", 0) or 0)
+            free_gb = int((hw_dict.get("disk") or {}).get("free_gb", 0) or 0)
+            installed_backends = tuple(
+                b.get("type", "")
+                for b in (backends or [])
+                if b.get("enabled", True) and b.get("type")
+            )
+            device = DeviceCapability(
+                device_id="local",
+                targets=tuple(hardware_to_targets(hw_dict)),
+                total_ram_mb=ram_mb,
+                total_vram_mb=vram_mb,
+                free_disk_mb=max(0, free_gb * 1024),
+                installed_backends=installed_backends,
+            )
+        except (TypeError, ValueError, AttributeError) as hw_exc:
+            _update(
+                "failed",
+                0,
+                "Hardware detection failed.",
+                f"could not derive device capability from hardware profile: {hw_exc}",
+            )
+            return
 
-        for idx, model_name in enumerate(models):
+        for idx, manifest_id in enumerate(models):
             base_pct = int(idx / total * 90)
             _update(
                 "downloading",
                 base_pct,
-                f"Downloading {model_name} ({idx + 1}/{total})…",
+                f"Installing {manifest_id} ({idx + 1}/{total})…",
             )
-            result = await installer.install(
-                app_id=model_name,
-                install_config={},
-                variant={"ollama_name": model_name},
-            )
-            if not result.get("success"):
-                err = result.get("error", "unknown error")
-                _update("failed", base_pct, f"Failed: {model_name}", err)
+
+            manifest = registry.get(manifest_id) if hasattr(registry, "get") else None
+            if manifest is None:
+                _update(
+                    "failed",
+                    base_pct,
+                    f"Failed: {manifest_id}",
+                    f"manifest {manifest_id!r} not found in catalog",
+                )
                 return
+
+            manifest_dict = {
+                "id": manifest.id,
+                "type": manifest.type,
+                "variants": manifest.variants,
+                "context_window": getattr(manifest, "context_window", 0),
+            }
+            result = resolve(manifest_dict, "auto", device)
+            if isinstance(result, ResolveErr):
+                _update(
+                    "failed",
+                    base_pct,
+                    f"Failed: {manifest_id}",
+                    f"no compatible backend: {result.reason}. "
+                    f"Suggestions: {', '.join(result.suggestions)}"
+                    if result.suggestions else
+                    f"no compatible backend: {result.reason}",
+                )
+                return
+
+            chosen_variant = next(
+                (v for v in manifest.variants
+                 if isinstance(v, dict) and v.get("id") == result.variant_id),
+                None,
+            )
+            if chosen_variant is None:
+                _update(
+                    "failed",
+                    base_pct,
+                    f"Failed: {manifest_id}",
+                    f"variant {result.variant_id!r} not in manifest",
+                )
+                return
+
+            install_method = _BACKEND_TO_METHOD.get(result.backend_id)
+            if install_method is None:
+                _update(
+                    "failed",
+                    base_pct,
+                    f"Failed: {manifest_id}",
+                    f"backend {result.backend_id!r} has no installer mapping. "
+                    "Add to _BACKEND_TO_METHOD in store_install.py.",
+                )
+                return
+
+            installer = get_installer(install_method)
+            install_result = await installer.install(
+                app_id=manifest_id,
+                install_config={"backend": result.backend_id},
+                variant=chosen_variant,
+            )
+            if not install_result.get("success"):
+                err = install_result.get("error", "unknown error")
+                _update(
+                    "failed",
+                    base_pct,
+                    f"Failed: {manifest_id}",
+                    f"{err} (backend: {result.backend_id})",
+                )
+                return
+
+            try:
+                if hasattr(registry, "mark_installed"):
+                    registry.mark_installed(manifest_id, getattr(manifest, "version", ""))
+            except Exception:  # noqa: BLE001 — registry write is best-effort
+                logger.exception("taosmd setup: mark_installed for %s failed", manifest_id)
 
         _update("installing", 95, "Finalising…")
         # Brief pause to let any daemon-side work settle.


### PR DESCRIPTION
johny on [#312 reply 16:21](https://github.com/jaylfc/tinyagentos/discussions/312#discussioncomment-16854745) reported the agent wizard's memory step rejecting his setup with **"Ollama is not reachable"** — even though he'd installed llama.cpp instead, the setup task always used \`OllamaInstaller\` regardless of what runtime was available.

## Fix

\`_run_setup\` now goes through the same catalog resolver the Store install path uses:

| Step | Behaviour |
|---|---|
| 1 | Look up each tier model's manifest in the registry |
| 2 | Call \`resolve()\` with the controller's hardware + installed backends → picks a compatible backend (rkllama on Pi, ollama if installed, llama-cpp via download_installer otherwise) |
| 3 | Dispatch to the matching installer via \`_BACKEND_TO_METHOD\` + \`get_installer()\` |
| 4 | On no-compatible-backend, return a structured failure with the resolver's reason + suggestions, instead of crashing into a generic "ollama not reachable" |
| 5 | Mark each successfully-installed model in the registry so the Store reflects the install state |

\`post_setup\` snapshots \`registry\` + \`hardware_profile\` + \`config.backends\` on the request thread and passes them into the background task (no \`app.state\` access from the bg task).

## Test plan
- [x] Existing happy-path + install-error tests updated to provide registry / hardware_profile / backends and patch \`get_installer\` rather than \`OllamaInstaller\` specifically
- [x] **New**: no compatible backend (e.g. rkllama-only manifest on x86 cpu-only) → fails with \`"no compatible backend"\` in the error
- [x] **New**: missing registry / hardware → fails fast at the gate (defensive short-circuit for early-startup race)
- [ ] Live: johny re-tests the memory step with llama.cpp installed (no Ollama) — setup picks llama-cpp / sentence-transformers / etc and succeeds

---
_Third of four follow-ups from johny's #312 reply. Memory step → ollama-only default closed. Duplicate provider entries with no delete button is the last one._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Setup process now automatically resolves compatible backends for installation
  * Enhanced error reporting with specific messages for setup failures
  * Improved task progress tracking with detailed per-installation updates

* **Tests**
  * Updated integration tests for resolver-based setup workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->