### PR TITLE
fix(browser): only emit upgrade-insecure-requests over HTTPS

### DIFF
--- a/tests/routes/desktop_browser/test_csp.py
+++ b/tests/routes/desktop_browser/test_csp.py
@@ -126,3 +126,19 @@ class TestProxiedResponseCsp:
             self._frame_ancestors(csp)
             == "frame-ancestors 'self' http://taos.example:6969"
         )
+
+    def test_no_upgrade_insecure_by_default(self):
+        """On an HTTP deploy, upgrade-insecure-requests would force rewritten
+        proxy subresources to https:// the HTTP-only origin can't serve,
+        breaking every stylesheet/script/image. Must be absent by default."""
+        from tinyagentos.routes.desktop_browser.csp import proxied_response_csp
+
+        assert "upgrade-insecure-requests" not in proxied_response_csp()
+
+    def test_upgrade_insecure_added_only_when_requested(self):
+        """When the proxy is served over HTTPS, the directive is safe and
+        included."""
+        from tinyagentos.routes.desktop_browser.csp import proxied_response_csp
+
+        csp = proxied_response_csp(upgrade_insecure=True)
+        assert "upgrade-insecure-requests" in csp

--- a/tinyagentos/routes/desktop_browser/csp.py
+++ b/tinyagentos/routes/desktop_browser/csp.py
@@ -57,13 +57,12 @@ _DIRECTIVES = (
     "font-src 'self' data:",
     # Form submissions may not target third parties.
     "form-action 'self'",
-    # Block legacy mixed-content in case the proxied page uses http://
-    # subresources after we serve over https://.
-    "upgrade-insecure-requests",
 )
 
 
-def proxied_response_csp(shell_origin: str | None = None) -> str:
+def proxied_response_csp(
+    shell_origin: str | None = None, *, upgrade_insecure: bool = False
+) -> str:
     """Return the strict CSP header value for proxied HTML responses.
 
     ``frame-ancestors`` is computed here rather than baked into the static
@@ -77,8 +76,18 @@ def proxied_response_csp(shell_origin: str | None = None) -> str:
     ``shell_origin`` should be ``scheme://host[:port]`` of the main taOS
     origin. When ``None`` (single-port fallback, where the proxy is served
     from the main origin itself), ``'self'`` alone is correct.
+
+    ``upgrade_insecure`` adds ``upgrade-insecure-requests``. This MUST only be
+    set when the proxy origin is served over HTTPS: rewritten subresources
+    point at the proxy origin (``http://host:proxy_port/...`` on a plain-HTTP
+    LAN deploy), and this directive would force-upgrade them to ``https://``
+    that the HTTP-only origin can't serve — breaking every stylesheet, script,
+    and image. Pass the request scheme through so HTTP deploys stay functional.
     """
     ancestors = "frame-ancestors 'self'"
     if shell_origin:
         ancestors += f" {shell_origin}"
-    return "; ".join((*_DIRECTIVES, ancestors))
+    directives = [*_DIRECTIVES, ancestors]
+    if upgrade_insecure:
+        directives.append("upgrade-insecure-requests")
+    return "; ".join(directives)

--- a/tinyagentos/routes/desktop_browser/proxy.py
+++ b/tinyagentos/routes/desktop_browser/proxy.py
@@ -128,14 +128,19 @@ def _shell_origin(request: Request) -> str | None:
     host = _strip_port(request.headers.get("host") or "")
     if not host:
         return None
-    # Behind a proxy, x-forwarded-proto may be a comma list ("https, http").
-    # Clamp to a known scheme so a hostile value can't deform the CSP.
+    return f"{_request_scheme(request)}://{host}:{main_port}"
+
+
+def _request_scheme(request: Request) -> str:
+    """The effective scheme of the request, clamped to http/https.
+
+    Honours ``x-forwarded-proto`` (which may be a comma list behind chained
+    proxies — take the first) so a hostile/odd value can't deform the CSP.
+    """
     scheme = (
         request.headers.get("x-forwarded-proto") or request.url.scheme or "http"
     ).split(",")[0].strip().lower()
-    if scheme not in ("http", "https"):
-        scheme = "http"
-    return f"{scheme}://{host}:{main_port}"
+    return scheme if scheme in ("http", "https") else "http"
 
 
 def _strip_port(host_header: str) -> str:
@@ -347,7 +352,10 @@ async def proxy_get(
                 )
             )
 
-        out_headers["content-security-policy"] = proxied_response_csp(_shell_origin(request))
+        out_headers["content-security-policy"] = proxied_response_csp(
+            _shell_origin(request),
+            upgrade_insecure=_request_scheme(request) == "https",
+        )
         return Response(
             content=injected,
             status_code=response.status_code,


### PR DESCRIPTION
## Problem
On a plain-HTTP LAN deploy (the default), the proxied-response CSP unconditionally included `upgrade-insecure-requests`. The rewriter points every subresource at the proxy origin (`http://host:proxy_port/...`), and that directive forces the browser to upgrade them to `https://` — which the HTTP-only proxy origin can't serve. Result: **every stylesheet, script, image, and the injected copilot.js failed with `ERR_SSL_PROTOCOL_ERROR`**, so real sites rendered unstyled with dead buttons (their JS never loaded).

## Fix
Emit `upgrade-insecure-requests` **only when the proxy request is HTTPS** (`_request_scheme(request) == "https"`). HTTPS deploys keep the mixed-content protection; HTTP deploys work. Scheme detection factored into `_request_scheme()` (also reused by `_shell_origin`).

## Verification (live on a Pi)
`google.com`: **24 `ERR_SSL_PROTOCOL_ERROR`s → 0 console errors**, page renders styled and interactive (Sign-in button, consent dialog) instead of faint/broken.

## Tests
Added: directive absent by default, present when `upgrade_insecure=True`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined Content Security Policy configuration to conditionally apply the `upgrade-insecure-requests` directive only for HTTPS-only proxy environments, improving security accuracy across different proxy configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->