### PR TITLE
feat(security): registry revocation feed (GET /api/agents/registry/revoked)

### DIFF
--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -169,6 +169,32 @@ class TestAgentRegistryStore:
         finally:
             await store.close()
 
+    # -- Revocation feed -----------------------------------------------------
+
+    async def test_list_revoked_empty_by_default(self, tmp_path):
+        store = await self._make_store(tmp_path / "reg.db")
+        try:
+            await store.register(framework="openclaw", display_name="Active")
+            assert await store.list_revoked() == []
+        finally:
+            await store.close()
+
+    async def test_list_revoked_returns_only_revoked(self, tmp_path):
+        store = await self._make_store(tmp_path / "reg.db")
+        try:
+            active = await store.register(framework="openclaw", display_name="Active")
+            gone = await store.register(framework="hermes", display_name="Gone")
+            await store.revoke(gone["canonical_id"])
+
+            revoked = await store.list_revoked()
+            ids = [r["canonical_id"] for r in revoked]
+            assert gone["canonical_id"] in ids
+            assert active["canonical_id"] not in ids
+            assert all(r["revoked_at"] is not None for r in revoked)
+            assert set(revoked[0].keys()) == {"canonical_id", "revoked_at"}
+        finally:
+            await store.close()
+
 
 # ---------------------------------------------------------------------------
 # Keypair + token tests
@@ -457,3 +483,29 @@ class TestAgentRegistryRoutes:
         rec = resp.json()["record"]
         assert rec["role"] == "researcher"
         assert rec["capabilities"] == ["web-search", "summarise"]
+
+    async def test_revoked_feed_empty_by_default(self, registry_client):
+        resp = await registry_client.get("/api/agents/registry/revoked")
+        assert resp.status_code == 200
+        assert resp.json() == {"revoked": []}
+
+    async def test_revoked_feed_lists_revoked_after_delete(self, registry_client):
+        reg_resp = await registry_client.post(
+            "/api/agents/registry/register",
+            json={"framework": "openclaw", "display_name": "Feed Me"},
+        )
+        cid = reg_resp.json()["canonical_id"]
+        await registry_client.delete(f"/api/agents/registry/{cid}")
+
+        resp = await registry_client.get("/api/agents/registry/revoked")
+        assert resp.status_code == 200
+        revoked = resp.json()["revoked"]
+        entry = next(r for r in revoked if r["canonical_id"] == cid)
+        assert entry["revoked_at"] is not None
+
+    async def test_revoked_path_not_matched_as_canonical_id(self, registry_client):
+        """`/revoked` must hit the feed route, not be read back as an agent id."""
+        resp = await registry_client.get("/api/agents/registry/revoked")
+        assert resp.status_code == 200
+        # The single-entry route would return a record dict or 404, never this.
+        assert "revoked" in resp.json()

--- a/tinyagentos/agent_registry_store.py
+++ b/tinyagentos/agent_registry_store.py
@@ -343,3 +343,23 @@ class AgentRegistryStore(BaseStore):
         )
         await self._db.commit()
         return await self.get(canonical_id)
+
+    async def list_revoked(self) -> list[dict]:
+        """Return ``[{canonical_id, revoked_at}]`` for every revoked entry.
+
+        Lightweight revocation feed the A2A bus polls to reject tokens whose
+        canonical_id has been revoked (the bus checks ``sub == from`` and
+        ``canonical_id not in`` this set). Revocation is per canonical_id, so
+        no per-jti tracking is needed.
+        """
+        if self._db is None:
+            raise RuntimeError("AgentRegistryStore not initialised")
+        cursor = await self._db.execute(
+            "SELECT canonical_id, revoked_at FROM agent_registry "
+            "WHERE revoked_at IS NOT NULL ORDER BY revoked_at"
+        )
+        rows = await cursor.fetchall()
+        return [
+            {"canonical_id": r["canonical_id"], "revoked_at": r["revoked_at"]}
+            for r in rows
+        ]

--- a/tinyagentos/routes/agent_registry.py
+++ b/tinyagentos/routes/agent_registry.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 POST /api/agents/registry/register  — register an agent, mint canonical_id, issue token
 GET  /api/agents/registry/pubkey    — public key for token verification (bus side)
 GET  /api/agents/registry           — list all registry entries
+GET  /api/agents/registry/revoked   — revocation feed (canonical_id + revoked_at) the bus polls
 GET  /api/agents/registry/{id}      — read a single entry
 DELETE /api/agents/registry/{id}    — revoke an entry
 
@@ -109,6 +110,20 @@ async def list_registry(request: Request):
     store = _get_store(request)
     records = await store.list_all()
     return records
+
+
+@router.get("/api/agents/registry/revoked")
+async def list_revoked(request: Request):
+    """Lightweight revocation feed for the A2A bus to poll.
+
+    Returns ``{"revoked": [{canonical_id, revoked_at}, ...]}``. The bus caches
+    this and rejects any token whose ``sub`` (canonical_id) is in the set.
+    Declared before the ``/{canonical_id}`` route so "revoked" is not matched
+    as a canonical_id.
+    """
+    store = _get_store(request)
+    revoked = await store.list_revoked()
+    return {"revoked": revoked}
 
 
 @router.get("/api/agents/registry/{canonical_id}")


### PR DESCRIPTION
Adds the revocation feed @taOSmd needs to wire its bus-side token verify (follow-up to the agent registry #705).

## What
- `GET /api/agents/registry/revoked` → `{"revoked": [{canonical_id, revoked_at}, ...]}`
- Backed by `AgentRegistryStore.list_revoked()` (selects only rows with `revoked_at` set)
- Route declared **before** `/{canonical_id}` so "revoked" isn't matched as an agent id

## Why
@taOSmd picked the poll model for revocation (locked decision: registry revocation-list). The bus caches this feed and rejects any token whose `sub` (canonical_id) is in the set. Revocation is per-canonical_id — revoking an agent kills all its tokens — so no per-jti tracking is needed.

## Tests
5 new (32 pass total): store-level `list_revoked` (empty default, only-revoked, exact key shape) + route-level (empty feed, lists after delete, route-ordering regression).
