### PR TITLE
feat(frontend): auto-refresh launchpad after install + setup checklist

### DIFF
--- a/desktop/src/apps/StoreApp/index.tsx
+++ b/desktop/src/apps/StoreApp/index.tsx
@@ -10,6 +10,7 @@ import { filterCatalog, compatFromResolver, hasUnknownHardwareDevice } from "./f
 import { resolveModel, type ResolveResponse } from "./resolver-types";
 import { compatVisuals } from "./compat-visuals";
 import { loadFilter, saveFilter } from "./storage";
+import { emitAppEvent, APP_INSTALLED } from "@/lib/app-event-bus";
 
 /* ------------------------------------------------------------------ */
 /*  Categories                                                         */
@@ -952,6 +953,7 @@ export function StoreApp({ windowId: _windowId }: { windowId: string }) {
   const handleInstall = useCallback((id: string) => {
     setApps((prev) => prev.map((a) => (a.id === id ? { ...a, installed: true } : a)));
     refreshInstalled();
+    emitAppEvent(APP_INSTALLED, id);
   }, [refreshInstalled]);
 
   const handleUninstall = useCallback((id: string) => {

--- a/desktop/src/components/NotificationCentre.tsx
+++ b/desktop/src/components/NotificationCentre.tsx
@@ -1,5 +1,7 @@
+import { useState } from "react";
 import { X, Bell, CheckCheck, Trash2 } from "lucide-react";
 import { useNotificationStore } from "@/stores/notification-store";
+import { SetupChecklist } from "./SetupChecklist";
 
 function formatTime(ts: number): string {
   const delta = Date.now() - ts;
@@ -11,6 +13,7 @@ function formatTime(ts: number): string {
 
 export function NotificationCentre() {
   const { notifications, centreOpen, closeCentre, markRead, markAllRead, clearAll, dismiss } = useNotificationStore();
+  const [checklistDismissed, setChecklistDismissed] = useState(false);
 
   if (!centreOpen) return null;
 
@@ -69,6 +72,9 @@ export function NotificationCentre() {
 
         {/* List */}
         <div className="flex-1 overflow-y-auto">
+          {!checklistDismissed && (
+            <SetupChecklist onDismissed={() => setChecklistDismissed(true)} />
+          )}
           {notifications.length === 0 ? (
             <div className="px-4 py-12 text-center">
               <Bell size={24} className="mx-auto text-shell-text-tertiary mb-2" />

--- a/desktop/src/components/SetupChecklist.tsx
+++ b/desktop/src/components/SetupChecklist.tsx
@@ -1,0 +1,147 @@
+import { useState, useEffect } from "react";
+import { CheckCircle2, Circle, ChevronRight, X } from "lucide-react";
+import { useProcessStore } from "@/stores/process-store";
+import { getApp } from "@/registry/app-registry";
+
+interface SetupStatus {
+  account: boolean;
+  has_provider: boolean;
+  taos_model_set: boolean;
+  has_agent: boolean;
+  memory_enabled: boolean;
+  dismissed: boolean;
+  complete: boolean;
+}
+
+interface Step {
+  key: keyof SetupStatus;
+  label: string;
+  detail: string;
+  appId?: string;
+}
+
+const STEPS: Step[] = [
+  {
+    key: "account",
+    label: "Create your account",
+    detail: "Done at sign-up",
+  },
+  {
+    key: "has_provider",
+    label: "Add a provider",
+    detail: "Connect a cloud API key or local model server",
+    appId: "providers",
+  },
+  {
+    key: "taos_model_set",
+    label: "Choose a model for the taOS agent",
+    detail: "Pick the model your taOS agent will use",
+    appId: "models",
+  },
+  {
+    key: "has_agent",
+    label: "Deploy your first agent",
+    detail: "Deploy an AI agent (Hermes recommended)",
+    appId: "agents",
+  },
+  {
+    key: "memory_enabled",
+    label: "Set up memory",
+    detail: "taOSmd memory is recommended and on by default",
+    appId: "memory",
+  },
+];
+
+export function SetupChecklist({ onDismissed }: { onDismissed?: () => void }) {
+  const [status, setStatus] = useState<SetupStatus | null>(null);
+  const [dismissing, setDismissing] = useState(false);
+  const openWindow = useProcessStore((s) => s.openWindow);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/setup/status")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data: SetupStatus | null) => {
+        if (!cancelled && data) setStatus(data);
+      })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, []);
+
+  const handleDismiss = async () => {
+    setDismissing(true);
+    try {
+      await fetch("/api/setup/dismiss", { method: "POST" });
+    } catch { /* ignore */ }
+    onDismissed?.();
+  };
+
+  const handleStep = (step: Step) => {
+    if (!step.appId) return;
+    const app = getApp(step.appId);
+    if (app) openWindow(step.appId, app.defaultSize);
+  };
+
+  if (!status || status.dismissed || status.complete) return null;
+
+  const doneCount = STEPS.filter((s) => Boolean(status[s.key])).length;
+
+  return (
+    <div className="border-b border-white/10">
+      {/* Checklist header */}
+      <div className="flex items-center justify-between px-4 py-2.5">
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-medium text-shell-text">Get started</span>
+          <span className="text-[10px] text-shell-text-tertiary bg-white/5 rounded-full px-1.5 py-0.5">
+            {doneCount}/{STEPS.length}
+          </span>
+        </div>
+        <button
+          onClick={handleDismiss}
+          disabled={dismissing}
+          className="p-0.5 rounded hover:bg-white/10 text-shell-text-tertiary"
+          aria-label="Dismiss setup checklist"
+          title="Dismiss"
+        >
+          <X size={12} />
+        </button>
+      </div>
+
+      {/* Steps */}
+      <ul role="list" className="pb-2">
+        {STEPS.map((step) => {
+          const done = Boolean(status[step.key]);
+          return (
+            <li key={step.key}>
+              <button
+                onClick={() => !done && handleStep(step)}
+                disabled={done || !step.appId}
+                className={`w-full text-left flex items-center gap-2.5 px-4 py-2 hover:bg-white/5 transition-colors ${
+                  done ? "cursor-default" : step.appId ? "cursor-pointer" : "cursor-default"
+                }`}
+                aria-label={done ? `${step.label} — complete` : step.label}
+              >
+                {done ? (
+                  <CheckCircle2 size={14} className="text-emerald-400 shrink-0" />
+                ) : (
+                  <Circle size={14} className="text-shell-text-tertiary shrink-0" />
+                )}
+                <div className="flex-1 min-w-0">
+                  <p className={`text-xs ${done ? "line-through text-shell-text-tertiary" : "text-shell-text"}`}>
+                    {step.label}
+                  </p>
+                  {!done && (
+                    <p className="text-[10px] text-shell-text-tertiary truncate">{step.detail}</p>
+                  )}
+                </div>
+                {!done && step.appId && (
+                  <ChevronRight size={12} className="text-shell-text-tertiary shrink-0" />
+                )}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/desktop/src/components/__tests__/Launchpad.test.tsx
+++ b/desktop/src/components/__tests__/Launchpad.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import type { InstalledService } from "@/hooks/use-installed-services";
+import { emitAppEvent, APP_INSTALLED } from "@/lib/app-event-bus";
 
 // Mockable list of installed services returned by the hook.
 let mockServices: InstalledService[] = [];
@@ -20,7 +21,7 @@ vi.mock("@/stores/process-store", () => ({
   useProcessStore: () => ({ openWindow }),
 }));
 
-// Registry: getAllApps returns no core apps so the test isolates the Apps
+// Registry: getAllApps returns no core apps so the test isolates the Services
 // section; getApp/getOrRegisterServiceApp echo a minimal manifest.
 vi.mock("@/registry/app-registry", () => ({
   getAllApps: () => [],
@@ -54,23 +55,23 @@ const gitea: InstalledService = {
   status: "running",
 };
 
-describe("Launchpad Apps section", () => {
+describe("Launchpad Services section", () => {
   beforeEach(() => {
     mockServices = [];
     openWindow.mockClear();
   });
 
-  it("does not render an Apps section when no apps are installed", () => {
+  it("does not render a Services section when no apps are installed", () => {
     mockServices = [];
     render(<Launchpad open onClose={() => {}} />);
-    expect(screen.queryByText("Apps")).toBeNull();
+    expect(screen.queryByText("Services")).toBeNull();
   });
 
-  it("renders an Apps section with a shortcut per installed app/service", () => {
+  it("renders a Services section with a shortcut per installed app/service", () => {
     mockServices = [searxng, gitea];
     render(<Launchpad open onClose={() => {}} />);
 
-    expect(screen.getByText("Apps")).toBeTruthy();
+    expect(screen.getByText("Services")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Open SearXNG" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Open Gitea" })).toBeTruthy();
   });
@@ -87,5 +88,16 @@ describe("Launchpad Apps section", () => {
       { w: 1100, h: 750 },
       { url: "/apps/searxng/", displayName: "SearXNG" },
     );
+  });
+
+  it("app-event-bus APP_INSTALLED event fires without error", () => {
+    // Verify the EventBus module works correctly in isolation:
+    // emitting an event should invoke any registered listener.
+    const listener = vi.fn();
+    const { onAppEvent } = require("@/lib/app-event-bus");
+    const unsub = onAppEvent(APP_INSTALLED, listener);
+    act(() => { emitAppEvent(APP_INSTALLED, "searxng"); });
+    expect(listener).toHaveBeenCalledWith("searxng");
+    unsub();
   });
 });

--- a/desktop/src/hooks/use-installed-services.ts
+++ b/desktop/src/hooks/use-installed-services.ts
@@ -1,4 +1,5 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
+import { onAppEvent, APP_INSTALLED } from "@/lib/app-event-bus";
 
 export interface InstalledService {
   app_id: string;
@@ -12,12 +13,14 @@ export interface InstalledService {
 
 /**
  * Fetches the list of installed services from /api/apps/installed.
+ * Re-fetches automatically when an app.installed event fires on the
+ * shared EventBus (e.g. after a successful StoreApp install).
  * Returns the list (empty while loading or on error).
  */
 export function useInstalledServices(): InstalledService[] {
   const [services, setServices] = useState<InstalledService[]>([]);
 
-  useEffect(() => {
+  const fetchServices = useCallback(() => {
     let cancelled = false;
     fetch("/api/apps/installed")
       .then((r) => (r.ok ? r.json() : []))
@@ -29,6 +32,16 @@ export function useInstalledServices(): InstalledService[] {
       });
     return () => { cancelled = true; };
   }, []);
+
+  // Initial fetch
+  useEffect(() => {
+    return fetchServices();
+  }, [fetchServices]);
+
+  // Re-fetch when an app installs successfully
+  useEffect(() => {
+    return onAppEvent(APP_INSTALLED, () => { fetchServices(); });
+  }, [fetchServices]);
 
   return services;
 }

--- a/desktop/src/lib/app-event-bus.ts
+++ b/desktop/src/lib/app-event-bus.ts
@@ -1,0 +1,32 @@
+/**
+ * Lightweight cross-component event bus for app-lifecycle events.
+ *
+ * Pattern mirrors dnd-bus.ts — uses a module-level EventTarget so all
+ * subscribers in the same page share one instance regardless of React tree.
+ *
+ * Current events:
+ *   app.installed  — fired after a store install succeeds
+ */
+
+const _emitter = new EventTarget();
+
+/** Emit a named event with an optional string payload. */
+export function emitAppEvent(name: string, detail?: string): void {
+  _emitter.dispatchEvent(
+    new CustomEvent(name, detail !== undefined ? { detail } : undefined)
+  );
+}
+
+/** Subscribe to a named event. Returns an unsubscribe function. */
+export function onAppEvent(
+  name: string,
+  listener: (detail?: string) => void
+): () => void {
+  const handler = (e: Event) =>
+    listener((e as CustomEvent<string | undefined>).detail);
+  _emitter.addEventListener(name, handler);
+  return () => _emitter.removeEventListener(name, handler);
+}
+
+/** Event name emitted on successful app install. */
+export const APP_INSTALLED = "app.installed";


### PR DESCRIPTION
## Summary

- Fixes the Launchpad not updating after a store app install without a full PWA refresh
- Adds guided first-run setup checklist to the notification centre

## #614 — Launchpad auto-refresh on install

- New `desktop/src/lib/app-event-bus.ts`: lightweight `EventTarget`-based bus following the existing `dnd-bus.ts` pattern. Exports `emitAppEvent`, `onAppEvent`, and `APP_INSTALLED` constant.
- `StoreApp/index.tsx`: `handleInstall` now calls `emitAppEvent(APP_INSTALLED, id)` after a successful install.
- `use-installed-services.ts`: subscribes to `APP_INSTALLED` and re-fetches `/api/apps/installed` on fire, so the Launchpad icon list updates immediately without a page reload.
- Fixed a pre-existing test heading mismatch (`"Apps"` → `"Services"`) and added an EventBus smoke test.

## #619 — Setup checklist in notification centre

- New `desktop/src/components/SetupChecklist.tsx`: polls `/api/setup/status` (backend in `tinyagentos/routes/setup.py`, already registered). Renders 5 guided steps (account ✓, add provider, choose taOS model, deploy first agent, set up memory). Each actionable step opens the relevant app window via `useProcessStore`. Dismiss button calls `/api/setup/dismiss` and hides the checklist. Component returns `null` when `status.complete` or `status.dismissed`, so it self-hides once done.
- `NotificationCentre.tsx`: mounts `<SetupChecklist>` at the top of the scrollable area, above notifications. Uses local `checklistDismissed` state for immediate UI response on dismiss.

## Verification

- TypeScript: all errors in `tsc --noEmit` are pre-existing environment-level errors (missing `react`/`lucide-react` in worktree node_modules); no new logic-level type errors introduced.
- Vitest: `src/hooks/__tests__/` passes (9 tests). Launchpad test updated for "Services" heading fix; EventBus smoke test added.
- Backend endpoints `/api/setup/status` and `/api/setup/dismiss` confirmed present in `tinyagentos/routes/setup.py` (registered in `routes/__init__.py`).

Closes #614
Closes #619