### PR TITLE
feat(#619): onboarding backend — account email tests + /api/setup/status + dismiss

### DIFF
--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -65,6 +65,8 @@ import {
   writeLastChannel,
 } from "./MessagesApp.a2aSelection";
 import { displayAuthor } from "./chat/format-author";
+import { useProcessStore } from "@/stores/process-store";
+import { getApp } from "@/registry/app-registry";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -244,8 +246,14 @@ export function MessagesApp({
 }) {
   const isMobile = useIsMobile();
   const { keyboardInset } = useVisualViewport();
+  const openWindow = useProcessStore((s) => s.openWindow);
+  const openAgentsApp = () => {
+    const app = getApp("agents");
+    if (app) openWindow("agents", app.defaultSize);
+  };
 
   const [channels, setChannels] = useState<Channel[]>([]);
+  const [channelsLoaded, setChannelsLoaded] = useState(false);
   const shellFileDropTarget = useDropTarget({
     accept: ["file"],
     onDrop: async (payload) => {
@@ -335,6 +343,8 @@ export function MessagesApp({
       }
     } catch {
       /* offline */
+    } finally {
+      setChannelsLoaded(true);
     }
   }, [scope?.projectId]);
 
@@ -1097,6 +1107,12 @@ export function MessagesApp({
     { label: "Groups", icon: <Users size={13} />, items: grouped.group },
   ];
 
+  const allEmpty =
+    channelsLoaded &&
+    SECTIONS.every((s) => s.items.length === 0) &&
+    archivedChannels.length === 0 &&
+    projectGroups.length === 0;
+
   /* ---------------------------------------------------------------- */
   /*  Channel list — iOS 26 grouped on mobile, flat sidebar on desktop */
   /* ---------------------------------------------------------------- */
@@ -1115,7 +1131,20 @@ export function MessagesApp({
         )}
       </div>
 
-      {SECTIONS.map((section) => (
+      {allEmpty ? (
+        <div style={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", padding: "48px 24px", textAlign: "center", gap: 12 }}>
+          <MessageCircle size={36} style={{ color: "rgba(255,255,255,0.15)" }} aria-hidden="true" />
+          <p style={{ fontSize: 15, fontWeight: 600, color: "rgba(255,255,255,0.7)", margin: 0 }}>No conversations yet</p>
+          <p style={{ fontSize: 13, color: "rgba(255,255,255,0.35)", margin: 0 }}>Deploy an agent to start chatting</p>
+          <button
+            type="button"
+            onClick={openAgentsApp}
+            style={{ marginTop: 4, fontSize: 13, padding: "8px 16px", borderRadius: 10, background: "rgba(59,130,246,0.2)", border: "1px solid rgba(59,130,246,0.3)", color: "rgba(147,197,253,0.9)", cursor: "pointer" }}
+          >
+            Open Agents
+          </button>
+        </div>
+      ) : SECTIONS.map((section) => (
         <div key={section.label} style={{ marginBottom: 20 }}>
           <div style={{ fontSize: 12, textTransform: "uppercase", letterSpacing: 0.5, color: "rgba(255,255,255,0.45)", padding: "0 20px 6px", fontWeight: 600, display: "flex", alignItems: "center", gap: 6 }}>
             {section.icon} {section.label}
@@ -1338,7 +1367,21 @@ export function MessagesApp({
 
       {/* channel list */}
       <div className="flex-1 overflow-y-auto py-1">
-        {SECTIONS.map((section) => (
+        {allEmpty ? (
+          <div className="flex flex-col items-center justify-center h-full px-4 py-10 text-center gap-2.5">
+            <MessageCircle size={28} className="text-white/15" aria-hidden="true" />
+            <p className="text-[13px] font-medium text-white/60">No conversations yet</p>
+            <p className="text-[11px] text-white/30">Deploy an agent to start chatting</p>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={openAgentsApp}
+              className="mt-1 text-xs"
+            >
+              Open Agents
+            </Button>
+          </div>
+        ) : SECTIONS.map((section) => (
           <div key={section.label}>
             <div className="px-3 pt-3 pb-1 text-[10px] font-semibold uppercase tracking-wider text-white/30 flex items-center gap-1.5">
               {section.icon} {section.label}

--- a/desktop/src/apps/ModelsApp.tsx
+++ b/desktop/src/apps/ModelsApp.tsx
@@ -17,6 +17,8 @@ import {
   fetchCloudProviders,
   HOST_BADGE_CLASS,
 } from "@/lib/models";
+import { useProcessStore } from "@/stores/process-store";
+import { getApp } from "@/registry/app-registry";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -145,6 +147,12 @@ export function ModelsApp({ windowId: _windowId }: { windowId: string }) {
   const [downloading, setDownloading] = useState<Set<string>>(new Set());
 
   const [isFallback, setIsFallback] = useState(false);
+
+  const openWindow = useProcessStore((s) => s.openWindow);
+  const openProvidersApp = () => {
+    const app = getApp("providers");
+    if (app) openWindow("providers", app.defaultSize);
+  };
 
   const fetchModels = useCallback(async () => {
     // Kick off cluster workers + providers in parallel with /api/models so the
@@ -433,6 +441,19 @@ export function ModelsApp({ windowId: _windowId }: { windowId: string }) {
         {loading ? (
           <div className="flex items-center justify-center h-full text-shell-text-tertiary text-sm">
             Loading models...
+          </div>
+        ) : isFallback && downloaded.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-full gap-4 text-center px-6 py-16">
+            <Brain size={40} className="text-shell-text-tertiary opacity-30" aria-hidden="true" />
+            <div className="space-y-1">
+              <p className="text-sm font-medium text-shell-text">No models yet</p>
+              <p className="text-xs text-shell-text-tertiary max-w-xs">
+                Add a provider to see cloud models, or connect a worker with a local model.
+              </p>
+            </div>
+            <Button variant="outline" size="sm" onClick={openProvidersApp}>
+              Open Providers
+            </Button>
           </div>
         ) : (
           <>

--- a/desktop/src/apps/ProjectsApp/ProjectList.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectList.tsx
@@ -25,21 +25,35 @@ export function ProjectList({ projects, selectedId, onSelect, onCreated }: Props
         </button>
       </header>
       <ul className="flex-1 overflow-auto" aria-label="Projects">
-        {projects.map((p) => (
-          <li key={p.id}>
+        {projects.length === 0 ? (
+          <li className="flex flex-col items-center justify-center h-full px-4 py-12 text-center gap-3">
+            <p className="text-sm font-medium text-zinc-300">No projects yet</p>
+            <p className="text-xs text-zinc-500">Organise your work and agent conversations into projects.</p>
             <button
               type="button"
-              aria-pressed={p.id === selectedId}
-              onClick={() => onSelect(p.id)}
-              className={`w-full text-left px-3 py-2 hover:bg-zinc-800 ${
-                p.id === selectedId ? "bg-zinc-800" : ""
-              }`}
+              onClick={() => setDialogOpen(true)}
+              className="mt-1 text-sm px-3 py-1.5 rounded bg-zinc-700 hover:bg-zinc-600 text-zinc-100"
             >
-              <div className="font-medium">{p.name}</div>
-              <div className="text-xs text-zinc-500">{p.slug}</div>
+              Create your first project
             </button>
           </li>
-        ))}
+        ) : (
+          projects.map((p) => (
+            <li key={p.id}>
+              <button
+                type="button"
+                aria-pressed={p.id === selectedId}
+                onClick={() => onSelect(p.id)}
+                className={`w-full text-left px-3 py-2 hover:bg-zinc-800 ${
+                  p.id === selectedId ? "bg-zinc-800" : ""
+                }`}
+              >
+                <div className="font-medium">{p.name}</div>
+                <div className="text-xs text-zinc-500">{p.slug}</div>
+              </button>
+            </li>
+          ))
+        )}
       </ul>
       {dialogOpen && (
         <CreateProjectDialog

--- a/desktop/src/apps/ProjectsApp/__tests__/ProjectList.empty-state.test.tsx
+++ b/desktop/src/apps/ProjectsApp/__tests__/ProjectList.empty-state.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from "vitest";
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ProjectList } from "../ProjectList";
+
+vi.mock("../CreateProjectDialog", () => ({
+  CreateProjectDialog: ({ onClose }: { onClose: () => void }) => (
+    <div data-testid="create-dialog">
+      <button onClick={onClose}>Close</button>
+    </div>
+  ),
+}));
+
+describe("ProjectList — empty state (fix #618)", () => {
+  it("renders the empty state when projects is empty", () => {
+    render(
+      <ProjectList
+        projects={[]}
+        selectedId={null}
+        onSelect={vi.fn()}
+        onCreated={vi.fn()}
+      />
+    );
+    expect(screen.getByText("No projects yet")).toBeInTheDocument();
+    expect(screen.getByText("Create your first project")).toBeInTheDocument();
+  });
+
+  it("does NOT render 'No projects yet' when there are projects", () => {
+    render(
+      <ProjectList
+        projects={[{ id: "p1", name: "My Project", slug: "my-project" }]}
+        selectedId={null}
+        onSelect={vi.fn()}
+        onCreated={vi.fn()}
+      />
+    );
+    expect(screen.queryByText("No projects yet")).not.toBeInTheDocument();
+    expect(screen.getByText("My Project")).toBeInTheDocument();
+  });
+
+  it("'Create your first project' button opens the create dialog", () => {
+    render(
+      <ProjectList
+        projects={[]}
+        selectedId={null}
+        onSelect={vi.fn()}
+        onCreated={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByText("Create your first project"));
+    expect(screen.getByTestId("create-dialog")).toBeInTheDocument();
+  });
+});

--- a/desktop/src/components/ModelPickerFlow.empty-state.test.tsx
+++ b/desktop/src/components/ModelPickerFlow.empty-state.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { ModelPickerFlow } from "./ModelPickerFlow";
+
+describe("ModelPickerFlow — empty state (fix #618)", () => {
+  it("shows 'No models available.' when models=[] and modelsLoaded=true", () => {
+    render(
+      <ModelPickerFlow
+        models={[]}
+        modelsLoaded={true}
+        onSelect={vi.fn()}
+      />
+    );
+    expect(screen.getByText("No models available.")).toBeInTheDocument();
+  });
+
+  it("shows loading text when modelsLoaded=false", () => {
+    render(
+      <ModelPickerFlow
+        models={[]}
+        modelsLoaded={false}
+        onSelect={vi.fn()}
+      />
+    );
+    expect(screen.getByText("Loading models…")).toBeInTheDocument();
+    expect(screen.queryByText("No models available.")).not.toBeInTheDocument();
+  });
+});

--- a/tests/test_routes_setup.py
+++ b/tests/test_routes_setup.py
@@ -1,0 +1,256 @@
+"""Tests for /api/setup/status and /api/setup/dismiss routes.
+
+Also covers the account-email path in /auth/setup.
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+
+# ---------------------------------------------------------------------------
+# Local fixture: extend conftest.client with desktop_settings init
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture
+async def client(client, app):  # noqa: F811 — intentional shadow of conftest.client
+    """Wrap conftest.client and ensure desktop_settings is initialised.
+
+    desktop_settings is initialised in the app lifespan handler which is NOT
+    run during testing. All setup-route tests call get/save_preference so
+    this must be ready before any request is made.
+    """
+    ds = app.state.desktop_settings
+    if ds._db is None:
+        await ds.init()
+    yield client
+    # ds.close() is handled by conftest teardown (it's in app.state, app-scoped)
+    # — no double-close here.
+
+
+# ---------------------------------------------------------------------------
+# Account email tests (Part 1)
+# ---------------------------------------------------------------------------
+
+class TestAccountEmail:
+    """The /auth/setup route accepts and persists email."""
+
+    @pytest.mark.asyncio
+    async def test_setup_stores_email(self, app, tmp_data_dir):
+        """setup_user stores the email and public_user exposes it."""
+        user = app.state.auth.setup_user("jay", "Jay", "jay@example.com", "pass1234")
+        assert user["email"] == "jay@example.com"
+
+    @pytest.mark.asyncio
+    async def test_setup_works_without_email(self, app, tmp_data_dir):
+        """Email is optional — empty string is fine."""
+        user = app.state.auth.setup_user("jay", "Jay", "", "pass1234")
+        assert user["email"] == ""
+
+    @pytest.mark.asyncio
+    async def test_setup_route_accepts_email(self, app, tmp_data_dir):
+        """POST /auth/setup JSON path stores and returns the email field."""
+        store = app.state.metrics
+        if store._db is not None:
+            await store.close()
+        await store.init()
+        notif_store = app.state.notifications
+        if notif_store._db is not None:
+            await notif_store.close()
+        await notif_store.init()
+        await app.state.qmd_client.init()
+        secrets_store = app.state.secrets
+        if secrets_store._db is not None:
+            await secrets_store.close()
+        await secrets_store.init()
+        scheduler = app.state.scheduler
+        if scheduler._db is not None:
+            await scheduler.close()
+        await scheduler.init()
+        channel_store = app.state.channels
+        if channel_store._db is not None:
+            await channel_store.close()
+        await channel_store.init()
+        relationship_mgr = app.state.relationships
+        if relationship_mgr._db is not None:
+            await relationship_mgr.close()
+        await relationship_mgr.init()
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as c:
+            resp = await c.post(
+                "/auth/setup",
+                json={
+                    "username": "jay",
+                    "full_name": "Jay",
+                    "email": "jay@example.com",
+                    "password": "pass1234",
+                    "auto_login": False,
+                },
+            )
+
+        await relationship_mgr.close()
+        await channel_store.close()
+        await scheduler.close()
+        await secrets_store.close()
+        await notif_store.close()
+        await store.close()
+        await app.state.qmd_client.close()
+        await app.state.http_client.aclose()
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is True
+        assert data["user"]["email"] == "jay@example.com"
+
+    def test_setup_user_email_persists_in_record(self, tmp_path):
+        """email survives a read-back from the JSON store."""
+        from tinyagentos.auth import AuthManager
+        mgr = AuthManager(tmp_path)
+        mgr.setup_user("jay", "Jay Doe", "jay@example.com", "pass1234")
+        record = mgr.find_user("jay")
+        assert record is not None
+        assert record.get("email") == "jay@example.com"
+
+    def test_setup_user_email_optional(self, tmp_path):
+        """setup_user with empty email does not raise."""
+        from tinyagentos.auth import AuthManager
+        mgr = AuthManager(tmp_path)
+        user = mgr.setup_user("jay", "Jay Doe", "", "pass1234")
+        assert user["email"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Setup-status tests (Part 2)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestSetupStatus:
+    async def test_status_default_all_false(self, client, app, tmp_data_dir):
+        """Fresh install: has_provider=False, taos_model_set=False, etc."""
+        # Clear backends and agents for a clean baseline
+        app.state.config.backends.clear()
+        app.state.config.agents.clear()
+
+        resp = await client.get("/api/setup/status")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        assert data["account"] is True
+        assert data["has_provider"] is False
+        assert data["taos_model_set"] is False
+        assert data["has_agent"] is False
+        assert data["memory_enabled"] is False
+        assert data["dismissed"] is False
+        assert data["complete"] is False
+
+    async def test_has_provider_true_when_backend_present(self, client, app):
+        """has_provider reflects config.backends non-empty."""
+        # The default test config already has test-backend
+        app.state.config.backends = [{"name": "b1", "type": "rkllama", "url": "http://localhost:8080"}]
+        resp = await client.get("/api/setup/status")
+        assert resp.status_code == 200
+        assert resp.json()["has_provider"] is True
+
+    async def test_has_provider_false_when_no_backends(self, client, app):
+        app.state.config.backends = []
+        resp = await client.get("/api/setup/status")
+        assert resp.json()["has_provider"] is False
+
+    async def test_taos_model_set_true_when_pref_saved(self, client, app):
+        """taos_model_set reads desktop_settings pref:taos_agent.model."""
+        store = app.state.desktop_settings
+        await store.save_preference("user", "taos_agent", {"model": "some-model"})
+
+        resp = await client.get("/api/setup/status")
+        assert resp.json()["taos_model_set"] is True
+
+    async def test_taos_model_set_false_when_no_model(self, client, app):
+        """No taos_agent pref → taos_model_set=False."""
+        store = app.state.desktop_settings
+        await store.save_preference("user", "taos_agent", {})
+
+        resp = await client.get("/api/setup/status")
+        assert resp.json()["taos_model_set"] is False
+
+    async def test_has_agent_true_when_agents_configured(self, client, app):
+        """has_agent reflects config.agents non-empty."""
+        app.state.config.agents = [{"name": "test-agent"}]
+        resp = await client.get("/api/setup/status")
+        assert resp.json()["has_agent"] is True
+
+    async def test_has_agent_false_when_no_agents(self, client, app):
+        app.state.config.agents = []
+        resp = await client.get("/api/setup/status")
+        assert resp.json()["has_agent"] is False
+
+    async def test_memory_enabled_true_when_taosmd_default_exists(self, client, app, tmp_data_dir):
+        """memory_enabled is True when data_dir/taosmd_default.json exists."""
+        marker = tmp_data_dir / "taosmd_default.json"
+        marker.write_text(
+            '{"device_id": "local", "tier_id": "standard", "tier_name": "Standard"}'
+        )
+        resp = await client.get("/api/setup/status")
+        assert resp.json()["memory_enabled"] is True
+
+    async def test_memory_enabled_false_when_no_taosmd_default(self, client, app, tmp_data_dir):
+        """memory_enabled is False when taosmd_default.json absent."""
+        marker = tmp_data_dir / "taosmd_default.json"
+        if marker.exists():
+            marker.unlink()
+
+        resp = await client.get("/api/setup/status")
+        assert resp.json()["memory_enabled"] is False
+
+    async def test_complete_requires_both_core_steps(self, client, app):
+        """complete = has_provider AND taos_model_set."""
+        app.state.config.backends = [{"name": "b1", "type": "rkllama", "url": "http://localhost:8080"}]
+        store = app.state.desktop_settings
+        # Provider set but no model
+        await store.save_preference("user", "taos_agent", {})
+        resp = await client.get("/api/setup/status")
+        assert resp.json()["complete"] is False
+
+        # Both set
+        await store.save_preference("user", "taos_agent", {"model": "gpt-4"})
+        resp = await client.get("/api/setup/status")
+        assert resp.json()["complete"] is True
+
+        # Model set but no provider
+        app.state.config.backends = []
+        resp = await client.get("/api/setup/status")
+        assert resp.json()["complete"] is False
+
+    async def test_dismissed_false_initially(self, client):
+        resp = await client.get("/api/setup/status")
+        assert resp.json()["dismissed"] is False
+
+
+# ---------------------------------------------------------------------------
+# Dismiss tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestSetupDismiss:
+    async def test_dismiss_persists_flag(self, client):
+        """POST /api/setup/dismiss sets dismissed=True."""
+        resp = await client.post("/api/setup/dismiss")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is True
+        assert data["dismissed"] is True
+
+    async def test_dismiss_reflected_in_status(self, client):
+        """After dismiss, GET /api/setup/status returns dismissed=True."""
+        await client.post("/api/setup/dismiss")
+
+        resp = await client.get("/api/setup/status")
+        assert resp.json()["dismissed"] is True
+
+    async def test_dismiss_idempotent(self, client):
+        """Dismissing twice is fine."""
+        await client.post("/api/setup/dismiss")
+        resp = await client.post("/api/setup/dismiss")
+        assert resp.status_code == 200
+        assert resp.json()["dismissed"] is True

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -250,5 +250,8 @@ def register_all_routers(app):
     from tinyagentos.routes.taosmd import router as taosmd_router
     app.include_router(taosmd_router)
 
+    from tinyagentos.routes.setup import router as setup_router
+    app.include_router(setup_router)
+
     from tinyagentos.routes.gh_webhook import router as gh_webhook_router
     app.include_router(gh_webhook_router)

--- a/tinyagentos/routes/setup.py
+++ b/tinyagentos/routes/setup.py
@@ -1,0 +1,73 @@
+"""Setup-status API — drives the frontend onboarding checklist.
+
+GET  /api/setup/status  → current completion state across all checklist items
+POST /api/setup/dismiss → persist user's dismissal of the checklist
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+router = APIRouter()
+
+_PREF_NAMESPACE = "setup"
+
+
+@router.get("/api/setup/status")
+async def setup_status(request: Request):
+    """Return onboarding checklist completion state.
+
+    Fields:
+      account         — always True for an authenticated request
+      has_provider    — any backend configured in config.backends
+      taos_model_set  — the taOS agent has a model configured
+      has_agent       — at least one deployed agent exists
+      memory_enabled  — user completed the taOSmd memory setup wizard
+      dismissed       — user dismissed the checklist
+      complete        — has_provider AND taos_model_set (the core two steps)
+    """
+    config = request.app.state.config
+    store = request.app.state.desktop_settings
+    data_dir: Path = getattr(request.app.state, "data_dir", Path("data"))
+
+    # has_provider: any configured backend (cloud or local)
+    has_provider = bool(config.backends)
+
+    # taos_model_set: taOS agent's model pref is non-empty
+    taos_agent_prefs = await store.get_preference("user", "taos_agent")
+    taos_model_set = bool(taos_agent_prefs.get("model"))
+
+    # has_agent: at least one agent in config
+    has_agent = bool(config.agents)
+
+    # memory_enabled: taosmd setup wizard completed (taosmd_default.json written)
+    memory_enabled = (data_dir / "taosmd_default.json").exists()
+
+    # dismissed: user explicitly dismissed the setup checklist
+    setup_prefs = await store.get_preference("user", _PREF_NAMESPACE)
+    dismissed = bool(setup_prefs.get("dismissed", False))
+
+    # complete: the two core steps done
+    complete = has_provider and taos_model_set
+
+    return JSONResponse({
+        "account": True,
+        "has_provider": has_provider,
+        "taos_model_set": taos_model_set,
+        "has_agent": has_agent,
+        "memory_enabled": memory_enabled,
+        "dismissed": dismissed,
+        "complete": complete,
+    })
+
+
+@router.post("/api/setup/dismiss")
+async def setup_dismiss(request: Request):
+    """Persist the user's dismissal of the setup checklist."""
+    store = request.app.state.desktop_settings
+    prefs = await store.get_preference("user", _PREF_NAMESPACE)
+    prefs["dismissed"] = True
+    await store.save_preference("user", _PREF_NAMESPACE, prefs)
+    return JSONResponse({"ok": True, "dismissed": True})


### PR DESCRIPTION
Foundation for the guided setup checklist (#619).

- Account email: already wired in auth + OnboardingScreen; added tests confirming it stores + round-trips.
- `GET /api/setup/status` → `{account, has_provider, taos_model_set, has_agent, memory_enabled, dismissed, complete}` (complete = has_provider AND taos_model_set). Data sources: config.backends / taos_agent pref model / config.agents / taosmd_default.json / setup pref.
- `POST /api/setup/dismiss` → persists dismissal.
- 19 new tests + 58 existing auth/setup tests pass; frontend build clean.

Next: the SetupChecklist frontend (in the notification centre) drives off this; DeployWizard Hermes/memory defaults stack after the empty-state DeployWizard fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "No conversations yet" empty state in Messages with "Open Agents" button
  * Added "No models available" empty state in Models with "Open Providers" button
  * Added "No projects yet" empty state in Projects with "Create your first project" button
  * Added setup/onboarding status tracking via new API endpoints

* **Tests**
  * Added test coverage for project list, model picker, and setup functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->