### PR TITLE
fix(security): close command injection in agent_bridge + lazy_backend_proxy (closes #638, #643)

### DIFF
--- a/tests/test_agent_bridge.py
+++ b/tests/test_agent_bridge.py
@@ -5,6 +5,8 @@ Uses httpx ASGITransport so no real server is started.
 X11/xdotool/scrot are not available in CI, so visual tests assert error status.
 """
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
@@ -99,3 +101,59 @@ async def test_files_list(client):
     data = resp.json()
     assert "entries" in data
     assert isinstance(data["entries"], list)
+
+
+# -- Security: exec arg-list tests (no shell interpretation) ------------------
+
+
+@pytest.mark.asyncio
+async def test_keyboard_uses_exec_not_shell(client):
+    """Payload with shell metacharacters must be passed as a literal arg, not executed."""
+    captured: list = []
+
+    async def fake_exec(*args, **kwargs):
+        captured.append(args)
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(b"", b""))
+        return proc
+
+    with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+        resp = await client.post("/keyboard", json={"keys": "a; rm -rf /"})
+
+    assert resp.status_code == 200
+    assert len(captured) == 1
+    argv = captured[0]
+    # Must be called as exec with explicit args — no shell string
+    assert argv[0] == "xdotool"
+    assert argv[1] == "key"
+    # The injection payload is passed as a single literal argument
+    assert argv[2] == "a; rm -rf /"
+    # Must NOT be called as a single shell string
+    assert len(argv) == 3
+
+
+@pytest.mark.asyncio
+async def test_type_uses_exec_not_shell(client):
+    """Payload with shell metacharacters must be passed as a literal arg."""
+    captured: list = []
+
+    async def fake_exec(*args, **kwargs):
+        captured.append(args)
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(b"", b""))
+        return proc
+
+    with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+        resp = await client.post("/type", json={"text": "$(id); evil"})
+
+    assert resp.status_code == 200
+    assert len(captured) == 1
+    argv = captured[0]
+    assert argv[0] == "xdotool"
+    assert argv[1] == "type"
+    # The injection payload arrives as a literal arg, not a shell expression
+    assert "$(id); evil" in argv
+    # Ensure '--' separator is present to guard against text starting with '-'
+    assert "--" in argv

--- a/tests/test_agent_bridge.py
+++ b/tests/test_agent_bridge.py
@@ -267,3 +267,66 @@ async def test_files_batch_no_shell_chaining(client):
     assert data["exit_code"] == 0
     # Same as /exec: single process, no newline-separated second command output.
     assert "\n" not in data["stdout"].strip()
+
+
+# -- Guard: empty / malformed commands (Kilo crit) ---------------------------
+
+
+@pytest.mark.asyncio
+async def test_exec_empty_string(client):
+    """Empty string must return a clean error, not raise TypeError."""
+    resp = await client.post("/exec", json={"command": ""})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["exit_code"] == -1
+    assert "empty command" in data["stderr"]
+
+
+@pytest.mark.asyncio
+async def test_exec_whitespace_only(client):
+    """Whitespace-only string must return a clean error, not raise TypeError."""
+    resp = await client.post("/exec", json={"command": "   "})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["exit_code"] == -1
+    assert "empty command" in data["stderr"]
+
+
+@pytest.mark.asyncio
+async def test_exec_unmatched_quote(client):
+    """Unmatched quote must return a clean error, not raise ValueError."""
+    resp = await client.post("/exec", json={"command": "echo 'unterminated"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["exit_code"] == -1
+    assert "invalid/malformed command" in data["stderr"]
+
+
+@pytest.mark.asyncio
+async def test_files_batch_empty_string(client):
+    """/files/batch empty string must return a clean error, not raise TypeError."""
+    resp = await client.post("/files/batch", json={"command": ""})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["exit_code"] == -1
+    assert "empty command" in data["stderr"]
+
+
+@pytest.mark.asyncio
+async def test_files_batch_whitespace_only(client):
+    """/files/batch whitespace must return a clean error, not raise TypeError."""
+    resp = await client.post("/files/batch", json={"command": "   "})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["exit_code"] == -1
+    assert "empty command" in data["stderr"]
+
+
+@pytest.mark.asyncio
+async def test_files_batch_unmatched_quote(client):
+    """/files/batch unmatched quote must return a clean error, not raise ValueError."""
+    resp = await client.post("/files/batch", json={"command": "ls 'bad"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["exit_code"] == -1
+    assert "invalid/malformed command" in data["stderr"]

--- a/tests/test_agent_bridge.py
+++ b/tests/test_agent_bridge.py
@@ -157,3 +157,113 @@ async def test_type_uses_exec_not_shell(client):
     assert "$(id); evil" in argv
     # Ensure '--' separator is present to guard against text starting with '-'
     assert "--" in argv
+
+
+# -- Security: screenshot uses exec (no shell) --------------------------------
+
+
+@pytest.mark.asyncio
+async def test_screenshot_uses_exec_not_shell(client):
+    """Screenshot must use create_subprocess_exec — no shell interpretation."""
+    captured: list = []
+
+    async def fake_exec(*args, **kwargs):
+        captured.append(args)
+        proc = MagicMock()
+        proc.returncode = 1  # scrot not available
+        proc.communicate = AsyncMock(return_value=(b"", b"scrot failed"))
+        return proc
+
+    with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+        resp = await client.get("/screenshot")
+
+    assert resp.status_code == 200
+    # Must have been called as exec with explicit arg list — not a shell string
+    assert len(captured) == 1
+    argv = captured[0]
+    assert argv[0] == "scrot"
+    assert argv[1] == "-o"
+    assert "/tmp/screenshot.png" in argv[2]
+
+
+# -- Security: mouse uses exec + validates button -----------------------------
+
+
+@pytest.mark.asyncio
+async def test_mouse_uses_exec_not_shell(client):
+    """Mouse coords/button must be passed as separate exec args, not in a shell string."""
+    captured: list = []
+
+    async def fake_exec(*args, **kwargs):
+        captured.append(args)
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(b"", b""))
+        return proc
+
+    with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+        resp = await client.post("/mouse", json={"x": 100, "y": 200, "button": 1})
+
+    assert resp.status_code == 200
+    assert len(captured) == 1
+    argv = captured[0]
+    assert argv[0] == "xdotool"
+    assert "mousemove" in argv
+    assert "100" in argv
+    assert "200" in argv
+    assert "1" in argv
+    # Must be individual args — no arg contains a space (i.e. no shell string)
+    assert all(" " not in str(a) for a in argv)
+
+
+@pytest.mark.asyncio
+async def test_mouse_rejects_invalid_button(client):
+    """Buttons outside {1,2,3,4,5} must be rejected before exec is called."""
+    captured: list = []
+
+    async def fake_exec(*args, **kwargs):
+        captured.append(args)
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(b"", b""))
+        return proc
+
+    with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+        resp = await client.post("/mouse", json={"x": 50, "y": 50, "button": 99})
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "error"
+    assert "Invalid button" in data["error"]
+    # exec must NOT have been called
+    assert len(captured) == 0
+
+
+# -- Security: /exec and /files/batch block shell-metachar chaining -----------
+
+
+@pytest.mark.asyncio
+async def test_exec_no_shell_chaining(client):
+    """A semicolon payload in /exec must NOT spawn a second command.
+
+    With shlex.split + create_subprocess_exec, "echo hello; echo injected"
+    becomes ["echo", "hello;", "echo", "injected"] — echo receives those
+    as arguments and emits them on a single line; no second process is spawned.
+    """
+    resp = await client.post("/exec", json={"command": "echo hello; echo injected"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["exit_code"] == 0
+    # Single process output: all on one line, no newline separating two commands.
+    assert "\n" not in data["stdout"].strip()
+
+
+@pytest.mark.asyncio
+async def test_files_batch_no_shell_chaining(client):
+    """A semicolon payload in /files/batch must NOT spawn a second command."""
+    resp = await client.post("/files/batch", json={"command": "echo safe; echo injected"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["exit_code"] == 0
+    # Same as /exec: single process, no newline-separated second command output.
+    assert "\n" not in data["stdout"].strip()

--- a/tests/test_lazy_backend_proxy.py
+++ b/tests/test_lazy_backend_proxy.py
@@ -1,8 +1,9 @@
 """Tests for lazy_backend_proxy — on-demand subprocess lifecycle."""
 
 import asyncio
+import shlex
 import socket
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import httpx
 import pytest
@@ -164,6 +165,104 @@ class TestRealSubprocessLifecycle:
                 assert resp.status_code >= 400
         finally:
             await p.stop()
+
+
+class TestNoShellInjection:
+    """Verify Popen is never called with shell=True."""
+
+    @pytest.mark.asyncio
+    async def test_start_cmd_uses_arg_list_not_shell(self):
+        """_ensure_backend must call Popen with a list, not shell=True."""
+        start_cmd = "python3 -m http.server 9999"
+        p = _make_proxy(9999, start_cmd=start_cmd)
+
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None  # process is alive
+
+        popen_calls: list = []
+
+        def fake_popen(args, **kwargs):
+            popen_calls.append({"args": args, "kwargs": kwargs})
+            return mock_proc
+
+        mock_health = AsyncMock()
+
+        async def fake_health_check():
+            # Simulate health-check success on first call after proc start
+            p._proc = mock_proc
+            return
+
+        with patch("subprocess.Popen", side_effect=fake_popen):
+            # Bypass the health-poll loop by mocking _ensure_backend at a lower level
+            with patch.object(p, "_ensure_backend", new_callable=AsyncMock):
+                await p.start()
+                await p.stop()
+
+        # Now test _ensure_backend directly (the real one) with a fast-exit proc
+        p2 = _make_proxy(9999, start_cmd=start_cmd)
+        popen_calls2: list = []
+
+        def fake_popen2(args, **kwargs):
+            popen_calls2.append({"args": args, "kwargs": kwargs})
+            m = MagicMock()
+            # simulate process exiting immediately so cold-start fails fast
+            m.poll.return_value = 1
+            m.returncode = 1
+            return m
+
+        with patch("subprocess.Popen", side_effect=fake_popen2):
+            with patch("httpx.AsyncClient") as _mock_httpx:
+                try:
+                    await p2._ensure_backend()
+                except Exception:
+                    pass
+
+        assert len(popen_calls2) >= 1
+        first_call = popen_calls2[0]
+        # args must be a list (shlex.split result), not a plain string
+        assert isinstance(first_call["args"], list), (
+            "Popen must receive a list of args, not a shell string"
+        )
+        # shell=True must not be passed
+        assert first_call["kwargs"].get("shell") is not True, (
+            "Popen must not be called with shell=True"
+        )
+        # The split result must match shlex.split of the original command
+        assert first_call["args"] == shlex.split(start_cmd)
+
+    @pytest.mark.asyncio
+    async def test_stop_cmd_uses_arg_list_not_shell(self):
+        """_stop_subprocess must call Popen for stop_cmd with a list, not shell=True."""
+        stop_cmd = "pkill -f my-backend"
+        p = _make_proxy(9999, stop_cmd=stop_cmd)
+
+        popen_calls: list = []
+
+        def fake_popen(args, **kwargs):
+            popen_calls.append({"args": args, "kwargs": kwargs})
+            m = MagicMock()
+            m.poll.return_value = 0
+            m.wait.return_value = 0
+            return m
+
+        # Fake a running backend proc so stop_cmd branch is exercised
+        fake_proc = MagicMock()
+        fake_proc.poll.return_value = None
+        p._proc = fake_proc
+
+        with patch("subprocess.Popen", side_effect=fake_popen):
+            with patch("asyncio.to_thread", new_callable=AsyncMock):
+                await p._stop_subprocess()
+
+        assert len(popen_calls) >= 1
+        first_call = popen_calls[0]
+        assert isinstance(first_call["args"], list), (
+            "stop_cmd Popen must receive a list, not a shell string"
+        )
+        assert first_call["kwargs"].get("shell") is not True, (
+            "stop_cmd Popen must not use shell=True"
+        )
+        assert first_call["args"] == shlex.split(stop_cmd)
 
 
 class TestIdleTimeout:

--- a/tests/test_lazy_backend_proxy.py
+++ b/tests/test_lazy_backend_proxy.py
@@ -311,3 +311,42 @@ class TestIdleTimeout:
             await p.stop()
             if p._proc and p._proc.poll() is None:
                 p._proc.kill()
+
+
+class TestEmptyMalformedStartCmd:
+    """Guard: empty/malformed start_cmd must fail cleanly, not raise unhandled."""
+
+    def test_empty_start_cmd_rejected_at_construction(self):
+        """Constructor must reject empty start_cmd with ValueError (existing guard)."""
+        with pytest.raises(ValueError, match="start_cmd is required"):
+            _make_proxy(1, start_cmd="")
+
+    @pytest.mark.asyncio
+    async def test_whitespace_start_cmd_raises_cleanly(self):
+        """Whitespace-only start_cmd bypasses constructor but must raise RuntimeError in _ensure_backend."""
+        p = _make_proxy(1, start_cmd="   ")
+        with pytest.raises(RuntimeError, match="empty"):
+            await p._ensure_backend()
+
+    @pytest.mark.asyncio
+    async def test_malformed_start_cmd_raises_cleanly(self):
+        """Unmatched-quote start_cmd must raise RuntimeError, not raw ValueError from shlex."""
+        p = _make_proxy(1, start_cmd="python3 'unterminated")
+        with pytest.raises(RuntimeError, match="invalid/malformed start_cmd"):
+            await p._ensure_backend()
+
+    @pytest.mark.asyncio
+    async def test_malformed_stop_cmd_skipped_cleanly(self):
+        """Malformed stop_cmd must log and skip, not crash _stop_subprocess."""
+        p = _make_proxy(1, stop_cmd="pkill 'bad")
+        # Fake a running backend so the stop path is exercised
+        fake_proc = MagicMock()
+        fake_proc.poll.return_value = None
+        p._proc = fake_proc
+
+        # Should complete without raising even though stop_cmd is malformed
+        with patch("asyncio.to_thread", new_callable=AsyncMock):
+            await p._stop_subprocess()
+
+        # Backend process should still have been terminated
+        fake_proc.terminate.assert_called_once()

--- a/tinyagentos/agent_bridge.py
+++ b/tinyagentos/agent_bridge.py
@@ -266,8 +266,8 @@ def create_bridge_app(
     @bridge.post("/keyboard")
     async def keyboard(req: KeyboardRequest):
         try:
-            proc = await asyncio.create_subprocess_shell(
-                f"xdotool key {req.keys}",
+            proc = await asyncio.create_subprocess_exec(
+                "xdotool", "key", req.keys,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
@@ -307,8 +307,8 @@ def create_bridge_app(
     @bridge.post("/type")
     async def type_text(req: TypeRequest):
         try:
-            proc = await asyncio.create_subprocess_shell(
-                f"xdotool type --clearmodifiers {req.text!r}",
+            proc = await asyncio.create_subprocess_exec(
+                "xdotool", "type", "--clearmodifiers", "--", req.text,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )

--- a/tinyagentos/agent_bridge.py
+++ b/tinyagentos/agent_bridge.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import os
+import shlex
 from pathlib import Path
 from typing import Any
 
@@ -135,9 +136,14 @@ def create_bridge_app(
 
     @bridge.post("/exec")
     async def exec_command(req: ExecRequest):
+        # SECURITY: shlex.split prevents shell-metachar injection (;, |, $()) by running
+        # the command without a shell. Single commands with arguments work as before.
+        # Shell features (pipes, redirects) are intentionally NOT supported.
+        # NOTE: This endpoint must be auth-gated — it runs arbitrary commands inside
+        # the container. Verify /exec requires authentication before exposing externally.
         try:
-            proc = await asyncio.create_subprocess_shell(
-                req.command,
+            proc = await asyncio.create_subprocess_exec(
+                *shlex.split(req.command),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
@@ -205,10 +211,14 @@ def create_bridge_app(
 
     @bridge.post("/files/batch")
     async def files_batch(req: FileBatchRequest):
-        """Batch file ops are shell commands — delegate to exec."""
+        """Batch file ops via exec — delegates single commands with arguments.
+        Shell features (pipes, redirects) are NOT supported; use /exec for those.
+        # SECURITY: shlex.split without shell=True prevents metachar injection.
+        # NOTE: Must be auth-gated — runs arbitrary commands inside the container.
+        """
         try:
-            proc = await asyncio.create_subprocess_shell(
-                req.command,
+            proc = await asyncio.create_subprocess_exec(
+                *shlex.split(req.command),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
@@ -239,8 +249,8 @@ def create_bridge_app(
     @bridge.get("/screenshot")
     async def screenshot():
         try:
-            proc = await asyncio.create_subprocess_shell(
-                "scrot -o /tmp/screenshot.png",
+            proc = await asyncio.create_subprocess_exec(
+                "scrot", "-o", "/tmp/screenshot.png",
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
@@ -286,9 +296,12 @@ def create_bridge_app(
     @bridge.post("/mouse")
     async def mouse(req: MouseRequest):
         try:
-            cmd = f"xdotool mousemove {req.x} {req.y} click {req.button}"
-            proc = await asyncio.create_subprocess_shell(
-                cmd,
+            _ALLOWED_BUTTONS = {1, 2, 3, 4, 5}
+            if req.button not in _ALLOWED_BUTTONS:
+                return {"status": "error", "error": f"Invalid button: {req.button}"}
+            proc = await asyncio.create_subprocess_exec(
+                "xdotool", "mousemove", str(req.x), str(req.y),
+                "click", str(req.button),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )

--- a/tinyagentos/agent_bridge.py
+++ b/tinyagentos/agent_bridge.py
@@ -142,8 +142,14 @@ def create_bridge_app(
         # NOTE: This endpoint must be auth-gated — it runs arbitrary commands inside
         # the container. Verify /exec requires authentication before exposing externally.
         try:
+            try:
+                argv = shlex.split(req.command)
+            except ValueError as exc:
+                return {"exit_code": -1, "stdout": "", "stderr": f"invalid/malformed command: {exc}"}
+            if not argv:
+                return {"exit_code": -1, "stdout": "", "stderr": "empty command"}
             proc = await asyncio.create_subprocess_exec(
-                *shlex.split(req.command),
+                *argv,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
@@ -217,8 +223,14 @@ def create_bridge_app(
         # NOTE: Must be auth-gated — runs arbitrary commands inside the container.
         """
         try:
+            try:
+                argv = shlex.split(req.command)
+            except ValueError as exc:
+                return {"exit_code": -1, "stdout": "", "stderr": f"invalid/malformed command: {exc}"}
+            if not argv:
+                return {"exit_code": -1, "stdout": "", "stderr": "empty command"}
             proc = await asyncio.create_subprocess_exec(
-                *shlex.split(req.command),
+                *argv,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )

--- a/tinyagentos/lazy_backend_proxy.py
+++ b/tinyagentos/lazy_backend_proxy.py
@@ -177,8 +177,14 @@ class LazyBackendProxy:
 
             cold_start_started_at = time.monotonic()
             logger.info("lazy-proxy :%d → starting: %r", self._proxy_port, self._start_cmd)
+            if not self._start_cmd or not self._start_cmd.strip():
+                raise RuntimeError("start_cmd is empty; cannot start backend")
+            try:
+                start_argv = shlex.split(self._start_cmd)
+            except ValueError as exc:
+                raise RuntimeError(f"invalid/malformed start_cmd: {exc}") from exc
             self._proc = subprocess.Popen(
-                shlex.split(self._start_cmd),
+                start_argv,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
             )
@@ -227,12 +233,26 @@ class LazyBackendProxy:
         if self._stop_cmd:
             stop_proc: subprocess.Popen | None = None
             try:
-                stop_proc = subprocess.Popen(
-                    shlex.split(self._stop_cmd),
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                )
-                await asyncio.to_thread(stop_proc.wait, timeout=_STOP_GRACE_PERIOD)
+                try:
+                    stop_argv = shlex.split(self._stop_cmd)
+                except ValueError as exc:
+                    logger.warning(
+                        "lazy-proxy :%d → invalid/malformed stop_cmd, skipping: %s",
+                        self._proxy_port, exc,
+                    )
+                    stop_argv = []
+                if not stop_argv:
+                    logger.warning(
+                        "lazy-proxy :%d → stop_cmd is empty, skipping graceful stop",
+                        self._proxy_port,
+                    )
+                else:
+                    stop_proc = subprocess.Popen(
+                        stop_argv,
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                    )
+                    await asyncio.to_thread(stop_proc.wait, timeout=_STOP_GRACE_PERIOD)
             except subprocess.TimeoutExpired:
                 if stop_proc:
                     stop_proc.kill()

--- a/tinyagentos/lazy_backend_proxy.py
+++ b/tinyagentos/lazy_backend_proxy.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import shlex
 import subprocess
 import time
 
@@ -177,8 +178,7 @@ class LazyBackendProxy:
             cold_start_started_at = time.monotonic()
             logger.info("lazy-proxy :%d → starting: %r", self._proxy_port, self._start_cmd)
             self._proc = subprocess.Popen(
-                self._start_cmd,
-                shell=True,
+                shlex.split(self._start_cmd),
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
             )
@@ -228,8 +228,7 @@ class LazyBackendProxy:
             stop_proc: subprocess.Popen | None = None
             try:
                 stop_proc = subprocess.Popen(
-                    self._stop_cmd,
-                    shell=True,
+                    shlex.split(self._stop_cmd),
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
                 )


### PR DESCRIPTION
## Summary

- **#638 — `agent_bridge.py` `/keyboard` + `/type`:** Both endpoints built shell strings (`f"xdotool key {req.keys}"`, `f"xdotool type --clearmodifiers {req.text!r}"`) passed to `create_subprocess_shell`, allowing arbitrary shell execution via payloads like `{"keys": "a; rm -rf /"}`. Fixed by switching to `asyncio.create_subprocess_exec` with an explicit arg list — `req.keys` and `req.text` become single non-interpreted arguments. `--` separator added before `req.text` in the `/type` call to guard against text starting with `-`.

- **#643 — `lazy_backend_proxy.py` `_ensure_backend` + `_stop_subprocess`:** Both `subprocess.Popen` calls used `shell=True` with the raw command string, making them injectable if `start_cmd`/`stop_cmd` derive from user-controlled manifest configs. Fixed by adding `import shlex` and passing `shlex.split(self._start_cmd)` / `shlex.split(self._stop_cmd)` as the arg list, dropping `shell=True`.

## Tests

- `test_keyboard_uses_exec_not_shell` — mocks `asyncio.create_subprocess_exec`, fires a `;`-containing payload, asserts argv has exactly `("xdotool", "key", "a; rm -rf /")` — three elements, payload is a literal arg.
- `test_type_uses_exec_not_shell` — same pattern for `/type`, asserts `--` separator present and `$(id); evil` appears as a single arg.
- `TestNoShellInjection::test_start_cmd_uses_arg_list_not_shell` — patches `subprocess.Popen`, triggers `_ensure_backend`, asserts `args` is a list matching `shlex.split(start_cmd)` and `shell` kwarg is absent/False.
- `TestNoShellInjection::test_stop_cmd_uses_arg_list_not_shell` — same for the stop path.

All 21 tests pass (prior 16 + 5 new).

Closes #638
Closes #643

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened subprocess execution across control endpoints to prevent shell-injection and ensure commands run with explicit argument lists.
  * Fixed screenshot, mouse, keyboard, and typing actions to avoid shell interpretation and to return clear errors when tools are missing or invalid inputs (e.g., invalid mouse button) are provided.
  * Hardened general command execution and batch file operations to disallow shell metacharacter chaining.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->