### PR TITLE
chore: promote dev to master (agent chat pop-out fix)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ desktop/tsconfig.tsbuildinfo
 # Local-only operational playbook (contains LAN IP + ops detail; agents read it from the working tree)
 docs/AGENT_HANDOFF.md
 docs/audit/
+.understand-anything/

--- a/desktop/src/apps/TaosAssistantWindow.tsx
+++ b/desktop/src/apps/TaosAssistantWindow.tsx
@@ -35,7 +35,7 @@ export function TaosAssistantWindow({ windowId }: { windowId: string }) {
         </div>
       </div>
       <div className="flex-1 min-h-0 overflow-hidden">
-        <TaosAssistantPanelInner />
+        <TaosAssistantPanelInner embedded />
       </div>
     </div>
   );

--- a/desktop/src/components/TaosAssistantPanel.tsx
+++ b/desktop/src/components/TaosAssistantPanel.tsx
@@ -26,7 +26,7 @@ export interface PendingAttachment {
   error?: string;
 }
 
-export function TaosAssistantPanelInner() {
+export function TaosAssistantPanelInner({ embedded = false }: { embedded?: boolean } = {}) {
   const {
     isOpen,
     messages,
@@ -48,16 +48,16 @@ export function TaosAssistantPanelInner() {
   const noModel = !model;
   const showEmptyState = messages.length === 0;
 
-  // Sync model from backend when panel opens
+  // Sync model from backend when panel opens (or when shown in the pop-out window)
   useEffect(() => {
-    if (!isOpen) return;
+    if (!isOpen && !embedded) return;
     fetch("/api/taos-agent/settings")
       .then((r) => r.ok ? r.json() : null)
       .then((data) => {
         if (data?.model !== undefined) setModel(data.model);
       })
       .catch(() => {});
-  }, [isOpen, setModel]);
+  }, [isOpen, embedded, setModel]);
 
   // Auto-scroll on new content
   useEffect(() => {
@@ -242,7 +242,9 @@ export function TaosAssistantPanelInner() {
   /*  Render                                                          */
   /* ---------------------------------------------------------------- */
 
-  if (!isOpen) return null;
+  // When embedded in the pop-out window the docked panel is closed (isOpen=false),
+  // so only gate on isOpen for the docked panel, never for the pop-out.
+  if (!isOpen && !embedded) return null;
 
   return (
     <>
@@ -314,7 +316,7 @@ export function TaosAssistantPanelInner() {
       {/* Input area */}
       <div
         className="px-4 py-3 border-t border-white/5 shrink-0"
-        style={{ paddingBottom: "calc(0.75rem + var(--spacing-dock-h, 52px))" }}
+        style={{ paddingBottom: embedded ? "0.75rem" : "calc(0.75rem + var(--spacing-dock-h, 52px))" }}
       >
         {noModel && (
           <p className="text-xs text-shell-text-tertiary mb-2">

--- a/desktop/src/lib/taos-agent-api.ts
+++ b/desktop/src/lib/taos-agent-api.ts
@@ -75,6 +75,11 @@ export async function uploadChatAttachment(form: FormData): Promise<AttachmentRe
  * Returns a PNG blob.  Throws if the user denies or cancels the permission prompt.
  */
 export async function takeChatScreenshot(): Promise<{ blob: Blob; mime_type: string }> {
+  if (!navigator.mediaDevices?.getDisplayMedia) {
+    throw new Error(
+      "Screen capture is not available in this view. Use the attach button to add an image file instead.",
+    );
+  }
   const stream = await navigator.mediaDevices.getDisplayMedia({ video: true });
   try {
     const video = document.createElement("video");

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -30,7 +30,7 @@
 4. **#744** external coding-agent onboarding: taosmd side merged (their PR #151); our 7 build tasks queued.
 
 ## Open issues filed this stretch
-#757 (fixed #771), #759 (fixed #764), #760 host badges everywhere (UI), #761 per-device emoji identity (brainstorm first), #772 fresh-install/pairing smoke (Pi+Fedora, PASSED+closed), #774 project/shelf registry (design done), #776 add-machine over SSH (design done), #777 install identity + version registration (per-bug context now, opt-in central reg later), #778 anonymous active-install count via the update check (aggregate only, no PII).
+#757 (fixed #771), #759 (fixed #764), #760 host badges everywhere (UI), #761 per-device emoji identity (brainstorm first), #772 fresh-install/pairing smoke (Pi+Fedora, PASSED+closed), #774 project/shelf registry (design done), #776 add-machine over SSH (design done), #777 install identity + version registration (per-bug context now, opt-in central reg later), #778 anonymous active-install count via the update check (aggregate only, no PII), #779 Projects-app code knowledge-graph plugin view for coding projects.
 
 ## Cross-project (taosmd / A2A)
 - #744 taosmd side MERGED (their PR #151): grant matching on (canonical_id, project_id) + verified-claim project binding; the `agent` field on data endpoints is a TARGET SHELF, not the caller. Our 7 #744 build tasks queued.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -21,14 +21,14 @@
 ## Recently landed
 - **#737 cluster-worker pairing auth:** Phase 1 backend (#762) + Phase 2 worker scripts/agent signing (#770) DONE and on master (#767, #775). E2E VALIDATED in production (#772 closed: real Pi controller + Fedora worker, full announce->confirm->claim->signed register/heartbeat, unsigned->401). Phases 3 (UI pending-workers + enter-code dialog) and 4 (fleet migration UX) remain.
 - **Beta incident fixes on master:** #763 (knowledge user_id migration self-heals bricked installs + exit-on-startup-failure), #754 (installer sudo gap), #768 (installer re-run ownership / priv-esc), #752 (perf), #758 (controller-rescue runbook), #757 (prefetch placeholder).
-- Pi controller was repaired during the incident; it is on an OLD master (93f395e2) and LACKS the pairing backend. Update it before using it as the #772 test controller.
+- Pi controller is UPDATED to master 66688348 (done for the #772 test) and has the pairing backend live.
 
 ## Immediate next actions
 1. **#737 Phase 3** (UI pending-workers list + enter-code dialog): frontend-design pass, HELD for a design session with Jay (Apple-grade bar), ties into #760/#761 badges.
 2. **#737 Phase 4** (fleet migration UX): existing workers re-pair once with a clear prompt, not silent 401s.
 3. **#774 project/shelf registry:** design DONE + spec at docs/superpowers/specs/2026-06-11-project-shelf-registry-design.md (local, gitignored). taOSmd integration thread OPEN (integration channel msg 322): 3 contract questions (shelf create/archive shape; empty-shelf archive reversibility for link; carve-out re-key vs re-ingest). Implementation plan gated on their answers.
 4. **#776 add-machine over SSH (#737 Phase 3.5):** design DONE + spec at docs/superpowers/specs/2026-06-11-add-machine-ssh-design.md (local). One-click Cluster "Add machine": paramiko SSH (not sshpass), controller auto-installs + auto-pairs (injects TAOS_PAIRING_CODE, confirms itself), key-exchange for durable mgmt, key-based auth v1 (Linux/macOS only; Windows = separate native app). Ready for an implementation plan; sequence the build behind Phase 3 UI (both Cluster-app frontend).
-4. **#744** external coding-agent onboarding: taosmd side merged (their PR #151); our 7 build tasks queued.
+5. **#744** external coding-agent onboarding: taosmd side merged (their PR #151); our 7 build tasks queued.
 
 ## Open issues filed this stretch
 #757 (fixed #771), #759 (fixed #764), #760 host badges everywhere (UI), #761 per-device emoji identity (brainstorm first), #772 fresh-install/pairing smoke (Pi+Fedora, PASSED+closed), #774 project/shelf registry (design done), #776 add-machine over SSH (design done), #777 install identity + version registration (per-bug context now, opt-in central reg later), #778 anonymous active-install count via the update check (aggregate only, no PII), #779 Projects-app code knowledge-graph plugin view for coding projects.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,7 +7,7 @@
 
 # taOS: Live Status
 
-**Last updated:** 2026-06-11 ~13:40 BST, by @taOS (Mac session). PR #781 (agent-chat pop-out + screenshot guard, fixes #780) in CI; merge when green.
+**Last updated:** 2026-06-11 ~14:40 BST, by @taOS (Mac session). #781 MERGED to dev (agent-chat pop-out + screenshot guard, closes #780); next promotion carries it. Session in usage wind-down at ~87% of the 5h window (resets 18:19 BST); resume pair armed (primary 18:23, retry 18:43) to promote + start #737 Phase 4. taOSmd #774 answers folded into the spec, plan unblocked. Shared usage snapshot publishing to the Pi at /home/jay/.taos-usage.json.
 **Local-only in flight (not in git):** an Understand-Anything `/understand` run on `tinyagentos/cluster/` is paused mid-Phase-2. Intermediate files live in `tinyagentos/cluster/.understand-anything/` (gitignored): scan + batches done, batch-1 graph written (51 nodes, 100 edges), phases 3-7 (assemble/architecture/tour/review/save) pending. Resume by re-running `/understand tinyagentos/cluster` (incremental) or merging batch-1 and continuing. Note: scoping to a subdir gave 0 deterministic import edges (absolute package imports do not resolve in the narrow root); a `tinyagentos/`-root run would be richer. #778 gained a Coolify deployment plan: host the version-check endpoint on the tinyagentos.com site (Coolify from a GitHub repo) so it serves the latest version for seamless self-update AND counts installs anonymously in one call.
 **Repo:** github.com/jaylfc/taOS, branches `master` (stable) <- `dev` (integration). master tip 66688348; dev = master + a STATUS commit only.
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,7 +7,7 @@
 
 # taOS: Live Status
 
-**Last updated:** 2026-06-11 ~12:30 BST, by @taOS (Mac session).
+**Last updated:** 2026-06-11 ~13:40 BST, by @taOS (Mac session). PR #781 (agent-chat pop-out + screenshot guard, fixes #780) in CI; merge when green.
 **Local-only in flight (not in git):** an Understand-Anything `/understand` run on `tinyagentos/cluster/` is paused mid-Phase-2. Intermediate files live in `tinyagentos/cluster/.understand-anything/` (gitignored): scan + batches done, batch-1 graph written (51 nodes, 100 edges), phases 3-7 (assemble/architecture/tour/review/save) pending. Resume by re-running `/understand tinyagentos/cluster` (incremental) or merging batch-1 and continuing. Note: scoping to a subdir gave 0 deterministic import edges (absolute package imports do not resolve in the narrow root); a `tinyagentos/`-root run would be richer. #778 gained a Coolify deployment plan: host the version-check endpoint on the tinyagentos.com site (Coolify from a GitHub repo) so it serves the latest version for seamless self-update AND counts installs anonymously in one call.
 **Repo:** github.com/jaylfc/taOS, branches `master` (stable) <- `dev` (integration). master tip 66688348; dev = master + a STATUS commit only.
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,7 +7,8 @@
 
 # taOS: Live Status
 
-**Last updated:** 2026-06-11 ~11:15 BST, by @taOS (Mac session).
+**Last updated:** 2026-06-11 ~12:30 BST, by @taOS (Mac session).
+**Local-only in flight (not in git):** an Understand-Anything `/understand` run on `tinyagentos/cluster/` is paused mid-Phase-2. Intermediate files live in `tinyagentos/cluster/.understand-anything/` (gitignored): scan + batches done, batch-1 graph written (51 nodes, 100 edges), phases 3-7 (assemble/architecture/tour/review/save) pending. Resume by re-running `/understand tinyagentos/cluster` (incremental) or merging batch-1 and continuing. Note: scoping to a subdir gave 0 deterministic import edges (absolute package imports do not resolve in the narrow root); a `tinyagentos/`-root run would be richer. #778 gained a Coolify deployment plan: host the version-check endpoint on the tinyagentos.com site (Coolify from a GitHub repo) so it serves the latest version for seamless self-update AND counts installs anonymously in one call.
 **Repo:** github.com/jaylfc/taOS, branches `master` (stable) <- `dev` (integration). master tip 66688348; dev = master + a STATUS commit only.
 
 ## GOTCHA for the next agent

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -7,26 +7,26 @@
 
 # taOS: Live Status
 
-**Last updated:** 2026-06-11 ~10:30 BST, by @taOS (Mac session).
-**Repo:** github.com/jaylfc/taOS, branches `master` (stable) <- `dev` (integration).
+**Last updated:** 2026-06-11 ~11:15 BST, by @taOS (Mac session).
+**Repo:** github.com/jaylfc/taOS, branches `master` (stable) <- `dev` (integration). master tip 66688348; dev = master + a STATUS commit only.
 
 ## GOTCHA for the next agent
 - **Protected merges:** `gh pr merge` 401s on the OAuth token but `gh api -X PUT repos/jaylfc/taOS/pulls/N/merge -f merge_method=squash` WORKS (use `merge_method=merge` for dev->master promotions; never squash a promotion, never `--delete-branch`).
-- **#775 (promotion: worker pairing + prefetch fix + pairing guards + README pairing note) may still be in CI.** If open and green, merge with the api method.
 - CodeRabbit fake passes: a green CodeRabbit check can be a rate-limit notice; check the PR comments, use `@coderabbitai full review`. Kilo often 504s ("Assistant request timed out") = infra flake, not findings.
 - `tests/` is NOT an importable package: never `from tests.conftest import X`; expose shared helpers as function-returning fixtures.
-- Worker onboarding now REQUIRES pairing (a worker prints a code, admin approves in Cluster, signing key minted) before register/heartbeat. The signing string + headers are in tinyagentos/cluster/worker_auth.py; worker side in tinyagentos/worker/pairing.py.
+- Worker onboarding now REQUIRES pairing (a worker prints a code, admin approves in Cluster, signing key minted) before register/heartbeat. Signing string + headers in tinyagentos/cluster/worker_auth.py; worker side in tinyagentos/worker/pairing.py. VALIDATED in production (#772 passed).
+- **Pi Claude session is ARCHIVED and its crons are stopped.** Freshness rides ONLY on the active agent's session cron (re-arm on a new session); there is no Pi-side durable backstop. The Pi controller + A2A bus are services and keep running.
 
 ## Recently landed
-- **#737 cluster-worker pairing auth:** Phase 1 backend (#762) + Phase 2 worker scripts/agent signing (#770) DONE, on master via #767 and (pending) #775. Phases 3 (UI pending-workers + enter-code dialog) and 4 (fleet migration UX) remain.
+- **#737 cluster-worker pairing auth:** Phase 1 backend (#762) + Phase 2 worker scripts/agent signing (#770) DONE and on master (#767, #775). E2E VALIDATED in production (#772 closed: real Pi controller + Fedora worker, full announce->confirm->claim->signed register/heartbeat, unsigned->401). Phases 3 (UI pending-workers + enter-code dialog) and 4 (fleet migration UX) remain.
 - **Beta incident fixes on master:** #763 (knowledge user_id migration self-heals bricked installs + exit-on-startup-failure), #754 (installer sudo gap), #768 (installer re-run ownership / priv-esc), #752 (perf), #758 (controller-rescue runbook), #757 (prefetch placeholder).
 - Pi controller was repaired during the incident; it is on an OLD master (93f395e2) and LACKS the pairing backend. Update it before using it as the #772 test controller.
 
 ## Immediate next actions
-1. Merge **#775** when green; that puts worker pairing + the README pairing note on master.
-2. **#772 smoke test** (Pi controller + Fedora worker): gated on #775 + updating the Pi to that master. Fedora access via @taOSmd (SSH from Pi as jay; details in a 600 file on the Pi, delete after). HARD constraint: Fedora is mid-benchmark, pairing/heartbeat OK but NO GPU model loads / Ollama restarts. Use a throwaway worker name.
-3. **#737 Phase 3** (UI dialog): frontend-design pass, holds for a design session (Apple-grade bar), ties into #760/#761 badges.
-4. **#774 project/shelf registry:** design DONE + spec at docs/superpowers/specs/2026-06-11-project-shelf-registry-design.md (local, gitignored). Next = taOSmd integration thread for the shelf create/archive contract, then a plan.
+1. **#737 Phase 3** (UI pending-workers list + enter-code dialog): frontend-design pass, HELD for a design session with Jay (Apple-grade bar), ties into #760/#761 badges.
+2. **#737 Phase 4** (fleet migration UX): existing workers re-pair once with a clear prompt, not silent 401s.
+3. **#774 project/shelf registry:** design DONE + spec at docs/superpowers/specs/2026-06-11-project-shelf-registry-design.md (local, gitignored). taOSmd integration thread OPEN (integration channel msg 322): 3 contract questions (shelf create/archive shape; empty-shelf archive reversibility for link; carve-out re-key vs re-ingest). Implementation plan gated on their answers.
+4. **#744** external coding-agent onboarding: taosmd side merged (their PR #151); our 7 build tasks queued.
 
 ## Open issues filed this stretch
 #757 (fixed #771), #759 (fixed #764), #760 host badges everywhere (UI), #761 per-device emoji identity (brainstorm first), #772 fresh-install/pairing smoke (Pi+Fedora), #774 project/shelf registry (design done).

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -26,10 +26,11 @@
 1. **#737 Phase 3** (UI pending-workers list + enter-code dialog): frontend-design pass, HELD for a design session with Jay (Apple-grade bar), ties into #760/#761 badges.
 2. **#737 Phase 4** (fleet migration UX): existing workers re-pair once with a clear prompt, not silent 401s.
 3. **#774 project/shelf registry:** design DONE + spec at docs/superpowers/specs/2026-06-11-project-shelf-registry-design.md (local, gitignored). taOSmd integration thread OPEN (integration channel msg 322): 3 contract questions (shelf create/archive shape; empty-shelf archive reversibility for link; carve-out re-key vs re-ingest). Implementation plan gated on their answers.
+4. **#776 add-machine over SSH (#737 Phase 3.5):** design DONE + spec at docs/superpowers/specs/2026-06-11-add-machine-ssh-design.md (local). One-click Cluster "Add machine": paramiko SSH (not sshpass), controller auto-installs + auto-pairs (injects TAOS_PAIRING_CODE, confirms itself), key-exchange for durable mgmt, key-based auth v1 (Linux/macOS only; Windows = separate native app). Ready for an implementation plan; sequence the build behind Phase 3 UI (both Cluster-app frontend).
 4. **#744** external coding-agent onboarding: taosmd side merged (their PR #151); our 7 build tasks queued.
 
 ## Open issues filed this stretch
-#757 (fixed #771), #759 (fixed #764), #760 host badges everywhere (UI), #761 per-device emoji identity (brainstorm first), #772 fresh-install/pairing smoke (Pi+Fedora), #774 project/shelf registry (design done).
+#757 (fixed #771), #759 (fixed #764), #760 host badges everywhere (UI), #761 per-device emoji identity (brainstorm first), #772 fresh-install/pairing smoke (Pi+Fedora, PASSED+closed), #774 project/shelf registry (design done), #776 add-machine over SSH (design done).
 
 ## Cross-project (taosmd / A2A)
 - #744 taosmd side MERGED (their PR #151): grant matching on (canonical_id, project_id) + verified-claim project binding; the `agent` field on data endpoints is a TARGET SHELF, not the caller. Our 7 #744 build tasks queued.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -30,7 +30,7 @@
 4. **#744** external coding-agent onboarding: taosmd side merged (their PR #151); our 7 build tasks queued.
 
 ## Open issues filed this stretch
-#757 (fixed #771), #759 (fixed #764), #760 host badges everywhere (UI), #761 per-device emoji identity (brainstorm first), #772 fresh-install/pairing smoke (Pi+Fedora, PASSED+closed), #774 project/shelf registry (design done), #776 add-machine over SSH (design done).
+#757 (fixed #771), #759 (fixed #764), #760 host badges everywhere (UI), #761 per-device emoji identity (brainstorm first), #772 fresh-install/pairing smoke (Pi+Fedora, PASSED+closed), #774 project/shelf registry (design done), #776 add-machine over SSH (design done), #777 install identity + version registration (per-bug context now, opt-in central reg later), #778 anonymous active-install count via the update check (aggregate only, no PII).
 
 ## Cross-project (taosmd / A2A)
 - #744 taosmd side MERGED (their PR #151): grant matching on (canonical_id, project_id) + verified-claim project binding; the `agent` field on data endpoints is a TARGET SHELF, not the caller. Our 7 #744 build tasks queued.


### PR DESCRIPTION
Promotes #781 to master: the taOS agent chat pop-out window rendered blank (the inner panel returned null when the docked panel was closed) and the screenshot button threw on undefined navigator.mediaDevices in the embedded context. Pop-out now renders fully via an embedded prop and the capture path fails with a clear actionable message. Fixes #780. Also carries STATUS doc updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Screen capture now validates browser support and provides clear guidance if the feature is unavailable.

* **Improvements**
  * Enhanced assistant panel rendering for embedded contexts with improved settings synchronization.

* **Documentation**
  * Updated project status documentation with latest developments and upcoming priorities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->