### PR TITLE
feat(agents): re-scope LiteLLM key on model change — synced model-management keystone (#570)

### DIFF
--- a/tests/test_update_agent_key.py
+++ b/tests/test_update_agent_key.py
@@ -47,3 +47,14 @@ async def test_update_agent_key_false_on_error(monkeypatch):
     import tinyagentos.llm_proxy as M
     monkeypatch.setattr(M.httpx, "AsyncClient", lambda **k: _Client(500))
     assert await _FakeProxy().update_agent_key("sk-x", ["a"]) is False
+
+
+@pytest.mark.asyncio
+async def test_update_agent_key_refuses_empty_models(monkeypatch):
+    # An empty scope must NOT silently become ["default"] — refuse and never
+    # hit /key/update (which would scope the key to a non-existent model).
+    cap = {}
+    import tinyagentos.llm_proxy as M
+    monkeypatch.setattr(M.httpx, "AsyncClient", lambda **k: _Client(200, cap))
+    assert await _FakeProxy().update_agent_key("sk-x", []) is False
+    assert cap == {}

--- a/tests/test_update_agent_key.py
+++ b/tests/test_update_agent_key.py
@@ -1,0 +1,49 @@
+"""LiteLLM virtual-key re-scope (update_agent_key) — keystone for synced model management."""
+from __future__ import annotations
+
+import pytest
+from tinyagentos.llm_proxy import LLMProxy
+
+
+class _Resp:
+    def __init__(self, status): self.status_code = status; self.text = ""
+
+class _Client:
+    def __init__(self, status=200, capture=None): self._s = status; self._cap = capture
+    async def __aenter__(self): return self
+    async def __aexit__(self, *a): return False
+    async def post(self, url, json=None, headers=None):
+        if self._cap is not None: self._cap["url"] = url; self._cap["json"] = json
+        return _Resp(self._s)
+
+
+class _FakeProxy:
+    """Duck-typed proxy borrowing the real update_agent_key implementation."""
+    update_agent_key = LLMProxy.update_agent_key
+    def __init__(self, running=True, db=True):
+        self.url = "http://127.0.0.1:4000"
+        self.database_url = "postgres://x" if db else None
+        self._running = running
+    def is_running(self): return self._running
+
+
+@pytest.mark.asyncio
+async def test_update_agent_key_calls_key_update(monkeypatch):
+    cap = {}
+    import tinyagentos.llm_proxy as M
+    monkeypatch.setattr(M.httpx, "AsyncClient", lambda **k: _Client(200, cap))
+    assert await _FakeProxy().update_agent_key("sk-x", ["a", "b"]) is True
+    assert cap["url"].endswith("/key/update")
+    assert cap["json"] == {"key": "sk-x", "models": ["a", "b"]}
+
+
+@pytest.mark.asyncio
+async def test_update_agent_key_noop_without_db():
+    assert await _FakeProxy(db=False).update_agent_key("sk-x", ["a"]) is False
+
+
+@pytest.mark.asyncio
+async def test_update_agent_key_false_on_error(monkeypatch):
+    import tinyagentos.llm_proxy as M
+    monkeypatch.setattr(M.httpx, "AsyncClient", lambda **k: _Client(500))
+    assert await _FakeProxy().update_agent_key("sk-x", ["a"]) is False

--- a/tinyagentos/llm_proxy.py
+++ b/tinyagentos/llm_proxy.py
@@ -368,11 +368,17 @@ class LLMProxy:
         """
         if not self.is_running() or not self.database_url or not key:
             return False
+        if not models:
+            # An empty scope is a caller error, not a request to allow nothing.
+            # Refuse rather than silently substitute a bogus "default" model
+            # (which would scope the key to a model that does not exist).
+            logger.warning("update_agent_key called with empty models; refusing to re-scope key")
+            return False
         try:
             async with httpx.AsyncClient(timeout=10) as client:
                 resp = await client.post(
                     f"{self.url}/key/update",
-                    json={"key": key, "models": models or ["default"]},
+                    json={"key": key, "models": models},
                     headers={"Authorization": f"Bearer {TAOS_LITELLM_MASTER_KEY}"},
                 )
                 if resp.status_code == 200:

--- a/tinyagentos/llm_proxy.py
+++ b/tinyagentos/llm_proxy.py
@@ -357,6 +357,34 @@ class LLMProxy:
             logger.warning(f"Failed to create LiteLLM key for {agent_name}: {e}")
         return None
 
+    async def update_agent_key(self, key: str, models: list[str]) -> bool:
+        """Re-scope an existing virtual key's allowed models via /key/update.
+
+        Keeps the key VALUE unchanged (no container env push / restart needed):
+        the framework's ``/v1/models`` with this key then reflects the new
+        permitted set, so it natively sees exactly what the agent is allowed to
+        use. Returns True on success. No-op (False) in routing-only mode (no DB)
+        — there are no per-agent keys to scope there.
+        """
+        if not self.is_running() or not self.database_url or not key:
+            return False
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                resp = await client.post(
+                    f"{self.url}/key/update",
+                    json={"key": key, "models": models or ["default"]},
+                    headers={"Authorization": f"Bearer {TAOS_LITELLM_MASTER_KEY}"},
+                )
+                if resp.status_code == 200:
+                    return True
+                logger.warning(
+                    "LiteLLM /key/update returned %d body=%.200s",
+                    resp.status_code, resp.text,
+                )
+        except Exception as e:
+            logger.warning("Failed to update LiteLLM key models: %s", e)
+        return False
+
     async def delete_agent_key(self, key: str) -> bool:
         """Delete a per-agent virtual key."""
         if not self.is_running():

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -733,10 +733,27 @@ async def update_agent_model(request: Request, name: str, body: AgentModelUpdate
     agent["paused"] = False
     await save_config_locked(config, config.config_path)
 
+    # Re-scope the agent's LiteLLM virtual key so it's actually ALLOWED to use
+    # the new model — without this the change only updates taOS's record and
+    # LiteLLM would 403 the new model. The key value is unchanged, so no
+    # container restart/env push is needed; the framework's /v1/models (with
+    # this key) reflects the new permitted set immediately. (Routing-only mode
+    # without a key DB is a no-op.) Pushing model.primary into the framework
+    # config + reverse reconcile from the framework are tracked in #570.
+    proxy = getattr(request.app.state, "llm_proxy", None)
+    llm_key = agent.get("llm_key")
+    key_rescoped = False
+    if proxy is not None and llm_key:
+        try:
+            key_rescoped = await proxy.update_agent_key(llm_key, [model_id])
+        except Exception:
+            logger.exception("update_agent_model: re-scoping key for %s failed", name)
+
     return {
         "status": "updated",
         "name": name,
         "model": model_id,
         "resumed": was_paused,
         "location": location.kind,
+        "key_rescoped": key_rescoped,
     }


### PR DESCRIPTION
First slice of the synced model-management design (#570).

## Problem
`POST /api/agents/{name}/model` only updated taOS's stored model — but the agent's **LiteLLM virtual key is scoped to its deployed model(s)**, so LiteLLM would **403 the new model**. The change wasn't real.

## This PR
- `LLMProxy.update_agent_key(key, models)` → LiteLLM **`/key/update`**: re-scopes the key's allowed models, **keeping the key value** (no container restart / env push).
- `update_agent_model` now calls it, so the new model is actually permitted.
- Because LiteLLM scopes a key's `/v1/models`, the **framework's native available-models list reflects the change too** — the foundation for "permitted set = what the framework sees natively."

## Follow-ons (tracked in #570)
- Permitted-**set** editing (multi-select) + the agent-facing API (`/api/agents/me/models`).
- Push `model.primary` into the framework config for settings-initiated live switches.
- **Reverse reconcile**: read the framework's current model (OpenClaw TUI switch, etc.) → sync taOS's record, so it's synced *no matter where* the change happens.

## Tests
`/key/update` call shape, routing-only no-op, error path (3). Existing `update_agent_model` route tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent API keys now automatically adjust their model permissions when an agent's assigned model is updated.
  * Added key re-scoping capability to ensure agent keys permit only their assigned models.

* **Tests**
  * Added comprehensive test coverage for API key re-scoping functionality, including scenarios for database connectivity, error handling, and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->