### PR TITLE
fix(deps): Python 3.14 / macOS full-suite segfault (fork-after-ObjC + aiosqlite worker thread)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,40 +22,42 @@ if sys.platform == "darwin":
 
 
 def _patch_aiosqlite_py314():
-    """Patch aiosqlite's worker thread for Python 3.14 compatibility.
+    """Patch aiosqlite's Connection for Python 3.14 / macOS compatibility.
 
-    Python 3.14 tightened thread-finalization and GC ordering, so unclosed
-    aiosqlite connections (whose background worker thread still holds a future
-    tied to an already-closed event loop) produce a SIGSEGV during interpreter
-    shutdown rather than the harmless "Exception in thread" logged on 3.12/3.13.
+    Python 3.14 tightened thread-finalization and GC ordering.  When aiosqlite
+    connections are not explicitly closed before the asyncio event loop shuts
+    down, their background worker threads remain blocked on SimpleQueue.get().
+    At interpreter shutdown Python destroys the C-level semaphore that backs
+    SimpleQueue while the worker threads are still blocked on it, producing a
+    SIGSEGV in the main process (visible in faulthandler output as "Fatal Python
+    error: Segmentation fault" with all thread frames in _safe_worker/tx.get()).
 
-    Root cause: the worker thread calls
-        future.get_loop().call_soon_threadsafe(set_result, future, result)
-    from a background thread.  On Python 3.14, if the event loop has already
-    been closed and partially freed, calling call_soon_threadsafe on it hits a
-    NULL pointer dereference at the C level (inside slot_tp_call /
-    _PyEval_EvalFrameDefault) — bypassing Python's exception mechanism entirely
-    and killing the process with SIGSEGV.
+    Root cause: the background thread is not a daemon thread, so Python's
+    interpreter shutdown waits for it.  The thread is blocked on tx.get()
+    because the Connection's __del__ / stop() was not called before the event
+    loop closed (or called too late).  When the shutdown sequence eventually
+    forces cleanup, the semaphore is torn down under the blocked thread.
 
-    Fix: check loop.is_closed() before calling call_soon_threadsafe, and wrap
-    the call in a try/except RuntimeError as a belt-and-suspenders guard.
-    The is_closed() pre-check avoids the C-level crash; the try/except handles
-    the narrow race where the loop closes between the check and the call.
+    Fix (two layers):
+    1. Mark the worker thread daemon=True so it is killed at interpreter exit
+       rather than being joined — avoids the blocking semaphore teardown.
+    2. Guard call_soon_threadsafe with an is_closed() pre-check so the worker
+       does not crash if it receives a future tied to a dead event loop.
 
-    Applied only on Python >= 3.14 to leave CI (3.12/3.13) behaviour unchanged.
+    Applied only on Python >= 3.14 to leave CI (3.12/3.13) unchanged.
     """
     import aiosqlite.core as _core
+    from threading import Thread
 
     _STOP = _core._STOP_RUNNING_SENTINEL
 
     def _threadsafe_call(loop, callback, *args):
-        """Call loop.call_soon_threadsafe only if the loop is still open."""
+        """Deliver result/exception only if the event loop is still alive."""
         try:
             if not loop.is_closed():
                 loop.call_soon_threadsafe(callback, *args)
         except RuntimeError:
-            # Race: loop closed between is_closed() check and the call.
-            # The test has already completed; safe to discard.
+            # Race: loop closed between the is_closed() check and the call.
             pass
 
     def _safe_worker(tx):
@@ -76,6 +78,16 @@ def _patch_aiosqlite_py314():
                     )
 
     _core._connection_worker_thread = _safe_worker
+
+    # Monkey-patch Connection.__init__ to mark the worker thread daemon so
+    # interpreter shutdown does not wait (and deadlock) on it.
+    _orig_init = _core.Connection.__init__
+
+    def _patched_init(self, connector, iter_chunk_size, loop=None):
+        _orig_init(self, connector, iter_chunk_size, loop)
+        self._thread.daemon = True
+
+    _core.Connection.__init__ = _patched_init
 
 
 def pytest_configure(config):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
+import os
 import sqlite3
+import sys
 
 import pytest
 import pytest_asyncio
@@ -7,6 +9,73 @@ from httpx import ASGITransport, AsyncClient
 
 from tinyagentos.app import create_app
 from tinyagentos.routes.desktop import SPA_DIR
+
+# macOS + Python 3.14: after the interpreter loads ObjC-backed extension
+# modules (psutil, zeroconf, Pillow, lxml …), forking a child process with
+# subprocess violates macOS's "unsafe after ObjC runtime init" restriction and
+# produces SIGSEGV in git/bash children (exit code -11).  Setting this env var
+# tells the ObjC runtime to skip the fork-safety check in child processes.
+# The variable propagates automatically to every subprocess the test suite
+# spawns; it is a no-op on Linux (ignored) so CI is unaffected.
+if sys.platform == "darwin":
+    os.environ.setdefault("OBJC_DISABLE_INITIALIZE_FORK_SAFETY", "YES")
+
+
+def _patch_aiosqlite_py314():
+    """Patch aiosqlite's worker thread for Python 3.14 compatibility.
+
+    Python 3.14 tightened thread-finalization and GC ordering, so unclosed
+    aiosqlite connections (whose background worker thread still holds a future
+    tied to an already-closed event loop) produce a SIGSEGV during interpreter
+    shutdown rather than the harmless "Exception in thread" logged on 3.12/3.13.
+
+    Root cause: the worker thread calls
+        future.get_loop().call_soon_threadsafe(set_result, future, result)
+    from a background thread.  On Python 3.14, if the event loop has already
+    been closed and partially freed, calling call_soon_threadsafe on it hits a
+    NULL pointer dereference at the C level (inside slot_tp_call /
+    _PyEval_EvalFrameDefault) — bypassing Python's exception mechanism entirely
+    and killing the process with SIGSEGV.
+
+    Fix: check loop.is_closed() before calling call_soon_threadsafe, and wrap
+    the call in a try/except RuntimeError as a belt-and-suspenders guard.
+    The is_closed() pre-check avoids the C-level crash; the try/except handles
+    the narrow race where the loop closes between the check and the call.
+
+    Applied only on Python >= 3.14 to leave CI (3.12/3.13) behaviour unchanged.
+    """
+    import aiosqlite.core as _core
+
+    _STOP = _core._STOP_RUNNING_SENTINEL
+
+    def _threadsafe_call(loop, callback, *args):
+        """Call loop.call_soon_threadsafe only if the loop is still open."""
+        try:
+            if not loop.is_closed():
+                loop.call_soon_threadsafe(callback, *args)
+        except RuntimeError:
+            # Race: loop closed between is_closed() check and the call.
+            # The test has already completed; safe to discard.
+            pass
+
+    def _safe_worker(tx):
+        while True:
+            future, function = tx.get()
+            try:
+                result = function()
+                if future:
+                    _threadsafe_call(
+                        future.get_loop(), _core.set_result, future, result
+                    )
+                if result is _STOP:
+                    break
+            except BaseException as exc:
+                if future:
+                    _threadsafe_call(
+                        future.get_loop(), _core.set_exception, future, exc
+                    )
+
+    _core._connection_worker_thread = _safe_worker
 
 
 def pytest_configure(config):
@@ -28,6 +97,12 @@ def pytest_configure(config):
         f = SPA_DIR / name
         if not f.exists():
             f.write_text(body)
+
+    # Python 3.14 changed thread-finalization ordering in a way that turns
+    # aiosqlite's unclosed-connection "Exception in thread" noise into a
+    # SIGSEGV on full-suite runs.  Apply the targeted patch only on 3.14+.
+    if sys.version_info >= (3, 14):
+        _patch_aiosqlite_py314()
 
 
 @pytest.fixture


### PR DESCRIPTION
## Problem

Running \`python3 -m pytest\` locally on **Python 3.14 / macOS** produced intermittent SIGSEGV crashes across ~54 tests during the full suite run. These did not appear on the CI matrix (Python 3.12/3.13 / Linux).

Two independent root causes:

### 1. macOS fork-after-Objective-C crash (subprocess tests)

After pytest imports ObjC-backed extension modules (psutil, zeroconf, Pillow, lxml), any subsequent \`subprocess.run\` / \`fork()\` call violates macOS's fork-safety contract and child processes (git, bash, echo) exit with SIGSEGV (exit code -11). Affected: test_update_runner, test_cow_storage_pool, test_agent_bridge, test_routes_settings, and others that spawn subprocesses.

### 2. aiosqlite worker thread crash (Python 3.14 + macOS)

Python 3.14 tightened thread-finalization and GC ordering. When aiosqlite connections are not explicitly closed before the asyncio event loop shuts down, their background worker threads remain blocked on \`SimpleQueue.get()\`. At interpreter shutdown Python destroys the C-level semaphore that backs the SimpleQueue while the worker threads are still blocked on it — producing SIGSEGV in the main process ("Fatal Python error: Segmentation fault" with thread frames in \`_safe_worker\`/\`tx.get()\`).

## Fix

All changes are in \`tests/conftest.py\` only — zero production code touched. aiosqlite version unchanged (0.22.1 is already latest).

**Fix 1 (macOS fork):** Set \`OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES\` at conftest import time on \`darwin\` only. The env var propagates automatically to every child process spawned by the test suite. It is a no-op on Linux so CI is unaffected.

**Fix 2 (aiosqlite):** Two layers applied only on \`sys.version_info >= (3, 14)\`:
- Mark the aiosqlite worker thread \`daemon=True\` so it is killed at interpreter exit rather than being joined — avoids the blocking semaphore teardown that causes SIGSEGV.
- Guard \`call_soon_threadsafe\` with an \`is_closed()\` pre-check so the worker does not crash on a future tied to a dead event loop.

## Verification

- 238 tests from previously-failing modules all pass in one run.
- Full suite runs to completion without segfaulting the test process.
- CI (3.12/3.13 / Linux): neither guard activates — \`sys.platform != "darwin"\` and \`sys.version_info < (3, 14)\`.