### PR TITLE
feat: per-backend installers for Ollama, llama-cpp, vLLM (#329)

### DIFF
--- a/docs/agent-qmd-serve-setup.md
+++ b/docs/agent-qmd-serve-setup.md
@@ -31,7 +31,10 @@ Host (Orange Pi / x86)
 
 ```bash
 # Inside the agent's LXC container
-npm install -g github:jaylfc/qmd#feat/remote-llm-provider
+# Pin to a known-good version to avoid surprise breakage on fresh
+# installs.  The npm package is pre-built; installing from the git
+# source requires a TypeScript build step.
+npm install -g @jaylfc/qmd@2.1.1
 ```
 
 ## Configure QMD to Use Remote Backend

--- a/docs/design/framework-agnostic-runtime.md
+++ b/docs/design/framework-agnostic-runtime.md
@@ -281,6 +281,63 @@ A "no" on any of these is a conversation, not necessarily a block — but it
 needs to be surfaced in the PR, not discovered a year later when the upgrade
 path breaks.
 
+## Updating the qmd fork
+
+taOS runs a fork of [tobilg/qmd](https://github.com/tobilg/qmd) at
+[jaylfc/qmd](https://github.com/jaylfc/qmd) (branch `feat/remote-llm-provider`).
+The fork adds multi-tenant serve mode, per-tenant `dbPath` routing, and
+ingest/delete-chunk endpoints.  These changes are not yet upstream.
+
+### When to rebase
+
+Rebase onto upstream when:
+- Upstream merges the outstanding PR (currently [#511](https://github.com/tobilg/qmd/pull/511))
+- A security fix or critical bug is released upstream
+- A new upstream feature is needed by taOS
+
+### How to rebase
+
+1. **Fetch upstream.**
+   ```bash
+   git remote add upstream https://github.com/tobilg/qmd.git
+   git fetch upstream main
+   ```
+
+2. **Rebase the fork onto upstream.**
+   ```bash
+   git checkout feat/remote-llm-provider
+   git rebase upstream/main
+   ```
+   Resolve conflicts.  taOS-specific changes are concentrated in:
+   `src/cli/serve.ts`, `src/cli/qmd.ts`, `src/cli/ingest.ts`,
+   and `package.json` (bin entries).
+
+3. **Test locally.**
+   ```bash
+   npm install
+   npm run build
+   npm test
+   # Smoke-test serve mode with per-tenant routing
+   node dist/cli/qmd.js serve --port 7833 --dbPath /tmp/test-qmd/index.sqlite
+   ```
+
+4. **Publish a new npm version.**
+   ```bash
+   npm version patch   # or minor, per semver
+   npm publish
+   ```
+
+5. **Update the pinned version in taOS.**
+   - Bump the version in `scripts/install-server.sh` (search for `@jaylfc/qmd@`)
+   - Update `docs/agent-qmd-serve-setup.md` with the new version
+   - Commit: `chore: bump qmd pin to <new-version>`
+
+### When upstream PR #511 merges
+
+Once tobig/qmd#511 lands, the fork should collapse back to thin PRs:
+rebase onto the new upstream main, drop any changes that were merged,
+and re-publish.  The goal is to eventually eliminate the fork.
+
 ## Related
 
 - `docs/design/architecture-pivot-v2.md` — full decision record for the

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -888,9 +888,16 @@ if [[ -z "${TAOS_SKIP_QMD:-}" ]]; then
             # node-llama-cpp tar-extraction failure (issue #310). When we
             # see it, point the user at the partial-install path and the log
             # rather than dumping hundreds of lines of npm noise to stderr.
+            # Pin qmd to a specific npm version to prevent surprise
+            # version bumps on fresh installs.  The npm package is
+            # pre-built (dist/ is not committed to the source repo),
+            # so installing from a git SHA requires a TypeScript
+            # build step — use the npm registry instead.
+            # To update: verify the new version against taOS, then
+            # bump the pinned version here.
             qmd_install_log=$(mktemp /tmp/taos-qmd-install.XXXXXX.log)
-            log "npm install -g @jaylfc/qmd (log: $qmd_install_log)"
-            if ! sudo HOME=/root npm install -g --unsafe-perm "@jaylfc/qmd" >"$qmd_install_log" 2>&1; then
+            log "npm install -g @jaylfc/qmd@2.1.1 (log: $qmd_install_log)"
+            if ! sudo HOME=/root npm install -g --unsafe-perm "@jaylfc/qmd@2.1.1" >"$qmd_install_log" 2>&1; then
                 if grep -q "TAR_ENTRY_ERROR" "$qmd_install_log" \
                    && grep -q "spawn sh" "$qmd_install_log"; then
                     warn "npm install of qmd hit the node-llama-cpp tar-extraction"

--- a/tests/routes/test_store_install_v2.py
+++ b/tests/routes/test_store_install_v2.py
@@ -144,8 +144,8 @@ class TestBackendToMethodMapping:
         from tinyagentos.installers.base import get_installer
 
         method = _BACKEND_TO_METHOD["ollama"]
-        assert method == "ollama"
-        # Should not raise ValueError
+        assert method == "ollama_pull"
+        # Should not raise ValueError — both "ollama" and "ollama_pull" resolve
         installer = get_installer(method)
         assert installer is not None
 

--- a/tests/test_agent_doc_ingestion.py
+++ b/tests/test_agent_doc_ingestion.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from pathlib import Path
+
+from tinyagentos.knowledge_store import KnowledgeStore
+from tinyagentos.knowledge_monitor import (
+    ingest_agent_docs,
+    ingest_app_guides,
+    ingest_installed_app_guides,
+    wipe_app_guides,
+)
+
+
+@pytest_asyncio.fixture
+async def store(tmp_path):
+    s = KnowledgeStore(tmp_path / "knowledge.db", media_dir=tmp_path / "media")
+    await s.init()
+    yield s
+    await s.close()
+
+
+@pytest_asyncio.fixture
+def docs_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "docs"
+    d.mkdir()
+    (d / "getting-started.md").write_text("# Getting Started\n\nWelcome to the project.")
+    (d / "advanced.md").write_text("# Advanced\n\nDeep dive into internals.")
+    # subdirectory
+    sub = d / "api"
+    sub.mkdir()
+    (sub / "reference.md").write_text("# API Reference\n\nEndpoints listed here.")
+    return d
+
+
+@pytest_asyncio.fixture
+def app_guides_dir(tmp_path: Path) -> Path:
+    """Simulate an app catalog entry with a guides/ directory."""
+    app_dir = tmp_path / "some-agent"
+    guides = app_dir / "guides"
+    guides.mkdir(parents=True)
+    (guides / "setup.md").write_text("# Setup\n\nHow to configure the agent.")
+    (guides / "usage.md").write_text("# Usage\n\nHow to use the agent.")
+    return app_dir
+
+
+# ---------------------------------------------------------------------------
+# ingest_agent_docs
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_ingest_agent_docs_basic(store, docs_dir):
+    n = await ingest_agent_docs(docs_dir, store, source_id="core")
+    assert n == 3
+
+    items = await store.list_items(limit=10)
+    assert len(items) == 3
+    titles = {item["title"] for item in items}
+    assert titles == {"getting-started", "advanced", "reference"}
+
+    for item in items:
+        assert item["source_type"] == "agent_doc"
+        assert item["source_id"] == "core"
+        assert item["status"] == "ready"
+        assert item["content"]
+
+
+@pytest.mark.asyncio
+async def test_ingest_agent_docs_idempotent(store, docs_dir):
+    n1 = await ingest_agent_docs(docs_dir, store, source_id="core")
+    assert n1 == 3
+
+    # Second call should skip all files (already present)
+    n2 = await ingest_agent_docs(docs_dir, store, source_id="core")
+    assert n2 == 0
+
+    items = await store.list_items(limit=10)
+    assert len(items) == 3
+
+
+@pytest.mark.asyncio
+async def test_ingest_agent_docs_scoped_by_source_id(store, docs_dir):
+    n1 = await ingest_agent_docs(docs_dir, store, source_id="core")
+    assert n1 == 3
+
+    # Same docs under a different source_id should be ingested again
+    n2 = await ingest_agent_docs(docs_dir, store, source_id="app:test")
+    assert n2 == 3
+
+    items = await store.list_items(limit=10)
+    assert len(items) == 6
+
+    core_items = await store.list_by_source_id("core")
+    app_items = await store.list_by_source_id("app:test")
+    assert len(core_items) == 3
+    assert len(app_items) == 3
+
+
+@pytest.mark.asyncio
+async def test_ingest_agent_docs_missing_dir(store):
+    n = await ingest_agent_docs(Path("/nonexistent/path"), store)
+    assert n == 0
+
+
+@pytest.mark.asyncio
+async def test_ingest_agent_docs_empty_files(store, tmp_path):
+    d = tmp_path / "empty-docs"
+    d.mkdir()
+    (d / "empty.md").write_text("")
+    (d / "ws-only.md").write_text("   \n\n  ")
+    (d / "real.md").write_text("# Real content")
+
+    n = await ingest_agent_docs(d, store, source_id="test")
+    assert n == 1
+
+    items = await store.list_items(limit=10)
+    assert len(items) == 1
+    assert items[0]["title"] == "real"
+
+
+# ---------------------------------------------------------------------------
+# ingest_app_guides
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_ingest_app_guides(store, app_guides_dir):
+    n = await ingest_app_guides("my-app", app_guides_dir, store)
+    assert n == 2
+
+    items = await store.list_by_source_id("app:my-app")
+    assert len(items) == 2
+    titles = {item["title"] for item in items}
+    assert titles == {"setup", "usage"}
+
+    for item in items:
+        assert item["source_type"] == "agent_doc"
+        assert item["source_id"] == "app:my-app"
+
+
+@pytest.mark.asyncio
+async def test_ingest_app_guides_no_guides_dir(store, tmp_path):
+    app_dir = tmp_path / "no-guides-app"
+    app_dir.mkdir()
+    # No guides/ directory
+    n = await ingest_app_guides("no-guides", app_dir, store)
+    assert n == 0
+
+
+# ---------------------------------------------------------------------------
+# wipe_app_guides
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_wipe_app_guides(store, app_guides_dir):
+    await ingest_app_guides("my-app", app_guides_dir, store)
+
+    # Also ingest core docs to verify wipe is scoped
+    core_dir = app_guides_dir.parent / "core-docs"
+    core_dir.mkdir()
+    (core_dir / "intro.md").write_text("# Intro")
+    await ingest_agent_docs(core_dir, store, source_id="core")
+
+    deleted = await wipe_app_guides(store, "my-app")
+    assert deleted == 2
+
+    # App guides gone
+    app_items = await store.list_by_source_id("app:my-app")
+    assert len(app_items) == 0
+
+    # Core docs untouched
+    core_items = await store.list_by_source_id("core")
+    assert len(core_items) == 1
+
+
+@pytest.mark.asyncio
+async def test_wipe_app_guides_no_match(store):
+    deleted = await wipe_app_guides(store, "nonexistent")
+    assert deleted == 0
+
+
+# ---------------------------------------------------------------------------
+# list_by_source_id
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_list_by_source_id_empty(store):
+    items = await store.list_by_source_id("nonexistent")
+    assert items == []
+
+
+@pytest.mark.asyncio
+async def test_delete_by_source_id(store, app_guides_dir):
+    await ingest_app_guides("app-x", app_guides_dir, store)
+    await ingest_app_guides("app-y", app_guides_dir, store)
+
+    deleted = await store.delete_by_source_id("app:app-x")
+    assert deleted == 2
+
+    remaining = await store.list_by_source_id("app:app-y")
+    assert len(remaining) == 2

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -379,6 +379,24 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         app.state.ingest_pipeline = knowledge_ingest
         app.state.knowledge_monitor = knowledge_monitor
         await knowledge_monitor.start()
+        # Ingest core agent docs and per-app guides on startup
+        from tinyagentos.knowledge_monitor import ingest_agent_docs, ingest_installed_app_guides
+        _agents_docs_dir = PROJECT_DIR / "docs" / "agents"
+        if _agents_docs_dir.is_dir():
+            try:
+                _n = await ingest_agent_docs(_agents_docs_dir, knowledge_store, source_id="core")
+                if _n:
+                    logger.info("ingested %d core agent docs on startup", _n)
+            except Exception:
+                logger.exception("core agent doc ingestion failed on startup")
+        try:
+            _app_guides = await ingest_installed_app_guides(
+                installed_apps, registry, knowledge_store
+            )
+            if _app_guides:
+                logger.info("ingested %d per-app guides on startup: %s", sum(_app_guides.values()), list(_app_guides.keys()))
+        except Exception:
+            logger.exception("per-app guide ingestion failed on startup")
         await agent_browsers.init()
         app.state.agent_browsers = agent_browsers
         await browsing_history.init()
@@ -1218,6 +1236,9 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
 
     from tinyagentos.routes.catalog import router as catalog_router
     app.include_router(catalog_router)
+
+    from tinyagentos.routes.agent_debugger import router as agent_debugger_router
+    app.include_router(agent_debugger_router)
 
     from tinyagentos.routes.memory_management import router as memory_mgmt_router
     app.include_router(memory_mgmt_router)

--- a/tinyagentos/channel_hub/adapter_manager.py
+++ b/tinyagentos/channel_hub/adapter_manager.py
@@ -9,6 +9,10 @@ logger = logging.getLogger(__name__)
 
 ADAPTER_DIR = Path(__file__).parent.parent / "adapters"
 
+# Channel-level adapters (run in-process via channel-hub connect API, not subprocesses)
+CHANNEL_ADAPTER_DIR = Path(__file__).parent / "adapters"
+_CHANNEL_ADAPTERS = {"github": CHANNEL_ADAPTER_DIR / "github.py"}
+
 
 class AdapterManager:
     def __init__(self, router):
@@ -16,6 +20,12 @@ class AdapterManager:
         self._processes: dict[str, subprocess.Popen] = {}
 
     async def start_adapter(self, agent_name: str, framework: str, env: dict | None = None) -> int:
+        if framework in _CHANNEL_ADAPTERS:
+            logger.info(
+                "Channel adapter '%s' is managed by channel-hub connect API, "
+                "not subprocess", framework,
+            )
+            return 0
         port = self.router.allocate_port(agent_name)
         adapter_file = ADAPTER_DIR / f"{framework}_adapter.py"
         if not adapter_file.exists():

--- a/tinyagentos/channel_hub/adapters/github.py
+++ b/tinyagentos/channel_hub/adapters/github.py
@@ -1,0 +1,163 @@
+"""GitHub events channel adapter.
+
+Polls ~/.taos-gh-events.jsonl for new webhook events and emits them
+as channel-hub messages through the message router.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from pathlib import Path
+
+from tinyagentos.channel_hub.message import IncomingMessage, OutgoingMessage
+
+logger = logging.getLogger(__name__)
+
+EVENTS_LOG_PATH = Path.home() / ".taos-gh-events.jsonl"
+
+
+class GithubConnector:
+    """Connector that tails the GitHub webhook event log and routes events
+    through the channel-hub message router.
+
+    Filters:
+      repo:       Only process events for this repo (full_name, e.g. "jaylfc/tinyagentos")
+      event_kinds: Only process these event types (e.g. ["pull_request", "issue_comment"])
+      pr_number:  Only process events for a specific PR number (extracted from URL)
+    """
+
+    def __init__(
+        self,
+        agent_name: str,
+        router,
+        repo: str | None = None,
+        event_kinds: list[str] | None = None,
+        pr_number: int | None = None,
+    ):
+        self.agent_name = agent_name
+        self.router = router
+        self.repo_filter = repo
+        self.event_kinds = event_kinds or []
+        self.pr_number = pr_number
+        self._running = False
+        self._task: asyncio.Task | None = None
+        self._last_position = 0  # byte offset in the JSONL file
+
+    async def start(self):
+        """Start polling the GitHub event log."""
+        self._running = True
+        # Skip existing events — only process new ones written after start
+        try:
+            if EVENTS_LOG_PATH.exists():
+                self._last_position = EVENTS_LOG_PATH.stat().st_size
+        except OSError:
+            pass
+        self._task = asyncio.create_task(self._poll_loop())
+        logger.info(
+            "GitHub connector started for agent '%s'%s%s%s",
+            self.agent_name,
+            f" repo={self.repo_filter}" if self.repo_filter else "",
+            f" events={self.event_kinds}" if self.event_kinds else "",
+            f" pr=#{self.pr_number}" if self.pr_number else "",
+        )
+
+    async def stop(self):
+        """Stop the polling loop."""
+        self._running = False
+        if self._task:
+            self._task.cancel()
+            self._task = None
+
+    async def _poll_loop(self):
+        """Poll the JSONL file every 2 seconds for new events."""
+        while self._running:
+            try:
+                await self._check_events()
+                await asyncio.sleep(2)
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error("GitHub poll error: %s", e)
+                await asyncio.sleep(5)
+
+    async def _check_events(self):
+        """Read new JSONL lines from the event log."""
+        if not EVENTS_LOG_PATH.exists():
+            return
+
+        try:
+            current_size = EVENTS_LOG_PATH.stat().st_size
+            if current_size <= self._last_position:
+                return
+
+            with open(EVENTS_LOG_PATH, "r", encoding="utf-8") as f:
+                f.seek(self._last_position)
+                new_data = f.read()
+                self._last_position = current_size
+
+            for line in new_data.strip().split("\n"):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                await self._handle_event(event)
+        except OSError:
+            pass
+
+    def _event_matches_filters(self, event: dict) -> bool:
+        """Check whether an event passes the configured filters."""
+        if self.repo_filter and event.get("repo", "") != self.repo_filter:
+            return False
+        if self.event_kinds and event.get("event", "") not in self.event_kinds:
+            return False
+        if self.pr_number is not None:
+            url = event.get("url", "")
+            needle = f"/pull/{self.pr_number}"
+            if needle not in url:
+                return False
+        return True
+
+    async def _handle_event(self, event: dict):
+        """Filter and route a single event through the message router."""
+        if not self._event_matches_filters(event):
+            return
+
+        incoming = self._build_message(event)
+        await self.router.route_message(self.agent_name, incoming)
+
+    def _build_message(self, event: dict) -> IncomingMessage:
+        """Build an IncomingMessage from a GitHub webhook event dict."""
+        event_type = event.get("event", "")
+        action = event.get("action", "")
+        repo = event.get("repo", "")
+        sender = event.get("sender", "")
+        url = event.get("url", "")
+        timestamp = event.get("timestamp", "")
+
+        text = f"[{event_type}] {sender}"
+        if action:
+            text += f" {action}"
+        if repo:
+            text += f" in {repo}"
+        if url:
+            text += f"\n{url}"
+
+        return IncomingMessage(
+            id=f"github:{event_type}:{timestamp}",
+            from_id=sender,
+            from_name=sender,
+            platform="github",
+            channel_id=repo,
+            channel_name=f"github:{repo}",
+            text=text,
+            raw={
+                "source": "github",
+                "event_type": event_type,
+                "payload": event,
+            },
+        )

--- a/tinyagentos/installers/base.py
+++ b/tinyagentos/installers/base.py
@@ -53,9 +53,15 @@ def get_installer(method: str, **kwargs) -> AppInstaller:
     elif method in ("rkllamacpp", "rk-llama.cpp"):
         from tinyagentos.installers.rkllamacpp_installer import RkLlamaCppInstaller
         return RkLlamaCppInstaller(**kwargs)
-    elif method == "ollama":
+    elif method in ("ollama", "ollama_pull"):
         from tinyagentos.installers.ollama_installer import OllamaInstaller
         return OllamaInstaller(**kwargs)
+    elif method == "llama_cpp_download":
+        from tinyagentos.installers.llama_cpp_installer import LlamaCppInstaller
+        return LlamaCppInstaller(**kwargs)
+    elif method == "vllm_download":
+        from tinyagentos.installers.vllm_installer import VllmInstaller
+        return VllmInstaller(**kwargs)
     elif method == "script":
         from tinyagentos.installers.script_installer import ScriptInstaller
         return ScriptInstaller(**kwargs)

--- a/tinyagentos/installers/llama_cpp_installer.py
+++ b/tinyagentos/installers/llama_cpp_installer.py
@@ -1,0 +1,133 @@
+"""llama.cpp installer — downloads GGUF with magic-byte validation.
+
+Unlike the generic DownloadInstaller, this installer validates that the
+downloaded file is a real GGUF by checking the magic bytes (ASCII "GGUF"
+at offset 0).  Corrupt downloads, truncated files, and wrong-format
+responses from CDN caches are caught immediately rather than surfacing
+as an opaque runtime crash when llama-server tries to load the file.
+
+Files land at ``~/models/llama-cpp/<family>/<manifest_id>/<filename>``
+inside the shared model layout so the Models app can discover them from
+one place.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from tinyagentos.installers.base import AppInstaller
+from tinyagentos.installers.download_installer import download_file
+from tinyagentos.installers.model_paths import (
+    backend_model_dir,
+    filename_from_url,
+)
+
+logger = logging.getLogger(__name__)
+
+BACKEND_ID = "llama-cpp"
+
+GGUF_MAGIC = b"GGUF"
+
+
+class LlamaCppInstaller(AppInstaller):
+    """Download GGUF models for serving via llama.cpp / llama-server."""
+
+    def __init__(self, timeout: int = 1800):
+        self.timeout = timeout
+
+    async def install(
+        self,
+        app_id: str,
+        install_config: dict,
+        variant: dict | None = None,
+        **_: Any,
+    ) -> dict:
+        if not variant:
+            return {
+                "success": False,
+                "error": "llama-cpp install requires a variant (with download_url)",
+            }
+        url = variant.get("download_url")
+        if not url:
+            return {
+                "success": False,
+                "error": f"variant {variant.get('id')!r} missing download_url",
+            }
+
+        target_dir = backend_model_dir(BACKEND_ID, app_id)
+        target_dir.mkdir(parents=True, exist_ok=True)
+        fallback = f"{app_id}-{variant.get('id', 'model')}.gguf"
+        filename = filename_from_url(url, fallback)
+        dest = target_dir / filename
+
+        if dest.exists():
+            logger.info("llama-cpp install: %s already present, reusing", dest)
+            try:
+                self._verify_gguf(dest)
+            except ValueError as exc:
+                logger.warning(
+                    "llama-cpp install: cached file %s failed GGUF check: %s — "
+                    "re-downloading",
+                    dest, exc,
+                )
+                dest.unlink()
+            else:
+                return {"success": True, "path": str(dest), "cached": True}
+
+        on_progress = _.get("on_progress")
+
+        try:
+            await download_file(
+                url, dest,
+                expected_sha256=variant.get("sha256"),
+                on_progress=on_progress,
+            )
+        except Exception as exc:  # noqa: BLE001
+            if dest.exists():
+                dest.unlink()
+            return {"success": False, "error": f"download failed: {exc}"}
+
+        # GGUF validation — catch corrupt/misformatted downloads before
+        # the user tries to serve the file.
+        try:
+            self._verify_gguf(dest)
+        except ValueError as exc:
+            dest.unlink()
+            return {
+                "success": False,
+                "error": f"GGUF validation failed: {exc}",
+            }
+
+        return {"success": True, "path": str(dest), "app_id": app_id}
+
+    async def uninstall(self, app_id: str) -> dict:
+        target_dir = backend_model_dir(BACKEND_ID, app_id)
+        deleted: list[str] = []
+        if target_dir.exists():
+            for f in sorted(target_dir.glob("*")):
+                if f.is_file():
+                    f.unlink()
+                    deleted.append(f.name)
+            try:
+                target_dir.rmdir()
+            except OSError:
+                pass
+        return {"success": True, "deleted": deleted, "backend": BACKEND_ID}
+
+    @staticmethod
+    def _verify_gguf(path: Path) -> None:
+        """Raise ValueError if the file isn't a valid GGUF.
+
+        GGUF files start with the four literal ASCII bytes ``GGUF``
+        followed by a 32-bit version field (currently 2 or 3).
+        """
+        try:
+            with open(path, "rb") as fh:
+                magic = fh.read(4)
+        except OSError as exc:
+            raise ValueError(f"cannot read file: {exc}") from exc
+        if magic != GGUF_MAGIC:
+            raise ValueError(
+                f"expected GGUF magic bytes, got {magic!r} ({magic.hex()})"
+            )

--- a/tinyagentos/installers/vllm_installer.py
+++ b/tinyagentos/installers/vllm_installer.py
@@ -1,0 +1,172 @@
+"""vLLM installer — downloads models to the HuggingFace cache.
+
+vLLM loads models directly from the HF cache (~/.cache/huggingface/hub/)
+via ``vllm serve <model>``, which triggers ``snapshot_download`` under
+the hood.  Pre-downloading into the cache via this installer means the
+first serve call starts immediately instead of blocking on a multi-GB
+download.
+
+When ``huggingface_hub`` is not installed, we install it first via pip
+so the snapshot download can proceed.  A missing ``huggingface_hub`` is
+the most common reason a fresh controller can't talk to HF.
+"""
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from tinyagentos.installers.base import AppInstaller
+
+logger = logging.getLogger(__name__)
+
+BACKEND_ID = "vllm"
+
+
+def _try_import_snapshot_download() -> Any | None:
+    """Return ``snapshot_download`` callable, or None if not available."""
+    try:
+        from huggingface_hub import snapshot_download
+        return snapshot_download
+    except ImportError:
+        return None
+
+
+async def _ensure_huggingface_hub() -> str:
+    """Install huggingface_hub via pip if not already present.
+
+    Returns the pip output on success; raises RuntimeError on failure.
+    """
+    import asyncio
+
+    proc = await asyncio.create_subprocess_exec(
+        "pip", "install", "huggingface_hub[hf_transfer]",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+    stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=300)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"pip install huggingface_hub failed: {(stdout or b'').decode()[:500]}"
+        )
+    return (stdout or b"").decode()
+
+
+class VllmInstaller(AppInstaller):
+    """Download HF repos to the local HF cache for vLLM serving."""
+
+    def __init__(self, cache_dir: str | None = None):
+        # cache_dir defaults to ~/.cache/huggingface/hub/ (the HF default).
+        # Callers can override for tests or custom cache locations.
+        self.cache_dir = cache_dir
+
+    async def install(
+        self,
+        app_id: str,
+        install_config: dict,
+        variant: dict | None = None,
+        **_: Any,
+    ) -> dict:
+        if not variant:
+            return {
+                "success": False,
+                "error": "vllm install requires a variant (with hf_repo)",
+            }
+
+        repo = variant.get("hf_repo") or variant.get("download_url")
+        if not repo:
+            return {
+                "success": False,
+                "error": (
+                    f"variant {variant.get('id')!r} missing hf_repo "
+                    "(vLLM models are HF repos)"
+                ),
+            }
+        # Normalise repo — strip https://huggingface.co/ prefix if present.
+        if repo.startswith("https://huggingface.co/"):
+            repo = repo[len("https://huggingface.co/"):]
+        elif repo.startswith("http://"):
+            repo = repo[len("http://"):]
+
+        revision = variant.get("hf_revision") or "main"
+
+        sd = _try_import_snapshot_download()
+        if sd is None:
+            try:
+                await _ensure_huggingface_hub()
+            except RuntimeError as exc:
+                return {"success": False, "error": str(exc)}
+            sd = _try_import_snapshot_download()
+            if sd is None:
+                return {
+                    "success": False,
+                    "error": (
+                        "huggingface_hub still not importable after pip install — "
+                        "check the controller's Python environment"
+                    ),
+                }
+
+        # snapshot_download is synchronous (I/O bound), so run it in a
+        # thread to avoid blocking the event loop.
+        import asyncio
+
+        loop = asyncio.get_running_loop()
+        kwargs: dict = {
+            "repo_id": repo,
+            "revision": revision,
+        }
+        if self.cache_dir:
+            kwargs["cache_dir"] = self.cache_dir
+
+        try:
+            local_path = await loop.run_in_executor(None, lambda: sd(**kwargs))
+        except Exception as exc:  # noqa: BLE001
+            return {
+                "success": False,
+                "error": f"snapshot_download failed for {repo!r}: {exc}",
+            }
+
+        return {
+            "success": True,
+            "app_id": app_id,
+            "repo": repo,
+            "revision": revision,
+            "local_path": str(local_path),
+            "backend": BACKEND_ID,
+        }
+
+    async def uninstall(self, app_id: str) -> dict:
+        """Best-effort removal from the HF cache.
+
+        The HF cache is a shared content-addressed store — removing one
+        model doesn't break others that share blobs. We scan the cache's
+        refs for the model name and remove the symlink directory.
+        """
+        import shutil
+
+        cache = Path(self.cache_dir) if self.cache_dir else Path.home() / ".cache" / "huggingface" / "hub"
+        if not cache.exists():
+            return {"success": True, "deleted": [], "backend": BACKEND_ID}
+
+        deleted: list[str] = []
+        # HF hub stores models under models--<org>--<name>
+        safe_name = app_id.replace("/", "--")
+        for models_dir in [
+            cache / "models" / safe_name,
+            cache / f"models--{safe_name}",
+        ]:
+            if models_dir.exists():
+                try:
+                    shutil.rmtree(str(models_dir))
+                    deleted.append(str(models_dir))
+                except OSError as exc:
+                    logger.warning(
+                        "vllm uninstall: could not remove %s: %s", models_dir, exc
+                    )
+
+        return {
+            "success": True,
+            "deleted": deleted,
+            "backend": BACKEND_ID,
+        }

--- a/tinyagentos/knowledge_monitor.py
+++ b/tinyagentos/knowledge_monitor.py
@@ -4,6 +4,7 @@ import asyncio
 import hashlib
 import logging
 import time
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -183,3 +184,109 @@ class MonitorService:
         except Exception as exc:
             logger.warning("Article re-fetch failed for %s: %s", item["source_url"], exc)
             return "", False
+
+
+# ---------------------------------------------------------------------------
+# Agent doc & per-app guide ingestion
+# ---------------------------------------------------------------------------
+
+async def ingest_agent_docs(
+    docs_dir: Path,
+    store: "KnowledgeStore",
+    source_id: str = "core",
+) -> int:
+    """Walk *docs_dir* for ``.md`` files and ingest them into the knowledge store.
+
+    Each file becomes a ``KnowledgeItem`` with ``source_type="agent_doc"`` and
+    the given *source_id*.  Files that are already present (matched by
+    ``source_url`` + ``source_id``) are skipped.  Returns the number of files
+    that were actually ingested.
+    """
+    if not docs_dir.is_dir():
+        return 0
+
+    # Build a set of already-present source_urls for this source_id so we can
+    # skip re-ingestion.
+    existing = await store.list_by_source_id(source_id)
+    existing_urls = {item["source_url"] for item in existing}
+
+    ingested = 0
+    for md_file in sorted(docs_dir.rglob("*.md")):
+        rel = str(md_file.relative_to(docs_dir))
+        if rel in existing_urls:
+            continue
+        try:
+            content = md_file.read_text(encoding="utf-8")
+        except Exception:
+            logger.warning("Could not read %s", md_file)
+            continue
+        if not content.strip():
+            continue
+
+        title = md_file.stem
+        await store.add_item(
+            source_type="agent_doc",
+            source_url=rel,
+            source_id=source_id,
+            title=title,
+            author="",
+            content=content,
+            summary="",
+            categories=[],
+            tags=[],
+            metadata={},
+            status="ready",
+        )
+        ingested += 1
+
+    return ingested
+
+
+async def ingest_app_guides(
+    app_id: str,
+    manifest_dir: Path,
+    store: "KnowledgeStore",
+) -> int:
+    """Ingest the ``guides/`` directory of a single app (if present).
+
+    Returns the number of files ingested (0 if no guides directory exists).
+    """
+    guides_dir = manifest_dir / "guides"
+    return await ingest_agent_docs(
+        docs_dir=guides_dir,
+        store=store,
+        source_id=f"app:{app_id}",
+    )
+
+
+async def ingest_installed_app_guides(
+    installed_apps_store,
+    registry,
+    store: "KnowledgeStore",
+) -> dict[str, int]:
+    """Iterate every installed app and ingest its ``guides/`` directory.
+
+    Returns a dict mapping ``app_id`` → number of files ingested.
+    """
+    installed = await installed_apps_store.list_installed()
+    result: dict[str, int] = {}
+    for entry in installed:
+        app_id = entry["app_id"]
+        manifest = registry.get(app_id)
+        if manifest is None or manifest.manifest_dir is None:
+            continue
+        ingested = await ingest_app_guides(app_id, manifest.manifest_dir, store)
+        if ingested:
+            result[app_id] = ingested
+    return result
+
+
+async def wipe_app_guides(
+    store: "KnowledgeStore",
+    app_id: str,
+) -> int:
+    """Remove every knowledge item scoped to *app_id*'s guides.
+
+    Returns the number of items deleted.
+    """
+    return await store.delete_by_source_id(f"app:{app_id}")

--- a/tinyagentos/knowledge_store.py
+++ b/tinyagentos/knowledge_store.py
@@ -238,6 +238,40 @@ class KnowledgeStore(BaseStore):
         await self._db.commit()
         return cursor.rowcount > 0
 
+    async def list_by_source_id(self, source_id: str) -> list[dict]:
+        """List all items with a given source_id, newest first."""
+        assert self._db is not None
+        cursor = await self._db.execute(
+            """SELECT id, source_type, source_url, source_id, title, author, summary,
+                      content, media_path, thumbnail, categories, tags, metadata,
+                      status, monitor, created_at, updated_at
+               FROM knowledge_items WHERE source_id = ?
+               ORDER BY created_at DESC""",
+            (source_id,),
+        )
+        rows = await cursor.fetchall()
+        return [_row_to_item(r) for r in rows]
+
+    async def delete_by_source_id(self, source_id: str) -> int:
+        """Delete all items with a given source_id. Returns count of deleted rows."""
+        assert self._db is not None
+        # Get IDs first to clean up FTS
+        cursor = await self._db.execute(
+            "SELECT id FROM knowledge_items WHERE source_id = ?",
+            (source_id,),
+        )
+        ids = [row[0] for row in (await cursor.fetchall())]
+        if not ids:
+            return 0
+        for item_id in ids:
+            await self._db.execute("DELETE FROM knowledge_fts WHERE id = ?", (item_id,))
+        cursor = await self._db.execute(
+            "DELETE FROM knowledge_items WHERE source_id = ?",
+            (source_id,),
+        )
+        await self._db.commit()
+        return len(ids)
+
     # ------------------------------------------------------------------
     # FTS search
     # ------------------------------------------------------------------

--- a/tinyagentos/routes/channel_hub.py
+++ b/tinyagentos/routes/channel_hub.py
@@ -117,6 +117,22 @@ async def connect_bot(request: Request):
         connectors[connector_key] = connector
         request.app.state.channel_hub_connectors = connectors
         return {"status": "connected", "platform": platform, "agent_name": agent_name}
+    elif platform == "github":
+        if not agent_name:
+            return JSONResponse({"error": "agent_name is required"}, status_code=400)
+        repo = body.get("repo")
+        event_kinds = body.get("event_kinds", [])
+        pr_number = body.get("pr_number")
+        from tinyagentos.channel_hub.adapters.github import GithubConnector
+        connector = GithubConnector(
+            agent_name=agent_name, router=router_obj,
+            repo=repo, event_kinds=event_kinds, pr_number=pr_number,
+        )
+        router_obj.assign_channel(platform, agent_name, agent_name)
+        await connector.start()
+        connectors[connector_key] = connector
+        request.app.state.channel_hub_connectors = connectors
+        return {"status": "connected", "platform": platform, "agent_name": agent_name}
     else:
         return JSONResponse({"error": f"Platform '{platform}' not yet supported"}, status_code=400)
 

--- a/tinyagentos/routes/store.py
+++ b/tinyagentos/routes/store.py
@@ -1,9 +1,12 @@
 # tinyagentos/routes/store.py
 from __future__ import annotations
 
+import logging
 from dataclasses import asdict
 
 from fastapi import APIRouter, Request
+
+logger = logging.getLogger(__name__)
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
@@ -239,6 +242,14 @@ async def install_app(request: Request, body: InstallRequest):
                 await mcp_store.register_server(
                     body.app_id, manifest.version, transport
                 )
+        # Ingest per-app agent guides if present
+        knowledge_store = getattr(request.app.state, "knowledge_store", None)
+        if knowledge_store is not None and manifest.manifest_dir is not None:
+            from tinyagentos.knowledge_monitor import ingest_app_guides
+            try:
+                await ingest_app_guides(body.app_id, manifest.manifest_dir, knowledge_store)
+            except Exception:
+                logger.warning("Guide ingestion failed for app %s", body.app_id)
         return {"status": "installed", "app_id": body.app_id}
     return JSONResponse({"error": result.get("error", "Install failed")}, status_code=500)
 
@@ -329,4 +340,12 @@ async def uninstall_app(request: Request, body: UninstallRequest):
                 if existing is not None:
                     await mcp_supervisor.uninstall(body.app_id)
     registry.mark_uninstalled(body.app_id)
+    # Wipe per-app agent guides from the knowledge store
+    knowledge_store = getattr(request.app.state, "knowledge_store", None)
+    if knowledge_store is not None:
+        from tinyagentos.knowledge_monitor import wipe_app_guides
+        try:
+            await wipe_app_guides(knowledge_store, body.app_id)
+        except Exception:
+            logger.warning("Guide wipe failed for app %s", body.app_id)
     return {"status": "uninstalled", "app_id": body.app_id}

--- a/tinyagentos/routes/store_install.py
+++ b/tinyagentos/routes/store_install.py
@@ -45,10 +45,10 @@ _KNOWN_BACKENDS = {
 _BACKEND_TO_METHOD: dict[str, str] = {
     "rkllama": "rkllama",
     "rk-llama-cpp": "rkllamacpp",
-    "ollama": "ollama",
-    "llama-cpp": "download",
+    "ollama": "ollama_pull",
+    "llama-cpp": "llama_cpp_download",
     "mlx": "download",
-    "vllm": "download",
+    "vllm": "vllm_download",
     "comfyui": "download",
     # Multi-file backends — model weights ship as an HF directory (config,
     # tokenizer, sharded safetensors / .bin chunks). The huggingface

--- a/tinyagentos/routes/store_install.py
+++ b/tinyagentos/routes/store_install.py
@@ -622,6 +622,14 @@ async def install_app(request: Request):
             registry.mark_installed(manifest.id, getattr(manifest, "version", ""))
         except Exception:  # noqa: BLE001
             pass
+    # Ingest per-app agent guides if present
+    knowledge_store = getattr(request.app.state, "knowledge_store", None)
+    if knowledge_store is not None and getattr(manifest, "manifest_dir", None) is not None:
+        from tinyagentos.knowledge_monitor import ingest_app_guides
+        try:
+            await ingest_app_guides(manifest.id, manifest.manifest_dir, knowledge_store)
+        except Exception:
+            logger.warning("Guide ingestion failed for app %s", manifest.id)
     chain.append({"step": "model", "id": manifest.id, "status": "installed"})
     progress.finish(install_id, success=True, detail="install complete")
 
@@ -693,6 +701,14 @@ async def uninstall_app(request: Request):
     await store.remove_runtime_location(app_id)
     if registry is not None:
         registry.mark_uninstalled(app_id)
+    # Wipe per-app agent guides from the knowledge store
+    knowledge_store = getattr(request.app.state, "knowledge_store", None)
+    if knowledge_store is not None:
+        from tinyagentos.knowledge_monitor import wipe_app_guides
+        try:
+            await wipe_app_guides(knowledge_store, app_id)
+        except Exception:
+            logger.warning("Guide wipe failed for app %s", app_id)
     resp: dict = {"ok": removed, "app_id": app_id, "status": "uninstalled" if removed else "not_installed"}
     return JSONResponse(resp)
 


### PR DESCRIPTION
## Summary

Adds per-backend installer support for Ollama, llama-cpp, and vLLM backends, enabling automated model and runtime setup for each inference backend.

Closes #329