### PR TITLE
chore: promote dev → master (registry UI, consent UI + scope validation, user-memory proxy, PyPI pin)

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -27,6 +27,7 @@ import { useTaosAgentStore } from "@/stores/taos-agent-store";
 import { InstallPromptBanner } from "@/shell/InstallPromptBanner";
 import { EffectsLayer } from "@/theme/effects/EffectsLayer";
 import { SafetyFloor } from "@/components/SafetyFloor";
+import { ConsentNotification } from "@/components/ConsentNotification";
 
 interface SystemShortcutsProps {
   toggleSearch: () => void;
@@ -271,6 +272,7 @@ export function App() {
               <NotificationCentre />
               <TaosAssistantPanel />
               <SafetyFloor />
+              <ConsentNotification />
             </div>
           </div>
         </LoginGate>
@@ -337,6 +339,7 @@ export function App() {
       <NotificationCentre />
       <TaosAssistantPanel />
       <SafetyFloor />
+      <ConsentNotification />
     </div>
       </LoginGate>
     </ShortcutProvider>

--- a/desktop/src/apps/AgentsApp.tsx
+++ b/desktop/src/apps/AgentsApp.tsx
@@ -14,6 +14,7 @@ import { AgentDetailPanel, type DetailTab } from "./agents/AgentDetailPanel";
 import { TaosAgentDetailPanel } from "./agents/TaosAgentDetailPanel";
 import { DeployWizard } from "./agents/DeployWizard";
 import { ArchivedAgentsPanel } from "./agents/ArchivedAgents";
+import { RegistryPanel } from "./agents/RegistryPanel";
 import { fetchTaosAgentConfig } from "@/lib/taos-agent-api";
 
 /* ------------------------------------------------------------------ */
@@ -526,6 +527,7 @@ export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
               onRestore={handleRestore}
               onPurge={handlePurge}
             />
+            <RegistryPanel />
           </div>
         ) : (
           <div className="p-4">
@@ -612,6 +614,7 @@ export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
               onRestore={handleRestore}
               onPurge={handlePurge}
             />
+            <RegistryPanel />
           </div>
         )}
       </div>

--- a/desktop/src/apps/agents/RegistryPanel.tsx
+++ b/desktop/src/apps/agents/RegistryPanel.tsx
@@ -1,0 +1,334 @@
+import { useState, useEffect, useCallback } from "react";
+import {
+  ChevronRight,
+  ShieldCheck,
+  CheckCircle,
+  XCircle,
+  PauseCircle,
+  PlayCircle,
+  ShieldOff,
+  RefreshCw,
+} from "lucide-react";
+import { Button, Card } from "@/components/ui";
+
+/* ------------------------------------------------------------------ */
+/*  Types                                                               */
+/* ------------------------------------------------------------------ */
+
+export type RegistryStatus =
+  | "pending"
+  | "active"
+  | "suspended"
+  | "rejected"
+  | "revoked";
+
+export interface RegistryEntry {
+  canonical_id: string;
+  framework: string;
+  display_name: string;
+  user_id: string;
+  origin: string;
+  handle: string;
+  role: string | null;
+  capabilities: string[];
+  status: RegistryStatus;
+  registered_at: string;
+  updated_at: string | null;
+  revoked_at: string | null;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+function relativeTime(ts: string | null): string {
+  if (!ts) return "—";
+  const d = new Date(ts);
+  if (isNaN(d.getTime())) return ts;
+  const diff = Date.now() - d.getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  if (days < 7) return `${days}d ago`;
+  return d.toLocaleDateString();
+}
+
+const STATUS_STYLES: Record<RegistryStatus, string> = {
+  pending: "bg-amber-500/20 text-amber-300 border-amber-500/30",
+  active: "bg-emerald-500/20 text-emerald-300 border-emerald-500/30",
+  suspended: "bg-orange-500/20 text-orange-300 border-orange-500/30",
+  rejected: "bg-red-500/20 text-red-300 border-red-500/30",
+  revoked: "bg-white/5 text-shell-text-tertiary border-white/10",
+};
+
+async function registryAction(
+  canonical_id: string,
+  action: "approve" | "reject" | "suspend" | "reactivate" | "revoke",
+): Promise<RegistryEntry> {
+  const method = action === "revoke" ? "DELETE" : "POST";
+  const url =
+    action === "revoke"
+      ? `/api/agents/registry/${encodeURIComponent(canonical_id)}`
+      : `/api/agents/registry/${encodeURIComponent(canonical_id)}/${action}`;
+  const resp = await fetch(url, { method, credentials: "include" });
+  if (!resp.ok) {
+    const err = await resp.json().catch(() => ({}));
+    throw new Error((err as { error?: string }).error ?? `HTTP ${resp.status}`);
+  }
+  return resp.json();
+}
+
+/* ------------------------------------------------------------------ */
+/*  RegistryEntryRow                                                    */
+/* ------------------------------------------------------------------ */
+
+function RegistryEntryRow({
+  entry,
+  isAdmin,
+  currentUserId,
+  onAction,
+}: {
+  entry: RegistryEntry;
+  isAdmin: boolean;
+  currentUserId: string;
+  onAction: (id: string, action: "approve" | "reject" | "suspend" | "reactivate" | "revoke") => Promise<void>;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const isOwner = entry.user_id === currentUserId;
+  const canRevoke = (isAdmin || isOwner) && (entry.status === "active" || entry.status === "suspended");
+
+  async function act(action: "approve" | "reject" | "suspend" | "reactivate" | "revoke") {
+    setBusy(true);
+    setErr(null);
+    try {
+      await onAction(entry.canonical_id, action);
+    } catch (e: unknown) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Card className="flex flex-col gap-2 px-4 py-3">
+      <div className="flex items-center gap-3 flex-wrap">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="font-medium text-sm truncate">
+              {entry.display_name || entry.handle || entry.framework}
+            </span>
+            <span
+              className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium border ${STATUS_STYLES[entry.status] ?? STATUS_STYLES.revoked}`}
+              aria-label={`Status: ${entry.status}`}
+            >
+              {entry.status}
+            </span>
+            <span className="text-[11px] text-shell-text-tertiary">{entry.framework}</span>
+          </div>
+          <div className="flex items-center gap-3 mt-0.5 flex-wrap">
+            <code
+              className="text-[10px] text-shell-text-tertiary font-mono truncate max-w-[220px]"
+              title={entry.canonical_id}
+            >
+              {entry.canonical_id}
+            </code>
+            <span className="text-[11px] text-shell-text-tertiary">
+              registered {relativeTime(entry.registered_at)}
+            </span>
+            {isAdmin && (
+              <span className="text-[11px] text-shell-text-tertiary">
+                by {entry.user_id}
+              </span>
+            )}
+          </div>
+        </div>
+
+        <div className="flex items-center gap-1 shrink-0" role="group" aria-label="Registry actions">
+          {entry.status === "pending" && isAdmin && (
+            <>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7 hover:bg-emerald-500/15 hover:text-emerald-400"
+                onClick={() => act("approve")}
+                disabled={busy}
+                aria-label={`Approve ${entry.display_name || entry.canonical_id}`}
+                title="Approve"
+              >
+                <CheckCircle size={14} />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7 hover:bg-red-500/15 hover:text-red-400"
+                onClick={() => act("reject")}
+                disabled={busy}
+                aria-label={`Reject ${entry.display_name || entry.canonical_id}`}
+                title="Reject"
+              >
+                <XCircle size={14} />
+              </Button>
+            </>
+          )}
+          {entry.status === "active" && isAdmin && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7 hover:bg-orange-500/15 hover:text-orange-400"
+              onClick={() => act("suspend")}
+              disabled={busy}
+              aria-label={`Suspend ${entry.display_name || entry.canonical_id}`}
+              title="Suspend"
+            >
+              <PauseCircle size={14} />
+            </Button>
+          )}
+          {entry.status === "suspended" && isAdmin && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7 hover:bg-emerald-500/15 hover:text-emerald-400"
+              onClick={() => act("reactivate")}
+              disabled={busy}
+              aria-label={`Reactivate ${entry.display_name || entry.canonical_id}`}
+              title="Reactivate"
+            >
+              <PlayCircle size={14} />
+            </Button>
+          )}
+          {canRevoke && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7 hover:bg-red-500/15 hover:text-red-400"
+              onClick={() => act("revoke")}
+              disabled={busy}
+              aria-label={`Revoke ${entry.display_name || entry.canonical_id}`}
+              title="Revoke"
+            >
+              <ShieldOff size={14} />
+            </Button>
+          )}
+        </div>
+      </div>
+      {err && (
+        <p className="text-[11px] text-red-400" role="alert">{err}</p>
+      )}
+    </Card>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  RegistryPanel                                                       */
+/* ------------------------------------------------------------------ */
+
+export function RegistryPanel() {
+  const [expanded, setExpanded] = useState(false);
+  const [entries, setEntries] = useState<RegistryEntry[]>([]);
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [currentUserId, setCurrentUserId] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setErr(null);
+    try {
+      const [statusResp, registryResp] = await Promise.all([
+        fetch("/auth/status", { credentials: "include" }),
+        fetch("/api/agents/registry", { credentials: "include" }),
+      ]);
+      if (statusResp.ok) {
+        const s = await statusResp.json();
+        setIsAdmin(!!s.user?.is_admin);
+        setCurrentUserId(s.user?.id ?? "");
+      }
+      if (registryResp.ok) {
+        const data = await registryResp.json();
+        setEntries(Array.isArray(data) ? data : []);
+      } else if (registryResp.status !== 404) {
+        setErr(`Failed to load registry (${registryResp.status})`);
+      }
+    } catch (e: unknown) {
+      setErr(e instanceof Error ? e.message : "Network error");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (expanded) load();
+  }, [expanded, load]);
+
+  async function handleAction(
+    canonical_id: string,
+    action: "approve" | "reject" | "suspend" | "reactivate" | "revoke",
+  ) {
+    await registryAction(canonical_id, action);
+    await load();
+  }
+
+  const pendingCount = entries.filter((e) => e.status === "pending").length;
+
+  return (
+    <section className="mt-4" aria-label="Agent registry">
+      <button
+        onClick={() => setExpanded((v) => !v)}
+        className="flex items-center gap-2 text-xs text-shell-text-secondary hover:text-shell-text transition-colors mb-2 w-full"
+        aria-expanded={expanded}
+        aria-controls="agent-registry-panel"
+      >
+        <ChevronRight
+          size={14}
+          className={`transition-transform shrink-0 ${expanded ? "rotate-90" : ""}`}
+          aria-hidden
+        />
+        <ShieldCheck size={13} aria-hidden />
+        <span>Agent Registry</span>
+        {entries.length > 0 && (
+          <span className="text-shell-text-tertiary">({entries.length})</span>
+        )}
+        {pendingCount > 0 && (
+          <span
+            className="ml-1 px-1.5 py-0.5 rounded-full text-[10px] font-medium bg-amber-500/25 text-amber-300 border border-amber-500/30"
+            aria-label={`${pendingCount} pending approval`}
+          >
+            {pendingCount} pending
+          </span>
+        )}
+      </button>
+
+      <div
+        id="agent-registry-panel"
+        className={`space-y-2 ${expanded ? "" : "hidden"}`}
+      >
+        {loading ? (
+          <div className="flex items-center gap-2 text-xs text-shell-text-tertiary py-2">
+            <RefreshCw size={12} className="animate-spin" aria-hidden />
+            Loading registry…
+          </div>
+        ) : err ? (
+          <p className="text-xs text-red-400" role="alert">{err}</p>
+        ) : entries.length === 0 ? (
+          <p className="text-xs text-shell-text-tertiary py-1">
+            No registered agents yet.
+          </p>
+        ) : (
+          entries.map((entry) => (
+            <RegistryEntryRow
+              key={entry.canonical_id}
+              entry={entry}
+              isAdmin={isAdmin}
+              currentUserId={currentUserId}
+              onAction={handleAction}
+            />
+          ))
+        )}
+      </div>
+    </section>
+  );
+}

--- a/desktop/src/apps/agents/RegistryPanel.tsx
+++ b/desktop/src/apps/agents/RegistryPanel.tsx
@@ -8,6 +8,8 @@ import {
   PlayCircle,
   ShieldOff,
   RefreshCw,
+  ScrollText,
+  ArrowRight,
 } from "lucide-react";
 import { Button, Card } from "@/components/ui";
 
@@ -223,6 +225,136 @@ function RegistryEntryRow({
 }
 
 /* ------------------------------------------------------------------ */
+/*  GovernanceAuditPanel                                                */
+/* ------------------------------------------------------------------ */
+
+interface GovernanceEvent {
+  id: string;
+  ts: number;
+  payload: {
+    action: string;
+    canonical_id: string;
+    actor_user_id: string;
+    before_status: string;
+    after_status: string;
+  };
+}
+
+const ACTION_LABELS: Record<string, string> = {
+  approve: "approved",
+  reject: "rejected",
+  suspend: "suspended",
+  reactivate: "reactivated",
+  revoke: "revoked",
+};
+
+function GovernanceAuditPanel({ isAdmin }: { isAdmin: boolean }) {
+  const [expanded, setExpanded] = useState(false);
+  const [events, setEvents] = useState<GovernanceEvent[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setErr(null);
+    try {
+      const resp = await fetch(
+        "/api/agents/taos-governance/trace?kind=governance&limit=50",
+        { credentials: "include" },
+      );
+      if (resp.ok) {
+        const data = await resp.json();
+        setEvents((data.events ?? []) as GovernanceEvent[]);
+      } else if (resp.status !== 404) {
+        setErr(`Failed to load audit log (${resp.status})`);
+      }
+    } catch (e: unknown) {
+      setErr(e instanceof Error ? e.message : "Network error");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (expanded) load();
+  }, [expanded, load]);
+
+  if (!isAdmin) return null;
+
+  return (
+    <section className="mt-3" aria-label="Governance audit log">
+      <button
+        onClick={() => setExpanded((v) => !v)}
+        className="flex items-center gap-2 text-xs text-shell-text-tertiary hover:text-shell-text-secondary transition-colors mb-2 w-full"
+        aria-expanded={expanded}
+        aria-controls="governance-audit-panel"
+      >
+        <ChevronRight
+          size={13}
+          className={`transition-transform shrink-0 ${expanded ? "rotate-90" : ""}`}
+          aria-hidden
+        />
+        <ScrollText size={12} aria-hidden />
+        <span>Governance audit log</span>
+        {events.length > 0 && (
+          <span className="text-shell-text-tertiary">({events.length})</span>
+        )}
+      </button>
+
+      <div
+        id="governance-audit-panel"
+        className={`space-y-1.5 ${expanded ? "" : "hidden"}`}
+      >
+        {loading ? (
+          <div className="flex items-center gap-2 text-xs text-shell-text-tertiary py-1">
+            <RefreshCw size={11} className="animate-spin" aria-hidden />
+            Loading…
+          </div>
+        ) : err ? (
+          <p className="text-xs text-red-400" role="alert">{err}</p>
+        ) : events.length === 0 ? (
+          <p className="text-xs text-shell-text-tertiary py-1">
+            No governance events recorded yet.
+          </p>
+        ) : (
+          events.map((ev) => {
+            const p = ev.payload;
+            const when = new Date(ev.ts * 1000).toLocaleString();
+            const label = ACTION_LABELS[p.action] ?? p.action;
+            return (
+              <div
+                key={ev.id}
+                className="flex items-start gap-2 px-3 py-2 rounded bg-white/3 border border-white/5 text-[11px]"
+                role="listitem"
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-1.5 flex-wrap">
+                    <span className="font-medium">{p.actor_user_id}</span>
+                    <span className="text-shell-text-tertiary">{label}</span>
+                    <code
+                      className="font-mono text-shell-text-secondary truncate max-w-[180px]"
+                      title={p.canonical_id}
+                    >
+                      {p.canonical_id}
+                    </code>
+                  </div>
+                  <div className="flex items-center gap-1 mt-0.5 text-shell-text-tertiary">
+                    <span>{p.before_status}</span>
+                    <ArrowRight size={10} aria-label="to" />
+                    <span>{p.after_status}</span>
+                    <span className="ml-2">{when}</span>
+                  </div>
+                </div>
+              </div>
+            );
+          })
+        )}
+      </div>
+    </section>
+  );
+}
+
+/* ------------------------------------------------------------------ */
 /*  RegistryPanel                                                       */
 /* ------------------------------------------------------------------ */
 
@@ -328,6 +460,7 @@ export function RegistryPanel() {
             />
           ))
         )}
+        <GovernanceAuditPanel isAdmin={isAdmin} />
       </div>
     </section>
   );

--- a/desktop/src/components/ConsentNotification.tsx
+++ b/desktop/src/components/ConsentNotification.tsx
@@ -1,0 +1,325 @@
+/**
+ * ConsentNotification — non-dismissable consent overlay for external-agent access requests.
+ *
+ * Polls /api/agents/auth-requests for pending entries. When found, shows a
+ * blocking overlay the user MUST answer before the desktop is usable. Supports
+ * per-scope toggles per the Trust & Comms Layer spec (Phase 2).
+ *
+ * Only admins can approve/deny (the backend enforces this too).
+ */
+
+import { useState, useEffect, useCallback } from "react";
+import {
+  ShieldQuestion,
+  CheckCircle,
+  XCircle,
+  Clock,
+  Tag,
+  Wrench,
+} from "lucide-react";
+
+/* ------------------------------------------------------------------ */
+/*  Types                                                               */
+/* ------------------------------------------------------------------ */
+
+interface AuthRequest {
+  id: string;
+  identity_claim: string;
+  framework: string;
+  requested_scopes: string[];
+  requested_skills: string[];
+  reason: string;
+  duration_secs: number | null;
+  project_id: string | null;
+  status: "pending" | "accepted" | "refused";
+  created_ts: string;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+function durationLabel(secs: number | null): string | null {
+  if (!secs) return null;
+  if (secs < 3600) return `${Math.round(secs / 60)} min`;
+  if (secs < 86400) return `${Math.round(secs / 3600)} h`;
+  return `${Math.round(secs / 86400)} d`;
+}
+
+const SCOPE_DESCRIPTIONS: Record<string, string> = {
+  memory_read: "Read from your memory store",
+  memory_write: "Write to your memory store",
+  a2a_send: "Send messages on the A2A bus",
+  a2a_receive: "Receive messages on the A2A bus",
+  files_read: "Read your files",
+  files_write: "Write to your files",
+  tools_execute: "Execute tools on your device",
+};
+
+/* ------------------------------------------------------------------ */
+/*  ConsentModal                                                        */
+/* ------------------------------------------------------------------ */
+
+function ConsentModal({
+  request,
+  onDecide,
+}: {
+  request: AuthRequest;
+  onDecide: (requestId: string, approved: boolean, scopes: string[]) => Promise<void>;
+}) {
+  const [toggledScopes, setToggledScopes] = useState<Set<string>>(
+    () => new Set(request.requested_scopes),
+  );
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  function toggleScope(scope: string) {
+    setToggledScopes((prev) => {
+      const next = new Set(prev);
+      if (next.has(scope)) next.delete(scope);
+      else next.add(scope);
+      return next;
+    });
+  }
+
+  async function decide(approved: boolean) {
+    setBusy(true);
+    setErr(null);
+    try {
+      await onDecide(request.id, approved, approved ? Array.from(toggledScopes) : []);
+    } catch (e: unknown) {
+      setErr(e instanceof Error ? e.message : String(e));
+      setBusy(false);
+    }
+  }
+
+  const dur = durationLabel(request.duration_secs);
+
+  return (
+    <div
+      className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/70 backdrop-blur-sm"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="consent-modal-title"
+    >
+      <div
+        className="w-full max-w-md mx-4 rounded-2xl border border-white/10 bg-shell-bg shadow-2xl overflow-hidden"
+        style={{ boxShadow: "0 32px 64px rgba(0,0,0,0.6), 0 0 0 1px rgba(255,255,255,0.07)" }}
+      >
+        {/* Header */}
+        <div className="px-6 pt-6 pb-4 border-b border-white/5">
+          <div className="flex items-start gap-3">
+            <div className="mt-0.5 p-2 rounded-xl bg-amber-500/15 shrink-0">
+              <ShieldQuestion size={20} className="text-amber-400" aria-hidden />
+            </div>
+            <div>
+              <h2
+                id="consent-modal-title"
+                className="text-base font-semibold leading-tight"
+              >
+                Access request
+              </h2>
+              <p className="text-sm text-shell-text-secondary mt-0.5">
+                An external agent is requesting access to your taOS resources.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Agent info */}
+        <div className="px-6 py-4 space-y-3 border-b border-white/5">
+          <div className="flex items-center gap-2">
+            <Tag size={13} className="text-shell-text-tertiary shrink-0" aria-hidden />
+            <div>
+              <span className="text-xs text-shell-text-tertiary">Identity</span>
+              <p className="text-sm font-medium break-all">{request.identity_claim}</p>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-4 flex-wrap">
+            <div>
+              <span className="text-xs text-shell-text-tertiary">Framework</span>
+              <p className="text-sm">{request.framework}</p>
+            </div>
+            {dur && (
+              <div className="flex items-center gap-1.5">
+                <Clock size={12} className="text-shell-text-tertiary" aria-hidden />
+                <div>
+                  <span className="text-xs text-shell-text-tertiary">Duration</span>
+                  <p className="text-sm">{dur}</p>
+                </div>
+              </div>
+            )}
+            {request.project_id && (
+              <div>
+                <span className="text-xs text-shell-text-tertiary">Project</span>
+                <p className="text-sm font-mono text-xs">{request.project_id}</p>
+              </div>
+            )}
+          </div>
+
+          {request.reason && (
+            <div>
+              <span className="text-xs text-shell-text-tertiary">Reason</span>
+              <p className="text-sm italic text-shell-text-secondary">
+                "{request.reason}"
+              </p>
+            </div>
+          )}
+        </div>
+
+        {/* Scopes */}
+        {request.requested_scopes.length > 0 && (
+          <div className="px-6 py-4 border-b border-white/5">
+            <p className="text-xs font-medium text-shell-text-tertiary uppercase tracking-wider mb-3">
+              Requested permissions
+            </p>
+            <ul className="space-y-2" aria-label="Requested permission scopes">
+              {request.requested_scopes.map((scope) => (
+                <li key={scope} className="flex items-center gap-3">
+                  <button
+                    role="checkbox"
+                    aria-checked={toggledScopes.has(scope)}
+                    onClick={() => toggleScope(scope)}
+                    disabled={busy}
+                    className={`w-10 h-6 rounded-full transition-colors flex items-center shrink-0 ${
+                      toggledScopes.has(scope)
+                        ? "bg-emerald-600 justify-end"
+                        : "bg-white/10 justify-start"
+                    } px-1`}
+                    aria-label={`${toggledScopes.has(scope) ? "Revoke" : "Grant"} ${scope} permission`}
+                  >
+                    <span className="w-4 h-4 rounded-full bg-white shadow-sm block" />
+                  </button>
+                  <div className="flex-1 min-w-0">
+                    <span className="text-sm font-mono text-shell-text-secondary">{scope}</span>
+                    {SCOPE_DESCRIPTIONS[scope] && (
+                      <p className="text-[11px] text-shell-text-tertiary">
+                        {SCOPE_DESCRIPTIONS[scope]}
+                      </p>
+                    )}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {/* Skills */}
+        {request.requested_skills.length > 0 && (
+          <div className="px-6 py-3 border-b border-white/5">
+            <div className="flex items-center gap-2 mb-2">
+              <Wrench size={12} className="text-shell-text-tertiary" aria-hidden />
+              <span className="text-xs font-medium text-shell-text-tertiary uppercase tracking-wider">
+                Requested skills
+              </span>
+            </div>
+            <ul className="flex flex-wrap gap-1.5" aria-label="Requested skills">
+              {request.requested_skills.map((skill) => (
+                <li
+                  key={skill}
+                  className="px-2 py-0.5 rounded bg-white/5 border border-white/10 text-xs font-mono"
+                >
+                  {skill}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="px-6 py-4">
+          {err && (
+            <p className="text-xs text-red-400 mb-3" role="alert">{err}</p>
+          )}
+          <div className="flex gap-3">
+            <button
+              onClick={() => decide(false)}
+              disabled={busy}
+              aria-label="Deny access request"
+              className="flex-1 flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl text-sm font-medium bg-white/5 hover:bg-red-500/15 hover:text-red-300 border border-white/10 hover:border-red-500/30 transition-colors disabled:opacity-50"
+            >
+              <XCircle size={15} aria-hidden />
+              Deny
+            </button>
+            <button
+              onClick={() => decide(true)}
+              disabled={busy || toggledScopes.size === 0}
+              aria-label="Approve access request with selected scopes"
+              className="flex-1 flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl text-sm font-medium bg-emerald-600 hover:bg-emerald-500 text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <CheckCircle size={15} aria-hidden />
+              {busy ? "Approving…" : `Allow${toggledScopes.size < request.requested_scopes.length ? ` (${toggledScopes.size} scope${toggledScopes.size !== 1 ? "s" : ""})` : ""}`}
+            </button>
+          </div>
+          <p className="text-[11px] text-shell-text-tertiary text-center mt-2">
+            You must accept or deny before continuing
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  ConsentNotification (global poller + renderer)                     */
+/* ------------------------------------------------------------------ */
+
+const POLL_INTERVAL_MS = 5_000;
+
+export function ConsentNotification() {
+  const [pendingRequests, setPendingRequests] = useState<AuthRequest[]>([]);
+  const [isAdmin, setIsAdmin] = useState(false);
+
+  const fetchPending = useCallback(async () => {
+    try {
+      const [statusResp, reqResp] = await Promise.all([
+        fetch("/auth/status", { credentials: "include" }),
+        fetch("/api/agents/auth-requests?status=pending", { credentials: "include" }),
+      ]);
+      if (statusResp.ok) {
+        const s = await statusResp.json();
+        setIsAdmin(!!s.user?.is_admin);
+      }
+      if (reqResp.ok) {
+        const data = await reqResp.json();
+        const requests = (data.requests ?? data ?? []) as AuthRequest[];
+        setPendingRequests(requests.filter((r) => r.status === "pending"));
+      }
+    } catch { /* silent — user may not be logged in yet */ }
+  }, []);
+
+  useEffect(() => {
+    fetchPending();
+    const interval = setInterval(fetchPending, POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [fetchPending]);
+
+  async function handleDecide(requestId: string, approved: boolean, scopes: string[]) {
+    const method = "POST";
+    const url = approved
+      ? `/api/agents/auth-requests/${encodeURIComponent(requestId)}/approve`
+      : `/api/agents/auth-requests/${encodeURIComponent(requestId)}/deny`;
+    const body = approved ? JSON.stringify({ granted_scopes: scopes }) : undefined;
+
+    const resp = await fetch(url, {
+      method,
+      headers: body ? { "Content-Type": "application/json" } : {},
+      body,
+      credentials: "include",
+    });
+    if (!resp.ok) {
+      const err = await resp.json().catch(() => ({}));
+      throw new Error((err as { detail?: string }).detail ?? `HTTP ${resp.status}`);
+    }
+    // Remove the decided request from the list and re-poll.
+    setPendingRequests((prev) => prev.filter((r) => r.id !== requestId));
+    await fetchPending();
+  }
+
+  if (!isAdmin || pendingRequests.length === 0) return null;
+
+  // Show the oldest pending request first (FIFO).
+  const current = pendingRequests[0]!;
+  return <ConsentModal request={current} onDecide={handleDecide} />;
+}

--- a/docs/AGENT_HANDOFF.md
+++ b/docs/AGENT_HANDOFF.md
@@ -1,0 +1,66 @@
+# Agent Handoff Playbook
+
+**Why this exists.** Work on taOS runs across rate-limit-prone agents on different platforms (Claude Code, Cursor, Codex, web, etc.). When one hits a limit, another picks up. The failure mode to prevent: an incoming agent acting on **stale knowledge** — re-doing finished work, missing in-flight tasks, or clobbering a branch. This playbook + `STATUS.md` + GitHub issues make the project's state **durable and platform-independent** so a handoff never loses work.
+
+The golden rule: **durable state lives in three committed/hosted places, not in any one agent's memory** — (1) GitHub issues, (2) `docs/STATUS.md`, (3) the A2A bus. If it isn't in one of those, the next agent can't see it.
+
+---
+
+## On arrival — orient before you act (5 steps, ~2 min)
+
+Run these before touching anything:
+
+1. **Read `docs/STATUS.md`** (repo root → docs/). Current branch tips, open PRs, in-flight work, blockers.
+2. **`git fetch origin && git log origin/master..origin/dev --oneline`** — what's on dev not yet promoted.
+3. **`gh issue list --state open --limit 40`** — the canonical task list. `gh pr list --state open` — what's mid-review.
+4. **A2A bus tail** (live coordination): `curl -s "http://<pi>:7900/a2a/messages?thread=general&limit=15"` (also observability, integration). The Pi IP is in your private notes, not committed here.
+5. **(Claude Code only) `~/.claude/.../memory/MEMORY.md`** — durable context index. Other platforms: skip; everything you need is in 1–4.
+
+Only after those: pick the top unblocked GitHub issue, or continue what `STATUS.md` says is in flight.
+
+---
+
+## Identity & non-negotiable rules
+
+- **Git identity:** `user.name=jaylfc`, `user.email=jaylfc25@gmail.com`. ALL activity appears as jaylfc.
+- **No AI attribution** anywhere — commits, PR bodies, issue comments. No "Co-Authored-By: Claude", no "Generated with…". Public repos must read as fully human-authored.
+- **No secrets in git:** no IPs, tokens, credentials, Tailscale IPs, env-specific config. The Pi IP and bus URL stay out of committed files.
+- **Branch policy:** small fixes → straight to `dev`. Features/refactors/redesigns → a branch + PR to `dev`. `master` is **protected** — promote only via a `dev`→`master` PR (squash). **NEVER `--delete-branch` on a dev→master PR** — deleting `dev` auto-closes every open PR that targets it.
+- **Verify before claiming done:** run the tests/commands, paste real output. Evidence before assertions.
+
+---
+
+## When YOU get rate-limited — hand off cleanly (do this the moment you see the limit warning, if you still can)
+
+1. **Commit or stash WIP** on a branch (never leave uncommitted work that only your session knows about). Push it.
+2. **Update `docs/STATUS.md`**: move your task to "In flight" with the branch name + exactly where you stopped + the next concrete step.
+3. **Post one A2A note** as your handle: what you finished, what's mid-flight, the branch, the next step.
+4. **(Claude Code) update memory** if a durable fact changed.
+
+If the limit hits before you can do this, the incoming agent recovers from: last pushed commit + open PR + `STATUS.md` + issues. That's why you push early and often.
+
+---
+
+## The freshness cron (keeps the durable layer honest)
+
+An hourly sweep (session-scoped on the active agent; the Pi's :00/:30 cron is the durable backstop) re-checks README / docs / memory / `STATUS.md` against merged commits and fixes trivial drift, opens PRs for bigger rewrites. If you are the active driver, keep it armed. Its job is to ensure steps 1–5 above never read stale.
+
+---
+
+## Task hygiene — so nothing is lost
+
+- **Every feature idea, bug, or TODO → a GitHub issue immediately.** Ideas in chat or memory evaporate across a handoff; issues don't. Label them (`feature`, `bug`, `security`, `docs`, `infra`).
+- **One issue = one pickup-able unit** with enough context that a cold agent can start it.
+- `STATUS.md` links to issues; it does not duplicate them.
+
+---
+
+## The durable stores at a glance
+
+| Store | Scope | Visible to | Use for |
+|-------|-------|-----------|---------|
+| GitHub issues | canonical task list | every platform | backlog, features, bugs, audit findings |
+| `docs/STATUS.md` | current snapshot | every platform (in repo) | "where are we right now" |
+| `docs/AGENT_HANDOFF.md` | the rules + protocol | every platform (in repo) | onboarding, identity, hop protocol |
+| A2A bus (:7900) | live coordination | the 3 bus agents | real-time @mentions, decisions |
+| @taOS Pi memory | durable context | Claude Code only | per-session continuity for CC |

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -13,18 +13,29 @@
 
 # taOS — Live Status
 
-**Last updated:** 2026-06-10 ~14:00 BST · by @taOS (Mac session, claude-fable-5)
+**Last updated:** 2026-06-10 ~14:30 BST · by @taOS (Mac session, claude-fable-5)
 **Repo:** github.com/jaylfc/taOS · **Branches:** `master` (stable, installs track) ← `dev` (integration)
 
 ## Branch state
 - `master` tip: `a13692de` — promotion #727 (install fixes + registry governance PR2)
 - `dev` tip: `dfee2b0f` — consent scope validation (#733), ahead of master by 7 commits
-- **Open PR `#734`** (dev→master promotion): CI GREEN + mergeable, but a GitHub merge-endpoint 401 blocked auto-merge. **ACTION: needs a manual merge** — `gh pr merge 734 --squash --admin` (or the green button). Non-destructive; do NOT `--delete-branch` (deleting `dev` auto-closes every PR that targets it — burned once on 2026-06-10).
+- **Open PR `#734`** (dev→master promotion): CI GREEN + mergeable. The CLI admin-merge over API persistently 401s against the protected `master` branch (a token/branch-protection limitation, not a CI failure). **ACTION (Jay): click "Merge" on PR #734 in the GitHub UI** — one click, the browser session bypasses the CLI-token limitation. Squash. Do NOT `--delete-branch` (deleting `dev` auto-closes every PR that targets it — burned once on 2026-06-10).
 
 ## In flight
-- **Repo audit** (principal-level, 4-phase): Phases 1–2 mostly done (7 of 8 dimensions; testing dimension interrupted by rate limit, needs re-run). Findings being folded into GitHub issues. Deliverable doc → `docs/audit/2026-06-10-repo-audit.md` (pending).
-- **Multi-agent resilience workflow** (this file + `AGENT_HANDOFF.md` + issues): in progress.
-- **Bug/feedback tracker feature**: to be filed as an issue (in-taOS form → DB → curate → draft replies → file issues).
+- **Repo audit** (principal-level, 4-phase): Phases 1–2 done (8 dimensions; testing got lighter review after a rate limit). NEW findings folded into issues #737 #738 #739 #740 #743; many findings corroborate existing issues (#672 #648 #646 #653 #642 #639 #660 #657 #655). Synthesized report doc → `docs/audit/2026-06-10-repo-audit.md` still **pending** (exec summary + themes + milestone plan).
+- **Multi-agent resilience workflow** — DONE (this file + `AGENT_HANDOFF.md`, commit 29172153) + tracked in #741.
+- **Bug/feedback tracker feature** — filed as #735 (+ websites #736).
+
+## Open feature / improvement issues (filed 2026-06-10)
+- `#735` feedback & bug tracker (in-taOS form → curated DB → issue triage)
+- `#736` websites: taos.my + tinyagentos.com redirect
+- `#741` cross-agent resilience workflow (STATUS/HANDOFF/cron)
+- `#742` memory-unification migrate cutover (deferred until real data)
+- `#737` security: unauthenticated cluster worker register/heartbeat (High)
+- `#738` security: SSRF in knowledge ingest (Medium-High)
+- `#739` CI: enforce ruff + run vitest + npm audit (quick win)
+- `#740` deps: no Python lockfile / non-reproducible installs
+- `#743` docs drift (getting-started /opt path = High, design docs, CONTRIBUTING htmx)
 
 ## Recently merged (dev, last batch)
 `#733` consent scope allowlist + granted⊆requested · `c1fb3f98` live taosmd hit-shape fix · `#732` taosmd→PyPI pin · `#731` consent notification UI · `#730` governance audit panel · `#728` user-memory proxy hardening · `#729` registry approval UI.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,0 +1,47 @@
+<!--
+  SINGLE SOURCE OF TRUTH for cross-agent handoff. Committed to the repo so it is
+  visible to ANY agent on ANY platform (Claude Code, Cursor, Codex, web, etc.) —
+  not just sessions that share the Pi memory store.
+
+  CONTRACT: update this file whenever you (a) merge work, (b) start a sizeable task,
+  (c) get rate-limited mid-task, or (d) hand off. The hourly freshness cron also
+  refreshes the "Branch state" + "Recently merged" blocks. Keep it SHORT — link to
+  GitHub issues for detail; this is the dashboard, not the archive.
+
+  See docs/AGENT_HANDOFF.md for the on-arrival checklist and the hop protocol.
+-->
+
+# taOS — Live Status
+
+**Last updated:** 2026-06-10 ~14:00 BST · by @taOS (Mac session, claude-fable-5)
+**Repo:** github.com/jaylfc/taOS · **Branches:** `master` (stable, installs track) ← `dev` (integration)
+
+## Branch state
+- `master` tip: `a13692de` — promotion #727 (install fixes + registry governance PR2)
+- `dev` tip: `dfee2b0f` — consent scope validation (#733), ahead of master by 7 commits
+- **Open PR `#734`** (dev→master promotion): CI GREEN + mergeable, but a GitHub merge-endpoint 401 blocked auto-merge. **ACTION: needs a manual merge** — `gh pr merge 734 --squash --admin` (or the green button). Non-destructive; do NOT `--delete-branch` (deleting `dev` auto-closes every PR that targets it — burned once on 2026-06-10).
+
+## In flight
+- **Repo audit** (principal-level, 4-phase): Phases 1–2 mostly done (7 of 8 dimensions; testing dimension interrupted by rate limit, needs re-run). Findings being folded into GitHub issues. Deliverable doc → `docs/audit/2026-06-10-repo-audit.md` (pending).
+- **Multi-agent resilience workflow** (this file + `AGENT_HANDOFF.md` + issues): in progress.
+- **Bug/feedback tracker feature**: to be filed as an issue (in-taOS form → DB → curate → draft replies → file issues).
+
+## Recently merged (dev, last batch)
+`#733` consent scope allowlist + granted⊆requested · `c1fb3f98` live taosmd hit-shape fix · `#732` taosmd→PyPI pin · `#731` consent notification UI · `#730` governance audit panel · `#728` user-memory proxy hardening · `#729` registry approval UI.
+
+## Cross-project (taosmd / A2A)
+- **#25 memory unification: DONE both sides.** taosmd `feat/user-memory-unification` merged to taosmd master (PR #149, `71e913a`); `/ingest/batch` + `?mode=bm25` live on the Pi serve (:7900), verified end-to-end. taOS proxy (`routes/user_memory.py`) points at it. **Next:** run `POST /api/user-memory/migrate` cutover when there's real user data (none yet).
+- **Trust & Comms enforcement: live** on taosmd (GrantsVerifier), dormant until `TAOSMD_REGISTRY_URL` is configured — held behind the consent flow by design.
+- A2A bus: `http://<pi>:7900`, channels general/observability/integration. @taOSmd (memory/bench), @hermes (framework agent), @taOS (this/controller).
+
+## Blocked / waiting on human (Jay)
+- `#734` manual merge (token write-endpoint hiccup — see Branch state).
+- `#15` exo fork deletion — needs `gh auth refresh -s delete_repo` run by Jay.
+- `TAOSMD_REGISTRY_URL` cutover — deliberate, gated on consent UI shipping.
+
+## Where to look (durable stores, in priority order)
+1. **GitHub issues** = the task list. `gh issue list --state open`. Cross-platform, the canonical backlog.
+2. **This file** = current snapshot.
+3. **`docs/AGENT_HANDOFF.md`** = how to get oriented + the rules + the hop protocol.
+4. **A2A bus** (`:7900`) = live inter-agent coordination (transient).
+5. **@taOS memory** on the Pi (`~/.claude/projects/-home-jay-Development-tinyagentos/memory/`) = durable context for Claude Code sessions (NOT visible to other platforms — that's why this file exists).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ dependencies = [
     "libtorrent>=2.0.9",
     "lxml>=5.0.0",
     "readability-lxml>=0.8.1",
-    # Memory system — standalone package, pulled from GitHub
-    "taosmd @ git+https://github.com/jaylfc/taosmd.git@master",
+    # Memory system — published to PyPI
+    "taosmd==0.3.0",
     # WebSocket client for dashboard proxy (shortcut_proxy.py)
     "websockets>=12.0",
     # Web Push VAPID signing — pulls in cryptography, http-ece, py-vapid

--- a/tests/test_auth_requests.py
+++ b/tests/test_auth_requests.py
@@ -51,13 +51,13 @@ class TestAuthRequestsStore:
             record = await store.create(
                 identity_claim="my-agent",
                 framework="hermes",
-                requested_scopes=["memory:read", "memory:write"],
+                requested_scopes=["memory_read", "memory_write"],
                 reason="need access to memory",
             )
             assert record["status"] == "pending"
             assert record["identity_claim"] == "my-agent"
             assert record["framework"] == "hermes"
-            assert record["requested_scopes"] == ["memory:read", "memory:write"]
+            assert record["requested_scopes"] == ["memory_read", "memory_write"]
             assert record["reason"] == "need access to memory"
             assert record["canonical_id"] is None
             assert record["token"] is None
@@ -73,21 +73,21 @@ class TestAuthRequestsStore:
             record = await store.create(
                 identity_claim="agent-a",
                 framework="openclaw",
-                requested_scopes=["memory:read"],
+                requested_scopes=["memory_read"],
             )
             updated = await store.set_decision(
                 record["id"],
                 "accepted",
                 canonical_id="agent-a-20260609-120000",
                 token="fake.token.value",
-                granted_scopes=["memory:read"],
+                granted_scopes=["memory_read"],
                 decided_by="admin-user",
             )
             assert updated is not None
             assert updated["status"] == "accepted"
             assert updated["canonical_id"] == "agent-a-20260609-120000"
             assert updated["token"] == "fake.token.value"
-            assert updated["granted_scopes"] == ["memory:read"]
+            assert updated["granted_scopes"] == ["memory_read"]
             assert updated["decided_by"] == "admin-user"
             assert updated["decided_ts"] is not None
         finally:
@@ -99,7 +99,7 @@ class TestAuthRequestsStore:
             record = await store.create(
                 identity_claim="agent-b",
                 framework="hermes",
-                requested_scopes=["memory:read"],
+                requested_scopes=["memory_read"],
             )
             updated = await store.set_decision(
                 record["id"],
@@ -120,7 +120,7 @@ class TestAuthRequestsStore:
             record = await store.create(
                 identity_claim="agent-c",
                 framework="hermes",
-                requested_scopes=["memory:read"],
+                requested_scopes=["memory_read"],
             )
             # First decision succeeds.
             first = await store.set_decision(
@@ -292,7 +292,7 @@ async def consent_client_nonadmin(app, tmp_data_dir):
 _CREATE_BODY = {
     "identity_claim": "my-external-agent",
     "framework": "hermes",
-    "requested_scopes": ["memory:read", "memory:write"],
+    "requested_scopes": ["memory_read", "memory_write"],
     "reason": "I need access to memory for context",
 }
 
@@ -335,7 +335,7 @@ class TestAuthRequestRoutes:
 
         resp = await consent_client.post(
             f"/api/agents/auth-requests/{request_id}/approve",
-            json={"granted_scopes": ["memory:read"]},
+            json={"granted_scopes": ["memory_read"]},
         )
         assert resp.status_code == 200
         data = resp.json()
@@ -345,7 +345,7 @@ class TestAuthRequestRoutes:
 
         # Check grants were written.
         grants = await consent_client._transport.app.state.agent_grants.list_grants(canonical_id)
-        assert any(g["scope"] == "memory:read" for g in grants)
+        assert any(g["scope"] == "memory_read" for g in grants)
 
         # Approval must ACTIVATE the agent — external-selfjoin lands 'pending';
         # consent-approve transitions it to 'active' so it's not in the bus
@@ -365,7 +365,7 @@ class TestAuthRequestRoutes:
 
         await consent_client.post(
             f"/api/agents/auth-requests/{request_id}/approve",
-            json={"granted_scopes": ["memory:read"]},
+            json={"granted_scopes": ["memory_read"]},
         )
 
         # Poll status as the external agent would (no auth).
@@ -389,9 +389,39 @@ class TestAuthRequestRoutes:
 
         resp = await consent_client_nonadmin.post(
             f"/api/agents/auth-requests/{request_id}/approve",
-            json={"granted_scopes": ["memory:read"]},
+            json={"granted_scopes": ["memory_read"]},
         )
         assert resp.status_code == 403
+
+    async def test_create_with_unknown_scope_returns_400(self, consent_client):
+        transport = ASGITransport(app=consent_client._transport.app)
+        async with AsyncClient(transport=transport, base_url="http://test") as bare:
+            resp = await bare.post(
+                "/api/agents/auth-requests",
+                json={**_CREATE_BODY, "requested_scopes": ["memory_read", "root_shell"]},
+            )
+        assert resp.status_code == 400
+        assert "root_shell" in resp.json()["detail"]
+
+    async def test_approve_scope_not_requested_returns_400(self, consent_client):
+        """The admin can narrow the requested scopes but never widen them."""
+        transport = ASGITransport(app=consent_client._transport.app)
+        async with AsyncClient(transport=transport, base_url="http://test") as bare:
+            create_resp = await bare.post("/api/agents/auth-requests", json=_CREATE_BODY)
+            request_id = create_resp.json()["request_id"]
+
+        # _CREATE_BODY requests memory_read + memory_write only.
+        resp = await consent_client.post(
+            f"/api/agents/auth-requests/{request_id}/approve",
+            json={"granted_scopes": ["memory_read", "tools_execute"]},
+        )
+        assert resp.status_code == 400
+        assert "tools_execute" in resp.json()["detail"]
+
+        # The request must still be pending (no side effects from the rejection).
+        async with AsyncClient(transport=transport, base_url="http://test") as bare:
+            status_resp = await bare.get(f"/api/agents/auth-requests/{request_id}")
+        assert status_resp.json()["status"] == "pending"
 
     async def test_approve_unknown_request_returns_404(self, consent_client):
         resp = await consent_client.post(
@@ -409,12 +439,12 @@ class TestAuthRequestRoutes:
         # First approve succeeds.
         await consent_client.post(
             f"/api/agents/auth-requests/{request_id}/approve",
-            json={"granted_scopes": ["memory:read"]},
+            json={"granted_scopes": ["memory_read"]},
         )
         # Second approve → 409 (already decided).
         resp2 = await consent_client.post(
             f"/api/agents/auth-requests/{request_id}/approve",
-            json={"granted_scopes": ["memory:read"]},
+            json={"granted_scopes": ["memory_read"]},
         )
         assert resp2.status_code == 409
 
@@ -503,7 +533,7 @@ class TestAuthRequestRoutes:
             create_resp = await bare.post("/api/agents/auth-requests", json=_CREATE_BODY)
         request_id = create_resp.json()["request_id"]
 
-        approve_body = {"granted_scopes": ["memory:read"]}
+        approve_body = {"granted_scopes": ["memory_read"]}
         cookies = dict(consent_client.cookies)
 
         async def do_approve():
@@ -530,15 +560,15 @@ class TestAuthRequestRoutes:
 
         await consent_client.post(
             f"/api/agents/auth-requests/{request_id}/approve",
-            json={"granted_scopes": ["memory:read", "memory:write"]},
+            json={"granted_scopes": ["memory_read", "memory_write"]},
         )
 
         resp = await consent_client.get("/api/agents/registry/grants")
         assert resp.status_code == 200
         grants = resp.json()["grants"]
         scopes = {g["scope"] for g in grants}
-        assert "memory:read" in scopes
-        assert "memory:write" in scopes
+        assert "memory_read" in scopes
+        assert "memory_write" in scopes
 
     async def test_grants_feed_nonadmin_returns_403(self, consent_client_nonadmin):
         resp = await consent_client_nonadmin.get("/api/agents/registry/grants")
@@ -553,7 +583,7 @@ class TestAuthRequestRoutes:
 
         approve_resp = await consent_client.post(
             f"/api/agents/auth-requests/{request_id}/approve",
-            json={"granted_scopes": ["memory:read"]},
+            json={"granted_scopes": ["memory_read"]},
         )
         canonical_id = approve_resp.json()["canonical_id"]
 

--- a/tests/test_user_memory.py
+++ b/tests/test_user_memory.py
@@ -101,3 +101,118 @@ async def test_fts5_injection_does_not_escape_user_filter(store):
     # fix the whole string is treated as a single phrase and matches nothing.
     results = await store.search("attacker", 'x" OR "secret')
     assert all(r["content"] != "secret data" for r in results)
+
+
+# ---------------------------------------------------------------------------
+# Route-level proxy tests
+# ---------------------------------------------------------------------------
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+from httpx import ASGITransport, AsyncClient as HttpxAsyncClient
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture
+async def mem_client(app, tmp_data_dir):
+    """Admin HTTP client with user_memory store initialised."""
+    store = app.state.user_memory
+    if store._db is None:
+        await store.init()
+    metrics = app.state.metrics
+    if metrics._db is None:
+        await metrics.init()
+    app.state.auth.setup_user("admin", "Admin", "", "testpass")
+    record = app.state.auth.find_user("admin")
+    token = app.state.auth.create_session(user_id=record["id"], long_lived=True)
+    app.state._startup_complete = True
+    transport = ASGITransport(app=app)
+    async with HttpxAsyncClient(
+        transport=transport, base_url="http://test", cookies={"taos_session": token}
+    ) as c:
+        yield c, store
+    await store.close()
+    await metrics.close()
+
+
+@pytest.mark.asyncio
+async def test_search_falls_back_to_sqlite_when_taosmd_unreachable(app, mem_client, tmp_data_dir):
+    client, store = mem_client
+    await store.save_chunk("user", "fallback content", "T", "snippets")
+    app.state.taosmd_url = "http://localhost:19999"
+    try:
+        resp = await client.get("/api/user-memory/search", params={"q": "fallback"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["backend"] == "sqlite"
+        assert any("fallback" in r["content"] for r in data["results"])
+    finally:
+        app.state.taosmd_url = None
+
+
+@pytest.mark.asyncio
+async def test_search_uses_taosmd_when_available(mem_client, tmp_data_dir):
+    client, store = mem_client
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {
+        "hits": [{"content": "taosmd result", "metadata": {"collection": "snippets"}}]
+    }
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.get = AsyncMock(return_value=mock_resp)
+
+    with patch("tinyagentos.routes.user_memory.httpx.AsyncClient", return_value=mock_client):
+        resp = await client.get("/api/user-memory/search", params={"q": "test"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["backend"] == "taosmd"
+    assert data["results"][0]["content"] == "taosmd result"
+
+
+@pytest.mark.asyncio
+async def test_save_writes_to_sqlite_and_ingest_to_taosmd(mem_client, tmp_data_dir):
+    client, store = mem_client
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.post = AsyncMock(return_value=MagicMock(status_code=200))
+
+    with patch("tinyagentos.routes.user_memory.httpx.AsyncClient", return_value=mock_client):
+        resp = await client.post(
+            "/api/user-memory/save",
+            json={"content": "dual write", "title": "T", "collection": "snippets"},
+        )
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+    # SQLite should have the chunk too
+    chunks = await store.browse("user")
+    assert any(c["content"] == "dual write" for c in chunks)
+
+
+@pytest.mark.asyncio
+async def test_save_succeeds_even_when_taosmd_unreachable(app, mem_client, tmp_data_dir):
+    client, store = mem_client
+    app.state.taosmd_url = "http://localhost:19999"
+    try:
+        resp = await client.post(
+            "/api/user-memory/save",
+            json={"content": "resilient", "collection": "notes"},
+        )
+        assert resp.status_code == 200
+        chunks = await store.browse("user")
+        assert any(c["content"] == "resilient" for c in chunks)
+    finally:
+        app.state.taosmd_url = None
+
+
+@pytest.mark.asyncio
+async def test_migrate_returns_503_when_taosmd_unreachable(app, mem_client, tmp_data_dir):
+    client, _ = mem_client
+    app.state.taosmd_url = "http://localhost:19999"
+    try:
+        resp = await client.post("/api/user-memory/migrate")
+        assert resp.status_code == 503
+    finally:
+        app.state.taosmd_url = None

--- a/tests/test_user_memory.py
+++ b/tests/test_user_memory.py
@@ -155,8 +155,16 @@ async def test_search_uses_taosmd_when_available(mem_client, tmp_data_dir):
     client, store = mem_client
     mock_resp = MagicMock()
     mock_resp.status_code = 200
+    # Real live hit shape from taosmd /search?mode=bm25: content is in
+    # "text", the chunk id only in metadata.source_id (verified live 2026-06-10).
     mock_resp.json.return_value = {
-        "hits": [{"content": "taosmd result", "metadata": {"collection": "snippets"}}]
+        "hits": [{
+            "text": "taosmd result",
+            "source": "vector",
+            "timestamp": 1781092259.28,
+            "confidence": 0.0476,
+            "metadata": {"collection": "snippets", "title": "T", "source_id": "abc123def4567890"},
+        }]
     }
     mock_client = AsyncMock()
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
@@ -169,6 +177,8 @@ async def test_search_uses_taosmd_when_available(mem_client, tmp_data_dir):
     data = resp.json()
     assert data["backend"] == "taosmd"
     assert data["results"][0]["content"] == "taosmd result"
+    assert data["results"][0]["hash"] == "abc123def4567890"
+    assert data["results"][0]["title"] == "T"
 
 
 @pytest.mark.asyncio

--- a/tests/test_user_memory.py
+++ b/tests/test_user_memory.py
@@ -216,3 +216,59 @@ async def test_migrate_returns_503_when_taosmd_unreachable(app, mem_client, tmp_
         assert resp.status_code == 503
     finally:
         app.state.taosmd_url = None
+
+
+@pytest.mark.asyncio
+async def test_browse_offset_pages_through_rows(store):
+    for i in range(5):
+        await store.save_chunk("user", f"chunk number {i}", f"T{i}", "snippets")
+    first = await store.browse("user", limit=2, offset=0)
+    second = await store.browse("user", limit=2, offset=2)
+    third = await store.browse("user", limit=2, offset=4)
+    assert len(first) == 2 and len(second) == 2 and len(third) == 1
+    hashes = {c["hash"] for c in first + second + third}
+    assert len(hashes) == 5  # no overlap between pages
+
+
+@pytest.mark.asyncio
+async def test_save_metadata_cannot_override_source_id(mem_client, tmp_data_dir):
+    """Caller-supplied metadata must not clobber the server-owned dedup key."""
+    client, _ = mem_client
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.post = AsyncMock(return_value=MagicMock(status_code=200))
+
+    with patch("tinyagentos.routes.user_memory.httpx.AsyncClient", return_value=mock_client):
+        resp = await client.post(
+            "/api/user-memory/save",
+            json={
+                "content": "override attempt",
+                "collection": "snippets",
+                "metadata": {"source_id": "evil", "collection": "other", "custom": "kept"},
+            },
+        )
+    assert resp.status_code == 200
+    saved_hash = resp.json()["hash"]
+    sent_meta = mock_client.post.call_args.kwargs["json"]["metadata"]
+    assert sent_meta["source_id"] == saved_hash
+    assert sent_meta["collection"] == "snippets"
+    assert sent_meta["custom"] == "kept"
+
+
+@pytest.mark.asyncio
+async def test_migrate_error_response_does_not_leak_exception_text(mem_client, tmp_data_dir):
+    """The /migrate 500 path must not reflect raw exception text to callers."""
+    client, store = mem_client
+    await store.save_chunk("user", "to migrate", "T", "snippets")
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.get = AsyncMock(return_value=MagicMock(status_code=200))  # health OK
+    mock_client.post = AsyncMock(side_effect=RuntimeError("http://internal-taosmd:7900 boom"))
+
+    with patch("tinyagentos.routes.user_memory.httpx.AsyncClient", return_value=mock_client):
+        resp = await client.post("/api/user-memory/migrate")
+    assert resp.status_code == 500
+    assert "internal-taosmd" not in resp.text
+    assert resp.json()["error"] == "taosmd ingest failed"

--- a/tinyagentos/routes/agent_auth_requests.py
+++ b/tinyagentos/routes/agent_auth_requests.py
@@ -39,6 +39,18 @@ router = APIRouter()
 # identity_claim + framework before new submissions are rate-limited.
 _PENDING_CAP = 5
 
+# Closed vocabulary of grantable scopes — must stay in sync with the
+# SCOPE_DESCRIPTIONS map in desktop/src/components/ConsentNotification.tsx.
+VALID_SCOPES = frozenset({
+    "memory_read",
+    "memory_write",
+    "a2a_send",
+    "a2a_receive",
+    "files_read",
+    "files_write",
+    "tools_execute",
+})
+
 
 # ---------------------------------------------------------------------------
 # Request bodies
@@ -120,6 +132,16 @@ async def create_auth_request(request: Request, body: CreateAuthRequest):
     Returns {request_id, status: 'pending'}.
     """
     store = _get_auth_requests_store(request)
+
+    # Only known scopes may be requested — reject unknown ones up front so
+    # the admin is never shown (and can never approve) a scope the system
+    # does not actually enforce.
+    unknown = sorted(set(body.requested_scopes) - VALID_SCOPES)
+    if unknown:
+        raise HTTPException(
+            status_code=400,
+            detail=f"unknown scopes: {unknown}; valid: {sorted(VALID_SCOPES)}",
+        )
 
     # Abuse cap: reject if too many pending requests from the same identity.
     pending_count = await store.count_pending_for(
@@ -207,6 +229,21 @@ async def _do_approve(request: Request, request_id: str, body: ApproveBody, user
         raise HTTPException(
             status_code=409,
             detail=f"request is already {record['status']!r}; cannot approve",
+        )
+
+    # The admin can narrow the requested scopes but never widen them, and
+    # every granted scope must be in the closed vocabulary (defence in depth
+    # for pending records created before scope validation existed).
+    requested = set(record["requested_scopes"] or [])
+    granted = set(body.granted_scopes)
+    invalid = sorted((granted - requested) | (granted - VALID_SCOPES))
+    if invalid:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"granted scopes must be a subset of the requested scopes; "
+                f"not grantable: {invalid}"
+            ),
         )
 
     registry = _get_registry_store(request)

--- a/tinyagentos/routes/user_memory.py
+++ b/tinyagentos/routes/user_memory.py
@@ -135,14 +135,22 @@ async def save(request: Request):
     base = _taosmd_base(request)
     try:
         async with httpx.AsyncClient(timeout=5.0) as client:
-            await client.post(
+            resp = await client.post(
                 f"{base}/ingest",
                 json={
                     "text": content,
                     "agent": _TAOSMD_AGENT,
-                    "metadata": {"collection": collection, "title": title, "source_id": h, **metadata},
+                    # Caller metadata first so the server-owned keys win —
+                    # source_id is taosmd's dedup key and must not be
+                    # overridable from the request body.
+                    "metadata": {**metadata, "collection": collection, "title": title, "source_id": h},
                 },
             )
+            if resp.status_code >= 400:
+                logger.debug(
+                    "taosmd ingest returned %s — chunk saved to SQLite only",
+                    resp.status_code,
+                )
     except Exception:
         logger.debug("taosmd ingest unavailable — chunk saved to SQLite only")
 
@@ -180,7 +188,16 @@ async def migrate_to_taosmd(request: Request):
     except Exception:
         return JSONResponse({"error": "taosmd unreachable"}, status_code=503)
 
-    chunks = await _store(request).browse(USER_ID, limit=10_000)
+    # Page through the store so installs with >page_size chunks migrate fully.
+    chunks: list[dict] = []
+    page_size = 1000
+    offset = 0
+    while True:
+        page = await _store(request).browse(USER_ID, limit=page_size, offset=offset)
+        chunks.extend(page)
+        if len(page) < page_size:
+            break
+        offset += page_size
     if not chunks:
         return JSONResponse({"ingested": 0, "skipped": 0, "total": 0})
 
@@ -188,11 +205,13 @@ async def migrate_to_taosmd(request: Request):
         {
             "text": c["content"],
             "id": c["hash"],
+            # Stored metadata first so the server-owned keys win — source_id
+            # is taosmd's dedup key and must not be overridable.
             "metadata": {
+                **(c.get("metadata") or {}),
                 "collection": c["collection"],
                 "title": c["title"],
                 "source_id": c["hash"],
-                **(c.get("metadata") or {}),
             },
         }
         for c in chunks
@@ -213,16 +232,20 @@ async def migrate_to_taosmd(request: Request):
             async with httpx.AsyncClient(timeout=30.0) as client:
                 for item in items:
                     try:
-                        await client.post(
+                        one = await client.post(
                             f"{base}/ingest",
                             json={"text": item["text"], "agent": _TAOSMD_AGENT,
                                   "metadata": item["metadata"]},
                         )
-                        ingested += 1
+                        if one.status_code < 400:
+                            ingested += 1
                     except Exception:
                         pass
             result = {"ingested": ingested, "skipped": len(items) - ingested}
-    except Exception as exc:
-        return JSONResponse({"error": str(exc)}, status_code=500)
+    except Exception:
+        # Don't reflect raw exception text (it can carry the internal taosmd
+        # host/URL) back to the caller; details go to the server log only.
+        logger.warning("taosmd bulk ingest failed", exc_info=True)
+        return JSONResponse({"error": "taosmd ingest failed"}, status_code=500)
 
     return JSONResponse({**result, "total": len(items)})

--- a/tinyagentos/routes/user_memory.py
+++ b/tinyagentos/routes/user_memory.py
@@ -1,15 +1,53 @@
 from __future__ import annotations
+
+import logging
+
+import httpx
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
 USER_ID = "user"  # Single-user for now
 
+# Fixed agent namespace for user memory in taosmd.
+_TAOSMD_AGENT = "user-memory"
+
 
 def _store(request: Request):
     return request.app.state.user_memory
 
+
+def _taosmd_base(request: Request) -> str:
+    """Base URL for the taosmd HTTP API.
+
+    Reads from app.state.taosmd_url when set (tests can override),
+    otherwise falls back to the local default.
+    """
+    return getattr(request.app.state, "taosmd_url", None) or "http://localhost:7900"
+
+
+# ---------------------------------------------------------------------------
+# Helper: map taosmd hit shape → user_memory_chunks shape
+# ---------------------------------------------------------------------------
+
+def _hit_to_chunk(hit: dict) -> dict:
+    meta = hit.get("metadata") or {}
+    return {
+        "hash": hit.get("id") or hit.get("source_id") or "",
+        "collection": meta.get("collection", "snippets"),
+        "title": meta.get("title", ""),
+        "content": hit.get("content", ""),
+        "metadata": meta,
+        "created_at": hit.get("timestamp") or hit.get("created_at"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
 
 @router.get("/api/user-memory/stats")
 async def get_stats(request: Request):
@@ -32,8 +70,28 @@ async def update_settings(request: Request):
 
 @router.get("/api/user-memory/search")
 async def search(request: Request, q: str, collection: str | None = None, limit: int = 20):
+    """Search user memory.
+
+    Proxies to taosmd /search?mode=bm25 when available; falls back to the
+    local SQLite FTS5 store if taosmd is unreachable or returns an error.
+    """
+    base = _taosmd_base(request)
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            params: dict = {"q": q, "agent": _TAOSMD_AGENT, "limit": limit, "mode": "bm25"}
+            if collection:
+                params["collection"] = collection
+            resp = await client.get(f"{base}/search", params=params)
+            if resp.status_code == 200:
+                data = resp.json()
+                hits = data.get("hits", [])
+                results = [_hit_to_chunk(h) for h in hits]
+                return JSONResponse({"results": results, "query": q, "backend": "taosmd"})
+    except Exception:
+        logger.debug("taosmd search unavailable, falling back to SQLite")
+
     results = await _store(request).search(USER_ID, q, collection, limit)
-    return JSONResponse({"results": results, "query": q})
+    return JSONResponse({"results": results, "query": q, "backend": "sqlite"})
 
 
 @router.get("/api/user-memory/agent-search")
@@ -69,7 +127,25 @@ async def save(request: Request):
     metadata = body.get("metadata", {})
     if not content:
         return JSONResponse({"error": "content required"}, status_code=400)
+
+    # Always write to SQLite for browse/stats/delete compatibility.
     h = await _store(request).save_chunk(USER_ID, content, title, collection, metadata)
+
+    # Also ingest to taosmd when available (best-effort, non-fatal).
+    base = _taosmd_base(request)
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            await client.post(
+                f"{base}/ingest",
+                json={
+                    "text": content,
+                    "agent": _TAOSMD_AGENT,
+                    "metadata": {"collection": collection, "title": title, "source_id": h, **metadata},
+                },
+            )
+    except Exception:
+        logger.debug("taosmd ingest unavailable — chunk saved to SQLite only")
+
     return JSONResponse({"ok": True, "hash": h})
 
 
@@ -83,3 +159,70 @@ async def delete_chunk(request: Request, chunk_hash: str):
 async def list_collections(request: Request):
     stats = await _store(request).get_stats(USER_ID)
     return JSONResponse({"collections": list(stats["collections"].keys())})
+
+
+@router.post("/api/user-memory/migrate")
+async def migrate_to_taosmd(request: Request):
+    """One-time bulk migration: push all SQLite chunks to taosmd /ingest/batch.
+
+    Returns counts of ingested and skipped items.  Safe to call multiple times
+    (taosmd uses source_id for deduplication).  Returns 503 if taosmd is
+    unreachable.
+    """
+    base = _taosmd_base(request)
+
+    # Probe availability first.
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            health = await client.get(f"{base}/health")
+            if health.status_code != 200:
+                return JSONResponse({"error": "taosmd not healthy"}, status_code=503)
+    except Exception:
+        return JSONResponse({"error": "taosmd unreachable"}, status_code=503)
+
+    chunks = await _store(request).browse(USER_ID, limit=10_000)
+    if not chunks:
+        return JSONResponse({"ingested": 0, "skipped": 0, "total": 0})
+
+    items = [
+        {
+            "text": c["content"],
+            "id": c["hash"],
+            "metadata": {
+                "collection": c["collection"],
+                "title": c["title"],
+                "source_id": c["hash"],
+                **(c.get("metadata") or {}),
+            },
+        }
+        for c in chunks
+    ]
+
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.post(
+                f"{base}/ingest/batch",
+                json={"agent": _TAOSMD_AGENT, "items": items},
+            )
+            resp.raise_for_status()
+            result = resp.json()
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 404:
+            # /ingest/batch not yet deployed — fall back to one-at-a-time
+            ingested = 0
+            async with httpx.AsyncClient(timeout=30.0) as client:
+                for item in items:
+                    try:
+                        await client.post(
+                            f"{base}/ingest",
+                            json={"text": item["text"], "agent": _TAOSMD_AGENT,
+                                  "metadata": item["metadata"]},
+                        )
+                        ingested += 1
+                    except Exception:
+                        pass
+            result = {"ingested": ingested, "skipped": len(items) - ingested}
+    except Exception as exc:
+        return JSONResponse({"error": str(exc)}, status_code=500)
+
+    return JSONResponse({**result, "total": len(items)})

--- a/tinyagentos/routes/user_memory.py
+++ b/tinyagentos/routes/user_memory.py
@@ -34,12 +34,15 @@ def _taosmd_base(request: Request) -> str:
 # ---------------------------------------------------------------------------
 
 def _hit_to_chunk(hit: dict) -> dict:
+    # Live taosmd hit shape (verified against /search?mode=bm25 on the #25
+    # unification deploy): content arrives in "text" and the chunk id
+    # round-trips as metadata.source_id — neither appears top-level.
     meta = hit.get("metadata") or {}
     return {
-        "hash": hit.get("id") or hit.get("source_id") or "",
+        "hash": hit.get("id") or meta.get("source_id") or hit.get("source_id") or "",
         "collection": meta.get("collection", "snippets"),
         "title": meta.get("title", ""),
-        "content": hit.get("content", ""),
+        "content": hit.get("content") or hit.get("text", ""),
         "metadata": meta,
         "created_at": hit.get("timestamp") or hit.get("created_at"),
     }

--- a/tinyagentos/user_memory.py
+++ b/tinyagentos/user_memory.py
@@ -124,6 +124,7 @@ class UserMemoryStore(BaseStore):
         user_id: str,
         collection: str | None = None,
         limit: int = 50,
+        offset: int = 0,
     ) -> list[dict]:
         assert self._db is not None
         sql = "SELECT hash, collection, title, content, metadata, created_at FROM user_memory_chunks WHERE user_id = ?"
@@ -131,8 +132,8 @@ class UserMemoryStore(BaseStore):
         if collection:
             sql += " AND collection = ?"
             params.append(collection)
-        sql += " ORDER BY created_at DESC LIMIT ?"
-        params.append(limit)
+        sql += " ORDER BY created_at DESC LIMIT ? OFFSET ?"
+        params.extend([limit, offset])
         cursor = await self._db.execute(sql, params)
         rows = await cursor.fetchall()
         return [


### PR DESCRIPTION
## What's in this batch

| PR | Change |
|----|--------|
| #729 | feat(registry): approval UI for agent registry lifecycle (RegistryPanel in Agents app; squash also carried the #728 proxy base — branches were stacked) |
| #728 | fix(memory): user-memory taosmd proxy hardening (metadata/source_id override blocked, paginated migrate, 2xx-only ingest counting, sanitized errors) |
| #730 | feat(registry): governance audit log panel (admin only) |
| #731 | feat(trust-comms): non-dismissable consent notification (Phase 2 UI) |
| #732 | chore: taosmd dependency git → PyPI (taosmd==0.3.0) |
| #733 | fix(consent): scope allowlist + granted ⊆ requested on approve |
| c1fb3f98 | fix(memory): map live taosmd hit shape in search proxy (verified against the deployed #25 endpoints) |

The taosmd side of #25 (POST /ingest/batch + ?mode=bm25) is merged on taosmd master (PR #149, 71e913a) and live on the Pi serve — this promotion brings the taOS side level.

## Verification
- All PRs CI-green (Kilo failures are the known infra timeout)
- #25 contract exercised live against the Pi serve: batch ingest idempotency, bm25 search shape, metadata round-trip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
* Admins receive a consent modal for pending external agent authentication requests
* Agent registry management panel with approval actions and governance audit log
* User memory search integrates external service with automatic SQLite fallback
* Added user memory migration to external service
* User memory browsing now supports pagination

**Documentation**
* Added agent handoff playbook and live status dashboard

**Tests**
* Enhanced auth request tests with scope validation coverage
* Added user memory integration tests for external service and fallback behavior

**Chores**
* Pinned taosmd dependency to stable version 0.3.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->