### PR TITLE
feat(cluster): worker pairing flow and signed register/heartbeat (#737)

### DIFF
--- a/scripts/install-worker.ps1
+++ b/scripts/install-worker.ps1
@@ -233,14 +233,35 @@ Log "installing worker python deps into .venv"
 & $venvPython -m pip install --quiet --upgrade pip
 & $venvPython -m pip install --quiet httpx pydantic psutil fastapi uvicorn pyyaml pillow libtorrent
 
+# --- pair + register with controller ------------------------------------
+# Pairing acquires the HMAC signing key; --register-after does the first
+# signed POST /api/cluster/workers. Crypto lives in Python, not PowerShell.
+
+$stateDir = Join-Path $InstallDir '.taos-worker-state'
+Log "pairing worker '$WorkerName' with controller at $ControllerUrl"
+Log "  (the pairing code will be printed below -- enter it in taOS > Cluster)"
+$pairArgs = @(
+    '-m', 'tinyagentos.worker.pair',
+    $ControllerUrl,
+    '--name', $WorkerName,
+    '--state-dir', $stateDir,
+    '--register-after'
+)
+& $venvPython @pairArgs
+if ($LASTEXITCODE -ne 0) {
+    Warn "pairing requires admin approval in taOS > Cluster."
+    Warn "  The code was printed above. Once approved, re-run this installer to resume."
+    exit 1
+}
+
 # --- first-boot benchmark -----------------------------------------------
 
 if (-not $SkipBenchmark) {
-    Log "running initial worker benchmark (first-join only — subsequent runs are manual)"
+    Log "running initial worker benchmark (first-join only -- subsequent runs are manual)"
     try {
         & $venvPython -m tinyagentos.benchmark.runner --report-to $ControllerUrl --worker-name $WorkerName --first-join
     } catch {
-        Warn "benchmark runner not available yet — skipping (worker will run without baseline scores)"
+        Warn "benchmark runner not available yet -- skipping (worker will run without baseline scores)"
     }
 }
 
@@ -261,15 +282,29 @@ function Install-ScheduledTask {
         -RestartCount 999
     $principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType Interactive
 
+    $envVars = @(
+        "TAOS_WORKER_STATE_DIR=$stateDir"
+    )
+
     Unregister-ScheduledTask -TaskName $taskName -Confirm:$false -ErrorAction SilentlyContinue
 
-    Register-ScheduledTask `
+    $task = Register-ScheduledTask `
         -TaskName $taskName `
         -Action $action `
         -Trigger $trigger `
         -Settings $settings `
         -Principal $principal `
-        -Description 'TinyAgentOS worker daemon — connects to the controller and serves inference work' | Out-Null
+        -Description 'TinyAgentOS worker daemon -- connects to the controller and serves inference work' | Out-Null
+
+    # Inject environment variables into the task XML (ScheduledTaskAction has no native env support)
+    try {
+        $xml = (Get-ScheduledTask -TaskName $taskName | Export-ScheduledTask)
+        $envXml = ($envVars | ForEach-Object { "<Variable><Name>$($_.Split('=')[0])</Name><Value>$($_.Split('=',2)[1])</Value></Variable>" }) -join ''
+        $xml = $xml -replace '(<Exec>)', "<EnvironmentVariables>$envXml</EnvironmentVariables>`$1"
+        Register-ScheduledTask -TaskName $taskName -Xml $xml -Force | Out-Null
+    } catch {
+        Warn "could not inject env vars into scheduled task -- worker will use default state dir"
+    }
 
     Start-ScheduledTask -TaskName $taskName
     Log "worker registered as Scheduled Task '$taskName' (starts at logon, auto-restarts)"
@@ -278,7 +313,7 @@ function Install-ScheduledTask {
 }
 
 if ($ServiceMode -eq 'skip') {
-    Log "TAOS_SERVICE=skip — not installing a service"
+    Log "TAOS_SERVICE=skip -- not installing a service"
     Log "run manually: cd $InstallDir; .\.venv\Scripts\python.exe -m tinyagentos.worker $ControllerUrl --name $WorkerName"
 } else {
     Install-ScheduledTask

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -500,36 +500,22 @@ install_and_enroll_incus() {
 
     log "LAN IP: $LAN_IP"
 
-    # ── 7. Register worker with controller ─────────────────────────────
-    # POST /api/cluster/workers so the controller knows this worker exists
-    # before we try to /incus-enroll (that endpoint 404s for unknown workers).
-    # Includes the new LXC-mode fields: host_lan_ip and worker_lxc_image_version.
-    log "registering worker '${WORKER_NAME}' with controller at $CONTROLLER_URL"
-    local reg_code
-    reg_code="$(curl -sS -o /tmp/taos-worker-register.out -w "%{http_code}" \
-        -X POST "$CONTROLLER_URL/api/cluster/workers" \
-        -H "Content-Type: application/json" \
-        -d "{
-            \"name\": \"${WORKER_NAME}\",
-            \"url\": \"https://${LAN_IP}:8443\",
-            \"hardware\": {},
-            \"backends\": [],
-            \"capabilities\": [],
-            \"platform\": \"linux\",
-            \"models\": [],
-            \"host_lan_ip\": \"${TAOS_HOST_LAN_IP:-${LAN_IP}}\",
-            \"worker_lxc_image_version\": \"ubuntu/24.04/amd64\"
-        }" \
-        2>/tmp/taos-worker-register.err || true)"
-
-    if [[ "$reg_code" == 2* ]]; then
-        log "worker registered successfully (HTTP $reg_code)"
-    elif [[ "$reg_code" == "409" ]]; then
-        log "worker already registered (HTTP 409) — continuing to incus-enroll"
-    else
-        warn "worker registration returned HTTP $reg_code"
-        warn "  response: $(cat /tmp/taos-worker-register.out 2>/dev/null)"
-        warn "  continuing to incus-enroll anyway"
+    # ── 7. Pair + register worker with controller ───────────────────────
+    # Pairing acquires the HMAC signing key; --register-after does the
+    # first signed POST /api/cluster/workers so the controller knows this
+    # worker before the incus-enroll step below (that endpoint 404s for
+    # unknown workers). Crypto lives in Python, not shell.
+    log "pairing worker '${WORKER_NAME}' with controller at $CONTROLLER_URL"
+    log "  (the pairing code will be printed below — enter it in taOS > Cluster)"
+    if ! "$INSTALL_DIR/.venv/bin/python" -m tinyagentos.worker.pair \
+            "$CONTROLLER_URL" \
+            --name "$WORKER_NAME" \
+            --url "https://${LAN_IP}:8443" \
+            --register-after; then
+        warn "pairing requires admin approval in taOS > Cluster."
+        warn "  The code was printed above. Once approved, re-run this installer to resume."
+        warn "  To resume later: run this installer again (it will skip already-done steps)."
+        return 1
     fi
 
     # ── 8. POST to controller ───────────────────────────────────────────
@@ -1225,6 +1211,7 @@ ExecStart=$INSTALL_DIR/.venv/bin/python -m tinyagentos.worker $CONTROLLER_URL --
 Restart=always
 RestartSec=5
 Environment=PYTHONUNBUFFERED=1
+Environment=TAOS_WORKER_STATE_DIR=$INSTALL_DIR/.taos-worker-state
 
 [Install]
 WantedBy=multi-user.target
@@ -1253,6 +1240,7 @@ ExecStart=$INSTALL_DIR/.venv/bin/python -m tinyagentos.worker $CONTROLLER_URL --
 Restart=always
 RestartSec=5
 Environment=PYTHONUNBUFFERED=1
+Environment=TAOS_WORKER_STATE_DIR=$INSTALL_DIR/.taos-worker-state
 
 [Install]
 WantedBy=default.target

--- a/tests/cluster/test_local_worker_enroll.py
+++ b/tests/cluster/test_local_worker_enroll.py
@@ -226,15 +226,20 @@ class TestWorkerRegistryBridge:
 
 
 @pytest.mark.asyncio
-async def test_heartbeat_includes_capacity_snapshot(monkeypatch):
+async def test_heartbeat_includes_capacity_snapshot(monkeypatch, tmp_path):
     """WorkerAgent.heartbeat() should call capacity_snapshot() and
     include the three byte counters in the POST body.
     """
+    import json as _json
+    import secrets
     from tinyagentos.worker.agent import WorkerAgent
+    from tinyagentos.worker.pairing import save_signing_key
+
+    save_signing_key(tmp_path, secrets.token_bytes(32))
 
     posted_bodies = []
 
-    # Fake httpx.AsyncClient that captures the POST body
+    # Fake httpx.AsyncClient that captures the POST body (sent as content=bytes)
     mock_response = MagicMock()
     mock_response.status_code = 200
 
@@ -242,8 +247,9 @@ async def test_heartbeat_includes_capacity_snapshot(monkeypatch):
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=False)
 
-    async def fake_post(url, json=None, **kwargs):
-        posted_bodies.append(json or {})
+    async def fake_post(url, content=None, headers=None, **kwargs):
+        if content is not None:
+            posted_bodies.append(_json.loads(content))
         return mock_response
 
     mock_client.post = fake_post
@@ -265,8 +271,8 @@ async def test_heartbeat_includes_capacity_snapshot(monkeypatch):
         },
     )
 
-    agent = WorkerAgent("http://controller:6969", name="test-worker")
-    # detect_backends makes outgoing network calls — short-circuit it
+    agent = WorkerAgent("http://controller:6969", name="test-worker", state_dir=tmp_path)
+    # detect_backends makes outgoing network calls -- short-circuit it
     monkeypatch.setattr(agent, "detect_backends", AsyncMock(return_value=[]))
 
     await agent.heartbeat()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -138,8 +138,11 @@ class TestWorkerAgent:
 class TestRegistration:
     """Test worker registration with mocked HTTP."""
 
-    async def test_register_success(self):
-        agent = WorkerAgent("http://controller:6969", name="test-worker")
+    async def test_register_success(self, tmp_path):
+        import secrets
+        from tinyagentos.worker.pairing import save_signing_key
+        save_signing_key(tmp_path, secrets.token_bytes(32))
+        agent = WorkerAgent("http://controller:6969", name="test-worker", state_dir=tmp_path)
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.raise_for_status = MagicMock()
@@ -180,8 +183,11 @@ class TestRegistration:
 class TestHeartbeat:
     """Test heartbeat sending with mocked HTTP."""
 
-    async def test_heartbeat_success(self):
-        agent = WorkerAgent("http://controller:6969", name="test-worker")
+    async def test_heartbeat_success(self, tmp_path):
+        import secrets
+        from tinyagentos.worker.pairing import save_signing_key
+        save_signing_key(tmp_path, secrets.token_bytes(32))
+        agent = WorkerAgent("http://controller:6969", name="test-worker", state_dir=tmp_path)
         mock_response = MagicMock()
         mock_response.status_code = 200
 
@@ -193,7 +199,8 @@ class TestHeartbeat:
             mock_client_cls.return_value = mock_client
 
             with patch("tinyagentos.worker.agent.psutil.cpu_percent", return_value=42.0):
-                result = await agent.heartbeat()
+                with patch("tinyagentos.worker.agent.WorkerAgent.detect_backends", return_value=[]):
+                    result = await agent.heartbeat()
 
         # heartbeat() returns the int HTTP status code (or 0 on failure), see #166
         assert result == 200

--- a/tests/worker/test_agent_browser_caps.py
+++ b/tests/worker/test_agent_browser_caps.py
@@ -1,11 +1,14 @@
 """Tests for WorkerAgent extra_capabilities + advertise_url (browser-worker additions)."""
 from __future__ import annotations
 
+import json as _json
+import secrets
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from tinyagentos.worker.agent import WorkerAgent
+from tinyagentos.worker.pairing import save_signing_key
 
 
 class TestWorkerAgentBrowserCaps:
@@ -42,12 +45,14 @@ class TestWorkerAgentBrowserCaps:
 class TestRegisterWithBrowserCaps:
     """Verify register() forwards browser capability + pinned URL to controller."""
 
-    async def test_register_includes_browser_capability(self):
+    async def test_register_includes_browser_capability(self, tmp_path):
+        save_signing_key(tmp_path, secrets.token_bytes(32))
         agent = WorkerAgent(
             "http://controller:6969",
             name="browser-node",
             extra_capabilities=["browser"],
             advertise_url="http://10.0.0.5:7080",
+            state_dir=tmp_path,
         )
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -55,9 +60,9 @@ class TestRegisterWithBrowserCaps:
 
         captured: list[dict] = []
 
-        async def _mock_post(url, json=None, **kwargs):
-            if json is not None:
-                captured.append(json)
+        async def _mock_post(url, content=None, headers=None, **kwargs):
+            if content is not None:
+                captured.append(_json.loads(content))
             return mock_response
 
         with patch("tinyagentos.worker.agent.httpx.AsyncClient") as mock_client_cls:
@@ -76,12 +81,14 @@ class TestRegisterWithBrowserCaps:
         payload = captured[0]
         assert "browser" in payload["capabilities"]
 
-    async def test_register_uses_advertise_url(self):
+    async def test_register_uses_advertise_url(self, tmp_path):
+        save_signing_key(tmp_path, secrets.token_bytes(32))
         agent = WorkerAgent(
             "http://controller:6969",
             name="browser-node",
             extra_capabilities=["browser"],
             advertise_url="http://10.0.0.5:7080",
+            state_dir=tmp_path,
         )
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -89,9 +96,9 @@ class TestRegisterWithBrowserCaps:
 
         captured: list[dict] = []
 
-        async def _mock_post(url, json=None, **kwargs):
-            if json is not None:
-                captured.append(json)
+        async def _mock_post(url, content=None, headers=None, **kwargs):
+            if content is not None:
+                captured.append(_json.loads(content))
             return mock_response
 
         with patch("tinyagentos.worker.agent.httpx.AsyncClient") as mock_client_cls:
@@ -107,12 +114,14 @@ class TestRegisterWithBrowserCaps:
 
         assert captured[0]["url"] == "http://10.0.0.5:7080"
 
-    async def test_register_without_advertise_url_falls_back(self):
+    async def test_register_without_advertise_url_falls_back(self, tmp_path):
         """Without advertise_url, register() falls back to get_worker_url()."""
+        save_signing_key(tmp_path, secrets.token_bytes(32))
         agent = WorkerAgent(
             "http://controller:6969",
             name="plain-node",
             worker_port=9999,
+            state_dir=tmp_path,
         )
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -120,9 +129,9 @@ class TestRegisterWithBrowserCaps:
 
         captured: list[dict] = []
 
-        async def _mock_post(url, json=None, **kwargs):
-            if json is not None:
-                captured.append(json)
+        async def _mock_post(url, content=None, headers=None, **kwargs):
+            if content is not None:
+                captured.append(_json.loads(content))
             return mock_response
 
         with patch("tinyagentos.worker.agent.httpx.AsyncClient") as mock_client_cls:
@@ -139,12 +148,14 @@ class TestRegisterWithBrowserCaps:
         # Should contain :9999 in the URL, not "http://10.0.0.5:7080"
         assert ":9999" in captured[0]["url"]
 
-    async def test_extra_caps_merged_with_backend_caps(self):
+    async def test_extra_caps_merged_with_backend_caps(self, tmp_path):
         """extra_capabilities are unioned with detected backend caps."""
+        save_signing_key(tmp_path, secrets.token_bytes(32))
         agent = WorkerAgent(
             "http://controller:6969",
             extra_capabilities=["browser"],
             advertise_url="http://10.0.0.5:7080",
+            state_dir=tmp_path,
         )
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -152,9 +163,9 @@ class TestRegisterWithBrowserCaps:
 
         captured: list[dict] = []
 
-        async def _mock_post(url, json=None, **kwargs):
-            if json is not None:
-                captured.append(json)
+        async def _mock_post(url, content=None, headers=None, **kwargs):
+            if content is not None:
+                captured.append(_json.loads(content))
             return mock_response
 
         fake_backend = {
@@ -184,22 +195,24 @@ class TestRegisterWithBrowserCaps:
         assert "llm-chat" in caps
         assert "embedding" in caps
 
-    async def test_heartbeat_includes_browser_capability(self):
+    async def test_heartbeat_includes_browser_capability(self, tmp_path):
         """heartbeat() unions extra_capabilities into the posted caps too."""
+        save_signing_key(tmp_path, secrets.token_bytes(32))
         agent = WorkerAgent(
             "http://controller:6969",
             name="browser-node",
             extra_capabilities=["browser"],
             advertise_url="http://10.0.0.5:7080",
+            state_dir=tmp_path,
         )
         mock_response = MagicMock()
         mock_response.status_code = 200
 
         captured: list[dict] = []
 
-        async def _mock_post(url, json=None, **kwargs):
-            if json is not None:
-                captured.append(json)
+        async def _mock_post(url, content=None, headers=None, **kwargs):
+            if content is not None:
+                captured.append(_json.loads(content))
             return mock_response
 
         snap = {

--- a/tests/worker/test_pairing.py
+++ b/tests/worker/test_pairing.py
@@ -1,0 +1,521 @@
+"""Tests for tinyagentos.worker.pairing and the pair CLI.
+
+Coverage:
+- sign_request_headers produces headers that PASS require_worker_hmac (round-trip)
+- tampered body -> 401 bad_signature (round-trip against real app)
+- save/load signing key round-trip + 0600 permissions on POSIX
+- generate_pairing_code: correct length, unambiguous alphabet only
+- code_hash: matches the controller-side sha256 expectation
+- default_state_dir: respects TAOS_WORKER_STATE_DIR and XDG_STATE_HOME
+- run_pairing happy path: announce -> 202 poll -> 200, key saved, returned
+- run_pairing 410 re-announce path: re-announces with fresh code
+- run_pairing timeout: raises TimeoutError
+- run_pairing already-paired short-circuit: returns existing key
+- WorkerAgent.register sends signed headers when key is present
+- WorkerAgent.heartbeat sends signed headers when key is present
+- WorkerAgent.register logs clear error when no key is loaded
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json as _json
+import os
+import sys
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_mock_response(status_code: int, json_data: dict) -> MagicMock:
+    r = MagicMock()
+    r.status_code = status_code
+    r.json = MagicMock(return_value=json_data)
+    return r
+
+
+# ---------------------------------------------------------------------------
+# unit: sign_request_headers
+# ---------------------------------------------------------------------------
+
+class TestSignRequestHeaders:
+    def test_returns_three_headers(self):
+        from tinyagentos.worker.pairing import sign_request_headers
+        key = b"\x01" * 32
+        h = sign_request_headers(key, "w1", "POST", "/api/cluster/workers", b'{"name":"w1"}')
+        assert set(h) == {"X-TAOS-Worker-Name", "X-TAOS-Timestamp", "X-TAOS-Signature"}
+
+    def test_worker_name_in_header(self):
+        from tinyagentos.worker.pairing import sign_request_headers
+        h = sign_request_headers(b"\x02" * 32, "my-worker", "POST", "/path", b"body")
+        assert h["X-TAOS-Worker-Name"] == "my-worker"
+
+    def test_timestamp_is_recent_unix_seconds(self):
+        from tinyagentos.worker.pairing import sign_request_headers
+        before = int(time.time())
+        h = sign_request_headers(b"\x03" * 32, "w", "POST", "/path", b"")
+        after = int(time.time())
+        ts = int(h["X-TAOS-Timestamp"])
+        assert before <= ts <= after
+
+    def test_signature_matches_independent_hmac(self):
+        from tinyagentos.worker.pairing import sign_request_headers
+        key = b"\x04" * 32
+        body = b'{"name":"w","url":"http://x"}'
+        h = sign_request_headers(key, "w", "POST", "/api/cluster/workers", body)
+        ts = h["X-TAOS-Timestamp"]
+        body_hash = hashlib.sha256(body).hexdigest()
+        message = f"{ts}.POST./api/cluster/workers.{body_hash}".encode()
+        expected = hmac.new(key, message, hashlib.sha256).hexdigest()
+        assert h["X-TAOS-Signature"] == expected
+
+    def test_method_uppercased(self):
+        from tinyagentos.worker.pairing import sign_request_headers
+        key = b"\x05" * 32
+        body = b"x"
+        h_lower = sign_request_headers(key, "w", "post", "/p", body)
+        h_upper = sign_request_headers(key, "w", "POST", "/p", body)
+        # same timestamp would differ but we just check the sig matches manual recompute
+        ts = h_lower["X-TAOS-Timestamp"]
+        body_hash = hashlib.sha256(body).hexdigest()
+        message = f"{ts}.POST./p.{body_hash}".encode()
+        expected = hmac.new(key, message, hashlib.sha256).hexdigest()
+        assert h_lower["X-TAOS-Signature"] == expected
+
+
+# ---------------------------------------------------------------------------
+# round-trip: sign_request_headers <-> require_worker_hmac (real app)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_sign_request_headers_passes_hmac_gate(app, client):
+    """Headers from sign_request_headers must satisfy require_worker_hmac."""
+    from tinyagentos.worker.pairing import sign_request_headers
+
+    # Pair a worker so the pairing store has a known key
+    await app.state.cluster_pairing.init()
+    code = "roundtrip-code-1"
+    ch = hashlib.sha256(code.encode()).hexdigest()
+    await client.post(
+        "/api/cluster/pairing/announce",
+        json={"name": "rt-worker", "url": "http://10.9.0.1:9000",
+              "platform": "linux", "code_hash": ch},
+    )
+    await client.post(
+        "/api/cluster/pairing/confirm",
+        json={"name": "rt-worker", "code": code},
+    )
+    resp = await client.post(
+        "/api/cluster/pairing/claim",
+        json={"name": "rt-worker", "code": code},
+    )
+    assert resp.status_code == 200
+    key = bytes.fromhex(resp.json()["signing_key"])
+
+    # Use sign_request_headers to sign a register request
+    reg_body = _json.dumps({
+        "name": "rt-worker", "url": "http://10.9.0.1:9000", "platform": "linux",
+    }).encode()
+    headers = sign_request_headers(key, "rt-worker", "POST", "/api/cluster/workers", reg_body)
+
+    resp = await client.post(
+        "/api/cluster/workers",
+        content=reg_body,
+        headers={**headers, "content-type": "application/json"},
+    )
+    assert resp.status_code == 200, f"expected 200, got {resp.status_code}: {resp.text}"
+    assert resp.json()["status"] == "registered"
+
+    await app.state.cluster_pairing.close()
+
+
+@pytest.mark.asyncio
+async def test_tampered_body_returns_401_bad_signature(app, client):
+    """A body tampered after signing must return 401 bad_signature."""
+    from tinyagentos.worker.pairing import sign_request_headers
+
+    await app.state.cluster_pairing.init()
+    code = "roundtrip-code-2"
+    ch = hashlib.sha256(code.encode()).hexdigest()
+    await client.post(
+        "/api/cluster/pairing/announce",
+        json={"name": "tamper-worker", "url": "http://10.9.0.2:9000",
+              "platform": "linux", "code_hash": ch},
+    )
+    await client.post(
+        "/api/cluster/pairing/confirm",
+        json={"name": "tamper-worker", "code": code},
+    )
+    resp = await client.post(
+        "/api/cluster/pairing/claim",
+        json={"name": "tamper-worker", "code": code},
+    )
+    key = bytes.fromhex(resp.json()["signing_key"])
+
+    # Sign the real body, but send a different (tampered) body
+    real_body = _json.dumps({
+        "name": "tamper-worker", "url": "http://10.9.0.2:9000",
+    }).encode()
+    headers = sign_request_headers(key, "tamper-worker", "POST",
+                                   "/api/cluster/workers", real_body)
+
+    tampered_body = _json.dumps({
+        "name": "tamper-worker", "url": "http://evil.example.com:9000",
+    }).encode()
+    resp = await client.post(
+        "/api/cluster/workers",
+        content=tampered_body,
+        headers={**headers, "content-type": "application/json"},
+    )
+    assert resp.status_code == 401
+    assert resp.json().get("code") == "bad_signature"
+
+    await app.state.cluster_pairing.close()
+
+
+# ---------------------------------------------------------------------------
+# unit: key persistence
+# ---------------------------------------------------------------------------
+
+class TestKeyPersistence:
+    def test_save_and_load_round_trip(self, tmp_path):
+        from tinyagentos.worker.pairing import save_signing_key, load_signing_key, key_path
+        key = b"\xab" * 32
+        save_signing_key(tmp_path, key)
+        loaded = load_signing_key(tmp_path)
+        assert loaded == key
+
+    def test_load_returns_none_when_missing(self, tmp_path):
+        from tinyagentos.worker.pairing import load_signing_key
+        assert load_signing_key(tmp_path) is None
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="chmod not applicable on Windows")
+    def test_save_sets_0600_permissions(self, tmp_path):
+        from tinyagentos.worker.pairing import save_signing_key, key_path
+        save_signing_key(tmp_path, b"\x00" * 32)
+        mode = key_path(tmp_path).stat().st_mode & 0o777
+        assert mode == 0o600
+
+    def test_key_path_is_inside_state_dir(self, tmp_path):
+        from tinyagentos.worker.pairing import key_path
+        p = key_path(tmp_path)
+        assert str(p).startswith(str(tmp_path))
+
+
+# ---------------------------------------------------------------------------
+# unit: generate_pairing_code + code_hash
+# ---------------------------------------------------------------------------
+
+class TestPairingCode:
+    _UNAMBIGUOUS = set("23456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz")
+
+    def test_length_8(self):
+        from tinyagentos.worker.pairing import generate_pairing_code
+        code = generate_pairing_code()
+        assert len(code) == 8
+
+    def test_only_unambiguous_chars(self):
+        from tinyagentos.worker.pairing import generate_pairing_code
+        for _ in range(50):
+            code = generate_pairing_code()
+            for ch in code:
+                assert ch in self._UNAMBIGUOUS, f"ambiguous char {ch!r} in code {code!r}"
+
+    def test_returns_string(self):
+        from tinyagentos.worker.pairing import generate_pairing_code
+        assert isinstance(generate_pairing_code(), str)
+
+    def test_code_hash_matches_sha256(self):
+        from tinyagentos.worker.pairing import code_hash
+        code = "ABCD1234"
+        expected = hashlib.sha256(code.encode()).hexdigest()
+        assert code_hash(code) == expected
+
+    def test_code_hash_is_64_hex_chars(self):
+        from tinyagentos.worker.pairing import code_hash
+        h = code_hash("X")
+        assert len(h) == 64
+        int(h, 16)  # raises if not hex
+
+
+# ---------------------------------------------------------------------------
+# unit: default_state_dir
+# ---------------------------------------------------------------------------
+
+class TestDefaultStateDir:
+    def test_env_override(self, monkeypatch, tmp_path):
+        from tinyagentos.worker import pairing as _p
+        monkeypatch.setenv("TAOS_WORKER_STATE_DIR", str(tmp_path))
+        monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+        d = _p.default_state_dir()
+        assert d == tmp_path
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="XDG not relevant on Windows")
+    def test_xdg_state_home(self, monkeypatch, tmp_path):
+        from tinyagentos.worker import pairing as _p
+        monkeypatch.delenv("TAOS_WORKER_STATE_DIR", raising=False)
+        monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+        d = _p.default_state_dir()
+        assert d == tmp_path / "taos-worker"
+
+    def test_returns_path(self, monkeypatch):
+        from tinyagentos.worker import pairing as _p
+        monkeypatch.delenv("TAOS_WORKER_STATE_DIR", raising=False)
+        d = _p.default_state_dir()
+        assert isinstance(d, Path)
+
+
+# ---------------------------------------------------------------------------
+# async unit: run_pairing
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_run_pairing_happy_path(tmp_path):
+    """announce -> 202 -> 200 with key -> key saved and returned."""
+    import secrets
+    from tinyagentos.worker.pairing import run_pairing
+
+    fake_key = secrets.token_bytes(32)
+    call_count = 0
+
+    async def mock_post(url, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if "/pairing/announce" in url:
+            return _make_mock_response(200, {"status": "pending"})
+        if "/pairing/claim" in url:
+            if call_count <= 2:
+                # first claim -> 202 awaiting
+                return _make_mock_response(202, {"status": "awaiting_confirm"})
+            # second claim -> 200 with key
+            return _make_mock_response(200, {"signing_key": fake_key.hex()})
+        raise AssertionError(f"unexpected POST to {url}")
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(side_effect=mock_post)
+
+    printed = []
+    key = await run_pairing(
+        mock_client,
+        "http://controller:6969",
+        "test-worker",
+        "http://10.0.0.1:9000",
+        "linux",
+        tmp_path,
+        poll_interval=0.01,
+        timeout=10.0,
+        print_fn=printed.append,
+    )
+
+    assert key == fake_key
+    # Key must be persisted
+    from tinyagentos.worker.pairing import load_signing_key
+    assert load_signing_key(tmp_path) == fake_key
+    # Pairing code banner must have been printed
+    assert any("Pairing code" in str(m) or "pairing code" in str(m).lower() for m in printed)
+
+
+@pytest.mark.asyncio
+async def test_run_pairing_already_paired_short_circuit(tmp_path):
+    """If a key already exists, run_pairing returns it without any HTTP calls."""
+    from tinyagentos.worker.pairing import run_pairing, save_signing_key
+
+    existing = b"\xcc" * 32
+    save_signing_key(tmp_path, existing)
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(side_effect=AssertionError("should not be called"))
+
+    key = await run_pairing(
+        mock_client,
+        "http://controller:6969",
+        "w",
+        "http://x",
+        "linux",
+        tmp_path,
+        poll_interval=0.01,
+        timeout=5.0,
+    )
+    assert key == existing
+    mock_client.post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_pairing_410_re_announces(tmp_path):
+    """On 410 from claim, run_pairing re-announces with a fresh code and keeps going."""
+    import secrets
+    from tinyagentos.worker.pairing import run_pairing
+
+    fake_key = secrets.token_bytes(32)
+    announce_count = 0
+    claim_count = 0
+
+    async def mock_post(url, **kwargs):
+        nonlocal announce_count, claim_count
+        if "/pairing/announce" in url:
+            announce_count += 1
+            return _make_mock_response(200, {"status": "pending"})
+        if "/pairing/claim" in url:
+            claim_count += 1
+            if claim_count == 1:
+                return _make_mock_response(410, {"error": "expired"})
+            if claim_count == 2:
+                # After re-announce, poll once as awaiting
+                return _make_mock_response(202, {"status": "awaiting_confirm"})
+            return _make_mock_response(200, {"signing_key": fake_key.hex()})
+        raise AssertionError(f"unexpected POST to {url}")
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(side_effect=mock_post)
+
+    key = await run_pairing(
+        mock_client,
+        "http://controller:6969",
+        "w",
+        "http://x",
+        "linux",
+        tmp_path,
+        poll_interval=0.01,
+        timeout=10.0,
+    )
+    assert key == fake_key
+    assert announce_count == 2  # re-announced once after 410
+
+
+@pytest.mark.asyncio
+async def test_run_pairing_timeout(tmp_path):
+    """run_pairing raises TimeoutError if the claim never returns 200."""
+    from tinyagentos.worker.pairing import run_pairing
+
+    async def mock_post(url, **kwargs):
+        if "/pairing/announce" in url:
+            return _make_mock_response(200, {"status": "pending"})
+        if "/pairing/claim" in url:
+            return _make_mock_response(202, {"status": "awaiting_confirm"})
+        raise AssertionError(f"unexpected POST to {url}")
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(side_effect=mock_post)
+
+    with pytest.raises(TimeoutError):
+        await run_pairing(
+            mock_client,
+            "http://controller:6969",
+            "w",
+            "http://x",
+            "linux",
+            tmp_path,
+            poll_interval=0.01,
+            timeout=0.1,
+        )
+
+
+# ---------------------------------------------------------------------------
+# WorkerAgent: signed register / heartbeat
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_worker_agent_register_sends_signed_headers(tmp_path):
+    """WorkerAgent.register must attach HMAC headers when a key is present."""
+    import secrets
+    from tinyagentos.worker.pairing import save_signing_key
+    from tinyagentos.worker.agent import WorkerAgent
+
+    key = secrets.token_bytes(32)
+    save_signing_key(tmp_path, key)
+
+    agent = WorkerAgent("http://controller:6969", name="signed-worker", state_dir=tmp_path)
+
+    captured = {}
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.raise_for_status = MagicMock()
+
+    async def mock_post(url, **kwargs):
+        captured["headers"] = kwargs.get("headers", {})
+        captured["content"] = kwargs.get("content")
+        return mock_response
+
+    with patch("tinyagentos.worker.agent.httpx.AsyncClient") as mock_cls:
+        mock_c = AsyncMock()
+        mock_c.__aenter__ = AsyncMock(return_value=mock_c)
+        mock_c.__aexit__ = AsyncMock(return_value=False)
+        mock_c.post = AsyncMock(side_effect=mock_post)
+        mock_c.get = AsyncMock(side_effect=Exception("not running"))
+        mock_cls.return_value = mock_c
+
+        with patch("tinyagentos.worker.agent.WorkerAgent.detect_backends", return_value=[]):
+            result = await agent.register()
+
+    assert result is True
+    assert "X-TAOS-Worker-Name" in captured["headers"]
+    assert "X-TAOS-Timestamp" in captured["headers"]
+    assert "X-TAOS-Signature" in captured["headers"]
+    assert captured["headers"]["X-TAOS-Worker-Name"] == "signed-worker"
+    # Body sent as bytes (content=), not json=
+    assert isinstance(captured["content"], bytes)
+
+
+@pytest.mark.asyncio
+async def test_worker_agent_heartbeat_sends_signed_headers(tmp_path):
+    """WorkerAgent.heartbeat must attach HMAC headers when a key is present."""
+    import secrets
+    from tinyagentos.worker.pairing import save_signing_key
+    from tinyagentos.worker.agent import WorkerAgent
+
+    key = secrets.token_bytes(32)
+    save_signing_key(tmp_path, key)
+
+    agent = WorkerAgent("http://controller:6969", name="hb-worker", state_dir=tmp_path)
+
+    captured = {}
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+
+    async def mock_post(url, **kwargs):
+        captured["headers"] = kwargs.get("headers", {})
+        captured["content"] = kwargs.get("content")
+        return mock_response
+
+    with patch("tinyagentos.worker.agent.httpx.AsyncClient") as mock_cls:
+        mock_c = AsyncMock()
+        mock_c.__aenter__ = AsyncMock(return_value=mock_c)
+        mock_c.__aexit__ = AsyncMock(return_value=False)
+        mock_c.post = AsyncMock(side_effect=mock_post)
+        mock_cls.return_value = mock_c
+
+        with patch("tinyagentos.worker.agent.psutil.cpu_percent", return_value=10.0):
+            with patch("tinyagentos.worker.agent.WorkerAgent.detect_backends", return_value=[]):
+                result = await agent.heartbeat()
+
+    assert result == 200
+    assert "X-TAOS-Worker-Name" in captured["headers"]
+    assert "X-TAOS-Signature" in captured["headers"]
+    assert isinstance(captured["content"], bytes)
+
+
+@pytest.mark.asyncio
+async def test_worker_agent_register_logs_error_when_no_key(tmp_path, caplog):
+    """WorkerAgent.register logs a clear actionable error if no signing key is present."""
+    import logging
+    from tinyagentos.worker.agent import WorkerAgent
+
+    agent = WorkerAgent("http://controller:6969", name="unpaired-worker", state_dir=tmp_path)
+
+    with caplog.at_level(logging.ERROR, logger="tinyagentos.worker.agent"):
+        with patch("tinyagentos.worker.agent.WorkerAgent.detect_backends", return_value=[]):
+            result = await agent.register()
+
+    assert result is False
+    # Check a clear error was logged mentioning pairing
+    combined = " ".join(r.message for r in caplog.records).lower()
+    assert "paired" in combined or "signing key" in combined

--- a/tinyagentos/worker/agent.py
+++ b/tinyagentos/worker/agent.py
@@ -73,6 +73,7 @@ class WorkerAgent:
         worker_port: int = 0,
         extra_capabilities: list[str] | None = None,
         advertise_url: str | None = None,
+        state_dir: "Path | None" = None,
     ):
         self.controller_url = controller_url.rstrip("/")
         self.name = name or socket.gethostname()
@@ -81,6 +82,10 @@ class WorkerAgent:
         self.advertise_url = advertise_url
         self._running = False
         self._registered = False
+
+        from tinyagentos.worker.pairing import default_state_dir, load_signing_key
+        self._state_dir = state_dir or default_state_dir()
+        self._signing_key: bytes | None = load_signing_key(self._state_dir)
 
     async def detect_backends(self) -> list[dict]:
         """Discover locally running inference backends via live probing.
@@ -336,9 +341,20 @@ class WorkerAgent:
         return f"http://{ip}:{self.worker_port}" if self.worker_port else f"http://{ip}"
 
     async def register(self) -> bool:
-        """Register with the controller."""
+        """Register with the controller (signed with HMAC key if paired)."""
         from tinyagentos.hardware import detect_hardware
         from dataclasses import asdict
+        import json as _json
+
+        if self._signing_key is None:
+            logger.error(
+                "worker not paired: no signing key at %s; "
+                "run `python -m tinyagentos.worker.pair %s --name %s` to pair this worker",
+                self._state_dir,
+                self.controller_url,
+                self.name,
+            )
+            return False
 
         hw = detect_hardware()
         backends = await self.detect_backends()
@@ -370,8 +386,17 @@ class WorkerAgent:
             payload["pending_storage_backup"] = backup
 
         try:
+            from tinyagentos.worker.pairing import sign_request_headers
+            path = "/api/cluster/workers"
+            body = _json.dumps(payload).encode()
+            auth_headers = sign_request_headers(self._signing_key, self.name, "POST", path, body)
+            auth_headers["content-type"] = "application/json"
             async with httpx.AsyncClient(timeout=10) as client:
-                resp = await client.post(f"{self.controller_url}/api/cluster/workers", json=payload)
+                resp = await client.post(
+                    f"{self.controller_url}{path}",
+                    content=body,
+                    headers=auth_headers,
+                )
                 resp.raise_for_status()
                 self._registered = True
                 logger.info(f"Registered with controller as '{self.name}'")
@@ -396,29 +421,47 @@ class WorkerAgent:
         trigger a re-registration.
         """
         from tinyagentos.cluster.worker_capacity import capacity_snapshot
+        import json as _json
+
+        if self._signing_key is None:
+            logger.error(
+                "worker not paired: no signing key at %s; "
+                "run `python -m tinyagentos.worker.pair %s --name %s` to pair this worker",
+                self._state_dir,
+                self.controller_url,
+                self.name,
+            )
+            return 0
 
         try:
+            from tinyagentos.worker.pairing import sign_request_headers
             load = psutil.cpu_percent() / 100.0
             backends = await self.detect_backends()
             caps = sorted(set(self.detect_capabilities(backends)) | set(self.extra_capabilities))
             kv_quant = self.detect_kv_quant_support(backends)
             snap = capacity_snapshot()
+            path = "/api/cluster/heartbeat"
+            payload = {
+                "name": self.name,
+                "load": load,
+                "backends": backends,
+                "capabilities": caps,
+                "kv_cache_quant_support": kv_quant.get("legacy", ["fp16"]),
+                "kv_cache_quant_k_support": kv_quant.get("k", ["fp16"]),
+                "kv_cache_quant_v_support": kv_quant.get("v", ["fp16"]),
+                "kv_cache_quant_boundary_layer_protect": bool(kv_quant.get("boundary", False)),
+                "storage_cap_bytes": snap["storage_cap_bytes"],
+                "storage_used_bytes": snap["storage_used_bytes"],
+                "bytes_deduped_total": snap["bytes_deduped_total"],
+            }
+            body = _json.dumps(payload).encode()
+            auth_headers = sign_request_headers(self._signing_key, self.name, "POST", path, body)
+            auth_headers["content-type"] = "application/json"
             async with httpx.AsyncClient(timeout=5) as client:
                 resp = await client.post(
-                    f"{self.controller_url}/api/cluster/heartbeat",
-                    json={
-                        "name": self.name,
-                        "load": load,
-                        "backends": backends,
-                        "capabilities": caps,
-                        "kv_cache_quant_support": kv_quant.get("legacy", ["fp16"]),
-                        "kv_cache_quant_k_support": kv_quant.get("k", ["fp16"]),
-                        "kv_cache_quant_v_support": kv_quant.get("v", ["fp16"]),
-                        "kv_cache_quant_boundary_layer_protect": bool(kv_quant.get("boundary", False)),
-                        "storage_cap_bytes": snap["storage_cap_bytes"],
-                        "storage_used_bytes": snap["storage_used_bytes"],
-                        "bytes_deduped_total": snap["bytes_deduped_total"],
-                    },
+                    f"{self.controller_url}{path}",
+                    content=body,
+                    headers=auth_headers,
                 )
                 return resp.status_code
         except Exception:

--- a/tinyagentos/worker/pair.py
+++ b/tinyagentos/worker/pair.py
@@ -1,0 +1,131 @@
+"""Worker pairing CLI.
+
+Drives the announce -> admin-confirm -> claim flow and optionally
+performs a signed first-registration so the worker is known to the
+controller before the incus-enroll step in the install script.
+
+Usage (called by install-worker.sh and install-worker.ps1):
+    python -m tinyagentos.worker.pair <controller_url> \\
+        --name <name> --url <worker_url> --register-after
+
+Exit codes:
+    0  paired (and registered if --register-after)
+    1  pairing error (timeout, invalidated, network)
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json as _json
+import platform
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Pair this worker with a taOS controller")
+    parser.add_argument("controller", help="Controller URL, e.g. http://192.168.1.10:6969")
+    parser.add_argument("--name", help="Worker name (default: hostname)")
+    parser.add_argument("--url", help="Advertised worker URL (default: auto-detected LAN URL)")
+    parser.add_argument("--platform", dest="platform_name",
+                        default=platform.system().lower(),
+                        help="Platform string (default: current OS)")
+    parser.add_argument("--state-dir", type=Path, default=None,
+                        help="Directory for key persistence (default: system default)")
+    parser.add_argument("--register-after", action="store_true",
+                        help="Send a signed POST /api/cluster/workers after pairing")
+    parser.add_argument("--timeout", type=float, default=600.0,
+                        help="Max seconds to wait for admin confirmation (default: 600)")
+    args = parser.parse_args()
+
+    try:
+        asyncio.run(_run(args))
+    except TimeoutError as exc:
+        print(f"\n[pair] {exc}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as exc:  # noqa: BLE001
+        print(f"\n[pair] pairing failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+async def _run(args) -> None:
+    import httpx
+    from tinyagentos.worker.pairing import default_state_dir, run_pairing, sign_request_headers
+
+    state_dir = args.state_dir or default_state_dir()
+    name = args.name or _hostname()
+
+    # Resolve advertised URL — use provided, or infer from LAN IP.
+    if args.url:
+        worker_url = args.url
+    else:
+        from tinyagentos.worker.agent import WorkerAgent
+        agent = WorkerAgent(args.controller, name=name, state_dir=state_dir)
+        worker_url = agent.get_worker_url()
+
+    async with httpx.AsyncClient(timeout=15) as client:
+        key = await run_pairing(
+            client,
+            args.controller,
+            name,
+            worker_url,
+            args.platform_name,
+            state_dir,
+            timeout=args.timeout,
+        )
+
+    print(f"\n[pair] paired successfully as '{name}'. Signing key saved to {state_dir}")
+
+    if args.register_after:
+        await _signed_register(args.controller, name, worker_url, args.platform_name, key)
+
+
+async def _signed_register(
+    controller_url: str,
+    name: str,
+    worker_url: str,
+    plat: str,
+    key: bytes,
+) -> None:
+    """POST /api/cluster/workers with HMAC auth so the worker is known before incus-enroll."""
+    import httpx
+    from tinyagentos.worker.pairing import sign_request_headers
+
+    controller_url = controller_url.rstrip("/")
+    path = "/api/cluster/workers"
+    payload = {
+        "name": name,
+        "url": worker_url,
+        "platform": plat,
+        "hardware": {},
+        "backends": [],
+        "capabilities": [],
+        "models": [],
+    }
+    body = _json.dumps(payload).encode()
+    headers = sign_request_headers(key, name, "POST", path, body)
+    headers["content-type"] = "application/json"
+
+    async with httpx.AsyncClient(timeout=15) as client:
+        resp = await client.post(
+            f"{controller_url}{path}",
+            content=body,
+            headers=headers,
+        )
+
+    if resp.status_code in (200, 409):
+        status = "registered" if resp.status_code == 200 else "already registered"
+        print(f"[pair] worker {status} with controller")
+    else:
+        raise RuntimeError(
+            f"signed register failed with HTTP {resp.status_code}: {resp.text}"
+        )
+
+
+def _hostname() -> str:
+    import socket
+    return socket.gethostname()
+
+
+if __name__ == "__main__":
+    main()

--- a/tinyagentos/worker/pairing.py
+++ b/tinyagentos/worker/pairing.py
@@ -180,9 +180,12 @@ async def _announce(
             f"announce failed with HTTP {resp.status_code}: {resp.json()}"
         )
     # Print the code prominently so the user can enter it in the taOS UI.
+    # Show the literal code with no separator: the controller hashes the
+    # exact string the admin types, so a cosmetic dash would make the
+    # entered code mismatch the announced hash and the confirm would fail.
     print_fn("")
     print_fn("=" * 56)
-    print_fn(f"  Pairing code: {code[:4]}-{code[4:]}")
+    print_fn(f"  Pairing code: {code}")
     print_fn("  Enter this in taOS > Cluster to approve this worker")
     print_fn("=" * 56)
     print_fn("")

--- a/tinyagentos/worker/pairing.py
+++ b/tinyagentos/worker/pairing.py
@@ -1,0 +1,188 @@
+"""Worker-side pairing utilities.
+
+Handles the announce -> admin-confirm -> claim flow, key persistence,
+and request signing. The HMAC signing string and headers must byte-match
+tinyagentos.cluster.worker_auth:
+
+    message = f"{timestamp}.{METHOD}.{path}.{sha256(body).hexdigest()}"
+    headers: X-TAOS-Worker-Name, X-TAOS-Timestamp, X-TAOS-Signature
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import os
+import secrets
+import sys
+import time
+from pathlib import Path
+
+# Unambiguous alphabet: strips 0/O/1/I/l to reduce transcription errors.
+_ALPHABET = "23456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz"
+
+
+def default_state_dir() -> Path:
+    """Return the default directory for persisting worker state.
+
+    Priority:
+      1. $TAOS_WORKER_STATE_DIR (explicit override)
+      2. $XDG_STATE_HOME/taos-worker  (POSIX)
+      3. %LOCALAPPDATA%/taos-worker   (Windows)
+      4. ~/.local/state/taos-worker   (POSIX fallback)
+    """
+    override = os.environ.get("TAOS_WORKER_STATE_DIR")
+    if override:
+        return Path(override)
+    if sys.platform == "win32":
+        base = os.environ.get("LOCALAPPDATA", str(Path.home() / "AppData" / "Local"))
+        return Path(base) / "taos-worker"
+    xdg = os.environ.get("XDG_STATE_HOME")
+    if xdg:
+        return Path(xdg) / "taos-worker"
+    return Path.home() / ".local" / "state" / "taos-worker"
+
+
+def key_path(state_dir: Path) -> Path:
+    """Return the path for the 32-byte signing key file."""
+    return state_dir / "signing_key"
+
+
+def load_signing_key(state_dir: Path) -> bytes | None:
+    """Return the persisted signing key, or None if absent."""
+    p = key_path(state_dir)
+    try:
+        return p.read_bytes()
+    except FileNotFoundError:
+        return None
+
+
+def save_signing_key(state_dir: Path, key: bytes) -> None:
+    """Persist the signing key with restricted permissions (0600 on POSIX)."""
+    state_dir.mkdir(parents=True, exist_ok=True)
+    p = key_path(state_dir)
+    p.write_bytes(key)
+    if sys.platform != "win32":
+        p.chmod(0o600)
+
+
+def generate_pairing_code() -> str:
+    """Return an 8-character code using an unambiguous alphabet."""
+    return "".join(secrets.choice(_ALPHABET) for _ in range(8))
+
+
+def code_hash(code: str) -> str:
+    """Return the sha256 hex digest of the code (matches pairing_store)."""
+    return hashlib.sha256(code.encode()).hexdigest()
+
+
+def sign_request_headers(
+    key: bytes,
+    name: str,
+    method: str,
+    path: str,
+    body: bytes,
+) -> dict:
+    """Return the three HMAC auth headers for a worker request.
+
+    Signing string: f"{timestamp}.{METHOD}.{path}.{sha256(body).hexdigest()}"
+    """
+    ts = str(int(time.time()))
+    body_hash = hashlib.sha256(body).hexdigest()
+    message = f"{ts}.{method.upper()}.{path}.{body_hash}".encode()
+    sig = hmac.new(key, message, hashlib.sha256).hexdigest()
+    return {
+        "X-TAOS-Worker-Name": name,
+        "X-TAOS-Timestamp": ts,
+        "X-TAOS-Signature": sig,
+    }
+
+
+async def run_pairing(
+    client,
+    controller_url: str,
+    name: str,
+    url: str,
+    platform: str,
+    state_dir: Path,
+    *,
+    poll_interval: float = 3.0,
+    timeout: float = 600.0,
+    print_fn=print,
+) -> bytes:
+    """Drive the full pairing flow and return the signing key.
+
+    If a key already exists in state_dir, returns it immediately (idempotent).
+
+    Raises TimeoutError if the admin does not confirm within timeout seconds.
+    Raises RuntimeError on a 404 (invalidated/unknown worker).
+    """
+    existing = load_signing_key(state_dir)
+    if existing is not None:
+        return existing
+
+    deadline = time.monotonic() + timeout
+    controller_url = controller_url.rstrip("/")
+
+    code = generate_pairing_code()
+    await _announce(client, controller_url, name, url, platform, code, print_fn)
+
+    while True:
+        if time.monotonic() >= deadline:
+            raise TimeoutError(
+                f"pairing timed out after {timeout}s; "
+                f"re-run `python -m tinyagentos.worker.pair {controller_url} --name {name}` to resume"
+            )
+        await asyncio.sleep(poll_interval)
+
+        resp = await client.post(
+            f"{controller_url}/api/cluster/pairing/claim",
+            json={"name": name, "code": code},
+        )
+        if resp.status_code == 202:
+            # Not confirmed yet; keep polling.
+            continue
+        if resp.status_code == 410:
+            # Expired; re-announce with a fresh code.
+            code = generate_pairing_code()
+            await _announce(client, controller_url, name, url, platform, code, print_fn)
+            continue
+        if resp.status_code == 200:
+            key = bytes.fromhex(resp.json()["signing_key"])
+            save_signing_key(state_dir, key)
+            return key
+        # 404 or any other error
+        raise RuntimeError(
+            f"pairing claim failed with HTTP {resp.status_code}: {resp.json()}"
+        )
+
+
+async def _announce(
+    client,
+    controller_url: str,
+    name: str,
+    url: str,
+    platform: str,
+    code: str,
+    print_fn,
+) -> None:
+    resp = await client.post(
+        f"{controller_url}/api/cluster/pairing/announce",
+        json={
+            "name": name,
+            "url": url,
+            "platform": platform,
+            "code_hash": code_hash(code),
+        },
+    )
+    if resp.status_code != 200:
+        raise RuntimeError(
+            f"announce failed with HTTP {resp.status_code}: {resp.json()}"
+        )
+    # Print the code prominently so the user can enter it in the taOS UI.
+    print_fn("")
+    print_fn("=" * 56)
+    print_fn(f"  Pairing code: {code[:4]}-{code[4:]}")
+    print_fn("  Enter this in taOS > Cluster to approve this worker")
+    print_fn("=" * 56)
+    print_fn("")


### PR DESCRIPTION
## Summary

- Adds `tinyagentos/worker/pairing.py`: announce -> claim polling loop, HMAC signing (`sign_request_headers`), key persistence with 0600 file permissions, unambiguous 8-char pairing codes, and `default_state_dir` that respects `TAOS_WORKER_STATE_DIR`.
- Adds `tinyagentos/worker/pair.py`: the `python -m tinyagentos.worker.pair` CLI that both install scripts invoke. `--register-after` does the first signed `POST /api/cluster/workers` so the worker is registered before the incus-enroll step (which 404s for unknown workers).
- Updates `WorkerAgent`: loads signing key from `state_dir` on init; `register()` and `heartbeat()` now serialise the body to bytes, sign with `sign_request_headers`, and send via `content=` + explicit headers instead of `json=`. Logs a clear actionable error when not paired rather than silently failing.
- Updates `scripts/install-worker.sh`: replaces the unauthenticated inline `curl` register block with the Python CLI call; threads `TAOS_WORKER_STATE_DIR` into both systemd unit `Environment=` stanzas so the running agent reads the same key the pairing step wrote.
- Updates `scripts/install-worker.ps1`: mirrors the same pairing CLI call and injects `TAOS_WORKER_STATE_DIR` into the scheduled task.

## Design decision: crypto in Python, not shell

Both scripts invoke the same `python -m tinyagentos.worker.pair` CLI rather than reimplementing HMAC-SHA256 and the announce/claim poll loop independently in bash and PowerShell. The one security-critical path is tested once (round-trip against `require_worker_hmac` using the real app) and the shell/PowerShell delta is a single subprocess call. This keeps bash -n and shellcheck clean and avoids the two scripts drifting.

## WorkerAgent signing change

`register()` and `heartbeat()` now produce a deterministic byte string (via `json.dumps(...).encode()`), compute the HMAC over that exact body, and send it with `content=body` plus explicit headers. Using `json=` would let httpx produce a different serialisation than the one that was signed, so the signature would be computed over bytes that never get sent.

## State dir / key persistence

The default state directory is `$TAOS_WORKER_STATE_DIR` (if set), then `$XDG_STATE_HOME/taos-worker` on POSIX, or `%LOCALAPPDATA%\taos-worker` on Windows. The install scripts set `TAOS_WORKER_STATE_DIR=$INSTALL_DIR/.taos-worker-state` in the service unit so the agent always reads the key written by the pairing step.

## Test plan

- `tests/worker/test_pairing.py` (26 tests, new): sign_request_headers round-trip against `require_worker_hmac`, tampered body -> 401 bad_signature, key save/load + 0600 permissions, pairing code alphabet, `run_pairing` happy/410/timeout/already-paired paths, WorkerAgent signed header assertions
- Existing worker/cluster tests updated to inject signing keys and capture `content=` instead of `json=`
- `bash -n scripts/install-worker.sh` passes; shellcheck --severity=warning reports 0 warnings (same as baseline on dev)
- Full suite: 288 cluster+worker tests pass

Phase 2 of #737

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workers now pair with the controller using a displayed pairing code and persist a signing key for authenticated requests.
  * Installer and service units set an explicit worker state directory so the runtime knows where to store pairing/signing material.

* **Bug Fixes**
  * Installer stops when pairing fails or requires admin approval, and clearly instructs the user.

* **Tests**
  * Expanded tests cover pairing, signing, and updated request/heartbeat behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->