### PR TITLE
docs: reflect the opencode taOS agent

### DIFF
--- a/docs/design/framework-agnostic-runtime.md
+++ b/docs/design/framework-agnostic-runtime.md
@@ -17,6 +17,14 @@ its container rootfs and travels with it as a snapshot archive.
 See `docs/design/architecture-pivot-v2.md` for the full decision record that
 produced this thesis.
 
+> **Note (opencode, 2026-06):** opencode is a supported framework like OpenClaw
+> and Hermes (installed from upstream npm, driven via `adapters/opencode_adapter.py`
+> + `opencode_runtime.py`). It also powers the **built-in taOS agent**, which is
+> the one host-resident exception to "one container per agent": the taOS agent
+> runs a host opencode server (`taos_agent_runtime.py`) so it can diagnose and
+> fix the instance, with its own scoped LiteLLM key and a persistent session.
+> See `docs/taos-agent-manual.md` and issue #588.
+
 ## The rule, stated precisely
 
 An agent container is allowed to contain:

--- a/docs/taos-agent-manual.md
+++ b/docs/taos-agent-manual.md
@@ -1,6 +1,6 @@
-# taOS Assistant — System Manual
+# taOS agent — System Manual
 
-You are the **taOS Assistant**, an AI built into taOS (TinyAgentOS). You help users understand and navigate their taOS instance. You have deep knowledge of how taOS works, what each app does, and how agents and channels operate.
+You are the **taOS agent**, an AI built into taOS (TinyAgentOS). You help users understand and navigate their taOS instance. You have deep knowledge of how taOS works, what each app does, and how agents and channels operate.
 
 **Important — v1 scope:** You do Q&A only. You cannot take actions yet (read live agent state, restart agents, inspect logs, etc.). If a user asks you to do something, explain the concept clearly and let them know you will be able to act on it in a future version.
 


### PR DESCRIPTION
Doc sweep after the opencode-agent work (#588): rename the agent manual to 'taOS agent' (the #593 rename missed the doc), and note in the framework-agnostic-runtime rule that opencode is a supported framework + powers the host-resident built-in taOS agent (the one exception to one-container-per-agent). Docs only.