### PR TITLE
fix(install): re-run update path trips git dubious-ownership after the taos chown

### DIFF
--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -980,14 +980,20 @@ if [[ ! -d "$INSTALL_DIR/.git" ]]; then
     git clone --depth 1 --branch "$BRANCH" "$REPO" "$INSTALL_DIR"
 else
     log "updating existing checkout"
-    # The repo is chowned to the 'taos' service user at the end of every
-    # install, so a re-run (running as root) trips git's dubious-ownership
-    # check.  Scope a safe.directory exception to these two commands rather
-    # than polluting global git config; the post-install chown re-fixes the
-    # ownership of anything these create.
-    (cd "$INSTALL_DIR" \
-        && git -c safe.directory="$INSTALL_DIR" fetch --depth 1 origin "$BRANCH" \
-        && git -c safe.directory="$INSTALL_DIR" reset --hard "origin/$BRANCH")
+    # The repo is chowned to the 'taos' service user at the end of a system
+    # install, so a re-run (as root) trips git's dubious-ownership check.
+    # That check is guarding a real privilege-escalation path: running git as
+    # root inside a tree the unprivileged 'taos' user can write to would let a
+    # planted .git/config or hook execute as root.  So drop to the owning user
+    # for the update instead of overriding the check.  When the tree is already
+    # root-owned, or we are not root (user-mode / macOS install), run directly.
+    _repo_owner="$(stat -c '%U' "$INSTALL_DIR" 2>/dev/null || stat -f '%Su' "$INSTALL_DIR" 2>/dev/null || echo "")"
+    if [[ "$(id -u)" == "0" && -n "$_repo_owner" && "$_repo_owner" != "root" ]]; then
+        sudo -u "$_repo_owner" git -C "$INSTALL_DIR" fetch --depth 1 origin "$BRANCH" \
+            && sudo -u "$_repo_owner" git -C "$INSTALL_DIR" reset --hard "origin/$BRANCH"
+    else
+        (cd "$INSTALL_DIR" && git fetch --depth 1 origin "$BRANCH" && git reset --hard "origin/$BRANCH")
+    fi
 fi
 
 cd "$INSTALL_DIR"

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -980,7 +980,14 @@ if [[ ! -d "$INSTALL_DIR/.git" ]]; then
     git clone --depth 1 --branch "$BRANCH" "$REPO" "$INSTALL_DIR"
 else
     log "updating existing checkout"
-    (cd "$INSTALL_DIR" && git fetch --depth 1 origin "$BRANCH" && git reset --hard "origin/$BRANCH")
+    # The repo is chowned to the 'taos' service user at the end of every
+    # install, so a re-run (running as root) trips git's dubious-ownership
+    # check.  Scope a safe.directory exception to these two commands rather
+    # than polluting global git config; the post-install chown re-fixes the
+    # ownership of anything these create.
+    (cd "$INSTALL_DIR" \
+        && git -c safe.directory="$INSTALL_DIR" fetch --depth 1 origin "$BRANCH" \
+        && git -c safe.directory="$INSTALL_DIR" reset --hard "origin/$BRANCH")
 fi
 
 cd "$INSTALL_DIR"


### PR DESCRIPTION
Re-running the installer on an existing install fails at 'updating existing checkout' with git's dubious-ownership error: the repo is chowned to the taos service user at the end of every install, and the next run executes git fetch/reset as root inside it. Reported in #765, and it blocks exactly the re-run-with-sudo recovery path we point users at.

Fix scopes a safe.directory exception to the two update commands (no global git config changes). The post-install chown re-fixes ownership of anything the update creates.

Fixes #765.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installer reliability when re-running against an existing repository: update steps now run with the repository's owning user when appropriate, preventing Git "dubious ownership" failures and avoiding unintended privileged updates. This reduces installation errors on subsequent runs and makes re-installation safer for non-root-owned install trees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->