### PR TITLE
fix(chat): fail-closed author identity (session_user, not get_user)

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -690,3 +690,36 @@ class TestMiddlewareBearerPath:
             headers={"Authorization": "Bearer nope"},
         )
         assert resp.status_code == 401
+
+
+class TestSessionUserNoFallback:
+    """session_user must resolve to *nobody* on a bad/empty token, unlike
+    get_user (which falls back to the first user). Author-ownership checks in
+    chat.py rely on this distinction, so lock the invariant in.
+    """
+
+    def test_session_user_bad_token_is_none(self, tmp_path):
+        mgr = AuthManager(tmp_path)
+        mgr.setup_user("alice", "Alice", "", "pw")
+        assert mgr.session_user("not-a-real-token") is None
+
+    def test_session_user_empty_token_is_none(self, tmp_path):
+        mgr = AuthManager(tmp_path)
+        mgr.setup_user("alice", "Alice", "", "pw")
+        assert mgr.session_user("") is None
+
+    def test_get_user_bad_token_falls_back_to_first_user(self, tmp_path):
+        # Documents the footgun session_user avoids: get_user with a present
+        # but invalid token returns the first user, which is wrong for
+        # identity/ownership decisions.
+        mgr = AuthManager(tmp_path)
+        mgr.setup_user("alice", "Alice", "", "pw")
+        assert mgr.get_user(token="not-a-real-token") is not None
+
+    def test_session_user_valid_token_returns_owner(self, tmp_path):
+        mgr = AuthManager(tmp_path)
+        mgr.setup_user("alice", "Alice", "", "pw")
+        rec = mgr.find_user("alice")
+        token = mgr.create_session(user_id=rec["id"])
+        u = mgr.session_user(token)
+        assert u is not None and u["id"] == rec["id"]

--- a/tinyagentos/routes/chat.py
+++ b/tinyagentos/routes/chat.py
@@ -545,7 +545,7 @@ async def pin_message_endpoint(message_id: str, request: Request):
     if auth is not None:
         token = request.cookies.get("taos_session") or ""
         if token:
-            session_user = auth.get_user(token=token)
+            session_user = auth.session_user(token)
     pinned_by = f"user:{session_user['id']}" if session_user else "user:unknown"
     try:
         await msg_store.pin_message(msg["channel_id"], message_id, pinned_by=pinned_by)
@@ -599,7 +599,7 @@ async def edit_message_endpoint(message_id: str, request: Request):
     session_user = None
     if auth is not None:
         token = request.cookies.get("taos_session") or ""
-        session_user = auth.get_user(token=token)
+        session_user = auth.session_user(token)
     caller_id = session_user["id"] if session_user else None
     if msg["author_id"] != caller_id:
         return JSONResponse({"error": "not the author"}, status_code=403)
@@ -625,7 +625,7 @@ async def delete_message_endpoint(message_id: str, request: Request):
     session_user = None
     if auth is not None:
         token = request.cookies.get("taos_session") or ""
-        session_user = auth.get_user(token=token)
+        session_user = auth.session_user(token)
     caller_id = session_user["id"] if session_user else None
     if msg["author_id"] != caller_id:
         return JSONResponse({"error": "not the author"}, status_code=403)
@@ -865,7 +865,7 @@ async def rewind_read_cursor_endpoint(channel_id: str, request: Request):
     session_user = None
     if auth is not None:
         token = request.cookies.get("taos_session") or ""
-        session_user = auth.get_user(token=token)
+        session_user = auth.session_user(token)
     if session_user is None:
         return JSONResponse({"error": "not authenticated"}, status_code=401)
     await ch_store.rewind_read_cursor(


### PR DESCRIPTION
From the modularity audit (B1). chat.py's pin/edit/delete/rewind used `auth.get_user(token=...)`, which **falls back to the first user** on an absent/invalid token (`auth.py:223-227`). For author-ownership checks that's the wrong identity. Swapped all 4 sites to `auth.session_user(token)`, which returns `None` on a bad/empty token so the ownership check fails closed.

Not a live bypass today (these endpoints are gated by the auth middleware, which requires a valid session), but `session_user` is the correct fail-closed primitive and removes the footgun for any future non-gated caller. `store_install.py` already uses `session_user`.

+4 `AuthManager` tests locking in `session_user(bad/empty) is None` vs `get_user`'s fallback. Existing chat edit/delete/pin tests (17) still pass.

Note: the audit's 'duplicate PATCH /channels' item was a false positive — line 470 is PUT, 652 is PATCH (distinct methods).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added test coverage for session-based user authentication and token validation.

* **Refactor**
  * Updated session authentication validation method in chat endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->