### PR TITLE
refactor(agents): extract _bulk_container_op helper (S11)

### DIFF
--- a/tests/test_bulk_container_op.py
+++ b/tests/test_bulk_container_op.py
@@ -1,0 +1,65 @@
+import pytest
+from tinyagentos.routes.agents import _bulk_container_op
+
+
+class FakeConfig:
+    def __init__(self, agents):
+        self.agents = agents
+
+
+@pytest.mark.asyncio
+class TestBulkContainerOp:
+    async def test_all_agents_succeed(self):
+        config = FakeConfig([{"name": "alpha"}, {"name": "beta"}])
+
+        async def op(container_name):
+            return {"success": True}
+
+        results = await _bulk_container_op(config, op)
+        assert results == {
+            "alpha": {"success": True},
+            "beta": {"success": True},
+        }
+
+    async def test_op_returns_success_false(self):
+        config = FakeConfig([{"name": "alpha"}])
+
+        async def op(container_name):
+            return {"success": False}
+
+        results = await _bulk_container_op(config, op)
+        assert results == {"alpha": {"success": False}}
+        assert "error" not in results["alpha"]
+
+    async def test_op_raises_for_one_agent_continues(self):
+        config = FakeConfig([{"name": "alpha"}, {"name": "beta"}, {"name": "gamma"}])
+
+        async def op(container_name):
+            if "beta" in container_name:
+                raise RuntimeError("container not found")
+            return {"success": True}
+
+        results = await _bulk_container_op(config, op)
+        assert results["alpha"] == {"success": True}
+        assert results["beta"] == {"success": False, "error": "container not found"}
+        assert results["gamma"] == {"success": True}
+
+    async def test_empty_agents(self):
+        config = FakeConfig([])
+
+        async def op(container_name):
+            return {"success": True}
+
+        results = await _bulk_container_op(config, op)
+        assert results == {}
+
+    async def test_container_name_format(self):
+        config = FakeConfig([{"name": "my-agent"}])
+        received = []
+
+        async def op(container_name):
+            received.append(container_name)
+            return {"success": True}
+
+        await _bulk_container_op(config, op)
+        assert received == ["taos-agent-my-agent"]

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -763,19 +763,29 @@ async def deploy_agent_endpoint(request: Request, body: DeployAgentRequest):
     return {"status": "deploying", "name": body.name, "archive_smoke_ok": smoke_ok}
 
 
+async def _bulk_container_op(config, op):
+    """Run an async container op over every configured agent, collecting per-agent results.
+
+    `op` is an async callable taking the container name (e.g. start_container).
+    Returns {agent_name: {"success": bool}} or {"success": False, "error": str} on exception.
+    """
+    results = {}
+    for agent in config.agents:
+        name = agent["name"]
+        try:
+            result = await op(f"taos-agent-{name}")
+            results[name] = {"success": result.get("success", False)}
+        except Exception as e:
+            results[name] = {"success": False, "error": str(e)}
+    return results
+
+
 @router.post("/api/agents/bulk/start")
 async def bulk_start_agents(request: Request):
     """Start all agent containers."""
     from tinyagentos.containers import start_container
     config = request.app.state.config
-    results = {}
-    for agent in config.agents:
-        name = agent["name"]
-        try:
-            result = await start_container(f"taos-agent-{name}")
-            results[name] = {"success": result.get("success", False)}
-        except Exception as e:
-            results[name] = {"success": False, "error": str(e)}
+    results = await _bulk_container_op(config, start_container)
     return {"action": "start", "results": results}
 
 
@@ -788,14 +798,7 @@ async def bulk_stop_agents(request: Request):
     report = {}
     if orchestrator is not None:
         report = await orchestrator.prepare("all", "stop")
-    results = {}
-    for agent in config.agents:
-        name = agent["name"]
-        try:
-            result = await stop_container(f"taos-agent-{name}")
-            results[name] = {"success": result.get("success", False)}
-        except Exception as e:
-            results[name] = {"success": False, "error": str(e)}
+    results = await _bulk_container_op(config, stop_container)
     return {"action": "stop", "prepare_report": report, "results": results}
 
 
@@ -804,14 +807,7 @@ async def bulk_restart_agents(request: Request):
     """Restart all agent containers."""
     from tinyagentos.containers import restart_container
     config = request.app.state.config
-    results = {}
-    for agent in config.agents:
-        name = agent["name"]
-        try:
-            result = await restart_container(f"taos-agent-{name}")
-            results[name] = {"success": result.get("success", False)}
-        except Exception as e:
-            results[name] = {"success": False, "error": str(e)}
+    results = await _bulk_container_op(config, restart_container)
     return {"action": "restart", "results": results}
 
 


### PR DESCRIPTION
Modularity plan S11. The bulk start/stop/restart endpoints each ran an identical loop over `config.agents` calling a container op and collecting per-agent {success}/error. Extracted into `_bulk_container_op(config, op)`; the three endpoints now call it. Response shapes, route paths, action labels, the stop endpoint's orchestrator.prepare/prepare_report logic, and the local container imports are all preserved exactly. +5 helper unit tests; 53 route-agent regression tests still pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for bulk container operations, including success aggregation, error handling, per-agent failure scenarios, empty agent lists, and container name formatting verification.

* **Refactor**
  * Consolidated bulk container operation logic to eliminate code duplication across bulk start, stop, and restart endpoints while preserving existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->