### PR TITLE
feat(agents): drive OpenClaw over ACP at runtime — bypass the fork bridge (#571 Phase A)

### DIFF
--- a/tests/test_openclaw_acp_runtime.py
+++ b/tests/test_openclaw_acp_runtime.py
@@ -1,0 +1,91 @@
+"""Tests for the fork-free OpenClaw ACP runtime driver."""
+from __future__ import annotations
+
+import pytest
+
+from tinyagentos.openclaw_acp_runtime import (
+    OPENCLAW_SESSION_KEY,
+    container_name,
+    drive_turn,
+)
+
+
+class _FakeAdapter:
+    def __init__(self, cfg, sink):
+        self.cfg = cfg
+        self.sink = sink
+        self.calls = []
+
+    async def spawn(self):
+        self.calls.append("spawn")
+
+    async def initialize(self):
+        self.calls.append("initialize")
+        return {"protocolVersion": 1}
+
+    async def new_session(self, *a, **k):
+        self.calls.append("new_session")
+        return "sid-1"
+
+    async def prompt(self, sid, text, trace_id=None):
+        self.calls.append(("prompt", sid, text, trace_id))
+        await self.sink({"kind": "delta", "trace_id": trace_id, "content": "hi"})
+        await self.sink({"kind": "final", "trace_id": trace_id, "content": "hi"})
+        return "end_turn"
+
+    async def close(self):
+        self.calls.append("close")
+
+
+def test_container_name():
+    assert container_name("kilotest") == "taos-agent-kilotest"
+
+
+@pytest.mark.asyncio
+async def test_drive_turn_binds_session_and_streams_replies():
+    captured = []
+
+    async def record_reply(slug, body):
+        captured.append((slug, body))
+
+    holder = {}
+
+    def factory(cfg, sink):
+        holder["a"] = _FakeAdapter(cfg, sink)
+        return holder["a"]
+
+    stop = await drive_turn(
+        slug="kilotest", text="hello", trace_id="t1",
+        record_reply=record_reply, adapter_factory=factory,
+    )
+    assert stop == "end_turn"
+    a = holder["a"]
+    # ACP bound to the agent session + launched via incus exec into the container.
+    assert a.cfg.session_key == OPENCLAW_SESSION_KEY
+    assert a.cfg.command == ["incus", "exec", "taos-agent-kilotest", "--", "openclaw", "acp"]
+    # Full lifecycle ran (and the transport was closed).
+    assert {"spawn", "initialize", "new_session", "close"} <= set(
+        c if isinstance(c, str) else c[0] for c in a.calls
+    )
+    # Replies streamed to record_reply tagged with the agent slug.
+    assert [b["kind"] for _, b in captured] == ["delta", "final"]
+    assert all(s == "kilotest" for s, _ in captured)
+
+
+@pytest.mark.asyncio
+async def test_drive_turn_emits_error_on_transport_failure():
+    captured = []
+
+    async def record_reply(slug, body):
+        captured.append((slug, body))
+
+    class _Boom(_FakeAdapter):
+        async def initialize(self):
+            raise RuntimeError("transport down")
+
+    stop = await drive_turn(
+        slug="x", text="t", trace_id="t1",
+        record_reply=record_reply, adapter_factory=lambda cfg, sink: _Boom(cfg, sink),
+    )
+    assert stop == "error"
+    assert any(b["kind"] == "error" for _, b in captured)

--- a/tests/test_openclaw_acp_runtime.py
+++ b/tests/test_openclaw_acp_runtime.py
@@ -89,3 +89,51 @@ async def test_drive_turn_emits_error_on_transport_failure():
     )
     assert stop == "error"
     assert any(b["kind"] == "error" for _, b in captured)
+
+
+@pytest.mark.asyncio
+async def test_drive_turn_handles_adapter_construction_failure():
+    """If building/spawning the adapter raises, drive_turn still degrades to
+    'error' (never propagates) and emits a chat-visible error."""
+    captured = []
+
+    async def record_reply(slug, body):
+        captured.append((slug, body))
+
+    def boom_factory(cfg, sink):
+        raise RuntimeError("cannot construct adapter")
+
+    stop = await drive_turn(
+        slug="x", text="t", trace_id="t1",
+        record_reply=record_reply, adapter_factory=boom_factory,
+    )
+    assert stop == "error"
+    assert any(b["kind"] == "error" for _, b in captured)
+
+
+@pytest.mark.asyncio
+async def test_run_acp_turn_serializes_per_agent(monkeypatch):
+    """Two turns for the SAME agent must not overlap (shared gateway session)."""
+    import asyncio
+    from unittest.mock import MagicMock
+    from tinyagentos.agent_chat_router import AgentChatRouter
+    import tinyagentos.openclaw_acp_runtime as rt
+
+    active = 0
+    max_concurrent = 0
+
+    async def fake_drive_turn(*, slug, text, trace_id, record_reply):
+        nonlocal active, max_concurrent
+        active += 1
+        max_concurrent = max(max_concurrent, active)
+        await asyncio.sleep(0.02)
+        active -= 1
+
+    monkeypatch.setattr(rt, "drive_turn", fake_drive_turn)
+
+    router = AgentChatRouter(MagicMock())
+    await asyncio.gather(
+        router._run_acp_turn("a1", "m1", "t1", None),
+        router._run_acp_turn("a1", "m2", "t2", None),
+    )
+    assert max_concurrent == 1  # serialized for the same agent

--- a/tinyagentos/adapters/acp_adapter.py
+++ b/tinyagentos/adapters/acp_adapter.py
@@ -208,6 +208,18 @@ class ACPAdapter:
                 self._proc.terminate()
             except ProcessLookupError:
                 pass
+            # Reap the child so a per-turn driver doesn't accumulate zombies
+            # (and to avoid the "Event loop is closed" __del__ noise). Bounded,
+            # then SIGKILL if it ignores SIGTERM.
+            try:
+                await asyncio.wait_for(self._proc.wait(), timeout=5)
+            except asyncio.TimeoutError:
+                try:
+                    self._proc.kill()
+                except ProcessLookupError:
+                    pass
+            except ProcessLookupError:
+                pass
 
     # ------------------------------------------------------- JSON-RPC plumbing
 

--- a/tinyagentos/adapters/acp_adapter.py
+++ b/tinyagentos/adapters/acp_adapter.py
@@ -216,6 +216,8 @@ class ACPAdapter:
             except asyncio.TimeoutError:
                 try:
                     self._proc.kill()
+                    # Reap after SIGKILL too, or the child lingers as a zombie.
+                    await self._proc.wait()
                 except ProcessLookupError:
                     pass
             except ProcessLookupError:

--- a/tinyagentos/agent_chat_router.py
+++ b/tinyagentos/agent_chat_router.py
@@ -2,9 +2,17 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+
+def _openclaw_transport() -> str:
+    """How taOS drives OpenClaw agents: ``acp`` (fork-free, default) drives the
+    agent over the Agent Client Protocol; ``bridge`` uses the legacy forked
+    taos-bridge SSE path. Override per-host with TAOS_OPENCLAW_TRANSPORT."""
+    return (os.environ.get("TAOS_OPENCLAW_TRANSPORT") or "acp").strip().lower()
 
 
 class AgentChatRouter:
@@ -21,6 +29,9 @@ class AgentChatRouter:
 
     def __init__(self, app_state: Any):
         self._state = app_state
+        # Holds in-flight ACP turn tasks so they aren't garbage-collected
+        # before completing (asyncio keeps only weak refs to tasks).
+        self._acp_tasks: set[asyncio.Task] = set()
 
     async def close(self) -> None:
         return
@@ -168,23 +179,41 @@ class AgentChatRouter:
                 )
                 continue
 
-            manual_text = build_manual(channel, agent_name, leads)
-            agent_context = [{"role": "system", "content": manual_text}, *context]
-            await bridge.enqueue_user_message(
-                agent_name,
-                {
-                    "id": message.get("id"),
-                    "trace_id": message.get("id"),
-                    "channel_id": message.get("channel_id"),
-                    "from": message.get("author_id", "user"),
-                    "text": message.get("content", ""),
-                    "created_at": message.get("created_at"),
-                    "hops_since_user": next_hops,
-                    "force_respond": forced,
-                    "context": agent_context,
-                    "thread_id": thread_id,
-                },
-            )
+            if agent.get("framework") == "openclaw" and _openclaw_transport() == "acp":
+                # Fork-free path: drive the OpenClaw turn over ACP instead of the
+                # legacy taos-bridge SSE. The agent's gateway session carries its
+                # own history + AGENTS.md, so we send the user message and stream
+                # the mapped replies straight into record_reply (same sink).
+                from tinyagentos.openclaw_acp_runtime import drive_turn
+
+                task = asyncio.create_task(
+                    drive_turn(
+                        slug=agent_name,
+                        text=message.get("content", ""),
+                        trace_id=message.get("id"),
+                        record_reply=bridge.record_reply,
+                    )
+                )
+                self._acp_tasks.add(task)
+                task.add_done_callback(self._acp_tasks.discard)
+            else:
+                manual_text = build_manual(channel, agent_name, leads)
+                agent_context = [{"role": "system", "content": manual_text}, *context]
+                await bridge.enqueue_user_message(
+                    agent_name,
+                    {
+                        "id": message.get("id"),
+                        "trace_id": message.get("id"),
+                        "channel_id": message.get("channel_id"),
+                        "from": message.get("author_id", "user"),
+                        "text": message.get("content", ""),
+                        "created_at": message.get("created_at"),
+                        "hops_since_user": next_hops,
+                        "force_respond": forced,
+                        "context": agent_context,
+                        "thread_id": thread_id,
+                    },
+                )
             if forced and policy is not None:
                 policy.record_send(policy_key, agent_name)
 

--- a/tinyagentos/agent_chat_router.py
+++ b/tinyagentos/agent_chat_router.py
@@ -32,9 +32,34 @@ class AgentChatRouter:
         # Holds in-flight ACP turn tasks so they aren't garbage-collected
         # before completing (asyncio keeps only weak refs to tasks).
         self._acp_tasks: set[asyncio.Task] = set()
+        # Per-agent lock so turns for the same agent run sequentially (a shared
+        # gateway session can't process two prompts at once) — concurrent
+        # across different agents. Preserves the bridge's queued-delivery order.
+        self._agent_locks: dict[str, asyncio.Lock] = {}
 
     async def close(self) -> None:
-        return
+        # Cancel + drain any in-flight ACP turns so shutdown doesn't orphan them.
+        tasks = list(self._acp_tasks)
+        for t in tasks:
+            t.cancel()
+        for t in tasks:
+            try:
+                await t
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
+        self._acp_tasks.clear()
+
+    async def _run_acp_turn(
+        self, agent_name: str, text: str, trace_id, record_reply,
+    ) -> None:
+        """Drive one OpenClaw ACP turn under the agent's serialization lock."""
+        from tinyagentos.openclaw_acp_runtime import drive_turn
+
+        lock = self._agent_locks.setdefault(agent_name, asyncio.Lock())
+        async with lock:
+            await drive_turn(
+                slug=agent_name, text=text, trace_id=trace_id, record_reply=record_reply,
+            )
 
     def dispatch(self, message: dict, channel: dict) -> None:
         """Fire-and-forget entry point. Runs routing in a background task."""
@@ -184,14 +209,13 @@ class AgentChatRouter:
                 # legacy taos-bridge SSE. The agent's gateway session carries its
                 # own history + AGENTS.md, so we send the user message and stream
                 # the mapped replies straight into record_reply (same sink).
-                from tinyagentos.openclaw_acp_runtime import drive_turn
-
+                # _run_acp_turn serializes turns per agent (shared session).
                 task = asyncio.create_task(
-                    drive_turn(
-                        slug=agent_name,
-                        text=message.get("content", ""),
-                        trace_id=message.get("id"),
-                        record_reply=bridge.record_reply,
+                    self._run_acp_turn(
+                        agent_name,
+                        message.get("content", ""),
+                        message.get("id"),
+                        bridge.record_reply,
                     )
                 )
                 self._acp_tasks.add(task)

--- a/tinyagentos/openclaw_acp_runtime.py
+++ b/tinyagentos/openclaw_acp_runtime.py
@@ -1,0 +1,75 @@
+"""Fork-free OpenClaw runtime: drive an agent turn over ACP.
+
+Replaces the forked ``taos-bridge`` (where OpenClaw connected OUT to taOS over
+SSE). Here taOS drives IN: it spawns ``openclaw acp --session <key>`` inside the
+agent's container and runs one turn via :class:`ACPAdapter`, mapping the ACP
+``session/update`` stream onto the same reply kinds ``bridge_session.record_reply``
+already consumes (delta/final/tool_call/tool_result/reasoning/error).
+
+Validated live against OpenClaw 2026.4.18: the bridge MUST be launched bound to
+the agent's gateway session (``agent:main:main``) or the turn hangs.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Awaitable, Callable
+
+from tinyagentos.adapters.acp_adapter import ACPAdapter, ACPConfig
+
+logger = logging.getLogger(__name__)
+
+# The persistent gateway session the agent runs under. Binding the ACP bridge
+# to it is required — an unbound session has no model and the turn hangs.
+OPENCLAW_SESSION_KEY = "agent:main:main"
+
+
+def container_name(slug: str) -> str:
+    """The LXC container name for an agent slug (matches deployer.py)."""
+    return f"taos-agent-{slug}"
+
+
+async def drive_turn(
+    *,
+    slug: str,
+    text: str,
+    trace_id: str | None,
+    record_reply: Callable[[str, dict], Awaitable[None]],
+    exec_command: list[str] | None = None,
+    adapter_factory: Callable[[ACPConfig, Callable], ACPAdapter] = ACPAdapter,
+) -> str:
+    """Run one OpenClaw turn for *slug* over ACP, streaming mapped replies to
+    ``record_reply(slug, body)``. Returns the ACP stopReason.
+
+    Spawns ``openclaw acp`` inside the agent's container via ``incus exec`` (the
+    controller runs as root, so no sudo). ``exec_command`` overrides the launch
+    argv (tests / non-incus backends); ``adapter_factory`` is injectable for
+    tests.
+    """
+    command = exec_command or [
+        "incus", "exec", container_name(slug), "--", "openclaw", "acp",
+    ]
+
+    async def sink(body: dict) -> None:
+        # The adapter emits bridge_session-shaped reply dicts already.
+        await record_reply(slug, body)
+
+    cfg = ACPConfig(command=command, session_key=OPENCLAW_SESSION_KEY)
+    adapter = adapter_factory(cfg, sink)
+    try:
+        await adapter.spawn()
+        await adapter.initialize()
+        session_id = await adapter.new_session()
+        stop_reason = await adapter.prompt(session_id, text, trace_id=trace_id)
+        logger.info("openclaw acp turn slug=%s stopReason=%s", slug, stop_reason)
+        return stop_reason
+    except Exception:
+        logger.exception("openclaw acp turn failed for %s", slug)
+        # Surface a turn-level error to the chat the same way a bridge error would.
+        await record_reply(slug, {
+            "kind": "error",
+            "trace_id": trace_id,
+            "error": "agent turn failed (ACP transport)",
+        })
+        return "error"
+    finally:
+        await adapter.close()

--- a/tinyagentos/openclaw_acp_runtime.py
+++ b/tinyagentos/openclaw_acp_runtime.py
@@ -54,8 +54,9 @@ async def drive_turn(
         await record_reply(slug, body)
 
     cfg = ACPConfig(command=command, session_key=OPENCLAW_SESSION_KEY)
-    adapter = adapter_factory(cfg, sink)
+    adapter = None
     try:
+        adapter = adapter_factory(cfg, sink)
         await adapter.spawn()
         await adapter.initialize()
         session_id = await adapter.new_session()
@@ -63,13 +64,22 @@ async def drive_turn(
         logger.info("openclaw acp turn slug=%s stopReason=%s", slug, stop_reason)
         return stop_reason
     except Exception:
+        # Never let a transport/adapter failure escape — always degrade to a
+        # chat-visible error so the turn ends cleanly. The record_reply itself
+        # is guarded too (its failure must not mask the original).
         logger.exception("openclaw acp turn failed for %s", slug)
-        # Surface a turn-level error to the chat the same way a bridge error would.
-        await record_reply(slug, {
-            "kind": "error",
-            "trace_id": trace_id,
-            "error": "agent turn failed (ACP transport)",
-        })
+        try:
+            await record_reply(slug, {
+                "kind": "error",
+                "trace_id": trace_id,
+                "error": "agent turn failed (ACP transport)",
+            })
+        except Exception:
+            logger.exception("openclaw acp: error reply also failed for %s", slug)
         return "error"
     finally:
-        await adapter.close()
+        if adapter is not None:
+            try:
+                await adapter.close()
+            except Exception:
+                logger.exception("openclaw acp: adapter close failed for %s", slug)


### PR DESCRIPTION
**#571 Phase A.** taOS now drives OpenClaw turns over **ACP** instead of the forked `taos-bridge` (where OpenClaw connected OUT via SSE). This removes the bridge from the loop — the keystone toward dropping the fork.

## Change
- **`openclaw_acp_runtime.drive_turn`** — spawns `incus exec taos-agent-<slug> -- openclaw acp --session agent:main:main` via the merged `ACPAdapter` and streams the mapped events (`delta/final/tool_call/tool_result/reasoning/error`) straight into `bridge_session.record_reply` (the existing sink — no chat/trace changes needed).
- **`agent_chat_router`** — OpenClaw agents route via `drive_turn` instead of `bridge.enqueue_user_message`. Gated by `TAOS_OPENCLAW_TRANSPORT` (default `acp`; set `bridge` to fall back — a safe escape hatch).
- **`acp_adapter.close()`** — reap the subprocess so a per-turn driver doesn't leak zombie `incus exec` processes.

## Validated live (Pi, kilotest agent, OpenClaw 2026.4.18)
Ran `drive_turn` through the real controller→`incus exec`→`openclaw acp` path: `stopReason=end_turn`, replies `['delta','final']`, model output `runtime-ok`. **The bridge is not involved.**

## Scope / what's next
- The agent still runs the fork's OpenClaw **binary** — **Phase B** switches `install.sh` to **upstream OpenClaw (latest)**, which fully drops the fork.
- The bridge endpoints (`routes/openclaw.py`) + SSE half stay until nothing uses them (retire after Phase B); the `bridge` transport flag keeps them reachable meanwhile.
- v1 sends the user message as the prompt (the gateway session holds history); richer multi-agent channel-manual passing is a follow-up.

## Tests
`drive_turn` lifecycle/session-binding/error-path (3) + adapter suite (7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fork-free OpenClaw ACP runtime with integrated ACP routing that drives and streams adapter replies, and serializes turns per agent.

* **Bug Fixes**
  * Improved subprocess cleanup to avoid zombie processes; ensures adapters are closed and adapter-close failures are handled.

* **Tests**
  * Added tests covering lifecycle, session binding, reply streaming, error scenarios, and per-agent serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->