### PR TITLE
chore(dependabot): target dev branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@ updates:
   # Python (controller + worker)
   - package-ecosystem: "pip"
     directory: "/"
+    target-branch: "dev"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
@@ -14,6 +15,7 @@ updates:
   # Desktop SPA (Vite/React)
   - package-ecosystem: "npm"
     directory: "/desktop"
+    target-branch: "dev"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
@@ -25,6 +27,7 @@ updates:
   # GitHub Actions workflows
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "dev"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5


### PR DESCRIPTION
Dependabot reads its config from the default branch (master) but defaults to opening PRs against that same default. Add `target-branch: dev` to all three ecosystems so bumps open against `dev` (the integration branch), consistent with the contribution model. Takes effect once promoted to master.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Dependabot configuration to direct dependency updates to the development branch across all package managers and tools, ensuring a unified workflow for automated dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->