### PR TITLE
fix(update): track checked-out branch, not hardcoded master

### DIFF
--- a/tests/test_auto_update_branch.py
+++ b/tests/test_auto_update_branch.py
@@ -1,0 +1,84 @@
+"""Tests for the update branch-tracking + ancestry helpers.
+
+Regression cover for the bug where the updater hard-coded ``origin/master``,
+so a dev/test box (running ahead on ``dev``) was told an older master commit
+was "available" and Install Update failed (ff-only pull of master aborts).
+"""
+import asyncio
+import subprocess
+
+import pytest
+
+from tinyagentos.auto_update import update_tracking_branch, remote_is_strictly_ahead
+
+
+def _git(cwd, *args):
+    subprocess.run(["git", *args], cwd=cwd, check=True,
+                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+def _sha(cwd, ref="HEAD"):
+    return subprocess.run(
+        ["git", "rev-parse", ref], cwd=cwd, check=True,
+        capture_output=True, text=True,
+    ).stdout.strip()
+
+
+@pytest.fixture
+def repo(tmp_path):
+    r = tmp_path / "repo"
+    r.mkdir()
+    _git(r, "init", "-q")
+    _git(r, "config", "user.email", "t@t")
+    _git(r, "config", "user.name", "t")
+    _git(r, "checkout", "-q", "-b", "master")
+    (r / "f").write_text("1")
+    _git(r, "add", "."); _git(r, "commit", "-qm", "c1")
+    return r
+
+
+def test_tracking_branch_is_checked_out_branch(repo):
+    _git(repo, "checkout", "-q", "-b", "dev")
+    assert asyncio.run(update_tracking_branch(repo)) == "dev"
+    _git(repo, "checkout", "-q", "master")
+    assert asyncio.run(update_tracking_branch(repo)) == "master"
+
+
+def test_tracking_branch_falls_back_to_master_when_detached(repo):
+    sha = _sha(repo)
+    _git(repo, "checkout", "-q", sha)  # detached HEAD
+    assert asyncio.run(update_tracking_branch(repo)) == "master"
+
+
+def test_strictly_ahead_true_when_current_is_ancestor(repo):
+    old = _sha(repo)
+    (repo / "f").write_text("2")
+    _git(repo, "add", "."); _git(repo, "commit", "-qm", "c2")
+    new = _sha(repo)
+    assert asyncio.run(remote_is_strictly_ahead(repo, old, new)) is True
+
+
+def test_not_ahead_when_remote_is_older_or_equal(repo):
+    old = _sha(repo)
+    (repo / "f").write_text("2")
+    _git(repo, "add", "."); _git(repo, "commit", "-qm", "c2")
+    new = _sha(repo)
+    # remote older than current (the dev-box-vs-master case) -> NOT an update
+    assert asyncio.run(remote_is_strictly_ahead(repo, new, old)) is False
+    # identical -> NOT an update
+    assert asyncio.run(remote_is_strictly_ahead(repo, new, new)) is False
+
+
+def test_not_ahead_when_divergent(repo):
+    base = _sha(repo)
+    _git(repo, "checkout", "-q", "-b", "dev")
+    (repo / "d").write_text("d")
+    _git(repo, "add", "."); _git(repo, "commit", "-qm", "dev-only")
+    dev = _sha(repo)
+    _git(repo, "checkout", "-q", "master")
+    (repo / "m").write_text("m")
+    _git(repo, "add", "."); _git(repo, "commit", "-qm", "master-only")
+    master = _sha(repo)
+    # dev and master diverged from base -> neither is ahead of the other
+    assert asyncio.run(remote_is_strictly_ahead(repo, dev, master)) is False
+    assert base  # sanity

--- a/tinyagentos/auto_update.py
+++ b/tinyagentos/auto_update.py
@@ -59,6 +59,31 @@ async def _run(args: list[str], cwd: Path) -> tuple[int, str]:
     return proc.returncode or 0, (stdout.decode() if stdout else "")
 
 
+async def update_tracking_branch(project_dir: Path) -> str:
+    """The branch this install tracks for updates.
+
+    Returns the currently checked-out branch (e.g. ``master`` on a stable
+    install, ``dev`` on a dev/test box). Falls back to ``master`` when the
+    repo is in detached HEAD (tag/SHA-pinned deploys) or the branch can't be
+    determined, preserving the historical stable-channel behaviour.
+    """
+    rc, out = await _run(["git", "rev-parse", "--abbrev-ref", "HEAD"], project_dir)
+    branch = out.strip() if rc == 0 else ""
+    return branch if branch and branch != "HEAD" else "master"
+
+
+async def remote_is_strictly_ahead(project_dir: Path, current: str, remote: str) -> bool:
+    """True only if ``current`` is a strict ancestor of ``remote`` — i.e. the
+    remote is genuinely newer. Prevents offering an older or divergent commit
+    (e.g. master's tip when running ahead on dev) as an "update"."""
+    if not current or not remote or current == remote:
+        return False
+    rc, _ = await _run(
+        ["git", "merge-base", "--is-ancestor", current, remote], project_dir
+    )
+    return rc == 0
+
+
 class AutoUpdateService:
     """Background service that periodically checks GitHub for updates.
 
@@ -126,7 +151,10 @@ class AutoUpdateService:
             pass
         else:
             current = await self._current_commit()
-            if new_commit != current:
+            # Only an update if the remote is strictly newer than us — never
+            # flag an older/divergent commit (e.g. master's tip while we run
+            # ahead on dev) as available.
+            if await remote_is_strictly_ahead(self._project_dir, current, new_commit):
                 # Skip re-notifying for a commit we've already flagged.
                 if prefs.get("last_notified_commit") != new_commit:
                     await self._notify_available(current, new_commit)
@@ -151,13 +179,17 @@ class AutoUpdateService:
             )
 
     async def _probe_remote(self) -> Optional[str]:
-        """Return the current HEAD commit of origin/master, or None on failure."""
+        """Return the tip of the tracked remote branch (the branch this install
+        is on), or None on failure."""
+        branch = await update_tracking_branch(self._project_dir)
         rc, _ = await _run(
-            ["git", "fetch", "--quiet", "origin", "master"], self._project_dir
+            ["git", "fetch", "--quiet", "origin", branch], self._project_dir
         )
         if rc != 0:
             return None
-        rc2, out = await _run(["git", "rev-parse", "origin/master"], self._project_dir)
+        rc2, out = await _run(
+            ["git", "rev-parse", f"origin/{branch}"], self._project_dir
+        )
         if rc2 != 0:
             return None
         return out.strip()

--- a/tinyagentos/routes/settings.py
+++ b/tinyagentos/routes/settings.py
@@ -496,12 +496,18 @@ async def set_container_runtime(request: Request):
 async def check_for_updates(request: Request):
     """Check if a newer version of TinyAgentOS is available on GitHub."""
     import asyncio
+    from tinyagentos.auto_update import update_tracking_branch, remote_is_strictly_ahead
     project_dir = str(Path(__file__).parent.parent.parent)
 
-    # Fetch remote refs so origin/master is current, then compare SHAs.
+    # Track whichever branch this install is on (master on stable, dev on a
+    # dev/test box) rather than hard-coding master — otherwise a dev box is
+    # told a stale master commit is "available" and Install Update fails.
+    branch = await update_tracking_branch(project_dir)
+
+    # Fetch remote refs so origin/<branch> is current, then compare SHAs.
     # Parsing dry-run output is unreliable on shallow clones / no tracking branch.
     fetch_proc = await asyncio.create_subprocess_exec(
-        "git", "fetch", "origin", "master",
+        "git", "fetch", "origin", branch,
         stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL,
         cwd=project_dir,
     )
@@ -518,9 +524,11 @@ async def check_for_updates(request: Request):
 
     local_sha, remote_sha = await asyncio.gather(
         _rev_parse("HEAD"),
-        _rev_parse("origin/master"),
+        _rev_parse(f"origin/{branch}"),
     )
-    has_updates = bool(local_sha and remote_sha and local_sha != remote_sha)
+    # Only a real update when the remote is strictly ahead of us — never offer
+    # an older or divergent commit.
+    has_updates = await remote_is_strictly_ahead(project_dir, local_sha, remote_sha)
 
     async def _log1(ref: str) -> str:
         p = await asyncio.create_subprocess_exec(
@@ -532,7 +540,7 @@ async def check_for_updates(request: Request):
         return out.decode().strip() if out else "unknown"
 
     current = await _log1("HEAD")
-    new_commit = await _log1("origin/master") if has_updates else None
+    new_commit = await _log1(f"origin/{branch}") if has_updates else None
 
     return {
         "has_updates": has_updates,
@@ -620,9 +628,13 @@ async def apply_update(request: Request):
     )
     await clean_proc.communicate()
 
-    # Git pull
+    # Git pull — pull the branch this install tracks (master on stable, dev on
+    # a dev/test box). Pulling a hard-coded master onto a dev box fails ff-only
+    # (dev is ahead of master) and the update silently never applies.
+    from tinyagentos.auto_update import update_tracking_branch
+    branch = await update_tracking_branch(project_dir)
     proc = await asyncio.create_subprocess_exec(
-        "git", "pull", "--ff-only", "origin", "master",
+        "git", "pull", "--ff-only", "origin", branch,
         stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT,
         cwd=str(project_dir),
     )


### PR DESCRIPTION
**Root cause of 'updating from Settings isn't working' on the dev box.**

The update machinery hard-coded `origin/master` in three active places:
1. `auto_update.py` `_probe_remote` (hourly check/notify)
2. `routes/settings.py` `/api/settings/update-check` (the Updates panel data)
3. `routes/settings.py` `/api/settings/update` `apply_update` (`git pull --ff-only origin master`)

On a box running `dev` (ahead of master): the panel showed an *older* master commit as 'available' (plain `!=`, no ancestry check), and Install Update's `git pull --ff-only origin master` **aborts** because dev isn't a descendant of master → the restart-to-apply flow then reports 'still on X, expected Y'.

**Fix:** new `update_tracking_branch()` resolves the checked-out branch (master on stable, dev on a dev box; falls back to master when detached so tag/SHA prod installs are unaffected). All three sites now use `origin/<branch>`. 'Available' is gated on `remote_is_strictly_ahead()` (ancestry) so an older/divergent commit is never offered.

`update_runner.py`'s `update_to_master` is dead code (no callers) — left as-is.

+5 tests (branch detection incl. detached-HEAD fallback; ancestry true/older/equal/divergent). 57 existing update/settings tests still pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Auto-update system now correctly tracks and pulls from the branch your instance was installed from, rather than always using the default branch
  * Update notifications only appear when the remote version is genuinely newer, preventing false alerts from older or divergent versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->