### PR TITLE
fix(install): rkllama default port 8080 -> 7833 (#795)

### DIFF
--- a/docs/UPDATE_BREAKAGE_LOG.md
+++ b/docs/UPDATE_BREAKAGE_LOG.md
@@ -15,6 +15,25 @@ Format per entry: date, change (PR), affected installs, symptom, check, fix.
 
 ---
 
+## 2026-06-12 — rkllama default port moved 8080 -> 7833 (#795)
+
+- **Affected:** installs that re-run `install-rknpu.sh` after this change while
+  their taOS config still points at 8080 (i.e. their recorded backend URL is
+  `http://localhost:8080` or `http://<host>:8080`).
+- **Symptom:** model pulls and chat fail with connection refused on 8080 after
+  re-running the installer, because the new systemd unit listens on 7833.
+- **Check:** `systemctl cat rkllama | grep port` -- should show `--port 7833`
+  on new installs. Compare against the backend URL shown in Settings; if it
+  still says `:8080` and rkllama is now on 7833, that is the mismatch.
+- **Fix:** re-run `install-rknpu.sh` (updates the systemd unit to 7833) AND
+  update the backend URL in Settings to `http://localhost:7833`, OR set
+  `TAOS_RKLLAMA_PORT=8080` before re-running to keep the old port.
+- **New installs:** unaffected -- the installer and all taOS defaults already
+  use 7833.
+- **Note:** the controller also probes port 8080 as a legacy fallback when
+  nothing is listening on 7833, so read-only operations (model list, health
+  checks) will still work automatically on mixed installs.
+
 ## 2026-06-11 — Docker app shortcuts recorded the container port (#788)
 
 - **Affected:** docker-backed store apps installed BEFORE #788 on builds that already

--- a/docs/agent-qmd-serve-setup.md
+++ b/docs/agent-qmd-serve-setup.md
@@ -6,7 +6,7 @@ Each agent runs its own `qmd serve` instance inside its LXC container. This keep
 
 ```
 Host (Orange Pi / x86)
-├── rkllama (port 8080) — shared NPU/GPU inference
+├── rkllama (port 7833) — shared NPU/GPU inference
 ├── TinyAgentOS (port 6969) — web GUI, talks to each agent's qmd serve
 │
 ├── LXC: agent-alpha
@@ -54,7 +54,7 @@ Each agent runs its own `qmd serve` that:
 2. Routes inference requests (embed, rerank, expand) to the shared rkllama backend on the host
 
 ```bash
-qmd serve --port 7832 --bind 0.0.0.0 --backend rkllama --rkllama-url http://<host-ip>:8080
+qmd serve --port 7832 --bind 0.0.0.0 --backend rkllama --rkllama-url http://<host-ip>:7833
 ```
 
 Replace `<host-ip>` with the host's IP address. If using Tailscale, the Tailscale IP avoids macvlan routing issues where LXC containers can't reach the host's LAN IP.
@@ -70,7 +70,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/qmd serve --port 7832 --bind 0.0.0.0 --backend rkllama --rkllama-url http://<host-ip>:8080
+ExecStart=/usr/local/bin/qmd serve --port 7832 --bind 0.0.0.0 --backend rkllama --rkllama-url http://<host-ip>:7833
 Restart=on-failure
 RestartSec=5
 Environment=NODE_ENV=production

--- a/docs/design/abstraction-layers.md
+++ b/docs/design/abstraction-layers.md
@@ -165,14 +165,14 @@ TinyAgentOS generates LiteLLM config from its own backend config on startup:
 # TinyAgentOS reads its config:
 backends = [
     {"name": "fedora-gpu", "type": "ollama", "url": "http://fedora:11434", "priority": 1},
-    {"name": "local-npu", "type": "rkllama", "url": "http://localhost:8080", "priority": 3},
+    {"name": "local-npu", "type": "rkllama", "url": "http://localhost:7833", "priority": 3},
 ]
 
 # Generates LiteLLM config:
 litellm_config = {
     "model_list": [
         {"model_name": "default", "litellm_params": {"model": "ollama/qwen3-8b", "api_base": "http://fedora:11434"}, "metadata": {"priority": 1}},
-        {"model_name": "default", "litellm_params": {"model": "ollama/qwen3-8b", "api_base": "http://localhost:8080"}, "metadata": {"priority": 3}},
+        {"model_name": "default", "litellm_params": {"model": "ollama/qwen3-8b", "api_base": "http://localhost:7833"}, "metadata": {"priority": 3}},
     ],
     "router_settings": {"routing_strategy": "simple-shuffle", "num_retries": 2, "fallbacks": [...]},
 }

--- a/docs/design/plan-complete-and-polish.md
+++ b/docs/design/plan-complete-and-polish.md
@@ -309,7 +309,7 @@ async def deploy_agent_endpoint(request: Request, body: DeployAgentRequest):
     deploy_tasks[body.name] = {"status": "deploying", "step": "starting", "error": None, "result": None}
 
     # Find rkllama URL
-    rkllama_url = "http://localhost:8080"
+    rkllama_url = "http://localhost:7833"
     for b in config.backends:
         if b.get("type") == "rkllama":
             rkllama_url = b["url"]

--- a/docs/design/plan-llm-proxy.md
+++ b/docs/design/plan-llm-proxy.md
@@ -53,7 +53,7 @@ class TestConfigGeneration:
     def test_generates_config_from_backends(self):
         backends = [
             {"name": "fedora-gpu", "type": "ollama", "url": "http://fedora:11434", "priority": 1},
-            {"name": "local-npu", "type": "rkllama", "url": "http://localhost:8080", "priority": 3},
+            {"name": "local-npu", "type": "rkllama", "url": "http://localhost:7833", "priority": 3},
         ]
         config = generate_litellm_config(backends)
         assert "model_list" in config
@@ -77,7 +77,7 @@ class TestConfigGeneration:
         assert "api_base" not in config["model_list"][0]["litellm_params"] or config["model_list"][0]["litellm_params"]["api_base"] == "https://api.openai.com"
 
     def test_rkllama_treated_as_ollama_compat(self):
-        backends = [{"name": "npu", "type": "rkllama", "url": "http://localhost:8080", "priority": 1}]
+        backends = [{"name": "npu", "type": "rkllama", "url": "http://localhost:7833", "priority": 1}]
         config = generate_litellm_config(backends)
         # rkllama is ollama-compatible
         model_param = config["model_list"][0]["litellm_params"]["model"]

--- a/scripts/install-rknpu.sh
+++ b/scripts/install-rknpu.sh
@@ -26,7 +26,7 @@
 #     TAOS_RKLLAMA_DIR        install dir (default: ~<user>/rkllama)
 #     TAOS_RKLLAMA_REPO       git remote (default: https://github.com/jaylfc/rkllama.git)
 #     TAOS_RKLLAMA_REF        git ref  (default: 06cf874d8b29767729ec06547cf02fc92acd875c)
-#     TAOS_RKLLAMA_PORT       HTTP port (default: 8080)
+#     TAOS_RKLLAMA_PORT       HTTP port (default: 7833)
 #     TAOS_QMD_EXPANSION_URL  override URL for qmd-query-expansion-1.7B-rk3588.rkllm
 #                             (default is the TAOS HF mirror at
 #                             jaysom/tinyagentos-rockchip-mirror; only set
@@ -64,7 +64,7 @@ LIBRKNNRT_EXPECTED_VERSION="2.3.0"
 
 RKLLAMA_REPO="${TAOS_RKLLAMA_REPO:-https://github.com/jaylfc/rkllama.git}"
 RKLLAMA_REF="${TAOS_RKLLAMA_REF:-06cf874d8b29767729ec06547cf02fc92acd875c}"
-RKLLAMA_PORT="${TAOS_RKLLAMA_PORT:-8080}"
+RKLLAMA_PORT="${TAOS_RKLLAMA_PORT:-7833}"
 
 # Qwen3-Embedding-0.6B rk3588 rkllm weights.
 # Upstream fallback: https://huggingface.co/dulimov/Qwen3-Embedding-0.6B-rk3588-1.2.1/resolve/main/Qwen3-Embedding-0.6B-rk3588-w8a8-opt-1-hybrid-ratio-0.5.rkllm

--- a/tests/test_rkllama_default_port.py
+++ b/tests/test_rkllama_default_port.py
@@ -1,0 +1,77 @@
+"""Tests for rkllama default port (7833) and legacy-fallback probe.
+
+Three cases:
+  (a) default_rkllama_url returns 7833 URL when nothing listens on either port.
+  (b) returns 8080 URL when only 8080 answers with rkllama's signature.
+  (c) regression guard: install-rknpu.sh default is 7833.
+"""
+from __future__ import annotations
+
+import http.server
+import json
+import pathlib
+import threading
+
+
+# ---------------------------------------------------------------------------
+# (a) Nothing listening -> returns 7833
+# ---------------------------------------------------------------------------
+
+class TestDefaultRkllamaUrlNothingListening:
+    def test_returns_7833_when_no_server(self, monkeypatch):
+        # Monkeypatch _port_responds_with_rkllama to always refuse.
+        import tinyagentos.installers.rkllama_installer as mod
+        monkeypatch.setattr(mod, "_port_responds_with_rkllama", lambda port, timeout=1.0: False)
+        assert mod.default_rkllama_url() == "http://localhost:7833"
+
+
+# ---------------------------------------------------------------------------
+# (b) 8080 answers, 7833 is dead -> returns 8080 with a log warning
+# ---------------------------------------------------------------------------
+
+class TestDefaultRkllamaUrlLegacyFallback:
+    def test_returns_8080_when_only_legacy_responds(self, monkeypatch):
+        import tinyagentos.installers.rkllama_installer as mod
+
+        def fake_probe(port: int, timeout: float = 1.0) -> bool:
+            return port == 8080
+
+        monkeypatch.setattr(mod, "_port_responds_with_rkllama", fake_probe)
+        result = mod.default_rkllama_url()
+        assert result == "http://localhost:8080"
+
+    def test_logs_warning_on_legacy_fallback(self, monkeypatch, caplog):
+        import logging
+        import tinyagentos.installers.rkllama_installer as mod
+
+        def fake_probe(port: int, timeout: float = 1.0) -> bool:
+            return port == 8080
+
+        monkeypatch.setattr(mod, "_port_responds_with_rkllama", fake_probe)
+
+        with caplog.at_level(logging.WARNING, logger="tinyagentos.installers.rkllama_installer"):
+            mod.default_rkllama_url()
+
+        assert any("legacy" in r.message.lower() or "8080" in r.message for r in caplog.records)
+
+    def test_returns_7833_when_both_respond(self, monkeypatch):
+        """If both ports answer, prefer the new default."""
+        import tinyagentos.installers.rkllama_installer as mod
+
+        monkeypatch.setattr(mod, "_port_responds_with_rkllama", lambda port, timeout=1.0: True)
+        assert mod.default_rkllama_url() == "http://localhost:7833"
+
+
+# ---------------------------------------------------------------------------
+# (c) Shell script regression guard
+# ---------------------------------------------------------------------------
+
+class TestInstallScriptDefault:
+    def test_shell_default_is_7833(self):
+        script = pathlib.Path(__file__).parents[1] / "scripts" / "install-rknpu.sh"
+        assert script.exists(), "scripts/install-rknpu.sh not found"
+        content = script.read_text()
+        assert "TAOS_RKLLAMA_PORT:-7833" in content, (
+            "install-rknpu.sh default port is not 7833; "
+            "found: " + repr([l for l in content.splitlines() if "TAOS_RKLLAMA_PORT" in l])
+        )

--- a/tests/test_rkllama_installer.py
+++ b/tests/test_rkllama_installer.py
@@ -67,17 +67,28 @@ class TestParseHfResolveUrl:
 
 
 class TestResolveRkllamaUrl:
-    def test_none_returns_loopback(self):
-        assert resolve_rkllama_url(None) == "http://localhost:8080"
+    """resolve_rkllama_url for local targets delegates to default_rkllama_url(),
+    which probes the network.  Monkeypatch _port_responds_with_rkllama to keep
+    tests hermetic (nothing listening -> returns 7833 default).
+    """
 
-    def test_empty_returns_loopback(self):
-        assert resolve_rkllama_url("") == "http://localhost:8080"
+    def test_none_returns_loopback_7833(self, monkeypatch):
+        import tinyagentos.installers.rkllama_installer as mod
+        monkeypatch.setattr(mod, "_port_responds_with_rkllama", lambda port, timeout=1.0: False)
+        assert resolve_rkllama_url(None) == "http://localhost:7833"
 
-    def test_local_returns_loopback(self):
-        assert resolve_rkllama_url("local") == "http://localhost:8080"
+    def test_empty_returns_loopback_7833(self, monkeypatch):
+        import tinyagentos.installers.rkllama_installer as mod
+        monkeypatch.setattr(mod, "_port_responds_with_rkllama", lambda port, timeout=1.0: False)
+        assert resolve_rkllama_url("") == "http://localhost:7833"
 
-    def test_remote_name_becomes_url(self):
-        assert resolve_rkllama_url("orange-pi") == "http://orange-pi:8080"
+    def test_local_returns_loopback_7833(self, monkeypatch):
+        import tinyagentos.installers.rkllama_installer as mod
+        monkeypatch.setattr(mod, "_port_responds_with_rkllama", lambda port, timeout=1.0: False)
+        assert resolve_rkllama_url("local") == "http://localhost:7833"
 
-    def test_ip_address(self):
-        assert resolve_rkllama_url("192.168.1.10") == "http://192.168.1.10:8080"
+    def test_remote_name_becomes_url_7833(self):
+        assert resolve_rkllama_url("orange-pi") == "http://orange-pi:7833"
+
+    def test_ip_address_7833(self):
+        assert resolve_rkllama_url("192.168.1.10") == "http://192.168.1.10:7833"

--- a/tinyagentos/benchmark/runner.py
+++ b/tinyagentos/benchmark/runner.py
@@ -373,7 +373,8 @@ async def _cli_main(args: argparse.Namespace) -> int:
     # WorkerAgent.detect_backends so this works before the worker process
     # is fully up.
     candidates = [
-        ("rkllama", "http://localhost:8080"),
+        ("rkllama", "http://localhost:7833"),
+        ("rkllama", "http://localhost:8080"),        # legacy port; existing installs
         ("sd-cpp", "http://localhost:7864"),
         ("ollama", "http://localhost:11434"),
         ("llama-cpp", "http://localhost:8000"),

--- a/tinyagentos/installers/rkllama_installer.py
+++ b/tinyagentos/installers/rkllama_installer.py
@@ -1,10 +1,10 @@
-"""rkllama installer — pulls .rkllm models via rkllama's own /api/pull endpoint.
+"""rkllama installer -- pulls .rkllm models via rkllama's own /api/pull endpoint.
 
 rkllama is a local NPU model server (already running on Orange Pi via
 ``install-rknpu.sh``). It exposes an Ollama-compatible HTTP API including
 ``POST /api/pull`` which downloads a model from HuggingFace, places the
 ``.rkllm`` weight in its models directory, and writes a ``Modelfile``
-alongside it. This installer just calls that endpoint — no file pushing
+alongside it. This installer just calls that endpoint -- no file pushing
 from the controller, no remote SSH, no Modelfile generation on our side.
 
 The endpoint expects the model identifier in three slash-separated parts:
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 import logging
 import re
+import socket
+import urllib.request
 from typing import Any
 from urllib.parse import urlparse
 
@@ -25,12 +27,59 @@ from tinyagentos.installers.base import AppInstaller
 
 logger = logging.getLogger(__name__)
 
+# New installs use port 7833 (taOS service block, adjacent to qmd on 7832).
+# The legacy upstream default was 8080; existing installs keep working because
+# the recorded backend URL is used directly.  This constant is only the
+# fallback when no config entry is present.
+_DEFAULT_RKLLAMA_PORT = 7833
+_LEGACY_RKLLAMA_PORT = 8080
 
 # Match a full HF resolve URL and capture (user, repo, filename).
 # Example: https://huggingface.co/c01zaut/Qwen2.5-3B-Instruct-rk3588-1.1.4/resolve/main/foo.rkllm
 _HF_RESOLVE_RE = re.compile(
     r"^https?://huggingface\.co/(?P<user>[^/]+)/(?P<repo>[^/]+)/resolve/[^/]+/(?P<filename>[^/?#]+)$"
 )
+
+
+def _port_responds_with_rkllama(port: int, timeout: float = 1.0) -> bool:
+    """Return True if localhost:<port>/api/tags answers with 200 JSON."""
+    try:
+        with socket.create_connection(("127.0.0.1", port), timeout=timeout):
+            pass
+    except OSError:
+        return False
+    try:
+        req = urllib.request.Request(
+            f"http://localhost:{port}/api/tags",
+            headers={"Accept": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.status == 200 and b"{" in resp.read(64)
+    except Exception:
+        return False
+
+
+def default_rkllama_url() -> str:
+    """Return the best local rkllama base URL.
+
+    Tries port 7833 (taOS default) first.  If nothing is there but port 8080
+    answers with rkllama's signature, returns the legacy URL and logs a hint
+    to update the service.
+
+    Safe to call at request time; uses a ~1 s socket timeout so it never
+    blocks startup paths for more than a couple of seconds.
+    """
+    if _port_responds_with_rkllama(_DEFAULT_RKLLAMA_PORT):
+        return f"http://localhost:{_DEFAULT_RKLLAMA_PORT}"
+    if _port_responds_with_rkllama(_LEGACY_RKLLAMA_PORT):
+        logger.warning(
+            "rkllama found on legacy port %d; update the service to %d "
+            "(re-run install-rknpu.sh or set TAOS_RKLLAMA_PORT=7833)",
+            _LEGACY_RKLLAMA_PORT,
+            _DEFAULT_RKLLAMA_PORT,
+        )
+        return f"http://localhost:{_LEGACY_RKLLAMA_PORT}"
+    return f"http://localhost:{_DEFAULT_RKLLAMA_PORT}"
 
 
 def parse_hf_resolve_url(url: str) -> tuple[str, str, str]:
@@ -50,15 +99,17 @@ def parse_hf_resolve_url(url: str) -> tuple[str, str, str]:
 class RkllamaInstaller(AppInstaller):
     """Install ``.rkllm`` models by calling the rkllama ``/api/pull`` endpoint.
 
-    By default the installer talks to ``http://localhost:8080`` — the
-    controller-local rkllama. When a remote worker hosts rkllama, callers
-    pass ``rkllama_url`` (e.g. ``http://192.168.6.123:8080``).
+    By default the installer talks to ``http://localhost:7833`` -- the
+    controller-local rkllama (taOS default port).  When a remote worker hosts
+    rkllama, callers pass ``rkllama_url`` (e.g. ``http://192.168.6.123:7833``).
+    Existing installs on 8080 keep working because the recorded backend URL is
+    used directly; ``default_rkllama_url()`` probes 8080 as a legacy fallback.
     """
 
     def __init__(self, rkllama_url: str | None = None, timeout: int = 1800):
-        # rkllama install can take many minutes for multi-GB weights — give it
+        # rkllama install can take many minutes for multi-GB weights -- give it
         # half an hour by default. Caller may override.
-        self.rkllama_url = (rkllama_url or "http://localhost:8080").rstrip("/")
+        self.rkllama_url = (rkllama_url or f"http://localhost:{_DEFAULT_RKLLAMA_PORT}").rstrip("/")
         self.timeout = timeout
 
     async def install(
@@ -139,7 +190,7 @@ class RkllamaInstaller(AppInstaller):
             logger.warning(
                 "rkllama install: /api/tags verification failed: %s", exc
             )
-            # Non-fatal — pull succeeded; verification problem is likely transient.
+            # Non-fatal -- pull succeeded; verification problem is likely transient.
 
         return {"success": True, "app_id": app_id, "model_name": app_id}
 
@@ -161,13 +212,12 @@ class RkllamaInstaller(AppInstaller):
 def resolve_rkllama_url(target_remote: str | None) -> str:
     """Resolve which rkllama instance to talk to.
 
-    - ``None`` / empty / "local" → controller's own rkllama on loopback.
-    - Anything else → the remote worker's hostname on port 8080.
+    - ``None`` / empty / "local" -> controller's own rkllama on loopback.
+    - Anything else -> the remote worker's hostname on port 7833 (taOS default).
 
-    rkllama always serves on 8080; that's hard-coded by ``install-rknpu.sh``
-    and the systemd unit. If we ever make the port configurable per worker
-    we'll need a registry lookup here.
+    New installs use port 7833; existing installs retain their recorded backend
+    URL so this fallback is only reached when no config entry exists.
     """
     if not target_remote or target_remote == "local":
-        return "http://localhost:8080"
-    return f"http://{target_remote}:8080"
+        return default_rkllama_url()
+    return f"http://{target_remote}:{_DEFAULT_RKLLAMA_PORT}"

--- a/tinyagentos/routes/store_install.py
+++ b/tinyagentos/routes/store_install.py
@@ -280,7 +280,7 @@ async def _legacy_install(request: Request, body: dict, app_id: str | None, targ
             await store.update_runtime_location(
                 app_id,
                 host=urlparse(rkllama_url).hostname or "localhost",
-                port=urlparse(rkllama_url).port or 8080,
+                port=urlparse(rkllama_url).port or 7833,
                 backend="rkllama",
                 ui_path="/",
             )

--- a/tinyagentos/scheduler/task_scheduler.py
+++ b/tinyagentos/scheduler/task_scheduler.py
@@ -41,7 +41,7 @@ DEFAULT_PRESETS = [
         "name": "Health Checks",
         "description": "Regular health monitoring tasks",
         "tasks": [
-            {"name": "Backend Ping", "schedule": "*/5 * * * *", "command": "curl -sf http://localhost:8080/health", "description": "Check rkllama every 5 min"},
+            {"name": "Backend Ping", "schedule": "*/5 * * * *", "command": "curl -sf http://localhost:7833/health", "description": "Check rkllama every 5 min"},
         ],
     },
 ]

--- a/tinyagentos/worker/agent.py
+++ b/tinyagentos/worker/agent.py
@@ -125,7 +125,8 @@ class WorkerAgent:
         # 11434; we want to detect both so the user's pre-existing
         # backends are first-class citizens alongside the bundled one.
         candidates = [
-            ("rkllama", "http://localhost:8080"),
+            ("rkllama", "http://localhost:7833"),
+            ("rkllama", "http://localhost:8080"),         # legacy port; existing installs
             ("ollama", "http://localhost:11434"),         # user / system Ollama (default port)
             ("ollama", "http://localhost:21434"),         # TAOS-bundled Ollama (taos-ollama.service)
             ("llama-cpp", "http://localhost:8000"),


### PR DESCRIPTION
## Why

8080 is the most contested port on any general-purpose host. rkllama only used it because that is the upstream default -- taOS launches rkllama itself, so we move our default to 7833 (adjacent to qmd on 7832, inside the quiet taOS service block). This is part 1 of issue #795; the LiteLLM half remains.

## What changed

- **`scripts/install-rknpu.sh`**: `TAOS_RKLLAMA_PORT` default changed from 8080 to 7833 (header comment + variable assignment). The rest of the script already uses `$RKLLAMA_PORT` throughout -- no other changes needed there.
- **`tinyagentos/installers/rkllama_installer.py`**: added `default_rkllama_url()` helper that probes 7833 first; if nothing answers and 8080 responds with rkllama's `/api/tags` signature, returns the 8080 URL with a log warning. Updated `RkllamaInstaller` constructor default and `resolve_rkllama_url` to use 7833.
- **`tinyagentos/benchmark/runner.py`**, **`tinyagentos/worker/agent.py`**: probe-candidate lists now try 7833 first; 8080 kept as a secondary entry for legacy installs.
- **`tinyagentos/scheduler/task_scheduler.py`**: default cron health-check command updated to 7833.
- **`tinyagentos/routes/store_install.py`**: `urlparse(rkllama_url).port or 8080` fallback updated to 7833.
- **`docs/UPDATE_BREAKAGE_LOG.md`**: new entry at the top documenting the breakage scenario and fix.
- **`docs/agent-qmd-serve-setup.md`**, design plan docs: live rkllama example URLs updated to 7833.

## Legacy fallback

Existing installs keep working -- everything config-driven reads the recorded backend URL directly. The `default_rkllama_url()` probe only runs when no config entry exists, and it checks 8080 automatically as a fallback with a log hint to migrate.

## Tests

17 passed (12 existing + 5 new in `tests/test_rkllama_default_port.py`). `bash -n scripts/install-rknpu.sh` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all documentation to reflect rkllama service port migration from 8080 to 7833.

* **New Features**
  * Added automatic port detection to support both legacy (8080) and new default (7833) configurations.
  * Installer intelligently detects existing installations and enables fallback compatibility.

* **Tests**
  * Added port detection and fallback behavior verification tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->