### PR TITLE
feat(hardware): detect RKNPU via platform-driver dir and DRM render node

### DIFF
--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -1,8 +1,10 @@
 # tests/test_hardware.py
 import json
+from pathlib import Path
 import pytest
 from unittest.mock import patch
 from tinyagentos.hardware import detect_hardware, get_hardware_profile, HardwareProfile
+from tinyagentos import hardware as hardware_mod
 
 import pytest_asyncio
 
@@ -39,6 +41,74 @@ class TestDetectHardware:
         loaded = HardwareProfile.load(path)
         assert loaded.profile_id == profile.profile_id
         assert loaded.ram_mb == profile.ram_mb
+
+
+class TestDetectNpuRknpuModernPaths:
+    """Modern RK3588 BSP kernels don't always expose /dev/rknpu, debugfs, or
+    devfreq. Detection should still succeed via the platform-drivers bind
+    dir or the DRM render-node driver symlink."""
+
+    def _stub_environment(self, monkeypatch, exists_set, drm_nodes):
+        """Stub filesystem probes so _detect_npu sees only the configured
+        signals. exists_set: set of str paths that _path_exists_safe should
+        report present. drm_nodes: list of (renderD_path, driver_basename)
+        tuples to expose under /sys/class/drm."""
+        def fake_exists_safe(p):
+            return str(p) in exists_set
+        monkeypatch.setattr(hardware_mod, "_path_exists_safe", fake_exists_safe)
+
+        real_glob = Path.glob
+        def fake_glob(self, pattern):
+            if str(self) == "/sys/class/drm" and pattern == "renderD*":
+                return iter([Path(node) for node, _ in drm_nodes])
+            if str(self) == "/dev":
+                return iter([])
+            return real_glob(self, pattern)
+        monkeypatch.setattr(Path, "glob", fake_glob)
+
+        driver_targets = {
+            f"{node}/device/driver": basename for node, basename in drm_nodes
+        }
+        real_resolve = Path.resolve
+        def fake_resolve(self, *args, **kwargs):
+            key = str(self)
+            if key in driver_targets:
+                return Path(f"/sys/bus/platform/drivers/{driver_targets[key]}")
+            return real_resolve(self, *args, **kwargs)
+        monkeypatch.setattr(Path, "resolve", fake_resolve)
+
+        # Block /proc/device-tree/model and rknpu/load reads — force the
+        # core-count fallback path so tests don't depend on host files.
+        real_read_text = Path.read_text
+        def fake_read_text(self, *args, **kwargs):
+            if str(self) in (
+                "/proc/device-tree/model",
+                "/sys/kernel/debug/rknpu/load",
+            ):
+                raise OSError("stubbed")
+            return real_read_text(self, *args, **kwargs)
+        monkeypatch.setattr(Path, "read_text", fake_read_text)
+
+        # Neutralise lspci / non-rknpu accelerator probes.
+        monkeypatch.setattr(hardware_mod, "_run", lambda *a, **k: "")
+
+    def test_platform_drivers_dir_alone_detects_rknpu(self, monkeypatch):
+        self._stub_environment(
+            monkeypatch,
+            exists_set={"/sys/bus/platform/drivers/RKNPU"},
+            drm_nodes=[],
+        )
+        npu = hardware_mod._detect_npu()
+        assert npu.type == "rknpu"
+
+    def test_drm_render_node_driver_symlink_detects_rknpu(self, monkeypatch):
+        self._stub_environment(
+            monkeypatch,
+            exists_set=set(),
+            drm_nodes=[("/sys/class/drm/renderD129", "RKNPU")],
+        )
+        npu = hardware_mod._detect_npu()
+        assert npu.type == "rknpu"
 
 
 class TestGetHardwareProfile:

--- a/tinyagentos/hardware.py
+++ b/tinyagentos/hardware.py
@@ -196,6 +196,21 @@ def _path_exists_safe(p: Path) -> bool:
         return False
 
 
+def _drm_has_rknpu() -> bool:
+    """Return True if any /sys/class/drm renderD* node binds to the RKNPU driver."""
+    try:
+        for node in Path("/sys/class/drm").glob("renderD*"):
+            driver_link = node / "device" / "driver"
+            try:
+                if driver_link.resolve().name == "RKNPU":
+                    return True
+            except (OSError, RuntimeError):
+                continue
+    except OSError:
+        pass
+    return False
+
+
 def _detect_npu() -> NpuInfo:
     # Rockchip RKNPU — detect via multiple paths (driver exposes different interfaces per board)
     rknpu_paths = [
@@ -207,19 +222,7 @@ def _detect_npu() -> NpuInfo:
     # DRM render-node fallback: modern RK3588 BSP exposes the NPU as a render
     # node whose device/driver symlink resolves to RKNPU. Catches hosts where
     # devfreq isn't exposed and the platform-drivers dir isn't readable.
-    rknpu_drm = False
-    try:
-        for node in Path("/sys/class/drm").glob("renderD*"):
-            driver_link = node / "device" / "driver"
-            try:
-                if driver_link.resolve().name == "RKNPU":
-                    rknpu_drm = True
-                    break
-            except (OSError, RuntimeError):
-                continue
-    except OSError:
-        pass
-    if rknpu_drm or any(_path_exists_safe(p) for p in rknpu_paths):
+    if any(_path_exists_safe(p) for p in rknpu_paths) or _drm_has_rknpu():
         # Detect SoC variant — RK3588 has 3 cores at 6 TOPS, RK3576 has 1 core at 6 TOPS,
         # RK3568 has 1 core at 1 TOPS
         soc = ""

--- a/tinyagentos/hardware.py
+++ b/tinyagentos/hardware.py
@@ -202,8 +202,24 @@ def _detect_npu() -> NpuInfo:
         Path("/dev/rknpu"),
         Path("/sys/kernel/debug/rknpu/load"),  # debugfs — most reliable detection
         Path("/sys/class/devfreq/fdab0000.npu"),  # RK3588 NPU devfreq node
+        Path("/sys/bus/platform/drivers/RKNPU"),  # platform-driver bind dir on modern BSP kernels
     ]
-    if any(_path_exists_safe(p) for p in rknpu_paths):
+    # DRM render-node fallback: modern RK3588 BSP exposes the NPU as a render
+    # node whose device/driver symlink resolves to RKNPU. Catches hosts where
+    # devfreq isn't exposed and the platform-drivers dir isn't readable.
+    rknpu_drm = False
+    try:
+        for node in Path("/sys/class/drm").glob("renderD*"):
+            driver_link = node / "device" / "driver"
+            try:
+                if driver_link.resolve().name == "RKNPU":
+                    rknpu_drm = True
+                    break
+            except (OSError, RuntimeError):
+                continue
+    except OSError:
+        pass
+    if rknpu_drm or any(_path_exists_safe(p) for p in rknpu_paths):
         # Detect SoC variant — RK3588 has 3 cores at 6 TOPS, RK3576 has 1 core at 6 TOPS,
         # RK3568 has 1 core at 1 TOPS
         soc = ""


### PR DESCRIPTION
## Summary

`_detect_npu()` currently identifies Rockchip RKNPU through `/dev/rknpu`, the debugfs `load` file, and the RK3588 devfreq node. Real-world testing on an Orange Pi 5 Plus LXC showed two more reliable modern signals:

- `/sys/bus/platform/drivers/RKNPU` — platform-driver bind directory
- `/sys/class/drm/renderD<N>/device/driver` symlink resolving to `RKNPU`

Detection on the test host happened to succeed via the devfreq node, but a kernel built without devfreq exposure would silently fall through to `type="none"` despite the RKNPU driver being bound and usable. This PR adds both new signals and short-circuits them through the existing SoC-detect block so behaviour is unchanged on already-recognised hosts.

## Changes

- `tinyagentos/hardware.py`: extend `rknpu_paths` with `/sys/bus/platform/drivers/RKNPU`; inline DRM render-node fallback walks `/sys/class/drm/renderD*` and matches `device/driver` basename `RKNPU`.
- `tests/test_hardware.py`: two new unit tests covering the new signals via `monkeypatch` of `_path_exists_safe`, `Path.glob`, `Path.resolve`, and `Path.read_text` — neither requires a real Rockchip host.

No changes to Hailo / Coral / Axera / Apple / NVIDIA paths.

## Test plan

- [x] `python3 -m pytest tests/test_hardware.py::TestDetectNpuRknpuModernPaths -v` passes (2/2).
- [ ] CI green on master.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved RK NPU hardware detection with additional fallback detection methods.

* **Tests**
  * Enhanced test coverage for RK NPU hardware detection on modern systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->