### PR TITLE
fix(install): unit template sed mangles TAOS_PREFETCH_BASE_IMAGE into 0_BASE_IMAGE

### DIFF
--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -1499,7 +1499,7 @@ install_linux_systemd_system() {
         -e "s|TAOS_PYTHON|$INSTALL_DIR/.venv/bin/python|g" \
         -e "s|TAOS_PORT|$TAOS_PORT|g" \
         -e "s|TAOS_STOP_SCRIPT|/usr/local/bin/taos-graceful-stop|g" \
-        -e "s|TAOS_PREFETCH|$taos_prefetch|g" \
+        -e "s|__TAOS_PREFETCH_VALUE__|$taos_prefetch|g" \
         "$INSTALL_DIR/scripts/systemd/tinyagentos.service" \
         | $sudo_cmd tee "$unit" > /dev/null
     # Inject bind host/port + proxy port into the unit's Environment block.
@@ -1546,7 +1546,7 @@ install_linux_systemd_user() {
         -e "s|TAOS_PYTHON|$INSTALL_DIR/.venv/bin/python|g" \
         -e "s|TAOS_PORT|$TAOS_PORT|g" \
         -e "s|TAOS_STOP_SCRIPT|$HOME/.local/bin/taos-graceful-stop|g" \
-        -e "s|TAOS_PREFETCH|$taos_prefetch|g" \
+        -e "s|__TAOS_PREFETCH_VALUE__|$taos_prefetch|g" \
         -e "/^User=/d" \
         -e "/^Group=/d" \
         -e "s|WantedBy=multi-user.target|WantedBy=default.target|g" \

--- a/scripts/systemd/tinyagentos.service
+++ b/scripts/systemd/tinyagentos.service
@@ -47,7 +47,7 @@ TimeoutStartSec=180
 # --max-time in taos-graceful-stop.sh.
 TimeoutStopSec=45
 Environment=PYTHONUNBUFFERED=1
-Environment=TAOS_PREFETCH_BASE_IMAGE=TAOS_PREFETCH
+Environment=TAOS_PREFETCH_BASE_IMAGE=__TAOS_PREFETCH_VALUE__
 
 [Install]
 WantedBy=multi-user.target

--- a/tests/test_agent_image_prefetch.py
+++ b/tests/test_agent_image_prefetch.py
@@ -79,9 +79,14 @@ class TestServiceTemplate:
             "..", "scripts", "systemd", "tinyagentos.service",
         )
         content = open(service_path).read()
-        assert "TAOS_PREFETCH_BASE_IMAGE=TAOS_PREFETCH" in content, (
-            "service template must have the TAOS_PREFETCH placeholder "
+        assert "TAOS_PREFETCH_BASE_IMAGE=__TAOS_PREFETCH_VALUE__" in content, (
+            "service template must have the __TAOS_PREFETCH_VALUE__ placeholder "
             "so install-server.sh can substitute it"
+        )
+        # Regression for #757: the old bare placeholder collided with the var
+        # name, so the sed mangled TAOS_PREFETCH_BASE_IMAGE into 0_BASE_IMAGE.
+        assert "=TAOS_PREFETCH\n" not in content, (
+            "placeholder must not be a substring of TAOS_PREFETCH_BASE_IMAGE"
         )
 
     def test_install_script_has_taos_prefetch_doc(self):
@@ -95,13 +100,14 @@ class TestServiceTemplate:
         )
 
     def test_install_script_substitutes_taos_prefetch(self):
-        """sed must have a substitution for TAOS_PREFETCH."""
+        """sed must substitute the prefetch value placeholder."""
         script_path = os.path.join(
             os.path.dirname(__file__),
             "..", "scripts", "install-server.sh",
         )
         content = open(script_path).read()
-        # The sed line that substitutes TAOS_PREFETCH into the service template
-        assert 's|TAOS_PREFETCH|$' in content, (
-            "install script must have sed substitution for TAOS_PREFETCH placeholder"
+        # The sed line that substitutes the value into the service template.
+        assert 's|__TAOS_PREFETCH_VALUE__|$' in content, (
+            "install script must have sed substitution for the "
+            "__TAOS_PREFETCH_VALUE__ placeholder"
         )


### PR DESCRIPTION
The unit template had `Environment=TAOS_PREFETCH_BASE_IMAGE=TAOS_PREFETCH` and the installer ran `s|TAOS_PREFETCH|<value>|g`, which matched both occurrences and produced `Environment=0_BASE_IMAGE=0` in the live unit. The prefetch opt-in could never reach the app through the unit.

Fix renames the value placeholder to `__TAOS_PREFETCH_VALUE__` (not a substring of any real env var) in the template and both substitution sites (system + user unit paths). Verified the substitution now yields `TAOS_PREFETCH_BASE_IMAGE=0` (and `=1` when enabled).

Fixes #757.