### PR TITLE
refactor(agents): extract model-resolution preamble to model_resolver

### DIFF
--- a/tests/cluster/test_model_resolver.py
+++ b/tests/cluster/test_model_resolver.py
@@ -1,0 +1,147 @@
+"""Tests for collect_cloud_model_ids and resolve_model_location.
+
+These cover the two helpers extracted from the deploy/update-model preamble
+in routes/agents.py.  find_model_hosts internals are already tested elsewhere;
+here we only verify the wiring (gather from app.state + call find_model_hosts).
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from tinyagentos.providers import CLOUD_TYPES
+from tinyagentos.cluster.model_resolver import (
+    ModelLocation,
+    collect_cloud_model_ids,
+    resolve_model_location,
+)
+
+# A cloud provider type guaranteed to be in CLOUD_TYPES.
+_CLOUD_TYPE = next(iter(sorted(CLOUD_TYPES)))
+
+
+def _make_config(backends):
+    return SimpleNamespace(backends=backends)
+
+
+class TestCollectCloudModelIds:
+    def test_cloud_backend_dict_models_with_id(self):
+        config = _make_config([
+            {
+                "type": _CLOUD_TYPE,
+                "models": [
+                    {"id": "gpt-4o"},
+                    {"id": "gpt-4o-mini"},
+                ],
+            }
+        ])
+        assert collect_cloud_model_ids(config) == ["gpt-4o", "gpt-4o-mini"]
+
+    def test_dict_model_falls_back_to_name_when_no_id(self):
+        config = _make_config([
+            {
+                "type": _CLOUD_TYPE,
+                "models": [{"name": "claude-3-opus"}],
+            }
+        ])
+        assert collect_cloud_model_ids(config) == ["claude-3-opus"]
+
+    def test_bare_string_model(self):
+        config = _make_config([
+            {"type": _CLOUD_TYPE, "models": ["gpt-4"]},
+        ])
+        assert collect_cloud_model_ids(config) == ["gpt-4"]
+
+    def test_non_cloud_backend_ignored(self):
+        config = _make_config([
+            {"type": "ollama", "models": [{"id": "llama3"}]},
+        ])
+        assert collect_cloud_model_ids(config) == []
+
+    def test_empty_backends_returns_empty(self):
+        assert collect_cloud_model_ids(_make_config([])) == []
+
+    def test_none_backends_returns_empty(self):
+        assert collect_cloud_model_ids(_make_config(None)) == []
+
+    def test_backend_with_none_models_returns_empty(self):
+        config = _make_config([{"type": _CLOUD_TYPE, "models": None}])
+        assert collect_cloud_model_ids(config) == []
+
+    def test_malformed_backend_does_not_propagate(self):
+        # A non-dict backend that would raise on .get() — should return
+        # whatever was gathered before the error, never propagate.
+        config = _make_config([
+            {"type": _CLOUD_TYPE, "models": [{"id": "gpt-4"}]},
+            "not-a-dict",  # will raise AttributeError on .get()
+        ])
+        result = collect_cloud_model_ids(config)
+        # Must not raise; may return the models collected before the bad entry
+        assert isinstance(result, list)
+
+    def test_dict_model_with_neither_id_nor_name_skipped(self):
+        config = _make_config([
+            {"type": _CLOUD_TYPE, "models": [{"other": "x"}]},
+        ])
+        assert collect_cloud_model_ids(config) == []
+
+
+class TestResolveModelLocation:
+    def _make_request(self, *, local_model_names=None, backends=None, workers=None):
+        """Build a minimal fake request with app.state wired up."""
+        local_model_names = local_model_names or []
+        backends = backends or []
+
+        catalog = SimpleNamespace(
+            all_models=lambda: [{"name": n} for n in local_model_names],
+        )
+
+        cluster = SimpleNamespace(
+            get_workers=lambda: workers or [],
+        )
+
+        config = SimpleNamespace(backends=backends)
+
+        state = SimpleNamespace(
+            cluster_manager=cluster,
+            backend_catalog=catalog,
+            config=config,
+        )
+
+        app = SimpleNamespace(state=state)
+        return SimpleNamespace(app=app)
+
+    def test_model_on_controller_returns_controller(self):
+        request = self._make_request(local_model_names=["llama3"])
+        location = resolve_model_location(request, "llama3")
+        assert location.kind == "controller"
+
+    def test_unknown_model_returns_not_found(self):
+        request = self._make_request(local_model_names=["llama3"])
+        location = resolve_model_location(request, "gpt-99-unknown")
+        assert location.kind == "not_found"
+
+    def test_cloud_model_returns_cloud(self):
+        request = self._make_request(
+            local_model_names=[],
+            backends=[{"type": _CLOUD_TYPE, "models": [{"id": "gpt-4o"}]}],
+        )
+        location = resolve_model_location(request, "gpt-4o")
+        assert location.kind == "cloud"
+
+    def test_returns_model_location_instance(self):
+        request = self._make_request()
+        result = resolve_model_location(request, "anything")
+        assert isinstance(result, ModelLocation)
+
+    def test_no_catalog_does_not_raise(self):
+        """backend_catalog missing from state → local_models=[] gracefully."""
+        state = SimpleNamespace(
+            cluster_manager=SimpleNamespace(get_workers=lambda: []),
+            config=SimpleNamespace(backends=[]),
+        )
+        # No backend_catalog attribute at all
+        request = SimpleNamespace(app=SimpleNamespace(state=state))
+        location = resolve_model_location(request, "some-model")
+        assert location.kind == "not_found"

--- a/tinyagentos/cluster/model_resolver.py
+++ b/tinyagentos/cluster/model_resolver.py
@@ -198,3 +198,45 @@ def find_model_hosts(
             return ModelLocation(kind="cloud")
 
     return ModelLocation(kind="not_found")
+
+
+def collect_cloud_model_ids(config) -> list[str]:
+    """Best-effort list of cloud-provider model ids advertised in config.backends.
+
+    Cloud provider types are :data:`tinyagentos.providers.CLOUD_TYPES`. Never
+    raises — on any error returns what was gathered so far.
+    """
+    # Lazy import to avoid any import cycle with providers.
+    from tinyagentos.providers import CLOUD_TYPES  # noqa: PLC0415
+
+    cloud_models: list[str] = []
+    try:
+        for b in config.backends or []:
+            if b.get("type") in CLOUD_TYPES:
+                for m in b.get("models") or []:
+                    mid = (m.get("id") or m.get("name") or "") if isinstance(m, dict) else str(m)
+                    if mid:
+                        cloud_models.append(mid)
+    except Exception:  # noqa: BLE001
+        pass
+    return cloud_models
+
+
+def resolve_model_location(request, model_id: str) -> ModelLocation:
+    """Resolve *model_id* against controller catalog + cluster workers + configured
+    cloud providers, reading state off ``request.app.state``.
+
+    Returns a :class:`ModelLocation`.
+    """
+    state = request.app.state
+    cluster = getattr(state, "cluster_manager", None)
+    catalog = getattr(state, "backend_catalog", None)
+    local_models = catalog.all_models() if catalog is not None else []
+    config = getattr(state, "config", None)
+    cloud_models = collect_cloud_model_ids(config) if config is not None else []
+    return find_model_hosts(
+        model_id,
+        cluster_state=cluster,
+        local_models=local_models,
+        cloud_models=cloud_models,
+    )

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -12,16 +12,9 @@ import taosmd.agents as tm_agents
 
 from tinyagentos.agent_db import find_agent, get_agent_summaries
 from tinyagentos.config import save_config_locked, validate_agent_name, slugify_agent_name
-from tinyagentos.providers import CLOUD_TYPES
-
 logger = logging.getLogger(__name__)
 
 EXPORT_VERSION = 1
-
-# Cloud provider backend types whose advertised models are routable for a
-# deploy / model-change. Single source of truth is providers.CLOUD_TYPES
-# (#351); aliased here so the call sites below read clearly.
-_CLOUD_PROVIDER_TYPES = CLOUD_TYPES
 
 router = APIRouter()
 
@@ -537,41 +530,9 @@ async def deploy_agent_endpoint(request: Request, body: DeployAgentRequest):
     # deploy with a clear 409 when the user's pin conflicts with where
     # the model actually is.
     if body.model:
-        from tinyagentos.cluster.model_resolver import find_model_hosts
+        from tinyagentos.cluster.model_resolver import resolve_model_location
 
-        cluster = getattr(request.app.state, "cluster_manager", None)
-        catalog = getattr(request.app.state, "backend_catalog", None)
-        local_models = catalog.all_models() if catalog is not None else []
-
-        # Cloud model ids are whatever openai/anthropic-typed backends
-        # advertise. Keep this a best-effort: missing provider state just
-        # means cloud models resolve as "not_found" and the caller can
-        # retry once providers are configured.
-        cloud_models: list[str] = []
-        try:
-            for b in config.backends or []:
-                # All cloud provider types, not just openai/anthropic — kilocode,
-                # openrouter and openai-compatible advertise routable cloud models
-                # too. Mirrors providers.CLOUD_TYPES (#351 tracks consolidating
-                # these lists). Without this, deploying an agent on e.g.
-                # kilo-auto/free 404s as "model not found".
-                if b.get("type") in _CLOUD_PROVIDER_TYPES:
-                    for m in b.get("models") or []:
-                        if isinstance(m, dict):
-                            mid = m.get("id") or m.get("name") or ""
-                        else:
-                            mid = str(m)
-                        if mid:
-                            cloud_models.append(mid)
-        except Exception:  # noqa: BLE001
-            pass
-
-        location = find_model_hosts(
-            body.model,
-            cluster_state=cluster,
-            local_models=local_models,
-            cloud_models=cloud_models,
-        )
+        location = resolve_model_location(request, body.model)
 
         if location.kind == "not_found":
             return JSONResponse(
@@ -1351,32 +1312,9 @@ async def update_agent_model(request: Request, name: str, body: AgentModelUpdate
         return JSONResponse({"error": "model must not be empty"}, status_code=400)
 
     # Validate reachability against the live cluster state.
-    from tinyagentos.cluster.model_resolver import find_model_hosts
+    from tinyagentos.cluster.model_resolver import resolve_model_location
 
-    cluster = getattr(request.app.state, "cluster_manager", None)
-    catalog = getattr(request.app.state, "backend_catalog", None)
-    local_models = catalog.all_models() if catalog is not None else []
-
-    cloud_models: list[str] = []
-    try:
-        for b in config.backends or []:
-            # All cloud provider types (see _CLOUD_PROVIDER_TYPES / #351), so a
-            # model change to a kilocode/openrouter/openai-compatible model
-            # resolves instead of 404ing.
-            if b.get("type") in _CLOUD_PROVIDER_TYPES:
-                for m in b.get("models") or []:
-                    mid = (m.get("id") or m.get("name") or "") if isinstance(m, dict) else str(m)
-                    if mid:
-                        cloud_models.append(mid)
-    except Exception:  # noqa: BLE001
-        pass
-
-    location = find_model_hosts(
-        model_id,
-        cluster_state=cluster,
-        local_models=local_models,
-        cloud_models=cloud_models,
-    )
+    location = resolve_model_location(request, model_id)
 
     if location.kind == "not_found":
         return JSONResponse(


### PR DESCRIPTION
First safe-win from the 2026-06-03 modularity audit (S2).

**Pure dedup, behavior-identical.** Two `agents.py` endpoints (`deploy_agent_endpoint`, `update_agent_model`) had a near-verbatim ~20-line preamble that gathers cluster/catalog/local + cloud model ids and calls `find_model_hosts`. Extracted to `cluster/model_resolver.py`:
- `collect_cloud_model_ids(config)` — best-effort cloud-model-id gather (never raises).
- `resolve_model_location(request, model_id)` — reads cluster/catalog/config off `app.state`, returns a `ModelLocation`.

Each endpoint's post-resolution handling (deploy's 404, update's 409, the worker/controller/cloud branches) is unchanged. Removed the now-orphaned `CLOUD_TYPES` import + `_CLOUD_PROVIDER_TYPES` alias from agents.py. `agents.py` −66 lines.

+14 unit tests for the new helpers; existing agents-route + resolver tests pass (67 green locally).

Part of the broader modularity plan (docs/superpowers/plans/2026-06-03-modularity-plan.md, local). Left for review — not auto-merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added extensive test coverage for model resolution functions, validating cloud model ID collection and location resolution across various backend configurations and edge cases.

* **Refactor**
  * Centralized model location resolution logic into dedicated helper functions, improving code organization and maintainability across the cluster management system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->