### PR TITLE
fix(browser): GET-form search through the proxy (query-clobber)

### DIFF
--- a/tests/routes/desktop_browser/test_proxy_post.py
+++ b/tests/routes/desktop_browser/test_proxy_post.py
@@ -119,3 +119,68 @@ class TestProxyPost:
                 params={"profile_id": "personal", "url": "http://example.com/page"},
             )
         assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+class TestProxyGetForm:
+    """GET-form submissions arrive with routing in reserved hidden-input names
+    and the site's fields as plain query params, which merge into the target."""
+
+    @respx.mock
+    async def test_merges_form_fields_into_target_url(self, client):
+        route = respx.route(
+            method="GET", url__startswith="https://www.google.com/search",
+        ).mock(
+            return_value=Response(200, content=b"<html><body>results</body></html>",
+                                  headers={"content-type": "text/html"}),
+        )
+        with _SSRF_PATCH:
+            resp = await client.get(
+                "/api/desktop/browser/proxy",
+                params={
+                    "__taos_pid": "personal",
+                    "__taos_url": "https://www.google.com/search",
+                    "q": "cats",
+                },
+            )
+        assert resp.status_code == 200
+        assert route.called
+        sent = str(route.calls.last.request.url)
+        assert sent.startswith("https://www.google.com/search")
+        assert "q=cats" in sent
+
+    @respx.mock
+    async def test_preserves_existing_target_query(self, client):
+        route = respx.route(
+            method="GET", url__startswith="https://ex.com/s",
+        ).mock(return_value=Response(200, content=b"x", headers={"content-type": "text/html"}))
+        with _SSRF_PATCH:
+            resp = await client.get(
+                "/api/desktop/browser/proxy",
+                params={
+                    "__taos_pid": "personal",
+                    "__taos_url": "https://ex.com/s?lang=en",
+                    "q": "dogs",
+                },
+            )
+        assert resp.status_code == 200
+        sent = str(route.calls.last.request.url)
+        assert "lang=en" in sent and "q=dogs" in sent
+
+    @respx.mock
+    async def test_missing_profile_id_is_400(self, client):
+        resp = await client.get(
+            "/api/desktop/browser/proxy",
+            params={"__taos_url": "https://ex.com/s", "q": "x"},
+        )
+        assert resp.status_code == 400
+        assert "profile_id" in resp.json()["error"]
+
+    @respx.mock
+    async def test_missing_url_is_400(self, client):
+        resp = await client.get(
+            "/api/desktop/browser/proxy",
+            params={"__taos_pid": "personal"},
+        )
+        assert resp.status_code == 400
+        assert "url" in resp.json()["error"]

--- a/tests/routes/desktop_browser/test_proxy_post.py
+++ b/tests/routes/desktop_browser/test_proxy_post.py
@@ -184,3 +184,31 @@ class TestProxyGetForm:
         )
         assert resp.status_code == 400
         assert "url" in resp.json()["error"]
+
+    @respx.mock
+    async def test_site_field_named_url_does_not_collide(self, client):
+        # A GET form whose own field is literally named "url"/"profile_id" must
+        # be forwarded to the target, NOT mistaken for taOS routing. Routing
+        # comes from the reserved __taos_* fields only.
+        route = respx.route(
+            method="GET", url__startswith="https://site.example/search",
+        ).mock(return_value=Response(200, content=b"ok", headers={"content-type": "text/html"}))
+        with _SSRF_PATCH:
+            resp = await client.get(
+                "/api/desktop/browser/proxy",
+                params=[
+                    ("__taos_pid", "personal"),
+                    ("__taos_url", "https://site.example/search"),
+                    ("url", "https://evil.example/inject"),   # site's own field
+                    ("profile_id", "site-value"),             # site's own field
+                    ("q", "cats"),
+                ],
+            )
+        assert resp.status_code == 200
+        sent = str(route.calls.last.request.url)
+        # Routed to the reserved target, not the site's "url" field.
+        assert sent.startswith("https://site.example/search")
+        # The colliding site fields are forwarded to the target, not dropped.
+        assert "q=cats" in sent
+        assert "url=https" in sent and "evil.example" in sent
+        assert "profile_id=site-value" in sent

--- a/tests/routes/desktop_browser/test_proxy_shell.py
+++ b/tests/routes/desktop_browser/test_proxy_shell.py
@@ -86,20 +86,24 @@ class TestSsrfGate:
 
 @pytest.mark.asyncio
 class TestParameterValidation:
-    async def test_missing_url_returns_422(self, client):
+    async def test_missing_url_returns_400(self, client):
         resp = await client.get(
             "/api/desktop/browser/proxy",
             params={"profile_id": "personal"},
         )
-        # FastAPI returns 422 for missing required query params
-        assert resp.status_code == 422
+        # profile_id/url are Optional in the signature (to allow the __taos_*
+        # GET-form fallback), so the route validates them and returns a clear
+        # 400 rather than FastAPI's generic 422.
+        assert resp.status_code == 400
+        assert "url" in resp.json()["error"]
 
-    async def test_missing_profile_returns_422(self, client):
+    async def test_missing_profile_returns_400(self, client):
         resp = await client.get(
             "/api/desktop/browser/proxy",
             params={"url": "http://example.com/"},
         )
-        assert resp.status_code == 422
+        assert resp.status_code == 400
+        assert "profile_id" in resp.json()["error"]
 
 
 @pytest.mark.asyncio

--- a/tests/routes/desktop_browser/test_rewriter.py
+++ b/tests/routes/desktop_browser/test_rewriter.py
@@ -23,7 +23,6 @@ class TestAttributeRewriting:
         ("src", "img"),
         ("src", "script"),
         ("src", "iframe"),
-        ("action", "form"),
     ])
     def test_rewrites_relative_url(self, attr, tag):
         from tinyagentos.routes.desktop_browser.rewriter import rewrite_html
@@ -176,3 +175,59 @@ class TestCharsetHandling:
         lower = out.lower()
         assert b"charset=\"utf-8\"" in lower
         assert b"iso-8859-1" not in lower
+
+
+class TestFormRewriting:
+    """Forms route through the proxy; GET and POST need different handling."""
+
+    def test_get_form_uses_bare_path_and_hidden_inputs(self):
+        from tinyagentos.routes.desktop_browser.rewriter import rewrite_html
+
+        html = (
+            b'<html><body><form action="/search" method="get">'
+            b'<input name="q"></form></body></html>'
+        )
+        out = rewrite_html(
+            html, base_url="https://www.google.com/", proxy=_proxy, profile_id="p",
+        ).decode()
+
+        # Bare proxy path (no query — a GET submit would clobber it anyway).
+        assert 'action="/api/desktop/browser/proxy"' in out
+        # Routing carried as reserved hidden inputs that survive the submit.
+        assert 'name="__taos_url"' in out
+        assert 'value="https://www.google.com/search"' in out
+        assert 'name="__taos_pid"' in out
+        assert 'value="p"' in out
+
+    def test_get_form_defaults_when_no_method(self):
+        from tinyagentos.routes.desktop_browser.rewriter import rewrite_html
+
+        html = b'<html><body><form action="/s"><input name="q"></form></body></html>'
+        out = rewrite_html(
+            html, base_url="https://ex.com/", proxy=_proxy, profile_id="p",
+        ).decode()
+        assert 'action="/api/desktop/browser/proxy"' in out
+        assert 'value="https://ex.com/s"' in out
+
+    def test_post_form_keeps_query_encoded_action(self):
+        from tinyagentos.routes.desktop_browser.rewriter import rewrite_html
+
+        html = (
+            b'<html><body><form action="/login" method="POST">'
+            b'<input name="u"></form></body></html>'
+        )
+        out = rewrite_html(
+            html, base_url="https://ex.com/", proxy=_proxy, profile_id="p",
+        ).decode()
+        # POST keeps the query-encoded proxied action; no hidden routing inputs.
+        assert "url=https%3A%2F%2Fex.com%2Flogin" in out
+        assert "__taos_url" not in out
+
+    def test_form_without_action_targets_current_page(self):
+        from tinyagentos.routes.desktop_browser.rewriter import rewrite_html
+
+        html = b'<html><body><form><input name="q"></form></body></html>'
+        out = rewrite_html(
+            html, base_url="https://ex.com/page", proxy=_proxy, profile_id="p",
+        ).decode()
+        assert 'value="https://ex.com/page"' in out

--- a/tinyagentos/routes/desktop_browser/proxy.py
+++ b/tinyagentos/routes/desktop_browser/proxy.py
@@ -77,10 +77,6 @@ _FORWARD_REQUEST_HEADERS = frozenset({"content-type"})
 _FORM_PID_FIELD = "__taos_pid"
 _FORM_URL_FIELD = "__taos_url"
 _FORM_TAB_FIELD = "__taos_tab"
-_RESERVED_QUERY_KEYS = frozenset({
-    "profile_id", "url", "tab_id",
-    _FORM_PID_FIELD, _FORM_URL_FIELD, _FORM_TAB_FIELD,
-})
 
 
 def _merge_query_params(url: str, extra: list[tuple[str, str]]) -> str:
@@ -224,21 +220,32 @@ async def proxy_get(
     if not user_id:
         return JSONResponse({"error": "session has no user id"}, status_code=401)
 
-    # Resolve routing params: query first, then the reserved GET-form fields.
+    # Resolve routing params. A GET form submit carries our routing in the
+    # reserved __taos_* hidden inputs (the rewriter injects them); when those
+    # are present, ANY plain profile_id/url/tab_id in the query is the SITE's
+    # own form field (a page is free to name a field "url"), so it must be
+    # merged into the target — never consumed as routing or stripped. Direct
+    # navigation has no __taos_* and uses the plain query params for routing.
     qp = request.query_params
-    profile_id = profile_id or qp.get(_FORM_PID_FIELD)
-    url = url or qp.get(_FORM_URL_FIELD)
-    tab_id = tab_id or qp.get(_FORM_TAB_FIELD)
+    form_mode = _FORM_URL_FIELD in qp or _FORM_PID_FIELD in qp
+    if form_mode:
+        profile_id = qp.get(_FORM_PID_FIELD)
+        url = qp.get(_FORM_URL_FIELD)
+        tab_id = qp.get(_FORM_TAB_FIELD)
+        reserved = {_FORM_PID_FIELD, _FORM_URL_FIELD, _FORM_TAB_FIELD}
+    else:
+        # profile_id/url/tab_id are already bound from the query by FastAPI.
+        reserved = {"profile_id", "url", "tab_id"}
     if not profile_id:
         return JSONResponse({"error": "profile_id required"}, status_code=400)
     if not url:
         return JSONResponse({"error": "url required"}, status_code=400)
 
-    # GET-form submission: everything that isn't a reserved routing param is
-    # one of the site's own form fields (e.g. ?q=cats). Merge those into the
-    # target URL's query before fetching. Normal links carry their own query
-    # percent-encoded *inside* the url param, so they produce no extras here.
-    extra_fields = [(k, v) for k, v in qp.multi_items() if k not in _RESERVED_QUERY_KEYS]
+    # Everything that isn't a reserved routing key is one of the site's own
+    # form fields (e.g. ?q=cats, or a field literally named "url"). Merge those
+    # into the target URL's query before fetching. Normal links carry their own
+    # query percent-encoded *inside* the url param, so they add no extras here.
+    extra_fields = [(k, v) for k, v in qp.multi_items() if k not in reserved]
     if extra_fields:
         url = _merge_query_params(url, extra_fields)
 

--- a/tinyagentos/routes/desktop_browser/proxy.py
+++ b/tinyagentos/routes/desktop_browser/proxy.py
@@ -23,7 +23,15 @@ import re
 import time
 from pathlib import Path
 from typing import Any
-from urllib.parse import quote, urljoin, urlparse, urlsplit
+from urllib.parse import (
+    parse_qsl,
+    quote,
+    urlencode,
+    urljoin,
+    urlparse,
+    urlsplit,
+    urlunsplit,
+)
 
 import httpx
 from fastapi import Depends, Request
@@ -61,6 +69,30 @@ _MAX_REQUEST_BYTES = 10 * 1024 * 1024   # 10 MB cap on forwarded request bodies 
 # framing — never the client's cookies (we use the server-side jar), Host,
 # auth, or other ambient headers, which could leak or be abused.
 _FORWARD_REQUEST_HEADERS = frozenset({"content-type"})
+
+# Reserved query keys for GET-form routing (mirror rewriter._FORM_*). A GET
+# form submit replaces the action's query with its own fields, so the routing
+# params arrive under these names; anything else in the query is the site's
+# form data, merged into the target URL.
+_FORM_PID_FIELD = "__taos_pid"
+_FORM_URL_FIELD = "__taos_url"
+_FORM_TAB_FIELD = "__taos_tab"
+_RESERVED_QUERY_KEYS = frozenset({
+    "profile_id", "url", "tab_id",
+    _FORM_PID_FIELD, _FORM_URL_FIELD, _FORM_TAB_FIELD,
+})
+
+
+def _merge_query_params(url: str, extra: list[tuple[str, str]]) -> str:
+    """Append *extra* query params to *url*, preserving any it already has.
+
+    Used to fold a GET form's submitted fields into the target URL. Only the
+    query is touched — scheme/host/path are unchanged, so the SSRF re-check on
+    the merged URL sees the same host.
+    """
+    parts = urlsplit(url)
+    merged = parse_qsl(parts.query, keep_blank_values=True) + extra
+    return urlunsplit(parts._replace(query=urlencode(merged)))
 
 # Headers we strip from upstream responses before returning to the client.
 # `content-type` is stripped here and re-set from `media_type` on the
@@ -173,17 +205,42 @@ def _strip_port(host_header: str) -> str:
 
 @router.api_route("/api/desktop/browser/proxy", methods=["GET", "POST"])
 async def proxy_get(
-    profile_id: str,
-    url: str,
     request: Request,
+    profile_id: str | None = None,
+    url: str | None = None,
     tab_id: str | None = None,
     current_user: dict[str, Any] = Depends(get_current_user),
 ):
-    """Real proxy fetch. Handles GET and POST (form submissions — cookie
-    consent, search, login — which the rewriter routes here as POSTs)."""
+    """Real proxy fetch. Handles GET and POST form submissions (cookie consent,
+    search, login).
+
+    GET forms replace the action's query string with their own fields on
+    submit, so the routing params arrive under reserved hidden-input names
+    (``__taos_pid`` / ``__taos_url``) instead, and the remaining fields are
+    merged into the target URL here. POST forms keep the query-encoded
+    ``profile_id``/``url`` and carry their fields in the body.
+    """
     user_id = str(current_user.get("id") or "")
     if not user_id:
         return JSONResponse({"error": "session has no user id"}, status_code=401)
+
+    # Resolve routing params: query first, then the reserved GET-form fields.
+    qp = request.query_params
+    profile_id = profile_id or qp.get(_FORM_PID_FIELD)
+    url = url or qp.get(_FORM_URL_FIELD)
+    tab_id = tab_id or qp.get(_FORM_TAB_FIELD)
+    if not profile_id:
+        return JSONResponse({"error": "profile_id required"}, status_code=400)
+    if not url:
+        return JSONResponse({"error": "url required"}, status_code=400)
+
+    # GET-form submission: everything that isn't a reserved routing param is
+    # one of the site's own form fields (e.g. ?q=cats). Merge those into the
+    # target URL's query before fetching. Normal links carry their own query
+    # percent-encoded *inside* the url param, so they produce no extras here.
+    extra_fields = [(k, v) for k, v in qp.multi_items() if k not in _RESERVED_QUERY_KEYS]
+    if extra_fields:
+        url = _merge_query_params(url, extra_fields)
 
     # Capture the request method + body so form POSTs reach upstream. GET/HEAD
     # carry no body. The body is size-capped before we buffer the whole thing.
@@ -345,7 +402,7 @@ async def proxy_get(
         charset = _detect_charset(content_type, response.content)
         rewritten = rewrite_html(
             response.content, base_url=str(response.url), proxy=_proxy_url,
-            charset=charset,
+            charset=charset, profile_id=profile_id,
         )
 
         # Use the effective scheme (honours x-forwarded-proto behind a TLS

--- a/tinyagentos/routes/desktop_browser/rewriter.py
+++ b/tinyagentos/routes/desktop_browser/rewriter.py
@@ -48,12 +48,23 @@ _CSS_URL_RE = re.compile(
 )
 
 
+# Kept in sync with the proxy route path in proxy.py. GET forms submit to this
+# bare path (their query string is replaced by the form's own fields on
+# submit), carrying the taOS routing params as hidden inputs instead.
+_PROXY_PATH = "/api/desktop/browser/proxy"
+# Reserved hidden-input names for GET-form routing — prefixed so they can't
+# collide with a site's own form field named e.g. "url" or "profile_id".
+_FORM_PID_FIELD = "__taos_pid"
+_FORM_URL_FIELD = "__taos_url"
+
+
 def rewrite_html(
     html_bytes: bytes,
     *,
     base_url: str,
     proxy: Callable[[str], str],
     charset: str = "utf-8",
+    profile_id: str | None = None,
 ) -> bytes:
     """Rewrite all URL-bearing references in `html_bytes` to proxied form.
 
@@ -84,6 +95,7 @@ def rewrite_html(
         return html_bytes
 
     _rewrite_attributes(tree, base_url=base_url, proxy=proxy)
+    _rewrite_forms(tree, base_url=base_url, proxy=proxy, profile_id=profile_id)
     _rewrite_srcset(tree, base_url=base_url, proxy=proxy)
     _rewrite_inline_styles(tree, base_url=base_url, proxy=proxy)
     _rewrite_style_tags(tree, base_url=base_url, proxy=proxy)
@@ -129,7 +141,9 @@ def _rewrite_one(url: str, *, base_url: str, proxy: Callable[[str], str]) -> str
 def _rewrite_attributes(
     tree, *, base_url: str, proxy: Callable[[str], str],
 ) -> None:
-    for attr in ("href", "src", "action"):
+    # NOTE: `action` is intentionally NOT here — form actions are handled by
+    # _rewrite_forms, which has to special-case GET vs POST submission.
+    for attr in ("href", "src"):
         for el in tree.iter():
             val = el.get(attr)
             if val is None:
@@ -137,6 +151,47 @@ def _rewrite_attributes(
             new = _rewrite_one(val, base_url=base_url, proxy=proxy)
             if new != val:
                 el.set(attr, new)
+
+
+def _rewrite_forms(
+    tree, *, base_url: str, proxy: Callable[[str], str], profile_id: str | None,
+) -> None:
+    """Rewrite <form> actions so submissions route through the proxy.
+
+    POST and GET need different treatment:
+
+    - **POST** keeps the action URL's query string on submit, so the regular
+      proxied action (``?profile_id=…&url=…``) works; the form fields ride in
+      the request body (forwarded by the proxy).
+    - **GET** *replaces* the action's query string with the form's own fields
+      on submit, which would wipe out query-encoded routing params. So we point
+      the action at the bare proxy path and carry the routing params as hidden
+      inputs (reserved names), which survive in the submitted query. The proxy
+      merges the remaining fields into the target URL.
+    """
+    for form in tree.iter("form"):
+        raw_action = form.get("action")
+        action_target = urljoin(base_url, raw_action) if raw_action else base_url
+        if not action_target.startswith(("http://", "https://")):
+            continue  # javascript:/data: etc — leave alone
+        method = (form.get("method") or "get").strip().lower()
+        if method == "post":
+            form.set("action", proxy(action_target))
+            continue
+        # GET form
+        form.set("action", _PROXY_PATH)
+        if profile_id:
+            _prepend_hidden(form, _FORM_PID_FIELD, profile_id)
+        _prepend_hidden(form, _FORM_URL_FIELD, action_target)
+
+
+def _prepend_hidden(form, name: str, value: str) -> None:
+    """Insert a hidden <input name=value> as the form's first child."""
+    inp = lxml_html.Element("input")
+    inp.set("type", "hidden")
+    inp.set("name", name)
+    inp.set("value", value)
+    form.insert(0, inp)
 
 
 def _rewrite_srcset(


### PR DESCRIPTION
## Problem

After the POST fix (#566), searching (e.g. Google) returned `422 — profile_id / url required`. A **GET form** submit replaces the action URL's query string with the form's own fields (`?q=…`), wiping the query-encoded `profile_id`/`url` the proxy needs.

## Fix

- Rewriter now owns all `<form>` actions (split out of the generic href/src pass):
  - **GET** forms → action set to the bare proxy path, with routing carried as **reserved hidden inputs** (`__taos_pid`/`__taos_url`, prefixed so they can't collide with a site field named `url`/`q`) that survive the submit.
  - **POST** forms → keep the query-encoded proxied action (body carries fields; handled by #566).
- Proxy route resolves the routing params from query *or* the reserved fields, then **merges the leftover form fields** (`q=cats`) into the target URL. Only the query is touched, so the per-hop SSRF re-check sees the same host.

## Tests
4 rewriter cases (GET hidden-inputs, no-method default, POST query action, no-action→current page) + 4 proxy-route cases (merge, preserve existing target query, missing-profile 400, missing-url 400). Targeted suites green.

## Note
JS/SPA-driven search submits via `fetch()` from inside the sandboxed iframe and isn't covered by HTML-form rewriting — that's the real-Chromium escalation tier's job (#567).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop proxy now routes form submissions: GET forms are proxied via a fixed proxy path with hidden routing inputs; POST forms keep proxied action info while preserving action query parameters.
  * Form fields submitted alongside routing inputs are merged into the target URL query string.

* **Bug Fixes**
  * Request validation now returns HTTP 400 with JSON error details for missing required parameters.

* **Tests**
  * Added and expanded tests covering form rewriting, query-parameter merging, preserved target queries, and validation/error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->