### PR TITLE
docs: staleness sweep (fork drop, Hermes, synced models, memory model)

### DIFF
--- a/app-catalog/agents/openclaw/scripts/README.md
+++ b/app-catalog/agents/openclaw/scripts/README.md
@@ -1,42 +1,46 @@
 # openclaw install script
 
-`install.sh` runs once inside a fresh Debian bookworm LXC container to set up the minimal openclaw agent runtime.
+`install.sh` runs once inside a fresh Debian bookworm LXC container to install the
+upstream OpenClaw agent runtime from npm.
 
 ## What it does
 
-1. Creates `/opt/openclaw` and a Python venv there.
-2. Pip-installs `fastapi`, `uvicorn`, `httpx`, and `openai` (pinned versions for reproducible arm64 builds).
-3. Writes `/opt/openclaw/server.py` — a FastAPI app that proxies messages to the host LiteLLM proxy.
-4. Installs and starts `openclaw.service` via systemd.
-5. Polls `http://127.0.0.1:8100/health` for up to 20 seconds before declaring success.
+1. Installs Node.js >=22.19 via NodeSource if not already present (full version check,
+   not just major — earlier 22.x releases are too old).
+2. Runs `npm install -g openclaw@latest` to install upstream OpenClaw.
+3. Writes `/root/.openclaw/openclaw.json` (gateway config) and `/root/.openclaw/env`
+   (env file) from env vars injected by the deployer.
+4. Installs a system-level `openclaw.service` systemd unit that runs `openclaw gateway`.
+5. Enables the service (but does NOT start it — the deployer starts it after writing
+   the LiteLLM key to prevent a crash-loop before the key is available).
+6. Installs `trash-cli` and the taOS shadow `rm` wrapper (recycle-bin layer).
 
-## Port and endpoints
+The gateway listens on port 18789 (loopback bind by default as set in openclaw.json).
+taOS drives agent turns via ACP (`openclaw_acp_runtime.py`), not via the gateway WS.
 
-| Endpoint | Method | Purpose |
-|---|---|---|
-| `/health` | GET | Liveness probe — returns `{"status":"ok"}` |
-| `/message` | POST | Chat — body `{"text":"...", "from":"..."}`, returns `{"content":"..."}` |
-
-## Env vars consumed (injected by the deployer)
+## Env vars consumed (injected by the deployer at container creation time)
 
 | Var | Purpose |
 |---|---|
-| `TAOS_AGENT_NAME` | Agent display name |
-| `TAOS_MODEL` | Model ID passed to LiteLLM |
-| `OPENAI_BASE_URL` | LiteLLM `/v1` root on the host |
-| `OPENAI_API_KEY` | Per-agent virtual key from LiteLLM |
+| `TAOS_AGENT_NAME` | Agent slug |
+| `TAOS_MODEL` | Primary model ID (e.g. `kilo-auto/free`) |
+| `TAOS_FALLBACK_MODELS` | Comma-separated fallback model IDs |
+| `LITELLM_API_KEY` | Per-agent LiteLLM virtual key |
+| `OPENAI_API_KEY` | Same as LITELLM_API_KEY; kept for compat |
+| `OPENAI_BASE_URL` | LiteLLM `/v1` root on the host (default `http://127.0.0.1:4000/v1`) |
+| `TAOS_BRIDGE_URL` | taOS API root (default `http://127.0.0.1:6969`) |
+| `TAOS_LOCAL_TOKEN` | Per-container bearer token for taOS API calls |
 
 ## Debugging
 
-SSH into the container and check the service log:
-
 ```bash
-incus exec taos-agent-<name> bash
+incus exec taos-agent-<name> -- bash
 journalctl -u openclaw -f
+openclaw health        # exits non-zero if gateway unreachable
 ```
 
-Re-run the health check manually:
+## Notes
 
-```bash
-curl http://127.0.0.1:8100/health
-```
+- The old Python/FastAPI stub (`/opt/openclaw/server.py`, port 8100) was replaced by
+  this upstream npm install. Do not refer to that stub in new code or docs.
+- `install.sh` is idempotent — safe to re-run on an already-provisioned container.

--- a/docs/design/framework-agnostic-runtime.md
+++ b/docs/design/framework-agnostic-runtime.md
@@ -389,6 +389,51 @@ beyond `incusbr0`.
 
 See `docs/design/lxc-docker-coexistence.md` for the full policy, install-scenario coverage, and operational runbook.
 
+## Synced model management
+
+Each agent has a `permitted_models` set (the subset of LiteLLM virtual-key model scopes
+the agent is allowed to use) and a primary `model`. When taOS updates either, it also
+pushes the change into the framework's native config file inside the container so the
+framework's own model picker reflects the new state immediately.
+
+**Forward push** (`tinyagentos/framework_model_sync.py::push_model_config_to_framework`):
+patches `/root/.openclaw/openclaw.json` (OpenClaw) or `/root/.hermes/config.yaml` (Hermes)
+inside the container via `incus exec`.
+
+**Reverse reconcile** (`FrameworkModelReconciler`, same file): a background task reads each
+framework's live primary-model field every 60 seconds and writes it back to the taOS agent
+record when it changed (user switched the model from the framework's native TUI).
+
+**API surface** (in `tinyagentos/routes/agents.py`):
+- `GET /api/agents/{name}/permitted-models` — list the permitted set
+- `PUT /api/agents/{name}/permitted-models` — replace the set, re-scopes the LiteLLM key
+- `GET /api/agents/me/models` — agent-facing: list models the calling agent may use
+- `POST /api/agents/me/model` — agent-facing: switch the primary model (within permitted set)
+- `POST /api/agents/{name}/model` — admin: switch the primary model for a named agent
+
+The `permitted_models` field is the LiteLLM key's `models` scope. An empty set means the
+agent inherits all models the key was minted for.
+
+## Hermes environment variables
+
+The Hermes bridge installer (`tinyagentos/scripts/install_hermes.sh`) writes
+`/root/.hermes/.env` with the following variables:
+
+| Variable | Value | Notes |
+|---|---|---|
+| `OPENAI_API_KEY` | LiteLLM virtual key | Used by the Hermes gateway for LLM calls |
+| `OPENAI_BASE_URL` | `http://127.0.0.1:4000/v1` | Points at the host LiteLLM proxy |
+| `HERMES_INFERENCE_PROVIDER` | `custom` | Tells Hermes to use the OpenAI-compat endpoint |
+| `HERMES_DEFAULT_MODEL` | agent's primary model | |
+| `API_SERVER_ENABLED` | `true` | Required — enables the Hermes REST API server |
+| `API_SERVER_HOST` | `127.0.0.1` | Loopback only |
+| `API_SERVER_PORT` | `8642` | Port the taOS-Hermes bridge connects to |
+| `API_SERVER_KEY` | LiteLLM virtual key | **Required** — Hermes refuses to start its api_server without this; reuses the LiteLLM key |
+
+`API_SERVER_KEY` is required by recent `hermes-agent` versions even for a loopback-only
+bind; omitting it causes the api_server to refuse connections and the taOS-Hermes bridge
+to log "All connection attempts failed".
+
 ## Related code
 
 - `tinyagentos/trace_store.py` — `AgentTraceStore` + `TraceStoreRegistry`
@@ -399,3 +444,9 @@ See `docs/design/lxc-docker-coexistence.md` for the full policy, install-scenari
 - `tinyagentos/containers/__init__.py` — `set_env`, `snapshot_create`,
   `snapshot_restore`, `snapshot_list`; `add_proxy_device` attaches incus
   proxy devices so the container reaches host services via 127.0.0.1
+- `tinyagentos/framework_model_sync.py` — `push_model_config_to_framework`,
+  `read_framework_primary`, `FrameworkModelReconciler`
+- `tinyagentos/routes/librarian.py` — `GET/PATCH /api/agents/{slug}/librarian`;
+  per-agent fields: `enabled`, `tasks`, `fanout`, `fanout_auto_scale`, `model`
+  (per-agent model override; a system-wide default is tracked separately in taosmd,
+  not yet exposed as a `/api/memory/model` endpoint on this branch)

--- a/docs/design/openclaw-integration.md
+++ b/docs/design/openclaw-integration.md
@@ -1,16 +1,41 @@
 # OpenClaw Integration Reference
 
-**Status:** Research complete — primary sources fetched 2026-04-16. Code-level implementation not started.
-**Last updated:** 2026-04-16
-**Supersedes:** `app-catalog/agents/openclaw/scripts/install.sh` stub (Python FastAPI, will be discarded)
+**Status:** Protocol/install/config research (§1–§5) is current reference material.
+§6 mapping table and §7 roadmap describe the **historical fork-bridge design** — the live
+implementation uses upstream npm + ACP instead. See the implementation summary before reading §6–§7.
+**Last updated:** 2026-04-16 (research); 2026-06-04 (implementation summary added)
+
+---
+
+## Implementation summary (as-built, 2026-06-04)
+
+The fork/bridge design documented in §6–§7 was superseded before it shipped. The live
+implementation is:
+
+- **Install:** `npm install -g openclaw@latest` (upstream npm, no fork). See
+  `app-catalog/agents/openclaw/scripts/install.sh`.
+- **Runtime:** taOS drives each agent turn **in** via ACP — it runs
+  `openclaw acp --session agent:main:main` inside the container using `incus exec` and
+  streams replies back. See `tinyagentos/openclaw_acp_runtime.py`.
+- **No fork.** `jaylfc/openclaw` is archived. `src/taos-bridge.ts` was never shipped.
+  Do not install `github:jaylfc/openclaw#<sha>` — it no longer exists.
+- **Bridge SSE endpoints survive** (`GET /api/openclaw/sessions/{agent}/events`,
+  `POST /api/openclaw/sessions/{agent}/reply`, `GET /api/openclaw/bootstrap`) — they
+  live in `tinyagentos/routes/openclaw.py` and are reused by the Hermes bridge adapter
+  (`tinyagentos/scripts/install_hermes.sh`). They are not dead code.
+- The gateway port 18789 is reserved for operator tooling (config reload, log tailing)
+  and is not used by taOS for normal chat turns.
+
+§6 and §7 are retained as historical design reference only. Do not implement them.
 
 ---
 
 ## What this doc is for
 
-This is the team's primary reference for wiring real OpenClaw into taOS. It covers the gateway protocol in detail, installation and runtime behaviour on Linux/arm64, the full configuration schema, the extension model, known limitations, a capability-mapping table, and a step-by-step MVP-to-full roadmap.
-
-It is **not** a product spec or a work-tracking document. It does not contain code changes. It does not represent the current state of the codebase — it represents what the integration should look like once built, grounded in primary sources from the OpenClaw repo and docs site (fetched April 2026).
+This is the team's primary reference for the OpenClaw gateway protocol, installation and
+runtime behaviour on Linux/arm64, the full configuration schema, the extension model, and
+known limitations. §6–§7 document the original fork-bridge design and are kept for
+historical context; they do not describe the live implementation.
 
 ---
 
@@ -599,17 +624,19 @@ Version 24 is recommended. The README quick start references `Node 22.16+` as mi
 
 The package manager is `pnpm@10.32.1` — only needed for source builds. Global npm installs work with npm, pnpm, or bun.
 
-> **taOS deployer note:** Debian bookworm's default `nodejs` apt package ships version 18, which does not satisfy openclaw's `>=22.14.0` engine requirement. The deployer must install Node 22.14+ (or 24) via NodeSource or nvm _before_ running `npm install -g openclaw`. See Step 1a in §7 for the exact NodeSource install snippet.
+> **taOS deployer note:** Debian bookworm's default `nodejs` apt package ships version 18, which does not satisfy openclaw's engine requirement. The deployer must install Node 22.19+ (or 24) via NodeSource before running `npm install -g openclaw`. The install script (`app-catalog/agents/openclaw/scripts/install.sh`) enforces `>=22.19` (not just `>=22.14.0`) because earlier 22.x releases have known issues with openclaw's dependency tree; it uses NodeSource `setup_22.x` and validates the minor version explicitly.
 
 ### 2.3 Install methods
 
-**Global npm install (taOS's path):**
+**Global npm install (taOS's path, as-built):**
 ```bash
 npm install -g openclaw@latest
-openclaw onboard --install-daemon
+# taOS does NOT call `openclaw onboard --install-daemon` — see §2.7.
+# install.sh writes openclaw.json + env directly and installs its own
+# system-level openclaw.service unit.
 ```
 
-**`openclaw onboard --install-daemon`** does the following:
+**`openclaw onboard --install-daemon`** does the following (for reference; taOS bypasses this):
 - Creates `~/.openclaw/` directory and initial `openclaw.json` config
 - On Linux/WSL2: installs a **systemd user service** (`openclaw.service` under `~/.config/systemd/user/`)
 - On macOS: installs a **LaunchAgent** (`~/Library/LaunchAgents/ai.openclaw.gateway.plist`)
@@ -1092,15 +1119,23 @@ Control-plane write RPCs are rate-limited to **3 requests per 60 seconds**. For 
 
 The `message` field in `ChatEventSchema` is typed as `Type.Optional(Type.Unknown())`. The exact runtime shape (string for text, structured object for tool results) is not schema-enforced. The taOS relay must handle both cases defensively.
 
-### 5.9 Node 22.14 vs 22.16 discrepancy
+### 5.9 Node 22.14 vs 22.16 vs 22.19 discrepancy
 
-`package.json` engine: `>=22.14.0`. README: `Node 22.16+`. taOS should pin Node 24 to avoid the ambiguity.
+`package.json` engine: `>=22.14.0`. README: `Node 22.16+`. taOS's install script enforces
+`>=22.19` (full-version check, not just major) because earlier 22.x point releases fail at
+runtime even though they satisfy a major-only guard. Pin Node 24 to avoid all ambiguity.
 
 ---
 
-## 6. taOS integration mapping
+## 6. taOS integration mapping (HISTORICAL — superseded)
 
-The MVP integration path is the **bridge adapter** — openclaw's fork patch fetches a bootstrap document from a taOS-hosted endpoint and configures openclaw's native clients from it. The operator-client (raw WS from taOS) approach was considered first; it is kept here as a documented fallback only, because it couples taOS to openclaw's v3 gateway protocol version, meaning every openclaw protocol bump can break the fleet. The bridge isolates that coupling to a single ~200 LoC patch inside the fork.
+> **Note:** This mapping table describes the fork-bridge design that was never shipped.
+> The live implementation uses upstream npm + ACP (see implementation summary at the top of
+> this doc). This section is retained for historical context only.
+
+The planned MVP integration path was the **bridge adapter** — openclaw's fork patch fetching
+a bootstrap document from a taOS-hosted endpoint and configuring openclaw's native clients
+from it. That design was abandoned in favour of upstream npm + ACP before implementation.
 
 | OpenClaw capability | taOS maps it to | Mechanism | Priority |
 |---|---|---|---|
@@ -1135,13 +1170,18 @@ The MVP integration path is the **bridge adapter** — openclaw's fork patch fet
 
 ---
 
-## 7. MVP-to-full roadmap
+## 7. MVP-to-full roadmap (HISTORICAL — superseded)
+
+> **Note:** This roadmap was written for the fork-bridge design. It was not executed.
+> The live integration is upstream npm + ACP (see implementation summary). Steps below
+> are retained for historical record only.
 
 ### Step 1: MVP — replace the stub with real openclaw (bridge adapter)
 
-**Goal:** A real openclaw gateway running inside an LXC container, wired to taOS via the bridge adapter, using LiteLLM as the LLM backend, with streaming text responses flowing into the taOS Messages UI.
+**[NOT IMPLEMENTED — replaced by ACP approach]**
 
-**Integration approach:** bridge adapter (`src/taos-bridge.ts` fork patch). The operator-client WS approach is the documented fallback — see §6.
+**Original goal:** A real openclaw gateway wired to taOS via the bridge adapter and fork patch.
+**Actual implementation:** upstream `npm install -g openclaw@latest` + `openclaw_acp_runtime.py`.
 
 **Review-gate refinements baked into this step:**
 
@@ -1161,72 +1201,16 @@ Fork already exists at `github.com/jaylfc/openclaw`. Pick a current baseline SHA
 
 New `install.sh` flow:
 
-```bash
-# 1. Install Node 22.14+ via NodeSource (Debian bookworm default is Node 18, too old)
-curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
-apt-get install -y nodejs
+**[NOT IMPLEMENTED — see implementation summary]**
 
-# 2. Install our forked openclaw at a pinned SHA — never @latest
-npm install -g github:jaylfc/openclaw#<sha>
+The install script that shipped (`app-catalog/agents/openclaw/scripts/install.sh`) installs
+upstream `openclaw@latest` from npm (not a fork), writes `openclaw.json` and env from
+injected env vars, and runs `openclaw gateway` (not `openclaw acp`) as the systemd unit.
+The gateway stays running as before; taOS drives turns via ACP, not via the WS gateway.
 
-# 3. Optional: pre-cached tarball fallback for airgapped rebuild
-#    If /opt/tinyagentos/vendor/openclaw-<sha>.tgz exists, use it instead of github
-
-# 4. Verify installation
-openclaw --version
-
-# 5. Create config directory (will be populated by deployer-generated config via bind mount)
-mkdir -p /root/.openclaw
-chmod 700 /root/.openclaw
-
-# 6. Write systemd unit for openclaw gateway
-cat > /etc/systemd/system/openclaw.service << 'EOF'
-[Unit]
-Description=OpenClaw Gateway
-After=network-online.target
-Wants=network-online.target
-
-[Service]
-Type=simple
-EnvironmentFile=-/root/.openclaw/env
-ExecStart=/usr/local/bin/openclaw gateway --port 18789
-Restart=on-failure
-RestartSec=5
-User=root
-WorkingDirectory=/root
-StandardOutput=journal
-StandardError=journal
-
-[Install]
-WantedBy=multi-user.target
-EOF
-
-systemctl daemon-reload
-systemctl enable openclaw.service
-
-# 7. Wait for gateway to start; openclaw health exits non-zero if unreachable
-for i in $(seq 1 15); do
-    if openclaw health --timeout 2000 > /dev/null 2>&1; then
-        echo "openclaw: gateway ready"
-        exit 0
-    fi
-    sleep 2
-done
-echo "openclaw: gateway failed to start" >&2
-exit 1
-```
-<!-- source: github.com/openclaw/openclaw/blob/main/docs/cli/health.md -->
-
-Remove the Python stub (`server.py`, venv creation, FastAPI install).
-
-**Pi/ARM note:** on low-RAM ARM hosts (Orange Pi 5 Plus has 16 GB so this is not critical, but relevant for smaller SBCs), the upstream Pi deployment guide recommends adding a 2 GB swapfile and setting `vm.swappiness=10`, plus `NODE_COMPILE_CACHE=/var/tmp/openclaw-compile-cache` and `OPENCLAW_NO_RESPAWN=1` for repeated CLI invocations. Also, `gpu_mem=16` in `/boot/config.txt` frees RAM on headless setups.
+**Pi/ARM note:** on low-RAM ARM hosts the upstream Pi deployment guide recommends adding a
+2 GB swapfile and setting `vm.swappiness=10`, plus `NODE_COMPILE_CACHE=/var/tmp/openclaw-compile-cache`.
 <!-- source: github.com/openclaw/openclaw/blob/main/docs/install/raspberry-pi.md -->
-
-Update `app-catalog/agents/openclaw/manifest.yaml`:
-- `disk_mb`: 500 → 2000 (real openclaw is 1-2 GB on disk)
-- `requires.ram_mb`: increase to 1024 (Node.js + npm modules heavier than Python venv)
-
-**Test:** `ss -tlnp | grep 18789` succeeds inside container.
 
 #### 1b. Generate `openclaw.json` at deploy time
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -75,7 +75,7 @@ At the end, it prints your device's IP address:
 
 Open that URL in your browser. You're done with installation.
 
-**If your network supports mDNS** (most home networks do), you can also use `http://tinyagentos.local:6969` from any device on the same network — no need to look up the IP.
+**If your network supports mDNS** (most home networks do), you can also use `http://taos.local:6969` from any device on the same network — no need to look up the IP.
 
 ---
 

--- a/docs/runbooks/framework-swap.md
+++ b/docs/runbooks/framework-swap.md
@@ -9,63 +9,78 @@ This runbook is the operational face of the
 If this runbook stops working, the rule has been violated somewhere and the
 violation is a bug.
 
+> **Snapshot model (Phase 2.A):** workspace, memory, and home all live **inside the
+> container rootfs** — not in host-side bind mounts. A framework swap therefore works
+> differently from the old bind-mount model: you must export the agent's state from the
+> old container before destroying it, then import it into the new one. The trace directory
+> (`{data_dir}/trace/{name}/`) remains on the host as the sole bind mount and is
+> unaffected by a swap.
+
 ## Pre-flight
 
-Before swapping, confirm the following — they should be true of every agent
-produced by `taos agent deploy`, but a one-second check costs nothing:
+Before swapping, confirm the following:
 
-1. `data/agent-workspaces/{name}/` exists on the host and contains the
-   agent's files.
-2. `data/agent-memory/{name}/` exists on the host. This is what the
-   container sees at `/memory`.
-3. The target framework is present in the catalog
+1. The agent's container is healthy: `incus info taos-agent-{name}` (LXC) or
+   `docker inspect taos-agent-{name}` (Docker) shows it running.
+2. The target framework is present in the catalog
    (`GET /api/catalog/apps?type=agent-framework`) or is a raw pip-installable
    package name.
+3. You have enough disk for two containers to exist briefly in parallel (the old
+   container is kept until the swap is verified).
 
 ## Procedure
 
 ```bash
-# 1. Stop the running container. State on disk is untouched.
+# 1. Stop the running container. State inside the container is untouched.
 taos agent stop my-research-agent
 
-# 2. Destroy the container. Only the container is destroyed — the mounted
-#    /workspace and /memory directories survive because they live on the
-#    host, not inside the container image.
+# 2. Export agent state from the container (workspace + memory + any other files
+#    the agent produced). Adjust paths as needed for your framework.
+incus exec taos-agent-my-research-agent -- tar czf /tmp/agent-state.tar.gz \
+    /workspace /memory /root/.openclaw 2>/dev/null || true
+incus file pull taos-agent-my-research-agent/tmp/agent-state.tar.gz \
+    /tmp/my-research-agent-state.tar.gz
+
+# 3. Undeploy the old container. This destroys it.
 taos agent undeploy my-research-agent
 
-# 3. Redeploy with the new framework. The deployer bind-mounts the existing
-#    workspace and memory directories into the new container, so the agent
-#    wakes up with every previous memory intact.
+# 4. Redeploy with the new framework. The deployer creates a fresh container.
 taos agent deploy \
     --name my-research-agent \
     --framework autogen \
-    --model qwen3-4b-q4 \
-    --memory-limit 2GB
+    --model qwen3-4b-q4
 
-# 4. Verify the agent retains its state.
-taos agent exec my-research-agent -- ls /workspace
-taos agent exec my-research-agent -- ls /memory
+# 5. Restore agent state into the new container.
+incus file push /tmp/my-research-agent-state.tar.gz \
+    taos-agent-my-research-agent/tmp/agent-state.tar.gz
+incus exec taos-agent-my-research-agent -- tar xzf /tmp/agent-state.tar.gz \
+    -C / --strip-components=0 2>/dev/null || true
+
+# 6. Start the agent and verify state.
+taos agent start my-research-agent
+incus exec taos-agent-my-research-agent -- ls /workspace
+incus exec taos-agent-my-research-agent -- ls /memory
 ```
 
-The deploy in step 3 is identical to a first-time deploy. The deployer
-doesn't know (or care) that this name previously existed — it creates the
-host-side directories if missing (idempotent) and mounts them into the new
-container. That's what makes this operation free.
+The state directories (`/workspace`, `/memory`) are framework-agnostic. Framework-specific
+config (e.g. `/root/.openclaw/`) is framework-specific and normally should be regenerated
+by the new deploy, not restored from the old container.
 
 ## What carries over
 
-| Thing | Carries? | Why |
+| Thing | Carries? | How |
 |---|---|---|
-| Workspace files | **Yes** | Lives in `data/agent-workspaces/{name}/`, mounted |
-| Vector store / embeddings | **Yes** | Lives in `data/agent-memory/{name}/`, mounted |
-| User memory grants | **Yes** | Lives in `data/user_memory.db` on host, agent reaches it via `TAOS_USER_MEMORY_URL` |
-| Secret grants | **Yes** | Lives in `data/secrets.db` on host, agent fetches via API |
-| Skill assignments | **Yes** | Lives in `data/skills.db` on host, agent reaches them via `TAOS_SKILLS_URL` |
-| Chat / conversation history | **Yes** | Lives in `data/chat.db` on host |
-| Agent-to-agent messages | **Yes** | Lives in `data/agent_messages.db` on host |
+| Workspace files | **Yes** | Tar export/import (step 2/5) |
+| Vector store / embeddings | **Yes** | Tar export/import |
+| Trace history | **Yes** | Lives in `{data_dir}/trace/{name}/` on host — unaffected by swap |
+| User memory grants | **Yes** | Lives in host DB, accessed via `TAOS_USER_MEMORY_URL` |
+| Secret grants | **Yes** | Lives in host DB, fetched via API |
+| Chat / conversation history | **Yes** | Lives in host `data/chat.db` |
+| Agent-to-agent messages | **Yes** | Lives in host `data/agent_messages.db` |
 | LLM proxy API key | **No** | Rotated on deploy — new key minted, old key revoked |
+| Framework-specific runtime config | **No** | Regenerated by `install.sh` for the new framework |
 | In-flight pip install cache | **No** | Container-local, expected to vanish |
-| Framework-specific ephemeral state | **No** | That's the point — the new framework is a clean slate |
+| Framework-specific ephemeral state | **No** | That's the point — new framework starts clean |
 
 ## What does NOT carry over, and why that's usually fine
 
@@ -81,14 +96,12 @@ container. That's what makes this operation free.
 
 ## Troubleshooting
 
-**"Agent starts with empty memory"**: the mount didn't land. Check
-`incus config device show taos-agent-{name}` (LXC) or `docker inspect
-taos-agent-{name}` (Docker) for the `/workspace` and `/memory` mounts. If
-they're missing, the deployer wasn't given `data_dir` — this is a bug,
-file an issue.
+**"Agent starts with empty memory"**: the tar restore didn't run, or the paths differ
+between frameworks. Check `incus exec taos-agent-{name} -- ls /memory` and `/workspace`.
+If empty, re-run steps 5-6.
 
 **"Agent can't reach the LLM proxy"**: the `OPENAI_BASE_URL` env var
-wasn't injected. Check with `taos agent exec {name} -- env | grep OPENAI`.
+wasn't injected. Check with `incus exec taos-agent-{name} -- env | grep OPENAI`.
 If empty, the host-side LiteLLM proxy was likely down during deploy.
 Restart the service and redeploy.
 
@@ -103,6 +116,5 @@ just restart the agent, since `TAOS_EMBEDDING_URL` is the same).
 
 An automated test of this runbook lives at
 `tests/test_framework_swap.py`. It deploys an agent with framework A,
-writes a file into `/workspace`, destroys the container, redeploys with
-framework B, and asserts the file is still there. If that test breaks,
-this runbook is lying.
+writes a file into `/workspace`, performs a framework swap, and asserts the
+file is still present after redeploy. If that test breaks, this runbook is lying.

--- a/docs/runbooks/framework-swap.md
+++ b/docs/runbooks/framework-swap.md
@@ -112,9 +112,9 @@ and [model-torrent-mesh.md](../design/model-torrent-mesh.md) — add an
 embedding model to the catalog and LiteLLM config, then redeploy (or
 just restart the agent, since `TAOS_EMBEDDING_URL` is the same).
 
-## Test
+## Verifying a swap preserves state
 
-An automated test of this runbook lives at
-`tests/test_framework_swap.py`. It deploys an agent with framework A,
-writes a file into `/workspace`, performs a framework swap, and asserts the
-file is still present after redeploy. If that test breaks, this runbook is lying.
+There is no automated test for this runbook yet. To verify a swap by hand:
+deploy an agent on framework A, write a file into its `/workspace`, perform the
+swap, and confirm the file is still present after redeploy. If the workspace or
+memory is empty afterwards, the state export/import step was missed.


### PR DESCRIPTION
## Summary

- **openclaw-integration.md**: Added implementation summary at top marking the fork/bridge design (§6–§7) as historical. The live integration is upstream npm + ACP (`openclaw_acp_runtime.py`), not `jaylfc/openclaw` fork + `taos-bridge.ts`. Clarified that the bridge SSE endpoints survive for Hermes. Fixed Node version note (22.19 minimum, not 22.14). Marked §7 Step 1a install snippet as superseded.
- **framework-agnostic-runtime.md**: Added two new sections — "Synced model management" (documents `permitted_models`, `GET/PUT /api/agents/{name}/permitted-models`, `GET/POST /api/agents/me/models|model`, and `FrameworkModelReconciler` in `framework_model_sync.py`) and "Hermes environment variables" (documents the full `.env` set written by `install_hermes.sh`, including the required `API_SERVER_KEY`). Extended Related code list.
- **framework-swap.md**: Rewrote the procedure for the Phase 2.A snapshot model — workspace/memory now live inside the container, not host bind mounts. Old procedure was for the pre-pivot bind-mount model and would silently fail on current deployments.
- **getting-started.md**: Fixed mDNS hostname `tinyagentos.local` → `taos.local` (matches `tinyagentos/services/mdns_publisher.py`).
- **app-catalog/agents/openclaw/scripts/README.md**: Replaced description of old Python/FastAPI stub (port 8100, `server.py`, pip-installed FastAPI) with accurate description of the npm-based upstream install.

## FLAGGED — claims I suspect are stale but could not fully verify

1. **`docs/runbooks/framework-swap.md` test reference**: The runbook references `tests/test_framework_swap.py` — I did not verify this test exists or still passes against the snapshot model. May need updating or creation.
2. **Librarian `model` field direction**: `tinyagentos/routes/librarian.py` and `taosmd.agents.set_librarian()` both still accept a per-agent `model` field on this branch. The task description says "memory model is SYSTEM-WIDE, not per-agent" — the system-wide `/api/memory/model` endpoint is NOT present on `dev`; it may be on a separate unmerged branch. I documented the current state accurately and added a note in the Related code list, rather than documenting a non-existent API.
3. **`docs/design/user-memory.md`**: References a QMD-based architecture (per-user `port 7833`, per-agent `port 7832`) that may be superseded by taosmd. No code contradiction found on this branch so left untouched — flagged for a future pass.
4. **`docs/runbooks/framework-swap.md` `taos agent` CLI**: The procedure now uses `incus exec` directly because I could not confirm `taos agent stop/undeploy/deploy` CLI commands exist. If that CLI is live, the procedure could be simplified.
5. **Node 22.14 vs 22.19 in upstream openclaw**: The `package.json` claim of `>=22.14.0` was not re-fetched from upstream; only the taOS `install.sh` check was verified. The upstream minimum may have changed since April 2026.