### PR TITLE
feat(registry): project_id claim in minted identity tokens (#744)

### DIFF
--- a/tests/test_auth_requests.py
+++ b/tests/test_auth_requests.py
@@ -610,3 +610,105 @@ class TestAuthRequestRoutes:
         # does not grow unbounded over the process lifetime.
         app = consent_client._transport.app
         assert getattr(app.state, "_approve_locks", {}).get(request_id) is None
+
+    async def test_project_id_carried_into_jwt_and_grants(self, consent_client):
+        """Request with project_id: JWT carries the claim; grant rows carry it too."""
+        import base64
+
+        transport = ASGITransport(app=consent_client._transport.app)
+        async with AsyncClient(transport=transport, base_url="http://test") as bare:
+            create_resp = await bare.post(
+                "/api/agents/auth-requests",
+                json={**_CREATE_BODY, "project_id": "proj-abc"},
+            )
+        request_id = create_resp.json()["request_id"]
+
+        approve_resp = await consent_client.post(
+            f"/api/agents/auth-requests/{request_id}/approve",
+            json={"granted_scopes": ["memory_read"]},
+        )
+        assert approve_resp.status_code == 200
+        canonical_id = approve_resp.json()["canonical_id"]
+
+        # Retrieve the minted token via the status poll.
+        async with AsyncClient(transport=transport, base_url="http://test") as bare:
+            status_resp = await bare.get(f"/api/agents/auth-requests/{request_id}")
+        token = status_resp.json()["token"]
+
+        # Decode the JWT payload (middle part, base64url without padding).
+        raw = token.split(".")[1]
+        padding = 4 - len(raw) % 4
+        if padding != 4:
+            raw += "=" * padding
+        import json as _json
+        jwt_payload = _json.loads(base64.urlsafe_b64decode(raw))
+        assert jwt_payload.get("project_id") == "proj-abc"
+
+        # Grant rows must also carry the project binding.
+        grants = await consent_client._transport.app.state.agent_grants.list_grants(canonical_id)
+        assert all(g["project_id"] == "proj-abc" for g in grants)
+
+    async def test_approve_body_project_id_overrides_request(self, consent_client):
+        """ApproveBody.project_id overrides the project_id from the original request."""
+        import base64
+        import json as _json
+
+        transport = ASGITransport(app=consent_client._transport.app)
+        async with AsyncClient(transport=transport, base_url="http://test") as bare:
+            create_resp = await bare.post(
+                "/api/agents/auth-requests",
+                json={**_CREATE_BODY, "project_id": "proj-original"},
+            )
+        request_id = create_resp.json()["request_id"]
+
+        approve_resp = await consent_client.post(
+            f"/api/agents/auth-requests/{request_id}/approve",
+            json={"granted_scopes": ["memory_read"], "project_id": "proj-override"},
+        )
+        assert approve_resp.status_code == 200
+        canonical_id = approve_resp.json()["canonical_id"]
+
+        async with AsyncClient(transport=transport, base_url="http://test") as bare:
+            status_resp = await bare.get(f"/api/agents/auth-requests/{request_id}")
+        token = status_resp.json()["token"]
+
+        raw = token.split(".")[1]
+        padding = 4 - len(raw) % 4
+        if padding != 4:
+            raw += "=" * padding
+        jwt_payload = _json.loads(base64.urlsafe_b64decode(raw))
+        assert jwt_payload.get("project_id") == "proj-override"
+
+        grants = await consent_client._transport.app.state.agent_grants.list_grants(canonical_id)
+        assert all(g["project_id"] == "proj-override" for g in grants)
+
+    async def test_no_project_id_omits_claim_and_grant_is_null(self, consent_client):
+        """When no project_id is set anywhere, JWT has no project_id key and grants have None."""
+        import base64
+        import json as _json
+
+        transport = ASGITransport(app=consent_client._transport.app)
+        async with AsyncClient(transport=transport, base_url="http://test") as bare:
+            create_resp = await bare.post("/api/agents/auth-requests", json=_CREATE_BODY)
+        request_id = create_resp.json()["request_id"]
+
+        approve_resp = await consent_client.post(
+            f"/api/agents/auth-requests/{request_id}/approve",
+            json={"granted_scopes": ["memory_read"]},
+        )
+        assert approve_resp.status_code == 200
+        canonical_id = approve_resp.json()["canonical_id"]
+
+        async with AsyncClient(transport=transport, base_url="http://test") as bare:
+            status_resp = await bare.get(f"/api/agents/auth-requests/{request_id}")
+        token = status_resp.json()["token"]
+
+        raw = token.split(".")[1]
+        padding = 4 - len(raw) % 4
+        if padding != 4:
+            raw += "=" * padding
+        jwt_payload = _json.loads(base64.urlsafe_b64decode(raw))
+        assert "project_id" not in jwt_payload
+
+        grants = await consent_client._transport.app.state.agent_grants.list_grants(canonical_id)
+        assert all(g.get("project_id") is None for g in grants)

--- a/tinyagentos/agent_registry_store.py
+++ b/tinyagentos/agent_registry_store.py
@@ -180,6 +180,7 @@ def mint_registry_token(
     *,
     user_id: str = "",
     framework: str = "",
+    project_id: Optional[str] = None,
 ) -> str:
     """Return a signed compact EdDSA JWT: <header>.<payload>.<signature> (base64url).
 
@@ -188,11 +189,13 @@ def mint_registry_token(
     can verify it without importing tinyagentos code.
 
     Claims:
-      sub       — canonical_id (immutable agent identity)
-      iss       — "taos-registry"
-      iat       — unix timestamp of issuance
-      user_id   — owning user_id at registration time
-      framework — agent framework at registration time
+      sub        — canonical_id (immutable agent identity)
+      iss        — "taos-registry"
+      iat        — unix timestamp of issuance
+      user_id    — owning user_id at registration time
+      framework  — agent framework at registration time
+      project_id — project binding, present only when non-empty; absent means
+                   the token is global (not bound to any project)
 
     Signed with Ed25519 over the UTF-8 bytes of ``<header_b64url>.<payload_b64url>``.
     """
@@ -203,18 +206,18 @@ def mint_registry_token(
     header = _b64url_encode(
         json.dumps({"alg": "EdDSA", "typ": "JWT"}, separators=(",", ":")).encode()
     )
+    claims: dict = {
+        "sub": canonical_id,
+        "iss": "taos-registry",
+        "iat": int(time.time()),
+        "jti": uuid.uuid4().hex,
+        "user_id": user_id,
+        "framework": framework,
+    }
+    if project_id:
+        claims["project_id"] = project_id
     payload = _b64url_encode(
-        json.dumps(
-            {
-                "sub": canonical_id,
-                "iss": "taos-registry",
-                "iat": int(time.time()),
-                "jti": uuid.uuid4().hex,
-                "user_id": user_id,
-                "framework": framework,
-            },
-            separators=(",", ":"),
-        ).encode()
+        json.dumps(claims, separators=(",", ":")).encode()
     )
     signing_input = f"{header}.{payload}".encode()
     signature = _b64url_encode(private_key.sign(signing_input))

--- a/tinyagentos/routes/agent_auth_requests.py
+++ b/tinyagentos/routes/agent_auth_requests.py
@@ -68,6 +68,7 @@ class CreateAuthRequest(BaseModel):
 
 class ApproveBody(BaseModel):
     granted_scopes: list[str]
+    project_id: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------
@@ -277,17 +278,24 @@ async def _do_approve(request: Request, request_id: str, body: ApproveBody, user
     # @taOSmd's identity-AND-grant gate accepts them.
     await registry.set_status(canonical_id, "active", actor=user.user_id)
 
+    # Resolve effective project binding: admin override wins; fall back to the
+    # project_id the agent requested (may be None for a global token).
+    effective_project = (
+        body.project_id if body.project_id is not None else record.get("project_id")
+    )
+
     # Issue the identity token.
     token = mint_registry_token(
         canonical_id,
         private_pem,
         user_id=user.user_id,
         framework=record["framework"],
+        project_id=effective_project,
     )
 
     # Record grants for each approved scope.
     for scope in body.granted_scopes:
-        await grants_store.add_grant(canonical_id, scope, tier="once")
+        await grants_store.add_grant(canonical_id, scope, tier="once", project_id=effective_project)
         # Also write a RelationshipManager permission edge so the existing
         # permission-check path (can_communicate etc.) is aware of the agent.
         await rel_mgr.set_permission(canonical_id, "taos-instance", scope)


### PR DESCRIPTION
## Summary

- mint_registry_token gains a project_id keyword; the claim is top-level only when non-empty — absent means the token is global.
- ApproveBody gains an optional project_id override applied at approval time.
- approve_auth_request computes effective_project (override wins, falls back to record) and passes it to both mint_registry_token and every grants_store.add_grant call.
- The register route is unchanged — no project context there.

## Tests

Three new cases in tests/test_auth_requests.py covering: bound request, admin override, and no project (absent claim + null grant rows).

## Test plan

- [ ] python3 -m pytest tests/test_auth_requests.py tests/test_registry.py tests/test_agent_registry.py -q — all 81 pass
- [ ] Smoke the approval flow with a project_id to confirm claim in returned token

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authentication requests now support project identification; admins can set or override project ID during approval
  * Minted tokens now include project identification when available
  * Project IDs are persisted in grant records for audit and tracking purposes

* **Tests**
  * Added validation tests for project ID handling across the authentication approval workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->