### PR TITLE
beta: promote dev → master (auth security fix + qmd 2.6.0)

### DIFF
--- a/docs/superpowers/specs/2026-06-09-multi-user-auth-context-design.md
+++ b/docs/superpowers/specs/2026-06-09-multi-user-auth-context-design.md
@@ -1,0 +1,112 @@
+# Multi-User Auth-Context Layer — Design
+
+**Date:** 2026-06-09
+**Status:** Approved (design decisions locked via review); ready for implementation
+**Branch:** `feat/multi-user-auth-context`
+**Supersedes:** PR #709 (registry revocation feed) — folded in here so a single PR owns the registry route changes.
+
+## Problem
+
+A background security review flagged two HIGH findings on the agent registry (`tinyagentos/routes/agent_registry.py`, merged in #705):
+
+1. **Spoofable identity in signed token** — `register_agent` reads `user_id` (and `origin`) from the request **body** and `mint_registry_token` signs that `user_id` into the EdDSA token. A caller can self-assert any `user_id`.
+2. **IDOR / cross-tenant exposure** — `DELETE /api/agents/registry/{id}` revokes any agent with no ownership check; `GET /api/agents/registry` and `/{id}` return every tenant's entries.
+
+Root cause is shared with the whole app: `AuthMiddleware` validates a session/local-token as a pass/401 gate but **does not expose the authenticated user to route handlers**, so no route can enforce per-user ownership. `AuthManager` already resolves sessions to a `user_id`, tracks `is_admin`, and exposes `is_multi_user()` — the building blocks exist; the wiring does not.
+
+## Decisions (locked)
+
+| # | Decision | Choice |
+|---|----------|--------|
+| 1 | How routes get the user | **Middleware sets `request.state` + a `current_user` FastAPI dependency** |
+| 2 | Authorization rule | **Owner-or-admin** (owner = `user_id` match, OR `is_admin`) |
+| 3 | Scope of this spec/PR | **Auth-context layer + apply to the registry now**; other stores user-scoped incrementally in tracked follow-ups |
+| 4 | Bus access to registry endpoints | **`/pubkey` public (exempt); `/revoked` behind the local/service token** |
+
+## Design
+
+### 1. Auth context in the middleware
+
+`AuthMiddleware.dispatch` resolves identity it currently discards. After each successful auth path, set request state; default to anonymous otherwise.
+
+- **Exempt paths** (SPA shell, static, `/pubkey`, etc.): `request.state.user_id = None`, `request.state.is_admin = False`. Routes that need a user use the dependency, which 401s.
+- **Local token path** (`Authorization: Bearer <.auth_local_token>`): possession = same-user-on-host trust → maps to the **primary/admin user**. Set `request.state.user_id = auth_mgr.get_primary_user()["id"]`, `request.state.is_admin = True`, `request.state.via = "local_token"`.
+- **Session cookie path**: `user_id = auth_mgr.validate_session(token)`; look up `is_admin` via `auth_mgr.get_user_by_id(user_id)`. Set `request.state.user_id`, `request.state.is_admin`, `request.state.via = "session"`.
+
+State is set on `request.state` before `call_next`. No behavioural change to the gate itself (same allow/redirect/401 logic).
+
+### 2. `current_user` dependency + authz helpers
+
+New module `tinyagentos/auth_context.py`:
+
+```python
+from dataclasses import dataclass
+from fastapi import Request, HTTPException
+
+@dataclass(frozen=True)
+class CurrentUser:
+    user_id: str
+    is_admin: bool
+
+def current_user(request: Request) -> CurrentUser:
+    """FastAPI dependency. 401 if no authenticated user on request.state."""
+    uid = getattr(request.state, "user_id", None)
+    if not uid:
+        raise HTTPException(status_code=401, detail="authentication required")
+    return CurrentUser(user_id=uid, is_admin=bool(getattr(request.state, "is_admin", False)))
+
+def require_owner_or_admin(user: CurrentUser, resource_user_id: str) -> None:
+    """403 unless the caller owns the resource or is an admin."""
+    if user.is_admin or user.user_id == resource_user_id:
+        return
+    raise HTTPException(status_code=403, detail="forbidden")
+```
+
+This is the **default pattern** for every user-scoped resource going forward, not registry-specific.
+
+### 3. Registry route changes (`routes/agent_registry.py`)
+
+- **`register`**: drop `user_id` from `RegisterRequest`; derive it from `Depends(current_user)`. Constrain `origin` to an allowlist `{"taos-deployed", "external-selfjoin"}` (default `taos-deployed`); reject others with 422. The minted token's `user_id` is now the authenticated caller's — no longer spoofable.
+- **`list_registry`**: admins see all; non-admins see only their own (`[r for r in records if r["user_id"] == user.user_id]`). Add `store.list_for_user(user_id)` to push the filter into SQL rather than filtering in Python.
+- **`get_registry_entry`**: 404 if missing; `require_owner_or_admin` on the record's `user_id` (403 otherwise — but return 404 to non-owners to avoid existence disclosure; see Testing).
+- **`revoke_registry_entry`**: fetch first, `require_owner_or_admin`, then revoke. 404 for unknown; 403/404 for not-owned.
+- **`get_pubkey`**: add `/api/agents/registry/pubkey` to `AuthMiddleware.EXEMPT_PATHS` so the bus fetches it with no session. Update the (now-accurate) docstring.
+- **`list_revoked`** (folded from #709): `GET /api/agents/registry/revoked` → `{"revoked": [{canonical_id, revoked_at}, ...]}`, declared **before** `/{canonical_id}`. **Admin-or-local-token only** (it returns the global revocation set the bus needs; members don't see it). The bus authenticates with the local token, which maps to admin. Backed by `store.list_revoked()`.
+
+### 4. Store additions (`agent_registry_store.py`)
+
+- `list_for_user(user_id) -> list[dict]` — `WHERE user_id = ?`.
+- `list_revoked() -> list[dict]` — `[{canonical_id, revoked_at}]WHERE revoked_at IS NOT NULL` (from #709).
+
+### Backward compatibility / standalone
+
+- **Single-user (today):** the one user is primary → `is_admin = True` → sees and manages everything. No functional change for Jay's deployment.
+- **First boot / not configured:** unchanged (onboarding redirect / 401).
+- **Local token:** existing scripts/CLI using the Bearer token keep working and now act explicitly as the admin user.
+
+## Coordination with @taOSmd
+
+- `/pubkey` becomes public — their pubkey fetch needs no token (simpler than today). Confirmed shape unchanged: `{"public_key": "<PEM SubjectPublicKeyInfo>"}`, `iss = "taos-registry"`.
+- `/revoked` requires the local/service token — they configure the bus with it (alongside `registry_url`). Feed shape unchanged: `{"revoked": [{canonical_id, revoked_at}]}`.
+- Their `feat/registry-bus-auth` branch already targets these contracts; only the `/revoked` auth requirement is new — relay it.
+
+## Testing
+
+- **Middleware:** state set correctly for session / local-token / exempt / anonymous paths.
+- **Dependency:** `current_user` 401s with no user; returns correct `is_admin`.
+- **Registry authz:** owner can read/revoke own; non-owner gets 404 (existence-hiding) on read and 403/404 on revoke; admin can do both across users; `register` ignores body `user_id` and signs the session user; `origin` allowlist enforced; `list` scoped for member vs full for admin.
+- **Pubkey:** reachable unauthenticated (exempt).
+- **Revoked feed:** admin/local-token only (member 403); correct shape; route-ordering regression (`/revoked` not matched as a canonical_id).
+- Existing 32 registry tests stay green (adjust the ones that posted body `user_id`).
+
+## Rollout
+
+1. This PR: auth-context layer + registry. Closes/supersedes #709.
+2. Follow-up (tracked, task #11 family): apply `current_user` + owner scoping to the other user-keyed stores (memory, projects, knowledge, …) incrementally — one store per PR, each with tests.
+3. After merge + @taOSmd's bus-auth: coordinate the shared-Pi deploy (config `registry_url` + service token + restart).
+
+## Out of scope
+
+- Full RBAC / capability-based authz (the existing caps system stays for shortcuts; revisit if finer granularity is needed).
+- Retrofitting every store in one epic (explicitly deferred to incremental follow-ups).
+- Token expiry/refresh (revocation-list is the chosen model; documented limitation stands).

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -1218,7 +1218,7 @@ if [[ -z "${TAOS_SKIP_QMD:-}" ]]; then
             # npm packages are signed via the registry's package-lock integrity
             # mechanism (sha512 in package-lock.json); pinning the version here
             # is the supply-chain control available at install time.
-            qmd_npm_version="${TAOS_QMD_NPM_VERSION:-2.5.3}"
+            qmd_npm_version="${TAOS_QMD_NPM_VERSION:-2.6.0}"
             qmd_install_log=$(mktemp /tmp/taos-qmd-install.XXXXXX.log)
             log "npm install -g @jaylfc/qmd@${qmd_npm_version} (log: $qmd_install_log)"
             if ! sudo HOME=/root npm install -g --unsafe-perm "@jaylfc/qmd@${qmd_npm_version}" >"$qmd_install_log" 2>&1; then

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -3,7 +3,9 @@
 Covers:
   - Store: canonical_id minting (format, immutability, collision suffix)
   - Store: token issue + verify-with-pubkey round-trip
+  - Store: list_for_user / list_revoked
   - Routes: register / read-back / list / revoke
+  - Routes: origin allowlist, revoked feed, route-ordering regression
 """
 from __future__ import annotations
 
@@ -169,6 +171,59 @@ class TestAgentRegistryStore:
         finally:
             await store.close()
 
+    # -- list_for_user -------------------------------------------------------
+
+    async def test_list_for_user_returns_only_own_records(self, tmp_path):
+        store = await self._make_store(tmp_path / "reg.db")
+        try:
+            await store.register(framework="openclaw", user_id="alice")
+            await store.register(framework="hermes", user_id="alice")
+            await store.register(framework="openclaw", user_id="bob")
+
+            alice_records = await store.list_for_user("alice")
+            bob_records = await store.list_for_user("bob")
+            nobody_records = await store.list_for_user("nobody")
+
+            assert len(alice_records) == 2
+            assert all(r["user_id"] == "alice" for r in alice_records)
+            assert len(bob_records) == 1
+            assert bob_records[0]["user_id"] == "bob"
+            assert len(nobody_records) == 0
+        finally:
+            await store.close()
+
+    # -- list_revoked --------------------------------------------------------
+
+    async def test_list_revoked_returns_only_revoked(self, tmp_path):
+        store = await self._make_store(tmp_path / "reg.db")
+        try:
+            rec_a = await store.register(framework="openclaw", display_name="A")
+            rec_b = await store.register(framework="hermes", display_name="B")
+            await store.register(framework="openclaw", display_name="C")  # not revoked
+
+            await store.revoke(rec_a["canonical_id"])
+            await store.revoke(rec_b["canonical_id"])
+
+            revoked = await store.list_revoked()
+            assert len(revoked) == 2
+            cids = {r["canonical_id"] for r in revoked}
+            assert rec_a["canonical_id"] in cids
+            assert rec_b["canonical_id"] in cids
+            # Each entry must have exactly canonical_id and revoked_at
+            for entry in revoked:
+                assert set(entry.keys()) == {"canonical_id", "revoked_at"}
+                assert entry["revoked_at"] is not None
+        finally:
+            await store.close()
+
+    async def test_list_revoked_empty_when_none_revoked(self, tmp_path):
+        store = await self._make_store(tmp_path / "reg.db")
+        try:
+            await store.register(framework="openclaw")
+            assert await store.list_revoked() == []
+        finally:
+            await store.close()
+
 
 # ---------------------------------------------------------------------------
 # Keypair + token tests
@@ -323,7 +378,7 @@ class TestTokenRoundTrip:
 
 @pytest_asyncio.fixture
 async def registry_client(app, tmp_data_dir):
-    """Async client with agent_registry store initialised."""
+    """Async client with agent_registry store initialised, authenticated as admin."""
     # Init the agent_registry store (lifespan not running in tests)
     registry_store = app.state.agent_registry
     if registry_store._db is None:
@@ -347,6 +402,8 @@ async def registry_client(app, tmp_data_dir):
         base_url="http://test",
         cookies={"taos_session": token},
     ) as c:
+        # Expose the admin uid so tests can assert token claims
+        c._test_admin_uid = uid
         yield c
 
     await registry_store.close()
@@ -369,8 +426,8 @@ class TestAgentRegistryRoutes:
         assert data["record"]["framework"] == "openclaw"
         assert data["record"]["display_name"] == "Route Agent"
 
-    async def test_register_token_verifiable_with_pubkey(self, registry_client):
-        """Token issued via route verifies against the pubkey route."""
+    async def test_register_token_carries_authenticated_user_id(self, registry_client):
+        """Token user_id must equal the authenticated caller's id, not a body value."""
         resp = await registry_client.post(
             "/api/agents/registry/register",
             json={"framework": "hermes", "display_name": "Verified Agent"},
@@ -386,8 +443,25 @@ class TestAgentRegistryRoutes:
         payload = verify_registry_token(token, pub_pem)
         assert payload["sub"] == canonical_id
         assert payload["iss"] == "taos-registry"
-        assert payload["user_id"] == ""
+        # user_id in the token must be the authenticated admin's id
+        assert payload["user_id"] == registry_client._test_admin_uid
         assert payload["framework"] == "hermes"
+
+    async def test_register_origin_allowlist_rejects_bad_value(self, registry_client):
+        """origin values outside the allowlist must be rejected with 422."""
+        resp = await registry_client.post(
+            "/api/agents/registry/register",
+            json={"framework": "openclaw", "origin": "evil-origin"},
+        )
+        assert resp.status_code == 422
+
+    async def test_register_origin_allowlist_accepts_valid_values(self, registry_client):
+        for origin in ("taos-deployed", "external-selfjoin"):
+            resp = await registry_client.post(
+                "/api/agents/registry/register",
+                json={"framework": "openclaw", "origin": origin},
+            )
+            assert resp.status_code == 200, f"origin={origin!r} should be accepted"
 
     async def test_pubkey_endpoint_returns_pem(self, registry_client):
         resp = await registry_client.get("/api/agents/registry/pubkey")
@@ -411,7 +485,7 @@ class TestAgentRegistryRoutes:
         resp = await registry_client.get("/api/agents/registry/no-such-agent")
         assert resp.status_code == 404
 
-    async def test_list_returns_all(self, registry_client):
+    async def test_list_returns_all_for_admin(self, registry_client):
         await registry_client.post(
             "/api/agents/registry/register",
             json={"framework": "openclaw", "display_name": "List A"},
@@ -457,3 +531,35 @@ class TestAgentRegistryRoutes:
         rec = resp.json()["record"]
         assert rec["role"] == "researcher"
         assert rec["capabilities"] == ["web-search", "summarise"]
+
+    # -- Revoked feed --------------------------------------------------------
+
+    async def test_revoked_feed_shape(self, registry_client):
+        """GET /api/agents/registry/revoked returns {revoked: [{canonical_id, revoked_at}]}."""
+        reg_resp = await registry_client.post(
+            "/api/agents/registry/register",
+            json={"framework": "openclaw", "display_name": "To Revoke"},
+        )
+        cid = reg_resp.json()["canonical_id"]
+        await registry_client.delete(f"/api/agents/registry/{cid}")
+
+        resp = await registry_client.get("/api/agents/registry/revoked")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "revoked" in data
+        assert isinstance(data["revoked"], list)
+        assert len(data["revoked"]) >= 1
+        entry = next(e for e in data["revoked"] if e["canonical_id"] == cid)
+        assert set(entry.keys()) == {"canonical_id", "revoked_at"}
+        assert entry["revoked_at"] is not None
+
+    async def test_revoked_route_not_captured_as_canonical_id(self, registry_client):
+        """Route ordering regression: /revoked must hit the feed, not the single-entry route."""
+        resp = await registry_client.get("/api/agents/registry/revoked")
+        # Must return the feed shape, not a 404 for canonical_id="revoked"
+        assert resp.status_code == 200
+        assert "revoked" in resp.json()
+
+    async def test_revoked_feed_admin_can_read(self, registry_client):
+        resp = await registry_client.get("/api/agents/registry/revoked")
+        assert resp.status_code == 200

--- a/tests/test_auth_context.py
+++ b/tests/test_auth_context.py
@@ -1,0 +1,106 @@
+"""Tests for tinyagentos/auth_context.py helpers.
+
+Covers:
+  - current_user: 401 when request.state.user_id is unset / falsy
+  - current_user: returns correct CurrentUser with is_admin
+  - require_owner_or_admin: owner allowed, admin allowed, stranger -> 403
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from tinyagentos.auth_context import CurrentUser, current_user, require_owner_or_admin
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_request(user_id=None, is_admin=False):
+    """Build a minimal mock Request whose state carries the given attrs."""
+    state = MagicMock()
+    # Simulate getattr(request.state, "user_id", None) behaviour
+    state.user_id = user_id
+    state.is_admin = is_admin
+    req = MagicMock()
+    req.state = state
+    return req
+
+
+# ---------------------------------------------------------------------------
+# current_user dependency
+# ---------------------------------------------------------------------------
+
+class TestCurrentUser:
+
+    def test_401_when_user_id_not_set(self):
+        """No user_id on request.state -> 401."""
+        req = MagicMock()
+        # getattr(request.state, "user_id", None) falls through to default
+        del req.state.user_id  # AttributeError -> getattr returns None
+        req.state = MagicMock(spec=[])  # empty spec: no attributes
+        with pytest.raises(HTTPException) as exc_info:
+            current_user(req)
+        assert exc_info.value.status_code == 401
+
+    def test_401_when_user_id_is_none(self):
+        req = _make_request(user_id=None, is_admin=False)
+        with pytest.raises(HTTPException) as exc_info:
+            current_user(req)
+        assert exc_info.value.status_code == 401
+
+    def test_401_when_user_id_is_empty_string(self):
+        req = _make_request(user_id="", is_admin=False)
+        with pytest.raises(HTTPException) as exc_info:
+            current_user(req)
+        assert exc_info.value.status_code == 401
+
+    def test_returns_current_user_with_correct_fields(self):
+        req = _make_request(user_id="uid-123", is_admin=True)
+        user = current_user(req)
+        assert user.user_id == "uid-123"
+        assert user.is_admin is True
+
+    def test_is_admin_false_for_non_admin(self):
+        req = _make_request(user_id="uid-456", is_admin=False)
+        user = current_user(req)
+        assert user.user_id == "uid-456"
+        assert user.is_admin is False
+
+    def test_current_user_is_frozen(self):
+        """CurrentUser is a frozen dataclass — mutation must raise."""
+        user = CurrentUser(user_id="u1", is_admin=False)
+        with pytest.raises((AttributeError, TypeError)):
+            user.user_id = "other"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# require_owner_or_admin
+# ---------------------------------------------------------------------------
+
+class TestRequireOwnerOrAdmin:
+
+    def test_owner_is_allowed(self):
+        user = CurrentUser(user_id="alice", is_admin=False)
+        # Should not raise
+        require_owner_or_admin(user, "alice")
+
+    def test_admin_is_allowed_for_any_resource(self):
+        user = CurrentUser(user_id="alice", is_admin=True)
+        # Should not raise even for a resource owned by someone else
+        require_owner_or_admin(user, "bob")
+
+    def test_stranger_gets_403(self):
+        user = CurrentUser(user_id="alice", is_admin=False)
+        with pytest.raises(HTTPException) as exc_info:
+            require_owner_or_admin(user, "bob")
+        assert exc_info.value.status_code == 403
+
+    def test_403_detail_is_forbidden(self):
+        user = CurrentUser(user_id="alice", is_admin=False)
+        with pytest.raises(HTTPException) as exc_info:
+            require_owner_or_admin(user, "charlie")
+        assert exc_info.value.detail == "forbidden"

--- a/tinyagentos/agent_registry_store.py
+++ b/tinyagentos/agent_registry_store.py
@@ -327,6 +327,28 @@ class AgentRegistryStore(BaseStore):
         rows = await cursor.fetchall()
         return [_row_to_dict(r) for r in rows]
 
+    async def list_for_user(self, user_id: str) -> list[dict]:
+        """Return all registry records owned by *user_id*."""
+        if self._db is None:
+            raise RuntimeError("AgentRegistryStore not initialised")
+        cursor = await self._db.execute(
+            "SELECT * FROM agent_registry WHERE user_id = ? ORDER BY id",
+            (user_id,),
+        )
+        rows = await cursor.fetchall()
+        return [_row_to_dict(r) for r in rows]
+
+    async def list_revoked(self) -> list[dict]:
+        """Return [{canonical_id, revoked_at}] for all revoked entries."""
+        if self._db is None:
+            raise RuntimeError("AgentRegistryStore not initialised")
+        cursor = await self._db.execute(
+            "SELECT canonical_id, revoked_at FROM agent_registry "
+            "WHERE revoked_at IS NOT NULL ORDER BY revoked_at",
+        )
+        rows = await cursor.fetchall()
+        return [{"canonical_id": r["canonical_id"], "revoked_at": r["revoked_at"]} for r in rows]
+
     # ------------------------------------------------------------------
     # Revoke
     # ------------------------------------------------------------------

--- a/tinyagentos/auth_context.py
+++ b/tinyagentos/auth_context.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from fastapi import HTTPException, Request
+
+
+@dataclass(frozen=True)
+class CurrentUser:
+    user_id: str
+    is_admin: bool
+
+
+def current_user(request: Request) -> CurrentUser:
+    """FastAPI dependency. 401 if no authenticated user on request.state."""
+    uid = getattr(request.state, "user_id", None)
+    if not uid:
+        raise HTTPException(status_code=401, detail="authentication required")
+    return CurrentUser(
+        user_id=uid,
+        is_admin=bool(getattr(request.state, "is_admin", False)),
+    )
+
+
+def require_owner_or_admin(user: CurrentUser, resource_user_id: str) -> None:
+    """403 unless the caller owns the resource or is an admin."""
+    if user.is_admin or user.user_id == resource_user_id:
+        return
+    raise HTTPException(status_code=403, detail="forbidden")

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -5,7 +5,7 @@ from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import RedirectResponse
 
-EXEMPT_PATHS = {"/auth/login", "/auth/setup", "/auth/status", "/auth/me", "/auth/complete", "/auth/lock", "/api/health", "/api/version", "/api/cluster/workers", "/api/cluster/heartbeat", "/setup", "/setup/complete", "/redeem", "/api/desktop/browser/push/vapid-public-key", "/api/desktop/browser/proxy-config", "/sw.js", "/desktop", "/desktop/index.html", "/chat-pwa"}
+EXEMPT_PATHS = {"/auth/login", "/auth/setup", "/auth/status", "/auth/me", "/auth/complete", "/auth/lock", "/api/health", "/api/version", "/api/cluster/workers", "/api/cluster/heartbeat", "/setup", "/setup/complete", "/redeem", "/api/desktop/browser/push/vapid-public-key", "/api/desktop/browser/proxy-config", "/sw.js", "/desktop", "/desktop/index.html", "/chat-pwa", "/api/agents/registry/pubkey"}
 # Bundle assets and the SPA shell HTML must be reachable without auth so:
 #   1. The browser can install and cache the shell for offline / PWA use.
 #   2. After a backend restart the cached shell loads immediately without
@@ -37,6 +37,9 @@ class AuthMiddleware(BaseHTTPMiddleware):
         # could bypass onboarding by hitting an /api endpoint that the
         # not-configured branch used to allow through unconditionally.
         if path in EXEMPT_PATHS or any(path.startswith(p) for p in EXEMPT_PREFIXES):
+            request.state.user_id = None
+            request.state.is_admin = False
+            request.state.via = "exempt"
             return await call_next(request)
 
         # Local token (Authorization: Bearer <token>) is accepted as a
@@ -49,6 +52,23 @@ class AuthMiddleware(BaseHTTPMiddleware):
         if auth_header.lower().startswith("bearer "):
             presented = auth_header[7:].strip()
             if presented and auth_mgr.validate_local_token(presented):
+                # A valid local token IS valid auth (same-host trust: the
+                # token file is 0600, possession = the host user). It maps to
+                # the primary/admin user when one exists. Before onboarding
+                # there is no primary user yet — the token still passes (it is
+                # how scripts/CLI operate pre-setup), but with no user_id, so
+                # current_user-gated routes still 401 while middleware-only
+                # routes proceed as before. (Not failing closed here: the
+                # local token already authenticates, so it is not a bypass.)
+                primary = auth_mgr.get_primary_user()
+                if primary:
+                    request.state.user_id = primary["id"]
+                    request.state.is_admin = True
+                    request.state.via = "local_token"
+                else:
+                    request.state.user_id = None
+                    request.state.is_admin = False
+                    request.state.via = "local_token"
                 return await call_next(request)
 
         # First boot: no user yet. Browsers go to the setup page; APIs
@@ -64,8 +84,16 @@ class AuthMiddleware(BaseHTTPMiddleware):
 
         # Check session cookie
         token = request.cookies.get("taos_session")
-        if token and auth_mgr.validate_session(token) is not None:
-            return await call_next(request)
+        if token:
+            user_id = auth_mgr.validate_session(token)
+            if user_id is not None:
+                user_record = auth_mgr.get_user_by_id(user_id)
+                request.state.user_id = user_id
+                request.state.is_admin = bool(
+                    user_record.get("is_admin") if user_record else False
+                )
+                request.state.via = "session"
+                return await call_next(request)
 
         # Redirect to login for browsers, 401 for API calls
         accept = request.headers.get("accept", "")

--- a/tinyagentos/routes/agent_registry.py
+++ b/tinyagentos/routes/agent_registry.py
@@ -2,25 +2,29 @@ from __future__ import annotations
 
 """Routes for the Agent Registry (SP-A, taOS side).
 
-POST /api/agents/registry/register  — register an agent, mint canonical_id, issue token
-GET  /api/agents/registry/pubkey    — public key for token verification (bus side)
-GET  /api/agents/registry           — list all registry entries
-GET  /api/agents/registry/{id}      — read a single entry
-DELETE /api/agents/registry/{id}    — revoke an entry
+POST   /api/agents/registry/register    — register an agent, mint canonical_id, issue token
+GET    /api/agents/registry/pubkey      — public key for token verification (exempt, no auth)
+GET    /api/agents/registry/revoked     — global revocation feed (admin/local-token only)
+GET    /api/agents/registry             — list registry entries (admin: all; member: own)
+GET    /api/agents/registry/{id}        — read a single entry (owner or admin; else 404)
+DELETE /api/agents/registry/{id}        — revoke an entry (owner or admin)
 
-The pubkey endpoint is intentionally unauthenticated so the A2A bus (taOSmd)
-can fetch it on its own schedule without a session cookie.
+Route ordering matters: /pubkey and /revoked are declared before /{canonical_id} so
+the literal strings are not captured as a canonical_id path parameter.
 """
 
 from typing import Optional
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
-from tinyagentos.agent_registry_store import mint_registry_token, verify_registry_token
+from tinyagentos.agent_registry_store import mint_registry_token
+from tinyagentos.auth_context import CurrentUser, current_user, require_owner_or_admin
 
 router = APIRouter()
+
+_ALLOWED_ORIGINS = {"taos-deployed", "external-selfjoin"}
 
 
 # ---------------------------------------------------------------------------
@@ -30,11 +34,18 @@ router = APIRouter()
 class RegisterRequest(BaseModel):
     framework: str
     display_name: Optional[str] = ""
-    user_id: Optional[str] = ""
     origin: Optional[str] = "taos-deployed"
     handle: Optional[str] = ""
     role: Optional[str] = None
     capabilities: Optional[list[str]] = None
+
+    @field_validator("origin")
+    @classmethod
+    def _validate_origin(cls, v: Optional[str]) -> Optional[str]:
+        val = v or "taos-deployed"
+        if val not in _ALLOWED_ORIGINS:
+            raise ValueError(f"origin must be one of {sorted(_ALLOWED_ORIGINS)}")
+        return val
 
 
 # ---------------------------------------------------------------------------
@@ -60,15 +71,23 @@ def _get_keypair(request: Request) -> tuple[bytes, bytes]:
 # ---------------------------------------------------------------------------
 
 @router.post("/api/agents/registry/register")
-async def register_agent(request: Request, body: RegisterRequest):
-    """Register an agent and issue a signed identity token."""
+async def register_agent(
+    request: Request,
+    body: RegisterRequest,
+    user: CurrentUser = Depends(current_user),
+):
+    """Register an agent and issue a signed identity token.
+
+    The minted token's user_id is the authenticated caller's id — not
+    a value from the request body, so identity cannot be spoofed.
+    """
     store = _get_store(request)
     private_pem, _public_pem = _get_keypair(request)
 
     record = await store.register(
         framework=body.framework,
         display_name=body.display_name or "",
-        user_id=body.user_id or "",
+        user_id=user.user_id,
         origin=body.origin or "taos-deployed",
         handle=body.handle or "",
         role=body.role,
@@ -78,7 +97,7 @@ async def register_agent(request: Request, body: RegisterRequest):
     token = mint_registry_token(
         record["canonical_id"],
         private_pem,
-        user_id=record.get("user_id", ""),
+        user_id=user.user_id,
         framework=record.get("framework", ""),
     )
     return {
@@ -92,8 +111,9 @@ async def register_agent(request: Request, body: RegisterRequest):
 async def get_pubkey(request: Request):
     """Return the registry's Ed25519 public key in PEM format.
 
-    This endpoint is intentionally open (no auth required) so the A2A bus
-    can fetch the key to verify tokens independently.
+    This endpoint is exempt from authentication (listed in EXEMPT_PATHS) so
+    the A2A bus (taOSmd) can fetch the key on its own schedule without a
+    session cookie or local token.
     """
     _private_pem, public_pem = _get_keypair(request)
     return {
@@ -103,29 +123,68 @@ async def get_pubkey(request: Request):
     }
 
 
-@router.get("/api/agents/registry")
-async def list_registry(request: Request):
-    """List all registry entries."""
+@router.get("/api/agents/registry/revoked")
+async def list_revoked_entries(
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    """Return the global revocation feed: [{canonical_id, revoked_at}, ...].
+
+    Admin or local-token only — this is the set the A2A bus needs to check
+    whether a token has been revoked.  Members do not have access.
+    """
+    if not user.is_admin:
+        raise HTTPException(status_code=403, detail="forbidden")
     store = _get_store(request)
-    records = await store.list_all()
-    return records
+    return {"revoked": await store.list_revoked()}
+
+
+@router.get("/api/agents/registry")
+async def list_registry(
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    """List registry entries. Admins see all; members see only their own."""
+    store = _get_store(request)
+    if user.is_admin:
+        return await store.list_all()
+    return await store.list_for_user(user.user_id)
 
 
 @router.get("/api/agents/registry/{canonical_id}")
-async def get_registry_entry(request: Request, canonical_id: str):
-    """Fetch a single registry entry by canonical_id."""
+async def get_registry_entry(
+    request: Request,
+    canonical_id: str,
+    user: CurrentUser = Depends(current_user),
+):
+    """Fetch a single registry entry by canonical_id.
+
+    Returns 404 for unknown entries and for entries the caller does not own
+    (existence-hiding — avoids disclosing whether an id exists to non-owners).
+    """
     store = _get_store(request)
     record = await store.get(canonical_id)
     if record is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    if not user.is_admin and user.user_id != record["user_id"]:
         return JSONResponse({"error": "not found"}, status_code=404)
     return record
 
 
 @router.delete("/api/agents/registry/{canonical_id}")
-async def revoke_registry_entry(request: Request, canonical_id: str):
-    """Revoke a registry entry (sets revoked_at, does not delete)."""
+async def revoke_registry_entry(
+    request: Request,
+    canonical_id: str,
+    user: CurrentUser = Depends(current_user),
+):
+    """Revoke a registry entry (sets revoked_at, does not delete).
+
+    Only the owning user or an admin may revoke an entry.
+    """
     store = _get_store(request)
-    record = await store.revoke(canonical_id)
+    record = await store.get(canonical_id)
     if record is None:
         return JSONResponse({"error": "not found or already revoked"}, status_code=404)
-    return {"status": "revoked", "canonical_id": canonical_id, "revoked_at": record.get("revoked_at")}
+    require_owner_or_admin(user, record["user_id"])
+    revoked = await store.revoke(canonical_id)
+    return {"status": "revoked", "canonical_id": canonical_id, "revoked_at": revoked.get("revoked_at")}


### PR DESCRIPTION
Promote `dev` → `master` so the beta install picks up the auth security fix and working memory search.

## Included (2 commits)
- **#710** feat(security): multi-user auth-context layer + registry authz — middleware sets `request.state.user_id`/`is_admin`; `current_user` dependency + owner-or-admin; `register` binds `user_id` from the verified session (fixes spoofable token); `/pubkey` public, `/revoked` admin-gated (fixes IDOR).
- **#711** fix(install): repin `@jaylfc/qmd` 2.5.3 → 2.6.0 — restores memory.py keyword (`/search`) + semantic (`/vsearch`) search (no code change).

Both passed CI on `dev`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added authenticated revoked agents feed endpoint (`/api/agents/registry/revoked`) for admins to view revocation history.

* **Changes**
  * Agent registry endpoints now require authentication.
  * Registry listing returns user's own agents for members; admins see all entries.
  * Agent retrieval enforces user ownership; non-owners receive 404 responses.
  * User identification in registration tokens is now derived from authenticated session.
  * Agent `origin` field validation now enforces an approved allowlist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->