### PR TITLE
fix: address review findings (archive path, canvas guard, deploy hints, settings fetch errors)

### DIFF
--- a/desktop/src/apps/SettingsApp/UpdatesPanel.tsx
+++ b/desktop/src/apps/SettingsApp/UpdatesPanel.tsx
@@ -56,15 +56,19 @@ export function UpdatesSection() {
   }, []);
 
   const savePrefs = useCallback(async (next: AutoUpdatePrefs) => {
+    const prev = prefs;
     setPrefs(next);
     try {
-      await fetch("/api/preferences/auto-update", {
+      const res = await fetch("/api/preferences/auto-update", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(next),
       });
-    } catch { /* ignore network */ }
-  }, []);
+      if (!res.ok) { setPrefs(prev); }   // revert on server error
+    } catch {
+      setPrefs(prev);                    // revert on network failure
+    }
+  }, [prefs]);
 
   const checkUpdates = async () => {
     setChecking(true);
@@ -120,10 +124,16 @@ export function UpdatesSection() {
   };
 
   const triggerRestart = async () => {
-    setShowRestartModal(true);
     try {
-      await fetch("/api/system/restart/prepare", { method: "POST" });
-    } catch { /* ignore — modal polls status */ }
+      const res = await fetch("/api/system/restart/prepare", { method: "POST" });
+      if (res.ok) {
+        setShowRestartModal(true);
+      } else {
+        setStatus("Could not start restart.");
+      }
+    } catch {
+      setStatus("Could not reach the restart endpoint.");
+    }
   };
 
   const hasPendingRestart = !!updateStatus?.pending_restart_sha;

--- a/desktop/src/apps/SettingsApp/UsersPanel.tsx
+++ b/desktop/src/apps/SettingsApp/UsersPanel.tsx
@@ -103,21 +103,26 @@ function AddUserModal({ onClose, onAdded }: { onClose: () => void; onAdded: () =
     if (!username.trim()) return;
     setLoading(true);
     setError("");
-    const resp = await fetch("/auth/users", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      credentials: "include",
-      body: JSON.stringify({ username: username.trim() }),
-    });
-    setLoading(false);
-    if (!resp.ok) {
-      const d = await resp.json().catch(() => ({}));
-      setError((d as { error?: string }).error ?? "Failed to add user");
-      return;
+    try {
+      const resp = await fetch("/auth/users", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ username: username.trim() }),
+      });
+      if (!resp.ok) {
+        const d = await resp.json().catch(() => ({}));
+        setError((d as { error?: string }).error ?? "Failed to add user");
+        return;
+      }
+      const d = await resp.json();
+      setCode(d.invite_code);
+      onAdded();
+    } catch {
+      setError("Network error, please try again.");
+    } finally {
+      setLoading(false);
     }
-    const d = await resp.json();
-    setCode(d.invite_code);
-    onAdded();
   };
 
   return (
@@ -165,19 +170,24 @@ function ResetPasswordModal({ username, onClose, onReset }: { username: string; 
 
   const doReset = async () => {
     setLoading(true);
-    const resp = await fetch(`/auth/users/${encodeURIComponent(username)}/reset`, {
-      method: "POST",
-      credentials: "include",
-    });
-    setLoading(false);
-    if (!resp.ok) {
-      const d = await resp.json().catch(() => ({}));
-      setError((d as { error?: string }).error ?? "Failed to reset");
-      return;
+    try {
+      const resp = await fetch(`/auth/users/${encodeURIComponent(username)}/reset`, {
+        method: "POST",
+        credentials: "include",
+      });
+      if (!resp.ok) {
+        const d = await resp.json().catch(() => ({}));
+        setError((d as { error?: string }).error ?? "Failed to reset");
+        return;
+      }
+      const d = await resp.json();
+      setCode(d.invite_code);
+      onReset();
+    } catch {
+      setError("Network error, please try again.");
+    } finally {
+      setLoading(false);
     }
-    const d = await resp.json();
-    setCode(d.invite_code);
-    onReset();
   };
 
   return (
@@ -224,19 +234,24 @@ function ChangePasswordModal({ username, onClose }: { username: string; onClose:
     if (!valid) return;
     setLoading(true);
     setError("");
-    const resp = await fetch(`/auth/users/${encodeURIComponent(username)}/password`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      credentials: "include",
-      body: JSON.stringify({ current, new: next }),
-    });
-    setLoading(false);
-    if (!resp.ok) {
-      const d = await resp.json().catch(() => ({}));
-      setError((d as { error?: string }).error ?? "Failed to change password");
-      return;
+    try {
+      const resp = await fetch(`/auth/users/${encodeURIComponent(username)}/password`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ current, new: next }),
+      });
+      if (!resp.ok) {
+        const d = await resp.json().catch(() => ({}));
+        setError((d as { error?: string }).error ?? "Failed to change password");
+        return;
+      }
+      setDone(true);
+    } catch {
+      setError("Network error, please try again.");
+    } finally {
+      setLoading(false);
     }
-    setDone(true);
   };
 
   return (
@@ -287,18 +302,23 @@ function DeleteUserModal({ username, onClose, onDeleted }: { username: string; o
 
   const doDelete = async () => {
     setLoading(true);
-    const resp = await fetch(`/auth/users/${encodeURIComponent(username)}`, {
-      method: "DELETE",
-      credentials: "include",
-    });
-    setLoading(false);
-    if (!resp.ok) {
-      const d = await resp.json().catch(() => ({}));
-      setError((d as { error?: string }).error ?? "Failed to remove user");
-      return;
+    try {
+      const resp = await fetch(`/auth/users/${encodeURIComponent(username)}`, {
+        method: "DELETE",
+        credentials: "include",
+      });
+      if (!resp.ok) {
+        const d = await resp.json().catch(() => ({}));
+        setError((d as { error?: string }).error ?? "Failed to remove user");
+        return;
+      }
+      onDeleted();
+      onClose();
+    } catch {
+      setError("Network error, please try again.");
+    } finally {
+      setLoading(false);
     }
-    onDeleted();
-    onClose();
   };
 
   return (

--- a/tinyagentos/routes/agent_archive.py
+++ b/tinyagentos/routes/agent_archive.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
+from pathlib import Path
 
 from fastapi import Request
 
@@ -156,7 +157,7 @@ async def archive_agent_fully(request: Request, name: str) -> dict:
     if archive_target and archive_target != "pool:":
         if archive_target.startswith("path:"):
             dest_dir = archive_target[len("path:"):]
-            tarball_dir = data_dir / "archive" / archive_subdir
+            tarball_dir = Path(dest_dir) / archive_subdir
             tarball_dir.mkdir(parents=True, exist_ok=True)
             tarball_path = tarball_dir / f"{snapshot_name}.tar.gz"
             from tinyagentos.containers import _run as _c_run

--- a/tinyagentos/routes/agent_deploy.py
+++ b/tinyagentos/routes/agent_deploy.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
 
 from fastapi import Request
 from fastapi.responses import JSONResponse
 
+if TYPE_CHECKING:
+    from tinyagentos.routes.agents import DeployAgentRequest
+
 logger = logging.getLogger(__name__)
 
 
-def validate_framework_and_ram(request: Request, body) -> "JSONResponse | None":
+def validate_framework_and_ram(request: Request, body: "DeployAgentRequest") -> "JSONResponse | None":
     """Validate the requested framework against the catalog and check available RAM.
 
     Returns a JSONResponse with an error payload if validation fails, or None
@@ -29,8 +33,8 @@ def validate_framework_and_ram(request: Request, body) -> "JSONResponse | None":
         if hw is not None and hw.ram_mb > 0:
             framework = registry.get(body.framework)
             framework_ram = framework.requires.get("ram_mb", 0) if framework else 0
-            # Controller needs ~500 MB + Debian base ~256 MB +
-            # framework dependencies + a small model (~2 GB headroom).
+            # Controller overhead ~500 MB + framework dependencies +
+            # model headroom ~2 GB (the headroom absorbs the Debian base).
             _CONTROLLER_OVERHEAD_MB = 500
             _MODEL_DEPS_OVERHEAD_MB = 2048
             min_ram = _CONTROLLER_OVERHEAD_MB + framework_ram + _MODEL_DEPS_OVERHEAD_MB
@@ -53,7 +57,7 @@ def validate_framework_and_ram(request: Request, body) -> "JSONResponse | None":
     return None
 
 
-def resolve_deploy_routing(request: Request, body) -> "JSONResponse | None":
+def resolve_deploy_routing(request: Request, body: "DeployAgentRequest") -> "JSONResponse | None":
     """Resolve cross-worker deploy routing for the requested model.
 
     Resolution order (task #176 stub):

--- a/tinyagentos/routes/canvas.py
+++ b/tinyagentos/routes/canvas.py
@@ -43,7 +43,8 @@ async def update_canvas(request: Request, canvas_id: str):
     # Broadcast to canvas viewers
     hub = request.app.state.chat_hub
     canvas = await canvas_store.get(canvas_id)
-    await hub.broadcast(f"canvas:{canvas_id}", {"type": "canvas_update", "content": canvas["content"], "title": canvas["title"]})
+    if canvas:
+        await hub.broadcast(f"canvas:{canvas_id}", {"type": "canvas_update", "content": canvas["content"], "title": canvas["title"]})
     return {"status": "updated"}
 
 


### PR DESCRIPTION
Addresses the legitimate bot-review findings accumulated during the refactor batch:

**Real bugs**
- `agent_archive.py`: `path:` archive target was extracted into `dest_dir` but ignored — tarball always landed in `data_dir/archive`. Now uses the configured `dest_dir` (#547 CodeRabbit Major).
- `canvas.py`: `update_canvas` could `canvas["content"]` on `None` if the canvas was deleted concurrently before the broadcast — now guarded (#544 CodeRabbit).

**Frontend robustness (S13 panels, moved verbatim — fixing the latent gaps)**
- `UpdatesPanel`: auto-update pref was set optimistically before the PUT; now reverts on failure. Restart modal opened before `/restart/prepare` was accepted; now opens only on success and surfaces an error otherwise.
- `UsersPanel`: add/reset-password/change-password/delete handlers had no catch for a rejected fetch (stuck spinner, no error). All four now try/catch/finally with a surfaced error.

**Polish**
- `agent_deploy.py`: added `DeployAgentRequest` type hints via a `TYPE_CHECKING` guard (no circular import); corrected the RAM-calc comment to match the constants.

Deliberately skipped the speculative None-guards (registry.list_available / location.hosts / canonical_host) — those are for states the upstream contracts prevent. 181 backend tests pass; `npm run build` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Auto-update preferences and restart operations now validate success before proceeding and display detailed error messages on failure
  * User management modals now display API error messages and properly handle network connection failures with appropriate user feedback
  * Canvas updates now validate data integrity before broadcasting changes to ensure data consistency

* **Refactor**
  * Enhanced type annotations for improved code quality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->