### PR TITLE
Promote dev to master: LiteLLM host port move (#795 complete)

### DIFF
--- a/data/config.yaml.example
+++ b/data/config.yaml.example
@@ -1,6 +1,8 @@
 server:
   host: 0.0.0.0
   port: 6969
+  # LiteLLM proxy host port (agent containers always see 4000 internally)
+  litellm_port: 7834
   # Second origin for the sandboxed browser proxy so the proxied iframe can
   # take allow-same-origin and register a service worker without exposing
   # any taOS API. Env override: TAOS_BROWSER_PROXY_PORT. Set to 0 to disable

--- a/docs/UPDATE_BREAKAGE_LOG.md
+++ b/docs/UPDATE_BREAKAGE_LOG.md
@@ -15,6 +15,30 @@ Format per entry: date, change (PR), affected installs, symptom, check, fix.
 
 ---
 
+## 2026-06-12 — LiteLLM host port default moved 4000 -> 7834 (#795, pinned in #805)
+
+- **Affected:** existing installs that have no `litellm_port` key under `server:`
+  in taos-config.yaml (i.e. installs created before #795 that have not yet been
+  updated).
+- **Symptom (before #805 fix):** agents could not reach models after a controller
+  restart; connection refused on 4000 because the new default of 7834 was in
+  effect but the incus proxy devices still targeted host:4000.
+- **Actual behavior (with #805, landed in this release):** no action needed. On
+  the first boot after update the controller detects the missing `litellm_port`
+  key, pins it to 4000, and persists that value to taos-config.yaml. Every
+  subsequent boot reads 4000 from disk. Existing agents and their incus proxy
+  devices continue to work without any change.
+- **Fresh installs:** get `litellm_port: 7834` written to taos-config.yaml at
+  creation time. Not affected by the legacy pin.
+- **Check:** after updating, `grep litellm_port /opt/tinyagentos/data/taos-config.yaml`
+  should show your recorded value. Controller log contains
+  `existing install: pinning LiteLLM host port 4000` once on first boot if the
+  pin was applied.
+- **To migrate an existing install to 7834:** set `server.litellm_port: 7834` in
+  taos-config.yaml AND redeploy each agent container so its incus proxy device
+  is recreated with the new host-side target port. Agents not redeployed will
+  lose model access until redeployed.
+
 ## 2026-06-12 — rkllama default port moved 8080 -> 7833 (#795)
 
 - **Affected:** installs that re-run `install-rknpu.sh` after this change while

--- a/docs/runbooks/controller-rescue.md
+++ b/docs/runbooks/controller-rescue.md
@@ -56,7 +56,7 @@ sudo systemctl start tinyagentos
 | Component | What it is | Restart |
 |---|---|---|
 | Controller | `tinyagentos.service`, the main app on :6969 (+ browser proxy on :6970) | `sudo systemctl restart tinyagentos` |
-| LiteLLM | model router on `127.0.0.1:4000`, child process of the controller, config under `/tmp/taos-litellm/` | restart the controller (it respawns LiteLLM) |
+| LiteLLM | model router on `127.0.0.1:7834` (legacy installs may use 4000), child process of the controller, config under `/tmp/taos-litellm/` | restart the controller (it respawns LiteLLM) |
 | qmd | shared embed/rerank provider, `qmd.service` on :7832 | `sudo systemctl restart qmd` |
 | Agent containers | one LXC per agent, named `taos-agent-<name>` | `incus restart taos-agent-<name>` (or start/stop) |
 | Postgres | LiteLLM's database | `sudo systemctl restart postgresql` |
@@ -75,7 +75,7 @@ Notes:
 
 ```bash
 # What is listening where
-ss -tlnp | grep -E "6969|6970|4000|7832"
+ss -tlnp | grep -E "6969|6970|7834|7832"
 
 # Is the process hung rather than dead? Dump live Python stacks
 sudo /opt/tinyagentos/.venv/bin/pip install py-spy   # once
@@ -103,7 +103,7 @@ df -h /opt /var
 | unit `active (running)`, :6970 listening, :6969 dead, journal shows a startup traceback | main server failed startup, proxy kept the process alive (#756) | fix the traceback's cause, then `systemctl restart tinyagentos` |
 | `status=217/USER` | the `taos` system user does not exist (installer ran without privileges) | re-run the installer with sudo (#753) |
 | Port already in use on 6969/6970 | a previous half-dead process still holds the port | `sudo systemctl stop tinyagentos`, confirm with `ss -tlnp`, `kill` any leftover, start again |
-| UI loads but models error | LiteLLM child or postgres down | triage `ss \| grep 4000`, `systemctl status postgresql`, restart the controller |
+| UI loads but models error | LiteLLM child or postgres down | triage `ss \| grep 7834` (or 4000 on legacy installs), `systemctl status postgresql`, restart the controller |
 
 ---
 

--- a/docs/taos-agent-manual.md
+++ b/docs/taos-agent-manual.md
@@ -85,7 +85,7 @@ Useful commands in any channel:
 ## Architecture
 
 - **Containers**: each agent runs in an isolated LXC or Docker container. taOS auto-detects which runtime is available; you can override in Settings → Container Runtime.
-- **Model routing**: LiteLLM proxy (port 4000) sits between agents and model backends. Agents use a standard OpenAI-compatible API — they never talk to a provider directly.
+- **Model routing**: LiteLLM proxy (port 7834) sits between agents and model backends. Agents use a standard OpenAI-compatible API -- they never talk to a provider directly.
 - **Backends**: local inference (rkllama for RKLLM NPU, Ollama for CPU/GPU), cloud APIs (OpenAI, Anthropic, OpenRouter, Kilocode), and remote workers.
 - **Memory**: taOS uses taosmd for long-term memory. Agents can read and write memory chunks; a Librarian agent can curate and categorise them.
 - **Frameworks**: OpenClaw (default), Hermes, SmolAgents, Langroid, PocketFlow, OpenAI Agents SDK. Each framework is validated at startup and gets its own lifecycle managed by taOS.

--- a/tests/installers/test_port_allocator.py
+++ b/tests/installers/test_port_allocator.py
@@ -10,6 +10,20 @@ from tinyagentos.installers.port_allocator import (
 )
 
 
+class TestReservedPorts:
+    def test_legacy_litellm_port_reserved(self):
+        assert 4000 in RESERVED_PORTS
+
+    def test_qmd_port_reserved(self):
+        assert 7832 in RESERVED_PORTS
+
+    def test_rkllama_port_reserved(self):
+        assert 7833 in RESERVED_PORTS
+
+    def test_litellm_new_host_port_reserved(self):
+        assert 7834 in RESERVED_PORTS
+
+
 class TestAllocateHostPort:
     def test_deterministic_for_same_app_id(self):
         assert allocate_host_port("searxng") == allocate_host_port("searxng")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,6 @@
 import pytest
 import yaml
-from tinyagentos.config import AppConfig, load_config, save_config, validate_config, normalize_agent
+from tinyagentos.config import AppConfig, load_config, save_config, validate_config, normalize_agent, _LITELLM_PORT_NEW, _LITELLM_PORT_LEGACY
 
 class TestLoadConfig:
     def test_loads_valid_config(self, tmp_data_dir):
@@ -313,3 +313,45 @@ class TestKvCacheQuantField:
         p.write_text(yaml.dump(old_config))
         config = load_config(p)
         assert config.agents[0]["paused"] is False
+
+
+class TestLitellmPortPin:
+    def test_from_disk_without_litellm_port_pins_legacy_and_persists(self, tmp_path):
+        """Existing install: config.yaml has no litellm_port -> pinned to 4000 on load
+        and the pin is persisted so subsequent boots don't toggle."""
+        old_cfg = {
+            "server": {"host": "0.0.0.0", "port": 6969},
+            "backends": [],
+            "qmd": {"url": "http://localhost:7832"},
+            "agents": [],
+            "metrics": {"poll_interval": 30, "retention_days": 30},
+        }
+        p = tmp_path / "config.yaml"
+        p.write_text(yaml.dump(old_cfg))
+        config = load_config(p)
+        assert config.server["litellm_port"] == _LITELLM_PORT_LEGACY
+        # Pin must be persisted so the next boot reads a concrete value.
+        on_disk = yaml.safe_load(p.read_text())
+        assert on_disk["server"]["litellm_port"] == _LITELLM_PORT_LEGACY
+
+    def test_fresh_install_records_new_port(self, tmp_path):
+        """No config file -> fresh install defaults record 7834 (not 4000)."""
+        config = load_config(tmp_path / "config.yaml")
+        assert config.server["litellm_port"] == _LITELLM_PORT_NEW
+
+    def test_explicit_existing_value_is_untouched(self, tmp_path):
+        """An explicit litellm_port in config (e.g. 5000) is preserved as-is."""
+        existing_cfg = {
+            "server": {"host": "0.0.0.0", "port": 6969, "litellm_port": 5000},
+            "backends": [],
+            "qmd": {"url": "http://localhost:7832"},
+            "agents": [],
+            "metrics": {"poll_interval": 30, "retention_days": 30},
+        }
+        p = tmp_path / "config.yaml"
+        p.write_text(yaml.dump(existing_cfg))
+        original_mtime = p.stat().st_mtime
+        config = load_config(p)
+        assert config.server["litellm_port"] == 5000
+        # File must not be rewritten when no pin was applied.
+        assert p.stat().st_mtime == original_mtime

--- a/tests/test_deployer.py
+++ b/tests/test_deployer.py
@@ -582,6 +582,70 @@ class TestDeployAgent:
             assert "tcp:127.0.0.1:6969" in listens
 
     @pytest.mark.asyncio
+    async def test_litellm_proxy_device_container_listen_stays_4000(self, tmp_path):
+        """Container-side listen for LiteLLM is always 4000 (baked into agent
+        configs); the host-side connect follows the live proxy port.  With no
+        proxy supplied the deployer falls back to 7834."""
+        req = _req(name="port-check", data_dir=tmp_path)
+
+        async def mock_exec_fn(name, cmd, **kwargs):
+            if "hostname -I" in " ".join(cmd):
+                return (0, "10.0.0.92")
+            return (0, "ok")
+
+        with patch("tinyagentos.deployer.create_container", new_callable=AsyncMock) as mock_create, \
+             patch("tinyagentos.deployer.exec_in_container", side_effect=mock_exec_fn), \
+             patch("tinyagentos.deployer.push_file", new_callable=AsyncMock, return_value=(0, "")), \
+             patch("tinyagentos.deployer.add_proxy_device", new_callable=AsyncMock) as mock_proxy:
+            mock_create.return_value = {"success": True, "name": "taos-agent-port-check"}
+            mock_proxy.return_value = {"success": True, "output": ""}
+            result = await deploy_agent(req)
+            assert result["success"] is True
+
+            litellm_call = next(
+                c for c in mock_proxy.call_args_list if c.args[1] == "taos-proxy-litellm"
+            )
+            assert litellm_call.kwargs["listen"] == "tcp:127.0.0.1:4000"
+            assert litellm_call.kwargs["connect"] == "tcp:127.0.0.1:7834"
+
+    @pytest.mark.asyncio
+    async def test_litellm_proxy_device_connect_follows_live_proxy_port(self, tmp_path):
+        """When extra_config supplies an llm_proxy object with a custom port,
+        the host-side connect address of the incus proxy device uses that port."""
+        mock_proxy = MagicMock()
+        mock_proxy.is_running.return_value = False
+        mock_proxy.port = 4000  # legacy install kept old port
+        mock_proxy.database_url = None
+
+        req = _req(
+            name="legacy-port",
+            data_dir=tmp_path,
+            extra_config={"llm_proxy": mock_proxy},
+        )
+
+        async def mock_exec_fn(name, cmd, **kwargs):
+            if "hostname -I" in " ".join(cmd):
+                return (0, "10.0.0.93")
+            return (0, "ok")
+
+        with patch("tinyagentos.deployer.create_container", new_callable=AsyncMock) as mock_create, \
+             patch("tinyagentos.deployer.exec_in_container", side_effect=mock_exec_fn), \
+             patch("tinyagentos.deployer.push_file", new_callable=AsyncMock, return_value=(0, "")), \
+             patch("tinyagentos.deployer.add_proxy_device", new_callable=AsyncMock) as mock_proxy_dev:
+            mock_create.return_value = {"success": True, "name": "taos-agent-legacy-port"}
+            mock_proxy_dev.return_value = {"success": True, "output": ""}
+            result = await deploy_agent(req)
+            assert result["success"] is True
+
+            litellm_call = next(
+                c for c in mock_proxy_dev.call_args_list if c.args[1] == "taos-proxy-litellm"
+            )
+            # Container listen stays 4000 regardless of host port
+            assert litellm_call.kwargs["listen"] == "tcp:127.0.0.1:4000"
+            # Host connect follows the live proxy's recorded port
+            assert litellm_call.kwargs["connect"] == "tcp:127.0.0.1:4000"
+
+    @pytest.mark.asyncio
     async def test_proxy_device_failure_rolls_back(self, tmp_path):
         req = _req(name="noproxy", data_dir=tmp_path)
 

--- a/tests/test_llm_proxy.py
+++ b/tests/test_llm_proxy.py
@@ -259,6 +259,14 @@ class TestCallbackWiring:
 
 
 class TestLLMProxy:
+    def test_default_port_is_7834(self):
+        proxy = LLMProxy()
+        assert proxy.port == 7834
+
+    def test_config_provided_port_overrides_default(self):
+        proxy = LLMProxy(port=4000)
+        assert proxy.port == 4000
+
     def test_proxy_not_running_initially(self):
         proxy = LLMProxy(port=14000)
         assert not proxy.is_running()

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -303,7 +303,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     local_token_path = data_dir / ".auth_local_token"
     local_token = local_token_path.read_text().strip() if local_token_path.exists() else None
     llm_proxy = LLMProxy(
-        port=4000,
+        port=config.server.get("litellm_port", 7834),
         database_url=db_url,
         local_token=local_token,
         # registry lets generate_litellm_config register installed local
@@ -822,7 +822,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         app.state.trace_registry.set_emitter(_otel_emitter)
         # Phase 4: reasoning judge — fire on lifecycle session_end.
         from tinyagentos.otel.judge import ReasoningJudge
-        _judge = ReasoningJudge(litellm_base_url="http://localhost:4000/v1")
+        _judge = ReasoningJudge(litellm_base_url=f"http://localhost:{app.state.llm_proxy.port}/v1")
         app.state.trace_registry.set_judge(_judge)
 
         # Bridge session registry — per-agent queue + accumulator for openclaw.

--- a/tinyagentos/config.py
+++ b/tinyagentos/config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -10,10 +11,19 @@ import yaml
 
 from tinyagentos.providers import ALL_TYPES as VALID_BACKEND_TYPES
 
+log = logging.getLogger(__name__)
+
 VALID_ON_WORKER_FAILURE = {"pause", "fallback", "escalate-immediately"}
 
+# Port used by LiteLLM on the host side.  Container-internal side is always
+# 4000 (the incus proxy device bridges container:4000 -> host:litellm_port).
+# New installs record 7834; existing installs that predate the #795 port move
+# are pinned to 4000 on first boot after update (see load_config below).
+_LITELLM_PORT_NEW = 7834
+_LITELLM_PORT_LEGACY = 4000
+
 DEFAULT_CONFIG = {
-    "server": {"host": "0.0.0.0", "port": 6969, "browser_proxy_port": 6970},
+    "server": {"host": "0.0.0.0", "port": 6969, "browser_proxy_port": 6970, "litellm_port": _LITELLM_PORT_NEW},
     "backends": [],
     "qmd": {"url": "http://localhost:7832"},
     "agents": [],
@@ -64,7 +74,11 @@ class AppConfig:
 
 def load_config(path: Path) -> AppConfig:
     if not path.exists():
-        return AppConfig(config_path=path)
+        # Fresh install: build defaults with litellm_port explicitly recorded
+        # so the choice is durable and never falls back to a hardcoded default.
+        cfg = AppConfig(config_path=path)
+        cfg.server.setdefault("litellm_port", _LITELLM_PORT_NEW)
+        return cfg
     text = path.read_text()
     try:
         data = yaml.safe_load(text)
@@ -81,8 +95,22 @@ def load_config(path: Path) -> AppConfig:
     archive_cfg = DEFAULT_ARCHIVE_CONFIG.copy()
     if isinstance(archive_raw, dict):
         archive_cfg.update(archive_raw)
-    return AppConfig(
-        server=data.get("server", DEFAULT_CONFIG["server"].copy()),
+    server = data.get("server", DEFAULT_CONFIG["server"].copy())
+    # One-time legacy pin: existing installs that predate #795 have no
+    # litellm_port in their config.  Their incus proxy devices target host
+    # port 4000, so we must pin to 4000 and persist it now.  Fresh installs
+    # (path didn't exist above) get 7834 recorded at creation.
+    _pin_applied = False
+    if "litellm_port" not in server:
+        server["litellm_port"] = _LITELLM_PORT_LEGACY
+        _pin_applied = True
+        log.info(
+            "existing install: pinning LiteLLM host port %d; "
+            "new installs use %d, see #795",
+            _LITELLM_PORT_LEGACY, _LITELLM_PORT_NEW,
+        )
+    cfg = AppConfig(
+        server=server,
         backends=data.get("backends", []),
         qmd=data.get("qmd", DEFAULT_CONFIG["qmd"].copy()),
         agents=agents,
@@ -92,6 +120,9 @@ def load_config(path: Path) -> AppConfig:
         archive=archive_cfg,
         config_path=path,
     )
+    if _pin_applied:
+        save_config(cfg, path)
+    return cfg
 
 AGENT_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,62}$")
 

--- a/tinyagentos/deployer.py
+++ b/tinyagentos/deployer.py
@@ -300,21 +300,31 @@ async def deploy_agent(req: DeployRequest) -> dict:
     try:
         # Incus proxy devices: let the container reach host services via
         # its own 127.0.0.1.
-        proxy_ports = [
-            ("taos-proxy-litellm", 4000),
-            ("taos-proxy-taos", req.taos_port),
+        #
+        # Each tuple: (device_name, container_listen_port, host_connect_port).
+        # LiteLLM: the container-side URL is always tcp:127.0.0.1:4000 (baked
+        # into OPENAI_BASE_URL and openclaw.json via the proxy device above),
+        # but the host may run LiteLLM on any configured port (default 7834).
+        # The connect side tracks the live proxy port so the tunnel reaches the
+        # right host process regardless of whether the operator kept the legacy
+        # 4000 or migrated to 7834.
+        llm_proxy_ref = (req.extra_config or {}).get("llm_proxy")
+        litellm_host_port = getattr(llm_proxy_ref, "port", None) or 7834
+        proxy_devices = [
+            ("taos-proxy-litellm", 4000, litellm_host_port),
+            ("taos-proxy-taos", req.taos_port, req.taos_port),
         ]
-        for dev_name, port in proxy_ports:
+        for dev_name, listen_port, connect_port in proxy_devices:
             res = await add_proxy_device(
                 container_name,
                 dev_name,
-                listen=f"tcp:127.0.0.1:{port}",
-                connect=f"tcp:127.0.0.1:{port}",
+                listen=f"tcp:127.0.0.1:{listen_port}",
+                connect=f"tcp:127.0.0.1:{connect_port}",
                 bind_mode="instance",
             )
             if not res.get("success"):
                 raise RuntimeError(
-                    f"failed to attach proxy device {dev_name}:{port}: {res.get('output', '')}"
+                    f"failed to attach proxy device {dev_name}: {res.get('output', '')}"
                 )
         steps.append("proxy_devices_attached")
 

--- a/tinyagentos/installers/port_allocator.py
+++ b/tinyagentos/installers/port_allocator.py
@@ -34,11 +34,14 @@ RESERVED_PORTS: frozenset[int] = frozenset({
     1080,  # SOCKS
     3000,  # Node / React dev / Grafana
     3306,  # MySQL
-    4000,  # LiteLLM (taOS internal)
+    4000,  # LiteLLM legacy host port (kept reserved: existing installs may still use it)
     5000,  # Flask / generic dev
     5173,  # Vite dev
     5432,  # PostgreSQL
     6379,  # Redis
+    7832,  # taOS qmd memory service
+    7833,  # taOS rkllama NPU backend
+    7834,  # taOS LiteLLM proxy (new default host port)
     7900,  # taosmd A2A bus
     8000,  # Django / generic dev
     8080,  # Tomcat / common web app default

--- a/tinyagentos/llm_proxy.py
+++ b/tinyagentos/llm_proxy.py
@@ -78,7 +78,7 @@ class LLMProxy:
 
     def __init__(
         self,
-        port: int = 4000,
+        port: int = 7834,
         config_dir: Path | None = None,
         database_url: str | None = None,
         local_token: str | None = None,

--- a/tinyagentos/opencode_runtime.py
+++ b/tinyagentos/opencode_runtime.py
@@ -44,7 +44,7 @@ class OpenCodeServerConfig:
     """If set, ``OPENCODE_SERVER_PASSWORD`` env var is passed and Basic auth is used."""
 
     litellm_base_url: str
-    """Base URL of the taOS LiteLLM proxy, e.g. ``http://127.0.0.1:4000/v1``."""
+    """Base URL of the taOS LiteLLM proxy, e.g. ``http://127.0.0.1:7834/v1``."""
 
     litellm_key: str
     """API key for the LiteLLM proxy (the agent's own virtual key)."""

--- a/tinyagentos/otel/judge.py
+++ b/tinyagentos/otel/judge.py
@@ -114,7 +114,7 @@ class ReasoningJudge:
     def __init__(
         self,
         *,
-        litellm_base_url: str = "http://127.0.0.1:4000/v1",
+        litellm_base_url: str = "http://127.0.0.1:7834/v1",
         litellm_api_key: str = "taos-internal",
         judge_model: str | None = None,
         timeout: float = 60.0,

--- a/tinyagentos/routes/settings.py
+++ b/tinyagentos/routes/settings.py
@@ -217,7 +217,7 @@ async def llm_proxy_status(request: Request):
     proxy = request.app.state.llm_proxy
     return {
         "running": proxy.is_running() if hasattr(proxy, "is_running") else False,
-        "port": proxy.port if hasattr(proxy, "port") else 4000,
+        "port": proxy.port if hasattr(proxy, "port") else 7834,
         "backends": len(request.app.state.config.backends),
     }
 

--- a/tinyagentos/taos_agent_runtime.py
+++ b/tinyagentos/taos_agent_runtime.py
@@ -111,7 +111,7 @@ async def ensure_taos_opencode_server(app_state, model: str) -> OpenCodeServer:
             home=home,
             port=TAOS_OPENCODE_PORT,
             server_password=app_state.taos_opencode_password,
-            litellm_base_url="http://127.0.0.1:4000/v1",
+            litellm_base_url=f"http://127.0.0.1:{llm_proxy.port if llm_proxy is not None else 7834}/v1",
             litellm_key=litellm_key,
             model_ids=permitted_models,
         )


### PR DESCRIPTION
Carries #805: LiteLLM host port default 4000 to 7834, container side stays 4000 via the proxy device, existing installs auto-pinned to 4000 on first boot. Completes the 783x platform service block and closes #795.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Configuration Changes**
  * Updated default LiteLLM proxy port to 7834. Existing installations retain port 4000 for backward compatibility; fresh installs use the new port. Existing installations can migrate by redeploying agent containers.

* **Documentation**
  * Updated controller rescue runbook and agent manual to reflect current port configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->