### PR TITLE
chore: switch taosmd dependency from git to PyPI (0.3.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ dependencies = [
     "libtorrent>=2.0.9",
     "lxml>=5.0.0",
     "readability-lxml>=0.8.1",
-    # Memory system — standalone package, pulled from GitHub
-    "taosmd @ git+https://github.com/jaylfc/taosmd.git@master",
+    # Memory system — published to PyPI
+    "taosmd==0.3.0",
     # WebSocket client for dashboard proxy (shortcut_proxy.py)
     "websockets>=12.0",
     # Web Push VAPID signing — pulls in cryptography, http-ece, py-vapid


### PR DESCRIPTION
## Summary

`taosmd 0.3.0` is now published on PyPI. Switching from the `git+https://github.com/jaylfc/taosmd.git@master` install to the versioned PyPI package.

- Faster installs (no git clone on every fresh venv)
- Reproducible builds (pinned version)
- No functional change — same package, same API surface

## Test plan

- [ ] `python3 -c "import taosmd; print(taosmd.__version__)"` → `0.3.0`
- [ ] CI passes (no import errors, no test failures)