### PR TITLE
chore: address post-merge bot review nitpicks (#423 + #425)

### DIFF
--- a/desktop/src/apps/StoreApp/IncompatibleToggle.tsx
+++ b/desktop/src/apps/StoreApp/IncompatibleToggle.tsx
@@ -1,5 +1,5 @@
 // desktop/src/apps/StoreApp/IncompatibleToggle.tsx
-import { useState, type ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { ChevronDown, ChevronUp, AlertCircle } from "lucide-react";
 
 interface Props {
@@ -17,6 +17,13 @@ interface Props {
 
 export function IncompatibleToggle({ count, compatibleCount = 1, children }: Props) {
   const [open, setOpen] = useState(compatibleCount === 0);
+  // compatibleCount can transition to 0 after mount when the user changes
+  // the device filter; without this the section stays collapsed and the
+  // empty-state CTA doesn't surface the dimmed list. Only auto-opens on
+  // the 0 transition — preserves user's choice in the other direction.
+  useEffect(() => {
+    if (compatibleCount === 0) setOpen(true);
+  }, [compatibleCount]);
 
   if (count === 0) return null;
 

--- a/tinyagentos/routes/providers.py
+++ b/tinyagentos/routes/providers.py
@@ -287,7 +287,7 @@ async def list_providers(request: Request):
         if (
             status == "ok"
             and not models
-            and backend.get("type") in ("openai", "anthropic", "openrouter", "kilocode", "openai-compatible")
+            and backend.get("type") in CLOUD_TYPES
         ):
             api_key = await _resolve_api_key_for_backend(request.app.state, backend)
             if api_key:


### PR DESCRIPTION
## Summary
Two small fixes from bot reviews on already-merged PRs:

- **#425 (providers re-probe)** — replace the inline `("openai", "anthropic", "openrouter", "kilocode", "openai-compatible")` tuple at `routes/providers.py:290` with the existing `CLOUD_TYPES` module constant. Same set, one source of truth.
- **#423 (IncompatibleToggle)** — `useState(compatibleCount === 0)` only ran once at mount, so when the user changed the device filter and `compatibleCount` transitioned to 0, the section stayed collapsed even though the prop docstring says the toggle should auto-open. Added a `useEffect` to open on the 0 transition; doesn't auto-close on the way back up so the user's explicit choice is preserved.

#418's manifest finding was a false positive — `mlc-llm/manifest.yaml` already has `type: service` at line 3.

## Test plan
- [x] `pytest tests/test_routes_providers.py -v` — 16 passed locally
- [ ] CI green