### PR TITLE
fix(a11y): ARIA labels + dialog roles + keyboard fixes for overlays

### DIFF
--- a/desktop/src/apps/FilesApp.tsx
+++ b/desktop/src/apps/FilesApp.tsx
@@ -1238,7 +1238,7 @@ export function FilesApp({
         <div className="mx-3 mt-2 flex items-center gap-2 px-3 py-2 rounded-lg bg-red-500/10 text-red-400 text-xs">
           <AlertCircle size={14} className="shrink-0" />
           <span className="flex-1">{error}</span>
-          <button onClick={() => setError(null)} className="hover:text-red-300">&times;</button>
+          <button onClick={() => setError(null)} className="hover:text-red-300" aria-label="Dismiss error">&times;</button>
         </div>
       )}
 

--- a/desktop/src/components/ContextMenu.tsx
+++ b/desktop/src/components/ContextMenu.tsx
@@ -43,6 +43,7 @@ export function ContextMenu({ x, y, items, onClose }: Props) {
   return (
     <div
       ref={menuRef}
+      role="menu"
       className="fixed z-[10001] min-w-[200px] py-1 rounded-lg border border-shell-border-strong overflow-hidden"
       style={{
         left: adjustedX,
@@ -64,6 +65,7 @@ export function ContextMenu({ x, y, items, onClose }: Props) {
         return (
           <button
             key={i}
+            role="menuitem"
             onClick={() => {
               if (!item.disabled && item.action) {
                 item.action();

--- a/desktop/src/components/Launchpad.tsx
+++ b/desktop/src/components/Launchpad.tsx
@@ -80,6 +80,9 @@ export function Launchpad({ open, onClose, onOpenApp }: Props) {
 
   return (
     <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Launchpad"
       className="fixed top-0 left-0 right-0 z-[9000] flex flex-col backdrop-blur-md bg-black/40"
       onClick={onClose}
       style={{
@@ -107,6 +110,7 @@ export function Launchpad({ open, onClose, onOpenApp }: Props) {
             placeholder="Search apps..."
             className="flex-1 bg-transparent text-sm text-shell-text outline-none placeholder:text-shell-text-tertiary"
             autoFocus={!isMobile}
+            aria-label="Search apps"
           />
           {query && (
             <button onClick={() => setQuery("")} aria-label="Clear search">

--- a/desktop/src/components/ModelPickerFlow.tsx
+++ b/desktop/src/components/ModelPickerFlow.tsx
@@ -247,6 +247,7 @@ export function ModelPickerFlow({ models, modelsLoaded, onSelect, onBack, onCanc
           onChange={e => setSearch(e.target.value)}
           className="w-full pl-8 pr-8 h-8 rounded-lg border border-white/10 bg-shell-bg-deep text-sm text-shell-text placeholder:text-shell-text-tertiary focus:outline-none focus:border-accent/40"
           autoFocus
+          aria-label="Search models"
         />
         {search && (
           <button

--- a/desktop/src/components/NotificationCentre.tsx
+++ b/desktop/src/components/NotificationCentre.tsx
@@ -20,6 +20,9 @@ export function NotificationCentre() {
     <>
       <div className="fixed inset-0 z-[10000]" onClick={closeCentre} />
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Notifications"
         className={
           isMobile
             ? "fixed left-2 right-2 z-[10001] rounded-xl border border-white/10 overflow-hidden flex flex-col"
@@ -58,7 +61,7 @@ export function NotificationCentre() {
                 </button>
               </>
             )}
-            <button onClick={closeCentre} className="p-1.5 rounded hover:bg-white/5">
+            <button onClick={closeCentre} className="p-1.5 rounded hover:bg-white/5" aria-label="Close notifications">
               <X size={14} className="text-shell-text-tertiary" />
             </button>
           </div>
@@ -97,6 +100,7 @@ export function NotificationCentre() {
                       dismiss(n.id);
                     }}
                     className="p-0.5 rounded hover:bg-white/10 shrink-0"
+                    aria-label={`Dismiss: ${n.title}`}
                   >
                     <X size={12} className="text-shell-text-tertiary" />
                   </button>

--- a/desktop/src/components/TopBar.tsx
+++ b/desktop/src/components/TopBar.tsx
@@ -51,7 +51,6 @@ function PowerMenu() {
           sideOffset={6}
           className="z-50 min-w-[180px] rounded-xl border border-white/10 bg-shell-surface p-1.5 shadow-2xl backdrop-blur-xl"
           style={{ backgroundColor: "rgba(28,26,44,0.96)" }}
-          onEscapeKeyDown={() => {}}
         >
           <DropdownMenu.Item
             className={menuItem}

--- a/desktop/src/components/WallpaperPicker.tsx
+++ b/desktop/src/components/WallpaperPicker.tsx
@@ -22,6 +22,9 @@ export function WallpaperPicker({ open, onClose }: Props) {
       }}
     >
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Change Wallpaper"
         className="w-full max-w-[500px] max-h-full flex flex-col rounded-xl border border-shell-border-strong overflow-hidden"
         style={{ backgroundColor: "rgba(26, 27, 46, 0.98)" }}
         onClick={(e) => e.stopPropagation()}
@@ -43,6 +46,8 @@ export function WallpaperPicker({ open, onClose }: Props) {
               onClick={() => {
                 setWallpaper(wp.id);
               }}
+              aria-label={wp.label}
+              aria-pressed={wallpaperId === wp.id}
               className={`relative rounded-lg overflow-hidden border-2 transition-all ${
                 wallpaperId === wp.id
                   ? "border-accent ring-1 ring-accent/30"


### PR DESCRIPTION
From a beta accessibility audit pass — applies targeted ARIA and keyboard fixes across desktop overlay components.

## Changes

- **NotificationCentre**: panel gains `role="dialog"`, `aria-modal`, `aria-label`; close button gets `aria-label="Close notifications"`; per-notification dismiss buttons get contextual `aria-label` using the notification title
- **Launchpad**: overlay div gains `role="dialog"`, `aria-modal`, `aria-label="Launchpad"`; search input gets `aria-label="Search apps"`
- **TopBar**: removed `onEscapeKeyDown={() => {}}` from the power-menu `DropdownMenu.Content` so Escape correctly closes the dropdown (Radix default behaviour restored)
- **ContextMenu**: container gets `role="menu"`; each item button gets `role="menuitem"`
- **WallpaperPicker**: inner dialog container gets `role="dialog"`, `aria-modal`, `aria-label="Change Wallpaper"`; each wallpaper button gets `aria-label` (wallpaper name) and `aria-pressed` (current selection state)
- **ModelPickerFlow**: model search input gets `aria-label="Search models"`
- **FilesApp**: error-bar dismiss button gets `aria-label="Dismiss error"` (recycle-bin error bar already had it)

Build verified clean (`tsc -b` + `vite build`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Enhanced accessibility across the application by adding ARIA labels and semantic roles to dialogs, menus, input fields, and interactive buttons.
* Improved screen reader support through descriptive labels on search inputs and notification dismiss buttons.
* Refined keyboard behavior in dropdown menus to use default framework handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->