### PR TITLE
fix(security): generate per-install LiteLLM master key + real encryption for secrets (#637)

### DIFF
--- a/tests/test_agent_permitted_models.py
+++ b/tests/test_agent_permitted_models.py
@@ -19,6 +19,7 @@ class _FakeProxy:
         self.database_url = "postgres://x" if db else None
         self._running = running
         self._capture = capture  # list to append (models,) tuples
+        self._data_dir = None  # in-memory master key (no disk I/O in tests)
 
     def is_running(self):
         return self._running

--- a/tests/test_deployer.py
+++ b/tests/test_deployer.py
@@ -228,14 +228,16 @@ class TestDeployAgent:
 
     @pytest.mark.asyncio
     async def test_master_key_never_injected_into_container_env(self, tmp_path):
-        """The shared master key (sk-taos-master) must never appear in the
-        container env — not as OPENAI_API_KEY, LITELLM_API_KEY, or any other
-        variable. Only scoped per-agent virtual keys are permitted."""
-        from tinyagentos.llm_proxy import TAOS_LITELLM_MASTER_KEY
+        """The per-install master key must never appear in the container env —
+        not as OPENAI_API_KEY, LITELLM_API_KEY, or any other variable.
+        Only scoped per-agent virtual keys are permitted."""
+        from tinyagentos.litellm_config import get_litellm_master_key
+        master_key = get_litellm_master_key(tmp_path)
         mock_proxy = MagicMock()
         mock_proxy.is_running.return_value = True
         mock_proxy.url = "http://localhost:4000"
         mock_proxy.database_url = "postgresql://u:p@h/db"
+        mock_proxy._data_dir = tmp_path
         mock_proxy.create_agent_key = AsyncMock(return_value="sk-scoped-agent-key")
 
         req = _req(
@@ -262,7 +264,7 @@ class TestDeployAgent:
             assert env["LITELLM_API_KEY"] == "sk-scoped-agent-key"
             # The master key must never appear anywhere in the container env
             for var, val in env.items():
-                assert val != TAOS_LITELLM_MASTER_KEY, (
+                assert val != master_key, (
                     f"master key leaked into container env var {var!r}"
                 )
 

--- a/tests/test_litellm_master_key.py
+++ b/tests/test_litellm_master_key.py
@@ -65,6 +65,50 @@ class TestMasterKeyGeneration:
         key = get_litellm_master_key(None)
         assert key.startswith("sk-taos-")
 
+    def test_exclusive_create_race_loser_reads_winner_key(self, tmp_path):
+        """Simulate the O_EXCL race: pre-write a key file, then call the loader.
+
+        The loader must detect the FileExistsError path and return the
+        pre-existing key rather than the freshly-generated token it minted,
+        ensuring the cache ends up with whatever key actually won on disk.
+        """
+        import os
+        key_path = tmp_path / ".litellm_master_key"
+        winner_key = "sk-taos-winner-key-abc123"
+        # Write the winner's key with O_CREAT|O_EXCL to simulate what the
+        # winning process does.
+        fd = os.open(str(key_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        os.write(fd, winner_key.encode())
+        os.close(fd)
+
+        # Now call the loader — it should see the file and return the winner's key.
+        loaded = get_litellm_master_key(tmp_path)
+        assert loaded == winner_key, (
+            "Loader must return the on-disk key (the race winner), "
+            "not a freshly generated token."
+        )
+        assert cfg_mod._master_key_cache[str(tmp_path)] == winner_key
+
+    def test_loser_path_via_file_exists_error(self, tmp_path, monkeypatch):
+        """Directly exercise the FileExistsError branch by patching os.open."""
+        import os as _os
+        key_path = tmp_path / ".litellm_master_key"
+        winner_key = "sk-taos-on-disk-winner"
+        key_path.write_text(winner_key)
+
+        original_open = _os.open
+
+        def _raise_exists(path, flags, mode=0o666):
+            if "litellm_master_key" in str(path) and (flags & _os.O_EXCL):
+                raise FileExistsError("simulated race")
+            return original_open(path, flags, mode)
+
+        monkeypatch.setattr(_os, "open", _raise_exists)
+
+        loaded = get_litellm_master_key(tmp_path)
+        assert loaded == winner_key
+        assert cfg_mod._master_key_cache[str(tmp_path)] == winner_key
+
     def test_generate_litellm_config_uses_supplied_key(self, tmp_path):
         key = get_litellm_master_key(tmp_path)
         config = generate_litellm_config([], master_key=key)

--- a/tests/test_litellm_master_key.py
+++ b/tests/test_litellm_master_key.py
@@ -1,0 +1,160 @@
+"""Tests for the per-install LiteLLM master key loader (Fix A / issue #637)."""
+from __future__ import annotations
+
+import pytest
+from pathlib import Path
+
+import tinyagentos.litellm_config as cfg_mod
+from tinyagentos.litellm_config import get_litellm_master_key, generate_litellm_config
+from tinyagentos.llm_proxy import LLMProxy
+
+
+@pytest.fixture(autouse=True)
+def clear_key_cache():
+    """Isolate the in-process cache between tests."""
+    cfg_mod._master_key_cache.clear()
+    yield
+    cfg_mod._master_key_cache.clear()
+
+
+class TestMasterKeyGeneration:
+    def test_key_has_correct_prefix(self, tmp_path):
+        key = get_litellm_master_key(tmp_path)
+        assert key.startswith("sk-taos-")
+
+    def test_key_longer_than_hardcoded(self, tmp_path):
+        """Generated key must be longer than the old 'sk-taos-master' constant."""
+        key = get_litellm_master_key(tmp_path)
+        assert len(key) > len("sk-taos-master")
+
+    def test_key_persisted_to_file(self, tmp_path):
+        key = get_litellm_master_key(tmp_path)
+        key_file = tmp_path / ".litellm_master_key"
+        assert key_file.exists()
+        assert key_file.read_text().strip() == key
+
+    def test_key_file_mode_600(self, tmp_path):
+        import stat
+        get_litellm_master_key(tmp_path)
+        key_file = tmp_path / ".litellm_master_key"
+        mode = stat.S_IMODE(key_file.stat().st_mode)
+        assert mode == 0o600
+
+    def test_same_key_on_second_call_same_process(self, tmp_path):
+        k1 = get_litellm_master_key(tmp_path)
+        k2 = get_litellm_master_key(tmp_path)
+        assert k1 == k2
+
+    def test_same_key_after_cache_cleared(self, tmp_path):
+        k1 = get_litellm_master_key(tmp_path)
+        cfg_mod._master_key_cache.clear()
+        k2 = get_litellm_master_key(tmp_path)
+        assert k1 == k2
+
+    def test_different_data_dirs_get_different_keys(self, tmp_path):
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        dir_a.mkdir()
+        dir_b.mkdir()
+        ka = get_litellm_master_key(dir_a)
+        kb = get_litellm_master_key(dir_b)
+        # Independently generated keys should not collide (with overwhelming probability).
+        assert ka != kb
+
+    def test_no_data_dir_returns_in_memory_key(self):
+        key = get_litellm_master_key(None)
+        assert key.startswith("sk-taos-")
+
+    def test_generate_litellm_config_uses_supplied_key(self, tmp_path):
+        key = get_litellm_master_key(tmp_path)
+        config = generate_litellm_config([], master_key=key)
+        assert config["general_settings"]["master_key"] == key
+
+    def test_generate_litellm_config_no_master_key_falls_back_to_loader(self):
+        """When master_key is not supplied, generate_litellm_config calls the loader."""
+        config = generate_litellm_config([])
+        mk = config["general_settings"]["master_key"]
+        assert mk.startswith("sk-taos-")
+
+
+class TestProxyConsistency:
+    """The proxy must use the SAME key for LITELLM_MASTER_KEY env and /key/generate auth."""
+
+    @pytest.mark.asyncio
+    async def test_proxy_env_and_bearer_use_same_key(self, tmp_path, monkeypatch):
+        """LITELLM_MASTER_KEY env and the Authorization header must match."""
+        import shutil
+        import tinyagentos.llm_proxy as mod
+
+        class _FakeClient:
+            def __init__(self, *a, **kw):
+                pass
+            async def __aenter__(self):
+                return self
+            async def __aexit__(self, *exc):
+                return False
+            async def get(self, url):
+                raise RuntimeError("no proxy")
+
+        monkeypatch.setattr(mod.httpx, "AsyncClient", _FakeClient)
+        monkeypatch.setattr(mod, "_pids_listening_on", lambda port: [])
+        monkeypatch.setattr(shutil, "which", lambda _: "/fake/litellm")
+
+        captured: dict = {}
+
+        class _FakePopen:
+            def __init__(self, *args, **kwargs):
+                captured["env"] = kwargs.get("env") or {}
+                raise FileNotFoundError("stubbed")
+
+        monkeypatch.setattr(mod.subprocess, "Popen", _FakePopen)
+
+        proxy = mod.LLMProxy(port=14099, data_dir=tmp_path)
+        await proxy.start(backends=[])
+
+        env_key = captured["env"].get("LITELLM_MASTER_KEY", "")
+        file_key = get_litellm_master_key(tmp_path)
+        assert env_key == file_key, (
+            "LITELLM_MASTER_KEY env var must match the on-disk key so the "
+            "controller can auth against its own proxy"
+        )
+        assert env_key.startswith("sk-taos-")
+
+    @pytest.mark.asyncio
+    async def test_create_agent_key_header_matches_env_key(self, tmp_path, monkeypatch):
+        """Bearer token in /key/generate request must equal the generated master key."""
+        import tinyagentos.llm_proxy as mod
+
+        expected_key = get_litellm_master_key(tmp_path)
+        captured_headers: list[dict] = []
+
+        class _FakeResp:
+            status_code = 200
+            def json(self):
+                return {"key": "sk-virtual-abc"}
+
+        class _FakeClient:
+            def __init__(self, *a, **kw):
+                pass
+            async def __aenter__(self):
+                return self
+            async def __aexit__(self, *exc):
+                return False
+            async def post(self, url, json=None, headers=None):
+                captured_headers.append(headers or {})
+                return _FakeResp()
+
+        monkeypatch.setattr(mod.httpx, "AsyncClient", _FakeClient)
+
+        proxy = mod.LLMProxy(port=14098, database_url="postgres://x:y@h/db", data_dir=tmp_path)
+
+        class _FakeProc:
+            def poll(self):
+                return None
+        proxy._process = _FakeProc()
+
+        await proxy.create_agent_key("test-agent")
+
+        assert captured_headers, "No HTTP call was made"
+        auth = captured_headers[0].get("Authorization", "")
+        assert auth == f"Bearer {expected_key}"

--- a/tests/test_llm_proxy.py
+++ b/tests/test_llm_proxy.py
@@ -3,11 +3,11 @@ from unittest.mock import patch
 import pytest
 from tinyagentos.llm_proxy import (
     EMBEDDING_ALIAS,
-    TAOS_LITELLM_MASTER_KEY,
     _is_embedding_model,
     generate_litellm_config,
     LLMProxy,
 )
+from tinyagentos.litellm_config import get_litellm_master_key
 
 
 class TestConfigGeneration:
@@ -26,13 +26,14 @@ class TestConfigGeneration:
         config = generate_litellm_config([])
         assert config["model_list"] == []
 
-    def test_config_emits_master_key(self):
-        """general_settings.master_key must carry the shared taOS master
-        key so LiteLLM rejects unauthenticated requests and accepts the
-        value the deployer injects into every agent container."""
-        config = generate_litellm_config([])
-        assert config["general_settings"]["master_key"] == "sk-taos-master"
-        assert config["general_settings"]["master_key"] == TAOS_LITELLM_MASTER_KEY
+    def test_config_emits_master_key(self, tmp_path):
+        """general_settings.master_key must carry the per-install taOS master
+        key (generated and persisted on first use) so LiteLLM rejects
+        unauthenticated requests and every internal admin call uses the same value."""
+        key = get_litellm_master_key(tmp_path)
+        config = generate_litellm_config([], master_key=key)
+        assert config["general_settings"]["master_key"] == key
+        assert config["general_settings"]["master_key"].startswith("sk-taos-")
 
     def test_ollama_backend_uses_ollama_prefix(self):
         backends = [{"name": "local", "type": "ollama", "url": "http://localhost:11434", "priority": 1}]
@@ -308,7 +309,7 @@ class TestDatabaseUrlPropagation:
         await p.start(backends=[])
 
         assert captured["env"]["DATABASE_URL"] == "postgresql://fake:pw@host/db"
-        assert captured["env"]["LITELLM_MASTER_KEY"] == "sk-taos-master"
+        assert captured["env"]["LITELLM_MASTER_KEY"].startswith("sk-taos-")
 
     @pytest.mark.asyncio
     async def test_start_omits_database_url_when_unset(self, monkeypatch):

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -1,7 +1,15 @@
 import pytest
 import pytest_asyncio
 
-from tinyagentos.secrets import SecretsStore, _encrypt, _decrypt
+from tinyagentos.secrets import (
+    SecretsStore,
+    _FERNET_PREFIX,
+    _encrypt,
+    _decrypt,
+    _xor_decrypt,
+    _xor_key,
+)
+import base64
 
 
 @pytest_asyncio.fixture
@@ -13,22 +21,49 @@ async def store(tmp_path):
 
 
 class TestEncryption:
-    def test_encrypt_decrypt_roundtrip(self):
+    def test_encrypt_decrypt_roundtrip_xor(self):
+        """Legacy XOR path (no key_dir) must still round-trip for migration."""
         original = "sk-abc123-secret-key"
         encrypted = _encrypt(original)
         assert encrypted != original
         assert _decrypt(encrypted) == original
 
-    def test_encrypt_produces_base64(self):
+    def test_encrypt_produces_base64_xor(self):
+        """XOR path output is valid base64."""
         encrypted = _encrypt("hello")
-        # Should be valid base64
-        import base64
-        base64.b64decode(encrypted)  # Should not raise
+        base64.b64decode(encrypted)  # should not raise
 
     def test_encrypt_different_values_differ(self):
         a = _encrypt("value-a")
         b = _encrypt("value-b")
         assert a != b
+
+    def test_fernet_encrypt_decrypt_roundtrip(self, tmp_path):
+        """Fernet path round-trips correctly."""
+        original = "sk-fernet-test-value"
+        encrypted = _encrypt(original, key_dir=tmp_path)
+        assert encrypted.startswith(_FERNET_PREFIX)
+        assert _decrypt(encrypted, key_dir=tmp_path) == original
+
+    def test_fernet_ciphertext_differs_from_plaintext(self, tmp_path):
+        encrypted = _encrypt("hello", key_dir=tmp_path)
+        assert encrypted != "hello"
+
+    def test_fernet_key_persists_across_calls(self, tmp_path):
+        """Same key_dir produces consistent decryption across two calls."""
+        enc = _encrypt("persist-test", key_dir=tmp_path)
+        assert _decrypt(enc, key_dir=tmp_path) == "persist-test"
+
+    def test_xor_to_fernet_migration_decrypt(self, tmp_path):
+        """_decrypt transparently decodes an old XOR ciphertext when key_dir given."""
+        # Produce a raw XOR ciphertext (no prefix, no key_dir).
+        key = _xor_key()
+        data = b"legacy-secret"
+        xor_blob = base64.b64encode(
+            bytes(b ^ key[i % len(key)] for i, b in enumerate(data))
+        ).decode()
+        # Should decode without error even with key_dir supplied.
+        assert _decrypt(xor_blob, key_dir=tmp_path) == "legacy-secret"
 
 
 @pytest.mark.asyncio

--- a/tests/test_secrets_fernet.py
+++ b/tests/test_secrets_fernet.py
@@ -1,0 +1,180 @@
+"""Tests for Fernet encryption + XOR→Fernet migration in SecretsStore (Fix B / issue #637)."""
+from __future__ import annotations
+
+import base64
+import stat
+
+import pytest
+import pytest_asyncio
+
+import tinyagentos.secrets as sec_mod
+from tinyagentos.secrets import (
+    SecretsStore,
+    _FERNET_PREFIX,
+    _encrypt,
+    _decrypt,
+    _get_fernet_key,
+    _xor_key,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_fernet_cache():
+    sec_mod._fernet_key_cache.clear()
+    yield
+    sec_mod._fernet_key_cache.clear()
+
+
+@pytest_asyncio.fixture
+async def store(tmp_path):
+    s = SecretsStore(tmp_path / "secrets.db")
+    await s.init()
+    yield s
+    await s.close()
+
+
+class TestFernetKeyFile:
+    def test_key_file_created_on_first_use(self, tmp_path):
+        _get_fernet_key(tmp_path)
+        assert (tmp_path / ".secrets_key").exists()
+
+    def test_key_file_is_32_bytes(self, tmp_path):
+        _get_fernet_key(tmp_path)
+        raw = (tmp_path / ".secrets_key").read_bytes()
+        assert len(raw) == 32
+
+    def test_key_file_mode_600(self, tmp_path):
+        _get_fernet_key(tmp_path)
+        mode = stat.S_IMODE((tmp_path / ".secrets_key").stat().st_mode)
+        assert mode == 0o600
+
+    def test_key_stable_across_calls(self, tmp_path):
+        k1 = _get_fernet_key(tmp_path)
+        k2 = _get_fernet_key(tmp_path)
+        assert k1 == k2
+
+    def test_key_stable_after_cache_clear(self, tmp_path):
+        k1 = _get_fernet_key(tmp_path)
+        sec_mod._fernet_key_cache.clear()
+        k2 = _get_fernet_key(tmp_path)
+        assert k1 == k2
+
+
+class TestFernetEncryptDecrypt:
+    def test_roundtrip(self, tmp_path):
+        enc = _encrypt("my-api-key", key_dir=tmp_path)
+        assert _decrypt(enc, key_dir=tmp_path) == "my-api-key"
+
+    def test_ciphertext_has_prefix(self, tmp_path):
+        enc = _encrypt("hello", key_dir=tmp_path)
+        assert enc.startswith(_FERNET_PREFIX)
+
+    def test_two_encryptions_differ(self, tmp_path):
+        """Fernet uses a random IV per encryption — same plaintext → different token."""
+        enc1 = _encrypt("same", key_dir=tmp_path)
+        enc2 = _encrypt("same", key_dir=tmp_path)
+        assert enc1 != enc2
+
+    def test_xor_migration_transparent(self, tmp_path):
+        """_decrypt handles an old XOR blob transparently when key_dir is given."""
+        key = _xor_key()
+        data = b"old-secret-value"
+        xor_blob = base64.b64encode(
+            bytes(b ^ key[i % len(key)] for i, b in enumerate(data))
+        ).decode()
+        assert not xor_blob.startswith(_FERNET_PREFIX)
+        assert _decrypt(xor_blob, key_dir=tmp_path) == "old-secret-value"
+
+
+class TestSecretsStoreFernet:
+    @pytest.mark.asyncio
+    async def test_new_secrets_encrypted_with_fernet(self, store, tmp_path):
+        """Secrets added after the upgrade are stored with Fernet ciphertext."""
+        await store.add("API_KEY", "sk-newvalue")
+        # Inspect raw DB value.
+        async with store._db.execute(
+            "SELECT value FROM secrets WHERE name = 'API_KEY'"
+        ) as cur:
+            row = await cur.fetchone()
+        assert row is not None
+        assert row[0].startswith(_FERNET_PREFIX)
+
+    @pytest.mark.asyncio
+    async def test_fernet_roundtrip_via_store(self, store):
+        await store.add("FERNET_KEY", "fernet-test-value")
+        result = await store.get("FERNET_KEY")
+        assert result is not None
+        assert result["value"] == "fernet-test-value"
+
+    @pytest.mark.asyncio
+    async def test_xor_migration_on_get(self, store, tmp_path):
+        """A secret stored with XOR is transparently migrated to Fernet on first get()."""
+        # Insert a raw XOR ciphertext directly into the DB.
+        key = _xor_key()
+        plaintext = b"legacy-api-key"
+        xor_blob = base64.b64encode(
+            bytes(b ^ key[i % len(key)] for i, b in enumerate(plaintext))
+        ).decode()
+        import time as _time
+        now = int(_time.time())
+        await store._db.execute(
+            "INSERT INTO secrets (name, category, value, description, created_at, updated_at) "
+            "VALUES (?, 'general', ?, '', ?, ?)",
+            ("LEGACY", xor_blob, now, now),
+        )
+        await store._db.commit()
+
+        # get() should decrypt and return the plaintext.
+        result = await store.get("LEGACY")
+        assert result is not None
+        assert result["value"] == "legacy-api-key"
+
+        # After the first get(), the stored value should now use Fernet.
+        async with store._db.execute(
+            "SELECT value FROM secrets WHERE name = 'LEGACY'"
+        ) as cur:
+            row = await cur.fetchone()
+        assert row[0].startswith(_FERNET_PREFIX), (
+            "XOR ciphertext should have been migrated to Fernet on first read"
+        )
+
+    @pytest.mark.asyncio
+    async def test_xor_migration_preserves_value_on_second_get(self, store, tmp_path):
+        """After migration, get() still returns the correct plaintext."""
+        key = _xor_key()
+        plaintext = b"migrate-me"
+        xor_blob = base64.b64encode(
+            bytes(b ^ key[i % len(key)] for i, b in enumerate(plaintext))
+        ).decode()
+        import time as _time
+        now = int(_time.time())
+        await store._db.execute(
+            "INSERT INTO secrets (name, category, value, description, created_at, updated_at) "
+            "VALUES (?, 'general', ?, '', ?, ?)",
+            ("MIGRATE", xor_blob, now, now),
+        )
+        await store._db.commit()
+
+        first = await store.get("MIGRATE")
+        second = await store.get("MIGRATE")
+        assert first["value"] == "migrate-me"
+        assert second["value"] == "migrate-me"
+
+    @pytest.mark.asyncio
+    async def test_update_re_encrypts_with_fernet(self, store):
+        await store.add("UPKEY", "old-val")
+        await store.update("UPKEY", value="new-val")
+        async with store._db.execute(
+            "SELECT value FROM secrets WHERE name = 'UPKEY'"
+        ) as cur:
+            row = await cur.fetchone()
+        assert row[0].startswith(_FERNET_PREFIX)
+        result = await store.get("UPKEY")
+        assert result["value"] == "new-val"
+
+    @pytest.mark.asyncio
+    async def test_agent_secrets_fernet(self, store):
+        await store.add("AGENT_KEY", "agent-val", agents=["bot-1"])
+        secrets = await store.get_agent_secrets("bot-1")
+        assert len(secrets) == 1
+        assert secrets[0]["value"] == "agent-val"

--- a/tests/test_secrets_fernet.py
+++ b/tests/test_secrets_fernet.py
@@ -59,6 +59,26 @@ class TestFernetKeyFile:
         k2 = _get_fernet_key(tmp_path)
         assert k1 == k2
 
+    def test_malformed_key_file_raises_not_regenerates(self, tmp_path):
+        """A key file with wrong length must raise ValueError, not silently regenerate.
+
+        If we regenerated, every already-encrypted secret would become
+        unrecoverable (silent data loss).
+        """
+        key_path = tmp_path / ".secrets_key"
+        key_path.write_bytes(b"tooshort")
+        with pytest.raises(ValueError, match="Corrupt Fernet key file"):
+            _get_fernet_key(tmp_path)
+        # The bad file must not have been overwritten.
+        assert key_path.read_bytes() == b"tooshort"
+
+    def test_empty_key_file_raises(self, tmp_path):
+        """Zero-length key file is also malformed — must not regenerate."""
+        key_path = tmp_path / ".secrets_key"
+        key_path.write_bytes(b"")
+        with pytest.raises(ValueError, match="Corrupt Fernet key file"):
+            _get_fernet_key(tmp_path)
+
 
 class TestFernetEncryptDecrypt:
     def test_roundtrip(self, tmp_path):

--- a/tests/test_taos_agent_chat.py
+++ b/tests/test_taos_agent_chat.py
@@ -291,7 +291,8 @@ async def test_ensure_server_uses_agent_key_when_available(tmp_path, monkeypatch
 async def test_ensure_server_falls_back_to_master_key(tmp_path, monkeypatch):
     """When create_agent_key returns None, the server falls back to the master key."""
     import tinyagentos.taos_agent_runtime as rt
-    from tinyagentos.llm_proxy import TAOS_LITELLM_MASTER_KEY
+    from tinyagentos.litellm_config import get_litellm_master_key
+    expected_master_key = get_litellm_master_key(tmp_path)
 
     spawned_cfgs: list = []
 
@@ -328,8 +329,8 @@ async def test_ensure_server_falls_back_to_master_key(tmp_path, monkeypatch):
     await rt.ensure_taos_opencode_server(state, "gpt-4o")
 
     assert len(spawned_cfgs) == 1
-    assert spawned_cfgs[0].litellm_key == TAOS_LITELLM_MASTER_KEY
-    assert state.taos_opencode_key == TAOS_LITELLM_MASTER_KEY
+    assert spawned_cfgs[0].litellm_key == expected_master_key
+    assert state.taos_opencode_key == expected_master_key
 
 
 @pytest.mark.asyncio

--- a/tests/test_update_agent_key.py
+++ b/tests/test_update_agent_key.py
@@ -24,6 +24,7 @@ class _FakeProxy:
         self.url = "http://127.0.0.1:4000"
         self.database_url = "postgres://x" if db else None
         self._running = running
+        self._data_dir = None  # in-memory master key (no disk I/O in tests)
     def is_running(self): return self._running
 
 

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -293,6 +293,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         # agent picker can show a local model but chatting with it 400s
         # at the proxy because no alias exists for that model_name.
         registry=registry,
+        data_dir=data_dir,
     )
     channel_hub_router = MessageRouter()
     adapter_manager = AdapterManager(channel_hub_router)

--- a/tinyagentos/litellm_config.py
+++ b/tinyagentos/litellm_config.py
@@ -8,6 +8,9 @@ one-way: ``llm_proxy`` imports from here, never the reverse.
 from __future__ import annotations
 
 import logging
+import os
+import secrets as _secrets
+from pathlib import Path
 
 import httpx
 
@@ -21,12 +24,53 @@ logger = logging.getLogger(__name__)
 # See docs/design/framework-agnostic-runtime.md.
 EMBEDDING_ALIAS = "taos-embedding-default"
 
-# Shared master key used for LiteLLM auth. When LiteLLM runs without a
-# Postgres DB it cannot issue per-agent virtual keys, so every client
-# (openclaw gateway, host-side key admin calls) authenticates with this
-# single value. Written into the config yaml AND exported into the
-# litellm subprocess env so whichever source LiteLLM reads first agrees.
-TAOS_LITELLM_MASTER_KEY = "sk-taos-master"
+# Per-install master key cache — keyed by resolved data_dir so multiple
+# data dirs in the same process (tests) don't collide.
+_master_key_cache: dict[str, str] = {}
+
+
+def get_litellm_master_key(data_dir: Path | None = None) -> str:
+    """Return the per-install LiteLLM master key, generating it on first use.
+
+    The key is stored at ``<data_dir>/.litellm_master_key`` with mode 0600.
+    On first call for a given data_dir the file is created with a random key;
+    subsequent calls (same process or new process) re-read it from disk.
+
+    When ``data_dir`` is None the call falls back to a process-lifetime
+    in-memory key so callers that don't know the data dir (e.g. tests) still
+    get a consistent value within a single process.
+
+    The master key is used only to authorise admin operations against the
+    LiteLLM proxy (key generation, key deletion, /v1/models).  Per-agent
+    virtual keys stored in Postgres are independent tokens and are NOT
+    invalidated when the master key changes.
+    """
+    cache_key = str(data_dir) if data_dir is not None else "__in_memory__"
+    if cache_key in _master_key_cache:
+        return _master_key_cache[cache_key]
+
+    if data_dir is not None:
+        key_path = Path(data_dir) / ".litellm_master_key"
+        if key_path.exists():
+            key = key_path.read_text().strip()
+            if key:
+                _master_key_cache[cache_key] = key
+                return key
+        # Generate and persist a new per-install key.
+        key = "sk-taos-" + _secrets.token_urlsafe(32)
+        key_path.parent.mkdir(parents=True, exist_ok=True)
+        # Write to a temp file then rename for atomicity.
+        tmp = key_path.with_suffix(".tmp")
+        tmp.write_text(key)
+        os.chmod(tmp, 0o600)
+        tmp.rename(key_path)
+        logger.info("Generated new per-install LiteLLM master key at %s", key_path)
+    else:
+        # No data dir — generate an in-memory key for this process lifetime.
+        key = "sk-taos-" + _secrets.token_urlsafe(32)
+
+    _master_key_cache[cache_key] = key
+    return key
 
 
 def _is_embedding_model(name: str) -> bool:
@@ -132,6 +176,7 @@ def generate_litellm_config(
     default_model: str = "default",
     *,
     registry=None,
+    master_key: str | None = None,
 ) -> dict:
     """Generate LiteLLM config from TinyAgentOS backend list.
 
@@ -303,6 +348,7 @@ def generate_litellm_config(
                     })
                     aliased_embedding_claimed = True
 
+    resolved_master_key = master_key if master_key is not None else get_litellm_master_key()
     return {
         "model_list": model_list,
         "router_settings": {
@@ -312,7 +358,7 @@ def generate_litellm_config(
             "enable_pre_call_checks": False,
         },
         "general_settings": {
-            "master_key": TAOS_LITELLM_MASTER_KEY,
+            "master_key": resolved_master_key,
             "background_health_checks": False,
             "disable_spend_logs": True,
         },

--- a/tinyagentos/litellm_config.py
+++ b/tinyagentos/litellm_config.py
@@ -56,15 +56,27 @@ def get_litellm_master_key(data_dir: Path | None = None) -> str:
             if key:
                 _master_key_cache[cache_key] = key
                 return key
-        # Generate and persist a new per-install key.
+        # Generate and persist a new per-install key using O_CREAT|O_EXCL so
+        # only one concurrent caller wins the creation race.  The loser gets
+        # EEXIST (FileExistsError) and reads whatever the winner wrote.
         key = "sk-taos-" + _secrets.token_urlsafe(32)
         key_path.parent.mkdir(parents=True, exist_ok=True)
-        # Write to a temp file then rename for atomicity.
-        tmp = key_path.with_suffix(".tmp")
-        tmp.write_text(key)
-        os.chmod(tmp, 0o600)
-        tmp.rename(key_path)
-        logger.info("Generated new per-install LiteLLM master key at %s", key_path)
+        encoded = key.encode()
+        try:
+            fd = os.open(str(key_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+            try:
+                os.write(fd, encoded)
+            finally:
+                os.close(fd)
+            logger.info("Generated new per-install LiteLLM master key at %s", key_path)
+        except FileExistsError:
+            # Another process/thread won the race — read the key it wrote.
+            key = key_path.read_text().strip()
+            if not key:
+                raise RuntimeError(
+                    f"LiteLLM master key file {key_path} exists but is empty; "
+                    "remove it and restart to regenerate."
+                )
     else:
         # No data dir — generate an in-memory key for this process lifetime.
         key = "sk-taos-" + _secrets.token_urlsafe(32)

--- a/tinyagentos/llm_proxy.py
+++ b/tinyagentos/llm_proxy.py
@@ -21,9 +21,9 @@ import httpx
 from tinyagentos.providers import CLOUD_TYPES as CLOUD_BACKEND_TYPES
 from tinyagentos.litellm_config import (
     EMBEDDING_ALIAS,
-    TAOS_LITELLM_MASTER_KEY,
     _is_embedding_model,
     generate_litellm_config,
+    get_litellm_master_key,
 )
 
 logger = logging.getLogger(__name__)
@@ -83,6 +83,7 @@ class LLMProxy:
         database_url: str | None = None,
         local_token: str | None = None,
         registry=None,
+        data_dir: Path | None = None,
     ):
         self.port = port
         self.config_dir = config_dir or Path("/tmp/taos-litellm")
@@ -99,6 +100,9 @@ class LLMProxy:
         # gemma-4-e2b-gguf" would 400 on the proxy because the alias was
         # never created.
         self._registry = registry
+        # data_dir drives the per-install master key file (.litellm_master_key).
+        # When None, an in-memory key is used (acceptable in tests / routing-only mode).
+        self._data_dir = data_dir
         self._process: subprocess.Popen | None = None
 
     @property
@@ -126,7 +130,11 @@ class LLMProxy:
         callback code in one place.
         """
         self.config_dir.mkdir(parents=True, exist_ok=True)
-        config = generate_litellm_config(backends, registry=self._registry)
+        config = generate_litellm_config(
+            backends,
+            registry=self._registry,
+            master_key=get_litellm_master_key(self._data_dir),
+        )
         config_path = self.config_dir / "litellm_config.yaml"
 
         import yaml
@@ -224,7 +232,7 @@ class LLMProxy:
         # whichever path the subprocess reads first matches the value the
         # deployer uses when auth'ing /key/generate and agent requests.
         env = os.environ.copy()
-        env["LITELLM_MASTER_KEY"] = TAOS_LITELLM_MASTER_KEY
+        env["LITELLM_MASTER_KEY"] = get_litellm_master_key(self._data_dir)
         # Forward the local auth token so the TaosLiteLLMCallback inside
         # the subprocess can POST to taOS's /api/trace (otherwise 401).
         if self.local_token:
@@ -344,7 +352,7 @@ class LLMProxy:
                 if max_budget is not None:
                     body["max_budget"] = max_budget
                 resp = await client.post(f"{self.url}/key/generate", json=body,
-                                          headers={"Authorization": f"Bearer {TAOS_LITELLM_MASTER_KEY}"})
+                                          headers={"Authorization": f"Bearer {get_litellm_master_key(self._data_dir)}"})
                 if resp.status_code == 200:
                     data = resp.json()
                     return data.get("key", data.get("token"))
@@ -379,7 +387,7 @@ class LLMProxy:
                 resp = await client.post(
                     f"{self.url}/key/update",
                     json={"key": key, "models": models},
-                    headers={"Authorization": f"Bearer {TAOS_LITELLM_MASTER_KEY}"},
+                    headers={"Authorization": f"Bearer {get_litellm_master_key(self._data_dir)}"},
                 )
                 if resp.status_code == 200:
                     return True
@@ -398,7 +406,7 @@ class LLMProxy:
         try:
             async with httpx.AsyncClient(timeout=10) as client:
                 resp = await client.post(f"{self.url}/key/delete", json={"keys": [key]},
-                                          headers={"Authorization": f"Bearer {TAOS_LITELLM_MASTER_KEY}"})
+                                          headers={"Authorization": f"Bearer {get_litellm_master_key(self._data_dir)}"})
                 if resp.status_code == 200:
                     return True
                 logger.warning(
@@ -416,7 +424,7 @@ class LLMProxy:
         try:
             async with httpx.AsyncClient(timeout=10) as client:
                 resp = await client.get(f"{self.url}/key/info", params={"key": key},
-                                         headers={"Authorization": f"Bearer {TAOS_LITELLM_MASTER_KEY}"})
+                                         headers={"Authorization": f"Bearer {get_litellm_master_key(self._data_dir)}"})
                 if resp.status_code == 200:
                     return resp.json()
                 logger.warning(

--- a/tinyagentos/routes/providers.py
+++ b/tinyagentos/routes/providers.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel
 from tinyagentos.backend_adapters import get_adapter
 from tinyagentos.config import save_config_locked, VALID_BACKEND_TYPES
 from tinyagentos.lifecycle_manager import LifecycleManager
-from tinyagentos.llm_proxy import TAOS_LITELLM_MASTER_KEY
+from tinyagentos.litellm_config import get_litellm_master_key
 from tinyagentos.providers import CLOUD_TYPES
 
 logger = logging.getLogger(__name__)
@@ -241,7 +241,7 @@ async def _fetch_litellm_models(proxy) -> list[dict]:
         async with httpx.AsyncClient(timeout=5.0) as client:
             resp = await client.get(
                 f"{proxy.url}/v1/models",
-                headers={"Authorization": f"Bearer {TAOS_LITELLM_MASTER_KEY}"},
+                headers={"Authorization": f"Bearer {get_litellm_master_key(getattr(proxy, '_data_dir', None))}"},
             )
         if resp.status_code != 200:
             logger.warning(

--- a/tinyagentos/secrets.py
+++ b/tinyagentos/secrets.py
@@ -5,6 +5,10 @@ import hashlib
 import os
 import time
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from cryptography.fernet import Fernet
 
 from tinyagentos.base_store import BaseStore
 
@@ -72,11 +76,16 @@ def _get_fernet_key(key_dir: Path) -> bytes:
     key_path = Path(key_dir) / ".secrets_key"
     if key_path.exists():
         raw = key_path.read_bytes()
-        if len(raw) == 32:
-            _fernet_key_cache[cache_key] = raw
-            return raw
+        if len(raw) != 32:
+            raise ValueError(
+                f"Corrupt Fernet key file at {key_path}: expected 32 bytes, got "
+                f"{len(raw)}. Remove the file only if you have no secrets to recover, "
+                "then restart to generate a fresh key."
+            )
+        _fernet_key_cache[cache_key] = raw
+        return raw
 
-    # Generate a fresh random 32-byte key.
+    # Generate a fresh random 32-byte key only when the file does not exist.
     raw = os.urandom(32)
     key_path.parent.mkdir(parents=True, exist_ok=True)
     tmp = key_path.with_suffix(".tmp")

--- a/tinyagentos/secrets.py
+++ b/tinyagentos/secrets.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import os
 import time
 from pathlib import Path
 
@@ -31,10 +32,13 @@ CREATE TABLE IF NOT EXISTS secret_categories (
 
 DEFAULT_CATEGORIES = ["api-keys", "tokens", "credentials", "webhooks", "general"]
 
+# Prefix written into every Fernet-encrypted value so decrypt can distinguish
+# new (Fernet) from old (XOR) ciphertext and migrate transparently.
+_FERNET_PREFIX = "fernet:"
 
-# Simple XOR-based obfuscation with machine-specific key
-# Not military-grade crypto, but prevents casual reading of the DB file
-def _get_key() -> bytes:
+
+def _xor_key() -> bytes:
+    """Derive the legacy XOR key from /etc/machine-id (or a fixed fallback)."""
     machine_id_path = Path("/etc/machine-id")
     machine_id = (
         machine_id_path.read_text().strip()
@@ -44,22 +48,95 @@ def _get_key() -> bytes:
     return hashlib.sha256(machine_id.encode()).digest()
 
 
-def _encrypt(value: str) -> str:
-    key = _get_key()
-    data = value.encode()
-    encrypted = bytes(b ^ key[i % len(key)] for i, b in enumerate(data))
-    return base64.b64encode(encrypted).decode()
-
-
-def _decrypt(encrypted: str) -> str:
-    key = _get_key()
+def _xor_decrypt(encrypted: str) -> str:
+    """Decrypt an XOR-obfuscated ciphertext (legacy format)."""
+    key = _xor_key()
     data = base64.b64decode(encrypted)
-    decrypted = bytes(b ^ key[i % len(key)] for i, b in enumerate(data))
-    return decrypted.decode()
+    return bytes(b ^ key[i % len(key)] for i, b in enumerate(data)).decode()
+
+
+# Per-process Fernet key cache keyed by key_dir path string.
+_fernet_key_cache: dict[str, bytes] = {}
+
+
+def _get_fernet_key(key_dir: Path) -> bytes:
+    """Return the 32-byte encryption key for *key_dir*, generating on first use.
+
+    Stored at ``<key_dir>/.secrets_key`` with mode 0600.  The file holds raw
+    bytes (not base64) so a stripped text editor cannot accidentally corrupt it.
+    """
+    cache_key = str(key_dir)
+    if cache_key in _fernet_key_cache:
+        return _fernet_key_cache[cache_key]
+
+    key_path = Path(key_dir) / ".secrets_key"
+    if key_path.exists():
+        raw = key_path.read_bytes()
+        if len(raw) == 32:
+            _fernet_key_cache[cache_key] = raw
+            return raw
+
+    # Generate a fresh random 32-byte key.
+    raw = os.urandom(32)
+    key_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = key_path.with_suffix(".tmp")
+    tmp.write_bytes(raw)
+    os.chmod(tmp, 0o600)
+    tmp.rename(key_path)
+    _fernet_key_cache[cache_key] = raw
+    return raw
+
+
+def _fernet_token(key_dir: Path) -> "Fernet":
+    """Return a :class:`cryptography.fernet.Fernet` instance for *key_dir*."""
+    from cryptography.fernet import Fernet
+    raw = _get_fernet_key(key_dir)
+    # Fernet requires a 32-byte URL-safe base64-encoded key.
+    return Fernet(base64.urlsafe_b64encode(raw))
+
+
+def _encrypt(value: str, key_dir: Path | None = None) -> str:
+    """Encrypt *value* with Fernet when *key_dir* is provided.
+
+    Falls back to the legacy XOR obfuscation when *key_dir* is None so the
+    module stays importable in test contexts that don't supply a data dir.
+    The returned string is prefixed with ``_FERNET_PREFIX`` when using Fernet
+    so :func:`_decrypt` can detect the format.
+    """
+    if key_dir is None:
+        # Legacy path — only reached in tests / callers that don't provide a dir.
+        key = _xor_key()
+        data = value.encode()
+        encrypted = bytes(b ^ key[i % len(key)] for i, b in enumerate(data))
+        return base64.b64encode(encrypted).decode()
+    token = _fernet_token(key_dir).encrypt(value.encode()).decode()
+    return _FERNET_PREFIX + token
+
+
+def _decrypt(encrypted: str, key_dir: Path | None = None) -> str:
+    """Decrypt *encrypted* transparently handling both Fernet and XOR formats.
+
+    Migration path: if *encrypted* does NOT start with ``_FERNET_PREFIX`` it is
+    an old XOR ciphertext.  We decrypt with XOR and, when *key_dir* is provided,
+    immediately re-encrypt with Fernet and return the plaintext — the caller
+    (``SecretsStore``) is responsible for persisting the upgraded ciphertext.
+    """
+    if encrypted.startswith(_FERNET_PREFIX):
+        if key_dir is None:
+            raise ValueError("Fernet-encrypted secret requires key_dir to decrypt")
+        token = encrypted[len(_FERNET_PREFIX):]
+        return _fernet_token(key_dir).decrypt(token.encode()).decode()
+    # Legacy XOR ciphertext.
+    return _xor_decrypt(encrypted)
 
 
 class SecretsStore(BaseStore):
     SCHEMA = SECRETS_SCHEMA
+
+    def __init__(self, db_path: Path):
+        super().__init__(db_path)
+        # key_dir is the directory that holds .secrets_key (same as data_dir).
+        self._key_dir: Path = Path(db_path).parent
 
     async def _post_init(self) -> None:
         await self._db.execute("PRAGMA foreign_keys = ON")
@@ -70,6 +147,30 @@ class SecretsStore(BaseStore):
             )
         await self._db.commit()
 
+    def _enc(self, value: str) -> str:
+        return _encrypt(value, self._key_dir)
+
+    async def _dec(self, ciphertext: str, *, name: str = "", secret_id: int | None = None) -> str:
+        """Decrypt *ciphertext*, migrating XOR→Fernet transparently.
+
+        When an old XOR ciphertext is detected we decrypt it with the legacy
+        key, immediately re-encrypt with Fernet, and persist the upgraded value
+        so the migration is a one-time write per secret.
+        """
+        if ciphertext.startswith(_FERNET_PREFIX):
+            return _decrypt(ciphertext, self._key_dir)
+        # Legacy XOR — decrypt and re-encrypt with Fernet.
+        plaintext = _decrypt(ciphertext, None)
+        upgraded = _encrypt(plaintext, self._key_dir)
+        if secret_id is not None:
+            now = int(time.time())
+            await self._db.execute(
+                "UPDATE secrets SET value = ?, updated_at = ? WHERE id = ?",
+                (upgraded, now, secret_id),
+            )
+            await self._db.commit()
+        return plaintext
+
     async def add(
         self,
         name: str,
@@ -79,7 +180,7 @@ class SecretsStore(BaseStore):
         agents: list[str] | None = None,
     ) -> int:
         now = int(time.time())
-        encrypted = _encrypt(value)
+        encrypted = self._enc(value)
         cursor = await self._db.execute(
             "INSERT INTO secrets (name, category, value, description, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
             (name, category, encrypted, description, now, now),
@@ -107,7 +208,7 @@ class SecretsStore(BaseStore):
             "id": row[0],
             "name": row[1],
             "category": row[2],
-            "value": _decrypt(row[3]),
+            "value": await self._dec(row[3], name=row[1], secret_id=row[0]),
             "description": row[4],
             "created_at": row[5],
             "updated_at": row[6],
@@ -154,7 +255,7 @@ class SecretsStore(BaseStore):
         if value is not None:
             await self._db.execute(
                 "UPDATE secrets SET value = ?, updated_at = ? WHERE name = ?",
-                (_encrypt(value), now, name),
+                (self._enc(value), now, name),
             )
         if category is not None:
             await self._db.execute(
@@ -196,16 +297,16 @@ class SecretsStore(BaseStore):
             (agent_name,),
         ) as cursor:
             rows = await cursor.fetchall()
-        return [
-            {
+        result = []
+        for r in rows:
+            result.append({
                 "id": r[0],
                 "name": r[1],
                 "category": r[2],
-                "value": _decrypt(r[3]),
+                "value": await self._dec(r[3], name=r[1], secret_id=r[0]),
                 "description": r[4],
-            }
-            for r in rows
-        ]
+            })
+        return result
 
     async def get_categories(self) -> list[dict]:
         async with self._db.execute(

--- a/tinyagentos/taos_agent_runtime.py
+++ b/tinyagentos/taos_agent_runtime.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 import secrets
 
-from tinyagentos.llm_proxy import TAOS_LITELLM_MASTER_KEY
+from tinyagentos.litellm_config import get_litellm_master_key
 from tinyagentos.opencode_runtime import OpenCodeServer, OpenCodeServerConfig
 
 logger = logging.getLogger(__name__)
@@ -101,7 +101,7 @@ async def ensure_taos_opencode_server(app_state, model: str) -> OpenCodeServer:
                 except Exception:
                     logger.debug("taos_agent_runtime: persisting key failed", exc_info=True)
         if not litellm_key:
-            litellm_key = TAOS_LITELLM_MASTER_KEY
+            litellm_key = get_litellm_master_key(getattr(app_state, "data_dir", None))
         app_state.taos_opencode_key = litellm_key
 
         data_dir = getattr(app_state, "data_dir", None)


### PR DESCRIPTION
## Summary

- **Fix A — master key**: Replaces the hardcoded `sk-taos-master` constant with `get_litellm_master_key(data_dir)`. The key is persisted at `<data_dir>/.litellm_master_key` (mode 0600) and generated once per install using `secrets.token_urlsafe(32)`. `LLMProxy` stores `data_dir` and calls the loader in `write_config`, `start`, and every Bearer-auth'd admin call (`/key/generate`, `/key/update`, `/key/delete`, `/key/info`, `/v1/models`) so the YAML config, `LITELLM_MASTER_KEY` env var, and HTTP auth always agree.

- **Fix B — real encryption**: Replaces the XOR obfuscation in `secrets.py` with `cryptography.Fernet`. The 32-byte key is stored at `<data_dir>/.secrets_key` (mode 0600). Migration is transparent: on first `get()` of an old XOR-ciphered value, `SecretsStore._dec()` detects the missing `fernet:` prefix, decrypts with XOR, re-encrypts with Fernet, and persists the upgrade atomically.

## New dependency
None. `cryptography` is already a transitive dependency via `pywebpush>=1.14` (listed in `pyproject.toml`).

## Migration notes
- **Master key**: Existing installs have no `.litellm_master_key` file. On next start, a key is generated and written. All callers read the loader — no manual action needed. Per-agent virtual keys in the LiteLLM Postgres DB are independent tokens and are NOT invalidated.
- **Secrets**: Old XOR-encrypted values are re-encrypted with Fernet on first read. No secrets are lost. The `.secrets_key` file is created on first `SecretsStore` use.

## Test plan
- [ ] `tests/test_litellm_master_key.py` — new: key generation, file persistence, mode 0600, cache stability, proxy consistency (env == Bearer header)
- [ ] `tests/test_secrets_fernet.py` — new: Fernet key file, round-trip, XOR migration on `get()`, migration durability on second `get()`, agent secrets
- [ ] `tests/test_secrets.py` — extended: XOR legacy path, Fernet round-trip, migration via raw `_decrypt`
- [ ] `tests/test_llm_proxy.py` — updated: `test_config_emits_master_key` uses generated key; `test_start_passes_database_url_when_set` checks prefix not literal
- [ ] `tests/test_taos_agent_chat.py` — updated: fallback key asserts against `get_litellm_master_key(tmp_path)` not the old constant
- [ ] `tests/test_deployer.py` — updated: master-key leak check uses generated key value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test coverage for master key generation, persistence, and consistency
  * Added tests for encryption with automatic migration from legacy format
  * Enhanced security-related test suite across authentication and secrets management

* **Refactor**
  * Improved security with per-installation master key generation and persistent storage
  * Upgraded encryption to use modern cryptographic standards with transparent migration from legacy format

<!-- end of auto-generated comment: release notes by coderabbit.ai -->