### PR TITLE
feat(agents): change an agent's model from agent settings

### DIFF
--- a/desktop/src/components/agent-settings/FrameworkTab.test.tsx
+++ b/desktop/src/components/agent-settings/FrameworkTab.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+
+vi.mock("@/lib/framework-api", () => ({
+  fetchFrameworkState: vi.fn(async () => ({
+    framework: "hermes",
+    installed: { tag: "v1", sha: "abc" },
+    latest: null,
+    update_available: false,
+    update_status: "idle",
+  })),
+  startFrameworkUpdate: vi.fn(),
+}));
+
+import { FrameworkTab } from "./FrameworkTab";
+
+const originalFetch = global.fetch;
+afterEach(() => { global.fetch = originalFetch; vi.clearAllMocks(); });
+
+describe("FrameworkTab — model change", () => {
+  beforeEach(() => {
+    global.fetch = vi.fn(async (url: string) => {
+      if (String(url).includes("/api/providers/models")) {
+        return { ok: true, json: async () => ({ data: [{ id: "nvidia/x:free" }] }) } as Response;
+      }
+      return { ok: true, json: async () => ({}) } as Response;
+    }) as unknown as typeof fetch;
+  });
+
+  it("shows the current model and opens the picker (loading routable models)", async () => {
+    render(<FrameworkTab agent={{ name: "naira", model: "stepfun/old:free" }} onUpdated={() => {}} />);
+    // Current model surfaced.
+    expect(await screen.findByText("stepfun/old:free")).toBeInTheDocument();
+    // Open the picker → it loads /api/providers/models.
+    fireEvent.click(screen.getByRole("button", { name: /change model/i }));
+    await waitFor(() =>
+      expect(
+        (global.fetch as any).mock.calls.some((c: any[]) => String(c[0]).includes("/api/providers/models")),
+      ).toBe(true),
+    );
+  });
+});

--- a/desktop/src/components/agent-settings/FrameworkTab.tsx
+++ b/desktop/src/components/agent-settings/FrameworkTab.tsx
@@ -1,12 +1,62 @@
 import { useEffect, useState } from "react";
 import { fetchFrameworkState, FrameworkState, startFrameworkUpdate } from "@/lib/framework-api";
+import { ModelPickerModal } from "@/components/ModelPickerModal";
+import type { AgentModel } from "@/components/ModelPickerFlow";
 
-export function FrameworkTab({ agent, onUpdated }: { agent: { name: string }; onUpdated: () => void }) {
+export function FrameworkTab(
+  { agent, onUpdated }: { agent: { name: string; model?: string }; onUpdated: () => void },
+) {
   const [state, setState] = useState<FrameworkState | null>(null);
   const [err, setErr] = useState<string | null>(null);
   const [confirming, setConfirming] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [elapsed, setElapsed] = useState(0);
+
+  // Model change — swap the agent's primary model without a redeploy
+  // (POST /api/agents/{name}/model updates the LiteLLM route + resumes).
+  const [currentModel, setCurrentModel] = useState<string | undefined>(agent.model);
+  const [models, setModels] = useState<AgentModel[]>([]);
+  const [modelsLoaded, setModelsLoaded] = useState(false);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [modelErr, setModelErr] = useState<string | null>(null);
+
+  // Routable models = LiteLLM /v1/models passthrough (single source of truth
+  // for what an agent can use). Loaded when the picker is first opened.
+  async function openPicker() {
+    setPickerOpen(true);
+    if (modelsLoaded) return;
+    try {
+      const res = await fetch("/api/providers/models?refresh=true", {
+        headers: { Accept: "application/json" },
+      });
+      const data = res.ok ? await res.json() : { data: [] };
+      setModels((data.data ?? []).map((m: { id: string }) => ({
+        id: m.id, name: m.id, hostKind: "cloud" as const,
+      })));
+    } catch { /* leave empty — picker shows no models */ }
+    finally { setModelsLoaded(true); }
+  }
+
+  async function changeModel(modelId: string) {
+    setModelErr(null);
+    try {
+      const res = await fetch(`/api/agents/${encodeURIComponent(agent.name)}/model`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ model: modelId }),
+      });
+      if (!res.ok) {
+        const e = await res.json().catch(() => ({}));
+        setModelErr(String(e.error ?? e.detail ?? `Failed (${res.status})`));
+        return;
+      }
+      setCurrentModel(modelId);
+      setPickerOpen(false);
+      onUpdated();
+    } catch {
+      setModelErr("Couldn't reach the server.");
+    }
+  }
 
   async function load() {
     try { setState(await fetchFrameworkState(agent.name)); setErr(null); }
@@ -50,6 +100,19 @@ export function FrameworkTab({ agent, onUpdated }: { agent: { name: string }; on
   return (
     <div className="flex flex-col gap-4 p-4">
       <div className="text-sm">This agent runs <b>{state.framework}</b></div>
+
+      {/* Model — change the agent's primary model without a redeploy. */}
+      <div className="flex items-center gap-2 flex-wrap">
+        <span className="opacity-60 text-sm">Model</span>
+        <code className="text-sm">{currentModel || "(not set)"}</code>
+        <button
+          onClick={openPicker}
+          className="bg-white/10 hover:bg-white/15 px-2.5 py-1 rounded text-xs"
+        >
+          Change model
+        </button>
+      </div>
+      {modelErr && <div className="text-xs text-red-400">{modelErr}</div>}
       <dl className="grid grid-cols-[120px_1fr] gap-y-1 text-sm">
         <dt className="opacity-60">Installed</dt>
         <dd><code>{state.installed.tag ?? "(unknown)"}</code> · <code>{state.installed.sha ?? "—"}</code></dd>
@@ -109,6 +172,15 @@ export function FrameworkTab({ agent, onUpdated }: { agent: { name: string }; on
       )}
 
       <div className="mt-auto pt-4 text-xs opacity-50">Switch framework — coming soon</div>
+
+      <ModelPickerModal
+        open={pickerOpen}
+        onClose={() => setPickerOpen(false)}
+        models={models}
+        modelsLoaded={modelsLoaded}
+        onSelect={(modelId) => changeModel(modelId)}
+        title="Change model"
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Why
You hit this: a deployed agent's model couldn't be changed from the Agents app. The **backend already supported it** (`POST /api/agents/{name}/model` — swaps the primary model + resumes, no redeploy), but there was **no UI**.

## What
Adds a **Model** row to the agent's **Framework** tab:
- shows the current model,
- a **"Change model"** button → opens the existing `ModelPickerModal`, loaded from `/api/providers/models?refresh=true` (LiteLLM's routable list — the single source of truth for what an agent can use),
- on select → `POST /api/agents/{name}/model`, updates the displayed model + refreshes; backend errors shown inline.

## Tests
`FrameworkTab.test.tsx`: current-model display + picker-open loads the routable models. tsc clean.

Closes the model-change gap (the picker reuse means it also picks up the LiteLLM auto-refresh from #576).