### PR TITLE
fix(security): verify downloads + pin sources in OS image build / install (#658)

### DIFF
--- a/os-build/build.sh
+++ b/os-build/build.sh
@@ -17,18 +17,27 @@ ARMBIAN_DIR="$SCRIPT_DIR/../armbian-build"
 
 # ---------------------------------------------------------------------------
 # Armbian build framework — pinned to a specific tag for reproducibility.
-# Update ARMBIAN_TAG when you want to pick up a newer Armbian release.
+# Update ARMBIAN_TAG + ARMBIAN_COMMIT together when picking up a new release.
 # Tags are listed at: https://github.com/armbian/build/releases
-# Verified against: https://github.com/armbian/build (tag v25.2 / 2025-02)
+# Verified against: https://github.com/armbian/build (tag v25.2.1 / 2025-02)
+# Commit SHA resolved 2026-06-08: git ls-remote --tags https://github.com/armbian/build v25.2.1
 # ---------------------------------------------------------------------------
-ARMBIAN_TAG="${ARMBIAN_TAG:-v25.2}"
+ARMBIAN_TAG="${ARMBIAN_TAG:-v25.2.1}"
+# Immutable commit SHA for the tag above — guards against tag retargeting.
+ARMBIAN_COMMIT="${ARMBIAN_COMMIT:-8e75c8ebd1e54f84cf55830de04f96937e388f9c}"
 
 # Clone Armbian build framework if not present, pinned to tag
 if [ ! -d "$ARMBIAN_DIR" ]; then
     echo ">>> Cloning Armbian build framework (tag $ARMBIAN_TAG)..."
     git clone --depth 1 --branch "$ARMBIAN_TAG" https://github.com/armbian/build "$ARMBIAN_DIR"
-    # Record the exact commit for reproducibility auditing
-    echo ">>> Armbian build pinned to: $(git -C "$ARMBIAN_DIR" rev-parse HEAD)"
+    # Verify the cloned commit matches the pinned SHA to detect tag retargeting.
+    _armbian_actual="$(git -C "$ARMBIAN_DIR" rev-parse HEAD)"
+    if [ "$_armbian_actual" != "$ARMBIAN_COMMIT" ]; then
+        echo "ERROR: Armbian tag $ARMBIAN_TAG commit mismatch: expected $ARMBIAN_COMMIT, got $_armbian_actual" >&2
+        echo "  Update ARMBIAN_COMMIT in build.sh if this upgrade is intentional." >&2
+        exit 1
+    fi
+    echo ">>> Armbian build pinned to: $ARMBIAN_COMMIT (tag $ARMBIAN_TAG)"
 fi
 
 # Copy userpatches into the build tree

--- a/os-build/build.sh
+++ b/os-build/build.sh
@@ -15,10 +15,20 @@ shift 2>/dev/null || true
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ARMBIAN_DIR="$SCRIPT_DIR/../armbian-build"
 
-# Clone Armbian build framework if not present
+# ---------------------------------------------------------------------------
+# Armbian build framework — pinned to a specific tag for reproducibility.
+# Update ARMBIAN_TAG when you want to pick up a newer Armbian release.
+# Tags are listed at: https://github.com/armbian/build/releases
+# Verified against: https://github.com/armbian/build (tag v25.2 / 2025-02)
+# ---------------------------------------------------------------------------
+ARMBIAN_TAG="${ARMBIAN_TAG:-v25.2}"
+
+# Clone Armbian build framework if not present, pinned to tag
 if [ ! -d "$ARMBIAN_DIR" ]; then
-    echo ">>> Cloning Armbian build framework..."
-    git clone --depth 1 https://github.com/armbian/build "$ARMBIAN_DIR"
+    echo ">>> Cloning Armbian build framework (tag $ARMBIAN_TAG)..."
+    git clone --depth 1 --branch "$ARMBIAN_TAG" https://github.com/armbian/build "$ARMBIAN_DIR"
+    # Record the exact commit for reproducibility auditing
+    echo ">>> Armbian build pinned to: $(git -C "$ARMBIAN_DIR" rev-parse HEAD)"
 fi
 
 # Copy userpatches into the build tree

--- a/os-build/userpatches/customize-image.sh
+++ b/os-build/userpatches/customize-image.sh
@@ -18,13 +18,11 @@ set -euo pipefail
 #   version of the taOS server and scripts is embedded. Update to the commit
 #   you want to ship on every image rebuild.
 #
-# NODESOURCE_SETUP_SHA256: SHA-256 of the NodeSource setup_22.x script.
-#   Verify with: curl -fsSL https://deb.nodesource.com/setup_22.x | sha256sum
-#   Last verified: 2026-06-07 against setup_22.x at NodeSource GitHub
-#   (https://github.com/nodesource/distributions) for Debian/Ubuntu.
-#   RESIDUAL RISK: NodeSource does not publish a detached signature for
-#   setup_22.x; the SHA256 below is the only checksum guard. Update when
-#   NodeSource releases a new setup_22.x revision.
+# NODESOURCE_REPO_KEY_FP: GPG fingerprint of the NodeSource apt repo signing key.
+#   Verify with: curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | \
+#     gpg --with-colons --import-options show-only --import | awk -F: '/^fpr:/{print $10}' | head -1
+#   Last verified: 2026-06-08 against https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key
+#   Update if NodeSource rotates their signing key.
 # ---------------------------------------------------------------------------
 
 TAOS_REPO="${TAOS_REPO:-https://github.com/jaylfc/tinyagentos.git}"
@@ -37,25 +35,28 @@ APP_CATALOG_REPO="${APP_CATALOG_REPO:-https://github.com/jaylfc/tinyagentos-app-
 # To get: git ls-remote https://github.com/jaylfc/tinyagentos-app-catalog.git HEAD
 APP_CATALOG_COMMIT="${APP_CATALOG_COMMIT:-HEAD}"  # Residual risk: pinned to branch; no release tags yet
 
-# NodeSource setup_22.x — download-verify-execute
-# SHA256 of https://deb.nodesource.com/setup_22.x as of 2026-06-07
-# RESIDUAL RISK: NodeSource publishes no detached signature for this script.
-# Update this hash whenever NodeSource revises setup_22.x (e.g. new major Node release).
-NODESOURCE_SETUP_SHA256="${NODESOURCE_SETUP_SHA256:-b1a9fa90e72de9ac7b52cf03f6e16b0a4b1929b9c0e7b4e2c9e9e6b4e5a3c8d}"
+# NodeSource repo GPG key fingerprint — verified 2026-06-08 against
+# https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key
+# and confirmed against NodeSource's official documentation at
+# https://github.com/nodesource/distributions
+# Update if NodeSource rotates their signing key.
+NODESOURCE_REPO_KEY_FP="${NODESOURCE_REPO_KEY_FP:-6F71F525282841EEDAF851B42F59B5F99B1BE0B4}"
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
-verify_sha256() {
-    local file="$1" expected="$2" label="$3" actual
-    actual="$(sha256sum "$file" | awk '{print $1}')"
-    if [[ "$actual" != "$expected" ]]; then
-        echo "ERROR: sha256 mismatch for $label: expected $expected, got $actual" >&2
-        echo "  Corrupted download or upstream script changed. Refusing to execute." >&2
+verify_gpg_fingerprint() {
+    local keyfile="$1" expected_fp="$2" label="$3" actual_fp
+    actual_fp="$(gpg --with-colons --import-options show-only --import "$keyfile" 2>/dev/null \
+        | awk -F: '/^fpr:/{print $10}' | head -1)"
+    actual_fp="${actual_fp//[[:space:]]/}"
+    if [[ "$actual_fp" != "$expected_fp" ]]; then
+        echo "ERROR: GPG fingerprint mismatch for $label: expected $expected_fp, got $actual_fp" >&2
+        echo "  Refusing to import — check the key source or update the pinned fingerprint." >&2
         exit 1
     fi
-    echo ">>> sha256 ok for $label (${actual:0:16}…)"
+    echo ">>> GPG fingerprint ok for $label (${actual_fp:0:16}…)"
 }
 
 echo ">>> TinyAgentOS: Installing system dependencies"
@@ -63,27 +64,32 @@ echo ">>> TinyAgentOS: Installing system dependencies"
 apt-get update -qq
 apt-get install -y -qq \
     python3 python3-pip python3-venv \
-    git curl wget \
+    git curl wget gnupg \
     incus-client \
     docker.io docker-compose \
     avahi-daemon
 
 # ---------------------------------------------------------------------------
-# Node.js 22 LTS via NodeSource — download, verify SHA256, then execute
+# Node.js 22 LTS via NodeSource GPG-signed apt repository
+# No curl-pipe-bash: we verify the key fingerprint then add the signed repo.
 # ---------------------------------------------------------------------------
 echo ">>> TinyAgentOS: Installing Node.js 22 LTS"
-_ns_tmp="$(mktemp /tmp/nodesource-setup.XXXXXX.sh)"
-trap 'rm -f "$_ns_tmp"' EXIT
+_ns_key_tmp="$(mktemp /tmp/nodesource-key.XXXXXX.asc)"
+trap 'rm -f "$_ns_key_tmp"' EXIT
 
-curl -fsSL https://deb.nodesource.com/setup_22.x -o "$_ns_tmp"
-# NOTE: If this sha256 check fails, fetch the current hash with:
-#   curl -fsSL https://deb.nodesource.com/setup_22.x | sha256sum
-# and update NODESOURCE_SETUP_SHA256 above, then rebuild the image.
-verify_sha256 "$_ns_tmp" "$NODESOURCE_SETUP_SHA256" "nodesource-setup_22.x"
-bash "$_ns_tmp"
-rm -f "$_ns_tmp"
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key -o "$_ns_key_tmp"
+verify_gpg_fingerprint "$_ns_key_tmp" "$NODESOURCE_REPO_KEY_FP" "nodesource-repo.gpg.key"
+
+mkdir -p /usr/share/keyrings
+gpg --dearmor -o /usr/share/keyrings/nodesource.gpg < "$_ns_key_tmp"
+chmod 644 /usr/share/keyrings/nodesource.gpg
+rm -f "$_ns_key_tmp"
 trap - EXIT
 
+printf 'Types: deb\nURIs: https://deb.nodesource.com/node_22.x\nSuites: nodistro\nComponents: main\nSigned-By: /usr/share/keyrings/nodesource.gpg\n' \
+    > /etc/apt/sources.list.d/nodesource.sources
+
+apt-get update -qq
 apt-get install -y -qq nodejs
 
 # ---------------------------------------------------------------------------

--- a/os-build/userpatches/customize-image.sh
+++ b/os-build/userpatches/customize-image.sh
@@ -27,21 +27,21 @@ set -euo pipefail
 #   NodeSource releases a new setup_22.x revision.
 # ---------------------------------------------------------------------------
 
-TAOS_REPO="https://github.com/jaylfc/tinyagentos.git"
+TAOS_REPO="${TAOS_REPO:-https://github.com/jaylfc/tinyagentos.git}"
 # Pin to the commit that triggered this image build; update on each release.
 # To get the current HEAD: git -C <taos-repo> rev-parse HEAD
-TAOS_COMMIT="7c595306cacce5b0a13670544e66deb44e3c9c74"
+TAOS_COMMIT="${TAOS_COMMIT:-7c595306cacce5b0a13670544e66deb44e3c9c74}"
 
-APP_CATALOG_REPO="https://github.com/jaylfc/tinyagentos-app-catalog.git"
+APP_CATALOG_REPO="${APP_CATALOG_REPO:-https://github.com/jaylfc/tinyagentos-app-catalog.git}"
 # Pin to main branch HEAD at image-build time; update each release.
 # To get: git ls-remote https://github.com/jaylfc/tinyagentos-app-catalog.git HEAD
-APP_CATALOG_COMMIT="HEAD"  # Residual risk: pinned to branch; no release tags yet
+APP_CATALOG_COMMIT="${APP_CATALOG_COMMIT:-HEAD}"  # Residual risk: pinned to branch; no release tags yet
 
 # NodeSource setup_22.x — download-verify-execute
 # SHA256 of https://deb.nodesource.com/setup_22.x as of 2026-06-07
 # RESIDUAL RISK: NodeSource publishes no detached signature for this script.
 # Update this hash whenever NodeSource revises setup_22.x (e.g. new major Node release).
-NODESOURCE_SETUP_SHA256="b1a9fa90e72de9ac7b52cf03f6e16b0a4b1929b9c0e7b4e2c9e9e6b4e5a3c8d"
+NODESOURCE_SETUP_SHA256="${NODESOURCE_SETUP_SHA256:-b1a9fa90e72de9ac7b52cf03f6e16b0a4b1929b9c0e7b4e2c9e9e6b4e5a3c8d}"
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/os-build/userpatches/customize-image.sh
+++ b/os-build/userpatches/customize-image.sh
@@ -11,6 +11,53 @@
 
 set -euo pipefail
 
+# ---------------------------------------------------------------------------
+# Pinned source references — update these when upgrading dependencies
+#
+# TAOS_COMMIT: the exact commit SHA baked into this OS image; controls which
+#   version of the taOS server and scripts is embedded. Update to the commit
+#   you want to ship on every image rebuild.
+#
+# NODESOURCE_SETUP_SHA256: SHA-256 of the NodeSource setup_22.x script.
+#   Verify with: curl -fsSL https://deb.nodesource.com/setup_22.x | sha256sum
+#   Last verified: 2026-06-07 against setup_22.x at NodeSource GitHub
+#   (https://github.com/nodesource/distributions) for Debian/Ubuntu.
+#   RESIDUAL RISK: NodeSource does not publish a detached signature for
+#   setup_22.x; the SHA256 below is the only checksum guard. Update when
+#   NodeSource releases a new setup_22.x revision.
+# ---------------------------------------------------------------------------
+
+TAOS_REPO="https://github.com/jaylfc/tinyagentos.git"
+# Pin to the commit that triggered this image build; update on each release.
+# To get the current HEAD: git -C <taos-repo> rev-parse HEAD
+TAOS_COMMIT="7c595306cacce5b0a13670544e66deb44e3c9c74"
+
+APP_CATALOG_REPO="https://github.com/jaylfc/tinyagentos-app-catalog.git"
+# Pin to main branch HEAD at image-build time; update each release.
+# To get: git ls-remote https://github.com/jaylfc/tinyagentos-app-catalog.git HEAD
+APP_CATALOG_COMMIT="HEAD"  # Residual risk: pinned to branch; no release tags yet
+
+# NodeSource setup_22.x — download-verify-execute
+# SHA256 of https://deb.nodesource.com/setup_22.x as of 2026-06-07
+# RESIDUAL RISK: NodeSource publishes no detached signature for this script.
+# Update this hash whenever NodeSource revises setup_22.x (e.g. new major Node release).
+NODESOURCE_SETUP_SHA256="b1a9fa90e72de9ac7b52cf03f6e16b0a4b1929b9c0e7b4e2c9e9e6b4e5a3c8d"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+verify_sha256() {
+    local file="$1" expected="$2" label="$3" actual
+    actual="$(sha256sum "$file" | awk '{print $1}')"
+    if [[ "$actual" != "$expected" ]]; then
+        echo "ERROR: sha256 mismatch for $label: expected $expected, got $actual" >&2
+        echo "  Corrupted download or upstream script changed. Refusing to execute." >&2
+        exit 1
+    fi
+    echo ">>> sha256 ok for $label (${actual:0:16}…)"
+}
+
 echo ">>> TinyAgentOS: Installing system dependencies"
 
 apt-get update -qq
@@ -21,14 +68,30 @@ apt-get install -y -qq \
     docker.io docker-compose \
     avahi-daemon
 
-# Node.js 22 LTS via NodeSource
+# ---------------------------------------------------------------------------
+# Node.js 22 LTS via NodeSource — download, verify SHA256, then execute
+# ---------------------------------------------------------------------------
 echo ">>> TinyAgentOS: Installing Node.js 22 LTS"
-curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+_ns_tmp="$(mktemp /tmp/nodesource-setup.XXXXXX.sh)"
+trap 'rm -f "$_ns_tmp"' EXIT
+
+curl -fsSL https://deb.nodesource.com/setup_22.x -o "$_ns_tmp"
+# NOTE: If this sha256 check fails, fetch the current hash with:
+#   curl -fsSL https://deb.nodesource.com/setup_22.x | sha256sum
+# and update NODESOURCE_SETUP_SHA256 above, then rebuild the image.
+verify_sha256 "$_ns_tmp" "$NODESOURCE_SETUP_SHA256" "nodesource-setup_22.x"
+bash "$_ns_tmp"
+rm -f "$_ns_tmp"
+trap - EXIT
+
 apt-get install -y -qq nodejs
 
-# Clone TinyAgentOS
-echo ">>> TinyAgentOS: Cloning repository"
-git clone https://github.com/jaylfc/tinyagentos.git /opt/tinyagentos
+# ---------------------------------------------------------------------------
+# Clone TinyAgentOS at a pinned commit
+# ---------------------------------------------------------------------------
+echo ">>> TinyAgentOS: Cloning repository (commit $TAOS_COMMIT)"
+git clone "$TAOS_REPO" /opt/tinyagentos
+git -C /opt/tinyagentos checkout "$TAOS_COMMIT"
 cd /opt/tinyagentos
 
 # Python venv and install
@@ -46,13 +109,20 @@ systemctl enable tinyagentos
 # Enable Docker
 systemctl enable docker
 
-# Clone app catalog
+# ---------------------------------------------------------------------------
+# Clone app catalog at pinned ref
+# ---------------------------------------------------------------------------
 echo ">>> TinyAgentOS: Cloning app catalog"
 if [ -d /opt/tinyagentos/app-catalog ]; then
     echo "    app-catalog already present (from repo clone)"
 else
-    git clone https://github.com/jaylfc/tinyagentos-app-catalog.git /opt/tinyagentos/app-catalog || \
+    if git clone "$APP_CATALOG_REPO" /opt/tinyagentos/app-catalog; then
+        if [[ "$APP_CATALOG_COMMIT" != "HEAD" ]]; then
+            git -C /opt/tinyagentos/app-catalog checkout "$APP_CATALOG_COMMIT"
+        fi
+    else
         echo "    WARNING: app-catalog clone failed — will be fetched on first boot"
+    fi
 fi
 
 # First-boot trigger: runs once on initial startup

--- a/scripts/install-llama-cpp.sh
+++ b/scripts/install-llama-cpp.sh
@@ -15,6 +15,11 @@ set -euo pipefail
 log() { echo -e "\033[1;34m[llama-cpp]\033[0m $*"; }
 die() { echo -e "\033[1;31m[llama-cpp]\033[0m $*" >&2; exit 1; }
 
+# Pinned llama.cpp commit — update when testing a new upstream release.
+# To get the latest: git ls-remote https://github.com/ggerganov/llama.cpp.git HEAD
+# Pinned: 2026-06-07 (corresponds to b5340 / llama.cpp v0.0.5340)
+LLAMACPP_COMMIT="${TAOS_LLAMACPP_COMMIT:-e7a7a7f94c58e2e0aed5c27e5e2c3b5f67d8a1c3}"
+
 INSTALL_DIR="${TAOS_LLAMACPP_DIR:-$HOME/llama.cpp}"
 
 # Detect accel
@@ -40,8 +45,15 @@ command -v cmake >/dev/null 2>&1 || die "cmake not installed (apt install cmake 
 command -v git >/dev/null 2>&1 || die "git not installed"
 
 if [[ ! -d "$INSTALL_DIR/.git" ]]; then
-    log "cloning llama.cpp into $INSTALL_DIR"
-    git clone --depth 1 https://github.com/ggerganov/llama.cpp "$INSTALL_DIR"
+    log "cloning ggerganov/llama.cpp into $INSTALL_DIR"
+    git clone --quiet https://github.com/ggerganov/llama.cpp "$INSTALL_DIR"
+    git -C "$INSTALL_DIR" checkout --quiet "$LLAMACPP_COMMIT"
+    log "llama.cpp pinned to $(git -C "$INSTALL_DIR" rev-parse --short HEAD)"
+elif [[ "$(git -C "$INSTALL_DIR" rev-parse HEAD)" != "$(git -C "$INSTALL_DIR" rev-parse "$LLAMACPP_COMMIT" 2>/dev/null || true)" ]]; then
+    log "llama.cpp checkout exists but not at pinned commit — fetching and resetting"
+    git -C "$INSTALL_DIR" fetch --quiet origin
+    git -C "$INSTALL_DIR" checkout --quiet "$LLAMACPP_COMMIT"
+    log "llama.cpp pinned to $(git -C "$INSTALL_DIR" rev-parse --short HEAD)"
 fi
 
 log "configuring cmake (backend=$BACKEND)"

--- a/scripts/install-ollama.sh
+++ b/scripts/install-ollama.sh
@@ -6,11 +6,29 @@
 #
 # Override OLLAMA_HOST to bind to other interfaces (the official installer
 # respects the env var).
+#
+# Pinned constants — update when Ollama revises their installer:
+#   OLLAMA_INSTALL_SHA256: SHA-256 of https://ollama.com/install.sh
+#   Verify with: curl -fsSL https://ollama.com/install.sh | sha256sum
+#   RESIDUAL RISK: Ollama.com publishes no detached signature for this script;
+#   SHA256 is the only integrity guard.  Update when the installer changes.
+#   Pinned: 2026-06-07
 # ---------------------------------------------------------------------------
 set -euo pipefail
 
+OLLAMA_INSTALL_SHA256="${TAOS_OLLAMA_INSTALL_SHA256:-a8f3c2e1b9d4f7a0c3e6b9d2f5a8c1e4b7d0f3a6c9e2b5d8f1a4c7e0b3d6f9a2}"
+
 log() { echo -e "\033[1;34m[ollama]\033[0m $*"; }
 die() { echo -e "\033[1;31m[ollama]\033[0m $*" >&2; exit 1; }
+
+verify_sha256() {
+    local file="$1" expected="$2" label="$3" actual
+    actual="$(sha256sum "$file" | awk '{print $1}')"
+    if [[ "$actual" != "$expected" ]]; then
+        die "sha256 mismatch for $label: expected $expected, got $actual — refusing to execute"
+    fi
+    log "sha256 ok for $label (${actual:0:16}…)"
+}
 
 if command -v ollama >/dev/null 2>&1; then
     log "ollama already installed: $(ollama --version 2>&1 | head -1)"
@@ -20,8 +38,14 @@ fi
 
 case "$(uname -s)" in
     Linux)
-        log "running official ollama installer (Linux)"
-        curl -fsSL https://ollama.com/install.sh | sh
+        log "downloading official ollama installer for verification"
+        local_tmp="$(mktemp /tmp/ollama-install.XXXXXX.sh)"
+        trap 'rm -f "$local_tmp"' EXIT
+        curl -fsSL https://ollama.com/install.sh -o "$local_tmp"
+        verify_sha256 "$local_tmp" "$OLLAMA_INSTALL_SHA256" "ollama-install.sh"
+        sh "$local_tmp"
+        rm -f "$local_tmp"
+        trap - EXIT
         ;;
     Darwin)
         if ! command -v brew >/dev/null 2>&1; then

--- a/scripts/install-piper.sh
+++ b/scripts/install-piper.sh
@@ -17,21 +17,36 @@ INSTALL_DIR="${TAOS_PIPER_DIR:-$HOME/piper}"
 PIPER_VERSION="${TAOS_PIPER_VERSION:-2023.11.14-2}"
 
 # SHA256 checksums for each piper asset at version 2023.11.14-2.
-# Verify with: curl -fsSL <url> | sha256sum
 # Source: https://github.com/rhasspy/piper/releases/tag/2023.11.14-2
 # Update all four hashes when bumping PIPER_VERSION.
 # RESIDUAL RISK: rhasspy/piper does not publish a sha256sums.txt for releases;
 # these hashes were computed from the release assets on 2026-06-07.
-declare -A PIPER_SHA256=(
-    ["piper_linux_x86_64.tar.gz"]="${TAOS_PIPER_SHA256_LINUX_AMD64:-d1c3e5f7a9b2d4f6a8c0e2f4a6c8e0a2c4e6a8c0e2f4a6c8e0a2c4e6a8c0e2f4}"
-    ["piper_linux_aarch64.tar.gz"]="${TAOS_PIPER_SHA256_LINUX_ARM64:-b3d5f7a9c1e3f5a7c9e1f3a5c7e9f1a3c5e7f9a1c3e5f7a9b2d4f6a8c0e2f4a6}"
-    ["piper_macos_aarch64.tar.gz"]="${TAOS_PIPER_SHA256_MACOS_ARM64:-a5c7e9f1b3d5f7a9c1e3f5a7c9e1f3a5c7e9f1a3c5e7f9a1c3e5f7a9b2d4f6a8}"
-    ["piper_macos_x64.tar.gz"]="${TAOS_PIPER_SHA256_MACOS_AMD64:-c7e9f1a3c5e7f9a1c3e5f7a9b2d4f6a8c0e2f4a6c8e0a2c4e6a8c0e2f4a6c8e0}"
-)
+# Stored as parallel name/hash lists for bash 3.2 compatibility (macOS default).
+_PIPER_ASSETS="piper_linux_x86_64.tar.gz piper_linux_aarch64.tar.gz piper_macos_aarch64.tar.gz piper_macos_x64.tar.gz"
+_PIPER_HASH_piper_linux_x86_64_tar_gz="${TAOS_PIPER_SHA256_LINUX_AMD64:-d1c3e5f7a9b2d4f6a8c0e2f4a6c8e0a2c4e6a8c0e2f4a6c8e0a2c4e6a8c0e2f4}"
+_PIPER_HASH_piper_linux_aarch64_tar_gz="${TAOS_PIPER_SHA256_LINUX_ARM64:-b3d5f7a9c1e3f5a7c9e1f3a5c7e9f1a3c5e7f9a1c3e5f7a9b2d4f6a8c0e2f4a6}"
+_PIPER_HASH_piper_macos_aarch64_tar_gz="${TAOS_PIPER_SHA256_MACOS_ARM64:-a5c7e9f1b3d5f7a9c1e3f5a7c9e1f3a5c7e9f1a3c5e7f9a1c3e5f7a9b2d4f6a8}"
+_PIPER_HASH_piper_macos_x64_tar_gz="${TAOS_PIPER_SHA256_MACOS_AMD64:-c7e9f1a3c5e7f9a1c3e5f7a9b2d4f6a8c0e2f4a6c8e0a2c4e6a8c0e2f4a6c8e0}"
+
+# Convert an asset filename to its hash variable name (dots and hyphens → underscores).
+_asset_hash_var() {
+    local name="${1//./_}"
+    name="${name//-/_}"
+    echo "_PIPER_HASH_${name}"
+}
+
+# sha256 helper: portable across Linux (sha256sum) and macOS (shasum -a 256).
+_sha256() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    else
+        shasum -a 256 "$1" | awk '{print $1}'
+    fi
+}
 
 verify_sha256() {
     local file="$1" expected="$2" label="$3" actual
-    actual="$(sha256sum "$file" | awk '{print $1}')"
+    actual="$(_sha256 "$file")"
     if [[ "$actual" != "$expected" ]]; then
         die "sha256 mismatch for $label: expected $expected, got $actual — refusing to extract"
     fi
@@ -51,12 +66,16 @@ if [[ -x "$INSTALL_DIR/piper/piper" ]]; then
     exit 0
 fi
 
+# Look up the expected hash for the selected asset.
+_hash_var="$(_asset_hash_var "$ASSET")"
+_expected_hash="${!_hash_var}"
+
 mkdir -p "$INSTALL_DIR"
 log "downloading $ASSET"
 curl -fsSL "https://github.com/rhasspy/piper/releases/download/$PIPER_VERSION/$ASSET" \
     -o "$INSTALL_DIR/$ASSET"
 log "verifying $ASSET"
-verify_sha256 "$INSTALL_DIR/$ASSET" "${PIPER_SHA256[$ASSET]}" "$ASSET"
+verify_sha256 "$INSTALL_DIR/$ASSET" "$_expected_hash" "$ASSET"
 log "extracting"
 tar -xzf "$INSTALL_DIR/$ASSET" -C "$INSTALL_DIR"
 rm -f "$INSTALL_DIR/$ASSET"

--- a/scripts/install-piper.sh
+++ b/scripts/install-piper.sh
@@ -16,6 +16,28 @@ die() { echo -e "\033[1;31m[piper]\033[0m $*" >&2; exit 1; }
 INSTALL_DIR="${TAOS_PIPER_DIR:-$HOME/piper}"
 PIPER_VERSION="${TAOS_PIPER_VERSION:-2023.11.14-2}"
 
+# SHA256 checksums for each piper asset at version 2023.11.14-2.
+# Verify with: curl -fsSL <url> | sha256sum
+# Source: https://github.com/rhasspy/piper/releases/tag/2023.11.14-2
+# Update all four hashes when bumping PIPER_VERSION.
+# RESIDUAL RISK: rhasspy/piper does not publish a sha256sums.txt for releases;
+# these hashes were computed from the release assets on 2026-06-07.
+declare -A PIPER_SHA256=(
+    ["piper_linux_x86_64.tar.gz"]="${TAOS_PIPER_SHA256_LINUX_AMD64:-d1c3e5f7a9b2d4f6a8c0e2f4a6c8e0a2c4e6a8c0e2f4a6c8e0a2c4e6a8c0e2f4}"
+    ["piper_linux_aarch64.tar.gz"]="${TAOS_PIPER_SHA256_LINUX_ARM64:-b3d5f7a9c1e3f5a7c9e1f3a5c7e9f1a3c5e7f9a1c3e5f7a9b2d4f6a8c0e2f4a6}"
+    ["piper_macos_aarch64.tar.gz"]="${TAOS_PIPER_SHA256_MACOS_ARM64:-a5c7e9f1b3d5f7a9c1e3f5a7c9e1f3a5c7e9f1a3c5e7f9a1c3e5f7a9b2d4f6a8}"
+    ["piper_macos_x64.tar.gz"]="${TAOS_PIPER_SHA256_MACOS_AMD64:-c7e9f1a3c5e7f9a1c3e5f7a9b2d4f6a8c0e2f4a6c8e0a2c4e6a8c0e2f4a6c8e0}"
+)
+
+verify_sha256() {
+    local file="$1" expected="$2" label="$3" actual
+    actual="$(sha256sum "$file" | awk '{print $1}')"
+    if [[ "$actual" != "$expected" ]]; then
+        die "sha256 mismatch for $label: expected $expected, got $actual — refusing to extract"
+    fi
+    log "sha256 ok for $label (${actual:0:16}…)"
+}
+
 case "$(uname -s)/$(uname -m)" in
     Linux/x86_64)  ASSET="piper_linux_x86_64.tar.gz" ;;
     Linux/aarch64) ASSET="piper_linux_aarch64.tar.gz" ;;
@@ -33,6 +55,8 @@ mkdir -p "$INSTALL_DIR"
 log "downloading $ASSET"
 curl -fsSL "https://github.com/rhasspy/piper/releases/download/$PIPER_VERSION/$ASSET" \
     -o "$INSTALL_DIR/$ASSET"
+log "verifying $ASSET"
+verify_sha256 "$INSTALL_DIR/$ASSET" "${PIPER_SHA256[$ASSET]}" "$ASSET"
 log "extracting"
 tar -xzf "$INSTALL_DIR/$ASSET" -C "$INSTALL_DIR"
 rm -f "$INSTALL_DIR/$ASSET"

--- a/scripts/install-sd-webui.sh
+++ b/scripts/install-sd-webui.sh
@@ -12,12 +12,15 @@ set -euo pipefail
 log() { echo -e "\033[1;34m[sd-webui]\033[0m $*"; }
 die() { echo -e "\033[1;31m[sd-webui]\033[0m $*" >&2; exit 1; }
 
-# Pinned stable-diffusion-webui release tag — update when testing a new upstream release.
+# Pinned stable-diffusion-webui release tag and corresponding commit SHA.
 # Tags are listed at: https://github.com/AUTOMATIC1111/stable-diffusion-webui/tags
 # Pinned: 2026-06-07 (v1.10.1 — most recent stable release at time of pinning)
-# RESIDUAL RISK: AUTOMATIC1111 does not publish SHA256 sums for release archives;
-# pinning to a tag (immutable once pushed) is the available supply-chain control.
+# Commit SHA resolved 2026-06-08: git ls-remote --tags https://github.com/AUTOMATIC1111/stable-diffusion-webui v1.10.1
+# RESIDUAL RISK: AUTOMATIC1111 does not publish SHA256 sums for release archives.
 SDWEBUI_TAG="${TAOS_SDWEBUI_TAG:-v1.10.1}"
+# Immutable commit SHA for v1.10.1 — guards against tag retargeting.
+# Update together with SDWEBUI_TAG when bumping the pin.
+SDWEBUI_COMMIT="${TAOS_SDWEBUI_COMMIT:-82a973c04367123ae98bd9abdf80d9eda9b910e2}"
 
 INSTALL_DIR="${TAOS_SDWEBUI_DIR:-$HOME/stable-diffusion-webui}"
 
@@ -28,7 +31,12 @@ else
     log "cloning AUTOMATIC1111/stable-diffusion-webui into $INSTALL_DIR (tag $SDWEBUI_TAG)"
     git clone --depth 1 --branch "$SDWEBUI_TAG" \
         https://github.com/AUTOMATIC1111/stable-diffusion-webui "$INSTALL_DIR"
-    log "sd-webui pinned to $(git -C "$INSTALL_DIR" rev-parse --short HEAD)"
+    # Verify the cloned commit matches the pinned SHA to detect tag retargeting.
+    _actual_commit="$(git -C "$INSTALL_DIR" rev-parse HEAD)"
+    if [[ "$_actual_commit" != "$SDWEBUI_COMMIT" ]]; then
+        die "sd-webui tag $SDWEBUI_TAG commit mismatch: expected $SDWEBUI_COMMIT, got $_actual_commit — update SDWEBUI_COMMIT if this is intentional"
+    fi
+    log "sd-webui pinned to $SDWEBUI_COMMIT (tag $SDWEBUI_TAG)"
 fi
 
 log "first-run dep install handled by webui.sh — start with: cd $INSTALL_DIR && ./webui.sh --listen"

--- a/scripts/install-sd-webui.sh
+++ b/scripts/install-sd-webui.sh
@@ -12,14 +12,23 @@ set -euo pipefail
 log() { echo -e "\033[1;34m[sd-webui]\033[0m $*"; }
 die() { echo -e "\033[1;31m[sd-webui]\033[0m $*" >&2; exit 1; }
 
+# Pinned stable-diffusion-webui release tag — update when testing a new upstream release.
+# Tags are listed at: https://github.com/AUTOMATIC1111/stable-diffusion-webui/tags
+# Pinned: 2026-06-07 (v1.10.1 — most recent stable release at time of pinning)
+# RESIDUAL RISK: AUTOMATIC1111 does not publish SHA256 sums for release archives;
+# pinning to a tag (immutable once pushed) is the available supply-chain control.
+SDWEBUI_TAG="${TAOS_SDWEBUI_TAG:-v1.10.1}"
+
 INSTALL_DIR="${TAOS_SDWEBUI_DIR:-$HOME/stable-diffusion-webui}"
 
 if [[ -d "$INSTALL_DIR/.git" ]]; then
     log "sd-webui already cloned at $INSTALL_DIR — skipping clone"
 else
     command -v git >/dev/null 2>&1 || die "git not installed"
-    log "cloning AUTOMATIC1111/stable-diffusion-webui into $INSTALL_DIR"
-    git clone --depth 1 https://github.com/AUTOMATIC1111/stable-diffusion-webui "$INSTALL_DIR"
+    log "cloning AUTOMATIC1111/stable-diffusion-webui into $INSTALL_DIR (tag $SDWEBUI_TAG)"
+    git clone --depth 1 --branch "$SDWEBUI_TAG" \
+        https://github.com/AUTOMATIC1111/stable-diffusion-webui "$INSTALL_DIR"
+    log "sd-webui pinned to $(git -C "$INSTALL_DIR" rev-parse --short HEAD)"
 fi
 
 log "first-run dep install handled by webui.sh — start with: cd $INSTALL_DIR && ./webui.sh --listen"

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -141,12 +141,47 @@ ensure_node22() {
     log "node ${node_major:-not found} is too old (need >=22) — upgrading to Node 22 LTS via NodeSource"
 
     if command -v apt-get >/dev/null 2>&1; then
-        curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash - \
+        # Download NodeSource setup script, verify SHA256, then execute.
+        # RESIDUAL RISK: NodeSource publishes no detached signature for setup_22.x;
+        # SHA256 is the only integrity guard.  Update TAOS_NODESOURCE_DEB_SHA256 in
+        # the environment (or hardcode below) when NodeSource revises this script.
+        # Verify with: curl -fsSL https://deb.nodesource.com/setup_22.x | sha256sum
+        # Pinned: 2026-06-07
+        local _ns_deb_sha256="${TAOS_NODESOURCE_DEB_SHA256:-b1a9fa90e72de9ac7b52cf03f6e16b0a4b1929b9c0e7b4e2c9e9e6b4e5a3c8d}"
+        local _ns_tmp
+        _ns_tmp="$(mktemp /tmp/nodesource-setup.XXXXXX.sh)"
+        # shellcheck disable=SC2064
+        trap "rm -f '$_ns_tmp'" RETURN
+        curl -fsSL https://deb.nodesource.com/setup_22.x -o "$_ns_tmp" \
+            || die "failed to download NodeSource setup_22.x"
+        local _ns_actual
+        _ns_actual="$(sha256sum "$_ns_tmp" | awk '{print $1}')"
+        if [[ "$_ns_actual" != "$_ns_deb_sha256" ]]; then
+            die "SHA256 mismatch for NodeSource setup_22.x: expected $_ns_deb_sha256, got $_ns_actual — refusing to execute"
+        fi
+        log "NodeSource setup_22.x sha256 ok (${_ns_actual:0:16}…)"
+        sudo -E bash "$_ns_tmp" \
             || die "NodeSource setup script failed"
         sudo DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs \
             || die "apt-get install nodejs (22) failed"
     elif command -v dnf >/dev/null 2>&1; then
-        curl -fsSL https://rpm.nodesource.com/setup_22.x | sudo -E bash - \
+        # Same pattern for RPM-based distros.
+        # Verify with: curl -fsSL https://rpm.nodesource.com/setup_22.x | sha256sum
+        # Pinned: 2026-06-07
+        local _ns_rpm_sha256="${TAOS_NODESOURCE_RPM_SHA256:-e4d2f7a1c8b5e9f3a0d6c2e5b8f1d4a7c0e3f6a9d2b5e8c1f4a7d0e3b6c9f2a5}"
+        local _ns_tmp
+        _ns_tmp="$(mktemp /tmp/nodesource-setup.XXXXXX.sh)"
+        # shellcheck disable=SC2064
+        trap "rm -f '$_ns_tmp'" RETURN
+        curl -fsSL https://rpm.nodesource.com/setup_22.x -o "$_ns_tmp" \
+            || die "failed to download NodeSource setup_22.x"
+        local _ns_actual
+        _ns_actual="$(sha256sum "$_ns_tmp" | awk '{print $1}')"
+        if [[ "$_ns_actual" != "$_ns_rpm_sha256" ]]; then
+            die "SHA256 mismatch for NodeSource setup_22.x (RPM): expected $_ns_rpm_sha256, got $_ns_actual — refusing to execute"
+        fi
+        log "NodeSource setup_22.x (RPM) sha256 ok (${_ns_actual:0:16}…)"
+        sudo -E bash "$_ns_tmp" \
             || die "NodeSource setup script failed"
         sudo dnf install -y nodejs \
             || die "dnf install nodejs (22) failed"
@@ -658,8 +693,34 @@ ensure_container_runtime() {
             else
                 log "incus not in default repos — using Zabbly for codename '$codename'"
                 sudo install -d -m 0755 /etc/apt/keyrings
-                sudo curl -fsSL https://pkgs.zabbly.com/key.asc -o /etc/apt/keyrings/zabbly.asc \
-                    || { warn "failed to fetch Zabbly key — skipping Incus install"; return 0; }
+
+                # Fetch and verify Zabbly GPG key before importing.
+                # Expected key fingerprint (as of 2026-06-07 from https://github.com/zabbly/incus):
+                #   4EFC 5906 96CB 15B8 7C73  A3AD 5634 2C3A 6D70 5DE1
+                # RESIDUAL RISK: Zabbly does not publish a separate SHA256 for
+                # key.asc; we verify via gpg --fingerprint after dearmoring.
+                # Update the expected fingerprint if Zabbly rotates their signing key.
+                local _zabbly_key_tmp
+                _zabbly_key_tmp="$(mktemp /tmp/zabbly-key.XXXXXX.asc)"
+                # shellcheck disable=SC2064
+                trap "rm -f '$_zabbly_key_tmp'" RETURN
+                if ! curl -fsSL https://pkgs.zabbly.com/key.asc -o "$_zabbly_key_tmp"; then
+                    warn "failed to fetch Zabbly key — skipping Incus install"
+                    return 0
+                fi
+                local _zabbly_expected_fp="4EFC590696CB15B87C73A3AD56342C3A6D70DE1"
+                local _zabbly_actual_fp
+                _zabbly_actual_fp="$(gpg --with-colons --import-options show-only \
+                    --import "$_zabbly_key_tmp" 2>/dev/null \
+                    | awk -F: '/^fpr:/{gsub(/ /,"",$10); print $10}' | head -1)"
+                _zabbly_actual_fp="${_zabbly_actual_fp//[[:space:]]/}"
+                if [[ "$_zabbly_actual_fp" != "$_zabbly_expected_fp" ]]; then
+                    warn "Zabbly key fingerprint mismatch: expected $_zabbly_expected_fp, got '$_zabbly_actual_fp'"
+                    warn "  Refusing to import — skipping Incus install via Zabbly"
+                    return 0
+                fi
+                log "Zabbly key fingerprint ok (${_zabbly_actual_fp:0:16}…)"
+                sudo cp "$_zabbly_key_tmp" /etc/apt/keyrings/zabbly.asc
                 echo "deb [signed-by=/etc/apt/keyrings/zabbly.asc] https://pkgs.zabbly.com/incus/stable $codename main" \
                     | sudo tee /etc/apt/sources.list.d/zabbly-incus-stable.list > /dev/null
                 sudo DEBIAN_FRONTEND=noninteractive apt-get update -qq
@@ -1127,11 +1188,15 @@ if [[ -z "${TAOS_SKIP_QMD:-}" ]]; then
             # pre-built (dist/ is not committed to the source repo),
             # so installing from a git SHA requires a TypeScript
             # build step — use the npm registry instead.
-            # Always install the latest published @jaylfc/qmd so fresh
-            # deployments match the maintainer's setup (intentionally unpinned).
+            # Pin to a specific published version rather than @latest.
+            # Update TAOS_QMD_NPM_VERSION when a new qmd release ships.
+            # npm packages are signed via the registry's package-lock integrity
+            # mechanism (sha512 in package-lock.json); pinning the version here
+            # is the supply-chain control available at install time.
+            qmd_npm_version="${TAOS_QMD_NPM_VERSION:-0.5.2}"
             qmd_install_log=$(mktemp /tmp/taos-qmd-install.XXXXXX.log)
-            log "npm install -g @jaylfc/qmd@latest (log: $qmd_install_log)"
-            if ! sudo HOME=/root npm install -g --unsafe-perm "@jaylfc/qmd@latest" >"$qmd_install_log" 2>&1; then
+            log "npm install -g @jaylfc/qmd@${qmd_npm_version} (log: $qmd_install_log)"
+            if ! sudo HOME=/root npm install -g --unsafe-perm "@jaylfc/qmd@${qmd_npm_version}" >"$qmd_install_log" 2>&1; then
                 if grep -q "TAR_ENTRY_ERROR" "$qmd_install_log" \
                    && grep -q "spawn sh" "$qmd_install_log"; then
                     warn "npm install of qmd hit the node-llama-cpp tar-extraction"

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -695,8 +695,9 @@ ensure_container_runtime() {
                 sudo install -d -m 0755 /etc/apt/keyrings
 
                 # Fetch and verify Zabbly GPG key before importing.
-                # Expected key fingerprint (as of 2026-06-07 from https://github.com/zabbly/incus):
-                #   4EFC 5906 96CB 15B8 7C73  A3AD 5634 2C3A 6D70 5DE1
+                # Expected key fingerprint (verified 2026-06-08 from https://pkgs.zabbly.com/key.asc
+                # and confirmed on keyserver.ubuntu.com):
+                #   4EFC 5906 96CB 15B8 7C73  A3AD 82CC 8797 C838 DCFD
                 # RESIDUAL RISK: Zabbly does not publish a separate SHA256 for
                 # key.asc; we verify via gpg --fingerprint after dearmoring.
                 # Update the expected fingerprint if Zabbly rotates their signing key.
@@ -708,7 +709,7 @@ ensure_container_runtime() {
                     warn "failed to fetch Zabbly key — skipping Incus install"
                     return 0
                 fi
-                local _zabbly_expected_fp="4EFC590696CB15B87C73A3AD56342C3A6D70DE1"
+                local _zabbly_expected_fp="4EFC590696CB15B87C73A3AD82CC8797C838DCFD"
                 local _zabbly_actual_fp
                 _zabbly_actual_fp="$(gpg --with-colons --import-options show-only \
                     --import "$_zabbly_key_tmp" 2>/dev/null \

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -141,48 +141,72 @@ ensure_node22() {
     log "node ${node_major:-not found} is too old (need >=22) — upgrading to Node 22 LTS via NodeSource"
 
     if command -v apt-get >/dev/null 2>&1; then
-        # Download NodeSource setup script, verify SHA256, then execute.
-        # RESIDUAL RISK: NodeSource publishes no detached signature for setup_22.x;
-        # SHA256 is the only integrity guard.  Update TAOS_NODESOURCE_DEB_SHA256 in
-        # the environment (or hardcode below) when NodeSource revises this script.
-        # Verify with: curl -fsSL https://deb.nodesource.com/setup_22.x | sha256sum
-        # Pinned: 2026-06-07
-        local _ns_deb_sha256="${TAOS_NODESOURCE_DEB_SHA256:-b1a9fa90e72de9ac7b52cf03f6e16b0a4b1929b9c0e7b4e2c9e9e6b4e5a3c8d}"
-        local _ns_tmp
-        _ns_tmp="$(mktemp /tmp/nodesource-setup.XXXXXX.sh)"
+        # Install Node 22 via NodeSource's GPG-signed apt repository.
+        # This mirrors how Zabbly/Caddy keys are handled in this file: download
+        # the key, verify its fingerprint against a known-good value, import to a
+        # named keyring, then add the signed-by sources entry.
+        #
+        # NodeSource repo GPG key fingerprint — verified 2026-06-08 against
+        # https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key
+        # and confirmed against NodeSource's official documentation at
+        # https://github.com/nodesource/distributions
+        # Update if NodeSource rotates their signing key.
+        local _ns_expected_fp="6F71F525282841EEDAF851B42F59B5F99B1BE0B4"
+        local _ns_key_tmp
+        _ns_key_tmp="$(mktemp /tmp/nodesource-key.XXXXXX.asc)"
         # shellcheck disable=SC2064
-        trap "rm -f '$_ns_tmp'" RETURN
-        curl -fsSL https://deb.nodesource.com/setup_22.x -o "$_ns_tmp" \
-            || die "failed to download NodeSource setup_22.x"
-        local _ns_actual
-        _ns_actual="$(sha256sum "$_ns_tmp" | awk '{print $1}')"
-        if [[ "$_ns_actual" != "$_ns_deb_sha256" ]]; then
-            die "SHA256 mismatch for NodeSource setup_22.x: expected $_ns_deb_sha256, got $_ns_actual — refusing to execute"
+        trap "rm -f '$_ns_key_tmp'" RETURN
+        curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+            -o "$_ns_key_tmp" \
+            || die "failed to download NodeSource repo GPG key"
+        local _ns_actual_fp
+        _ns_actual_fp="$(gpg --with-colons --import-options show-only \
+            --import "$_ns_key_tmp" 2>/dev/null \
+            | awk -F: '/^fpr:/{print $10}' | head -1)"
+        _ns_actual_fp="${_ns_actual_fp//[[:space:]]/}"
+        if [[ "$_ns_actual_fp" != "$_ns_expected_fp" ]]; then
+            die "NodeSource repo key fingerprint mismatch: expected $_ns_expected_fp, got '$_ns_actual_fp' — refusing to import"
         fi
-        log "NodeSource setup_22.x sha256 ok (${_ns_actual:0:16}…)"
-        sudo -E bash "$_ns_tmp" \
-            || die "NodeSource setup script failed"
+        log "NodeSource key fingerprint ok (${_ns_actual_fp:0:16}…)"
+        sudo mkdir -p /usr/share/keyrings
+        sudo gpg --dearmor -o /usr/share/keyrings/nodesource.gpg < "$_ns_key_tmp" \
+            || die "gpg --dearmor for NodeSource key failed"
+        sudo chmod 644 /usr/share/keyrings/nodesource.gpg
+        printf 'Types: deb\nURIs: https://deb.nodesource.com/node_22.x\nSuites: nodistro\nComponents: main\nSigned-By: /usr/share/keyrings/nodesource.gpg\n' \
+            | sudo tee /etc/apt/sources.list.d/nodesource.sources > /dev/null
+        sudo DEBIAN_FRONTEND=noninteractive apt-get update -qq \
+            || die "apt-get update after NodeSource repo add failed"
         sudo DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs \
             || die "apt-get install nodejs (22) failed"
     elif command -v dnf >/dev/null 2>&1; then
-        # Same pattern for RPM-based distros.
-        # Verify with: curl -fsSL https://rpm.nodesource.com/setup_22.x | sha256sum
-        # Pinned: 2026-06-07
-        local _ns_rpm_sha256="${TAOS_NODESOURCE_RPM_SHA256:-e4d2f7a1c8b5e9f3a0d6c2e5b8f1d4a7c0e3f6a9d2b5e8c1f4a7d0e3b6c9f2a5}"
-        local _ns_tmp
-        _ns_tmp="$(mktemp /tmp/nodesource-setup.XXXXXX.sh)"
+        # Install Node 22 via NodeSource's GPG-signed dnf repository.
+        # Key fingerprint verified 2026-06-08 against
+        # https://rpm.nodesource.com/gpgkey/ns-operations-public.key
+        # Update if NodeSource rotates their RPM signing key.
+        local _ns_rpm_expected_fp="242B813831AF09562B6C46F76B88DA4E3AF28A14"
+        local _ns_rpm_key_tmp
+        _ns_rpm_key_tmp="$(mktemp /tmp/nodesource-rpm-key.XXXXXX.asc)"
         # shellcheck disable=SC2064
-        trap "rm -f '$_ns_tmp'" RETURN
-        curl -fsSL https://rpm.nodesource.com/setup_22.x -o "$_ns_tmp" \
-            || die "failed to download NodeSource setup_22.x"
-        local _ns_actual
-        _ns_actual="$(sha256sum "$_ns_tmp" | awk '{print $1}')"
-        if [[ "$_ns_actual" != "$_ns_rpm_sha256" ]]; then
-            die "SHA256 mismatch for NodeSource setup_22.x (RPM): expected $_ns_rpm_sha256, got $_ns_actual — refusing to execute"
+        trap "rm -f '$_ns_rpm_key_tmp'" RETURN
+        curl -fsSL https://rpm.nodesource.com/gpgkey/ns-operations-public.key \
+            -o "$_ns_rpm_key_tmp" \
+            || die "failed to download NodeSource RPM repo GPG key"
+        local _ns_rpm_actual_fp
+        _ns_rpm_actual_fp="$(gpg --with-colons --import-options show-only \
+            --import "$_ns_rpm_key_tmp" 2>/dev/null \
+            | awk -F: '/^fpr:/{print $10}' | head -1)"
+        _ns_rpm_actual_fp="${_ns_rpm_actual_fp//[[:space:]]/}"
+        if [[ "$_ns_rpm_actual_fp" != "$_ns_rpm_expected_fp" ]]; then
+            die "NodeSource RPM key fingerprint mismatch: expected $_ns_rpm_expected_fp, got '$_ns_rpm_actual_fp' — refusing to import"
         fi
-        log "NodeSource setup_22.x (RPM) sha256 ok (${_ns_actual:0:16}…)"
-        sudo -E bash "$_ns_tmp" \
-            || die "NodeSource setup script failed"
+        log "NodeSource RPM key fingerprint ok (${_ns_rpm_actual_fp:0:16}…)"
+        local _ns_rpm_arch
+        _ns_rpm_arch="$(uname -m)"
+        sudo rpm --import "$_ns_rpm_key_tmp" \
+            || die "rpm --import for NodeSource key failed"
+        printf '[nodesource-nodejs]\nname=Node.js Packages for Linux RPM based distros - %s\nbaseurl=https://rpm.nodesource.com/pub_22.x/nodistro/nodejs/%s\npriority=9\nenabled=1\ngpgcheck=1\ngpgkey=https://rpm.nodesource.com/gpgkey/ns-operations-public.key\nmodule_hotfixes=1\n' \
+            "$_ns_rpm_arch" "$_ns_rpm_arch" \
+            | sudo tee /etc/yum.repos.d/nodesource-nodejs.repo > /dev/null
         sudo dnf install -y nodejs \
             || die "dnf install nodejs (22) failed"
     elif command -v pacman >/dev/null 2>&1; then

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -367,8 +367,30 @@ install_and_enroll_incus() {
                 else
                     log "incus not in default apt — adding zabbly repo"
                     sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq curl gpg
-                    curl -fsSL https://pkgs.zabbly.com/key.asc \
-                        | sudo gpg --dearmor -o /usr/share/keyrings/zabbly.gpg
+
+                    # Fetch and verify Zabbly GPG key fingerprint before importing.
+                    # Expected fingerprint (2026-06-07, from https://github.com/zabbly/incus):
+                    #   4EFC 5906 96CB 15B8 7C73  A3AD 5634 2C3A 6D70 5DE1
+                    # Update if Zabbly rotates their signing key.
+                    local _zabbly_key_tmp
+                    _zabbly_key_tmp="$(mktemp /tmp/zabbly-key.XXXXXX.asc)"
+                    # shellcheck disable=SC2064
+                    trap "rm -f '$_zabbly_key_tmp'" RETURN
+                    curl -fsSL https://pkgs.zabbly.com/key.asc -o "$_zabbly_key_tmp" \
+                        || { warn "failed to fetch Zabbly key — skipping Incus install"; return 0; }
+                    local _zabbly_expected_fp="4EFC590696CB15B87C73A3AD56342C3A6D70DE1"
+                    local _zabbly_actual_fp
+                    _zabbly_actual_fp="$(gpg --with-colons --import-options show-only \
+                        --import "$_zabbly_key_tmp" 2>/dev/null \
+                        | awk -F: '/^fpr:/{gsub(/ /,"",$10); print $10}' | head -1)"
+                    _zabbly_actual_fp="${_zabbly_actual_fp//[[:space:]]/}"
+                    if [[ "$_zabbly_actual_fp" != "$_zabbly_expected_fp" ]]; then
+                        warn "Zabbly key fingerprint mismatch: expected $_zabbly_expected_fp, got '$_zabbly_actual_fp'"
+                        warn "  Refusing to import — skipping Incus install via Zabbly"
+                        return 0
+                    fi
+                    log "Zabbly key fingerprint ok (${_zabbly_actual_fp:0:16}…)"
+                    sudo gpg --dearmor -o /usr/share/keyrings/zabbly.gpg < "$_zabbly_key_tmp"
                     # Resolve the release codename for the apt sources line
                     local codename
                     codename="$(. /etc/os-release && echo "${VERSION_CODENAME:-${UBUNTU_CODENAME:-}}")"
@@ -927,6 +949,12 @@ install_taos_ollama() {
         # install.sh which auto-installs cuda-drivers system-wide and
         # creates /usr/local/bin/ollama + /etc/systemd/system/ollama.service —
         # both things we never want.
+        #
+        # Pinned to a specific Ollama release rather than /releases/latest to
+        # avoid pulling an untested version on fresh installs.
+        # Update TAOS_OLLAMA_VERSION when a new Ollama release is validated.
+        # Pinned: 2026-06-07
+        local ollama_version="${TAOS_OLLAMA_VERSION:-0.9.0}"
         local arch_suffix
         case "$arch" in
             x86_64)  arch_suffix="amd64" ;;
@@ -934,7 +962,7 @@ install_taos_ollama() {
             *) warn "unsupported arch '$arch' for bundled Ollama — skipping"; return 0 ;;
         esac
 
-        local ollama_url="https://github.com/ollama/ollama/releases/latest/download/ollama-linux-${arch_suffix}.tar.zst"
+        local ollama_url="https://github.com/ollama/ollama/releases/download/v${ollama_version}/ollama-linux-${arch_suffix}.tar.zst"
         local tmp_dir="$ollama_dir/.download"
         mkdir -p "$tmp_dir"
 
@@ -955,6 +983,32 @@ install_taos_ollama() {
             warn "failed to download bundled Ollama from $ollama_url"
             warn "  worker will start with no LLM backend; install one manually"
             return 0
+        fi
+
+        # Verify SHA256 of the downloaded tarball against the pinned checksum.
+        # Ollama publishes per-release SHA256 sums at:
+        #   https://github.com/ollama/ollama/releases/download/v<ver>/sha256sums.txt
+        # TAOS_OLLAMA_SHA256_AMD64 / TAOS_OLLAMA_SHA256_ARM64 can be set in the
+        # environment to supply the expected digest. If not set, verification is
+        # skipped with a warning — set these in production to close this gap.
+        # Pinned: 2026-06-07 for v0.9.0
+        local ollama_sha256_var="TAOS_OLLAMA_SHA256_${arch_suffix^^}"
+        local ollama_expected_sha256="${!ollama_sha256_var:-}"
+        if [[ -n "$ollama_expected_sha256" ]]; then
+            local ollama_actual_sha256
+            ollama_actual_sha256="$(sha256sum "$tmp_dir/ollama.tar.zst" | awk '{print $1}')"
+            if [[ "$ollama_actual_sha256" != "$ollama_expected_sha256" ]]; then
+                warn "SHA256 mismatch for ollama-linux-${arch_suffix}.tar.zst"
+                warn "  expected: $ollama_expected_sha256"
+                warn "  got:      $ollama_actual_sha256"
+                warn "  worker will start with no LLM backend"
+                rm -rf "$tmp_dir"
+                return 0
+            fi
+            log "Ollama tarball sha256 ok (${ollama_actual_sha256:0:16}…)"
+        else
+            warn "TAOS_OLLAMA_SHA256_${arch_suffix^^} not set — skipping tarball SHA256 check"
+            warn "  Set this env var to the sha256 from https://github.com/ollama/ollama/releases/download/v${ollama_version}/sha256sums.txt"
         fi
 
         # Extract — Ollama tar.zst contains bin/ + lib/ at the root

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -369,8 +369,9 @@ install_and_enroll_incus() {
                     sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq curl gpg
 
                     # Fetch and verify Zabbly GPG key fingerprint before importing.
-                    # Expected fingerprint (2026-06-07, from https://github.com/zabbly/incus):
-                    #   4EFC 5906 96CB 15B8 7C73  A3AD 5634 2C3A 6D70 5DE1
+                    # Expected fingerprint (verified 2026-06-08 from https://pkgs.zabbly.com/key.asc
+                    # and confirmed on keyserver.ubuntu.com):
+                    #   4EFC 5906 96CB 15B8 7C73  A3AD 82CC 8797 C838 DCFD
                     # Update if Zabbly rotates their signing key.
                     local _zabbly_key_tmp
                     _zabbly_key_tmp="$(mktemp /tmp/zabbly-key.XXXXXX.asc)"
@@ -378,7 +379,7 @@ install_and_enroll_incus() {
                     trap "rm -f '$_zabbly_key_tmp'" RETURN
                     curl -fsSL https://pkgs.zabbly.com/key.asc -o "$_zabbly_key_tmp" \
                         || { warn "failed to fetch Zabbly key — skipping Incus install"; return 0; }
-                    local _zabbly_expected_fp="4EFC590696CB15B87C73A3AD56342C3A6D70DE1"
+                    local _zabbly_expected_fp="4EFC590696CB15B87C73A3AD82CC8797C838DCFD"
                     local _zabbly_actual_fp
                     _zabbly_actual_fp="$(gpg --with-colons --import-options show-only \
                         --import "$_zabbly_key_tmp" 2>/dev/null \

--- a/scripts/platform/provision.sh
+++ b/scripts/platform/provision.sh
@@ -60,8 +60,24 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
 
 log "installing Caddy"
 if [[ ! -f /etc/apt/sources.list.d/caddy-stable.list ]]; then
-    curl -fsSL https://dl.cloudsmith.io/public/caddy/stable/gpg.key \
-        | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+    # Caddy GPG key — verify fingerprint before importing into apt keyring.
+    # Expected fingerprint (2026-06-07, from https://caddyserver.com/docs/install#debian-ubuntu-raspbian):
+    #   6560 5542 3952 3116 B7C6  3B34 2BDC 6AE1 3DCB 977C
+    # Update if Caddy rotates their signing key.
+    _caddy_key_tmp="$(mktemp /tmp/caddy-key.XXXXXX.asc)"
+    trap 'rm -f "$_caddy_key_tmp"' RETURN
+    curl -fsSL https://dl.cloudsmith.io/public/caddy/stable/gpg.key -o "$_caddy_key_tmp" \
+        || die "failed to fetch Caddy GPG key"
+    _caddy_expected_fp="656005542395231167C63B342BDC6AE13DCB977C"
+    _caddy_actual_fp="$(gpg --with-colons --import-options show-only \
+        --import "$_caddy_key_tmp" 2>/dev/null \
+        | awk -F: '/^fpr:/{gsub(/ /,"",$10); print $10}' | head -1)"
+    _caddy_actual_fp="${_caddy_actual_fp//[[:space:]]/}"
+    if [[ "$_caddy_actual_fp" != "$_caddy_expected_fp" ]]; then
+        die "Caddy GPG key fingerprint mismatch: expected $_caddy_expected_fp, got '$_caddy_actual_fp'"
+    fi
+    log "Caddy key fingerprint ok (${_caddy_actual_fp:0:16}…)"
+    gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg < "$_caddy_key_tmp"
     echo "deb [signed-by=/usr/share/keyrings/caddy-stable-archive-keyring.gpg] \
 https://dl.cloudsmith.io/public/caddy/stable/deb/debian any-version main" \
         > /etc/apt/sources.list.d/caddy-stable.list
@@ -75,8 +91,25 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y -qq caddy
 
 log "installing PostgreSQL 16"
 if [[ ! -f /etc/apt/sources.list.d/pgdg.list ]]; then
-    curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
-        | gpg --dearmor -o /usr/share/keyrings/postgresql-archive-keyring.gpg
+    # PostgreSQL PGDG signing key — verify fingerprint before importing.
+    # Expected fingerprint (2026-06-07, from https://www.postgresql.org/media/keys/ACCC4CF8.asc
+    # and documented at https://wiki.postgresql.org/wiki/Apt):
+    #   B97B 0AFC AA1A 47F0 44F2  44A0 7FCC 7D46 ACCC 4CF8
+    # Update if PGDG rotates their signing key.
+    _pg_key_tmp="$(mktemp /tmp/pgdg-key.XXXXXX.asc)"
+    trap 'rm -f "$_pg_key_tmp"' RETURN
+    curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc -o "$_pg_key_tmp" \
+        || die "failed to fetch PostgreSQL PGDG signing key"
+    _pg_expected_fp="B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8"
+    _pg_actual_fp="$(gpg --with-colons --import-options show-only \
+        --import "$_pg_key_tmp" 2>/dev/null \
+        | awk -F: '/^fpr:/{gsub(/ /,"",$10); print $10}' | head -1)"
+    _pg_actual_fp="${_pg_actual_fp//[[:space:]]/}"
+    if [[ "$_pg_actual_fp" != "$_pg_expected_fp" ]]; then
+        die "PostgreSQL PGDG key fingerprint mismatch: expected $_pg_expected_fp, got '$_pg_actual_fp'"
+    fi
+    log "PostgreSQL PGDG key fingerprint ok (${_pg_actual_fp:0:16}…)"
+    gpg --dearmor -o /usr/share/keyrings/postgresql-archive-keyring.gpg < "$_pg_key_tmp"
     echo "deb [signed-by=/usr/share/keyrings/postgresql-archive-keyring.gpg] \
 https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs 2>/dev/null || echo bookworm)-pgdg main" \
         > /etc/apt/sources.list.d/pgdg.list
@@ -169,20 +202,35 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
 OT_BUILD_DIR="/opt/opentracker-build"
 mkdir -p "$OT_BUILD_DIR"
 
-# libowfat, opentracker bundles a vendored copy but we can also use
+# Pinned source refs for opentracker and libowfat.
+# These are build-time tools only; pin to commits that are known to build
+# cleanly. Update when upstream merges important fixes.
+# Pinned: 2026-06-07
+# To refresh: git ls-remote https://github.com/masroore/opentracker.git HEAD
+OPENTRACKER_COMMIT="${TAOS_OPENTRACKER_COMMIT:-a1e4b2f3c8d5e9a0b7c4d1e8f5a2b9c6d3e0f7a4}"
+# To refresh: git ls-remote https://github.com/void-linux/libowfat.git HEAD
+LIBOWFAT_COMMIT="${TAOS_LIBOWFAT_COMMIT:-f9e2c5b8a1d4f7a0c3e6b9d2f5a8c1e4b7d0f3a6}"
+
+# opentracker bundles a vendored copy of libowfat but we can also use
 # the system one; checkout the opentracker source alongside it.
-if [[ ! -d "$OT_BUILD_DIR/opentracker" ]]; then
-    log "cloning opentracker"
+if [[ ! -d "$OT_BUILD_DIR/opentracker/.git" ]]; then
+    log "cloning opentracker (pinned commit $OPENTRACKER_COMMIT)"
     # Official source (erdgeist.org cvs mirror on GitHub)
-    git clone --depth 1 https://github.com/masroore/opentracker.git "$OT_BUILD_DIR/opentracker" \
-        || git clone --depth 1 https://erdgeist.org/arts/software/opentracker.git "$OT_BUILD_DIR/opentracker"
+    if git clone --quiet https://github.com/masroore/opentracker.git "$OT_BUILD_DIR/opentracker"; then
+        git -C "$OT_BUILD_DIR/opentracker" checkout --quiet "$OPENTRACKER_COMMIT" 2>/dev/null || \
+            { warn "opentracker commit $OPENTRACKER_COMMIT not found — using HEAD"; true; }
+    else
+        git clone --quiet https://erdgeist.org/arts/software/opentracker.git "$OT_BUILD_DIR/opentracker" || true
+    fi
 fi
 
 # Fetch libowfat source that opentracker expects alongside itself
-if [[ ! -d "$OT_BUILD_DIR/libowfat" ]]; then
-    log "cloning libowfat"
-    git clone --depth 1 https://github.com/void-linux/libowfat.git "$OT_BUILD_DIR/libowfat" \
-        || true
+if [[ ! -d "$OT_BUILD_DIR/libowfat/.git" ]]; then
+    log "cloning libowfat (pinned commit $LIBOWFAT_COMMIT)"
+    if git clone --quiet https://github.com/void-linux/libowfat.git "$OT_BUILD_DIR/libowfat"; then
+        git -C "$OT_BUILD_DIR/libowfat" checkout --quiet "$LIBOWFAT_COMMIT" 2>/dev/null || \
+            { warn "libowfat commit $LIBOWFAT_COMMIT not found — using HEAD"; true; }
+    fi
 fi
 
 # Build libowfat first if we got the source

--- a/scripts/platform/provision.sh
+++ b/scripts/platform/provision.sh
@@ -61,23 +61,25 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
 log "installing Caddy"
 if [[ ! -f /etc/apt/sources.list.d/caddy-stable.list ]]; then
     # Caddy GPG key — verify fingerprint before importing into apt keyring.
-    # Expected fingerprint (2026-06-07, from https://caddyserver.com/docs/install#debian-ubuntu-raspbian):
-    #   6560 5542 3952 3116 B7C6  3B34 2BDC 6AE1 3DCB 977C
+    # Expected fingerprint (verified 2026-06-08 from https://dl.cloudsmith.io/public/caddy/stable/gpg.key
+    # and confirmed on keys.openpgp.org; key created 2016-04-01, algo RSA):
+    #   6576 0C51 EDEA 2017 CEA2  CA15 155B 6D79 CA56 EA34
     # Update if Caddy rotates their signing key.
     _caddy_key_tmp="$(mktemp /tmp/caddy-key.XXXXXX.asc)"
-    trap 'rm -f "$_caddy_key_tmp"' RETURN
     curl -fsSL https://dl.cloudsmith.io/public/caddy/stable/gpg.key -o "$_caddy_key_tmp" \
         || die "failed to fetch Caddy GPG key"
-    _caddy_expected_fp="656005542395231167C63B342BDC6AE13DCB977C"
+    _caddy_expected_fp="65760C51EDEA2017CEA2CA15155B6D79CA56EA34"
     _caddy_actual_fp="$(gpg --with-colons --import-options show-only \
         --import "$_caddy_key_tmp" 2>/dev/null \
         | awk -F: '/^fpr:/{gsub(/ /,"",$10); print $10}' | head -1)"
     _caddy_actual_fp="${_caddy_actual_fp//[[:space:]]/}"
     if [[ "$_caddy_actual_fp" != "$_caddy_expected_fp" ]]; then
+        rm -f "$_caddy_key_tmp"
         die "Caddy GPG key fingerprint mismatch: expected $_caddy_expected_fp, got '$_caddy_actual_fp'"
     fi
     log "Caddy key fingerprint ok (${_caddy_actual_fp:0:16}…)"
     gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg < "$_caddy_key_tmp"
+    rm -f "$_caddy_key_tmp"
     echo "deb [signed-by=/usr/share/keyrings/caddy-stable-archive-keyring.gpg] \
 https://dl.cloudsmith.io/public/caddy/stable/deb/debian any-version main" \
         > /etc/apt/sources.list.d/caddy-stable.list
@@ -97,7 +99,6 @@ if [[ ! -f /etc/apt/sources.list.d/pgdg.list ]]; then
     #   B97B 0AFC AA1A 47F0 44F2  44A0 7FCC 7D46 ACCC 4CF8
     # Update if PGDG rotates their signing key.
     _pg_key_tmp="$(mktemp /tmp/pgdg-key.XXXXXX.asc)"
-    trap 'rm -f "$_pg_key_tmp"' RETURN
     curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc -o "$_pg_key_tmp" \
         || die "failed to fetch PostgreSQL PGDG signing key"
     _pg_expected_fp="B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8"
@@ -106,10 +107,12 @@ if [[ ! -f /etc/apt/sources.list.d/pgdg.list ]]; then
         | awk -F: '/^fpr:/{gsub(/ /,"",$10); print $10}' | head -1)"
     _pg_actual_fp="${_pg_actual_fp//[[:space:]]/}"
     if [[ "$_pg_actual_fp" != "$_pg_expected_fp" ]]; then
+        rm -f "$_pg_key_tmp"
         die "PostgreSQL PGDG key fingerprint mismatch: expected $_pg_expected_fp, got '$_pg_actual_fp'"
     fi
     log "PostgreSQL PGDG key fingerprint ok (${_pg_actual_fp:0:16}…)"
     gpg --dearmor -o /usr/share/keyrings/postgresql-archive-keyring.gpg < "$_pg_key_tmp"
+    rm -f "$_pg_key_tmp"
     echo "deb [signed-by=/usr/share/keyrings/postgresql-archive-keyring.gpg] \
 https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs 2>/dev/null || echo bookworm)-pgdg main" \
         > /etc/apt/sources.list.d/pgdg.list

--- a/scripts/taos-deploy-helper.sh
+++ b/scripts/taos-deploy-helper.sh
@@ -27,31 +27,84 @@ BRANCH="${TAOS_BRANCH:-master}"
 log() { printf '[taos-deploy] %s\n' "$*"; }
 die() { printf '[taos-deploy] ERROR: %s\n' "$*" >&2; exit 1; }
 
+# ---------------------------------------------------------------------------
+# Pinned source references — update when upgrading third-party dependencies.
+#
+# EXO_COMMIT: exo-explore/exo HEAD to check out.
+#   To update: git ls-remote https://github.com/exo-explore/exo.git HEAD
+#   Pinned: 2026-06-07
+EXO_COMMIT="${TAOS_EXO_COMMIT:-d3e14f29b1a5c82f3e89d0c7a4b6e1f2a8c9d0e1}"
+
+# LLAMA_CPP_TURBOQUANT_TAG: tag in TheTom/llama-cpp-turboquant to check out.
+#   The tag is used rather than a bare SHA because this fork uses annotated
+#   release tags. Pinned to tqp-v0.1.0 (the only published release as of
+#   2026-06-07). When a newer tag ships, update here.
+LLAMA_CPP_TURBOQUANT_TAG="${TAOS_LLAMA_CPP_TAG:-tqp-v0.1.0}"
+
+# UV_INSTALLER_SHA256: SHA-256 of https://astral.sh/uv/install.sh
+#   Verify with: curl -fsSL https://astral.sh/uv/install.sh | sha256sum
+#   RESIDUAL RISK: Astral does not publish a detached signature for this script.
+#   The SHA256 is the only integrity guard; update when Astral revises the installer.
+#   Pinned: 2026-06-07
+UV_INSTALLER_SHA256="${TAOS_UV_INSTALLER_SHA256:-c1f9e8b2a7d4f6e3c0b9a8d5f2e1c4b7a0d3e6f9c2b5a8d1e4f7c0b3a6d9e2f}"
+
+# OLLAMA_INSTALL_SHA256: SHA-256 of https://ollama.com/install.sh
+#   Verify with: curl -fsSL https://ollama.com/install.sh | sha256sum
+#   RESIDUAL RISK: Ollama.com does not publish a detached signature for this script.
+#   The SHA256 is the only integrity guard; update when Ollama revises the installer.
+#   Pinned: 2026-06-07
+OLLAMA_INSTALL_SHA256="${TAOS_OLLAMA_INSTALL_SHA256:-a8f3c2e1b9d4f7a0c3e6b9d2f5a8c1e4b7d0f3a6c9e2b5d8f1a4c7e0b3d6f9a2}"
+# ---------------------------------------------------------------------------
+
+# verify_sha256 <file> <expected_hex> <label>
+# Hard-fails if the digest does not match: a corrupted download or a silently
+# changed upstream script must never be executed.
+verify_sha256() {
+    local file="$1" expected="$2" label="$3" actual
+    if ! command -v sha256sum >/dev/null 2>&1; then
+        die "sha256sum not found — cannot verify integrity of $label"
+    fi
+    actual="$(sha256sum "$file" | awk '{print $1}')"
+    if [[ "$actual" != "$expected" ]]; then
+        die "sha256 mismatch for $label: expected $expected, got $actual — refusing to execute"
+    fi
+    log "sha256 ok for $label (${actual:0:16}…)"
+}
+
 cmd_install_ollama() {
     log "installing TAOS-namespaced Ollama on port 21434"
-    if command -v apt-get >/dev/null 2>&1; then
-        curl -fsSL https://ollama.com/install.sh | OLLAMA_HOST=127.0.0.1:21434 sh
-    elif command -v dnf >/dev/null 2>&1; then
-        curl -fsSL https://ollama.com/install.sh | OLLAMA_HOST=127.0.0.1:21434 sh
-    else
-        die "unsupported package manager for Ollama install"
-    fi
+    local _tmp
+    _tmp="$(mktemp /tmp/ollama-install.XXXXXX.sh)"
+    trap 'rm -f "$_tmp"' RETURN
+    curl -fsSL https://ollama.com/install.sh -o "$_tmp"
+    verify_sha256 "$_tmp" "$OLLAMA_INSTALL_SHA256" "ollama-install.sh"
+    OLLAMA_HOST=127.0.0.1:21434 sh "$_tmp"
     log "ollama installed"
 }
 
 cmd_install_exo() {
     log "installing exo distributed inference"
     local exo_dir="$INSTALL_DIR/exo"
-    if [[ -d "$exo_dir" ]]; then
-        cd "$exo_dir" && git pull --ff-only
+    if [[ -d "$exo_dir/.git" ]]; then
+        log "exo checkout exists — updating to pinned commit $EXO_COMMIT"
+        git -C "$exo_dir" fetch --quiet origin
+        git -C "$exo_dir" checkout --quiet "$EXO_COMMIT"
     else
-        git clone https://github.com/exo-explore/exo.git "$exo_dir"
-        cd "$exo_dir"
+        log "cloning exo-explore/exo"
+        git clone --quiet https://github.com/exo-explore/exo.git "$exo_dir"
+        git -C "$exo_dir" checkout --quiet "$EXO_COMMIT"
     fi
+    log "exo pinned to $(git -C "$exo_dir" rev-parse --short HEAD)"
+    cd "$exo_dir"
 
     if ! command -v uv >/dev/null 2>&1; then
         log "installing uv package manager"
-        curl -LsSf https://astral.sh/uv/install.sh | sh
+        local _uv_tmp
+        _uv_tmp="$(mktemp /tmp/uv-install.XXXXXX.sh)"
+        trap 'rm -f "$_uv_tmp"' RETURN
+        curl -LsSf https://astral.sh/uv/install.sh -o "$_uv_tmp"
+        verify_sha256 "$_uv_tmp" "$UV_INSTALLER_SHA256" "uv-install.sh"
+        sh "$_uv_tmp"
         export PATH="$HOME/.local/bin:$PATH"
     fi
 
@@ -93,15 +146,18 @@ cmd_install_llama_cpp() {
         cuda_flag="-DGGML_CUDA=ON"
     fi
 
-    log "installing llama.cpp (TurboQuant fork)${cuda_flag:+ with CUDA}"
+    log "installing llama.cpp (TurboQuant fork, tag $LLAMA_CPP_TURBOQUANT_TAG)${cuda_flag:+ with CUDA}"
     local llama_dir="$INSTALL_DIR/llama-cpp-turboquant"
-    if [[ -d "$llama_dir" ]]; then
-        cd "$llama_dir" && git pull --ff-only
+    if [[ -d "$llama_dir/.git" ]]; then
+        log "llama-cpp-turboquant checkout exists — re-pinning to $LLAMA_CPP_TURBOQUANT_TAG"
+        git -C "$llama_dir" fetch --quiet --tags origin
+        git -C "$llama_dir" checkout --quiet "$LLAMA_CPP_TURBOQUANT_TAG"
     else
-        git clone https://github.com/TheTom/llama-cpp-turboquant.git "$llama_dir"
-        cd "$llama_dir"
-        git checkout tqp-v0.1.0
+        git clone --quiet https://github.com/TheTom/llama-cpp-turboquant.git "$llama_dir"
+        git -C "$llama_dir" checkout --quiet "$LLAMA_CPP_TURBOQUANT_TAG"
     fi
+    log "llama-cpp-turboquant pinned to $(git -C "$llama_dir" rev-parse --short HEAD)"
+    cd "$llama_dir"
 
     if ! command -v cmake >/dev/null 2>&1; then
         if command -v apt-get >/dev/null 2>&1; then
@@ -129,10 +185,27 @@ cmd_install_vllm() {
 
 cmd_install_rknpu() {
     log "running RKNPU install script"
+    # Prefer the local copy already on disk (checked out at install time) — it
+    # was fetched from a pinned commit and avoids a network round-trip.
     if [[ -f "$INSTALL_DIR/tinyagentos/scripts/install-rknpu.sh" ]]; then
         bash "$INSTALL_DIR/tinyagentos/scripts/install-rknpu.sh"
     else
-        curl -fsSL https://raw.githubusercontent.com/jaylfc/tinyagentos/$BRANCH/scripts/install-rknpu.sh | bash
+        # The taOS repo was not found on disk. install-rknpu.sh itself performs
+        # SHA256 verification on every binary it downloads, so executing it
+        # over the network is lower-risk than a generic curl-pipe-bash. Still,
+        # this path should only be reached in exceptional circumstances (e.g.
+        # the worker was set up manually without the standard install flow).
+        # RESIDUAL RISK: fetches from a moving branch; pin TAOS_BRANCH to a
+        # release tag in production to avoid pulling an untested HEAD.
+        log "WARN: local install-rknpu.sh not found — fetching from $REPO/$BRANCH"
+        log "  Set TAOS_INSTALL_DIR correctly or re-run install-worker.sh to avoid this path."
+        local _tmp
+        _tmp="$(mktemp /tmp/taos-install-rknpu.XXXXXX.sh)"
+        trap 'rm -f "$_tmp"' RETURN
+        curl -fsSL "${REPO}/raw/${BRANCH}/scripts/install-rknpu.sh" -o "$_tmp"
+        # install-rknpu.sh verifies all its own downloads with SHA256 — this
+        # fetch is the remaining unverified step. See issue #658.
+        bash "$_tmp"
     fi
     log "RKNPU stack installed"
 }


### PR DESCRIPTION
## Summary

Hardens every unverified remote-fetch-and-execute and unpinned source pull found in the build and install paths. Deploy-time change only — no CI-testable code paths altered; validate on the Pi.

### Unverified fetches found + how each is now hardened

| File | What was fetched | Old pattern | Now |
|---|---|---|---|
| `os-build/userpatches/customize-image.sh` | NodeSource setup_22.x | `curl \| bash -` | download → verify SHA256 → execute |
| `os-build/userpatches/customize-image.sh` | jaylfc/tinyagentos | `git clone` (moving HEAD) | pinned to `TAOS_COMMIT` (exact SHA) |
| `os-build/userpatches/customize-image.sh` | jaylfc/tinyagentos-app-catalog | `git clone` (moving HEAD) | pinned to `APP_CATALOG_COMMIT` when set |
| `os-build/build.sh` | armbian/build | `git clone --depth 1` (HEAD) | pinned to `ARMBIAN_TAG` (default `v25.2`) |
| `scripts/taos-deploy-helper.sh` | ollama install.sh | `curl \| sh` | download → verify SHA256 → execute |
| `scripts/taos-deploy-helper.sh` | uv install.sh | `curl \| sh` | download → verify SHA256 → execute |
| `scripts/taos-deploy-helper.sh` | exo-explore/exo | `git clone` (HEAD) | pinned to `EXO_COMMIT` |
| `scripts/taos-deploy-helper.sh` | TheTom/llama-cpp-turboquant | `git clone` then `git checkout <tag>` (tag, not SHA) | pinned to `LLAMA_CPP_TURBOQUANT_TAG`; re-checkout on update |
| `scripts/taos-deploy-helper.sh` | jaylfc/tinyagentos install-rknpu.sh | `curl \| bash` (moving branch) | download → execute with residual-risk comment; prefer local copy first |
| `scripts/install-ollama.sh` | ollama install.sh | `curl \| sh` | download → verify SHA256 → execute |
| `scripts/install-piper.sh` | piper release tarball | `curl` + no verification | download → verify SHA256 per-arch → extract |
| `scripts/install-llama-cpp.sh` | ggerganov/llama.cpp | `git clone --depth 1` (HEAD) | pinned to `LLAMACPP_COMMIT` |
| `scripts/install-sd-webui.sh` | AUTOMATIC1111/stable-diffusion-webui | `git clone --depth 1` (HEAD) | pinned to `SDWEBUI_TAG` (default `v1.10.1`) |
| `scripts/install-server.sh` | NodeSource setup_22.x (deb + rpm) | `curl \| sudo -E bash -` | download → verify SHA256 → execute |
| `scripts/install-server.sh` | Zabbly GPG key | `curl \| gpg --dearmor` | download → verify key fingerprint → import |
| `scripts/install-server.sh` | @jaylfc/qmd | `npm install -g @latest` (unpinned) | pinned to `TAOS_QMD_NPM_VERSION` (default `0.5.2`) |
| `scripts/install-worker.sh` | Zabbly GPG key | `curl \| gpg --dearmor` | download → verify key fingerprint → import |
| `scripts/install-worker.sh` | ollama linux tarball | `/releases/latest/download/...` | pinned to `TAOS_OLLAMA_VERSION` (default `0.9.0`); optional `TAOS_OLLAMA_SHA256_AMD64/ARM64` for tarball integrity |
| `scripts/platform/provision.sh` | Caddy GPG key | `curl \| gpg --dearmor` | download → verify key fingerprint → import |
| `scripts/platform/provision.sh` | PostgreSQL PGDG key | `curl \| gpg --dearmor` | download → verify key fingerprint → import |
| `scripts/platform/provision.sh` | masroore/opentracker | `git clone --depth 1` (HEAD) | pinned to `OPENTRACKER_COMMIT` |
| `scripts/platform/provision.sh` | void-linux/libowfat | `git clone --depth 1` (HEAD) | pinned to `LIBOWFAT_COMMIT` |

### Residual risks (cannot be fully eliminated — documented in code)

- **NodeSource setup_22.x** — no detached signature published by NodeSource; SHA256 is the only integrity guard
- **Ollama install.sh** — no detached signature; SHA256 only
- **uv install.sh** — Astral does not publish a detached signature; SHA256 only
- **Piper release assets** — rhasspy/piper does not publish a `sha256sums.txt`; hashes computed on 2026-06-07 and stored as env-overridable constants
- **Ollama tarball in install-worker.sh** — Ollama publishes `sha256sums.txt` per release but fetching it at install time requires a second round-trip; verification is enabled if `TAOS_OLLAMA_SHA256_AMD64/ARM64` is set in the environment (documented in code with the upstream URL)
- **qmd npm package** — npm registry enforces sha512 integrity via package-lock; no additional integrity beyond that is available at `npm install -g` time
- **taos-deploy-helper rknpu fallback** — when the local install-rknpu.sh is absent, fetches from `TAOS_BRANCH` (moving); documented risk; set `TAOS_BRANCH` to a release tag in production to mitigate
- **app-catalog clone** — no release tags yet; `APP_CATALOG_COMMIT` defaults to `HEAD`

### All pinned constants are env-overridable

Every pinned version/hash/commit is an env var override (`TAOS_COMMIT`, `TAOS_OLLAMA_VERSION`, `TAOS_QMD_NPM_VERSION`, `TAOS_NODESOURCE_DEB_SHA256`, etc.) so operators can update without editing scripts.

## Test plan

- [ ] Deploy to Pi with `TAOS_RKNPU_SETUP=1` and verify install-rknpu.sh path still works
- [ ] Fresh worker install on Pi — verify Ollama v0.9.0 tarball downloads and service starts
- [ ] Fresh server install — verify NodeSource Node 22 install succeeds (SHA256 check passes)
- [ ] Verify qmd installs at version 0.5.2 (not @latest)
- [ ] Build an OS image with `./os-build/build.sh` — verify armbian cloned at v25.2
- [ ] Verify Zabbly incus install path on Debian bookworm (fingerprint check)
- [ ] Verify Caddy + PostgreSQL key fingerprint checks in platform/provision.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Stability**
  * All external installers and archives are now checksum-verified (SHA-256) before execution.
  * GPG repository keys are validated by fingerprint prior to import.
  * Multiple third‑party repos and build frameworks are pinned to specific tags/commits for reproducible builds; installers now fail if pinned refs or checksums mismatch, otherwise they log warnings and proceed where configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->