### PR TITLE
fix(security): atomic registry lifecycle transitions + rejected→revoked

### DIFF
--- a/tests/test_registry_governance_lifecycle.py
+++ b/tests/test_registry_governance_lifecycle.py
@@ -125,6 +125,18 @@ class TestSetStatus:
         finally:
             await store.close()
 
+    async def test_rejected_to_revoked(self, tmp_path):
+        """A rejected agent can still be revoked (any non-terminal → revoked)."""
+        store = await self._make_store(tmp_path / "reg.db")
+        try:
+            rec = await store.register(framework="f", origin="external-selfjoin")
+            await store.set_status(rec["canonical_id"], "rejected")
+            updated = await store.set_status(rec["canonical_id"], "revoked")
+            assert updated["status"] == "revoked"
+            assert updated["revoked_at"] is not None
+        finally:
+            await store.close()
+
     # -- Revoke sets revoked_at ---------------------------------------------
 
     async def test_set_status_revoked_sets_revoked_at(self, tmp_path):
@@ -522,10 +534,11 @@ class TestInactiveRoute:
         """GET /inactive must not be routed to the /{canonical_id} handler."""
         client, _uid = gov_client
         resp = await client.get("/api/agents/registry/inactive")
-        # Correct admin response (may be empty list) — NOT a 404 for canonical_id
-        assert resp.status_code in (200, 403)
-        if resp.status_code == 200:
-            assert "inactive" in resp.json()
+        # gov_client is an admin session, so this MUST be 200 (proves /inactive
+        # beat the /{canonical_id} route). Accepting 403 would let an auth
+        # regression slip through without proving the routing.
+        assert resp.status_code == 200
+        assert "inactive" in resp.json()
 
 
 @pytest.mark.asyncio

--- a/tinyagentos/agent_registry_store.py
+++ b/tinyagentos/agent_registry_store.py
@@ -63,6 +63,7 @@ _VALID_TRANSITIONS: frozenset[tuple[str, str]] = frozenset({
     ("active",    "revoked"),     # revoke (terminal)
     ("suspended", "revoked"),     # revoke (terminal)
     ("pending",   "revoked"),     # revoke (terminal)
+    ("rejected",  "revoked"),     # revoke (terminal) — any non-terminal → revoked
     ("rejected",  "pending"),     # undo denial → re-open
     ("rejected",  "active"),      # undo denial → directly approve
 })
@@ -460,19 +461,29 @@ class AgentRegistryStore(BaseStore):
         _assert_valid_transition(before_status, new_status)
 
         now = datetime.now(timezone.utc).isoformat()
+        # Atomic: the UPDATE is conditional on the status still being
+        # ``before_status``, so two concurrent transitions cannot both win a
+        # read/validate/write race — the loser's WHERE matches 0 rows. This
+        # also guarantees the returned/audited before_status is accurate.
         if new_status == "revoked":
-            # Terminal: also set revoked_at if not already set.
-            await self._db.execute(
+            cur = await self._db.execute(
                 "UPDATE agent_registry SET status = ?, revoked_at = COALESCE(revoked_at, ?) "
-                "WHERE canonical_id = ?",
-                (new_status, now, canonical_id),
+                "WHERE canonical_id = ? AND status = ?",
+                (new_status, now, canonical_id, before_status),
             )
         else:
-            await self._db.execute(
-                "UPDATE agent_registry SET status = ? WHERE canonical_id = ?",
-                (new_status, canonical_id),
+            cur = await self._db.execute(
+                "UPDATE agent_registry SET status = ? "
+                "WHERE canonical_id = ? AND status = ?",
+                (new_status, canonical_id, before_status),
             )
         await self._db.commit()
+        if cur.rowcount == 0:
+            # Status changed under us between the read and the write.
+            raise ValueError(
+                f"lifecycle transition conflict: {canonical_id!r} is no longer "
+                f"in state {before_status!r}"
+            )
         return await self.get(canonical_id)  # type: ignore[return-value]
 
     # ------------------------------------------------------------------
@@ -490,9 +501,11 @@ class AgentRegistryStore(BaseStore):
             # Already revoked — return the existing record unchanged.
             return record
         now = datetime.now(timezone.utc).isoformat()
+        # Atomic: only the first concurrent revoke matches (revoked_at IS NULL);
+        # a second one no-ops and returns the already-revoked record.
         await self._db.execute(
             "UPDATE agent_registry SET revoked_at = ?, status = 'revoked' "
-            "WHERE canonical_id = ?",
+            "WHERE canonical_id = ? AND revoked_at IS NULL",
             (now, canonical_id),
         )
         await self._db.commit()


### PR DESCRIPTION
Follow-up addressing CodeRabbit's review on the governance lifecycle (#716, already merged to dev):

- **Major:** add missing `rejected → revoked` transition (spec says any non-terminal → revoked).
- **Major:** `set_status()` is now atomic — conditional `UPDATE ... WHERE status = before_status` + rowcount check, so concurrent transitions can't both pass a read/validate/write race (loser raises a conflict ValueError → 409). This also makes the audited `before_status` accurate.
- **Major:** `revoke()` atomic (`WHERE revoked_at IS NULL`).
- **Minor:** tightened the `/inactive` route-ordering test to require 200 (admin), not 200|403.
- Added `rejected→revoked` regression test. 84 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Agent status transitions now execute atomically, preventing race conditions and state inconsistencies during concurrent operations.

* **Tests**
  * Expanded test coverage for agent lifecycle status transitions and API route validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->