### PR TITLE
chore(qmd): install @jaylfc/qmd@latest, drop the 2.1.1 pin

### DIFF
--- a/data/config.yaml.example
+++ b/data/config.yaml.example
@@ -19,7 +19,7 @@ qmd:
 # Agent memory (qmd index databases) lives on the cluster's shared storage,
 # mounted on every worker at /srv/taos/agent-memory/. Each worker LXC runs a
 # single qmd serve which routes requests to the right tenant's database via
-# the per-tenant dbPath parameter (see @jaylfc/qmd@2.1.1+). This means an
+# the per-tenant dbPath parameter (see @jaylfc/qmd). This means an
 # agent can migrate between worker nodes without copying its memory — the
 # memory follows the agent identity, not the host.
 agents: []

--- a/docs/agent-qmd-serve-setup.md
+++ b/docs/agent-qmd-serve-setup.md
@@ -31,10 +31,10 @@ Host (Orange Pi / x86)
 
 ```bash
 # Inside the agent's LXC container
-# Pin to a known-good version to avoid surprise breakage on fresh
-# installs.  The npm package is pre-built; installing from the git
-# source requires a TypeScript build step.
-npm install -g @jaylfc/qmd@2.1.1
+# Always install the latest published qmd so deployments match the
+# maintainer's setup.  The npm package is pre-built; installing from the
+# git source requires a TypeScript build step.
+npm install -g @jaylfc/qmd@latest
 ```
 
 ## Configure QMD to Use Remote Backend

--- a/docs/design/framework-agnostic-runtime.md
+++ b/docs/design/framework-agnostic-runtime.md
@@ -284,9 +284,11 @@ path breaks.
 ## Updating the qmd fork
 
 taOS runs a fork of [tobilg/qmd](https://github.com/tobilg/qmd) at
-[jaylfc/qmd](https://github.com/jaylfc/qmd) (branch `feat/remote-llm-provider`).
-The fork adds multi-tenant serve mode, per-tenant `dbPath` routing, and
-ingest/delete-chunk endpoints.  These changes are not yet upstream.
+[jaylfc/qmd](https://github.com/jaylfc/qmd) (branch `main`), published to npm
+as `@jaylfc/qmd`. The fork adds multi-tenant serve mode, per-tenant `dbPath`
+routing, ingest/delete-chunk endpoints, and a pluggable model backend
+(`qmd serve`, remote `--server`/RemoteLLM, `--backend ollama`).  These changes
+are not yet upstream.
 
 ### When to rebase
 
@@ -305,7 +307,7 @@ Rebase onto upstream when:
 
 2. **Rebase the fork onto upstream.**
    ```bash
-   git checkout feat/remote-llm-provider
+   git checkout main
    git rebase upstream/main
    ```
    Resolve conflicts.  taOS-specific changes are concentrated in:
@@ -327,10 +329,10 @@ Rebase onto upstream when:
    npm publish
    ```
 
-5. **Update the pinned version in taOS.**
-   - Bump the version in `scripts/install-server.sh` (search for `@jaylfc/qmd@`)
-   - Update `docs/agent-qmd-serve-setup.md` with the new version
-   - Commit: `chore: bump qmd pin to <new-version>`
+5. **That's it — taOS installs `@jaylfc/qmd@latest`.**
+   `scripts/install-server.sh` installs the package unpinned, so fresh
+   deployments pick up the newly published version automatically. There is
+   no version to bump in taOS.
 
 ### When upstream PR #511 merges
 

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -1127,11 +1127,11 @@ if [[ -z "${TAOS_SKIP_QMD:-}" ]]; then
             # pre-built (dist/ is not committed to the source repo),
             # so installing from a git SHA requires a TypeScript
             # build step — use the npm registry instead.
-            # To update: verify the new version against taOS, then
-            # bump the pinned version here.
+            # Always install the latest published @jaylfc/qmd so fresh
+            # deployments match the maintainer's setup (intentionally unpinned).
             qmd_install_log=$(mktemp /tmp/taos-qmd-install.XXXXXX.log)
-            log "npm install -g @jaylfc/qmd@2.1.1 (log: $qmd_install_log)"
-            if ! sudo HOME=/root npm install -g --unsafe-perm "@jaylfc/qmd@2.1.1" >"$qmd_install_log" 2>&1; then
+            log "npm install -g @jaylfc/qmd@latest (log: $qmd_install_log)"
+            if ! sudo HOME=/root npm install -g --unsafe-perm "@jaylfc/qmd@latest" >"$qmd_install_log" 2>&1; then
                 if grep -q "TAR_ENTRY_ERROR" "$qmd_install_log" \
                    && grep -q "spawn sh" "$qmd_install_log"; then
                     warn "npm install of qmd hit the node-llama-cpp tar-extraction"


### PR DESCRIPTION
Closes #553.

Provisioning hard-pinned `@jaylfc/qmd@2.1.1`, which is stale. Per the no-pin policy, install `@jaylfc/qmd@latest` so fresh deployments always match the maintainer's setup (currently 2.5.3+, which adds the pluggable model backend).

- `scripts/install-server.sh` — install + log line now `@jaylfc/qmd@latest`; comment updated (intentionally unpinned).
- `docs/agent-qmd-serve-setup.md` — `@latest` + comment.
- `data/config.yaml.example` — drop the version from the package reference.
- `docs/design/framework-agnostic-runtime.md` — replace the obsolete 'bump the pinned version' step with 'installs auto-pick-up latest after publish'; fix stale `feat/remote-llm-provider` branch refs -> `main`.

Safe per #553: embeddings byte-identical 2.1.1↔2.5.3 (cosine 1.000000), serve API unchanged, no reindex. `bash -n` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration examples and setup instructions to reference the latest package version
  * Documented multi-tenant serve mode, per-tenant database routing, new API endpoints, and pluggable model backend capabilities
  
* **Chores**
  * Updated installation scripts to use the latest published package version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->