### PR TITLE
fix: apply knowledge user_id migration to existing DBs and exit on main-server startup failure

### DIFF
--- a/tests/test_dual_port_helper.py
+++ b/tests/test_dual_port_helper.py
@@ -1,0 +1,93 @@
+"""Tests for _serve_until_first_exit helper in tinyagentos.__main__."""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+
+class _StubServer:
+    """Minimal stand-in for uvicorn.Server."""
+
+    def __init__(self, *, started: bool = True, raise_on_serve: Exception | None = None):
+        self.started = started
+        self._raise = raise_on_serve
+        self._cancelled = False
+
+    async def serve(self) -> None:
+        await asyncio.sleep(0)  # yield once to let the other task run
+        if self._raise is not None:
+            raise self._raise
+
+
+class _HangingServer:
+    """Server whose serve() never returns (simulates a running server)."""
+
+    def __init__(self, *, started: bool = True):
+        self.started = started
+        self._task: asyncio.Task | None = None
+
+    async def serve(self) -> None:
+        try:
+            await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            raise
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_main_fails_to_start_returns_false():
+    """When main server exits with started=False, helper returns False.
+
+    The proxy stub's serve task must be cancelled.
+    """
+    from tinyagentos.__main__ import _serve_until_first_exit
+
+    main_server = _StubServer(started=False)
+    proxy_server = _HangingServer(started=True)
+
+    result = await _serve_until_first_exit(main_server, proxy_server)
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_main_starts_and_proxy_exits_returns_true():
+    """When proxy exits first but main started=True, helper returns True."""
+    from tinyagentos.__main__ import _serve_until_first_exit
+
+    main_server = _HangingServer(started=True)
+    proxy_server = _StubServer(started=True)
+
+    result = await _serve_until_first_exit(main_server, proxy_server)
+
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_both_exit_main_started_returns_true():
+    """Both servers exit; main.started=True -> returns True."""
+    from tinyagentos.__main__ import _serve_until_first_exit
+
+    main_server = _StubServer(started=True)
+    proxy_server = _StubServer(started=True)
+
+    result = await _serve_until_first_exit(main_server, proxy_server)
+
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_serve_exception_is_reraised():
+    """An exception raised inside serve() propagates out of the helper."""
+    from tinyagentos.__main__ import _serve_until_first_exit
+
+    boom = RuntimeError("lifespan crash")
+    main_server = _StubServer(started=False, raise_on_serve=boom)
+    proxy_server = _HangingServer(started=True)
+
+    with pytest.raises(RuntimeError, match="lifespan crash"):
+        await _serve_until_first_exit(main_server, proxy_server)

--- a/tests/test_knowledge_migration.py
+++ b/tests/test_knowledge_migration.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+from tinyagentos.knowledge_store import KnowledgeStore
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _create_old_schema_db(db_path: Path) -> None:
+    """Create a knowledge.db with the pre-user_id schema (simulates a bricked install)."""
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS knowledge_items (
+            id TEXT PRIMARY KEY,
+            source_type TEXT NOT NULL,
+            source_url TEXT NOT NULL,
+            source_id TEXT,
+            title TEXT NOT NULL DEFAULT '',
+            author TEXT NOT NULL DEFAULT '',
+            summary TEXT NOT NULL DEFAULT '',
+            content TEXT NOT NULL DEFAULT '',
+            media_path TEXT,
+            thumbnail TEXT,
+            categories TEXT NOT NULL DEFAULT '[]',
+            tags TEXT NOT NULL DEFAULT '[]',
+            metadata TEXT NOT NULL DEFAULT '{}',
+            status TEXT NOT NULL DEFAULT 'pending',
+            monitor TEXT NOT NULL DEFAULT '{}',
+            created_at REAL NOT NULL,
+            updated_at REAL NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_ki_source_type ON knowledge_items(source_type);
+        CREATE INDEX IF NOT EXISTS idx_ki_status ON knowledge_items(status);
+        CREATE INDEX IF NOT EXISTS idx_ki_created ON knowledge_items(created_at DESC);
+
+        CREATE VIRTUAL TABLE IF NOT EXISTS knowledge_fts USING fts5(
+            id UNINDEXED,
+            title,
+            content,
+            summary,
+            author,
+            tokenize='porter unicode61'
+        );
+
+        CREATE TABLE IF NOT EXISTS knowledge_snapshots (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            item_id TEXT NOT NULL REFERENCES knowledge_items(id) ON DELETE CASCADE,
+            snapshot_at REAL NOT NULL,
+            content_hash TEXT NOT NULL,
+            diff_json TEXT NOT NULL DEFAULT '{}',
+            metadata_json TEXT NOT NULL DEFAULT '{}'
+        );
+        CREATE INDEX IF NOT EXISTS idx_ks_item ON knowledge_snapshots(item_id, snapshot_at DESC);
+
+        CREATE TABLE IF NOT EXISTS category_rules (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            pattern TEXT NOT NULL,
+            match_on TEXT NOT NULL,
+            category TEXT NOT NULL,
+            priority INTEGER NOT NULL DEFAULT 0
+        );
+
+        CREATE TABLE IF NOT EXISTS agent_knowledge_subscriptions (
+            agent_name TEXT NOT NULL,
+            category TEXT NOT NULL,
+            auto_ingest INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (agent_name, category)
+        );
+    """)
+    conn.commit()
+    conn.close()
+
+
+def _get_columns(db_path: Path) -> set[str]:
+    conn = sqlite3.connect(str(db_path))
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(knowledge_items)").fetchall()}
+    conn.close()
+    return cols
+
+
+def _get_indexes(db_path: Path) -> set[str]:
+    conn = sqlite3.connect(str(db_path))
+    indexes = {row[1] for row in conn.execute("PRAGMA index_list(knowledge_items)").fetchall()}
+    conn.close()
+    return indexes
+
+
+# ---------------------------------------------------------------------------
+# Migration tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_migration_adds_user_id_to_old_db(tmp_path):
+    """init() must succeed on an old-shape DB and add user_id + index."""
+    db_path = tmp_path / "knowledge.db"
+    _create_old_schema_db(db_path)
+
+    # Confirm pre-condition: no user_id column
+    assert "user_id" not in _get_columns(db_path)
+
+    store = KnowledgeStore(db_path, media_dir=tmp_path / "media")
+    await store.init()
+    await store.close()
+
+    cols = _get_columns(db_path)
+    assert "user_id" in cols, "user_id column must exist after init"
+
+    indexes = _get_indexes(db_path)
+    assert "idx_ki_user_id" in indexes, "idx_ki_user_id must exist after init"
+
+
+@pytest.mark.asyncio
+async def test_migration_is_idempotent(tmp_path):
+    """A second init() on an already-migrated DB must be a no-op (no error)."""
+    db_path = tmp_path / "knowledge.db"
+    _create_old_schema_db(db_path)
+
+    store = KnowledgeStore(db_path, media_dir=tmp_path / "media")
+    await store.init()
+    await store.close()
+
+    # Second init -- must not raise
+    store2 = KnowledgeStore(db_path, media_dir=tmp_path / "media")
+    await store2.init()
+    await store2.close()
+
+    assert "user_id" in _get_columns(db_path)
+    assert "idx_ki_user_id" in _get_indexes(db_path)
+
+
+@pytest.mark.asyncio
+async def test_fresh_db_has_user_id_column_and_index(tmp_path):
+    """A brand-new DB must also have user_id + index after init."""
+    db_path = tmp_path / "knowledge_fresh.db"
+
+    store = KnowledgeStore(db_path, media_dir=tmp_path / "media")
+    await store.init()
+    await store.close()
+
+    assert "user_id" in _get_columns(db_path)
+    assert "idx_ki_user_id" in _get_indexes(db_path)

--- a/tinyagentos/__main__.py
+++ b/tinyagentos/__main__.py
@@ -76,19 +76,26 @@ def _serve_dual_port(app, *, host: str, port: int, proxy_port: int) -> None:
     """Run the main app and the browser-proxy origin concurrently.
 
     ``uvicorn.run`` is blocking and we need two servers, so we drive two
-    ``uvicorn.Server`` instances under one event loop via ``asyncio.gather``.
+    ``uvicorn.Server`` instances under one event loop.
 
     The proxy-origin app shares the main app's ``app.state`` object (see
     ``create_browser_proxy_app``), which the main app's lifespan populates
     on startup. Both servers start together; the proxy origin only receives
     traffic after the shell has loaded and redeemed a ticket (post-startup),
     so the shared state is always ready by the time it is read.
+
+    If the main server's serve() returns without having reached the
+    'started' state (lifespan raised during startup), we exit non-zero so
+    systemd's Restart= fires instead of leaving a half-alive process.
     """
     import asyncio
+    import logging
 
     import uvicorn
 
     from tinyagentos.browser_proxy_origin import create_browser_proxy_app
+
+    _log = logging.getLogger(__name__)
 
     proxy_app = create_browser_proxy_app(app.state)
 
@@ -97,10 +104,44 @@ def _serve_dual_port(app, *, host: str, port: int, proxy_port: int) -> None:
     main_server = uvicorn.Server(main_config)
     proxy_server = uvicorn.Server(proxy_config)
 
-    async def _run() -> None:
-        await asyncio.gather(main_server.serve(), proxy_server.serve())
+    started = asyncio.run(_serve_until_first_exit(main_server, proxy_server))
+    if not started:
+        _log.error(
+            "Main server failed to start on %s:%d -- check lifespan errors above",
+            host,
+            port,
+        )
+        raise SystemExit(3)
 
-    asyncio.run(_run())
+
+async def _serve_until_first_exit(main_server, proxy_server) -> bool:
+    """Drive both servers; cancel the survivor when one exits.
+
+    Returns True when the main server reached the started state before
+    either serve() returned, False otherwise (startup failure).
+    """
+    import asyncio
+
+    main_task = asyncio.create_task(main_server.serve())
+    proxy_task = asyncio.create_task(proxy_server.serve())
+
+    done, pending = await asyncio.wait(
+        {main_task, proxy_task},
+        return_when=asyncio.FIRST_COMPLETED,
+    )
+
+    for task in pending:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    for task in done:
+        if task.exception() is not None:
+            raise task.exception()
+
+    return bool(getattr(main_server, "started", False))
 
 
 def _seed_data_dir(target: Path) -> None:

--- a/tinyagentos/base_store.py
+++ b/tinyagentos/base_store.py
@@ -11,6 +11,16 @@ class BaseStore:
     Subclasses set ``SCHEMA`` (applied once on first open) and may set
     ``MIGRATIONS`` to a list of ``(version, sql_or_callable)`` pairs that
     will be tracked and applied in order by the migration runner.
+
+    WARNING: init order is SCHEMA -> MIGRATIONS -> _post_init.  Never
+    reference a column inside SCHEMA that is introduced by a migration --
+    the SCHEMA executescript runs first and will crash on any existing
+    database that lacks the column.  The migration runner also uses
+    baseline-at-latest semantics: pre-existing databases are stamped at the
+    latest version without executing any SQL, so retrofit migrations are
+    silently skipped.  Use a guarded _post_init coroutine (PRAGMA
+    table_info check + ALTER TABLE only when absent) for columns added
+    after initial release.  See db_migrations.py module docstring.
     """
     SCHEMA: str = ""
     # List of (version: int, sql_or_callable) pairs. See db_migrations.py.

--- a/tinyagentos/db_migrations.py
+++ b/tinyagentos/db_migrations.py
@@ -39,6 +39,22 @@ Both set:
 WAL gives better read concurrency and avoids most "database is locked" errors.
 NORMAL synchronous is safe for nearly all crash scenarios while being
 significantly faster than the default FULL.
+
+FOOTGUNS -- READ BEFORE ADDING MIGRATIONS
+------------------------------------------
+1. SCHEMA runs before MIGRATIONS (see BaseStore.init).  Never put a
+   reference to a column that is introduced by a migration inside SCHEMA
+   (e.g. an index on a column added by ALTER TABLE).  The SCHEMA
+   executescript will crash on existing databases that lack the column
+   before the migration that adds it has had a chance to run.
+
+2. Baseline-at-latest semantics (step 2 above) stamp pre-existing databases
+   at the newest migration version WITHOUT executing any SQL.  This means
+   retrofit migrations -- ones written for databases that predate them -- are
+   silently skipped on exactly the databases that need them.  Use a guarded
+   _post_init coroutine instead (PRAGMA table_info check + ALTER TABLE only
+   when the column is absent).  See knowledge_store._migration_v1_add_user_id
+   and agent_registry_store._migration_v1_add_status for the pattern.
 """
 from __future__ import annotations
 

--- a/tinyagentos/knowledge_store.py
+++ b/tinyagentos/knowledge_store.py
@@ -34,7 +34,6 @@ CREATE TABLE IF NOT EXISTS knowledge_items (
 CREATE INDEX IF NOT EXISTS idx_ki_source_type ON knowledge_items(source_type);
 CREATE INDEX IF NOT EXISTS idx_ki_status ON knowledge_items(status);
 CREATE INDEX IF NOT EXISTS idx_ki_created ON knowledge_items(created_at DESC);
-CREATE INDEX IF NOT EXISTS idx_ki_user_id ON knowledge_items(user_id);
 
 CREATE VIRTUAL TABLE IF NOT EXISTS knowledge_fts USING fts5(
     id UNINDEXED,
@@ -95,19 +94,41 @@ def _row_to_item(row: tuple) -> dict:
     }
 
 
+
+async def _migration_v1_add_user_id(conn) -> None:
+    """Add user_id column and index to knowledge_items (idempotent).
+
+    Runs at the top of _post_init so it self-heals databases created before
+    the multi-user keying was introduced.  SQLite lacks IF NOT EXISTS for
+    ADD COLUMN prior to 3.37, so we use PRAGMA table_info for broad
+    compatibility.
+    """
+    existing_cols = {
+        row[1]
+        for row in await (
+            await conn.execute("PRAGMA table_info(knowledge_items)")
+        ).fetchall()
+    }
+    if "user_id" not in existing_cols:
+        await conn.execute(
+            "ALTER TABLE knowledge_items ADD COLUMN user_id TEXT NOT NULL DEFAULT ''"
+        )
+    await conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_ki_user_id ON knowledge_items(user_id)"
+    )
+    await conn.commit()
+
+
 class KnowledgeStore(BaseStore):
     """SQLite + FTS5 store for the Knowledge Base Service."""
 
     SCHEMA = KNOWLEDGE_SCHEMA
-    MIGRATIONS = [
-        (1, "ALTER TABLE knowledge_items ADD COLUMN user_id TEXT NOT NULL DEFAULT ''"),
-    ]
-
     def __init__(self, db_path: Path, media_dir: Path | None = None) -> None:
         super().__init__(db_path)
         self.media_dir = media_dir or db_path.parent / "knowledge-media"
 
     async def _post_init(self) -> None:
+        await _migration_v1_add_user_id(self._db)
         self.media_dir.mkdir(parents=True, exist_ok=True)
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **#755 (knowledge_store):** `KNOWLEDGE_SCHEMA` contained `CREATE INDEX IF NOT EXISTS idx_ki_user_id ON knowledge_items(user_id)`, which crashes `executescript` on any pre-existing database that lacks the `user_id` column -- because SCHEMA runs before MIGRATIONS. The registered `MIGRATIONS` entry could never help: `run_migrations_async` uses baseline-at-latest semantics, stamping pre-existing DBs at the latest version without executing the SQL.

  Fix: remove `idx_ki_user_id` from SCHEMA, drop the `MIGRATIONS` list, and add a guarded `_migration_v1_add_user_id` module-level coroutine (PRAGMA table_info check + ALTER TABLE only when the column is absent + CREATE INDEX IF NOT EXISTS). It runs at the top of `_post_init`, before anything else, so it self-heals already-bricked installs on their next update -- no manual DB surgery needed. Adds loud docstring warnings to `db_migrations.py` and `BaseStore` documenting the two footguns (SCHEMA-runs-first; baseline-at-latest skips retrofit migrations).

- **#756 (__main__):** `asyncio.gather(main_server.serve(), proxy_server.serve())` waits forever when the main server's lifespan raises on startup -- uvicorn logs the error and returns from `serve()` instead of raising, leaving the process alive on the proxy port only. systemd sees the unit as active and `Restart=` never fires.

  Fix: replace the bare gather with a `_serve_until_first_exit(main_server, proxy_server)` helper that uses `asyncio.wait(FIRST_COMPLETED)`, cancels and awaits the survivor, re-raises any exception from the completed task, and returns `bool(main_server.started)`. If `False`, `_serve_dual_port` logs a clear error and raises `SystemExit(3)` so systemd surfaces the failure.

## Tests

- `tests/test_knowledge_migration.py`: init against an old-shape DB (knowledge_items without user_id), assert column+index exist after init and a second init is a no-op; fresh-DB path also asserted.
- `tests/test_dual_port_helper.py`: stub server objects (no real sockets) cover: main-fails-to-start returns False, proxy-exits-first-with-started-main returns True, both-exit returns True, serve-exception propagates.

Fixes #755, fixes #756

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for server startup scenarios and database migration behavior

* **Bug Fixes**
  * Enhanced server startup and shutdown handling to detect initialization failures and report errors
  * Improved database schema migration reliability and robustness

* **Chores**
  * Updated internal documentation on database initialization patterns and migration design considerations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->