### PR TITLE
feat(agents): add agent debugger with SSE step-through (#131)

### DIFF
--- a/tests/test_agent_debugger.py
+++ b/tests/test_agent_debugger.py
@@ -1,6 +1,71 @@
 """Tests for the agent debugger route module."""
 
+import asyncio
+import json
+
 import pytest
+
+
+async def _collect_sse_lines(app, path, cookies, n_lines, timeout=5.0):
+    """Drive an ASGI SSE endpoint, collect the first n_lines non-empty lines,
+    then cancel the request task.
+
+    httpx's buffered ``client.get`` would block until the long-lived
+    StreamingResponse closes, so we drive the ASGI app directly with a
+    controlled receive/send and cancel once we have enough lines.
+    """
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "GET",
+        "headers": [
+            (b"cookie", "; ".join(f"{k}={v}" for k, v in cookies.items()).encode()),
+            (b"accept", b"text/event-stream"),
+        ],
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": b"",
+        "server": ("testserver", 80),
+        "client": ("127.0.0.1", 1234),
+        "root_path": "",
+    }
+
+    lines: list[str] = []
+    done = asyncio.Event()
+    status_code = {"value": None}
+
+    async def receive():
+        await done.wait()
+        return {"type": "http.disconnect"}
+
+    async def send(message):
+        if message["type"] == "http.response.start":
+            status_code["value"] = message["status"]
+        elif message["type"] == "http.response.body":
+            body = message.get("body", b"")
+            if body:
+                for line in body.decode().split("\n"):
+                    stripped = line.rstrip("\r")
+                    if stripped:
+                        lines.append(stripped)
+                        if len(lines) >= n_lines:
+                            done.set()
+
+    task = asyncio.create_task(app(scope, receive, send))
+    try:
+        await asyncio.wait_for(asyncio.shield(done.wait()), timeout=timeout)
+    except asyncio.TimeoutError:
+        pass
+    finally:
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):
+            pass
+
+    return status_code["value"], lines
 
 
 @pytest.mark.asyncio
@@ -17,6 +82,9 @@ async def test_debugger_ui_returns_html(client):
 @pytest.mark.asyncio
 async def test_trace_records_event(client):
     """POST /agent/{agent_id}/debug/trace records a trace event."""
+    # The trace buffer is module-level and not reset between tests, so clear it
+    # first to keep the exact-count assertion deterministic.
+    await client.post("/agent/test-agent/debug/clear")
     resp = await client.post(
         "/agent/test-agent/debug/trace",
         json={"type": "tool_call", "data": {"tool": "search", "query": "test"}},
@@ -134,16 +202,23 @@ async def test_separate_agents_have_separate_traces(client):
 
 
 @pytest.mark.asyncio
-async def test_events_endpoint_returns_sse(client):
-    """GET /agent/{agent_id}/debug/events returns SSE stream."""
+async def test_events_endpoint_returns_sse(app, client):
+    """GET /agent/{agent_id}/debug/events streams an SSE frame."""
+    await client.post("/agent/sse-agent/debug/clear")
     # Record an event first so there's data to stream
     await client.post(
-        "/agent/test-agent/debug/trace",
+        "/agent/sse-agent/debug/trace",
         json={"type": "tool_call", "data": {"tool": "test"}},
     )
 
-    resp = await client.get("/agent/test-agent/debug/events", timeout=2)
-    assert resp.status_code == 200
+    cookies = {"taos_session": client.cookies.get("taos_session", "")}
+    status, lines = await _collect_sse_lines(
+        app, "/agent/sse-agent/debug/events", cookies, n_lines=1, timeout=5.0
+    )
+
+    assert status == 200
+    data_lines = [l for l in lines if l.startswith("data:")]
+    assert data_lines, f"No data: lines received; got: {lines}"
 
 
 @pytest.mark.asyncio
@@ -157,16 +232,32 @@ async def test_status_no_events(client):
 
 
 @pytest.mark.asyncio
-async def test_multiple_events_ordered(client):
-    """Events are recorded in order."""
-    await client.post(
-        "/agent/test-agent/debug/clear",
-    )
+async def test_multiple_events_ordered(app, client):
+    """Events are recorded and replayed in order."""
+    await client.post("/agent/ordered-agent/debug/clear")
     for i in range(10):
         await client.post(
-            "/agent/test-agent/debug/trace",
+            "/agent/ordered-agent/debug/trace",
             json={"type": "log", "data": {"num": i}},
         )
 
-    status = await client.get("/agent/test-agent/debug/status")
+    status = await client.get("/agent/ordered-agent/debug/status")
     assert status.json()["total_events"] == 10
+
+    # Replaying the trace over SSE must yield the events in recorded order.
+    # The stream emits one position frame followed by the 10 buffered logs, so
+    # collect 11 data lines and check the log sequence.
+    cookies = {"taos_session": client.cookies.get("taos_session", "")}
+    _, lines = await _collect_sse_lines(
+        app, "/agent/ordered-agent/debug/events", cookies, n_lines=11, timeout=5.0
+    )
+
+    nums = []
+    for line in lines:
+        if not line.startswith("data:"):
+            continue
+        payload = json.loads(line[len("data:"):].strip())
+        if payload.get("type") == "log":
+            nums.append(payload["data"]["num"])
+
+    assert nums == list(range(10))

--- a/tests/test_agent_debugger.py
+++ b/tests/test_agent_debugger.py
@@ -17,6 +17,12 @@ async def test_debugger_ui_returns_html(client):
 @pytest.mark.asyncio
 async def test_trace_records_event(client):
     """POST /agent/{agent_id}/debug/trace records a trace event."""
+    # Reset shared module-level state for deterministic test
+    from tinyagentos.routes.agent_debugger import _traces, _positions, _step_events
+    _traces.clear()
+    _positions.clear()
+    _step_events.clear()
+
     resp = await client.post(
         "/agent/test-agent/debug/trace",
         json={"type": "tool_call", "data": {"tool": "search", "query": "test"}},
@@ -136,14 +142,24 @@ async def test_separate_agents_have_separate_traces(client):
 @pytest.mark.asyncio
 async def test_events_endpoint_returns_sse(client):
     """GET /agent/{agent_id}/debug/events returns SSE stream."""
+    import httpx
+
     # Record an event first so there's data to stream
     await client.post(
         "/agent/test-agent/debug/trace",
         json={"type": "tool_call", "data": {"tool": "test"}},
     )
 
-    resp = await client.get("/agent/test-agent/debug/events", timeout=2)
-    assert resp.status_code == 200
+    # Use streaming to avoid buffering the entire infinite SSE response
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=client._transport.app),  # type: ignore[arg-type]
+        base_url="http://test",
+    ) as ac:
+        async with ac.stream("GET", "/agent/test-agent/debug/events", timeout=2) as resp:
+            assert resp.status_code == 200
+            # Read one chunk to verify SSE frame delivery
+            chunk = await resp.aiter_raw().__anext__()
+            assert chunk, "SSE stream returned no data"
 
 
 @pytest.mark.asyncio
@@ -170,3 +186,9 @@ async def test_multiple_events_ordered(client):
 
     status = await client.get("/agent/test-agent/debug/status")
     assert status.json()["total_events"] == 10
+
+    # Verify ordering: data.num should match insertion order 0..9
+    events = status.json().get("events", [])
+    if events:
+        nums = [e["data"]["num"] for e in events if "num" in e.get("data", {})]
+        assert nums == list(range(len(nums))), f"events not in insertion order: {nums}"

--- a/tests/test_agent_debugger.py
+++ b/tests/test_agent_debugger.py
@@ -1,0 +1,172 @@
+"""Tests for the agent debugger route module."""
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_debugger_ui_returns_html(client):
+    """GET /agent/{agent_id}/debug returns an HTML page."""
+    resp = await client.get("/agent/test-agent/debug")
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers.get("content-type", "")
+    body = resp.text
+    assert "Agent Debugger" in body
+    assert "debugger" in body.lower()
+
+
+@pytest.mark.asyncio
+async def test_trace_records_event(client):
+    """POST /agent/{agent_id}/debug/trace records a trace event."""
+    resp = await client.post(
+        "/agent/test-agent/debug/trace",
+        json={"type": "tool_call", "data": {"tool": "search", "query": "test"}},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "recorded"
+    assert data["total"] == 1
+
+
+@pytest.mark.asyncio
+async def test_status_returns_state(client):
+    """GET /agent/{agent_id}/debug/status returns trace state."""
+    # Record an event first
+    await client.post(
+        "/agent/test-agent/debug/trace",
+        json={"type": "prompt", "data": {"text": "Hello"}},
+    )
+    resp = await client.get("/agent/test-agent/debug/status")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["agent_id"] == "test-agent"
+    assert data["total_events"] >= 1
+    assert "position" in data
+
+
+@pytest.mark.asyncio
+async def test_step_advances_position(client):
+    """POST /agent/{agent_id}/debug/step advances the position."""
+    await client.post(
+        "/agent/test-agent/debug/trace",
+        json={"type": "tool_call", "data": {"tool": "read"}},
+    )
+    await client.post(
+        "/agent/test-agent/debug/trace",
+        json={"type": "tool_result", "data": {"result": "ok"}},
+    )
+
+    resp = await client.post("/agent/test-agent/debug/step")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["pos"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_continue_jumps_to_end(client):
+    """POST /agent/{agent_id}/debug/continue advances to end of trace."""
+    for i in range(5):
+        await client.post(
+            "/agent/test-agent/debug/trace",
+            json={"type": "log", "data": {"msg": f"step {i}"}},
+        )
+
+    resp = await client.post("/agent/test-agent/debug/continue")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "continued"
+    assert data["pos"] >= 5
+
+
+@pytest.mark.asyncio
+async def test_clear_removes_trace(client):
+    """POST /agent/{agent_id}/debug/clear removes all trace data."""
+    await client.post(
+        "/agent/test-agent/debug/trace",
+        json={"type": "tool_call", "data": {"tool": "exec"}},
+    )
+    resp = await client.post("/agent/test-agent/debug/clear")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "cleared"
+
+    # Status should show 0 events
+    status = await client.get("/agent/test-agent/debug/status")
+    assert status.json()["total_events"] == 0
+
+
+@pytest.mark.asyncio
+async def test_trace_rejects_invalid_type(client):
+    """POST trace rejects unknown event types."""
+    resp = await client.post(
+        "/agent/test-agent/debug/trace",
+        json={"type": "garbage", "data": {}},
+    )
+    assert resp.status_code == 400
+    assert "Unknown event type" in resp.json()["error"]
+
+
+@pytest.mark.asyncio
+async def test_trace_rejects_missing_type(client):
+    """POST trace with missing type field gets 400."""
+    resp = await client.post(
+        "/agent/test-agent/debug/trace",
+        json={"data": {}},
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_separate_agents_have_separate_traces(client):
+    """Each agent has its own trace."""
+    await client.post(
+        "/agent/alpha/debug/trace",
+        json={"type": "log", "data": {"msg": "alpha event"}},
+    )
+    await client.post(
+        "/agent/beta/debug/trace",
+        json={"type": "log", "data": {"msg": "beta event"}},
+    )
+
+    alpha_status = await client.get("/agent/alpha/debug/status")
+    beta_status = await client.get("/agent/beta/debug/status")
+
+    assert alpha_status.json()["total_events"] == 1
+    assert beta_status.json()["total_events"] == 1
+
+
+@pytest.mark.asyncio
+async def test_events_endpoint_returns_sse(client):
+    """GET /agent/{agent_id}/debug/events returns SSE stream."""
+    # Record an event first so there's data to stream
+    await client.post(
+        "/agent/test-agent/debug/trace",
+        json={"type": "tool_call", "data": {"tool": "test"}},
+    )
+
+    resp = await client.get("/agent/test-agent/debug/events", timeout=2)
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_status_no_events(client):
+    """GET status for an agent with no events."""
+    resp = await client.get("/agent/new-agent/debug/status")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_events"] == 0
+    assert data["position"] == 0
+
+
+@pytest.mark.asyncio
+async def test_multiple_events_ordered(client):
+    """Events are recorded in order."""
+    await client.post(
+        "/agent/test-agent/debug/clear",
+    )
+    for i in range(10):
+        await client.post(
+            "/agent/test-agent/debug/trace",
+            json={"type": "log", "data": {"num": i}},
+        )
+
+    status = await client.get("/agent/test-agent/debug/status")
+    assert status.json()["total_events"] == 10

--- a/tests/test_agent_debugger.py
+++ b/tests/test_agent_debugger.py
@@ -226,8 +226,9 @@ async def test_multiple_events_ordered(client):
     status = await client.get("/agent/test-agent/debug/status")
     assert status.json()["total_events"] == 10
 
-    # Verify ordering: data.num should match insertion order 0..9
-    events = status.json().get("events", [])
-    if events:
-        nums = [e["data"]["num"] for e in events if "num" in e.get("data", {})]
-        assert nums == list(range(len(nums))), f"events not in insertion order: {nums}"
+    # Verify ordering against the recorded trace store. The /status endpoint
+    # only returns counts (not the events), so assert against _traces directly
+    # — otherwise the ordering check is dead code that never runs.
+    from tinyagentos.routes.agent_debugger import _traces
+    nums = [e["data"]["num"] for e in _traces.get("test-agent", []) if "num" in e.get("data", {})]
+    assert nums == list(range(10)), f"events not in insertion order: {nums}"

--- a/tests/test_agent_debugger.py
+++ b/tests/test_agent_debugger.py
@@ -3,6 +3,28 @@
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _reset_debugger_state():
+    """Reset module-level debugger globals around every test.
+
+    The debugger uses process-global dicts for traces, queues, positions and
+    step events. Without an explicit reset, state leaks across tests (and into
+    other test modules in a full-suite run), which can leave a connected SSE
+    queue or an unset step event behind and make a later /trace POST block.
+    """
+    from tinyagentos.routes import agent_debugger as dbg
+
+    dbg._traces.clear()
+    dbg._queues.clear()
+    dbg._positions.clear()
+    dbg._step_events.clear()
+    yield
+    dbg._traces.clear()
+    dbg._queues.clear()
+    dbg._positions.clear()
+    dbg._step_events.clear()
+
+
 @pytest.mark.asyncio
 async def test_debugger_ui_returns_html(client):
     """GET /agent/{agent_id}/debug returns an HTML page."""
@@ -141,25 +163,42 @@ async def test_separate_agents_have_separate_traces(client):
 
 @pytest.mark.asyncio
 async def test_events_endpoint_returns_sse(client):
-    """GET /agent/{agent_id}/debug/events returns SSE stream."""
-    import httpx
+    """GET /agent/{agent_id}/debug/events yields an SSE stream and terminates.
 
-    # Record an event first so there's data to stream
+    The SSE generator runs an infinite ``while True`` loop, so it cannot be
+    consumed over httpx's buffering ASGI transport without hanging. Drive the
+    handler directly with a Request that reports a client disconnect, so the
+    generator yields its initial position frame and then exits cleanly — this
+    proves frame delivery AND that the stream terminates (no leaked task).
+    """
+    import asyncio
+
+    from tinyagentos.routes.agent_debugger import debugger_events
+
+    # Record an event first so there's trace data to replay.
     await client.post(
         "/agent/test-agent/debug/trace",
         json={"type": "tool_call", "data": {"tool": "test"}},
     )
 
-    # Use streaming to avoid buffering the entire infinite SSE response
-    async with httpx.AsyncClient(
-        transport=httpx.ASGITransport(app=client._transport.app),  # type: ignore[arg-type]
-        base_url="http://test",
-    ) as ac:
-        async with ac.stream("GET", "/agent/test-agent/debug/events", timeout=2) as resp:
-            assert resp.status_code == 200
-            # Read one chunk to verify SSE frame delivery
-            chunk = await resp.aiter_raw().__anext__()
-            assert chunk, "SSE stream returned no data"
+    class _DisconnectedRequest:
+        async def is_disconnected(self) -> bool:
+            return True
+
+    resp = await debugger_events("test-agent", _DisconnectedRequest())  # type: ignore[arg-type]
+
+    frames: list = []
+
+    async def _drain():
+        async for frame in resp.body_iterator:
+            frames.append(frame)
+
+    # Bound the drain so a regression that breaks termination fails loudly
+    # instead of hanging.
+    await asyncio.wait_for(_drain(), timeout=5)
+
+    assert frames, "SSE stream returned no data"
+    assert "position" in frames[0], frames[0]
 
 
 @pytest.mark.asyncio

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -1259,6 +1259,10 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     except ImportError:
         pass  # Lobby not present in public release
 
+    # --- Agent Debugger Routes ---
+    from tinyagentos.routes.agent_debugger import router as agent_debugger_router
+    app.include_router(agent_debugger_router)
+
     # --- Memory Management Routes ---
     from tinyagentos.routes.memory_management import router as memory_management_router
     app.include_router(memory_management_router)

--- a/tinyagentos/routes/agent_debugger.py
+++ b/tinyagentos/routes/agent_debugger.py
@@ -38,6 +38,11 @@ _TEMPLATE_DIR = Path(__file__).resolve().parent.parent / "templates"
 
 _MAX_TRACE_LENGTH = 10_000  # cap per-agent trace to avoid unbounded memory growth
 
+# Max time a /trace POST will block waiting for the UI to step/continue.
+# A debugger UI that vanishes (closed tab, disconnect, never connected) must
+# NOT freeze agent trace recording forever, so the wait is always bounded.
+_STEP_WAIT_TIMEOUT = 30.0
+
 
 def _get_template(name: str) -> str:
     """Read an HTML template file, falling back to an error message."""
@@ -215,12 +220,18 @@ async def debugger_trace(agent_id: str, request: Request) -> JSONResponse:
 
     await _broadcast(agent_id, event)
 
-    # Only block for step/continue when a debugger UI is actively listening.
-    # Without a listener the agent runs free — no reason to pause.
+    # Block for step/continue only while a debugger UI is actually connected;
+    # otherwise no one can ever signal the step, so blocking would hang the
+    # agent forever. The wait is always bounded by _STEP_WAIT_TIMEOUT so a UI
+    # that disconnects mid-step can never freeze trace recording.
     if _queues.get(agent_id):
         step_event = _step_events.setdefault(agent_id, asyncio.Event())
         step_event.clear()
-        await step_event.wait()
+        try:
+            await asyncio.wait_for(step_event.wait(), timeout=_STEP_WAIT_TIMEOUT)
+        except asyncio.TimeoutError:
+            # No step/continue arrived in time — proceed rather than block.
+            pass
 
     return JSONResponse({"status": "recorded", "total": len(_traces[agent_id])})
 

--- a/tinyagentos/routes/agent_debugger.py
+++ b/tinyagentos/routes/agent_debugger.py
@@ -51,9 +51,15 @@ def _trim_trace(agent_id: str) -> None:
     """Drop oldest events if the trace exceeds the cap."""
     events = _traces[agent_id]
     if len(events) > _MAX_TRACE_LENGTH:
+        dropped = len(events) - _MAX_TRACE_LENGTH
         _traces[agent_id] = events[-_MAX_TRACE_LENGTH:]
-        if _positions.get(agent_id, 0) < len(events) - _MAX_TRACE_LENGTH:
-            _positions[agent_id] = max(0, len(_traces[agent_id]) - 1)
+        _positions[agent_id] = max(
+            0,
+            min(
+                _positions.get(agent_id, 0) - dropped,
+                max(0, len(_traces[agent_id]) - 1),
+            ),
+        )
 
 
 async def _broadcast(agent_id: str, event: dict) -> None:
@@ -76,7 +82,8 @@ async def debugger_ui(agent_id: str) -> HTMLResponse:
 @router.get("/agent/{agent_id}/debug/events")
 async def debugger_events(agent_id: str, request: Request):
     """SSE endpoint that streams trace events to the debugger UI."""
-    queue: asyncio.Queue = asyncio.Queue(maxsize=256)
+    # Use unbounded queue — traces can hold up to _MAX_TRACE_LENGTH events
+    queue: asyncio.Queue = asyncio.Queue()
 
     # Replay existing trace events
     for event in _traces.get(agent_id, []):
@@ -186,6 +193,21 @@ async def debugger_trace(agent_id: str, request: Request) -> JSONResponse:
         "type": event_type,
         "ts": time.time(),
         "data": body.get("data", {}),
+        # Stable identifiers for tree / replay / rerun flows
+        "node_id": body.get("node_id", body.get("data", {}).get("node_id")),
+        "parent_id": body.get("parent_id", body.get("data", {}).get("parent_id")),
+        # Timing and duration
+        "start_ts": body.get("start_ts", time.time()),
+        "end_ts": body.get("end_ts"),
+        "duration_ms": body.get("duration_ms"),
+        # Token / usage / model metadata
+        "token_count": body.get("token_count"),
+        "model": body.get("model"),
+        "latency_ms": body.get("latency_ms"),
+        # Replay / checkpoint flags
+        "replay_checkpoint": body.get("replay_checkpoint"),
+        "checkpoint_id": body.get("checkpoint_id"),
+        "metadata": body.get("metadata", {}),
     }
 
     _traces[agent_id].append(event)

--- a/tinyagentos/routes/agent_debugger.py
+++ b/tinyagentos/routes/agent_debugger.py
@@ -1,0 +1,226 @@
+"""Agent debugger — step through tool calls and inspect results.
+
+Provides an SSE-backed debugger UI that lets users step through an agent's
+execution trace. Agents (or their adapters) push events via
+POST /agent/{agent_id}/debug/trace; the UI subscribes via SSE and offers
+step/continue controls.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from collections import defaultdict
+from pathlib import Path
+
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+# In-memory trace store: {agent_id: [{"type": "tool_call"|"tool_result"|"prompt", ...}]}
+_traces: dict[str, list[dict]] = defaultdict(list)
+
+# Per-agent SSE queues so multiple listeners can subscribe
+_queues: dict[str, list[asyncio.Queue]] = defaultdict(list)
+
+# Per-agent step position (index into trace)
+_positions: dict[str, int] = {}
+
+# Per-agent step events for blocking step/continue
+_step_events: dict[str, asyncio.Event] = {}
+
+_TEMPLATE_DIR = Path(__file__).resolve().parent.parent / "templates"
+
+_MAX_TRACE_LENGTH = 10_000  # cap per-agent trace to avoid unbounded memory growth
+
+
+def _get_template(name: str) -> str:
+    """Read an HTML template file, falling back to an error message."""
+    path = _TEMPLATE_DIR / name
+    if path.exists():
+        return path.read_text(encoding="utf-8")
+    return "<h1>Template not found</h1>"
+
+
+def _trim_trace(agent_id: str) -> None:
+    """Drop oldest events if the trace exceeds the cap."""
+    events = _traces[agent_id]
+    if len(events) > _MAX_TRACE_LENGTH:
+        _traces[agent_id] = events[-_MAX_TRACE_LENGTH:]
+        if _positions.get(agent_id, 0) < len(events) - _MAX_TRACE_LENGTH:
+            _positions[agent_id] = max(0, len(_traces[agent_id]) - 1)
+
+
+async def _broadcast(agent_id: str, event: dict) -> None:
+    """Push an event to all SSE listeners for this agent."""
+    payload = json.dumps(event)
+    for q in _queues.get(agent_id, []):
+        try:
+            q.put_nowait(payload)
+        except asyncio.QueueFull:
+            pass
+
+
+@router.get("/agent/{agent_id}/debug", response_class=HTMLResponse)
+async def debugger_ui(agent_id: str) -> HTMLResponse:
+    """Serve the debugger UI."""
+    html = _get_template("agent_debugger.html")
+    return HTMLResponse(html)
+
+
+@router.get("/agent/{agent_id}/debug/events")
+async def debugger_events(agent_id: str, request: Request):
+    """SSE endpoint that streams trace events to the debugger UI."""
+    queue: asyncio.Queue = asyncio.Queue(maxsize=256)
+
+    # Replay existing trace events
+    for event in _traces.get(agent_id, []):
+        queue.put_nowait(json.dumps(event))
+
+    _queues[agent_id].append(queue)
+
+    async def event_generator():
+        try:
+            # Send current position so the UI knows where to resume
+            pos = _positions.get(agent_id, 0)
+            yield f"data: {json.dumps({'type': 'position', 'pos': pos, 'total': len(_traces.get(agent_id, []))})}\n\n"
+
+            while True:
+                if await request.is_disconnected():
+                    break
+                try:
+                    data = await asyncio.wait_for(queue.get(), timeout=30.0)
+                    yield f"data: {data}\n\n"
+                except asyncio.TimeoutError:
+                    yield f"data: {json.dumps({'type': 'heartbeat'})}\n\n"
+        except asyncio.CancelledError:
+            pass
+        finally:
+            if queue in _queues.get(agent_id, []):
+                _queues[agent_id].remove(queue)
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+@router.post("/agent/{agent_id}/debug/step")
+async def debugger_step(agent_id: str) -> JSONResponse:
+    """Advance the debugger one step.
+
+    Steps the position forward by one event and broadcasts the new position.
+    If the agent is blocked waiting for a step, signals it to continue.
+    """
+    events = _traces.get(agent_id, [])
+    pos = _positions.get(agent_id, 0)
+
+    if pos < len(events):
+        _positions[agent_id] = pos + 1
+        await _broadcast(agent_id, {
+            "type": "position",
+            "pos": pos + 1,
+            "total": len(events),
+        })
+
+    # Signal any waiting agent
+    step_event = _step_events.get(agent_id)
+    if step_event:
+        step_event.set()
+
+    return JSONResponse({"status": "stepped", "pos": _positions.get(agent_id, 0)})
+
+
+@router.post("/agent/{agent_id}/debug/continue")
+async def debugger_continue(agent_id: str) -> JSONResponse:
+    """Run until breakpoint or completion.
+
+    Jumps to end of current trace and signals the agent to continue.
+    """
+    events = _traces.get(agent_id, [])
+    _positions[agent_id] = len(events)
+    await _broadcast(agent_id, {
+        "type": "position",
+        "pos": len(events),
+        "total": len(events),
+    })
+
+    # Signal any waiting agent
+    step_event = _step_events.get(agent_id)
+    if step_event:
+        step_event.set()
+
+    return JSONResponse({"status": "continued", "pos": len(events)})
+
+
+@router.post("/agent/{agent_id}/debug/trace")
+async def debugger_trace(agent_id: str, request: Request) -> JSONResponse:
+    """Record a trace event from the agent runtime.
+
+    Agents (or adapters) POST here to push tool call / result / prompt events
+    into the trace buffer. The SSE stream picks them up and broadcasts to
+    connected debugger UIs.
+
+    Request body: {"type": "tool_call"|"tool_result"|"prompt", ...}
+    """
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse({"error": "Invalid JSON body"}, status_code=400)
+
+    event_type = body.get("type", "unknown")
+    if event_type not in ("tool_call", "tool_result", "prompt", "error", "log"):
+        return JSONResponse(
+            {"error": f"Unknown event type: {event_type}"}, status_code=400
+        )
+
+    event = {
+        "type": event_type,
+        "ts": time.time(),
+        "data": body.get("data", {}),
+    }
+
+    _traces[agent_id].append(event)
+    _trim_trace(agent_id)
+
+    await _broadcast(agent_id, event)
+
+    # If in step mode, wait for user to step/continue
+    step_event = _step_events.get(agent_id)
+    if step_event:
+        step_event.clear()
+        await step_event.wait()
+
+    return JSONResponse({"status": "recorded", "total": len(_traces[agent_id])})
+
+
+@router.post("/agent/{agent_id}/debug/clear")
+async def debugger_clear(agent_id: str) -> JSONResponse:
+    """Clear the trace for an agent."""
+    _traces.pop(agent_id, None)
+    _positions.pop(agent_id, None)
+    _step_events.pop(agent_id, None)
+    await _broadcast(agent_id, {"type": "clear"})
+    return JSONResponse({"status": "cleared"})
+
+
+@router.get("/agent/{agent_id}/debug/status")
+async def debugger_status(agent_id: str) -> JSONResponse:
+    """Return current debugger state for the agent."""
+    events = _traces.get(agent_id, [])
+    return JSONResponse({
+        "agent_id": agent_id,
+        "total_events": len(events),
+        "position": _positions.get(agent_id, 0),
+        "has_listener": len(_queues.get(agent_id, [])) > 0,
+    })

--- a/tinyagentos/routes/agent_debugger.py
+++ b/tinyagentos/routes/agent_debugger.py
@@ -34,6 +34,11 @@ _positions: dict[str, int] = {}
 # Per-agent step events for blocking step/continue
 _step_events: dict[str, asyncio.Event] = {}
 
+# Per-agent step-mode flag. Recording only blocks waiting for a step/continue
+# while a debugger UI is attached (i.e. step mode is active). When no UI is
+# connected the agent records events and continues without blocking.
+_step_mode: dict[str, bool] = {}
+
 _TEMPLATE_DIR = Path(__file__).resolve().parent.parent / "templates"
 
 _MAX_TRACE_LENGTH = 10_000  # cap per-agent trace to avoid unbounded memory growth
@@ -48,12 +53,19 @@ def _get_template(name: str) -> str:
 
 
 def _trim_trace(agent_id: str) -> None:
-    """Drop oldest events if the trace exceeds the cap."""
+    """Drop oldest events if the trace exceeds the cap.
+
+    Dropping the first N events shifts every remaining index left by N, so the
+    stored position is rebased by the same amount and clamped to the new bounds.
+    """
     events = _traces[agent_id]
     if len(events) > _MAX_TRACE_LENGTH:
+        dropped = len(events) - _MAX_TRACE_LENGTH
         _traces[agent_id] = events[-_MAX_TRACE_LENGTH:]
-        if _positions.get(agent_id, 0) < len(events) - _MAX_TRACE_LENGTH:
-            _positions[agent_id] = max(0, len(_traces[agent_id]) - 1)
+        new_len = len(_traces[agent_id])
+        _positions[agent_id] = max(
+            0, min(_positions.get(agent_id, 0) - dropped, new_len)
+        )
 
 
 async def _broadcast(agent_id: str, event: dict) -> None:
@@ -76,13 +88,19 @@ async def debugger_ui(agent_id: str) -> HTMLResponse:
 @router.get("/agent/{agent_id}/debug/events")
 async def debugger_events(agent_id: str, request: Request):
     """SSE endpoint that streams trace events to the debugger UI."""
-    queue: asyncio.Queue = asyncio.Queue(maxsize=256)
+    backlog = _traces.get(agent_id, [])
+    # Size the queue to fit the full backlog plus headroom for live events so
+    # replaying a large stored trace never raises QueueFull on connect.
+    queue: asyncio.Queue = asyncio.Queue(maxsize=len(backlog) + 256)
 
     # Replay existing trace events
-    for event in _traces.get(agent_id, []):
+    for event in backlog:
         queue.put_nowait(json.dumps(event))
 
     _queues[agent_id].append(queue)
+    # A connected UI puts the agent into step mode so recording blocks on
+    # step/continue.
+    _step_mode[agent_id] = True
 
     async def event_generator():
         try:
@@ -103,6 +121,12 @@ async def debugger_events(agent_id: str, request: Request):
         finally:
             if queue in _queues.get(agent_id, []):
                 _queues[agent_id].remove(queue)
+            # When the last UI disconnects, leave step mode and release any
+            # agent currently blocked on a step so it does not hang forever.
+            if not _queues.get(agent_id):
+                _step_mode[agent_id] = False
+                if agent_id in _step_events:
+                    _step_events[agent_id].set()
 
     return StreamingResponse(
         event_generator(),
@@ -193,10 +217,13 @@ async def debugger_trace(agent_id: str, request: Request) -> JSONResponse:
 
     await _broadcast(agent_id, event)
 
-    # If in step mode, wait for user to step/continue
-    step_event = _step_events.setdefault(agent_id, asyncio.Event())
-    step_event.clear()
-    await step_event.wait()
+    # Only block when a debugger UI is attached (step mode active). Without a
+    # connected UI the agent records the event and continues immediately, so a
+    # trace POST never hangs when nobody is debugging.
+    if _step_mode.get(agent_id):
+        step_event = _step_events.setdefault(agent_id, asyncio.Event())
+        step_event.clear()
+        await step_event.wait()
 
     return JSONResponse({"status": "recorded", "total": len(_traces[agent_id])})
 
@@ -206,7 +233,11 @@ async def debugger_clear(agent_id: str) -> JSONResponse:
     """Clear the trace for an agent."""
     _traces.pop(agent_id, None)
     _positions.pop(agent_id, None)
-    _step_events.pop(agent_id, None)
+    # Release any agent blocked on a step before discarding its event so the
+    # POST /trace coroutine does not hang on a dropped event.
+    step_event = _step_events.pop(agent_id, None)
+    if step_event is not None:
+        step_event.set()
     await _broadcast(agent_id, {"type": "clear"})
     return JSONResponse({"status": "cleared"})
 

--- a/tinyagentos/routes/agent_debugger.py
+++ b/tinyagentos/routes/agent_debugger.py
@@ -134,9 +134,8 @@ async def debugger_step(agent_id: str) -> JSONResponse:
         })
 
     # Signal any waiting agent
-    step_event = _step_events.get(agent_id)
-    if step_event:
-        step_event.set()
+    step_event = _step_events.setdefault(agent_id, asyncio.Event())
+    step_event.set()
 
     return JSONResponse({"status": "stepped", "pos": _positions.get(agent_id, 0)})
 
@@ -156,9 +155,8 @@ async def debugger_continue(agent_id: str) -> JSONResponse:
     })
 
     # Signal any waiting agent
-    step_event = _step_events.get(agent_id)
-    if step_event:
-        step_event.set()
+    step_event = _step_events.setdefault(agent_id, asyncio.Event())
+    step_event.set()
 
     return JSONResponse({"status": "continued", "pos": len(events)})
 
@@ -196,10 +194,9 @@ async def debugger_trace(agent_id: str, request: Request) -> JSONResponse:
     await _broadcast(agent_id, event)
 
     # If in step mode, wait for user to step/continue
-    step_event = _step_events.get(agent_id)
-    if step_event:
-        step_event.clear()
-        await step_event.wait()
+    step_event = _step_events.setdefault(agent_id, asyncio.Event())
+    step_event.clear()
+    await step_event.wait()
 
     return JSONResponse({"status": "recorded", "total": len(_traces[agent_id])})
 

--- a/tinyagentos/routes/agent_debugger.py
+++ b/tinyagentos/routes/agent_debugger.py
@@ -215,10 +215,12 @@ async def debugger_trace(agent_id: str, request: Request) -> JSONResponse:
 
     await _broadcast(agent_id, event)
 
-    # If in step mode, wait for user to step/continue
-    step_event = _step_events.setdefault(agent_id, asyncio.Event())
-    step_event.clear()
-    await step_event.wait()
+    # Only block for step/continue when a debugger UI is actively listening.
+    # Without a listener the agent runs free — no reason to pause.
+    if _queues.get(agent_id):
+        step_event = _step_events.setdefault(agent_id, asyncio.Event())
+        step_event.clear()
+        await step_event.wait()
 
     return JSONResponse({"status": "recorded", "total": len(_traces[agent_id])})
 

--- a/tinyagentos/templates/agent_debugger.html
+++ b/tinyagentos/templates/agent_debugger.html
@@ -1,0 +1,320 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Agent Debugger — TinyAgentOS</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
+  <script src="https://unpkg.com/htmx.org@2"></script>
+  <style>
+    :root {
+      --debugger-header-height: 3.5rem;
+      --debugger-footer-height: 3.5rem;
+    }
+    body {
+      margin: 0;
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+    .debugger-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0.5rem 1rem;
+      border-bottom: 1px solid var(--pico-muted-border-color);
+      height: var(--debugger-header-height);
+      box-sizing: border-box;
+    }
+    .debugger-header h2 {
+      margin: 0;
+      font-size: 1.1rem;
+    }
+    .debugger-main {
+      display: flex;
+      flex: 1;
+      overflow: hidden;
+    }
+    .left-panel {
+      width: 40%;
+      border-right: 1px solid var(--pico-muted-border-color);
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+    .left-panel-header {
+      padding: 0.5rem 1rem;
+      border-bottom: 1px solid var(--pico-muted-border-color);
+      font-weight: 600;
+      font-size: 0.9rem;
+    }
+    .event-list {
+      flex: 1;
+      overflow-y: auto;
+      padding: 0;
+      margin: 0;
+      list-style: none;
+    }
+    .event-item {
+      border-bottom: 1px solid var(--pico-muted-border-color);
+      padding: 0.5rem 1rem;
+      cursor: pointer;
+      font-size: 0.85rem;
+      font-family: ui-monospace, monospace;
+    }
+    .event-item:hover {
+      background: var(--pico-secondary-hover-background);
+    }
+    .event-item.active {
+      background: var(--pico-primary-focus);
+    }
+    .event-item .event-type {
+      display: inline-block;
+      padding: 0.1rem 0.4rem;
+      border-radius: 3px;
+      font-size: 0.7rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      margin-right: 0.5rem;
+    }
+    .event-type-tool_call { background: var(--pico-primary-background); }
+    .event-type-tool_result { background: var(--pico-mark-background); }
+    .event-type-prompt { background: var(--pico-ins-background); }
+    .event-type-error { background: var(--pico-del-background); }
+    .event-type-log { background: var(--pico-muted-color); }
+
+    .right-panel {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+    .right-panel-header {
+      padding: 0.5rem 1rem;
+      border-bottom: 1px solid var(--pico-muted-border-color);
+      font-weight: 600;
+      font-size: 0.9rem;
+    }
+    .event-detail {
+      flex: 1;
+      overflow-y: auto;
+      padding: 1rem;
+    }
+    .event-detail pre {
+      margin: 0;
+      white-space: pre-wrap;
+      font-size: 0.85rem;
+      font-family: ui-monospace, monospace;
+      background: var(--pico-secondary-background);
+      padding: 0.75rem;
+      border-radius: 4px;
+    }
+    .event-detail .empty-state {
+      color: var(--pico-muted-color);
+      font-style: italic;
+      padding: 2rem;
+      text-align: center;
+    }
+    .debugger-footer {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.75rem;
+      padding: 0.5rem 1rem;
+      border-top: 1px solid var(--pico-muted-border-color);
+      height: var(--debugger-footer-height);
+      box-sizing: border-box;
+    }
+    .status-bar {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      font-size: 0.8rem;
+      color: var(--pico-muted-color);
+    }
+    .status-indicator {
+      display: inline-block;
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+    }
+    .status-connected { background: var(--pico-ins-color, #4caf50); }
+    .status-disconnected { background: var(--pico-del-color, #f44336); }
+  </style>
+</head>
+<body>
+  <header class="debugger-header">
+    <h2>
+      <span id="agent-name">Agent</span>
+      <span class="status-indicator status-disconnected" id="connection-status"
+            role="status" aria-label="Connection status"></span>
+    </h2>
+    <div class="status-bar">
+      <small id="event-count">0 events</small>
+      <small id="position-label">Position: 0</small>
+    </div>
+  </header>
+
+  <main class="debugger-main">
+    <nav class="left-panel" aria-label="Event timeline">
+      <div class="left-panel-header">Events</div>
+      <ol class="event-list" id="event-list" role="list"
+          aria-label="Execution trace events"
+          hx-get="/agent/REPLACE_AGENT_ID/debug/events"
+          hx-trigger="sse:message"
+          hx-swap="none">
+      </ol>
+    </nav>
+
+    <section class="right-panel" aria-label="Event details">
+      <div class="right-panel-header">Details</div>
+      <div class="event-detail" id="event-detail">
+        <div class="empty-state">Select an event from the timeline to view details.</div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="debugger-footer">
+    <button id="btn-step" aria-label="Step to next event"
+            hx-post="/agent/REPLACE_AGENT_ID/debug/step"
+            hx-swap="none">
+      Step
+    </button>
+    <button id="btn-continue" aria-label="Continue until breakpoint or completion"
+            hx-post="/agent/REPLACE_AGENT_ID/debug/continue"
+            hx-swap="none">
+      Continue
+    </button>
+    <button id="btn-stop" class="secondary" aria-label="Stop debugging"
+            hx-post="/agent/REPLACE_AGENT_ID/debug/clear"
+            hx-swap="none">
+      Stop
+    </button>
+  </footer>
+
+  <script>
+    (function() {
+      const agentId = window.location.pathname.split('/')[2] || 'unknown';
+      document.getElementById('agent-name').textContent = agentId;
+
+      // Fix htmx URLs
+      document.querySelectorAll('[hx-get],[hx-post]').forEach(el => {
+        ['hx-get','hx-post'].forEach(attr => {
+          const val = el.getAttribute(attr);
+          if (val && val.includes('REPLACE_AGENT_ID')) {
+            el.setAttribute(attr, val.replace('REPLACE_AGENT_ID', agentId));
+          }
+        });
+      });
+
+      const eventList = document.getElementById('event-list');
+      const eventDetail = document.getElementById('event-detail');
+      const eventCount = document.getElementById('event-count');
+      const positionLabel = document.getElementById('position-label');
+      const connectionStatus = document.getElementById('connection-status');
+
+      let events = [];
+      let currentPos = 0;
+      let activeIdx = -1;
+
+      // SSE connection
+      const es = new EventSource('/agent/' + agentId + '/debug/events');
+
+      es.onopen = function() {
+        connectionStatus.className = 'status-indicator status-connected';
+        connectionStatus.setAttribute('aria-label', 'Connected');
+      };
+
+      es.onerror = function() {
+        connectionStatus.className = 'status-indicator status-disconnected';
+        connectionStatus.setAttribute('aria-label', 'Disconnected');
+      };
+
+      es.addEventListener('message', function(e) {
+        try {
+          const data = JSON.parse(e.data);
+
+          if (data.type === 'heartbeat') return;
+
+          if (data.type === 'position') {
+            currentPos = data.pos;
+            updateUI();
+            return;
+          }
+
+          if (data.type === 'clear') {
+            events = [];
+            currentPos = 0;
+            activeIdx = -1;
+            eventList.innerHTML = '';
+            eventDetail.innerHTML = '<div class="empty-state">Trace cleared.</div>';
+            return;
+          }
+
+          // Regular event — add to list
+          events.push(data);
+          renderEvent(data, events.length - 1);
+          updateUI();
+        } catch (err) {
+          // ignore parse errors
+        }
+      });
+
+      function renderEvent(event, idx) {
+        const li = document.createElement('li');
+        li.className = 'event-item';
+        li.setAttribute('role', 'listitem');
+        li.setAttribute('tabindex', '0');
+        li.setAttribute('aria-label', event.type + ' event');
+        li.onclick = function() { selectEvent(idx); };
+
+        const span = document.createElement('span');
+        span.className = 'event-type event-type-' + event.type;
+        span.textContent = event.type.replace('_', ' ');
+
+        const label = document.createElement('span');
+        const data = event.data || {};
+        const summary = data.name || data.function || data.tool || data.text || '';
+        const truncated = typeof summary === 'string' ? summary.substring(0, 60) : JSON.stringify(summary).substring(0, 60);
+
+        label.textContent = truncated;
+
+        li.appendChild(span);
+        li.appendChild(label);
+        eventList.appendChild(li);
+      }
+
+      function selectEvent(idx) {
+        activeIdx = idx;
+        updateUI();
+
+        const event = events[idx];
+        if (!event) return;
+
+        let detailHtml = '<div class="event-type event-type-' + event.type + '" style="margin-bottom:0.5rem">' +
+                         event.type.replace('_', ' ') + '</div>';
+        detailHtml += '<pre>' + escapeHtml(JSON.stringify(event.data || {}, null, 2)) + '</pre>';
+        eventDetail.innerHTML = detailHtml;
+      }
+
+      function updateUI() {
+        eventCount.textContent = events.length + ' events';
+        positionLabel.textContent = 'Position: ' + currentPos;
+
+        // Update active styling
+        document.querySelectorAll('.event-item').forEach((el, i) => {
+          el.classList.toggle('active', i === activeIdx);
+        });
+      }
+
+      function escapeHtml(text) {
+        return String(text)
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+          .replace(/"/g, '&quot;');
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/tinyagentos/templates/agent_debugger.html
+++ b/tinyagentos/templates/agent_debugger.html
@@ -248,6 +248,7 @@
             activeIdx = -1;
             eventList.innerHTML = '';
             eventDetail.innerHTML = '<div class="empty-state">Trace cleared.</div>';
+            updateUI();
             return;
           }
 
@@ -263,10 +264,17 @@
       function renderEvent(event, idx) {
         const li = document.createElement('li');
         li.className = 'event-item';
-        li.setAttribute('role', 'listitem');
+        li.setAttribute('role', 'button');
         li.setAttribute('tabindex', '0');
         li.setAttribute('aria-label', event.type + ' event');
+        li.setAttribute('aria-pressed', 'false');
         li.onclick = function() { selectEvent(idx); };
+        li.onkeydown = function(e) {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            selectEvent(idx);
+          }
+        };
 
         const span = document.createElement('span');
         span.className = 'event-type event-type-' + event.type;

--- a/tinyagentos/templates/agent_debugger.html
+++ b/tinyagentos/templates/agent_debugger.html
@@ -4,8 +4,12 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Agent Debugger — TinyAgentOS</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
-  <script src="https://unpkg.com/htmx.org@2"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2.1.1/css/pico.min.css"
+        integrity="sha384-L1dWfspMTHU/ApYnFiMz2QID/PlP1xCW9visvBdbEkOLkSSWsP6ZJWhPw6apiXxU"
+        crossorigin="anonymous">
+  <script src="https://unpkg.com/htmx.org@2.0.10/dist/htmx.min.js"
+          integrity="sha384-H5SrcfygHmAuTDZphMHqBJLc3FhssKjG7w/CeCpFReSfwBWDTKpkzPP8c+cLsK+V"
+          crossorigin="anonymous"></script>
   <style>
     :root {
       --debugger-header-height: 3.5rem;
@@ -248,6 +252,7 @@
             activeIdx = -1;
             eventList.innerHTML = '';
             eventDetail.innerHTML = '<div class="empty-state">Trace cleared.</div>';
+            updateUI();
             return;
           }
 
@@ -263,10 +268,16 @@
       function renderEvent(event, idx) {
         const li = document.createElement('li');
         li.className = 'event-item';
-        li.setAttribute('role', 'listitem');
+        li.setAttribute('role', 'button');
         li.setAttribute('tabindex', '0');
         li.setAttribute('aria-label', event.type + ' event');
         li.onclick = function() { selectEvent(idx); };
+        li.addEventListener('keydown', function(e) {
+          if (e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar') {
+            e.preventDefault();
+            selectEvent(idx);
+          }
+        });
 
         const span = document.createElement('span');
         span.className = 'event-type event-type-' + event.type;


### PR DESCRIPTION
Implements agent debugger with SSE-based step-through execution.

- GET /agent/{id}/debug — debugger UI
- GET /agent/{id}/debug/events — SSE stream
- POST /agent/{id}/debug/step — step to next event
- POST /agent/{id}/debug/continue — run until breakpoint
- Pico CSS + htmx UI with ARIA labels

Closes #131

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive dark-themed agent debugger UI with timeline, details panel, and step/continue/stop controls
  * Real-time event streaming with backlog replay, heartbeat messages, per-agent isolation, and clear/reset of traces
  * Position and total-event counters with selectable event payload viewing; debugger controls advance or jump position

* **Tests**
  * Added async integration tests covering UI responses, trace recording/validation, stepping/continuing/clearing, isolation, ordering, and SSE streaming
<!-- end of auto-generated comment: release notes by coderabbit.ai -->