### PR TITLE
fix(providers): set-semantics + honest reload claim (#576 follow-up)

### DIFF
--- a/tests/test_provider_refresh.py
+++ b/tests/test_provider_refresh.py
@@ -59,6 +59,55 @@ async def test_no_cloud_backends_is_noop(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_change_with_proxy_down_persists_but_reports_no_reload(monkeypatch, tmp_path):
+    # Catalog changed but the proxy isn't running: persist the config, but the
+    # return value must be False (no reload happened) rather than claiming one.
+    backend = {"name": "kilo", "type": "kilocode", "url": "u", "models": [{"id": "a"}]}
+    config = SimpleNamespace(backends=[backend], config_path=tmp_path / "config.yaml")
+
+    class _DownProxy:
+        def __init__(self): self.reloads = 0
+        def is_running(self): return False
+        async def reload_config(self, backends, secrets=None): self.reloads += 1
+
+    proxy = _DownProxy()
+    state = SimpleNamespace(config=config, llm_proxy=proxy)
+
+    saved = {"n": 0}
+    async def _save(*a, **k): saved["n"] += 1
+    monkeypatch.setattr(P, "save_config_locked", _save)
+    async def _adds_model(app_state, b, timeout=5.0):
+        b["models"] = [{"id": "a"}, {"id": "b"}]
+        return b
+    monkeypatch.setattr(P, "_refresh_backend", _adds_model)
+
+    assert await P.refresh_cloud_backends_if_changed(state, config, proxy) is False
+    assert saved["n"] == 1          # config WAS persisted
+    assert proxy.reloads == 0       # but no reload was attempted
+
+
+@pytest.mark.asyncio
+async def test_duplicate_ids_are_not_a_change(monkeypatch, tmp_path):
+    # A transient duplicate id in a re-probed catalog must not count as a change.
+    backend = {"name": "kilo", "type": "kilocode", "url": "u", "models": [{"id": "a"}, {"id": "b"}]}
+    config = SimpleNamespace(backends=[backend], config_path=tmp_path / "config.yaml")
+    proxy = _FakeProxy()
+    state = SimpleNamespace(config=config, llm_proxy=proxy)
+
+    async def _noop_save(*a, **k): return None
+    async def _no_secrets(*a, **k): return []
+    monkeypatch.setattr(P, "save_config_locked", _noop_save)
+    monkeypatch.setattr(P, "_resolve_backend_secrets", _no_secrets)
+
+    async def _dupes(app_state, b, timeout=5.0):
+        b["models"] = [{"id": "a"}, {"id": "b"}, {"id": "a"}]  # same set, with a dupe
+        return b
+    monkeypatch.setattr(P, "_refresh_backend", _dupes)
+    assert await P.refresh_cloud_backends_if_changed(state, config, proxy) is False
+    assert proxy.reloads == 0
+
+
+@pytest.mark.asyncio
 async def test_refresher_start_stop():
     state = SimpleNamespace(config=SimpleNamespace(backends=[]), llm_proxy=None)
     r = CloudProviderRefresher(state, interval=0.01, initial_delay=0.01)

--- a/tinyagentos/routes/providers.py
+++ b/tinyagentos/routes/providers.py
@@ -183,18 +183,23 @@ async def _refresh_all_cloud_backends(app_state, config, proxy) -> int:
     return len(cloud)
 
 
-def _cloud_model_ids(backend: dict) -> list[str]:
-    """Sorted model id list for a backend, for change detection."""
-    return sorted(
+def _cloud_model_ids(backend: dict) -> set[str]:
+    """Set of model ids for a backend, for change detection.
+
+    A set (not a list) so detection is duplicate-insensitive: a transient
+    duplicate id in a re-probed catalog must not read as a real change and
+    trigger a needless LiteLLM reload.
+    """
+    return {
         (m.get("id") or m.get("name") or "") if isinstance(m, dict) else str(m)
         for m in (backend.get("models") or [])
-    )
+    }
 
 
 async def refresh_cloud_backends_if_changed(app_state, config, proxy) -> bool:
     """Re-probe cloud backends; persist + reload LiteLLM ONLY if a model list
     actually changed (so a stable catalog doesn't trigger needless reloads that
-    disrupt in-flight requests). Returns True if a reload happened.
+    disrupt in-flight requests). Returns True only if a reload actually happened.
 
     This is what the periodic refresher calls — it keeps LiteLLM's model_list
     fresh as upstream provider catalogs gain/lose models, without a restart.
@@ -211,9 +216,13 @@ async def refresh_cloud_backends_if_changed(app_state, config, proxy) -> bool:
     if before == after:
         return False
     await save_config_locked(config, config.config_path)
-    if proxy and proxy.is_running():
-        resolved = await _resolve_backend_secrets(app_state, config.backends)
-        await proxy.reload_config(config.backends, secrets=resolved)
+    if not (proxy and proxy.is_running()):
+        # Catalog changed and we persisted it, but with no live proxy there is
+        # nothing to reload — don't claim a reload that didn't happen.
+        logger.info("provider refresh: cloud model list changed — persisted (LiteLLM not running, no reload)")
+        return False
+    resolved = await _resolve_backend_secrets(app_state, config.backends)
+    await proxy.reload_config(config.backends, secrets=resolved)
     logger.info("provider refresh: cloud model list changed — reloaded LiteLLM")
     return True
 


### PR DESCRIPTION
Fix-forward for the two CodeRabbit Major findings on #576 (already merged to dev).

### What
- **Set semantics for change detection.** \`_cloud_model_ids\` now returns a \`set\` instead of a sorted list, so a transient duplicate model id in a re-probed catalog no longer reads as a real change and triggers a needless LiteLLM reload that disrupts in-flight requests.
- **Honest reload claim.** When no proxy is running, \`refresh_cloud_backends_if_changed\` still persisted the changed config but logged "reloaded LiteLLM" and returned \`True\`. It now takes the persist-only path: logs that nothing was reloaded and returns \`False\`. The return value never claims a reload that didn't happen.

### Tests
- \`test_change_with_proxy_down_persists_but_reports_no_reload\` — proxy down: config persisted, no reload attempted, returns False.
- \`test_duplicate_ids_are_not_a_change\` — duplicate id in re-probe: no change, no reload.
- Existing #576 tests still green (5 passed).