### PR TITLE
fix(browser): blank page area in mobile/PWA layout

### DIFF
--- a/desktop/src/apps/BrowserApp/BrowserApp.test.tsx
+++ b/desktop/src/apps/BrowserApp/BrowserApp.test.tsx
@@ -4,6 +4,11 @@ import { BrowserApp } from "./BrowserApp";
 import { useBrowserStore } from "@/stores/browser-store";
 import { useProcessStore } from "@/stores/process-store";
 
+vi.mock("@/hooks/use-is-mobile", () => ({
+  useIsMobile: vi.fn(() => false),
+}));
+import { useIsMobile } from "@/hooks/use-is-mobile";
+
 const TEST_WINDOW_ID = "win-test";
 
 const originalFetch = global.fetch;
@@ -56,6 +61,31 @@ describe("BrowserApp — composition", () => {
     render(<BrowserApp windowId={TEST_WINDOW_ID} />);
     const win = useBrowserStore.getState().getWindow(TEST_WINDOW_ID);
     expect(win?.profileId).toBe("work"); // Existing window preserved, NOT overwritten with "personal"
+  });
+});
+
+describe("BrowserApp — mobile layout", () => {
+  beforeEach(() => {
+    vi.mocked(useIsMobile).mockReturnValue(true);
+  });
+  afterEach(() => {
+    vi.mocked(useIsMobile).mockReturnValue(false);
+  });
+
+  it("renders the iframe inside a flex container so TabRenderer fills height", () => {
+    // Regression: the mobile content wrapper must be `display:flex`, otherwise
+    // TabRenderer's `flex flex-1` root collapses to 0 height and the page area
+    // renders blank on mobile/PWA.
+    const { container } = render(<BrowserApp windowId={TEST_WINDOW_ID} />);
+    const iframe = container.querySelector("iframe");
+    expect(iframe).toBeTruthy();
+
+    // The content wrapper holds TabRenderer (`flex flex-1` root). It is the
+    // div that is both `flex-1 relative` and the parent of TabRenderer's root.
+    const wrapper = container.querySelector(".flex-1.relative.overflow-hidden");
+    expect(wrapper).toBeTruthy();
+    // Must be a flex container so TabRenderer's `flex-1` root fills the height.
+    expect(wrapper?.classList.contains("flex")).toBe(true);
   });
 });
 

--- a/desktop/src/apps/BrowserApp/BrowserApp.tsx
+++ b/desktop/src/apps/BrowserApp/BrowserApp.tsx
@@ -100,7 +100,12 @@ export function BrowserApp({ windowId }: BrowserAppProps) {
           />
         )}
 
-        <div className="flex-1 relative overflow-hidden">
+        {/* `flex` is required: TabRenderer's root is `flex flex-1` and only
+            grows to fill height when its parent is itself a flex container.
+            Without it the renderer collapses to 0 height and the page area is
+            blank (the desktop layout mounts TabRenderer directly in the column
+            flex root, so it doesn't hit this). */}
+        <div className="flex flex-1 relative overflow-hidden">
           <TabRenderer windowId={windowId} />
           {tabOverviewOpen && (
             <TabOverview


### PR DESCRIPTION
## Problem

On mobile / installed PWA, the Browser app showed a **blank page area** — the address bar worked (e.g. "Google.com") but no page content rendered. Desktop was unaffected.

## Cause

The mobile layout wrapped `TabRenderer` in a plain `flex-1 relative overflow-hidden` div. `TabRenderer`'s root is `flex flex-1`, which only grows to fill height when its **parent is itself a flex container**. The wrapper wasn't one, so the renderer collapsed to 0 height. The tab iframe is absolutely positioned (`inset-0`), so with a 0-height ancestor it had nothing to fill — hence the blank area.

The desktop layout mounts `TabRenderer` directly inside the column flex root, so it never hit this.

## Fix

Add `flex` to the mobile content wrapper so `TabRenderer` stretches to the available height. One class, no behaviour change on desktop.

## Test

`BrowserApp.test.tsx` gains a mobile-layout case (mocks `useIsMobile → true`) asserting the content wrapper holding the iframe is a flex container. Pre-fix it fails; post-fix it passes. Full BrowserApp suite: 10 passed.