### PR TITLE
feat(observability): Phase 1 — trace capture-seam timing + otel-spans store + route

### DIFF
--- a/tests/test_otel_span_store.py
+++ b/tests/test_otel_span_store.py
@@ -1,0 +1,338 @@
+"""Tests for Phase 1 observability additions.
+
+Covers:
+  - _build_envelope: ts_start -> duration_ms derivation
+  - _build_envelope: explicit duration_ms unchanged by ts_start
+  - reasoning_audit kind validates
+  - SpanStore: write -> query round-trip (fresh DB)
+  - SpanStore: filter by trace_id
+  - SpanStore: filter by time window (since/until)
+  - GET /api/agents/{name}/otel-spans route
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+import pytest_asyncio
+
+from tinyagentos.trace_store import (
+    _build_envelope,
+    VALID_KINDS,
+    AgentTraceStore,
+)
+from tinyagentos.otel.span_store import SpanStore, SpanStoreRegistry
+
+
+# ---------------------------------------------------------------------------
+# 1. _build_envelope: ts_start -> duration_ms
+# ---------------------------------------------------------------------------
+
+def test_build_envelope_ts_start_computes_duration_ms():
+    """When ts_start is passed and duration_ms is absent, duration_ms is derived."""
+    ts_start = time.time() - 0.5  # 500 ms ago
+    env = _build_envelope("agent-a", "lifecycle", {"ts_start": ts_start, "payload": {"event": "test"}})
+    assert env["duration_ms"] is not None
+    assert isinstance(env["duration_ms"], int)
+    assert env["duration_ms"] >= 0
+    # Rough bound: should not exceed 10 seconds for a half-second-ago start
+    assert env["duration_ms"] < 10_000
+
+
+def test_build_envelope_explicit_duration_ms_not_overwritten():
+    """An explicit duration_ms must survive even when ts_start is also provided."""
+    ts_start = time.time() - 1.0
+    env = _build_envelope(
+        "agent-b", "llm_call",
+        {
+            "ts_start": ts_start,
+            "duration_ms": 42,
+            "payload": {"status": "success", "messages": [], "response": "ok", "metadata": {}},
+        },
+    )
+    assert env["duration_ms"] == 42
+
+
+def test_build_envelope_no_ts_start_no_duration_ms_stays_none():
+    """Without ts_start or duration_ms, duration_ms remains None."""
+    env = _build_envelope("agent-c", "lifecycle", {"payload": {"event": "x"}})
+    assert env["duration_ms"] is None
+
+
+def test_build_envelope_ts_start_not_in_payload():
+    """ts_start must not leak into the stored payload."""
+    ts_start = time.time() - 0.1
+    env = _build_envelope("agent-d", "lifecycle", {"ts_start": ts_start, "payload": {"event": "y"}})
+    # The payload dict must not contain ts_start
+    assert "ts_start" not in env["payload"]
+    # And the envelope dict itself has no ts_start column
+    assert "ts_start" not in env
+
+
+# ---------------------------------------------------------------------------
+# 2. reasoning_audit kind
+# ---------------------------------------------------------------------------
+
+def test_reasoning_audit_in_valid_kinds():
+    assert "reasoning_audit" in VALID_KINDS
+
+
+@pytest.mark.asyncio
+async def test_reasoning_audit_records_without_error(tmp_path):
+    store = AgentTraceStore(tmp_path, "agent-audit")
+    env = await store.record(
+        "reasoning_audit",
+        payload={"verdict": "pass", "flags": [], "model": "test-model", "latency_ms": 123},
+    )
+    assert env["kind"] == "reasoning_audit"
+    assert env["payload"]["verdict"] == "pass"
+    await store.close()
+
+
+# ---------------------------------------------------------------------------
+# 3. SpanStore write -> query round-trip
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_span_store_write_and_query(tmp_path):
+    store = SpanStore(tmp_path, "agent-span-1")
+    try:
+        await store.write_span(
+            span_id="span-001",
+            trace_id="trace-abc",
+            parent_span_id=None,
+            name="chat",
+            start_time_ns=1_000_000_000,
+            end_time_ns=2_000_000_000,
+            attributes={"gen_ai.system": "openai"},
+            status_code="OK",
+            agent_name="agent-span-1",
+            conversation_id="conv-xyz",
+        )
+        spans = await store.query_spans("agent-span-1")
+        assert len(spans) == 1
+        s = spans[0]
+        assert s["span_id"] == "span-001"
+        assert s["trace_id"] == "trace-abc"
+        assert s["name"] == "chat"
+        assert s["attributes"]["gen_ai.system"] == "openai"
+        assert s["status_code"] == "OK"
+        assert s["conversation_id"] == "conv-xyz"
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_span_store_idempotent_write(tmp_path):
+    """INSERT OR IGNORE: writing the same span_id twice keeps only one row."""
+    store = SpanStore(tmp_path, "agent-span-idem")
+    try:
+        for _ in range(2):
+            await store.write_span(
+                span_id="span-dupe",
+                trace_id="trace-dupe",
+                parent_span_id=None,
+                name="execute_tool",
+                start_time_ns=500,
+                end_time_ns=1500,
+                agent_name="agent-span-idem",
+            )
+        spans = await store.query_spans("agent-span-idem")
+        assert len(spans) == 1
+    finally:
+        await store.close()
+
+
+# ---------------------------------------------------------------------------
+# 4. SpanStore: filter by trace_id
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_span_store_filter_by_trace_id(tmp_path):
+    store = SpanStore(tmp_path, "agent-span-filter")
+    now = time.time()
+    try:
+        await store.write_span(
+            span_id="s-tr1", trace_id="tr-1", parent_span_id=None,
+            name="chat", start_time_ns=100, end_time_ns=200,
+            agent_name="agent-span-filter", created_at=now,
+        )
+        await store.write_span(
+            span_id="s-tr2", trace_id="tr-2", parent_span_id=None,
+            name="chat", start_time_ns=300, end_time_ns=400,
+            agent_name="agent-span-filter", created_at=now + 1,
+        )
+        result = await store.query_spans("agent-span-filter", trace_id="tr-1")
+        assert len(result) == 1
+        assert result[0]["span_id"] == "s-tr1"
+    finally:
+        await store.close()
+
+
+# ---------------------------------------------------------------------------
+# 5. SpanStore: filter by time window
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_span_store_filter_by_time_window(tmp_path):
+    store = SpanStore(tmp_path, "agent-span-time")
+    base = time.time()
+    try:
+        for i in range(5):
+            await store.write_span(
+                span_id=f"span-t{i}",
+                trace_id="tr-time",
+                parent_span_id=None,
+                name="chat",
+                start_time_ns=i * 1_000_000,
+                end_time_ns=(i + 1) * 1_000_000,
+                agent_name="agent-span-time",
+                created_at=base + i,
+            )
+        # Query only spans at t=base+1, base+2, base+3 (i=1,2,3)
+        result = await store.query_spans(
+            "agent-span-time",
+            since=base + 0.5,
+            until=base + 3.5,
+        )
+        assert len(result) == 3
+        span_ids = {s["span_id"] for s in result}
+        assert span_ids == {"span-t1", "span-t2", "span-t3"}
+    finally:
+        await store.close()
+
+
+# ---------------------------------------------------------------------------
+# 6. SpanStore: limit honoured
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_span_store_limit(tmp_path):
+    store = SpanStore(tmp_path, "agent-span-lim")
+    now = time.time()
+    try:
+        for i in range(20):
+            await store.write_span(
+                span_id=f"span-lim-{i}",
+                trace_id="tr-lim",
+                parent_span_id=None,
+                name="chat",
+                start_time_ns=i,
+                end_time_ns=i + 1,
+                agent_name="agent-span-lim",
+                created_at=now + i,
+            )
+        result = await store.query_spans("agent-span-lim", limit=5)
+        assert len(result) == 5
+        # Newest-first
+        assert result[0]["created_at"] > result[-1]["created_at"]
+    finally:
+        await store.close()
+
+
+# ---------------------------------------------------------------------------
+# 7. SpanStoreRegistry caches instances
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_span_store_registry_same_instance(tmp_path):
+    registry = SpanStoreRegistry(tmp_path)
+    s1 = await registry.get("some-agent")
+    s2 = await registry.get("some-agent")
+    assert s1 is s2
+    await registry.close_all()
+
+
+# ---------------------------------------------------------------------------
+# 8. GET /api/agents/{name}/otel-spans route
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_otel_spans_route_no_registry(client):
+    """Without span_store_registry on app.state, returns empty spans list."""
+    app = client._transport.app
+    # Ensure no registry is set
+    original = getattr(app.state, "span_store_registry", None)
+    if hasattr(app.state, "span_store_registry"):
+        del app.state.span_store_registry
+    try:
+        resp = await client.get("/api/agents/my-agent/otel-spans")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["agent_name"] == "my-agent"
+        assert body["spans"] == []
+    finally:
+        if original is not None:
+            app.state.span_store_registry = original
+
+
+@pytest.mark.asyncio
+async def test_otel_spans_route_returns_spans(client, tmp_path):
+    """With a registry, spans written to the store are returned by the route."""
+    app = client._transport.app
+    registry = SpanStoreRegistry(tmp_path)
+    original = getattr(app.state, "span_store_registry", None)
+    app.state.span_store_registry = registry
+    try:
+        store = await registry.get("route-agent")
+        await store.write_span(
+            span_id="route-span-1",
+            trace_id="route-trace-1",
+            parent_span_id=None,
+            name="chat",
+            start_time_ns=100_000_000,
+            end_time_ns=200_000_000,
+            agent_name="route-agent",
+        )
+
+        resp = await client.get("/api/agents/route-agent/otel-spans")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["agent_name"] == "route-agent"
+        assert len(body["spans"]) == 1
+        assert body["spans"][0]["span_id"] == "route-span-1"
+    finally:
+        await registry.close_all()
+        if original is not None:
+            app.state.span_store_registry = original
+        elif hasattr(app.state, "span_store_registry"):
+            del app.state.span_store_registry
+
+
+@pytest.mark.asyncio
+async def test_otel_spans_route_filter_by_trace_id(client, tmp_path):
+    """trace_id query param filters correctly."""
+    app = client._transport.app
+    registry = SpanStoreRegistry(tmp_path)
+    original = getattr(app.state, "span_store_registry", None)
+    app.state.span_store_registry = registry
+    try:
+        store = await registry.get("filter-route-agent")
+        now = time.time()
+        for i, tid in enumerate(["tr-A", "tr-B", "tr-A"]):
+            await store.write_span(
+                span_id=f"filt-span-{i}",
+                trace_id=tid,
+                parent_span_id=None,
+                name="chat",
+                start_time_ns=i,
+                end_time_ns=i + 1,
+                agent_name="filter-route-agent",
+                created_at=now + i,
+            )
+
+        resp = await client.get(
+            "/api/agents/filter-route-agent/otel-spans",
+            params={"trace_id": "tr-A"},
+        )
+        assert resp.status_code == 200
+        spans = resp.json()["spans"]
+        assert len(spans) == 2
+        assert all(s["trace_id"] == "tr-A" for s in spans)
+    finally:
+        await registry.close_all()
+        if original is not None:
+            app.state.span_store_registry = original
+        elif hasattr(app.state, "span_store_registry"):
+            del app.state.span_store_registry

--- a/tinyagentos/otel/__init__.py
+++ b/tinyagentos/otel/__init__.py
@@ -1,0 +1,4 @@
+# tinyagentos.otel — OpenTelemetry integration package (Phase 1 foundation).
+# Phase 1: span_store (per-agent otel-spans.db + helpers).
+# Phase 2: emitter + receiver.
+# Phase 4: judge.

--- a/tinyagentos/otel/span_store.py
+++ b/tinyagentos/otel/span_store.py
@@ -1,0 +1,194 @@
+"""Per-agent OTel span store — Phase 1 foundation.
+
+Stores OpenTelemetry GenAI spans received from the local emitter (Phase 2)
+and from taOSmd (when configured). Each agent gets its own SQLite database at:
+
+    {data_dir}/trace/{slug}/otel-spans.db
+
+System spans (no agent) land in:
+
+    {data_dir}/trace/_system/otel-spans.db
+
+Schema: otel_spans(span_id PK, trace_id, parent_span_id, name,
+        start_time_ns, end_time_ns, attributes JSON, status_code,
+        agent_name, conversation_id, created_at)
+
+Design: WAL mode for concurrent readers (receiver + query route). Uses
+aiosqlite to stay on the async event loop, matching the rest of the codebase.
+#653's WAL helpers are not yet merged to dev; this module sets the PRAGMA
+directly on open.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Any
+
+import aiosqlite
+
+logger = logging.getLogger(__name__)
+
+_SCHEMA = """
+PRAGMA journal_mode=WAL;
+CREATE TABLE IF NOT EXISTS otel_spans (
+    span_id          TEXT PRIMARY KEY,
+    trace_id         TEXT NOT NULL,
+    parent_span_id   TEXT,
+    name             TEXT NOT NULL,
+    start_time_ns    INTEGER NOT NULL,
+    end_time_ns      INTEGER NOT NULL,
+    attributes       TEXT NOT NULL DEFAULT '{}',
+    status_code      TEXT,
+    agent_name       TEXT,
+    conversation_id  TEXT,
+    created_at       REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_otelspan_trace_id
+    ON otel_spans(trace_id);
+CREATE INDEX IF NOT EXISTS idx_otelspan_agent_created
+    ON otel_spans(agent_name, created_at);
+CREATE INDEX IF NOT EXISTS idx_otelspan_conversation_id
+    ON otel_spans(conversation_id);
+"""
+
+
+def _span_db_path(data_dir: Path, slug: str) -> Path:
+    """Resolve the otel-spans.db path for a given agent slug."""
+    return data_dir / "trace" / slug / "otel-spans.db"
+
+
+class SpanStore:
+    """Manages a single otel-spans.db for one agent (or _system)."""
+
+    def __init__(self, data_dir: Path, slug: str):
+        self._db_path = _span_db_path(data_dir, slug)
+        self._conn: aiosqlite.Connection | None = None
+        self._lock = asyncio.Lock()
+
+    async def _ensure_open(self) -> aiosqlite.Connection:
+        if self._conn is not None:
+            return self._conn
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            self._db_path.parent.chmod(0o700)
+        except OSError:
+            pass
+        conn = await aiosqlite.connect(str(self._db_path))
+        await conn.executescript(_SCHEMA)
+        await conn.commit()
+        self._conn = conn
+        return conn
+
+    async def close(self) -> None:
+        async with self._lock:
+            if self._conn is not None:
+                try:
+                    await self._conn.close()
+                except Exception:
+                    pass
+                self._conn = None
+
+    async def write_span(
+        self,
+        *,
+        span_id: str,
+        trace_id: str,
+        parent_span_id: str | None,
+        name: str,
+        start_time_ns: int,
+        end_time_ns: int,
+        attributes: dict | None = None,
+        status_code: str | None = None,
+        agent_name: str | None = None,
+        conversation_id: str | None = None,
+        created_at: float | None = None,
+    ) -> None:
+        """Persist one OTel span. Idempotent (INSERT OR IGNORE on span_id PK)."""
+        attrs_json = json.dumps(attributes or {}, default=str)
+        ts = created_at if created_at is not None else time.time()
+        async with self._lock:
+            conn = await self._ensure_open()
+            await conn.execute(
+                """INSERT OR IGNORE INTO otel_spans
+                   (span_id, trace_id, parent_span_id, name,
+                    start_time_ns, end_time_ns, attributes,
+                    status_code, agent_name, conversation_id, created_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    span_id, trace_id, parent_span_id, name,
+                    start_time_ns, end_time_ns, attrs_json,
+                    status_code, agent_name, conversation_id, ts,
+                ),
+            )
+            await conn.commit()
+
+    async def query_spans(
+        self,
+        agent_name: str | None = None,
+        *,
+        since: float | None = None,
+        until: float | None = None,
+        trace_id: str | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """Return spans newest-first, filtered by any combination of
+        agent_name / trace_id / time window. limit is capped at 1000."""
+        limit = max(1, min(limit, 1000))
+        clauses: list[str] = []
+        params: list[Any] = []
+        if agent_name is not None:
+            clauses.append("agent_name = ?")
+            params.append(agent_name)
+        if trace_id is not None:
+            clauses.append("trace_id = ?")
+            params.append(trace_id)
+        if since is not None:
+            clauses.append("created_at >= ?")
+            params.append(since)
+        if until is not None:
+            clauses.append("created_at <= ?")
+            params.append(until)
+        where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+        sql = f"SELECT * FROM otel_spans{where} ORDER BY created_at DESC LIMIT ?"
+        params.append(limit)
+        async with self._lock:
+            conn = await self._ensure_open()
+            cur = await conn.execute(sql, params)
+            rows = await cur.fetchall()
+            cols = [d[0] for d in cur.description]
+            await cur.close()
+        result = []
+        for row in rows:
+            span = dict(zip(cols, row))
+            try:
+                span["attributes"] = json.loads(span.get("attributes") or "{}")
+            except Exception:
+                pass
+            result.append(span)
+        return result
+
+
+class SpanStoreRegistry:
+    """Opens and caches one SpanStore per agent slug."""
+
+    def __init__(self, data_dir: Path):
+        self._data_dir = data_dir
+        self._stores: dict[str, SpanStore] = {}
+        self._lock = asyncio.Lock()
+
+    async def get(self, slug: str) -> SpanStore:
+        async with self._lock:
+            store = self._stores.get(slug)
+            if store is None:
+                store = SpanStore(self._data_dir, slug)
+                self._stores[slug] = store
+            return store
+
+    async def close_all(self) -> None:
+        async with self._lock:
+            for s in self._stores.values():
+                await s.close()
+            self._stores.clear()

--- a/tinyagentos/routes/trace.py
+++ b/tinyagentos/routes/trace.py
@@ -4,6 +4,7 @@ POST /api/trace — any taOS-owned caller records an event. agent_name
 picks the per-agent, per-hour bucket in the home-folder mount.
 
 GET /api/agents/{name}/trace — librarian reads structured history.
+GET /api/agents/{name}/otel-spans — OTel span store (Phase 1 foundation).
 
 POST /api/lifecycle/notify — LiteLLM callback resets keep-alive timer.
 """
@@ -73,6 +74,37 @@ async def list_agent_trace(
         since=since, until=until, limit=limit,
     )
     return {"agent_name": name, "schema_version": SCHEMA_VERSION, "events": events}
+
+
+@router.get("/api/agents/{name}/otel-spans")
+async def list_agent_otel_spans(
+    request: Request,
+    name: str,
+    trace_id: str | None = None,
+    since: float | None = None,
+    until: float | None = None,
+    limit: int = 100,
+):
+    """Return OTel spans for an agent from its per-agent otel-spans.db.
+
+    Mirrors the shape of GET /api/agents/{name}/trace. The span_store
+    registry is mounted on app.state.span_store_registry (set by the Phase 2
+    receiver; falls back gracefully when absent). Returns an empty list when
+    no spans exist yet — never 503 on a missing registry (the store is
+    lazily created on first write).
+    """
+    registry = getattr(request.app.state, "span_store_registry", None)
+    if registry is None:
+        return {"agent_name": name, "spans": []}
+    store = await registry.get(name)
+    spans = await store.query_spans(
+        agent_name=name,
+        trace_id=trace_id,
+        since=since,
+        until=until,
+        limit=limit,
+    )
+    return {"agent_name": name, "spans": spans}
 
 
 class LifecycleNotifyIn(BaseModel):

--- a/tinyagentos/trace_store.py
+++ b/tinyagentos/trace_store.py
@@ -68,6 +68,9 @@ CREATE INDEX IF NOT EXISTS idx_trace_created ON trace_events(created_at);
 VALID_KINDS = frozenset({
     "message_in", "message_out", "llm_call", "tool_call",
     "tool_result", "reasoning", "error", "lifecycle",
+    # Phase 1 observability: post-hoc reasoning judge result (§4.7 / §7).
+    # Never emitted as an OTel span — it is an internal eval artifact.
+    "reasoning_audit",
 })
 
 # Documented envelope schema — the librarian parses against this.
@@ -89,6 +92,9 @@ ENVELOPE_V1_SCHEMA = {
         "reasoning": {"text": "str", "block_type": "str?"},
         "error": {"stage": "str", "message": "str", "traceback": "str?"},
         "lifecycle": {"event": "str", "reason": "str?"},
+        # Phase 1 observability — judge result written by tinyagentos/otel/judge.py (Phase 4).
+        # Payload shape: {verdict: "pass"|"warn"|"fail", flags: list[str], model: str, latency_ms: int}
+        "reasoning_audit": {"verdict": "pass|warn|fail", "flags": "list[str]", "model": "str", "latency_ms": "int"},
     },
 }
 
@@ -121,9 +127,20 @@ def _new_id() -> str:
 
 
 def _build_envelope(agent_name: str, kind: str, fields: dict) -> dict:
-    """Produce a v1 envelope from loose input, filling ids + created_at."""
+    """Produce a v1 envelope from loose input, filling ids + created_at.
+
+    Timing convenience: callers may pass ``ts_start`` (float Unix epoch) instead
+    of a pre-computed ``duration_ms``. When ``ts_start`` is present and
+    ``duration_ms`` is absent, ``duration_ms`` is computed as
+    ``int((time.time() - ts_start) * 1000)``. Callers that already supply
+    ``duration_ms`` directly are unaffected. ``ts_start`` itself is NOT
+    persisted as a column or stored in the payload.
+    """
     if kind not in VALID_KINDS:
         raise ValueError(f"unknown kind: {kind!r}; valid: {sorted(VALID_KINDS)}")
+    duration_ms = fields.get("duration_ms")
+    if duration_ms is None and fields.get("ts_start") is not None:
+        duration_ms = int((time.time() - fields["ts_start"]) * 1000)
     return {
         "v": SCHEMA_VERSION,
         "id": fields.get("id") or _new_id(),
@@ -136,7 +153,7 @@ def _build_envelope(agent_name: str, kind: str, fields: dict) -> dict:
         "thread_id": fields.get("thread_id"),
         "backend_name": fields.get("backend_name"),
         "model": fields.get("model"),
-        "duration_ms": fields.get("duration_ms"),
+        "duration_ms": duration_ms,
         "tokens_in": fields.get("tokens_in"),
         "tokens_out": fields.get("tokens_out"),
         "cost_usd": fields.get("cost_usd"),


### PR DESCRIPTION
## Summary

- **`ts_start` → `duration_ms`** in `_build_envelope`: callers pass `ts_start` (float Unix epoch) and `duration_ms` is auto-computed as `int((time.time() - ts_start) * 1000)` when absent. Existing callers with explicit `duration_ms` are unaffected. `ts_start` is never persisted.
- **`reasoning_audit` kind**: added to `VALID_KINDS` with documented payload shape `{verdict: "pass"|"warn"|"fail", flags: list[str], model: str, latency_ms: int}`. No judge logic yet (Phase 4).
- **`tinyagentos/otel/span_store.py`** (new package `tinyagentos/otel/`): per-agent `data/trace/{slug}/otel-spans.db` with WAL mode. Schema matches §4.3. `SpanStore.write_span(...)` and `query_spans(agent_name, since, until, trace_id, limit)` async helpers. `SpanStoreRegistry` caches one store per slug.
- **`GET /api/agents/{name}/otel-spans`** in `routes/trace.py`: mirrors `/trace` route shape. Filters: `trace_id`, `since`, `until`, `limit`. Returns empty list (not 503) when no registry is mounted — the registry is wired by the Phase 2 receiver.

Foundation for the agent observability layer per `docs/superpowers/specs/2026-06-08-agent-observability-layer-design.md §7 Phase 1`. Phase 2 = OTLP emitter + receiver.

## Note on #653 WAL helpers

`fix/sqlite-wal-migrations-653` is NOT merged to `dev`. `span_store.py` sets `PRAGMA journal_mode=WAL` directly in the schema script (matching the codebase pattern used pre-#653).

## Test plan

- [x] `test_build_envelope_ts_start_computes_duration_ms` — derives correct duration
- [x] `test_build_envelope_explicit_duration_ms_not_overwritten` — explicit value wins
- [x] `test_build_envelope_no_ts_start_no_duration_ms_stays_none` — no regression
- [x] `test_build_envelope_ts_start_not_in_payload` — ts_start not persisted
- [x] `test_reasoning_audit_in_valid_kinds` — kind registered
- [x] `test_reasoning_audit_records_without_error` — full write round-trip
- [x] `test_span_store_write_and_query` — fresh DB write → query round-trip
- [x] `test_span_store_idempotent_write` — INSERT OR IGNORE
- [x] `test_span_store_filter_by_trace_id` — trace_id filter
- [x] `test_span_store_filter_by_time_window` — since/until filter
- [x] `test_span_store_limit` — limit cap + newest-first ordering
- [x] `test_span_store_registry_same_instance` — registry caching
- [x] Route: no registry → empty spans list
- [x] Route: spans returned correctly
- [x] Route: trace_id filter via query param
- [x] All existing `test_trace_store.py` and `test_routes_trace.py` still pass (42 tests)

`python3 -m pytest tests/ --ignore=tests/e2e -k "trace or otel or span or envelope" -q` → **64 passed, 2 skipped** (skips are pre-existing, unrelated to this PR).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added OpenTelemetry span persistence with per-agent SQLite storage for observability.
  * New `GET /api/agents/{name}/otel-spans` endpoint to query spans with filtering by trace ID, time window, and result limits.
  * Added "reasoning_audit" span kind support.
  * Span envelope now auto-computes duration from start timestamp when omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->