### PR TITLE
fix(browser): proxy 405 on form POST (cookie consent, search, login)

### DIFF
--- a/tests/routes/desktop_browser/test_proxy_post.py
+++ b/tests/routes/desktop_browser/test_proxy_post.py
@@ -1,0 +1,121 @@
+"""Proxy POST support — form submissions (cookie consent, search, login).
+
+The proxy was GET-only, so any form POST through it returned 405
+("Method Not Allowed"). These tests cover forwarding the request method +
+body to upstream and the redirect method-downgrade rules.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+import respx
+from httpx import Response
+
+_SSRF_PATCH = patch(
+    "tinyagentos.routes.desktop_browser.ssrf.socket.getaddrinfo",
+    return_value=[(2, 1, 6, "", ("93.184.216.34", 0))],
+)
+
+
+@pytest.mark.asyncio
+class TestProxyPost:
+    @respx.mock
+    async def test_forwards_post_body_to_upstream(self, client):
+        route = respx.post("http://example.com/submit").mock(
+            return_value=Response(200, content=b"<html><body>ok</body></html>",
+                                  headers={"content-type": "text/html"}),
+        )
+        with _SSRF_PATCH:
+            resp = await client.post(
+                "/api/desktop/browser/proxy",
+                params={"profile_id": "personal", "url": "http://example.com/submit"},
+                content=b"consent=all&gl=GB",
+                headers={"content-type": "application/x-www-form-urlencoded"},
+            )
+
+        assert resp.status_code == 200
+        assert route.called
+        sent = route.calls.last.request
+        assert sent.method == "POST"
+        assert sent.content == b"consent=all&gl=GB"
+        assert sent.headers.get("content-type") == "application/x-www-form-urlencoded"
+
+    @respx.mock
+    async def test_post_303_redirect_downgrades_to_get(self, client):
+        # 303 See Other → the next hop must be a GET with no body (HTTP spec).
+        post_route = respx.post("http://example.com/submit").mock(
+            return_value=Response(303, headers={"location": "http://example.com/done"}),
+        )
+        get_route = respx.get("http://example.com/done").mock(
+            return_value=Response(200, content=b"<html><body>done</body></html>",
+                                  headers={"content-type": "text/html"}),
+        )
+        with _SSRF_PATCH:
+            resp = await client.post(
+                "/api/desktop/browser/proxy",
+                params={"profile_id": "personal", "url": "http://example.com/submit"},
+                content=b"consent=all",
+                headers={"content-type": "application/x-www-form-urlencoded"},
+            )
+
+        assert resp.status_code == 200
+        assert post_route.called
+        assert get_route.called
+        # The redirect hop dropped the body and used GET.
+        followed = get_route.calls.last.request
+        assert followed.method == "GET"
+        assert followed.content == b""
+
+    @respx.mock
+    async def test_post_307_preserves_method_and_body(self, client):
+        # 307 Temporary Redirect → method + body preserved.
+        first = respx.post("http://example.com/submit").mock(
+            return_value=Response(307, headers={"location": "http://example.com/relay"}),
+        )
+        second = respx.post("http://example.com/relay").mock(
+            return_value=Response(200, content=b"<html><body>relayed</body></html>",
+                                  headers={"content-type": "text/html"}),
+        )
+        with _SSRF_PATCH:
+            resp = await client.post(
+                "/api/desktop/browser/proxy",
+                params={"profile_id": "personal", "url": "http://example.com/submit"},
+                content=b"q=keep",
+                headers={"content-type": "application/x-www-form-urlencoded"},
+            )
+
+        assert resp.status_code == 200
+        assert first.called and second.called
+        relayed = second.calls.last.request
+        assert relayed.method == "POST"
+        assert relayed.content == b"q=keep"
+
+    @respx.mock
+    async def test_oversize_post_body_rejected(self, client):
+        respx.post("http://example.com/submit").mock(
+            return_value=Response(200, content=b"ok"),
+        )
+        big = b"x" * (10 * 1024 * 1024 + 1)  # just over the 10 MB cap
+        with _SSRF_PATCH:
+            resp = await client.post(
+                "/api/desktop/browser/proxy",
+                params={"profile_id": "personal", "url": "http://example.com/submit"},
+                content=big,
+                headers={"content-type": "application/octet-stream"},
+            )
+        assert resp.status_code == 413
+
+    @respx.mock
+    async def test_get_still_works(self, client):
+        # Regression: GET path unchanged.
+        respx.get("http://example.com/page").mock(
+            return_value=Response(200, content=b"<html><body>g</body></html>",
+                                  headers={"content-type": "text/html"}),
+        )
+        with _SSRF_PATCH:
+            resp = await client.get(
+                "/api/desktop/browser/proxy",
+                params={"profile_id": "personal", "url": "http://example.com/page"},
+            )
+        assert resp.status_code == 200

--- a/tinyagentos/routes/desktop_browser/proxy.py
+++ b/tinyagentos/routes/desktop_browser/proxy.py
@@ -56,6 +56,11 @@ _MAX_REDIRECTS = 5
 _FETCH_TIMEOUT = 15.0   # seconds — total deadline including all redirect hops
 _HOP_TIMEOUT = 5.0      # seconds — per-operation (connect + read) limit per hop
 _MAX_RESPONSE_BYTES = 10 * 1024 * 1024  # 10 MB hard cap
+_MAX_REQUEST_BYTES = 10 * 1024 * 1024   # 10 MB cap on forwarded request bodies (POST forms/uploads)
+# Request headers we forward to upstream for non-GET methods. Only the content
+# framing — never the client's cookies (we use the server-side jar), Host,
+# auth, or other ambient headers, which could leak or be abused.
+_FORWARD_REQUEST_HEADERS = frozenset({"content-type"})
 
 # Headers we strip from upstream responses before returning to the client.
 # `content-type` is stripped here and re-set from `media_type` on the
@@ -166,7 +171,7 @@ def _strip_port(host_header: str) -> str:
     return host.rsplit(":", 1)[0] if ":" in host else host
 
 
-@router.get("/api/desktop/browser/proxy")
+@router.api_route("/api/desktop/browser/proxy", methods=["GET", "POST"])
 async def proxy_get(
     profile_id: str,
     url: str,
@@ -174,10 +179,28 @@ async def proxy_get(
     tab_id: str | None = None,
     current_user: dict[str, Any] = Depends(get_current_user),
 ):
-    """Real proxy fetch — replaces PR 2's 501 stub."""
+    """Real proxy fetch. Handles GET and POST (form submissions — cookie
+    consent, search, login — which the rewriter routes here as POSTs)."""
     user_id = str(current_user.get("id") or "")
     if not user_id:
         return JSONResponse({"error": "session has no user id"}, status_code=401)
+
+    # Capture the request method + body so form POSTs reach upstream. GET/HEAD
+    # carry no body. The body is size-capped before we buffer the whole thing.
+    method = request.method.upper()
+    req_body: bytes = b""
+    fwd_headers: dict[str, str] = {}
+    if method not in ("GET", "HEAD"):
+        # Reject oversize via Content-Length when present (cheap, before read).
+        clen = request.headers.get("content-length")
+        if clen and clen.isdigit() and int(clen) > _MAX_REQUEST_BYTES:
+            return JSONResponse({"error": "request body too large"}, status_code=413)
+        req_body = await request.body()
+        if len(req_body) > _MAX_REQUEST_BYTES:
+            return JSONResponse({"error": "request body too large"}, status_code=413)
+        for hk, hv in request.headers.items():
+            if hk.lower() in _FORWARD_REQUEST_HEADERS:
+                fwd_headers[hk] = hv
 
     # Bootstrap default profiles (idempotent — safe per-request)
     browser_store = request.app.state.browser_store
@@ -215,6 +238,10 @@ async def proxy_get(
 
     async def _fetch_with_redirects() -> httpx.Response | None:
         nonlocal current_url
+        # Method + body for the current hop. Redirects may downgrade these
+        # (see the 3xx handling below). Start from the client's request.
+        hop_method = method
+        hop_body = req_body
         _resp: httpx.Response | None = None
         async with httpx.AsyncClient(
             follow_redirects=False, timeout=_HOP_TIMEOUT,
@@ -226,8 +253,14 @@ async def proxy_get(
                     cookie_store, user_id=user_id, profile_id=profile_id, host=host,
                 )
 
+                send_body = hop_body if hop_method not in ("GET", "HEAD") else None
                 try:
-                    _resp = await http.get(current_url, cookies=jar)
+                    _resp = await http.request(
+                        hop_method, current_url,
+                        cookies=jar,
+                        content=send_body,
+                        headers=fwd_headers if send_body is not None else None,
+                    )
                 except httpx.HTTPError as e:
                     _logger.info("browser proxy fetch error: err=%s", e)
                     return None
@@ -253,6 +286,12 @@ async def proxy_get(
                         )
                         _ssrf_blocked_url.append(next_url)
                         return None
+                    # Method semantics on redirect (mirrors browsers/RFC 7231):
+                    # 301/302/303 downgrade a non-GET to GET and drop the body;
+                    # 307/308 preserve the method and body.
+                    if _resp.status_code in (301, 302, 303) and hop_method != "GET":
+                        hop_method = "GET"
+                        hop_body = b""
                     current_url = next_url
                     continue
 


### PR DESCRIPTION
## Problem

In the mobile/desktop Browser, submitting any form through the proxy — e.g. clicking **"Accept all"** on a cookie-consent banner, a search, or a login — rendered `{"detail":"Method Not Allowed"}`. (Found right after the mobile blank-page fix #565: the page now renders, exposing this next layer.)

## Cause

`proxy_get` was registered **GET-only** (`@router.get`). The HTML rewriter correctly rewrites form `action`s through the proxy and preserves `method=POST`, and the CSP `form-action 'self'` keeps the POST on the proxy origin — so the form **reaches** the proxy, but the route rejects the method → 405. The proxy-origin (port 6970) re-registers the route from `route.methods`, so it inherited the GET-only restriction too.

## Fix

- `@router.api_route(..., methods=["GET", "POST"])` so both the main app and the re-registered proxy-origin route accept POST.
- Forward the request **method + body + content-type** to upstream. Only `content-type` is forwarded — never the client's cookies (we use the server-side jar), Host, or auth headers.
- **Body cap 10 MB**: Content-Length fast-path before buffering, plus a post-read check → `413`.
- **Redirect method semantics** (mirrors browsers / RFC 7231): `301/302/303` downgrade a non-GET to GET and drop the body; `307/308` preserve method + body. The per-hop SSRF re-check is unchanged.
- GET path untouched.

## Tests

`tests/routes/desktop_browser/test_proxy_post.py`: POST body forwarding, 303→GET downgrade, 307 preserve method+body, oversize→413, GET regression. Full `desktop_browser` suite: 565 passed.

## Notes

The proxy is the default browsing tier; this is needed regardless of the planned escalate-to-real-Chromium path. SSRF gating, cookie-jar handling, and the response pipeline are all unchanged — this only adds the request-direction method/body forwarding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Desktop browser proxy endpoint now accepts and forwards POST requests to upstream servers.
  * Implements proper HTTP redirect handling: 303 responses downgrade POST to GET, while 307 responses preserve the POST method and body.
  * Enforces a 10MB size limit on request bodies with appropriate error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->