### PR TITLE
fix(knowledge): ingest backpressure, FTS5 injection, category search perf

### DIFF
--- a/tests/test_knowledge_ingest.py
+++ b/tests/test_knowledge_ingest.py
@@ -273,6 +273,22 @@ async def test_semaphore_custom_max_concurrent(store, mock_http):
 
 
 @pytest.mark.asyncio
+async def test_max_concurrent_zero_raises(store, mock_http):
+    """max_concurrent=0 must raise ValueError to prevent Semaphore(0) deadlock."""
+    from tinyagentos.knowledge_ingest import IngestPipeline
+    notif = AsyncMock()
+    cat_engine = AsyncMock()
+    with pytest.raises(ValueError, match="max_concurrent"):
+        IngestPipeline(
+            store=store,
+            http_client=mock_http,
+            notifications=notif,
+            category_engine=cat_engine,
+            max_concurrent=0,
+        )
+
+
+@pytest.mark.asyncio
 async def test_semaphore_limits_concurrent_tasks(store, mock_http):
     """At most max_concurrent tasks run the pipeline body simultaneously."""
     import asyncio
@@ -280,8 +296,6 @@ async def test_semaphore_limits_concurrent_tasks(store, mock_http):
 
     active: list[int] = []
     peak: list[int] = []
-
-    original_run = None
 
     async def counting_run(self, item_id: str) -> None:
         active.append(1)

--- a/tests/test_knowledge_ingest.py
+++ b/tests/test_knowledge_ingest.py
@@ -241,6 +241,89 @@ async def test_embed_called_when_qmd_url_set(store):
     assert any("ingest" in c for c in calls)
 
 
+# ------------------------------------------------------------------
+# Ingest backpressure semaphore (#659)
+# ------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_semaphore_is_created_with_default_slots(pipeline):
+    """Pipeline should have a Semaphore with the default slot count."""
+    import asyncio
+    assert isinstance(pipeline._semaphore, asyncio.Semaphore)
+    # Default is 5 as defined by _INGEST_SEMAPHORE_SLOTS.
+    assert pipeline._semaphore._value == 5
+
+
+@pytest.mark.asyncio
+async def test_semaphore_custom_max_concurrent(store, mock_http):
+    """max_concurrent kwarg controls the Semaphore slot count."""
+    from tinyagentos.knowledge_ingest import IngestPipeline
+    notif = AsyncMock()
+    notif.emit_event = AsyncMock()
+    cat_engine = AsyncMock()
+    cat_engine.categorise = AsyncMock(return_value=[])
+    p = IngestPipeline(
+        store=store,
+        http_client=mock_http,
+        notifications=notif,
+        category_engine=cat_engine,
+        max_concurrent=2,
+    )
+    assert p._semaphore._value == 2
+
+
+@pytest.mark.asyncio
+async def test_semaphore_limits_concurrent_tasks(store, mock_http):
+    """At most max_concurrent tasks run the pipeline body simultaneously."""
+    import asyncio
+    from tinyagentos.knowledge_ingest import IngestPipeline
+
+    active: list[int] = []
+    peak: list[int] = []
+
+    original_run = None
+
+    async def counting_run(self, item_id: str) -> None:
+        active.append(1)
+        peak.append(len(active))
+        await asyncio.sleep(0)  # yield to let other tasks start
+        active.pop()
+        # call real pipeline logic via store update only
+        await self._store.update_status(item_id, "ready")
+
+    notif = AsyncMock()
+    notif.emit_event = AsyncMock()
+    cat_engine = AsyncMock()
+    cat_engine.categorise = AsyncMock(return_value=[])
+
+    p = IngestPipeline(
+        store=store,
+        http_client=mock_http,
+        notifications=notif,
+        category_engine=cat_engine,
+        max_concurrent=2,
+    )
+
+    # Submit 6 items
+    ids = []
+    for i in range(6):
+        item_id = await p.submit(
+            url=f"https://example.com/batch-{i}",
+            title=f"Batch {i}",
+            text="Enough content to proceed.",
+            categories=["Test"],
+            source="test",
+        )
+        ids.append(item_id)
+
+    # Patch run so we can count concurrency
+    with patch.object(IngestPipeline, "run", counting_run):
+        tasks = [asyncio.create_task(p._run_safe(item_id)) for item_id in ids]
+        await asyncio.gather(*tasks)
+
+    assert max(peak) <= 2, f"Peak concurrency {max(peak)} exceeded semaphore limit 2"
+
+
 @pytest.mark.asyncio
 async def test_categories_from_caller_are_preserved(store):
     """When categories are provided at submit time, they bypass the engine."""

--- a/tests/test_knowledge_store.py
+++ b/tests/test_knowledge_store.py
@@ -212,3 +212,132 @@ async def test_list_items_filter_by_category(store):
     results = await store.list_items(category="AI/ML")
     assert len(results) == 1
     assert results[0]["title"] == "AI Article"
+
+
+# ------------------------------------------------------------------
+# FTS5 injection fix (#659)
+# ------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_search_fts_bare_quote_does_not_raise(store):
+    """A lone double-quote must not cause an OperationalError."""
+    await store.add_item(
+        source_type="article",
+        source_url="https://example.com/safe",
+        title="Safe",
+        author="dev",
+        content="safe content",
+        summary="",
+        categories=[],
+        tags=[],
+        metadata={},
+    )
+    results = await store.search_fts('"')
+    assert isinstance(results, list)
+
+
+@pytest.mark.asyncio
+async def test_search_fts_operators_are_literal(store):
+    """FTS5 boolean operators in query are not interpreted as operators."""
+    await store.add_item(
+        source_type="article",
+        source_url="https://example.com/a",
+        title="Alpha",
+        author="dev",
+        content="alpha text here",
+        summary="",
+        categories=[],
+        tags=[],
+        metadata={},
+    )
+    await store.add_item(
+        source_type="article",
+        source_url="https://example.com/b",
+        title="Beta",
+        author="dev",
+        content="beta text here",
+        summary="",
+        categories=[],
+        tags=[],
+        metadata={},
+    )
+    # As a phrase "alpha AND beta" should not match either row.
+    results = await store.search_fts("alpha AND beta")
+    assert len(results) == 0
+
+
+@pytest.mark.asyncio
+async def test_search_fts_prefix_wildcard_is_literal(store):
+    """A trailing * must not be treated as a wildcard prefix operator."""
+    await store.add_item(
+        source_type="article",
+        source_url="https://example.com/hello",
+        title="Hello World",
+        author="dev",
+        content="hello world",
+        summary="",
+        categories=[],
+        tags=[],
+        metadata={},
+    )
+    results = await store.search_fts("hell*")
+    assert len(results) == 0
+
+
+# ------------------------------------------------------------------
+# Category filter via json_each() (#659)
+# ------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_category_filter_no_false_positive_substring(store):
+    """'AI' must not match a row whose category is 'AI/ML' via substring."""
+    await store.add_item(
+        source_type="article",
+        source_url="https://example.com/ai-ml",
+        title="AI/ML Article",
+        author="tester",
+        content="content",
+        summary="",
+        categories=["AI/ML"],
+        tags=[],
+        metadata={},
+    )
+    results = await store.list_items(category="AI")
+    assert len(results) == 0
+
+
+@pytest.mark.asyncio
+async def test_category_filter_no_false_positive_suffix(store):
+    """'ML' must not match a row whose category is 'AI/ML' via substring."""
+    await store.add_item(
+        source_type="article",
+        source_url="https://example.com/ai-ml-2",
+        title="AI/ML Article 2",
+        author="tester",
+        content="content",
+        summary="",
+        categories=["AI/ML"],
+        tags=[],
+        metadata={},
+    )
+    results = await store.list_items(category="ML")
+    assert len(results) == 0
+
+
+@pytest.mark.asyncio
+async def test_category_filter_exact_match(store):
+    """json_each filter returns the row whose categories contain the exact value."""
+    await store.add_item(
+        source_type="article",
+        source_url="https://example.com/exact",
+        title="Exact Match",
+        author="tester",
+        content="content",
+        summary="",
+        categories=["Rockchip", "AI/ML"],
+        tags=[],
+        metadata={},
+    )
+    results = await store.list_items(category="Rockchip")
+    assert len(results) == 1
+    assert results[0]["title"] == "Exact Match"

--- a/tests/test_user_memory.py
+++ b/tests/test_user_memory.py
@@ -1,5 +1,6 @@
 import pytest
 import pytest_asyncio
+from unittest.mock import patch
 from tinyagentos.user_memory import UserMemoryStore
 
 
@@ -54,3 +55,49 @@ async def test_settings(store):
     await store.update_settings("user", {"capture_notes": False})
     settings = await store.get_settings("user")
     assert settings["capture_notes"] is False
+
+
+# ------------------------------------------------------------------
+# FTS5 injection fix (#659)
+# ------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_fts5_double_quote_does_not_break_search(store):
+    """A bare double-quote in the query must not raise or return wrong rows."""
+    await store.save_chunk("user", "safe content here", "Safe Title", "snippets")
+    # Prior to the fix this raised an OperationalError (malformed FTS5 query).
+    results = await store.search("user", '"')
+    # No crash; may return 0 results but must not raise.
+    assert isinstance(results, list)
+
+
+@pytest.mark.asyncio
+async def test_fts5_operator_keywords_are_literal(store):
+    """FTS5 operators like AND/OR/NOT must not alter the query semantics."""
+    await store.save_chunk("user", "alpha content", "A", "snippets")
+    await store.save_chunk("user", "beta content", "B", "snippets")
+    # "alpha AND beta" as a phrase should match neither row (phrase not present).
+    results = await store.search("user", "alpha AND beta")
+    assert len(results) == 0
+
+
+@pytest.mark.asyncio
+async def test_fts5_star_operator_is_literal(store):
+    """A trailing * must not be treated as a prefix wildcard."""
+    await store.save_chunk("user", "hello world", "Hello", "snippets")
+    # "hell*" as a phrase literal should not match "hello"; would match if
+    # the star were interpreted as a wildcard by FTS5.
+    results = await store.search("user", "hell*")
+    assert len(results) == 0
+
+
+@pytest.mark.asyncio
+async def test_fts5_injection_does_not_escape_user_filter(store):
+    """Injected column filter syntax must not leak data from another user."""
+    await store.save_chunk("victim", "secret data", "Secret", "snippets")
+    await store.save_chunk("attacker", "normal data", "Normal", "snippets")
+    # Without the fix, a query like 'x" OR "secret' could be crafted so the
+    # FTS MATCH returns rows regardless of the user_id WHERE clause.  With the
+    # fix the whole string is treated as a single phrase and matches nothing.
+    results = await store.search("attacker", 'x" OR "secret')
+    assert all(r["content"] != "secret data" for r in results)

--- a/tinyagentos/knowledge_ingest.py
+++ b/tinyagentos/knowledge_ingest.py
@@ -16,6 +16,9 @@ logger = logging.getLogger(__name__)
 # Quality threshold: minimum chars for readability extraction to count as success
 _MIN_CONTENT_CHARS = 100
 
+# Limit concurrent background ingest tasks to prevent resource exhaustion.
+_INGEST_SEMAPHORE_SLOTS = 5
+
 # Per-source default monitor config
 _DEFAULT_MONITOR: dict[str, dict] = {
     "reddit":  {"frequency": 3600,  "decay_rate": 1.5, "stop_after_days": 30,  "pinned": False, "last_poll": 0, "current_interval": 3600},
@@ -78,6 +81,7 @@ class IngestPipeline:
         category_engine: "CategoryEngine",
         qmd_base_url: str = "",
         llm_base_url: str = "",
+        max_concurrent: int = _INGEST_SEMAPHORE_SLOTS,
     ) -> None:
         self._store = store
         self._http_client = http_client
@@ -85,6 +89,7 @@ class IngestPipeline:
         self._category_engine = category_engine
         self._qmd_base_url = qmd_base_url
         self._llm_base_url = llm_base_url
+        self._semaphore = asyncio.Semaphore(max_concurrent)
 
     async def submit(
         self,
@@ -130,12 +135,13 @@ class IngestPipeline:
         return item_id
 
     async def _run_safe(self, item_id: str) -> None:
-        """Wrapper that catches all exceptions so background tasks never crash silently."""
-        try:
-            await self.run(item_id)
-        except Exception as exc:
-            logger.exception("IngestPipeline background task failed for %s: %s", item_id, exc)
-            await self._store.update_status(item_id, "error")
+        """Wrapper that enforces backpressure and catches all exceptions."""
+        async with self._semaphore:
+            try:
+                await self.run(item_id)
+            except Exception as exc:
+                logger.exception("IngestPipeline background task failed for %s: %s", item_id, exc)
+                await self._store.update_status(item_id, "error")
 
     async def run(self, item_id: str) -> None:
         """Execute all pipeline steps for an existing pending item."""

--- a/tinyagentos/knowledge_ingest.py
+++ b/tinyagentos/knowledge_ingest.py
@@ -89,6 +89,8 @@ class IngestPipeline:
         self._category_engine = category_engine
         self._qmd_base_url = qmd_base_url
         self._llm_base_url = llm_base_url
+        if max_concurrent < 1:
+            raise ValueError(f"max_concurrent must be >= 1, got {max_concurrent}")
         self._semaphore = asyncio.Semaphore(max_concurrent)
 
     async def submit(

--- a/tinyagentos/knowledge_store.py
+++ b/tinyagentos/knowledge_store.py
@@ -220,8 +220,15 @@ class KnowledgeStore(BaseStore):
             sql += " AND status = ?"
             params.append(status)
         if category:
-            sql += " AND categories LIKE ?"
-            params.append(f'%"{category}"%')
+            # Use json_each() instead of a LIKE scan so this is an exact
+            # match on a JSON array element rather than a substring scan.
+            sql += (
+                " AND id IN ("
+                "SELECT ki2.id FROM knowledge_items ki2, "
+                "json_each(ki2.categories) WHERE json_each.value = ?"
+                ")"
+            )
+            params.append(category)
         sql += " ORDER BY created_at DESC LIMIT ? OFFSET ?"
         params.extend([limit, offset])
         cursor = await self._db.execute(sql, params)
@@ -245,7 +252,9 @@ class KnowledgeStore(BaseStore):
     async def search_fts(self, query: str, limit: int = 20) -> list[dict]:
         """Keyword search across title, content, summary, author using FTS5."""
         assert self._db is not None
-        safe_query = query.replace('"', '""')
+        # Wrap as a quoted phrase so FTS5 operators in user input are not
+        # interpreted (AND, OR, NOT, *, NEAR, column:filter, etc.).
+        safe_query = '"' + query.replace('"', '""') + '"'
         sql = """
             SELECT i.id, i.source_type, i.source_url, i.source_id, i.title, i.author,
                    i.summary, i.content, i.media_path, i.thumbnail, i.categories,

--- a/tinyagentos/user_memory.py
+++ b/tinyagentos/user_memory.py
@@ -71,7 +71,11 @@ class UserMemoryStore(BaseStore):
         limit: int = 20,
     ) -> list[dict]:
         assert self._db is not None
-        fts_query = query.replace('"', '""')
+        # Wrap as a quoted phrase: double internal quotes first, then wrap the
+        # whole string in double-quotes.  This prevents FTS5 special characters
+        # (AND, OR, NOT, ^, *, NEAR, column filters, etc.) from being
+        # interpreted as query operators.
+        fts_query = '"' + query.replace('"', '""') + '"'
         sql = """
             SELECT c.hash, c.collection, c.title, c.content, c.metadata, c.created_at
             FROM user_memory_fts f


### PR DESCRIPTION
## Summary

- **Ingest backpressure** (`knowledge_ingest.py`): `IngestPipeline` now holds an `asyncio.Semaphore(5)` acquired in `_run_safe()`. A flood of `submit_background()` calls will queue beyond the fifth slot instead of spawning unbounded concurrent tasks. `max_concurrent` kwarg lets callers (and tests) override the limit.

- **FTS5 injection** (`user_memory.py`, `knowledge_store.py`): User query strings are now wrapped as a quoted FTS5 phrase (`"<escaped-input>"`) before being passed to `MATCH`. Internal double-quotes are doubled first. This means FTS5 boolean/prefix operators (`AND`, `OR`, `NOT`, `*`, `NEAR`, column-filter syntax) in user input are treated as literal text rather than query operators. A crafted payload like `x" OR "secret` can no longer escape the phrase boundary to leak rows from other users.

- **Category search perf** (`knowledge_store.py`): `list_items(category=...)` previously used `categories LIKE '%"x"%'`, a full table scan susceptible to substring false-positives. Replaced with a `json_each()` sub-select that does an exact array-element match.

## Test evidence

13 new tests added (all passing):

```
tests/test_knowledge_ingest.py::test_semaphore_is_created_with_default_slots PASSED
tests/test_knowledge_ingest.py::test_semaphore_custom_max_concurrent PASSED
tests/test_knowledge_ingest.py::test_semaphore_limits_concurrent_tasks PASSED
tests/test_user_memory.py::test_fts5_double_quote_does_not_break_search PASSED
tests/test_user_memory.py::test_fts5_operator_keywords_are_literal PASSED
tests/test_user_memory.py::test_fts5_star_operator_is_literal PASSED
tests/test_user_memory.py::test_fts5_injection_does_not_escape_user_filter PASSED
tests/test_knowledge_store.py::test_search_fts_bare_quote_does_not_raise PASSED
tests/test_knowledge_store.py::test_search_fts_operators_are_literal PASSED
tests/test_knowledge_store.py::test_search_fts_prefix_wildcard_is_literal PASSED
tests/test_knowledge_store.py::test_category_filter_no_false_positive_substring PASSED
tests/test_knowledge_store.py::test_category_filter_no_false_positive_suffix PASSED
tests/test_knowledge_store.py::test_category_filter_exact_match PASSED

41 passed in 0.18s (28 pre-existing + 13 new)
```

Closes #659

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Beta announcement to release documentation
  * Implemented concurrency limits for background knowledge ingestion tasks

* **Bug Fixes**
  * Improved search robustness for special characters and query operators
  * Enhanced category filtering to perform exact matching instead of substring matching

* **Tests**
  * Added comprehensive test coverage for ingest concurrency, search security, and category filtering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->