### PR TITLE
refactor(agents): extract deploy validation/routing/smoke-check into agent_deploy.py (B2b)

### DIFF
--- a/tinyagentos/routes/agent_deploy.py
+++ b/tinyagentos/routes/agent_deploy.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import logging
+
+from fastapi import Request
+from fastapi.responses import JSONResponse
+
+logger = logging.getLogger(__name__)
+
+
+def validate_framework_and_ram(request: Request, body) -> "JSONResponse | None":
+    """Validate the requested framework against the catalog and check available RAM.
+
+    Returns a JSONResponse with an error payload if validation fails, or None
+    if the request is acceptable and deploy should continue.
+    """
+    if body.framework != "none":
+        registry = request.app.state.registry
+        known = {a.id for a in registry.list_available(type_filter="agent-framework")}
+        if body.framework not in known:
+            return JSONResponse({"error": f"Unknown framework '{body.framework}'. Available: {sorted(known)}"}, status_code=400)
+
+        # Pre-flight RAM check — low-RAM hosts (≤4GB) silently fail at
+        # container launch because incus accepts the request but the
+        # container never reaches RUNNING.  Check before we mutate any
+        # state so the user gets an actionable message, not a generic
+        # "failed" with no diagnostic.  (#384)
+        hw = getattr(request.app.state, "hardware_profile", None)
+        if hw is not None and hw.ram_mb > 0:
+            framework = registry.get(body.framework)
+            framework_ram = framework.requires.get("ram_mb", 0) if framework else 0
+            # Controller needs ~500 MB + Debian base ~256 MB +
+            # framework dependencies + a small model (~2 GB headroom).
+            _CONTROLLER_OVERHEAD_MB = 500
+            _MODEL_DEPS_OVERHEAD_MB = 2048
+            min_ram = _CONTROLLER_OVERHEAD_MB + framework_ram + _MODEL_DEPS_OVERHEAD_MB
+            if hw.ram_mb < min_ram:
+                return JSONResponse(
+                    {
+                        "error": (
+                            f"Your device has {hw.ram_mb / 1024:.1f} GB RAM. "
+                            f"{body.framework} needs at least "
+                            f"{min_ram / 1024:.1f} GB to run with a model. "
+                            f"Deploy this agent on a worker with more RAM, or "
+                            f"pick a smaller framework."
+                        ),
+                        "ram_mb": hw.ram_mb,
+                        "min_ram_mb": min_ram,
+                        "framework": body.framework,
+                    },
+                    status_code=400,
+                )
+    return None
+
+
+def resolve_deploy_routing(request: Request, body) -> "JSONResponse | None":
+    """Resolve cross-worker deploy routing for the requested model.
+
+    Resolution order (task #176 stub):
+    - not_found: 404
+    - worker + pin conflict: 409
+    - worker (no conflict or no pin): 202 routed
+    - controller/cloud: returns None to fall through to local deploy
+
+    Returns a JSONResponse to short-circuit, or None to continue the
+    controller-local deploy path.
+    """
+    if body.model:
+        from tinyagentos.cluster.model_resolver import resolve_model_location
+
+        location = resolve_model_location(request, body.model)
+
+        if location.kind == "not_found":
+            return JSONResponse(
+                {
+                    "error": (
+                        f"model '{body.model}' was not found on the controller, "
+                        f"on any online worker, or among configured cloud providers. "
+                        f"Download it first or pick a model that is already in the cluster."
+                    ),
+                },
+                status_code=404,
+            )
+
+        if location.kind == "worker":
+            # Case 5: pin conflict — user asked for a specific worker
+            # that does not hold the model.
+            if body.target_worker and body.target_worker not in location.hosts:
+                return JSONResponse(
+                    {
+                        "error": (
+                            f"model '{body.model}' is not on worker "
+                            f"'{body.target_worker}'. It is available on: "
+                            f"{location.hosts}. Deploy there, or wait for "
+                            f"Phase 1.5 network model placement."
+                        ),
+                        "model": body.model,
+                        "pinned_worker": body.target_worker,
+                        "available_on": location.hosts,
+                    },
+                    status_code=409,
+                )
+
+            # Cases 3 + 4: route to the worker that holds the model.
+            # Phase 1.5 will actually instruct the worker to launch; for
+            # now we return a 202 naming the destination so the caller
+            # knows where the agent needs to land. Deliberately do NOT
+            # add a local agent entry — a ghost entry on the controller
+            # for an agent that lives on Fedora would confuse both the
+            # UI and the LXC bulk-ops endpoints.
+            chosen = body.target_worker or location.canonical_host
+            return JSONResponse(
+                {
+                    "status": "routed",
+                    "name": body.name,
+                    "model": body.model,
+                    "worker": chosen,
+                    "available_on": location.hosts,
+                    "message": (
+                        f"model '{body.model}' lives on worker '{chosen}'. "
+                        f"Routed deploy target only — remote launch lands "
+                        f"with Phase 1.5 network model placement."
+                    ),
+                },
+                status_code=202,
+            )
+        # kind == "controller" or "cloud": fall through to the unchanged
+        # controller-local deploy path below.
+    return None
+
+
+async def archive_smoke_check(request: Request, unique_slug: str, framework: str) -> bool:
+    """Verify the archive trace path end-to-end after provisioning.
+
+    A failure here does NOT abort the deploy — it surfaces a warning flag.
+    Returns True if the smoke-check record was written and read back
+    successfully, False otherwise.
+    """
+    archive = getattr(request.app.state, "archive", None)
+    smoke_ok = False
+    if archive is not None:
+        try:
+            await archive.record(
+                event_type="agent_deployed",
+                data={"slug": unique_slug, "framework": framework},
+                agent_name=unique_slug,
+                summary=f"deployed {unique_slug}",
+            )
+            rows = await archive.query(agent_name=unique_slug, limit=1)
+            smoke_ok = bool(rows)
+        except Exception:
+            logger.exception("archive smoke-check failed for %s", unique_slug)
+            smoke_ok = False
+    return smoke_ok

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -12,6 +12,7 @@ import taosmd.agents as tm_agents
 from tinyagentos.agent_db import find_agent, get_agent_summaries
 from tinyagentos.config import save_config_locked, validate_agent_name, unique_agent_slug
 from tinyagentos.routes import agent_archive
+from tinyagentos.routes import agent_deploy
 logger = logging.getLogger(__name__)
 
 EXPORT_VERSION = 1
@@ -235,113 +236,17 @@ async def deploy_agent_endpoint(request: Request, body: DeployAgentRequest):
     # Rewrite body.name to the unique slug; the original user-entered name
     # is preserved as display_name for the UI.
     body.name = unique_slug
-    # Validate framework against catalog instead of hardcoded list
-    if body.framework != "none":
-        registry = request.app.state.registry
-        known = {a.id for a in registry.list_available(type_filter="agent-framework")}
-        if body.framework not in known:
-            return JSONResponse({"error": f"Unknown framework '{body.framework}'. Available: {sorted(known)}"}, status_code=400)
-
-        # Pre-flight RAM check — low-RAM hosts (≤4GB) silently fail at
-        # container launch because incus accepts the request but the
-        # container never reaches RUNNING.  Check before we mutate any
-        # state so the user gets an actionable message, not a generic
-        # "failed" with no diagnostic.  (#384)
-        hw = getattr(request.app.state, "hardware_profile", None)
-        if hw is not None and hw.ram_mb > 0:
-            framework = registry.get(body.framework)
-            framework_ram = framework.requires.get("ram_mb", 0) if framework else 0
-            # Controller needs ~500 MB + Debian base ~256 MB +
-            # framework dependencies + a small model (~2 GB headroom).
-            _CONTROLLER_OVERHEAD_MB = 500
-            _MODEL_DEPS_OVERHEAD_MB = 2048
-            min_ram = _CONTROLLER_OVERHEAD_MB + framework_ram + _MODEL_DEPS_OVERHEAD_MB
-            if hw.ram_mb < min_ram:
-                return JSONResponse(
-                    {
-                        "error": (
-                            f"Your device has {hw.ram_mb / 1024:.1f} GB RAM. "
-                            f"{body.framework} needs at least "
-                            f"{min_ram / 1024:.1f} GB to run with a model. "
-                            f"Deploy this agent on a worker with more RAM, or "
-                            f"pick a smaller framework."
-                        ),
-                        "ram_mb": hw.ram_mb,
-                        "min_ram_mb": min_ram,
-                        "framework": body.framework,
-                    },
-                    status_code=400,
-                )
+    # Validate framework against catalog and check RAM headroom.
+    fw_err = agent_deploy.validate_framework_and_ram(request, body)
+    if fw_err is not None:
+        return fw_err
 
     # ------------------------------------------------------------------
     # Cross-worker deploy routing (task #176 stub)
     # ------------------------------------------------------------------
-    # Resolve the requested model's host BEFORE we touch config or kick
-    # off a background deploy. If the model lives on a remote worker we
-    # need to either route there (no local container) or reject the
-    # deploy with a clear 409 when the user's pin conflicts with where
-    # the model actually is.
-    if body.model:
-        from tinyagentos.cluster.model_resolver import resolve_model_location
-
-        location = resolve_model_location(request, body.model)
-
-        if location.kind == "not_found":
-            return JSONResponse(
-                {
-                    "error": (
-                        f"model '{body.model}' was not found on the controller, "
-                        f"on any online worker, or among configured cloud providers. "
-                        f"Download it first or pick a model that is already in the cluster."
-                    ),
-                },
-                status_code=404,
-            )
-
-        if location.kind == "worker":
-            # Case 5: pin conflict — user asked for a specific worker
-            # that does not hold the model.
-            if body.target_worker and body.target_worker not in location.hosts:
-                return JSONResponse(
-                    {
-                        "error": (
-                            f"model '{body.model}' is not on worker "
-                            f"'{body.target_worker}'. It is available on: "
-                            f"{location.hosts}. Deploy there, or wait for "
-                            f"Phase 1.5 network model placement."
-                        ),
-                        "model": body.model,
-                        "pinned_worker": body.target_worker,
-                        "available_on": location.hosts,
-                    },
-                    status_code=409,
-                )
-
-            # Cases 3 + 4: route to the worker that holds the model.
-            # Phase 1.5 will actually instruct the worker to launch; for
-            # now we return a 202 naming the destination so the caller
-            # knows where the agent needs to land. Deliberately do NOT
-            # add a local agent entry — a ghost entry on the controller
-            # for an agent that lives on Fedora would confuse both the
-            # UI and the LXC bulk-ops endpoints.
-            chosen = body.target_worker or location.canonical_host
-            return JSONResponse(
-                {
-                    "status": "routed",
-                    "name": body.name,
-                    "model": body.model,
-                    "worker": chosen,
-                    "available_on": location.hosts,
-                    "message": (
-                        f"model '{body.model}' lives on worker '{chosen}'. "
-                        f"Routed deploy target only — remote launch lands "
-                        f"with Phase 1.5 network model placement."
-                    ),
-                },
-                status_code=202,
-            )
-        # kind == "controller" or "cloud": fall through to the unchanged
-        # controller-local deploy path below.
+    routed = agent_deploy.resolve_deploy_routing(request, body)
+    if routed is not None:
+        return routed
 
     # Register the agent with taosmd BEFORE mutating config so a failure
     # here aborts cleanly with no half-state.
@@ -504,21 +409,7 @@ async def deploy_agent_endpoint(request: Request, body: DeployAgentRequest):
 
     # Archive smoke-check: verify trace path end-to-end after provisioning.
     # A failure here does NOT abort the deploy — it surfaces a warning flag.
-    archive = getattr(request.app.state, "archive", None)
-    smoke_ok = False
-    if archive is not None:
-        try:
-            await archive.record(
-                event_type="agent_deployed",
-                data={"slug": unique_slug, "framework": body.framework},
-                agent_name=unique_slug,
-                summary=f"deployed {unique_slug}",
-            )
-            rows = await archive.query(agent_name=unique_slug, limit=1)
-            smoke_ok = bool(rows)
-        except Exception:
-            logger.exception("archive smoke-check failed for %s", unique_slug)
-            smoke_ok = False
+    smoke_ok = await agent_deploy.archive_smoke_check(request, unique_slug, body.framework)
 
     return {"status": "deploying", "name": body.name, "archive_smoke_ok": smoke_ok}
 


### PR DESCRIPTION
Modularity plan B2b (second half of the agents.py split). Decomposes the ~320-line `deploy_agent_endpoint` by extracting three cleanly-bounded phases into `routes/agent_deploy.py`:

- `validate_framework_and_ram(request, body) -> JSONResponse | None` — framework-catalog check + low-RAM pre-flight (the 400s).
- `resolve_deploy_routing(request, body) -> JSONResponse | None` — cross-worker model-host resolution (404/409/202 cases).
- `archive_smoke_check(request, slug, framework) -> bool` — the non-aborting post-deploy trace check.

Each preserves exact status codes/messages via an Optional[JSONResponse] contract; the orchestrator returns early when a helper returns a response. Deliberately LEFT in the orchestrator: the slug derivation, the 'register with taosmd BEFORE mutating config' ordering, the config mutation, and the intricate `_background_deploy` coroutine (extracting those adds risk without readability gain).

agents.py 843 → 734; agent_deploy.py 154 lines. No circular import. 53 agents-route tests + 74 deploy-keyed tests pass; deploy route still registered.