### PR TITLE
chore: promote dev to master (controller brick fix, installer sudo fix, perf cleanups, rescue runbook)

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,10 +7,12 @@
 
 # taOS: Live Status
 
-**Last updated:** 2026-06-10 ~18:55 BST, by @taOS (Mac session, claude-fable-5), handing off before a rate limit.
+**Last updated:** 2026-06-10 ~19:30 BST, by @taOS (Mac session). SESSION ENDING, Jay restarting Claude in the correct folder.
 **Repo:** github.com/jaylfc/taOS, branches `master` (stable) <- `dev` (integration).
 
 ## GOTCHA for the next agent
+- **FOLDER:** all taOS work is `jaylfc/taOS` at `~/Development/tinyagentos`. The prior session was launched from `~/Development/taosmd` by mistake (Claude then labels the session taOSmd, cosmetic). RESTART Claude in `~/Development/tinyagentos`, then say "read docs/AGENT_HANDOFF.md".
+- **#752 (safe cleanups) is OPEN, CI green-pending, NOT yet merged.** The auto-merge watcher died with the prior session. Merge it to dev when CI is green (approve-lock leak eviction + auth_requests indexes + shared httpx client #660; 45 tests passed on the Pi). Use the GitHub UI or a PAT.
 - **Merges/protected writes 401 on the gh OAuth token** intermittently (read calls are fine). Use the **GitHub UI merge button**, or a `ghp_` PAT via `GH_TOKEN=<pat> gh pr merge ...`. This is a token limitation, not a CI failure.
 - A background merge-watcher was auto-merging #746/#748/#749 via PAT, but **it dies when this session ends**, so finish them manually (below).
 - Never `--delete-branch` on a dev->master PR (auto-closes PRs targeting dev).
@@ -18,7 +20,7 @@
 
 ## Immediate next actions
 - M1 security CLEARED to master (93f395e2): SSRF #745, CSRF #746, CI-fix #748, docs #749 all merged + promoted.
-- NEXT BUILD: **#737** cluster-worker pairing-code auth (designed in the #737 comment, 4 phases, mechanical -> sonnet with a full spec). Then **#751** beads-inspired native task-graph (joint rec, awaiting Jay greenlight).
+- FIRST: merge #752 (safe cleanups) once CI green. Then NEXT BUILD: **#737** cluster-worker pairing-code auth (designed in the #737 comment, 4 phases, mechanical -> sonnet with a full spec). Then **#751** beads-inspired native task-graph (joint rec, awaiting Jay greenlight).
 
 ## In flight
 - **M1 security (audit milestone 1):** SSRF #738 DONE (#745 merged). CSRF #648 -> #746 (Strict session cookie + token wiring + fixed a latent silent-403 lock bug; per-route rollout tracked in #747). Remaining M1: **#737 cluster-worker auth** = a device-pairing-code flow, fully designed in the #737 comment (worker prints a code, admin pairs in taOS, mints the signing_key; 4 build phases). Not started.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,39 +7,45 @@
 
 # taOS: Live Status
 
-**Last updated:** 2026-06-10 ~19:30 BST, by @taOS (Mac session). SESSION ENDING, Jay restarting Claude in the correct folder.
+**Last updated:** 2026-06-10 ~23:40 BST, by @taOS (Mac session), at a rate-limit pause point.
 **Repo:** github.com/jaylfc/taOS, branches `master` (stable) <- `dev` (integration).
 
 ## GOTCHA for the next agent
-- **FOLDER:** all taOS work is `jaylfc/taOS` at `~/Development/tinyagentos`. The prior session was launched from `~/Development/taosmd` by mistake (Claude then labels the session taOSmd, cosmetic). RESTART Claude in `~/Development/tinyagentos`, then say "read docs/AGENT_HANDOFF.md".
-- **#752 (safe cleanups) is OPEN, CI green-pending, NOT yet merged.** The auto-merge watcher died with the prior session. Merge it to dev when CI is green (approve-lock leak eviction + auth_requests indexes + shared httpx client #660; 45 tests passed on the Pi). Use the GitHub UI or a PAT.
-- **Merges/protected writes 401 on the gh OAuth token** intermittently (read calls are fine). Use the **GitHub UI merge button**, or a `ghp_` PAT via `GH_TOKEN=<pat> gh pr merge ...`. This is a token limitation, not a CI failure.
-- A background merge-watcher was auto-merging #746/#748/#749 via PAT, but **it dies when this session ends**, so finish them manually (below).
-- Never `--delete-branch` on a dev->master PR (auto-closes PRs targeting dev).
-- **Promote with `--merge`, NOT squash.** Repeated squash-promotions diverge dev/master and conflict on shared files (hit this on #750). Fixed by reconciling with `git merge -s ours origin/master` on dev then a real `--merge` promotion, so dev is an ancestor of master again.
+- **Protected merges:** `gh pr merge` 401s on the OAuth token but `gh api -X PUT repos/jaylfc/taOS/pulls/N/merge -f merge_method=squash` WORKS with the same token. No PAT needed. Never `--delete-branch` on a dev->master PR. Promote with `--merge`, not squash.
+- **PR #762 (cluster pairing auth, #737 Phase 1) is OPEN, review half-done, NOT merged.** pairing_store.py reviewed clean by me; still to review: worker_auth.py, auth_middleware split, routes/cluster.py changes. CI was green-pending (lint/spa green, tests running). It is a SECURITY pr: finish the manual review, check Kilo+CodeRabbit comments, then merge via the gh api method.
+- **Two sonnet agents may have died mid-build with this session.** Check `gh pr list` for: (a) fix for #755+#756 on branch `fix/knowledge-migration-and-dual-port-exit`, (b) fix for #759 on branch `fix/worker-backend-name-localhost`. If no PR exists, re-dispatch: issues #755, #756, #759 contain the complete analysis and fix design (they are the spec).
+- CodeRabbit rate-limit fake-passes: a green CodeRabbit check can be a rate-limit notice. Check the PR comments; use `@coderabbitai full review`.
 
-## Immediate next actions
-- M1 security CLEARED to master (93f395e2): SSRF #745, CSRF #746, CI-fix #748, docs #749 all merged + promoted.
-- FIRST: merge #752 (safe cleanups) once CI green. Then NEXT BUILD: **#737** cluster-worker pairing-code auth (designed in the #737 comment, 4 phases, mechanical -> sonnet with a full spec). Then **#751** beads-inspired native task-graph (joint rec, awaiting Jay greenlight).
+## Tonight's incident (resolved): beta Pi controller down
+Root cause chain, all filed: knowledge.db predating user_id crashed init (schema index referenced the column before the migration could run, and the migration runner's baseline-at-latest would have skipped it anyway) = **#755**; uvicorn serve() returns instead of raising on lifespan failure so the dual-port gather left a half-alive process on :6970 with systemd showing active = **#756**. Pi repaired manually (ALTER TABLE + update to master 93f395e2) and verified healthy. py-spy is now installed in the Pi venv. New runbook: `docs/runbooks/controller-rescue.md` (#758, merged). **#755 fix must reach master before any beta user updates across the user_id boundary.**
 
-## In flight
-- **M1 security (audit milestone 1):** SSRF #738 DONE (#745 merged). CSRF #648 -> #746 (Strict session cookie + token wiring + fixed a latent silent-403 lock bug; per-route rollout tracked in #747). Remaining M1: **#737 cluster-worker auth** = a device-pairing-code flow, fully designed in the #737 comment (worker prints a code, admin pairs in taOS, mints the signing_key; 4 build phases). Not started.
-- **beads evaluation (handoff tooling):** design thread OPEN with @taOSmd on the A2A integration channel (msg #289). beads = github.com/gastownhall/beads, a Go CLI+MCP, Dolt-backed, AI-agent-native dependency-graph issue tracker (hash IDs for concurrent multi-agent writes, `bd ready` offline unblocked-work queue, `bd prime` session context). 4 open questions posed (boundary: taosmd component vs peer; overlap with our A2A+memory; SBC/Dolt weight; adopt-as-is vs concepts-only). CONVERGED with taOSmd: BUILD thin-native (Dolt too heavy for SBC; native task events feed the v2 memory engine, which beads cannot). Joint rec filed as **#751**, AWAITING Jay greenlight (buy vs build). taOSmd drafts the taosmd-side schema/endpoints; taOS wires the Tasks-app + handoff-bootstrap consumption side.
-- **#744 external coding-agent onboarding:** spec committed (`docs/design/external-agent-onboarding.md`), token->project-memory contract v1 locked with taOSmd. 7 taOS build tasks queued behind M1.
-- **Repo audit:** done, grade B-, report at `docs/audit/2026-06-10-repo-audit.md` (LOCAL-ONLY, gitignored, unpatched security detail). Findings tracked in issues #737-740 #743 + existing.
+## Immediate next actions (in order)
+1. Finish review + merge **#762** (pairing auth Phase 1) when CI green.
+2. Land the **#755+#756 fix** (re-dispatch if the agent died, see GOTCHA).
+3. Land the **#759 fix** (same).
+4. **Promote dev -> master** (carries #752 perf cleanups, #754 installer sudo fix, #758 runbook, plus whatever lands above). Use a dev->master PR with `--merge`.
+5. **Post the approved #723 reply** (Jay approved the draft verbatim, it is in the session transcript and summarised in the issue context: two causes, #724 fixed the CHDIR loop, #753 tracked the no-sudo gap, recovery = re-run installer with sudo). Post AFTER #753's fix (#754) is on master via step 4.
+6. #737 Phase 2 (worker scripts) once Phase 1 merged; spec pattern in the #737 comment.
+
+## Merged to dev this session
+#752 (approve-lock eviction + auth_requests indexes + shared httpx client), #754 (installer sudo gap, closes #753), #758 (controller rescue runbook).
 
 ## Open issues filed this session
-#735 feedback/bug tracker, #736 websites (taos.my + redirect), #737 cluster-worker pairing auth, #738 SSRF (fixed #745), #739 CI ruff+vitest+npm-audit, #740 Python lockfile, #741 resilience workflow, #742 memory-migrate cutover, #743 docs drift, #744 external-agent onboarding, #747 CSRF per-route rollout, #751 native task-graph (beads-inspired, joint rec).
+#753 installer sudo gap (fixed by #754), #755 knowledge migration bricks updates (CRITICAL), #756 half-alive controller on startup failure, #757 unit template env mangling (0_BASE_IMAGE), #759 worker backend names embed localhost URLs, #760 host badges everywhere (UI principle, design pass), #761 per-device emoji/badge identity (brainstorm first, depends on #760 + #737 pairing store).
+
+## In flight
+- **M1 security:** #737 Phase 1 = PR #762 (open). Phases 2-4 queued (scripts, UI, migration).
+- **#751** beads-inspired native task-graph: AWAITING Jay greenlight (buy vs build).
+- **#744 external coding-agent onboarding:** 7 build tasks queued behind M1.
 
 ## Cross-project (taosmd / A2A)
-- #25 memory unification DONE both sides + live + verified. Trust enforcement live-but-dormant (needs TAOSMD_REGISTRY_URL).
-- Progress channels live: `taos-progress` (mine), `taosmd-progress` (theirs); both feed project memory.
-- Workflow rules adopted both sides; durable 30-min freshness crons (taOS :00/:30, taosmd :15/:45). Pi Claude session is CLOSED (Mac session is sole @taOS driver this stretch). taOSmd confirmed clean-handoff protocol LIVE + battle-tested (msg 294, recovered with zero lost work at 17:05).
+- Progress channels live: `taos-progress` (incident + all merges posted), `taosmd-progress`. Durable 30-min freshness crons (taOS :00/:30, taosmd :15/:45).
 
 ## Blocked / waiting on human (Jay)
 - `#15` exo fork deletion: needs `gh auth refresh -s delete_repo`.
 - `TAOSMD_REGISTRY_URL` cutover: gated on the consent UI shipping (deliberate).
-- Decide buy-vs-build on beads once taOSmd + I bring the joint rec.
+- #751 beads buy-vs-build greenlight.
+- #761 emoji identity brainstorm.
 
 ## Where to look
 1. GitHub issues = task list. 2. This file = snapshot. 3. docs/AGENT_HANDOFF.md (local) = rules + bootstrap. 4. A2A bus :7900 (taos-progress / general / integration). 5. @taOS Pi memory (Claude Code only).

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,31 +7,32 @@
 
 # taOS: Live Status
 
-**Last updated:** 2026-06-10 ~18:30 BST, by @taOS (Mac session, claude-fable-5), handing off before a rate limit.
+**Last updated:** 2026-06-10 ~18:55 BST, by @taOS (Mac session, claude-fable-5), handing off before a rate limit.
 **Repo:** github.com/jaylfc/taOS, branches `master` (stable) <- `dev` (integration).
 
 ## GOTCHA for the next agent
 - **Merges/protected writes 401 on the gh OAuth token** intermittently (read calls are fine). Use the **GitHub UI merge button**, or a `ghp_` PAT via `GH_TOKEN=<pat> gh pr merge ...`. This is a token limitation, not a CI failure.
 - A background merge-watcher was auto-merging #746/#748/#749 via PAT, but **it dies when this session ends**, so finish them manually (below).
 - Never `--delete-branch` on a dev->master PR (auto-closes PRs targeting dev).
+- **Promote with `--merge`, NOT squash.** Repeated squash-promotions diverge dev/master and conflict on shared files (hit this on #750). Fixed by reconciling with `git merge -s ours origin/master` on dev then a real `--merge` promotion, so dev is an ancestor of master again.
 
-## Immediate next actions (finish M1 merges, then promote)
-1. Merge to dev once CI green (Kilo failure = ignore, infra): **#746** (CSRF defense-in-depth), **#748** (add-to-project non-blocking CI), **#749** (docs taosmd coverage). #745 (SSRF) is already merged.
-2. Promote dev -> master via a dev->master PR (squash, no --delete-branch). Needs the UI button or PAT.
+## Immediate next actions
+- M1 security CLEARED to master (93f395e2): SSRF #745, CSRF #746, CI-fix #748, docs #749 all merged + promoted.
+- NEXT BUILD: **#737** cluster-worker pairing-code auth (designed in the #737 comment, 4 phases, mechanical -> sonnet with a full spec). Then **#751** beads-inspired native task-graph (joint rec, awaiting Jay greenlight).
 
 ## In flight
 - **M1 security (audit milestone 1):** SSRF #738 DONE (#745 merged). CSRF #648 -> #746 (Strict session cookie + token wiring + fixed a latent silent-403 lock bug; per-route rollout tracked in #747). Remaining M1: **#737 cluster-worker auth** = a device-pairing-code flow, fully designed in the #737 comment (worker prints a code, admin pairs in taOS, mints the signing_key; 4 build phases). Not started.
-- **beads evaluation (handoff tooling):** design thread OPEN with @taOSmd on the A2A integration channel (msg #289). beads = github.com/gastownhall/beads, a Go CLI+MCP, Dolt-backed, AI-agent-native dependency-graph issue tracker (hash IDs for concurrent multi-agent writes, `bd ready` offline unblocked-work queue, `bd prime` session context). 4 open questions posed (boundary: taosmd component vs peer; overlap with our A2A+memory; SBC/Dolt weight; adopt-as-is vs concepts-only). My lean: adopt-and-bridge over rebuild. AWAITING taOSmd reply, then bring Jay a joint buy-vs-build recommendation. Do NOT fold Jay in until taOSmd + I converge.
+- **beads evaluation (handoff tooling):** design thread OPEN with @taOSmd on the A2A integration channel (msg #289). beads = github.com/gastownhall/beads, a Go CLI+MCP, Dolt-backed, AI-agent-native dependency-graph issue tracker (hash IDs for concurrent multi-agent writes, `bd ready` offline unblocked-work queue, `bd prime` session context). 4 open questions posed (boundary: taosmd component vs peer; overlap with our A2A+memory; SBC/Dolt weight; adopt-as-is vs concepts-only). CONVERGED with taOSmd: BUILD thin-native (Dolt too heavy for SBC; native task events feed the v2 memory engine, which beads cannot). Joint rec filed as **#751**, AWAITING Jay greenlight (buy vs build). taOSmd drafts the taosmd-side schema/endpoints; taOS wires the Tasks-app + handoff-bootstrap consumption side.
 - **#744 external coding-agent onboarding:** spec committed (`docs/design/external-agent-onboarding.md`), token->project-memory contract v1 locked with taOSmd. 7 taOS build tasks queued behind M1.
 - **Repo audit:** done, grade B-, report at `docs/audit/2026-06-10-repo-audit.md` (LOCAL-ONLY, gitignored, unpatched security detail). Findings tracked in issues #737-740 #743 + existing.
 
 ## Open issues filed this session
-#735 feedback/bug tracker, #736 websites (taos.my + redirect), #737 cluster-worker pairing auth, #738 SSRF (fixed #745), #739 CI ruff+vitest+npm-audit, #740 Python lockfile, #741 resilience workflow, #742 memory-migrate cutover, #743 docs drift, #744 external-agent onboarding, #747 CSRF per-route rollout.
+#735 feedback/bug tracker, #736 websites (taos.my + redirect), #737 cluster-worker pairing auth, #738 SSRF (fixed #745), #739 CI ruff+vitest+npm-audit, #740 Python lockfile, #741 resilience workflow, #742 memory-migrate cutover, #743 docs drift, #744 external-agent onboarding, #747 CSRF per-route rollout, #751 native task-graph (beads-inspired, joint rec).
 
 ## Cross-project (taosmd / A2A)
 - #25 memory unification DONE both sides + live + verified. Trust enforcement live-but-dormant (needs TAOSMD_REGISTRY_URL).
 - Progress channels live: `taos-progress` (mine), `taosmd-progress` (theirs); both feed project memory.
-- Workflow rules adopted both sides; durable 30-min freshness crons (taOS :00/:30, taosmd :15/:45). Pi Claude session is CLOSED (Mac session is sole @taOS driver this stretch).
+- Workflow rules adopted both sides; durable 30-min freshness crons (taOS :00/:30, taosmd :15/:45). Pi Claude session is CLOSED (Mac session is sole @taOS driver this stretch). taOSmd confirmed clean-handoff protocol LIVE + battle-tested (msg 294, recovered with zero lost work at 17:05).
 
 ## Blocked / waiting on human (Jay)
 - `#15` exo fork deletion: needs `gh auth refresh -s delete_repo`.

--- a/docs/runbooks/controller-rescue.md
+++ b/docs/runbooks/controller-rescue.md
@@ -1,0 +1,134 @@
+# Runbook: Controller Rescue and Component Restarts
+
+**Audience:** taOS admins, power users, and the taOS host agent diagnosing an instance that is down, hung, or misbehaving. If the desktop UI is reachable, prefer it: most recovery actions here have UI surfaces. This runbook is for when it is not.
+
+**Where things live:** the install directory is `/opt/tinyagentos` on system installs (legacy installs used `~/tinyagentos`; substitute accordingly). The data directory is `<install dir>/data`. All commands below assume a Linux system install running as the `taos` user; see the end for user-mode and macOS variants.
+
+---
+
+## Quick triage
+
+Work down this list. Stop at the first failing step: that layer is your problem.
+
+| # | Check | Command | Healthy looks like |
+|---|---|---|---|
+| 1 | Host reachable | `ping <host>` | replies |
+| 2 | Service state | `systemctl status tinyagentos` | `active (running)` |
+| 3 | Port actually listening | `ss -tlnp \| grep 6969` | a `python` process on `0.0.0.0:6969` |
+| 4 | API answering | `curl -s http://127.0.0.1:6969/api/health` | HTTP 200 |
+| 5 | Version | `curl -s http://127.0.0.1:6969/api/version` | current release |
+
+**Beware the half-alive state:** `active (running)` with port 6970 listening but **not** 6969 means the main app crashed during startup while the browser-proxy origin survived (issue #756). systemd will not restart it. Read the journal (below), fix the cause, then `systemctl restart tinyagentos`.
+
+---
+
+## Reading the journal
+
+```bash
+journalctl -u tinyagentos -n 100 --no-pager        # last 100 lines
+journalctl -u tinyagentos --since "10 minutes ago" # around a restart
+journalctl -xeu tinyagentos                        # why the last start failed
+```
+
+The line that matters most after a failed boot is the last Python traceback before `ERROR: Application startup failed. Exiting.`
+
+---
+
+## Complete restart
+
+```bash
+sudo systemctl restart tinyagentos
+```
+
+This is the big hammer: it also restarts LiteLLM (a child process of the controller) and re-runs the desktop bundle check. A clean boot takes roughly a minute on SBC hardware. Verify with triage steps 3 to 5.
+
+Stop and start separately when you need a gap (for example to move the data dir):
+
+```bash
+sudo systemctl stop tinyagentos    # graceful stop, waits for in-flight work
+sudo systemctl start tinyagentos
+```
+
+---
+
+## Per-component restarts
+
+| Component | What it is | Restart |
+|---|---|---|
+| Controller | `tinyagentos.service`, the main app on :6969 (+ browser proxy on :6970) | `sudo systemctl restart tinyagentos` |
+| LiteLLM | model router on `127.0.0.1:4000`, child process of the controller, config under `/tmp/taos-litellm/` | restart the controller (it respawns LiteLLM) |
+| qmd | shared embed/rerank provider, `qmd.service` on :7832 | `sudo systemctl restart qmd` |
+| Agent containers | one LXC per agent, named `taos-agent-<name>` | `incus restart taos-agent-<name>` (or start/stop) |
+| Postgres | LiteLLM's database | `sudo systemctl restart postgresql` |
+| Store apps (Docker) | one container per installed app | `docker restart <name>` (`docker ps` to list) |
+| RK3588 extras | `rkllama.service` (NPU models), `taos-rk3588-perf.service` (boot-time governors) | `sudo systemctl restart rkllama` |
+| Workers | separate boxes, paired via the cluster | see `worker-lxc-enrollment.md` |
+
+Notes:
+
+- Stopped agent containers are often normal: agents that were archived or never started stay `STOPPED`. Check the Agents app or `incus list` against what you expect to be running.
+- Restarting the controller does not touch agent containers. Agents reconnect on their own.
+
+---
+
+## Diagnosis toolkit
+
+```bash
+# What is listening where
+ss -tlnp | grep -E "6969|6970|4000|7832"
+
+# Is the process hung rather than dead? Dump live Python stacks
+sudo /opt/tinyagentos/.venv/bin/pip install py-spy   # once
+sudo /opt/tinyagentos/.venv/bin/py-spy dump --pid $(systemctl show -p MainPID --value tinyagentos)
+
+# SQLite store integrity (controller must be stopped for a write check)
+sqlite3 /opt/tinyagentos/data/<store>.db "PRAGMA integrity_check;"
+
+# What version is installed vs latest
+git -C /opt/tinyagentos log --oneline -1
+git -C /opt/tinyagentos fetch origin && git -C /opt/tinyagentos log --oneline origin/master -1
+
+# Disk space (a full disk breaks SQLite writes in odd ways)
+df -h /opt /var
+```
+
+---
+
+## Known failure signatures
+
+| Symptom in journal / status | Cause | Fix |
+|---|---|---|
+| `status=200/CHDIR`, restart counter climbing | service user cannot traverse into the install dir (install under `/root`, or privileged setup skipped on a non-sudo install run) | re-run the installer with sudo; it repairs ownership and parent-dir permissions (#723, #724, #753) |
+| `sqlite3.OperationalError: no such column: user_id` then `Application startup failed` | knowledge.db predates the multi-user schema and the migration never applied | update to a release with the guarded migration (#755); it self-heals on boot. Manual bridge: `sqlite3 data/knowledge.db "ALTER TABLE knowledge_items ADD COLUMN user_id TEXT NOT NULL DEFAULT '';"` |
+| unit `active (running)`, :6970 listening, :6969 dead, journal shows a startup traceback | main server failed startup, proxy kept the process alive (#756) | fix the traceback's cause, then `systemctl restart tinyagentos` |
+| `status=217/USER` | the `taos` system user does not exist (installer ran without privileges) | re-run the installer with sudo (#753) |
+| Port already in use on 6969/6970 | a previous half-dead process still holds the port | `sudo systemctl stop tinyagentos`, confirm with `ss -tlnp`, `kill` any leftover, start again |
+| UI loads but models error | LiteLLM child or postgres down | triage `ss \| grep 4000`, `systemctl status postgresql`, restart the controller |
+
+---
+
+## Updating to latest (and as a repair)
+
+The installer is idempotent and doubles as a repair tool: it fixes ownership, permissions, units, and dependencies without touching your data.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/jaylfc/tinyagentos/master/scripts/install-server.sh | sudo bash
+```
+
+Manual update of an existing install:
+
+```bash
+cd /opt/tinyagentos
+sudo -u taos git -c safe.directory=/opt/tinyagentos pull --ff-only origin master
+sudo -u taos .venv/bin/pip install -q -e .
+sudo systemctl restart tinyagentos
+```
+
+The `safe.directory` flag is needed because the repo is owned by the `taos` service user, not the account you are typing from.
+
+---
+
+## User-mode and macOS variants
+
+- **User-mode systemd** (installer ran without root): same commands with `systemctl --user` and `journalctl --user -u tinyagentos`. No `taos` user exists; everything runs as you.
+- **macOS** (launchd agent): `launchctl kickstart -k gui/$(id -u)/com.tinyagentos.controller` to restart; logs land in the paths configured in `~/Library/LaunchAgents/com.tinyagentos.controller.plist`.

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -1366,14 +1366,17 @@ fi
 ensure_taos_user() {
     [[ "$os_name" == "Linux" ]] || return 0  # no-op on macOS (launchd agent)
 
+    local sudo_cmd=""
+    [[ "$(id -u)" != "0" ]] && sudo_cmd="sudo"
+
     # Create the system user if absent. useradd -r = system account (no home
     # dir by default, no expiry). -M = do not create /home/taos. -d sets the
     # "home" field in /etc/passwd to INSTALL_DIR (used by some tools for ~
     # expansion, not an actual home directory on disk).
     if ! id -u taos >/dev/null 2>&1; then
         log "creating system user 'taos' for the controller service"
-        useradd -r -M -s /usr/sbin/nologin -d "$INSTALL_DIR" taos \
-            || useradd -r -M -s /sbin/nologin -d "$INSTALL_DIR" taos \
+        $sudo_cmd useradd -r -M -s /usr/sbin/nologin -d "$INSTALL_DIR" taos \
+            || $sudo_cmd useradd -r -M -s /sbin/nologin -d "$INSTALL_DIR" taos \
             || { warn "useradd failed — the service will not run as 'taos'"; return 1; }
         log "system user 'taos' created"
     else
@@ -1384,7 +1387,7 @@ ensure_taos_user() {
     # root. Warn (don't fail) if the group doesn't exist — the socket is still
     # usable if incus is not installed on this host.
     if getent group incus >/dev/null 2>&1; then
-        usermod -aG incus taos >/dev/null 2>&1 \
+        $sudo_cmd usermod -aG incus taos >/dev/null 2>&1 \
             && log "added 'taos' to the 'incus' group" \
             || warn "could not add 'taos' to the 'incus' group — agent container deploys may fail"
     else
@@ -1394,7 +1397,7 @@ ensure_taos_user() {
     # Mirror the existing docker-group handling: add 'taos' to docker so the
     # controller can manage Store Docker apps. Warn if docker isn't present.
     if getent group docker >/dev/null 2>&1; then
-        usermod -aG docker taos >/dev/null 2>&1 \
+        $sudo_cmd usermod -aG docker taos >/dev/null 2>&1 \
             && log "added 'taos' to the 'docker' group" \
             || warn "could not add 'taos' to the 'docker' group — Store Docker apps may fail"
     else
@@ -1412,13 +1415,18 @@ set_data_dir_ownership() {
     [[ "$os_name" == "Linux" ]] || return 0  # no-op on macOS
     ! id -u taos >/dev/null 2>&1 && return 0  # no-op if user wasn't created
 
+    local sudo_cmd=""
+    [[ "$(id -u)" != "0" ]] && sudo_cmd="sudo"
+
     # Security trade-off: taos must OWN the entire install dir (repo, .git,
     # .venv, static/desktop/) so the in-app self-updater can write to those
     # paths while running non-root (git pull, pip install -e ., npm run build).
     # Full update-privilege-separation (a dedicated updater suid helper that
     # verifies signatures before writing) is a post-beta hardening task.
     log "setting ownership of $INSTALL_DIR → taos:taos (required for non-root in-app self-update)"
-    chown -R taos:taos "$INSTALL_DIR" 2>/dev/null || true
+    if ! $sudo_cmd chown -R taos:taos "$INSTALL_DIR" 2>/dev/null; then
+        warn "chown -R taos:taos $INSTALL_DIR failed — the service will not start; re-run the installer with sudo"
+    fi
 
     # Ensure every parent directory of INSTALL_DIR is traversable by the taos
     # service user — without this, systemd CHDIR fails (exit 200) when the
@@ -1427,7 +1435,8 @@ set_data_dir_ownership() {
     _parent="$(dirname "$INSTALL_DIR")"
     while [[ "$_parent" != "/" && "$_parent" != "." ]]; do
         if [[ -d "$_parent" ]]; then
-            chmod o+x "$_parent" 2>/dev/null || true
+            $sudo_cmd chmod o+x "$_parent" 2>/dev/null \
+                || warn "chmod o+x $_parent failed — the service may not start; re-run the installer with sudo"
         fi
         _parent="$(dirname "$_parent")"
     done
@@ -1435,7 +1444,7 @@ set_data_dir_ownership() {
     # Tighten the data directory and sensitive credential files on top of the
     # broad chown above — done AFTER so the restrictive perms win.
     log "tightening $INSTALL_DIR/data/ → mode 0700 and secret files → 0600"
-    chmod 0700 "$INSTALL_DIR/data"
+    $sudo_cmd chmod 0700 "$INSTALL_DIR/data"
     for f in \
         "$INSTALL_DIR/data/.auth_password" \
         "$INSTALL_DIR/data/.auth_user.json" \
@@ -1443,7 +1452,7 @@ set_data_dir_ownership() {
         "$INSTALL_DIR/data/.auth_local_token" \
         "$INSTALL_DIR/data/.litellm_db_url" \
         "$INSTALL_DIR/data/browser_cookie_key.hex"; do
-        [[ -f "$f" ]] && chmod 0600 "$f" || true
+        [[ -f "$f" ]] && $sudo_cmd chmod 0600 "$f" || true
     done
 }
 

--- a/tests/test_auth_requests.py
+++ b/tests/test_auth_requests.py
@@ -593,3 +593,20 @@ class TestAuthRequestRoutes:
         assert resp.status_code == 200
         grants = resp.json()["grants"]
         assert all(g["canonical_id"] == canonical_id for g in grants)
+
+    async def test_approve_lock_is_evicted_after_decision(self, consent_client):
+        """After approval the per-request lock entry is removed from the dict."""
+        transport = ASGITransport(app=consent_client._transport.app)
+        async with AsyncClient(transport=transport, base_url="http://test") as bare:
+            create_resp = await bare.post("/api/agents/auth-requests", json=_CREATE_BODY)
+            request_id = create_resp.json()["request_id"]
+
+        await consent_client.post(
+            f"/api/agents/auth-requests/{request_id}/approve",
+            json={"granted_scopes": ["memory_read"]},
+        )
+
+        # After a terminal decision the lock entry must be absent so the dict
+        # does not grow unbounded over the process lifetime.
+        app = consent_client._transport.app
+        assert getattr(app.state, "_approve_locks", {}).get(request_id) is None

--- a/tests/test_dual_port_helper.py
+++ b/tests/test_dual_port_helper.py
@@ -1,0 +1,93 @@
+"""Tests for _serve_until_first_exit helper in tinyagentos.__main__."""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+
+class _StubServer:
+    """Minimal stand-in for uvicorn.Server."""
+
+    def __init__(self, *, started: bool = True, raise_on_serve: Exception | None = None):
+        self.started = started
+        self._raise = raise_on_serve
+        self._cancelled = False
+
+    async def serve(self) -> None:
+        await asyncio.sleep(0)  # yield once to let the other task run
+        if self._raise is not None:
+            raise self._raise
+
+
+class _HangingServer:
+    """Server whose serve() never returns (simulates a running server)."""
+
+    def __init__(self, *, started: bool = True):
+        self.started = started
+        self._task: asyncio.Task | None = None
+
+    async def serve(self) -> None:
+        try:
+            await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            raise
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_main_fails_to_start_returns_false():
+    """When main server exits with started=False, helper returns False.
+
+    The proxy stub's serve task must be cancelled.
+    """
+    from tinyagentos.__main__ import _serve_until_first_exit
+
+    main_server = _StubServer(started=False)
+    proxy_server = _HangingServer(started=True)
+
+    result = await _serve_until_first_exit(main_server, proxy_server)
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_main_starts_and_proxy_exits_returns_true():
+    """When proxy exits first but main started=True, helper returns True."""
+    from tinyagentos.__main__ import _serve_until_first_exit
+
+    main_server = _HangingServer(started=True)
+    proxy_server = _StubServer(started=True)
+
+    result = await _serve_until_first_exit(main_server, proxy_server)
+
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_both_exit_main_started_returns_true():
+    """Both servers exit; main.started=True -> returns True."""
+    from tinyagentos.__main__ import _serve_until_first_exit
+
+    main_server = _StubServer(started=True)
+    proxy_server = _StubServer(started=True)
+
+    result = await _serve_until_first_exit(main_server, proxy_server)
+
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_serve_exception_is_reraised():
+    """An exception raised inside serve() propagates out of the helper."""
+    from tinyagentos.__main__ import _serve_until_first_exit
+
+    boom = RuntimeError("lifespan crash")
+    main_server = _StubServer(started=False, raise_on_serve=boom)
+    proxy_server = _HangingServer(started=True)
+
+    with pytest.raises(RuntimeError, match="lifespan crash"):
+        await _serve_until_first_exit(main_server, proxy_server)

--- a/tests/test_knowledge_migration.py
+++ b/tests/test_knowledge_migration.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+from tinyagentos.knowledge_store import KnowledgeStore
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _create_old_schema_db(db_path: Path) -> None:
+    """Create a knowledge.db with the pre-user_id schema (simulates a bricked install)."""
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS knowledge_items (
+            id TEXT PRIMARY KEY,
+            source_type TEXT NOT NULL,
+            source_url TEXT NOT NULL,
+            source_id TEXT,
+            title TEXT NOT NULL DEFAULT '',
+            author TEXT NOT NULL DEFAULT '',
+            summary TEXT NOT NULL DEFAULT '',
+            content TEXT NOT NULL DEFAULT '',
+            media_path TEXT,
+            thumbnail TEXT,
+            categories TEXT NOT NULL DEFAULT '[]',
+            tags TEXT NOT NULL DEFAULT '[]',
+            metadata TEXT NOT NULL DEFAULT '{}',
+            status TEXT NOT NULL DEFAULT 'pending',
+            monitor TEXT NOT NULL DEFAULT '{}',
+            created_at REAL NOT NULL,
+            updated_at REAL NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_ki_source_type ON knowledge_items(source_type);
+        CREATE INDEX IF NOT EXISTS idx_ki_status ON knowledge_items(status);
+        CREATE INDEX IF NOT EXISTS idx_ki_created ON knowledge_items(created_at DESC);
+
+        CREATE VIRTUAL TABLE IF NOT EXISTS knowledge_fts USING fts5(
+            id UNINDEXED,
+            title,
+            content,
+            summary,
+            author,
+            tokenize='porter unicode61'
+        );
+
+        CREATE TABLE IF NOT EXISTS knowledge_snapshots (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            item_id TEXT NOT NULL REFERENCES knowledge_items(id) ON DELETE CASCADE,
+            snapshot_at REAL NOT NULL,
+            content_hash TEXT NOT NULL,
+            diff_json TEXT NOT NULL DEFAULT '{}',
+            metadata_json TEXT NOT NULL DEFAULT '{}'
+        );
+        CREATE INDEX IF NOT EXISTS idx_ks_item ON knowledge_snapshots(item_id, snapshot_at DESC);
+
+        CREATE TABLE IF NOT EXISTS category_rules (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            pattern TEXT NOT NULL,
+            match_on TEXT NOT NULL,
+            category TEXT NOT NULL,
+            priority INTEGER NOT NULL DEFAULT 0
+        );
+
+        CREATE TABLE IF NOT EXISTS agent_knowledge_subscriptions (
+            agent_name TEXT NOT NULL,
+            category TEXT NOT NULL,
+            auto_ingest INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (agent_name, category)
+        );
+    """)
+    conn.commit()
+    conn.close()
+
+
+def _get_columns(db_path: Path) -> set[str]:
+    conn = sqlite3.connect(str(db_path))
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(knowledge_items)").fetchall()}
+    conn.close()
+    return cols
+
+
+def _get_indexes(db_path: Path) -> set[str]:
+    conn = sqlite3.connect(str(db_path))
+    indexes = {row[1] for row in conn.execute("PRAGMA index_list(knowledge_items)").fetchall()}
+    conn.close()
+    return indexes
+
+
+# ---------------------------------------------------------------------------
+# Migration tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_migration_adds_user_id_to_old_db(tmp_path):
+    """init() must succeed on an old-shape DB and add user_id + index."""
+    db_path = tmp_path / "knowledge.db"
+    _create_old_schema_db(db_path)
+
+    # Confirm pre-condition: no user_id column
+    assert "user_id" not in _get_columns(db_path)
+
+    store = KnowledgeStore(db_path, media_dir=tmp_path / "media")
+    await store.init()
+    await store.close()
+
+    cols = _get_columns(db_path)
+    assert "user_id" in cols, "user_id column must exist after init"
+
+    indexes = _get_indexes(db_path)
+    assert "idx_ki_user_id" in indexes, "idx_ki_user_id must exist after init"
+
+
+@pytest.mark.asyncio
+async def test_migration_is_idempotent(tmp_path):
+    """A second init() on an already-migrated DB must be a no-op (no error)."""
+    db_path = tmp_path / "knowledge.db"
+    _create_old_schema_db(db_path)
+
+    store = KnowledgeStore(db_path, media_dir=tmp_path / "media")
+    await store.init()
+    await store.close()
+
+    # Second init -- must not raise
+    store2 = KnowledgeStore(db_path, media_dir=tmp_path / "media")
+    await store2.init()
+    await store2.close()
+
+    assert "user_id" in _get_columns(db_path)
+    assert "idx_ki_user_id" in _get_indexes(db_path)
+
+
+@pytest.mark.asyncio
+async def test_fresh_db_has_user_id_column_and_index(tmp_path):
+    """A brand-new DB must also have user_id + index after init."""
+    db_path = tmp_path / "knowledge_fresh.db"
+
+    store = KnowledgeStore(db_path, media_dir=tmp_path / "media")
+    await store.init()
+    await store.close()
+
+    assert "user_id" in _get_columns(db_path)
+    assert "idx_ki_user_id" in _get_indexes(db_path)

--- a/tests/test_user_memory.py
+++ b/tests/test_user_memory.py
@@ -1,6 +1,5 @@
 import pytest
 import pytest_asyncio
-from unittest.mock import patch
 from tinyagentos.user_memory import UserMemoryStore
 
 
@@ -108,7 +107,7 @@ async def test_fts5_injection_does_not_escape_user_filter(store):
 # ---------------------------------------------------------------------------
 
 import json
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 from httpx import ASGITransport, AsyncClient as HttpxAsyncClient
 import pytest_asyncio
 
@@ -171,8 +170,9 @@ async def test_search_uses_taosmd_when_available(mem_client, tmp_data_dir):
     mock_client.__aexit__ = AsyncMock(return_value=False)
     mock_client.get = AsyncMock(return_value=mock_resp)
 
-    with patch("tinyagentos.routes.user_memory.httpx.AsyncClient", return_value=mock_client):
-        resp = await client.get("/api/user-memory/search", params={"q": "test"})
+    app = client._transport.app
+    app.state.http_client = mock_client
+    resp = await client.get("/api/user-memory/search", params={"q": "test"})
     assert resp.status_code == 200
     data = resp.json()
     assert data["backend"] == "taosmd"
@@ -189,11 +189,12 @@ async def test_save_writes_to_sqlite_and_ingest_to_taosmd(mem_client, tmp_data_d
     mock_client.__aexit__ = AsyncMock(return_value=False)
     mock_client.post = AsyncMock(return_value=MagicMock(status_code=200))
 
-    with patch("tinyagentos.routes.user_memory.httpx.AsyncClient", return_value=mock_client):
-        resp = await client.post(
-            "/api/user-memory/save",
-            json={"content": "dual write", "title": "T", "collection": "snippets"},
-        )
+    app = client._transport.app
+    app.state.http_client = mock_client
+    resp = await client.post(
+        "/api/user-memory/save",
+        json={"content": "dual write", "title": "T", "collection": "snippets"},
+    )
     assert resp.status_code == 200
     assert resp.json()["ok"] is True
     # SQLite should have the chunk too
@@ -249,15 +250,16 @@ async def test_save_metadata_cannot_override_source_id(mem_client, tmp_data_dir)
     mock_client.__aexit__ = AsyncMock(return_value=False)
     mock_client.post = AsyncMock(return_value=MagicMock(status_code=200))
 
-    with patch("tinyagentos.routes.user_memory.httpx.AsyncClient", return_value=mock_client):
-        resp = await client.post(
-            "/api/user-memory/save",
-            json={
-                "content": "override attempt",
-                "collection": "snippets",
-                "metadata": {"source_id": "evil", "collection": "other", "custom": "kept"},
-            },
-        )
+    app = client._transport.app
+    app.state.http_client = mock_client
+    resp = await client.post(
+        "/api/user-memory/save",
+        json={
+            "content": "override attempt",
+            "collection": "snippets",
+            "metadata": {"source_id": "evil", "collection": "other", "custom": "kept"},
+        },
+    )
     assert resp.status_code == 200
     saved_hash = resp.json()["hash"]
     sent_meta = mock_client.post.call_args.kwargs["json"]["metadata"]
@@ -277,8 +279,9 @@ async def test_migrate_error_response_does_not_leak_exception_text(mem_client, t
     mock_client.get = AsyncMock(return_value=MagicMock(status_code=200))  # health OK
     mock_client.post = AsyncMock(side_effect=RuntimeError("http://internal-taosmd:7900 boom"))
 
-    with patch("tinyagentos.routes.user_memory.httpx.AsyncClient", return_value=mock_client):
-        resp = await client.post("/api/user-memory/migrate")
+    app = client._transport.app
+    app.state.http_client = mock_client
+    resp = await client.post("/api/user-memory/migrate")
     assert resp.status_code == 500
     assert "internal-taosmd" not in resp.text
     assert resp.json()["error"] == "taosmd ingest failed"

--- a/tinyagentos/__main__.py
+++ b/tinyagentos/__main__.py
@@ -76,19 +76,26 @@ def _serve_dual_port(app, *, host: str, port: int, proxy_port: int) -> None:
     """Run the main app and the browser-proxy origin concurrently.
 
     ``uvicorn.run`` is blocking and we need two servers, so we drive two
-    ``uvicorn.Server`` instances under one event loop via ``asyncio.gather``.
+    ``uvicorn.Server`` instances under one event loop.
 
     The proxy-origin app shares the main app's ``app.state`` object (see
     ``create_browser_proxy_app``), which the main app's lifespan populates
     on startup. Both servers start together; the proxy origin only receives
     traffic after the shell has loaded and redeemed a ticket (post-startup),
     so the shared state is always ready by the time it is read.
+
+    If the main server's serve() returns without having reached the
+    'started' state (lifespan raised during startup), we exit non-zero so
+    systemd's Restart= fires instead of leaving a half-alive process.
     """
     import asyncio
+    import logging
 
     import uvicorn
 
     from tinyagentos.browser_proxy_origin import create_browser_proxy_app
+
+    _log = logging.getLogger(__name__)
 
     proxy_app = create_browser_proxy_app(app.state)
 
@@ -97,10 +104,44 @@ def _serve_dual_port(app, *, host: str, port: int, proxy_port: int) -> None:
     main_server = uvicorn.Server(main_config)
     proxy_server = uvicorn.Server(proxy_config)
 
-    async def _run() -> None:
-        await asyncio.gather(main_server.serve(), proxy_server.serve())
+    started = asyncio.run(_serve_until_first_exit(main_server, proxy_server))
+    if not started:
+        _log.error(
+            "Main server failed to start on %s:%d -- check lifespan errors above",
+            host,
+            port,
+        )
+        raise SystemExit(3)
 
-    asyncio.run(_run())
+
+async def _serve_until_first_exit(main_server, proxy_server) -> bool:
+    """Drive both servers; cancel the survivor when one exits.
+
+    Returns True when the main server reached the started state before
+    either serve() returned, False otherwise (startup failure).
+    """
+    import asyncio
+
+    main_task = asyncio.create_task(main_server.serve())
+    proxy_task = asyncio.create_task(proxy_server.serve())
+
+    done, pending = await asyncio.wait(
+        {main_task, proxy_task},
+        return_when=asyncio.FIRST_COMPLETED,
+    )
+
+    for task in pending:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    for task in done:
+        if task.exception() is not None:
+            raise task.exception()
+
+    return bool(getattr(main_server, "started", False))
 
 
 def _seed_data_dir(target: Path) -> None:

--- a/tinyagentos/auth_requests_store.py
+++ b/tinyagentos/auth_requests_store.py
@@ -40,6 +40,8 @@ CREATE TABLE IF NOT EXISTS auth_requests (
     decided_ts      TEXT,
     decided_by      TEXT
 );
+CREATE INDEX IF NOT EXISTS idx_auth_requests_status ON auth_requests(status);
+CREATE INDEX IF NOT EXISTS idx_auth_requests_identity ON auth_requests(identity_claim, framework, status);
 """
 
 _VALID_DECISION_STATUSES = frozenset({"accepted", "refused"})

--- a/tinyagentos/base_store.py
+++ b/tinyagentos/base_store.py
@@ -11,6 +11,16 @@ class BaseStore:
     Subclasses set ``SCHEMA`` (applied once on first open) and may set
     ``MIGRATIONS`` to a list of ``(version, sql_or_callable)`` pairs that
     will be tracked and applied in order by the migration runner.
+
+    WARNING: init order is SCHEMA -> MIGRATIONS -> _post_init.  Never
+    reference a column inside SCHEMA that is introduced by a migration --
+    the SCHEMA executescript runs first and will crash on any existing
+    database that lacks the column.  The migration runner also uses
+    baseline-at-latest semantics: pre-existing databases are stamped at the
+    latest version without executing any SQL, so retrofit migrations are
+    silently skipped.  Use a guarded _post_init coroutine (PRAGMA
+    table_info check + ALTER TABLE only when absent) for columns added
+    after initial release.  See db_migrations.py module docstring.
     """
     SCHEMA: str = ""
     # List of (version: int, sql_or_callable) pairs. See db_migrations.py.

--- a/tinyagentos/db_migrations.py
+++ b/tinyagentos/db_migrations.py
@@ -39,6 +39,22 @@ Both set:
 WAL gives better read concurrency and avoids most "database is locked" errors.
 NORMAL synchronous is safe for nearly all crash scenarios while being
 significantly faster than the default FULL.
+
+FOOTGUNS -- READ BEFORE ADDING MIGRATIONS
+------------------------------------------
+1. SCHEMA runs before MIGRATIONS (see BaseStore.init).  Never put a
+   reference to a column that is introduced by a migration inside SCHEMA
+   (e.g. an index on a column added by ALTER TABLE).  The SCHEMA
+   executescript will crash on existing databases that lack the column
+   before the migration that adds it has had a chance to run.
+
+2. Baseline-at-latest semantics (step 2 above) stamp pre-existing databases
+   at the newest migration version WITHOUT executing any SQL.  This means
+   retrofit migrations -- ones written for databases that predate them -- are
+   silently skipped on exactly the databases that need them.  Use a guarded
+   _post_init coroutine instead (PRAGMA table_info check + ALTER TABLE only
+   when the column is absent).  See knowledge_store._migration_v1_add_user_id
+   and agent_registry_store._migration_v1_add_status for the pattern.
 """
 from __future__ import annotations
 

--- a/tinyagentos/knowledge_store.py
+++ b/tinyagentos/knowledge_store.py
@@ -34,7 +34,6 @@ CREATE TABLE IF NOT EXISTS knowledge_items (
 CREATE INDEX IF NOT EXISTS idx_ki_source_type ON knowledge_items(source_type);
 CREATE INDEX IF NOT EXISTS idx_ki_status ON knowledge_items(status);
 CREATE INDEX IF NOT EXISTS idx_ki_created ON knowledge_items(created_at DESC);
-CREATE INDEX IF NOT EXISTS idx_ki_user_id ON knowledge_items(user_id);
 
 CREATE VIRTUAL TABLE IF NOT EXISTS knowledge_fts USING fts5(
     id UNINDEXED,
@@ -95,19 +94,41 @@ def _row_to_item(row: tuple) -> dict:
     }
 
 
+
+async def _migration_v1_add_user_id(conn) -> None:
+    """Add user_id column and index to knowledge_items (idempotent).
+
+    Runs at the top of _post_init so it self-heals databases created before
+    the multi-user keying was introduced.  SQLite lacks IF NOT EXISTS for
+    ADD COLUMN prior to 3.37, so we use PRAGMA table_info for broad
+    compatibility.
+    """
+    existing_cols = {
+        row[1]
+        for row in await (
+            await conn.execute("PRAGMA table_info(knowledge_items)")
+        ).fetchall()
+    }
+    if "user_id" not in existing_cols:
+        await conn.execute(
+            "ALTER TABLE knowledge_items ADD COLUMN user_id TEXT NOT NULL DEFAULT ''"
+        )
+    await conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_ki_user_id ON knowledge_items(user_id)"
+    )
+    await conn.commit()
+
+
 class KnowledgeStore(BaseStore):
     """SQLite + FTS5 store for the Knowledge Base Service."""
 
     SCHEMA = KNOWLEDGE_SCHEMA
-    MIGRATIONS = [
-        (1, "ALTER TABLE knowledge_items ADD COLUMN user_id TEXT NOT NULL DEFAULT ''"),
-    ]
-
     def __init__(self, db_path: Path, media_dir: Path | None = None) -> None:
         super().__init__(db_path)
         self.media_dir = media_dir or db_path.parent / "knowledge-media"
 
     async def _post_init(self) -> None:
+        await _migration_v1_add_user_id(self._db)
         self.media_dir.mkdir(parents=True, exist_ok=True)
 
     # ------------------------------------------------------------------

--- a/tinyagentos/routes/agent_auth_requests.py
+++ b/tinyagentos/routes/agent_auth_requests.py
@@ -215,8 +215,18 @@ async def approve_auth_request(
 
     # Serialise concurrent approvals for the same request to prevent orphaned
     # registry entries and duplicate grants from a TOCTOU race.
-    async with _get_approve_lock(request, request_id):
-        return await _do_approve(request, request_id, body, user)
+    lock = _get_approve_lock(request, request_id)
+    async with lock:
+        try:
+            return await _do_approve(request, request_id, body, user)
+        finally:
+            # The request is now terminally decided (or errored); drop its lock so
+            # request.app.state._approve_locks does not grow unbounded over the
+            # process lifetime. A concurrent waiter already holds a reference to the
+            # lock object, so popping the dict entry is safe.
+            locks = getattr(request.app.state, "_approve_locks", None)
+            if locks is not None:
+                locks.pop(request_id, None)
 
 
 async def _do_approve(request: Request, request_id: str, body: ApproveBody, user):

--- a/tinyagentos/routes/user_memory.py
+++ b/tinyagentos/routes/user_memory.py
@@ -80,16 +80,16 @@ async def search(request: Request, q: str, collection: str | None = None, limit:
     """
     base = _taosmd_base(request)
     try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
-            params: dict = {"q": q, "agent": _TAOSMD_AGENT, "limit": limit, "mode": "bm25"}
-            if collection:
-                params["collection"] = collection
-            resp = await client.get(f"{base}/search", params=params)
-            if resp.status_code == 200:
-                data = resp.json()
-                hits = data.get("hits", [])
-                results = [_hit_to_chunk(h) for h in hits]
-                return JSONResponse({"results": results, "query": q, "backend": "taosmd"})
+        client = request.app.state.http_client
+        params: dict = {"q": q, "agent": _TAOSMD_AGENT, "limit": limit, "mode": "bm25"}
+        if collection:
+            params["collection"] = collection
+        resp = await client.get(f"{base}/search", params=params, timeout=5.0)
+        if resp.status_code == 200:
+            data = resp.json()
+            hits = data.get("hits", [])
+            results = [_hit_to_chunk(h) for h in hits]
+            return JSONResponse({"results": results, "query": q, "backend": "taosmd"})
     except Exception:
         logger.debug("taosmd search unavailable, falling back to SQLite")
 
@@ -137,23 +137,24 @@ async def save(request: Request):
     # Also ingest to taosmd when available (best-effort, non-fatal).
     base = _taosmd_base(request)
     try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
-            resp = await client.post(
-                f"{base}/ingest",
-                json={
-                    "text": content,
-                    "agent": _TAOSMD_AGENT,
-                    # Caller metadata first so the server-owned keys win —
-                    # source_id is taosmd's dedup key and must not be
-                    # overridable from the request body.
-                    "metadata": {**metadata, "collection": collection, "title": title, "source_id": h},
-                },
+        client = request.app.state.http_client
+        resp = await client.post(
+            f"{base}/ingest",
+            json={
+                "text": content,
+                "agent": _TAOSMD_AGENT,
+                # Caller metadata first so the server-owned keys win —
+                # source_id is taosmd's dedup key and must not be
+                # overridable from the request body.
+                "metadata": {**metadata, "collection": collection, "title": title, "source_id": h},
+            },
+            timeout=5.0,
+        )
+        if resp.status_code >= 400:
+            logger.debug(
+                "taosmd ingest returned %s — chunk saved to SQLite only",
+                resp.status_code,
             )
-            if resp.status_code >= 400:
-                logger.debug(
-                    "taosmd ingest returned %s — chunk saved to SQLite only",
-                    resp.status_code,
-                )
     except Exception:
         logger.debug("taosmd ingest unavailable — chunk saved to SQLite only")
 
@@ -184,10 +185,10 @@ async def migrate_to_taosmd(request: Request):
 
     # Probe availability first.
     try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
-            health = await client.get(f"{base}/health")
-            if health.status_code != 200:
-                return JSONResponse({"error": "taosmd not healthy"}, status_code=503)
+        client = request.app.state.http_client
+        health = await client.get(f"{base}/health", timeout=5.0)
+        if health.status_code != 200:
+            return JSONResponse({"error": "taosmd not healthy"}, status_code=503)
     except Exception:
         return JSONResponse({"error": "taosmd unreachable"}, status_code=503)
 
@@ -221,29 +222,31 @@ async def migrate_to_taosmd(request: Request):
     ]
 
     try:
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            resp = await client.post(
-                f"{base}/ingest/batch",
-                json={"agent": _TAOSMD_AGENT, "items": items},
-            )
-            resp.raise_for_status()
-            result = resp.json()
+        client = request.app.state.http_client
+        resp = await client.post(
+            f"{base}/ingest/batch",
+            json={"agent": _TAOSMD_AGENT, "items": items},
+            timeout=30.0,
+        )
+        resp.raise_for_status()
+        result = resp.json()
     except httpx.HTTPStatusError as exc:
         if exc.response.status_code == 404:
             # /ingest/batch not yet deployed — fall back to one-at-a-time
             ingested = 0
-            async with httpx.AsyncClient(timeout=30.0) as client:
-                for item in items:
-                    try:
-                        one = await client.post(
-                            f"{base}/ingest",
-                            json={"text": item["text"], "agent": _TAOSMD_AGENT,
-                                  "metadata": item["metadata"]},
-                        )
-                        if one.status_code < 400:
-                            ingested += 1
-                    except Exception:
-                        pass
+            client = request.app.state.http_client
+            for item in items:
+                try:
+                    one = await client.post(
+                        f"{base}/ingest",
+                        json={"text": item["text"], "agent": _TAOSMD_AGENT,
+                              "metadata": item["metadata"]},
+                        timeout=30.0,
+                    )
+                    if one.status_code < 400:
+                        ingested += 1
+                except Exception:
+                    pass
             result = {"ingested": ingested, "skipped": len(items) - ingested}
     except Exception:
         # Don't reflect raw exception text (it can carry the internal taosmd


### PR DESCRIPTION
Promotes to master:
- #763: knowledge user_id migration now applies to existing DBs (self-heals bricked installs) and the controller exits non-zero when the main server fails startup instead of lingering half-alive (fixes #755, #756). Required on master before beta installs update across the multi-user schema boundary.
- #754: installer runs privileged user/ownership setup via sudo when invoked non-root (fixes #753, hardens the #723 scenario).
- #752: approve-lock eviction, auth_requests indexes, shared httpx client (#660).
- #758: docs/runbooks/controller-rescue.md, triage and recovery runbook.