### PR TITLE
fix(memory): harden user-memory taosmd proxy per review

### DIFF
--- a/tests/test_user_memory.py
+++ b/tests/test_user_memory.py
@@ -216,3 +216,59 @@ async def test_migrate_returns_503_when_taosmd_unreachable(app, mem_client, tmp_
         assert resp.status_code == 503
     finally:
         app.state.taosmd_url = None
+
+
+@pytest.mark.asyncio
+async def test_browse_offset_pages_through_rows(store):
+    for i in range(5):
+        await store.save_chunk("user", f"chunk number {i}", f"T{i}", "snippets")
+    first = await store.browse("user", limit=2, offset=0)
+    second = await store.browse("user", limit=2, offset=2)
+    third = await store.browse("user", limit=2, offset=4)
+    assert len(first) == 2 and len(second) == 2 and len(third) == 1
+    hashes = {c["hash"] for c in first + second + third}
+    assert len(hashes) == 5  # no overlap between pages
+
+
+@pytest.mark.asyncio
+async def test_save_metadata_cannot_override_source_id(mem_client, tmp_data_dir):
+    """Caller-supplied metadata must not clobber the server-owned dedup key."""
+    client, _ = mem_client
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.post = AsyncMock(return_value=MagicMock(status_code=200))
+
+    with patch("tinyagentos.routes.user_memory.httpx.AsyncClient", return_value=mock_client):
+        resp = await client.post(
+            "/api/user-memory/save",
+            json={
+                "content": "override attempt",
+                "collection": "snippets",
+                "metadata": {"source_id": "evil", "collection": "other", "custom": "kept"},
+            },
+        )
+    assert resp.status_code == 200
+    saved_hash = resp.json()["hash"]
+    sent_meta = mock_client.post.call_args.kwargs["json"]["metadata"]
+    assert sent_meta["source_id"] == saved_hash
+    assert sent_meta["collection"] == "snippets"
+    assert sent_meta["custom"] == "kept"
+
+
+@pytest.mark.asyncio
+async def test_migrate_error_response_does_not_leak_exception_text(mem_client, tmp_data_dir):
+    """The /migrate 500 path must not reflect raw exception text to callers."""
+    client, store = mem_client
+    await store.save_chunk("user", "to migrate", "T", "snippets")
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.get = AsyncMock(return_value=MagicMock(status_code=200))  # health OK
+    mock_client.post = AsyncMock(side_effect=RuntimeError("http://internal-taosmd:7900 boom"))
+
+    with patch("tinyagentos.routes.user_memory.httpx.AsyncClient", return_value=mock_client):
+        resp = await client.post("/api/user-memory/migrate")
+    assert resp.status_code == 500
+    assert "internal-taosmd" not in resp.text
+    assert resp.json()["error"] == "taosmd ingest failed"

--- a/tinyagentos/routes/user_memory.py
+++ b/tinyagentos/routes/user_memory.py
@@ -135,14 +135,22 @@ async def save(request: Request):
     base = _taosmd_base(request)
     try:
         async with httpx.AsyncClient(timeout=5.0) as client:
-            await client.post(
+            resp = await client.post(
                 f"{base}/ingest",
                 json={
                     "text": content,
                     "agent": _TAOSMD_AGENT,
-                    "metadata": {"collection": collection, "title": title, "source_id": h, **metadata},
+                    # Caller metadata first so the server-owned keys win —
+                    # source_id is taosmd's dedup key and must not be
+                    # overridable from the request body.
+                    "metadata": {**metadata, "collection": collection, "title": title, "source_id": h},
                 },
             )
+            if resp.status_code >= 400:
+                logger.debug(
+                    "taosmd ingest returned %s — chunk saved to SQLite only",
+                    resp.status_code,
+                )
     except Exception:
         logger.debug("taosmd ingest unavailable — chunk saved to SQLite only")
 
@@ -180,7 +188,16 @@ async def migrate_to_taosmd(request: Request):
     except Exception:
         return JSONResponse({"error": "taosmd unreachable"}, status_code=503)
 
-    chunks = await _store(request).browse(USER_ID, limit=10_000)
+    # Page through the store so installs with >page_size chunks migrate fully.
+    chunks: list[dict] = []
+    page_size = 1000
+    offset = 0
+    while True:
+        page = await _store(request).browse(USER_ID, limit=page_size, offset=offset)
+        chunks.extend(page)
+        if len(page) < page_size:
+            break
+        offset += page_size
     if not chunks:
         return JSONResponse({"ingested": 0, "skipped": 0, "total": 0})
 
@@ -188,11 +205,13 @@ async def migrate_to_taosmd(request: Request):
         {
             "text": c["content"],
             "id": c["hash"],
+            # Stored metadata first so the server-owned keys win — source_id
+            # is taosmd's dedup key and must not be overridable.
             "metadata": {
+                **(c.get("metadata") or {}),
                 "collection": c["collection"],
                 "title": c["title"],
                 "source_id": c["hash"],
-                **(c.get("metadata") or {}),
             },
         }
         for c in chunks
@@ -213,16 +232,20 @@ async def migrate_to_taosmd(request: Request):
             async with httpx.AsyncClient(timeout=30.0) as client:
                 for item in items:
                     try:
-                        await client.post(
+                        one = await client.post(
                             f"{base}/ingest",
                             json={"text": item["text"], "agent": _TAOSMD_AGENT,
                                   "metadata": item["metadata"]},
                         )
-                        ingested += 1
+                        if one.status_code < 400:
+                            ingested += 1
                     except Exception:
                         pass
             result = {"ingested": ingested, "skipped": len(items) - ingested}
-    except Exception as exc:
-        return JSONResponse({"error": str(exc)}, status_code=500)
+    except Exception:
+        # Don't reflect raw exception text (it can carry the internal taosmd
+        # host/URL) back to the caller; details go to the server log only.
+        logger.warning("taosmd bulk ingest failed", exc_info=True)
+        return JSONResponse({"error": "taosmd ingest failed"}, status_code=500)
 
     return JSONResponse({**result, "total": len(items)})

--- a/tinyagentos/user_memory.py
+++ b/tinyagentos/user_memory.py
@@ -124,6 +124,7 @@ class UserMemoryStore(BaseStore):
         user_id: str,
         collection: str | None = None,
         limit: int = 50,
+        offset: int = 0,
     ) -> list[dict]:
         assert self._db is not None
         sql = "SELECT hash, collection, title, content, metadata, created_at FROM user_memory_chunks WHERE user_id = ?"
@@ -131,8 +132,8 @@ class UserMemoryStore(BaseStore):
         if collection:
             sql += " AND collection = ?"
             params.append(collection)
-        sql += " ORDER BY created_at DESC LIMIT ?"
-        params.append(limit)
+        sql += " ORDER BY created_at DESC LIMIT ? OFFSET ?"
+        params.extend([limit, offset])
         cursor = await self._db.execute(sql, params)
         rows = await cursor.fetchall()
         return [


### PR DESCRIPTION
## Summary
The proxy layer itself landed on dev via the #729 squash (stacked branches). This PR is now the review-hardening pass on top:

- Caller-supplied `metadata` can no longer override server-owned keys (`source_id` is taosmd dedup key) in `/save` and `/migrate` payloads
- `/migrate` pages through the store (`browse` gains `offset`) instead of a hard 10k cap
- Ingest fallback only counts 2xx responses as ingested; `/save` logs non-2xx
- `/migrate` 500 path returns a generic error instead of reflecting raw exception text (internal taosmd URL)

Addresses both security-review findings (MEDIUM metadata/source_id override, LOW error-text leak) and all 3 CodeRabbit comments.

## Test plan
- [x] tests/test_user_memory.py 17/17 pass locally (+3 new: offset paging, source_id override blocked, error-text leak)