### PR TITLE
fix(browser): serve proxied HTML as utf-8 (fixes mojibake) + charset detection

### DIFF
--- a/tests/routes/desktop_browser/test_proxy_fetch.py
+++ b/tests/routes/desktop_browser/test_proxy_fetch.py
@@ -86,6 +86,71 @@ class TestProxyFetchHtml:
 
 
 @pytest.mark.asyncio
+class TestProxyFetchEncoding:
+    @respx.mock
+    async def test_utf8_page_served_without_mojibake(self, client):
+        """A UTF-8 page with © / nbsp is served as UTF-8 — no `Â©` mojibake."""
+        body = (
+            "<html><head><meta charset=\"utf-8\"></head>"
+            "<body><p>© 2026 Example Co</p></body></html>"
+        ).encode("utf-8")
+        respx.get("http://example.com/utf8").mock(
+            return_value=Response(
+                200, content=body, headers={"content-type": "text/html; charset=utf-8"},
+            )
+        )
+
+        with patch(
+            "tinyagentos.routes.desktop_browser.ssrf.socket.getaddrinfo",
+            return_value=[(2, 1, 6, "", ("93.184.216.34", 0))],
+        ):
+            resp = await client.get(
+                "/api/desktop/browser/proxy",
+                params={"profile_id": "personal", "url": "http://example.com/utf8"},
+            )
+
+        assert resp.status_code == 200
+        # Served as UTF-8.
+        ct = next(v for k, v in resp.headers.items() if k.lower() == "content-type")
+        assert "charset=utf-8" in ct.lower()
+        # Real UTF-8 © bytes present; the Latin-1 mojibake signature is not.
+        assert "©".encode("utf-8") in resp.content
+        assert "Â©".encode("utf-8") not in resp.content
+        resp.content.decode("utf-8")
+
+    @respx.mock
+    async def test_latin1_page_decoded_and_served_as_utf8(self, client):
+        """Upstream ISO-8859-1 charset must not leak into our response label."""
+        # Raw 0xa9 is © in Latin-1.
+        body = (
+            b"<html><head><meta charset=\"iso-8859-1\"></head>"
+            b"<body><p>\xa9 2026 Example</p></body></html>"
+        )
+        respx.get("http://example.com/latin1").mock(
+            return_value=Response(
+                200, content=body,
+                headers={"content-type": "text/html; charset=ISO-8859-1"},
+            )
+        )
+
+        with patch(
+            "tinyagentos.routes.desktop_browser.ssrf.socket.getaddrinfo",
+            return_value=[(2, 1, 6, "", ("93.184.216.34", 0))],
+        ):
+            resp = await client.get(
+                "/api/desktop/browser/proxy",
+                params={"profile_id": "personal", "url": "http://example.com/latin1"},
+            )
+
+        assert resp.status_code == 200
+        ct = next(v for k, v in resp.headers.items() if k.lower() == "content-type")
+        assert "charset=utf-8" in ct.lower()
+        assert "iso-8859-1" not in ct.lower()
+        # Body decodes cleanly as UTF-8 with the correct glyph.
+        assert "© 2026 Example" in resp.content.decode("utf-8")
+
+
+@pytest.mark.asyncio
 class TestProxyFetchNonHtml:
     @respx.mock
     async def test_passes_through_image_unchanged(self, client):

--- a/tests/routes/desktop_browser/test_rewriter.py
+++ b/tests/routes/desktop_browser/test_rewriter.py
@@ -128,3 +128,51 @@ class TestNonHtmlInput:
         # but our rewriter should be defensive about empty/binary input
         out = rewrite_html(b"", base_url="https://example.com/", proxy=_proxy)
         assert out == b""
+
+
+class TestCharsetHandling:
+    def test_utf8_copyright_and_nbsp_survive_roundtrip(self):
+        from tinyagentos.routes.desktop_browser.rewriter import rewrite_html
+
+        html = (
+            "<html><head><meta charset=\"utf-8\"></head>"
+            "<body><p>© 2026 Example Co</p></body></html>"
+        ).encode("utf-8")
+        out = rewrite_html(
+            html, base_url="https://example.com/", proxy=_proxy, charset="utf-8"
+        )
+        # Real UTF-8 bytes for © and nbsp present; no Latin-1 mojibake.
+        assert "©".encode("utf-8") in out
+        assert " ".encode("utf-8") in out
+        # The mojibake signature (Â©) would be the bytes for U+00C2 U+00A9.
+        assert "Â©".encode("utf-8") not in out
+        # Output is valid UTF-8.
+        out.decode("utf-8")
+
+    def test_latin1_page_decoded_with_declared_charset(self):
+        from tinyagentos.routes.desktop_browser.rewriter import rewrite_html
+
+        # Raw 0xa9 is © in ISO-8859-1.
+        html = (
+            b"<html><head><meta charset=\"iso-8859-1\"></head>"
+            b"<body><p>\xa9 2026</p></body></html>"
+        )
+        out = rewrite_html(
+            html, base_url="https://example.com/", proxy=_proxy, charset="ISO-8859-1"
+        )
+        text = out.decode("utf-8")
+        assert "© 2026" in text
+
+    def test_meta_charset_normalized_to_utf8(self):
+        from tinyagentos.routes.desktop_browser.rewriter import rewrite_html
+
+        html = (
+            b"<html><head><meta charset=\"iso-8859-1\"></head>"
+            b"<body><p>x</p></body></html>"
+        )
+        out = rewrite_html(
+            html, base_url="https://example.com/", proxy=_proxy, charset="ISO-8859-1"
+        )
+        lower = out.lower()
+        assert b"charset=\"utf-8\"" in lower
+        assert b"iso-8859-1" not in lower

--- a/tinyagentos/routes/desktop_browser/proxy.py
+++ b/tinyagentos/routes/desktop_browser/proxy.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 import time
 from pathlib import Path
 from typing import Any
@@ -57,12 +58,55 @@ _HOP_TIMEOUT = 5.0      # seconds — per-operation (connect + read) limit per h
 _MAX_RESPONSE_BYTES = 10 * 1024 * 1024  # 10 MB hard cap
 
 # Headers we strip from upstream responses before returning to the client.
+# `content-type` is stripped here and re-set from `media_type` on the
+# response. This is critical: for HTML we re-serialize the upstream body
+# as UTF-8 bytes (see rewriter/injector), so carrying through the upstream
+# charset (e.g. `text/html; charset=ISO-8859-1`) would mislabel UTF-8 bytes
+# and the iframe would decode them as Latin-1 — the classic `Â©` mojibake.
 _STRIP_RESPONSE_HEADERS = frozenset({
     "set-cookie", "set-cookie2",
     "content-security-policy", "content-security-policy-report-only",
     "x-frame-options",
     "content-length", "transfer-encoding", "content-encoding",
+    "content-type",
 })
+
+# charset= token in a Content-Type header value.
+_CT_CHARSET_RE = re.compile(r"charset\s*=\s*([\"']?)([^\";,\s]+)\1", re.IGNORECASE)
+# <meta charset="..."> and <meta http-equiv="Content-Type" content="...charset=...">
+_META_CHARSET_RE = re.compile(
+    rb"""<meta[^>]+charset\s*=\s*["']?\s*([a-zA-Z0-9_\-]+)""",
+    re.IGNORECASE,
+)
+
+
+def _detect_charset(content_type: str, body: bytes) -> str:
+    """Resolve the charset of an upstream HTML response.
+
+    Precedence: Content-Type header charset, then a <meta charset> /
+    <meta http-equiv> declaration in the first chunk of the body, else
+    UTF-8. The returned label is validated against the codec registry;
+    an unknown label falls back to UTF-8.
+    """
+    label = ""
+    m = _CT_CHARSET_RE.search(content_type or "")
+    if m:
+        label = m.group(2).strip()
+    if not label:
+        # Only sniff the head of the document — meta charset must appear
+        # within the first 1024 bytes per the HTML spec.
+        mm = _META_CHARSET_RE.search(body[:2048])
+        if mm:
+            label = mm.group(1).decode("ascii", "ignore").strip()
+    if not label:
+        return "utf-8"
+    try:
+        import codecs
+
+        codecs.lookup(label)
+    except (LookupError, ValueError):
+        return "utf-8"
+    return label
 
 
 @router.get("/api/desktop/browser/proxy")
@@ -202,8 +246,10 @@ async def proxy_get(
         def _proxy_url(absolute: str) -> str:
             return f"{proxy_prefix}{quote(absolute, safe='')}"
 
+        charset = _detect_charset(content_type, response.content)
         rewritten = rewrite_html(
             response.content, base_url=str(response.url), proxy=_proxy_url,
+            charset=charset,
         )
 
         ws_scheme = "wss" if request.url.scheme == "https" else "ws"
@@ -256,7 +302,7 @@ async def proxy_get(
             content=injected,
             status_code=response.status_code,
             headers=out_headers,
-            media_type="text/html",
+            media_type="text/html; charset=utf-8",
         )
 
     # Non-HTML — pass through bytes verbatim

--- a/tinyagentos/routes/desktop_browser/rewriter.py
+++ b/tinyagentos/routes/desktop_browser/rewriter.py
@@ -53,8 +53,16 @@ def rewrite_html(
     *,
     base_url: str,
     proxy: Callable[[str], str],
+    charset: str = "utf-8",
 ) -> bytes:
     """Rewrite all URL-bearing references in `html_bytes` to proxied form.
+
+    `charset` is the encoding the upstream bytes are actually in (resolved
+    by the proxy from the Content-Type header / <meta charset>). We feed it
+    to the lxml parser so non-UTF-8 pages (Latin-1, windows-1252, …) decode
+    correctly. The output is always re-serialized as UTF-8 bytes, and any
+    stale `<meta charset>` is normalized to utf-8 so the iframe never
+    re-guesses the encoding.
 
     Returns the rewritten HTML as bytes. Empty input returns empty.
     """
@@ -63,8 +71,9 @@ def rewrite_html(
 
     # lxml is forgiving — even malformed HTML produces a tree. We use
     # `fromstring` rather than `parse` because we're working with bytes
-    # in memory, and we explicitly handle the encoding via the parser.
-    parser = lxml_html.HTMLParser(encoding="utf-8")
+    # in memory. The parser's `encoding` overrides any <meta charset> in
+    # the document, so we pass the charset the proxy already resolved.
+    parser = lxml_html.HTMLParser(encoding=charset or "utf-8")
     try:
         tree = lxml_html.fromstring(html_bytes, parser=parser)
     except Exception:
@@ -79,8 +88,27 @@ def rewrite_html(
     _rewrite_inline_styles(tree, base_url=base_url, proxy=proxy)
     _rewrite_style_tags(tree, base_url=base_url, proxy=proxy)
     _rewrite_meta_refresh(tree, base_url=base_url, proxy=proxy)
+    _normalize_meta_charset(tree)
 
     return lxml_html.tostring(tree, encoding="utf-8")
+
+
+def _normalize_meta_charset(tree) -> None:
+    """Rewrite any <meta charset> / <meta http-equiv content-type> to utf-8.
+
+    The body is re-serialized as UTF-8, so a leftover declaration of the
+    original charset would tell the iframe to decode UTF-8 bytes as, say,
+    Latin-1 — reintroducing mojibake even with a correct response header.
+    """
+    for meta in tree.iter("meta"):
+        if meta.get("charset") is not None:
+            meta.set("charset", "utf-8")
+            continue
+        http_equiv = (meta.get("http-equiv") or "").lower()
+        if http_equiv == "content-type":
+            content = meta.get("content") or ""
+            if "charset" in content.lower():
+                meta.set("content", "text/html; charset=utf-8")
 
 
 def _should_rewrite(url: str) -> bool:


### PR DESCRIPTION
Fixes the mojibake (`Â©`, `Â`) seen rendering pages in the Browser app.

**Root cause:** the proxy carried through the upstream `Content-Type` charset (e.g. Google's `ISO-8859-1`) while the rewriter re-serializes the DOM as UTF-8 bytes (`lxml.tostring(encoding="utf-8")`). UTF-8 bytes served under a Latin-1 label → the iframe decodes `©` (0xC2 0xA9) as `Â©`. The parser was also hardcoded to UTF-8, corrupting genuinely Latin-1 pages.

**Fix:** strip the upstream `content-type`, serve rewritten HTML as `text/html; charset=utf-8`, detect the real upstream charset (Content-Type → `<meta charset>` → utf-8) and feed it to the lxml parser, and normalize `<meta charset>` in the output to utf-8 so the iframe can't re-guess. Adds 3 rewriter + 2 proxy integration tests.

Note: this does NOT address JS-heavy sites rendering with broken images/styling — that's an architectural matter (strict CSP blocks inline JS; server-side rewrite can't see JS-computed URLs) tracked separately.