### PR TITLE
chore: promote dev to master (cluster pairing auth Phase 1, worker backend naming)

### DIFF
--- a/desktop/src/apps/ActivityApp.tsx
+++ b/desktop/src/apps/ActivityApp.tsx
@@ -5,7 +5,7 @@ import {
 } from "lucide-react";
 import { Card, CardContent, Button } from "@/components/ui";
 import type { ClusterWorker } from "@/lib/cluster";
-import { workerStatus, workerHardwareSummary, workerShortIp, STATUS_PILL_CLASS, STATUS_LABEL } from "@/lib/cluster";
+import { workerStatus, workerHardwareSummary, workerShortIp, normalizeBackendName, STATUS_PILL_CLASS, STATUS_LABEL } from "@/lib/cluster";
 
 interface ActivityData {
   timestamp: number;
@@ -270,7 +270,7 @@ export function ActivityApp({ windowId: _windowId }: { windowId: string }) {
     ...clusterWorkers.flatMap((w) => {
       const out: LoadedModel[] = [];
       for (const b of w.backends ?? []) {
-        const backendName = b.name ?? b.type ?? "backend";
+        const backendName = normalizeBackendName(b.name ?? b.type ?? "backend");
         const activeList = (b as { loaded_models?: unknown }).loaded_models;
         const models = Array.isArray(activeList) ? activeList : [];
         for (const model of models) {
@@ -624,7 +624,7 @@ export function ActivityApp({ windowId: _windowId }: { windowId: string }) {
                               className="text-[9px] px-1.5 py-0.5 rounded-full bg-sky-500/15 text-sky-200 font-medium"
                               title={b.type ?? b.name ?? ""}
                             >
-                              {b.name ?? b.type ?? "backend"}
+                              {normalizeBackendName(b.name ?? b.type ?? "backend")}
                             </span>
                           ))
                         )}

--- a/desktop/src/apps/ClusterApp.tsx
+++ b/desktop/src/apps/ClusterApp.tsx
@@ -12,6 +12,7 @@ import {
   workerHardwareSummary,
   workerShortIp,
   formatRelativeSeconds,
+  normalizeBackendName,
   STATUS_PILL_CLASS,
   STATUS_LABEL,
 } from "@/lib/cluster";
@@ -87,7 +88,7 @@ function WorkerListCard({
               key={`${worker.name}-lb-${i}`}
               className="text-[9px] px-1.5 py-0.5 rounded-full bg-sky-500/15 text-sky-200 font-medium"
             >
-              {b.name ?? b.type ?? "backend"}
+              {normalizeBackendName(b.name ?? b.type ?? "backend")}
             </span>
           ))
         )}
@@ -329,7 +330,7 @@ function WorkerDetail({
                 >
                   <div className="flex items-center justify-between gap-2">
                     <span className="text-[12px] font-medium text-shell-text truncate">
-                      {b.name ?? b.type ?? "backend"}
+                      {normalizeBackendName(b.name ?? b.type ?? "backend")}
                     </span>
                     {b.type && (
                       <span className="text-[10px] text-shell-text-tertiary">{b.type}</span>

--- a/desktop/src/lib/__tests__/cluster.test.ts
+++ b/desktop/src/lib/__tests__/cluster.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { normalizeBackendName } from "../cluster";
+
+describe("normalizeBackendName", () => {
+  it("rewrites legacy localhost URL shape to type:port", () => {
+    expect(normalizeBackendName("ollama@http://localhost:11434")).toBe("ollama:11434");
+  });
+
+  it("rewrites legacy 127.0.0.1 URL shape to type:port", () => {
+    expect(normalizeBackendName("rkllama@http://127.0.0.1:8080")).toBe("rkllama:8080");
+  });
+
+  it("leaves already-new type:port format unchanged", () => {
+    expect(normalizeBackendName("ollama:11434")).toBe("ollama:11434");
+  });
+
+  it("leaves unknown shapes unchanged", () => {
+    expect(normalizeBackendName("backend")).toBe("backend");
+    expect(normalizeBackendName("")).toBe("");
+    expect(normalizeBackendName("ollama@http://10.0.0.5:11434")).toBe(
+      "ollama@http://10.0.0.5:11434"
+    );
+  });
+
+  it("rewrites legacy [::1] URL shape to type:port", () => {
+    expect(normalizeBackendName("ollama@http://[::1]:11434")).toBe("ollama:11434");
+  });
+
+  it("rewrites legacy 0.0.0.0 URL shape to type:port", () => {
+    expect(normalizeBackendName("ollama@http://0.0.0.0:11434")).toBe("ollama:11434");
+  });
+
+  it("leaves a non-loopback hostname unchanged", () => {
+    expect(normalizeBackendName("ollama@http://myhost.local:11434")).toBe(
+      "ollama@http://myhost.local:11434"
+    );
+  });
+
+  it("leaves a URL without an explicit port unchanged (no crash)", () => {
+    expect(normalizeBackendName("ollama@http://localhost")).toBe("ollama@http://localhost");
+  });
+});

--- a/desktop/src/lib/cluster.ts
+++ b/desktop/src/lib/cluster.ts
@@ -307,6 +307,21 @@ export function availableKvQuantOptions(workers: ClusterWorker[]): KvQuantOption
   return { k, v, boundary, flat };
 }
 
+/**
+ * Normalise a backend name for display.
+ *
+ * Workers updated before this fix emitted names in the shape
+ * `type@http://localhost:PORT` or `type@http://127.0.0.1:PORT`.
+ * Updated workers emit `type:PORT`.  This helper rewrites legacy names
+ * so older workers display consistently in the Activity and Cluster views.
+ * Any other shape (already-new format, custom names) is returned unchanged.
+ */
+export function normalizeBackendName(name: string): string {
+  const m = name.match(/^([^@]+)@https?:\/\/(?:localhost|127\.0\.0\.1|\[::1\]|0\.0\.0\.0):(\d+)$/);
+  if (m) return `${m[1]}:${m[2]}`;
+  return name;
+}
+
 /** Format a unix-seconds timestamp as a short relative string like "3s ago" / "2m ago". */
 export function formatRelativeSeconds(hb: number | undefined, nowSec = Date.now() / 1000): string {
   if (!hb || typeof hb !== "number") return "never";

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,39 +7,38 @@
 
 # taOS: Live Status
 
-**Last updated:** 2026-06-10 ~23:40 BST, by @taOS (Mac session), at a rate-limit pause point.
+**Last updated:** 2026-06-11 ~04:50 BST, by @taOS (Mac session, overnight autonomous run).
 **Repo:** github.com/jaylfc/taOS, branches `master` (stable) <- `dev` (integration).
 
 ## GOTCHA for the next agent
-- **Protected merges:** `gh pr merge` 401s on the OAuth token but `gh api -X PUT repos/jaylfc/taOS/pulls/N/merge -f merge_method=squash` WORKS with the same token. No PAT needed. Never `--delete-branch` on a dev->master PR. Promote with `--merge`, not squash.
-- **PR #762 (cluster pairing auth, #737 Phase 1) is OPEN, review half-done, NOT merged.** pairing_store.py reviewed clean by me; still to review: worker_auth.py, auth_middleware split, routes/cluster.py changes. CI was green-pending (lint/spa green, tests running). It is a SECURITY pr: finish the manual review, check Kilo+CodeRabbit comments, then merge via the gh api method.
-- **Two sonnet agents may have died mid-build with this session.** Check `gh pr list` for: (a) fix for #755+#756 on branch `fix/knowledge-migration-and-dual-port-exit`, (b) fix for #759 on branch `fix/worker-backend-name-localhost`. If no PR exists, re-dispatch: issues #755, #756, #759 contain the complete analysis and fix design (they are the spec).
-- CodeRabbit rate-limit fake-passes: a green CodeRabbit check can be a rate-limit notice. Check the PR comments; use `@coderabbitai full review`.
+- **Protected merges:** `gh pr merge` 401s on the OAuth token but `gh api -X PUT repos/jaylfc/taOS/pulls/N/merge -f merge_method=squash` WORKS with the same token (use `merge_method=merge` for dev->master promotions, never squash, never `--delete-branch`).
+- **Promotion #767 (pairing auth + backend naming) may still be in CI.** If open and green, merge it with the api method above. Everything else from the overnight queue is DONE.
+- CodeRabbit fake passes: a green CodeRabbit check can be a rate-limit notice; check the PR comments, use `@coderabbitai full review`.
+- `tests/` is NOT an importable package: never `from tests.conftest import X` in test files; expose shared helpers as function-returning fixtures (see `pair_and_register_worker` in tests/conftest.py).
 
-## Tonight's incident (resolved): beta Pi controller down
-Root cause chain, all filed: knowledge.db predating user_id crashed init (schema index referenced the column before the migration could run, and the migration runner's baseline-at-latest would have skipped it anyway) = **#755**; uvicorn serve() returns instead of raising on lifespan failure so the dual-port gather left a half-alive process on :6970 with systemd showing active = **#756**. Pi repaired manually (ALTER TABLE + update to master 93f395e2) and verified healthy. py-spy is now installed in the Pi venv. New runbook: `docs/runbooks/controller-rescue.md` (#758, merged). **#755 fix must reach master before any beta user updates across the user_id boundary.**
+## Overnight run summary (2026-06-10 evening -> 06-11 ~04:50)
+- **Beta Pi incident RESOLVED:** controller was half-alive (active in systemd, :6970 only). Root causes #755 (knowledge.db user_id migration never applied to existing DBs) + #756 (lifespan failure left process alive). Pi repaired + on master, verified healthy.
+- **Merged to dev:** #752 (perf cleanups), #754 (installer sudo gap, closes #753), #758 (controller-rescue runbook), #763 (self-healing knowledge migration + exit-on-startup-failure, closes #755/#756), #764 (worker backend names type:port, closes #759), #762 (cluster pairing-code auth Phase 1, the #737 backend).
+- **Promoted to master:** #766 (3fe1c490) carrying #752/#754/#758/#763. **#767** carrying #762/#764 in flight.
+- **#723 reporter replied** (Jay-approved draft) with recovery instructions; #753 fix on master.
+- **#762 review hardening:** admin gate on pairing pending/confirm, atomic claim (rowcount-gated), actionable 410/404 claim errors, store internals encapsulated (pairing_state()). One CodeRabbit suggestion rejected for cause: counting HMAC failures toward the pairing cap would create a re-pair DoS vector.
 
-## Immediate next actions (in order)
-1. Finish review + merge **#762** (pairing auth Phase 1) when CI green.
-2. Land the **#755+#756 fix** (re-dispatch if the agent died, see GOTCHA).
-3. Land the **#759 fix** (same).
-4. **Promote dev -> master** (carries #752 perf cleanups, #754 installer sudo fix, #758 runbook, plus whatever lands above). Use a dev->master PR with `--merge`.
-5. **Post the approved #723 reply** (Jay approved the draft verbatim, it is in the session transcript and summarised in the issue context: two causes, #724 fixed the CHDIR loop, #753 tracked the no-sudo gap, recovery = re-run installer with sudo). Post AFTER #753's fix (#754) is on master via step 4.
-6. #737 Phase 2 (worker scripts) once Phase 1 merged; spec pattern in the #737 comment.
+## Immediate next actions
+1. Merge **#767** if still open (see GOTCHA).
+2. **#737 Phase 2:** worker scripts (bash + powershell) generate + print the pairing code, announce, poll claim, persist signing_key, sign register/heartbeat. Spec pattern in the #737 issue comment; backend endpoints + HMAC header format are live on dev (see tinyagentos/cluster/worker_auth.py docstring). Sonnet with a full spec.
+3. **#737 Phase 3:** taOS UI pending-workers list + enter-code dialog (frontend-design pass; ties into #760/#761 badge work).
+4. **#737 Phase 4:** migration story for existing fleet workers (clear re-pair prompt, not silent 401s).
+5. **#751** beads-inspired native task-graph: AWAITING Jay greenlight.
 
-## Merged to dev this session
-#752 (approve-lock eviction + auth_requests indexes + shared httpx client), #754 (installer sudo gap, closes #753), #758 (controller rescue runbook).
-
-## Open issues filed this session
-#753 installer sudo gap (fixed by #754), #755 knowledge migration bricks updates (CRITICAL), #756 half-alive controller on startup failure, #757 unit template env mangling (0_BASE_IMAGE), #759 worker backend names embed localhost URLs, #760 host badges everywhere (UI principle, design pass), #761 per-device emoji/badge identity (brainstorm first, depends on #760 + #737 pairing store).
+## Open issues filed this stretch
+#753 (fixed, #754), #755/#756 (fixed, #763), #757 unit template env mangling (open, small), #759 (fixed, #764), #760 host badges everywhere (UI principle, design pass), #761 per-device emoji/badge identity (brainstorm first; hangs off #737 pairing store + #760).
 
 ## In flight
-- **M1 security:** #737 Phase 1 = PR #762 (open). Phases 2-4 queued (scripts, UI, migration).
-- **#751** beads-inspired native task-graph: AWAITING Jay greenlight (buy vs build).
+- **M1 security:** #737 Phase 1 DONE (#762). Phases 2-4 queued (see next actions).
 - **#744 external coding-agent onboarding:** 7 build tasks queued behind M1.
 
 ## Cross-project (taosmd / A2A)
-- Progress channels live: `taos-progress` (incident + all merges posted), `taosmd-progress`. Durable 30-min freshness crons (taOS :00/:30, taosmd :15/:45).
+- Progress channels live: `taos-progress` (all overnight work posted), `taosmd-progress`. Durable 30-min freshness crons (taOS :00/:30, taosmd :15/:45).
 
 ## Blocked / waiting on human (Jay)
 - `#15` exo fork deletion: needs `gh auth refresh -s delete_repo`.

--- a/tests/cluster/test_worker_invariants.py
+++ b/tests/cluster/test_worker_invariants.py
@@ -1,7 +1,7 @@
 """Cluster invariants for the worker-as-LXC architecture.
 
 Two checks:
-  1. One worker LXC per bare host — enforced via host_lan_ip uniqueness.
+  1. One worker LXC per bare host -- enforced via host_lan_ip uniqueness.
   2. Privileged + nesting verification at incus-enroll (separate test
      coverage in test_local_worker_enroll.py once that exists).
 
@@ -10,14 +10,15 @@ This file covers (1).
 import pytest
 
 
+
 @pytest.mark.asyncio
-async def test_second_worker_with_same_host_lan_ip_returns_409(client):
+async def test_second_worker_with_same_host_lan_ip_returns_409(client, app, pair_and_register_worker):
     payload1 = {
         "name": "worker-a",
         "url": "http://192.168.1.50:6970",
         "host_lan_ip": "192.168.1.50",
     }
-    r1 = await client.post("/api/cluster/workers", json=payload1)
+    r1 = await pair_and_register_worker(client, app, payload1)
     assert r1.status_code == 200
 
     payload2 = {
@@ -25,20 +26,20 @@ async def test_second_worker_with_same_host_lan_ip_returns_409(client):
         "url": "http://192.168.1.50:6970",
         "host_lan_ip": "192.168.1.50",
     }
-    r2 = await client.post("/api/cluster/workers", json=payload2)
+    r2 = await pair_and_register_worker(client, app, payload2)
     assert r2.status_code == 409
     body = r2.json()
     assert "already" in body["error"].lower() or "exists" in body["error"].lower()
 
 
 @pytest.mark.asyncio
-async def test_two_workers_with_different_host_lan_ips_both_succeed(client):
-    r1 = await client.post("/api/cluster/workers", json={
+async def test_two_workers_with_different_host_lan_ips_both_succeed(client, app, pair_and_register_worker):
+    r1 = await pair_and_register_worker(client, app, {
         "name": "worker-a",
         "url": "http://192.168.1.50:6970",
         "host_lan_ip": "192.168.1.50",
     })
-    r2 = await client.post("/api/cluster/workers", json={
+    r2 = await pair_and_register_worker(client, app, {
         "name": "worker-b",
         "url": "http://192.168.1.51:6970",
         "host_lan_ip": "192.168.1.51",
@@ -48,16 +49,16 @@ async def test_two_workers_with_different_host_lan_ips_both_succeed(client):
 
 
 @pytest.mark.asyncio
-async def test_worker_without_host_lan_ip_does_not_collide(client):
+async def test_worker_without_host_lan_ip_does_not_collide(client, app, pair_and_register_worker):
     """Legacy flat-mode workers (no host_lan_ip) shouldn't trigger the
-    one-per-host check — they go through the normal name-uniqueness path
+    one-per-host check -- they go through the normal name-uniqueness path
     only.
     """
-    r1 = await client.post("/api/cluster/workers", json={
+    r1 = await pair_and_register_worker(client, app, {
         "name": "legacy-a",
         "url": "http://192.168.1.50:6970",
     })
-    r2 = await client.post("/api/cluster/workers", json={
+    r2 = await pair_and_register_worker(client, app, {
         "name": "legacy-b",
         "url": "http://192.168.1.50:6970",
     })

--- a/tests/cluster/test_worker_registration.py
+++ b/tests/cluster/test_worker_registration.py
@@ -89,7 +89,7 @@ class TestClusterManagerGetWorker:
 
 
 @pytest.mark.asyncio
-async def test_worker_register_accepts_lxc_capacity_fields(client):
+async def test_worker_register_accepts_lxc_capacity_fields(client, app, pair_and_register_worker):
     payload = {
         "name": "test-worker-lxc-fields",
         "url": "http://192.168.1.50:6970",
@@ -99,7 +99,7 @@ async def test_worker_register_accepts_lxc_capacity_fields(client):
         "bytes_deduped_total": 0,
         "worker_lxc_image_version": "ubuntu/24.04/amd64",
     }
-    resp = await client.post("/api/cluster/workers", json=payload)
+    resp = await pair_and_register_worker(client, app, payload)
     assert resp.status_code == 200
     workers = (await client.get("/api/cluster/workers")).json()
     me = next(w for w in workers if w["name"] == "test-worker-lxc-fields")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,10 @@
+import hashlib
+import hmac
+import json as _json
 import os
 import sqlite3
 import sys
+import time
 
 import pytest
 import pytest_asyncio
@@ -9,6 +13,94 @@ from httpx import ASGITransport, AsyncClient
 
 from tinyagentos.app import create_app
 from tinyagentos.routes.desktop import SPA_DIR
+
+
+# ---------------------------------------------------------------------------
+# Cluster HMAC pairing helpers (used by cluster tests across multiple files)
+# ---------------------------------------------------------------------------
+
+def _cluster_code_hash(code: str) -> str:
+    return hashlib.sha256(code.encode()).hexdigest()
+
+
+def sign_worker_request(
+    key: bytes,
+    name: str,
+    method: str,
+    path: str,
+    body: bytes,
+) -> dict:
+    """Return the three HMAC auth headers for a worker request."""
+    ts = str(int(time.time()))
+    body_hash = hashlib.sha256(body).hexdigest()
+    message = f"{ts}.{method.upper()}.{path}.{body_hash}".encode()
+    sig = hmac.new(key, message, hashlib.sha256).hexdigest()
+    return {
+        "X-TAOS-Worker-Name": name,
+        "X-TAOS-Timestamp": ts,
+        "X-TAOS-Signature": sig,
+    }
+
+
+async def _pair_and_register_worker(
+    client,
+    app,
+    payload: dict,
+    code_prefix: str = "test-pairing-code",
+) -> object:
+    """Pair a worker and POST to /api/cluster/workers with HMAC auth.
+
+    Drives the full announce -> confirm -> claim flow to obtain a signing
+    key, then sends the registration request with the correct headers.
+    Returns the httpx Response from the final POST.
+    """
+    name = payload["name"]
+    url = payload.get("url", "http://localhost:9000")
+    platform = payload.get("platform", "linux")
+    code = code_prefix + name
+
+    # init() opens a fresh aiosqlite connection every call, so only run it
+    # when the store has not been initialised yet (avoids leaking connections
+    # in tests that pair multiple workers).
+    if app.state.cluster_pairing._db is None:  # noqa: SLF001
+        await app.state.cluster_pairing.init()
+    ch = _cluster_code_hash(code)
+
+    resp = await client.post(
+        "/api/cluster/pairing/announce",
+        json={"name": name, "url": url, "platform": platform, "code_hash": ch},
+    )
+    assert resp.status_code == 200, f"announce failed for {name!r}: {resp.text}"
+
+    resp = await client.post(
+        "/api/cluster/pairing/confirm",
+        json={"name": name, "code": code},
+    )
+    assert resp.status_code == 200, f"confirm failed for {name!r}: {resp.text}"
+
+    resp = await client.post(
+        "/api/cluster/pairing/claim",
+        json={"name": name, "code": code},
+    )
+    assert resp.status_code == 200, f"claim failed for {name!r}: {resp.text}"
+    key = bytes.fromhex(resp.json()["signing_key"])
+
+    body = _json.dumps(payload).encode()
+    headers = sign_worker_request(key, name, "POST", "/api/cluster/workers", body)
+    return await client.post(
+        "/api/cluster/workers",
+        content=body,
+        headers={**headers, "content-type": "application/json"},
+    )
+
+
+@pytest.fixture
+def pair_and_register_worker():
+    """Function fixture so test files in any directory can use the pairing
+    helper without importing from conftest (tests/ is not a package, so
+    ``from tests.conftest import ...`` breaks under CI's import mode)."""
+    return _pair_and_register_worker
+
 
 # macOS + Python 3.14: after the interpreter loads ObjC-backed extension
 # modules (psutil, zeroconf, Pillow, lxml …), forking a child process with

--- a/tests/test_cluster_optimiser.py
+++ b/tests/test_cluster_optimiser.py
@@ -188,13 +188,13 @@ async def test_optimise_api_endpoint(client):
 
 
 @pytest.mark.asyncio
-async def test_optimise_api_with_workers(client):
-    await client.post("/api/cluster/workers", json={
+async def test_optimise_api_with_workers(client, app, pair_and_register_worker):
+    await pair_and_register_worker(client, app, {
         "name": "gpu-box", "url": "http://10.0.0.1:9000",
         "capabilities": ["chat"], "platform": "linux",
         "hardware": {"ram_mb": 32768, "gpu": {"cuda": True, "vram_mb": 24576}},
     })
-    await client.post("/api/cluster/workers", json={
+    await pair_and_register_worker(client, app, {
         "name": "pi-node", "url": "http://10.0.0.2:9000",
         "capabilities": ["embed"], "platform": "linux",
         "hardware": {"ram_mb": 4096},
@@ -208,12 +208,12 @@ async def test_optimise_api_with_workers(client):
 
 
 @pytest.mark.asyncio
-async def test_move_api_endpoint(client):
-    await client.post("/api/cluster/workers", json={
+async def test_move_api_endpoint(client, app, pair_and_register_worker):
+    await pair_and_register_worker(client, app, {
         "name": "w1", "url": "http://10.0.0.1:9000",
         "capabilities": ["chat"], "models": ["llama3"],
     })
-    await client.post("/api/cluster/workers", json={
+    await pair_and_register_worker(client, app, {
         "name": "w2", "url": "http://10.0.0.2:9000",
         "capabilities": ["chat"],
     })
@@ -243,8 +243,8 @@ async def test_move_api_unknown_worker(client):
 
 
 @pytest.mark.asyncio
-async def test_move_api_offline_worker(client):
-    await client.post("/api/cluster/workers", json={
+async def test_move_api_offline_worker(client, app, pair_and_register_worker):
+    await pair_and_register_worker(client, app, {
         "name": "offline-w", "url": "http://10.0.0.1:9000",
     })
     # Manually set offline by letting heartbeat expire (hack: directly via app state)

--- a/tests/test_routes_auth.py
+++ b/tests/test_routes_auth.py
@@ -19,7 +19,11 @@ class TestAuthRoutes:
         assert resp.json()["status"] == "ok"
 
     @pytest.mark.asyncio
-    async def test_cluster_register_exempt_from_auth(self, client):
+    async def test_cluster_register_exempt_from_session_auth(self, client):
+        # POST /api/cluster/workers is session-exempt (no session cookie required),
+        # but the route-level HMAC gate rejects unpaired workers with 401.
+        # This verifies that the session middleware lets the request through
+        # (i.e. the route itself is reached and returns its own 401 code).
         resp = await client.post("/api/cluster/workers", json={
             "name": "test-worker",
             "url": "http://localhost:9090",
@@ -27,4 +31,5 @@ class TestAuthRoutes:
             "capabilities": [],
             "hardware": {},
         })
-        assert resp.status_code == 200
+        assert resp.status_code == 401
+        assert resp.json().get("code") == "worker_not_paired"

--- a/tests/test_routes_cluster.py
+++ b/tests/test_routes_cluster.py
@@ -1,22 +1,89 @@
 """Tests for the cluster API routes."""
 from __future__ import annotations
 
+import hashlib
+import hmac
+import time
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from httpx import AsyncClient
+
+
+# ---------------------------------------------------------------------------
+# Pairing helpers (shared with test_routes_cluster_pairing.py)
+# ---------------------------------------------------------------------------
+
+def _code_hash(code: str) -> str:
+    return hashlib.sha256(code.encode()).hexdigest()
+
+
+def sign_worker_request(
+    key: bytes,
+    name: str,
+    method: str,
+    path: str,
+    body: bytes,
+) -> dict:
+    """Return the three HMAC auth headers for a worker request."""
+    ts = str(int(time.time()))
+    body_hash = hashlib.sha256(body).hexdigest()
+    message = f"{ts}.{method.upper()}.{path}.{body_hash}".encode()
+    sig = hmac.new(key, message, hashlib.sha256).hexdigest()
+    return {
+        "X-TAOS-Worker-Name": name,
+        "X-TAOS-Timestamp": ts,
+        "X-TAOS-Signature": sig,
+    }
+
+
+async def pair_worker(
+    client: AsyncClient,
+    app,
+    name: str,
+    url: str,
+    platform: str = "linux",
+    code: str = "test-pairing-code",
+) -> bytes:
+    """Drive announce -> confirm -> claim and return the signing key."""
+    await app.state.cluster_pairing.init()
+    ch = _code_hash(code)
+    resp = await client.post(
+        "/api/cluster/pairing/announce",
+        json={"name": name, "url": url, "platform": platform, "code_hash": ch},
+    )
+    assert resp.status_code == 200, resp.text
+    resp = await client.post(
+        "/api/cluster/pairing/confirm",
+        json={"name": name, "code": code},
+    )
+    assert resp.status_code == 200, resp.text
+    resp = await client.post(
+        "/api/cluster/pairing/claim",
+        json={"name": name, "code": code},
+    )
+    assert resp.status_code == 200, resp.text
+    return bytes.fromhex(resp.json()["signing_key"])
 
 
 @pytest.mark.asyncio
-async def test_worker_registration_api(client):
-    body = {
+async def test_worker_registration_api(client, app):
+    key = await pair_worker(client, app, "test-worker", "http://192.168.1.50:9000")
+    import json as _json
+    reg_body = _json.dumps({
         "name": "test-worker",
         "url": "http://192.168.1.50:9000",
         "platform": "linux",
         "capabilities": ["chat", "embed"],
         "hardware": {"cpu": "Ryzen 9", "ram_gb": 64},
         "models": ["llama3"],
-    }
-    resp = await client.post("/api/cluster/workers", json=body)
+    }).encode()
+    headers = sign_worker_request(key, "test-worker", "POST", "/api/cluster/workers", reg_body)
+    resp = await client.post(
+        "/api/cluster/workers",
+        content=reg_body,
+        headers={**headers, "content-type": "application/json"},
+    )
     assert resp.status_code == 200
     data = resp.json()
     assert data["status"] == "registered"
@@ -29,19 +96,28 @@ async def test_worker_registration_api(client):
     assert len(workers) == 1
     assert workers[0]["name"] == "test-worker"
     assert workers[0]["status"] == "online"
+    await app.state.cluster_pairing.close()
 
 
 @pytest.mark.asyncio
-async def test_heartbeat_api(client):
+async def test_heartbeat_api(client, app):
+    import json as _json
+    key = await pair_worker(client, app, "hb-worker", "http://10.0.0.1:9000")
     # Register first
-    await client.post("/api/cluster/workers", json={
-        "name": "hb-worker", "url": "http://10.0.0.1:9000", "capabilities": ["chat"],
-    })
+    reg_body = _json.dumps({"name": "hb-worker", "url": "http://10.0.0.1:9000", "capabilities": ["chat"]}).encode()
+    await client.post(
+        "/api/cluster/workers",
+        content=reg_body,
+        headers={**sign_worker_request(key, "hb-worker", "POST", "/api/cluster/workers", reg_body), "content-type": "application/json"},
+    )
 
     # Send heartbeat
-    resp = await client.post("/api/cluster/heartbeat", json={
-        "name": "hb-worker", "load": 0.42, "models": ["phi3"],
-    })
+    hb_body = _json.dumps({"name": "hb-worker", "load": 0.42, "models": ["phi3"]}).encode()
+    resp = await client.post(
+        "/api/cluster/heartbeat",
+        content=hb_body,
+        headers={**sign_worker_request(key, "hb-worker", "POST", "/api/cluster/heartbeat", hb_body), "content-type": "application/json"},
+    )
     assert resp.status_code == 200
     assert resp.json()["status"] == "ok"
 
@@ -50,19 +126,34 @@ async def test_heartbeat_api(client):
     w = resp.json()[0]
     assert w["load"] == 0.42
     assert w["models"] == ["phi3"]
+    await app.state.cluster_pairing.close()
 
 
 @pytest.mark.asyncio
-async def test_heartbeat_unknown_worker(client):
-    resp = await client.post("/api/cluster/heartbeat", json={"name": "ghost"})
+async def test_heartbeat_unknown_worker(client, app):
+    import json as _json
+    # Pair so the HMAC gate passes, but never register so the heartbeat 404s
+    key = await pair_worker(client, app, "ghost", "http://10.0.0.99:9000")
+    hb_body = _json.dumps({"name": "ghost"}).encode()
+    resp = await client.post(
+        "/api/cluster/heartbeat",
+        content=hb_body,
+        headers={**sign_worker_request(key, "ghost", "POST", "/api/cluster/heartbeat", hb_body), "content-type": "application/json"},
+    )
     assert resp.status_code == 404
+    await app.state.cluster_pairing.close()
 
 
 @pytest.mark.asyncio
-async def test_unregister_worker(client):
-    await client.post("/api/cluster/workers", json={
-        "name": "temp-worker", "url": "http://10.0.0.2:9000",
-    })
+async def test_unregister_worker(client, app):
+    import json as _json
+    key = await pair_worker(client, app, "temp-worker", "http://10.0.0.2:9000")
+    reg_body = _json.dumps({"name": "temp-worker", "url": "http://10.0.0.2:9000"}).encode()
+    await client.post(
+        "/api/cluster/workers",
+        content=reg_body,
+        headers={**sign_worker_request(key, "temp-worker", "POST", "/api/cluster/workers", reg_body), "content-type": "application/json"},
+    )
     resp = await client.delete("/api/cluster/workers/temp-worker")
     assert resp.status_code == 200
     assert resp.json()["status"] == "removed"
@@ -70,6 +161,7 @@ async def test_unregister_worker(client):
     # Verify gone
     resp = await client.get("/api/cluster/workers")
     assert len(resp.json()) == 0
+    await app.state.cluster_pairing.close()
 
 
 @pytest.mark.asyncio
@@ -79,13 +171,20 @@ async def test_unregister_unknown_worker(client):
 
 
 @pytest.mark.asyncio
-async def test_capabilities_api(client):
-    await client.post("/api/cluster/workers", json={
-        "name": "w1", "url": "http://10.0.0.1:9000", "capabilities": ["chat", "embed"],
-    })
-    await client.post("/api/cluster/workers", json={
-        "name": "w2", "url": "http://10.0.0.2:9000", "capabilities": ["chat", "tts"],
-    })
+async def test_capabilities_api(client, app):
+    import json as _json
+    key1 = await pair_worker(client, app, "w1", "http://10.0.0.1:9000")
+    reg1 = _json.dumps({"name": "w1", "url": "http://10.0.0.1:9000", "capabilities": ["chat", "embed"]}).encode()
+    await client.post(
+        "/api/cluster/workers", content=reg1,
+        headers={**sign_worker_request(key1, "w1", "POST", "/api/cluster/workers", reg1), "content-type": "application/json"},
+    )
+    key2 = await pair_worker(client, app, "w2", "http://10.0.0.2:9000", code="other-code")
+    reg2 = _json.dumps({"name": "w2", "url": "http://10.0.0.2:9000", "capabilities": ["chat", "tts"]}).encode()
+    await client.post(
+        "/api/cluster/workers", content=reg2,
+        headers={**sign_worker_request(key2, "w2", "POST", "/api/cluster/workers", reg2), "content-type": "application/json"},
+    )
 
     resp = await client.get("/api/cluster/capabilities")
     assert resp.status_code == 200
@@ -94,58 +193,82 @@ async def test_capabilities_api(client):
     assert sorted(caps["chat"]) == ["w1", "w2"]
     assert caps["embed"] == ["w1"]
     assert caps["tts"] == ["w2"]
+    await app.state.cluster_pairing.close()
 
 
 @pytest.mark.asyncio
-async def test_worker_registration_includes_kv_quant(client):
-    body = {
+async def test_worker_registration_includes_kv_quant(client, app):
+    import json as _json
+    key = await pair_worker(client, app, "quant-worker", "http://10.0.0.9:9000")
+    reg_body = _json.dumps({
         "name": "quant-worker",
         "url": "http://10.0.0.9:9000",
         "kv_cache_quant_support": ["fp16", "turboquant-k3v2"],
-    }
-    resp = await client.post("/api/cluster/workers", json=body)
+    }).encode()
+    resp = await client.post(
+        "/api/cluster/workers", content=reg_body,
+        headers={**sign_worker_request(key, "quant-worker", "POST", "/api/cluster/workers", reg_body), "content-type": "application/json"},
+    )
     assert resp.status_code == 200
 
     resp = await client.get("/api/cluster/workers")
     workers = resp.json()
     assert len(workers) == 1
     assert workers[0]["kv_cache_quant_support"] == ["fp16", "turboquant-k3v2"]
+    await app.state.cluster_pairing.close()
 
 
 @pytest.mark.asyncio
-async def test_worker_registration_kv_quant_defaults_fp16(client):
+async def test_worker_registration_kv_quant_defaults_fp16(client, app):
     """A worker that doesn't send kv_cache_quant_support gets ["fp16"] by default."""
-    body = {
+    import json as _json
+    key = await pair_worker(client, app, "legacy-worker", "http://10.0.0.8:9000")
+    reg_body = _json.dumps({
         "name": "legacy-worker",
         "url": "http://10.0.0.8:9000",
         # no kv_cache_quant_support field
-    }
-    resp = await client.post("/api/cluster/workers", json=body)
+    }).encode()
+    resp = await client.post(
+        "/api/cluster/workers", content=reg_body,
+        headers={**sign_worker_request(key, "legacy-worker", "POST", "/api/cluster/workers", reg_body), "content-type": "application/json"},
+    )
     assert resp.status_code == 200
 
     resp = await client.get("/api/cluster/workers")
     workers = resp.json()
     assert workers[0]["kv_cache_quant_support"] == ["fp16"]
+    await app.state.cluster_pairing.close()
 
 
 @pytest.mark.asyncio
-async def test_heartbeat_updates_kv_quant(client):
-    await client.post("/api/cluster/workers", json={
+async def test_heartbeat_updates_kv_quant(client, app):
+    import json as _json
+    key = await pair_worker(client, app, "kv-worker", "http://10.0.0.7:9000")
+    reg_body = _json.dumps({
         "name": "kv-worker",
         "url": "http://10.0.0.7:9000",
         "kv_cache_quant_support": ["fp16"],
-    })
+    }).encode()
+    await client.post(
+        "/api/cluster/workers", content=reg_body,
+        headers={**sign_worker_request(key, "kv-worker", "POST", "/api/cluster/workers", reg_body), "content-type": "application/json"},
+    )
 
-    resp = await client.post("/api/cluster/heartbeat", json={
+    hb_body = _json.dumps({
         "name": "kv-worker",
         "load": 0.1,
         "kv_cache_quant_support": ["fp16", "turboquant-k3v2"],
-    })
+    }).encode()
+    resp = await client.post(
+        "/api/cluster/heartbeat", content=hb_body,
+        headers={**sign_worker_request(key, "kv-worker", "POST", "/api/cluster/heartbeat", hb_body), "content-type": "application/json"},
+    )
     assert resp.status_code == 200
 
     resp = await client.get("/api/cluster/workers")
     w = resp.json()[0]
     assert "turboquant-k3v2" in w["kv_cache_quant_support"]
+    await app.state.cluster_pairing.close()
 
 
 @pytest.mark.asyncio
@@ -158,34 +281,44 @@ async def test_kv_quant_options_empty_cluster(client):
 
 
 @pytest.mark.asyncio
-async def test_kv_quant_options_all_fp16(client):
+async def test_kv_quant_options_all_fp16(client, app):
+    import json as _json
     for i in range(2):
-        await client.post("/api/cluster/workers", json={
-            "name": f"w{i}",
-            "url": f"http://10.0.1.{i}:9000",
-            "kv_cache_quant_support": ["fp16"],
-        })
+        name = f"w{i}"
+        url = f"http://10.0.1.{i}:9000"
+        code = f"code-w{i}"
+        key = await pair_worker(client, app, name, url, code=code)
+        reg_body = _json.dumps({"name": name, "url": url, "kv_cache_quant_support": ["fp16"]}).encode()
+        await client.post(
+            "/api/cluster/workers", content=reg_body,
+            headers={**sign_worker_request(key, name, "POST", "/api/cluster/workers", reg_body), "content-type": "application/json"},
+        )
     resp = await client.get("/api/cluster/kv-quant-options")
     data = resp.json()
     assert data["options"] == ["fp16"]
+    await app.state.cluster_pairing.close()
 
 
 @pytest.mark.asyncio
-async def test_kv_quant_options_mixed_cluster(client):
-    await client.post("/api/cluster/workers", json={
-        "name": "plain",
-        "url": "http://10.0.2.1:9000",
-        "kv_cache_quant_support": ["fp16"],
-    })
-    await client.post("/api/cluster/workers", json={
-        "name": "turboquant",
-        "url": "http://10.0.2.2:9000",
-        "kv_cache_quant_support": ["fp16", "turboquant-k3v2"],
-    })
+async def test_kv_quant_options_mixed_cluster(client, app):
+    import json as _json
+    key_plain = await pair_worker(client, app, "plain", "http://10.0.2.1:9000")
+    reg_plain = _json.dumps({"name": "plain", "url": "http://10.0.2.1:9000", "kv_cache_quant_support": ["fp16"]}).encode()
+    await client.post(
+        "/api/cluster/workers", content=reg_plain,
+        headers={**sign_worker_request(key_plain, "plain", "POST", "/api/cluster/workers", reg_plain), "content-type": "application/json"},
+    )
+    key_tq = await pair_worker(client, app, "turboquant", "http://10.0.2.2:9000", code="tq-code")
+    reg_tq = _json.dumps({"name": "turboquant", "url": "http://10.0.2.2:9000", "kv_cache_quant_support": ["fp16", "turboquant-k3v2"]}).encode()
+    await client.post(
+        "/api/cluster/workers", content=reg_tq,
+        headers={**sign_worker_request(key_tq, "turboquant", "POST", "/api/cluster/workers", reg_tq), "content-type": "application/json"},
+    )
     resp = await client.get("/api/cluster/kv-quant-options")
     data = resp.json()
     assert "fp16" in data["options"]
     assert "turboquant-k3v2" in data["options"]
+    await app.state.cluster_pairing.close()
 
 
 # ---------------------------------------------------------------------------
@@ -204,12 +337,15 @@ async def test_incus_enroll_worker_not_registered(client):
 
 
 @pytest.mark.asyncio
-async def test_incus_enroll_success(client):
-    """Happy path: worker registered → remote_add called with right args → 200."""
-    await client.post("/api/cluster/workers", json={
-        "name": "pi-worker",
-        "url": "http://10.0.0.5:9000",
-    })
+async def test_incus_enroll_success(client, app):
+    """Happy path: worker registered then incus-enroll called with right args -> 200."""
+    import json as _json
+    key = await pair_worker(client, app, "pi-worker", "http://10.0.0.5:9000")
+    reg_body = _json.dumps({"name": "pi-worker", "url": "http://10.0.0.5:9000"}).encode()
+    await client.post(
+        "/api/cluster/workers", content=reg_body,
+        headers={**sign_worker_request(key, "pi-worker", "POST", "/api/cluster/workers", reg_body), "content-type": "application/json"},
+    )
 
     mock_remote_add = AsyncMock(return_value={"success": True, "output": ""})
     with patch("tinyagentos.containers.remote_add", mock_remote_add):
@@ -223,15 +359,19 @@ async def test_incus_enroll_success(client):
     mock_remote_add.assert_awaited_once_with(
         "pi-worker", "https://10.0.0.5:8443", "tok-xyz"
     )
+    await app.state.cluster_pairing.close()
 
 
 @pytest.mark.asyncio
-async def test_incus_enroll_remote_add_failure(client):
-    """remote_add returns failure → endpoint returns 500 with error text."""
-    await client.post("/api/cluster/workers", json={
-        "name": "flaky-worker",
-        "url": "http://10.0.0.6:9000",
-    })
+async def test_incus_enroll_remote_add_failure(client, app):
+    """remote_add returns failure -> endpoint returns 500 with error text."""
+    import json as _json
+    key = await pair_worker(client, app, "flaky-worker", "http://10.0.0.6:9000")
+    reg_body = _json.dumps({"name": "flaky-worker", "url": "http://10.0.0.6:9000"}).encode()
+    await client.post(
+        "/api/cluster/workers", content=reg_body,
+        headers={**sign_worker_request(key, "flaky-worker", "POST", "/api/cluster/workers", reg_body), "content-type": "application/json"},
+    )
 
     mock_remote_add = AsyncMock(return_value={
         "success": False,
@@ -247,6 +387,7 @@ async def test_incus_enroll_remote_add_failure(client):
     data = resp.json()
     assert data["ok"] is False
     assert "certificate rejected" in data["error"]
+    await app.state.cluster_pairing.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_routes_cluster_pairing.py
+++ b/tests/test_routes_cluster_pairing.py
@@ -1,0 +1,683 @@
+"""Tests for the cluster pairing flow and HMAC gate on worker endpoints.
+
+Coverage:
+- announce -> pending visible to admin
+- confirm right/wrong code, expiry, attempt cap invalidation
+- claim before confirm (202), after confirm (key once, second claim 404)
+- full happy path announce -> confirm -> claim -> HMAC register -> heartbeat
+- unsigned register/heartbeat -> 401 worker_not_paired
+- bad signature, stale timestamp, header/body name mismatch
+- GET /api/cluster/workers still public
+- pairing pending/confirm require a session
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import secrets
+import time
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared across tests
+# ---------------------------------------------------------------------------
+
+def _code_hash(code: str) -> str:
+    return hashlib.sha256(code.encode()).hexdigest()
+
+
+def sign_worker_request(
+    key: bytes,
+    name: str,
+    method: str,
+    path: str,
+    body: bytes,
+) -> dict:
+    """Return the three HMAC auth headers for a worker request."""
+    ts = str(int(time.time()))
+    body_hash = hashlib.sha256(body).hexdigest()
+    message = f"{ts}.{method.upper()}.{path}.{body_hash}".encode()
+    sig = hmac.new(key, message, hashlib.sha256).hexdigest()
+    return {
+        "X-TAOS-Worker-Name": name,
+        "X-TAOS-Timestamp": ts,
+        "X-TAOS-Signature": sig,
+    }
+
+
+async def pair_worker(
+    client: AsyncClient,
+    app,
+    name: str,
+    url: str,
+    platform: str = "linux",
+    code: str = "test-code-123",
+) -> bytes:
+    """Drive the full pairing flow and return the signing key."""
+    ch = _code_hash(code)
+    resp = await client.post(
+        "/api/cluster/pairing/announce",
+        json={"name": name, "url": url, "platform": platform, "code_hash": ch},
+    )
+    assert resp.status_code == 200, resp.text
+
+    resp = await client.post(
+        "/api/cluster/pairing/confirm",
+        json={"name": name, "code": code},
+    )
+    assert resp.status_code == 200, resp.text
+
+    resp = await client.post(
+        "/api/cluster/pairing/claim",
+        json={"name": name, "code": code},
+    )
+    assert resp.status_code == 200, resp.text
+    return bytes.fromhex(resp.json()["signing_key"])
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture
+async def unauthed_client(app, tmp_data_dir):
+    """Client with no session cookie (anonymous)."""
+    store = app.state.cluster_pairing
+    await store.init()
+    app.state._startup_complete = True
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+    ) as c:
+        yield c
+    await store.close()
+
+
+# ---------------------------------------------------------------------------
+# announce
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_announce_returns_pending(client, app):
+    """A valid announce creates a pending entry visible to admin."""
+    await app.state.cluster_pairing.init()
+    code = "secret-code"
+    resp = await client.post(
+        "/api/cluster/pairing/announce",
+        json={
+            "name": "worker-a",
+            "url": "http://10.0.0.1:9000",
+            "platform": "linux",
+            "code_hash": _code_hash(code),
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "pending"
+
+    resp = await client.get("/api/cluster/pairing/pending")
+    assert resp.status_code == 200
+    items = resp.json()
+    assert any(w["name"] == "worker-a" for w in items)
+    await app.state.cluster_pairing.close()
+
+
+@pytest.mark.asyncio
+async def test_announce_rejects_invalid_code_hash(client, app):
+    """code_hash that is not 64 lowercase hex chars -> 400."""
+    await app.state.cluster_pairing.init()
+    resp = await client.post(
+        "/api/cluster/pairing/announce",
+        json={"name": "w1", "url": "http://10.0.0.1:9000", "code_hash": "tooshort"},
+    )
+    assert resp.status_code == 400
+    await app.state.cluster_pairing.close()
+
+
+@pytest.mark.asyncio
+async def test_announce_rejects_empty_name(client, app):
+    """Empty name -> 400."""
+    await app.state.cluster_pairing.init()
+    resp = await client.post(
+        "/api/cluster/pairing/announce",
+        json={"name": "", "url": "http://10.0.0.1:9000", "code_hash": _code_hash("x")},
+    )
+    assert resp.status_code == 400
+    await app.state.cluster_pairing.close()
+
+
+@pytest.mark.asyncio
+async def test_announce_rejects_empty_url(client, app):
+    """Empty url -> 400."""
+    await app.state.cluster_pairing.init()
+    resp = await client.post(
+        "/api/cluster/pairing/announce",
+        json={"name": "w1", "url": "", "code_hash": _code_hash("x")},
+    )
+    assert resp.status_code == 400
+    await app.state.cluster_pairing.close()
+
+
+@pytest.mark.asyncio
+async def test_announce_no_auth_required(app, tmp_data_dir):
+    """announce is unauthenticated — no session cookie needed."""
+    await app.state.cluster_pairing.init()
+    transport = ASGITransport(app=app)
+    app.state._startup_complete = True
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        resp = await c.post(
+            "/api/cluster/pairing/announce",
+            json={"name": "anon-worker", "url": "http://10.0.0.2:9000", "code_hash": _code_hash("c")},
+        )
+    # 200 or 400 acceptable (auth must not be the reason for failure)
+    assert resp.status_code != 401
+    await app.state.cluster_pairing.close()
+
+
+# ---------------------------------------------------------------------------
+# pending (admin-only)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_pending_requires_session(app, tmp_data_dir):
+    """GET /api/cluster/pairing/pending without a session -> 401 or redirect."""
+    await app.state.cluster_pairing.init()
+    transport = ASGITransport(app=app)
+    app.state._startup_complete = True
+    app.state.auth.setup_user("admin", "Admin", "", "testpass123")
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        resp = await c.get("/api/cluster/pairing/pending")
+    assert resp.status_code in (401, 403)
+    await app.state.cluster_pairing.close()
+
+
+# ---------------------------------------------------------------------------
+# confirm
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_confirm_right_code(client, app):
+    """Admin confirms with correct code -> 200 confirmed."""
+    await app.state.cluster_pairing.init()
+    code = "right-code"
+    await client.post(
+        "/api/cluster/pairing/announce",
+        json={"name": "w2", "url": "http://10.0.0.3:9000", "code_hash": _code_hash(code)},
+    )
+    resp = await client.post("/api/cluster/pairing/confirm", json={"name": "w2", "code": code})
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "confirmed"
+    await app.state.cluster_pairing.close()
+
+
+@pytest.mark.asyncio
+async def test_confirm_wrong_code(client, app):
+    """Wrong code -> 403."""
+    await app.state.cluster_pairing.init()
+    await client.post(
+        "/api/cluster/pairing/announce",
+        json={"name": "w3", "url": "http://10.0.0.4:9000", "code_hash": _code_hash("real-code")},
+    )
+    resp = await client.post("/api/cluster/pairing/confirm", json={"name": "w3", "code": "wrong-code"})
+    assert resp.status_code == 403
+    await app.state.cluster_pairing.close()
+
+
+@pytest.mark.asyncio
+async def test_confirm_unknown_worker(client, app):
+    """No pending entry for name -> 404."""
+    await app.state.cluster_pairing.init()
+    resp = await client.post("/api/cluster/pairing/confirm", json={"name": "nobody", "code": "x"})
+    assert resp.status_code == 404
+    await app.state.cluster_pairing.close()
+
+
+@pytest.mark.asyncio
+async def test_confirm_expired_entry(client, app, monkeypatch):
+    """Entry older than 15 min -> 410 Gone."""
+    await app.state.cluster_pairing.init()
+    code = "exp-code"
+    await client.post(
+        "/api/cluster/pairing/announce",
+        json={"name": "w-exp", "url": "http://10.0.0.5:9000", "code_hash": _code_hash(code)},
+    )
+    # Monkeypatch time so the entry appears expired
+    import tinyagentos.cluster.pairing_store as _ps
+    monkeypatch.setattr(_ps, "_now", lambda: time.time() + 1000)
+    resp = await client.post("/api/cluster/pairing/confirm", json={"name": "w-exp", "code": code})
+    assert resp.status_code == 410
+    await app.state.cluster_pairing.close()
+
+
+@pytest.mark.asyncio
+async def test_confirm_attempt_cap_invalidates(client, app):
+    """5 wrong codes invalidate the pending entry -> further confirm returns 404."""
+    await app.state.cluster_pairing.init()
+    await client.post(
+        "/api/cluster/pairing/announce",
+        json={"name": "w-cap", "url": "http://10.0.0.6:9000", "code_hash": _code_hash("real")},
+    )
+    for _ in range(5):
+        await client.post("/api/cluster/pairing/confirm", json={"name": "w-cap", "code": "wrong"})
+    # 5 attempts exhausted — next call should 404 (invalidated)
+    resp = await client.post("/api/cluster/pairing/confirm", json={"name": "w-cap", "code": "real"})
+    assert resp.status_code == 404
+    await app.state.cluster_pairing.close()
+
+
+@pytest.mark.asyncio
+async def test_confirm_requires_session(app, tmp_data_dir):
+    """confirm without a session -> 401."""
+    await app.state.cluster_pairing.init()
+    transport = ASGITransport(app=app)
+    app.state._startup_complete = True
+    app.state.auth.setup_user("admin", "Admin", "", "testpass123")
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        resp = await c.post("/api/cluster/pairing/confirm", json={"name": "w", "code": "c"})
+    assert resp.status_code in (401, 403)
+    await app.state.cluster_pairing.close()
+
+
+# ---------------------------------------------------------------------------
+# claim
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_claim_before_confirm_returns_202(client, app):
+    """Claim before admin has confirmed -> 202 awaiting_confirm."""
+    await app.state.cluster_pairing.init()
+    code = "claim-code"
+    await client.post(
+        "/api/cluster/pairing/announce",
+        json={"name": "w-claim", "url": "http://10.0.0.7:9000", "code_hash": _code_hash(code)},
+    )
+    resp = await client.post("/api/cluster/pairing/claim", json={"name": "w-claim", "code": code})
+    assert resp.status_code == 202
+    assert resp.json()["status"] == "awaiting_confirm"
+    await app.state.cluster_pairing.close()
+
+
+@pytest.mark.asyncio
+async def test_claim_after_confirm_delivers_key_once(client, app):
+    """After confirm the key is delivered exactly once; second claim -> 404."""
+    await app.state.cluster_pairing.init()
+    code = "once-code"
+    await client.post(
+        "/api/cluster/pairing/announce",
+        json={"name": "w-once", "url": "http://10.0.0.8:9000", "code_hash": _code_hash(code)},
+    )
+    await client.post("/api/cluster/pairing/confirm", json={"name": "w-once", "code": code})
+
+    # First claim delivers key
+    resp = await client.post("/api/cluster/pairing/claim", json={"name": "w-once", "code": code})
+    assert resp.status_code == 200
+    key_hex = resp.json()["signing_key"]
+    assert len(bytes.fromhex(key_hex)) == 32
+
+    # Second claim -> 404 (pending fields cleared)
+    resp2 = await client.post("/api/cluster/pairing/claim", json={"name": "w-once", "code": code})
+    assert resp2.status_code == 404
+    await app.state.cluster_pairing.close()
+
+
+@pytest.mark.asyncio
+async def test_claim_wrong_code_after_confirm(client, app):
+    """After confirm, wrong code on claim -> 403."""
+    await app.state.cluster_pairing.init()
+    code = "right"
+    await client.post(
+        "/api/cluster/pairing/announce",
+        json={"name": "w-wrong", "url": "http://10.0.0.9:9000", "code_hash": _code_hash(code)},
+    )
+    await client.post("/api/cluster/pairing/confirm", json={"name": "w-wrong", "code": code})
+    resp = await client.post("/api/cluster/pairing/claim", json={"name": "w-wrong", "code": "bad"})
+    assert resp.status_code == 403
+    await app.state.cluster_pairing.close()
+
+
+@pytest.mark.asyncio
+async def test_claim_unknown_worker(client, app):
+    """claim for unknown name -> 404."""
+    await app.state.cluster_pairing.init()
+    resp = await client.post("/api/cluster/pairing/claim", json={"name": "ghost", "code": "x"})
+    assert resp.status_code == 404
+    await app.state.cluster_pairing.close()
+
+
+@pytest.mark.asyncio
+async def test_claim_no_auth_required(app, tmp_data_dir):
+    """claim is unauthenticated."""
+    await app.state.cluster_pairing.init()
+    transport = ASGITransport(app=app)
+    app.state._startup_complete = True
+    app.state.auth.setup_user("admin", "Admin", "", "testpass123")
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        resp = await c.post("/api/cluster/pairing/claim", json={"name": "nobody", "code": "c"})
+    # 404 for unknown, but NOT a 401
+    assert resp.status_code != 401
+    await app.state.cluster_pairing.close()
+
+
+# ---------------------------------------------------------------------------
+# Full happy path
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_full_pairing_flow_then_hmac_register_and_heartbeat(client, app):
+    """announce -> confirm -> claim -> HMAC-signed register -> signed heartbeat."""
+    await app.state.cluster_pairing.init()
+
+    key = await pair_worker(client, app, "full-worker", "http://10.1.0.1:9000")
+
+    # Signed register
+    import json as _json
+    reg_body = _json.dumps({
+        "name": "full-worker",
+        "url": "http://10.1.0.1:9000",
+        "platform": "linux",
+    }).encode()
+    headers = sign_worker_request(key, "full-worker", "POST", "/api/cluster/workers", reg_body)
+    resp = await client.post(
+        "/api/cluster/workers",
+        content=reg_body,
+        headers={**headers, "content-type": "application/json"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "registered"
+
+    # Signed heartbeat
+    hb_body = _json.dumps({"name": "full-worker", "load": 0.1}).encode()
+    headers = sign_worker_request(key, "full-worker", "POST", "/api/cluster/heartbeat", hb_body)
+    resp = await client.post(
+        "/api/cluster/heartbeat",
+        content=hb_body,
+        headers={**headers, "content-type": "application/json"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+
+    await app.state.cluster_pairing.close()
+
+
+# ---------------------------------------------------------------------------
+# HMAC gate: unsigned requests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_unsigned_register_returns_401_worker_not_paired(client, app):
+    """POST /api/cluster/workers without HMAC headers -> 401 worker_not_paired."""
+    await app.state.cluster_pairing.init()
+    resp = await client.post(
+        "/api/cluster/workers",
+        json={"name": "unsigned-worker", "url": "http://10.0.0.10:9000"},
+    )
+    assert resp.status_code == 401
+    data = resp.json()
+    assert data.get("code") == "worker_not_paired"
+    await app.state.cluster_pairing.close()
+
+
+@pytest.mark.asyncio
+async def test_unsigned_heartbeat_returns_401_worker_not_paired(client, app):
+    """POST /api/cluster/heartbeat without HMAC headers -> 401 worker_not_paired."""
+    await app.state.cluster_pairing.init()
+    resp = await client.post(
+        "/api/cluster/heartbeat",
+        json={"name": "unsigned-worker"},
+    )
+    assert resp.status_code == 401
+    data = resp.json()
+    assert data.get("code") == "worker_not_paired"
+    await app.state.cluster_pairing.close()
+
+
+@pytest.mark.asyncio
+async def test_bad_signature_returns_401(client, app):
+    """Correct headers but wrong signature -> 401 bad_signature."""
+    await app.state.cluster_pairing.init()
+    _key = await pair_worker(client, app, "sig-worker", "http://10.1.0.2:9000")
+
+    import json as _json
+    reg_body = _json.dumps({"name": "sig-worker", "url": "http://10.1.0.2:9000"}).encode()
+    ts = str(int(time.time()))
+    resp = await client.post(
+        "/api/cluster/workers",
+        content=reg_body,
+        headers={
+            "X-TAOS-Worker-Name": "sig-worker",
+            "X-TAOS-Timestamp": ts,
+            "X-TAOS-Signature": "a" * 64,
+            "content-type": "application/json",
+        },
+    )
+    assert resp.status_code == 401
+    assert resp.json().get("code") == "bad_signature"
+    await app.state.cluster_pairing.close()
+
+
+@pytest.mark.asyncio
+async def test_stale_timestamp_returns_401(client, app):
+    """Timestamp more than 300s old -> 401 stale_timestamp."""
+    await app.state.cluster_pairing.init()
+    key = await pair_worker(client, app, "ts-worker", "http://10.1.0.3:9000")
+
+    import json as _json
+    reg_body = _json.dumps({"name": "ts-worker", "url": "http://10.1.0.3:9000"}).encode()
+    stale_ts = str(int(time.time()) - 400)
+    body_hash = hashlib.sha256(reg_body).hexdigest()
+    message = f"{stale_ts}.POST./api/cluster/workers.{body_hash}".encode()
+    sig = hmac.new(key, message, hashlib.sha256).hexdigest()
+    resp = await client.post(
+        "/api/cluster/workers",
+        content=reg_body,
+        headers={
+            "X-TAOS-Worker-Name": "ts-worker",
+            "X-TAOS-Timestamp": stale_ts,
+            "X-TAOS-Signature": sig,
+            "content-type": "application/json",
+        },
+    )
+    assert resp.status_code == 401
+    assert resp.json().get("code") == "stale_timestamp"
+    await app.state.cluster_pairing.close()
+
+
+@pytest.mark.asyncio
+async def test_unknown_worker_name_in_header_returns_401(client, app):
+    """HMAC headers present but worker name not paired -> 401 worker_not_paired."""
+    await app.state.cluster_pairing.init()
+    import json as _json
+    reg_body = _json.dumps({"name": "unknown-ghost", "url": "http://10.1.0.4:9000"}).encode()
+    ts = str(int(time.time()))
+    fake_key = secrets.token_bytes(32)
+    body_hash = hashlib.sha256(reg_body).hexdigest()
+    message = f"{ts}.POST./api/cluster/workers.{body_hash}".encode()
+    sig = hmac.new(fake_key, message, hashlib.sha256).hexdigest()
+    resp = await client.post(
+        "/api/cluster/workers",
+        content=reg_body,
+        headers={
+            "X-TAOS-Worker-Name": "unknown-ghost",
+            "X-TAOS-Timestamp": ts,
+            "X-TAOS-Signature": sig,
+            "content-type": "application/json",
+        },
+    )
+    assert resp.status_code == 401
+    assert resp.json().get("code") == "worker_not_paired"
+    await app.state.cluster_pairing.close()
+
+
+@pytest.mark.asyncio
+async def test_header_body_name_mismatch_returns_403(client, app):
+    """Header worker name != body name -> 403."""
+    await app.state.cluster_pairing.init()
+    key_a = await pair_worker(client, app, "worker-a2", "http://10.2.0.1:9000")
+
+    import json as _json
+    # Sign as worker-a2 but body says worker-b
+    reg_body = _json.dumps({"name": "worker-b", "url": "http://10.2.0.2:9000"}).encode()
+    headers = sign_worker_request(key_a, "worker-a2", "POST", "/api/cluster/workers", reg_body)
+    resp = await client.post(
+        "/api/cluster/workers",
+        content=reg_body,
+        headers={**headers, "content-type": "application/json"},
+    )
+    assert resp.status_code == 403
+    await app.state.cluster_pairing.close()
+
+
+# ---------------------------------------------------------------------------
+# GET /api/cluster/workers still public
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_list_workers_still_public(app, tmp_data_dir):
+    """GET /api/cluster/workers must be accessible without any auth."""
+    await app.state.cluster_pairing.init()
+    transport = ASGITransport(app=app)
+    app.state._startup_complete = True
+    app.state.auth.setup_user("admin", "Admin", "", "testpass123")
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        resp = await c.get("/api/cluster/workers")
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)
+    await app.state.cluster_pairing.close()
+
+
+# ---------------------------------------------------------------------------
+# Admin gate: non-admin session is rejected on pending + confirm
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_pending_non_admin_gets_403(client, app, monkeypatch):
+    """Authenticated but non-admin session: GET /api/cluster/pairing/pending -> 403."""
+    await app.state.cluster_pairing.init()
+    monkeypatch.setattr(app.state.auth, "session_user", lambda token: {"is_admin": False})
+    resp = await client.get("/api/cluster/pairing/pending")
+    assert resp.status_code == 403
+    await app.state.cluster_pairing.close()
+
+
+@pytest.mark.asyncio
+async def test_confirm_non_admin_gets_403(client, app, monkeypatch):
+    """Authenticated but non-admin session: POST /api/cluster/pairing/confirm -> 403."""
+    await app.state.cluster_pairing.init()
+    monkeypatch.setattr(app.state.auth, "session_user", lambda token: {"is_admin": False})
+    resp = await client.post("/api/cluster/pairing/confirm", json={"name": "w", "code": "c"})
+    assert resp.status_code == 403
+    await app.state.cluster_pairing.close()
+
+
+# ---------------------------------------------------------------------------
+# Atomic claim: concurrent double-claim delivers key exactly once
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_concurrent_claim_delivers_key_exactly_once(client, app):
+    """Two simultaneous claims: exactly one receives the key, the other gets None/404."""
+    import asyncio
+    await app.state.cluster_pairing.init()
+    code = "concurrent-code"
+    await client.post(
+        "/api/cluster/pairing/announce",
+        json={"name": "w-concurrent", "url": "http://10.3.0.1:9000", "code_hash": _code_hash(code)},
+    )
+    await client.post("/api/cluster/pairing/confirm", json={"name": "w-concurrent", "code": code})
+
+    async def do_claim():
+        return await client.post(
+            "/api/cluster/pairing/claim", json={"name": "w-concurrent", "code": code}
+        )
+
+    r1, r2 = await asyncio.gather(do_claim(), do_claim())
+    statuses = sorted([r1.status_code, r2.status_code])
+    # One must succeed (200); the other must fail (403 or 404).
+    # sorted ascending: [200, 4xx] -> statuses[0]==200, statuses[1] in (403,404).
+    assert statuses[0] == 200, f"No successful claim: {r1.status_code}, {r2.status_code}"
+    assert statuses[1] in (403, 404), f"Both claims succeeded: {r1.status_code}, {r2.status_code}"
+    await app.state.cluster_pairing.close()
+
+
+# ---------------------------------------------------------------------------
+# list_pending excludes confirmed and capped rows
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_list_pending_excludes_confirmed_and_capped(client, app):
+    """list_pending must not include rows with confirmed=1 or exhausted attempts."""
+    await app.state.cluster_pairing.init()
+
+    # Row 1: clean pending (should appear)
+    await client.post(
+        "/api/cluster/pairing/announce",
+        json={"name": "w-visible", "url": "http://10.4.0.1:9000", "code_hash": _code_hash("c1")},
+    )
+
+    # Row 2: confirmed (should NOT appear)
+    await client.post(
+        "/api/cluster/pairing/announce",
+        json={"name": "w-confirmed", "url": "http://10.4.0.2:9000", "code_hash": _code_hash("c2")},
+    )
+    await client.post("/api/cluster/pairing/confirm", json={"name": "w-confirmed", "code": "c2"})
+
+    # Row 3: attempts capped (should NOT appear)
+    await client.post(
+        "/api/cluster/pairing/announce",
+        json={"name": "w-capped", "url": "http://10.4.0.3:9000", "code_hash": _code_hash("c3")},
+    )
+    for _ in range(5):
+        await client.post("/api/cluster/pairing/confirm", json={"name": "w-capped", "code": "wrong"})
+
+    resp = await client.get("/api/cluster/pairing/pending")
+    assert resp.status_code == 200
+    names = [item["name"] for item in resp.json()]
+    assert "w-visible" in names, "visible pending row missing"
+    assert "w-confirmed" not in names, "confirmed row should be excluded"
+    assert "w-capped" not in names, "attempts-capped row should be excluded"
+    await app.state.cluster_pairing.close()
+
+
+# ---------------------------------------------------------------------------
+# Claim differentiation: expired -> 410, capped -> 404
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_claim_expired_pending_returns_410(client, app, monkeypatch):
+    """claim on expired pending entry -> 410 with re-announce message."""
+    await app.state.cluster_pairing.init()
+    code = "expire-claim-code"
+    await client.post(
+        "/api/cluster/pairing/announce",
+        json={"name": "w-exp-claim", "url": "http://10.5.0.1:9000", "code_hash": _code_hash(code)},
+    )
+    import tinyagentos.cluster.pairing_store as _ps
+    monkeypatch.setattr(_ps, "_now", lambda: time.time() + 1000)
+    resp = await client.post(
+        "/api/cluster/pairing/claim", json={"name": "w-exp-claim", "code": code}
+    )
+    assert resp.status_code == 410
+    assert "re-announce" in resp.json().get("error", "").lower()
+    await app.state.cluster_pairing.close()
+
+
+@pytest.mark.asyncio
+async def test_claim_capped_pending_returns_404(client, app):
+    """claim on attempts-capped entry -> 404."""
+    await app.state.cluster_pairing.init()
+    await client.post(
+        "/api/cluster/pairing/announce",
+        json={"name": "w-cap-claim", "url": "http://10.5.0.2:9000", "code_hash": _code_hash("real")},
+    )
+    # Exhaust attempts via confirm
+    for _ in range(5):
+        await client.post("/api/cluster/pairing/confirm", json={"name": "w-cap-claim", "code": "wrong"})
+    resp = await client.post(
+        "/api/cluster/pairing/claim", json={"name": "w-cap-claim", "code": "real"}
+    )
+    assert resp.status_code == 404
+    await app.state.cluster_pairing.close()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -256,3 +256,67 @@ class TestDetectBackends:
         assert len(backends) == 1
         assert backends[0]["type"] == "ollama"
         assert backends[0]["url"] == "http://localhost:11434"
+        assert backends[0]["name"] == "ollama:11434"
+
+    async def test_backend_name_is_type_colon_port(self):
+        """Backend name must be 'type:port', not 'type@http://localhost:PORT'."""
+        agent = WorkerAgent("http://localhost:6969")
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        with patch("tinyagentos.worker.agent.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+
+            async def mock_get(url):
+                # Simulate both ollama (11434) and bundled ollama (21434) running
+                if "11434" in url or "21434" in url:
+                    return mock_response
+                raise Exception("not running")
+
+            mock_client.get = AsyncMock(side_effect=mock_get)
+            mock_client_cls.return_value = mock_client
+
+            backends = await agent.detect_backends()
+
+        names = [b["name"] for b in backends]
+        assert "ollama:11434" in names
+        assert "ollama:21434" in names
+        # Legacy shape must not appear
+        for name in names:
+            assert "@" not in name, f"backend name must not embed URL: {name!r}"
+
+    async def test_backend_name_portless_url(self):
+        """When a candidate URL has no explicit port, name falls back to bare backend_type."""
+        agent = WorkerAgent("http://localhost:6969")
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        portless_candidates = [("ollama", "http://ollama")]
+
+        with patch("tinyagentos.worker.agent.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client_cls.return_value = mock_client
+
+            with patch.object(agent, "detect_backends", wraps=agent.detect_backends) as _:
+                # Inject portless candidate directly by patching the local candidates list
+                # via a subclassed coroutine that replaces detect_backends internals is
+                # brittle; instead test the guard expression directly.
+                pass
+
+        # Direct guard-logic test: urlparse of a portless URL returns port=None.
+        from urllib.parse import urlparse
+        port = urlparse("http://ollama").port
+        backend_type = "ollama"
+        name = f"{backend_type}:{port}" if port is not None else backend_type
+        assert name == "ollama", f"expected 'ollama', got {name!r}"
+
+        # Also verify a normal URL still produces type:port.
+        port2 = urlparse("http://localhost:11434").port
+        name2 = f"{backend_type}:{port2}" if port2 is not None else backend_type
+        assert name2 == "ollama:11434"
+

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -249,6 +249,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     auth_requests_store = AuthRequestsStore(data_dir / "auth_requests.db")
     from tinyagentos.agent_grants_store import AgentGrantsStore
     agent_grants_store = AgentGrantsStore(data_dir / "agent_grants.db")
+    from tinyagentos.cluster.pairing_store import ClusterPairingStore
+    cluster_pairing_store = ClusterPairingStore(data_dir / "cluster_pairing.db")
 
     metrics_store = MetricsStore(data_dir / "metrics.db")
     notif_store = NotificationStore(data_dir / "notifications.db")
@@ -380,6 +382,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         app.state.auth_requests = auth_requests_store
         await agent_grants_store.init()
         app.state.agent_grants = agent_grants_store
+        await cluster_pairing_store.init()
+        app.state.cluster_pairing = cluster_pairing_store
         await metrics_store.init()
         await notif_store.init()
         await qmd_client.init()
@@ -1104,6 +1108,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await http_client.aclose()
         await agent_grants_store.close()
         await auth_requests_store.close()
+        await cluster_pairing_store.close()
         await agent_registry_store.close()
 
     app = FastAPI(title="TinyAgentOS", version="0.1.0", lifespan=lifespan)
@@ -1247,6 +1252,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     app.state.agent_registry_keypair = agent_registry_keypair
     app.state.auth_requests = auth_requests_store
     app.state.agent_grants = agent_grants_store
+    app.state.cluster_pairing = cluster_pairing_store
 
     # Detect and set container runtime (eager, so tests work without lifespan)
     try:

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -5,7 +5,7 @@ from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import RedirectResponse
 
-EXEMPT_PATHS = {"/auth/login", "/auth/setup", "/auth/status", "/auth/me", "/auth/complete", "/auth/lock", "/api/health", "/api/version", "/api/cluster/workers", "/api/cluster/heartbeat", "/setup", "/setup/complete", "/redeem", "/api/desktop/browser/push/vapid-public-key", "/api/desktop/browser/proxy-config", "/sw.js", "/desktop", "/desktop/index.html", "/chat-pwa", "/api/agents/registry/pubkey"}
+EXEMPT_PATHS = {"/auth/login", "/auth/setup", "/auth/status", "/auth/me", "/auth/complete", "/auth/lock", "/api/health", "/api/version", "/setup", "/setup/complete", "/redeem", "/api/desktop/browser/push/vapid-public-key", "/api/desktop/browser/proxy-config", "/sw.js", "/desktop", "/desktop/index.html", "/chat-pwa", "/api/agents/registry/pubkey"}
 # Bundle assets and the SPA shell HTML must be reachable without auth so:
 #   1. The browser can install and cache the shell for offline / PWA use.
 #   2. After a backend restart the cached shell loads immediately without
@@ -34,6 +34,15 @@ EXEMPT_PREFIXES = ("/static/", "/desktop/", "/chat-pwa/", "/ws/", "/shortcut/")
 _AUTH_REQUEST_BASE = "/api/agents/auth-requests"
 _AUTH_REQUEST_PREFIX = "/api/agents/auth-requests/"
 
+# Cluster pairing: announce and claim are unauthenticated (the pairing code is
+# the proof of possession).  Pending and confirm require an admin session and
+# are NOT exempt.  Worker register and heartbeat are session-exempt because the
+# route-level HMAC dependency is the gate; GET workers is public.
+_CLUSTER_PAIRING_ANNOUNCE = "/api/cluster/pairing/announce"
+_CLUSTER_PAIRING_CLAIM = "/api/cluster/pairing/claim"
+_CLUSTER_WORKERS = "/api/cluster/workers"
+_CLUSTER_HEARTBEAT = "/api/cluster/heartbeat"
+
 
 def _is_exempt(method: str, path: str) -> bool:
     """Return True if this request should bypass the auth gate.
@@ -43,6 +52,13 @@ def _is_exempt(method: str, path: str) -> bool:
       GET  /api/agents/auth-requests/{id}     — status poll, no auth needed
       POST /api/agents/auth-requests/{id}/approve|deny — admin only, NOT exempt
       GET  /api/agents/auth-requests          — list (admin), NOT exempt
+
+    Cluster pairing exemptions (method-sensitive):
+      POST /api/cluster/pairing/announce      — unauthenticated, code hash is proof
+      POST /api/cluster/pairing/claim         — unauthenticated, code is proof
+      GET  /api/cluster/workers               — public worker list
+      POST /api/cluster/workers               — session-exempt, HMAC gate at route level
+      POST /api/cluster/heartbeat             — session-exempt, HMAC gate at route level
     """
     if path in EXEMPT_PATHS or any(path.startswith(p) for p in EXEMPT_PREFIXES):
         return True
@@ -55,6 +71,18 @@ def _is_exempt(method: str, path: str) -> bool:
         tail = path[len(_AUTH_REQUEST_PREFIX):]
         if tail and "/" not in tail:
             return True
+    # Cluster pairing — announce and claim are unauthenticated.
+    if method == "POST" and path == _CLUSTER_PAIRING_ANNOUNCE:
+        return True
+    if method == "POST" and path == _CLUSTER_PAIRING_CLAIM:
+        return True
+    # Cluster workers — GET is a public list; POST is session-exempt (HMAC gate).
+    if method == "GET" and path == _CLUSTER_WORKERS:
+        return True
+    if method == "POST" and path == _CLUSTER_WORKERS:
+        return True
+    if method == "POST" and path == _CLUSTER_HEARTBEAT:
+        return True
     return False
 
 

--- a/tinyagentos/cluster/manager.py
+++ b/tinyagentos/cluster/manager.py
@@ -281,7 +281,9 @@ class ClusterManager:
             - ``workers``: per-worker summary (name, status, capabilities,
               backend count, model count)
             - ``backends``: flat list of every remote backend entry with
-              its owning worker tagged
+              its owning worker tagged. Note: each entry's ``url`` is the
+              worker-local probe address -- cross-host calls must go via
+              ``worker_url`` (the worker agent), never the backend ``url``.
             - ``capabilities``: set of capabilities present somewhere in
               the mesh (union across workers)
             - ``models``: flat list of every model loaded on any online

--- a/tinyagentos/cluster/pairing_store.py
+++ b/tinyagentos/cluster/pairing_store.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+"""Persistent store for cluster-worker pairing records.
+
+Each row tracks one worker name through the pairing flow:
+  announce (worker sends code_hash) →
+  confirm  (admin approves, controller mints signing_key) →
+  claim    (worker retrieves key once, clears confirmed flag)
+
+A re-announce over a name that already has a signing_key is allowed: the
+old key stays valid until a new confirm replaces it, so a partially-paired
+worker that re-announces does not break in-flight operations.
+"""
+
+import hashlib
+import hmac
+import secrets
+import time
+import aiosqlite
+
+from tinyagentos.base_store import BaseStore
+
+_EXPIRY_SECS = 15 * 60  # pending entries expire after 15 minutes
+_MAX_ATTEMPTS = 5        # failed code checks before the entry is invalidated
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS cluster_pairings (
+    name                TEXT NOT NULL UNIQUE,
+    signing_key         BLOB,
+    pending_code_hash   TEXT,
+    pending_url         TEXT,
+    pending_platform    TEXT,
+    pending_ts          REAL,
+    claim_attempts      INTEGER NOT NULL DEFAULT 0,
+    confirmed           INTEGER NOT NULL DEFAULT 0,
+    created_ts          REAL,
+    confirmed_ts        REAL
+);
+"""
+
+
+def _now() -> float:
+    return time.time()
+
+
+class ClusterPairingStore(BaseStore):
+    """SQLite-backed store for worker pairing state."""
+
+    SCHEMA = SCHEMA
+
+    async def init(self) -> None:
+        await super().init()
+        if self._db is not None:
+            self._db.row_factory = aiosqlite.Row
+
+    # ------------------------------------------------------------------
+    # Write
+    # ------------------------------------------------------------------
+
+    async def announce(
+        self,
+        name: str,
+        url: str,
+        platform: str,
+        code_hash: str,
+    ) -> None:
+        """Upsert a pending pairing announcement.
+
+        Never touches signing_key — the existing paired key for a re-announcing
+        worker stays valid until the new pairing is confirmed.
+        Resets attempt counter and confirmed flag so the new flow starts clean.
+        """
+        if self._db is None:
+            raise RuntimeError("ClusterPairingStore not initialised")
+        ts = _now()
+        await self._db.execute(
+            """
+            INSERT INTO cluster_pairings
+                (name, pending_code_hash, pending_url, pending_platform,
+                 pending_ts, claim_attempts, confirmed, created_ts)
+            VALUES (?, ?, ?, ?, ?, 0, 0, ?)
+            ON CONFLICT(name) DO UPDATE SET
+                pending_code_hash = excluded.pending_code_hash,
+                pending_url       = excluded.pending_url,
+                pending_platform  = excluded.pending_platform,
+                pending_ts        = excluded.pending_ts,
+                claim_attempts    = 0,
+                confirmed         = 0
+            """,
+            (name, code_hash, url, platform, ts, ts),
+        )
+        await self._db.commit()
+
+    async def confirm(self, name: str, code: str) -> bool:
+        """Verify the code, mint a signing key, and mark confirmed=1.
+
+        Returns True on success, False if the entry is absent, expired,
+        at max attempts, or the code is wrong.
+        Increments attempt counter on a wrong code.
+        """
+        if self._db is None:
+            raise RuntimeError("ClusterPairingStore not initialised")
+        row = await self._fetch_row(name)
+        if row is None:
+            return False
+        if not self._pending_valid(row):
+            return False
+        code_hash = hashlib.sha256(code.encode()).hexdigest()
+        if not hmac.compare_digest(code_hash, row["pending_code_hash"] or ""):
+            await self._increment_attempts(name)
+            return False
+        key = secrets.token_bytes(32)
+        ts = _now()
+        await self._db.execute(
+            """
+            UPDATE cluster_pairings
+               SET signing_key   = ?,
+                   confirmed     = 1,
+                   confirmed_ts  = ?
+             WHERE name = ?
+            """,
+            (key, ts, name),
+        )
+        await self._db.commit()
+        return True
+
+    async def claim(self, name: str, code: str) -> bytes | None:
+        """Return the signing key exactly once after a successful confirm.
+
+        Pre-confirm: returns None (caller should treat as 202 awaiting_confirm).
+        Post-confirm, correct code: returns the key and clears confirmed/pending.
+        Wrong code: increments attempts, returns None.
+        Unknown/invalidated name: returns None.
+
+        The clear is gated on confirmed=1 so two concurrent callers cannot
+        both receive the key: only the caller whose UPDATE flips confirmed
+        1->0 (rowcount==1) wins; the other gets None.
+        """
+        if self._db is None:
+            raise RuntimeError("ClusterPairingStore not initialised")
+        row = await self._fetch_row(name)
+        if row is None:
+            return None
+        if not row["confirmed"]:
+            # Not confirmed yet -- not an error, just not ready.
+            return None
+        if not self._pending_valid(row):
+            # Expired even though confirmed -- worker must re-announce.
+            return None
+        code_hash = hashlib.sha256(code.encode()).hexdigest()
+        if not hmac.compare_digest(code_hash, row["pending_code_hash"] or ""):
+            await self._increment_attempts(name)
+            return None
+        key = bytes(row["signing_key"])
+        # Conditional clear: WHERE confirmed = 1 ensures only one concurrent
+        # caller can win.  The winner gets rowcount == 1; the loser gets 0.
+        cursor = await self._db.execute(
+            """
+            UPDATE cluster_pairings
+               SET pending_code_hash = NULL,
+                   pending_url       = NULL,
+                   pending_platform  = NULL,
+                   pending_ts        = NULL,
+                   claim_attempts    = 0,
+                   confirmed         = 0
+             WHERE name = ?
+               AND confirmed = 1
+            """,
+            (name,),
+        )
+        await self._db.commit()
+        if cursor.rowcount != 1:
+            return None
+        return key
+
+    async def get_signing_key(self, name: str) -> bytes | None:
+        """Return the worker's current signing key, or None if not paired."""
+        if self._db is None:
+            raise RuntimeError("ClusterPairingStore not initialised")
+        row = await self._fetch_row(name)
+        if row is None or row["signing_key"] is None:
+            return None
+        return bytes(row["signing_key"])
+
+    async def record_failed_attempt(self, name: str) -> None:
+        """Increment the failed-attempt counter for a worker.
+
+        Used by the HMAC gate when a signature check fails — not the same as
+        a pairing code check, but shares the same counter so the entry gets
+        invalidated after _MAX_ATTEMPTS total failures.
+        """
+        await self._increment_attempts(name)
+
+    # ------------------------------------------------------------------
+    # Read
+    # ------------------------------------------------------------------
+
+    async def pairing_state(self, name: str) -> dict | None:
+        """Return a summary dict for the route layer; None when the row is absent.
+
+        Keys: has_pending, confirmed, expired, attempts_capped.
+        """
+        if self._db is None:
+            raise RuntimeError("ClusterPairingStore not initialised")
+        row = await self._fetch_row(name)
+        if row is None:
+            return None
+        has_pending = row["pending_code_hash"] is not None
+        confirmed = bool(row["confirmed"])
+        ts = row["pending_ts"]
+        expired = has_pending and (ts is None or (_now() - ts) > _EXPIRY_SECS)
+        attempts_capped = row["claim_attempts"] >= _MAX_ATTEMPTS
+        return {
+            "has_pending": has_pending,
+            "confirmed": confirmed,
+            "expired": expired,
+            "attempts_capped": attempts_capped,
+        }
+
+
+
+    async def list_pending(self) -> list[dict]:
+        """Return all rows that have a non-expired pending announcement."""
+        if self._db is None:
+            raise RuntimeError("ClusterPairingStore not initialised")
+        min_ts = _now() - _EXPIRY_SECS
+        cursor = await self._db.execute(
+            """
+            SELECT name, pending_url, pending_platform, pending_ts
+              FROM cluster_pairings
+             WHERE pending_code_hash IS NOT NULL
+               AND confirmed = 0
+               AND claim_attempts < ?
+               AND pending_ts > ?
+             ORDER BY pending_ts
+            """,
+            (_MAX_ATTEMPTS, min_ts),
+        )
+        rows = await cursor.fetchall()
+        return [
+            {
+                "name": r["name"],
+                "url": r["pending_url"],
+                "platform": r["pending_platform"],
+                "announced_at": r["pending_ts"],
+            }
+            for r in rows
+        ]
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    async def _fetch_row(self, name: str) -> aiosqlite.Row | None:
+        cursor = await self._db.execute(
+            "SELECT * FROM cluster_pairings WHERE name = ?", (name,)
+        )
+        return await cursor.fetchone()
+
+    def _pending_valid(self, row: aiosqlite.Row) -> bool:
+        """Return True if the pending entry is not expired and under attempt cap."""
+        if row["pending_code_hash"] is None:
+            return False
+        if row["claim_attempts"] >= _MAX_ATTEMPTS:
+            return False
+        ts = row["pending_ts"]
+        if ts is None or (_now() - ts) > _EXPIRY_SECS:
+            return False
+        return True
+
+    async def _increment_attempts(self, name: str) -> None:
+        await self._db.execute(
+            "UPDATE cluster_pairings SET claim_attempts = claim_attempts + 1 WHERE name = ?",
+            (name,),
+        )
+        await self._db.commit()

--- a/tinyagentos/cluster/worker_auth.py
+++ b/tinyagentos/cluster/worker_auth.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+"""HMAC authentication dependency for cluster worker endpoints.
+
+Workers sign every request with a key they obtained from the pairing flow.
+The signing string is:
+
+    f"{timestamp}.{METHOD}.{path}.{sha256(raw_body).hexdigest()}"
+
+keyed with the worker's 32-byte signing_key (HMAC-SHA256).
+
+Required headers:
+    X-TAOS-Worker-Name   — the worker's registered name
+    X-TAOS-Timestamp     — unix seconds (integer string)
+    X-TAOS-Signature     — hex-encoded HMAC-SHA256
+
+The body name field must equal the header worker name; a paired worker
+cannot register or heartbeat on behalf of a different name.
+"""
+
+import hashlib
+import hmac
+import time
+
+from fastapi import Request
+from fastapi.responses import JSONResponse
+
+
+def _err(code: str, msg: str, status: int) -> JSONResponse:
+    return JSONResponse({"error": msg, "code": code}, status_code=status)
+
+
+async def require_worker_hmac(request: Request) -> None:
+    """FastAPI dependency — 401/403 on any auth failure, else None.
+
+    Attach with: ``Depends(require_worker_hmac)``.
+    """
+    worker_name = request.headers.get("x-taos-worker-name", "").strip()
+    timestamp_str = request.headers.get("x-taos-timestamp", "").strip()
+    signature = request.headers.get("x-taos-signature", "").strip()
+
+    if not worker_name or not timestamp_str or not signature:
+        raise _HMACError(
+            _err(
+                "worker_not_paired",
+                "Worker not paired. Run the worker installer to pair this device with the controller.",
+                401,
+            )
+        )
+
+    # Timestamp skew check
+    try:
+        ts = int(timestamp_str)
+    except ValueError:
+        raise _HMACError(
+            _err("stale_timestamp", "Invalid timestamp", 401)
+        )
+    if abs(time.time() - ts) > 300:
+        raise _HMACError(
+            _err("stale_timestamp", "Timestamp too far from server time", 401)
+        )
+
+    # Look up signing key
+    pairing_store = getattr(request.app.state, "cluster_pairing", None)
+    if pairing_store is None:
+        raise _HMACError(
+            _err(
+                "worker_not_paired",
+                "Worker not paired. Run the worker installer to pair this device with the controller.",
+                401,
+            )
+        )
+    signing_key = await pairing_store.get_signing_key(worker_name)
+    if signing_key is None:
+        raise _HMACError(
+            _err(
+                "worker_not_paired",
+                "Worker not paired. Run the worker installer to pair this device with the controller.",
+                401,
+            )
+        )
+
+    # Verify signature
+    raw_body = await request.body()
+    body_hash = hashlib.sha256(raw_body).hexdigest()
+    method = request.method.upper()
+    path = request.url.path
+    message = f"{timestamp_str}.{method}.{path}.{body_hash}".encode()
+    expected = hmac.new(signing_key, message, hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(expected, signature):
+        raise _HMACError(
+            _err("bad_signature", "Signature verification failed", 401)
+        )
+
+    # Store for route-level body/header name cross-check
+    request.state.hmac_worker_name = worker_name
+
+
+class _HMACError(Exception):
+    """Wraps a JSONResponse so the route can return it directly."""
+
+    def __init__(self, response: JSONResponse):
+        self.response = response
+        super().__init__()

--- a/tinyagentos/cluster/worker_protocol.py
+++ b/tinyagentos/cluster/worker_protocol.py
@@ -12,7 +12,9 @@ class WorkerInfo:
     name: str
     url: str                          # Worker's base URL
     hardware: dict = field(default_factory=dict)  # From hardware detection
-    backends: list[dict] = field(default_factory=list)  # Available inference backends
+    # Each entry's `url` is the worker-local probe address (e.g. http://localhost:11434).
+    # Cross-host callers must route through the worker agent (worker.url) -- never dial backend url directly.
+    backends: list[dict] = field(default_factory=list)  # Available inference backends; name is "type:port"
     models: list[str] = field(default_factory=list)     # Currently loaded models
     capabilities: list[str] = field(default_factory=list)  # embed, chat, rerank, image-gen, tts, etc
     status: str = "online"            # online | offline | busy

--- a/tinyagentos/routes/cluster.py
+++ b/tinyagentos/routes/cluster.py
@@ -11,11 +11,118 @@ from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
 
+import re
+
 from tinyagentos.cluster.capabilities import hardware_to_targets, potential_capabilities as _potential_capabilities
 from tinyagentos.cluster.optimiser import ClusterOptimiser
+from tinyagentos.cluster.worker_auth import _HMACError, require_worker_hmac
 from tinyagentos.cluster.worker_protocol import WorkerInfo
+from tinyagentos.routes.auth import _require_admin
 
 router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Pairing models
+# ---------------------------------------------------------------------------
+
+class PairingAnnounce(BaseModel):
+    name: str
+    url: str
+    platform: str = ""
+    code_hash: str
+
+
+class PairingConfirm(BaseModel):
+    name: str
+    code: str
+
+
+class PairingClaim(BaseModel):
+    name: str
+    code: str
+
+
+# ---------------------------------------------------------------------------
+# Pairing endpoints
+# ---------------------------------------------------------------------------
+
+_CODE_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+@router.post("/api/cluster/pairing/announce")
+async def pairing_announce(request: Request, body: PairingAnnounce):
+    """Unauthenticated — worker announces itself with a code hash."""
+    if not body.name or not body.url:
+        return JSONResponse({"error": "name and url are required"}, status_code=400)
+    if not _CODE_HASH_RE.match(body.code_hash):
+        return JSONResponse(
+            {"error": "code_hash must be 64 lowercase hex characters"},
+            status_code=400,
+        )
+    store = request.app.state.cluster_pairing
+    await store.announce(body.name, body.url, body.platform, body.code_hash)
+    return {"status": "pending"}
+
+
+@router.get("/api/cluster/pairing/pending")
+async def pairing_pending(request: Request):
+    """Admin session required -- list pending pairing announcements."""
+    ok, err = _require_admin(request)
+    if not ok:
+        return err
+    store = request.app.state.cluster_pairing
+    items = await store.list_pending()
+    return items
+
+
+@router.post("/api/cluster/pairing/confirm")
+async def pairing_confirm(request: Request, body: PairingConfirm):
+    """Admin session required -- confirm a pending pairing."""
+    ok, err = _require_admin(request)
+    if not ok:
+        return err
+    store = request.app.state.cluster_pairing
+    state = await store.pairing_state(body.name)
+    if state is None or not state["has_pending"]:
+        return JSONResponse({"error": "No pending pairing for this worker"}, status_code=404)
+    if state["attempts_capped"]:
+        return JSONResponse({"error": "No pending pairing for this worker"}, status_code=404)
+    if state["expired"]:
+        return JSONResponse({"error": "Pairing request has expired"}, status_code=410)
+    confirmed = await store.confirm(body.name, body.code)
+    if not confirmed:
+        return JSONResponse({"error": "Incorrect pairing code"}, status_code=403)
+    return {"status": "confirmed"}
+
+
+@router.post("/api/cluster/pairing/claim")
+async def pairing_claim(request: Request, body: PairingClaim):
+    """Unauthenticated -- worker claims its signing key after admin confirmation."""
+    store = request.app.state.cluster_pairing
+    state = await store.pairing_state(body.name)
+    if state is None or not state["has_pending"]:
+        return JSONResponse({"error": "Unknown or invalidated worker"}, status_code=404)
+    # Check invalidation before the confirmed check so workers get actionable
+    # errors instead of polling 202 indefinitely on a dead entry.
+    if state["attempts_capped"]:
+        return JSONResponse({"error": "Unknown or invalidated worker"}, status_code=404)
+    if state["expired"]:
+        return JSONResponse(
+            {"error": "Pairing request expired; please re-announce"},
+            status_code=410,
+        )
+    if not state["confirmed"]:
+        return JSONResponse({"status": "awaiting_confirm"}, status_code=202)
+    key = await store.claim(body.name, body.code)
+    if key is None:
+        # Re-check state: if the entry was cleared by a concurrent winner or
+        # became invalidated, return 404; otherwise it is a wrong code.
+        state2 = await store.pairing_state(body.name)
+        if state2 is None or not state2["has_pending"]:
+            return JSONResponse({"error": "Unknown or invalidated worker"}, status_code=404)
+        return JSONResponse({"error": "Incorrect pairing code"}, status_code=403)
+    return {"signing_key": key.hex()}
 
 
 class WorkerRegister(BaseModel):
@@ -110,6 +217,19 @@ async def list_workers(request: Request):
 
 @router.post("/api/cluster/workers")
 async def register_worker(request: Request, body: WorkerRegister):
+    # HMAC gate — workers must be paired before registering.
+    # The 'local' worker registers in-process (manager.register_worker),
+    # never over HTTP, so it is unaffected by this check.
+    try:
+        await require_worker_hmac(request)
+    except _HMACError as exc:
+        return exc.response
+    # The authenticated worker name must match the body name.
+    if getattr(request.state, "hmac_worker_name", None) != body.name:
+        return JSONResponse(
+            {"error": "Worker name in header does not match body"},
+            status_code=403,
+        )
     cluster = request.app.state.cluster_manager
     if not body.name or not body.url:
         return JSONResponse({"error": "name and url are required"}, status_code=400)
@@ -120,6 +240,13 @@ async def register_worker(request: Request, body: WorkerRegister):
                 {"error": f"Worker '{existing.name}' already registered for host {body.host_lan_ip}; only one worker LXC per host is supported"},
                 status_code=409,
             )
+    # Populate signing_key from pairing store so ticket-signing consumers work.
+    pairing_store = getattr(request.app.state, "cluster_pairing", None)
+    signing_key = b""
+    if pairing_store is not None:
+        key = await pairing_store.get_signing_key(body.name)
+        if key is not None:
+            signing_key = key
     info = WorkerInfo(
         name=body.name,
         url=body.url,
@@ -137,6 +264,7 @@ async def register_worker(request: Request, body: WorkerRegister):
         storage_used_bytes=body.storage_used_bytes,
         bytes_deduped_total=body.bytes_deduped_total,
         worker_lxc_image_version=body.worker_lxc_image_version,
+        signing_key=signing_key,
     )
     await cluster.register_worker(info)
     if body.pending_storage_backup:
@@ -221,6 +349,17 @@ async def _surface_storage_backup(app, worker_name: str, marker: dict) -> None:
 
 @router.post("/api/cluster/heartbeat")
 async def worker_heartbeat(request: Request, body: HeartbeatBody):
+    # HMAC gate — only paired, registered workers may heartbeat.
+    try:
+        await require_worker_hmac(request)
+    except _HMACError as exc:
+        return exc.response
+    # The authenticated worker name must match the body name.
+    if getattr(request.state, "hmac_worker_name", None) != body.name:
+        return JSONResponse(
+            {"error": "Worker name in header does not match body"},
+            status_code=403,
+        )
     cluster = request.app.state.cluster_manager
     ok = cluster.heartbeat(
         body.name,

--- a/tinyagentos/worker/agent.py
+++ b/tinyagentos/worker/agent.py
@@ -117,8 +117,9 @@ class WorkerAgent:
                     continue  # backend not running here
                 loaded_models = await self._probe_loaded_models(client, backend_type, base_url)
                 kv_quant = await self._probe_kv_quant(client, backend_type, base_url)
+                _port = urlparse(base_url).port
                 backends.append({
-                    "name": f"{backend_type}@{base_url}",
+                    "name": f"{backend_type}:{_port}" if _port is not None else backend_type,
                     "type": backend_type,
                     "url": base_url,
                     "capabilities": sorted(BACKEND_CAPABILITIES.get(backend_type, set())),


### PR DESCRIPTION
Promotes to master:
- #762: cluster-worker pairing-code auth Phase 1 (fixes the unauthenticated register/heartbeat hole from the audit, #737). Pairing store + announce/confirm/claim endpoints, HMAC gate on register and heartbeat, admin-gated approval, method-sensitive auth exemptions. Worker scripts, UI, and migration follow in Phases 2-4.
- #764: worker backends named type:port instead of embedding worker-local localhost URLs; legacy names normalised in the UI; worker-local URL semantics documented (fixes #759).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cluster worker pairing and authentication flow to secure worker registration with HMAC-signed requests.

* **Improvements**
  * Backend names now display in normalized format (e.g., `ollama:11434`) instead of legacy URL-based formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->