### PR TITLE
feat(adapters): opencode HTTP/SSE adapter (#588 phase 1)

### DIFF
--- a/tests/test_opencode_adapter.py
+++ b/tests/test_opencode_adapter.py
@@ -1,0 +1,546 @@
+"""Tests for the opencode adapter.
+
+Unit-tests cover:
+  - map_opencode_event: pure codec with captured live event shapes
+  - OpenCodeAdapter.prompt(): integration with monkeypatched httpx
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tinyagentos.adapters.opencode_adapter import (
+    OpenCodeAdapter,
+    OpenCodeConfig,
+    map_opencode_event,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _fresh_state(session_id: str = "ses_abc123") -> dict:
+    return {"session_id": session_id, "text": "", "done": False, "switched_model": None}
+
+
+# ---------------------------------------------------------------------------
+# map_opencode_event — unit tests
+# ---------------------------------------------------------------------------
+
+class TestMapOpencodeEvent:
+    """Pure codec tests using event shapes captured live on the Pi."""
+
+    # ---------------------------------------------------------------- ignored
+    def test_server_connected_ignored(self):
+        evt = {"type": "server.connected", "properties": {}}
+        assert map_opencode_event(evt, _fresh_state()) == []
+
+    def test_session_created_ignored(self):
+        evt = {"type": "session.created", "properties": {"sessionID": "ses_abc123"}}
+        assert map_opencode_event(evt, _fresh_state()) == []
+
+    def test_message_updated_ignored(self):
+        evt = {"type": "message.updated", "properties": {"sessionID": "ses_abc123", "info": {}}}
+        assert map_opencode_event(evt, _fresh_state()) == []
+
+    def test_unknown_type_returns_empty(self):
+        evt = {"type": "whatever.new", "properties": {}}
+        assert map_opencode_event(evt, _fresh_state()) == []
+
+    # ---------------------------------------------------------------- text delta
+    def test_text_delta_emits_delta_and_accumulates(self):
+        state = _fresh_state()
+        evt = {
+            "type": "message.part.delta",
+            "properties": {
+                "sessionID": "ses_abc123",
+                "messageID": "msg_001",
+                "partID": "p0",
+                "field": "text",
+                "delta": "Hello",
+            },
+        }
+        result = map_opencode_event(evt, state)
+        assert result == [("delta", {"content": "Hello"})]
+        assert state["text"] == "Hello"
+
+    def test_text_delta_accumulates_across_calls(self):
+        state = _fresh_state()
+        for chunk in ["foo", " ", "bar"]:
+            evt = {
+                "type": "message.part.delta",
+                "properties": {
+                    "sessionID": "ses_abc123",
+                    "field": "text",
+                    "delta": chunk,
+                },
+            }
+            map_opencode_event(evt, state)
+        assert state["text"] == "foo bar"
+
+    def test_text_delta_ignored_for_other_session(self):
+        state = _fresh_state("ses_mine")
+        evt = {
+            "type": "message.part.delta",
+            "properties": {
+                "sessionID": "ses_other",
+                "field": "text",
+                "delta": "noise",
+            },
+        }
+        result = map_opencode_event(evt, state)
+        assert result == []
+        assert state["text"] == ""
+
+    # ---------------------------------------------------------------- reasoning delta
+    def test_reasoning_delta_emits_reasoning(self):
+        state = _fresh_state()
+        evt = {
+            "type": "message.part.delta",
+            "properties": {
+                "sessionID": "ses_abc123",
+                "field": "reasoning",
+                "delta": "Let me think...",
+            },
+        }
+        result = map_opencode_event(evt, state)
+        assert result == [("reasoning", {"content": "Let me think..."})]
+        # reasoning does NOT accumulate into text
+        assert state["text"] == ""
+
+    def test_unknown_field_in_delta_ignored(self):
+        state = _fresh_state()
+        evt = {
+            "type": "message.part.delta",
+            "properties": {
+                "sessionID": "ses_abc123",
+                "field": "image",
+                "delta": "data:...",
+            },
+        }
+        assert map_opencode_event(evt, state) == []
+
+    # ---------------------------------------------------------------- tool parts
+    def test_tool_part_updated_started_emits_tool_call(self):
+        state = _fresh_state()
+        evt = {
+            "type": "message.part.updated",
+            "properties": {
+                "part": {
+                    "type": "tool",
+                    "callID": "call_xyz",
+                    "tool": "bash",
+                    "input": {"cmd": "ls -la"},
+                    "state": {"status": "started"},
+                },
+            },
+        }
+        result = map_opencode_event(evt, state)
+        assert len(result) == 1
+        kind, payload = result[0]
+        assert kind == "tool_call"
+        assert payload["tool"] == "bash"
+        assert payload["args"] == {"cmd": "ls -la"}
+        assert payload["call_id"] == "call_xyz"
+
+    def test_tool_part_updated_success_emits_tool_result(self):
+        state = _fresh_state()
+        evt = {
+            "type": "message.part.updated",
+            "properties": {
+                "part": {
+                    "type": "tool",
+                    "callID": "call_xyz",
+                    "tool": "bash",
+                    "input": {"cmd": "ls -la"},
+                    "state": {"status": "completed", "output": "file.txt\ndir/"},
+                },
+            },
+        }
+        result = map_opencode_event(evt, state)
+        assert len(result) == 1
+        kind, payload = result[0]
+        assert kind == "tool_result"
+        assert payload["success"] is True
+        assert "file.txt" in payload["result"]
+        assert payload["call_id"] == "call_xyz"
+
+    def test_tool_part_updated_error_emits_tool_result_failure(self):
+        state = _fresh_state()
+        evt = {
+            "type": "message.part.updated",
+            "properties": {
+                "part": {
+                    "type": "tool",
+                    "callID": "call_xyz",
+                    "tool": "bash",
+                    "input": {},
+                    "state": {"status": "error", "error": "command not found"},
+                },
+            },
+        }
+        result = map_opencode_event(evt, state)
+        assert len(result) == 1
+        kind, payload = result[0]
+        assert kind == "tool_result"
+        assert payload["success"] is False
+        assert "command not found" in payload["result"]
+
+    def test_non_tool_part_updated_ignored(self):
+        state = _fresh_state()
+        evt = {
+            "type": "message.part.updated",
+            "properties": {
+                "part": {"type": "text", "content": "..."},
+            },
+        }
+        assert map_opencode_event(evt, state) == []
+
+    def test_tool_part_unknown_status_returns_empty(self):
+        """Unknown tool part status → no emit (wait for next update)."""
+        state = _fresh_state()
+        evt = {
+            "type": "message.part.updated",
+            "properties": {
+                "part": {
+                    "type": "tool",
+                    "callID": "c1",
+                    "tool": "search",
+                    "input": {},
+                    "state": {"status": "pending"},
+                },
+            },
+        }
+        assert map_opencode_event(evt, state) == []
+
+    # ---------------------------------------------------------------- model switched
+    def test_model_switched_sets_state_no_reply(self):
+        state = _fresh_state()
+        evt = {
+            "type": "session.next.model.switched",
+            "properties": {
+                "sessionID": "ses_abc123",
+                "model": {"providerID": "litellm", "modelID": "gpt-4o"},
+            },
+        }
+        result = map_opencode_event(evt, state)
+        assert result == []
+        assert state["switched_model"] == {"providerID": "litellm", "modelID": "gpt-4o"}
+
+    # ---------------------------------------------------------------- session.idle
+    def test_session_idle_our_session_emits_final(self):
+        state = _fresh_state("ses_mine")
+        state["text"] = "Accumulated text"
+        evt = {
+            "type": "session.idle",
+            "properties": {"sessionID": "ses_mine"},
+        }
+        result = map_opencode_event(evt, state)
+        assert len(result) == 1
+        kind, payload = result[0]
+        assert kind == "final"
+        assert payload["content"] == "Accumulated text"
+        assert state["done"] is True
+
+    def test_session_idle_other_session_ignored(self):
+        state = _fresh_state("ses_mine")
+        state["text"] = "Should not flush"
+        evt = {
+            "type": "session.idle",
+            "properties": {"sessionID": "ses_other"},
+        }
+        result = map_opencode_event(evt, state)
+        assert result == []
+        assert state["done"] is False
+
+    def test_session_idle_empty_text_emits_empty_final(self):
+        state = _fresh_state("ses_1")
+        evt = {
+            "type": "session.idle",
+            "properties": {"sessionID": "ses_1"},
+        }
+        result = map_opencode_event(evt, state)
+        assert result == [("final", {"content": ""})]
+        assert state["done"] is True
+
+    # ---------------------------------------------------------------- defensive
+    def test_missing_properties_key_is_safe(self):
+        """Events without 'properties' must not raise; sessionID filter silently excludes them."""
+        evt = {"type": "session.idle"}
+        state = _fresh_state()
+        # properties absent → no sessionID to match → excluded, no emit
+        result = map_opencode_event(evt, state)
+        assert isinstance(result, list)
+        # state must not be corrupted
+        assert state["done"] is False
+
+    def test_none_properties_is_safe(self):
+        evt = {"type": "server.connected", "properties": None}
+        assert map_opencode_event(evt, _fresh_state()) == []
+
+
+# ---------------------------------------------------------------------------
+# OpenCodeAdapter.prompt() — integration test with monkeypatched httpx
+# ---------------------------------------------------------------------------
+
+def _build_sse_bytes(*events: dict) -> bytes:
+    """Encode a sequence of dicts as SSE ``data:`` lines."""
+    lines = []
+    for evt in events:
+        lines.append(f"data: {json.dumps(evt)}\n\n")
+    return "".join(lines).encode()
+
+
+class _FakeStreamResponse:
+    """Minimal async context manager that yields SSE lines."""
+
+    def __init__(self, body: bytes) -> None:
+        self._body = body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        pass
+
+    async def aiter_lines(self):
+        for line in self._body.decode().splitlines():
+            yield line
+
+
+class TestOpenCodeAdapterPrompt:
+    """Integration test: monkeypatch httpx, assert the sink receives the
+    reply-dict sequence ({"kind", "trace_id", ...})."""
+
+    def _make_adapter(self, sink) -> OpenCodeAdapter:
+        cfg = OpenCodeConfig(
+            base_url="http://127.0.0.1:5888",
+            model_provider_id="litellm",
+            model_id="gpt-4o",
+            agent="test-agent",
+        )
+        return OpenCodeAdapter(cfg, sink)
+
+    def _sse_body(self) -> bytes:
+        events = [
+            {"type": "server.connected", "properties": {}},
+            {
+                "type": "message.part.delta",
+                "properties": {
+                    "sessionID": "ses_test",
+                    "field": "text",
+                    "delta": "Hello",
+                },
+            },
+            {
+                "type": "message.part.delta",
+                "properties": {
+                    "sessionID": "ses_test",
+                    "field": "text",
+                    "delta": " world",
+                },
+            },
+            {
+                "type": "session.idle",
+                "properties": {"sessionID": "ses_test"},
+            },
+        ]
+        return _build_sse_bytes(*events)
+
+    @pytest.mark.asyncio
+    async def test_prompt_calls_record_reply_in_order(self, monkeypatch):
+        # Track sink reply dicts
+        calls: list[dict] = []
+
+        def sink(reply: dict):
+            calls.append(reply)
+
+        adapter = self._make_adapter(sink)
+        sse_body = self._sse_body()
+
+        # Fake POST /session → returns session id
+        session_resp = MagicMock()
+        session_resp.status_code = 200
+        session_resp.raise_for_status = MagicMock()
+        session_resp.json = MagicMock(return_value={"id": "ses_test"})
+
+        # Fake POST /session/:id/prompt_async → returns 204
+        prompt_resp = MagicMock()
+        prompt_resp.status_code = 204
+
+        # Fake GET /event stream
+        stream_ctx = _FakeStreamResponse(sse_body)
+
+        async def fake_post(url, **kwargs):
+            if "/session" in url and "prompt_async" not in url:
+                return session_resp
+            return prompt_resp
+
+        fake_client = MagicMock()
+        fake_client.is_closed = False
+        fake_client.post = AsyncMock(side_effect=fake_post)
+        fake_client.stream = MagicMock(return_value=stream_ctx)
+        fake_client.aclose = AsyncMock()
+
+        async def fake_get_client():
+            return fake_client
+
+        monkeypatch.setattr(adapter, "_get_client", fake_get_client)
+
+        await adapter.prompt("Say hello")
+
+        # Should have: delta("Hello"), delta(" world"), final("Hello world")
+        assert len(calls) == 3
+
+        assert calls[0]["kind"] == "delta"
+        assert calls[0]["content"] == "Hello"
+
+        assert calls[1]["kind"] == "delta"
+        assert calls[1]["content"] == " world"
+
+        assert calls[2]["kind"] == "final"
+        assert calls[2]["content"] == "Hello world"
+
+    @pytest.mark.asyncio
+    async def test_prompt_with_trace_id_forwarded(self, monkeypatch):
+        calls: list[dict] = []
+
+        def sink(reply: dict):
+            calls.append(reply)
+
+        adapter = self._make_adapter(sink)
+
+        sse_body = _build_sse_bytes(
+            {"type": "session.idle", "properties": {"sessionID": "ses_t2"}},
+        )
+        stream_ctx = _FakeStreamResponse(sse_body)
+
+        session_resp = MagicMock()
+        session_resp.status_code = 200
+        session_resp.raise_for_status = MagicMock()
+        session_resp.json = MagicMock(return_value={"id": "ses_t2"})
+
+        prompt_resp = MagicMock()
+        prompt_resp.status_code = 204
+
+        async def fake_post(url, **kwargs):
+            if "prompt_async" not in url:
+                return session_resp
+            return prompt_resp
+
+        fake_client = MagicMock()
+        fake_client.is_closed = False
+        fake_client.post = AsyncMock(side_effect=fake_post)
+        fake_client.stream = MagicMock(return_value=stream_ctx)
+        fake_client.aclose = AsyncMock()
+
+        async def fake_get_client():
+            return fake_client
+
+        monkeypatch.setattr(adapter, "_get_client", fake_get_client)
+
+        await adapter.prompt("hi", trace_id="trace-42")
+
+        # Every emitted reply should carry trace_id
+        assert all(c.get("trace_id") == "trace-42" for c in calls)
+        # There should be a final call
+        final_calls = [c for c in calls if c["kind"] == "final"]
+        assert len(final_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_prompt_emits_error_on_transport_failure(self, monkeypatch):
+        calls: list[dict] = []
+
+        def sink(reply: dict):
+            calls.append(reply)
+
+        adapter = self._make_adapter(sink)
+
+        async def fake_get_client():
+            raise ConnectionError("connection refused")
+
+        monkeypatch.setattr(adapter, "_get_client", fake_get_client)
+
+        # Should not raise
+        await adapter.prompt("hello")
+
+        error_calls = [c for c in calls if c["kind"] == "error"]
+        assert len(error_calls) == 1
+        assert "connection refused" in error_calls[0].get("error", "")
+
+    @pytest.mark.asyncio
+    async def test_prompt_emits_error_when_stream_ends_early(self, monkeypatch):
+        """Stream closes without session.idle → error reply."""
+        calls: list[dict] = []
+
+        def sink(reply: dict):
+            calls.append(reply)
+
+        adapter = self._make_adapter(sink)
+
+        # SSE body ends without session.idle
+        sse_body = _build_sse_bytes(
+            {
+                "type": "message.part.delta",
+                "properties": {"sessionID": "ses_early", "field": "text", "delta": "partial"},
+            },
+        )
+        stream_ctx = _FakeStreamResponse(sse_body)
+
+        session_resp = MagicMock()
+        session_resp.status_code = 200
+        session_resp.raise_for_status = MagicMock()
+        session_resp.json = MagicMock(return_value={"id": "ses_early"})
+
+        prompt_resp = MagicMock()
+        prompt_resp.status_code = 204
+
+        async def fake_post(url, **kwargs):
+            if "prompt_async" not in url:
+                return session_resp
+            return prompt_resp
+
+        fake_client = MagicMock()
+        fake_client.is_closed = False
+        fake_client.post = AsyncMock(side_effect=fake_post)
+        fake_client.stream = MagicMock(return_value=stream_ctx)
+        fake_client.aclose = AsyncMock()
+
+        async def fake_get_client():
+            return fake_client
+
+        monkeypatch.setattr(adapter, "_get_client", fake_get_client)
+
+        await adapter.prompt("hi")
+
+        error_calls = [c for c in calls if c["kind"] == "error"]
+        assert len(error_calls) == 1
+        assert "session.idle" in error_calls[0]["error"]
+
+
+# ---------------------------------------------------------------------------
+# OpenCodeAdapter.close() — safety checks
+# ---------------------------------------------------------------------------
+
+class TestOpenCodeAdapterClose:
+    @pytest.mark.asyncio
+    async def test_close_safe_when_no_client(self):
+        cfg = OpenCodeConfig(base_url="http://127.0.0.1:5888")
+        adapter = OpenCodeAdapter(cfg, sink=lambda r: None)
+        # Should not raise
+        await adapter.close()
+
+    @pytest.mark.asyncio
+    async def test_close_safe_when_already_closed(self):
+        cfg = OpenCodeConfig(base_url="http://127.0.0.1:5888")
+        adapter = OpenCodeAdapter(cfg, sink=lambda r: None)
+        fake = MagicMock()
+        fake.is_closed = True
+        fake.aclose = AsyncMock()
+        adapter._client = fake
+        await adapter.close()
+        fake.aclose.assert_not_called()

--- a/tinyagentos/adapters/opencode_adapter.py
+++ b/tinyagentos/adapters/opencode_adapter.py
@@ -1,0 +1,380 @@
+"""opencode adapter — drives opencode's headless HTTP server and maps its SSE
+event stream onto taOS's fixed 6-kind reply vocabulary:
+  delta | final | tool_call | tool_result | reasoning | error
+
+opencode server: `opencode serve --port <n> --hostname 127.0.0.1`
+Optional HTTP Basic auth when OPENCODE_SERVER_PASSWORD is set.
+
+Usage (callers drive the adapter):
+    # sink receives reply dicts (the body shape bridge_session.record_reply
+    # consumes): {"kind": ..., "trace_id": ..., "content"/"error": ...}
+    cfg = OpenCodeConfig(base_url="http://127.0.0.1:5888", ...)
+    adapter = OpenCodeAdapter(cfg, sink=my_sink)
+    await adapter.prompt("Hello", trace_id="t1")
+    await adapter.close()
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+@dataclass
+class OpenCodeConfig:
+    """Configuration for a single opencode server instance."""
+
+    base_url: str
+    """Base URL of the opencode server, e.g. http://127.0.0.1:5888"""
+
+    server_password: str | None = None
+    """If set, HTTP Basic auth is used (username defaults to 'opencode')."""
+
+    server_username: str = "opencode"
+    """HTTP Basic auth username; only used when server_password is set."""
+
+    model_provider_id: str = "litellm"
+    """opencode provider ID, e.g. 'litellm'."""
+
+    model_id: str = ""
+    """opencode model ID, e.g. 'stepfun/step-3.7-flash:free'."""
+
+    agent: str | None = None
+    """Optional agent slug for informational purposes."""
+
+    system: str | None = None
+    """Unused by the opencode API directly; reserved for future injection."""
+
+    connect_timeout: float = 10.0
+    read_timeout: float = 300.0
+
+
+# ---------------------------------------------------------------------------
+# Pure event mapper (unit-testable, no I/O)
+# ---------------------------------------------------------------------------
+
+def map_opencode_event(evt: dict, state: dict) -> list[tuple[str, dict]]:
+    """Map one opencode SSE event dict onto zero or more (kind, payload) tuples.
+
+    Args:
+        evt:   Parsed JSON dict from a ``data: ...`` SSE line.
+        state: Mutable dict shared across a single turn:
+               - ``"session_id"``    — the session we own (set before streaming).
+               - ``"text"``          — accumulated final-text buffer (str).
+               - ``"done"``          — True once session.idle fires.
+               - ``"switched_model"``— last model reported by session.next.model.switched.
+
+    Returns:
+        List of ``(kind, payload)`` where ``kind`` is one of the 6 reply
+        kinds and ``payload`` is kwargs for ``record_reply``. Returns ``[]``
+        for events we ignore or that belong to a different session.
+    """
+    evt_type = evt.get("type", "")
+    props = evt.get("properties") or {}
+    our_session = state.get("session_id")
+
+    # Helper: does this event belong to our session?
+    def _our(sid_key: str = "sessionID") -> bool:
+        if our_session is None:
+            return True  # before session is established; accept
+        return props.get(sid_key) == our_session
+
+    # ------------------------------------------------------------------ ignore
+    if evt_type in ("server.connected", "session.created", "message.updated"):
+        return []
+
+    # -------------------------------------------- streaming text / reasoning
+    if evt_type == "message.part.delta":
+        if not _our():
+            return []
+        field = props.get("field", "")
+        delta = props.get("delta", "")
+        if field == "text":
+            state["text"] = state.get("text", "") + delta
+            return [("delta", {"content": delta})]
+        if field == "reasoning":
+            return [("reasoning", {"content": delta})]
+        return []
+
+    # -------------------------------------------- part reached a new state
+    if evt_type == "message.part.updated":
+        part = props.get("part") or {}
+        part_type = part.get("type", "")
+        if part_type != "tool":
+            return []
+        # Only act on parts that belong to our session (best-effort — part
+        # objects don't always carry sessionID; we accept if no filter hits).
+        part_session = part.get("sessionID") or props.get("sessionID")
+        if our_session and part_session and part_session != our_session:
+            return []
+
+        call_id = part.get("callID") or part.get("id", "")
+        tool_name = part.get("tool") or part.get("name", "")
+        tool_input = part.get("input") or {}
+        part_state = part.get("state") or {}
+        status = part_state.get("status", "")
+
+        results: list[tuple[str, dict]] = []
+
+        # A "started" / "calling" status = tool invocation begun.
+        if status in ("started", "calling", "running"):
+            results.append(("tool_call", {
+                "tool": tool_name,
+                "args": tool_input,
+                "call_id": call_id,
+            }))
+        # A "completed" / "success" status = tool finished with output.
+        elif status in ("completed", "success"):
+            output = part_state.get("output") or part_state.get("result") or ""
+            results.append(("tool_result", {
+                "tool": tool_name,
+                "result": output,
+                "success": True,
+                "call_id": call_id,
+            }))
+        # An "error" status = tool failed.
+        elif status in ("error", "failed"):
+            err_msg = (
+                part_state.get("error")
+                or part_state.get("message")
+                or f"tool '{tool_name}' failed"
+            )
+            results.append(("tool_result", {
+                "tool": tool_name,
+                "result": err_msg,
+                "success": False,
+                "call_id": call_id,
+            }))
+        # Unknown status — no emit; caller can re-examine on next update.
+        return results
+
+    # -------------------------------------------- native model switched
+    if evt_type == "session.next.model.switched":
+        # Record for reverse reconcile; do NOT emit a reply kind.
+        state["switched_model"] = props.get("model")
+        return []
+
+    # -------------------------------------------- turn complete
+    if evt_type == "session.idle":
+        if not _our():
+            return []
+        accumulated = state.get("text", "")
+        state["done"] = True
+        return [("final", {"content": accumulated})]
+
+    # -------------------------------------------- unrecognised
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Adapter
+# ---------------------------------------------------------------------------
+
+class OpenCodeAdapter:
+    """Drive an opencode headless server for one agent turn at a time.
+
+    Lifecycle:
+        1. ``ensure_session()`` — idempotent; creates an opencode session once.
+        2. ``prompt(text, record_reply)`` — sends the user turn, streams events,
+           calls ``record_reply(kind, **payload)`` for each reply, blocks until
+           ``session.idle`` or transport failure.
+        3. ``close()`` — shuts down the httpx client.
+
+    ``prompt()`` never raises; transport / server errors degrade to an
+    ``error`` reply kind, mirroring the acp_adapter contract.
+    """
+
+    def __init__(self, config: OpenCodeConfig, sink) -> None:
+        self._cfg = config
+        # sink is called once per mapped taOS reply with a dict carrying at
+        # least ``kind`` and ``trace_id`` plus kind-specific fields, matching
+        # bridge_session.record_reply's body contract (mirrors ACPAdapter).
+        self._sink = sink
+        self.session_id: str | None = None
+        self._client: httpx.AsyncClient | None = None
+        self._stream_ctx = None  # holds the active httpx stream context
+        # Per-turn mutable state, reset in finally block.
+        self._turn_state: dict = {}
+
+    async def _emit(self, reply: dict) -> None:
+        """Deliver one reply dict to the sink (sync or async)."""
+        try:
+            res = self._sink(reply)
+            if asyncio.iscoroutine(res):
+                await res
+        except Exception:
+            logger.exception("opencode_adapter: sink raised for reply kind=%s", reply.get("kind"))
+
+    # ---------------------------------------------------------------- helpers
+
+    @property
+    def _base(self) -> str:
+        return self._cfg.base_url.rstrip("/")
+
+    def _auth(self) -> tuple[str, str] | None:
+        if self._cfg.server_password:
+            return (self._cfg.server_username, self._cfg.server_password)
+        return None
+
+    # ------------------------------------------------------------- session
+
+    async def ensure_session(self) -> str:
+        """Create the opencode session if one doesn't exist yet.
+
+        Returns the session id.  Idempotent — safe to call multiple times.
+        """
+        if self.session_id is not None:
+            return self.session_id
+
+        client = await self._get_client()
+        resp = await client.post(
+            f"{self._base}/session",
+            json={"title": f"taOS-{self._cfg.agent or 'agent'}"},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        # Spec says id is at .id with fallback .info.id
+        session_id = data.get("id") or (data.get("info") or {}).get("id") or ""
+        if not session_id:
+            raise ValueError(f"opencode /session returned no id: {data!r}")
+        self.session_id = session_id
+        logger.debug("opencode_adapter: created session %s", session_id)
+        return session_id
+
+    # ---------------------------------------------------------------- I/O
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None or self._client.is_closed:
+            auth = self._auth()
+            self._client = httpx.AsyncClient(
+                auth=auth,
+                timeout=httpx.Timeout(
+                    connect=self._cfg.connect_timeout,
+                    read=self._cfg.read_timeout,
+                    write=30.0,
+                    pool=30.0,
+                ),
+            )
+        return self._client
+
+    async def prompt(
+        self,
+        text: str,
+        trace_id: str | None = None,
+    ) -> None:
+        """Send *text* to opencode and stream results to the sink.
+
+        Each event that maps to one of the 6 reply kinds is delivered to the
+        sink as a dict ``{"kind", "trace_id", ...kind-specific...}``.  ``prompt``
+        never raises — any transport or server error results in an ``error``
+        reply, mirroring the acp_adapter contract.
+
+        Args:
+            text:     User message text.
+            trace_id: Optional trace id, forwarded on every emitted reply.
+        """
+        state: dict = {
+            "session_id": self.session_id,
+            "text": "",
+            "done": False,
+            "switched_model": None,
+        }
+        self._turn_state = state
+
+        async def _emit(kind: str, payload: dict) -> None:
+            await self._emit({"kind": kind, "trace_id": trace_id, **payload})
+
+        try:
+            # Ensure we have a session before opening the SSE stream.
+            await self.ensure_session()
+            state["session_id"] = self.session_id
+
+            client = await self._get_client()
+
+            # Open the event stream BEFORE sending the prompt so we don't miss
+            # events that fire immediately after prompt_async returns 204.
+            async with client.stream(
+                "GET",
+                f"{self._base}/event",
+                timeout=httpx.Timeout(
+                    connect=self._cfg.connect_timeout,
+                    read=self._cfg.read_timeout,
+                    write=30.0,
+                    pool=30.0,
+                ),
+            ) as stream:
+                # Now fire the async prompt.
+                prompt_resp = await client.post(
+                    f"{self._base}/session/{self.session_id}/prompt_async",
+                    json={
+                        "model": {
+                            "providerID": self._cfg.model_provider_id,
+                            "modelID": self._cfg.model_id,
+                        },
+                        "parts": [{"type": "text", "text": text}],
+                    },
+                )
+                if prompt_resp.status_code not in (200, 204):
+                    await _emit("error", {
+                        "error": (
+                            f"opencode prompt_async returned "
+                            f"{prompt_resp.status_code}: {prompt_resp.text[:200]}"
+                        ),
+                    })
+                    return
+
+                # Consume SSE lines until session.idle or EOF.
+                async for line in stream.aiter_lines():
+                    line = line.strip()
+                    if not line.startswith("data:"):
+                        continue
+                    raw = line[len("data:"):].strip()
+                    if not raw:
+                        continue
+                    try:
+                        evt = json.loads(raw)
+                    except json.JSONDecodeError:
+                        logger.debug("opencode_adapter: non-JSON SSE line: %r", raw)
+                        continue
+
+                    pairs = map_opencode_event(evt, state)
+                    for kind, payload in pairs:
+                        await _emit(kind, payload)
+
+                    if state.get("done"):
+                        break
+
+                # If we exhausted the stream without session.idle → error.
+                if not state.get("done"):
+                    await _emit("error", {
+                        "error": "opencode stream ended before session.idle",
+                    })
+
+        except Exception as exc:
+            logger.exception("opencode_adapter: prompt() transport error")
+            try:
+                await _emit("error", {"error": f"opencode transport error: {exc}"})
+            except Exception:
+                pass
+        finally:
+            self._turn_state = {}
+
+    # ---------------------------------------------------------------- close
+
+    async def close(self) -> None:
+        """Close the underlying httpx client.  Safe to call multiple times."""
+        try:
+            if self._client is not None and not self._client.is_closed:
+                await self._client.aclose()
+        except Exception:
+            logger.debug("opencode_adapter: error during close", exc_info=True)
+        finally:
+            self._client = None


### PR DESCRIPTION
First building block of the opencode taOS agent (#588). A host-side adapter that drives opencode's headless server and maps its event stream onto taOS's reply vocabulary.

## What
`tinyagentos/adapters/opencode_adapter.py`:
- Drives the opencode headless API: `POST /session` → `POST /session/:id/prompt_async` → SSE `GET /event`. Optional HTTP Basic auth (`OPENCODE_SERVER_PASSWORD`).
- Pure codec `map_opencode_event(evt, state)` keyed on the real event vocabulary (verified live on the Pi): `message.part.delta`{field:text|reasoning, delta} → delta/reasoning, tool parts → tool_call/tool_result, `session.idle` → final, `session.next.model.switched` → recorded for reverse-reconcile.
- Matches the **ACPAdapter contract**: constructed with `(config, sink)`; the sink receives reply dicts `{kind, trace_id, content/error}` — the body shape `bridge_session.record_reply` consumes. `prompt()` never raises (transport/server errors degrade to an `error` reply).

## Grounding
Built against opencode-ai `1.15.13` running live on the Pi (drove a real turn through the LiteLLM proxy). Event shapes captured from the live `/event` stream, not docs.

## Tests
`tests/test_opencode_adapter.py` — 26 unit + integration tests: the codec per event type (text/reasoning/tool/idle/model-switch/other-session/malformed), and `prompt()` over a mocked SSE stream asserting the sink reply-dict sequence (delta, delta, final), trace-id propagation, and error-on-transport-failure / stream-ends-early.

Next (#588): the host opencode runtime + the taOS agent as an agent record with its own LiteLLM key, configurable in the Agents app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Opencode adapter for integrating Opencode services into agent workflows. Supports configurable server connection, authentication, model/provider selection, and streaming event handling with comprehensive error management.

* **Tests**
  * Added comprehensive test coverage for Opencode adapter functionality, including event mapping, streaming behavior, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->