### PR TITLE
fix(installers): declare named volumes in generated docker-compose

### DIFF
--- a/tests/test_installers.py
+++ b/tests/test_installers.py
@@ -64,6 +64,29 @@ class TestDockerInstaller:
             compose_file = tmp_path / "gitea" / "docker-compose.yaml"
             assert compose_file.exists()
 
+    def test_generate_compose_declares_named_volumes_and_omits_version(self, tmp_path):
+        # Regression: named volumes (e.g. searxng's "config:/etc/searxng") must
+        # be declared at the top level or compose rejects the project with
+        # "refers to undefined volume". The obsolete `version` key is dropped.
+        installer = DockerInstaller(apps_dir=tmp_path)
+        compose = installer._generate_compose("searxng", {
+            "image": "searxng/searxng:latest",
+            "volumes": ["config:/etc/searxng", "/host/path:/data"],
+            "ports": [8080],
+        })
+        assert "version" not in compose
+        assert compose["volumes"] == {"config": None}  # only the named volume
+        assert compose["services"]["searxng"]["volumes"] == ["config:/etc/searxng", "/host/path:/data"]
+        assert compose["services"]["searxng"]["ports"] == ["8080:8080"]
+
+    def test_generate_compose_omits_volumes_block_for_bind_mounts_only(self, tmp_path):
+        installer = DockerInstaller(apps_dir=tmp_path)
+        compose = installer._generate_compose("app", {
+            "image": "x:1",
+            "volumes": ["/host:/data", "./rel:/r", "~/h:/hh"],
+        })
+        assert "volumes" not in compose  # no named volumes → no top-level block
+
     @pytest.mark.asyncio
     async def test_start_runs_compose_up(self, tmp_path):
         installer = DockerInstaller(apps_dir=tmp_path)

--- a/tinyagentos/installers/docker_installer.py
+++ b/tinyagentos/installers/docker_installer.py
@@ -15,14 +15,31 @@ class DockerInstaller(AppInstaller):
     def _compose_path(self, app_id: str) -> Path:
         return self.apps_dir / app_id / "docker-compose.yaml"
 
+    @staticmethod
+    def _is_named_volume(source: str) -> bool:
+        """True when a compose volume source is a named volume (not a host path).
+
+        Host bind mounts start with /, ./, ../ or ~; anything else (e.g.
+        ``config``) is a named volume that must be declared at the top level.
+        """
+        return bool(source) and not source.startswith(("/", "./", "../", "~"))
+
     def _generate_compose(self, app_id: str, install_config: dict) -> dict:
         """Generate a docker-compose.yaml from the manifest install config."""
         service = {
             "image": install_config["image"],
             "restart": "unless-stopped",
         }
+        named_volumes: dict[str, None] = {}
         if "volumes" in install_config:
             service["volumes"] = install_config["volumes"]
+            # Named volumes (e.g. "config:/etc/searxng") must also be declared
+            # in a top-level `volumes:` block or compose rejects the project
+            # with "refers to undefined volume".
+            for vol in install_config["volumes"]:
+                source = str(vol).split(":", 1)[0]
+                if self._is_named_volume(source):
+                    named_volumes[source] = None
         if "env" in install_config:
             service["environment"] = install_config["env"]
         if "ports" in install_config.get("requires", {}):
@@ -30,10 +47,12 @@ class DockerInstaller(AppInstaller):
         elif "ports" in install_config:
             service["ports"] = [f"{p}:{p}" for p in install_config["ports"]]
 
-        return {
-            "version": "3.8",
-            "services": {app_id: service},
-        }
+        # No top-level `version:` — it's obsolete in Compose v2 and emits a
+        # warning on every command.
+        compose: dict = {"services": {app_id: service}}
+        if named_volumes:
+            compose["volumes"] = named_volumes
+        return compose
 
     async def install(self, app_id: str, install_config: dict, **kwargs) -> dict:
         app_dir = self.apps_dir / app_id


### PR DESCRIPTION
## Problem

Installing a Docker Store app with a **named volume** (e.g. SearXNG's `config:/etc/searxng`) failed:

```
service "searxng" refers to undefined volume config: invalid compose project
```

## Root cause

`DockerInstaller._generate_compose` copied volume mounts into the service but never declared **named** volumes in a top-level `volumes:` block, which Compose requires. It also emitted the obsolete top-level `version:` key (warning on every command).

## Fix

- Detect named volumes (sources that aren't host paths — not `/`, `./`, `../`, `~`) and declare them at the top level.
- Drop the `version:` key.

## Verification

- New unit tests in `tests/test_installers.py` (named volume declared, bind-mounts not, no `version`). 11/11 pass.
- Live: with this + the Docker-by-default installer change, SearXNG installs from the Store on an incus controller (`status: installed`, valid compose, image pulled).

Refs #461

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Docker Compose generation now correctly handles named volumes by declaring them at the top level while preserving service-level volume mappings.
  * Fixed compose generation to omit obsolete version declarations and skip unnecessary volume blocks when only bind mounts are present.

* **Tests**
  * Added regression tests validating Docker Compose generation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jaylfc/tinyagentos/pull/467?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->