### PR TITLE
feat: publish taOS over mDNS as taos.local

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,10 @@ dependencies = [
     "websockets>=12.0",
     # Web Push VAPID signing — pulls in cryptography, http-ece, py-vapid
     "pywebpush>=1.14",
+    # mDNS/Bonjour publisher so the controller is reachable at
+    # http://taos.local:<port>/ on the LAN without users knowing its IP
+    # (tinyagentos/services/mdns_publisher.py).
+    "zeroconf>=0.140",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_mdns_publisher.py
+++ b/tests/test_mdns_publisher.py
@@ -48,6 +48,26 @@ async def test_stop_unregisters_then_closes(fake_zc):
 
 
 @pytest.mark.asyncio
+async def test_failed_register_closes_zeroconf_instance(monkeypatch):
+    """If async_register_service raises after AsyncZeroconf() is built,
+    the half-initialised instance must be closed — otherwise its sockets
+    and multicast subscriptions leak. Caught by kilo-code-bot on #449."""
+    monkeypatch.setattr(mp, "_detect_primary_ipv4", lambda: "192.168.1.42")
+    zc_instance = MagicMock()
+    zc_instance.async_register_service = AsyncMock(
+        side_effect=RuntimeError("port in use")
+    )
+    zc_instance.async_close = AsyncMock()
+    monkeypatch.setattr(mp, "AsyncZeroconf", MagicMock(return_value=zc_instance))
+
+    pub = MdnsPublisher(port=6969)
+    await pub.start()  # must not raise
+
+    assert zc_instance.async_close.await_count == 1
+    assert pub._active is False
+
+
+@pytest.mark.asyncio
 async def test_start_swallows_exceptions_and_stop_is_noop(monkeypatch):
     monkeypatch.setattr(mp, "_detect_primary_ipv4", lambda: "192.168.1.42")
 

--- a/tests/test_mdns_publisher.py
+++ b/tests/test_mdns_publisher.py
@@ -45,6 +45,11 @@ async def test_stop_unregisters_then_closes(fake_zc):
 
     assert zc_instance.async_unregister_service.await_count == 1
     assert zc_instance.async_close.await_count == 1
+    # Order matters — closing zeroconf before unregistering would drop the
+    # goodbye packet on the floor and leave stale records on the LAN until
+    # they age out (~75min). mock_calls accumulates across the instance.
+    names = [c[0] for c in zc_instance.mock_calls]
+    assert names.index("async_unregister_service") < names.index("async_close")
 
 
 @pytest.mark.asyncio

--- a/tests/test_mdns_publisher.py
+++ b/tests/test_mdns_publisher.py
@@ -1,0 +1,63 @@
+"""Tests for tinyagentos.services.mdns_publisher."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tinyagentos.services import mdns_publisher as mp
+from tinyagentos.services.mdns_publisher import MdnsPublisher
+
+
+@pytest.fixture
+def fake_zc(monkeypatch):
+    """Patch AsyncZeroconf and the IPv4 detector — no real sockets."""
+    zc_instance = MagicMock()
+    zc_instance.async_register_service = AsyncMock()
+    zc_instance.async_unregister_service = AsyncMock()
+    zc_instance.async_close = AsyncMock()
+    factory = MagicMock(return_value=zc_instance)
+    monkeypatch.setattr(mp, "AsyncZeroconf", factory)
+    monkeypatch.setattr(mp, "_detect_primary_ipv4", lambda: "192.168.1.42")
+    return zc_instance, factory
+
+
+@pytest.mark.asyncio
+async def test_start_registers_service_with_taos_local(fake_zc):
+    zc_instance, _ = fake_zc
+    pub = MdnsPublisher(port=6969)
+
+    await pub.start()
+
+    assert zc_instance.async_register_service.await_count == 1
+    info = zc_instance.async_register_service.await_args.args[0]
+    assert info.server == "taos.local."
+    assert info.port == 6969
+
+
+@pytest.mark.asyncio
+async def test_stop_unregisters_then_closes(fake_zc):
+    zc_instance, _ = fake_zc
+    pub = MdnsPublisher(port=6969)
+    await pub.start()
+
+    await pub.stop()
+
+    assert zc_instance.async_unregister_service.await_count == 1
+    assert zc_instance.async_close.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_start_swallows_exceptions_and_stop_is_noop(monkeypatch):
+    monkeypatch.setattr(mp, "_detect_primary_ipv4", lambda: "192.168.1.42")
+
+    def _boom(*_a, **_kw):
+        raise RuntimeError("multicast disabled")
+
+    monkeypatch.setattr(mp, "AsyncZeroconf", _boom)
+
+    pub = MdnsPublisher(port=6969)
+    await pub.start()  # must not raise
+
+    assert pub._active is False
+    await pub.stop()  # must be a no-op, must not raise

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -820,11 +820,31 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
             logger.exception("canvas snapshotter failed to start")
             app.state.canvas_snapshotter = None
 
+        # mDNS publisher — advertises http://taos.local:<port>/ on the LAN.
+        # Failure must never break startup; the publisher swallows its own
+        # errors but wrap it again here for belt-and-braces.
+        try:
+            from tinyagentos.services.mdns_publisher import MdnsPublisher
+            mdns_publisher = MdnsPublisher(port=config.server.get("port", 6969))
+            await mdns_publisher.start()
+            app.state.mdns_publisher = mdns_publisher
+        except Exception:
+            logger.exception("mdns publisher failed to start — continuing without")
+            app.state.mdns_publisher = None
+
         yield
         # NOTE: controller restart/shutdown does NOT touch agent containers —
         # agents and LiteLLM keep running independently, so there's nothing to
         # gracefully drain here. Only true system halt (system-shutdown) and
         # explicit agent pause/stop go through the orchestrator.
+        # Unregister mDNS first so the goodbye packet goes out before other
+        # services start tearing down (and potentially blocking the loop).
+        _mdns = getattr(app.state, "mdns_publisher", None)
+        if _mdns is not None:
+            try:
+                await _mdns.stop()
+            except Exception:
+                logger.exception("mdns publisher stop failed")
         adapter_manager.stop_all()
         for c in list(getattr(app.state, "channel_hub_connectors", {}).values()):
             await c.stop()

--- a/tinyagentos/services/mdns_publisher.py
+++ b/tinyagentos/services/mdns_publisher.py
@@ -1,0 +1,118 @@
+"""mDNS / Bonjour publisher for the taOS controller.
+
+Advertises the running HTTP server on the local network so users on the
+same LAN can browse to ``http://taos.local:<port>/`` (or discover taOS
+via any Bonjour service browser) without having to know the host's IP.
+
+Uses ``zeroconf.asyncio.AsyncZeroconf`` so registration runs on the event
+loop and does not block startup. The ``server`` field on
+:class:`zeroconf.ServiceInfo` is what makes ``taos.local`` resolve to the
+detected primary LAN IPv4.
+
+This is a *nice-to-have* — if multicast is disabled, a port is already
+bound by another responder, or anything else goes wrong, we log and move
+on. The controller's HTTP server is still reachable via its IP address.
+
+Coexists fine with a system avahi-daemon: multiple responders on the
+same multicast group is normal mDNS behaviour, not a conflict.
+
+If two taOS instances run on the same LAN both claiming ``taos.local``,
+zeroconf resolves the collision by suffixing the second one
+(``taos-2.local`` etc.). No special-case code needed here — the library
+handles it via ``allow_name_change``.
+"""
+from __future__ import annotations
+
+import logging
+import socket
+
+from zeroconf import ServiceInfo
+from zeroconf.asyncio import AsyncZeroconf
+
+logger = logging.getLogger(__name__)
+
+_SERVICE_TYPE = "_http._tcp.local."
+
+
+def _detect_primary_ipv4() -> str | None:
+    """Pick the LAN IPv4 the kernel would use for default-route traffic.
+
+    Opens a UDP socket "to" 8.8.8.8 and reads ``getsockname()`` — no
+    packets are actually sent, so this works fine on air-gapped
+    networks (the kernel still resolves the source interface).
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        sock.connect(("8.8.8.8", 80))
+        return sock.getsockname()[0]
+    except OSError as exc:
+        logger.warning("mDNS: could not detect primary LAN IPv4: %s", exc)
+        return None
+    finally:
+        sock.close()
+
+
+class MdnsPublisher:
+    """Publishes the controller as ``_http._tcp`` on the local network."""
+
+    def __init__(
+        self,
+        *,
+        hostname: str = "taos.local.",
+        service_name: str = "taOS",
+        port: int,
+    ) -> None:
+        self._hostname = hostname
+        self._service_name = service_name
+        self._port = port
+        self._zc: AsyncZeroconf | None = None
+        self._info: ServiceInfo | None = None
+        self._active = False
+
+    async def start(self) -> None:
+        """Register the service. Never raises into the caller."""
+        try:
+            ip = _detect_primary_ipv4()
+            if ip is None:
+                logger.warning(
+                    "mDNS: skipping publish — no LAN IPv4 detected"
+                )
+                return
+            info = ServiceInfo(
+                _SERVICE_TYPE,
+                f"{self._service_name}.{_SERVICE_TYPE}",
+                addresses=[socket.inet_aton(ip)],
+                port=self._port,
+                properties={"path": "/"},
+                server=self._hostname,
+            )
+            zc = AsyncZeroconf()
+            await zc.async_register_service(info, allow_name_change=True)
+            self._zc = zc
+            self._info = info
+            self._active = True
+            logger.info(
+                "mDNS: published %s at http://%s:%d/ (ip=%s)",
+                self._service_name,
+                self._hostname.rstrip("."),
+                self._port,
+                ip,
+            )
+        except Exception:
+            logger.exception("mDNS: publish failed — continuing without")
+            self._active = False
+
+    async def stop(self) -> None:
+        """Unregister and close. No-op if start() failed."""
+        if not self._active:
+            return
+        try:
+            if self._zc is not None and self._info is not None:
+                await self._zc.async_unregister_service(self._info)
+                await self._zc.async_close()
+        except Exception:
+            logger.exception("mDNS: stop failed")
+        finally:
+            self._active = False
+            self._zc = None
+            self._info = None

--- a/tinyagentos/services/mdns_publisher.py
+++ b/tinyagentos/services/mdns_publisher.py
@@ -87,7 +87,21 @@ class MdnsPublisher:
                 server=self._hostname,
             )
             zc = AsyncZeroconf()
-            await zc.async_register_service(info, allow_name_change=True)
+            try:
+                await zc.async_register_service(info, allow_name_change=True)
+            except Exception:
+                # async_register_service can raise after the AsyncZeroconf
+                # is constructed (port conflict, multicast disabled mid-init,
+                # etc.). Close the half-built instance so its sockets and
+                # multicast subscriptions don't leak; re-raise into the
+                # outer except for logging.
+                try:
+                    await zc.async_close()
+                except Exception:
+                    logger.exception(
+                        "mDNS: cleanup after failed register also failed"
+                    )
+                raise
             self._zc = zc
             self._info = info
             self._active = True

--- a/tinyagentos/services/mdns_publisher.py
+++ b/tinyagentos/services/mdns_publisher.py
@@ -41,15 +41,13 @@ def _detect_primary_ipv4() -> str | None:
     packets are actually sent, so this works fine on air-gapped
     networks (the kernel still resolves the source interface).
     """
-    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     try:
-        sock.connect(("8.8.8.8", 80))
-        return sock.getsockname()[0]
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+            sock.connect(("8.8.8.8", 80))
+            return sock.getsockname()[0]
     except OSError as exc:
         logger.warning("mDNS: could not detect primary LAN IPv4: %s", exc)
         return None
-    finally:
-        sock.close()
 
 
 class MdnsPublisher:


### PR DESCRIPTION
## Summary

Adds an mDNS / Bonjour publisher so the taOS controller advertises itself on the LAN. Users on the same network can now visit **`http://taos.local:6969/`** in any browser instead of needing to look up the host's IP, and the service shows up in Bonjour browsers under `_http._tcp` as `taOS`.

- New `tinyagentos/services/mdns_publisher.py` (`MdnsPublisher` class, ~110 lines) using `zeroconf.asyncio.AsyncZeroconf`.
- Wired into the existing `lifespan` in `tinyagentos/app.py`: started just before `yield`, stopped as the *first* shutdown step so the mDNS goodbye packet goes out before other services start tearing down.
- New dep: `zeroconf>=0.140` (pure Python, no system packages required).

## Behaviour notes

- **avahi coexistence:** zeroconf is a userland responder on the same multicast group as avahi-daemon. Multiple responders on one group is normal mDNS — no conflict, no extra config.
- **Name collisions:** if a second taOS instance starts on the same LAN both claiming `taos.local`, zeroconf resolves it via `allow_name_change=True` and the loser registers as `taos-2.local`. No special-case code in this PR.
- **Resilience:** the publisher is a nice-to-have, not critical path. If multicast is disabled, the LAN IP can't be detected, or registration fails for any reason, the error is logged and startup continues. The HTTP server is still reachable on its IP.
- **No system deps:** install path unchanged; `pip install` of the wheel pulls `zeroconf` automatically. No `apt install avahi-daemon` needed.

## Test plan

- [x] `python3 -m pytest tests/test_mdns_publisher.py -v` — 3 passed
- [x] `python3 -c "from tinyagentos.app import create_app; print('ok')"` — clean import
- [ ] CI green on this branch
- [ ] Manual: deploy to Pi, visit `http://taos.local:6969/` from a phone/laptop on the same Wi-Fi, confirm it loads the desktop SPA
- [ ] Manual: open a Bonjour browser (e.g. macOS `dns-sd -B _http._tcp local.`), confirm `taOS` entry appears, and disappears within a few seconds of stopping the controller

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The taOS controller is now automatically discoverable on your local network via mDNS/Bonjour at taos.local, so you don't need its IP.
  * Network discovery starts automatically on launch and is stopped on shutdown; startup/shutdown tolerate discovery errors without blocking the app.

* **Tests**
  * Added tests covering network discovery behavior and error handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jaylfc/tinyagentos/pull/449)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->