### PR TITLE
fix(containers): agent terminal/TUI PTY — incus exec --force-interactive (not --tty)

### DIFF
--- a/tinyagentos/containers/lxc.py
+++ b/tinyagentos/containers/lxc.py
@@ -54,8 +54,11 @@ class _IncusPtyHandle(PtyHandle):
 def _open_incus_pty(container: str, shell_cmd: str) -> _IncusPtyHandle:
     """Open an incus exec session with a real PTY."""
     master_fd, slave_fd = pty.openpty()
+    # `incus exec` has no --tty/--interactive flags; -t/--force-interactive
+    # forces pseudo-terminal allocation. stdin/stdout are wired to the PTY slave
+    # below, so this gives a real interactive terminal in the container.
     proc = subprocess.Popen(
-        ["incus", "exec", "--tty", "--interactive", container, "--",
+        ["incus", "exec", "--force-interactive", container, "--",
          "bash", "-lc", shell_cmd],
         stdin=slave_fd,
         stdout=slave_fd,


### PR DESCRIPTION
Agent terminal/TUI failed with `error: unknown flag: --tty`. `incus exec` has no `--tty`/`--interactive` flags — the correct flag is `-t`/`--force-interactive` (confirmed against the live Pi's incus). This only surfaced now that #607's redirect fix lets the WebSocket actually reach the PTY spawn. One-line fix in `containers/lxc.py`.