### PR TITLE
fix(install): chmod o+x parent dirs so taos user can traverse to INSTALL_DIR

### DIFF
--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -1420,6 +1420,18 @@ set_data_dir_ownership() {
     log "setting ownership of $INSTALL_DIR → taos:taos (required for non-root in-app self-update)"
     chown -R taos:taos "$INSTALL_DIR" 2>/dev/null || true
 
+    # Ensure every parent directory of INSTALL_DIR is traversable by the taos
+    # service user — without this, systemd CHDIR fails (exit 200) when the
+    # install lives under a restricted root like /root (mode 700).
+    # o+x = traverse only, not list: minimal security impact.
+    _parent="$(dirname "$INSTALL_DIR")"
+    while [[ "$_parent" != "/" && "$_parent" != "." ]]; do
+        if [[ -d "$_parent" ]]; then
+            chmod o+x "$_parent" 2>/dev/null || true
+        fi
+        _parent="$(dirname "$_parent")"
+    done
+
     # Tighten the data directory and sensitive credential files on top of the
     # broad chown above — done AFTER so the restrictive perms win.
     log "tightening $INSTALL_DIR/data/ → mode 0700 and secret files → 0600"


### PR DESCRIPTION
## Summary

- When the installer runs as root, `INSTALL_DIR` defaults to `/root/tinyagentos`
- The `taos` service user cannot `chdir` into `/root` (mode 700), causing systemd to exit with **status 200 (CHDIR failed)** before the process starts
- Fix: after `chown -R taos:taos "$INSTALL_DIR"`, walk every parent dir of `INSTALL_DIR` and apply `chmod o+x` — traversal only, not read/list

## Root cause

Reported by @hermes in issue #723 (Rock 5B install, root-owned path). The `WorkingDirectory=` in the systemd unit template uses the install path verbatim; systemd calls `chdir()` as the service user before `ExecStart`, which fails when `/root` has mode 700.

## Security

`o+x` grants traversal to the directory entry — not listing or reading contents. `/root` itself remains unexplorable by the `taos` user; it can only walk through it to reach `/root/tinyagentos`.

## Test plan
- [ ] Fresh install as root on a system where `/root` is mode 700 — service starts without exit 200
- [ ] Install as non-root (`/home/user/tinyagentos`) — fix is a no-op (parent dirs already world-traversable), no regression

Closes #723

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installer permission handling to ensure proper directory access configuration throughout the installation path, allowing the system service to function correctly with appropriate access levels post-installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->