### PR TITLE
fix: address CodeRabbit findings across refactored modules

### DIFF
--- a/desktop/src/apps/agents/AgentDetailPanel.tsx
+++ b/desktop/src/apps/agents/AgentDetailPanel.tsx
@@ -76,8 +76,14 @@ export function AgentDetailPanel({
   }, [logs]);
 
   const dismissMigrationBanner = async () => {
-    await fetch(`/api/agents/${encodeURIComponent(agentName)}/dismiss-migration-banner`, { method: "POST" });
-    onAgentUpdated();
+    try {
+      const res = await fetch(`/api/agents/${encodeURIComponent(agentName)}/dismiss-migration-banner`, { method: "POST" });
+      if (res.ok) {
+        onAgentUpdated();
+      }
+    } catch {
+      // Network error — banner stays visible; user can retry.
+    }
   };
 
   const addPersonaClick = async () => {

--- a/tinyagentos/litellm_config.py
+++ b/tinyagentos/litellm_config.py
@@ -239,9 +239,15 @@ def generate_litellm_config(
         backend_name = backend.get("name", "")
         if backend_name.startswith("local-") and url:
             for manifest_id in _local_backend_models_from_registry(backend, registry):
-                # Skip if already added (e.g. cloud per-model loop above
-                # already registered it under the same name).
-                if any(e.get("model_name") == manifest_id for e in model_list):
+                # Skip if an EXACT duplicate for this same backend already
+                # exists (same model_name AND same api_base).  A different
+                # backend serving the same manifest_id is a distinct entry
+                # (multi-backend failover) and must NOT be skipped.
+                if any(
+                    e.get("model_name") == manifest_id
+                    and e.get("litellm_params", {}).get("api_base") == url
+                    for e in model_list
+                ):
                     continue
                 per_model_params: dict = {
                     "model": f"{prefix}/{manifest_id}",

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -200,6 +200,10 @@ class DeployAgentRequest(BaseModel):
     memory_config: dict | None = None
     source_persona_id: str | None = None
     save_to_library: dict | None = None  # {"name": str, "description": str|None}
+    # KV-cache quantisation — sent by DeployWizard; defaults mirror normalize_agent.
+    kv_cache_quant_k: str = "fp16"
+    kv_cache_quant_v: str = "fp16"
+    kv_cache_quant_boundary_layers: int = 0
 
 
 @router.post("/api/agents/deploy")
@@ -288,6 +292,10 @@ async def deploy_agent_endpoint(request: Request, body: DeployAgentRequest):
     new_agent["memory_config"] = body.memory_config
     new_agent["source_persona_id"] = body.source_persona_id
     new_agent["migrated_to_v2_personas"] = True
+    # Apply KV-cache quantisation choices from the deploy wizard.
+    new_agent["kv_cache_quant_k"] = body.kv_cache_quant_k
+    new_agent["kv_cache_quant_v"] = body.kv_cache_quant_v
+    new_agent["kv_cache_quant_boundary_layers"] = body.kv_cache_quant_boundary_layers
 
     config.agents.append(new_agent)
     await save_config_locked(config, config.config_path)

--- a/tinyagentos/routes/chat_files.py
+++ b/tinyagentos/routes/chat_files.py
@@ -89,6 +89,8 @@ async def upload_file(request: Request, file: UploadFile = File(...), channel_id
     stored_name = f"{file_id}{ext}"
     dest = upload_dir / stored_name
     content = await file.read()
+    if len(content) > _MAX_ATTACHMENT_BYTES:
+        return JSONResponse({"error": "file too large (100 MB max)"}, status_code=413)
     dest.write_bytes(content)
 
     attachment = {

--- a/tinyagentos/routes/desktop_browser/store_mixins/bookmarks.py
+++ b/tinyagentos/routes/desktop_browser/store_mixins/bookmarks.py
@@ -37,6 +37,8 @@ class BookmarksMixin:
         """Return bookmarks for (user, profile), optionally substring-filtered."""
         if not user_id or not profile_id:
             raise ValueError("user_id and profile_id required")
+        if limit <= 0:
+            raise ValueError("limit must be positive")
         assert self._db is not None
         if query:
             like = f"%{query}%"

--- a/tinyagentos/routes/desktop_browser/store_mixins/drive_sessions.py
+++ b/tinyagentos/routes/desktop_browser/store_mixins/drive_sessions.py
@@ -98,6 +98,8 @@ class DriveSessionsMixin:
         idle_timeout_s: float = 30.0,
     ) -> int:
         """Atomically delete rows idle for >= idle_timeout_s. Returns rowcount."""
+        if idle_timeout_s <= 0:
+            raise ValueError("idle_timeout_s must be positive")
         assert self._db is not None
         cutoff = (datetime.now(timezone.utc) - timedelta(seconds=idle_timeout_s)).isoformat()
         cursor = await self._db.execute(

--- a/tinyagentos/routes/desktop_browser/store_mixins/history.py
+++ b/tinyagentos/routes/desktop_browser/store_mixins/history.py
@@ -34,6 +34,8 @@ class HistoryMixin:
         """Substring match on url + title for the (user, profile). Most-recent first."""
         if not user_id or not profile_id:
             raise ValueError("user_id and profile_id required")
+        if limit <= 0:
+            raise ValueError("limit must be positive")
         assert self._db is not None
         like = f"%{query}%"
         cursor = await self._db.execute(

--- a/tinyagentos/routes/desktop_browser/store_mixins/pins.py
+++ b/tinyagentos/routes/desktop_browser/store_mixins/pins.py
@@ -59,6 +59,8 @@ class PinsMixin:
             raise ValueError("tab_id is required")
         if not agent_id:
             raise ValueError("agent_id is required")
+        if max_pins <= 0:
+            raise ValueError("max_pins must be positive")
         assert self._db is not None
         pinned_at = datetime.now(timezone.utc).isoformat()
         cursor = await self._db.execute(
@@ -97,6 +99,12 @@ class PinsMixin:
         tab_id: str,
     ) -> list[dict]:
         """Returns list of {agent_id, pinned_at} ordered by pinned_at ASC."""
+        if not user_id:
+            raise ValueError("user_id is required")
+        if not profile_id:
+            raise ValueError("profile_id is required")
+        if not tab_id:
+            raise ValueError("tab_id is required")
         assert self._db is not None
         cursor = await self._db.execute(
             "SELECT agent_id, pinned_at FROM agent_pins "
@@ -109,6 +117,8 @@ class PinsMixin:
 
     async def list_pins_for_user(self, *, user_id: str) -> list[dict]:
         """Returns list of {profile_id, tab_id, agent_id, pinned_at}."""
+        if not user_id:
+            raise ValueError("user_id is required")
         assert self._db is not None
         cursor = await self._db.execute(
             "SELECT profile_id, tab_id, agent_id, pinned_at FROM agent_pins "
@@ -129,6 +139,12 @@ class PinsMixin:
         tab_id: str,
     ) -> int:
         """Returns the number of pins on the (user, profile, tab) tuple."""
+        if not user_id:
+            raise ValueError("user_id is required")
+        if not profile_id:
+            raise ValueError("profile_id is required")
+        if not tab_id:
+            raise ValueError("tab_id is required")
         assert self._db is not None
         cursor = await self._db.execute(
             "SELECT COUNT(*) FROM agent_pins "

--- a/tinyagentos/routes/desktop_browser/store_mixins/push.py
+++ b/tinyagentos/routes/desktop_browser/store_mixins/push.py
@@ -27,6 +27,12 @@ class PushMixin:
             raise ValueError("user_id is required")
         if not device_id:
             raise ValueError("device_id is required")
+        if not endpoint:
+            raise ValueError("endpoint is required")
+        if not p256dh_key:
+            raise ValueError("p256dh_key is required")
+        if not auth_key:
+            raise ValueError("auth_key is required")
         import time
         assert self._db is not None
         now = int(time.time())


### PR DESCRIPTION
Addresses all outstanding CodeRabbit findings on the refactored code (Batch 2 + the B6a/B7 ones). Each verified against current code; all 9 were real:

**Backend**
- `litellm_config.py`: local-model alias dedup was global by `model_name` — killed LiteLLM multi-backend failover. Now dedupes by `(model_name, api_base)` so the same model on different backends both register. (Major)
- `store_mixins/drive_sessions.py`: reject non-positive `idle_timeout_s` (a negative made the cutoff a future time → would prune ALL sessions). (Major)
- `store_mixins/history.py` + `bookmarks.py`: reject non-positive `limit` (SQLite treats negative `LIMIT` as unbounded → cap bypass). (Major/Minor)
- `store_mixins/pins.py`: validate `max_pins`; add the required-id checks to the read-side methods.
- `store_mixins/push.py`: validate endpoint/p256dh/auth in `upsert_push_subscription`.
- `chat_files.py`: `upload_file` now enforces the 100 MB `_MAX_ATTACHMENT_BYTES` cap that `attachment_from_path` already had. (Major, mild security)
- `routes/agents.py` `DeployAgentRequest`: **silent data-loss fix** — the deploy wizard sends `kv_cache_quant_k/v/boundary_layers` but the model omitted them, so Pydantic dropped them. Added the 3 fields (defaults match `normalize_agent`) + persist them on the new agent. (Major)

**Frontend**
- `agents/AgentDetailPanel.tsx`: migration-banner dismiss POST now try/catch'd; `onAgentUpdated()` only on success.

449 backend tests + 9 skipped pass; `npm run build` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added KV-cache quantization parameters for agent deployment configuration.

* **Bug Fixes**
  * Migration banner dismissal now handles network errors gracefully, leaving the banner visible for retry.
  * File uploads now enforce the 100 MB size limit consistently.

* **Improvements**
  * Local backend models now support multi-backend failover scenarios with the same manifest ID on different URLs.
  * Enhanced input validation across multiple endpoints to prevent invalid operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->