### PR TITLE
feat(#611): EventBus core — unified system-event spine (E1)

### DIFF
--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -353,3 +353,107 @@ async def test_emit_event_helper_pulls_from_app_state():
 
     assert len(trace.events) == 1
     assert len(notifications.calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Finding 1 — SystemEventStore.close() is callable
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_system_event_store_close_is_callable(tmp_path):
+    """close() must exist on SystemEventStore and leave the store unusable."""
+    store = SystemEventStore(tmp_path / "close-test.db")
+    await store.init()
+    # Should not raise
+    await store.close()
+    # Underlying connection should be gone
+    assert store._db is None
+
+
+# ---------------------------------------------------------------------------
+# Finding 2 — emit() deduplicates targets
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_emit_duplicate_agent_targets_delivers_once():
+    """Duplicate agent ids in targets must not cause duplicate sends."""
+    bus = EventBus()
+    notifications = FakeNotifications()
+    agent_messages = FakeAgentMessages()
+    trace = FakeTraceStore()
+
+    ev = _make_event(targets=["agent-x", "agent-x"])
+    await bus.emit(ev, notifications=notifications, agent_messages=agent_messages, trace_store=trace)
+
+    # agent_messages.send should be called exactly once for agent-x
+    assert len(agent_messages.calls) == 1
+    assert agent_messages.calls[0]["to"] == "agent-x"
+
+
+@pytest.mark.asyncio
+async def test_emit_broadcast_in_targets_delivers_once_to_broadcast_channel():
+    """broadcast in targets must not cause a double publish to the broadcast channel."""
+    bus = EventBus()
+    notifications = FakeNotifications()
+    agent_messages = FakeAgentMessages()
+    trace = FakeTraceStore()
+
+    bcast_queue = await bus.subscribe("broadcast")
+    ev = _make_event(targets=["broadcast"])
+    await bus.emit(ev, notifications=notifications, agent_messages=agent_messages, trace_store=trace)
+
+    # Exactly one item on the broadcast queue
+    received = bcast_queue.get_nowait()
+    assert received is ev
+    assert bcast_queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_emit_duplicate_targets_single_channel_delivery():
+    """A subscriber on a channel gets the event exactly once despite duplicate targets."""
+    bus = EventBus()
+    notifications = FakeNotifications()
+    agent_messages = FakeAgentMessages()
+    trace = FakeTraceStore()
+
+    queue = await bus.subscribe("agent-y")
+    ev = _make_event(targets=["agent-y", "agent-y", "agent-y"])
+    await bus.emit(ev, notifications=notifications, agent_messages=agent_messages, trace_store=trace)
+
+    received = queue.get_nowait()
+    assert received is ev
+    assert queue.empty()
+
+
+# ---------------------------------------------------------------------------
+# Finding 3 — SystemEventStore.list() clamps limit
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_store_list_negative_limit_clamped(tmp_path):
+    """list(limit=-1) must not trigger an unbounded SQLite read; clamps to 1."""
+    store = SystemEventStore(tmp_path / "clamp-test.db")
+    await store.init()
+    try:
+        for i in range(5):
+            await store.add(_make_event(kind=f"ev.{i}"))
+        rows = await store.list(limit=-1)
+        # Should return at most 1 row (clamped to max(1, ...))
+        assert len(rows) <= 1
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_store_list_huge_limit_clamped(tmp_path):
+    """list(limit=99999) must be clamped to at most 1000 rows returned."""
+    store = SystemEventStore(tmp_path / "huge-limit-test.db")
+    await store.init()
+    try:
+        for i in range(5):
+            await store.add(_make_event(kind=f"ev.{i}"))
+        rows = await store.list(limit=99999)
+        # Only 5 rows exist; all returned, but the SQL cap was 1000 not 99999
+        assert len(rows) == 5
+    finally:
+        await store.close()

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -1,0 +1,355 @@
+"""Tests for the EventBus core (tinyagentos/events/)."""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import pytest_asyncio
+
+from tinyagentos.events.bus import EventBus, SystemEvent, _derive_notification, emit_event
+from tinyagentos.events.store import SystemEventStore
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fakes
+# ---------------------------------------------------------------------------
+
+def _make_event(**kwargs) -> SystemEvent:
+    defaults = dict(
+        kind="test.event",
+        source="system",
+        targets=["user"],
+        payload={"message": "hello"},
+    )
+    defaults.update(kwargs)
+    return SystemEvent(**defaults)
+
+
+class FakeNotifications:
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    async def add(self, title: str, message: str, level: str = "info", source: str = "system"):
+        self.calls.append({"title": title, "message": message, "level": level, "source": source})
+
+
+class FakeAgentMessages:
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    async def send(self, from_agent: str, to_agent: str, message: str, **_kwargs):
+        self.calls.append({"from": from_agent, "to": to_agent, "message": message})
+
+
+class FakeTraceStore:
+    def __init__(self):
+        self.events: list[SystemEvent] = []
+
+    async def add(self, event: SystemEvent):
+        self.events.append(event)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_emit_persists_to_trace_store():
+    bus = EventBus()
+    notifications = FakeNotifications()
+    agent_messages = FakeAgentMessages()
+    trace = FakeTraceStore()
+
+    ev = _make_event(targets=[])  # no notification or agent routing
+    await bus.emit(ev, notifications=notifications, agent_messages=agent_messages, trace_store=trace)
+
+    assert len(trace.events) == 1
+    assert trace.events[0] is ev
+
+
+@pytest.mark.asyncio
+async def test_emit_user_target_calls_notifications_add():
+    bus = EventBus()
+    notifications = FakeNotifications()
+    agent_messages = FakeAgentMessages()
+    trace = FakeTraceStore()
+
+    ev = _make_event(targets=["user"], payload={"message": "disk full"})
+    await bus.emit(ev, notifications=notifications, agent_messages=agent_messages, trace_store=trace)
+
+    assert len(notifications.calls) == 1
+    assert notifications.calls[0]["level"] == "info"
+    assert notifications.calls[0]["source"] == "system"
+
+
+@pytest.mark.asyncio
+async def test_emit_warning_level_calls_notifications_even_without_user_target():
+    bus = EventBus()
+    notifications = FakeNotifications()
+    agent_messages = FakeAgentMessages()
+    trace = FakeTraceStore()
+
+    ev = _make_event(targets=[], level="warning", payload={})
+    await bus.emit(ev, notifications=notifications, agent_messages=agent_messages, trace_store=trace)
+
+    assert len(notifications.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_emit_error_level_calls_notifications():
+    bus = EventBus()
+    notifications = FakeNotifications()
+    agent_messages = FakeAgentMessages()
+    trace = FakeTraceStore()
+
+    ev = _make_event(targets=[], level="error", payload={})
+    await bus.emit(ev, notifications=notifications, agent_messages=agent_messages, trace_store=trace)
+
+    assert len(notifications.calls) == 1
+    assert notifications.calls[0]["level"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_emit_agent_id_target_calls_agent_messages_send():
+    bus = EventBus()
+    notifications = FakeNotifications()
+    agent_messages = FakeAgentMessages()
+    trace = FakeTraceStore()
+
+    ev = _make_event(targets=["my-agent"], payload={"detail": "restarted"})
+    await bus.emit(ev, notifications=notifications, agent_messages=agent_messages, trace_store=trace)
+
+    assert len(agent_messages.calls) == 1
+    call = agent_messages.calls[0]
+    assert call["from"] == "system"
+    assert call["to"] == "my-agent"
+
+
+@pytest.mark.asyncio
+async def test_emit_user_sentinel_not_forwarded_as_agent_message():
+    """'user' and 'broadcast' sentinels must not be sent as agent messages."""
+    bus = EventBus()
+    notifications = FakeNotifications()
+    agent_messages = FakeAgentMessages()
+    trace = FakeTraceStore()
+
+    ev = _make_event(targets=["user", "broadcast"])
+    await bus.emit(ev, notifications=notifications, agent_messages=agent_messages, trace_store=trace)
+
+    assert len(agent_messages.calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_subscribe_receives_published_event():
+    bus = EventBus()
+    notifications = FakeNotifications()
+    agent_messages = FakeAgentMessages()
+    trace = FakeTraceStore()
+
+    queue = await bus.subscribe("my-agent")
+    ev = _make_event(targets=["my-agent"])
+    await bus.emit(ev, notifications=notifications, agent_messages=agent_messages, trace_store=trace)
+
+    received = queue.get_nowait()
+    assert received is ev
+
+
+@pytest.mark.asyncio
+async def test_broadcast_channel_receives_every_event():
+    bus = EventBus()
+    notifications = FakeNotifications()
+    agent_messages = FakeAgentMessages()
+    trace = FakeTraceStore()
+
+    queue = await bus.subscribe("broadcast")
+    ev = _make_event(targets=["some-other-agent"])
+    await bus.emit(ev, notifications=notifications, agent_messages=agent_messages, trace_store=trace)
+
+    received = queue.get_nowait()
+    assert received is ev
+
+
+@pytest.mark.asyncio
+async def test_subscribe_replays_buffered_events():
+    bus = EventBus()
+    notifications = FakeNotifications()
+    agent_messages = FakeAgentMessages()
+    trace = FakeTraceStore()
+
+    ev = _make_event(targets=["my-agent"])
+    await bus.emit(ev, notifications=notifications, agent_messages=agent_messages, trace_store=trace)
+
+    # Subscribe AFTER emit — replay should fill the queue
+    queue = await bus.subscribe("my-agent")
+    replayed = queue.get_nowait()
+    assert replayed is ev
+
+
+@pytest.mark.asyncio
+async def test_permission_check_false_drops_event():
+    bus = EventBus()
+    notifications = FakeNotifications()
+    agent_messages = FakeAgentMessages()
+    trace = FakeTraceStore()
+
+    ev = _make_event(targets=["user"])
+    await bus.emit(
+        ev,
+        notifications=notifications,
+        agent_messages=agent_messages,
+        trace_store=trace,
+        permission_check=lambda e: False,
+    )
+
+    # Nothing should be routed
+    assert len(trace.events) == 0
+    assert len(notifications.calls) == 0
+    assert len(agent_messages.calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_permission_check_true_allows_event():
+    bus = EventBus()
+    notifications = FakeNotifications()
+    agent_messages = FakeAgentMessages()
+    trace = FakeTraceStore()
+
+    ev = _make_event(targets=["user"])
+    await bus.emit(
+        ev,
+        notifications=notifications,
+        agent_messages=agent_messages,
+        trace_store=trace,
+        permission_check=lambda e: True,
+    )
+
+    assert len(trace.events) == 1
+    assert len(notifications.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_async_permission_check_supported():
+    """permission_check may be an async function."""
+    bus = EventBus()
+    notifications = FakeNotifications()
+    agent_messages = FakeAgentMessages()
+    trace = FakeTraceStore()
+
+    async def _deny(event: SystemEvent) -> bool:
+        return False
+
+    ev = _make_event(targets=["user"])
+    await bus.emit(
+        ev,
+        notifications=notifications,
+        agent_messages=agent_messages,
+        trace_store=trace,
+        permission_check=_deny,
+    )
+
+    assert len(trace.events) == 0
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe_stops_delivery():
+    bus = EventBus()
+    notifications = FakeNotifications()
+    agent_messages = FakeAgentMessages()
+    trace = FakeTraceStore()
+
+    queue = await bus.subscribe("my-agent")
+    await bus.unsubscribe("my-agent", queue)
+
+    ev = _make_event(targets=["my-agent"])
+    await bus.emit(ev, notifications=notifications, agent_messages=agent_messages, trace_store=trace)
+
+    assert queue.empty()
+
+
+# ---------------------------------------------------------------------------
+# SystemEventStore tests (real SQLite via tmp_path)
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture
+async def event_store(tmp_path):
+    store = SystemEventStore(tmp_path / "test-events.db")
+    await store.init()
+    yield store
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_store_add_and_list(event_store):
+    ev = _make_event(kind="worker.join", targets=["user"], payload={"worker_id": "w1"})
+    await event_store.add(ev)
+
+    rows = await event_store.list()
+    assert len(rows) == 1
+    assert rows[0]["kind"] == "worker.join"
+    assert rows[0]["targets"] == ["user"]
+    assert rows[0]["payload"] == {"worker_id": "w1"}
+    assert rows[0]["trace_id"] == ev.trace_id
+
+
+@pytest.mark.asyncio
+async def test_store_list_filter_by_kind(event_store):
+    ev1 = _make_event(kind="worker.join")
+    ev2 = _make_event(kind="backend.up")
+    await event_store.add(ev1)
+    await event_store.add(ev2)
+
+    rows = await event_store.list(kind="worker.join")
+    assert len(rows) == 1
+    assert rows[0]["kind"] == "worker.join"
+
+
+@pytest.mark.asyncio
+async def test_store_list_limit(event_store):
+    for i in range(5):
+        await event_store.add(_make_event(kind=f"event.{i}"))
+
+    rows = await event_store.list(limit=3)
+    assert len(rows) == 3
+
+
+# ---------------------------------------------------------------------------
+# _derive_notification helper
+# ---------------------------------------------------------------------------
+
+def test_derive_notification_uses_payload_message():
+    ev = _make_event(kind="worker.join", payload={"message": "Worker W1 joined"})
+    title, message = _derive_notification(ev)
+    assert "Worker" in title or "Join" in title
+    assert message == "Worker W1 joined"
+
+
+def test_derive_notification_falls_back_to_source():
+    ev = _make_event(kind="test.thing", payload={})
+    title, message = _derive_notification(ev)
+    assert "system" in message
+
+
+# ---------------------------------------------------------------------------
+# emit_event helper (app_state integration)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_emit_event_helper_pulls_from_app_state():
+    notifications = FakeNotifications()
+    agent_messages = FakeAgentMessages()
+    trace = FakeTraceStore()
+    bus = EventBus()
+
+    app_state = MagicMock()
+    app_state.event_bus = bus
+    app_state.notifications = notifications
+    app_state.agent_messages = agent_messages
+    app_state.system_events = trace
+
+    ev = _make_event(targets=["user"])
+    await emit_event(app_state, ev)
+
+    assert len(trace.events) == 1
+    assert len(notifications.calls) == 1

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -1005,6 +1005,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await browser_store.close()
         await secrets_store.close()
         await notif_store.close()
+        await app.state.system_events.close()
         await metrics_store.close()
         await qmd_client.close()
         await http_client.aclose()

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -903,6 +903,13 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
             logger.exception("mdns publisher failed to start — continuing without")
             app.state.mdns_publisher = None
 
+        # System event bus — unified typed-event broadcast.
+        from tinyagentos.events import EventBus, SystemEventStore
+        _system_events = SystemEventStore(data_dir / "system-events.db")
+        await _system_events.init()
+        app.state.system_events = _system_events
+        app.state.event_bus = EventBus()
+
         yield
         # NOTE: controller restart/shutdown does NOT touch agent containers —
         # agents and LiteLLM keep running independently, so there's nothing to

--- a/tinyagentos/events/__init__.py
+++ b/tinyagentos/events/__init__.py
@@ -1,0 +1,4 @@
+from tinyagentos.events.bus import EventBus, SystemEvent, emit_event
+from tinyagentos.events.store import SystemEventStore
+
+__all__ = ["EventBus", "SystemEvent", "SystemEventStore", "emit_event"]

--- a/tinyagentos/events/bus.py
+++ b/tinyagentos/events/bus.py
@@ -122,8 +122,9 @@ class EventBus:
             except Exception:
                 logger.exception("EventBus: notifications.add failed for event %s", event.trace_id)
 
-        # d. Agent messages
-        for target in event.targets:
+        # d. Agent messages — deduplicate targets to avoid duplicate sends
+        _seen_targets: dict[str, None] = dict.fromkeys(event.targets)
+        for target in _seen_targets:
             if target in ("user", _BROADCAST_CHANNEL):
                 continue
             try:
@@ -139,13 +140,13 @@ class EventBus:
                     target, event.trace_id,
                 )
 
-        # e. In-process pub/sub
+        # e. In-process pub/sub — deduplicate, then ensure broadcast is published
+        #    exactly once even if it appeared in targets.
         async with self._lock:
-            # Publish to every named target channel
-            for target in event.targets:
+            for target in _seen_targets:
                 await self._publish_to_channel(target, event)
-            # Always publish to the broadcast channel
-            await self._publish_to_channel(_BROADCAST_CHANNEL, event)
+            if _BROADCAST_CHANNEL not in _seen_targets:
+                await self._publish_to_channel(_BROADCAST_CHANNEL, event)
 
 
 # ------------------------------------------------------------------

--- a/tinyagentos/events/bus.py
+++ b/tinyagentos/events/bus.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+import uuid
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SystemEvent:
+    kind: str
+    source: str  # e.g. "system", "scheduler", or an agent name
+    targets: list[str]  # agent ids and/or sentinels "user" / "broadcast"
+    payload: dict[str, Any]
+    level: str = "info"
+    ts: float = field(default_factory=time.time)
+    trace_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+
+
+# Sentinel channel that every subscriber can also listen on for all events.
+_BROADCAST_CHANNEL = "broadcast"
+
+PermissionCheck = Callable[[SystemEvent], bool | Awaitable[bool]]
+
+
+class EventBus:
+    """In-process pub/sub for SystemEvents, mirroring ProjectEventBroker.
+
+    Channels correspond to target names (agent ids) plus the "broadcast"
+    sentinel that receives every emitted event regardless of targets.
+
+    Single-worker assumption: all subscribers/publishers share one process.
+    """
+
+    def __init__(self, replay_size: int = 32) -> None:
+        self._replay_size = replay_size
+        self._queues: dict[str, list[asyncio.Queue[SystemEvent]]] = {}
+        self._replay: dict[str, deque[SystemEvent]] = {}
+        self._lock = asyncio.Lock()
+
+    # ------------------------------------------------------------------
+    # Subscribe / unsubscribe / replay  (mirrors ProjectEventBroker API)
+    # ------------------------------------------------------------------
+
+    async def subscribe(self, channel: str) -> asyncio.Queue[SystemEvent]:
+        """Return a queue that receives future events on *channel*.
+
+        Already-buffered events are replayed into the queue immediately.
+        """
+        queue: asyncio.Queue[SystemEvent] = asyncio.Queue()
+        async with self._lock:
+            self._queues.setdefault(channel, []).append(queue)
+            for ev in self._replay.get(channel, ()):
+                queue.put_nowait(ev)
+        return queue
+
+    async def unsubscribe(self, channel: str, queue: asyncio.Queue[SystemEvent]) -> None:
+        async with self._lock:
+            qs = self._queues.get(channel, [])
+            if queue in qs:
+                qs.remove(queue)
+
+    async def _publish_to_channel(self, channel: str, event: SystemEvent) -> None:
+        """Append *event* to the replay buffer and fan it out to all queues."""
+        buf = self._replay.setdefault(channel, deque(maxlen=self._replay_size))
+        buf.append(event)
+        for q in list(self._queues.get(channel, [])):
+            q.put_nowait(event)
+
+    # ------------------------------------------------------------------
+    # Emit
+    # ------------------------------------------------------------------
+
+    async def emit(
+        self,
+        event: SystemEvent,
+        *,
+        notifications,
+        agent_messages,
+        trace_store,
+        permission_check: PermissionCheck | None = None,
+    ) -> None:
+        """Route *event* through all sinks.
+
+        Steps:
+        a. Run permission_check if provided; drop silently on False.
+        b. Persist to trace_store.
+        c. If "user" in targets or level in {warning, error}: push a
+           user notification.
+        d. For each agent id in targets: send an agent message.
+        e. Publish to in-process channels for each target + "broadcast".
+        """
+        # a. Permission gate (stub; default allow)
+        if permission_check is not None:
+            result = permission_check(event)
+            if asyncio.iscoroutine(result):
+                result = await result
+            if not result:
+                return
+
+        # b. Persist to trace store
+        try:
+            await trace_store.add(event)
+        except Exception:
+            logger.exception("EventBus: trace_store.add failed for event %s", event.trace_id)
+
+        # c. User notification
+        should_notify_user = (
+            "user" in event.targets
+            or event.level in {"warning", "error"}
+        )
+        if should_notify_user:
+            title, message = _derive_notification(event)
+            try:
+                await notifications.add(title, message, level=event.level, source=event.source)
+            except Exception:
+                logger.exception("EventBus: notifications.add failed for event %s", event.trace_id)
+
+        # d. Agent messages
+        for target in event.targets:
+            if target in ("user", _BROADCAST_CHANNEL):
+                continue
+            try:
+                await agent_messages.send(
+                    from_agent="system",
+                    to_agent=target,
+                    message=json.dumps({"kind": event.kind, "payload": event.payload,
+                                        "trace_id": event.trace_id, "ts": event.ts}),
+                )
+            except Exception:
+                logger.exception(
+                    "EventBus: agent_messages.send failed for target=%s event=%s",
+                    target, event.trace_id,
+                )
+
+        # e. In-process pub/sub
+        async with self._lock:
+            # Publish to every named target channel
+            for target in event.targets:
+                await self._publish_to_channel(target, event)
+            # Always publish to the broadcast channel
+            await self._publish_to_channel(_BROADCAST_CHANNEL, event)
+
+
+# ------------------------------------------------------------------
+# Notification text derivation
+# ------------------------------------------------------------------
+
+def _derive_notification(event: SystemEvent) -> tuple[str, str]:
+    """Return (title, message) for a user-visible notification."""
+    kind_label = event.kind.replace(".", " ").replace("_", " ").title()
+    title = f"{kind_label}"
+    # Use payload "message" key if present, otherwise a short summary
+    message = event.payload.get("message") or event.payload.get("detail") or ""
+    if not message:
+        message = f"source={event.source}"
+    return title, message
+
+
+# ------------------------------------------------------------------
+# App-state helper
+# ------------------------------------------------------------------
+
+async def emit_event(app_state, event: SystemEvent) -> None:
+    """Convenience helper: pull stores from app_state and call bus.emit.
+
+    Usage in a route or background task::
+
+        from tinyagentos.events import emit_event, SystemEvent
+        await emit_event(request.app.state, SystemEvent(
+            kind="worker.join", source="cluster", targets=["user"],
+            payload={"worker_id": w_id},
+        ))
+    """
+    bus: EventBus = app_state.event_bus
+    await bus.emit(
+        event,
+        notifications=app_state.notifications,
+        agent_messages=app_state.agent_messages,
+        trace_store=app_state.system_events,
+    )

--- a/tinyagentos/events/store.py
+++ b/tinyagentos/events/store.py
@@ -43,6 +43,7 @@ class SystemEventStore(BaseStore):
         await self._db.commit()
 
     async def list(self, limit: int = 100, kind: str | None = None) -> list[dict]:
+        limit = max(1, min(int(limit), 1000))
         if kind is not None:
             sql = (
                 "SELECT id, kind, source, targets, level, payload, ts, trace_id "

--- a/tinyagentos/events/store.py
+++ b/tinyagentos/events/store.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tinyagentos.base_store import BaseStore
+from tinyagentos.events.bus import SystemEvent
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS system_events (
+    id       INTEGER PRIMARY KEY AUTOINCREMENT,
+    kind     TEXT    NOT NULL,
+    source   TEXT    NOT NULL,
+    targets  TEXT    NOT NULL,
+    level    TEXT    NOT NULL,
+    payload  TEXT    NOT NULL,
+    ts       REAL    NOT NULL,
+    trace_id TEXT    NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_sev_ts   ON system_events(ts DESC);
+CREATE INDEX IF NOT EXISTS idx_sev_kind ON system_events(kind);
+"""
+
+
+class SystemEventStore(BaseStore):
+    SCHEMA = _SCHEMA
+
+    async def add(self, event: SystemEvent) -> None:
+        await self._db.execute(
+            """INSERT INTO system_events
+               (kind, source, targets, level, payload, ts, trace_id)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (
+                event.kind,
+                event.source,
+                json.dumps(event.targets),
+                event.level,
+                json.dumps(event.payload),
+                event.ts,
+                event.trace_id,
+            ),
+        )
+        await self._db.commit()
+
+    async def list(self, limit: int = 100, kind: str | None = None) -> list[dict]:
+        if kind is not None:
+            sql = (
+                "SELECT id, kind, source, targets, level, payload, ts, trace_id "
+                "FROM system_events WHERE kind = ? ORDER BY ts DESC LIMIT ?"
+            )
+            params = (kind, limit)
+        else:
+            sql = (
+                "SELECT id, kind, source, targets, level, payload, ts, trace_id "
+                "FROM system_events ORDER BY ts DESC LIMIT ?"
+            )
+            params = (limit,)
+        async with self._db.execute(sql, params) as cursor:
+            rows = await cursor.fetchall()
+        return [
+            {
+                "id": r[0],
+                "kind": r[1],
+                "source": r[2],
+                "targets": json.loads(r[3]),
+                "level": r[4],
+                "payload": json.loads(r[5]),
+                "ts": r[6],
+                "trace_id": r[7],
+            }
+            for r in rows
+        ]

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -252,3 +252,6 @@ def register_all_routers(app):
 
     from tinyagentos.routes.gh_webhook import router as gh_webhook_router
     app.include_router(gh_webhook_router)
+
+    from tinyagentos.routes.events import router as events_router
+    app.include_router(events_router)

--- a/tinyagentos/routes/events.py
+++ b/tinyagentos/routes/events.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Request
+
+from tinyagentos.auth import get_current_user
+
+router = APIRouter()
+
+
+@router.get("/api/events")
+async def list_system_events(
+    request: Request,
+    limit: int = 100,
+    kind: str | None = None,
+    _user: dict = Depends(get_current_user),
+):
+    """Return the system event trace log (newest first)."""
+    store = request.app.state.system_events
+    events = await store.list(limit=limit, kind=kind)
+    return {"events": events, "count": len(events)}


### PR DESCRIPTION
First slice of the unified event/notification bus (#611). **Additive** — routes typed events to the existing stores, replaces nothing.

- `SystemEvent {kind, source, targets, level, payload, ts, trace_id}` + `EventBus.emit()` → persists to a `system_events` trace, routes to NotificationStore (user), agent_messages (agent targets, from='system'), + in-process pub/sub (mirrors ProjectEventBroker).
- `emit_event(app_state, event)` helper; `GET /api/events` trace route; wired into app.state.
- Permission hook is a stub (default allow) per the approved design.
- 19 unit tests.

Next (separate PRs): wire F's session_migrating/resumed + #610 browser-request onto it; app.installed → Launchpad refresh; post-beta migrate the other producers + real permission gating.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added system-wide event tracking and routing infrastructure with persistent storage
  * New API endpoint (`/api/events`) to retrieve system events, filterable by type with configurable limits

* **Tests**
  * Comprehensive test suite covering event emission, routing, subscriptions, storage, and API integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->