### PR TITLE
fix(security): CSRF defense in depth, SameSite=Strict session cookie + token wiring (#648)

### DIFF
--- a/desktop/src/components/TopBar.tsx
+++ b/desktop/src/components/TopBar.tsx
@@ -5,6 +5,7 @@ import { useWidgetStore } from "@/stores/widget-store";
 import { useNotificationStore } from "@/stores/notification-store";
 import { useProcessStore } from "@/stores/process-store";
 import { StatusIndicators } from "./StatusIndicators";
+import { withCsrf } from "@/lib/csrf";
 
 interface Props {
   onSearchOpen: () => void;
@@ -15,7 +16,7 @@ function PowerMenu() {
   const openWindow = useProcessStore((s) => s.openWindow);
 
   const lock = async () => {
-    await fetch("/auth/lock", { method: "POST", credentials: "include" }).catch(() => {});
+    await fetch("/auth/lock", { method: "POST", credentials: "include", headers: withCsrf({ method: "POST" })?.headers }).catch(() => {});
     window.location.reload();
   };
 

--- a/desktop/src/lib/csrf.ts
+++ b/desktop/src/lib/csrf.ts
@@ -1,0 +1,34 @@
+/**
+ * CSRF double-submit helper.
+ *
+ * The backend's CSRFMiddleware sets a non-HttpOnly `csrf_token` cookie; the
+ * `verify_csrf` dependency requires a matching `X-CSRF-Token` header on
+ * cookie-authenticated mutating requests. This helper reads that cookie and
+ * attaches the header so the SPA's mutating calls satisfy the check.
+ *
+ * Combined with the session cookie now being SameSite=Strict (browser-level
+ * CSRF defense), this is the double-submit second layer.
+ */
+
+const MUTATING = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+export function getCsrfToken(): string | null {
+  if (typeof document === "undefined") return null;
+  const m = document.cookie.match(/(?:^|;\s*)csrf_token=([^;]+)/);
+  return m?.[1] ? decodeURIComponent(m[1]) : null;
+}
+
+/**
+ * Return request init with the CSRF header attached when the method mutates
+ * state and a token cookie is present. Non-mutating methods pass through
+ * unchanged.
+ */
+export function withCsrf(init?: RequestInit): RequestInit | undefined {
+  const method = (init?.method ?? "GET").toUpperCase();
+  if (!MUTATING.has(method)) return init;
+  const token = getCsrfToken();
+  if (!token) return init;
+  const headers = new Headers(init?.headers);
+  if (!headers.has("X-CSRF-Token")) headers.set("X-CSRF-Token", token);
+  return { ...init, headers };
+}

--- a/desktop/src/lib/taos-fetch.ts
+++ b/desktop/src/lib/taos-fetch.ts
@@ -12,6 +12,7 @@
  * new code uses this from day one.
  */
 import type { BackendStatusController } from "./backendStatus";
+import { withCsrf } from "./csrf";
 
 export class BackendUnavailableError extends Error {
   constructor(message = "Backend is unavailable") {
@@ -29,7 +30,7 @@ export function createTaosFetch(opts: Options): typeof fetch {
   const inner = opts.fetchImpl ?? fetch;
   const wrapped: typeof fetch = async (input, init) => {
     try {
-      const r = await inner(input as RequestInfo, init);
+      const r = await inner(input as RequestInfo, withCsrf(init));
       const v = r.headers.get("X-Taos-Version");
       if (v) opts.status.reportVersion(v);
       return r;

--- a/tinyagentos/routes/auth.py
+++ b/tinyagentos/routes/auth.py
@@ -394,11 +394,11 @@ async def login(request: Request):
             })
             if long_lived:
                 resp.set_cookie(
-                    "taos_session", token, httponly=True, samesite="lax",
+                    "taos_session", token, httponly=True, samesite="strict",
                     max_age=auth_mgr.session_ttl_for(True),
                 )
             else:
-                resp.set_cookie("taos_session", token, httponly=True, samesite="lax")
+                resp.set_cookie("taos_session", token, httponly=True, samesite="strict")
             return resp
 
         user_id = user_record["id"] if user_record else ""
@@ -409,11 +409,11 @@ async def login(request: Request):
         resp = JSONResponse({"ok": True, "user": pub})
         if long_lived:
             resp.set_cookie(
-                "taos_session", token, httponly=True, samesite="lax",
+                "taos_session", token, httponly=True, samesite="strict",
                 max_age=auth_mgr.session_ttl_for(True),
             )
         else:
-            resp.set_cookie("taos_session", token, httponly=True, samesite="lax")
+            resp.set_cookie("taos_session", token, httponly=True, samesite="strict")
         return resp
 
     # Form-encoded path — used by the no-JS HTML login page.
@@ -449,11 +449,11 @@ async def login(request: Request):
     response = RedirectResponse(destination, status_code=303)
     if long_lived:
         response.set_cookie(
-            "taos_session", token, httponly=True, samesite="lax",
+            "taos_session", token, httponly=True, samesite="strict",
             max_age=auth_mgr.session_ttl_for(True),
         )
     else:
-        response.set_cookie("taos_session", token, httponly=True, samesite="lax")
+        response.set_cookie("taos_session", token, httponly=True, samesite="strict")
     return response
 
 
@@ -522,11 +522,11 @@ async def auth_setup(request: Request):
         resp = JSONResponse({"ok": True, "user": user})
         if long_lived:
             resp.set_cookie(
-                "taos_session", token, httponly=True, samesite="lax",
+                "taos_session", token, httponly=True, samesite="strict",
                 max_age=auth_mgr.session_ttl_for(True),
             )
         else:
-            resp.set_cookie("taos_session", token, httponly=True, samesite="lax")
+            resp.set_cookie("taos_session", token, httponly=True, samesite="strict")
         return resp
 
     # Form-encoded path — used by the no-JS HTML setup page.
@@ -555,11 +555,11 @@ async def auth_setup(request: Request):
     response = RedirectResponse("/desktop", status_code=303)
     if long_lived:
         response.set_cookie(
-            "taos_session", token, httponly=True, samesite="lax",
+            "taos_session", token, httponly=True, samesite="strict",
             max_age=auth_mgr.session_ttl_for(True),
         )
     else:
-        response.set_cookie("taos_session", token, httponly=True, samesite="lax")
+        response.set_cookie("taos_session", token, httponly=True, samesite="strict")
     return response
 
 
@@ -611,11 +611,11 @@ async def complete_invite(request: Request):
     resp = JSONResponse({"ok": True, "user": user})
     if long_lived:
         resp.set_cookie(
-            "taos_session", token, httponly=True, samesite="lax",
+            "taos_session", token, httponly=True, samesite="strict",
             max_age=auth_mgr.session_ttl_for(True),
         )
     else:
-        resp.set_cookie("taos_session", token, httponly=True, samesite="lax")
+        resp.set_cookie("taos_session", token, httponly=True, samesite="strict")
     return resp
 
 


### PR DESCRIPTION
## Summary

- Flips all 12 `taos_session` cookie set calls from `SameSite=Lax` to `SameSite=Strict`, providing browser-level CSRF protection: the session cookie is never sent on cross-site navigations.
- Adds `desktop/src/lib/csrf.ts` with `getCsrfToken()` and `withCsrf(init)`, and wires it into the central `taos-fetch.ts` wrapper so every mutating SPA call automatically satisfies the backend `verify_csrf` check (double-submit second layer).
- Fixes a latent bug where `/auth/lock` in `TopBar.tsx` was silently 403-ing because it never sent the CSRF token. The no-op `.catch()` hid the failure, so lock/sign-out appeared to succeed but the session was not invalidated server-side.

## Test plan

- [ ] `python3.12 -m pytest tests/test_auth.py tests/test_routes_auth.py tests/test_auth_email_login.py -q` passes (89 passed, 0 failures confirmed on Pi)
- [ ] `npx tsc --noEmit` shows no errors for csrf.ts, taos-fetch.ts, or TopBar.tsx
- [ ] Manual: lock taOS from the power menu, confirm the session is actually cleared and the page redirects to login (not a silent no-op)
- [ ] Manual: login flow creates a `taos_session` cookie with `SameSite=Strict` in browser devtools

## Follow-up

Broad per-route `verify_csrf` rollout (migrating remaining bare fetches in the SPA to the central `taos-fetch` wrapper, then enabling the dependency on each mutating route group) is tracked in a separate issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added CSRF token validation to session lock operations, preventing unauthorized account locking
  * Enhanced authentication cookie security by updating the SameSite policy to strict mode
  * Improved cross-site request forgery protection across authentication requests and endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->