### PR TITLE
chore(ci): add CLA Assistant Lite workflow (self-hosted)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,45 @@
+name: CLA Assistant
+
+# Contributor License Agreement gate (CLA Assistant Lite, self-hosted — no
+# third-party service). Contributors sign ONCE by commenting the exact phrase
+# below on their PR; signatures are stored as JSON in the `cla-signatures`
+# branch of this repo (nothing leaves GitHub). See CLA.md / CONTRIBUTING.md.
+# Complements the DCO sign-off check (DCO = per-commit attestation; CLA =
+# one-time legal agreement).
+#
+# Scoped to PRs targeting `dev` (incoming contributions); the internal
+# dev->master release promotion is not gated here.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, synchronize]
+    branches: [dev]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    steps:
+      - name: CLA Assistant
+        if: >-
+          (github.event.comment.body == 'recreate-cla' ||
+           github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA')
+          || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/version1/cla.json'
+          path-to-document: 'https://github.com/jaylfc/taOS/blob/master/CLA.md'
+          # Dedicated branch for signature records — keeps dev/master clean and
+          # avoids the protected-branch push restrictions on master.
+          branch: 'cla-signatures'
+          # Founder + project bots don't sign the CLA.
+          allowlist: 'jaylfc,naira,dependabot[bot]'

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -18,7 +18,6 @@ on:
     branches: [dev]
 
 permissions:
-  actions: write
   contents: write
   pull-requests: write
   statuses: write
@@ -32,7 +31,7 @@ jobs:
           (github.event.comment.body == 'recreate-cla' ||
            github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA')
           || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.6.1
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08  # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Sets up Option A — CLA Assistant Lite (`contributor-assistant/github-action@v2.6.1`). Contributors sign once by commenting the agreed phrase on their PR; signatures are stored as JSON in a dedicated `cla-signatures` branch — **no third-party service**, nothing leaves GitHub.

- Points `path-to-document` at `CLA.md` (master blob).
- Scoped to `pull_request_target` on **dev** (mirrors `dco.yml`; internal dev→master promotion not gated).
- Allowlist: `jaylfc` (founder) + project bots (`naira`, `dependabot[bot]`).
- Complements the interim DCO check (DCO = per-commit attestation; CLA = one-time legal agreement). DCO can be retired later if you prefer CLA-only.
- `comment.body` is used only in an `if:` equality expression — no shell interpolation (security-safe).

After merge: the first external contributor PR to dev will get the CLA comment + check; signing creates the `cla-signatures` branch automatically.