### PR TITLE
fix(install): repin @jaylfc/qmd to 2.6.0 (restores memory keyword + semantic search)

### DIFF
--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -1218,7 +1218,7 @@ if [[ -z "${TAOS_SKIP_QMD:-}" ]]; then
             # npm packages are signed via the registry's package-lock integrity
             # mechanism (sha512 in package-lock.json); pinning the version here
             # is the supply-chain control available at install time.
-            qmd_npm_version="${TAOS_QMD_NPM_VERSION:-2.5.3}"
+            qmd_npm_version="${TAOS_QMD_NPM_VERSION:-2.6.0}"
             qmd_install_log=$(mktemp /tmp/taos-qmd-install.XXXXXX.log)
             log "npm install -g @jaylfc/qmd@${qmd_npm_version} (log: $qmd_install_log)"
             if ! sudo HOME=/root npm install -g --unsafe-perm "@jaylfc/qmd@${qmd_npm_version}" >"$qmd_install_log" 2>&1; then


### PR DESCRIPTION
qmd 2.6.0 is live on npm (published from PR #511). Its serve exposes both `GET /search` (keyword) and `POST /vsearch` (semantic), which 2.5.3 lacked — so taOS `memory.py:117` and `:140` resolve again with **no code change**, just the pin bump. The #707 `@latest` ETARGET fallback de-risks propagation lag. Closes the /vsearch+/search gap (task #17).