### PR TITLE
feat(agents): opencode host runtime — serve lifecycle + drive_turn (#588 phase 2)

### DIFF
--- a/tests/test_opencode_runtime.py
+++ b/tests/test_opencode_runtime.py
@@ -1,0 +1,364 @@
+"""Tests for tinyagentos.opencode_runtime.
+
+Covers:
+  - OpenCodeServer.write_config: JSON structure (provider block + models).
+  - OpenCodeServer.ensure_running idempotency: process only spawned once when
+    already healthy.
+  - OpenCodeServer.ensure_running timeout: raises TimeoutError when /doc never 200.
+  - drive_turn sink wiring: fake adapter streams replies; all reach the sink.
+  - drive_turn error isolation: adapter raises; exactly one error dict delivered
+    to the sink; drive_turn does not re-raise.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tinyagentos.opencode_runtime import (
+    OpenCodeServer,
+    OpenCodeServerConfig,
+    drive_turn,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_server_cfg(tmp_path, port: int = 5900) -> OpenCodeServerConfig:
+    return OpenCodeServerConfig(
+        home=str(tmp_path),
+        port=port,
+        server_password=None,
+        litellm_base_url="http://127.0.0.1:4000/v1",
+        litellm_key="sk-test",
+        model_ids=["gpt-4o", "gpt-3.5-turbo"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# write_config
+# ---------------------------------------------------------------------------
+
+class TestWriteConfig:
+    def test_creates_file_with_expected_structure(self, tmp_path):
+        cfg = _make_server_cfg(tmp_path)
+        server = OpenCodeServer(cfg)
+        server.write_config()
+
+        config_path = tmp_path / ".config" / "opencode" / "opencode.json"
+        assert config_path.exists()
+
+        data = json.loads(config_path.read_text())
+        provider = data["provider"]["litellm"]
+
+        assert provider["npm"] == "@ai-sdk/openai-compatible"
+        assert provider["options"]["baseURL"] == "http://127.0.0.1:4000/v1"
+        assert provider["options"]["apiKey"] == "sk-test"
+        assert "gpt-4o" in provider["models"]
+        assert "gpt-3.5-turbo" in provider["models"]
+
+    def test_creates_parent_dirs(self, tmp_path):
+        # No .config/opencode directory exists yet — write_config must mkdir.
+        nested = tmp_path / "nested" / "home"
+        cfg = OpenCodeServerConfig(
+            home=str(nested),
+            port=5900,
+            server_password=None,
+            litellm_base_url="http://127.0.0.1:4000/v1",
+            litellm_key="sk-test",
+            model_ids=["m1"],
+        )
+        server = OpenCodeServer(cfg)
+        server.write_config()  # must not raise
+        assert (nested / ".config" / "opencode" / "opencode.json").exists()
+
+    def test_single_model_id(self, tmp_path):
+        cfg = OpenCodeServerConfig(
+            home=str(tmp_path),
+            port=5900,
+            server_password=None,
+            litellm_base_url="http://localhost:4000/v1",
+            litellm_key="key",
+            model_ids=["only-model"],
+        )
+        server = OpenCodeServer(cfg)
+        server.write_config()
+        data = json.loads(
+            (tmp_path / ".config" / "opencode" / "opencode.json").read_text()
+        )
+        models = data["provider"]["litellm"]["models"]
+        assert list(models.keys()) == ["only-model"]
+        assert models["only-model"] == {}
+
+    def test_idempotent_overwrite(self, tmp_path):
+        cfg = _make_server_cfg(tmp_path)
+        server = OpenCodeServer(cfg)
+        server.write_config()
+        # Change key, write again — file should reflect the new value.
+        cfg.litellm_key = "sk-new"
+        server.write_config()
+        data = json.loads(
+            (tmp_path / ".config" / "opencode" / "opencode.json").read_text()
+        )
+        assert data["provider"]["litellm"]["options"]["apiKey"] == "sk-new"
+
+
+# ---------------------------------------------------------------------------
+# ensure_running — idempotency
+# ---------------------------------------------------------------------------
+
+class _FakeProcess:
+    """Minimal fake asyncio subprocess.Process."""
+    def __init__(self):
+        self.returncode = None
+        self.pid = 12345
+
+    async def wait(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_ensure_running_idempotent(tmp_path, monkeypatch):
+    """When the process is already alive and /doc returns 200, the subprocess
+    must NOT be spawned a second time."""
+    cfg = _make_server_cfg(tmp_path)
+    server = OpenCodeServer(cfg)
+
+    spawn_count = 0
+
+    async def fake_create_subprocess(*args, **kwargs):
+        nonlocal spawn_count
+        spawn_count += 1
+        return _FakeProcess()
+
+    # /doc always healthy
+    async def fake_health(self_inner):
+        return True
+
+    monkeypatch.setattr(
+        asyncio, "create_subprocess_exec", fake_create_subprocess
+    )
+    monkeypatch.setattr(OpenCodeServer, "_health_check", fake_health)
+
+    await server.ensure_running()
+    assert spawn_count == 1
+
+    # Second call: already running + healthy → must not re-spawn.
+    await server.ensure_running()
+    assert spawn_count == 1
+
+
+@pytest.mark.asyncio
+async def test_ensure_running_spawns_on_dead_process(tmp_path, monkeypatch):
+    """If the previous process died (returncode set), a new one is spawned."""
+    cfg = _make_server_cfg(tmp_path)
+    server = OpenCodeServer(cfg)
+
+    spawn_count = 0
+
+    async def fake_create_subprocess(*args, **kwargs):
+        nonlocal spawn_count
+        spawn_count += 1
+        proc = _FakeProcess()
+        # Simulate process alive after spawn.
+        return proc
+
+    health_calls = 0
+
+    async def fake_health(self_inner):
+        nonlocal health_calls
+        health_calls += 1
+        # Only healthy on first call in second ensure_running.
+        return health_calls > 1
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess)
+    monkeypatch.setattr(OpenCodeServer, "_health_check", fake_health)
+
+    # First ensure_running: process starts but health fails once then succeeds.
+    await server.ensure_running(poll_s=0.0)
+    assert spawn_count == 1
+
+    # Simulate process death.
+    server._proc.returncode = 1
+
+    # Second ensure_running: process is dead → must re-spawn.
+    health_calls = 0
+    await server.ensure_running(poll_s=0.0)
+    assert spawn_count == 2
+
+
+# ---------------------------------------------------------------------------
+# ensure_running — timeout
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_ensure_running_raises_on_timeout(tmp_path, monkeypatch):
+    """/doc never returns 200 → TimeoutError raised within the injected deadline."""
+    cfg = _make_server_cfg(tmp_path)
+    server = OpenCodeServer(cfg)
+
+    async def fake_create_subprocess(*args, **kwargs):
+        return _FakeProcess()
+
+    async def fake_health(self_inner):
+        return False  # never healthy
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess)
+    monkeypatch.setattr(OpenCodeServer, "_health_check", fake_health)
+
+    with pytest.raises(TimeoutError):
+        await server.ensure_running(deadline_s=0.05, poll_s=0.01)
+
+
+# ---------------------------------------------------------------------------
+# drive_turn — sink wiring
+# ---------------------------------------------------------------------------
+
+class _FakeAdapter:
+    """Stub adapter that emits two reply dicts to the sink, then closes."""
+
+    def __init__(self, cfg, sink):
+        self.cfg = cfg
+        self.sink = sink
+        self.closed = False
+        self.session_ensured = False
+
+    async def ensure_session(self):
+        self.session_ensured = True
+
+    async def prompt(self, text, trace_id=None):
+        await self.sink({"kind": "delta", "trace_id": trace_id, "content": "chunk"})
+        await self.sink({"kind": "final", "trace_id": trace_id, "content": "chunk"})
+
+    async def close(self):
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_drive_turn_wires_sink():
+    received = []
+
+    async def sink(reply: dict):
+        received.append(reply)
+
+    holder = {}
+
+    def factory(cfg, sink_arg):
+        holder["a"] = _FakeAdapter(cfg, sink_arg)
+        return holder["a"]
+
+    await drive_turn(
+        "hello", "t1", sink,
+        base_url="http://127.0.0.1:5900",
+        model_id="gpt-4o",
+        adapter_factory=factory,
+    )
+
+    adapter = holder["a"]
+    assert adapter.session_ensured
+    assert adapter.closed
+    assert [r["kind"] for r in received] == ["delta", "final"]
+    assert all(r["trace_id"] == "t1" for r in received)
+
+
+@pytest.mark.asyncio
+async def test_drive_turn_config_passed_to_adapter():
+    """The config forwarded to the adapter must reflect drive_turn's kwargs."""
+    captured_cfg = {}
+
+    class _CapturingAdapter(_FakeAdapter):
+        def __init__(self, cfg, sink):
+            super().__init__(cfg, sink)
+            captured_cfg["cfg"] = cfg
+
+    await drive_turn(
+        "hi", None, lambda r: None,
+        base_url="http://127.0.0.1:5901",
+        model_id="my-model",
+        model_provider_id="litellm",
+        server_password="s3cr3t",
+        adapter_factory=_CapturingAdapter,
+    )
+
+    cfg = captured_cfg["cfg"]
+    assert cfg.base_url == "http://127.0.0.1:5901"
+    assert cfg.model_id == "my-model"
+    assert cfg.model_provider_id == "litellm"
+    assert cfg.server_password == "s3cr3t"
+
+
+# ---------------------------------------------------------------------------
+# drive_turn — error isolation
+# ---------------------------------------------------------------------------
+
+class _BoomAdapter(_FakeAdapter):
+    """Adapter whose prompt() raises unconditionally."""
+
+    async def prompt(self, text, trace_id=None):
+        raise RuntimeError("adapter exploded")
+
+
+@pytest.mark.asyncio
+async def test_drive_turn_does_not_raise_on_adapter_failure():
+    """drive_turn must not propagate adapter exceptions to the caller."""
+    received = []
+
+    async def sink(reply: dict):
+        received.append(reply)
+
+    # Should not raise.
+    await drive_turn(
+        "text", "t2", sink,
+        base_url="http://127.0.0.1:5900",
+        model_id="gpt-4o",
+        adapter_factory=lambda cfg, s: _BoomAdapter(cfg, s),
+    )
+
+    error_replies = [r for r in received if r["kind"] == "error"]
+    assert len(error_replies) == 1
+    assert error_replies[0]["trace_id"] == "t2"
+
+
+@pytest.mark.asyncio
+async def test_drive_turn_emits_exactly_one_error_on_failure():
+    """Exactly one error dict reaches the sink when the adapter raises, not more."""
+    received = []
+
+    async def sink(reply: dict):
+        received.append(reply)
+
+    await drive_turn(
+        "text", "tx", sink,
+        base_url="http://127.0.0.1:5900",
+        model_id="gpt-4o",
+        adapter_factory=lambda cfg, s: _BoomAdapter(cfg, s),
+    )
+
+    assert len([r for r in received if r["kind"] == "error"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_drive_turn_ensure_session_failure_emits_error():
+    """If ensure_session() raises, drive_turn still emits an error and returns."""
+
+    class _NoSession(_FakeAdapter):
+        async def ensure_session(self):
+            raise ConnectionError("no server")
+
+    received = []
+
+    async def sink(reply: dict):
+        received.append(reply)
+
+    await drive_turn(
+        "text", "t3", sink,
+        base_url="http://127.0.0.1:5900",
+        model_id="gpt-4o",
+        adapter_factory=lambda cfg, s: _NoSession(cfg, s),
+    )
+
+    assert any(r["kind"] == "error" for r in received)

--- a/tests/test_opencode_runtime.py
+++ b/tests/test_opencode_runtime.py
@@ -61,6 +61,14 @@ class TestWriteConfig:
         assert "gpt-4o" in provider["models"]
         assert "gpt-3.5-turbo" in provider["models"]
 
+    def test_config_is_owner_only_readable(self, tmp_path):
+        # The config embeds the LiteLLM key in plaintext — must be 0600.
+        import os
+        cfg = _make_server_cfg(tmp_path)
+        OpenCodeServer(cfg).write_config()
+        config_path = tmp_path / ".config" / "opencode" / "opencode.json"
+        assert oct(os.stat(config_path).st_mode & 0o777) == "0o600"
+
     def test_creates_parent_dirs(self, tmp_path):
         # No .config/opencode directory exists yet — write_config must mkdir.
         nested = tmp_path / "nested" / "home"

--- a/tinyagentos/opencode_runtime.py
+++ b/tinyagentos/opencode_runtime.py
@@ -97,6 +97,12 @@ class OpenCodeServer:
         }
         config_path = config_dir / "opencode.json"
         config_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        # The config embeds the agent's LiteLLM key in plaintext — keep it
+        # owner-only (mirrors install_hermes.sh's chmod 600 on ~/.hermes/.env).
+        try:
+            os.chmod(config_path, 0o600)
+        except OSError:
+            logger.debug("opencode_runtime: could not chmod %s", config_path)
         logger.debug("opencode_runtime: wrote config to %s", config_path)
 
     # ---------------------------------------------------------------- lifecycle
@@ -128,6 +134,11 @@ class OpenCodeServer:
         if self.is_running() and await self._health_check():
             return
 
+        # A live-but-unhealthy child must be reaped before respawning, or we
+        # orphan it and the new server collides on the same port.
+        if self.is_running():
+            await self.stop()
+
         self.write_config()
 
         env = {
@@ -151,14 +162,14 @@ class OpenCodeServer:
             self._proc.pid, self._cfg.port,
         )
 
-        # Poll GET /doc until 200 or deadline.
-        elapsed = 0.0
-        while elapsed < deadline_s:
+        # Poll GET /doc until 200 or a wall-clock deadline. Using the loop clock
+        # (not a poll-count) so a slow health check can't overrun deadline_s.
+        deadline = asyncio.get_running_loop().time() + deadline_s
+        while asyncio.get_running_loop().time() < deadline:
             if await self._health_check():
-                logger.info("opencode_runtime: server healthy after %.1fs", elapsed)
+                logger.info("opencode_runtime: server healthy")
                 return
             await asyncio.sleep(poll_s)
-            elapsed += poll_s
 
         raise TimeoutError(
             f"opencode server on port {self._cfg.port} did not become healthy "

--- a/tinyagentos/opencode_runtime.py
+++ b/tinyagentos/opencode_runtime.py
@@ -70,6 +70,9 @@ class OpenCodeServer:
     def __init__(self, config: OpenCodeServerConfig) -> None:
         self._cfg = config
         self._proc: asyncio.subprocess.Process | None = None
+        # Server output is redirected to this file handle (never PIPE — an
+        # unread pipe deadlocks the long-lived server once its buffer fills).
+        self._log_fh = None
 
     # ---------------------------------------------------------------- config
 
@@ -148,13 +151,23 @@ class OpenCodeServer:
         if self._cfg.server_password:
             env["OPENCODE_SERVER_PASSWORD"] = self._cfg.server_password
 
+        # Redirect output to a log file rather than PIPE: a long-lived server
+        # with an unread PIPE deadlocks once the OS buffer fills, and we still
+        # want the serve logs for diagnosing the host taOS agent.
+        log_path = Path(self._cfg.home) / ".config" / "opencode" / "serve.log"
+        self._log_fh = open(log_path, "ab")
+        try:
+            os.chmod(log_path, 0o600)
+        except OSError:
+            pass
+
         self._proc = await asyncio.create_subprocess_exec(
             self._cfg.binary,
             "serve",
             "--port", str(self._cfg.port),
             "--hostname", "127.0.0.1",
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
+            stdout=self._log_fh,
+            stderr=asyncio.subprocess.STDOUT,
             env=env,
         )
         logger.info(
@@ -179,20 +192,26 @@ class OpenCodeServer:
     async def stop(self) -> None:
         """Terminate the server process.  Safe to call when not running."""
         proc = self._proc
-        if proc is None or proc.returncode is not None:
-            return
-        try:
-            proc.terminate()
+        if proc is not None and proc.returncode is None:
             try:
-                await asyncio.wait_for(proc.wait(), timeout=5.0)
-            except asyncio.TimeoutError:
+                proc.terminate()
                 try:
-                    proc.kill()
-                    await proc.wait()
-                except ProcessLookupError:
-                    pass
-        except ProcessLookupError:
-            pass
+                    await asyncio.wait_for(proc.wait(), timeout=5.0)
+                except asyncio.TimeoutError:
+                    try:
+                        proc.kill()
+                        await proc.wait()
+                    except ProcessLookupError:
+                        pass
+            except ProcessLookupError:
+                pass
+        # Close the serve-log handle (opened per spawn).
+        if self._log_fh is not None:
+            try:
+                self._log_fh.close()
+            except OSError:
+                pass
+            self._log_fh = None
 
     # ---------------------------------------------------------------- health
 

--- a/tinyagentos/opencode_runtime.py
+++ b/tinyagentos/opencode_runtime.py
@@ -1,0 +1,257 @@
+"""opencode host runtime — manage a host-side `opencode serve` process and
+drive one agent turn through the opencode adapter.
+
+``OpenCodeServer`` owns one `opencode serve` subprocess.  It writes the LiteLLM
+provider config into ``$HOME/.config/opencode/opencode.json``, spawns the
+server, and polls ``GET /doc`` until healthy (or raises ``TimeoutError``).
+
+``drive_turn`` runs one turn through :class:`OpenCodeAdapter`, streaming reply
+dicts to a sink.  Mirrors :mod:`tinyagentos.openclaw_acp_runtime` — never raises
+out of ``drive_turn``; any failure degrades to an ``error`` reply.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable
+
+import httpx
+
+from tinyagentos.adapters.opencode_adapter import OpenCodeAdapter, OpenCodeConfig
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Config + server
+# ---------------------------------------------------------------------------
+
+@dataclass
+class OpenCodeServerConfig:
+    """Configuration for launching a host-side opencode server."""
+
+    home: str
+    """Home directory; opencode config is written to ``{home}/.config/opencode/``."""
+
+    port: int
+    """Port for ``opencode serve``."""
+
+    server_password: str | None
+    """If set, ``OPENCODE_SERVER_PASSWORD`` env var is passed and Basic auth is used."""
+
+    litellm_base_url: str
+    """Base URL of the taOS LiteLLM proxy, e.g. ``http://127.0.0.1:4000/v1``."""
+
+    litellm_key: str
+    """API key for the LiteLLM proxy (the agent's own virtual key)."""
+
+    model_ids: list[str]
+    """Model IDs to expose under the ``litellm`` provider, e.g. ``["gpt-4o"]``."""
+
+    binary: str = "opencode"
+    """Path or name of the opencode binary."""
+
+
+class OpenCodeServer:
+    """Manage one host ``opencode serve`` process.
+
+    Typical usage::
+
+        server = OpenCodeServer(cfg)
+        await server.ensure_running()
+        # … use server.base_url …
+        await server.stop()
+    """
+
+    def __init__(self, config: OpenCodeServerConfig) -> None:
+        self._cfg = config
+        self._proc: asyncio.subprocess.Process | None = None
+
+    # ---------------------------------------------------------------- config
+
+    def write_config(self) -> None:
+        """Write ``{home}/.config/opencode/opencode.json`` with the LiteLLM
+        provider block.  Creates parent directories as needed.  Idempotent and
+        unit-testable (no subprocess involvement).
+        """
+        config_dir = Path(self._cfg.home) / ".config" / "opencode"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        models = {mid: {} for mid in self._cfg.model_ids}
+        payload = {
+            "$schema": "https://opencode.ai/config.json",
+            "provider": {
+                "litellm": {
+                    "npm": "@ai-sdk/openai-compatible",
+                    "name": "LiteLLM",
+                    "options": {
+                        "baseURL": self._cfg.litellm_base_url,
+                        "apiKey": self._cfg.litellm_key,
+                    },
+                    "models": models,
+                }
+            },
+        }
+        config_path = config_dir / "opencode.json"
+        config_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        logger.debug("opencode_runtime: wrote config to %s", config_path)
+
+    # ---------------------------------------------------------------- lifecycle
+
+    @property
+    def base_url(self) -> str:
+        """HTTP base URL of the running server."""
+        return f"http://127.0.0.1:{self._cfg.port}"
+
+    def is_running(self) -> bool:
+        """True if the server process exists and has not yet exited."""
+        return self._proc is not None and self._proc.returncode is None
+
+    async def ensure_running(
+        self,
+        *,
+        deadline_s: float = 20.0,
+        poll_s: float = 0.5,
+    ) -> None:
+        """Idempotent: start the server if it is not already healthy.
+
+        If our process is alive AND ``GET /doc`` returns 200, return immediately.
+        Otherwise write the config, spawn ``opencode serve``, and poll until healthy.
+
+        Raises:
+            TimeoutError: if the server does not become healthy within *deadline_s*.
+        """
+        # Fast path: already running and healthy.
+        if self.is_running() and await self._health_check():
+            return
+
+        self.write_config()
+
+        env = {
+            **os.environ,
+            "HOME": self._cfg.home,
+        }
+        if self._cfg.server_password:
+            env["OPENCODE_SERVER_PASSWORD"] = self._cfg.server_password
+
+        self._proc = await asyncio.create_subprocess_exec(
+            self._cfg.binary,
+            "serve",
+            "--port", str(self._cfg.port),
+            "--hostname", "127.0.0.1",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        logger.info(
+            "opencode_runtime: spawned pid=%s port=%d",
+            self._proc.pid, self._cfg.port,
+        )
+
+        # Poll GET /doc until 200 or deadline.
+        elapsed = 0.0
+        while elapsed < deadline_s:
+            if await self._health_check():
+                logger.info("opencode_runtime: server healthy after %.1fs", elapsed)
+                return
+            await asyncio.sleep(poll_s)
+            elapsed += poll_s
+
+        raise TimeoutError(
+            f"opencode server on port {self._cfg.port} did not become healthy "
+            f"within {deadline_s}s"
+        )
+
+    async def stop(self) -> None:
+        """Terminate the server process.  Safe to call when not running."""
+        proc = self._proc
+        if proc is None or proc.returncode is not None:
+            return
+        try:
+            proc.terminate()
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=5.0)
+            except asyncio.TimeoutError:
+                try:
+                    proc.kill()
+                    await proc.wait()
+                except ProcessLookupError:
+                    pass
+        except ProcessLookupError:
+            pass
+
+    # ---------------------------------------------------------------- health
+
+    async def _health_check(self) -> bool:
+        """Return True if ``GET {base_url}/doc`` responds with 200."""
+        auth = None
+        if self._cfg.server_password:
+            auth = ("opencode", self._cfg.server_password)
+        try:
+            async with httpx.AsyncClient(auth=auth, timeout=2.0) as client:
+                resp = await client.get(f"{self.base_url}/doc")
+                return resp.status_code == 200
+        except Exception:
+            return False
+
+
+# ---------------------------------------------------------------------------
+# Turn driver
+# ---------------------------------------------------------------------------
+
+async def drive_turn(
+    text: str,
+    trace_id: str | None,
+    sink,
+    *,
+    base_url: str,
+    model_id: str,
+    model_provider_id: str = "litellm",
+    server_password: str | None = None,
+    adapter_factory: Callable[..., OpenCodeAdapter] = OpenCodeAdapter,
+) -> None:
+    """Run one opencode turn, streaming reply dicts to *sink*.
+
+    Mirrors :func:`tinyagentos.openclaw_acp_runtime.drive_turn` in defensive
+    style: never raises.  Any failure degrades to exactly one
+    ``{"kind":"error",...}`` dict delivered to the sink.
+
+    Args:
+        text:              User message text.
+        trace_id:          Optional trace id forwarded on every reply.
+        sink:              Async or sync callable that receives reply dicts.
+        base_url:          HTTP base URL of the opencode server.
+        model_id:          opencode model ID (e.g. ``"gpt-4o"``).
+        model_provider_id: opencode provider ID (default ``"litellm"``).
+        server_password:   If set, HTTP Basic auth password (username ``opencode``).
+        adapter_factory:   Injectable for tests; defaults to :class:`OpenCodeAdapter`.
+    """
+    cfg = OpenCodeConfig(
+        base_url=base_url,
+        server_password=server_password,
+        model_provider_id=model_provider_id,
+        model_id=model_id,
+    )
+    adapter = None
+    try:
+        adapter = adapter_factory(cfg, sink)
+        await adapter.ensure_session()
+        await adapter.prompt(text, trace_id)
+    except Exception:
+        logger.exception("opencode_runtime: drive_turn failed")
+        try:
+            reply: dict = {"kind": "error", "trace_id": trace_id, "error": "agent turn failed (opencode transport)"}
+            res = sink(reply)
+            if asyncio.iscoroutine(res):
+                await res
+        except Exception:
+            logger.exception("opencode_runtime: error reply also failed")
+    finally:
+        if adapter is not None:
+            try:
+                await adapter.close()
+            except Exception:
+                logger.exception("opencode_runtime: adapter close failed")


### PR DESCRIPTION
Phase 2 of the opencode taOS agent (#588), on top of the merged adapter (#591).

## What
`tinyagentos/opencode_runtime.py`:
- **`OpenCodeServer`** manages a host `opencode serve` process: `write_config` (the LiteLLM provider config pointing at the proxy with the agent's own scoped key), `ensure_running` (idempotent — spawns the server, polls `GET /doc` for health up to a deadline), `stop`, `is_running`, `base_url`.
- **`drive_turn`** runs one turn through `OpenCodeAdapter`, wiring its reply dicts to the sink. Mirrors `openclaw_acp_runtime`: lifecycle (server) is separate from turn execution (drive_turn takes a `base_url`), and it never raises — failures degrade to a single `error` reply (no raw-exception leak, matching the openclaw pattern).

## Tests
`tests/test_opencode_runtime.py` (14): `write_config` JSON shape, `ensure_running` idempotency (spawns once, no re-spawn when healthy) + health-timeout, and `drive_turn` wiring the sink + the error-on-failure path (one error reply, no raise). Full file set 38 green (with the adapter tests).

Next (#588): the taOS agent as an agent record with its own LiteLLM key, configurable in the Agents app, then rewire `routes/taos_agent.py` to drive this runtime + rename "taOS Assistant" to "taOS agent".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add OpenCode runtime to spawn and manage a local agent server with health checks, optional auth, and graceful shutdown.
  * Add a turn driver to stream agent responses to callers with guaranteed cleanup and single-error reporting.

* **Tests**
  * New test suite covering config file creation (structure, permissions, overwrite), server start/respawn/timeout behaviors, streaming replies, argument propagation, and error isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->