### PR TITLE
refactor(agents): extract unique_agent_slug helper (S3)

### DIFF
--- a/tests/test_unique_agent_slug.py
+++ b/tests/test_unique_agent_slug.py
@@ -1,0 +1,52 @@
+import pytest
+from tinyagentos.config import AppConfig, unique_agent_slug
+
+
+def _config(*names: str) -> AppConfig:
+    """Build a minimal AppConfig with agents having the given names."""
+    cfg = AppConfig()
+    cfg.agents = [{"name": n} for n in names]
+    return cfg
+
+
+class TestUniqueAgentSlug:
+    def test_no_collision_returns_plain_slug(self):
+        cfg = _config()
+        assert unique_agent_slug(cfg, "My Agent") == "my-agent"
+
+    def test_one_collision_returns_suffix_2(self):
+        cfg = _config("my-agent")
+        assert unique_agent_slug(cfg, "My Agent") == "my-agent-2"
+
+    def test_two_collisions_returns_suffix_3(self):
+        cfg = _config("my-agent", "my-agent-2")
+        assert unique_agent_slug(cfg, "My Agent") == "my-agent-3"
+
+    def test_many_collisions_increments_correctly(self):
+        occupied = ["my-agent"] + [f"my-agent-{i}" for i in range(2, 10)]
+        cfg = _config(*occupied)
+        assert unique_agent_slug(cfg, "My Agent") == "my-agent-10"
+
+    def test_cap_100_raises_value_error(self):
+        occupied = ["my-agent"] + [f"my-agent-{i}" for i in range(2, 101)]
+        cfg = _config(*occupied)
+        with pytest.raises(ValueError, match="unique agent slug"):
+            unique_agent_slug(cfg, "My Agent")
+
+    def test_cap_99_still_succeeds(self):
+        # Slots my-agent through my-agent-98 are taken; my-agent-99 is free.
+        occupied = ["my-agent"] + [f"my-agent-{i}" for i in range(2, 99)]
+        cfg = _config(*occupied)
+        assert unique_agent_slug(cfg, "My Agent") == "my-agent-99"
+
+    def test_unrelated_agents_do_not_block(self):
+        cfg = _config("other-agent", "another-one")
+        assert unique_agent_slug(cfg, "My Agent") == "my-agent"
+
+    def test_special_characters_in_display_name(self):
+        cfg = _config()
+        assert unique_agent_slug(cfg, "Agent_42!") == "agent-42"
+
+    def test_emoji_display_name(self):
+        cfg = _config()
+        assert unique_agent_slug(cfg, "🚀 Alpha v2") == "alpha-v2"

--- a/tinyagentos/config.py
+++ b/tinyagentos/config.py
@@ -129,6 +129,25 @@ def slugify_agent_name(name: str) -> str:
     return slug[:63]
 
 
+def unique_agent_slug(config: "AppConfig", display_name: str) -> str:
+    """Slugify display_name and append -2, -3, … until the slug is unique.
+
+    Checks for collisions against config.agents by matching the ``name``
+    field, mirroring the semantics of agent_db.find_agent.
+
+    Raises ValueError if no unique slug can be found within 100 attempts.
+    """
+    slug = slugify_agent_name(display_name)
+    unique_slug = slug
+    suffix = 2
+    while any(a.get("name") == unique_slug for a in config.agents):
+        unique_slug = f"{slug}-{suffix}"
+        suffix += 1
+        if suffix > 100:
+            raise ValueError("Could not generate a unique agent slug")
+    return unique_slug
+
+
 def _default_on_worker_failure(agent: dict) -> str:
     """Return the default on_worker_failure policy for an agent dict.
 

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel
 import taosmd.agents as tm_agents
 
 from tinyagentos.agent_db import find_agent, get_agent_summaries
-from tinyagentos.config import save_config_locked, validate_agent_name, slugify_agent_name
+from tinyagentos.config import save_config_locked, validate_agent_name, unique_agent_slug
 logger = logging.getLogger(__name__)
 
 EXPORT_VERSION = 1
@@ -105,14 +105,10 @@ async def add_agent(request: Request, body: AgentCreate):
     if name_error:
         return JSONResponse({"error": name_error}, status_code=400)
 
-    slug = slugify_agent_name(display_name)
-    unique_slug = slug
-    suffix = 2
-    while find_agent(config, unique_slug):
-        unique_slug = f"{slug}-{suffix}"
-        suffix += 1
-        if suffix > 100:
-            return JSONResponse({"error": "Could not generate a unique agent slug"}, status_code=400)
+    try:
+        unique_slug = unique_agent_slug(config, display_name)
+    except ValueError as e:
+        return JSONResponse({"error": str(e)}, status_code=400)
 
     agent = body.model_dump()
     agent["name"] = unique_slug
@@ -472,14 +468,10 @@ async def deploy_agent_endpoint(request: Request, body: DeployAgentRequest):
     if name_error:
         return JSONResponse({"error": name_error}, status_code=400)
     # Derive a container-safe slug and ensure uniqueness
-    slug = slugify_agent_name(display_name)
-    unique_slug = slug
-    suffix = 2
-    while find_agent(config, unique_slug):
-        unique_slug = f"{slug}-{suffix}"
-        suffix += 1
-        if suffix > 100:
-            return JSONResponse({"error": "Could not generate a unique agent slug"}, status_code=400)
+    try:
+        unique_slug = unique_agent_slug(config, display_name)
+    except ValueError as e:
+        return JSONResponse({"error": str(e)}, status_code=400)
     # Rewrite body.name to the unique slug; the original user-entered name
     # is preserved as display_name for the UI.
     body.name = unique_slug
@@ -987,13 +979,10 @@ async def restore_archived_agent(request: Request, archive_id: str):
     container = f"taos-agent-{desired_slug}"
 
     # Resolve slug collisions with currently-live agents.
-    final_slug = desired_slug
-    suffix = 2
-    while find_agent(config, final_slug):
-        final_slug = f"{desired_slug}-{suffix}"
-        suffix += 1
-        if suffix > 100:
-            return JSONResponse({"error": "Could not resolve restore slug"}, status_code=500)
+    try:
+        final_slug = unique_agent_slug(config, desired_slug)
+    except ValueError:
+        return JSONResponse({"error": "Could not resolve restore slug"}, status_code=500)
 
     data_dir = request.app.state.data_dir
     archive_base = data_dir / entry.get("archive_dir", "")


### PR DESCRIPTION
Modularity plan S3. Three copies of the slugify + numeric-suffix collision loop in agents.py (`add_agent`, `deploy_agent_endpoint`, restore) → one `unique_agent_slug(config, display_name)` helper in config.py. Pure dedup, behavior preserved (each caller keeps its own overflow response — 400/500 — by catching the helper's `ValueError`). Collision check is inlined against `config.agents` to avoid an agent_db import cycle. +9 tests; 101 agent tests still pass. Preps the B2 agents.py split.