### PR TITLE
feat(memory): system-wide memory model; drop per-agent model (#580)

### DIFF
--- a/desktop/src/apps/__tests__/MemoryApp.test.tsx
+++ b/desktop/src/apps/__tests__/MemoryApp.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * Tests for the system-wide memory-model control (MemoryModelSection inside
+ * MemorySettings). Tests render MemorySettings directly to avoid tab-visibility
+ * complexity in jsdom, and verify that:
+ * - GET /api/memory/model drives the rendered UI
+ * - Selecting a model issues PUT /api/memory/model
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import React from "react";
+
+// Stub heavy deps that MemorySettings pulls in transitively
+vi.mock("@/components/ModelPickerFlow", () => ({ ModelPickerFlow: () => null }));
+vi.mock("@/components/ModelPickerModal", () => ({
+  ModelPickerModal: ({
+    open,
+    onSelect,
+    title,
+  }: {
+    open: boolean;
+    onSelect: (id: string) => void;
+    title?: string;
+  }) =>
+    open ? (
+      <div data-testid="model-picker-modal" aria-label={title}>
+        <button
+          data-testid="picker-select-model"
+          onClick={() => onSelect("ollama:qwen3:4b")}
+        >
+          Pick ollama:qwen3:4b
+        </button>
+      </div>
+    ) : null,
+}));
+vi.mock("@/components/memory/SchemaFormRenderer", () => ({
+  SchemaFormRenderer: () => null,
+}));
+
+import { MemorySettings } from "@/components/memory/MemorySettings";
+
+function makeFetch(overrides: Record<string, unknown> = {}) {
+  return vi.fn(async (url: string, init?: RequestInit) => {
+    const u = String(url);
+
+    if (u === "/api/memory/model" && (!init || !init.method || init.method.toUpperCase() === "GET")) {
+      const v = overrides["GET /api/memory/model"] ?? { model: "ollama:qwen3:4b", supported: true };
+      return {
+        ok: true,
+        headers: { get: () => "application/json" },
+        json: async () => v,
+      };
+    }
+    if (u === "/api/memory/model" && init?.method?.toUpperCase() === "PUT") {
+      const v = overrides["PUT /api/memory/model"] ?? { model: "ollama:qwen3:4b" };
+      return {
+        ok: true,
+        headers: { get: () => "application/json" },
+        json: async () => v,
+      };
+    }
+    if (u.includes("/api/memory/backend/settings-schema")) {
+      return { ok: true, headers: { get: () => "application/json" }, json: async () => ({}) };
+    }
+    if (u.includes("/api/memory/settings")) {
+      return { ok: true, headers: { get: () => "application/json" }, json: async () => ({}) };
+    }
+    if (u.includes("/api/providers/models")) {
+      return {
+        ok: true,
+        headers: { get: () => "application/json" },
+        json: async () => ({ data: [{ id: "ollama:qwen3:4b" }] }),
+      };
+    }
+    return { ok: true, headers: { get: () => "application/json" }, json: async () => ({}) };
+  });
+}
+
+describe("MemorySettings — memory model section", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders current model from GET /api/memory/model", async () => {
+    global.fetch = makeFetch({ "GET /api/memory/model": { model: "ollama:qwen3:4b", supported: true } }) as typeof fetch;
+
+    render(<MemorySettings />);
+
+    await waitFor(() => {
+      expect(screen.getByText("ollama:qwen3:4b")).toBeDefined();
+    });
+  });
+
+  it("shows Built-in default when model is null", async () => {
+    global.fetch = makeFetch({ "GET /api/memory/model": { model: null, supported: true } }) as typeof fetch;
+
+    render(<MemorySettings />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Built-in default")).toBeDefined();
+    });
+  });
+
+  it("shows unsupported note when supported=false", async () => {
+    global.fetch = makeFetch({ "GET /api/memory/model": { model: null, supported: false } }) as typeof fetch;
+
+    render(<MemorySettings />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Memory model not supported")).toBeDefined();
+    });
+  });
+
+  it("PUT /api/memory/model is called when a model is selected via picker", async () => {
+    const fetchMock = makeFetch({
+      "GET /api/memory/model": { model: null, supported: true },
+      "PUT /api/memory/model": { model: "ollama:qwen3:4b" },
+    });
+    global.fetch = fetchMock as typeof fetch;
+
+    render(<MemorySettings />);
+
+    const changeBtn = await screen.findByRole("button", { name: /change memory model/i });
+    fireEvent.click(changeBtn);
+
+    const pickBtn = await screen.findByTestId("picker-select-model");
+    fireEvent.click(pickBtn);
+
+    await waitFor(() => {
+      const putCalls = (fetchMock.mock.calls as [string, RequestInit?][]).filter(
+        ([u, init]) => String(u) === "/api/memory/model" && init?.method?.toUpperCase() === "PUT",
+      );
+      expect(putCalls.length).toBeGreaterThan(0);
+      const body = JSON.parse(putCalls[0]![1]!.body as string);
+      expect(body.model).toBe("ollama:qwen3:4b");
+    });
+  });
+});

--- a/desktop/src/components/agent-settings/MemoryTab.tsx
+++ b/desktop/src/components/agent-settings/MemoryTab.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import { detectHwClass, type HwClass } from "@/lib/hw-detect";
 
 interface MemoryTabProps {
   agent: { name: string; memory_plugin?: string };
@@ -8,7 +7,6 @@ interface MemoryTabProps {
 
 interface LibrarianConfig {
   enabled?: boolean;
-  model?: string | null;
   tasks?: Record<string, boolean>;
   fanout?: { default?: string; auto_scale?: boolean };
 }
@@ -24,11 +22,6 @@ export function MemoryTab({ agent, onUpdated }: MemoryTabProps) {
   const [librarian, setLibrarian] = useState<LibrarianConfig | null>(null);
   const [stats, setStats] = useState<MemoryStats | null>(null);
   const [advanced, setAdvanced] = useState(false);
-  const [hw, setHw] = useState<HwClass>("cpu");
-
-  useEffect(() => {
-    detectHwClass().then(setHw);
-  }, []);
 
   useEffect(() => {
     fetch(`/api/agents/${agent.name}/librarian`)
@@ -126,34 +119,6 @@ export function MemoryTab({ agent, onUpdated }: MemoryTabProps) {
               onChange={(e) => patchLib({ enabled: e.target.checked })}
               aria-label="Enable Librarian"
             />
-          </label>
-
-          <label className="flex flex-col gap-1">
-            <span className="text-xs uppercase opacity-60">Model</span>
-            <select
-              value={librarian.model ?? ""}
-              onChange={(e) =>
-                patchLib(
-                  e.target.value
-                    ? { model: e.target.value }
-                    : { clear_model: true }
-                )
-              }
-              className="border border-white/10 rounded bg-shell-bg px-2 py-1 text-sm text-shell-text-secondary focus:outline-none focus:ring-1 focus:ring-white/20"
-              aria-label="Librarian model"
-            >
-              <option value="">Use install default</option>
-              <option value="ollama:qwen3:4b">
-                {hw === "rk3588"
-                  ? "ollama:qwen3:4b"
-                  : "ollama:qwen3:4b \u2713 recommended"}
-              </option>
-              <option value="dulimov/Qwen3-4B-rk3588-1.2.1-base">
-                {hw === "rk3588"
-                  ? "Qwen3-4B NPU (RK3588) \u2713 recommended"
-                  : "Qwen3-4B NPU (RK3588)"}
-              </option>
-            </select>
           </label>
 
           <button

--- a/desktop/src/components/memory/MemorySettings.tsx
+++ b/desktop/src/components/memory/MemorySettings.tsx
@@ -3,7 +3,139 @@ import { Save, RefreshCw, CheckCircle, AlertTriangle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { fetchSettingsSchema, fetchMemorySettings, updateMemorySettings } from "@/lib/memory";
+import { fetchMemoryModel, setMemoryModel } from "@/lib/memory-api";
+import { ModelPickerModal } from "@/components/ModelPickerModal";
+import type { AgentModel } from "@/components/ModelPickerFlow";
 import { SchemaFormRenderer } from "./SchemaFormRenderer";
+
+/* ------------------------------------------------------------------ */
+/*  MemoryModelSection                                                 */
+/* ------------------------------------------------------------------ */
+
+function MemoryModelSection() {
+  const [model, setModel] = useState<string | null>(null);
+  const [supported, setSupported] = useState<boolean | null>(null);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [models, setModels] = useState<AgentModel[]>([]);
+  const [modelsLoaded, setModelsLoaded] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchMemoryModel()
+      .then((d) => { setModel(d.model); setSupported(d.supported); })
+      .catch(() => setSupported(false));
+  }, []);
+
+  async function openPicker() {
+    setPickerOpen(true);
+    if (modelsLoaded) return;
+    try {
+      const res = await fetch("/api/providers/models?refresh=true", {
+        headers: { Accept: "application/json" },
+      });
+      const data = res.ok ? await res.json() : { data: [] };
+      setModels((data.data ?? []).map((m: { id: string }) => ({
+        id: m.id, name: m.id, hostKind: "cloud" as const,
+      })));
+    } catch { /* leave empty */ }
+    finally { setModelsLoaded(true); }
+  }
+
+  async function handleSelect(modelId: string) {
+    setSaving(true);
+    setErr(null);
+    try {
+      const result = await setMemoryModel({ model: modelId });
+      setModel(result.model);
+      setPickerOpen(false);
+    } catch (e: any) {
+      setErr(String(e?.message ?? e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleClear() {
+    setSaving(true);
+    setErr(null);
+    try {
+      const result = await setMemoryModel({ clear: true });
+      setModel(result.model);
+    } catch (e: any) {
+      setErr(String(e?.message ?? e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (supported === null) return null;
+
+  if (!supported) {
+    return (
+      <Card className="bg-white/[0.02] border-white/8">
+        <CardContent className="p-4">
+          <p className="text-xs text-shell-text-tertiary" aria-label="Memory model not supported">
+            Memory model selection needs a newer taOSmd.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="bg-white/[0.02] border-white/8">
+      <CardContent className="p-4 flex flex-col gap-3">
+        <div className="flex items-center justify-between gap-2 flex-wrap">
+          <div>
+            <p className="text-xs uppercase opacity-60 mb-0.5">Memory model</p>
+            <p className="text-sm font-medium" aria-label="Current memory model">
+              {model ?? "Built-in default"}
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={openPicker}
+              disabled={saving}
+              aria-label="Change memory model"
+              className="h-7 px-2.5 text-xs"
+            >
+              Change model
+            </Button>
+            {model !== null && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleClear}
+                disabled={saving}
+                aria-label="Use built-in default memory model"
+                className="h-7 px-2.5 text-xs opacity-70 hover:opacity-100"
+              >
+                Use built-in default
+              </Button>
+            )}
+          </div>
+        </div>
+        {err && (
+          <div className="flex items-center gap-2 px-3 py-2 rounded-md bg-red-500/10 border border-red-500/20" role="alert" aria-live="assertive">
+            <AlertTriangle size={13} className="text-red-400 shrink-0" aria-hidden="true" />
+            <p className="text-xs text-red-300">{err}</p>
+          </div>
+        )}
+        <ModelPickerModal
+          open={pickerOpen}
+          onClose={() => setPickerOpen(false)}
+          models={models}
+          modelsLoaded={modelsLoaded}
+          onSelect={(modelId) => handleSelect(modelId)}
+          title="Change memory model"
+        />
+      </CardContent>
+    </Card>
+  );
+}
 
 /* ------------------------------------------------------------------ */
 /*  MemorySettings                                                     */
@@ -54,6 +186,9 @@ export function MemorySettings() {
 
   return (
     <section className="flex flex-col gap-5 p-4 overflow-auto h-full" aria-label="Memory settings">
+      {/* System-wide memory model */}
+      <MemoryModelSection />
+
       <div className="flex items-center justify-between">
         <h2 className="text-sm font-semibold text-shell-text">Backend Settings</h2>
         <Button

--- a/desktop/src/lib/memory-api.ts
+++ b/desktop/src/lib/memory-api.ts
@@ -1,0 +1,32 @@
+/* ------------------------------------------------------------------ */
+/*  Memory model API helpers                                           */
+/* ------------------------------------------------------------------ */
+
+async function throwOnError(res: Response): Promise<Response> {
+  if (res.ok) return res;
+  let detail = `Request failed (${res.status})`;
+  try {
+    const body = await res.json();
+    if (body.detail) detail = String(body.detail);
+    else if (body.error) detail = String(body.error);
+  } catch { /* ignore parse error */ }
+  throw new Error(detail);
+}
+
+export async function fetchMemoryModel(): Promise<{ model: string | null; supported: boolean }> {
+  const res = await fetch("/api/memory/model", { headers: { Accept: "application/json" } });
+  await throwOnError(res);
+  return res.json();
+}
+
+export async function setMemoryModel(
+  args: { model?: string; clear?: boolean },
+): Promise<{ model: string | null }> {
+  const res = await fetch("/api/memory/model", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json", Accept: "application/json" },
+    body: JSON.stringify(args),
+  });
+  await throwOnError(res);
+  return res.json();
+}

--- a/tests/test_librarian_api.py
+++ b/tests/test_librarian_api.py
@@ -7,7 +7,6 @@ from taosmd.agents import AgentNotFoundError
 
 _DEFAULT_LIBRARIAN = {
     "enabled": True,
-    "model": None,
     "tasks": {t: True for t in tm_agents.LIBRARIAN_TASKS},
     "fanout": {"default": "low", "auto_scale": True},
 }
@@ -59,25 +58,9 @@ class TestPatchLibrarian:
         assert resp.status_code == 200
         assert received["name"] == "atlas"
         assert received["kwargs"]["enabled"] is False
-        # clear_model=False (default) must NOT be forwarded
+        # model/clear_model are no longer forwarded (dropped fields)
+        assert "model" not in received["kwargs"]
         assert "clear_model" not in received["kwargs"]
-
-    async def test_patch_librarian_forwards_clear_model_when_true(self, client, monkeypatch):
-        received: dict = {}
-
-        def _set(name, **kwargs):
-            received["kwargs"] = kwargs
-            return dict(_DEFAULT_LIBRARIAN)
-
-        monkeypatch.setattr(tm_agents, "set_librarian", _set)
-
-        resp = await client.patch(
-            "/api/agents/atlas/librarian",
-            json={"clear_model": True},
-        )
-
-        assert resp.status_code == 200
-        assert received["kwargs"].get("clear_model") is True
 
     async def test_patch_librarian_404_for_unknown_agent(self, client, monkeypatch):
         def _raise(name, **kwargs):

--- a/tests/test_memory_model.py
+++ b/tests/test_memory_model.py
@@ -1,0 +1,99 @@
+"""Tests for GET/PUT /api/memory/model endpoints."""
+from __future__ import annotations
+
+import pytest
+
+import taosmd
+import tinyagentos.routes.librarian as librarian_mod
+
+
+@pytest.mark.asyncio
+class TestGetMemoryModel:
+    async def test_get_returns_model(self, client, monkeypatch):
+        monkeypatch.setattr(librarian_mod.taosmd, "get_memory_model", lambda: "ollama:qwen3:4b")
+
+        resp = await client.get("/api/memory/model")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["model"] == "ollama:qwen3:4b"
+        assert data["supported"] is True
+
+    async def test_get_returns_none_when_no_model_set(self, client, monkeypatch):
+        monkeypatch.setattr(librarian_mod.taosmd, "get_memory_model", lambda: None)
+
+        resp = await client.get("/api/memory/model")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["model"] is None
+        assert data["supported"] is True
+
+    async def test_get_supported_false_when_attr_absent(self, client, monkeypatch):
+        monkeypatch.delattr(librarian_mod.taosmd, "get_memory_model", raising=False)
+
+        resp = await client.get("/api/memory/model")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["supported"] is False
+        assert data["model"] is None
+
+
+@pytest.mark.asyncio
+class TestPutMemoryModel:
+    async def test_put_sets_model(self, client, monkeypatch):
+        received: dict = {}
+
+        def _set(model: str, clear: bool = False):
+            received["model"] = model
+            received["clear"] = clear
+
+        monkeypatch.setattr(librarian_mod.taosmd, "set_memory_model", _set)
+        monkeypatch.setattr(librarian_mod.taosmd, "get_memory_model", lambda: "ollama:qwen3:4b")
+
+        resp = await client.put("/api/memory/model", json={"model": "ollama:qwen3:4b"})
+
+        assert resp.status_code == 200
+        assert received["model"] == "ollama:qwen3:4b"
+        assert received["clear"] is False
+        assert resp.json()["model"] == "ollama:qwen3:4b"
+
+    async def test_put_clear_true_calls_setter_with_clear(self, client, monkeypatch):
+        received: dict = {}
+
+        def _set(model: str, clear: bool = False):
+            received["model"] = model
+            received["clear"] = clear
+
+        monkeypatch.setattr(librarian_mod.taosmd, "set_memory_model", _set)
+        monkeypatch.setattr(librarian_mod.taosmd, "get_memory_model", lambda: None)
+
+        resp = await client.put("/api/memory/model", json={"clear": True})
+
+        assert resp.status_code == 200
+        assert received["clear"] is True
+        assert resp.json()["model"] is None
+
+    async def test_put_neither_model_nor_clear_returns_400(self, client, monkeypatch):
+        monkeypatch.setattr(librarian_mod.taosmd, "set_memory_model", lambda m, clear=False: None)
+
+        resp = await client.put("/api/memory/model", json={})
+
+        assert resp.status_code == 400
+        assert "model" in resp.json()["detail"]
+
+    async def test_put_empty_string_model_returns_400(self, client, monkeypatch):
+        monkeypatch.setattr(librarian_mod.taosmd, "set_memory_model", lambda m, clear=False: None)
+
+        resp = await client.put("/api/memory/model", json={"model": "   "})
+
+        assert resp.status_code == 400
+
+    async def test_put_returns_501_when_set_memory_model_absent(self, client, monkeypatch):
+        monkeypatch.delattr(librarian_mod.taosmd, "set_memory_model", raising=False)
+
+        resp = await client.put("/api/memory/model", json={"model": "ollama:qwen3:4b"})
+
+        assert resp.status_code == 501
+        assert "taosmd" in resp.json()["detail"]

--- a/tests/test_memory_model.py
+++ b/tests/test_memory_model.py
@@ -97,3 +97,16 @@ class TestPutMemoryModel:
 
         assert resp.status_code == 501
         assert "taosmd" in resp.json()["detail"]
+
+    async def test_put_forbidden_for_non_admin(self, client, app, monkeypatch):
+        # System-wide setting: a non-admin session must be rejected (403) before
+        # the setter is ever invoked.
+        called = {"set": False}
+        monkeypatch.setattr(librarian_mod.taosmd, "set_memory_model",
+                            lambda m, clear=False: called.__setitem__("set", True))
+        monkeypatch.setattr(app.state.auth, "session_user", lambda token: {"is_admin": False})
+
+        resp = await client.put("/api/memory/model", json={"model": "ollama:qwen3:4b"})
+
+        assert resp.status_code == 403
+        assert called["set"] is False

--- a/tinyagentos/routes/librarian.py
+++ b/tinyagentos/routes/librarian.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
+import taosmd
 import taosmd.agents as tm_agents
 from taosmd.agents import AgentNotFoundError
 
@@ -12,11 +13,14 @@ router = APIRouter()
 
 class LibrarianPatch(BaseModel):
     enabled: bool | None = None
-    model: str | None = None
-    clear_model: bool = False
     tasks: dict[str, bool] | None = None
     fanout: str | None = None
     fanout_auto_scale: bool | None = None
+
+
+class MemoryModelUpdate(BaseModel):
+    model: str | None = None
+    clear: bool = False
 
 
 @router.get("/api/agents/{slug}/librarian")
@@ -30,9 +34,6 @@ async def get_librarian(slug: str):
 @router.patch("/api/agents/{slug}/librarian")
 async def patch_librarian(slug: str, body: LibrarianPatch):
     kwargs = body.model_dump(exclude_none=True)
-    # clear_model=False is the default and should not be forwarded unless explicitly True
-    if not body.clear_model:
-        kwargs.pop("clear_model", None)
     try:
         result = tm_agents.set_librarian(slug, **kwargs)
         return result
@@ -40,3 +41,26 @@ async def patch_librarian(slug: str, body: LibrarianPatch):
         return JSONResponse(status_code=404, content={"detail": f"agent {slug!r} not found"})
     except ValueError as exc:
         return JSONResponse(status_code=400, content={"detail": str(exc)})
+
+
+@router.get("/api/memory/model")
+async def get_memory_model():
+    getter = getattr(taosmd, "get_memory_model", None)
+    if getter is None:
+        return {"model": None, "supported": False}
+    return {"model": getter(), "supported": True}
+
+
+@router.put("/api/memory/model")
+async def set_memory_model(body: MemoryModelUpdate):
+    setter = getattr(taosmd, "set_memory_model", None)
+    if setter is None:
+        return JSONResponse(status_code=501, content={"detail": "installed taosmd has no system memory-model API"})
+    if not body.clear and not (body.model and body.model.strip()):
+        return JSONResponse(status_code=400, content={"detail": "model is required unless clear=true"})
+    try:
+        setter(body.model or "", clear=body.clear)
+    except Exception as exc:
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
+    getter = getattr(taosmd, "get_memory_model", None)
+    return {"model": getter() if getter else None}

--- a/tinyagentos/routes/librarian.py
+++ b/tinyagentos/routes/librarian.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
@@ -52,7 +52,13 @@ async def get_memory_model():
 
 
 @router.put("/api/memory/model")
-async def set_memory_model(body: MemoryModelUpdate):
+async def set_memory_model(request: Request, body: MemoryModelUpdate):
+    # System-wide setting — only an admin may change which model powers memory
+    # for the whole install. (GET stays open: it returns only a model-id string.)
+    from tinyagentos.routes.auth import _require_admin
+    ok, err = _require_admin(request)
+    if not ok:
+        return err
     setter = getattr(taosmd, "set_memory_model", None)
     if setter is None:
         return JSONResponse(status_code=501, content={"detail": "installed taosmd has no system memory-model API"})


### PR DESCRIPTION
Completes the memory-model move (taOS#580). Pairs with taOSmd#82 (shipped): `taosmd.get_memory_model()` / `set_memory_model(model, clear=False)`.

## What
The memory/Librarian model is now a single **system-wide** setting (managed in the Memory app), not per-agent. Memory is shared infrastructure, so its model is a quality/infra choice — distinct from each agent's per-agent chat model.

- **Backend** (`routes/librarian.py`): `GET/PUT /api/memory/model` calling taOSmd's global getter/setter, guarded with `getattr` so an older taosmd degrades gracefully (`supported:false` / 501) instead of crashing. Removed `model`/`clear_model` from `LibrarianPatch` and stopped forwarding them (taOSmd dropped per-agent model).
- **Frontend**: removed the per-agent model `<select>` from the agent's Memory tab (Enable Librarian / tasks / fanout stay per-agent). Added a single **Memory model** control to the Memory app settings (`MemorySettings.tsx`) — shows the current model or "Built-in default", with a picker (reusing `ModelPickerModal`) and a "use built-in default" action. New `memory-api.ts` helpers.

Model id format is `provider:model` (e.g. `ollama:qwen3:4b`); `null` = built-in default.

## Tests
`tests/test_memory_model.py` (8: GET model/null/unsupported, PUT set/clear/400/501), `test_librarian_api.py` updated (model no longer forwarded), `MemoryApp.test.tsx` (4). Full vitest 973 pass; `npm run build` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System-wide memory model section added to settings — view, select, change, or clear the memory model; shows “not supported” or “Built-in default” when applicable. Updates require admin privileges.

* **Refactor**
  * Librarian model selector removed from the librarian controls; librarian advanced controls remain under “Show advanced…”

* **Tests**
  * Added UI and API tests covering memory model display, selection, clearing, and server endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->