### PR TITLE
fix(hermes): never emit a blank [hermes error: ]

### DIFF
--- a/tinyagentos/scripts/install_hermes.sh
+++ b/tinyagentos/scripts/install_hermes.sh
@@ -209,7 +209,13 @@ async def call_hermes(client: httpx.AsyncClient, messages: list) -> str:
         data = resp.json()
         return data["choices"][0]["message"]["content"]
     except Exception as e:
-        return f"[hermes error: {e}]"
+        # str(e) is empty for several httpx errors (notably ReadTimeout), which
+        # produced a blank "[hermes error: ]" that hid the real cause — e.g. the
+        # Hermes agent loop running past the request timeout against a slow
+        # local model. Always surface a non-empty detail (exception type at
+        # minimum) so the user/logs see what actually failed.
+        detail = str(e) or type(e).__name__
+        return f"[hermes error: {detail}]"
 
 
 async def post_reply(client: httpx.AsyncClient, reply_url: str, token: str,


### PR DESCRIPTION
## Problem

Reported in discussion #357 / issue #460: a deployed **Hermes** agent processed the first message, then on the second turn returned an empty **`[hermes error: ]`** and kept hammering the model backend.

## Root cause

The taOS hermes-bridge (`tinyagentos/scripts/install_hermes.sh`, installed into the agent container) wraps every `call_hermes` failure as:

```python
except Exception as e:
    return f"[hermes error: {e}]"
```

`str(e)` is **empty** for several `httpx` exceptions — notably `ReadTimeout` — so the message rendered as a bare `[hermes error: ]`, hiding the real cause. The actual failure was a **timeout**: Hermes's agentic loop ran past the bridge's 120s request timeout against a slow local model (the "sending prompts again and again" the user saw is Hermes's own multi-step loop, server-side).

## Fix

Fall back to the exception type name when `str(e)` is empty, so the error is never blank:

```python
detail = str(e) or type(e).__name__
return f"[hermes error: {detail}]"
```

Now the user sees e.g. `[hermes error: ReadTimeout]` and can tell it timed out.

## Scope

This fixes the **blank-error** half of #460 (taOS-side). The runaway agent loop itself is Hermes-runtime behaviour against an underpowered local model and is out of scope here — tracked in #460 for a follow-up (e.g. surfacing the timeout in-UI / bounding the turn).

## Verification

- Embedded bridge script `py_compile`s cleanly after the change.

Refs #460