### PR TITLE
fix(desktop): render taOS agent chat in the pop-out window and guard screenshot capture (#780)

### DIFF
--- a/desktop/src/apps/TaosAssistantWindow.tsx
+++ b/desktop/src/apps/TaosAssistantWindow.tsx
@@ -35,7 +35,7 @@ export function TaosAssistantWindow({ windowId }: { windowId: string }) {
         </div>
       </div>
       <div className="flex-1 min-h-0 overflow-hidden">
-        <TaosAssistantPanelInner />
+        <TaosAssistantPanelInner embedded />
       </div>
     </div>
   );

--- a/desktop/src/components/TaosAssistantPanel.tsx
+++ b/desktop/src/components/TaosAssistantPanel.tsx
@@ -26,7 +26,7 @@ export interface PendingAttachment {
   error?: string;
 }
 
-export function TaosAssistantPanelInner() {
+export function TaosAssistantPanelInner({ embedded = false }: { embedded?: boolean } = {}) {
   const {
     isOpen,
     messages,
@@ -48,16 +48,16 @@ export function TaosAssistantPanelInner() {
   const noModel = !model;
   const showEmptyState = messages.length === 0;
 
-  // Sync model from backend when panel opens
+  // Sync model from backend when panel opens (or when shown in the pop-out window)
   useEffect(() => {
-    if (!isOpen) return;
+    if (!isOpen && !embedded) return;
     fetch("/api/taos-agent/settings")
       .then((r) => r.ok ? r.json() : null)
       .then((data) => {
         if (data?.model !== undefined) setModel(data.model);
       })
       .catch(() => {});
-  }, [isOpen, setModel]);
+  }, [isOpen, embedded, setModel]);
 
   // Auto-scroll on new content
   useEffect(() => {
@@ -242,7 +242,9 @@ export function TaosAssistantPanelInner() {
   /*  Render                                                          */
   /* ---------------------------------------------------------------- */
 
-  if (!isOpen) return null;
+  // When embedded in the pop-out window the docked panel is closed (isOpen=false),
+  // so only gate on isOpen for the docked panel, never for the pop-out.
+  if (!isOpen && !embedded) return null;
 
   return (
     <>
@@ -314,7 +316,7 @@ export function TaosAssistantPanelInner() {
       {/* Input area */}
       <div
         className="px-4 py-3 border-t border-white/5 shrink-0"
-        style={{ paddingBottom: "calc(0.75rem + var(--spacing-dock-h, 52px))" }}
+        style={{ paddingBottom: embedded ? "0.75rem" : "calc(0.75rem + var(--spacing-dock-h, 52px))" }}
       >
         {noModel && (
           <p className="text-xs text-shell-text-tertiary mb-2">

--- a/desktop/src/lib/taos-agent-api.ts
+++ b/desktop/src/lib/taos-agent-api.ts
@@ -75,6 +75,11 @@ export async function uploadChatAttachment(form: FormData): Promise<AttachmentRe
  * Returns a PNG blob.  Throws if the user denies or cancels the permission prompt.
  */
 export async function takeChatScreenshot(): Promise<{ blob: Blob; mime_type: string }> {
+  if (!navigator.mediaDevices?.getDisplayMedia) {
+    throw new Error(
+      "Screen capture is not available in this view. Use the attach button to add an image file instead.",
+    );
+  }
   const stream = await navigator.mediaDevices.getDisplayMedia({ video: true });
   try {
     const video = document.createElement("video");


### PR DESCRIPTION
## What

The pop-out assistant window rendered blank because `TaosAssistantPanelInner` returned null when the docked panel was closed (`isOpen` was false). The fix adds an `embedded` prop; when set, the null-return guard and the model-fetch effect that depends on open state are both bypassed, so the pop-out always renders.

When embedded, the composer also drops the dock-height bottom padding that only makes sense when the panel is docked.

The screenshot button threw a runtime error in the embedded context because `navigator.mediaDevices` is not available in all browser window contexts. The `takeChatScreenshot` function now guards the call with `navigator.mediaDevices?.getDisplayMedia` and surfaces a clear, actionable error message instead of crashing.

Fixes #780.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screenshot functionality with explicit browser compatibility checks; users will receive guidance to use the attach button if their browser doesn't support the feature.

* **Improvements**
  * Enhanced Taos Assistant Panel to work seamlessly in pop-out and embedded window layouts with updated padding and model synchronization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->