### PR TITLE
chore(agents): use providers.CLOUD_TYPES as single source of truth

### DIFF
--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -12,15 +12,16 @@ import taosmd.agents as tm_agents
 
 from tinyagentos.agent_db import find_agent, get_agent_summaries
 from tinyagentos.config import save_config_locked, validate_agent_name, slugify_agent_name
+from tinyagentos.providers import CLOUD_TYPES
 
 logger = logging.getLogger(__name__)
 
 EXPORT_VERSION = 1
 
 # Cloud provider backend types whose advertised models are routable for a
-# deploy / model-change. Mirrors providers.CLOUD_TYPES; kept local to avoid a
-# cross-route import. #351 tracks consolidating these provider-type lists.
-_CLOUD_PROVIDER_TYPES = ("openai", "anthropic", "openrouter", "kilocode", "openai-compatible")
+# deploy / model-change. Single source of truth is providers.CLOUD_TYPES
+# (#351); aliased here so the call sites below read clearly.
+_CLOUD_PROVIDER_TYPES = CLOUD_TYPES
 
 router = APIRouter()
 


### PR DESCRIPTION
Follow-up to #477 (provider-type consolidation). `routes/agents.py` kept a local `_CLOUD_PROVIDER_TYPES` tuple that mirrored `providers.CLOUD_TYPES` byte-for-byte. Now that the canonical set lives in `tinyagentos/providers`, import it directly and alias it (the call sites read unchanged). `providers` is a leaf data module — no circular import (`routes/providers.py` already imports it). Resolves the duplication tracked by #351.

Verified: `from tinyagentos.routes import agents` imports cleanly; 110 tests pass across cloud-model-resolution, agents routes, providers routes, and deployer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code improvements to enhance maintainability through standardization of configuration references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->