### PR TITLE
fix(themes): stop SafetyFloor from duplicating the assistant button on the default theme

### DIFF
--- a/desktop/src/components/SafetyFloor.tsx
+++ b/desktop/src/components/SafetyFloor.tsx
@@ -1,19 +1,29 @@
 import { Sparkles } from "lucide-react";
 import { useTaosAgentStore } from "@/stores/taos-agent-store";
+import { useThemeStore } from "@/stores/theme-store";
 
 /**
- * SafetyFloor — the system-owned, always-present assistant button.
+ * SafetyFloor — the system-owned assistant button of last resort.
  *
- * Mounted by the shell in a guaranteed top layer (z-index 10000, above
- * the effects layer and all windows) and outside any themeable region,
- * so no theme can ever hide it. This is the un-overridable escape hatch:
- * the user can always summon the taOS assistant to fix a broken theme.
+ * The standard assistant trigger lives in the top bar (TopBar). When the
+ * active theme hides that bar, the user would lose all access to the
+ * assistant — so this fallback is mounted in a guaranteed top layer
+ * (z-index 10000, above the effects layer and all windows) and outside any
+ * themeable region. It is the un-overridable escape hatch enforcing the
+ * `requires: ["assistant"]` safety contract.
+ *
+ * It renders ONLY when the active theme hides the top bar; otherwise it
+ * would duplicate the existing top-bar button (e.g. on the default theme).
  *
  * It opens the SAME assistant panel as every other trigger by calling
  * the shared taos-agent-store — it does not own its own panel state.
  */
 export function SafetyFloor() {
   const openPanel = useTaosAgentStore((s) => s.openPanel);
+  const topBarHidden = useThemeStore((s) => s.structure?.topBar?.variant === "hidden");
+
+  // Standard chrome present → the top-bar assistant button already covers it.
+  if (!topBarHidden) return null;
 
   return (
     <div style={{ position: "fixed", zIndex: 10000, top: 4, right: 8, pointerEvents: "auto" }}>

--- a/desktop/src/theme/__tests__/safety-regression.test.tsx
+++ b/desktop/src/theme/__tests__/safety-regression.test.tsx
@@ -1,10 +1,21 @@
 // desktop/src/theme/__tests__/safety-regression.test.tsx
-import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
-import { applyThemeConfig } from "@/stores/theme-store";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { applyThemeConfig, revertTheme } from "@/stores/theme-store";
 import { SafetyFloor } from "@/components/SafetyFloor";
 
-describe("safety floor survives a hostile theme", () => {
+describe("safety floor", () => {
+  beforeEach(() => revertTheme());
+  afterEach(() => cleanup());
+
+  it("is hidden on the default theme so it does not duplicate the top-bar button", () => {
+    // Default theme: structure {} — the standard top-bar assistant button is present.
+    render(<SafetyFloor />);
+    expect(
+      screen.queryByRole("button", { name: /assistant/i }),
+    ).not.toBeInTheDocument();
+  });
+
   it("assistant button still present after applying a theme that hides everything", () => {
     applyThemeConfig({ tokens: {}, structure: { dock: { variant: "hidden" }, topBar: { variant: "hidden" } }, effects: [], requires: [] });
     render(<SafetyFloor />);


### PR DESCRIPTION
## Problem
After the Theme Manager landed (#513), the **default theme shows two taOS assistant buttons** — the normal one top-left (in the TopBar) and a second one top-right. The second is the `SafetyFloor` escape-hatch button, which was rendering **unconditionally**.

## Fix
`SafetyFloor` is meant to be a *fallback* that guarantees assistant access only when a theme hides the standard chrome. It now renders only when the active theme hides the top bar (`structure.topBar?.variant === "hidden"`), where the normal top-bar button would otherwise be lost.

- Default / Matrix themes (`structure: {}`) → SafetyFloor renders nothing → single button top-left. ✅
- A theme that hides the top bar → SafetyFloor appears top-right → assistant still reachable, honouring the `requires: ["assistant"]` safety contract. ✅

## Tests
Extended `safety-regression.test.tsx`:
- **new:** hidden on the default theme (no duplicate).
- **kept:** present after a theme that hides everything.

Both pass; `tsc --noEmit` and `npm run build` clean.

Found during live smoke-testing on the Pi after updating to master.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the assistant escape hatch button to intelligently show/hide based on the active theme. The button now only appears when the top bar is hidden, reducing redundancy and improving the user interface contextually.

* **Tests**
  * Enhanced test coverage to verify the escape hatch button visibility across different theme configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->