### PR TITLE
fix(install): validate every allocated host port, not just the first

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 # taOS
 
 > **Beta (2026-06-02).** This is beta software meant for testers running it on their own hardware, so expect rough edges. The install script, backend, API, memory system (taOSmd), and multi-framework group chat all work; the desktop GUI is wired up for everyday use but a few flows (some agent management, worker connections, model routing) are still being smoothed out. Star or watch the repo to follow progress and catch the next release.
+>
+> **A heads-up on the catalogs:** with 100+ apps, 16 frameworks, and a large model catalog, plenty of install manifests have not been exercised on real hardware yet, so some apps, frameworks, and models will fail to install. If one does, [open an issue](https://github.com/jaylfc/tinyagentos/issues) with the name and the error you saw and I will fix the manifest as soon as I can. These reports are genuinely useful, most manifest fixes ship same-day.
 
 <p align="center">
 <a href="https://www.star-history.com/?repos=jaylfc%2Ftinyagentos&type=date&legend=top-left">

--- a/tests/installers/test_port_allocator.py
+++ b/tests/installers/test_port_allocator.py
@@ -1,0 +1,75 @@
+"""Tests for host-port allocation: every handed-out port is probed free."""
+import socket
+
+from tinyagentos.installers.docker_installer import DockerInstaller
+from tinyagentos.installers.port_allocator import (
+    RESERVED_PORTS,
+    _POOL_END,
+    _POOL_START,
+    allocate_host_port,
+)
+
+
+class TestAllocateHostPort:
+    def test_deterministic_for_same_app_id(self):
+        assert allocate_host_port("searxng") == allocate_host_port("searxng")
+
+    def test_within_pool_and_not_reserved(self):
+        port = allocate_host_port("some-app")
+        assert _POOL_START <= port < _POOL_END
+        assert port not in RESERVED_PORTS
+
+    def test_walks_past_a_bound_port(self):
+        preferred = allocate_host_port("walk-test-app")
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("0.0.0.0", preferred))
+            s.listen(1)
+            moved = allocate_host_port("walk-test-app")
+        assert moved != preferred
+        assert _POOL_START <= moved < _POOL_END
+
+    def test_exclude_skips_unbound_claims(self):
+        first = allocate_host_port("multi-port-app")
+        second = allocate_host_port("multi-port-app", exclude={first})
+        assert second != first
+
+
+class TestDockerComposeMultiPort:
+    def test_multi_port_app_gets_distinct_probed_ports(self, tmp_path):
+        installer = DockerInstaller.__new__(DockerInstaller)
+        installer.apps_dir = tmp_path
+        compose, host_port = installer._generate_compose(
+            "multi-port-compose-app",
+            {"image": "example/image:latest", "requires": {"ports": [8080, 9090, 7070]}},
+        )
+        mappings = compose["services"]["multi-port-compose-app"]["ports"]
+        host_side = [int(m.split(":")[0]) for m in mappings]
+        container_side = [int(m.split(":")[1]) for m in mappings]
+
+        assert container_side == [8080, 9090, 7070]
+        assert len(set(host_side)) == 3
+        assert host_port == host_side[0]
+        for hp in host_side:
+            assert _POOL_START <= hp < _POOL_END
+            assert hp not in RESERVED_PORTS
+
+    def test_extra_port_not_blindly_consecutive_when_taken(self, tmp_path):
+        installer = DockerInstaller.__new__(DockerInstaller)
+        installer.apps_dir = tmp_path
+        app_id = "occupied-second-port-app"
+        first = allocate_host_port(app_id)
+        # Whatever the second port's deterministic seed resolves to, occupy
+        # the naive `first + 1` slot; the mapping must still be conflict-free.
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("0.0.0.0", first + 1))
+            s.listen(1)
+            compose, _ = installer._generate_compose(
+                app_id,
+                {"image": "example/image:latest", "requires": {"ports": [8080, 9090]}},
+            )
+            host_side = [
+                int(m.split(":")[0])
+                for m in compose["services"][app_id]["ports"]
+            ]
+        assert first + 1 not in host_side
+        assert len(set(host_side)) == 2

--- a/tinyagentos/installers/docker_installer.py
+++ b/tinyagentos/installers/docker_installer.py
@@ -66,12 +66,22 @@ class DockerInstaller(AppInstaller):
         allocated_host_port: int | None = None
         if container_ports:
             # Allocate a host port from the managed pool for each container
-            # port.  The mapping is host_port:container_port so the app's
-            # internal wiring (container port) is unchanged.
-            allocated_host_port = allocate_host_port(app_id)
+            # port.  Every port is individually probed free on the host; a
+            # bare `allocated + idx` for the extra ports could hand out a
+            # port something else is bound to and crash compose up.  The
+            # first port keeps app_id as its hash seed so existing
+            # single-port installs keep their stable assignment.
+            taken: set[int] = set()
+            host_ports: list[int] = []
+            for idx in range(len(container_ports)):
+                seed = app_id if idx == 0 else f"{app_id}#{idx}"
+                hp = allocate_host_port(seed, exclude=taken)
+                taken.add(hp)
+                host_ports.append(hp)
+            allocated_host_port = host_ports[0]
             service["ports"] = [
-                f"{allocated_host_port + idx}:{cport}"
-                for idx, cport in enumerate(container_ports)
+                f"{hp}:{cport}"
+                for hp, cport in zip(host_ports, container_ports)
             ]
 
         # No top-level `version:` — it's obsolete in Compose v2 and emits a

--- a/tinyagentos/installers/port_allocator.py
+++ b/tinyagentos/installers/port_allocator.py
@@ -66,13 +66,17 @@ def _is_port_free(port: int) -> bool:
             return False
 
 
-def allocate_host_port(app_id: str) -> int:
+def allocate_host_port(app_id: str, *, exclude: set[int] | frozenset[int] = frozenset()) -> int:
     """Return a stable, non-reserved, free host port for *app_id*.
 
     The starting point is derived from a hash of *app_id* so the same
     app always gets the same port on a fresh install (assuming the slot
     is available).  If the preferred slot is occupied or reserved we walk
     forward (wrapping within the pool) until we find a usable port.
+
+    ``exclude`` holds ports already claimed by the caller in this
+    allocation round but not yet bound (e.g. earlier ports of a
+    multi-port app), so consecutive calls cannot hand out the same port.
 
     Raises ``RuntimeError`` if the entire pool is exhausted.
     """
@@ -83,7 +87,7 @@ def allocate_host_port(app_id: str) -> int:
 
     for i in range(pool_size):
         candidate = _POOL_START + (start_offset + i) % pool_size
-        if candidate in RESERVED_PORTS:
+        if candidate in RESERVED_PORTS or candidate in exclude:
             continue
         if _is_port_free(candidate):
             return candidate


### PR DESCRIPTION
Multi-port apps mapped extra container ports to allocated_host_port + idx without checking the slot was free, so an occupied neighbour port crashed compose up at install time. Every published port now goes through allocate_host_port with a real bind probe, an exclusion set prevents duplicate claims within one app, and the first port keeps its existing deterministic seed so current single-port installs are unaffected. Adds allocator and compose-generation tests.