### PR TITLE
feat(ui): rename 'taOS Assistant' to 'taOS agent'

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -79,7 +79,7 @@ function SystemShortcuts({ toggleSearch, toggleLaunchpad, toggleAssistant }: Sys
 
   useShortcut("Ctrl+Space", toggleSearch, "Toggle search palette", "system");
   useShortcut("Ctrl+l", toggleLaunchpad, "Toggle launchpad", "system");
-  useShortcut("Ctrl+/", toggleAssistant, "Toggle taOS Assistant", "system");
+  useShortcut("Ctrl+/", toggleAssistant, "Toggle taOS agent", "system");
   useShortcut("Ctrl+w", closeFocused, "Close focused window", "system");
   useShortcut("Ctrl+m", minimizeFocused, "Minimize focused window", "system");
   useShortcut("Ctrl+f", maximizeFocused, "Maximize/restore focused window", "system");

--- a/desktop/src/components/TaosAssistantPanel.test.tsx
+++ b/desktop/src/components/TaosAssistantPanel.test.tsx
@@ -43,8 +43,8 @@ describe("TaosAssistantPanel", () => {
 
   it("shows title when open", () => {
     render(<TaosAssistantPanel />);
-    expect(screen.getByRole("dialog", { name: /taOS Assistant/i })).toBeInTheDocument();
-    expect(screen.getByText("taOS Assistant")).toBeInTheDocument();
+    expect(screen.getByRole("dialog", { name: /taOS agent/i })).toBeInTheDocument();
+    expect(screen.getByText("taOS agent")).toBeInTheDocument();
   });
 
   it("shows empty state with pick-model button when no model", () => {
@@ -55,7 +55,7 @@ describe("TaosAssistantPanel", () => {
 
   it("shows message input disabled when no model", () => {
     render(<TaosAssistantPanel />);
-    const textarea = screen.getByRole("textbox", { name: /message taOS Assistant/i });
+    const textarea = screen.getByRole("textbox", { name: /message taOS agent/i });
     expect(textarea).toBeDisabled();
   });
 
@@ -80,7 +80,7 @@ describe("TaosAssistantPanel", () => {
 
   it("close button calls closePanel", () => {
     render(<TaosAssistantPanel />);
-    const closeBtn = screen.getByRole("button", { name: /close taOS Assistant/i });
+    const closeBtn = screen.getByRole("button", { name: /close taOS agent/i });
     fireEvent.click(closeBtn);
     expect(useTaosAgentStore.getState().isOpen).toBe(false);
   });

--- a/desktop/src/components/TaosAssistantPanel.tsx
+++ b/desktop/src/components/TaosAssistantPanel.tsx
@@ -133,7 +133,7 @@ export function TaosAssistantPanel() {
           backdrop blur for the macOS-style sidebar feel. */}
       <div
         role="dialog"
-        aria-label="taOS Assistant"
+        aria-label="taOS agent"
         aria-modal="true"
         className="fixed right-0 z-[101] flex flex-col border-l border-white/10 shadow-2xl"
         style={{
@@ -154,7 +154,7 @@ export function TaosAssistantPanel() {
         {/* Header */}
         <div className="flex items-center gap-2 px-4 py-3 border-b border-white/5 shrink-0">
           <Sparkles size={15} className="text-accent shrink-0" />
-          <span className="text-sm font-semibold flex-1">taOS Assistant</span>
+          <span className="text-sm font-semibold flex-1">taOS agent</span>
           <button
             className="p-1 rounded hover:bg-shell-surface-hover transition-colors text-shell-text-secondary"
             aria-label="Assistant settings"
@@ -164,7 +164,7 @@ export function TaosAssistantPanel() {
           </button>
           <button
             className="p-1 rounded hover:bg-shell-surface-hover transition-colors text-shell-text-secondary"
-            aria-label="Close taOS Assistant"
+            aria-label="Close taOS agent"
             onClick={closePanel}
           >
             <X size={14} />
@@ -229,10 +229,10 @@ export function TaosAssistantPanel() {
               value={input}
               onChange={(e) => setInput(e.target.value)}
               onKeyDown={handleKeyDown}
-              placeholder={noModel ? "Choose a model first…" : "Ask taOS Assistant…"}
+              placeholder={noModel ? "Choose a model first…" : "Ask taOS agent…"}
               disabled={noModel || streaming}
               rows={2}
-              aria-label="Message taOS Assistant"
+              aria-label="Message taOS agent"
               className="flex-1 resize-none rounded-lg border border-white/10 bg-shell-bg-deep text-sm text-shell-text placeholder:text-shell-text-tertiary focus:outline-none focus:border-accent/40 px-3 py-2 disabled:opacity-40"
               style={{ minHeight: 64, maxHeight: 160 }}
             />

--- a/desktop/src/components/TaosAssistantSettings.tsx
+++ b/desktop/src/components/TaosAssistantSettings.tsx
@@ -109,7 +109,7 @@ export function TaosAssistantSettings({ open, onClose }: Props) {
       >
         <div className="flex items-center justify-between px-5 py-4 border-b border-white/5 shrink-0">
           <h2 id="taos-assistant-settings-title" className="text-sm font-semibold">
-            taOS Assistant — Settings
+            taOS agent — Settings
           </h2>
           {model && (
             <span className="text-xs text-shell-text-tertiary mr-auto ml-3 truncate max-w-[120px]">
@@ -126,7 +126,7 @@ export function TaosAssistantSettings({ open, onClose }: Props) {
         </div>
         <div className="px-5 py-5 flex-1 min-h-0 overflow-y-auto">
           <p className="text-xs text-shell-text-secondary mb-4">
-            Pick the model the taOS Assistant will use. You can change this at any time.
+            Pick the model the taOS agent will use. You can change this at any time.
           </p>
           <ModelPickerFlow
             models={models}

--- a/desktop/src/components/TopBar.test.tsx
+++ b/desktop/src/components/TopBar.test.tsx
@@ -31,15 +31,15 @@ describe("TopBar", () => {
     vi.clearAllMocks();
   });
 
-  it("renders the taOS Assistant sparkles button", () => {
+  it("renders the taOS agent sparkles button", () => {
     render(<TopBar onSearchOpen={onSearchOpen} onAssistantOpen={onAssistantOpen} />);
-    const btn = screen.getByRole("button", { name: /open taOS Assistant/i });
+    const btn = screen.getByRole("button", { name: /open taOS agent/i });
     expect(btn).toBeInTheDocument();
   });
 
   it("calls onAssistantOpen when sparkles button is clicked", () => {
     render(<TopBar onSearchOpen={onSearchOpen} onAssistantOpen={onAssistantOpen} />);
-    const btn = screen.getByRole("button", { name: /open taOS Assistant/i });
+    const btn = screen.getByRole("button", { name: /open taOS agent/i });
     fireEvent.click(btn);
     expect(onAssistantOpen).toHaveBeenCalledOnce();
   });

--- a/desktop/src/components/TopBar.tsx
+++ b/desktop/src/components/TopBar.tsx
@@ -118,8 +118,8 @@ export function TopBar({ onSearchOpen, onAssistantOpen }: Props) {
       <button
         onClick={onAssistantOpen}
         className="ml-3 p-1 rounded hover:bg-shell-surface-hover transition-colors text-shell-text-secondary"
-        aria-label="Open taOS Assistant"
-        title="taOS Assistant"
+        aria-label="Open taOS agent"
+        title="taOS agent"
       >
         <Sparkles size={14} />
       </button>


### PR DESCRIPTION
Renames the user-facing name from "taOS Assistant" to "taOS agent" (the panel title, settings header, TopBar sparkles button aria-label/title, the message placeholder, and the Ctrl+/ shortcut label), plus the affected tests. Internal component and store names are unchanged. Part of the opencode taOS agent work (#588). Vitest (11) + build green.