### PR TITLE
feat(update): update-check ping + notification dedupe (#778)

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ Search across agents, apps, messages, and files from a single endpoint. Finds an
 - **Notifications.** Health alerts, backend up/down, worker join/leave, webhook forwarding (Slack/Discord/Telegram). Toast notifications appear top-right. The welcome notification is gated on a `localStorage` flag so it fires once per install, not on every page load.
 - **Agent Logs.** Real-time log viewer with auto-refresh
 - **Backup & Restore.** Downloadable config backup, one-click restore, scheduled auto-backup (daily/weekly)
-- **System Updates.** Pull latest from GitHub via Settings page
+- **System Updates.** Pull latest from GitHub via Settings page. taOS periodically checks for updates and reports an anonymous install count (a daily aggregate estimate, no identifiers); disable with `TAOS_NO_UPDATE_PING=1` or in Settings.
 - **Provider Management.** Add/test/remove inference providers with live connectivity checks. The Providers desktop app manages cloud LLM credentials; the model browser reflects configured providers automatically.
 
 ## App Catalog (108 Catalog Apps + 36 Desktop Apps + 47 MCP Plugins)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -262,7 +262,7 @@ Here's a quick map of the apps available from the desktop dock and launchpad.
 | **Tasks** | Schedule recurring jobs for your agents — daily summaries, memory cleanup, data imports. Built-in presets for common patterns. |
 | **Import** | Drag and drop files to embed into an agent's memory. Supported formats: `.txt`, `.md`, `.pdf`, `.html`, `.json`, `.csv`. |
 | **Files** | Real virtual filesystem with your personal workspace and shared folders that agents can read and write to. |
-| **Settings** | System info, storage usage, backup/restore, update TinyAgentOS, test backend connections, toggle dark/light theme, and per-category toggles for User Memory auto-capture. |
+| **Settings** | System info, storage usage, backup/restore, update TinyAgentOS, test backend connections, toggle dark/light theme, and per-category toggles for User Memory auto-capture. taOS periodically checks for updates and reports an anonymous install count (a daily aggregate estimate, no identifiers); disable with `TAOS_NO_UPDATE_PING=1` or in Settings. |
 
 ### OS apps
 

--- a/tests/test_auto_update_ping.py
+++ b/tests/test_auto_update_ping.py
@@ -1,0 +1,345 @@
+"""Tests for the anonymous install-count ping added in #778.
+
+Covers:
+- ping sends the right query params (v + platform)
+- network errors are swallowed silently
+- TAOS_NO_UPDATE_PING=1 skips the ping
+- update_ping_enabled=False skips the ping
+- notification dedupe: same commit notifies once, new commit notifies again
+"""
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_http_client(status=200, json_body=None, raise_exc=None):
+    """Return a mock httpx.AsyncClient-like object."""
+    client = AsyncMock()
+    if raise_exc is not None:
+        client.get = AsyncMock(side_effect=raise_exc)
+    else:
+        resp = MagicMock()
+        resp.status_code = status
+        resp.json = MagicMock(return_value=json_body or {})
+        client.get = AsyncMock(return_value=resp)
+    return client
+
+
+def _make_settings(prefs=None):
+    store = AsyncMock()
+    store.get_preference = AsyncMock(return_value=prefs or {})
+    store.save_preference = AsyncMock()
+    return store
+
+
+def _make_notif():
+    notif = AsyncMock()
+    notif.emit_event = AsyncMock()
+    return notif
+
+
+# ---------------------------------------------------------------------------
+# send_version_ping
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_ping_sends_version_and_platform(monkeypatch):
+    """Ping must include v= and platform= query params."""
+    from tinyagentos.auto_update import send_version_ping
+    import tinyagentos
+
+    monkeypatch.setenv("TAOS_UPDATE_CHECK_URL", "http://test.local/version-check")
+    monkeypatch.setattr(tinyagentos, "__version__", "1.2.3-test")
+
+    client = _make_http_client(status=200, json_body={"latest_version": "1.2.3"})
+    await send_version_ping(client)
+
+    client.get.assert_called_once()
+    _, kwargs = client.get.call_args
+    params = kwargs.get("params", {})
+    assert params.get("v") == "1.2.3-test"
+    assert "platform" in params
+    plat = params["platform"]
+    assert "-" in plat  # should be "<sys.platform>-<machine>"
+
+
+@pytest.mark.asyncio
+async def test_ping_tolerates_connection_error():
+    """A network error must not propagate -- silently dropped."""
+    import httpx
+    from tinyagentos.auto_update import send_version_ping
+
+    client = _make_http_client(raise_exc=httpx.ConnectError("no route"))
+    # Should not raise
+    await send_version_ping(client)
+
+
+@pytest.mark.asyncio
+async def test_ping_tolerates_timeout():
+    """A timeout must not propagate."""
+    import httpx
+    from tinyagentos.auto_update import send_version_ping
+
+    client = _make_http_client(raise_exc=httpx.TimeoutException("timed out"))
+    await send_version_ping(client)
+
+
+@pytest.mark.asyncio
+async def test_ping_tolerates_bad_json():
+    """A non-JSON 200 response must not propagate."""
+    from tinyagentos.auto_update import send_version_ping
+
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json = MagicMock(side_effect=ValueError("no json"))
+    client = AsyncMock()
+    client.get = AsyncMock(return_value=resp)
+
+    await send_version_ping(client)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Opt-out: env var
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_env_opt_out_skips_ping(monkeypatch):
+    """TAOS_NO_UPDATE_PING=1 must prevent the ping from being sent."""
+    from tinyagentos.auto_update import AutoUpdateService
+
+    monkeypatch.setenv("TAOS_NO_UPDATE_PING", "1")
+
+    ping_called = []
+
+    async def _fake_ping(client):
+        ping_called.append(True)
+
+    with patch("tinyagentos.auto_update.send_version_ping", side_effect=_fake_ping):
+        settings = _make_settings({"check_enabled": True, "update_ping_enabled": True})
+        notif = _make_notif()
+
+        app_state = MagicMock()
+        app_state.http_client = _make_http_client()
+
+        svc = AutoUpdateService(
+            project_dir=None,
+            notif_store=notif,
+            settings_store=settings,
+            app_state=app_state,
+        )
+
+        # Patch out the git/framework parts so _run_once only tests the ping path
+        with patch.object(svc, "_probe_remote", AsyncMock(return_value=None)):
+            with patch("tinyagentos.auto_update.poll_frameworks", AsyncMock()):
+                with patch("tinyagentos.frameworks.FRAMEWORKS", {}):
+                    await svc._run_once()
+
+    assert ping_called == [], "ping should not fire when TAOS_NO_UPDATE_PING=1"
+
+
+@pytest.mark.asyncio
+async def test_pref_opt_out_skips_ping(monkeypatch):
+    """update_ping_enabled=False in prefs must prevent the ping."""
+    from tinyagentos.auto_update import AutoUpdateService
+
+    monkeypatch.delenv("TAOS_NO_UPDATE_PING", raising=False)
+
+    ping_called = []
+
+    async def _fake_ping(client):
+        ping_called.append(True)
+
+    with patch("tinyagentos.auto_update.send_version_ping", side_effect=_fake_ping):
+        settings = _make_settings({"check_enabled": True, "update_ping_enabled": False})
+        notif = _make_notif()
+
+        app_state = MagicMock()
+        app_state.http_client = _make_http_client()
+
+        svc = AutoUpdateService(
+            project_dir=None,
+            notif_store=notif,
+            settings_store=settings,
+            app_state=app_state,
+        )
+
+        with patch.object(svc, "_probe_remote", AsyncMock(return_value=None)):
+            with patch("tinyagentos.auto_update.poll_frameworks", AsyncMock()):
+                with patch("tinyagentos.frameworks.FRAMEWORKS", {}):
+                    await svc._run_once()
+
+    assert ping_called == [], "ping should not fire when update_ping_enabled=False"
+
+
+@pytest.mark.asyncio
+async def test_ping_fires_when_both_opts_enabled(monkeypatch):
+    """Ping fires when neither opt-out is active."""
+    from tinyagentos.auto_update import AutoUpdateService
+
+    monkeypatch.delenv("TAOS_NO_UPDATE_PING", raising=False)
+
+    ping_called = []
+
+    async def _fake_ping(client):
+        ping_called.append(True)
+
+    with patch("tinyagentos.auto_update.send_version_ping", side_effect=_fake_ping):
+        settings = _make_settings({"check_enabled": True, "update_ping_enabled": True})
+        notif = _make_notif()
+
+        app_state = MagicMock()
+        app_state.http_client = _make_http_client()
+
+        svc = AutoUpdateService(
+            project_dir=None,
+            notif_store=notif,
+            settings_store=settings,
+            app_state=app_state,
+        )
+
+        with patch.object(svc, "_probe_remote", AsyncMock(return_value=None)):
+            with patch("tinyagentos.auto_update.poll_frameworks", AsyncMock()):
+                with patch("tinyagentos.frameworks.FRAMEWORKS", {}):
+                    await svc._run_once()
+
+    assert len(ping_called) == 1, "ping should fire exactly once per cycle"
+
+
+# ---------------------------------------------------------------------------
+# Notification dedupe
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_dedupe_same_commit_notifies_once(monkeypatch):
+    """The same remote commit must trigger at most one notification."""
+    from tinyagentos.auto_update import AutoUpdateService
+
+    monkeypatch.delenv("TAOS_NO_UPDATE_PING", raising=False)
+
+    REMOTE = "aabbccdd" * 5  # fake 40-char SHA
+    CURRENT = "11111111" * 5
+
+    notif_count = []
+
+    async def _fake_notify(current, new_commit):
+        notif_count.append(new_commit)
+
+    # First call: last_notified_commit is None -> should notify
+    settings = _make_settings({
+        "check_enabled": True,
+        "update_ping_enabled": False,
+        "last_notified_commit": None,
+    })
+    notif = _make_notif()
+    svc = AutoUpdateService(
+        project_dir=None,
+        notif_store=notif,
+        settings_store=settings,
+        app_state=None,
+    )
+    svc._notify_available = _fake_notify
+
+    with patch.object(svc, "_probe_remote", AsyncMock(return_value=REMOTE)):
+        with patch.object(svc, "_current_commit", AsyncMock(return_value=CURRENT)):
+            with patch("tinyagentos.auto_update.remote_is_strictly_ahead", AsyncMock(return_value=True)):
+                with patch("tinyagentos.auto_update.poll_frameworks", AsyncMock()):
+                    with patch("tinyagentos.frameworks.FRAMEWORKS", {}):
+                        await svc._run_once()
+
+    assert len(notif_count) == 1
+
+    # Second call: last_notified_commit is now REMOTE -> should NOT notify again
+    settings2 = _make_settings({
+        "check_enabled": True,
+        "update_ping_enabled": False,
+        "last_notified_commit": REMOTE,
+    })
+    svc2 = AutoUpdateService(
+        project_dir=None,
+        notif_store=_make_notif(),
+        settings_store=settings2,
+        app_state=None,
+    )
+    notif_count2 = []
+
+    async def _fake_notify2(current, new_commit):
+        notif_count2.append(new_commit)
+
+    svc2._notify_available = _fake_notify2
+
+    with patch.object(svc2, "_probe_remote", AsyncMock(return_value=REMOTE)):
+        with patch.object(svc2, "_current_commit", AsyncMock(return_value=CURRENT)):
+            with patch("tinyagentos.auto_update.remote_is_strictly_ahead", AsyncMock(return_value=True)):
+                with patch("tinyagentos.auto_update.poll_frameworks", AsyncMock()):
+                    with patch("tinyagentos.frameworks.FRAMEWORKS", {}):
+                        await svc2._run_once()
+
+    assert len(notif_count2) == 0, "should not re-notify for the same commit"
+
+
+@pytest.mark.asyncio
+async def test_dedupe_new_commit_notifies_again(monkeypatch):
+    """A new remote commit (different SHA) must fire a new notification."""
+    from tinyagentos.auto_update import AutoUpdateService
+
+    monkeypatch.delenv("TAOS_NO_UPDATE_PING", raising=False)
+
+    OLD_REMOTE = "aabbccdd" * 5
+    NEW_REMOTE = "eeff0011" * 5
+    CURRENT = "11111111" * 5
+
+    notif_count = []
+
+    settings = _make_settings({
+        "check_enabled": True,
+        "update_ping_enabled": False,
+        "last_notified_commit": OLD_REMOTE,  # already notified for OLD
+    })
+    notif = _make_notif()
+    svc = AutoUpdateService(
+        project_dir=None,
+        notif_store=notif,
+        settings_store=settings,
+        app_state=None,
+    )
+
+    async def _fake_notify(current, new_commit):
+        notif_count.append(new_commit)
+
+    svc._notify_available = _fake_notify
+
+    with patch.object(svc, "_probe_remote", AsyncMock(return_value=NEW_REMOTE)):
+        with patch.object(svc, "_current_commit", AsyncMock(return_value=CURRENT)):
+            with patch("tinyagentos.auto_update.remote_is_strictly_ahead", AsyncMock(return_value=True)):
+                with patch("tinyagentos.auto_update.poll_frameworks", AsyncMock()):
+                    with patch("tinyagentos.frameworks.FRAMEWORKS", {}):
+                        await svc._run_once()
+
+    assert len(notif_count) == 1
+    assert notif_count[0] == NEW_REMOTE
+
+
+# ---------------------------------------------------------------------------
+# _ping_enabled_by_env helper
+# ---------------------------------------------------------------------------
+
+def test_ping_enabled_by_env_true(monkeypatch):
+    from tinyagentos.auto_update import _ping_enabled_by_env
+    monkeypatch.delenv("TAOS_NO_UPDATE_PING", raising=False)
+    assert _ping_enabled_by_env() is True
+
+
+def test_ping_enabled_by_env_false_1(monkeypatch):
+    from tinyagentos.auto_update import _ping_enabled_by_env
+    monkeypatch.setenv("TAOS_NO_UPDATE_PING", "1")
+    assert _ping_enabled_by_env() is False
+
+
+def test_ping_enabled_by_env_false_true(monkeypatch):
+    from tinyagentos.auto_update import _ping_enabled_by_env
+    monkeypatch.setenv("TAOS_NO_UPDATE_PING", "true")
+    assert _ping_enabled_by_env() is False

--- a/tinyagentos/auto_update.py
+++ b/tinyagentos/auto_update.py
@@ -4,6 +4,12 @@ Polls the configured git remote once an hour and notifies the user when new
 commits land. De-dupes notifications via the "last notified commit" marker so
 the user gets one notification per new release, not one per poll cycle.
 
+Also fires a single anonymous install-count ping per cycle to
+``TAOS_UPDATE_CHECK_URL`` (default ``https://taos.my/api/v1/version-check``).
+The server counts a daily-salted sketch of the caller; no per-caller data is
+stored. Disable with ``TAOS_NO_UPDATE_PING=1`` or the ``update_ping_enabled``
+preference in Settings. All failures degrade silently to debug logging.
+
 Uses ``asyncio.create_subprocess_exec`` (list-of-args, never shell) so
 untrusted paths cannot cause command injection.
 """
@@ -11,11 +17,14 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import re
+import os
+import platform
+import sys
 from pathlib import Path
 from typing import Optional
 
 import tinyagentos.github_releases as github_releases
+import tinyagentos
 
 logger = logging.getLogger(__name__)
 
@@ -50,12 +59,54 @@ CHECK_INTERVAL = 60 * 60
 # Namespace used in /api/preferences/auto-update for user settings.
 PREF_NAMESPACE = "auto-update"
 
+# Default URL for the version-check/install-ping endpoint.
+_DEFAULT_UPDATE_CHECK_URL = "https://taos.my/api/v1/version-check"
+
 # Defaults the user gets on a fresh install.
 DEFAULT_PREFS = {
     "check_enabled": True,
+    "update_ping_enabled": True,
     "last_notified_commit": None,
     "last_reminder_at": None,
 }
+
+
+def _ping_enabled_by_env() -> bool:
+    """False when the operator sets TAOS_NO_UPDATE_PING=1 in the environment."""
+    return os.environ.get("TAOS_NO_UPDATE_PING", "").strip() not in ("1", "true", "yes")
+
+
+async def send_version_ping(http_client) -> None:
+    """Fire the anonymous version-check/install-count ping.
+
+    Sends ``GET <url>?v=<version>&platform=<sys.platform>-<machine>``.
+    The server increments a daily-salted HyperLogLog sketch; nothing is
+    stored per caller. Any error (network, DNS, timeout, bad status) is
+    logged at DEBUG and silently dropped.
+    """
+    url = os.environ.get("TAOS_UPDATE_CHECK_URL", "").strip() or _DEFAULT_UPDATE_CHECK_URL
+    version = getattr(tinyagentos, "__version__", "unknown")
+    plat = f"{sys.platform}-{platform.machine()}"
+    try:
+        resp = await http_client.get(
+            url,
+            params={"v": version, "platform": plat},
+            timeout=5.0,
+            follow_redirects=True,
+        )
+        logger.debug(
+            "version-check ping: status=%s url=%s", resp.status_code, url
+        )
+        if resp.status_code == 200:
+            try:
+                data = resp.json()
+                latest = data.get("latest_version")
+                if latest:
+                    logger.debug("latest release from taos.my: %s", latest)
+            except Exception:
+                pass
+    except Exception as exc:
+        logger.debug("version-check ping failed (ignored): %s", exc)
 
 
 async def poll_frameworks(manifests, *, http_client, arch, cache):
@@ -120,7 +171,7 @@ async def resolve_tracked_branch(settings_store, project_dir: Path) -> str:
 
 
 async def remote_is_strictly_ahead(project_dir: Path, current: str, remote: str) -> bool:
-    """True only if ``current`` is a strict ancestor of ``remote`` — i.e. the
+    """True only if ``current`` is a strict ancestor of ``remote`` -- i.e. the
     remote is genuinely newer. Prevents offering an older or divergent commit
     (e.g. master's tip when running ahead on dev) as an "update"."""
     if not current or not remote or current == remote:
@@ -137,7 +188,7 @@ class AutoUpdateService:
     Depends on:
         - ``notif_store`` for firing user notifications
         - ``settings_store`` for reading user prefs (check-enabled toggle,
-          dedupe marker)
+          dedupe marker, ping opt-out)
 
     Start with ``start()`` during app lifespan, stop with ``stop()``.
     """
@@ -169,7 +220,7 @@ class AutoUpdateService:
 
     async def _loop(self) -> None:
         # Small initial delay so we don't slam GitHub the instant the
-        # server boots — space out with the rest of startup.
+        # server boots -- space out with the rest of startup.
         try:
             await asyncio.wait_for(self._stop_event.wait(), timeout=90)
             return
@@ -192,13 +243,28 @@ class AutoUpdateService:
         if not prefs.get("check_enabled", True):
             return
 
-        # Fetch latest from origin/master
+        # Anonymous install-count ping. Two opt-out layers:
+        # 1. TAOS_NO_UPDATE_PING=1 env var (operator/system level)
+        # 2. update_ping_enabled pref (Settings UI toggle, per-user)
+        if _ping_enabled_by_env() and prefs.get("update_ping_enabled", True):
+            _app = self._app_state
+            _http = getattr(_app, "http_client", None)
+            if _http is not None:
+                await send_version_ping(_http)
+            else:
+                # No shared client available yet -- create a one-shot client.
+                try:
+                    import httpx
+                    async with httpx.AsyncClient() as tmp_client:
+                        await send_version_ping(tmp_client)
+                except Exception as exc:
+                    logger.debug("version-check ping (standalone client) failed: %s", exc)
+
+        # Fetch latest from origin/<tracked branch>
         new_commit = await self._probe_remote()
-        if new_commit is None:
-            pass
-        else:
+        if new_commit is not None:
             current = await self._current_commit()
-            # Only an update if the remote is strictly newer than us — never
+            # Only an update if the remote is strictly newer than us -- never
             # flag an older/divergent commit (e.g. master's tip while we run
             # ahead on dev) as available.
             if await remote_is_strictly_ahead(self._project_dir, current, new_commit):
@@ -270,5 +336,3 @@ class AutoUpdateService:
             await self._settings.save_preference("user", PREF_NAMESPACE, prefs)
         except Exception:
             logger.exception("failed to save auto-update prefs")
-
-


### PR DESCRIPTION
## Summary

- Adds an anonymous install-count ping to the hourly update loop: `GET https://taos.my/api/v1/version-check?v=<version>&platform=<os>-<arch>`. The server counts a daily-salted aggregate sketch of active installs; nothing is stored per caller and no identifiers leave the device.
- Two opt-out layers: `TAOS_NO_UPDATE_PING=1` env var (operator/system level) and a new `update_ping_enabled` pref in the `auto-update` namespace (surfaces as a Settings toggle). Either one independently suppresses the ping while leaving the git-based update check fully intact.
- All failures (DNS, timeout, non-200, bad JSON) degrade silently to `DEBUG` logging and never block the git check or produce user-visible errors.
- Notification dedupe via `last_notified_commit` was already in place; this PR adds regression tests confirming one notification per new remote commit and no repeat notifications for the same commit.
- Version source: `tinyagentos.__version__` from `tinyagentos/__init__.py` (`1.0.0-beta`).
- Docs: one sentence added to README's System Updates bullet and the docs/getting-started.md Settings row.

## Privacy posture

The ping is counted in aggregate only (daily-salted HyperLogLog on the server side). No IP address, no device fingerprint, and no per-caller state is retained. Users can opt out at the env level before the process starts or via the Settings UI at runtime.

## Test plan

- [x] `tests/test_auto_update_ping.py` -- 12 new tests: params sent, silent degradation on errors (ConnectError, TimeoutException, bad JSON), env opt-out, pref opt-out, both enabled fires once, dedupe same commit notifies once, new commit notifies again, `_ping_enabled_by_env` helper values
- [x] `tests/test_auto_update_branch.py` -- 5 existing tests, all green
- [x] `tests/test_auto_update_framework.py` -- 3 existing tests, all green
- [x] 20/20 pass

Closes #778