### PR TITLE
fix(agents): terminal shortcuts fail to connect (open PTY endpoint, not /redeem)

### DIFF
--- a/desktop/src/apps/AgentsApp.tsx
+++ b/desktop/src/apps/AgentsApp.tsx
@@ -36,6 +36,8 @@ import { AgentShortcutRow } from "@/components/AgentShortcutRow";
 import type { AgentShortcut } from "@/hooks/use-agent-shortcuts";
 import { useProcessStore } from "@/stores/process-store";
 import { getApp } from "@/registry/app-registry";
+import { useNotificationStore } from "@/stores/notification-store";
+import { deriveTerminalShortcutTarget } from "./shortcut-launch";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -2302,22 +2304,52 @@ export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
   }
 
   const handleShortcutLaunch = useCallback(async (agentId: string, shortcut: AgentShortcut) => {
-    const res = await fetch(
-      `/api/agents/${encodeURIComponent(agentId)}/shortcuts/${shortcut.idx}/launch`,
-      { method: "POST", headers: { Accept: "application/json" } }
-    );
-    if (!res.ok) return;
+    const failed = (body: string) =>
+      useNotificationStore.getState().addNotification({
+        source: agentId,
+        title: `Couldn't open ${shortcut.label}`,
+        body,
+        level: "error",
+        icon: "terminal",
+      });
+
+    let res: Response;
+    try {
+      res = await fetch(
+        `/api/agents/${encodeURIComponent(agentId)}/shortcuts/${shortcut.idx}/launch`,
+        { method: "POST", headers: { Accept: "application/json" } }
+      );
+    } catch {
+      failed("Couldn't reach the server.");
+      return;
+    }
+    if (!res.ok) {
+      let detail = `Request failed (${res.status}).`;
+      try {
+        const e = await res.json();
+        if (e?.detail || e?.error) detail = String(e.detail ?? e.error);
+      } catch { /* keep generic detail */ }
+      failed(detail);
+      return;
+    }
+
     const { redirect_url } = await res.json() as { redirect_url: string };
     const kind = shortcut.kind;
     if (kind === "dashboard") {
       const app = getApp("browser");
       if (app) openWindow("browser", app.defaultSize, { initialUrl: redirect_url });
     } else if (kind === "tui" || kind === "container-terminal") {
-      const parsed = new URL(redirect_url, window.location.href);
-      const ticket = parsed.searchParams.get("t") ?? "";
-      const wsUrl = redirect_url
-        .replace(/^http:\/\//, "ws://")
-        .replace(/^https:\/\//, "wss://");
+      const { ticket, wsUrl, redeemUrl } = deriveTerminalShortcutTarget(
+        redirect_url,
+        agentId,
+        shortcut.idx,
+        window.location.href,
+      );
+      // Establish the taos_shortcut session cookie before opening the PTY
+      // socket. The WebSocket endpoint authenticates via that cookie, which
+      // only GET /redeem sets; the 302 it returns sets the cookie regardless
+      // of where the redirect points, so we ignore the follow-up response.
+      await fetch(redeemUrl, { credentials: "include" }).catch(() => { /* cookie still set */ });
       const app = getApp("terminal");
       if (app) openWindow("terminal", app.defaultSize, { shortcut: { wsUrl, ticket } });
     }

--- a/desktop/src/apps/__tests__/AgentsApp.shortcut-click.test.tsx
+++ b/desktop/src/apps/__tests__/AgentsApp.shortcut-click.test.tsx
@@ -63,6 +63,7 @@ vi.mock("@/components/AgentShortcutRow", () => ({
 }));
 
 import { AgentsApp } from "../AgentsApp";
+import { useNotificationStore } from "@/stores/notification-store";
 
 const MOCK_AGENT = {
   name: "test-agent",
@@ -135,7 +136,7 @@ describe("AgentsApp — handleShortcutLaunch routing (Task 28)", () => {
     );
   });
 
-  it("tui kind opens TerminalApp with wsUrl (ws://) and ticket extracted from t= param", async () => {
+  it("tui kind opens TerminalApp pointed at the PTY endpoint (not /redeem) and redeems the cookie first", async () => {
     const redirectUrl = "http://worker.local/redeem?t=myticket42";
     setupFetch({ redirect_url: redirectUrl, expires_in: 30 });
 
@@ -147,19 +148,24 @@ describe("AgentsApp — handleShortcutLaunch routing (Task 28)", () => {
       await onLaunch!("test-agent", { idx: 1, label: "TUI", icon: "tui", kind: "tui", requires_capability: "agent.terminal" });
     });
 
+    // The cookie-establishing GET /redeem must happen before the socket opens.
+    expect(fetch).toHaveBeenCalledWith(
+      redirectUrl,
+      expect.objectContaining({ credentials: "include" }),
+    );
     expect(mockOpenWindow).toHaveBeenCalledWith(
       "terminal",
       expect.objectContaining({ w: expect.any(Number), h: expect.any(Number) }),
       expect.objectContaining({
         shortcut: expect.objectContaining({
-          wsUrl: "ws://worker.local/redeem?t=myticket42",
+          wsUrl: "ws://worker.local/shortcut/terminal/test-agent/1",
           ticket: "myticket42",
         }),
       })
     );
   });
 
-  it("https redirect_url is converted to wss:// scheme for TerminalApp", async () => {
+  it("https redirect_url yields a wss:// PTY endpoint", async () => {
     const redirectUrl = "https://worker.secure/redeem?t=secureticket";
     setupFetch({ redirect_url: redirectUrl, expires_in: 30 });
 
@@ -176,14 +182,14 @@ describe("AgentsApp — handleShortcutLaunch routing (Task 28)", () => {
       expect.objectContaining({ w: expect.any(Number), h: expect.any(Number) }),
       expect.objectContaining({
         shortcut: expect.objectContaining({
-          wsUrl: "wss://worker.secure/redeem?t=secureticket",
+          wsUrl: "wss://worker.secure/shortcut/terminal/test-agent/1",
           ticket: "secureticket",
         }),
       })
     );
   });
 
-  it("container-terminal kind opens TerminalApp with wsUrl (ws://) and ticket", async () => {
+  it("container-terminal kind opens TerminalApp pointed at the PTY endpoint", async () => {
     const redirectUrl = "http://worker.local/redeem?t=containerticket";
     setupFetch({ redirect_url: redirectUrl, expires_in: 30 });
 
@@ -200,10 +206,40 @@ describe("AgentsApp — handleShortcutLaunch routing (Task 28)", () => {
       expect.objectContaining({ w: expect.any(Number), h: expect.any(Number) }),
       expect.objectContaining({
         shortcut: expect.objectContaining({
-          wsUrl: "ws://worker.local/redeem?t=containerticket",
+          wsUrl: "ws://worker.local/shortcut/terminal/test-agent/2",
           ticket: "containerticket",
         }),
       })
     );
+  });
+
+  it("surfaces an error notification when the launch request fails (no silent no-op)", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockImplementation((url: string, opts?: RequestInit) => {
+      if (url === "/api/agents" && !opts?.method) {
+        return Promise.resolve({ ok: true, headers: { get: () => "application/json" }, json: () => Promise.resolve([MOCK_AGENT]) } as unknown as Response);
+      }
+      if (url === "/api/agents/archived") {
+        return Promise.resolve({ ok: true, headers: { get: () => "application/json" }, json: () => Promise.resolve([]) } as unknown as Response);
+      }
+      if (url.includes("/shortcuts/") && url.includes("/launch")) {
+        return Promise.resolve({ ok: false, status: 403, headers: { get: () => "application/json" }, json: () => Promise.resolve({ detail: "Capability 'agent.shell' required" }) } as unknown as Response);
+      }
+      return Promise.resolve({ ok: false, headers: { get: () => "application/json" }, json: () => Promise.resolve({}) } as unknown as Response);
+    }));
+
+    const before = useNotificationStore.getState().notifications.length;
+    render(<AgentsApp windowId="test" />);
+    await screen.findByTestId("shortcut-row-test-agent");
+
+    const { onLaunch } = captors["test-agent"]!;
+    await act(async () => {
+      await onLaunch!("test-agent", { idx: 2, label: "Shell", icon: "terminal", kind: "container-terminal", requires_capability: "agent.shell" });
+    });
+
+    expect(mockOpenWindow).not.toHaveBeenCalled();
+    const notifs = useNotificationStore.getState().notifications;
+    expect(notifs.length).toBe(before + 1);
+    expect(notifs[0].level).toBe("error");
+    expect(notifs[0].body).toContain("agent.shell");
   });
 });

--- a/desktop/src/apps/__tests__/shortcut-launch.test.ts
+++ b/desktop/src/apps/__tests__/shortcut-launch.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { deriveTerminalShortcutTarget } from "../shortcut-launch";
+
+const BASE = "http://controller.local/";
+
+describe("deriveTerminalShortcutTarget", () => {
+  it("points the WebSocket at the PTY endpoint, not /redeem", () => {
+    const t = deriveTerminalShortcutTarget(
+      "http://worker.local/redeem?t=myticket42",
+      "test-agent",
+      1,
+      BASE,
+    );
+    expect(t.ticket).toBe("myticket42");
+    expect(t.wsUrl).toBe("ws://worker.local/shortcut/terminal/test-agent/1");
+    expect(t.redeemUrl).toBe("http://worker.local/redeem?t=myticket42");
+  });
+
+  it("upgrades https redeem URLs to wss", () => {
+    const t = deriveTerminalShortcutTarget(
+      "https://worker.secure/redeem?t=secureticket",
+      "test-agent",
+      2,
+      BASE,
+    );
+    expect(t.wsUrl).toBe("wss://worker.secure/shortcut/terminal/test-agent/2");
+    expect(t.ticket).toBe("secureticket");
+  });
+
+  it("keeps the worker origin (host + port), not the SPA origin", () => {
+    const t = deriveTerminalShortcutTarget(
+      "http://worker.local:8443/redeem?t=abc",
+      "agent",
+      0,
+      BASE,
+    );
+    expect(t.wsUrl).toBe("ws://worker.local:8443/shortcut/terminal/agent/0");
+  });
+
+  it("url-encodes agent ids with spaces or slashes", () => {
+    const t = deriveTerminalShortcutTarget(
+      "http://worker.local/redeem?t=x",
+      "my agent/2",
+      3,
+      BASE,
+    );
+    expect(t.wsUrl).toBe(
+      "ws://worker.local/shortcut/terminal/my%20agent%2F2/3",
+    );
+  });
+
+  it("yields an empty ticket when t= is absent rather than throwing", () => {
+    const t = deriveTerminalShortcutTarget(
+      "http://worker.local/redeem",
+      "agent",
+      0,
+      BASE,
+    );
+    expect(t.ticket).toBe("");
+  });
+});

--- a/desktop/src/apps/shortcut-launch.ts
+++ b/desktop/src/apps/shortcut-launch.ts
@@ -1,0 +1,34 @@
+/**
+ * Helpers for launching terminal-kind agent shortcuts.
+ *
+ * The launch endpoint returns a one-shot redeem URL of the form
+ * `<worker>/redeem?t=<ticket>`. Performing a GET against it sets the
+ * `taos_shortcut` session cookie and 302-redirects to the real PTY endpoint
+ * `/shortcut/terminal/<agent>/<idx>`.
+ *
+ * The PTY WebSocket must therefore be opened against that endpoint on the
+ * worker origin — NOT against `/redeem`, which is a plain HTTP route. Opening a
+ * WebSocket straight at `/redeem` (the previous behaviour) failed the upgrade
+ * immediately and never set the cookie the PTY socket authenticates with.
+ */
+export interface TerminalShortcutTarget {
+  /** Opaque ticket carried in the redeem URL's `t=` param. */
+  ticket: string;
+  /** WebSocket URL of the PTY endpoint on the worker origin. */
+  wsUrl: string;
+  /** The redeem URL to GET first so the session cookie is established. */
+  redeemUrl: string;
+}
+
+export function deriveTerminalShortcutTarget(
+  redirectUrl: string,
+  agentId: string,
+  idx: number,
+  baseHref: string,
+): TerminalShortcutTarget {
+  const parsed = new URL(redirectUrl, baseHref);
+  const ticket = parsed.searchParams.get("t") ?? "";
+  const wsProto = parsed.protocol === "https:" ? "wss:" : "ws:";
+  const wsUrl = `${wsProto}//${parsed.host}/shortcut/terminal/${encodeURIComponent(agentId)}/${idx}`;
+  return { ticket, wsUrl, redeemUrl: parsed.toString() };
+}


### PR DESCRIPTION
## Problem

Reported by @johny-mnemonic in discussion #357 / issue #458: in the Agents app, **Hermes chat**, **Hermes doctor**, and **Container shell** each show "Connecting to shortcut…" then immediately fail with `WebSocket connection error` / `Connection closed`.

## Root cause

All three are terminal-kind shortcuts (Hermes chat/doctor = `tui`, Container shell = `container-terminal`). The launch endpoint returns a one-shot redeem URL: `http://<worker>/redeem?t=<ticket>`. The terminal branch of `handleShortcutLaunch` converted that to `ws://<worker>/redeem?t=<ticket>` and opened a WebSocket **straight at `/redeem`** — which is a plain HTTP route, so the upgrade failed instantly. Worse, `/redeem` is what sets the `taos_shortcut` session cookie the PTY socket authenticates with, and it was never actually fetched.

Dashboard shortcuts worked only because they open `redirect_url` as a real browser navigation, which does GET `/redeem` → cookie + 302.

The buggy `ws://…/redeem…` target was **codified in the existing tests**, which is why CI never caught it.

## Fix

- New helper `deriveTerminalShortcutTarget()` builds the correct PTY WebSocket URL — `ws(s)://<worker-origin>/shortcut/terminal/<agent>/<idx>` — and surfaces the redeem URL.
- `handleShortcutLaunch` now GETs `/redeem` first (establishes the `taos_shortcut` cookie via the 302's `Set-Cookie`), then opens the socket against the real PTY endpoint.
- Corrected the tests that encoded the bug; added a unit test for the helper.
- **Also (refs #459):** launch failures now raise an error notification instead of returning silently, so a failing shortcut button no longer looks like it "does nothing".

## Verification

- `tsc -b` clean.
- 10/10 unit tests pass (`shortcut-launch.test.ts` + `AgentsApp.shortcut-click.test.tsx`).
- End-to-end (deployed agent on incus) to be confirmed on a running instance.

Closes #458
Refs #459