### PR TITLE
fix(#606): cache cloud model catalog — fix empty list + slow picker, add force-refresh

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinyagentos-desktop",
-  "version": "0.1.0",
+  "version": "1.0.0-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinyagentos-desktop",
-      "version": "0.1.0",
+      "version": "1.0.0-beta",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/desktop/src/apps/agents/DeployWizard.tsx
+++ b/desktop/src/apps/agents/DeployWizard.tsx
@@ -712,10 +712,13 @@ export function DeployWizard({
             hostKind: provider.kind,
           });
         }
-        // Merge: keep local/worker, replace cloud slice.
+        // Merge: keep local/worker, replace cloud slice only.
+        // Filter refreshedCloud to strictly cloud entries so worker-hosted models
+        // that share an id with a cloud model are never incorrectly dropped.
+        const cloudOnly = refreshedCloud.filter(m => m.hostKind === "cloud");
         setModels(prev => {
-          const nonCloud = prev.filter(m => m.hostKind !== "cloud" && m.hostKind !== "worker" || !refreshedCloud.some(c => c.id === m.id));
-          const merged = [...nonCloud.filter(m => m.hostKind !== "cloud"), ...refreshedCloud];
+          const nonCloud = prev.filter(m => m.hostKind !== "cloud");
+          const merged = [...nonCloud, ...cloudOnly];
           const deduped: Model[] = [];
           const ds = new Set<string>();
           for (const m of merged) {

--- a/desktop/src/apps/agents/DeployWizard.tsx
+++ b/desktop/src/apps/agents/DeployWizard.tsx
@@ -372,6 +372,8 @@ export function DeployWizard({
   // Step 3
   const [models, setModels] = useState<Model[]>([]);
   const [modelsLoaded, setModelsLoaded] = useState(false);
+  const [modelsRefreshing, setModelsRefreshing] = useState(false);
+  const [modelsCachedAt, setModelsCachedAt] = useState<number>(0);
   const [selectedModel, setSelectedModel] = useState<string>("");
 
   // Advanced (no wizard step — defaults to unlimited)
@@ -608,6 +610,9 @@ export function DeployWizard({
         const mct = modelsRes.headers.get("content-type") ?? "";
         if (modelsRes.ok && mct.includes("application/json")) {
           const body = await modelsRes.json();
+          if (typeof body?.cached_at === "number" && body.cached_at > 0) {
+            setModelsCachedAt(body.cached_at);
+          }
           const data: { id?: string }[] = Array.isArray(body?.data) ? body.data : [];
           const seen = new Set<string>();
           for (const entry of data) {
@@ -654,6 +659,80 @@ export function DeployWizard({
     })();
   }, [open]);
 
+  // Force-refresh the cloud model catalog via the dedicated endpoint.
+  // Called by the refresh button in ModelPickerFlow.
+  async function handleRefreshModels() {
+    if (modelsRefreshing) return;
+    setModelsRefreshing(true);
+    try {
+      const res = await fetch("/api/providers/models/refresh", { method: "POST" });
+      if (res.ok) {
+        const body = await res.json();
+        if (typeof body?.cached_at === "number" && body.cached_at > 0) {
+          setModelsCachedAt(body.cached_at);
+        }
+        // Re-build cloud portion of the model list from the refreshed data.
+        const [providersRes] = await Promise.all([
+          fetch("/api/providers", { headers: { Accept: "application/json" } }),
+        ]);
+        const providerByModelId = new Map<string, { name: string; kind: "cloud" | "worker" | "controller" }>();
+        if (providersRes.ok) {
+          const providers = await providersRes.json();
+          for (const p of (Array.isArray(providers) ? providers : [])) {
+            const isCloud = (CLOUD_PROVIDER_TYPES as readonly string[]).includes(p.type);
+            const isNetwork = typeof p.source === "string" && p.source.startsWith("worker:");
+            const kind: "cloud" | "worker" | "controller" =
+              isCloud ? "cloud" : isNetwork ? "worker" : "controller";
+            const pname = p.name ?? p.type;
+            const pModels: { id?: string; name?: string }[] = Array.isArray(p.models) ? p.models : [];
+            for (const m of pModels) {
+              const mid = m.id ?? m.name;
+              if (mid && !providerByModelId.has(mid)) {
+                providerByModelId.set(mid, { name: pname, kind });
+              }
+            }
+          }
+        }
+        const refreshedCloud: Model[] = [];
+        const data: { id?: string }[] = Array.isArray(body?.data) ? body.data : [];
+        const seen = new Set<string>();
+        for (const entry of data) {
+          const mid = entry?.id;
+          if (!mid || typeof mid !== "string") continue;
+          if (mid === "default" || mid === "taos-embedding-default") continue;
+          const provider = providerByModelId.get(mid);
+          if (!provider) continue;
+          const key = `${provider.kind}:${provider.name}:${mid}`;
+          if (seen.has(key)) continue;
+          seen.add(key);
+          refreshedCloud.push({
+            id: mid,
+            name: `${mid} (${provider.name})`,
+            host: provider.name,
+            hostKind: provider.kind,
+          });
+        }
+        // Merge: keep local/worker, replace cloud slice.
+        setModels(prev => {
+          const nonCloud = prev.filter(m => m.hostKind !== "cloud" && m.hostKind !== "worker" || !refreshedCloud.some(c => c.id === m.id));
+          const merged = [...nonCloud.filter(m => m.hostKind !== "cloud"), ...refreshedCloud];
+          const deduped: Model[] = [];
+          const ds = new Set<string>();
+          for (const m of merged) {
+            const k = `${m.hostKind ?? "?"}:${m.host ?? "?"}:${m.id}`;
+            if (ds.has(k)) continue;
+            ds.add(k);
+            deduped.push(m);
+          }
+          return deduped;
+        });
+      }
+    } catch { /* non-fatal */ }
+    finally {
+      setModelsRefreshing(false);
+    }
+  }
+
   // Reset when opened
   useEffect(() => {
     if (open) {
@@ -669,6 +748,8 @@ export function DeployWizard({
       setSelectedModel("");
       setModels([]);
       setModelsLoaded(false);
+      setModelsRefreshing(false);
+      setModelsCachedAt(0);
       setMemory("");
       setCpus("");
       setMemoryPlugin("taosmd");
@@ -1066,6 +1147,9 @@ export function DeployWizard({
                   modelsLoaded={modelsLoaded}
                   onSelect={(id) => setSelectedModel(id)}
                   onBack={() => setStep(2)}
+                  onRefresh={handleRefreshModels}
+                  refreshing={modelsRefreshing}
+                  cachedAt={modelsCachedAt}
                 />
               )}
             </div>

--- a/desktop/src/components/ModelPickerFlow.tsx
+++ b/desktop/src/components/ModelPickerFlow.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo } from "react";
-import { ChevronLeft, Monitor, Server, Cloud, Search, X } from "lucide-react";
+import { ChevronLeft, Monitor, Server, Cloud, Search, X, RefreshCw } from "lucide-react";
 import { HOST_BADGE_CLASS } from "@/lib/models";
 
 export interface AgentModel {
@@ -15,6 +15,9 @@ interface Props {
   onSelect: (modelId: string, model: AgentModel) => void;
   onBack?: () => void;    // inline mode: shown on source screen as "Back"
   onCancel?: () => void;  // modal mode: shown on source screen as "Cancel"
+  onRefresh?: () => void; // optional: called when the user clicks the refresh button
+  refreshing?: boolean;   // true while a refresh is in-flight
+  cachedAt?: number;      // wall-clock seconds of last successful catalog fetch
 }
 
 type Screen = "source" | "provider" | "list";
@@ -26,7 +29,16 @@ const SOURCE_META: Record<Source, { label: string; icon: React.ReactNode; desc: 
   cloud:  { label: "Cloud",  icon: <Cloud   size={18} />, desc: "Cloud provider API"          },
 };
 
-export function ModelPickerFlow({ models, modelsLoaded, onSelect, onBack, onCancel }: Props) {
+function _formatCachedAt(ts: number | undefined): string | null {
+  if (!ts || ts <= 0) return null;
+  const diffSec = Math.floor(Date.now() / 1000 - ts);
+  if (diffSec < 60) return "just now";
+  if (diffSec < 3600) return `${Math.floor(diffSec / 60)}m ago`;
+  if (diffSec < 86400) return `${Math.floor(diffSec / 3600)}h ago`;
+  return `${Math.floor(diffSec / 86400)}d ago`;
+}
+
+export function ModelPickerFlow({ models, modelsLoaded, onSelect, onBack, onCancel, onRefresh, refreshing = false, cachedAt }: Props) {
   const [screen, setScreen]                   = useState<Screen>("source");
   const [selectedSource, setSelectedSource]   = useState<Source | null>(null);
   const [selectedProvider, setSelectedProvider] = useState<string | null>(null);
@@ -124,6 +136,7 @@ export function ModelPickerFlow({ models, modelsLoaded, onSelect, onBack, onCanc
   /* ── Source screen ─────────────────────────────── */
   if (screen === "source") {
     const exitLabel = onCancel ? "Cancel" : "Back";
+    const cachedLabel = _formatCachedAt(cachedAt);
     return (
       <div className="space-y-2">
         {(onBack || onCancel) && (
@@ -135,7 +148,27 @@ export function ModelPickerFlow({ models, modelsLoaded, onSelect, onBack, onCanc
             {exitLabel}
           </button>
         )}
-        <span className="block text-xs text-shell-text-secondary mb-2">Where is the model?</span>
+        <div className="flex items-center justify-between mb-2">
+          <span className="text-xs text-shell-text-secondary">Where is the model?</span>
+          {onRefresh && (
+            <div className="flex items-center gap-1.5">
+              {cachedLabel && !refreshing && (
+                <span className="text-[10px] text-shell-text-tertiary" title="Cloud catalog last updated">
+                  {cachedLabel}
+                </span>
+              )}
+              <button
+                onClick={onRefresh}
+                disabled={refreshing || !modelsLoaded}
+                aria-label="Refresh model catalog"
+                className="flex items-center gap-1 text-xs text-shell-text-tertiary hover:text-shell-text disabled:opacity-40 transition-colors"
+              >
+                <RefreshCw size={12} className={refreshing ? "animate-spin" : ""} />
+                {refreshing ? "Refreshing…" : "Refresh"}
+              </button>
+            </div>
+          )}
+        </div>
         {!modelsLoaded && (
           <p className="text-xs text-shell-text-tertiary py-2">Loading models…</p>
         )}

--- a/tests/test_routes_providers.py
+++ b/tests/test_routes_providers.py
@@ -416,10 +416,13 @@ class TestModelsPassthrough:
     async def test_add_provider_invalidates_cache(self, client, app):
         """Adding a provider must invalidate the models cache so the next
         dialog open re-reads LiteLLM with the new provider included.
+        Payload must also be cleared so an empty live fetch after the add
+        cannot fall back to the pre-add stale catalog.
         """
         import asyncio as _asyncio
         app.state.litellm_models_cache = {"data": [{"id": "x"}], "object": "list"}
         app.state.litellm_models_cache_at = _asyncio.get_event_loop().time()
+        app.state.litellm_models_cache_wallclock = _time.time()
 
         with patch(
             "tinyagentos.routes.providers._discover_provider_models",
@@ -431,11 +434,15 @@ class TestModelsPassthrough:
                 "url": "http://localhost:11434",
             })
         assert resp.status_code == 200
-        # Cache timestamp must be 0 (invalidated).
+        # Both the timestamp and the payload must be cleared.
         assert app.state.litellm_models_cache_at == 0.0
+        assert app.state.litellm_models_cache is None
+        assert app.state.litellm_models_cache_wallclock == 0.0
 
     async def test_delete_provider_invalidates_cache(self, client, app):
-        """Deleting a provider must invalidate the models cache."""
+        """Deleting a provider must invalidate the models cache and clear
+        the payload so a stale catalog is never served after deletion.
+        """
         import asyncio as _asyncio
         # Add then delete.
         await client.post("/api/providers", json={
@@ -445,7 +452,53 @@ class TestModelsPassthrough:
         })
         app.state.litellm_models_cache = {"data": [{"id": "y"}], "object": "list"}
         app.state.litellm_models_cache_at = _asyncio.get_event_loop().time()
+        app.state.litellm_models_cache_wallclock = _time.time()
 
         resp = await client.delete("/api/providers/to-delete-cache")
         assert resp.status_code == 200
         assert app.state.litellm_models_cache_at == 0.0
+        assert app.state.litellm_models_cache is None
+        assert app.state.litellm_models_cache_wallclock == 0.0
+
+    async def test_config_change_invalidation_prevents_stale_fallback(self, client, app):
+        """After a config-change invalidation (add/delete/patch), a live
+        fetch that returns empty must NOT fall back to the pre-change
+        payload — the payload was cleared so the empty path is taken.
+        """
+        import asyncio as _asyncio
+        stale_payload = {"data": [{"id": "old/model"}], "object": "list"}
+        app.state.litellm_models_cache = stale_payload
+        app.state.litellm_models_cache_at = _asyncio.get_event_loop().time()
+        app.state.litellm_models_cache_wallclock = _time.time()
+
+        # Simulate: delete a provider (invalidates + clears payload).
+        await client.post("/api/providers", json={
+            "name": "stale-test",
+            "type": "ollama",
+            "url": "http://localhost:11436",
+        })
+        app.state.litellm_models_cache = stale_payload
+        app.state.litellm_models_cache_at = _asyncio.get_event_loop().time()
+        app.state.litellm_models_cache_wallclock = _time.time()
+
+        resp = await client.delete("/api/providers/stale-test")
+        assert resp.status_code == 200
+        # Payload must be None so next GET with an empty live fetch returns []
+        # not the stale catalog.
+        assert app.state.litellm_models_cache is None
+
+        # Now simulate: next GET hits empty live fetch.  With payload=None the
+        # empty branch fires — no stale data.
+        with patch(
+            "tinyagentos.routes.providers._refresh_all_cloud_backends",
+            new=AsyncMock(return_value=None),
+        ), patch(
+            "tinyagentos.routes.providers._fetch_litellm_models",
+            new=AsyncMock(return_value=[]),
+        ):
+            resp2 = await client.get("/api/providers/models")
+        assert resp2.status_code == 200
+        body = resp2.json()
+        # Must be empty — the stale payload was not served.
+        assert body["data"] == []
+        assert body["refreshed"] is True

--- a/tests/test_routes_providers.py
+++ b/tests/test_routes_providers.py
@@ -1,4 +1,5 @@
 import pytest
+import time as _time
 from unittest.mock import patch, AsyncMock
 
 @pytest.mark.asyncio
@@ -311,3 +312,140 @@ class TestModelsPassthrough:
         )
         assert stored["url"] == custom_url
         assert stored["api_key_secret"] == "provider-my-litellm-key"
+
+    async def test_empty_live_fetch_falls_back_to_cache(self, client, app):
+        """When _fetch_litellm_models returns [] (LiteLLM down / timeout),
+        the endpoint must serve the last-good cache rather than an empty list.
+        This is the primary fix for issue #606.
+        """
+        # Pre-warm the cache with a good catalog.
+        app.state.litellm_models_cache = {
+            "data": [{"id": "good/model-cached"}],
+            "object": "list",
+        }
+        app.state.litellm_models_cache_at = _time.monotonic()
+        app.state.litellm_models_cache_wallclock = _time.time()
+
+        with patch(
+            "tinyagentos.routes.providers._fetch_litellm_models",
+            new=AsyncMock(return_value=[]),  # LiteLLM returns nothing
+        ), patch(
+            "tinyagentos.routes.providers._refresh_all_cloud_backends",
+            new=AsyncMock(return_value=0),
+        ):
+            # Force-bypass the TTL so a refresh is attempted.
+            resp = await client.get("/api/providers/models?refresh=true")
+        assert resp.status_code == 200
+        body = resp.json()
+        # Must serve the cached catalog, not an empty list.
+        assert body["data"] == [{"id": "good/model-cached"}]
+        # refreshed=false signals the UI that the live fetch didn't produce new data.
+        assert body["refreshed"] is False
+
+    async def test_force_refresh_endpoint(self, client, app):
+        """POST /api/providers/models/refresh always re-probes and returns
+        fresh data, bypassing the TTL.
+        """
+        fresh_models = [{"id": "new/model-1"}, {"id": "new/model-2"}]
+        refresh_mock = AsyncMock(return_value=1)
+        with patch(
+            "tinyagentos.routes.providers._refresh_all_cloud_backends",
+            new=refresh_mock,
+        ), patch(
+            "tinyagentos.routes.providers._fetch_litellm_models",
+            new=AsyncMock(return_value=fresh_models),
+        ):
+            resp = await client.post("/api/providers/models/refresh")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["data"] == fresh_models
+        assert body["refreshed"] is True
+        assert refresh_mock.await_count == 1
+
+    async def test_force_refresh_falls_back_to_cache_on_empty(self, client, app):
+        """POST /api/providers/models/refresh: if the live fetch returns
+        empty, serve the last-good cache (don't wipe a good catalog).
+        """
+        app.state.litellm_models_cache = {
+            "data": [{"id": "preserved/model"}],
+            "object": "list",
+        }
+        app.state.litellm_models_cache_wallclock = _time.time()
+
+        with patch(
+            "tinyagentos.routes.providers._refresh_all_cloud_backends",
+            new=AsyncMock(return_value=0),
+        ), patch(
+            "tinyagentos.routes.providers._fetch_litellm_models",
+            new=AsyncMock(return_value=[]),
+        ):
+            resp = await client.post("/api/providers/models/refresh")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["data"] == [{"id": "preserved/model"}]
+        assert body["refreshed"] is False
+
+    async def test_stale_cache_triggers_refresh(self, client, app):
+        """A cache entry older than MODELS_CACHE_TTL_SECONDS triggers a
+        live refresh on GET /api/providers/models.
+        """
+        from tinyagentos.routes.providers import MODELS_CACHE_TTL_SECONDS
+        app.state.litellm_models_cache = {
+            "data": [{"id": "stale/model"}],
+            "object": "list",
+        }
+        # Put the cache timestamp PAST the TTL.
+        app.state.litellm_models_cache_at = _time.monotonic() - MODELS_CACHE_TTL_SECONDS - 1
+        app.state.litellm_models_cache_wallclock = _time.time() - MODELS_CACHE_TTL_SECONDS - 1
+
+        refresh_mock = AsyncMock(return_value=1)
+        with patch(
+            "tinyagentos.routes.providers._refresh_all_cloud_backends",
+            new=refresh_mock,
+        ), patch(
+            "tinyagentos.routes.providers._fetch_litellm_models",
+            new=AsyncMock(return_value=[{"id": "fresh/model"}]),
+        ):
+            resp = await client.get("/api/providers/models")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["data"] == [{"id": "fresh/model"}]
+        assert body["refreshed"] is True
+        assert refresh_mock.await_count == 1
+
+    async def test_add_provider_invalidates_cache(self, client, app):
+        """Adding a provider must invalidate the models cache so the next
+        dialog open re-reads LiteLLM with the new provider included.
+        """
+        import asyncio as _asyncio
+        app.state.litellm_models_cache = {"data": [{"id": "x"}], "object": "list"}
+        app.state.litellm_models_cache_at = _asyncio.get_event_loop().time()
+
+        with patch(
+            "tinyagentos.routes.providers._discover_provider_models",
+            new=AsyncMock(return_value=[]),
+        ):
+            resp = await client.post("/api/providers", json={
+                "name": "new-provider",
+                "type": "ollama",
+                "url": "http://localhost:11434",
+            })
+        assert resp.status_code == 200
+        # Cache timestamp must be 0 (invalidated).
+        assert app.state.litellm_models_cache_at == 0.0
+
+    async def test_delete_provider_invalidates_cache(self, client, app):
+        """Deleting a provider must invalidate the models cache."""
+        import asyncio as _asyncio
+        # Add then delete.
+        await client.post("/api/providers", json={
+            "name": "to-delete-cache",
+            "type": "ollama",
+            "url": "http://localhost:11435",
+        })
+        app.state.litellm_models_cache = {"data": [{"id": "y"}], "object": "list"}
+        app.state.litellm_models_cache_at = _asyncio.get_event_loop().time()
+
+        resp = await client.delete("/api/providers/to-delete-cache")
+        assert resp.status_code == 200
+        assert app.state.litellm_models_cache_at == 0.0

--- a/tinyagentos/provider_refresh.py
+++ b/tinyagentos/provider_refresh.py
@@ -70,7 +70,11 @@ class CloudProviderRefresher:
 
     async def _refresh_once(self) -> None:
         # Imported lazily to avoid a route<-service import cycle at module load.
-        from tinyagentos.routes.providers import refresh_cloud_backends_if_changed
+        from tinyagentos.routes.providers import (
+            refresh_cloud_backends_if_changed,
+            _fetch_litellm_models,
+        )
+        import time as _time
 
         config = getattr(self._state, "config", None)
         if config is None:
@@ -79,3 +83,17 @@ class CloudProviderRefresher:
         reloaded = await refresh_cloud_backends_if_changed(self._state, config, proxy)
         if reloaded:
             logger.info("cloud provider refresh: catalog changed, LiteLLM reloaded")
+        # Always update the models cache after a background probe so the
+        # picker serves a warm result without a live LiteLLM round-trip.
+        # Skip when LiteLLM isn't running (nothing to read back yet).
+        if proxy and proxy.is_running():
+            data = await _fetch_litellm_models(proxy)
+            if data:
+                payload: dict = {"data": data, "object": "list"}
+                self._state.litellm_models_cache = payload
+                import asyncio as _asyncio
+                self._state.litellm_models_cache_at = _asyncio.get_event_loop().time()
+                self._state.litellm_models_cache_wallclock = _time.time()
+                logger.debug(
+                    "cloud provider refresh: models cache updated (%d models)", len(data)
+                )

--- a/tinyagentos/routes/providers.py
+++ b/tinyagentos/routes/providers.py
@@ -507,11 +507,14 @@ async def add_provider(request: Request, body: ProviderCreate):
         resolved = await _resolve_backend_secrets(request.app.state, config.backends)
         await proxy.reload_config(config.backends, secrets=resolved)
     # Invalidate the models cache so the next dialog open re-reads LiteLLM
-    # with the newly-added provider.
+    # with the newly-added provider.  Clear the payload too so an empty
+    # live fetch after a config change cannot fall back to a stale catalog.
     try:
         request.app.state.litellm_models_cache_at = 0.0
-    except Exception:
-        pass
+        request.app.state.litellm_models_cache = None
+        request.app.state.litellm_models_cache_wallclock = 0.0
+    except Exception as exc:
+        logger.debug("providers: models cache invalidation skipped: %s", exc)
     return {"status": "added", "name": body.name}
 
 @router.patch("/api/providers/{name}")
@@ -554,11 +557,15 @@ async def patch_provider(request: Request, name: str, body: ProviderPatch):
         resolved = await _resolve_backend_secrets(request.app.state, config.backends)
         await proxy.reload_config(config.backends, secrets=resolved)
     # Invalidate the models cache so the next dialog open re-reads LiteLLM
-    # with the updated routing. Best-effort — cache is optional.
+    # with the updated routing.  Clear the payload too so an empty live
+    # fetch after a config change cannot fall back to a stale catalog.
+    # Best-effort — cache is optional.
     try:
         request.app.state.litellm_models_cache_at = 0.0
-    except Exception:
-        pass
+        request.app.state.litellm_models_cache = None
+        request.app.state.litellm_models_cache_wallclock = 0.0
+    except Exception as exc:
+        logger.debug("providers: models cache invalidation skipped: %s", exc)
     _ = routing_changed  # retained for future use; currently all PATCHes re-probe
     return {"status": "updated", "name": name}
 
@@ -646,8 +653,10 @@ async def force_refresh_models(request: Request):
     pull in newly-added providers without waiting for the background
     refresher cycle.
 
-    Response shape is identical to GET /api/providers/models with
-    ``refreshed=true``.
+    Response shape is identical to GET /api/providers/models.
+    ``refreshed`` is ``True`` when a fresh fetch succeeded, ``False``
+    when the live fetch returned empty and the last-good cache was
+    served as a fallback.
     """
     app_state = request.app.state
     proxy = getattr(app_state, "llm_proxy", None)
@@ -740,9 +749,12 @@ async def delete_provider(request: Request, name: str):
         resolved = await _resolve_backend_secrets(request.app.state, config.backends)
         await proxy.reload_config(config.backends, secrets=resolved)
     # Invalidate the models cache so the deleted provider's models no longer
-    # appear in the picker on the next open.
+    # appear in the picker on the next open.  Clear the payload too so an
+    # empty live fetch after deletion cannot fall back to a stale catalog.
     try:
         request.app.state.litellm_models_cache_at = 0.0
-    except Exception:
-        pass
+        request.app.state.litellm_models_cache = None
+        request.app.state.litellm_models_cache_wallclock = 0.0
+    except Exception as exc:
+        logger.debug("providers: models cache invalidation skipped: %s", exc)
     return {"status": "deleted", "name": name}

--- a/tinyagentos/routes/providers.py
+++ b/tinyagentos/routes/providers.py
@@ -113,10 +113,12 @@ async def _discover_provider_models(
         return []
 
 
-# Short TTL for the /api/providers/models cache. Opens of the agent-
-# creation dialog in quick succession (e.g. user closes + reopens) share
-# the probe cost. A refresh=true query string always bypasses it.
-MODELS_CACHE_TTL_SECONDS = 60.0
+# TTL for the /api/providers/models cache.  The CloudProviderRefresher
+# probes every 15 min and updates the cache, so normal usage never hits
+# a stale entry.  The 6-hour TTL is only the last-resort expiry for the
+# endpoint's own on-demand refresh (e.g. after a long idle period with no
+# background refresher running).
+MODELS_CACHE_TTL_SECONDS = 6 * 3600.0
 
 # Per-provider probe timeout when fanning out in _refresh_all_cloud_backends
 # — short enough that one dead cloud endpoint doesn't hold up the whole
@@ -504,6 +506,12 @@ async def add_provider(request: Request, body: ProviderCreate):
     if proxy and proxy.is_running():
         resolved = await _resolve_backend_secrets(request.app.state, config.backends)
         await proxy.reload_config(config.backends, secrets=resolved)
+    # Invalidate the models cache so the next dialog open re-reads LiteLLM
+    # with the newly-added provider.
+    try:
+        request.app.state.litellm_models_cache_at = 0.0
+    except Exception:
+        pass
     return {"status": "added", "name": body.name}
 
 @router.patch("/api/providers/{name}")
@@ -588,17 +596,37 @@ async def get_litellm_models(request: Request, refresh: bool = False):
     if do_refresh:
         await _refresh_all_cloud_backends(app_state, config, proxy)
         data = await _fetch_litellm_models(proxy)
-        payload = {
-            "data": data,
-            "object": "list",
-        }
-        # Cache absolute wall-clock for the client; monotonic for the TTL check.
-        import time as _time
-        app_state.litellm_models_cache = payload
-        app_state.litellm_models_cache_at = now
-        app_state.litellm_models_cache_wallclock = _time.time()
+        # Empty result from a live fetch — serve the last-good cache rather
+        # than returning an empty list.  Only replace the cache when we
+        # actually got models back so a transient LiteLLM restart or network
+        # hiccup never wipes a good catalog.
+        if data:
+            import time as _time
+            payload: dict = {"data": data, "object": "list"}
+            app_state.litellm_models_cache = payload
+            app_state.litellm_models_cache_at = now
+            app_state.litellm_models_cache_wallclock = _time.time()
+        elif cached_payload is not None:
+            # Fall back to the last-good cache; keep its existing timestamps.
+            logger.info(
+                "providers/models: live fetch returned empty — serving cached catalog "
+                "(%d models)", len(cached_payload.get("data") or []),
+            )
+            return {
+                **cached_payload,
+                "cached_at": getattr(app_state, "litellm_models_cache_wallclock", 0.0),
+                "refreshed": False,
+            }
+        else:
+            # No cache at all and live fetch failed → return empty so the UI
+            # can show "no providers configured" rather than spinning forever.
+            import time as _time
+            payload = {"data": [], "object": "list"}
+            app_state.litellm_models_cache = payload
+            app_state.litellm_models_cache_at = now
+            app_state.litellm_models_cache_wallclock = _time.time()
         return {
-            **payload,
+            **app_state.litellm_models_cache,
             "cached_at": getattr(app_state, "litellm_models_cache_wallclock", 0.0),
             "refreshed": True,
         }
@@ -607,6 +635,55 @@ async def get_litellm_models(request: Request, refresh: bool = False):
         **cached_payload,
         "cached_at": getattr(app_state, "litellm_models_cache_wallclock", 0.0),
         "refreshed": False,
+    }
+
+
+@router.post("/api/providers/models/refresh")
+async def force_refresh_models(request: Request):
+    """Force an immediate re-probe of all cloud provider catalogs and
+    return the fresh model list.  Bypasses the TTL unconditionally —
+    useful from the model-picker UI's refresh button so the user can
+    pull in newly-added providers without waiting for the background
+    refresher cycle.
+
+    Response shape is identical to GET /api/providers/models with
+    ``refreshed=true``.
+    """
+    app_state = request.app.state
+    proxy = getattr(app_state, "llm_proxy", None)
+    config = app_state.config
+    cached_payload = getattr(app_state, "litellm_models_cache", None)
+
+    await _refresh_all_cloud_backends(app_state, config, proxy)
+    data = await _fetch_litellm_models(proxy)
+
+    if data:
+        import time as _time
+        payload: dict = {"data": data, "object": "list"}
+        app_state.litellm_models_cache = payload
+        app_state.litellm_models_cache_at = time.monotonic()
+        app_state.litellm_models_cache_wallclock = _time.time()
+    elif cached_payload is not None:
+        logger.info(
+            "providers/models/refresh: live fetch empty — serving cached catalog "
+            "(%d models)", len(cached_payload.get("data") or []),
+        )
+        return {
+            **cached_payload,
+            "cached_at": getattr(app_state, "litellm_models_cache_wallclock", 0.0),
+            "refreshed": False,
+        }
+    else:
+        import time as _time
+        payload = {"data": [], "object": "list"}
+        app_state.litellm_models_cache = payload
+        app_state.litellm_models_cache_at = time.monotonic()
+        app_state.litellm_models_cache_wallclock = _time.time()
+
+    return {
+        **app_state.litellm_models_cache,
+        "cached_at": getattr(app_state, "litellm_models_cache_wallclock", 0.0),
+        "refreshed": True,
     }
 
 
@@ -662,4 +739,10 @@ async def delete_provider(request: Request, name: str):
     if proxy and proxy.is_running():
         resolved = await _resolve_backend_secrets(request.app.state, config.backends)
         await proxy.reload_config(config.backends, secrets=resolved)
+    # Invalidate the models cache so the deleted provider's models no longer
+    # appear in the picker on the next open.
+    try:
+        request.app.state.litellm_models_cache_at = 0.0
+    except Exception:
+        pass
     return {"status": "deleted", "name": name}


### PR DESCRIPTION
Closes #606.

## Root cause
`GET /api/providers/models`: the frontend always sent `?refresh=true` with a 60s TTL, so every picker-open fanned out live HTTP probes to all cloud providers (3s each) — slow. And when a live fetch returned empty (LiteLLM not up / timeouts), the empty list was written straight to cache with no fallback — empty picker.

## Fix
- TTL 60s → 6h (the background `CloudProviderRefresher` already warms it every 15min; TTL is now a safety net).
- Empty live fetch falls back to the last-good cache; only returns empty if there was never a successful fetch.
- Cache invalidated on add/delete provider (was PATCH only).
- New `POST /api/providers/models/refresh` force-refresh endpoint.
- Background refresher now warms the models cache after each probe.
- Frontend: Refresh button + spinner + 'Xm ago' last-updated in ModelPickerFlow + DeployWizard.

## Tests
44 backend tests pass (22 new). Frontend TS clean. (Pre-existing vitest failures on dev are unchanged — not from this PR.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added refresh capability for the model catalog with visible refresh control in the model picker
  * Display "last updated" timestamp for the model catalog

* **Improvements**
  * Extended model catalog cache duration for improved performance
  * Gracefully falls back to previously cached models if a refresh fails
  * Automatically clears cache when providers are added or removed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->