### PR TITLE
fix(security): add shared-token auth guard on agent_bridge command routes

### DIFF
--- a/tests/test_agent_bridge.py
+++ b/tests/test_agent_bridge.py
@@ -13,12 +13,50 @@ from httpx import ASGITransport, AsyncClient
 
 from tinyagentos.agent_bridge import create_bridge_app
 
+_TOKEN = "test-bridge-secret"
+
 
 @pytest_asyncio.fixture
 async def client():
+    """Unauthenticated client — no token configured on bridge."""
     bridge = create_bridge_app(app_id="blender", mcp_server=None)
     transport = ASGITransport(app=bridge)
     async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+@pytest_asyncio.fixture
+async def authed_client():
+    """Client with correct X-Bridge-Token header against a token-protected bridge."""
+    bridge = create_bridge_app(app_id="blender", mcp_server=None, bridge_token=_TOKEN)
+    transport = ASGITransport(app=bridge)
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        headers={"X-Bridge-Token": _TOKEN},
+    ) as c:
+        yield c
+
+
+@pytest_asyncio.fixture
+async def unauthed_token_client():
+    """Client hitting a token-protected bridge without a token."""
+    bridge = create_bridge_app(app_id="blender", mcp_server=None, bridge_token=_TOKEN)
+    transport = ASGITransport(app=bridge)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+@pytest_asyncio.fixture
+async def wrong_token_client():
+    """Client hitting a token-protected bridge with the wrong token."""
+    bridge = create_bridge_app(app_id="blender", mcp_server=None, bridge_token=_TOKEN)
+    transport = ASGITransport(app=bridge)
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        headers={"X-Bridge-Token": "wrong-token"},
+    ) as c:
         yield c
 
 
@@ -330,3 +368,58 @@ async def test_files_batch_unmatched_quote(client):
     data = resp.json()
     assert data["exit_code"] == -1
     assert "invalid/malformed command" in data["stderr"]
+
+
+# ---------------------------------------------------------------------------
+# Auth guard tests (issue #672)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_exec_requires_token_when_configured(unauthed_token_client):
+    """POST /exec must return 401 when bridge_token is set and no header provided."""
+    resp = await unauthed_token_client.post("/exec", json={"command": "echo hi"})
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_exec_rejects_wrong_token(wrong_token_client):
+    """POST /exec must return 401 when bridge_token is set and wrong token sent."""
+    resp = await wrong_token_client.post("/exec", json={"command": "echo hi"})
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_exec_accepts_correct_token(authed_client):
+    """POST /exec must succeed when the correct X-Bridge-Token header is provided."""
+    resp = await authed_client.post("/exec", json={"command": "echo hi"})
+    assert resp.status_code == 200
+    assert resp.json()["exit_code"] == 0
+
+
+@pytest.mark.asyncio
+async def test_files_batch_requires_token(unauthed_token_client):
+    """POST /files/batch must return 401 without the token."""
+    resp = await unauthed_token_client.post("/files/batch", json={"command": "ls /tmp"})
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_files_batch_accepts_correct_token(authed_client):
+    """POST /files/batch must succeed with correct token."""
+    resp = await authed_client.post("/files/batch", json={"command": "ls /tmp"})
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_health_always_accessible(unauthed_token_client):
+    """GET /health must be accessible without a token even when auth is configured."""
+    resp = await unauthed_token_client.get("/health")
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_no_token_configured_allows_exec(client):
+    """When no bridge_token is set, /exec is accessible (backward compat)."""
+    resp = await client.post("/exec", json={"command": "echo hello"})
+    assert resp.status_code == 200
+    assert resp.json()["exit_code"] == 0

--- a/tests/test_agent_bridge.py
+++ b/tests/test_agent_bridge.py
@@ -423,3 +423,27 @@ async def test_no_token_configured_allows_exec(client):
     resp = await client.post("/exec", json={"command": "echo hello"})
     assert resp.status_code == 200
     assert resp.json()["exit_code"] == 0
+
+
+@pytest.mark.asyncio
+async def test_exec_rejects_same_length_wrong_token():
+    """POST /exec must return 401 for a wrong token that is the same length as the real one.
+
+    Ensures secrets.compare_digest is used rather than a timing-leaky != comparison.
+    The same-length property is important: a length-leaky check would also fail early
+    on different-length strings, so testing equal-length isolates the constant-time guarantee.
+    """
+    real_token = "abcdefghijklmnop"        # 16 chars
+    wrong_token = "abcdefghijklmnoX"       # same length, last char differs
+    assert len(real_token) == len(wrong_token)
+
+    bridge = create_bridge_app(app_id="test", bridge_token=real_token)
+    transport = ASGITransport(app=bridge)
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        headers={"X-Bridge-Token": wrong_token},
+    ) as c:
+        resp = await c.post("/exec", json={"command": "echo hi"})
+
+    assert resp.status_code == 401

--- a/tests/test_deployer.py
+++ b/tests/test_deployer.py
@@ -801,6 +801,32 @@ class TestDeployAgent:
             env = mock_create.call_args.kwargs["env"]
             assert env["TAOS_BRIDGE_URL"] == "http://127.0.0.1:6969"
 
+    @pytest.mark.asyncio
+    async def test_bridge_token_injected_per_deployment(self, tmp_path):
+        """TAOS_BRIDGE_TOKEN is a 64-char hex secret generated uniquely per deployment."""
+        req = _req(name="token-test", data_dir=tmp_path)
+
+        async def mock_exec_fn(name, cmd, **kwargs):
+            if "hostname -I" in " ".join(cmd):
+                return (0, "10.0.0.5")
+            return (0, "ok")
+
+        tokens = []
+        for _ in range(2):
+            with patch("tinyagentos.deployer.create_container", new_callable=AsyncMock) as mock_create, \
+                 patch("tinyagentos.deployer.exec_in_container", side_effect=mock_exec_fn), \
+                 patch("tinyagentos.deployer.push_file", new_callable=AsyncMock, return_value=(0, "")), \
+                 patch("tinyagentos.deployer.add_proxy_device", new_callable=AsyncMock, return_value={"success": True, "output": ""}):
+                mock_create.return_value = {"success": True, "name": "taos-agent-token-test"}
+                await deploy_agent(req)
+                env = mock_create.call_args.kwargs["env"]
+                token = env["TAOS_BRIDGE_TOKEN"]
+                assert len(token) == 64, f"expected 64 hex chars, got {len(token)}"
+                assert all(c in "0123456789abcdef" for c in token)
+                tokens.append(token)
+        # Two deployments must produce different tokens.
+        assert tokens[0] != tokens[1], "bridge tokens must be unique per deployment"
+
 
 class TestSpliceTaosmdBlock:
     """Unit tests for the _splice_taosmd_block helper — no I/O involved."""

--- a/tinyagentos/agent_bridge.py
+++ b/tinyagentos/agent_bridge.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import os
+import secrets
 import shlex
 from pathlib import Path
 from typing import Any
@@ -109,11 +110,13 @@ def create_bridge_app(
 
     # Shared-token auth dependency (issue #672 — defense-in-depth).
     # Applied to every endpoint that executes commands or mutates state.
-    def _require_token(x_bridge_token: str = Header(default="")) -> None:
+    def _require_token(x_bridge_token: str | None = Header(default=None)) -> None:
         if not resolved_token:
             # No token configured — allow through (backward compat).
             return
-        if not x_bridge_token or x_bridge_token != resolved_token:
+        if not x_bridge_token:
+            raise HTTPException(status_code=401, detail="Invalid or missing X-Bridge-Token")
+        if not secrets.compare_digest(x_bridge_token, resolved_token):
             raise HTTPException(status_code=401, detail="Invalid or missing X-Bridge-Token")
 
     # -----------------------------------------------------------------------

--- a/tinyagentos/agent_bridge.py
+++ b/tinyagentos/agent_bridge.py
@@ -14,7 +14,7 @@ import shlex
 from pathlib import Path
 from typing import Any
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI, Header, HTTPException
 from pydantic import BaseModel
 
 
@@ -80,13 +80,22 @@ class McpToolRequest(BaseModel):
 def create_bridge_app(
     app_id: str | None = None,
     mcp_server: str | None = None,
+    bridge_token: str | None = None,
 ) -> FastAPI:
-    """Return a configured FastAPI bridge app."""
+    """Return a configured FastAPI bridge app.
+
+    ``bridge_token`` sets the shared secret that callers must supply via the
+    ``X-Bridge-Token`` request header on all command-executing endpoints.
+    When *None* the value is read from the ``TAOS_BRIDGE_TOKEN`` environment
+    variable.  If neither is set the dangerous routes are still accessible
+    (backward-compatible default for containers that predate this guard).
+    """
 
     resolved_app_id = app_id or os.environ.get("TAOS_APP_ID", "unknown")
     resolved_mcp = mcp_server or os.environ.get("TAOS_MCP_SERVER", "")
     resolved_agent_name = os.environ.get("TAOS_AGENT_NAME", "default")
     resolved_agent_type = os.environ.get("TAOS_AGENT_TYPE", "general")
+    resolved_token: str = bridge_token or os.environ.get("TAOS_BRIDGE_TOKEN", "")
 
     state: dict[str, Any] = {
         "app_id": resolved_app_id,
@@ -97,6 +106,15 @@ def create_bridge_app(
     }
 
     bridge = FastAPI(title="TinyAgentOS Agent Bridge", version="1.0.0")
+
+    # Shared-token auth dependency (issue #672 — defense-in-depth).
+    # Applied to every endpoint that executes commands or mutates state.
+    def _require_token(x_bridge_token: str = Header(default="")) -> None:
+        if not resolved_token:
+            # No token configured — allow through (backward compat).
+            return
+        if not x_bridge_token or x_bridge_token != resolved_token:
+            raise HTTPException(status_code=401, detail="Invalid or missing X-Bridge-Token")
 
     # -----------------------------------------------------------------------
     # Health
@@ -135,7 +153,7 @@ def create_bridge_app(
     # -----------------------------------------------------------------------
 
     @bridge.post("/exec")
-    async def exec_command(req: ExecRequest):
+    async def exec_command(req: ExecRequest, _: None = Depends(_require_token)):
         # SECURITY: shlex.split prevents shell-metachar injection (;, |, $()) by running
         # the command without a shell. Single commands with arguments work as before.
         # Shell features (pipes, redirects) are intentionally NOT supported.
@@ -206,7 +224,7 @@ def create_bridge_app(
             return {"content": "", "error": str(exc)}
 
     @bridge.post("/files/write")
-    async def files_write(req: FileWriteRequest):
+    async def files_write(req: FileWriteRequest, _: None = Depends(_require_token)):
         try:
             p = Path(req.path)
             p.parent.mkdir(parents=True, exist_ok=True)
@@ -216,7 +234,7 @@ def create_bridge_app(
             return {"status": "error", "error": str(exc)}
 
     @bridge.post("/files/batch")
-    async def files_batch(req: FileBatchRequest):
+    async def files_batch(req: FileBatchRequest, _: None = Depends(_require_token)):
         """Batch file ops via exec — delegates single commands with arguments.
         Shell features (pipes, redirects) are NOT supported; use /exec for those.
         # SECURITY: shlex.split without shell=True prevents metachar injection.
@@ -259,7 +277,7 @@ def create_bridge_app(
     # -----------------------------------------------------------------------
 
     @bridge.get("/screenshot")
-    async def screenshot():
+    async def screenshot(_: None = Depends(_require_token)):
         try:
             proc = await asyncio.create_subprocess_exec(
                 "scrot", "-o", "/tmp/screenshot.png",
@@ -286,7 +304,7 @@ def create_bridge_app(
             return {"status": "error", "error": str(exc)}
 
     @bridge.post("/keyboard")
-    async def keyboard(req: KeyboardRequest):
+    async def keyboard(req: KeyboardRequest, _: None = Depends(_require_token)):
         try:
             proc = await asyncio.create_subprocess_exec(
                 "xdotool", "key", req.keys,
@@ -306,7 +324,7 @@ def create_bridge_app(
             return {"status": "error", "error": str(exc)}
 
     @bridge.post("/mouse")
-    async def mouse(req: MouseRequest):
+    async def mouse(req: MouseRequest, _: None = Depends(_require_token)):
         try:
             _ALLOWED_BUTTONS = {1, 2, 3, 4, 5}
             if req.button not in _ALLOWED_BUTTONS:
@@ -330,7 +348,7 @@ def create_bridge_app(
             return {"status": "error", "error": str(exc)}
 
     @bridge.post("/type")
-    async def type_text(req: TypeRequest):
+    async def type_text(req: TypeRequest, _: None = Depends(_require_token)):
         try:
             proc = await asyncio.create_subprocess_exec(
                 "xdotool", "type", "--clearmodifiers", "--", req.text,
@@ -358,7 +376,7 @@ def create_bridge_app(
         return {"enabled": state["computer_use"]}
 
     @bridge.post("/computer-use")
-    async def computer_use_set(req: ComputerUseRequest):
+    async def computer_use_set(req: ComputerUseRequest, _: None = Depends(_require_token)):
         state["computer_use"] = req.enabled
         return {"enabled": state["computer_use"]}
 
@@ -370,7 +388,7 @@ def create_bridge_app(
         }
 
     @bridge.post("/agent/swap")
-    async def agent_swap(req: AgentSwapRequest):
+    async def agent_swap(req: AgentSwapRequest, _: None = Depends(_require_token)):
         state["agent_name"] = req.agent_name
         state["agent_type"] = req.agent_type
         return {

--- a/tinyagentos/deployer.py
+++ b/tinyagentos/deployer.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import logging
 import os
+import secrets
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -241,6 +242,11 @@ async def deploy_agent(req: DeployRequest) -> dict:
     except Exception:
         pass
     env["TAOS_TRACE_URL"] = f"http://{req.taos_host}:{req.taos_port}/api/trace"
+
+    # Agent-bridge shared token (issue #672 — defense-in-depth auth guard).
+    # Generate a per-deployment secret so only the controller (which knows
+    # the token) can call the command-executing bridge endpoints.
+    env["TAOS_BRIDGE_TOKEN"] = secrets.token_hex(32)
 
     # openclaw bridge connection info — injected so install.sh can write
     # /root/.openclaw/openclaw.json and /root/.openclaw/env inside the container


### PR DESCRIPTION
## Summary

- **Binding verified**: `agent_bridge:app` has no explicit `--host` in any startup path — uvicorn defaults to `0.0.0.0` inside the container. Port 9100 is `EXPOSE`d in the Dockerfiles but **not** published to the host via `-p` flags (Incus/LXC only proxies ports 4000 and the taOS port). Risk is limited to the container's own bridge network, but not zero (other containers on the same bridge can reach port 9100).
- **Auth guard added**: `create_bridge_app()` now accepts a `bridge_token` param (falls back to `TAOS_BRIDGE_TOKEN` env var). A `_require_token` FastAPI `Depends` is applied to all command-executing routes: `/exec`, `/files/batch`, `/files/write`, `/screenshot`, `/keyboard`, `/mouse`, `/type`, `POST /computer-use`, `/agent/swap`.
- **Deployer injects token**: `deploy_agent()` now generates `secrets.token_hex(32)` per deployment and injects it as `TAOS_BRIDGE_TOKEN` in the container env. Read-only endpoints (`/health`, `/files/list`, `/files/read`, `GET /computer-use`, `/agent/current`) require no token. No `TAOS_BRIDGE_TOKEN` set = backward-compatible open mode.

Closes #672

## Test evidence

```
python3 -m pytest tests/test_agent_bridge.py -v
# 15 passed in 0.15s
```

New tests added (7):
- `test_exec_requires_token_when_configured` — 401 without token
- `test_exec_rejects_wrong_token` — 401 with wrong token
- `test_exec_accepts_correct_token` — 200 with correct token
- `test_files_batch_requires_token` — 401 without token
- `test_files_batch_accepts_correct_token` — 200 with correct token
- `test_health_always_accessible` — 200 without token (health is exempt)
- `test_no_token_configured_allows_exec` — backward-compat: 200 when no token set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Bridge daemon now supports optional token-based authentication. Each deployment automatically generates a unique token protecting command execution and file operation endpoints. Health check endpoint remains accessible without authentication.

* **Tests**
  * Added comprehensive token authentication coverage for protected and unprotected endpoints, including backward compatibility verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->