### PR TITLE
feat(agents): multi-select permitted-model set in the Framework tab (#570)

### DIFF
--- a/desktop/src/components/agent-settings/FrameworkTab.test.tsx
+++ b/desktop/src/components/agent-settings/FrameworkTab.test.tsx
@@ -10,6 +10,14 @@ vi.mock("@/lib/framework-api", () => ({
     update_status: "idle",
   })),
   startFrameworkUpdate: vi.fn(),
+  fetchPermittedModels: vi.fn(async () => ({
+    permitted: ["llama3", "qwen3"],
+    current: "llama3",
+  })),
+  setPermittedModels: vi.fn(async (_name: string, models: string[]) => ({
+    permitted: models,
+    current: "llama3",
+  })),
 }));
 
 import { FrameworkTab } from "./FrameworkTab";
@@ -38,5 +46,70 @@ describe("FrameworkTab — model change", () => {
         (global.fetch as any).mock.calls.some((c: any[]) => String(c[0]).includes("/api/providers/models")),
       ).toBe(true),
     );
+  });
+});
+
+describe("FrameworkTab — permitted models", () => {
+  beforeEach(() => {
+    global.fetch = vi.fn(async (url: string) => {
+      if (String(url).includes("/api/providers/models")) {
+        return { ok: true, json: async () => ({ data: [{ id: "mistral/7b:free" }] }) } as Response;
+      }
+      return { ok: true, json: async () => ({}) } as Response;
+    }) as unknown as typeof fetch;
+  });
+
+  it("renders the permitted set from the mocked GET", async () => {
+    render(<FrameworkTab agent={{ name: "alpha", model: "llama3" }} onUpdated={() => {}} />);
+    // qwen3 only appears in the permitted chips (not in the primary model row).
+    expect(await screen.findByText("qwen3")).toBeInTheDocument();
+    // The current model should have a "current" badge.
+    expect(await screen.findByLabelText("current primary model")).toBeInTheDocument();
+    // The permitted chips list should contain both models.
+    const list = screen.getByRole("list", { name: /permitted model chips/i });
+    expect(list.textContent).toContain("llama3");
+    expect(list.textContent).toContain("qwen3");
+  });
+
+  it("adding a model and saving issues the PUT with the expected body", async () => {
+    const { setPermittedModels } = await import("@/lib/framework-api");
+    render(<FrameworkTab agent={{ name: "alpha", model: "llama3" }} onUpdated={() => {}} />);
+    // Wait for permitted set to load.
+    await screen.findByRole("list", { name: /permitted model chips/i });
+
+    // Open the "Add" picker.
+    fireEvent.click(screen.getByRole("button", { name: /add permitted model/i }));
+    // Wait for the picker to open — it loads models.
+    await waitFor(() =>
+      expect(
+        (global.fetch as any).mock.calls.some((c: any[]) => String(c[0]).includes("/api/providers/models")),
+      ).toBe(true),
+    );
+
+    // Close the picker without selecting (reset state) then verify Save works
+    // by directly manipulating the draft via remove (triggers dirty).
+    // Remove qwen3 first so draftDirty becomes true, then Save.
+    const removeBtn = screen.getByRole("button", { name: /remove qwen3/i });
+    fireEvent.click(removeBtn);
+
+    // Save button should now be visible.
+    const saveBtn = await screen.findByRole("button", { name: /save permitted models/i });
+    fireEvent.click(saveBtn);
+
+    await waitFor(() => {
+      expect(setPermittedModels).toHaveBeenCalledWith("alpha", ["llama3"]);
+    });
+  });
+
+  it("the current model cannot be removed", async () => {
+    render(<FrameworkTab agent={{ name: "alpha", model: "llama3" }} onUpdated={() => {}} />);
+    // Wait for permitted chips to appear.
+    await screen.findByRole("list", { name: /permitted model chips/i });
+
+    // The remove button for the current model should be disabled.
+    const removeCurrentBtn = screen.getByRole("button", {
+      name: /cannot remove current model llama3/i,
+    });
+    expect(removeCurrentBtn).toBeDisabled();
   });
 });

--- a/desktop/src/components/agent-settings/FrameworkTab.tsx
+++ b/desktop/src/components/agent-settings/FrameworkTab.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { fetchFrameworkState, FrameworkState, startFrameworkUpdate } from "@/lib/framework-api";
+import { fetchFrameworkState, FrameworkState, startFrameworkUpdate, fetchPermittedModels, setPermittedModels } from "@/lib/framework-api";
 import { ModelPickerModal } from "@/components/ModelPickerModal";
 import type { AgentModel } from "@/components/ModelPickerFlow";
 
@@ -20,10 +20,19 @@ export function FrameworkTab(
   const [pickerOpen, setPickerOpen] = useState(false);
   const [modelErr, setModelErr] = useState<string | null>(null);
 
+  // Permitted models set — the list of models this agent is allowed to use.
+  const [permittedCurrent, setPermittedCurrent] = useState<string>("");
+  const [permittedLoaded, setPermittedLoaded] = useState(false);
+  const [addPickerOpen, setAddPickerOpen] = useState(false);
+  const [permittedSaving, setPermittedSaving] = useState(false);
+  const [permittedErr, setPermittedErr] = useState<string | null>(null);
+  // Local draft — initialised from GET, only committed to backend on Save
+  const [draftPermitted, setDraftPermitted] = useState<string[]>([]);
+  const [draftDirty, setDraftDirty] = useState(false);
+
   // Routable models = LiteLLM /v1/models passthrough (single source of truth
   // for what an agent can use). Loaded when the picker is first opened.
-  async function openPicker() {
-    setPickerOpen(true);
+  async function ensureModelsLoaded() {
     if (modelsLoaded) return;
     try {
       const res = await fetch("/api/providers/models?refresh=true", {
@@ -35,6 +44,16 @@ export function FrameworkTab(
       })));
     } catch { /* leave empty — picker shows no models */ }
     finally { setModelsLoaded(true); }
+  }
+
+  async function openPicker() {
+    setPickerOpen(true);
+    await ensureModelsLoaded();
+  }
+
+  async function openAddPicker() {
+    setAddPickerOpen(true);
+    await ensureModelsLoaded();
   }
 
   async function changeModel(modelId: string) {
@@ -58,12 +77,57 @@ export function FrameworkTab(
     }
   }
 
+  async function loadPermitted() {
+    try {
+      const data = await fetchPermittedModels(agent.name);
+      setPermittedCurrent(data.current);
+      setDraftPermitted(data.permitted);
+      setDraftDirty(false);
+    } catch { /* non-critical — section stays hidden */ }
+    finally { setPermittedLoaded(true); }
+  }
+
+  function addToPermitted(modelId: string) {
+    if (draftPermitted.includes(modelId)) return;
+    const next = [...draftPermitted, modelId];
+    setDraftPermitted(next);
+    setDraftDirty(true);
+    setAddPickerOpen(false);
+  }
+
+  function removeFromPermitted(modelId: string) {
+    // The current/primary model cannot be removed — the backend would just
+    // re-add it, so we prevent the confusing round-trip here.
+    if (modelId === permittedCurrent) return;
+    const next = draftPermitted.filter((m) => m !== modelId);
+    setDraftPermitted(next);
+    setDraftDirty(true);
+  }
+
+  async function savePermitted() {
+    setPermittedSaving(true);
+    setPermittedErr(null);
+    try {
+      const data = await setPermittedModels(agent.name, draftPermitted);
+      setPermittedCurrent(data.current);
+      setDraftPermitted(data.permitted);
+      setDraftDirty(false);
+    } catch (e: any) {
+      setPermittedErr(String(e?.message ?? e));
+    } finally {
+      setPermittedSaving(false);
+    }
+  }
+
   async function load() {
     try { setState(await fetchFrameworkState(agent.name)); setErr(null); }
     catch (e: any) { setErr(String(e)); }
   }
 
-  useEffect(() => { load(); }, [agent.name]);
+  useEffect(() => {
+    load();
+    loadPermitted();
+  }, [agent.name]);
 
   useEffect(() => {
     if (state?.update_status !== "updating") return;
@@ -107,12 +171,80 @@ export function FrameworkTab(
         <code className="text-sm">{currentModel || "(not set)"}</code>
         <button
           onClick={openPicker}
+          aria-label="Change model"
           className="bg-white/10 hover:bg-white/15 px-2.5 py-1 rounded text-xs"
         >
           Change model
         </button>
       </div>
       {modelErr && <div className="text-xs text-red-400">{modelErr}</div>}
+
+      {/* Permitted models — the set of models this agent is allowed to use. */}
+      {permittedLoaded && (
+        <section aria-label="Permitted models">
+          <div className="flex items-center gap-2 mb-2">
+            <span className="opacity-60 text-sm">Permitted models</span>
+            <button
+              onClick={openAddPicker}
+              aria-label="Add permitted model"
+              className="bg-white/10 hover:bg-white/15 px-2.5 py-1 rounded text-xs"
+            >
+              + Add
+            </button>
+          </div>
+
+          {draftPermitted.length === 0 ? (
+            <p className="text-xs opacity-50">No models in the permitted set yet.</p>
+          ) : (
+            <ul className="flex flex-wrap gap-2" aria-label="Permitted model chips">
+              {draftPermitted.map((m) => {
+                const isCurrent = m === permittedCurrent;
+                return (
+                  <li
+                    key={m}
+                    className="flex items-center gap-1.5 bg-white/10 rounded px-2 py-0.5 text-xs"
+                  >
+                    <code>{m}</code>
+                    {isCurrent && (
+                      <span
+                        className="bg-blue-600/50 text-blue-200 px-1.5 py-0.5 rounded text-[10px] leading-none"
+                        aria-label="current primary model"
+                      >
+                        current
+                      </span>
+                    )}
+                    <button
+                      onClick={() => removeFromPermitted(m)}
+                      disabled={isCurrent}
+                      aria-label={isCurrent ? `Cannot remove current model ${m}` : `Remove ${m} from permitted models`}
+                      className="opacity-60 hover:opacity-100 disabled:opacity-20 disabled:cursor-not-allowed leading-none"
+                    >
+                      ×
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+
+          {permittedErr && (
+            <div className="text-xs text-red-400 mt-2">{permittedErr}</div>
+          )}
+
+          {draftDirty && (
+            <button
+              onClick={savePermitted}
+              disabled={permittedSaving}
+              aria-label="Save permitted models"
+              aria-busy={permittedSaving}
+              className="mt-2 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 px-3 py-1.5 rounded text-xs"
+            >
+              {permittedSaving ? "Saving…" : "Save"}
+            </button>
+          )}
+        </section>
+      )}
+
       <dl className="grid grid-cols-[120px_1fr] gap-y-1 text-sm">
         <dt className="opacity-60">Installed</dt>
         <dd><code>{state.installed.tag ?? "(unknown)"}</code> · <code>{state.installed.sha ?? "—"}</code></dd>
@@ -173,6 +305,7 @@ export function FrameworkTab(
 
       <div className="mt-auto pt-4 text-xs opacity-50">Switch framework — coming soon</div>
 
+      {/* Change model picker (primary model) */}
       <ModelPickerModal
         open={pickerOpen}
         onClose={() => setPickerOpen(false)}
@@ -180,6 +313,16 @@ export function FrameworkTab(
         modelsLoaded={modelsLoaded}
         onSelect={(modelId) => changeModel(modelId)}
         title="Change model"
+      />
+
+      {/* Add to permitted set picker */}
+      <ModelPickerModal
+        open={addPickerOpen}
+        onClose={() => setAddPickerOpen(false)}
+        models={models}
+        modelsLoaded={modelsLoaded}
+        onSelect={(modelId) => addToPermitted(modelId)}
+        title="Add permitted model"
       />
     </div>
   );

--- a/desktop/src/lib/framework-api.ts
+++ b/desktop/src/lib/framework-api.ts
@@ -35,3 +35,30 @@ export async function fetchLatestFrameworks(refresh = false): Promise<Record<str
   if (!r.ok) throw new Error(`latest frameworks ${r.status}`);
   return r.json();
 }
+
+export interface PermittedModelsState {
+  permitted: string[];
+  current: string;
+}
+
+export async function fetchPermittedModels(name: string): Promise<PermittedModelsState> {
+  const r = await fetch(`/api/agents/${encodeURIComponent(name)}/permitted-models`);
+  if (!r.ok) {
+    const body = await r.json().catch(() => ({}));
+    throw new Error(body.error || `permitted-models fetch ${r.status}`);
+  }
+  return r.json();
+}
+
+export async function setPermittedModels(name: string, models: string[]): Promise<PermittedModelsState> {
+  const r = await fetch(`/api/agents/${encodeURIComponent(name)}/permitted-models`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ models }),
+  });
+  if (!r.ok) {
+    const body = await r.json().catch(() => ({}));
+    throw new Error(body.error || `permitted-models set ${r.status}`);
+  }
+  return r.json();
+}


### PR DESCRIPTION
The user-facing surface for the permitted-model set (#581 backend). Last piece of the synced model-management feature.

## What
Adds a "Permitted models" section to the agent's Framework settings tab, below the existing single-model picker (#577):
- Loads the set from `GET /api/agents/{name}/permitted-models` and shows each member as a chip.
- The current/primary model chip carries a "current" badge and its remove button is disabled (the backend forces it back in anyway).
- "+ Add" opens the same `ModelPickerModal` the Change-model flow uses (same `/api/providers/models` source).
- Local draft + explicit **Save** (matches the tab's confirm-before-commit pattern) → `PUT /api/agents/{name}/permitted-models`. 409 (unreachable model) surfaces inline; Save disabled while in flight.

## API helpers
`fetchPermittedModels` / `setPermittedModels` added to `framework-api.ts`, matching the existing error-handling style.

## Tests
`FrameworkTab.test.tsx` (+3): renders chips from a mocked GET, removing a model + saving issues the expected PUT body, the current-model remove button is disabled. Vitest 4/4 green; `npm run build` succeeds.