### PR TITLE
fix(deploy): actionable error for unprivileged-LXC agent-deploy failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ One-click install for agent frameworks, AI models, and services. Hardware-aware,
 ### Agent Deployment
 5-step wizard: pick framework → choose model → configure → deploy into an isolated container (LXC on bare metal, Docker on VPS, auto-detected). Each agent gets its own memory system (taOSmd instance), its own file storage, and its own network identity. The framework runs inside the container but TinyAgentOS manages everything around it: memory, channels, secrets, model access, scheduled tasks, and inter-agent communication. This means the framework is a swappable component, not a lock-in decision.
 
+> **Running taOS *inside* an LXC (e.g. Proxmox)?** Deploying an agent creates a *nested* container, which an **unprivileged** LXC cannot do — the kernel can't remap the nested container's filesystem, so the deploy fails with an `idmapped storage / change ownership` error. Run the taOS LXC as **privileged with nesting enabled**. On Proxmox: untick *Unprivileged container* and set Options → Features → `nesting=1` (plus `keyctl=1`, `fuse=1`), then redeploy. Bare-metal and VM installs are unaffected. (taOS detects this and surfaces the fix in the deploy error.)
+
 <p align="center">
   <img src="docs/images/mobile-agents-empty.png" alt="Agents app empty state on mobile — one tap to deploy" width="30%">
 </p>

--- a/tests/test_deployer.py
+++ b/tests/test_deployer.py
@@ -986,3 +986,45 @@ class TestUndeployWithStateCleanup:
             result = await undeploy_agent("keeper", data_dir=tmp_path, delete_state=False)
             assert result["success"] is True
             assert (tmp_path / "agent-workspaces" / "keeper").exists()
+
+
+class TestContainerFailureExplanation:
+    """The opaque incus 'idmapped storage / change ownership' failure (nested
+    deploy in an unprivileged LXC) must be translated into actionable guidance.
+    See the discussion #357 LXC investigation."""
+
+    def test_idmap_failure_gives_privileged_container_guidance(self):
+        from tinyagentos.deployer import _explain_container_failure
+        raw = ("Launching taos-agent-x\nError: Failed instance creation: Failed "
+               "to handle idmapped storage: Failed to change ownership of: "
+               "/var/lib/incus/storage-pools/default/containers/taos-agent-x/rootfs")
+        msg = _explain_container_failure(raw)
+        assert "privileged" in msg.lower()
+        assert "nesting" in msg.lower()
+        assert raw in msg  # underlying error preserved for debugging
+
+    def test_generic_failure_passes_through_when_privileged(self, monkeypatch):
+        from tinyagentos import deployer
+        # Pretend we're NOT in an unprivileged userns so a generic error isn't
+        # misattributed to the container-privilege problem.
+        monkeypatch.setattr(deployer, "_is_unprivileged_userns", lambda: False)
+        msg = deployer._explain_container_failure("no space left on device")
+        assert msg == "Container creation failed: no space left on device"
+        assert "privileged" not in msg.lower()
+
+    def test_unprivileged_userns_flags_even_generic_error(self, monkeypatch):
+        from tinyagentos import deployer
+        monkeypatch.setattr(deployer, "_is_unprivileged_userns", lambda: True)
+        msg = deployer._explain_container_failure("some other failure")
+        assert "privileged" in msg.lower()
+
+    def test_uid_map_parsing(self, tmp_path):
+        from tinyagentos import deployer
+        # privileged / host: root maps to 0
+        f = tmp_path / "privileged"; f.write_text("         0          0 4294967295\n")
+        assert deployer._is_unprivileged_userns(str(f)) is False
+        # unprivileged: root maps to 100000
+        f2 = tmp_path / "unpriv"; f2.write_text("         0     100000      65536\n")
+        assert deployer._is_unprivileged_userns(str(f2)) is True
+        # missing file (e.g. macOS): not an unprivileged Linux userns
+        assert deployer._is_unprivileged_userns(str(tmp_path / "nope")) is False

--- a/tinyagentos/deployer.py
+++ b/tinyagentos/deployer.py
@@ -28,6 +28,47 @@ from tinyagentos.containers import (
 
 logger = logging.getLogger(__name__)
 
+
+def _is_unprivileged_userns(uid_map_path: str = "/proc/self/uid_map") -> bool:
+    """True when this process runs in an unprivileged user namespace.
+
+    In an unprivileged container (e.g. an unprivileged LXC) the root user is
+    mapped to a non-zero host UID. The first line of ``/proc/self/uid_map`` is
+    ``<ns_start> <host_start> <count>``; a privileged container or the host maps
+    ``0 0 ...`` (root↦root), while an unprivileged one maps ``0 100000 ...``.
+    Nested container creation can't remap a new container's rootfs in that case,
+    so agent deploys fail with an "idmapped storage / change ownership" error.
+    """
+    try:
+        with open(uid_map_path, encoding="ascii") as f:
+            fields = f.readline().split()
+    except OSError:
+        return False  # no procfs (e.g. macOS) — not an unprivileged Linux userns
+    return len(fields) == 3 and fields[1] != "0"
+
+
+def _explain_container_failure(raw_error: object) -> str:
+    """Turn a raw container-creation error into an actionable message.
+
+    The kernel-level "Failed to handle idmapped storage / change ownership"
+    error is opaque to users. When we see it — or we can confirm we're in an
+    unprivileged user namespace — explain that taOS needs a privileged
+    container and how to fix it (the common Proxmox case)."""
+    text = str(raw_error).strip() if raw_error else "unknown error"
+    idmap_failure = ("idmapped storage" in text.lower()
+                     or "change ownership" in text.lower())
+    if idmap_failure or _is_unprivileged_userns():
+        return (
+            "Container creation failed — taOS appears to be running in an "
+            "unprivileged container, which cannot create the nested agent "
+            "container (the kernel can't remap the new container's filesystem). "
+            "Fix: run taOS in a privileged container with nesting enabled. On "
+            "Proxmox, set the LXC to Privileged and enable Nesting (Options → "
+            "Features: nesting=1, keyctl=1, fuse=1), then redeploy. "
+            f"Underlying error: {text}"
+        )
+    return f"Container creation failed: {text}"
+
 _TAOSMD_BEGIN = "<!-- taosmd:rules-begin -->"
 _TAOSMD_END = "<!-- taosmd:rules-end -->"
 
@@ -242,7 +283,7 @@ async def deploy_agent(req: DeployRequest) -> dict:
         root_size_gib=req.root_size_gib,
     )
     if not result["success"]:
-        return {"success": False, "error": f"Container creation failed: {result.get('error')}", "steps": steps}
+        return {"success": False, "error": _explain_container_failure(result.get("error")), "steps": steps}
     steps.append("container_created")
 
     try:


### PR DESCRIPTION
## Problem

Deploying an agent while taOS runs inside an **unprivileged LXC** fails with an opaque kernel error:

```
Failed to handle idmapped storage: Failed to change ownership of: …/taos-agent-<x>/rootfs
```

Root cause (proven via a minimal nested-incus experiment): you can't stack an idmapped mount on an already-idmapped (unprivileged container) rootfs, so nested incus falls back to a recursive `chown` the nested userns can't perform. Fix is a **privileged container with nesting** (the standard Proxmox pattern). Full diagnosis in #471.

## Change

- `deployer._is_unprivileged_userns()` detects the unprivileged user namespace via `/proc/self/uid_map`.
- `deployer._explain_container_failure()` translates the `idmapped storage / change ownership` failure (or any failure when we can confirm an unprivileged userns) into actionable guidance: run a privileged container with nesting, with the exact Proxmox steps. Falls back to the original message otherwise (the underlying error is always preserved).
- README documents the privileged-LXC requirement under **Agent Deployment**.

## Verification

- 4 new unit tests in `tests/test_deployer.py` (idmap → guidance, generic → passthrough when privileged, unprivileged-userns flag, uid_map parsing incl. missing-file/macOS). Full file: 43/43 pass.
- Diagnosis validated live: nested container failed unprivileged, ran after `security.privileged=true` on the same pool.

Closes #471