### PR TITLE
fix: surface silent failures (store install, agent deploy, container backend)

### DIFF
--- a/tests/test_deployer.py
+++ b/tests/test_deployer.py
@@ -953,6 +953,30 @@ class TestBackgroundDeploy:
         resp = await client.get("/api/agents/nonexistent/deploy-status")
         assert resp.status_code == 404
 
+    @pytest.mark.asyncio
+    async def test_deploy_failure_emits_notification(self, client, app):
+        """When background deploy fails, a notification must be pushed so the
+        tray surfaces the error rather than leaving the user stuck on 'deploying'."""
+        import asyncio
+
+        with patch(
+            "tinyagentos.deployer.deploy_agent",
+            new_callable=AsyncMock,
+            return_value={"success": False, "error": "container create failed"},
+        ):
+            await client.post("/api/agents/deploy", json={
+                "name": "notif-fail-test",
+                "framework": "none",
+            })
+            # Yield to the event loop so the background task runs to completion.
+            await asyncio.sleep(0.1)
+
+        notifs = await app.state.notifications.list(limit=20)
+        error_notifs = [n for n in notifs if "notif-fail-test" in n.get("message", "")]
+        assert error_notifs, "Expected a notification for the failed deploy"
+        assert error_notifs[0].get("level") == "error"
+        assert "container create failed" in error_notifs[0].get("message", "")
+
 
 class TestUndeployAgent:
     @pytest.mark.asyncio

--- a/tests/test_routes_store.py
+++ b/tests/test_routes_store.py
@@ -378,4 +378,66 @@ class TestDockerInstallRecordsRuntimeLocation:
         assert item["url"] == "/apps/searxng/"
         assert item["status"] == "running"
 
+    @pytest.mark.asyncio
+    async def test_docker_compose_up_failure_returns_error_not_success(
+        self, docker_client
+    ):
+        """When docker pull succeeds but compose up fails, the install must
+        return a failure response — not silently mark the app as installed."""
+        from unittest.mock import AsyncMock, patch
+
+        client, app = docker_client
+
+        with patch(
+            "tinyagentos.installers.docker_installer.DockerInstaller"
+        ) as MockDocker:
+            instance = MockDocker.return_value
+            instance.install = AsyncMock(return_value={"success": True, "path": "/tmp/x"})
+            instance.start = AsyncMock(
+                return_value={"success": False, "output": "port 8080 already in use"}
+            )
+
+            resp = await client.post(
+                "/api/store/install-v2", json={"app_id": "searxng"}
+            )
+
+        assert resp.status_code == 500
+        body = resp.json()
+        assert body.get("ok") is False
+        assert "container failed to start" in body.get("error", "").lower()
+        assert "port" in body.get("error", "").lower() or "conflict" in body.get("error", "").lower() or "check logs" in body.get("error", "").lower()
+
+        # Must NOT have been recorded as installed.
+        loc = await app.state.installed_apps.get_runtime_location("searxng")
+        assert loc is None
+
+    @pytest.mark.asyncio
+    async def test_docker_compose_up_raises_returns_error_not_success(
+        self, docker_client
+    ):
+        """When compose up raises an exception, the install must return a
+        failure — not silently mark the app as installed."""
+        from unittest.mock import AsyncMock, patch
+
+        client, app = docker_client
+
+        with patch(
+            "tinyagentos.installers.docker_installer.DockerInstaller"
+        ) as MockDocker:
+            instance = MockDocker.return_value
+            instance.install = AsyncMock(return_value={"success": True, "path": "/tmp/x"})
+            instance.start = AsyncMock(side_effect=RuntimeError("daemon not running"))
+
+            resp = await client.post(
+                "/api/store/install-v2", json={"app_id": "searxng"}
+            )
+
+        assert resp.status_code == 500
+        body = resp.json()
+        assert body.get("ok") is False
+        assert "daemon not running" in body.get("error", "")
+
+        loc = await app.state.installed_apps.get_runtime_location("searxng")
+        assert loc is None
+
 

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -446,20 +446,38 @@ async def deploy_agent_endpoint(request: Request, body: DeployAgentRequest):
             else:
                 if agent is not None:
                     agent["status"] = "failed"
+                err_msg = result.get("error", "unknown error")
                 deploy_tasks[body.name] = {
                     "status": "failed",
                     "name": body.name,
-                    "error": result.get("error", "unknown error"),
+                    "error": err_msg,
                 }
+                notif = getattr(request.app.state, "notifications", None)
+                if notif:
+                    await notif.add(
+                        title=f"Deploy failed: {body.name}",
+                        message=f"Deploy failed for {body.name}: {err_msg}",
+                        level="error",
+                        source="agents.deploy",
+                    )
         except Exception as exc:  # noqa: BLE001
             agent = find_agent(config, body.name)
             if agent is not None:
                 agent["status"] = "failed"
+            err_msg = str(exc)
             deploy_tasks[body.name] = {
                 "status": "failed",
                 "name": body.name,
-                "error": str(exc),
+                "error": err_msg,
             }
+            notif = getattr(request.app.state, "notifications", None)
+            if notif:
+                await notif.add(
+                    title=f"Deploy failed: {body.name}",
+                    message=f"Deploy failed for {body.name}: {err_msg}",
+                    level="error",
+                    source="agents.deploy",
+                )
         finally:
             await save_config_locked(config, config.config_path)
 

--- a/tinyagentos/routes/shortcut_proxy.py
+++ b/tinyagentos/routes/shortcut_proxy.py
@@ -436,6 +436,13 @@ async def shortcut_terminal_ws(
 
     try:
         pty_handle = await asyncio.to_thread(_get_container_pty, agent_name, cmd)
+    except RuntimeError as exc:
+        logger.warning("terminal: no container backend for %s: %s", agent_name, exc)
+        await websocket.close(
+            code=1011,
+            reason="No container backend available. Install Incus or Docker and restart taOS.",
+        )
+        return
     except Exception as exc:
         logger.warning("terminal: spawn_pty failed for %s: %s", agent_name, exc)
         await websocket.close(code=1011, reason="PTY spawn failed")

--- a/tinyagentos/routes/store_install.py
+++ b/tinyagentos/routes/store_install.py
@@ -389,22 +389,38 @@ async def _legacy_install(request: Request, body: dict, app_id: str | None, targ
         # Auto-start docker compose so the service is actually serving
         # on its declared ports. Pip installs don't have a generic start
         # command — those are libraries the user invokes from code.
-        # docker pull succeeded → image is on disk, the install is
-        # 'installed' even if compose up trips on a port collision /
-        # daemon hiccup. We surface a warning instead of failing the
-        # whole install so the user can `docker compose up -d` manually
-        # without re-pulling.
         if backend == "docker":
             try:
                 start_result = await installer.start(app_id)
                 if not start_result.get("success"):
-                    logger.warning(
-                        "_legacy_install: docker pull succeeded but compose up failed for %s: %s",
-                        app_id, start_result.get("output", "")[:500],
+                    detail = start_result.get("output", "") or start_result.get("error", "")
+                    logger.error(
+                        "_legacy_install: docker compose up failed for %s: %s",
+                        app_id, detail[:500],
+                    )
+                    return JSONResponse(
+                        {
+                            "ok": False,
+                            "error": (
+                                f"App container failed to start: {detail[:200] or 'unknown error'}. "
+                                "Port conflict or image error — check logs."
+                            ),
+                        },
+                        status_code=500,
                     )
             except (FileNotFoundError, OSError, RuntimeError) as exc:
-                logger.warning(
+                logger.error(
                     "_legacy_install: docker compose up raised for %s: %s", app_id, exc,
+                )
+                return JSONResponse(
+                    {
+                        "ok": False,
+                        "error": (
+                            f"App container failed to start: {exc}. "
+                            "Port conflict or image error — check logs."
+                        ),
+                    },
+                    status_code=500,
                 )
 
     # Default: delegate to InstalledAppsStore (records the install in db / store).


### PR DESCRIPTION
Three beta-blocking bugs where a novice user would get a blank/false-success/raw-traceback instead of a clear message, surfaced in a no-silent-failure audit.

## What was fixed

**1. Store install silently marks broken Docker app as installed (`store_install.py`)**
After `docker pull` succeeded, if `docker compose up` (or `.start()`) failed, the code only logged a warning and continued — recording the app as installed in the DB with a runtime location. Now a compose-up failure returns HTTP 500 with `{"ok": false, "error": "App container failed to start: <detail>. Port conflict or image error — check logs."}` and the install is aborted before any DB write.

**2. Background agent deploy left users stuck on "deploying" with no notice (`agents.py`)**
When the background deploy task set `status = "failed"`, it wrote the task dict but never surfaced anything in the notification tray. The user had no way to know a deploy had failed without polling the status endpoint. Now both failure branches (result `success: false` and unhandled exception) also call `notifications.add(level="error")` with the agent name and error detail, matching the existing pattern used in `system.py`.

**3. `get_backend()` RuntimeError in shortcut_proxy terminal WS gave a generic close reason (`shortcut_proxy.py`)**
When no container backend (Incus / Docker) is available, `_get_container_pty` raises `RuntimeError`. This was caught by the broad `except Exception` handler which sent close code 1011 with reason "PTY spawn failed" — not actionable. A specific `except RuntimeError` clause now sends "No container backend available. Install Incus or Docker and restart taOS." before the generic fallback.

## Tests

- `tests/test_routes_store.py` — two new cases: compose-up returns `{"success": False}`, and compose-up raises `RuntimeError`; both assert HTTP 500 + `ok: false` body + no runtime location recorded
- `tests/test_deployer.py` — new `test_deploy_failure_emits_notification`: patches `deploy_agent` to return failure, yields to the event loop, asserts a notification with `level=error` was pushed

All 115 tests in the three affected files pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Failed agent deployments now emit error notifications with failure details
  * Service installation failures return detailed error responses instead of silent failures
  * Terminal shortcuts display clear error messages when container backends are unavailable
  * Enhanced error reporting throughout deployment and installation flows

* **Tests**
  * Added deployment failure notification tests
  * Added service installation failure regression tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->