### PR TITLE
feat(security): external-agent consent loop backend (Trust & Comms Phase 1)

### DIFF
--- a/tests/test_auth_requests.py
+++ b/tests/test_auth_requests.py
@@ -520,3 +520,46 @@ class TestAuthRequestRoutes:
         r1, r2 = await asyncio.gather(do_approve(), do_approve())
         codes = sorted([r1.status_code, r2.status_code])
         assert codes == [200, 409], f"expected [200, 409], got {codes}"
+
+    async def test_grants_feed_populated_after_approve(self, consent_client):
+        """After approval the grants feed returns the approved scopes."""
+        transport = ASGITransport(app=consent_client._transport.app)
+        async with AsyncClient(transport=transport, base_url="http://test") as bare:
+            create_resp = await bare.post("/api/agents/auth-requests", json=_CREATE_BODY)
+        request_id = create_resp.json()["request_id"]
+
+        await consent_client.post(
+            f"/api/agents/auth-requests/{request_id}/approve",
+            json={"granted_scopes": ["memory:read", "memory:write"]},
+        )
+
+        resp = await consent_client.get("/api/agents/registry/grants")
+        assert resp.status_code == 200
+        grants = resp.json()["grants"]
+        scopes = {g["scope"] for g in grants}
+        assert "memory:read" in scopes
+        assert "memory:write" in scopes
+
+    async def test_grants_feed_nonadmin_returns_403(self, consent_client_nonadmin):
+        resp = await consent_client_nonadmin.get("/api/agents/registry/grants")
+        assert resp.status_code == 403
+
+    async def test_grants_feed_filtered_by_canonical_id(self, consent_client):
+        """?canonical_id= filter returns only that agent's grants."""
+        transport = ASGITransport(app=consent_client._transport.app)
+        async with AsyncClient(transport=transport, base_url="http://test") as bare:
+            r = await bare.post("/api/agents/auth-requests", json=_CREATE_BODY)
+        request_id = r.json()["request_id"]
+
+        approve_resp = await consent_client.post(
+            f"/api/agents/auth-requests/{request_id}/approve",
+            json={"granted_scopes": ["memory:read"]},
+        )
+        canonical_id = approve_resp.json()["canonical_id"]
+
+        resp = await consent_client.get(
+            f"/api/agents/registry/grants?canonical_id={canonical_id}"
+        )
+        assert resp.status_code == 200
+        grants = resp.json()["grants"]
+        assert all(g["canonical_id"] == canonical_id for g in grants)

--- a/tests/test_auth_requests.py
+++ b/tests/test_auth_requests.py
@@ -347,6 +347,12 @@ class TestAuthRequestRoutes:
         grants = await consent_client._transport.app.state.agent_grants.list_grants(canonical_id)
         assert any(g["scope"] == "memory:read" for g in grants)
 
+        # Approval must ACTIVATE the agent — external-selfjoin lands 'pending';
+        # consent-approve transitions it to 'active' so it's not in the bus
+        # inactive feed. (Regression guard.)
+        reg = await consent_client._transport.app.state.agent_registry.get(canonical_id)
+        assert reg is not None and reg["status"] == "active"
+
         # Token not returned by approve endpoint — only by the status poll.
         assert "token" not in data
 

--- a/tests/test_auth_requests.py
+++ b/tests/test_auth_requests.py
@@ -488,3 +488,35 @@ class TestAuthRequestRoutes:
         async with AsyncClient(transport=transport, base_url="http://test") as bare:
             resp = await bare.get("/api/agents/auth-requests/no-such-id")
         assert resp.status_code == 404
+
+    async def test_list_unsupported_status_returns_400(self, consent_client):
+        resp = await consent_client.get("/api/agents/auth-requests?status=all")
+        assert resp.status_code == 400
+
+    async def test_concurrent_approve_only_one_wins(self, consent_client):
+        """Two simultaneous approvals of the same request: one 200, one 409."""
+        import asyncio
+        from httpx import ASGITransport, AsyncClient
+
+        transport = ASGITransport(app=consent_client._transport.app)
+        async with AsyncClient(transport=transport, base_url="http://test") as bare:
+            create_resp = await bare.post("/api/agents/auth-requests", json=_CREATE_BODY)
+        request_id = create_resp.json()["request_id"]
+
+        approve_body = {"granted_scopes": ["memory:read"]}
+        cookies = dict(consent_client.cookies)
+
+        async def do_approve():
+            async with AsyncClient(
+                transport=ASGITransport(app=consent_client._transport.app),
+                base_url="http://test",
+                cookies=cookies,
+            ) as c:
+                return await c.post(
+                    f"/api/agents/auth-requests/{request_id}/approve",
+                    json=approve_body,
+                )
+
+        r1, r2 = await asyncio.gather(do_approve(), do_approve())
+        codes = sorted([r1.status_code, r2.status_code])
+        assert codes == [200, 409], f"expected [200, 409], got {codes}"

--- a/tests/test_auth_requests.py
+++ b/tests/test_auth_requests.py
@@ -1,0 +1,484 @@
+"""Tests for the external-agent consent loop (Phase 1).
+
+Covers:
+  Store:
+    - create → pending record returned
+    - set_decision: pending → accepted
+    - set_decision: pending → refused
+    - set_decision: already decided → returns None (idempotency / conflict guard)
+    - list_pending: only pending rows
+    - count_pending_for: abuse-cap helper
+
+  Routes:
+    - POST create (no auth) → {request_id, status: 'pending'}
+    - GET status pending (no auth, no token in response)
+    - Admin approve → canonical_id minted + grants written + status accepted
+    - GET status accepted → token returned
+    - Non-admin approve → 403
+    - Approve unknown → 404
+    - Approve already-decided → 409
+    - Deny → refused
+    - Deny already-decided → 409
+    - Abuse cap → 429
+    - List pending (admin) → returns pending records
+    - List pending (non-admin) → 403
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from tinyagentos.auth_requests_store import AuthRequestsStore
+from tinyagentos.agent_grants_store import AgentGrantsStore
+
+
+# ---------------------------------------------------------------------------
+# Store tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestAuthRequestsStore:
+
+    async def _make_store(self, db_path):
+        store = AuthRequestsStore(db_path)
+        await store.init()
+        return store
+
+    async def test_create_returns_pending_record(self, tmp_path):
+        store = await self._make_store(tmp_path / "ar.db")
+        try:
+            record = await store.create(
+                identity_claim="my-agent",
+                framework="hermes",
+                requested_scopes=["memory:read", "memory:write"],
+                reason="need access to memory",
+            )
+            assert record["status"] == "pending"
+            assert record["identity_claim"] == "my-agent"
+            assert record["framework"] == "hermes"
+            assert record["requested_scopes"] == ["memory:read", "memory:write"]
+            assert record["reason"] == "need access to memory"
+            assert record["canonical_id"] is None
+            assert record["token"] is None
+            assert record["granted_scopes"] is None
+            assert record["decided_ts"] is None
+            assert record["id"] is not None
+        finally:
+            await store.close()
+
+    async def test_set_decision_accepted(self, tmp_path):
+        store = await self._make_store(tmp_path / "ar.db")
+        try:
+            record = await store.create(
+                identity_claim="agent-a",
+                framework="openclaw",
+                requested_scopes=["memory:read"],
+            )
+            updated = await store.set_decision(
+                record["id"],
+                "accepted",
+                canonical_id="agent-a-20260609-120000",
+                token="fake.token.value",
+                granted_scopes=["memory:read"],
+                decided_by="admin-user",
+            )
+            assert updated is not None
+            assert updated["status"] == "accepted"
+            assert updated["canonical_id"] == "agent-a-20260609-120000"
+            assert updated["token"] == "fake.token.value"
+            assert updated["granted_scopes"] == ["memory:read"]
+            assert updated["decided_by"] == "admin-user"
+            assert updated["decided_ts"] is not None
+        finally:
+            await store.close()
+
+    async def test_set_decision_refused(self, tmp_path):
+        store = await self._make_store(tmp_path / "ar.db")
+        try:
+            record = await store.create(
+                identity_claim="agent-b",
+                framework="hermes",
+                requested_scopes=["memory:read"],
+            )
+            updated = await store.set_decision(
+                record["id"],
+                "refused",
+                decided_by="admin-user",
+            )
+            assert updated is not None
+            assert updated["status"] == "refused"
+            assert updated["canonical_id"] is None
+            assert updated["token"] is None
+        finally:
+            await store.close()
+
+    async def test_set_decision_already_decided_returns_none(self, tmp_path):
+        """Second decision on an already-decided request returns None (atomic guard)."""
+        store = await self._make_store(tmp_path / "ar.db")
+        try:
+            record = await store.create(
+                identity_claim="agent-c",
+                framework="hermes",
+                requested_scopes=["memory:read"],
+            )
+            # First decision succeeds.
+            first = await store.set_decision(
+                record["id"], "accepted",
+                canonical_id="cid", token="tok",
+                granted_scopes=[], decided_by="admin",
+            )
+            assert first is not None
+            # Second decision returns None — already decided.
+            second = await store.set_decision(
+                record["id"], "refused",
+                decided_by="admin",
+            )
+            assert second is None
+        finally:
+            await store.close()
+
+    async def test_list_pending_only_returns_pending(self, tmp_path):
+        store = await self._make_store(tmp_path / "ar.db")
+        try:
+            r1 = await store.create(identity_claim="a", framework="f", requested_scopes=[])
+            r2 = await store.create(identity_claim="b", framework="f", requested_scopes=[])
+            r3 = await store.create(identity_claim="c", framework="f", requested_scopes=[])
+
+            # Decide r2.
+            await store.set_decision(r2["id"], "accepted",
+                                     canonical_id="cid", token="tok",
+                                     granted_scopes=[], decided_by="admin")
+
+            pending = await store.list_pending()
+            pending_ids = {r["id"] for r in pending}
+            assert r1["id"] in pending_ids
+            assert r3["id"] in pending_ids
+            assert r2["id"] not in pending_ids
+        finally:
+            await store.close()
+
+    async def test_count_pending_for(self, tmp_path):
+        store = await self._make_store(tmp_path / "ar.db")
+        try:
+            await store.create(identity_claim="agent-x", framework="hermes", requested_scopes=[])
+            await store.create(identity_claim="agent-x", framework="hermes", requested_scopes=[])
+            await store.create(identity_claim="agent-y", framework="hermes", requested_scopes=[])
+
+            assert await store.count_pending_for("agent-x", "hermes") == 2
+            assert await store.count_pending_for("agent-y", "hermes") == 1
+            assert await store.count_pending_for("nobody", "hermes") == 0
+        finally:
+            await store.close()
+
+    async def test_invalid_decision_status_raises(self, tmp_path):
+        store = await self._make_store(tmp_path / "ar.db")
+        try:
+            record = await store.create(
+                identity_claim="agent-d", framework="f", requested_scopes=[]
+            )
+            with pytest.raises(ValueError, match="accepted.*refused"):
+                await store.set_decision(record["id"], "pending", decided_by="admin")
+        finally:
+            await store.close()
+
+
+# ---------------------------------------------------------------------------
+# Route fixture — mirrors registry_client pattern
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture
+async def consent_client(app, tmp_data_dir):
+    """Async client with auth_requests + agent_grants + agent_registry stores
+    initialised, authenticated as admin.  Mirrors registry_client in
+    test_agent_registry.py.
+    """
+    # Init required stores (lifespan not running in tests)
+    registry_store = app.state.agent_registry
+    if registry_store._db is None:
+        await registry_store.init()
+
+    auth_requests = app.state.auth_requests
+    if auth_requests._db is None:
+        await auth_requests.init()
+
+    agent_grants = app.state.agent_grants
+    if agent_grants._db is None:
+        await agent_grants.init()
+
+    relationship_mgr = app.state.relationships
+    if relationship_mgr._db is None:
+        await relationship_mgr.init()
+
+    metrics_store = app.state.metrics
+    if metrics_store._db is None:
+        await metrics_store.init()
+
+    # Set up admin user + session
+    app.state.auth.setup_user("admin", "Test Admin", "", "testpass")
+    record = app.state.auth.find_user("admin")
+    uid = record["id"] if record else ""
+    token = app.state.auth.create_session(user_id=uid, long_lived=True)
+    app.state._startup_complete = True
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        cookies={"taos_session": token},
+    ) as c:
+        c._test_admin_uid = uid
+        yield c
+
+    await auth_requests.close()
+    await agent_grants.close()
+    await registry_store.close()
+    await relationship_mgr.close()
+    await metrics_store.close()
+
+
+@pytest_asyncio.fixture
+async def consent_client_nonadmin(app, tmp_data_dir):
+    """Async client authenticated as a non-admin member."""
+    registry_store = app.state.agent_registry
+    if registry_store._db is None:
+        await registry_store.init()
+
+    auth_requests = app.state.auth_requests
+    if auth_requests._db is None:
+        await auth_requests.init()
+
+    agent_grants = app.state.agent_grants
+    if agent_grants._db is None:
+        await agent_grants.init()
+
+    relationship_mgr = app.state.relationships
+    if relationship_mgr._db is None:
+        await relationship_mgr.init()
+
+    metrics_store = app.state.metrics
+    if metrics_store._db is None:
+        await metrics_store.init()
+
+    # Set up admin first (required by auth manager), then a member via invite.
+    auth_mgr = app.state.auth
+    auth_mgr.setup_user("admin", "Test Admin", "", "testpass")
+    invite_code = auth_mgr.add_user_invite("member", "admin")
+    auth_mgr.complete_invite("member", invite_code, "Test Member", "", "memberpass123")
+    member_record = auth_mgr.find_user("member")
+    member_uid = member_record["id"] if member_record else ""
+    member_token = auth_mgr.create_session(user_id=member_uid, long_lived=True)
+    app.state._startup_complete = True
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        cookies={"taos_session": member_token},
+    ) as c:
+        yield c
+
+    await auth_requests.close()
+    await agent_grants.close()
+    await registry_store.close()
+    await relationship_mgr.close()
+    await metrics_store.close()
+
+
+# ---------------------------------------------------------------------------
+# Route tests
+# ---------------------------------------------------------------------------
+
+_CREATE_BODY = {
+    "identity_claim": "my-external-agent",
+    "framework": "hermes",
+    "requested_scopes": ["memory:read", "memory:write"],
+    "reason": "I need access to memory for context",
+}
+
+
+@pytest.mark.asyncio
+class TestAuthRequestRoutes:
+
+    async def test_create_no_auth_returns_pending(self, consent_client):
+        """POST with no auth must succeed (EXEMPT path) and return pending."""
+        # Use a bare client without cookies to confirm no-auth path works.
+        transport = ASGITransport(app=consent_client._transport.app)
+        async with AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as bare:
+            resp = await bare.post("/api/agents/auth-requests", json=_CREATE_BODY)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "request_id" in data
+        assert data["status"] == "pending"
+
+    async def test_get_status_pending_no_token(self, consent_client):
+        """GET status on a pending request returns status but NOT a token."""
+        transport = ASGITransport(app=consent_client._transport.app)
+        async with AsyncClient(transport=transport, base_url="http://test") as bare:
+            create_resp = await bare.post("/api/agents/auth-requests", json=_CREATE_BODY)
+            request_id = create_resp.json()["request_id"]
+            status_resp = await bare.get(f"/api/agents/auth-requests/{request_id}")
+        assert status_resp.status_code == 200
+        data = status_resp.json()
+        assert data["status"] == "pending"
+        assert "token" not in data
+        assert "canonical_id" not in data
+
+    async def test_approve_mints_identity_and_grants(self, consent_client):
+        """Admin approve → canonical_id minted + grants recorded + status accepted."""
+        transport = ASGITransport(app=consent_client._transport.app)
+        async with AsyncClient(transport=transport, base_url="http://test") as bare:
+            create_resp = await bare.post("/api/agents/auth-requests", json=_CREATE_BODY)
+            request_id = create_resp.json()["request_id"]
+
+        resp = await consent_client.post(
+            f"/api/agents/auth-requests/{request_id}/approve",
+            json={"granted_scopes": ["memory:read"]},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "accepted"
+        assert "canonical_id" in data
+        canonical_id = data["canonical_id"]
+
+        # Check grants were written.
+        grants = await consent_client._transport.app.state.agent_grants.list_grants(canonical_id)
+        assert any(g["scope"] == "memory:read" for g in grants)
+
+        # Token not returned by approve endpoint — only by the status poll.
+        assert "token" not in data
+
+    async def test_get_status_accepted_returns_token(self, consent_client):
+        """After accept, status poll returns canonical_id and token."""
+        transport = ASGITransport(app=consent_client._transport.app)
+        async with AsyncClient(transport=transport, base_url="http://test") as bare:
+            create_resp = await bare.post("/api/agents/auth-requests", json=_CREATE_BODY)
+            request_id = create_resp.json()["request_id"]
+
+        await consent_client.post(
+            f"/api/agents/auth-requests/{request_id}/approve",
+            json={"granted_scopes": ["memory:read"]},
+        )
+
+        # Poll status as the external agent would (no auth).
+        async with AsyncClient(transport=transport, base_url="http://test") as bare:
+            status_resp = await bare.get(f"/api/agents/auth-requests/{request_id}")
+        assert status_resp.status_code == 200
+        data = status_resp.json()
+        assert data["status"] == "accepted"
+        assert "canonical_id" in data
+        assert "token" in data
+        # Token must look like a JWT (3 dot-separated parts).
+        assert data["token"].count(".") == 2
+
+    async def test_non_admin_approve_returns_403(self, consent_client_nonadmin):
+        """Non-admin calling approve must get 403."""
+        # First create a request via the nonadmin client (still works — EXEMPT).
+        transport = ASGITransport(app=consent_client_nonadmin._transport.app)
+        async with AsyncClient(transport=transport, base_url="http://test") as bare:
+            create_resp = await bare.post("/api/agents/auth-requests", json=_CREATE_BODY)
+            request_id = create_resp.json()["request_id"]
+
+        resp = await consent_client_nonadmin.post(
+            f"/api/agents/auth-requests/{request_id}/approve",
+            json={"granted_scopes": ["memory:read"]},
+        )
+        assert resp.status_code == 403
+
+    async def test_approve_unknown_request_returns_404(self, consent_client):
+        resp = await consent_client.post(
+            "/api/agents/auth-requests/doesnotexist/approve",
+            json={"granted_scopes": []},
+        )
+        assert resp.status_code == 404
+
+    async def test_approve_already_decided_returns_409(self, consent_client):
+        transport = ASGITransport(app=consent_client._transport.app)
+        async with AsyncClient(transport=transport, base_url="http://test") as bare:
+            create_resp = await bare.post("/api/agents/auth-requests", json=_CREATE_BODY)
+            request_id = create_resp.json()["request_id"]
+
+        # First approve succeeds.
+        await consent_client.post(
+            f"/api/agents/auth-requests/{request_id}/approve",
+            json={"granted_scopes": ["memory:read"]},
+        )
+        # Second approve → 409 (already decided).
+        resp2 = await consent_client.post(
+            f"/api/agents/auth-requests/{request_id}/approve",
+            json={"granted_scopes": ["memory:read"]},
+        )
+        assert resp2.status_code == 409
+
+    async def test_deny_returns_refused(self, consent_client):
+        transport = ASGITransport(app=consent_client._transport.app)
+        async with AsyncClient(transport=transport, base_url="http://test") as bare:
+            create_resp = await bare.post("/api/agents/auth-requests", json=_CREATE_BODY)
+            request_id = create_resp.json()["request_id"]
+
+        resp = await consent_client.post(
+            f"/api/agents/auth-requests/{request_id}/deny"
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "refused"
+
+        # Poll confirms refused — and no token.
+        async with AsyncClient(transport=transport, base_url="http://test") as bare:
+            status_resp = await bare.get(f"/api/agents/auth-requests/{request_id}")
+        assert status_resp.json()["status"] == "refused"
+        assert "token" not in status_resp.json()
+
+    async def test_deny_already_decided_returns_409(self, consent_client):
+        transport = ASGITransport(app=consent_client._transport.app)
+        async with AsyncClient(transport=transport, base_url="http://test") as bare:
+            create_resp = await bare.post("/api/agents/auth-requests", json=_CREATE_BODY)
+            request_id = create_resp.json()["request_id"]
+
+        await consent_client.post(f"/api/agents/auth-requests/{request_id}/deny")
+        resp2 = await consent_client.post(f"/api/agents/auth-requests/{request_id}/deny")
+        assert resp2.status_code == 409
+
+    async def test_abuse_cap_returns_429(self, consent_client):
+        """Submitting more than _PENDING_CAP requests from the same identity → 429."""
+        from tinyagentos.routes.agent_auth_requests import _PENDING_CAP
+
+        transport = ASGITransport(app=consent_client._transport.app)
+        async with AsyncClient(transport=transport, base_url="http://test") as bare:
+            for _ in range(_PENDING_CAP):
+                r = await bare.post(
+                    "/api/agents/auth-requests",
+                    json={**_CREATE_BODY, "identity_claim": "flood-agent"},
+                )
+                assert r.status_code == 200
+
+            # The (_PENDING_CAP + 1)th request must be rate-limited.
+            r = await bare.post(
+                "/api/agents/auth-requests",
+                json={**_CREATE_BODY, "identity_claim": "flood-agent"},
+            )
+            assert r.status_code == 429
+
+    async def test_list_pending_admin(self, consent_client):
+        transport = ASGITransport(app=consent_client._transport.app)
+        async with AsyncClient(transport=transport, base_url="http://test") as bare:
+            await bare.post("/api/agents/auth-requests", json=_CREATE_BODY)
+            await bare.post("/api/agents/auth-requests",
+                            json={**_CREATE_BODY, "identity_claim": "agent-2"})
+
+        resp = await consent_client.get("/api/agents/auth-requests")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "requests" in data
+        assert len(data["requests"]) >= 2
+
+    async def test_list_pending_nonadmin_returns_403(self, consent_client_nonadmin):
+        resp = await consent_client_nonadmin.get("/api/agents/auth-requests")
+        assert resp.status_code == 403
+
+    async def test_get_status_unknown_returns_404(self, consent_client):
+        transport = ASGITransport(app=consent_client._transport.app)
+        async with AsyncClient(transport=transport, base_url="http://test") as bare:
+            resp = await bare.get("/api/agents/auth-requests/no-such-id")
+        assert resp.status_code == 404

--- a/tinyagentos/agent_grants_store.py
+++ b/tinyagentos/agent_grants_store.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+"""Store for per-agent scope grants minted by the consent loop.
+
+A grant records that an admin approved a specific scope for an external agent.
+Phase 1 only writes tier='once' (single-decision, no expiry); the full
+permission-tier system (time-boxed, project-scoped, always-allow, always-block)
+is Phase 2, built on top of this table.
+
+The Permissions app and the A2A bus read this table to check what an agent
+may do.  ``list_active_grants`` is the feed @taOSmd polls later.
+"""
+
+import json
+from datetime import datetime, timezone
+from typing import Optional
+
+import aiosqlite
+
+from tinyagentos.base_store import BaseStore
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS agent_grants (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    canonical_id TEXT    NOT NULL,
+    scope        TEXT    NOT NULL,
+    tier         TEXT    NOT NULL DEFAULT 'once',
+    project_id   TEXT,
+    granted_at   TEXT    NOT NULL,
+    expires_at   TEXT,
+    UNIQUE (canonical_id, scope)
+);
+"""
+
+
+def _row_to_dict(row: aiosqlite.Row) -> dict:
+    return {k: row[k] for k in row.keys()}
+
+
+class AgentGrantsStore(BaseStore):
+    """Persistent store for per-agent scope grants."""
+
+    SCHEMA = SCHEMA
+
+    async def init(self) -> None:
+        await super().init()
+        if self._db is not None:
+            self._db.row_factory = aiosqlite.Row
+
+    # ------------------------------------------------------------------
+    # Write
+    # ------------------------------------------------------------------
+
+    async def add_grant(
+        self,
+        canonical_id: str,
+        scope: str,
+        *,
+        tier: str = "once",
+        project_id: Optional[str] = None,
+        expires_at: Optional[str] = None,
+    ) -> dict:
+        """Insert or replace a grant for (canonical_id, scope).
+
+        Uses INSERT OR REPLACE so re-approving a scope is idempotent.
+        """
+        if self._db is None:
+            raise RuntimeError("AgentGrantsStore not initialised — call init() first")
+
+        now = datetime.now(timezone.utc).isoformat()
+        await self._db.execute(
+            """
+            INSERT OR REPLACE INTO agent_grants
+                (canonical_id, scope, tier, project_id, granted_at, expires_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (canonical_id, scope, tier, project_id, now, expires_at),
+        )
+        await self._db.commit()
+        row = await (
+            await self._db.execute(
+                "SELECT * FROM agent_grants WHERE canonical_id = ? AND scope = ?",
+                (canonical_id, scope),
+            )
+        ).fetchone()
+        return _row_to_dict(row)  # type: ignore[return-value]
+
+    # ------------------------------------------------------------------
+    # Read
+    # ------------------------------------------------------------------
+
+    async def list_grants(self, canonical_id: str) -> list[dict]:
+        """Return all grants for *canonical_id*."""
+        if self._db is None:
+            raise RuntimeError("AgentGrantsStore not initialised")
+        cursor = await self._db.execute(
+            "SELECT * FROM agent_grants WHERE canonical_id = ? ORDER BY granted_at",
+            (canonical_id,),
+        )
+        return [_row_to_dict(r) for r in await cursor.fetchall()]
+
+    async def list_active_grants(self) -> list[dict]:
+        """Return all grants that are not yet expired.
+
+        Phase 1: no expiry is set (expires_at IS NULL), so every row is active.
+        Phase 2: add WHERE (expires_at IS NULL OR expires_at > now).
+        """
+        if self._db is None:
+            raise RuntimeError("AgentGrantsStore not initialised")
+        now = datetime.now(timezone.utc).isoformat()
+        cursor = await self._db.execute(
+            "SELECT * FROM agent_grants "
+            "WHERE expires_at IS NULL OR expires_at > ? "
+            "ORDER BY canonical_id, scope",
+            (now,),
+        )
+        return [_row_to_dict(r) for r in await cursor.fetchall()]

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -245,6 +245,11 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     agent_registry_store = AgentRegistryStore(data_dir / "agent_registry.db")
     agent_registry_keypair = load_or_create_signing_keypair(data_dir)
 
+    from tinyagentos.auth_requests_store import AuthRequestsStore
+    auth_requests_store = AuthRequestsStore(data_dir / "auth_requests.db")
+    from tinyagentos.agent_grants_store import AgentGrantsStore
+    agent_grants_store = AgentGrantsStore(data_dir / "agent_grants.db")
+
     metrics_store = MetricsStore(data_dir / "metrics.db")
     notif_store = NotificationStore(data_dir / "notifications.db")
     mcp_store = MCPServerStore(data_dir / "mcp.db")
@@ -371,6 +376,10 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await agent_registry_store.init()
         app.state.agent_registry = agent_registry_store
         app.state.agent_registry_keypair = agent_registry_keypair
+        await auth_requests_store.init()
+        app.state.auth_requests = auth_requests_store
+        await agent_grants_store.init()
+        app.state.agent_grants = agent_grants_store
         await metrics_store.init()
         await notif_store.init()
         await qmd_client.init()
@@ -1089,6 +1098,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await metrics_store.close()
         await qmd_client.close()
         await http_client.aclose()
+        await agent_grants_store.close()
+        await auth_requests_store.close()
         await agent_registry_store.close()
 
     app = FastAPI(title="TinyAgentOS", version="0.1.0", lifespan=lifespan)
@@ -1230,6 +1241,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     # ensures attribute-existence checks work during the pre-startup window.
     app.state.agent_registry = agent_registry_store
     app.state.agent_registry_keypair = agent_registry_keypair
+    app.state.auth_requests = auth_requests_store
+    app.state.agent_grants = agent_grants_store
 
     # Detect and set container runtime (eager, so tests work without lifespan)
     try:

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -26,6 +26,37 @@ EXEMPT_PATHS = {"/auth/login", "/auth/setup", "/auth/status", "/auth/me", "/auth
 # check is the authoritative guard for all WebSocket endpoints.
 EXEMPT_PREFIXES = ("/static/", "/desktop/", "/chat-pwa/", "/ws/", "/shortcut/")
 
+# Consent-loop status-poll paths are unauthenticated (the opaque request_id is
+# the capability), but the sub-action paths (/approve, /deny) require admin
+# auth.  We exempt GET requests to /api/agents/auth-requests/<id> specifically
+# so the external agent can poll without credentials, while ensuring that POST
+# requests to /approve and /deny still require a session cookie.
+_AUTH_REQUEST_BASE = "/api/agents/auth-requests"
+_AUTH_REQUEST_PREFIX = "/api/agents/auth-requests/"
+
+
+def _is_exempt(method: str, path: str) -> bool:
+    """Return True if this request should bypass the auth gate.
+
+    Consent-loop exemptions (method-sensitive):
+      POST /api/agents/auth-requests          — create request, no auth needed
+      GET  /api/agents/auth-requests/{id}     — status poll, no auth needed
+      POST /api/agents/auth-requests/{id}/approve|deny — admin only, NOT exempt
+      GET  /api/agents/auth-requests          — list (admin), NOT exempt
+    """
+    if path in EXEMPT_PATHS or any(path.startswith(p) for p in EXEMPT_PREFIXES):
+        return True
+    # POST /api/agents/auth-requests (exact) — external agent creates a request.
+    if method == "POST" and path == _AUTH_REQUEST_BASE:
+        return True
+    # GET /api/agents/auth-requests/<id> — status poll; only when there's a
+    # single path segment after the prefix (no further slashes → not a subaction).
+    if method == "GET" and path.startswith(_AUTH_REQUEST_PREFIX):
+        tail = path[len(_AUTH_REQUEST_PREFIX):]
+        if tail and "/" not in tail:
+            return True
+    return False
+
 
 class AuthMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
@@ -36,7 +67,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
         # endpoints, cluster heartbeat). Without this, a cached old client
         # could bypass onboarding by hitting an /api endpoint that the
         # not-configured branch used to allow through unconditionally.
-        if path in EXEMPT_PATHS or any(path.startswith(p) for p in EXEMPT_PREFIXES):
+        if _is_exempt(request.method, path):
             request.state.user_id = None
             request.state.is_admin = False
             request.state.via = "exempt"

--- a/tinyagentos/auth_requests_store.py
+++ b/tinyagentos/auth_requests_store.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+"""Store for external-agent consent / auth-request records.
+
+Each record tracks one inbound access request from an external agent.
+Pending requests wait for an admin to accept or deny; accepted requests
+carry the minted canonical_id and signed JWT token so the agent can poll
+and retrieve them.
+
+The state machine is simple: pending → accepted | refused (terminal).
+``set_decision`` is atomic — it uses a conditional UPDATE that only
+matches rows still in ``pending`` status, so two concurrent approve calls
+cannot both win a read-check-then-write race.
+"""
+
+import json
+import uuid
+from datetime import datetime, timezone
+from typing import Optional
+
+import aiosqlite
+
+from tinyagentos.base_store import BaseStore
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS auth_requests (
+    id              TEXT PRIMARY KEY,
+    identity_claim  TEXT NOT NULL DEFAULT '',
+    framework       TEXT NOT NULL DEFAULT '',
+    requested_scopes  TEXT NOT NULL DEFAULT '[]',
+    requested_skills  TEXT NOT NULL DEFAULT '[]',
+    reason          TEXT NOT NULL DEFAULT '',
+    duration_secs   INTEGER,
+    project_id      TEXT,
+    status          TEXT NOT NULL DEFAULT 'pending',
+    canonical_id    TEXT,
+    token           TEXT,
+    granted_scopes  TEXT,
+    created_ts      TEXT NOT NULL,
+    decided_ts      TEXT,
+    decided_by      TEXT
+);
+"""
+
+_VALID_DECISION_STATUSES = frozenset({"accepted", "refused"})
+
+
+def _row_to_dict(row: aiosqlite.Row) -> dict:
+    d = {k: row[k] for k in row.keys()}
+    for field in ("requested_scopes", "requested_skills", "granted_scopes"):
+        raw = d.get(field)
+        if raw is not None:
+            try:
+                d[field] = json.loads(raw)
+            except (ValueError, TypeError):
+                d[field] = []
+        else:
+            d[field] = None if field == "granted_scopes" else []
+    return d
+
+
+class AuthRequestsStore(BaseStore):
+    """Persistent store for external-agent auth requests."""
+
+    SCHEMA = SCHEMA
+
+    async def init(self) -> None:
+        await super().init()
+        if self._db is not None:
+            self._db.row_factory = aiosqlite.Row
+
+    # ------------------------------------------------------------------
+    # Write
+    # ------------------------------------------------------------------
+
+    async def create(
+        self,
+        *,
+        identity_claim: str,
+        framework: str,
+        requested_scopes: list[str],
+        requested_skills: Optional[list[str]] = None,
+        reason: str = "",
+        duration_secs: Optional[int] = None,
+        project_id: Optional[str] = None,
+    ) -> dict:
+        """Create a new pending auth request. Returns the full record."""
+        if self._db is None:
+            raise RuntimeError("AuthRequestsStore not initialised — call init() first")
+
+        request_id = uuid.uuid4().hex
+        now = datetime.now(timezone.utc).isoformat()
+
+        await self._db.execute(
+            """
+            INSERT INTO auth_requests
+                (id, identity_claim, framework, requested_scopes, requested_skills,
+                 reason, duration_secs, project_id, status, created_ts)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?)
+            """,
+            (
+                request_id,
+                identity_claim,
+                framework,
+                json.dumps(requested_scopes),
+                json.dumps(requested_skills or []),
+                reason,
+                duration_secs,
+                project_id,
+                now,
+            ),
+        )
+        await self._db.commit()
+        return await self.get(request_id)  # type: ignore[return-value]
+
+    async def set_decision(
+        self,
+        request_id: str,
+        status: str,
+        *,
+        canonical_id: Optional[str] = None,
+        token: Optional[str] = None,
+        granted_scopes: Optional[list[str]] = None,
+        decided_by: str,
+    ) -> Optional[dict]:
+        """Atomically transition a pending request to accepted or refused.
+
+        Returns the updated record on success, or ``None`` if the row was
+        already decided (rowcount == 0 from the conditional UPDATE).
+        Raises ``ValueError`` for an invalid target status.
+        """
+        if self._db is None:
+            raise RuntimeError("AuthRequestsStore not initialised")
+        if status not in _VALID_DECISION_STATUSES:
+            raise ValueError(f"status must be 'accepted' or 'refused', got {status!r}")
+
+        now = datetime.now(timezone.utc).isoformat()
+        granted_json = json.dumps(granted_scopes) if granted_scopes is not None else None
+
+        cur = await self._db.execute(
+            """
+            UPDATE auth_requests
+               SET status       = ?,
+                   canonical_id = ?,
+                   token        = ?,
+                   granted_scopes = ?,
+                   decided_ts   = ?,
+                   decided_by   = ?
+             WHERE id = ? AND status = 'pending'
+            """,
+            (status, canonical_id, token, granted_json, now, decided_by, request_id),
+        )
+        await self._db.commit()
+
+        if cur.rowcount == 0:
+            # Already decided — caller should treat as conflict.
+            return None
+
+        return await self.get(request_id)
+
+    # ------------------------------------------------------------------
+    # Read
+    # ------------------------------------------------------------------
+
+    async def get(self, request_id: str) -> Optional[dict]:
+        """Return the record for *request_id*, or ``None``."""
+        if self._db is None:
+            raise RuntimeError("AuthRequestsStore not initialised")
+        row = await (
+            await self._db.execute(
+                "SELECT * FROM auth_requests WHERE id = ?", (request_id,)
+            )
+        ).fetchone()
+        return _row_to_dict(row) if row else None
+
+    async def list_pending(self) -> list[dict]:
+        """Return all pending auth requests, oldest first."""
+        if self._db is None:
+            raise RuntimeError("AuthRequestsStore not initialised")
+        cursor = await self._db.execute(
+            "SELECT * FROM auth_requests WHERE status = 'pending' ORDER BY created_ts"
+        )
+        rows = await cursor.fetchall()
+        return [_row_to_dict(r) for r in rows]
+
+    async def count_pending_for(self, identity_claim: str, framework: str) -> int:
+        """Return the number of pending requests for a given identity+framework pair."""
+        if self._db is None:
+            raise RuntimeError("AuthRequestsStore not initialised")
+        row = await (
+            await self._db.execute(
+                "SELECT COUNT(*) FROM auth_requests "
+                "WHERE identity_claim = ? AND framework = ? AND status = 'pending'",
+                (identity_claim, framework),
+            )
+        ).fetchone()
+        return row[0] if row else 0

--- a/tinyagentos/auth_requests_store.py
+++ b/tinyagentos/auth_requests_store.py
@@ -111,7 +111,10 @@ class AuthRequestsStore(BaseStore):
             ),
         )
         await self._db.commit()
-        return await self.get(request_id)  # type: ignore[return-value]
+        record = await self.get(request_id)
+        if record is None:
+            raise RuntimeError(f"auth_request {request_id!r} missing immediately after insert")
+        return record
 
     async def set_decision(
         self,

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -19,6 +19,11 @@ def register_all_routers(app):
     from tinyagentos.routes.agent_registry import router as agent_registry_router
     app.include_router(agent_registry_router)
 
+    # Consent loop — registered before /api/agents/{name} so that
+    # /api/agents/auth-requests/* paths are not captured as an agent name.
+    from tinyagentos.routes.agent_auth_requests import router as agent_auth_requests_router
+    app.include_router(agent_auth_requests_router)
+
     from tinyagentos.routes.agents import router as agents_router
     app.include_router(agents_router)
 

--- a/tinyagentos/routes/agent_auth_requests.py
+++ b/tinyagentos/routes/agent_auth_requests.py
@@ -20,6 +20,7 @@ Security notes
   further submissions receive 429.
 """
 
+import asyncio
 import logging
 from typing import Optional
 
@@ -94,6 +95,17 @@ def _get_relationships(request: Request):
     if rel is None:
         raise RuntimeError("relationships manager not on app.state")
     return rel
+
+
+def _get_approve_lock(request: Request, request_id: str) -> asyncio.Lock:
+    """Per-request-id lock preventing concurrent approve races."""
+    locks = getattr(request.app.state, "_approve_locks", None)
+    if locks is None:
+        request.app.state._approve_locks = {}
+        locks = request.app.state._approve_locks
+    if request_id not in locks:
+        locks[request_id] = asyncio.Lock()
+    return locks[request_id]
 
 
 # ---------------------------------------------------------------------------
@@ -179,6 +191,14 @@ async def approve_auth_request(
     if not user.is_admin:
         raise HTTPException(status_code=403, detail="forbidden")
 
+    # Serialise concurrent approvals for the same request to prevent orphaned
+    # registry entries and duplicate grants from a TOCTOU race.
+    async with _get_approve_lock(request, request_id):
+        return await _do_approve(request, request_id, body, user)
+
+
+async def _do_approve(request: Request, request_id: str, body: ApproveBody, user):
+    """Inner approve logic — called under a per-request lock."""
     auth_store = _get_auth_requests_store(request)
     record = await auth_store.get(request_id)
     if record is None:
@@ -291,11 +311,16 @@ async def list_auth_requests(
     """List pending auth requests (admin only).
 
     This is the feed the desktop notification / Permissions app reads.
-    The ?status= filter defaults to 'pending'; pass status=all for every record
-    (not yet implemented — Phase 1 only needs the pending feed).
+    Phase 1 only supports status=pending (the default).
     """
     if not user.is_admin:
         raise HTTPException(status_code=403, detail="forbidden")
+
+    if status is not None and status != "pending":
+        raise HTTPException(
+            status_code=400,
+            detail=f"status={status!r} is not supported in Phase 1; omit or pass status=pending",
+        )
 
     store = _get_auth_requests_store(request)
     pending = await store.list_pending()

--- a/tinyagentos/routes/agent_auth_requests.py
+++ b/tinyagentos/routes/agent_auth_requests.py
@@ -204,6 +204,12 @@ async def approve_auth_request(
     )
     canonical_id = reg_record["canonical_id"]
 
+    # Consent approval IS the activation. external-selfjoin agents are born
+    # 'pending' (governance lifecycle); approving the auth-request transitions
+    # them to 'active' so they are NOT in the bus inactive/revocation feed and
+    # @taOSmd's identity-AND-grant gate accepts them.
+    await registry.set_status(canonical_id, "active", actor=user.user_id)
+
     # Issue the identity token.
     token = mint_registry_token(
         canonical_id,

--- a/tinyagentos/routes/agent_auth_requests.py
+++ b/tinyagentos/routes/agent_auth_requests.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+"""Routes for the external-agent consent loop (Phase 1).
+
+POST   /api/agents/auth-requests                       — submit an access request (EXEMPT, no auth)
+GET    /api/agents/auth-requests/{request_id}          — poll request status (EXEMPT, opaque-id cap)
+POST   /api/agents/auth-requests/{request_id}/approve  — approve + mint identity (admin only)
+POST   /api/agents/auth-requests/{request_id}/deny     — deny the request (admin only)
+GET    /api/agents/auth-requests                       — list pending requests (admin only)
+
+The two public endpoints (create + status poll) are added to auth_middleware.EXEMPT_PATHS
+so unauthenticated external agents can reach them.  The opaque UUID request_id acts as a
+capability token for the poll endpoint — only the caller who received the id can poll it.
+
+Security notes
+--------------
+* The token field is returned ONLY on status == 'accepted'.
+* Admin gate on approve / deny / list — checked via current_user + is_admin flag.
+* Abuse cap: at most _PENDING_CAP pending requests per (identity_claim, framework) pair;
+  further submissions receive 429.
+"""
+
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from tinyagentos.agent_registry_store import mint_registry_token
+from tinyagentos.auth_context import CurrentUser, current_user
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+# Maximum number of unresolved pending requests allowed from the same
+# identity_claim + framework before new submissions are rate-limited.
+_PENDING_CAP = 5
+
+
+# ---------------------------------------------------------------------------
+# Request bodies
+# ---------------------------------------------------------------------------
+
+class CreateAuthRequest(BaseModel):
+    identity_claim: str
+    framework: str
+    requested_scopes: list[str]
+    requested_skills: Optional[list[str]] = None
+    reason: str = ""
+    duration_secs: Optional[int] = None
+    project_id: Optional[str] = None
+
+
+class ApproveBody(BaseModel):
+    granted_scopes: list[str]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _get_auth_requests_store(request: Request):
+    store = getattr(request.app.state, "auth_requests", None)
+    if store is None:
+        raise RuntimeError("auth_requests store not on app.state")
+    return store
+
+
+def _get_grants_store(request: Request):
+    store = getattr(request.app.state, "agent_grants", None)
+    if store is None:
+        raise RuntimeError("agent_grants store not on app.state")
+    return store
+
+
+def _get_registry_store(request: Request):
+    store = getattr(request.app.state, "agent_registry", None)
+    if store is None:
+        raise RuntimeError("agent_registry store not on app.state")
+    return store
+
+
+def _get_keypair(request: Request) -> tuple[bytes, bytes]:
+    kp = getattr(request.app.state, "agent_registry_keypair", None)
+    if kp is None:
+        raise RuntimeError("agent_registry_keypair not on app.state")
+    return kp
+
+
+def _get_relationships(request: Request):
+    rel = getattr(request.app.state, "relationships", None)
+    if rel is None:
+        raise RuntimeError("relationships manager not on app.state")
+    return rel
+
+
+# ---------------------------------------------------------------------------
+# Routes — public (EXEMPT)
+# ---------------------------------------------------------------------------
+
+@router.post("/api/agents/auth-requests")
+async def create_auth_request(request: Request, body: CreateAuthRequest):
+    """Submit an access request from an external agent.
+
+    No authentication required — the agent has no credentials yet.
+    Returns {request_id, status: 'pending'}.
+    """
+    store = _get_auth_requests_store(request)
+
+    # Abuse cap: reject if too many pending requests from the same identity.
+    pending_count = await store.count_pending_for(
+        body.identity_claim, body.framework
+    )
+    if pending_count >= _PENDING_CAP:
+        raise HTTPException(
+            status_code=429,
+            detail=(
+                f"too many pending requests from identity {body.identity_claim!r} "
+                f"({pending_count} pending; resolve existing requests first)"
+            ),
+        )
+
+    record = await store.create(
+        identity_claim=body.identity_claim,
+        framework=body.framework,
+        requested_scopes=body.requested_scopes,
+        requested_skills=body.requested_skills,
+        reason=body.reason,
+        duration_secs=body.duration_secs,
+        project_id=body.project_id,
+    )
+    return {"request_id": record["id"], "status": "pending"}
+
+
+@router.get("/api/agents/auth-requests/{request_id}")
+async def get_auth_request_status(request: Request, request_id: str):
+    """Poll the status of a consent request.
+
+    No authentication required — the opaque request_id acts as a capability.
+    Returns {status} on pending/refused, and additionally {canonical_id, token}
+    once the request is accepted.
+    """
+    store = _get_auth_requests_store(request)
+    record = await store.get(request_id)
+    if record is None:
+        raise HTTPException(status_code=404, detail="request not found")
+
+    result: dict = {"status": record["status"]}
+    if record["status"] == "accepted":
+        result["canonical_id"] = record["canonical_id"]
+        result["token"] = record["token"]
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Routes — authenticated (admin only)
+# ---------------------------------------------------------------------------
+
+@router.post("/api/agents/auth-requests/{request_id}/approve")
+async def approve_auth_request(
+    request: Request,
+    request_id: str,
+    body: ApproveBody,
+    user: CurrentUser = Depends(current_user),
+):
+    """Approve a pending consent request and mint an agent identity.
+
+    Flow:
+    1. Load the pending request (404/409 guard).
+    2. Register the agent in the registry → canonical_id.
+    3. Issue a signed EdDSA JWT token.
+    4. Write per-scope grants (RelationshipManager edge + AgentGrantsStore).
+    5. Atomically mark the request accepted with canonical_id + token.
+
+    Returns {status: 'accepted', canonical_id}.
+    """
+    if not user.is_admin:
+        raise HTTPException(status_code=403, detail="forbidden")
+
+    auth_store = _get_auth_requests_store(request)
+    record = await auth_store.get(request_id)
+    if record is None:
+        raise HTTPException(status_code=404, detail="request not found")
+    if record["status"] != "pending":
+        raise HTTPException(
+            status_code=409,
+            detail=f"request is already {record['status']!r}; cannot approve",
+        )
+
+    registry = _get_registry_store(request)
+    private_pem, _public_pem = _get_keypair(request)
+    grants_store = _get_grants_store(request)
+    rel_mgr = _get_relationships(request)
+
+    # Mint canonical identity in the registry.
+    reg_record = await registry.register(
+        framework=record["framework"],
+        display_name=record["identity_claim"],
+        user_id=user.user_id,
+        origin="external-selfjoin",
+        handle="",
+    )
+    canonical_id = reg_record["canonical_id"]
+
+    # Issue the identity token.
+    token = mint_registry_token(
+        canonical_id,
+        private_pem,
+        user_id=user.user_id,
+        framework=record["framework"],
+    )
+
+    # Record grants for each approved scope.
+    for scope in body.granted_scopes:
+        await grants_store.add_grant(canonical_id, scope, tier="once")
+        # Also write a RelationshipManager permission edge so the existing
+        # permission-check path (can_communicate etc.) is aware of the agent.
+        await rel_mgr.set_permission(canonical_id, "taos-instance", scope)
+
+    # Atomically commit the decision.
+    result = await auth_store.set_decision(
+        request_id,
+        "accepted",
+        canonical_id=canonical_id,
+        token=token,
+        granted_scopes=body.granted_scopes,
+        decided_by=user.user_id,
+    )
+    if result is None:
+        # Another concurrent approve beat us — 409.
+        raise HTTPException(
+            status_code=409,
+            detail="request was decided concurrently; check current status",
+        )
+
+    return {"status": "accepted", "canonical_id": canonical_id}
+
+
+@router.post("/api/agents/auth-requests/{request_id}/deny")
+async def deny_auth_request(
+    request: Request,
+    request_id: str,
+    user: CurrentUser = Depends(current_user),
+):
+    """Deny a pending consent request (admin only).
+
+    Denial is recorded as 'refused'.  Per the spec it is reversible in
+    Phase 2 — for now the request simply stays in the DB with status refused.
+    """
+    if not user.is_admin:
+        raise HTTPException(status_code=403, detail="forbidden")
+
+    store = _get_auth_requests_store(request)
+    record = await store.get(request_id)
+    if record is None:
+        raise HTTPException(status_code=404, detail="request not found")
+    if record["status"] != "pending":
+        raise HTTPException(
+            status_code=409,
+            detail=f"request is already {record['status']!r}; cannot deny",
+        )
+
+    result = await store.set_decision(
+        request_id,
+        "refused",
+        decided_by=user.user_id,
+    )
+    if result is None:
+        raise HTTPException(
+            status_code=409,
+            detail="request was decided concurrently; check current status",
+        )
+
+    return {"status": "refused"}
+
+
+@router.get("/api/agents/auth-requests")
+async def list_auth_requests(
+    request: Request,
+    status: Optional[str] = "pending",
+    user: CurrentUser = Depends(current_user),
+):
+    """List pending auth requests (admin only).
+
+    This is the feed the desktop notification / Permissions app reads.
+    The ?status= filter defaults to 'pending'; pass status=all for every record
+    (not yet implemented — Phase 1 only needs the pending feed).
+    """
+    if not user.is_admin:
+        raise HTTPException(status_code=403, detail="forbidden")
+
+    store = _get_auth_requests_store(request)
+    pending = await store.list_pending()
+    return {"requests": pending}

--- a/tinyagentos/routes/agent_registry.py
+++ b/tinyagentos/routes/agent_registry.py
@@ -6,6 +6,7 @@ POST   /api/agents/registry/register         — register an agent, mint canonic
 GET    /api/agents/registry/pubkey           — public key for token verification (exempt, no auth)
 GET    /api/agents/registry/revoked          — global revocation feed (admin/local-token only)
 GET    /api/agents/registry/inactive         — all non-active entries for the bus (admin only)
+GET    /api/agents/registry/grants           — active grant feed for @taOSmd enforcement (admin only)
 GET    /api/agents/registry                  — list registry entries (admin: all; member: own)
 GET    /api/agents/registry/{id}             — read a single entry (owner or admin; else 404)
 DELETE /api/agents/registry/{id}             — revoke an entry (owner or admin)
@@ -67,6 +68,13 @@ def _get_store(request: Request):
     store = getattr(request.app.state, "agent_registry", None)
     if store is None:
         raise RuntimeError("agent_registry store not on app.state")
+    return store
+
+
+def _get_grants_store(request: Request):
+    store = getattr(request.app.state, "agent_grants", None)
+    if store is None:
+        raise RuntimeError("agent_grants store not on app.state")
     return store
 
 
@@ -195,6 +203,32 @@ async def list_inactive_entries(
         raise HTTPException(status_code=403, detail="forbidden")
     store = _get_store(request)
     return {"inactive": await store.list_inactive()}
+
+
+@router.get("/api/agents/registry/grants")
+async def list_active_grants(
+    request: Request,
+    canonical_id: Optional[str] = None,
+    user: CurrentUser = Depends(current_user),
+):
+    """Return the active grant feed for A2A bus enforcement.
+
+    Response: {"grants": [{canonical_id, scope, tier, project_id, granted_at, expires_at}, ...]}
+
+    Admin only — @taOSmd polls this on interval to keep its local cache current.
+    Grants are active if expires_at IS NULL or expires_at > now (Phase 1: all
+    grants are non-expiring, so the full list is always returned).
+
+    Optional ``?canonical_id=`` filter narrows to a single agent.
+    """
+    if not user.is_admin:
+        raise HTTPException(status_code=403, detail="forbidden")
+    grants_store = _get_grants_store(request)
+    if canonical_id:
+        grants = await grants_store.list_grants(canonical_id)
+    else:
+        grants = await grants_store.list_active_grants()
+    return {"grants": grants}
 
 
 @router.get("/api/agents/registry")


### PR DESCRIPTION
**Phase 1 of the Trust & Comms Layer** (spec: `docs/superpowers/specs/2026-06-09-trust-comms-layer-design.md`) — the external-agent consent loop backend.

## What
- `auth_requests_store.py` — pending/accepted/refused requests; atomic `set_decision` (UPDATE…WHERE status='pending').
- `agent_grants_store.py` — minimal per-scope grants (`canonical_id, scope, tier, expires_at`); `list_active_grants()` for the feed @taOSmd polls.
- `routes/agent_auth_requests.py` — `POST /api/agents/auth-requests` (public — external agent's front door) + `GET .../{id}` status poll (public; token returned only on accepted) + `POST .../{id}/approve|deny` + `GET` list (**admin-only**). Approve flow: registry.register (mint canonical_id) → **set_status active** → mint EdDSA-JWT → grants → atomic accept.
- `auth_middleware.py` — method-sensitive `_is_exempt`: exempts only `POST` create + single-segment `GET` status; approve/deny/list require admin auth.

## Contract (confirmed w/ @taOSmd)
Token = identity-only (sub=canonical_id, user_id, iss=taos-registry); all tiering in the grant store/feed; bus gate = valid token AND active grant.

## Security review notes
- Exemption is method+path scoped — verified approve/deny/list are NOT exempt (subactions have `/` in tail; list has no trailing slash).
- Token only surfaced on `accepted` status; request_id is an opaque uuid capability.
- **Fix included:** consent-approve transitions the agent pending→active (else an approved agent would sit in the inactive feed and be rejected) — regression test added.

65 tests pass (20 new + registry + auth_context). Desktop notification UI (per-scope toggles, impeccable skill) is the next build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * External-agent consent workflow: submit auth requests, poll status, and admin approve/deny endpoints.
  * Persistent per-agent grants store and admin-visible active grants feed (with optional agent filtering).
  * Updated auth exemption rules so specific consent endpoints behave correctly for unauthenticated callers.

* **Tests**
  * Expanded end-to-end tests covering store behavior, HTTP routes, access control (403 for non-admin grants), grants-list filtering, rate limits, idempotency/conflict handling, and concurrent approvals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->