### PR TITLE
fix(agents): taOS agent uses the standard agent card + settings (unbreakable)

### DIFF
--- a/desktop/src/apps/AgentsApp.tsx
+++ b/desktop/src/apps/AgentsApp.tsx
@@ -12,13 +12,28 @@ import { Button } from "@/components/ui";
 import { type Agent, type DiskState, type ArchivedAgent } from "./agents/types";
 import { AgentRow } from "./agents/AgentRow";
 import { AgentDetailPanel, type DetailTab } from "./agents/AgentDetailPanel";
+import { TaosAgentDetailPanel } from "./agents/TaosAgentDetailPanel";
 import { DeployWizard } from "./agents/DeployWizard";
 import { ArchivedAgentsPanel } from "./agents/ArchivedAgents";
-import { TaosAgentCard } from "@/components/TaosAgentCard";
+import { fetchTaosAgentConfig } from "@/lib/taos-agent-api";
 
 /* ------------------------------------------------------------------ */
 /*  AgentsApp (main)                                                   */
 /* ------------------------------------------------------------------ */
+
+// Minimal fixed representation of the taOS system agent as an Agent shape.
+// Status is always "running" — it is host-resident and cannot be stopped.
+const TAOS_AGENT_STUB: Agent = {
+  name: "taos-agent",
+  display_name: "taOS agent",
+  host: "localhost",
+  color: "#6366f1",
+  emoji: "🤖",
+  status: "running",
+  vectors: 0,
+  framework: "opencode",
+  paused: false,
+};
 
 export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
   const [agents, setAgents] = useState<Agent[]>([]);
@@ -26,9 +41,14 @@ export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
   const [loading, setLoading] = useState(true);
   const [wizardOpen, setWizardOpen] = useState(false);
   const [detail, setDetail] = useState<{ name: string; tab: DetailTab } | null>(null);
+  const [taosDetailOpen, setTaosDetailOpen] = useState(false);
   const [diskStates, setDiskStates] = useState<Record<string, DiskState>>({});
   const [quotaErrors, setQuotaErrors] = useState<Record<string, string>>({});
   const [latestByFramework, setLatestByFramework] = useState<Record<string, LatestVersion>>({});
+  // Hydrate the taOS agent stub with live model info (display only — the detail
+  // panel fetches its own config on open). We only use this to show the current
+  // model in the row's framework pill area; failures are silently ignored.
+  const [taosModel, setTaosModel] = useState<string | undefined>(undefined);
   const isMobile = useIsMobile();
   const openWindow = useProcessStore((s) => s.openWindow);
 
@@ -135,6 +155,7 @@ export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
 
   useEffect(() => {
     fetchLatestFrameworks().then(setLatestByFramework).catch(() => {});
+    fetchTaosAgentConfig().then((cfg) => setTaosModel(cfg.model ?? undefined)).catch(() => {});
   }, []);
 
   async function handleResume(name: string) {
@@ -393,7 +414,17 @@ export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
           <div className="flex flex-col h-full min-h-0">
             <div className="p-4">
               <p className="text-xs font-medium text-shell-text-tertiary uppercase tracking-wider mb-2">System agent</p>
-              <TaosAgentCard />
+              <AgentRow
+                agent={{ ...TAOS_AGENT_STUB, display_name: taosModel ? `taOS agent — ${taosModel}` : "taOS agent" }}
+                diskState={null}
+                latestByFramework={latestByFramework}
+                onViewLogs={() => setTaosDetailOpen(true)}
+                onViewSkills={() => setTaosDetailOpen(true)}
+                onViewMessages={() => setTaosDetailOpen(true)}
+                onDelete={() => {}}
+                onResume={() => {}}
+                protected
+              />
             </div>
             <div className="flex flex-col items-center justify-center flex-1 gap-4 text-shell-text-tertiary px-4 pb-8">
               <div className="w-20 h-20 rounded-2xl flex items-center justify-center"
@@ -418,7 +449,17 @@ export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
         ) : agents.length === 0 ? (
           <div className="p-4">
             <p className="text-xs font-medium text-shell-text-tertiary uppercase tracking-wider mb-2">System agent</p>
-            <TaosAgentCard />
+            <AgentRow
+              agent={{ ...TAOS_AGENT_STUB, display_name: taosModel ? `taOS agent — ${taosModel}` : "taOS agent" }}
+              diskState={null}
+              latestByFramework={latestByFramework}
+              onViewLogs={() => setTaosDetailOpen(true)}
+              onViewSkills={() => setTaosDetailOpen(true)}
+              onViewMessages={() => setTaosDetailOpen(true)}
+              onDelete={() => {}}
+              onResume={() => {}}
+              protected
+            />
             <ArchivedAgentsPanel
               archived={archived}
               onRestore={handleRestore}
@@ -429,7 +470,17 @@ export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
           <div className="p-4">
             {/* System agent — always shown above the deployed agents list */}
             <p className="text-xs font-medium text-shell-text-tertiary uppercase tracking-wider mb-2">System agent</p>
-            <TaosAgentCard />
+            <AgentRow
+              agent={{ ...TAOS_AGENT_STUB, display_name: taosModel ? `taOS agent — ${taosModel}` : "taOS agent" }}
+              diskState={null}
+              latestByFramework={latestByFramework}
+              onViewLogs={() => setTaosDetailOpen(true)}
+              onViewSkills={() => setTaosDetailOpen(true)}
+              onViewMessages={() => setTaosDetailOpen(true)}
+              onDelete={() => {}}
+              onResume={() => {}}
+              protected
+            />
 
             {/* Disk quota notification cards */}
             {agents
@@ -559,6 +610,38 @@ export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
           />
         );
       })()}
+
+      {/* taOS agent detail panel */}
+      {taosDetailOpen && (
+        isMobile ? (
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-label="taOS agent settings"
+            className="absolute inset-0 z-30 flex flex-col bg-shell-bg text-zinc-200"
+          >
+            <div className="flex items-center gap-2 border-b border-zinc-800 bg-zinc-900 px-3 py-2">
+              <button
+                type="button"
+                aria-label="Back to agents"
+                onClick={() => setTaosDetailOpen(false)}
+                className="rounded-lg px-2 py-1 text-sm text-zinc-300"
+              >
+                ‹ Back
+              </button>
+              <div className="flex-1 truncate text-center text-sm font-medium text-zinc-200">
+                taOS agent
+              </div>
+              <span className="w-10" aria-hidden="true" />
+            </div>
+            <div className="flex flex-1 min-h-0 flex-col overflow-hidden">
+              <TaosAgentDetailPanel onClose={() => setTaosDetailOpen(false)} fullHeight />
+            </div>
+          </div>
+        ) : (
+          <TaosAgentDetailPanel onClose={() => setTaosDetailOpen(false)} />
+        )
+      )}
 
       {/* Deploy wizard overlay */}
       <DeployWizard open={wizardOpen} onClose={handleWizardClose} />

--- a/desktop/src/apps/AgentsApp.tsx
+++ b/desktop/src/apps/AgentsApp.tsx
@@ -381,6 +381,67 @@ export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
     }
   }
 
+  // Full-window detail view for a regular agent
+  if (detail) {
+    const agent = agents.find((a) => a.name === detail.name);
+    if (agent) {
+      return (
+        <div className="flex flex-col h-full min-h-0 overflow-hidden bg-shell-bg text-shell-text select-none">
+          {/* Back header */}
+          <div className="flex items-center gap-2 px-3 py-2 border-b border-white/5 shrink-0">
+            <button
+              type="button"
+              aria-label="Back to agents"
+              onClick={() => setDetail(null)}
+              className="flex items-center gap-1 rounded-lg px-2 py-1 text-sm text-shell-text-secondary hover:text-shell-text hover:bg-white/5 transition-colors"
+            >
+              ← Back
+            </button>
+            <span className="text-sm font-medium text-shell-text truncate">
+              {agent.display_name || agent.name}
+            </span>
+          </div>
+          <div className="flex flex-1 min-h-0 flex-col overflow-hidden">
+            <AgentDetailPanel
+              agent={agent}
+              initialTab={detail.tab}
+              onClose={() => setDetail(null)}
+              onAgentUpdated={fetchAgents}
+              fullHeight
+            />
+          </div>
+          <DeployWizard open={wizardOpen} onClose={handleWizardClose} />
+        </div>
+      );
+    }
+    // Agent not found — fall through to list (clears stale detail)
+    setDetail(null);
+  }
+
+  // Full-window detail view for the taOS system agent
+  if (taosDetailOpen) {
+    return (
+      <div className="flex flex-col h-full min-h-0 overflow-hidden bg-shell-bg text-shell-text select-none">
+        {/* Back header */}
+        <div className="flex items-center gap-2 px-3 py-2 border-b border-white/5 shrink-0">
+          <button
+            type="button"
+            aria-label="Back to agents"
+            onClick={() => setTaosDetailOpen(false)}
+            className="flex items-center gap-1 rounded-lg px-2 py-1 text-sm text-shell-text-secondary hover:text-shell-text hover:bg-white/5 transition-colors"
+          >
+            ← Back
+          </button>
+          <span className="text-sm font-medium text-shell-text truncate">taOS agent</span>
+        </div>
+        <div className="flex flex-1 min-h-0 flex-col overflow-hidden">
+          <TaosAgentDetailPanel onClose={() => setTaosDetailOpen(false)} fullHeight />
+        </div>
+        <DeployWizard open={wizardOpen} onClose={handleWizardClose} />
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-col h-full min-h-0 overflow-hidden bg-shell-bg text-shell-text select-none relative">
       {/* Toolbar */}
@@ -555,93 +616,6 @@ export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
           </div>
         )}
       </div>
-
-      {/* Detail panel (Logs + Skills tabs) */}
-      {detail && (() => {
-        const agent = agents.find((a) => a.name === detail.name);
-        if (!agent) return null;
-        if (isMobile) {
-          // Render in-place over the agent list, scoped to the AgentsApp's
-          // relative wrapper. The previous implementation portaled to
-          // document.body with fixed inset-0, which escaped the
-          // MobileAppWindow chrome and covered the whole viewport — the
-          // user lost the app's title bar and the safe-area insets had to
-          // be reapplied here. Inline absolute keeps the app window
-          // visible and matches how ProjectsApp renders its workspace.
-          return (
-            <div
-              role="dialog"
-              aria-modal="true"
-              aria-label={`Agent details — ${agent.display_name || agent.name}`}
-              className="absolute inset-0 z-30 flex flex-col bg-shell-bg text-zinc-200"
-            >
-              <div className="flex items-center gap-2 border-b border-zinc-800 bg-zinc-900 px-3 py-2">
-                <button
-                  type="button"
-                  aria-label="Back to agents"
-                  onClick={() => setDetail(null)}
-                  className="rounded-lg px-2 py-1 text-sm text-zinc-300"
-                >
-                  ‹ Back
-                </button>
-                <div className="flex-1 truncate text-center text-sm font-medium text-zinc-200">
-                  {agent.display_name || agent.name}
-                </div>
-                <span className="w-10" aria-hidden="true" />
-              </div>
-              <div className="flex flex-1 min-h-0 flex-col overflow-hidden">
-                <AgentDetailPanel
-                  agent={agent}
-                  initialTab={detail.tab}
-                  onClose={() => setDetail(null)}
-                  onAgentUpdated={fetchAgents}
-                  fullHeight
-                />
-              </div>
-            </div>
-          );
-        }
-        return (
-          <AgentDetailPanel
-            agent={agent}
-            initialTab={detail.tab}
-            onClose={() => setDetail(null)}
-            onAgentUpdated={fetchAgents}
-          />
-        );
-      })()}
-
-      {/* taOS agent detail panel */}
-      {taosDetailOpen && (
-        isMobile ? (
-          <div
-            role="dialog"
-            aria-modal="true"
-            aria-label="taOS agent settings"
-            className="absolute inset-0 z-30 flex flex-col bg-shell-bg text-zinc-200"
-          >
-            <div className="flex items-center gap-2 border-b border-zinc-800 bg-zinc-900 px-3 py-2">
-              <button
-                type="button"
-                aria-label="Back to agents"
-                onClick={() => setTaosDetailOpen(false)}
-                className="rounded-lg px-2 py-1 text-sm text-zinc-300"
-              >
-                ‹ Back
-              </button>
-              <div className="flex-1 truncate text-center text-sm font-medium text-zinc-200">
-                taOS agent
-              </div>
-              <span className="w-10" aria-hidden="true" />
-            </div>
-            <div className="flex flex-1 min-h-0 flex-col overflow-hidden">
-              <TaosAgentDetailPanel onClose={() => setTaosDetailOpen(false)} fullHeight />
-            </div>
-          </div>
-        ) : (
-          <TaosAgentDetailPanel onClose={() => setTaosDetailOpen(false)} />
-        )
-      )}
 
       {/* Deploy wizard overlay */}
       <DeployWizard open={wizardOpen} onClose={handleWizardClose} />

--- a/desktop/src/apps/__tests__/AgentsApp.mobile.test.tsx
+++ b/desktop/src/apps/__tests__/AgentsApp.mobile.test.tsx
@@ -101,19 +101,19 @@ describe("AgentsApp mobile layout (390px viewport)", () => {
   });
 
   it("renders agent name on its own line with status chip alongside it", async () => {
-    const { findByText } = render(<AgentsApp windowId="test" />);
+    render(<AgentsApp windowId="test" />);
 
     // Agent name must be visible
-    const nameEl = await findByText("My Agent");
+    const nameEl = await screen.findByText("My Agent");
     expect(nameEl).toBeTruthy();
 
-    // Status chip must be visible
-    const statusEl = await findByText("running");
-    expect(statusEl).toBeTruthy();
+    // Status chip must be visible (taOS agent is also "running", so match at least one)
+    const statusEls = await screen.findAllByText("running");
+    expect(statusEls.length).toBeGreaterThan(0);
 
-    // Host must be visible on a second row
-    const hostEl = await findByText("localhost");
-    expect(hostEl).toBeTruthy();
+    // Host must be visible on a second row (may appear multiple times for system + regular agent)
+    const hostEls = await screen.findAllByText("localhost");
+    expect(hostEls.length).toBeGreaterThan(0);
   });
 
   it("renders all 4 action buttons with accessible labels", async () => {

--- a/desktop/src/apps/__tests__/AgentsApp.mobile.test.tsx
+++ b/desktop/src/apps/__tests__/AgentsApp.mobile.test.tsx
@@ -131,23 +131,19 @@ describe("AgentsApp mobile layout (390px viewport)", () => {
     expect(deleteBtn).toBeTruthy();
   });
 
-  it("renders a Back button in a full-screen dialog when the detail panel is opened on mobile", async () => {
+  it("renders a Back button in a full-window detail view when the detail panel is opened on mobile", async () => {
     render(<AgentsApp windowId="test" />);
 
     // Wait for the agent list to load and click the skills button
     const skillsBtn = await screen.findByRole("button", { name: /manage skills for my-agent/i });
     fireEvent.click(skillsBtn);
 
-    // The full-screen overlay must render with a back button
+    // The full-window detail view must render with a back button
     const backBtn = screen.getByRole("button", { name: /back to agents/i });
     expect(backBtn).toBeTruthy();
-
-    // The overlay must be a dialog with aria-modal
-    const dialog = screen.getByRole("dialog");
-    expect(dialog.getAttribute("aria-modal")).toBe("true");
   });
 
-  it("closes the full-screen panel when the Back button is clicked", async () => {
+  it("returns to the agent list when the Back button is clicked", async () => {
     render(<AgentsApp windowId="test" />);
 
     const skillsBtn = await screen.findByRole("button", { name: /manage skills for my-agent/i });
@@ -156,8 +152,8 @@ describe("AgentsApp mobile layout (390px viewport)", () => {
     const backBtn = screen.getByRole("button", { name: /back to agents/i });
     fireEvent.click(backBtn);
 
-    // Panel must be gone
-    expect(screen.queryByRole("dialog")).toBeNull();
+    // Back button must be gone and the agent list heading must reappear
     expect(screen.queryByRole("button", { name: /back to agents/i })).toBeNull();
+    expect(screen.getByText("My Agent")).toBeTruthy();
   });
 });

--- a/desktop/src/apps/__tests__/AgentsApp.taos-agent.test.tsx
+++ b/desktop/src/apps/__tests__/AgentsApp.taos-agent.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * Tests for the taOS system agent rendered as a standard AgentRow
+ * with destructive actions hidden and settings wired to /api/taos-agent/*.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import React from "react";
+
+// Stub heavy deps (same pattern as other AgentsApp tests)
+vi.mock("@/hooks/use-is-mobile", () => ({ useIsMobile: () => false }));
+vi.mock("@/lib/framework-api", () => ({ fetchLatestFrameworks: async () => ({}) }));
+vi.mock("@/lib/models", () => ({
+  fetchClusterWorkers: async () => [],
+  workersToAggregated: () => [],
+  HOST_BADGE_CLASS: "",
+  CLOUD_PROVIDER_TYPES: [],
+}));
+vi.mock("@/lib/cluster", () => ({
+  availableKvQuantOptions: () => ({ k: ["fp16"], v: ["fp16"], boundary: false, flat: ["fp16"] }),
+}));
+vi.mock("@/lib/agent-emoji", () => ({ resolveAgentEmoji: () => "🤖" }));
+vi.mock("@/components/EmojiPicker", () => ({ EmojiPickerField: () => null }));
+vi.mock("@/components/ModelPickerFlow", () => ({ ModelPickerFlow: () => null }));
+vi.mock("@/components/ModelPickerModal", () => ({ ModelPickerModal: () => null }));
+vi.mock("@/components/persona-picker/PersonaPicker", () => ({ PersonaPicker: () => null }));
+vi.mock("@/lib/slug", () => ({
+  slugifyClient: (s: string) => s,
+  isValidSlug: () => true,
+  SLUG_REGEX: /^[a-z0-9][a-z0-9-]{0,62}$/,
+}));
+vi.mock("@/components/MigrationBanner", () => ({ MigrationBanner: () => null }));
+vi.mock("@/components/agent-settings/PersonaTab", () => ({ PersonaTab: () => null }));
+vi.mock("@/components/agent-settings/MemoryTab", () => ({ MemoryTab: () => null }));
+vi.mock("@/components/agent-settings/FrameworkTab", () => ({ FrameworkTab: () => null }));
+vi.mock("../AgentSkillsPanel", () => ({ AgentSkillsPanel: () => null }));
+vi.mock("../AgentMessagesPanel", () => ({ AgentMessagesPanel: () => null }));
+vi.mock("@/components/AgentShortcutRow", () => ({
+  AgentShortcutRow: () => null,
+}));
+vi.mock("@/stores/process-store", () => ({
+  useProcessStore: (sel: (s: { openWindow: ReturnType<typeof vi.fn> }) => unknown) =>
+    sel({ openWindow: vi.fn() }),
+}));
+vi.mock("@/components/ui", () => ({
+  Button: ({ children, onClick, className, disabled, "aria-label": ariaLabel, title, ...rest }:
+    React.ButtonHTMLAttributes<HTMLButtonElement> & { children?: React.ReactNode }) => (
+    <button onClick={onClick} className={className} disabled={disabled}
+      aria-label={ariaLabel} title={title} {...rest}>
+      {children}
+    </button>
+  ),
+  Card: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+  Label: ({ children }: { children: React.ReactNode }) => <label>{children}</label>,
+  Tabs: ({ children, value, onValueChange }: { children: React.ReactNode; value?: string; onValueChange?: (v: string) => void }) => (
+    <div data-value={value} onClick={() => {}}>{children}</div>
+  ),
+  TabsContent: ({ children, value }: { children: React.ReactNode; value?: string }) => (
+    <div data-tab-content={value}>{children}</div>
+  ),
+  TabsList: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsTrigger: ({ children, value, onClick }: { children: React.ReactNode; value?: string; onClick?: () => void }) => (
+    <button data-tab-trigger={value} onClick={onClick}>{children}</button>
+  ),
+}));
+
+import { AgentsApp } from "../AgentsApp";
+
+// Helper: build a minimal fetch mock that includes taos-agent/config
+function makeFetch(agents: unknown[], taosConfig?: object) {
+  return vi.fn().mockImplementation((url: string) => {
+    if (url === "/api/agents") {
+      return Promise.resolve({
+        ok: true,
+        headers: { get: () => "application/json" },
+        json: () => Promise.resolve(agents),
+      } as unknown as Response);
+    }
+    if (url === "/api/agents/archived") {
+      return Promise.resolve({
+        ok: true,
+        headers: { get: () => "application/json" },
+        json: () => Promise.resolve([]),
+      } as unknown as Response);
+    }
+    if (url === "/api/taos-agent/config") {
+      return Promise.resolve({
+        ok: true,
+        headers: { get: () => "application/json" },
+        json: () => Promise.resolve(taosConfig ?? {
+          model: "ollama/llama3",
+          permitted_models: ["ollama/llama3"],
+          persona: "",
+          key_masked: "sk-test…key",
+          framework: "opencode",
+          system: true,
+        }),
+      } as unknown as Response);
+    }
+    return Promise.resolve({
+      ok: false,
+      headers: { get: () => "application/json" },
+      json: () => Promise.resolve({}),
+    } as unknown as Response);
+  });
+}
+
+const MOCK_AGENT = {
+  name: "agent-alpha",
+  display_name: "Agent Alpha",
+  host: "localhost",
+  color: "#3b82f6",
+  status: "running",
+  vectors: 10,
+  framework: "openclaw",
+  paused: false,
+};
+
+describe("AgentsApp — taOS system agent rendered as standard AgentRow", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", makeFetch([MOCK_AGENT]));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders the 'System agent' section header", async () => {
+    render(<AgentsApp windowId="test" />);
+    await waitFor(() =>
+      expect(screen.getByText(/system agent/i)).toBeInTheDocument()
+    );
+  });
+
+  it("renders the taOS agent name in the same card structure as regular agents", async () => {
+    render(<AgentsApp windowId="test" />);
+    await waitFor(() =>
+      expect(screen.getByText(/taOS agent/i)).toBeInTheDocument()
+    );
+  });
+
+  it("does NOT render a Delete button for the taOS system agent", async () => {
+    render(<AgentsApp windowId="test" />);
+    // Wait for agents to load
+    await screen.findByText(/taOS agent/i);
+    // Delete button for the system agent must not exist
+    expect(screen.queryByRole("button", { name: /delete taos-agent/i })).toBeNull();
+  });
+
+  it("DOES render a Delete button for a regular deployed agent", async () => {
+    render(<AgentsApp windowId="test" />);
+    const deleteBtn = await screen.findByRole("button", { name: /delete agent-alpha/i });
+    expect(deleteBtn).toBeInTheDocument();
+  });
+
+  it("the taOS agent's logs button opens TaosAgentDetailPanel (not regular detail panel)", async () => {
+    render(<AgentsApp windowId="test" />);
+    // System agent is always running so the logs button is enabled
+    const logsBtn = await screen.findByRole("button", {
+      name: /view logs for taos-agent/i,
+    });
+    expect(logsBtn).not.toBeDisabled();
+    fireEvent.click(logsBtn);
+    // The taOS detail panel has a close button
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /close detail panel/i })).toBeInTheDocument()
+    );
+  });
+
+  it("does NOT show a Resume button for the taOS system agent even when paused would normally show it", async () => {
+    render(<AgentsApp windowId="test" />);
+    await screen.findByText(/taOS agent/i);
+    // No resume button scoped to the system agent
+    expect(screen.queryByRole("button", { name: /resume taos-agent/i })).toBeNull();
+  });
+});
+
+describe("AgentsApp — taOS agent when no deployed agents exist", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", makeFetch([]));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("still renders the taOS agent card in the empty-state view", async () => {
+    render(<AgentsApp windowId="test" />);
+    await waitFor(() =>
+      expect(screen.getByText(/taOS agent/i)).toBeInTheDocument()
+    );
+    // Confirm no deployed count text says something useful
+    expect(screen.getByText("0 deployed")).toBeInTheDocument();
+  });
+
+  it("delete is absent for taOS agent in empty-state view", async () => {
+    render(<AgentsApp windowId="test" />);
+    await screen.findByText(/taOS agent/i);
+    expect(screen.queryByRole("button", { name: /delete taos-agent/i })).toBeNull();
+  });
+});

--- a/desktop/src/apps/__tests__/AgentsApp.test.tsx
+++ b/desktop/src/apps/__tests__/AgentsApp.test.tsx
@@ -130,16 +130,18 @@ describe("AgentsApp — AgentShortcutRow wiring (Task 27)", () => {
     expect(rowBeta.getAttribute("data-has-launch")).toBe("true");
   });
 
-  it("does NOT render a Back button or full-screen dialog when the detail panel is opened on desktop", async () => {
+  it("renders a Back button and hides the agent list when a detail view is opened on desktop", async () => {
     render(<AgentsApp windowId="test" />);
 
-    // Open the detail panel via the logs button on the first agent
+    // Open the detail view via the logs button on the first agent
     const logsBtn = await screen.findByRole("button", { name: /view logs for agent-alpha/i });
     fireEvent.click(logsBtn);
 
-    // No back button and no dialog wrapper on desktop
-    expect(screen.queryByRole("button", { name: /back to agents/i })).toBeNull();
-    expect(screen.queryByRole("dialog", { name: /agent details/i })).toBeNull();
+    // Back button must be visible in the full-window detail view
+    expect(screen.getByRole("button", { name: /back to agents/i })).toBeTruthy();
+
+    // The agent list toolbar heading must be gone (detail replaced the list)
+    expect(screen.queryByRole("heading", { name: /^agents$/i })).toBeNull();
   });
 });
 

--- a/desktop/src/apps/__tests__/TaosAgentDetailPanel.test.tsx
+++ b/desktop/src/apps/__tests__/TaosAgentDetailPanel.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * Unit tests for TaosAgentDetailPanel — the settings screen for the taOS
+ * system agent, wired to /api/taos-agent/* endpoints.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import React from "react";
+
+// Mock taos-agent-api
+vi.mock("@/lib/taos-agent-api", () => ({
+  fetchTaosAgentConfig: vi.fn(),
+  setTaosAgentModel: vi.fn(),
+  setTaosAgentPermitted: vi.fn(),
+  setTaosAgentPersona: vi.fn(),
+}));
+vi.mock("@/components/ModelPickerModal", () => ({
+  ModelPickerModal: () => null,
+}));
+vi.mock("@/components/ui", () => ({
+  Button: ({ children, onClick, "aria-label": ariaLabel, ...rest }:
+    React.ButtonHTMLAttributes<HTMLButtonElement> & { children?: React.ReactNode }) => (
+    <button onClick={onClick} aria-label={ariaLabel} {...rest}>{children}</button>
+  ),
+  Tabs: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsList: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsTrigger: ({ children }: { children: React.ReactNode }) => <button>{children}</button>,
+}));
+
+import {
+  fetchTaosAgentConfig,
+  setTaosAgentPermitted,
+  setTaosAgentPersona,
+} from "@/lib/taos-agent-api";
+import { TaosAgentDetailPanel } from "../agents/TaosAgentDetailPanel";
+
+const BASE_CONFIG = {
+  model: "ollama/llama3",
+  permitted_models: ["ollama/llama3", "ollama/qwen3"],
+  persona: "Be helpful.",
+  key_masked: "sk-test…key",
+  framework: "opencode" as const,
+  system: true as const,
+};
+
+describe("<TaosAgentDetailPanel />", () => {
+  const onClose = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fetchTaosAgentConfig).mockResolvedValue({ ...BASE_CONFIG });
+  });
+
+  it("renders Settings and Persona tab triggers", async () => {
+    render(<TaosAgentDetailPanel onClose={onClose} />);
+    await waitFor(() =>
+      expect(screen.getByText("Settings")).toBeInTheDocument()
+    );
+    expect(screen.getByText("Persona")).toBeInTheDocument();
+  });
+
+  it("shows the current model", async () => {
+    render(<TaosAgentDetailPanel onClose={onClose} />);
+    // ollama/llama3 appears in both the model display row and the permitted chips
+    await waitFor(() => {
+      const matches = screen.getAllByText("ollama/llama3");
+      expect(matches.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("shows permitted model chips", async () => {
+    render(<TaosAgentDetailPanel onClose={onClose} />);
+    await waitFor(() =>
+      expect(screen.getByText("ollama/qwen3")).toBeInTheDocument()
+    );
+  });
+
+  it("remove button is disabled for the current model chip", async () => {
+    render(<TaosAgentDetailPanel onClose={onClose} />);
+    await waitFor(() =>
+      expect(screen.getByLabelText("Cannot remove current model ollama/llama3")).toBeDisabled()
+    );
+  });
+
+  it("remove button is enabled for non-current permitted models", async () => {
+    render(<TaosAgentDetailPanel onClose={onClose} />);
+    await waitFor(() =>
+      expect(
+        screen.getByLabelText("Remove ollama/qwen3 from taOS agent permitted models")
+      ).not.toBeDisabled()
+    );
+  });
+
+  it("persona textarea pre-fills with config persona", async () => {
+    render(<TaosAgentDetailPanel onClose={onClose} />);
+    await waitFor(() => {
+      const ta = screen.getByLabelText("taOS agent persona — system-prompt override");
+      expect((ta as HTMLTextAreaElement).value).toBe("Be helpful.");
+    });
+  });
+
+  it("Save (persona) button appears only after editing persona", async () => {
+    render(<TaosAgentDetailPanel onClose={onClose} />);
+    await waitFor(() =>
+      screen.getByLabelText("taOS agent persona — system-prompt override")
+    );
+    // Initially no save button
+    expect(screen.queryByLabelText("Save taOS agent persona")).toBeNull();
+    // Edit the textarea
+    fireEvent.change(screen.getByLabelText("taOS agent persona — system-prompt override"), {
+      target: { value: "Be terse." },
+    });
+    await waitFor(() =>
+      expect(screen.getByLabelText("Save taOS agent persona")).toBeInTheDocument()
+    );
+  });
+
+  it("calls setTaosAgentPersona when Save (persona) is clicked", async () => {
+    vi.mocked(setTaosAgentPersona).mockResolvedValue({ persona: "Be terse." });
+    render(<TaosAgentDetailPanel onClose={onClose} />);
+    await waitFor(() =>
+      screen.getByLabelText("taOS agent persona — system-prompt override")
+    );
+    fireEvent.change(screen.getByLabelText("taOS agent persona — system-prompt override"), {
+      target: { value: "Be terse." },
+    });
+    await waitFor(() => screen.getByLabelText("Save taOS agent persona"));
+    fireEvent.click(screen.getByLabelText("Save taOS agent persona"));
+    await waitFor(() =>
+      expect(setTaosAgentPersona).toHaveBeenCalledWith("Be terse.")
+    );
+  });
+
+  it("calls setTaosAgentPermitted when removing a model and saving", async () => {
+    vi.mocked(setTaosAgentPermitted).mockResolvedValue({
+      permitted_models: ["ollama/llama3"],
+      key_rescoped: false,
+    });
+    render(<TaosAgentDetailPanel onClose={onClose} />);
+    await waitFor(() =>
+      screen.getByLabelText("Remove ollama/qwen3 from taOS agent permitted models")
+    );
+    fireEvent.click(
+      screen.getByLabelText("Remove ollama/qwen3 from taOS agent permitted models")
+    );
+    await waitFor(() =>
+      screen.getByLabelText("Save taOS agent permitted models")
+    );
+    fireEvent.click(screen.getByLabelText("Save taOS agent permitted models"));
+    await waitFor(() =>
+      expect(setTaosAgentPermitted).toHaveBeenCalledWith(["ollama/llama3"])
+    );
+  });
+
+  it("calls onClose when Close button is clicked", async () => {
+    render(<TaosAgentDetailPanel onClose={onClose} />);
+    await waitFor(() => screen.getByRole("button", { name: /close detail panel/i }));
+    fireEvent.click(screen.getByRole("button", { name: /close detail panel/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("shows an error alert when fetchTaosAgentConfig fails", async () => {
+    vi.mocked(fetchTaosAgentConfig).mockRejectedValue(new Error("Network error"));
+    render(<TaosAgentDetailPanel onClose={onClose} />);
+    await waitFor(() =>
+      expect(screen.getAllByRole("alert").length).toBeGreaterThan(0)
+    );
+    expect(screen.getAllByText(/network error/i).length).toBeGreaterThan(0);
+  });
+});

--- a/desktop/src/apps/agents/AgentRow.tsx
+++ b/desktop/src/apps/agents/AgentRow.tsx
@@ -21,6 +21,7 @@ export function AgentRow({
   onDelete,
   onResume,
   leftActions,
+  protected: isProtected = false,
 }: {
   agent: Agent;
   diskState?: DiskState | null;
@@ -31,6 +32,8 @@ export function AgentRow({
   onDelete: (name: string) => void;
   onResume: (name: string) => void;
   leftActions?: ReactNode;
+  /** When true, destructive actions (delete, resume-from-paused) are hidden. */
+  protected?: boolean;
 }) {
   const isMobile = useIsMobile();
   const emoji = resolveAgentEmoji(agent.emoji, agent.framework);
@@ -66,7 +69,7 @@ export function AgentRow({
 
   const actionButtons = (
     <>
-      {agent.paused && (
+      {!isProtected && agent.paused && (
         <Button
           variant="ghost"
           size="icon"
@@ -111,16 +114,18 @@ export function AgentRow({
       >
         <MessageSquare size={15} />
       </Button>
-      <Button
-        variant="ghost"
-        size="icon"
-        className={`${btnCls} hover:bg-red-500/15 hover:text-red-400`}
-        onClick={() => onDelete(agent.name)}
-        aria-label={`Delete ${agent.name}`}
-        title="Delete"
-      >
-        <Trash2 size={15} />
-      </Button>
+      {!isProtected && (
+        <Button
+          variant="ghost"
+          size="icon"
+          className={`${btnCls} hover:bg-red-500/15 hover:text-red-400`}
+          onClick={() => onDelete(agent.name)}
+          aria-label={`Delete ${agent.name}`}
+          title="Delete"
+        >
+          <Trash2 size={15} />
+        </Button>
+      )}
     </>
   );
 

--- a/desktop/src/apps/agents/TaosAgentDetailPanel.tsx
+++ b/desktop/src/apps/agents/TaosAgentDetailPanel.tsx
@@ -1,0 +1,357 @@
+import { useState, useEffect } from "react";
+import { Bot, Settings, X } from "lucide-react";
+import { ModelPickerModal } from "@/components/ModelPickerModal";
+import type { AgentModel } from "@/components/ModelPickerFlow";
+import {
+  fetchTaosAgentConfig,
+  setTaosAgentModel,
+  setTaosAgentPermitted,
+  setTaosAgentPersona,
+  type TaosAgentConfig,
+} from "@/lib/taos-agent-api";
+import {
+  Button,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/components/ui";
+
+/* ------------------------------------------------------------------ */
+/*  TaosAgentDetailPanel                                               */
+/*  Same chrome as AgentDetailPanel but wired to /api/taos-agent/*    */
+/* ------------------------------------------------------------------ */
+
+type TaosDetailTab = "settings" | "persona";
+
+export function TaosAgentDetailPanel({
+  onClose,
+  fullHeight = false,
+}: {
+  onClose: () => void;
+  fullHeight?: boolean;
+}) {
+  const [tab, setTab] = useState<TaosDetailTab>("settings");
+  const [config, setConfig] = useState<TaosAgentConfig | null>(null);
+  const [loadErr, setLoadErr] = useState<string | null>(null);
+
+  // Model picker
+  const [models, setModels] = useState<AgentModel[]>([]);
+  const [modelsLoaded, setModelsLoaded] = useState(false);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [modelErr, setModelErr] = useState<string | null>(null);
+
+  // Permitted models
+  const [draftPermitted, setDraftPermitted] = useState<string[]>([]);
+  const [draftDirty, setDraftDirty] = useState(false);
+  const [addPickerOpen, setAddPickerOpen] = useState(false);
+  const [permittedSaving, setPermittedSaving] = useState(false);
+  const [permittedErr, setPermittedErr] = useState<string | null>(null);
+
+  // Persona
+  const [draftPersona, setDraftPersona] = useState("");
+  const [personaDirty, setPersonaDirty] = useState(false);
+  const [personaSaving, setPersonaSaving] = useState(false);
+  const [personaErr, setPersonaErr] = useState<string | null>(null);
+
+  async function load() {
+    try {
+      const cfg = await fetchTaosAgentConfig();
+      setConfig(cfg);
+      setDraftPermitted(cfg.permitted_models);
+      setDraftPersona(cfg.persona);
+      setDraftDirty(false);
+      setPersonaDirty(false);
+      setLoadErr(null);
+    } catch (e: any) {
+      setLoadErr(String(e?.message ?? e));
+    }
+  }
+
+  useEffect(() => { load(); }, []);
+
+  async function ensureModelsLoaded() {
+    if (modelsLoaded) return;
+    try {
+      const res = await fetch("/api/providers/models?refresh=true", {
+        headers: { Accept: "application/json" },
+      });
+      const data = res.ok ? await res.json() : { data: [] };
+      setModels((data.data ?? []).map((m: { id: string }) => ({
+        id: m.id, name: m.id, hostKind: "cloud" as const,
+      })));
+    } catch { /* leave empty */ }
+    finally { setModelsLoaded(true); }
+  }
+
+  async function changeModel(modelId: string) {
+    setModelErr(null);
+    try {
+      await setTaosAgentModel(modelId);
+      setConfig((prev) => prev ? { ...prev, model: modelId } : prev);
+      setPickerOpen(false);
+    } catch (e: any) {
+      setModelErr(String(e?.message ?? e));
+    }
+  }
+
+  function addToPermitted(modelId: string) {
+    if (draftPermitted.includes(modelId)) return;
+    setDraftPermitted([...draftPermitted, modelId]);
+    setDraftDirty(true);
+    setAddPickerOpen(false);
+  }
+
+  function removeFromPermitted(modelId: string) {
+    if (modelId === config?.model) return;
+    setDraftPermitted(draftPermitted.filter((m) => m !== modelId));
+    setDraftDirty(true);
+  }
+
+  async function savePermitted() {
+    setPermittedSaving(true);
+    setPermittedErr(null);
+    try {
+      const data = await setTaosAgentPermitted(draftPermitted);
+      setDraftPermitted(data.permitted_models);
+      setDraftDirty(false);
+    } catch (e: any) {
+      setPermittedErr(String(e?.message ?? e));
+    } finally {
+      setPermittedSaving(false);
+    }
+  }
+
+  async function savePersona() {
+    setPersonaSaving(true);
+    setPersonaErr(null);
+    try {
+      const data = await setTaosAgentPersona(draftPersona);
+      setConfig((prev) => prev ? { ...prev, persona: data.persona } : prev);
+      setPersonaDirty(false);
+    } catch (e: any) {
+      setPersonaErr(String(e?.message ?? e));
+    } finally {
+      setPersonaSaving(false);
+    }
+  }
+
+  const currentModel = config?.model ?? null;
+
+  return (
+    <Tabs
+      value={tab}
+      onValueChange={(v) => setTab(v as TaosDetailTab)}
+      className={
+        fullHeight
+          ? "border-t border-white/5 bg-shell-bg-deep flex flex-1 min-h-0 flex-col"
+          : "border-t border-white/5 bg-shell-bg-deep flex flex-col"
+      }
+      style={fullHeight ? undefined : { height: "22rem" }}
+    >
+      <div className="flex items-center justify-between px-4 py-2 border-b border-white/5 shrink-0">
+        <div className="flex items-center gap-3">
+          <div className="flex items-center gap-1.5 text-sm">
+            <span className="text-base leading-none" aria-hidden="true">🤖</span>
+            <span className="font-medium">taOS agent</span>
+            <span
+              className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium lowercase shrink-0 bg-white/5 text-shell-text-secondary border border-white/10"
+              aria-label="System agent"
+            >
+              system
+            </span>
+          </div>
+          <TabsList aria-label="taOS agent detail tabs">
+            <TabsTrigger value="settings">
+              <Settings size={13} className="mr-1.5" />
+              Settings
+            </TabsTrigger>
+            <TabsTrigger value="persona">
+              <Bot size={13} className="mr-1.5" />
+              Persona
+            </TabsTrigger>
+          </TabsList>
+        </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7"
+          onClick={onClose}
+          aria-label="Close detail panel"
+        >
+          <X size={14} />
+        </Button>
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-hidden">
+        {/* Settings tab: model + permitted models */}
+        <TabsContent value="settings" className="h-full mt-0">
+          <div className="h-full overflow-auto p-4 flex flex-col gap-4">
+            {loadErr ? (
+              <div className="text-xs text-red-400" role="alert">
+                Failed to load taOS agent config: {loadErr}
+              </div>
+            ) : !config ? (
+              <div className="text-sm opacity-60">Loading…</div>
+            ) : (
+              <>
+                <div className="text-sm">
+                  This is the taOS system agent. It runs <b>opencode</b> and is always present.
+                </div>
+
+                {/* Model */}
+                <div className="flex items-center gap-2 flex-wrap">
+                  <span className="opacity-60 text-sm">Model</span>
+                  <code className="text-sm">{currentModel || "(not set)"}</code>
+                  <button
+                    onClick={async () => { setPickerOpen(true); await ensureModelsLoaded(); }}
+                    aria-label="Change taOS agent model"
+                    className="bg-white/10 hover:bg-white/15 px-2.5 py-1 rounded text-xs"
+                  >
+                    Change model
+                  </button>
+                </div>
+                {modelErr && <div className="text-xs text-red-400">{modelErr}</div>}
+
+                {/* Permitted models */}
+                <section aria-label="Permitted models">
+                  <div className="flex items-center gap-2 mb-2">
+                    <span className="opacity-60 text-sm">Permitted models</span>
+                    <button
+                      onClick={async () => { setAddPickerOpen(true); await ensureModelsLoaded(); }}
+                      aria-label="Add permitted model for taOS agent"
+                      className="bg-white/10 hover:bg-white/15 px-2.5 py-1 rounded text-xs"
+                    >
+                      + Add
+                    </button>
+                  </div>
+
+                  {draftPermitted.length === 0 ? (
+                    <p className="text-xs opacity-50">No models in the permitted set yet.</p>
+                  ) : (
+                    <ul className="flex flex-wrap gap-2" aria-label="Permitted model chips">
+                      {draftPermitted.map((m) => {
+                        const isCurrent = m === currentModel;
+                        return (
+                          <li
+                            key={m}
+                            className="flex items-center gap-1.5 bg-white/10 rounded px-2 py-0.5 text-xs"
+                          >
+                            <code>{m}</code>
+                            {isCurrent && (
+                              <span
+                                className="bg-blue-600/50 text-blue-200 px-1.5 py-0.5 rounded text-[10px] leading-none"
+                                aria-label="current primary model"
+                              >
+                                current
+                              </span>
+                            )}
+                            <button
+                              onClick={() => removeFromPermitted(m)}
+                              disabled={isCurrent}
+                              aria-label={
+                                isCurrent
+                                  ? `Cannot remove current model ${m}`
+                                  : `Remove ${m} from taOS agent permitted models`
+                              }
+                              className="opacity-60 hover:opacity-100 disabled:opacity-20 disabled:cursor-not-allowed leading-none"
+                            >
+                              ×
+                            </button>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  )}
+
+                  {permittedErr && <div className="text-xs text-red-400 mt-2">{permittedErr}</div>}
+
+                  {draftDirty && (
+                    <button
+                      onClick={savePermitted}
+                      disabled={permittedSaving}
+                      aria-label="Save taOS agent permitted models"
+                      aria-busy={permittedSaving}
+                      className="mt-2 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 px-3 py-1.5 rounded text-xs"
+                    >
+                      {permittedSaving ? "Saving…" : "Save"}
+                    </button>
+                  )}
+                </section>
+
+                {config.key_masked && (
+                  <div className="flex items-center gap-2">
+                    <span className="opacity-60 text-xs">API key</span>
+                    <code className="text-xs bg-white/5 px-2 py-0.5 rounded" aria-label="Masked API key">
+                      {config.key_masked}
+                    </code>
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+        </TabsContent>
+
+        {/* Persona tab */}
+        <TabsContent value="persona" className="h-full mt-0">
+          <div className="h-full overflow-auto p-4 flex flex-col gap-3">
+            {loadErr ? (
+              <div className="text-xs text-red-400" role="alert">
+                Failed to load: {loadErr}
+              </div>
+            ) : !config ? (
+              <div className="text-sm opacity-60">Loading…</div>
+            ) : (
+              <>
+                <label className="flex flex-col gap-1">
+                  <span className="text-xs uppercase opacity-60">Persona (system-prompt override)</span>
+                  <textarea
+                    value={draftPersona}
+                    onChange={(e) => {
+                      setDraftPersona(e.target.value);
+                      setPersonaDirty(e.target.value !== (config.persona ?? ""));
+                    }}
+                    rows={10}
+                    aria-label="taOS agent persona — system-prompt override"
+                    placeholder="Leave empty to use the built-in manual as the system prompt."
+                    className="border border-white/10 rounded bg-shell-bg px-2 py-1 font-mono text-xs text-shell-text-secondary resize-none focus:outline-none focus:ring-1 focus:ring-white/20"
+                  />
+                </label>
+                {personaErr && <div className="text-xs text-red-400">{personaErr}</div>}
+                {personaDirty && (
+                  <button
+                    onClick={savePersona}
+                    disabled={personaSaving}
+                    aria-label="Save taOS agent persona"
+                    aria-busy={personaSaving}
+                    className="self-end bg-blue-600 hover:bg-blue-500 disabled:opacity-50 px-3 py-1.5 rounded text-sm text-white transition-colors"
+                  >
+                    {personaSaving ? "Saving…" : "Save"}
+                  </button>
+                )}
+              </>
+            )}
+          </div>
+        </TabsContent>
+      </div>
+
+      {/* Model picker modals */}
+      <ModelPickerModal
+        open={pickerOpen}
+        onClose={() => setPickerOpen(false)}
+        models={models}
+        modelsLoaded={modelsLoaded}
+        onSelect={(modelId) => changeModel(modelId)}
+        title="Change model"
+      />
+      <ModelPickerModal
+        open={addPickerOpen}
+        onClose={() => setAddPickerOpen(false)}
+        models={models}
+        modelsLoaded={modelsLoaded}
+        onSelect={(modelId) => addToPermitted(modelId)}
+        title="Add permitted model"
+      />
+    </Tabs>
+  );
+}


### PR DESCRIPTION
The built-in taOS agent rendered with a bespoke `TaosAgentCard`. Now it uses the SAME `AgentRow` card as deployed agents (via a `protected` prop that hides delete/resume) and a `TaosAgentDetailPanel` settings screen wired to `/api/taos-agent/*` (model / permitted-models / persona). It can't be deleted, moved, or stopped.

66 vitest tests pass, build clean. (Pre-existing SafetyFloor.test.tsx failure is on dev, unrelated.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * taOS system agent now includes a detail panel allowing configuration of the agent model, permitted models, and system persona.

* **UI Changes**
  * taOS system agent displays as a standard agent row in the list with automatic model fetching on load.
  * Removed destructive actions for the taOS system agent to prevent accidental modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->