### PR TITLE
fix(widgets): GreetingWidget uses lucide icons instead of emoji

### DIFF
--- a/desktop/src/components/widgets/GreetingWidget.tsx
+++ b/desktop/src/components/widgets/GreetingWidget.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { Sun, CloudSun, Sunset, Moon, type LucideIcon } from "lucide-react";
 import { useWidgetSize } from "@/hooks/use-widget-size";
 
 function getGreeting(hour: number): string {
@@ -8,11 +9,14 @@ function getGreeting(hour: number): string {
   return "Good night.";
 }
 
-function getGreetingEmoji(hour: number): string {
-  if (hour >= 5 && hour < 12) return "☀️";
-  if (hour >= 12 && hour < 17) return "⛅";
-  if (hour >= 17 && hour < 21) return "🌆";
-  return "🌙";
+// Lucide SVG icons rather than emoji: emoji glyphs (esp. 🌆) render as a
+// tofu/box on iOS where the font lacks them. SVGs are font-independent and
+// match the rest of the app's icon system.
+function getGreetingIcon(hour: number): LucideIcon {
+  if (hour >= 5 && hour < 12) return Sun;
+  if (hour >= 12 && hour < 17) return CloudSun;
+  if (hour >= 17 && hour < 21) return Sunset;
+  return Moon;
 }
 
 interface SystemSummary {
@@ -52,7 +56,7 @@ export function GreetingWidget() {
 
   const hour = now.getHours();
   const greeting = getGreeting(hour);
-  const emoji = getGreetingEmoji(hour);
+  const Icon = getGreetingIcon(hour);
 
   const subtitleParts: string[] = [];
   if (summary !== null) {
@@ -75,7 +79,7 @@ export function GreetingWidget() {
       role="region"
     >
       {tier !== "s" && (
-        <span style={{ fontSize: tier === "l" ? 36 : 28, lineHeight: 1 }} aria-hidden="true">{emoji}</span>
+        <Icon size={tier === "l" ? 36 : 28} color="rgba(255,255,255,0.92)" aria-hidden="true" />
       )}
 
       <span
@@ -85,11 +89,17 @@ export function GreetingWidget() {
           color: "rgba(255,255,255,0.92)",
           lineHeight: 1.2,
           letterSpacing: "-0.02em",
+          ...(tier === "s"
+            ? { display: "inline-flex", alignItems: "center", justifyContent: "center", gap: 6 }
+            : {}),
         }}
       >
         {tier === "s" ? (
-          // Compact: emoji inline with text
-          <>{emoji} {greeting}</>
+          // Compact: icon inline with text
+          <>
+            <Icon size={16} color="rgba(255,255,255,0.92)" aria-hidden="true" />
+            {greeting}
+          </>
         ) : greeting}
       </span>
 

--- a/desktop/src/components/widgets/__tests__/GreetingWidget.test.tsx
+++ b/desktop/src/components/widgets/__tests__/GreetingWidget.test.tsx
@@ -1,0 +1,45 @@
+import { render } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { GreetingWidget } from "../GreetingWidget";
+
+// Fixed tier so the standalone icon renders deterministically (avoids relying
+// on ResizeObserver in jsdom).
+vi.mock("@/hooks/use-widget-size", () => ({
+  useWidgetSize: () => [{ current: null }, { tier: "l" }],
+}));
+
+// Greeting fetches a system summary on mount — stub it so jsdom doesn't throw.
+vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, json: async () => ({}) }));
+
+describe("GreetingWidget", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  function renderAtHour(hour: number) {
+    vi.setSystemTime(new Date(2026, 0, 1, hour, 0, 0));
+    return render(<GreetingWidget />);
+  }
+
+  it("renders a Sunset SVG icon in the evening (not a font-dependent emoji)", () => {
+    const { container } = renderAtHour(19);
+    expect(container.querySelector(".lucide-sunset")).not.toBeNull();
+    expect(container.textContent).toContain("Good evening.");
+  });
+
+  it("renders a Sun SVG icon in the morning", () => {
+    const { container } = renderAtHour(8);
+    expect(container.querySelector(".lucide-sun")).not.toBeNull();
+    expect(container.textContent).toContain("Good morning.");
+  });
+
+  it("renders a Moon SVG icon at night", () => {
+    const { container } = renderAtHour(23);
+    expect(container.querySelector(".lucide-moon")).not.toBeNull();
+    expect(container.textContent).toContain("Good night.");
+  });
+
+  it("does not emit the iOS-broken sunset emoji glyph", () => {
+    const { container } = renderAtHour(19);
+    expect(container.textContent).not.toContain("\u{1F306}"); // 🌆
+  });
+});


### PR DESCRIPTION
Fixes the broken "Good evening" icon (one of the deferred UI bugs). The evening emoji (U+1F306 🌆) renders as a tofu/box glyph on iOS where the font lacks it. All four time-of-day emoji are now lucide SVG icons (`Sun` / `CloudSun` / `Sunset` / `Moon`) — font-independent and consistent with the app's existing lucide-based icon system.

Includes a vitest test asserting the correct SVG renders per time of day and that the broken glyph no longer appears. `tsc -b` clean.

Left for your review since it's a visual change — worth an eyeball on the widget at the different sizes (s/m/l tiers).