### PR TITLE
feat(agents): framework label pill in the Agents app

### DIFF
--- a/desktop/src/apps/__tests__/AgentsApp.test.tsx
+++ b/desktop/src/apps/__tests__/AgentsApp.test.tsx
@@ -142,3 +142,28 @@ describe("AgentsApp — AgentShortcutRow wiring (Task 27)", () => {
     expect(screen.queryByRole("dialog", { name: /agent details/i })).toBeNull();
   });
 });
+
+describe("AgentsApp — framework label", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn().mockImplementation((url: string) => {
+      if (url === "/api/agents") {
+        return Promise.resolve({
+          ok: true, headers: { get: () => "application/json" },
+          json: () => Promise.resolve(MOCK_AGENTS),
+        } as unknown as Response);
+      }
+      return Promise.resolve({
+        ok: true, headers: { get: () => "application/json" },
+        json: () => Promise.resolve([]),
+      } as unknown as Response);
+    }));
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("shows each agent's framework as a labelled pill", async () => {
+    render(<AgentsApp windowId="test" />);
+    // The row surfaces the framework name (not just the emoji) for clarity.
+    expect(await screen.findByLabelText(/Framework: openclaw/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Framework: smolagents/i)).toBeInTheDocument();
+  });
+});

--- a/desktop/src/apps/agents/AgentRow.tsx
+++ b/desktop/src/apps/agents/AgentRow.tsx
@@ -39,6 +39,22 @@ export function AgentRow({
     agent.framework_version_sha &&
     latestForAgent &&
     latestForAgent.sha !== agent.framework_version_sha;
+  // The framework an agent runs on (openclaw, hermes, …). The emoji alone is
+  // ambiguous, so surface the name as a small pill. "none"/"generic" agents
+  // have no meaningful framework to show.
+  const frameworkLabel =
+    agent.framework && !["none", "generic"].includes(agent.framework)
+      ? agent.framework
+      : null;
+  const FrameworkPill = frameworkLabel ? (
+    <span
+      className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium lowercase shrink-0 bg-white/5 text-shell-text-secondary border border-white/10"
+      title={`Framework: ${frameworkLabel}`}
+      aria-label={`Framework: ${frameworkLabel}`}
+    >
+      {frameworkLabel}
+    </span>
+  ) : null;
 
   const btnCls = isMobile ? "h-11 w-11" : "h-8 w-8";
   // Only allow management actions while the agent is running
@@ -142,6 +158,7 @@ export function AgentRow({
         <div className="flex items-center gap-2 mt-1 min-w-0">
           <Server size={11} className="text-shell-text-tertiary shrink-0" />
           <span className="text-xs text-shell-text-secondary truncate flex-1 min-w-0">{agent.host}</span>
+          {FrameworkPill}
           <span className="text-xs text-shell-text-tertiary tabular-nums shrink-0">
             {agent.vectors.toLocaleString()} vectors
           </span>
@@ -200,6 +217,7 @@ export function AgentRow({
           {emoji}
         </span>
         <span className="font-medium text-sm truncate">{agent.display_name || agent.name}</span>
+        {FrameworkPill}
         {updateAvailable && (
           <span
             aria-label="framework update available"


### PR DESCRIPTION
## What

Adds a small **framework-name pill** to each agent in the Agents app, so you can tell at a glance which framework an agent runs on (openclaw, hermes, smolagents, …). Previously the row showed only a framework-*derived emoji*, which is ambiguous.

- Desktop list row: pill next to the agent name.
- Mobile card: pill in the detail row (alongside host/vectors).
- Hidden for `none`/`generic` agents (no meaningful framework).
- `aria-label`/`title` = `Framework: <name>` for a11y + tooltips.

## Test

`AgentsApp.test.tsx` asserts the labelled pill renders per agent (openclaw + smolagents fixtures). Full AgentsApp suite green; tsc clean.

## Context

Requested while validating an end-to-end OpenClaw deploy (kilo provider + `stepfun/step-3.7-flash:free`) on the Pi.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Framework information is now displayed on agent rows as accessible labeled indicators in mobile and desktop layouts, helping users quickly identify agent types.

* **Tests**
  * Added test coverage to verify framework labels are properly rendered and accessible across different agent implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->