### PR TITLE
fix: address post-merge bot-review nitpicks (#463, #470, #472)

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -258,7 +258,7 @@ export function App() {
     <ShortcutProvider>
       <SystemShortcuts toggleSearch={toggleSearch} toggleLaunchpad={toggleLaunchpad} toggleAssistant={toggleAssistant} />
       <LoginGate>
-    <div className={`taos-wallpaper h-screen w-screen flex flex-col text-shell-text ${isBrowserMobile ? "taos-browser" : ""}`} style={{ backgroundColor: wallpaperFallback, ["--wallpaper-desktop" as never]: wallpaperImage, ["--wallpaper-mobile" as never]: wallpaperMobileImage }}>
+    <div className={`taos-wallpaper h-screen w-screen flex flex-col text-shell-text${isBrowserMobile ? " taos-browser" : ""}`} style={{ backgroundColor: wallpaperFallback, ["--wallpaper-desktop" as never]: wallpaperImage, ["--wallpaper-mobile" as never]: wallpaperMobileImage }}>
       {/* Install banner — shown in browser mode, hidden in PWA */}
       {isBrowserMobile && <InstallPromptBanner />}
       <div className={`flex-1 flex flex-col overflow-hidden transition-all duration-500 ${launched ? "opacity-100 scale-100" : "opacity-0 scale-95"}`}>

--- a/desktop/src/apps/AgentsApp.tsx
+++ b/desktop/src/apps/AgentsApp.tsx
@@ -2347,7 +2347,13 @@ export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
       return;
     }
 
-    const { redirect_url } = await res.json() as { redirect_url: string };
+    let redirect_url: string;
+    try {
+      ({ redirect_url } = await res.json() as { redirect_url: string });
+    } catch {
+      failed("Server returned an unexpected response.");
+      return;
+    }
     const kind = shortcut.kind;
     if (kind === "dashboard") {
       const app = getApp("browser");
@@ -2362,8 +2368,12 @@ export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
       // Establish the taos_shortcut session cookie before opening the PTY
       // socket. The WebSocket endpoint authenticates via that cookie, which
       // only GET /redeem sets; the 302 it returns sets the cookie regardless
-      // of where the redirect points, so we ignore the follow-up response.
-      await fetch(redeemUrl, { credentials: "include" }).catch(() => { /* cookie still set */ });
+      // of where the redirect points, so the follow-up response is ignored.
+      // Best-effort: a failure here just means the socket may fail to auth (the
+      // terminal surfaces its own connection error), so we log rather than block.
+      await fetch(redeemUrl, { credentials: "include" }).catch((e) => {
+        console.warn(`shortcut /redeem failed for ${agentId}:`, e);
+      });
       const app = getApp("terminal");
       if (app) openWindow("terminal", app.defaultSize, { shortcut: { wsUrl, ticket } });
     }

--- a/desktop/src/apps/AgentsApp.tsx
+++ b/desktop/src/apps/AgentsApp.tsx
@@ -2347,11 +2347,15 @@ export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
       return;
     }
 
-    let redirect_url: string;
+    let redirect_url: unknown;
     try {
-      ({ redirect_url } = await res.json() as { redirect_url: string });
+      ({ redirect_url } = await res.json() as { redirect_url?: unknown });
     } catch {
       failed("Server returned an unexpected response.");
+      return;
+    }
+    if (typeof redirect_url !== "string" || !redirect_url) {
+      failed("Server response was missing a launch URL.");
       return;
     }
     const kind = shortcut.kind;
@@ -2368,12 +2372,18 @@ export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
       // Establish the taos_shortcut session cookie before opening the PTY
       // socket. The WebSocket endpoint authenticates via that cookie, which
       // only GET /redeem sets; the 302 it returns sets the cookie regardless
-      // of where the redirect points, so the follow-up response is ignored.
-      // Best-effort: a failure here just means the socket may fail to auth (the
-      // terminal surfaces its own connection error), so we log rather than block.
-      await fetch(redeemUrl, { credentials: "include" }).catch((e) => {
+      // of where the redirect points. Best-effort: a failure just means the
+      // socket may fail to auth (the terminal surfaces its own connection
+      // error), so we log rather than block — but log non-OK responses too,
+      // not only rejected fetches (a 401/500 resolves and wouldn't hit .catch).
+      try {
+        const redeemRes = await fetch(redeemUrl, { credentials: "include" });
+        if (!redeemRes.ok) {
+          console.warn(`shortcut /redeem for ${agentId} returned ${redeemRes.status}`);
+        }
+      } catch (e) {
         console.warn(`shortcut /redeem failed for ${agentId}:`, e);
-      });
+      }
       const app = getApp("terminal");
       if (app) openWindow("terminal", app.defaultSize, { shortcut: { wsUrl, ticket } });
     }

--- a/desktop/src/hooks/__tests__/use-is-pwa.test.ts
+++ b/desktop/src/hooks/__tests__/use-is-pwa.test.ts
@@ -31,6 +31,9 @@ describe("useIsPwa", () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    // Always reset navigator.standalone — doing it here (not inline after an
+    // assertion) means a failing expect can't leak PWA state into later tests.
+    Object.defineProperty(navigator, "standalone", { value: undefined, configurable: true });
   });
 
   it("returns false when display-mode is NOT standalone", () => {
@@ -52,8 +55,6 @@ describe("useIsPwa", () => {
     });
     const { result } = renderHook(() => useIsPwa());
     expect(result.current).toBe(true);
-    // Clean up
-    Object.defineProperty(navigator, "standalone", { value: undefined, configurable: true });
   });
 
   it("updates when media query changes from non-standalone to standalone", () => {
@@ -106,8 +107,5 @@ describe("useIsPwa", () => {
       matchMediaListeners.get("change")?.forEach((h) => h({ matches: false }));
     });
     expect(result.current).toBe(true);  // still PWA via navigator.standalone
-
-    // Clean up
-    Object.defineProperty(navigator, "standalone", { value: undefined, configurable: true });
   });
 });

--- a/desktop/src/hooks/use-is-pwa.ts
+++ b/desktop/src/hooks/use-is-pwa.ts
@@ -6,17 +6,24 @@ import { useEffect, useState } from "react";
  * viewport handling to account for Safari's dynamic URL bar and
  * the share/tab bars that consume screen space.
  */
+function isStandaloneNow(): boolean {
+  if (typeof window === "undefined") return false;
+  // matchMedia is absent in some embedded webviews / SSR / older runtimes —
+  // guard it rather than assume it's callable.
+  const standaloneDisplay =
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(display-mode: standalone)").matches;
+  return (
+    standaloneDisplay ||
+    (navigator as unknown as { standalone?: boolean }).standalone === true
+  );
+}
+
 export function useIsPwa(): boolean {
-  const [isPwa, setIsPwa] = useState(() => {
-    if (typeof window === "undefined") return false;
-    return (
-      window.matchMedia("(display-mode: standalone)").matches ||
-      (navigator as unknown as { standalone?: boolean }).standalone === true
-    );
-  });
+  const [isPwa, setIsPwa] = useState(isStandaloneNow);
 
   useEffect(() => {
-    if (typeof window === "undefined") return;
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") return;
     const mql = window.matchMedia("(display-mode: standalone)");
     const update = () =>
       setIsPwa(

--- a/desktop/src/theme/tokens.css
+++ b/desktop/src/theme/tokens.css
@@ -120,13 +120,12 @@
    The PWA layout is UNCHANGED — this only activates with .taos-browser.
    ================================================================== */
 .taos-browser {
-  /* Drop safe-area insets — browser chrome already provides padding */
-  padding-top: 0 !important;
-  padding-bottom: 0 !important;
-
-  /* Use dvh (dynamic viewport height) so Safari's collapsing URL bar
-     doesn't leave a gap at the bottom. The 100vh line is the real fallback
-     for browsers without dvh support; the dvh line overrides it where supported. */
+  /* Note: safe-area insets are applied inline on individual components
+     (ChatStandalone, BottomSheet, OnboardingScreen, ModelPickerModal, …),
+     not on this element, and env(safe-area-inset-*) is already 0 in browser
+     (non-standalone) mode — so a padding reset here would be a no-op. We only
+     fix the viewport height: use dvh so Safari's collapsing URL bar doesn't
+     leave a gap, with 100vh as the fallback for browsers without dvh. */
   height: 100vh !important;
   height: 100dvh !important;
 }

--- a/desktop/src/theme/tokens.css
+++ b/desktop/src/theme/tokens.css
@@ -125,7 +125,9 @@
   padding-bottom: 0 !important;
 
   /* Use dvh (dynamic viewport height) so Safari's collapsing URL bar
-     doesn't leave a gap at the bottom. Falls back to 100vh. */
+     doesn't leave a gap at the bottom. The 100vh line is the real fallback
+     for browsers without dvh support; the dvh line overrides it where supported. */
+  height: 100vh !important;
   height: 100dvh !important;
 }
 
@@ -134,7 +136,10 @@
   background-size: 100% 100%;
 }
 
-/* Push the dock up slightly in browser mode to clear the tab bar */
+/* Push the dock up slightly in browser mode to clear the tab bar. The
+   attribute selector matches the CSS-module-hashed MobileDock class
+   (e.g. MobileDock_dock__ab12); scoped under .taos-browser so it only
+   applies in browser (non-PWA) mode. */
 .taos-browser [class*="MobileDock"] {
   padding-bottom: 4px;
 }


### PR DESCRIPTION
Addresses the Kilo review findings on the just-merged PRs (no criticals — all WARNING/SUGGESTION): matchMedia guard + 100dvh fallback + trailing className + test-cleanup robustness (#470), and a res.json guard + logged best-effort /redeem failure (#463). The #472 em-dash finding was already consistent. Local: 11/11 affected tests pass, tsc clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for agent launch redirects with clearer fallback notifications
  * Added CSS height fallback for browser layout compatibility and adjusted safe-area handling
  * Fixed wallpaper background class handling so browser-specific styling is applied correctly

* **Refactor**
  * Improved progressive web app detection to safely handle edge-case runtimes

* **Tests**
  * Strengthened test isolation to prevent PWA state leakage between tests

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jaylfc/tinyagentos/pull/478?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->