### PR TITLE
fix(install): rknpu verification follows the rkllama port move (#795)

### DIFF
--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -439,7 +439,7 @@ detect_and_advise_accelerators() {
             log "  fork: https://github.com/jaylfc/rkllama"
             # Chained auto-install on by default for RK3588 hosts: if the
             # NPU is present and rkllama isn't installed yet, set up our
-            # fork now so rkllama is already serving on :8080 before the
+            # fork now so rkllama is already serving (port 7833) before the
             # controller systemd unit lands. Opt-out via TAOS_NO_RKNPU=1.
             if [[ "${TAOS_NO_RKNPU:-}" == "1" || "${TAOS_NO_RKNPU:-}" == "true" ]]; then
                 warn "TAOS_NO_RKNPU=1 — skipping rkllama install; controller will run CPU-only on this NPU box"
@@ -1803,8 +1803,10 @@ verify_hardware_capabilities() {
         if [[ -r /dev/rknpu ]] || [[ -r /sys/kernel/debug/rknpu/load ]]; then
             rknpu_ok=1
         fi
-        # Also check if rkllama is responding on :8080
-        if curl -sf --max-time 3 "http://localhost:8080/health" >/dev/null 2>&1; then
+        # Also check if rkllama is responding (7833 default, 8080 legacy)
+        local _rk_port="${TAOS_RKLLAMA_PORT:-7833}"
+        if curl -sf --max-time 3 "http://localhost:${_rk_port}/health" >/dev/null 2>&1 \
+           || curl -sf --max-time 3 "http://localhost:8080/health" >/dev/null 2>&1; then
             rknpu_ok=1
         fi
         if (( rknpu_ok )); then
@@ -1812,7 +1814,7 @@ verify_hardware_capabilities() {
             verified_ok=$((verified_ok + 1))
         else
             warn "  ✗ rknpu: claimed by controller but device node not readable and rkllama not responding"
-            warn "     check: ls -l /dev/rknpu && curl http://localhost:8080/health"
+            warn "     check: ls -l /dev/rknpu && curl http://localhost:${TAOS_RKLLAMA_PORT:-7833}/health"
             warn "     ensure rkllama.service is running: sudo systemctl status rkllama"
             verified_warn=$((verified_warn + 1))
         fi

--- a/tinyagentos/installers/rkllama_installer.py
+++ b/tinyagentos/installers/rkllama_installer.py
@@ -109,7 +109,7 @@ class RkllamaInstaller(AppInstaller):
     def __init__(self, rkllama_url: str | None = None, timeout: int = 1800):
         # rkllama install can take many minutes for multi-GB weights -- give it
         # half an hour by default. Caller may override.
-        self.rkllama_url = (rkllama_url or f"http://localhost:{_DEFAULT_RKLLAMA_PORT}").rstrip("/")
+        self.rkllama_url = (rkllama_url or default_rkllama_url()).rstrip("/")
         self.timeout = timeout
 
     async def install(


### PR DESCRIPTION
Follow-up to #802 from the bot review: the install verification still probed only 8080/health, so a fresh install with rkllama on 7833 failed its own check. Verification now probes TAOS_RKLLAMA_PORT (default 7833) first with 8080 as legacy fallback, and RkllamaInstaller's no-URL default goes through default_rkllama_url() so legacy installs without a recorded backend URL still resolve. Known accepted limitations, documented here on purpose: the rkllama detection signature is a 200 JSON on /api/tags (same shape as any Ollama-compatible server) and the probe is synchronous with a 1s timeout (bounded 2s worst case on first construct); both are fine for localhost defaults and config-recorded URLs bypass the probe entirely. Remote workers always advertise their backend URL so the remote path never probes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined Rockchip RKNPU installation messaging and configuration handling
  * Enhanced post-installation hardware capability verification with improved fallback mechanisms
  * Updated error messages to provide clearer troubleshooting guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->