### PR TITLE
fix(cluster): guard non-JSON pairing errors and tighten the method-case test

### DIFF
--- a/tests/worker/test_pairing.py
+++ b/tests/worker/test_pairing.py
@@ -80,14 +80,16 @@ class TestSignRequestHeaders:
         from tinyagentos.worker.pairing import sign_request_headers
         key = b"\x05" * 32
         body = b"x"
-        h_lower = sign_request_headers(key, "w", "post", "/p", body)
-        h_upper = sign_request_headers(key, "w", "POST", "/p", body)
-        # same timestamp would differ but we just check the sig matches manual recompute
-        ts = h_lower["X-TAOS-Timestamp"]
         body_hash = hashlib.sha256(body).hexdigest()
-        message = f"{ts}.POST./p.{body_hash}".encode()
-        expected = hmac.new(key, message, hashlib.sha256).hexdigest()
-        assert h_lower["X-TAOS-Signature"] == expected
+        # Both a lowercase and an already-uppercase method must sign over the
+        # normalised "POST" message, so the controller (which sees the real
+        # request method) and the worker agree regardless of caller casing.
+        for method in ("post", "POST"):
+            h = sign_request_headers(key, "w", method, "/p", body)
+            ts = h["X-TAOS-Timestamp"]
+            message = f"{ts}.POST./p.{body_hash}".encode()
+            expected = hmac.new(key, message, hashlib.sha256).hexdigest()
+            assert h["X-TAOS-Signature"] == expected
 
 
 # ---------------------------------------------------------------------------

--- a/tinyagentos/worker/pairing.py
+++ b/tinyagentos/worker/pairing.py
@@ -98,6 +98,18 @@ def sign_request_headers(
     }
 
 
+def _describe_error(resp) -> str:
+    """Best-effort error detail that tolerates non-JSON bodies.
+
+    A reverse proxy or gateway in front of the controller can return plain
+    text or HTML, so resp.json() would raise and mask the real status.
+    """
+    try:
+        return str(resp.json())
+    except Exception:  # noqa: BLE001
+        return resp.text
+
+
 async def run_pairing(
     client,
     controller_url: str,
@@ -153,7 +165,7 @@ async def run_pairing(
             return key
         # 404 or any other error
         raise RuntimeError(
-            f"pairing claim failed with HTTP {resp.status_code}: {resp.json()}"
+            f"pairing claim failed with HTTP {resp.status_code}: {_describe_error(resp)}"
         )
 
 
@@ -177,7 +189,7 @@ async def _announce(
     )
     if resp.status_code != 200:
         raise RuntimeError(
-            f"announce failed with HTTP {resp.status_code}: {resp.json()}"
+            f"announce failed with HTTP {resp.status_code}: {_describe_error(resp)}"
         )
     # Print the code prominently so the user can enter it in the taOS UI.
     # Show the literal code with no separator: the controller hashes the


### PR DESCRIPTION
Follow-up to #770 review (CodeRabbit minors): announce/claim error paths called resp.json() which raises on a non-JSON body (reverse-proxy HTML/text) and masks the real status; now falls back to resp.text via a small _describe_error helper. Also fixed test_method_uppercased which computed an unused h_upper and never asserted normalisation for the uppercase case; now asserts both casings sign over the normalised POST message.