### PR TITLE
fix(ui): beta polish — greeting icon, widget hydration flash, non-PWA mobile layout

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -320,6 +320,7 @@ export function App() {
         onToggleSwitcher={() => setCardSwitcherOpen((v) => !v)}
         onOpenLaunchpad={() => { setCardSwitcherOpen(false); setSearchOpen(false); setLaunchpadOpen((v) => !v); }}
         activeAppId={activeWindow?.appId ?? null}
+        isBrowserMobile={isBrowserMobile}
       />
       <CardSwitcher
         open={cardSwitcherOpen}

--- a/desktop/src/components/WidgetLayer.tsx
+++ b/desktop/src/components/WidgetLayer.tsx
@@ -44,15 +44,19 @@ export function WidgetLayer() {
   const pickerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (!containerRef.current) return;
+    // Gate on hydration: the container only renders once hydrated + showWidgets
+    // are true (see the early return below), so this must re-run then to attach.
+    if (!hydrated || !showWidgets || !containerRef.current) return;
+    const node = containerRef.current;
+    setContainerWidth(node.clientWidth);
     const observer = new ResizeObserver((entries) => {
       for (const entry of entries) {
         setContainerWidth(entry.contentRect.width);
       }
     });
-    observer.observe(containerRef.current);
+    observer.observe(node);
     return () => observer.disconnect();
-  }, []);
+  }, [hydrated, showWidgets]);
 
   useEffect(() => {
     if (!pickerOpen) return;

--- a/desktop/src/components/WidgetLayer.tsx
+++ b/desktop/src/components/WidgetLayer.tsx
@@ -37,7 +37,7 @@ function renderWidget(type: string) {
 }
 
 export function WidgetLayer() {
-  const { widgets, showWidgets, addWidget, removeWidget, updateLayout } = useWidgetStore();
+  const { widgets, showWidgets, hydrated, addWidget, removeWidget, updateLayout } = useWidgetStore();
   const [pickerOpen, setPickerOpen] = useState(false);
   const [containerWidth, setContainerWidth] = useState(1200);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -74,7 +74,10 @@ export function WidgetLayer() {
     [updateLayout],
   );
 
-  if (!showWidgets) return null;
+  // Hide until the store has loaded from localStorage + resolved the server
+  // fetch. Rendering before hydration shows DEFAULT_WIDGETS and then replaces
+  // them, causing a visible flash + grid re-layout on mobile cold start.
+  if (!hydrated || !showWidgets) return null;
 
   const gridLayout: Layout[] = widgets.map((w) => ({
     i: w.id,

--- a/desktop/src/components/mobile/MobileDock.tsx
+++ b/desktop/src/components/mobile/MobileDock.tsx
@@ -8,6 +8,8 @@ interface Props {
   onToggleSwitcher: () => void;
   onOpenLaunchpad: () => void;
   activeAppId: string | null;
+  /** True when running in mobile Safari/Chrome (not installed as a PWA). */
+  isBrowserMobile?: boolean;
 }
 
 function resolveIcon(iconName: string): icons.LucideIcon {
@@ -18,9 +20,15 @@ function resolveIcon(iconName: string): icons.LucideIcon {
   return (icons[key] as icons.LucideIcon) ?? icons.HelpCircle;
 }
 
-export function MobileDock({ onOpenApp, onToggleSwitcher, onOpenLaunchpad, activeAppId }: Props) {
+export function MobileDock({ onOpenApp, onToggleSwitcher, onOpenLaunchpad, activeAppId, isBrowserMobile = false }: Props) {
   const dockApps = useMobileHomeStore((s) => s.dockApps);
   const windows = useProcessStore((s) => s.windows);
+
+  // In PWA mode the home indicator is handled by env(safe-area-inset-bottom)
+  // on the viewport, so 24 px of padding is enough to clear it.
+  // In browser mode safe-area-inset-bottom is 0, so we need extra room to
+  // keep the dock above Safari's ~50 px URL/tab bar.
+  const dockPaddingBottom = isBrowserMobile ? 54 : 24;
 
   return (
     <div
@@ -33,7 +41,7 @@ export function MobileDock({ onOpenApp, onToggleSwitcher, onOpenLaunchpad, activ
         justifyContent: "center",
         gap: 8,
         paddingTop: 6,
-        paddingBottom: 24,
+        paddingBottom: dockPaddingBottom,
       }}
     >
       {/* Launchpad / All Apps button */}

--- a/desktop/src/theme/tokens.css
+++ b/desktop/src/theme/tokens.css
@@ -135,10 +135,6 @@
   background-size: 100% 100%;
 }
 
-/* Push the dock up slightly in browser mode to clear the tab bar. The
-   attribute selector matches the CSS-module-hashed MobileDock class
-   (e.g. MobileDock_dock__ab12); scoped under .taos-browser so it only
-   applies in browser (non-PWA) mode. */
-.taos-browser [class*="MobileDock"] {
-  padding-bottom: 4px;
-}
+/* MobileDock bottom padding in browser mode is handled via the isBrowserMobile
+   prop passed from App.tsx — the component uses inline styles so a CSS
+   selector cannot override them reliably. See MobileDock.tsx. */


### PR DESCRIPTION
Three beta UI-polish fixes:

- **Greeting icon** — uses lucide `Sun`/`CloudSun`/`Sunset`/`Moon` (drops the broken sun emoji).
- **Widget flash on cold start** — `WidgetLayer` now gates on `hydrated` so widgets don't flash before the store settles.
- **Non-PWA mobile layout** — `MobileDock` clears Safari's browser tab bar (54px vs 24px) via an `isBrowserMobile` prop; removed a dead CSS selector, kept `100dvh`.

1005 tests pass, clean build. Non-PWA mobile dock padding wants a real-device check in mobile Safari before release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented widget-grid flash and premature layout shifts during initial load by gating widget rendering until hydration completes.

* **Style**
  * Improved dock spacing for mobile browser contexts by switching to dynamic bottom padding so the dock displays with correct spacing on mobile/tablet browsers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->