### PR TITLE
feat(agents): permitted-model set + agent-facing model API (#570)

### DIFF
--- a/tests/test_agent_permitted_models.py
+++ b/tests/test_agent_permitted_models.py
@@ -1,0 +1,418 @@
+"""Tests for the agent permitted-model set and agent-facing model API."""
+from __future__ import annotations
+
+import pytest
+from tinyagentos.llm_proxy import LLMProxy
+from tinyagentos.cluster.model_resolver import ModelLocation
+
+
+# ---------------------------------------------------------------------------
+# Minimal fakes — mirror the pattern from test_update_agent_key.py
+# ---------------------------------------------------------------------------
+
+class _FakeProxy:
+    """Duck-typed LLMProxy that records calls to update_agent_key."""
+    update_agent_key = LLMProxy.update_agent_key
+
+    def __init__(self, running=True, db=True, capture=None):
+        self.url = "http://127.0.0.1:4000"
+        self.database_url = "postgres://x" if db else None
+        self._running = running
+        self._capture = capture  # list to append (models,) tuples
+
+    def is_running(self):
+        return self._running
+
+
+class _Resp:
+    def __init__(self, status):
+        self.status_code = status
+        self.text = ""
+
+
+class _Client:
+    def __init__(self, status=200, capture=None):
+        self._s = status
+        self._cap = capture
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def post(self, url, json=None, headers=None):
+        if self._cap is not None:
+            self._cap.setdefault("calls", []).append({"url": url, "json": json})
+        return _Resp(self._s)
+
+
+class _FakeState:
+    """Minimal app.state stub."""
+    def __init__(self, agents, proxy=None):
+        self.config = _FakeConfig(agents)
+        self.llm_proxy = proxy
+        self.cluster_manager = None
+        self.backend_catalog = None
+
+
+class _FakeConfig:
+    def __init__(self, agents):
+        self.agents = agents
+        self.config_path = "/dev/null"
+        self.backends = []
+
+
+class _FakeApp:
+    def __init__(self, state):
+        self.state = state
+
+
+class _FakeRequest:
+    """Minimal Request stub for calling route functions directly."""
+    def __init__(self, agents, proxy=None, headers=None):
+        state = _FakeState(agents, proxy=proxy)
+        self.app = _FakeApp(state)
+        self.headers = headers or {}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+async def _noop_save(*args, **kwargs):
+    pass
+
+
+def _patch_save(monkeypatch):
+    import tinyagentos.routes.agents as mod
+    monkeypatch.setattr(mod, "save_config_locked", _noop_save)
+
+
+def _make_location(kind):
+    return ModelLocation(kind=kind)
+
+
+def _patch_resolver(monkeypatch, mapping: dict):
+    """mapping: {model_id: kind} — default "controller" for unknown models."""
+    import tinyagentos.routes.agents as mod
+
+    def _resolve(request, model_id):
+        return _make_location(mapping.get(model_id, "controller"))
+
+    monkeypatch.setattr(mod, "resolve_model_location", _resolve, raising=False)
+
+    # Also patch the local import inside the route functions
+    import tinyagentos.cluster.model_resolver as resolver_mod
+    monkeypatch.setattr(resolver_mod, "resolve_model_location", _resolve)
+
+
+# ---------------------------------------------------------------------------
+# Piece 2 — GET /api/agents/{name}/permitted-models
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_permitted_defaults_to_current_model(monkeypatch):
+    _patch_save(monkeypatch)
+    from tinyagentos.routes.agents import get_permitted_models
+    agents = [{"name": "alpha", "model": "llama3"}]
+    req = _FakeRequest(agents)
+    resp = await get_permitted_models(req, "alpha")
+    data = resp if isinstance(resp, dict) else resp.body
+    if isinstance(resp, dict):
+        assert resp["permitted"] == ["llama3"]
+        assert resp["current"] == "llama3"
+    else:
+        import json
+        body = json.loads(resp.body)
+        assert body["permitted"] == ["llama3"]
+        assert body["current"] == "llama3"
+
+
+@pytest.mark.asyncio
+async def test_get_permitted_returns_explicit_set(monkeypatch):
+    _patch_save(monkeypatch)
+    from tinyagentos.routes.agents import get_permitted_models
+    agents = [{"name": "alpha", "model": "llama3", "permitted_models": ["llama3", "qwen3"]}]
+    req = _FakeRequest(agents)
+    resp = await get_permitted_models(req, "alpha")
+    assert resp["permitted"] == ["llama3", "qwen3"]
+    assert resp["current"] == "llama3"
+
+
+@pytest.mark.asyncio
+async def test_get_permitted_404_unknown_agent(monkeypatch):
+    _patch_save(monkeypatch)
+    from tinyagentos.routes.agents import get_permitted_models
+    req = _FakeRequest([])
+    resp = await get_permitted_models(req, "ghost")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Piece 2 — PUT /api/agents/{name}/permitted-models
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_put_permitted_sets_field(monkeypatch):
+    _patch_save(monkeypatch)
+    _patch_resolver(monkeypatch, {})
+    from tinyagentos.routes.agents import set_permitted_models, PermittedModelsUpdate
+    agents = [{"name": "alpha", "model": "llama3", "llm_key": "sk-a"}]
+    cap = {}
+    import tinyagentos.llm_proxy as M
+    monkeypatch.setattr(M.httpx, "AsyncClient", lambda **k: _Client(200, cap))
+    proxy = _FakeProxy()
+    req = _FakeRequest(agents, proxy=proxy)
+    body = PermittedModelsUpdate(models=["llama3", "qwen3"])
+    resp = await set_permitted_models(req, "alpha", body)
+    assert resp["status"] == "updated"
+    assert "llama3" in resp["permitted"]
+    assert "qwen3" in resp["permitted"]
+    assert agents[0]["permitted_models"] == resp["permitted"]
+
+
+@pytest.mark.asyncio
+async def test_put_permitted_empty_list_returns_400(monkeypatch):
+    _patch_save(monkeypatch)
+    from tinyagentos.routes.agents import set_permitted_models, PermittedModelsUpdate
+    agents = [{"name": "alpha", "model": "llama3"}]
+    req = _FakeRequest(agents)
+    body = PermittedModelsUpdate(models=[])
+    resp = await set_permitted_models(req, "alpha", body)
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_put_permitted_unreachable_model_returns_409(monkeypatch):
+    _patch_save(monkeypatch)
+    _patch_resolver(monkeypatch, {"bad-model": "not_found"})
+    from tinyagentos.routes.agents import set_permitted_models, PermittedModelsUpdate
+    agents = [{"name": "alpha", "model": "llama3"}]
+    req = _FakeRequest(agents)
+    body = PermittedModelsUpdate(models=["llama3", "bad-model"])
+    resp = await set_permitted_models(req, "alpha", body)
+    assert resp.status_code == 409
+    import json
+    data = json.loads(resp.body)
+    assert data["model"] == "bad-model"
+
+
+@pytest.mark.asyncio
+async def test_put_permitted_prepends_current_if_omitted(monkeypatch):
+    _patch_save(monkeypatch)
+    _patch_resolver(monkeypatch, {})
+    import tinyagentos.llm_proxy as M
+    monkeypatch.setattr(M.httpx, "AsyncClient", lambda **k: _Client(200, {}))
+    from tinyagentos.routes.agents import set_permitted_models, PermittedModelsUpdate
+    agents = [{"name": "alpha", "model": "llama3", "llm_key": "sk-a"}]
+    proxy = _FakeProxy()
+    req = _FakeRequest(agents, proxy=proxy)
+    # body does NOT include llama3
+    body = PermittedModelsUpdate(models=["qwen3"])
+    resp = await set_permitted_models(req, "alpha", body)
+    assert resp["status"] == "updated"
+    assert "llama3" in resp["permitted"]
+    assert "qwen3" in resp["permitted"]
+    # current should be first
+    assert resp["permitted"][0] == "llama3"
+
+
+@pytest.mark.asyncio
+async def test_put_permitted_rescopes_key(monkeypatch):
+    _patch_save(monkeypatch)
+    _patch_resolver(monkeypatch, {})
+    cap = {}
+    import tinyagentos.llm_proxy as M
+    monkeypatch.setattr(M.httpx, "AsyncClient", lambda **k: _Client(200, cap))
+    from tinyagentos.routes.agents import set_permitted_models, PermittedModelsUpdate
+    agents = [{"name": "alpha", "model": "llama3", "llm_key": "sk-a"}]
+    proxy = _FakeProxy()
+    req = _FakeRequest(agents, proxy=proxy)
+    body = PermittedModelsUpdate(models=["llama3", "qwen3"])
+    resp = await set_permitted_models(req, "alpha", body)
+    assert resp["key_rescoped"] is True
+    calls = cap.get("calls", [])
+    assert any(c["json"]["models"] == resp["permitted"] for c in calls)
+
+
+@pytest.mark.asyncio
+async def test_put_permitted_404_unknown_agent(monkeypatch):
+    _patch_save(monkeypatch)
+    from tinyagentos.routes.agents import set_permitted_models, PermittedModelsUpdate
+    req = _FakeRequest([])
+    body = PermittedModelsUpdate(models=["llama3"])
+    resp = await set_permitted_models(req, "ghost", body)
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Piece 2 — update_agent_model scopes key to full permitted set
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_update_agent_model_scopes_key_to_permitted_set(monkeypatch):
+    _patch_save(monkeypatch)
+    _patch_resolver(monkeypatch, {})
+    cap = {}
+    import tinyagentos.llm_proxy as M
+    monkeypatch.setattr(M.httpx, "AsyncClient", lambda **k: _Client(200, cap))
+    from tinyagentos.routes.agents import update_agent_model, AgentModelUpdate
+    agents = [
+        {
+            "name": "alpha",
+            "model": "llama3",
+            "llm_key": "sk-a",
+            "permitted_models": ["llama3", "qwen3"],
+        }
+    ]
+    proxy = _FakeProxy()
+    req = _FakeRequest(agents, proxy=proxy)
+    body = AgentModelUpdate(model="qwen3")
+    resp = await update_agent_model(req, "alpha", body)
+    assert resp["status"] == "updated"
+    assert resp["model"] == "qwen3"
+    # The key should be scoped to ALL permitted models, not just [qwen3]
+    assert set(resp["permitted"]) == {"llama3", "qwen3"}
+    calls = cap.get("calls", [])
+    rescope_calls = [c for c in calls if c["url"].endswith("/key/update")]
+    assert rescope_calls, "update_agent_key was not called"
+    models_sent = rescope_calls[-1]["json"]["models"]
+    assert set(models_sent) == {"llama3", "qwen3"}
+
+
+@pytest.mark.asyncio
+async def test_update_agent_model_adds_new_model_to_permitted(monkeypatch):
+    _patch_save(monkeypatch)
+    _patch_resolver(monkeypatch, {})
+    cap = {}
+    import tinyagentos.llm_proxy as M
+    monkeypatch.setattr(M.httpx, "AsyncClient", lambda **k: _Client(200, cap))
+    from tinyagentos.routes.agents import update_agent_model, AgentModelUpdate
+    # agent has no permitted_models yet
+    agents = [{"name": "alpha", "model": "llama3", "llm_key": "sk-a"}]
+    proxy = _FakeProxy()
+    req = _FakeRequest(agents, proxy=proxy)
+    body = AgentModelUpdate(model="qwen3")
+    resp = await update_agent_model(req, "alpha", body)
+    # Should auto-create permitted set with qwen3 prepended
+    assert "qwen3" in resp["permitted"]
+    calls = cap.get("calls", [])
+    rescope_calls = [c for c in calls if c["url"].endswith("/key/update")]
+    assert rescope_calls
+    models_sent = rescope_calls[-1]["json"]["models"]
+    assert "qwen3" in models_sent
+
+
+# ---------------------------------------------------------------------------
+# Piece 3 — GET /api/agents/me/models (agent-facing, bearer auth)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_agent_get_own_models_resolves_by_key(monkeypatch):
+    _patch_save(monkeypatch)
+    from tinyagentos.routes.agents import agent_get_own_models
+    agents = [
+        {"name": "alpha", "model": "llama3", "llm_key": "sk-agent-abc", "permitted_models": ["llama3", "qwen3"]},
+    ]
+    req = _FakeRequest(agents, headers={"authorization": "Bearer sk-agent-abc"})
+    resp = await agent_get_own_models(req)
+    assert resp["permitted"] == ["llama3", "qwen3"]
+    assert resp["current"] == "llama3"
+
+
+@pytest.mark.asyncio
+async def test_agent_get_own_models_defaults_permitted_to_current(monkeypatch):
+    _patch_save(monkeypatch)
+    from tinyagentos.routes.agents import agent_get_own_models
+    agents = [{"name": "alpha", "model": "llama3", "llm_key": "sk-abc"}]
+    req = _FakeRequest(agents, headers={"authorization": "Bearer sk-abc"})
+    resp = await agent_get_own_models(req)
+    assert resp["permitted"] == ["llama3"]
+
+
+@pytest.mark.asyncio
+async def test_agent_get_own_models_401_no_header(monkeypatch):
+    _patch_save(monkeypatch)
+    from tinyagentos.routes.agents import agent_get_own_models
+    agents = [{"name": "alpha", "model": "llama3", "llm_key": "sk-abc"}]
+    req = _FakeRequest(agents)
+    resp = await agent_get_own_models(req)
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_agent_get_own_models_401_unknown_token(monkeypatch):
+    _patch_save(monkeypatch)
+    from tinyagentos.routes.agents import agent_get_own_models
+    agents = [{"name": "alpha", "model": "llama3", "llm_key": "sk-abc"}]
+    req = _FakeRequest(agents, headers={"authorization": "Bearer sk-wrong"})
+    resp = await agent_get_own_models(req)
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Piece 3 — POST /api/agents/me/model (agent-facing, bearer auth)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_agent_set_own_model_accepts_permitted(monkeypatch):
+    _patch_save(monkeypatch)
+    from tinyagentos.routes.agents import agent_set_own_model, AgentSelfModelUpdate
+    agents = [
+        {"name": "alpha", "model": "llama3", "llm_key": "sk-abc", "permitted_models": ["llama3", "qwen3"]},
+    ]
+    req = _FakeRequest(agents, headers={"authorization": "Bearer sk-abc"})
+    body = AgentSelfModelUpdate(model="qwen3")
+    resp = await agent_set_own_model(req, body)
+    assert resp["status"] == "updated"
+    assert resp["current"] == "qwen3"
+    assert agents[0]["model"] == "qwen3"
+
+
+@pytest.mark.asyncio
+async def test_agent_set_own_model_rejects_non_permitted(monkeypatch):
+    _patch_save(monkeypatch)
+    from tinyagentos.routes.agents import agent_set_own_model, AgentSelfModelUpdate
+    agents = [
+        {"name": "alpha", "model": "llama3", "llm_key": "sk-abc", "permitted_models": ["llama3", "qwen3"]},
+    ]
+    req = _FakeRequest(agents, headers={"authorization": "Bearer sk-abc"})
+    body = AgentSelfModelUpdate(model="gpt-4o")
+    resp = await agent_set_own_model(req, body)
+    assert resp.status_code == 403
+    import json
+    data = json.loads(resp.body)
+    assert "gpt-4o" in data["error"]
+    assert "permitted" in data
+
+
+@pytest.mark.asyncio
+async def test_agent_set_own_model_401_no_token(monkeypatch):
+    _patch_save(monkeypatch)
+    from tinyagentos.routes.agents import agent_set_own_model, AgentSelfModelUpdate
+    agents = [{"name": "alpha", "model": "llama3", "llm_key": "sk-abc"}]
+    req = _FakeRequest(agents)
+    body = AgentSelfModelUpdate(model="llama3")
+    resp = await agent_set_own_model(req, body)
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_agent_set_own_model_no_rescope_on_same_permitted_set(monkeypatch):
+    """Switching active model within the permitted set must NOT call update_agent_key."""
+    _patch_save(monkeypatch)
+    cap = {}
+    import tinyagentos.llm_proxy as M
+    monkeypatch.setattr(M.httpx, "AsyncClient", lambda **k: _Client(200, cap))
+    from tinyagentos.routes.agents import agent_set_own_model, AgentSelfModelUpdate
+    agents = [
+        {"name": "alpha", "model": "llama3", "llm_key": "sk-abc", "permitted_models": ["llama3", "qwen3"]},
+    ]
+    req = _FakeRequest(agents, headers={"authorization": "Bearer sk-abc"})
+    body = AgentSelfModelUpdate(model="qwen3")
+    resp = await agent_set_own_model(req, body)
+    assert resp["status"] == "updated"
+    # No key/update call should have been made
+    calls = cap.get("calls", [])
+    assert not any(c["url"].endswith("/key/update") for c in calls)

--- a/tests/test_agent_permitted_models.py
+++ b/tests/test_agent_permitted_models.py
@@ -199,6 +199,22 @@ async def test_put_permitted_unreachable_model_returns_409(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_put_permitted_unreachable_current_returns_409(monkeypatch):
+    # The auto-added current model must also be validated — an unreachable
+    # current model must not be injected into the permitted set / key scope.
+    _patch_save(monkeypatch)
+    _patch_resolver(monkeypatch, {"stale-current": "not_found"})
+    from tinyagentos.routes.agents import set_permitted_models, PermittedModelsUpdate
+    agents = [{"name": "alpha", "model": "stale-current", "llm_key": "sk-a"}]
+    req = _FakeRequest(agents)
+    body = PermittedModelsUpdate(models=["qwen3"])  # all reachable, but current is not
+    resp = await set_permitted_models(req, "alpha", body)
+    assert resp.status_code == 409
+    import json
+    assert json.loads(resp.body)["model"] == "stale-current"
+
+
+@pytest.mark.asyncio
 async def test_put_permitted_prepends_current_if_omitted(monkeypatch):
     _patch_save(monkeypatch)
     _patch_resolver(monkeypatch, {})

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -844,21 +844,23 @@ async def set_permitted_models(request: Request, name: str, body: PermittedModel
     if not body.models:
         return JSONResponse({"error": "models must not be empty"}, status_code=400)
 
+    # Build the final set up front — the current primary must always be a
+    # member — so it is validated alongside the requested models. Otherwise an
+    # unreachable current model could be injected into the key scope unchecked.
+    permitted = list(body.models)
+    current = agent.get("model")
+    if current and current not in permitted:
+        permitted = [current, *permitted]
+
     from tinyagentos.cluster.model_resolver import resolve_model_location
 
-    for model_id in body.models:
+    for model_id in permitted:
         location = resolve_model_location(request, model_id)
         if location.kind == "not_found":
             return JSONResponse(
                 {"error": f"model '{model_id}' is not reachable anywhere in the cluster right now.", "model": model_id},
                 status_code=409,
             )
-
-    # Ensure the current primary is always in the permitted set.
-    permitted = list(body.models)
-    current = agent.get("model")
-    if current and current not in permitted:
-        permitted = [current, *permitted]
 
     agent["permitted_models"] = permitted
     await save_config_locked(config, config.config_path)

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -66,6 +66,56 @@ async def list_archived_agents(request: Request):
     return config.archived_agents
 
 
+def _resolve_agent_by_bearer(request: Request) -> dict | None:
+    """Return the agent whose llm_key matches the Authorization: Bearer token.
+
+    Returns None if the header is missing/malformed or no agent matches.
+    """
+    auth = request.headers.get("authorization", "")
+    if not auth.lower().startswith("bearer "):
+        return None
+    token = auth[7:]
+    if not token:
+        return None
+    config = request.app.state.config
+    return next((a for a in config.agents if a.get("llm_key") == token), None)
+
+
+@router.get("/api/agents/me/models")
+async def agent_get_own_models(request: Request):
+    """Return the calling agent's permitted model set (authed by its LiteLLM key)."""
+    agent = _resolve_agent_by_bearer(request)
+    if agent is None:
+        return JSONResponse({"error": "unauthorized"}, status_code=401)
+    permitted = [m for m in (agent.get("permitted_models") or [agent.get("model")]) if m]
+    return {"permitted": permitted, "current": agent.get("model")}
+
+
+class AgentSelfModelUpdate(BaseModel):
+    model: str
+
+
+@router.post("/api/agents/me/model")
+async def agent_set_own_model(request: Request, body: AgentSelfModelUpdate):
+    """Move the calling agent's active primary within its permitted set (authed by its LiteLLM key)."""
+    agent = _resolve_agent_by_bearer(request)
+    if agent is None:
+        return JSONResponse({"error": "unauthorized"}, status_code=401)
+
+    model = body.model
+    permitted = [m for m in (agent.get("permitted_models") or [agent.get("model")]) if m]
+    if model not in permitted:
+        return JSONResponse(
+            {"error": f"model '{model}' is not in this agent's permitted set", "permitted": permitted},
+            status_code=403,
+        )
+
+    agent["model"] = model
+    config = request.app.state.config
+    await save_config_locked(config, config.config_path)
+    return {"status": "updated", "current": model}
+
+
 @router.get("/api/agents/{name}/deploy-status")
 async def get_deploy_status(request: Request, name: str):
     """Get the background deploy task status for an agent."""
@@ -731,6 +781,14 @@ async def update_agent_model(request: Request, name: str, body: AgentModelUpdate
     agent["model"] = model_id
     was_paused = agent.get("paused", False)
     agent["paused"] = False
+
+    # Ensure the new primary is in the permitted set and scope the key to
+    # the full permitted set (not just [model_id]).
+    permitted = agent.get("permitted_models") or []
+    if model_id not in permitted:
+        permitted = [model_id, *permitted]
+    agent["permitted_models"] = permitted
+
     await save_config_locked(config, config.config_path)
 
     # Re-scope the agent's LiteLLM virtual key so it's actually ALLOWED to use
@@ -745,7 +803,7 @@ async def update_agent_model(request: Request, name: str, body: AgentModelUpdate
     key_rescoped = False
     if proxy is not None and llm_key:
         try:
-            key_rescoped = await proxy.update_agent_key(llm_key, [model_id])
+            key_rescoped = await proxy.update_agent_key(llm_key, permitted)
         except Exception:
             logger.exception("update_agent_model: re-scoping key for %s failed", name)
 
@@ -753,7 +811,71 @@ async def update_agent_model(request: Request, name: str, body: AgentModelUpdate
         "status": "updated",
         "name": name,
         "model": model_id,
+        "permitted": permitted,
         "resumed": was_paused,
         "location": location.kind,
+        "key_rescoped": key_rescoped,
+    }
+
+
+@router.get("/api/agents/{name}/permitted-models")
+async def get_permitted_models(request: Request, name: str):
+    """Return the permitted model set and current primary for an agent."""
+    config = request.app.state.config
+    agent = find_agent(config, name)
+    if not agent:
+        return JSONResponse({"error": f"Agent '{name}' not found"}, status_code=404)
+    permitted = [m for m in (agent.get("permitted_models") or [agent.get("model")]) if m]
+    return {"permitted": permitted, "current": agent.get("model")}
+
+
+class PermittedModelsUpdate(BaseModel):
+    models: list[str]
+
+
+@router.put("/api/agents/{name}/permitted-models")
+async def set_permitted_models(request: Request, name: str, body: PermittedModelsUpdate):
+    """Set the permitted model set for an agent and re-scope its LiteLLM key."""
+    config = request.app.state.config
+    agent = find_agent(config, name)
+    if not agent:
+        return JSONResponse({"error": f"Agent '{name}' not found"}, status_code=404)
+
+    if not body.models:
+        return JSONResponse({"error": "models must not be empty"}, status_code=400)
+
+    from tinyagentos.cluster.model_resolver import resolve_model_location
+
+    for model_id in body.models:
+        location = resolve_model_location(request, model_id)
+        if location.kind == "not_found":
+            return JSONResponse(
+                {"error": f"model '{model_id}' is not reachable anywhere in the cluster right now.", "model": model_id},
+                status_code=409,
+            )
+
+    # Ensure the current primary is always in the permitted set.
+    permitted = list(body.models)
+    current = agent.get("model")
+    if current and current not in permitted:
+        permitted = [current, *permitted]
+
+    agent["permitted_models"] = permitted
+    await save_config_locked(config, config.config_path)
+
+    proxy = getattr(request.app.state, "llm_proxy", None)
+    llm_key = agent.get("llm_key")
+    key_rescoped = False
+    if proxy is not None and llm_key:
+        try:
+            key_rescoped = await proxy.update_agent_key(llm_key, permitted)
+        except Exception:
+            logger.exception("set_permitted_models: re-scoping key for %s failed", name)
+
+    return {
+        "status": "updated",
+        "name": name,
+        "permitted": permitted,
+        "current": agent.get("model"),
         "key_rescoped": key_rescoped,
     }


### PR DESCRIPTION
Pieces 2 and 3 of the agreed synced model-management design ([#570 comment](https://github.com/jaylfc/taOS/issues/570)). Builds on #578 (now merged).

## What

**Permitted set (taOS-authoritative).** Each agent gets a `permitted_models` list. That set becomes the `models` scope on the agent's LiteLLM virtual key, so the framework natively sees exactly the permitted models via `/v1/models` and can switch among them, with LiteLLM enforcing the boundary. The primary `model` is always a member of the set.

- `GET /api/agents/{name}/permitted-models` -> `{permitted, current}`
- `PUT /api/agents/{name}/permitted-models {models}` -> validates each model is reachable in the cluster (409 naming the first unreachable one), guarantees the current model is included, persists, and re-scopes the key via `update_agent_key`.
- `update_agent_model` now scopes the key to the **whole permitted set** (was just the single new model), and adds the new primary to the set if absent. Backward compatible: an agent with no `permitted_models` behaves exactly as before (`[current]`).

**Agent-facing API (authed by the agent's own LiteLLM key).** Lets the framework or the agent itself query/switch models with governance:
- `GET /api/agents/me/models` -> `{permitted, current}`
- `POST /api/agents/me/model {model}` -> moves the active model within the permitted set. Out-of-set requests are 403. No key re-scope (the scope is unchanged), so this is cheap.

The caller is resolved by matching `Authorization: Bearer <token>` to the agent whose `llm_key` equals the token; unresolved -> 401.

## Notes
- The `me` routes register before the `{name}` parametric routes so `me` is not captured as a name.
- No container restart / env push: the key value never changes, only its model scope.

## Tests
`tests/test_agent_permitted_models.py` (19 tests): permitted defaulting, PUT validation (empty -> 400, unreachable -> 409, current always included), update_agent_model scoping the key to the full set, and the agent-facing GET/POST (401 unknown token, 403 out-of-set, accept in-set). Existing `test_update_agent_key.py` still green (4).

## Remaining for #570
Piece 4 (reverse reconcile: read the framework's live model -> sync the taOS record) + the multi-select permitted-set UI in the Framework tab. Those follow in a separate PR (the UI extends #577's picker; reverse reconcile is framework-specific and needs live Pi testing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agents can view their permitted models and change their active model via bearer-token endpoints.
  * Admins can get and replace an agent’s permitted models; updates validate reachability, preserve the current model, and rescope keys to the full permitted set.

* **Tests**
  * New test suite covering permitted-models and agent-facing endpoints, authorization, validation, update behaviors, and key rescoping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->