### PR TITLE
chore(governance): add CLA + interim DCO contributor gate

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,34 @@
+name: DCO
+
+# Interim contributor gate: require a Developer Certificate of Origin
+# sign-off on every PR commit until the CLA bot is enabled. See CONTRIBUTING.md / CLA.md.
+
+on:
+  pull_request:
+    branches: [master, dev]
+
+jobs:
+  dco:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Verify Signed-off-by on all PR commits
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          missing=0
+          for c in $(git rev-list "${BASE_SHA}..${HEAD_SHA}"); do
+            if ! git show -s --format=%B "$c" | grep -qiE "^Signed-off-by: .+ <.+@.+>"; then
+              author=$(git show -s --format='%an' "$c")
+              echo "::error::Commit ${c:0:8} by ${author} is missing a 'Signed-off-by' line. Re-commit with: git commit -s"
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            echo "DCO check failed — see CONTRIBUTING.md and CLA.md."
+            exit 1
+          fi
+          echo "All commits are signed off."

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,21 @@
+# taOS Contributor License Agreement (Individual) — v0.1
+
+> Interim version, to be ratified by an IP lawyer. By contributing to taOS you agree to the terms below so the project can stay sustainable: source-available for everyone, with a separate commercial license for commercial use.
+
+Thank you for contributing to **taOS** (the "Project"), maintained by **JAN LABS LTD** (the "Company").
+
+By submitting any contribution (code, documentation, configuration, or other material) to the Project, you agree to the following:
+
+1. **Grant of rights.** You grant the Company a perpetual, worldwide, non-exclusive, royalty-free, irrevocable license to use, reproduce, modify, prepare derivative works of, publicly display, sublicense, and distribute your contribution and such derivative works, **and to relicense your contribution under any license terms the Company chooses** — including source-available and commercial licenses.
+
+2. **Original work / right to submit.** Each contribution is your own original creation, or you otherwise have the right to submit it, and submitting it does not violate any third party's rights or any agreement you are bound by.
+
+3. **Retained ownership.** You retain all right, title, and interest in your contributions. This is a license to the Company, **not** an assignment of copyright.
+
+4. **No obligation.** The Company is under no obligation to use or include your contribution.
+
+5. **No warranty.** Your contribution is provided "as is", without warranties of any kind.
+
+## How to agree
+
+The first time you open a pull request, the CLA check will ask you to confirm agreement (a one-time signature that covers all your future contributions). For contributions made before this CLA was adopted, you may confirm agreement by commenting on the project's relicensing/CLA issue.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,14 @@ Welcome — and thanks for your interest in contributing. TinyAgentOS is a self-
 
 ---
 
+## License & Contributor License Agreement
+
+taOS is currently licensed under **AGPL-3.0** (see [`LICENSE`](LICENSE)) and is moving to a **source-available license** — free to use, modify, and self-host for personal and internal business use, with a separate commercial license required to sell it, host it as a paid service, or build it into a product you monetise.
+
+To keep this sustainable, **all contributors must agree to the Contributor License Agreement ([`CLA.md`](CLA.md))** before their contributions are merged. The CLA grants JAN LABS LTD the right to include and **relicense** your contributions under the project's licenses; **you keep ownership of your work**. You sign once — on your first pull request, via the CLA check — and it covers all your future contributions. While the CLA bot is being set up, please sign off your commits with `git commit -s` (a Developer Certificate of Origin acknowledgement) — the automated check requires it.
+
+---
+
 ## Getting Started for Contributors
 
 ```bash


### PR DESCRIPTION
Adds CLA.md (relicensing grant to JAN LABS LTD), a License & CLA section in CONTRIBUTING.md, and an interim DCO sign-off workflow until the CLA bot is installed. Protects the planned source-available relicensing against future contributor copyright blockers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Contributor License Agreement document
  * Updated contribution guidelines to reflect licensing terms and requirements

* **Chores**
  * Added automated commit verification workflow for contributor compliance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->