### PR TITLE
fix(shell): validate taos:activate-window event shape (#585 nit)

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -159,12 +159,17 @@ export function App() {
   // id; on desktop the window manager already renders it, so this just focuses.
   useEffect(() => {
     const handler = (e: Event) => {
-      const wid = (e as CustomEvent<{ windowId?: string }>).detail?.windowId;
+      // Validate the event's detail shape at runtime rather than trusting a cast.
+      const detail = (e as CustomEvent<unknown>).detail;
+      const wid =
+        detail && typeof (detail as { windowId?: unknown }).windowId === "string"
+          ? (detail as { windowId: string }).windowId
+          : null;
       if (wid) setActiveWindowId(wid);
     };
     window.addEventListener("taos:activate-window", handler);
     return () => window.removeEventListener("taos:activate-window", handler);
-  }, []);
+  }, [setActiveWindowId]);
 
   useSessionPersistence();
 


### PR DESCRIPTION
Tidy for the kilo review nits on #585. Replaces the blind `CustomEvent<{windowId?}>` cast in the `taos:activate-window` handler with a runtime check that `detail.windowId` is a string, and adds the (stable) `setActiveWindowId` to the effect deps. No behaviour change — the original cast was already guarded by optional chaining + an `if`. Build clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of window-activation functionality by adding runtime validation for event data to ensure stable window management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->