### PR TITLE
fix(agents): deploy/model-change resolve models from all cloud provider types

### DIFF
--- a/tests/test_deploy_cloud_model_resolution.py
+++ b/tests/test_deploy_cloud_model_resolution.py
@@ -1,0 +1,71 @@
+"""Deploy/model-change must resolve models from every cloud provider type.
+
+Regression: the resolver only gathered models from openai/anthropic backends,
+so deploying an agent on a kilocode / openrouter / openai-compatible model
+(e.g. the kilo-auto/free test model) 404'd as "model not found". See the
+discussion #357 fresh-install repro.
+"""
+import pytest
+
+import tinyagentos.cluster.model_resolver as model_resolver
+
+
+class _NotFound:
+    kind = "not_found"
+    hosts: list = []
+
+
+@pytest.fixture
+def capture_cloud_models(monkeypatch):
+    """Patch find_model_hosts to record the cloud_models it was handed."""
+    seen: dict = {}
+
+    def _fake(model, *, cluster_state=None, local_models=None, cloud_models=None):
+        seen["cloud_models"] = list(cloud_models or [])
+        return _NotFound()
+
+    monkeypatch.setattr(model_resolver, "find_model_hosts", _fake)
+    return seen
+
+
+def _add_kilocode_backend(app):
+    app.state.config.backends.append({
+        "name": "kilocode",
+        "type": "kilocode",
+        "url": "https://api.kilo.ai/api/gateway",
+        "models": [{"name": "kilo-auto/free", "size_mb": 0}],
+    })
+
+
+@pytest.mark.asyncio
+async def test_deploy_gathers_kilocode_models(client, app, capture_cloud_models):
+    _add_kilocode_backend(app)
+
+    resp = await client.post(
+        "/api/agents/deploy",
+        json={"name": "Hermes Test", "framework": "none", "model": "kilo-auto/free"},
+    )
+
+    # Resolution must have considered the kilocode model (the fix). The patched
+    # resolver returns not_found, so the request 404s — that's fine; we assert
+    # on what the resolver was actually given.
+    assert "kilo-auto/free" in capture_cloud_models["cloud_models"]
+    assert resp.status_code >= 400  # _NotFound short-circuits before container creation
+
+
+@pytest.mark.asyncio
+async def test_model_change_gathers_openai_compatible_models(client, app, capture_cloud_models):
+    app.state.config.backends.append({
+        "name": "local-llama",
+        "type": "openai-compatible",
+        "url": "http://localhost:8081",
+        "models": [{"id": "llama-3.1-8b"}],
+    })
+
+    resp = await client.post(
+        "/api/agents/test-agent/model",
+        json={"model": "llama-3.1-8b"},
+    )
+
+    assert "llama-3.1-8b" in capture_cloud_models["cloud_models"]
+    assert resp.status_code >= 400

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -17,6 +17,11 @@ logger = logging.getLogger(__name__)
 
 EXPORT_VERSION = 1
 
+# Cloud provider backend types whose advertised models are routable for a
+# deploy / model-change. Mirrors providers.CLOUD_TYPES; kept local to avoid a
+# cross-route import. #351 tracks consolidating these provider-type lists.
+_CLOUD_PROVIDER_TYPES = ("openai", "anthropic", "openrouter", "kilocode", "openai-compatible")
+
 router = APIRouter()
 
 
@@ -513,7 +518,12 @@ async def deploy_agent_endpoint(request: Request, body: DeployAgentRequest):
         cloud_models: list[str] = []
         try:
             for b in config.backends or []:
-                if b.get("type") in ("openai", "anthropic"):
+                # All cloud provider types, not just openai/anthropic — kilocode,
+                # openrouter and openai-compatible advertise routable cloud models
+                # too. Mirrors providers.CLOUD_TYPES (#351 tracks consolidating
+                # these lists). Without this, deploying an agent on e.g.
+                # kilo-auto/free 404s as "model not found".
+                if b.get("type") in _CLOUD_PROVIDER_TYPES:
                     for m in b.get("models") or []:
                         if isinstance(m, dict):
                             mid = m.get("id") or m.get("name") or ""
@@ -1318,7 +1328,10 @@ async def update_agent_model(request: Request, name: str, body: AgentModelUpdate
     cloud_models: list[str] = []
     try:
         for b in config.backends or []:
-            if b.get("type") in ("openai", "anthropic"):
+            # All cloud provider types (see _CLOUD_PROVIDER_TYPES / #351), so a
+            # model change to a kilocode/openrouter/openai-compatible model
+            # resolves instead of 404ing.
+            if b.get("type") in _CLOUD_PROVIDER_TYPES:
                 for m in b.get("models") or []:
                     mid = (m.get("id") or m.get("name") or "") if isinstance(m, dict) else str(m)
                     if mid:


### PR DESCRIPTION
## Problem

Found during the discussion #357 fresh-install reproduction. On a clean install with a **kilocode** provider configured, deploying an agent on `kilo-auto/free` failed:

```
404 — model 'kilo-auto/free' was not found on the controller, on any online
worker, or among configured cloud providers.
```

## Root cause

Both the deploy resolver (`/api/agents/deploy`) and the model-change endpoint (`/api/agents/{name}/model`) gathered candidate cloud models from **only** `("openai", "anthropic")` backends:

```python
if b.get("type") in ("openai", "anthropic"):
```

So models advertised by `kilocode`, `openrouter`, and `openai-compatible` providers were never considered, and `find_model_hosts` returned `not_found`. This blocks the sanctioned `kilo-auto/free` test model and any self-hosted OpenAI-compatible endpoint (the deploy-side sibling of #356).

## Fix

Broaden the gather to the full cloud-provider set via a module constant `_CLOUD_PROVIDER_TYPES` (mirrors `providers.CLOUD_TYPES`; #351 tracks consolidating these lists), applied in both call sites.

## Verification

- Validated live in the fresh-install LXC: deploy of a `kilo-auto/free` Hermes agent went from **404 → 200 (accepted)** after this change.
- New tests `tests/test_deploy_cloud_model_resolution.py` assert the resolver now receives kilocode and openai-compatible models. 2/2 pass.

Refs #356

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for kilocode and openai-compatible cloud provider backends in agent deployment and model updates.

* **Tests**
  * Added regression test coverage for model resolution with various cloud provider backends.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jaylfc/tinyagentos/pull/464?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->