### PR TITLE
fix(agents): persist + reuse the taOS agent's own LiteLLM key

### DIFF
--- a/tests/test_taos_agent_chat.py
+++ b/tests/test_taos_agent_chat.py
@@ -330,3 +330,57 @@ async def test_ensure_server_falls_back_to_master_key(tmp_path, monkeypatch):
     assert len(spawned_cfgs) == 1
     assert spawned_cfgs[0].litellm_key == TAOS_LITELLM_MASTER_KEY
     assert state.taos_opencode_key == TAOS_LITELLM_MASTER_KEY
+
+
+@pytest.mark.asyncio
+async def test_ensure_server_reuses_persisted_key(tmp_path, monkeypatch):
+    """A persisted own-key is reused and re-scoped, never re-minted (the fixed
+    key alias would otherwise 400 on the second mint)."""
+    import tinyagentos.taos_agent_runtime as rt
+
+    spawned_cfgs: list = []
+
+    class _FakeServer:
+        def __init__(self, cfg):
+            spawned_cfgs.append(cfg)
+            self._cfg = cfg
+        async def ensure_running(self, **kwargs):
+            pass
+        async def stop(self):
+            pass
+        @property
+        def base_url(self):
+            return f"http://127.0.0.1:{self._cfg.port}"
+        def is_running(self):
+            return True
+
+    monkeypatch.setattr(rt, "OpenCodeServer", _FakeServer)
+
+    class _FakeSettings:
+        async def get_preference(self, user, ns):
+            return {"llm_key": "sk-persisted-9", "permitted_models": ["gpt-4o", "claude"]}
+        async def save_preference(self, user, ns, prefs):
+            pass
+
+    mock_proxy = MagicMock()
+    mock_proxy.create_agent_key = AsyncMock(return_value="sk-NEW-should-not-be-used")
+    mock_proxy.update_agent_key = AsyncMock(return_value=True)
+    mock_proxy.is_running.return_value = True
+
+    state = SimpleNamespace(
+        data_dir=tmp_path,
+        llm_proxy=mock_proxy,
+        desktop_settings=_FakeSettings(),
+        taos_opencode_password=None,
+        taos_opencode_server=None,
+        taos_opencode_model=None,
+        taos_opencode_session_id=None,
+    )
+
+    await rt.ensure_taos_opencode_server(state, "gpt-4o")
+
+    # Reused the persisted key, did NOT re-mint, and re-scoped it to the set.
+    assert spawned_cfgs[0].litellm_key == "sk-persisted-9"
+    assert state.taos_opencode_key == "sk-persisted-9"
+    mock_proxy.create_agent_key.assert_not_called()
+    mock_proxy.update_agent_key.assert_awaited()

--- a/tinyagentos/routes/taos_agent.py
+++ b/tinyagentos/routes/taos_agent.py
@@ -1,4 +1,4 @@
-"""taOS Assistant — settings, config and chat completion endpoint.
+"""taOS agent — settings, config and chat completion endpoint.
 
 GET  /api/taos-agent/settings          → {model: str | null}
 PATCH /api/taos-agent/settings         → accepts {model: str}, persists via desktop_settings
@@ -36,7 +36,7 @@ _DONE = object()
 
 
 # Read the system-prompt manual once at startup (or import time).
-# If the file is absent the assistant still works — it just won't have a
+# If the file is absent the taOS agent still works — it just won't have a
 # system prompt until the file is created and the server restarted.
 def _load_manual() -> str:
     try:
@@ -194,7 +194,7 @@ async def chat(request: Request, body: ChatRequest):
     model = prefs.get("model")
     if not model:
         return JSONResponse(
-            {"error": "No model configured. Open taOS Assistant settings and pick a model first."},
+            {"error": "No model configured. Open taOS agent settings and pick a model first."},
             status_code=400,
         )
 

--- a/tinyagentos/routes/taos_agent.py
+++ b/tinyagentos/routes/taos_agent.py
@@ -50,9 +50,15 @@ SYSTEM_PROMPT: str = _load_manual()
 
 
 def _mask_key(key: str | None) -> str | None:
-    """Return a masked form of a LiteLLM key (first 6 + … + last 4), or None."""
-    if not key or len(key) < 12:
-        return key or None
+    """Return a masked form of a LiteLLM key (first 6 + … + last 4), or None.
+
+    Keys too short for that pattern are fully masked rather than surfaced raw
+    (GET /api/taos-agent/config returns this value).
+    """
+    if not key:
+        return None
+    if len(key) < 12:
+        return "…"
     return key[:6] + "…" + key[-4:]
 
 

--- a/tinyagentos/taos_agent_runtime.py
+++ b/tinyagentos/taos_agent_runtime.py
@@ -81,7 +81,12 @@ async def ensure_taos_opencode_server(app_state, model: str) -> OpenCodeServer:
             litellm_key = stored_key
             if llm_proxy is not None:
                 try:
-                    await llm_proxy.update_agent_key(stored_key, permitted_models)
+                    rescoped = await llm_proxy.update_agent_key(stored_key, permitted_models)
+                    if not rescoped:
+                        logger.warning(
+                            "taos_agent_runtime: re-scoping the taOS agent key returned False "
+                            "(key scope may be stale)"
+                        )
                 except Exception:
                     logger.debug("taos_agent_runtime: re-scoping stored key failed", exc_info=True)
         elif llm_proxy is not None:

--- a/tinyagentos/taos_agent_runtime.py
+++ b/tinyagentos/taos_agent_runtime.py
@@ -52,30 +52,49 @@ async def ensure_taos_opencode_server(app_state, model: str) -> OpenCodeServer:
         existing = None
 
     if existing is None:
-        # Read the permitted_models set from the namespace so the key is scoped
-        # to the full set the admin configured, not just the current model.
+        # Read the taos_agent prefs once: the permitted set (to scope the key)
+        # and a persisted own-key (so we reuse it instead of re-minting).
         permitted_models: list[str] = [model]
+        stored_key: str | None = None
+        prefs: dict = {}
         desktop_settings = getattr(app_state, "desktop_settings", None)
         if desktop_settings is not None:
             try:
-                prefs = await desktop_settings.get_preference("user", "taos_agent")
+                prefs = await desktop_settings.get_preference("user", "taos_agent") or {}
                 stored = prefs.get("permitted_models", [])
                 if stored:
                     # Always ensure the current model is in the set.
                     permitted_models = list(stored)
                     if model not in permitted_models:
                         permitted_models = [model, *permitted_models]
+                stored_key = prefs.get("llm_key") or None
             except Exception:
-                logger.debug("taos_agent_runtime: could not read permitted_models from prefs", exc_info=True)
+                logger.debug("taos_agent_runtime: could not read taos_agent prefs", exc_info=True)
 
-        # Mint the taOS agent's own LiteLLM virtual key scoped to permitted_models.
+        # The taOS agent's own LiteLLM virtual key. Reuse the persisted one
+        # (re-scoping it to the current permitted set), else mint once and persist
+        # it. create_agent_key uses a fixed alias, so re-minting would 400 on the
+        # alias collision — persisting the value avoids that and keeps it stable.
         llm_proxy = getattr(app_state, "llm_proxy", None)
         litellm_key: str | None = None
-        if llm_proxy is not None:
+        if stored_key:
+            litellm_key = stored_key
+            if llm_proxy is not None:
+                try:
+                    await llm_proxy.update_agent_key(stored_key, permitted_models)
+                except Exception:
+                    logger.debug("taos_agent_runtime: re-scoping stored key failed", exc_info=True)
+        elif llm_proxy is not None:
             try:
                 litellm_key = await llm_proxy.create_agent_key("taos-agent", models=permitted_models)
             except Exception:
                 logger.debug("taos_agent_runtime: create_agent_key failed", exc_info=True)
+            if litellm_key and desktop_settings is not None:
+                try:
+                    prefs["llm_key"] = litellm_key
+                    await desktop_settings.save_preference("user", "taos_agent", prefs)
+                except Exception:
+                    logger.debug("taos_agent_runtime: persisting key failed", exc_info=True)
         if not litellm_key:
             litellm_key = TAOS_LITELLM_MASTER_KEY
         app_state.taos_opencode_key = litellm_key


### PR DESCRIPTION
Found live on the Pi during the test pass: the taOS agent's own-key minting **falls back to the master key** after the first run.

## Root cause
`create_agent_key("taos-agent", ...)` uses a fixed key alias. On the second+ server start it 400s (`Key with alias 'taos-taos-agent' already exists`) and silently falls back to `TAOS_LITELLM_MASTER_KEY` — so `key_masked` showed the master key and `key_rescoped` was false.

## Fix
Mint the key **once**, persist it in the `taos_agent` prefs, and on later starts **reuse + re-scope** it (via `update_agent_key`) to the current permitted set instead of re-minting. Master-key fallback only when minting genuinely isn't available (routing-only mode). +test for the reuse path; existing mint/fallback tests still green (7 passed).

Note: an install that already minted under the old code (e.g. the Pi from earlier testing) has a stale alias with no persisted value; that key is cleared once so the fresh mint+persist can take over.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent keys are now persisted and reused across sessions instead of being created anew each time, improving consistency. Keys are properly refreshed when model configurations change.

* **Tests**
  * Added test coverage verifying agent key persistence and reuse behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->