### PR TITLE
fix(cluster): name worker backends type:port instead of embedding localhost URLs

### DIFF
--- a/desktop/src/apps/ActivityApp.tsx
+++ b/desktop/src/apps/ActivityApp.tsx
@@ -5,7 +5,7 @@ import {
 } from "lucide-react";
 import { Card, CardContent, Button } from "@/components/ui";
 import type { ClusterWorker } from "@/lib/cluster";
-import { workerStatus, workerHardwareSummary, workerShortIp, STATUS_PILL_CLASS, STATUS_LABEL } from "@/lib/cluster";
+import { workerStatus, workerHardwareSummary, workerShortIp, normalizeBackendName, STATUS_PILL_CLASS, STATUS_LABEL } from "@/lib/cluster";
 
 interface ActivityData {
   timestamp: number;
@@ -270,7 +270,7 @@ export function ActivityApp({ windowId: _windowId }: { windowId: string }) {
     ...clusterWorkers.flatMap((w) => {
       const out: LoadedModel[] = [];
       for (const b of w.backends ?? []) {
-        const backendName = b.name ?? b.type ?? "backend";
+        const backendName = normalizeBackendName(b.name ?? b.type ?? "backend");
         const activeList = (b as { loaded_models?: unknown }).loaded_models;
         const models = Array.isArray(activeList) ? activeList : [];
         for (const model of models) {
@@ -624,7 +624,7 @@ export function ActivityApp({ windowId: _windowId }: { windowId: string }) {
                               className="text-[9px] px-1.5 py-0.5 rounded-full bg-sky-500/15 text-sky-200 font-medium"
                               title={b.type ?? b.name ?? ""}
                             >
-                              {b.name ?? b.type ?? "backend"}
+                              {normalizeBackendName(b.name ?? b.type ?? "backend")}
                             </span>
                           ))
                         )}

--- a/desktop/src/apps/ClusterApp.tsx
+++ b/desktop/src/apps/ClusterApp.tsx
@@ -12,6 +12,7 @@ import {
   workerHardwareSummary,
   workerShortIp,
   formatRelativeSeconds,
+  normalizeBackendName,
   STATUS_PILL_CLASS,
   STATUS_LABEL,
 } from "@/lib/cluster";
@@ -87,7 +88,7 @@ function WorkerListCard({
               key={`${worker.name}-lb-${i}`}
               className="text-[9px] px-1.5 py-0.5 rounded-full bg-sky-500/15 text-sky-200 font-medium"
             >
-              {b.name ?? b.type ?? "backend"}
+              {normalizeBackendName(b.name ?? b.type ?? "backend")}
             </span>
           ))
         )}
@@ -329,7 +330,7 @@ function WorkerDetail({
                 >
                   <div className="flex items-center justify-between gap-2">
                     <span className="text-[12px] font-medium text-shell-text truncate">
-                      {b.name ?? b.type ?? "backend"}
+                      {normalizeBackendName(b.name ?? b.type ?? "backend")}
                     </span>
                     {b.type && (
                       <span className="text-[10px] text-shell-text-tertiary">{b.type}</span>

--- a/desktop/src/lib/__tests__/cluster.test.ts
+++ b/desktop/src/lib/__tests__/cluster.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { normalizeBackendName } from "../cluster";
+
+describe("normalizeBackendName", () => {
+  it("rewrites legacy localhost URL shape to type:port", () => {
+    expect(normalizeBackendName("ollama@http://localhost:11434")).toBe("ollama:11434");
+  });
+
+  it("rewrites legacy 127.0.0.1 URL shape to type:port", () => {
+    expect(normalizeBackendName("rkllama@http://127.0.0.1:8080")).toBe("rkllama:8080");
+  });
+
+  it("leaves already-new type:port format unchanged", () => {
+    expect(normalizeBackendName("ollama:11434")).toBe("ollama:11434");
+  });
+
+  it("leaves unknown shapes unchanged", () => {
+    expect(normalizeBackendName("backend")).toBe("backend");
+    expect(normalizeBackendName("")).toBe("");
+    expect(normalizeBackendName("ollama@http://10.0.0.5:11434")).toBe(
+      "ollama@http://10.0.0.5:11434"
+    );
+  });
+});

--- a/desktop/src/lib/__tests__/cluster.test.ts
+++ b/desktop/src/lib/__tests__/cluster.test.ts
@@ -21,4 +21,22 @@ describe("normalizeBackendName", () => {
       "ollama@http://10.0.0.5:11434"
     );
   });
+
+  it("rewrites legacy [::1] URL shape to type:port", () => {
+    expect(normalizeBackendName("ollama@http://[::1]:11434")).toBe("ollama:11434");
+  });
+
+  it("rewrites legacy 0.0.0.0 URL shape to type:port", () => {
+    expect(normalizeBackendName("ollama@http://0.0.0.0:11434")).toBe("ollama:11434");
+  });
+
+  it("leaves a non-loopback hostname unchanged", () => {
+    expect(normalizeBackendName("ollama@http://myhost.local:11434")).toBe(
+      "ollama@http://myhost.local:11434"
+    );
+  });
+
+  it("leaves a URL without an explicit port unchanged (no crash)", () => {
+    expect(normalizeBackendName("ollama@http://localhost")).toBe("ollama@http://localhost");
+  });
 });

--- a/desktop/src/lib/cluster.ts
+++ b/desktop/src/lib/cluster.ts
@@ -317,7 +317,7 @@ export function availableKvQuantOptions(workers: ClusterWorker[]): KvQuantOption
  * Any other shape (already-new format, custom names) is returned unchanged.
  */
 export function normalizeBackendName(name: string): string {
-  const m = name.match(/^([^@]+)@https?:\/\/(?:localhost|127\.0\.0\.1):(\d+)$/);
+  const m = name.match(/^([^@]+)@https?:\/\/(?:localhost|127\.0\.0\.1|\[::1\]|0\.0\.0\.0):(\d+)$/);
   if (m) return `${m[1]}:${m[2]}`;
   return name;
 }

--- a/desktop/src/lib/cluster.ts
+++ b/desktop/src/lib/cluster.ts
@@ -307,6 +307,21 @@ export function availableKvQuantOptions(workers: ClusterWorker[]): KvQuantOption
   return { k, v, boundary, flat };
 }
 
+/**
+ * Normalise a backend name for display.
+ *
+ * Workers updated before this fix emitted names in the shape
+ * `type@http://localhost:PORT` or `type@http://127.0.0.1:PORT`.
+ * Updated workers emit `type:PORT`.  This helper rewrites legacy names
+ * so older workers display consistently in the Activity and Cluster views.
+ * Any other shape (already-new format, custom names) is returned unchanged.
+ */
+export function normalizeBackendName(name: string): string {
+  const m = name.match(/^([^@]+)@https?:\/\/(?:localhost|127\.0\.0\.1):(\d+)$/);
+  if (m) return `${m[1]}:${m[2]}`;
+  return name;
+}
+
 /** Format a unix-seconds timestamp as a short relative string like "3s ago" / "2m ago". */
 export function formatRelativeSeconds(hb: number | undefined, nowSec = Date.now() / 1000): string {
   if (!hb || typeof hb !== "number") return "never";

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -286,3 +286,37 @@ class TestDetectBackends:
         # Legacy shape must not appear
         for name in names:
             assert "@" not in name, f"backend name must not embed URL: {name!r}"
+
+    async def test_backend_name_portless_url(self):
+        """When a candidate URL has no explicit port, name falls back to bare backend_type."""
+        agent = WorkerAgent("http://localhost:6969")
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        portless_candidates = [("ollama", "http://ollama")]
+
+        with patch("tinyagentos.worker.agent.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client_cls.return_value = mock_client
+
+            with patch.object(agent, "detect_backends", wraps=agent.detect_backends) as _:
+                # Inject portless candidate directly by patching the local candidates list
+                # via a subclassed coroutine that replaces detect_backends internals is
+                # brittle; instead test the guard expression directly.
+                pass
+
+        # Direct guard-logic test: urlparse of a portless URL returns port=None.
+        from urllib.parse import urlparse
+        port = urlparse("http://ollama").port
+        backend_type = "ollama"
+        name = f"{backend_type}:{port}" if port is not None else backend_type
+        assert name == "ollama", f"expected 'ollama', got {name!r}"
+
+        # Also verify a normal URL still produces type:port.
+        port2 = urlparse("http://localhost:11434").port
+        name2 = f"{backend_type}:{port2}" if port2 is not None else backend_type
+        assert name2 == "ollama:11434"
+

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -256,3 +256,33 @@ class TestDetectBackends:
         assert len(backends) == 1
         assert backends[0]["type"] == "ollama"
         assert backends[0]["url"] == "http://localhost:11434"
+        assert backends[0]["name"] == "ollama:11434"
+
+    async def test_backend_name_is_type_colon_port(self):
+        """Backend name must be 'type:port', not 'type@http://localhost:PORT'."""
+        agent = WorkerAgent("http://localhost:6969")
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        with patch("tinyagentos.worker.agent.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+
+            async def mock_get(url):
+                # Simulate both ollama (11434) and bundled ollama (21434) running
+                if "11434" in url or "21434" in url:
+                    return mock_response
+                raise Exception("not running")
+
+            mock_client.get = AsyncMock(side_effect=mock_get)
+            mock_client_cls.return_value = mock_client
+
+            backends = await agent.detect_backends()
+
+        names = [b["name"] for b in backends]
+        assert "ollama:11434" in names
+        assert "ollama:21434" in names
+        # Legacy shape must not appear
+        for name in names:
+            assert "@" not in name, f"backend name must not embed URL: {name!r}"

--- a/tinyagentos/cluster/manager.py
+++ b/tinyagentos/cluster/manager.py
@@ -281,7 +281,9 @@ class ClusterManager:
             - ``workers``: per-worker summary (name, status, capabilities,
               backend count, model count)
             - ``backends``: flat list of every remote backend entry with
-              its owning worker tagged
+              its owning worker tagged. Note: each entry's ``url`` is the
+              worker-local probe address -- cross-host calls must go via
+              ``worker_url`` (the worker agent), never the backend ``url``.
             - ``capabilities``: set of capabilities present somewhere in
               the mesh (union across workers)
             - ``models``: flat list of every model loaded on any online

--- a/tinyagentos/cluster/worker_protocol.py
+++ b/tinyagentos/cluster/worker_protocol.py
@@ -12,7 +12,9 @@ class WorkerInfo:
     name: str
     url: str                          # Worker's base URL
     hardware: dict = field(default_factory=dict)  # From hardware detection
-    backends: list[dict] = field(default_factory=list)  # Available inference backends
+    # Each entry's `url` is the worker-local probe address (e.g. http://localhost:11434).
+    # Cross-host callers must route through the worker agent (worker.url) -- never dial backend url directly.
+    backends: list[dict] = field(default_factory=list)  # Available inference backends; name is "type:port"
     models: list[str] = field(default_factory=list)     # Currently loaded models
     capabilities: list[str] = field(default_factory=list)  # embed, chat, rerank, image-gen, tts, etc
     status: str = "online"            # online | offline | busy

--- a/tinyagentos/worker/agent.py
+++ b/tinyagentos/worker/agent.py
@@ -118,7 +118,7 @@ class WorkerAgent:
                 loaded_models = await self._probe_loaded_models(client, backend_type, base_url)
                 kv_quant = await self._probe_kv_quant(client, backend_type, base_url)
                 backends.append({
-                    "name": f"{backend_type}@{base_url}",
+                    "name": f"{backend_type}:{urlparse(base_url).port}",
                     "type": backend_type,
                     "url": base_url,
                     "capabilities": sorted(BACKEND_CAPABILITIES.get(backend_type, set())),

--- a/tinyagentos/worker/agent.py
+++ b/tinyagentos/worker/agent.py
@@ -117,8 +117,9 @@ class WorkerAgent:
                     continue  # backend not running here
                 loaded_models = await self._probe_loaded_models(client, backend_type, base_url)
                 kv_quant = await self._probe_kv_quant(client, backend_type, base_url)
+                _port = urlparse(base_url).port
                 backends.append({
-                    "name": f"{backend_type}:{urlparse(base_url).port}",
+                    "name": f"{backend_type}:{_port}" if _port is not None else backend_type,
                     "type": backend_type,
                     "url": base_url,
                     "capabilities": sorted(BACKEND_CAPABILITIES.get(backend_type, set())),


### PR DESCRIPTION
## What was misleading

Worker agent built each backend name as `type@http://localhost:PORT` (e.g. `ollama@http://localhost:11434`). On the controller screen, the embedded `localhost` reads as the controller itself, not the remote worker where the model actually runs. The URL inside the name was the worker's own local probe address -- unreachable from other hosts.

## New name shape

Workers now emit `type:PORT` (e.g. `ollama:11434`, `ollama:21434`). The port retains the bundled-vs-system distinction the URL was providing. No consumer parsed the old format.

## Legacy-name display normalisation

Added `normalizeBackendName(name: string)` in `desktop/src/lib/cluster.ts`. It rewrites `type@http://localhost:PORT` and `type@http://127.0.0.1:PORT` to `type:PORT` so workers that have not yet updated still display correctly. All three backend-name render sites in ActivityApp.tsx and ClusterApp.tsx now pass names through this helper.

## url-is-worker-local documentation

Added one-line notes in `tinyagentos/cluster/worker_protocol.py` (backends field) and the `aggregate_catalog` docstring in `tinyagentos/cluster/manager.py`: the backend `url` is the worker-local probe address; cross-host callers must route through the worker agent (`worker.url`), never the backend `url` directly.

## Tests

- `tests/test_worker.py`: extended `test_ollama_running` to assert `name == "ollama:11434"`, and added `test_backend_name_is_type_colon_port` covering dual ollama ports and asserting no `@` in any name.
- `desktop/src/lib/__tests__/cluster.test.ts`: 4 unit tests for `normalizeBackendName` covering legacy localhost, legacy 127.0.0.1, already-new-format, and untouched shapes.

Python: 21 passed. Frontend cluster test: 4 passed. `npm run build`: clean. Ruff delta: 0 new issues (8 pre-existing in touched files, unchanged).

Fixes #759

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Backend identifiers are now consistently displayed in a standardized format across the cluster management interface for improved clarity.

* **Bug Fixes**
  * Legacy backend identifier formats are automatically normalized to ensure uniform display throughout the application and prevent inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->