### PR TITLE
feat(registry): scoped read-only access to the registry feeds (#744 follow-up)

### DIFF
--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -563,3 +563,234 @@ class TestAgentRegistryRoutes:
     async def test_revoked_feed_admin_can_read(self, registry_client):
         resp = await registry_client.get("/api/agents/registry/revoked")
         assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# registry_feeds_read scope -- feed token auth
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture
+async def feeds_client(app, tmp_data_dir):
+    """Admin client with all stores needed for the feed-token tests.
+
+    Mirrors registry_client but also initialises agent_grants, auth_requests,
+    and relationships so the consent-flow helpers used inside tests work.
+    """
+    for attr in ("agent_registry", "agent_grants", "auth_requests", "relationships", "metrics"):
+        store = getattr(app.state, attr)
+        if store._db is None:
+            await store.init()
+
+    app.state.auth.setup_user("admin", "Test Admin", "", "testpass")
+    record = app.state.auth.find_user("admin")
+    uid = record["id"] if record else ""
+    token = app.state.auth.create_session(user_id=uid, long_lived=True)
+    app.state._startup_complete = True
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        cookies={"taos_session": token},
+    ) as c:
+        c._test_admin_uid = uid
+        c._app = app
+        yield c
+
+    for attr in ("agent_registry", "agent_grants", "auth_requests", "relationships", "metrics"):
+        store = getattr(app.state, attr)
+        if store._db is not None:
+            await store.close()
+
+
+async def _make_feed_token(client) -> str:
+    """Register an agent and grant it registry_feeds_read via the consent flow.
+
+    Returns the signed registry JWT for that agent.
+    """
+    from httpx import ASGITransport, AsyncClient
+
+    app = client._app
+    transport = ASGITransport(app=app)
+
+    # Submit the auth-request as an unauthenticated external agent.
+    async with AsyncClient(transport=transport, base_url="http://test") as bare:
+        cr = await bare.post(
+            "/api/agents/auth-requests",
+            json={
+                "identity_claim": "taosmd-feed-reader",
+                "framework": "taosmd",
+                "requested_scopes": ["registry_feeds_read"],
+                "reason": "poll grant and revocation feeds",
+            },
+        )
+    assert cr.status_code == 200, cr.text
+    request_id = cr.json()["request_id"]
+
+    # Admin approves.
+    approve = await client.post(
+        f"/api/agents/auth-requests/{request_id}/approve",
+        json={"granted_scopes": ["registry_feeds_read"]},
+    )
+    assert approve.status_code == 200, approve.text
+
+    # Poll to get the token.
+    async with AsyncClient(transport=transport, base_url="http://test") as bare:
+        status = await bare.get(f"/api/agents/auth-requests/{request_id}")
+    assert status.status_code == 200
+    return status.json()["token"]
+
+
+@pytest.mark.asyncio
+class TestFeedReadScope:
+
+    async def test_no_auth_revoked_returns_401_or_403(self, feeds_client):
+        """Unauthenticated request (no session, no Bearer) is rejected."""
+        from httpx import ASGITransport, AsyncClient
+
+        transport = ASGITransport(app=feeds_client._app)
+        async with AsyncClient(transport=transport, base_url="http://test") as bare:
+            resp = await bare.get("/api/agents/registry/revoked")
+        assert resp.status_code in (401, 403)
+
+    async def test_no_auth_grants_returns_401_or_403(self, feeds_client):
+        """Unauthenticated request (no session, no Bearer) is rejected."""
+        from httpx import ASGITransport, AsyncClient
+
+        transport = ASGITransport(app=feeds_client._app)
+        async with AsyncClient(transport=transport, base_url="http://test") as bare:
+            resp = await bare.get("/api/agents/registry/grants")
+        assert resp.status_code in (401, 403)
+
+    async def test_token_with_scope_reads_revoked_feed(self, feeds_client):
+        """A JWT with an active registry_feeds_read grant can read the revoked feed."""
+        feed_token = await _make_feed_token(feeds_client)
+
+        from httpx import ASGITransport, AsyncClient
+
+        transport = ASGITransport(app=feeds_client._app)
+        async with AsyncClient(transport=transport, base_url="http://test") as bare:
+            resp = await bare.get(
+                "/api/agents/registry/revoked",
+                headers={"Authorization": f"Bearer {feed_token}"},
+            )
+        assert resp.status_code == 200
+        assert "revoked" in resp.json()
+
+    async def test_token_with_scope_reads_grants_feed(self, feeds_client):
+        """A JWT with an active registry_feeds_read grant can read the grants feed."""
+        feed_token = await _make_feed_token(feeds_client)
+
+        from httpx import ASGITransport, AsyncClient
+
+        transport = ASGITransport(app=feeds_client._app)
+        async with AsyncClient(transport=transport, base_url="http://test") as bare:
+            resp = await bare.get(
+                "/api/agents/registry/grants",
+                headers={"Authorization": f"Bearer {feed_token}"},
+            )
+        assert resp.status_code == 200
+        assert "grants" in resp.json()
+
+    async def test_token_without_scope_gets_403(self, feeds_client):
+        """A valid JWT for an agent that has no registry_feeds_read grant gets 403."""
+        # Register an agent directly (no grants written).
+        reg = await feeds_client.post(
+            "/api/agents/registry/register",
+            json={"framework": "openclaw", "display_name": "No Scope Agent"},
+        )
+        assert reg.status_code == 200
+        no_scope_token = reg.json()["token"]
+
+        from httpx import ASGITransport, AsyncClient
+
+        transport = ASGITransport(app=feeds_client._app)
+        async with AsyncClient(transport=transport, base_url="http://test") as bare:
+            r1 = await bare.get(
+                "/api/agents/registry/revoked",
+                headers={"Authorization": f"Bearer {no_scope_token}"},
+            )
+            r2 = await bare.get(
+                "/api/agents/registry/grants",
+                headers={"Authorization": f"Bearer {no_scope_token}"},
+            )
+        assert r1.status_code == 403
+        assert r2.status_code == 403
+
+    async def test_expired_grant_gets_403(self, feeds_client):
+        """A token whose registry_feeds_read grant has expired gets 403."""
+        from datetime import datetime, timezone, timedelta
+
+        feed_token = await _make_feed_token(feeds_client)
+
+        # Decode the canonical_id from the token payload.
+        import base64, json as _json
+        raw = feed_token.split(".")[1]
+        padding = 4 - len(raw) % 4
+        if padding != 4:
+            raw += "=" * padding
+        canonical_id = _json.loads(base64.urlsafe_b64decode(raw))["sub"]
+
+        # Overwrite the grant with an already-expired expires_at.
+        past = (datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat()
+        grants_store = feeds_client._app.state.agent_grants
+        await grants_store.add_grant(
+            canonical_id,
+            "registry_feeds_read",
+            tier="once",
+            expires_at=past,
+        )
+
+        from httpx import ASGITransport, AsyncClient
+
+        transport = ASGITransport(app=feeds_client._app)
+        async with AsyncClient(transport=transport, base_url="http://test") as bare:
+            r1 = await bare.get(
+                "/api/agents/registry/revoked",
+                headers={"Authorization": f"Bearer {feed_token}"},
+            )
+            r2 = await bare.get(
+                "/api/agents/registry/grants",
+                headers={"Authorization": f"Bearer {feed_token}"},
+            )
+        assert r1.status_code == 403
+        assert r2.status_code == 403
+
+    async def test_suspended_agent_gets_403(self, feeds_client):
+        """A token for a suspended agent gets 403 even with the correct scope."""
+        feed_token = await _make_feed_token(feeds_client)
+
+        import base64, json as _json
+        raw = feed_token.split(".")[1]
+        padding = 4 - len(raw) % 4
+        if padding != 4:
+            raw += "=" * padding
+        canonical_id = _json.loads(base64.urlsafe_b64decode(raw))["sub"]
+
+        # Suspend the agent via the admin endpoint.
+        suspend = await feeds_client.post(f"/api/agents/registry/{canonical_id}/suspend")
+        assert suspend.status_code == 200
+
+        from httpx import ASGITransport, AsyncClient
+
+        transport = ASGITransport(app=feeds_client._app)
+        async with AsyncClient(transport=transport, base_url="http://test") as bare:
+            r1 = await bare.get(
+                "/api/agents/registry/revoked",
+                headers={"Authorization": f"Bearer {feed_token}"},
+            )
+            r2 = await bare.get(
+                "/api/agents/registry/grants",
+                headers={"Authorization": f"Bearer {feed_token}"},
+            )
+        assert r1.status_code == 403
+        assert r2.status_code == 403
+
+    async def test_admin_session_still_works(self, feeds_client):
+        """Admin cookie session continues to work alongside Bearer token auth."""
+        r1 = await feeds_client.get("/api/agents/registry/revoked")
+        r2 = await feeds_client.get("/api/agents/registry/grants")
+        assert r1.status_code == 200
+        assert "revoked" in r1.json()
+        assert r2.status_code == 200
+        assert "grants" in r2.json()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -292,14 +292,17 @@ class TestAuthMiddleware:
             "/auth/setup",
             json={"username": "admin", "full_name": "Admin", "email": "", "password": "adminpass", "auto_login": False},
         )
-        if app.state.agent_grants._db is None:
-            await app.state.agent_grants.init()
+        for attr in ("agent_grants", "agent_registry"):
+            store = getattr(app.state, attr)
+            if store._db is None:
+                await store.init()
         tok = app.state.auth.get_local_token()
-        resp = await auth_client.get(
-            "/api/agents/registry/grants",
-            headers={"Authorization": f"Bearer {tok}"},
-        )
-        assert resp.status_code == 200
+        for path in ("/api/agents/registry/grants", "/api/agents/registry/revoked"):
+            resp = await auth_client.get(
+                path,
+                headers={"Authorization": f"Bearer {tok}"},
+            )
+            assert resp.status_code == 200, path
 
     @pytest.mark.asyncio
     async def test_protected_route_returns_401(self, app, auth_client):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -284,6 +284,24 @@ class TestAuthMiddleware:
         assert resp.json().get("needs_onboarding") is True
 
     @pytest.mark.asyncio
+    async def test_local_token_keeps_admin_on_registry_feeds(self, app, auth_client):
+        """The admin-equivalent local token must NOT be mis-verified as a
+        registry JWT on the feed endpoints (regression: the feed JWT branch
+        must sit after the local-token branch in the middleware)."""
+        await auth_client.post(
+            "/auth/setup",
+            json={"username": "admin", "full_name": "Admin", "email": "", "password": "adminpass", "auto_login": False},
+        )
+        if app.state.agent_grants._db is None:
+            await app.state.agent_grants.init()
+        tok = app.state.auth.get_local_token()
+        resp = await auth_client.get(
+            "/api/agents/registry/grants",
+            headers={"Authorization": f"Bearer {tok}"},
+        )
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
     async def test_protected_route_returns_401(self, app, auth_client):
         """With auth configured, API routes should return 401 without session."""
         app.state.auth.set_password("secretpass")

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -109,25 +109,13 @@ class AuthMiddleware(BaseHTTPMiddleware):
             request.state.via = "exempt"
             return await call_next(request)
 
-        # Registry feed endpoints (revoked + grants) accept a registry JWT as an
-        # alternative to the admin session.  When a Bearer token is present for
-        # these paths, pass the request through to the route handler, which calls
-        # _check_feed_token() to verify the JWT and the registry_feeds_read grant.
-        # The route also falls back to request.state.is_admin for admin sessions,
-        # so normal cookie-authenticated admin access continues to work.
-        auth_header = request.headers.get("authorization", "")
-        if path in _REGISTRY_FEED_PATHS and auth_header.lower().startswith("bearer "):
-            request.state.user_id = None
-            request.state.is_admin = False
-            request.state.via = "registry_jwt_candidate"
-            return await call_next(request)
-
         # Local token (Authorization: Bearer <token>) is accepted as a
         # substitute for the session cookie. The token lives at
         # {data_dir}/.auth_local_token, readable only by the user
         # running taOS, so possession = same-user-on-the-host trust.
         # Used by scripts and the upcoming CLI; the browser SPA keeps
         # using cookies.
+        auth_header = request.headers.get("authorization", "")
         if auth_header.lower().startswith("bearer "):
             presented = auth_header[7:].strip()
             if presented and auth_mgr.validate_local_token(presented):
@@ -149,6 +137,18 @@ class AuthMiddleware(BaseHTTPMiddleware):
                     request.state.is_admin = False
                     request.state.via = "local_token"
                 return await call_next(request)
+
+        # Registry feed endpoints (revoked + grants) accept a registry JWT as an
+        # alternative to the admin session.  This branch sits AFTER the
+        # local-token check on purpose: a local token is admin-equivalent and
+        # must keep its admin semantics on these paths (taOSmd polls the feeds
+        # with it today).  Only a Bearer that is NOT the local token falls
+        # through to here and is verified as a registry JWT by the route.
+        if path in _REGISTRY_FEED_PATHS and auth_header.lower().startswith("bearer "):
+            request.state.user_id = None
+            request.state.is_admin = False
+            request.state.via = "registry_jwt_candidate"
+            return await call_next(request)
 
         # First boot: no user yet. Browsers go to the setup page; APIs
         # hard-fail so a stale cached client knows to refresh.

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -6,6 +6,14 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import RedirectResponse
 
 EXEMPT_PATHS = {"/auth/login", "/auth/setup", "/auth/status", "/auth/me", "/auth/complete", "/auth/lock", "/api/health", "/api/version", "/setup", "/setup/complete", "/redeem", "/api/desktop/browser/push/vapid-public-key", "/api/desktop/browser/proxy-config", "/sw.js", "/desktop", "/desktop/index.html", "/chat-pwa", "/api/agents/registry/pubkey"}
+
+# Registry feed endpoints accept EITHER an admin session OR a registry JWT.
+# When a Bearer token is present for these paths the request bypasses the
+# session gate; the route handler verifies the JWT and grant itself.
+_REGISTRY_FEED_PATHS = frozenset({
+    "/api/agents/registry/revoked",
+    "/api/agents/registry/grants",
+})
 # Bundle assets and the SPA shell HTML must be reachable without auth so:
 #   1. The browser can install and cache the shell for offline / PWA use.
 #   2. After a backend restart the cached shell loads immediately without
@@ -101,13 +109,25 @@ class AuthMiddleware(BaseHTTPMiddleware):
             request.state.via = "exempt"
             return await call_next(request)
 
+        # Registry feed endpoints (revoked + grants) accept a registry JWT as an
+        # alternative to the admin session.  When a Bearer token is present for
+        # these paths, pass the request through to the route handler, which calls
+        # _check_feed_token() to verify the JWT and the registry_feeds_read grant.
+        # The route also falls back to request.state.is_admin for admin sessions,
+        # so normal cookie-authenticated admin access continues to work.
+        auth_header = request.headers.get("authorization", "")
+        if path in _REGISTRY_FEED_PATHS and auth_header.lower().startswith("bearer "):
+            request.state.user_id = None
+            request.state.is_admin = False
+            request.state.via = "registry_jwt_candidate"
+            return await call_next(request)
+
         # Local token (Authorization: Bearer <token>) is accepted as a
         # substitute for the session cookie. The token lives at
         # {data_dir}/.auth_local_token, readable only by the user
         # running taOS, so possession = same-user-on-the-host trust.
         # Used by scripts and the upcoming CLI; the browser SPA keeps
         # using cookies.
-        auth_header = request.headers.get("authorization", "")
         if auth_header.lower().startswith("bearer "):
             presented = auth_header[7:].strip()
             if presented and auth_mgr.validate_local_token(presented):

--- a/tinyagentos/routes/agent_auth_requests.py
+++ b/tinyagentos/routes/agent_auth_requests.py
@@ -49,6 +49,7 @@ VALID_SCOPES = frozenset({
     "files_read",
     "files_write",
     "tools_execute",
+    "registry_feeds_read",
 })
 
 

--- a/tinyagentos/routes/agent_registry.py
+++ b/tinyagentos/routes/agent_registry.py
@@ -253,10 +253,12 @@ async def list_revoked_entries(request: Request):
     exists.  JWT revocation is handled by suspending the agent or expiring the
     grant -- the token itself carries no exp claim.
     """
-    feed_caller = await _check_feed_token(request)
-    if feed_caller is None:
-        # Fall back to session/local-token admin check.
-        if not getattr(request.state, "is_admin", False):
+    # Admin (session or local token) wins before any JWT verification, so an
+    # admin-equivalent Bearer local token is never mis-verified as a registry
+    # JWT and rejected.
+    if not getattr(request.state, "is_admin", False):
+        feed_caller = await _check_feed_token(request)
+        if feed_caller is None:
             raise HTTPException(status_code=403, detail="forbidden")
     store = _get_store(request)
     return {"revoked": await store.list_revoked()}
@@ -298,10 +300,12 @@ async def list_active_grants(request: Request, canonical_id: Optional[str] = Non
 
     Optional ``?canonical_id=`` filter narrows to a single agent.
     """
-    feed_caller = await _check_feed_token(request)
-    if feed_caller is None:
-        # Fall back to session/local-token admin check.
-        if not getattr(request.state, "is_admin", False):
+    # Admin (session or local token) wins before any JWT verification, so an
+    # admin-equivalent Bearer local token is never mis-verified as a registry
+    # JWT and rejected.
+    if not getattr(request.state, "is_admin", False):
+        feed_caller = await _check_feed_token(request)
+        if feed_caller is None:
             raise HTTPException(status_code=403, detail="forbidden")
     grants_store = _get_grants_store(request)
     if canonical_id:

--- a/tinyagentos/routes/agent_registry.py
+++ b/tinyagentos/routes/agent_registry.py
@@ -303,13 +303,23 @@ async def list_active_grants(request: Request, canonical_id: Optional[str] = Non
     # Admin (session or local token) wins before any JWT verification, so an
     # admin-equivalent Bearer local token is never mis-verified as a registry
     # JWT and rejected.
-    if not getattr(request.state, "is_admin", False):
+    is_admin = getattr(request.state, "is_admin", False)
+    if not is_admin:
         feed_caller = await _check_feed_token(request)
         if feed_caller is None:
             raise HTTPException(status_code=403, detail="forbidden")
     grants_store = _get_grants_store(request)
     if canonical_id:
         grants = await grants_store.list_grants(canonical_id)
+        if not is_admin:
+            # Feed-scoped callers see the same view as the unfiltered feed:
+            # active grants only, no expired history.
+            from datetime import datetime, timezone
+            now = datetime.now(timezone.utc).isoformat()
+            grants = [
+                g for g in grants
+                if not g.get("expires_at") or g["expires_at"] > now
+            ]
     else:
         grants = await grants_store.list_active_grants()
     return {"grants": grants}

--- a/tinyagentos/routes/agent_registry.py
+++ b/tinyagentos/routes/agent_registry.py
@@ -27,7 +27,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, field_validator
 
-from tinyagentos.agent_registry_store import mint_registry_token
+from tinyagentos.agent_registry_store import mint_registry_token, verify_registry_token
 from tinyagentos.auth_context import CurrentUser, current_user, require_owner_or_admin
 
 logger = logging.getLogger(__name__)
@@ -91,6 +91,70 @@ def _get_keypair(request: Request) -> tuple[bytes, bytes]:
     if kp is None:
         raise RuntimeError("agent_registry_keypair not on app.state")
     return kp
+
+
+_FEED_SCOPE = "registry_feeds_read"
+
+
+async def _check_feed_token(request: Request) -> Optional[str]:
+    """Return the canonical_id from a valid Bearer token that holds an active
+    ``registry_feeds_read`` grant, or raise an HTTPException.
+
+    Returns None when no Authorization header is present (caller falls through
+    to the standard admin session check).
+
+    Raises:
+      401 -- Authorization header present but token is malformed or signature invalid.
+      403 -- Token is valid but the agent lacks the scope, is not active in the
+             registry, or the grant has expired.
+
+    Note: registry JWTs themselves carry no expiry claim -- revocation is
+    achieved by suspending the agent (sets status != 'active') or by setting
+    expires_at on the grant row.  The grant expiry checked here is the only
+    time-based gate.
+    """
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header.lower().startswith("bearer "):
+        return None
+
+    raw_token = auth_header[7:].strip()
+
+    # Verify the EdDSA signature using the registry public key.
+    _private_pem, public_pem = _get_keypair(request)
+    try:
+        payload = verify_registry_token(raw_token, public_pem)
+    except ValueError:
+        raise HTTPException(status_code=401, detail="invalid or malformed registry token")
+
+    canonical_id: str = payload.get("sub", "")
+    if not canonical_id:
+        raise HTTPException(status_code=401, detail="token missing sub claim")
+
+    # Agent must be active in the registry.
+    registry = _get_store(request)
+    record = await registry.get(canonical_id)
+    if record is None or record.get("status") != "active":
+        raise HTTPException(status_code=403, detail="agent is not active in the registry")
+
+    # Must hold an active registry_feeds_read grant.
+    grants_store = _get_grants_store(request)
+    grants = await grants_store.list_grants(canonical_id)
+
+    from datetime import datetime, timezone
+    now = datetime.now(timezone.utc).isoformat()
+
+    has_scope = any(
+        g["scope"] == _FEED_SCOPE
+        and (g.get("expires_at") is None or g["expires_at"] > now)
+        for g in grants
+    )
+    if not has_scope:
+        raise HTTPException(
+            status_code=403,
+            detail=f"token does not hold an active {_FEED_SCOPE!r} grant",
+        )
+
+    return canonical_id
 
 
 async def _audit_governance(
@@ -180,17 +244,20 @@ async def get_pubkey(request: Request):
 
 
 @router.get("/api/agents/registry/revoked")
-async def list_revoked_entries(
-    request: Request,
-    user: CurrentUser = Depends(current_user),
-):
+async def list_revoked_entries(request: Request):
     """Return the global revocation feed: [{canonical_id, revoked_at}, ...].
 
-    Admin or local-token only — this is the set the A2A bus needs to check
-    whether a token has been revoked.  Members do not have access.
+    Accessible to admin sessions/local-token OR a registry JWT whose
+    canonical_id holds an active ``registry_feeds_read`` grant.  The grant is
+    issued through the normal consent-flow path; no separate minting machinery
+    exists.  JWT revocation is handled by suspending the agent or expiring the
+    grant -- the token itself carries no exp claim.
     """
-    if not user.is_admin:
-        raise HTTPException(status_code=403, detail="forbidden")
+    feed_caller = await _check_feed_token(request)
+    if feed_caller is None:
+        # Fall back to session/local-token admin check.
+        if not getattr(request.state, "is_admin", False):
+            raise HTTPException(status_code=403, detail="forbidden")
     store = _get_store(request)
     return {"revoked": await store.list_revoked()}
 
@@ -214,23 +281,28 @@ async def list_inactive_entries(
 
 
 @router.get("/api/agents/registry/grants")
-async def list_active_grants(
-    request: Request,
-    canonical_id: Optional[str] = None,
-    user: CurrentUser = Depends(current_user),
-):
+async def list_active_grants(request: Request, canonical_id: Optional[str] = None):
     """Return the active grant feed for A2A bus enforcement.
 
     Response: {"grants": [{canonical_id, scope, tier, project_id, granted_at, expires_at}, ...]}
 
-    Admin only — @taOSmd polls this on interval to keep its local cache current.
+    Accessible to admin sessions/local-token OR a registry JWT whose
+    canonical_id holds an active ``registry_feeds_read`` grant.  The grant is
+    issued through the normal consent-flow path; no separate minting machinery
+    exists.  JWT revocation is handled by suspending the agent or expiring the
+    grant -- the token itself carries no exp claim.
+
+    @taOSmd polls this on interval to keep its local cache current.
     Grants are active if expires_at IS NULL or expires_at > now (Phase 1: all
     grants are non-expiring, so the full list is always returned).
 
     Optional ``?canonical_id=`` filter narrows to a single agent.
     """
-    if not user.is_admin:
-        raise HTTPException(status_code=403, detail="forbidden")
+    feed_caller = await _check_feed_token(request)
+    if feed_caller is None:
+        # Fall back to session/local-token admin check.
+        if not getattr(request.state, "is_admin", False):
+            raise HTTPException(status_code=403, detail="forbidden")
     grants_store = _get_grants_store(request)
     if canonical_id:
         grants = await grants_store.list_grants(canonical_id)


### PR DESCRIPTION
## Summary

- Adds a new consent-flow scope `registry_feeds_read` that lets a granted external agent (e.g. taOSmd) read the registry grants and revocation feeds without holding admin credentials.
- The two feed routes (`GET /api/agents/registry/grants` and `GET /api/agents/registry/revoked`) now accept either an admin session **or** a signed registry JWT whose `canonical_id` holds an active `registry_feeds_read` grant.
- No new token-minting path. The grant is issued through the existing consent loop: taOSmd submits a `CreateAuthRequest` with `scopes=["registry_feeds_read"]`, an admin approves, and the returned JWT is used as a Bearer token on subsequent feed polls.

## How it works

1. **Middleware layer** -- when a `Bearer` header is present for either feed path, the auth middleware passes the request through to the route handler (flagged as `registry_jwt_candidate`). Normal admin session/cookie requests are unaffected.
2. **Route layer** -- `_check_feed_token()` in `agent_registry.py` verifies the EdDSA signature via `verify_registry_token`, confirms the registry record is `active`, and checks that an unexpired `registry_feeds_read` grant exists in `agent_grants`. Returns 401 on a bad signature, 403 on missing or expired scope or a suspended agent. If no Bearer header is present the route falls back to `request.state.is_admin` (admin session path, unchanged).
3. **Expiry** -- JWT tokens carry no `exp` claim. Revocation is via agent suspension (sets `status != active`) or setting `expires_at` on the grant row. The grant expiry is the only time gate.

## Use case (taOSmd e2e)

taOSmd needs to poll both the grants feed (to enforce scope gates on A2A bus traffic) and the revocation feed (to reject tokens for revoked agents) without running as a taOS admin. This change closes that gap via the same consent flow already used for `memory_read` and other scopes, so the permission model is consistent and auditable.

## Test plan

- 8 new tests in `TestFeedReadScope` in `tests/test_agent_registry.py`
  - [ ] 401/403 with no auth on both feeds (baseline unchanged)
  - [ ] 200 on both feeds with active `registry_feeds_read` grant
  - [ ] 403 without the scope
  - [ ] 403 with expired grant
  - [ ] 403 with suspended agent
  - [ ] 200 for admin session (regression guard)
- 74 total tests across `test_agent_registry.py` + `test_auth_requests.py`, all passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Registry feed endpoints (revoked and grants) now accept scoped Bearer tokens with a new registry_feeds_read scope for time-limited, agent-status–checked access.

* **Bug Fixes**
  * Admin/local-token behavior preserved: existing admin tokens continue to access feed endpoints as before.

* **Tests**
  * Added comprehensive tests for scoped feed access, expired/suspended cases, and middleware auth branching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->