### PR TITLE
fix(providers): dedupe at startup + always allow delete for non-transitional

### DIFF
--- a/desktop/src/apps/ProvidersApp.tsx
+++ b/desktop/src/apps/ProvidersApp.tsx
@@ -839,7 +839,13 @@ function ProviderDetail({
               <RefreshCw size={13} className={testing ? "animate-spin" : ""} />
               {testing ? "Testing..." : "Test"}
             </Button>
-            {(!isLocal || lifecycleState === "running" || !provider.lifecycle_state) && (
+            {/* Edit + Delete: previously hidden for local providers in any
+                non-running lifecycle state, which trapped johny on #312
+                with stopped rkllama entries that couldn't be removed.
+                Now hide ONLY during transitional moments (starting /
+                stopping) to avoid mid-operation surprises; running and
+                stopped both allow Edit/Delete. */}
+            {!isTransitional && (
               <>
                 <Button size="sm" variant="outline" onClick={onEdit} aria-label={`Edit provider ${provider.name}`}>
                   <Edit size={13} />

--- a/tests/test_routes_providers.py
+++ b/tests/test_routes_providers.py
@@ -40,6 +40,26 @@ class TestProviderAPI:
         })
         assert resp.status_code == 409
 
+    async def test_add_duplicate_by_type_and_url(self, client):
+        """Two providers with different names but the same (type, url) is
+        always wrong — they'd point at the same backend and the picker /
+        lifecycle logic can't disambiguate. johny on #312 saw two rkllama
+        entries because this case wasn't blocked.
+        """
+        first = await client.post("/api/providers", json={
+            "name": "rkllama-one", "type": "rkllama",
+            "url": "http://localhost:8080", "priority": 1,
+        })
+        assert first.status_code == 200
+        second = await client.post("/api/providers", json={
+            "name": "rkllama-two", "type": "rkllama",
+            "url": "http://localhost:8080", "priority": 2,
+        })
+        assert second.status_code == 409
+        body = second.json()
+        assert "rkllama" in body.get("error", "").lower()
+        assert "already exists" in body.get("error", "").lower()
+
     async def test_add_kilocode_autofills_url_and_models(self, client, app):
         """Kilocode add form only collects name + api_key — server must fill
         the canonical base URL and a routable model list (from live probe,

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -147,6 +147,44 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
             shutil.copy2(example, config_path)
     config = load_config(config_path)
 
+    # Sweep config.backends for duplicates accumulated over restarts —
+    # auto-register and the manual /api/providers POST both write here,
+    # and a manifest id rename or repeated registration could land two
+    # entries that share (type, url) or even share name. johny saw this
+    # on #312 with two rkllama entries and no way to remove them. Dedupe
+    # by name first, then by (type, url) tuple — persist the cleaned
+    # list so the file matches what we serve.
+    if config.backends:
+        seen_names: set[str] = set()
+        seen_url_type: set[tuple[str, str]] = set()
+        deduped: list[dict] = []
+        for b in config.backends:
+            name = b.get("name") or ""
+            url = b.get("url") or ""
+            btype = b.get("type") or ""
+            url_type_key = (btype, url) if url and btype else None
+            if name and name in seen_names:
+                logger.warning(
+                    "config.backends: dropping duplicate-by-name entry %r", name,
+                )
+                continue
+            if url_type_key and url_type_key in seen_url_type:
+                logger.warning(
+                    "config.backends: dropping duplicate-by-(type,url) entry "
+                    "name=%r type=%r url=%r",
+                    name, btype, url,
+                )
+                continue
+            if name:
+                seen_names.add(name)
+            if url_type_key:
+                seen_url_type.add(url_type_key)
+            deduped.append(b)
+        if len(deduped) != len(config.backends):
+            config.backends = deduped
+            if config.config_path and config.config_path.exists():
+                save_config(config, config.config_path)
+
     # Hardware profile drives auto-registration: a service whose manifest
     # declares e.g. ``arm-npu-*: full`` and ``x86-cuda-*: unsupported``
     # shouldn't be added as a backend on an x86 controller (rk-llama.cpp

--- a/tinyagentos/routes/providers.py
+++ b/tinyagentos/routes/providers.py
@@ -397,6 +397,23 @@ async def add_provider(request: Request, body: ProviderCreate):
         entry["url"] = PROVIDER_URL_DEFAULTS[entry["type"]]
     if not entry.get("url"):
         return JSONResponse({"error": "URL required for this provider type"}, status_code=400)
+    # Reject (type, url) duplicates too — johny on #312 ended up with two
+    # rkllama provider entries (different names, same type+url) because
+    # the existing check only looked at name. Two providers pointing at
+    # the same URL is never useful and confuses the picker / lifecycle
+    # logic.
+    if any(
+        b.get("type") == entry.get("type") and b.get("url") == entry.get("url")
+        for b in config.backends
+    ):
+        return JSONResponse(
+            {"error": (
+                f"A provider for {entry.get('type')!r} at {entry.get('url')!r} "
+                "already exists. Edit it from the Providers list rather than adding "
+                "another."
+            )},
+            status_code=409,
+        )
     # Auto-discover models for cloud providers when the caller didn't
     # supply any. Keeps the path generic across openai/anthropic/
     # openrouter/kilocode — each exposes an OpenAI-shaped {url}/models.


### PR DESCRIPTION
johny on [#312 reply 16:21](https://github.com/jaylfc/tinyagentos/discussions/312#discussioncomment-16854745) had **two rkllama provider entries** he couldn't remove. Two distinct bugs combined.

## Bug 1 — `config.backends` had no dedupe at startup

Both \`auto_register_from_manifest\` and \`POST /api/providers\` write to \`config.backends\`. Across restarts a manifest id rename or repeated registration could leave entries that share \`name\` OR \`(type, url)\` and they accumulated.

**Fix:** \`create_app()\` sweeps \`config.backends\` on load — drops duplicate-by-name and duplicate-by-(type, url), persists the cleaned list. Loud warning per drop.

## Bug 2 — UI hid Edit/Delete for non-running local providers

The gate was \`(!isLocal || lifecycleState === "running" || !provider.lifecycle_state)\`. A **stopped** or never-started local entry was unremovable through the UI.

**Fix:** \`ProvidersApp\` gates Edit/Delete on \`!isTransitional\` instead. Stopped and running both allow user action; only mid-transition states (starting / draining / stopping) hide the buttons.

## Defence in depth — `POST /api/providers`

The existing duplicate-by-name check is now joined by a duplicate-by-(type, url) check that returns 409 with a helpful error message — stops new dupes ever entering \`config.backends\` in the first place.

## Test plan
- [x] New \`test_add_duplicate_by_type_and_url\` — two providers with different names but same \`(type, url)\` → 409
- [x] Existing \`test_add_duplicate_provider\` (by name) still passes
- [ ] Live: johny's stale rkllama dupes get cleaned at next controller startup; Delete button returns on stopped entries

---
_Fourth and final follow-up from johny's #312 reply. Issues 1-3 already merged: #441 (local providers in picker), #442 (auto-register hardware-compat gate), #443 (stale registry no longer "installed"), #444 (memory wizard resolver, not Ollama-only)._