### PR TITLE
refactor: consolidate provider-type lists to single source of truth

### DIFF
--- a/desktop/src/apps/ProvidersApp.tsx
+++ b/desktop/src/apps/ProvidersApp.tsx
@@ -1164,7 +1164,9 @@ export function ProvidersApp({ windowId: _windowId }: { windowId: string }) {
       .then((data) => {
         if (data?.local) setLocalTypes(data.local);
       })
-      .catch(() => {}); // keep fallback
+      .catch((err) => {
+        console.warn("Failed to fetch provider types, using fallback:", err);
+      });
   }, []);
 
   async function handleDelete(name: string) {

--- a/desktop/src/apps/ProvidersApp.tsx
+++ b/desktop/src/apps/ProvidersApp.tsx
@@ -1130,7 +1130,9 @@ export function ProvidersApp({ windowId: _windowId }: { windowId: string }) {
   const [editingProvider, setEditingProvider] = useState<Provider | null>(null);
   const [toast, setToast] = useState<string | null>(null);
   const [localTypes, setLocalTypes] = useState<string[]>([...FALLBACK_LOCAL_TYPES]);
-  const [cloudTypes, setCloudTypes] = useState<string[]>([...FALLBACK_CLOUD_TYPES]);
+  // Only the setter is used — it re-renders so categorization picks up the
+  // updated `_activeCloudTypes`; the value itself is read via that module var.
+  const [, setCloudTypes] = useState<string[]>([...FALLBACK_CLOUD_TYPES]);
 
   const showToast = useCallback((msg: string) => {
     setToast(msg);

--- a/desktop/src/apps/ProvidersApp.tsx
+++ b/desktop/src/apps/ProvidersApp.tsx
@@ -1187,6 +1187,13 @@ export function ProvidersApp({ windowId: _windowId }: { windowId: string }) {
         }
       })
       .finally(() => clearTimeout(timeout));
+
+    // Abort the in-flight fetch and clear the timeout on unmount so the
+    // .then handlers can't setState after the component is gone.
+    return () => {
+      controller.abort();
+      clearTimeout(timeout);
+    };
   }, []);
 
   async function handleDelete(name: string) {

--- a/desktop/src/apps/ProvidersApp.tsx
+++ b/desktop/src/apps/ProvidersApp.tsx
@@ -257,10 +257,12 @@ function ProviderForm({
   editing,
   onSave,
   onClose,
+  localTypes,
 }: {
   editing: Provider | null;
   onSave: () => void;
   onClose: () => void;
+  localTypes: string[];
 }) {
   type WizardCategory = "local" | "cluster" | "cloud";
   type WizardStep = "category" | "cloud-pick" | "cluster-info" | "config";
@@ -1120,7 +1122,6 @@ export function ProvidersApp({ windowId: _windowId }: { windowId: string }) {
   const [showForm, setShowForm] = useState(false);
   const [editingProvider, setEditingProvider] = useState<Provider | null>(null);
   const [toast, setToast] = useState<string | null>(null);
-  const [cloudTypes, setCloudTypes] = useState<string[]>([...FALLBACK_CLOUD_TYPES]);
   const [localTypes, setLocalTypes] = useState<string[]>([...FALLBACK_LOCAL_TYPES]);
 
   const showToast = useCallback((msg: string) => {
@@ -1161,7 +1162,6 @@ export function ProvidersApp({ windowId: _windowId }: { windowId: string }) {
     fetch("/api/providers/types", { headers: { Accept: "application/json" } })
       .then((r) => r.ok ? r.json() : null)
       .then((data) => {
-        if (data?.cloud) setCloudTypes(data.cloud);
         if (data?.local) setLocalTypes(data.local);
       })
       .catch(() => {}); // keep fallback
@@ -1399,6 +1399,7 @@ export function ProvidersApp({ windowId: _windowId }: { windowId: string }) {
           editing={editingProvider}
           onSave={handleFormSave}
           onClose={handleFormClose}
+          localTypes={localTypes}
         />
       )}
 

--- a/desktop/src/apps/ProvidersApp.tsx
+++ b/desktop/src/apps/ProvidersApp.tsx
@@ -20,6 +20,13 @@ import { useIsMobile } from "@/hooks/use-is-mobile";
 /** Fallback constants used before the API call completes. */
 const FALLBACK_CLOUD_TYPES = ["openai", "anthropic", "openrouter", "kilocode", "openai-compatible"] as const;
 const FALLBACK_LOCAL_TYPES = ["rkllama", "ollama", "llama-cpp", "vllm", "exo", "mlx", "sd-cpp", "rknn-sd"] as const;
+
+/** Active cloud types — seeded with fallback, updated from /api/providers/types.
+ *  Referenced by isCloud() and groupByCategory() directly so they don't
+ *  need prop-drilling through the entire component tree.  React state in
+ *  ProvidersApp mirrors this for re-render scheduling. */
+let _activeCloudTypes: readonly string[] = [...FALLBACK_CLOUD_TYPES];
+
 type ProviderType = string;
 
 const DEFAULT_URLS: Partial<Record<ProviderType, string>> = {
@@ -146,7 +153,7 @@ type TestResult = { reachable: boolean; response_ms?: number; models?: ProviderM
 /* ------------------------------------------------------------------ */
 
 function isCloud(type: string): boolean {
-  return (FALLBACK_CLOUD_TYPES as readonly string[]).includes(type);
+  return (_activeCloudTypes as readonly string[]).includes(type);
 }
 
 function TypePill({ type }: { type: string }) {
@@ -224,7 +231,7 @@ function WorkerBadge({ name, platform }: { name: string; platform?: string }) {
 function groupByCategory(providers: Provider[]): Record<ProviderCategory, Provider[]> {
   const groups: Record<ProviderCategory, Provider[]> = { local: [], network: [], cloud: [] };
   for (const p of providers) {
-    const cat: ProviderCategory = p.category ?? (p.source?.startsWith("worker:") ? "network" : (FALLBACK_CLOUD_TYPES as readonly string[]).includes(p.type) ? "cloud" : "local");
+    const cat: ProviderCategory = p.category ?? (p.source?.startsWith("worker:") ? "network" : (_activeCloudTypes as readonly string[]).includes(p.type) ? "cloud" : "local");
     groups[cat].push(p);
   }
   return groups;
@@ -1123,6 +1130,7 @@ export function ProvidersApp({ windowId: _windowId }: { windowId: string }) {
   const [editingProvider, setEditingProvider] = useState<Provider | null>(null);
   const [toast, setToast] = useState<string | null>(null);
   const [localTypes, setLocalTypes] = useState<string[]>([...FALLBACK_LOCAL_TYPES]);
+  const [cloudTypes, setCloudTypes] = useState<string[]>([...FALLBACK_CLOUD_TYPES]);
 
   const showToast = useCallback((msg: string) => {
     setToast(msg);
@@ -1159,14 +1167,26 @@ export function ProvidersApp({ windowId: _windowId }: { windowId: string }) {
 
   // Fetch canonical provider types once at boot (single source of truth).
   useEffect(() => {
-    fetch("/api/providers/types", { headers: { Accept: "application/json" } })
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5000);
+    fetch("/api/providers/types", {
+      headers: { Accept: "application/json" },
+      signal: controller.signal,
+    })
       .then((r) => r.ok ? r.json() : null)
       .then((data) => {
+        if (data?.cloud) {
+          _activeCloudTypes = data.cloud;
+          setCloudTypes(data.cloud);
+        }
         if (data?.local) setLocalTypes(data.local);
       })
       .catch((err) => {
-        console.warn("Failed to fetch provider types, using fallback:", err);
-      });
+        if (err.name !== "AbortError") {
+          console.warn("Failed to fetch provider types, using fallback:", err);
+        }
+      })
+      .finally(() => clearTimeout(timeout));
   }, []);
 
   async function handleDelete(name: string) {

--- a/desktop/src/apps/ProvidersApp.tsx
+++ b/desktop/src/apps/ProvidersApp.tsx
@@ -13,12 +13,14 @@ import { MobileSplitView } from "@/components/mobile/MobileSplitView";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 
 /* ------------------------------------------------------------------ */
-/*  Constants — matches VALID_BACKEND_TYPES in tinyagentos/config.py  */
+/*  Provider types — fetched from /api/providers/types at boot.       */
+/*  Single source of truth: tinyagentos/providers/__init__.py         */
 /* ------------------------------------------------------------------ */
 
-const CLOUD_TYPES = ["openai", "anthropic", "openrouter", "kilocode", "openai-compatible"] as const;
-const LOCAL_TYPES = ["rkllama", "ollama", "llama-cpp", "vllm", "exo", "mlx"] as const;
-type ProviderType = typeof CLOUD_TYPES[number] | typeof LOCAL_TYPES[number];
+/** Fallback constants used before the API call completes. */
+const FALLBACK_CLOUD_TYPES = ["openai", "anthropic", "openrouter", "kilocode", "openai-compatible"] as const;
+const FALLBACK_LOCAL_TYPES = ["rkllama", "ollama", "llama-cpp", "vllm", "exo", "mlx", "sd-cpp", "rknn-sd"] as const;
+type ProviderType = string;
 
 const DEFAULT_URLS: Partial<Record<ProviderType, string>> = {
   openai: "https://api.openai.com/v1",
@@ -144,7 +146,7 @@ type TestResult = { reachable: boolean; response_ms?: number; models?: ProviderM
 /* ------------------------------------------------------------------ */
 
 function isCloud(type: string): boolean {
-  return (CLOUD_TYPES as readonly string[]).includes(type);
+  return (FALLBACK_CLOUD_TYPES as readonly string[]).includes(type);
 }
 
 function TypePill({ type }: { type: string }) {
@@ -222,7 +224,7 @@ function WorkerBadge({ name, platform }: { name: string; platform?: string }) {
 function groupByCategory(providers: Provider[]): Record<ProviderCategory, Provider[]> {
   const groups: Record<ProviderCategory, Provider[]> = { local: [], network: [], cloud: [] };
   for (const p of providers) {
-    const cat: ProviderCategory = p.category ?? (p.source?.startsWith("worker:") ? "network" : (CLOUD_TYPES as readonly string[]).includes(p.type) ? "cloud" : "local");
+    const cat: ProviderCategory = p.category ?? (p.source?.startsWith("worker:") ? "network" : (FALLBACK_CLOUD_TYPES as readonly string[]).includes(p.type) ? "cloud" : "local");
     groups[cat].push(p);
   }
   return groups;
@@ -557,7 +559,7 @@ function ProviderForm({
                       onChange={(e) => handleTypeChange(e.target.value as ProviderType)}
                       className="flex h-9 w-full rounded-lg border border-white/10 bg-shell-bg-deep px-3 py-1 text-sm text-shell-text focus-visible:outline-none focus-visible:border-accent/40 focus-visible:ring-2 focus-visible:ring-accent/20"
                     >
-                      {LOCAL_TYPES.map((t) => <option key={t} value={t}>{t}</option>)}
+                      {localTypes.map((t) => <option key={t} value={t}>{t}</option>)}
                     </select>
                   </div>
                   <div className="space-y-1.5">
@@ -1118,6 +1120,8 @@ export function ProvidersApp({ windowId: _windowId }: { windowId: string }) {
   const [showForm, setShowForm] = useState(false);
   const [editingProvider, setEditingProvider] = useState<Provider | null>(null);
   const [toast, setToast] = useState<string | null>(null);
+  const [cloudTypes, setCloudTypes] = useState<string[]>([...FALLBACK_CLOUD_TYPES]);
+  const [localTypes, setLocalTypes] = useState<string[]>([...FALLBACK_LOCAL_TYPES]);
 
   const showToast = useCallback((msg: string) => {
     setToast(msg);
@@ -1151,6 +1155,17 @@ export function ProvidersApp({ windowId: _windowId }: { windowId: string }) {
     const interval = setInterval(fetchProviders, 30_000);
     return () => clearInterval(interval);
   }, [fetchProviders]);
+
+  // Fetch canonical provider types once at boot (single source of truth).
+  useEffect(() => {
+    fetch("/api/providers/types", { headers: { Accept: "application/json" } })
+      .then((r) => r.ok ? r.json() : null)
+      .then((data) => {
+        if (data?.cloud) setCloudTypes(data.cloud);
+        if (data?.local) setLocalTypes(data.local);
+      })
+      .catch(() => {}); // keep fallback
+  }, []);
 
   async function handleDelete(name: string) {
     if (!window.confirm(`Remove provider "${name}"?`)) return;

--- a/tinyagentos/config.py
+++ b/tinyagentos/config.py
@@ -8,7 +8,7 @@ from typing import Literal
 
 import yaml
 
-VALID_BACKEND_TYPES = {"rkllama", "ollama", "llama-cpp", "vllm", "exo", "mlx", "openai", "anthropic", "sd-cpp", "rknn-sd", "openrouter", "kilocode", "openai-compatible"}
+from tinyagentos.providers import ALL_TYPES as VALID_BACKEND_TYPES
 
 VALID_ON_WORKER_FAILURE = {"pause", "fallback", "escalate-immediately"}
 

--- a/tinyagentos/llm_proxy.py
+++ b/tinyagentos/llm_proxy.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 import httpx
 
-from tinyagentos.providers import BACKEND_TYPE_MAP, CHAT_BACKEND_TYPE_MAP, CLOUD_TYPES as CLOUD_BACKEND_TYPES
+from tinyagentos.providers import BACKEND_TYPE_MAP, CHAT_BACKEND_TYPE_MAP, CLOUD_TYPES as CLOUD_BACKEND_TYPES, NEEDS_API_BASE_TYPES
 
 logger = logging.getLogger(__name__)
 
@@ -217,7 +217,7 @@ def generate_litellm_config(
         }
 
         # Set api_base for local/self-hosted backends and openai-compatible
-        if backend_type in ("ollama", "rkllama", "llama-cpp", "vllm", "exo", "mlx", "openai-compatible"):
+        if backend_type in NEEDS_API_BASE_TYPES:
             litellm_params["api_base"] = url
 
         # API key from secrets reference

--- a/tinyagentos/llm_proxy.py
+++ b/tinyagentos/llm_proxy.py
@@ -18,6 +18,8 @@ from pathlib import Path
 
 import httpx
 
+from tinyagentos.providers import BACKEND_TYPE_MAP, CHAT_BACKEND_TYPE_MAP, CLOUD_TYPES as CLOUD_BACKEND_TYPES
+
 logger = logging.getLogger(__name__)
 
 
@@ -56,34 +58,6 @@ def _pids_listening_on(port: int) -> list[int]:
         except ValueError:
             continue
     return pids
-
-# Map TinyAgentOS backend types to LiteLLM model prefixes
-BACKEND_TYPE_MAP = {
-    "ollama": "ollama",
-    "rkllama": "ollama",  # rkllama is ollama-compatible on /api/embed too
-    "llama-cpp": "openai",
-    "vllm": "openai",
-    "exo": "openai",
-    "mlx": "openai",
-    "openai": "openai",
-    "anthropic": "anthropic",
-    "openrouter": "openrouter",
-    "kilocode": "openai",  # kilocode is OpenAI-compatible; api_base set explicitly
-    "openai-compatible": "openai",  # user-supplied OpenAI-compatible endpoint; api_base required
-}
-
-# Chat prefix is different from the embedding prefix for ollama-compat
-# backends: ollama_chat uses /api/chat, plain ollama uses /api/generate and
-# /api/embed. LiteLLM needs the right one to route requests correctly.
-CHAT_BACKEND_TYPE_MAP = {
-    **BACKEND_TYPE_MAP,
-    "ollama": "ollama_chat",
-    "rkllama": "ollama_chat",
-}
-
-# Cloud provider types that may serve multiple named models and require
-# per-model model_list entries so agents can route by exact model id.
-CLOUD_BACKEND_TYPES = {"openai", "anthropic", "openrouter", "kilocode", "openai-compatible"}
 
 # Canonical alias the deployer injects into agent containers as
 # TAOS_EMBEDDING_MODEL. Agents that want an embedding call this name and

--- a/tinyagentos/providers/__init__.py
+++ b/tinyagentos/providers/__init__.py
@@ -46,6 +46,12 @@ CLOUD_TYPES: set[str] = {
 
 LOCAL_TYPES: set[str] = ALL_TYPES - CLOUD_TYPES
 
+# Backends where LiteLLM must receive an explicit api_base (self-hosted or
+# user-supplied endpoints). Cloud providers discover their base URL from the
+# LiteLLM provider registry.
+IMAGE_GEN_TYPES: set[str] = {"sd-cpp", "rknn-sd"}
+NEEDS_API_BASE_TYPES: set[str] = (LOCAL_TYPES - IMAGE_GEN_TYPES) | {"openai-compatible"}
+
 # ---------------------------------------------------------------------------
 # LiteLLM routing maps
 # ---------------------------------------------------------------------------

--- a/tinyagentos/providers/__init__.py
+++ b/tinyagentos/providers/__init__.py
@@ -1,0 +1,74 @@
+"""Canonical provider type definitions — single source of truth.
+
+Adding a new provider type means touching this file ONLY.
+
+  ALL_TYPES          — every valid backend type
+  CLOUD_TYPES        — cloud providers (require API key, serve multiple models)
+  LOCAL_TYPES        — everything that isn't cloud (derived: ALL_TYPES - CLOUD_TYPES)
+  BACKEND_TYPE_MAP   — TinyAgentOS type → LiteLLM model prefix
+  CHAT_BACKEND_TYPE_MAP — variant for chat routing (ollama_chat vs ollama)
+
+The frontend fetches these from GET /api/providers/types at boot.
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Type sets
+# ---------------------------------------------------------------------------
+
+ALL_TYPES: set[str] = {
+    # -- local LLM backends --
+    "rkllama",
+    "ollama",
+    "llama-cpp",
+    "vllm",
+    "exo",
+    "mlx",
+    # -- cloud LLM providers --
+    "openai",
+    "anthropic",
+    "openrouter",
+    "kilocode",
+    "openai-compatible",
+    # -- local image-generation backends --
+    "sd-cpp",
+    "rknn-sd",
+}
+
+CLOUD_TYPES: set[str] = {
+    "openai",
+    "anthropic",
+    "openrouter",
+    "kilocode",
+    "openai-compatible",
+}
+
+LOCAL_TYPES: set[str] = ALL_TYPES - CLOUD_TYPES
+
+# ---------------------------------------------------------------------------
+# LiteLLM routing maps
+# ---------------------------------------------------------------------------
+
+BACKEND_TYPE_MAP: dict[str, str] = {
+    "ollama": "ollama",
+    "rkllama": "ollama",  # rkllama is ollama-compatible on /api/embed too
+    "llama-cpp": "openai",
+    "vllm": "openai",
+    "exo": "openai",
+    "mlx": "openai",
+    "openai": "openai",
+    "anthropic": "anthropic",
+    "openrouter": "openrouter",
+    "kilocode": "openai",  # kilocode is OpenAI-compatible; api_base set explicitly
+    "openai-compatible": "openai",  # user-supplied OpenAI-compatible endpoint
+}
+
+# Chat prefix is different from the embedding prefix for ollama-compat
+# backends: ollama_chat uses /api/chat, plain ollama uses /api/generate and
+# /api/embed. LiteLLM needs the right one to route requests correctly.
+CHAT_BACKEND_TYPE_MAP: dict[str, str] = {
+    **BACKEND_TYPE_MAP,
+    "ollama": "ollama_chat",
+    "rkllama": "ollama_chat",
+}

--- a/tinyagentos/routes/providers.py
+++ b/tinyagentos/routes/providers.py
@@ -44,7 +44,7 @@ async def get_provider_types():
     The frontend fetches this at boot so adding a new provider type only
     touches ``tinyagentos/providers/__init__.py``.
     """
-    from tinyagentos.providers import ALL_TYPES, CLOUD_TYPES, LOCAL_TYPES
+    from tinyagentos.providers import ALL_TYPES, LOCAL_TYPES
 
     return {
         "all": sorted(ALL_TYPES),

--- a/tinyagentos/routes/providers.py
+++ b/tinyagentos/routes/providers.py
@@ -12,14 +12,11 @@ from tinyagentos.backend_adapters import get_adapter
 from tinyagentos.config import save_config_locked, VALID_BACKEND_TYPES
 from tinyagentos.lifecycle_manager import LifecycleManager
 from tinyagentos.llm_proxy import TAOS_LITELLM_MASTER_KEY
+from tinyagentos.providers import CLOUD_TYPES
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
-
-# Provider categories used by the UI to group entries. The backend
-# doesn't care about category for routing — it's purely display metadata.
-CLOUD_TYPES = {"openai", "anthropic", "openrouter", "kilocode", "openai-compatible"}
 
 # Defaults applied per-type when the Add Provider form doesn't supply
 # them. Covers the case where the UI collects just api_key + name and
@@ -38,6 +35,22 @@ PROVIDER_URL_DEFAULTS: dict[str, str] = {
 PROVIDER_DEFAULT_MODELS: dict[str, list[dict]] = {
     "kilocode": [{"id": "kilo-auto/free"}],
 }
+
+
+@router.get("/api/providers/types")
+async def get_provider_types():
+    """Return canonical provider type definitions (single source of truth).
+
+    The frontend fetches this at boot so adding a new provider type only
+    touches ``tinyagentos/providers/__init__.py``.
+    """
+    from tinyagentos.providers import ALL_TYPES, CLOUD_TYPES, LOCAL_TYPES
+
+    return {
+        "all": sorted(ALL_TYPES),
+        "cloud": sorted(CLOUD_TYPES),
+        "local": sorted(LOCAL_TYPES),
+    }
 
 
 async def _resolve_backend_secrets(


### PR DESCRIPTION
## Problem

Provider types were duplicated across 4 files (issue #351):
- `tinyagentos/config.py` — `VALID_BACKEND_TYPES`
- `tinyagentos/routes/providers.py` — `CLOUD_TYPES`
- `tinyagentos/llm_proxy.py` — `BACKEND_TYPE_MAP`, `CHAT_BACKEND_TYPE_MAP`, `CLOUD_BACKEND_TYPES`
- `desktop/src/apps/ProvidersApp.tsx` — `CLOUD_TYPES`, `LOCAL_TYPES`

Adding a new provider type meant touching all four. #350 missed
`llm_proxy.py` and would have silently routed requests to
`https://api.openai.com` instead of the user's configured URL.

## Solution

Single source of truth in `tinyagentos/providers/__init__.py`:
- `ALL_TYPES` — complete set
- `CLOUD_TYPES` / `LOCAL_TYPES` (derived: ALL - CLOUD)
- `BACKEND_TYPE_MAP` / `CHAT_BACKEND_TYPE_MAP` — LiteLLM routing

**Backend:** `config.py`, `llm_proxy.py`, `routes/providers.py` import
from `tinyagentos.providers` instead of defining their own copies.

**API:** New `GET /api/providers/types` endpoint returns canonical types
as JSON so the frontend can stay in sync without codegen.

**Frontend:** `ProvidersApp.tsx` fetches types from the API at boot.
Hardcoded values are kept as fallback defaults. Also fixed a bug where
`LOCAL_TYPES` was missing `sd-cpp` and `rknn-sd` (image gen backends).

## Verification

- No circular imports — verified via import smoke test
- `tinyagentos.providers` derivations: CLOUD ⊆ ALL, LOCAL = ALL - CLOUD
- Targeted tests: 56/56 pass (config, manifest, registry, auto-register)
- Provider-specific tests pass (backend catalog lifecycle, subscriptions)
- Frontend: TypeScript references updated, no orphaned constant names

Closes #351

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `/api/providers/types` endpoint that returns canonical provider type categorizations (all, cloud, local).

* **Refactor**
  * Centralized provider type definitions across backend services; application now dynamically loads provider types from the API at startup instead of using static configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jaylfc/tinyagentos/pull/477?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->