### PR TITLE
feat(agents): run the taOS agent chat on opencode (#588 phase 3)

### DIFF
--- a/tests/test_opencode_adapter.py
+++ b/tests/test_opencode_adapter.py
@@ -544,3 +544,71 @@ class TestOpenCodeAdapterClose:
         adapter._client = fake
         await adapter.close()
         fake.aclose.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# OpenCodeConfig.system → prompt_async body
+# ---------------------------------------------------------------------------
+
+class TestSystemPromptBody:
+    """Assert that the system field is included in prompt_async when configured
+    and omitted when None."""
+
+    def _make_adapter_and_interceptor(self, system: str | None):
+        """Build an adapter with a fake HTTP client that captures the
+        prompt_async POST body.  Returns (adapter, captured_bodies list)."""
+        cfg = OpenCodeConfig(
+            base_url="http://127.0.0.1:5888",
+            model_provider_id="litellm",
+            model_id="gpt-4o",
+            system=system,
+        )
+        captured: list[dict] = []
+
+        sse_body = _build_sse_bytes(
+            {
+                "type": "session.idle",
+                "properties": {"sessionID": "ses_sys"},
+            }
+        )
+        stream_ctx = _FakeStreamResponse(sse_body)
+
+        session_resp = MagicMock()
+        session_resp.status_code = 200
+        session_resp.raise_for_status = MagicMock()
+        session_resp.json = MagicMock(return_value={"id": "ses_sys"})
+
+        async def fake_post(url, **kwargs):
+            if "prompt_async" in url:
+                captured.append(kwargs.get("json", {}))
+                resp = MagicMock()
+                resp.status_code = 204
+                return resp
+            return session_resp
+
+        fake_client = MagicMock()
+        fake_client.is_closed = False
+        fake_client.post = AsyncMock(side_effect=fake_post)
+        fake_client.stream = MagicMock(return_value=stream_ctx)
+        fake_client.aclose = AsyncMock()
+
+        async def fake_get_client():
+            return fake_client
+
+        adapter = OpenCodeAdapter(cfg, sink=lambda r: None)
+        adapter._get_client = fake_get_client  # type: ignore[method-assign]
+        return adapter, captured
+
+    @pytest.mark.asyncio
+    async def test_system_included_when_configured(self):
+        adapter, captured = self._make_adapter_and_interceptor("You are helpful.")
+        await adapter.prompt("hello")
+        assert len(captured) == 1
+        assert captured[0].get("system") == "You are helpful."
+
+    @pytest.mark.asyncio
+    async def test_system_omitted_when_none(self):
+        adapter, captured = self._make_adapter_and_interceptor(None)
+        await adapter.prompt("hello")
+        assert len(captured) == 1
+        assert "system" not in captured[0]

--- a/tests/test_taos_agent_chat.py
+++ b/tests/test_taos_agent_chat.py
@@ -252,7 +252,7 @@ async def test_ensure_server_uses_agent_key_when_available(tmp_path, monkeypatch
             spawned_cfgs.append(cfg)
             self._cfg = cfg
 
-        async def ensure_running(self):
+        async def ensure_running(self, **kwargs):
             pass
 
         async def stop(self):
@@ -300,7 +300,7 @@ async def test_ensure_server_falls_back_to_master_key(tmp_path, monkeypatch):
             spawned_cfgs.append(cfg)
             self._cfg = cfg
 
-        async def ensure_running(self):
+        async def ensure_running(self, **kwargs):
             pass
 
         @property

--- a/tests/test_taos_agent_chat.py
+++ b/tests/test_taos_agent_chat.py
@@ -1,0 +1,332 @@
+"""Tests for the rewired POST /api/taos-agent/chat endpoint (opencode backend).
+
+Uses the same client/app fixtures as the rest of the route tests.
+Adapters and ensure_taos_opencode_server are monkeypatched so no real
+opencode server or LiteLLM proxy is needed.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+import yaml
+from httpx import ASGITransport, AsyncClient
+
+from tinyagentos.app import create_app
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def tmp_data_dir(tmp_path):
+    config = {
+        "server": {"host": "0.0.0.0", "port": 6969},
+        "backends": [
+            {"name": "test-backend", "type": "rkllama", "url": "http://localhost:8080", "priority": 1}
+        ],
+        "qmd": {"url": "http://localhost:7832"},
+        "agents": [],
+        "metrics": {"poll_interval": 30, "retention_days": 30},
+    }
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.dump(config))
+    (tmp_path / ".setup_complete").touch()
+    return tmp_path
+
+
+@pytest.fixture
+def app(tmp_data_dir):
+    return create_app(data_dir=tmp_data_dir)
+
+
+@pytest_asyncio.fixture
+async def client(app):
+    ds = app.state.desktop_settings
+    if ds._db is not None:
+        await ds.close()
+    await ds.init()
+    app.state.auth.setup_user("admin", "Test Admin", "", "testpass")
+    record = app.state.auth.find_user("admin")
+    uid = record["id"] if record else ""
+    token = app.state.auth.create_session(user_id=uid, long_lived=True)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        cookies={"taos_session": token},
+    ) as c:
+        yield c
+    await ds.close()
+    await app.state.http_client.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _fake_server(base_url: str = "http://127.0.0.1:4188"):
+    """A minimal stand-in for OpenCodeServer that has a base_url."""
+    s = SimpleNamespace()
+    s.base_url = base_url
+    return s
+
+
+def _make_mock_proxy(running: bool = True):
+    proxy = MagicMock()
+    proxy.is_running.return_value = running
+    return proxy
+
+
+def _parse_ndjson(text: str) -> list[dict]:
+    """Parse all non-empty NDJSON lines from a response body."""
+    items = []
+    for line in text.splitlines():
+        line = line.strip()
+        if line:
+            items.append(json.loads(line))
+    return items
+
+
+# ---------------------------------------------------------------------------
+# Guard tests (400 / 503 before opencode is touched)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_chat_no_model_returns_400(client):
+    """POST /api/taos-agent/chat with no model configured → 400."""
+    resp = await client.post(
+        "/api/taos-agent/chat",
+        json={"messages": [{"role": "user", "content": "Hello"}]},
+    )
+    assert resp.status_code == 400
+    data = resp.json()
+    assert "model" in data.get("error", "").lower()
+
+
+@pytest.mark.asyncio
+async def test_chat_proxy_not_running_returns_503(client, app):
+    """POST /api/taos-agent/chat when proxy not running → 503."""
+    await client.patch("/api/taos-agent/settings", json={"model": "gpt-4o"})
+    app.state.llm_proxy = _make_mock_proxy(running=False)
+
+    resp = await client.post(
+        "/api/taos-agent/chat",
+        json={"messages": [{"role": "user", "content": "Hello"}]},
+    )
+    assert resp.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# Happy-path: two deltas then final → delta, delta, done
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_chat_happy_path_ndjson(client, app, monkeypatch):
+    """Two delta replies followed by a final reply → {delta}, {delta}, {done}."""
+    await client.patch("/api/taos-agent/settings", json={"model": "gpt-4o"})
+    app.state.llm_proxy = _make_mock_proxy(running=True)
+    app.state.taos_opencode_password = "testpw"
+    app.state.taos_opencode_session_id = None
+
+    server = _fake_server()
+
+    async def fake_ensure_server(state, model):
+        return server
+
+    monkeypatch.setattr(
+        "tinyagentos.routes.taos_agent.ensure_taos_opencode_server",
+        fake_ensure_server,
+    )
+
+    class _FakeAdapter:
+        def __init__(self, cfg, sink):
+            self._sink = sink
+            self.session_id = None
+
+        async def ensure_session(self):
+            self.session_id = "ses_happy"
+
+        async def prompt(self, text, trace_id=None):
+            self._sink({"kind": "delta", "content": "Hello"})
+            self._sink({"kind": "delta", "content": " world"})
+            self._sink({"kind": "final", "content": "Hello world"})
+
+        async def close(self):
+            pass
+
+    monkeypatch.setattr(
+        "tinyagentos.routes.taos_agent.OpenCodeAdapter",
+        _FakeAdapter,
+    )
+
+    resp = await client.post(
+        "/api/taos-agent/chat",
+        json={"messages": [{"role": "user", "content": "Hi"}]},
+    )
+    assert resp.status_code == 200
+    assert "application/x-ndjson" in resp.headers.get("content-type", "")
+
+    items = _parse_ndjson(resp.text)
+    delta_items = [i for i in items if "delta" in i]
+    assert len(delta_items) == 2
+    assert delta_items[0]["delta"] == "Hello"
+    assert delta_items[1]["delta"] == " world"
+    done_items = [i for i in items if i.get("done") is True]
+    assert len(done_items) == 1
+    # done must be the last item
+    assert items[-1] == {"done": True}
+
+
+# ---------------------------------------------------------------------------
+# Error path: adapter emits error → {error}, {done}
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_chat_error_path_ndjson(client, app, monkeypatch):
+    """Adapter emits an error reply → {error:...}, {done:true}."""
+    await client.patch("/api/taos-agent/settings", json={"model": "gpt-4o"})
+    app.state.llm_proxy = _make_mock_proxy(running=True)
+    app.state.taos_opencode_password = "testpw"
+    app.state.taos_opencode_session_id = None
+
+    server = _fake_server()
+
+    async def fake_ensure_server(state, model):
+        return server
+
+    monkeypatch.setattr(
+        "tinyagentos.routes.taos_agent.ensure_taos_opencode_server",
+        fake_ensure_server,
+    )
+
+    class _ErrorAdapter:
+        def __init__(self, cfg, sink):
+            self._sink = sink
+            self.session_id = None
+
+        async def ensure_session(self):
+            self.session_id = "ses_err"
+
+        async def prompt(self, text, trace_id=None):
+            self._sink({"kind": "error", "error": "boom"})
+
+        async def close(self):
+            pass
+
+    monkeypatch.setattr(
+        "tinyagentos.routes.taos_agent.OpenCodeAdapter",
+        _ErrorAdapter,
+    )
+
+    resp = await client.post(
+        "/api/taos-agent/chat",
+        json={"messages": [{"role": "user", "content": "Hi"}]},
+    )
+    assert resp.status_code == 200
+    items = _parse_ndjson(resp.text)
+    error_items = [i for i in items if "error" in i]
+    assert len(error_items) >= 1
+    assert error_items[0]["error"] == "boom"
+    assert items[-1] == {"done": True}
+
+
+# ---------------------------------------------------------------------------
+# ensure_taos_opencode_server: key minting and master-key fallback
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_ensure_server_uses_agent_key_when_available(tmp_path, monkeypatch):
+    """When create_agent_key returns a key, the server config uses that key."""
+    import tinyagentos.taos_agent_runtime as rt
+
+    spawned_cfgs: list = []
+
+    class _FakeServer:
+        def __init__(self, cfg):
+            spawned_cfgs.append(cfg)
+            self._cfg = cfg
+
+        async def ensure_running(self):
+            pass
+
+        async def stop(self):
+            pass
+
+        @property
+        def base_url(self):
+            return f"http://127.0.0.1:{self._cfg.port}"
+
+        def is_running(self):
+            return True
+
+    monkeypatch.setattr(rt, "OpenCodeServer", _FakeServer)
+
+    mock_proxy = MagicMock()
+    mock_proxy.create_agent_key = AsyncMock(return_value="sk-agent-key-123")
+    mock_proxy.is_running.return_value = True
+
+    state = SimpleNamespace(
+        data_dir=tmp_path,
+        llm_proxy=mock_proxy,
+        taos_opencode_password=None,
+        taos_opencode_server=None,
+        taos_opencode_model=None,
+        taos_opencode_session_id=None,
+    )
+
+    await rt.ensure_taos_opencode_server(state, "gpt-4o")
+
+    assert len(spawned_cfgs) == 1
+    assert spawned_cfgs[0].litellm_key == "sk-agent-key-123"
+    assert state.taos_opencode_key == "sk-agent-key-123"
+
+
+@pytest.mark.asyncio
+async def test_ensure_server_falls_back_to_master_key(tmp_path, monkeypatch):
+    """When create_agent_key returns None, the server falls back to the master key."""
+    import tinyagentos.taos_agent_runtime as rt
+    from tinyagentos.llm_proxy import TAOS_LITELLM_MASTER_KEY
+
+    spawned_cfgs: list = []
+
+    class _FakeServer:
+        def __init__(self, cfg):
+            spawned_cfgs.append(cfg)
+            self._cfg = cfg
+
+        async def ensure_running(self):
+            pass
+
+        @property
+        def base_url(self):
+            return f"http://127.0.0.1:{self._cfg.port}"
+
+        def is_running(self):
+            return True
+
+    monkeypatch.setattr(rt, "OpenCodeServer", _FakeServer)
+
+    mock_proxy = MagicMock()
+    mock_proxy.create_agent_key = AsyncMock(return_value=None)
+    mock_proxy.is_running.return_value = True
+
+    state = SimpleNamespace(
+        data_dir=tmp_path,
+        llm_proxy=mock_proxy,
+        taos_opencode_password=None,
+        taos_opencode_server=None,
+        taos_opencode_model=None,
+        taos_opencode_session_id=None,
+    )
+
+    await rt.ensure_taos_opencode_server(state, "gpt-4o")
+
+    assert len(spawned_cfgs) == 1
+    assert spawned_cfgs[0].litellm_key == TAOS_LITELLM_MASTER_KEY
+    assert state.taos_opencode_key == TAOS_LITELLM_MASTER_KEY

--- a/tinyagentos/adapters/opencode_adapter.py
+++ b/tinyagentos/adapters/opencode_adapter.py
@@ -312,15 +312,18 @@ class OpenCodeAdapter:
                 ),
             ) as stream:
                 # Now fire the async prompt.
+                prompt_body: dict = {
+                    "model": {
+                        "providerID": self._cfg.model_provider_id,
+                        "modelID": self._cfg.model_id,
+                    },
+                    "parts": [{"type": "text", "text": text}],
+                }
+                if self._cfg.system:
+                    prompt_body["system"] = self._cfg.system
                 prompt_resp = await client.post(
                     f"{self._base}/session/{self.session_id}/prompt_async",
-                    json={
-                        "model": {
-                            "providerID": self._cfg.model_provider_id,
-                            "modelID": self._cfg.model_id,
-                        },
-                        "parts": [{"type": "text", "text": text}],
-                    },
+                    json=prompt_body,
                 )
                 if prompt_resp.status_code not in (200, 204):
                     await _emit("error", {

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -932,6 +932,11 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
                 pass
         await cluster_manager.stop()
         llm_proxy.stop()
+        try:
+            from tinyagentos.taos_agent_runtime import stop_taos_opencode_server
+            await stop_taos_opencode_server(app.state)
+        except Exception:
+            logger.exception("taos opencode server stop failed")
         await monitor.stop()
         try:
             await auto_updater.stop()

--- a/tinyagentos/routes/taos_agent.py
+++ b/tinyagentos/routes/taos_agent.py
@@ -2,29 +2,34 @@
 
 GET  /api/taos-agent/settings  → {model: str | null}
 PATCH /api/taos-agent/settings → accepts {model: str}, persists via desktop_settings
-POST  /api/taos-agent/chat     → streams chat completion via LiteLLM proxy (NDJSON)
+POST  /api/taos-agent/chat     → streams chat completion via opencode (NDJSON)
 
 The system prompt is read from docs/taos-agent-manual.md at module import time.
 """
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
+import uuid
 from pathlib import Path
 
-import httpx
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel
 
-from tinyagentos.llm_proxy import TAOS_LITELLM_MASTER_KEY
+from tinyagentos.adapters.opencode_adapter import OpenCodeAdapter, OpenCodeConfig
+from tinyagentos.taos_agent_runtime import ensure_taos_opencode_server
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
 
 _PREF_NAMESPACE = "taos_agent"
-_LITELLM_URL = "http://localhost:4000"
 _MANUAL_PATH = Path(__file__).resolve().parent.parent.parent / "docs" / "taos-agent-manual.md"
+
+# Sentinel object placed on the queue to signal the stream is done.
+_DONE = object()
+
 
 # Read the system-prompt manual once at startup (or import time).
 # If the file is absent the assistant still works — it just won't have a
@@ -35,6 +40,7 @@ def _load_manual() -> str:
     except FileNotFoundError:
         logger.warning("taos-agent-manual.md not found at %s", _MANUAL_PATH)
         return ""
+
 
 SYSTEM_PROMPT: str = _load_manual()
 
@@ -65,7 +71,7 @@ async def patch_settings(request: Request, body: SettingsPatch):
 
 @router.post("/api/taos-agent/chat")
 async def chat(request: Request, body: ChatRequest):
-    """Stream a chat completion through the LiteLLM proxy.
+    """Stream a chat completion through a host opencode server.
 
     Returns NDJSON where each line is a JSON object with a ``delta`` string
     field, followed by a final ``{"done": true}`` line.  The frontend reads
@@ -80,12 +86,6 @@ async def chat(request: Request, body: ChatRequest):
             status_code=400,
         )
 
-    # Build the messages list: system prompt prepended, then user messages.
-    messages: list[dict] = []
-    if SYSTEM_PROMPT:
-        messages.append({"role": "system", "content": SYSTEM_PROMPT})
-    messages.extend(body.messages)
-
     llm_proxy = getattr(request.app.state, "llm_proxy", None)
     proxy_running = llm_proxy is not None and llm_proxy.is_running()
     if not proxy_running:
@@ -94,52 +94,86 @@ async def chat(request: Request, body: ChatRequest):
             status_code=503,
         )
 
-    payload = {
-        "model": model,
-        "messages": messages,
-        "stream": True,
-    }
+    # Ensure the host opencode server is running.
+    try:
+        server = await ensure_taos_opencode_server(request.app.state, model)
+    except Exception:
+        logger.exception("taos-agent: failed to start opencode server")
+        return JSONResponse(
+            {"error": "taOS agent runtime unavailable. Check that opencode is installed."},
+            status_code=503,
+        )
+
+    # Extract the latest user message text.
+    text = body.messages[-1].get("content", "") if body.messages else ""
+    if not text:
+        return JSONResponse({"error": "Empty message."}, status_code=400)
+
+    app_state = request.app.state
+    queue: asyncio.Queue = asyncio.Queue()
+
+    def sink(reply: dict) -> None:
+        """Map adapter reply dicts onto NDJSON queue items."""
+        kind = reply.get("kind")
+        if kind == "delta":
+            queue.put_nowait({"delta": reply.get("content", "")})
+        elif kind == "error":
+            queue.put_nowait({"error": reply.get("error", "error")})
+            queue.put_nowait(_DONE)
+        elif kind == "final":
+            # Text already arrived as deltas; final just signals completion.
+            queue.put_nowait(_DONE)
+        # reasoning / tool_call / tool_result — not rendered by the panel; ignore.
+
+    cfg = OpenCodeConfig(
+        base_url=server.base_url,
+        server_password=app_state.taos_opencode_password,
+        model_provider_id="litellm",
+        model_id=model,
+        system=SYSTEM_PROMPT or None,
+    )
+    adapter = OpenCodeAdapter(cfg, sink)
+    # Reuse the persistent session so opencode keeps conversation history.
+    adapter.session_id = getattr(app_state, "taos_opencode_session_id", None)
+
+    async def _drive() -> None:
+        """Run the opencode turn; always puts a done-sentinel when finished."""
+        try:
+            await adapter.ensure_session()
+            app_state.taos_opencode_session_id = adapter.session_id
+            trace_id = uuid.uuid4().hex
+            await adapter.prompt(text, trace_id=trace_id)
+            await adapter.close()
+        except Exception as exc:
+            logger.exception("taos-agent: drive task error")
+            queue.put_nowait({"error": str(exc)})
+        finally:
+            queue.put_nowait(_DONE)
+
+    drive_task = asyncio.create_task(_drive())
 
     async def _generate():
         try:
-            async with httpx.AsyncClient(timeout=120) as client:
-                async with client.stream(
-                    "POST",
-                    f"{_LITELLM_URL}/v1/chat/completions",
-                    json=payload,
-                    headers={
-                        "Authorization": f"Bearer {TAOS_LITELLM_MASTER_KEY}",
-                        "Content-Type": "application/json",
-                    },
-                ) as resp:
-                    if resp.status_code != 200:
-                        body_text = await resp.aread()
-                        error_msg = body_text.decode(errors="replace")[:500]
-                        yield json.dumps({"error": f"LLM proxy error {resp.status_code}: {error_msg}"}) + "\n"
-                        return
-
-                    async for line in resp.aiter_lines():
-                        if not line.startswith("data: "):
-                            continue
-                        data = line[6:]
-                        if data.strip() == "[DONE]":
-                            break
-                        try:
-                            chunk = json.loads(data)
-                        except json.JSONDecodeError:
-                            continue
-                        delta = (
-                            chunk.get("choices", [{}])[0]
-                            .get("delta", {})
-                            .get("content", "")
-                        )
-                        if delta:
-                            yield json.dumps({"delta": delta}) + "\n"
-        except httpx.ConnectError:
-            yield json.dumps({"error": "Cannot connect to LiteLLM proxy."}) + "\n"
+            while True:
+                item = await queue.get()
+                if item is _DONE:
+                    break
+                yield json.dumps(item) + "\n"
         except Exception as exc:
-            logger.exception("taos-agent chat error")
+            logger.exception("taos-agent: generator error")
             yield json.dumps({"error": str(exc)}) + "\n"
+        finally:
+            # Ensure the drive task is awaited so exceptions surface in logs.
+            if not drive_task.done():
+                drive_task.cancel()
+                try:
+                    await drive_task
+                except (asyncio.CancelledError, Exception):
+                    pass
+            elif not drive_task.cancelled():
+                exc = drive_task.exception()
+                if exc is not None:
+                    logger.error("taos-agent: drive task raised %r", exc)
         yield json.dumps({"done": True}) + "\n"
 
     return StreamingResponse(

--- a/tinyagentos/taos_agent_runtime.py
+++ b/tinyagentos/taos_agent_runtime.py
@@ -79,7 +79,10 @@ async def ensure_taos_opencode_server(app_state, model: str) -> OpenCodeServer:
             app_state.taos_opencode_session_id = None
 
     server = app_state.taos_opencode_server
-    await server.ensure_running()
+    # Generous deadline: opencode's first run on a fresh home performs a one-time
+    # SQLite migration that can take a couple of minutes; a short deadline would
+    # spuriously time out the very first taOS-agent chat.
+    await server.ensure_running(deadline_s=180.0)
     return server
 
 

--- a/tinyagentos/taos_agent_runtime.py
+++ b/tinyagentos/taos_agent_runtime.py
@@ -1,0 +1,100 @@
+"""taOS agent opencode server lifecycle helpers.
+
+Manages the single host opencode server used exclusively by the taOS assistant
+chat endpoint.  The server is started lazily on first chat request and kept
+alive for the process lifetime.  The persistent session id is stored on
+app.state so opencode remembers conversation history across requests.
+"""
+from __future__ import annotations
+
+import logging
+import secrets
+
+from tinyagentos.llm_proxy import TAOS_LITELLM_MASTER_KEY
+from tinyagentos.opencode_runtime import OpenCodeServer, OpenCodeServerConfig
+
+logger = logging.getLogger(__name__)
+
+TAOS_OPENCODE_PORT = 4188  # local-only port for the taOS agent opencode server
+
+
+async def ensure_taos_opencode_server(app_state, model: str) -> OpenCodeServer:
+    """Lazily create and start the taOS agent opencode server.
+
+    Stores the server on ``app_state.taos_opencode_server``.  If the model
+    changed since last start the old server is stopped and a new one is
+    created so the LiteLLM provider config and key scope track the chosen model.
+
+    Returns the running :class:`~tinyagentos.opencode_runtime.OpenCodeServer`.
+    """
+    # Generate a stable per-process password once.
+    if not getattr(app_state, "taos_opencode_password", None):
+        app_state.taos_opencode_password = secrets.token_hex(16)
+
+    existing: OpenCodeServer | None = getattr(app_state, "taos_opencode_server", None)
+    existing_model: str | None = getattr(app_state, "taos_opencode_model", None)
+
+    if existing is not None and existing_model != model:
+        # Model changed — stop old server so it picks up the new config.
+        logger.info(
+            "taos_agent_runtime: model changed (%s → %s); restarting opencode server",
+            existing_model, model,
+        )
+        try:
+            await existing.stop()
+        except Exception:
+            logger.debug("taos_agent_runtime: error stopping old server", exc_info=True)
+        app_state.taos_opencode_server = None
+        app_state.taos_opencode_session_id = None
+        existing = None
+
+    if existing is None:
+        # Mint the taOS agent's own LiteLLM virtual key.
+        llm_proxy = getattr(app_state, "llm_proxy", None)
+        litellm_key: str | None = None
+        if llm_proxy is not None:
+            try:
+                litellm_key = await llm_proxy.create_agent_key("taos-agent", models=[model])
+            except Exception:
+                logger.debug("taos_agent_runtime: create_agent_key failed", exc_info=True)
+        if not litellm_key:
+            litellm_key = TAOS_LITELLM_MASTER_KEY
+        app_state.taos_opencode_key = litellm_key
+
+        data_dir = getattr(app_state, "data_dir", None)
+        home = str(data_dir / "taos-agent-opencode") if data_dir else "taos-agent-opencode"
+
+        cfg = OpenCodeServerConfig(
+            home=home,
+            port=TAOS_OPENCODE_PORT,
+            server_password=app_state.taos_opencode_password,
+            litellm_base_url="http://127.0.0.1:4000/v1",
+            litellm_key=litellm_key,
+            model_ids=[model],
+        )
+        server = OpenCodeServer(cfg)
+        app_state.taos_opencode_server = server
+        app_state.taos_opencode_model = model
+        if not hasattr(app_state, "taos_opencode_session_id"):
+            app_state.taos_opencode_session_id = None
+
+    server = app_state.taos_opencode_server
+    await server.ensure_running()
+    return server
+
+
+async def stop_taos_opencode_server(app_state) -> None:
+    """Stop the taOS agent opencode server if it was started.
+
+    Safe to call even if the server was never created.
+    """
+    server = getattr(app_state, "taos_opencode_server", None)
+    if server is None:
+        return
+    try:
+        await server.stop()
+    except Exception:
+        logger.debug("taos_agent_runtime: error during stop", exc_info=True)
+    finally:
+        app_state.taos_opencode_server = None
+        app_state.taos_opencode_session_id = None


### PR DESCRIPTION
The keystone: `POST /api/taos-agent/chat` now runs on opencode instead of streaming LiteLLM directly. The taOS agent's panel works unchanged (same `{delta}`/`{error}`/`{done}` NDJSON contract).

## What
- **`taos_agent_runtime.py`** (new): `ensure_taos_opencode_server` lazily starts one host `OpenCodeServer` (under `data/taos-agent-opencode`, port 4188, a stable server password), configured with the taOS agent's **own LiteLLM key** (`create_agent_key("taos-agent", [model])`, master-key fallback in routing-only mode), reconfiguring when the model changes. `stop_taos_opencode_server` for teardown.
- **`routes/taos_agent.py`**: `chat` keeps the model/proxy guards, then drives the server via `OpenCodeAdapter` over a **persistent session** (`app.state.taos_opencode_session_id` — opencode keeps conversation history), with the system prompt from `taos-agent-manual.md`. A per-request queue + sink maps the adapter's reply kinds → the existing NDJSON; the drive runs as a concurrent task that always emits a done-sentinel (never hangs the stream).
- **`opencode_adapter.py`**: wires `OpenCodeConfig.system` into the `prompt_async` body.
- **`app.py`**: guarded `stop_taos_opencode_server` in lifespan teardown.

## Tests
`tests/test_taos_agent_chat.py` (7: 400/503 guards, happy-path NDJSON order, error path, own-key minting + master fallback) + adapter `system`-body tests. 47 green across the opencode suite.

## Validation
Adapter + runtime were already proven live on the Pi. This PR's end-to-end (server lifecycle + streaming + session) is being **validated live on the Pi** before merge.

Next (#588): surface the taOS agent as a configurable agent record in the Agents app (own key/model/permitted/persona).