### PR TITLE
fix(install): allocate non-core host ports for installed apps (closes #695)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@
 
 > **Beta (2026-06-02).** This is beta software meant for testers running it on their own hardware, so expect rough edges. The install script, backend, API, memory system (taOSmd), and multi-framework group chat all work; the desktop GUI is wired up for everyday use but a few flows (some agent management, worker connections, model routing) are still being smoothed out. Star or watch the repo to follow progress and catch the next release.
 
+## Star History
+
+<a href="https://www.star-history.com/?repos=jaylfc%2Ftinyagentos&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=jaylfc/tinyagentos&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=jaylfc/tinyagentos&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=jaylfc/tinyagentos&type=date&legend=top-left" />
+ </picture>
+</a>
+
 Self-hosted AI agent platform that runs on whatever hardware you have. An old laptop, a Raspberry Pi, a gaming PC, an SBC gathering dust, or all of them at once. TinyAgentOS turns your spare hardware into a distributed AI compute cluster.
 
 A full web desktop environment with 36 bundled apps, 108 catalog apps, 47 MCP plugins, 16 agent frameworks, a curated local model catalog of 112 manifests covering LLMs, vision, embeddings, audio, and image generation (including RK3588 NPU variants via c01zaut/happyme531), plus 167k+ searchable models from HuggingFace, agent deployment, training, image/video/audio generation, and full system monitoring, all from a single web dashboard. Supports Apple Silicon (MLX), NVIDIA, AMD, Rockchip NPU, Raspberry Pi, Android phones, and more.

--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@
 
 > **Beta (2026-06-02).** This is beta software meant for testers running it on their own hardware, so expect rough edges. The install script, backend, API, memory system (taOSmd), and multi-framework group chat all work; the desktop GUI is wired up for everyday use but a few flows (some agent management, worker connections, model routing) are still being smoothed out. Star or watch the repo to follow progress and catch the next release.
 
-## Star History
-
+<p align="center">
 <a href="https://www.star-history.com/?repos=jaylfc%2Ftinyagentos&type=date&legend=top-left">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=jaylfc/tinyagentos&type=date&theme=dark&legend=top-left" />
    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=jaylfc/tinyagentos&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=jaylfc/tinyagentos&type=date&legend=top-left" />
+   <img alt="Star History Chart" width="600" src="https://api.star-history.com/chart?repos=jaylfc/tinyagentos&type=date&legend=top-left" />
  </picture>
 </a>
+</p>
 
 Self-hosted AI agent platform that runs on whatever hardware you have. An old laptop, a Raspberry Pi, a gaming PC, an SBC gathering dust, or all of them at once. TinyAgentOS turns your spare hardware into a distributed AI compute cluster.
 

--- a/app-catalog/services/searxng/manifest.yaml
+++ b/app-catalog/services/searxng/manifest.yaml
@@ -10,13 +10,14 @@ license: AGPL-3.0
 requires:
   ram_mb: 128
   disk_mb: 200
-  ports: [8080]
 
 install:
   method: docker
   image: searxng/searxng:latest
   volumes:
     - config:/etc/searxng
+  # 8080 is the container-internal port; the host port is allocated from the
+  # managed pool (30000-40000) by the installer — never bound to 8080 on the host.
   ports: [8080]
 
 hardware_tiers:

--- a/tests/test_installers.py
+++ b/tests/test_installers.py
@@ -6,6 +6,12 @@ from tinyagentos.installers.base import get_installer
 from tinyagentos.installers.pip_installer import PipInstaller
 from tinyagentos.installers.docker_installer import DockerInstaller
 from tinyagentos.installers.download_installer import DownloadInstaller
+from tinyagentos.installers.port_allocator import (
+    RESERVED_PORTS,
+    allocate_host_port,
+    _POOL_START,
+    _POOL_END,
+)
 
 
 class TestGetInstaller:
@@ -69,7 +75,7 @@ class TestDockerInstaller:
         # be declared at the top level or compose rejects the project with
         # "refers to undefined volume". The obsolete `version` key is dropped.
         installer = DockerInstaller(apps_dir=tmp_path)
-        compose = installer._generate_compose("searxng", {
+        compose, host_port = installer._generate_compose("searxng", {
             "image": "searxng/searxng:latest",
             "volumes": ["config:/etc/searxng", "/host/path:/data"],
             "ports": [8080],
@@ -77,15 +83,20 @@ class TestDockerInstaller:
         assert "version" not in compose
         assert compose["volumes"] == {"config": None}  # only the named volume
         assert compose["services"]["searxng"]["volumes"] == ["config:/etc/searxng", "/host/path:/data"]
-        assert compose["services"]["searxng"]["ports"] == ["8080:8080"]
+        # Host port must be in the managed pool, never 8080
+        assert host_port is not None
+        assert _POOL_START <= host_port < _POOL_END
+        assert host_port not in RESERVED_PORTS
+        assert compose["services"]["searxng"]["ports"] == [f"{host_port}:8080"]
 
     def test_generate_compose_omits_volumes_block_for_bind_mounts_only(self, tmp_path):
         installer = DockerInstaller(apps_dir=tmp_path)
-        compose = installer._generate_compose("app", {
+        compose, host_port = installer._generate_compose("app", {
             "image": "x:1",
             "volumes": ["/host:/data", "./rel:/r", "~/h:/hh"],
         })
         assert "volumes" not in compose  # no named volumes → no top-level block
+        assert host_port is None
 
     @pytest.mark.asyncio
     async def test_start_runs_compose_up(self, tmp_path):
@@ -116,3 +127,79 @@ class TestDownloadInstaller:
             result = await installer.install("qwen3-8b", {"method": "download"}, variant=variant)
             assert result["success"] is True
             mock_dl.assert_called_once()
+
+
+class TestPortAllocator:
+    """Allocator must never return a core/reserved port."""
+
+    def test_allocate_returns_port_in_pool(self):
+        port = allocate_host_port("searxng")
+        assert _POOL_START <= port < _POOL_END
+
+    def test_allocate_never_returns_reserved_port(self):
+        # Verify none of the well-known reserved ports are ever returned.
+        seen: set[int] = set()
+        # Generate ports for a range of distinct app IDs.
+        for i in range(50):
+            port = allocate_host_port(f"testapp-{i}")
+            seen.add(port)
+        assert seen.isdisjoint(RESERVED_PORTS), (
+            f"Allocator returned reserved port(s): {seen & RESERVED_PORTS}"
+        )
+
+    def test_allocate_skips_8080(self):
+        # 8080 is the searxng container port — the host port must never be 8080.
+        assert 8080 in RESERVED_PORTS
+        port = allocate_host_port("searxng")
+        assert port != 8080
+
+    def test_allocate_skips_taos_port(self):
+        assert 6969 in RESERVED_PORTS
+        port = allocate_host_port("some-app")
+        assert port != 6969
+
+    def test_allocate_is_deterministic(self):
+        # Same app_id always gets the same preferred starting slot.
+        port_a = allocate_host_port("stable-app")
+        port_b = allocate_host_port("stable-app")
+        assert port_a == port_b
+
+    def test_allocate_skips_in_use_port(self):
+        import socket
+        # Bind a port in the pool so the allocator is forced to skip it.
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            # Use a fixed port outside the reserved set to make this predictable.
+            blocked = 35000
+            s.bind(("0.0.0.0", blocked))
+            # Temporarily stub allocate_host_port's start to land on `blocked`.
+            from tinyagentos.installers import port_allocator
+            original_start = port_allocator._POOL_START
+            original_end = port_allocator._POOL_END
+            port_allocator._POOL_START = blocked
+            port_allocator._POOL_END = blocked + 5
+            try:
+                port = allocate_host_port("testapp-blocked")
+                assert port != blocked
+                assert blocked <= port < blocked + 5
+            finally:
+                port_allocator._POOL_START = original_start
+                port_allocator._POOL_END = original_end
+
+    def test_docker_installer_searxng_host_port_not_8080(self, tmp_path):
+        """End-to-end: searxng compose must not map host 8080."""
+        installer = DockerInstaller(apps_dir=tmp_path)
+        compose, host_port = installer._generate_compose("searxng", {
+            "image": "searxng/searxng:latest",
+            "volumes": ["config:/etc/searxng"],
+            "ports": [8080],
+        })
+        assert host_port is not None
+        assert host_port != 8080
+        assert host_port not in RESERVED_PORTS
+        # Container-internal port must still be 8080.
+        port_mappings = compose["services"]["searxng"]["ports"]
+        assert len(port_mappings) == 1
+        host_side, _, container_side = port_mappings[0].partition(":")
+        assert int(host_side) == host_port
+        assert int(container_side) == 8080

--- a/tinyagentos/installers/docker_installer.py
+++ b/tinyagentos/installers/docker_installer.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import yaml
 
 from tinyagentos.installers.base import AppInstaller, run_cmd
+from tinyagentos.installers.port_allocator import allocate_host_port
 
 
 class DockerInstaller(AppInstaller):
@@ -24,8 +25,20 @@ class DockerInstaller(AppInstaller):
         """
         return bool(source) and not source.startswith(("/", "./", "../", "~"))
 
-    def _generate_compose(self, app_id: str, install_config: dict) -> dict:
-        """Generate a docker-compose.yaml from the manifest install config."""
+    def _generate_compose(
+        self, app_id: str, install_config: dict
+    ) -> tuple[dict, int | None]:
+        """Generate a docker-compose.yaml from the manifest install config.
+
+        The host port for each container port is always allocated from the
+        managed high pool (30000-40000) via ``allocate_host_port``.  Apps must
+        not bind core/well-known ports on the host regardless of what the
+        manifest declares.  The container-side port is preserved as-is so the
+        app's internal wiring is unaffected.
+
+        Returns a ``(compose_dict, host_port)`` tuple.  ``host_port`` is
+        ``None`` when the manifest declares no ports.
+        """
         service = {
             "image": install_config["image"],
             "restart": "unless-stopped",
@@ -42,23 +55,37 @@ class DockerInstaller(AppInstaller):
                     named_volumes[source] = None
         if "env" in install_config:
             service["environment"] = install_config["env"]
+
+        # Collect the container-internal ports from the manifest.
+        container_ports: list[int] = []
         if "ports" in install_config.get("requires", {}):
-            service["ports"] = [f"{p}:{p}" for p in install_config["requires"]["ports"]]
+            container_ports = [int(p) for p in install_config["requires"]["ports"]]
         elif "ports" in install_config:
-            service["ports"] = [f"{p}:{p}" for p in install_config["ports"]]
+            container_ports = [int(p) for p in install_config["ports"]]
+
+        allocated_host_port: int | None = None
+        if container_ports:
+            # Allocate a host port from the managed pool for each container
+            # port.  The mapping is host_port:container_port so the app's
+            # internal wiring (container port) is unchanged.
+            allocated_host_port = allocate_host_port(app_id)
+            service["ports"] = [
+                f"{allocated_host_port + idx}:{cport}"
+                for idx, cport in enumerate(container_ports)
+            ]
 
         # No top-level `version:` — it's obsolete in Compose v2 and emits a
         # warning on every command.
         compose: dict = {"services": {app_id: service}}
         if named_volumes:
             compose["volumes"] = named_volumes
-        return compose
+        return compose, allocated_host_port
 
     async def install(self, app_id: str, install_config: dict, **kwargs) -> dict:
         app_dir = self.apps_dir / app_id
         app_dir.mkdir(parents=True, exist_ok=True)
 
-        compose = self._generate_compose(app_id, install_config)
+        compose, host_port = self._generate_compose(app_id, install_config)
         compose_path = self._compose_path(app_id)
         compose_path.write_text(yaml.dump(compose, default_flow_style=False))
 
@@ -70,7 +97,10 @@ class DockerInstaller(AppInstaller):
         if code != 0:
             return {"success": False, "error": f"docker pull failed: {output}"}
 
-        return {"success": True, "path": str(app_dir)}
+        result: dict = {"success": True, "path": str(app_dir)}
+        if host_port is not None:
+            result["host_port"] = host_port
+        return result
 
     async def uninstall(self, app_id: str) -> dict:
         compose_path = self._compose_path(app_id)

--- a/tinyagentos/installers/lxc_installer.py
+++ b/tinyagentos/installers/lxc_installer.py
@@ -7,6 +7,7 @@ import socket
 from contextlib import closing
 
 from tinyagentos.installers.base import AppInstaller
+from tinyagentos.installers.port_allocator import RESERVED_PORTS
 import tinyagentos.containers as containers
 
 logger = logging.getLogger(__name__)
@@ -70,16 +71,18 @@ def _render_app_ini(app_id: str = "gitea-lxc") -> str:
     )
 
 
-def _find_free_port(start: int = 13000, end: int = 14000) -> int:
-    """Return the first available TCP port in [start, end)."""
+def _find_free_port(start: int = 30_000, end: int = 40_000) -> int:
+    """Return the first available TCP port in [start, end) that is not reserved."""
     for port in range(start, end):
+        if port in RESERVED_PORTS:
+            continue
         with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
             try:
                 s.bind(("0.0.0.0", port))
                 return port
             except OSError:
                 continue
-    raise RuntimeError(f"No free port found in range {start}-{end}")
+    raise RuntimeError(f"No free non-reserved port found in range {start}-{end}")
 
 
 class LXCInstaller(AppInstaller):

--- a/tinyagentos/installers/port_allocator.py
+++ b/tinyagentos/installers/port_allocator.py
@@ -1,0 +1,94 @@
+"""Host-port allocation for installed apps.
+
+Apps installed via Docker or LXC need a host port to be reachable.
+Ports in the well-known / core / taOS-reserved range must never be
+assigned to user-installed apps — they collide with system services.
+
+Allocation is deterministic per app_id (stable across restarts) by
+hashing the id into the high pool; if the deterministic slot is already
+taken we walk forward until we find a free, non-reserved port.
+"""
+from __future__ import annotations
+
+import hashlib
+import socket
+from contextlib import closing
+
+# Ports that must never be assigned to an app host-port.
+# Includes IANA well-known ports that commonly run on dev machines,
+# core taOS services, and taosmd bus.
+RESERVED_PORTS: frozenset[int] = frozenset({
+    # Well-known / OS
+    22,    # SSH
+    25,    # SMTP
+    53,    # DNS
+    80,    # HTTP
+    110,   # POP3
+    143,   # IMAP
+    443,   # HTTPS
+    465,   # SMTPS
+    587,   # SMTP submission
+    993,   # IMAPS
+    995,   # POP3S
+    # Common dev / framework defaults that clash
+    1080,  # SOCKS
+    3000,  # Node / React dev / Grafana
+    3306,  # MySQL
+    4000,  # LiteLLM (taOS internal)
+    5000,  # Flask / generic dev
+    5173,  # Vite dev
+    5432,  # PostgreSQL
+    6379,  # Redis
+    7900,  # taosmd A2A bus
+    8000,  # Django / generic dev
+    8080,  # Tomcat / common web app default
+    8443,  # HTTPS alt
+    8888,  # Jupyter
+    9000,  # MinIO / SonarQube
+    9090,  # Prometheus
+    27017, # MongoDB
+    # taOS core
+    6969,  # taOS controller
+})
+
+# High pool used for all app host-port assignments.
+_POOL_START = 30_000
+_POOL_END   = 40_000
+
+
+def _is_port_free(port: int) -> bool:
+    """Return True if no process is currently bound to *port* on 0.0.0.0."""
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        try:
+            s.bind(("0.0.0.0", port))
+            return True
+        except OSError:
+            return False
+
+
+def allocate_host_port(app_id: str) -> int:
+    """Return a stable, non-reserved, free host port for *app_id*.
+
+    The starting point is derived from a hash of *app_id* so the same
+    app always gets the same port on a fresh install (assuming the slot
+    is available).  If the preferred slot is occupied or reserved we walk
+    forward (wrapping within the pool) until we find a usable port.
+
+    Raises ``RuntimeError`` if the entire pool is exhausted.
+    """
+    pool_size = _POOL_END - _POOL_START
+    # Deterministic starting offset from the app_id.
+    digest = int(hashlib.sha256(app_id.encode()).hexdigest(), 16)
+    start_offset = digest % pool_size
+
+    for i in range(pool_size):
+        candidate = _POOL_START + (start_offset + i) % pool_size
+        if candidate in RESERVED_PORTS:
+            continue
+        if _is_port_free(candidate):
+            return candidate
+
+    raise RuntimeError(
+        f"Port allocator exhausted the full pool {_POOL_START}-{_POOL_END} "
+        f"for app '{app_id}' — no free non-reserved port found."
+    )


### PR DESCRIPTION
## Summary

- Adds `tinyagentos/installers/port_allocator.py`: a `RESERVED_PORTS` deny-set (22, 80, 443, 3000, 5000, 5432, 6379, 8080, 6969, 7900 and others) plus `allocate_host_port(app_id)` that picks a deterministic, non-reserved, free port from the 30000–40000 pool.
- `DockerInstaller._generate_compose` now maps `host_port:container_port` instead of the old `container_port:container_port`. `install()` surfaces `host_port` in its result so the store route can register the correct URL.
- `LXCInstaller._find_free_port` migrated to the same 30000–40000 pool and now skips reserved ports.
- `app-catalog/services/searxng/manifest.yaml`: removed `ports:[8080]` from the `requires` block (which was the source of the 8080 host binding). The `install.ports:[8080]` entry is kept as the container-internal port so the Docker mapping target is correct.

## What searxng now uses

SearXNG's container-internal port stays 8080. The host port is determined by `allocate_host_port("searxng")` — deterministic hash of the app_id into the 30000–40000 pool, always skipping reserved entries. No core port is ever bound on the host.

## Test plan

- [ ] `tests/test_installers.py::TestPortAllocator` — 7 new assertions: pool bounds, never-returns-reserved, skips 8080, skips taOS port 6969, determinism, skips in-use port, and end-to-end searxng compose check
- [ ] Existing `TestDockerInstaller` tests updated for new `_generate_compose` tuple return and correct host-port assertions
- [ ] `tests/test_lxc_installer.py` — all 15 pass unchanged
- [ ] Full suite (excluding pre-existing e2e/playwright failures): 3571 passed, 0 new failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced dynamic host port allocation for app installations, preventing port conflicts when running multiple services simultaneously.
  * Reserved system ports are now protected from automatic assignment.

* **Bug Fixes**
  * Improved service volume configuration for proper data persistence.

* **Documentation**
  * Added star history badge to project README.

* **Tests**
  * Expanded test coverage for port allocation and installer behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->