### PR TITLE
feat(#336): GitHub webhook receiver with signature verification

### DIFF
--- a/tests/test_gh_webhook.py
+++ b/tests/test_gh_webhook.py
@@ -1,0 +1,194 @@
+"""Tests for GitHub webhook receiver endpoint."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+
+import pytest
+
+
+def _make_signature(secret: str, body: bytes) -> str:
+    return "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+def _build_payload(event_type: str, action: str = "opened", **overrides) -> dict:
+    base = {
+        "action": action,
+        "repository": {"full_name": "test-owner/test-repo", "html_url": "https://github.com/test-owner/test-repo"},
+        "sender": {"login": "test-user"},
+    }
+    if event_type == "pull_request":
+        base["pull_request"] = {"html_url": "https://github.com/test-owner/test-repo/pull/1"}
+    elif event_type == "issue_comment":
+        base["issue"] = {"html_url": "https://github.com/test-owner/test-repo/issues/1"}
+        base["comment"] = {"html_url": "https://github.com/test-owner/test-repo/issues/1#issuecomment-1"}
+    elif event_type == "pull_request_review":
+        base["pull_request"] = {"html_url": "https://github.com/test-owner/test-repo/pull/1"}
+        base["review"] = {"html_url": "https://github.com/test-owner/test-repo/pull/1#pullrequestreview-1"}
+    elif event_type == "push":
+        base["compare"] = "https://github.com/test-owner/test-repo/compare/abc...def"
+        base["commits"] = [{"id": "abc123", "message": "test commit"}]
+    elif event_type == "check_run":
+        base["check_run"] = {"name": "CI", "status": "completed"}
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.asyncio
+async def test_valid_signature_returns_200(client, monkeypatch, tmp_data_dir):
+    monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", "test-secret")
+    body = json.dumps(_build_payload("pull_request")).encode()
+    sig = _make_signature("test-secret", body)
+    r = await client.post("/api/webhooks/github", content=body, headers={
+        "X-Hub-Signature-256": sig, "X-GitHub-Event": "pull_request", "Content-Type": "application/json"})
+    assert r.status_code == 200
+    assert r.json() == {"status": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_missing_signature_returns_403_verified(client, monkeypatch):
+    monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", "test-secret")
+    body = json.dumps(_build_payload("pull_request")).encode()
+    r = await client.post("/api/webhooks/github", content=body, headers={
+        "X-GitHub-Event": "pull_request", "Content-Type": "application/json"})
+    assert r.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_invalid_signature_returns_403(client, monkeypatch):
+    monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", "test-secret")
+    body = json.dumps(_build_payload("pull_request")).encode()
+    r = await client.post("/api/webhooks/github", content=body, headers={
+        "X-Hub-Signature-256": "sha256=deadbeef", "X-GitHub-Event": "pull_request", "Content-Type": "application/json"})
+    assert r.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_no_secret_accepts_events_dev_mode(client, monkeypatch):
+    monkeypatch.delenv("GITHUB_WEBHOOK_SECRET", raising=False)
+    body = json.dumps(_build_payload("pull_request")).encode()
+    r = await client.post("/api/webhooks/github", content=body, headers={
+        "X-GitHub-Event": "pull_request", "Content-Type": "application/json"})
+    assert r.status_code == 200
+    assert r.json() == {"status": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_event_written_to_log_file(client, monkeypatch, tmp_data_dir):
+    monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", "test-secret")
+    body = json.dumps(_build_payload("pull_request", action="closed")).encode()
+    sig = _make_signature("test-secret", body)
+    r = await client.post("/api/webhooks/github", content=body, headers={
+        "X-Hub-Signature-256": sig, "X-GitHub-Event": "pull_request", "Content-Type": "application/json"})
+    assert r.status_code == 200
+    log_path = tmp_data_dir / "github_events.jsonl"
+    assert log_path.exists()
+    lines = log_path.read_text().strip().splitlines()
+    assert len(lines) >= 1
+    event = json.loads(lines[0])
+    assert event["event"] == "pull_request"
+    assert event["action"] == "closed"
+    assert event["repo"] == "test-owner/test-repo"
+    assert event["sender"] == "test-user"
+    assert event["url"] == "https://github.com/test-owner/test-repo/pull/1"
+    assert "timestamp" in event
+
+
+@pytest.mark.asyncio
+async def test_log_file_uses_correct_path(client, monkeypatch, tmp_data_dir):
+    monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", "test-secret")
+    body = json.dumps(_build_payload("pull_request")).encode()
+    sig = _make_signature("test-secret", body)
+    await client.post("/api/webhooks/github", content=body, headers={
+        "X-Hub-Signature-256": sig, "X-GitHub-Event": "pull_request", "Content-Type": "application/json"})
+    log_path = tmp_data_dir / "github_events.jsonl"
+    assert log_path.exists()
+    assert "test-owner/test-repo" in log_path.read_text()
+
+
+@pytest.mark.asyncio
+async def test_push_event_extracts_compare_url(client, monkeypatch, tmp_data_dir):
+    monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", "test-secret")
+    body = json.dumps(_build_payload("push")).encode()
+    sig = _make_signature("test-secret", body)
+    r = await client.post("/api/webhooks/github", content=body, headers={
+        "X-Hub-Signature-256": sig, "X-GitHub-Event": "push", "Content-Type": "application/json"})
+    assert r.status_code == 200
+    event = json.loads((tmp_data_dir / "github_events.jsonl").read_text().strip())
+    assert event["event"] == "push"
+    assert "compare" in event["url"]
+
+
+@pytest.mark.asyncio
+async def test_issue_comment_event_extracts_url(client, monkeypatch, tmp_data_dir):
+    monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", "test-secret")
+    body = json.dumps(_build_payload("issue_comment", action="created")).encode()
+    sig = _make_signature("test-secret", body)
+    r = await client.post("/api/webhooks/github", content=body, headers={
+        "X-Hub-Signature-256": sig, "X-GitHub-Event": "issue_comment", "Content-Type": "application/json"})
+    assert r.status_code == 200
+    event = json.loads((tmp_data_dir / "github_events.jsonl").read_text().strip())
+    assert event["event"] == "issue_comment"
+    assert "issuecomment" in event["url"]
+
+
+@pytest.mark.asyncio
+async def test_pull_request_review_event(client, monkeypatch, tmp_data_dir):
+    monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", "test-secret")
+    body = json.dumps(_build_payload("pull_request_review", action="submitted")).encode()
+    sig = _make_signature("test-secret", body)
+    r = await client.post("/api/webhooks/github", content=body, headers={
+        "X-Hub-Signature-256": sig, "X-GitHub-Event": "pull_request_review", "Content-Type": "application/json"})
+    assert r.status_code == 200
+    event = json.loads((tmp_data_dir / "github_events.jsonl").read_text().strip())
+    assert event["event"] == "pull_request_review"
+    assert "pullrequestreview" in event["url"]
+
+
+@pytest.mark.asyncio
+async def test_check_run_event(client, monkeypatch, tmp_data_dir):
+    monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", "test-secret")
+    body = json.dumps(_build_payload("check_run")).encode()
+    sig = _make_signature("test-secret", body)
+    r = await client.post("/api/webhooks/github", content=body, headers={
+        "X-Hub-Signature-256": sig, "X-GitHub-Event": "check_run", "Content-Type": "application/json"})
+    assert r.status_code == 200
+    event = json.loads((tmp_data_dir / "github_events.jsonl").read_text().strip())
+    assert event["event"] == "check_run"
+    assert event["url"] == "https://github.com/test-owner/test-repo"
+
+
+@pytest.mark.asyncio
+async def test_invalid_json_returns_400(client, monkeypatch):
+    monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", "test-secret")
+    body = b"not json at all"
+    sig = _make_signature("test-secret", body)
+    r = await client.post("/api/webhooks/github", content=body, headers={
+        "X-Hub-Signature-256": sig, "X-GitHub-Event": "pull_request", "Content-Type": "text/plain"})
+    assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_missing_event_type_header_still_logs(client, monkeypatch, tmp_data_dir):
+    monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", "test-secret")
+    body = json.dumps(_build_payload("pull_request")).encode()
+    sig = _make_signature("test-secret", body)
+    r = await client.post("/api/webhooks/github", content=body, headers={
+        "X-Hub-Signature-256": sig, "Content-Type": "application/json"})
+    assert r.status_code == 200
+    event = json.loads((tmp_data_dir / "github_events.jsonl").read_text().strip())
+    assert event["event"] == ""
+
+
+@pytest.mark.asyncio
+async def test_unknown_event_type_still_logged(client, monkeypatch, tmp_data_dir):
+    monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", "test-secret")
+    body = json.dumps(_build_payload("pull_request")).encode()
+    sig = _make_signature("test-secret", body)
+    r = await client.post("/api/webhooks/github", content=body, headers={
+        "X-Hub-Signature-256": sig, "X-GitHub-Event": "deployment", "Content-Type": "application/json"})
+    assert r.status_code == 200
+    event = json.loads((tmp_data_dir / "github_events.jsonl").read_text().strip())
+    assert event["event"] == "deployment"

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -1201,6 +1201,9 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     from tinyagentos.routes.github import router as github_router
     app.include_router(github_router)
 
+    from tinyagentos.routes.gh_webhook import router as gh_webhook_router
+    app.include_router(gh_webhook_router)
+
     from tinyagentos.routes.youtube import router as youtube_router
     app.include_router(youtube_router)
 

--- a/tinyagentos/routes/gh_webhook.py
+++ b/tinyagentos/routes/gh_webhook.py
@@ -1,9 +1,4 @@
-"""GitHub webhook receiver endpoint.
-
-Receives webhook events at POST /api/webhooks/github, verifies the
-HMAC-SHA256 signature, and appends a structured JSONL line to
-~/.taos-gh-events.jsonl for later consumption by automation.
-"""
+"""GitHub webhook receiver — signature verification + JSONL event log."""
 
 from __future__ import annotations
 
@@ -12,135 +7,69 @@ import hmac
 import json
 import logging
 import os
-from datetime import datetime, timezone
+import time
 from pathlib import Path
 
 from fastapi import APIRouter, Request
-from fastapi.responses import JSONResponse, Response
+from fastapi.responses import JSONResponse
 
 logger = logging.getLogger(__name__)
-
 router = APIRouter()
 
-EVENTS_LOG_PATH = Path.home() / ".taos-gh-events.jsonl"
+
+def _extract_url(payload: dict, event_type: str) -> str:
+    repo = payload.get("repository", {})
+    repo_url = repo.get("html_url", "")
+    if event_type == "pull_request_review":
+        return payload.get("review", {}).get("html_url", repo_url)
+    if event_type == "pull_request":
+        return payload.get("pull_request", {}).get("html_url", repo_url)
+    if event_type == "issue_comment":
+        return payload.get("comment", {}).get("html_url", repo_url)
+    if event_type == "push":
+        return payload.get("compare", repo_url)
+    return repo_url
 
 
-def _extract_event_data(event_type: str, payload: dict) -> dict | None:
-    """Extract the canonical fields from a payload for the given event type.
-
-    Returns a dict with event, action, timestamp, repo, sender, url
-    or None if the payload does not match a known shape.
-    """
-    try:
-        repo = payload.get("repository", {})
-        repo_full_name = repo.get("full_name", "")
-        sender = payload.get("sender", {})
-        sender_login = sender.get("login", "")
-
-        action = payload.get("action", "")
-
-        # Resolve the best URL depending on event type
-        url = ""
-        if event_type == "pull_request_review_comment":
-            comment = payload.get("comment", {})
-            url = comment.get("html_url", "")
-        elif event_type == "pull_request_review":
-            review = payload.get("review", {})
-            url = review.get("html_url", "")
-        elif event_type == "issue_comment":
-            comment = payload.get("comment", {})
-            url = comment.get("html_url", "")
-        elif event_type == "pull_request":
-            pr = payload.get("pull_request", {})
-            url = pr.get("html_url", "")
-        elif event_type in ("check_run", "check_suite"):
-            repo_url = repo.get("html_url", "")
-            url = repo_url if repo_url else ""
-        else:
-            # Unknown event type — still log with what we have
-            pass
-
-        return {
-            "event": event_type,
-            "action": action,
-            "timestamp": datetime.now(timezone.utc).isoformat(),
-            "repo": repo_full_name,
-            "sender": sender_login,
-            "url": url,
-        }
-    except Exception:
-        logger.exception("Failed to extract event data from payload")
-        return None
+def _verify_signature(secret: str, body: bytes, sig: str) -> bool:
+    if not sig.startswith("sha256="):
+        return False
+    expected = "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, sig)
 
 
 @router.post("/api/webhooks/github")
-async def github_webhook(request: Request) -> Response:
-    """Receive and validate a GitHub webhook event."""
-
-    secret = os.environ.get("GITHUB_WEBHOOK_SECRET", "")
-    if not secret:
-        logger.warning("GITHUB_WEBHOOK_SECRET not set — rejecting webhook")
-        return JSONResponse(
-            {"error": "webhook secret not configured"}, status_code=500
-        )
-
-    signature_header = request.headers.get("X-Hub-Signature-256", "")
-    if not signature_header:
-        logger.warning("Missing X-Hub-Signature-256 header")
-        return JSONResponse({"error": "missing signature"}, status_code=403)
-
-    # Read raw body as bytes for HMAC verification
-    raw_body = await request.body()
-
-    # Compute expected signature
-    expected_signature = (
-        "sha256=" + hmac.new(
-            secret.encode("utf-8"),
-            raw_body,
-            hashlib.sha256,
-        ).hexdigest()
-    )
-
-    if not hmac.compare_digest(expected_signature, signature_header):
-        logger.warning("Webhook signature mismatch")
-        return JSONResponse({"error": "invalid signature"}, status_code=403)
-
-    # Parse the JSON payload
+async def github_webhook(request: Request):
+    secret = os.environ.get("GITHUB_WEBHOOK_SECRET")
+    signature = request.headers.get("X-Hub-Signature-256", "")
+    if secret:
+        if not signature:
+            logger.warning("gh_webhook: missing X-Hub-Signature-256 header")
+            return JSONResponse({"error": "missing signature"}, status_code=403)
+        body = await request.body()
+        if not _verify_signature(secret, body, signature):
+            logger.warning("gh_webhook: invalid signature")
+            return JSONResponse({"error": "invalid signature"}, status_code=403)
+    else:
+        logger.warning("gh_webhook: GITHUB_WEBHOOK_SECRET not set - accepting events without verification (dev mode)")
+        body = await request.body()
     try:
-        payload = json.loads(raw_body)
-    except json.JSONDecodeError:
-        logger.warning("Webhook body is not valid JSON")
-        return JSONResponse({"error": "invalid JSON"}, status_code=400)
-
+        payload = json.loads(body)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return JSONResponse({"error": "invalid JSON body"}, status_code=400)
     event_type = request.headers.get("X-GitHub-Event", "")
-
-    event_data = _extract_event_data(event_type, payload)
-    if event_data is None:
-        # Could not extract canonical fields; still accept the event
-        event_data = {
-            "event": event_type,
-            "action": "",
-            "timestamp": datetime.now(timezone.utc).isoformat(),
-            "repo": "",
-            "sender": "",
-            "url": "",
-        }
-
-    # Append as a single JSONL line
-    jsonl_line = json.dumps(event_data, ensure_ascii=False) + "\n"
-    try:
-        EVENTS_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
-        with open(EVENTS_LOG_PATH, "a", encoding="utf-8") as f:
-            f.write(jsonl_line)
-    except OSError:
-        logger.exception("Failed to write webhook event to %s", EVENTS_LOG_PATH)
-        return JSONResponse(
-            {"error": "failed to persist event"}, status_code=500
-        )
-
-    logger.info(
-        "Webhook event persisted: event=%s action=%s repo=%s",
-        event_type, event_data.get("action", ""), event_data.get("repo", ""),
-    )
-
-    return JSONResponse({"status": "ok"}, status_code=200)
+    event = {
+        "event": event_type,
+        "action": payload.get("action", ""),
+        "repo": payload.get("repository", {}).get("full_name", ""),
+        "sender": payload.get("sender", {}).get("login", ""),
+        "url": _extract_url(payload, event_type),
+        "timestamp": time.time(),
+    }
+    data_dir: Path = request.app.state.data_dir
+    log_path = data_dir / "github_events.jsonl"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(log_path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(event, ensure_ascii=False) + "\n")
+    logger.debug("gh_webhook: logged event %s from %s", event_type, event["repo"])
+    return JSONResponse({"status": "ok"})


### PR DESCRIPTION
## Summary
Stand up a FastAPI receiver at POST /api/webhooks/github that accepts GitHub webhook events with HMAC-SHA256 signature verification.

## What it does
- Verify signatures via X-Hub-Signature-256 header  
- Parses common event types: check_run, pull_request_review, issue_comment, push, pull_request
- Writes structured events to data/github_events.jsonl in JSON lines format
- Dev mode: when GITHUB_WEBHOOK_SECRET is unset, accepts all events with a warning log
- Returns 403 for invalid/missing signatures when secret is configured
- No external dependencies beyond stdlib + FastAPI

## Tests
13/13 tests passing

## Files changed
- tinyagentos/routes/gh_webhook.py — route handler
- tinyagentos/app.py — route registration
- tests/test_gh_webhook.py — test suite (13 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub webhook endpoint now accepts events when no secret is configured (logs a warning) and returns {"status":"ok"} on success; event records are written to the app's configured data directory and include a numeric timestamp.

* **Bug Fixes**
  * Missing/invalid signatures are rejected when a secret is set; invalid JSON still returns 400. Missing or unknown event-type headers are tolerated and logged.

* **Tests**
  * Added comprehensive tests for signature handling, no-secret acceptance, JSON validation, event logging/persistence, and URL extraction for multiple event types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->