### PR TITLE
chore: promote dev to master (worker pairing scripts, prefetch fix, pairing guards)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ $env:TAOS_CONTROLLER_URL = 'http://your-server:6969'
 iwr -useb https://raw.githubusercontent.com/jaylfc/tinyagentos/master/scripts/install-worker.ps1 | iex
 ```
 
+**Pairing.** A worker no longer registers automatically just by reaching the controller. On first run it prints a short pairing code and announces itself as pending; you approve it in taOS (Cluster) by entering that code, which mints the worker's signing key. From then on the worker signs its register and heartbeat calls with that key, so a host on the LAN cannot register or impersonate a worker it does not physically control. Re-run the installer to resume pairing if you do not approve it straight away.
+
 **Hardware detection on minimal systems.** The worker detects NVIDIA GPUs even when `nvidia-smi` is not installed: it probes `/proc/driver/nvidia` to confirm the driver is loaded and looks up VRAM from a known-cards table keyed by device ID. On native (non-container) hosts the installer offers to install `nvidia-utils` (via `apt`/`dnf`/`pacman`, matching the loaded driver branch automatically). Rockchip NPU detection uses unprivileged sysfs paths so it works inside LXC containers and other restricted environments where `/sys/kernel/debug` is inaccessible. Hosts that have neither GPU nor NPU are registered as CPU workers and contribute embeddings and small-model inference.
 
 **Sudo and freshness.** The Linux/macOS worker installer is designed to run on **either a fresh Debian install or your existing system.** No clean slate required. It installs cleanly on Debian, Ubuntu, Fedora, Arch, Alpine, and macOS.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,52 +1,45 @@
 <!--
   SINGLE SOURCE OF TRUTH for cross-agent handoff. Committed so any agent on any
-  platform sees it. Update on merge / task-start / rate-limit / handoff. The Pi
-  :00/:30 cron also refreshes it. Keep it SHORT, link issues for detail.
-  See docs/AGENT_HANDOFF.md (local-only) for the on-arrival checklist + rules.
+  platform sees it. Update on merge / task-start / rate-limit / handoff. The
+  session freshness cron (:08/:38) also refreshes it. Keep it SHORT, link issues.
+  See docs/AGENT_HANDOFF.md for the on-arrival checklist + rules.
 -->
 
 # taOS: Live Status
 
-**Last updated:** 2026-06-11 ~04:50 BST, by @taOS (Mac session, overnight autonomous run).
+**Last updated:** 2026-06-11 ~10:30 BST, by @taOS (Mac session).
 **Repo:** github.com/jaylfc/taOS, branches `master` (stable) <- `dev` (integration).
 
 ## GOTCHA for the next agent
-- **Protected merges:** `gh pr merge` 401s on the OAuth token but `gh api -X PUT repos/jaylfc/taOS/pulls/N/merge -f merge_method=squash` WORKS with the same token (use `merge_method=merge` for dev->master promotions, never squash, never `--delete-branch`).
-- **Promotion #767 (pairing auth + backend naming) may still be in CI.** If open and green, merge it with the api method above. Everything else from the overnight queue is DONE.
-- CodeRabbit fake passes: a green CodeRabbit check can be a rate-limit notice; check the PR comments, use `@coderabbitai full review`.
-- `tests/` is NOT an importable package: never `from tests.conftest import X` in test files; expose shared helpers as function-returning fixtures (see `pair_and_register_worker` in tests/conftest.py).
+- **Protected merges:** `gh pr merge` 401s on the OAuth token but `gh api -X PUT repos/jaylfc/taOS/pulls/N/merge -f merge_method=squash` WORKS (use `merge_method=merge` for dev->master promotions; never squash a promotion, never `--delete-branch`).
+- **#775 (promotion: worker pairing + prefetch fix + pairing guards + README pairing note) may still be in CI.** If open and green, merge with the api method.
+- CodeRabbit fake passes: a green CodeRabbit check can be a rate-limit notice; check the PR comments, use `@coderabbitai full review`. Kilo often 504s ("Assistant request timed out") = infra flake, not findings.
+- `tests/` is NOT an importable package: never `from tests.conftest import X`; expose shared helpers as function-returning fixtures.
+- Worker onboarding now REQUIRES pairing (a worker prints a code, admin approves in Cluster, signing key minted) before register/heartbeat. The signing string + headers are in tinyagentos/cluster/worker_auth.py; worker side in tinyagentos/worker/pairing.py.
 
-## Overnight run summary (2026-06-10 evening -> 06-11 ~04:50)
-- **Beta Pi incident RESOLVED:** controller was half-alive (active in systemd, :6970 only). Root causes #755 (knowledge.db user_id migration never applied to existing DBs) + #756 (lifespan failure left process alive). Pi repaired + on master, verified healthy.
-- **Merged to dev:** #752 (perf cleanups), #754 (installer sudo gap, closes #753), #758 (controller-rescue runbook), #763 (self-healing knowledge migration + exit-on-startup-failure, closes #755/#756), #764 (worker backend names type:port, closes #759), #762 (cluster pairing-code auth Phase 1, the #737 backend).
-- **Promoted to master:** #766 (3fe1c490) carrying #752/#754/#758/#763. **#767** carrying #762/#764 in flight.
-- **#723 reporter replied** (Jay-approved draft) with recovery instructions; #753 fix on master.
-- **#762 review hardening:** admin gate on pairing pending/confirm, atomic claim (rowcount-gated), actionable 410/404 claim errors, store internals encapsulated (pairing_state()). One CodeRabbit suggestion rejected for cause: counting HMAC failures toward the pairing cap would create a re-pair DoS vector.
+## Recently landed
+- **#737 cluster-worker pairing auth:** Phase 1 backend (#762) + Phase 2 worker scripts/agent signing (#770) DONE, on master via #767 and (pending) #775. Phases 3 (UI pending-workers + enter-code dialog) and 4 (fleet migration UX) remain.
+- **Beta incident fixes on master:** #763 (knowledge user_id migration self-heals bricked installs + exit-on-startup-failure), #754 (installer sudo gap), #768 (installer re-run ownership / priv-esc), #752 (perf), #758 (controller-rescue runbook), #757 (prefetch placeholder).
+- Pi controller was repaired during the incident; it is on an OLD master (93f395e2) and LACKS the pairing backend. Update it before using it as the #772 test controller.
 
 ## Immediate next actions
-1. **POST the #765 reply** (drafted, awaiting Jay go-ahead per draft-first rule): installer re-run ownership bug fixed on master, re-run with sudo now works. Draft in the session transcript.
-2. **#737 Phase 2:** worker scripts (bash + powershell) generate + print the pairing code, announce, poll claim, persist signing_key, sign register/heartbeat. Spec pattern in the #737 issue comment; backend endpoints + HMAC header format are live on dev (see tinyagentos/cluster/worker_auth.py docstring). Sonnet with a full spec.
-3. **#737 Phase 3:** taOS UI pending-workers list + enter-code dialog (frontend-design pass; ties into #760/#761 badge work).
-4. **#737 Phase 4:** migration story for existing fleet workers (clear re-pair prompt, not silent 401s).
-5. **#751** beads-inspired native task-graph: AWAITING Jay greenlight.
-
-Master is fully current: #766 + #767 + #769 all promoted. Whole overnight queue cleared.
+1. Merge **#775** when green; that puts worker pairing + the README pairing note on master.
+2. **#772 smoke test** (Pi controller + Fedora worker): gated on #775 + updating the Pi to that master. Fedora access via @taOSmd (SSH from Pi as jay; details in a 600 file on the Pi, delete after). HARD constraint: Fedora is mid-benchmark, pairing/heartbeat OK but NO GPU model loads / Ollama restarts. Use a throwaway worker name.
+3. **#737 Phase 3** (UI dialog): frontend-design pass, holds for a design session (Apple-grade bar), ties into #760/#761 badges.
+4. **#774 project/shelf registry:** design DONE + spec at docs/superpowers/specs/2026-06-11-project-shelf-registry-design.md (local, gitignored). Next = taOSmd integration thread for the shelf create/archive contract, then a plan.
 
 ## Open issues filed this stretch
-#753 (fixed, #754), #755/#756 (fixed, #763), #757 unit template env mangling (open, small), #759 (fixed, #764), #760 host badges everywhere (UI principle, design pass), #761 per-device emoji/badge identity (brainstorm first; hangs off #737 pairing store + #760).
-
-## In flight
-- **M1 security:** #737 Phase 1 DONE (#762). Phases 2-4 queued (see next actions).
-- **#744 external coding-agent onboarding:** 7 build tasks queued behind M1.
+#757 (fixed #771), #759 (fixed #764), #760 host badges everywhere (UI), #761 per-device emoji identity (brainstorm first), #772 fresh-install/pairing smoke (Pi+Fedora), #774 project/shelf registry (design done).
 
 ## Cross-project (taosmd / A2A)
-- Progress channels live: `taos-progress` (all overnight work posted), `taosmd-progress`. Durable 30-min freshness crons (taOS :00/:30, taosmd :15/:45).
+- #744 taosmd side MERGED (their PR #151): grant matching on (canonical_id, project_id) + verified-claim project binding; the `agent` field on data endpoints is a TARGET SHELF, not the caller. Our 7 #744 build tasks queued.
+- Progress channels live: `taos-progress`, `taosmd-progress`. Freshness crons: taOS session :08/:38 (re-armed 2026-06-11, was dark), Pi durable backstop NOT installed (decision pending Jay).
 
 ## Blocked / waiting on human (Jay)
 - `#15` exo fork deletion: needs `gh auth refresh -s delete_repo`.
-- `TAOSMD_REGISTRY_URL` cutover: gated on the consent UI shipping (deliberate).
-- #751 beads buy-vs-build greenlight.
-- #761 emoji identity brainstorm.
+- `TAOSMD_REGISTRY_URL` cutover: gated on the consent UI shipping.
+- #751 beads buy-vs-build greenlight; #761 emoji brainstorm; #774 -> taOSmd thread.
+- Whether to install a durable Pi-side freshness cron as a backstop to the session cron.
 
 ## Where to look
-1. GitHub issues = task list. 2. This file = snapshot. 3. docs/AGENT_HANDOFF.md (local) = rules + bootstrap. 4. A2A bus :7900 (taos-progress / general / integration). 5. @taOS Pi memory (Claude Code only).
+1. GitHub issues = task list. 2. This file = snapshot. 3. docs/AGENT_HANDOFF.md = rules + bootstrap. 4. A2A bus :7900. 5. @taOS Pi memory (Claude Code only).

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -24,11 +24,13 @@
 - **#762 review hardening:** admin gate on pairing pending/confirm, atomic claim (rowcount-gated), actionable 410/404 claim errors, store internals encapsulated (pairing_state()). One CodeRabbit suggestion rejected for cause: counting HMAC failures toward the pairing cap would create a re-pair DoS vector.
 
 ## Immediate next actions
-1. Merge **#767** if still open (see GOTCHA).
+1. **POST the #765 reply** (drafted, awaiting Jay go-ahead per draft-first rule): installer re-run ownership bug fixed on master, re-run with sudo now works. Draft in the session transcript.
 2. **#737 Phase 2:** worker scripts (bash + powershell) generate + print the pairing code, announce, poll claim, persist signing_key, sign register/heartbeat. Spec pattern in the #737 issue comment; backend endpoints + HMAC header format are live on dev (see tinyagentos/cluster/worker_auth.py docstring). Sonnet with a full spec.
 3. **#737 Phase 3:** taOS UI pending-workers list + enter-code dialog (frontend-design pass; ties into #760/#761 badge work).
 4. **#737 Phase 4:** migration story for existing fleet workers (clear re-pair prompt, not silent 401s).
 5. **#751** beads-inspired native task-graph: AWAITING Jay greenlight.
+
+Master is fully current: #766 + #767 + #769 all promoted. Whole overnight queue cleared.
 
 ## Open issues filed this stretch
 #753 (fixed, #754), #755/#756 (fixed, #763), #757 unit template env mangling (open, small), #759 (fixed, #764), #760 host badges everywhere (UI principle, design pass), #761 per-device emoji/badge identity (brainstorm first; hangs off #737 pairing store + #760).

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -1499,7 +1499,7 @@ install_linux_systemd_system() {
         -e "s|TAOS_PYTHON|$INSTALL_DIR/.venv/bin/python|g" \
         -e "s|TAOS_PORT|$TAOS_PORT|g" \
         -e "s|TAOS_STOP_SCRIPT|/usr/local/bin/taos-graceful-stop|g" \
-        -e "s|TAOS_PREFETCH|$taos_prefetch|g" \
+        -e "s|__TAOS_PREFETCH_VALUE__|$taos_prefetch|g" \
         "$INSTALL_DIR/scripts/systemd/tinyagentos.service" \
         | $sudo_cmd tee "$unit" > /dev/null
     # Inject bind host/port + proxy port into the unit's Environment block.
@@ -1546,7 +1546,7 @@ install_linux_systemd_user() {
         -e "s|TAOS_PYTHON|$INSTALL_DIR/.venv/bin/python|g" \
         -e "s|TAOS_PORT|$TAOS_PORT|g" \
         -e "s|TAOS_STOP_SCRIPT|$HOME/.local/bin/taos-graceful-stop|g" \
-        -e "s|TAOS_PREFETCH|$taos_prefetch|g" \
+        -e "s|__TAOS_PREFETCH_VALUE__|$taos_prefetch|g" \
         -e "/^User=/d" \
         -e "/^Group=/d" \
         -e "s|WantedBy=multi-user.target|WantedBy=default.target|g" \

--- a/scripts/install-worker.ps1
+++ b/scripts/install-worker.ps1
@@ -233,14 +233,35 @@ Log "installing worker python deps into .venv"
 & $venvPython -m pip install --quiet --upgrade pip
 & $venvPython -m pip install --quiet httpx pydantic psutil fastapi uvicorn pyyaml pillow libtorrent
 
+# --- pair + register with controller ------------------------------------
+# Pairing acquires the HMAC signing key; --register-after does the first
+# signed POST /api/cluster/workers. Crypto lives in Python, not PowerShell.
+
+$stateDir = Join-Path $InstallDir '.taos-worker-state'
+Log "pairing worker '$WorkerName' with controller at $ControllerUrl"
+Log "  (the pairing code will be printed below -- enter it in taOS > Cluster)"
+$pairArgs = @(
+    '-m', 'tinyagentos.worker.pair',
+    $ControllerUrl,
+    '--name', $WorkerName,
+    '--state-dir', $stateDir,
+    '--register-after'
+)
+& $venvPython @pairArgs
+if ($LASTEXITCODE -ne 0) {
+    Warn "pairing requires admin approval in taOS > Cluster."
+    Warn "  The code was printed above. Once approved, re-run this installer to resume."
+    exit 1
+}
+
 # --- first-boot benchmark -----------------------------------------------
 
 if (-not $SkipBenchmark) {
-    Log "running initial worker benchmark (first-join only — subsequent runs are manual)"
+    Log "running initial worker benchmark (first-join only -- subsequent runs are manual)"
     try {
         & $venvPython -m tinyagentos.benchmark.runner --report-to $ControllerUrl --worker-name $WorkerName --first-join
     } catch {
-        Warn "benchmark runner not available yet — skipping (worker will run without baseline scores)"
+        Warn "benchmark runner not available yet -- skipping (worker will run without baseline scores)"
     }
 }
 
@@ -261,15 +282,29 @@ function Install-ScheduledTask {
         -RestartCount 999
     $principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType Interactive
 
+    $envVars = @(
+        "TAOS_WORKER_STATE_DIR=$stateDir"
+    )
+
     Unregister-ScheduledTask -TaskName $taskName -Confirm:$false -ErrorAction SilentlyContinue
 
-    Register-ScheduledTask `
+    $task = Register-ScheduledTask `
         -TaskName $taskName `
         -Action $action `
         -Trigger $trigger `
         -Settings $settings `
         -Principal $principal `
-        -Description 'TinyAgentOS worker daemon — connects to the controller and serves inference work' | Out-Null
+        -Description 'TinyAgentOS worker daemon -- connects to the controller and serves inference work' | Out-Null
+
+    # Inject environment variables into the task XML (ScheduledTaskAction has no native env support)
+    try {
+        $xml = (Get-ScheduledTask -TaskName $taskName | Export-ScheduledTask)
+        $envXml = ($envVars | ForEach-Object { "<Variable><Name>$($_.Split('=')[0])</Name><Value>$($_.Split('=',2)[1])</Value></Variable>" }) -join ''
+        $xml = $xml -replace '(<Exec>)', "<EnvironmentVariables>$envXml</EnvironmentVariables>`$1"
+        Register-ScheduledTask -TaskName $taskName -Xml $xml -Force | Out-Null
+    } catch {
+        Warn "could not inject env vars into scheduled task -- worker will use default state dir"
+    }
 
     Start-ScheduledTask -TaskName $taskName
     Log "worker registered as Scheduled Task '$taskName' (starts at logon, auto-restarts)"
@@ -278,7 +313,7 @@ function Install-ScheduledTask {
 }
 
 if ($ServiceMode -eq 'skip') {
-    Log "TAOS_SERVICE=skip — not installing a service"
+    Log "TAOS_SERVICE=skip -- not installing a service"
     Log "run manually: cd $InstallDir; .\.venv\Scripts\python.exe -m tinyagentos.worker $ControllerUrl --name $WorkerName"
 } else {
     Install-ScheduledTask

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -500,36 +500,22 @@ install_and_enroll_incus() {
 
     log "LAN IP: $LAN_IP"
 
-    # ── 7. Register worker with controller ─────────────────────────────
-    # POST /api/cluster/workers so the controller knows this worker exists
-    # before we try to /incus-enroll (that endpoint 404s for unknown workers).
-    # Includes the new LXC-mode fields: host_lan_ip and worker_lxc_image_version.
-    log "registering worker '${WORKER_NAME}' with controller at $CONTROLLER_URL"
-    local reg_code
-    reg_code="$(curl -sS -o /tmp/taos-worker-register.out -w "%{http_code}" \
-        -X POST "$CONTROLLER_URL/api/cluster/workers" \
-        -H "Content-Type: application/json" \
-        -d "{
-            \"name\": \"${WORKER_NAME}\",
-            \"url\": \"https://${LAN_IP}:8443\",
-            \"hardware\": {},
-            \"backends\": [],
-            \"capabilities\": [],
-            \"platform\": \"linux\",
-            \"models\": [],
-            \"host_lan_ip\": \"${TAOS_HOST_LAN_IP:-${LAN_IP}}\",
-            \"worker_lxc_image_version\": \"ubuntu/24.04/amd64\"
-        }" \
-        2>/tmp/taos-worker-register.err || true)"
-
-    if [[ "$reg_code" == 2* ]]; then
-        log "worker registered successfully (HTTP $reg_code)"
-    elif [[ "$reg_code" == "409" ]]; then
-        log "worker already registered (HTTP 409) — continuing to incus-enroll"
-    else
-        warn "worker registration returned HTTP $reg_code"
-        warn "  response: $(cat /tmp/taos-worker-register.out 2>/dev/null)"
-        warn "  continuing to incus-enroll anyway"
+    # ── 7. Pair + register worker with controller ───────────────────────
+    # Pairing acquires the HMAC signing key; --register-after does the
+    # first signed POST /api/cluster/workers so the controller knows this
+    # worker before the incus-enroll step below (that endpoint 404s for
+    # unknown workers). Crypto lives in Python, not shell.
+    log "pairing worker '${WORKER_NAME}' with controller at $CONTROLLER_URL"
+    log "  (the pairing code will be printed below — enter it in taOS > Cluster)"
+    if ! "$INSTALL_DIR/.venv/bin/python" -m tinyagentos.worker.pair \
+            "$CONTROLLER_URL" \
+            --name "$WORKER_NAME" \
+            --url "https://${LAN_IP}:8443" \
+            --register-after; then
+        warn "pairing requires admin approval in taOS > Cluster."
+        warn "  The code was printed above. Once approved, re-run this installer to resume."
+        warn "  To resume later: run this installer again (it will skip already-done steps)."
+        return 1
     fi
 
     # ── 8. POST to controller ───────────────────────────────────────────
@@ -1225,6 +1211,7 @@ ExecStart=$INSTALL_DIR/.venv/bin/python -m tinyagentos.worker $CONTROLLER_URL --
 Restart=always
 RestartSec=5
 Environment=PYTHONUNBUFFERED=1
+Environment=TAOS_WORKER_STATE_DIR=$INSTALL_DIR/.taos-worker-state
 
 [Install]
 WantedBy=multi-user.target
@@ -1253,6 +1240,7 @@ ExecStart=$INSTALL_DIR/.venv/bin/python -m tinyagentos.worker $CONTROLLER_URL --
 Restart=always
 RestartSec=5
 Environment=PYTHONUNBUFFERED=1
+Environment=TAOS_WORKER_STATE_DIR=$INSTALL_DIR/.taos-worker-state
 
 [Install]
 WantedBy=default.target

--- a/scripts/systemd/tinyagentos.service
+++ b/scripts/systemd/tinyagentos.service
@@ -47,7 +47,7 @@ TimeoutStartSec=180
 # --max-time in taos-graceful-stop.sh.
 TimeoutStopSec=45
 Environment=PYTHONUNBUFFERED=1
-Environment=TAOS_PREFETCH_BASE_IMAGE=TAOS_PREFETCH
+Environment=TAOS_PREFETCH_BASE_IMAGE=__TAOS_PREFETCH_VALUE__
 
 [Install]
 WantedBy=multi-user.target

--- a/tests/cluster/test_local_worker_enroll.py
+++ b/tests/cluster/test_local_worker_enroll.py
@@ -226,15 +226,20 @@ class TestWorkerRegistryBridge:
 
 
 @pytest.mark.asyncio
-async def test_heartbeat_includes_capacity_snapshot(monkeypatch):
+async def test_heartbeat_includes_capacity_snapshot(monkeypatch, tmp_path):
     """WorkerAgent.heartbeat() should call capacity_snapshot() and
     include the three byte counters in the POST body.
     """
+    import json as _json
+    import secrets
     from tinyagentos.worker.agent import WorkerAgent
+    from tinyagentos.worker.pairing import save_signing_key
+
+    save_signing_key(tmp_path, secrets.token_bytes(32))
 
     posted_bodies = []
 
-    # Fake httpx.AsyncClient that captures the POST body
+    # Fake httpx.AsyncClient that captures the POST body (sent as content=bytes)
     mock_response = MagicMock()
     mock_response.status_code = 200
 
@@ -242,8 +247,9 @@ async def test_heartbeat_includes_capacity_snapshot(monkeypatch):
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=False)
 
-    async def fake_post(url, json=None, **kwargs):
-        posted_bodies.append(json or {})
+    async def fake_post(url, content=None, headers=None, **kwargs):
+        if content is not None:
+            posted_bodies.append(_json.loads(content))
         return mock_response
 
     mock_client.post = fake_post
@@ -265,8 +271,8 @@ async def test_heartbeat_includes_capacity_snapshot(monkeypatch):
         },
     )
 
-    agent = WorkerAgent("http://controller:6969", name="test-worker")
-    # detect_backends makes outgoing network calls — short-circuit it
+    agent = WorkerAgent("http://controller:6969", name="test-worker", state_dir=tmp_path)
+    # detect_backends makes outgoing network calls -- short-circuit it
     monkeypatch.setattr(agent, "detect_backends", AsyncMock(return_value=[]))
 
     await agent.heartbeat()

--- a/tests/test_agent_image_prefetch.py
+++ b/tests/test_agent_image_prefetch.py
@@ -79,9 +79,14 @@ class TestServiceTemplate:
             "..", "scripts", "systemd", "tinyagentos.service",
         )
         content = open(service_path).read()
-        assert "TAOS_PREFETCH_BASE_IMAGE=TAOS_PREFETCH" in content, (
-            "service template must have the TAOS_PREFETCH placeholder "
+        assert "TAOS_PREFETCH_BASE_IMAGE=__TAOS_PREFETCH_VALUE__" in content, (
+            "service template must have the __TAOS_PREFETCH_VALUE__ placeholder "
             "so install-server.sh can substitute it"
+        )
+        # Regression for #757: the old bare placeholder collided with the var
+        # name, so the sed mangled TAOS_PREFETCH_BASE_IMAGE into 0_BASE_IMAGE.
+        assert "=TAOS_PREFETCH\n" not in content, (
+            "placeholder must not be a substring of TAOS_PREFETCH_BASE_IMAGE"
         )
 
     def test_install_script_has_taos_prefetch_doc(self):
@@ -95,13 +100,14 @@ class TestServiceTemplate:
         )
 
     def test_install_script_substitutes_taos_prefetch(self):
-        """sed must have a substitution for TAOS_PREFETCH."""
+        """sed must substitute the prefetch value placeholder."""
         script_path = os.path.join(
             os.path.dirname(__file__),
             "..", "scripts", "install-server.sh",
         )
         content = open(script_path).read()
-        # The sed line that substitutes TAOS_PREFETCH into the service template
-        assert 's|TAOS_PREFETCH|$' in content, (
-            "install script must have sed substitution for TAOS_PREFETCH placeholder"
+        # The sed line that substitutes the value into the service template.
+        assert 's|__TAOS_PREFETCH_VALUE__|$' in content, (
+            "install script must have sed substitution for the "
+            "__TAOS_PREFETCH_VALUE__ placeholder"
         )

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -138,8 +138,11 @@ class TestWorkerAgent:
 class TestRegistration:
     """Test worker registration with mocked HTTP."""
 
-    async def test_register_success(self):
-        agent = WorkerAgent("http://controller:6969", name="test-worker")
+    async def test_register_success(self, tmp_path):
+        import secrets
+        from tinyagentos.worker.pairing import save_signing_key
+        save_signing_key(tmp_path, secrets.token_bytes(32))
+        agent = WorkerAgent("http://controller:6969", name="test-worker", state_dir=tmp_path)
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.raise_for_status = MagicMock()
@@ -180,8 +183,11 @@ class TestRegistration:
 class TestHeartbeat:
     """Test heartbeat sending with mocked HTTP."""
 
-    async def test_heartbeat_success(self):
-        agent = WorkerAgent("http://controller:6969", name="test-worker")
+    async def test_heartbeat_success(self, tmp_path):
+        import secrets
+        from tinyagentos.worker.pairing import save_signing_key
+        save_signing_key(tmp_path, secrets.token_bytes(32))
+        agent = WorkerAgent("http://controller:6969", name="test-worker", state_dir=tmp_path)
         mock_response = MagicMock()
         mock_response.status_code = 200
 
@@ -193,7 +199,8 @@ class TestHeartbeat:
             mock_client_cls.return_value = mock_client
 
             with patch("tinyagentos.worker.agent.psutil.cpu_percent", return_value=42.0):
-                result = await agent.heartbeat()
+                with patch("tinyagentos.worker.agent.WorkerAgent.detect_backends", return_value=[]):
+                    result = await agent.heartbeat()
 
         # heartbeat() returns the int HTTP status code (or 0 on failure), see #166
         assert result == 200

--- a/tests/worker/test_agent_browser_caps.py
+++ b/tests/worker/test_agent_browser_caps.py
@@ -1,11 +1,14 @@
 """Tests for WorkerAgent extra_capabilities + advertise_url (browser-worker additions)."""
 from __future__ import annotations
 
+import json as _json
+import secrets
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from tinyagentos.worker.agent import WorkerAgent
+from tinyagentos.worker.pairing import save_signing_key
 
 
 class TestWorkerAgentBrowserCaps:
@@ -42,12 +45,14 @@ class TestWorkerAgentBrowserCaps:
 class TestRegisterWithBrowserCaps:
     """Verify register() forwards browser capability + pinned URL to controller."""
 
-    async def test_register_includes_browser_capability(self):
+    async def test_register_includes_browser_capability(self, tmp_path):
+        save_signing_key(tmp_path, secrets.token_bytes(32))
         agent = WorkerAgent(
             "http://controller:6969",
             name="browser-node",
             extra_capabilities=["browser"],
             advertise_url="http://10.0.0.5:7080",
+            state_dir=tmp_path,
         )
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -55,9 +60,9 @@ class TestRegisterWithBrowserCaps:
 
         captured: list[dict] = []
 
-        async def _mock_post(url, json=None, **kwargs):
-            if json is not None:
-                captured.append(json)
+        async def _mock_post(url, content=None, headers=None, **kwargs):
+            if content is not None:
+                captured.append(_json.loads(content))
             return mock_response
 
         with patch("tinyagentos.worker.agent.httpx.AsyncClient") as mock_client_cls:
@@ -76,12 +81,14 @@ class TestRegisterWithBrowserCaps:
         payload = captured[0]
         assert "browser" in payload["capabilities"]
 
-    async def test_register_uses_advertise_url(self):
+    async def test_register_uses_advertise_url(self, tmp_path):
+        save_signing_key(tmp_path, secrets.token_bytes(32))
         agent = WorkerAgent(
             "http://controller:6969",
             name="browser-node",
             extra_capabilities=["browser"],
             advertise_url="http://10.0.0.5:7080",
+            state_dir=tmp_path,
         )
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -89,9 +96,9 @@ class TestRegisterWithBrowserCaps:
 
         captured: list[dict] = []
 
-        async def _mock_post(url, json=None, **kwargs):
-            if json is not None:
-                captured.append(json)
+        async def _mock_post(url, content=None, headers=None, **kwargs):
+            if content is not None:
+                captured.append(_json.loads(content))
             return mock_response
 
         with patch("tinyagentos.worker.agent.httpx.AsyncClient") as mock_client_cls:
@@ -107,12 +114,14 @@ class TestRegisterWithBrowserCaps:
 
         assert captured[0]["url"] == "http://10.0.0.5:7080"
 
-    async def test_register_without_advertise_url_falls_back(self):
+    async def test_register_without_advertise_url_falls_back(self, tmp_path):
         """Without advertise_url, register() falls back to get_worker_url()."""
+        save_signing_key(tmp_path, secrets.token_bytes(32))
         agent = WorkerAgent(
             "http://controller:6969",
             name="plain-node",
             worker_port=9999,
+            state_dir=tmp_path,
         )
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -120,9 +129,9 @@ class TestRegisterWithBrowserCaps:
 
         captured: list[dict] = []
 
-        async def _mock_post(url, json=None, **kwargs):
-            if json is not None:
-                captured.append(json)
+        async def _mock_post(url, content=None, headers=None, **kwargs):
+            if content is not None:
+                captured.append(_json.loads(content))
             return mock_response
 
         with patch("tinyagentos.worker.agent.httpx.AsyncClient") as mock_client_cls:
@@ -139,12 +148,14 @@ class TestRegisterWithBrowserCaps:
         # Should contain :9999 in the URL, not "http://10.0.0.5:7080"
         assert ":9999" in captured[0]["url"]
 
-    async def test_extra_caps_merged_with_backend_caps(self):
+    async def test_extra_caps_merged_with_backend_caps(self, tmp_path):
         """extra_capabilities are unioned with detected backend caps."""
+        save_signing_key(tmp_path, secrets.token_bytes(32))
         agent = WorkerAgent(
             "http://controller:6969",
             extra_capabilities=["browser"],
             advertise_url="http://10.0.0.5:7080",
+            state_dir=tmp_path,
         )
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -152,9 +163,9 @@ class TestRegisterWithBrowserCaps:
 
         captured: list[dict] = []
 
-        async def _mock_post(url, json=None, **kwargs):
-            if json is not None:
-                captured.append(json)
+        async def _mock_post(url, content=None, headers=None, **kwargs):
+            if content is not None:
+                captured.append(_json.loads(content))
             return mock_response
 
         fake_backend = {
@@ -184,22 +195,24 @@ class TestRegisterWithBrowserCaps:
         assert "llm-chat" in caps
         assert "embedding" in caps
 
-    async def test_heartbeat_includes_browser_capability(self):
+    async def test_heartbeat_includes_browser_capability(self, tmp_path):
         """heartbeat() unions extra_capabilities into the posted caps too."""
+        save_signing_key(tmp_path, secrets.token_bytes(32))
         agent = WorkerAgent(
             "http://controller:6969",
             name="browser-node",
             extra_capabilities=["browser"],
             advertise_url="http://10.0.0.5:7080",
+            state_dir=tmp_path,
         )
         mock_response = MagicMock()
         mock_response.status_code = 200
 
         captured: list[dict] = []
 
-        async def _mock_post(url, json=None, **kwargs):
-            if json is not None:
-                captured.append(json)
+        async def _mock_post(url, content=None, headers=None, **kwargs):
+            if content is not None:
+                captured.append(_json.loads(content))
             return mock_response
 
         snap = {

--- a/tests/worker/test_pairing.py
+++ b/tests/worker/test_pairing.py
@@ -1,0 +1,521 @@
+"""Tests for tinyagentos.worker.pairing and the pair CLI.
+
+Coverage:
+- sign_request_headers produces headers that PASS require_worker_hmac (round-trip)
+- tampered body -> 401 bad_signature (round-trip against real app)
+- save/load signing key round-trip + 0600 permissions on POSIX
+- generate_pairing_code: correct length, unambiguous alphabet only
+- code_hash: matches the controller-side sha256 expectation
+- default_state_dir: respects TAOS_WORKER_STATE_DIR and XDG_STATE_HOME
+- run_pairing happy path: announce -> 202 poll -> 200, key saved, returned
+- run_pairing 410 re-announce path: re-announces with fresh code
+- run_pairing timeout: raises TimeoutError
+- run_pairing already-paired short-circuit: returns existing key
+- WorkerAgent.register sends signed headers when key is present
+- WorkerAgent.heartbeat sends signed headers when key is present
+- WorkerAgent.register logs clear error when no key is loaded
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json as _json
+import os
+import sys
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_mock_response(status_code: int, json_data: dict) -> MagicMock:
+    r = MagicMock()
+    r.status_code = status_code
+    r.json = MagicMock(return_value=json_data)
+    return r
+
+
+# ---------------------------------------------------------------------------
+# unit: sign_request_headers
+# ---------------------------------------------------------------------------
+
+class TestSignRequestHeaders:
+    def test_returns_three_headers(self):
+        from tinyagentos.worker.pairing import sign_request_headers
+        key = b"\x01" * 32
+        h = sign_request_headers(key, "w1", "POST", "/api/cluster/workers", b'{"name":"w1"}')
+        assert set(h) == {"X-TAOS-Worker-Name", "X-TAOS-Timestamp", "X-TAOS-Signature"}
+
+    def test_worker_name_in_header(self):
+        from tinyagentos.worker.pairing import sign_request_headers
+        h = sign_request_headers(b"\x02" * 32, "my-worker", "POST", "/path", b"body")
+        assert h["X-TAOS-Worker-Name"] == "my-worker"
+
+    def test_timestamp_is_recent_unix_seconds(self):
+        from tinyagentos.worker.pairing import sign_request_headers
+        before = int(time.time())
+        h = sign_request_headers(b"\x03" * 32, "w", "POST", "/path", b"")
+        after = int(time.time())
+        ts = int(h["X-TAOS-Timestamp"])
+        assert before <= ts <= after
+
+    def test_signature_matches_independent_hmac(self):
+        from tinyagentos.worker.pairing import sign_request_headers
+        key = b"\x04" * 32
+        body = b'{"name":"w","url":"http://x"}'
+        h = sign_request_headers(key, "w", "POST", "/api/cluster/workers", body)
+        ts = h["X-TAOS-Timestamp"]
+        body_hash = hashlib.sha256(body).hexdigest()
+        message = f"{ts}.POST./api/cluster/workers.{body_hash}".encode()
+        expected = hmac.new(key, message, hashlib.sha256).hexdigest()
+        assert h["X-TAOS-Signature"] == expected
+
+    def test_method_uppercased(self):
+        from tinyagentos.worker.pairing import sign_request_headers
+        key = b"\x05" * 32
+        body = b"x"
+        h_lower = sign_request_headers(key, "w", "post", "/p", body)
+        h_upper = sign_request_headers(key, "w", "POST", "/p", body)
+        # same timestamp would differ but we just check the sig matches manual recompute
+        ts = h_lower["X-TAOS-Timestamp"]
+        body_hash = hashlib.sha256(body).hexdigest()
+        message = f"{ts}.POST./p.{body_hash}".encode()
+        expected = hmac.new(key, message, hashlib.sha256).hexdigest()
+        assert h_lower["X-TAOS-Signature"] == expected
+
+
+# ---------------------------------------------------------------------------
+# round-trip: sign_request_headers <-> require_worker_hmac (real app)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_sign_request_headers_passes_hmac_gate(app, client):
+    """Headers from sign_request_headers must satisfy require_worker_hmac."""
+    from tinyagentos.worker.pairing import sign_request_headers
+
+    # Pair a worker so the pairing store has a known key
+    await app.state.cluster_pairing.init()
+    code = "roundtrip-code-1"
+    ch = hashlib.sha256(code.encode()).hexdigest()
+    await client.post(
+        "/api/cluster/pairing/announce",
+        json={"name": "rt-worker", "url": "http://10.9.0.1:9000",
+              "platform": "linux", "code_hash": ch},
+    )
+    await client.post(
+        "/api/cluster/pairing/confirm",
+        json={"name": "rt-worker", "code": code},
+    )
+    resp = await client.post(
+        "/api/cluster/pairing/claim",
+        json={"name": "rt-worker", "code": code},
+    )
+    assert resp.status_code == 200
+    key = bytes.fromhex(resp.json()["signing_key"])
+
+    # Use sign_request_headers to sign a register request
+    reg_body = _json.dumps({
+        "name": "rt-worker", "url": "http://10.9.0.1:9000", "platform": "linux",
+    }).encode()
+    headers = sign_request_headers(key, "rt-worker", "POST", "/api/cluster/workers", reg_body)
+
+    resp = await client.post(
+        "/api/cluster/workers",
+        content=reg_body,
+        headers={**headers, "content-type": "application/json"},
+    )
+    assert resp.status_code == 200, f"expected 200, got {resp.status_code}: {resp.text}"
+    assert resp.json()["status"] == "registered"
+
+    await app.state.cluster_pairing.close()
+
+
+@pytest.mark.asyncio
+async def test_tampered_body_returns_401_bad_signature(app, client):
+    """A body tampered after signing must return 401 bad_signature."""
+    from tinyagentos.worker.pairing import sign_request_headers
+
+    await app.state.cluster_pairing.init()
+    code = "roundtrip-code-2"
+    ch = hashlib.sha256(code.encode()).hexdigest()
+    await client.post(
+        "/api/cluster/pairing/announce",
+        json={"name": "tamper-worker", "url": "http://10.9.0.2:9000",
+              "platform": "linux", "code_hash": ch},
+    )
+    await client.post(
+        "/api/cluster/pairing/confirm",
+        json={"name": "tamper-worker", "code": code},
+    )
+    resp = await client.post(
+        "/api/cluster/pairing/claim",
+        json={"name": "tamper-worker", "code": code},
+    )
+    key = bytes.fromhex(resp.json()["signing_key"])
+
+    # Sign the real body, but send a different (tampered) body
+    real_body = _json.dumps({
+        "name": "tamper-worker", "url": "http://10.9.0.2:9000",
+    }).encode()
+    headers = sign_request_headers(key, "tamper-worker", "POST",
+                                   "/api/cluster/workers", real_body)
+
+    tampered_body = _json.dumps({
+        "name": "tamper-worker", "url": "http://evil.example.com:9000",
+    }).encode()
+    resp = await client.post(
+        "/api/cluster/workers",
+        content=tampered_body,
+        headers={**headers, "content-type": "application/json"},
+    )
+    assert resp.status_code == 401
+    assert resp.json().get("code") == "bad_signature"
+
+    await app.state.cluster_pairing.close()
+
+
+# ---------------------------------------------------------------------------
+# unit: key persistence
+# ---------------------------------------------------------------------------
+
+class TestKeyPersistence:
+    def test_save_and_load_round_trip(self, tmp_path):
+        from tinyagentos.worker.pairing import save_signing_key, load_signing_key, key_path
+        key = b"\xab" * 32
+        save_signing_key(tmp_path, key)
+        loaded = load_signing_key(tmp_path)
+        assert loaded == key
+
+    def test_load_returns_none_when_missing(self, tmp_path):
+        from tinyagentos.worker.pairing import load_signing_key
+        assert load_signing_key(tmp_path) is None
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="chmod not applicable on Windows")
+    def test_save_sets_0600_permissions(self, tmp_path):
+        from tinyagentos.worker.pairing import save_signing_key, key_path
+        save_signing_key(tmp_path, b"\x00" * 32)
+        mode = key_path(tmp_path).stat().st_mode & 0o777
+        assert mode == 0o600
+
+    def test_key_path_is_inside_state_dir(self, tmp_path):
+        from tinyagentos.worker.pairing import key_path
+        p = key_path(tmp_path)
+        assert str(p).startswith(str(tmp_path))
+
+
+# ---------------------------------------------------------------------------
+# unit: generate_pairing_code + code_hash
+# ---------------------------------------------------------------------------
+
+class TestPairingCode:
+    _UNAMBIGUOUS = set("23456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz")
+
+    def test_length_8(self):
+        from tinyagentos.worker.pairing import generate_pairing_code
+        code = generate_pairing_code()
+        assert len(code) == 8
+
+    def test_only_unambiguous_chars(self):
+        from tinyagentos.worker.pairing import generate_pairing_code
+        for _ in range(50):
+            code = generate_pairing_code()
+            for ch in code:
+                assert ch in self._UNAMBIGUOUS, f"ambiguous char {ch!r} in code {code!r}"
+
+    def test_returns_string(self):
+        from tinyagentos.worker.pairing import generate_pairing_code
+        assert isinstance(generate_pairing_code(), str)
+
+    def test_code_hash_matches_sha256(self):
+        from tinyagentos.worker.pairing import code_hash
+        code = "ABCD1234"
+        expected = hashlib.sha256(code.encode()).hexdigest()
+        assert code_hash(code) == expected
+
+    def test_code_hash_is_64_hex_chars(self):
+        from tinyagentos.worker.pairing import code_hash
+        h = code_hash("X")
+        assert len(h) == 64
+        int(h, 16)  # raises if not hex
+
+
+# ---------------------------------------------------------------------------
+# unit: default_state_dir
+# ---------------------------------------------------------------------------
+
+class TestDefaultStateDir:
+    def test_env_override(self, monkeypatch, tmp_path):
+        from tinyagentos.worker import pairing as _p
+        monkeypatch.setenv("TAOS_WORKER_STATE_DIR", str(tmp_path))
+        monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+        d = _p.default_state_dir()
+        assert d == tmp_path
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="XDG not relevant on Windows")
+    def test_xdg_state_home(self, monkeypatch, tmp_path):
+        from tinyagentos.worker import pairing as _p
+        monkeypatch.delenv("TAOS_WORKER_STATE_DIR", raising=False)
+        monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+        d = _p.default_state_dir()
+        assert d == tmp_path / "taos-worker"
+
+    def test_returns_path(self, monkeypatch):
+        from tinyagentos.worker import pairing as _p
+        monkeypatch.delenv("TAOS_WORKER_STATE_DIR", raising=False)
+        d = _p.default_state_dir()
+        assert isinstance(d, Path)
+
+
+# ---------------------------------------------------------------------------
+# async unit: run_pairing
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_run_pairing_happy_path(tmp_path):
+    """announce -> 202 -> 200 with key -> key saved and returned."""
+    import secrets
+    from tinyagentos.worker.pairing import run_pairing
+
+    fake_key = secrets.token_bytes(32)
+    call_count = 0
+
+    async def mock_post(url, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if "/pairing/announce" in url:
+            return _make_mock_response(200, {"status": "pending"})
+        if "/pairing/claim" in url:
+            if call_count <= 2:
+                # first claim -> 202 awaiting
+                return _make_mock_response(202, {"status": "awaiting_confirm"})
+            # second claim -> 200 with key
+            return _make_mock_response(200, {"signing_key": fake_key.hex()})
+        raise AssertionError(f"unexpected POST to {url}")
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(side_effect=mock_post)
+
+    printed = []
+    key = await run_pairing(
+        mock_client,
+        "http://controller:6969",
+        "test-worker",
+        "http://10.0.0.1:9000",
+        "linux",
+        tmp_path,
+        poll_interval=0.01,
+        timeout=10.0,
+        print_fn=printed.append,
+    )
+
+    assert key == fake_key
+    # Key must be persisted
+    from tinyagentos.worker.pairing import load_signing_key
+    assert load_signing_key(tmp_path) == fake_key
+    # Pairing code banner must have been printed
+    assert any("Pairing code" in str(m) or "pairing code" in str(m).lower() for m in printed)
+
+
+@pytest.mark.asyncio
+async def test_run_pairing_already_paired_short_circuit(tmp_path):
+    """If a key already exists, run_pairing returns it without any HTTP calls."""
+    from tinyagentos.worker.pairing import run_pairing, save_signing_key
+
+    existing = b"\xcc" * 32
+    save_signing_key(tmp_path, existing)
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(side_effect=AssertionError("should not be called"))
+
+    key = await run_pairing(
+        mock_client,
+        "http://controller:6969",
+        "w",
+        "http://x",
+        "linux",
+        tmp_path,
+        poll_interval=0.01,
+        timeout=5.0,
+    )
+    assert key == existing
+    mock_client.post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_pairing_410_re_announces(tmp_path):
+    """On 410 from claim, run_pairing re-announces with a fresh code and keeps going."""
+    import secrets
+    from tinyagentos.worker.pairing import run_pairing
+
+    fake_key = secrets.token_bytes(32)
+    announce_count = 0
+    claim_count = 0
+
+    async def mock_post(url, **kwargs):
+        nonlocal announce_count, claim_count
+        if "/pairing/announce" in url:
+            announce_count += 1
+            return _make_mock_response(200, {"status": "pending"})
+        if "/pairing/claim" in url:
+            claim_count += 1
+            if claim_count == 1:
+                return _make_mock_response(410, {"error": "expired"})
+            if claim_count == 2:
+                # After re-announce, poll once as awaiting
+                return _make_mock_response(202, {"status": "awaiting_confirm"})
+            return _make_mock_response(200, {"signing_key": fake_key.hex()})
+        raise AssertionError(f"unexpected POST to {url}")
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(side_effect=mock_post)
+
+    key = await run_pairing(
+        mock_client,
+        "http://controller:6969",
+        "w",
+        "http://x",
+        "linux",
+        tmp_path,
+        poll_interval=0.01,
+        timeout=10.0,
+    )
+    assert key == fake_key
+    assert announce_count == 2  # re-announced once after 410
+
+
+@pytest.mark.asyncio
+async def test_run_pairing_timeout(tmp_path):
+    """run_pairing raises TimeoutError if the claim never returns 200."""
+    from tinyagentos.worker.pairing import run_pairing
+
+    async def mock_post(url, **kwargs):
+        if "/pairing/announce" in url:
+            return _make_mock_response(200, {"status": "pending"})
+        if "/pairing/claim" in url:
+            return _make_mock_response(202, {"status": "awaiting_confirm"})
+        raise AssertionError(f"unexpected POST to {url}")
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(side_effect=mock_post)
+
+    with pytest.raises(TimeoutError):
+        await run_pairing(
+            mock_client,
+            "http://controller:6969",
+            "w",
+            "http://x",
+            "linux",
+            tmp_path,
+            poll_interval=0.01,
+            timeout=0.1,
+        )
+
+
+# ---------------------------------------------------------------------------
+# WorkerAgent: signed register / heartbeat
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_worker_agent_register_sends_signed_headers(tmp_path):
+    """WorkerAgent.register must attach HMAC headers when a key is present."""
+    import secrets
+    from tinyagentos.worker.pairing import save_signing_key
+    from tinyagentos.worker.agent import WorkerAgent
+
+    key = secrets.token_bytes(32)
+    save_signing_key(tmp_path, key)
+
+    agent = WorkerAgent("http://controller:6969", name="signed-worker", state_dir=tmp_path)
+
+    captured = {}
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.raise_for_status = MagicMock()
+
+    async def mock_post(url, **kwargs):
+        captured["headers"] = kwargs.get("headers", {})
+        captured["content"] = kwargs.get("content")
+        return mock_response
+
+    with patch("tinyagentos.worker.agent.httpx.AsyncClient") as mock_cls:
+        mock_c = AsyncMock()
+        mock_c.__aenter__ = AsyncMock(return_value=mock_c)
+        mock_c.__aexit__ = AsyncMock(return_value=False)
+        mock_c.post = AsyncMock(side_effect=mock_post)
+        mock_c.get = AsyncMock(side_effect=Exception("not running"))
+        mock_cls.return_value = mock_c
+
+        with patch("tinyagentos.worker.agent.WorkerAgent.detect_backends", return_value=[]):
+            result = await agent.register()
+
+    assert result is True
+    assert "X-TAOS-Worker-Name" in captured["headers"]
+    assert "X-TAOS-Timestamp" in captured["headers"]
+    assert "X-TAOS-Signature" in captured["headers"]
+    assert captured["headers"]["X-TAOS-Worker-Name"] == "signed-worker"
+    # Body sent as bytes (content=), not json=
+    assert isinstance(captured["content"], bytes)
+
+
+@pytest.mark.asyncio
+async def test_worker_agent_heartbeat_sends_signed_headers(tmp_path):
+    """WorkerAgent.heartbeat must attach HMAC headers when a key is present."""
+    import secrets
+    from tinyagentos.worker.pairing import save_signing_key
+    from tinyagentos.worker.agent import WorkerAgent
+
+    key = secrets.token_bytes(32)
+    save_signing_key(tmp_path, key)
+
+    agent = WorkerAgent("http://controller:6969", name="hb-worker", state_dir=tmp_path)
+
+    captured = {}
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+
+    async def mock_post(url, **kwargs):
+        captured["headers"] = kwargs.get("headers", {})
+        captured["content"] = kwargs.get("content")
+        return mock_response
+
+    with patch("tinyagentos.worker.agent.httpx.AsyncClient") as mock_cls:
+        mock_c = AsyncMock()
+        mock_c.__aenter__ = AsyncMock(return_value=mock_c)
+        mock_c.__aexit__ = AsyncMock(return_value=False)
+        mock_c.post = AsyncMock(side_effect=mock_post)
+        mock_cls.return_value = mock_c
+
+        with patch("tinyagentos.worker.agent.psutil.cpu_percent", return_value=10.0):
+            with patch("tinyagentos.worker.agent.WorkerAgent.detect_backends", return_value=[]):
+                result = await agent.heartbeat()
+
+    assert result == 200
+    assert "X-TAOS-Worker-Name" in captured["headers"]
+    assert "X-TAOS-Signature" in captured["headers"]
+    assert isinstance(captured["content"], bytes)
+
+
+@pytest.mark.asyncio
+async def test_worker_agent_register_logs_error_when_no_key(tmp_path, caplog):
+    """WorkerAgent.register logs a clear actionable error if no signing key is present."""
+    import logging
+    from tinyagentos.worker.agent import WorkerAgent
+
+    agent = WorkerAgent("http://controller:6969", name="unpaired-worker", state_dir=tmp_path)
+
+    with caplog.at_level(logging.ERROR, logger="tinyagentos.worker.agent"):
+        with patch("tinyagentos.worker.agent.WorkerAgent.detect_backends", return_value=[]):
+            result = await agent.register()
+
+    assert result is False
+    # Check a clear error was logged mentioning pairing
+    combined = " ".join(r.message for r in caplog.records).lower()
+    assert "paired" in combined or "signing key" in combined

--- a/tests/worker/test_pairing.py
+++ b/tests/worker/test_pairing.py
@@ -80,14 +80,16 @@ class TestSignRequestHeaders:
         from tinyagentos.worker.pairing import sign_request_headers
         key = b"\x05" * 32
         body = b"x"
-        h_lower = sign_request_headers(key, "w", "post", "/p", body)
-        h_upper = sign_request_headers(key, "w", "POST", "/p", body)
-        # same timestamp would differ but we just check the sig matches manual recompute
-        ts = h_lower["X-TAOS-Timestamp"]
         body_hash = hashlib.sha256(body).hexdigest()
-        message = f"{ts}.POST./p.{body_hash}".encode()
-        expected = hmac.new(key, message, hashlib.sha256).hexdigest()
-        assert h_lower["X-TAOS-Signature"] == expected
+        # Both a lowercase and an already-uppercase method must sign over the
+        # normalised "POST" message, so the controller (which sees the real
+        # request method) and the worker agree regardless of caller casing.
+        for method in ("post", "POST"):
+            h = sign_request_headers(key, "w", method, "/p", body)
+            ts = h["X-TAOS-Timestamp"]
+            message = f"{ts}.POST./p.{body_hash}".encode()
+            expected = hmac.new(key, message, hashlib.sha256).hexdigest()
+            assert h["X-TAOS-Signature"] == expected
 
 
 # ---------------------------------------------------------------------------

--- a/tinyagentos/worker/agent.py
+++ b/tinyagentos/worker/agent.py
@@ -73,6 +73,7 @@ class WorkerAgent:
         worker_port: int = 0,
         extra_capabilities: list[str] | None = None,
         advertise_url: str | None = None,
+        state_dir: "Path | None" = None,
     ):
         self.controller_url = controller_url.rstrip("/")
         self.name = name or socket.gethostname()
@@ -81,6 +82,10 @@ class WorkerAgent:
         self.advertise_url = advertise_url
         self._running = False
         self._registered = False
+
+        from tinyagentos.worker.pairing import default_state_dir, load_signing_key
+        self._state_dir = state_dir or default_state_dir()
+        self._signing_key: bytes | None = load_signing_key(self._state_dir)
 
     async def detect_backends(self) -> list[dict]:
         """Discover locally running inference backends via live probing.
@@ -336,9 +341,20 @@ class WorkerAgent:
         return f"http://{ip}:{self.worker_port}" if self.worker_port else f"http://{ip}"
 
     async def register(self) -> bool:
-        """Register with the controller."""
+        """Register with the controller (signed with HMAC key if paired)."""
         from tinyagentos.hardware import detect_hardware
         from dataclasses import asdict
+        import json as _json
+
+        if self._signing_key is None:
+            logger.error(
+                "worker not paired: no signing key at %s; "
+                "run `python -m tinyagentos.worker.pair %s --name %s` to pair this worker",
+                self._state_dir,
+                self.controller_url,
+                self.name,
+            )
+            return False
 
         hw = detect_hardware()
         backends = await self.detect_backends()
@@ -370,8 +386,17 @@ class WorkerAgent:
             payload["pending_storage_backup"] = backup
 
         try:
+            from tinyagentos.worker.pairing import sign_request_headers
+            path = "/api/cluster/workers"
+            body = _json.dumps(payload).encode()
+            auth_headers = sign_request_headers(self._signing_key, self.name, "POST", path, body)
+            auth_headers["content-type"] = "application/json"
             async with httpx.AsyncClient(timeout=10) as client:
-                resp = await client.post(f"{self.controller_url}/api/cluster/workers", json=payload)
+                resp = await client.post(
+                    f"{self.controller_url}{path}",
+                    content=body,
+                    headers=auth_headers,
+                )
                 resp.raise_for_status()
                 self._registered = True
                 logger.info(f"Registered with controller as '{self.name}'")
@@ -396,29 +421,47 @@ class WorkerAgent:
         trigger a re-registration.
         """
         from tinyagentos.cluster.worker_capacity import capacity_snapshot
+        import json as _json
+
+        if self._signing_key is None:
+            logger.error(
+                "worker not paired: no signing key at %s; "
+                "run `python -m tinyagentos.worker.pair %s --name %s` to pair this worker",
+                self._state_dir,
+                self.controller_url,
+                self.name,
+            )
+            return 0
 
         try:
+            from tinyagentos.worker.pairing import sign_request_headers
             load = psutil.cpu_percent() / 100.0
             backends = await self.detect_backends()
             caps = sorted(set(self.detect_capabilities(backends)) | set(self.extra_capabilities))
             kv_quant = self.detect_kv_quant_support(backends)
             snap = capacity_snapshot()
+            path = "/api/cluster/heartbeat"
+            payload = {
+                "name": self.name,
+                "load": load,
+                "backends": backends,
+                "capabilities": caps,
+                "kv_cache_quant_support": kv_quant.get("legacy", ["fp16"]),
+                "kv_cache_quant_k_support": kv_quant.get("k", ["fp16"]),
+                "kv_cache_quant_v_support": kv_quant.get("v", ["fp16"]),
+                "kv_cache_quant_boundary_layer_protect": bool(kv_quant.get("boundary", False)),
+                "storage_cap_bytes": snap["storage_cap_bytes"],
+                "storage_used_bytes": snap["storage_used_bytes"],
+                "bytes_deduped_total": snap["bytes_deduped_total"],
+            }
+            body = _json.dumps(payload).encode()
+            auth_headers = sign_request_headers(self._signing_key, self.name, "POST", path, body)
+            auth_headers["content-type"] = "application/json"
             async with httpx.AsyncClient(timeout=5) as client:
                 resp = await client.post(
-                    f"{self.controller_url}/api/cluster/heartbeat",
-                    json={
-                        "name": self.name,
-                        "load": load,
-                        "backends": backends,
-                        "capabilities": caps,
-                        "kv_cache_quant_support": kv_quant.get("legacy", ["fp16"]),
-                        "kv_cache_quant_k_support": kv_quant.get("k", ["fp16"]),
-                        "kv_cache_quant_v_support": kv_quant.get("v", ["fp16"]),
-                        "kv_cache_quant_boundary_layer_protect": bool(kv_quant.get("boundary", False)),
-                        "storage_cap_bytes": snap["storage_cap_bytes"],
-                        "storage_used_bytes": snap["storage_used_bytes"],
-                        "bytes_deduped_total": snap["bytes_deduped_total"],
-                    },
+                    f"{self.controller_url}{path}",
+                    content=body,
+                    headers=auth_headers,
                 )
                 return resp.status_code
         except Exception:

--- a/tinyagentos/worker/pair.py
+++ b/tinyagentos/worker/pair.py
@@ -1,0 +1,131 @@
+"""Worker pairing CLI.
+
+Drives the announce -> admin-confirm -> claim flow and optionally
+performs a signed first-registration so the worker is known to the
+controller before the incus-enroll step in the install script.
+
+Usage (called by install-worker.sh and install-worker.ps1):
+    python -m tinyagentos.worker.pair <controller_url> \\
+        --name <name> --url <worker_url> --register-after
+
+Exit codes:
+    0  paired (and registered if --register-after)
+    1  pairing error (timeout, invalidated, network)
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json as _json
+import platform
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Pair this worker with a taOS controller")
+    parser.add_argument("controller", help="Controller URL, e.g. http://192.168.1.10:6969")
+    parser.add_argument("--name", help="Worker name (default: hostname)")
+    parser.add_argument("--url", help="Advertised worker URL (default: auto-detected LAN URL)")
+    parser.add_argument("--platform", dest="platform_name",
+                        default=platform.system().lower(),
+                        help="Platform string (default: current OS)")
+    parser.add_argument("--state-dir", type=Path, default=None,
+                        help="Directory for key persistence (default: system default)")
+    parser.add_argument("--register-after", action="store_true",
+                        help="Send a signed POST /api/cluster/workers after pairing")
+    parser.add_argument("--timeout", type=float, default=600.0,
+                        help="Max seconds to wait for admin confirmation (default: 600)")
+    args = parser.parse_args()
+
+    try:
+        asyncio.run(_run(args))
+    except TimeoutError as exc:
+        print(f"\n[pair] {exc}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as exc:  # noqa: BLE001
+        print(f"\n[pair] pairing failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+async def _run(args) -> None:
+    import httpx
+    from tinyagentos.worker.pairing import default_state_dir, run_pairing, sign_request_headers
+
+    state_dir = args.state_dir or default_state_dir()
+    name = args.name or _hostname()
+
+    # Resolve advertised URL — use provided, or infer from LAN IP.
+    if args.url:
+        worker_url = args.url
+    else:
+        from tinyagentos.worker.agent import WorkerAgent
+        agent = WorkerAgent(args.controller, name=name, state_dir=state_dir)
+        worker_url = agent.get_worker_url()
+
+    async with httpx.AsyncClient(timeout=15) as client:
+        key = await run_pairing(
+            client,
+            args.controller,
+            name,
+            worker_url,
+            args.platform_name,
+            state_dir,
+            timeout=args.timeout,
+        )
+
+    print(f"\n[pair] paired successfully as '{name}'. Signing key saved to {state_dir}")
+
+    if args.register_after:
+        await _signed_register(args.controller, name, worker_url, args.platform_name, key)
+
+
+async def _signed_register(
+    controller_url: str,
+    name: str,
+    worker_url: str,
+    plat: str,
+    key: bytes,
+) -> None:
+    """POST /api/cluster/workers with HMAC auth so the worker is known before incus-enroll."""
+    import httpx
+    from tinyagentos.worker.pairing import sign_request_headers
+
+    controller_url = controller_url.rstrip("/")
+    path = "/api/cluster/workers"
+    payload = {
+        "name": name,
+        "url": worker_url,
+        "platform": plat,
+        "hardware": {},
+        "backends": [],
+        "capabilities": [],
+        "models": [],
+    }
+    body = _json.dumps(payload).encode()
+    headers = sign_request_headers(key, name, "POST", path, body)
+    headers["content-type"] = "application/json"
+
+    async with httpx.AsyncClient(timeout=15) as client:
+        resp = await client.post(
+            f"{controller_url}{path}",
+            content=body,
+            headers=headers,
+        )
+
+    if resp.status_code in (200, 409):
+        status = "registered" if resp.status_code == 200 else "already registered"
+        print(f"[pair] worker {status} with controller")
+    else:
+        raise RuntimeError(
+            f"signed register failed with HTTP {resp.status_code}: {resp.text}"
+        )
+
+
+def _hostname() -> str:
+    import socket
+    return socket.gethostname()
+
+
+if __name__ == "__main__":
+    main()

--- a/tinyagentos/worker/pairing.py
+++ b/tinyagentos/worker/pairing.py
@@ -1,0 +1,191 @@
+"""Worker-side pairing utilities.
+
+Handles the announce -> admin-confirm -> claim flow, key persistence,
+and request signing. The HMAC signing string and headers must byte-match
+tinyagentos.cluster.worker_auth:
+
+    message = f"{timestamp}.{METHOD}.{path}.{sha256(body).hexdigest()}"
+    headers: X-TAOS-Worker-Name, X-TAOS-Timestamp, X-TAOS-Signature
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import os
+import secrets
+import sys
+import time
+from pathlib import Path
+
+# Unambiguous alphabet: strips 0/O/1/I/l to reduce transcription errors.
+_ALPHABET = "23456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz"
+
+
+def default_state_dir() -> Path:
+    """Return the default directory for persisting worker state.
+
+    Priority:
+      1. $TAOS_WORKER_STATE_DIR (explicit override)
+      2. $XDG_STATE_HOME/taos-worker  (POSIX)
+      3. %LOCALAPPDATA%/taos-worker   (Windows)
+      4. ~/.local/state/taos-worker   (POSIX fallback)
+    """
+    override = os.environ.get("TAOS_WORKER_STATE_DIR")
+    if override:
+        return Path(override)
+    if sys.platform == "win32":
+        base = os.environ.get("LOCALAPPDATA", str(Path.home() / "AppData" / "Local"))
+        return Path(base) / "taos-worker"
+    xdg = os.environ.get("XDG_STATE_HOME")
+    if xdg:
+        return Path(xdg) / "taos-worker"
+    return Path.home() / ".local" / "state" / "taos-worker"
+
+
+def key_path(state_dir: Path) -> Path:
+    """Return the path for the 32-byte signing key file."""
+    return state_dir / "signing_key"
+
+
+def load_signing_key(state_dir: Path) -> bytes | None:
+    """Return the persisted signing key, or None if absent."""
+    p = key_path(state_dir)
+    try:
+        return p.read_bytes()
+    except FileNotFoundError:
+        return None
+
+
+def save_signing_key(state_dir: Path, key: bytes) -> None:
+    """Persist the signing key with restricted permissions (0600 on POSIX)."""
+    state_dir.mkdir(parents=True, exist_ok=True)
+    p = key_path(state_dir)
+    p.write_bytes(key)
+    if sys.platform != "win32":
+        p.chmod(0o600)
+
+
+def generate_pairing_code() -> str:
+    """Return an 8-character code using an unambiguous alphabet."""
+    return "".join(secrets.choice(_ALPHABET) for _ in range(8))
+
+
+def code_hash(code: str) -> str:
+    """Return the sha256 hex digest of the code (matches pairing_store)."""
+    return hashlib.sha256(code.encode()).hexdigest()
+
+
+def sign_request_headers(
+    key: bytes,
+    name: str,
+    method: str,
+    path: str,
+    body: bytes,
+) -> dict:
+    """Return the three HMAC auth headers for a worker request.
+
+    Signing string: f"{timestamp}.{METHOD}.{path}.{sha256(body).hexdigest()}"
+    """
+    ts = str(int(time.time()))
+    body_hash = hashlib.sha256(body).hexdigest()
+    message = f"{ts}.{method.upper()}.{path}.{body_hash}".encode()
+    sig = hmac.new(key, message, hashlib.sha256).hexdigest()
+    return {
+        "X-TAOS-Worker-Name": name,
+        "X-TAOS-Timestamp": ts,
+        "X-TAOS-Signature": sig,
+    }
+
+
+async def run_pairing(
+    client,
+    controller_url: str,
+    name: str,
+    url: str,
+    platform: str,
+    state_dir: Path,
+    *,
+    poll_interval: float = 3.0,
+    timeout: float = 600.0,
+    print_fn=print,
+) -> bytes:
+    """Drive the full pairing flow and return the signing key.
+
+    If a key already exists in state_dir, returns it immediately (idempotent).
+
+    Raises TimeoutError if the admin does not confirm within timeout seconds.
+    Raises RuntimeError on a 404 (invalidated/unknown worker).
+    """
+    existing = load_signing_key(state_dir)
+    if existing is not None:
+        return existing
+
+    deadline = time.monotonic() + timeout
+    controller_url = controller_url.rstrip("/")
+
+    code = generate_pairing_code()
+    await _announce(client, controller_url, name, url, platform, code, print_fn)
+
+    while True:
+        if time.monotonic() >= deadline:
+            raise TimeoutError(
+                f"pairing timed out after {timeout}s; "
+                f"re-run `python -m tinyagentos.worker.pair {controller_url} --name {name}` to resume"
+            )
+        await asyncio.sleep(poll_interval)
+
+        resp = await client.post(
+            f"{controller_url}/api/cluster/pairing/claim",
+            json={"name": name, "code": code},
+        )
+        if resp.status_code == 202:
+            # Not confirmed yet; keep polling.
+            continue
+        if resp.status_code == 410:
+            # Expired; re-announce with a fresh code.
+            code = generate_pairing_code()
+            await _announce(client, controller_url, name, url, platform, code, print_fn)
+            continue
+        if resp.status_code == 200:
+            key = bytes.fromhex(resp.json()["signing_key"])
+            save_signing_key(state_dir, key)
+            return key
+        # 404 or any other error
+        raise RuntimeError(
+            f"pairing claim failed with HTTP {resp.status_code}: {resp.json()}"
+        )
+
+
+async def _announce(
+    client,
+    controller_url: str,
+    name: str,
+    url: str,
+    platform: str,
+    code: str,
+    print_fn,
+) -> None:
+    resp = await client.post(
+        f"{controller_url}/api/cluster/pairing/announce",
+        json={
+            "name": name,
+            "url": url,
+            "platform": platform,
+            "code_hash": code_hash(code),
+        },
+    )
+    if resp.status_code != 200:
+        raise RuntimeError(
+            f"announce failed with HTTP {resp.status_code}: {resp.json()}"
+        )
+    # Print the code prominently so the user can enter it in the taOS UI.
+    # Show the literal code with no separator: the controller hashes the
+    # exact string the admin types, so a cosmetic dash would make the
+    # entered code mismatch the announced hash and the confirm would fail.
+    print_fn("")
+    print_fn("=" * 56)
+    print_fn(f"  Pairing code: {code}")
+    print_fn("  Enter this in taOS > Cluster to approve this worker")
+    print_fn("=" * 56)
+    print_fn("")

--- a/tinyagentos/worker/pairing.py
+++ b/tinyagentos/worker/pairing.py
@@ -98,6 +98,18 @@ def sign_request_headers(
     }
 
 
+def _describe_error(resp) -> str:
+    """Best-effort error detail that tolerates non-JSON bodies.
+
+    A reverse proxy or gateway in front of the controller can return plain
+    text or HTML, so resp.json() would raise and mask the real status.
+    """
+    try:
+        return str(resp.json())
+    except Exception:  # noqa: BLE001
+        return resp.text
+
+
 async def run_pairing(
     client,
     controller_url: str,
@@ -153,7 +165,7 @@ async def run_pairing(
             return key
         # 404 or any other error
         raise RuntimeError(
-            f"pairing claim failed with HTTP {resp.status_code}: {resp.json()}"
+            f"pairing claim failed with HTTP {resp.status_code}: {_describe_error(resp)}"
         )
 
 
@@ -177,7 +189,7 @@ async def _announce(
     )
     if resp.status_code != 200:
         raise RuntimeError(
-            f"announce failed with HTTP {resp.status_code}: {resp.json()}"
+            f"announce failed with HTTP {resp.status_code}: {_describe_error(resp)}"
         )
     # Print the code prominently so the user can enter it in the taOS UI.
     # Show the literal code with no separator: the controller hashes the


### PR DESCRIPTION
Promotes to master:
- #770: worker pairing flow + signed register/heartbeat (#737 Phase 2). Worker agent and install scripts now obtain a signing key via the pairing CLI and sign cluster calls; unblocks worker onboarding against the Phase 1 HMAC gate.
- #771: unit template no longer mangles TAOS_PREFETCH_BASE_IMAGE into 0_BASE_IMAGE (#757).
- #773: tolerate non-JSON pairing error bodies; tighten the method-case test (#770 review follow-up).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added worker pairing flow: workers now must be paired with the controller before registration, requiring admin approval via a generated pairing code.
  * Enhanced installer scripts for both Windows and Linux to include the pairing step before initial benchmarking.
  * Introduced signed request authentication for worker communications with the controller.

* **Tests**
  * Added comprehensive test coverage for the new worker pairing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->