### PR TITLE
refactor(chat): split file + channel-admin routes into chat_files.py + chat_admin.py (B5)

### DIFF
--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -130,6 +130,10 @@ def register_all_routers(app):
 
     from tinyagentos.routes.chat import router as chat_router
     app.include_router(chat_router)
+    from tinyagentos.routes.chat_files import router as chat_files_router
+    app.include_router(chat_files_router)
+    from tinyagentos.routes.chat_admin import router as chat_admin_router
+    app.include_router(chat_admin_router)
 
     from tinyagentos.routes.canvas import router as canvas_router
     app.include_router(canvas_router)

--- a/tinyagentos/routes/chat.py
+++ b/tinyagentos/routes/chat.py
@@ -3,15 +3,11 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import mimetypes
 import os
-import secrets
-import shutil
-import uuid
 from pathlib import Path
 
-from fastapi import APIRouter, File, Request, UploadFile, WebSocket, WebSocketDisconnect
-from fastapi.responses import FileResponse, JSONResponse, Response
+from fastapi import APIRouter, Request, WebSocket, WebSocketDisconnect
+from fastapi.responses import JSONResponse, Response
 
 from tinyagentos.chat.reactions import maybe_trigger_semantic
 
@@ -442,22 +438,6 @@ async def list_channels(
     return {"channels": channels}
 
 
-@router.post("/api/chat/channels")
-async def create_channel(request: Request):
-    body = await request.json()
-    ch_store = request.app.state.chat_channels
-    channel = await ch_store.create_channel(
-        name=body["name"],
-        type=body.get("type", "topic"),
-        created_by=body.get("created_by", "user"),
-        members=body.get("members"),
-        description=body.get("description", ""),
-        topic=body.get("topic", ""),
-        project_id=body.get("project_id", ""),
-    )
-    return channel
-
-
 @router.get("/api/chat/channels/{channel_id}")
 async def get_channel(request: Request, channel_id: str):
     ch_store = request.app.state.chat_channels
@@ -465,31 +445,6 @@ async def get_channel(request: Request, channel_id: str):
     if not channel:
         return JSONResponse({"error": "Channel not found"}, status_code=404)
     return channel
-
-
-@router.put("/api/chat/channels/{channel_id}")
-async def update_channel(request: Request, channel_id: str):
-    body = await request.json()
-    ch_store = request.app.state.chat_channels
-    channel = await ch_store.get_channel(channel_id)
-    if not channel:
-        return JSONResponse({"error": "Channel not found"}, status_code=404)
-    await ch_store.update_channel(
-        channel_id,
-        name=body.get("name"),
-        description=body.get("description"),
-        topic=body.get("topic"),
-    )
-    return {"status": "updated"}
-
-
-@router.delete("/api/chat/channels/{channel_id}")
-async def delete_channel(request: Request, channel_id: str):
-    ch_store = request.app.state.chat_channels
-    deleted = await ch_store.delete_channel(channel_id)
-    if not deleted:
-        return JSONResponse({"error": "Channel not found"}, status_code=404)
-    return {"status": "deleted"}
 
 
 @router.get("/api/chat/channels/{channel_id}/messages")
@@ -638,196 +593,6 @@ async def delete_message_endpoint(message_id: str, request: Request):
         "deleted_at": (deleted or {}).get("deleted_at"),
     })
     return Response(status_code=204)
-
-
-@router.delete("/api/chat/channels/{channel_id}/members/{member_id}")
-async def remove_channel_member(request: Request, channel_id: str, member_id: str):
-    ch_store = request.app.state.chat_channels
-    await ch_store.remove_member(channel_id, member_id)
-    return {"status": "removed"}
-
-
-# ── Admin endpoints (UI-driven channel control-plane) ─────────────────────────
-
-@router.patch("/api/chat/channels/{channel_id}")
-async def update_channel_settings(channel_id: str, body: dict, request: Request):
-    """Update channel settings. Body may include: response_mode, max_hops,
-    cooldown_seconds, topic, name. Each is optional; only provided keys are
-    applied. Returns 400 on validation failure."""
-    state = request.app.state
-    chs = state.chat_channels
-    ch = await chs.get_channel(channel_id)
-    if ch is None:
-        return JSONResponse({"error": "channel not found"}, status_code=404)
-    try:
-        if "response_mode" in body:
-            await chs.set_response_mode(channel_id, body["response_mode"])
-        if "max_hops" in body:
-            await chs.set_max_hops(channel_id, int(body["max_hops"]))
-        if "cooldown_seconds" in body:
-            await chs.set_cooldown_seconds(channel_id, int(body["cooldown_seconds"]))
-        if "ephemeral_ttl_seconds" in body:
-            raw = body["ephemeral_ttl_seconds"]
-            ttl: int | None = None if raw is None else int(raw)
-            await chs.set_ephemeral_ttl(channel_id, ttl)
-        if "topic" in body:
-            topic = str(body["topic"])
-            if len(topic) > 500:
-                return JSONResponse({"error": "topic must be <= 500 chars"}, status_code=400)
-            await chs.update_channel(channel_id, topic=topic)
-        if "name" in body:
-            name = str(body["name"]).strip()
-            if not name or len(name) > 100:
-                return JSONResponse({"error": "name must be 1..100 chars"}, status_code=400)
-            await chs.update_channel(channel_id, name=name)
-    except ValueError as e:
-        return JSONResponse({"error": str(e)}, status_code=400)
-    return JSONResponse({"ok": True}, status_code=200)
-
-
-@router.post("/api/chat/channels/{channel_id}/members")
-async def modify_channel_members(channel_id: str, body: dict, request: Request):
-    """Add or remove a member. Body: {"action": "add" | "remove", "slug": "..."}."""
-    action = (body.get("action") or "").lower()
-    slug = (body.get("slug") or "").lstrip("@")
-    if action not in ("add", "remove") or not slug:
-        return JSONResponse({"error": "action must be add|remove, slug required"}, status_code=400)
-    state = request.app.state
-    chs = state.chat_channels
-    ch = await chs.get_channel(channel_id)
-    if ch is None:
-        return JSONResponse({"error": "channel not found"}, status_code=404)
-    if action == "add":
-        known = {a.get("name") for a in getattr(state.config, "agents", []) or []}
-        if slug != "user" and slug not in known:
-            return JSONResponse({"error": f"unknown agent: {slug}"}, status_code=400)
-        await chs.add_member(channel_id, slug)
-    else:
-        await chs.remove_member(channel_id, slug)
-    return JSONResponse({"ok": True}, status_code=200)
-
-
-@router.post("/api/chat/channels/{channel_id}/muted")
-async def modify_channel_muted(channel_id: str, body: dict, request: Request):
-    """Add or remove an agent from the channel's muted list.
-    Body: {"action": "add" | "remove", "slug": "..."}."""
-    action = (body.get("action") or "").lower()
-    slug = (body.get("slug") or "").lstrip("@")
-    if action not in ("add", "remove") or not slug:
-        return JSONResponse({"error": "action must be add|remove, slug required"}, status_code=400)
-    state = request.app.state
-    chs = state.chat_channels
-    ch = await chs.get_channel(channel_id)
-    if ch is None:
-        return JSONResponse({"error": "channel not found"}, status_code=404)
-    if action == "add":
-        await chs.mute_agent(channel_id, slug)
-    else:
-        await chs.unmute_agent(channel_id, slug)
-    return JSONResponse({"ok": True}, status_code=200)
-
-
-# ── File upload / serve ───────────────────────────────────────────────────────
-
-_MAX_ATTACHMENT_BYTES = 100 * 1024 * 1024  # 100 MB
-
-
-def _resolve_workspace_path(data_dir: Path, source: str, slug: str | None, vfs_path: str) -> Path:
-    """Resolve a VFS path like '/workspaces/user/foo.md' to an on-disk
-    absolute path under data_dir/agent-workspaces/{slug-or-user}.
-    Raises ValueError on traversal or bad shape.
-    """
-    if not vfs_path.startswith("/workspaces/"):
-        raise ValueError("path must start with /workspaces/")
-    parts = vfs_path.split("/", 3)  # ['', 'workspaces', '<slug>', 'rest...']
-    if len(parts) < 3 or not parts[2]:
-        raise ValueError("path missing slug")
-    owner = parts[2]
-    if source == "agent-workspace":
-        if not slug or slug != owner:
-            raise ValueError("slug must match path owner for agent-workspace")
-    if source == "workspace":
-        if owner != "user":
-            raise ValueError("workspace source requires /workspaces/user/...")
-    rel = parts[3] if len(parts) > 3 else ""
-    root = (data_dir / "agent-workspaces" / owner).resolve()
-    target = (root / rel).resolve()
-    # Traversal check: target must be inside root.
-    if not str(target).startswith(str(root) + os.sep) and target != root:
-        raise ValueError("path traversal rejected")
-    if not target.exists() or target.is_dir():
-        raise ValueError("file not found")
-    return target
-
-
-@router.post("/api/chat/attachments/from-path")
-async def attachment_from_path(body: dict, request: Request):
-    """Server-side reference to a file in a workspace. Copies into
-    chat-files/ and returns the attachment record."""
-    vfs_path = (body or {}).get("path")
-    source = (body or {}).get("source")
-    slug = (body or {}).get("slug")
-    if not vfs_path or source not in ("workspace", "agent-workspace"):
-        return JSONResponse(
-            {"error": "path and source in {workspace,agent-workspace} required"},
-            status_code=400,
-        )
-    data_dir = request.app.state.config_path.parent
-    try:
-        src = _resolve_workspace_path(data_dir, source, slug, vfs_path)
-    except ValueError as e:
-        return JSONResponse({"error": str(e)}, status_code=400)
-    if src.stat().st_size > _MAX_ATTACHMENT_BYTES:
-        return JSONResponse({"error": "file too large (100 MB max)"}, status_code=413)
-    chat_files = data_dir / "chat-files"
-    chat_files.mkdir(parents=True, exist_ok=True)
-    stored_name = f"{secrets.token_hex(8)}-{src.name}"
-    dest = chat_files / stored_name
-    shutil.copy2(src, dest)
-    mime, _ = mimetypes.guess_type(src.name)
-    return JSONResponse({
-        "filename": src.name,
-        "mime_type": mime or "application/octet-stream",
-        "size": src.stat().st_size,
-        "url": f"/api/chat/files/{stored_name}",
-        "source": source,
-    }, status_code=200)
-
-
-@router.post("/api/chat/upload")
-async def upload_file(request: Request, file: UploadFile = File(...), channel_id: str = ""):
-    """Upload a file attachment for use in chat messages."""
-    data_dir = request.app.state.config_path.parent
-    upload_dir = data_dir / "chat-files"
-    upload_dir.mkdir(parents=True, exist_ok=True)
-
-    file_id = uuid.uuid4().hex[:12]
-    ext = Path(file.filename).suffix if file.filename else ""
-    stored_name = f"{file_id}{ext}"
-    dest = upload_dir / stored_name
-    content = await file.read()
-    dest.write_bytes(content)
-
-    attachment = {
-        "id": file_id,
-        "filename": file.filename or "unnamed",
-        "content_type": file.content_type or "application/octet-stream",
-        "size": len(content),
-        "url": f"/api/chat/files/{stored_name}",
-    }
-    return attachment
-
-
-@router.get("/api/chat/files/{filename}")
-async def serve_file(request: Request, filename: str):
-    """Serve an uploaded chat file."""
-    data_dir = request.app.state.config_path.parent
-    file_path = data_dir / "chat-files" / filename
-    if not file_path.exists() or not file_path.resolve().is_relative_to(
-        (data_dir / "chat-files").resolve()
-    ):
-        return JSONResponse({"error": "File not found"}, status_code=404)
-    return FileResponse(file_path)
 
 
 # ── Search & unread ───────────────────────────────────────────────────────────

--- a/tinyagentos/routes/chat_admin.py
+++ b/tinyagentos/routes/chat_admin.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+router = APIRouter()
+
+
+@router.post("/api/chat/channels")
+async def create_channel(request: Request):
+    body = await request.json()
+    ch_store = request.app.state.chat_channels
+    channel = await ch_store.create_channel(
+        name=body["name"],
+        type=body.get("type", "topic"),
+        created_by=body.get("created_by", "user"),
+        members=body.get("members"),
+        description=body.get("description", ""),
+        topic=body.get("topic", ""),
+        project_id=body.get("project_id", ""),
+    )
+    return channel
+
+
+@router.put("/api/chat/channels/{channel_id}")
+async def update_channel(request: Request, channel_id: str):
+    body = await request.json()
+    ch_store = request.app.state.chat_channels
+    channel = await ch_store.get_channel(channel_id)
+    if not channel:
+        return JSONResponse({"error": "Channel not found"}, status_code=404)
+    await ch_store.update_channel(
+        channel_id,
+        name=body.get("name"),
+        description=body.get("description"),
+        topic=body.get("topic"),
+    )
+    return {"status": "updated"}
+
+
+@router.delete("/api/chat/channels/{channel_id}")
+async def delete_channel(request: Request, channel_id: str):
+    ch_store = request.app.state.chat_channels
+    deleted = await ch_store.delete_channel(channel_id)
+    if not deleted:
+        return JSONResponse({"error": "Channel not found"}, status_code=404)
+    return {"status": "deleted"}
+
+
+@router.delete("/api/chat/channels/{channel_id}/members/{member_id}")
+async def remove_channel_member(request: Request, channel_id: str, member_id: str):
+    ch_store = request.app.state.chat_channels
+    await ch_store.remove_member(channel_id, member_id)
+    return {"status": "removed"}
+
+
+@router.patch("/api/chat/channels/{channel_id}")
+async def update_channel_settings(channel_id: str, body: dict, request: Request):
+    """Update channel settings. Body may include: response_mode, max_hops,
+    cooldown_seconds, topic, name. Each is optional; only provided keys are
+    applied. Returns 400 on validation failure."""
+    state = request.app.state
+    chs = state.chat_channels
+    ch = await chs.get_channel(channel_id)
+    if ch is None:
+        return JSONResponse({"error": "channel not found"}, status_code=404)
+    try:
+        if "response_mode" in body:
+            await chs.set_response_mode(channel_id, body["response_mode"])
+        if "max_hops" in body:
+            await chs.set_max_hops(channel_id, int(body["max_hops"]))
+        if "cooldown_seconds" in body:
+            await chs.set_cooldown_seconds(channel_id, int(body["cooldown_seconds"]))
+        if "ephemeral_ttl_seconds" in body:
+            raw = body["ephemeral_ttl_seconds"]
+            ttl: int | None = None if raw is None else int(raw)
+            await chs.set_ephemeral_ttl(channel_id, ttl)
+        if "topic" in body:
+            topic = str(body["topic"])
+            if len(topic) > 500:
+                return JSONResponse({"error": "topic must be <= 500 chars"}, status_code=400)
+            await chs.update_channel(channel_id, topic=topic)
+        if "name" in body:
+            name = str(body["name"]).strip()
+            if not name or len(name) > 100:
+                return JSONResponse({"error": "name must be 1..100 chars"}, status_code=400)
+            await chs.update_channel(channel_id, name=name)
+    except ValueError as e:
+        return JSONResponse({"error": str(e)}, status_code=400)
+    return JSONResponse({"ok": True}, status_code=200)
+
+
+@router.post("/api/chat/channels/{channel_id}/members")
+async def modify_channel_members(channel_id: str, body: dict, request: Request):
+    """Add or remove a member. Body: {"action": "add" | "remove", "slug": "..."}."""
+    action = (body.get("action") or "").lower()
+    slug = (body.get("slug") or "").lstrip("@")
+    if action not in ("add", "remove") or not slug:
+        return JSONResponse({"error": "action must be add|remove, slug required"}, status_code=400)
+    state = request.app.state
+    chs = state.chat_channels
+    ch = await chs.get_channel(channel_id)
+    if ch is None:
+        return JSONResponse({"error": "channel not found"}, status_code=404)
+    if action == "add":
+        known = {a.get("name") for a in getattr(state.config, "agents", []) or []}
+        if slug != "user" and slug not in known:
+            return JSONResponse({"error": f"unknown agent: {slug}"}, status_code=400)
+        await chs.add_member(channel_id, slug)
+    else:
+        await chs.remove_member(channel_id, slug)
+    return JSONResponse({"ok": True}, status_code=200)
+
+
+@router.post("/api/chat/channels/{channel_id}/muted")
+async def modify_channel_muted(channel_id: str, body: dict, request: Request):
+    """Add or remove an agent from the channel's muted list.
+    Body: {"action": "add" | "remove", "slug": "..."}."""
+    action = (body.get("action") or "").lower()
+    slug = (body.get("slug") or "").lstrip("@")
+    if action not in ("add", "remove") or not slug:
+        return JSONResponse({"error": "action must be add|remove, slug required"}, status_code=400)
+    state = request.app.state
+    chs = state.chat_channels
+    ch = await chs.get_channel(channel_id)
+    if ch is None:
+        return JSONResponse({"error": "channel not found"}, status_code=404)
+    if action == "add":
+        await chs.mute_agent(channel_id, slug)
+    else:
+        await chs.unmute_agent(channel_id, slug)
+    return JSONResponse({"ok": True}, status_code=200)

--- a/tinyagentos/routes/chat_files.py
+++ b/tinyagentos/routes/chat_files.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import mimetypes
+import os
+import secrets
+import shutil
+import uuid
+from pathlib import Path
+
+from fastapi import APIRouter, File, Request, UploadFile
+from fastapi.responses import FileResponse, JSONResponse
+
+router = APIRouter()
+
+_MAX_ATTACHMENT_BYTES = 100 * 1024 * 1024  # 100 MB
+
+
+def _resolve_workspace_path(data_dir: Path, source: str, slug: str | None, vfs_path: str) -> Path:
+    """Resolve a VFS path like '/workspaces/user/foo.md' to an on-disk
+    absolute path under data_dir/agent-workspaces/{slug-or-user}.
+    Raises ValueError on traversal or bad shape.
+    """
+    if not vfs_path.startswith("/workspaces/"):
+        raise ValueError("path must start with /workspaces/")
+    parts = vfs_path.split("/", 3)  # ['', 'workspaces', '<slug>', 'rest...']
+    if len(parts) < 3 or not parts[2]:
+        raise ValueError("path missing slug")
+    owner = parts[2]
+    if source == "agent-workspace":
+        if not slug or slug != owner:
+            raise ValueError("slug must match path owner for agent-workspace")
+    if source == "workspace":
+        if owner != "user":
+            raise ValueError("workspace source requires /workspaces/user/...")
+    rel = parts[3] if len(parts) > 3 else ""
+    root = (data_dir / "agent-workspaces" / owner).resolve()
+    target = (root / rel).resolve()
+    # Traversal check: target must be inside root.
+    if not str(target).startswith(str(root) + os.sep) and target != root:
+        raise ValueError("path traversal rejected")
+    if not target.exists() or target.is_dir():
+        raise ValueError("file not found")
+    return target
+
+
+@router.post("/api/chat/attachments/from-path")
+async def attachment_from_path(body: dict, request: Request):
+    """Server-side reference to a file in a workspace. Copies into
+    chat-files/ and returns the attachment record."""
+    vfs_path = (body or {}).get("path")
+    source = (body or {}).get("source")
+    slug = (body or {}).get("slug")
+    if not vfs_path or source not in ("workspace", "agent-workspace"):
+        return JSONResponse(
+            {"error": "path and source in {workspace,agent-workspace} required"},
+            status_code=400,
+        )
+    data_dir = request.app.state.data_dir
+    try:
+        src = _resolve_workspace_path(data_dir, source, slug, vfs_path)
+    except ValueError as e:
+        return JSONResponse({"error": str(e)}, status_code=400)
+    if src.stat().st_size > _MAX_ATTACHMENT_BYTES:
+        return JSONResponse({"error": "file too large (100 MB max)"}, status_code=413)
+    chat_files = data_dir / "chat-files"
+    chat_files.mkdir(parents=True, exist_ok=True)
+    stored_name = f"{secrets.token_hex(8)}-{src.name}"
+    dest = chat_files / stored_name
+    shutil.copy2(src, dest)
+    mime, _ = mimetypes.guess_type(src.name)
+    return JSONResponse({
+        "filename": src.name,
+        "mime_type": mime or "application/octet-stream",
+        "size": src.stat().st_size,
+        "url": f"/api/chat/files/{stored_name}",
+        "source": source,
+    }, status_code=200)
+
+
+@router.post("/api/chat/upload")
+async def upload_file(request: Request, file: UploadFile = File(...), channel_id: str = ""):
+    """Upload a file attachment for use in chat messages."""
+    data_dir = request.app.state.data_dir
+    upload_dir = data_dir / "chat-files"
+    upload_dir.mkdir(parents=True, exist_ok=True)
+
+    file_id = uuid.uuid4().hex[:12]
+    ext = Path(file.filename).suffix if file.filename else ""
+    stored_name = f"{file_id}{ext}"
+    dest = upload_dir / stored_name
+    content = await file.read()
+    dest.write_bytes(content)
+
+    attachment = {
+        "id": file_id,
+        "filename": file.filename or "unnamed",
+        "content_type": file.content_type or "application/octet-stream",
+        "size": len(content),
+        "url": f"/api/chat/files/{stored_name}",
+    }
+    return attachment
+
+
+@router.get("/api/chat/files/{filename}")
+async def serve_file(request: Request, filename: str):
+    """Serve an uploaded chat file."""
+    data_dir = request.app.state.data_dir
+    file_path = data_dir / "chat-files" / filename
+    if not file_path.exists() or not file_path.resolve().is_relative_to(
+        (data_dir / "chat-files").resolve()
+    ):
+        return JSONResponse({"error": "File not found"}, status_code=404)
+    return FileResponse(file_path)


### PR DESCRIPTION
Modularity plan B5. Splits two cohesive route groups out of the 1015-line chat.py:
- `chat_files.py` — `_resolve_workspace_path` + the attachment/upload/serve-file routes.
- `chat_admin.py` — channel-management routes (create/update[PUT]/delete channel, members, muted, settings[PATCH]).

Both get their own APIRouter, registered in `register_all_routers`. Routes moved verbatim; new modules don't import chat.py (no circular import).

**Also unifies the two data-dir resolution strategies** the plan flagged: the file routes used `request.app.state.config_path.parent` while the rest of chat.py uses `request.app.state.data_dir`. Since `config_path == data_dir/config.yaml`, these are the same path — now both use the canonical `app.state.data_dir`.

(Note: the plan's 'duplicate PATCH route' was a false positive — `/api/chat/channels/{id}` PUT and PATCH are distinct handlers; both moved, both kept.)

chat.py 1015 → 780; chat_files.py 113, chat_admin.py 132. Route parity verified (all moved paths+methods still registered); chat unit tests pass.