### PR TITLE
fix(themes): block path traversal in theme asset endpoint

### DIFF
--- a/tests/themes/test_routes.py
+++ b/tests/themes/test_routes.py
@@ -24,3 +24,35 @@ async def test_install_rejects_bad_config(client):
     r = await client.post("/api/themes/install",
                           files={"package": ("b.taostheme", _zip(bad), "application/zip")})
     assert r.status_code == 400
+
+
+def _zip_with_asset(m, asset_path, asset_bytes):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        z.writestr("theme.yaml", yaml.safe_dump(m))
+        z.writestr(asset_path, asset_bytes)
+    return buf.getvalue()
+
+
+@pytest.mark.asyncio
+async def test_theme_asset_served_but_traversal_blocked(client):
+    """Assets are served, but neither a non-slug theme_id nor a ../ in the
+    asset path can escape the theme's assets dir (path-traversal guard)."""
+    pkg = _zip_with_asset(M, "assets/logo.txt", b"PIXELS")
+    r = await client.post("/api/themes/install",
+                          files={"package": ("matrix.taostheme", pkg, "application/zip")})
+    assert r.status_code == 200
+
+    # Positive: a legitimate asset is served.
+    ok = await client.get("/api/themes/matrix/assets/logo.txt")
+    assert ok.status_code == 200 and ok.content == b"PIXELS"
+
+    # A non-slug theme_id (would relocate the assets root) is rejected.
+    bad_id = await client.get("/api/themes/matrix.evil/assets/logo.txt")
+    assert bad_id.status_code == 404
+
+    # A ../ in the asset path (percent-encoded so the client doesn't
+    # normalise it away) must not escape the assets dir — theme.yaml lives
+    # one level up in the theme dir, so a successful escape would leak it.
+    escape = await client.get("/api/themes/matrix/assets/%2e%2e/theme.yaml")
+    assert escape.status_code == 404

--- a/tinyagentos/routes/themes.py
+++ b/tinyagentos/routes/themes.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import re
 from pathlib import Path
 from fastapi import APIRouter, Request, UploadFile, File
 from fastapi.responses import JSONResponse, FileResponse
@@ -6,6 +7,15 @@ from fastapi.responses import JSONResponse, FileResponse
 from tinyagentos.themes.package import extract_theme_package, ThemePackageError
 
 router = APIRouter()
+
+# theme_id is interpolated into filesystem paths, so it must be a plain slug —
+# never a value that could contain "/" or ".." and escape the themes root.
+_THEME_ID_RE = re.compile(r"[A-Za-z0-9_-]+")
+
+
+def _valid_theme_id(theme_id: str) -> bool:
+    return bool(_THEME_ID_RE.fullmatch(theme_id))
+
 
 def _themes_root(request: Request) -> Path:
     return Path(request.app.state.data_dir) / "themes"
@@ -33,17 +43,23 @@ async def install_theme(request: Request, package: UploadFile = File(...)):
 @router.delete("/api/themes/{theme_id}")
 async def remove_theme(request: Request, theme_id: str):
     import shutil
+    if not _valid_theme_id(theme_id):
+        return JSONResponse({"error": "not found"}, status_code=404)
     removed = await request.app.state.themes.remove(theme_id)
     root = _themes_root(request).resolve()
     d = (root / theme_id).resolve()
-    if str(d).startswith(str(root) + "/") and d.exists():
+    if d.is_relative_to(root) and d != root and d.exists():
         shutil.rmtree(d, ignore_errors=True)
     return {"status": "ok", "removed": removed}
 
 @router.get("/api/themes/{theme_id}/assets/{path:path}")
 async def theme_asset(request: Request, theme_id: str, path: str):
-    root = (_themes_root(request) / theme_id / "assets").resolve()
-    target = (root / path).resolve()
-    if not str(target).startswith(str(root) + "/") or not target.is_file():
+    if not _valid_theme_id(theme_id):
+        return JSONResponse({"error": "not found"}, status_code=404)
+    asset_root = (_themes_root(request) / theme_id / "assets").resolve()
+    target = (asset_root / path).resolve()
+    # asset_root can't escape the themes root (theme_id is a validated slug);
+    # is_relative_to then blocks any "../" traversal via the {path:path} segment.
+    if not target.is_relative_to(asset_root) or not target.is_file():
         return JSONResponse({"error": "not found"}, status_code=404)
     return FileResponse(target)


### PR DESCRIPTION
**Security fix** (flagged by automated push review; MEDIUM path traversal).

`GET /api/themes/{theme_id}/assets/{path:path}` interpolated an unvalidated `theme_id` into a filesystem path. A traversing `theme_id` (e.g. `../../..`) could relocate the assets root outside the themes directory, and the original guard only checked the requested file against that **already-relocated** root, so it could serve files from an arbitrary `<dir>/assets/` location.

Fix:
- Validate `theme_id` against `[A-Za-z0-9_-]+` (a plain slug) before using it in any path.
- Resolve the assets root and require `target.is_relative_to(asset_root)`, so neither `theme_id` nor the `{path:path}` segment can escape.
- Added the same slug guard to the DELETE handler (defense-in-depth). The install path (`extract_theme_package`) was already guarded against unsafe ids + zip-slip.

+1 regression test: legit asset served (200), non-slug `theme_id` rejected (404), percent-encoded `../` traversal rejected (404).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened theme asset serving with stricter theme ID validation that rejects invalid formats.
  * Enhanced path traversal protection to prevent unauthorized access to theme assets outside their designated directory.

* **Tests**
  * Added comprehensive test coverage for theme asset serving, including path traversal attack prevention and ID validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->