### PR TITLE
feat(update): persistent install id for the historical install count

### DIFF
--- a/tests/test_auto_update_ping.py
+++ b/tests/test_auto_update_ping.py
@@ -68,6 +68,40 @@ async def test_ping_sends_version_and_platform(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_ping_includes_persistent_install_id(monkeypatch, tmp_path):
+    """With a data_dir, the ping carries a stable random install id that
+    persists across calls (the historical-count key)."""
+    from tinyagentos.auto_update import send_version_ping
+    import tinyagentos
+
+    monkeypatch.setenv("TAOS_UPDATE_CHECK_URL", "http://test.local/version-check")
+    monkeypatch.setattr(tinyagentos, "__version__", "1.2.3-test")
+
+    c1 = _make_http_client(status=200, json_body={})
+    await send_version_ping(c1, tmp_path)
+    id1 = c1.get.call_args[1]["params"].get("id")
+    assert id1 and len(id1) >= 16
+    assert (tmp_path / ".install_id").exists()
+
+    c2 = _make_http_client(status=200, json_body={})
+    await send_version_ping(c2, tmp_path)
+    id2 = c2.get.call_args[1]["params"].get("id")
+    assert id2 == id1  # stable across calls
+
+
+@pytest.mark.asyncio
+async def test_ping_without_data_dir_sends_no_id(monkeypatch):
+    """No data_dir means no id param (and the call still succeeds)."""
+    from tinyagentos.auto_update import send_version_ping
+    import tinyagentos
+    monkeypatch.setenv("TAOS_UPDATE_CHECK_URL", "http://test.local/version-check")
+    monkeypatch.setattr(tinyagentos, "__version__", "1.2.3-test")
+    c = _make_http_client(status=200, json_body={})
+    await send_version_ping(c, None)
+    assert "id" not in c.get.call_args[1]["params"]
+
+
+@pytest.mark.asyncio
 async def test_ping_tolerates_connection_error():
     """A network error must not propagate -- silently dropped."""
     import httpx
@@ -115,7 +149,7 @@ async def test_env_opt_out_skips_ping(monkeypatch):
 
     ping_called = []
 
-    async def _fake_ping(client):
+    async def _fake_ping(client, data_dir=None):
         ping_called.append(True)
 
     with patch("tinyagentos.auto_update.send_version_ping", side_effect=_fake_ping):
@@ -150,7 +184,7 @@ async def test_pref_opt_out_skips_ping(monkeypatch):
 
     ping_called = []
 
-    async def _fake_ping(client):
+    async def _fake_ping(client, data_dir=None):
         ping_called.append(True)
 
     with patch("tinyagentos.auto_update.send_version_ping", side_effect=_fake_ping):
@@ -184,7 +218,7 @@ async def test_ping_fires_when_both_opts_enabled(monkeypatch):
 
     ping_called = []
 
-    async def _fake_ping(client):
+    async def _fake_ping(client, data_dir=None):
         ping_called.append(True)
 
     with patch("tinyagentos.auto_update.send_version_ping", side_effect=_fake_ping):

--- a/tinyagentos/auto_update.py
+++ b/tinyagentos/auto_update.py
@@ -6,9 +6,10 @@ the user gets one notification per new release, not one per poll cycle.
 
 Also fires a single anonymous install-count ping per cycle to
 ``TAOS_UPDATE_CHECK_URL`` (default ``https://taos.my/api/v1/version-check``).
-The server counts a daily-salted sketch of the caller; no per-caller data is
-stored. Disable with ``TAOS_NO_UPDATE_PING=1`` or the ``update_ping_enabled``
-preference in Settings. All failures degrade silently to debug logging.
+The ping carries a random per-install id (no PII, stored in the data dir) so
+the server keeps an exact historical install count. Disable with
+``TAOS_NO_UPDATE_PING=1`` or the ``update_ping_enabled`` preference in
+Settings. All failures degrade silently to debug logging.
 
 Uses ``asyncio.create_subprocess_exec`` (list-of-args, never shell) so
 untrusted paths cannot cause command injection.
@@ -76,21 +77,50 @@ def _ping_enabled_by_env() -> bool:
     return os.environ.get("TAOS_NO_UPDATE_PING", "").strip() not in ("1", "true", "yes")
 
 
-async def send_version_ping(http_client) -> None:
+def _install_id(data_dir: Optional[Path]) -> str:
+    """Return this install's stable random id, creating it once if needed.
+
+    A random UUID with no PII and no hardware fingerprint, stored at
+    ``<data_dir>/.install_id``. The data dir is preserved across upgrades and
+    in-place reinstalls, so the id (and the install's place in the historical
+    count) is stable. A full wipe yields a new id, which is correct: that is a
+    genuinely new install.
+    """
+    if data_dir is None:
+        return ""
+    path = Path(data_dir) / ".install_id"
+    try:
+        if path.exists():
+            existing = path.read_text(encoding="utf-8").strip()
+            if existing:
+                return existing
+        import uuid
+        new_id = uuid.uuid4().hex
+        path.write_text(new_id, encoding="utf-8")
+        return new_id
+    except Exception:
+        return ""
+
+
+async def send_version_ping(http_client, data_dir: Optional[Path] = None) -> None:
     """Fire the anonymous version-check/install-count ping.
 
-    Sends ``GET <url>?v=<version>&platform=<sys.platform>-<machine>``.
-    The server increments a daily-salted HyperLogLog sketch; nothing is
-    stored per caller. Any error (network, DNS, timeout, bad status) is
-    logged at DEBUG and silently dropped.
+    Sends ``GET <url>?v=<version>&platform=<sys.platform>-<machine>&id=<uuid>``.
+    The id is a random per-install UUID (no PII) so the server keeps an exact
+    historical count. Any error (network, DNS, timeout, bad status) is logged
+    at DEBUG and silently dropped.
     """
     url = os.environ.get("TAOS_UPDATE_CHECK_URL", "").strip() or _DEFAULT_UPDATE_CHECK_URL
     version = getattr(tinyagentos, "__version__", "unknown")
     plat = f"{sys.platform}-{platform.machine()}"
+    params = {"v": version, "platform": plat}
+    iid = _install_id(data_dir)
+    if iid:
+        params["id"] = iid
     try:
         resp = await http_client.get(
             url,
-            params={"v": version, "platform": plat},
+            params=params,
             timeout=5.0,
             follow_redirects=True,
         )
@@ -249,14 +279,15 @@ class AutoUpdateService:
         if _ping_enabled_by_env() and prefs.get("update_ping_enabled", True):
             _app = self._app_state
             _http = getattr(_app, "http_client", None)
+            _data_dir = getattr(_app, "data_dir", None)
             if _http is not None:
-                await send_version_ping(_http)
+                await send_version_ping(_http, _data_dir)
             else:
                 # No shared client available yet -- create a one-shot client.
                 try:
                     import httpx
                     async with httpx.AsyncClient() as tmp_client:
-                        await send_version_ping(tmp_client)
+                        await send_version_ping(tmp_client, _data_dir)
                 except Exception as exc:
                     logger.debug("version-check ping (standalone client) failed: %s", exc)
 


### PR DESCRIPTION
The taos.my counter keeps one row per install id forever (exact history). The client now sends a random per-install UUID stored at data_dir/.install_id (no PII, no fingerprint), which survives upgrades and in-place reinstalls; a full wipe yields a new id, correctly counting a fresh install. Without this the forever-id server counts nothing, so this must land with (or before) the counter goes live.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Auto-update version checks now include a stable, persistent installation ID for improved telemetry tracking. The ID is automatically generated and reused across multiple version checks.

* **Tests**
  * Added comprehensive test coverage for installation ID persistence and handling in version ping requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->