### PR TITLE
docs: fix stale install path, memory design, and contributing guide (#743)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,12 +157,13 @@ Submit a pull request. The CI will run the catalog tests automatically. Include 
 - One concern per module; avoid cross-importing between route files
 - Use `async def` for route handlers; use `await` for all I/O
 
-### Templates
+### Frontend
 
-- Use Pico CSS utility classes — do not introduce other CSS frameworks
-- Use htmx attributes (`hx-get`, `hx-target`, `hx-swap`) for dynamic updates
-- Write semantic HTML — use the right element for the job (`<nav>`, `<main>`, `<section>`, etc.)
+The UI is a React SPA (`desktop/`) built with Vite. Static assets are served from `static/desktop/` after `npm run build`. If you are adding a new UI surface:
+
+- Follow existing React patterns in `desktop/src/` — no server-rendered templates for new features
 - ARIA labels are required on interactive elements without visible text labels
+- One concern per component; keep API calls in dedicated hooks or service files
 
 ### Tests
 
@@ -213,7 +214,7 @@ When adding a feature, add tests that cover the new behaviour. When fixing a bug
 tinyagentos/
   app.py               # FastAPI application factory, lifespan, route registration
   config.py            # Platform config, hardware detection
-  routes/              # One module per feature area (77 route modules)
+  routes/              # One module per feature area (86 route modules)
   templates/           # Minimal: only agent_debugger.html remains (frontend is a React SPA)
   channel_hub/         # Framework-agnostic messaging (6 connectors + message router)
   adapters/            # Framework adapters (15 adapters, ~25 lines each)
@@ -224,7 +225,7 @@ app-catalog/           # YAML manifests for installable apps (108 apps)
 tests/                 # pytest test suite (~3,590 tests)
 ```
 
-Routes are registered in `app.py`. Each route module imports its own store. Templates use htmx for partial page updates — full-page navigations are rare.
+Routes are registered in `app.py`. Route modules access stores via `request.app.state` (dependency injection set up in the app lifespan) — they do not import stores directly. The frontend is a React SPA; `templates/` is minimal and only used for the agent debugger page.
 
 ---
 

--- a/docs/design/app-store-platform.md
+++ b/docs/design/app-store-platform.md
@@ -52,7 +52,8 @@ TinyAgentOS evolves from an agent monitoring dashboard into a full AI-focused ho
 │  Existing services:                                         │
 │  ├── Metrics Store (SQLite)                                 │
 │  ├── Backend Adapters (rkllama, ollama, llama.cpp, vllm)    │
-│  ├── QMD Client (per-agent HTTP)                            │
+│  ├── QMD Client (per-agent memory, HTTP :7832)              │
+│  ├── taosmd Client (user memory + librarian, HTTP :7900)    │
 │  └── Health Monitor (background poller)                     │
 └─────────────────────────────────────────────────────────────┘
 ```

--- a/docs/design/user-memory.md
+++ b/docs/design/user-memory.md
@@ -1,11 +1,11 @@
-# User Memory — Personal QMD Instance
+# User Memory — taosmd-backed Personal Memory
 
 **Date:** 2026-04-10
 **Status:** Draft
 
 ## Overview
 
-Every user gets their own QMD instance — the same memory system agents use, but for the user's personal context. It captures conversation history, notes, file activity, search history, and clipboard snippets. Searchable via keyword (FTS5), semantic (sqlite-vec), and hybrid search. Agents can query user memory (with permission) to understand what the user has been working on.
+User memory gives every user their own personal context store — separate from agent memories. It captures conversation history, notes, file activity, search history, and clipboard snippets. Searchable via keyword (BM25) with a local SQLite FTS5 fallback. Agents can query user memory (with permission) to understand what the user has been working on.
 
 Like Pieces App but self-hosted, offline-first, and agent-aware.
 
@@ -14,15 +14,16 @@ Like Pieces App but self-hosted, offline-first, and agent-aware.
 ```
 Host
 ├── TinyAgentOS (port 6969)
-├── User QMD (port 7833) → user's personal memory
-│   └── ~/.cache/qmd/user-index.sqlite
+│   └── user_memory routes → taosmd proxy (:7900), namespace "user-memory"
+│       └── SQLite FTS5 store (local fallback when taosmd is unreachable)
+├── taosmd (port 7900) → shared memory backend
 ├── LXC: agent-alpha
-│   └── QMD (port 7832) → agent's memory
+│   └── QMD (port 7832) → agent's per-agent memory
 └── LXC: agent-beta
-    └── QMD (port 7832) → agent's memory
+    └── QMD (port 7832) → agent's per-agent memory
 ```
 
-The user QMD runs on the host alongside TinyAgentOS (not in a container). It uses the same QMD binary and the same rkllama/ollama backend for embeddings.
+User memory rides the taosmd proxy on port 7900 under the agent namespace `user-memory`. Writes go to taosmd `POST /ingest` (and `POST /ingest/batch` for bulk migration); keyword reads go to `GET /search?mode=bm25`. A local SQLite FTS5 store acts as an automatic fallback if taosmd is unreachable. The taosmd base URL is read from `app.state.taosmd_url` at runtime; set the `TAOS_USER_MEMORY_URL` environment variable to override the default `http://localhost:7900`.
 
 ## What Gets Captured
 
@@ -53,8 +54,8 @@ User memory is organised into collections (same as agent QMD):
 - **User → User Memory**: always allowed (it's your data)
 - **Agent → User Memory**: configurable per agent in Agent Settings
   - "Can read user memory" toggle (default: off)
-  - When enabled, the agent's QMD_USER_MEMORY_URL env var points to user QMD
-  - Agents can search user memory via the same QMD API: GET /search?q=...
+  - When enabled, the agent is permitted to call `GET /api/user-memory/agent-search`
+  - Agents search user memory through the TinyAgentOS API; they do not talk to taosmd directly
   - Agents CANNOT write to user memory (read-only access)
 
 ## Integration Points
@@ -87,7 +88,6 @@ Right-click anywhere → "Save to Memory" option. Saves selected text, current U
 ```sql
 CREATE TABLE IF NOT EXISTS user_memory_settings (
     user_id TEXT PRIMARY KEY,
-    qmd_url TEXT DEFAULT 'http://localhost:7833',
     capture_conversations INTEGER DEFAULT 1,
     capture_files INTEGER DEFAULT 1,
     capture_searches INTEGER DEFAULT 0,
@@ -132,11 +132,12 @@ User Action (send message, save file, search, save note)
   → Available for search immediately
 ```
 
-The pipeline is async — never blocks the user action. Uses the same QMD embed API as agent memory:
+The pipeline is async — never blocks the user action. Writes reach taosmd via:
 ```
-POST http://localhost:7833/embed
-Body: {content, title, collection, metadata}
+POST http://localhost:7900/ingest
+Body: {text, agent: "user-memory", metadata: {collection, title, source_id}}
 ```
+The local SQLite FTS5 store is always written first; taosmd ingest is best-effort and non-fatal.
 
 ## Privacy
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -53,12 +53,12 @@ The platform itself uses roughly 345 MB of RAM when idle, so it runs comfortably
 On your device, open a terminal and run:
 
 ```bash
-curl -sL https://raw.githubusercontent.com/jaylfc/tinyagentos/master/install.sh | sudo bash
+curl -fsSL https://raw.githubusercontent.com/jaylfc/tinyagentos/master/scripts/install-server.sh | sudo bash
 ```
 
 This script will:
 1. Install system dependencies (`python3`, `git`, `nodejs`, `avahi-daemon` for mDNS, and others)
-2. Clone TinyAgentOS to `/opt/tinyagentos`
+2. Clone TinyAgentOS to `~/tinyagentos` (override with `TAOS_INSTALL_DIR`)
 3. Create a Python virtual environment and install all Python packages
 4. Register and start a `systemd` service so TinyAgentOS runs automatically on boot
 
@@ -412,7 +412,7 @@ The `-f` flag follows the log in real time.
 
 ## 8. Backup
 
-TinyAgentOS stores your configuration, agent data, secrets, and memories in `/opt/tinyagentos/data/` (or wherever you set your data directory during install).
+TinyAgentOS stores your configuration, agent data, secrets, and memories in `~/tinyagentos/data/` (or `$TAOS_INSTALL_DIR/data/` if you set a custom install path).
 
 ### Backup via Settings
 
@@ -431,7 +431,7 @@ On a fresh TinyAgentOS install, go to **Settings > Backup > Restore**, upload yo
 If you prefer to do it yourself:
 
 ```bash
-sudo cp -r /opt/tinyagentos/data /your/backup/location/tinyagentos-data-$(date +%Y%m%d)
+cp -r ~/tinyagentos/data /your/backup/location/tinyagentos-data-$(date +%Y%m%d)
 ```
 
 ---


### PR DESCRIPTION
## Summary

- **getting-started.md**: corrected quick-install URL to `scripts/install-server.sh`, install dir from `/opt/tinyagentos` to `~/tinyagentos`, and backup path to match
- **docs/design/user-memory.md**: rewrote architecture, access-control, pipeline, and schema sections to reflect taosmd on :7900 with namespace `user-memory` and `TAOS_USER_MEMORY_URL` (removed stale port-7833 QMD instance and `QMD_USER_MEMORY_URL`)
- **docs/design/app-store-platform.md**: updated the platform architecture block to list both QMD (per-agent :7832) and taosmd (user memory + librarian :7900)
- **CONTRIBUTING.md**: replaced htmx/Pico-CSS "Templates" section with accurate React SPA note, updated route count to 86 (counted from `ls tinyagentos/routes/*.py`), and corrected store access to `request.app.state` DI pattern

Closes #743