### PR TITLE
feat(security): scope projects + tasks by user_id

### DIFF
--- a/tests/test_routes_project_ownership.py
+++ b/tests/test_routes_project_ownership.py
@@ -1,0 +1,509 @@
+"""Tests for per-user ownership scoping on the projects stores and routes.
+
+Covers:
+  - Store: create_project binds caller's user_id; list_for_user returns only own
+  - Routes: create binds user_id from auth; member sees only own projects/tasks
+  - Routes: non-owner gets 404 on read; 403 on mutate
+  - Routes: admin sees/manages all
+  - Legacy rows (user_id='') are visible to admin only
+"""
+from __future__ import annotations
+
+import secrets
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from tinyagentos.projects.project_store import ProjectStore
+from tinyagentos.auth_context import CurrentUser, require_owner_or_admin
+
+
+# ---------------------------------------------------------------------------
+# Store-level ownership tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestProjectStoreOwnership:
+
+    async def _make_store(self, db_path):
+        s = ProjectStore(db_path)
+        await s.init()
+        return s
+
+    async def test_create_project_stores_user_id(self, tmp_path):
+        store = await self._make_store(tmp_path / "p.db")
+        try:
+            p = await store.create_project(
+                name="Alpha", slug="alpha", created_by="user-1", user_id="user-1"
+            )
+            assert p["user_id"] == "user-1"
+            again = await store.get_project(p["id"])
+            assert again["user_id"] == "user-1"
+        finally:
+            await store.close()
+
+    async def test_create_project_default_user_id_is_empty(self, tmp_path):
+        store = await self._make_store(tmp_path / "p.db")
+        try:
+            p = await store.create_project(name="Beta", slug="beta", created_by="u")
+            assert p["user_id"] == ""
+        finally:
+            await store.close()
+
+    async def test_list_for_user_returns_only_own(self, tmp_path):
+        store = await self._make_store(tmp_path / "p.db")
+        try:
+            await store.create_project(name="A", slug="a", created_by="alice", user_id="alice")
+            await store.create_project(name="B", slug="b", created_by="alice", user_id="alice")
+            await store.create_project(name="C", slug="c", created_by="bob", user_id="bob")
+            await store.create_project(name="Legacy", slug="leg", created_by="u")  # user_id=''
+
+            alice_projects = await store.list_for_user("alice")
+            bob_projects = await store.list_for_user("bob")
+            nobody_projects = await store.list_for_user("nobody")
+
+            assert len(alice_projects) == 2
+            assert all(p["user_id"] == "alice" for p in alice_projects)
+            assert len(bob_projects) == 1
+            assert bob_projects[0]["user_id"] == "bob"
+            assert len(nobody_projects) == 0
+        finally:
+            await store.close()
+
+    async def test_list_for_user_respects_status_filter(self, tmp_path):
+        store = await self._make_store(tmp_path / "p.db")
+        try:
+            active = await store.create_project(name="A", slug="a", created_by="u", user_id="u")
+            archived = await store.create_project(name="B", slug="b", created_by="u", user_id="u")
+            await store.set_status(archived["id"], "archived")
+
+            active_list = await store.list_for_user("u", status="active")
+            archived_list = await store.list_for_user("u", status="archived")
+            all_list = await store.list_for_user("u", status=None)
+
+            assert [p["id"] for p in active_list] == [active["id"]]
+            assert [p["id"] for p in archived_list] == [archived["id"]]
+            assert len(all_list) == 2
+        finally:
+            await store.close()
+
+    async def test_list_projects_includes_all(self, tmp_path):
+        """list_projects (admin view) returns all projects regardless of user_id."""
+        store = await self._make_store(tmp_path / "p.db")
+        try:
+            await store.create_project(name="A", slug="a", created_by="u1", user_id="u1")
+            await store.create_project(name="B", slug="b", created_by="u2", user_id="u2")
+            await store.create_project(name="Leg", slug="leg", created_by="u")  # user_id=''
+            all_projects = await store.list_projects(status=None)
+            assert len(all_projects) == 3
+        finally:
+            await store.close()
+
+    async def test_legacy_row_not_in_list_for_user(self, tmp_path):
+        """Legacy rows (user_id='') must NOT appear in list_for_user('') — empty string is not a valid user."""
+        store = await self._make_store(tmp_path / "p.db")
+        try:
+            await store.create_project(name="Legacy", slug="leg", created_by="u")
+            items = await store.list_for_user("")
+            assert items == []
+        finally:
+            await store.close()
+
+
+# ---------------------------------------------------------------------------
+# require_owner_or_admin unit tests
+# ---------------------------------------------------------------------------
+
+class TestRequireOwnerOrAdmin:
+
+    def test_owner_passes(self):
+        user = CurrentUser(user_id="alice", is_admin=False)
+        require_owner_or_admin(user, "alice")  # no exception
+
+    def test_admin_passes_for_any_resource(self):
+        user = CurrentUser(user_id="admin-1", is_admin=True)
+        require_owner_or_admin(user, "bob")  # no exception
+
+    def test_non_owner_raises_403(self):
+        from fastapi import HTTPException
+        user = CurrentUser(user_id="alice", is_admin=False)
+        with pytest.raises(HTTPException) as exc_info:
+            require_owner_or_admin(user, "bob")
+        assert exc_info.value.status_code == 403
+
+    def test_admin_passes_for_legacy_empty_user_id(self):
+        user = CurrentUser(user_id="admin-1", is_admin=True)
+        require_owner_or_admin(user, "")  # admin can manage legacy rows
+
+
+# ---------------------------------------------------------------------------
+# Route fixtures — admin client + member client
+# ---------------------------------------------------------------------------
+
+def _add_member_user(app, username: str = "member", password: str = "memberpass1") -> str:
+    """Inject a non-admin user into the auth store and return their user_id."""
+    auth = app.state.auth
+    invite_code = auth.add_user_invite(username, invited_by_username="admin")
+    auth.complete_invite(
+        username=username,
+        invite_code=invite_code,
+        full_name="Member User",
+        email=f"{username}@test.local",
+        password=password,
+    )
+    record = auth.find_user(username)
+    return record["id"]
+
+
+def _init_stores_and_admin(app) -> str:
+    """Set up admin user, return admin user_id. Idempotent."""
+    # setup_user raises if a user already exists — guard for shared fixtures
+    if not app.state.auth.is_configured():
+        app.state.auth.setup_user("admin", "Test Admin", "", "testpass")
+    record = app.state.auth.find_user("admin")
+    return record["id"] if record else ""
+
+
+async def _init_project_stores(app):
+    for attr in ("project_store", "project_task_store"):
+        store = getattr(app.state, attr, None)
+        if store is not None and store._db is None:
+            await store.init()
+    app.state.projects_root.mkdir(parents=True, exist_ok=True)
+
+
+@pytest_asyncio.fixture
+async def member_client(app, tmp_data_dir):
+    """Authenticated non-admin member client."""
+    await _init_project_stores(app)
+    _init_stores_and_admin(app)
+    member_uid = _add_member_user(app, username="member", password="memberpass1")
+    token = app.state.auth.create_session(user_id=member_uid, long_lived=True)
+    app.state._startup_complete = True
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        cookies={"taos_session": token},
+    ) as c:
+        c._test_uid = member_uid
+        c._test_app = app
+        yield c
+
+    await app.state.project_store.close()
+    await app.state.project_task_store.close()
+
+
+@pytest_asyncio.fixture
+async def two_member_clients(app, tmp_data_dir):
+    """Two separate non-admin member clients (alice and bob) sharing one app."""
+    await _init_project_stores(app)
+    _init_stores_and_admin(app)
+    alice_uid = _add_member_user(app, username="alice", password="alicepass1")
+    bob_uid = _add_member_user(app, username="bob", password="bobspass1")
+    alice_token = app.state.auth.create_session(user_id=alice_uid, long_lived=True)
+    bob_token = app.state.auth.create_session(user_id=bob_uid, long_lived=True)
+    app.state._startup_complete = True
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport, base_url="http://test",
+        cookies={"taos_session": alice_token},
+    ) as alice_c:
+        async with AsyncClient(
+            transport=transport, base_url="http://test",
+            cookies={"taos_session": bob_token},
+        ) as bob_c:
+            alice_c._test_uid = alice_uid
+            alice_c._test_app = app
+            bob_c._test_uid = bob_uid
+            bob_c._test_app = app
+            yield alice_c, bob_c
+
+    await app.state.project_store.close()
+    await app.state.project_task_store.close()
+
+
+# ---------------------------------------------------------------------------
+# Route ownership tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_create_binds_caller_user_id(member_client):
+    """Creating a project via the route binds the authenticated user's id."""
+    resp = await member_client.post(
+        "/api/projects",
+        json={"name": "My Project", "slug": "my-project"},
+    )
+    assert resp.status_code == 200
+    p = resp.json()
+    assert p["user_id"] == member_client._test_uid
+
+
+@pytest.mark.asyncio
+async def test_member_list_sees_only_own_projects(two_member_clients):
+    """A member only sees their own projects in the list."""
+    alice, bob = two_member_clients
+    await alice.post("/api/projects", json={"name": "Alice Project", "slug": "alice-proj"})
+    await bob.post("/api/projects", json={"name": "Bob Project", "slug": "bob-proj"})
+
+    alice_resp = await alice.get("/api/projects")
+    bob_resp = await bob.get("/api/projects")
+
+    assert alice_resp.status_code == 200
+    assert bob_resp.status_code == 200
+    alice_slugs = {p["slug"] for p in alice_resp.json()["items"]}
+    bob_slugs = {p["slug"] for p in bob_resp.json()["items"]}
+    assert "alice-proj" in alice_slugs
+    assert "bob-proj" not in alice_slugs
+    assert "bob-proj" in bob_slugs
+    assert "alice-proj" not in bob_slugs
+
+
+@pytest.mark.asyncio
+async def test_non_owner_get_project_returns_404(two_member_clients):
+    """A non-owner getting a single project gets existence-hiding 404."""
+    alice, bob = two_member_clients
+    resp = await alice.post("/api/projects", json={"name": "A", "slug": "a-secret"})
+    pid = resp.json()["id"]
+
+    # Bob cannot see Alice's project
+    resp = await bob.get(f"/api/projects/{pid}")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_owner_can_get_own_project(member_client):
+    """The owner can retrieve their own project."""
+    resp = await member_client.post(
+        "/api/projects", json={"name": "Mine", "slug": "mine"}
+    )
+    pid = resp.json()["id"]
+    resp = await member_client.get(f"/api/projects/{pid}")
+    assert resp.status_code == 200
+    assert resp.json()["id"] == pid
+
+
+@pytest.mark.asyncio
+async def test_non_owner_update_returns_403(two_member_clients):
+    """A non-owner patching another user's project gets 403."""
+    alice, bob = two_member_clients
+    resp = await alice.post("/api/projects", json={"name": "A", "slug": "a-upd"})
+    pid = resp.json()["id"]
+
+    resp = await bob.patch(f"/api/projects/{pid}", json={"name": "Hijacked"})
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_non_owner_delete_returns_403(two_member_clients):
+    """A non-owner deleting another user's project gets 403."""
+    alice, bob = two_member_clients
+    resp = await alice.post("/api/projects", json={"name": "A", "slug": "a-del"})
+    pid = resp.json()["id"]
+
+    resp = await bob.delete(f"/api/projects/{pid}")
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_non_owner_archive_returns_403(two_member_clients):
+    """A non-owner archiving another user's project gets 403."""
+    alice, bob = two_member_clients
+    resp = await alice.post("/api/projects", json={"name": "A", "slug": "a-arch"})
+    pid = resp.json()["id"]
+
+    resp = await bob.post(f"/api/projects/{pid}/archive")
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_admin_sees_all_projects(two_member_clients):
+    """Admin list returns all projects including other users'."""
+    alice, bob = two_member_clients
+    await alice.post("/api/projects", json={"name": "A", "slug": "adm-a"})
+    await bob.post("/api/projects", json={"name": "B", "slug": "adm-b"})
+
+    # Create an admin client on the same app (admin was set up in two_member_clients)
+    app = alice._test_app
+    admin_record = app.state.auth.find_user("admin")
+    admin_uid = admin_record["id"]
+    admin_token = app.state.auth.create_session(user_id=admin_uid, long_lived=True)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport, base_url="http://test",
+        cookies={"taos_session": admin_token},
+    ) as admin_c:
+        # default status=active; alice and bob's projects are active
+        resp = await admin_c.get("/api/projects")
+        assert resp.status_code == 200
+        slugs = {p["slug"] for p in resp.json()["items"]}
+        assert "adm-a" in slugs
+        assert "adm-b" in slugs
+
+
+@pytest.mark.asyncio
+async def test_admin_can_get_any_project(two_member_clients):
+    """Admin can fetch any user's project by id."""
+    alice, _bob = two_member_clients
+    resp = await alice.post("/api/projects", json={"name": "Alice Private", "slug": "adm-get"})
+    pid = resp.json()["id"]
+
+    app = alice._test_app
+    admin_record = app.state.auth.find_user("admin")
+    admin_uid = admin_record["id"]
+    admin_token = app.state.auth.create_session(user_id=admin_uid, long_lived=True)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport, base_url="http://test",
+        cookies={"taos_session": admin_token},
+    ) as admin_c:
+        resp = await admin_c.get(f"/api/projects/{pid}")
+        assert resp.status_code == 200
+        assert resp.json()["id"] == pid
+
+
+@pytest.mark.asyncio
+async def test_admin_can_update_any_project(two_member_clients):
+    """Admin can update another user's project."""
+    alice, _bob = two_member_clients
+    resp = await alice.post("/api/projects", json={"name": "A", "slug": "adm-upd"})
+    pid = resp.json()["id"]
+
+    app = alice._test_app
+    admin_record = app.state.auth.find_user("admin")
+    admin_uid = admin_record["id"]
+    admin_token = app.state.auth.create_session(user_id=admin_uid, long_lived=True)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport, base_url="http://test",
+        cookies={"taos_session": admin_token},
+    ) as admin_c:
+        resp = await admin_c.patch(f"/api/projects/{pid}", json={"name": "Admin Updated"})
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "Admin Updated"
+
+
+@pytest.mark.asyncio
+async def test_non_owner_cannot_create_task_in_others_project(two_member_clients):
+    """A non-owner cannot create tasks in another user's project (404)."""
+    alice, bob = two_member_clients
+    resp = await alice.post("/api/projects", json={"name": "A", "slug": "tsk-a"})
+    pid = resp.json()["id"]
+
+    resp = await bob.post(f"/api/projects/{pid}/tasks", json={"title": "Hack"})
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_non_owner_cannot_list_tasks_in_others_project(two_member_clients):
+    """A non-owner cannot list tasks in another user's project (404)."""
+    alice, bob = two_member_clients
+    resp = await alice.post("/api/projects", json={"name": "A", "slug": "ltsk-a"})
+    pid = resp.json()["id"]
+    await alice.post(f"/api/projects/{pid}/tasks", json={"title": "Secret"})
+
+    resp = await bob.get(f"/api/projects/{pid}/tasks")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_non_owner_cannot_get_task_in_others_project(two_member_clients):
+    """A non-owner cannot get a specific task in another user's project (404)."""
+    alice, bob = two_member_clients
+    resp = await alice.post("/api/projects", json={"name": "A", "slug": "gtsk-a"})
+    pid = resp.json()["id"]
+    task = (await alice.post(f"/api/projects/{pid}/tasks", json={"title": "T"})).json()
+
+    resp = await bob.get(f"/api/projects/{pid}/tasks/{task['id']}")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_non_owner_cannot_update_task_in_others_project(two_member_clients):
+    """A non-owner cannot update tasks in another user's project (404)."""
+    alice, bob = two_member_clients
+    resp = await alice.post("/api/projects", json={"name": "A", "slug": "utsk-a"})
+    pid = resp.json()["id"]
+    task = (await alice.post(f"/api/projects/{pid}/tasks", json={"title": "T"})).json()
+
+    resp = await bob.patch(f"/api/projects/{pid}/tasks/{task['id']}", json={"title": "Stolen"})
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_owner_can_create_and_list_tasks(member_client):
+    """Project owner can fully create and list tasks."""
+    resp = await member_client.post("/api/projects", json={"name": "My P", "slug": "my-p"})
+    pid = resp.json()["id"]
+
+    t = (await member_client.post(
+        f"/api/projects/{pid}/tasks", json={"title": "Task 1"}
+    )).json()
+    assert t["id"].startswith("tsk-")
+
+    resp = await member_client.get(f"/api/projects/{pid}/tasks")
+    assert resp.status_code == 200
+    assert any(item["id"] == t["id"] for item in resp.json()["items"])
+
+
+@pytest.mark.asyncio
+async def test_legacy_row_hidden_from_members(app, tmp_data_dir):
+    """Projects with user_id='' are not visible to any member — only to admin."""
+    # Initialise stores
+    for attr in ("metrics", "notifications", "project_store", "project_task_store"):
+        store = getattr(app.state, attr, None)
+        if store is not None and store._db is None:
+            await store.init()
+    if app.state.project_store._db is None:
+        await app.state.project_store.init()
+    if app.state.project_task_store._db is None:
+        await app.state.project_task_store.init()
+    app.state.projects_root.mkdir(parents=True, exist_ok=True)
+
+    # Insert legacy row directly into the store (user_id='')
+    pstore = app.state.project_store
+    legacy = await pstore.create_project(name="Legacy", slug="legacy", created_by="old-system")
+    assert legacy["user_id"] == ""
+
+    # Set up admin + member
+    app.state.auth.setup_user("admin", "Test Admin", "", "testpass")
+    member_uid = _add_member_user(app, username="member2", password="memberpass1")
+    admin_record = app.state.auth.find_user("admin")
+    admin_uid = admin_record["id"]
+
+    admin_token = app.state.auth.create_session(user_id=admin_uid, long_lived=True)
+    member_token = app.state.auth.create_session(user_id=member_uid, long_lived=True)
+    app.state._startup_complete = True
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport, base_url="http://test",
+        cookies={"taos_session": member_token},
+    ) as member_c:
+        # Member cannot see legacy row in list (legacy rows have status='active')
+        resp = await member_c.get("/api/projects")
+        slugs = {p["slug"] for p in resp.json()["items"]}
+        assert "legacy" not in slugs
+
+        # Member cannot get legacy row by id (existence-hiding 404)
+        resp = await member_c.get(f"/api/projects/{legacy['id']}")
+        assert resp.status_code == 404
+
+    async with AsyncClient(
+        transport=transport, base_url="http://test",
+        cookies={"taos_session": admin_token},
+    ) as admin_c:
+        # Admin CAN see legacy row in list (legacy rows have status='active')
+        resp = await admin_c.get("/api/projects")
+        slugs = {p["slug"] for p in resp.json()["items"]}
+        assert "legacy" in slugs
+
+        # Admin CAN get legacy row by id
+        resp = await admin_c.get(f"/api/projects/{legacy['id']}")
+        assert resp.status_code == 200
+
+    await pstore.close()
+    await app.state.project_task_store.close()

--- a/tinyagentos/projects/project_store.py
+++ b/tinyagentos/projects/project_store.py
@@ -15,6 +15,7 @@ CREATE TABLE IF NOT EXISTS projects (
     description TEXT NOT NULL DEFAULT '',
     status TEXT NOT NULL DEFAULT 'active',
     created_by TEXT NOT NULL,
+    user_id TEXT NOT NULL DEFAULT '',
     created_at REAL NOT NULL,
     updated_at REAL NOT NULL,
     archived_at REAL,
@@ -67,6 +68,7 @@ class ProjectStore(BaseStore):
         for col_def in (
             "ALTER TABLE project_members ADD COLUMN can_edit_canvas INTEGER NOT NULL DEFAULT 0",
             "ALTER TABLE project_members ADD COLUMN is_lead INTEGER NOT NULL DEFAULT 0",
+            "ALTER TABLE projects ADD COLUMN user_id TEXT NOT NULL DEFAULT ''",
         ):
             try:
                 await self._db.execute(col_def)
@@ -92,15 +94,16 @@ class ProjectStore(BaseStore):
         created_by: str,
         description: str = "",
         settings: dict | None = None,
+        user_id: str = "",
     ) -> dict:
         pid = new_id("prj")
         now = time.time()
         try:
             await self._db.execute(
                 """INSERT INTO projects
-                   (id, name, slug, description, status, created_by, created_at, updated_at, settings)
-                   VALUES (?, ?, ?, ?, 'active', ?, ?, ?, ?)""",
-                (pid, name, slug, description, created_by, now, now, json.dumps(settings or {})),
+                   (id, name, slug, description, status, created_by, user_id, created_at, updated_at, settings)
+                   VALUES (?, ?, ?, ?, 'active', ?, ?, ?, ?, ?)""",
+                (pid, name, slug, description, created_by, user_id, now, now, json.dumps(settings or {})),
             )
             await self._db.commit()
         except sqlite3.IntegrityError as exc:
@@ -129,12 +132,33 @@ class ProjectStore(BaseStore):
             return _row_to_project(row, cur.description)
 
     async def list_projects(self, status: str | None = "active") -> list[dict]:
+        """List all projects (admin view). No user_id filter."""
         if status is None:
             sql = "SELECT * FROM projects ORDER BY created_at DESC"
             params: tuple = ()
         else:
             sql = "SELECT * FROM projects WHERE status = ? ORDER BY created_at DESC"
             params = (status,)
+        async with self._db.execute(sql, params) as cur:
+            rows = await cur.fetchall()
+            desc = cur.description
+        return [_row_to_project(r, desc) for r in rows]
+
+    async def list_for_user(self, user_id: str, status: str | None = "active") -> list[dict]:
+        """List projects owned by a specific user (member view).
+
+        Returns an empty list for an empty user_id — legacy rows (user_id='')
+        are never owned by any real user and must only be visible to admins
+        via list_projects().
+        """
+        if not user_id:
+            return []
+        if status is None:
+            sql = "SELECT * FROM projects WHERE user_id = ? ORDER BY created_at DESC"
+            params: tuple = (user_id,)
+        else:
+            sql = "SELECT * FROM projects WHERE user_id = ? AND status = ? ORDER BY created_at DESC"
+            params = (user_id, status)
         async with self._db.execute(sql, params) as cur:
             rows = await cur.fetchall()
             desc = cur.description

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -7,10 +7,11 @@ import time as _time
 import asyncio as _asyncio
 import json as _json
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, Field, field_validator
 
+from tinyagentos.auth_context import CurrentUser, current_user, require_owner_or_admin
 from tinyagentos.projects.folders import ensure_project_layout, write_project_yaml
 
 logger = logging.getLogger(__name__)
@@ -37,13 +38,6 @@ class UpdateProjectIn(BaseModel):
     name: str | None = None
     description: str | None = None
     settings: dict | None = None
-
-
-def _user_id(request: Request) -> str:
-    user = getattr(request.state, "user", None)
-    if user and isinstance(user, dict) and "id" in user:
-        return user["id"]
-    return "system"
 
 
 def _mirror(request: Request, project: dict) -> None:
@@ -74,7 +68,11 @@ def _beads_mark_dirty(request: Request, project_id: str) -> None:
 
 
 @router.post("/api/projects")
-async def create_project(payload: CreateProjectIn, request: Request):
+async def create_project(
+    payload: CreateProjectIn,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
     store = request.app.state.project_store
     try:
         p = await store.create_project(
@@ -82,11 +80,12 @@ async def create_project(payload: CreateProjectIn, request: Request):
             slug=payload.slug,
             description=payload.description,
             settings=payload.settings,
-            created_by=_user_id(request),
+            created_by=user.user_id,
+            user_id=user.user_id,
         )
     except ValueError as e:
         return JSONResponse({"error": str(e)}, status_code=409)
-    await store.log_activity(p["id"], _user_id(request), "project.created", {"slug": p["slug"]})
+    await store.log_activity(p["id"], user.user_id, "project.created", {"slug": p["slug"]})
     _mirror(request, p)
     try:
         from tinyagentos.projects.a2a import ensure_a2a_channel
@@ -102,24 +101,46 @@ async def create_project(payload: CreateProjectIn, request: Request):
 
 
 @router.get("/api/projects")
-async def list_projects(request: Request, status: str | None = "active"):
+async def list_projects(
+    request: Request,
+    status: str | None = "active",
+    user: CurrentUser = Depends(current_user),
+):
     store = request.app.state.project_store
-    items = await store.list_projects(status=status)
+    if user.is_admin:
+        items = await store.list_projects(status=status)
+    else:
+        items = await store.list_for_user(user.user_id, status=status)
     return {"items": items}
 
 
 @router.get("/api/projects/{project_id}")
-async def get_project(project_id: str, request: Request):
+async def get_project(
+    project_id: str,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
     store = request.app.state.project_store
     p = await store.get_project(project_id)
     if p is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    if not user.is_admin and user.user_id != p["user_id"]:
         return JSONResponse({"error": "not found"}, status_code=404)
     return p
 
 
 @router.patch("/api/projects/{project_id}")
-async def update_project(project_id: str, payload: UpdateProjectIn, request: Request):
+async def update_project(
+    project_id: str,
+    payload: UpdateProjectIn,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
     store = request.app.state.project_store
+    p = await store.get_project(project_id)
+    if p is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    require_owner_or_admin(user, p["user_id"])
     await store.update_project(
         project_id,
         name=payload.name,
@@ -127,33 +148,42 @@ async def update_project(project_id: str, payload: UpdateProjectIn, request: Req
         settings=payload.settings,
     )
     p = await store.get_project(project_id)
-    if p is None:
-        return JSONResponse({"error": "not found"}, status_code=404)
-    await store.log_activity(project_id, _user_id(request), "project.updated", payload.model_dump(exclude_none=True))
+    await store.log_activity(project_id, user.user_id, "project.updated", payload.model_dump(exclude_none=True))
     _mirror(request, p)
     return p
 
 
 @router.post("/api/projects/{project_id}/archive")
-async def archive_project(project_id: str, request: Request):
+async def archive_project(
+    project_id: str,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
     store = request.app.state.project_store
-    if await store.get_project(project_id) is None:
+    p = await store.get_project(project_id)
+    if p is None:
         return JSONResponse({"error": "not found"}, status_code=404)
+    require_owner_or_admin(user, p["user_id"])
     await store.set_status(project_id, "archived")
     p = await store.get_project(project_id)
-    await store.log_activity(project_id, _user_id(request), "project.archived", {})
+    await store.log_activity(project_id, user.user_id, "project.archived", {})
     return p
 
 
 @router.delete("/api/projects/{project_id}")
-async def delete_project(project_id: str, request: Request):
+async def delete_project(
+    project_id: str,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
     store = request.app.state.project_store
     project = await store.get_project(project_id)
     if project is None:
         return JSONResponse({"error": "not found"}, status_code=404)
+    require_owner_or_admin(user, project["user_id"])
 
     await store.set_status(project_id, "deleted")
-    await store.log_activity(project_id, _user_id(request), "project.deleted", {})
+    await store.log_activity(project_id, user.user_id, "project.deleted", {})
 
     # Archive scoped chat channels
     channels = request.app.state.chat_channels
@@ -186,11 +216,17 @@ class AddMemberIn(BaseModel):
 
 
 @router.post("/api/projects/{project_id}/members")
-async def add_member(project_id: str, payload: AddMemberIn, request: Request):
+async def add_member(
+    project_id: str,
+    payload: AddMemberIn,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
     store = request.app.state.project_store
     project = await store.get_project(project_id)
     if project is None:
         return JSONResponse({"error": "project not found"}, status_code=404)
+    require_owner_or_admin(user, project["user_id"])
 
     if payload.mode == "native":
         if not payload.agent_id:
@@ -218,7 +254,7 @@ async def add_member(project_id: str, payload: AddMemberIn, request: Request):
         memory_seed=memory_seed,
     )
     await store.log_activity(
-        project_id, _user_id(request), "member.added",
+        project_id, user.user_id, "member.added",
         {"member_id": member_id, "kind": member_kind, "memory_seed": memory_seed},
     )
     members = await store.list_members(project_id)
@@ -237,8 +273,17 @@ async def add_member(project_id: str, payload: AddMemberIn, request: Request):
 
 
 @router.get("/api/projects/{project_id}/members")
-async def list_members(project_id: str, request: Request):
+async def list_members(
+    project_id: str,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
     store = request.app.state.project_store
+    p = await store.get_project(project_id)
+    if p is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    if not user.is_admin and user.user_id != p["user_id"]:
+        return JSONResponse({"error": "not found"}, status_code=404)
     return {"items": await store.list_members(project_id)}
 
 
@@ -247,8 +292,18 @@ class LeadIn(BaseModel):
 
 
 @router.patch("/api/projects/{project_id}/members/{member_id}/lead")
-async def set_lead(project_id: str, member_id: str, body: LeadIn, request: Request):
+async def set_lead(
+    project_id: str,
+    member_id: str,
+    body: LeadIn,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
     store = request.app.state.project_store
+    p = await store.get_project(project_id)
+    if p is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    require_owner_or_admin(user, p["user_id"])
     try:
         await store.set_member_lead(project_id, member_id, body.is_lead)
     except KeyError as e:
@@ -267,14 +322,21 @@ async def set_lead(project_id: str, member_id: str, body: LeadIn, request: Reque
 
 
 @router.delete("/api/projects/{project_id}/members/{member_id}")
-async def remove_member(project_id: str, member_id: str, request: Request):
+async def remove_member(
+    project_id: str,
+    member_id: str,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
     store = request.app.state.project_store
-    await store.remove_member(project_id, member_id)
-    await store.log_activity(project_id, _user_id(request), "member.removed", {"member_id": member_id})
     project = await store.get_project(project_id)
+    if project is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    require_owner_or_admin(user, project["user_id"])
+    await store.remove_member(project_id, member_id)
+    await store.log_activity(project_id, user.user_id, "member.removed", {"member_id": member_id})
     members = await store.list_members(project_id)
-    if project is not None:
-        _mirror(request, {**project, "members": members})
+    _mirror(request, {**project, "members": members})
     try:
         from tinyagentos.projects.a2a import ensure_a2a_channel
         await ensure_a2a_channel(
@@ -329,15 +391,46 @@ class AddRelIn(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Task route helpers
+# ---------------------------------------------------------------------------
+
+async def _get_owned_project(
+    pstore, project_id: str, user: CurrentUser
+) -> "dict | JSONResponse":
+    """Fetch a project and apply existence-hiding 404 for non-owners."""
+    p = await pstore.get_project(project_id)
+    if p is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    if not user.is_admin and user.user_id != p["user_id"]:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    return p
+
+
+async def _require_task_in_project(
+    store, project_id: str, task_id: str
+) -> "dict | JSONResponse":
+    task = await store.get_task(task_id)
+    if task is None or task["project_id"] != project_id:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    return task
+
+
+# ---------------------------------------------------------------------------
 # Task routes — order matters: /tasks/ready before /tasks/{task_id}
 # ---------------------------------------------------------------------------
 
 @router.post("/api/projects/{project_id}/tasks")
-async def create_task(project_id: str, payload: CreateTaskIn, request: Request):
+async def create_task(
+    project_id: str,
+    payload: CreateTaskIn,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
     store = request.app.state.project_task_store
     pstore = request.app.state.project_store
-    if await pstore.get_project(project_id) is None:
-        return JSONResponse({"error": "not found"}, status_code=404)
+    project_or_err = await _get_owned_project(pstore, project_id, user)
+    if isinstance(project_or_err, JSONResponse):
+        return project_or_err
     if payload.parent_task_id is not None:
         parent = await store.get_task(payload.parent_task_id)
         if parent is None or parent["project_id"] != project_id:
@@ -350,27 +443,53 @@ async def create_task(project_id: str, payload: CreateTaskIn, request: Request):
         labels=payload.labels,
         assignee_id=payload.assignee_id,
         parent_task_id=payload.parent_task_id,
-        created_by=_user_id(request),
+        created_by=user.user_id,
     )
     _beads_mark_dirty(request, project_id)
-    await pstore.log_activity(project_id, _user_id(request), "task.created", {"task_id": t["id"], "title": t["title"]})
+    await pstore.log_activity(project_id, user.user_id, "task.created", {"task_id": t["id"], "title": t["title"]})
     return t
 
 
 @router.get("/api/projects/{project_id}/tasks")
-async def list_tasks(project_id: str, request: Request, status: str | None = None):
+async def list_tasks(
+    project_id: str,
+    request: Request,
+    status: str | None = None,
+    user: CurrentUser = Depends(current_user),
+):
+    pstore = request.app.state.project_store
+    project_or_err = await _get_owned_project(pstore, project_id, user)
+    if isinstance(project_or_err, JSONResponse):
+        return project_or_err
     store = request.app.state.project_task_store
     return {"items": await store.list_tasks(project_id=project_id, status=status)}
 
 
 @router.get("/api/projects/{project_id}/tasks/ready")
-async def ready_tasks(project_id: str, request: Request):
+async def ready_tasks(
+    project_id: str,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    pstore = request.app.state.project_store
+    project_or_err = await _get_owned_project(pstore, project_id, user)
+    if isinstance(project_or_err, JSONResponse):
+        return project_or_err
     store = request.app.state.project_task_store
     return {"items": await store.list_ready_tasks(project_id=project_id)}
 
 
 @router.get("/api/projects/{project_id}/tasks/{task_id}")
-async def get_task(project_id: str, task_id: str, request: Request):
+async def get_task(
+    project_id: str,
+    task_id: str,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    pstore = request.app.state.project_store
+    project_or_err = await _get_owned_project(pstore, project_id, user)
+    if isinstance(project_or_err, JSONResponse):
+        return project_or_err
     store = request.app.state.project_task_store
     t = await store.get_task(task_id)
     if t is None or t["project_id"] != project_id:
@@ -379,7 +498,17 @@ async def get_task(project_id: str, task_id: str, request: Request):
 
 
 @router.patch("/api/projects/{project_id}/tasks/{task_id}")
-async def update_task(project_id: str, task_id: str, payload: UpdateTaskIn, request: Request):
+async def update_task(
+    project_id: str,
+    task_id: str,
+    payload: UpdateTaskIn,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    pstore = request.app.state.project_store
+    project_or_err = await _get_owned_project(pstore, project_id, user)
+    if isinstance(project_or_err, JSONResponse):
+        return project_or_err
     store = request.app.state.project_task_store
     existing = await store.get_task(task_id)
     if existing is None or existing["project_id"] != project_id:
@@ -406,7 +535,17 @@ async def update_task(project_id: str, task_id: str, payload: UpdateTaskIn, requ
 
 
 @router.post("/api/projects/{project_id}/tasks/{task_id}/claim")
-async def claim_task(project_id: str, task_id: str, payload: ClaimIn, request: Request):
+async def claim_task(
+    project_id: str,
+    task_id: str,
+    payload: ClaimIn,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    pstore = request.app.state.project_store
+    project_or_err = await _get_owned_project(pstore, project_id, user)
+    if isinstance(project_or_err, JSONResponse):
+        return project_or_err
     store = request.app.state.project_task_store
     existing = await store.get_task(task_id)
     if existing is None or existing["project_id"] != project_id:
@@ -415,13 +554,22 @@ async def claim_task(project_id: str, task_id: str, payload: ClaimIn, request: R
     if not ok:
         return JSONResponse({"error": "already claimed"}, status_code=409)
     _beads_mark_dirty(request, project_id)
-    pstore = request.app.state.project_store
     await pstore.log_activity(project_id, payload.claimer_id, "task.claimed", {"task_id": task_id})
     return await store.get_task(task_id)
 
 
 @router.post("/api/projects/{project_id}/tasks/{task_id}/release")
-async def release_task(project_id: str, task_id: str, payload: ReleaseIn, request: Request):
+async def release_task(
+    project_id: str,
+    task_id: str,
+    payload: ReleaseIn,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    pstore = request.app.state.project_store
+    project_or_err = await _get_owned_project(pstore, project_id, user)
+    if isinstance(project_or_err, JSONResponse):
+        return project_or_err
     store = request.app.state.project_task_store
     existing = await store.get_task(task_id)
     if existing is None or existing["project_id"] != project_id:
@@ -434,7 +582,17 @@ async def release_task(project_id: str, task_id: str, payload: ReleaseIn, reques
 
 
 @router.post("/api/projects/{project_id}/tasks/{task_id}/close")
-async def close_task(project_id: str, task_id: str, payload: CloseIn, request: Request):
+async def close_task(
+    project_id: str,
+    task_id: str,
+    payload: CloseIn,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    pstore = request.app.state.project_store
+    project_or_err = await _get_owned_project(pstore, project_id, user)
+    if isinstance(project_or_err, JSONResponse):
+        return project_or_err
     store = request.app.state.project_task_store
     existing = await store.get_task(task_id)
     if existing is None or existing["project_id"] != project_id:
@@ -443,12 +601,11 @@ async def close_task(project_id: str, task_id: str, payload: CloseIn, request: R
     if not ok:
         return JSONResponse({"error": "cannot close"}, status_code=409)
     _beads_mark_dirty(request, project_id)
-    pstore = request.app.state.project_store
     await pstore.log_activity(project_id, payload.closed_by, "task.closed", {"task_id": task_id})
-    project = await pstore.get_project(project_id)
+    project = project_or_err
     task = await store.get_task(task_id)
     qmd = getattr(request.app.state, "qmd_client", None)
-    if qmd is not None and project is not None and task is not None:
+    if qmd is not None and task is not None:
         try:
             from tinyagentos.projects.lifecycle import index_closed_task
             await index_closed_task(qmd, project, task)
@@ -459,17 +616,18 @@ async def close_task(project_id: str, task_id: str, payload: CloseIn, request: R
     return task
 
 
-async def _require_task_in_project(
-    store, project_id: str, task_id: str
-) -> dict | JSONResponse:
-    task = await store.get_task(task_id)
-    if task is None or task["project_id"] != project_id:
-        return JSONResponse({"error": "not found"}, status_code=404)
-    return task
-
-
 @router.post("/api/projects/{project_id}/tasks/{task_id}/relationships")
-async def add_relationship(project_id: str, task_id: str, payload: AddRelIn, request: Request):
+async def add_relationship(
+    project_id: str,
+    task_id: str,
+    payload: AddRelIn,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    pstore = request.app.state.project_store
+    project_or_err = await _get_owned_project(pstore, project_id, user)
+    if isinstance(project_or_err, JSONResponse):
+        return project_or_err
     store = request.app.state.project_task_store
     guard = await _require_task_in_project(store, project_id, task_id)
     if isinstance(guard, JSONResponse):
@@ -480,7 +638,7 @@ async def add_relationship(project_id: str, task_id: str, payload: AddRelIn, req
             from_task_id=task_id,
             to_task_id=payload.to_task_id,
             kind=payload.kind,
-            created_by=_user_id(request),
+            created_by=user.user_id,
         )
     except ValueError as e:
         return JSONResponse({"error": str(e)}, status_code=400)
@@ -495,7 +653,17 @@ class AddCommentIn(BaseModel):
 
 
 @router.post("/api/projects/{project_id}/tasks/{task_id}/comments")
-async def add_comment(project_id: str, task_id: str, payload: AddCommentIn, request: Request):
+async def add_comment(
+    project_id: str,
+    task_id: str,
+    payload: AddCommentIn,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    pstore = request.app.state.project_store
+    project_or_err = await _get_owned_project(pstore, project_id, user)
+    if isinstance(project_or_err, JSONResponse):
+        return project_or_err
     store = request.app.state.project_task_store
     guard = await _require_task_in_project(store, project_id, task_id)
     if isinstance(guard, JSONResponse):
@@ -512,7 +680,16 @@ async def add_comment(project_id: str, task_id: str, payload: AddCommentIn, requ
 
 
 @router.get("/api/projects/{project_id}/tasks/{task_id}/comments")
-async def list_comments(project_id: str, task_id: str, request: Request):
+async def list_comments(
+    project_id: str,
+    task_id: str,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    pstore = request.app.state.project_store
+    project_or_err = await _get_owned_project(pstore, project_id, user)
+    if isinstance(project_or_err, JSONResponse):
+        return project_or_err
     store = request.app.state.project_task_store
     guard = await _require_task_in_project(store, project_id, task_id)
     if isinstance(guard, JSONResponse):
@@ -521,7 +698,17 @@ async def list_comments(project_id: str, task_id: str, request: Request):
 
 
 @router.get("/api/projects/{project_id}/tasks/{task_id}/relationships")
-async def list_relationships(project_id: str, task_id: str, request: Request, direction: str = "from"):
+async def list_relationships(
+    project_id: str,
+    task_id: str,
+    request: Request,
+    direction: str = "from",
+    user: CurrentUser = Depends(current_user),
+):
+    pstore = request.app.state.project_store
+    project_or_err = await _get_owned_project(pstore, project_id, user)
+    if isinstance(project_or_err, JSONResponse):
+        return project_or_err
     store = request.app.state.project_task_store
     guard = await _require_task_in_project(store, project_id, task_id)
     if isinstance(guard, JSONResponse):
@@ -530,17 +717,34 @@ async def list_relationships(project_id: str, task_id: str, request: Request, di
 
 
 @router.get("/api/projects/{project_id}/activity")
-async def activity_feed(project_id: str, request: Request, limit: int = 100):
+async def activity_feed(
+    project_id: str,
+    request: Request,
+    limit: int = 100,
+    user: CurrentUser = Depends(current_user),
+):
     store = request.app.state.project_store
+    p = await store.get_project(project_id)
+    if p is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    if not user.is_admin and user.user_id != p["user_id"]:
+        return JSONResponse({"error": "not found"}, status_code=404)
     return {"items": await store.list_activity(project_id, limit=limit)}
 
 
 @router.get("/api/projects/{project_id}/memory/search")
-async def memory_search(project_id: str, request: Request, q: str, limit: int = 10):
+async def memory_search(
+    project_id: str,
+    request: Request,
+    q: str,
+    limit: int = 10,
+    user: CurrentUser = Depends(current_user),
+):
     store = request.app.state.project_store
-    project = await store.get_project(project_id)
-    if project is None:
-        return JSONResponse({"error": "not found"}, status_code=404)
+    project_or_err = await _get_owned_project(store, project_id, user)
+    if isinstance(project_or_err, JSONResponse):
+        return project_or_err
+    project = project_or_err
     qmd = getattr(request.app.state, "qmd_client", None)
     if qmd is None:
         return {"items": []}
@@ -554,7 +758,15 @@ async def memory_search(project_id: str, request: Request, q: str, limit: int = 
 
 
 @router.get("/api/projects/{project_id}/events")
-async def project_events(project_id: str, request: Request):
+async def project_events(
+    project_id: str,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    pstore = request.app.state.project_store
+    project_or_err = await _get_owned_project(pstore, project_id, user)
+    if isinstance(project_or_err, JSONResponse):
+        return project_or_err
     broker = request.app.state.project_event_broker
     queue = await broker.subscribe(project_id)
 
@@ -580,15 +792,20 @@ async def project_events(project_id: str, request: Request):
 
 
 @router.post("/api/projects/{project_id}/beads/export")
-async def beads_export(project_id: str, request: Request):
+async def beads_export(
+    project_id: str,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
     """Force a synchronous render of the project's .beads/tasks.jsonl
     snapshot. Returns 503 when the bridge isn't running."""
     bridge = getattr(request.app.state, "beads_bridge", None)
     if bridge is None:
         return JSONResponse({"error": "beads bridge not running"}, status_code=503)
     pstore = request.app.state.project_store
-    if await pstore.get_project(project_id) is None:
-        return JSONResponse({"error": "not found"}, status_code=404)
+    project_or_err = await _get_owned_project(pstore, project_id, user)
+    if isinstance(project_or_err, JSONResponse):
+        return project_or_err
     path = await bridge.export_now(project_id)
     if path is None:
         return JSONResponse({"error": "export failed"}, status_code=500)


### PR DESCRIPTION
Per-user store-scoping rollout (task #18), using #710's auth_context. Projects is agent-facing (A2A/tasks), so it uses `current_user` (session + local-token).

- `project_store.py` — `user_id` column (idempotent migration; legacy `''` rows admin-only), `list_for_user`, `create_project(user_id=)`.
- `routes/projects.py` — all project + task routes `Depends(current_user)`; tasks scoped THROUGH parent project ownership via `_get_owned_project` (existence-hiding 404); owner-or-admin on mutate; admin sees all.
- 26 ownership tests; 283 pass.

Security-sensitive — auditing before merge.