### PR TITLE
feat(browser): custom CDP-enabled Neko Chromium image (option C foundation)

### DIFF
--- a/.github/workflows/build-neko-cdp-image.yml
+++ b/.github/workflows/build-neko-cdp-image.yml
@@ -1,0 +1,110 @@
+name: Build Neko CDP image
+
+# Builds and pushes ghcr.io/jaylfc/taos-neko-cdp for arm64 (RK3588 / Pi) +
+# amd64 (x86 nodes). Triggered on changes to the Dockerfile or on demand.
+#
+# The CDP-enabled image is the option C foundation: Chromium >=148 from
+# trixie-security + DeveloperToolsAvailability=0 + CDP flags bound to
+# 127.0.0.1:9222 + --enable-dev-shm-usage (requires --shm-size=4g at run).
+
+on:
+  push:
+    branches: [master, dev]
+    paths:
+      - 'app-catalog/streaming/neko-browser/Dockerfile.cdp'
+      - '.github/workflows/build-neko-cdp-image.yml'
+  workflow_dispatch: {}
+  schedule:
+    # Weekly rebuild to pick up trixie-security Chromium updates (Tuesdays 04:00 UTC).
+    - cron: '0 4 * * 2'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            platform: linux/amd64
+          - runner: ubuntu-24.04-arm
+            platform: linux/arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract platform slug
+        id: slug
+        run: echo "slug=$(echo '${{ matrix.platform }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push per-arch digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: app-catalog/streaming/neko-browser
+          file: app-catalog/streaming/neko-browser/Dockerfile.cdp
+          platforms: ${{ matrix.platform }}
+          push: true
+          outputs: type=image,name=ghcr.io/jaylfc/taos-neko-cdp,push-by-digest=true,name-canonical=true
+          cache-from: type=gha,scope=neko-cdp-${{ steps.slug.outputs.slug }}
+          cache-to: type=gha,mode=max,scope=neko-cdp-${{ steps.slug.outputs.slug }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: digest-${{ steps.slug.outputs.slug }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: digest-*
+          path: /tmp/digests
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push multi-arch manifest
+        working-directory: /tmp/digests
+        run: |
+          digests=$(ls | awk '{print "ghcr.io/jaylfc/taos-neko-cdp@sha256:" $1}')
+          docker buildx imagetools create \
+            -t ghcr.io/jaylfc/taos-neko-cdp:latest \
+            -t ghcr.io/jaylfc/taos-neko-cdp:${{ github.sha }} \
+            $digests
+
+      - name: Inspect final manifest
+        run: docker buildx imagetools inspect ghcr.io/jaylfc/taos-neko-cdp:latest

--- a/app-catalog/streaming/neko-browser/Dockerfile.cdp
+++ b/app-catalog/streaming/neko-browser/Dockerfile.cdp
@@ -1,0 +1,89 @@
+# taOS Neko Chromium with CDP enabled — option C foundation.
+#
+# Why: The stock Neko chromium image ships Chromium 146 with a managed policy
+# that disables DevTools (DeveloperToolsAvailability=2), and Chromium 146 has
+# a flat-session CDP bug even when the policy is patched. This image fixes
+# both: upgrades to Chromium >=148 from Debian trixie-security, patches the
+# policy to DeveloperToolsAvailability=0, and adds the CDP launch flags with
+# the remote-debugging port bound to 127.0.0.1 only (security: never 0.0.0.0).
+#
+# Multi-arch: arm64 (primary — RK3588/Orange Pi 5 Plus) + amd64 (x86 nodes).
+# Upstream provides a multi-arch base so the same Dockerfile works for both;
+# the CI build matrix handles the per-arch push.
+#
+# Requires: docker run --shm-size=4g (stock Neko uses 2g; 4g is required for
+# stable CDP page sessions with HW-decode enabled).
+#
+# CDP endpoint (inside the container, not published to host network):
+#   http://127.0.0.1:9222   — curl .../json/version to confirm.
+# The taOS launcher maps this to a host-local address via docker exec / a
+# dedicated port binding — see browser_container.py build_neko_run_args.
+
+FROM ghcr.io/m1k1o/neko/chromium:latest
+
+# ── 1. Upgrade Chromium to >=148 from Debian trixie-security ────────────────
+# The stock Neko chromium image is Debian trixie-based, so trixie-security is
+# the correct pin target. Chromium >=148 fixes the flat-session CDP bug that
+# affects 146. We install what is current in trixie-security at build time;
+# the exact version in the image is recorded in the LABEL below.
+#
+# NOTE FOR JAY: if the build fails with "Package 'chromium' has no installation
+# candidate" or the installed version is <148, the trixie-security pool may
+# have rolled forward. Check:
+#   docker run --rm --platform linux/arm64 debian:trixie-slim \
+#     bash -c "apt-get update -qq && apt-cache policy chromium | head -5"
+# and pin the current >=148 version. The exact version is intentionally NOT
+# hardcoded here so the image picks the latest >=148 trixie-security build.
+RUN apt-get update -qq \
+    && apt-get install -y --no-install-recommends \
+         -t trixie-security \
+         chromium \
+    && chromium --version \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── 2. Patch the managed policy: re-enable DevTools ─────────────────────────
+# The stock image ships /etc/chromium/policies/managed/policies.json with
+# DeveloperToolsAvailability=2 (fully disabled). Set it to 0 (allowed).
+RUN python3 -c "
+import json, pathlib
+p = pathlib.Path('/etc/chromium/policies/managed/policies.json')
+data = json.loads(p.read_text()) if p.exists() else {}
+data['DeveloperToolsAvailability'] = 0
+p.parent.mkdir(parents=True, exist_ok=True)
+p.write_text(json.dumps(data, indent=2))
+print('policy patched:', data)
+"
+
+# ── 3. CDP launch flags (127.0.0.1-only binding) ────────────────────────────
+# Neko reads Chromium flags from drop-in files under /etc/chromium.d/.
+# We add a taOS-cdp drop-in that:
+#   - Binds CDP to 127.0.0.1:9222 (never 0.0.0.0 — security requirement).
+#   - Allows any origin to connect (required for docker-exec-tunnelled access).
+#   - Enables touch events (required for mobile-emulation / option C UX).
+#
+# We also DROP --disable-dev-shm-usage (step 4) via a second drop-in so the
+# VPU/GPU can use the larger /dev/shm backed by --shm-size=4g.
+RUN mkdir -p /etc/chromium.d \
+    && printf '%s\n' \
+        '--remote-debugging-port=9222' \
+        '--remote-debugging-address=127.0.0.1' \
+        '--remote-allow-origins=*' \
+        '--touch-events=enabled' \
+       > /etc/chromium.d/taos-cdp
+
+# ── 4. Remove --disable-dev-shm-usage ───────────────────────────────────────
+# The stock Neko supervisord config passes --disable-dev-shm-usage which
+# forces Chromium to use /tmp instead of /dev/shm, defeating the benefit of
+# --shm-size=4g. We override by writing a drop-in that explicitly restores the
+# default (Chromium ignores unknown flags in drop-ins gracefully).
+# The container MUST be started with --shm-size=4g by the launcher.
+RUN printf '%s\n' \
+        '--enable-dev-shm-usage' \
+       > /etc/chromium.d/taos-shm
+
+LABEL taos.app.id="neko-browser-cdp" \
+      taos.cdp.port="9222" \
+      taos.cdp.bind="127.0.0.1" \
+      taos.chromium.min_version="148" \
+      taos.shm_required="4g" \
+      taos.hardware.soc="multi-arch"

--- a/app-catalog/streaming/neko-browser/NOTES-cdp.md
+++ b/app-catalog/streaming/neko-browser/NOTES-cdp.md
@@ -1,0 +1,139 @@
+# taOS Neko CDP image — recipe notes + Pi test plan
+
+## What this image fixes
+
+The stock `ghcr.io/m1k1o/neko/chromium:latest` ships Chromium 146 with two
+CDP blockers:
+
+1. `/etc/chromium/policies/managed/policies.json` sets
+   `DeveloperToolsAvailability: 2` — CDP flat-sessions are silently rejected.
+2. Chromium 146 has a flat-session bug; CDP does not work even with the policy
+   patched.
+
+`Dockerfile.cdp` applies the proven fix:
+
+| Step | What | Why |
+|---|---|---|
+| 1 | Upgrade Chromium to >=148 via `trixie-security` | Fixes the flat-session CDP bug present in 146 |
+| 2 | Patch `policies.json` to `DeveloperToolsAvailability: 0` | Re-enables DevTools / CDP |
+| 3 | Drop-in `/etc/chromium.d/taos-cdp`: `--remote-debugging-port=9222 --remote-debugging-address=127.0.0.1 --remote-allow-origins=* --touch-events=enabled` | Binds CDP to loopback only (security) |
+| 4 | Drop-in `/etc/chromium.d/taos-shm`: `--enable-dev-shm-usage` | Lets Chromium use the larger /dev/shm from `--shm-size=4g` |
+
+**Security:** CDP is bound to `127.0.0.1` only — never `0.0.0.0`.
+Access from the taOS host is via `docker exec` / a host-local port tunnel,
+not a publicly-exposed port.
+
+---
+
+## Image name
+
+```
+ghcr.io/jaylfc/taos-neko-cdp:latest
+```
+
+Architectures: `linux/arm64` (primary — RK3588), `linux/amd64` (x86 nodes).
+
+---
+
+## Pi test plan (RK3588, arm64)
+
+### Prerequisites
+
+- Pi running taOS (Orange Pi 5 Plus, arm64).
+- Docker installed and running.
+- At least 4 GB RAM free for the container.
+
+### Step 1 — pull the image
+
+```bash
+docker pull ghcr.io/jaylfc/taos-neko-cdp:latest
+docker inspect ghcr.io/jaylfc/taos-neko-cdp:latest | grep -i arch
+# expect: "Architecture": "arm64"
+```
+
+### Step 2 — spin the container
+
+```bash
+docker run -d --rm \
+  --name taos-neko-cdp-test \
+  --shm-size=4g \
+  -p 18080:8080 \
+  -e NEKO_MEMBER_MULTIUSER_USER_PASSWORD=testuser \
+  -e NEKO_MEMBER_MULTIUSER_ADMIN_PASSWORD=testadmin \
+  -e NEKO_WEBRTC_EPR=59100-59110 \
+  -e NEKO_WEBRTC_NAT1TO1=127.0.0.1 \
+  -e NEKO_DESKTOP_SCREEN=1280x720@30 \
+  --device /dev/mpp_service \
+  --device /dev/dri \
+  --device /dev/rga \
+  ghcr.io/jaylfc/taos-neko-cdp:latest
+```
+
+### Step 3 — confirm Chromium version >=148
+
+```bash
+docker exec taos-neko-cdp-test chromium --version
+# expect: Chromium 148.x.x.x  (or higher)
+```
+
+### Step 4 — confirm CDP is reachable
+
+CDP is bound to `127.0.0.1` inside the container, so use `docker exec`:
+
+```bash
+docker exec taos-neko-cdp-test \
+  curl -sf http://127.0.0.1:9222/json/version | python3 -m json.tool
+# expect: JSON with "Browser": "Chrome/148..." and "webSocketDebuggerUrl"
+```
+
+### Step 5 — confirm policy patch (DeveloperToolsAvailability=0)
+
+```bash
+docker exec taos-neko-cdp-test \
+  cat /etc/chromium/policies/managed/policies.json
+# expect: {"DeveloperToolsAvailability": 0}
+```
+
+### Step 6 — open a CDP page session (flat-session smoke)
+
+```bash
+# List targets
+docker exec taos-neko-cdp-test \
+  curl -sf http://127.0.0.1:9222/json/list
+# expect: JSON array with at least one entry (the default Chromium tab)
+```
+
+### Step 7 — open the Neko stream in a browser
+
+Navigate to `http://<pi-ip>:18080` in a browser on the same LAN.
+Log in with `testuser` / `testuser`. Confirm the Chromium stream appears and
+is interactive.
+
+### Step 8 — clean up
+
+```bash
+docker stop taos-neko-cdp-test
+```
+
+---
+
+## Known unknowns (flag for Jay)
+
+- **Exact Chromium version:** `Dockerfile.cdp` installs the current
+  `trixie-security` chromium at build time without pinning an exact version.
+  This means the version baked into the image depends on what trixie-security
+  has at the moment the CI workflow ran. The `docker exec chromium --version`
+  step above reveals the exact version. If it is <148, the trixie-security
+  pool has not yet landed 148 on arm64 — check the pool and pin explicitly.
+  At the time of writing (2026-06), trixie-security carries 148.x on both
+  amd64 and arm64, but this should be verified on the first build.
+
+- **rkmpp HW-encode:** this image uses software encode (same as the
+  validated stock base). The rkmpp GStreamer layer (#624) is a follow-on that
+  extends this image; the CDP fix is independent and ships first.
+
+- **CDP inside taOS launcher:** `browser_container.py` sets `cdp_url =
+  "http://127.0.0.1:9222"` for RK3588 sessions. The taOS backend currently
+  does not publish CDP port 9222 from the container to the host — wiring the
+  host-side port binding or docker-exec tunnel is the next step in the agent
+  automation layer (tracked separately).

--- a/tests/test_browser_container.py
+++ b/tests/test_browser_container.py
@@ -1,7 +1,8 @@
 from types import SimpleNamespace
 from tinyagentos.worker.browser_container import (
     resolve_neko_image, NekoImageSpec,
-    DEFAULT_NEKO_IMAGE, DEFAULT_NEKO_GPU_IMAGE, DEFAULT_NEKO_RK3588_IMAGE,
+    DEFAULT_NEKO_CDP_IMAGE, DEFAULT_NEKO_IMAGE, DEFAULT_NEKO_GPU_IMAGE,
+    DEFAULT_NEKO_RK3588_IMAGE,
     NEKO_SCREEN, NEKO_SCREEN_MOBILE, MOBILE_CHROMIUM_CONF,
 )
 
@@ -166,3 +167,21 @@ async def test_runner_start_desktop_mock_returns_details():
     out = await runner.start(session_id="desktop-session", profile_volume="v", mobile=False)
     assert "container_id" in out
     assert "neko_url" in out
+
+
+# ---------------------------------------------------------------------------
+# CDP image (option C foundation)
+# ---------------------------------------------------------------------------
+
+def test_rk3588_image_is_cdp_image():
+    """RK3588 must resolve to the CDP-enabled custom image."""
+    assert DEFAULT_NEKO_RK3588_IMAGE == DEFAULT_NEKO_CDP_IMAGE
+
+
+@pytest.mark.asyncio
+async def test_rk3588_runner_exposes_cdp_url():
+    """Running on RK3588 hardware must yield a cdp_url pointing to 127.0.0.1:9222."""
+    hw = _hw(soc="rk3588")
+    runner = BrowserContainerRunner(node_ip="10.0.0.2", mock=True, hw_profile=hw)
+    out = await runner.start(session_id="cdp-session", profile_volume="v")
+    assert out["cdp_url"] == "http://127.0.0.1:9222"

--- a/tests/worker/test_browser_container.py
+++ b/tests/worker/test_browser_container.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from tinyagentos.worker.browser_container import (
+    DEFAULT_NEKO_CDP_IMAGE,
     DEFAULT_NEKO_GPU_IMAGE,
     DEFAULT_NEKO_IMAGE,
     NEKO_PROFILE_MOUNT,
@@ -87,8 +88,14 @@ class TestBuildNekoRunArgs:
         env_pairs = {args[i + 1] for i, a in enumerate(args) if a == "-e"}
         assert "NEKO_WEBRTC_NAT1TO1=10.0.0.5" in env_pairs
 
-    def test_shm_size(self):
+    def test_shm_size_default_is_4g(self):
+        # Default raised to 4g — required by the CDP image for stable page
+        # sessions; safe (and better) for all other images too.
         args = build_neko_run_args(**self._base_kwargs())
+        assert "--shm-size=4g" in args
+
+    def test_shm_size_custom(self):
+        args = build_neko_run_args(**self._base_kwargs(), shm_size="2g")
         assert "--shm-size=2g" in args
 
     def test_volume_mount(self):
@@ -235,6 +242,23 @@ class TestBrowserContainerRunnerMock:
         r2 = await runner.start(session_id="sess-2", profile_volume="vol2")
         assert r1["http_port"] != r2["http_port"]
         assert r1["epr_lo"] != r2["epr_lo"]
+
+    async def test_cdp_image_yields_cdp_url(self):
+        """When resolve_neko_image selects the CDP image, cdp_url is set."""
+        from types import SimpleNamespace
+        hw = SimpleNamespace(cpu=SimpleNamespace(soc="rk3588"), gpu=None)
+        runner = BrowserContainerRunner(node_ip="10.0.0.5", mock=True, hw_profile=hw)
+        result = await runner.start(session_id="sess-cdp", profile_volume="vol1")
+        assert result["cdp_url"] == "http://127.0.0.1:9222"
+
+    async def test_non_cdp_image_cdp_url_is_none(self):
+        """Stock images (software/GPU) must not expose a cdp_url."""
+        from types import SimpleNamespace
+        # No SOC, no CUDA → software encode → DEFAULT_NEKO_IMAGE (not CDP)
+        hw = SimpleNamespace(cpu=SimpleNamespace(soc=""), gpu=SimpleNamespace(type="", cuda=False, vulkan=False))
+        runner = BrowserContainerRunner(node_ip="10.0.0.5", mock=True, hw_profile=hw)
+        result = await runner.start(session_id="sess-sw", profile_volume="vol1")
+        assert result["cdp_url"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/tinyagentos/worker/browser_container.py
+++ b/tinyagentos/worker/browser_container.py
@@ -17,11 +17,18 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_NEKO_IMAGE = "ghcr.io/m1k1o/neko/chromium:latest"
 DEFAULT_NEKO_GPU_IMAGE = "ghcr.io/m1k1o/neko/nvidia-chromium:latest"
-# Temporarily the validated multi-arch base (runs healthy on the Pi, software
-# encode). The custom rkmpp HW-encode image (built FROM this + Rockchip GStreamer
-# from the Armbian/Rockchip repos) is tracked in #624; flip this back once it's
-# built + published. Device nodes are still passed (harmless on RK3588).
-DEFAULT_NEKO_RK3588_IMAGE = "ghcr.io/m1k1o/neko/chromium:latest"
+# Custom CDP-enabled image (option C foundation, #<PR>).
+# Chromium >=148 from trixie-security + DeveloperToolsAvailability=0 +
+# --remote-debugging-port=9222 bound to 127.0.0.1 + --enable-dev-shm-usage.
+# Requires --shm-size=4g at container run time.
+# Built for arm64 (RK3588 primary) + amd64.
+DEFAULT_NEKO_CDP_IMAGE = "ghcr.io/jaylfc/taos-neko-cdp:latest"
+# RK3588 uses the CDP image so agent automation is available out of the box
+# on the Pi. The rkmpp HW-encode layer (#624) will extend this image once
+# the GStreamer Rockchip packages are validated; for now software encode is
+# the fallback (RK3588 hardware decode of page content still works via the
+# kernel driver even without GStreamer rkmpp).
+DEFAULT_NEKO_RK3588_IMAGE = DEFAULT_NEKO_CDP_IMAGE
 NEKO_SCREEN = "1280x720@30"
 NEKO_SCREEN_MOBILE = "800x1600@30"
 NEKO_PROFILE_MOUNT = "/home/neko"
@@ -87,6 +94,7 @@ def build_neko_run_args(
     image: str | None = None,
     device_args: list[str] | None = None,
     mobile: bool = False,
+    shm_size: str = "4g",
 ) -> list[str]:
     """Return the full ``docker run`` argv (starting with 'docker') for a Neko
     Chromium session, per the validated spike recipe.
@@ -94,6 +102,10 @@ def build_neko_run_args(
     When ``mobile=True`` the container runs portrait (800x1600@30) and mounts
     the mobile Chromium supervisord config so Chromium presents a mobile UA,
     touch events, and a 3x device scale factor.
+
+    ``shm_size`` controls ``--shm-size``. The default is ``"4g"`` — required
+    by the CDP-enabled image (``DEFAULT_NEKO_CDP_IMAGE``) for stable page
+    sessions; 4g is safe for all images and strictly better than the old 2g.
     """
     if image is None:
         image = DEFAULT_NEKO_GPU_IMAGE if gpu else DEFAULT_NEKO_IMAGE
@@ -110,7 +122,7 @@ def build_neko_run_args(
         "-e", f"NEKO_MEMBER_MULTIUSER_ADMIN_PASSWORD={admin_pwd}",
         "-e", f"NEKO_WEBRTC_EPR={epr_lo}-{epr_hi}",
         "-e", f"NEKO_WEBRTC_NAT1TO1={node_ip}",
-        "--shm-size=2g",
+        f"--shm-size={shm_size}",
         "-v", f"{profile_volume}:{NEKO_PROFILE_MOUNT}",
     ]
     if mobile:
@@ -245,8 +257,16 @@ class BrowserContainerRunner:
         # (full-bleed but no mouse/keyboard control).  Interactive sessions
         # need it absent.
         neko_url = f"http://{self.node_ip}:{http_port}/?usr=neko&pwd={user_pwd}"
-        cdp_url = None  # CDP not exposed by this image in Phase 1 (deferred to Phase 2)
         spec = resolve_neko_image(self.hw_profile)
+        # CDP is available when the image is the CDP-enabled custom build.
+        # The port is bound to 127.0.0.1 inside the container; the launcher
+        # accesses it via `docker exec` / a loopback port binding on the host.
+        # None for images that don't expose CDP (stock Neko, GPU image).
+        cdp_url = (
+            "http://127.0.0.1:9222"
+            if spec.image == DEFAULT_NEKO_CDP_IMAGE
+            else None
+        )
 
         if self.mock:
             container_id = f"mock-neko-{session_id[:8]}"


### PR DESCRIPTION
## Summary

- **Dockerfile.cdp** (`app-catalog/streaming/neko-browser/`): four-step recipe that fixes the two CDP blockers in the stock Neko image — upgrades Chromium to >=148 from Debian trixie-security (fixes the flat-session bug in 146), patches `DeveloperToolsAvailability` from 2→0 (removes the policy block), adds CDP flags bound to `127.0.0.1:9222` (never 0.0.0.0 — security), and restores `--enable-dev-shm-usage` so the 4g shm is usable.
- **build-neko-cdp-image.yml**: CI workflow that builds arm64 + amd64 digests separately (native runners) and merges into a multi-arch manifest at `ghcr.io/jaylfc/taos-neko-cdp:latest`. Triggers on Dockerfile changes, `workflow_dispatch`, and a weekly Tuesday cron for trixie-security Chromium updates.
- **browser_container.py**: adds `DEFAULT_NEKO_CDP_IMAGE = "ghcr.io/jaylfc/taos-neko-cdp:latest"`, points `DEFAULT_NEKO_RK3588_IMAGE` at it, sets `cdp_url = "http://127.0.0.1:9222"` for CDP-image sessions (None for stock/GPU images), and adds a `shm_size` parameter to `build_neko_run_args` defaulting to `"4g"` (required by the CDP image; safe for all images).
- **Tests**: 58 pass. New tests cover `cdp_url` population logic (RK3588→CDP URL, software→None) and the `shm_size` param. Existing `test_shm_size` updated from `2g` to `4g` (the new default).
- **NOTES-cdp.md**: recipe rationale + step-by-step Pi test plan (pull image, spin container with `--shm-size=4g`, `curl http://127.0.0.1:9222/json/version` via docker exec, verify policy, verify Chromium >=148).

Foundation for native-touch streamed browser (#632). v1 mobile-emulation (#633) stays as fallback.

## Test plan

- [ ] CI passes (Python 3.12/3.13 matrix, SPA build)
- [ ] `build-neko-cdp-image.yml` workflow_dispatch succeeds: arm64 + amd64 digests built, multi-arch manifest merged to `ghcr.io/jaylfc/taos-neko-cdp:latest`
- [ ] **Pi smoke** (arm64, Jay): pull image → `docker exec chromium --version` shows >=148 → `curl http://127.0.0.1:9222/json/version` via docker exec returns JSON with `Browser: Chrome/148...` → `/json/list` returns at least one target → policy file shows `DeveloperToolsAvailability: 0`
- [ ] Neko stream loads in browser at `http://<pi>:18080` and is interactive