### PR TITLE
fix(security): SSRF guard on knowledge article ingest (#738)

### DIFF
--- a/tests/test_knowledge_ingest.py
+++ b/tests/test_knowledge_ingest.py
@@ -44,12 +44,29 @@ async def store(tmp_path):
     await s.close()
 
 
+# Capture the real SSRF validator before any test patches it, so the
+# loopback-block test can exercise the genuine guard.
+from tinyagentos.routes.desktop_browser import ssrf as _ssrf_mod
+_REAL_VALIDATE_URL = _ssrf_mod.validate_url_or_raise
+
+
+@pytest.fixture(autouse=True)
+def _ssrf_noop():
+    """Happy-path ingest tests fetch example.com; stub the SSRF guard so they
+    stay hermetic (no real DNS). The dedicated SSRF test re-patches the real
+    validator for its scope."""
+    with patch.object(_ssrf_mod, "validate_url_or_raise", lambda url: None):
+        yield
+
+
 @pytest.fixture
 def mock_http():
     client = AsyncMock()
     # Default: return minimal HTML for article fetch
     response = MagicMock()
     response.status_code = 200
+    response.is_redirect = False
+    response.headers = {}
     response.text = "<html><body><article><p>This is the main article content with enough text to pass the quality threshold.</p></article></body></html>"
     response.raise_for_status = MagicMock()
     client.get = AsyncMock(return_value=response)
@@ -165,6 +182,8 @@ async def test_summarise_called_when_llm_url_set(store):
 
     article_response = AsyncMock()
     article_response.status_code = 200
+    article_response.is_redirect = False
+    article_response.headers = {}
     article_response.text = "<html><body><p>Long enough article body text content here for testing purposes.</p></body></html>"
     article_response.raise_for_status = MagicMock()
 
@@ -373,3 +392,24 @@ async def test_categories_from_caller_are_preserved(store):
     item = await store.get_item(item_id)
     assert "AI/ML" in item["categories"]
     assert "Rockchip" in item["categories"]
+
+
+@pytest.mark.asyncio
+async def test_download_article_blocks_internal_url(pipeline, store):
+    """SSRF guard: an article URL pointing at loopback is rejected, the item
+    lands in error, and the host never fetches the internal address."""
+    # Re-patch the real validator for this test (overrides the autouse no-op).
+    with patch.object(_ssrf_mod, "validate_url_or_raise", _REAL_VALIDATE_URL):
+        item_id = await pipeline.submit(
+            url="http://127.0.0.1/admin",
+            title="",
+            text="",
+            categories=[],
+            source="test",
+        )
+        await pipeline.run(item_id)
+    item = await store.get_item(item_id)
+    assert item["status"] == "error"
+    # The guard raises before any HTTP call to the internal address.
+    for call in pipeline._http_client.get.await_args_list:
+        assert "127.0.0.1" not in str(call)

--- a/tinyagentos/knowledge_ingest.py
+++ b/tinyagentos/knowledge_ingest.py
@@ -16,6 +16,11 @@ logger = logging.getLogger(__name__)
 # Quality threshold: minimum chars for readability extraction to count as success
 _MIN_CONTENT_CHARS = 100
 
+# Article fetches must not reach loopback / link-local / private hosts (SSRF).
+# We reuse the browser proxy's validated guard and walk redirects manually so a
+# 3xx to an internal address cannot smuggle past the front-door check.
+_MAX_ARTICLE_REDIRECTS = 5
+
 # Limit concurrent background ingest tasks to prevent resource exhaustion.
 _INGEST_SEMAPHORE_SLOTS = 5
 
@@ -275,8 +280,34 @@ class IngestPipeline:
     async def _download_article(
         self, url: str, title: str, metadata: dict
     ) -> tuple[str, str, str, dict]:
-        """Fetch an article URL and extract readable text."""
-        resp = await self._http_client.get(url, timeout=30, follow_redirects=True)
+        """Fetch an article URL and extract readable text.
+
+        SSRF-guarded: the initial URL and every redirect hop are validated
+        against the loopback / link-local / private-range blocklist before the
+        request is issued, so an attacker-supplied URL (or a public URL that
+        302-redirects inward) cannot make the host fetch internal services.
+        """
+        from urllib.parse import urljoin
+
+        from tinyagentos.routes.desktop_browser.ssrf import (
+            SsrfBlockedError,
+            validate_url_or_raise,
+        )
+
+        current_url = url
+        resp = None
+        for _hop in range(_MAX_ARTICLE_REDIRECTS + 1):
+            validate_url_or_raise(current_url)  # raises SsrfBlockedError
+            resp = await self._http_client.get(
+                current_url, timeout=30, follow_redirects=False
+            )
+            if resp.is_redirect and resp.headers.get("location"):
+                current_url = urljoin(current_url, resp.headers["location"])
+                continue
+            break
+        else:
+            raise SsrfBlockedError(f"too many redirects fetching {url!r}")
+
         resp.raise_for_status()
         html = resp.text
         content = _extract_text_readability(html)


### PR DESCRIPTION
Closes #738.

## Problem
`knowledge_ingest.py:_download_article` fetched the user-supplied URL with `follow_redirects=True` and no SSRF validation, unlike the browser proxy which routes every hop through `validate_url_or_raise`. An authenticated `POST /api/knowledge/ingest` (or any public URL that 302-redirects inward) could make the host fetch `http://127.0.0.1:6969/...`, cloud-metadata `169.254.169.254`, or LAN admin interfaces, and the response body is ingested back to the caller.

## Fix
Validate the initial URL and every redirect hop against the existing `validate_url_or_raise` blocklist, walking redirects manually with `follow_redirects=False` (cap 5 hops) so a 3xx to an internal address cannot smuggle past the check. Reuses the guard the browser proxy already uses.

## Test plan
- [x] tests/test_knowledge_ingest.py 18/18 pass on the Pi venv (+1 new: loopback URL rejected, item lands in error, no fetch to the internal address)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced article download security with SSRF protection, redirect validation, and configurable hop limits to prevent unauthorized access to internal URLs.

* **Tests**
  * Added test coverage to verify SSRF guard behavior effectively blocks internal addresses during article ingestion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->