### PR TITLE
feat: add Discord channel adapter for channel_hub (#335)

### DIFF
--- a/tests/channel_hub/test_discord.py
+++ b/tests/channel_hub/test_discord.py
@@ -1,0 +1,782 @@
+"""Tests for the Discord channel adapter.
+
+Mirrors tinyagentos/channel_hub/adapters/discord.py structure.
+Tests cover: init with token, message conversion, sending, rate limits,
+missing token, reconnection, and source="discord" verification.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from tinyagentos.channel_hub.adapters.discord import (
+    DISCORD_API_BASE,
+    DiscordConnector,
+)
+from tinyagentos.channel_hub.message import IncomingMessage, OutgoingMessage
+from tinyagentos.channel_hub.router import MessageRouter
+
+
+# ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+
+
+def _make_mock_httpx_response(status_code: int, json_data: object) -> MagicMock:
+    """Create a non-awaitable MagicMock that mimics an httpx.Response.
+
+    The httpx client's .get()/.post() return the response via await,
+    so the caller must wrap this in an AsyncMock.
+    """
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json = MagicMock(return_value=json_data)
+    return resp
+
+
+def _async_client_with_get(status_code: int = 200, json_data: object = None):
+    """Create an AsyncMock client whose .get() returns a mock response."""
+    client = AsyncMock()
+    client.get.return_value = _make_mock_httpx_response(
+        status_code, json_data if json_data is not None else [],
+    )
+    # .post() defaults to a successful empty response
+    client.post.return_value = _make_mock_httpx_response(200, {})
+    return client
+
+
+# ------------------------------------------------------------------
+# Fixtures
+# ------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_router():
+    """Router mock that echoes a simple text response by default."""
+    router = AsyncMock(spec=MessageRouter)
+    router.route_message.return_value = OutgoingMessage(content="hello")
+    return router
+
+
+@pytest.fixture
+def connector(mock_router):
+    """Baseline DiscordConnector with a bot token and one channel."""
+    return DiscordConnector(
+        bot_token="fake-token-123",
+        agent_name="test-agent",
+        router=mock_router,
+        channel_ids=["123456789"],
+    )
+
+
+@pytest.fixture
+def sample_discord_message():
+    """A realistic Discord message JSON payload."""
+    return {
+        "id": "1000000000000000001",
+        "channel_id": "123456789",
+        "guild_id": "987654321",
+        "author": {
+            "id": "222222222222222222",
+            "username": "test_user",
+            "global_name": "Test User",
+        },
+        "content": "Hello from Discord!",
+        "timestamp": "2026-05-31T12:00:00.000000+00:00",
+    }
+
+
+# ------------------------------------------------------------------
+# Initialization and token handling
+# ------------------------------------------------------------------
+
+
+class TestInitialization:
+    """Tests for DiscordConnector.__init__ and token/auth setup."""
+
+    def test_stores_bot_token(self, connector):
+        assert connector.bot_token == "fake-token-123"
+        assert connector.headers == {"Authorization": "Bot fake-token-123"}
+
+    def test_default_channel_ids_empty(self, mock_router):
+        c = DiscordConnector(
+            bot_token="tok", agent_name="a", router=mock_router,
+        )
+        assert c.channel_ids == []
+
+    def test_stores_agent_name(self, connector):
+        assert connector.agent_name == "test-agent"
+
+    def test_initial_running_state(self, connector):
+        assert connector._running is False
+        assert connector._task is None
+
+    def test_missing_token_is_empty_string(self, mock_router):
+        c = DiscordConnector(
+            bot_token="", agent_name="a", router=mock_router,
+        )
+        assert c.bot_token == ""
+        assert c.headers == {"Authorization": "Bot "}
+
+    def test_stores_last_message_ids_dict(self, connector):
+        assert isinstance(connector._last_message_ids, dict)
+        assert len(connector._last_message_ids) == 0
+
+    def test_stores_per_channel_semaphores(self, connector):
+        assert isinstance(connector._channel_sem, dict)
+        assert len(connector._channel_sem) == 0
+
+
+# ------------------------------------------------------------------
+# Start / stop lifecycle
+# ------------------------------------------------------------------
+
+
+class TestStartStop:
+    """Tests for start(), stop(), and the poll loop lifecycle."""
+
+    @pytest.mark.asyncio
+    async def test_start_sets_running_flag(self, connector):
+        with patch(
+            "tinyagentos.channel_hub.adapters.discord.httpx.AsyncClient"
+        ) as mock_client_cls:
+            # The client.__aenter__ returns an AsyncMock
+            mock_client = AsyncMock()
+            mock_client.get.return_value = _make_mock_httpx_response(
+                200, {"id": "99999"},
+            )
+            mock_client_cls.return_value.__aenter__.return_value = mock_client
+
+            await connector.start()
+
+        assert connector._running is True
+        assert connector._task is not None
+        assert connector._bot_user_id == "99999"
+
+    @pytest.mark.asyncio
+    async def test_start_resolves_bot_user_id_failure(self, connector):
+        with patch(
+            "tinyagentos.channel_hub.adapters.discord.httpx.AsyncClient"
+        ) as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = _make_mock_httpx_response(
+                401, {"message": "Unauthorized"},
+            )
+            mock_client_cls.return_value.__aenter__.return_value = mock_client
+
+            await connector.start()
+
+        assert connector._running is True
+        assert connector._bot_user_id is None
+
+    @pytest.mark.asyncio
+    async def test_stop_cancels_task(self, connector):
+        connector._running = True
+        fake_task = MagicMock()
+        connector._task = fake_task
+
+        await connector.stop()
+
+        assert connector._running is False
+        fake_task.cancel.assert_called_once()
+        assert connector._task is None
+
+    @pytest.mark.asyncio
+    async def test_stop_no_task_is_safe(self, connector):
+        connector._running = False
+        connector._task = None
+
+        await connector.stop()
+
+        assert connector._running is False
+
+
+# ------------------------------------------------------------------
+# Message conversion (incoming)
+# ------------------------------------------------------------------
+
+
+class TestIncomingMessageConversion:
+    """Tests for _handle_message → IncomingMessage creation."""
+
+    @pytest.mark.asyncio
+    async def test_source_is_set_to_discord(
+        self, connector, sample_discord_message,
+    ):
+        """The raw payload has source='discord'."""
+        client = _async_client_with_get()
+        await connector._handle_message(client, "123456789", sample_discord_message)
+
+        incoming = connector.router.route_message.call_args[0][1]
+        assert incoming.raw["source"] == "discord"
+
+    @pytest.mark.asyncio
+    async def test_converts_message_id(
+        self, connector, sample_discord_message,
+    ):
+        client = _async_client_with_get()
+        await connector._handle_message(client, "123456789", sample_discord_message)
+
+        incoming = connector.router.route_message.call_args[0][1]
+        assert incoming.id == "1000000000000000001"
+
+    @pytest.mark.asyncio
+    async def test_converts_author_id_and_name(
+        self, connector, sample_discord_message,
+    ):
+        client = _async_client_with_get()
+        await connector._handle_message(client, "123456789", sample_discord_message)
+
+        incoming = connector.router.route_message.call_args[0][1]
+        assert incoming.from_id == "222222222222222222"
+        assert incoming.from_name == "test_user"
+
+    @pytest.mark.asyncio
+    async def test_converts_fallback_to_global_name(self, connector):
+        msg = {
+            "id": "1", "channel_id": "c",
+            "author": {"id": "999", "global_name": "Global Name"},
+            "content": "hi",
+        }
+        client = _async_client_with_get()
+        await connector._handle_message(client, "c", msg)
+
+        incoming = connector.router.route_message.call_args[0][1]
+        assert incoming.from_name == "Global Name"
+
+    @pytest.mark.asyncio
+    async def test_converts_fallback_to_user_literal_when_no_name(
+        self, connector,
+    ):
+        msg = {
+            "id": "1", "channel_id": "c",
+            "author": {"id": "999"}, "content": "hi",
+        }
+        client = _async_client_with_get()
+        await connector._handle_message(client, "c", msg)
+
+        incoming = connector.router.route_message.call_args[0][1]
+        assert incoming.from_name == "User"
+
+    @pytest.mark.asyncio
+    async def test_converts_platform_to_discord(
+        self, connector, sample_discord_message,
+    ):
+        client = _async_client_with_get()
+        await connector._handle_message(client, "123456789", sample_discord_message)
+
+        incoming = connector.router.route_message.call_args[0][1]
+        assert incoming.platform == "discord"
+
+    @pytest.mark.asyncio
+    async def test_converts_channel_id(
+        self, connector, sample_discord_message,
+    ):
+        client = _async_client_with_get()
+        await connector._handle_message(client, "123456789", sample_discord_message)
+
+        incoming = connector.router.route_message.call_args[0][1]
+        assert incoming.channel_id == "123456789"
+
+    @pytest.mark.asyncio
+    async def test_channel_name_with_guild(
+        self, connector, sample_discord_message,
+    ):
+        client = _async_client_with_get()
+        await connector._handle_message(client, "ch1", sample_discord_message)
+
+        incoming = connector.router.route_message.call_args[0][1]
+        assert incoming.channel_name == "discord:987654321:ch1"
+
+    @pytest.mark.asyncio
+    async def test_channel_name_without_guild(self, connector):
+        msg = {
+            "id": "1", "channel_id": "dm123",
+            "author": {"id": "999", "username": "u"}, "content": "hi",
+        }
+        client = _async_client_with_get()
+        await connector._handle_message(client, "dm123", msg)
+
+        incoming = connector.router.route_message.call_args[0][1]
+        assert incoming.channel_name == "discord:dm:dm123"
+
+    @pytest.mark.asyncio
+    async def test_converts_text_content(
+        self, connector, sample_discord_message,
+    ):
+        client = _async_client_with_get()
+        await connector._handle_message(client, "123456789", sample_discord_message)
+
+        incoming = connector.router.route_message.call_args[0][1]
+        assert incoming.text == "Hello from Discord!"
+
+    @pytest.mark.asyncio
+    async def test_raw_payload_includes_guild_and_author(
+        self, connector, sample_discord_message,
+    ):
+        client = _async_client_with_get()
+        await connector._handle_message(client, "123456789", sample_discord_message)
+
+        incoming = connector.router.route_message.call_args[0][1]
+        assert incoming.raw["guild_id"] == "987654321"
+        assert incoming.raw["author"]["username"] == "test_user"
+        assert incoming.raw["author"]["global_name"] == "Test User"
+
+    @pytest.mark.asyncio
+    async def test_skips_own_messages(
+        self, connector, sample_discord_message,
+    ):
+        """Own messages are filtered in _check_channel before _handle_message."""
+        connector._bot_user_id = "222222222222222222"
+        client = AsyncMock()
+        client.get.return_value = _make_mock_httpx_response(
+            200, [sample_discord_message],
+        )
+
+        with patch.object(connector, "_handle_message") as mock_handle:
+            await connector._check_channel(client, "123456789")
+
+        # _handle_message should never be called for bot's own messages
+        mock_handle.assert_not_called()
+
+        # But the message ID is still tracked (newest-first)
+        assert connector._last_message_ids["123456789"] == "1000000000000000001"
+
+    @pytest.mark.asyncio
+    async def test_does_not_skip_when_bot_user_id_is_none(
+        self, connector, sample_discord_message,
+    ):
+        connector._bot_user_id = None
+        client = _async_client_with_get()
+
+        await connector._handle_message(client, "123456789", sample_discord_message)
+
+        connector.router.route_message.assert_called_once()
+
+
+# ------------------------------------------------------------------
+# Sending outgoing messages
+# ------------------------------------------------------------------
+
+
+class TestOutgoingMessageSending:
+    """Tests for _send_response → Discord HTTP POST."""
+
+    @pytest.mark.asyncio
+    async def test_sends_text_content(self, connector):
+        response = OutgoingMessage(content="hello world")
+        client = AsyncMock()
+        client.post.return_value = _make_mock_httpx_response(200, {})
+
+        await connector._send_response(client, "ch99", response)
+
+        client.post.assert_called_once()
+        call_kwargs = client.post.call_args
+        assert call_kwargs[0][0] == f"{DISCORD_API_BASE}/channels/ch99/messages"
+        assert call_kwargs[1]["json"] == {"content": "hello world"}
+
+    @pytest.mark.asyncio
+    async def test_sends_images_as_embeds(self, connector):
+        response = OutgoingMessage(
+            content="look!",
+            images=["https://example.com/img.png", "https://example.com/img2.jpg"],
+        )
+        client = AsyncMock()
+        client.post.return_value = _make_mock_httpx_response(200, {})
+
+        await connector._send_response(client, "ch99", response)
+
+        payload = client.post.call_args[1]["json"]
+        assert payload["content"] == "look!"
+        assert payload["embeds"] == [
+            {"image": {"url": "https://example.com/img.png"}},
+            {"image": {"url": "https://example.com/img2.jpg"}},
+        ]
+
+    @pytest.mark.asyncio
+    async def test_skips_non_http_images(self, connector):
+        response = OutgoingMessage(
+            images=["/local/path.png", "https://example.com/x.png"],
+        )
+        client = AsyncMock()
+        client.post.return_value = _make_mock_httpx_response(200, {})
+
+        await connector._send_response(client, "ch99", response)
+
+        payload = client.post.call_args[1]["json"]
+        assert payload["embeds"] == [
+            {"image": {"url": "https://example.com/x.png"}},
+        ]
+
+    @pytest.mark.asyncio
+    async def test_sends_buttons_as_components(self, connector):
+        response = OutgoingMessage(
+            buttons=[
+                {"label": "Yes", "action": "yes"},
+                {"label": "No", "action": "no"},
+            ],
+        )
+        client = AsyncMock()
+        client.post.return_value = _make_mock_httpx_response(200, {})
+
+        await connector._send_response(client, "ch99", response)
+
+        payload = client.post.call_args[1]["json"]
+        components = payload["components"]
+        assert len(components) == 1
+        row = components[0]
+        assert row["type"] == 1
+        assert len(row["components"]) == 2
+        assert row["components"][0]["label"] == "Yes"
+        assert row["components"][0]["custom_id"] == "yes"
+        assert row["components"][1]["label"] == "No"
+
+    @pytest.mark.asyncio
+    async def test_buttons_fallback_action_to_label(self, connector):
+        response = OutgoingMessage(buttons=[{"label": "Click Here"}])
+        client = AsyncMock()
+        client.post.return_value = _make_mock_httpx_response(200, {})
+
+        await connector._send_response(client, "ch99", response)
+
+        payload = client.post.call_args[1]["json"]
+        btn = payload["components"][0]["components"][0]
+        assert btn["custom_id"] == "Click Here"
+
+    @pytest.mark.asyncio
+    async def test_buttons_capped_at_5(self, connector):
+        response = OutgoingMessage(
+            buttons=[{"label": f"Btn {i}"} for i in range(10)],
+        )
+        client = AsyncMock()
+        client.post.return_value = _make_mock_httpx_response(200, {})
+
+        await connector._send_response(client, "ch99", response)
+
+        payload = client.post.call_args[1]["json"]
+        row = payload["components"][0]
+        assert len(row["components"]) == 5
+
+    @pytest.mark.asyncio
+    async def test_passthrough_sends_raw_payload(self, connector):
+        response = OutgoingMessage(
+            passthrough=True,
+            passthrough_platform="discord",
+            passthrough_payload={"content": "raw payload", "flags": 4},
+        )
+        client = AsyncMock()
+        client.post.return_value = _make_mock_httpx_response(200, {})
+
+        await connector._send_response(client, "ch99", response)
+
+        client.post.assert_called_once_with(
+            f"{DISCORD_API_BASE}/channels/ch99/messages",
+            headers=connector.headers,
+            json={"content": "raw payload", "flags": 4},
+        )
+
+    @pytest.mark.asyncio
+    async def test_passthrough_ignored_for_non_discord(self, connector):
+        response = OutgoingMessage(
+            passthrough=True,
+            passthrough_platform="telegram",
+            passthrough_payload={"text": "hello"},
+            content="Should use this instead",
+        )
+        client = AsyncMock()
+        client.post.return_value = _make_mock_httpx_response(200, {})
+
+        await connector._send_response(client, "ch99", response)
+
+        payload = client.post.call_args[1]["json"]
+        assert payload == {"content": "Should use this instead"}
+
+    @pytest.mark.asyncio
+    async def test_empty_payload_skips_post(self, connector):
+        response = OutgoingMessage()
+        client = AsyncMock()
+
+        await connector._send_response(client, "ch99", response)
+
+        client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_http_error_does_not_raise(self, connector):
+        """An httpx.RequestError during send is caught and logged, not raised."""
+        response = OutgoingMessage(content="test")
+        client = AsyncMock()
+        client.post.side_effect = httpx.RequestError("connection refused")
+
+        # Should not raise
+        await connector._send_response(client, "ch99", response)
+
+
+# ------------------------------------------------------------------
+# Rate limit handling (HTTP 429)
+# ------------------------------------------------------------------
+
+
+class TestRateLimitHandling:
+    """Tests for 429 rate limit detection and retry-after backoff."""
+
+    @pytest.mark.asyncio
+    async def test_429_sleeps_retry_after(self, connector):
+        client = AsyncMock()
+        client.get.return_value = _make_mock_httpx_response(
+            429, {"retry_after": 3.5},
+        )
+
+        with patch("asyncio.sleep") as mock_sleep:
+            await connector._check_channel(client, "123456789")
+
+        mock_sleep.assert_called_once_with(3.5)
+
+    @pytest.mark.asyncio
+    async def test_429_default_retry_after(self, connector):
+        client = AsyncMock()
+        client.get.return_value = _make_mock_httpx_response(
+            429, {"message": "rate limited"},
+        )
+
+        with patch("asyncio.sleep") as mock_sleep:
+            await connector._check_channel(client, "123456789")
+
+        mock_sleep.assert_called_once_with(5.0)  # _RATE_LIMIT_WINDOW
+
+    @pytest.mark.asyncio
+    async def test_401_auth_failure_logged(self, connector):
+        client = AsyncMock()
+        client.get.return_value = _make_mock_httpx_response(
+            401, {"message": "Unauthorized"},
+        )
+
+        await connector._check_channel(client, "123456789")
+
+        connector.router.route_message.assert_not_called()
+
+
+# ------------------------------------------------------------------
+# Poll loop and reconnection logic
+# ------------------------------------------------------------------
+
+
+class TestPollLoopReconnection:
+    """Tests for _poll_loop resilience and error recovery."""
+
+    @pytest.mark.asyncio
+    async def test_poll_loop_iterates_channels(self, connector):
+        connector._running = True
+        connector.channel_ids = ["ch_a", "ch_b"]
+        call_count = 0
+
+        async def fake_check(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 2:
+                connector._running = False
+
+        with patch.object(connector, "_check_channel", side_effect=fake_check):
+            with patch(
+                "tinyagentos.channel_hub.adapters.discord.httpx.AsyncClient",
+            ) as mock_client_cls:
+                mock_client = AsyncMock()
+                mock_inst = MagicMock()
+                mock_inst.__aenter__ = AsyncMock(return_value=mock_client)
+                mock_inst.__aexit__ = AsyncMock(return_value=None)
+                mock_client_cls.return_value = mock_inst
+                await connector._poll_loop()
+
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_poll_loop_recovers_from_exception(self, connector):
+        connector._running = True
+        connector.channel_ids = ["ch_a"]
+        call_count = 0
+
+        async def fake_check(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise RuntimeError("transient failure")
+            connector._running = False
+
+        with patch.object(connector, "_check_channel", side_effect=fake_check):
+            with patch(
+                "tinyagentos.channel_hub.adapters.discord.httpx.AsyncClient",
+            ) as mock_client_cls:
+                mock_client = AsyncMock()
+                mock_inst = MagicMock()
+                mock_inst.__aenter__ = AsyncMock(return_value=mock_client)
+                mock_inst.__aexit__ = AsyncMock(return_value=None)
+                mock_client_cls.return_value = mock_inst
+                await connector._poll_loop()
+
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_poll_loop_exits_on_cancelled_error(self, connector):
+        connector._running = True
+        connector.channel_ids = ["ch_a"]
+
+        async def fake_check(*args, **kwargs):
+            raise asyncio.CancelledError()
+
+        with patch.object(connector, "_check_channel", side_effect=fake_check):
+            with patch(
+                "tinyagentos.channel_hub.adapters.discord.httpx.AsyncClient",
+            ) as mock_client_cls:
+                mock_client = AsyncMock()
+                mock_inst = MagicMock()
+                mock_inst.__aenter__ = AsyncMock(return_value=mock_client)
+                mock_inst.__aexit__ = AsyncMock(return_value=None)
+                mock_client_cls.return_value = mock_inst
+                await connector._poll_loop()
+
+        # Loop exits cleanly; _running stays True (not changed by loop)
+        assert connector._running is True
+
+    @pytest.mark.asyncio
+    async def test_poll_loop_stops_when_not_running(self, connector):
+        connector._running = False
+
+        with patch.object(connector, "_check_channel") as mock_check:
+            await connector._poll_loop()
+
+        mock_check.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_http_request_error_is_handled(self, connector):
+        client = AsyncMock()
+        client.get.side_effect = httpx.RequestError("connection lost")
+
+        await connector._check_channel(client, "123456789")
+
+        # Should not raise
+
+    @pytest.mark.asyncio
+    async def test_non_200_status_skips_message_processing(self, connector):
+        client = AsyncMock()
+        client.get.return_value = _make_mock_httpx_response(
+            500, {"message": "server error"},
+        )
+
+        await connector._check_channel(client, "123456789")
+
+        connector.router.route_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_200_empty_array_does_nothing(self, connector):
+        client = AsyncMock()
+        client.get.return_value = _make_mock_httpx_response(200, [])
+
+        await connector._check_channel(client, "123456789")
+
+        connector.router.route_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_200_with_messages_routes_them(self, connector):
+        client = AsyncMock()
+        msg = {
+            "id": "m1",
+            "author": {"id": "u1", "username": "Alice"},
+            "content": "hi there",
+            "channel_id": "123456789",
+        }
+        client.get.return_value = _make_mock_httpx_response(200, [msg])
+        client.post.return_value = _make_mock_httpx_response(200, {})
+
+        await connector._check_channel(client, "123456789")
+
+        connector.router.route_message.assert_called_once()
+        incoming = connector.router.route_message.call_args[0][1]
+        assert incoming.text == "hi there"
+        assert incoming.from_name == "Alice"
+
+    @pytest.mark.asyncio
+    async def test_messages_processed_oldest_first(self, connector):
+        client = AsyncMock()
+        msgs = [
+            {"id": "m2", "author": {"id": "u2", "username": "Second"}, "content": "2"},
+            {"id": "m1", "author": {"id": "u1", "username": "First"}, "content": "1"},
+        ]
+        client.get.return_value = _make_mock_httpx_response(200, msgs)
+        client.post.return_value = _make_mock_httpx_response(200, {})
+
+        await connector._check_channel(client, "123456789")
+
+        assert connector.router.route_message.call_count == 2
+        assert connector.router.route_message.call_args_list[0][0][1].id == "m1"
+        assert connector.router.route_message.call_args_list[1][0][1].id == "m2"
+
+    @pytest.mark.asyncio
+    async def test_last_message_id_tracked(self, connector):
+        client = AsyncMock()
+        msgs = [
+            {"id": "m2", "author": {"id": "u2", "username": "B"}, "content": "b"},
+            {"id": "m1", "author": {"id": "u1", "username": "A"}, "content": "a"},
+        ]
+        client.get.return_value = _make_mock_httpx_response(200, msgs)
+        client.post.return_value = _make_mock_httpx_response(200, {})
+
+        await connector._check_channel(client, "ch_abc")
+
+        assert connector._last_message_ids["ch_abc"] == "m2"
+
+
+# ------------------------------------------------------------------
+# Channel name builder
+# ------------------------------------------------------------------
+
+
+class TestChannelNameBuilder:
+    """Tests for the static _build_channel_name helper."""
+
+    def test_with_guild(self):
+        name = DiscordConnector._build_channel_name("guild1", "chan1")
+        assert name == "discord:guild1:chan1"
+
+    def test_without_guild(self):
+        name = DiscordConnector._build_channel_name("", "dm1")
+        assert name == "discord:dm:dm1"
+
+
+# ------------------------------------------------------------------
+# Router integration (response → send)
+# ------------------------------------------------------------------
+
+
+class TestRouterResponseToSend:
+    """Tests that route_message responses are forwarded to _send_response."""
+
+    @pytest.mark.asyncio
+    async def test_router_response_sent_to_channel(
+        self, connector, sample_discord_message,
+    ):
+        connector.router.route_message.return_value = OutgoingMessage(
+            content="response",
+        )
+
+        client = AsyncMock()
+        client.post.return_value = _make_mock_httpx_response(200, {})
+
+        await connector._handle_message(client, "chX", sample_discord_message)
+
+        client.post.assert_called_once()
+        call_args = client.post.call_args
+        assert call_args[0][0] == f"{DISCORD_API_BASE}/channels/chX/messages"
+
+    @pytest.mark.asyncio
+    async def test_none_response_does_not_send(
+        self, connector, sample_discord_message,
+    ):
+        connector.router.route_message.return_value = None
+        client = AsyncMock()
+
+        await connector._handle_message(client, "chX", sample_discord_message)
+
+        client.post.assert_not_called()

--- a/tests/channel_hub/test_discord.py
+++ b/tests/channel_hub/test_discord.py
@@ -126,9 +126,9 @@ class TestInitialization:
         assert isinstance(connector._last_message_ids, dict)
         assert len(connector._last_message_ids) == 0
 
-    def test_stores_per_channel_semaphores(self, connector):
-        assert isinstance(connector._channel_sem, dict)
-        assert len(connector._channel_sem) == 0
+    def test_initial_bot_user_id_none(self, connector):
+        """_bot_user_id is None until start() resolves it from /users/@me."""
+        assert connector._bot_user_id is None
 
 
 # ------------------------------------------------------------------
@@ -159,6 +159,7 @@ class TestStartStop:
 
     @pytest.mark.asyncio
     async def test_start_resolves_bot_user_id_failure(self, connector):
+        """A failed /users/@me call (e.g. bad token) raises RuntimeError."""
         with patch(
             "tinyagentos.channel_hub.adapters.discord.httpx.AsyncClient"
         ) as mock_client_cls:
@@ -168,9 +169,9 @@ class TestStartStop:
             )
             mock_client_cls.return_value.__aenter__.return_value = mock_client
 
-            await connector.start()
+            with pytest.raises(RuntimeError, match="returned an empty user ID"):
+                await connector.start()
 
-        assert connector._running is True
         assert connector._bot_user_id is None
 
     @pytest.mark.asyncio

--- a/tests/test_channel_hub_new.py
+++ b/tests/test_channel_hub_new.py
@@ -272,6 +272,113 @@ class TestDiscordConnector:
 
 
 # ---------------------------------------------------------------------------
+# Discord Adapter (channel_hub/adapters/discord.py)
+# Tests for the reviewed findings: start() raises on missing bot ID + no semaphore.
+# ---------------------------------------------------------------------------
+
+class TestDiscordAdapter:
+    @pytest.mark.asyncio
+    async def test_start_raises_on_network_error(self):
+        """start() raises RuntimeError when the /users/@me request fails."""
+        from tinyagentos.channel_hub.adapters.discord import DiscordConnector
+
+        router = MagicMock()
+        connector = DiscordConnector(
+            bot_token="bad_token", agent_name="test", router=router, channel_ids=["ch1"],
+        )
+
+        with patch("tinyagentos.channel_hub.adapters.discord.httpx.AsyncClient") as mock_httpx:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.get = AsyncMock(side_effect=Exception("network error"))
+            mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+            mock_client_instance.__aexit__ = AsyncMock(return_value=False)
+            mock_httpx.return_value = mock_client_instance
+
+            with pytest.raises(RuntimeError, match="could not resolve bot user ID"):
+                await connector.start()
+
+    @pytest.mark.asyncio
+    async def test_start_raises_on_empty_user_id(self):
+        """start() raises RuntimeError when /users/@me returns no id."""
+        from tinyagentos.channel_hub.adapters.discord import DiscordConnector
+
+        router = MagicMock()
+        connector = DiscordConnector(
+            bot_token="bad_token", agent_name="test", router=router, channel_ids=["ch1"],
+        )
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {}  # no "id" field
+
+        with patch("tinyagentos.channel_hub.adapters.discord.httpx.AsyncClient") as mock_httpx:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.get = AsyncMock(return_value=mock_resp)
+            mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+            mock_client_instance.__aexit__ = AsyncMock(return_value=False)
+            mock_httpx.return_value = mock_client_instance
+
+            with pytest.raises(RuntimeError, match="empty user ID"):
+                await connector.start()
+
+    @pytest.mark.asyncio
+    async def test_start_succeeds_with_valid_token(self):
+        """start() sets _bot_user_id and starts the poll task when token is valid."""
+        from tinyagentos.channel_hub.adapters.discord import DiscordConnector
+
+        router = MagicMock()
+        connector = DiscordConnector(
+            bot_token="good_token", agent_name="test", router=router, channel_ids=["ch1"],
+        )
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"id": "bot_id_42"}
+
+        with patch.object(connector, "_poll_loop", new_callable=AsyncMock):
+            with patch("tinyagentos.channel_hub.adapters.discord.httpx.AsyncClient") as mock_httpx:
+                mock_client_instance = AsyncMock()
+                mock_client_instance.get = AsyncMock(return_value=mock_resp)
+                mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+                mock_client_instance.__aexit__ = AsyncMock(return_value=False)
+                mock_httpx.return_value = mock_client_instance
+
+                await connector.start()
+                assert connector._bot_user_id == "bot_id_42"
+                assert connector._running is True
+
+                await connector.stop()
+                assert connector._running is False
+
+    @pytest.mark.asyncio
+    async def test_check_channel_no_semaphore(self):
+        """_check_channel works without any semaphore — channels are polled sequentially."""
+        from tinyagentos.channel_hub.adapters.discord import DiscordConnector
+
+        mock_router = AsyncMock()
+        mock_router.route_message = AsyncMock(return_value=None)
+        connector = DiscordConnector(
+            bot_token="fake", agent_name="bot1", router=mock_router, channel_ids=["ch1"],
+        )
+        connector._bot_user_id = "bot_id_99"
+
+        assert not hasattr(connector, "_channel_sem"), \
+            "_channel_sem must not exist on the adapter"
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = [
+            {"id": "m1", "author": {"id": "user1", "username": "Jay"}, "content": "hello"},
+        ]
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_resp)
+
+        await connector._check_channel(mock_client, "ch1")
+        assert mock_router.route_message.call_count == 1
+
+
+# ---------------------------------------------------------------------------
 # WebChat Connector
 # ---------------------------------------------------------------------------
 

--- a/tinyagentos/channel_hub/adapters/discord.py
+++ b/tinyagentos/channel_hub/adapters/discord.py
@@ -1,0 +1,279 @@
+"""Discord channel adapter.
+
+Connects to Discord via bot token and polls channels for new messages,
+emitting them as channel-hub messages through the message router.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import httpx
+
+from tinyagentos.channel_hub.message import IncomingMessage, OutgoingMessage
+
+logger = logging.getLogger(__name__)
+
+DISCORD_API_BASE = "https://discord.com/api/v10"
+# Discord rate limit: 5 requests per 5 seconds per channel
+_RATE_LIMIT_WINDOW = 5.0
+_RATE_LIMIT_MAX = 5
+
+
+class DiscordConnector:
+    """Connector that polls Discord channels via HTTP API and routes messages
+    through the channel-hub message router.
+
+    Uses Discord's Get Channel Messages endpoint with after-id pagination
+    to catch new messages. Respects Discord's rate limits (5 requests per
+    5 seconds per channel).
+
+    Filters:
+      channel_ids: Only poll these channel IDs. If empty/unset, polls none.
+    """
+
+    def __init__(
+        self,
+        bot_token: str,
+        agent_name: str,
+        router,
+        channel_ids: list[str] | None = None,
+    ):
+        self.bot_token = bot_token
+        self.agent_name = agent_name
+        self.router = router
+        self.channel_ids = channel_ids or []
+        self.headers = {"Authorization": f"Bot {bot_token}"}
+        self._running = False
+        self._task: asyncio.Task | None = None
+        self._bot_user_id: str | None = None
+        # Track last-seen message ID per channel for polling
+        self._last_message_ids: dict[str, str] = {}
+        # Per-channel rate limiting: 5 requests per 5-second window
+        self._channel_sem: dict[str, asyncio.Semaphore] = {}
+
+    async def start(self) -> None:
+        """Start the Discord polling loop.
+
+        Fetches the bot's user ID so we can filter out our own messages,
+        then begins the poll loop.
+        """
+        self._running = True
+        # Resolve bot user ID
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                resp = await client.get(
+                    f"{DISCORD_API_BASE}/users/@me", headers=self.headers,
+                )
+                if resp.status_code == 200:
+                    self._bot_user_id = resp.json().get("id")
+        except Exception as exc:
+            logger.warning("Could not resolve bot user ID: %s", exc)
+
+        self._task = asyncio.create_task(self._poll_loop())
+        logger.info(
+            "Discord connector started for agent '%s', %d channel(s)",
+            self.agent_name, len(self.channel_ids),
+        )
+
+    async def stop(self) -> None:
+        """Stop the polling loop and cancel the background task."""
+        self._running = False
+        if self._task is not None:
+            self._task.cancel()
+            self._task = None
+
+    # ------------------------------------------------------------------
+    # Poll loop
+    # ------------------------------------------------------------------
+
+    async def _poll_loop(self) -> None:
+        """Poll Discord channels every 2 seconds."""
+        async with httpx.AsyncClient(timeout=15) as client:
+            while self._running:
+                try:
+                    for channel_id in self.channel_ids:
+                        await self._check_channel(client, channel_id)
+                    await asyncio.sleep(2)
+                except asyncio.CancelledError:
+                    break
+                except Exception as exc:
+                    logger.error("Discord poll error: %s", exc)
+                    await asyncio.sleep(5)
+
+    async def _check_channel(
+        self, client: httpx.AsyncClient, channel_id: str,
+    ) -> None:
+        """Fetch new messages from a single Discord channel.
+
+        Uses after-id pagination so we only see messages newer than the
+        last one we processed.  Respects per-channel rate limits via a
+        semaphore (5 concurrent requests per 5-second window).
+        """
+        if channel_id not in self._channel_sem:
+            self._channel_sem[channel_id] = asyncio.Semaphore(_RATE_LIMIT_MAX)
+
+        async with self._channel_sem[channel_id]:
+            params: dict[str, str | int] = {"limit": 10}
+            last_id = self._last_message_ids.get(channel_id)
+            if last_id:
+                params["after"] = last_id
+
+            try:
+                resp = await client.get(
+                    f"{DISCORD_API_BASE}/channels/{channel_id}/messages",
+                    headers=self.headers,
+                    params=params,
+                )
+            except httpx.RequestError as exc:
+                logger.error(
+                    "Discord HTTP error on channel %s: %s", channel_id, exc,
+                )
+                return
+
+            if resp.status_code == 429:
+                retry_after = float(
+                    resp.json().get("retry_after", _RATE_LIMIT_WINDOW),
+                )
+                logger.warning(
+                    "Discord rate limited on channel %s, waiting %.1fs",
+                    channel_id, retry_after,
+                )
+                await asyncio.sleep(retry_after)
+                return
+
+            if resp.status_code == 401:
+                logger.error(
+                    "Discord auth failure on channel %s — bad token?", channel_id,
+                )
+                return
+
+            if resp.status_code != 200:
+                logger.debug(
+                    "Discord channel %s returned %d", channel_id, resp.status_code,
+                )
+                return
+
+            messages = resp.json()
+            if not messages:
+                return
+
+            # Update last-seen ID (API returns newest first)
+            self._last_message_ids[channel_id] = messages[0]["id"]
+
+            # Process in chronological order (oldest first)
+            for msg in reversed(messages):
+                if msg.get("author", {}).get("id") == self._bot_user_id:
+                    continue  # Skip our own messages
+                await self._handle_message(client, channel_id, msg)
+
+    # ------------------------------------------------------------------
+    # Message handling
+    # ------------------------------------------------------------------
+
+    async def _handle_message(
+        self,
+        client: httpx.AsyncClient,
+        channel_id: str,
+        msg: dict,
+    ) -> None:
+        """Route a single Discord message through the message router."""
+        guild_id = msg.get("guild_id", "")
+        author = msg.get("author", {})
+
+        incoming = IncomingMessage(
+            id=msg["id"],
+            from_id=author.get("id", ""),
+            from_name=author.get("username") or author.get("global_name", "User"),
+            platform="discord",
+            channel_id=channel_id,
+            channel_name=self._build_channel_name(guild_id, channel_id),
+            text=msg.get("content", ""),
+            raw={
+                "source": "discord",
+                "channel_id": channel_id,
+                "guild_id": guild_id,
+                "author": {
+                    "id": author.get("id"),
+                    "username": author.get("username"),
+                    "global_name": author.get("global_name"),
+                },
+                "payload": msg,
+            },
+        )
+
+        response = await self.router.route_message(self.agent_name, incoming)
+        if response is not None:
+            await self._send_response(client, channel_id, response)
+
+    async def _send_response(
+        self,
+        client: httpx.AsyncClient,
+        channel_id: str,
+        response: OutgoingMessage,
+    ) -> None:
+        """Send a response back to a Discord channel.
+
+        Supports passthrough payloads, content, embeds (images), and
+        interactive components (buttons).
+        """
+        if response.passthrough and response.passthrough_platform == "discord":
+            payload = response.passthrough_payload
+            await client.post(
+                f"{DISCORD_API_BASE}/channels/{channel_id}/messages",
+                headers=self.headers,
+                json=payload,
+            )
+            return
+
+        payload: dict[str, object] = {}
+
+        if response.content:
+            payload["content"] = response.content
+
+        if response.images:
+            payload["embeds"] = [
+                {"image": {"url": img}}
+                for img in response.images
+                if img.startswith("http")
+            ]
+
+        if response.buttons:
+            payload["components"] = [
+                {
+                    "type": 1,  # ACTION_ROW
+                    "components": [
+                        {
+                            "type": 2,   # BUTTON
+                            "style": 1,  # PRIMARY
+                            "label": b["label"],
+                            "custom_id": b.get("action", b["label"]),
+                        }
+                        for b in response.buttons[:5]  # Discord max 5 per row
+                    ],
+                },
+            ]
+
+        if payload:
+            try:
+                await client.post(
+                    f"{DISCORD_API_BASE}/channels/{channel_id}/messages",
+                    headers=self.headers,
+                    json=payload,
+                )
+            except httpx.RequestError as exc:
+                logger.error(
+                    "Failed to send Discord response to %s: %s", channel_id, exc,
+                )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _build_channel_name(guild_id: str, channel_id: str) -> str:
+        """Build a human-readable channel name for logging."""
+        if guild_id:
+            return f"discord:{guild_id}:{channel_id}"
+        return f"discord:dm:{channel_id}"

--- a/tinyagentos/channel_hub/adapters/discord.py
+++ b/tinyagentos/channel_hub/adapters/discord.py
@@ -16,9 +16,8 @@ from tinyagentos.channel_hub.message import IncomingMessage, OutgoingMessage
 logger = logging.getLogger(__name__)
 
 DISCORD_API_BASE = "https://discord.com/api/v10"
-# Discord rate limit: 5 requests per 5 seconds per channel
+# Default retry delay when Discord returns 429 (used if retry_after is absent)
 _RATE_LIMIT_WINDOW = 5.0
-_RATE_LIMIT_MAX = 5
 
 
 class DiscordConnector:
@@ -50,17 +49,20 @@ class DiscordConnector:
         self._bot_user_id: str | None = None
         # Track last-seen message ID per channel for polling
         self._last_message_ids: dict[str, str] = {}
-        # Per-channel rate limiting: 5 requests per 5-second window
-        self._channel_sem: dict[str, asyncio.Semaphore] = {}
 
     async def start(self) -> None:
         """Start the Discord polling loop.
 
         Fetches the bot's user ID so we can filter out our own messages,
         then begins the poll loop.
+
+        Raises:
+            RuntimeError: If the bot user ID cannot be resolved (bad token,
+                network error, etc.).  Without it the connector cannot filter
+                its own messages, which would cause an infinite response loop.
         """
         self._running = True
-        # Resolve bot user ID
+        # Resolve bot user ID — required to skip the bot's own messages.
         try:
             async with httpx.AsyncClient(timeout=10) as client:
                 resp = await client.get(
@@ -69,7 +71,16 @@ class DiscordConnector:
                 if resp.status_code == 200:
                     self._bot_user_id = resp.json().get("id")
         except Exception as exc:
-            logger.warning("Could not resolve bot user ID: %s", exc)
+            raise RuntimeError(
+                f"Discord connector for '{self.agent_name}': could not resolve "
+                f"bot user ID — check your token. ({exc})"
+            ) from exc
+
+        if not self._bot_user_id:
+            raise RuntimeError(
+                f"Discord connector for '{self.agent_name}': /users/@me returned "
+                f"an empty user ID — token may be invalid."
+            )
 
         self._task = asyncio.create_task(self._poll_loop())
         logger.info(
@@ -108,65 +119,61 @@ class DiscordConnector:
         """Fetch new messages from a single Discord channel.
 
         Uses after-id pagination so we only see messages newer than the
-        last one we processed.  Respects per-channel rate limits via a
-        semaphore (5 concurrent requests per 5-second window).
+        last one we processed.  Rate limiting is handled reactively: if
+        Discord returns 429 we back off for retry_after seconds.
         """
-        if channel_id not in self._channel_sem:
-            self._channel_sem[channel_id] = asyncio.Semaphore(_RATE_LIMIT_MAX)
+        params: dict[str, str | int] = {"limit": 10}
+        last_id = self._last_message_ids.get(channel_id)
+        if last_id:
+            params["after"] = last_id
 
-        async with self._channel_sem[channel_id]:
-            params: dict[str, str | int] = {"limit": 10}
-            last_id = self._last_message_ids.get(channel_id)
-            if last_id:
-                params["after"] = last_id
+        try:
+            resp = await client.get(
+                f"{DISCORD_API_BASE}/channels/{channel_id}/messages",
+                headers=self.headers,
+                params=params,
+            )
+        except httpx.RequestError as exc:
+            logger.error(
+                "Discord HTTP error on channel %s: %s", channel_id, exc,
+            )
+            return
 
-            try:
-                resp = await client.get(
-                    f"{DISCORD_API_BASE}/channels/{channel_id}/messages",
-                    headers=self.headers,
-                    params=params,
-                )
-            except httpx.RequestError as exc:
-                logger.error(
-                    "Discord HTTP error on channel %s: %s", channel_id, exc,
-                )
-                return
+        if resp.status_code == 429:
+            retry_after = float(
+                resp.json().get("retry_after", _RATE_LIMIT_WINDOW),
+            )
+            logger.warning(
+                "Discord rate limited on channel %s, waiting %.1fs",
+                channel_id, retry_after,
+            )
+            await asyncio.sleep(retry_after)
+            return
 
-            if resp.status_code == 429:
-                retry_after = float(
-                    resp.json().get("retry_after", _RATE_LIMIT_WINDOW),
-                )
-                logger.warning(
-                    "Discord rate limited on channel %s, waiting %.1fs",
-                    channel_id, retry_after,
-                )
-                await asyncio.sleep(retry_after)
-                return
+        if resp.status_code == 401:
+            logger.error(
+                "Discord auth failure on channel %s — bad token?", channel_id,
+            )
+            return
 
-            if resp.status_code == 401:
-                logger.error(
-                    "Discord auth failure on channel %s — bad token?", channel_id,
-                )
-                return
+        if resp.status_code != 200:
+            logger.debug(
+                "Discord channel %s returned %d", channel_id, resp.status_code,
+            )
+            return
 
-            if resp.status_code != 200:
-                logger.debug(
-                    "Discord channel %s returned %d", channel_id, resp.status_code,
-                )
-                return
+        messages = resp.json()
+        if not messages:
+            return
 
-            messages = resp.json()
-            if not messages:
-                return
+        # Update last-seen ID (API returns newest first)
+        self._last_message_ids[channel_id] = messages[0]["id"]
 
-            # Update last-seen ID (API returns newest first)
-            self._last_message_ids[channel_id] = messages[0]["id"]
-
-            # Process in chronological order (oldest first)
-            for msg in reversed(messages):
-                if msg.get("author", {}).get("id") == self._bot_user_id:
-                    continue  # Skip our own messages
-                await self._handle_message(client, channel_id, msg)
+        # Process in chronological order (oldest first)
+        for msg in reversed(messages):
+            if msg.get("author", {}).get("id") == self._bot_user_id:
+                continue  # Skip our own messages
+            await self._handle_message(client, channel_id, msg)
 
     # ------------------------------------------------------------------
     # Message handling


### PR DESCRIPTION
## Summary

Adds a Discord channel adapter that integrates with the channel_hub system, enabling agents to communicate through Discord channels.

Closes #335

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Discord channel integration: poll messages, route to agents, and send replies with text, images, and interactive buttons; skips bot-authored messages and handles rate limiting/auth.
* **Tests**
  * Comprehensive test suite added covering startup, message handling, outgoing responses, rate-limit/auth behavior, and poll-loop resilience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->