### PR TITLE
fix(security): run controller as non-root 'taos' user (#639)

### DIFF
--- a/os-build/userpatches/extensions/tinyagentos.sh
+++ b/os-build/userpatches/extensions/tinyagentos.sh
@@ -40,14 +40,18 @@ function post_customize_image__tinyagentos() {
         " || display_alert "TinyAgentOS" "could not add taos to '${grp}' group" "warn"
     done
 
-    # Set ownership of the install and data directories so the 'taos' user can
-    # write to them at runtime.  The source files stay owned by root (readable
-    # by taos).  The data directory gets 0700 so only taos can enter it.
+    # Set ownership of the entire install directory so the 'taos' user can
+    # write to .git/, .venv/, and static/desktop/ during non-root in-app
+    # self-updates (git pull, pip install -e ., npm run build).
+    # Security trade-off: taos owns its own code, which is required for
+    # self-update without a root helper.  Full update-privilege-separation
+    # (a signed updater suid helper) is a post-beta hardening task.
+    # The data directory is then tightened on top so secrets stay 0700/0600.
     if [[ -d "${SDCARD}/opt/tinyagentos" ]]; then
         chroot "${SDCARD}" /bin/bash -c "
-            chown -R taos:taos /opt/tinyagentos/data 2>/dev/null || true
+            chown -R taos:taos /opt/tinyagentos 2>/dev/null || true
             chmod 0700 /opt/tinyagentos/data 2>/dev/null || true
         "
-        display_alert "TinyAgentOS" "Set /opt/tinyagentos/data ownership to taos:taos (0700)" "info"
+        display_alert "TinyAgentOS" "Set /opt/tinyagentos ownership to taos:taos; data/ → 0700" "info"
     fi
 }

--- a/os-build/userpatches/extensions/tinyagentos.sh
+++ b/os-build/userpatches/extensions/tinyagentos.sh
@@ -13,4 +13,41 @@ function post_customize_image__tinyagentos() {
     # Verify critical paths exist in the image
     [[ -d "${SDCARD}/opt/tinyagentos" ]] || \
         display_alert "TinyAgentOS" "/opt/tinyagentos missing — customize-image.sh may have failed" "warn"
+
+    # Create the dedicated 'taos' system user that the controller service runs
+    # as.  The service unit in the overlay already references User=taos; without
+    # this user present at first boot the service fails to start.
+    #
+    # chroot into the image target so useradd writes to the image's /etc/passwd
+    # rather than the build host.  -r = system account, -M = no home dir,
+    # -s /usr/sbin/nologin = non-interactive, -d = home field in passwd (not
+    # an actual directory on disk).
+    display_alert "TinyAgentOS" "Creating 'taos' system user" "info"
+    chroot "${SDCARD}" /bin/bash -c "
+        id taos >/dev/null 2>&1 && exit 0
+        useradd -r -M -s /usr/sbin/nologin -d /opt/tinyagentos taos \
+            || useradd -r -M -s /sbin/nologin -d /opt/tinyagentos taos
+    " || display_alert "TinyAgentOS" "useradd taos failed — service will not start as non-root" "warn"
+
+    # Add 'taos' to the incus and docker groups so the controller can reach
+    # those sockets without root.  These groups may not exist at image-build
+    # time (the packages are installed at first-boot or post-flash), so we
+    # create them if absent and add the user idempotently.
+    for grp in incus docker; do
+        chroot "${SDCARD}" /bin/bash -c "
+            getent group ${grp} >/dev/null 2>&1 || groupadd -r ${grp}
+            usermod -aG ${grp} taos 2>/dev/null || true
+        " || display_alert "TinyAgentOS" "could not add taos to '${grp}' group" "warn"
+    done
+
+    # Set ownership of the install and data directories so the 'taos' user can
+    # write to them at runtime.  The source files stay owned by root (readable
+    # by taos).  The data directory gets 0700 so only taos can enter it.
+    if [[ -d "${SDCARD}/opt/tinyagentos" ]]; then
+        chroot "${SDCARD}" /bin/bash -c "
+            chown -R taos:taos /opt/tinyagentos/data 2>/dev/null || true
+            chmod 0700 /opt/tinyagentos/data 2>/dev/null || true
+        "
+        display_alert "TinyAgentOS" "Set /opt/tinyagentos/data ownership to taos:taos (0700)" "info"
+    fi
 }

--- a/os-build/userpatches/extensions/tinyagentos.sh
+++ b/os-build/userpatches/extensions/tinyagentos.sh
@@ -36,7 +36,7 @@ function post_customize_image__tinyagentos() {
     for grp in incus docker; do
         chroot "${SDCARD}" /bin/bash -c "
             getent group ${grp} >/dev/null 2>&1 || groupadd -r ${grp}
-            usermod -aG ${grp} taos 2>/dev/null || true
+            usermod -aG ${grp} taos
         " || display_alert "TinyAgentOS" "could not add taos to '${grp}' group" "warn"
     done
 
@@ -48,10 +48,13 @@ function post_customize_image__tinyagentos() {
     # (a signed updater suid helper) is a post-beta hardening task.
     # The data directory is then tightened on top so secrets stay 0700/0600.
     if [[ -d "${SDCARD}/opt/tinyagentos" ]]; then
-        chroot "${SDCARD}" /bin/bash -c "
-            chown -R taos:taos /opt/tinyagentos 2>/dev/null || true
-            chmod 0700 /opt/tinyagentos/data 2>/dev/null || true
-        "
-        display_alert "TinyAgentOS" "Set /opt/tinyagentos ownership to taos:taos; data/ → 0700" "info"
+        if chroot "${SDCARD}" /bin/bash -c "
+            chown -R taos:taos /opt/tinyagentos &&
+            chmod 0700 /opt/tinyagentos/data
+        "; then
+            display_alert "TinyAgentOS" "Set /opt/tinyagentos ownership to taos:taos; data/ → 0700" "info"
+        else
+            display_alert "TinyAgentOS" "Failed to set /opt/tinyagentos ownership or data/ permissions" "warn"
+        fi
     fi
 }

--- a/os-build/userpatches/overlay/etc/systemd/system/tinyagentos.service
+++ b/os-build/userpatches/overlay/etc/systemd/system/tinyagentos.service
@@ -5,7 +5,8 @@ Wants=docker.service
 
 [Service]
 Type=simple
-User=root
+User=taos
+Group=taos
 WorkingDirectory=/opt/tinyagentos
 ExecStart=/opt/tinyagentos/venv/bin/python -m uvicorn tinyagentos.app:create_app --factory --host 0.0.0.0 --port 6969
 Restart=on-failure

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -1230,6 +1230,80 @@ else
     log "TAOS_SKIP_QMD is set — skipping qmd.service install"
 fi
 
+# --- dedicated service user -----------------------------------------------
+# The controller runs as an unprivileged system user 'taos' rather than root.
+# The installer itself still runs as root (via sudo bash); only the resulting
+# systemd unit drops to 'taos'.  The user needs access to the incus and docker
+# sockets (group membership) but no elevated privileges beyond that.
+
+ensure_taos_user() {
+    [[ "$os_name" == "Linux" ]] || return 0  # no-op on macOS (launchd agent)
+
+    # Create the system user if absent. useradd -r = system account (no home
+    # dir by default, no expiry). -M = do not create /home/taos. -d sets the
+    # "home" field in /etc/passwd to INSTALL_DIR (used by some tools for ~
+    # expansion, not an actual home directory on disk).
+    if ! id -u taos >/dev/null 2>&1; then
+        log "creating system user 'taos' for the controller service"
+        useradd -r -M -s /usr/sbin/nologin -d "$INSTALL_DIR" taos \
+            || useradd -r -M -s /sbin/nologin -d "$INSTALL_DIR" taos \
+            || { warn "useradd failed — the service will not run as 'taos'"; return 1; }
+        log "system user 'taos' created"
+    else
+        log "system user 'taos' already exists — skipping useradd"
+    fi
+
+    # Add 'taos' to the incus group so it can reach the incus socket without
+    # root. Warn (don't fail) if the group doesn't exist — the socket is still
+    # usable if incus is not installed on this host.
+    if getent group incus >/dev/null 2>&1; then
+        usermod -aG incus taos >/dev/null 2>&1 \
+            && log "added 'taos' to the 'incus' group" \
+            || warn "could not add 'taos' to the 'incus' group — agent container deploys may fail"
+    else
+        warn "'incus' group not found — skipping (install Incus first, then re-run to add 'taos' to the group)"
+    fi
+
+    # Mirror the existing docker-group handling: add 'taos' to docker so the
+    # controller can manage Store Docker apps. Warn if docker isn't present.
+    if getent group docker >/dev/null 2>&1; then
+        usermod -aG docker taos >/dev/null 2>&1 \
+            && log "added 'taos' to the 'docker' group" \
+            || warn "could not add 'taos' to the 'docker' group — Store Docker apps may fail"
+    else
+        warn "'docker' group not found — skipping (install Docker first, then re-run to add 'taos' to the group)"
+    fi
+}
+
+# --- data dir ownership + permissions ------------------------------------
+# After the venv + data dir are set up, hand ownership of the runtime data
+# tree to the 'taos' user so the service can read/write it.  Sensitive files
+# get tighter permissions (600).  Idempotent: chown/chmod are always safe
+# to re-run.
+
+set_data_dir_ownership() {
+    [[ "$os_name" == "Linux" ]] || return 0  # no-op on macOS
+    ! id -u taos >/dev/null 2>&1 && return 0  # no-op if user wasn't created
+
+    log "setting ownership of $INSTALL_DIR/data/ → taos:taos (mode 0700)"
+    # The venv + source files stay owned by root (readable by taos).
+    # Only the runtime data directory — where the controller writes secrets,
+    # sessions, and the agent trace files — needs to be owned by 'taos'.
+    chown -R taos:taos "$INSTALL_DIR/data" 2>/dev/null || true
+    chmod 0700 "$INSTALL_DIR/data"
+
+    # Tighten sensitive credential files if they already exist.
+    for f in \
+        "$INSTALL_DIR/data/.auth_password" \
+        "$INSTALL_DIR/data/.auth_user.json" \
+        "$INSTALL_DIR/data/.auth_sessions" \
+        "$INSTALL_DIR/data/.auth_local_token" \
+        "$INSTALL_DIR/data/.litellm_db_url" \
+        "$INSTALL_DIR/data/browser_cookie_key.hex"; do
+        [[ -f "$f" ]] && chmod 0600 "$f" || true
+    done
+}
+
 # --- tinyagentos.service install -----------------------------------------
 
 install_linux_systemd_system() {
@@ -1243,14 +1317,19 @@ install_linux_systemd_system() {
     # if set at install time, default to 0 (disabled).
     local taos_prefetch="${TAOS_PREFETCH_BASE_IMAGE:-0}"
 
+    # Create the dedicated service user and assign group memberships.
+    ensure_taos_user
+
     # Install graceful-stop script
     $sudo_cmd install -m 0755 "$INSTALL_DIR/scripts/taos-graceful-stop.sh" /usr/local/bin/taos-graceful-stop
     log "installed /usr/local/bin/taos-graceful-stop"
 
     # Stamp the template from the repo, substituting install-time variables.
+    # The service runs as the dedicated 'taos' system user, not the installer's
+    # $USER.  The installer itself still runs as root.
     sed \
-        -e "s|TAOS_USER|$USER|g" \
-        -e "s|TAOS_GROUP|$(id -gn)|g" \
+        -e "s|TAOS_USER|taos|g" \
+        -e "s|TAOS_GROUP|taos|g" \
         -e "s|TAOS_INSTALL_DIR|$INSTALL_DIR|g" \
         -e "s|TAOS_PYTHON|$INSTALL_DIR/.venv/bin/python|g" \
         -e "s|TAOS_PORT|$TAOS_PORT|g" \
@@ -1262,7 +1341,10 @@ install_linux_systemd_system() {
     # ExecStart now runs `python -m tinyagentos`, which reads these (rather
     # than uvicorn CLI args), so the dual-port browser-proxy origin starts.
     $sudo_cmd sed -i "s|^Environment=PYTHONUNBUFFERED=1|Environment=PYTHONUNBUFFERED=1\nEnvironment=TAOS_HOST=0.0.0.0\nEnvironment=TAOS_PORT=$TAOS_PORT\nEnvironment=TAOS_BROWSER_PROXY_PORT=$TAOS_BROWSER_PROXY_PORT|" "$unit"
-    log "installed $unit (system unit, runs as $USER)"
+    log "installed $unit (system unit, runs as 'taos')"
+
+    # Hand the data directory to the service user before the unit first starts.
+    set_data_dir_ownership
 
     # Install pre-shutdown hook
     if [[ -f "$INSTALL_DIR/systemd/taos-pre-shutdown.service" ]]; then
@@ -1275,7 +1357,7 @@ install_linux_systemd_system() {
     if [[ -f /etc/systemd/system/taos-pre-shutdown.service ]]; then
         $sudo_cmd systemctl enable taos-pre-shutdown.service
     fi
-    log "controller running as system service"
+    log "controller running as system service (user: taos)"
     log "check: systemctl status tinyagentos"
     log "logs:  journalctl -u tinyagentos -f"
 }

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -1661,6 +1661,28 @@ if [[ "$SERVICE_MODE" != "skip" ]]; then
     fi
 fi
 
+# --- pre-beta install hint -----------------------------------------------
+# If a root-based pre-beta install exists at a different location than the
+# new install, point the user to the migration script so they can preserve
+# their existing data.
+
+if [[ "$os_name" == "Linux" ]]; then
+    _prebeta_found=""
+    for _cand in /root/tinyagentos /home/*/tinyagentos; do
+        [[ -d "$_cand/data" ]] || continue
+        [[ "$(realpath "$_cand" 2>/dev/null)" == "$(realpath "$INSTALL_DIR" 2>/dev/null)" ]] && continue
+        _prebeta_found="$_cand"
+        break
+    done
+    if [[ -n "$_prebeta_found" ]]; then
+        warn ""
+        warn "Pre-beta install detected at $_prebeta_found"
+        warn "To migrate your existing data to this install, run:"
+        warn "  sudo bash $INSTALL_DIR/scripts/pre-beta-to-beta.sh"
+        warn ""
+    fi
+fi
+
 # --- success summary -----------------------------------------------------
 
 host_ip=""

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -1285,14 +1285,18 @@ set_data_dir_ownership() {
     [[ "$os_name" == "Linux" ]] || return 0  # no-op on macOS
     ! id -u taos >/dev/null 2>&1 && return 0  # no-op if user wasn't created
 
-    log "setting ownership of $INSTALL_DIR/data/ → taos:taos (mode 0700)"
-    # The venv + source files stay owned by root (readable by taos).
-    # Only the runtime data directory — where the controller writes secrets,
-    # sessions, and the agent trace files — needs to be owned by 'taos'.
-    chown -R taos:taos "$INSTALL_DIR/data" 2>/dev/null || true
-    chmod 0700 "$INSTALL_DIR/data"
+    # Security trade-off: taos must OWN the entire install dir (repo, .git,
+    # .venv, static/desktop/) so the in-app self-updater can write to those
+    # paths while running non-root (git pull, pip install -e ., npm run build).
+    # Full update-privilege-separation (a dedicated updater suid helper that
+    # verifies signatures before writing) is a post-beta hardening task.
+    log "setting ownership of $INSTALL_DIR → taos:taos (required for non-root in-app self-update)"
+    chown -R taos:taos "$INSTALL_DIR" 2>/dev/null || true
 
-    # Tighten sensitive credential files if they already exist.
+    # Tighten the data directory and sensitive credential files on top of the
+    # broad chown above — done AFTER so the restrictive perms win.
+    log "tightening $INSTALL_DIR/data/ → mode 0700 and secret files → 0600"
+    chmod 0700 "$INSTALL_DIR/data"
     for f in \
         "$INSTALL_DIR/data/.auth_password" \
         "$INSTALL_DIR/data/.auth_user.json" \

--- a/scripts/pre-beta-to-beta.sh
+++ b/scripts/pre-beta-to-beta.sh
@@ -1,0 +1,411 @@
+#!/usr/bin/env bash
+# pre-beta-to-beta.sh — migrate a root-based pre-beta taOS install to the
+# non-root 'taos' beta layout introduced in PR #639 / #677.
+#
+# Run this AFTER re-installing taOS with the beta installer so the new
+# install dir and systemd unit are already in place.  The script then copies
+# your old data across, fixes ownership/permissions, and patches the service
+# unit if it still says User=root.
+#
+# Usage (as root or via sudo):
+#   sudo bash scripts/pre-beta-to-beta.sh [--yes] \
+#         [OLD_TAOS_DIR=/root/tinyagentos] [NEW_TAOS_DIR=/opt/tinyagentos]
+#
+# Environment overrides (can also be set before calling the script):
+#   OLD_TAOS_DIR   path of the pre-beta install containing a data/ subdirectory
+#   NEW_TAOS_DIR   path of the freshly-installed beta install
+#
+# Safety properties:
+#   - Refuses to run unless EUID=0.
+#   - Never overwrites NEW/data without first taking a timestamped tarball backup.
+#   - Never deletes or modifies the OLD install — it is left entirely intact.
+#   - Fails loudly if OLD or NEW cannot be determined unambiguously; does NOT guess.
+#   - All destructive steps require confirmation unless --yes is passed.
+#   - Idempotent: safe to re-run; backup is taken each time if data is already present.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+log()  { printf '\033[1;34m[pre-beta-mig]\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m[pre-beta-mig]\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[1;31m[pre-beta-mig]\033[0m %s\n' "$*" >&2; exit 1; }
+ok()   { printf '\033[1;32m[pre-beta-mig]\033[0m %s\n' "$*"; }
+
+# ---------------------------------------------------------------------------
+# argument / flag parsing
+# ---------------------------------------------------------------------------
+
+CONFIRM_YES=0
+
+usage() {
+    cat <<EOF
+Usage: sudo bash $0 [--yes] [OLD_TAOS_DIR=<path>] [NEW_TAOS_DIR=<path>]
+
+Migrates a root-based pre-beta taOS install to the non-root 'taos' beta layout.
+Run AFTER the beta installer has been applied.
+
+Options:
+  --yes               skip the interactive confirmation prompt
+  OLD_TAOS_DIR=PATH   pre-beta install directory (must contain a data/ subdir)
+  NEW_TAOS_DIR=PATH   beta install directory (installed by the beta installer)
+  -h, --help          show this help
+
+Environment variables OLD_TAOS_DIR and NEW_TAOS_DIR may also be set before
+calling the script instead of passing them as KEY=VALUE arguments.
+EOF
+}
+
+for arg in "$@"; do
+    case "$arg" in
+        -h|--help)    usage; exit 0 ;;
+        --yes)        CONFIRM_YES=1 ;;
+        OLD_TAOS_DIR=*) OLD_TAOS_DIR="${arg#OLD_TAOS_DIR=}" ;;
+        NEW_TAOS_DIR=*) NEW_TAOS_DIR="${arg#NEW_TAOS_DIR=}" ;;
+        *) die "unknown argument: $arg  (run with -h for usage)" ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# guard: must run as root
+# ---------------------------------------------------------------------------
+
+if [[ "${EUID:-$(id -u)}" != "0" ]]; then
+    die "this script must be run as root (use: sudo bash $0)"
+fi
+
+# ---------------------------------------------------------------------------
+# auto-detect NEW_TAOS_DIR
+# ---------------------------------------------------------------------------
+
+if [[ -z "${NEW_TAOS_DIR:-}" ]]; then
+    # Try the running systemd unit's WorkingDirectory first.
+    _unit_wd=""
+    if command -v systemctl >/dev/null 2>&1; then
+        _unit_wd=$(systemctl show -p WorkingDirectory tinyagentos 2>/dev/null \
+                   | sed 's/^WorkingDirectory=//' | grep -v '^$' || true)
+    fi
+
+    if [[ -n "$_unit_wd" && -d "$_unit_wd" ]]; then
+        NEW_TAOS_DIR="$_unit_wd"
+        log "auto-detected NEW_TAOS_DIR from systemd unit: $NEW_TAOS_DIR"
+    elif [[ -d /opt/tinyagentos ]]; then
+        NEW_TAOS_DIR="/opt/tinyagentos"
+        log "auto-detected NEW_TAOS_DIR from default location: $NEW_TAOS_DIR"
+    else
+        die "cannot determine NEW_TAOS_DIR — pass it explicitly: NEW_TAOS_DIR=/opt/tinyagentos"
+    fi
+fi
+
+# Normalise (remove trailing slash).
+NEW_TAOS_DIR="${NEW_TAOS_DIR%/}"
+
+[[ -d "$NEW_TAOS_DIR" ]] || die "NEW_TAOS_DIR '$NEW_TAOS_DIR' does not exist"
+
+# ---------------------------------------------------------------------------
+# auto-detect OLD_TAOS_DIR
+# ---------------------------------------------------------------------------
+
+if [[ -z "${OLD_TAOS_DIR:-}" ]]; then
+    # Scan common pre-beta locations for a data/ directory that differs from NEW.
+    _candidates=()
+    for candidate in /root/tinyagentos /home/*/tinyagentos; do
+        # Skip if it is (or resolves to) the same path as NEW.
+        [[ -d "$candidate" ]] || continue
+        [[ "$(realpath "$candidate")" == "$(realpath "$NEW_TAOS_DIR")" ]] && continue
+        # A valid pre-beta install must have a data/ directory.
+        [[ -d "$candidate/data" ]] || continue
+        _candidates+=("$candidate")
+    done
+
+    if [[ "${#_candidates[@]}" -eq 1 ]]; then
+        OLD_TAOS_DIR="${_candidates[0]}"
+        log "auto-detected OLD_TAOS_DIR: $OLD_TAOS_DIR"
+    elif [[ "${#_candidates[@]}" -eq 0 ]]; then
+        die "no pre-beta install found in /root/tinyagentos or /home/*/tinyagentos
+     Pass OLD_TAOS_DIR explicitly: OLD_TAOS_DIR=/root/tinyagentos"
+    else
+        # More than one candidate — refuse to guess destructively.
+        warn "multiple pre-beta installs found:"
+        for c in "${_candidates[@]}"; do warn "  $c"; done
+        die "cannot determine which is OLD — pass it explicitly:
+     OLD_TAOS_DIR=<path>  (e.g. OLD_TAOS_DIR=/root/tinyagentos)"
+    fi
+fi
+
+OLD_TAOS_DIR="${OLD_TAOS_DIR%/}"
+
+[[ -d "$OLD_TAOS_DIR" ]] || die "OLD_TAOS_DIR '$OLD_TAOS_DIR' does not exist"
+[[ -d "$OLD_TAOS_DIR/data" ]] \
+    || die "OLD_TAOS_DIR '$OLD_TAOS_DIR' has no data/ subdirectory — is this the right path?"
+[[ "$(realpath "$OLD_TAOS_DIR")" != "$(realpath "$NEW_TAOS_DIR")" ]] \
+    || die "OLD_TAOS_DIR and NEW_TAOS_DIR resolve to the same path ('$OLD_TAOS_DIR') — nothing to do"
+
+# ---------------------------------------------------------------------------
+# confirmation
+# ---------------------------------------------------------------------------
+
+BACKUP_TS=$(date +%Y%m%d-%H%M%S)
+BACKUP_PATH="$NEW_TAOS_DIR/data.pre-migration-backup.$BACKUP_TS.tgz"
+
+log ""
+log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+log "  Pre-beta → Beta migration plan"
+log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+log "  OLD install : $OLD_TAOS_DIR"
+log "  NEW install : $NEW_TAOS_DIR"
+log ""
+log "  Steps:"
+log "  1. Stop tinyagentos.service"
+log "  2. Backup NEW data dir → $BACKUP_PATH"
+log "     (only if NEW/data/ already has content)"
+log "  3. Copy OLD/data/ → NEW/data/  (cp -a, preserving timestamps)"
+log "  4. Ensure 'taos' system user exists + has incus/docker group membership"
+log "  5. chown -R taos:taos NEW/data/  +  chmod 0700 data/  +  chmod 0600 secrets"
+log "  6. Patch tinyagentos.service to User=taos if it still says User=root"
+log "  7. systemctl daemon-reload && systemctl start tinyagentos"
+log "  8. Verify service is active and running as 'taos'"
+log ""
+log "  The OLD install is NEVER modified or deleted."
+log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+log ""
+
+if [[ "$CONFIRM_YES" -eq 0 ]]; then
+    printf '\033[1;33m[pre-beta-mig]\033[0m Proceed? [y/N] '
+    read -r _reply
+    case "$_reply" in
+        y|Y|yes|YES) ;;
+        *) die "aborted by user" ;;
+    esac
+fi
+
+# ---------------------------------------------------------------------------
+# step 1 — stop the service
+# ---------------------------------------------------------------------------
+
+log "[1/8] stopping tinyagentos.service..."
+if command -v systemctl >/dev/null 2>&1; then
+    systemctl stop tinyagentos 2>/dev/null || true
+    log "  service stopped (or was not running)"
+else
+    warn "  systemctl not available — skipping service stop"
+fi
+
+# ---------------------------------------------------------------------------
+# step 2 — backup NEW data dir if it has content
+# ---------------------------------------------------------------------------
+
+log "[2/8] checking for existing content in $NEW_TAOS_DIR/data/ ..."
+mkdir -p "$NEW_TAOS_DIR/data"
+
+_new_data_empty=1
+if [[ -n "$(ls -A "$NEW_TAOS_DIR/data" 2>/dev/null)" ]]; then
+    _new_data_empty=0
+fi
+
+if [[ "$_new_data_empty" -eq 0 ]]; then
+    log "  NEW/data/ has content — creating backup at:"
+    log "  $BACKUP_PATH"
+    tar -czf "$BACKUP_PATH" -C "$NEW_TAOS_DIR" data \
+        || die "backup failed — aborting (NEW/data/ is untouched)"
+    log "  backup created: $BACKUP_PATH"
+else
+    log "  NEW/data/ is empty — skipping backup"
+fi
+
+# ---------------------------------------------------------------------------
+# step 3 — copy OLD data → NEW data
+# ---------------------------------------------------------------------------
+
+log "[3/8] copying $OLD_TAOS_DIR/data/ → $NEW_TAOS_DIR/data/ ..."
+# cp -a: archive mode (preserves perms, timestamps, symlinks, ownership).
+# Trailing /. copies the CONTENTS of data/, not the directory itself.
+cp -a "$OLD_TAOS_DIR/data/." "$NEW_TAOS_DIR/data/"
+
+# Also carry the top-level trace/ directory if it lives separately from data/
+# (pre-beta versions sometimes placed it at the install root).
+if [[ -d "$OLD_TAOS_DIR/trace" ]]; then
+    log "  detected separate trace/ dir — copying to $NEW_TAOS_DIR/data/trace/"
+    mkdir -p "$NEW_TAOS_DIR/data/trace"
+    cp -a "$OLD_TAOS_DIR/trace/." "$NEW_TAOS_DIR/data/trace/"
+fi
+
+log "  copy complete"
+
+# ---------------------------------------------------------------------------
+# step 4 — ensure taos user + group memberships
+# ---------------------------------------------------------------------------
+
+log "[4/8] ensuring 'taos' system user exists..."
+
+_os_name="$(uname -s)"
+
+if [[ "$_os_name" == "Linux" ]]; then
+    if ! id -u taos >/dev/null 2>&1; then
+        log "  creating system user 'taos'"
+        useradd -r -M -s /usr/sbin/nologin -d "$NEW_TAOS_DIR" taos \
+            || useradd -r -M -s /sbin/nologin -d "$NEW_TAOS_DIR" taos \
+            || { warn "useradd failed — chown step may also fail"; }
+        log "  'taos' user created"
+    else
+        log "  'taos' user already exists — skipping useradd"
+    fi
+
+    if getent group incus >/dev/null 2>&1; then
+        if usermod -aG incus taos >/dev/null 2>&1; then
+            log "  added 'taos' to the 'incus' group"
+        else
+            warn "  could not add 'taos' to 'incus' — agent container deploys may fail"
+        fi
+    else
+        warn "  'incus' group not found — skipping (install Incus first, then re-run the installer)"
+    fi
+
+    if getent group docker >/dev/null 2>&1; then
+        if usermod -aG docker taos >/dev/null 2>&1; then
+            log "  added 'taos' to the 'docker' group"
+        else
+            warn "  could not add 'taos' to 'docker' — Store Docker apps may fail"
+        fi
+    else
+        warn "  'docker' group not found — skipping (install Docker first, then re-run the installer)"
+    fi
+else
+    log "  non-Linux OS ($_os_name) — skipping user setup (launchd agent uses the invoking user)"
+fi
+
+# ---------------------------------------------------------------------------
+# step 5 — fix ownership + permissions
+# ---------------------------------------------------------------------------
+
+log "[5/8] setting ownership and permissions on $NEW_TAOS_DIR/data/ ..."
+chown -R taos:taos "$NEW_TAOS_DIR/data" 2>/dev/null \
+    || warn "  chown failed (taos user may not exist) — service will fail to start"
+chmod 0700 "$NEW_TAOS_DIR/data"
+
+# Tighten known sensitive credential files (mirrors set_data_dir_ownership in
+# install-server.sh — keep this list in sync if new secret files are added).
+for _f in \
+    "$NEW_TAOS_DIR/data/.auth_password" \
+    "$NEW_TAOS_DIR/data/.auth_user.json" \
+    "$NEW_TAOS_DIR/data/.auth_sessions" \
+    "$NEW_TAOS_DIR/data/.auth_local_token" \
+    "$NEW_TAOS_DIR/data/.litellm_db_url" \
+    "$NEW_TAOS_DIR/data/browser_cookie_key.hex"; do
+    [[ -f "$_f" ]] && chmod 0600 "$_f" && log "  chmod 0600 $_f"
+done
+
+# The venv and source tree must be readable by the taos user (group
+# execute+read) but owned by root is fine — taos does not need write access.
+if [[ -d "$NEW_TAOS_DIR/.venv" ]]; then
+    chmod -R o+rX "$NEW_TAOS_DIR/.venv" 2>/dev/null || true
+fi
+
+log "  ownership + permissions set"
+
+# ---------------------------------------------------------------------------
+# step 6 — patch systemd unit if it still says User=root
+# ---------------------------------------------------------------------------
+
+UNIT_FILE="/etc/systemd/system/tinyagentos.service"
+
+log "[6/8] checking systemd unit: $UNIT_FILE ..."
+if [[ "$_os_name" != "Linux" ]]; then
+    log "  non-Linux — skipping systemd step"
+elif [[ ! -f "$UNIT_FILE" ]]; then
+    warn "  $UNIT_FILE not found — skipping unit patch (re-run the installer to install the unit)"
+else
+    _current_user=$(grep -Po '(?<=^User=)\S+' "$UNIT_FILE" 2>/dev/null | head -1 || echo "")
+    if [[ "$_current_user" == "root" ]]; then
+        warn "  unit has User=root — patching to User=taos"
+        sed -i 's/^User=root$/User=taos/' "$UNIT_FILE"
+        # Also add Group=taos if missing.
+        if ! grep -q '^Group=' "$UNIT_FILE"; then
+            sed -i '/^User=taos$/a Group=taos' "$UNIT_FILE"
+        else
+            sed -i 's/^Group=root$/Group=taos/' "$UNIT_FILE"
+        fi
+        log "  unit patched: User=taos Group=taos"
+    elif [[ "$_current_user" == "taos" ]]; then
+        log "  unit already has User=taos — no patch needed"
+    else
+        warn "  unit has User=$_current_user — not patching (expected 'taos' or 'root')"
+    fi
+
+    systemctl daemon-reload
+    log "  systemctl daemon-reload done"
+fi
+
+# ---------------------------------------------------------------------------
+# step 7 — start the service
+# ---------------------------------------------------------------------------
+
+log "[7/8] starting tinyagentos.service..."
+if command -v systemctl >/dev/null 2>&1 && [[ "$_os_name" == "Linux" ]]; then
+    systemctl start tinyagentos \
+        || { warn "  systemctl start failed — check: journalctl -u tinyagentos --no-pager -n 30"; }
+    sleep 3
+else
+    log "  non-Linux or no systemctl — skipping service start"
+fi
+
+# ---------------------------------------------------------------------------
+# step 8 — verify
+# ---------------------------------------------------------------------------
+
+log "[8/8] verifying service state..."
+
+_pass=1
+
+if command -v systemctl >/dev/null 2>&1 && [[ "$_os_name" == "Linux" ]]; then
+    _active=$(systemctl is-active tinyagentos 2>/dev/null || echo "unknown")
+    _svc_user=$(systemctl show -p User tinyagentos 2>/dev/null \
+                | sed 's/^User=//' | grep -v '^$' || echo "unknown")
+
+    if [[ "$_active" == "active" ]]; then
+        ok "  service is active"
+    else
+        warn "  service state: $_active (expected: active)"
+        _pass=0
+    fi
+
+    if [[ "$_svc_user" == "taos" ]]; then
+        ok "  service user: taos"
+    else
+        warn "  service user: $_svc_user (expected: taos)"
+        _pass=0
+    fi
+fi
+
+log ""
+log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+if [[ "$_pass" -eq 1 ]]; then
+    ok "  Migration PASSED"
+    log ""
+    log "  Your old install at $OLD_TAOS_DIR has been left intact."
+    log "  Once you have verified the beta works, you may remove it with:"
+    log "    sudo rm -rf $OLD_TAOS_DIR"
+    if [[ "$_new_data_empty" -eq 0 ]]; then
+        log ""
+        log "  Pre-migration backup of NEW/data/ is at:"
+        log "    $BACKUP_PATH"
+        log "  Remove it once you are confident the migration succeeded."
+    fi
+else
+    warn "  Migration finished with WARNINGS — service may not be fully operational."
+    log ""
+    log "  Diagnose with:"
+    log "    journalctl -u tinyagentos --no-pager -n 50"
+    log "    systemctl status tinyagentos"
+    log ""
+    log "  Your OLD install is untouched: $OLD_TAOS_DIR"
+    if [[ "$_new_data_empty" -eq 0 ]]; then
+        log "  Your pre-migration data backup is at: $BACKUP_PATH"
+    fi
+    log ""
+    log "  If you need to roll back: stop the service, restore from the backup"
+    log "  (or simply re-install pointing to the old dir), then investigate."
+fi
+log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/scripts/pre-beta-to-beta.sh
+++ b/scripts/pre-beta-to-beta.sh
@@ -163,7 +163,7 @@ log "  2. Backup NEW data dir → $BACKUP_PATH"
 log "     (only if NEW/data/ already has content)"
 log "  3. Copy OLD/data/ → NEW/data/  (cp -a, preserving timestamps)"
 log "  4. Ensure 'taos' system user exists + has incus/docker group membership"
-log "  5. chown -R taos:taos NEW/data/  +  chmod 0700 data/  +  chmod 0600 secrets"
+log "  5. chown -R taos:taos NEW/  (whole install dir)  +  chmod 0700 data/  +  chmod 0600 secrets"
 log "  6. Patch tinyagentos.service to User=taos if it still says User=root"
 log "  7. systemctl daemon-reload && systemctl start tinyagentos"
 log "  8. Verify service is active and running as 'taos'"
@@ -280,13 +280,19 @@ fi
 # step 5 — fix ownership + permissions
 # ---------------------------------------------------------------------------
 
-log "[5/8] setting ownership and permissions on $NEW_TAOS_DIR/data/ ..."
-chown -R taos:taos "$NEW_TAOS_DIR/data" 2>/dev/null \
-    || warn "  chown failed (taos user may not exist) — service will fail to start"
-chmod 0700 "$NEW_TAOS_DIR/data"
+log "[5/8] setting ownership and permissions on $NEW_TAOS_DIR ..."
 
-# Tighten known sensitive credential files (mirrors set_data_dir_ownership in
-# install-server.sh — keep this list in sync if new secret files are added).
+# Security trade-off: taos must OWN the entire install dir (repo, .git,
+# .venv, static/desktop/) so the in-app self-updater can write to those
+# paths while running non-root (git pull, pip install -e ., npm run build).
+# Full update-privilege-separation is a post-beta hardening task.
+chown -R taos:taos "$NEW_TAOS_DIR" 2>/dev/null \
+    || warn "  chown failed (taos user may not exist) — service will fail to start"
+
+# Tighten the data directory and known sensitive credential files on top of
+# the broad chown above — done AFTER so the restrictive perms win.
+# (Mirrors set_data_dir_ownership in install-server.sh — keep in sync.)
+chmod 0700 "$NEW_TAOS_DIR/data"
 for _f in \
     "$NEW_TAOS_DIR/data/.auth_password" \
     "$NEW_TAOS_DIR/data/.auth_user.json" \
@@ -296,12 +302,6 @@ for _f in \
     "$NEW_TAOS_DIR/data/browser_cookie_key.hex"; do
     [[ -f "$_f" ]] && chmod 0600 "$_f" && log "  chmod 0600 $_f"
 done
-
-# The venv and source tree must be readable by the taos user (group
-# execute+read) but owned by root is fine — taos does not need write access.
-if [[ -d "$NEW_TAOS_DIR/.venv" ]]; then
-    chmod -R o+rX "$NEW_TAOS_DIR/.venv" 2>/dev/null || true
-fi
 
 log "  ownership + permissions set"
 

--- a/tinyagentos/deployer.py
+++ b/tinyagentos/deployer.py
@@ -281,6 +281,9 @@ async def deploy_agent(req: DeployRequest) -> dict:
         cpu_limit=req.cpu_limit,
         mounts=mounts,
         env=env,
+        # os.getuid() is the UID of the controller process (the 'taos' system
+        # user when running under systemd).  raw.idmap maps container-root to
+        # this host UID so the trace bind-mount is writable by the container.
         host_uid=os.getuid(),
         root_size_gib=req.root_size_gib,
     )

--- a/tinyagentos/restart_orchestrator.py
+++ b/tinyagentos/restart_orchestrator.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import time
 from pathlib import Path
 from typing import Literal
@@ -11,30 +12,56 @@ import httpx
 
 logger = logging.getLogger(__name__)
 
-PENDING_RESTART_PATH = Path("~/.config/taos/pending-restart.json").expanduser()
-
 Reason = Literal["pause", "stop", "system-shutdown"]
 
 
+def _pending_restart_path() -> Path:
+    """Return the path for the pending-restart flag file.
+
+    Resolution order:
+    1. ``$TAOS_DATA_DIR/pending-restart.json`` — preferred when the process runs
+       as the non-root ``taos`` service user, which has no real home directory.
+       The systemd unit sets ``WorkingDirectory`` to the install dir; the data
+       dir is always ``<install_dir>/data``, which ``taos`` owns.
+    2. ``<install_dir>/data/pending-restart.json`` — derived from this module's
+       location (``tinyagentos/restart_orchestrator.py`` → ``../../data``).
+       Matches the ``PROJECT_DIR / "data"`` convention used throughout app.py.
+    3. ``~/.config/taos/pending-restart.json`` — backward-compatible fallback
+       for root-based or developer installs where ``TAOS_DATA_DIR`` is unset and
+       ``~`` resolves to a writable home directory.
+    """
+    env_data = os.environ.get("TAOS_DATA_DIR")
+    if env_data:
+        return Path(env_data) / "pending-restart.json"
+    # Derive from module location: tinyagentos/restart_orchestrator.py → ../../data
+    install_data = Path(__file__).parent.parent / "data"
+    if install_data.is_dir():
+        return install_data / "pending-restart.json"
+    # Fallback for root/dev installs (taos service user has no usable ~)
+    return Path("~/.config/taos/pending-restart.json").expanduser()
+
+
 def write_pending_restart(target_sha: str) -> None:
-    PENDING_RESTART_PATH.parent.mkdir(parents=True, exist_ok=True)
-    PENDING_RESTART_PATH.write_text(
+    path = _pending_restart_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
         json.dumps({"target_sha": target_sha, "pulled_at": int(time.time())})
     )
 
 
 def read_pending_restart() -> dict | None:
-    if not PENDING_RESTART_PATH.exists():
+    path = _pending_restart_path()
+    if not path.exists():
         return None
     try:
-        return json.loads(PENDING_RESTART_PATH.read_text())
+        return json.loads(path.read_text())
     except Exception:
         return None
 
 
 def clear_pending_restart() -> None:
     try:
-        PENDING_RESTART_PATH.unlink(missing_ok=True)
+        _pending_restart_path().unlink(missing_ok=True)
     except Exception:
         pass
 

--- a/tinyagentos/restart_orchestrator.py
+++ b/tinyagentos/restart_orchestrator.py
@@ -56,14 +56,16 @@ def read_pending_restart() -> dict | None:
     try:
         return json.loads(path.read_text())
     except Exception:
+        logger.warning("Failed to read pending-restart flag at %s", path, exc_info=True)
         return None
 
 
 def clear_pending_restart() -> None:
+    path = _pending_restart_path()
     try:
-        _pending_restart_path().unlink(missing_ok=True)
+        path.unlink(missing_ok=True)
     except Exception:
-        pass
+        logger.warning("Failed to clear pending-restart flag at %s", path, exc_info=True)
 
 
 class RestartOrchestrator:


### PR DESCRIPTION
## Summary

- **Installer** (`scripts/install-server.sh`): creates a dedicated `taos` system user (idempotent), adds it to the `incus` and `docker` groups (warns instead of failing if either group is absent), substitutes `User=taos`/`Group=taos` into the rendered system unit (was `$USER`), then `chown -R taos:taos data/` (mode 0700) and `chmod 0600` the sensitive credential files after the venv/data setup.
- **Installer service template** (`scripts/systemd/tinyagentos.service`): no change needed — `TAOS_USER`/`TAOS_GROUP` placeholders were already there; the `ExecStartPre=+chmod` debugfs lines already carry the `+` root-override prefix and continue to work as-is.
- **Armbian image overlay** (`os-build/userpatches/overlay/etc/systemd/system/tinyagentos.service`): `User=root` → `User=taos`, `Group=taos` added.
- **Armbian build extension** (`os-build/userpatches/extensions/tinyagentos.sh`): creates `taos` user in the image chroot, adds to `incus`/`docker` groups (creates them if absent so the user record is correct even before packages land at first-boot), `chown -R taos:taos /opt/tinyagentos/data` (0700).
- **`tinyagentos/deployer.py`**: one-line comment only — `os.getuid()` returning the `taos` UID is correct for `raw.idmap both {uid} 0` (maps container-root to the host `taos` UID for the trace bind-mount). No behaviour change.
- **`systemd/tinyagentos-host-firewall.service`**: left as-is — it is a separate root oneshot for iptables rules and does not need to change.
- **Migration script** (`scripts/pre-beta-to-beta.sh`): run-once helper for existing users upgrading from a root-based pre-beta install to this non-root beta layout (see below).

## What was not changed

- The installer itself still runs as root (via `sudo bash`) — the drop to `taos` is in the systemd unit only.
- The `install_linux_systemd_user` path (no-sudo fallback) still uses `$USER` as before — it runs as the calling user by design.
- No auth bypass; no weakening of any security boundary.

## Root-only assumptions checked

The only genuine concern was `os.getuid()` in `deployer.py` being passed as `host_uid` to incus `raw.idmap`. Verified: `raw.idmap both {uid} 0` maps container-root to whatever UID the controller runs as. When running as `taos` (a non-zero UID) this is correct and required — it ensures the trace bind-mount directory owned by `taos` is writable by the container. No code change needed.

## Migration script — pre-beta → beta (`scripts/pre-beta-to-beta.sh`)

Existing users who ran a root-based pre-beta install (typically at `/root/tinyagentos` on the Pi) need to copy their data to the new non-root layout. Run this **after** the beta installer has been applied:

```bash
sudo bash scripts/pre-beta-to-beta.sh
```

Or with explicit paths if auto-detection is ambiguous:

```bash
sudo bash scripts/pre-beta-to-beta.sh \
  OLD_TAOS_DIR=/root/tinyagentos \
  NEW_TAOS_DIR=/opt/tinyagentos
```

Pass `--yes` to skip the interactive confirmation prompt.

**What it does (in order):**
1. Stops `tinyagentos.service`
2. Backs up `NEW/data/` to a timestamped `.tgz` if it already has content (never overwrites without a backup)
3. Copies `OLD/data/` → `NEW/data/` (`cp -a`, preserving timestamps/perms)
4. Ensures the `taos` system user exists and has `incus`/`docker` group membership (same logic as the installer)
5. `chown -R taos:taos NEW/` (whole install dir) + `chmod 0700 data/` + `chmod 0600` credential files
6. Patches the systemd unit from `User=root` → `User=taos` if the old unit is still in place
7. `systemctl daemon-reload && systemctl start tinyagentos`
8. Verifies the service is `active` and running as `taos`; prints PASS/FAIL with next steps

The OLD install is **never modified or deleted** — it is left intact for rollback.

## Updater compatibility

Two additional fixes so the in-app updater (Settings → Updates) works correctly when running as non-root `taos`:

### Fix 1 — taos owns the whole install dir, not just data/

The updater needs to write to `.git/` (git pull), `.venv/` (pip install -e .), and `static/desktop/` (npm run build). `set_data_dir_ownership()` in `install-server.sh` previously only chowned `data/`; it now chowns the entire `INSTALL_DIR` first, then tightens `data/` to 0700 and secret files to 0600 on top (order matters — restrictive perms win). The same change is mirrored in `pre-beta-to-beta.sh` and the Armbian build extension.

**Security trade-off**: `taos` owning its own code directory is the minimum required for non-root in-app self-update without a privileged helper. Full update-privilege-separation (a signed updater suid binary that verifies integrity before writing) is a post-beta hardening task.

### Fix 2 — pending-restart flag moved out of ~/.config

`restart_orchestrator.py` previously hardcoded `~/.config/taos/pending-restart.json`. The `taos` service user is created with `-M` (no home directory), so `~` does not resolve to a writable path under systemd.

Replaced the module-level constant with a `_pending_restart_path()` helper. Resolution order:
1. `$TAOS_DATA_DIR/pending-restart.json` — when the env var is set (already used by `__main__.py` for the Mac app).
2. `<install_dir>/data/pending-restart.json` — derived from `Path(__file__).parent.parent / "data"`, which is the same `PROJECT_DIR / "data"` convention used throughout `app.py`. This is the path used on every standard Linux install.
3. `~/.config/taos/pending-restart.json` — backward-compatible fallback for root-based or developer installs where `~` resolves correctly.

The systemd unit template does not need a new `Environment=TAOS_DATA_DIR=…` line: the module-location fallback (`__file__` → `../../data`) resolves to the correct `<install_dir>/data` directory automatically, because the process is always launched with `WorkingDirectory=<install_dir>` and the module lives inside that tree.

All three functions (`write_pending_restart`, `read_pending_restart`, `clear_pending_restart`) now call `_pending_restart_path()` so the path is consistent across write/read/clear.

## Pi test plan (deploy-time — validate on Pi before relying on it)

This is a deploy-time change with no automated CI coverage. Validate on the Orange Pi 5 Plus:

- [ ] **Re-run the installer** (or `sudo bash scripts/install-server.sh`) on the Pi to create the `taos` user and update the unit.
- [ ] **Verify user and groups**: `id taos` — expect `uid=<N>(taos) gid=<N>(taos) groups=...,incus,docker`.
- [ ] **Verify unit user**: `systemctl show -p User tinyagentos` — expect `User=taos`.
- [ ] **Verify service starts**: `systemctl status tinyagentos` — Active: active (running).
- [ ] **Verify process UID**: `ps -o user= -p $(systemctl show -p MainPID tinyagentos | cut -d= -f2)` — expect `taos`.
- [ ] **Install dir ownership**: `ls -la /opt/tinyagentos/` — expect `taos:taos` owner throughout; `data/` should be `drwx------`.
- [ ] **Auth/login works**: open `http://taos.local:6969`, log in.
- [ ] **Agent deploy works**: deploy a test agent — verifies incus socket access via `incus` group.
- [ ] **Traces write**: check `data/trace/<slug>/` is created and populated by the container.
- [ ] **Host-firewall unit**: `systemctl status tinyagentos-host-firewall` — still applies iptables rules (runs as root, unaffected by this change).
- [ ] **RKNPU stats**: check the taOS hardware panel shows NPU load (the `ExecStartPre=+chmod` debugfs lines run as root regardless of `User=taos`).
- [ ] **In-app updater**: trigger an update from Settings → Updates and confirm it completes without permission errors.
- [ ] **Pending-restart flag**: after an update, confirm `data/pending-restart.json` is created (not `~/.config/taos/`).
- [ ] **Migration script (Pi)**: on the Pi with an existing `/root/tinyagentos` install, run `sudo bash scripts/pre-beta-to-beta.sh --yes` and verify the 8-step output ends with `Migration PASSED`, the service is active as `taos`, and data is intact.

> **Note**: deploy-time change only. Validate on Pi before merging to dev.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Service now runs under a dedicated unprivileged system user for improved safety.
  * Added a migration tool to move pre-beta installs into the new layout while preserving data.

* **Security Improvements**
  * Data and credential files now receive stricter ownership and permissions to limit access.

* **Install/Upgrade**
  * Installer and upgrade workflow log and enforce the new service user and data ownership.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->