### PR TITLE
chore: add security policy + dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  # Python (controller + worker)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      python-deps:
+        patterns:
+          - "*"
+
+  # Desktop SPA (Vite/React)
+  - package-ecosystem: "npm"
+    directory: "/desktop"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      spa-deps:
+        patterns:
+          - "*"
+
+  # GitHub Actions workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/pr-base-guard.yml
+++ b/.github/workflows/pr-base-guard.yml
@@ -1,0 +1,38 @@
+name: PR base branch guard
+
+# Friendly nudge when a PR is opened against master. master is the stable
+# branch that installs track; contributions belong on dev. We don't auto-close
+# or auto-retarget — just leave a one-time comment so the author can switch the
+# base (the commits and review carry over).
+
+on:
+  pull_request_target:
+    types: [opened]
+    branches: [master]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  nudge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment with retarget guidance
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = [
+              "👋 Thanks for the PR! This one targets **`master`**, which is our",
+              "stable branch (it's what live installs track). Please retarget it to",
+              "**`dev`** — click **Edit** next to the PR title and change the base",
+              "branch dropdown from `master` to `dev`. Your commits and any review",
+              "carry over, nothing is lost.",
+              "",
+              "See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for the branch model.",
+            ].join("\n");
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body,
+            });

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,9 +51,14 @@ The app catalog is one of the easiest ways to contribute. See [Adding an App to 
 2. Create a branch: `git checkout -b feat/my-feature`
 3. Make your changes and add tests
 4. Run `pytest tests/ -v` — all tests must pass
-5. Open a pull request against `main`
+5. Open a pull request against **`dev`**, not `master`
 
 Keep pull requests focused. One feature or fix per PR is easier to review.
+
+> **Branches:** `master` is the stable branch that installs track, so it only
+> receives tested changes promoted from `dev`. All contributions target `dev`.
+> If you open a PR against `master` by mistake, no problem — we'll retarget it
+> to `dev` (the commits and review carry over).
 
 ### Documentation
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,50 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please do not open a public issue for security problems.
+
+Report vulnerabilities privately through GitHub's "Report a vulnerability"
+button under the repository's **Security** tab (Security Advisories). This
+opens a private channel visible only to the maintainers.
+
+When reporting, please include:
+
+- A description of the issue and the impact you think it has
+- Steps to reproduce, or a proof of concept if you have one
+- The affected component (controller API, browser proxy, worker, desktop SPA, etc.)
+- Any relevant logs or configuration (with secrets redacted)
+
+## What to expect
+
+- An acknowledgement within a few days
+- An assessment of severity and scope, and follow-up questions if needed
+- A fix or mitigation plan, with credit to the reporter if you would like it
+- Coordinated disclosure once a fix is available
+
+Please give us reasonable time to address the issue before disclosing it
+publicly.
+
+## Supported versions
+
+taOS is developed on `master`, which is what running installs track. Fixes
+land on `master`; there is no separate long-term support branch. Please test
+against the latest `master` before reporting.
+
+## Scope
+
+In scope:
+
+- The controller (FastAPI) and its HTTP/WebSocket APIs
+- The browser proxy and the live browser worker
+- Agent deployment and container handling
+- Authentication, session handling, and the SSRF guards
+- The desktop SPA
+
+Out of scope:
+
+- Findings that require a pre-compromised host or physical access
+- Denial of service from unrealistic traffic volumes
+- Vulnerabilities in third-party dependencies that are already public and
+  have an upstream fix (open a normal dependency-bump PR instead)
+- Issues only reproducible on unsupported, modified, or end-of-life setups

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,9 +27,10 @@ publicly.
 
 ## Supported versions
 
-taOS is developed on `master`, which is what running installs track. Fixes
-land on `master`; there is no separate long-term support branch. Please test
-against the latest `master` before reporting.
+Active development happens on `dev`; `master` is the stable branch that running
+installs track. Fixes are promoted from `dev` to `master` once tested; there is
+no separate long-term support branch. Please test against the latest `master`
+before reporting (or `dev` if the issue is in unreleased work).
 
 ## Scope
 
@@ -45,6 +46,10 @@ Out of scope:
 
 - Findings that require a pre-compromised host or physical access
 - Denial of service from unrealistic traffic volumes
-- Vulnerabilities in third-party dependencies that are already public and
-  have an upstream fix (open a normal dependency-bump PR instead)
 - Issues only reproducible on unsupported, modified, or end-of-life setups
+
+For a public vulnerability in a third-party dependency: if taOS is still on the
+affected version, please report it privately here first (don't open a public PR
+that signals taOS is exploitable before the bump lands) — we'll prioritise the
+upgrade. If the dependency is already patched in taOS, a normal public
+dependency-bump PR is fine.


### PR DESCRIPTION
Closes the most common repo-audit gap (missing security policy) and turns on dependency update automation.

## What

- **SECURITY.md** — private vulnerability reporting via GitHub Security Advisories, supported-versions note (master), and in/out-of-scope lists. Satisfies GitHub Community Standards and OpenSSF Scorecard's security-policy check.
- **.github/dependabot.yml** — weekly updates, grouped, for three ecosystems: `pip` (root), `npm` (`/desktop`), and `github-actions`.

## Notes

No code changes. Reporting points at the Security tab's "Report a vulnerability" flow rather than an email address.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security vulnerability reporting policy with guidelines for responsible disclosure and supported versions.

* **Chores**
  * Configured automated dependency updates for Python, npm, and GitHub Actions on a weekly schedule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->