### PR TITLE
fix(security): SSRF + SQL injection in cluster mesh_sync (closes #644)

### DIFF
--- a/tests/scheduling/test_mesh_sync_security.py
+++ b/tests/scheduling/test_mesh_sync_security.py
@@ -131,6 +131,29 @@ class TestIsSafeUrl:
             assert is_safe_url("http://lan-worker.local/", allow_private=True) is True
 
 
+
+    def test_dns_timeout_causes_rejection(self):
+        """A socket.timeout during getaddrinfo must cause is_safe_url to return False."""
+        import socket as _socket
+        def _raise_timeout(host, port, *args, **kwargs):
+            raise _socket.timeout("timed out")
+
+        with patch("tinyagentos.scheduling.mesh_sync.socket.getaddrinfo", _raise_timeout):
+            assert is_safe_url("http://slow-peer.example.com/") is False
+
+    def test_dns_timeout_restores_default(self):
+        """The global socket timeout is restored after is_safe_url, even on timeout."""
+        import socket as _socket
+        _socket.setdefaulttimeout(None)
+
+        def _raise_timeout(host, port, *args, **kwargs):
+            raise _socket.timeout("timed out")
+
+        with patch("tinyagentos.scheduling.mesh_sync.socket.getaddrinfo", _raise_timeout):
+            is_safe_url("http://slow-peer.example.com/")
+
+        assert _socket.getdefaulttimeout() is None
+
 # ---------------------------------------------------------------------------
 # SQL injection — import_delta column validation
 # ---------------------------------------------------------------------------

--- a/tests/scheduling/test_mesh_sync_security.py
+++ b/tests/scheduling/test_mesh_sync_security.py
@@ -1,0 +1,179 @@
+"""Security regression tests for mesh_sync: SSRF + SQL injection (issue #644)."""
+
+from __future__ import annotations
+
+import sqlite3
+from unittest.mock import patch
+
+import pytest
+
+from tinyagentos.scheduling.mesh_sync import MeshSync, is_safe_url
+
+
+# ---------------------------------------------------------------------------
+# SSRF — is_safe_url
+# ---------------------------------------------------------------------------
+
+
+def _mock_getaddrinfo(ip: str):
+    """Return a getaddrinfo stub that resolves any hostname to *ip*."""
+
+    def _stub(host, port, *args, **kwargs):
+        return [(None, None, None, None, (ip, port or 80))]
+
+    return _stub
+
+
+class TestIsSafeUrl:
+    def test_cloud_metadata_rejected_by_default(self):
+        """169.254.169.254 must be rejected when allow_private=False (default)."""
+        with patch("socket.getaddrinfo", _mock_getaddrinfo("169.254.169.254")):
+            assert is_safe_url("http://169.254.169.254/latest/meta-data/") is False
+
+    def test_cloud_metadata_rejected_even_with_allow_private(self):
+        """169.254.169.254 is always blocked, even when allow_private=True."""
+        with patch("socket.getaddrinfo", _mock_getaddrinfo("169.254.169.254")):
+            assert is_safe_url("http://169.254.169.254/", allow_private=True) is False
+
+    def test_loopback_rejected_by_default(self):
+        with patch("socket.getaddrinfo", _mock_getaddrinfo("127.0.0.1")):
+            assert is_safe_url("http://127.0.0.1/", allow_private=False) is False
+
+    def test_loopback_rejected_even_with_allow_private(self):
+        with patch("socket.getaddrinfo", _mock_getaddrinfo("127.0.0.1")):
+            assert is_safe_url("http://127.0.0.1/", allow_private=True) is False
+
+    def test_public_ip_allowed_by_default(self):
+        with patch("socket.getaddrinfo", _mock_getaddrinfo("93.184.216.34")):
+            assert is_safe_url("https://example.com/", allow_private=False) is True
+
+    def test_public_ip_rejected_with_allow_private_false(self):
+        """Public IPs should still pass — they're not private ranges."""
+        with patch("socket.getaddrinfo", _mock_getaddrinfo("8.8.8.8")):
+            assert is_safe_url("https://dns.google/", allow_private=False) is True
+
+    def test_rfc1918_10_rejected_by_default(self):
+        with patch("socket.getaddrinfo", _mock_getaddrinfo("10.0.0.1")):
+            assert is_safe_url("http://10.0.0.1:6969/", allow_private=False) is False
+
+    def test_rfc1918_192168_rejected_by_default(self):
+        with patch("socket.getaddrinfo", _mock_getaddrinfo("192.168.1.100")):
+            assert is_safe_url("http://192.168.1.100/", allow_private=False) is False
+
+    def test_rfc1918_172_rejected_by_default(self):
+        with patch("socket.getaddrinfo", _mock_getaddrinfo("172.16.0.5")):
+            assert is_safe_url("http://172.16.0.5/", allow_private=False) is False
+
+    def test_rfc1918_allowed_with_allow_private(self):
+        """LAN workers on RFC1918 are permitted when allow_private=True."""
+        with patch("socket.getaddrinfo", _mock_getaddrinfo("192.168.6.123")):
+            assert is_safe_url("http://192.168.6.123:6969/", allow_private=True) is True
+
+    def test_empty_url_rejected(self):
+        assert is_safe_url("") is False
+
+    def test_no_hostname_rejected(self):
+        assert is_safe_url("not-a-url") is False
+
+
+# ---------------------------------------------------------------------------
+# SQL injection — import_delta column validation
+# ---------------------------------------------------------------------------
+
+
+def _make_db_with_table(table: str, columns: list[str]) -> sqlite3.Connection:
+    """Create an in-memory SQLite DB with the given table and columns."""
+    col_defs = ", ".join(f"{c} TEXT" for c in columns)
+    db = sqlite3.connect(":memory:")
+    db.execute(f"CREATE TABLE {table} ({col_defs})")
+    db.commit()
+    return db
+
+
+@pytest.mark.asyncio
+async def test_import_delta_rejects_unknown_column():
+    """A peer record with a column not in the local schema must be dropped."""
+    mesh = MeshSync(db_path=":memory:")
+    # table must be in SYNCABLE_TABLES — use kg_triples
+    table = "kg_triples"
+    db = _make_db_with_table(table, ["subject", "predicate", "object", "created_at"])
+
+    malicious_record = {
+        "subject": "foo",
+        "predicate": "bar",
+        "object": "baz",
+        "created_at": "1.0",
+        # attacker-controlled column name attempting injection
+        "injected); DROP TABLE kg_triples; --": "evil",
+    }
+
+    imported = await mesh.import_delta(db, table, [malicious_record])
+
+    assert imported == 0, "Malicious record should be rejected"
+    # Table must still exist and be empty
+    rows = db.execute(f"SELECT * FROM {table}").fetchall()
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_import_delta_accepts_valid_record():
+    """A clean peer record with only known columns should be imported."""
+    mesh = MeshSync(db_path=":memory:")
+    table = "kg_triples"
+    db = _make_db_with_table(table, ["subject", "predicate", "object", "created_at"])
+
+    good_record = {
+        "subject": "alice",
+        "predicate": "knows",
+        "object": "bob",
+        "created_at": "1.0",
+    }
+
+    imported = await mesh.import_delta(db, table, [good_record])
+
+    assert imported == 1
+    rows = db.execute(f"SELECT subject FROM {table}").fetchall()
+    assert rows[0][0] == "alice"
+
+
+@pytest.mark.asyncio
+async def test_import_delta_partial_batch_skips_bad_records():
+    """Good records in a batch are imported; bad records are skipped."""
+    mesh = MeshSync(db_path=":memory:")
+    table = "kg_triples"
+    db = _make_db_with_table(table, ["subject", "predicate", "object", "created_at"])
+
+    records = [
+        {"subject": "a", "predicate": "p", "object": "o", "created_at": "1.0"},
+        {
+            "subject": "a",
+            "predicate": "p",
+            "object": "o",
+            "created_at": "1.0",
+            "EVIL) --": "bad",
+        },
+        {"subject": "b", "predicate": "q", "object": "r", "created_at": "2.0"},
+    ]
+
+    imported = await mesh.import_delta(db, table, records)
+
+    assert imported == 2  # only the two clean records
+
+
+@pytest.mark.asyncio
+async def test_import_delta_unknown_table_returns_zero():
+    """Records for a table not in SYNCABLE_TABLES are silently dropped."""
+    mesh = MeshSync(db_path=":memory:")
+    db = sqlite3.connect(":memory:")
+    imported = await mesh.import_delta(db, "not_a_real_table", [{"col": "val"}])
+    assert imported == 0
+
+
+@pytest.mark.asyncio
+async def test_import_delta_empty_schema_returns_zero():
+    """If the local DB has no schema for the table, import returns 0."""
+    mesh = MeshSync(db_path=":memory:")
+    # DB with no tables at all
+    db = sqlite3.connect(":memory:")
+    imported = await mesh.import_delta(db, "kg_triples", [{"subject": "x"}])
+    assert imported == 0

--- a/tests/scheduling/test_mesh_sync_security.py
+++ b/tests/scheduling/test_mesh_sync_security.py
@@ -24,49 +24,58 @@ def _mock_getaddrinfo(ip: str):
     return _stub
 
 
+def _mock_getaddrinfo_multi(*ips: str):
+    """Return a getaddrinfo stub that resolves a hostname to multiple addresses."""
+
+    def _stub(host, port, *args, **kwargs):
+        return [(None, None, None, None, (ip, port or 80)) for ip in ips]
+
+    return _stub
+
+
 class TestIsSafeUrl:
     def test_cloud_metadata_rejected_by_default(self):
         """169.254.169.254 must be rejected when allow_private=False (default)."""
-        with patch("socket.getaddrinfo", _mock_getaddrinfo("169.254.169.254")):
+        with patch("tinyagentos.scheduling.mesh_sync.socket.getaddrinfo", _mock_getaddrinfo("169.254.169.254")):
             assert is_safe_url("http://169.254.169.254/latest/meta-data/") is False
 
     def test_cloud_metadata_rejected_even_with_allow_private(self):
         """169.254.169.254 is always blocked, even when allow_private=True."""
-        with patch("socket.getaddrinfo", _mock_getaddrinfo("169.254.169.254")):
+        with patch("tinyagentos.scheduling.mesh_sync.socket.getaddrinfo", _mock_getaddrinfo("169.254.169.254")):
             assert is_safe_url("http://169.254.169.254/", allow_private=True) is False
 
     def test_loopback_rejected_by_default(self):
-        with patch("socket.getaddrinfo", _mock_getaddrinfo("127.0.0.1")):
+        with patch("tinyagentos.scheduling.mesh_sync.socket.getaddrinfo", _mock_getaddrinfo("127.0.0.1")):
             assert is_safe_url("http://127.0.0.1/", allow_private=False) is False
 
     def test_loopback_rejected_even_with_allow_private(self):
-        with patch("socket.getaddrinfo", _mock_getaddrinfo("127.0.0.1")):
+        with patch("tinyagentos.scheduling.mesh_sync.socket.getaddrinfo", _mock_getaddrinfo("127.0.0.1")):
             assert is_safe_url("http://127.0.0.1/", allow_private=True) is False
 
     def test_public_ip_allowed_by_default(self):
-        with patch("socket.getaddrinfo", _mock_getaddrinfo("93.184.216.34")):
+        with patch("tinyagentos.scheduling.mesh_sync.socket.getaddrinfo", _mock_getaddrinfo("93.184.216.34")):
             assert is_safe_url("https://example.com/", allow_private=False) is True
 
     def test_public_ip_rejected_with_allow_private_false(self):
         """Public IPs should still pass — they're not private ranges."""
-        with patch("socket.getaddrinfo", _mock_getaddrinfo("8.8.8.8")):
+        with patch("tinyagentos.scheduling.mesh_sync.socket.getaddrinfo", _mock_getaddrinfo("8.8.8.8")):
             assert is_safe_url("https://dns.google/", allow_private=False) is True
 
     def test_rfc1918_10_rejected_by_default(self):
-        with patch("socket.getaddrinfo", _mock_getaddrinfo("10.0.0.1")):
+        with patch("tinyagentos.scheduling.mesh_sync.socket.getaddrinfo", _mock_getaddrinfo("10.0.0.1")):
             assert is_safe_url("http://10.0.0.1:6969/", allow_private=False) is False
 
     def test_rfc1918_192168_rejected_by_default(self):
-        with patch("socket.getaddrinfo", _mock_getaddrinfo("192.168.1.100")):
+        with patch("tinyagentos.scheduling.mesh_sync.socket.getaddrinfo", _mock_getaddrinfo("192.168.1.100")):
             assert is_safe_url("http://192.168.1.100/", allow_private=False) is False
 
     def test_rfc1918_172_rejected_by_default(self):
-        with patch("socket.getaddrinfo", _mock_getaddrinfo("172.16.0.5")):
+        with patch("tinyagentos.scheduling.mesh_sync.socket.getaddrinfo", _mock_getaddrinfo("172.16.0.5")):
             assert is_safe_url("http://172.16.0.5/", allow_private=False) is False
 
     def test_rfc1918_allowed_with_allow_private(self):
         """LAN workers on RFC1918 are permitted when allow_private=True."""
-        with patch("socket.getaddrinfo", _mock_getaddrinfo("192.168.6.123")):
+        with patch("tinyagentos.scheduling.mesh_sync.socket.getaddrinfo", _mock_getaddrinfo("192.168.6.123")):
             assert is_safe_url("http://192.168.6.123:6969/", allow_private=True) is True
 
     def test_empty_url_rejected(self):
@@ -74,6 +83,52 @@ class TestIsSafeUrl:
 
     def test_no_hostname_rejected(self):
         assert is_safe_url("not-a-url") is False
+
+
+    def test_ipv4_mapped_ipv6_metadata_rejected(self):
+        """::ffff:169.254.169.254 must be rejected — IPv4-mapped IPv6 bypass."""
+        with patch("tinyagentos.scheduling.mesh_sync.socket.getaddrinfo", _mock_getaddrinfo("::ffff:169.254.169.254")):
+            assert is_safe_url("http://metadata.internal/", allow_private=False) is False
+
+    def test_ipv4_mapped_ipv6_metadata_rejected_allow_private(self):
+        """::ffff:169.254.169.254 is always blocked regardless of allow_private."""
+        with patch("tinyagentos.scheduling.mesh_sync.socket.getaddrinfo", _mock_getaddrinfo("::ffff:169.254.169.254")):
+            assert is_safe_url("http://metadata.internal/", allow_private=True) is False
+
+    def test_ipv4_mapped_ipv6_loopback_rejected(self):
+        """::ffff:127.0.0.1 must be rejected."""
+        with patch("tinyagentos.scheduling.mesh_sync.socket.getaddrinfo", _mock_getaddrinfo("::ffff:127.0.0.1")):
+            assert is_safe_url("http://internal.example.com/", allow_private=False) is False
+
+    def test_plain_ipv6_loopback_rejected(self):
+        """Pure IPv6 loopback ::1 must be rejected."""
+        with patch("tinyagentos.scheduling.mesh_sync.socket.getaddrinfo", _mock_getaddrinfo("::1")):
+            assert is_safe_url("http://[::1]/", allow_private=False) is False
+
+    def test_plain_ipv6_link_local_rejected(self):
+        """IPv6 link-local fe80:: must be rejected."""
+        with patch("tinyagentos.scheduling.mesh_sync.socket.getaddrinfo", _mock_getaddrinfo("fe80::1")):
+            assert is_safe_url("http://[fe80::1]/", allow_private=False) is False
+
+    def test_multi_address_any_blocked_rejects_all(self):
+        """A hostname resolving to [public, 169.254.x] must be rejected entirely."""
+        with patch("tinyagentos.scheduling.mesh_sync.socket.getaddrinfo", _mock_getaddrinfo_multi("93.184.216.34", "169.254.169.254")):
+            assert is_safe_url("http://evil-rebind.example.com/", allow_private=False) is False
+
+    def test_multi_address_any_rfc1918_rejects_when_private_not_allowed(self):
+        """[public, 10.x] is rejected when allow_private=False."""
+        with patch("tinyagentos.scheduling.mesh_sync.socket.getaddrinfo", _mock_getaddrinfo_multi("93.184.216.34", "10.0.0.1")):
+            assert is_safe_url("http://dual.example.com/", allow_private=False) is False
+
+    def test_multi_address_all_public_passes(self):
+        """A hostname resolving to multiple public IPs is allowed."""
+        with patch("tinyagentos.scheduling.mesh_sync.socket.getaddrinfo", _mock_getaddrinfo_multi("93.184.216.34", "2606:2800:220:1:248:1893:25c8:1946")):
+            assert is_safe_url("http://dual-stack.example.com/", allow_private=False) is True
+
+    def test_multi_address_rfc1918_passes_with_allow_private(self):
+        """[public, 192.168.x] is allowed when allow_private=True (LAN worker)."""
+        with patch("tinyagentos.scheduling.mesh_sync.socket.getaddrinfo", _mock_getaddrinfo_multi("93.184.216.34", "192.168.6.123")):
+            assert is_safe_url("http://lan-worker.local/", allow_private=True) is True
 
 
 # ---------------------------------------------------------------------------

--- a/tinyagentos/scheduling/mesh_sync.py
+++ b/tinyagentos/scheduling/mesh_sync.py
@@ -93,6 +93,12 @@ def _effective_ip(addr: str) -> "ipaddress.IPv4Address | ipaddress.IPv6Address":
     return ip
 
 
+# Maximum seconds allowed for a single DNS resolution.  A malicious or
+# misconfigured peer hostname must not be able to block the calling thread
+# indefinitely.
+_DNS_TIMEOUT_SECONDS = 5
+
+
 def is_safe_url(url: str, allow_private: bool = False) -> bool:
     """Check if a URL is safe (not targeting private/internal networks).
 
@@ -104,6 +110,9 @@ def is_safe_url(url: str, allow_private: bool = False) -> bool:
     multi-address hostnames and DNS-rebinding cannot present a safe address
     first and an unsafe one later.  IPv4-mapped IPv6 addresses
     (``::ffff:<ipv4>``) are normalised to their IPv4 form before range checks.
+
+    DNS resolution is bounded by ``_DNS_TIMEOUT_SECONDS`` to prevent an
+    attacker-controlled hostname from hanging the calling thread.
     """
     try:
         parsed = urlparse(url)
@@ -111,7 +120,15 @@ def is_safe_url(url: str, allow_private: bool = False) -> bool:
         if not hostname:
             return False
 
-        results = socket.getaddrinfo(hostname, parsed.port or 80)
+        # Scope the timeout to this resolution only; restore the previous
+        # value (None = no timeout) so other socket operations are unaffected.
+        _prev = socket.getdefaulttimeout()
+        socket.setdefaulttimeout(_DNS_TIMEOUT_SECONDS)
+        try:
+            results = socket.getaddrinfo(hostname, parsed.port or 80)
+        finally:
+            socket.setdefaulttimeout(_prev)
+
         if not results:
             return False
 
@@ -213,7 +230,16 @@ class MeshSync:
     # ------------------------------------------------------------------
 
     def _get_table_columns(self, db: sqlite3.Connection, table: str) -> frozenset[str]:
-        """Return the set of column names in *table* from the local DB schema."""
+        """Return the set of column names in *table* from the local DB schema.
+
+        ``table`` must already be validated against SYNCABLE_TABLES by the
+        caller (import_delta does this).  The PRAGMA identifier is never
+        peer-supplied — it comes from our own allowlist.
+        """
+        # Defense-in-depth: assert the table is in our allowlist even though
+        # import_delta already checks.  This keeps _get_table_columns safe if
+        # ever called from a new code path.
+        assert table in SYNCABLE_TABLES, f"_get_table_columns called with unlisted table: {table!r}"
         rows = db.execute(f"PRAGMA table_info({table})").fetchall()
         return frozenset(r[1] for r in rows)
 
@@ -268,6 +294,8 @@ class MeshSync:
                 )
                 imported += 1
             except Exception as e:
+                # Logged at warning so constraint violations / type mismatches
+                # are visible; record is skipped but the batch continues.
                 logger.warning("Import failed for %s record: %s", table, e)
 
         if imported:

--- a/tinyagentos/scheduling/mesh_sync.py
+++ b/tinyagentos/scheduling/mesh_sync.py
@@ -59,39 +59,50 @@ SYNCABLE_TABLES = {
     "insights": "created_at",
 }
 
-# SSRF protection — block private/reserved IP ranges
+# SSRF protection — networks always blocked (cloud metadata, loopback, ULA, link-local)
 BLOCKED_NETWORKS = [
-    ipaddress.ip_network("10.0.0.0/8"),
-    ipaddress.ip_network("172.16.0.0/12"),
-    ipaddress.ip_network("192.168.0.0/16"),
     ipaddress.ip_network("127.0.0.0/8"),
-    ipaddress.ip_network("169.254.0.0/16"),
+    ipaddress.ip_network("169.254.0.0/16"),  # cloud metadata (AWS/GCP/Azure IMDSv1)
     ipaddress.ip_network("::1/128"),
     ipaddress.ip_network("fc00::/7"),
     ipaddress.ip_network("fe80::/10"),
+]
+
+# RFC1918 ranges permitted only when the caller explicitly opts in for LAN peers
+LAN_NETWORKS = [
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
 ]
 
 
 def is_safe_url(url: str, allow_private: bool = False) -> bool:
     """Check if a URL is safe (not targeting private/internal networks).
 
-    In taOS worker mesh, allow_private=True since workers are on the LAN.
-    For external sync, allow_private=False blocks SSRF.
+    By default (allow_private=False) all private ranges are blocked.
+    Pass allow_private=True only for known LAN peer connections; even then
+    cloud-metadata / loopback / link-local addresses are always rejected.
     """
-    if allow_private:
-        return True
     try:
         parsed = urlparse(url)
         hostname = parsed.hostname
         if not hostname:
             return False
-        # Resolve hostname to IP
         import socket
         addr = socket.getaddrinfo(hostname, parsed.port or 80)[0][4][0]
         ip = ipaddress.ip_address(addr)
+
+        # Always-blocked ranges (cloud metadata, loopback, link-local, ULA)
         for network in BLOCKED_NETWORKS:
             if ip in network:
                 return False
+
+        # RFC1918 ranges: only allowed when caller explicitly opts in for LAN
+        if not allow_private:
+            for network in LAN_NETWORKS:
+                if ip in network:
+                    return False
+
         return True
     except Exception:
         return False
@@ -175,6 +186,11 @@ class MeshSync:
     # Delta import (worker ← controller)
     # ------------------------------------------------------------------
 
+    def _get_table_columns(self, db: sqlite3.Connection, table: str) -> frozenset[str]:
+        """Return the set of column names in *table* from the local DB schema."""
+        rows = db.execute(f"PRAGMA table_info({table})").fetchall()
+        return frozenset(r[1] for r in rows)
+
     async def import_delta(
         self,
         target_db: sqlite3.Connection,
@@ -185,27 +201,47 @@ class MeshSync:
 
         Last-write-wins: if a record with the same primary key exists,
         the one with the newer timestamp wins.
+
+        Column names from peer records are validated against the local table
+        schema (via PRAGMA table_info) before any SQL is constructed.
+        Peer-supplied identifiers are never interpolated into SQL.
         """
         if not records or table not in SYNCABLE_TABLES:
             return 0
 
-        ts_col = SYNCABLE_TABLES[table]
+        # Build an allowlist of known columns from our own local schema.
+        # Any peer record containing an unknown column is skipped entirely.
+        known_columns = self._get_table_columns(target_db, table)
+        if not known_columns:
+            logger.warning("No schema found for table %s — skipping import", table)
+            return 0
+
         imported = 0
 
         for record in records:
-            columns = list(record.keys())
-            placeholders = ", ".join(["?"] * len(columns))
-            col_names = ", ".join(columns)
+            peer_cols = list(record.keys())
 
-            # LWW: INSERT OR REPLACE (the newer record wins by timestamp)
+            # Reject the record if any column is not in our local schema.
+            if not all(col in known_columns for col in peer_cols):
+                unknown = [c for c in peer_cols if c not in known_columns]
+                logger.warning(
+                    "Rejected peer record for %s: unknown columns %s", table, unknown
+                )
+                continue
+
+            # Use only the validated column names (from peer_cols, now confirmed
+            # against known_columns). Table name comes from SYNCABLE_TABLES, not
+            # peer data. VALUES are parameterized — no identifier interpolation.
+            placeholders = ", ".join(["?"] * len(peer_cols))
+            col_names = ", ".join(peer_cols)  # safe: every entry verified above
+
             try:
                 target_db.execute(
-                    f"INSERT OR REPLACE INTO {col_names} VALUES ({placeholders})",
-                    tuple(record[c] for c in columns),
+                    f"INSERT OR REPLACE INTO {table} ({col_names}) VALUES ({placeholders})",
+                    tuple(record[c] for c in peer_cols),
                 )
                 imported += 1
             except Exception as e:
-                # If schema mismatch, try column-by-column
                 logger.debug("Import failed for %s record: %s", table, e)
 
         if imported:

--- a/tinyagentos/scheduling/mesh_sync.py
+++ b/tinyagentos/scheduling/mesh_sync.py
@@ -19,6 +19,7 @@ import hashlib
 import ipaddress
 import json
 import logging
+import socket
 import sqlite3
 import time
 from pathlib import Path
@@ -76,32 +77,57 @@ LAN_NETWORKS = [
 ]
 
 
+def _effective_ip(addr: str) -> "ipaddress.IPv4Address | ipaddress.IPv6Address":
+    """Normalize a raw address string for SSRF range checks.
+
+    IPv4-mapped IPv6 addresses (e.g. ``::ffff:169.254.169.254``) are
+    unwrapped to their IPv4 form so that checks against IPv4 BLOCKED_NETWORKS
+    work correctly.
+    """
+    ip = ipaddress.ip_address(addr)
+    # ipv4_mapped is only present on IPv6Address; IPv4Address has no such attr
+    if isinstance(ip, ipaddress.IPv6Address):
+        mapped = ip.ipv4_mapped  # non-None only for ::ffff:x.x.x.x
+        if mapped is not None:
+            return mapped
+    return ip
+
+
 def is_safe_url(url: str, allow_private: bool = False) -> bool:
     """Check if a URL is safe (not targeting private/internal networks).
 
     By default (allow_private=False) all private ranges are blocked.
     Pass allow_private=True only for known LAN peer connections; even then
     cloud-metadata / loopback / link-local addresses are always rejected.
+
+    All resolved addresses are checked — not just the first — so that
+    multi-address hostnames and DNS-rebinding cannot present a safe address
+    first and an unsafe one later.  IPv4-mapped IPv6 addresses
+    (``::ffff:<ipv4>``) are normalised to their IPv4 form before range checks.
     """
     try:
         parsed = urlparse(url)
         hostname = parsed.hostname
         if not hostname:
             return False
-        import socket
-        addr = socket.getaddrinfo(hostname, parsed.port or 80)[0][4][0]
-        ip = ipaddress.ip_address(addr)
 
-        # Always-blocked ranges (cloud metadata, loopback, link-local, ULA)
-        for network in BLOCKED_NETWORKS:
-            if ip in network:
-                return False
+        results = socket.getaddrinfo(hostname, parsed.port or 80)
+        if not results:
+            return False
 
-        # RFC1918 ranges: only allowed when caller explicitly opts in for LAN
-        if not allow_private:
-            for network in LAN_NETWORKS:
+        for res in results:
+            ip = _effective_ip(res[4][0])
+
+            # Always-blocked ranges (cloud metadata, loopback, link-local, ULA)
+            for network in BLOCKED_NETWORKS:
                 if ip in network:
                     return False
+
+            # RFC1918 ranges: only allowed when caller explicitly opts in for LAN
+            if not allow_private:
+                for network in LAN_NETWORKS:
+                    if ip in network:
+                        return False
 
         return True
     except Exception:
@@ -242,7 +268,7 @@ class MeshSync:
                 )
                 imported += 1
             except Exception as e:
-                logger.debug("Import failed for %s record: %s", table, e)
+                logger.warning("Import failed for %s record: %s", table, e)
 
         if imported:
             target_db.commit()


### PR DESCRIPTION
## What

Two security vulnerabilities in `tinyagentos/scheduling/mesh_sync.py`.

### 1. SSRF bypass (line 81)

`is_safe_url` returned `True` unconditionally when `allow_private=True`, accepting any URL including `http://169.254.169.254/` (cloud metadata). The default signature was `allow_private=False` but all LAN callers passed `True`, making the check a no-op.

**Fix:** Split the blocked list into two tiers:
- `BLOCKED_NETWORKS` — always rejected: loopback (`127/8`), cloud metadata (`169.254/16`), loopback IPv6, ULA (`fc00::/7`), link-local IPv6.
- `LAN_NETWORKS` — RFC1918 ranges (`10/8`, `172.16/12`, `192.168/16`), only allowed when the caller explicitly passes `allow_private=True` for known LAN peers.

Cloud metadata and loopback are now rejected even when `allow_private=True`.

### 2. SQL injection via peer-supplied column names (line 203)

`import_delta` interpolated `record.keys()` from untrusted peer data directly into an INSERT statement. A malicious peer could craft column names like `); DROP TABLE kg_triples; --`.

**Fix:** Fetch the local table schema with `PRAGMA table_info` and build an allowlist of known columns. Any peer record containing a column not in that allowlist is rejected entirely and logged as a warning. Table name is sourced only from the `SYNCABLE_TABLES` constant. All VALUES remain parameterized (`?` placeholders).

## Tests

`tests/scheduling/test_mesh_sync_security.py` — 17 new tests:
- `is_safe_url` rejects `169.254.169.254` with both `allow_private=False` and `allow_private=True`
- `is_safe_url` rejects loopback always; rejects RFC1918 by default; allows RFC1918 only when `allow_private=True`
- `import_delta` drops records with injected column names, imports clean records, handles mixed batches, and returns 0 for unknown tables or empty schemas

closes #644

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced SSRF protection to always block loopback and cloud metadata addresses; RFC1918 private networks are now conditionally blocked based on configuration.
  * Improved SQL injection defense by validating record columns against local schema before import; records with unknown columns are skipped.

* **Tests**
  * Added security regression tests for mesh_sync SSRF and SQL injection protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->