### PR TITLE
fix: disable agent management buttons when not running, add error feedback

### DIFF
--- a/desktop/src/apps/AgentsApp.tsx
+++ b/desktop/src/apps/AgentsApp.tsx
@@ -152,6 +152,12 @@ function AgentRow({
     latestForAgent.sha !== agent.framework_version_sha;
 
   const btnCls = isMobile ? "h-11 w-11" : "h-8 w-8";
+  // Only allow management actions while the agent is running
+  const running = agent.status === "running";
+  const disabledCls = running
+    ? "hover:bg-shell-surface-hover"
+    : "opacity-40 cursor-not-allowed";
+  const disabledAria = running ? undefined : "Agent is not running";
 
   const actionButtons = (
     <>
@@ -170,30 +176,33 @@ function AgentRow({
       <Button
         variant="ghost"
         size="icon"
-        className={btnCls}
-        onClick={() => onViewLogs(agent.name)}
-        aria-label={`View logs for ${agent.name}`}
-        title="View Logs"
+        className={`${btnCls} ${running ? "hover:bg-shell-surface-hover" : "opacity-40 cursor-not-allowed"}`}
+        onClick={running ? () => onViewLogs(agent.name) : undefined}
+        disabled={!running}
+        aria-label={`View logs for ${agent.name}${disabledAria ? ` (${disabledAria})` : ""}`}
+        title={running ? "View Logs" : "Agent must be running to view logs"}
       >
         <ScrollText size={15} />
       </Button>
       <Button
         variant="ghost"
         size="icon"
-        className={btnCls}
-        onClick={() => onViewSkills(agent.name)}
-        aria-label={`Manage skills for ${agent.name}`}
-        title="Skills"
+        className={`${btnCls} ${running ? "hover:bg-shell-surface-hover" : "opacity-40 cursor-not-allowed"}`}
+        onClick={running ? () => onViewSkills(agent.name) : undefined}
+        disabled={!running}
+        aria-label={`Manage skills for ${agent.name}${disabledAria ? ` (${disabledAria})` : ""}`}
+        title={running ? "Skills" : "Agent must be running to manage skills"}
       >
         <Wrench size={15} />
       </Button>
       <Button
         variant="ghost"
         size="icon"
-        className={btnCls}
-        onClick={() => onViewMessages(agent.name)}
-        aria-label={`View messages for ${agent.name}`}
-        title="Messages"
+        className={`${btnCls} ${running ? "hover:bg-shell-surface-hover" : "opacity-40 cursor-not-allowed"}`}
+        onClick={running ? () => onViewMessages(agent.name) : undefined}
+        disabled={!running}
+        aria-label={`View messages for ${agent.name}${disabledAria ? ` (${disabledAria})` : ""}`}
+        title={running ? "Messages" : "Agent must be running to view messages"}
       >
         <MessageSquare size={15} />
       </Button>
@@ -2185,12 +2194,17 @@ export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
           const err = await res.json();
           if (err?.error) msg = String(err.error);
         } catch { /* ignore */ }
-        window.alert(msg);
+        useNotificationStore.getState().addNotification({
+          source: name, title: "Resume failed", body: msg, level: "error",
+        });
         return;
       }
       fetchAgents();
     } catch (e) {
-      window.alert(e instanceof Error ? e.message : "Network error");
+      useNotificationStore.getState().addNotification({
+        source: name, title: "Resume failed",
+        body: e instanceof Error ? e.message : "Network error", level: "error",
+      });
     }
   }
 

--- a/desktop/src/apps/AgentsApp.tsx
+++ b/desktop/src/apps/AgentsApp.tsx
@@ -176,7 +176,7 @@ function AgentRow({
       <Button
         variant="ghost"
         size="icon"
-        className={`${btnCls} ${running ? "hover:bg-shell-surface-hover" : "opacity-40 cursor-not-allowed"}`}
+        className={`${btnCls} ${disabledCls}`}
         onClick={running ? () => onViewLogs(agent.name) : undefined}
         disabled={!running}
         aria-label={`View logs for ${agent.name}${disabledAria ? ` (${disabledAria})` : ""}`}
@@ -187,7 +187,7 @@ function AgentRow({
       <Button
         variant="ghost"
         size="icon"
-        className={`${btnCls} ${running ? "hover:bg-shell-surface-hover" : "opacity-40 cursor-not-allowed"}`}
+        className={`${btnCls} ${disabledCls}`}
         onClick={running ? () => onViewSkills(agent.name) : undefined}
         disabled={!running}
         aria-label={`Manage skills for ${agent.name}${disabledAria ? ` (${disabledAria})` : ""}`}
@@ -198,7 +198,7 @@ function AgentRow({
       <Button
         variant="ghost"
         size="icon"
-        className={`${btnCls} ${running ? "hover:bg-shell-surface-hover" : "opacity-40 cursor-not-allowed"}`}
+        className={`${btnCls} ${disabledCls}`}
         onClick={running ? () => onViewMessages(agent.name) : undefined}
         disabled={!running}
         aria-label={`View messages for ${agent.name}${disabledAria ? ` (${disabledAria})` : ""}`}

--- a/desktop/src/apps/__tests__/AgentsApp.button-disable.test.tsx
+++ b/desktop/src/apps/__tests__/AgentsApp.button-disable.test.tsx
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+// Stub heavy deps (same pattern as AgentsApp.test.tsx)
+vi.mock("@/hooks/use-is-mobile", () => ({ useIsMobile: () => false }));
+vi.mock("@/lib/framework-api", () => ({ fetchLatestFrameworks: async () => ({}) }));
+vi.mock("@/lib/models", () => ({
+  fetchClusterWorkers: async () => [],
+  workersToAggregated: () => [],
+  HOST_BADGE_CLASS: "",
+  CLOUD_PROVIDER_TYPES: [],
+}));
+vi.mock("@/lib/cluster", () => ({
+  availableKvQuantOptions: () => ({ k: ["fp16"], v: ["fp16"], boundary: false, flat: ["fp16"] }),
+}));
+vi.mock("@/lib/agent-emoji", () => ({ resolveAgentEmoji: () => "🤖" }));
+vi.mock("@/components/EmojiPicker", () => ({ EmojiPickerField: () => null }));
+vi.mock("@/components/ModelPickerFlow", () => ({ ModelPickerFlow: () => null }));
+vi.mock("@/components/ModelPickerModal", () => ({ ModelPickerModal: () => null }));
+vi.mock("@/components/persona-picker/PersonaPicker", () => ({ PersonaPicker: () => null }));
+vi.mock("@/lib/slug", () => ({
+  slugifyClient: (s: string) => s,
+  isValidSlug: () => true,
+  SLUG_REGEX: /^[a-z0-9][a-z0-9-]{0,62}$/,
+}));
+vi.mock("@/components/MigrationBanner", () => ({ MigrationBanner: () => null }));
+vi.mock("@/components/agent-settings/PersonaTab", () => ({ PersonaTab: () => null }));
+vi.mock("@/components/agent-settings/MemoryTab", () => ({ MemoryTab: () => null }));
+vi.mock("@/components/agent-settings/FrameworkTab", () => ({ FrameworkTab: () => null }));
+vi.mock("../AgentSkillsPanel", () => ({ AgentSkillsPanel: () => null }));
+vi.mock("../AgentMessagesPanel", () => ({ AgentMessagesPanel: () => null }));
+vi.mock("@/components/ui", () => ({
+  Button: ({ children, onClick, className, disabled, "aria-label": ariaLabel, title, ...rest }:
+    React.ButtonHTMLAttributes<HTMLButtonElement> & { children?: React.ReactNode }) => (
+    <button
+      onClick={onClick}
+      className={className}
+      disabled={disabled}
+      aria-label={ariaLabel}
+      title={title}
+      {...rest}
+    >
+      {children}
+    </button>
+  ),
+  Card: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+  Label: ({ children }: { children: React.ReactNode }) => <label>{children}</label>,
+  Tabs: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsList: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsTrigger: ({ children }: { children: React.ReactNode }) => <button>{children}</button>,
+}));
+vi.mock("@/stores/process-store", () => ({
+  useProcessStore: (sel: (s: { openWindow: ReturnType<typeof vi.fn> }) => unknown) =>
+    sel({ openWindow: vi.fn() }),
+}));
+
+// Mock AgentShortcutRow
+vi.mock("@/components/AgentShortcutRow", () => ({
+  AgentShortcutRow: ({ agentId, onLaunch }: { agentId: string; onLaunch: unknown }) => (
+    <div data-testid={`shortcut-row-${agentId}`} data-has-launch={typeof onLaunch === "function" ? "true" : "false"} />
+  ),
+}));
+
+// Mock notification store so we can assert toast was shown
+const mockAddNotification = vi.fn();
+vi.mock("@/stores/notification-store", () => ({
+  useNotificationStore: { getState: () => ({ addNotification: mockAddNotification }) },
+}));
+
+import { AgentsApp } from "../AgentsApp";
+
+const STOPPED_AGENT = {
+  name: "agent-stopped",
+  display_name: "Stopped Agent",
+  host: "localhost",
+  color: "#ef4444",
+  status: "stopped",
+  vectors: 0,
+  framework: "openclaw",
+  paused: false,
+};
+
+const RUNNING_AGENT = {
+  name: "agent-running",
+  display_name: "Running Agent",
+  host: "localhost",
+  color: "#22c55e",
+  status: "running",
+  vectors: 10,
+  framework: "openclaw",
+  paused: false,
+};
+
+describe("AgentsApp — button disable for non-running agents (PR #469)", () => {
+  beforeEach(() => {
+    mockAddNotification.mockReset();
+    vi.stubGlobal("fetch", vi.fn().mockImplementation((url: string) => {
+      if (url === "/api/agents") {
+        return Promise.resolve({
+          ok: true,
+          headers: { get: () => "application/json" },
+          json: () => Promise.resolve([STOPPED_AGENT]),
+        } as unknown as Response);
+      }
+      if (url === "/api/agents/archived") {
+        return Promise.resolve({
+          ok: true,
+          headers: { get: () => "application/json" },
+          json: () => Promise.resolve([]),
+        } as unknown as Response);
+      }
+      return Promise.resolve({
+        ok: false,
+        headers: { get: () => "application/json" },
+        json: () => Promise.resolve({}),
+      } as unknown as Response);
+    }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("disables logs/skills/messages buttons when agent is stopped", async () => {
+    render(<AgentsApp windowId="test" />);
+
+    const logsBtn = await screen.findByRole("button", { name: /view logs for agent-stopped/i });
+    expect(logsBtn).toBeDisabled();
+    expect(logsBtn.className).toContain("cursor-not-allowed");
+    expect(logsBtn.getAttribute("aria-label")).toContain("Agent is not running");
+    expect(logsBtn.getAttribute("title")).toBe("Agent must be running to view logs");
+
+    const skillsBtn = screen.getByRole("button", { name: /manage skills for agent-stopped/i });
+    expect(skillsBtn).toBeDisabled();
+    expect(skillsBtn.getAttribute("title")).toBe("Agent must be running to manage skills");
+
+    const msgsBtn = screen.getByRole("button", { name: /view messages for agent-stopped/i });
+    expect(msgsBtn).toBeDisabled();
+    expect(msgsBtn.getAttribute("title")).toBe("Agent must be running to view messages");
+  });
+
+  it("delete button stays enabled when agent is stopped", async () => {
+    render(<AgentsApp windowId="test" />);
+
+    const deleteBtn = await screen.findByRole("button", { name: /delete agent-stopped/i });
+    expect(deleteBtn).not.toBeDisabled();
+    expect(deleteBtn.className).not.toContain("cursor-not-allowed");
+  });
+});
+
+describe("AgentsApp — buttons enabled for running agents", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn().mockImplementation((url: string) => {
+      if (url === "/api/agents") {
+        return Promise.resolve({
+          ok: true,
+          headers: { get: () => "application/json" },
+          json: () => Promise.resolve([RUNNING_AGENT]),
+        } as unknown as Response);
+      }
+      if (url === "/api/agents/archived") {
+        return Promise.resolve({
+          ok: true,
+          headers: { get: () => "application/json" },
+          json: () => Promise.resolve([]),
+        } as unknown as Response);
+      }
+      return Promise.resolve({
+        ok: false,
+        headers: { get: () => "application/json" },
+        json: () => Promise.resolve({}),
+      } as unknown as Response);
+    }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("enables logs/skills/messages buttons when agent is running", async () => {
+    render(<AgentsApp windowId="test" />);
+
+    const logsBtn = await screen.findByRole("button", { name: /view logs for agent-running/i });
+    expect(logsBtn).not.toBeDisabled();
+    expect(logsBtn.getAttribute("title")).toBe("View Logs");
+    expect(logsBtn.getAttribute("aria-label")).not.toContain("Agent is not running");
+
+    const skillsBtn = screen.getByRole("button", { name: /manage skills for agent-running/i });
+    expect(skillsBtn).not.toBeDisabled();
+    expect(skillsBtn.getAttribute("title")).toBe("Skills");
+
+    const msgsBtn = screen.getByRole("button", { name: /view messages for agent-running/i });
+    expect(msgsBtn).not.toBeDisabled();
+    expect(msgsBtn.getAttribute("title")).toBe("Messages");
+  });
+});


### PR DESCRIPTION
## Problem

Reported in issue #459: the Agents app management buttons (View Logs,
Skills, Messages) silently did nothing when clicked on a stopped, error,
or deploying agent — no visual change, no error message, no feedback.

## Root cause

The button onClick handlers initiated navigation/panel changes that
depended on the agent being in a "running" state, but the buttons
themselves had no disabled state and gave no indication they were
inoperable.

## Fix

**Disable management buttons for non-running agents:**
- View Logs → disabled unless agent.status === "running"
- Skills → disabled unless agent.status === "running"  
- Messages → disabled unless agent.status === "running"
- Delete → always enabled (destructive, always actionable)

**Visual feedback on disabled state:**
- `opacity-40` + `cursor-not-allowed` classes applied
- `aria-label` includes "(Agent is not running)" suffix
- `title` explains why: "Agent must be running to view logs" etc.

**Resume-failure UX improvement:**
- Replaced `window.alert()` with notification toasts for resume
  failures — matches the rest of the app's notification pattern

**Regression tests (`AgentsApp.button-disable.test.tsx`):**
- 3 tests: stopped agent buttons disabled with correct aria/title,
  delete always enabled, running agent buttons enabled with normal labels

## Verification
- ✓ 3/3 frontend tests pass: `npx vitest run src/apps/__tests__/AgentsApp.button-disable.test.tsx` (Node 22)
- Visual: buttons on stopped agents show disabled styling + tooltips
- Running agents: buttons work normally
- Notification toasts fire on resume failures instead of modal alerts

Closes #459