### PR TITLE
fix(security): per-agent scoped LiteLLM keys instead of the master key (closes #645)

### DIFF
--- a/tests/test_deployer.py
+++ b/tests/test_deployer.py
@@ -198,11 +198,12 @@ class TestDeployAgent:
             )
 
     @pytest.mark.asyncio
-    async def test_fallback_to_master_key_when_create_returns_none(self, tmp_path):
-        """When LiteLLM runs without a Postgres DB, create_agent_key
-        returns None. The deployer must fall back to the shared master
-        key so the container still gets a non-empty LITELLM_API_KEY —
-        otherwise openclaw's gateway crashes on boot."""
+    async def test_deploy_fails_when_key_mint_returns_none_no_db(self, tmp_path):
+        """When LiteLLM runs without a Postgres DB, create_agent_key returns None.
+        The deployer must refuse to fall back to the shared master key — injecting
+        it would give the agent full admin API access and access to every other
+        agent's key. Deploy must fail with a clear error directing operators to
+        configure a Postgres database."""
         mock_proxy = MagicMock()
         mock_proxy.is_running.return_value = True
         mock_proxy.url = "http://localhost:4000"
@@ -215,26 +216,55 @@ class TestDeployAgent:
             extra_config={"llm_proxy": mock_proxy},
         )
 
+        with patch("tinyagentos.deployer.create_container", new_callable=AsyncMock) as mock_create, \
+             patch("tinyagentos.deployer.exec_in_container", new_callable=AsyncMock, return_value=(0, "")), \
+             patch("tinyagentos.deployer.push_file", new_callable=AsyncMock, return_value=(0, "")), \
+             patch("tinyagentos.deployer.add_proxy_device", new_callable=AsyncMock, return_value={"success": True, "output": ""}):
+            mock_create.return_value = {"success": True, "name": "taos-agent-routing-only"}
+            result = await deploy_agent(req)
+            assert result["success"] is False
+            assert "routing-only" in result["error"] or "DATABASE_URL" in result["error"]
+            assert "master key" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_master_key_never_injected_into_container_env(self, tmp_path):
+        """The shared master key (sk-taos-master) must never appear in the
+        container env — not as OPENAI_API_KEY, LITELLM_API_KEY, or any other
+        variable. Only scoped per-agent virtual keys are permitted."""
+        from tinyagentos.llm_proxy import TAOS_LITELLM_MASTER_KEY
+        mock_proxy = MagicMock()
+        mock_proxy.is_running.return_value = True
+        mock_proxy.url = "http://localhost:4000"
+        mock_proxy.database_url = "postgresql://u:p@h/db"
+        mock_proxy.create_agent_key = AsyncMock(return_value="sk-scoped-agent-key")
+
+        req = _req(
+            name="master-key-test",
+            data_dir=tmp_path,
+            extra_config={"llm_proxy": mock_proxy},
+        )
+
         async def mock_exec_fn(name, cmd, **kwargs):
             if "hostname -I" in " ".join(cmd):
-                return (0, "10.0.0.14")
+                return (0, "10.0.0.42")
             return (0, "ok")
 
         with patch("tinyagentos.deployer.create_container", new_callable=AsyncMock) as mock_create, \
              patch("tinyagentos.deployer.exec_in_container", side_effect=mock_exec_fn), \
              patch("tinyagentos.deployer.push_file", new_callable=AsyncMock, return_value=(0, "")), \
              patch("tinyagentos.deployer.add_proxy_device", new_callable=AsyncMock, return_value={"success": True, "output": ""}):
-            mock_create.return_value = {"success": True, "name": "taos-agent-routing-only"}
+            mock_create.return_value = {"success": True, "name": "taos-agent-master-key-test"}
             result = await deploy_agent(req)
             assert result["success"] is True
             env = mock_create.call_args.kwargs["env"]
-            assert env["LITELLM_API_KEY"] == "sk-taos-master"
-            assert env["OPENAI_API_KEY"] == "sk-taos-master"
-            assert env["OPENAI_BASE_URL"] == "http://localhost:4000/v1"
-            # Embedding env must still fire under the fallback path — the
-            # LiteLLM routing-only mode serves /v1/embeddings identically.
-            assert env["TAOS_EMBEDDING_URL"] == "http://localhost:4000/v1/embeddings"
-            assert env["TAOS_EMBEDDING_MODEL"] == "taos-embedding-default"
+            # The scoped virtual key must be injected
+            assert env["OPENAI_API_KEY"] == "sk-scoped-agent-key"
+            assert env["LITELLM_API_KEY"] == "sk-scoped-agent-key"
+            # The master key must never appear anywhere in the container env
+            for var, val in env.items():
+                assert val != TAOS_LITELLM_MASTER_KEY, (
+                    f"master key leaked into container env var {var!r}"
+                )
 
     @pytest.mark.asyncio
     async def test_create_agent_key_called_with_agent_models(self, tmp_path):

--- a/tinyagentos/deployer.py
+++ b/tinyagentos/deployer.py
@@ -172,28 +172,30 @@ async def deploy_agent(req: DeployRequest) -> dict:
             key_models = [m for m in [req.model, *(req.fallback_models or [])] if m]
             llm_key = await proxy.create_agent_key(req.name, models=key_models or None)
             if llm_key is None:
+                # Key mint failed — either LiteLLM is running without a
+                # Postgres DB (routing-only mode, so /key/generate is
+                # unavailable) or the DB is configured but the call failed
+                # (migration pending, DB unreachable, master key mismatch).
+                # Either way we must NOT fall back to the shared master key:
+                # injecting it gives every agent full admin API access and
+                # access to all other agents' keys. Fail loudly instead.
                 db_url = getattr(proxy, "database_url", None)
                 if db_url is None:
-                    # Routing-only mode — LiteLLM can't mint virtual keys
-                    # without a Postgres DB. Fall back to the shared master
-                    # key so the container can still authenticate.
-                    from tinyagentos.llm_proxy import TAOS_LITELLM_MASTER_KEY
-                    llm_key = TAOS_LITELLM_MASTER_KEY
-                    logger.info(
-                        "deploy %s: LiteLLM routing-only mode — using shared master key (no DB configured for virtual keys)",
-                        req.name,
+                    msg = (
+                        "per-agent LiteLLM virtual key could not be minted: "
+                        "LiteLLM is running in routing-only mode (no Postgres "
+                        "DATABASE_URL configured). Configure a Postgres database "
+                        "for LiteLLM so per-agent scoped keys can be issued. "
+                        "Deploying with the shared master key is not permitted "
+                        "because it grants agents full admin API access."
                     )
                 else:
-                    # DB configured but key mint failed — something else
-                    # is wrong (migration pending, DB unreachable, master
-                    # key mismatch). Don't silently fall back; that hides
-                    # the bug and ships broken agents.
                     db_host = db_url.split("@")[-1] if "@" in db_url else db_url
                     msg = (
                         f"virtual key mint failed despite DB configured at {db_host}"
                     )
-                    logger.error("deploy %s: %s", req.name, msg)
-                    return {"success": False, "error": msg, "steps": steps}
+                logger.error("deploy %s: %s", req.name, msg)
+                return {"success": False, "error": msg, "steps": steps}
             from tinyagentos.llm_proxy import EMBEDDING_ALIAS
             # Primary key for openclaw's litellm provider.
             env["LITELLM_API_KEY"] = llm_key


### PR DESCRIPTION
## The exposure

When LiteLLM ran without a Postgres database (routing-only mode), `deployer.py` fell back to injecting the shared master key (`sk-taos-master`) as `OPENAI_API_KEY` and `LITELLM_API_KEY` into every agent container. Any agent that discovered this key could hit the LiteLLM admin API, create or delete keys for other agents, and consume unlimited LLM credits without restriction.

## Fix

The master-key fallback path in `deployer.py` is removed entirely. When `create_agent_key` returns `None` for any reason — no Postgres DB configured (routing-only mode), DB unreachable, or master key mismatch — the deploy now **fails with a clear error** rather than silently falling back. The error message directs operators to configure a Postgres database so LiteLLM can issue per-agent scoped virtual keys.

The existing path that issues scoped keys (DB configured, key mint succeeds) is unchanged. The per-agent key is still scoped to only the models the agent is permitted to use (primary + fallbacks), with the key alias set to the agent name.

## Tests

- `test_fallback_to_master_key_when_create_returns_none` — replaced with `test_deploy_fails_when_key_mint_returns_none_no_db`: asserts deploy returns `success=False` with an actionable error when routing-only mode prevents key minting
- `test_master_key_never_injected_into_container_env` — new test: iterates every env var passed to `create_container` and asserts none carries the master key value; the scoped virtual key is injected instead

73 tests pass (all existing deployer + llm_proxy tests green).

closes #645

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deployment now fails with a clear error message when required database configuration is missing, preventing fallback to shared master keys
  * Ensured shared master keys are never injected into container environments; only scoped virtual keys are used for agent deployments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->