### PR TITLE
fix(db): SQLite WAL + NORMAL sync, lightweight migration framework, fix sync-in-async (#653)

### DIFF
--- a/tests/test_db_migrations.py
+++ b/tests/test_db_migrations.py
@@ -1,0 +1,218 @@
+"""Tests for the lightweight db_migrations module.
+
+Covers:
+  - Fresh DB: migrations applied in order, tracking table populated.
+  - Existing DB: baselines at latest version without re-running SQL.
+  - Idempotent re-run: running again does nothing.
+  - Callable migration: Python function accepted alongside SQL strings.
+  - WAL pragma helpers: journal_mode and synchronous set correctly.
+  - Async variants: run_migrations_async / apply_wal_pragmas_async.
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+from tinyagentos.db_migrations import (
+    apply_wal_pragmas,
+    apply_wal_pragmas_async,
+    run_migrations,
+    run_migrations_async,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _open(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(path))
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _applied_versions(conn: sqlite3.Connection) -> list[int]:
+    try:
+        rows = conn.execute(
+            "SELECT version FROM schema_migrations ORDER BY version"
+        ).fetchall()
+        return [r[0] for r in rows]
+    except sqlite3.OperationalError:
+        return []
+
+
+V1_SQL = "CREATE TABLE IF NOT EXISTS items (id INTEGER PRIMARY KEY, name TEXT NOT NULL);"
+V2_SQL = "ALTER TABLE items ADD COLUMN tag TEXT;"
+
+
+# ---------------------------------------------------------------------------
+# Sync API
+# ---------------------------------------------------------------------------
+
+class TestRunMigrationsSync:
+    def test_fresh_db_applies_all(self, tmp_path):
+        conn = _open(tmp_path / "fresh.db")
+        migrations = [(1, V1_SQL), (2, V2_SQL)]
+        run_migrations(conn, migrations)
+
+        assert _applied_versions(conn) == [1, 2]
+        # Both columns should exist
+        conn.execute("INSERT INTO items (id, name, tag) VALUES (1, 'a', 'x')")
+        row = conn.execute("SELECT tag FROM items WHERE id = 1").fetchone()
+        assert row[0] == "x"
+        conn.close()
+
+    def test_existing_db_baselines_without_rerun(self, tmp_path):
+        db_path = tmp_path / "existing.db"
+        # Simulate a DB created before the migration system: tables exist, no
+        # schema_migrations table.
+        conn = _open(db_path)
+        conn.executescript(V1_SQL)
+        conn.executescript(V2_SQL)
+        conn.commit()
+        conn.close()
+
+        # Now run migrations — should baseline, NOT re-run SQL.
+        conn = _open(db_path)
+        migrations = [(1, V1_SQL), (2, V2_SQL)]
+        run_migrations(conn, migrations)
+
+        # Should be baselined at v2.
+        assert _applied_versions(conn) == [2]
+        conn.close()
+
+    def test_idempotent_rerun(self, tmp_path):
+        conn = _open(tmp_path / "idem.db")
+        migrations = [(1, V1_SQL)]
+        run_migrations(conn, migrations)
+        # Run again — should not raise or duplicate records.
+        run_migrations(conn, migrations)
+        assert _applied_versions(conn) == [1]
+        conn.close()
+
+    def test_partial_apply(self, tmp_path):
+        """Apply v1 first, then add v2 in a second call."""
+        conn = _open(tmp_path / "partial.db")
+        run_migrations(conn, [(1, V1_SQL)])
+        assert _applied_versions(conn) == [1]
+
+        run_migrations(conn, [(1, V1_SQL), (2, V2_SQL)])
+        assert _applied_versions(conn) == [1, 2]
+        conn.close()
+
+    def test_callable_migration(self, tmp_path):
+        """A callable is accepted instead of a SQL string."""
+        conn = _open(tmp_path / "callable.db")
+
+        def _create_table(c: sqlite3.Connection) -> None:
+            c.execute(
+                "CREATE TABLE IF NOT EXISTS widgets (id INTEGER PRIMARY KEY)"
+            )
+            c.commit()
+
+        run_migrations(conn, [(1, _create_table)])
+        assert _applied_versions(conn) == [1]
+        # Table should exist.
+        conn.execute("INSERT INTO widgets (id) VALUES (42)")
+        assert conn.execute("SELECT id FROM widgets").fetchone()[0] == 42
+        conn.close()
+
+    def test_empty_migrations_list(self, tmp_path):
+        conn = _open(tmp_path / "empty.db")
+        run_migrations(conn, [])
+        # Tracking table still created.
+        assert _applied_versions(conn) == []
+        conn.close()
+
+
+class TestApplyWalPragmasSync:
+    def test_wal_mode_set(self, tmp_path):
+        conn = _open(tmp_path / "wal.db")
+        apply_wal_pragmas(conn)
+        mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+        assert mode == "wal"
+        conn.close()
+
+    def test_synchronous_normal(self, tmp_path):
+        conn = _open(tmp_path / "sync.db")
+        apply_wal_pragmas(conn)
+        # PRAGMA synchronous returns 1 for NORMAL.
+        val = conn.execute("PRAGMA synchronous").fetchone()[0]
+        assert val == 1
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Async API
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestRunMigrationsAsync:
+    async def test_fresh_db_applies_all(self, tmp_path):
+        import aiosqlite
+        db_path = str(tmp_path / "async_fresh.db")
+        conn = await aiosqlite.connect(db_path)
+        conn.row_factory = aiosqlite.Row
+        await run_migrations_async(conn, [(1, V1_SQL), (2, V2_SQL)])
+
+        cur = await conn.execute(
+            "SELECT version FROM schema_migrations ORDER BY version"
+        )
+        versions = [r[0] for r in await cur.fetchall()]
+        assert versions == [1, 2]
+        await conn.close()
+
+    async def test_existing_db_baselines(self, tmp_path):
+        import aiosqlite
+        db_path = str(tmp_path / "async_existing.db")
+        # Create tables without migration tracking.
+        conn = await aiosqlite.connect(db_path)
+        await conn.executescript(V1_SQL)
+        await conn.commit()
+        await conn.close()
+
+        conn = await aiosqlite.connect(db_path)
+        conn.row_factory = aiosqlite.Row
+        await run_migrations_async(conn, [(1, V1_SQL)])
+
+        cur = await conn.execute(
+            "SELECT version FROM schema_migrations ORDER BY version"
+        )
+        versions = [r[0] for r in await cur.fetchall()]
+        assert versions == [1]
+        await conn.close()
+
+    async def test_idempotent(self, tmp_path):
+        import aiosqlite
+        conn = await aiosqlite.connect(str(tmp_path / "async_idem.db"))
+        await run_migrations_async(conn, [(1, V1_SQL)])
+        await run_migrations_async(conn, [(1, V1_SQL)])
+        cur = await conn.execute(
+            "SELECT version FROM schema_migrations ORDER BY version"
+        )
+        versions = [r[0] for r in await cur.fetchall()]
+        assert versions == [1]
+        await conn.close()
+
+
+@pytest.mark.asyncio
+class TestApplyWalPragmasAsync:
+    async def test_wal_mode_set(self, tmp_path):
+        import aiosqlite
+        conn = await aiosqlite.connect(str(tmp_path / "async_wal.db"))
+        await apply_wal_pragmas_async(conn)
+        cur = await conn.execute("PRAGMA journal_mode")
+        row = await cur.fetchone()
+        assert row[0] == "wal"
+        await conn.close()
+
+    async def test_synchronous_normal(self, tmp_path):
+        import aiosqlite
+        conn = await aiosqlite.connect(str(tmp_path / "async_sync.db"))
+        await apply_wal_pragmas_async(conn)
+        cur = await conn.execute("PRAGMA synchronous")
+        row = await cur.fetchone()
+        assert row[0] == 1
+        await conn.close()

--- a/tinyagentos/base_store.py
+++ b/tinyagentos/base_store.py
@@ -2,9 +2,19 @@ from __future__ import annotations
 from pathlib import Path
 import aiosqlite
 
+from tinyagentos.db_migrations import apply_wal_pragmas_async, run_migrations_async
+
+
 class BaseStore:
-    """Base class for all SQLite-backed stores."""
+    """Base class for all SQLite-backed stores.
+
+    Subclasses set ``SCHEMA`` (applied once on first open) and may set
+    ``MIGRATIONS`` to a list of ``(version, sql_or_callable)`` pairs that
+    will be tracked and applied in order by the migration runner.
+    """
     SCHEMA: str = ""
+    # List of (version: int, sql_or_callable) pairs. See db_migrations.py.
+    MIGRATIONS: list = []
 
     def __init__(self, db_path: Path):
         self.db_path = db_path
@@ -13,9 +23,12 @@ class BaseStore:
     async def init(self) -> None:
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         self._db = await aiosqlite.connect(str(self.db_path))
+        await apply_wal_pragmas_async(self._db)
         if self.SCHEMA:
             await self._db.executescript(self.SCHEMA)
             await self._db.commit()
+        if self.MIGRATIONS:
+            await run_migrations_async(self._db, self.MIGRATIONS)
         await self._post_init()
 
     async def _post_init(self) -> None:

--- a/tinyagentos/benchmark/store.py
+++ b/tinyagentos/benchmark/store.py
@@ -13,6 +13,8 @@ from typing import Optional
 
 import aiosqlite
 
+from tinyagentos.db_migrations import apply_wal_pragmas_async
+
 
 CREATE_SQL = """
 CREATE TABLE IF NOT EXISTS benchmarks (
@@ -49,6 +51,7 @@ class BenchmarkStore:
         self.path.parent.mkdir(parents=True, exist_ok=True)
         self._db = await aiosqlite.connect(str(self.path))
         self._db.row_factory = aiosqlite.Row
+        await apply_wal_pragmas_async(self._db)
         await self._db.executescript(CREATE_SQL)
         await self._db.commit()
 

--- a/tinyagentos/db_migrations.py
+++ b/tinyagentos/db_migrations.py
@@ -1,0 +1,221 @@
+"""Lightweight versioned migration runner for taOS SQLite stores.
+
+Design
+------
+Each store that uses this module registers an ordered list of migrations:
+
+    MIGRATIONS = [
+        (1, "CREATE TABLE IF NOT EXISTS foo (id INTEGER PRIMARY KEY)"),
+        (2, "ALTER TABLE foo ADD COLUMN bar TEXT"),
+    ]
+
+On open, ``run_migrations(conn, MIGRATIONS)`` is called.  It:
+
+1. Creates a ``schema_migrations`` table if absent.
+2. Detects existing databases (tables present but no migration record) and
+   **baselines** them at the highest version WITHOUT re-running any SQL.
+   This keeps existing on-disk databases intact.
+3. Applies any pending migrations in ascending version order.
+4. Is idempotent: running it twice does nothing on the second pass.
+
+Each migration is either a plain SQL string (executed via executescript) or a
+callable ``fn(conn: sqlite3.Connection) -> None`` for cases that need Python
+logic.
+
+Async variant
+-------------
+``run_migrations_async(conn, migrations)`` accepts an ``aiosqlite.Connection``
+and awaits each step.  Use this in stores that open their DB with aiosqlite.
+
+WAL / synchronous helpers
+--------------------------
+``apply_wal_pragmas(conn)``        — sync sqlite3.Connection
+``apply_wal_pragmas_async(conn)``  — async aiosqlite.Connection
+
+Both set:
+    PRAGMA journal_mode = WAL
+    PRAGMA synchronous  = NORMAL
+
+WAL gives better read concurrency and avoids most "database is locked" errors.
+NORMAL synchronous is safe for nearly all crash scenarios while being
+significantly faster than the default FULL.
+"""
+from __future__ import annotations
+
+import logging
+import sqlite3
+from typing import Callable, Union
+
+logger = logging.getLogger(__name__)
+
+# A migration is a (version, sql_or_callable) pair.
+Migration = tuple[int, Union[str, Callable[[sqlite3.Connection], None]]]
+
+_TRACKING_SCHEMA = """
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    version     INTEGER PRIMARY KEY,
+    applied_at  REAL    NOT NULL
+);
+"""
+
+
+# ---------------------------------------------------------------------------
+# Sync (sqlite3) API
+# ---------------------------------------------------------------------------
+
+def apply_wal_pragmas(conn: sqlite3.Connection) -> None:
+    """Enable WAL journal mode and NORMAL synchronous on *conn*."""
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.execute("PRAGMA synchronous = NORMAL")
+
+
+def run_migrations(
+    conn: sqlite3.Connection,
+    migrations: list[Migration],
+) -> None:
+    """Apply pending migrations to *conn* (sync sqlite3 version).
+
+    Baselines existing databases so that on-disk DBs with tables but no
+    migration record are stamped at the latest version instead of having
+    all migrations re-run on them.
+    """
+    import time
+
+    # Create the tracking table.
+    conn.executescript(_TRACKING_SCHEMA)
+    conn.commit()
+
+    if not migrations:
+        return
+
+    latest_version = max(v for v, _ in migrations)
+
+    # Detect existing databases: any user table present means the DB was
+    # created before this migration system existed.  Baseline without running.
+    applied_row = conn.execute(
+        "SELECT COUNT(*) FROM schema_migrations"
+    ).fetchone()[0]
+
+    if applied_row == 0:
+        # Check for pre-existing user tables (i.e. not the sqlite_* system
+        # tables and not schema_migrations itself).
+        existing_tables = conn.execute(
+            "SELECT COUNT(*) FROM sqlite_master "
+            "WHERE type = 'table' AND name != 'schema_migrations'"
+        ).fetchone()[0]
+
+        if existing_tables > 0:
+            # Existing install — stamp at latest without running any SQL.
+            conn.execute(
+                "INSERT OR IGNORE INTO schema_migrations (version, applied_at) VALUES (?, ?)",
+                (latest_version, time.time()),
+            )
+            conn.commit()
+            logger.debug(
+                "db_migrations: baselined existing DB at v%d (skipped %d migrations)",
+                latest_version,
+                len(migrations),
+            )
+            return
+
+    # Collect applied versions.
+    applied = {
+        row[0]
+        for row in conn.execute("SELECT version FROM schema_migrations").fetchall()
+    }
+
+    for version, step in sorted(migrations, key=lambda m: m[0]):
+        if version in applied:
+            continue
+        logger.info("db_migrations: applying migration v%d", version)
+        if callable(step):
+            step(conn)
+        else:
+            conn.executescript(step)
+        conn.execute(
+            "INSERT OR IGNORE INTO schema_migrations (version, applied_at) VALUES (?, ?)",
+            (version, time.time()),
+        )
+        conn.commit()
+
+    logger.debug("db_migrations: schema up to date at v%d", latest_version)
+
+
+# ---------------------------------------------------------------------------
+# Async (aiosqlite) API
+# ---------------------------------------------------------------------------
+
+async def apply_wal_pragmas_async(conn) -> None:
+    """Enable WAL journal mode and NORMAL synchronous on an aiosqlite *conn*."""
+    await conn.execute("PRAGMA journal_mode = WAL")
+    await conn.execute("PRAGMA synchronous = NORMAL")
+
+
+async def run_migrations_async(
+    conn,
+    migrations: list[Migration],
+) -> None:
+    """Apply pending migrations to *conn* (async aiosqlite version).
+
+    Same semantics as ``run_migrations``; baselines existing databases.
+    """
+    import time
+
+    # Create the tracking table.
+    await conn.executescript(_TRACKING_SCHEMA)
+    await conn.commit()
+
+    if not migrations:
+        return
+
+    latest_version = max(v for v, _ in migrations)
+
+    applied_row_count = (
+        await (await conn.execute("SELECT COUNT(*) FROM schema_migrations")).fetchone()
+    )[0]
+
+    if applied_row_count == 0:
+        existing_tables = (
+            await (
+                await conn.execute(
+                    "SELECT COUNT(*) FROM sqlite_master "
+                    "WHERE type = 'table' AND name != 'schema_migrations'"
+                )
+            ).fetchone()
+        )[0]
+
+        if existing_tables > 0:
+            await conn.execute(
+                "INSERT OR IGNORE INTO schema_migrations (version, applied_at) VALUES (?, ?)",
+                (latest_version, time.time()),
+            )
+            await conn.commit()
+            logger.debug(
+                "db_migrations: baselined existing DB at v%d (skipped %d migrations)",
+                latest_version,
+                len(migrations),
+            )
+            return
+
+    applied = {
+        row[0]
+        for row in await (
+            await conn.execute("SELECT version FROM schema_migrations")
+        ).fetchall()
+    }
+
+    for version, step in sorted(migrations, key=lambda m: m[0]):
+        if version in applied:
+            continue
+        logger.info("db_migrations: applying migration v%d", version)
+        if callable(step):
+            await step(conn)
+        else:
+            await conn.executescript(step)
+        await conn.execute(
+            "INSERT OR IGNORE INTO schema_migrations (version, applied_at) VALUES (?, ?)",
+            (version, time.time()),
+        )
+        await conn.commit()
+
+    logger.debug("db_migrations: schema up to date at v%d", latest_version)

--- a/tinyagentos/knowledge_fetchers/x.py
+++ b/tinyagentos/knowledge_fetchers/x.py
@@ -15,6 +15,8 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from tinyagentos.db_migrations import apply_wal_pragmas
+
 if TYPE_CHECKING:
     import httpx
 
@@ -241,6 +243,7 @@ class XWatchStore:
         self._db_path.parent.mkdir(parents=True, exist_ok=True)
         self._conn = sqlite3.connect(str(self._db_path), check_same_thread=False)
         self._conn.row_factory = sqlite3.Row
+        apply_wal_pragmas(self._conn)
         self._conn.execute(WATCH_SCHEMA)
         self._conn.commit()
 

--- a/tinyagentos/qmd_db.py
+++ b/tinyagentos/qmd_db.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
+from tinyagentos.db_migrations import apply_wal_pragmas
+
+
 class QmdDatabase:
     def __init__(self, db_path: Path):
         self.db_path = Path(db_path)
@@ -11,6 +14,7 @@ class QmdDatabase:
     def _connect(self) -> sqlite3.Connection:
         conn = sqlite3.connect(str(self.db_path))
         conn.row_factory = sqlite3.Row
+        apply_wal_pragmas(conn)
         return conn
 
     def collections(self) -> list[dict]:

--- a/tinyagentos/routes/user_personas.py
+++ b/tinyagentos/routes/user_personas.py
@@ -29,13 +29,13 @@ class UpdatePersonaBody(BaseModel):
 
 @router.get("/api/user-personas")
 async def list_personas(request: Request):
-    personas = _store(request).list()
+    personas = await _store(request).alist()
     return JSONResponse({"personas": personas})
 
 
 @router.post("/api/user-personas")
 async def create_persona(request: Request, body: CreatePersonaBody):
-    pid = _store(request).create(
+    pid = await _store(request).acreate(
         name=body.name,
         soul_md=body.soul_md or "",
         agent_md=body.agent_md or "",
@@ -46,7 +46,7 @@ async def create_persona(request: Request, body: CreatePersonaBody):
 
 @router.get("/api/user-personas/{pid}")
 async def get_persona(request: Request, pid: str):
-    persona = _store(request).get(pid)
+    persona = await _store(request).aget(pid)
     if persona is None:
         return JSONResponse({"error": "not found"}, status_code=404)
     return JSONResponse(persona)
@@ -54,14 +54,14 @@ async def get_persona(request: Request, pid: str):
 
 @router.patch("/api/user-personas/{pid}")
 async def update_persona(request: Request, pid: str, body: UpdatePersonaBody):
-    if _store(request).get(pid) is None:
+    if await _store(request).aget(pid) is None:
         return JSONResponse({"error": "not found"}, status_code=404)
     fields = {k: v for k, v in body.model_dump().items() if v is not None}
-    _store(request).update(pid, **fields)
+    await _store(request).aupdate(pid, **fields)
     return JSONResponse({"ok": True})
 
 
 @router.delete("/api/user-personas/{pid}")
 async def delete_persona(request: Request, pid: str):
-    _store(request).delete(pid)
+    await _store(request).adelete(pid)
     return JSONResponse({"ok": True})

--- a/tinyagentos/scheduler/history_store.py
+++ b/tinyagentos/scheduler/history_store.py
@@ -18,6 +18,7 @@ from typing import Optional
 
 import aiosqlite
 
+from tinyagentos.db_migrations import apply_wal_pragmas_async
 from tinyagentos.scheduler.types import TaskRecord, TaskStatus
 
 logger = logging.getLogger(__name__)
@@ -65,6 +66,7 @@ class HistoryStore:
         self.path.parent.mkdir(parents=True, exist_ok=True)
         self._db = await aiosqlite.connect(str(self.path))
         self._db.row_factory = aiosqlite.Row
+        await apply_wal_pragmas_async(self._db)
         await self._db.executescript(CREATE_SQL)
         await self._db.commit()
 

--- a/tinyagentos/scheduling/job_queue.py
+++ b/tinyagentos/scheduling/job_queue.py
@@ -17,14 +17,16 @@ controller. For cluster-level job distribution, use taOS's worker dispatch.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import sqlite3
 import time
 import uuid
-from datetime import datetime, timezone
 from enum import IntEnum
 from pathlib import Path
+
+from tinyagentos.db_migrations import apply_wal_pragmas, run_migrations
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +57,11 @@ CREATE TABLE IF NOT EXISTS queue_config (
     value TEXT NOT NULL
 );
 """
+
+# Migrations list — version 1 is the baseline schema above.
+MIGRATIONS: list = [
+    (1, SCHEMA),
+]
 
 # Job types
 JOB_EMBED = "embed"              # Embed text into vector memory
@@ -88,19 +95,29 @@ DEFAULT_LIMITS = {
 
 
 class JobQueue:
-    """SQLite-backed job queue for serialising heavy memory tasks."""
+    """SQLite-backed job queue for serialising heavy memory tasks.
+
+    All public methods are async.  Blocking sqlite3 calls are dispatched to a
+    thread via asyncio.to_thread so they never stall the event loop.  The
+    connection is opened with check_same_thread=False so the same Connection
+    object can be handed to different thread-pool workers.
+    """
 
     def __init__(self, db_path: str | Path = "data/job-queue.db"):
         self._db_path = str(db_path)
         self._conn: sqlite3.Connection | None = None
         self._limits: dict[str, int] = dict(DEFAULT_LIMITS)
 
-    async def init(self) -> None:
-        Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
-        self._conn = sqlite3.connect(self._db_path)
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def _sync_init(self) -> None:
+        """Open DB, apply WAL + migrations, recover stale jobs."""
+        self._conn = sqlite3.connect(self._db_path, check_same_thread=False)
         self._conn.row_factory = sqlite3.Row
-        self._conn.executescript(SCHEMA)
-        self._conn.commit()
+        apply_wal_pragmas(self._conn)
+        run_migrations(self._conn, MIGRATIONS)
 
         # Load custom limits from config
         for row in self._conn.execute("SELECT key, value FROM queue_config").fetchall():
@@ -120,6 +137,10 @@ class JobQueue:
             logger.info("Marked %d stale running jobs as failed", stale.rowcount)
             self._conn.commit()
 
+    async def init(self) -> None:
+        Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
+        await asyncio.to_thread(self._sync_init)
+
     async def close(self) -> None:
         if self._conn:
             self._conn.close()
@@ -128,6 +149,27 @@ class JobQueue:
     # ------------------------------------------------------------------
     # Enqueue
     # ------------------------------------------------------------------
+
+    def _sync_enqueue(
+        self,
+        job_type: str,
+        payload_json: str,
+        agent_name: str | None,
+        priority: int,
+        resource_type: str,
+        estimated_seconds: int,
+    ) -> str:
+        job_id = uuid.uuid4().hex[:12]
+        now = time.time()
+        self._conn.execute(
+            """INSERT INTO jobs (id, job_type, priority, status, agent_name,
+               payload_json, resource_type, estimated_seconds, created_at)
+               VALUES (?, ?, ?, 'pending', ?, ?, ?, ?, ?)""",
+            (job_id, job_type, priority, agent_name,
+             payload_json, resource_type, estimated_seconds, now),
+        )
+        self._conn.commit()
+        return job_id
 
     async def enqueue(
         self,
@@ -139,36 +181,28 @@ class JobQueue:
         estimated_seconds: int = 0,
     ) -> str:
         """Add a job to the queue. Returns job ID."""
-        job_id = uuid.uuid4().hex[:12]
-        now = time.time()
-        self._conn.execute(
-            """INSERT INTO jobs (id, job_type, priority, status, agent_name,
-               payload_json, resource_type, estimated_seconds, created_at)
-               VALUES (?, ?, ?, 'pending', ?, ?, ?, ?, ?)""",
-            (job_id, job_type, priority, agent_name,
-             json.dumps(payload or {}), resource_type, estimated_seconds, now),
+        return await asyncio.to_thread(
+            self._sync_enqueue,
+            job_type,
+            json.dumps(payload or {}),
+            agent_name,
+            priority,
+            resource_type,
+            estimated_seconds,
         )
-        self._conn.commit()
-        return job_id
 
     # ------------------------------------------------------------------
     # Dequeue (pull-based)
     # ------------------------------------------------------------------
 
-    async def dequeue(self, resource_types: list[str] | None = None) -> dict | None:
-        """Get the next eligible job to run.
-
-        Checks concurrency limits for the job's resource type.
-        Returns the job dict or None if nothing is eligible.
-        """
-        # Count currently running jobs per resource type
-        running = {}
+    def _sync_dequeue(self, resource_types: list[str] | None) -> dict | None:
+        """Get the next eligible job to run (sync, called via to_thread)."""
+        running: dict[str, int] = {}
         for row in self._conn.execute(
             "SELECT resource_type, COUNT(*) as n FROM jobs WHERE status = 'running' GROUP BY resource_type"
         ).fetchall():
             running[row["resource_type"]] = row["n"]
 
-        # Find the next pending job whose resource type has capacity
         query = "SELECT * FROM jobs WHERE status = 'pending'"
         params: list = []
         if resource_types:
@@ -183,14 +217,12 @@ class JobQueue:
             limit = self._limits.get(resource, 1)
             current = running.get(resource, 0)
             if current < limit:
-                # Claim the job
                 now = time.time()
                 self._conn.execute(
                     "UPDATE jobs SET status = 'running', started_at = ? WHERE id = ?",
                     (now, row["id"]),
                 )
                 self._conn.commit()
-                # Re-fetch to get updated status
                 claimed = self._conn.execute(
                     "SELECT * FROM jobs WHERE id = ?", (row["id"],)
                 ).fetchone()
@@ -198,32 +230,49 @@ class JobQueue:
 
         return None
 
+    async def dequeue(self, resource_types: list[str] | None = None) -> dict | None:
+        """Get the next eligible job to run.
+
+        Checks concurrency limits for the job's resource type.
+        Returns the job dict or None if nothing is eligible.
+        """
+        return await asyncio.to_thread(self._sync_dequeue, resource_types)
+
     # ------------------------------------------------------------------
     # Complete / fail
     # ------------------------------------------------------------------
 
-    async def complete(self, job_id: str, result: dict | None = None) -> bool:
-        """Mark a job as completed."""
+    def _sync_complete(self, job_id: str, result_json: str) -> bool:
         now = time.time()
         cursor = self._conn.execute(
-            "UPDATE jobs SET status = 'completed', completed_at = ?, result_json = ? WHERE id = ? AND status = 'running'",
-            (now, json.dumps(result or {}), job_id),
+            "UPDATE jobs SET status = 'completed', completed_at = ?, result_json = ? "
+            "WHERE id = ? AND status = 'running'",
+            (now, result_json, job_id),
+        )
+        self._conn.commit()
+        return cursor.rowcount > 0
+
+    async def complete(self, job_id: str, result: dict | None = None) -> bool:
+        """Mark a job as completed."""
+        return await asyncio.to_thread(
+            self._sync_complete, job_id, json.dumps(result or {})
+        )
+
+    def _sync_fail(self, job_id: str, error: str) -> bool:
+        now = time.time()
+        cursor = self._conn.execute(
+            "UPDATE jobs SET status = 'failed', completed_at = ?, error = ? "
+            "WHERE id = ? AND status = 'running'",
+            (now, error, job_id),
         )
         self._conn.commit()
         return cursor.rowcount > 0
 
     async def fail(self, job_id: str, error: str) -> bool:
         """Mark a job as failed."""
-        now = time.time()
-        cursor = self._conn.execute(
-            "UPDATE jobs SET status = 'failed', completed_at = ?, error = ? WHERE id = ? AND status = 'running'",
-            (now, error, job_id),
-        )
-        self._conn.commit()
-        return cursor.rowcount > 0
+        return await asyncio.to_thread(self._sync_fail, job_id, error)
 
-    async def cancel(self, job_id: str) -> bool:
-        """Cancel a pending job."""
+    def _sync_cancel(self, job_id: str) -> bool:
         cursor = self._conn.execute(
             "UPDATE jobs SET status = 'cancelled' WHERE id = ? AND status = 'pending'",
             (job_id,),
@@ -231,31 +280,46 @@ class JobQueue:
         self._conn.commit()
         return cursor.rowcount > 0
 
+    async def cancel(self, job_id: str) -> bool:
+        """Cancel a pending job."""
+        return await asyncio.to_thread(self._sync_cancel, job_id)
+
     # ------------------------------------------------------------------
     # Queries
     # ------------------------------------------------------------------
 
-    async def get_job(self, job_id: str) -> dict | None:
+    def _sync_get_job(self, job_id: str) -> dict | None:
         row = self._conn.execute("SELECT * FROM jobs WHERE id = ?", (job_id,)).fetchone()
         return dict(row) if row else None
 
-    async def pending_count(self, agent_name: str | None = None) -> int:
+    async def get_job(self, job_id: str) -> dict | None:
+        return await asyncio.to_thread(self._sync_get_job, job_id)
+
+    def _sync_pending_count(self, agent_name: str | None) -> int:
         if agent_name:
             row = self._conn.execute(
                 "SELECT COUNT(*) as n FROM jobs WHERE status = 'pending' AND agent_name = ?",
                 (agent_name,),
             ).fetchone()
         else:
-            row = self._conn.execute("SELECT COUNT(*) as n FROM jobs WHERE status = 'pending'").fetchone()
+            row = self._conn.execute(
+                "SELECT COUNT(*) as n FROM jobs WHERE status = 'pending'"
+            ).fetchone()
         return row["n"]
 
-    async def running_jobs(self) -> list[dict]:
+    async def pending_count(self, agent_name: str | None = None) -> int:
+        return await asyncio.to_thread(self._sync_pending_count, agent_name)
+
+    def _sync_running_jobs(self) -> list[dict]:
         rows = self._conn.execute(
             "SELECT * FROM jobs WHERE status = 'running' ORDER BY started_at"
         ).fetchall()
         return [dict(r) for r in rows]
 
-    async def recent(self, limit: int = 20, status: str | None = None) -> list[dict]:
+    async def running_jobs(self) -> list[dict]:
+        return await asyncio.to_thread(self._sync_running_jobs)
+
+    def _sync_recent(self, limit: int, status: str | None) -> list[dict]:
         if status:
             rows = self._conn.execute(
                 "SELECT * FROM jobs WHERE status = ? ORDER BY created_at DESC LIMIT ?",
@@ -267,25 +331,35 @@ class JobQueue:
             ).fetchall()
         return [dict(r) for r in rows]
 
-    async def agent_jobs(self, agent_name: str, limit: int = 20) -> list[dict]:
+    async def recent(self, limit: int = 20, status: str | None = None) -> list[dict]:
+        return await asyncio.to_thread(self._sync_recent, limit, status)
+
+    def _sync_agent_jobs(self, agent_name: str, limit: int) -> list[dict]:
         rows = self._conn.execute(
             "SELECT * FROM jobs WHERE agent_name = ? ORDER BY created_at DESC LIMIT ?",
             (agent_name, limit),
         ).fetchall()
         return [dict(r) for r in rows]
 
+    async def agent_jobs(self, agent_name: str, limit: int = 20) -> list[dict]:
+        return await asyncio.to_thread(self._sync_agent_jobs, agent_name, limit)
+
     # ------------------------------------------------------------------
     # Config
     # ------------------------------------------------------------------
 
-    async def set_limit(self, resource_type: str, max_concurrent: int) -> None:
-        """Set the concurrency limit for a resource type."""
+    def _sync_set_limit(self, resource_type: str, max_concurrent: int) -> None:
         self._limits[resource_type] = max_concurrent
         self._conn.execute(
-            "INSERT INTO queue_config (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            "INSERT INTO queue_config (key, value) VALUES (?, ?) "
+            "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
             (f"limit_{resource_type}", str(max_concurrent)),
         )
         self._conn.commit()
+
+    async def set_limit(self, resource_type: str, max_concurrent: int) -> None:
+        """Set the concurrency limit for a resource type."""
+        await asyncio.to_thread(self._sync_set_limit, resource_type, max_concurrent)
 
     async def get_limits(self) -> dict[str, int]:
         return dict(self._limits)
@@ -294,8 +368,7 @@ class JobQueue:
     # Cleanup
     # ------------------------------------------------------------------
 
-    async def cleanup(self, older_than_days: int = 7) -> int:
-        """Remove completed/failed/cancelled jobs older than N days."""
+    def _sync_cleanup(self, older_than_days: int) -> int:
         cutoff = time.time() - (older_than_days * 86400)
         cursor = self._conn.execute(
             "DELETE FROM jobs WHERE status IN ('completed', 'failed', 'cancelled') AND created_at < ?",
@@ -304,19 +377,22 @@ class JobQueue:
         self._conn.commit()
         return cursor.rowcount
 
+    async def cleanup(self, older_than_days: int = 7) -> int:
+        """Remove completed/failed/cancelled jobs older than N days."""
+        return await asyncio.to_thread(self._sync_cleanup, older_than_days)
+
     # ------------------------------------------------------------------
     # Stats
     # ------------------------------------------------------------------
 
-    async def stats(self) -> dict:
-        """Queue statistics."""
-        counts = {}
+    def _sync_stats(self) -> dict:
+        counts: dict[str, int] = {}
         for row in self._conn.execute(
             "SELECT status, COUNT(*) as n FROM jobs GROUP BY status"
         ).fetchall():
             counts[row["status"]] = row["n"]
 
-        running_by_resource = {}
+        running_by_resource: dict[str, int] = {}
         for row in self._conn.execute(
             "SELECT resource_type, COUNT(*) as n FROM jobs WHERE status = 'running' GROUP BY resource_type"
         ).fetchall():
@@ -329,3 +405,7 @@ class JobQueue:
             "total_pending": counts.get("pending", 0),
             "total_running": counts.get("running", 0),
         }
+
+    async def stats(self) -> dict:
+        """Queue statistics."""
+        return await asyncio.to_thread(self._sync_stats)

--- a/tinyagentos/scheduling/leases.py
+++ b/tinyagentos/scheduling/leases.py
@@ -14,10 +14,13 @@ Lease model:
 
 from __future__ import annotations
 
+import asyncio
 import sqlite3
 import time
 import uuid
 from pathlib import Path
+
+from tinyagentos.db_migrations import apply_wal_pragmas, run_migrations
 
 SCHEMA = """
 CREATE TABLE IF NOT EXISTS leases (
@@ -33,24 +36,35 @@ CREATE INDEX IF NOT EXISTS idx_leases_agent ON leases(agent_name);
 CREATE INDEX IF NOT EXISTS idx_leases_expires ON leases(expires_at);
 """
 
+MIGRATIONS: list = [
+    (1, SCHEMA),
+]
+
 DEFAULT_TTL = 600      # 10 minutes
 MAX_TTL = 3600         # 1 hour
 MAX_RENEW_COUNT = 5    # Prevent infinite lease hogging
 
 
 class LeaseManager:
-    """SQLite-backed lease manager for multi-agent coordination."""
+    """SQLite-backed lease manager for multi-agent coordination.
+
+    All public methods are async.  Blocking sqlite3 calls are dispatched to a
+    thread via asyncio.to_thread so they never stall the event loop.
+    """
 
     def __init__(self, db_path: str | Path = "data/leases.db"):
         self._db_path = str(db_path)
         self._conn: sqlite3.Connection | None = None
 
+    def _sync_init(self) -> None:
+        self._conn = sqlite3.connect(self._db_path, check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        apply_wal_pragmas(self._conn)
+        run_migrations(self._conn, MIGRATIONS)
+
     async def init(self) -> None:
         Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
-        self._conn = sqlite3.connect(self._db_path)
-        self._conn.row_factory = sqlite3.Row
-        self._conn.executescript(SCHEMA)
-        self._conn.commit()
+        await asyncio.to_thread(self._sync_init)
 
     async def close(self) -> None:
         if self._conn:
@@ -67,22 +81,20 @@ class LeaseManager:
             self._conn.commit()
         return cursor.rowcount
 
-    async def acquire(
+    # ------------------------------------------------------------------
+    # Acquire / renew / release  (sync helpers)
+    # ------------------------------------------------------------------
+
+    def _sync_acquire(
         self,
         resource_key: str,
         agent_name: str,
-        ttl: float = DEFAULT_TTL,
+        ttl: float,
     ) -> dict | None:
-        """Acquire an exclusive lease on a resource.
-
-        Returns lease dict on success, None if resource is already held
-        by another agent.
-        """
         ttl = min(ttl, MAX_TTL)
         self._cleanup_expired()
         now = time.time()
 
-        # Check existing lease
         existing = self._conn.execute(
             "SELECT * FROM leases WHERE resource_key = ?",
             (resource_key,),
@@ -91,8 +103,7 @@ class LeaseManager:
         if existing:
             if existing["agent_name"] == agent_name:
                 # Same agent — auto-renew
-                return await self.renew(resource_key, agent_name, ttl)
-            # Different agent holds it
+                return self._sync_renew(resource_key, agent_name, ttl)
             return None
 
         lease_id = uuid.uuid4().hex[:16]
@@ -112,13 +123,12 @@ class LeaseManager:
             "renewed_count": 0,
         }
 
-    async def renew(
+    def _sync_renew(
         self,
         resource_key: str,
         agent_name: str,
-        ttl: float = DEFAULT_TTL,
+        ttl: float,
     ) -> dict | None:
-        """Renew an existing lease. Only the holder can renew."""
         ttl = min(ttl, MAX_TTL)
         now = time.time()
 
@@ -131,7 +141,7 @@ class LeaseManager:
             return None
 
         if existing["renewed_count"] >= MAX_RENEW_COUNT:
-            return None  # Force release — prevent lease hogging
+            return None
 
         self._conn.execute(
             "UPDATE leases SET expires_at = ?, renewed_count = renewed_count + 1 WHERE id = ?",
@@ -148,54 +158,96 @@ class LeaseManager:
             "renewed_count": existing["renewed_count"] + 1,
         }
 
+    # ------------------------------------------------------------------
+    # Public async API
+    # ------------------------------------------------------------------
+
+    async def acquire(
+        self,
+        resource_key: str,
+        agent_name: str,
+        ttl: float = DEFAULT_TTL,
+    ) -> dict | None:
+        """Acquire an exclusive lease on a resource.
+
+        Returns lease dict on success, None if resource is already held
+        by another agent.
+        """
+        return await asyncio.to_thread(self._sync_acquire, resource_key, agent_name, ttl)
+
+    async def renew(
+        self,
+        resource_key: str,
+        agent_name: str,
+        ttl: float = DEFAULT_TTL,
+    ) -> dict | None:
+        """Renew an existing lease. Only the holder can renew."""
+        return await asyncio.to_thread(self._sync_renew, resource_key, agent_name, ttl)
+
     async def release(self, resource_key: str, agent_name: str) -> bool:
         """Release a lease. Only the holder can release."""
-        cursor = self._conn.execute(
-            "DELETE FROM leases WHERE resource_key = ? AND agent_name = ?",
-            (resource_key, agent_name),
-        )
-        self._conn.commit()
-        return cursor.rowcount > 0
+        def _do() -> bool:
+            cursor = self._conn.execute(
+                "DELETE FROM leases WHERE resource_key = ? AND agent_name = ?",
+                (resource_key, agent_name),
+            )
+            self._conn.commit()
+            return cursor.rowcount > 0
+        return await asyncio.to_thread(_do)
 
     async def check(self, resource_key: str) -> dict | None:
         """Check who holds a lease on a resource. Returns lease dict or None."""
-        self._cleanup_expired()
-        row = self._conn.execute(
-            "SELECT * FROM leases WHERE resource_key = ?",
-            (resource_key,),
-        ).fetchone()
-        return dict(row) if row else None
+        def _do() -> dict | None:
+            self._cleanup_expired()
+            row = self._conn.execute(
+                "SELECT * FROM leases WHERE resource_key = ?",
+                (resource_key,),
+            ).fetchone()
+            return dict(row) if row else None
+        return await asyncio.to_thread(_do)
 
     async def is_held_by(self, resource_key: str, agent_name: str) -> bool:
         """Check if a specific agent holds the lease."""
-        self._cleanup_expired()
-        row = self._conn.execute(
-            "SELECT 1 FROM leases WHERE resource_key = ? AND agent_name = ?",
-            (resource_key, agent_name),
-        ).fetchone()
-        return row is not None
+        def _do() -> bool:
+            self._cleanup_expired()
+            row = self._conn.execute(
+                "SELECT 1 FROM leases WHERE resource_key = ? AND agent_name = ?",
+                (resource_key, agent_name),
+            ).fetchone()
+            return row is not None
+        return await asyncio.to_thread(_do)
 
     async def agent_leases(self, agent_name: str) -> list[dict]:
         """List all active leases held by an agent."""
-        self._cleanup_expired()
-        rows = self._conn.execute(
-            "SELECT * FROM leases WHERE agent_name = ? ORDER BY acquired_at",
-            (agent_name,),
-        ).fetchall()
-        return [dict(r) for r in rows]
+        def _do() -> list[dict]:
+            self._cleanup_expired()
+            rows = self._conn.execute(
+                "SELECT * FROM leases WHERE agent_name = ? ORDER BY acquired_at",
+                (agent_name,),
+            ).fetchall()
+            return [dict(r) for r in rows]
+        return await asyncio.to_thread(_do)
 
     async def release_all(self, agent_name: str) -> int:
         """Release all leases held by an agent (e.g., on agent shutdown)."""
-        cursor = self._conn.execute(
-            "DELETE FROM leases WHERE agent_name = ?",
-            (agent_name,),
-        )
-        self._conn.commit()
-        return cursor.rowcount
+        def _do() -> int:
+            cursor = self._conn.execute(
+                "DELETE FROM leases WHERE agent_name = ?",
+                (agent_name,),
+            )
+            self._conn.commit()
+            return cursor.rowcount
+        return await asyncio.to_thread(_do)
 
     async def stats(self) -> dict:
         """Lease statistics."""
-        self._cleanup_expired()
-        total = self._conn.execute("SELECT COUNT(*) as n FROM leases").fetchone()["n"]
-        agents = self._conn.execute("SELECT COUNT(DISTINCT agent_name) as n FROM leases").fetchone()["n"]
-        return {"active_leases": total, "agents_with_leases": agents}
+        def _do() -> dict:
+            self._cleanup_expired()
+            total = self._conn.execute(
+                "SELECT COUNT(*) as n FROM leases"
+            ).fetchone()["n"]
+            agents = self._conn.execute(
+                "SELECT COUNT(DISTINCT agent_name) as n FROM leases"
+            ).fetchone()["n"]
+            return {"active_leases": total, "agents_with_leases": agents}
+        return await asyncio.to_thread(_do)

--- a/tinyagentos/scheduling/mesh_sync.py
+++ b/tinyagentos/scheduling/mesh_sync.py
@@ -25,6 +25,8 @@ import time
 from pathlib import Path
 from urllib.parse import urlparse
 
+from tinyagentos.db_migrations import apply_wal_pragmas, run_migrations
+
 logger = logging.getLogger(__name__)
 
 SCHEMA = """
@@ -49,6 +51,10 @@ CREATE TABLE IF NOT EXISTS sync_log (
 CREATE INDEX IF NOT EXISTS idx_sync_log_peer ON sync_log(peer_id);
 CREATE INDEX IF NOT EXISTS idx_sync_log_ts ON sync_log(timestamp DESC);
 """
+
+MIGRATIONS: list = [
+    (1, SCHEMA),
+]
 
 # Tables and their timestamp columns for delta sync
 SYNCABLE_TABLES = {
@@ -167,10 +173,10 @@ class MeshSync:
 
     async def init(self) -> None:
         Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
-        self._conn = sqlite3.connect(self._db_path)
+        self._conn = sqlite3.connect(self._db_path, check_same_thread=False)
         self._conn.row_factory = sqlite3.Row
-        self._conn.executescript(SCHEMA)
-        self._conn.commit()
+        apply_wal_pragmas(self._conn)
+        run_migrations(self._conn, MIGRATIONS)
 
     async def close(self) -> None:
         if self._conn:

--- a/tinyagentos/scheduling/worker_heartbeat.py
+++ b/tinyagentos/scheduling/worker_heartbeat.py
@@ -15,10 +15,14 @@ fallback to local models.
 
 from __future__ import annotations
 
+import asyncio
+import json
 import logging
 import sqlite3
 import time
 from pathlib import Path
+
+from tinyagentos.db_migrations import apply_wal_pragmas, run_migrations
 
 logger = logging.getLogger(__name__)
 
@@ -42,52 +46,43 @@ CREATE TABLE IF NOT EXISTS workers (
 CREATE INDEX IF NOT EXISTS idx_workers_heartbeat ON workers(last_heartbeat);
 """
 
+MIGRATIONS: list = [
+    (1, SCHEMA),
+]
+
 # Worker is offline if no heartbeat for this many seconds
 OFFLINE_THRESHOLD = 90  # 3 missed heartbeats at 30s interval
 
 
 class WorkerRegistry:
-    """Controller-side registry of cluster workers."""
+    """Controller-side registry of cluster workers.
+
+    All public methods are async.  Blocking sqlite3 calls are dispatched to a
+    thread via asyncio.to_thread so they never stall the event loop.
+    """
 
     def __init__(self, db_path: str | Path = "data/workers.db"):
         self._db_path = str(db_path)
         self._conn: sqlite3.Connection | None = None
 
+    def _sync_init(self) -> None:
+        self._conn = sqlite3.connect(self._db_path, check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        apply_wal_pragmas(self._conn)
+        run_migrations(self._conn, MIGRATIONS)
+
     async def init(self) -> None:
         Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
-        self._conn = sqlite3.connect(self._db_path)
-        self._conn.row_factory = sqlite3.Row
-        self._conn.executescript(SCHEMA)
-        self._conn.commit()
+        await asyncio.to_thread(self._sync_init)
 
     async def close(self) -> None:
         if self._conn:
             self._conn.close()
             self._conn = None
 
-    async def receive_heartbeat(self, heartbeat: dict) -> dict:
-        """Process a heartbeat from a worker.
-
-        Args:
-            heartbeat: {
-                name: str,
-                url: str,
-                cpu_cores: int,
-                npu_cores: int,
-                gpu_name: str | None,
-                gpu_vram_mb: int,
-                gpu_utilisation: int (0-100),
-                ram_total_mb: int,
-                ram_available_mb: int,
-                models: list[str],
-                is_yielded: bool,
-                worker_type: str ("general" | "gaming" | "headless" | "mobile"),
-            }
-        """
-        import json
+    def _sync_receive_heartbeat(self, heartbeat: dict) -> dict:
         now = time.time()
         name = heartbeat["name"]
-
         self._conn.execute(
             """INSERT INTO workers (name, url, last_heartbeat, cpu_cores, npu_cores,
                gpu_name, gpu_vram_mb, gpu_utilisation, ram_total_mb, ram_available_mb,
@@ -118,9 +113,11 @@ class WorkerRegistry:
         self._conn.commit()
         return {"status": "ok", "worker": name}
 
-    async def online_workers(self) -> list[dict]:
-        """Get all workers with a recent heartbeat."""
-        import json
+    async def receive_heartbeat(self, heartbeat: dict) -> dict:
+        """Process a heartbeat from a worker."""
+        return await asyncio.to_thread(self._sync_receive_heartbeat, heartbeat)
+
+    def _sync_online_workers(self) -> list[dict]:
         cutoff = time.time() - OFFLINE_THRESHOLD
         rows = self._conn.execute(
             "SELECT * FROM workers WHERE last_heartbeat > ? ORDER BY name",
@@ -135,9 +132,11 @@ class WorkerRegistry:
             result.append(d)
         return result
 
-    async def all_workers(self) -> list[dict]:
-        """Get all known workers (online and offline)."""
-        import json
+    async def online_workers(self) -> list[dict]:
+        """Get all workers with a recent heartbeat."""
+        return await asyncio.to_thread(self._sync_online_workers)
+
+    def _sync_all_workers(self) -> list[dict]:
         cutoff = time.time() - OFFLINE_THRESHOLD
         rows = self._conn.execute(
             "SELECT * FROM workers ORDER BY last_heartbeat DESC"
@@ -151,9 +150,11 @@ class WorkerRegistry:
             result.append(d)
         return result
 
-    async def get_worker(self, name: str) -> dict | None:
-        """Get a specific worker's status."""
-        import json
+    async def all_workers(self) -> list[dict]:
+        """Get all known workers (online and offline)."""
+        return await asyncio.to_thread(self._sync_all_workers)
+
+    def _sync_get_worker(self, name: str) -> dict | None:
         row = self._conn.execute(
             "SELECT * FROM workers WHERE name = ?", (name,)
         ).fetchone()
@@ -165,11 +166,17 @@ class WorkerRegistry:
         d["online"] = d["last_heartbeat"] > (time.time() - OFFLINE_THRESHOLD)
         return d
 
+    async def get_worker(self, name: str) -> dict | None:
+        """Get a specific worker's status."""
+        return await asyncio.to_thread(self._sync_get_worker, name)
+
     async def remove_worker(self, name: str) -> bool:
         """Remove a worker from the registry."""
-        cursor = self._conn.execute("DELETE FROM workers WHERE name = ?", (name,))
-        self._conn.commit()
-        return cursor.rowcount > 0
+        def _do() -> bool:
+            cursor = self._conn.execute("DELETE FROM workers WHERE name = ?", (name,))
+            self._conn.commit()
+            return cursor.rowcount > 0
+        return await asyncio.to_thread(_do)
 
     async def for_resource_manager(self) -> list[dict]:
         """Get online workers formatted for the resource manager's snapshot.
@@ -189,17 +196,22 @@ class WorkerRegistry:
                 "worker_type": w.get("worker_type", "general"),
             }
             for w in workers
-            if not w.get("is_yielded")  # Exclude yielded workers from scheduling
+            if not w.get("is_yielded")
         ]
 
     async def stats(self) -> dict:
-        cutoff = time.time() - OFFLINE_THRESHOLD
-        total = self._conn.execute("SELECT COUNT(*) as n FROM workers").fetchone()["n"]
-        online = self._conn.execute(
-            "SELECT COUNT(*) as n FROM workers WHERE last_heartbeat > ?", (cutoff,)
-        ).fetchone()["n"]
-        gpu_workers = self._conn.execute(
-            "SELECT COUNT(*) as n FROM workers WHERE gpu_name IS NOT NULL AND last_heartbeat > ?",
-            (cutoff,),
-        ).fetchone()["n"]
-        return {"total_workers": total, "online": online, "gpu_workers": gpu_workers}
+        def _do() -> dict:
+            cutoff = time.time() - OFFLINE_THRESHOLD
+            total = self._conn.execute(
+                "SELECT COUNT(*) as n FROM workers"
+            ).fetchone()["n"]
+            online = self._conn.execute(
+                "SELECT COUNT(*) as n FROM workers WHERE last_heartbeat > ?", (cutoff,)
+            ).fetchone()["n"]
+            gpu_workers = self._conn.execute(
+                "SELECT COUNT(*) as n FROM workers "
+                "WHERE gpu_name IS NOT NULL AND last_heartbeat > ?",
+                (cutoff,),
+            ).fetchone()["n"]
+            return {"total_workers": total, "online": online, "gpu_workers": gpu_workers}
+        return await asyncio.to_thread(_do)

--- a/tinyagentos/trace_store.py
+++ b/tinyagentos/trace_store.py
@@ -35,6 +35,8 @@ from typing import Any
 
 import aiosqlite
 
+from tinyagentos.db_migrations import apply_wal_pragmas_async
+
 logger = logging.getLogger(__name__)
 
 SCHEMA_VERSION = 1
@@ -171,6 +173,7 @@ class AgentTraceStore:
             pass
         db_path = _bucket_db_path(self._data_dir, self._slug, bucket)
         conn = await aiosqlite.connect(str(db_path))
+        await apply_wal_pragmas_async(conn)
         await conn.executescript(TRACE_SCHEMA)
         await conn.commit()
         self._connections[bucket] = conn

--- a/tinyagentos/user_personas.py
+++ b/tinyagentos/user_personas.py
@@ -1,11 +1,14 @@
 """SQLite-backed store for user-authored personas."""
 from __future__ import annotations
 
+import asyncio
 import sqlite3
 import time
 import uuid
 from pathlib import Path
 from typing import Any
+
+from tinyagentos.db_migrations import apply_wal_pragmas
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS user_personas (
@@ -24,6 +27,7 @@ class UserPersonaStore:
         self._db = Path(db_path)
         self._db.parent.mkdir(parents=True, exist_ok=True)
         with self._conn() as con:
+            apply_wal_pragmas(con)
             con.executescript(_SCHEMA)
 
     def _conn(self) -> sqlite3.Connection:
@@ -31,7 +35,11 @@ class UserPersonaStore:
         con.row_factory = sqlite3.Row
         return con
 
-    def create(
+    # ------------------------------------------------------------------
+    # Sync helpers — used internally and wrapped in to_thread below
+    # ------------------------------------------------------------------
+
+    def _sync_create(
         self,
         *,
         name: str,
@@ -48,7 +56,7 @@ class UserPersonaStore:
             )
         return pid
 
-    def get(self, pid: str) -> dict[str, Any] | None:
+    def _sync_get(self, pid: str) -> dict[str, Any] | None:
         with self._conn() as con:
             row = con.execute(
                 "SELECT id, name, description, soul_md, agent_md, created_at "
@@ -57,7 +65,7 @@ class UserPersonaStore:
             ).fetchone()
         return dict(row) if row else None
 
-    def list(self) -> list[dict[str, Any]]:
+    def _sync_list(self) -> list[dict[str, Any]]:
         with self._conn() as con:
             rows = con.execute(
                 "SELECT id, name, description, soul_md, agent_md, created_at "
@@ -65,7 +73,7 @@ class UserPersonaStore:
             ).fetchall()
         return [dict(r) for r in rows]
 
-    def update(self, pid: str, **fields) -> None:
+    def _sync_update(self, pid: str, **fields) -> None:
         allowed = {"name", "description", "soul_md", "agent_md"}
         bad = set(fields) - allowed
         if bad:
@@ -77,6 +85,61 @@ class UserPersonaStore:
         with self._conn() as con:
             con.execute(f"UPDATE user_personas SET {assignments} WHERE id = ?", values)
 
-    def delete(self, pid: str) -> None:
+    def _sync_delete(self, pid: str) -> None:
         with self._conn() as con:
             con.execute("DELETE FROM user_personas WHERE id = ?", (pid,))
+
+    # ------------------------------------------------------------------
+    # Public API — sync wrappers kept for backward-compat (non-async callers),
+    # async variants added for use from FastAPI route handlers.
+    # ------------------------------------------------------------------
+
+    def create(
+        self,
+        *,
+        name: str,
+        soul_md: str,
+        agent_md: str = "",
+        description: str | None = None,
+    ) -> str:
+        return self._sync_create(
+            name=name, soul_md=soul_md, agent_md=agent_md, description=description
+        )
+
+    def get(self, pid: str) -> dict[str, Any] | None:
+        return self._sync_get(pid)
+
+    def list(self) -> list[dict[str, Any]]:
+        return self._sync_list()
+
+    def update(self, pid: str, **fields) -> None:
+        return self._sync_update(pid, **fields)
+
+    def delete(self, pid: str) -> None:
+        return self._sync_delete(pid)
+
+    # Async variants for use inside FastAPI async route handlers
+    async def acreate(
+        self,
+        *,
+        name: str,
+        soul_md: str,
+        agent_md: str = "",
+        description: str | None = None,
+    ) -> str:
+        return await asyncio.to_thread(
+            self._sync_create,
+            name=name, soul_md=soul_md, agent_md=agent_md, description=description,
+        )
+
+    async def aget(self, pid: str) -> dict[str, Any] | None:
+        return await asyncio.to_thread(self._sync_get, pid)
+
+    async def alist(self) -> list[dict[str, Any]]:
+        return await asyncio.to_thread(self._sync_list)
+
+    async def aupdate(self, pid: str, **fields) -> None:
+        return await asyncio.to_thread(self._sync_update, pid, **fields)
+
+    async def adelete(self, pid: str) -> None:
+        return await asyncio.to_thread(self._sync_delete, pid)


### PR DESCRIPTION
## Summary

- **Migration framework** (`tinyagentos/db_migrations.py`): lightweight versioned runner using a `schema_migrations` table. Baselines existing on-disk DBs at the latest version (stamped but SQL not re-run) so no existing install is clobbered. Idempotent on every startup. Supports SQL strings and Python callables. Sync (`sqlite3`) and async (`aiosqlite`) variants.

- **WAL mode**: `PRAGMA journal_mode=WAL` + `PRAGMA synchronous=NORMAL` applied via centralised helpers. Wired into `BaseStore.init()` (covers all aiosqlite stores) and individually applied to `trace_store`, `benchmark/store`, `scheduler/history_store`, all `scheduling/` stores, `user_personas`, `qmd_db`, `knowledge_fetchers/x`.

- **Sync-in-async fixes**: `scheduling/job_queue.py`, `scheduling/leases.py`, `scheduling/worker_heartbeat.py` refactored — each `async def` method now dispatches its sqlite3 work via `asyncio.to_thread` with `check_same_thread=False`. `user_personas.py` gained `acreate/aget/alist/aupdate/adelete` async variants; `routes/user_personas.py` updated to use them.

## SQLite store inventory

| Store | Driver | Status |
|---|---|---|
| All `BaseStore` subclasses (~20 stores) | aiosqlite | WAL + migrations wired via base |
| `trace_store.AgentTraceStore` | aiosqlite | WAL added to bucket open |
| `benchmark/store.BenchmarkStore` | aiosqlite | WAL added |
| `scheduler/history_store.HistoryStore` | aiosqlite | WAL added |
| `scheduling/job_queue.JobQueue` | sqlite3 (async facade) | WAL + migrations + to_thread fix |
| `scheduling/leases.LeaseManager` | sqlite3 (async facade) | WAL + migrations + to_thread fix |
| `scheduling/worker_heartbeat.WorkerRegistry` | sqlite3 (async facade) | WAL + migrations + to_thread fix |
| `scheduling/mesh_sync.MeshSyncManager` | sqlite3 (async facade) | WAL + migrations; see deferred below |
| `user_personas.UserPersonaStore` | sqlite3 | WAL + async variants added |
| `qmd_db.QmdDatabase` | sqlite3 (read-only, per-call) | WAL added |
| `knowledge_fetchers/x.XWatchStore` | sqlite3 (sync class) | WAL added |
| `routes/desktop_browser/cookie_store` | sqlcipher3 | Already uses run_in_executor — no change |

## Baseline strategy

On first startup after this PR, `run_migrations` detects any user tables present in a DB with no `schema_migrations` record and stamps it at the latest version without re-running any SQL. New empty DBs get all migrations applied normally. Idempotent in both cases.

## Deferred sync-in-async spots

1. `scheduling/mesh_sync.py` — `export_delta`/`import_delta` accept external `sqlite3.Connection` objects as parameters (callers own those connections). Converting to `to_thread` requires changing call-site signatures.
2. `health.py` line 119 — `db.vector_count()` (sync `QmdDatabase`) called from `async def _poll`. Read-only, every ~10 min. Low risk but should be `to_thread`-wrapped.
3. `qmd_db.QmdDatabase` — pure sync class, per-call connections, used from sync polling paths. Low risk as-is.

## Backward compatibility

- Existing DBs: baselined — no data loss, no schema changes.
- WAL creates `-wal`/`-shm` sidecar files alongside existing `.db` files — expected.
- Sync public API on `UserPersonaStore` kept for non-async callers.
- `check_same_thread=False` added to `scheduling/` stores: safe — connections are accessed exclusively from the thread pool worker dispatched by `to_thread`.

## Test plan

- [x] 13 new unit tests in `tests/test_db_migrations.py` — fresh DB, baseline detection, idempotency, partial apply, callable migration, WAL pragmas (sync + async)
- [x] 100/100 targeted DB/scheduling/persona tests pass
- [x] 821/821 broader targeted suite passes (excluding pre-existing e2e Playwright collection errors)