### PR TITLE
fix(agents): surface agent shortcut windows on mobile

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -153,6 +153,19 @@ export function App() {
     return () => window.removeEventListener("open-launchpad", handler);
   }, []);
 
+  // Surface a window opened programmatically from inside an app (e.g. an agent
+  // shortcut launching a terminal/browser). On mobile a window is only visible
+  // when it is the active window, so callers dispatch this with the new window
+  // id; on desktop the window manager already renders it, so this just focuses.
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const wid = (e as CustomEvent<{ windowId?: string }>).detail?.windowId;
+      if (wid) setActiveWindowId(wid);
+    };
+    window.addEventListener("taos:activate-window", handler);
+    return () => window.removeEventListener("taos:activate-window", handler);
+  }, []);
+
   useSessionPersistence();
 
   // Re-apply the persisted active theme on app boot so a reload keeps the

--- a/desktop/src/apps/AgentsApp.tsx
+++ b/desktop/src/apps/AgentsApp.tsx
@@ -312,10 +312,18 @@ export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
       failed("Server response was missing a launch URL.");
       return;
     }
+    // On mobile a freshly opened window only shows once it's the active window
+    // (App.tsx renders MobileAppWindow for activeWindowId). openWindow alone
+    // leaves it invisible, so announce the new window id for activation.
+    const surface = (wid: string | undefined) => {
+      if (isMobile && wid) {
+        window.dispatchEvent(new CustomEvent("taos:activate-window", { detail: { windowId: wid } }));
+      }
+    };
     const kind = shortcut.kind;
     if (kind === "dashboard") {
       const app = getApp("browser");
-      if (app) openWindow("browser", app.defaultSize, { initialUrl: redirect_url });
+      if (app) surface(openWindow("browser", app.defaultSize, { initialUrl: redirect_url }));
     } else if (kind === "tui" || kind === "container-terminal") {
       const { ticket, wsUrl, redeemUrl } = deriveTerminalShortcutTarget(
         redirect_url,
@@ -339,9 +347,9 @@ export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
         console.warn(`shortcut /redeem failed for ${agentId}:`, e);
       }
       const app = getApp("terminal");
-      if (app) openWindow("terminal", app.defaultSize, { shortcut: { wsUrl, ticket } });
+      if (app) surface(openWindow("terminal", app.defaultSize, { shortcut: { wsUrl, ticket } }));
     }
-  }, [openWindow]);
+  }, [openWindow, isMobile]);
 
   function handleWizardClose(deployed?: boolean) {
     setWizardOpen(false);


### PR DESCRIPTION
The agent shortcut buttons (container-terminal / TUI / dashboard) below an agent's name rendered and the tap fired, but **nothing appeared on mobile**.

## Root cause
`handleShortcutLaunch` (AgentsApp.tsx) calls `openWindow(...)` but never sets `activeWindowId`. On mobile, `App.tsx` only renders a window (`MobileAppWindow`) when it's the active window; desktop renders all windows via the window manager regardless — which is why it worked on desktop but not mobile. The launch POST succeeded; the window just never surfaced.

## Fix
After `openWindow()` returns the new window id, on mobile dispatch a `taos:activate-window` event; `App.tsx` listens and calls `setActiveWindowId(wid)`. Applied to both shortcut paths (browser dashboard + terminal/TUI). No-op on desktop (the manager already renders it; this just focuses).

## Verification
`npm run build` clean; existing AgentsApp desktop + mobile vitest suites pass (25). The window-surfacing itself is best confirmed live on a phone — flagged for the Pi test pass.