### PR TITLE
fix(shortcuts): terminal/TUI/dashboard redeem on browser-reachable host + correct TUI commands

### DIFF
--- a/tests/shortcuts/test_framework_shortcuts.py
+++ b/tests/shortcuts/test_framework_shortcuts.py
@@ -37,7 +37,7 @@ def test_hermes_shortcuts_exact():
     shortcuts = _shortcuts("hermes")
     assert len(shortcuts) == 3
     assert shortcuts[0]["kind"] == "container-terminal"
-    assert shortcuts[1]["command"] == "hermes"
+    assert shortcuts[1]["command"] == "hermes --tui"
     assert shortcuts[2]["command"] == "hermes doctor"
 
 

--- a/tinyagentos/frameworks.py
+++ b/tinyagentos/frameworks.py
@@ -30,8 +30,8 @@ FRAMEWORKS: dict[str, dict] = {
         "shortcuts": [
             {"kind": "container-terminal", "label": "Container shell",
              "icon": "terminal", "requires_capability": "agent.shell"},
-            {"kind": "tui", "label": "OpenClaw agent",
-             "command": "openclaw agent",
+            {"kind": "tui", "label": "OpenClaw TUI",
+             "command": "openclaw tui",
              "icon": "tui", "requires_capability": "agent.terminal"},
             {"kind": "tui", "label": "OpenClaw doctor",
              "command": "openclaw doctor",
@@ -121,8 +121,8 @@ FRAMEWORKS: dict[str, dict] = {
         "shortcuts": [
             {"kind": "container-terminal", "label": "Container shell",
              "icon": "terminal", "requires_capability": "agent.shell"},
-            {"kind": "tui", "label": "Hermes chat",
-             "command": "hermes",
+            {"kind": "tui", "label": "Hermes TUI",
+             "command": "hermes --tui",
              "icon": "tui", "requires_capability": "agent.terminal"},
             {"kind": "tui", "label": "Hermes doctor",
              "command": "hermes doctor",

--- a/tinyagentos/routes/shortcuts.py
+++ b/tinyagentos/routes/shortcuts.py
@@ -109,5 +109,14 @@ async def launch_shortcut(
         ttl=30,
     )
 
-    redirect_url = f"{worker_url}/redeem?t={token}"
+    # The browser must reach /redeem (and the follow-up PTY/dashboard WebSocket,
+    # which the frontend derives from this URL's host) on the host IT used to
+    # reach the controller — NOT the worker's internal loopback. worker_url is
+    # http://127.0.0.1:<port> (correct for server-side calls, but unreachable
+    # from a remote browser). Build the redeem URL from the request Host header
+    # so it works over LAN IP, mDNS (taos.local), or a relay.
+    fwd_proto = request.headers.get("x-forwarded-proto")
+    scheme = fwd_proto.split(",")[0].strip() if fwd_proto else request.url.scheme
+    host = request.headers.get("host") or request.url.netloc
+    redirect_url = f"{scheme}://{host}/redeem?t={token}"
     return {"redirect_url": redirect_url, "expires_in": 30}


### PR DESCRIPTION
Fixes agent terminal/TUI/dashboard shortcuts that failed with 'WebSocket connection error, connection closed' for any remote browser.

## Root cause
`launch_shortcut` built the redeem URL from the local worker's internal loopback (`http://127.0.0.1:<port>`). The frontend derives BOTH the redeem GET and the PTY/dashboard WebSocket from that host, so a remote browser pointed them at its own machine — launch returned 200 but nothing reached the controller (confirmed live: 6 launches 200 OK, zero /redeem on the Pi).

## Fix
- Build the redeem URL from the request `Host` header (works over LAN IP, `taos.local` mDNS, or a relay). worker_url stays for server-side calls.
- Correct TUI commands vs the real CLIs: OpenClaw `openclaw agent`→`openclaw tui`; Hermes `hermes`→`hermes --tui`.

86 shortcut tests pass. Needs a Pi deploy to confirm the live terminal/TUI/dashboard now connect.