### PR TITLE
feat(registry): PATCH route for mutable metadata — governance PR2

### DIFF
--- a/tests/test_registry_governance_lifecycle.py
+++ b/tests/test_registry_governance_lifecycle.py
@@ -637,3 +637,165 @@ class TestAuditEvent:
         assert ev is not None
         assert ev["payload"]["action"] == "suspend"
         await ts.close()
+
+
+# ---------------------------------------------------------------------------
+# Store-level tests for update()
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestRegistryUpdate:
+
+    async def _store(self, tmp_path):
+        store = AgentRegistryStore(tmp_path / "reg.db")
+        await store.init()
+        return store
+
+    async def test_update_display_name(self, tmp_path):
+        store = await self._store(tmp_path)
+        try:
+            rec = await store.register(framework="f", display_name="Original")
+            cid = rec["canonical_id"]
+            updated = await store.update(cid, display_name="Updated Name")
+            assert updated["display_name"] == "Updated Name"
+        finally:
+            await store.close()
+
+    async def test_update_capabilities(self, tmp_path):
+        store = await self._store(tmp_path)
+        try:
+            rec = await store.register(framework="f", capabilities=["read"])
+            cid = rec["canonical_id"]
+            updated = await store.update(cid, capabilities=["read", "write", "execute"])
+            assert updated["capabilities"] == ["read", "write", "execute"]
+        finally:
+            await store.close()
+
+    async def test_update_handle_and_role(self, tmp_path):
+        store = await self._store(tmp_path)
+        try:
+            rec = await store.register(framework="f")
+            cid = rec["canonical_id"]
+            updated = await store.update(cid, handle="agent-x", role="assistant")
+            assert updated["handle"] == "agent-x"
+            assert updated["role"] == "assistant"
+        finally:
+            await store.close()
+
+    async def test_update_partial_only_changes_provided_fields(self, tmp_path):
+        store = await self._store(tmp_path)
+        try:
+            rec = await store.register(framework="f", display_name="Keep Me", handle="keep")
+            cid = rec["canonical_id"]
+            updated = await store.update(cid, role="new-role")
+            assert updated["display_name"] == "Keep Me"
+            assert updated["handle"] == "keep"
+            assert updated["role"] == "new-role"
+        finally:
+            await store.close()
+
+    async def test_update_no_fields_is_noop(self, tmp_path):
+        store = await self._store(tmp_path)
+        try:
+            rec = await store.register(framework="f", display_name="Stable")
+            cid = rec["canonical_id"]
+            updated = await store.update(cid)  # nothing provided
+            assert updated["display_name"] == "Stable"
+        finally:
+            await store.close()
+
+    async def test_update_unknown_id_returns_none(self, tmp_path):
+        store = await self._store(tmp_path)
+        try:
+            result = await store.update("no-such-id", display_name="X")
+            assert result is None
+        finally:
+            await store.close()
+
+    async def test_update_does_not_touch_status_or_user_id(self, tmp_path):
+        store = await self._store(tmp_path)
+        try:
+            rec = await store.register(framework="f", user_id="uid-1")
+            cid = rec["canonical_id"]
+            await store.update(cid, display_name="Changed")
+            fresh = await store.get(cid)
+            assert fresh["status"] == "active"
+            assert fresh["user_id"] == "uid-1"
+        finally:
+            await store.close()
+
+
+# ---------------------------------------------------------------------------
+# Route-level tests for PATCH /api/agents/registry/{canonical_id}
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestPatchRegistryRoute:
+
+    async def _register(self, client, **kwargs):
+        resp = await client.post(
+            "/api/agents/registry/register",
+            json={"framework": "test", **kwargs},
+        )
+        assert resp.status_code == 200
+        return resp.json()
+
+    async def test_patch_display_name_as_owner(self, gov_client, tmp_data_dir):
+        client, uid = gov_client
+        rec = await self._register(client, display_name="Before")
+        cid = rec["canonical_id"]
+        resp = await client.patch(
+            f"/api/agents/registry/{cid}",
+            json={"display_name": "After"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["display_name"] == "After"
+
+    async def test_patch_capabilities_replaces_list(self, gov_client, tmp_data_dir):
+        client, uid = gov_client
+        rec = await self._register(client, capabilities=["read"])
+        cid = rec["canonical_id"]
+        resp = await client.patch(
+            f"/api/agents/registry/{cid}",
+            json={"capabilities": ["read", "write"]},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["capabilities"] == ["read", "write"]
+
+    async def test_patch_unknown_id_returns_404(self, gov_client, tmp_data_dir):
+        client, _ = gov_client
+        resp = await client.patch(
+            "/api/agents/registry/does-not-exist",
+            json={"display_name": "X"},
+        )
+        assert resp.status_code == 404
+
+    async def test_patch_by_non_owner_member_returns_403(
+        self, gov_member_client, app, tmp_data_dir
+    ):
+        # Insert an entry owned by a different user directly via the store so
+        # we avoid the "admin already configured" conflict that arises when
+        # both gov_client and gov_member_client share the same app fixture.
+        registry_store = app.state.agent_registry
+        if registry_store._db is None:
+            await registry_store.init()
+        rec = await registry_store.register(
+            framework="test",
+            display_name="Other User Entry",
+            user_id="other-user-uid",
+        )
+        cid = rec["canonical_id"]
+        # member tries to patch another user's entry → 403
+        resp = await gov_member_client.patch(
+            f"/api/agents/registry/{cid}",
+            json={"display_name": "Hijacked"},
+        )
+        assert resp.status_code == 403
+
+    async def test_patch_empty_body_is_noop(self, gov_client, tmp_data_dir):
+        client, _ = gov_client
+        rec = await self._register(client, display_name="Unchanged")
+        cid = rec["canonical_id"]
+        resp = await client.patch(f"/api/agents/registry/{cid}", json={})
+        assert resp.status_code == 200
+        assert resp.json()["display_name"] == "Unchanged"

--- a/tinyagentos/agent_registry_store.py
+++ b/tinyagentos/agent_registry_store.py
@@ -490,6 +490,51 @@ class AgentRegistryStore(BaseStore):
     # Revoke
     # ------------------------------------------------------------------
 
+    async def update(
+        self,
+        canonical_id: str,
+        *,
+        display_name: Optional[str] = None,
+        handle: Optional[str] = None,
+        role: Optional[str] = None,
+        capabilities: Optional[list[str]] = None,
+    ) -> Optional[dict]:
+        """Update mutable metadata fields on *canonical_id*.
+
+        Only the provided (non-None) fields are changed.
+        Status, user_id, framework, canonical_id, and timestamps are immutable.
+        Returns the updated record, or None if *canonical_id* does not exist.
+        """
+        if self._db is None:
+            raise RuntimeError("AgentRegistryStore not initialised")
+        record = await self.get(canonical_id)
+        if record is None:
+            return None
+
+        cols: list[str] = []
+        vals: list = []
+        if display_name is not None:
+            cols.append("display_name = ?")
+            vals.append(display_name)
+        if handle is not None:
+            cols.append("handle = ?")
+            vals.append(handle)
+        if role is not None:
+            cols.append("role = ?")
+            vals.append(role)
+        if capabilities is not None:
+            cols.append("capabilities = ?")
+            vals.append(json.dumps(capabilities))
+        if not cols:
+            return record
+        vals.append(canonical_id)
+        await self._db.execute(
+            f"UPDATE agent_registry SET {', '.join(cols)} WHERE canonical_id = ?",
+            vals,
+        )
+        await self._db.commit()
+        return await self.get(canonical_id)
+
     async def revoke(self, canonical_id: str) -> Optional[dict]:
         """Set revoked_at on *canonical_id*.  Returns updated record or None."""
         if self._db is None:

--- a/tinyagentos/routes/agent_registry.py
+++ b/tinyagentos/routes/agent_registry.py
@@ -9,6 +9,7 @@ GET    /api/agents/registry/inactive         — all non-active entries for the 
 GET    /api/agents/registry/grants           — active grant feed for @taOSmd enforcement (admin only)
 GET    /api/agents/registry                  — list registry entries (admin: all; member: own)
 GET    /api/agents/registry/{id}             — read a single entry (owner or admin; else 404)
+PATCH  /api/agents/registry/{id}             — update mutable fields (owner or admin)
 DELETE /api/agents/registry/{id}             — revoke an entry (owner or admin)
 POST   /api/agents/registry/{id}/approve     — lifecycle: pending → active (admin only)
 POST   /api/agents/registry/{id}/reject      — lifecycle: pending → rejected (admin only)
@@ -58,6 +59,13 @@ class RegisterRequest(BaseModel):
         if val not in _ALLOWED_ORIGINS:
             raise ValueError(f"origin must be one of {sorted(_ALLOWED_ORIGINS)}")
         return val
+
+
+class PatchRegistryRequest(BaseModel):
+    display_name: Optional[str] = None
+    handle: Optional[str] = None
+    role: Optional[str] = None
+    capabilities: Optional[list[str]] = None
 
 
 # ---------------------------------------------------------------------------
@@ -266,6 +274,34 @@ async def get_registry_entry(
     if not user.is_admin and user.user_id != record["user_id"]:
         return JSONResponse({"error": "not found"}, status_code=404)
     return record
+
+
+@router.patch("/api/agents/registry/{canonical_id}")
+async def patch_registry_entry(
+    request: Request,
+    canonical_id: str,
+    body: PatchRegistryRequest,
+    user: CurrentUser = Depends(current_user),
+):
+    """Update mutable metadata fields on a registry entry.
+
+    Allowed fields: display_name, handle, role, capabilities.
+    Status, framework, user_id, and timestamps are immutable.
+    Only the owning user or an admin may update an entry.
+    """
+    store = _get_store(request)
+    record = await store.get(canonical_id)
+    if record is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    require_owner_or_admin(user, record["user_id"])
+    updated = await store.update(
+        canonical_id,
+        display_name=body.display_name,
+        handle=body.handle,
+        role=body.role,
+        capabilities=body.capabilities,
+    )
+    return updated
 
 
 @router.delete("/api/agents/registry/{canonical_id}")


### PR DESCRIPTION
## Summary

- Agents can now update their declared `capabilities`, `display_name`, `handle`, and `role` without re-registering
- Status, framework, user_id, and timestamps remain immutable
- Owner-or-admin gate (403 for others)

## New route

```
PATCH /api/agents/registry/{canonical_id}
```

Body fields (all optional; omitted fields are unchanged):
- `display_name` — human-readable name
- `handle` — short identifier  
- `role` — agent's stated role
- `capabilities` — list of declared capability strings (replaces existing list)

Returns 200 with the updated record, 404 for unknown ids, 403 for non-owner/non-admin.

## Changes

- `AgentRegistryStore.update()` — targeted UPDATE, only non-None fields are written; no-field call is a no-op
- `PATCH /api/agents/registry/{canonical_id}` route in `routes/agent_registry.py`
- 12 new tests in `tests/test_registry_governance_lifecycle.py`

## Test plan
- [ ] 61 governance lifecycle tests pass (61 passed, 3 warnings)
- [ ] Store-level: partial update, empty no-op, unknown-id returns None, status/user_id untouched
- [ ] Route-level: owner can patch, non-owner 403, unknown id 404, empty body no-op