### PR TITLE
feat(providers): periodic cloud-provider refresh — keep LiteLLM fresh with upstream catalogs

### DIFF
--- a/tests/test_provider_refresh.py
+++ b/tests/test_provider_refresh.py
@@ -1,0 +1,66 @@
+"""Cloud-provider periodic refresh: reload LiteLLM only when the catalog changes."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import tinyagentos.routes.providers as P
+from tinyagentos.provider_refresh import CloudProviderRefresher
+
+
+class _FakeProxy:
+    def __init__(self):
+        self.reloads = 0
+    def is_running(self):
+        return True
+    async def reload_config(self, backends, secrets=None):
+        self.reloads += 1
+
+
+@pytest.mark.asyncio
+async def test_reloads_only_when_catalog_changes(monkeypatch, tmp_path):
+    backend = {"name": "kilo", "type": "kilocode", "url": "u", "models": [{"id": "a"}]}
+    config = SimpleNamespace(backends=[backend], config_path=tmp_path / "config.yaml")
+    proxy = _FakeProxy()
+    state = SimpleNamespace(config=config, llm_proxy=proxy)
+
+    async def _noop_save(*a, **k):
+        return None
+    async def _no_secrets(*a, **k):
+        return []
+    monkeypatch.setattr(P, "save_config_locked", _noop_save)
+    monkeypatch.setattr(P, "_resolve_backend_secrets", _no_secrets)
+
+    # 1) Re-probe discovers a NEW model -> change -> reload.
+    async def _adds_model(app_state, b, timeout=5.0):
+        b["models"] = [{"id": "a"}, {"id": "b"}]
+        return b
+    monkeypatch.setattr(P, "_refresh_backend", _adds_model)
+    assert await P.refresh_cloud_backends_if_changed(state, config, proxy) is True
+    assert proxy.reloads == 1
+
+    # 2) Re-probe finds the SAME models -> no change -> no reload.
+    async def _no_change(app_state, b, timeout=5.0):
+        return b
+    monkeypatch.setattr(P, "_refresh_backend", _no_change)
+    assert await P.refresh_cloud_backends_if_changed(state, config, proxy) is False
+    assert proxy.reloads == 1  # unchanged
+
+
+@pytest.mark.asyncio
+async def test_no_cloud_backends_is_noop(monkeypatch, tmp_path):
+    config = SimpleNamespace(backends=[{"name": "local", "type": "rkllama"}],
+                             config_path=tmp_path / "c.yaml")
+    proxy = _FakeProxy()
+    state = SimpleNamespace(config=config, llm_proxy=proxy)
+    assert await P.refresh_cloud_backends_if_changed(state, config, proxy) is False
+    assert proxy.reloads == 0
+
+
+@pytest.mark.asyncio
+async def test_refresher_start_stop():
+    state = SimpleNamespace(config=SimpleNamespace(backends=[]), llm_proxy=None)
+    r = CloudProviderRefresher(state, interval=0.01, initial_delay=0.01)
+    await r.start()
+    await r.stop()  # must not hang/raise

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -680,6 +680,15 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
             await auto_updater.start()
         except Exception:
             logger.exception("auto-update service failed to start")
+        # Keep LiteLLM's model_list fresh as cloud provider catalogs change
+        # upstream (e.g. a newly published model), without a restart.
+        from tinyagentos.provider_refresh import CloudProviderRefresher
+        provider_refresher = CloudProviderRefresher(app.state)
+        app.state.provider_refresher = provider_refresher
+        try:
+            await provider_refresher.start()
+        except Exception:
+            logger.exception("cloud provider refresher failed to start")
         await cluster_manager.start()
         # Enroll this controller as the 'local' cluster worker so route-layer
         # code (get_local_worker) picks up the in-memory signing key.
@@ -917,6 +926,10 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await monitor.stop()
         try:
             await auto_updater.stop()
+        except Exception:
+            pass
+        try:
+            await provider_refresher.stop()
         except Exception:
             pass
         await app.state.mcp_supervisor.stop_all()

--- a/tinyagentos/provider_refresh.py
+++ b/tinyagentos/provider_refresh.py
@@ -1,0 +1,81 @@
+"""Periodic cloud-provider catalog refresh.
+
+Cloud providers (kilocode/openrouter/openai/…) gain and lose models upstream
+over time. Without a refresh, taOS's LiteLLM ``model_list`` goes stale — a
+newly published model 404s until someone PATCHes the provider or restarts.
+This service re-probes the cloud providers on an interval and reloads LiteLLM
+ONLY when the catalog actually changed (see
+``providers.refresh_cloud_backends_if_changed``).
+
+Mirrors AutoUpdateService's lifecycle (start/stop in the app lifespan).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# How often to re-probe cloud provider catalogs (seconds).
+REFRESH_INTERVAL = 15 * 60
+# Delay before the first probe so we don't add load during boot.
+INITIAL_DELAY = 120
+
+
+class CloudProviderRefresher:
+    """Background task that keeps LiteLLM's model_list fresh with upstream."""
+
+    def __init__(self, app_state, interval: float = REFRESH_INTERVAL,
+                 initial_delay: float = INITIAL_DELAY):
+        self._state = app_state
+        self._interval = interval
+        self._initial_delay = initial_delay
+        self._task: Optional[asyncio.Task] = None
+        self._stop = asyncio.Event()
+
+    async def start(self) -> None:
+        if self._task is not None:
+            return
+        self._stop.clear()
+        self._task = asyncio.create_task(self._loop(), name="cloud-provider-refresh")
+        logger.info("CloudProviderRefresher started (interval=%ds)", self._interval)
+
+    async def stop(self) -> None:
+        self._stop.set()
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+
+    async def _loop(self) -> None:
+        try:
+            await asyncio.wait_for(self._stop.wait(), timeout=self._initial_delay)
+            return  # stopped during the initial delay
+        except asyncio.TimeoutError:
+            pass
+        while True:
+            try:
+                await self._refresh_once()
+            except Exception:
+                logger.exception("cloud provider refresh failed")
+            try:
+                await asyncio.wait_for(self._stop.wait(), timeout=self._interval)
+                return
+            except asyncio.TimeoutError:
+                pass  # next cycle
+
+    async def _refresh_once(self) -> None:
+        # Imported lazily to avoid a route<-service import cycle at module load.
+        from tinyagentos.routes.providers import refresh_cloud_backends_if_changed
+
+        config = getattr(self._state, "config", None)
+        if config is None:
+            return
+        proxy = getattr(self._state, "llm_proxy", None)
+        reloaded = await refresh_cloud_backends_if_changed(self._state, config, proxy)
+        if reloaded:
+            logger.info("cloud provider refresh: catalog changed, LiteLLM reloaded")

--- a/tinyagentos/routes/providers.py
+++ b/tinyagentos/routes/providers.py
@@ -183,6 +183,41 @@ async def _refresh_all_cloud_backends(app_state, config, proxy) -> int:
     return len(cloud)
 
 
+def _cloud_model_ids(backend: dict) -> list[str]:
+    """Sorted model id list for a backend, for change detection."""
+    return sorted(
+        (m.get("id") or m.get("name") or "") if isinstance(m, dict) else str(m)
+        for m in (backend.get("models") or [])
+    )
+
+
+async def refresh_cloud_backends_if_changed(app_state, config, proxy) -> bool:
+    """Re-probe cloud backends; persist + reload LiteLLM ONLY if a model list
+    actually changed (so a stable catalog doesn't trigger needless reloads that
+    disrupt in-flight requests). Returns True if a reload happened.
+
+    This is what the periodic refresher calls — it keeps LiteLLM's model_list
+    fresh as upstream provider catalogs gain/lose models, without a restart.
+    """
+    cloud = [b for b in config.backends if b.get("type") in CLOUD_TYPES]
+    if not cloud:
+        return False
+    before = {b.get("name"): _cloud_model_ids(b) for b in cloud}
+    await asyncio.gather(
+        *(_refresh_backend(app_state, b) for b in cloud),
+        return_exceptions=True,
+    )
+    after = {b.get("name"): _cloud_model_ids(b) for b in cloud}
+    if before == after:
+        return False
+    await save_config_locked(config, config.config_path)
+    if proxy and proxy.is_running():
+        resolved = await _resolve_backend_secrets(app_state, config.backends)
+        await proxy.reload_config(config.backends, secrets=resolved)
+    logger.info("provider refresh: cloud model list changed — reloaded LiteLLM")
+    return True
+
+
 async def _fetch_litellm_models(proxy) -> list[dict]:
     """Fetch ``/v1/models`` from the running LiteLLM proxy using the master
     key. Returns the raw ``data`` list (list of dicts) or ``[]`` on any


### PR DESCRIPTION
## Why
Cloud provider catalogs change upstream over time. Kilo published `nvidia/nemotron-3-ultra-550b-a55b:free` today — but taOS's LiteLLM `model_list` stayed stale, so the model **404'd** until I manually PATCHed the provider (re-probe → reload). Same drift would bite any new upstream model.

## What
`CloudProviderRefresher` — a background service (started in the app lifespan, mirroring `AutoUpdateService`) that every **15 min** re-probes cloud providers and reloads LiteLLM **only when the catalog actually changed** (`refresh_cloud_backends_if_changed` diffs the model-id sets, so a stable catalog never triggers a needless reload that would disrupt in-flight requests).

- Key/secret changes already reload via `PATCH /api/providers`; this closes the **upstream-catalog-drift** gap.
- Initial 120s delay so it doesn't add boot load; clean start/stop.

## Tests
reload-on-change, no-reload-when-unchanged, no-cloud-backends no-op, start/stop (3 pass).

Part of the "ensure LiteLLM updates when needed" ask.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cloud provider catalogs now refresh periodically in the background, automatically updating the model list when changes are detected.

* **Tests**
  * Added test coverage for catalog change detection, selective model reloading, and background refresher lifecycle management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->