### PR TITLE
fix(models): delete orphaned .safetensors/.onnx model files

### DIFF
--- a/tests/test_routes_models.py
+++ b/tests/test_routes_models.py
@@ -406,3 +406,34 @@ class TestLoadedModelsImageBackends:
 
         assert resp.status_code == 200
         assert resp.json()["loaded"] == []
+
+
+@pytest.mark.asyncio
+class TestDeleteModel:
+    async def test_delete_removes_all_model_suffixes(self, models_app, models_client):
+        """DELETE removes every recognised model suffix (incl .safetensors/.onnx
+        and uppercase) but leaves non-model files alone. Regression: the old
+        hardcoded (.gguf,.rkllm,.bin) list orphaned .safetensors/.onnx files."""
+        models_dir = models_app.state.models_dir
+        # NB: use uppercase .GGUF only (no lowercase twin) — it proves both the
+        # .gguf suffix match AND case-insensitivity, and avoids a case-insensitive
+        # filesystem (macOS) collapsing .gguf/.GGUF into one file.
+        for fn in (
+            "test-model.GGUF",      # uppercase → exercises case-insensitive match
+            "test-model.safetensors",
+            "test-model.onnx",
+        ):
+            (models_dir / fn).write_bytes(b"x")
+        (models_dir / "test-model.txt").write_bytes(b"x")  # non-model, must survive
+
+        resp = await models_client.delete("/api/models/test-model")
+        assert resp.status_code == 200
+        deleted = set(resp.json()["deleted_files"])
+        assert {
+            "test-model.GGUF",
+            "test-model.safetensors",
+            "test-model.onnx",
+        } <= deleted
+        assert not (models_dir / "test-model.safetensors").exists()
+        assert not (models_dir / "test-model.onnx").exists()
+        assert (models_dir / "test-model.txt").exists()

--- a/tinyagentos/routes/models.py
+++ b/tinyagentos/routes/models.py
@@ -740,7 +740,10 @@ async def delete_model(request: Request, model_id: str):
 
     deleted = []
     for f in models_dir.glob(f"{model_id}*"):
-        if f.is_file() and f.suffix in (".gguf", ".rkllm", ".bin"):
+        # Use the same canonical suffix set (case-insensitive) the scan uses,
+        # so .safetensors/.onnx models aren't left orphaned on disk after a
+        # "delete" — the narrower hardcoded list missed them.
+        if f.is_file() and f.suffix.lower() in _MODEL_FILE_SUFFIXES:
             f.unlink()
             deleted.append(f.name)
 


### PR DESCRIPTION
Bug found during the 2026-06-03 modularity audit.

`DELETE /api/models/{id}` only unlinked `(.gguf,.rkllm,.bin)` (case-sensitive), but the model scan recognises `(.gguf,.rkllm,.bin,.safetensors,.onnx)`. So deleting a `.safetensors` or `.onnx` model reported success but **left the files on disk** (silent disk leak; the model could even re-appear in the scan). Fix: delete using the same canonical `_MODEL_FILE_SUFFIXES` set, case-insensitively (also catches uppercase suffixes).

+1 regression test (cross-platform: avoids the macOS case-insensitive-FS collision). 22 models-route tests green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed model deletion to properly remove all recognized model file formats, including `.safetensors`, `.onnx`, and case-insensitive variants like `.GGUF`.

* **Tests**
  * Added test coverage for model deletion across multiple file formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->