### PR TITLE
chore(ci): make add-to-project step non-blocking

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -37,6 +37,7 @@ jobs:
           fi
       - name: Add to Project
         if: steps.cfg.outputs.skip != 'true'
+        continue-on-error: true
         uses: actions/add-to-project@v2
         with:
           project-url: ${{ vars.PROJECT_URL }}


### PR DESCRIPTION
## Summary

- Adds `continue-on-error: true` to the `Add to Project` step in `.github/workflows/add-to-project.yml`.
- The workflow was failing auth on every new issue/PR due to an expired (or missing) `ADD_TO_PROJECT_PAT` secret, which was turning each issue/PR's CI run red.
- With this change the step logs the failure but does not block or red the overall workflow run.

## Real fix

Rotate the `ADD_TO_PROJECT_PAT` repo secret (Settings > Secrets > Actions) with a fresh fine-grained PAT that has `project:write` scope. Once that is done, the step will succeed again and `continue-on-error` becomes a no-op safety net.

## Test plan

- [ ] Open a new issue or PR after merging, confirm the workflow run shows green even if the PAT is still expired.
- [ ] After rotating the PAT, confirm new issues/PRs are added to the project board.