### PR TITLE
fix(tests): initialise lifespan-owned app.state objects in test fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -233,6 +233,11 @@ async def client(app, tmp_data_dir):
     )
     await _browser_cookie_store.init()
     app.state.browser_cookie_store = _browser_cookie_store
+    # Lifespan-owned objects set to None by create_app() — tests that bypass
+    # the lifespan need these initialised so routes don't fail on NoneType.
+    from tinyagentos.routes.desktop_browser.copilot_ws import CopilotTicketStore, CopilotHub
+    app.state.copilot_ticket_store = CopilotTicketStore()
+    app.state.copilot_hub = CopilotHub()
     # Auth middleware requires a configured user — set up a test admin so all
     # routes respond normally instead of returning 401 needs_onboarding.
     app.state.auth.setup_user("admin", "Test Admin", "", "testpass")

--- a/tests/routes/conftest.py
+++ b/tests/routes/conftest.py
@@ -22,7 +22,12 @@ def _make_app(tmp_path):
     config_path = tmp_path / "config.yaml"
     config_path.write_text(yaml.dump(config))
     (tmp_path / ".setup_complete").touch()
-    return create_app(data_dir=tmp_path)
+    app = create_app(data_dir=tmp_path)
+    # Lifespan-owned objects set to None by create_app() — initialise them
+    # eagerly so sync TestClient tests work without running the lifespan.
+    from tinyagentos.routes.desktop_browser.vapid import load_or_create_vapid_keypair
+    app.state.vapid_keypair = load_or_create_vapid_keypair(tmp_path)
+    return app
 
 
 @pytest.fixture

--- a/tests/routes/desktop_browser/test_proxy_fetch.py
+++ b/tests/routes/desktop_browser/test_proxy_fetch.py
@@ -203,9 +203,15 @@ class TestProxyFetchCookies:
 
         assert resp.status_code == 200
 
-        # Set-Cookie from upstream MUST NOT appear in our response (cookies
-        # live in the jar, not the user's browser)
-        assert "set-cookie" not in {k.lower() for k in resp.headers}
+        # Upstream Set-Cookie headers must NOT leak into our response — the
+        # cookies are stored in the server-side jar.  The CSRF middleware may
+        # legitimately add its own csrf_token cookie, so we check that no
+        # upstream cookie value (session=abc123) appears in any Set-Cookie
+        # header rather than asserting the header is absent entirely.
+        all_set_cookie = [v for k, v in resp.headers.items() if k.lower() == "set-cookie"]
+        assert not any("session=abc123" in c for c in all_set_cookie), (
+            "upstream Set-Cookie leaked to client response"
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_routes_openclaw.py
+++ b/tests/test_routes_openclaw.py
@@ -71,6 +71,14 @@ async def bearer_client(openclaw_app):
             await store.close()
         await store.init()
     await app.state.qmd_client.init()
+    # bridge_sessions is lifespan-owned (set to None by create_app); init it
+    # so /api/openclaw/sessions/* routes can function without the lifespan.
+    from tinyagentos.bridge_session import BridgeSessionRegistry
+    app.state.bridge_sessions = BridgeSessionRegistry(
+        chat_messages=app.state.chat_messages,
+        chat_channels=app.state.chat_channels,
+        chat_hub=app.state.chat_hub,
+    )
     app.state.auth.setup_user("admin", "Test Admin", "", "testpass")
     token = app.state.auth.get_local_token()
     transport = ASGITransport(app=app)


### PR DESCRIPTION
## Summary

- **#690 NoneType failures** (10 tests): PR #690 deferred `CopilotTicketStore`, `CopilotHub`, `vapid_keypair`, and `BridgeSessionRegistry` to the lifespan. Tests that call `create_app()` without running the lifespan saw `None` for these objects. Fixed by eagerly initialising them in the relevant test fixtures (`tests/conftest.py client`, `tests/routes/conftest.py _make_app()`, `tests/test_routes_openclaw.py bearer_client`).
- **#687 CSRF cookie leaking** (1 test): PR #687 added `CSRFMiddleware` which injects a `csrf_token` cookie on every response, breaking `test_persists_set_cookie_to_jar`'s blanket `"set-cookie" not in response headers` assertion. Narrowed to check that the upstream `session=abc123` value doesn't appear, which is the actual security property.

## Per-test root cause

| Test | Root cause | Fix |
|------|-----------|-----|
| `TestMintTicketEndpoint::test_mint_ticket_happy_path` | `copilot_ticket_store` is `None` (#690) | Add `CopilotTicketStore()` to `client` fixture |
| `TestMintTicketEndpoint::test_minted_ticket_can_be_consumed_via_app_state` | Same | Same |
| `TestPageChangedBroadcast::test_broadcast_*` (4 tests) | `copilot_hub` is `None` (#690) | Add `CopilotHub()` to `client` fixture |
| `TestProxyFetchCookies::test_persists_set_cookie_to_jar` | CSRF middleware adds `set-cookie` (#687) | Narrow assertion to check upstream value not present |
| `TestVapidPublicKey::test_returns_200_without_auth` | `vapid_keypair` is `None` (#690) | Init vapid keypair in `_make_app()` |
| `TestVapidPublicKey::test_same_key_on_second_call` | Same | Same |
| `test_events_stream_receives_user_message` | `bridge_sessions` is `None` (#690) | Add `BridgeSessionRegistry` to `bearer_client` fixture |
| `test_reply_invalid_json_returns_400` | Same — route returns 202 guard-early before parsing body | Same |

## Test plan

- All 12 named failing tests now pass
- All 693 `tests/routes/` tests pass (no regressions)
- All 126 `tests/scheduling/` + newly added test files pass
- Pre-existing failures (`test_hardware`, `test_update_runner`, etc.) are Linux/subprocess-dependent and unaffected by this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test fixture initialization to ensure proper setup of internal systems during testing, preventing test failures and enhancing test reliability across multiple test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->