### PR TITLE
docs: add container shell access runbook + FAQ entry (fixes #462)

### DIFF
--- a/docs/runbooks/container-shell-access.md
+++ b/docs/runbooks/container-shell-access.md
@@ -75,7 +75,7 @@ docker ps --filter "name=taos-agent-"
 docker exec -it taos-agent-<slug> bash
 
 # Single command:
-docker exec taos-agent-<slug> ls -la /workspace
+docker exec -i taos-agent-<slug> ls -la /workspace
 ```
 
 The principle is identical: `exec` bypasses the virtual console and runs
@@ -87,6 +87,7 @@ directly inside the container.
 |---|---|
 | Interactive shell (LXC) | `incus exec taos-agent-<slug> -- bash` |
 | Single command (LXC) | `incus exec taos-agent-<slug> -- <cmd>` |
+| Single command (Docker) | `docker exec -i taos-agent-<slug> <cmd>` |
 | List agent containers (LXC) | `incus list \| grep taos-agent-` |
 | Interactive shell (Docker) | `docker exec -it taos-agent-<slug> bash` |
 | Preferred CLI wrapper | `taos agent exec <name> -- bash` |

--- a/docs/runbooks/container-shell-access.md
+++ b/docs/runbooks/container-shell-access.md
@@ -1,0 +1,99 @@
+# Container Shell Access
+
+**Goal:** reach a running agent container's shell from the host, including
+when the in-UI shell shortcut is unavailable.
+
+taOS agents run inside isolated LXC (or Docker) containers. The primary way
+to interact with a containerised agent is via the taOS desktop shell — the
+in-UI terminal reachable from the Agents app. When that shortcut is
+unavailable (network issue, browser disconnect, companion WS bug), you can
+reach the container directly from the host.
+
+## Don't use `incus console`
+
+`incus console <container>` prompts for a **login and password**. These
+credentials are never generated, documented, or exposed to end users by
+taOS — the container images ship with password-less root. `incus console`
+attaches to the container's virtual console (getty), which expects a login
+that does not exist. This is not a bug in your setup; `incus console` is
+the wrong tool for this.
+
+## Use `incus exec`
+
+`incus exec` runs a command directly inside the container, bypassing the
+login prompt entirely. This is the supported host-side fallback:
+
+```bash
+# Interactive shell (bash in the agent container):
+incus exec agent-<slug> -- bash
+
+# Run a single command:
+incus exec agent-<slug> -- ls -la /workspace
+
+# Run a command with full environment:
+incus exec agent-<slug> -- env TERM=xterm-256color bash
+```
+
+### Container naming
+
+Agent containers are named `agent-<slug>` where `<slug>` is the lowercase
+URL-safe version of the agent's display name with spaces replaced by
+hyphens. You can find the exact container name with:
+
+```bash
+incus list --format csv --columns n | grep '^agent-'
+```
+
+Or, from within taOS, open the Agents app — the container name is shown
+in the agent detail panel.
+
+## `taos agent exec` (preferred when available)
+
+When the taOS CLI is installed and the taOS API is reachable, use the
+built-in wrapper instead of raw `incus exec`:
+
+```bash
+taos agent exec my-agent -- bash
+taos agent exec my-agent -- ls -la /workspace
+taos agent exec my-agent -- journalctl --no-pager -n 50
+```
+
+The CLI wrapper handles container name resolution automatically (you use
+the human-readable agent name, not the container slug) and works across
+both LXC and Docker runtimes.
+
+## Docker containers
+
+If your taOS instance uses Docker instead of LXC (Settings → Container
+Runtime), the equivalent commands are:
+
+```bash
+# List running agent containers:
+docker ps --filter "name=agent-"
+
+# Interactive shell:
+docker exec -it agent-<slug> bash
+
+# Single command:
+docker exec agent-<slug> ls -la /workspace
+```
+
+The principle is identical: `exec` bypasses the virtual console and runs
+directly inside the container.
+
+## Quick reference
+
+| Goal | Command |
+|---|---|
+| Interactive shell (LXC) | `incus exec agent-<slug> -- bash` |
+| Single command (LXC) | `incus exec agent-<slug> -- <cmd>` |
+| List agent containers (LXC) | `incus list \| grep agent-` |
+| Interactive shell (Docker) | `docker exec -it agent-<slug> bash` |
+| Preferred CLI wrapper | `taos agent exec <name> -- bash` |
+
+## Related
+
+- [Container upgrade runbook](./container-upgrade.md) — full rebuild workflow
+- [Framework swap runbook](./framework-swap.md) — changing an agent's framework
+- [Discussion #357](https://github.com/jaylfc/tinyagentos/discussions/357) —
+  original report that surfaced the `incus console` login gap

--- a/docs/runbooks/container-shell-access.md
+++ b/docs/runbooks/container-shell-access.md
@@ -25,23 +25,23 @@ login prompt entirely. This is the supported host-side fallback:
 
 ```bash
 # Interactive shell (bash in the agent container):
-incus exec agent-<slug> -- bash
+incus exec taos-agent-<slug> -- bash
 
 # Run a single command:
-incus exec agent-<slug> -- ls -la /workspace
+incus exec taos-agent-<slug> -- ls -la /workspace
 
 # Run a command with full environment:
-incus exec agent-<slug> -- env TERM=xterm-256color bash
+incus exec taos-agent-<slug> -- env TERM=xterm-256color bash
 ```
 
 ### Container naming
 
-Agent containers are named `agent-<slug>` where `<slug>` is the lowercase
+Agent containers are named `taos-agent-<slug>` where `<slug>` is the lowercase
 URL-safe version of the agent's display name with spaces replaced by
 hyphens. You can find the exact container name with:
 
 ```bash
-incus list --format csv --columns n | grep '^agent-'
+incus list --format csv --columns n | grep '^taos-agent-'
 ```
 
 Or, from within taOS, open the Agents app — the container name is shown
@@ -69,13 +69,13 @@ Runtime), the equivalent commands are:
 
 ```bash
 # List running agent containers:
-docker ps --filter "name=agent-"
+docker ps --filter "name=taos-agent-"
 
 # Interactive shell:
-docker exec -it agent-<slug> bash
+docker exec -it taos-agent-<slug> bash
 
 # Single command:
-docker exec agent-<slug> ls -la /workspace
+docker exec taos-agent-<slug> ls -la /workspace
 ```
 
 The principle is identical: `exec` bypasses the virtual console and runs
@@ -85,10 +85,10 @@ directly inside the container.
 
 | Goal | Command |
 |---|---|
-| Interactive shell (LXC) | `incus exec agent-<slug> -- bash` |
-| Single command (LXC) | `incus exec agent-<slug> -- <cmd>` |
-| List agent containers (LXC) | `incus list \| grep agent-` |
-| Interactive shell (Docker) | `docker exec -it agent-<slug> bash` |
+| Interactive shell (LXC) | `incus exec taos-agent-<slug> -- bash` |
+| Single command (LXC) | `incus exec taos-agent-<slug> -- <cmd>` |
+| List agent containers (LXC) | `incus list \| grep taos-agent-` |
+| Interactive shell (Docker) | `docker exec -it taos-agent-<slug> bash` |
 | Preferred CLI wrapper | `taos agent exec <name> -- bash` |
 
 ## Related

--- a/docs/runbooks/container-shell-access.md
+++ b/docs/runbooks/container-shell-access.md
@@ -88,7 +88,7 @@ directly inside the container.
 | Interactive shell (LXC) | `incus exec taos-agent-<slug> -- bash` |
 | Single command (LXC) | `incus exec taos-agent-<slug> -- <cmd>` |
 | Single command (Docker) | `docker exec -i taos-agent-<slug> <cmd>` |
-| List agent containers (LXC) | `incus list \| grep taos-agent-` |
+| List agent containers (LXC) | `incus list --format csv --columns n \| grep '^taos-agent-'` |
 | Interactive shell (Docker) | `docker exec -it taos-agent-<slug> bash` |
 | Preferred CLI wrapper | `taos agent exec <name> -- bash` |
 

--- a/docs/taos-agent-manual.md
+++ b/docs/taos-agent-manual.md
@@ -110,4 +110,4 @@ Open the Activity app. Every LLM call, tool use, and memory operation is logged 
 Settings → Updates → Install Update. taOS pulls the latest code from GitHub, rebuilds the desktop bundle, and prompts you to restart.
 
 **How do I get a shell inside an agent container?**
-In the UI, use the container shell shortcut in the Agents app. If that's unavailable, use the host-side fallback: `incus exec agent-<slug> -- bash` (LXC) or `docker exec -it agent-<slug> bash` (Docker). See the [Container Shell Access runbook](runbooks/container-shell-access.md) for details. Never use `incus console` — it asks for a password that doesn't exist.
+In the UI, use the container shell shortcut in the Agents app. If that's unavailable, use the host-side fallback: `incus exec taos-agent-<slug> -- bash` (LXC) or `docker exec -it taos-agent-<slug> bash` (Docker). See the [Container Shell Access runbook](runbooks/container-shell-access.md) for details. Never use `incus console` — it asks for a password that doesn't exist.

--- a/docs/taos-agent-manual.md
+++ b/docs/taos-agent-manual.md
@@ -108,3 +108,6 @@ Open the Activity app. Every LLM call, tool use, and memory operation is logged 
 
 **How do I update taOS?**
 Settings → Updates → Install Update. taOS pulls the latest code from GitHub, rebuilds the desktop bundle, and prompts you to restart.
+
+**How do I get a shell inside an agent container?**
+In the UI, use the container shell shortcut in the Agents app. If that's unavailable, use the host-side fallback: `incus exec agent-<slug> -- bash` (LXC) or `docker exec -it agent-<slug> bash` (Docker). See the [Container Shell Access runbook](runbooks/container-shell-access.md) for details. Never use `incus console` — it asks for a password that doesn't exist.


### PR DESCRIPTION
## Problem

When an agent container's in-UI shell shortcut is unavailable (WS issue,
network disconnect, companion bug), users try `incus console <container>`
on the host — but it prompts for a login/password that was never generated
or documented. There is no documented host-side fallback.

Reported by @johny-mnemonic in discussion #357:
https://github.com/jaylfc/tinyagentos/discussions/357

## Solution

Adds two documentation pieces:

1. `docs/runbooks/container-shell-access.md` — operational runbook covering:
   - Why `incus console` is the wrong tool (asks for non-existent credentials)
   - `incus exec agent-<slug> -- bash` as the correct host-side fallback
   - Container naming convention (`agent-<slug>`)
   - Docker runtime equivalents (`docker exec -it`)
   - `taos agent exec` CLI wrapper (preferred when available)
   - Quick-reference table for both LXC and Docker

2. `docs/taos-agent-manual.md` — new FAQ entry:
   - "How do I get a shell inside an agent container?"
   - Links to the runbook for full details
   - Includes the "never use incus console" warning

## Verification

- Markdown renders correctly (no broken links, code blocks valid)
- References the existing container-upgrade.md and framework-swap.md runbooks
- Consistent with the existing runbook style

Closes #462


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a runbook explaining how to access taOS agent container shells from the host when the in‑UI terminal is unavailable, with step‑by‑step host commands, discovery tips, and a quick reference table.
  * Clarified supported interactive and single‑command approaches for both LXC and Docker, and recommended a wrapper that resolves human‑readable agent names.
  * Added an FAQ entry linking to related runbooks and discussion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->