### PR TITLE
chore(release): 1.0.0-beta — version bump, finish rename, release notes

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "0.1.0",
+  "version": "1.0.0-beta",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src/components/SafetyFloor.tsx
+++ b/desktop/src/components/SafetyFloor.tsx
@@ -28,7 +28,7 @@ export function SafetyFloor() {
   return (
     <div style={{ position: "fixed", zIndex: 10000, top: 4, right: 8, pointerEvents: "auto" }}>
       <button
-        aria-label="taOS assistant"
+        aria-label="taOS agent"
         onClick={openPanel}
         className="rounded-full p-2 bg-shell-surface-active hover:brightness-110 transition-[filter]"
       >

--- a/docs/release-notes/v1.0.0-beta.md
+++ b/docs/release-notes/v1.0.0-beta.md
@@ -1,0 +1,51 @@
+# taOS 1.0.0-beta
+
+The first fully functional beta. taOS is a self-hosted AI agent OS for consumer
+hardware: a web desktop, an app store, agent deployment in isolated containers,
+and a distributed compute cluster, all running on your own machine.
+
+## What's in this beta
+
+**Agents, framework-agnostic.** Deploy agents on multiple upstream frameworks
+(OpenClaw, Hermes, SmolAgents and more), each installed from upstream and run in
+its own container. No forks: frameworks integrate through a host-side adapter,
+driven over their native protocol (ACP, HTTP, or opencode's headless API).
+
+**The built-in taOS agent runs on opencode.** The OS assistant is a host
+opencode instance with its own scoped LiteLLM key and a persistent session. It
+is configurable from the Agents app (model, permitted-model set, persona) and
+reachable from the desktop panel.
+
+**Synced model management.** Change an agent's model anywhere (the settings UI,
+the framework's native picker, or by asking the agent) and it converges. The
+agent's permitted-model set is its LiteLLM key scope, and the choice is pushed
+into the framework's own config.
+
+**One governed model surface.** All chat and embeddings route through a single
+host LiteLLM proxy with per-agent virtual keys. Cloud provider catalogs are
+re-checked periodically so newly published models stay routable without a
+restart.
+
+**System-wide memory.** A single memory model (taOSmd) powers extraction, the
+knowledge graph, and retrieval across all agents, managed in the Memory app.
+
+**The rest of the desktop.** App store, model browser, cluster view, browser
+app, messages, projects, and per-agent shortcuts, reachable over the LAN at
+`taos.local:6969`.
+
+## Known limitations
+
+This is a beta. Notable in-progress areas:
+
+- The taOS agent's tool surface (taOS operations as injectable, permission-bound
+  skills) and the `taosagent` terminal recovery console are designed but not yet
+  shipped.
+- The opencode App Builder (sandboxed app creation + share-to-store) is planned.
+- Framework version rollback, the model advisor, and mobile/wearable worker apps
+  are tracked for later releases.
+- Off-LAN access is not part of the local-first core.
+
+## Notes
+
+- Upstream dependencies taOS integrates are tracked in `docs/upstreams.yml`.
+- Architecture: see `docs/design/framework-agnostic-runtime.md`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tinyagentos"
-version = "0.1.0"
+version = "1.0.0-beta"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { text = "AGPL-3.0-or-later" }
 requires-python = ">=3.11"

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.1.0"
+__version__ = "1.0.0-beta"

--- a/tinyagentos/routes/cluster.py
+++ b/tinyagentos/routes/cluster.py
@@ -627,7 +627,7 @@ async def deploy_backend(request: Request, name: str, body: DeployRequest):
 async def worker_remote_command(request: Request, name: str, body: WorkerRemoteRequest):
     """Run an allowlisted command on a remote worker for debugging.
 
-    Used by the TAOS assistant/expert agent and the admin UI to
+    Used by the taOS agent/expert agent and the admin UI to
     diagnose worker issues without SSH access. Commands must match
     a prefix in the allowlist. The worker-side endpoint uses
     create_subprocess_exec (no shell) with the command split into

--- a/tinyagentos/routes/mcp.py
+++ b/tinyagentos/routes/mcp.py
@@ -254,8 +254,8 @@ async def proxy_call(request: Request):
     return JSONResponse(result, status_code=status_code)
 
 
-# --- taOS assistant theme tools ----------------------------------------------
-# These three endpoints are the agent-facing tools that let the taOS assistant
+# --- taOS agent theme tools ----------------------------------------------
+# These three endpoints are the agent-facing tools that let the taOS agent
 # discover the theme vocabulary, create a validated theme, and request a preview.
 
 

--- a/tinyagentos/taos_agent_runtime.py
+++ b/tinyagentos/taos_agent_runtime.py
@@ -1,6 +1,6 @@
 """taOS agent opencode server lifecycle helpers.
 
-Manages the single host opencode server used exclusively by the taOS assistant
+Manages the single host opencode server used exclusively by the taOS agent
 chat endpoint.  The server is started lazily on first chat request and kept
 alive for the process lifetime.  The persistent session id is stored on
 app.state so opencode remembers conversation history across requests.


### PR DESCRIPTION
Beta-prep loose ends (part of the pre-release pass):
- **Version** 0.1.0 -> **1.0.0-beta** (pyproject, desktop/package.json, `__version__`).
- **Finish the #593 rename**: `SafetyFloor` aria-label (user-facing) + backend docstrings/comments still said 'taOS assistant' -> 'taOS agent'.
- **Beta release notes**: `docs/release-notes/v1.0.0-beta.md`.

Pairs with the UI-polish PR (greeting icon / widget flash / non-PWA layout). SPA build green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Beta release (v1.0.0-beta) with agent framework-agnostic deployment, unified model management across protocols, and system-wide memory features.

* **Documentation**
  * Added comprehensive v1.0.0-beta release notes documenting beta scope, key features, and known limitations.

* **Chores**
  * Updated package version to 1.0.0-beta.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->