### PR TITLE
feat(browser): hybrid browser Phase 1 — user-owned live sessions (controller + SPA)

### DIFF
--- a/desktop/src/apps/BrowserApp/Chrome.tsx
+++ b/desktop/src/apps/BrowserApp/Chrome.tsx
@@ -19,6 +19,7 @@ import { SettingsPanel } from "./SettingsPanel";
 import { AgentPickerPopover } from "./AgentPickerPopover";
 import { AgentPresencePill } from "./AgentPresencePill";
 import { CoPilotBanner } from "./CoPilotBanner";
+import { EscalateButton } from "./EscalateButton";
 
 interface ChromeProps {
   windowId: string;
@@ -128,6 +129,11 @@ export function Chrome({ windowId }: ChromeProps) {
       >
         <RotateCw size={16} />
       </button>
+
+      {/* Escalate to full browser (Neko session) */}
+      <div className="relative flex items-center">
+        <EscalateButton tabUrl={activeTab.url} />
+      </div>
 
       {/* Spacer pushes the profile chip to the right */}
       <div className="flex-1" />

--- a/desktop/src/apps/BrowserApp/Chrome.tsx
+++ b/desktop/src/apps/BrowserApp/Chrome.tsx
@@ -132,7 +132,7 @@ export function Chrome({ windowId }: ChromeProps) {
 
       {/* Escalate to full browser (Neko session) */}
       <div className="relative flex items-center">
-        <EscalateButton tabUrl={activeTab.url} />
+        <EscalateButton tabUrl={activeTab.url} tabId={activeTab.id} windowId={windowId} />
       </div>
 
       {/* Spacer pushes the profile chip to the right */}

--- a/desktop/src/apps/BrowserApp/EscalateButton.tsx
+++ b/desktop/src/apps/BrowserApp/EscalateButton.tsx
@@ -4,15 +4,18 @@
  * Extracted as a standalone component so it's independently testable without
  * mounting the full BrowserApp tree.
  *
- * State machine (local only — no store changes):
- *   idle → starting (POST 201) → polling → live  (render LiveBrowserView)
- *   idle → no_node             (POST 409)         (render gate banner)
+ * State machine (local only — transient UI states):
+ *   idle → starting (POST 201) → polling → calls store.setTabLiveSession
+ *   idle → no_node             (POST 409) → render gate banner
+ *
+ * On success the liveSession is stored in the tab via setTabLiveSession so
+ * TabRenderer can render LiveBrowserView in the tab body (not the toolbar).
  *
  * Polling: every ~1.5 s, cap 20 tries (~30 s).
  */
 import { useState, useRef, useCallback } from "react";
 import { MonitorPlay } from "lucide-react";
-import { LiveBrowserView } from "./LiveBrowserView";
+import { useBrowserStore } from "@/stores/browser-store";
 
 interface BrowserSession {
   id: string;
@@ -25,7 +28,6 @@ type EscalateState =
   | { phase: "idle" }
   | { phase: "starting" }
   | { phase: "polling"; sessionId: string }
-  | { phase: "live"; nekoUrl: string; streamToken: string }
   | { phase: "no_node" };
 
 const POLL_INTERVAL_MS = 1500;
@@ -34,13 +36,19 @@ const POLL_MAX_TRIES = 20;
 interface EscalateButtonProps {
   /** The URL of the current tab — sent as the body of POST /api/browser/sessions */
   tabUrl: string;
+  /** The id of the active tab — used to set liveSession in the store on success */
+  tabId: string;
+  /** The windowId — used to set liveSession in the store on success */
+  windowId: string;
 }
 
-export function EscalateButton({ tabUrl }: EscalateButtonProps) {
+export function EscalateButton({ tabUrl, tabId, windowId }: EscalateButtonProps) {
   const [state, setState] = useState<EscalateState>({ phase: "idle" });
   const pollRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const triesRef = useRef(0);
   const cancelledRef = useRef(false);
+
+  const setTabLiveSession = useBrowserStore((s) => s.setTabLiveSession);
 
   const stopPolling = useCallback(() => {
     if (pollRef.current) {
@@ -48,6 +56,11 @@ export function EscalateButton({ tabUrl }: EscalateButtonProps) {
       pollRef.current = null;
     }
   }, []);
+
+  const goLive = useCallback((nekoUrl: string, streamToken: string) => {
+    setTabLiveSession(windowId, tabId, { nekoUrl, streamToken });
+    setState({ phase: "idle" });
+  }, [setTabLiveSession, windowId, tabId]);
 
   const poll = useCallback((sessionId: string) => {
     if (cancelledRef.current) return;
@@ -68,11 +81,7 @@ export function EscalateButton({ tabUrl }: EscalateButtonProps) {
         }
         const session: BrowserSession = await resp.json();
         if (session.status === "running" && session.neko_url && session.stream_token) {
-          setState({
-            phase: "live",
-            nekoUrl: session.neko_url,
-            streamToken: session.stream_token,
-          });
+          goLive(session.neko_url, session.stream_token);
         } else {
           // Still pending — schedule next poll
           pollRef.current = setTimeout(() => poll(sessionId), POLL_INTERVAL_MS);
@@ -81,7 +90,7 @@ export function EscalateButton({ tabUrl }: EscalateButtonProps) {
       .catch(() => {
         if (!cancelledRef.current) setState({ phase: "idle" });
       });
-  }, []);
+  }, [goLive]);
 
   const handleEscalate = useCallback(async () => {
     if (state.phase !== "idle") return;
@@ -129,20 +138,13 @@ export function EscalateButton({ tabUrl }: EscalateButtonProps) {
 
     // If already running (fast path), go live immediately
     if (session.status === "running" && session.neko_url && session.stream_token) {
-      setState({ phase: "live", nekoUrl: session.neko_url, streamToken: session.stream_token });
+      goLive(session.neko_url, session.stream_token);
       return;
     }
 
     setState({ phase: "polling", sessionId: session.id });
     poll(session.id);
-  }, [state.phase, tabUrl, poll]);
-
-  // If live, render the browser view filling the parent
-  if (state.phase === "live") {
-    return (
-      <LiveBrowserView nekoUrl={state.nekoUrl} streamToken={state.streamToken} />
-    );
-  }
+  }, [state.phase, tabUrl, poll, goLive]);
 
   return (
     <>

--- a/desktop/src/apps/BrowserApp/EscalateButton.tsx
+++ b/desktop/src/apps/BrowserApp/EscalateButton.tsx
@@ -1,0 +1,193 @@
+/**
+ * EscalateButton — "Open in full browser" control + live session lifecycle.
+ *
+ * Extracted as a standalone component so it's independently testable without
+ * mounting the full BrowserApp tree.
+ *
+ * State machine (local only — no store changes):
+ *   idle → starting (POST 201) → polling → live  (render LiveBrowserView)
+ *   idle → no_node             (POST 409)         (render gate banner)
+ *
+ * Polling: every ~1.5 s, cap 20 tries (~30 s).
+ */
+import { useState, useRef, useCallback } from "react";
+import { MonitorPlay } from "lucide-react";
+import { LiveBrowserView } from "./LiveBrowserView";
+
+interface BrowserSession {
+  id: string;
+  status: string;
+  neko_url: string | null;
+  stream_token?: string | null;
+}
+
+type EscalateState =
+  | { phase: "idle" }
+  | { phase: "starting" }
+  | { phase: "polling"; sessionId: string }
+  | { phase: "live"; nekoUrl: string; streamToken: string }
+  | { phase: "no_node" };
+
+const POLL_INTERVAL_MS = 1500;
+const POLL_MAX_TRIES = 20;
+
+interface EscalateButtonProps {
+  /** The URL of the current tab — sent as the body of POST /api/browser/sessions */
+  tabUrl: string;
+}
+
+export function EscalateButton({ tabUrl }: EscalateButtonProps) {
+  const [state, setState] = useState<EscalateState>({ phase: "idle" });
+  const pollRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const triesRef = useRef(0);
+  const cancelledRef = useRef(false);
+
+  const stopPolling = useCallback(() => {
+    if (pollRef.current) {
+      clearTimeout(pollRef.current);
+      pollRef.current = null;
+    }
+  }, []);
+
+  const poll = useCallback((sessionId: string) => {
+    if (cancelledRef.current) return;
+    triesRef.current += 1;
+    if (triesRef.current > POLL_MAX_TRIES) {
+      setState({ phase: "idle" });
+      return;
+    }
+
+    fetch(`/api/browser/sessions/${encodeURIComponent(sessionId)}`, {
+      credentials: "include",
+    })
+      .then(async (resp) => {
+        if (cancelledRef.current) return;
+        if (!resp.ok) {
+          setState({ phase: "idle" });
+          return;
+        }
+        const session: BrowserSession = await resp.json();
+        if (session.status === "running" && session.neko_url && session.stream_token) {
+          setState({
+            phase: "live",
+            nekoUrl: session.neko_url,
+            streamToken: session.stream_token,
+          });
+        } else {
+          // Still pending — schedule next poll
+          pollRef.current = setTimeout(() => poll(sessionId), POLL_INTERVAL_MS);
+        }
+      })
+      .catch(() => {
+        if (!cancelledRef.current) setState({ phase: "idle" });
+      });
+  }, []);
+
+  const handleEscalate = useCallback(async () => {
+    if (state.phase !== "idle") return;
+    cancelledRef.current = false;
+    triesRef.current = 0;
+    setState({ phase: "starting" });
+
+    let resp: Response;
+    try {
+      resp = await fetch("/api/browser/sessions", {
+        method: "POST",
+        credentials: "include",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ url: tabUrl }),
+      });
+    } catch {
+      setState({ phase: "idle" });
+      return;
+    }
+
+    if (resp.status === 409) {
+      let body: { error?: string } = {};
+      try { body = await resp.json(); } catch { /* ignore */ }
+      if (body.error === "no_capable_node") {
+        setState({ phase: "no_node" });
+      } else {
+        setState({ phase: "idle" });
+      }
+      return;
+    }
+
+    if (!resp.ok) {
+      setState({ phase: "idle" });
+      return;
+    }
+
+    let session: BrowserSession;
+    try {
+      const body = await resp.json();
+      session = body.session ?? body;
+    } catch {
+      setState({ phase: "idle" });
+      return;
+    }
+
+    // If already running (fast path), go live immediately
+    if (session.status === "running" && session.neko_url && session.stream_token) {
+      setState({ phase: "live", nekoUrl: session.neko_url, streamToken: session.stream_token });
+      return;
+    }
+
+    setState({ phase: "polling", sessionId: session.id });
+    poll(session.id);
+  }, [state.phase, tabUrl, poll]);
+
+  // If live, render the browser view filling the parent
+  if (state.phase === "live") {
+    return (
+      <LiveBrowserView nekoUrl={state.nekoUrl} streamToken={state.streamToken} />
+    );
+  }
+
+  return (
+    <>
+      {/* The trigger button — always present so the toolbar keeps its shape */}
+      <button
+        type="button"
+        aria-label="Open in full browser"
+        disabled={state.phase !== "idle"}
+        onClick={handleEscalate}
+        className="p-1 rounded hover:bg-shell-hover disabled:opacity-40 disabled:cursor-not-allowed"
+        title="Open in full browser"
+      >
+        <MonitorPlay size={16} />
+      </button>
+
+      {/* Starting / polling indicator */}
+      {(state.phase === "starting" || state.phase === "polling") && (
+        <span className="text-xs text-shell-text-secondary px-1">
+          Starting full browser…
+        </span>
+      )}
+
+      {/* No-node gate banner */}
+      {state.phase === "no_node" && (
+        <div
+          role="alert"
+          className="absolute top-full left-0 right-0 z-50 flex items-start gap-2 px-3 py-2 bg-shell-surface border border-shell-border-subtle text-shell-text-secondary text-xs shadow-md"
+        >
+          <span className="flex-1">
+            A full browser needs a more capable device on your taOS. Add one to enable this.
+          </span>
+          <button
+            type="button"
+            aria-label="Dismiss"
+            onClick={() => {
+              stopPolling();
+              cancelledRef.current = true;
+              setState({ phase: "idle" });
+            }}
+            className="shrink-0 p-0.5 rounded hover:bg-shell-hover"
+          >
+            ✕
+          </button>
+        </div>
+      )}
+    </>
+  );
+}

--- a/desktop/src/apps/BrowserApp/LiveBrowserView.tsx
+++ b/desktop/src/apps/BrowserApp/LiveBrowserView.tsx
@@ -1,0 +1,28 @@
+/**
+ * LiveBrowserView — thin presentational component for a live Neko browser session.
+ *
+ * Token convention: the stream token is appended as a URL fragment:
+ *   <nekoUrl>#token=<streamToken>
+ * The Neko room page reads window.location.hash on load and uses the token to
+ * authenticate the WebRTC/WebSocket connection. Fragment params never reach the
+ * server in HTTP logs, which keeps the token out of access logs.
+ */
+
+interface LiveBrowserViewProps {
+  nekoUrl: string;
+  streamToken: string;
+}
+
+export function LiveBrowserView({ nekoUrl, streamToken }: LiveBrowserViewProps) {
+  // Append the token as a fragment so the Neko room can read it client-side.
+  const src = `${nekoUrl}#token=${streamToken}`;
+
+  return (
+    <iframe
+      title="Full browser"
+      src={src}
+      sandbox="allow-scripts allow-same-origin allow-forms"
+      style={{ width: "100%", height: "100%", borderStyle: "none", borderWidth: 0, display: "block" }}
+    />
+  );
+}

--- a/desktop/src/apps/BrowserApp/TabRenderer.test.tsx
+++ b/desktop/src/apps/BrowserApp/TabRenderer.test.tsx
@@ -308,6 +308,57 @@ describe("TabRenderer — graceful handling", () => {
   });
 });
 
+describe("TabRenderer — liveSession renders LiveBrowserView", () => {
+  it("renders a LiveBrowserView iframe (src contains nekoUrl) instead of the proxy iframe when liveSession is set", async () => {
+    const tabId = useBrowserStore.getState().getWindow(TEST_WINDOW_ID)!.tabs[0].id;
+    useBrowserStore.getState().navigateTab(
+      TEST_WINDOW_ID,
+      tabId,
+      "https://example.com/",
+    );
+    useBrowserStore.getState().setTabLiveSession(TEST_WINDOW_ID, tabId, {
+      nekoUrl: "http://neko.local:8080/room",
+      streamToken: "tok-live",
+    });
+
+    const { container } = render(<TabRenderer windowId={TEST_WINDOW_ID} />);
+    const iframes = container.querySelectorAll("iframe");
+    // Should be exactly one iframe — the LiveBrowserView one
+    expect(iframes.length).toBe(1);
+    const iframe = iframes[0] as HTMLIFrameElement;
+    expect(iframe.src).toContain("http://neko.local:8080/room");
+    expect(iframe.src).toContain("tok-live");
+    expect(iframe.title).toBe("Full browser");
+  });
+
+  it("returns to the proxy iframe after liveSession is cleared (navigateTab)", async () => {
+    const tabId = useBrowserStore.getState().getWindow(TEST_WINDOW_ID)!.tabs[0].id;
+    useBrowserStore.getState().navigateTab(
+      TEST_WINDOW_ID,
+      tabId,
+      "https://example.com/",
+    );
+    useBrowserStore.getState().setTabLiveSession(TEST_WINDOW_ID, tabId, {
+      nekoUrl: "http://neko.local:8080/room",
+      streamToken: "tok-live",
+    });
+    // Navigate away — clears liveSession
+    useBrowserStore.getState().navigateTab(
+      TEST_WINDOW_ID,
+      tabId,
+      "https://other.com/",
+    );
+
+    const { container } = render(<TabRenderer windowId={TEST_WINDOW_ID} />);
+    const iframes = container.querySelectorAll("iframe");
+    expect(iframes.length).toBe(1);
+    const iframe = iframes[0] as HTMLIFrameElement;
+    // Should NOT be the Neko URL
+    expect(iframe.src).not.toContain("neko.local");
+    expect(iframe.title).not.toBe("Full browser");
+  });
+});
+
 describe("TabRenderer — reader mode", () => {
   it("renders ReaderMode for active tab when readerActive is true", () => {
     const tabId = useBrowserStore.getState().getWindow(TEST_WINDOW_ID)!.activeTabId;

--- a/desktop/src/apps/BrowserApp/TabRenderer.tsx
+++ b/desktop/src/apps/BrowserApp/TabRenderer.tsx
@@ -33,6 +33,7 @@ import { openParentWs } from "./agent-ws-bridge";
 import type { AgentWsHandle } from "./agent-ws-bridge";
 import { detectLiveExclusion } from "./live-exclusion";
 import { ReaderMode } from "./ReaderMode";
+import { LiveBrowserView } from "./LiveBrowserView";
 import { AgentPanel } from "./AgentPanel";
 import { PageContextMenu } from "./PageContextMenu";
 import type { Tab } from "./types";
@@ -277,6 +278,22 @@ export function TabRenderer({ windowId }: TabRendererProps) {
           }
 
           const showReader = isActive && !!tab.readerActive && !!tab.readerExtract;
+
+          // Full Neko session replaces the proxy iframe for the active tab
+          if (isActive && tab.liveSession) {
+            return (
+              <div
+                key={tab.id}
+                style={{ position: "absolute", inset: 0 }}
+                data-window-tab={tab.id}
+              >
+                <LiveBrowserView
+                  nekoUrl={tab.liveSession.nekoUrl}
+                  streamToken={tab.liveSession.streamToken}
+                />
+              </div>
+            );
+          }
 
           return (
             <div

--- a/desktop/src/apps/BrowserApp/__tests__/LiveBrowserView.test.tsx
+++ b/desktop/src/apps/BrowserApp/__tests__/LiveBrowserView.test.tsx
@@ -6,11 +6,13 @@ import { useBrowserStore } from "@/stores/browser-store";
 
 const originalFetch = global.fetch;
 
+const WIN_ID = "win-1";
+
 beforeEach(() => {
   useBrowserStore.setState({ windows: {} });
-  useBrowserStore.getState().createWindow("win-1", "personal");
-  const tabId = useBrowserStore.getState().getWindow("win-1")!.tabs[0].id;
-  useBrowserStore.getState().navigateTab("win-1", tabId, "https://example.com/");
+  useBrowserStore.getState().createWindow(WIN_ID, "personal");
+  const tabId = useBrowserStore.getState().getWindow(WIN_ID)!.tabs[0].id;
+  useBrowserStore.getState().navigateTab(WIN_ID, tabId, "https://example.com/");
 });
 
 afterEach(() => {
@@ -65,8 +67,10 @@ describe("EscalateButton — no-node gate", () => {
       json: async () => ({ error: "no_capable_node" }),
     } as Response);
 
-    const tabUrl = useBrowserStore.getState().getWindow("win-1")!.tabs[0].url;
-    render(<EscalateButton tabUrl={tabUrl} />);
+    const win = useBrowserStore.getState().getWindow(WIN_ID)!;
+    const tabId = win.tabs[0].id;
+    const tabUrl = win.tabs[0].url;
+    render(<EscalateButton tabUrl={tabUrl} tabId={tabId} windowId={WIN_ID} />);
 
     fireEvent.click(screen.getByRole("button", { name: /open in full browser/i }));
 
@@ -89,7 +93,14 @@ describe("EscalateButton — no-node gate", () => {
       json: async () => ({ error: "no_capable_node" }),
     } as Response);
 
-    render(<EscalateButton tabUrl="https://example.com/" />);
+    const win = useBrowserStore.getState().getWindow(WIN_ID)!;
+    render(
+      <EscalateButton
+        tabUrl="https://example.com/"
+        tabId={win.tabs[0].id}
+        windowId={WIN_ID}
+      />,
+    );
     fireEvent.click(screen.getByRole("button", { name: /open in full browser/i }));
 
     await waitFor(() => screen.getByRole("alert"));
@@ -112,11 +123,105 @@ describe("EscalateButton — no-node gate", () => {
         json: async () => ({ id: "sess-1", status: "pending", neko_url: null }),
       } as Response);
 
-    render(<EscalateButton tabUrl="https://example.com/" />);
+    const win = useBrowserStore.getState().getWindow(WIN_ID)!;
+    render(
+      <EscalateButton
+        tabUrl="https://example.com/"
+        tabId={win.tabs[0].id}
+        windowId={WIN_ID}
+      />,
+    );
     fireEvent.click(screen.getByRole("button", { name: /open in full browser/i }));
 
     await waitFor(() => {
       expect(screen.getByText(/Starting full browser/i)).toBeTruthy();
+    });
+  });
+});
+
+// ── Test C: EscalateButton sets liveSession in store on success ───────────────
+
+describe("EscalateButton — sets tab liveSession on success", () => {
+  it("calls setTabLiveSession when POST returns a running session", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: async () => ({
+        session: {
+          id: "sess-2",
+          status: "running",
+          neko_url: "http://neko.local:8080/room",
+          stream_token: "tok-xyz",
+        },
+      }),
+    } as Response);
+
+    const win = useBrowserStore.getState().getWindow(WIN_ID)!;
+    const tabId = win.tabs[0].id;
+    render(
+      <EscalateButton
+        tabUrl="https://example.com/"
+        tabId={tabId}
+        windowId={WIN_ID}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /open in full browser/i }));
+
+    await waitFor(() => {
+      const tab = useBrowserStore.getState().getWindow(WIN_ID)!.tabs.find(
+        (t) => t.id === tabId,
+      );
+      expect(tab?.liveSession).toEqual({
+        nekoUrl: "http://neko.local:8080/room",
+        streamToken: "tok-xyz",
+      });
+    });
+
+    // EscalateButton itself should NOT render a LiveBrowserView iframe
+    expect(screen.queryByTitle("Full browser")).toBeNull();
+  });
+
+  it("sets liveSession via poll when session is initially pending", async () => {
+    global.fetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        json: async () => ({
+          session: { id: "sess-3", status: "pending", neko_url: null, stream_token: null },
+        }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          id: "sess-3",
+          status: "running",
+          neko_url: "http://neko.local:8080/room",
+          stream_token: "tok-poll",
+        }),
+      } as Response);
+
+    const win = useBrowserStore.getState().getWindow(WIN_ID)!;
+    const tabId = win.tabs[0].id;
+    render(
+      <EscalateButton
+        tabUrl="https://example.com/"
+        tabId={tabId}
+        windowId={WIN_ID}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /open in full browser/i }));
+
+    await waitFor(() => {
+      const tab = useBrowserStore.getState().getWindow(WIN_ID)!.tabs.find(
+        (t) => t.id === tabId,
+      );
+      expect(tab?.liveSession).toEqual({
+        nekoUrl: "http://neko.local:8080/room",
+        streamToken: "tok-poll",
+      });
     });
   });
 });

--- a/desktop/src/apps/BrowserApp/__tests__/LiveBrowserView.test.tsx
+++ b/desktop/src/apps/BrowserApp/__tests__/LiveBrowserView.test.tsx
@@ -1,0 +1,122 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import { LiveBrowserView } from "../LiveBrowserView";
+import { EscalateButton } from "../EscalateButton";
+import { useBrowserStore } from "@/stores/browser-store";
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  useBrowserStore.setState({ windows: {} });
+  useBrowserStore.getState().createWindow("win-1", "personal");
+  const tabId = useBrowserStore.getState().getWindow("win-1")!.tabs[0].id;
+  useBrowserStore.getState().navigateTab("win-1", tabId, "https://example.com/");
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+  cleanup();
+});
+
+// ── Test A: LiveBrowserView renders iframe with nekoUrl + streamToken ──────────
+
+describe("LiveBrowserView", () => {
+  it("renders an iframe whose src contains the nekoUrl and streamToken", () => {
+    const { container } = render(
+      <LiveBrowserView
+        nekoUrl="http://node:8080/room"
+        streamToken="tok123"
+      />,
+    );
+    const iframe = container.querySelector("iframe");
+    expect(iframe).not.toBeNull();
+    expect(iframe!.src).toContain("http://node:8080/room");
+    expect(iframe!.src).toContain("tok123");
+  });
+
+  it("renders with title 'Full browser'", () => {
+    const { container } = render(
+      <LiveBrowserView nekoUrl="http://node:8080/room" streamToken="tok123" />,
+    );
+    const iframe = container.querySelector("iframe");
+    expect(iframe!.title).toBe("Full browser");
+  });
+
+  it("fills its container (100% width and height, no border)", () => {
+    const { container } = render(
+      <LiveBrowserView nekoUrl="http://node:8080/room" streamToken="tok123" />,
+    );
+    const iframe = container.querySelector("iframe") as HTMLIFrameElement;
+    expect(iframe.style.width).toBe("100%");
+    expect(iframe.style.height).toBe("100%");
+    // jsdom normalises "border:none" → borderWidth=0, borderStyle=none
+    expect(iframe.style.borderStyle).toBe("none");
+  });
+});
+
+// ── Test B: EscalateButton gate banner on 409 no_capable_node ─────────────────
+
+describe("EscalateButton — no-node gate", () => {
+  it("shows the gate banner when POST returns 409 no_capable_node", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 409,
+      json: async () => ({ error: "no_capable_node" }),
+    } as Response);
+
+    const tabUrl = useBrowserStore.getState().getWindow("win-1")!.tabs[0].url;
+    render(<EscalateButton tabUrl={tabUrl} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /open in full browser/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/A full browser needs a more capable device/i),
+      ).toBeTruthy();
+    });
+
+    const alert = screen.getByRole("alert");
+    expect(alert.textContent).toContain(
+      "A full browser needs a more capable device on your taOS. Add one to enable this.",
+    );
+  });
+
+  it("gate banner is dismissible", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 409,
+      json: async () => ({ error: "no_capable_node" }),
+    } as Response);
+
+    render(<EscalateButton tabUrl="https://example.com/" />);
+    fireEvent.click(screen.getByRole("button", { name: /open in full browser/i }));
+
+    await waitFor(() => screen.getByRole("alert"));
+    fireEvent.click(screen.getByRole("button", { name: /dismiss/i }));
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("shows 'Starting full browser…' state after a successful 201", async () => {
+    // First call: POST 201 (session pending). Second call: GET poll — stays pending,
+    // but we only care about the "Starting full browser…" UI transition here.
+    global.fetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        json: async () => ({ session: { id: "sess-1", status: "pending", neko_url: null } }),
+      } as Response)
+      .mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ id: "sess-1", status: "pending", neko_url: null }),
+      } as Response);
+
+    render(<EscalateButton tabUrl="https://example.com/" />);
+    fireEvent.click(screen.getByRole("button", { name: /open in full browser/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Starting full browser/i)).toBeTruthy();
+    });
+  });
+});

--- a/desktop/src/apps/BrowserApp/types.ts
+++ b/desktop/src/apps/BrowserApp/types.ts
@@ -37,6 +37,8 @@ export interface Tab {
   readerExtract?: ReaderExtract | null;
   /** Agent IDs pinned to this tab — sticky across navigation and discard. */
   pinnedAgentIds: string[];
+  /** Set when a full Neko browser session is live for this tab. */
+  liveSession?: { nekoUrl: string; streamToken: string };
 }
 
 export interface RecentlyClosedTab {

--- a/desktop/src/stores/browser-store.test.ts
+++ b/desktop/src/stores/browser-store.test.ts
@@ -537,6 +537,75 @@ describe("browser-store: switchProfile snapshot/restore", () => {
   });
 });
 
+describe("browser-store: setTabLiveSession", () => {
+  beforeEach(async () => {
+    const mod = await import("./browser-store");
+    mod.useBrowserStore.setState({ windows: {} });
+  });
+
+  it("sets liveSession on the correct tab", async () => {
+    const s = await freshStore();
+    s.createWindow("win-1", "personal");
+    const tabId = s.getWindow("win-1")!.tabs[0].id;
+
+    s.setTabLiveSession("win-1", tabId, {
+      nekoUrl: "http://neko.local:8080/room",
+      streamToken: "tok-abc",
+    });
+
+    const tab = s.getWindow("win-1")!.tabs[0];
+    expect(tab.liveSession).toEqual({
+      nekoUrl: "http://neko.local:8080/room",
+      streamToken: "tok-abc",
+    });
+  });
+
+  it("clears liveSession when called with null", async () => {
+    const s = await freshStore();
+    s.createWindow("win-1", "personal");
+    const tabId = s.getWindow("win-1")!.tabs[0].id;
+
+    s.setTabLiveSession("win-1", tabId, {
+      nekoUrl: "http://neko.local:8080/room",
+      streamToken: "tok-abc",
+    });
+    s.setTabLiveSession("win-1", tabId, null);
+
+    const tab = s.getWindow("win-1")!.tabs[0];
+    expect(tab.liveSession).toBeUndefined();
+  });
+
+  it("only updates the targeted tab, not others", async () => {
+    const s = await freshStore();
+    s.createWindow("win-1", "personal");
+    const tabA = s.getWindow("win-1")!.tabs[0].id;
+    const tabB = s.addTab("win-1", "https://b.test/");
+
+    s.setTabLiveSession("win-1", tabA, {
+      nekoUrl: "http://neko.local:8080/room",
+      streamToken: "tok-a",
+    });
+
+    const tabBData = s.getWindow("win-1")!.tabs.find((t) => t.id === tabB);
+    expect(tabBData?.liveSession).toBeUndefined();
+  });
+
+  it("navigateTab clears liveSession", async () => {
+    const s = await freshStore();
+    s.createWindow("win-1", "personal");
+    const tabId = s.getWindow("win-1")!.tabs[0].id;
+
+    s.setTabLiveSession("win-1", tabId, {
+      nekoUrl: "http://neko.local:8080/room",
+      streamToken: "tok-abc",
+    });
+    s.navigateTab("win-1", tabId, "https://new-page.test/");
+
+    const tab = s.getWindow("win-1")!.tabs[0];
+    expect(tab.liveSession).toBeUndefined();
+  });
+});
+
 describe("browser-store: pinnedAgentIds", () => {
   beforeEach(async () => {
     const mod = await import("./browser-store");

--- a/desktop/src/stores/browser-store.ts
+++ b/desktop/src/stores/browser-store.ts
@@ -91,6 +91,13 @@ interface BrowserStore {
     patch: Partial<Pick<Tab, "readerAvailable" | "readerActive" | "readerExtract">>,
   ) => void;
 
+  // Live session (full Neko browser) — set/clear per tab
+  setTabLiveSession: (
+    windowId: string,
+    tabId: string,
+    liveSession: { nekoUrl: string; streamToken: string } | null,
+  ) => void;
+
   // Agent pin set — local state mutations; server calls happen via browser-agent-api.ts
   addPinnedAgent: (windowId: string, tabId: string, agentId: string) => void;
   removePinnedAgent: (windowId: string, tabId: string, agentId: string) => void;
@@ -253,10 +260,11 @@ export const useBrowserStore = create<BrowserStore>((set, get) => ({
         historyIndex: newHistory.length - 1,
         state: "live",
         lastActiveAt: Date.now(),
-        // Reset reader state on navigation — new URL invalidates the extract
+        // Reset reader state and live session on navigation
         readerAvailable: undefined,
         readerActive: undefined,
         readerExtract: null,
+        liveSession: undefined,
       };
     }));
   },
@@ -366,6 +374,13 @@ export const useBrowserStore = create<BrowserStore>((set, get) => ({
       };
     });
   },
+  setTabLiveSession(windowId, tabId, liveSession) {
+    set((s) => updateTab(s, windowId, tabId, (t) => ({
+      ...t,
+      liveSession: liveSession ?? undefined,
+    })));
+  },
+
   setTabReader(windowId, tabId, patch) {
     set((s) => updateTab(s, windowId, tabId, (t) => ({ ...t, ...patch })));
   },

--- a/tests/routes/desktop_browser/test_session_token.py
+++ b/tests/routes/desktop_browser/test_session_token.py
@@ -1,0 +1,130 @@
+"""Tests for scoped per-session stream tokens (session_token.py)."""
+from __future__ import annotations
+
+import time
+from unittest.mock import patch
+
+import pytest
+
+from tinyagentos.shortcuts.tickets import JtiTracker
+
+KEY = b"a" * 32  # exactly 32 bytes, minimal valid key
+SHORT_KEY = b"tooshort"
+
+
+def _fresh_tracker() -> JtiTracker:
+    return JtiTracker()
+
+
+class TestMintValidateRoundtrip:
+    def test_returns_correct_session_and_user(self):
+        from tinyagentos.routes.desktop_browser.session_token import mint_session_token, validate_session_token
+
+        tracker = _fresh_tracker()
+        payload, token = mint_session_token("sess-123", "user-abc", KEY)
+
+        assert payload["session_id"] == "sess-123"
+        assert payload["user_id"] == "user-abc"
+        assert "exp" in payload
+        assert isinstance(token, str)
+
+        result = validate_session_token(token, KEY, tracker=tracker)
+        assert result["session_id"] == "sess-123"
+        assert result["user_id"] == "user-abc"
+
+    def test_mint_payload_has_no_jti(self):
+        """mint returns only session_id, user_id, exp — jti is internal."""
+        from tinyagentos.routes.desktop_browser.session_token import mint_session_token
+
+        payload, _ = mint_session_token("s", "u", KEY)
+        assert set(payload.keys()) == {"session_id", "user_id", "exp"}
+
+    def test_exp_is_in_future(self):
+        from tinyagentos.routes.desktop_browser.session_token import mint_session_token
+
+        payload, _ = mint_session_token("s", "u", KEY, ttl=60)
+        assert payload["exp"] > int(time.time())
+
+
+class TestTamperedToken:
+    def test_tampered_token_raises(self):
+        from tinyagentos.routes.desktop_browser.session_token import mint_session_token, validate_session_token
+
+        tracker = _fresh_tracker()
+        _, token = mint_session_token("sess-1", "user-1", KEY)
+        # Flip the last character
+        tampered = token[:-1] + ("A" if token[-1] != "A" else "B")
+        with pytest.raises(ValueError):
+            validate_session_token(tampered, KEY, tracker=tracker)
+
+    def test_wrong_key_raises(self):
+        from tinyagentos.routes.desktop_browser.session_token import mint_session_token, validate_session_token
+
+        tracker = _fresh_tracker()
+        _, token = mint_session_token("sess-2", "user-2", KEY)
+        wrong_key = b"b" * 32
+        with pytest.raises(ValueError):
+            validate_session_token(token, wrong_key, tracker=tracker)
+
+
+class TestExpiredToken:
+    def test_expired_token_raises(self):
+        from tinyagentos.routes.desktop_browser.session_token import mint_session_token, validate_session_token
+
+        tracker = _fresh_tracker()
+        _, token = mint_session_token("sess-3", "user-3", KEY, ttl=60)
+        # Advance time past expiry
+        future = int(time.time()) + 120
+        with patch("tinyagentos.routes.desktop_browser.session_token.time") as mock_time:
+            mock_time.time.return_value = future
+            with pytest.raises(ValueError, match="expired"):
+                validate_session_token(token, KEY, tracker=tracker)
+
+    def test_zero_ttl_expires_immediately(self):
+        from tinyagentos.routes.desktop_browser.session_token import mint_session_token, validate_session_token
+
+        tracker = _fresh_tracker()
+        _, token = mint_session_token("sess-4", "user-4", KEY, ttl=0)
+        future = int(time.time()) + 5
+        with patch("tinyagentos.routes.desktop_browser.session_token.time") as mock_time:
+            mock_time.time.return_value = future
+            with pytest.raises(ValueError, match="expired"):
+                validate_session_token(token, KEY, tracker=tracker)
+
+
+class TestReplay:
+    def test_replay_raises_on_second_validate(self):
+        from tinyagentos.routes.desktop_browser.session_token import mint_session_token, validate_session_token
+
+        tracker = _fresh_tracker()
+        _, token = mint_session_token("sess-5", "user-5", KEY)
+        # First validation succeeds
+        validate_session_token(token, KEY, tracker=tracker)
+        # Second validation with the same token must fail
+        with pytest.raises(ValueError, match="replay"):
+            validate_session_token(token, KEY, tracker=tracker)
+
+    def test_different_tokens_each_succeed(self):
+        from tinyagentos.routes.desktop_browser.session_token import mint_session_token, validate_session_token
+
+        tracker = _fresh_tracker()
+        _, token1 = mint_session_token("sess-6", "user-6", KEY)
+        _, token2 = mint_session_token("sess-6", "user-6", KEY)
+        validate_session_token(token1, KEY, tracker=tracker)
+        validate_session_token(token2, KEY, tracker=tracker)  # different jti, must pass
+
+
+class TestShortKey:
+    def test_mint_short_key_raises(self):
+        from tinyagentos.routes.desktop_browser.session_token import mint_session_token
+
+        with pytest.raises(ValueError, match="32 bytes"):
+            mint_session_token("s", "u", SHORT_KEY)
+
+    def test_validate_short_key_raises(self):
+        from tinyagentos.routes.desktop_browser.session_token import mint_session_token, validate_session_token
+
+        tracker = _fresh_tracker()
+        _, token = mint_session_token("s", "u", KEY)
+        with pytest.raises(ValueError, match="32 bytes"):
+            validate_session_token(token, SHORT_KEY, tracker=tracker)

--- a/tests/routes/test_browser_sessions_routes.py
+++ b/tests/routes/test_browser_sessions_routes.py
@@ -2,13 +2,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from unittest.mock import AsyncMock, MagicMock, patch
 from typing import Any
 
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
-from tinyagentos.browser_sessions import BrowserSessionManager
+from tinyagentos.browser_sessions import BrowserSessionManager, BrowserWorkerError
 
 
 # ---------------------------------------------------------------------------
@@ -22,6 +23,7 @@ class _StubWorker:
     hardware: dict = field(default_factory=dict)
     load: float = 0.0
     capabilities: list[str] = field(default_factory=lambda: ["browser"])
+    url: str = "http://worker.example:7080"
 
 
 class _StubCluster:
@@ -30,6 +32,12 @@ class _StubCluster:
 
     def get_workers(self) -> list[_StubWorker]:
         return self._workers
+
+    def get_worker(self, name: str) -> _StubWorker | None:
+        for w in self._workers:
+            if w.name == name:
+                return w
+        return None
 
 
 def _capable_worker() -> _StubWorker:
@@ -47,6 +55,19 @@ def _no_cluster() -> _StubCluster:
 
 def _capable_cluster() -> _StubCluster:
     return _StubCluster(workers=[_capable_worker()])
+
+
+def _make_mock_httpx_client(status_code: int, json_body: dict):
+    """Return a patched httpx.AsyncClient context manager returning a stub response."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_body
+    resp.text = str(json_body)
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.post = AsyncMock(return_value=resp)
+    return mock_client
 
 
 # ---------------------------------------------------------------------------
@@ -125,15 +146,62 @@ async def test_post_session_unauthenticated(app, tmp_path):
     await app.state.browser_sessions.close()
 
 
+_WORKER_START_BODY = {
+    "container_id": "ctr-test-01",
+    "neko_url": "http://10.0.0.5:8800/?usr=neko&pwd=testpwd",
+    "cdp_url": None,
+    "http_port": 8800,
+    "epr_lo": 59000,
+    "epr_hi": 59009,
+}
+
+
 @pytest.mark.asyncio
 async def test_post_session_capable_node_returns_201(client):
-    """Authed POST with a capable node returns 201 and a pending session."""
-    resp = await client.post("/api/browser/sessions", json={"url": "https://example.com"})
+    """Authed POST with a capable node returns 201 and a running session."""
+    mock_client = _make_mock_httpx_client(200, _WORKER_START_BODY)
+    with patch("tinyagentos.browser_sessions.httpx.AsyncClient", return_value=mock_client):
+        resp = await client.post("/api/browser/sessions", json={"url": "https://example.com"})
     assert resp.status_code == 201
     body = resp.json()
-    assert body["status"] == "pending"
+    assert body["status"] == "running"
     assert body["url"] == "https://example.com"
+    assert body["container_id"] == "ctr-test-01"
     assert "id" in body
+
+
+@pytest.mark.asyncio
+async def test_post_session_worker_start_failure_returns_502(client):
+    """When start_on_worker raises BrowserWorkerError the route returns 502."""
+    mock_client = _make_mock_httpx_client(500, {"error": "docker failed"})
+    with patch("tinyagentos.browser_sessions.httpx.AsyncClient", return_value=mock_client):
+        resp = await client.post("/api/browser/sessions", json={"url": "https://example.com"})
+    assert resp.status_code == 502
+    assert resp.json()["error"] == "worker_start_failed"
+
+
+@pytest.mark.asyncio
+async def test_post_session_specific_node_returns_201(client):
+    """Authed POST with explicit node= returns 201 when node is capable."""
+    mock_client = _make_mock_httpx_client(200, _WORKER_START_BODY)
+    with patch("tinyagentos.browser_sessions.httpx.AsyncClient", return_value=mock_client):
+        resp = await client.post(
+            "/api/browser/sessions",
+            json={"url": "https://example.com", "node": "node-1"},
+        )
+    assert resp.status_code == 201
+    assert resp.json()["status"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_post_session_specific_unknown_node_returns_409(client):
+    """Authed POST with explicit node that is not capable returns 409."""
+    resp = await client.post(
+        "/api/browser/sessions",
+        json={"url": "https://example.com", "node": "nonexistent-node"},
+    )
+    assert resp.status_code == 409
+    assert resp.json()["error"] == "no_capable_node"
 
 
 @pytest.mark.asyncio
@@ -150,9 +218,11 @@ async def test_post_session_no_capable_node_returns_409(client_no_node):
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_get_own_pending_session_no_stream_token(client):
-    """GET own pending session returns 200 with no stream_token."""
-    create_resp = await client.post("/api/browser/sessions", json={"url": "https://example.com"})
+async def test_get_own_running_session_has_stream_token(client):
+    """GET own running session returns 200 with a stream_token."""
+    mock_client = _make_mock_httpx_client(200, _WORKER_START_BODY)
+    with patch("tinyagentos.browser_sessions.httpx.AsyncClient", return_value=mock_client):
+        create_resp = await client.post("/api/browser/sessions", json={"url": "https://example.com"})
     assert create_resp.status_code == 201
     session_id = create_resp.json()["id"]
 
@@ -160,8 +230,8 @@ async def test_get_own_pending_session_no_stream_token(client):
     assert resp.status_code == 200
     body = resp.json()
     assert body["id"] == session_id
-    assert body["status"] == "pending"
-    assert "stream_token" not in body
+    assert body["status"] == "running"
+    assert "stream_token" in body
 
 
 @pytest.mark.asyncio
@@ -208,12 +278,63 @@ async def test_get_other_users_session_returns_404(app, tmp_path):
 
 @pytest.mark.asyncio
 async def test_terminate_own_session_returns_ok(client):
-    """Terminate own session returns {ok: true}."""
-    create_resp = await client.post("/api/browser/sessions", json={"url": "https://example.com"})
+    """Terminate own running session calls stop_on_worker and returns {ok: true}."""
+    start_mock = _make_mock_httpx_client(200, _WORKER_START_BODY)
+    with patch("tinyagentos.browser_sessions.httpx.AsyncClient", return_value=start_mock):
+        create_resp = await client.post("/api/browser/sessions", json={"url": "https://example.com"})
     assert create_resp.status_code == 201
     session_id = create_resp.json()["id"]
 
-    resp = await client.post(f"/api/browser/sessions/{session_id}/terminate")
+    stop_mock = _make_mock_httpx_client(200, {"ok": True})
+    with patch("tinyagentos.browser_sessions.httpx.AsyncClient", return_value=stop_mock):
+        resp = await client.post(f"/api/browser/sessions/{session_id}/terminate")
     assert resp.status_code == 200
     body = resp.json()
     assert body["ok"] is True
+    # Verify stop was called
+    stop_mock.post.assert_awaited_once()
+    call_kwargs = stop_mock.post.call_args
+    assert "/worker/browser/stop" in call_kwargs.args[0]
+
+
+# ---------------------------------------------------------------------------
+# GET /api/browser/nodes
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_browser_nodes_unauthenticated(app, tmp_path):
+    """Unauthenticated GET /api/browser/nodes must return 401."""
+    app.state.browser_sessions = BrowserSessionManager(tmp_path / "bs_nodes.db", mock=True)
+    await app.state.browser_sessions.init()
+    app.state.browser_session_signing_key = b"0" * 32
+    app.state.cluster_manager = _capable_cluster()
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        resp = await c.get("/api/browser/nodes")
+    assert resp.status_code == 401
+    await app.state.browser_sessions.close()
+
+
+@pytest.mark.asyncio
+async def test_get_browser_nodes_returns_capable_nodes(client):
+    """GET /api/browser/nodes returns the list of capable nodes."""
+    resp = await client.get("/api/browser/nodes")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "nodes" in body
+    assert len(body["nodes"]) == 1
+    node = body["nodes"][0]
+    assert node["name"] == "node-1"
+    assert "gpu" in node
+    assert "ram_mb" in node
+    assert "cores" in node
+    assert "load" in node
+
+
+@pytest.mark.asyncio
+async def test_get_browser_nodes_empty_when_no_capable_workers(client_no_node):
+    """GET /api/browser/nodes returns empty list when no capable workers."""
+    resp = await client_no_node.get("/api/browser/nodes")
+    assert resp.status_code == 200
+    assert resp.json() == {"nodes": []}

--- a/tests/routes/test_browser_sessions_routes.py
+++ b/tests/routes/test_browser_sessions_routes.py
@@ -1,0 +1,218 @@
+"""Tests for /api/browser/sessions routes (Task 4)."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from tinyagentos.browser_sessions import BrowserSessionManager
+
+
+# ---------------------------------------------------------------------------
+# Stub cluster manager
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _StubWorker:
+    name: str
+    status: str = "online"
+    hardware: dict = field(default_factory=dict)
+    load: float = 0.0
+
+
+class _StubCluster:
+    def __init__(self, workers: list[_StubWorker]):
+        self._workers = workers
+
+    def get_workers(self) -> list[_StubWorker]:
+        return self._workers
+
+
+def _capable_worker() -> _StubWorker:
+    return _StubWorker(
+        name="node-1",
+        status="online",
+        hardware={"ram_mb": 8192, "cpu": {"cores": 8}},
+        load=0.2,
+    )
+
+
+def _no_cluster() -> _StubCluster:
+    return _StubCluster(workers=[])
+
+
+def _capable_cluster() -> _StubCluster:
+    return _StubCluster(workers=[_capable_worker()])
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture
+async def client(app, tmp_path):
+    """Async client with browser_sessions store, signing key, and cluster stub injected."""
+    bs = BrowserSessionManager(tmp_path / "bs.db", mock=True)
+    await bs.init()
+
+    app.state.browser_sessions = bs
+    app.state.browser_session_signing_key = b"0" * 32
+    app.state.cluster_manager = _capable_cluster()
+
+    # Set up auth
+    app.state.auth.setup_user("admin", "Test Admin", "", "testpass")
+    record = app.state.auth.find_user("admin")
+    uid = record["id"] if record else ""
+    token = app.state.auth.create_session(user_id=uid, long_lived=True)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        cookies={"taos_session": token},
+    ) as c:
+        yield c
+
+    await bs.close()
+
+
+@pytest_asyncio.fixture
+async def client_no_node(app, tmp_path):
+    """Same as client but cluster has no capable workers."""
+    bs = BrowserSessionManager(tmp_path / "bs2.db", mock=True)
+    await bs.init()
+
+    app.state.browser_sessions = bs
+    app.state.browser_session_signing_key = b"0" * 32
+    app.state.cluster_manager = _no_cluster()
+
+    app.state.auth.setup_user("admin", "Test Admin", "", "testpass")
+    record = app.state.auth.find_user("admin")
+    uid = record["id"] if record else ""
+    token = app.state.auth.create_session(user_id=uid, long_lived=True)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        cookies={"taos_session": token},
+    ) as c:
+        yield c
+
+    await bs.close()
+
+
+# ---------------------------------------------------------------------------
+# POST /api/browser/sessions
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_post_session_unauthenticated(app, tmp_path):
+    """Unauthenticated POST must return 401."""
+    app.state.browser_sessions = BrowserSessionManager(tmp_path / "bs_unauth.db", mock=True)
+    await app.state.browser_sessions.init()
+    app.state.browser_session_signing_key = b"0" * 32
+    app.state.cluster_manager = _capable_cluster()
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        resp = await c.post("/api/browser/sessions", json={"url": "https://example.com"})
+    assert resp.status_code == 401
+    await app.state.browser_sessions.close()
+
+
+@pytest.mark.asyncio
+async def test_post_session_capable_node_returns_201(client):
+    """Authed POST with a capable node returns 201 and a pending session."""
+    resp = await client.post("/api/browser/sessions", json={"url": "https://example.com"})
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["status"] == "pending"
+    assert body["url"] == "https://example.com"
+    assert "id" in body
+
+
+@pytest.mark.asyncio
+async def test_post_session_no_capable_node_returns_409(client_no_node):
+    """Authed POST with no capable node returns 409 no_capable_node."""
+    resp = await client_no_node.post("/api/browser/sessions", json={"url": "https://example.com"})
+    assert resp.status_code == 409
+    body = resp.json()
+    assert body["error"] == "no_capable_node"
+
+
+# ---------------------------------------------------------------------------
+# GET /api/browser/sessions/{id}
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_own_pending_session_no_stream_token(client):
+    """GET own pending session returns 200 with no stream_token."""
+    create_resp = await client.post("/api/browser/sessions", json={"url": "https://example.com"})
+    assert create_resp.status_code == 201
+    session_id = create_resp.json()["id"]
+
+    resp = await client.get(f"/api/browser/sessions/{session_id}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"] == session_id
+    assert body["status"] == "pending"
+    assert "stream_token" not in body
+
+
+@pytest.mark.asyncio
+async def test_get_nonexistent_session_returns_404(client):
+    """GET a session that doesn't exist returns 404."""
+    resp = await client.get("/api/browser/sessions/nonexistent-id")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_other_users_session_returns_404(app, tmp_path):
+    """GET another user's session returns 404 (ownership check)."""
+    # Create a session owned by a different user directly via manager
+    bs = BrowserSessionManager(tmp_path / "bs_other.db", mock=True)
+    await bs.init()
+    session = await bs.create_session("user", "other-user-id", "https://example.com")
+    session_id = session["id"]
+
+    app.state.browser_sessions = bs
+    app.state.browser_session_signing_key = b"0" * 32
+    app.state.cluster_manager = _capable_cluster()
+
+    # Auth as a different user (admin)
+    app.state.auth.setup_user("admin", "Test Admin", "", "testpass")
+    record = app.state.auth.find_user("admin")
+    uid = record["id"] if record else ""
+    token = app.state.auth.create_session(user_id=uid, long_lived=True)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        cookies={"taos_session": token},
+    ) as c:
+        resp = await c.get(f"/api/browser/sessions/{session_id}")
+
+    assert resp.status_code == 404
+    await bs.close()
+
+
+# ---------------------------------------------------------------------------
+# POST /api/browser/sessions/{id}/terminate
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_terminate_own_session_returns_ok(client):
+    """Terminate own session returns {ok: true}."""
+    create_resp = await client.post("/api/browser/sessions", json={"url": "https://example.com"})
+    assert create_resp.status_code == 201
+    session_id = create_resp.json()["id"]
+
+    resp = await client.post(f"/api/browser/sessions/{session_id}/terminate")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True

--- a/tests/routes/test_browser_sessions_routes.py
+++ b/tests/routes/test_browser_sessions_routes.py
@@ -21,6 +21,7 @@ class _StubWorker:
     status: str = "online"
     hardware: dict = field(default_factory=dict)
     load: float = 0.0
+    capabilities: list[str] = field(default_factory=lambda: ["browser"])
 
 
 class _StubCluster:

--- a/tests/test_browser_sessions.py
+++ b/tests/test_browser_sessions.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 import pytest_asyncio
 from pathlib import Path
 
-from tinyagentos.browser_sessions import BrowserSessionManager, pick_browser_node
+from tinyagentos.browser_sessions import (
+    BrowserSessionManager,
+    BrowserWorkerError,
+    list_browser_nodes,
+    pick_browser_node,
+)
 
 
 @pytest_asyncio.fixture
@@ -273,3 +280,206 @@ async def test_reap_idle_nothing_stale_returns_empty(mgr):
 
     reaped = await mgr.reap_idle(now=now)
     assert reaped == []
+
+
+# ---------------------------------------------------------------------------
+# start_on_worker / stop_on_worker / mark_error tests
+# ---------------------------------------------------------------------------
+
+def _make_mock_response(status_code: int, json_body: dict):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_body
+    resp.text = str(json_body)
+    return resp
+
+
+@pytest.mark.asyncio
+async def test_start_on_worker_success(mgr):
+    session = await mgr.create_session("user", "u1", "https://example.com")
+    sid = session["id"]
+
+    worker_resp = _make_mock_response(200, {
+        "container_id": "ctr-xyz",
+        "neko_url": "http://10.0.0.5:8800/?usr=neko&pwd=abc",
+        "cdp_url": None,
+        "http_port": 8800,
+        "epr_lo": 59000,
+        "epr_hi": 59009,
+    })
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.post = AsyncMock(return_value=worker_resp)
+
+    with patch("tinyagentos.browser_sessions.httpx.AsyncClient", return_value=mock_client):
+        result = await mgr.start_on_worker(
+            sid,
+            node="node-1",
+            worker_url="http://worker.example:7080",
+            profile_volume=f"taos-browser-{sid}",
+        )
+
+    assert result["status"] == "running"
+    assert result["container_id"] == "ctr-xyz"
+    assert result["neko_url"] == "http://10.0.0.5:8800/?usr=neko&pwd=abc"
+    assert result["node"] == "node-1"
+
+    # Confirm DB was updated
+    fetched = await mgr.get_session(sid)
+    assert fetched["status"] == "running"
+    assert fetched["container_id"] == "ctr-xyz"
+
+
+@pytest.mark.asyncio
+async def test_start_on_worker_non_200_marks_error_and_raises(mgr):
+    session = await mgr.create_session("user", "u2", "https://example.com")
+    sid = session["id"]
+
+    worker_resp = _make_mock_response(500, {"error": "docker failed"})
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.post = AsyncMock(return_value=worker_resp)
+
+    with patch("tinyagentos.browser_sessions.httpx.AsyncClient", return_value=mock_client):
+        with pytest.raises(BrowserWorkerError):
+            await mgr.start_on_worker(
+                sid,
+                node="node-1",
+                worker_url="http://worker.example:7080",
+                profile_volume=f"taos-browser-{sid}",
+            )
+
+    fetched = await mgr.get_session(sid)
+    assert fetched["status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_start_on_worker_exception_marks_error_and_raises(mgr):
+    session = await mgr.create_session("user", "u3", "https://example.com")
+    sid = session["id"]
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.post = AsyncMock(side_effect=Exception("connection refused"))
+
+    with patch("tinyagentos.browser_sessions.httpx.AsyncClient", return_value=mock_client):
+        with pytest.raises(BrowserWorkerError):
+            await mgr.start_on_worker(
+                sid,
+                node="node-1",
+                worker_url="http://worker.example:7080",
+                profile_volume=f"taos-browser-{sid}",
+            )
+
+    fetched = await mgr.get_session(sid)
+    assert fetched["status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_stop_on_worker_failure_does_not_raise(mgr):
+    session = await mgr.create_session("user", "u4", "https://example.com")
+    sid = session["id"]
+    await mgr.mark_running(
+        sid, node="node-1", container_id="ctr-1",
+        neko_url="http://neko:8080", cdp_url=None,
+    )
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.post = AsyncMock(side_effect=Exception("network error"))
+
+    with patch("tinyagentos.browser_sessions.httpx.AsyncClient", return_value=mock_client):
+        # Must not raise
+        await mgr.stop_on_worker(
+            sid, worker_url="http://worker.example:7080",
+            container_id="ctr-1",
+        )
+
+    fetched = await mgr.get_session(sid)
+    assert fetched["status"] == "stopped"
+
+
+@pytest.mark.asyncio
+async def test_stop_on_worker_set_status_none_leaves_status_unchanged(mgr):
+    session = await mgr.create_session("user", "u5", "https://example.com")
+    sid = session["id"]
+    await mgr.mark_running(
+        sid, node="node-1", container_id="ctr-2",
+        neko_url="http://neko:8081", cdp_url=None,
+    )
+    # Simulate reap already flipped to idle
+    db = mgr._assert_db()
+    await db.execute("UPDATE browser_sessions SET status='idle' WHERE id=?", (sid,))
+    await db.commit()
+
+    worker_resp = _make_mock_response(200, {"ok": True})
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.post = AsyncMock(return_value=worker_resp)
+
+    with patch("tinyagentos.browser_sessions.httpx.AsyncClient", return_value=mock_client):
+        await mgr.stop_on_worker(
+            sid, worker_url="http://worker.example:7080",
+            container_id="ctr-2", set_status=None,
+        )
+
+    fetched = await mgr.get_session(sid)
+    assert fetched["status"] == "idle"
+
+
+# ---------------------------------------------------------------------------
+# list_browser_nodes tests
+# ---------------------------------------------------------------------------
+
+class TestListBrowserNodes:
+    def test_returns_only_capable_nodes(self):
+        cluster = _FakeCluster([
+            _FakeWorker("capable", "online", _hw(ram_mb=8192, cores=8)),
+            _FakeWorker("no-cap", "online", _hw(ram_mb=8192, cores=8), capabilities=["embed"]),
+            _FakeWorker("offline", "offline", _hw(ram_mb=8192, cores=8)),
+        ])
+        nodes = list_browser_nodes(cluster)
+        assert len(nodes) == 1
+        assert nodes[0]["name"] == "capable"
+
+    def test_node_dict_shape(self):
+        cluster = _FakeCluster([
+            _FakeWorker("w1", "online", _hw(ram_mb=8192, cores=8, cuda=True, vram_mb=4096), load=0.3),
+        ])
+        nodes = list_browser_nodes(cluster)
+        assert len(nodes) == 1
+        n = nodes[0]
+        assert n["name"] == "w1"
+        assert n["gpu"] is True
+        assert n["ram_mb"] == 8192
+        assert n["cores"] == 8
+        assert n["load"] == 0.3
+
+    def test_gpu_first_ordering(self):
+        cluster = _FakeCluster([
+            _FakeWorker("cpu-node", "online", _hw(ram_mb=8192, cores=8, cuda=False), load=0.1),
+            _FakeWorker("gpu-node", "online", _hw(ram_mb=8192, cores=8, cuda=True, vram_mb=8192), load=0.5),
+        ])
+        nodes = list_browser_nodes(cluster)
+        assert nodes[0]["name"] == "gpu-node"
+        assert nodes[1]["name"] == "cpu-node"
+
+    def test_same_gpu_tier_sorted_by_load(self):
+        cluster = _FakeCluster([
+            _FakeWorker("heavy", "online", _hw(ram_mb=8192, cores=8), load=0.8),
+            _FakeWorker("light", "online", _hw(ram_mb=8192, cores=8), load=0.2),
+        ])
+        nodes = list_browser_nodes(cluster)
+        assert nodes[0]["name"] == "light"
+        assert nodes[1]["name"] == "heavy"
+
+    def test_empty_cluster_returns_empty_list(self):
+        cluster = _FakeCluster([])
+        assert list_browser_nodes(cluster) == []

--- a/tests/test_browser_sessions.py
+++ b/tests/test_browser_sessions.py
@@ -4,7 +4,7 @@ import pytest
 import pytest_asyncio
 from pathlib import Path
 
-from tinyagentos.browser_sessions import BrowserSessionManager
+from tinyagentos.browser_sessions import BrowserSessionManager, pick_browser_node
 
 
 @pytest_asyncio.fixture
@@ -106,3 +106,88 @@ async def test_terminate_session(mgr):
     # Unknown id returns False
     result2 = await mgr.terminate_session("does-not-exist")
     assert result2 is False
+
+
+# ---------------------------------------------------------------------------
+# pick_browser_node tests
+# ---------------------------------------------------------------------------
+
+def _hw(ram_mb: int = 8192, cores: int = 8, cuda: bool = False, vram_mb: int = 0) -> dict:
+    """Build a minimal hardware dict matching the HardwareProfile asdict shape."""
+    return {
+        "ram_mb": ram_mb,
+        "cpu": {"cores": cores},
+        "gpu": {"cuda": cuda, "vram_mb": vram_mb},
+    }
+
+
+class _FakeWorker:
+    def __init__(self, name: str, status: str, hardware: dict, load: float = 0.0) -> None:
+        self.name = name
+        self.status = status
+        self.hardware = hardware
+        self.load = load
+
+
+class _FakeCluster:
+    def __init__(self, workers: list) -> None:
+        self._workers = workers
+
+    def get_workers(self) -> list:
+        return self._workers
+
+
+class TestPickBrowserNode:
+    def test_no_workers_returns_none(self):
+        cluster = _FakeCluster([])
+        assert pick_browser_node(cluster) is None
+
+    def test_under_spec_ram_returns_none(self):
+        cluster = _FakeCluster([
+            _FakeWorker("w1", "online", _hw(ram_mb=2048, cores=8)),
+        ])
+        assert pick_browser_node(cluster) is None
+
+    def test_offline_capable_node_returns_none(self):
+        cluster = _FakeCluster([
+            _FakeWorker("w1", "offline", _hw(ram_mb=8192, cores=8)),
+        ])
+        assert pick_browser_node(cluster) is None
+
+    def test_single_capable_node_returned(self):
+        cluster = _FakeCluster([
+            _FakeWorker("w1", "online", _hw(ram_mb=8192, cores=8)),
+        ])
+        assert pick_browser_node(cluster) == "w1"
+
+    def test_prefers_gpu_capable_node(self):
+        cluster = _FakeCluster([
+            _FakeWorker("cpu-node", "online", _hw(ram_mb=8192, cores=8, cuda=False), load=0.1),
+            _FakeWorker("gpu-node", "online", _hw(ram_mb=8192, cores=8, cuda=True, vram_mb=8192), load=0.5),
+        ])
+        assert pick_browser_node(cluster) == "gpu-node"
+
+    def test_same_gpu_status_prefers_lower_load(self):
+        cluster = _FakeCluster([
+            _FakeWorker("heavy", "online", _hw(ram_mb=8192, cores=8), load=0.8),
+            _FakeWorker("light", "online", _hw(ram_mb=8192, cores=8), load=0.2),
+        ])
+        assert pick_browser_node(cluster) == "light"
+
+    def test_under_spec_cores_returns_none(self):
+        cluster = _FakeCluster([
+            _FakeWorker("w1", "online", _hw(ram_mb=8192, cores=2)),
+        ])
+        assert pick_browser_node(cluster) is None
+
+    def test_missing_hardware_keys_treated_as_zero(self):
+        cluster = _FakeCluster([
+            _FakeWorker("w1", "online", {}),
+        ])
+        assert pick_browser_node(cluster) is None
+
+    def test_exact_min_spec_qualifies(self):
+        cluster = _FakeCluster([
+            _FakeWorker("w1", "online", _hw(ram_mb=4096, cores=4)),
+        ])
+        assert pick_browser_node(cluster) == "w1"

--- a/tests/test_browser_sessions.py
+++ b/tests/test_browser_sessions.py
@@ -191,3 +191,71 @@ class TestPickBrowserNode:
             _FakeWorker("w1", "online", _hw(ram_mb=4096, cores=4)),
         ])
         assert pick_browser_node(cluster) == "w1"
+
+
+# ---------------------------------------------------------------------------
+# reap_idle tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_reap_idle_returns_only_stale_session(mgr):
+    base = 1_000_000.0
+    fresh_session = await mgr.create_session("user", "user-1", "https://fresh.com", now=base)
+    stale_session = await mgr.create_session("user", "user-2", "https://stale.com", now=base)
+
+    await mgr.mark_running(
+        fresh_session["id"],
+        node="n1", container_id="ctr-1", neko_url="http://neko:8080", cdp_url="ws://cdp:9222",
+        now=base,
+    )
+    await mgr.mark_running(
+        stale_session["id"],
+        node="n2", container_id="ctr-2", neko_url="http://neko:8081", cdp_url="ws://cdp:9223",
+        now=base,
+    )
+
+    # Fresh session touched recently; stale session last touched 1000s ago
+    now = base + 2000.0
+    await mgr.touch_active(fresh_session["id"], now=now - 10)
+    await mgr.touch_active(stale_session["id"], now=base + 100)  # 1900s ago relative to now
+
+    reaped = await mgr.reap_idle(now=now)
+
+    assert reaped == [stale_session["id"]]
+
+    stale_row = await mgr.get_session(stale_session["id"])
+    assert stale_row["status"] == "idle"
+
+    fresh_row = await mgr.get_session(fresh_session["id"])
+    assert fresh_row["status"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_reap_idle_skips_pending_session(mgr):
+    base = 1_000_000.0
+    pending_session = await mgr.create_session("user", "user-1", "https://pending.com", now=base)
+    # pending session has an old last_active but should NOT be reaped (only running sessions are)
+
+    now = base + 2000.0
+    reaped = await mgr.reap_idle(now=now)
+
+    assert pending_session["id"] not in reaped
+    row = await mgr.get_session(pending_session["id"])
+    assert row["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_reap_idle_nothing_stale_returns_empty(mgr):
+    base = 1_000_000.0
+    session = await mgr.create_session("user", "user-1", "https://active.com", now=base)
+    await mgr.mark_running(
+        session["id"],
+        node="n1", container_id="ctr-1", neko_url="http://neko:8080", cdp_url="ws://cdp:9222",
+        now=base,
+    )
+    # Touch it fresh relative to now
+    now = base + 100.0
+    await mgr.touch_active(session["id"], now=now - 10)
+
+    reaped = await mgr.reap_idle(now=now)
+    assert reaped == []

--- a/tests/test_browser_sessions.py
+++ b/tests/test_browser_sessions.py
@@ -122,11 +122,19 @@ def _hw(ram_mb: int = 8192, cores: int = 8, cuda: bool = False, vram_mb: int = 0
 
 
 class _FakeWorker:
-    def __init__(self, name: str, status: str, hardware: dict, load: float = 0.0) -> None:
+    def __init__(
+        self,
+        name: str,
+        status: str,
+        hardware: dict,
+        load: float = 0.0,
+        capabilities: list[str] | None = None,
+    ) -> None:
         self.name = name
         self.status = status
         self.hardware = hardware
         self.load = load
+        self.capabilities = capabilities if capabilities is not None else ["browser"]
 
 
 class _FakeCluster:
@@ -191,6 +199,12 @@ class TestPickBrowserNode:
             _FakeWorker("w1", "online", _hw(ram_mb=4096, cores=4)),
         ])
         assert pick_browser_node(cluster) == "w1"
+
+    def test_capable_node_without_browser_capability_returns_none(self):
+        cluster = _FakeCluster([
+            _FakeWorker("w1", "online", _hw(ram_mb=8192, cores=8), capabilities=["embed"]),
+        ])
+        assert pick_browser_node(cluster) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_browser_sessions.py
+++ b/tests/test_browser_sessions.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from pathlib import Path
+
+from tinyagentos.browser_sessions import BrowserSessionManager
+
+
+@pytest_asyncio.fixture
+async def mgr(tmp_path):
+    m = BrowserSessionManager(db_path=tmp_path / "browser_sessions.db", mock=True)
+    await m.init()
+    yield m
+    await m.close()
+
+
+@pytest.mark.asyncio
+async def test_create_and_get_session_roundtrip(mgr):
+    session = await mgr.create_session(
+        owner_type="user",
+        owner_id="user-1",
+        url="https://example.com",
+        profile_name="default",
+    )
+    assert session["owner_type"] == "user"
+    assert session["owner_id"] == "user-1"
+    assert session["url"] == "https://example.com"
+    assert session["profile_name"] == "default"
+    assert session["status"] == "pending"
+    assert "id" in session
+    assert "created_at" in session
+    assert "updated_at" in session
+    assert "last_active" in session
+
+    fetched = await mgr.get_session(session["id"])
+    assert fetched == session
+
+
+@pytest.mark.asyncio
+async def test_list_sessions_filters_by_owner(mgr):
+    await mgr.create_session("user", "user-1", "https://a.com")
+    await mgr.create_session("user", "user-1", "https://b.com")
+    await mgr.create_session("agent", "agent-42", "https://c.com")
+
+    user1_sessions = await mgr.list_sessions("user", "user-1")
+    assert len(user1_sessions) == 2
+    assert all(s["owner_type"] == "user" and s["owner_id"] == "user-1" for s in user1_sessions)
+
+    agent_sessions = await mgr.list_sessions("agent", "agent-42")
+    assert len(agent_sessions) == 1
+    assert agent_sessions[0]["owner_type"] == "agent"
+
+    nobody = await mgr.list_sessions("user", "nobody")
+    assert nobody == []
+
+
+@pytest.mark.asyncio
+async def test_mark_running_sets_fields(mgr):
+    session = await mgr.create_session("agent", "agent-1", "https://work.com")
+    sid = session["id"]
+
+    await mgr.mark_running(
+        sid,
+        node="node-1",
+        container_id="ctr-abc",
+        neko_url="http://neko:8080",
+        cdp_url="ws://cdp:9222",
+    )
+
+    updated = await mgr.get_session(sid)
+    assert updated["status"] == "running"
+    assert updated["node"] == "node-1"
+    assert updated["container_id"] == "ctr-abc"
+    assert updated["neko_url"] == "http://neko:8080"
+    assert updated["cdp_url"] == "ws://cdp:9222"
+
+
+@pytest.mark.asyncio
+async def test_touch_active_updates_last_active(mgr):
+    t0 = 1_000_000.0
+    session = await mgr.create_session("user", "user-2", "https://touch.com", now=t0)
+    sid = session["id"]
+
+    assert session["last_active"] == t0
+
+    t1 = t0 + 60.0
+    await mgr.touch_active(sid, now=t1)
+
+    updated = await mgr.get_session(sid)
+    assert updated["last_active"] == t1
+    assert updated["updated_at"] == t1
+
+
+@pytest.mark.asyncio
+async def test_terminate_session(mgr):
+    session = await mgr.create_session("user", "user-3", "https://stop.com")
+    sid = session["id"]
+
+    result = await mgr.terminate_session(sid)
+    assert result is True
+
+    stopped = await mgr.get_session(sid)
+    assert stopped["status"] == "stopped"
+
+    # Unknown id returns False
+    result2 = await mgr.terminate_session("does-not-exist")
+    assert result2 is False

--- a/tests/worker/test_agent_browser_caps.py
+++ b/tests/worker/test_agent_browser_caps.py
@@ -183,3 +183,45 @@ class TestRegisterWithBrowserCaps:
         assert "browser" in caps
         assert "llm-chat" in caps
         assert "embedding" in caps
+
+    async def test_heartbeat_includes_browser_capability(self):
+        """heartbeat() unions extra_capabilities into the posted caps too."""
+        agent = WorkerAgent(
+            "http://controller:6969",
+            name="browser-node",
+            extra_capabilities=["browser"],
+            advertise_url="http://10.0.0.5:7080",
+        )
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        captured: list[dict] = []
+
+        async def _mock_post(url, json=None, **kwargs):
+            if json is not None:
+                captured.append(json)
+            return mock_response
+
+        snap = {
+            "storage_cap_bytes": 0,
+            "storage_used_bytes": 0,
+            "bytes_deduped_total": 0,
+        }
+
+        with patch("tinyagentos.worker.agent.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.post = AsyncMock(side_effect=_mock_post)
+            mock_client_cls.return_value = mock_client
+
+            with patch("tinyagentos.worker.agent.WorkerAgent.detect_backends", return_value=[]):
+                with patch(
+                    "tinyagentos.cluster.worker_capacity.capacity_snapshot",
+                    return_value=snap,
+                ):
+                    status = await agent.heartbeat()
+
+        assert status == 200
+        assert len(captured) == 1
+        assert "browser" in captured[0]["capabilities"]

--- a/tests/worker/test_agent_browser_caps.py
+++ b/tests/worker/test_agent_browser_caps.py
@@ -1,0 +1,185 @@
+"""Tests for WorkerAgent extra_capabilities + advertise_url (browser-worker additions)."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tinyagentos.worker.agent import WorkerAgent
+
+
+class TestWorkerAgentBrowserCaps:
+    def test_extra_capabilities_stored(self):
+        agent = WorkerAgent(
+            "http://controller:6969",
+            extra_capabilities=["browser"],
+            advertise_url="http://10.0.0.5:7080",
+        )
+        assert "browser" in agent.extra_capabilities
+
+    def test_advertise_url_stored(self):
+        agent = WorkerAgent(
+            "http://controller:6969",
+            extra_capabilities=["browser"],
+            advertise_url="http://10.0.0.5:7080",
+        )
+        assert agent.advertise_url == "http://10.0.0.5:7080"
+
+    def test_no_extra_capabilities_defaults_to_empty(self):
+        agent = WorkerAgent("http://controller:6969")
+        assert agent.extra_capabilities == []
+
+    def test_no_advertise_url_defaults_to_none(self):
+        agent = WorkerAgent("http://controller:6969")
+        assert agent.advertise_url is None
+
+    def test_extra_capabilities_passed_as_none_is_empty(self):
+        agent = WorkerAgent("http://controller:6969", extra_capabilities=None)
+        assert agent.extra_capabilities == []
+
+
+@pytest.mark.asyncio
+class TestRegisterWithBrowserCaps:
+    """Verify register() forwards browser capability + pinned URL to controller."""
+
+    async def test_register_includes_browser_capability(self):
+        agent = WorkerAgent(
+            "http://controller:6969",
+            name="browser-node",
+            extra_capabilities=["browser"],
+            advertise_url="http://10.0.0.5:7080",
+        )
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = MagicMock()
+
+        captured: list[dict] = []
+
+        async def _mock_post(url, json=None, **kwargs):
+            if json is not None:
+                captured.append(json)
+            return mock_response
+
+        with patch("tinyagentos.worker.agent.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.get = AsyncMock(side_effect=Exception("not running"))
+            mock_client.post = AsyncMock(side_effect=_mock_post)
+            mock_client_cls.return_value = mock_client
+
+            with patch("tinyagentos.worker.agent.WorkerAgent.detect_backends", return_value=[]):
+                result = await agent.register()
+
+        assert result is True
+        assert len(captured) == 1
+        payload = captured[0]
+        assert "browser" in payload["capabilities"]
+
+    async def test_register_uses_advertise_url(self):
+        agent = WorkerAgent(
+            "http://controller:6969",
+            name="browser-node",
+            extra_capabilities=["browser"],
+            advertise_url="http://10.0.0.5:7080",
+        )
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = MagicMock()
+
+        captured: list[dict] = []
+
+        async def _mock_post(url, json=None, **kwargs):
+            if json is not None:
+                captured.append(json)
+            return mock_response
+
+        with patch("tinyagentos.worker.agent.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.get = AsyncMock(side_effect=Exception("not running"))
+            mock_client.post = AsyncMock(side_effect=_mock_post)
+            mock_client_cls.return_value = mock_client
+
+            with patch("tinyagentos.worker.agent.WorkerAgent.detect_backends", return_value=[]):
+                await agent.register()
+
+        assert captured[0]["url"] == "http://10.0.0.5:7080"
+
+    async def test_register_without_advertise_url_falls_back(self):
+        """Without advertise_url, register() falls back to get_worker_url()."""
+        agent = WorkerAgent(
+            "http://controller:6969",
+            name="plain-node",
+            worker_port=9999,
+        )
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = MagicMock()
+
+        captured: list[dict] = []
+
+        async def _mock_post(url, json=None, **kwargs):
+            if json is not None:
+                captured.append(json)
+            return mock_response
+
+        with patch("tinyagentos.worker.agent.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.get = AsyncMock(side_effect=Exception("not running"))
+            mock_client.post = AsyncMock(side_effect=_mock_post)
+            mock_client_cls.return_value = mock_client
+
+            with patch("tinyagentos.worker.agent.WorkerAgent.detect_backends", return_value=[]):
+                await agent.register()
+
+        # Should contain :9999 in the URL, not "http://10.0.0.5:7080"
+        assert ":9999" in captured[0]["url"]
+
+    async def test_extra_caps_merged_with_backend_caps(self):
+        """extra_capabilities are unioned with detected backend caps."""
+        agent = WorkerAgent(
+            "http://controller:6969",
+            extra_capabilities=["browser"],
+            advertise_url="http://10.0.0.5:7080",
+        )
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = MagicMock()
+
+        captured: list[dict] = []
+
+        async def _mock_post(url, json=None, **kwargs):
+            if json is not None:
+                captured.append(json)
+            return mock_response
+
+        fake_backend = {
+            "name": "ollama@http://localhost:11434",
+            "type": "ollama",
+            "url": "http://localhost:11434",
+            "capabilities": ["llm-chat", "embedding"],
+            "models": [],
+            "loaded_models": [],
+            "status": "ok",
+            "kv_quant_support": {"k": ["fp16"], "v": ["fp16"], "boundary": False},
+        }
+
+        with patch("tinyagentos.worker.agent.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.post = AsyncMock(side_effect=_mock_post)
+            mock_client_cls.return_value = mock_client
+
+            with patch("tinyagentos.worker.agent.WorkerAgent.detect_backends", return_value=[fake_backend]):
+                with patch("shutil.which", return_value=None):
+                    await agent.register()
+
+        caps = captured[0]["capabilities"]
+        assert "browser" in caps
+        assert "llm-chat" in caps
+        assert "embedding" in caps

--- a/tests/worker/test_browser_container.py
+++ b/tests/worker/test_browser_container.py
@@ -1,0 +1,228 @@
+"""Tests for tinyagentos.worker.browser_container."""
+from __future__ import annotations
+
+import pytest
+
+from tinyagentos.worker.browser_container import (
+    DEFAULT_NEKO_GPU_IMAGE,
+    DEFAULT_NEKO_IMAGE,
+    NEKO_PROFILE_MOUNT,
+    NEKO_SCREEN,
+    BrowserContainerRunner,
+    PortAllocator,
+    build_neko_run_args,
+)
+
+
+# ---------------------------------------------------------------------------
+# build_neko_run_args
+# ---------------------------------------------------------------------------
+
+class TestBuildNekoRunArgs:
+    """Pure-function arg builder — no I/O."""
+
+    def _base_kwargs(self) -> dict:
+        return dict(
+            container_name="taos-neko-abc123",
+            profile_volume="taos-browser-abc123456",
+            node_ip="10.0.0.5",
+            http_port=8800,
+            epr_lo=59000,
+            epr_hi=59009,
+            user_pwd="userpwd1234",
+            admin_pwd="adminpwd5678",
+        )
+
+    def test_starts_with_docker_run(self):
+        args = build_neko_run_args(**self._base_kwargs())
+        assert args[:3] == ["docker", "run", "-d"]
+
+    def test_container_name(self):
+        args = build_neko_run_args(**self._base_kwargs())
+        idx = args.index("--name")
+        assert args[idx + 1] == "taos-neko-abc123"
+
+    def test_http_port_mapping(self):
+        args = build_neko_run_args(**self._base_kwargs())
+        assert "-p" in args
+        port_args = [args[i + 1] for i, a in enumerate(args) if a == "-p"]
+        assert "8800:8080" in port_args
+
+    def test_udp_epr_port_mapping(self):
+        args = build_neko_run_args(**self._base_kwargs())
+        port_args = [args[i + 1] for i, a in enumerate(args) if a == "-p"]
+        assert "59000-59009:59000-59009/udp" in port_args
+
+    def test_screen_env(self):
+        args = build_neko_run_args(**self._base_kwargs())
+        env_pairs = {args[i + 1] for i, a in enumerate(args) if a == "-e"}
+        assert f"NEKO_DESKTOP_SCREEN={NEKO_SCREEN}" in env_pairs
+
+    def test_user_password_env(self):
+        args = build_neko_run_args(**self._base_kwargs())
+        env_pairs = {args[i + 1] for i, a in enumerate(args) if a == "-e"}
+        assert "NEKO_MEMBER_MULTIUSER_USER_PASSWORD=userpwd1234" in env_pairs
+
+    def test_admin_password_env(self):
+        args = build_neko_run_args(**self._base_kwargs())
+        env_pairs = {args[i + 1] for i, a in enumerate(args) if a == "-e"}
+        assert "NEKO_MEMBER_MULTIUSER_ADMIN_PASSWORD=adminpwd5678" in env_pairs
+
+    def test_webrtc_epr_env(self):
+        args = build_neko_run_args(**self._base_kwargs())
+        env_pairs = {args[i + 1] for i, a in enumerate(args) if a == "-e"}
+        assert "NEKO_WEBRTC_EPR=59000-59009" in env_pairs
+
+    def test_nat1to1_env(self):
+        args = build_neko_run_args(**self._base_kwargs())
+        env_pairs = {args[i + 1] for i, a in enumerate(args) if a == "-e"}
+        assert "NEKO_WEBRTC_NAT1TO1=10.0.0.5" in env_pairs
+
+    def test_shm_size(self):
+        args = build_neko_run_args(**self._base_kwargs())
+        assert "--shm-size=2g" in args
+
+    def test_volume_mount(self):
+        args = build_neko_run_args(**self._base_kwargs())
+        vol_args = [args[i + 1] for i, a in enumerate(args) if a == "-v"]
+        assert f"taos-browser-abc123456:{NEKO_PROFILE_MOUNT}" in vol_args
+
+    def test_default_image_cpu(self):
+        args = build_neko_run_args(**self._base_kwargs())
+        assert args[-1] == DEFAULT_NEKO_IMAGE
+
+    def test_gpu_flag_adds_gpus_all(self):
+        args = build_neko_run_args(**self._base_kwargs(), gpu=True)
+        assert "--gpus" in args
+        idx = args.index("--gpus")
+        assert args[idx + 1] == "all"
+
+    def test_gpu_selects_gpu_image(self):
+        args = build_neko_run_args(**self._base_kwargs(), gpu=True)
+        assert args[-1] == DEFAULT_NEKO_GPU_IMAGE
+
+    def test_explicit_image_overrides_default(self):
+        args = build_neko_run_args(**self._base_kwargs(), image="custom/image:tag")
+        assert args[-1] == "custom/image:tag"
+
+    def test_cpu_no_gpus_flag(self):
+        args = build_neko_run_args(**self._base_kwargs(), gpu=False)
+        assert "--gpus" not in args
+
+
+# ---------------------------------------------------------------------------
+# PortAllocator
+# ---------------------------------------------------------------------------
+
+class TestPortAllocator:
+    def test_first_allocation(self):
+        pa = PortAllocator(http_base=9000, epr_base=60000, epr_span=10)
+        http_port, epr_lo, epr_hi = pa.allocate()
+        assert http_port == 9000
+        assert epr_lo == 60000
+        assert epr_hi == 60009
+
+    def test_second_allocation_is_different(self):
+        pa = PortAllocator(http_base=9000, epr_base=60000, epr_span=10)
+        p1 = pa.allocate()
+        p2 = pa.allocate()
+        assert p1[0] != p2[0], "http_port must differ"
+        # EPR ranges must not overlap
+        assert p2[1] >= p1[2] + 1 or p1[1] >= p2[2] + 1
+
+    def test_sequential_http_ports_increase(self):
+        pa = PortAllocator(http_base=8800)
+        ports = [pa.allocate()[0] for _ in range(5)]
+        assert ports == sorted(ports)
+        assert len(set(ports)) == 5
+
+    def test_epr_ranges_are_non_overlapping(self):
+        pa = PortAllocator(epr_base=59000, epr_span=10)
+        ranges = [pa.allocate()[1:] for _ in range(3)]  # [(lo, hi), ...]
+        for i in range(len(ranges)):
+            for j in range(i + 1, len(ranges)):
+                lo_i, hi_i = ranges[i]
+                lo_j, hi_j = ranges[j]
+                assert hi_i < lo_j or hi_j < lo_i, f"Ranges overlap: {ranges[i]} vs {ranges[j]}"
+
+    def test_release_allows_reuse(self):
+        pa = PortAllocator(http_base=8800)
+        p1, _, _ = pa.allocate()
+        pa.release(p1)
+        p2, _, _ = pa.allocate()
+        # After release, next allocate should reuse the freed slot
+        assert p2 == p1
+
+    def test_release_unknown_port_is_noop(self):
+        pa = PortAllocator()
+        pa.release(99999)  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# BrowserContainerRunner (mock mode)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestBrowserContainerRunnerMock:
+    async def test_start_returns_expected_fields(self):
+        runner = BrowserContainerRunner(node_ip="10.0.0.5", mock=True)
+        result = await runner.start(session_id="sess-abc12345", profile_volume="taos-browser-sess-abc12345")
+        assert "container_id" in result
+        assert "neko_url" in result
+        assert "cdp_url" in result
+        assert "http_port" in result
+        assert "epr_lo" in result
+        assert "epr_hi" in result
+
+    async def test_start_container_id_prefix(self):
+        runner = BrowserContainerRunner(node_ip="10.0.0.5", mock=True)
+        result = await runner.start(session_id="sess-abc12345", profile_volume="vol1")
+        assert result["container_id"].startswith("mock-neko-")
+
+    async def test_start_neko_url_contains_node_ip(self):
+        runner = BrowserContainerRunner(node_ip="10.0.0.5", mock=True)
+        result = await runner.start(session_id="sess-abc12345", profile_volume="vol1")
+        assert "10.0.0.5" in result["neko_url"]
+
+    async def test_start_neko_url_contains_usr_neko(self):
+        runner = BrowserContainerRunner(node_ip="10.0.0.5", mock=True)
+        result = await runner.start(session_id="sess-abc12345", profile_volume="vol1")
+        assert "usr=neko" in result["neko_url"]
+
+    async def test_start_neko_url_contains_pwd(self):
+        runner = BrowserContainerRunner(node_ip="10.0.0.5", mock=True)
+        result = await runner.start(session_id="sess-abc12345", profile_volume="vol1")
+        assert "pwd=" in result["neko_url"]
+
+    async def test_start_cdp_url_is_none(self):
+        runner = BrowserContainerRunner(node_ip="10.0.0.5", mock=True)
+        result = await runner.start(session_id="sess-abc12345", profile_volume="vol1")
+        assert result["cdp_url"] is None
+
+    async def test_start_ports_are_integers(self):
+        runner = BrowserContainerRunner(node_ip="10.0.0.5", mock=True)
+        result = await runner.start(session_id="sess-abc12345", profile_volume="vol1")
+        assert isinstance(result["http_port"], int)
+        assert isinstance(result["epr_lo"], int)
+        assert isinstance(result["epr_hi"], int)
+
+    async def test_stop_returns_ok(self):
+        runner = BrowserContainerRunner(node_ip="10.0.0.5", mock=True)
+        result = await runner.stop(container_id="mock-neko-abc12345")
+        assert result == {"ok": True}
+
+    async def test_stop_with_http_port_releases_port(self):
+        runner = BrowserContainerRunner(node_ip="10.0.0.5", mock=True)
+        started = await runner.start(session_id="sess-xyz", profile_volume="vol1")
+        http_port = started["http_port"]
+        await runner.stop(container_id=started["container_id"], http_port=http_port)
+        # After release the next allocation should reuse the port
+        next_started = await runner.start(session_id="sess-xyz2", profile_volume="vol2")
+        assert next_started["http_port"] == http_port
+
+    async def test_concurrent_starts_get_different_ports(self):
+        runner = BrowserContainerRunner(node_ip="10.0.0.5", mock=True)
+        r1 = await runner.start(session_id="sess-1", profile_volume="vol1")
+        r2 = await runner.start(session_id="sess-2", profile_volume="vol2")
+        assert r1["http_port"] != r2["http_port"]
+        assert r1["epr_lo"] != r2["epr_lo"]

--- a/tests/worker/test_browser_container.py
+++ b/tests/worker/test_browser_container.py
@@ -1,6 +1,9 @@
 """Tests for tinyagentos.worker.browser_container."""
 from __future__ import annotations
 
+import asyncio
+from unittest.mock import AsyncMock, patch
+
 import pytest
 
 from tinyagentos.worker.browser_container import (
@@ -9,6 +12,7 @@ from tinyagentos.worker.browser_container import (
     NEKO_PROFILE_MOUNT,
     NEKO_SCREEN,
     BrowserContainerRunner,
+    BrowserContainerError,
     PortAllocator,
     build_neko_run_args,
 )
@@ -231,3 +235,86 @@ class TestBrowserContainerRunnerMock:
         r2 = await runner.start(session_id="sess-2", profile_volume="vol2")
         assert r1["http_port"] != r2["http_port"]
         assert r1["epr_lo"] != r2["epr_lo"]
+
+
+# ---------------------------------------------------------------------------
+# _ensure_image tests (real-mode subprocess mocking)
+# ---------------------------------------------------------------------------
+
+def _make_proc(returncode: int, stdout: bytes = b"", stderr: bytes = b""):
+    """Return an AsyncMock simulating asyncio.subprocess.Process."""
+    proc = AsyncMock()
+    proc.returncode = returncode
+    proc.communicate = AsyncMock(return_value=(stdout, stderr))
+    return proc
+
+
+@pytest.mark.asyncio
+class TestEnsureImage:
+    async def test_image_present_no_pull(self):
+        """When docker image inspect succeeds, docker pull is NOT called."""
+        inspect_proc = _make_proc(returncode=0)
+
+        call_args_list = []
+
+        async def fake_exec(*args, **kwargs):
+            call_args_list.append(args)
+            return inspect_proc
+
+        runner = BrowserContainerRunner(node_ip="10.0.0.5", mock=False)
+        with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+            await runner._ensure_image(DEFAULT_NEKO_IMAGE)
+
+        # Only the inspect call should have been made
+        assert len(call_args_list) == 1
+        assert call_args_list[0][1] == "image"  # docker image inspect ...
+
+    async def test_image_absent_triggers_pull(self):
+        """When docker image inspect fails, docker pull is invoked."""
+        inspect_proc = _make_proc(returncode=1)
+        pull_proc = _make_proc(returncode=0)
+
+        call_args_list = []
+
+        async def fake_exec(*args, **kwargs):
+            call_args_list.append(args)
+            if args[1] == "image":
+                return inspect_proc
+            return pull_proc
+
+        runner = BrowserContainerRunner(node_ip="10.0.0.5", mock=False)
+        with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+            await runner._ensure_image(DEFAULT_NEKO_IMAGE)
+
+        commands = [a[1] for a in call_args_list]
+        assert "image" in commands
+        assert "pull" in commands
+
+    async def test_pull_failure_raises(self):
+        """When docker pull fails, BrowserContainerError is raised."""
+        inspect_proc = _make_proc(returncode=1)
+        pull_proc = _make_proc(returncode=1, stderr=b"manifest unknown")
+
+        async def fake_exec(*args, **kwargs):
+            if args[1] == "image":
+                return inspect_proc
+            return pull_proc
+
+        runner = BrowserContainerRunner(node_ip="10.0.0.5", mock=False)
+        with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+            with pytest.raises(BrowserContainerError, match="docker pull"):
+                await runner._ensure_image(DEFAULT_NEKO_IMAGE)
+
+    async def test_mock_mode_skips_ensure_image(self):
+        """In mock=True mode _ensure_image returns immediately without subprocess calls."""
+        called = []
+
+        async def fake_exec(*args, **kwargs):
+            called.append(args)
+            return _make_proc(returncode=0)
+
+        runner = BrowserContainerRunner(node_ip="10.0.0.5", mock=True)
+        with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+            await runner._ensure_image(DEFAULT_NEKO_IMAGE)
+
+        assert called == []

--- a/tests/worker/test_browser_container.py
+++ b/tests/worker/test_browser_container.py
@@ -37,6 +37,11 @@ class TestBuildNekoRunArgs:
         args = build_neko_run_args(**self._base_kwargs())
         assert args[:3] == ["docker", "run", "-d"]
 
+    def test_uses_rm_for_auto_cleanup(self):
+        # --rm so stopped containers don't accumulate / block name reuse.
+        args = build_neko_run_args(**self._base_kwargs())
+        assert "--rm" in args
+
     def test_container_name(self):
         args = build_neko_run_args(**self._base_kwargs())
         idx = args.index("--name")

--- a/tests/worker/test_browser_main.py
+++ b/tests/worker/test_browser_main.py
@@ -1,0 +1,37 @@
+"""Smoke tests for tinyagentos.worker.browser_main.build()."""
+from __future__ import annotations
+
+from tinyagentos.worker.browser_main import build
+
+
+class TestBrowserMainBuild:
+    def test_build_returns_app_and_agent(self):
+        app, agent = build("http://controller:6969", node_ip="10.0.0.5")
+        assert app is not None
+        assert agent is not None
+
+    def test_app_has_start_route(self):
+        app, _ = build("http://controller:6969", node_ip="10.0.0.5")
+        paths = [route.path for route in app.routes]
+        assert "/worker/browser/start" in paths
+
+    def test_app_has_stop_route(self):
+        app, _ = build("http://controller:6969", node_ip="10.0.0.5")
+        paths = [route.path for route in app.routes]
+        assert "/worker/browser/stop" in paths
+
+    def test_agent_has_browser_capability(self):
+        _, agent = build("http://controller:6969", node_ip="10.0.0.5")
+        assert "browser" in agent.extra_capabilities
+
+    def test_agent_advertise_url_uses_node_ip_and_port(self):
+        _, agent = build("http://controller:6969", node_ip="10.0.0.5", http_api_port=7080)
+        assert agent.advertise_url == "http://10.0.0.5:7080"
+
+    def test_agent_advertise_url_custom_port(self):
+        _, agent = build("http://controller:6969", node_ip="node.example", http_api_port=9090)
+        assert agent.advertise_url == "http://node.example:9090"
+
+    def test_agent_name_forwarded(self):
+        _, agent = build("http://controller:6969", node_ip="10.0.0.5", name="my-browser-node")
+        assert agent.name == "my-browser-node"

--- a/tests/worker/test_browser_server.py
+++ b/tests/worker/test_browser_server.py
@@ -1,0 +1,155 @@
+"""Tests for tinyagentos.worker.browser_server."""
+from __future__ import annotations
+
+import pytest
+import httpx
+from httpx import ASGITransport
+
+from tinyagentos.worker.browser_container import BrowserContainerRunner
+from tinyagentos.worker.browser_server import create_browser_worker_app
+
+
+def _make_app(auth_token: str | None = None):
+    runner = BrowserContainerRunner(node_ip="10.0.0.5", mock=True)
+    return create_browser_worker_app(runner, auth_token=auth_token)
+
+
+# ---------------------------------------------------------------------------
+# No-auth app
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestBrowserServerNoAuth:
+    async def _client(self):
+        app = _make_app()
+        transport = ASGITransport(app=app)
+        return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+    async def test_start_returns_200(self):
+        async with await self._client() as client:
+            resp = await client.post(
+                "/worker/browser/start",
+                json={"session_id": "sess-abc123", "profile_volume": "taos-browser-sess-abc123"},
+            )
+        assert resp.status_code == 200
+
+    async def test_start_response_has_expected_fields(self):
+        async with await self._client() as client:
+            resp = await client.post(
+                "/worker/browser/start",
+                json={"session_id": "sess-abc123", "profile_volume": "taos-browser-sess-abc123"},
+            )
+        data = resp.json()
+        for field in ("container_id", "neko_url", "cdp_url", "http_port", "epr_lo", "epr_hi"):
+            assert field in data, f"missing field: {field}"
+
+    async def test_start_container_id_is_mock(self):
+        async with await self._client() as client:
+            resp = await client.post(
+                "/worker/browser/start",
+                json={"session_id": "sess-abc123", "profile_volume": "vol1"},
+            )
+        assert resp.json()["container_id"].startswith("mock-neko-")
+
+    async def test_stop_returns_200(self):
+        async with await self._client() as client:
+            # Start first so we have a container_id
+            start = await client.post(
+                "/worker/browser/start",
+                json={"session_id": "sess-stop-test", "profile_volume": "vol1"},
+            )
+            container_id = start.json()["container_id"]
+            resp = await client.post(
+                "/worker/browser/stop",
+                json={"container_id": container_id},
+            )
+        assert resp.status_code == 200
+
+    async def test_stop_returns_ok_true(self):
+        async with await self._client() as client:
+            start = await client.post(
+                "/worker/browser/start",
+                json={"session_id": "sess-stop-test2", "profile_volume": "vol1"},
+            )
+            container_id = start.json()["container_id"]
+            resp = await client.post(
+                "/worker/browser/stop",
+                json={"container_id": container_id},
+            )
+        assert resp.json() == {"ok": True}
+
+    async def test_stop_with_http_port(self):
+        async with await self._client() as client:
+            start = await client.post(
+                "/worker/browser/start",
+                json={"session_id": "sess-stop-port", "profile_volume": "vol1"},
+            )
+            data = start.json()
+            resp = await client.post(
+                "/worker/browser/stop",
+                json={"container_id": data["container_id"], "http_port": data["http_port"]},
+            )
+        assert resp.json() == {"ok": True}
+
+
+# ---------------------------------------------------------------------------
+# Auth-required app
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestBrowserServerWithAuth:
+    def _app(self):
+        return _make_app(auth_token="secret")
+
+    async def test_missing_auth_header_is_401_start(self):
+        async with httpx.AsyncClient(
+            transport=ASGITransport(app=self._app()), base_url="http://testserver"
+        ) as client:
+            resp = await client.post(
+                "/worker/browser/start",
+                json={"session_id": "s1", "profile_volume": "v1"},
+            )
+        assert resp.status_code == 401
+
+    async def test_wrong_token_is_401_start(self):
+        async with httpx.AsyncClient(
+            transport=ASGITransport(app=self._app()), base_url="http://testserver"
+        ) as client:
+            resp = await client.post(
+                "/worker/browser/start",
+                json={"session_id": "s1", "profile_volume": "v1"},
+                headers={"Authorization": "Bearer wrongtoken"},
+            )
+        assert resp.status_code == 401
+
+    async def test_correct_token_is_200_start(self):
+        async with httpx.AsyncClient(
+            transport=ASGITransport(app=self._app()), base_url="http://testserver"
+        ) as client:
+            resp = await client.post(
+                "/worker/browser/start",
+                json={"session_id": "s1", "profile_volume": "v1"},
+                headers={"Authorization": "Bearer secret"},
+            )
+        assert resp.status_code == 200
+
+    async def test_missing_auth_header_is_401_stop(self):
+        async with httpx.AsyncClient(
+            transport=ASGITransport(app=self._app()), base_url="http://testserver"
+        ) as client:
+            resp = await client.post(
+                "/worker/browser/stop",
+                json={"container_id": "mock-neko-abc12345"},
+            )
+        assert resp.status_code == 401
+
+    async def test_correct_token_is_200_stop(self):
+        async with httpx.AsyncClient(
+            transport=ASGITransport(app=self._app()), base_url="http://testserver"
+        ) as client:
+            resp = await client.post(
+                "/worker/browser/stop",
+                json={"container_id": "mock-neko-abc12345"},
+                headers={"Authorization": "Bearer secret"},
+            )
+        assert resp.status_code == 200

--- a/tests/worker/test_browser_server.py
+++ b/tests/worker/test_browser_server.py
@@ -5,7 +5,7 @@ import pytest
 import httpx
 from httpx import ASGITransport
 
-from tinyagentos.worker.browser_container import BrowserContainerRunner
+from tinyagentos.worker.browser_container import BrowserContainerError, BrowserContainerRunner
 from tinyagentos.worker.browser_server import create_browser_worker_app
 
 
@@ -90,6 +90,25 @@ class TestBrowserServerNoAuth:
                 json={"container_id": data["container_id"], "http_port": data["http_port"]},
             )
         assert resp.json() == {"ok": True}
+
+    async def test_start_container_error_is_500(self):
+        """A BrowserContainerError from the runner surfaces as HTTP 500."""
+        runner = BrowserContainerRunner(node_ip="10.0.0.5", mock=True)
+
+        async def _boom(*args, **kwargs):
+            raise BrowserContainerError("docker run failed (rc=1): boom")
+
+        runner.start = _boom  # type: ignore[method-assign]
+        app = create_browser_worker_app(runner)
+        async with httpx.AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://testserver"
+        ) as client:
+            resp = await client.post(
+                "/worker/browser/start",
+                json={"session_id": "sess-err", "profile_volume": "vol1"},
+            )
+        assert resp.status_code == 500
+        assert "error" in resp.json()
 
 
 # ---------------------------------------------------------------------------

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -510,14 +510,17 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
                     auth_token = getattr(app.state, "browser_worker_auth_token", None)
                     reaped = await mgr.reap_idle()  # flips stale running→idle, returns ids
                     for sid in reaped:
-                        s = await mgr.get_session(sid)
-                        if s and s.get("node") and s.get("container_id"):
-                            w = cluster.get_worker(s["node"])
-                            if w is not None:
-                                await mgr.stop_on_worker(
-                                    sid, worker_url=w.url, container_id=s["container_id"],
-                                    auth_token=auth_token, set_status=None,
-                                )
+                        try:
+                            s = await mgr.get_session(sid)
+                            if s and s.get("node") and s.get("container_id"):
+                                w = cluster.get_worker(s["node"])
+                                if w is not None:
+                                    await mgr.stop_on_worker(
+                                        sid, worker_url=w.url, container_id=s["container_id"],
+                                        auth_token=auth_token, set_status=None,
+                                    )
+                        except Exception as _sid_e:
+                            logger.warning("browser reap: stop for %s failed: %s", sid, _sid_e)
                 except Exception as _e:
                     logger.warning("browser reap failed: %s", _e)
                 await _asyncio.sleep(300)

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -501,6 +501,29 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
 
         asyncio.create_task(_ephemeral_sweep_loop(app))
 
+        async def _browser_reap_loop(app: FastAPI) -> None:
+            import asyncio as _asyncio
+            mgr = app.state.browser_sessions
+            cluster = app.state.cluster_manager
+            while True:
+                try:
+                    auth_token = getattr(app.state, "browser_worker_auth_token", None)
+                    reaped = await mgr.reap_idle()  # flips stale running→idle, returns ids
+                    for sid in reaped:
+                        s = await mgr.get_session(sid)
+                        if s and s.get("node") and s.get("container_id"):
+                            w = cluster.get_worker(s["node"])
+                            if w is not None:
+                                await mgr.stop_on_worker(
+                                    sid, worker_url=w.url, container_id=s["container_id"],
+                                    auth_token=auth_token, set_status=None,
+                                )
+                except Exception as _e:
+                    logger.warning("browser reap failed: %s", _e)
+                await _asyncio.sleep(300)
+
+        asyncio.create_task(_browser_reap_loop(app))
+
         # Per-agent state lives on the host and is mounted into containers.
         # See docs/design/framework-agnostic-runtime.md.
         app.state.agent_workspaces_dir = data_dir / "agent-workspaces"

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -337,6 +337,9 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     from tinyagentos.agent_browsers import AgentBrowsersManager
     agent_browsers = AgentBrowsersManager(db_path=data_dir / "agent-browsers.db", mock=True)
 
+    from tinyagentos.browser_sessions import BrowserSessionManager
+    browser_sessions = BrowserSessionManager(data_dir / "browser_sessions.db")
+
     from taosmd import BrowsingHistory as BrowsingHistoryStore
     browsing_history = BrowsingHistoryStore(db_path=data_dir / "browsing-history.db")
 
@@ -385,6 +388,10 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await knowledge_monitor.start()
         await agent_browsers.init()
         app.state.agent_browsers = agent_browsers
+        await browser_sessions.init()
+        app.state.browser_sessions = browser_sessions
+        import secrets as _secrets
+        app.state.browser_session_signing_key = _secrets.token_bytes(32)
         await browsing_history.init()
         app.state.browsing_history = browsing_history
         await knowledge_graph.init()
@@ -871,6 +878,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await knowledge_monitor.stop()
         await knowledge_store.close()
         await agent_browsers.close()
+        await browser_sessions.close()
         await browsing_history.close()
         await knowledge_graph.close()
         await archive.close()
@@ -1203,6 +1211,9 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
 
     from tinyagentos.routes.agent_browsers import router as agent_browsers_router
     app.include_router(agent_browsers_router)
+
+    from tinyagentos.routes.browser_sessions import router as browser_sessions_router
+    app.include_router(browser_sessions_router)
 
     from tinyagentos.routes.reddit import router as reddit_router
     app.include_router(reddit_router)

--- a/tinyagentos/browser_sessions.py
+++ b/tinyagentos/browser_sessions.py
@@ -13,6 +13,8 @@ from pathlib import Path
 
 import aiosqlite
 
+IDLE_TIMEOUT_S = 600
+
 BROWSER_SESSIONS_SCHEMA = """
 CREATE TABLE IF NOT EXISTS browser_sessions (
     id           TEXT PRIMARY KEY,
@@ -180,6 +182,36 @@ class BrowserSessionManager:
             (now, now, session_id),
         )
         await db.commit()
+
+    async def reap_idle(
+        self,
+        *,
+        now: float | None = None,
+        timeout_s: int = IDLE_TIMEOUT_S,
+    ) -> list[str]:
+        """Mark running sessions idle when last_active is older than timeout_s.
+
+        Returns the list of reaped session ids.  Mock mode: only the DB
+        transition (status -> 'idle'), keeping the row/profile.  Real
+        container stop is wired in a later task.
+        """
+        db = self._assert_db()
+        if now is None:
+            now = time.time()
+        cutoff = now - timeout_s
+        cursor = await db.execute(
+            "SELECT id FROM browser_sessions WHERE status='running' AND last_active < ?",
+            (cutoff,),
+        )
+        rows = await cursor.fetchall()
+        ids = [r[0] for r in rows]
+        if ids:
+            await db.execute(
+                f"UPDATE browser_sessions SET status='idle', updated_at=? WHERE id IN ({','.join('?' * len(ids))})",
+                (now, *ids),
+            )
+            await db.commit()
+        return ids
 
     async def terminate_session(self, session_id: str) -> bool:
         """Set status='stopped'.  Returns False if the session does not exist."""

--- a/tinyagentos/browser_sessions.py
+++ b/tinyagentos/browser_sessions.py
@@ -194,3 +194,45 @@ class BrowserSessionManager:
         )
         await db.commit()
         return True
+
+
+# ---------------------------------------------------------------------------
+# Tier-2 node placement
+# ---------------------------------------------------------------------------
+
+# Min specs for a Tier-2 browser node (the 4GB Pi must never qualify).
+TIER2_MIN_RAM_MB = 4096
+TIER2_MIN_CORES = 4
+
+
+def pick_browser_node(
+    cluster,
+    *,
+    min_ram_mb: int = TIER2_MIN_RAM_MB,
+    min_cores: int = TIER2_MIN_CORES,
+) -> str | None:
+    """Return the name of an online worker meeting Tier-2 specs, else None.
+
+    Reads WorkerInfo.hardware for ram_mb + cpu cores.  Prefers GPU-capable
+    nodes (cuda=True or vram_mb > 0), then lowest load.
+    """
+    candidates = []
+    for w in cluster.get_workers():
+        if w.status != "online":
+            continue
+        hw = w.hardware if isinstance(w.hardware, dict) else {}
+        ram = hw.get("ram_mb", 0) if isinstance(hw.get("ram_mb"), int) else 0
+        cpu = hw.get("cpu")
+        cores = cpu.get("cores", 0) if isinstance(cpu, dict) else 0
+        if ram < min_ram_mb or cores < min_cores:
+            continue
+        gpu = hw.get("gpu")
+        has_gpu = False
+        if isinstance(gpu, dict):
+            has_gpu = bool(gpu.get("cuda")) or (gpu.get("vram_mb") or 0) > 0
+        candidates.append((not has_gpu, w.load, w.name))
+
+    if not candidates:
+        return None
+    candidates.sort()
+    return candidates[0][2]

--- a/tinyagentos/browser_sessions.py
+++ b/tinyagentos/browser_sessions.py
@@ -243,14 +243,23 @@ def pick_browser_node(
     min_ram_mb: int = TIER2_MIN_RAM_MB,
     min_cores: int = TIER2_MIN_CORES,
 ) -> str | None:
-    """Return the name of an online worker meeting Tier-2 specs, else None.
+    """Return the name of an online, browser-capable worker meeting Tier-2
+    specs, else None.
 
-    Reads WorkerInfo.hardware for ram_mb + cpu cores.  Prefers GPU-capable
-    nodes (cuda=True or vram_mb > 0), then lowest load.
+    Requires the worker to advertise the ``browser`` capability (only a node
+    running the lightweight browser-worker does), then reads
+    WorkerInfo.hardware for ram_mb + cpu cores.  Prefers GPU-capable nodes
+    (cuda=True or vram_mb > 0), then lowest load.
+
+    The capability requirement is what keeps the controller host (e.g. the
+    4 GB Pi) from ever being picked — it never advertises ``browser`` —
+    rather than relying on it reporting under the RAM floor.
     """
     candidates = []
     for w in cluster.get_workers():
         if w.status != "online":
+            continue
+        if "browser" not in (getattr(w, "capabilities", None) or []):
             continue
         hw = w.hardware if isinstance(w.hardware, dict) else {}
         ram = hw.get("ram_mb", 0) if isinstance(hw.get("ram_mb"), int) else 0

--- a/tinyagentos/browser_sessions.py
+++ b/tinyagentos/browser_sessions.py
@@ -7,11 +7,19 @@ and neko/CDP endpoints.  In ``mock=True`` mode all Docker/HTTP calls are
 skipped so the manager can be used in unit tests without a container runtime.
 """
 
+import logging
 import time
 import uuid
 from pathlib import Path
 
 import aiosqlite
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+class BrowserWorkerError(Exception):
+    """Raised when a worker browser-container call fails."""
 
 IDLE_TIMEOUT_S = 600
 
@@ -213,6 +221,105 @@ class BrowserSessionManager:
             await db.commit()
         return ids
 
+    async def mark_error(self, session_id: str, *, now: float | None = None) -> None:
+        db = self._assert_db()
+        if now is None:
+            now = time.time()
+        await db.execute(
+            "UPDATE browser_sessions SET status='error', updated_at=? WHERE id=?",
+            (now, session_id),
+        )
+        await db.commit()
+
+    async def start_on_worker(
+        self,
+        session_id: str,
+        *,
+        node: str,
+        worker_url: str,
+        profile_volume: str,
+        auth_token: str | None = None,
+    ) -> dict:
+        """POST /worker/browser/start on the given worker and update the session.
+
+        On success marks the session running and returns the refreshed session dict.
+        On any failure marks the session as 'error' and raises BrowserWorkerError.
+        """
+        headers = {}
+        if auth_token:
+            headers["Authorization"] = f"Bearer {auth_token}"
+        try:
+            async with httpx.AsyncClient(timeout=30) as client:
+                resp = await client.post(
+                    f"{worker_url.rstrip('/')}/worker/browser/start",
+                    json={"session_id": session_id, "profile_volume": profile_volume},
+                    headers=headers,
+                )
+        except Exception as exc:
+            await self.mark_error(session_id)
+            raise BrowserWorkerError(f"worker request failed: {exc}") from exc
+
+        if resp.status_code != 200:
+            await self.mark_error(session_id)
+            raise BrowserWorkerError(
+                f"worker returned {resp.status_code}: {resp.text[:200]}"
+            )
+
+        data = resp.json()
+        await self.mark_running(
+            session_id,
+            node=node,
+            container_id=data["container_id"],
+            neko_url=data["neko_url"],
+            cdp_url=data["cdp_url"],
+        )
+        return await self.get_session(session_id)
+
+    async def stop_on_worker(
+        self,
+        session_id: str,
+        *,
+        worker_url: str,
+        container_id: str,
+        http_port: int | None = None,
+        auth_token: str | None = None,
+        set_status: str | None = "stopped",
+    ) -> None:
+        """POST /worker/browser/stop on the given worker.  Best-effort — all
+        errors are logged as warnings and swallowed.  The profile volume is
+        intentionally kept.
+
+        If ``set_status`` is not None the session row's status is updated.
+        Pass ``set_status=None`` when the caller (reap loop) has already
+        transitioned the status.
+        """
+        headers = {}
+        if auth_token:
+            headers["Authorization"] = f"Bearer {auth_token}"
+        try:
+            async with httpx.AsyncClient(timeout=30) as client:
+                resp = await client.post(
+                    f"{worker_url.rstrip('/')}/worker/browser/stop",
+                    json={"container_id": container_id, "http_port": http_port},
+                    headers=headers,
+                )
+            if resp.status_code != 200:
+                logger.warning(
+                    "stop_on_worker for %s returned %s: %s",
+                    session_id, resp.status_code, resp.text[:200],
+                )
+        except Exception as exc:
+            logger.warning("stop_on_worker for %s failed: %s", session_id, exc)
+
+        if set_status is not None:
+            db = self._assert_db()
+            now = time.time()
+            await db.execute(
+                "UPDATE browser_sessions SET status=?, updated_at=? WHERE id=?",
+                (set_status, now, session_id),
+            )
+            await db.commit()
+
     async def terminate_session(self, session_id: str) -> bool:
         """Set status='stopped'.  Returns False if the session does not exist."""
         db = self._assert_db()
@@ -237,6 +344,34 @@ TIER2_MIN_RAM_MB = 4096
 TIER2_MIN_CORES = 4
 
 
+def _capable_workers(
+    cluster,
+    min_ram_mb: int,
+    min_cores: int,
+) -> list:
+    """Return online workers advertising the ``browser`` capability that meet
+    the given RAM and core floor, sorted GPU-first then by ascending load."""
+    candidates = []
+    for w in cluster.get_workers():
+        if w.status != "online":
+            continue
+        if "browser" not in (getattr(w, "capabilities", None) or []):
+            continue
+        hw = w.hardware if isinstance(w.hardware, dict) else {}
+        ram = hw.get("ram_mb", 0) if isinstance(hw.get("ram_mb"), int) else 0
+        cpu = hw.get("cpu")
+        cores = cpu.get("cores", 0) if isinstance(cpu, dict) else 0
+        if ram < min_ram_mb or cores < min_cores:
+            continue
+        gpu = hw.get("gpu")
+        has_gpu = False
+        if isinstance(gpu, dict):
+            has_gpu = bool(gpu.get("cuda")) or (gpu.get("vram_mb") or 0) > 0
+        candidates.append((not has_gpu, w.load, w))
+    candidates.sort(key=lambda t: (t[0], t[1]))
+    return [t[2] for t in candidates]
+
+
 def pick_browser_node(
     cluster,
     *,
@@ -255,25 +390,35 @@ def pick_browser_node(
     4 GB Pi) from ever being picked — it never advertises ``browser`` —
     rather than relying on it reporting under the RAM floor.
     """
-    candidates = []
-    for w in cluster.get_workers():
-        if w.status != "online":
-            continue
-        if "browser" not in (getattr(w, "capabilities", None) or []):
-            continue
+    workers = _capable_workers(cluster, min_ram_mb, min_cores)
+    return workers[0].name if workers else None
+
+
+def list_browser_nodes(
+    cluster,
+    *,
+    min_ram_mb: int = TIER2_MIN_RAM_MB,
+    min_cores: int = TIER2_MIN_CORES,
+) -> list[dict]:
+    """Return a list of capable browser nodes, GPU-first then by ascending load.
+
+    Each entry has keys: name, gpu (bool), ram_mb (int), cores (int), load (float).
+    """
+    result = []
+    for w in _capable_workers(cluster, min_ram_mb, min_cores):
         hw = w.hardware if isinstance(w.hardware, dict) else {}
         ram = hw.get("ram_mb", 0) if isinstance(hw.get("ram_mb"), int) else 0
         cpu = hw.get("cpu")
         cores = cpu.get("cores", 0) if isinstance(cpu, dict) else 0
-        if ram < min_ram_mb or cores < min_cores:
-            continue
         gpu = hw.get("gpu")
         has_gpu = False
         if isinstance(gpu, dict):
             has_gpu = bool(gpu.get("cuda")) or (gpu.get("vram_mb") or 0) > 0
-        candidates.append((not has_gpu, w.load, w.name))
-
-    if not candidates:
-        return None
-    candidates.sort()
-    return candidates[0][2]
+        result.append({
+            "name": w.name,
+            "gpu": has_gpu,
+            "ram_mb": ram,
+            "cores": cores,
+            "load": w.load,
+        })
+    return result

--- a/tinyagentos/browser_sessions.py
+++ b/tinyagentos/browser_sessions.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+"""BrowserSessionManager -- live browser sessions backed by neko/CDP containers.
+
+Each session belongs to an owner (user or agent), tracks a URL, container,
+and neko/CDP endpoints.  In ``mock=True`` mode all Docker/HTTP calls are
+skipped so the manager can be used in unit tests without a container runtime.
+"""
+
+import time
+import uuid
+from pathlib import Path
+
+import aiosqlite
+
+BROWSER_SESSIONS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS browser_sessions (
+    id           TEXT PRIMARY KEY,
+    owner_type   TEXT NOT NULL,
+    owner_id     TEXT NOT NULL,
+    profile_name TEXT NOT NULL,
+    url          TEXT,
+    node         TEXT,
+    status       TEXT NOT NULL DEFAULT 'pending',
+    container_id TEXT,
+    neko_url     TEXT,
+    cdp_url      TEXT,
+    created_at   REAL NOT NULL,
+    updated_at   REAL NOT NULL,
+    last_active  REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_bs_owner ON browser_sessions(owner_type, owner_id);
+CREATE INDEX IF NOT EXISTS idx_bs_status ON browser_sessions(status);
+"""
+
+
+def _row_to_session(row: tuple) -> dict:
+    return {
+        "id": row[0],
+        "owner_type": row[1],
+        "owner_id": row[2],
+        "profile_name": row[3],
+        "url": row[4],
+        "node": row[5],
+        "status": row[6],
+        "container_id": row[7],
+        "neko_url": row[8],
+        "cdp_url": row[9],
+        "created_at": row[10],
+        "updated_at": row[11],
+        "last_active": row[12],
+    }
+
+
+class BrowserSessionManager:
+    """Manages live browser sessions for users and agents."""
+
+    def __init__(self, db_path: Path, mock: bool = False) -> None:
+        self.db_path = Path(db_path)
+        self.mock = mock
+        self._db: aiosqlite.Connection | None = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def init(self) -> None:
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._db = await aiosqlite.connect(str(self.db_path))
+        await self._db.executescript(BROWSER_SESSIONS_SCHEMA)
+        await self._db.commit()
+
+    async def close(self) -> None:
+        if self._db:
+            await self._db.close()
+            self._db = None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _assert_db(self) -> aiosqlite.Connection:
+        assert self._db is not None, "BrowserSessionManager not initialised -- call await init() first"
+        return self._db
+
+    # ------------------------------------------------------------------
+    # Session CRUD
+    # ------------------------------------------------------------------
+
+    async def create_session(
+        self,
+        owner_type: str,
+        owner_id: str,
+        url: str,
+        profile_name: str = "default",
+        *,
+        now: float | None = None,
+    ) -> dict:
+        db = self._assert_db()
+        if now is None:
+            now = time.time()
+        session_id = uuid.uuid4().hex
+        await db.execute(
+            """INSERT INTO browser_sessions
+               (id, owner_type, owner_id, profile_name, url, node, status,
+                container_id, neko_url, cdp_url, created_at, updated_at, last_active)
+               VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+            (session_id, owner_type, owner_id, profile_name, url, None, "pending",
+             None, None, None, now, now, now),
+        )
+        await db.commit()
+        return {
+            "id": session_id,
+            "owner_type": owner_type,
+            "owner_id": owner_id,
+            "profile_name": profile_name,
+            "url": url,
+            "node": None,
+            "status": "pending",
+            "container_id": None,
+            "neko_url": None,
+            "cdp_url": None,
+            "created_at": now,
+            "updated_at": now,
+            "last_active": now,
+        }
+
+    async def get_session(self, session_id: str) -> dict | None:
+        db = self._assert_db()
+        cursor = await db.execute(
+            """SELECT id, owner_type, owner_id, profile_name, url, node, status,
+                      container_id, neko_url, cdp_url, created_at, updated_at, last_active
+               FROM browser_sessions WHERE id = ?""",
+            (session_id,),
+        )
+        row = await cursor.fetchone()
+        return _row_to_session(row) if row else None
+
+    async def list_sessions(self, owner_type: str, owner_id: str) -> list[dict]:
+        db = self._assert_db()
+        cursor = await db.execute(
+            """SELECT id, owner_type, owner_id, profile_name, url, node, status,
+                      container_id, neko_url, cdp_url, created_at, updated_at, last_active
+               FROM browser_sessions
+               WHERE owner_type = ? AND owner_id = ?
+               ORDER BY created_at DESC""",
+            (owner_type, owner_id),
+        )
+        rows = await cursor.fetchall()
+        return [_row_to_session(r) for r in rows]
+
+    async def mark_running(
+        self,
+        session_id: str,
+        *,
+        node: str,
+        container_id: str,
+        neko_url: str,
+        cdp_url: str,
+        now: float | None = None,
+    ) -> None:
+        db = self._assert_db()
+        if now is None:
+            now = time.time()
+        await db.execute(
+            """UPDATE browser_sessions
+               SET node=?, container_id=?, neko_url=?, cdp_url=?,
+                   status='running', updated_at=?
+               WHERE id=?""",
+            (node, container_id, neko_url, cdp_url, now, session_id),
+        )
+        await db.commit()
+
+    async def touch_active(self, session_id: str, *, now: float | None = None) -> None:
+        db = self._assert_db()
+        if now is None:
+            now = time.time()
+        await db.execute(
+            "UPDATE browser_sessions SET last_active=?, updated_at=? WHERE id=?",
+            (now, now, session_id),
+        )
+        await db.commit()
+
+    async def terminate_session(self, session_id: str) -> bool:
+        """Set status='stopped'.  Returns False if the session does not exist."""
+        db = self._assert_db()
+        session = await self.get_session(session_id)
+        if session is None:
+            return False
+        now = time.time()
+        await db.execute(
+            "UPDATE browser_sessions SET status='stopped', updated_at=? WHERE id=?",
+            (now, session_id),
+        )
+        await db.commit()
+        return True

--- a/tinyagentos/routes/browser_sessions.py
+++ b/tinyagentos/routes/browser_sessions.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+"""API routes for browser sessions (hybrid neko/CDP tier-2 sessions).
+
+Routes:
+  POST   /api/browser/sessions            create a new session
+  GET    /api/browser/sessions/{id}       get session (with stream token if running)
+  POST   /api/browser/sessions/{id}/terminate  stop a session
+"""
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from tinyagentos.auth import get_current_user
+from tinyagentos.browser_sessions import pick_browser_node
+from tinyagentos.routes.desktop_browser.session_token import mint_session_token
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+class CreateSessionBody(BaseModel):
+    url: str
+    profile: str | None = None
+
+
+@router.post("/api/browser/sessions")
+async def create_session(
+    body: CreateSessionBody,
+    request: Request,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    user_id = str(current_user.get("id") or "")
+    if not user_id:
+        return JSONResponse({"error": "session has no user id"}, status_code=401)
+
+    node = pick_browser_node(request.app.state.cluster_manager)
+    if node is None:
+        return JSONResponse({"error": "no_capable_node"}, status_code=409)
+
+    mgr = request.app.state.browser_sessions
+    session = await mgr.create_session(
+        "user", user_id, body.url, body.profile or "default"
+    )
+    return JSONResponse(session, status_code=201)
+
+
+@router.get("/api/browser/sessions/{session_id}")
+async def get_session(
+    session_id: str,
+    request: Request,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    user_id = str(current_user.get("id") or "")
+    if not user_id:
+        return JSONResponse({"error": "session has no user id"}, status_code=401)
+
+    mgr = request.app.state.browser_sessions
+    session = await mgr.get_session(session_id)
+    if session is None:
+        return JSONResponse({"error": "not_found"}, status_code=404)
+
+    if session["owner_type"] != "user" or session["owner_id"] != user_id:
+        return JSONResponse({"error": "not_found"}, status_code=404)
+
+    if session["status"] == "running" and session.get("neko_url"):
+        signing_key = request.app.state.browser_session_signing_key
+        _, token = mint_session_token(session_id, user_id, signing_key)
+        return {**session, "stream_token": token}
+
+    return dict(session)
+
+
+@router.post("/api/browser/sessions/{session_id}/terminate")
+async def terminate_session(
+    session_id: str,
+    request: Request,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    user_id = str(current_user.get("id") or "")
+    if not user_id:
+        return JSONResponse({"error": "session has no user id"}, status_code=401)
+
+    mgr = request.app.state.browser_sessions
+    session = await mgr.get_session(session_id)
+    if session is None:
+        return JSONResponse({"error": "not_found"}, status_code=404)
+
+    if session["owner_type"] != "user" or session["owner_id"] != user_id:
+        return JSONResponse({"error": "not_found"}, status_code=404)
+
+    await mgr.terminate_session(session_id)
+    return {"ok": True}

--- a/tinyagentos/routes/browser_sessions.py
+++ b/tinyagentos/routes/browser_sessions.py
@@ -16,7 +16,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from tinyagentos.auth import get_current_user
-from tinyagentos.browser_sessions import pick_browser_node
+from tinyagentos.browser_sessions import BrowserWorkerError, list_browser_nodes, pick_browser_node
 from tinyagentos.routes.desktop_browser.session_token import mint_session_token
 
 logger = logging.getLogger(__name__)
@@ -27,6 +27,7 @@ router = APIRouter()
 class CreateSessionBody(BaseModel):
     url: str
     profile: str | None = None
+    node: str | None = None
 
 
 @router.post("/api/browser/sessions")
@@ -39,15 +40,49 @@ async def create_session(
     if not user_id:
         return JSONResponse({"error": "session has no user id"}, status_code=401)
 
-    node = pick_browser_node(request.app.state.cluster_manager)
-    if node is None:
+    cluster = request.app.state.cluster_manager
+    if body.node is not None:
+        capable_names = {n["name"] for n in list_browser_nodes(cluster)}
+        if body.node not in capable_names:
+            return JSONResponse({"error": "no_capable_node"}, status_code=409)
+        node = body.node
+    else:
+        node = pick_browser_node(cluster)
+        if node is None:
+            return JSONResponse({"error": "no_capable_node"}, status_code=409)
+
+    worker = cluster.get_worker(node)
+    if worker is None:
         return JSONResponse({"error": "no_capable_node"}, status_code=409)
 
     mgr = request.app.state.browser_sessions
     session = await mgr.create_session(
         "user", user_id, body.url, body.profile or "default"
     )
+    auth_token = getattr(request.app.state, "browser_worker_auth_token", None)
+    try:
+        session = await mgr.start_on_worker(
+            session["id"],
+            node=node,
+            worker_url=worker.url,
+            profile_volume=f"taos-browser-{session['id']}",
+            auth_token=auth_token,
+        )
+    except BrowserWorkerError:
+        return JSONResponse({"error": "worker_start_failed"}, status_code=502)
     return JSONResponse(session, status_code=201)
+
+
+@router.get("/api/browser/nodes")
+async def get_browser_nodes(
+    request: Request,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    user_id = str(current_user.get("id") or "")
+    if not user_id:
+        return JSONResponse({"error": "session has no user id"}, status_code=401)
+    nodes = list_browser_nodes(request.app.state.cluster_manager)
+    return {"nodes": nodes}
 
 
 @router.get("/api/browser/sessions/{session_id}")
@@ -94,5 +129,19 @@ async def terminate_session(
     if session["owner_type"] != "user" or session["owner_id"] != user_id:
         return JSONResponse({"error": "not_found"}, status_code=404)
 
-    await mgr.terminate_session(session_id)
+    cluster = request.app.state.cluster_manager
+    auth_token = getattr(request.app.state, "browser_worker_auth_token", None)
+    if session.get("node") and session.get("container_id"):
+        worker = cluster.get_worker(session["node"])
+        if worker is not None:
+            await mgr.stop_on_worker(
+                session_id,
+                worker_url=worker.url,
+                container_id=session["container_id"],
+                auth_token=auth_token,
+            )
+        else:
+            await mgr.terminate_session(session_id)
+    else:
+        await mgr.terminate_session(session_id)
     return {"ok": True}

--- a/tinyagentos/routes/desktop_browser/session_token.py
+++ b/tinyagentos/routes/desktop_browser/session_token.py
@@ -1,0 +1,98 @@
+"""Short-lived HMAC tokens scoped to a single browser session.
+
+Each token binds a ``session_id`` to a ``user_id`` so it grants access to
+exactly one browser room.  The scheme mirrors
+:mod:`tinyagentos.routes.desktop_browser.proxy_ticket` (HMAC-SHA256 +
+base64url, same ``payload + "." + sig`` framing) and reuses the same
+:class:`~tinyagentos.shortcuts.tickets.JtiTracker` for replay protection.
+
+Typical flow:
+
+  1. The main app (:6969) calls :func:`mint_session_token` when a browser
+     session is created and returns the token to the client.
+  2. The client presents the token on the stream endpoint; the endpoint
+     calls :func:`validate_session_token` and admits only the matching
+     session.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import time
+import uuid
+
+from tinyagentos.shortcuts.tickets import JtiTracker
+
+# Module-level single-use tracker. Process-local, mirrors _PROXY_JTI_TRACKER.
+_SESSION_JTI_TRACKER: JtiTracker = JtiTracker()
+
+
+def _sign(payload: bytes, key: bytes) -> bytes:
+    return hmac.new(key, payload, hashlib.sha256).digest()
+
+
+def mint_session_token(
+    session_id: str,
+    user_id: str,
+    signing_key: bytes,
+    ttl: int = 60,
+) -> tuple[dict, str]:
+    """Mint a signed session token.
+
+    Returns ``({"session_id": ..., "user_id": ..., "exp": ...}, token_string)``.
+    The ``jti`` is embedded in the token but not exposed in the returned dict.
+    """
+    if len(signing_key) < 32:
+        raise ValueError("signing_key must be at least 32 bytes")
+    jti = uuid.uuid4().hex
+    exp = int(time.time()) + ttl
+    payload = json.dumps(
+        {"session_id": session_id, "user_id": user_id, "exp": exp, "jti": jti},
+        separators=(",", ":"),
+    ).encode()
+    sig = _sign(payload, signing_key)
+    token = base64.urlsafe_b64encode(payload + b"." + sig).decode()
+    return {"session_id": session_id, "user_id": user_id, "exp": exp}, token
+
+
+def validate_session_token(
+    token: str,
+    signing_key: bytes,
+    tracker: JtiTracker = _SESSION_JTI_TRACKER,
+) -> dict:
+    """Validate a session token. Returns ``{"session_id": ..., "user_id": ...}`` on success.
+
+    Raises ``ValueError`` on invalid signature, expiry, or replay.
+    """
+    if len(signing_key) < 32:
+        raise ValueError("signing_key must be at least 32 bytes")
+    try:
+        raw = base64.urlsafe_b64decode(token.encode() + b"=" * (-len(token) % 4))
+        # HMAC-SHA256 is always 32 bytes; separator '.' sits at len(raw) - 33.
+        sig_start = len(raw) - 32
+        if sig_start < 2 or raw[sig_start - 1:sig_start] != b".":
+            raise ValueError("malformed token: no separator")
+        payload_bytes = raw[:sig_start - 1]
+        sig = raw[sig_start:]
+    except Exception as exc:
+        raise ValueError(f"invalid signature: token decode failed — {exc}") from exc
+
+    expected_sig = _sign(payload_bytes, signing_key)
+    if not hmac.compare_digest(sig, expected_sig):
+        raise ValueError("invalid signature")
+
+    try:
+        data = json.loads(payload_bytes)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid signature: payload not JSON — {exc}") from exc
+
+    if int(time.time()) > data["exp"]:
+        raise ValueError("token expired")
+
+    jti = data["jti"]
+    if not tracker.record_if_new(jti, data["exp"]):
+        raise ValueError("replayed jti")
+
+    return {"session_id": data["session_id"], "user_id": data["user_id"]}

--- a/tinyagentos/worker/agent.py
+++ b/tinyagentos/worker/agent.py
@@ -66,10 +66,19 @@ def _detect_lan_ip(controller_url: str) -> str | None:
 
 
 class WorkerAgent:
-    def __init__(self, controller_url: str, name: str | None = None, worker_port: int = 0):
+    def __init__(
+        self,
+        controller_url: str,
+        name: str | None = None,
+        worker_port: int = 0,
+        extra_capabilities: list[str] | None = None,
+        advertise_url: str | None = None,
+    ):
         self.controller_url = controller_url.rstrip("/")
         self.name = name or socket.gethostname()
         self.worker_port = worker_port
+        self.extra_capabilities = list(extra_capabilities or [])
+        self.advertise_url = advertise_url
         self._running = False
         self._registered = False
 
@@ -340,11 +349,11 @@ class WorkerAgent:
 
         hw = detect_hardware()
         backends = await self.detect_backends()
-        caps = self.detect_capabilities(backends)
+        caps = sorted(set(self.detect_capabilities(backends)) | set(self.extra_capabilities))
         kv_quant = self.detect_kv_quant_support(backends)
 
-        # Find the actual backend URL to use (first discovered)
-        worker_url = backends[0]["url"] if backends else self.get_worker_url()
+        # Use pinned advertise_url if provided; otherwise infer from backends or LAN IP.
+        worker_url = self.advertise_url or (backends[0]["url"] if backends else self.get_worker_url())
 
         payload = {
             "name": self.name,
@@ -398,7 +407,7 @@ class WorkerAgent:
         try:
             load = psutil.cpu_percent() / 100.0
             backends = await self.detect_backends()
-            caps = self.detect_capabilities(backends)
+            caps = sorted(set(self.detect_capabilities(backends)) | set(self.extra_capabilities))
             kv_quant = self.detect_kv_quant_support(backends)
             snap = capacity_snapshot()
             async with httpx.AsyncClient(timeout=5) as client:

--- a/tinyagentos/worker/browser_container.py
+++ b/tinyagentos/worker/browser_container.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+"""Neko Chromium container runner for the browser-worker.
+
+Manages per-session Neko containers (WebRTC-streamed Chromium) on a capable
+host node.  In ``mock=True`` mode all subprocess calls are skipped so the
+module can be used in unit tests without a Docker daemon.
+"""
+
+import asyncio
+import logging
+import secrets
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_NEKO_IMAGE = "ghcr.io/m1k1o/neko/chromium:latest"
+DEFAULT_NEKO_GPU_IMAGE = "ghcr.io/m1k1o/neko/nvidia-chromium:latest"
+NEKO_SCREEN = "1280x720@30"
+NEKO_PROFILE_MOUNT = "/home/neko"
+
+
+class BrowserContainerError(Exception):
+    """Raised when a Docker operation for a Neko container fails."""
+
+
+def build_neko_run_args(
+    *,
+    container_name: str,
+    profile_volume: str,
+    node_ip: str,
+    http_port: int,
+    epr_lo: int,
+    epr_hi: int,
+    user_pwd: str,
+    admin_pwd: str,
+    gpu: bool = False,
+    image: str | None = None,
+) -> list[str]:
+    """Return the full ``docker run`` argv (starting with 'docker') for a Neko
+    Chromium session, per the validated spike recipe."""
+    if image is None:
+        image = DEFAULT_NEKO_GPU_IMAGE if gpu else DEFAULT_NEKO_IMAGE
+
+    args = [
+        "docker", "run", "-d",
+        "--name", container_name,
+        "-p", f"{http_port}:8080",
+        "-p", f"{epr_lo}-{epr_hi}:{epr_lo}-{epr_hi}/udp",
+        "-e", f"NEKO_DESKTOP_SCREEN={NEKO_SCREEN}",
+        "-e", f"NEKO_MEMBER_MULTIUSER_USER_PASSWORD={user_pwd}",
+        "-e", f"NEKO_MEMBER_MULTIUSER_ADMIN_PASSWORD={admin_pwd}",
+        "-e", f"NEKO_WEBRTC_EPR={epr_lo}-{epr_hi}",
+        "-e", f"NEKO_WEBRTC_NAT1TO1={node_ip}",
+        "--shm-size=2g",
+        "-v", f"{profile_volume}:{NEKO_PROFILE_MOUNT}",
+    ]
+    if gpu:
+        args += ["--gpus", "all"]
+    args.append(image)
+    return args
+
+
+class PortAllocator:
+    """Hands out a unique HTTP port + a small UDP EPR range per session.
+
+    In-process, monotonic; good enough for one host running a handful of
+    sessions.
+    """
+
+    def __init__(
+        self,
+        *,
+        http_base: int = 8800,
+        epr_base: int = 59000,
+        epr_span: int = 10,
+    ) -> None:
+        self._http_base = http_base
+        self._epr_base = epr_base
+        self._epr_span = epr_span
+        self._next_slot = 0
+        # slot → http_port (for release)
+        self._active: dict[int, int] = {}
+        # freed slots available for re-use
+        self._free: list[int] = []
+
+    def allocate(self) -> tuple[int, int, int]:
+        """Return ``(http_port, epr_lo, epr_hi)`` for a new session."""
+        if self._free:
+            slot = self._free.pop()
+        else:
+            slot = self._next_slot
+            self._next_slot += 1
+        http_port = self._http_base + slot
+        epr_lo = self._epr_base + slot * self._epr_span
+        epr_hi = epr_lo + self._epr_span - 1
+        self._active[slot] = http_port
+        return http_port, epr_lo, epr_hi
+
+    def release(self, http_port: int) -> None:
+        """Return the slot corresponding to ``http_port`` to the free pool."""
+        for slot, port in list(self._active.items()):
+            if port == http_port:
+                del self._active[slot]
+                self._free.append(slot)
+                return
+
+
+class BrowserContainerRunner:
+    """Start and stop per-session Neko Chromium containers."""
+
+    def __init__(
+        self,
+        *,
+        node_ip: str,
+        mock: bool = False,
+        gpu: bool = False,
+        allocator: PortAllocator | None = None,
+    ) -> None:
+        self.node_ip = node_ip
+        self.mock = mock
+        self.gpu = gpu
+        self._allocator = allocator or PortAllocator()
+
+    async def start(self, *, session_id: str, profile_volume: str) -> dict:
+        """Start a Neko container and return connection details.
+
+        Returns a dict with keys: container_id, neko_url, cdp_url,
+        http_port, epr_lo, epr_hi.
+        """
+        http_port, epr_lo, epr_hi = self._allocator.allocate()
+        container_name = f"taos-neko-{session_id[:12]}"
+        user_pwd = secrets.token_urlsafe(16)
+        admin_pwd = secrets.token_urlsafe(16)
+
+        # cast=1 omitted intentionally: the spike found cast=1 is VIEW-ONLY
+        # (full-bleed but no mouse/keyboard control).  Interactive sessions
+        # need it absent.
+        neko_url = f"http://{self.node_ip}:{http_port}/?usr=neko&pwd={user_pwd}"
+        cdp_url = None  # CDP not exposed by this image in Phase 1 (deferred to Phase 2)
+
+        if self.mock:
+            container_id = f"mock-neko-{session_id[:8]}"
+        else:
+            argv = build_neko_run_args(
+                container_name=container_name,
+                profile_volume=profile_volume,
+                node_ip=self.node_ip,
+                http_port=http_port,
+                epr_lo=epr_lo,
+                epr_hi=epr_hi,
+                user_pwd=user_pwd,
+                admin_pwd=admin_pwd,
+                gpu=self.gpu,
+            )
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    *argv,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                stdout, stderr = await proc.communicate()
+                if proc.returncode != 0:
+                    self._allocator.release(http_port)
+                    raise BrowserContainerError(
+                        f"docker run failed (rc={proc.returncode}): {stderr.decode().strip()}"
+                    )
+                container_id = stdout.decode().strip()
+            except BrowserContainerError:
+                raise
+            except Exception as exc:
+                self._allocator.release(http_port)
+                logger.warning("docker run failed for session %s: %s", session_id, exc)
+                raise BrowserContainerError(str(exc)) from exc
+
+        return {
+            "container_id": container_id,
+            "neko_url": neko_url,
+            "cdp_url": cdp_url,
+            "http_port": http_port,
+            "epr_lo": epr_lo,
+            "epr_hi": epr_hi,
+        }
+
+    async def stop(self, *, container_id: str, http_port: int | None = None) -> dict:
+        """Stop a Neko container (keeps the profile volume) and release ports."""
+        if not self.mock:
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    "docker", "stop", container_id,
+                    stdout=asyncio.subprocess.DEVNULL,
+                    stderr=asyncio.subprocess.DEVNULL,
+                )
+                await proc.communicate()
+            except Exception as exc:
+                logger.warning("docker stop failed for %s: %s", container_id, exc)
+        if http_port is not None:
+            self._allocator.release(http_port)
+        return {"ok": True}

--- a/tinyagentos/worker/browser_container.py
+++ b/tinyagentos/worker/browser_container.py
@@ -121,6 +121,29 @@ class BrowserContainerRunner:
         self.gpu = gpu
         self._allocator = allocator or PortAllocator()
 
+    async def _ensure_image(self, image: str) -> None:
+        """Pull ``image`` if it is not already present locally."""
+        if self.mock:
+            return
+        inspect_proc = await asyncio.create_subprocess_exec(
+            "docker", "image", "inspect", image,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        await inspect_proc.communicate()
+        if inspect_proc.returncode == 0:
+            return
+        logger.info("pulling Neko image %s", image)
+        pull_proc = await asyncio.create_subprocess_exec(
+            "docker", "pull", image,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        _, stderr = await pull_proc.communicate()
+        if pull_proc.returncode != 0:
+            detail = stderr.decode().strip()
+            raise BrowserContainerError(f"docker pull {image} failed: {detail}")
+
     async def start(self, *, session_id: str, profile_volume: str) -> dict:
         """Start a Neko container and return connection details.
 
@@ -143,6 +166,8 @@ class BrowserContainerRunner:
         if self.mock:
             container_id = f"mock-neko-{session_id[:8]}"
         else:
+            image = DEFAULT_NEKO_GPU_IMAGE if self.gpu else DEFAULT_NEKO_IMAGE
+            await self._ensure_image(image)
             argv = build_neko_run_args(
                 container_name=container_name,
                 profile_volume=profile_volume,
@@ -153,6 +178,7 @@ class BrowserContainerRunner:
                 user_pwd=user_pwd,
                 admin_pwd=admin_pwd,
                 gpu=self.gpu,
+                image=image,
             )
             try:
                 proc = await asyncio.create_subprocess_exec(

--- a/tinyagentos/worker/browser_container.py
+++ b/tinyagentos/worker/browser_container.py
@@ -42,7 +42,7 @@ def build_neko_run_args(
         image = DEFAULT_NEKO_GPU_IMAGE if gpu else DEFAULT_NEKO_IMAGE
 
     args = [
-        "docker", "run", "-d",
+        "docker", "run", "-d", "--rm",
         "--name", container_name,
         "-p", f"{http_port}:8080",
         "-p", f"{epr_lo}-{epr_hi}:{epr_lo}-{epr_hi}/udp",
@@ -128,7 +128,9 @@ class BrowserContainerRunner:
         http_port, epr_lo, epr_hi.
         """
         http_port, epr_lo, epr_hi = self._allocator.allocate()
-        container_name = f"taos-neko-{session_id[:12]}"
+        # Full session_id (a uuid hex) — avoids name collisions from a
+        # truncated prefix; Docker accepts the length.
+        container_name = f"taos-neko-{session_id}"
         user_pwd = secrets.token_urlsafe(16)
         admin_pwd = secrets.token_urlsafe(16)
 

--- a/tinyagentos/worker/browser_container.py
+++ b/tinyagentos/worker/browser_container.py
@@ -161,8 +161,13 @@ class BrowserContainerRunner:
                 stdout, stderr = await proc.communicate()
                 if proc.returncode != 0:
                     self._allocator.release(http_port)
+                    detail = stderr.decode().strip()
+                    logger.warning(
+                        "docker run failed for session %s (rc=%s): %s",
+                        session_id, proc.returncode, detail,
+                    )
                     raise BrowserContainerError(
-                        f"docker run failed (rc={proc.returncode}): {stderr.decode().strip()}"
+                        f"docker run failed (rc={proc.returncode}): {detail}"
                     )
                 container_id = stdout.decode().strip()
             except BrowserContainerError:

--- a/tinyagentos/worker/browser_main.py
+++ b/tinyagentos/worker/browser_main.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+"""Browser-worker entrypoint.
+
+Wires together a BrowserContainerRunner, the browser-worker FastAPI app, and
+a WorkerAgent that advertises the 'browser' capability to the taOS controller.
+
+Usage::
+
+    python -m tinyagentos.worker.browser_main \\
+        --controller http://taos.local:6969 \\
+        --node-ip 192.168.1.10 \\
+        [--name my-browser-node] \\
+        [--http-api-port 7080] \\
+        [--gpu] \\
+        [--auth-token <secret>]
+"""
+
+import argparse
+import asyncio
+import logging
+
+from fastapi import FastAPI
+
+from tinyagentos.worker.agent import WorkerAgent
+from tinyagentos.worker.browser_container import BrowserContainerRunner
+from tinyagentos.worker.browser_server import create_browser_worker_app
+
+logger = logging.getLogger(__name__)
+
+
+def build(
+    controller_url: str,
+    *,
+    name: str | None = None,
+    node_ip: str,
+    http_api_port: int = 7080,
+    gpu: bool = False,
+    auth_token: str | None = None,
+) -> tuple[FastAPI, WorkerAgent]:
+    """Construct the app + agent pair for the browser-worker.
+
+    Returns ``(app, agent)`` without starting any server or loop.  Callers
+    use this for testing; ``serve()`` drives the actual runtime.
+    """
+    runner = BrowserContainerRunner(node_ip=node_ip, gpu=gpu)
+    app = create_browser_worker_app(runner, auth_token=auth_token)
+    agent = WorkerAgent(
+        controller_url,
+        name=name,
+        worker_port=http_api_port,
+        extra_capabilities=["browser"],
+        advertise_url=f"http://{node_ip}:{http_api_port}",
+    )
+    return app, agent
+
+
+async def serve(
+    controller_url: str,
+    *,
+    name: str | None = None,
+    node_ip: str,
+    http_api_port: int = 7080,
+    gpu: bool = False,
+    auth_token: str | None = None,
+) -> None:
+    """Run the browser-worker: HTTP API + WorkerAgent heartbeat loop."""
+    import uvicorn
+
+    app, agent = build(
+        controller_url,
+        name=name,
+        node_ip=node_ip,
+        http_api_port=http_api_port,
+        gpu=gpu,
+        auth_token=auth_token,
+    )
+
+    config = uvicorn.Config(app, host="0.0.0.0", port=http_api_port, log_level="info")
+    server = uvicorn.Server(config)
+
+    # Run the WorkerAgent registration + heartbeat loop concurrently with uvicorn.
+    agent_task = asyncio.create_task(agent.run())
+    try:
+        await server.serve()
+    finally:
+        agent.stop()
+        agent_task.cancel()
+        try:
+            await agent_task
+        except asyncio.CancelledError:
+            pass
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="taOS browser-worker")
+    parser.add_argument("controller", help="Controller base URL, e.g. http://taos.local:6969")
+    parser.add_argument("--name", default=None, help="Worker name (defaults to hostname)")
+    parser.add_argument("--node-ip", required=True, help="Reachable IP of this node")
+    parser.add_argument("--http-api-port", type=int, default=7080, help="Port for the worker HTTP API")
+    parser.add_argument("--gpu", action="store_true", help="Use the GPU-accelerated Neko image")
+    parser.add_argument("--auth-token", default=None, help="Shared secret for Bearer auth (optional)")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(
+        serve(
+            args.controller,
+            name=args.name,
+            node_ip=args.node_ip,
+            http_api_port=args.http_api_port,
+            gpu=args.gpu,
+            auth_token=args.auth_token,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tinyagentos/worker/browser_main.py
+++ b/tinyagentos/worker/browser_main.py
@@ -9,7 +9,7 @@ Usage::
 
     python -m tinyagentos.worker.browser_main \\
         --controller http://taos.local:6969 \\
-        --node-ip 192.168.1.10 \\
+        --node-ip 10.0.0.5 \\
         [--name my-browser-node] \\
         [--http-api-port 7080] \\
         [--gpu] \\

--- a/tinyagentos/worker/browser_server.py
+++ b/tinyagentos/worker/browser_server.py
@@ -9,6 +9,7 @@ Chromium containers on a capable cluster node.
 import logging
 
 from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from tinyagentos.worker.browser_container import BrowserContainerError, BrowserContainerRunner
@@ -57,7 +58,7 @@ def create_browser_worker_app(
             )
         except BrowserContainerError as exc:
             logger.warning("start_session failed: %s", exc)
-            raise HTTPException(status_code=500, detail=str(exc))
+            return JSONResponse(status_code=500, content={"error": str(exc)})
         return result
 
     @app.post("/worker/browser/stop")

--- a/tinyagentos/worker/browser_server.py
+++ b/tinyagentos/worker/browser_server.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+"""Browser-worker HTTP API.
+
+Exposes two endpoints the taOS controller calls to start/stop Neko
+Chromium containers on a capable cluster node.
+"""
+
+import logging
+
+from fastapi import FastAPI, HTTPException, Request
+from pydantic import BaseModel
+
+from tinyagentos.worker.browser_container import BrowserContainerError, BrowserContainerRunner
+
+logger = logging.getLogger(__name__)
+
+
+class _StartRequest(BaseModel):
+    session_id: str
+    profile_volume: str
+
+
+class _StopRequest(BaseModel):
+    container_id: str
+    http_port: int | None = None
+
+
+def create_browser_worker_app(
+    runner: BrowserContainerRunner,
+    *,
+    auth_token: str | None = None,
+) -> FastAPI:
+    """Return a FastAPI app exposing the browser-worker start/stop API.
+
+    If ``auth_token`` is set, every request must carry
+    ``Authorization: Bearer <auth_token>``; missing or wrong tokens are
+    rejected with 401.  If ``auth_token`` is None, no auth is required
+    (test / development).
+    """
+    app = FastAPI(title="taOS Browser Worker")
+
+    def _check_auth(request: Request) -> None:
+        if auth_token is None:
+            return
+        header = request.headers.get("authorization", "")
+        if not header.startswith("Bearer ") or header[len("Bearer "):] != auth_token:
+            raise HTTPException(status_code=401, detail="Unauthorized")
+
+    @app.post("/worker/browser/start")
+    async def start_session(body: _StartRequest, request: Request) -> dict:
+        _check_auth(request)
+        try:
+            result = await runner.start(
+                session_id=body.session_id,
+                profile_volume=body.profile_volume,
+            )
+        except BrowserContainerError as exc:
+            logger.warning("start_session failed: %s", exc)
+            raise HTTPException(status_code=500, detail=str(exc))
+        return result
+
+    @app.post("/worker/browser/stop")
+    async def stop_session(body: _StopRequest, request: Request) -> dict:
+        _check_auth(request)
+        return await runner.stop(
+            container_id=body.container_id,
+            http_port=body.http_port,
+        )
+
+    return app

--- a/tinyagentos/worker/browser_server.py
+++ b/tinyagentos/worker/browser_server.py
@@ -49,7 +49,7 @@ def create_browser_worker_app(
             raise HTTPException(status_code=401, detail="Unauthorized")
 
     @app.post("/worker/browser/start")
-    async def start_session(body: _StartRequest, request: Request) -> dict:
+    async def start_session(body: _StartRequest, request: Request):
         _check_auth(request)
         try:
             result = await runner.start(


### PR DESCRIPTION
Phase 1 of the hybrid browser (spec: `docs/superpowers/specs/2026-06-02-hybrid-browser-design.md`, plan: `docs/superpowers/plans/2026-06-02-hybrid-browser-phase-1.md`). **Draft** — the controller + SPA layer is complete and tested; the Fedora/Neko-backed tasks (7–10) are pending.

## Done (Tasks 1–6, no infra needed — all mock-mode + component tested)
- **`BrowserSessionManager`** (`tinyagentos/browser_sessions.py`) — `BrowserSession` schema + lifecycle (create/get/list/mark_running/touch_active/terminate), `mock=True` like `AgentBrowsersManager`.
- **Tier-2 placement** — `pick_browser_node()` picks an online cluster node meeting min specs (RAM/cores, GPU-preferred); the 4 GB Pi never qualifies → drives the no-node gate.
- **Scoped stream tokens** — `session_token.py` (per-session HMAC, mirrors `proxy_ticket`).
- **API** — `routes/browser_sessions.py`: `POST /api/browser/sessions` (201 or 409 `no_capable_node`), `GET …/{id}` (mints stream token when running), `POST …/{id}/terminate`; wired into `app.py` lifespan + signing key.
- **SPA** — `<LiveBrowserView>` (iframe to the Neko room, token via URL fragment), an "Open in full browser" toolbar control that escalates + polls, the live view rendered in the **tab body** via `tab.liveSession` (cleared on navigation), and the no-capable-node gate banner.
- **Idle reap** — `reap_idle()` selection + state transition.

**Current behaviour on the Pi (no capable node):** escalation correctly shows the "add a device" gate — so this is a coherent gated increment.

## Pending (Tasks 7–10, require the Fedora cluster node + a Neko spike)
- Neko/Fedora spike (pin image/env/CDP/framing), register Fedora as a worker, worker-side browser-container endpoint, wire real placement (controller→worker), idle-reap background loop, and Playwright E2E on Fedora.

## Tests
578 backend tests pass (incl. full desktop_browser + cluster suites, zero regressions); SPA tsc + build clean; 73 SPA component/store tests green.
