### PR TITLE
feat(agents): sync model into framework config + reverse reconcile (#570)

### DIFF
--- a/tests/test_framework_model_sync.py
+++ b/tests/test_framework_model_sync.py
@@ -1,0 +1,328 @@
+"""Unit tests for tinyagentos.framework_model_sync."""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from tinyagentos.framework_model_sync import (
+    OPENCLAW_MODEL_DEFAULTS,
+    FrameworkModelReconciler,
+    build_openclaw_models,
+    patch_hermes_default,
+    patch_openclaw_config,
+    read_hermes_default,
+    read_openclaw_primary,
+)
+
+# ---------------------------------------------------------------------------
+# Sample Hermes YAML used across multiple tests
+# ---------------------------------------------------------------------------
+
+HERMES_YAML = """\
+agent:
+  memory_enabled: true
+model:
+  api_key: sk-x
+  base_url: http://127.0.0.1:4000/v1
+  default: old-model
+  provider: custom
+platform_toolsets:
+  cli:
+  - hermes-cli
+"""
+
+
+# ---------------------------------------------------------------------------
+# build_openclaw_models
+# ---------------------------------------------------------------------------
+
+
+def test_build_openclaw_models_shape():
+    result = build_openclaw_models(["llama3", "qwen3"])
+    assert len(result) == 2
+    for entry, mid in zip(result, ["llama3", "qwen3"]):
+        assert entry["id"] == mid
+        assert entry["name"] == mid
+        assert entry["contextWindow"] == OPENCLAW_MODEL_DEFAULTS["contextWindow"]
+        assert entry["maxTokens"] == OPENCLAW_MODEL_DEFAULTS["maxTokens"]
+        assert entry["input"] == OPENCLAW_MODEL_DEFAULTS["input"]
+        assert entry["reasoning"] == OPENCLAW_MODEL_DEFAULTS["reasoning"]
+
+
+def test_build_openclaw_models_empty():
+    assert build_openclaw_models([]) == []
+
+
+# ---------------------------------------------------------------------------
+# patch_openclaw_config
+# ---------------------------------------------------------------------------
+
+
+def test_patch_openclaw_config_minimal_cfg():
+    cfg = patch_openclaw_config({}, "llama3", ["llama3", "qwen3"])
+    assert cfg["agents"]["defaults"]["model"]["primary"] == "litellm/llama3"
+    models = cfg["models"]["providers"]["litellm"]["models"]
+    assert len(models) == 2
+    ids = [m["id"] for m in models]
+    assert ids == ["llama3", "qwen3"]
+
+
+def test_patch_openclaw_config_nested_structure_created():
+    cfg = patch_openclaw_config({}, "my-model", ["my-model"])
+    # All nesting must exist
+    assert "models" in cfg
+    assert "providers" in cfg["models"]
+    assert "litellm" in cfg["models"]["providers"]
+    assert "models" in cfg["models"]["providers"]["litellm"]
+    assert "agents" in cfg
+    assert "defaults" in cfg["agents"]
+    assert "model" in cfg["agents"]["defaults"]
+
+
+def test_patch_openclaw_config_fixed_metadata():
+    cfg = patch_openclaw_config({}, "m1", ["m1"])
+    entry = cfg["models"]["providers"]["litellm"]["models"][0]
+    assert entry["contextWindow"] == 128000
+    assert entry["maxTokens"] == 16384
+    assert entry["input"] == ["text"]
+    assert entry["reasoning"] is False
+
+
+# ---------------------------------------------------------------------------
+# read_openclaw_primary
+# ---------------------------------------------------------------------------
+
+
+def test_read_openclaw_primary_strips_prefix():
+    cfg = {"agents": {"defaults": {"model": {"primary": "litellm/llama3"}}}}
+    assert read_openclaw_primary(cfg) == "llama3"
+
+
+def test_read_openclaw_primary_no_prefix():
+    cfg = {"agents": {"defaults": {"model": {"primary": "qwen3"}}}}
+    assert read_openclaw_primary(cfg) == "qwen3"
+
+
+def test_read_openclaw_primary_missing_returns_none():
+    assert read_openclaw_primary({}) is None
+    assert read_openclaw_primary({"agents": {}}) is None
+    assert read_openclaw_primary({"agents": {"defaults": {}}}) is None
+
+
+# ---------------------------------------------------------------------------
+# patch_hermes_default
+# ---------------------------------------------------------------------------
+
+
+def test_patch_hermes_default_replaces_value():
+    result = patch_hermes_default(HERMES_YAML, "new-model")
+    assert "default: new-model" in result
+
+
+def test_patch_hermes_default_preserves_other_lines():
+    result = patch_hermes_default(HERMES_YAML, "new-model")
+    assert "base_url: http://127.0.0.1:4000/v1" in result
+    assert "provider: custom" in result
+    assert "memory_enabled: true" in result
+    assert "- hermes-cli" in result
+    assert "api_key: sk-x" in result
+
+
+def test_patch_hermes_default_does_not_duplicate_lines():
+    result = patch_hermes_default(HERMES_YAML, "new-model")
+    # Only one default: line should exist
+    default_lines = [l for l in result.splitlines() if "default:" in l]
+    assert len(default_lines) == 1
+
+
+def test_patch_hermes_default_old_value_gone():
+    result = patch_hermes_default(HERMES_YAML, "new-model")
+    assert "old-model" not in result
+
+
+def test_patch_hermes_default_no_model_default_unchanged():
+    yaml_no_default = """\
+agent:
+  memory_enabled: true
+model:
+  api_key: sk-x
+  provider: custom
+"""
+    result = patch_hermes_default(yaml_no_default, "new-model")
+    assert result == yaml_no_default
+
+
+def test_patch_hermes_default_no_model_block_unchanged():
+    yaml_no_block = "foo: bar\n"
+    result = patch_hermes_default(yaml_no_block, "new-model")
+    assert result == yaml_no_block
+
+
+# ---------------------------------------------------------------------------
+# read_hermes_default
+# ---------------------------------------------------------------------------
+
+
+def test_read_hermes_default_parses_value():
+    assert read_hermes_default(HERMES_YAML) == "old-model"
+
+
+def test_read_hermes_default_returns_none_when_absent():
+    assert read_hermes_default("foo: bar\n") is None
+
+
+def test_read_hermes_default_after_patch():
+    patched = patch_hermes_default(HERMES_YAML, "new-model")
+    assert read_hermes_default(patched) == "new-model"
+
+
+# ---------------------------------------------------------------------------
+# FrameworkModelReconciler
+# ---------------------------------------------------------------------------
+
+
+class _FakeConfig:
+    def __init__(self, agents):
+        self.agents = agents
+        self.config_path = "/dev/null"
+
+
+class _FakeState:
+    def __init__(self, agents):
+        self.config = _FakeConfig(agents)
+
+
+async def _noop_save(*args, **kwargs):
+    pass
+
+
+@pytest.mark.asyncio
+async def test_reconciler_updates_agent_record(monkeypatch):
+    """When live primary differs from agent record, it must be updated."""
+    agents = [
+        {
+            "name": "alpha",
+            "framework": "openclaw",
+            "model": "old-model",
+            "permitted_models": ["old-model"],
+        }
+    ]
+    state = _FakeState(agents)
+
+    import tinyagentos.framework_model_sync as mod
+
+    async def _fake_read(slug, framework):
+        return "new-model"
+
+    monkeypatch.setattr(mod, "read_framework_primary", _fake_read)
+    monkeypatch.setattr(mod, "save_config_locked", _noop_save, raising=False)
+    # Also patch the import inside _reconcile_once
+    import tinyagentos.config as cfg_mod
+    monkeypatch.setattr(cfg_mod, "save_config_locked", _noop_save)
+
+    reconciler = FrameworkModelReconciler(state, interval=60.0, initial_delay=30.0)
+    await reconciler._reconcile_once()
+
+    assert agents[0]["model"] == "new-model"
+    assert "new-model" in agents[0]["permitted_models"]
+
+
+@pytest.mark.asyncio
+async def test_reconciler_no_change_when_model_same(monkeypatch):
+    agents = [
+        {
+            "name": "beta",
+            "framework": "hermes",
+            "model": "same-model",
+            "permitted_models": ["same-model"],
+        }
+    ]
+    state = _FakeState(agents)
+
+    save_calls = []
+
+    import tinyagentos.framework_model_sync as mod
+
+    async def _fake_read(slug, framework):
+        return "same-model"
+
+    async def _capture_save(*args, **kwargs):
+        save_calls.append(True)
+
+    monkeypatch.setattr(mod, "read_framework_primary", _fake_read)
+    import tinyagentos.config as cfg_mod
+    monkeypatch.setattr(cfg_mod, "save_config_locked", _capture_save)
+
+    reconciler = FrameworkModelReconciler(state, interval=60.0, initial_delay=30.0)
+    await reconciler._reconcile_once()
+
+    assert agents[0]["model"] == "same-model"
+    assert not save_calls  # no save because nothing changed
+
+
+@pytest.mark.asyncio
+async def test_reconciler_skips_non_framework_agents(monkeypatch):
+    agents = [
+        {"name": "gamma", "framework": "none", "model": "x"},
+        {"name": "delta", "model": "y"},  # no framework key
+    ]
+    state = _FakeState(agents)
+
+    reads = []
+
+    import tinyagentos.framework_model_sync as mod
+
+    async def _fake_read(slug, framework):
+        reads.append(slug)
+        return "z"
+
+    monkeypatch.setattr(mod, "read_framework_primary", _fake_read)
+    import tinyagentos.config as cfg_mod
+    monkeypatch.setattr(cfg_mod, "save_config_locked", _noop_save)
+
+    reconciler = FrameworkModelReconciler(state, interval=60.0, initial_delay=30.0)
+    await reconciler._reconcile_once()
+
+    # Neither agent should have been read
+    assert reads == []
+
+
+@pytest.mark.asyncio
+async def test_reconciler_start_stop_no_hang():
+    """start() + stop() must complete without hanging."""
+    state = _FakeState([])
+    reconciler = FrameworkModelReconciler(state, interval=0.05, initial_delay=0.05)
+    await reconciler.start()
+    await asyncio.sleep(0.01)
+    await reconciler.stop()  # must not block
+
+
+@pytest.mark.asyncio
+async def test_reconciler_appends_new_model_to_permitted(monkeypatch):
+    """A live model not in permitted_models must be prepended."""
+    agents = [
+        {
+            "name": "epsilon",
+            "framework": "hermes",
+            "model": "old",
+            "permitted_models": ["old"],
+        }
+    ]
+    state = _FakeState(agents)
+
+    import tinyagentos.framework_model_sync as mod
+
+    async def _fake_read(slug, framework):
+        return "brand-new"
+
+    monkeypatch.setattr(mod, "read_framework_primary", _fake_read)
+    import tinyagentos.config as cfg_mod
+    monkeypatch.setattr(cfg_mod, "save_config_locked", _noop_save)
+
+    reconciler = FrameworkModelReconciler(state)
+    await reconciler._reconcile_once()
+
+    assert agents[0]["model"] == "brand-new"
+    assert agents[0]["permitted_models"][0] == "brand-new"
+    assert "old" in agents[0]["permitted_models"]

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -689,6 +689,15 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
             await provider_refresher.start()
         except Exception:
             logger.exception("cloud provider refresher failed to start")
+        # Reverse sync: detect when a user changes the model in the
+        # framework's native TUI and update the taOS agent record.
+        from tinyagentos.framework_model_sync import FrameworkModelReconciler
+        framework_reconciler = FrameworkModelReconciler(app.state)
+        app.state.framework_reconciler = framework_reconciler
+        try:
+            await framework_reconciler.start()
+        except Exception:
+            logger.exception("framework model reconciler failed to start")
         await cluster_manager.start()
         # Enroll this controller as the 'local' cluster worker so route-layer
         # code (get_local_worker) picks up the in-memory signing key.
@@ -930,6 +939,10 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
             pass
         try:
             await provider_refresher.stop()
+        except Exception:
+            pass
+        try:
+            await framework_reconciler.stop()
         except Exception:
             pass
         await app.state.mcp_supervisor.stop_all()

--- a/tinyagentos/framework_model_sync.py
+++ b/tinyagentos/framework_model_sync.py
@@ -1,0 +1,351 @@
+"""Keep each framework's native model config in sync with taOS's permitted
+set and primary model.
+
+Two directions:
+- Forward push: when taOS updates an agent's model or permitted set, push
+  the change into the framework's config file inside its container so the
+  framework's own model picker reflects the new state immediately.
+- Reverse reconcile: a background interval reads each framework's live
+  primary-model field and updates the taOS record when it changed (the user
+  switched the model from the framework's native TUI).
+
+Frameworks supported: openclaw (JSON), hermes (YAML).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+import tempfile
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Fixed metadata applied to every entry in OpenClaw's models array.
+OPENCLAW_MODEL_DEFAULTS: dict = {
+    "contextWindow": 128000,
+    "maxTokens": 16384,
+    "input": ["text"],
+    "reasoning": False,
+}
+
+# ---------------------------------------------------------------------------
+# Pure functions — fully unit-testable
+# ---------------------------------------------------------------------------
+
+
+def build_openclaw_models(model_ids: list[str]) -> list[dict]:
+    """Build the models array for OpenClaw's providers.litellm.models."""
+    return [{"id": mid, "name": mid, **OPENCLAW_MODEL_DEFAULTS} for mid in model_ids]
+
+
+def patch_openclaw_config(cfg: dict, primary: str, permitted: list[str]) -> dict:
+    """Mutate *cfg* so it reflects *primary* and *permitted*, then return it.
+
+    Creates any missing nested dicts via setdefault so it works on a minimal
+    ``{}`` config as well as a real openclaw.json.
+    """
+    cfg.setdefault("models", {}).setdefault("providers", {}).setdefault(
+        "litellm", {}
+    )["models"] = build_openclaw_models(permitted)
+
+    cfg.setdefault("agents", {}).setdefault("defaults", {}).setdefault(
+        "model", {}
+    )["primary"] = f"litellm/{primary}"
+
+    return cfg
+
+
+def read_openclaw_primary(cfg: dict) -> str | None:
+    """Return the bare model id from ``agents.defaults.model.primary``.
+
+    Strips a leading ``litellm/`` prefix if present.  Returns None when the
+    key path is absent.
+    """
+    try:
+        raw = cfg["agents"]["defaults"]["model"]["primary"]
+    except (KeyError, TypeError):
+        return None
+    if isinstance(raw, str) and raw.startswith("litellm/"):
+        return raw[len("litellm/"):]
+    return raw if isinstance(raw, str) else None
+
+
+def patch_hermes_default(text: str, primary: str) -> str:
+    """Return *text* with the ``default:`` line inside the top-level
+    ``model:`` block replaced to *primary*.
+
+    Line-oriented: preserves every other line (including comments).
+    If no ``model.default`` line exists the text is returned unchanged.
+    """
+    lines = text.splitlines(keepends=True)
+    in_model_block = False
+    result = []
+    for line in lines:
+        if re.match(r"^model:\s*$", line):
+            in_model_block = True
+            result.append(line)
+            continue
+        # A non-whitespace-leading line (other than the first) closes the block.
+        if in_model_block and line and not line[0].isspace():
+            in_model_block = False
+        if in_model_block and re.match(r"^(\s+)default:\s*\S*", line):
+            # Replace only the value; preserve indent and key name.
+            line = re.sub(r"^(\s+default:\s*)\S*", rf"\g<1>{primary}", line)
+        result.append(line)
+    return "".join(result)
+
+
+def read_hermes_default(text: str) -> str | None:
+    """Parse the ``default:`` value from the top-level ``model:`` block.
+
+    Returns None when absent.
+    """
+    in_model_block = False
+    for line in text.splitlines():
+        if re.match(r"^model:\s*$", line):
+            in_model_block = True
+            continue
+        if in_model_block and line and not line[0].isspace():
+            # Left the model block without finding default
+            break
+        if in_model_block:
+            m = re.match(r"^\s+default:\s*(\S+)", line)
+            if m:
+                return m.group(1)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Container I/O — async, guarded, NEVER raise
+# ---------------------------------------------------------------------------
+
+
+async def push_model_config_to_framework(
+    slug: str, framework: str, primary: str, permitted: list[str]
+) -> bool:
+    """Push the current model config into the framework's config file.
+
+    Returns True on success, False on any error (always guarded).
+    """
+    from tinyagentos.containers import exec_in_container, push_file
+
+    container = f"taos-agent-{slug}"
+
+    try:
+        if framework == "openclaw":
+            rc, out = await exec_in_container(
+                container, ["cat", "/root/.openclaw/openclaw.json"]
+            )
+            if rc != 0:
+                logger.warning(
+                    "model sync: cannot read openclaw.json from %s (rc=%d): %s",
+                    container, rc, out,
+                )
+                return False
+            try:
+                cfg = json.loads(out)
+            except json.JSONDecodeError as exc:
+                logger.warning("model sync: invalid JSON in openclaw.json for %s: %s", container, exc)
+                return False
+            patch_openclaw_config(cfg, primary, permitted)
+            data = json.dumps(cfg, indent=2)
+            with tempfile.NamedTemporaryFile(
+                mode="w", suffix=".json", delete=False
+            ) as tmp:
+                tmp.write(data)
+                tmp_path = tmp.name
+            try:
+                rc, out = await push_file(container, tmp_path, "/root/.openclaw/openclaw.json")
+                return rc == 0
+            finally:
+                import os
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+
+        elif framework == "hermes":
+            rc, out = await exec_in_container(
+                container, ["cat", "/root/.hermes/config.yaml"]
+            )
+            if rc != 0:
+                logger.warning(
+                    "model sync: cannot read config.yaml from %s (rc=%d): %s",
+                    container, rc, out,
+                )
+                return False
+            new_text = patch_hermes_default(out, primary)
+            with tempfile.NamedTemporaryFile(
+                mode="w", suffix=".yaml", delete=False
+            ) as tmp:
+                tmp.write(new_text)
+                tmp_path = tmp.name
+            try:
+                rc, out = await push_file(container, tmp_path, "/root/.hermes/config.yaml")
+                return rc == 0
+            finally:
+                import os
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+
+        else:
+            return False
+
+    except Exception:
+        logger.exception(
+            "model sync: push_model_config_to_framework failed for %s/%s",
+            slug, framework,
+        )
+        return False
+
+
+async def read_framework_primary(slug: str, framework: str) -> str | None:
+    """Read the live primary model id from the framework's config.
+
+    Returns None on any error.
+    """
+    from tinyagentos.containers import exec_in_container
+
+    container = f"taos-agent-{slug}"
+    try:
+        if framework == "openclaw":
+            rc, out = await exec_in_container(
+                container, ["cat", "/root/.openclaw/openclaw.json"]
+            )
+            if rc != 0:
+                return None
+            try:
+                cfg = json.loads(out)
+            except json.JSONDecodeError:
+                return None
+            return read_openclaw_primary(cfg)
+
+        elif framework == "hermes":
+            rc, out = await exec_in_container(
+                container, ["cat", "/root/.hermes/config.yaml"]
+            )
+            if rc != 0:
+                return None
+            return read_hermes_default(out)
+
+        else:
+            return None
+
+    except Exception:
+        logger.exception(
+            "model sync: read_framework_primary failed for %s/%s", slug, framework
+        )
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Interval reconciler — reverse sync (framework → taOS)
+# ---------------------------------------------------------------------------
+
+RECONCILE_INTERVAL = 60.0
+RECONCILE_INITIAL_DELAY = 30.0
+
+
+class FrameworkModelReconciler:
+    """Background task: reads each framework's live primary model and
+    updates the taOS agent record when it changed (the user switched
+    the model in the framework's native TUI).
+
+    Mirrors the lifecycle of CloudProviderRefresher (start/stop/loop).
+    """
+
+    def __init__(
+        self,
+        app_state,
+        interval: float = RECONCILE_INTERVAL,
+        initial_delay: float = RECONCILE_INITIAL_DELAY,
+    ):
+        self._state = app_state
+        self._interval = interval
+        self._initial_delay = initial_delay
+        self._task: Optional[asyncio.Task] = None
+        self._stop = asyncio.Event()
+
+    async def start(self) -> None:
+        if self._task is not None:
+            return
+        self._stop.clear()
+        self._task = asyncio.create_task(
+            self._loop(), name="framework-model-reconciler"
+        )
+        logger.info(
+            "FrameworkModelReconciler started (interval=%ds)", self._interval
+        )
+
+    async def stop(self) -> None:
+        self._stop.set()
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+
+    async def _loop(self) -> None:
+        try:
+            await asyncio.wait_for(self._stop.wait(), timeout=self._initial_delay)
+            return  # stopped during initial delay
+        except asyncio.TimeoutError:
+            pass
+        while True:
+            try:
+                await self._reconcile_once()
+            except Exception:
+                logger.exception("framework model reconciler iteration failed")
+            try:
+                await asyncio.wait_for(self._stop.wait(), timeout=self._interval)
+                return
+            except asyncio.TimeoutError:
+                pass  # next cycle
+
+    async def _reconcile_once(self) -> None:
+        from tinyagentos.config import save_config_locked
+
+        config = getattr(self._state, "config", None)
+        if config is None:
+            return
+
+        changed: list[str] = []
+        for agent in config.agents:
+            framework = agent.get("framework")
+            if framework not in ("openclaw", "hermes"):
+                continue
+            slug = agent.get("name")
+            if not slug:
+                continue
+            try:
+                live = await read_framework_primary(slug, framework)
+            except Exception:
+                logger.exception(
+                    "framework reconciler: read_framework_primary failed for %s", slug
+                )
+                continue
+            if live and live != agent.get("model"):
+                old = agent.get("model")
+                agent["model"] = live
+                # Ensure the new primary is in the permitted set.
+                permitted = agent.get("permitted_models") or []
+                if live not in permitted:
+                    agent["permitted_models"] = [live, *permitted]
+                changed.append(slug)
+                logger.info(
+                    "framework reconciler: %s model updated %s → %s",
+                    slug, old, live,
+                )
+
+        if changed and config.config_path:
+            await save_config_locked(config, config.config_path)
+            logger.info(
+                "framework reconciler: saved config after updating %d agent(s): %s",
+                len(changed), changed,
+            )

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -807,6 +807,14 @@ async def update_agent_model(request: Request, name: str, body: AgentModelUpdate
         except Exception:
             logger.exception("update_agent_model: re-scoping key for %s failed", name)
 
+    framework = agent.get("framework")
+    if framework in ("openclaw", "hermes"):
+        from tinyagentos.framework_model_sync import push_model_config_to_framework
+        try:
+            await push_model_config_to_framework(name, framework, agent["model"], permitted)
+        except Exception:
+            logger.exception("model sync: pushing framework config for %s failed", name)
+
     return {
         "status": "updated",
         "name": name,
@@ -873,6 +881,14 @@ async def set_permitted_models(request: Request, name: str, body: PermittedModel
             key_rescoped = await proxy.update_agent_key(llm_key, permitted)
         except Exception:
             logger.exception("set_permitted_models: re-scoping key for %s failed", name)
+
+    framework = agent.get("framework")
+    if framework in ("openclaw", "hermes"):
+        from tinyagentos.framework_model_sync import push_model_config_to_framework
+        try:
+            await push_model_config_to_framework(name, framework, agent["model"], permitted)
+        except Exception:
+            logger.exception("model sync: pushing framework config for %s failed", name)
 
     return {
         "status": "updated",


### PR DESCRIPTION
Piece 4 of the synced model-management design ([#570 comment](https://github.com/jaylfc/taOS/issues/570)). Builds on the merged permitted-set core (#578/#581).

## What
Keeps each framework's native model config in sync with taOS's permitted set + primary model, both directions. Schemas verified against the live containers on the Pi.

**Forward push** (taOS -> framework, best-effort, guarded) on `set_permitted_models` and `update_agent_model`:
- **OpenClaw** (`/root/.openclaw/openclaw.json`): rewrites `models.providers.litellm.models[]` from the permitted set (same fixed metadata `install.sh` uses) and sets `agents.defaults.model.primary` to `litellm/<primary>`. OpenClaw reads this static list for its native picker (it has no generic `/v1/models` discovery), so this is what makes the permitted set visible there. ACP re-reads the file each turn, so no reload signal needed.
- **Hermes** (`/root/.hermes/config.yaml`): line-oriented replace of `model.default` (preserves the rest of the file incl. comments). Hermes' list comes from the proxy `/v1/models`, which the key scope already governs.

**Reverse reconcile** (framework -> taOS): `FrameworkModelReconciler`, a background interval service (mirrors `CloudProviderRefresher`) that reads each framework's live primary model and updates the taOS agent record when it changed — the "switch the model in the native TUI, settings catches up" path. Wired into the app lifespan alongside the provider refresher.

## Why both directions
The LiteLLM key scope *enforces* the permitted boundary on both frameworks. This PR makes the framework's own UI *reflect* the set (forward) and lets taOS *learn* native switches (reverse), so the model is consistent no matter where it's changed.

## Notes
- All container I/O is guarded and never raises; a stopped/absent container is a no-op.
- Reverse reconcile only adds a TUI-selected model to `permitted_models` defensively — both frameworks only surface the permitted set, so a user can't select outside it.
- Container read/write logic can only be exercised live (no incus in CI); the static-validate-on-Pi step is the test pass.

## Tests
`tests/test_framework_model_sync.py` (22): the pure builders/patchers/readers for both frameworks (incl. Hermes preserving surrounding lines) and the reconciler updating the record on a diff + clean start/stop. Existing `test_agent_permitted_models.py` still green (20).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic model configuration synchronization between agent records and framework containers (OpenClaw and Hermes).
  * Agent model updates are now pushed to framework configurations in real-time.
  * Background reconciler periodically syncs framework model changes back into the agent system.

* **Tests**
  * Added comprehensive test coverage for model synchronization utilities and reconciliation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->