### PR TITLE
feat(agents): ACP adapter for fork-free OpenClaw (session-binding fix, live-validated)

### DIFF
--- a/tests/adapters/test_acp_adapter.py
+++ b/tests/adapters/test_acp_adapter.py
@@ -1,0 +1,385 @@
+"""Tests for the ACP adapter against a scripted mock ACP server.
+
+The mock speaks the real ACP wire format (JSON-RPC 2.0 over a stdio pipe pair)
+and emits a scripted turn: text deltas, a thought, a plan, a tool_call +
+tool_call_update, a permission request, then PromptResponse{stopReason}. The
+tests assert the handshake works and that every session/update variant maps to
+the taOS reply ``kind`` that bridge_session.record_reply consumes.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from tinyagentos.adapters.acp_adapter import ACPAdapter, ACPConfig
+
+
+class MockACPServer:
+    """In-process ACP server: reads JSON-RPC lines, scripts a prompt turn.
+
+    Wired to the adapter via a pair of asyncio pipes so no subprocess or model
+    is needed. Emits the full session/update variant set during a turn.
+    """
+
+    def __init__(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
+        self._r = reader
+        self._w = writer
+        self.session_id = "sess_mock_1"
+        self.initialized = False
+        # Captured permission response from the client.
+        self.permission_outcome: dict | None = None
+        self._perm_event = asyncio.Event()
+
+    async def _send(self, obj: dict) -> None:
+        self._w.write((json.dumps(obj) + "\n").encode())
+        await self._w.drain()
+
+    async def run(self) -> None:
+        while True:
+            line = await self._r.readline()
+            if not line:
+                return
+            line = line.strip()
+            if not line:
+                continue
+            msg = json.loads(line)
+            await self._handle(msg)
+
+    async def _handle(self, msg: dict) -> None:
+        method = msg.get("method")
+        rid = msg.get("id")
+        # Responses from the client to our request (permission).
+        if method is None and "result" in msg:
+            self.permission_outcome = msg["result"]
+            self._perm_event.set()
+            return
+        if method == "initialize":
+            self.initialized = True
+            await self._send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": rid,
+                    "result": {
+                        "protocolVersion": 1,
+                        "agentCapabilities": {"promptCapabilities": {"image": False}},
+                    },
+                }
+            )
+        elif method == "session/new":
+            await self._send(
+                {"jsonrpc": "2.0", "id": rid, "result": {"sessionId": self.session_id}}
+            )
+        elif method == "session/prompt":
+            # Run the turn concurrently so run() keeps reading the pipe and can
+            # receive the client's permission response mid-turn (otherwise the
+            # server would deadlock waiting on _perm_event while blocking reads).
+            asyncio.create_task(self._run_turn(rid, msg["params"]["sessionId"]))
+
+    async def _update(self, session_id: str, update: dict) -> None:
+        await self._send(
+            {
+                "jsonrpc": "2.0",
+                "method": "session/update",
+                "params": {"sessionId": session_id, "update": update},
+            }
+        )
+
+    async def _run_turn(self, rid, session_id: str) -> None:
+        # 1. Plan
+        await self._update(
+            session_id,
+            {
+                "sessionUpdate": "plan",
+                "entries": [
+                    {"content": "Read the file", "status": "pending", "priority": "high"},
+                    {"content": "Summarise it", "status": "pending", "priority": "medium"},
+                ],
+            },
+        )
+        # 2. Thought (reasoning)
+        await self._update(
+            session_id,
+            {
+                "sessionUpdate": "agent_thought_chunk",
+                "content": {"type": "text", "text": "I should read config.json first."},
+            },
+        )
+        # 3. Streamed assistant text (two deltas)
+        await self._update(
+            session_id,
+            {"sessionUpdate": "agent_message_chunk", "content": {"type": "text", "text": "Let me "}},
+        )
+        await self._update(
+            session_id,
+            {"sessionUpdate": "agent_message_chunk", "content": {"type": "text", "text": "check that."}},
+        )
+        # 4. Tool call (pending) with rawInput args
+        await self._update(
+            session_id,
+            {
+                "sessionUpdate": "tool_call",
+                "toolCallId": "call_1",
+                "title": "Read config.json",
+                "kind": "read",
+                "status": "pending",
+                "rawInput": {"path": "config.json"},
+            },
+        )
+        # 5. Permission request (JSON-RPC request — expects a response)
+        perm_id = 9001
+        await self._send(
+            {
+                "jsonrpc": "2.0",
+                "id": perm_id,
+                "method": "session/request_permission",
+                "params": {
+                    "sessionId": session_id,
+                    "toolCall": {"toolCallId": "call_1", "title": "Read config.json", "kind": "read"},
+                    "options": [
+                        {"optionId": "o-allow", "name": "Allow", "kind": "allow_once"},
+                        {"optionId": "o-reject", "name": "Reject", "kind": "reject_once"},
+                    ],
+                },
+            }
+        )
+        # Wait for the client's permission answer before continuing the turn.
+        await asyncio.wait_for(self._perm_event.wait(), timeout=5)
+        # 6. Tool call completed with output
+        await self._update(
+            session_id,
+            {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "call_1",
+                "status": "completed",
+                "content": [
+                    {"type": "content", "content": {"type": "text", "text": "{\"k\":1}"}}
+                ],
+                "rawOutput": {"k": 1},
+            },
+        )
+        # 7. Final assistant text
+        await self._update(
+            session_id,
+            {"sessionUpdate": "agent_message_chunk", "content": {"type": "text", "text": " Done."}},
+        )
+        # 8. PromptResponse
+        await self._send({"jsonrpc": "2.0", "id": rid, "result": {"stopReason": "end_turn"}})
+
+
+def _make_pipe():
+    """Create a connected (reader, writer) pair over an in-memory transport."""
+    # Two queues simulate two directions. We build StreamReader/Writer on top of
+    # a simple in-memory protocol so adapter and mock can talk without a socket.
+    return _MemoryPipe()
+
+
+class _MemoryPipe:
+    """A bidirectional in-memory stream pair (no OS sockets/subprocess)."""
+
+    def __init__(self):
+        self.a_to_b = asyncio.StreamReader()
+        self.b_to_a = asyncio.StreamReader()
+        self.a_writer = _QueueWriter(self.a_to_b)
+        self.b_writer = _QueueWriter(self.b_to_a)
+
+    # Adapter uses (stdin=writer to server, stdout=reader from server)
+    def client_io(self):
+        return self.a_writer, self.b_to_a  # client writes to a_to_b, reads b_to_a
+
+    def server_io(self):
+        return self.b_to_a, self.a_to_b  # unused directly; server uses readers below
+
+
+class _QueueWriter:
+    """Minimal StreamWriter-like shim feeding bytes into a StreamReader."""
+
+    def __init__(self, target: asyncio.StreamReader):
+        self._target = target
+
+    def write(self, data: bytes) -> None:
+        self._target.feed_data(data)
+
+    async def drain(self) -> None:
+        return None
+
+    def close(self) -> None:
+        self._target.feed_eof()
+
+
+@pytest.fixture
+def collected():
+    return []
+
+
+@pytest.fixture
+def sink(collected):
+    def _sink(reply: dict):
+        collected.append(reply)
+
+    return _sink
+
+
+@pytest.mark.asyncio
+async def test_handshake_and_full_turn_mapping(sink, collected):
+    pipe = _MemoryPipe()
+    # Adapter: writes to a_to_b, reads from b_to_a.
+    client_writer = pipe.a_writer
+    client_reader = pipe.b_to_a
+    # Server: reads a_to_b, writes b_to_a.
+    server_reader = pipe.a_to_b
+    server_writer = pipe.b_writer
+
+    server = MockACPServer(server_reader, server_writer)
+    server_task = asyncio.create_task(server.run())
+
+    cfg = ACPConfig(command=["mock"], permission_policy="allow_once", request_timeout=5)
+    adapter = ACPAdapter(cfg, sink)
+    await adapter.start(client_writer, client_reader)
+
+    init = await adapter.initialize()
+    assert server.initialized is True
+    assert init["protocolVersion"] == 1
+
+    sid = await adapter.new_session()
+    assert sid == "sess_mock_1"
+
+    stop = await adapter.prompt(sid, "summarise config.json", trace_id="t-abc")
+    assert stop == "end_turn"
+
+    # Give the reader loop a tick to drain any trailing notifications.
+    await asyncio.sleep(0.05)
+    await adapter.close()
+    server_task.cancel()
+
+    kinds = [c["kind"] for c in collected]
+
+    # Every taOS reply kind we expect from this scripted turn appeared.
+    assert "reasoning" in kinds  # thought + plan
+    assert "delta" in kinds
+    assert "tool_call" in kinds
+    assert "tool_result" in kinds
+    assert "final" in kinds
+
+    # --- Field-level parity assertions ---
+
+    # Reasoning: thought text preserved.
+    reasonings = [c for c in collected if c["kind"] == "reasoning"]
+    assert any("read config.json" in c["content"].lower() for c in reasonings)
+    # Plan rendered into a reasoning event.
+    assert any(c["content"].startswith("Plan:") for c in reasonings)
+
+    # Deltas accumulate the streamed assistant text.
+    deltas = "".join(c["content"] for c in collected if c["kind"] == "delta")
+    assert deltas == "Let me check that. Done."
+
+    # tool_call carries the tool title + rawInput as args (arg fidelity).
+    tcs = [c for c in collected if c["kind"] == "tool_call" and not c["tool"].startswith("permission:")]
+    assert len(tcs) == 1
+    assert tcs[0]["tool"] == "Read config.json"
+    assert tcs[0]["args"] == {"path": "config.json"}
+
+    # Permission ask surfaced as a tool_call note.
+    perms = [c for c in collected if c["kind"] == "tool_call" and c["tool"].startswith("permission:")]
+    assert len(perms) == 1
+
+    # tool_result pairs back to the tool title and carries output + success.
+    trs = [c for c in collected if c["kind"] == "tool_result"]
+    assert len(trs) == 1
+    assert trs[0]["tool"] == "Read config.json"
+    assert trs[0]["success"] is True
+    assert trs[0]["result"] == {"k": 1}
+
+    # Permission was answered with the policy-matching option.
+    assert server.permission_outcome == {"outcome": {"outcome": "selected", "optionId": "o-allow"}}
+
+    # All events share the active trace_id.
+    assert all(c["trace_id"] == "t-abc" for c in collected)
+
+
+@pytest.mark.asyncio
+async def test_permission_reject_when_policy_no_match(collected):
+    """If no option matches the policy, the adapter cancels the permission."""
+
+    def sink(reply):
+        collected.append(reply)
+
+    pipe = _MemoryPipe()
+    server = MockACPServer(pipe.a_to_b, pipe.b_writer)
+    server_task = asyncio.create_task(server.run())
+
+    # Policy 'allow_always' is offered by neither scripted option -> cancelled.
+    cfg = ACPConfig(command=["mock"], permission_policy="allow_always", request_timeout=5)
+    adapter = ACPAdapter(cfg, sink)
+    await adapter.start(pipe.a_writer, pipe.b_to_a)
+    await adapter.initialize()
+    sid = await adapter.new_session()
+    await adapter.prompt(sid, "go", trace_id="t-2")
+    await asyncio.sleep(0.05)
+    await adapter.close()
+    server_task.cancel()
+
+    assert server.permission_outcome == {"outcome": {"outcome": "cancelled"}}
+
+
+@pytest.mark.asyncio
+async def test_refusal_stop_reason_emits_error(collected):
+    """A refusal stopReason produces a taOS error event."""
+
+    def sink(reply):
+        collected.append(reply)
+
+    pipe = _MemoryPipe()
+
+    class RefusingServer(MockACPServer):
+        async def _run_turn(self, rid, session_id):
+            await self._update(
+                session_id,
+                {"sessionUpdate": "agent_message_chunk", "content": {"type": "text", "text": "No."}},
+            )
+            await self._send({"jsonrpc": "2.0", "id": rid, "result": {"stopReason": "refusal"}})
+
+    server = RefusingServer(pipe.a_to_b, pipe.b_writer)
+    server_task = asyncio.create_task(server.run())
+
+    adapter = ACPAdapter(ACPConfig(command=["mock"], request_timeout=5), sink)
+    await adapter.start(pipe.a_writer, pipe.b_to_a)
+    await adapter.initialize()
+    sid = await adapter.new_session()
+    stop = await adapter.prompt(sid, "do something bad", trace_id="t-3")
+    await asyncio.sleep(0.05)
+    await adapter.close()
+    server_task.cancel()
+
+    assert stop == "refusal"
+    kinds = [c["kind"] for c in collected]
+    assert "error" in kinds
+    err = next(c for c in collected if c["kind"] == "error")
+    assert "refusal" in err["error"]
+
+
+class TestSessionBinding:
+    """The ACP bridge must be launched bound to the agent's gateway session,
+    or `session/prompt` hangs (validated live against OpenClaw 2026.4.18)."""
+
+    def test_session_key_appended_to_command(self):
+        from tinyagentos.adapters.acp_adapter import ACPAdapter, ACPConfig
+
+        cfg = ACPConfig(command=["openclaw", "acp"], session_key="agent:main:main")
+        ad = ACPAdapter(cfg, sink=lambda r: None)
+        assert ad._effective_command() == ["openclaw", "acp", "--session", "agent:main:main"]
+
+    def test_no_session_key_leaves_command_unchanged(self):
+        from tinyagentos.adapters.acp_adapter import ACPAdapter, ACPConfig
+
+        cfg = ACPConfig(command=["openclaw", "acp"])
+        ad = ACPAdapter(cfg, sink=lambda r: None)
+        assert ad._effective_command() == ["openclaw", "acp"]
+
+    def test_existing_session_flag_not_duplicated(self):
+        from tinyagentos.adapters.acp_adapter import ACPAdapter, ACPConfig
+
+        cfg = ACPConfig(command=["openclaw", "acp", "--session", "x"], session_key="agent:main:main")
+        ad = ACPAdapter(cfg, sink=lambda r: None)
+        assert ad._effective_command().count("--session") == 1

--- a/tests/adapters/test_acp_adapter.py
+++ b/tests/adapters/test_acp_adapter.py
@@ -13,7 +13,7 @@ import json
 
 import pytest
 
-from tinyagentos.adapters.acp_adapter import ACPAdapter, ACPConfig
+from tinyagentos.adapters.acp_adapter import ACPAdapter, ACPConfig, ACPProtocolError
 
 
 class MockACPServer:
@@ -274,6 +274,12 @@ async def test_handshake_and_full_turn_mapping(sink, collected):
     deltas = "".join(c["content"] for c in collected if c["kind"] == "delta")
     assert deltas == "Let me check that. Done."
 
+    # The `final` reply carries the full accumulated assistant text (not "")
+    # so sinks that don't reassemble deltas still get the complete message.
+    finals = [c for c in collected if c["kind"] == "final"]
+    assert len(finals) == 1
+    assert finals[0]["content"] == "Let me check that. Done."
+
     # tool_call carries the tool title + rawInput as args (arg fidelity).
     tcs = [c for c in collected if c["kind"] == "tool_call" and not c["tool"].startswith("permission:")]
     assert len(tcs) == 1
@@ -383,3 +389,24 @@ class TestSessionBinding:
         cfg = ACPConfig(command=["openclaw", "acp", "--session", "x"], session_key="agent:main:main")
         ad = ACPAdapter(cfg, sink=lambda r: None)
         assert ad._effective_command().count("--session") == 1
+
+
+@pytest.mark.asyncio
+async def test_eof_fails_pending_requests_fast():
+    """When the ACP server's stream closes, in-flight requests fail
+    immediately with a transport error instead of hanging to request_timeout."""
+    pipe = _MemoryPipe()
+    client_writer, client_reader = pipe.client_io()
+    adapter = ACPAdapter(ACPConfig(command=["mock"], request_timeout=30), sink=lambda r: None)
+    await adapter.start(client_writer, client_reader)
+
+    # Start a request, let it register its pending future + send, THEN kill the
+    # stream — the read loop must reject the pending future on EOF.
+    task = asyncio.create_task(adapter.initialize())
+    await asyncio.sleep(0)
+    pipe.b_to_a.feed_eof()
+
+    with pytest.raises(ACPProtocolError):
+        await asyncio.wait_for(task, timeout=2)
+
+    await adapter.close()

--- a/tinyagentos/adapters/acp_adapter.py
+++ b/tinyagentos/adapters/acp_adapter.py
@@ -1,0 +1,442 @@
+"""ACP adapter — fork-free OpenClaw integration via the Agent Client Protocol.
+
+SPIKE / PROTOTYPE. This module de-risks dropping taOS's OpenClaw *fork* (the
+in-process ``taos-bridge.ts`` patch) in favour of talking to OpenClaw — or any
+ACP-speaking agent — over its published wire protocol.
+
+ACP (Zed's Agent Client Protocol, https://agentclientprotocol.com) is JSON-RPC
+2.0 over stdio. OpenClaw ships ``openclaw acp`` (the ``@openclaw/acpx`` runtime).
+The handshake is::
+
+    initialize        -> negotiate protocolVersion + capabilities
+    session/new       -> { sessionId }
+    session/prompt    -> drives a turn; agent streams session/update
+                         notifications until it returns { stopReason }
+
+While a turn runs the agent emits ``session/update`` notifications. This adapter
+consumes them and maps each onto a taOS *trace-event kind* — the exact ``kind``
+strings that ``tinyagentos/bridge_session.py``'s ``record_reply`` already
+understands (delta, final, tool_call, tool_result, reasoning, error). That means
+taOS keeps its existing trace/observability contract without forking OpenClaw:
+the fork's hand-written bridge becomes a standards-based protocol client.
+
+Mapping (ACP session/update -> taOS reply kind):
+
+    agent_message_chunk        -> delta        (streamed assistant text)
+    agent_thought_chunk        -> reasoning    (model thoughts/deliberation)
+    plan                       -> reasoning    (plan entries, summarised)
+    tool_call (pending/...)    -> tool_call    (title + rawInput as args)
+    tool_call_update completed -> tool_result  (rawOutput/content + success)
+    tool_call_update failed    -> tool_result  (success=False)
+    (turn end, stopReason)     -> final        (flush accumulated text)
+    (stopReason=refusal/error) -> error
+
+``session/request_permission`` is a *request* (expects a response), not a
+notification. The adapter answers it with a configurable auto policy so a
+headless taOS turn does not deadlock, and surfaces it as a ``tool_call``-shaped
+trace note for visibility.
+
+The adapter is framework-agnostic and config-driven: give it a ``command`` and
+``args`` (e.g. ``["openclaw", "acp"]``) and a sink callback that receives taOS
+reply dicts. It does not import OpenClaw or FastAPI; the sink is where a caller
+wires ``BridgeSessionRegistry.record_reply`` (or an HTTP POST to the reply URL).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+# A sink receives taOS reply dicts (the body shape record_reply consumes) and
+# may be sync or async.
+ReplySink = Callable[[dict], Any]
+
+# Default answer to session/request_permission so a headless turn never hangs.
+# "reject_once" is the safe default for an unattended controller; callers can
+# override to allow. We answer with the first option whose kind matches.
+DEFAULT_PERMISSION = "reject_once"
+
+
+@dataclass
+class ACPConfig:
+    """Config for launching and driving an ACP server subprocess."""
+
+    command: list[str]  # e.g. ["openclaw", "acp"] or ["npx", "openclaw", "acp"]
+    cwd: Optional[str] = None
+    env: Optional[dict[str, str]] = None
+    protocol_version: int = 1
+    # Gateway session key to bind the ACP bridge to (e.g. "agent:main:main").
+    # CRITICAL for OpenClaw: without it, `session/new` creates an unbound
+    # session with no model, and `session/prompt` hangs forever. Validated live
+    # against OpenClaw 2026.4.18 — binding to the agent's session is what makes
+    # a turn complete. When set, `--session <key>` is appended to the command.
+    session_key: Optional[str] = None
+    # How to answer session/request_permission unattended.
+    permission_policy: str = DEFAULT_PERMISSION  # allow_once|allow_always|reject_once|reject_always
+    request_timeout: float = 120.0
+    client_capabilities: dict = field(
+        default_factory=lambda: {"fs": {"readTextFile": False, "writeTextFile": False}}
+    )
+
+
+class ACPProtocolError(RuntimeError):
+    """Raised when the ACP server returns a JSON-RPC error to a request."""
+
+
+class ACPAdapter:
+    """Drives one ACP server subprocess and maps its updates to taOS replies.
+
+    Lifecycle:
+        adapter = ACPAdapter(config, sink)
+        await adapter.start(stdin, stdout)   # or .spawn() to launch subprocess
+        await adapter.initialize()
+        sid = await adapter.new_session()
+        stop_reason = await adapter.prompt(sid, "hello", trace_id="t1")
+        await adapter.close()
+
+    ``sink`` is called once per mapped taOS reply event with a dict carrying at
+    least ``kind`` and ``trace_id`` plus kind-specific fields, matching
+    bridge_session.record_reply's body contract.
+    """
+
+    def __init__(self, config: ACPConfig, sink: ReplySink) -> None:
+        self._cfg = config
+        self._sink = sink
+        self._proc: asyncio.subprocess.Process | None = None
+        self._stdin: asyncio.StreamWriter | None = None
+        self._stdout: asyncio.StreamReader | None = None
+        self._reader_task: asyncio.Task | None = None
+        # JSON-RPC id -> Future for in-flight outbound requests.
+        self._pending: dict[int, asyncio.Future] = {}
+        self._next_id = 0
+        # The trace_id of the turn currently in flight (for mapping updates).
+        self._active_trace: str | None = None
+        # Per-tool-call accumulated state so a tool_call_update can be paired
+        # with the originating tool's name/title.
+        self._tool_titles: dict[str, str] = {}
+        self._started = asyncio.Event()
+
+    # ------------------------------------------------------------------ I/O
+
+    def _effective_command(self) -> list[str]:
+        """The launch command, with ``--session <key>`` appended when a
+        session_key is configured and not already present. Binding the ACP
+        bridge to the agent's gateway session is required for turns to run."""
+        cmd = list(self._cfg.command)
+        if self._cfg.session_key and "--session" not in cmd:
+            cmd += ["--session", self._cfg.session_key]
+        return cmd
+
+    async def spawn(self) -> None:
+        """Launch the configured ACP server as a subprocess over stdio."""
+        self._proc = await asyncio.create_subprocess_exec(
+            *self._effective_command(),
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=self._cfg.cwd,
+            env=self._cfg.env,
+        )
+        assert self._proc.stdin and self._proc.stdout
+        await self.start(self._proc.stdin, self._proc.stdout)
+
+    async def start(
+        self, stdin: asyncio.StreamWriter, stdout: asyncio.StreamReader
+    ) -> None:
+        """Attach to an already-open stdio pair (used by tests with a stub)."""
+        self._stdin = stdin
+        self._stdout = stdout
+        self._reader_task = asyncio.create_task(self._read_loop())
+        self._started.set()
+
+    async def close(self) -> None:
+        if self._reader_task:
+            self._reader_task.cancel()
+            try:
+                await self._reader_task
+            except asyncio.CancelledError:
+                pass
+        if self._stdin:
+            try:
+                self._stdin.close()
+            except Exception:
+                pass
+        if self._proc and self._proc.returncode is None:
+            try:
+                self._proc.terminate()
+            except ProcessLookupError:
+                pass
+
+    # ------------------------------------------------------- JSON-RPC plumbing
+
+    def _alloc_id(self) -> int:
+        self._next_id += 1
+        return self._next_id
+
+    async def _send(self, obj: dict) -> None:
+        assert self._stdin is not None
+        line = json.dumps(obj, separators=(",", ":")) + "\n"
+        self._stdin.write(line.encode("utf-8"))
+        await self._stdin.drain()
+
+    async def _request(self, method: str, params: dict) -> dict:
+        """Send a JSON-RPC request and await its response."""
+        rid = self._alloc_id()
+        fut: asyncio.Future = asyncio.get_event_loop().create_future()
+        self._pending[rid] = fut
+        await self._send({"jsonrpc": "2.0", "id": rid, "method": method, "params": params})
+        try:
+            result = await asyncio.wait_for(fut, timeout=self._cfg.request_timeout)
+        finally:
+            self._pending.pop(rid, None)
+        return result
+
+    async def _notify(self, method: str, params: dict) -> None:
+        await self._send({"jsonrpc": "2.0", "method": method, "params": params})
+
+    async def _respond(self, rid: Any, result: dict) -> None:
+        await self._send({"jsonrpc": "2.0", "id": rid, "result": result})
+
+    async def _read_loop(self) -> None:
+        assert self._stdout is not None
+        while True:
+            line = await self._stdout.readline()
+            if not line:
+                break  # EOF — server exited
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                msg = json.loads(line)
+            except json.JSONDecodeError:
+                logger.warning("acp: non-JSON line from server: %r", line[:200])
+                continue
+            await self._dispatch(msg)
+
+    async def _dispatch(self, msg: dict) -> None:
+        # Response to one of our requests.
+        if "id" in msg and ("result" in msg or "error" in msg):
+            fut = self._pending.get(msg["id"])
+            if fut and not fut.done():
+                if "error" in msg:
+                    fut.set_exception(ACPProtocolError(str(msg["error"])))
+                else:
+                    fut.set_result(msg.get("result", {}))
+            return
+        # Inbound request FROM the agent (expects a response).
+        method = msg.get("method")
+        if method and "id" in msg:
+            await self._handle_server_request(msg)
+            return
+        # Notification from the agent (no id).
+        if method:
+            await self._handle_notification(method, msg.get("params", {}))
+
+    # ----------------------------------------------------- handshake + prompt
+
+    async def initialize(self) -> dict:
+        return await self._request(
+            "initialize",
+            {
+                "protocolVersion": self._cfg.protocol_version,
+                "clientCapabilities": self._cfg.client_capabilities,
+            },
+        )
+
+    async def new_session(self, cwd: str | None = None, mcp_servers: list | None = None) -> str:
+        result = await self._request(
+            "session/new",
+            {"cwd": cwd or self._cfg.cwd or ".", "mcpServers": mcp_servers or []},
+        )
+        sid = result.get("sessionId")
+        if not sid:
+            raise ACPProtocolError(f"session/new returned no sessionId: {result}")
+        return sid
+
+    async def prompt(self, session_id: str, text: str, trace_id: str | None = None) -> str:
+        """Run one turn. Returns the stopReason. Streams mapped events to sink."""
+        self._active_trace = trace_id or uuid.uuid4().hex
+        result = await self._request(
+            "session/prompt",
+            {"sessionId": session_id, "prompt": [{"type": "text", "text": text}]},
+        )
+        stop_reason = result.get("stopReason", "end_turn")
+        # Flush accumulated assistant text as the turn's final message.
+        await self._emit({"kind": "final", "trace_id": self._active_trace, "content": ""})
+        if stop_reason in ("refusal",):
+            await self._emit(
+                {
+                    "kind": "error",
+                    "trace_id": self._active_trace,
+                    "error": f"agent stopped: {stop_reason}",
+                }
+            )
+        trace = self._active_trace
+        self._active_trace = None
+        self._tool_titles.clear()
+        logger.debug("acp turn %s ended: stopReason=%s", trace, stop_reason)
+        return stop_reason
+
+    # ----------------------------------------------- notification -> taOS map
+
+    async def _handle_notification(self, method: str, params: dict) -> None:
+        if method != "session/update":
+            logger.debug("acp: ignoring notification %s", method)
+            return
+        update = params.get("update", {})
+        kind = update.get("sessionUpdate")
+        trace = self._active_trace or params.get("sessionId") or uuid.uuid4().hex
+
+        if kind == "agent_message_chunk":
+            text = _content_text(update.get("content"))
+            if text:
+                await self._emit({"kind": "delta", "trace_id": trace, "content": text})
+
+        elif kind == "agent_thought_chunk":
+            text = _content_text(update.get("content"))
+            if text:
+                await self._emit({"kind": "reasoning", "trace_id": trace, "content": text})
+
+        elif kind == "plan":
+            summary = _plan_text(update.get("entries") or update.get("plan", {}).get("entries"))
+            if summary:
+                await self._emit({"kind": "reasoning", "trace_id": trace, "content": summary})
+
+        elif kind == "tool_call":
+            tc = update  # ToolCall fields are inline on the update
+            tool_id = tc.get("toolCallId", "")
+            title = tc.get("title") or tc.get("kind") or "tool"
+            self._tool_titles[tool_id] = title
+            await self._emit(
+                {
+                    "kind": "tool_call",
+                    "trace_id": trace,
+                    "tool": title,
+                    "args": tc.get("rawInput") or {},
+                }
+            )
+
+        elif kind == "tool_call_update":
+            status = update.get("status")
+            tool_id = update.get("toolCallId", "")
+            title = self._tool_titles.get(tool_id, "tool")
+            if status in ("completed", "failed"):
+                await self._emit(
+                    {
+                        "kind": "tool_result",
+                        "trace_id": trace,
+                        "tool": title,
+                        "result": update.get("rawOutput")
+                        or _tool_content_text(update.get("content")),
+                        "success": status == "completed",
+                    }
+                )
+            # pending/in_progress updates are progress noise; taOS has no kind
+            # for them, so they are intentionally dropped.
+
+        else:
+            # user_message_chunk / available_commands_update / current_mode_update
+            logger.debug("acp: no taOS mapping for sessionUpdate=%s", kind)
+
+    async def _handle_server_request(self, msg: dict) -> None:
+        method = msg.get("method")
+        rid = msg.get("id")
+        params = msg.get("params", {})
+        if method == "session/request_permission":
+            await self._handle_permission(rid, params)
+        elif method in ("fs/read_text_file", "fs/write_text_file"):
+            # We declared no fs capability; reject politely so the agent moves on.
+            await self._send(
+                {"jsonrpc": "2.0", "id": rid, "error": {"code": -32601, "message": "fs disabled"}}
+            )
+        else:
+            logger.debug("acp: unhandled server request %s", method)
+            await self._send(
+                {"jsonrpc": "2.0", "id": rid, "error": {"code": -32601, "message": "unsupported"}}
+            )
+
+    async def _handle_permission(self, rid: Any, params: dict) -> None:
+        trace = self._active_trace or params.get("sessionId") or uuid.uuid4().hex
+        tool_call = params.get("toolCall", {})
+        options = params.get("options", []) or []
+        # Surface the permission ask as a trace note (tool_call-shaped).
+        await self._emit(
+            {
+                "kind": "tool_call",
+                "trace_id": trace,
+                "tool": f"permission:{tool_call.get('title') or tool_call.get('kind') or 'op'}",
+                "args": {"requested": True, "policy": self._cfg.permission_policy},
+            }
+        )
+        # Pick the option matching our policy; else cancel.
+        chosen = next(
+            (o for o in options if o.get("kind") == self._cfg.permission_policy), None
+        )
+        if chosen is not None:
+            outcome = {"outcome": "selected", "optionId": chosen.get("optionId")}
+        else:
+            outcome = {"outcome": "cancelled"}
+        await self._respond(rid, {"outcome": outcome})
+
+    # --------------------------------------------------------------- sink
+
+    async def _emit(self, reply: dict) -> None:
+        try:
+            res = self._sink(reply)
+            if asyncio.iscoroutine(res):
+                await res
+        except Exception:
+            logger.exception("acp: sink raised for reply kind=%s", reply.get("kind"))
+
+
+# ----------------------------------------------------------- content helpers
+
+
+def _content_text(content: Any) -> str:
+    """Extract text from an ACP ContentBlock (or list of them)."""
+    if content is None:
+        return ""
+    if isinstance(content, list):
+        return "".join(_content_text(c) for c in content)
+    if isinstance(content, dict):
+        if content.get("type") == "text":
+            return content.get("text", "")
+        # resource with embedded text
+        res = content.get("resource")
+        if isinstance(res, dict) and "text" in res:
+            return res["text"]
+    if isinstance(content, str):
+        return content
+    return ""
+
+
+def _tool_content_text(content: Any) -> str:
+    """Extract text from ToolCallContent[] (each is {type:'content', content:<block>})."""
+    if not isinstance(content, list):
+        return _content_text(content)
+    out = []
+    for item in content:
+        if isinstance(item, dict) and item.get("type") == "content":
+            out.append(_content_text(item.get("content")))
+        else:
+            out.append(_content_text(item))
+    return "".join(out)
+
+
+def _plan_text(entries: Any) -> str:
+    """Render a Plan's entries into a readable reasoning string."""
+    if not isinstance(entries, list):
+        return ""
+    lines = []
+    for e in entries:
+        if isinstance(e, dict):
+            status = e.get("status", "")
+            content = e.get("content", "")
+            mark = {"completed": "[x]", "in_progress": "[~]", "pending": "[ ]"}.get(status, "-")
+            lines.append(f"{mark} {content}".strip())
+    return "Plan:\n" + "\n".join(lines) if lines else ""

--- a/tinyagentos/adapters/acp_adapter.py
+++ b/tinyagentos/adapters/acp_adapter.py
@@ -111,9 +111,13 @@ class ACPAdapter:
         self._stdin: asyncio.StreamWriter | None = None
         self._stdout: asyncio.StreamReader | None = None
         self._reader_task: asyncio.Task | None = None
+        self._stderr_task: asyncio.Task | None = None
         # JSON-RPC id -> Future for in-flight outbound requests.
         self._pending: dict[int, asyncio.Future] = {}
         self._next_id = 0
+        # Accumulates assistant text across agent_message_chunk updates so the
+        # turn's `final` reply carries the full message (not just the deltas).
+        self._assistant_buf = ""
         # The trace_id of the turn currently in flight (for mapping updates).
         self._active_trace: str | None = None
         # Per-tool-call accumulated state so a tool_call_update can be paired
@@ -143,7 +147,24 @@ class ACPAdapter:
             env=self._cfg.env,
         )
         assert self._proc.stdin and self._proc.stdout
+        # Drain stderr continuously. If we pipe it but never read, a chatty
+        # server fills the OS pipe buffer and the child deadlocks. We log lines
+        # at debug for diagnostics rather than discarding blind.
+        if self._proc.stderr is not None:
+            self._stderr_task = asyncio.create_task(self._drain_stderr(self._proc.stderr))
         await self.start(self._proc.stdin, self._proc.stdout)
+
+    async def _drain_stderr(self, stream: asyncio.StreamReader) -> None:
+        try:
+            while True:
+                line = await stream.readline()
+                if not line:
+                    return
+                logger.debug("acp stderr: %s", line.decode("utf-8", "replace").rstrip()[:300])
+        except asyncio.CancelledError:
+            return
+        except Exception:
+            return
 
     async def start(
         self, stdin: asyncio.StreamWriter, stdout: asyncio.StreamReader
@@ -154,6 +175,14 @@ class ACPAdapter:
         self._reader_task = asyncio.create_task(self._read_loop())
         self._started.set()
 
+    def _fail_pending(self, exc: Exception) -> None:
+        """Reject every in-flight request so callers fail fast instead of
+        blocking until request_timeout when the transport dies."""
+        pending, self._pending = self._pending, {}
+        for fut in pending.values():
+            if not fut.done():
+                fut.set_exception(exc)
+
     async def close(self) -> None:
         if self._reader_task:
             self._reader_task.cancel()
@@ -161,6 +190,14 @@ class ACPAdapter:
                 await self._reader_task
             except asyncio.CancelledError:
                 pass
+        if self._stderr_task:
+            self._stderr_task.cancel()
+            try:
+                await self._stderr_task
+            except asyncio.CancelledError:
+                pass
+        # Don't leave callers awaiting a response that can never arrive.
+        self._fail_pending(ACPProtocolError("ACP transport closed"))
         if self._stdin:
             try:
                 self._stdin.close()
@@ -207,7 +244,10 @@ class ACPAdapter:
         while True:
             line = await self._stdout.readline()
             if not line:
-                break  # EOF — server exited
+                # EOF — server exited. Reject in-flight requests immediately so
+                # initialize()/new_session()/prompt() fail fast, not on timeout.
+                self._fail_pending(ACPProtocolError("ACP server closed the stream"))
+                break
             line = line.strip()
             if not line:
                 continue
@@ -260,27 +300,32 @@ class ACPAdapter:
 
     async def prompt(self, session_id: str, text: str, trace_id: str | None = None) -> str:
         """Run one turn. Returns the stopReason. Streams mapped events to sink."""
-        self._active_trace = trace_id or uuid.uuid4().hex
-        result = await self._request(
-            "session/prompt",
-            {"sessionId": session_id, "prompt": [{"type": "text", "text": text}]},
-        )
-        stop_reason = result.get("stopReason", "end_turn")
-        # Flush accumulated assistant text as the turn's final message.
-        await self._emit({"kind": "final", "trace_id": self._active_trace, "content": ""})
-        if stop_reason in ("refusal",):
-            await self._emit(
-                {
-                    "kind": "error",
-                    "trace_id": self._active_trace,
-                    "error": f"agent stopped: {stop_reason}",
-                }
+        trace = trace_id or uuid.uuid4().hex
+        self._active_trace = trace
+        self._assistant_buf = ""
+        try:
+            result = await self._request(
+                "session/prompt",
+                {"sessionId": session_id, "prompt": [{"type": "text", "text": text}]},
             )
-        trace = self._active_trace
-        self._active_trace = None
-        self._tool_titles.clear()
-        logger.debug("acp turn %s ended: stopReason=%s", trace, stop_reason)
-        return stop_reason
+            stop_reason = result.get("stopReason", "end_turn")
+            # Flush the accumulated assistant text as the turn's final message,
+            # so sinks that don't reassemble deltas still get the full reply.
+            await self._emit({"kind": "final", "trace_id": trace, "content": self._assistant_buf})
+            # Per the module contract, both refusal and error stop reasons are
+            # surfaced as an error event (not just refusal).
+            if stop_reason in ("refusal", "error"):
+                await self._emit(
+                    {"kind": "error", "trace_id": trace, "error": f"agent stopped: {stop_reason}"}
+                )
+            logger.debug("acp turn %s ended: stopReason=%s", trace, stop_reason)
+            return stop_reason
+        finally:
+            # Always clear turn state, even on timeout/EOF/JSON-RPC error, so a
+            # failed turn can't poison the next one with stale trace/tool data.
+            self._active_trace = None
+            self._tool_titles.clear()
+            self._assistant_buf = ""
 
     # ----------------------------------------------- notification -> taOS map
 
@@ -295,6 +340,9 @@ class ACPAdapter:
         if kind == "agent_message_chunk":
             text = _content_text(update.get("content"))
             if text:
+                # Accumulate for the turn's `final` reply, and stream as a delta.
+                if trace == self._active_trace:
+                    self._assistant_buf += text
                 await self._emit({"kind": "delta", "trace_id": trace, "content": text})
 
         elif kind == "agent_thought_chunk":


### PR DESCRIPTION
First concrete step of #571 (drop the OpenClaw fork). Lands the spike's ACP adapter into `dev` as a building block, with the fix that makes it actually work against real OpenClaw.

## Live validation (Pi, OpenClaw 2026.4.18, model `stepfun/step-3.7-flash:free`)
Drove a real `openclaw acp` bridge end-to-end:
- ✅ `initialize` + `session/new` handshake
- ✅ plain turn → `agent_message_chunk "acp-ok"`, `stopReason=end_turn`
- ✅ tool-forcing turn → completes, correct output
- **Keystone:** the bridge MUST be launched **bound to the agent's gateway session** (`--session agent:main:main`). Without it, `session/new` is unbound/model-less and `session/prompt` hangs forever (that was the earlier stall).
- No permission/fs round-trip occurs in gateway-backed mode (OpenClaw runs tools server-side), so the adapter's conservative `reject_once`/fs-disabled defaults are never hit on the happy path.

## Change
- `ACPConfig.session_key` + `_effective_command()` append `--session <key>`.
- Docstrings record the binding requirement.

## Scope
**Building block only** — nothing imports the adapter yet. Wiring it as OpenClaw's transport + switching `install.sh` to upstream OpenClaw (latest, no fork) is the next PR in #571.

## Tests
3 existing mock-server wire-parity tests + 3 new session-binding tests (6 pass).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added Agent Client Protocol (ACP) adapter for fork-free integration with ACP-compliant servers.
* Supports complete agent workflows: session management, streaming responses, tool execution, and permission requests.
* Configurable permission policies allow automated handling of server permission requests without manual intervention.
* Full integration with taOS event tracing for comprehensive activity monitoring and debugging across all protocol operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->