### PR TITLE
fix(tests): unbreak master CI — taosmd HardwareProfile + providers dedupe

### DIFF
--- a/tests/test_routes_providers.py
+++ b/tests/test_routes_providers.py
@@ -48,12 +48,12 @@ class TestProviderAPI:
         """
         first = await client.post("/api/providers", json={
             "name": "rkllama-one", "type": "rkllama",
-            "url": "http://localhost:8080", "priority": 1,
+            "url": "http://localhost:18080", "priority": 1,
         })
         assert first.status_code == 200
         second = await client.post("/api/providers", json={
             "name": "rkllama-two", "type": "rkllama",
-            "url": "http://localhost:8080", "priority": 2,
+            "url": "http://localhost:18080", "priority": 2,
         })
         assert second.status_code == 409
         body = second.json()

--- a/tests/test_routes_taosmd.py
+++ b/tests/test_routes_taosmd.py
@@ -5,6 +5,14 @@ import asyncio
 import pytest
 from unittest.mock import AsyncMock, patch
 
+from tinyagentos.hardware import (
+    CpuInfo,
+    DiskInfo,
+    GpuInfo,
+    HardwareProfile,
+    NpuInfo,
+    OsInfo,
+)
 from tinyagentos.routes.taosmd import MEMORY_TIERS
 
 
@@ -150,14 +158,13 @@ class TestSetup:
             get=lambda _id: fake_manifest if _id == "nomic-embed-text-v1.5" else None,
             mark_installed=lambda *_a, **_kw: None,
         )
-        # Hardware profile shaped to dataclasses.asdict — flat dict.
-        fake_hw = SimpleNamespace(
+        fake_hw = HardwareProfile(
             ram_mb=4096,
-            cpu={"arch": "x86_64"},
-            gpu={"type": "nvidia", "cuda": True, "vram_mb": 12288},
-            npu={"type": "none"},
-            disk={"free_gb": 100},
-            os={"distro": "linux"},
+            cpu=CpuInfo(arch="x86_64"),
+            gpu=GpuInfo(type="nvidia", cuda=True, vram_mb=12288),
+            npu=NpuInfo(type="none"),
+            disk=DiskInfo(free_gb=100),
+            os=OsInfo(distro="linux"),
         )
 
         mock_installer = AsyncMock()
@@ -200,13 +207,13 @@ class TestSetup:
             get=lambda _id: fake_manifest,
             mark_installed=lambda *_a, **_kw: None,
         )
-        fake_hw = SimpleNamespace(
+        fake_hw = HardwareProfile(
             ram_mb=4096,
-            cpu={"arch": "x86_64"},
-            gpu={"type": "none"},
-            npu={"type": "none"},
-            disk={"free_gb": 100},
-            os={"distro": "linux"},
+            cpu=CpuInfo(arch="x86_64"),
+            gpu=GpuInfo(type="none"),
+            npu=NpuInfo(type="none"),
+            disk=DiskInfo(free_gb=100),
+            os=OsInfo(distro="linux"),
         )
 
         mock_installer = AsyncMock()
@@ -257,13 +264,13 @@ class TestSetupResolverPath:
             context_window=0,
         )
         fake_registry = SimpleNamespace(get=lambda _id: fake_manifest)
-        fake_hw = SimpleNamespace(
+        fake_hw = HardwareProfile(
             ram_mb=4096,
-            cpu={"arch": "x86_64"},
-            gpu={"type": "none"},
-            npu={"type": "none"},
-            disk={"free_gb": 100},
-            os={"distro": "linux"},
+            cpu=CpuInfo(arch="x86_64"),
+            gpu=GpuInfo(type="none"),
+            npu=NpuInfo(type="none"),
+            disk=DiskInfo(free_gb=100),
+            os=OsInfo(distro="linux"),
         )
 
         await _run_setup(


### PR DESCRIPTION
## Summary
master CI has been red since PR #444 (taosmd) and PR #445 (providers) merged. Both shipped tests that were broken on the way in. Fixes both:

1. **PR #444 fallout** — `routes/taosmd.py` now calls `asdict(hardware_profile)`, but the three updated tests in `tests/test_routes_taosmd.py` kept passing `SimpleNamespace` stand-ins, which `asdict()` rejects. Tests now build real `HardwareProfile` / `CpuInfo` / `GpuInfo` / `NpuInfo` / `DiskInfo` / `OsInfo` instances. Production code is unchanged.
2. **PR #445 fallout** — the new `test_add_duplicate_by_type_and_url` POSTed a rkllama provider at `http://localhost:8080`, which is the URL `tests/conftest.py` already seeds into `config.backends`. The test's first POST collided with the fixture seed and returned 409, failing the very first assertion. Switched the test to port 18080.

## Test plan
- [x] `pytest tests/test_routes_taosmd.py tests/test_routes_providers.py -v` — 30 passed locally
- [ ] CI green on this PR
- [ ] master CI back to green after merge