### PR TITLE
feat(security): registry governance — lifecycle core (status, transitions, /inactive, audit)

### DIFF
--- a/tests/test_registry_governance_lifecycle.py
+++ b/tests/test_registry_governance_lifecycle.py
@@ -1,0 +1,626 @@
+"""Tests for the agent-registry governance lifecycle layer (PR 1).
+
+Covers:
+  - Store: set_status() valid transitions
+  - Store: set_status() invalid transitions raise ValueError
+  - Store: revoke() sets status=revoked + revoked_at
+  - Store: external-selfjoin born pending; taos-deployed born active
+  - Store: migration backfills revoked_at rows to status=revoked
+  - Store: list_inactive() + list_all(status=...)
+  - Routes: approve / reject / suspend / reactivate — happy paths
+  - Routes: 404 on unknown canonical_id
+  - Routes: 409 on invalid transition
+  - Routes: /inactive shape + admin-only (member 403)
+  - Routes: route-ordering (/inactive not matched as /{canonical_id})
+  - Routes: ?status= filter
+  - Routes: non-admin forbidden on lifecycle transitions
+  - Audit: governance event recorded on transition
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from tinyagentos.agent_registry_store import AgentRegistryStore
+
+
+# ---------------------------------------------------------------------------
+# Store-level tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestSetStatus:
+    async def _make_store(self, db_path):
+        store = AgentRegistryStore(db_path)
+        await store.init()
+        return store
+
+    # -- Valid transitions ---------------------------------------------------
+
+    async def test_pending_to_active(self, tmp_path):
+        store = await self._make_store(tmp_path / "reg.db")
+        try:
+            rec = await store.register(framework="f", origin="external-selfjoin")
+            assert rec["status"] == "pending"
+            updated = await store.set_status(rec["canonical_id"], "active", actor="admin-1")
+            assert updated["status"] == "active"
+        finally:
+            await store.close()
+
+    async def test_pending_to_rejected(self, tmp_path):
+        store = await self._make_store(tmp_path / "reg.db")
+        try:
+            rec = await store.register(framework="f", origin="external-selfjoin")
+            updated = await store.set_status(rec["canonical_id"], "rejected")
+            assert updated["status"] == "rejected"
+        finally:
+            await store.close()
+
+    async def test_active_to_suspended(self, tmp_path):
+        store = await self._make_store(tmp_path / "reg.db")
+        try:
+            rec = await store.register(framework="f")
+            assert rec["status"] == "active"
+            updated = await store.set_status(rec["canonical_id"], "suspended")
+            assert updated["status"] == "suspended"
+        finally:
+            await store.close()
+
+    async def test_suspended_to_active(self, tmp_path):
+        store = await self._make_store(tmp_path / "reg.db")
+        try:
+            rec = await store.register(framework="f")
+            await store.set_status(rec["canonical_id"], "suspended")
+            updated = await store.set_status(rec["canonical_id"], "active")
+            assert updated["status"] == "active"
+        finally:
+            await store.close()
+
+    async def test_active_to_revoked(self, tmp_path):
+        store = await self._make_store(tmp_path / "reg.db")
+        try:
+            rec = await store.register(framework="f")
+            updated = await store.set_status(rec["canonical_id"], "revoked")
+            assert updated["status"] == "revoked"
+        finally:
+            await store.close()
+
+    async def test_suspended_to_revoked(self, tmp_path):
+        store = await self._make_store(tmp_path / "reg.db")
+        try:
+            rec = await store.register(framework="f")
+            await store.set_status(rec["canonical_id"], "suspended")
+            updated = await store.set_status(rec["canonical_id"], "revoked")
+            assert updated["status"] == "revoked"
+        finally:
+            await store.close()
+
+    async def test_pending_to_revoked(self, tmp_path):
+        store = await self._make_store(tmp_path / "reg.db")
+        try:
+            rec = await store.register(framework="f", origin="external-selfjoin")
+            updated = await store.set_status(rec["canonical_id"], "revoked")
+            assert updated["status"] == "revoked"
+        finally:
+            await store.close()
+
+    async def test_rejected_to_pending(self, tmp_path):
+        store = await self._make_store(tmp_path / "reg.db")
+        try:
+            rec = await store.register(framework="f", origin="external-selfjoin")
+            await store.set_status(rec["canonical_id"], "rejected")
+            updated = await store.set_status(rec["canonical_id"], "pending")
+            assert updated["status"] == "pending"
+        finally:
+            await store.close()
+
+    async def test_rejected_to_active(self, tmp_path):
+        store = await self._make_store(tmp_path / "reg.db")
+        try:
+            rec = await store.register(framework="f", origin="external-selfjoin")
+            await store.set_status(rec["canonical_id"], "rejected")
+            updated = await store.set_status(rec["canonical_id"], "active")
+            assert updated["status"] == "active"
+        finally:
+            await store.close()
+
+    # -- Revoke sets revoked_at ---------------------------------------------
+
+    async def test_set_status_revoked_sets_revoked_at(self, tmp_path):
+        store = await self._make_store(tmp_path / "reg.db")
+        try:
+            rec = await store.register(framework="f")
+            updated = await store.set_status(rec["canonical_id"], "revoked")
+            assert updated["status"] == "revoked"
+            assert updated["revoked_at"] is not None
+        finally:
+            await store.close()
+
+    # -- Invalid transitions raise ValueError --------------------------------
+
+    @pytest.mark.parametrize("from_s,to_s", [
+        ("active",    "pending"),
+        ("active",    "rejected"),
+        ("suspended", "pending"),
+        ("suspended", "rejected"),
+        ("revoked",   "active"),    # terminal — no transition out
+        ("revoked",   "suspended"),
+        ("rejected",  "suspended"),
+        ("active",    "active"),    # same-state is not a valid transition
+    ])
+    async def test_invalid_transition_raises(self, tmp_path, from_s, to_s):
+        store = await self._make_store(tmp_path / "reg.db")
+        try:
+            # Create in 'active' state and manually force to from_s if needed.
+            rec = await store.register(framework="f")
+            if from_s != "active":
+                await store._db.execute(
+                    "UPDATE agent_registry SET status = ? WHERE canonical_id = ?",
+                    (from_s, rec["canonical_id"]),
+                )
+                await store._db.commit()
+            with pytest.raises(ValueError):
+                await store.set_status(rec["canonical_id"], to_s)
+        finally:
+            await store.close()
+
+    async def test_unknown_canonical_id_raises_key_error(self, tmp_path):
+        store = await self._make_store(tmp_path / "reg.db")
+        try:
+            with pytest.raises(KeyError):
+                await store.set_status("no-such-id", "active")
+        finally:
+            await store.close()
+
+    # -- Origin-based initial status ----------------------------------------
+
+    async def test_external_selfjoin_born_pending(self, tmp_path):
+        store = await self._make_store(tmp_path / "reg.db")
+        try:
+            rec = await store.register(framework="f", origin="external-selfjoin")
+            assert rec["status"] == "pending"
+        finally:
+            await store.close()
+
+    async def test_taos_deployed_born_active(self, tmp_path):
+        store = await self._make_store(tmp_path / "reg.db")
+        try:
+            rec = await store.register(framework="f", origin="taos-deployed")
+            assert rec["status"] == "active"
+        finally:
+            await store.close()
+
+    async def test_default_origin_born_active(self, tmp_path):
+        store = await self._make_store(tmp_path / "reg.db")
+        try:
+            rec = await store.register(framework="f")
+            assert rec["status"] == "active"
+        finally:
+            await store.close()
+
+    # -- Migration: existing revoked_at rows get status=revoked -------------
+
+    async def test_migration_backfills_revoked_at_rows(self, tmp_path):
+        """Simulate a pre-migration DB (no status column) and verify backfill."""
+        import aiosqlite
+        from tinyagentos.db_migrations import apply_wal_pragmas_async
+
+        db_path = tmp_path / "old.db"
+
+        # Create a bare DB without the status column (old schema).
+        async with aiosqlite.connect(str(db_path)) as conn:
+            conn.row_factory = aiosqlite.Row
+            await apply_wal_pragmas_async(conn)
+            await conn.executescript("""
+                CREATE TABLE IF NOT EXISTS agent_registry (
+                    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                    canonical_id TEXT NOT NULL UNIQUE,
+                    display_name TEXT NOT NULL DEFAULT '',
+                    framework    TEXT NOT NULL DEFAULT '',
+                    user_id      TEXT NOT NULL DEFAULT '',
+                    origin       TEXT NOT NULL DEFAULT 'taos-deployed',
+                    handle       TEXT NOT NULL DEFAULT '',
+                    role         TEXT,
+                    capabilities TEXT NOT NULL DEFAULT '[]',
+                    created_ts   TEXT NOT NULL,
+                    revoked_at   TEXT
+                );
+            """)
+            # Insert two rows: one active, one already-revoked.
+            await conn.execute(
+                "INSERT INTO agent_registry (canonical_id, framework, created_ts) "
+                "VALUES ('active-agent', 'f', '2026-01-01T00:00:00')"
+            )
+            await conn.execute(
+                "INSERT INTO agent_registry (canonical_id, framework, created_ts, revoked_at) "
+                "VALUES ('revoked-agent', 'f', '2026-01-01T00:00:00', '2026-01-02T00:00:00')"
+            )
+            await conn.commit()
+
+        # Open through the store — migration should add column + backfill.
+        store = AgentRegistryStore(db_path)
+        await store.init()
+        try:
+            active = await store.get("active-agent")
+            revoked = await store.get("revoked-agent")
+            assert active["status"] == "active"
+            assert revoked["status"] == "revoked"
+        finally:
+            await store.close()
+
+    # -- list_inactive + list_all(status=) ----------------------------------
+
+    async def test_list_inactive_returns_non_active(self, tmp_path):
+        store = await self._make_store(tmp_path / "reg.db")
+        try:
+            rec_a = await store.register(framework="f")           # active
+            rec_p = await store.register(framework="f", origin="external-selfjoin")  # pending
+            rec_s = await store.register(framework="f")
+            await store.set_status(rec_s["canonical_id"], "suspended")
+
+            inactive = await store.list_inactive()
+            cids = {e["canonical_id"] for e in inactive}
+            assert rec_p["canonical_id"] in cids
+            assert rec_s["canonical_id"] in cids
+            assert rec_a["canonical_id"] not in cids
+        finally:
+            await store.close()
+
+    async def test_list_inactive_shape(self, tmp_path):
+        store = await self._make_store(tmp_path / "reg.db")
+        try:
+            rec = await store.register(framework="f", origin="external-selfjoin")
+            inactive = await store.list_inactive()
+            assert len(inactive) == 1
+            entry = inactive[0]
+            assert "canonical_id" in entry
+            assert "status" in entry
+            assert entry["status"] == "pending"
+        finally:
+            await store.close()
+
+    async def test_list_all_status_filter(self, tmp_path):
+        store = await self._make_store(tmp_path / "reg.db")
+        try:
+            await store.register(framework="f")                     # active
+            await store.register(framework="f", origin="external-selfjoin")  # pending
+            pending = await store.list_all(status="pending")
+            assert len(pending) == 1
+            assert pending[0]["status"] == "pending"
+        finally:
+            await store.close()
+
+
+# ---------------------------------------------------------------------------
+# Route-level tests
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture
+async def gov_client(app, tmp_data_dir):
+    """Async HTTP client with admin session + all required stores init'd."""
+    registry_store = app.state.agent_registry
+    if registry_store._db is None:
+        await registry_store.init()
+
+    metrics = app.state.metrics
+    if metrics._db is None:
+        await metrics.init()
+
+    # Set up a trace_registry so audit events can be written.
+    from pathlib import Path
+    from tinyagentos.trace_store import TraceStoreRegistry
+    trace_registry = TraceStoreRegistry(Path(tmp_data_dir))
+    app.state.trace_registry = trace_registry
+
+    app.state.auth.setup_user("admin", "Test Admin", "", "testpass")
+    record = app.state.auth.find_user("admin")
+    uid = record["id"] if record else ""
+    token = app.state.auth.create_session(user_id=uid, long_lived=True)
+    app.state._startup_complete = True
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        cookies={"taos_session": token},
+    ) as c:
+        yield c, uid
+
+    await registry_store.close()
+    await metrics.close()
+    await trace_registry.close_all()
+
+
+@pytest_asyncio.fixture
+async def gov_member_client(app, tmp_data_dir):
+    """Async HTTP client with a non-admin member session."""
+    registry_store = app.state.agent_registry
+    if registry_store._db is None:
+        await registry_store.init()
+
+    metrics = app.state.metrics
+    if metrics._db is None:
+        await metrics.init()
+
+    # Create admin first, then create a member via the invite flow.
+    app.state.auth.setup_user("admin", "Test Admin", "", "testpass")
+    admin_record = app.state.auth.find_user("admin")
+    assert admin_record is not None
+
+    invite_code = app.state.auth.add_user_invite("member", "admin")
+    app.state.auth.complete_invite(
+        username="member",
+        invite_code=invite_code,
+        full_name="Test Member",
+        email="",
+        password="testpass1",
+    )
+    member_record = app.state.auth.find_user("member")
+    assert member_record is not None
+    assert not member_record.get("is_admin")
+
+    member_token = app.state.auth.create_session(
+        user_id=member_record["id"], long_lived=True
+    )
+    app.state._startup_complete = True
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        cookies={"taos_session": member_token},
+    ) as c:
+        yield c
+
+    await registry_store.close()
+    await metrics.close()
+
+
+@pytest.mark.asyncio
+class TestLifecycleRoutes:
+
+    async def _register(self, client, origin="taos-deployed"):
+        resp = await client.post(
+            "/api/agents/registry/register",
+            json={"framework": "test", "display_name": "Test Agent", "origin": origin},
+        )
+        assert resp.status_code == 200
+        return resp.json()["canonical_id"]
+
+    # -- approve -------------------------------------------------------------
+
+    async def test_approve_pending_returns_active(self, gov_client):
+        client, _uid = gov_client
+        cid = await self._register(client, origin="external-selfjoin")
+        resp = await client.post(f"/api/agents/registry/{cid}/approve")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "active"
+
+    async def test_approve_unknown_returns_404(self, gov_client):
+        client, _uid = gov_client
+        resp = await client.post("/api/agents/registry/no-such-id/approve")
+        assert resp.status_code == 404
+
+    async def test_approve_active_returns_409(self, gov_client):
+        """Approving an already-active agent is an invalid transition."""
+        client, _uid = gov_client
+        cid = await self._register(client)  # taos-deployed → active
+        resp = await client.post(f"/api/agents/registry/{cid}/approve")
+        assert resp.status_code == 409
+
+    # -- reject --------------------------------------------------------------
+
+    async def test_reject_pending_returns_rejected(self, gov_client):
+        client, _uid = gov_client
+        cid = await self._register(client, origin="external-selfjoin")
+        resp = await client.post(f"/api/agents/registry/{cid}/reject")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "rejected"
+
+    async def test_reject_active_returns_409(self, gov_client):
+        client, _uid = gov_client
+        cid = await self._register(client)
+        resp = await client.post(f"/api/agents/registry/{cid}/reject")
+        assert resp.status_code == 409
+
+    # -- suspend -------------------------------------------------------------
+
+    async def test_suspend_active_returns_suspended(self, gov_client):
+        client, _uid = gov_client
+        cid = await self._register(client)
+        resp = await client.post(f"/api/agents/registry/{cid}/suspend")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "suspended"
+
+    async def test_suspend_pending_returns_409(self, gov_client):
+        client, _uid = gov_client
+        cid = await self._register(client, origin="external-selfjoin")
+        resp = await client.post(f"/api/agents/registry/{cid}/suspend")
+        assert resp.status_code == 409
+
+    async def test_suspend_unknown_returns_404(self, gov_client):
+        client, _uid = gov_client
+        resp = await client.post("/api/agents/registry/no-such-id/suspend")
+        assert resp.status_code == 404
+
+    # -- reactivate ----------------------------------------------------------
+
+    async def test_reactivate_suspended_returns_active(self, gov_client):
+        client, _uid = gov_client
+        cid = await self._register(client)
+        await client.post(f"/api/agents/registry/{cid}/suspend")
+        resp = await client.post(f"/api/agents/registry/{cid}/reactivate")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "active"
+
+    async def test_reactivate_active_returns_409(self, gov_client):
+        client, _uid = gov_client
+        cid = await self._register(client)
+        resp = await client.post(f"/api/agents/registry/{cid}/reactivate")
+        assert resp.status_code == 409
+
+    # -- non-admin forbidden -------------------------------------------------
+
+    async def test_approve_non_admin_forbidden(self, gov_member_client):
+        resp = await gov_member_client.post("/api/agents/registry/any-id/approve")
+        assert resp.status_code == 403
+
+    async def test_reject_non_admin_forbidden(self, gov_member_client):
+        resp = await gov_member_client.post("/api/agents/registry/any-id/reject")
+        assert resp.status_code == 403
+
+    async def test_suspend_non_admin_forbidden(self, gov_member_client):
+        resp = await gov_member_client.post("/api/agents/registry/any-id/suspend")
+        assert resp.status_code == 403
+
+    async def test_reactivate_non_admin_forbidden(self, gov_member_client):
+        resp = await gov_member_client.post("/api/agents/registry/any-id/reactivate")
+        assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+class TestInactiveRoute:
+
+    async def _admin_register(self, client, origin="taos-deployed"):
+        resp = await client.post(
+            "/api/agents/registry/register",
+            json={"framework": "test", "display_name": "Test Agent", "origin": origin},
+        )
+        assert resp.status_code == 200
+        return resp.json()["canonical_id"]
+
+    async def test_inactive_returns_non_active_entries(self, gov_client):
+        client, _uid = gov_client
+        cid_active = await self._admin_register(client)
+        cid_pending = await self._admin_register(client, origin="external-selfjoin")
+
+        resp = await client.get("/api/agents/registry/inactive")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "inactive" in data
+        cids = {e["canonical_id"] for e in data["inactive"]}
+        assert cid_pending in cids
+        assert cid_active not in cids
+
+    async def test_inactive_entry_shape(self, gov_client):
+        client, _uid = gov_client
+        await self._admin_register(client, origin="external-selfjoin")
+        resp = await client.get("/api/agents/registry/inactive")
+        assert resp.status_code == 200
+        entries = resp.json()["inactive"]
+        assert len(entries) >= 1
+        entry = entries[0]
+        assert "canonical_id" in entry
+        assert "status" in entry
+
+    async def test_inactive_admin_only(self, gov_member_client):
+        resp = await gov_member_client.get("/api/agents/registry/inactive")
+        assert resp.status_code == 403
+
+    async def test_inactive_not_matched_as_canonical_id(self, gov_client):
+        """GET /inactive must not be routed to the /{canonical_id} handler."""
+        client, _uid = gov_client
+        resp = await client.get("/api/agents/registry/inactive")
+        # Correct admin response (may be empty list) — NOT a 404 for canonical_id
+        assert resp.status_code in (200, 403)
+        if resp.status_code == 200:
+            assert "inactive" in resp.json()
+
+
+@pytest.mark.asyncio
+class TestStatusFilter:
+
+    async def test_list_status_pending_filter(self, gov_client):
+        client, _uid = gov_client
+        cid_active = await client.post(
+            "/api/agents/registry/register",
+            json={"framework": "f", "display_name": "Active Agent"},
+        )
+        cid_pending_resp = await client.post(
+            "/api/agents/registry/register",
+            json={"framework": "f", "display_name": "Pending Agent", "origin": "external-selfjoin"},
+        )
+        assert cid_active.status_code == 200
+        assert cid_pending_resp.status_code == 200
+        cid_pending = cid_pending_resp.json()["canonical_id"]
+
+        resp = await client.get("/api/agents/registry?status=pending")
+        assert resp.status_code == 200
+        records = resp.json()
+        assert isinstance(records, list)
+        cids = {r["canonical_id"] for r in records}
+        assert cid_pending in cids
+        assert cid_active.json()["canonical_id"] not in cids
+
+    async def test_list_no_filter_returns_all(self, gov_client):
+        client, _uid = gov_client
+        await client.post(
+            "/api/agents/registry/register",
+            json={"framework": "f", "display_name": "A1"},
+        )
+        await client.post(
+            "/api/agents/registry/register",
+            json={"framework": "f", "display_name": "A2", "origin": "external-selfjoin"},
+        )
+        resp = await client.get("/api/agents/registry")
+        assert resp.status_code == 200
+        assert len(resp.json()) >= 2
+
+
+@pytest.mark.asyncio
+class TestAuditEvent:
+
+    async def test_audit_event_recorded_on_approve(self, gov_client, tmp_data_dir):
+        """Approving an agent must write a governance audit event to trace_store."""
+        client, _uid = gov_client
+        # Register a pending agent.
+        resp = await client.post(
+            "/api/agents/registry/register",
+            json={"framework": "f", "display_name": "Audit Target", "origin": "external-selfjoin"},
+        )
+        cid = resp.json()["canonical_id"]
+
+        # Approve it.
+        await client.post(f"/api/agents/registry/{cid}/approve")
+
+        # Read the governance audit events from the trace store.
+        from pathlib import Path
+        from tinyagentos.trace_store import AgentTraceStore
+        ts = AgentTraceStore(Path(tmp_data_dir), "taos-governance")
+        events = await ts.list(kind="governance", limit=50)
+        governance_events = [
+            e for e in events
+            if isinstance(e.get("payload"), dict)
+            and e["payload"].get("canonical_id") == cid
+        ]
+        assert len(governance_events) >= 1
+        ev = governance_events[0]
+        payload = ev["payload"]
+        assert payload["action"] == "approve"
+        assert payload["before_status"] == "pending"
+        assert payload["after_status"] == "active"
+        await ts.close()
+
+    async def test_audit_event_recorded_on_suspend(self, gov_client, tmp_data_dir):
+        client, _uid = gov_client
+        resp = await client.post(
+            "/api/agents/registry/register",
+            json={"framework": "f", "display_name": "Suspend Audit"},
+        )
+        cid = resp.json()["canonical_id"]
+        await client.post(f"/api/agents/registry/{cid}/suspend")
+
+        from pathlib import Path
+        from tinyagentos.trace_store import AgentTraceStore
+        ts = AgentTraceStore(Path(tmp_data_dir), "taos-governance")
+        events = await ts.list(kind="governance", limit=50)
+        ev = next(
+            (e for e in events
+             if isinstance(e.get("payload"), dict)
+             and e["payload"].get("canonical_id") == cid),
+            None,
+        )
+        assert ev is not None
+        assert ev["payload"]["action"] == "suspend"
+        await ts.close()

--- a/tinyagentos/agent_registry_store.py
+++ b/tinyagentos/agent_registry_store.py
@@ -43,9 +43,64 @@ CREATE TABLE IF NOT EXISTS agent_registry (
     role            TEXT,
     capabilities    TEXT    NOT NULL DEFAULT '[]',
     created_ts      TEXT    NOT NULL,
-    revoked_at      TEXT
+    revoked_at      TEXT,
+    status          TEXT    NOT NULL DEFAULT 'active'
 );
 """
+
+# ---------------------------------------------------------------------------
+# Lifecycle state machine
+# ---------------------------------------------------------------------------
+
+VALID_STATUSES = frozenset({"pending", "active", "suspended", "revoked", "rejected"})
+
+# Maps (from_status, to_status) → True for allowed transitions.
+_VALID_TRANSITIONS: frozenset[tuple[str, str]] = frozenset({
+    ("pending",   "active"),      # approve
+    ("pending",   "rejected"),    # reject
+    ("active",    "suspended"),   # suspend
+    ("suspended", "active"),      # reactivate
+    ("active",    "revoked"),     # revoke (terminal)
+    ("suspended", "revoked"),     # revoke (terminal)
+    ("pending",   "revoked"),     # revoke (terminal)
+    ("rejected",  "pending"),     # undo denial → re-open
+    ("rejected",  "active"),      # undo denial → directly approve
+})
+
+
+def _assert_valid_transition(before: str, after: str) -> None:
+    """Raise ValueError if the transition is not allowed."""
+    if after not in VALID_STATUSES:
+        raise ValueError(f"unknown status {after!r}; valid: {sorted(VALID_STATUSES)}")
+    if (before, after) not in _VALID_TRANSITIONS:
+        raise ValueError(
+            f"invalid lifecycle transition: {before!r} → {after!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Migration: add status column + backfill
+# ---------------------------------------------------------------------------
+
+async def _migration_v1_add_status(conn) -> None:
+    """Add status column (idempotent) and backfill existing rows."""
+    # Check if the column already exists (SQLite has no IF NOT EXISTS for ADD COLUMN
+    # prior to 3.37 — use PRAGMA instead for broad compatibility).
+    existing_cols = {
+        row[1]
+        for row in await (
+            await conn.execute("PRAGMA table_info(agent_registry)")
+        ).fetchall()
+    }
+    if "status" not in existing_cols:
+        await conn.execute(
+            "ALTER TABLE agent_registry ADD COLUMN status TEXT NOT NULL DEFAULT 'active'"
+        )
+    # Backfill: rows with revoked_at set → 'revoked'; others → 'active'.
+    await conn.execute(
+        "UPDATE agent_registry SET status = 'revoked' WHERE revoked_at IS NOT NULL AND status = 'active'"
+    )
+    await conn.commit()
 
 # ---------------------------------------------------------------------------
 # Signing-key helpers (Ed25519, persisted to disk)
@@ -238,6 +293,10 @@ class AgentRegistryStore(BaseStore):
         if self._db is not None:
             self._db.row_factory = aiosqlite.Row
 
+    async def _post_init(self) -> None:
+        """Idempotently ensure the status column exists and is backfilled."""
+        await _migration_v1_add_status(self._db)
+
     # ------------------------------------------------------------------
     # Registration
     # ------------------------------------------------------------------
@@ -283,15 +342,16 @@ class AgentRegistryStore(BaseStore):
             canonical_id = f"{base_id}-{suffix_n:02x}"
 
         caps_json = json.dumps(capabilities)
+        initial_status = "pending" if origin == "external-selfjoin" else "active"
         await self._db.execute(
             """
             INSERT INTO agent_registry
                 (canonical_id, display_name, framework, user_id, origin,
-                 handle, role, capabilities, created_ts)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 handle, role, capabilities, created_ts, status)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (canonical_id, display_name, framework, user_id, origin,
-             handle, role, caps_json, created_ts),
+             handle, role, caps_json, created_ts, initial_status),
         )
         await self._db.commit()
 
@@ -319,27 +379,39 @@ class AgentRegistryStore(BaseStore):
         ).fetchone()
         return _row_to_dict(row) if row else None
 
-    async def list_all(self) -> list[dict]:
-        """Return all registry records (revoked and active)."""
+    async def list_all(self, *, status: Optional[str] = None) -> list[dict]:
+        """Return all registry records, optionally filtered by *status*."""
         if self._db is None:
             raise RuntimeError("AgentRegistryStore not initialised")
-        cursor = await self._db.execute("SELECT * FROM agent_registry ORDER BY id")
+        if status is not None:
+            cursor = await self._db.execute(
+                "SELECT * FROM agent_registry WHERE status = ? ORDER BY id",
+                (status,),
+            )
+        else:
+            cursor = await self._db.execute("SELECT * FROM agent_registry ORDER BY id")
         rows = await cursor.fetchall()
         return [_row_to_dict(r) for r in rows]
 
-    async def list_for_user(self, user_id: str) -> list[dict]:
-        """Return all registry records owned by *user_id*."""
+    async def list_for_user(self, user_id: str, *, status: Optional[str] = None) -> list[dict]:
+        """Return all registry records owned by *user_id*, optionally filtered by *status*."""
         if self._db is None:
             raise RuntimeError("AgentRegistryStore not initialised")
-        cursor = await self._db.execute(
-            "SELECT * FROM agent_registry WHERE user_id = ? ORDER BY id",
-            (user_id,),
-        )
+        if status is not None:
+            cursor = await self._db.execute(
+                "SELECT * FROM agent_registry WHERE user_id = ? AND status = ? ORDER BY id",
+                (user_id, status),
+            )
+        else:
+            cursor = await self._db.execute(
+                "SELECT * FROM agent_registry WHERE user_id = ? ORDER BY id",
+                (user_id,),
+            )
         rows = await cursor.fetchall()
         return [_row_to_dict(r) for r in rows]
 
     async def list_revoked(self) -> list[dict]:
-        """Return [{canonical_id, revoked_at}] for all revoked entries."""
+        """Return [{canonical_id, revoked_at}] for all revoked entries (back-compat feed)."""
         if self._db is None:
             raise RuntimeError("AgentRegistryStore not initialised")
         cursor = await self._db.execute(
@@ -349,6 +421,60 @@ class AgentRegistryStore(BaseStore):
         rows = await cursor.fetchall()
         return [{"canonical_id": r["canonical_id"], "revoked_at": r["revoked_at"]} for r in rows]
 
+    async def list_inactive(self) -> list[dict]:
+        """Return [{canonical_id, status}] for all non-active entries."""
+        if self._db is None:
+            raise RuntimeError("AgentRegistryStore not initialised")
+        cursor = await self._db.execute(
+            "SELECT canonical_id, status FROM agent_registry "
+            "WHERE status != 'active' ORDER BY id",
+        )
+        rows = await cursor.fetchall()
+        return [{"canonical_id": r["canonical_id"], "status": r["status"]} for r in rows]
+
+    # ------------------------------------------------------------------
+    # Lifecycle state machine
+    # ------------------------------------------------------------------
+
+    async def set_status(
+        self,
+        canonical_id: str,
+        new_status: str,
+        *,
+        actor: str = "",
+    ) -> dict:
+        """Transition *canonical_id* to *new_status*, enforcing valid transitions.
+
+        Returns the updated record.
+        Raises ``ValueError`` on invalid/disallowed transition.
+        Raises ``KeyError`` if *canonical_id* does not exist.
+        """
+        if self._db is None:
+            raise RuntimeError("AgentRegistryStore not initialised")
+
+        record = await self.get(canonical_id)
+        if record is None:
+            raise KeyError(canonical_id)
+
+        before_status = record.get("status") or "active"
+        _assert_valid_transition(before_status, new_status)
+
+        now = datetime.now(timezone.utc).isoformat()
+        if new_status == "revoked":
+            # Terminal: also set revoked_at if not already set.
+            await self._db.execute(
+                "UPDATE agent_registry SET status = ?, revoked_at = COALESCE(revoked_at, ?) "
+                "WHERE canonical_id = ?",
+                (new_status, now, canonical_id),
+            )
+        else:
+            await self._db.execute(
+                "UPDATE agent_registry SET status = ? WHERE canonical_id = ?",
+                (new_status, canonical_id),
+            )
+        await self._db.commit()
+        return await self.get(canonical_id)  # type: ignore[return-value]
+
     # ------------------------------------------------------------------
     # Revoke
     # ------------------------------------------------------------------
@@ -357,10 +483,16 @@ class AgentRegistryStore(BaseStore):
         """Set revoked_at on *canonical_id*.  Returns updated record or None."""
         if self._db is None:
             raise RuntimeError("AgentRegistryStore not initialised")
+        record = await self.get(canonical_id)
+        if record is None:
+            return None
+        if record.get("revoked_at"):
+            # Already revoked — return the existing record unchanged.
+            return record
         now = datetime.now(timezone.utc).isoformat()
         await self._db.execute(
-            "UPDATE agent_registry SET revoked_at = ? "
-            "WHERE canonical_id = ? AND revoked_at IS NULL",
+            "UPDATE agent_registry SET revoked_at = ?, status = 'revoked' "
+            "WHERE canonical_id = ?",
             (now, canonical_id),
         )
         await self._db.commit()

--- a/tinyagentos/routes/agent_registry.py
+++ b/tinyagentos/routes/agent_registry.py
@@ -2,17 +2,23 @@ from __future__ import annotations
 
 """Routes for the Agent Registry (SP-A, taOS side).
 
-POST   /api/agents/registry/register    — register an agent, mint canonical_id, issue token
-GET    /api/agents/registry/pubkey      — public key for token verification (exempt, no auth)
-GET    /api/agents/registry/revoked     — global revocation feed (admin/local-token only)
-GET    /api/agents/registry             — list registry entries (admin: all; member: own)
-GET    /api/agents/registry/{id}        — read a single entry (owner or admin; else 404)
-DELETE /api/agents/registry/{id}        — revoke an entry (owner or admin)
+POST   /api/agents/registry/register         — register an agent, mint canonical_id, issue token
+GET    /api/agents/registry/pubkey           — public key for token verification (exempt, no auth)
+GET    /api/agents/registry/revoked          — global revocation feed (admin/local-token only)
+GET    /api/agents/registry/inactive         — all non-active entries for the bus (admin only)
+GET    /api/agents/registry                  — list registry entries (admin: all; member: own)
+GET    /api/agents/registry/{id}             — read a single entry (owner or admin; else 404)
+DELETE /api/agents/registry/{id}             — revoke an entry (owner or admin)
+POST   /api/agents/registry/{id}/approve     — lifecycle: pending → active (admin only)
+POST   /api/agents/registry/{id}/reject      — lifecycle: pending → rejected (admin only)
+POST   /api/agents/registry/{id}/suspend     — lifecycle: active → suspended (admin only)
+POST   /api/agents/registry/{id}/reactivate  — lifecycle: suspended → active (admin only)
 
-Route ordering matters: /pubkey and /revoked are declared before /{canonical_id} so
-the literal strings are not captured as a canonical_id path parameter.
+Route ordering matters: /pubkey, /revoked, and /inactive are declared before
+/{canonical_id} so the literal strings are not captured as a path parameter.
 """
 
+import logging
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -22,9 +28,14 @@ from pydantic import BaseModel, field_validator
 from tinyagentos.agent_registry_store import mint_registry_token
 from tinyagentos.auth_context import CurrentUser, current_user, require_owner_or_admin
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter()
 
 _ALLOWED_ORIGINS = {"taos-deployed", "external-selfjoin"}
+
+# Dedicated trace slug for governance audit events.
+_GOVERNANCE_SLUG = "taos-governance"
 
 
 # ---------------------------------------------------------------------------
@@ -64,6 +75,35 @@ def _get_keypair(request: Request) -> tuple[bytes, bytes]:
     if kp is None:
         raise RuntimeError("agent_registry_keypair not on app.state")
     return kp
+
+
+async def _audit_governance(
+    request: Request,
+    *,
+    action: str,
+    canonical_id: str,
+    actor_user_id: str,
+    before_status: str,
+    after_status: str,
+) -> None:
+    """Write a governance audit event to the trace store (best-effort, non-fatal)."""
+    try:
+        trace_registry = getattr(request.app.state, "trace_registry", None)
+        if trace_registry is None:
+            return
+        ts = await trace_registry.get(_GOVERNANCE_SLUG)
+        await ts.record(
+            "governance",
+            payload={
+                "action": action,
+                "canonical_id": canonical_id,
+                "actor_user_id": actor_user_id,
+                "before_status": before_status,
+                "after_status": after_status,
+            },
+        )
+    except Exception:
+        logger.exception("governance audit write failed (non-fatal)")
 
 
 # ---------------------------------------------------------------------------
@@ -139,16 +179,39 @@ async def list_revoked_entries(
     return {"revoked": await store.list_revoked()}
 
 
-@router.get("/api/agents/registry")
-async def list_registry(
+@router.get("/api/agents/registry/inactive")
+async def list_inactive_entries(
     request: Request,
     user: CurrentUser = Depends(current_user),
 ):
-    """List registry entries. Admins see all; members see only their own."""
+    """Return all non-active registry entries for bus enforcement.
+
+    Response: {"inactive": [{canonical_id, status}, ...]}
+
+    Admin only — covers pending/suspended/rejected/revoked.
+    The bus polls this to reject any canonical_id present.
+    """
+    if not user.is_admin:
+        raise HTTPException(status_code=403, detail="forbidden")
+    store = _get_store(request)
+    return {"inactive": await store.list_inactive()}
+
+
+@router.get("/api/agents/registry")
+async def list_registry(
+    request: Request,
+    status: Optional[str] = None,
+    user: CurrentUser = Depends(current_user),
+):
+    """List registry entries.
+
+    Admins see all matching entries; members see only their own.
+    Optional ``?status=<value>`` filter.
+    """
     store = _get_store(request)
     if user.is_admin:
-        return await store.list_all()
-    return await store.list_for_user(user.user_id)
+        return await store.list_all(status=status)
+    return await store.list_for_user(user.user_id, status=status)
 
 
 @router.get("/api/agents/registry/{canonical_id}")
@@ -186,5 +249,91 @@ async def revoke_registry_entry(
     if record is None:
         return JSONResponse({"error": "not found or already revoked"}, status_code=404)
     require_owner_or_admin(user, record["user_id"])
+    before_status = record.get("status") or "active"
     revoked = await store.revoke(canonical_id)
+    await _audit_governance(
+        request,
+        action="revoke",
+        canonical_id=canonical_id,
+        actor_user_id=user.user_id,
+        before_status=before_status,
+        after_status="revoked",
+    )
     return {"status": "revoked", "canonical_id": canonical_id, "revoked_at": revoked.get("revoked_at")}
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle transition routes (admin only)
+# ---------------------------------------------------------------------------
+
+async def _transition(
+    request: Request,
+    canonical_id: str,
+    action: str,
+    new_status: str,
+    user: CurrentUser,
+):
+    """Shared handler for approve / reject / suspend / reactivate."""
+    if not user.is_admin:
+        raise HTTPException(status_code=403, detail="forbidden")
+
+    store = _get_store(request)
+    record = await store.get(canonical_id)
+    if record is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+
+    before_status = record.get("status") or "active"
+    try:
+        updated = await store.set_status(canonical_id, new_status, actor=user.user_id)
+    except (ValueError, KeyError) as exc:
+        return JSONResponse({"error": str(exc)}, status_code=409)
+
+    await _audit_governance(
+        request,
+        action=action,
+        canonical_id=canonical_id,
+        actor_user_id=user.user_id,
+        before_status=before_status,
+        after_status=new_status,
+    )
+    return updated
+
+
+@router.post("/api/agents/registry/{canonical_id}/approve")
+async def approve_agent(
+    request: Request,
+    canonical_id: str,
+    user: CurrentUser = Depends(current_user),
+):
+    """Approve a pending agent (pending → active). Admin only."""
+    return await _transition(request, canonical_id, "approve", "active", user)
+
+
+@router.post("/api/agents/registry/{canonical_id}/reject")
+async def reject_agent(
+    request: Request,
+    canonical_id: str,
+    user: CurrentUser = Depends(current_user),
+):
+    """Reject a pending agent (pending → rejected). Admin only."""
+    return await _transition(request, canonical_id, "reject", "rejected", user)
+
+
+@router.post("/api/agents/registry/{canonical_id}/suspend")
+async def suspend_agent(
+    request: Request,
+    canonical_id: str,
+    user: CurrentUser = Depends(current_user),
+):
+    """Suspend an active agent (active → suspended). Admin only."""
+    return await _transition(request, canonical_id, "suspend", "suspended", user)
+
+
+@router.post("/api/agents/registry/{canonical_id}/reactivate")
+async def reactivate_agent(
+    request: Request,
+    canonical_id: str,
+    user: CurrentUser = Depends(current_user),
+):
+    """Reactivate a suspended agent (suspended → active). Admin only."""
+    return await _transition(request, canonical_id, "reactivate", "active", user)

--- a/tinyagentos/trace_store.py
+++ b/tinyagentos/trace_store.py
@@ -73,6 +73,9 @@ VALID_KINDS = frozenset({
     # Phase 1 observability: post-hoc reasoning judge result (§4.7 / §7).
     # Never emitted as an OTel span — it is an internal eval artifact.
     "reasoning_audit",
+    # Registry governance audit events (PR1 — lifecycle state machine).
+    # Payload shape: {action, canonical_id, actor_user_id, before_status, after_status}
+    "governance",
 })
 
 # Documented envelope schema — the librarian parses against this.
@@ -97,6 +100,14 @@ ENVELOPE_V1_SCHEMA = {
         # Phase 1 observability — judge result written by tinyagentos/otel/judge.py (Phase 4).
         # Payload shape: {verdict: "pass"|"warn"|"fail", flags: list[str], model: str, latency_ms: int}
         "reasoning_audit": {"verdict": "pass|warn|fail", "flags": "list[str]", "model": "str", "latency_ms": "int"},
+        # Registry governance audit (PR1 — lifecycle state machine).
+        "governance": {
+            "action": "str",
+            "canonical_id": "str",
+            "actor_user_id": "str",
+            "before_status": "str",
+            "after_status": "str",
+        },
     },
 }
 


### PR DESCRIPTION
Governance PR 1 (lifecycle core) per the governance spec. Builds on #710.

- `agent_registry_store.py` — `status` column (idempotent _post_init migration; existing revoked rows → revoked); `_VALID_TRANSITIONS` state machine (pending/active/suspended/revoked/rejected); register sets external-selfjoin → pending; `set_status`, `list_inactive`, `?status=` filter; revoke also sets status=revoked.
- `routes/agent_registry.py` — admin-only `POST /{id}/approve|reject|suspend|reactivate` (404/409 on bad), `GET /inactive` (before /{id}), `?status=` list filter, `_audit_governance()` → trace_store.
- `trace_store.py` — adds `governance` event kind.
- 48 new tests; 83 pass.

Capabilities (PR2), approval notification (PR3), audit UI (PR4) follow. Auditing before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Admin agents can now approve, reject, suspend, and reactivate pending agent registrations
  * New endpoint to view inactive agents
  * Filter agents by status in registry queries
  * Governance audit trail automatically recorded for all lifecycle actions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->