### PR TITLE
fix(memory): user-scope search pins a dedicated taOS index (not qmd's shared default)

### DIFF
--- a/tests/test_routes_memory.py
+++ b/tests/test_routes_memory.py
@@ -88,3 +88,25 @@ class TestMemoryPage:
         assert resp.status_code == 200
         data = resp.json()
         assert len(data) == 2
+
+
+class TestAgentDbPath:
+    """Regression: user/default scope must pin an explicit taOS index, never
+    qmd's shared default (which on a shared serve can be another framework's
+    collection, e.g. openclaw's workspace)."""
+
+    def test_user_scope_uses_dedicated_taos_index(self, tmp_path):
+        from tinyagentos.routes.memory import _agent_db_path
+        req = MagicMock()
+        req.app.state.agent_memory_dir = tmp_path / "agent-memory"
+        p = _agent_db_path(req, None)
+        assert p is not None  # never None / never omits dbPath
+        assert p.endswith("user-qmd-index/index.sqlite")
+        assert "/agent-memory/" not in p  # sibling of agent dir, not a child
+
+    def test_agent_scope_uses_per_agent_index(self, tmp_path):
+        from tinyagentos.routes.memory import _agent_db_path
+        req = MagicMock()
+        req.app.state.agent_memory_dir = tmp_path / "agent-memory"
+        p = _agent_db_path(req, "foo")
+        assert p.endswith("agent-memory/foo/index.sqlite")

--- a/tinyagentos/routes/memory.py
+++ b/tinyagentos/routes/memory.py
@@ -8,8 +8,8 @@ file to operate on. TinyAgentOS resolves the ``dbPath`` based on the
 calling scope:
 
 - ``agent=foo``  → ``data/agent-memory/foo/index.sqlite``
-- no agent       → the default user index (``~/.cache/qmd/index.sqlite``,
-  served when ``dbPath`` is omitted)
+- no agent       → a dedicated taOS user index
+  (``<data>/user-qmd-index/index.sqlite``), never qmd's shared default
 
 This is the load-bearing piece of per-agent memory isolation — each
 agent reads and writes its own index, so Agent A cannot see Agent B's
@@ -89,9 +89,7 @@ async def memory_browse(
     params: dict = {"limit": limit, "offset": offset}
     if collection:
         params["collection"] = collection
-    db_path = _agent_db_path(request, agent)
-    if db_path:
-        params["dbPath"] = db_path
+    params["dbPath"] = _agent_db_path(request, agent)
     headers = build_trace_context_headers(conversation_id=conversation_id)
     try:
         resp = await http_client.get(f"{_qmd_base(request)}/browse", params=params, headers=headers, timeout=30)
@@ -182,10 +180,7 @@ async def memory_collections(
 ):
     """List memory collections for an agent via qmd serve GET /collections."""
     http_client = request.app.state.http_client
-    params: dict = {}
-    db_path = _agent_db_path(request, agent_name)
-    if db_path:
-        params["dbPath"] = db_path
+    params: dict = {"dbPath": _agent_db_path(request, agent_name)}
     headers = build_trace_context_headers(conversation_id=conversation_id)
     try:
         resp = await http_client.get(f"{_qmd_base(request)}/collections", params=params, headers=headers, timeout=30)
@@ -207,10 +202,7 @@ async def memory_delete_chunk(
     the default user index.
     """
     http_client = request.app.state.http_client
-    payload: dict = {"hash": content_hash}
-    db_path = _agent_db_path(request, agent)
-    if db_path:
-        payload["dbPath"] = db_path
+    payload: dict = {"hash": content_hash, "dbPath": _agent_db_path(request, agent)}
     headers = build_trace_context_headers(conversation_id=conversation_id)
     try:
         resp = await http_client.post(

--- a/tinyagentos/routes/memory.py
+++ b/tinyagentos/routes/memory.py
@@ -53,19 +53,24 @@ def _qmd_base(request: Request) -> str:
     return request.app.state.qmd_client.base_url
 
 
-def _agent_db_path(request: Request, agent: str | None) -> str | None:
-    """Resolve the SQLite path for an agent's memory index.
+def _agent_db_path(request: Request, agent: str | None) -> str:
+    """Resolve the SQLite path for a memory index. ALWAYS taOS-owned.
 
-    Returns ``None`` for the user/default scope so the qmd request
-    omits ``dbPath`` and the qmd serve process falls back to its
-    default index. Per-agent paths are computed deterministically
-    from ``app.state.agent_memory_dir`` so they always match what the
-    deployer bind-mounts into the agent's container at ``/memory``.
+    - ``agent`` given → that agent's per-agent index
+      (``agent_memory_dir/<agent>/index.sqlite``), matching what the deployer
+      bind-mounts into the agent's container at ``/memory``.
+    - no ``agent`` (user/default scope) → a DEDICATED taOS user index, never
+      qmd's *shared default*. The qmd serve is shared across frameworks and its
+      default collection may belong to another one (e.g. openclaw's workspace),
+      so omitting ``dbPath`` would query/return that foreign data. We therefore
+      always pin an explicit taOS-owned ``dbPath`` (an empty index returns no
+      results, which is correct — never another framework's data).
     """
-    if not agent:
-        return None
     base: Path = request.app.state.agent_memory_dir
-    target = base / agent / "index.sqlite"
+    if not agent:
+        target = base.parent / "user-qmd-index" / "index.sqlite"
+    else:
+        target = base / agent / "index.sqlite"
     target.parent.mkdir(parents=True, exist_ok=True)
     return str(target)
 


### PR DESCRIPTION
Found via @taOSmd while debugging the Pi qmd swap.

## Bug
`memory.py` user/default scope (`_agent_db_path(agent=None)`) returned `None` → the qmd call omitted `dbPath` → qmd used its **default collection**. On a shared qmd serve that default belongs to whatever framework configured it — on the Pi it's **openclaw's workspace index** (`/home/jay/.openclaw/workspace`). So taOS user-scope `/search`+`/vsearch` queried/returned **openclaw's files**, not taOS memory (and hit that index's 1024-vs-768 dim mismatch → 500 on /vsearch).

## Fix
User/default scope now pins an explicit taOS-owned path `data/user-qmd-index/index.sqlite` (sibling of the per-agent dir). An empty index returns no results — correct — never another framework's data. Per-agent scope unchanged.

## Notes
- taOS native user memory is in `UserMemoryStore` (`user_memory.db`); this qmd path is the vector-search lane and was the one leaking. A deeper question (whether user memory should be ingested into this qmd index vs staying in UserMemoryStore) is separate (#23 / memory-app architecture).
- Regression tests added (user-scope dedicated path; agent-scope unchanged). Memory route tests green.

Coordinated with @taOSmd (the qmd-side default-collection config + a dimension-guard are their side).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests to verify memory database path resolution for default/user scope and per-agent scope.

* **Refactor**
  * Memory routes now always provide an explicit SQLite database path: a dedicated user index for default scope and per-agent indexes for agent scope; directories are created as needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->