### PR TITLE
feat(agents): configurable taOS agent system-card in the Agents app (#588 phase 4)

### DIFF
--- a/desktop/src/apps/AgentsApp.tsx
+++ b/desktop/src/apps/AgentsApp.tsx
@@ -14,6 +14,7 @@ import { AgentRow } from "./agents/AgentRow";
 import { AgentDetailPanel, type DetailTab } from "./agents/AgentDetailPanel";
 import { DeployWizard } from "./agents/DeployWizard";
 import { ArchivedAgentsPanel } from "./agents/ArchivedAgents";
+import { TaosAgentCard } from "@/components/TaosAgentCard";
 
 /* ------------------------------------------------------------------ */
 /*  AgentsApp (main)                                                   */
@@ -389,27 +390,35 @@ export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
             Loading agents...
           </div>
         ) : agents.length === 0 && archived.length === 0 ? (
-          <div className="flex flex-col items-center justify-center h-full gap-4 text-shell-text-tertiary">
-            <div className="w-20 h-20 rounded-2xl flex items-center justify-center"
-              style={{ background: "linear-gradient(135deg, rgba(139,146,163,0.15), rgba(91,97,112,0.08))" }}
-            >
-              <Bot size={36} className="text-accent/50" />
+          <div className="flex flex-col h-full min-h-0">
+            <div className="p-4">
+              <p className="text-xs font-medium text-shell-text-tertiary uppercase tracking-wider mb-2">System agent</p>
+              <TaosAgentCard />
             </div>
-            <div className="text-center">
-              <p className="text-base font-medium text-shell-text-secondary mb-1">No agents deployed yet</p>
-              <p className="text-xs text-shell-text-tertiary max-w-xs">Deploy your first AI agent to start automating tasks on your device.</p>
+            <div className="flex flex-col items-center justify-center flex-1 gap-4 text-shell-text-tertiary px-4 pb-8">
+              <div className="w-20 h-20 rounded-2xl flex items-center justify-center"
+                style={{ background: "linear-gradient(135deg, rgba(139,146,163,0.15), rgba(91,97,112,0.08))" }}
+              >
+                <Bot size={36} className="text-accent/50" />
+              </div>
+              <div className="text-center">
+                <p className="text-base font-medium text-shell-text-secondary mb-1">No agents deployed yet</p>
+                <p className="text-xs text-shell-text-tertiary max-w-xs">Deploy your first AI agent to start automating tasks on your device.</p>
+              </div>
+              <Button
+                onClick={() => setWizardOpen(true)}
+                className="text-white shadow-lg hover:shadow-xl hover:-translate-y-0.5 hover:brightness-110 border-0 mt-1"
+                style={{ background: "linear-gradient(135deg, #8b92a3, #5b6170)" }}
+              >
+                <Plus size={15} />
+                Deploy your first agent
+              </Button>
             </div>
-            <Button
-              onClick={() => setWizardOpen(true)}
-              className="text-white shadow-lg hover:shadow-xl hover:-translate-y-0.5 hover:brightness-110 border-0 mt-1"
-              style={{ background: "linear-gradient(135deg, #8b92a3, #5b6170)" }}
-            >
-              <Plus size={15} />
-              Deploy your first agent
-            </Button>
           </div>
         ) : agents.length === 0 ? (
           <div className="p-4">
+            <p className="text-xs font-medium text-shell-text-tertiary uppercase tracking-wider mb-2">System agent</p>
+            <TaosAgentCard />
             <ArchivedAgentsPanel
               archived={archived}
               onRestore={handleRestore}
@@ -418,6 +427,10 @@ export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
           </div>
         ) : (
           <div className="p-4">
+            {/* System agent — always shown above the deployed agents list */}
+            <p className="text-xs font-medium text-shell-text-tertiary uppercase tracking-wider mb-2">System agent</p>
+            <TaosAgentCard />
+
             {/* Disk quota notification cards */}
             {agents
               .filter((a) => diskStates[a.name] != null && diskStates[a.name]!.state !== "ok")

--- a/desktop/src/components/TaosAgentCard.tsx
+++ b/desktop/src/components/TaosAgentCard.tsx
@@ -1,0 +1,315 @@
+import { useEffect, useState } from "react";
+import { ModelPickerModal } from "@/components/ModelPickerModal";
+import type { AgentModel } from "@/components/ModelPickerFlow";
+import {
+  fetchTaosAgentConfig,
+  setTaosAgentModel,
+  setTaosAgentPermitted,
+  setTaosAgentPersona,
+  type TaosAgentConfig,
+} from "@/lib/taos-agent-api";
+
+export function TaosAgentCard() {
+  const [config, setConfig] = useState<TaosAgentConfig | null>(null);
+  const [loadErr, setLoadErr] = useState<string | null>(null);
+
+  // Model picker
+  const [models, setModels] = useState<AgentModel[]>([]);
+  const [modelsLoaded, setModelsLoaded] = useState(false);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [modelErr, setModelErr] = useState<string | null>(null);
+
+  // Permitted models
+  const [draftPermitted, setDraftPermitted] = useState<string[]>([]);
+  const [draftDirty, setDraftDirty] = useState(false);
+  const [addPickerOpen, setAddPickerOpen] = useState(false);
+  const [permittedSaving, setPermittedSaving] = useState(false);
+  const [permittedErr, setPermittedErr] = useState<string | null>(null);
+
+  // Persona
+  const [draftPersona, setDraftPersona] = useState("");
+  const [personaDirty, setPersonaDirty] = useState(false);
+  const [personaSaving, setPersonaSaving] = useState(false);
+  const [personaErr, setPersonaErr] = useState<string | null>(null);
+
+  async function load() {
+    try {
+      const cfg = await fetchTaosAgentConfig();
+      setConfig(cfg);
+      setDraftPermitted(cfg.permitted_models);
+      setDraftPersona(cfg.persona);
+      setDraftDirty(false);
+      setPersonaDirty(false);
+      setLoadErr(null);
+    } catch (e: any) {
+      setLoadErr(String(e?.message ?? e));
+    }
+  }
+
+  useEffect(() => { load(); }, []);
+
+  async function ensureModelsLoaded() {
+    if (modelsLoaded) return;
+    try {
+      const res = await fetch("/api/providers/models?refresh=true", {
+        headers: { Accept: "application/json" },
+      });
+      const data = res.ok ? await res.json() : { data: [] };
+      setModels((data.data ?? []).map((m: { id: string }) => ({
+        id: m.id, name: m.id, hostKind: "cloud" as const,
+      })));
+    } catch { /* leave empty */ }
+    finally { setModelsLoaded(true); }
+  }
+
+  async function openPicker() {
+    setPickerOpen(true);
+    await ensureModelsLoaded();
+  }
+
+  async function openAddPicker() {
+    setAddPickerOpen(true);
+    await ensureModelsLoaded();
+  }
+
+  async function changeModel(modelId: string) {
+    setModelErr(null);
+    try {
+      await setTaosAgentModel(modelId);
+      setConfig((prev) => prev ? { ...prev, model: modelId } : prev);
+      setPickerOpen(false);
+    } catch (e: any) {
+      setModelErr(String(e?.message ?? e));
+    }
+  }
+
+  function addToPermitted(modelId: string) {
+    if (draftPermitted.includes(modelId)) return;
+    setDraftPermitted([...draftPermitted, modelId]);
+    setDraftDirty(true);
+    setAddPickerOpen(false);
+  }
+
+  function removeFromPermitted(modelId: string) {
+    // Cannot remove the current primary model.
+    if (modelId === config?.model) return;
+    setDraftPermitted(draftPermitted.filter((m) => m !== modelId));
+    setDraftDirty(true);
+  }
+
+  async function savePermitted() {
+    setPermittedSaving(true);
+    setPermittedErr(null);
+    try {
+      const data = await setTaosAgentPermitted(draftPermitted);
+      setDraftPermitted(data.permitted_models);
+      setDraftDirty(false);
+    } catch (e: any) {
+      setPermittedErr(String(e?.message ?? e));
+    } finally {
+      setPermittedSaving(false);
+    }
+  }
+
+  async function savePersona() {
+    setPersonaSaving(true);
+    setPersonaErr(null);
+    try {
+      const data = await setTaosAgentPersona(draftPersona);
+      setConfig((prev) => prev ? { ...prev, persona: data.persona } : prev);
+      setPersonaDirty(false);
+    } catch (e: any) {
+      setPersonaErr(String(e?.message ?? e));
+    } finally {
+      setPersonaSaving(false);
+    }
+  }
+
+  if (loadErr) {
+    return (
+      <div
+        className="rounded-lg border border-white/10 bg-white/5 p-4 mb-3"
+        role="alert"
+        aria-label="taOS agent config error"
+      >
+        <p className="text-xs text-red-400">Failed to load taOS agent config: {loadErr}</p>
+      </div>
+    );
+  }
+
+  if (!config) {
+    return (
+      <div className="rounded-lg border border-white/10 bg-white/5 p-4 mb-3 animate-pulse">
+        <div className="h-3 w-40 bg-white/10 rounded" aria-label="Loading taOS agent" />
+      </div>
+    );
+  }
+
+  const currentModel = config.model;
+
+  return (
+    <section
+      className="rounded-lg border border-white/10 bg-white/5 p-4 mb-3"
+      aria-label="taOS agent system card"
+    >
+      {/* Header */}
+      <div className="flex items-center gap-2 mb-3 flex-wrap">
+        <span className="text-sm font-semibold">taOS agent</span>
+        <span
+          className="bg-indigo-600/40 text-indigo-200 px-2 py-0.5 rounded text-[10px] leading-none"
+          aria-label="Framework: opencode"
+        >
+          opencode
+        </span>
+        <span
+          className="bg-amber-600/40 text-amber-200 px-2 py-0.5 rounded text-[10px] leading-none"
+          aria-label="System agent"
+        >
+          System
+        </span>
+        <span className="text-xs text-shell-text-tertiary ml-auto">Host-resident</span>
+      </div>
+
+      {/* API key (read-only) */}
+      {config.key_masked && (
+        <div className="flex items-center gap-2 mb-3">
+          <span className="opacity-60 text-xs">API key</span>
+          <code
+            className="text-xs bg-white/5 px-2 py-0.5 rounded"
+            aria-label="Masked API key"
+          >
+            {config.key_masked}
+          </code>
+        </div>
+      )}
+
+      {/* Model */}
+      <div className="flex items-center gap-2 flex-wrap mb-1">
+        <span className="opacity-60 text-sm">Model</span>
+        <code className="text-sm">{currentModel || "(not set)"}</code>
+        <button
+          onClick={openPicker}
+          aria-label="Change taOS agent model"
+          className="bg-white/10 hover:bg-white/15 px-2.5 py-1 rounded text-xs"
+        >
+          Change model
+        </button>
+      </div>
+      {modelErr && <div className="text-xs text-red-400 mb-2">{modelErr}</div>}
+
+      {/* Permitted models */}
+      <section className="mt-3" aria-label="Permitted models">
+        <div className="flex items-center gap-2 mb-2">
+          <span className="opacity-60 text-sm">Permitted models</span>
+          <button
+            onClick={openAddPicker}
+            aria-label="Add a permitted model for taOS agent"
+            className="bg-white/10 hover:bg-white/15 px-2.5 py-1 rounded text-xs"
+          >
+            + Add
+          </button>
+        </div>
+
+        {draftPermitted.length === 0 ? (
+          <p className="text-xs opacity-50">No models in the permitted set yet.</p>
+        ) : (
+          <ul className="flex flex-wrap gap-2" aria-label="Permitted model chips">
+            {draftPermitted.map((m) => {
+              const isCurrent = m === currentModel;
+              return (
+                <li
+                  key={m}
+                  className="flex items-center gap-1.5 bg-white/10 rounded px-2 py-0.5 text-xs"
+                >
+                  <code>{m}</code>
+                  {isCurrent && (
+                    <span
+                      className="bg-blue-600/50 text-blue-200 px-1.5 py-0.5 rounded text-[10px] leading-none"
+                      aria-label="current primary model"
+                    >
+                      current
+                    </span>
+                  )}
+                  <button
+                    onClick={() => removeFromPermitted(m)}
+                    disabled={isCurrent}
+                    aria-label={
+                      isCurrent
+                        ? `Cannot remove current model ${m}`
+                        : `Remove ${m} from taOS agent permitted models`
+                    }
+                    className="opacity-60 hover:opacity-100 disabled:opacity-20 disabled:cursor-not-allowed leading-none"
+                  >
+                    ×
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+
+        {permittedErr && <div className="text-xs text-red-400 mt-2">{permittedErr}</div>}
+
+        {draftDirty && (
+          <button
+            onClick={savePermitted}
+            disabled={permittedSaving}
+            aria-label="Save taOS agent permitted models"
+            aria-busy={permittedSaving}
+            className="mt-2 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 px-3 py-1.5 rounded text-xs"
+          >
+            {permittedSaving ? "Saving…" : "Save"}
+          </button>
+        )}
+      </section>
+
+      {/* Persona (system-prompt override) */}
+      <section className="mt-3" aria-label="Persona override">
+        <div className="flex items-center gap-2 mb-1">
+          <span className="opacity-60 text-sm">Persona</span>
+        </div>
+        <textarea
+          value={draftPersona}
+          onChange={(e) => {
+            setDraftPersona(e.target.value);
+            setPersonaDirty(e.target.value !== (config.persona ?? ""));
+          }}
+          rows={4}
+          aria-label="taOS agent persona — system-prompt override"
+          placeholder="Leave empty to use the built-in manual as the system prompt."
+          className="w-full bg-white/5 border border-white/10 rounded px-3 py-2 text-xs resize-y focus:outline-none focus:border-white/25"
+        />
+        {personaErr && <div className="text-xs text-red-400 mt-1">{personaErr}</div>}
+        {personaDirty && (
+          <button
+            onClick={savePersona}
+            disabled={personaSaving}
+            aria-label="Save taOS agent persona"
+            aria-busy={personaSaving}
+            className="mt-2 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 px-3 py-1.5 rounded text-xs"
+          >
+            {personaSaving ? "Saving…" : "Save"}
+          </button>
+        )}
+      </section>
+
+      {/* Model picker modals */}
+      <ModelPickerModal
+        open={pickerOpen}
+        onClose={() => setPickerOpen(false)}
+        models={models}
+        modelsLoaded={modelsLoaded}
+        onSelect={(modelId) => changeModel(modelId)}
+        title="Change model"
+      />
+      <ModelPickerModal
+        open={addPickerOpen}
+        onClose={() => setAddPickerOpen(false)}
+        models={models}
+        modelsLoaded={modelsLoaded}
+        onSelect={(modelId) => addToPermitted(modelId)}
+        title="Add permitted model"
+      />
+    </section>
+  );
+}

--- a/desktop/src/components/__tests__/TaosAgentCard.test.tsx
+++ b/desktop/src/components/__tests__/TaosAgentCard.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { TaosAgentCard } from "../TaosAgentCard";
+
+// Mock the taos-agent-api helpers
+vi.mock("@/lib/taos-agent-api", () => ({
+  fetchTaosAgentConfig: vi.fn(),
+  setTaosAgentModel: vi.fn(),
+  setTaosAgentPermitted: vi.fn(),
+  setTaosAgentPersona: vi.fn(),
+}));
+
+// Mock ModelPickerModal — it is always closed in these tests
+vi.mock("@/components/ModelPickerModal", () => ({
+  ModelPickerModal: () => null,
+}));
+
+import {
+  fetchTaosAgentConfig,
+  setTaosAgentPermitted,
+} from "@/lib/taos-agent-api";
+
+const BASE_CONFIG = {
+  model: "ollama/llama3",
+  permitted_models: ["ollama/llama3", "ollama/qwen3"],
+  persona: "",
+  key_masked: "sk-age\u2026key1",
+  framework: "opencode" as const,
+  system: true as const,
+};
+
+describe("<TaosAgentCard />", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fetchTaosAgentConfig).mockResolvedValue({ ...BASE_CONFIG });
+  });
+
+  it("renders title, framework pill, and system badge", async () => {
+    render(<TaosAgentCard />);
+    await waitFor(() => expect(screen.getByText("taOS agent")).toBeInTheDocument());
+    expect(screen.getByText("opencode")).toBeInTheDocument();
+    expect(screen.getByText("System")).toBeInTheDocument();
+  });
+
+  it("renders current model from config", async () => {
+    render(<TaosAgentCard />);
+    // Wait for the card to load — the model appears in both the model row and chips,
+    // so use getAllByText and assert at least one instance.
+    await waitFor(() => {
+      const matches = screen.getAllByText("ollama/llama3");
+      expect(matches.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("renders the masked key", async () => {
+    render(<TaosAgentCard />);
+    await waitFor(() => expect(screen.getByLabelText("Masked API key")).toBeInTheDocument());
+  });
+
+  it("renders permitted model chips", async () => {
+    render(<TaosAgentCard />);
+    await waitFor(() => {
+      // qwen3 only appears in the chips section — unambiguous
+      expect(screen.getByText("ollama/qwen3")).toBeInTheDocument();
+    });
+    // llama3 appears at least once (chip)
+    expect(screen.getAllByText("ollama/llama3").length).toBeGreaterThan(0);
+  });
+
+  it("remove button is disabled on current model chip", async () => {
+    render(<TaosAgentCard />);
+    await waitFor(() =>
+      expect(screen.getByLabelText("Cannot remove current model ollama/llama3")).toBeInTheDocument()
+    );
+    const removeBtn = screen.getByLabelText("Cannot remove current model ollama/llama3");
+    expect(removeBtn).toBeDisabled();
+  });
+
+  it("remove button is enabled for non-current models", async () => {
+    render(<TaosAgentCard />);
+    await waitFor(() =>
+      expect(screen.getByLabelText("Remove ollama/qwen3 from taOS agent permitted models")).toBeInTheDocument()
+    );
+    const removeBtn = screen.getByLabelText("Remove ollama/qwen3 from taOS agent permitted models");
+    expect(removeBtn).not.toBeDisabled();
+  });
+
+  it("removing a chip marks draft dirty and shows Save button", async () => {
+    render(<TaosAgentCard />);
+    await waitFor(() =>
+      expect(screen.getByLabelText("Remove ollama/qwen3 from taOS agent permitted models")).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByLabelText("Remove ollama/qwen3 from taOS agent permitted models"));
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("Save taOS agent permitted models")).toBeInTheDocument()
+    );
+  });
+
+  it("clicking Save calls setTaosAgentPermitted with remaining models", async () => {
+    vi.mocked(setTaosAgentPermitted).mockResolvedValue({
+      permitted_models: ["ollama/llama3"],
+      key_rescoped: true,
+    });
+
+    render(<TaosAgentCard />);
+    await waitFor(() =>
+      expect(screen.getByLabelText("Remove ollama/qwen3 from taOS agent permitted models")).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByLabelText("Remove ollama/qwen3 from taOS agent permitted models"));
+    await waitFor(() =>
+      expect(screen.getByLabelText("Save taOS agent permitted models")).toBeInTheDocument()
+    );
+    fireEvent.click(screen.getByLabelText("Save taOS agent permitted models"));
+
+    await waitFor(() =>
+      expect(setTaosAgentPermitted).toHaveBeenCalledWith(["ollama/llama3"])
+    );
+  });
+
+  it("renders host-resident note", async () => {
+    render(<TaosAgentCard />);
+    await waitFor(() => expect(screen.getByText(/host-resident/i)).toBeInTheDocument());
+  });
+
+  it("renders error state when fetch fails", async () => {
+    vi.mocked(fetchTaosAgentConfig).mockRejectedValue(new Error("Network error"));
+    render(<TaosAgentCard />);
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toBeInTheDocument()
+    );
+    expect(screen.getByText(/network error/i)).toBeInTheDocument();
+  });
+});

--- a/desktop/src/lib/taos-agent-api.ts
+++ b/desktop/src/lib/taos-agent-api.ts
@@ -1,0 +1,51 @@
+/**
+ * API helpers for the taOS system agent configuration endpoints.
+ */
+
+export interface TaosAgentConfig {
+  model: string | null;
+  permitted_models: string[];
+  persona: string;
+  key_masked: string | null;
+  framework: "opencode";
+  system: true;
+}
+
+async function _request(url: string, method: string, body?: unknown): Promise<unknown> {
+  const res = await fetch(url, {
+    method,
+    headers: body !== undefined ? { "Content-Type": "application/json" } : undefined,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) {
+    let detail = `Request failed (${res.status})`;
+    try {
+      const err = await res.json();
+      if (err?.error) detail = String(err.error);
+      else if (err?.detail) detail = String(err.detail);
+    } catch { /* ignore */ }
+    throw new Error(detail);
+  }
+  return res.json();
+}
+
+export async function fetchTaosAgentConfig(): Promise<TaosAgentConfig> {
+  return _request("/api/taos-agent/config", "GET") as Promise<TaosAgentConfig>;
+}
+
+export async function setTaosAgentModel(model: string): Promise<{ model: string }> {
+  return _request("/api/taos-agent/settings", "PATCH", { model }) as Promise<{ model: string }>;
+}
+
+export async function setTaosAgentPermitted(
+  models: string[],
+): Promise<{ permitted_models: string[]; key_rescoped: boolean }> {
+  return _request("/api/taos-agent/permitted-models", "PUT", { models }) as Promise<{
+    permitted_models: string[];
+    key_rescoped: boolean;
+  }>;
+}
+
+export async function setTaosAgentPersona(persona: string): Promise<{ persona: string }> {
+  return _request("/api/taos-agent/persona", "PUT", { persona }) as Promise<{ persona: string }>;
+}

--- a/tests/test_taos_agent_config.py
+++ b/tests/test_taos_agent_config.py
@@ -1,0 +1,281 @@
+"""Tests for GET /api/taos-agent/config and PUT permitted-models / persona endpoints."""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+import yaml
+from httpx import ASGITransport, AsyncClient
+
+from tinyagentos.app import create_app
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — own fixtures with desktop_settings initialised
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def tmp_data_dir(tmp_path):
+    config = {
+        "server": {"host": "0.0.0.0", "port": 6969},
+        "backends": [
+            {"name": "test-backend", "type": "rkllama", "url": "http://localhost:8080", "priority": 1}
+        ],
+        "qmd": {"url": "http://localhost:7832"},
+        "agents": [],
+        "metrics": {"poll_interval": 30, "retention_days": 30},
+    }
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.dump(config))
+    (tmp_path / ".setup_complete").touch()
+    return tmp_path
+
+
+@pytest.fixture
+def app(tmp_data_dir):
+    return create_app(data_dir=tmp_data_dir)
+
+
+@pytest_asyncio.fixture
+async def client(app):
+    ds = app.state.desktop_settings
+    if ds._db is not None:
+        await ds.close()
+    await ds.init()
+    app.state.auth.setup_user("admin", "Test Admin", "", "testpass")
+    record = app.state.auth.find_user("admin")
+    uid = record["id"] if record else ""
+    token = app.state.auth.create_session(user_id=uid, long_lived=True)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        cookies={"taos_session": token},
+    ) as c:
+        yield c
+    await ds.close()
+    await app.state.http_client.aclose()
+
+
+# ---------------------------------------------------------------------------
+# GET /api/taos-agent/config
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestGetConfig:
+    async def test_returns_shape(self, client):
+        """GET /api/taos-agent/config returns all required fields."""
+        resp = await client.get("/api/taos-agent/config")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["framework"] == "opencode"
+        assert data["system"] is True
+        assert "model" in data
+        assert "permitted_models" in data
+        assert "persona" in data
+        assert "key_masked" in data
+
+    async def test_returns_persisted_model(self, client, app):
+        """model field reflects whatever PATCH /settings stored."""
+        await client.patch("/api/taos-agent/settings", json={"model": "ollama/llama3"})
+        resp = await client.get("/api/taos-agent/config")
+        assert resp.status_code == 200
+        assert resp.json()["model"] == "ollama/llama3"
+
+    async def test_key_masked_null_when_not_provisioned(self, client, app):
+        """key_masked is null when no key has been minted yet."""
+        if hasattr(app.state, "taos_opencode_key"):
+            del app.state.taos_opencode_key
+        resp = await client.get("/api/taos-agent/config")
+        assert resp.status_code == 200
+        assert resp.json()["key_masked"] is None
+
+    async def test_key_masked_format(self, client, app):
+        """key_masked shows first 6 + ellipsis + last 4 of the key."""
+        app.state.taos_opencode_key = "sk-agent-very-long-secret-key-1234"
+        resp = await client.get("/api/taos-agent/config")
+        assert resp.status_code == 200
+        masked = resp.json()["key_masked"]
+        assert masked is not None
+        assert masked.startswith("sk-age")
+        assert masked.endswith("1234")
+        assert "\u2026" in masked or "..." in masked or "\xe2\x80\xa6" in masked or "\u2026" in repr(masked) or "…" in masked
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/taos-agent/permitted-models
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestPutPermittedModels:
+    async def _set_model(self, client, model: str):
+        resp = await client.patch("/api/taos-agent/settings", json={"model": model})
+        assert resp.status_code == 200
+
+    async def test_empty_list_returns_400(self, client):
+        resp = await client.put("/api/taos-agent/permitted-models", json={"models": []})
+        assert resp.status_code == 400
+        assert "empty" in resp.json().get("error", "").lower()
+
+    async def test_unreachable_model_returns_409(self, client, monkeypatch):
+        """A model not found in the cluster -> 409."""
+        from types import SimpleNamespace
+
+        def _not_found(request, model_id):
+            return SimpleNamespace(kind="not_found")
+
+        monkeypatch.setattr(
+            "tinyagentos.cluster.model_resolver.resolve_model_location",
+            _not_found,
+        )
+        resp = await client.put(
+            "/api/taos-agent/permitted-models",
+            json={"models": ["ghost/model"]},
+        )
+        assert resp.status_code == 409
+        assert "ghost/model" in resp.json().get("error", "")
+
+    async def test_current_model_always_included(self, client, monkeypatch):
+        """The current primary model is prepended if missing from the requested set."""
+        from types import SimpleNamespace
+
+        await self._set_model(client, "ollama/primary")
+
+        def _reachable(request, model_id):
+            return SimpleNamespace(kind="local")
+
+        monkeypatch.setattr(
+            "tinyagentos.cluster.model_resolver.resolve_model_location",
+            _reachable,
+        )
+
+        resp = await client.put(
+            "/api/taos-agent/permitted-models",
+            json={"models": ["ollama/extra"]},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "ollama/primary" in data["permitted_models"]
+        assert "ollama/extra" in data["permitted_models"]
+
+    async def test_key_rescoped_via_proxy(self, client, app, monkeypatch):
+        """If llm_proxy + taos_opencode_key are set, update_agent_key is called."""
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock, MagicMock
+
+        await self._set_model(client, "ollama/m1")
+        app.state.taos_opencode_key = "sk-existing-key-0001"
+
+        mock_proxy = MagicMock()
+        mock_proxy.update_agent_key = AsyncMock(return_value=True)
+        app.state.llm_proxy = mock_proxy
+
+        def _reachable(request, model_id):
+            return SimpleNamespace(kind="local")
+
+        monkeypatch.setattr(
+            "tinyagentos.cluster.model_resolver.resolve_model_location",
+            _reachable,
+        )
+
+        resp = await client.put(
+            "/api/taos-agent/permitted-models",
+            json={"models": ["ollama/m1", "ollama/m2"]},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["key_rescoped"] is True
+        mock_proxy.update_agent_key.assert_called_once()
+        call_key = mock_proxy.update_agent_key.call_args.args[0]
+        assert call_key == "sk-existing-key-0001"
+
+    async def test_persists_permitted_models(self, client, monkeypatch):
+        """permitted_models shows up in subsequent GET /config."""
+        from types import SimpleNamespace
+
+        await self._set_model(client, "ollama/main")
+
+        def _reachable(request, model_id):
+            return SimpleNamespace(kind="local")
+
+        monkeypatch.setattr(
+            "tinyagentos.cluster.model_resolver.resolve_model_location",
+            _reachable,
+        )
+
+        await client.put(
+            "/api/taos-agent/permitted-models",
+            json={"models": ["ollama/main", "ollama/alt"]},
+        )
+
+        resp = await client.get("/api/taos-agent/config")
+        assert resp.status_code == 200
+        permitted = resp.json()["permitted_models"]
+        assert "ollama/main" in permitted
+        assert "ollama/alt" in permitted
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/taos-agent/persona
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestPutPersona:
+    async def test_persona_persists(self, client):
+        """PUT /api/taos-agent/persona stores the persona and GET /config reflects it."""
+        resp = await client.put(
+            "/api/taos-agent/persona",
+            json={"persona": "You are a pirate."},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["persona"] == "You are a pirate."
+
+        config_resp = await client.get("/api/taos-agent/config")
+        assert config_resp.status_code == 200
+        assert config_resp.json()["persona"] == "You are a pirate."
+
+    async def test_empty_persona_clears(self, client):
+        """Empty string persona is accepted (clears override — falls back to manual)."""
+        await client.put("/api/taos-agent/persona", json={"persona": "some override"})
+        resp = await client.put("/api/taos-agent/persona", json={"persona": ""})
+        assert resp.status_code == 200
+        assert resp.json()["persona"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Admin gate
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestAdminGate:
+    async def test_put_permitted_models_forbidden_for_non_admin(self, client, app):
+        """PUT /api/taos-agent/permitted-models -> 403 for a non-admin session."""
+        app.state.auth.session_user = lambda token: {"is_admin": False, "username": "guest"}
+        resp = await client.put(
+            "/api/taos-agent/permitted-models",
+            json={"models": ["ollama/m1"]},
+        )
+        assert resp.status_code == 403
+
+    async def test_put_persona_forbidden_for_non_admin(self, client, app):
+        """PUT /api/taos-agent/persona -> 403 for a non-admin session."""
+        app.state.auth.session_user = lambda token: {"is_admin": False, "username": "guest"}
+        resp = await client.put(
+            "/api/taos-agent/persona",
+            json={"persona": "Hacked!"},
+        )
+        assert resp.status_code == 403
+
+    async def test_patch_settings_forbidden_for_non_admin(self, client, app):
+        """PATCH /api/taos-agent/settings -> 403 for a non-admin session."""
+        app.state.auth.session_user = lambda token: {"is_admin": False, "username": "guest"}
+        resp = await client.patch(
+            "/api/taos-agent/settings",
+            json={"model": "ollama/hacked"},
+        )
+        assert resp.status_code == 403
+
+    async def test_get_config_open_for_non_admin(self, client, app):
+        """GET /api/taos-agent/config is open — no admin required."""
+        app.state.auth.session_user = lambda token: {"is_admin": False, "username": "guest"}
+        resp = await client.get("/api/taos-agent/config")
+        assert resp.status_code == 200

--- a/tinyagentos/routes/taos_agent.py
+++ b/tinyagentos/routes/taos_agent.py
@@ -1,10 +1,14 @@
-"""taOS Assistant — settings and chat completion endpoint.
+"""taOS Assistant — settings, config and chat completion endpoint.
 
-GET  /api/taos-agent/settings  → {model: str | null}
-PATCH /api/taos-agent/settings → accepts {model: str}, persists via desktop_settings
-POST  /api/taos-agent/chat     → streams chat completion via opencode (NDJSON)
+GET  /api/taos-agent/settings          → {model: str | null}
+PATCH /api/taos-agent/settings         → accepts {model: str}, persists via desktop_settings
+GET  /api/taos-agent/config            → {model, permitted_models, persona, key_masked, framework, system}
+PUT  /api/taos-agent/permitted-models  → validate + persist permitted_models; re-scope the agent key
+PUT  /api/taos-agent/persona           → persist persona (system-prompt override)
+POST /api/taos-agent/chat              → streams chat completion via opencode (NDJSON)
 
 The system prompt is read from docs/taos-agent-manual.md at module import time.
+When a persona is set via PUT /api/taos-agent/persona it is used instead.
 """
 from __future__ import annotations
 
@@ -45,8 +49,23 @@ def _load_manual() -> str:
 SYSTEM_PROMPT: str = _load_manual()
 
 
+def _mask_key(key: str | None) -> str | None:
+    """Return a masked form of a LiteLLM key (first 6 + … + last 4), or None."""
+    if not key or len(key) < 12:
+        return key or None
+    return key[:6] + "…" + key[-4:]
+
+
 class SettingsPatch(BaseModel):
     model: str
+
+
+class PermittedModelsUpdate(BaseModel):
+    models: list[str]
+
+
+class PersonaUpdate(BaseModel):
+    persona: str
 
 
 class ChatRequest(BaseModel):
@@ -62,11 +81,98 @@ async def get_settings(request: Request):
 
 @router.patch("/api/taos-agent/settings")
 async def patch_settings(request: Request, body: SettingsPatch):
+    from tinyagentos.routes.auth import _require_admin
+    ok, err = _require_admin(request)
+    if not ok:
+        return err
+
     store = request.app.state.desktop_settings
     prefs = await store.get_preference("user", _PREF_NAMESPACE)
     prefs["model"] = body.model
     await store.save_preference("user", _PREF_NAMESPACE, prefs)
     return JSONResponse({"model": body.model})
+
+
+@router.get("/api/taos-agent/config")
+async def get_config(request: Request):
+    """Return the full taOS agent configuration (model, permitted_models, persona, key)."""
+    store = request.app.state.desktop_settings
+    prefs = await store.get_preference("user", _PREF_NAMESPACE)
+
+    raw_key: str | None = getattr(request.app.state, "taos_opencode_key", None)
+
+    return JSONResponse({
+        "model": prefs.get("model", None),
+        "permitted_models": prefs.get("permitted_models", []),
+        "persona": prefs.get("persona", ""),
+        "key_masked": _mask_key(raw_key),
+        "framework": "opencode",
+        "system": True,
+    })
+
+
+@router.put("/api/taos-agent/permitted-models")
+async def put_permitted_models(request: Request, body: PermittedModelsUpdate):
+    """Set the taOS agent's permitted model set and re-scope its LiteLLM key."""
+    from tinyagentos.routes.auth import _require_admin
+    ok, err = _require_admin(request)
+    if not ok:
+        return err
+
+    if not body.models:
+        return JSONResponse({"error": "models must not be empty"}, status_code=400)
+
+    store = request.app.state.desktop_settings
+    prefs = await store.get_preference("user", _PREF_NAMESPACE)
+    current_model: str | None = prefs.get("model")
+
+    # Build final set — always include the current primary model.
+    permitted = list(body.models)
+    if current_model and current_model not in permitted:
+        permitted = [current_model, *permitted]
+
+    # Validate every model is reachable.
+    from tinyagentos.cluster.model_resolver import resolve_model_location
+    for model_id in permitted:
+        location = resolve_model_location(request, model_id)
+        if location.kind == "not_found":
+            return JSONResponse(
+                {
+                    "error": f"model '{model_id}' is not reachable anywhere in the cluster right now.",
+                    "model": model_id,
+                },
+                status_code=409,
+            )
+
+    prefs["permitted_models"] = permitted
+    await store.save_preference("user", _PREF_NAMESPACE, prefs)
+
+    # Re-scope the agent's own LiteLLM key.
+    proxy = getattr(request.app.state, "llm_proxy", None)
+    key: str | None = getattr(request.app.state, "taos_opencode_key", None)
+    key_rescoped = False
+    if proxy is not None and key:
+        try:
+            key_rescoped = await proxy.update_agent_key(key, permitted)
+        except Exception:
+            logger.exception("taos-agent: re-scoping key after permitted-models update failed")
+
+    return JSONResponse({"permitted_models": permitted, "key_rescoped": key_rescoped})
+
+
+@router.put("/api/taos-agent/persona")
+async def put_persona(request: Request, body: PersonaUpdate):
+    """Persist a system-prompt override for the taOS agent."""
+    from tinyagentos.routes.auth import _require_admin
+    ok, err = _require_admin(request)
+    if not ok:
+        return err
+
+    store = request.app.state.desktop_settings
+    prefs = await store.get_preference("user", _PREF_NAMESPACE)
+    prefs["persona"] = body.persona
+    await store.save_preference("user", _PREF_NAMESPACE, prefs)
+    return JSONResponse({"persona": body.persona})
 
 
 @router.post("/api/taos-agent/chat")
@@ -110,6 +216,11 @@ async def chat(request: Request, body: ChatRequest):
         return JSONResponse({"error": "Empty message."}, status_code=400)
 
     app_state = request.app.state
+
+    # Use persona override if set, else fall back to the built-in manual.
+    persona: str = prefs.get("persona", "").strip()
+    system_prompt = persona if persona else (SYSTEM_PROMPT or None)
+
     queue: asyncio.Queue = asyncio.Queue()
 
     def sink(reply: dict) -> None:
@@ -130,7 +241,7 @@ async def chat(request: Request, body: ChatRequest):
         server_password=app_state.taos_opencode_password,
         model_provider_id="litellm",
         model_id=model,
-        system=SYSTEM_PROMPT or None,
+        system=system_prompt,
     )
     adapter = OpenCodeAdapter(cfg, sink)
     # Reuse the persistent session so opencode keeps conversation history.

--- a/tinyagentos/taos_agent_runtime.py
+++ b/tinyagentos/taos_agent_runtime.py
@@ -25,6 +25,9 @@ async def ensure_taos_opencode_server(app_state, model: str) -> OpenCodeServer:
     changed since last start the old server is stopped and a new one is
     created so the LiteLLM provider config and key scope track the chosen model.
 
+    The key is scoped to the full ``permitted_models`` set read from the
+    ``taos_agent`` desktop_settings namespace (falls back to ``[model]``).
+
     Returns the running :class:`~tinyagentos.opencode_runtime.OpenCodeServer`.
     """
     # Generate a stable per-process password once.
@@ -49,12 +52,28 @@ async def ensure_taos_opencode_server(app_state, model: str) -> OpenCodeServer:
         existing = None
 
     if existing is None:
-        # Mint the taOS agent's own LiteLLM virtual key.
+        # Read the permitted_models set from the namespace so the key is scoped
+        # to the full set the admin configured, not just the current model.
+        permitted_models: list[str] = [model]
+        desktop_settings = getattr(app_state, "desktop_settings", None)
+        if desktop_settings is not None:
+            try:
+                prefs = await desktop_settings.get_preference("user", "taos_agent")
+                stored = prefs.get("permitted_models", [])
+                if stored:
+                    # Always ensure the current model is in the set.
+                    permitted_models = list(stored)
+                    if model not in permitted_models:
+                        permitted_models = [model, *permitted_models]
+            except Exception:
+                logger.debug("taos_agent_runtime: could not read permitted_models from prefs", exc_info=True)
+
+        # Mint the taOS agent's own LiteLLM virtual key scoped to permitted_models.
         llm_proxy = getattr(app_state, "llm_proxy", None)
         litellm_key: str | None = None
         if llm_proxy is not None:
             try:
-                litellm_key = await llm_proxy.create_agent_key("taos-agent", models=[model])
+                litellm_key = await llm_proxy.create_agent_key("taos-agent", models=permitted_models)
             except Exception:
                 logger.debug("taos_agent_runtime: create_agent_key failed", exc_info=True)
         if not litellm_key:
@@ -70,7 +89,7 @@ async def ensure_taos_opencode_server(app_state, model: str) -> OpenCodeServer:
             server_password=app_state.taos_opencode_password,
             litellm_base_url="http://127.0.0.1:4000/v1",
             litellm_key=litellm_key,
-            model_ids=[model],
+            model_ids=permitted_models,
         )
         server = OpenCodeServer(cfg)
         app_state.taos_opencode_server = server


### PR DESCRIPTION
Surfaces the host-resident taOS agent as a configurable **system-agent card** in the Agents app — the "configurable via the Agents app + own key" requirement.

## What
- **Backend** (`routes/taos_agent.py`): `GET /api/taos-agent/config` → `{model, permitted_models, persona, key_masked, framework:"opencode", system:true}`; admin-gated `PUT /permitted-models` (validates reachability, ensures current model included, re-scopes the agent's own LiteLLM key) + `PUT /persona` + `PATCH /settings`. The chat uses the persona as the system prompt when set. `taos_agent_runtime` scopes the minted key to the full `permitted_models` set.
- **Frontend**: `TaosAgentCard.tsx` — a system-agent card at the top of the Agents app (no deploy/delete): model picker, permitted-model chips (current model badged + not removable), persona textarea, and a masked view of the agent's **own key**. New `taos-agent-api.ts` helpers.

## Tests
`tests/test_taos_agent_config.py` (15: config shape, key masking, permitted-models 400/409/include-current/key-rescoped/persist, persona, admin-gate on all writes) + `TaosAgentCard.test.tsx` (10). 62 backend tests across the opencode suite green; build clean.

Completes the taOS-agent-on-opencode core: runs on opencode (#594) + own key + fully configurable in the Agents app. Remaining #588 items (host service + taosagent TUI, MCP tools, sandboxed build lane) are follow-on phases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added System Agent configuration interface enabling admins to select the agent model, manage permitted models, and customize the agent persona
  * System Agent section now displays in additional app states for better visibility

* **Tests**
  * Added comprehensive test coverage for System Agent configuration functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->