### PR TITLE
feat(install): install Docker + Compose by default for Store Docker apps

### DIFF
--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -486,7 +486,99 @@ ensure_container_runtime() {
     fi
 }
 
+# Re-apply (idempotently) the incusbr0 FORWARD ACCEPT rules and persist them.
+# Docker sets the iptables FORWARD policy to DROP, which severs incus bridge
+# (incusbr0) traffic — agent containers would lose network. When both engines
+# are present we must explicitly ACCEPT incusbr0 forwarding, and persist it
+# because Docker re-inserts its rules on every restart / reboot.
+_apply_incusbr0_forward_accept() {
+    sudo iptables -C FORWARD -i incusbr0 -j ACCEPT 2>/dev/null || sudo iptables -I FORWARD -i incusbr0 -j ACCEPT || true
+    sudo iptables -C FORWARD -o incusbr0 -j ACCEPT 2>/dev/null || sudo iptables -I FORWARD -o incusbr0 -j ACCEPT || true
+    log "applied incusbr0 FORWARD ACCEPT rules (Docker ↔ incus coexistence)"
+
+    if command -v systemctl >/dev/null 2>&1; then
+        sudo tee /etc/systemd/system/taos-incus-docker-net.service >/dev/null <<'UNIT'
+[Unit]
+Description=taOS: keep incus bridge forwarding open alongside Docker
+After=docker.service incus.service
+Wants=docker.service
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c 'iptables -C FORWARD -i incusbr0 -j ACCEPT 2>/dev/null || iptables -I FORWARD -i incusbr0 -j ACCEPT; iptables -C FORWARD -o incusbr0 -j ACCEPT 2>/dev/null || iptables -I FORWARD -o incusbr0 -j ACCEPT'
+[Install]
+WantedBy=multi-user.target
+UNIT
+        sudo systemctl daemon-reload >/dev/null 2>&1 || true
+        sudo systemctl enable taos-incus-docker-net.service >/dev/null 2>&1 \
+            && log "installed taos-incus-docker-net.service (persists incusbr0 rules across reboots)" \
+            || warn "could not enable taos-incus-docker-net.service — incusbr0 rules may not survive a reboot"
+    else
+        warn "non-systemd host: incusbr0 FORWARD ACCEPT rules applied now but won't persist a reboot — re-apply via your firewall manager"
+    fi
+}
+
+# Docker is the engine for Store "Docker apps" (manifest install.method: docker),
+# including compose-style stacks like SearXNG / Perplexica. incus runs agent
+# LXCs; Docker runs Docker apps. Installed by default — set TAOS_SKIP_DOCKER=1
+# to opt out (Store Docker apps then stay unavailable).
+ensure_docker_for_apps() {
+    if [[ "${TAOS_SKIP_DOCKER:-0}" == "1" ]]; then
+        log "TAOS_SKIP_DOCKER=1 — skipping Docker (Store Docker apps will be unavailable)"
+        return 0
+    fi
+    # macOS Docker Desktop is user-managed — don't touch it.
+    [[ "$(uname -s)" == "Darwin" ]] && return 0
+
+    if command -v docker >/dev/null 2>&1; then
+        log "docker present: $(docker --version 2>/dev/null | head -1)"
+    else
+        log "installing Docker (for Store Docker apps)"
+        if command -v apt-get >/dev/null 2>&1; then
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq docker.io \
+                || warn "apt install docker.io failed — Store Docker apps will be unavailable"
+        elif command -v dnf >/dev/null 2>&1; then
+            sudo dnf install -y -q moby-engine \
+                || warn "dnf install moby-engine failed — Store Docker apps will be unavailable"
+        elif command -v pacman >/dev/null 2>&1; then
+            sudo pacman -Sy --noconfirm --needed docker \
+                || warn "pacman install docker failed — Store Docker apps will be unavailable"
+        elif command -v apk >/dev/null 2>&1; then
+            sudo apk add --no-cache docker \
+                || warn "apk add docker failed — Store Docker apps will be unavailable"
+        else
+            warn "unrecognised package manager — install Docker manually for Store Docker apps"
+            return 0
+        fi
+    fi
+
+    command -v docker >/dev/null 2>&1 || { warn "docker not on PATH after install — skipping daemon/group setup"; return 0; }
+
+    # Enable + start the daemon (systemd, else OpenRC for Alpine).
+    if command -v systemctl >/dev/null 2>&1; then
+        sudo systemctl enable --now docker >/dev/null 2>&1 \
+            || warn "could not enable/start docker.service — start it manually (sudo systemctl start docker)"
+    elif command -v rc-update >/dev/null 2>&1; then
+        sudo rc-update add docker default >/dev/null 2>&1 || true
+        sudo service docker start >/dev/null 2>&1 || warn "could not start docker (OpenRC) — start it manually"
+    fi
+
+    # Let the controller's user run docker without sudo.
+    local duser="${SUDO_USER:-$USER}"
+    if [[ -n "$duser" && "$duser" != "root" ]]; then
+        sudo groupadd -f docker >/dev/null 2>&1 || true
+        sudo usermod -aG docker "$duser" >/dev/null 2>&1 \
+            && log "added '$duser' to the docker group (re-login for it to take effect)" \
+            || warn "could not add '$duser' to the docker group"
+    fi
+
+    # Keep incus agent networking alive now that Docker owns the FORWARD chain.
+    if command -v incus >/dev/null 2>&1 && command -v iptables >/dev/null 2>&1; then
+        _apply_incusbr0_forward_accept
+    fi
+}
+
 ensure_container_runtime
+ensure_docker_for_apps
 
 # --- clone / update the repo ---------------------------------------------
 

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -492,35 +492,44 @@ _docker_running() {
     sudo docker info >/dev/null 2>&1
 }
 
-# Re-apply (idempotently) the incusbr0 FORWARD ACCEPT rules and persist them.
-# Docker sets the iptables FORWARD policy to DROP, which severs incus bridge
-# (incusbr0) traffic — agent containers would lose network. When both engines
-# are present we must explicitly ACCEPT incusbr0 forwarding, and persist it
-# because Docker re-inserts its rules on every restart / reboot.
-_apply_incusbr0_forward_accept() {
-    sudo iptables -C FORWARD -i incusbr0 -j ACCEPT 2>/dev/null || sudo iptables -I FORWARD -i incusbr0 -j ACCEPT || true
-    sudo iptables -C FORWARD -o incusbr0 -j ACCEPT 2>/dev/null || sudo iptables -I FORWARD -o incusbr0 -j ACCEPT || true
-    log "applied incusbr0 FORWARD ACCEPT rules (Docker ↔ incus coexistence)"
+# Configure Docker so it coexists with incus networking.
+#
+# When Docker enables IP forwarding it sets the iptables FORWARD chain's
+# default policy to DROP, which severs incus bridge (incusbr0) traffic and
+# kills agent-container networking. The upstream-recommended fix (Incus
+# firewall docs + Docker packet-filtering docs) is Docker's own switch
+# `ip-forward-no-drop`, which tells Docker to never touch that policy — far
+# cleaner than patching the FORWARD chain by hand (Docker reorders/reinserts
+# its own rules, so hand-added FORWARD rules are fragile). We also enable IP
+# forwarding via sysctl as a belt-and-suspenders for older Docker builds that
+# predate the option. This must run BEFORE Docker's daemon first starts so the
+# DROP policy is never set in the first place.
+_configure_docker_incus_coexistence() {
+    sudo mkdir -p /etc/docker
+    # Merge "ip-forward-no-drop": true into any existing daemon.json. python3 is
+    # a controller dependency installed earlier, so it's always available here.
+    sudo python3 - <<'PY'
+import json, os
+path = "/etc/docker/daemon.json"
+data = {}
+if os.path.exists(path):
+    try:
+        with open(path) as f:
+            data = json.load(f) or {}
+    except Exception:
+        data = {}  # malformed/empty — start clean rather than fail the install
+if data.get("ip-forward-no-drop") is not True:
+    data["ip-forward-no-drop"] = True
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+PY
+    log "set Docker ip-forward-no-drop=true for incus coexistence (/etc/docker/daemon.json)"
 
-    if command -v systemctl >/dev/null 2>&1; then
-        sudo tee /etc/systemd/system/taos-incus-docker-net.service >/dev/null <<'UNIT'
-[Unit]
-Description=taOS: keep incus bridge forwarding open alongside Docker
-After=docker.service incus.service
-Wants=docker.service
-[Service]
-Type=oneshot
-ExecStart=/bin/sh -c 'iptables -C FORWARD -i incusbr0 -j ACCEPT 2>/dev/null || iptables -I FORWARD -i incusbr0 -j ACCEPT; iptables -C FORWARD -o incusbr0 -j ACCEPT 2>/dev/null || iptables -I FORWARD -o incusbr0 -j ACCEPT'
-[Install]
-WantedBy=multi-user.target
-UNIT
-        sudo systemctl daemon-reload >/dev/null 2>&1 || true
-        sudo systemctl enable taos-incus-docker-net.service >/dev/null 2>&1 \
-            && log "installed taos-incus-docker-net.service (persists incusbr0 rules across reboots)" \
-            || warn "could not enable taos-incus-docker-net.service — incusbr0 rules may not survive a reboot"
-    else
-        warn "non-systemd host: incusbr0 FORWARD ACCEPT rules applied now but won't persist a reboot — re-apply via your firewall manager"
-    fi
+    # Independently ensure IPv4 forwarding is on; if it's already enabled when
+    # Docker starts, Docker won't flip the FORWARD policy even on engines that
+    # lack ip-forward-no-drop.
+    printf 'net.ipv4.conf.all.forwarding=1\n' | sudo tee /etc/sysctl.d/99-taos-forwarding.conf >/dev/null
+    sudo sysctl -p /etc/sysctl.d/99-taos-forwarding.conf >/dev/null 2>&1 || true
 }
 
 # Docker is the engine for Store "Docker apps" (manifest install.method: docker),
@@ -542,11 +551,21 @@ ensure_docker_for_apps() {
         return 0
     fi
 
+    local had_docker=0
+    command -v docker >/dev/null 2>&1 && had_docker=1
+
+    # Configure Docker↔incus coexistence BEFORE the daemon's first start so
+    # Docker never sets the FORWARD policy to DROP. Only relevant when incus is
+    # also present (it runs the agent containers).
+    if command -v incus >/dev/null 2>&1; then
+        _configure_docker_incus_coexistence
+    fi
+
     # Linux, including WSL2: install the native Docker Engine + CLI in-distro.
     # We deliberately use the in-distro engine rather than Docker Desktop on
     # WSL2 so the controller is self-contained and headless; the daemon-start
     # ladder below covers WSL2 setups where systemd isn't enabled.
-    if command -v docker >/dev/null 2>&1; then
+    if (( had_docker )); then
         log "docker present: $(docker --version 2>/dev/null | head -1)"
     else
         # Install the engine AND the Compose v2 plugin — taOS deploys Store
@@ -604,9 +623,19 @@ ensure_docker_for_apps() {
             || warn "could not add '$duser' to the docker group"
     fi
 
-    # Keep incus agent networking alive now that Docker owns the FORWARD chain.
-    if command -v incus >/dev/null 2>&1 && command -v iptables >/dev/null 2>&1; then
-        _apply_incusbr0_forward_accept
+    # Keep incus agent networking alive alongside Docker. ip-forward-no-drop
+    # (set above, before first start) stops Docker setting FORWARD=DROP going
+    # forward. For a Docker that was already running, restart so it re-reads the
+    # config, then normalise any DROP a prior start may have left (idempotent;
+    # ACCEPT is ip-forward-no-drop's intended end-state — Docker still filters
+    # its own containers via the DOCKER/DOCKER-USER chains).
+    if command -v incus >/dev/null 2>&1; then
+        if (( had_docker )) && command -v systemctl >/dev/null 2>&1; then
+            sudo systemctl restart docker >/dev/null 2>&1 || true
+        fi
+        if command -v iptables >/dev/null 2>&1; then
+            sudo iptables -P FORWARD ACCEPT 2>/dev/null || true
+        fi
     fi
 }
 

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -532,38 +532,24 @@ ensure_docker_for_apps() {
         log "TAOS_SKIP_DOCKER=1 — skipping Docker (Store Docker apps will be unavailable)"
         return 0
     fi
-    # macOS: Docker apps run under Docker Desktop / the Apple Containerization
-    # framework, both user-managed — never apt/brew a daemon here.
+    # macOS: the Docker Engine can't run natively (it needs a Linux VM), so the
+    # server doesn't install it here — agents use the Apple Containerization
+    # framework, and Docker apps need a user-provided Docker (Desktop/colima).
     if [[ "$(uname -s)" == "Darwin" ]]; then
         command -v docker >/dev/null 2>&1 \
             && log "macOS: using existing Docker ($(docker --version 2>/dev/null | head -1))" \
-            || log "macOS: install Docker Desktop for Store Docker apps (server uses Apple Containerization for agents)"
+            || log "macOS: provide Docker (Desktop or colima) for Store Docker apps; agents use Apple Containerization"
         return 0
     fi
 
-    # WSL2: Docker is normally Docker Desktop with WSL integration, and systemd
-    # is often disabled. Use whatever's already on PATH; don't fight Desktop.
-    local is_wsl=0
-    grep -qi microsoft /proc/version 2>/dev/null && is_wsl=1
-
+    # Linux, including WSL2: install the native Docker Engine + CLI in-distro.
+    # We deliberately use the in-distro engine rather than Docker Desktop on
+    # WSL2 so the controller is self-contained and headless; the daemon-start
+    # ladder below covers WSL2 setups where systemd isn't enabled.
     if command -v docker >/dev/null 2>&1; then
         log "docker present: $(docker --version 2>/dev/null | head -1)"
-        if (( is_wsl )); then
-            log "WSL2: leaving daemon management to Docker Desktop / your distro"
-            _docker_running || warn "docker is installed but the daemon isn't reachable — enable Docker Desktop's WSL integration or start it in-distro"
-            return 0
-        fi
-    elif (( is_wsl )); then
-        warn "WSL2 without docker on PATH — enable Docker Desktop's WSL integration (recommended) for Store Docker apps; attempting an in-distro install as fallback"
-        if command -v apt-get >/dev/null 2>&1; then
-            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq docker.io \
-                || warn "apt install docker.io failed — enable Docker Desktop WSL integration instead"
-        else
-            warn "install Docker Desktop and enable WSL integration for Store Docker apps"
-            return 0
-        fi
     else
-        log "installing Docker (for Store Docker apps)"
+        log "installing Docker Engine (for Store Docker apps)"
         if command -v apt-get >/dev/null 2>&1; then
             sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq docker.io \
                 || warn "apt install docker.io failed — Store Docker apps will be unavailable"

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -549,24 +549,32 @@ ensure_docker_for_apps() {
     if command -v docker >/dev/null 2>&1; then
         log "docker present: $(docker --version 2>/dev/null | head -1)"
     else
-        log "installing Docker Engine (for Store Docker apps)"
+        # Install the engine AND the Compose v2 plugin — taOS deploys Store
+        # Docker apps via `docker compose`, and most distro 'docker' packages
+        # (e.g. Ubuntu's docker.io) don't bundle compose, which otherwise fails
+        # with "unknown command: docker compose".
+        log "installing Docker Engine + Compose plugin (for Store Docker apps)"
         if command -v apt-get >/dev/null 2>&1; then
-            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq docker.io \
-                || warn "apt install docker.io failed — Store Docker apps will be unavailable"
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq docker.io docker-compose-v2 \
+                || warn "apt install docker.io/docker-compose-v2 failed — Store Docker apps will be unavailable"
         elif command -v dnf >/dev/null 2>&1; then
-            sudo dnf install -y -q moby-engine \
-                || warn "dnf install moby-engine failed — Store Docker apps will be unavailable"
+            sudo dnf install -y -q moby-engine docker-compose \
+                || warn "dnf install moby-engine/docker-compose failed — Store Docker apps will be unavailable"
         elif command -v pacman >/dev/null 2>&1; then
-            sudo pacman -Sy --noconfirm --needed docker \
-                || warn "pacman install docker failed — Store Docker apps will be unavailable"
+            sudo pacman -Sy --noconfirm --needed docker docker-compose \
+                || warn "pacman install docker/docker-compose failed — Store Docker apps will be unavailable"
         elif command -v apk >/dev/null 2>&1; then
-            sudo apk add --no-cache docker \
-                || warn "apk add docker failed — Store Docker apps will be unavailable"
+            sudo apk add --no-cache docker docker-cli-compose \
+                || warn "apk add docker/docker-cli-compose failed — Store Docker apps will be unavailable"
         else
-            warn "unrecognised package manager — install Docker manually for Store Docker apps"
+            warn "unrecognised package manager — install Docker + the compose plugin manually for Store Docker apps"
             return 0
         fi
     fi
+
+    # Verify the Compose v2 plugin is usable; taOS installs apps via it.
+    docker compose version >/dev/null 2>&1 \
+        || warn "the 'docker compose' plugin isn't available — Store Docker apps need it (install docker-compose-v2 / docker-compose-plugin)"
 
     command -v docker >/dev/null 2>&1 || { warn "docker not on PATH after install — skipping daemon/group setup"; return 0; }
 

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -486,6 +486,12 @@ ensure_container_runtime() {
     fi
 }
 
+# True when the Docker daemon is reachable (don't trust a single start call's
+# exit code — WSL2/systemd quirks make that unreliable).
+_docker_running() {
+    sudo docker info >/dev/null 2>&1
+}
+
 # Re-apply (idempotently) the incusbr0 FORWARD ACCEPT rules and persist them.
 # Docker sets the iptables FORWARD policy to DROP, which severs incus bridge
 # (incusbr0) traffic — agent containers would lose network. When both engines
@@ -526,11 +532,36 @@ ensure_docker_for_apps() {
         log "TAOS_SKIP_DOCKER=1 — skipping Docker (Store Docker apps will be unavailable)"
         return 0
     fi
-    # macOS Docker Desktop is user-managed — don't touch it.
-    [[ "$(uname -s)" == "Darwin" ]] && return 0
+    # macOS: Docker apps run under Docker Desktop / the Apple Containerization
+    # framework, both user-managed — never apt/brew a daemon here.
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        command -v docker >/dev/null 2>&1 \
+            && log "macOS: using existing Docker ($(docker --version 2>/dev/null | head -1))" \
+            || log "macOS: install Docker Desktop for Store Docker apps (server uses Apple Containerization for agents)"
+        return 0
+    fi
+
+    # WSL2: Docker is normally Docker Desktop with WSL integration, and systemd
+    # is often disabled. Use whatever's already on PATH; don't fight Desktop.
+    local is_wsl=0
+    grep -qi microsoft /proc/version 2>/dev/null && is_wsl=1
 
     if command -v docker >/dev/null 2>&1; then
         log "docker present: $(docker --version 2>/dev/null | head -1)"
+        if (( is_wsl )); then
+            log "WSL2: leaving daemon management to Docker Desktop / your distro"
+            _docker_running || warn "docker is installed but the daemon isn't reachable — enable Docker Desktop's WSL integration or start it in-distro"
+            return 0
+        fi
+    elif (( is_wsl )); then
+        warn "WSL2 without docker on PATH — enable Docker Desktop's WSL integration (recommended) for Store Docker apps; attempting an in-distro install as fallback"
+        if command -v apt-get >/dev/null 2>&1; then
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq docker.io \
+                || warn "apt install docker.io failed — enable Docker Desktop WSL integration instead"
+        else
+            warn "install Docker Desktop and enable WSL integration for Store Docker apps"
+            return 0
+        fi
     else
         log "installing Docker (for Store Docker apps)"
         if command -v apt-get >/dev/null 2>&1; then
@@ -553,14 +584,22 @@ ensure_docker_for_apps() {
 
     command -v docker >/dev/null 2>&1 || { warn "docker not on PATH after install — skipping daemon/group setup"; return 0; }
 
-    # Enable + start the daemon (systemd, else OpenRC for Alpine).
+    # Start + enable the daemon across init systems: systemd (most distros),
+    # SysV 'service' (e.g. WSL2 without systemd), then OpenRC (Alpine). Verify
+    # reachability afterwards rather than trusting any single call's exit code.
     if command -v systemctl >/dev/null 2>&1; then
-        sudo systemctl enable --now docker >/dev/null 2>&1 \
-            || warn "could not enable/start docker.service — start it manually (sudo systemctl start docker)"
-    elif command -v rc-update >/dev/null 2>&1; then
-        sudo rc-update add docker default >/dev/null 2>&1 || true
-        sudo service docker start >/dev/null 2>&1 || warn "could not start docker (OpenRC) — start it manually"
+        sudo systemctl enable --now docker >/dev/null 2>&1 || true
     fi
+    if ! _docker_running && command -v service >/dev/null 2>&1; then
+        sudo service docker start >/dev/null 2>&1 || true
+    fi
+    if ! _docker_running && command -v rc-update >/dev/null 2>&1; then
+        sudo rc-update add docker default >/dev/null 2>&1 || true
+        sudo service docker start >/dev/null 2>&1 || true
+    fi
+    _docker_running \
+        && log "docker daemon is running" \
+        || warn "docker installed but the daemon isn't reachable — start it manually (e.g. sudo systemctl start docker)"
 
     # Let the controller's user run docker without sudo.
     local duser="${SUDO_USER:-$USER}"

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -591,9 +591,24 @@ ensure_docker_for_apps() {
         fi
     fi
 
-    # Verify the Compose v2 plugin is usable; taOS installs apps via it.
-    docker compose version >/dev/null 2>&1 \
-        || warn "the 'docker compose' plugin isn't available — Store Docker apps need it (install docker-compose-v2 / docker-compose-plugin)"
+    # Ensure the Compose v2 plugin (taOS deploys apps via `docker compose`).
+    # This also covers the case where Docker was ALREADY installed but without
+    # the plugin — the fresh-install branch above bundles it, but a pre-existing
+    # Docker (the `had_docker` path) may lack it, so install it here too.
+    if ! docker compose version >/dev/null 2>&1; then
+        log "installing the Docker Compose v2 plugin"
+        if command -v apt-get >/dev/null 2>&1; then
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq docker-compose-v2 || true
+        elif command -v dnf >/dev/null 2>&1; then
+            sudo dnf install -y -q docker-compose || true
+        elif command -v pacman >/dev/null 2>&1; then
+            sudo pacman -Sy --noconfirm --needed docker-compose || true
+        elif command -v apk >/dev/null 2>&1; then
+            sudo apk add --no-cache docker-cli-compose || true
+        fi
+        docker compose version >/dev/null 2>&1 \
+            || warn "the 'docker compose' plugin isn't available — Store Docker apps need it (install docker-compose-v2 / docker-compose-plugin manually)"
+    fi
 
     command -v docker >/dev/null 2>&1 || { warn "docker not on PATH after install — skipping daemon/group setup"; return 0; }
 


### PR DESCRIPTION
## What

taOS uses two container engines by role: **incus** for agent LXCs, **Docker** for Store "Docker apps" (`install.method: docker`, incl. compose stacks like SearXNG / Perplexica). The installer only set up incus, so installing a Docker app failed with *"docker is not available on this controller"* (discussion #357).

`ensure_docker_for_apps()` now, by default:
- Installs the **Docker Engine + Compose v2 plugin** cross-distro (apt `docker.io`+`docker-compose-v2`, dnf `moby-engine`+`docker-compose`, pacman `docker`+`docker-compose`, apk `docker`+`docker-cli-compose`). The compose plugin matters — most distro docker packages don't bundle it, which broke `docker compose`.
- Starts/enables the daemon across init systems (**systemd → SysV `service` → OpenRC**), verifying reachability via `docker info`.
- Adds the controller user to the `docker` group.
- `TAOS_SKIP_DOCKER=1` opts out.

### Docker ↔ incus networking (upstream-recommended fix)
When Docker enables IP forwarding it sets the iptables `FORWARD` policy to DROP, which severs the incus bridge (`incusbr0`) and kills agent-container networking. Per the [Incus firewall docs](https://linuxcontainers.org/incus/docs/main/howto/network_bridge_firewalld/) and [Docker packet-filtering docs](https://docs.docker.com/engine/network/packet-filtering-firewalls/), the clean fix is Docker's own **`ip-forward-no-drop`** switch — it stops Docker touching that policy at the source, rather than patching the FORWARD chain by hand (which Docker reorders/reinserts, making hand-added rules fragile).

- `{"ip-forward-no-drop": true}` is merged into `/etc/docker/daemon.json` **before** the daemon's first start (preserving existing keys; malformed files start clean).
- `net.ipv4.conf.all.forwarding=1` via `/etc/sysctl.d` as belt-and-suspenders for older engines.
- An already-running Docker is restarted to re-read the config; any pre-existing `FORWARD=DROP` is normalised once.

No custom systemd unit, no per-bridge iptables rules.

### Cross-platform
- **Linux** (incl. **WSL2**): native in-distro engine (self-contained, headless) rather than Docker Desktop; the daemon ladder covers WSL2 without systemd.
- **macOS**: skips engine install (Docker can't run natively); points at Docker Desktop/colima while agents use Apple Containerization.

## Verification
- `bash -n` clean; daemon.json merge logic unit-checked (new / preserve-existing / malformed / idempotent).
- Live (fresh Ubuntu 24.04 incus controller, earlier revision): Docker 29.1.3 + Compose 2.40.3 installed, daemon active, **SearXNG installs from the Store end-to-end** (the original #357 failure).
- Full agent-networking-under-Docker behaviour should be confirmed on real hardware (Pi/VM) — a nested LXC doesn't exercise the incusbr0 forwarding path.

Requires the companion compose-generation fix (#467) for the full SearXNG path.

Closes #461