### PR TITLE
fix(perf): evict approve-lock leak, index auth_requests, reuse shared httpx client (#660)

### DIFF
--- a/tests/test_auth_requests.py
+++ b/tests/test_auth_requests.py
@@ -593,3 +593,20 @@ class TestAuthRequestRoutes:
         assert resp.status_code == 200
         grants = resp.json()["grants"]
         assert all(g["canonical_id"] == canonical_id for g in grants)
+
+    async def test_approve_lock_is_evicted_after_decision(self, consent_client):
+        """After approval the per-request lock entry is removed from the dict."""
+        transport = ASGITransport(app=consent_client._transport.app)
+        async with AsyncClient(transport=transport, base_url="http://test") as bare:
+            create_resp = await bare.post("/api/agents/auth-requests", json=_CREATE_BODY)
+            request_id = create_resp.json()["request_id"]
+
+        await consent_client.post(
+            f"/api/agents/auth-requests/{request_id}/approve",
+            json={"granted_scopes": ["memory_read"]},
+        )
+
+        # After a terminal decision the lock entry must be absent so the dict
+        # does not grow unbounded over the process lifetime.
+        app = consent_client._transport.app
+        assert getattr(app.state, "_approve_locks", {}).get(request_id) is None

--- a/tests/test_user_memory.py
+++ b/tests/test_user_memory.py
@@ -1,6 +1,5 @@
 import pytest
 import pytest_asyncio
-from unittest.mock import patch
 from tinyagentos.user_memory import UserMemoryStore
 
 
@@ -108,7 +107,7 @@ async def test_fts5_injection_does_not_escape_user_filter(store):
 # ---------------------------------------------------------------------------
 
 import json
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 from httpx import ASGITransport, AsyncClient as HttpxAsyncClient
 import pytest_asyncio
 
@@ -171,8 +170,9 @@ async def test_search_uses_taosmd_when_available(mem_client, tmp_data_dir):
     mock_client.__aexit__ = AsyncMock(return_value=False)
     mock_client.get = AsyncMock(return_value=mock_resp)
 
-    with patch("tinyagentos.routes.user_memory.httpx.AsyncClient", return_value=mock_client):
-        resp = await client.get("/api/user-memory/search", params={"q": "test"})
+    app = client._transport.app
+    app.state.http_client = mock_client
+    resp = await client.get("/api/user-memory/search", params={"q": "test"})
     assert resp.status_code == 200
     data = resp.json()
     assert data["backend"] == "taosmd"
@@ -189,11 +189,12 @@ async def test_save_writes_to_sqlite_and_ingest_to_taosmd(mem_client, tmp_data_d
     mock_client.__aexit__ = AsyncMock(return_value=False)
     mock_client.post = AsyncMock(return_value=MagicMock(status_code=200))
 
-    with patch("tinyagentos.routes.user_memory.httpx.AsyncClient", return_value=mock_client):
-        resp = await client.post(
-            "/api/user-memory/save",
-            json={"content": "dual write", "title": "T", "collection": "snippets"},
-        )
+    app = client._transport.app
+    app.state.http_client = mock_client
+    resp = await client.post(
+        "/api/user-memory/save",
+        json={"content": "dual write", "title": "T", "collection": "snippets"},
+    )
     assert resp.status_code == 200
     assert resp.json()["ok"] is True
     # SQLite should have the chunk too
@@ -249,15 +250,16 @@ async def test_save_metadata_cannot_override_source_id(mem_client, tmp_data_dir)
     mock_client.__aexit__ = AsyncMock(return_value=False)
     mock_client.post = AsyncMock(return_value=MagicMock(status_code=200))
 
-    with patch("tinyagentos.routes.user_memory.httpx.AsyncClient", return_value=mock_client):
-        resp = await client.post(
-            "/api/user-memory/save",
-            json={
-                "content": "override attempt",
-                "collection": "snippets",
-                "metadata": {"source_id": "evil", "collection": "other", "custom": "kept"},
-            },
-        )
+    app = client._transport.app
+    app.state.http_client = mock_client
+    resp = await client.post(
+        "/api/user-memory/save",
+        json={
+            "content": "override attempt",
+            "collection": "snippets",
+            "metadata": {"source_id": "evil", "collection": "other", "custom": "kept"},
+        },
+    )
     assert resp.status_code == 200
     saved_hash = resp.json()["hash"]
     sent_meta = mock_client.post.call_args.kwargs["json"]["metadata"]
@@ -277,8 +279,9 @@ async def test_migrate_error_response_does_not_leak_exception_text(mem_client, t
     mock_client.get = AsyncMock(return_value=MagicMock(status_code=200))  # health OK
     mock_client.post = AsyncMock(side_effect=RuntimeError("http://internal-taosmd:7900 boom"))
 
-    with patch("tinyagentos.routes.user_memory.httpx.AsyncClient", return_value=mock_client):
-        resp = await client.post("/api/user-memory/migrate")
+    app = client._transport.app
+    app.state.http_client = mock_client
+    resp = await client.post("/api/user-memory/migrate")
     assert resp.status_code == 500
     assert "internal-taosmd" not in resp.text
     assert resp.json()["error"] == "taosmd ingest failed"

--- a/tinyagentos/auth_requests_store.py
+++ b/tinyagentos/auth_requests_store.py
@@ -40,6 +40,8 @@ CREATE TABLE IF NOT EXISTS auth_requests (
     decided_ts      TEXT,
     decided_by      TEXT
 );
+CREATE INDEX IF NOT EXISTS idx_auth_requests_status ON auth_requests(status);
+CREATE INDEX IF NOT EXISTS idx_auth_requests_identity ON auth_requests(identity_claim, framework, status);
 """
 
 _VALID_DECISION_STATUSES = frozenset({"accepted", "refused"})

--- a/tinyagentos/routes/agent_auth_requests.py
+++ b/tinyagentos/routes/agent_auth_requests.py
@@ -215,8 +215,18 @@ async def approve_auth_request(
 
     # Serialise concurrent approvals for the same request to prevent orphaned
     # registry entries and duplicate grants from a TOCTOU race.
-    async with _get_approve_lock(request, request_id):
-        return await _do_approve(request, request_id, body, user)
+    lock = _get_approve_lock(request, request_id)
+    async with lock:
+        try:
+            return await _do_approve(request, request_id, body, user)
+        finally:
+            # The request is now terminally decided (or errored); drop its lock so
+            # request.app.state._approve_locks does not grow unbounded over the
+            # process lifetime. A concurrent waiter already holds a reference to the
+            # lock object, so popping the dict entry is safe.
+            locks = getattr(request.app.state, "_approve_locks", None)
+            if locks is not None:
+                locks.pop(request_id, None)
 
 
 async def _do_approve(request: Request, request_id: str, body: ApproveBody, user):

--- a/tinyagentos/routes/user_memory.py
+++ b/tinyagentos/routes/user_memory.py
@@ -80,16 +80,16 @@ async def search(request: Request, q: str, collection: str | None = None, limit:
     """
     base = _taosmd_base(request)
     try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
-            params: dict = {"q": q, "agent": _TAOSMD_AGENT, "limit": limit, "mode": "bm25"}
-            if collection:
-                params["collection"] = collection
-            resp = await client.get(f"{base}/search", params=params)
-            if resp.status_code == 200:
-                data = resp.json()
-                hits = data.get("hits", [])
-                results = [_hit_to_chunk(h) for h in hits]
-                return JSONResponse({"results": results, "query": q, "backend": "taosmd"})
+        client = request.app.state.http_client
+        params: dict = {"q": q, "agent": _TAOSMD_AGENT, "limit": limit, "mode": "bm25"}
+        if collection:
+            params["collection"] = collection
+        resp = await client.get(f"{base}/search", params=params, timeout=5.0)
+        if resp.status_code == 200:
+            data = resp.json()
+            hits = data.get("hits", [])
+            results = [_hit_to_chunk(h) for h in hits]
+            return JSONResponse({"results": results, "query": q, "backend": "taosmd"})
     except Exception:
         logger.debug("taosmd search unavailable, falling back to SQLite")
 
@@ -137,23 +137,24 @@ async def save(request: Request):
     # Also ingest to taosmd when available (best-effort, non-fatal).
     base = _taosmd_base(request)
     try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
-            resp = await client.post(
-                f"{base}/ingest",
-                json={
-                    "text": content,
-                    "agent": _TAOSMD_AGENT,
-                    # Caller metadata first so the server-owned keys win —
-                    # source_id is taosmd's dedup key and must not be
-                    # overridable from the request body.
-                    "metadata": {**metadata, "collection": collection, "title": title, "source_id": h},
-                },
+        client = request.app.state.http_client
+        resp = await client.post(
+            f"{base}/ingest",
+            json={
+                "text": content,
+                "agent": _TAOSMD_AGENT,
+                # Caller metadata first so the server-owned keys win —
+                # source_id is taosmd's dedup key and must not be
+                # overridable from the request body.
+                "metadata": {**metadata, "collection": collection, "title": title, "source_id": h},
+            },
+            timeout=5.0,
+        )
+        if resp.status_code >= 400:
+            logger.debug(
+                "taosmd ingest returned %s — chunk saved to SQLite only",
+                resp.status_code,
             )
-            if resp.status_code >= 400:
-                logger.debug(
-                    "taosmd ingest returned %s — chunk saved to SQLite only",
-                    resp.status_code,
-                )
     except Exception:
         logger.debug("taosmd ingest unavailable — chunk saved to SQLite only")
 
@@ -184,10 +185,10 @@ async def migrate_to_taosmd(request: Request):
 
     # Probe availability first.
     try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
-            health = await client.get(f"{base}/health")
-            if health.status_code != 200:
-                return JSONResponse({"error": "taosmd not healthy"}, status_code=503)
+        client = request.app.state.http_client
+        health = await client.get(f"{base}/health", timeout=5.0)
+        if health.status_code != 200:
+            return JSONResponse({"error": "taosmd not healthy"}, status_code=503)
     except Exception:
         return JSONResponse({"error": "taosmd unreachable"}, status_code=503)
 
@@ -221,29 +222,31 @@ async def migrate_to_taosmd(request: Request):
     ]
 
     try:
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            resp = await client.post(
-                f"{base}/ingest/batch",
-                json={"agent": _TAOSMD_AGENT, "items": items},
-            )
-            resp.raise_for_status()
-            result = resp.json()
+        client = request.app.state.http_client
+        resp = await client.post(
+            f"{base}/ingest/batch",
+            json={"agent": _TAOSMD_AGENT, "items": items},
+            timeout=30.0,
+        )
+        resp.raise_for_status()
+        result = resp.json()
     except httpx.HTTPStatusError as exc:
         if exc.response.status_code == 404:
             # /ingest/batch not yet deployed — fall back to one-at-a-time
             ingested = 0
-            async with httpx.AsyncClient(timeout=30.0) as client:
-                for item in items:
-                    try:
-                        one = await client.post(
-                            f"{base}/ingest",
-                            json={"text": item["text"], "agent": _TAOSMD_AGENT,
-                                  "metadata": item["metadata"]},
-                        )
-                        if one.status_code < 400:
-                            ingested += 1
-                    except Exception:
-                        pass
+            client = request.app.state.http_client
+            for item in items:
+                try:
+                    one = await client.post(
+                        f"{base}/ingest",
+                        json={"text": item["text"], "agent": _TAOSMD_AGENT,
+                              "metadata": item["metadata"]},
+                        timeout=30.0,
+                    )
+                    if one.status_code < 400:
+                        ingested += 1
+                except Exception:
+                    pass
             result = {"ingested": ingested, "skipped": len(items) - ingested}
     except Exception:
         # Don't reflect raw exception text (it can carry the internal taosmd


### PR DESCRIPTION
Three audit safe-cleanups with zero runtime-behavior change:

- **Fix 1 (memory leak):** Evict the per-request `asyncio.Lock` from `_approve_locks` in a `try/finally` block after `approve_auth_request` reaches a terminal decision. Without this the dict grows for the process lifetime (one entry per unique `request_id` ever approved).
- **Fix 2 (missing indexes):** Add `idx_auth_requests_status` and `idx_auth_requests_identity` to the `auth_requests` SCHEMA. `list_pending` and `count_pending_for` previously did full-table scans. The `IF NOT EXISTS` guard means `BaseStore.init()` applies them idempotently on next startup with no migration step.
- **Fix 3 (connection churn):** Replace five per-call `async with httpx.AsyncClient(timeout=...)` blocks in `user_memory` routes with `request.app.state.http_client` (the shared client already owned by the app). Timeout is forwarded on each individual `.get`/`.post` call. Affected tests updated to inject mocks via `app.state.http_client = mock_client` instead of patching the constructor.

[label: perf, audit]