### PR TITLE
feat(security): scope knowledge store to per-user ownership

### DIFF
--- a/tests/test_knowledge_ownership.py
+++ b/tests/test_knowledge_ownership.py
@@ -1,0 +1,475 @@
+"""Tests for per-user ownership scoping of the knowledge store.
+
+Covers:
+- Store: add_item stores user_id; list_for_user returns only that user's items
+- Store: search_fts scoped by user_id returns only that user's items
+- Store: get_item with user_id filter hides other users' items
+- Routes: create binds caller's user_id
+- Routes: member keyword search returns only own items
+- Routes: member semantic search (mocked qmd) returns only own items
+- Routes: member get_item returns 404 for other user's item
+- Routes: member delete returns 403 for other user's item
+- Routes: admin sees all items
+- Routes: legacy rows (user_id='') visible to admin, hidden from members
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import pytest_asyncio
+import yaml
+from httpx import ASGITransport, AsyncClient
+
+from tinyagentos.app import create_app
+from tinyagentos.auth import get_current_user
+from tinyagentos.knowledge_store import KnowledgeStore
+
+
+# ---------------------------------------------------------------------------
+# Store-level tests (no HTTP, direct method calls)
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture
+async def store(tmp_path):
+    s = KnowledgeStore(tmp_path / "knowledge.db", media_dir=tmp_path / "knowledge-media")
+    await s.init()
+    yield s
+    await s.close()
+
+
+async def _add(store: KnowledgeStore, title: str, user_id: str = "") -> str:
+    return await store.add_item(
+        source_type="article",
+        source_url=f"https://example.com/{title.lower().replace(' ', '-')}",
+        title=title,
+        author="tester",
+        content=f"content for {title}",
+        summary="",
+        categories=[],
+        tags=[],
+        metadata={},
+        user_id=user_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_add_item_stores_user_id(store):
+    item_id = await _add(store, "Alice Article", user_id="user-alice")
+    item = await store.get_item(item_id)
+    assert item is not None
+    assert item["user_id"] == "user-alice"
+
+
+@pytest.mark.asyncio
+async def test_list_for_user_returns_only_own(store):
+    await _add(store, "Alice Post", user_id="user-alice")
+    await _add(store, "Bob Post", user_id="user-bob")
+    await _add(store, "Legacy Post", user_id="")  # legacy row
+
+    alice_items = await store.list_for_user("user-alice")
+    assert len(alice_items) == 1
+    assert alice_items[0]["title"] == "Alice Post"
+
+    bob_items = await store.list_for_user("user-bob")
+    assert len(bob_items) == 1
+    assert bob_items[0]["title"] == "Bob Post"
+
+
+@pytest.mark.asyncio
+async def test_list_items_no_filter_returns_all(store):
+    """No user_id filter (admin path) returns all rows."""
+    await _add(store, "A", user_id="user-1")
+    await _add(store, "B", user_id="user-2")
+    await _add(store, "C", user_id="")
+    all_items = await store.list_items()
+    assert len(all_items) == 3
+
+
+@pytest.mark.asyncio
+async def test_get_item_with_user_id_filter_hides_other_owner(store):
+    item_id = await _add(store, "Bob Secret", user_id="user-bob")
+    # Alice cannot see it
+    result = await store.get_item(item_id, user_id="user-alice")
+    assert result is None
+    # Bob can see it
+    result = await store.get_item(item_id, user_id="user-bob")
+    assert result is not None
+    assert result["title"] == "Bob Secret"
+    # No filter (admin) can see it
+    result = await store.get_item(item_id)
+    assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_search_fts_scoped_by_user_id(store):
+    await _add(store, "Asyncio Guide", user_id="user-alice")
+    await store.add_item(
+        source_type="article",
+        source_url="https://example.com/asyncio-bob",
+        title="Asyncio Bob",
+        author="dev",
+        content="asyncio event loop bob",
+        summary="",
+        categories=[],
+        tags=[],
+        metadata={},
+        user_id="user-bob",
+    )
+
+    alice_results = await store.search_fts("asyncio", user_id="user-alice")
+    assert all(r["user_id"] == "user-alice" for r in alice_results)
+    assert len(alice_results) == 1
+
+    bob_results = await store.search_fts("asyncio", user_id="user-bob")
+    assert len(bob_results) == 1
+    assert bob_results[0]["user_id"] == "user-bob"
+
+    # Admin (no filter) sees both
+    all_results = await store.search_fts("asyncio")
+    assert len(all_results) == 2
+
+
+@pytest.mark.asyncio
+async def test_legacy_rows_hidden_from_member_search(store):
+    """Legacy rows (user_id='') are not returned when filtering by a user_id."""
+    await _add(store, "Old Article asyncio", user_id="")
+    results = await store.search_fts("asyncio", user_id="user-alice")
+    assert len(results) == 0
+    # Admin (no filter) sees it
+    results_admin = await store.search_fts("asyncio")
+    assert len(results_admin) == 1
+
+
+# ---------------------------------------------------------------------------
+# Route-level tests
+# ---------------------------------------------------------------------------
+
+def _make_app(tmp_path: Path):
+    config = {
+        "server": {"host": "0.0.0.0", "port": 6969},
+        "backends": [],
+        "qmd": {"url": "http://localhost:7832"},
+        "agents": [],
+        "metrics": {"poll_interval": 30, "retention_days": 30},
+    }
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    (tmp_path / ".setup_complete").touch()
+    return create_app(data_dir=tmp_path)
+
+
+async def _init_app_stores(app):
+    await app.state.metrics.init()
+    await app.state.notifications.init()
+    await app.state.qmd_client.init()
+    await app.state.knowledge_store.init()
+    app.state._startup_complete = True
+
+
+async def _teardown_app_stores(app):
+    await app.state.knowledge_store.close()
+    await app.state.notifications.close()
+    await app.state.metrics.close()
+    await app.state.qmd_client.close()
+    await app.state.http_client.aclose()
+
+
+def _make_client(app, token: str) -> AsyncClient:
+    return AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        cookies={"taos_session": token},
+    )
+
+
+@pytest_asyncio.fixture
+async def two_user_app(tmp_path):
+    """App with an admin user and a member user, plus their session tokens."""
+    app = _make_app(tmp_path)
+    await _init_app_stores(app)
+
+    auth = app.state.auth
+    # Admin user
+    auth.setup_user("admin", "Test Admin", "", "testpass")
+    admin_record = auth.find_user("admin")
+    admin_uid = admin_record["id"]
+    admin_token = auth.create_session(user_id=admin_uid, long_lived=True)
+
+    # Member user (via invite flow)
+    invite_code = auth.add_user_invite("member", invited_by_username="admin")
+    auth.complete_invite("member", invite_code, "Test Member", "", "testpass2")
+    member_record = auth.find_user("member")
+    member_uid = member_record["id"]
+    member_token = auth.create_session(user_id=member_uid, long_lived=True)
+
+    yield app, admin_uid, admin_token, member_uid, member_token
+
+    await _teardown_app_stores(app)
+
+
+@pytest.mark.asyncio
+async def test_ingest_binds_caller_user_id(two_user_app):
+    app, admin_uid, admin_token, member_uid, member_token = two_user_app
+    async with _make_client(app, member_token) as client:
+        resp = await client.post("/api/knowledge/ingest", json={
+            "url": "https://example.com/member-article",
+            "title": "Member Article",
+            "text": "Some content.",
+            "categories": [],
+            "source": "test",
+        })
+    assert resp.status_code == 200
+    item_id = resp.json()["id"]
+    # Verify item was stored with member's user_id
+    item = await app.state.knowledge_store.get_item(item_id)
+    assert item is not None
+    assert item["user_id"] == member_uid
+
+
+@pytest.mark.asyncio
+async def test_member_list_returns_only_own_items(two_user_app):
+    app, admin_uid, admin_token, member_uid, member_token = two_user_app
+    store = app.state.knowledge_store
+
+    # Seed one item per user and one legacy row
+    await _add(store, "Admin Item", user_id=admin_uid)
+    await _add(store, "Member Item", user_id=member_uid)
+    await _add(store, "Legacy Item", user_id="")
+
+    async with _make_client(app, member_token) as client:
+        resp = await client.get("/api/knowledge/items")
+    assert resp.status_code == 200
+    items = resp.json()["items"]
+    assert len(items) == 1
+    assert items[0]["title"] == "Member Item"
+
+
+@pytest.mark.asyncio
+async def test_admin_list_returns_all_items(two_user_app):
+    app, admin_uid, admin_token, member_uid, member_token = two_user_app
+    store = app.state.knowledge_store
+
+    await _add(store, "Admin Item", user_id=admin_uid)
+    await _add(store, "Member Item", user_id=member_uid)
+    await _add(store, "Legacy Item", user_id="")
+
+    async with _make_client(app, admin_token) as client:
+        resp = await client.get("/api/knowledge/items")
+    assert resp.status_code == 200
+    items = resp.json()["items"]
+    assert len(items) == 3
+
+
+@pytest.mark.asyncio
+async def test_legacy_rows_hidden_from_member_list(two_user_app):
+    app, admin_uid, admin_token, member_uid, member_token = two_user_app
+    store = app.state.knowledge_store
+    await _add(store, "Old Row", user_id="")
+
+    async with _make_client(app, member_token) as client:
+        resp = await client.get("/api/knowledge/items")
+    assert resp.status_code == 200
+    assert resp.json()["items"] == []
+
+
+@pytest.mark.asyncio
+async def test_member_get_own_item_ok(two_user_app):
+    app, admin_uid, admin_token, member_uid, member_token = two_user_app
+    store = app.state.knowledge_store
+    item_id = await _add(store, "Mine", user_id=member_uid)
+
+    async with _make_client(app, member_token) as client:
+        resp = await client.get(f"/api/knowledge/items/{item_id}")
+    assert resp.status_code == 200
+    assert resp.json()["id"] == item_id
+
+
+@pytest.mark.asyncio
+async def test_member_get_other_item_404(two_user_app):
+    """Non-owner receives 404 (existence-hiding)."""
+    app, admin_uid, admin_token, member_uid, member_token = two_user_app
+    store = app.state.knowledge_store
+    item_id = await _add(store, "Not Mine", user_id=admin_uid)
+
+    async with _make_client(app, member_token) as client:
+        resp = await client.get(f"/api/knowledge/items/{item_id}")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_admin_get_any_item_ok(two_user_app):
+    app, admin_uid, admin_token, member_uid, member_token = two_user_app
+    store = app.state.knowledge_store
+    item_id = await _add(store, "Member Item", user_id=member_uid)
+
+    async with _make_client(app, admin_token) as client:
+        resp = await client.get(f"/api/knowledge/items/{item_id}")
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_member_delete_own_item_ok(two_user_app):
+    app, admin_uid, admin_token, member_uid, member_token = two_user_app
+    store = app.state.knowledge_store
+    item_id = await _add(store, "Delete Me", user_id=member_uid)
+
+    async with _make_client(app, member_token) as client:
+        resp = await client.delete(f"/api/knowledge/items/{item_id}")
+    assert resp.status_code == 200
+    assert await store.get_item(item_id) is None
+
+
+@pytest.mark.asyncio
+async def test_member_delete_other_item_403(two_user_app):
+    """Non-owner gets 403 when trying to delete another user's item."""
+    app, admin_uid, admin_token, member_uid, member_token = two_user_app
+    store = app.state.knowledge_store
+    item_id = await _add(store, "Admin Only Item", user_id=admin_uid)
+
+    async with _make_client(app, member_token) as client:
+        resp = await client.delete(f"/api/knowledge/items/{item_id}")
+    assert resp.status_code == 403
+    # Item must still exist
+    assert await store.get_item(item_id) is not None
+
+
+@pytest.mark.asyncio
+async def test_member_keyword_search_returns_only_own(two_user_app):
+    app, admin_uid, admin_token, member_uid, member_token = two_user_app
+    store = app.state.knowledge_store
+
+    await store.add_item(
+        source_type="article",
+        source_url="https://example.com/admin-asyncio",
+        title="Admin Asyncio",
+        author="admin",
+        content="asyncio stuff",
+        summary="",
+        categories=[],
+        tags=[],
+        metadata={},
+        user_id=admin_uid,
+    )
+    await store.add_item(
+        source_type="article",
+        source_url="https://example.com/member-asyncio",
+        title="Member Asyncio",
+        author="member",
+        content="asyncio stuff",
+        summary="",
+        categories=[],
+        tags=[],
+        metadata={},
+        user_id=member_uid,
+    )
+
+    async with _make_client(app, member_token) as client:
+        resp = await client.get("/api/knowledge/search?q=asyncio&mode=keyword")
+    assert resp.status_code == 200
+    results = resp.json()["results"]
+    assert len(results) == 1
+    assert results[0]["user_id"] == member_uid
+
+
+@pytest.mark.asyncio
+async def test_admin_keyword_search_returns_all(two_user_app):
+    app, admin_uid, admin_token, member_uid, member_token = two_user_app
+    store = app.state.knowledge_store
+
+    for uid in [admin_uid, member_uid, ""]:
+        await store.add_item(
+            source_type="article",
+            source_url=f"https://example.com/asyncio-{uid}",
+            title=f"Asyncio {uid}",
+            author="dev",
+            content="asyncio coroutine",
+            summary="",
+            categories=[],
+            tags=[],
+            metadata={},
+            user_id=uid,
+        )
+
+    async with _make_client(app, admin_token) as client:
+        resp = await client.get("/api/knowledge/search?q=asyncio&mode=keyword")
+    assert resp.status_code == 200
+    assert len(resp.json()["results"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_member_semantic_search_scoped(two_user_app):
+    """Semantic search post-filters qmd results to caller's items."""
+    app, admin_uid, admin_token, member_uid, member_token = two_user_app
+    store = app.state.knowledge_store
+
+    member_id = await _add(store, "Member Vector Article", user_id=member_uid)
+    admin_id = await _add(store, "Admin Vector Article", user_id=admin_uid)
+
+    # Mock http_client to return both ids from qmd
+    mock_http = AsyncMock()
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "results": [
+            {"id": member_id, "score": 0.9},
+            {"id": admin_id, "score": 0.8},
+        ]
+    }
+    mock_response.raise_for_status = MagicMock()
+    mock_http.post = AsyncMock(return_value=mock_response)
+    app.state.http_client = mock_http
+
+    async with _make_client(app, member_token) as client:
+        resp = await client.get("/api/knowledge/search?q=vector&mode=semantic")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["mode"] == "semantic"
+    results = data["results"]
+    assert len(results) == 1
+    assert results[0]["id"] == member_id
+
+
+@pytest.mark.asyncio
+async def test_admin_semantic_search_returns_all(two_user_app):
+    """Admin receives all qmd results unfiltered."""
+    app, admin_uid, admin_token, member_uid, member_token = two_user_app
+    store = app.state.knowledge_store
+
+    member_id = await _add(store, "M Vector", user_id=member_uid)
+    admin_id = await _add(store, "A Vector", user_id=admin_uid)
+
+    mock_http = AsyncMock()
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "results": [
+            {"id": member_id, "score": 0.9},
+            {"id": admin_id, "score": 0.8},
+        ]
+    }
+    mock_response.raise_for_status = MagicMock()
+    mock_http.post = AsyncMock(return_value=mock_response)
+    app.state.http_client = mock_http
+
+    async with _make_client(app, admin_token) as client:
+        resp = await client.get("/api/knowledge/search?q=vector&mode=semantic")
+
+    assert resp.status_code == 200
+    assert len(resp.json()["results"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated_request_returns_401(tmp_path):
+    """Unauthenticated requests to knowledge routes return 401."""
+    app = _make_app(tmp_path)
+    await _init_app_stores(app)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            resp = await client.get("/api/knowledge/items")
+        assert resp.status_code == 401
+    finally:
+        await _teardown_app_stores(app)

--- a/tinyagentos/knowledge_ingest.py
+++ b/tinyagentos/knowledge_ingest.py
@@ -100,6 +100,7 @@ class IngestPipeline:
         text: str = "",
         categories: list[str] | None = None,
         source: str = "unknown",
+        user_id: str = "",
     ) -> str:
         """Create a pending KnowledgeItem and return its id.
 
@@ -120,6 +121,7 @@ class IngestPipeline:
             metadata={"ingest_source": source},
             status="pending",
             monitor=monitor_config,
+            user_id=user_id,
         )
         return item_id
 
@@ -130,9 +132,10 @@ class IngestPipeline:
         text: str = "",
         categories: list[str] | None = None,
         source: str = "unknown",
+        user_id: str = "",
     ) -> str:
         """Submit and immediately fire ``run()`` as a background asyncio task."""
-        item_id = await self.submit(url=url, title=title, text=text, categories=categories, source=source)
+        item_id = await self.submit(url=url, title=title, text=text, categories=categories, source=source, user_id=user_id)
         asyncio.create_task(self._run_safe(item_id))
         return item_id
 

--- a/tinyagentos/knowledge_store.py
+++ b/tinyagentos/knowledge_store.py
@@ -28,11 +28,13 @@ CREATE TABLE IF NOT EXISTS knowledge_items (
     status TEXT NOT NULL DEFAULT 'pending',
     monitor TEXT NOT NULL DEFAULT '{}',
     created_at REAL NOT NULL,
-    updated_at REAL NOT NULL
+    updated_at REAL NOT NULL,
+    user_id TEXT NOT NULL DEFAULT ''
 );
 CREATE INDEX IF NOT EXISTS idx_ki_source_type ON knowledge_items(source_type);
 CREATE INDEX IF NOT EXISTS idx_ki_status ON knowledge_items(status);
 CREATE INDEX IF NOT EXISTS idx_ki_created ON knowledge_items(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_ki_user_id ON knowledge_items(user_id);
 
 CREATE VIRTUAL TABLE IF NOT EXISTS knowledge_fts USING fts5(
     id UNINDEXED,
@@ -89,6 +91,7 @@ def _row_to_item(row: tuple) -> dict:
         "monitor": json.loads(row[14] or "{}"),
         "created_at": row[15],
         "updated_at": row[16],
+        "user_id": row[17] if len(row) > 17 else "",
     }
 
 
@@ -96,6 +99,9 @@ class KnowledgeStore(BaseStore):
     """SQLite + FTS5 store for the Knowledge Base Service."""
 
     SCHEMA = KNOWLEDGE_SCHEMA
+    MIGRATIONS = [
+        (1, "ALTER TABLE knowledge_items ADD COLUMN user_id TEXT NOT NULL DEFAULT ''"),
+    ]
 
     def __init__(self, db_path: Path, media_dir: Path | None = None) -> None:
         super().__init__(db_path)
@@ -124,6 +130,7 @@ class KnowledgeStore(BaseStore):
         thumbnail: str | None = None,
         status: str = "pending",
         monitor: dict | None = None,
+        user_id: str = "",
     ) -> str:
         """Insert a new KnowledgeItem and add it to the FTS index. Returns the item id."""
         assert self._db is not None
@@ -133,13 +140,13 @@ class KnowledgeStore(BaseStore):
             """INSERT INTO knowledge_items
                (id, source_type, source_url, source_id, title, author, summary,
                 content, media_path, thumbnail, categories, tags, metadata,
-                status, monitor, created_at, updated_at)
-               VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                status, monitor, created_at, updated_at, user_id)
+               VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
             (
                 item_id, source_type, source_url, source_id, title, author,
                 summary, content, media_path, thumbnail,
                 json.dumps(categories), json.dumps(tags), json.dumps(metadata),
-                status, json.dumps(monitor or {}), now, now,
+                status, json.dumps(monitor or {}), now, now, user_id,
             ),
         )
         await self._db.execute(
@@ -149,16 +156,31 @@ class KnowledgeStore(BaseStore):
         await self._db.commit()
         return item_id
 
-    async def get_item(self, item_id: str) -> dict | None:
-        """Fetch a single item by id. Returns None if not found."""
+    async def get_item(self, item_id: str, user_id: str | None = None) -> dict | None:
+        """Fetch a single item by id.
+
+        When *user_id* is given, only items owned by that user are returned
+        (existence-hiding: returns None for items owned by other users).
+        Pass ``user_id=None`` (default) to skip ownership filtering — used
+        internally and by admin callers.
+        """
         assert self._db is not None
-        cursor = await self._db.execute(
-            """SELECT id, source_type, source_url, source_id, title, author, summary,
-                      content, media_path, thumbnail, categories, tags, metadata,
-                      status, monitor, created_at, updated_at
-               FROM knowledge_items WHERE id = ?""",
-            (item_id,),
-        )
+        if user_id is not None:
+            cursor = await self._db.execute(
+                """SELECT id, source_type, source_url, source_id, title, author, summary,
+                          content, media_path, thumbnail, categories, tags, metadata,
+                          status, monitor, created_at, updated_at, user_id
+                   FROM knowledge_items WHERE id = ? AND user_id = ?""",
+                (item_id, user_id),
+            )
+        else:
+            cursor = await self._db.execute(
+                """SELECT id, source_type, source_url, source_id, title, author, summary,
+                          content, media_path, thumbnail, categories, tags, metadata,
+                          status, monitor, created_at, updated_at, user_id
+                   FROM knowledge_items WHERE id = ?""",
+                (item_id,),
+            )
         row = await cursor.fetchone()
         return _row_to_item(row) if row else None
 
@@ -205,14 +227,22 @@ class KnowledgeStore(BaseStore):
         category: str | None = None,
         limit: int = 50,
         offset: int = 0,
+        user_id: str | None = None,
     ) -> list[dict]:
-        """List items with optional filters, newest first."""
+        """List items with optional filters, newest first.
+
+        When *user_id* is given, only items owned by that user are returned.
+        Pass ``user_id=None`` (default) to list all items (admin / internal use).
+        """
         assert self._db is not None
         sql = """SELECT id, source_type, source_url, source_id, title, author, summary,
                         content, media_path, thumbnail, categories, tags, metadata,
-                        status, monitor, created_at, updated_at
+                        status, monitor, created_at, updated_at, user_id
                  FROM knowledge_items WHERE 1=1"""
         params: list = []
+        if user_id is not None:
+            sql += " AND user_id = ?"
+            params.append(user_id)
         if source_type:
             sql += " AND source_type = ?"
             params.append(source_type)
@@ -235,6 +265,10 @@ class KnowledgeStore(BaseStore):
         rows = await cursor.fetchall()
         return [_row_to_item(r) for r in rows]
 
+    async def list_for_user(self, user_id: str, **kwargs) -> list[dict]:
+        """List items belonging to a specific user. Convenience wrapper around list_items."""
+        return await self.list_items(user_id=user_id, **kwargs)
+
     async def delete_item(self, item_id: str) -> bool:
         """Delete an item and its FTS entry. Returns True if a row was deleted."""
         assert self._db is not None
@@ -249,37 +283,67 @@ class KnowledgeStore(BaseStore):
     # FTS search
     # ------------------------------------------------------------------
 
-    async def search_fts(self, query: str, limit: int = 20) -> list[dict]:
-        """Keyword search across title, content, summary, author using FTS5."""
+    async def search_fts(self, query: str, limit: int = 20, user_id: str | None = None) -> list[dict]:
+        """Keyword search across title, content, summary, author using FTS5.
+
+        When *user_id* is given, results are restricted to items owned by that user.
+        Pass ``user_id=None`` (default) to search across all items (admin / internal).
+        """
         assert self._db is not None
         # Wrap as a quoted phrase so FTS5 operators in user input are not
         # interpreted (AND, OR, NOT, *, NEAR, column:filter, etc.).
         safe_query = '"' + query.replace('"', '""') + '"'
-        sql = """
-            SELECT i.id, i.source_type, i.source_url, i.source_id, i.title, i.author,
-                   i.summary, i.content, i.media_path, i.thumbnail, i.categories,
-                   i.tags, i.metadata, i.status, i.monitor, i.created_at, i.updated_at
-            FROM knowledge_fts f
-            JOIN knowledge_items i ON i.id = f.id
-            WHERE knowledge_fts MATCH ?
-            ORDER BY rank
-            LIMIT ?
-        """
-        try:
-            cursor = await self._db.execute(sql, (safe_query, limit))
-            rows = await cursor.fetchall()
-        except Exception:
-            # Fallback to LIKE when FTS query syntax is invalid
-            fallback = """
+        if user_id is not None:
+            sql = """
+                SELECT i.id, i.source_type, i.source_url, i.source_id, i.title, i.author,
+                       i.summary, i.content, i.media_path, i.thumbnail, i.categories,
+                       i.tags, i.metadata, i.status, i.monitor, i.created_at, i.updated_at,
+                       i.user_id
+                FROM knowledge_fts f
+                JOIN knowledge_items i ON i.id = f.id
+                WHERE knowledge_fts MATCH ? AND i.user_id = ?
+                ORDER BY rank
+                LIMIT ?
+            """
+            fts_params = (safe_query, user_id, limit)
+            fallback_params_fn = lambda pattern: (pattern, pattern, pattern, user_id, limit)
+            fallback_sql = """
                 SELECT id, source_type, source_url, source_id, title, author, summary,
                        content, media_path, thumbnail, categories, tags, metadata,
-                       status, monitor, created_at, updated_at
+                       status, monitor, created_at, updated_at, user_id
+                FROM knowledge_items
+                WHERE (title LIKE ? OR content LIKE ? OR summary LIKE ?) AND user_id = ?
+                ORDER BY created_at DESC LIMIT ?
+            """
+        else:
+            sql = """
+                SELECT i.id, i.source_type, i.source_url, i.source_id, i.title, i.author,
+                       i.summary, i.content, i.media_path, i.thumbnail, i.categories,
+                       i.tags, i.metadata, i.status, i.monitor, i.created_at, i.updated_at,
+                       i.user_id
+                FROM knowledge_fts f
+                JOIN knowledge_items i ON i.id = f.id
+                WHERE knowledge_fts MATCH ?
+                ORDER BY rank
+                LIMIT ?
+            """
+            fts_params = (safe_query, limit)
+            fallback_params_fn = lambda pattern: (pattern, pattern, pattern, limit)
+            fallback_sql = """
+                SELECT id, source_type, source_url, source_id, title, author, summary,
+                       content, media_path, thumbnail, categories, tags, metadata,
+                       status, monitor, created_at, updated_at, user_id
                 FROM knowledge_items
                 WHERE title LIKE ? OR content LIKE ? OR summary LIKE ?
                 ORDER BY created_at DESC LIMIT ?
             """
+        try:
+            cursor = await self._db.execute(sql, fts_params)
+            rows = await cursor.fetchall()
+        except Exception:
+            # Fallback to LIKE when FTS query syntax is invalid
             pattern = f"%{query}%"
-            cursor = await self._db.execute(fallback, (pattern, pattern, pattern, limit))
+            cursor = await self._db.execute(fallback_sql, fallback_params_fn(pattern))
             rows = await cursor.fetchall()
         return [_row_to_item(r) for r in rows]
 

--- a/tinyagentos/routes/knowledge.py
+++ b/tinyagentos/routes/knowledge.py
@@ -8,13 +8,22 @@ All routes live under /api/knowledge/. The router reads state from
 - ``knowledge_store``   — KnowledgeStore instance
 - ``ingest_pipeline``   — IngestPipeline instance
 - ``http_client``       — shared httpx.AsyncClient
+
+Access control
+--------------
+All item/search routes require authentication (``Depends(get_current_user)``).
+Admins see all items; regular members see only their own.
+Legacy rows (``user_id == ''``) are treated as admin-only.
 """
 
 import logging
+from typing import Any
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
+
+from tinyagentos.auth import get_current_user
 
 logger = logging.getLogger(__name__)
 
@@ -53,17 +62,37 @@ class RuleRequest(BaseModel):
 
 
 # ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+
+def _scope_user_id(user: dict[str, Any]) -> str | None:
+    """Return the user_id filter to apply for list/search queries.
+
+    Admins get ``None`` (no filter — see all items including legacy rows).
+    Regular members get their user_id as the filter.
+    """
+    if user.get("is_admin"):
+        return None
+    return str(user.get("id") or "")
+
+
+# ------------------------------------------------------------------
 # Ingest
 # ------------------------------------------------------------------
 
 @router.post("/api/knowledge/ingest")
-async def ingest(request: Request, body: IngestRequest):
+async def ingest(
+    request: Request,
+    body: IngestRequest,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
     """Submit a URL or pre-provided text for ingest.
 
     Returns immediately with the new item id and status='pending'.
     The pipeline runs in the background.
     """
     pipeline = request.app.state.ingest_pipeline
+    user_id = str(current_user.get("id") or "")
     try:
         item_id = await pipeline.submit_background(
             url=body.url,
@@ -71,6 +100,7 @@ async def ingest(request: Request, body: IngestRequest):
             text=body.text,
             categories=body.categories,
             source=body.source,
+            user_id=user_id,
         )
         return {"id": item_id, "status": "pending"}
     except Exception as exc:
@@ -90,24 +120,33 @@ async def list_items(
     category: str | None = None,
     limit: int = 50,
     offset: int = 0,
+    current_user: dict[str, Any] = Depends(get_current_user),
 ):
     """List knowledge items with optional filters."""
     store = request.app.state.knowledge_store
+    filter_user_id = _scope_user_id(current_user)
     items = await store.list_items(
         source_type=source_type,
         status=status,
         category=category,
         limit=limit,
         offset=offset,
+        user_id=filter_user_id,
     )
     return {"items": items, "count": len(items)}
 
 
 @router.get("/api/knowledge/items/{item_id}/snapshots")
-async def list_snapshots(request: Request, item_id: str, limit: int = 20):
+async def list_snapshots(
+    request: Request,
+    item_id: str,
+    limit: int = 20,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
     """List monitoring snapshots for an item."""
     store = request.app.state.knowledge_store
-    item = await store.get_item(item_id)
+    filter_user_id = _scope_user_id(current_user)
+    item = await store.get_item(item_id, user_id=filter_user_id)
     if item is None:
         return JSONResponse({"error": "not found"}, status_code=404)
     snapshots = await store.list_snapshots(item_id, limit=limit)
@@ -115,19 +154,38 @@ async def list_snapshots(request: Request, item_id: str, limit: int = 20):
 
 
 @router.get("/api/knowledge/items/{item_id}")
-async def get_item(request: Request, item_id: str):
+async def get_item(
+    request: Request,
+    item_id: str,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
     """Fetch a single knowledge item by id."""
     store = request.app.state.knowledge_store
-    item = await store.get_item(item_id)
+    filter_user_id = _scope_user_id(current_user)
+    item = await store.get_item(item_id, user_id=filter_user_id)
     if item is None:
         return JSONResponse({"error": "not found"}, status_code=404)
     return item
 
 
 @router.delete("/api/knowledge/items/{item_id}")
-async def delete_item(request: Request, item_id: str):
+async def delete_item(
+    request: Request,
+    item_id: str,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
     """Delete a knowledge item."""
     store = request.app.state.knowledge_store
+    # Fetch without user filter to check existence, then enforce ownership.
+    item = await store.get_item(item_id)
+    if item is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    # Ownership check: admin always allowed; member only their own items.
+    if not current_user.get("is_admin"):
+        owner = item.get("user_id", "")
+        caller = str(current_user.get("id") or "")
+        if owner != caller:
+            return JSONResponse({"error": "forbidden"}, status_code=403)
     deleted = await store.delete_item(item_id)
     if not deleted:
         return JSONResponse({"error": "not found"}, status_code=404)
@@ -144,9 +202,12 @@ async def search(
     q: str = "",
     mode: str = "keyword",
     limit: int = 20,
+    current_user: dict[str, Any] = Depends(get_current_user),
 ):
     """Search the knowledge base by keyword (FTS5) or semantic (QMD vectors)."""
     store = request.app.state.knowledge_store
+    filter_user_id = _scope_user_id(current_user)
+
     if mode == "semantic":
         http_client = request.app.state.http_client
         qmd_base = request.app.state.qmd_client.base_url
@@ -157,10 +218,25 @@ async def search(
                 timeout=60,
             )
             resp.raise_for_status()
-            return {"results": resp.json().get("results", []), "mode": "semantic"}
+            raw_results = resp.json().get("results", [])
+            # Post-filter: restrict to caller's items (or all for admin).
+            if filter_user_id is not None:
+                # Resolve each result id against the store to check ownership.
+                scoped = []
+                for result in raw_results:
+                    result_id = result.get("id") if isinstance(result, dict) else None
+                    if result_id:
+                        item = await store.get_item(result_id, user_id=filter_user_id)
+                        if item is not None:
+                            scoped.append(result)
+                    else:
+                        # If the result has no id we cannot scope it — skip.
+                        pass
+                raw_results = scoped
+            return {"results": raw_results, "mode": "semantic"}
         except Exception as exc:
             logger.warning("QMD vsearch failed, falling back to FTS: %s", exc)
-    results = await store.search_fts(q, limit=limit)
+    results = await store.search_fts(q, limit=limit, user_id=filter_user_id)
     return {"results": results, "mode": "keyword"}
 
 
@@ -169,14 +245,21 @@ async def search(
 # ------------------------------------------------------------------
 
 @router.get("/api/knowledge/rules")
-async def list_rules(request: Request):
+async def list_rules(
+    request: Request,
+    _user: dict[str, Any] = Depends(get_current_user),
+):
     """List all category rules."""
     store = request.app.state.knowledge_store
     return {"rules": await store.list_rules()}
 
 
 @router.post("/api/knowledge/rules")
-async def create_rule(request: Request, body: RuleRequest):
+async def create_rule(
+    request: Request,
+    body: RuleRequest,
+    _user: dict[str, Any] = Depends(get_current_user),
+):
     """Create a new category rule."""
     store = request.app.state.knowledge_store
     rule_id = await store.add_rule(
@@ -189,7 +272,11 @@ async def create_rule(request: Request, body: RuleRequest):
 
 
 @router.delete("/api/knowledge/rules/{rule_id}")
-async def delete_rule(request: Request, rule_id: int):
+async def delete_rule(
+    request: Request,
+    rule_id: int,
+    _user: dict[str, Any] = Depends(get_current_user),
+):
     """Delete a category rule."""
     store = request.app.state.knowledge_store
     deleted = await store.delete_rule(rule_id)
@@ -203,14 +290,22 @@ async def delete_rule(request: Request, rule_id: int):
 # ------------------------------------------------------------------
 
 @router.get("/api/knowledge/subscriptions")
-async def list_subscriptions(request: Request, agent_name: str | None = None):
+async def list_subscriptions(
+    request: Request,
+    agent_name: str | None = None,
+    _user: dict[str, Any] = Depends(get_current_user),
+):
     """List agent knowledge subscriptions."""
     store = request.app.state.knowledge_store
     return {"subscriptions": await store.list_subscriptions(agent_name=agent_name)}
 
 
 @router.post("/api/knowledge/subscriptions")
-async def set_subscription(request: Request, body: SubscriptionRequest):
+async def set_subscription(
+    request: Request,
+    body: SubscriptionRequest,
+    _user: dict[str, Any] = Depends(get_current_user),
+):
     """Upsert an agent subscription for a category."""
     store = request.app.state.knowledge_store
     await store.set_subscription(
@@ -222,7 +317,12 @@ async def set_subscription(request: Request, body: SubscriptionRequest):
 
 
 @router.delete("/api/knowledge/subscriptions/{agent_name}/{category}")
-async def delete_subscription(request: Request, agent_name: str, category: str):
+async def delete_subscription(
+    request: Request,
+    agent_name: str,
+    category: str,
+    _user: dict[str, Any] = Depends(get_current_user),
+):
     """Remove an agent subscription."""
     store = request.app.state.knowledge_store
     deleted = await store.delete_subscription(agent_name=agent_name, category=category)


### PR DESCRIPTION
Part of the per-user store-scoping rollout (task #18), using the auth-context layer from #710.

## Changes
- `knowledge_store.py` — `user_id` column (idempotent migration; legacy rows keep `user_id=''`, visible to admin only), `list_for_user`, owner filters on get/list/search.
- `knowledge_ingest.py` — threads `user_id` through the ingest pipeline.
- `routes/knowledge.py` — `Depends(current_user)`: create binds caller's user_id; list + **both search paths** scoped (FTS adds `AND i.user_id=?`; qmd/vsearch results filtered via owner-checked `get_item`); single-get existence-hiding 404; mutate `require_owner_or_admin`. Admin sees all.

## Tests
20 new ownership tests; 56 knowledge tests pass in the main repo; no regressions.

Security-sensitive — for your review before merge.