### PR TITLE
feat(update): branch/release-channel selector in Settings → Updates (#562)

### DIFF
--- a/desktop/src/apps/SettingsApp/UpdatesPanel.test.tsx
+++ b/desktop/src/apps/SettingsApp/UpdatesPanel.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { UpdatesPanel } from "./UpdatesPanel";
+
+const jResp = (b: any) => Promise.resolve({ ok: true, json: async () => b } as any);
+
+beforeEach(() => {
+  global.fetch = vi.fn(async (url: string) => {
+    if (url === "/api/preferences/auto-update") return jResp({ check_enabled: true });
+    if (url === "/api/settings/update-check") return jResp({ has_updates: false, current_commit: "abc x" });
+    if (url === "/api/settings/update-status") return jResp({ current_sha: "abc", pending_restart_sha: null });
+    if (url === "/api/settings/branches") return jResp({ branches: ["master", "dev"], current: "dev" });
+    if (url === "/api/settings/update-channel") return jResp({ status: "switching", branch: "master" });
+    return jResp({});
+  }) as any;
+});
+
+describe("UpdatesPanel — branch selector", () => {
+  it("hides the branch selector until Advanced is expanded", async () => {
+    render(<UpdatesPanel />);
+    expect(screen.queryByRole("combobox", { name: /branch/i })).toBeNull();
+    fireEvent.click(await screen.findByRole("button", { name: /advanced/i }));
+    await waitFor(() => expect(screen.getByRole("combobox", { name: /branch/i })).toBeInTheDocument());
+  });
+
+  it("requires confirm before posting a switch", async () => {
+    render(<UpdatesPanel />);
+    fireEvent.click(await screen.findByRole("button", { name: /advanced/i }));
+    const select = await screen.findByRole("combobox", { name: /branch/i });
+    fireEvent.change(select, { target: { value: "master" } });
+    fireEvent.click(screen.getByRole("button", { name: /switch branch/i }));
+    expect((global.fetch as any).mock.calls.find((c: any[]) => c[0] === "/api/settings/update-channel")).toBeUndefined();
+    fireEvent.click(await screen.findByRole("button", { name: /^confirm/i }));
+    await waitFor(() =>
+      expect((global.fetch as any).mock.calls.find((c: any[]) => c[0] === "/api/settings/update-channel")).toBeTruthy()
+    );
+  });
+});

--- a/desktop/src/apps/SettingsApp/UpdatesPanel.tsx
+++ b/desktop/src/apps/SettingsApp/UpdatesPanel.tsx
@@ -42,6 +42,17 @@ export function UpdatesPanel() {
   const [switching, setSwitching] = useState(false);
   const [showSwitchConfirm, setShowSwitchConfirm] = useState(false);
   const branchFetched = useRef(false);
+  const confirmBtnRef = useRef<HTMLButtonElement>(null);
+
+  // Focus management for the confirm dialog: move focus into the dialog when it
+  // opens and return it to the previously focused control when it closes, so
+  // keyboard/screen-reader users get and keep the confirmation context.
+  useEffect(() => {
+    if (!showSwitchConfirm) return;
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    confirmBtnRef.current?.focus();
+    return () => previouslyFocused?.focus?.();
+  }, [showSwitchConfirm]);
 
   // Load current prefs + info on mount
   useEffect(() => {
@@ -149,10 +160,11 @@ export function UpdatesPanel() {
     }
   };
 
-  // Fetch branches once when Advanced is first opened
+  // Fetch branches once when Advanced is first opened. Only mark as fetched on
+  // success so a transient 500/network error can be retried by re-opening
+  // Advanced, rather than wedging the panel until a full page refresh.
   useEffect(() => {
     if (!advancedOpen || branchFetched.current) return;
-    branchFetched.current = true;
     (async () => {
       try {
         const r = await fetch("/api/settings/branches");
@@ -160,6 +172,7 @@ export function UpdatesPanel() {
           const data: BranchInfo = await r.json();
           setBranchInfo(data);
           setSelectedBranch(data.current);
+          branchFetched.current = true;
         } else {
           setStatus("Could not load branch list.");
         }
@@ -344,10 +357,22 @@ export function UpdatesPanel() {
 
       {/* Branch-switch confirm dialog */}
       {showSwitchConfirm && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
-          <div className="bg-shell-surface border border-white/10 rounded-xl shadow-2xl p-6 max-w-md w-full mx-4 space-y-4">
-            <h3 className="text-sm font-semibold">Switch branch?</h3>
-            <p className="text-xs text-shell-text-secondary leading-relaxed">
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+          onClick={() => setShowSwitchConfirm(false)}
+          onKeyDown={(e) => { if (e.key === "Escape") setShowSwitchConfirm(false); }}
+          tabIndex={-1}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="switch-branch-title"
+          aria-describedby="switch-branch-desc"
+        >
+          <div
+            className="bg-shell-surface border border-white/10 rounded-xl shadow-2xl p-6 max-w-md w-full mx-4 space-y-4"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 id="switch-branch-title" className="text-sm font-semibold">Switch branch?</h3>
+            <p id="switch-branch-desc" className="text-xs text-shell-text-secondary leading-relaxed">
               This switches taOS to <span className="font-mono font-semibold">{selectedBranch}</span> and restarts.
               Your data/ is backed up first (data-backups/).
               Switching to an older branch may leave data written by a newer version unreadable.
@@ -356,7 +381,7 @@ export function UpdatesPanel() {
               <Button size="sm" variant="outline" onClick={() => setShowSwitchConfirm(false)}>
                 Cancel
               </Button>
-              <Button size="sm" onClick={confirmSwitchBranch} aria-label="Confirm">
+              <Button ref={confirmBtnRef} size="sm" onClick={confirmSwitchBranch} aria-label="Confirm">
                 Confirm
               </Button>
             </div>

--- a/desktop/src/apps/SettingsApp/UpdatesPanel.tsx
+++ b/desktop/src/apps/SettingsApp/UpdatesPanel.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useCallback } from "react";
-import { Settings, RefreshCw, AlertCircle, Check } from "lucide-react";
+import { useState, useEffect, useCallback, useRef } from "react";
+import { Settings, RefreshCw, AlertCircle, Check, ChevronDown, ChevronRight } from "lucide-react";
 import { Button, Card, Label, Switch } from "@/components/ui";
 import { RestartProgressModal } from "@/apps/SettingsApp/_shared";
 
@@ -20,7 +20,12 @@ interface UpdateStatus {
   auto_check: boolean;
 }
 
-export function UpdatesSection() {
+interface BranchInfo {
+  branches: string[];
+  current: string;
+}
+
+export function UpdatesPanel() {
   const [checking, setChecking] = useState(false);
   const [applying, setApplying] = useState(false);
   const [rebuilding, setRebuilding] = useState(false);
@@ -29,6 +34,14 @@ export function UpdatesSection() {
   const [prefs, setPrefs] = useState<AutoUpdatePrefs>({ check_enabled: true });
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus | null>(null);
   const [showRestartModal, setShowRestartModal] = useState(false);
+
+  // Advanced / branch selector state
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [branchInfo, setBranchInfo] = useState<BranchInfo | null>(null);
+  const [selectedBranch, setSelectedBranch] = useState<string>("");
+  const [switching, setSwitching] = useState(false);
+  const [showSwitchConfirm, setShowSwitchConfirm] = useState(false);
+  const branchFetched = useRef(false);
 
   // Load current prefs + info on mount
   useEffect(() => {
@@ -136,6 +149,49 @@ export function UpdatesSection() {
     }
   };
 
+  // Fetch branches once when Advanced is first opened
+  useEffect(() => {
+    if (!advancedOpen || branchFetched.current) return;
+    branchFetched.current = true;
+    (async () => {
+      try {
+        const r = await fetch("/api/settings/branches");
+        if (r.ok) {
+          const data: BranchInfo = await r.json();
+          setBranchInfo(data);
+          setSelectedBranch(data.current);
+        } else {
+          setStatus("Could not load branch list.");
+        }
+      } catch {
+        setStatus("Could not reach branch endpoint.");
+      }
+    })();
+  }, [advancedOpen]);
+
+  const confirmSwitchBranch = async () => {
+    setShowSwitchConfirm(false);
+    setSwitching(true);
+    setStatus(null);
+    try {
+      const res = await fetch("/api/settings/update-channel", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ branch: selectedBranch }),
+      });
+      const data = await res.json().catch(() => ({})) as { status?: string; branch?: string; snapshot?: string; recovery_tag?: string; message?: string; error?: string };
+      if (res.ok && !data.error) {
+        setStatus(data.message ?? data.snapshot ?? `Switching to ${data.branch ?? selectedBranch}…`);
+        setShowRestartModal(true);
+      } else {
+        setStatus(data.error ?? "Branch switch failed.");
+      }
+    } catch {
+      setStatus("Could not reach the update-channel endpoint.");
+    }
+    setSwitching(false);
+  };
+
   const hasPendingRestart = !!updateStatus?.pending_restart_sha;
 
   return (
@@ -233,7 +289,80 @@ export function UpdatesSection() {
           </div>
 
         </div>
+
+        {/* Advanced disclosure */}
+        <div className="border-t border-white/5 pt-4">
+          <button
+            type="button"
+            aria-label="Advanced"
+            aria-expanded={advancedOpen}
+            onClick={() => setAdvancedOpen((v) => !v)}
+            className="flex items-center gap-1.5 text-xs text-shell-text-tertiary hover:text-shell-text-secondary transition-colors"
+          >
+            {advancedOpen ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+            Advanced
+          </button>
+
+          {advancedOpen && (
+            <div className="mt-3 space-y-3">
+              <div className="flex items-end gap-2 flex-wrap">
+                <div className="flex flex-col gap-1">
+                  <label htmlFor="branch-select" className="text-[11px] text-shell-text-tertiary">
+                    Branch
+                  </label>
+                  <select
+                    id="branch-select"
+                    aria-label="Branch"
+                    value={selectedBranch}
+                    onChange={(e) => setSelectedBranch(e.target.value)}
+                    className="text-sm bg-white/5 border border-white/10 rounded px-2 py-1 text-shell-text-primary focus:outline-none focus:ring-1 focus:ring-sky-500"
+                  >
+                    {branchInfo?.branches.map((b) => (
+                      <option key={b} value={b}>{b}</option>
+                    ))}
+                  </select>
+                </div>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={switching || !selectedBranch || selectedBranch === branchInfo?.current}
+                  onClick={() => setShowSwitchConfirm(true)}
+                  aria-label="Switch branch"
+                >
+                  {switching ? "Switching…" : "Switch branch"}
+                </Button>
+              </div>
+              {branchInfo && (
+                <p className="text-[11px] text-shell-text-tertiary">
+                  Current branch: <span className="font-mono">{branchInfo.current}</span>
+                </p>
+              )}
+            </div>
+          )}
+        </div>
       </Card>
+
+      {/* Branch-switch confirm dialog */}
+      {showSwitchConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+          <div className="bg-shell-surface border border-white/10 rounded-xl shadow-2xl p-6 max-w-md w-full mx-4 space-y-4">
+            <h3 className="text-sm font-semibold">Switch branch?</h3>
+            <p className="text-xs text-shell-text-secondary leading-relaxed">
+              This switches taOS to <span className="font-mono font-semibold">{selectedBranch}</span> and restarts.
+              Your data/ is backed up first (data-backups/).
+              Switching to an older branch may leave data written by a newer version unreadable.
+            </p>
+            <div className="flex justify-end gap-2 pt-1">
+              <Button size="sm" variant="outline" onClick={() => setShowSwitchConfirm(false)}>
+                Cancel
+              </Button>
+              <Button size="sm" onClick={confirmSwitchBranch} aria-label="Confirm">
+                Confirm
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
 
       {showRestartModal && (
         <RestartProgressModal onClose={() => setShowRestartModal(false)} />
@@ -241,3 +370,6 @@ export function UpdatesSection() {
     </section>
   );
 }
+
+// Alias for backward compatibility with existing imports
+export { UpdatesPanel as UpdatesSection };

--- a/tests/test_data_snapshot.py
+++ b/tests/test_data_snapshot.py
@@ -54,3 +54,21 @@ def test_backup_dir_is_owner_only(tmp_path):
     dest = snapshot_data_dir(data)
     mode = stat.S_IMODE(os.stat(dest).st_mode)
     assert mode == 0o700
+
+
+def test_copied_contents_are_owner_only(tmp_path):
+    # The security contract is about the copied secrets, not just the top dir.
+    # Seed a world-readable file + subdir so we prove perms are tightened.
+    data = tmp_path / "data"; data.mkdir()
+    secrets_db = data / "secrets.db"; secrets_db.write_text("KEY")
+    os.chmod(secrets_db, 0o644)
+    sub = data / "vault"; sub.mkdir(); os.chmod(sub, 0o755)
+    nested = sub / "token.json"; nested.write_text("{}"); os.chmod(nested, 0o644)
+
+    dest = snapshot_data_dir(data)
+
+    # No copied file may be group- or world-readable/writable.
+    group_world = stat.S_IRWXG | stat.S_IRWXO
+    assert stat.S_IMODE(os.stat(dest / "secrets.db").st_mode) & group_world == 0
+    assert stat.S_IMODE(os.stat(dest / "vault").st_mode) & group_world == 0
+    assert stat.S_IMODE(os.stat(dest / "vault" / "token.json").st_mode) & group_world == 0

--- a/tests/test_data_snapshot.py
+++ b/tests/test_data_snapshot.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+from tinyagentos.data_snapshot import snapshot_data_dir
+
+
+def test_copies_dbs_and_config_excludes_models_and_workspace(tmp_path):
+    data = tmp_path / "data"; data.mkdir()
+    (data / "config.yaml").write_text("server: {}\n")
+    (data / "chat.db").write_text("sqlite")
+    (data / ".auth_user.json").write_text("{}")
+    (data / "models").mkdir(); (data / "models" / "big.gguf").write_text("x" * 1000)
+    (data / "workspace").mkdir(); (data / "workspace" / "img.png").write_text("y" * 1000)
+    (data / "data-backups").mkdir(); (data / "data-backups" / "old").write_text("z")
+
+    dest = snapshot_data_dir(data)
+
+    assert dest.exists()
+    assert dest.parent.name == "data-backups"
+    assert dest.name.startswith("pre-switch-")
+    assert (dest / "config.yaml").read_text() == "server: {}\n"
+    assert (dest / "chat.db").exists()
+    assert (dest / ".auth_user.json").exists()
+    assert not (dest / "models").exists()
+    assert not (dest / "workspace").exists()
+    assert not (dest / "data-backups").exists()
+
+
+def test_returns_none_when_data_dir_missing(tmp_path):
+    assert snapshot_data_dir(tmp_path / "nope") is None

--- a/tests/test_data_snapshot.py
+++ b/tests/test_data_snapshot.py
@@ -1,3 +1,5 @@
+import os
+import stat
 from pathlib import Path
 from tinyagentos.data_snapshot import snapshot_data_dir
 
@@ -26,3 +28,29 @@ def test_copies_dbs_and_config_excludes_models_and_workspace(tmp_path):
 
 def test_returns_none_when_data_dir_missing(tmp_path):
     assert snapshot_data_dir(tmp_path / "nope") is None
+
+
+def test_symlink_is_preserved_not_dereferenced(tmp_path):
+    # A symlink under data/ pointing OUTSIDE data/ must be copied as a link,
+    # never followed — otherwise it would pull arbitrary files into the backup.
+    secret = tmp_path / "outside-secret.txt"
+    secret.write_text("SENSITIVE")
+    data = tmp_path / "data"; data.mkdir()
+    (data / "config.yaml").write_text("server: {}\n")
+    (data / "leak").symlink_to(secret)
+
+    dest = snapshot_data_dir(data)
+
+    backed = dest / "leak"
+    assert backed.is_symlink()                      # preserved as a link
+    assert not backed.read_text() == "SENSITIVE" or backed.is_symlink()
+    # the symlink target's content was not materialized as a real file
+    assert os.path.islink(backed)
+
+
+def test_backup_dir_is_owner_only(tmp_path):
+    data = tmp_path / "data"; data.mkdir()
+    (data / "secrets.db").write_text("x")
+    dest = snapshot_data_dir(data)
+    mode = stat.S_IMODE(os.stat(dest).st_mode)
+    assert mode == 0o700

--- a/tests/test_resolve_tracked_branch.py
+++ b/tests/test_resolve_tracked_branch.py
@@ -1,0 +1,42 @@
+import asyncio
+import pytest
+from tinyagentos.auto_update import resolve_tracked_branch, PREF_NAMESPACE
+
+
+class _FakeSettings:
+    def __init__(self, prefs):
+        self._prefs = prefs
+    async def get_preference(self, user_id, namespace):
+        assert namespace == PREF_NAMESPACE
+        return dict(self._prefs)
+
+
+@pytest.fixture
+def repo(tmp_path):
+    import subprocess
+    r = tmp_path / "repo"; r.mkdir()
+    def g(*a): subprocess.run(["git", *a], cwd=r, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    g("init", "-q"); g("config", "user.email", "t@t"); g("config", "user.name", "t")
+    g("checkout", "-q", "-b", "master"); (r / "f").write_text("1"); g("add", "."); g("commit", "-qm", "c1")
+    return r
+
+
+def test_returns_pref_branch_when_set(repo):
+    s = _FakeSettings({"tracked_branch": "dev"})
+    assert asyncio.run(resolve_tracked_branch(s, repo)) == "dev"
+
+
+def test_falls_back_to_checked_out_branch_when_pref_absent(repo):
+    s = _FakeSettings({})
+    assert asyncio.run(resolve_tracked_branch(s, repo)) == "master"
+
+
+def test_ignores_blank_pref(repo):
+    s = _FakeSettings({"tracked_branch": ""})
+    assert asyncio.run(resolve_tracked_branch(s, repo)) == "master"
+
+
+def test_tolerates_settings_failure(repo):
+    class Boom:
+        async def get_preference(self, *a): raise RuntimeError("db down")
+    assert asyncio.run(resolve_tracked_branch(Boom(), repo)) == "master"

--- a/tests/test_resolve_tracked_branch.py
+++ b/tests/test_resolve_tracked_branch.py
@@ -1,6 +1,10 @@
 import asyncio
 import pytest
-from tinyagentos.auto_update import resolve_tracked_branch, PREF_NAMESPACE
+from tinyagentos.auto_update import (
+    is_valid_branch_name,
+    resolve_tracked_branch,
+    PREF_NAMESPACE,
+)
 
 
 class _FakeSettings:
@@ -40,3 +44,26 @@ def test_tolerates_settings_failure(repo):
     class Boom:
         async def get_preference(self, *a): raise RuntimeError("db down")
     assert asyncio.run(resolve_tracked_branch(Boom(), repo)) == "master"
+
+
+@pytest.mark.parametrize("name", [
+    "master", "dev", "feature/foo", "release-1.2", "user/fix_bug-3",
+])
+def test_is_valid_branch_name_accepts_plain_refs(name):
+    assert is_valid_branch_name(name) is True
+
+
+@pytest.mark.parametrize("name", [
+    "--upload-pack=touch /tmp/pwned",  # flag injection
+    "-x", "", "  ", "a b", "a..b", "a~b", "a^b", "a:b", "a?b", "a*b",
+    "a[b", "a\\b", "a//b", "/lead", "trail/", "ref.lock", "x@{0}",
+    "a\tb", "a\nb", "x.", "a" * 256,
+])
+def test_is_valid_branch_name_rejects_unsafe(name):
+    assert is_valid_branch_name(name) is False
+
+
+def test_rejects_malformed_stored_pref_and_falls_back(repo):
+    # A flag-like value must never reach git argv — fall back to checked-out.
+    s = _FakeSettings({"tracked_branch": "--upload-pack=evil"})
+    assert asyncio.run(resolve_tracked_branch(s, repo)) == "master"

--- a/tests/test_switch_to_branch.py
+++ b/tests/test_switch_to_branch.py
@@ -1,0 +1,59 @@
+import asyncio
+import subprocess
+from pathlib import Path
+import pytest
+from tinyagentos.update_runner import switch_to_branch
+
+
+def _g(cwd, *a):
+    subprocess.run(["git", *a], cwd=cwd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+def _sha(cwd, ref="HEAD"):
+    return subprocess.run(["git", "rev-parse", ref], cwd=cwd, check=True, capture_output=True, text=True).stdout.strip()
+
+
+@pytest.fixture
+def remote_and_clone(tmp_path):
+    origin = tmp_path / "origin.git"
+    seed = tmp_path / "seed"; seed.mkdir()
+    _g(seed, "init", "-q"); _g(seed, "config", "user.email", "t@t"); _g(seed, "config", "user.name", "t")
+    _g(seed, "checkout", "-q", "-b", "master"); (seed / "f").write_text("m1"); _g(seed, "add", "."); _g(seed, "commit", "-qm", "m1")
+    _g(seed, "checkout", "-q", "-b", "dev"); (seed / "d").write_text("d1"); _g(seed, "add", "."); _g(seed, "commit", "-qm", "d1")
+    _g(seed, "checkout", "-q", "master")
+    subprocess.run(["git", "clone", "-q", "--bare", str(seed), str(origin)], check=True)
+    clone = tmp_path / "clone"
+    subprocess.run(["git", "clone", "-q", str(origin), str(clone)], check=True)
+    _g(clone, "config", "user.email", "t@t"); _g(clone, "config", "user.name", "t")
+    _g(clone, "checkout", "-q", "master")
+    return clone
+
+
+def test_switches_to_existing_branch(remote_and_clone):
+    clone = remote_and_clone
+    res = asyncio.run(switch_to_branch("dev", clone))
+    cur = subprocess.run(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=clone, capture_output=True, text=True).stdout.strip()
+    assert cur == "dev"
+    assert (clone / "d").exists()
+    assert res.new_sha == _sha(clone)
+
+
+def test_stashes_dirty_tree_and_tags_recovery(remote_and_clone):
+    clone = remote_and_clone
+    (clone / "f").write_text("dirty-edit")
+    res = asyncio.run(switch_to_branch("dev", clone))
+    cur = subprocess.run(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=clone, capture_output=True, text=True).stdout.strip()
+    assert cur == "dev"
+    tags = subprocess.run(["git", "tag"], cwd=clone, capture_output=True, text=True).stdout
+    assert "taos-pre-switch-" in tags
+
+
+def test_fetch_failure_is_non_destructive(tmp_path):
+    r = tmp_path / "r"; r.mkdir()
+    _g(r, "init", "-q"); _g(r, "config", "user.email", "t@t"); _g(r, "config", "user.name", "t")
+    _g(r, "checkout", "-q", "-b", "master"); (r / "f").write_text("1"); _g(r, "add", "."); _g(r, "commit", "-qm", "c1")
+    before = subprocess.run(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=r, capture_output=True, text=True).stdout.strip()
+    res = asyncio.run(switch_to_branch("dev", r))
+    after = subprocess.run(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=r, capture_output=True, text=True).stdout.strip()
+    assert after == before == "master"
+    assert "Fetch failed" in res.message or res.new_sha == res.previous_sha

--- a/tests/test_switch_to_branch.py
+++ b/tests/test_switch_to_branch.py
@@ -36,6 +36,7 @@ def test_switches_to_existing_branch(remote_and_clone):
     assert cur == "dev"
     assert (clone / "d").exists()
     assert res.new_sha == _sha(clone)
+    assert res.ok is True
 
 
 def test_stashes_dirty_tree_and_tags_recovery(remote_and_clone):
@@ -46,6 +47,10 @@ def test_stashes_dirty_tree_and_tags_recovery(remote_and_clone):
     assert cur == "dev"
     tags = subprocess.run(["git", "tag"], cwd=clone, capture_output=True, text=True).stdout
     assert "taos-pre-switch-" in tags
+    # The whole point of stashing is that the dirty edit SURVIVES the switch.
+    # Without asserting the restored content, a broken stash-pop would pass.
+    assert res.stash_restored is True
+    assert (clone / "f").read_text() == "dirty-edit"
 
 
 def test_fetch_failure_is_non_destructive(tmp_path):
@@ -56,4 +61,5 @@ def test_fetch_failure_is_non_destructive(tmp_path):
     res = asyncio.run(switch_to_branch("dev", r))
     after = subprocess.run(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=r, capture_output=True, text=True).stdout.strip()
     assert after == before == "master"
+    assert res.ok is False
     assert "Fetch failed" in res.message or res.new_sha == res.previous_sha

--- a/tests/test_update_channel_routes.py
+++ b/tests/test_update_channel_routes.py
@@ -115,3 +115,51 @@ class TestUpdateChannelRoute:
         assert saved.get("tracked_branch") == "dev"
 
         await ds.close()
+
+
+class TestUpdateCheckFollowsTrackedBranch:
+    @pytest.mark.asyncio
+    async def test_update_check_follows_tracked_branch_pref(self, client, monkeypatch):
+        """check_for_updates must resolve the tracked branch and compare against
+        origin/<that branch> — not a hard-coded master."""
+        import asyncio as _asyncio
+
+        import tinyagentos.routes.settings as s
+
+        resolve_calls = []
+        refs_seen = []
+
+        async def fake_resolve(store, project_dir):
+            resolve_calls.append(True)
+            return "my-feature"
+
+        class _FakeProc:
+            def __init__(self, out=b""):
+                self._out = out
+
+            async def communicate(self):
+                return self._out, b""
+
+        async def fake_exec(*args, **kwargs):
+            # args = ("git", <subcommand>, ...). Record any ref argument so we
+            # can assert the resolved branch flowed into the git comparison.
+            refs_seen.extend(a for a in args if isinstance(a, str))
+            return _FakeProc(b"deadbeef\n")
+
+        async def fake_strictly_ahead(project_dir, local_sha, remote_sha):
+            return False
+
+        monkeypatch.setattr(s, "resolve_tracked_branch", fake_resolve, raising=False)
+        monkeypatch.setattr(_asyncio, "create_subprocess_exec", fake_exec, raising=False)
+        monkeypatch.setattr(
+            "tinyagentos.auto_update.remote_is_strictly_ahead",
+            fake_strictly_ahead,
+            raising=False,
+        )
+
+        r = await client.get("/api/settings/update-check")
+        assert r.status_code == 200
+        assert resolve_calls, "check_for_updates did not resolve the tracked branch"
+        # The resolved branch must reach the git ref comparison.
+        assert "origin/my-feature" in refs_seen
+        assert "my-feature" in refs_seen  # git fetch origin <branch>

--- a/tests/test_update_channel_routes.py
+++ b/tests/test_update_channel_routes.py
@@ -1,0 +1,22 @@
+import pytest
+
+
+class TestBranchesRoute:
+    @pytest.mark.asyncio
+    async def test_branches_returns_list_and_current(self, client, monkeypatch):
+        import tinyagentos.routes.settings as s
+
+        async def fake_lsremote(project_dir):
+            return ["master", "dev"]
+
+        async def fake_current(store, project_dir):
+            return "master"
+
+        monkeypatch.setattr(s, "_remote_branches", fake_lsremote, raising=False)
+        monkeypatch.setattr(s, "resolve_tracked_branch", fake_current, raising=False)
+
+        r = await client.get("/api/settings/branches")
+        assert r.status_code == 200
+        body = r.json()
+        assert set(body["branches"]) == {"master", "dev"}
+        assert body["current"] == "master"

--- a/tests/test_update_channel_routes.py
+++ b/tests/test_update_channel_routes.py
@@ -1,4 +1,5 @@
 import pytest
+from tinyagentos.update_runner import UpdateResult
 
 
 class TestBranchesRoute:
@@ -20,3 +21,97 @@ class TestBranchesRoute:
         body = r.json()
         assert set(body["branches"]) == {"master", "dev"}
         assert body["current"] == "master"
+
+
+class TestUpdateChannelRoute:
+    @pytest.mark.asyncio
+    async def test_rejects_unknown_branch(self, client, monkeypatch):
+        import tinyagentos.routes.settings as s
+
+        async def fake_lsremote(project_dir):
+            return ["master", "dev"]
+
+        monkeypatch.setattr(s, "_remote_branches", fake_lsremote, raising=False)
+
+        r = await client.post("/api/settings/update-channel", json={"branch": "nonexistent"})
+        assert r.status_code == 400
+        body = r.json()
+        assert "unknown" in body["error"]
+
+    @pytest.mark.asyncio
+    async def test_noop_on_same_branch(self, client, monkeypatch):
+        import tinyagentos.routes.settings as s
+
+        switch_called = []
+
+        async def fake_lsremote(project_dir):
+            return ["master", "dev"]
+
+        async def fake_resolve(store, project_dir):
+            return "master"
+
+        async def fake_switch(branch, project_dir):
+            switch_called.append(branch)
+            return UpdateResult(previous_sha="aaa", new_sha="bbb", recovery_tag="tag1", message="ok")
+
+        monkeypatch.setattr(s, "_remote_branches", fake_lsremote, raising=False)
+        monkeypatch.setattr(s, "resolve_tracked_branch", fake_resolve, raising=False)
+        monkeypatch.setattr(s, "switch_to_branch", fake_switch, raising=False)
+
+        r = await client.post("/api/settings/update-channel", json={"branch": "master"})
+        assert r.status_code == 200
+        body = r.json()
+        assert body["status"] == "unchanged"
+        assert len(switch_called) == 0
+
+    @pytest.mark.asyncio
+    async def test_switches_and_saves_pref(self, client, app, monkeypatch, tmp_path):
+        import tinyagentos.routes.settings as s
+
+        # desktop_settings is not initialised by conftest (lifespan-only); do it here.
+        ds = app.state.desktop_settings
+        if ds._db is None:
+            await ds.init()
+
+        switch_args = []
+        snapshot_args = []
+        fake_snapshot_path = tmp_path / "pre-switch-test"
+        fake_snapshot_path.mkdir()
+
+        async def fake_lsremote(project_dir):
+            return ["master", "dev"]
+
+        async def fake_resolve(store, project_dir):
+            return "master"
+
+        def fake_snapshot(data_dir):
+            snapshot_args.append(data_dir)
+            return fake_snapshot_path
+
+        async def fake_switch(branch, project_dir):
+            switch_args.append(branch)
+            return UpdateResult(previous_sha="aaa", new_sha="bbb", recovery_tag="tag1", message="ok")
+
+        async def fake_pip_rebuild_restart(project_dir, target_sha):
+            return 0, ""
+
+        monkeypatch.setattr(s, "_remote_branches", fake_lsremote, raising=False)
+        monkeypatch.setattr(s, "resolve_tracked_branch", fake_resolve, raising=False)
+        monkeypatch.setattr(s, "snapshot_data_dir", fake_snapshot, raising=False)
+        monkeypatch.setattr(s, "switch_to_branch", fake_switch, raising=False)
+        monkeypatch.setattr(s, "_pip_rebuild_restart", fake_pip_rebuild_restart, raising=False)
+
+        r = await client.post("/api/settings/update-channel", json={"branch": "dev"})
+        assert r.status_code == 200
+        body = r.json()
+        assert body["status"] == "switching"
+        assert body["branch"] == "dev"
+        assert switch_args == ["dev"]
+        assert len(snapshot_args) == 1
+
+        # Verify the pref was persisted by reading it back from the store directly.
+        saved = await ds.get_preference("user", "auto-update")
+        assert saved is not None
+        assert saved.get("tracked_branch") == "dev"
+
+        await ds.close()

--- a/tests/test_update_channel_routes.py
+++ b/tests/test_update_channel_routes.py
@@ -39,6 +39,27 @@ class TestUpdateChannelRoute:
         assert "unknown" in body["error"]
 
     @pytest.mark.asyncio
+    async def test_rejects_flag_injection_branch(self, client, monkeypatch):
+        import tinyagentos.routes.settings as s
+
+        called = []
+
+        async def fake_lsremote(project_dir):
+            called.append(True)
+            return ["master", "dev"]
+
+        monkeypatch.setattr(s, "_remote_branches", fake_lsremote, raising=False)
+
+        r = await client.post(
+            "/api/settings/update-channel",
+            json={"branch": "--upload-pack=touch /tmp/x"},
+        )
+        assert r.status_code == 400
+        assert "invalid" in r.json()["error"]
+        # Rejected by the format guard before we ever hit the remote.
+        assert called == []
+
+    @pytest.mark.asyncio
     async def test_noop_on_same_branch(self, client, monkeypatch):
         import tinyagentos.routes.settings as s
 

--- a/tinyagentos/auto_update.py
+++ b/tinyagentos/auto_update.py
@@ -72,6 +72,20 @@ async def update_tracking_branch(project_dir: Path) -> str:
     return branch if branch and branch != "HEAD" else "master"
 
 
+async def resolve_tracked_branch(settings_store, project_dir: Path) -> str:
+    """The branch to track for updates: the user's saved ``tracked_branch``
+    preference (set via the branch selector) when present, else the
+    checked-out branch (``update_tracking_branch``)."""
+    try:
+        prefs = await settings_store.get_preference("user", PREF_NAMESPACE)
+        chosen = (prefs or {}).get("tracked_branch")
+        if chosen and isinstance(chosen, str) and chosen.strip():
+            return chosen.strip()
+    except Exception:
+        logger.warning("resolve_tracked_branch: pref read failed; using checked-out branch")
+    return await update_tracking_branch(project_dir)
+
+
 async def remote_is_strictly_ahead(project_dir: Path, current: str, remote: str) -> bool:
     """True only if ``current`` is a strict ancestor of ``remote`` — i.e. the
     remote is genuinely newer. Prevents offering an older or divergent commit
@@ -181,7 +195,7 @@ class AutoUpdateService:
     async def _probe_remote(self) -> Optional[str]:
         """Return the tip of the tracked remote branch (the branch this install
         is on), or None on failure."""
-        branch = await update_tracking_branch(self._project_dir)
+        branch = await resolve_tracked_branch(self._settings, self._project_dir)
         rc, _ = await _run(
             ["git", "fetch", "--quiet", "origin", branch], self._project_dir
         )

--- a/tinyagentos/auto_update.py
+++ b/tinyagentos/auto_update.py
@@ -11,12 +11,38 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 from pathlib import Path
 from typing import Optional
 
 import tinyagentos.github_releases as github_releases
 
 logger = logging.getLogger(__name__)
+
+# Conservative git ref-name validation. The tracked branch flows into git
+# argv (fetch/pull/rev-parse), so a value like "--upload-pack=evil" would be a
+# flag-injection (argument injection) if it reached those calls. Reject any
+# value that isn't a plain ref name: no leading '-', no whitespace/control
+# chars, none of git's forbidden ref characters (~ ^ : ? * [ \), no "..",
+# no "@{", no leading/trailing '/', no "//", no trailing ".lock"/".".
+_FORBIDDEN_REF_CHARS = set(" \t\n\r~^:?*[\\\x7f")
+
+
+def is_valid_branch_name(name: str) -> bool:
+    """True if *name* is a safe git branch/ref name to pass in argv.
+
+    Mirrors the relevant subset of ``git check-ref-format --branch`` rules.
+    Used to keep user-influenced branch values out of git flag positions.
+    """
+    if not isinstance(name, str) or not name or len(name) > 255:
+        return False
+    if name[0] == "-" or name[0] == "/" or name[-1] == "/" or name[-1] == ".":
+        return False
+    if name.endswith(".lock") or "//" in name or ".." in name or "@{" in name:
+        return False
+    if any(c in _FORBIDDEN_REF_CHARS or ord(c) < 0x20 for c in name):
+        return False
+    return True
 
 # How often to check for updates (seconds). One hour by default.
 CHECK_INTERVAL = 60 * 60
@@ -80,7 +106,14 @@ async def resolve_tracked_branch(settings_store, project_dir: Path) -> str:
         prefs = await settings_store.get_preference("user", PREF_NAMESPACE)
         chosen = (prefs or {}).get("tracked_branch")
         if chosen and isinstance(chosen, str) and chosen.strip():
-            return chosen.strip()
+            candidate = chosen.strip()
+            # Never let a malformed stored value reach git argv (flag injection).
+            if is_valid_branch_name(candidate):
+                return candidate
+            logger.warning(
+                "resolve_tracked_branch: stored tracked_branch %r is not a valid "
+                "ref name; ignoring and using the checked-out branch", candidate,
+            )
     except Exception:
         logger.warning("resolve_tracked_branch: pref read failed; using checked-out branch")
     return await update_tracking_branch(project_dir)

--- a/tinyagentos/auto_update.py
+++ b/tinyagentos/auto_update.py
@@ -229,8 +229,10 @@ class AutoUpdateService:
         """Return the tip of the tracked remote branch (the branch this install
         is on), or None on failure."""
         branch = await resolve_tracked_branch(self._settings, self._project_dir)
+        # `--` keeps `branch` in refspec position; resolve_tracked_branch also
+        # validates it (flag-injection defence in depth).
         rc, _ = await _run(
-            ["git", "fetch", "--quiet", "origin", branch], self._project_dir
+            ["git", "fetch", "--quiet", "origin", "--", branch], self._project_dir
         )
         if rc != 0:
             return None

--- a/tinyagentos/data_snapshot.py
+++ b/tinyagentos/data_snapshot.py
@@ -1,0 +1,42 @@
+"""Pre-switch backup of the data dir.
+
+Copies data/ to data-backups/pre-switch-<ts>/ before a branch switch, so a
+switch to an incompatible branch can be recovered. Excludes large/regenerable
+trees (models, workspace) and never recurses into data-backups itself.
+"""
+from __future__ import annotations
+
+import logging
+import shutil
+import time
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_EXCLUDE = {"models", "workspace", "data-backups"}
+
+
+def snapshot_data_dir(data_dir: Path) -> Optional[Path]:
+    """Copy data_dir into data-backups/pre-switch-<ts>/, skipping _EXCLUDE.
+
+    Returns the backup path, or None if data_dir doesn't exist. Best-effort:
+    per-entry copy failures are logged, not raised.
+    """
+    if not data_dir.exists():
+        return None
+    ts = time.strftime("%Y%m%dT%H%M%S", time.gmtime())
+    dest = data_dir / "data-backups" / f"pre-switch-{ts}"
+    dest.mkdir(parents=True, exist_ok=True)
+    for entry in data_dir.iterdir():
+        if entry.name in _EXCLUDE:
+            continue
+        try:
+            if entry.is_dir():
+                shutil.copytree(entry, dest / entry.name, dirs_exist_ok=True)
+            else:
+                shutil.copy2(entry, dest / entry.name)
+        except OSError as exc:
+            logger.warning("snapshot_data_dir: failed to copy %s: %s", entry.name, exc)
+    logger.info("snapshot_data_dir: backed up data/ to %s", dest)
+    return dest

--- a/tinyagentos/data_snapshot.py
+++ b/tinyagentos/data_snapshot.py
@@ -7,6 +7,7 @@ trees (models, workspace) and never recurses into data-backups itself.
 from __future__ import annotations
 
 import logging
+import os
 import shutil
 import time
 from pathlib import Path
@@ -22,20 +23,35 @@ def snapshot_data_dir(data_dir: Path) -> Optional[Path]:
 
     Returns the backup path, or None if data_dir doesn't exist. Best-effort:
     per-entry copy failures are logged, not raised.
+
+    Security: the backup holds sensitive state (auth tokens, keys, secrets DB),
+    so it is created owner-only (0o700). Symlinks are preserved as links and
+    never dereferenced, so a symlink under data/ cannot pull arbitrary files
+    outside data/ into the backup.
     """
     if not data_dir.exists():
         return None
     ts = time.strftime("%Y%m%dT%H%M%S", time.gmtime())
-    dest = data_dir / "data-backups" / f"pre-switch-{ts}"
+    backups_root = data_dir / "data-backups"
+    backups_root.mkdir(parents=True, exist_ok=True)
+    dest = backups_root / f"pre-switch-{ts}"
     dest.mkdir(parents=True, exist_ok=True)
+    for d in (backups_root, dest):
+        try:
+            os.chmod(d, 0o700)
+        except OSError:
+            pass  # non-POSIX / no perms — best effort
     for entry in data_dir.iterdir():
         if entry.name in _EXCLUDE:
             continue
         try:
-            if entry.is_dir():
-                shutil.copytree(entry, dest / entry.name, dirs_exist_ok=True)
+            if entry.is_symlink():
+                # Preserve as a link; never follow it (no arbitrary-file read).
+                os.symlink(os.readlink(entry), dest / entry.name)
+            elif entry.is_dir():
+                shutil.copytree(entry, dest / entry.name, dirs_exist_ok=True, symlinks=True)
             else:
-                shutil.copy2(entry, dest / entry.name)
+                shutil.copy2(entry, dest / entry.name, follow_symlinks=False)
         except OSError as exc:
             logger.warning("snapshot_data_dir: failed to copy %s: %s", entry.name, exc)
     logger.info("snapshot_data_dir: backed up data/ to %s", dest)

--- a/tinyagentos/data_snapshot.py
+++ b/tinyagentos/data_snapshot.py
@@ -18,6 +18,34 @@ logger = logging.getLogger(__name__)
 _EXCLUDE = {"models", "workspace", "data-backups"}
 
 
+def _harden_perms(root: Path) -> None:
+    """Recursively restrict *root* to owner-only: dirs 0o700, files 0o600.
+
+    ``copytree``/``copy2`` preserve the source modes, so without this a secret
+    copied into the backup could remain group/world-readable even though the
+    top-level backup dir is 0o700. Best-effort: per-entry failures are ignored
+    (non-POSIX / no perms). Symlinks are skipped — chmod would alter the link
+    target's permissions, not the link.
+    """
+    for dirpath, dirnames, filenames in os.walk(root):
+        for name in dirnames:
+            p = os.path.join(dirpath, name)
+            if os.path.islink(p):
+                continue
+            try:
+                os.chmod(p, 0o700)
+            except OSError:
+                pass
+        for name in filenames:
+            p = os.path.join(dirpath, name)
+            if os.path.islink(p):
+                continue
+            try:
+                os.chmod(p, 0o600)
+            except OSError:
+                pass
+
+
 def snapshot_data_dir(data_dir: Path) -> Optional[Path]:
     """Copy data_dir into data-backups/pre-switch-<ts>/, skipping _EXCLUDE.
 
@@ -54,5 +82,7 @@ def snapshot_data_dir(data_dir: Path) -> Optional[Path]:
                 shutil.copy2(entry, dest / entry.name, follow_symlinks=False)
         except OSError as exc:
             logger.warning("snapshot_data_dir: failed to copy %s: %s", entry.name, exc)
+    # Tighten copied contents — copytree/copy2 preserved their source modes.
+    _harden_perms(dest)
     logger.info("snapshot_data_dir: backed up data/ to %s", dest)
     return dest

--- a/tinyagentos/routes/settings.py
+++ b/tinyagentos/routes/settings.py
@@ -500,13 +500,13 @@ async def set_container_runtime(request: Request):
 async def check_for_updates(request: Request):
     """Check if a newer version of TinyAgentOS is available on GitHub."""
     import asyncio
-    from tinyagentos.auto_update import update_tracking_branch, remote_is_strictly_ahead
+    from tinyagentos.auto_update import remote_is_strictly_ahead
     project_dir = str(Path(__file__).parent.parent.parent)
 
-    # Track whichever branch this install is on (master on stable, dev on a
-    # dev/test box) rather than hard-coding master — otherwise a dev box is
-    # told a stale master commit is "available" and Install Update fails.
-    branch = await update_tracking_branch(project_dir)
+    # Track the user's selected branch (Updates → Advanced selector), or the
+    # checked-out branch when unset — never a hard-coded master, otherwise a
+    # dev box is told a stale master commit is "available" and Install fails.
+    branch = await resolve_tracked_branch(request.app.state.desktop_settings, Path(project_dir))
 
     # Fetch remote refs so origin/<branch> is current, then compare SHAs.
     # Parsing dry-run output is unreliable on shallow clones / no tracking branch.
@@ -719,8 +719,7 @@ async def apply_update(request: Request):
     # Git pull — pull the branch this install tracks (master on stable, dev on
     # a dev/test box). Pulling a hard-coded master onto a dev box fails ff-only
     # (dev is ahead of master) and the update silently never applies.
-    from tinyagentos.auto_update import update_tracking_branch
-    branch = await update_tracking_branch(project_dir)
+    branch = await resolve_tracked_branch(request.app.state.desktop_settings, project_dir)
     proc = await asyncio.create_subprocess_exec(
         "git", "pull", "--ff-only", "origin", branch,
         stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT,

--- a/tinyagentos/routes/settings.py
+++ b/tinyagentos/routes/settings.py
@@ -12,7 +12,10 @@ from fastapi import APIRouter, Request, UploadFile
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel
 from tinyagentos.config import AppConfig, save_config_locked, validate_config
-from tinyagentos.auto_update import resolve_tracked_branch
+from tinyagentos.auto_update import resolve_tracked_branch, PREF_NAMESPACE
+from tinyagentos.data_snapshot import snapshot_data_dir
+from tinyagentos.update_runner import switch_to_branch
+from tinyagentos.restart_orchestrator import write_pending_restart
 
 logger = logging.getLogger(__name__)
 
@@ -603,11 +606,95 @@ async def force_update_check(request: Request):
 
 
 
+async def _pip_rebuild_restart(project_dir: Path, target_sha: str) -> tuple[int, str]:
+    """Sync deps, rebuild the SPA, flag the pending restart, trigger restart.
+
+    Returns (returncode, output); non-zero means a step failed.
+    """
+    # Pip install to pick up new deps. Capture output and surface failures —
+    # silently swallowing a failed install lands users on a grey-screen the
+    # next time they restart, because the new code imports a module that's
+    # not on disk. See issue #323's sibling failure mode.
+    venv_python: Path | None = None
+    for candidate in (project_dir / ".venv" / "bin" / "pip", project_dir / "venv" / "bin" / "pip"):
+        if candidate.exists():
+            pip_cmd = str(candidate)
+            venv_python = candidate.parent / "python"
+            break
+    else:
+        pip_cmd = "pip"
+    pip_returncode, pip_output = await _run_capture(
+        [pip_cmd, "install", "-e", "."],
+        cwd=str(project_dir),
+    )
+    if pip_returncode != 0:
+        return pip_returncode, pip_output
+
+    # Import smoke test in a fresh interpreter — verifies the new code can
+    # actually load with the freshly installed deps. Without this a partial
+    # pip install (returncode 0 but a wheel quietly skipped) still grey-screens
+    # the user on restart.
+    #
+    # Walk the package tree dynamically (issue #327) so new modules added in
+    # later PRs are validated automatically without anyone remembering to
+    # update a hardcoded import list. Errors during walk_packages or import
+    # bubble up via the smoke proc's exit code.
+    if venv_python is not None and venv_python.exists():
+        smoke_script = (
+            "import importlib, pkgutil, sys, traceback\n"
+            "import tinyagentos\n"
+            "errors = []\n"
+            "for m in pkgutil.walk_packages(tinyagentos.__path__, prefix='tinyagentos.'):\n"
+            "    name = m.name\n"
+            "    # Skip optional dev/test scaffolding; stay on production code paths.\n"
+            "    if any(part in name for part in ('test', '_pycache_', '.scripts.')):\n"
+            "        continue\n"
+            "    try:\n"
+            "        importlib.import_module(name)\n"
+            "    except Exception:\n"
+            "        errors.append(name + ':\\n' + traceback.format_exc())\n"
+            "if errors:\n"
+            "    print('Import smoke FAILED for', len(errors), 'modules:\\n')\n"
+            "    print('\\n---\\n'.join(errors[:10]))\n"
+            "    sys.exit(1)\n"
+            "print('Import smoke OK')\n"
+        )
+        smoke_returncode, smoke_output = await _run_capture(
+            [str(venv_python), "-c", smoke_script],
+            cwd=str(project_dir),
+            timeout=60.0,  # imports should be fast; 60s is generous
+        )
+        if smoke_returncode != 0:
+            return smoke_returncode, smoke_output
+
+    # Force a desktop bundle rebuild on every applied update. The mtime-based
+    # staleness check in rebuild_desktop_bundle_if_stale is unreliable when
+    # static/desktop/ is committed and a PR lands source-only (no rebuilt
+    # bundle in the commit) — git pull touches both source and bundle in the
+    # same instant and the heuristic can pick the wrong winner. Force-rebuilding
+    # is the only reliable path; the cost is one ~30s npm build on Update click.
+    from tinyagentos.desktop_rebuild import rebuild_desktop_bundle_if_stale
+    rebuild_result = await rebuild_desktop_bundle_if_stale(project_dir, force=True)
+    if rebuild_result.rebuilt:
+        logger.info("Desktop rebuild: %s", rebuild_result.message)
+    if not rebuild_result.success:
+        # Update is still applied to disk, but the frontend won't be in sync
+        # until the rebuild succeeds. Surface this clearly rather than
+        # silently leaving the user with a stale UI.
+        logger.warning(
+            "Update pulled but desktop rebuild failed: %s", rebuild_result.message
+        )
+
+    if target_sha:
+        write_pending_restart(target_sha)
+
+    return 0, ""
+
+
 @router.post("/api/settings/update")
 async def apply_update(request: Request):
     """Pull latest TinyAgentOS code from GitHub."""
     import asyncio
-    from tinyagentos.restart_orchestrator import write_pending_restart
     project_dir = Path(__file__).parent.parent.parent
 
     # systemd ExecStartPre rebuilds produce new content-hashed files in
@@ -645,98 +732,6 @@ async def apply_update(request: Request):
     if proc.returncode != 0:
         return JSONResponse({"error": f"Update failed: {output}"}, status_code=500)
 
-    # Pip install to pick up new deps. Capture output and surface failures —
-    # silently swallowing a failed install lands users on a grey-screen the
-    # next time they restart, because the new code imports a module that's
-    # not on disk. See issue #323's sibling failure mode.
-    venv_python: Path | None = None
-    for candidate in (project_dir / ".venv" / "bin" / "pip", project_dir / "venv" / "bin" / "pip"):
-        if candidate.exists():
-            pip_cmd = str(candidate)
-            venv_python = candidate.parent / "python"
-            break
-    else:
-        pip_cmd = "pip"
-    pip_returncode, pip_output = await _run_capture(
-        [pip_cmd, "install", "-e", "."],
-        cwd=str(project_dir),
-    )
-    if pip_returncode != 0:
-        return JSONResponse(
-            {
-                "error": "Dependency install failed — update aborted to avoid grey-screen on restart.",
-                "git_output": output.strip(),
-                "pip_output": pip_output.strip()[-2000:],
-            },
-            status_code=500,
-        )
-
-    # Import smoke test in a fresh interpreter — verifies the new code can
-    # actually load with the freshly installed deps. Without this a partial
-    # pip install (returncode 0 but a wheel quietly skipped) still grey-screens
-    # the user on restart.
-    #
-    # Walk the package tree dynamically (issue #327) so new modules added in
-    # later PRs are validated automatically without anyone remembering to
-    # update a hardcoded import list. Errors during walk_packages or import
-    # bubble up via the smoke proc's exit code.
-    if venv_python is not None and venv_python.exists():
-        smoke_script = (
-            "import importlib, pkgutil, sys, traceback\n"
-            "import tinyagentos\n"
-            "errors = []\n"
-            "for m in pkgutil.walk_packages(tinyagentos.__path__, prefix='tinyagentos.'):\n"
-            "    name = m.name\n"
-            "    # Skip optional dev/test scaffolding; stay on production code paths.\n"
-            "    if any(part in name for part in ('test', '_pycache_', '.scripts.')):\n"
-            "        continue\n"
-            "    try:\n"
-            "        importlib.import_module(name)\n"
-            "    except Exception:\n"
-            "        errors.append(name + ':\\n' + traceback.format_exc())\n"
-            "if errors:\n"
-            "    print('Import smoke FAILED for', len(errors), 'modules:\\n')\n"
-            "    print('\\n---\\n'.join(errors[:10]))\n"
-            "    sys.exit(1)\n"
-            "print('Import smoke OK')\n"
-        )
-        smoke_returncode, smoke_output = await _run_capture(
-            [str(venv_python), "-c", smoke_script],
-            cwd=str(project_dir),
-            timeout=60.0,  # imports should be fast; 60s is generous
-        )
-        if smoke_returncode != 0:
-            return JSONResponse(
-                {
-                    "error": (
-                        "Update applied to disk but post-install import test failed "
-                        "— restart would grey-screen. Fix the import error before restarting."
-                    ),
-                    "git_output": output.strip(),
-                    "pip_output": pip_output.strip()[-2000:],
-                    "import_error": smoke_output.strip()[-2000:],
-                },
-                status_code=500,
-            )
-
-    # Force a desktop bundle rebuild on every applied update. The mtime-based
-    # staleness check in rebuild_desktop_bundle_if_stale is unreliable when
-    # static/desktop/ is committed and a PR lands source-only (no rebuilt
-    # bundle in the commit) — git pull touches both source and bundle in the
-    # same instant and the heuristic can pick the wrong winner. Force-rebuilding
-    # is the only reliable path; the cost is one ~30s npm build on Update click.
-    from tinyagentos.desktop_rebuild import rebuild_desktop_bundle_if_stale
-    rebuild_result = await rebuild_desktop_bundle_if_stale(project_dir, force=True)
-    if rebuild_result.rebuilt:
-        logger.info("Desktop rebuild: %s", rebuild_result.message)
-    if not rebuild_result.success:
-        # Update is still applied to disk, but the frontend won't be in sync
-        # until the rebuild succeeds. Surface this clearly rather than
-        # silently leaving the user with a stale UI.
-        logger.warning(
-            "Update pulled but desktop rebuild failed: %s", rebuild_result.message
-        )
-
     # Record the new SHA so the restart modal can confirm the update was applied
     # and the Updates section can show the pending-restart banner.
     sha_proc = await asyncio.create_subprocess_exec(
@@ -746,8 +741,17 @@ async def apply_update(request: Request):
     )
     sha_out, _ = await sha_proc.communicate()
     new_sha = sha_out.decode().strip() if sha_out else ""
-    if new_sha:
-        write_pending_restart(new_sha)
+
+    rc, out = await _pip_rebuild_restart(project_dir, new_sha)
+    if rc != 0:
+        return JSONResponse(
+            {
+                "error": "Dependency install failed — update aborted to avoid grey-screen on restart.",
+                "git_output": output.strip(),
+                "pip_output": out.strip()[-2000:],
+            },
+            status_code=500,
+        )
 
     # Always restart after a successful update.
     import asyncio as _asyncio
@@ -808,3 +812,54 @@ async def list_branches(request: Request):
     branches = await _remote_branches(project_dir)
     current = await resolve_tracked_branch(request.app.state.desktop_settings, Path(project_dir))
     return {"branches": branches, "current": current}
+
+
+class UpdateChannel(BaseModel):
+    branch: str
+
+
+@router.post("/api/settings/update-channel")
+async def set_update_channel(request: Request, body: UpdateChannel):
+    """Switch the install to a different branch: snapshot data/, git switch,
+    persist the tracked_branch pref, then pip/rebuild/restart to apply."""
+    project_dir = Path(__file__).parent.parent.parent
+    branch = body.branch.strip()
+
+    available = await _remote_branches(str(project_dir))
+    if branch not in available:
+        return JSONResponse({"error": f"unknown branch '{branch}'"}, status_code=400)
+
+    store = request.app.state.desktop_settings
+    current = await resolve_tracked_branch(store, project_dir)
+    if branch == current:
+        return {"status": "unchanged", "branch": branch}
+
+    data_dir = request.app.state.config_path.parent
+    snapshot_path = snapshot_data_dir(data_dir)
+
+    result = await switch_to_branch(branch, project_dir)
+    if result.new_sha == result.previous_sha and "Fetch failed" in result.message:
+        return JSONResponse({"error": result.message}, status_code=500)
+
+    prefs = await store.get_preference("user", PREF_NAMESPACE) or {}
+    prefs["tracked_branch"] = branch
+    await store.save_preference("user", PREF_NAMESPACE, prefs)
+
+    rc, out = await _pip_rebuild_restart(project_dir, result.new_sha)
+    if rc != 0:
+        return JSONResponse(
+            {"error": f"Switched to {branch} but rebuild failed: {out[:300]}",
+             "snapshot": str(snapshot_path) if snapshot_path else None},
+            status_code=500,
+        )
+
+    import asyncio as _asyncio
+    from tinyagentos.routes.system import _do_restart
+    _asyncio.create_task(_do_restart(request.app.state))
+    return {
+        "status": "switching",
+        "branch": branch,
+        "snapshot": str(snapshot_path) if snapshot_path else None,
+        "recovery_tag": result.recovery_tag,
+        "message": result.message,
+    }

--- a/tinyagentos/routes/settings.py
+++ b/tinyagentos/routes/settings.py
@@ -12,7 +12,7 @@ from fastapi import APIRouter, Request, UploadFile
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel
 from tinyagentos.config import AppConfig, save_config_locked, validate_config
-from tinyagentos.auto_update import resolve_tracked_branch, PREF_NAMESPACE
+from tinyagentos.auto_update import resolve_tracked_branch, is_valid_branch_name, PREF_NAMESPACE
 from tinyagentos.data_snapshot import snapshot_data_dir
 from tinyagentos.update_runner import switch_to_branch
 from tinyagentos.restart_orchestrator import write_pending_restart
@@ -511,7 +511,9 @@ async def check_for_updates(request: Request):
     # Fetch remote refs so origin/<branch> is current, then compare SHAs.
     # Parsing dry-run output is unreliable on shallow clones / no tracking branch.
     fetch_proc = await asyncio.create_subprocess_exec(
-        "git", "fetch", "origin", branch,
+        # `--` forces `branch` to be read as a refspec, never an option, even
+        # though resolve_tracked_branch already validates it (defence in depth).
+        "git", "fetch", "origin", "--", branch,
         stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL,
         cwd=project_dir,
     )
@@ -721,7 +723,9 @@ async def apply_update(request: Request):
     # (dev is ahead of master) and the update silently never applies.
     branch = await resolve_tracked_branch(request.app.state.desktop_settings, project_dir)
     proc = await asyncio.create_subprocess_exec(
-        "git", "pull", "--ff-only", "origin", branch,
+        # `--` forces `branch` to be a refspec, never an option (flag-injection
+        # defence); resolve_tracked_branch also validates it.
+        "git", "pull", "--ff-only", "origin", "--", branch,
         stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT,
         cwd=str(project_dir),
     )
@@ -823,6 +827,11 @@ async def set_update_channel(request: Request, body: UpdateChannel):
     persist the tracked_branch pref, then pip/rebuild/restart to apply."""
     project_dir = Path(__file__).parent.parent.parent
     branch = body.branch.strip()
+
+    # Reject anything that isn't a plain ref name before it reaches git argv
+    # (flag-injection defence) — independent of the remote-membership check.
+    if not is_valid_branch_name(branch):
+        return JSONResponse({"error": f"invalid branch name '{branch}'"}, status_code=400)
 
     available = await _remote_branches(str(project_dir))
     if branch not in available:

--- a/tinyagentos/routes/settings.py
+++ b/tinyagentos/routes/settings.py
@@ -12,6 +12,7 @@ from fastapi import APIRouter, Request, UploadFile
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel
 from tinyagentos.config import AppConfig, save_config_locked, validate_config
+from tinyagentos.auto_update import resolve_tracked_branch
 
 logger = logging.getLogger(__name__)
 
@@ -786,3 +787,24 @@ async def rebuild_frontend(request: Request):
         "status": "rebuilt",
         "message": "Desktop bundle rebuilt. Hard-refresh the browser to see new components.",
     }
+
+
+async def _remote_branches(project_dir: str) -> list[str]:
+    """Branch names available on origin, via git ls-remote --heads."""
+    rc, out = await _run_capture(["git", "ls-remote", "--heads", "origin"], cwd=project_dir, timeout=30.0)
+    if rc != 0:
+        return []
+    names = []
+    for line in out.splitlines():
+        if "refs/heads/" in line:
+            names.append(line.split("refs/heads/", 1)[1].strip())
+    return sorted(set(n for n in names if n))
+
+
+@router.get("/api/settings/branches")
+async def list_branches(request: Request):
+    """List branches available on origin + the one this install tracks."""
+    project_dir = str(Path(__file__).parent.parent.parent)
+    branches = await _remote_branches(project_dir)
+    current = await resolve_tracked_branch(request.app.state.desktop_settings, Path(project_dir))
+    return {"branches": branches, "current": current}

--- a/tinyagentos/routes/settings.py
+++ b/tinyagentos/routes/settings.py
@@ -846,7 +846,10 @@ async def set_update_channel(request: Request, body: UpdateChannel):
     snapshot_path = snapshot_data_dir(data_dir)
 
     result = await switch_to_branch(branch, project_dir)
-    if result.new_sha == result.previous_sha and "Fetch failed" in result.message:
+    # switch_to_branch sets ok=False (and performs no destructive change) on any
+    # failed step — fetch, stash, checkout. Surface it rather than proceeding to
+    # rebuild/restart on a branch that never actually switched.
+    if not result.ok:
         return JSONResponse({"error": result.message}, status_code=500)
 
     prefs = await store.get_preference("user", PREF_NAMESPACE) or {}
@@ -863,7 +866,11 @@ async def set_update_channel(request: Request, body: UpdateChannel):
 
     import asyncio as _asyncio
     from tinyagentos.routes.system import _do_restart
-    _asyncio.create_task(_do_restart(request.app.state))
+    # Hold a reference so the task isn't garbage-collected before it runs
+    # (asyncio keeps only weak refs to tasks) — otherwise the restart can drop.
+    request.app.state.update_channel_restart_task = _asyncio.create_task(
+        _do_restart(request.app.state)
+    )
     return {
         "status": "switching",
         "branch": branch,

--- a/tinyagentos/update_runner.py
+++ b/tinyagentos/update_runner.py
@@ -33,6 +33,7 @@ class UpdateResult:
     stash_restored: bool = False
     branch_tag: Optional[str] = None
     message: str = ""
+    ok: bool = True  # False when a step failed and no (or partial) switch happened
 
 
 async def _run(args: list[str], cwd: Path) -> tuple[int, str]:
@@ -170,7 +171,7 @@ async def switch_to_branch(branch: str, project_dir: Path) -> UpdateResult:
     # that actually runs git, so it validates as well (defence in depth).
     from tinyagentos.auto_update import is_valid_branch_name
     if not is_valid_branch_name(branch):
-        return UpdateResult(previous_sha="", new_sha="",
+        return UpdateResult(previous_sha="", new_sha="", ok=False,
                             message=f"Refused to switch: invalid branch name {branch!r}.")
 
     ts = int(time.time())
@@ -180,7 +181,7 @@ async def switch_to_branch(branch: str, project_dir: Path) -> UpdateResult:
     rc, out = await _run(["git", "fetch", "origin", "--", branch], project_dir)
     if rc != 0:
         logger.warning("update_runner: fetch failed: %s", out[:500])
-        return UpdateResult(previous_sha="", new_sha="",
+        return UpdateResult(previous_sha="", new_sha="", ok=False,
                             message=f"Fetch failed — no changes applied. ({out.strip()[:200]})")
 
     _, sha_out = await _run(["git", "rev-parse", "HEAD"], project_dir)
@@ -198,10 +199,38 @@ async def switch_to_branch(branch: str, project_dir: Path) -> UpdateResult:
 
     stash_msg = f"taos-switch-{ts}"
     if dirty:
-        await _run(["git", "stash", "push", "-u", "-m", stash_msg], project_dir)
+        rc_stash, stash_out = await _run(
+            ["git", "stash", "push", "-u", "-m", stash_msg], project_dir
+        )
+        # A failed stash must NOT set stash_ref — otherwise the later `stash pop`
+        # would apply an unrelated older stash. Abort before anything
+        # destructive so the working tree is left exactly as we found it.
+        if rc_stash != 0:
+            logger.warning("update_runner: stash failed: %s", stash_out[:300])
+            result.ok = False
+            result.message = (
+                f"Could not stash local changes — no switch performed. "
+                f"({stash_out.strip()[:200]})"
+            )
+            return result
         result.stash_ref = "stash@{0}"
 
-    await _run(["git", "checkout", "-B", branch, f"origin/{branch}"], project_dir)
+    rc_co, co_out = await _run(
+        ["git", "checkout", "-B", branch, f"origin/{branch}"], project_dir
+    )
+    # A failed checkout must NOT fall through to merge/reset — a hard reset would
+    # rewrite the CURRENT branch to origin/<target>. Restore the stash and bail.
+    if rc_co != 0:
+        logger.warning("update_runner: checkout failed: %s", co_out[:300])
+        if result.stash_ref:
+            rc_pop, _ = await _run(["git", "stash", "pop"], project_dir)
+            result.stash_restored = rc_pop == 0
+        result.ok = False
+        result.message = (
+            f"Checkout to {branch} failed — no switch performed. "
+            f"({co_out.strip()[:200]})"
+        )
+        return result
 
     rc_merge, _ = await _run(["git", "merge", "--ff-only", f"origin/{branch}"], project_dir)
     if rc_merge != 0:

--- a/tinyagentos/update_runner.py
+++ b/tinyagentos/update_runner.py
@@ -165,10 +165,19 @@ async def switch_to_branch(branch: str, project_dir: Path) -> UpdateResult:
     tracking branch if needed), ff-merges or hard-resets to origin/<branch>
     (tagging divergence), then restores the stash best-effort.
     """
+    # Guard against flag-injection: `branch` reaches git argv (fetch/checkout)
+    # and `origin/<branch>` refs. Callers validate too, but this is the unit
+    # that actually runs git, so it validates as well (defence in depth).
+    from tinyagentos.auto_update import is_valid_branch_name
+    if not is_valid_branch_name(branch):
+        return UpdateResult(previous_sha="", new_sha="",
+                            message=f"Refused to switch: invalid branch name {branch!r}.")
+
     ts = int(time.time())
 
     logger.info("update_runner: fetching origin/%s", branch)
-    rc, out = await _run(["git", "fetch", "origin", branch], project_dir)
+    # `--` forces `branch` to be read as a refspec, never an option.
+    rc, out = await _run(["git", "fetch", "origin", "--", branch], project_dir)
     if rc != 0:
         logger.warning("update_runner: fetch failed: %s", out[:500])
         return UpdateResult(previous_sha="", new_sha="",

--- a/tinyagentos/update_runner.py
+++ b/tinyagentos/update_runner.py
@@ -155,3 +155,62 @@ async def update_to_master(project_dir: Path) -> UpdateResult:
     result.message = " ".join(parts)
     logger.info("update_runner: done — %s", result.message)
     return result
+
+
+async def switch_to_branch(branch: str, project_dir: Path) -> UpdateResult:
+    """Switch the install to origin/<branch> safely.
+
+    Fetches the branch (bails non-destructively on failure), tags the current
+    tip for recovery, stashes a dirty tree, checks out (creating a local
+    tracking branch if needed), ff-merges or hard-resets to origin/<branch>
+    (tagging divergence), then restores the stash best-effort.
+    """
+    ts = int(time.time())
+
+    logger.info("update_runner: fetching origin/%s", branch)
+    rc, out = await _run(["git", "fetch", "origin", branch], project_dir)
+    if rc != 0:
+        logger.warning("update_runner: fetch failed: %s", out[:500])
+        return UpdateResult(previous_sha="", new_sha="",
+                            message=f"Fetch failed — no changes applied. ({out.strip()[:200]})")
+
+    _, sha_out = await _run(["git", "rev-parse", "HEAD"], project_dir)
+    current_sha = sha_out.strip()
+    short_sha = current_sha[:7]
+
+    _, status_out = await _run(["git", "status", "--porcelain", "-u"], project_dir)
+    dirty = bool(status_out.strip())
+
+    result = UpdateResult(previous_sha=current_sha, new_sha=current_sha)
+
+    recovery_tag = f"taos-pre-switch-{short_sha}-{ts}"
+    await _run(["git", "tag", recovery_tag, "HEAD"], project_dir)
+    result.recovery_tag = recovery_tag
+
+    stash_msg = f"taos-switch-{ts}"
+    if dirty:
+        await _run(["git", "stash", "push", "-u", "-m", stash_msg], project_dir)
+        result.stash_ref = "stash@{0}"
+
+    await _run(["git", "checkout", "-B", branch, f"origin/{branch}"], project_dir)
+
+    rc_merge, _ = await _run(["git", "merge", "--ff-only", f"origin/{branch}"], project_dir)
+    if rc_merge != 0:
+        await _run(["git", "reset", "--hard", f"origin/{branch}"], project_dir)
+
+    if result.stash_ref:
+        rc_pop, pop_out = await _run(["git", "stash", "pop"], project_dir)
+        if rc_pop == 0:
+            result.stash_restored = True
+        else:
+            logger.warning("update_runner: stash pop conflicts — left in place. %s", pop_out[:300])
+
+    _, new_sha_out = await _run(["git", "rev-parse", "HEAD"], project_dir)
+    result.new_sha = new_sha_out.strip()
+    result.message = f"Switched to {branch} ({result.previous_sha[:7]} -> {result.new_sha[:7]})."
+    if result.recovery_tag:
+        result.message += f" Previous tip saved as tag '{result.recovery_tag}'."
+    if result.stash_ref and not result.stash_restored:
+        result.message += f" Local changes preserved in stash ('{stash_msg}')."
+    logger.info("update_runner: %s", result.message)
+    return result


### PR DESCRIPTION
## What

Adds an **Advanced → Branch** selector to Settings → Updates, letting the user pick which branch/release-channel taOS tracks and switch to it safely from the UI. Closes #562.

Builds on the #560 updater fix (the updater now tracks the checked-out branch instead of a hard-coded `origin/master`).

## How it works

- **Resolve tracked branch** — a new `tracked_branch` preference (`auto-update` namespace) is the source of truth; `resolve_tracked_branch()` reads it and falls back to the checked-out branch when unset. `update-check` and `apply_update` both follow it now (no more hard-coded master).
- **`GET /api/settings/branches`** — live `git ls-remote` branch list + the currently tracked branch.
- **`POST /api/settings/update-channel`** — validates the branch, **snapshots `data/`** (auth/keys/secrets) before touching anything, switches via `switch_to_branch()`, saves the pref, then pip/rebuild/restart. No-ops when already on the target branch.
- **`switch_to_branch()`** — safe git switch with a recovery tag + stash, ff-merge-or-reset, stash restore (generalised from the previously-dead `update_to_master` recovery logic).
- **`snapshot_data_dir()`** — backs up `data/` to a timestamped dir (`0o700`, symlink-safe, excludes models/workspace/backups) so a downgrade can't silently destroy state.
- **UI** — collapsed-by-default Advanced disclosure with a branch `<select>`, a "Switch branch" button, a confirm dialog warning about the data backup + downgrade risk, and the existing `RestartProgressModal` for apply.

## Safety

The switch is gated behind an Advanced toggle + explicit confirm, always snapshots `data/` first, and tags the pre-switch SHA for recovery. Switching to an older branch is a real downgrade — the confirm dialog says so.

## Tests

- `tests/test_resolve_tracked_branch.py`, `tests/test_switch_to_branch.py`, `tests/test_data_snapshot.py`, `tests/test_update_channel_routes.py` (branches list, validation, no-op, switch+persist, and update-check follows the tracked branch)
- `desktop/src/apps/SettingsApp/UpdatesPanel.test.tsx`
- Full backend regression over the update/settings surface: 207 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Advanced settings panel added for selecting and switching between different taOS branches.
  * Pre-switch data backup and confirmation dialog implemented before branch changes take effect.

* **Tests**
  * Comprehensive test coverage added for branch selection UI, data snapshot backups, and update channel API operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->