### PR TITLE
fix(agent): heal the LiteLLM warmup race and stop silent empty replies

### DIFF
--- a/tests/test_taos_agent_chat.py
+++ b/tests/test_taos_agent_chat.py
@@ -385,3 +385,212 @@ async def test_ensure_server_reuses_persisted_key(tmp_path, monkeypatch):
     assert state.taos_opencode_key == "sk-persisted-9"
     mock_proxy.create_agent_key.assert_not_called()
     mock_proxy.update_agent_key.assert_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Degraded-birth detection and self-heal
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_ensure_server_born_degraded_when_proxy_not_running(tmp_path, monkeypatch):
+    """Server built while proxy not running sets the born_degraded flag."""
+    import tinyagentos.taos_agent_runtime as rt
+
+    class _FakeServer:
+        def __init__(self, cfg):
+            self._cfg = cfg
+
+        async def ensure_running(self, **kwargs):
+            pass
+
+        async def stop(self):
+            pass
+
+        @property
+        def base_url(self):
+            return f"http://127.0.0.1:{self._cfg.port}"
+
+        def is_running(self):
+            return False
+
+    monkeypatch.setattr(rt, "OpenCodeServer", _FakeServer)
+
+    mock_proxy = MagicMock()
+    mock_proxy.is_running.return_value = False
+    mock_proxy.create_agent_key = AsyncMock(return_value=None)
+
+    state = SimpleNamespace(
+        data_dir=tmp_path,
+        llm_proxy=mock_proxy,
+        taos_opencode_password=None,
+        taos_opencode_server=None,
+        taos_opencode_model=None,
+        taos_opencode_session_id=None,
+    )
+
+    await rt.ensure_taos_opencode_server(state, "gpt-4o")
+
+    assert state.taos_opencode_born_degraded is True
+
+
+@pytest.mark.asyncio
+async def test_ensure_server_self_heals_when_proxy_becomes_ready(tmp_path, monkeypatch):
+    """Second ensure call with proxy now running rebuilds: old server stopped, new one created, flag cleared."""
+    import tinyagentos.taos_agent_runtime as rt
+
+    stop_calls: list[str] = []
+    spawned_cfgs: list = []
+
+    class _FakeServer:
+        def __init__(self, cfg):
+            spawned_cfgs.append(cfg)
+            self._cfg = cfg
+
+        async def ensure_running(self, **kwargs):
+            pass
+
+        async def stop(self):
+            stop_calls.append("stopped")
+
+        @property
+        def base_url(self):
+            return f"http://127.0.0.1:{self._cfg.port}"
+
+        def is_running(self):
+            return True
+
+    monkeypatch.setattr(rt, "OpenCodeServer", _FakeServer)
+
+    mock_proxy = MagicMock()
+    mock_proxy.is_running.return_value = False
+    mock_proxy.create_agent_key = AsyncMock(return_value="sk-key-1")
+
+    state = SimpleNamespace(
+        data_dir=tmp_path,
+        llm_proxy=mock_proxy,
+        taos_opencode_password=None,
+        taos_opencode_server=None,
+        taos_opencode_model=None,
+        taos_opencode_session_id=None,
+    )
+
+    # First call: proxy not ready, server born degraded.
+    await rt.ensure_taos_opencode_server(state, "gpt-4o")
+    assert state.taos_opencode_born_degraded is True
+    assert len(spawned_cfgs) == 1
+
+    # Proxy comes up.
+    mock_proxy.is_running.return_value = True
+
+    # Second call: proxy is ready now, so should tear down and rebuild.
+    await rt.ensure_taos_opencode_server(state, "gpt-4o")
+
+    assert len(stop_calls) == 1, "old server must have been stopped"
+    assert len(spawned_cfgs) == 2, "a new server must have been created"
+    assert state.taos_opencode_born_degraded is False
+
+
+# ---------------------------------------------------------------------------
+# Silent-stream guard
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_chat_empty_stream_yields_error_frame(client, app, monkeypatch):
+    """When the runtime stream is empty (only done), an error frame is emitted."""
+    await client.patch("/api/taos-agent/settings", json={"model": "gpt-4o"})
+    app.state.llm_proxy = _make_mock_proxy(running=True)
+    app.state.taos_opencode_password = "testpw"
+    app.state.taos_opencode_session_id = None
+
+    server = _fake_server()
+
+    async def fake_ensure_server(state, model):
+        return server
+
+    monkeypatch.setattr(
+        "tinyagentos.routes.taos_agent.ensure_taos_opencode_server",
+        fake_ensure_server,
+    )
+
+    class _EmptyAdapter:
+        def __init__(self, cfg, sink):
+            self._sink = sink
+            self.session_id = None
+
+        async def ensure_session(self):
+            self.session_id = "ses_empty"
+
+        async def prompt(self, text, trace_id=None, attachments=None):
+            # Emit only final with no deltas — simulates degraded opencode.
+            self._sink({"kind": "final", "content": ""})
+
+        async def close(self):
+            pass
+
+    monkeypatch.setattr(
+        "tinyagentos.routes.taos_agent.OpenCodeAdapter",
+        _EmptyAdapter,
+    )
+
+    resp = await client.post(
+        "/api/taos-agent/chat",
+        json={"messages": [{"role": "user", "content": "Hi"}]},
+    )
+    assert resp.status_code == 200
+    items = _parse_ndjson(resp.text)
+    error_items = [i for i in items if "error" in i]
+    assert len(error_items) >= 1
+    assert "warming" in error_items[0]["error"] or "proxy" in error_items[0]["error"]
+    assert items[-1] == {"done": True}
+
+
+@pytest.mark.asyncio
+async def test_chat_normal_stream_no_spurious_error(client, app, monkeypatch):
+    """A normal stream with deltas must NOT emit the empty-stream error frame."""
+    await client.patch("/api/taos-agent/settings", json={"model": "gpt-4o"})
+    app.state.llm_proxy = _make_mock_proxy(running=True)
+    app.state.taos_opencode_password = "testpw"
+    app.state.taos_opencode_session_id = None
+
+    server = _fake_server()
+
+    async def fake_ensure_server(state, model):
+        return server
+
+    monkeypatch.setattr(
+        "tinyagentos.routes.taos_agent.ensure_taos_opencode_server",
+        fake_ensure_server,
+    )
+
+    class _NormalAdapter:
+        def __init__(self, cfg, sink):
+            self._sink = sink
+            self.session_id = None
+
+        async def ensure_session(self):
+            self.session_id = "ses_normal"
+
+        async def prompt(self, text, trace_id=None, attachments=None):
+            self._sink({"kind": "delta", "content": "pong"})
+            self._sink({"kind": "final", "content": "pong"})
+
+        async def close(self):
+            pass
+
+    monkeypatch.setattr(
+        "tinyagentos.routes.taos_agent.OpenCodeAdapter",
+        _NormalAdapter,
+    )
+
+    resp = await client.post(
+        "/api/taos-agent/chat",
+        json={"messages": [{"role": "user", "content": "Hi"}]},
+    )
+    assert resp.status_code == 200
+    items = _parse_ndjson(resp.text)
+    error_items = [i for i in items if "error" in i]
+    assert len(error_items) == 0
+    delta_items = [i for i in items if "delta" in i]
+    assert len(delta_items) == 1
+    assert delta_items[0]["delta"] == "pong"
+    assert items[-1] == {"done": True}

--- a/tinyagentos/routes/taos_agent.py
+++ b/tinyagentos/routes/taos_agent.py
@@ -455,15 +455,19 @@ async def chat(request: Request, body: ChatRequest):
     drive_task = asyncio.create_task(_drive())
 
     async def _generate():
+        content_frame_yielded = False
         try:
             while True:
                 item = await queue.get()
                 if item is _DONE:
                     break
+                if "error" not in item:
+                    content_frame_yielded = True
                 yield json.dumps(item) + "\n"
         except Exception as exc:
             logger.exception("taos-agent: generator error")
             yield json.dumps({"error": str(exc)}) + "\n"
+            content_frame_yielded = True
         finally:
             if not drive_task.done():
                 drive_task.cancel()
@@ -475,6 +479,13 @@ async def chat(request: Request, body: ChatRequest):
                 exc = drive_task.exception()
                 if exc is not None:
                     logger.error("taos-agent: drive task raised %r", exc)
+        if not content_frame_yielded:
+            yield json.dumps({
+                "error": (
+                    "the agent backend returned no output; if taOS just restarted "
+                    "the model proxy may still be warming, try again shortly"
+                )
+            }) + "\n"
         yield json.dumps({"done": True}) + "\n"
 
     return StreamingResponse(

--- a/tinyagentos/taos_agent_runtime.py
+++ b/tinyagentos/taos_agent_runtime.py
@@ -28,6 +28,10 @@ async def ensure_taos_opencode_server(app_state, model: str) -> OpenCodeServer:
     The key is scoped to the full ``permitted_models`` set read from the
     ``taos_agent`` desktop_settings namespace (falls back to ``[model]``).
 
+    If the server was created while LiteLLM was not yet ready (born degraded),
+    it is torn down and rebuilt transparently on the next call once the proxy
+    is running so callers never need to know about the race.
+
     Returns the running :class:`~tinyagentos.opencode_runtime.OpenCodeServer`.
     """
     # Generate a stable per-process password once.
@@ -37,10 +41,29 @@ async def ensure_taos_opencode_server(app_state, model: str) -> OpenCodeServer:
     existing: OpenCodeServer | None = getattr(app_state, "taos_opencode_server", None)
     existing_model: str | None = getattr(app_state, "taos_opencode_model", None)
 
+    # Self-heal: if the cached server was born before LiteLLM was ready and
+    # LiteLLM is now running, tear down the degraded server and fall through
+    # to a fresh build so the key re-scope and model_ids are applied properly.
+    if existing is not None and getattr(app_state, "taos_opencode_born_degraded", False):
+        llm_proxy_check = getattr(app_state, "llm_proxy", None)
+        if llm_proxy_check is not None and llm_proxy_check.is_running():
+            logger.info(
+                "taos_agent_runtime: LiteLLM now ready; rebuilding taOS opencode server "
+                "that was born degraded"
+            )
+            try:
+                await existing.stop()
+            except Exception:
+                logger.debug("taos_agent_runtime: error stopping degraded server", exc_info=True)
+            app_state.taos_opencode_server = None
+            app_state.taos_opencode_session_id = None
+            app_state.taos_opencode_born_degraded = False
+            existing = None
+
     if existing is not None and existing_model != model:
         # Model changed — stop old server so it picks up the new config.
         logger.info(
-            "taos_agent_runtime: model changed (%s → %s); restarting opencode server",
+            "taos_agent_runtime: model changed (%s -> %s); restarting opencode server",
             existing_model, model,
         )
         try:
@@ -77,6 +100,9 @@ async def ensure_taos_opencode_server(app_state, model: str) -> OpenCodeServer:
         # alias collision — persisting the value avoids that and keeps it stable.
         llm_proxy = getattr(app_state, "llm_proxy", None)
         litellm_key: str | None = None
+        born_degraded = False
+        if llm_proxy is None or not llm_proxy.is_running():
+            born_degraded = True
         if stored_key:
             litellm_key = stored_key
             if llm_proxy is not None:
@@ -87,6 +113,7 @@ async def ensure_taos_opencode_server(app_state, model: str) -> OpenCodeServer:
                             "taos_agent_runtime: re-scoping the taOS agent key returned False "
                             "(key scope may be stale)"
                         )
+                        born_degraded = True
                 except Exception:
                     logger.debug("taos_agent_runtime: re-scoping stored key failed", exc_info=True)
         elif llm_proxy is not None:
@@ -118,6 +145,7 @@ async def ensure_taos_opencode_server(app_state, model: str) -> OpenCodeServer:
         server = OpenCodeServer(cfg)
         app_state.taos_opencode_server = server
         app_state.taos_opencode_model = model
+        app_state.taos_opencode_born_degraded = born_degraded
         if not hasattr(app_state, "taos_opencode_session_id"):
             app_state.taos_opencode_session_id = None
 


### PR DESCRIPTION
## Summary

- **Production symptom:** After a taOS restart, any chat to the taOS agent streams only `{"done": true}` with no content and no error, forever. The user gets a blank response with no indication of what went wrong.
- **Root cause:** Since #809 made LiteLLM warm up in the background, the opencode server can be built before LiteLLM is ready. The server config bakes in the key and model list at creation time; key re-scoping returns False (LiteLLM not yet accepting requests), and the degraded server is cached on `app_state` and never rebuilt -- so every subsequent chat hits the broken server.
- **Fix -- three parts:**
  1. **Degraded-birth flag** (`taos_agent_runtime.py`): when `ensure_taos_opencode_server` creates a new server, it checks whether the proxy is running and whether the key re-scope succeeded. If either fails, it sets `app_state.taos_opencode_born_degraded = True`.
  2. **Self-heal on next call** (`taos_agent_runtime.py`): at the top of `ensure_taos_opencode_server`, if the degraded flag is set and LiteLLM is now running, the cached server is stopped, the flag is cleared, and the function falls through to a full fresh build with a proper key re-scope.
  3. **Silent-stream error guard** (`routes/taos_agent.py`): the streaming generator now tracks whether any non-error, non-done frame was yielded. If the stream finishes with zero content frames, it emits an error frame explaining the proxy may still be warming up, before the final `{"done": true}`. This surfaces the failure to the user instead of silently swallowing it.

## Test plan

Four new tests added to `tests/test_taos_agent_chat.py`:
- `test_ensure_server_born_degraded_when_proxy_not_running`: server built while proxy not running sets the `born_degraded` flag
- `test_ensure_server_self_heals_when_proxy_becomes_ready`: second ensure call with proxy now running stops the old server, creates a new one, and clears the flag
- `test_chat_empty_stream_yields_error_frame`: chat route emits an error frame when the runtime stream is empty
- `test_chat_normal_stream_no_spurious_error`: normal stream with deltas does not trigger the empty-stream error

All 30 tests across `test_taos_agent_chat.py` and `test_taos_agent_route.py` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for chat streaming edge cases and server degraded-start and recovery scenarios.

* **Bug Fixes**
  * Chat responses now properly emit error frames when the backend returns empty content, with messaging suggesting model proxy warming.
  * Servers can now recover from degraded state when the LLM proxy becomes available after initial unavailability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->