### PR TITLE
fix(messages): make conversation text selectable

### DIFF
--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -1565,11 +1565,13 @@ export function MessagesApp({
             )}
           </div>
 
-          {/* message list */}
+          {/* message list — explicitly selectable. Most app shells set
+              `select-none` for the native-OS feel; Messages is the exception
+              where users expect to copy conversation text, so opt back in. */}
           <div
             ref={messageListRef}
             onScroll={handleScroll}
-            className={`flex-1 overflow-y-auto px-4 py-3 space-y-0.5 message-list-drop-target ${
+            className={`flex-1 overflow-y-auto px-4 py-3 space-y-0.5 select-text message-list-drop-target ${
               shellFileDropTarget.isOver
                 ? "ring-2 ring-sky-400/60 ring-inset bg-sky-500/5"
                 : shellFileDropTarget.isValidTarget


### PR DESCRIPTION
## Problem

Reported in #455 (@johny-mnemonic): text in the Messages app can't be selected — neither your own messages nor agent replies.

## Root cause

Most app shells in the desktop deliberately set \`select-none\` for a native-OS feel (Models, Providers, Library, Channels, …). The Messages app relied on the *absence* of that class to stay selectable, rather than opting in explicitly. That's fragile — any \`select-none\` added to an ancestor silently makes conversation text unselectable, and it leaves intent unclear.

## Fix

Add \`select-text\` to the message-list container so message content is selectable **by design** and resilient to future shell changes. One line + an explanatory comment; device-agnostic (same content component on desktop and mobile).

## Verification

- \`tsc -b\` clean.
- Visual confirmation (selecting/copying message text) to be done on a running instance.

Closes #455

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Users can now select and copy text from conversations in the Messages app. Text selection is now enabled in the message list, allowing you to highlight and copy conversation text as needed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jaylfc/tinyagentos/pull/457?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->