### PR TITLE
fix(#618): first-run empty-state polish — Messages, Projects, Models, DeployWizard

### DIFF
--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -65,6 +65,8 @@ import {
   writeLastChannel,
 } from "./MessagesApp.a2aSelection";
 import { displayAuthor } from "./chat/format-author";
+import { useProcessStore } from "@/stores/process-store";
+import { getApp } from "@/registry/app-registry";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -244,8 +246,14 @@ export function MessagesApp({
 }) {
   const isMobile = useIsMobile();
   const { keyboardInset } = useVisualViewport();
+  const openWindow = useProcessStore((s) => s.openWindow);
+  const openAgentsApp = () => {
+    const app = getApp("agents");
+    if (app) openWindow("agents", app.defaultSize);
+  };
 
   const [channels, setChannels] = useState<Channel[]>([]);
+  const [channelsLoaded, setChannelsLoaded] = useState(false);
   const shellFileDropTarget = useDropTarget({
     accept: ["file"],
     onDrop: async (payload) => {
@@ -335,6 +343,8 @@ export function MessagesApp({
       }
     } catch {
       /* offline */
+    } finally {
+      setChannelsLoaded(true);
     }
   }, [scope?.projectId]);
 
@@ -1097,6 +1107,12 @@ export function MessagesApp({
     { label: "Groups", icon: <Users size={13} />, items: grouped.group },
   ];
 
+  const allEmpty =
+    channelsLoaded &&
+    SECTIONS.every((s) => s.items.length === 0) &&
+    archivedChannels.length === 0 &&
+    projectGroups.length === 0;
+
   /* ---------------------------------------------------------------- */
   /*  Channel list — iOS 26 grouped on mobile, flat sidebar on desktop */
   /* ---------------------------------------------------------------- */
@@ -1115,7 +1131,20 @@ export function MessagesApp({
         )}
       </div>
 
-      {SECTIONS.map((section) => (
+      {allEmpty ? (
+        <div style={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", padding: "48px 24px", textAlign: "center", gap: 12 }}>
+          <MessageCircle size={36} style={{ color: "rgba(255,255,255,0.15)" }} aria-hidden="true" />
+          <p style={{ fontSize: 15, fontWeight: 600, color: "rgba(255,255,255,0.7)", margin: 0 }}>No conversations yet</p>
+          <p style={{ fontSize: 13, color: "rgba(255,255,255,0.35)", margin: 0 }}>Deploy an agent to start chatting</p>
+          <button
+            type="button"
+            onClick={openAgentsApp}
+            style={{ marginTop: 4, fontSize: 13, padding: "8px 16px", borderRadius: 10, background: "rgba(59,130,246,0.2)", border: "1px solid rgba(59,130,246,0.3)", color: "rgba(147,197,253,0.9)", cursor: "pointer" }}
+          >
+            Open Agents
+          </button>
+        </div>
+      ) : SECTIONS.map((section) => (
         <div key={section.label} style={{ marginBottom: 20 }}>
           <div style={{ fontSize: 12, textTransform: "uppercase", letterSpacing: 0.5, color: "rgba(255,255,255,0.45)", padding: "0 20px 6px", fontWeight: 600, display: "flex", alignItems: "center", gap: 6 }}>
             {section.icon} {section.label}
@@ -1338,7 +1367,21 @@ export function MessagesApp({
 
       {/* channel list */}
       <div className="flex-1 overflow-y-auto py-1">
-        {SECTIONS.map((section) => (
+        {allEmpty ? (
+          <div className="flex flex-col items-center justify-center h-full px-4 py-10 text-center gap-2.5">
+            <MessageCircle size={28} className="text-white/15" aria-hidden="true" />
+            <p className="text-[13px] font-medium text-white/60">No conversations yet</p>
+            <p className="text-[11px] text-white/30">Deploy an agent to start chatting</p>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={openAgentsApp}
+              className="mt-1 text-xs"
+            >
+              Open Agents
+            </Button>
+          </div>
+        ) : SECTIONS.map((section) => (
           <div key={section.label}>
             <div className="px-3 pt-3 pb-1 text-[10px] font-semibold uppercase tracking-wider text-white/30 flex items-center gap-1.5">
               {section.icon} {section.label}

--- a/desktop/src/apps/ModelsApp.tsx
+++ b/desktop/src/apps/ModelsApp.tsx
@@ -17,6 +17,8 @@ import {
   fetchCloudProviders,
   HOST_BADGE_CLASS,
 } from "@/lib/models";
+import { useProcessStore } from "@/stores/process-store";
+import { getApp } from "@/registry/app-registry";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -145,6 +147,12 @@ export function ModelsApp({ windowId: _windowId }: { windowId: string }) {
   const [downloading, setDownloading] = useState<Set<string>>(new Set());
 
   const [isFallback, setIsFallback] = useState(false);
+
+  const openWindow = useProcessStore((s) => s.openWindow);
+  const openProvidersApp = () => {
+    const app = getApp("providers");
+    if (app) openWindow("providers", app.defaultSize);
+  };
 
   const fetchModels = useCallback(async () => {
     // Kick off cluster workers + providers in parallel with /api/models so the
@@ -433,6 +441,19 @@ export function ModelsApp({ windowId: _windowId }: { windowId: string }) {
         {loading ? (
           <div className="flex items-center justify-center h-full text-shell-text-tertiary text-sm">
             Loading models...
+          </div>
+        ) : isFallback && downloaded.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-full gap-4 text-center px-6 py-16">
+            <Brain size={40} className="text-shell-text-tertiary opacity-30" aria-hidden="true" />
+            <div className="space-y-1">
+              <p className="text-sm font-medium text-shell-text">No models yet</p>
+              <p className="text-xs text-shell-text-tertiary max-w-xs">
+                Add a provider to see cloud models, or connect a worker with a local model.
+              </p>
+            </div>
+            <Button variant="outline" size="sm" onClick={openProvidersApp}>
+              Open Providers
+            </Button>
           </div>
         ) : (
           <>

--- a/desktop/src/apps/ModelsApp.tsx
+++ b/desktop/src/apps/ModelsApp.tsx
@@ -50,11 +50,6 @@ type SourceFilter = "all" | "local" | "workers" | "cloud";
 /*  Fallback data                                                      */
 /* ------------------------------------------------------------------ */
 
-const MOCK_DOWNLOADED: DownloadedModel[] = [
-  { id: "qwen2.5-7b-q4", filename: "qwen2.5-7b-instruct-q4_k_m.gguf", size: "4.4 GB", format: "GGUF", quantization: "Q4_K_M", host: "controller", hostKind: "controller" },
-  { id: "phi3-mini-q5", filename: "phi-3-mini-4k-q5_k_m.gguf", size: "2.8 GB", format: "GGUF", quantization: "Q5_K_M", host: "controller", hostKind: "controller" },
-];
-
 function aggregatedToDownloaded(a: AggregatedModel): DownloadedModel {
   return {
     id: a.key,
@@ -275,8 +270,12 @@ export function ModelsApp({ windowId: _windowId }: { windowId: string }) {
     } catch {
       /* ignore */
     }
-    setDownloaded(MOCK_DOWNLOADED);
-    setAvailable(MOCK_AVAILABLE);
+    // No real models reachable anywhere (backend down AND no providers/workers
+    // configured) — leave the lists empty so the clear "No models yet" empty
+    // state renders instead of misleading mock cards. This is what makes the
+    // `isFallback && downloaded.length === 0` empty state actually reachable.
+    setDownloaded([]);
+    setAvailable([]);
     setIsFallback(true);
     setLoading(false);
   }, []);

--- a/desktop/src/apps/ProjectsApp/ProjectList.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectList.tsx
@@ -25,21 +25,35 @@ export function ProjectList({ projects, selectedId, onSelect, onCreated }: Props
         </button>
       </header>
       <ul className="flex-1 overflow-auto" aria-label="Projects">
-        {projects.map((p) => (
-          <li key={p.id}>
+        {projects.length === 0 ? (
+          <li className="flex flex-col items-center justify-center h-full px-4 py-12 text-center gap-3">
+            <p className="text-sm font-medium text-zinc-300">No projects yet</p>
+            <p className="text-xs text-zinc-500">Organise your work and agent conversations into projects.</p>
             <button
               type="button"
-              aria-pressed={p.id === selectedId}
-              onClick={() => onSelect(p.id)}
-              className={`w-full text-left px-3 py-2 hover:bg-zinc-800 ${
-                p.id === selectedId ? "bg-zinc-800" : ""
-              }`}
+              onClick={() => setDialogOpen(true)}
+              className="mt-1 text-sm px-3 py-1.5 rounded bg-zinc-700 hover:bg-zinc-600 text-zinc-100"
             >
-              <div className="font-medium">{p.name}</div>
-              <div className="text-xs text-zinc-500">{p.slug}</div>
+              Create your first project
             </button>
           </li>
-        ))}
+        ) : (
+          projects.map((p) => (
+            <li key={p.id}>
+              <button
+                type="button"
+                aria-pressed={p.id === selectedId}
+                onClick={() => onSelect(p.id)}
+                className={`w-full text-left px-3 py-2 hover:bg-zinc-800 ${
+                  p.id === selectedId ? "bg-zinc-800" : ""
+                }`}
+              >
+                <div className="font-medium">{p.name}</div>
+                <div className="text-xs text-zinc-500">{p.slug}</div>
+              </button>
+            </li>
+          ))
+        )}
       </ul>
       {dialogOpen && (
         <CreateProjectDialog

--- a/desktop/src/apps/ProjectsApp/__tests__/ProjectList.empty-state.test.tsx
+++ b/desktop/src/apps/ProjectsApp/__tests__/ProjectList.empty-state.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from "vitest";
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ProjectList } from "../ProjectList";
+
+vi.mock("../CreateProjectDialog", () => ({
+  CreateProjectDialog: ({ onClose }: { onClose: () => void }) => (
+    <div data-testid="create-dialog">
+      <button onClick={onClose}>Close</button>
+    </div>
+  ),
+}));
+
+describe("ProjectList — empty state (fix #618)", () => {
+  it("renders the empty state when projects is empty", () => {
+    render(
+      <ProjectList
+        projects={[]}
+        selectedId={null}
+        onSelect={vi.fn()}
+        onCreated={vi.fn()}
+      />
+    );
+    expect(screen.getByText("No projects yet")).toBeInTheDocument();
+    expect(screen.getByText("Create your first project")).toBeInTheDocument();
+  });
+
+  it("does NOT render 'No projects yet' when there are projects", () => {
+    render(
+      <ProjectList
+        projects={[{ id: "p1", name: "My Project", slug: "my-project" }]}
+        selectedId={null}
+        onSelect={vi.fn()}
+        onCreated={vi.fn()}
+      />
+    );
+    expect(screen.queryByText("No projects yet")).not.toBeInTheDocument();
+    expect(screen.getByText("My Project")).toBeInTheDocument();
+  });
+
+  it("'Create your first project' button opens the create dialog", () => {
+    render(
+      <ProjectList
+        projects={[]}
+        selectedId={null}
+        onSelect={vi.fn()}
+        onCreated={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByText("Create your first project"));
+    expect(screen.getByTestId("create-dialog")).toBeInTheDocument();
+  });
+});

--- a/desktop/src/apps/__tests__/DeployWizard.empty-models.test.tsx
+++ b/desktop/src/apps/__tests__/DeployWizard.empty-models.test.tsx
@@ -1,0 +1,178 @@
+/**
+ * DeployWizard — empty model list banner (fix #618).
+ *
+ * Navigates the wizard to step 3 (Model) with no models loaded
+ * and asserts the "You haven't added a provider yet" banner appears.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+
+// --- Stubs (same pattern as AgentsApp.test.tsx) ---
+vi.mock("@/hooks/use-is-mobile", () => ({ useIsMobile: () => false }));
+vi.mock("@/lib/framework-api", () => ({ fetchLatestFrameworks: async () => ({}) }));
+vi.mock("@/lib/models", () => ({
+  fetchClusterWorkers: async () => [],
+  workersToAggregated: () => [],
+  HOST_BADGE_CLASS: "",
+  CLOUD_PROVIDER_TYPES: [],
+}));
+vi.mock("@/lib/cluster", () => ({
+  availableKvQuantOptions: () => ({ k: ["fp16"], v: ["fp16"], boundary: false, flat: ["fp16"] }),
+}));
+vi.mock("@/lib/agent-emoji", () => ({ resolveAgentEmoji: () => "🤖" }));
+vi.mock("@/components/EmojiPicker", () => ({ EmojiPickerField: () => null }));
+vi.mock("@/components/ModelPickerFlow", () => ({ ModelPickerFlow: () => null }));
+vi.mock("@/components/ModelPickerModal", () => ({ ModelPickerModal: () => null }));
+vi.mock("@/lib/slug", () => ({
+  slugifyClient: (s: string) => s,
+  isValidSlug: () => true,
+  SLUG_REGEX: /^[a-z0-9][a-z0-9-]{0,62}$/,
+}));
+vi.mock("@/components/MigrationBanner", () => ({ MigrationBanner: () => null }));
+vi.mock("@/components/agent-settings/PersonaTab", () => ({ PersonaTab: () => null }));
+vi.mock("@/components/agent-settings/MemoryTab", () => ({ MemoryTab: () => null }));
+vi.mock("@/components/agent-settings/FrameworkTab", () => ({ FrameworkTab: () => null }));
+vi.mock("../AgentSkillsPanel", () => ({ AgentSkillsPanel: () => null }));
+vi.mock("../AgentMessagesPanel", () => ({ AgentMessagesPanel: () => null }));
+vi.mock("@/components/ui", () => ({
+  Button: ({
+    children, onClick, className, disabled, variant, size, "aria-label": ariaLabel,
+    ...rest
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    children?: React.ReactNode; variant?: string; size?: string;
+  }) => (
+    <button onClick={onClick} className={className} disabled={disabled} aria-label={ariaLabel} {...rest}>
+      {children}
+    </button>
+  ),
+  Card: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+  Label: ({ children }: { children: React.ReactNode }) => <label>{children}</label>,
+  Tabs: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsList: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsTrigger: ({ children }: { children: React.ReactNode }) => <button>{children}</button>,
+}));
+
+const mockOpenWindow = vi.fn();
+vi.mock("@/stores/process-store", () => ({
+  useProcessStore: (sel: (s: { openWindow: typeof mockOpenWindow }) => unknown) =>
+    sel({ openWindow: mockOpenWindow }),
+}));
+vi.mock("@/stores/notification-store", () => ({
+  useNotificationStore: { getState: () => ({ addNotification: vi.fn() }) },
+}));
+vi.mock("@/components/AgentShortcutRow", () => ({
+  AgentShortcutRow: () => null,
+}));
+
+// PersonaPicker that immediately calls onSelect so the wizard advances to step 1
+vi.mock("@/components/persona-picker/PersonaPicker", () => ({
+  PersonaPicker: ({ onSelect }: { onSelect: (s: unknown) => void }) => {
+    React.useEffect(() => {
+      onSelect({ soul_md: "", agent_md: "", save_to_library: false });
+    }, [onSelect]);
+    return null;
+  },
+}));
+
+import { AgentsApp } from "../AgentsApp";
+
+const MOCK_FRAMEWORK = {
+  id: "openclaw",
+  name: "OpenClaw",
+  description: "General purpose agent",
+  verification_status: "stable",
+};
+
+describe("DeployWizard — 'no provider' banner at model step (fix #618)", () => {
+  beforeEach(() => {
+    mockOpenWindow.mockReset();
+    vi.stubGlobal("fetch", vi.fn().mockImplementation((url: string) => {
+      if (url === "/api/agents") {
+        return Promise.resolve({
+          ok: true,
+          headers: { get: () => "application/json" },
+          json: () => Promise.resolve([]),
+        } as unknown as Response);
+      }
+      if (url === "/api/agents/archived") {
+        return Promise.resolve({
+          ok: true,
+          headers: { get: () => "application/json" },
+          json: () => Promise.resolve([]),
+        } as unknown as Response);
+      }
+      if (url === "/api/frameworks") {
+        return Promise.resolve({
+          ok: true,
+          headers: { get: () => "application/json" },
+          json: () => Promise.resolve([MOCK_FRAMEWORK]),
+        } as unknown as Response);
+      }
+      // /api/models, /api/providers/*, /api/cluster/kv-quant-options — all fail
+      return Promise.resolve({
+        ok: false,
+        headers: { get: () => "text/html" },
+        json: () => Promise.resolve({}),
+        text: () => Promise.resolve(""),
+      } as unknown as Response);
+    }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("shows the 'no provider' banner when model list is empty", async () => {
+    render(<AgentsApp windowId="test" />);
+
+    // Open wizard
+    const deployBtn = await screen.findByRole("button", { name: /deploy new agent/i });
+    fireEvent.click(deployBtn);
+
+    // PersonaPicker mock auto-advances to step 1. Fill name (match placeholder).
+    const nameInput = await screen.findByPlaceholderText("my-agent");
+    fireEvent.change(nameInput, { target: { value: "my-agent" } });
+
+    // Next → step 2 (framework)
+    const nextBtn = screen.getByRole("button", { name: /next/i });
+    fireEvent.click(nextBtn);
+
+    // Select framework → Next is enabled once one is selected
+    const frameworkBtn = await screen.findByRole("button", { name: /openclaw/i });
+    fireEvent.click(frameworkBtn);
+
+    // Next → step 3 (model)
+    const nextBtn2 = screen.getByRole("button", { name: /next/i });
+    fireEvent.click(nextBtn2);
+
+    // Banner should appear
+    expect(
+      await screen.findByText(/you haven't added a provider yet/i)
+    ).toBeInTheDocument();
+  });
+
+  it("'Add Provider' button in banner calls openWindow with 'providers'", async () => {
+    render(<AgentsApp windowId="test" />);
+
+    const deployBtn = await screen.findByRole("button", { name: /deploy new agent/i });
+    fireEvent.click(deployBtn);
+
+    const nameInput = await screen.findByPlaceholderText("my-agent");
+    fireEvent.change(nameInput, { target: { value: "my-agent" } });
+    fireEvent.click(screen.getByRole("button", { name: /next/i }));
+
+    const frameworkBtn = await screen.findByRole("button", { name: /openclaw/i });
+    fireEvent.click(frameworkBtn);
+    fireEvent.click(screen.getByRole("button", { name: /next/i }));
+
+    const addProviderBtn = await screen.findByRole("button", { name: /add provider/i });
+    fireEvent.click(addProviderBtn);
+
+    expect(mockOpenWindow).toHaveBeenCalledWith("providers", expect.any(Object));
+  });
+});

--- a/desktop/src/apps/agents/DeployWizard.tsx
+++ b/desktop/src/apps/agents/DeployWizard.tsx
@@ -16,6 +16,8 @@ import type { PersonaSelection } from "@/components/persona-picker/types";
 import { slugifyClient, isValidSlug, SLUG_REGEX } from "@/lib/slug";
 import { type Framework, type Model } from "./types";
 import { COLORS, MEMORY_STEPS_MB } from "./constants";
+import { useProcessStore } from "@/stores/process-store";
+import { getApp } from "@/registry/app-registry";
 
 /* ------------------------------------------------------------------ */
 /*  MemoryWizardStep                                                   */
@@ -377,6 +379,12 @@ export function DeployWizard({
   // Advanced (no wizard step — defaults to unlimited)
   const [memory, setMemory] = useState("");
   const [cpus, setCpus] = useState("");
+
+  const openWindow = useProcessStore((s) => s.openWindow);
+  const openProvidersApp = () => {
+    const app = getApp("providers");
+    if (app) openWindow("providers", app.defaultSize);
+  };
 
   // Step 4 — Memory layer
   // null = no choice yet (show picker); "taosmd" = enabled; null plugin = skipped
@@ -1061,12 +1069,32 @@ export function DeployWizard({
                 </div>
               ) : (
                 /* Tiered picker — source → provider → list */
-                <ModelPickerFlow
-                  models={models}
-                  modelsLoaded={modelsLoaded}
-                  onSelect={(id) => setSelectedModel(id)}
-                  onBack={() => setStep(2)}
-                />
+                <>
+                  {modelsLoaded && models.length === 0 && (
+                    <div className="mb-3 px-3 py-2.5 rounded-lg border border-amber-500/20 bg-amber-500/5 flex items-start gap-2.5">
+                      <span className="text-amber-400 shrink-0 mt-0.5 text-xs leading-none">!</span>
+                      <div className="flex-1 min-w-0">
+                        <p className="text-xs text-shell-text-secondary">
+                          You haven't added a provider yet — models appear here once a provider is configured.
+                        </p>
+                      </div>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={openProvidersApp}
+                        className="shrink-0 text-xs h-auto py-0.5 px-2 text-amber-300 hover:text-amber-200"
+                      >
+                        Add Provider
+                      </Button>
+                    </div>
+                  )}
+                  <ModelPickerFlow
+                    models={models}
+                    modelsLoaded={modelsLoaded}
+                    onSelect={(id) => setSelectedModel(id)}
+                    onBack={() => setStep(2)}
+                  />
+                </>
               )}
             </div>
           )}

--- a/desktop/src/components/ModelPickerFlow.empty-state.test.tsx
+++ b/desktop/src/components/ModelPickerFlow.empty-state.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { ModelPickerFlow } from "./ModelPickerFlow";
+
+describe("ModelPickerFlow — empty state (fix #618)", () => {
+  it("shows 'No models available.' when models=[] and modelsLoaded=true", () => {
+    render(
+      <ModelPickerFlow
+        models={[]}
+        modelsLoaded={true}
+        onSelect={vi.fn()}
+      />
+    );
+    expect(screen.getByText("No models available.")).toBeInTheDocument();
+  });
+
+  it("shows loading text when modelsLoaded=false", () => {
+    render(
+      <ModelPickerFlow
+        models={[]}
+        modelsLoaded={false}
+        onSelect={vi.fn()}
+      />
+    );
+    expect(screen.getByText("Loading models…")).toBeInTheDocument();
+    expect(screen.queryByText("No models available.")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Four small first-run empty-state fixes so a fresh-install novice isn't confused:
- **Messages**: empty-all-channels → 'No conversations yet. Deploy an agent to start chatting' + button to Agents.
- **Projects**: empty list → 'No projects yet' + create CTA.
- **Models**: fallback + no models → clear actionable empty state instead of silent mock cards.
- **DeployWizard**: empty model picker → 'Add a provider first' banner + Add Provider button (so a blank picker isn't read as a bug).

Build clean; empty-state tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * “No conversations yet” empty state in Messages (mobile & desktop) with an “Open Agents” CTA
  * “No models yet” empty state in Models with an “Open Providers” CTA when no models/providers are available
  * “No projects yet” empty state in Projects with a “Create your first project” CTA
  * Cross-app navigation wired from empty-state CTAs

* **Tests**
  * Added tests covering empty-state behaviors across Models, Projects, DeployWizard, and ModelPickerFlow
<!-- end of auto-generated comment: release notes by coderabbit.ai -->