### PR TITLE
fix(store): docker app Launchpad shortcut points at the allocated port, not the container port

### DIFF
--- a/tests/routes/test_store_install_v2.py
+++ b/tests/routes/test_store_install_v2.py
@@ -259,6 +259,70 @@ class TestResolveErrorReturns422:
 # Tests for get_device_capability disk-free logic (#368)
 # ---------------------------------------------------------------------------
 
+class TestDockerServiceAllocatedPort:
+    """Regression guard: docker install records the ALLOCATED host port, not the container port.
+
+    Before the fix in store_install.py, _legacy_install called _docker_published_port()
+    which returned the container port from the manifest (e.g. 8080). The DockerInstaller
+    now allocates from the 30000-40000 pool and returns the allocated port as
+    inst_result["host_port"]. The route must use that value when calling
+    store.update_runtime_location, not the stale container port.
+    """
+
+    @pytest.mark.asyncio
+    async def test_records_allocated_host_port_not_container_port(self, client):
+        """update_runtime_location is called with port=31234 (allocated), not 8080 (container)."""
+        docker_manifest = MagicMock()
+        docker_manifest.id = "searxng"
+        docker_manifest.type = "service"
+        docker_manifest.install = {
+            "method": "docker",
+            "ports": [8080],
+        }
+        docker_manifest.requires = {}
+        docker_manifest.hardware_tiers = {}
+        docker_manifest.version = "1.0.0"
+
+        registry = MagicMock()
+        registry.get_app = MagicMock(return_value=docker_manifest)
+        registry.get = MagicMock(return_value=docker_manifest)
+        registry.mark_installed = MagicMock()
+        registry.list_available = MagicMock(return_value=[])
+        client._transport.app.state.registry = registry
+
+        mock_installed_apps = MagicMock()
+        mock_installed_apps.install = AsyncMock(return_value=None)
+        mock_installed_apps.update_runtime_location = AsyncMock(return_value=None)
+        client._transport.app.state.installed_apps = mock_installed_apps
+
+        mock_installer = MagicMock()
+        mock_installer.install = AsyncMock(
+            return_value={"success": True, "host_port": 31234, "path": "/opt/apps/searxng"}
+        )
+        mock_installer.start = AsyncMock(return_value={"success": True})
+
+        mock_docker_class = MagicMock(return_value=mock_installer)
+
+        with patch("tinyagentos.installers.docker_installer.DockerInstaller", mock_docker_class):
+            r = await client.post("/api/store/install-v2", json={"manifest_id": "searxng"})
+
+        assert r.status_code == 200
+
+        mock_installed_apps.update_runtime_location.assert_awaited_once()
+        call_kwargs = mock_installed_apps.update_runtime_location.call_args
+        recorded_port = call_kwargs.kwargs.get("port") or call_kwargs.args[2]
+        assert recorded_port == 31234, (
+            f"expected allocated port 31234 but got {recorded_port}"
+        )
+
+        all_calls = mock_installed_apps.update_runtime_location.call_args_list
+        for call in all_calls:
+            port_arg = call.kwargs.get("port") or (call.args[2] if len(call.args) > 2 else None)
+            assert port_arg != 8080, (
+                "update_runtime_location must NOT be called with the container port 8080"
+            )
+
+
 class TestGetDeviceCapabilityDisk:
     """Unit tests for the free-disk probe in get_device_capability."""
 

--- a/tinyagentos/routes/store_install.py
+++ b/tinyagentos/routes/store_install.py
@@ -429,14 +429,18 @@ async def _legacy_install(request: Request, body: dict, app_id: str | None, targ
     raw_remote = body.get("target_remote") or ""
     _target_remote = raw_remote if raw_remote and raw_remote != "local" else None
 
-    # Docker services publish their port on the host (compose maps {p}:{p}),
-    # so they are reachable via the service proxy at /apps/{app_id}/. Record a
-    # runtime location so the app appears in /api/apps/installed and gets a
-    # Launchpad shortcut. Without this, a local docker install (e.g. SearxNG)
-    # succeeds but never surfaces a shortcut. Remote docker installs resolve
-    # the host from the registered incus remote; local installs use 127.0.0.1.
+    # Docker services publish on an ALLOCATED host port (the DockerInstaller
+    # maps {allocated_pool_port}:{container_port} so apps never bind a core port
+    # like 8080). Record that allocated host port as the runtime location so the
+    # app appears in /api/apps/installed and gets a Launchpad shortcut pointing
+    # at the right place. The installer returns it as inst_result["host_port"];
+    # use that, never the container port. (Falling back to the manifest's
+    # container port only for the no-ports / legacy case.) Without a recorded
+    # location a local docker install (e.g. SearxNG) succeeds but never surfaces
+    # a shortcut. Remote docker installs resolve the host from the registered
+    # incus remote; local installs use 127.0.0.1.
     if backend == "docker":
-        docker_port = _docker_published_port(install_config)
+        docker_port = inst_result.get("host_port") or _docker_published_port(install_config)
         if docker_port:
             runtime_host = (
                 await _resolve_host(_target_remote) if _target_remote else "127.0.0.1"


### PR DESCRIPTION
When a docker app installs, the DockerInstaller allocates a host port from the managed high pool (30000-40000) and maps allocated:container so apps never bind a core port like 8080. But the install handler recorded the runtime location (which drives the Launchpad shortcut and the service proxy) using _docker_published_port(install_config), whose 'host port equals container port' assumption is stale. So the shortcut pointed at the container port (e.g. 8080) instead of the allocated one, and web/dashboard apps opened the wrong place or collided with core services.

Fix: use the allocated host port the installer already returns (inst_result['host_port']) for the runtime location, falling back to the container port only when there is none. This makes the launcher shortcut open the app at its real allocated URL.

Surfaced while fixing the Pi where SearxNG (a legacy 8080:8080 install) had displaced rkllama; relates to #695 (reserve core ports + allocate from a pool).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Docker service port handling for installations. The system now correctly records installer-allocated host ports for runtime configuration instead of relying solely on container port declarations from manifests.

* **Tests**
  * Added integration test for Docker service installations, verifying that allocated host ports are properly captured and recorded in runtime location configuration rather than container port declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->