### PR TITLE
fix(security): auth hardening — argon2, brute-force limits, invite entropy, session TTL (#646, closes #649)

### DIFF
--- a/tests/routes/desktop_browser/test_agent_pin_routes.py
+++ b/tests/routes/desktop_browser/test_agent_pin_routes.py
@@ -19,7 +19,7 @@ def _make_auth_client(app, tmp_data_dir):
     # Invite a second user
     if auth_mgr.find_user("user_b") is None:
         invite_code = auth_mgr.add_user_invite("user_b", "admin")
-        auth_mgr.complete_invite("user_b", invite_code, "user_b", "", "pass_b")
+        auth_mgr.complete_invite("user_b", invite_code, "user_b", "", "pass_b_ok")
     record = auth_mgr.find_user("user_b")
     token = auth_mgr.create_session(user_id=record["id"], long_lived=True)
     return AsyncClient(

--- a/tests/routes/desktop_browser/test_bookmark_routes.py
+++ b/tests/routes/desktop_browser/test_bookmark_routes.py
@@ -17,7 +17,7 @@ def _make_auth_client(app, tmp_data_dir):
     auth_mgr = app.state.auth
     if auth_mgr.find_user("user_b") is None:
         invite_code = auth_mgr.add_user_invite("user_b", "admin")
-        auth_mgr.complete_invite("user_b", invite_code, "user_b", "", "pass_b")
+        auth_mgr.complete_invite("user_b", invite_code, "user_b", "", "pass_b_ok")
     record = auth_mgr.find_user("user_b")
     token = auth_mgr.create_session(user_id=record["id"], long_lived=True)
     return AsyncClient(

--- a/tests/routes/desktop_browser/test_capability_routes.py
+++ b/tests/routes/desktop_browser/test_capability_routes.py
@@ -18,7 +18,7 @@ def _make_auth_client(app, tmp_data_dir):
     auth_mgr = app.state.auth
     if auth_mgr.find_user("user_b") is None:
         invite_code = auth_mgr.add_user_invite("user_b", "admin")
-        auth_mgr.complete_invite("user_b", invite_code, "user_b", "", "pass_b")
+        auth_mgr.complete_invite("user_b", invite_code, "user_b", "", "pass_b_ok")
     record = auth_mgr.find_user("user_b")
     token = auth_mgr.create_session(user_id=record["id"], long_lived=True)
     return AsyncClient(

--- a/tests/routes/desktop_browser/test_copilot_ws.py
+++ b/tests/routes/desktop_browser/test_copilot_ws.py
@@ -172,7 +172,7 @@ class TestMintTicketEndpoint:
         auth_mgr = app.state.auth
         if auth_mgr.find_user("user_b") is None:
             invite_code = auth_mgr.add_user_invite("user_b", "admin")
-            auth_mgr.complete_invite("user_b", invite_code, "user_b", "", "pass_b")
+            auth_mgr.complete_invite("user_b", invite_code, "user_b", "", "pass_b_ok")
         record = auth_mgr.find_user("user_b")
         token_b = auth_mgr.create_session(user_id=record["id"], long_lived=True)
 

--- a/tests/routes/desktop_browser/test_push_mutes.py
+++ b/tests/routes/desktop_browser/test_push_mutes.py
@@ -30,7 +30,7 @@ def _make_user_b_client(app):
     auth_mgr = app.state.auth
     if auth_mgr.find_user("user_b") is None:
         invite_code = auth_mgr.add_user_invite("user_b", "admin")
-        auth_mgr.complete_invite("user_b", invite_code, "user_b", "", "pass_b")
+        auth_mgr.complete_invite("user_b", invite_code, "user_b", "", "pass_b_ok")
     record = auth_mgr.find_user("user_b")
     token = auth_mgr.create_session(user_id=record["id"], long_lived=True)
     return AsyncClient(

--- a/tests/routes/desktop_browser/test_push_routes.py
+++ b/tests/routes/desktop_browser/test_push_routes.py
@@ -25,7 +25,7 @@ def _make_auth_client(app, tmp_data_dir):
     auth_mgr = app.state.auth
     if auth_mgr.find_user("user_b") is None:
         invite_code = auth_mgr.add_user_invite("user_b", "admin")
-        auth_mgr.complete_invite("user_b", invite_code, "user_b", "", "pass_b")
+        auth_mgr.complete_invite("user_b", invite_code, "user_b", "", "pass_b_ok")
     record = auth_mgr.find_user("user_b")
     token = auth_mgr.create_session(user_id=record["id"], long_lived=True)
     return AsyncClient(

--- a/tests/routes/desktop_browser/test_site_permission_routes.py
+++ b/tests/routes/desktop_browser/test_site_permission_routes.py
@@ -18,7 +18,7 @@ def _make_auth_client(app, tmp_data_dir):
     auth_mgr = app.state.auth
     if auth_mgr.find_user("user_b") is None:
         invite_code = auth_mgr.add_user_invite("user_b", "admin")
-        auth_mgr.complete_invite("user_b", invite_code, "user_b", "", "pass_b")
+        auth_mgr.complete_invite("user_b", invite_code, "user_b", "", "pass_b_ok")
     record = auth_mgr.find_user("user_b")
     token = auth_mgr.create_session(user_id=record["id"], long_lived=True)
     return AsyncClient(

--- a/tests/shortcuts/test_auth_capabilities.py
+++ b/tests/shortcuts/test_auth_capabilities.py
@@ -32,7 +32,7 @@ def test_new_user_has_only_chat_capability(tmp_path):
     mgr = AuthManager(tmp_path)
     mgr.setup_user("admin", "Admin", "", "adminpass")
     code = mgr.add_user_invite("testcap_user", "admin")
-    user = mgr.complete_invite("testcap_user", code, "Test Cap", "", "hunter2")
+    user = mgr.complete_invite("testcap_user", code, "Test Cap", "", "hunter2x")
     caps = set(user.get("capabilities", []))
     assert caps == {"chat"}
 
@@ -42,7 +42,7 @@ def test_capabilities_persisted_on_user_record(tmp_path):
     mgr = AuthManager(tmp_path)
     mgr.setup_user("admin", "Admin", "", "adminpass")
     code = mgr.add_user_invite("testcap_persist", "admin")
-    user = mgr.complete_invite("testcap_persist", code, "Test Persist", "", "hunter2")
+    user = mgr.complete_invite("testcap_persist", code, "Test Persist", "", "hunter2x")
     fetched = mgr.get_user_by_id(user["id"])
     assert "capabilities" in fetched
     assert set(fetched["capabilities"]) == {"chat"}

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -855,3 +855,95 @@ class TestLoginRateLimit:
         )
         _login_limiter.reset(self._TEST_IP)
         assert resp.status_code == 401  # not 429
+
+
+class TestFailCounterBounds:
+    """Rate-limiter _FailCounter is bounded: expired entries prune, size caps."""
+
+    def test_expired_entries_are_pruned(self):
+        from tinyagentos.routes.auth import _FailCounter
+        fc = _FailCounter(max_attempts=5, window_seconds=1)
+        fc.record_failure("1.2.3.4")
+        assert "1.2.3.4" in fc._log
+        # Backdate the timestamp so it looks expired
+        fc._log["1.2.3.4"] = [0.0]
+        # Accessing via is_limited triggers _prune, which drops the stale entry
+        assert fc.is_limited("1.2.3.4") is False
+        assert "1.2.3.4" not in fc._log
+
+    def test_size_cap_evicts_oldest(self):
+        from tinyagentos.routes.auth import _FailCounter, _FAIL_COUNTER_MAX_KEYS
+        fc = _FailCounter(max_attempts=5, window_seconds=600)
+        # Fill to capacity
+        for i in range(_FAIL_COUNTER_MAX_KEYS):
+            fc.record_failure(f"10.0.{i // 256}.{i % 256}")
+        assert len(fc._log) == _FAIL_COUNTER_MAX_KEYS
+        # One more entry must not grow beyond the cap
+        fc.record_failure("99.99.99.99")
+        assert len(fc._log) == _FAIL_COUNTER_MAX_KEYS
+
+    def test_active_entries_survive_pruning(self):
+        from tinyagentos.routes.auth import _FailCounter
+        fc = _FailCounter(max_attempts=5, window_seconds=600)
+        for _ in range(3):
+            fc.record_failure("5.5.5.5")
+        # Entry should still be present and not counted as expired
+        assert fc.is_limited("5.5.5.5") is False
+        assert "5.5.5.5" in fc._log
+
+    def test_reset_removes_entry(self):
+        from tinyagentos.routes.auth import _FailCounter
+        fc = _FailCounter(max_attempts=5, window_seconds=600)
+        fc.record_failure("6.6.6.6")
+        fc.reset("6.6.6.6")
+        assert "6.6.6.6" not in fc._log
+
+
+class TestConcurrentHashUpgrade:
+    """Hash-upgrade write is protected by a lock — concurrent logins don't lose writes."""
+
+    def test_concurrent_upgrade_does_not_lose_write(self, tmp_path):
+        """Two threads racing on a legacy-hash login must both succeed and
+        the final stored hash must be valid argon2 (not clobbered back to SHA-256)."""
+        import threading
+        from tinyagentos.auth import AuthManager, _hash_password_sha256
+
+        mgr = AuthManager(tmp_path)
+        # Seed a user with an old SHA-256 hash directly (bypassing set_password)
+        import json, time as _time
+        legacy_hash = _hash_password_sha256("legacypass", "mysalt")
+        user_data = {
+            "users": [{
+                "id": "u1",
+                "username": "legacyuser",
+                "full_name": "Legacy",
+                "email": "",
+                "password_hash": legacy_hash,
+                "created_at": _time.time(),
+                "last_login_at": None,
+                "is_admin": True,
+            }],
+            "current_user_id": "u1",
+        }
+        mgr._user_file.parent.mkdir(parents=True, exist_ok=True)
+        mgr._user_file.write_text(json.dumps(user_data))
+
+        results = []
+
+        def login():
+            ok, _ = mgr.check_password("legacypass", username="legacyuser")
+            results.append(ok)
+
+        threads = [threading.Thread(target=login) for _ in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # All logins must succeed
+        assert all(results), f"Some logins failed: {results}"
+
+        # The stored hash must now be argon2 (not corrupted back to SHA-256)
+        stored = json.loads(mgr._user_file.read_text())
+        final_hash = stored["users"][0]["password_hash"]
+        assert final_hash.startswith("$argon2"), f"Hash was not upgraded: {final_hash[:40]}"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -729,12 +729,12 @@ class TestSessionUserNoFallback:
 
     def test_session_user_bad_token_is_none(self, tmp_path):
         mgr = AuthManager(tmp_path)
-        mgr.setup_user("alice", "Alice", "", "pw")
+        mgr.setup_user("alice", "Alice", "", "alicepwd1")
         assert mgr.session_user("not-a-real-token") is None
 
     def test_session_user_empty_token_is_none(self, tmp_path):
         mgr = AuthManager(tmp_path)
-        mgr.setup_user("alice", "Alice", "", "pw")
+        mgr.setup_user("alice", "Alice", "", "alicepwd1")
         assert mgr.session_user("") is None
 
     def test_get_user_bad_token_falls_back_to_first_user(self, tmp_path):
@@ -742,12 +742,12 @@ class TestSessionUserNoFallback:
         # but invalid token returns the first user, which is wrong for
         # identity/ownership decisions.
         mgr = AuthManager(tmp_path)
-        mgr.setup_user("alice", "Alice", "", "pw")
+        mgr.setup_user("alice", "Alice", "", "alicepwd1")
         assert mgr.get_user(token="not-a-real-token") is not None
 
     def test_session_user_valid_token_returns_owner(self, tmp_path):
         mgr = AuthManager(tmp_path)
-        mgr.setup_user("alice", "Alice", "", "pw")
+        mgr.setup_user("alice", "Alice", "", "alicepwd1")
         rec = mgr.find_user("alice")
         token = mgr.create_session(user_id=rec["id"])
         u = mgr.session_user(token)
@@ -775,6 +775,17 @@ class TestPasswordPolicy:
         mgr.setup_user("alice", "Alice", "", "alicepass")
         result = mgr.change_password("alice", "alicepass", "short")
         assert result is False
+
+    def test_setup_user_rejects_short_password(self, tmp_path):
+        mgr = AuthManager(tmp_path)
+        import pytest
+        with pytest.raises(ValueError, match="8"):
+            mgr.setup_user("admin", "Admin", "", "short")
+
+    def test_setup_user_accepts_8_char_password(self, tmp_path):
+        mgr = AuthManager(tmp_path)
+        user = mgr.setup_user("admin", "Admin", "", "exactly8")
+        assert user["username"] == "admin"
 
     def test_session_ttl_is_30_days(self, tmp_path):
         mgr = AuthManager(tmp_path)
@@ -818,12 +829,13 @@ class TestLoginRateLimit:
         from tinyagentos.routes.auth import _login_limiter
         _login_limiter.reset(self._TEST_IP)
         app.state.auth.setup_user("admin", "Admin", "", "adminpass")
-        # 5 failures using JSON path
-        for _ in range(5):
-            await auth_client.post(
+        # First 5 failures should each return 401 (not yet limited)
+        for i in range(5):
+            r = await auth_client.post(
                 "/auth/login",
                 json={"username": "admin", "password": "wrongpass"},
             )
+            assert r.status_code == 401, f"attempt {i+1} expected 401, got {r.status_code}"
         # 6th attempt should be 429
         resp = await auth_client.post(
             "/auth/login",
@@ -855,6 +867,28 @@ class TestLoginRateLimit:
         )
         _login_limiter.reset(self._TEST_IP)
         assert resp.status_code == 401  # not 429
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_form_login_redirects_not_json(self, app, auth_client):
+        """Form-submitted logins that hit the rate limit must get an HTML redirect,
+        not a raw JSON response (the no-JS form has no way to render JSON)."""
+        from tinyagentos.routes.auth import _login_limiter
+        _login_limiter.reset(self._TEST_IP)
+        app.state.auth.setup_user("admin", "Admin", "", "adminpass")
+        # Exhaust the limit via form posts
+        for _ in range(5):
+            await auth_client.post(
+                "/auth/login",
+                data={"username": "admin", "password": "wrongpass"},
+            )
+        # 6th form post should redirect (303), not return JSON 429
+        resp = await auth_client.post(
+            "/auth/login",
+            data={"username": "admin", "password": "wrongpass"},
+        )
+        _login_limiter.reset(self._TEST_IP)
+        assert resp.status_code == 303
+        assert "/auth/login" in resp.headers.get("location", "")
 
 
 class TestFailCounterBounds:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -7,35 +7,65 @@ import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
-from tinyagentos.auth import AuthManager, hash_password, verify_password
+from tinyagentos.auth import (
+    AuthManager,
+    hash_password,
+    verify_password,
+    verify_and_maybe_rehash,
+    _hash_password_sha256,
+)
 
 
 # --- Unit tests for password hashing ---
 
 class TestPasswordHashing:
-    def test_hash_produces_salt_and_hash(self):
+    def test_hash_produces_argon2_hash(self):
         result = hash_password("secret")
-        parts = result.split(":")
-        assert len(parts) == 2
-        assert len(parts[0]) == 32  # 16 bytes hex
-        assert len(parts[1]) == 64  # sha256 hex
+        assert result.startswith("$argon2")
 
-    def test_hash_with_explicit_salt(self):
+    def test_hash_with_salt_param_ignored(self):
+        # salt param is accepted for backward-compat but ignored; result is still argon2
         result = hash_password("secret", "abcd1234")
-        assert result.startswith("abcd1234:")
+        assert result.startswith("$argon2")
 
     def test_verify_correct_password(self):
-        stored = hash_password("mypass")
-        assert verify_password("mypass", stored) is True
+        stored = hash_password("mypassword")
+        assert verify_password("mypassword", stored) is True
 
     def test_verify_wrong_password(self):
-        stored = hash_password("mypass")
+        stored = hash_password("mypassword")
         assert verify_password("wrong", stored) is False
 
     def test_different_passwords_different_hashes(self):
-        h1 = hash_password("alpha", "same_salt")
-        h2 = hash_password("beta", "same_salt")
+        h1 = hash_password("alpha")
+        h2 = hash_password("beta")
         assert h1 != h2
+
+    def test_verify_legacy_sha256_hash(self):
+        """Legacy SHA-256 hashes are still verified correctly."""
+        legacy = _hash_password_sha256("mypassword", "somesalt")
+        assert verify_password("mypassword", legacy) is True
+        assert verify_password("wrong", legacy) is False
+
+    def test_verify_and_maybe_rehash_upgrades_sha256(self):
+        """verify_and_maybe_rehash returns a new argon2 hash for old SHA-256 stored values."""
+        legacy = _hash_password_sha256("mypassword", "somesalt")
+        ok, new_hash = verify_and_maybe_rehash("mypassword", legacy)
+        assert ok is True
+        assert new_hash is not None
+        assert new_hash.startswith("$argon2")
+
+    def test_verify_and_maybe_rehash_no_upgrade_for_argon2(self):
+        stored = hash_password("mypassword")
+        ok, new_hash = verify_and_maybe_rehash("mypassword", stored)
+        assert ok is True
+        assert new_hash is None  # already argon2, no upgrade needed
+
+    def test_verify_and_maybe_rehash_wrong_password(self):
+        stored = hash_password("mypassword")
+        ok, new_hash = verify_and_maybe_rehash("wrong", stored)
+        assert ok is False
+        assert new_hash is None
 
 
 # --- Unit tests for AuthManager ---
@@ -161,7 +191,7 @@ class TestAuthRoutes:
 
     @pytest.mark.asyncio
     async def test_login_wrong_password(self, app, auth_client):
-        app.state.auth.set_password("correct")
+        app.state.auth.set_password("correctpass")
         resp = await auth_client.post(
             "/auth/login",
             data={"password": "wrong"},
@@ -172,10 +202,10 @@ class TestAuthRoutes:
 
     @pytest.mark.asyncio
     async def test_login_correct_password(self, app, auth_client):
-        app.state.auth.set_password("correct")
+        app.state.auth.set_password("correctpass")
         resp = await auth_client.post(
             "/auth/login",
-            data={"password": "correct"},
+            data={"password": "correctpass"},
             follow_redirects=False,
         )
         assert resp.status_code == 303
@@ -184,11 +214,11 @@ class TestAuthRoutes:
 
     @pytest.mark.asyncio
     async def test_logout_clears_session(self, app, auth_client):
-        app.state.auth.set_password("pass")
+        app.state.auth.set_password("passw0rd")
         # Login first
         resp = await auth_client.post(
             "/auth/login",
-            data={"password": "pass"},
+            data={"password": "passw0rd"},
             follow_redirects=False,
         )
         cookies = resp.cookies
@@ -202,12 +232,12 @@ class TestAuthRoutes:
         assert app.state.auth.is_configured() is False
         resp = await auth_client.post(
             "/auth/setup",
-            data={"username": "admin", "full_name": "Admin", "email": "", "password": "newpass"},
+            data={"username": "admin", "full_name": "Admin", "email": "", "password": "newpassword"},
             follow_redirects=False,
         )
         assert resp.status_code == 303
         assert app.state.auth.is_configured() is True
-        ok, _ = app.state.auth.check_password("newpass", username="admin")
+        ok, _ = app.state.auth.check_password("newpassword", username="admin")
         assert ok is True
 
     @pytest.mark.asyncio
@@ -215,7 +245,7 @@ class TestAuthRoutes:
         app.state.auth.setup_user("admin", "Admin", "", "existing")
         resp = await auth_client.post(
             "/auth/setup",
-            json={"username": "other", "full_name": "", "email": "", "password": "newpass"},
+            json={"username": "other", "full_name": "", "email": "", "password": "newpassword"},
         )
         assert resp.status_code == 409
 
@@ -250,28 +280,28 @@ class TestAuthMiddleware:
     @pytest.mark.asyncio
     async def test_protected_route_returns_401(self, app, auth_client):
         """With auth configured, API routes should return 401 without session."""
-        app.state.auth.set_password("secret")
+        app.state.auth.set_password("secretpass")
         resp = await auth_client.get("/api/system")
         assert resp.status_code == 401
 
     @pytest.mark.asyncio
     async def test_health_exempt(self, app, auth_client):
         """Health endpoint should be accessible without auth."""
-        app.state.auth.set_password("secret")
+        app.state.auth.set_password("secretpass")
         resp = await auth_client.get("/api/health")
         assert resp.status_code == 200
 
     @pytest.mark.asyncio
     async def test_login_page_exempt(self, app, auth_client):
         """Login page should be accessible without auth."""
-        app.state.auth.set_password("secret")
+        app.state.auth.set_password("secretpass")
         resp = await auth_client.get("/auth/login")
         assert resp.status_code == 200
 
     @pytest.mark.asyncio
     async def test_static_exempt(self, app, auth_client):
         """Static files should be accessible without auth (404 is fine, not 401)."""
-        app.state.auth.set_password("secret")
+        app.state.auth.set_password("secretpass")
         resp = await auth_client.get("/static/app.css")
         # Should not be 401 — could be 200 or 404 depending on file existence
         assert resp.status_code != 401
@@ -279,11 +309,11 @@ class TestAuthMiddleware:
     @pytest.mark.asyncio
     async def test_authenticated_request_passes(self, app, auth_client):
         """With valid session cookie, protected routes should work."""
-        app.state.auth.set_password("secret")
+        app.state.auth.set_password("secretpass")
         # Login to get session
         resp = await auth_client.post(
             "/auth/login",
-            data={"password": "secret"},
+            data={"password": "secretpass"},
             follow_redirects=False,
         )
         cookies = resp.cookies
@@ -294,7 +324,7 @@ class TestAuthMiddleware:
     @pytest.mark.asyncio
     async def test_html_request_redirects_to_login(self, app, auth_client):
         """Browser requests should redirect to login page."""
-        app.state.auth.set_password("secret")
+        app.state.auth.set_password("secretpass")
         resp = await auth_client.get(
             "/",
             headers={"accept": "text/html,application/xhtml+xml"},
@@ -306,7 +336,7 @@ class TestAuthMiddleware:
     @pytest.mark.asyncio
     async def test_cluster_worker_exempt(self, app, auth_client):
         """Worker registration should be exempt from auth."""
-        app.state.auth.set_password("secret")
+        app.state.auth.set_password("secretpass")
         resp = await auth_client.post(
             "/api/cluster/workers",
             json={"worker_id": "test", "capabilities": {}},
@@ -317,7 +347,7 @@ class TestAuthMiddleware:
     @pytest.mark.asyncio
     async def test_cluster_heartbeat_exempt(self, app, auth_client):
         """Worker heartbeat should be exempt from auth."""
-        app.state.auth.set_password("secret")
+        app.state.auth.set_password("secretpass")
         resp = await auth_client.post(
             "/api/cluster/heartbeat",
             json={"worker_id": "test"},
@@ -360,8 +390,8 @@ class TestMultiUser:
         data = resp.json()
         assert data["ok"] is True
         code = data["invite_code"]
-        assert len(code) == 8
-        assert code.isdigit()
+        # token_urlsafe(16) produces 22 base64url chars
+        assert len(code) >= 16
 
     @pytest.mark.asyncio
     async def test_pending_user_login_with_invite_code(self, app, auth_client):
@@ -488,7 +518,7 @@ class TestMultiUser:
         code = add.json()["invite_code"]
         await auth_client.post(
             "/auth/complete",
-            json={"username": "eve", "invite_code": code, "full_name": "Eve", "email": "", "password": "evepass", "auto_login": False},
+            json={"username": "eve", "invite_code": code, "full_name": "Eve", "email": "", "password": "evepasswd", "auto_login": False},
         )
         # Try to delete admin (the only admin)
         resp = await auth_client.delete("/auth/users/eve", cookies=login_admin.cookies)
@@ -516,8 +546,7 @@ class TestMultiUser:
         resp = await auth_client.post("/auth/users/frank/reset", cookies=login.cookies)
         assert resp.status_code == 200
         new_code = resp.json()["invite_code"]
-        assert len(new_code) == 8
-        assert new_code.isdigit()
+        assert len(new_code) >= 16
         # Frank can no longer log in with old password
         bad = await auth_client.post(
             "/auth/login",
@@ -723,3 +752,106 @@ class TestSessionUserNoFallback:
         token = mgr.create_session(user_id=rec["id"])
         u = mgr.session_user(token)
         assert u is not None and u["id"] == rec["id"]
+
+
+class TestPasswordPolicy:
+    def test_complete_invite_rejects_short_password(self, tmp_path):
+        mgr = AuthManager(tmp_path)
+        mgr.setup_user("admin", "Admin", "", "adminpass")
+        code = mgr.add_user_invite("bob", "admin")
+        import pytest
+        with pytest.raises(ValueError, match="8"):
+            mgr.complete_invite("bob", code, "Bob", "", "short")
+
+    def test_complete_invite_accepts_8_char_password(self, tmp_path):
+        mgr = AuthManager(tmp_path)
+        mgr.setup_user("admin", "Admin", "", "adminpass")
+        code = mgr.add_user_invite("bob", "admin")
+        user = mgr.complete_invite("bob", code, "Bob", "", "exactly8")
+        assert user["username"] == "bob"
+
+    def test_change_password_rejects_short(self, tmp_path):
+        mgr = AuthManager(tmp_path)
+        mgr.setup_user("alice", "Alice", "", "alicepass")
+        result = mgr.change_password("alice", "alicepass", "short")
+        assert result is False
+
+    def test_session_ttl_is_30_days(self, tmp_path):
+        mgr = AuthManager(tmp_path)
+        assert mgr.long_session_ttl == 86400 * 30
+
+
+class TestInviteCodeEntropy:
+    def test_invite_code_is_urlsafe_token(self, tmp_path):
+        mgr = AuthManager(tmp_path)
+        mgr.setup_user("admin", "Admin", "", "adminpass")
+        code = mgr.add_user_invite("bob", "admin")
+        # token_urlsafe(16) → 22 base64url chars; definitely not all digits
+        assert len(code) >= 16
+        assert not code.isdigit()
+
+    def test_invite_codes_are_unique(self, tmp_path):
+        mgr = AuthManager(tmp_path)
+        mgr.setup_user("admin", "Admin", "", "adminpass")
+        codes = set()
+        for i in range(10):
+            code = mgr.add_user_invite(f"user{i}", "admin")
+            codes.add(code)
+        assert len(codes) == 10  # all unique
+
+    def test_admin_reset_gives_high_entropy_code(self, tmp_path):
+        mgr = AuthManager(tmp_path)
+        mgr.setup_user("admin", "Admin", "", "adminpass")
+        code = mgr.add_user_invite("bob", "admin")
+        mgr.complete_invite("bob", code, "Bob", "", "bobpasswd")
+        new_code = mgr.admin_reset_password("bob", "admin")
+        assert len(new_code) >= 16
+        assert not new_code.isdigit()
+
+
+class TestLoginRateLimit:
+    # ASGITransport sends requests from 127.0.0.1
+    _TEST_IP = "127.0.0.1"
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_blocks_after_5_failures(self, app, auth_client):
+        from tinyagentos.routes.auth import _login_limiter
+        _login_limiter.reset(self._TEST_IP)
+        app.state.auth.setup_user("admin", "Admin", "", "adminpass")
+        # 5 failures using JSON path
+        for _ in range(5):
+            await auth_client.post(
+                "/auth/login",
+                json={"username": "admin", "password": "wrongpass"},
+            )
+        # 6th attempt should be 429
+        resp = await auth_client.post(
+            "/auth/login",
+            json={"username": "admin", "password": "wrongpass"},
+        )
+        _login_limiter.reset(self._TEST_IP)  # clean up after test
+        assert resp.status_code == 429
+
+    @pytest.mark.asyncio
+    async def test_successful_login_resets_rate_limit(self, app, auth_client):
+        from tinyagentos.routes.auth import _login_limiter
+        _login_limiter.reset(self._TEST_IP)
+        app.state.auth.setup_user("admin", "Admin", "", "adminpass")
+        # 4 failures
+        for _ in range(4):
+            await auth_client.post(
+                "/auth/login",
+                json={"username": "admin", "password": "wrongpass"},
+            )
+        # Success resets counter
+        await auth_client.post(
+            "/auth/login",
+            json={"username": "admin", "password": "adminpass"},
+        )
+        # Should not be blocked on next failure
+        resp = await auth_client.post(
+            "/auth/login",
+            json={"username": "admin", "password": "wrongpass"},
+        )
+        _login_limiter.reset(self._TEST_IP)
+        assert resp.status_code == 401  # not 429

--- a/tinyagentos/auth.py
+++ b/tinyagentos/auth.py
@@ -300,8 +300,10 @@ class AuthManager:
         users = self._read_users()
         if users.get("users"):
             raise ValueError("a user is already configured")
-        if not username or not password:
+        if not username:
             raise ValueError("username and password are required")
+        if not password or len(password) < 8:
+            raise ValueError("password must be at least 8 characters")
         record = {
             "id": secrets.token_urlsafe(8),
             "username": username,

--- a/tinyagentos/auth.py
+++ b/tinyagentos/auth.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import secrets
+import threading
 import time
 from collections.abc import Iterator
 from pathlib import Path
@@ -16,6 +17,9 @@ from fastapi import HTTPException, Request
 from tinyagentos.shortcuts.capabilities import default_caps_for_admin, default_caps_for_new_user
 
 _ph = PasswordHasher()
+
+# Lock that makes the SHA-256→argon2 upgrade read-modify-write atomic across threads.
+_hash_upgrade_lock = threading.Lock()
 
 logger = logging.getLogger(__name__)
 
@@ -430,13 +434,16 @@ class AuthManager:
                     ok, new_hash = verify_and_maybe_rehash(password, u.get("password_hash", ""))
                     if ok:
                         if new_hash:
-                            # Upgrade the stored hash in-place
-                            data = self._read_users()
-                            for i, ru in enumerate(data.get("users", [])):
-                                if ru.get("id") == u.get("id"):
-                                    data["users"][i]["password_hash"] = new_hash
-                                    break
-                            self._write_users(data)
+                            # Upgrade the stored hash in-place.
+                            # Lock ensures the read-modify-write is atomic when
+                            # concurrent logins race on the same legacy hash.
+                            with _hash_upgrade_lock:
+                                data = self._read_users()
+                                for i, ru in enumerate(data.get("users", [])):
+                                    if ru.get("id") == u.get("id"):
+                                        data["users"][i]["password_hash"] = new_hash
+                                        break
+                                self._write_users(data)
                             u["password_hash"] = new_hash
                         return (True, u)
                 # Pending user — accept invite code as "password"

--- a/tinyagentos/auth.py
+++ b/tinyagentos/auth.py
@@ -9,9 +9,13 @@ from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
+from argon2 import PasswordHasher
+from argon2.exceptions import VerifyMismatchError, VerificationError, InvalidHashError
 from fastapi import HTTPException, Request
 
 from tinyagentos.shortcuts.capabilities import default_caps_for_admin, default_caps_for_new_user
+
+_ph = PasswordHasher()
 
 logger = logging.getLogger(__name__)
 
@@ -72,15 +76,62 @@ class _PersistentSessions:
 
 
 def hash_password(password: str, salt: str = "") -> str:
-    if not salt:
-        salt = secrets.token_hex(16)
+    """Hash a password with argon2id.
+
+    The ``salt`` parameter is accepted for backward-compatibility but ignored —
+    argon2 manages its own salt internally.  Old callers that passed an explicit
+    salt (e.g. legacy tests) will silently receive a fresh argon2 hash.
+    """
+    return _ph.hash(password)
+
+
+def _hash_password_sha256(password: str, salt: str) -> str:
+    """Internal: produce the old SHA-256 hash for migration verification only."""
     hashed = hashlib.sha256(f"{salt}:{password}".encode()).hexdigest()
     return f"{salt}:{hashed}"
 
 
 def verify_password(password: str, stored: str) -> bool:
-    salt = stored.split(":")[0]
-    return hash_password(password, salt) == stored
+    """Verify *password* against *stored* hash.
+
+    Supports both the legacy ``<salt>:<sha256hex>`` format and the new argon2
+    format (identified by the ``$argon2`` prefix).  Callers that need to know
+    whether the hash was upgraded should use ``verify_and_maybe_rehash``.
+    """
+    if stored.startswith("$argon2"):
+        try:
+            return _ph.verify(stored, password)
+        except (VerifyMismatchError, VerificationError, InvalidHashError):
+            return False
+    # Legacy SHA-256 format: "<salt>:<hex>"
+    parts = stored.split(":", 1)
+    if len(parts) != 2:
+        return False
+    salt = parts[0]
+    return _hash_password_sha256(password, salt) == stored
+
+
+def verify_and_maybe_rehash(password: str, stored: str) -> tuple[bool, str | None]:
+    """Verify *password* and return ``(ok, new_hash_or_None)``.
+
+    If the stored hash is the legacy SHA-256 format and the password is correct,
+    returns a fresh argon2 hash in the second element so the caller can
+    transparently upgrade the stored value.  Returns ``(True, None)`` when the
+    stored hash is already argon2.  Returns ``(False, None)`` on mismatch.
+    """
+    if stored.startswith("$argon2"):
+        try:
+            ok = _ph.verify(stored, password)
+        except (VerifyMismatchError, VerificationError, InvalidHashError):
+            return False, None
+        # argon2-cffi can also signal that re-hash is needed (param changes)
+        if ok and _ph.check_needs_rehash(stored):
+            return True, _ph.hash(password)
+        return ok, None
+    # Legacy SHA-256
+    if not verify_password(password, stored):
+        return False, None
+    return True, _ph.hash(password)
 
 
 class AuthManager:
@@ -114,7 +165,7 @@ class AuthManager:
         self._sessions_file = data_dir / ".auth_sessions"
         self._sessions = _PersistentSessions(self._sessions_file)
         self.session_ttl = 86400 * 7  # 7 days, default
-        self.long_session_ttl = 86400 * 365  # 1 year for "stay signed in"
+        self.long_session_ttl = 86400 * 30  # 30 days for "stay signed in"
 
     # ------------------------------------------------------------------ #
     #  Profile storage helpers                                             #
@@ -267,14 +318,14 @@ class AuthManager:
     # ------------------------------------------------------------------ #
 
     def add_user_invite(self, username: str, invited_by_username: str) -> str:
-        """Create a pending user and return the 8-digit invite code."""
+        """Create a pending user and return a high-entropy invite code."""
         if not username:
             raise ValueError("username is required")
         data = self._read_users()
         for u in data.get("users", []):
             if u.get("username") == username:
                 raise ValueError(f"username '{username}' is already taken")
-        code = f"{secrets.randbelow(100_000_000):08d}"
+        code = secrets.token_urlsafe(16)
         record = {
             "id": secrets.token_urlsafe(8),
             "username": username,
@@ -296,8 +347,8 @@ class AuthManager:
         password: str,
     ) -> dict:
         """Convert a pending invite into a full user record."""
-        if not password or len(password) < 4:
-            raise ValueError("password must be at least 4 characters")
+        if not password or len(password) < 8:
+            raise ValueError("password must be at least 8 characters")
         data = self._read_users()
         users = data.get("users", [])
         target_idx = None
@@ -334,7 +385,7 @@ class AuthManager:
             if u.get("username") == username:
                 if "password_hash" not in u and "pending_invite" not in u:
                     raise ValueError("user record is malformed")
-                code = f"{secrets.randbelow(100_000_000):08d}"
+                code = secrets.token_urlsafe(16)
                 u.pop("password_hash", None)
                 u["pending_invite"] = code
                 u["invited_at"] = int(time.time())
@@ -374,13 +425,23 @@ class AuthManager:
             if username:
                 candidates = [u for u in users if u.get("username") == username]
             for u in candidates:
-                # Full user — verify password
+                # Full user — verify password (with transparent SHA-256→argon2 upgrade)
                 if "password_hash" in u:
-                    if verify_password(password, u.get("password_hash", "")):
+                    ok, new_hash = verify_and_maybe_rehash(password, u.get("password_hash", ""))
+                    if ok:
+                        if new_hash:
+                            # Upgrade the stored hash in-place
+                            data = self._read_users()
+                            for i, ru in enumerate(data.get("users", [])):
+                                if ru.get("id") == u.get("id"):
+                                    data["users"][i]["password_hash"] = new_hash
+                                    break
+                            self._write_users(data)
+                            u["password_hash"] = new_hash
                         return (True, u)
                 # Pending user — accept invite code as "password"
                 elif "pending_invite" in u:
-                    if u["pending_invite"] == password:
+                    if secrets.compare_digest(u["pending_invite"], password):
                         return (True, u)
             return (False, None)
 
@@ -388,13 +449,16 @@ class AuthManager:
         if not self._password_file.exists():
             return (False, None)
         stored = self._password_file.read_text().strip()
-        if verify_password(password, stored):
+        ok, new_hash = verify_and_maybe_rehash(password, stored)
+        if ok:
+            if new_hash:
+                self._password_file.write_text(new_hash)
             return (True, None)
         return (False, None)
 
     def change_password(self, username: str, current_password: str, new_password: str) -> bool:
         """Self-change, requires current password."""
-        if not new_password or len(new_password) < 4:
+        if not new_password or len(new_password) < 8:
             return False
         data = self._read_users()
         users = data.get("users", [])

--- a/tinyagentos/routes/auth.py
+++ b/tinyagentos/routes/auth.py
@@ -1,9 +1,45 @@
 from __future__ import annotations
 
+import time
+from collections import defaultdict
+
 from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 
 router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+# ---------------------------------------------------------------------------
+# Brute-force rate limiter (in-memory, per-IP, fixed window)
+# ---------------------------------------------------------------------------
+
+class _FailCounter:
+    """Count failed attempts per key in a rolling window."""
+
+    def __init__(self, max_attempts: int = 5, window_seconds: int = 600):
+        self._max = max_attempts
+        self._window = window_seconds
+        # key → list of failure timestamps
+        self._log: dict[str, list[float]] = defaultdict(list)
+
+    def _prune(self, key: str) -> None:
+        cutoff = time.monotonic() - self._window
+        self._log[key] = [t for t in self._log[key] if t > cutoff]
+
+    def is_limited(self, key: str) -> bool:
+        self._prune(key)
+        return len(self._log[key]) >= self._max
+
+    def record_failure(self, key: str) -> None:
+        self._prune(key)
+        self._log[key].append(time.monotonic())
+
+    def reset(self, key: str) -> None:
+        self._log.pop(key, None)
+
+
+_login_limiter = _FailCounter(max_attempts=5, window_seconds=600)
+_complete_limiter = _FailCounter(max_attempts=5, window_seconds=600)
 
 # Self-contained HTML pages for the auth flow.
 #
@@ -192,8 +228,8 @@ def _setup_page(error: str = "") -> str:
     </label>
     <label class="field">
       <span>Password</span>
-      <input type="password" name="password" autocomplete="new-password" minlength="4" required>
-      <span class="hint">At least 4 characters.</span>
+      <input type="password" name="password" autocomplete="new-password" minlength="8" required>
+      <span class="hint">At least 8 characters.</span>
     </label>
     <label class="checkbox">
       <input type="checkbox" name="auto_login" value="1" checked>
@@ -256,7 +292,7 @@ async def setup_page(request: Request, error: str = ""):
     if error:
         err_text = {
             "username": "Username is required.",
-            "password": "Password must be at least 4 characters.",
+            "password": "Password must be at least 8 characters.",
         }.get(error, "Setup failed. Please try again.")
     return HTMLResponse(_setup_page(err_text))
 
@@ -275,6 +311,13 @@ async def login(request: Request):
     Form body: legacy password-only login (kept for backward compat).
     """
     auth_mgr = request.app.state.auth
+    client_ip = request.client.host if request.client else "unknown"
+
+    if _login_limiter.is_limited(client_ip):
+        return JSONResponse(
+            {"error": "too many failed login attempts, try again later"},
+            status_code=429,
+        )
 
     content_type = request.headers.get("content-type", "")
     if "application/json" in content_type:
@@ -287,7 +330,10 @@ async def login(request: Request):
 
         ok, user_record = auth_mgr.check_password(password, username=username)
         if not ok:
+            _login_limiter.record_failure(client_ip)
             return JSONResponse({"error": "invalid credentials"}, status_code=401)
+
+        _login_limiter.reset(client_ip)
 
         # Determine long_lived. In multi-user mode default to False when
         # auto_login is not explicitly set.
@@ -340,8 +386,11 @@ async def login(request: Request):
 
     ok, user_record = auth_mgr.check_password(password, username=username)
     if not ok:
+        _login_limiter.record_failure(client_ip)
         next_qs = f"&next={next_url}" if next_url else ""
         return RedirectResponse(f"/auth/login?error=1{next_qs}", status_code=303)
+
+    _login_limiter.reset(client_ip)
 
     if user_record and user_record.get("pending_invite"):
         # Pending user — create their session, then send to /desktop. The
@@ -416,8 +465,8 @@ async def auth_setup(request: Request):
         password = body.get("password") or ""
         if not username:
             return JSONResponse({"error": "username is required"}, status_code=400)
-        if not password or len(password) < 4:
-            return JSONResponse({"error": "password must be at least 4 characters"}, status_code=400)
+        if not password or len(password) < 8:
+            return JSONResponse({"error": "password must be at least 8 characters"}, status_code=400)
         try:
             user = auth_mgr.setup_user(username, full_name, email, password)
         except ValueError as exc:
@@ -450,7 +499,7 @@ async def auth_setup(request: Request):
 
     if not username:
         return RedirectResponse("/auth/setup?error=username", status_code=303)
-    if not password or len(password) < 4:
+    if not password or len(password) < 8:
         return RedirectResponse("/auth/setup?error=password", status_code=303)
     try:
         auth_mgr.setup_user(username, full_name, email, password)
@@ -479,6 +528,14 @@ async def complete_invite(request: Request):
     Body: ``{username, invite_code, full_name, email, password, auto_login?}``
     """
     auth_mgr = request.app.state.auth
+    client_ip = request.client.host if request.client else "unknown"
+
+    if _complete_limiter.is_limited(client_ip):
+        return JSONResponse(
+            {"error": "too many attempts, try again later"},
+            status_code=429,
+        )
+
     try:
         body = await request.json()
     except Exception:
@@ -492,12 +549,13 @@ async def complete_invite(request: Request):
 
     if not username or not invite_code:
         return JSONResponse({"error": "username and invite_code are required"}, status_code=400)
-    if not password or len(password) < 4:
-        return JSONResponse({"error": "password must be at least 4 characters"}, status_code=400)
+    if not password or len(password) < 8:
+        return JSONResponse({"error": "password must be at least 8 characters"}, status_code=400)
 
     try:
         user = auth_mgr.complete_invite(username, invite_code, full_name, email, password)
     except ValueError as exc:
+        _complete_limiter.record_failure(client_ip)
         return JSONResponse({"error": str(exc)}, status_code=400)
 
     long_lived = bool(body.get("auto_login", False))
@@ -667,8 +725,8 @@ async def change_password(username: str, request: Request):
         return JSONResponse({"error": "invalid JSON body"}, status_code=400)
     current = body.get("current") or ""
     new_pw = body.get("new") or ""
-    if not new_pw or len(new_pw) < 4:
-        return JSONResponse({"error": "new password must be at least 4 characters"}, status_code=400)
+    if not new_pw or len(new_pw) < 8:
+        return JSONResponse({"error": "new password must be at least 8 characters"}, status_code=400)
     auth_mgr = request.app.state.auth
     changed = auth_mgr.change_password(username, current, new_pw)
     if not changed:

--- a/tinyagentos/routes/auth.py
+++ b/tinyagentos/routes/auth.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import threading
 import time
 from collections import OrderedDict
 
@@ -23,6 +24,8 @@ class _FailCounter:
     - Expired entries (all timestamps outside the window) are dropped on access.
     - Total key count is capped at ``_FAIL_COUNTER_MAX_KEYS``; oldest-accessed
       entries are evicted first (LRU via OrderedDict).
+
+    Thread-safe: all mutating operations are protected by a Lock.
     """
 
     def __init__(self, max_attempts: int = 5, window_seconds: int = 600):
@@ -30,8 +33,10 @@ class _FailCounter:
         self._window = window_seconds
         # key → list of failure timestamps; OrderedDict for LRU eviction
         self._log: OrderedDict[str, list[float]] = OrderedDict()
+        self._lock = threading.Lock()
 
     def _prune(self, key: str) -> None:
+        """Must be called with self._lock held."""
         cutoff = time.monotonic() - self._window
         if key not in self._log:
             return
@@ -44,23 +49,27 @@ class _FailCounter:
             self._log.move_to_end(key)
 
     def _ensure_capacity(self) -> None:
+        """Must be called with self._lock held."""
         while len(self._log) >= _FAIL_COUNTER_MAX_KEYS:
             self._log.popitem(last=False)  # evict oldest-accessed
 
     def is_limited(self, key: str) -> bool:
-        self._prune(key)
-        return len(self._log.get(key, [])) >= self._max
+        with self._lock:
+            self._prune(key)
+            return len(self._log.get(key, [])) >= self._max
 
     def record_failure(self, key: str) -> None:
-        self._prune(key)
-        if key not in self._log:
-            self._ensure_capacity()
-            self._log[key] = []
-        self._log[key].append(time.monotonic())
-        self._log.move_to_end(key)
+        with self._lock:
+            self._prune(key)
+            if key not in self._log:
+                self._ensure_capacity()
+                self._log[key] = []
+            self._log[key].append(time.monotonic())
+            self._log.move_to_end(key)
 
     def reset(self, key: str) -> None:
-        self._log.pop(key, None)
+        with self._lock:
+            self._log.pop(key, None)
 
 
 _login_limiter = _FailCounter(max_attempts=5, window_seconds=600)
@@ -300,7 +309,12 @@ async def login_page(request: Request, error: str = "", next: str = ""):
     # showing a useless login form.
     if not auth_mgr.is_configured():
         return RedirectResponse("/auth/setup", status_code=303)
-    err_text = "Incorrect username or password." if error else ""
+    if error == "rate_limit":
+        err_text = "Too many failed attempts. Please try again later."
+    elif error:
+        err_text = "Incorrect username or password."
+    else:
+        err_text = ""
     # Only allow relative paths starting with / to prevent open redirect
     safe_next = next if (next.startswith("/") and not next.startswith("//")) else ""
     return HTMLResponse(_login_page(err_text, multi_user=auth_mgr.is_multi_user(), next_url=safe_next))
@@ -338,13 +352,15 @@ async def login(request: Request):
     auth_mgr = request.app.state.auth
     client_ip = request.client.host if request.client else "unknown"
 
-    if _login_limiter.is_limited(client_ip):
-        return JSONResponse(
-            {"error": "too many failed login attempts, try again later"},
-            status_code=429,
-        )
-
     content_type = request.headers.get("content-type", "")
+
+    if _login_limiter.is_limited(client_ip):
+        if "application/json" in content_type:
+            return JSONResponse(
+                {"error": "too many failed login attempts, try again later"},
+                status_code=429,
+            )
+        return RedirectResponse("/auth/login?error=rate_limit", status_code=303)
     if "application/json" in content_type:
         try:
             body = await request.json()
@@ -583,6 +599,7 @@ async def complete_invite(request: Request):
         _complete_limiter.record_failure(client_ip)
         return JSONResponse({"error": str(exc)}, status_code=400)
 
+    _complete_limiter.reset(client_ip)
     long_lived = bool(body.get("auto_login", False))
     record = auth_mgr.find_user(username)
     user_id = record["id"] if record else ""

--- a/tinyagentos/routes/auth.py
+++ b/tinyagentos/routes/auth.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import time
-from collections import defaultdict
+from collections import OrderedDict
 
 from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
@@ -13,26 +13,51 @@ router = APIRouter(prefix="/auth", tags=["auth"])
 # Brute-force rate limiter (in-memory, per-IP, fixed window)
 # ---------------------------------------------------------------------------
 
+_FAIL_COUNTER_MAX_KEYS = 10_000  # cap total tracked IPs to prevent unbounded growth
+
+
 class _FailCounter:
-    """Count failed attempts per key in a rolling window."""
+    """Count failed attempts per key in a rolling window.
+
+    Bounded to avoid memory leaks:
+    - Expired entries (all timestamps outside the window) are dropped on access.
+    - Total key count is capped at ``_FAIL_COUNTER_MAX_KEYS``; oldest-accessed
+      entries are evicted first (LRU via OrderedDict).
+    """
 
     def __init__(self, max_attempts: int = 5, window_seconds: int = 600):
         self._max = max_attempts
         self._window = window_seconds
-        # key → list of failure timestamps
-        self._log: dict[str, list[float]] = defaultdict(list)
+        # key → list of failure timestamps; OrderedDict for LRU eviction
+        self._log: OrderedDict[str, list[float]] = OrderedDict()
 
     def _prune(self, key: str) -> None:
         cutoff = time.monotonic() - self._window
+        if key not in self._log:
+            return
         self._log[key] = [t for t in self._log[key] if t > cutoff]
+        if not self._log[key]:
+            # All timestamps expired — drop the entry entirely
+            del self._log[key]
+        else:
+            # Keep active entry fresh in LRU order
+            self._log.move_to_end(key)
+
+    def _ensure_capacity(self) -> None:
+        while len(self._log) >= _FAIL_COUNTER_MAX_KEYS:
+            self._log.popitem(last=False)  # evict oldest-accessed
 
     def is_limited(self, key: str) -> bool:
         self._prune(key)
-        return len(self._log[key]) >= self._max
+        return len(self._log.get(key, [])) >= self._max
 
     def record_failure(self, key: str) -> None:
         self._prune(key)
+        if key not in self._log:
+            self._ensure_capacity()
+            self._log[key] = []
         self._log[key].append(time.monotonic())
+        self._log.move_to_end(key)
 
     def reset(self, key: str) -> None:
         self._log.pop(key, None)


### PR DESCRIPTION
## What

Five targeted security hardening changes to `tinyagentos/auth.py` and `tinyagentos/routes/auth.py`.

### 1. Argon2 password hashing (replaces single-round SHA-256)

`argon2-cffi` was already a dependency; now it's actually used. `hash_password()` now produces argon2id hashes. `verify_password()` still accepts the legacy `<salt>:<sha256hex>` format, and `verify_and_maybe_rehash()` upgrades those hashes transparently on the next successful login — no migration script needed, no user-visible disruption.

### 2. Login brute-force rate limiting

`POST /auth/login` is now gated by a per-IP fixed-window counter: 5 failures in 10 minutes triggers a 429. A successful login resets the counter. Implemented as `_FailCounter` — a lightweight in-process class, consistent with the existing `RateLimiter` pattern in `rate_limit.py`.

### 3. Rate limiting on `/auth/complete` (invite redemption)

Same 5-per-10-min limit on `POST /auth/complete`. Prevents brute-forcing invite codes even when entropy was low (it isn't anymore — see below).

### 4. Invite code entropy

`add_user_invite()` and `admin_reset_password()` now use `secrets.token_urlsafe(16)` (~128-bit entropy) instead of 8-digit numeric strings (~26-bit). The invite code is now URL-safe base64, 22 characters long.

### 5. Session TTL

"Stay signed in" `long_session_ttl` reduced from 1 year (`86400 * 365`) to 30 days (`86400 * 30`).

### 6. Minimum password length

Raised from 4 to 8 characters in all auth paths: `complete_invite`, `change_password`, route-layer validation in setup/complete/change-password endpoints.

## Tests

76 tests pass (`test_auth.py`, `test_routes_auth.py`, `shortcuts/test_auth_capabilities.py`). Added:
- `TestPasswordHashing`: argon2 roundtrip, legacy SHA-256 verify, `verify_and_maybe_rehash` upgrade path
- `TestPasswordPolicy`: min-length enforcement, 30-day TTL assertion
- `TestInviteCodeEntropy`: code length/format, uniqueness, admin reset
- `TestLoginRateLimit`: blocks after 5 failures, resets on success

Existing tests updated: short passwords lengthened, invite code assertions changed from `len == 8 and isdigit()` to `len >= 16`.

## Deferred (follow-up PRs for remaining #646 items)

- Session file race condition (concurrent async writes) — needs `asyncio.Lock` or `fcntl.flock`
- Session-to-IP/User-Agent binding — stolen cookie mitigation
- Reflected XSS in auth pages — `html.escape()` on `error` and `next_url` query params

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Login rate limiting: Excessive failed authentication attempts are now blocked (HTTP 429) to prevent brute-force attacks.

* **Security Improvements**
  * Enhanced password hashing algorithm for stronger security.
  * Minimum password length requirement increased from 4 to 8 characters.
  * Invite codes now use higher-entropy format for improved security.
  * Session timeout reduced from 1 year to 30 days.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->