### PR TITLE
fix(spa): drop deprecated tsconfig baseUrl (TS7-ready)

### DIFF
--- a/desktop/tsconfig.json
+++ b/desktop/tsconfig.json
@@ -18,8 +18,7 @@
     "noUncheckedIndexedAccess": true,
     "paths": {
       "@/*": ["./src/*"]
-    },
-    "baseUrl": "."
+    }
   },
   "include": ["src"],
   "exclude": [


### PR DESCRIPTION
Unblocks #530. The SPA dep group bump fails `spa-build` because it bumps TypeScript to 7.0, which errors on the deprecated `baseUrl` option (TS5101). We only use `baseUrl` for the `@/*` path alias, and TS 5.0+ resolves `paths` relative to the config directory without it. Dropping `baseUrl` builds clean on TS 5.7 (verified locally) and makes us TS7-ready. After this lands, #530 rebases and builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript configuration by removing an unused setting from the desktop build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->