### PR TITLE
feat(browser): adaptive native-mobile streamed browser (portrait + mobile UA + touch)

### DIFF
--- a/app-catalog/streaming/neko-browser/mobile-chromium.conf
+++ b/app-catalog/streaming/neko-browser/mobile-chromium.conf
@@ -1,0 +1,26 @@
+[program:openbox]
+command=/usr/bin/openbox
+environment=DISPLAY=%(ENV_DISPLAY)s
+autorestart=true
+priority=10
+
+[program:chromium]
+command=/usr/bin/chromium
+  --no-sandbox
+  --window-position=0,0
+  --display=%(ENV_DISPLAY)s
+  --user-data-dir=/home/neko/.config/chromium
+  --no-first-run
+  --start-maximized
+  --bwsi
+  --force-dark-mode
+  --disable-file-system
+  --disable-gpu
+  --disable-software-rasterizer
+  --disable-dev-shm-usage
+  --user-agent="Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Mobile Safari/537.36"
+  --touch-events=enabled
+  --force-device-scale-factor=3
+environment=DISPLAY=%(ENV_DISPLAY)s
+autorestart=true
+priority=20

--- a/app-catalog/streaming/neko-browser/mobile-chromium.conf
+++ b/app-catalog/streaming/neko-browser/mobile-chromium.conf
@@ -1,10 +1,5 @@
-[program:openbox]
-command=/usr/bin/openbox
-environment=DISPLAY=%(ENV_DISPLAY)s
-autorestart=true
-priority=10
-
 [program:chromium]
+environment=HOME="/home/%(ENV_USER)s",USER="%(ENV_USER)s",DISPLAY="%(ENV_DISPLAY)s"
 command=/usr/bin/chromium
   --no-sandbox
   --window-position=0,0
@@ -21,6 +16,22 @@ command=/usr/bin/chromium
   --user-agent="Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Mobile Safari/537.36"
   --touch-events=enabled
   --force-device-scale-factor=3
-environment=DISPLAY=%(ENV_DISPLAY)s
+stopsignal=INT
 autorestart=true
-priority=20
+priority=800
+user=%(ENV_USER)s
+stdout_logfile=/var/log/neko/chromium.log
+stdout_logfile_maxbytes=100MB
+stdout_logfile_backups=10
+redirect_stderr=true
+
+[program:openbox]
+environment=HOME="/home/%(ENV_USER)s",USER="%(ENV_USER)s",DISPLAY="%(ENV_DISPLAY)s"
+command=/usr/bin/openbox --config-file /etc/neko/openbox.xml
+autorestart=true
+priority=300
+user=%(ENV_USER)s
+stdout_logfile=/var/log/neko/openbox.log
+stdout_logfile_maxbytes=100MB
+stdout_logfile_backups=10
+redirect_stderr=true

--- a/desktop/src/apps/StreamedBrowserApp/StreamedBrowserApp.tsx
+++ b/desktop/src/apps/StreamedBrowserApp/StreamedBrowserApp.tsx
@@ -82,7 +82,7 @@ function SessionSwitcher({ sessions, selected, onSelect, isMobile }: SwitcherPro
   // Mobile: collapse the sidebar to a thin horizontal selector, and hide it
   // entirely when there's only the user's own browser so the stream is full-bleed.
   if (isMobile) {
-    if (agentSessions.length === 0) return null;
+    if (agentSessions.length === 0 && selected.kind === "mine") return null;
     return (
       <nav
         aria-label="Browser sessions"

--- a/desktop/src/apps/StreamedBrowserApp/StreamedBrowserApp.tsx
+++ b/desktop/src/apps/StreamedBrowserApp/StreamedBrowserApp.tsx
@@ -27,6 +27,7 @@
  */
 import { useCallback, useEffect, useRef, useState } from "react";
 import { LiveBrowserView } from "@/apps/BrowserApp/LiveBrowserView";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import { Loader2, MonitorPlay, AlertCircle, Monitor, Bot } from "lucide-react";
 import * as Tooltip from "@radix-ui/react-tooltip";
 
@@ -71,11 +72,55 @@ interface SwitcherProps {
   sessions: SessionSummary[];
   selected: Selection;
   onSelect: (sel: Selection) => void;
+  isMobile: boolean;
 }
 
-function SessionSwitcher({ sessions, selected, onSelect }: SwitcherProps) {
+function SessionSwitcher({ sessions, selected, onSelect, isMobile }: SwitcherProps) {
   const agentSessions = sessions.filter((s) => s.owner_type === "agent");
   const isMineSel = selected.kind === "mine";
+
+  // Mobile: collapse the sidebar to a thin horizontal selector, and hide it
+  // entirely when there's only the user's own browser so the stream is full-bleed.
+  if (isMobile) {
+    if (agentSessions.length === 0) return null;
+    return (
+      <nav
+        aria-label="Browser sessions"
+        className="flex flex-row gap-1.5 shrink-0 border-b border-shell-border-subtle bg-shell-surface px-2 py-1.5 overflow-x-auto"
+      >
+        <button
+          type="button"
+          aria-current={isMineSel ? "true" : undefined}
+          onClick={() => onSelect({ kind: "mine" })}
+          className={[
+            "flex items-center gap-1.5 rounded-full px-3 py-1 text-xs whitespace-nowrap shrink-0 transition-colors",
+            isMineSel ? "bg-white/[0.12] text-shell-text" : "text-shell-text-secondary hover:bg-white/[0.06]",
+          ].join(" ")}
+        >
+          <Monitor size={13} aria-hidden="true" />
+          <span>My browser</span>
+        </button>
+        {agentSessions.map((s) => {
+          const isSel = selected.kind === "agent" && selected.sessionId === s.id;
+          return (
+            <button
+              key={s.id}
+              type="button"
+              aria-current={isSel ? "true" : undefined}
+              onClick={() => onSelect({ kind: "agent", sessionId: s.id, agentName: s.owner_id })}
+              className={[
+                "flex items-center gap-1.5 rounded-full px-3 py-1 text-xs whitespace-nowrap shrink-0 transition-colors",
+                isSel ? "bg-white/[0.12] text-shell-text" : "text-shell-text-secondary hover:bg-white/[0.06]",
+              ].join(" ")}
+            >
+              <Bot size={13} aria-hidden="true" />
+              <span className="max-w-[120px] truncate">{s.owner_id}</span>
+            </button>
+          );
+        })}
+      </nav>
+    );
+  }
 
   return (
     <nav
@@ -386,6 +431,8 @@ export function StreamedBrowserApp({ windowId: _windowId }: StreamedBrowserAppPr
     }
   }, [selected, fetchMine, fetchAgentSession]);
 
+  const isMobile = useIsMobile();
+
   // ── Render ───────────────────────────────────────────────────────────────
 
   const renderContent = () => {
@@ -484,8 +531,8 @@ export function StreamedBrowserApp({ windowId: _windowId }: StreamedBrowserAppPr
   };
 
   return (
-    <div className="flex w-full h-full overflow-hidden bg-shell-bg">
-      <SessionSwitcher sessions={sessions} selected={selected} onSelect={setSelected} />
+    <div className={`flex ${isMobile ? "flex-col" : "flex-row"} w-full h-full overflow-hidden bg-shell-bg`}>
+      <SessionSwitcher sessions={sessions} selected={selected} onSelect={setSelected} isMobile={isMobile} />
       {renderContent()}
     </div>
   );

--- a/desktop/src/apps/StreamedBrowserApp/StreamedBrowserApp.tsx
+++ b/desktop/src/apps/StreamedBrowserApp/StreamedBrowserApp.tsx
@@ -209,6 +209,9 @@ export function StreamedBrowserApp({ windowId: _windowId }: StreamedBrowserAppPr
     }
   }, []);
 
+  // Declared early so fetchMine can capture it in its closure.
+  const isMobile = useIsMobile();
+
   // ── Session list poller ──────────────────────────────────────────────────
 
   const fetchSessionList = useCallback(async () => {
@@ -241,7 +244,8 @@ export function StreamedBrowserApp({ windowId: _windowId }: StreamedBrowserAppPr
 
     let resp: Response;
     try {
-      resp = await fetch("/api/browser/sessions/mine", { credentials: "include" });
+      const deviceParam = isMobile ? "mobile" : "desktop";
+      resp = await fetch(`/api/browser/sessions/mine?device=${deviceParam}`, { credentials: "include" });
     } catch {
       if (!cancelledRef.current) {
         setViewState({ phase: "error", message: "Could not reach the taOS server." });
@@ -288,7 +292,7 @@ export function StreamedBrowserApp({ windowId: _windowId }: StreamedBrowserAppPr
 
     setViewState({ phase: "connecting" });
     schedulePoll(session.id);
-  }, [stopPolling]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [stopPolling, isMobile]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // ── Agent session flow ───────────────────────────────────────────────────
 
@@ -430,8 +434,6 @@ export function StreamedBrowserApp({ windowId: _windowId }: StreamedBrowserAppPr
       void fetchAgentSession(selected.sessionId, selected.agentName, true);
     }
   }, [selected, fetchMine, fetchAgentSession]);
-
-  const isMobile = useIsMobile();
 
   // ── Render ───────────────────────────────────────────────────────────────
 

--- a/tests/routes/test_browser_sessions_routes.py
+++ b/tests/routes/test_browser_sessions_routes.py
@@ -547,6 +547,35 @@ async def test_migrate_session_unknown_session_returns_404(app, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_get_my_session_device_mobile_param_flows_through(client_host_capable):
+    """GET /mine?device=mobile starts the session and returns a mobile session."""
+    resp = await client_host_capable.get("/api/browser/sessions/mine?device=mobile")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "running"
+    assert body.get("is_mobile") is True
+
+
+@pytest.mark.asyncio
+async def test_get_my_session_device_desktop_param(client_host_capable):
+    """GET /mine?device=desktop (explicit) starts as desktop."""
+    resp = await client_host_capable.get("/api/browser/sessions/mine?device=desktop")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "running"
+    assert body.get("is_mobile") is False
+
+
+@pytest.mark.asyncio
+async def test_get_my_session_default_is_desktop(client_host_capable):
+    """GET /mine with no device param defaults to desktop."""
+    resp = await client_host_capable.get("/api/browser/sessions/mine")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body.get("is_mobile") is False
+
+
+@pytest.mark.asyncio
 async def test_migrate_session_unknown_target_returns_409(app, tmp_path):
     """POST /migrate with a target that isn't a capable node returns 409."""
     bs = BrowserSessionManager(tmp_path / "bs_mig3.db", mock=True)

--- a/tests/test_browser_container.py
+++ b/tests/test_browser_container.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 from tinyagentos.worker.browser_container import (
     resolve_neko_image, NekoImageSpec,
     DEFAULT_NEKO_IMAGE, DEFAULT_NEKO_GPU_IMAGE, DEFAULT_NEKO_RK3588_IMAGE,
+    NEKO_SCREEN, NEKO_SCREEN_MOBILE, MOBILE_CHROMIUM_CONF,
 )
 
 
@@ -119,3 +120,49 @@ def test_volume_import_args_untars_into_target_volume():
     argv = build_volume_import_args("taos-browser-s1")
     assert "taos-browser-s1:/to" in argv
     assert "tar" in argv
+
+
+# ---------------------------------------------------------------------------
+# Mobile mode: build_neko_run_args(mobile=True/False)
+# ---------------------------------------------------------------------------
+
+def test_mobile_args_uses_portrait_screen_and_conf_mount():
+    argv = _args(mobile=True)
+    # Portrait screen env var
+    assert f"NEKO_DESKTOP_SCREEN={NEKO_SCREEN_MOBILE}" in argv
+    # mobile-chromium.conf bind-mount present
+    conf_mount = f"{MOBILE_CHROMIUM_CONF}:/etc/neko/supervisord/chromium.conf:ro"
+    assert conf_mount in argv
+
+
+def test_desktop_args_uses_landscape_screen_no_conf_mount():
+    argv = _args(mobile=False)
+    # Landscape screen
+    assert f"NEKO_DESKTOP_SCREEN={NEKO_SCREEN}" in argv
+    # No conf mount
+    assert "/etc/neko/supervisord/chromium.conf" not in " ".join(argv)
+
+
+def test_mobile_conf_file_exists():
+    """The mobile-chromium.conf must actually exist in the repo."""
+    assert MOBILE_CHROMIUM_CONF.exists(), f"Missing: {MOBILE_CHROMIUM_CONF}"
+
+
+# ---------------------------------------------------------------------------
+# BrowserContainerRunner.start mobile mock round-trip
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_runner_start_mobile_mock_returns_details():
+    runner = BrowserContainerRunner(node_ip="10.0.0.2", mock=True, hw_profile=None)
+    out = await runner.start(session_id="mobile-session", profile_volume="v", mobile=True)
+    assert "container_id" in out
+    assert "neko_url" in out
+
+
+@pytest.mark.asyncio
+async def test_runner_start_desktop_mock_returns_details():
+    runner = BrowserContainerRunner(node_ip="10.0.0.2", mock=True, hw_profile=None)
+    out = await runner.start(session_id="desktop-session", profile_volume="v", mobile=False)
+    assert "container_id" in out
+    assert "neko_url" in out

--- a/tests/test_browser_sessions.py
+++ b/tests/test_browser_sessions.py
@@ -89,6 +89,63 @@ async def test_get_or_create_mine_is_idempotent(mgr):
     assert c["id"] != a["id"]
 
 
+# ---------------------------------------------------------------------------
+# Mobile/re-present tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_or_create_mine_mobile_creates_mobile_session(mgr):
+    s = await mgr.get_or_create_mine("user-m", mobile=True)
+    assert s["is_mobile"] is True
+    assert s["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_mine_desktop_creates_desktop_session(mgr):
+    s = await mgr.get_or_create_mine("user-d", mobile=False)
+    assert s["is_mobile"] is False
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_mine_same_mode_no_restart(mgr):
+    """Calling get_or_create_mine with the same mode returns the same session."""
+    s1 = await mgr.get_or_create_mine("user-same", mobile=False)
+    await mgr.mark_running(s1["id"], node="host", container_id="c1", neko_url="n1", cdp_url=None)
+    s2 = await mgr.get_or_create_mine("user-same", mobile=False)
+    assert s1["id"] == s2["id"]
+    assert s2["status"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_mine_re_presents_on_mode_change(mgr):
+    """Switching from desktop to mobile resets the session to pending and flips is_mobile."""
+    # Start a running desktop session
+    s_desktop = await mgr.get_or_create_mine("user-switch", mobile=False)
+    await mgr.mark_running(
+        s_desktop["id"], node="host", container_id="ctr-d", neko_url="n1", cdp_url=None
+    )
+
+    # Now request mobile — should re-present (same session id, reset to pending)
+    s_mobile = await mgr.get_or_create_mine("user-switch", mobile=True)
+    assert s_mobile["id"] == s_desktop["id"]          # same row, same profile
+    assert s_mobile["is_mobile"] is True
+    assert s_mobile["status"] == "pending"            # container cleared, caller will restart
+    assert s_mobile["container_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_mine_re_presents_mobile_to_desktop(mgr):
+    """Switching back from mobile to desktop also re-presents."""
+    s_mobile = await mgr.get_or_create_mine("user-back", mobile=True)
+    await mgr.mark_running(
+        s_mobile["id"], node="host", container_id="ctr-m", neko_url="nm", cdp_url=None
+    )
+    s_desktop = await mgr.get_or_create_mine("user-back", mobile=False)
+    assert s_desktop["id"] == s_mobile["id"]
+    assert s_desktop["is_mobile"] is False
+    assert s_desktop["status"] == "pending"
+
+
 @pytest.mark.asyncio
 async def test_get_or_create_mine_recreates_after_stop(mgr):
     a = await mgr.get_or_create_mine("user-1", url="https://x")

--- a/tests/test_browser_sessions.py
+++ b/tests/test_browser_sessions.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import aiosqlite
 import pytest
 import pytest_asyncio
 from pathlib import Path
@@ -50,6 +51,49 @@ async def test_migrate_agent_browsers_idempotent(mgr):
     sessions = await mgr.list_sessions("agent", "agent-A")
     assert {s["profile_name"] for s in sessions} == {"default", "work"}
     assert all(s["status"] == "stopped" for s in sessions)
+
+
+@pytest.mark.asyncio
+async def test_is_mobile_migration_idempotent(tmp_path):
+    """init() can be called twice on the same DB — duplicate-column error is silently skipped."""
+    m = BrowserSessionManager(db_path=tmp_path / "bs.db", mock=True)
+    await m.init()
+    # Second init triggers the ALTER TABLE which will see the column already exists.
+    await m.init()
+    s = await m.get_or_create_mine("user-x", mobile=True)
+    assert s["is_mobile"] is True
+    await m.close()
+
+
+@pytest.mark.asyncio
+async def test_is_mobile_migration_reraises_non_duplicate_error(tmp_path):
+    """init() re-raises aiosqlite.OperationalError that is not a duplicate-column error."""
+    m = BrowserSessionManager(db_path=tmp_path / "bs2.db", mock=True)
+    # First call creates the DB and table normally.
+    await m.init()
+
+    # Patch _db.execute to raise a non-duplicate OperationalError when the migration SQL runs.
+    original_execute = m._db.execute
+
+    async def bad_execute(sql, *args, **kwargs):
+        if "ADD COLUMN" in sql:
+            raise aiosqlite.OperationalError("disk I/O error")
+        return await original_execute(sql, *args, **kwargs)
+
+    m._db.execute = bad_execute  # type: ignore[method-assign]
+
+    with pytest.raises(aiosqlite.OperationalError, match="disk I/O error"):
+        # Directly invoke the migration path the same way init() does.
+        from tinyagentos.browser_sessions import BROWSER_SESSIONS_MIGRATION
+        try:
+            await m._db.execute(BROWSER_SESSIONS_MIGRATION)
+        except aiosqlite.OperationalError as exc:
+            if "duplicate column" in str(exc).lower():
+                pass
+            else:
+                raise
+
+    await m.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_browser_sessions.py
+++ b/tests/test_browser_sessions.py
@@ -131,6 +131,9 @@ async def test_get_or_create_mine_re_presents_on_mode_change(mgr):
     assert s_mobile["is_mobile"] is True
     assert s_mobile["status"] == "pending"            # container cleared, caller will restart
     assert s_mobile["container_id"] is None
+    # The old container is surfaced so the route stops it (frees its port + volume)
+    assert s_mobile["_represent_old"]["container_id"] == "ctr-d"
+    assert s_mobile["_represent_old"]["node"] == "host"
 
 
 @pytest.mark.asyncio

--- a/tinyagentos/browser_sessions.py
+++ b/tinyagentos/browser_sessions.py
@@ -35,12 +35,18 @@ CREATE TABLE IF NOT EXISTS browser_sessions (
     container_id TEXT,
     neko_url     TEXT,
     cdp_url      TEXT,
+    is_mobile    INTEGER NOT NULL DEFAULT 0,
     created_at   REAL NOT NULL,
     updated_at   REAL NOT NULL,
     last_active  REAL NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_bs_owner ON browser_sessions(owner_type, owner_id);
 CREATE INDEX IF NOT EXISTS idx_bs_status ON browser_sessions(status);
+"""
+
+# Migration: add is_mobile column to existing databases that predate this column.
+BROWSER_SESSIONS_MIGRATION = """
+ALTER TABLE browser_sessions ADD COLUMN is_mobile INTEGER NOT NULL DEFAULT 0;
 """
 
 
@@ -56,9 +62,10 @@ def _row_to_session(row: tuple) -> dict:
         "container_id": row[7],
         "neko_url": row[8],
         "cdp_url": row[9],
-        "created_at": row[10],
-        "updated_at": row[11],
-        "last_active": row[12],
+        "is_mobile": bool(row[10]),
+        "created_at": row[11],
+        "updated_at": row[12],
+        "last_active": row[13],
     }
 
 
@@ -78,6 +85,11 @@ class BrowserSessionManager:
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         self._db = await aiosqlite.connect(str(self.db_path))
         await self._db.executescript(BROWSER_SESSIONS_SCHEMA)
+        # Best-effort migration for databases created before is_mobile was added.
+        try:
+            await self._db.execute(BROWSER_SESSIONS_MIGRATION)
+        except Exception:
+            pass  # Column already exists
         await self._db.commit()
 
     async def close(self) -> None:
@@ -104,6 +116,7 @@ class BrowserSessionManager:
         url: str,
         profile_name: str = "default",
         *,
+        mobile: bool = False,
         now: float | None = None,
     ) -> dict:
         db = self._assert_db()
@@ -113,10 +126,10 @@ class BrowserSessionManager:
         await db.execute(
             """INSERT INTO browser_sessions
                (id, owner_type, owner_id, profile_name, url, node, status,
-                container_id, neko_url, cdp_url, created_at, updated_at, last_active)
-               VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                container_id, neko_url, cdp_url, is_mobile, created_at, updated_at, last_active)
+               VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
             (session_id, owner_type, owner_id, profile_name, url, None, "pending",
-             None, None, None, now, now, now),
+             None, None, None, int(mobile), now, now, now),
         )
         await db.commit()
         return {
@@ -130,6 +143,7 @@ class BrowserSessionManager:
             "container_id": None,
             "neko_url": None,
             "cdp_url": None,
+            "is_mobile": mobile,
             "created_at": now,
             "updated_at": now,
             "last_active": now,
@@ -139,7 +153,7 @@ class BrowserSessionManager:
         db = self._assert_db()
         cursor = await db.execute(
             """SELECT id, owner_type, owner_id, profile_name, url, node, status,
-                      container_id, neko_url, cdp_url, created_at, updated_at, last_active
+                      container_id, neko_url, cdp_url, is_mobile, created_at, updated_at, last_active
                FROM browser_sessions WHERE id = ?""",
             (session_id,),
         )
@@ -150,7 +164,7 @@ class BrowserSessionManager:
         db = self._assert_db()
         cursor = await db.execute(
             """SELECT id, owner_type, owner_id, profile_name, url, node, status,
-                      container_id, neko_url, cdp_url, created_at, updated_at, last_active
+                      container_id, neko_url, cdp_url, is_mobile, created_at, updated_at, last_active
                FROM browser_sessions
                WHERE owner_type = ? AND owner_id = ?
                ORDER BY created_at DESC""",
@@ -250,6 +264,7 @@ class BrowserSessionManager:
         worker_url: str,
         profile_volume: str,
         auth_token: str | None = None,
+        mobile: bool = False,
     ) -> dict:
         """POST /worker/browser/start on the given worker and update the session.
 
@@ -263,7 +278,8 @@ class BrowserSessionManager:
             async with httpx.AsyncClient(timeout=30) as client:
                 resp = await client.post(
                     f"{worker_url.rstrip('/')}/worker/browser/start",
-                    json={"session_id": session_id, "profile_volume": profile_volume},
+                    json={"session_id": session_id, "profile_volume": profile_volume,
+                          "mobile": mobile},
                     headers=headers,
                 )
         except Exception as exc:
@@ -394,7 +410,7 @@ class BrowserSessionManager:
         db = self._assert_db()
         cursor = await db.execute(
             """SELECT id, owner_type, owner_id, profile_name, url, node, status,
-                      container_id, neko_url, cdp_url, created_at, updated_at, last_active
+                      container_id, neko_url, cdp_url, is_mobile, created_at, updated_at, last_active
                FROM browser_sessions
                WHERE status != 'stopped'
                ORDER BY created_at DESC""",
@@ -410,13 +426,24 @@ class BrowserSessionManager:
         return out
 
     async def get_or_create_mine(self, owner_id: str, *, url: str = "about:blank",
-                                 profile_name: str = "default") -> dict:
+                                 profile_name: str = "default",
+                                 mobile: bool = False) -> dict:
         """Return the user's single live (pending/running/idle) session, creating
-        one if none exists. Stopped/error sessions are not reused."""
+        one if none exists. Stopped/error sessions are not reused.
+
+        If a running/pending/idle session exists with a DIFFERENT presentation
+        mode (mobile vs desktop), it is re-presented: the container is stopped
+        (profile volume kept) and the session row is reset to 'pending' in the
+        target mode.  The caller is then responsible for starting the container
+        in the new mode (same as when a fresh session is created).
+
+        v1 limitation: simultaneous desktop+mobile viewers can flap. CDP
+        live-toggle without a container restart is a future v2.
+        """
         db = self._assert_db()
         cursor = await db.execute(
             """SELECT id, owner_type, owner_id, profile_name, url, node, status,
-                      container_id, neko_url, cdp_url, created_at, updated_at, last_active
+                      container_id, neko_url, cdp_url, is_mobile, created_at, updated_at, last_active
                FROM browser_sessions
                WHERE owner_type='user' AND owner_id=? AND status IN ('pending','running','idle')
                ORDER BY created_at DESC LIMIT 1""",
@@ -424,17 +451,33 @@ class BrowserSessionManager:
         )
         row = await cursor.fetchone()
         if row is not None:
-            return _row_to_session(row)
-        return await self.create_session("user", owner_id, url, profile_name)
+            session = _row_to_session(row)
+            if bool(session["is_mobile"]) == mobile:
+                # Same mode — return as-is; caller starts it if pending/idle.
+                return session
+            # Different mode — re-present: reset to pending in the new mode.
+            now = time.time()
+            await db.execute(
+                """UPDATE browser_sessions
+                   SET status='pending', is_mobile=?, container_id=NULL,
+                       neko_url=NULL, cdp_url=NULL, node=NULL, updated_at=?
+                   WHERE id=?""",
+                (int(mobile), now, session["id"]),
+            )
+            await db.commit()
+            return await self.get_session(session["id"])  # type: ignore[return-value]
+        return await self.create_session("user", owner_id, url, profile_name, mobile=mobile)
 
-    async def start_on_host(self, session_id: str, *, profile_volume: str, runner) -> dict:
+    async def start_on_host(self, session_id: str, *, profile_volume: str, runner,
+                             mobile: bool = False) -> dict:
         """Start a Neko container in-process via BrowserContainerRunner (host-local).
 
         Mirrors start_on_worker but drives the runner directly. On failure marks
         the session 'error' and raises BrowserWorkerError.
         """
         try:
-            data = await runner.start(session_id=session_id, profile_volume=profile_volume)
+            data = await runner.start(session_id=session_id, profile_volume=profile_volume,
+                                      mobile=mobile)
         except Exception as exc:
             await self.mark_error(session_id)
             raise BrowserWorkerError(f"host browser start failed: {exc}") from exc

--- a/tinyagentos/browser_sessions.py
+++ b/tinyagentos/browser_sessions.py
@@ -455,7 +455,18 @@ class BrowserSessionManager:
             if bool(session["is_mobile"]) == mobile:
                 # Same mode — return as-is; caller starts it if pending/idle.
                 return session
-            # Different mode — re-present: reset to pending in the new mode.
+            # Different mode — re-present. Capture the old container so the
+            # caller can stop it (freeing its port + profile-volume lock)
+            # before starting the new one; then reset to pending in the new mode.
+            old_container = session.get("container_id")
+            old_node = session.get("node")
+            old_port = None
+            if session.get("neko_url"):
+                from urllib.parse import urlparse
+                try:
+                    old_port = urlparse(session["neko_url"]).port
+                except Exception:
+                    old_port = None
             now = time.time()
             await db.execute(
                 """UPDATE browser_sessions
@@ -465,7 +476,14 @@ class BrowserSessionManager:
                 (int(mobile), now, session["id"]),
             )
             await db.commit()
-            return await self.get_session(session["id"])  # type: ignore[return-value]
+            new_session = await self.get_session(session["id"])
+            if old_container and new_session is not None:
+                new_session["_represent_old"] = {
+                    "container_id": old_container,
+                    "node": old_node,
+                    "http_port": old_port,
+                }
+            return new_session  # type: ignore[return-value]
         return await self.create_session("user", owner_id, url, profile_name, mobile=mobile)
 
     async def start_on_host(self, session_id: str, *, profile_volume: str, runner,

--- a/tinyagentos/browser_sessions.py
+++ b/tinyagentos/browser_sessions.py
@@ -88,8 +88,11 @@ class BrowserSessionManager:
         # Best-effort migration for databases created before is_mobile was added.
         try:
             await self._db.execute(BROWSER_SESSIONS_MIGRATION)
-        except Exception:
-            pass  # Column already exists
+        except aiosqlite.OperationalError as exc:
+            if "duplicate column" in str(exc).lower():
+                logger.debug("is_mobile column already exists; skipping migration")
+            else:
+                raise
         await self._db.commit()
 
     async def close(self) -> None:
@@ -427,7 +430,7 @@ class BrowserSessionManager:
 
     async def get_or_create_mine(self, owner_id: str, *, url: str = "about:blank",
                                  profile_name: str = "default",
-                                 mobile: bool = False) -> dict:
+                                 mobile: bool = False) -> dict | None:
         """Return the user's single live (pending/running/idle) session, creating
         one if none exists. Stopped/error sessions are not reused.
 
@@ -483,7 +486,7 @@ class BrowserSessionManager:
                     "node": old_node,
                     "http_port": old_port,
                 }
-            return new_session  # type: ignore[return-value]
+            return new_session
         return await self.create_session("user", owner_id, url, profile_name, mobile=mobile)
 
     async def start_on_host(self, session_id: str, *, profile_volume: str, runner,

--- a/tinyagentos/routes/browser_sessions.py
+++ b/tinyagentos/routes/browser_sessions.py
@@ -144,6 +144,8 @@ async def get_my_session(
 
     mgr = request.app.state.browser_sessions
     session = await mgr.get_or_create_mine(user_id, mobile=mobile)
+    if session is None:
+        return JSONResponse({"error": "failed to create browser session"}, status_code=500)
 
     # A device-class switch re-presents the session: stop the old container
     # first so it releases its port + profile-volume lock before the new one.
@@ -162,6 +164,7 @@ async def get_my_session(
                         session["id"], worker_url=worker.url,
                         container_id=old["container_id"], http_port=old.get("http_port"),
                         auth_token=auth_token,
+                        set_status=None,
                     )
         except Exception as exc:
             logger.warning("re-present: failed to stop old container %s: %s", old.get("container_id"), exc)

--- a/tinyagentos/routes/browser_sessions.py
+++ b/tinyagentos/routes/browser_sessions.py
@@ -145,6 +145,27 @@ async def get_my_session(
     mgr = request.app.state.browser_sessions
     session = await mgr.get_or_create_mine(user_id, mobile=mobile)
 
+    # A device-class switch re-presents the session: stop the old container
+    # first so it releases its port + profile-volume lock before the new one.
+    old = session.pop("_represent_old", None) if isinstance(session, dict) else None
+    if old and old.get("container_id"):
+        try:
+            if old.get("node") in (None, "host"):
+                runner = request.app.state.browser_container_runner
+                await runner.stop(container_id=old["container_id"], http_port=old.get("http_port"))
+            else:
+                cluster = request.app.state.cluster_manager
+                worker = cluster.get_worker(old["node"])
+                if worker is not None:
+                    auth_token = getattr(request.app.state, "browser_worker_auth_token", None)
+                    await mgr.stop_on_worker(
+                        session["id"], worker_url=worker.url,
+                        container_id=old["container_id"], http_port=old.get("http_port"),
+                        auth_token=auth_token,
+                    )
+        except Exception as exc:
+            logger.warning("re-present: failed to stop old container %s: %s", old.get("container_id"), exc)
+
     if session["status"] in ("pending", "idle"):
         cluster = request.app.state.cluster_manager
         host_hw = getattr(request.app.state, "host_hardware", None)

--- a/tinyagentos/routes/browser_sessions.py
+++ b/tinyagentos/routes/browser_sessions.py
@@ -12,7 +12,7 @@ Routes:
 import logging
 from typing import Any
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
@@ -119,8 +119,16 @@ async def list_sessions(
 async def get_my_session(
     request: Request,
     current_user: dict[str, Any] = Depends(get_current_user),
+    device: str = Query(default="desktop"),
 ):
     """Return the caller's always-on browser session, creating and starting it if needed.
+
+    Pass ``?device=mobile`` for a phone client — the session runs portrait
+    (800x1600@30) with a mobile Chromium UA + touch so sites serve mobile
+    layouts. ``?device=desktop`` (default) runs landscape 1280x720.
+
+    If a running session exists in the opposite mode, it is re-presented:
+    container stopped (profile volume kept), restarted in the target mode.
 
     Placement order: host (if RAM-capable) -> best cluster worker -> 409.
     When running with a neko_url, attaches a short-lived stream_token.
@@ -132,8 +140,10 @@ async def get_my_session(
     if not user_id:
         return JSONResponse({"error": "session has no user id"}, status_code=401)
 
+    mobile = device == "mobile"
+
     mgr = request.app.state.browser_sessions
-    session = await mgr.get_or_create_mine(user_id)
+    session = await mgr.get_or_create_mine(user_id, mobile=mobile)
 
     if session["status"] in ("pending", "idle"):
         cluster = request.app.state.cluster_manager
@@ -146,7 +156,8 @@ async def get_my_session(
         try:
             if kind == "host":
                 runner = request.app.state.browser_container_runner
-                session = await mgr.start_on_host(session["id"], profile_volume=vol, runner=runner)
+                session = await mgr.start_on_host(session["id"], profile_volume=vol,
+                                                   runner=runner, mobile=mobile)
             else:
                 worker = cluster.get_worker(node)
                 auth_token = getattr(request.app.state, "browser_worker_auth_token", None)
@@ -156,6 +167,7 @@ async def get_my_session(
                     worker_url=worker.url,
                     profile_volume=vol,
                     auth_token=auth_token,
+                    mobile=mobile,
                 )
         except BrowserWorkerError:
             return JSONResponse({"error": "worker_start_failed"}, status_code=502)

--- a/tinyagentos/worker/browser_container.py
+++ b/tinyagentos/worker/browser_container.py
@@ -11,6 +11,7 @@ import asyncio
 import logging
 import secrets
 from dataclasses import dataclass, field
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +23,16 @@ DEFAULT_NEKO_GPU_IMAGE = "ghcr.io/m1k1o/neko/nvidia-chromium:latest"
 # built + published. Device nodes are still passed (harmless on RK3588).
 DEFAULT_NEKO_RK3588_IMAGE = "ghcr.io/m1k1o/neko/chromium:latest"
 NEKO_SCREEN = "1280x720@30"
+NEKO_SCREEN_MOBILE = "800x1600@30"
 NEKO_PROFILE_MOUNT = "/home/neko"
+
+# Path to the mobile Chromium supervisord config, relative to the repo root.
+# browser_container.py lives at tinyagentos/worker/browser_container.py so
+# three parents up reaches the repo root.
+_REPO_ROOT = Path(__file__).parent.parent.parent
+MOBILE_CHROMIUM_CONF = (
+    _REPO_ROOT / "app-catalog" / "streaming" / "neko-browser" / "mobile-chromium.conf"
+)
 
 
 @dataclass
@@ -76,18 +86,26 @@ def build_neko_run_args(
     gpu: bool = False,
     image: str | None = None,
     device_args: list[str] | None = None,
+    mobile: bool = False,
 ) -> list[str]:
     """Return the full ``docker run`` argv (starting with 'docker') for a Neko
-    Chromium session, per the validated spike recipe."""
+    Chromium session, per the validated spike recipe.
+
+    When ``mobile=True`` the container runs portrait (800x1600@30) and mounts
+    the mobile Chromium supervisord config so Chromium presents a mobile UA,
+    touch events, and a 3x device scale factor.
+    """
     if image is None:
         image = DEFAULT_NEKO_GPU_IMAGE if gpu else DEFAULT_NEKO_IMAGE
+
+    screen = NEKO_SCREEN_MOBILE if mobile else NEKO_SCREEN
 
     args = [
         "docker", "run", "-d", "--rm",
         "--name", container_name,
         "-p", f"{http_port}:8080",
         "-p", f"{epr_lo}-{epr_hi}:{epr_lo}-{epr_hi}/udp",
-        "-e", f"NEKO_DESKTOP_SCREEN={NEKO_SCREEN}",
+        "-e", f"NEKO_DESKTOP_SCREEN={screen}",
         "-e", f"NEKO_MEMBER_MULTIUSER_USER_PASSWORD={user_pwd}",
         "-e", f"NEKO_MEMBER_MULTIUSER_ADMIN_PASSWORD={admin_pwd}",
         "-e", f"NEKO_WEBRTC_EPR={epr_lo}-{epr_hi}",
@@ -95,6 +113,8 @@ def build_neko_run_args(
         "--shm-size=2g",
         "-v", f"{profile_volume}:{NEKO_PROFILE_MOUNT}",
     ]
+    if mobile:
+        args += ["-v", f"{MOBILE_CHROMIUM_CONF}:/etc/neko/supervisord/chromium.conf:ro"]
     for dev in device_args or []:
         args += ["--device", dev]
     if gpu:
@@ -205,11 +225,14 @@ class BrowserContainerRunner:
             detail = stderr.decode().strip()
             raise BrowserContainerError(f"docker pull {image} failed: {detail}")
 
-    async def start(self, *, session_id: str, profile_volume: str) -> dict:
+    async def start(self, *, session_id: str, profile_volume: str, mobile: bool = False) -> dict:
         """Start a Neko container and return connection details.
 
         Returns a dict with keys: container_id, neko_url, cdp_url,
         http_port, epr_lo, epr_hi.
+
+        When ``mobile=True`` the container runs portrait (800x1600@30) with a
+        mobile Chromium UA + touch events so sites serve mobile layouts.
         """
         http_port, epr_lo, epr_hi = self._allocator.allocate()
         # Full session_id (a uuid hex) — avoids name collisions from a
@@ -242,6 +265,7 @@ class BrowserContainerRunner:
                 gpu=spec.gpu,
                 image=image,
                 device_args=spec.device_args,
+                mobile=mobile,
             )
             try:
                 proc = await asyncio.create_subprocess_exec(


### PR DESCRIPTION
## Summary

- When the client is a phone, the always-on Neko session **re-presents mobile-emulated**: portrait screen (800x1600@30), Pixel 8 mobile UA, touch events enabled, 3x device scale factor — so sites serve genuine mobile layouts rather than squashed desktop pages
- On a computer, desktop mode (1280x720 landscape) runs as before
- **Profile volume is preserved** across re-presents — logins and browser history survive mode switches
- v1 mechanism is relaunch-on-switch: if the running container's mode differs from the requested device class, the container is stopped (volume kept) and restarted in target mode; CDP live-toggle without a container restart is future v2

## What ships

- `app-catalog/streaming/neko-browser/mobile-chromium.conf` — supervisord conf with mobile UA, touch-events, force-device-scale-factor=3; bind-mounted read-only into mobile containers
- `tinyagentos/worker/browser_container.py` — `build_neko_run_args` and `BrowserContainerRunner.start` gain `mobile: bool = False`; portrait screen + conf mount wired in
- `tinyagentos/browser_sessions.py` — `is_mobile` column (+ best-effort ALTER TABLE migration for existing DBs); `get_or_create_mine` re-presents when mode differs; `start_on_host`/`start_on_worker` forward the mobile flag
- `tinyagentos/routes/browser_sessions.py` — `GET /api/browser/sessions/mine` reads `?device=mobile|desktop` (default desktop)
- `desktop/src/apps/StreamedBrowserApp/StreamedBrowserApp.tsx` — appends `?device=mobile|desktop`; `isMobile` moved before `fetchMine` so the callback captures the correct value and re-fetches when device class changes
- Built on top of the full-bleed frontend fix already on this branch

## Validated recipe used

Portrait Modeline `800x1600@30` is the only portrait resolution baked into the Neko image. Mobile conf flags: `--user-agent="…Pixel 8…Mobile Safari…"`, `--touch-events=enabled`, `--force-device-scale-factor=3`.

## Test plan

- [ ] `python3 -m pytest tests/test_browser_container.py tests/test_browser_sessions.py tests/routes/test_browser_sessions_routes.py -q` — 88 passed
- [ ] `cd desktop && npm run build` — clean
- [ ] On a phone, `GET /api/browser/sessions/mine?device=mobile` re-presents an existing desktop session to portrait mobile
- [ ] Profile (logins) survive the re-present
- [ ] On a desktop after a prior mobile session, `?device=desktop` flips back

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile device mode for the streamed browser with optimized display and container behavior
  * UI adapts layout on mobile (collapsed horizontal rail, column flow) and desktop (sidebar, row flow)
  * API now accepts a device parameter to fetch mobile or desktop sessions
  * Sessions re-present intelligently when switching between mobile and desktop

* **Tests**
  * Added coverage for mobile vs desktop session behavior and startup paths
<!-- end of auto-generated comment: release notes by coderabbit.ai -->