### PR TITLE
feat(knowledge): add per-app agent guides ingestion (#451)

### DIFF
--- a/tests/framework_integrations/test_agent_state.py
+++ b/tests/framework_integrations/test_agent_state.py
@@ -1,0 +1,555 @@
+"""Tests for AgentState data model and YAML I/O."""
+import textwrap
+
+import pytest
+import yaml
+
+from tinyagentos.framework_integrations.agent_state import (
+    AgentState,
+    AgentStatus,
+    Display,
+    Memory,
+    MemoryCollection,
+    Models,
+    ModelSlot,
+    NetworkMode,
+    Observability,
+    Plugin,
+    Routing,
+    RoutingStrategy,
+    Sandbox,
+    Schedule,
+    ScheduleJob,
+    ScheduleJobTask,
+    State,
+    dump_agent,
+    dump_agent_to_string,
+    load_agent,
+    load_agent_by_name,
+)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Fixtures
+# ═══════════════════════════════════════════════════════════════════════
+
+FULL_SPEC_YAML = """\
+name: research-agent
+framework: openclaw
+framework_version: 2026.4.4
+
+display:
+  color: "#5b8def"
+  emoji: "\U0001f50d"
+
+models:
+  chat:
+    id: qwen3-4b-q4
+    temperature: 0.2
+  fast:
+    id: qwen3-1.7b
+    temperature: 0.0
+  reasoning:
+    id: qwen3-32b
+    temperature: 0.4
+  embedding:
+    id: qwen3-embedding-0.6b
+  vision:
+    id: qwen2-vl-7b
+  stt:
+    id: whisper-large-v3-turbo
+  routing:
+    strategy: latency_first
+    fallback: chat
+
+memory:
+  enabled: true
+  collections:
+    - name: notes
+    - name: imports
+
+skills:
+  - web_search
+  - file_read
+  - file_write
+  - memory_search
+
+plugins:
+  - id: playwright-mcp
+    enabled: true
+    config_ref: secrets://playwright-creds
+
+channels:
+  - taos_id: channel-discord-research-server-general
+    permissions: [read, write, react]
+  - taos_id: channel-slack-eng-standup
+    permissions: [read]
+
+secrets:
+  - id: github-pat
+
+resources:
+  memory_limit: 2GB
+  cpu_limit: 2
+
+permissions:
+  can_read_user_memory: false
+  can_read_agent_memories:
+    - name: inbox-agent
+      mode: read-only
+      collections: ["summaries"]
+  can_write_agent_memories: []
+  can_send_email: false
+  can_use_browser: true
+
+observability:
+  tags:
+    team: research
+    project: model-mesh
+    cost_center: rd
+    owner: jay
+  trace_sample_rate: 1.0
+  log_level: info
+  emit_to: [dashboard, prometheus]
+
+schedule:
+  enabled: true
+  jobs:
+    - id: morning-digest
+      cron: "0 9 * * 1-5"
+      task:
+        kind: prompt
+        prompt: "Summarise overnight emails into MEMORY.md"
+        timeout_seconds: 600
+      enabled: true
+      on_failure: notify
+      max_retries: 0
+
+sandbox:
+  filesystem:
+    readable: [/workspace, /memory]
+    writable: [/workspace]
+    denied: [/etc, /proc, /sys]
+  network:
+    mode: allowlist
+    allow: [github.com, huggingface.co, "*.tinyagentos.local"]
+    rate_limit_rpm: 600
+  subprocess:
+    mode: denylist
+    denied: [rm, dd, mkfs, sudo]
+    timeout_seconds: 30
+  resources:
+    disk_quota_mb: 1024
+    max_processes: 64
+    max_open_files: 256
+  approval:
+    require_for: [subprocess, network_write]
+    approver: jay
+    timeout_seconds: 300
+
+state:
+  status: running
+  container_id: taos-agent-research-agent
+  last_deployed_at: 2026-04-11T13:22:01Z
+  framework_config_hash: sha256:...
+  skills_gateway_id: sgw-default-controller
+"""
+
+
+@pytest.fixture
+def full_spec_yaml() -> str:
+    return FULL_SPEC_YAML
+
+
+@pytest.fixture
+def full_spec_path(tmp_path, full_spec_yaml):
+    p = tmp_path / "research-agent.yaml"
+    p.write_text(full_spec_yaml)
+    return p
+
+
+MINIMAL_YAML = """\
+name: minimal
+framework: hermes
+framework_version: 2026.1.0
+"""
+
+
+@pytest.fixture
+def minimal_path(tmp_path):
+    p = tmp_path / "minimal.yaml"
+    p.write_text(MINIMAL_YAML)
+    return p
+
+
+@pytest.fixture
+def agents_dir(tmp_path):
+    d = tmp_path / "agents"
+    d.mkdir()
+    (d / "research-agent.yaml").write_text(FULL_SPEC_YAML)
+    return tmp_path
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Loading
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestLoadFullSpec:
+    """Smoke-test: the spec's own example YAML must parse without error."""
+
+    def test_loads_without_validation_error(self, full_spec_path):
+        agent = load_agent(full_spec_path)
+        assert agent.name == "research-agent"
+
+    def test_name_is_immutable(self, full_spec_path):
+        """name is the primary key — changing it requires model_copy."""
+        agent = load_agent(full_spec_path)
+        # Pydantic v2 non-frozen models allow attribute assignment,
+        # but the intent is that name is the primary key for the
+        # agent — users should model_copy(update={"name": ...})
+        # instead of in-place mutation.
+        updated = agent.model_copy(update={"name": "changed"})
+        assert updated.name == "changed"
+        assert agent.name == "research-agent"  # original unchanged
+
+    def test_framework_field(self, full_spec_path):
+        agent = load_agent(full_spec_path)
+        assert agent.framework == "openclaw"
+        assert agent.framework_version == "2026.4.4"
+
+    def test_display_emoji_and_color(self, full_spec_path):
+        agent = load_agent(full_spec_path)
+        assert agent.display.color == "#5b8def"
+        assert agent.display.emoji == "🔍"
+
+    def test_model_slots(self, full_spec_path):
+        agent = load_agent(full_spec_path)
+        assert agent.models.chat is not None
+        assert agent.models.chat.id == "qwen3-4b-q4"
+        assert agent.models.chat.temperature == 0.2
+        assert agent.models.fast is not None
+        assert agent.models.fast.temperature == 0.0
+        assert agent.models.reasoning is not None
+        assert agent.models.reasoning.temperature == 0.4
+        assert agent.models.routing.strategy == RoutingStrategy.LATENCY_FIRST
+        assert agent.models.routing.fallback == "chat"
+
+    def test_memory(self, full_spec_path):
+        agent = load_agent(full_spec_path)
+        assert agent.memory.enabled is True
+        assert len(agent.memory.collections) == 2
+        assert agent.memory.collections[0].name == "notes"
+
+    def test_skills_plain_strings(self, full_spec_path):
+        agent = load_agent(full_spec_path)
+        assert agent.skills == ["web_search", "file_read", "file_write", "memory_search"]
+
+    def test_plugins_model_objects(self, full_spec_path):
+        agent = load_agent(full_spec_path)
+        assert len(agent.plugins) == 1
+        p = agent.plugins[0]
+        assert p.id == "playwright-mcp"
+        assert p.enabled is True
+        assert p.config_ref == "secrets://playwright-creds"
+
+    def test_channels(self, full_spec_path):
+        agent = load_agent(full_spec_path)
+        assert len(agent.channels) == 2
+        assert agent.channels[0].taos_id == "channel-discord-research-server-general"
+        assert "read" in agent.channels[0].permissions
+
+    def test_secrets_are_opaque_refs(self, full_spec_path):
+        agent = load_agent(full_spec_path)
+        assert len(agent.secrets) == 1
+        assert agent.secrets[0].id == "github-pat"
+
+    def test_no_file_paths_on_model(self, full_spec_path):
+        """Rule 1: no file paths — the Reconciler computes them.
+        Sandbox paths (/workspace, /memory, etc.) are allowed because
+        they are runtime container paths, not host config paths."""
+        agent = load_agent(full_spec_path)
+        dumped = agent.model_dump()
+        for v in _walk_strings(dumped):
+            assert "/data/agents/" not in v, (
+                f"found config file path in model: {v!r}"
+            )
+
+    def test_resource_limits(self, full_spec_path):
+        agent = load_agent(full_spec_path)
+        assert agent.resources.memory_limit == "2GB"
+        assert agent.resources.cpu_limit == 2
+
+    def test_permissions(self, full_spec_path):
+        agent = load_agent(full_spec_path)
+        assert agent.permissions.can_read_user_memory is False
+        assert len(agent.permissions.can_read_agent_memories) == 1
+        mem = agent.permissions.can_read_agent_memories[0]
+        assert mem.name == "inbox-agent"
+        assert mem.collections == ["summaries"]
+        assert agent.permissions.can_use_browser is True
+
+    def test_observability(self, full_spec_path):
+        agent = load_agent(full_spec_path)
+        assert agent.observability.tags == {
+            "team": "research",
+            "project": "model-mesh",
+            "cost_center": "rd",
+            "owner": "jay",
+        }
+        assert agent.observability.trace_sample_rate == 1.0
+        assert agent.observability.log_level == "info"
+
+    def test_schedule(self, full_spec_path):
+        agent = load_agent(full_spec_path)
+        assert agent.schedule.enabled is True
+        assert len(agent.schedule.jobs) == 1
+        job = agent.schedule.jobs[0]
+        assert job.id == "morning-digest"
+        assert job.cron == "0 9 * * 1-5"
+        assert job.task.kind == "prompt"
+        assert job.task.timeout_seconds == 600
+
+    def test_sandbox(self, full_spec_path):
+        agent = load_agent(full_spec_path)
+        sandbox = agent.sandbox
+        assert sandbox.filesystem.readable == ["/workspace", "/memory"]
+        assert sandbox.filesystem.denied == ["/etc", "/proc", "/sys"]
+        assert sandbox.network.mode == NetworkMode.ALLOWLIST
+        assert "github.com" in sandbox.network.allow
+        assert sandbox.subprocess.denied == ["rm", "dd", "mkfs", "sudo"]
+        assert sandbox.resources.disk_quota_mb == 1024
+        assert sandbox.approval.require_for == ["subprocess", "network_write"]
+
+    def test_state(self, full_spec_path):
+        agent = load_agent(full_spec_path)
+        assert agent.state.status == AgentStatus.RUNNING
+        assert agent.state.container_id == "taos-agent-research-agent"
+        assert agent.state.last_deployed_at == "2026-04-11T13:22:01Z"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Minimal agent
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestLoadMinimal:
+    def test_minimal_fields(self, minimal_path):
+        agent = load_agent(minimal_path)
+        assert agent.name == "minimal"
+        assert agent.framework == "hermes"
+        assert agent.framework_version == "2026.1.0"
+
+    def test_defaults_applied(self, minimal_path):
+        agent = load_agent(minimal_path)
+        # display
+        assert agent.display.color == "#5b8def"
+        assert agent.display.emoji == "🤖"
+        # models
+        assert agent.models.chat is None
+        assert agent.models.routing.strategy == RoutingStrategy.LATENCY_FIRST
+        # memory
+        assert agent.memory.enabled is False
+        assert agent.memory.collections == []
+        # empty collections
+        assert agent.skills == []
+        assert agent.plugins == []
+        assert agent.channels == []
+        assert agent.secrets == []
+        # resources
+        assert agent.resources.memory_limit == "512MB"
+        assert agent.resources.cpu_limit == 1
+        # permissions all false
+        assert agent.permissions.can_read_user_memory is False
+        assert agent.permissions.can_send_email is False
+        assert agent.permissions.can_use_browser is False
+        # schedule disabled
+        assert agent.schedule.enabled is False
+        assert agent.schedule.jobs == []
+        # state
+        assert agent.state.status == AgentStatus.STOPPED
+        assert agent.state.container_id == ""
+
+    def test_skills_and_plugins_are_separate_buckets(self, minimal_path):
+        """Rule 3: skills (plain strings) vs plugins (objects)."""
+        agent = load_agent(minimal_path)
+        assert isinstance(agent.skills, list)
+        assert isinstance(agent.plugins, list)
+        # They are different types in the model
+        from tinyagentos.framework_integrations.agent_state import Plugin as PluginT
+
+        # Verify model types — skills are List[str], plugins are List[Plugin]
+        # (checked at import time above)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Round-trip
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestRoundTrip:
+    def test_round_trip_preserves_core_fields(self, full_spec_path):
+        agent = load_agent(full_spec_path)
+        dumped = dump_agent_to_string(agent)
+        reloaded = AgentState.model_validate(yaml.safe_load(dumped))
+        assert reloaded.name == agent.name
+        assert reloaded.framework == agent.framework
+        assert reloaded.framework_version == agent.framework_version
+
+    def test_round_trip_full_spec_is_idempotent(self, full_spec_path):
+        agent = load_agent(full_spec_path)
+        yaml_str = dump_agent_to_string(agent)
+        reloaded = AgentState.model_validate(yaml.safe_load(yaml_str))
+        # Core identity
+        assert reloaded.name == agent.name
+        assert reloaded.framework == agent.framework
+        # Nested equality
+        assert reloaded.models.chat is not None
+        assert agent.models.chat is not None
+        assert reloaded.models.chat.id == agent.models.chat.id
+        assert reloaded.models.routing.strategy == agent.models.routing.strategy
+        assert reloaded.memory.enabled == agent.memory.enabled
+        assert len(reloaded.memory.collections) == len(agent.memory.collections)
+        assert reloaded.skills == agent.skills
+        assert len(reloaded.plugins) == len(agent.plugins)
+        assert reloaded.plugins[0].id == agent.plugins[0].id
+        assert len(reloaded.channels) == len(agent.channels)
+        assert len(reloaded.secrets) == len(agent.secrets)
+        assert reloaded.sandbox.network.mode == agent.sandbox.network.mode
+        assert reloaded.state.status == agent.state.status
+
+    def test_write_and_read_back(self, full_spec_path, tmp_path):
+        agent = load_agent(full_spec_path)
+        out = tmp_path / "roundtrip.yaml"
+        dump_agent(agent, out)
+        reloaded = load_agent(out)
+        assert reloaded.name == agent.name
+        assert reloaded.framework == agent.framework
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# load_agent_by_name
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestLoadAgentByName:
+    def test_loads_from_standard_location(self, agents_dir):
+        agent = load_agent_by_name(agents_dir, "research-agent")
+        assert agent.name == "research-agent"
+        assert agent.framework == "openclaw"
+
+    def test_file_not_found(self, agents_dir):
+        with pytest.raises(FileNotFoundError):
+            load_agent_by_name(agents_dir, "no-such-agent")
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Validation
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestValidation:
+    def test_extra_fields_forbidden(self, tmp_path):
+        yaml_str = textwrap.dedent("""\
+        name: bad-agent
+        framework: openclaw
+        framework_version: "1.0"
+        extra_field: nope
+        """)
+        p = tmp_path / "bad.yaml"
+        p.write_text(yaml_str)
+        with pytest.raises(Exception):
+            load_agent(p)
+
+    def test_missing_required_name(self):
+        with pytest.raises(Exception):
+            AgentState.model_validate({"framework": "x", "framework_version": "1.0"})
+
+    def test_missing_framework(self):
+        with pytest.raises(Exception):
+            AgentState.model_validate({"name": "x", "framework_version": "1.0"})
+
+    def test_bad_routing_strategy_rejected(self, tmp_path):
+        yaml_str = textwrap.dedent("""\
+        name: bad-routing
+        framework: openclaw
+        framework_version: "1.0"
+        models:
+          routing:
+            strategy: not_a_real_strategy
+            fallback: chat
+        """)
+        p = tmp_path / "bad-routing.yaml"
+        p.write_text(yaml_str)
+        with pytest.raises(Exception):
+            load_agent(p)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Three rules
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestThreeRules:
+    """Verification of the three design rules from the spec."""
+
+    def test_rule1_no_file_paths_as_fields(self):
+        """Rule 1: AgentState must not carry file paths.
+        The Reconciler computes them."""
+        fields = list(AgentState.model_fields.keys())
+        for pathy_name in ("data_dir", "workspace_dir", "config_path",
+                           "agent_path", "yaml_path", "file_path"):
+            assert pathy_name not in fields, (
+                f"'{pathy_name}' violates rule 1: no file paths"
+            )
+
+    def test_rule2_secrets_are_opaque_refs(self, full_spec_path):
+        """Rule 2: secrets are id-only refs, not inline creds."""
+        agent = load_agent(full_spec_path)
+        for s in agent.secrets:
+            assert isinstance(s.id, str)
+            assert len(s.id) > 0
+            # No secret value should be present
+            assert not hasattr(s, "value")
+            assert not hasattr(s, "secret")
+
+    def test_rule3_skills_vs_plugins_different_types(self):
+        """Rule 3: skills (List[str]) vs plugins (List[Plugin]) are
+        separate buckets with different model types."""
+        from tinyagentos.framework_integrations.agent_state import Plugin as PluginT
+
+        # skills field annotation should be list[str]
+        skills_field = AgentState.model_fields["skills"]
+        skills_args = getattr(skills_field.annotation, "__args__", ())
+        assert str in skills_args, (
+            f"skills must be List[str], got {skills_field.annotation}"
+        )
+        # plugins field annotation should be list[Plugin]
+        plugins_field = AgentState.model_fields["plugins"]
+        # The field annotation should involve Plugin
+        import typing
+        plugins_annotation = plugins_field.annotation
+        # In Pydantic v2 the annotation may be wrapped; unwrap if needed
+        origin = typing.get_origin(plugins_annotation)
+        args = typing.get_args(plugins_annotation)
+        if origin is list and args:
+            assert args[0] is PluginT, (
+                f"plugins must be List[Plugin], got List[{args[0].__name__ if hasattr(args[0], '__name__') else args[0]}]"
+            )
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Helpers
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def _walk_strings(obj):
+    """Recursively yield all string values from a nested dict/list."""
+    if isinstance(obj, dict):
+        for v in obj.values():
+            yield from _walk_strings(v)
+    elif isinstance(obj, list):
+        for v in obj:
+            yield from _walk_strings(v)
+    elif isinstance(obj, str):
+        yield obj

--- a/tests/routes/test_store_install_v2.py
+++ b/tests/routes/test_store_install_v2.py
@@ -144,8 +144,8 @@ class TestBackendToMethodMapping:
         from tinyagentos.installers.base import get_installer
 
         method = _BACKEND_TO_METHOD["ollama"]
-        assert method == "ollama"
-        # Should not raise ValueError
+        assert method == "ollama_pull"
+        # Should not raise ValueError — both "ollama" and "ollama_pull" resolve
         installer = get_installer(method)
         assert installer is not None
 

--- a/tests/test_agent_doc_ingestion.py
+++ b/tests/test_agent_doc_ingestion.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from pathlib import Path
+
+from tinyagentos.knowledge_store import KnowledgeStore
+from tinyagentos.knowledge_monitor import (
+    ingest_agent_docs,
+    ingest_app_guides,
+    ingest_installed_app_guides,
+    wipe_app_guides,
+)
+
+
+@pytest_asyncio.fixture
+async def store(tmp_path):
+    s = KnowledgeStore(tmp_path / "knowledge.db", media_dir=tmp_path / "media")
+    await s.init()
+    yield s
+    await s.close()
+
+
+@pytest_asyncio.fixture
+def docs_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "docs"
+    d.mkdir()
+    (d / "getting-started.md").write_text("# Getting Started\n\nWelcome to the project.")
+    (d / "advanced.md").write_text("# Advanced\n\nDeep dive into internals.")
+    # subdirectory
+    sub = d / "api"
+    sub.mkdir()
+    (sub / "reference.md").write_text("# API Reference\n\nEndpoints listed here.")
+    return d
+
+
+@pytest_asyncio.fixture
+def app_guides_dir(tmp_path: Path) -> Path:
+    """Simulate an app catalog entry with a guides/ directory."""
+    app_dir = tmp_path / "some-agent"
+    guides = app_dir / "guides"
+    guides.mkdir(parents=True)
+    (guides / "setup.md").write_text("# Setup\n\nHow to configure the agent.")
+    (guides / "usage.md").write_text("# Usage\n\nHow to use the agent.")
+    return app_dir
+
+
+# ---------------------------------------------------------------------------
+# ingest_agent_docs
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_ingest_agent_docs_basic(store, docs_dir):
+    n = await ingest_agent_docs(docs_dir, store, source_id="core")
+    assert n == 3
+
+    items = await store.list_items(limit=10)
+    assert len(items) == 3
+    titles = {item["title"] for item in items}
+    assert titles == {"getting-started", "advanced", "reference"}
+
+    for item in items:
+        assert item["source_type"] == "agent_doc"
+        assert item["source_id"] == "core"
+        assert item["status"] == "ready"
+        assert item["content"]
+
+
+@pytest.mark.asyncio
+async def test_ingest_agent_docs_idempotent(store, docs_dir):
+    n1 = await ingest_agent_docs(docs_dir, store, source_id="core")
+    assert n1 == 3
+
+    # Second call should skip all files (already present)
+    n2 = await ingest_agent_docs(docs_dir, store, source_id="core")
+    assert n2 == 0
+
+    items = await store.list_items(limit=10)
+    assert len(items) == 3
+
+
+@pytest.mark.asyncio
+async def test_ingest_agent_docs_scoped_by_source_id(store, docs_dir):
+    n1 = await ingest_agent_docs(docs_dir, store, source_id="core")
+    assert n1 == 3
+
+    # Same docs under a different source_id should be ingested again
+    n2 = await ingest_agent_docs(docs_dir, store, source_id="app:test")
+    assert n2 == 3
+
+    items = await store.list_items(limit=10)
+    assert len(items) == 6
+
+    core_items = await store.list_by_source_id("core")
+    app_items = await store.list_by_source_id("app:test")
+    assert len(core_items) == 3
+    assert len(app_items) == 3
+
+
+@pytest.mark.asyncio
+async def test_ingest_agent_docs_missing_dir(store):
+    n = await ingest_agent_docs(Path("/nonexistent/path"), store)
+    assert n == 0
+
+
+@pytest.mark.asyncio
+async def test_ingest_agent_docs_empty_files(store, tmp_path):
+    d = tmp_path / "empty-docs"
+    d.mkdir()
+    (d / "empty.md").write_text("")
+    (d / "ws-only.md").write_text("   \n\n  ")
+    (d / "real.md").write_text("# Real content")
+
+    n = await ingest_agent_docs(d, store, source_id="test")
+    assert n == 1
+
+    items = await store.list_items(limit=10)
+    assert len(items) == 1
+    assert items[0]["title"] == "real"
+
+
+# ---------------------------------------------------------------------------
+# ingest_app_guides
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_ingest_app_guides(store, app_guides_dir):
+    n = await ingest_app_guides("my-app", app_guides_dir, store)
+    assert n == 2
+
+    items = await store.list_by_source_id("app:my-app")
+    assert len(items) == 2
+    titles = {item["title"] for item in items}
+    assert titles == {"setup", "usage"}
+
+    for item in items:
+        assert item["source_type"] == "agent_doc"
+        assert item["source_id"] == "app:my-app"
+
+
+@pytest.mark.asyncio
+async def test_ingest_app_guides_no_guides_dir(store, tmp_path):
+    app_dir = tmp_path / "no-guides-app"
+    app_dir.mkdir()
+    # No guides/ directory
+    n = await ingest_app_guides("no-guides", app_dir, store)
+    assert n == 0
+
+
+# ---------------------------------------------------------------------------
+# wipe_app_guides
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_wipe_app_guides(store, app_guides_dir):
+    await ingest_app_guides("my-app", app_guides_dir, store)
+
+    # Also ingest core docs to verify wipe is scoped
+    core_dir = app_guides_dir.parent / "core-docs"
+    core_dir.mkdir()
+    (core_dir / "intro.md").write_text("# Intro")
+    await ingest_agent_docs(core_dir, store, source_id="core")
+
+    deleted = await wipe_app_guides(store, "my-app")
+    assert deleted == 2
+
+    # App guides gone
+    app_items = await store.list_by_source_id("app:my-app")
+    assert len(app_items) == 0
+
+    # Core docs untouched
+    core_items = await store.list_by_source_id("core")
+    assert len(core_items) == 1
+
+
+@pytest.mark.asyncio
+async def test_wipe_app_guides_no_match(store):
+    deleted = await wipe_app_guides(store, "nonexistent")
+    assert deleted == 0
+
+
+# ---------------------------------------------------------------------------
+# list_by_source_id
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_list_by_source_id_empty(store):
+    items = await store.list_by_source_id("nonexistent")
+    assert items == []
+
+
+@pytest.mark.asyncio
+async def test_delete_by_source_id(store, app_guides_dir):
+    await ingest_app_guides("app-x", app_guides_dir, store)
+    await ingest_app_guides("app-y", app_guides_dir, store)
+
+    deleted = await store.delete_by_source_id("app:app-x")
+    assert deleted == 2
+
+    remaining = await store.list_by_source_id("app:app-y")
+    assert len(remaining) == 2

--- a/tinyagentos/agent_tokens_store.py
+++ b/tinyagentos/agent_tokens_store.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+import aiosqlite
+
+from tinyagentos.base_store import BaseStore
+
+logger = logging.getLogger(__name__)
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS agent_tokens (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    agent_name  TEXT    NOT NULL,
+    token       TEXT    NOT NULL,
+    created_at  TEXT    NOT NULL,
+    revoked_at  TEXT
+);
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_agent_active_token
+    ON agent_tokens(agent_name)
+    WHERE revoked_at IS NULL;
+"""
+
+
+def _row_to_dict(row: aiosqlite.Row) -> dict:
+    """Convert an aiosqlite.Row to a plain dict."""
+    return {key: row[key] for key in row.keys()}
+
+
+class AgentTokenExistsError(Exception):
+    """Raised when attempting to issue a token for an agent that already
+    has an active (non-revoked) token."""
+
+    def __init__(self, agent_name: str) -> None:
+        super().__init__(
+            f"Agent '{agent_name}' already has an active token. "
+            f"Revoke the existing token before issuing a new one."
+        )
+        self.agent_name = agent_name
+
+
+class AgentTokensStore(BaseStore):
+    """Per-agent token store with multi-worker-safe issuance.
+
+    Uses ``BEGIN IMMEDIATE`` so concurrent workers cannot bypass the
+    unique partial index ``uniq_agent_active_token`` — the reservation
+    is visible to all connections as soon as the transaction begins.
+    """
+
+    SCHEMA = SCHEMA
+
+    async def init(self) -> None:
+        await super().init()
+        if self._db is not None:
+            self._db.row_factory = aiosqlite.Row
+
+    async def issue(self, agent_name: str, token: str) -> dict:
+        """Issue a new active token for *agent_name*.
+
+        Returns the row dict on success.  Raises ``AgentTokenExistsError``
+        when the agent already has an active (non-revoked) token.
+        """
+        if self._db is None:
+            raise RuntimeError("AgentTokensStore not initialised — call init() first")
+
+        now = datetime.now(timezone.utc).isoformat()
+
+        try:
+            # BEGIN IMMEDIATE acquires the reserved lock straight away so
+            # other workers see the intent before we commit — no window
+            # where an asyncio.Lock in a single process would be bypassed.
+            await self._db.execute("BEGIN IMMEDIATE")
+            await self._db.execute(
+                "INSERT INTO agent_tokens (agent_name, token, created_at) "
+                "VALUES (?, ?, ?)",
+                (agent_name, token, now),
+            )
+            await self._db.commit()
+        except aiosqlite.IntegrityError:
+            await self._db.execute("ROLLBACK")
+            raise AgentTokenExistsError(agent_name) from None
+        except Exception:
+            await self._db.execute("ROLLBACK")
+            raise
+
+        row = await (
+            await self._db.execute(
+                "SELECT id, agent_name, token, created_at, revoked_at "
+                "FROM agent_tokens WHERE agent_name = ? AND revoked_at IS NULL",
+                (agent_name,),
+            )
+        ).fetchone()
+
+        if row is None:
+            raise RuntimeError(f"Token for '{agent_name}' not found after issue")
+
+        return _row_to_dict(row)
+
+    async def revoke(self, agent_name: str) -> dict | None:
+        """Revoke the active token for *agent_name*, if one exists.
+
+        Returns the updated row dict, or ``None`` when no active token
+        was found.
+        """
+        if self._db is None:
+            raise RuntimeError("AgentTokensStore not initialised — call init() first")
+
+        now = datetime.now(timezone.utc).isoformat()
+
+        await self._db.execute(
+            "UPDATE agent_tokens SET revoked_at = ? "
+            "WHERE agent_name = ? AND revoked_at IS NULL",
+            (now, agent_name),
+        )
+        await self._db.commit()
+
+        row = await (
+            await self._db.execute(
+                "SELECT id, agent_name, token, created_at, revoked_at "
+                "FROM agent_tokens WHERE agent_name = ? AND revoked_at = ?",
+                (agent_name, now),
+            )
+        ).fetchone()
+
+        return _row_to_dict(row) if row else None
+
+    async def get_active(self, agent_name: str) -> dict | None:
+        """Return the active (non-revoked) token row for *agent_name*,
+        or ``None``."""
+        if self._db is None:
+            raise RuntimeError("AgentTokensStore not initialised — call init() first")
+
+        row = await (
+            await self._db.execute(
+                "SELECT id, agent_name, token, created_at, revoked_at "
+                "FROM agent_tokens WHERE agent_name = ? AND revoked_at IS NULL",
+                (agent_name,),
+            )
+        ).fetchone()
+
+        return _row_to_dict(row) if row else None

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -1237,9 +1237,6 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     from tinyagentos.routes.catalog import router as catalog_router
     app.include_router(catalog_router)
 
-    from tinyagentos.routes.agent_debugger import router as agent_debugger_router
-    app.include_router(agent_debugger_router)
-
     from tinyagentos.routes.memory_management import router as memory_mgmt_router
     app.include_router(memory_mgmt_router)
 

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -379,6 +379,24 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         app.state.ingest_pipeline = knowledge_ingest
         app.state.knowledge_monitor = knowledge_monitor
         await knowledge_monitor.start()
+        # Ingest core agent docs and per-app guides on startup
+        from tinyagentos.knowledge_monitor import ingest_agent_docs, ingest_installed_app_guides
+        _agents_docs_dir = PROJECT_DIR / "docs" / "agents"
+        if _agents_docs_dir.is_dir():
+            try:
+                _n = await ingest_agent_docs(_agents_docs_dir, knowledge_store, source_id="core")
+                if _n:
+                    logger.info("ingested %d core agent docs on startup", _n)
+            except Exception:
+                logger.exception("core agent doc ingestion failed on startup")
+        try:
+            _app_guides = await ingest_installed_app_guides(
+                installed_apps, registry, knowledge_store
+            )
+            if _app_guides:
+                logger.info("ingested %d per-app guides on startup: %s", sum(_app_guides.values()), list(_app_guides.keys()))
+        except Exception:
+            logger.exception("per-app guide ingestion failed on startup")
         await agent_browsers.init()
         app.state.agent_browsers = agent_browsers
         await browsing_history.init()
@@ -1218,6 +1236,9 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
 
     from tinyagentos.routes.catalog import router as catalog_router
     app.include_router(catalog_router)
+
+    from tinyagentos.routes.agent_debugger import router as agent_debugger_router
+    app.include_router(agent_debugger_router)
 
     from tinyagentos.routes.memory_management import router as memory_mgmt_router
     app.include_router(memory_mgmt_router)

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -558,6 +558,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         app.state.adapter_manager = adapter_manager
         app.state.channel_hub_connectors = {}
         app.state.deploy_tasks = {}
+        from tinyagentos.routes.agents import IdempotencyCache
+        app.state.idempotency_cache = IdempotencyCache()
         app.state.chat_messages = chat_messages
         app.state.chat_channels = chat_channels
         app.state.project_store = project_store
@@ -975,6 +977,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     app.state.adapter_manager = adapter_manager
     app.state.channel_hub_connectors = {}
     app.state.deploy_tasks = {}
+    from tinyagentos.routes.agents import IdempotencyCache
+    app.state.idempotency_cache = IdempotencyCache()
     app.state.chat_messages = chat_messages
     app.state.chat_channels = chat_channels
     app.state.project_store = project_store

--- a/tinyagentos/channel_hub/adapter_manager.py
+++ b/tinyagentos/channel_hub/adapter_manager.py
@@ -11,8 +11,11 @@ ADAPTER_DIR = Path(__file__).parent.parent / "adapters"
 
 # Channel-level adapters (run in-process via channel-hub connect API, not subprocesses)
 CHANNEL_ADAPTER_DIR = Path(__file__).parent / "adapters"
-_CHANNEL_ADAPTERS = {"github": CHANNEL_ADAPTER_DIR / "github.py"}
-
+_CHANNEL_ADAPTERS = {
+    "github": CHANNEL_ADAPTER_DIR / "github.py",
+    # === Discord adapter (issue #335) ===
+    "discord": CHANNEL_ADAPTER_DIR / "discord.py",
+}
 
 class AdapterManager:
     def __init__(self, router):

--- a/tinyagentos/framework_integrations/__init__.py
+++ b/tinyagentos/framework_integrations/__init__.py
@@ -1,0 +1,6 @@
+"""Framework integrations for TAOS Bridge.
+
+The Reconciler reads AgentState YAML files, resolves secrets and config
+references, computes file paths, and renders framework-specific runtime
+configuration that the framework's container consumes at boot.
+"""

--- a/tinyagentos/framework_integrations/agent_state.py
+++ b/tinyagentos/framework_integrations/agent_state.py
@@ -1,0 +1,330 @@
+"""AgentState data model — the framework-agnostic agent definition.
+
+Lives at data/agents/{name}.yaml, owned by the TAOS UI, consumed by the
+Reconciler.  See docs/superpowers/specs/2026-04-11-taos-framework-integration-bridge-design.md.
+
+Three rules guiding the schema (enforced here):
+1. No file paths.  The Reconciler computes them from ``name`` and the
+   host's ``data_dir``.
+2. Secrets and config refs are opaque references — the AgentState file
+   only carries references; resolution happens at render time.
+3. Skills and plugins are separate buckets.  *Skills* are TAOS-generic;
+   *Plugins* are framework-specific extensions from the catalog.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+from pydantic import BaseModel, Field, field_validator
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Enums
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class RoutingStrategy(str, Enum):
+    LATENCY_FIRST = "latency_first"
+    COST_FIRST = "cost_first"
+    QUALITY_FIRST = "quality_first"
+    MANUAL = "manual"
+
+
+class AgentStatus(str, Enum):
+    DEPLOYING = "deploying"
+    RUNNING = "running"
+    FAILED = "failed"
+    STOPPED = "stopped"
+
+
+class NetworkMode(str, Enum):
+    ALLOWLIST = "allowlist"
+    ALL = "all"
+    NONE = "none"
+
+
+class SubprocessMode(str, Enum):
+    DENYLIST = "denylist"
+
+
+class LogLevel(str, Enum):
+    DEBUG = "debug"
+    INFO = "info"
+    WARNING = "warning"
+    ERROR = "error"
+
+
+class ChannelPermission(str, Enum):
+    READ = "read"
+    WRITE = "write"
+    REACT = "react"
+
+
+class ApprovalRequire(str, Enum):
+    SUBPROCESS = "subprocess"
+    NETWORK_WRITE = "network_write"
+
+
+class EmitTarget(str, Enum):
+    DASHBOARD = "dashboard"
+    PROMETHEUS = "prometheus"
+
+
+class MemoryAccessMode(str, Enum):
+    READ_ONLY = "read-only"
+
+
+class OnFailure(str, Enum):
+    NOTIFY = "notify"
+
+
+class TaskKind(str, Enum):
+    PROMPT = "prompt"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Nested models
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class Display(BaseModel):
+    color: str = "#5b8def"
+    emoji: str = "🤖"
+
+
+class ModelSlot(BaseModel):
+    id: str
+    temperature: float = 0.2
+
+
+class Routing(BaseModel):
+    strategy: RoutingStrategy = RoutingStrategy.LATENCY_FIRST
+    fallback: str = "chat"
+
+
+class Models(BaseModel):
+    chat: Optional[ModelSlot] = None
+    fast: Optional[ModelSlot] = None
+    reasoning: Optional[ModelSlot] = None
+    embedding: Optional[ModelSlot] = None
+    vision: Optional[ModelSlot] = None
+    stt: Optional[ModelSlot] = None
+    routing: Routing = Field(default_factory=Routing)
+
+
+class MemoryCollection(BaseModel):
+    name: str
+
+
+class Memory(BaseModel):
+    enabled: bool = False
+    collections: list[MemoryCollection] = Field(default_factory=list)
+
+
+class Plugin(BaseModel):
+    id: str
+    enabled: bool = True
+    config_ref: Optional[str] = None
+
+
+class Channel(BaseModel):
+    taos_id: str
+    permissions: list[ChannelPermission] = Field(default_factory=list)
+
+
+class SecretRef(BaseModel):
+    id: str
+
+
+class Resources(BaseModel):
+    memory_limit: str = "512MB"
+    cpu_limit: int = 1
+
+
+class AgentMemoryAccess(BaseModel):
+    name: str
+    mode: MemoryAccessMode = MemoryAccessMode.READ_ONLY
+    collections: list[str] = Field(default_factory=list)
+
+
+class Permissions(BaseModel):
+    can_read_user_memory: bool = False
+    can_read_agent_memories: list[AgentMemoryAccess] = Field(default_factory=list)
+    can_write_agent_memories: list[str] = Field(default_factory=list)
+    can_send_email: bool = False
+    can_use_browser: bool = False
+
+
+class Observability(BaseModel):
+    tags: dict[str, str] = Field(default_factory=dict)
+    trace_sample_rate: float = 1.0
+    log_level: LogLevel = LogLevel.INFO
+    emit_to: list[EmitTarget] = Field(default_factory=list)
+
+
+class ScheduleJobTask(BaseModel):
+    kind: TaskKind
+    prompt: str
+    timeout_seconds: int = 600
+
+
+class ScheduleJob(BaseModel):
+    id: str
+    cron: str
+    task: ScheduleJobTask
+    enabled: bool = True
+    on_failure: OnFailure = OnFailure.NOTIFY
+    max_retries: int = 0
+
+
+class Schedule(BaseModel):
+    enabled: bool = False
+    jobs: list[ScheduleJob] = Field(default_factory=list)
+
+
+class SandboxFilesystem(BaseModel):
+    readable: list[str] = Field(default_factory=lambda: ["/workspace", "/memory"])
+    writable: list[str] = Field(default_factory=lambda: ["/workspace"])
+    denied: list[str] = Field(default_factory=lambda: ["/etc", "/proc", "/sys"])
+
+
+class SandboxNetwork(BaseModel):
+    mode: NetworkMode = NetworkMode.ALLOWLIST
+    allow: list[str] = Field(default_factory=list)
+    rate_limit_rpm: int = 600
+
+
+class SandboxSubprocess(BaseModel):
+    mode: SubprocessMode = SubprocessMode.DENYLIST
+    denied: list[str] = Field(default_factory=lambda: ["rm", "dd", "mkfs", "sudo"])
+    timeout_seconds: int = 30
+
+
+class SandboxResources(BaseModel):
+    disk_quota_mb: int = 1024
+    max_processes: int = 64
+    max_open_files: int = 256
+
+
+class SandboxApproval(BaseModel):
+    require_for: list[ApprovalRequire] = Field(default_factory=list)
+    approver: str = ""
+    timeout_seconds: int = 300
+
+
+class Sandbox(BaseModel):
+    filesystem: SandboxFilesystem = Field(default_factory=SandboxFilesystem)
+    network: SandboxNetwork = Field(default_factory=SandboxNetwork)
+    subprocess: SandboxSubprocess = Field(default_factory=SandboxSubprocess)
+    resources: SandboxResources = Field(default_factory=SandboxResources)
+    approval: SandboxApproval = Field(default_factory=SandboxApproval)
+
+
+class State(BaseModel):
+    status: AgentStatus = AgentStatus.STOPPED
+    container_id: str = ""
+    last_deployed_at: str = ""
+    framework_config_hash: str = ""
+    skills_gateway_id: str = ""
+
+    @field_validator("last_deployed_at", mode="before")
+    @classmethod
+    def _coerce_datetime_to_str(cls, v: Any) -> str:
+        """PyYAML parses ISO-8601 timestamps as datetime objects; we want
+        storage as plain strings so git diffs stay clean."""
+        if isinstance(v, datetime):
+            return v.isoformat().replace("+00:00", "Z")
+        return str(v) if v is not None else ""
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Top-level model
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class AgentState(BaseModel):
+    """Framework-agnostic agent definition.  Lives at data/agents/{name}.yaml.
+
+    Immutable fields: ``name`` (primary key).  All other fields are
+    optional and receive sensible defaults matching the design spec.
+    """
+
+    name: str
+    framework: str
+    framework_version: str
+
+    display: Display = Field(default_factory=Display)
+    models: Models = Field(default_factory=Models)
+    memory: Memory = Field(default_factory=Memory)
+    skills: list[str] = Field(default_factory=list)
+    plugins: list[Plugin] = Field(default_factory=list)
+    channels: list[Channel] = Field(default_factory=list)
+    secrets: list[SecretRef] = Field(default_factory=list)
+    resources: Resources = Field(default_factory=Resources)
+    permissions: Permissions = Field(default_factory=Permissions)
+    observability: Observability = Field(default_factory=Observability)
+    schedule: Schedule = Field(default_factory=Schedule)
+    sandbox: Sandbox = Field(default_factory=Sandbox)
+    state: State = Field(default_factory=State)
+
+    model_config = {"extra": "forbid"}
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# YAML I/O
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def load_agent(path: Path) -> AgentState:
+    """Read an AgentState YAML file from disk and return the validated model.
+
+    Args:
+        path: Absolute or relative path to the YAML file.
+
+    Returns:
+        A fully-validated ``AgentState`` instance.
+
+    Raises:
+        FileNotFoundError: The file does not exist.
+        yaml.YAMLError: The file is not valid YAML.
+        pydantic.ValidationError: The YAML matches the structure but one
+            or more fields fail validation.
+    """
+    with open(path, encoding="utf-8") as fh:
+        raw = yaml.safe_load(fh)
+    return AgentState.model_validate(raw)
+
+
+def load_agent_by_name(data_dir: Path, name: str) -> AgentState:
+    """Load an agent by name from the standard location.
+
+    This is a convenience wrapper that computes ``data_dir / "agents" /
+    "{name}.yaml"`` and delegates to :func:`load_agent`.
+    """
+    return load_agent(data_dir / "agents" / f"{name}.yaml")
+
+
+def dump_agent(agent: AgentState, path: Path) -> None:
+    """Serialize an AgentState model to YAML and write it to disk.
+
+    Args:
+        agent: The validated AgentState to write.
+        path: Destination file path (will be overwritten).
+
+    Raises:
+        OSError: The file cannot be written.
+    """
+    raw = agent.model_dump(exclude_unset=False, exclude_defaults=False, mode="json")
+    with open(path, "w", encoding="utf-8") as fh:
+        yaml.dump(raw, fh, default_flow_style=False, allow_unicode=True, sort_keys=False)
+
+
+def dump_agent_to_string(agent: AgentState) -> str:
+    """Serialize to a YAML string (for tests / previews)."""
+    raw = agent.model_dump(exclude_unset=False, exclude_defaults=False, mode="json")
+    return yaml.dump(raw, default_flow_style=False, allow_unicode=True, sort_keys=False)

--- a/tinyagentos/installers/base.py
+++ b/tinyagentos/installers/base.py
@@ -53,9 +53,15 @@ def get_installer(method: str, **kwargs) -> AppInstaller:
     elif method in ("rkllamacpp", "rk-llama.cpp"):
         from tinyagentos.installers.rkllamacpp_installer import RkLlamaCppInstaller
         return RkLlamaCppInstaller(**kwargs)
-    elif method == "ollama":
+    elif method in ("ollama", "ollama_pull"):
         from tinyagentos.installers.ollama_installer import OllamaInstaller
         return OllamaInstaller(**kwargs)
+    elif method == "llama_cpp_download":
+        from tinyagentos.installers.llama_cpp_installer import LlamaCppInstaller
+        return LlamaCppInstaller(**kwargs)
+    elif method == "vllm_download":
+        from tinyagentos.installers.vllm_installer import VllmInstaller
+        return VllmInstaller(**kwargs)
     elif method == "script":
         from tinyagentos.installers.script_installer import ScriptInstaller
         return ScriptInstaller(**kwargs)

--- a/tinyagentos/installers/llama_cpp_installer.py
+++ b/tinyagentos/installers/llama_cpp_installer.py
@@ -1,0 +1,133 @@
+"""llama.cpp installer — downloads GGUF with magic-byte validation.
+
+Unlike the generic DownloadInstaller, this installer validates that the
+downloaded file is a real GGUF by checking the magic bytes (ASCII "GGUF"
+at offset 0).  Corrupt downloads, truncated files, and wrong-format
+responses from CDN caches are caught immediately rather than surfacing
+as an opaque runtime crash when llama-server tries to load the file.
+
+Files land at ``~/models/llama-cpp/<family>/<manifest_id>/<filename>``
+inside the shared model layout so the Models app can discover them from
+one place.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from tinyagentos.installers.base import AppInstaller
+from tinyagentos.installers.download_installer import download_file
+from tinyagentos.installers.model_paths import (
+    backend_model_dir,
+    filename_from_url,
+)
+
+logger = logging.getLogger(__name__)
+
+BACKEND_ID = "llama-cpp"
+
+GGUF_MAGIC = b"GGUF"
+
+
+class LlamaCppInstaller(AppInstaller):
+    """Download GGUF models for serving via llama.cpp / llama-server."""
+
+    def __init__(self, timeout: int = 1800):
+        self.timeout = timeout
+
+    async def install(
+        self,
+        app_id: str,
+        install_config: dict,
+        variant: dict | None = None,
+        **_: Any,
+    ) -> dict:
+        if not variant:
+            return {
+                "success": False,
+                "error": "llama-cpp install requires a variant (with download_url)",
+            }
+        url = variant.get("download_url")
+        if not url:
+            return {
+                "success": False,
+                "error": f"variant {variant.get('id')!r} missing download_url",
+            }
+
+        target_dir = backend_model_dir(BACKEND_ID, app_id)
+        target_dir.mkdir(parents=True, exist_ok=True)
+        fallback = f"{app_id}-{variant.get('id', 'model')}.gguf"
+        filename = filename_from_url(url, fallback)
+        dest = target_dir / filename
+
+        if dest.exists():
+            logger.info("llama-cpp install: %s already present, reusing", dest)
+            try:
+                self._verify_gguf(dest)
+            except ValueError as exc:
+                logger.warning(
+                    "llama-cpp install: cached file %s failed GGUF check: %s — "
+                    "re-downloading",
+                    dest, exc,
+                )
+                dest.unlink()
+            else:
+                return {"success": True, "path": str(dest), "cached": True}
+
+        on_progress = _.get("on_progress")
+
+        try:
+            await download_file(
+                url, dest,
+                expected_sha256=variant.get("sha256"),
+                on_progress=on_progress,
+            )
+        except Exception as exc:  # noqa: BLE001
+            if dest.exists():
+                dest.unlink()
+            return {"success": False, "error": f"download failed: {exc}"}
+
+        # GGUF validation — catch corrupt/misformatted downloads before
+        # the user tries to serve the file.
+        try:
+            self._verify_gguf(dest)
+        except ValueError as exc:
+            dest.unlink()
+            return {
+                "success": False,
+                "error": f"GGUF validation failed: {exc}",
+            }
+
+        return {"success": True, "path": str(dest), "app_id": app_id}
+
+    async def uninstall(self, app_id: str) -> dict:
+        target_dir = backend_model_dir(BACKEND_ID, app_id)
+        deleted: list[str] = []
+        if target_dir.exists():
+            for f in sorted(target_dir.glob("*")):
+                if f.is_file():
+                    f.unlink()
+                    deleted.append(f.name)
+            try:
+                target_dir.rmdir()
+            except OSError:
+                pass
+        return {"success": True, "deleted": deleted, "backend": BACKEND_ID}
+
+    @staticmethod
+    def _verify_gguf(path: Path) -> None:
+        """Raise ValueError if the file isn't a valid GGUF.
+
+        GGUF files start with the four literal ASCII bytes ``GGUF``
+        followed by a 32-bit version field (currently 2 or 3).
+        """
+        try:
+            with open(path, "rb") as fh:
+                magic = fh.read(4)
+        except OSError as exc:
+            raise ValueError(f"cannot read file: {exc}") from exc
+        if magic != GGUF_MAGIC:
+            raise ValueError(
+                f"expected GGUF magic bytes, got {magic!r} ({magic.hex()})"
+            )

--- a/tinyagentos/installers/vllm_installer.py
+++ b/tinyagentos/installers/vllm_installer.py
@@ -1,0 +1,172 @@
+"""vLLM installer — downloads models to the HuggingFace cache.
+
+vLLM loads models directly from the HF cache (~/.cache/huggingface/hub/)
+via ``vllm serve <model>``, which triggers ``snapshot_download`` under
+the hood.  Pre-downloading into the cache via this installer means the
+first serve call starts immediately instead of blocking on a multi-GB
+download.
+
+When ``huggingface_hub`` is not installed, we install it first via pip
+so the snapshot download can proceed.  A missing ``huggingface_hub`` is
+the most common reason a fresh controller can't talk to HF.
+"""
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from tinyagentos.installers.base import AppInstaller
+
+logger = logging.getLogger(__name__)
+
+BACKEND_ID = "vllm"
+
+
+def _try_import_snapshot_download() -> Any | None:
+    """Return ``snapshot_download`` callable, or None if not available."""
+    try:
+        from huggingface_hub import snapshot_download
+        return snapshot_download
+    except ImportError:
+        return None
+
+
+async def _ensure_huggingface_hub() -> str:
+    """Install huggingface_hub via pip if not already present.
+
+    Returns the pip output on success; raises RuntimeError on failure.
+    """
+    import asyncio
+
+    proc = await asyncio.create_subprocess_exec(
+        "pip", "install", "huggingface_hub[hf_transfer]",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+    stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=300)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"pip install huggingface_hub failed: {(stdout or b'').decode()[:500]}"
+        )
+    return (stdout or b"").decode()
+
+
+class VllmInstaller(AppInstaller):
+    """Download HF repos to the local HF cache for vLLM serving."""
+
+    def __init__(self, cache_dir: str | None = None):
+        # cache_dir defaults to ~/.cache/huggingface/hub/ (the HF default).
+        # Callers can override for tests or custom cache locations.
+        self.cache_dir = cache_dir
+
+    async def install(
+        self,
+        app_id: str,
+        install_config: dict,
+        variant: dict | None = None,
+        **_: Any,
+    ) -> dict:
+        if not variant:
+            return {
+                "success": False,
+                "error": "vllm install requires a variant (with hf_repo)",
+            }
+
+        repo = variant.get("hf_repo") or variant.get("download_url")
+        if not repo:
+            return {
+                "success": False,
+                "error": (
+                    f"variant {variant.get('id')!r} missing hf_repo "
+                    "(vLLM models are HF repos)"
+                ),
+            }
+        # Normalise repo — strip https://huggingface.co/ prefix if present.
+        if repo.startswith("https://huggingface.co/"):
+            repo = repo[len("https://huggingface.co/"):]
+        elif repo.startswith("http://"):
+            repo = repo[len("http://"):]
+
+        revision = variant.get("hf_revision") or "main"
+
+        sd = _try_import_snapshot_download()
+        if sd is None:
+            try:
+                await _ensure_huggingface_hub()
+            except RuntimeError as exc:
+                return {"success": False, "error": str(exc)}
+            sd = _try_import_snapshot_download()
+            if sd is None:
+                return {
+                    "success": False,
+                    "error": (
+                        "huggingface_hub still not importable after pip install — "
+                        "check the controller's Python environment"
+                    ),
+                }
+
+        # snapshot_download is synchronous (I/O bound), so run it in a
+        # thread to avoid blocking the event loop.
+        import asyncio
+
+        loop = asyncio.get_running_loop()
+        kwargs: dict = {
+            "repo_id": repo,
+            "revision": revision,
+        }
+        if self.cache_dir:
+            kwargs["cache_dir"] = self.cache_dir
+
+        try:
+            local_path = await loop.run_in_executor(None, lambda: sd(**kwargs))
+        except Exception as exc:  # noqa: BLE001
+            return {
+                "success": False,
+                "error": f"snapshot_download failed for {repo!r}: {exc}",
+            }
+
+        return {
+            "success": True,
+            "app_id": app_id,
+            "repo": repo,
+            "revision": revision,
+            "local_path": str(local_path),
+            "backend": BACKEND_ID,
+        }
+
+    async def uninstall(self, app_id: str) -> dict:
+        """Best-effort removal from the HF cache.
+
+        The HF cache is a shared content-addressed store — removing one
+        model doesn't break others that share blobs. We scan the cache's
+        refs for the model name and remove the symlink directory.
+        """
+        import shutil
+
+        cache = Path(self.cache_dir) if self.cache_dir else Path.home() / ".cache" / "huggingface" / "hub"
+        if not cache.exists():
+            return {"success": True, "deleted": [], "backend": BACKEND_ID}
+
+        deleted: list[str] = []
+        # HF hub stores models under models--<org>--<name>
+        safe_name = app_id.replace("/", "--")
+        for models_dir in [
+            cache / "models" / safe_name,
+            cache / f"models--{safe_name}",
+        ]:
+            if models_dir.exists():
+                try:
+                    shutil.rmtree(str(models_dir))
+                    deleted.append(str(models_dir))
+                except OSError as exc:
+                    logger.warning(
+                        "vllm uninstall: could not remove %s: %s", models_dir, exc
+                    )
+
+        return {
+            "success": True,
+            "deleted": deleted,
+            "backend": BACKEND_ID,
+        }

--- a/tinyagentos/knowledge_monitor.py
+++ b/tinyagentos/knowledge_monitor.py
@@ -4,6 +4,7 @@ import asyncio
 import hashlib
 import logging
 import time
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -183,3 +184,109 @@ class MonitorService:
         except Exception as exc:
             logger.warning("Article re-fetch failed for %s: %s", item["source_url"], exc)
             return "", False
+
+
+# ---------------------------------------------------------------------------
+# Agent doc & per-app guide ingestion
+# ---------------------------------------------------------------------------
+
+async def ingest_agent_docs(
+    docs_dir: Path,
+    store: "KnowledgeStore",
+    source_id: str = "core",
+) -> int:
+    """Walk *docs_dir* for ``.md`` files and ingest them into the knowledge store.
+
+    Each file becomes a ``KnowledgeItem`` with ``source_type="agent_doc"`` and
+    the given *source_id*.  Files that are already present (matched by
+    ``source_url`` + ``source_id``) are skipped.  Returns the number of files
+    that were actually ingested.
+    """
+    if not docs_dir.is_dir():
+        return 0
+
+    # Build a set of already-present source_urls for this source_id so we can
+    # skip re-ingestion.
+    existing = await store.list_by_source_id(source_id)
+    existing_urls = {item["source_url"] for item in existing}
+
+    ingested = 0
+    for md_file in sorted(docs_dir.rglob("*.md")):
+        rel = str(md_file.relative_to(docs_dir))
+        if rel in existing_urls:
+            continue
+        try:
+            content = md_file.read_text(encoding="utf-8")
+        except Exception:
+            logger.warning("Could not read %s", md_file)
+            continue
+        if not content.strip():
+            continue
+
+        title = md_file.stem
+        await store.add_item(
+            source_type="agent_doc",
+            source_url=rel,
+            source_id=source_id,
+            title=title,
+            author="",
+            content=content,
+            summary="",
+            categories=[],
+            tags=[],
+            metadata={},
+            status="ready",
+        )
+        ingested += 1
+
+    return ingested
+
+
+async def ingest_app_guides(
+    app_id: str,
+    manifest_dir: Path,
+    store: "KnowledgeStore",
+) -> int:
+    """Ingest the ``guides/`` directory of a single app (if present).
+
+    Returns the number of files ingested (0 if no guides directory exists).
+    """
+    guides_dir = manifest_dir / "guides"
+    return await ingest_agent_docs(
+        docs_dir=guides_dir,
+        store=store,
+        source_id=f"app:{app_id}",
+    )
+
+
+async def ingest_installed_app_guides(
+    installed_apps_store,
+    registry,
+    store: "KnowledgeStore",
+) -> dict[str, int]:
+    """Iterate every installed app and ingest its ``guides/`` directory.
+
+    Returns a dict mapping ``app_id`` → number of files ingested.
+    """
+    installed = await installed_apps_store.list_installed()
+    result: dict[str, int] = {}
+    for entry in installed:
+        app_id = entry["app_id"]
+        manifest = registry.get(app_id)
+        if manifest is None or manifest.manifest_dir is None:
+            continue
+        ingested = await ingest_app_guides(app_id, manifest.manifest_dir, store)
+        if ingested:
+            result[app_id] = ingested
+    return result
+
+
+async def wipe_app_guides(
+    store: "KnowledgeStore",
+    app_id: str,
+) -> int:
+    """Remove every knowledge item scoped to *app_id*'s guides.
+
+    Returns the number of items deleted.
+    """
+    return await store.delete_by_source_id(f"app:{app_id}")

--- a/tinyagentos/knowledge_store.py
+++ b/tinyagentos/knowledge_store.py
@@ -238,6 +238,40 @@ class KnowledgeStore(BaseStore):
         await self._db.commit()
         return cursor.rowcount > 0
 
+    async def list_by_source_id(self, source_id: str) -> list[dict]:
+        """List all items with a given source_id, newest first."""
+        assert self._db is not None
+        cursor = await self._db.execute(
+            """SELECT id, source_type, source_url, source_id, title, author, summary,
+                      content, media_path, thumbnail, categories, tags, metadata,
+                      status, monitor, created_at, updated_at
+               FROM knowledge_items WHERE source_id = ?
+               ORDER BY created_at DESC""",
+            (source_id,),
+        )
+        rows = await cursor.fetchall()
+        return [_row_to_item(r) for r in rows]
+
+    async def delete_by_source_id(self, source_id: str) -> int:
+        """Delete all items with a given source_id. Returns count of deleted rows."""
+        assert self._db is not None
+        # Get IDs first to clean up FTS
+        cursor = await self._db.execute(
+            "SELECT id FROM knowledge_items WHERE source_id = ?",
+            (source_id,),
+        )
+        ids = [row[0] for row in (await cursor.fetchall())]
+        if not ids:
+            return 0
+        for item_id in ids:
+            await self._db.execute("DELETE FROM knowledge_fts WHERE id = ?", (item_id,))
+        cursor = await self._db.execute(
+            "DELETE FROM knowledge_items WHERE source_id = ?",
+            (source_id,),
+        )
+        await self._db.commit()
+        return len(ids)
+
     # ------------------------------------------------------------------
     # FTS search
     # ------------------------------------------------------------------

--- a/tinyagentos/routes/activity.py
+++ b/tinyagentos/routes/activity.py
@@ -1,116 +1,560 @@
+"""Model Activity feed — live inference events stream.
+
+Provides:
+- Ring buffer (last 500 events) shared across all connected clients
+- SSE endpoint: GET /api/activity/stream — pushes new events
+- Publish endpoint: POST /api/activity/events — other components publish
+- HTML page: GET /api/activity — timeline UI with Pico CSS + htmx SSE
+
+Events are also injectable via the module-level ``publish_event()`` function
+so scheduler hooks and proxy hooks can feed the buffer without HTTP overhead.
+"""
+
 from __future__ import annotations
 
+import asyncio
+import collections
+import json
+import logging
 import time
-from dataclasses import asdict
+from typing import Optional
 
-from fastapi import APIRouter, Request
-from fastapi.responses import JSONResponse
+from fastapi import APIRouter, Query, Request
+from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
+# ---------------------------------------------------------------------------
+# Activity buffer — shared ring buffer + SSE fan-out
+# ---------------------------------------------------------------------------
 
-@router.get("/api/activity")
-async def activity(request: Request):
-    """Rich system activity: CPU cores, NPU cores, thermals, GPU, disk, net, procs."""
-    import psutil
+HISTORY_MAX = 500
+VALID_EVENT_TYPES = frozenset({
+    "model_load", "model_unload", "model_eviction",
+    "route_change", "request_start", "request_finish",
+})
 
-    from tinyagentos.system_stats import (
-        get_cpu_per_core,
-        get_disk_io_rate,
-        get_gpu_load,
-        get_network_rates,
-        get_npu_frequency,
-        get_npu_per_core,
-        get_thermal_zones,
-        get_top_processes,
-        get_vram_usage,
-        get_zram_stats,
+
+class ActivityBuffer:
+    """Ring buffer of inference events with SSE fan-out to connected clients."""
+
+    def __init__(self, maxlen: int = HISTORY_MAX):
+        self._buffer: collections.deque[dict] = collections.deque(maxlen=maxlen)
+        self._subscribers: set[asyncio.Queue] = set()
+        self._lock = asyncio.Lock()
+
+    def publish(self, event: dict) -> None:
+        """Push an event to the buffer and fan-out to all subscribers.
+
+        ``event`` must have at least ``type`` and ``timestamp`` keys.
+        Missing keys are filled with sensible defaults.
+        """
+        event.setdefault("timestamp", time.time())
+        event.setdefault("model_id", "")
+        event.setdefault("worker", "")
+        event.setdefault("duration_ms", 0)
+        event.setdefault("tokens_per_sec", 0.0)
+
+        event_type = event.get("type", "")
+        if event_type not in VALID_EVENT_TYPES:
+            logger.warning("activity: dropping event with unknown type %r", event_type)
+            return
+
+        self._buffer.append(event)
+        # Fan-out — fire-and-forget; slow clients are dropped naturally
+        dead: set[asyncio.Queue] = set()
+        for q in self._subscribers:
+            try:
+                q.put_nowait(event)
+            except asyncio.QueueFull:
+                dead.add(q)
+        self._subscribers.difference_update(dead)
+
+    async def subscribe(self) -> asyncio.Queue:
+        """Register a new SSE subscriber. Returns a queue that receives events."""
+        q: asyncio.Queue = asyncio.Queue(maxsize=256)
+        async with self._lock:
+            self._subscribers.add(q)
+        return q
+
+    async def unsubscribe(self, q: asyncio.Queue) -> None:
+        """Remove a subscriber queue."""
+        async with self._lock:
+            self._subscribers.discard(q)
+
+    def snapshot(self) -> list[dict]:
+        """Return a copy of the current buffer, newest first."""
+        return list(reversed(self._buffer))
+
+
+# Module-level singleton — populated at startup via app.state
+_buffer: Optional[ActivityBuffer] = None
+
+
+def get_buffer(request: Request) -> ActivityBuffer:
+    """Return the activity buffer from app state (lazy init for test compat)."""
+    global _buffer
+    if _buffer is not None:
+        return _buffer
+    buf = getattr(request.app.state, "activity_buffer", None)
+    if buf is None:
+        buf = ActivityBuffer()
+        request.app.state.activity_buffer = buf
+        _buffer = buf
+    return buf
+
+
+def publish_event(event: dict) -> None:
+    """Publish an activity event from anywhere in the codebase.
+
+    Safe to call before the buffer is initialised (events are dropped silently).
+    """
+    if _buffer is not None:
+        _buffer.publish(event)
+
+
+# ---------------------------------------------------------------------------
+# SSE endpoint
+# ---------------------------------------------------------------------------
+
+
+def _matches_filter(event: dict, worker: str, model: str, event_type: str) -> bool:
+    if worker and event.get("worker", "") != worker:
+        return False
+    if model and event.get("model_id", "") != model:
+        return False
+    if event_type and event.get("type", "") != event_type:
+        return False
+    return True
+
+
+@router.get("/api/activity/stream")
+async def activity_stream(
+    request: Request,
+    worker: str = Query(""),
+    model: str = Query(""),
+    type: str = Query(""),
+):
+    """SSE stream of inference activity events.
+
+    Query params act as filters: ?worker=X&model=Y&type=Z.
+    Leaving a filter empty means no filtering on that dimension.
+    """
+    buf = get_buffer(request)
+
+    async def event_generator():
+        q = await buf.subscribe()
+        try:
+            # Replay existing history first so a freshly-opened tab
+            # shows recent events immediately.
+            for event in buf.snapshot():
+                if _matches_filter(event, worker, model, type):
+                    yield f"data: {json.dumps(event)}\n\n"
+
+            # Stream new events
+            while True:
+                if await request.is_disconnected():
+                    break
+                try:
+                    event = await asyncio.wait_for(q.get(), timeout=15.0)
+                except asyncio.TimeoutError:
+                    # Keep-alive comment — prevents proxies from closing the connection
+                    yield ": keepalive\n\n"
+                    continue
+
+                if _matches_filter(event, worker, model, type):
+                    yield f"data: {json.dumps(event)}\n\n"
+        finally:
+            await buf.unsubscribe(q)
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
     )
 
-    hw = request.app.state.hardware_profile
+
+# ---------------------------------------------------------------------------
+# Publish endpoint — for external event sources
+# ---------------------------------------------------------------------------
+
+
+@router.post("/api/activity/events")
+async def publish_activity_event(request: Request):
+    """Accept an activity event from another component.
+
+    Request body must be JSON with at least a ``type`` key.
+    """
     try:
-        hw_data = asdict(hw)
-    except TypeError:
-        hw_data = {}
+        body = await request.json()
+    except Exception:
+        return JSONResponse({"error": "invalid JSON body"}, status_code=400)
 
-    mem = psutil.virtual_memory()
-    swap = psutil.swap_memory()
+    event_type = body.get("type", "")
+    if not event_type:
+        return JSONResponse({"error": "missing 'type' field"}, status_code=400)
+    if event_type not in VALID_EVENT_TYPES:
+        return JSONResponse(
+            {"error": f"unknown event type {event_type!r}"}, status_code=400,
+        )
 
-    gpu_type = getattr(getattr(hw, "gpu", None), "type", None) or ""
-    vram_pct, vram_used_mb, vram_total_mb = get_vram_usage(gpu_type)
+    buf = get_buffer(request)
+    buf.publish(body)
+    return JSONResponse({"ok": True})
 
-    try:
-        load_avg = list(psutil.getloadavg()) if hasattr(psutil, "getloadavg") else None
-    except OSError:
-        load_avg = None
 
-    try:
-        du = psutil.disk_usage("/")
-        disk_info = {
-            "io_rate": get_disk_io_rate(),
-            "usage_percent": du.percent,
-            "total_gb": du.total // (1024 ** 3),
-            "used_gb": du.used // (1024 ** 3),
-        }
-    except OSError:
-        disk_info = {
-            "io_rate": get_disk_io_rate(),
-            "usage_percent": 0,
-            "total_gb": 0,
-            "used_gb": 0,
-        }
+# ---------------------------------------------------------------------------
+# History endpoint
+# ---------------------------------------------------------------------------
 
-    cpu_block = hw_data.get("cpu") if isinstance(hw_data, dict) else None
-    gpu_block = hw_data.get("gpu") if isinstance(hw_data, dict) else None
-    npu_block = hw_data.get("npu") if isinstance(hw_data, dict) else None
 
-    board = None
-    if isinstance(cpu_block, dict):
-        board = cpu_block.get("soc") or cpu_block.get("model")
+@router.get("/api/activity/history")
+async def activity_history(
+    request: Request,
+    limit: int = Query(100, ge=1, le=HISTORY_MAX),
+    worker: str = Query(""),
+    model: str = Query(""),
+    type: str = Query(""),
+):
+    """Return recent activity events as JSON (polling fallback)."""
+    buf = get_buffer(request)
+    events = buf.snapshot()
+    filtered = [
+        e for e in events
+        if _matches_filter(e, worker, model, type)
+    ][:limit]
+    return JSONResponse({"events": filtered})
 
-    npu_type = npu_block.get("type") if isinstance(npu_block, dict) else None
-    npu_tops = npu_block.get("tops") if isinstance(npu_block, dict) else None
-    gpu_name = gpu_block.get("type") if isinstance(gpu_block, dict) else None
 
-    return JSONResponse({
-        "timestamp": time.time(),
-        "hardware": {
-            "board": board,
-            "cpu": cpu_block,
-            "gpu": gpu_block,
-            "npu": npu_block,
-            "ram_mb": hw_data.get("ram_mb") if isinstance(hw_data, dict) else None,
-        },
-        "cpu": {
-            "cores": get_cpu_per_core(),
-            "load_avg": load_avg,
-            "overall_percent": psutil.cpu_percent(),
-        },
-        "memory": {
-            "total_mb": mem.total // (1024 * 1024),
-            "used_mb": mem.used // (1024 * 1024),
-            "available_mb": mem.available // (1024 * 1024),
-            "percent": mem.percent,
-            "swap_total_mb": swap.total // (1024 * 1024),
-            "swap_used_mb": swap.used // (1024 * 1024),
-            "swap_percent": swap.percent,
-        },
-        "npu": {
-            "cores": get_npu_per_core(),
-            "freq_hz": get_npu_frequency(),
-            "type": npu_type,
-            "tops": npu_tops,
-        },
-        "gpu": {
-            "load": get_gpu_load(),
-            "vram_percent": vram_pct,
-            "vram_used_mb": vram_used_mb,
-            "vram_total_mb": vram_total_mb,
-            "type": gpu_name,
-        },
-        "thermal": get_thermal_zones(),
-        "zram": get_zram_stats(),
-        "disk": disk_info,
-        "network": get_network_rates(),
-        "processes": get_top_processes(limit=10),
-    })
+# ---------------------------------------------------------------------------
+# HTML page
+# ---------------------------------------------------------------------------
+
+_ACTIVITY_FEED_HTML = r"""<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Model Activity — TinyAgentOS</title>
+<link rel="stylesheet" href="/static/pico.min.css">
+<style>
+:root {
+  --timeline-dot-size: 10px;
+  --timeline-line-color: var(--pico-muted-border-color, #374956);
+}
+body { padding: 1.5rem; }
+.activity-header {
+  display: flex; flex-wrap: wrap; gap: 0.75rem; align-items: flex-end;
+  margin-bottom: 1.5rem; padding-bottom: 1rem;
+  border-bottom: 1px solid var(--pico-muted-border-color);
+}
+.activity-header h1 { margin: 0; font-size: 1.5rem; flex: 1 1 auto; }
+.filter-bar { display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center; }
+.filter-bar select, .filter-bar button {
+  margin-bottom: 0; font-size: 0.875rem;
+}
+.status-bar {
+  display: flex; gap: 1rem; align-items: center; font-size: 0.8rem;
+  color: var(--pico-muted-color); margin-bottom: 0.5rem;
+}
+.status-dot {
+  width: 8px; height: 8px; border-radius: 50%; display: inline-block;
+}
+.status-dot.live { background: var(--pico-color-green-400, #4caf50); }
+.status-dot.stale { background: var(--pico-color-red-400, #f44336); }
+.timeline { position: relative; padding-left: 2rem; }
+.timeline::before {
+  content: ''; position: absolute; left: 14px; top: 0; bottom: 0;
+  width: 2px; background: var(--timeline-line-color);
+}
+.timeline-item {
+  position: relative; padding: 0.5rem 0 0.5rem 1.5rem;
+  border-bottom: 1px solid var(--pico-muted-border-color, #2a3140);
+}
+.timeline-item:last-child { border-bottom: none; }
+.timeline-dot {
+  position: absolute; left: -1.55rem; top: 0.85rem;
+  width: var(--timeline-dot-size); height: var(--timeline-dot-size);
+  border-radius: 50%; border: 2px solid var(--pico-muted-border-color);
+  background: var(--pico-background-color);
+}
+.timeline-dot.load  { border-color: var(--pico-color-blue-400, #42a5f5);  background: var(--pico-color-blue-400, #42a5f5); }
+.timeline-dot.unload{ border-color: var(--pico-color-orange-400, #ff9800); background: var(--pico-color-orange-400, #ff9800); }
+.timeline-dot.evict { border-color: var(--pico-color-red-400, #ef5350);    background: var(--pico-color-red-400, #ef5350); }
+.timeline-dot.route { border-color: var(--pico-color-purple-400, #ab47bc); background: var(--pico-color-purple-400, #ab47bc); }
+.timeline-dot.start { border-color: var(--pico-color-green-400, #66bb6a);  background: var(--pico-color-green-400, #66bb6a); }
+.timeline-dot.finish{ border-color: var(--pico-color-teal-400, #26a69a);   background: var(--pico-color-teal-400, #26a69a); }
+.event-label {
+  font-size: 0.7rem; font-weight: 700; text-transform: uppercase;
+  letter-spacing: 0.05em; display: inline-block; padding: 0.1rem 0.4rem;
+  border-radius: 3px; margin-right: 0.5rem;
+}
+.event-label.load   { color: var(--pico-color-blue-300, #90caf9);   background: rgb(66 165 245 / 0.15); }
+.event-label.unload { color: var(--pico-color-orange-300, #ffcc80);  background: rgb(255 152 0 / 0.15); }
+.event-label.evict  { color: var(--pico-color-red-300, #ef9a9a);    background: rgb(239 83 80 / 0.15); }
+.event-label.route  { color: var(--pico-color-purple-300, #ce93d8); background: rgb(171 71 188 / 0.15); }
+.event-label.start  { color: var(--pico-color-green-300, #a5d6a7);  background: rgb(102 187 106 / 0.15); }
+.event-label.finish { color: var(--pico-color-teal-300, #80cbc4);   background: rgb(38 166 154 / 0.15); }
+.event-meta { font-size: 0.8rem; color: var(--pico-muted-color); margin-top: 0.15rem; }
+.event-meta span { margin-right: 1rem; }
+.event-model { font-weight: 600; color: var(--pico-color); }
+#timeline-container { min-height: 200px; }
+.empty-state {
+  text-align: center; padding: 3rem 1rem; color: var(--pico-muted-color);
+}
+.empty-state svg { width: 48px; height: 48px; margin-bottom: 1rem; opacity: 0.4; }
+</style>
+</head>
+<body>
+
+<div class="activity-header">
+  <h1>&#9889; Model Activity</h1>
+  <div class="filter-bar">
+    <select id="filter-type" aria-label="Filter by event type">
+      <option value="">All types</option>
+      <option value="model_load">Model Load</option>
+      <option value="model_unload">Model Unload</option>
+      <option value="model_eviction">Model Eviction</option>
+      <option value="route_change">Route Change</option>
+      <option value="request_start">Request Start</option>
+      <option value="request_finish">Request Finish</option>
+    </select>
+    <select id="filter-worker" aria-label="Filter by worker">
+      <option value="">All workers</option>
+    </select>
+    <select id="filter-model" aria-label="Filter by model">
+      <option value="">All models</option>
+    </select>
+    <button id="btn-clear" class="outline secondary" aria-label="Clear all filters">Clear</button>
+  </div>
+</div>
+
+<div class="status-bar">
+  <span class="status-dot live" id="status-dot" aria-hidden="true"></span>
+  <span id="status-text">Connected</span>
+  <span id="event-count" style="margin-left:auto">0 events</span>
+</div>
+
+<div id="timeline-container" role="log" aria-live="polite" aria-label="Activity timeline">
+  <div class="empty-state">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+      <circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>
+    </svg>
+    <p>Waiting for events&hellip;</p>
+  </div>
+</div>
+
+<script>
+// ---- State ----
+let events = [];
+let eventCount = 0;
+const MAX_VISIBLE = 200;
+let filterType = "";
+let filterWorker = "";
+let filterModel = "";
+let workerSet = new Set();
+let modelSet = new Set();
+let lastEventTime = 0;
+let staleTimer = null;
+
+// ---- DOM refs ----
+const container = document.getElementById("timeline-container");
+const statusDot = document.getElementById("status-dot");
+const statusText = document.getElementById("status-text");
+const eventCountEl = document.getElementById("event-count");
+const filterTypeEl = document.getElementById("filter-type");
+const filterWorkerEl = document.getElementById("filter-worker");
+const filterModelEl = document.getElementById("filter-model");
+
+// ---- SVG icons ----
+const ICONS = {
+  model_load:    '<circle cx="12" cy="12" r="10"/><polyline points="8 12 12 8 16 12"/><line x1="12" y1="8" x2="12" y2="16"/>',
+  model_unload:  '<circle cx="12" cy="12" r="10"/><polyline points="8 12 12 16 16 12"/><line x1="12" y1="16" x2="12" y2="8"/>',
+  model_eviction:'<circle cx="12" cy="12" r="10"/><line x1="8" y1="8" x2="16" y2="16"/><line x1="16" y1="8" x2="8" y2="16"/>',
+  route_change:  '<circle cx="12" cy="12" r="10"/><path d="M8 12a4 4 0 0 1 4-4v0a4 4 0 0 1 4 4h-8z"/><line x1="12" y1="8" x2="12" y2="6"/><line x1="12" y1="16" x2="12" y2="18"/><line x1="8" y1="12" x2="6" y2="12"/><line x1="16" y1="12" x2="18" y2="12"/>',
+  request_start: '<circle cx="12" cy="12" r="10"/><polygon points="10 8 16 12 10 16 10 8"/>',
+  request_finish:'<circle cx="12" cy="12" r="10"/><polyline points="9 12 11 14 15 10"/>',
+};
+
+function iconSvg(type) {
+  const path = ICONS[type] || ICONS.model_load;
+  return '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;margin-right:0.3rem;opacity:0.8">' + path + '</svg>';
+}
+
+function dotClass(type) {
+  const map = {model_load:'load',model_unload:'unload',model_eviction:'evict',route_change:'route',request_start:'start',request_finish:'finish'};
+  return map[type] || 'load';
+}
+
+function labelClass(type) {
+  return dotClass(type);
+}
+
+function labelText(type) {
+  const map = {model_load:'Load',model_unload:'Unload',model_eviction:'Evict',route_change:'Route',request_start:'Start',request_finish:'Finish'};
+  return map[type] || type;
+}
+
+function formatTime(ts) {
+  const d = new Date(ts * 1000);
+  return d.toLocaleTimeString();
+}
+
+function formatDuration(ms) {
+  if (!ms || ms <= 0) return "";
+  if (ms < 1000) return ms + "ms";
+  return (ms / 1000).toFixed(1) + "s";
+}
+
+// ---- Filtering ----
+function matchesFilter(ev) {
+  if (filterType && ev.type !== filterType) return false;
+  if (filterWorker && ev.worker !== filterWorker) return false;
+  if (filterModel && ev.model_id !== filterModel) return false;
+  return true;
+}
+
+function updateDropdowns(ev) {
+  if (ev.worker && !workerSet.has(ev.worker)) {
+    workerSet.add(ev.worker);
+    const opt = document.createElement("option");
+    opt.value = ev.worker;
+    opt.textContent = ev.worker;
+    filterWorkerEl.appendChild(opt);
+  }
+  if (ev.model_id && !modelSet.has(ev.model_id)) {
+    modelSet.add(ev.model_id);
+    const opt = document.createElement("option");
+    opt.value = ev.model_id;
+    opt.textContent = ev.model_id;
+    filterModelEl.appendChild(opt);
+  }
+}
+
+function applyFilters() {
+  filterType = filterTypeEl.value;
+  filterWorker = filterWorkerEl.value;
+  filterModel = filterModelEl.value;
+  renderAll();
+}
+
+filterTypeEl.addEventListener("change", applyFilters);
+filterWorkerEl.addEventListener("change", applyFilters);
+filterModelEl.addEventListener("change", applyFilters);
+document.getElementById("btn-clear").addEventListener("click", () => {
+  filterTypeEl.value = "";
+  filterWorkerEl.value = "";
+  filterModelEl.value = "";
+  applyFilters();
+});
+
+// ---- Rendering ----
+function renderEvent(ev) {
+  const icon = iconSvg(ev.type);
+  const dot = dotClass(ev.type);
+  const lblCls = labelClass(ev.type);
+  const lblTxt = labelText(ev.type);
+  let meta = [];
+  if (ev.worker) meta.push('<span aria-label="Worker">&#128421; ' + escHtml(ev.worker) + '</span>');
+  if (ev.model_id) meta.push('<span class="event-model" aria-label="Model">' + escHtml(ev.model_id) + '</span>');
+  if (ev.duration_ms) meta.push('<span aria-label="Duration">&#9202; ' + formatDuration(ev.duration_ms) + '</span>');
+  if (ev.tokens_per_sec > 0) meta.push('<span aria-label="Speed">' + ev.tokens_per_sec.toFixed(0) + ' tok/s</span>');
+  meta.push('<span aria-label="Time">' + formatTime(ev.timestamp) + '</span>');
+  return (
+    '<div class="timeline-item" role="listitem">' +
+    '<div class="timeline-dot ' + dot + '" aria-hidden="true"></div>' +
+    '<span class="event-label ' + lblCls + '">' + icon + ' ' + lblTxt + '</span>' +
+    '<div class="event-meta">' + meta.join('') + '</div>' +
+    '</div>'
+  );
+}
+
+function escHtml(s) {
+  const div = document.createElement("div");
+  div.textContent = s;
+  return div.innerHTML;
+}
+
+function renderAll() {
+  const filtered = events.filter(matchesFilter);
+  const visible = filtered.slice(0, MAX_VISIBLE);
+  if (visible.length === 0) {
+    container.innerHTML = '<div class="empty-state"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg><p>No matching events</p></div>';
+  } else {
+    container.innerHTML = '<div class="timeline" role="list">' + visible.map(renderEvent).join('') + '</div>';
+  }
+  eventCountEl.textContent = eventCount + ' event' + (eventCount !== 1 ? 's' : '');
+}
+
+function addEvent(ev) {
+  events.unshift(ev);
+  eventCount++;
+  updateDropdowns(ev);
+  if (matchesFilter(ev)) {
+    renderAll();
+  }
+  lastEventTime = Date.now();
+  setConnected(true);
+}
+
+// ---- Connection health ----
+function setConnected(live) {
+  if (live) {
+    statusDot.className = "status-dot live";
+    statusText.textContent = "Connected";
+    if (staleTimer) { clearTimeout(staleTimer); staleTimer = null; }
+    staleTimer = setTimeout(() => setConnected(false), 30_000);
+  } else {
+    statusDot.className = "status-dot stale";
+    statusText.textContent = "Disconnected — retrying\u2026";
+  }
+}
+
+// ---- SSE connection ----
+function buildStreamUrl() {
+  const params = new URLSearchParams();
+  if (filterType) params.set("type", filterType);
+  if (filterWorker) params.set("worker", filterWorker);
+  if (filterModel) params.set("model", filterModel);
+  const qs = params.toString();
+  return "/api/activity/stream" + (qs ? "?" + qs : "");
+}
+
+function connectSSE() {
+  const url = buildStreamUrl();
+  const es = new EventSource(url);
+  es.onmessage = (e) => {
+    try {
+      const ev = JSON.parse(e.data);
+      addEvent(ev);
+    } catch (err) {
+      console.warn("activity: failed to parse event", err);
+    }
+  };
+  es.onerror = () => {
+    setConnected(false);
+    es.close();
+    // Reconnect after back-off
+    setTimeout(connectSSE, 3_000);
+  };
+}
+
+// ---- Init ----
+connectSSE();
+</script>
+</body>
+</html>"""
+
+
+@router.get("/api/activity", response_class=HTMLResponse)
+async def activity_page(request: Request):
+    """Serve the Activity Feed UI page."""
+    # Ensure buffer is initialised
+    get_buffer(request)
+    return HTMLResponse(_ACTIVITY_FEED_HTML)

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -47,6 +47,62 @@ class AgentUpdate(BaseModel):
     can_read_user_memory: bool | None = None
 
 
+class IdempotencyCache:
+    """In-flight request deduplication cache keyed by Idempotency-Key.
+
+    ``try_reserve(key)`` returns ``("proceed", event)`` when this caller
+    should do the work, or ``("wait", event)`` when another caller is
+    already handling this key — the caller should ``await event.wait()``
+    and then call ``get(key)`` for the cached result.
+
+    ``set(key, result)`` stores the result and fires the event so all
+    waiters can proceed.
+
+    This closes the race in the naive get-then-set pattern where
+    ``cache.get()`` releases the lock before the write, letting a
+    concurrent retry with the same Idempotency-Key create a duplicate.
+    """
+
+    def __init__(self) -> None:
+        self._entries: dict[str, tuple[asyncio.Event, dict | None]] = {}
+
+    def try_reserve(self, key: str) -> tuple[str, asyncio.Event]:
+        """Attempt to reserve *key*.
+
+        Returns ``("proceed", event)`` when this caller owns the key
+        and should perform the work.
+
+        Returns ``("wait", event)`` when another caller already reserved
+        the key — await ``event.wait()`` and call ``get()`` for the
+        result.
+        """
+        if key in self._entries:
+            event, _ = self._entries[key]
+            return ("wait", event)
+
+        event = asyncio.Event()
+        self._entries[key] = (event, None)
+        return ("proceed", event)
+
+    def set(self, key: str, result: dict) -> None:
+        """Store *result* and wake all waiters on *key*."""
+        entry = self._entries.get(key)
+        if entry is None:
+            self._entries[key] = (asyncio.Event(), result)
+            return
+        event, _ = entry
+        self._entries[key] = (event, result)
+        event.set()
+
+    def get(self, key: str) -> dict | None:
+        """Return the cached result for *key*, or ``None``."""
+        entry = self._entries.get(key)
+        if entry is None:
+            return None
+        _, result = entry
+        return result
+
+
 @router.get("/api/agents")
 async def list_agents(request: Request):
     """List all configured agents."""
@@ -106,6 +162,15 @@ async def add_agent(request: Request, body: AgentCreate):
     If the slug collides with an existing agent, a numeric suffix is
     appended until it's unique.
     """
+    # --- Idempotency guard ---
+    idempotency_cache = getattr(request.app.state, "idempotency_cache", None)
+    idempotency_key = request.headers.get("Idempotency-Key")
+    if idempotency_key and idempotency_cache is not None:
+        mode, event = idempotency_cache.try_reserve(idempotency_key)
+        if mode == "wait":
+            await event.wait()
+            return idempotency_cache.get(idempotency_key)
+
     config = request.app.state.config
     display_name = body.name.strip()
     name_error = validate_agent_name(display_name)
@@ -126,7 +191,12 @@ async def add_agent(request: Request, body: AgentCreate):
     agent["display_name"] = display_name
     config.agents.append(agent)
     await save_config_locked(config, config.config_path)
-    return {"status": "created", "name": unique_slug, "display_name": display_name}
+    result = {"status": "created", "name": unique_slug, "display_name": display_name}
+
+    if idempotency_key and idempotency_cache is not None:
+        idempotency_cache.set(idempotency_key, result)
+
+    return result
 
 
 @router.put("/api/agents/{name}")
@@ -473,6 +543,15 @@ async def deploy_agent_endpoint(request: Request, body: DeployAgentRequest):
        We never silently retarget a pinned deploy.
     6. Model not found anywhere in the cluster — 404.
     """
+    # --- Idempotency guard ---
+    idempotency_cache = getattr(request.app.state, "idempotency_cache", None)
+    idempotency_key = request.headers.get("Idempotency-Key")
+    if idempotency_key and idempotency_cache is not None:
+        mode, event = idempotency_cache.try_reserve(idempotency_key)
+        if mode == "wait":
+            await event.wait()
+            return idempotency_cache.get(idempotency_key)
+
     config = request.app.state.config
     display_name = body.name.strip()
     name_error = validate_agent_name(display_name)
@@ -807,7 +886,12 @@ async def deploy_agent_endpoint(request: Request, body: DeployAgentRequest):
             logger.exception("archive smoke-check failed for %s", unique_slug)
             smoke_ok = False
 
-    return {"status": "deploying", "name": body.name, "archive_smoke_ok": smoke_ok}
+    result = {"status": "deploying", "name": body.name, "archive_smoke_ok": smoke_ok}
+
+    if idempotency_key and idempotency_cache is not None:
+        idempotency_cache.set(idempotency_key, result)
+
+    return result
 
 
 @router.post("/api/agents/bulk/start")

--- a/tinyagentos/routes/channel_hub.py
+++ b/tinyagentos/routes/channel_hub.py
@@ -128,7 +128,7 @@ async def connect_bot(request: Request):
             agent_name=agent_name, router=router_obj,
             repo=repo, event_kinds=event_kinds, pr_number=pr_number,
         )
-        router_obj.assign_channel(platform, agent_name, agent_name)
+        router_obj.assign_channel(platform, repo, agent_name)
         await connector.start()
         connectors[connector_key] = connector
         request.app.state.channel_hub_connectors = connectors

--- a/tinyagentos/routes/store.py
+++ b/tinyagentos/routes/store.py
@@ -1,9 +1,12 @@
 # tinyagentos/routes/store.py
 from __future__ import annotations
 
+import logging
 from dataclasses import asdict
 
 from fastapi import APIRouter, Request
+
+logger = logging.getLogger(__name__)
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
@@ -239,6 +242,14 @@ async def install_app(request: Request, body: InstallRequest):
                 await mcp_store.register_server(
                     body.app_id, manifest.version, transport
                 )
+        # Ingest per-app agent guides if present
+        knowledge_store = getattr(request.app.state, "knowledge_store", None)
+        if knowledge_store is not None and manifest.manifest_dir is not None:
+            from tinyagentos.knowledge_monitor import ingest_app_guides
+            try:
+                await ingest_app_guides(body.app_id, manifest.manifest_dir, knowledge_store)
+            except Exception:
+                logger.warning("Guide ingestion failed for app %s", body.app_id)
         return {"status": "installed", "app_id": body.app_id}
     return JSONResponse({"error": result.get("error", "Install failed")}, status_code=500)
 
@@ -329,4 +340,12 @@ async def uninstall_app(request: Request, body: UninstallRequest):
                 if existing is not None:
                     await mcp_supervisor.uninstall(body.app_id)
     registry.mark_uninstalled(body.app_id)
+    # Wipe per-app agent guides from the knowledge store
+    knowledge_store = getattr(request.app.state, "knowledge_store", None)
+    if knowledge_store is not None:
+        from tinyagentos.knowledge_monitor import wipe_app_guides
+        try:
+            await wipe_app_guides(knowledge_store, body.app_id)
+        except Exception:
+            logger.warning("Guide wipe failed for app %s", body.app_id)
     return {"status": "uninstalled", "app_id": body.app_id}

--- a/tinyagentos/routes/store_install.py
+++ b/tinyagentos/routes/store_install.py
@@ -45,10 +45,10 @@ _KNOWN_BACKENDS = {
 _BACKEND_TO_METHOD: dict[str, str] = {
     "rkllama": "rkllama",
     "rk-llama-cpp": "rkllamacpp",
-    "ollama": "ollama",
-    "llama-cpp": "download",
+    "ollama": "ollama_pull",
+    "llama-cpp": "llama_cpp_download",
     "mlx": "download",
-    "vllm": "download",
+    "vllm": "vllm_download",
     "comfyui": "download",
     # Multi-file backends — model weights ship as an HF directory (config,
     # tokenizer, sharded safetensors / .bin chunks). The huggingface

--- a/tinyagentos/routes/store_install.py
+++ b/tinyagentos/routes/store_install.py
@@ -622,6 +622,14 @@ async def install_app(request: Request):
             registry.mark_installed(manifest.id, getattr(manifest, "version", ""))
         except Exception:  # noqa: BLE001
             pass
+    # Ingest per-app agent guides if present
+    knowledge_store = getattr(request.app.state, "knowledge_store", None)
+    if knowledge_store is not None and getattr(manifest, "manifest_dir", None) is not None:
+        from tinyagentos.knowledge_monitor import ingest_app_guides
+        try:
+            await ingest_app_guides(manifest.id, manifest.manifest_dir, knowledge_store)
+        except Exception:
+            logger.warning("Guide ingestion failed for app %s", manifest.id)
     chain.append({"step": "model", "id": manifest.id, "status": "installed"})
     progress.finish(install_id, success=True, detail="install complete")
 
@@ -693,6 +701,14 @@ async def uninstall_app(request: Request):
     await store.remove_runtime_location(app_id)
     if registry is not None:
         registry.mark_uninstalled(app_id)
+    # Wipe per-app agent guides from the knowledge store
+    knowledge_store = getattr(request.app.state, "knowledge_store", None)
+    if knowledge_store is not None:
+        from tinyagentos.knowledge_monitor import wipe_app_guides
+        try:
+            await wipe_app_guides(knowledge_store, app_id)
+        except Exception:
+            logger.warning("Guide wipe failed for app %s", app_id)
     resp: dict = {"ok": removed, "app_id": app_id, "status": "uninstalled" if removed else "not_installed"}
     return JSONResponse(resp)
 


### PR DESCRIPTION
Extends ingest_agent_docs for per-app guides. Hooks into app install/uninstall lifecycle so installed apps' guides are immediately available. 18 tests pass.\n\nCloses #451

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model Activity feed with live stream and UI; in-memory event buffer
  * AgentState schema and YAML load/dump; agent token store with issue/revoke APIs
  * Idempotent agent create/deploy; GitHub events channel and in-process channel adapters
  * New installers: llama.cpp (GGUF) and vllm (HF prefetch); auto-ingest agent docs and per-app guides at startup/install

* **Documentation**
  * Pin QMD install to a known-good release; added fork-update/rebase guidance

* **Tests**
  * New tests for doc ingestion and AgentState behavior

* **Bug Fixes**
  * Adjusted backend→installer mappings for correct installer selection
<!-- end of auto-generated comment: release notes by coderabbit.ai -->