### PR TITLE
fix(install): qmd @latest fallback on ETARGET (hardening for #706)

### DIFF
--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -1233,8 +1233,21 @@ if [[ -z "${TAOS_SKIP_QMD:-}" ]]; then
                     warn "hit the same failure mode against npm's own tarball and leave"
                     warn "your npm in a broken state requiring a full nodejs reinstall."
                 fi
-                tail -20 "$qmd_install_log" >&2
-                die "npm install of qmd failed — see $qmd_install_log"
+                # Pinned version missing from npm (ETARGET) — fall back to @latest
+                # so a stale/wrong pin can't hard-fail the whole install (see #706).
+                if grep -qiE "ETARGET|No matching version found" "$qmd_install_log" \
+                   && [[ "$qmd_npm_version" != "latest" ]]; then
+                    warn "qmd ${qmd_npm_version} not found on npm (ETARGET); retrying @latest"
+                    if sudo HOME=/root npm install -g --unsafe-perm "@jaylfc/qmd@latest" >>"$qmd_install_log" 2>&1; then
+                        log "qmd installed via @latest fallback"
+                    else
+                        tail -20 "$qmd_install_log" >&2
+                        die "npm install of qmd failed (pinned ${qmd_npm_version} and @latest) — see $qmd_install_log"
+                    fi
+                else
+                    tail -20 "$qmd_install_log" >&2
+                    die "npm install of qmd failed — see $qmd_install_log"
+                fi
             fi
             rm -f "$qmd_install_log"
             # Confirm the binary is reachable before we proceed.


### PR DESCRIPTION
Follow-up hardening to #706. If the pinned `@jaylfc/qmd` version is missing from npm (ETARGET / no matching version), the installer now retries `@latest` instead of aborting the whole install — so a stale/wrong pin can never hard-fail installation again. `bash -n` clean; `TAOS_QMD_NPM_VERSION` override unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server installation robustness: installation script now intelligently retries with the latest version when the pinned version is unavailable, while preserving error reporting for other failure types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->