### PR TITLE
refactor(containers): extract configure_container_runtime helper (S4)

### DIFF
--- a/tests/test_container_runtime_config.py
+++ b/tests/test_container_runtime_config.py
@@ -1,0 +1,92 @@
+"""Tests for configure_container_runtime() helper in containers.backend."""
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import tinyagentos.containers.backend as _be
+from tinyagentos.containers.backend import configure_container_runtime
+
+
+@pytest.fixture(autouse=True)
+def restore_backend():
+    """Restore the global backend after each test."""
+    original = _be._active_backend
+    yield
+    _be._active_backend = original
+
+
+class TestConfigureContainerRuntimeFound:
+    def test_lxc_sets_lxc_backend(self):
+        with patch("tinyagentos.containers.backend.detect_runtime", return_value="lxc"):
+            result = configure_container_runtime(None)
+        assert result == "lxc"
+        from tinyagentos.containers.lxc import LXCBackend
+        assert isinstance(_be._active_backend, LXCBackend)
+
+    def test_docker_sets_docker_backend(self):
+        with patch("tinyagentos.containers.backend.detect_runtime", return_value="docker"):
+            result = configure_container_runtime(None)
+        assert result == "docker"
+        from tinyagentos.containers.docker import DockerBackend
+        assert isinstance(_be._active_backend, DockerBackend)
+
+    def test_podman_sets_docker_backend_with_podman_binary(self):
+        with patch("tinyagentos.containers.backend.detect_runtime", return_value="podman"):
+            result = configure_container_runtime(None)
+        assert result == "podman"
+        from tinyagentos.containers.docker import DockerBackend
+        assert isinstance(_be._active_backend, DockerBackend)
+
+    def test_apple_sets_apple_backend(self, monkeypatch):
+        monkeypatch.setenv("TAOS_CONTAINER_BIN", "/usr/local/bin/container")
+        with patch("tinyagentos.containers.backend.detect_runtime", return_value="apple"):
+            result = configure_container_runtime(None)
+        assert result == "apple"
+        from tinyagentos.containers.apple_backend import AppleContainerBackend
+        assert isinstance(_be._active_backend, AppleContainerBackend)
+
+
+class TestConfigureContainerRuntimeNone:
+    def test_returns_none_when_no_runtime(self, caplog):
+        with patch("tinyagentos.containers.backend.detect_runtime", return_value="none"), \
+             caplog.at_level(logging.WARNING, logger="tinyagentos.containers.backend"):
+            result = configure_container_runtime(None)
+        assert result is None
+        assert any(
+            "No container backend detected (Incus / Docker / Podman / Apple)" in r.message
+            for r in caplog.records
+        )
+
+    def test_does_not_set_backend_when_none(self):
+        _be._active_backend = None
+        with patch("tinyagentos.containers.backend.detect_runtime", return_value="none"):
+            configure_container_runtime(None)
+        assert _be._active_backend is None
+
+
+class TestConfigureContainerRuntimeConfigOverride:
+    def test_config_pin_bypasses_detect(self):
+        config = MagicMock()
+        config.container_runtime = "lxc"
+        # detect_runtime should never be called when pinned
+        with patch("tinyagentos.containers.backend.detect_runtime") as mock_detect:
+            result = configure_container_runtime(config)
+        mock_detect.assert_not_called()
+        assert result == "lxc"
+
+    def test_config_auto_calls_detect(self):
+        config = MagicMock()
+        config.container_runtime = "auto"
+        with patch("tinyagentos.containers.backend.detect_runtime", return_value="docker") as mock_detect:
+            result = configure_container_runtime(config)
+        mock_detect.assert_called_once()
+        assert result == "docker"
+
+    def test_none_config_defaults_to_auto(self):
+        with patch("tinyagentos.containers.backend.detect_runtime", return_value="lxc") as mock_detect:
+            result = configure_container_runtime(None)
+        mock_detect.assert_called_once()
+        assert result == "lxc"

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -787,26 +787,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
             logger.exception("resource scheduler failed to build — routes will use static config")
             app.state.resource_scheduler = None
         # Detect and set container runtime
-        from tinyagentos.containers.backend import detect_runtime, set_backend
-        from tinyagentos.containers.lxc import LXCBackend
-        from tinyagentos.containers.docker import DockerBackend
-        runtime = getattr(config, "container_runtime", "auto")
-        if runtime == "auto":
-            runtime = detect_runtime()
-        if runtime == "apple":
-            from tinyagentos.containers.apple_backend import AppleContainerBackend
-            set_backend(AppleContainerBackend())
-        elif runtime == "lxc":
-            set_backend(LXCBackend())
-        elif runtime in ("docker", "podman"):
-            set_backend(DockerBackend(binary=runtime))
-        else:
-            logger.warning(
-                "No container backend detected (Incus / Docker / Podman / Apple). "
-                "Cluster features and worker containers will be disabled. "
-                "Install one (e.g. 'sudo apt install incus' on Ubuntu/Debian, "
-                "'sudo dnf install incus' on Fedora) and restart taOS."
-            )
+        from tinyagentos.containers.backend import configure_container_runtime
+        configure_container_runtime(config)
 
         # Disk quota monitor — build and attach to app state so the route
         # handler can reuse the same instance (preserves in-memory last_state).
@@ -1059,26 +1041,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
 
     # Detect and set container runtime (eager, so tests work without lifespan)
     try:
-        from tinyagentos.containers.backend import detect_runtime, set_backend
-        from tinyagentos.containers.lxc import LXCBackend
-        from tinyagentos.containers.docker import DockerBackend
-        _runtime = getattr(config, "container_runtime", "auto")
-        if _runtime == "auto":
-            _runtime = detect_runtime()
-        if _runtime == "apple":
-            from tinyagentos.containers.apple_backend import AppleContainerBackend
-            set_backend(AppleContainerBackend())
-        elif _runtime == "lxc":
-            set_backend(LXCBackend())
-        elif _runtime in ("docker", "podman"):
-            set_backend(DockerBackend(binary=_runtime))
-        else:
-            logger.warning(
-                "No container backend detected (Incus / Docker / Podman / Apple). "
-                "Cluster features and worker containers will be disabled. "
-                "Install one (e.g. 'sudo apt install incus' on Ubuntu/Debian, "
-                "'sudo dnf install incus' on Fedora) and restart taOS."
-            )
+        from tinyagentos.containers.backend import configure_container_runtime
+        configure_container_runtime(config)
     except Exception:
         logger.exception("container backend auto-init failed")
 

--- a/tinyagentos/containers/backend.py
+++ b/tinyagentos/containers/backend.py
@@ -286,3 +286,39 @@ def set_backend(backend: ContainerBackend) -> None:
     """Set the active container backend."""
     global _active_backend
     _active_backend = backend
+
+
+def configure_container_runtime(config: object = None) -> str | None:
+    """Detect the container runtime, set it as the active backend, and return it.
+
+    Reads ``config.container_runtime`` (default ``"auto"``) to allow the
+    operator to pin a specific runtime.  When ``"auto"``, ``detect_runtime()``
+    is called to probe the host.
+
+    Returns the runtime name (``"apple"``, ``"lxc"``, ``"docker"``, or
+    ``"podman"``), or ``None`` (after logging a warning) if no runtime is
+    available.
+    """
+    from tinyagentos.containers.lxc import LXCBackend
+    from tinyagentos.containers.docker import DockerBackend
+
+    runtime = getattr(config, "container_runtime", "auto")
+    if runtime == "auto":
+        runtime = detect_runtime()
+    if runtime == "apple":
+        from tinyagentos.containers.apple_backend import AppleContainerBackend
+        set_backend(AppleContainerBackend())
+        return runtime
+    if runtime == "lxc":
+        set_backend(LXCBackend())
+        return runtime
+    if runtime in ("docker", "podman"):
+        set_backend(DockerBackend(binary=runtime))
+        return runtime
+    logger.warning(
+        "No container backend detected (Incus / Docker / Podman / Apple). "
+        "Cluster features and worker containers will be disabled. "
+        "Install one (e.g. 'sudo apt install incus' on Ubuntu/Debian, "
+        "'sudo dnf install incus' on Fedora) and restart taOS."
+    )
+    return None


### PR DESCRIPTION
Modularity plan S4. The detect-runtime → set-backend → warn-if-none block was duplicated verbatim in two places in app.py. Extracted into `configure_container_runtime(config)` in containers/backend.py (alongside detect_runtime/set_backend); both app.py sites now call it. Warning text preserved byte-for-byte. app.py −40 lines, orphaned imports removed. +9 tests; 55 container/app tests still pass. Preps the B3 app.py split.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for container runtime configuration, covering runtime detection-to-backend mapping for `lxc`, `docker`, `podman`, and `apple`.
  * Verified configuration override semantics and runtime detection behavior.

* **Refactor**
  * Refactored container runtime initialization during application startup to use a new centralized configuration function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->