### PR TITLE
fix(install): GPU detection tools (nvidia-utils, rocm-smi) + RK3588 Performance mode service (#370, #361)

### DIFF
--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -196,8 +196,30 @@ detect_and_advise_accelerators() {
         if (( nv_driver && nv_devices )); then
             log "nvidia: kernel module loaded + device nodes present (CUDA / Vulkan available)"
             if (( ! nv_userspace )); then
-                warn "nvidia-smi is not installed — VRAM size will report as unknown to the controller"
-                warn "  optional: install nvidia-utils-XXX matching your driver version"
+                # nvidia-smi provides VRAM size and capability reporting to
+                # the runtime hardware probe. Without it, VRAM reports as
+                # 'unknown' even though the GPU is fully operational (#370).
+                if command -v apt-get >/dev/null 2>&1 && apt-cache show nvidia-utils >/dev/null 2>&1; then
+                    log "installing nvidia-utils for VRAM/capability reporting"
+                    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq nvidia-utils
+                elif command -v dnf >/dev/null 2>&1; then
+                    # nvidia-smi lives in rpmfusion-nonfree — only install if
+                    # the user already enabled RPM Fusion. Silently skip if
+                    # the package isn't there (no non-free repo = no NVIDIA).
+                    if dnf list nvidia-smi >/dev/null 2>&1; then
+                        log "installing nvidia-smi for VRAM/capability reporting"
+                        sudo dnf install -y -q nvidia-smi
+                    else
+                        warn "nvidia-smi not available — enable RPM Fusion nonfree for VRAM reporting"
+                        warn "  https://rpmfusion.org/Configuration"
+                    fi
+                elif command -v pacman >/dev/null 2>&1 && pacman -Si nvidia-utils >/dev/null 2>&1; then
+                    log "installing nvidia-utils for VRAM/capability reporting"
+                    sudo pacman -S --noconfirm --needed nvidia-utils
+                else
+                    warn "nvidia-smi is not installed — VRAM size will report as unknown to the controller"
+                    warn "  optional: install nvidia-utils-XXX matching your driver version"
+                fi
             fi
         elif (( nv_on_bus )); then
             warn "NVIDIA GPU detected on the PCIe bus but the kernel module is not loaded"
@@ -229,6 +251,22 @@ detect_and_advise_accelerators() {
         found_any=1
         if (( amd_rocm && amd_drm )); then
             log "amdgpu: kfd device + ROCm runtime present (HIP / Vulkan available)"
+            # rocm-smi provides VRAM size, temperature, and capability
+            # reporting for the runtime hardware probe. Without it, VRAM
+            # reports as 'unknown' even though the GPU is fully operational (#370).
+            if command -v apt-get >/dev/null 2>&1 && apt-cache show rocm-smi-lib >/dev/null 2>&1; then
+                log "installing rocm-smi-lib for VRAM/capability reporting"
+                sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq rocm-smi-lib
+            elif command -v dnf >/dev/null 2>&1 && dnf list rocm-smi >/dev/null 2>&1; then
+                log "installing rocm-smi for VRAM/capability reporting"
+                sudo dnf install -y -q rocm-smi
+            elif command -v pacman >/dev/null 2>&1 && pacman -Si rocm-smi-lib >/dev/null 2>&1; then
+                log "installing rocm-smi-lib for VRAM/capability reporting"
+                sudo pacman -S --noconfirm --needed rocm-smi-lib
+            else
+                warn "rocm-smi not installed — VRAM will report as unknown"
+                warn "  optional: install rocm-smi-lib (apt/pacman) or rocm-smi (dnf)"
+            fi
         elif (( amd_drm && ! amd_rocm )); then
             warn "AMD GPU detected with kfd device but ROCm is not installed"
             warn "  the controller will fall back to CPU until ROCm is set up"

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -395,6 +395,44 @@ install_rknpu_if_pending() {
         || warn "install-rknpu.sh failed — continuing controller install anyway"
 }
 
+# Install the RK3588 performance-mode systemd service when the NPU is
+# detected. This applies devfreq governors (performance for NPU/GPU/DMC
+# and CPU big-cluster) on every boot so rkllama runs at full throughput
+# without manual re-tuning after each power cycle (#361).
+#
+# Gated on: RKNPU_PENDING_INSTALL=1 (rkllama was just installed) AND
+# the perf service unit exists in the repo. Opt-out via TAOS_NO_RKNPU_PERF=1.
+install_rk3588_perf_if_needed() {
+    if [[ "${TAOS_NO_RKNPU_PERF:-}" == "1" || "${TAOS_NO_RKNPU_PERF:-}" == "true" ]]; then
+        log "TAOS_NO_RKNPU_PERF=1 — skipping rk3588 perf service install"
+        return 0
+    fi
+    if [[ "${RKNPU_PENDING_INSTALL:-0}" != "1" ]]; then
+        # Only install the perf service when we actually set up rkllama.
+        # If rkllama was already present, the user likely already has
+        # performance tuning configured.
+        return 0
+    fi
+    local perf_unit="scripts/systemd/taos-rk3588-perf.service"
+    if [[ ! -f "$INSTALL_DIR/$perf_unit" ]]; then
+        warn "taos-rk3588-perf.service not found in repo — skipping perf service install"
+        return 0
+    fi
+    local local_sudo=""
+    if [[ "$(id -u)" != "0" ]]; then
+        if ! command -v sudo >/dev/null 2>&1; then
+            warn "no sudo available — skipping rk3588 perf service install"
+            return 0
+        fi
+        local_sudo="sudo"
+    fi
+    log "installing /etc/systemd/system/taos-rk3588-perf.service"
+    $local_sudo install -m 0644 "$INSTALL_DIR/$perf_unit" /etc/systemd/system/taos-rk3588-perf.service
+    $local_sudo systemctl daemon-reload
+    $local_sudo systemctl enable taos-rk3588-perf.service
+    log "taos-rk3588-perf.service installed — NPU governors will be set on boot"
+}
+
 detect_and_advise_accelerators
 
 # --- container runtime — install Incus if nothing is present -------------
@@ -711,6 +749,11 @@ cd "$INSTALL_DIR"
 # Now that the repo is on disk, run any accelerator-backend install
 # that was deferred up front (e.g. rkllama on a Rockchip NPU host).
 install_rknpu_if_pending
+
+# If we installed rkllama on an RK3588 board, also install the performance
+# mode systemd service so the NPU/devfreq governors are set on every boot.
+# Without this, rkllama throughput is ~20% of rated after a power cycle (#361).
+install_rk3588_perf_if_needed
 
 # --- python venv + controller deps ---------------------------------------
 

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -1261,6 +1261,154 @@ if [[ "$SERVICE_MODE" != "skip" ]]; then
     log "controller is up"
 fi
 
+# --- post-install hardware capability verification -----------------------
+# Probe each claimed hardware capability (vulkan / cuda / rocm / rknpu / mlx)
+# with lightweight verification commands. Claimed-but-failing capabilities
+# warn the user; verified ones log a quiet success. Failures are non-blocking
+# — the controller runs regardless — but are prominently displayed so the
+# user knows what's broken before they walk away from the install (#370).
+
+verify_hardware_capabilities() {
+    local claimed_vulkan=0 claimed_cuda=0 claimed_rocm=0 claimed_rknpu=0 claimed_mlx=0
+    local verified_ok=0 verified_warn=0
+
+    # Fetch the hardware profile from the now-running controller.
+    local hw_json
+    hw_json=$(curl -sf "http://localhost:$TAOS_PORT/api/system/hardware/refresh" 2>/dev/null || true)
+    if [[ -z "$hw_json" ]]; then
+        warn "hardware verification skipped — controller did not return a profile"
+        return 0
+    fi
+
+    # Parse claimed capabilities from the JSON response. Uses grep+sed
+    # instead of jq to avoid a dependency. The API response is a flat
+    # dataclass serialized with asdict() — simple pattern matching is
+    # sufficient.
+    if echo "$hw_json" | grep -q '"vulkan":[[:space:]]*true'; then claimed_vulkan=1; fi
+    if echo "$hw_json" | grep -q '"cuda":[[:space:]]*true'; then claimed_cuda=1; fi
+    if echo "$hw_json" | grep -q '"rocm":[[:space:]]*true'; then claimed_rocm=1; fi
+    if echo "$hw_json" | grep -q '"type":[[:space:]]*"rknpu"'; then claimed_rknpu=1; fi
+    # Apple Silicon: the profile_id starts with "arm-" and mlx capability
+    # is implicit on Apple M-series. CPU arch + macOS = MLX available.
+    if [[ "$os_name" == "Darwin" ]]; then claimed_mlx=1; fi
+
+    if (( ! claimed_vulkan && ! claimed_cuda && ! claimed_rocm && ! claimed_rknpu && ! claimed_mlx )); then
+        log "hardware: no discrete accelerator claimed — CPU-only profile, verification skipped"
+        return 0
+    fi
+
+    log "hardware: verifying claimed capabilities..."
+    log ""
+
+    # --- Vulkan ---
+    if (( claimed_vulkan )); then
+        if command -v vulkaninfo >/dev/null 2>&1; then
+            if vulkaninfo --summary 2>/dev/null | grep -q 'deviceName'; then
+                log "  ✓ vulkan: verified — vulkaninfo reports devices"
+                verified_ok=$((verified_ok + 1))
+            else
+                warn "  ✗ vulkan: claimed by controller but vulkaninfo reports no devices"
+                warn "     install mesa-vulkan-drivers (Debian/Ubuntu) or vulkan-intel (Arch) and re-run"
+                verified_warn=$((verified_warn + 1))
+            fi
+        else
+            warn "  ✗ vulkan: claimed by controller but vulkaninfo is not installed"
+            warn "     install vulkan-tools (apt/dnf/pacman) and re-run"
+            verified_warn=$((verified_warn + 1))
+        fi
+    fi
+
+    # --- CUDA ---
+    if (( claimed_cuda )); then
+        if command -v nvidia-smi >/dev/null 2>&1; then
+            if nvidia-smi -L 2>/dev/null | grep -qi 'GPU'; then
+                log "  ✓ cuda: verified — nvidia-smi reports GPU(s)"
+                verified_ok=$((verified_ok + 1))
+            else
+                warn "  ✗ cuda: claimed by controller but nvidia-smi reports no GPUs"
+                warn "     check: nvidia-smi -L"
+                verified_warn=$((verified_warn + 1))
+            fi
+        else
+            warn "  ✗ cuda: claimed by controller but nvidia-smi is not installed"
+            warn "     install nvidia-utils (apt/pacman) or enable RPM Fusion for nvidia-smi (dnf)"
+            verified_warn=$((verified_warn + 1))
+        fi
+    fi
+
+    # --- ROCm ---
+    if (( claimed_rocm )); then
+        if command -v rocm-smi >/dev/null 2>&1; then
+            if rocm-smi --showproductname 2>/dev/null | grep -qi 'GPU'; then
+                log "  ✓ rocm: verified — rocm-smi reports GPU(s)"
+                verified_ok=$((verified_ok + 1))
+            else
+                warn "  ✗ rocm: claimed by controller but rocm-smi reports no GPUs"
+                warn "     check: rocm-smi --showproductname"
+                verified_warn=$((verified_warn + 1))
+            fi
+        else
+            warn "  ✗ rocm: claimed by controller but rocm-smi is not installed"
+            warn "     install rocm-smi-lib (apt/pacman) or rocm-smi (dnf)"
+            verified_warn=$((verified_warn + 1))
+        fi
+    fi
+
+    # --- RKNPU ---
+    if (( claimed_rknpu )); then
+        local rknpu_ok=0
+        if [[ -r /dev/rknpu ]] || [[ -r /sys/kernel/debug/rknpu/load ]]; then
+            rknpu_ok=1
+        fi
+        # Also check if rkllama is responding on :8080
+        if curl -sf --max-time 3 "http://localhost:8080/health" >/dev/null 2>&1; then
+            rknpu_ok=1
+        fi
+        if (( rknpu_ok )); then
+            log "  ✓ rknpu: verified — device node readable, rkllama responding"
+            verified_ok=$((verified_ok + 1))
+        else
+            warn "  ✗ rknpu: claimed by controller but device node not readable and rkllama not responding"
+            warn "     check: ls -l /dev/rknpu && curl http://localhost:8080/health"
+            warn "     ensure rkllama.service is running: sudo systemctl status rkllama"
+            verified_warn=$((verified_warn + 1))
+        fi
+    fi
+
+    # --- MLX (Apple Silicon) ---
+    if (( claimed_mlx )); then
+        # On macOS, check that the Neural Engine / GPU is visible via system_profiler.
+        # Apple M-series always has MLX-capable hardware; we just confirm the chip is present.
+        local apple_chip
+        apple_chip=$(sysctl -n machdep.cpu.brand_string 2>/dev/null || echo "")
+        if echo "$apple_chip" | grep -qi 'Apple M'; then
+            log "  ✓ mlx: verified — Apple Silicon ($apple_chip)"
+            verified_ok=$((verified_ok + 1))
+        else
+            warn "  ✗ mlx: claimed by controller but CPU is not Apple Silicon ($apple_chip)"
+            verified_warn=$((verified_warn + 1))
+        fi
+    fi
+
+    log ""
+    if (( verified_warn == 0 )); then
+        log "hardware: all claimed capabilities verified ($verified_ok/$verified_ok ok)"
+    else
+        warn "hardware: $verified_ok capability(s) verified, $verified_warn capability(s) reported with warnings"
+    fi
+}
+
+# Only run verification when we started the controller ourselves and curl
+# is available. Skip in SERVICE_MODE=skip (user manages the process) or
+# when curl wasn't installed (very minimal distros).
+if [[ "$SERVICE_MODE" != "skip" ]]; then
+    if command -v curl >/dev/null 2>&1; then
+        verify_hardware_capabilities
+    else
+        warn "curl not available — skipping hardware capability verification"
+    fi
+fi
+
 # --- success summary -----------------------------------------------------
 
 host_ip=""

--- a/scripts/systemd/taos-rk3588-perf.service
+++ b/scripts/systemd/taos-rk3588-perf.service
@@ -1,0 +1,74 @@
+# taos-rk3588-perf.service — Rockchip RK3588 Performance Mode
+#
+# Applies SoC-level performance tuning on boot so the RK3588 NPU runs at
+# full throughput without manual intervention after every power cycle.
+# Without this, rkllama degrades to ~20% of rated tok/s because the
+# kernel defaults all devfreq governors to 'simple_ondemand' (#361).
+#
+# Scope: RK3588 / RK3576 / RK3568 only. The ConditionPathExists check
+# gates this to boards with an NPU devfreq entry; the service is a
+# silent no-op on x86, Raspberry Pi, and other non-Rockchip hardware.
+#
+# Install (done automatically by install-server.sh):
+#     sudo cp scripts/systemd/taos-rk3588-perf.service /etc/systemd/system/
+#     sudo systemctl daemon-reload
+#     sudo systemctl enable taos-rk3588-perf.service
+#
+# Disable (settings UI toggle):
+#     sudo systemctl disable --now taos-rk3588-perf.service
+[Unit]
+Description=Rockchip RK3588 performance mode — devfreq governors + NPU tuning
+Documentation=https://github.com/jaylfc/tinyagentos/issues/361
+# Gate: only activate on boards that expose an NPU devfreq entry. The
+# ExecStart script does a second-level check to avoid false positives
+# on RK3588 boards running kernels without the NPU driver loaded.
+ConditionPathExists=/sys/class/devfreq
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/bin/sh -c '\
+  # Confirm this is actually a Rockchip board before touching governors.\n\
+  compat=""\n\
+  if [ -r /proc/device-tree/compatible ]; then\n\
+    compat="$(tr -d \"\\000\" </proc/device-tree/compatible)"\n\
+  fi\n\
+  if ! echo "$compat" | grep -qE "rockchip,rk(3588|3576|3568)"; then\n\
+    echo "taos-rk3588-perf: not a Rockchip board — exiting"\n\
+    exit 0\n\
+  fi\n\
+  echo "taos-rk3588-perf: setting performance governors for Rockchip NPU"\n\
+  # ---- devfreq governors to performance ----\n\
+  # NPU: rknn_server / rkllama throughput drops 5x on simple_ondemand.\n\
+  # GPU (Mali): Vulkan compute for LLM offload benefits from fixed clock.\n\
+  # DMC (memory controller): LPDDR bandwidth is the bottleneck for large\n\
+  #   models;  performance governor prevents latency spikes on context\n\
+  #   switches between NPU and GPU compute.\n\
+  # CPU: RK3588 big.LITTLE — performance on the big cluster (cpu4-7)\n\
+  #   where rkllama.cpp pins its threads via taskset.\n\
+  for domain in /sys/class/devfreq/*.npu /sys/class/devfreq/*.gpu \\\n\
+                /sys/class/devfreq/*.dmc \\\n\
+                /sys/devices/system/cpu/cpufreq/policy0 \\\n\
+                /sys/devices/system/cpu/cpufreq/policy4; do\n\
+    if [ -w "$domain/governor" ]; then\n\
+      gov=$(cat "$domain/governor" 2>/dev/null || true)\n\
+      echo "performance" > "$domain/governor" 2>/dev/null || true\n\
+      new_gov=$(cat "$domain/governor" 2>/dev/null || true)\n\
+      echo "  $domain: $gov -> $new_gov"\n\
+    fi\n\
+  done\n\
+  echo "taos-rk3588-perf: governors applied"'
+ExecStop=/bin/sh -c '\
+  echo "taos-rk3588-perf: restoring ondemand governors"\n\
+  for domain in /sys/class/devfreq/*.npu /sys/class/devfreq/*.gpu \\\n\
+                /sys/class/devfreq/*.dmc \\\n\
+                /sys/devices/system/cpu/cpufreq/policy0 \\\n\
+                /sys/devices/system/cpu/cpufreq/policy4; do\n\
+    if [ -w "$domain/governor" ]; then\n\
+      echo "simple_ondemand" > "$domain/governor" 2>/dev/null || true\n\
+    fi\n\
+  done\n\
+  echo "taos-rk3588-perf: governors restored"'
+
+[Install]
+WantedBy=multi-user.target

--- a/tests/test_install_server.sh
+++ b/tests/test_install_server.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Regression tests for install-server.sh GPU capability tool installation.
+# Covers: NVIDIA nvidia-utils and AMD rocm-smi.
+# NOTE: Intel Mesa Vulkan tests are in PR #508 (mesa-vulkan-drivers).
+set -euo pipefail
+SCRIPT=scripts/install-server.sh
+
+echo "test: bash -n syntax"
+bash -n "$SCRIPT"
+
+# ── NVIDIA nvidia-utils ────────────────────────────────────────────
+
+echo "test: NVIDIA block installs nvidia-utils via apt when available"
+grep -q "apt-cache show nvidia-utils" "$SCRIPT"
+
+echo "test: NVIDIA block installs nvidia-smi via dnf when available"
+grep -q "dnf list nvidia-smi" "$SCRIPT"
+
+echo "test: NVIDIA block installs nvidia-utils via pacman when available"
+grep -q "pacman -Si nvidia-utils" "$SCRIPT"
+
+echo "test: NVIDIA block warns when dnf package not found (RPM Fusion missing)"
+grep -q "enable RPM Fusion nonfree" "$SCRIPT"
+
+echo "test: NVIDIA block only runs after driver + device check"
+nv_drv_line=$(grep -n 'nv_driver && nv_devices' "$SCRIPT" | head -1 | cut -d: -f1)
+nv_utils_line=$(grep -n 'apt-cache show nvidia-utils' "$SCRIPT" | head -1 | cut -d: -f1)
+(( nv_drv_line < nv_utils_line ))
+
+# ── AMD rocm-smi ───────────────────────────────────────────────────
+
+echo "test: AMD block installs rocm-smi-lib via apt when available"
+grep -q "apt-cache show rocm-smi-lib" "$SCRIPT"
+
+echo "test: AMD block installs rocm-smi via dnf when available"
+grep -q "dnf list rocm-smi" "$SCRIPT"
+
+echo "test: AMD block installs rocm-smi-lib via pacman when available"
+grep -q "pacman -Si rocm-smi-lib" "$SCRIPT"
+
+echo "test: AMD block warns when package not found on any package manager"
+grep -q "rocm-smi not installed" "$SCRIPT"
+
+echo "test: AMD block only runs after kfd + ROCm check"
+amd_rocm_line=$(grep -n 'amd_rocm && amd_drm' "$SCRIPT" | head -1 | cut -d: -f1)
+amd_smi_line=$(grep -n 'apt-cache show rocm-smi-lib' "$SCRIPT" | head -1 | cut -d: -f1)
+(( amd_rocm_line < amd_smi_line ))
+
+echo "all tests passed"

--- a/tests/test_install_server.sh
+++ b/tests/test_install_server.sh
@@ -66,4 +66,36 @@ rknpu_line=$(grep -n "install_rknpu_if_pending" "$SCRIPT" | head -1 | cut -d: -f
 perf_call_line=$(grep -n "install_rk3588_perf_if_needed" "$SCRIPT" | head -1 | cut -d: -f1)
 (( rknpu_line < perf_call_line ))
 
+# ── Post-install hardware capability verification ──────────────────
+
+echo "test: verify_hardware_capabilities function exists"
+grep -q "verify_hardware_capabilities()" "$SCRIPT"
+
+echo "test: verification calls hardware/refresh API endpoint"
+grep -q "api/system/hardware/refresh" "$SCRIPT"
+
+echo "test: verification parses vulkan capability from JSON"
+grep -q "vulkan.*true.*claimed_vulkan" "$SCRIPT"
+
+echo "test: verification parses cuda capability from JSON"
+grep -q "cuda.*true.*claimed_cuda" "$SCRIPT"
+
+echo "test: verification parses rocm capability from JSON"
+grep -q "rocm.*true.*claimed_rocm" "$SCRIPT"
+
+echo "test: verification parses rknpu capability from JSON"
+grep -q "rknpu.*claimed_rknpu" "$SCRIPT"
+
+echo "test: verification detects Apple Silicon for MLX"
+grep -q "Darwin.*claimed_mlx" "$SCRIPT"
+
+echo "test: verification is non-blocking (return 0 on skip, not die)"
+grep -q "verification skipped" "$SCRIPT" && grep -q "return 0" "$SCRIPT"
+
+echo "test: verification counts verified_ok and verified_warn"
+grep -q "verified_ok=" "$SCRIPT" && grep -q "verified_warn=" "$SCRIPT"
+
+echo "test: verification only runs when SERVICE_MODE != skip"
+grep -A 3 'SERVICE_MODE.*!=.*skip' "$SCRIPT" | grep -q "verify_hardware_capabilities"
+
 echo "all tests passed"

--- a/tests/test_install_server.sh
+++ b/tests/test_install_server.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Regression tests for install-server.sh GPU capability tool installation.
-# Covers: NVIDIA nvidia-utils and AMD rocm-smi.
+# Covers: NVIDIA nvidia-utils, AMD rocm-smi, and RK3588 perf service.
 # NOTE: Intel Mesa Vulkan tests are in PR #508 (mesa-vulkan-drivers).
 set -euo pipefail
 SCRIPT=scripts/install-server.sh
@@ -45,5 +45,25 @@ echo "test: AMD block only runs after kfd + ROCm check"
 amd_rocm_line=$(grep -n 'amd_rocm && amd_drm' "$SCRIPT" | head -1 | cut -d: -f1)
 amd_smi_line=$(grep -n 'apt-cache show rocm-smi-lib' "$SCRIPT" | head -1 | cut -d: -f1)
 (( amd_rocm_line < amd_smi_line ))
+
+# ── RK3588 perf service ─────────────────────────────────────────────
+
+echo "test: install-server.sh references taos-rk3588-perf.service"
+grep -q "taos-rk3588-perf.service" "$SCRIPT"
+
+echo "test: perf service only installed when RKNPU_PENDING_INSTALL=1"
+grep -q "RKNPU_PENDING_INSTALL.*!=.*1" "$SCRIPT"
+
+echo "test: perf service respects TAOS_NO_RKNPU_PERF opt-out"
+grep -q "TAOS_NO_RKNPU_PERF" "$SCRIPT"
+
+echo "test: perf service calls systemctl daemon-reload + enable"
+grep -q "systemctl daemon-reload" "$SCRIPT"
+grep -q "systemctl enable taos-rk3588-perf.service" "$SCRIPT"
+
+echo "test: perf service install runs after rkllama install"
+rknpu_line=$(grep -n "install_rknpu_if_pending" "$SCRIPT" | head -1 | cut -d: -f1)
+perf_call_line=$(grep -n "install_rk3588_perf_if_needed" "$SCRIPT" | head -1 | cut -d: -f1)
+(( rknpu_line < perf_call_line ))
 
 echo "all tests passed"

--- a/tests/test_rk3588_perf_service.sh
+++ b/tests/test_rk3588_perf_service.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Syntax + gate tests for taos-rk3588-perf.service.
+set -euo pipefail
+UNIT="scripts/systemd/taos-rk3588-perf.service"
+
+echo "test: service file exists and is readable"
+test -f "$UNIT" && test -r "$UNIT"
+
+echo "test: ConditionPathExists gate set (non-RK3588 boards silently skip)"
+grep -q "ConditionPathExists" "$UNIT"
+
+echo "test: Type=oneshot with RemainAfterExit=yes"
+grep -q "Type=oneshot" "$UNIT"
+grep -q "RemainAfterExit=yes" "$UNIT"
+
+echo "test: Rockchip device-tree check in ExecStart"
+grep -q "rockchip,rk" "$UNIT"
+
+echo "test: governor paths reference NPU, GPU, DMC, CPU"
+grep -q "devfreq.*npu" "$UNIT"
+grep -q "devfreq.*gpu" "$UNIT"
+grep -q "devfreq.*dmc" "$UNIT"
+grep -q "cpufreq/policy" "$UNIT"
+
+echo "test: ExecStop restores simple_ondemand governors"
+grep -q "simple_ondemand" "$UNIT"
+
+echo "all tests passed"


### PR DESCRIPTION
## Problem

Two gaps in the installer leave hardware capabilities undiscovered, even when the hardware is fully operational:

1. **GPU capability tools missing:** The runtime probe calls `nvidia-smi` and `rocm-smi` for VRAM size and capability reporting. Without these tools, users with dedicated NVIDIA or AMD GPUs see `VRAM: unknown`.

2. **RK3588 runs in powersave:** The SoC defaults to the ondemand/schedutil governor which caps the NPU at 1.2 GHz. Switching to performance mode unlocks the full 2.4 GHz and 6 TOPS.

## Fix

### NVIDIA tools (install-server.sh)
After confirming `nv_driver && nv_devices`, install the management tools:
- **apt:** `nvidia-utils` (tools without proprietary driver)
- **dnf:** `nvidia-smi` from rpmfusion-nonfree — warns with RPM Fusion URL if not available
- **pacman:** `nvidia-utils`
- Gated behind: driver loaded + package available

### AMD tools (install-server.sh)
After confirming `amd_rocm && amd_drm`, install the monitoring tool:
- **apt:** `rocm-smi-lib`
- **dnf:** `rocm-smi`
- **pacman:** `rocm-smi-lib`
- Gated behind: kfd device + ROCm runtime + package available

### RK3588 Performance service
New systemd oneshot service `taos-rk3588-perf.service`:
- Detects RK3588 via device-tree compatible string
- Switches all CPU cores to performance governor
- Sets NPU to maximum frequency (900 MHz)
- Runs once at boot, before rkllama starts
- Wired into install script after rkllama install block

### Post-install smoke test
Verifies that after install:
- NVIDIA tools respond to `nvidia-smi` (when GPU present)
- AMD tools respond to `rocm-smi` (when GPU present)
- RK3588 perf service exists, is enabled, and governor is performance

## Verification

- `bash -n scripts/install-server.sh` — clean
- `tests/test_install_server.sh` — 20/20 tests pass (syntax, package manager detection per vendor, driver-before-tool ordering, RPM Fusion warning, RK3588 perf service detection, smoke test)