### PR TITLE
feat(agents): install upstream OpenClaw from npm — drop the fork (#571 Phase B)

### DIFF
--- a/.github/workflows/build-agent-images.yml
+++ b/.github/workflows/build-agent-images.yml
@@ -92,14 +92,10 @@ jobs:
           curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
           apt-get install -y -qq --no-install-recommends nodejs
 
-          # openclaw prebuilt tarball from the fork's rolling release.
-          TARBALL="/tmp/openclaw-taos-fork-${ARCH}.tgz"
-          curl -fsSL --max-time 120 \
-            -o "$TARBALL" \
-            "https://github.com/jaylfc/openclaw/releases/latest/download/openclaw-taos-fork-linux-${ARCH}.tgz"
-          file "$TARBALL" | grep -qE "gzip|compressed"
-          npm install -g --unsafe-perm --ignore-scripts "$TARBALL"
-          rm -f "$TARBALL"
+          # Upstream OpenClaw from npm (latest) — no fork. The deploy-time
+          # install.sh also installs openclaw@latest, so this just warms the
+          # base image with a current build.
+          npm install -g --unsafe-perm openclaw@latest
 
           # Sanity check
           test -f /usr/lib/node_modules/openclaw/dist/entry.js \

--- a/app-catalog/agents/openclaw/scripts/install.sh
+++ b/app-catalog/agents/openclaw/scripts/install.sh
@@ -8,39 +8,40 @@
 # taos-bridge channel is no longer installed/needed.
 set -euo pipefail
 
-# When the deployer launched this container from the pre-built
-# taos-openclaw-base image, Node + openclaw + recycle-bin are already
-# installed. In that case skip everything up to the config/env writes
-# and the systemd unit — those still need per-deploy values.
+# The pre-built taos-openclaw-base image warms Node + system deps + a recent
+# openclaw. We still always install openclaw@latest from npm (the base image's
+# baked version may lag) and re-write per-deploy config/env + the systemd unit.
 # See tinyagentos/agent_image.py and .github/workflows/build-agent-images.yml.
 TAOS_BASE_IMAGE_PRESENT="${TAOS_BASE_IMAGE_PRESENT:-0}"
-if [ "$TAOS_BASE_IMAGE_PRESENT" = "1" ]; then
-  echo "[openclaw] base image present — skipping Node + openclaw install"
-else
-  echo "[openclaw] installing Node 22.x (NodeSource) + openclaw prebuilt from GitHub Releases"
-fi
+echo "[openclaw] installing upstream OpenClaw (openclaw@latest from npm)"
 
 # ---------------------------------------------------------------------------
-# 1. Node 22.14+ via NodeSource (Debian bookworm default is Node 18, too old).
-#    Also ensure:
-#    - 'file' is present — used to sanity-check the downloaded tarball.
-#    - 'git' is present — openclaw's transitive dep libsignal
-#      (@whiskeysockets/baileys -> libsignal@git+https://github.com/...)
-#      is a git-URL dependency and npm needs git to fetch it at install time.
+# 1. Node >= 22.19 via NodeSource (upstream OpenClaw's minimum; Debian default
+#    is too old). Also ensure 'git' — OpenClaw has a git-URL transitive dep
+#    (libsignal via @whiskeysockets/baileys) that npm fetches at install time.
 #
-#    All three are baked into the pre-built base image; skip when it's present.
+#    Checked the FULL version, not just major: Node 22.0–22.18 satisfies a
+#    major-only "== 22" guard but is too old for OpenClaw and only fails later.
+#    Run unconditionally — a base image with an older baked Node must be
+#    upgraded too (the check is a no-op when Node is already current).
 # ---------------------------------------------------------------------------
-if [ "$TAOS_BASE_IMAGE_PRESENT" != "1" ]; then
-  if ! command -v node >/dev/null 2>&1 || [ "$(node -v | sed 's/^v//; s/\..*//')" -lt 22 ]; then
-    curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends nodejs
-  fi
-  if ! command -v file >/dev/null 2>&1; then
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends file
-  fi
-  if ! command -v git >/dev/null 2>&1; then
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends git
-  fi
+_node_ok() {
+  command -v node >/dev/null 2>&1 || return 1
+  local v maj min
+  v=$(node -v | sed 's/^v//')      # e.g. 22.22.3
+  maj=${v%%.*}
+  min=${v#*.}; min=${min%%.*}
+  [ "$maj" -gt 22 ] && return 0
+  [ "$maj" -eq 22 ] && [ "$min" -ge 19 ] && return 0
+  return 1
+}
+if ! _node_ok; then
+  echo "[openclaw] installing Node >=22.19 via NodeSource"
+  curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends nodejs
+fi
+if ! command -v git >/dev/null 2>&1; then
+  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends git
 fi
 
 # ----------------------------------------------------------------------

--- a/app-catalog/agents/openclaw/scripts/install.sh
+++ b/app-catalog/agents/openclaw/scripts/install.sh
@@ -3,8 +3,9 @@
 # Runs once inside a fresh Debian bookworm LXC container.
 # Idempotent: safe to re-run on an already-provisioned container.
 #
-# Installs openclaw from prebuilt tarballs published by jaylfc/openclaw taos-fork CI.
-# The fork's .github/workflows/release.yml builds per-arch tarballs on every push.
+# Installs UPSTREAM OpenClaw from npm (openclaw@latest) — no fork. taOS drives
+# the agent over ACP (tinyagentos/openclaw_acp_runtime), so the legacy
+# taos-bridge channel is no longer installed/needed.
 set -euo pipefail
 
 # When the deployer launched this container from the pre-built
@@ -43,85 +44,29 @@ if [ "$TAOS_BASE_IMAGE_PRESENT" != "1" ]; then
 fi
 
 # ----------------------------------------------------------------------
-# 2. Install openclaw from a prebuilt tarball published by the fork's CI.
-# This avoids any build-at-deploy time. The fork's GitHub Actions
-# workflow .github/workflows/release.yml builds a fresh tarball per
-# architecture on every push to taos-fork and publishes them as assets
-# on the "rolling" Release. We always grab the latest.
-#
-# If GitHub is unreachable we FAIL — there is no build fallback. Build
-# at deploy time was tried and is brittle (workspace deps, partial
-# artefacts, slow on arm64); the right fix is to make the prebuilt path
-# reliable, not to paper over its absence.
+# 2. Install upstream OpenClaw from npm (latest by default — NO fork).
+# The published `openclaw` package ships ready-to-run; we always pull
+# @latest so deploys and updates track upstream OpenClaw. We install even
+# when the pre-built base image is present (its baked openclaw may be an
+# older/forked build) — the npm install is the source of truth for the
+# binary version. Requires Node 22.19+ (installed above / in the base image).
+# taOS drives the agent over ACP (openclaw_acp_runtime), so no fork bridge
+# is needed.
 # ----------------------------------------------------------------------
 
-if [ "$TAOS_BASE_IMAGE_PRESENT" = "1" ]; then
-  # Base image already has openclaw installed globally. Just verify.
-  if [ ! -f /usr/lib/node_modules/openclaw/dist/entry.js ] && [ ! -f /usr/lib/node_modules/openclaw/dist/entry.mjs ]; then
-    echo "[openclaw] FATAL: base image claims openclaw installed but dist/entry.{js,mjs} missing"
-    ls -la /usr/lib/node_modules/openclaw/dist/ 2>/dev/null | head -10
-    exit 1
-  fi
-  echo "[openclaw] using baked-in openclaw from base image"
-else
-  # Architecture detection
-  ARCH=$(uname -m)
-  case "$ARCH" in
-    aarch64|arm64) NPM_ARCH=arm64 ;;
-    x86_64|amd64)  NPM_ARCH=x64 ;;
-    *)
-      echo "[openclaw] FATAL: unsupported architecture $ARCH"
-      echo "[openclaw] supported: aarch64, x86_64"
-      echo "[openclaw] open an issue at github.com/jaylfc/openclaw if you need another arch."
-      exit 1
-      ;;
-  esac
-
-  TARBALL_URL="https://github.com/jaylfc/openclaw/releases/latest/download/openclaw-taos-fork-linux-${NPM_ARCH}.tgz"
-  TARBALL_DEST="/tmp/openclaw-taos-fork-${NPM_ARCH}.tgz"
-
-  echo "[openclaw] downloading prebuilt tarball for ${NPM_ARCH} from GitHub Releases"
-  if ! curl -fsSL --max-time 120 -o "$TARBALL_DEST" "$TARBALL_URL"; then
-    echo "[openclaw] FATAL: cannot download $TARBALL_URL"
-    echo "[openclaw] check network connectivity to github.com from inside this container."
-    echo "[openclaw] cf. docs/runbooks/openclaw-install-troubleshooting.md"
-    exit 1
-  fi
-
-  # Sanity check the file we got
-  if ! [ -s "$TARBALL_DEST" ]; then
-    echo "[openclaw] FATAL: downloaded tarball is empty"
-    exit 1
-  fi
-  file "$TARBALL_DEST" | grep -qE "gzip|compressed" || {
-    echo "[openclaw] FATAL: downloaded file is not a gzipped tarball:"
-    file "$TARBALL_DEST"
-    head -c 500 "$TARBALL_DEST"
-    exit 1
-  }
-
-  # Install from the local file (no network re-fetch, no build).
-  # --ignore-scripts: the tarball already has dist/ built by CI; we must NOT
-  # run the prepare script because it tries to spawn git (for hook setup) and
-  # falls back to pnpm build:docker — both of which are wrong and unnecessary
-  # when installing a prebuilt tarball.
-  echo "[openclaw] installing $TARBALL_DEST"
-  npm install -g --unsafe-perm --ignore-scripts "$TARBALL_DEST"
-
-  # Cleanup the downloaded tarball — keeps container small
-  rm -f "$TARBALL_DEST"
-
-  # Verify entry exists
-  if [ ! -f /usr/lib/node_modules/openclaw/dist/entry.js ] && [ ! -f /usr/lib/node_modules/openclaw/dist/entry.mjs ]; then
-    echo "[openclaw] FATAL: install completed but dist/entry.{js,mjs} missing"
-    echo "[openclaw] this means the published tarball is broken. report at:"
-    echo "  github.com/jaylfc/openclaw/issues — include the URL above and the build SHA."
-    ls -la /usr/lib/node_modules/openclaw/dist/ | head -10
-    exit 1
-  fi
-
-  echo "[openclaw] install OK"
+echo "[openclaw] installing openclaw@latest from npm (upstream)"
+if ! npm install -g --unsafe-perm openclaw@latest; then
+  echo "[openclaw] FATAL: 'npm install -g openclaw@latest' failed"
+  echo "[openclaw] check network connectivity to the npm registry from inside this container."
+  exit 1
 fi
+
+if ! command -v openclaw >/dev/null 2>&1; then
+  echo "[openclaw] FATAL: openclaw CLI not on PATH after install"
+  exit 1
+fi
+
+echo "[openclaw] install OK: $(openclaw --version 2>/dev/null | head -1)"
 
 # ------------------------------------------------------------------
 # 2a. Bootstrap config + env for the openclaw bridge. Written from env

--- a/tests/test_framework_api.py
+++ b/tests/test_framework_api.py
@@ -43,12 +43,23 @@ async def test_get_framework_no_latest_when_source_missing(client, app):
 
 @pytest.mark.asyncio
 async def test_post_update_kicks_off_task(client, app, monkeypatch):
+    # The GitHub-asset update route needs a framework with a release_source.
+    # OpenClaw is npm-based now (no release_source), so use a synthetic
+    # release-sourced framework to exercise the route mechanism generically.
+    from tinyagentos import frameworks as fw_mod
+    monkeypatch.setitem(fw_mod.FRAMEWORKS, "fwupd", {
+        "id": "fwupd", "name": "FwUpd",
+        "release_source": "github:example/fwupd",
+        "release_asset_pattern": "fwupd-{arch}.tgz",
+        "install_script": "/usr/local/bin/taos-framework-update",
+        "service_name": "fwupd",
+    })
     app.state.config.agents.append({
-        "name": "atlas-post", "framework": "openclaw",
+        "name": "atlas-post", "framework": "fwupd",
         "framework_update_status": "idle",
     })
     app.state.latest_framework_versions = {
-        "openclaw": {"tag": "T2", "sha": "b2b2b2b", "asset_url": "u"},
+        "fwupd": {"tag": "T2", "sha": "b2b2b2b", "asset_url": "u"},
     }
     kicked = {}
     async def fake(agent, manifest, latest, *, save_config):

--- a/tests/test_framework_manifest.py
+++ b/tests/test_framework_manifest.py
@@ -1,10 +1,13 @@
 import pytest
 from tinyagentos.frameworks import FRAMEWORKS, validate_framework_manifest, FrameworkManifestError
 
-def test_openclaw_has_update_metadata():
+def test_openclaw_is_npm_based_no_fork_release_source():
+    # OpenClaw installs from npm (openclaw@latest) and is driven over ACP — no
+    # fork, so no GitHub-asset release_source/asset_pattern. npm version
+    # tracking lands with #570.
     fw = FRAMEWORKS["openclaw"]
-    assert fw["release_source"] == "github:jaylfc/openclaw"
-    assert "{arch}" in fw["release_asset_pattern"]
+    assert "release_source" not in fw
+    assert "release_asset_pattern" not in fw
     assert fw["install_script"] == "/usr/local/bin/taos-framework-update"
     assert fw["service_name"] == "openclaw"
 

--- a/tinyagentos/frameworks.py
+++ b/tinyagentos/frameworks.py
@@ -12,10 +12,13 @@ FRAMEWORKS: dict[str, dict] = {
     "openclaw": {
         "id": "openclaw",
         "name": "OpenClaw",
-        "description": "OpenClaw LXC-native agent via HTTP proxy",
+        "description": "Upstream OpenClaw, driven over ACP (no fork)",
         "verification_status": "beta",
-        "release_source": "github:jaylfc/openclaw",
-        "release_asset_pattern": "openclaw-taos-fork-linux-{arch}.tgz",
+        # Installed from npm (openclaw@latest) — see install.sh — and driven
+        # over ACP (openclaw_acp_runtime), so there is no fork release to track.
+        # The GitHub-asset version-check doesn't fit an npm-distributed package;
+        # npm-based version tracking lands with #570. (Dropping release_source
+        # makes auto_update.poll_frameworks skip the version probe for openclaw.)
         "install_script": "/usr/local/bin/taos-framework-update",
         "service_name": "openclaw",
         "slash_commands": [


### PR DESCRIPTION
**#571 Phase B** — completes dropping the OpenClaw fork. With #574 (ACP runtime) already merged, the agent now runs **upstream OpenClaw** driven over **ACP** — no fork binary, no `taos-bridge`.

## Changes
- **`install.sh`** → `npm install -g openclaw@latest` (upstream), dropping the `jaylfc/openclaw` fork tarball. Runs unconditionally (base image just warms Node/system deps).
- **`build-agent-images.yml`** → warms the base image with `openclaw@latest` instead of the fork tarball.
- **`frameworks.py`** → drops the fork `release_source`/`release_asset_pattern` (openclaw is npm-distributed; the GitHub-asset version-check doesn't fit npm — npm version tracking is #570). `poll_frameworks` skips the version-probe for openclaw.
- **Tests** → openclaw manifest asserts npm-based; the github-asset update-route test uses a synthetic release-sourced framework so the route stays covered.

## Validated
`npm install -g openclaw@latest` on arm64 (Pi) → **OpenClaw 2026.6.1** (newer than the fork's 2026.4.18), Node 22.22, `openclaw acp` present. The ACP runtime (#574) already drove a live turn end-to-end.

## Follow-ups (not blocking)
- Retire the fork's `release.yml` + the `openclaw-fork-published` cross-repo dispatch.
- Retire the bridge endpoints (`routes/openclaw.py`) once `TAOS_OPENCLAW_TRANSPORT=acp` is confirmed everywhere.
- npm-based per-agent version selection/rollback → #570.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified OpenClaw installation to use the upstream npm package instead of fork-specific artifacts
  * Updated installation scripts and framework configuration to reflect the npm-based release mechanism
  * Updated tests to verify the new npm-driven approach

<!-- end of auto-generated comment: release notes by coderabbit.ai -->