### PR TITLE
fix(agents): hide permitted-models section when its fetch fails (#583 follow-up)

### DIFF
--- a/desktop/src/components/agent-settings/FrameworkTab.tsx
+++ b/desktop/src/components/agent-settings/FrameworkTab.tsx
@@ -83,8 +83,9 @@ export function FrameworkTab(
       setPermittedCurrent(data.current);
       setDraftPermitted(data.permitted);
       setDraftDirty(false);
+      // Only reveal the section once the set loaded — on error it stays hidden.
+      setPermittedLoaded(true);
     } catch { /* non-critical — section stays hidden */ }
-    finally { setPermittedLoaded(true); }
   }
 
   function addToPermitted(modelId: string) {


### PR DESCRIPTION
Fix-forward for the kilo review finding on #583.

`loadPermitted`'s `finally` set `permittedLoaded = true` even when `fetchPermittedModels` threw, so the permitted-models section rendered (empty, "No models in the permitted set yet") on a failed load — contradicting the `/* section stays hidden */` comment. Moved the flag into the success path; on error the section stays hidden as intended.

FrameworkTab vitest (4) pass; `npm run build` clean.