### PR TITLE
fix: bounded retry + backoff + dedup for Hermes bridge to prevent runaway error loops

### DIFF
--- a/tests/test_hermes_bridge.py
+++ b/tests/test_hermes_bridge.py
@@ -1,0 +1,237 @@
+"""Tests for the Hermes bridge embedded in install_hermes.sh.
+
+The bridge Python code lives inside a shell heredoc. These tests extract it,
+verify it compiles, and exercise the retry/backoff/dedup/cooldown logic with
+mocked httpx clients.
+"""
+
+import ast
+import asyncio
+import py_compile
+import re
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# -- extraction helpers --------------------------------------------------------
+
+SCRIPT_PATH = Path(__file__).resolve().parent.parent / "tinyagentos" / "scripts" / "install_hermes.sh"
+
+
+def extract_bridge_python() -> str:
+    """Extract the embedded Python from the shell heredoc."""
+    text = SCRIPT_PATH.read_text()
+    m = re.search(r"<<'BRIDGE_EOF'\n(.*?)BRIDGE_EOF", text, re.DOTALL)
+    if not m:
+        raise RuntimeError("Could not find BRIDGE_EOF heredoc in install_hermes.sh")
+    return m.group(1)
+
+
+BRIDGE_PY = extract_bridge_python()
+
+
+# -- compilation ---------------------------------------------------------------
+
+def test_bridge_python_compiles():
+    """The embedded Python must compile without syntax errors."""
+    with tempfile.NamedTemporaryFile(suffix=".py", mode="w", delete=False) as f:
+        f.write(BRIDGE_PY)
+        tmp = f.name
+    try:
+        py_compile.compile(tmp, doraise=True)
+    finally:
+        Path(tmp).unlink()
+
+
+# -- helpers for loading bridge functions into a test namespace -----------------
+
+def _load_bridge_functions():
+    """exec the bridge code (without running main) and return the globals dict."""
+    # Strip the 'if __name__ == "__main__":' guard so main() doesn't fire.
+    code = BRIDGE_PY
+    # Remove from the last occurrence of "if __name__" to end-of-file
+    m = re.search(r'\nif __name__\s*==\s*["\']__main__["\']', code)
+    if m:
+        code = code[: m.start()]
+    # Set env vars the bridge expects at import time
+    import os as _os
+    _os.environ.setdefault("TAOS_BRIDGE_URL", "http://127.0.0.1:8989")
+    _os.environ.setdefault("TAOS_AGENT_NAME", "test-agent")
+    _os.environ.setdefault("TAOS_LOCAL_TOKEN", "test-token")
+    _os.environ.setdefault("LITELLM_API_KEY", "")
+    _os.environ.setdefault("TAOS_MODEL", "test-model")
+    ns: dict = {}
+    exec(code, ns)
+    return ns
+
+
+@pytest.fixture(scope="module")
+def bridge_ns():
+    """Module-scoped fixture: loads the bridge functions once."""
+    return _load_bridge_functions()
+
+
+# -- call_hermes retry tests ---------------------------------------------------
+
+class TestCallHermesRetry:
+    """call_hermes(client, messages) → str"""
+
+    def test_200_returns_content(self, bridge_ns):
+        call_hermes = bridge_ns["call_hermes"]
+        client = MagicMock()
+        client.post = AsyncMock(return_value=MagicMock(
+            status_code=200,
+            json=MagicMock(return_value={"choices": [{"message": {"content": "hello"}}]}),
+        ))
+
+        result = asyncio.run(call_hermes(client, [{"role": "user", "content": "hi"}]))
+        assert result == "hello"
+        assert client.post.call_count == 1
+
+    def test_5xx_retries_with_backoff(self, bridge_ns):
+        call_hermes = bridge_ns["call_hermes"]
+        client = MagicMock()
+
+        # Fail twice with 503, succeed on third attempt
+        client.post = AsyncMock(side_effect=[
+            MagicMock(status_code=503, text="Service Unavailable"),
+            MagicMock(status_code=503, text="Service Unavailable"),
+            MagicMock(status_code=200, json=MagicMock(
+                return_value={"choices": [{"message": {"content": "recovered"}}]},
+            )),
+        ])
+
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = asyncio.run(call_hermes(client, [{"role": "user", "content": "hi"}]))
+
+        assert result == "recovered"
+        assert client.post.call_count == 3
+        # Backoff: attempt 1 delay=2, attempt 2 delay=4
+        assert mock_sleep.call_count == 2
+        assert mock_sleep.call_args_list[0].args[0] == pytest.approx(2.0)   # 2^1
+        assert mock_sleep.call_args_list[1].args[0] == pytest.approx(4.0)   # 2^2
+
+    def test_4xx_returns_immediately_no_retry(self, bridge_ns):
+        call_hermes = bridge_ns["call_hermes"]
+        client = MagicMock()
+        client.post = AsyncMock(return_value=MagicMock(
+            status_code=400, text="Bad Request",
+        ))
+
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = asyncio.run(call_hermes(client, [{"role": "user", "content": "hi"}]))
+
+        assert result.startswith("[hermes returned 400:")
+        assert client.post.call_count == 1
+        mock_sleep.assert_not_called()
+
+    def test_exception_retries_then_returns_error(self, bridge_ns):
+        call_hermes = bridge_ns["call_hermes"]
+        client = MagicMock()
+        client.post = AsyncMock(side_effect=TimeoutError("timed out"))
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = asyncio.run(call_hermes(client, [{"role": "user", "content": "hi"}]))
+
+        assert "[hermes error: timed out]" in result or "[hermes error: TimeoutError]" in result
+        assert client.post.call_count == 3  # MAX_RETRIES
+
+    def test_all_retries_exhausted_returns_last_error(self, bridge_ns):
+        call_hermes = bridge_ns["call_hermes"]
+        client = MagicMock()
+
+        # All three attempts return 503
+        client.post = AsyncMock(return_value=MagicMock(
+            status_code=503, text="Gateway Timeout",
+        ))
+
+        result = asyncio.run(call_hermes(client, [{"role": "user", "content": "hi"}]))
+        assert result.startswith("[hermes returned 503:")
+        assert client.post.call_count == 3
+
+
+# -- handle_user_message dedup + cooldown tests --------------------------------
+
+class TestHandleUserMessageDedup:
+    """handle_user_message(client, evt, channel, _seen, _error_until) → bool"""
+
+    def _make_evt(self, msg_id="msg-1", text="hello"):
+        return {"id": msg_id, "trace_id": msg_id, "text": text}
+
+    def _make_channel(self):
+        return {"reply_url": "http://x/reply", "auth_bearer": "tok"}
+
+    def test_duplicate_message_skipped(self, bridge_ns):
+        handle = bridge_ns["handle_user_message"]
+        client = MagicMock()
+        client.post = AsyncMock()
+        evt = self._make_evt()
+        channel = self._make_channel()
+        seen: set = set()
+        error_until: list = [0.0]
+
+        # First call — should process
+        seen_before = seen.copy()
+        # We need to mock call_hermes to return a non-error
+        with patch.dict(bridge_ns, {"call_hermes": AsyncMock(return_value="ok")}):
+            result1 = asyncio.run(handle(client, evt, channel, seen, error_until))
+        assert result1 is True
+        assert "msg-1" in seen
+
+        # Second call with same msg_id — should be skipped
+        with patch.dict(bridge_ns, {"call_hermes": AsyncMock(return_value="ok")}):
+            result2 = asyncio.run(handle(client, evt, channel, seen, error_until))
+        assert result2 is False  # dedup suppressed
+
+    def test_error_cooldown_blocks_subsequent_messages(self, bridge_ns):
+        handle = bridge_ns["handle_user_message"]
+        client = MagicMock()
+        client.post = AsyncMock()
+        channel = self._make_channel()
+        seen: set = set()
+        error_until: list = [0.0]
+
+        # First message returns a hermes error → starts cooldown
+        with patch.dict(bridge_ns, {"call_hermes": AsyncMock(
+            return_value="[hermes error: ReadTimeout]"
+        )}):
+            result1 = asyncio.run(handle(client, self._make_evt("m1"), channel, seen, error_until))
+        assert result1 is True
+        assert error_until[0] > 0  # cooldown timestamp set
+
+        # Second message arrives during cooldown → suppressed
+        with patch.dict(bridge_ns, {"call_hermes": AsyncMock(return_value="ok")}):
+            result2 = asyncio.run(handle(client, self._make_evt("m2"), channel, seen, error_until))
+        assert result2 is False  # cooldown suppressed
+
+    def test_no_cooldown_for_non_error_reply(self, bridge_ns):
+        handle = bridge_ns["handle_user_message"]
+        client = MagicMock()
+        client.post = AsyncMock()
+        channel = self._make_channel()
+        seen: set = set()
+        error_until: list = [0.0]
+
+        with patch.dict(bridge_ns, {"call_hermes": AsyncMock(return_value="Normal reply")}):
+            result1 = asyncio.run(handle(client, self._make_evt("m1"), channel, seen, error_until))
+        assert result1 is True
+        assert error_until[0] == 0.0  # no cooldown triggered
+
+        # Next message should process normally
+        with patch.dict(bridge_ns, {"call_hermes": AsyncMock(return_value="Another reply")}):
+            result2 = asyncio.run(handle(client, self._make_evt("m2"), channel, seen, error_until))
+        assert result2 is True
+
+
+# -- bounded _seen test --------------------------------------------------------
+
+class TestSeenBounded:
+    def test_seen_clears_at_1000_to_prevent_unbounded_growth(self, bridge_ns):
+        """Verify the _MAX_SEEN guard exists in the source."""
+        assert "_MAX_SEEN" in BRIDGE_PY, "Missing _MAX_SEEN constant"
+        assert "len(_seen) >= _MAX_SEEN" in BRIDGE_PY, "Missing bound check"
+        assert "_seen.clear()" in BRIDGE_PY, "Missing clear on bound"

--- a/tinyagentos/scripts/install_hermes.sh
+++ b/tinyagentos/scripts/install_hermes.sh
@@ -263,11 +263,16 @@ async def handle_user_message(client: httpx.AsyncClient, evt: dict, channel: dic
     attach_line = _render_attachments(evt.get("attachments") or [])
     cid = evt.get("channel_id")
 
-    # Dedup: never re-process the same message
+    # Dedup: never re-process the same message.
+    # Bound the set to prevent unbounded growth over very long-lived SSE sessions.
+    _MAX_SEEN = 1000
     if msg_id and msg_id in _seen:
         log.info("user_message id=%s already processed — skipping", msg_id)
         return False
     if msg_id:
+        if len(_seen) >= _MAX_SEEN:
+            # Discard oldest half to keep memory bounded
+            _seen.clear()
         _seen.add(msg_id)
 
     # Error cooldown: after a final failure, pause before accepting new messages

--- a/tinyagentos/scripts/install_hermes.sh
+++ b/tinyagentos/scripts/install_hermes.sh
@@ -123,6 +123,9 @@ HERMES_URL = os.environ.get("HERMES_API_URL", "http://127.0.0.1:8642")
 HERMES_KEY = os.environ.get("LITELLM_API_KEY", "")
 HERMES_MODEL = os.environ.get("TAOS_MODEL", "kilo-auto/free")
 RECONNECT_DELAY = 2.0
+MAX_RETRIES = 3
+RETRY_BACKOFF_BASE = 2.0  # seconds — grows to 2, 4, 8 for retries 1-3
+ERROR_COOLDOWN = 5.0      # seconds after a final error before accepting new messages
 
 
 async def fetch_bootstrap(client: httpx.AsyncClient) -> dict:
@@ -192,7 +195,8 @@ async def _thinking(c: httpx.AsyncClient, ch_id, state: str, *,
 
 async def call_hermes(client: httpx.AsyncClient, messages: list) -> str:
     """Call Hermes' OpenAI-compatible /v1/chat/completions and return the
-    assistant's reply text. Errors return a short error string so the
+    assistant's reply text. Retries with exponential backoff on transient
+    failures; returns a short error string if all attempts fail so the
     user always sees something."""
     payload = {
         "model": HERMES_MODEL,
@@ -201,21 +205,34 @@ async def call_hermes(client: httpx.AsyncClient, messages: list) -> str:
     headers = {"Content-Type": "application/json"}
     if HERMES_KEY:
         headers["Authorization"] = f"Bearer {HERMES_KEY}"
-    try:
-        resp = await client.post(f"{HERMES_URL}/v1/chat/completions",
-                                  json=payload, headers=headers, timeout=120)
-        if resp.status_code != 200:
+    last_error = ""
+    for attempt in range(1, MAX_RETRIES + 1):
+        try:
+            resp = await client.post(f"{HERMES_URL}/v1/chat/completions",
+                                      json=payload, headers=headers, timeout=120)
+            if resp.status_code == 200:
+                data = resp.json()
+                return data["choices"][0]["message"]["content"]
+            # Non-200: 5xx are retryable, 4xx are not
+            if 500 <= resp.status_code < 600 and attempt < MAX_RETRIES:
+                delay = RETRY_BACKOFF_BASE ** attempt
+                log.warning("hermes %d (attempt %d/%d) — retry in %.1fs",
+                            resp.status_code, attempt, MAX_RETRIES, delay)
+                last_error = f"[hermes returned {resp.status_code}: {resp.text[:200]}]"
+                await asyncio.sleep(delay)
+                continue
             return f"[hermes returned {resp.status_code}: {resp.text[:200]}]"
-        data = resp.json()
-        return data["choices"][0]["message"]["content"]
-    except Exception as e:
-        # str(e) is empty for several httpx errors (notably ReadTimeout), which
-        # produced a blank "[hermes error: ]" that hid the real cause — e.g. the
-        # Hermes agent loop running past the request timeout against a slow
-        # local model. Always surface a non-empty detail (exception type at
-        # minimum) so the user/logs see what actually failed.
-        detail = str(e) or type(e).__name__
-        return f"[hermes error: {detail}]"
+        except Exception as e:
+            detail = str(e) or type(e).__name__
+            if attempt < MAX_RETRIES:
+                delay = RETRY_BACKOFF_BASE ** attempt
+                log.warning("hermes error %s (attempt %d/%d) — retry in %.1fs",
+                            detail, attempt, MAX_RETRIES, delay)
+                last_error = f"[hermes error: {detail}]"
+                await asyncio.sleep(delay)
+                continue
+            return f"[hermes error: {detail}]"
+    return last_error or "[hermes error: unknown]"
 
 
 async def post_reply(client: httpx.AsyncClient, reply_url: str, token: str,
@@ -233,7 +250,11 @@ async def post_reply(client: httpx.AsyncClient, reply_url: str, token: str,
         log.warning("reply POST failed: %s", e)
 
 
-async def handle_user_message(client: httpx.AsyncClient, evt: dict, channel: dict) -> None:
+async def handle_user_message(client: httpx.AsyncClient, evt: dict, channel: dict,
+                              _seen: set, _error_until: list) -> bool:
+    """Process one user_message event. Returns True if a reply was posted.
+    Deduplicates by msg_id and enforces an error cooldown to prevent
+    runaway retry loops driven by repeated SSE events."""
     msg_id = evt.get("id", "")
     trace_id = evt.get("trace_id", msg_id)
     text = evt.get("text", "")
@@ -241,6 +262,21 @@ async def handle_user_message(client: httpx.AsyncClient, evt: dict, channel: dic
     ctx = _render_context(evt.get("context") or [])
     attach_line = _render_attachments(evt.get("attachments") or [])
     cid = evt.get("channel_id")
+
+    # Dedup: never re-process the same message
+    if msg_id and msg_id in _seen:
+        log.info("user_message id=%s already processed — skipping", msg_id)
+        return False
+    if msg_id:
+        _seen.add(msg_id)
+
+    # Error cooldown: after a final failure, pause before accepting new messages
+    now = asyncio.get_event_loop().time()
+    if now < _error_until[0]:
+        log.info("user_message id=%s suppressed during error cooldown (%.1fs remaining)",
+                 msg_id, _error_until[0] - now)
+        return False
+
     log.info("user_message id=%s text=%r force=%s", msg_id, text[:80], force)
     system = _SYSTEM_PROMPT + ("\n\nYou were directly addressed. Reply naturally; do not output NO_RESPONSE."
         if force else
@@ -259,12 +295,21 @@ async def handle_user_message(client: httpx.AsyncClient, evt: dict, channel: dic
     final = _suppress(reply, force)
     if final is None:
         log.info("suppressed NO_RESPONSE for id=%s", msg_id)
-        return
+        return False
+
+    # If the reply is an error, start the cooldown to prevent tight retry loops
+    if final.startswith("[hermes "):
+        log.warning("hermes error reply for id=%s — enabling %.1fs cooldown", msg_id, ERROR_COOLDOWN)
+        _error_until[0] = asyncio.get_event_loop().time() + ERROR_COOLDOWN
+
     await post_reply(client, channel["reply_url"], channel["auth_bearer"],
                      msg_id, trace_id, final, cid)
+    return True
 
 
 async def sse_loop(client: httpx.AsyncClient, channel: dict, stop: asyncio.Event) -> None:
+    seen_ids: set[str] = set()
+    error_until: list[float] = [0.0]  # mutable so tasks can update it
     while not stop.is_set():
         try:
             log.info("SSE connecting to %s", channel["events_url"])
@@ -287,7 +332,8 @@ async def sse_loop(client: httpx.AsyncClient, channel: dict, stop: asyncio.Event
                         if evt_type == "user_message" and evt_data:
                             try:
                                 evt = json.loads(evt_data)
-                                asyncio.create_task(handle_user_message(client, evt, channel))
+                                asyncio.create_task(handle_user_message(
+                                    client, evt, channel, seen_ids, error_until))
                             except Exception as e:
                                 log.warning("parse error: %s", e)
                         evt_type, evt_data = "", ""


### PR DESCRIPTION
## Problem

Reported in issue #460: a deployed Hermes agent on a slow local model would hit the bridge 120s timeout, return `[hermes error: ReadTimeout]`, then re-enter the same request because the SSE stream kept delivering the same user-message event — creating a silent retry loop. PR #465 fixed the blank-error half. This PR adds defense-in-depth against the loop itself.

## Changes

**Bounded retry with exponential backoff:** MAX_RETRIES=3 with 2s/4s/8s backoff. 5xx responses retry; 4xx return immediately. Exceptions retry the same way. After exhausting retries, the last error is surfaced.

**Message deduplication:** Track processed message IDs in a _seen set inside sse_loop. Duplicate SSE events are logged and skipped. Set is bounded at 1000 IDs (clears when full) to prevent unbounded memory growth over long-lived SSE sessions.

**Error cooldown:** After a final Hermes failure, a 5s cooldown suppresses all incoming user messages. This breaks the tight retry loop at the bridge layer. Only triggered by `[hermes …]` error replies, not normal replies or suppressed NO_RESPONSE.

**Regression tests (tests/test_hermes_bridge.py):** 10 tests covering compilation, retry behaviour (200/4xx/5xx/exception), dedup suppression, cooldown blocking, and source-level guard assertions. Extracts embedded Python from the shell heredoc and exercises functions with mocked httpx clients.

## Verification
- ✓ 10/10 tests pass: `pytest tests/test_hermes_bridge.py -v` (Python 3.12)
- Existing `py_compile` guard for embedded Python still passes
- No regression: blank-error fix from #465 preserved

Closes #460