### PR TITLE
fix(cluster): local worker reports host hardware + self-heartbeats

### DIFF
--- a/tests/cluster/test_local_worker_enroll.py
+++ b/tests/cluster/test_local_worker_enroll.py
@@ -38,6 +38,49 @@ class TestEnrollLocalWorker:
         worker = mgr.get_worker("local")
         assert worker.worker_url == "http://127.0.0.1:6969"
 
+    def test_enroll_sets_hardware_and_backends(self):
+        from tinyagentos.cluster.local_worker import enroll_local_worker
+
+        hw = {"cpu": {"cores": 8, "arch": "aarch64"}, "ram_mb": 15600,
+              "npu": {"name": "rknpu"}}
+        backends = [{"name": "rkllama", "type": "rkllama", "url": "http://localhost:8080"}]
+        mgr = ClusterManager()
+        asyncio.run(enroll_local_worker(mgr, hardware=hw, backends=backends))
+        worker = mgr.get_worker("local")
+        assert worker.hardware == hw
+        assert worker.backends == backends
+
+
+class TestLocalHeartbeat:
+    """The controller self-heartbeats its own 'local' worker."""
+
+    def test_heartbeat_loop_keeps_local_online_and_fresh(self):
+        from tinyagentos.cluster.local_worker import enroll_local_worker, local_heartbeat_loop
+
+        async def run():
+            mgr = ClusterManager()
+            await enroll_local_worker(mgr)
+            # Force it stale + a fake config with one backend.
+            mgr.get_worker("local").last_heartbeat = 0.0
+            cfg = MagicMock()
+            cfg.backends = [{"name": "rkllama", "type": "rkllama",
+                             "url": "http://localhost:8080", "models": [{"name": "gemma"}]}]
+            task = asyncio.create_task(local_heartbeat_loop(mgr, cfg, interval=0.01))
+            await asyncio.sleep(0.05)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            w = mgr.get_worker("local")
+            assert w.status == "online"
+            assert w.last_heartbeat > 0.0
+            assert w.backends == cfg.backends
+            # heartbeat derives the model list from the backends
+            assert "gemma" in w.models
+
+        asyncio.run(run())
+
     def test_enroll_generates_random_signing_key(self):
         import tinyagentos.cluster.local_worker as lw
         from tinyagentos.cluster.local_worker import enroll_local_worker

--- a/tests/cluster/test_local_worker_enroll.py
+++ b/tests/cluster/test_local_worker_enroll.py
@@ -81,6 +81,60 @@ class TestLocalHeartbeat:
 
         asyncio.run(run())
 
+    def test_heartbeat_loop_prefers_live_backends_provider(self):
+        """When a backends_provider is given it overrides config.backends, so
+        the local worker reports the live (loaded-model) catalog."""
+        from tinyagentos.cluster.local_worker import enroll_local_worker, local_heartbeat_loop
+
+        async def run():
+            mgr = ClusterManager()
+            await enroll_local_worker(mgr)
+            cfg = MagicMock()
+            cfg.backends = [{"name": "stale", "type": "x", "url": "u", "models": [{"name": "old"}]}]
+            live = [{"name": "rkllama", "type": "rkllama", "url": "u2",
+                     "models": [{"name": "qwen-live"}]}]
+            task = asyncio.create_task(
+                local_heartbeat_loop(mgr, cfg, interval=0.01, backends_provider=lambda: live)
+            )
+            await asyncio.sleep(0.05)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            w = mgr.get_worker("local")
+            assert w.backends == live
+            assert "qwen-live" in w.models
+            assert "old" not in w.models  # config list was NOT used
+
+        asyncio.run(run())
+
+    def test_heartbeat_loop_falls_back_to_config_when_provider_raises(self):
+        from tinyagentos.cluster.local_worker import enroll_local_worker, local_heartbeat_loop
+
+        async def run():
+            mgr = ClusterManager()
+            await enroll_local_worker(mgr)
+            cfg = MagicMock()
+            cfg.backends = [{"name": "cfg", "type": "x", "url": "u", "models": [{"name": "fallback"}]}]
+
+            def boom():
+                raise RuntimeError("catalog not ready")
+
+            task = asyncio.create_task(
+                local_heartbeat_loop(mgr, cfg, interval=0.01, backends_provider=boom)
+            )
+            await asyncio.sleep(0.05)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            w = mgr.get_worker("local")
+            assert "fallback" in w.models  # gracefully used config.backends
+
+        asyncio.run(run())
+
     def test_enroll_generates_random_signing_key(self):
         import tinyagentos.cluster.local_worker as lw
         from tinyagentos.cluster.local_worker import enroll_local_worker

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -685,9 +685,25 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         # code (get_local_worker) picks up the in-memory signing key.
         from tinyagentos.cluster.local_worker import enroll_local_worker
         from tinyagentos.cluster.worker_registry import set_active_manager
+        from dataclasses import asdict as _asdict
         _bind_port = config.server.get("port", 6969)
-        await enroll_local_worker(cluster_manager, bind_port=_bind_port)
+        # Give the local worker the controller's own hardware + backends so the
+        # Cluster view shows the host's real CPU/RAM/NPU and loaded backends.
+        _local_hw = _asdict(hardware_profile) if hardware_profile is not None else {}
+        await enroll_local_worker(
+            cluster_manager,
+            bind_port=_bind_port,
+            hardware=_local_hw,
+            backends=list(config.backends or []),
+        )
         set_active_manager(cluster_manager)
+        # Self-heartbeat the local worker so it stays online + refreshes its
+        # backends/loaded-models like a real worker (it never gets heartbeats
+        # from elsewhere — it IS the controller).
+        from tinyagentos.cluster.local_worker import local_heartbeat_loop
+        app.state.local_heartbeat_task = asyncio.create_task(
+            local_heartbeat_loop(cluster_manager, config), name="local-heartbeat"
+        )
         # Start the live backend catalog — everything that asks "what's
         # available?" reads from this rather than the filesystem.
         try:
@@ -879,6 +895,9 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
             await c.stop()
         await score_cache.stop()
         await backend_catalog.stop()
+        _hb_task = getattr(app.state, "local_heartbeat_task", None)
+        if _hb_task is not None:
+            _hb_task.cancel()
         await cluster_manager.stop()
         llm_proxy.stop()
         await monitor.stop()

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -699,10 +699,18 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         set_active_manager(cluster_manager)
         # Self-heartbeat the local worker so it stays online + refreshes its
         # backends/loaded-models like a real worker (it never gets heartbeats
-        # from elsewhere — it IS the controller).
+        # from elsewhere — it IS the controller). Source backends from the LIVE
+        # catalog (which probes for loaded models), not config.backends (static,
+        # no model data). The lambda is evaluated each tick so it self-heals
+        # once the catalog has completed its first probe.
         from tinyagentos.cluster.local_worker import local_heartbeat_loop
         app.state.local_heartbeat_task = asyncio.create_task(
-            local_heartbeat_loop(cluster_manager, config), name="local-heartbeat"
+            local_heartbeat_loop(
+                cluster_manager,
+                config,
+                backends_provider=lambda: [e.to_dict() for e in backend_catalog.backends()],
+            ),
+            name="local-heartbeat",
         )
         # Start the live backend catalog — everything that asks "what's
         # available?" reads from this rather than the filesystem.
@@ -898,6 +906,12 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         _hb_task = getattr(app.state, "local_heartbeat_task", None)
         if _hb_task is not None:
             _hb_task.cancel()
+            # Await it so the loop has actually exited before teardown moves on
+            # (cancel() alone doesn't guarantee the coroutine has unwound).
+            try:
+                await _hb_task
+            except asyncio.CancelledError:
+                pass
         await cluster_manager.stop()
         llm_proxy.stop()
         await monitor.stop()

--- a/tinyagentos/cluster/local_worker.py
+++ b/tinyagentos/cluster/local_worker.py
@@ -28,7 +28,12 @@ def _cpu_load() -> float:
         return 0.0
 
 
-async def local_heartbeat_loop(manager: ClusterManager, config, interval: float = 15.0) -> None:
+async def local_heartbeat_loop(
+    manager: ClusterManager,
+    config,
+    interval: float = 15.0,
+    backends_provider=None,
+) -> None:
     """Self-heartbeat the 'local' worker (the controller itself).
 
     The controller never receives heartbeats from elsewhere — it IS the
@@ -36,13 +41,29 @@ async def local_heartbeat_loop(manager: ClusterManager, config, interval: float 
     timeout and its backends/loaded-models would never refresh. Heartbeating
     here keeps it online and, by passing the live backends, keeps its backend
     + derived model list current the same way a remote worker's agent does.
+
+    ``backends_provider`` is an optional zero-arg callable returning the live
+    backend dicts (``{name, type, url, models, ...}``). Prefer it over
+    ``config.backends``: the configured list carries no live model data, while
+    the live catalog actually knows which models are loaded right now. Falls
+    back to ``config.backends`` when no provider is given or it raises.
     """
+    # psutil.cpu_percent(interval=None) returns 0.0 on its first call (no prior
+    # sample to diff against). Prime it once so the first heartbeat carries a
+    # real reading rather than a meaningless zero.
+    _cpu_load()
     while True:
+        backends = list(getattr(config, "backends", None) or [])
+        if backends_provider is not None:
+            try:
+                backends = list(backends_provider() or [])
+            except Exception:
+                logger.exception("local heartbeat: backends_provider failed; using config")
         try:
             manager.heartbeat(
                 "local",
                 load=_cpu_load(),
-                backends=list(getattr(config, "backends", None) or []),
+                backends=backends,
             )
         except Exception:
             logger.exception("local heartbeat failed")

--- a/tinyagentos/cluster/local_worker.py
+++ b/tinyagentos/cluster/local_worker.py
@@ -6,21 +6,65 @@ calls). The signing key is in-memory only (regenerated on restart).
 """
 from __future__ import annotations
 
+import asyncio
+import logging
 import os
 
 from tinyagentos.cluster.manager import ClusterManager
 from tinyagentos.cluster.worker_protocol import WorkerInfo
 
+logger = logging.getLogger(__name__)
+
 # Module-level. Survives across calls within the same process. Reset on restart.
 _LOCAL_SIGNING_KEY: bytes | None = None
 
 
-async def enroll_local_worker(manager: ClusterManager, bind_port: int = 6969) -> None:
-    """Register the 'local' worker in *manager*. Idempotent.
+def _cpu_load() -> float:
+    """Best-effort 0-1 CPU utilisation for the local worker's load field."""
+    try:
+        import psutil
+        return min(1.0, max(0.0, psutil.cpu_percent(interval=None) / 100.0))
+    except Exception:
+        return 0.0
+
+
+async def local_heartbeat_loop(manager: ClusterManager, config, interval: float = 15.0) -> None:
+    """Self-heartbeat the 'local' worker (the controller itself).
+
+    The controller never receives heartbeats from elsewhere — it IS the
+    server — so without this it would be marked offline after the heartbeat
+    timeout and its backends/loaded-models would never refresh. Heartbeating
+    here keeps it online and, by passing the live backends, keeps its backend
+    + derived model list current the same way a remote worker's agent does.
+    """
+    while True:
+        try:
+            manager.heartbeat(
+                "local",
+                load=_cpu_load(),
+                backends=list(getattr(config, "backends", None) or []),
+            )
+        except Exception:
+            logger.exception("local heartbeat failed")
+        try:
+            await asyncio.sleep(interval)
+        except asyncio.CancelledError:
+            return
+
+
+async def enroll_local_worker(
+    manager: ClusterManager,
+    bind_port: int = 6969,
+    hardware: dict | None = None,
+    backends: list[dict] | None = None,
+) -> None:
+    """Register the 'local' worker (the controller itself) in *manager*. Idempotent.
 
     On first call, generates a 32-byte random signing key and registers the
-    worker. On subsequent calls (same process, same manager) the existing
-    worker is left untouched.
+    worker with the controller's own hardware + backends so the Cluster view
+    shows the host's real CPU/RAM/NPU and loaded backends rather than
+    "Unknown CPU / CPU only / No backends loaded". On subsequent calls (same
+    process, same manager) the existing worker is left untouched.
     """
     global _LOCAL_SIGNING_KEY
 
@@ -36,5 +80,7 @@ async def enroll_local_worker(manager: ClusterManager, bind_port: int = 6969) ->
         worker_url=f"http://127.0.0.1:{bind_port}",
         signing_key=_LOCAL_SIGNING_KEY,
         platform="local",
+        hardware=hardware or {},
+        backends=list(backends or []),
     )
     await manager.register_worker(worker)

--- a/tinyagentos/cluster/manager.py
+++ b/tinyagentos/cluster/manager.py
@@ -331,6 +331,10 @@ class ClusterManager:
         while True:
             now = time.time()
             for worker in self._workers.values():
+                # The 'local' worker is the controller itself — it never sends
+                # heartbeats (it IS the server), so never mark it offline.
+                if worker.name == "local":
+                    continue
                 if worker.status == "online" and (now - worker.last_heartbeat) > HEARTBEAT_TIMEOUT:
                     worker.status = "offline"
                     logger.warning(f"Worker '{worker.name}' marked offline (no heartbeat for {HEARTBEAT_TIMEOUT}s)")


### PR DESCRIPTION
The Cluster app showed the controller's own 'local' worker as **offline, Unknown CPU, CPU only, No backends loaded** — even though System Info reads the host hardware fine.

Cause: `enroll_local_worker` registered 'local' with no hardware/backends, and nothing heartbeated it, so the monitor marked it offline after 30s.

Fix:
- `enroll_local_worker` now takes the controller's `hardware_profile` (asdict) + configured backends and sets them on the worker.
- New `local_heartbeat_loop` self-heartbeats 'local' every 15s with the live backends (heartbeat derives the loaded-model list from them) + CPU load, keeping it online and fresh like a remote worker.
- The heartbeat monitor skips 'local' entirely (it IS the controller — never offline).

+3 tests (enroll sets hardware/backends; heartbeat loop keeps it online + fresh). create_app imports clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic heartbeat mechanism for the local cluster worker to maintain an active online status.
  * Enhanced local worker registration to include detailed hardware profile and backend configuration information for accurate cluster visibility.

* **Bug Fixes**
  * Fixed controller (local worker) from being incorrectly marked offline during cluster monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->