### PR TITLE
feat(messages): full markdown rendering in chat

### DIFF
--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -264,6 +264,9 @@ function renderInline(text: string, keyPrefix: string) {
           blockquote: ({ node, ...props }) => (
             <blockquote className="border-l-2 border-white/20 pl-3 text-white/70" {...props} />
           ),
+          pre: ({ node, ...props }) => (
+            <pre className="my-2 overflow-x-auto max-w-full bg-black/30 border border-white/10 rounded p-2 text-[13px]" {...props} />
+          ),
           table: ({ node, ...props }) => (
             <div className="my-2 overflow-x-auto">
               <table className="min-w-full text-left text-[13px]" {...props} />

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -242,6 +242,7 @@ function renderInline(text: string, keyPrefix: string) {
     <div key={keyPrefix}>
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
+        disallowedElements={["img"]}
         components={{
           p: ({ node, ...props }) => <p className="mb-1 last:mb-0" {...props} />,
           a: ({ node, ...props }) => (
@@ -263,10 +264,23 @@ function renderInline(text: string, keyPrefix: string) {
           blockquote: ({ node, ...props }) => (
             <blockquote className="border-l-2 border-white/20 pl-3 text-white/70" {...props} />
           ),
+          table: ({ node, ...props }) => (
+            <div className="my-2 overflow-x-auto">
+              <table className="min-w-full text-left text-[13px]" {...props} />
+            </div>
+          ),
+          th: ({ node, ...props }) => (
+            <th className="border-b border-white/10 px-2 py-1 font-semibold" {...props} />
+          ),
+          td: ({ node, ...props }) => (
+            <td className="border-b border-white/5 px-2 py-1 align-top" {...props} />
+          ),
           h1: ({ node, ...props }) => <p className="font-semibold mb-1" {...props} />,
           h2: ({ node, ...props }) => <p className="font-semibold mb-1" {...props} />,
           h3: ({ node, ...props }) => <p className="font-semibold mb-1" {...props} />,
           h4: ({ node, ...props }) => <p className="font-semibold mb-1" {...props} />,
+          h5: ({ node, ...props }) => <p className="font-semibold mb-1" {...props} />,
+          h6: ({ node, ...props }) => <p className="font-semibold mb-1" {...props} />,
         }}
       >
         {text}

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -68,6 +68,8 @@ import { displayAuthor } from "./chat/format-author";
 import { useProcessStore } from "@/stores/process-store";
 import { getApp } from "@/registry/app-registry";
 import { CodeBlock } from "@/components/CodeBlock";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -236,21 +238,41 @@ function renderContent(text: string) {
 }
 
 function renderInline(text: string, keyPrefix: string) {
-  // basic markdown: bold, italic, inline code
-  const parts: (string | React.ReactElement)[] = [];
-  const regex = /(\*\*(.+?)\*\*|\*(.+?)\*|`(.+?)`)/g;
-  let last = 0;
-  let match: RegExpExecArray | null;
-  let key = 0;
-  while ((match = regex.exec(text)) !== null) {
-    if (match.index > last) parts.push(text.slice(last, match.index));
-    if (match[2]) parts.push(<strong key={`${keyPrefix}-${key++}`} className="font-semibold">{match[2]}</strong>);
-    else if (match[3]) parts.push(<em key={`${keyPrefix}-${key++}`} className="italic">{match[3]}</em>);
-    else if (match[4]) parts.push(<code key={`${keyPrefix}-${key++}`} className="bg-white/10 px-1.5 py-0.5 rounded text-[13px] font-mono">{match[4]}</code>);
-    last = match.index + match[0].length;
-  }
-  if (last < text.length) parts.push(text.slice(last));
-  return parts;
+  return [
+    <div key={keyPrefix}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          p: ({ node, ...props }) => <p className="mb-1 last:mb-0" {...props} />,
+          a: ({ node, ...props }) => (
+            <a className="text-blue-400 underline" target="_blank" rel="noopener noreferrer" {...props} />
+          ),
+          code: ({ node, className, children, ...props }) => {
+            const isBlock = typeof className === "string" && /language-/.test(className);
+            if (isBlock) {
+              return <code className={className} {...props}>{children}</code>;
+            }
+            return (
+              <code className="bg-white/10 px-1.5 py-0.5 rounded text-[13px] font-mono" {...props}>
+                {children}
+              </code>
+            );
+          },
+          ul: ({ node, ...props }) => <ul className="list-disc pl-5 mb-1" {...props} />,
+          ol: ({ node, ...props }) => <ol className="list-decimal pl-5 mb-1" {...props} />,
+          blockquote: ({ node, ...props }) => (
+            <blockquote className="border-l-2 border-white/20 pl-3 text-white/70" {...props} />
+          ),
+          h1: ({ node, ...props }) => <p className="font-semibold mb-1" {...props} />,
+          h2: ({ node, ...props }) => <p className="font-semibold mb-1" {...props} />,
+          h3: ({ node, ...props }) => <p className="font-semibold mb-1" {...props} />,
+          h4: ({ node, ...props }) => <p className="font-semibold mb-1" {...props} />,
+        }}
+      >
+        {text}
+      </ReactMarkdown>
+    </div>,
+  ];
 }
 
 const EMOJI_PICKER = ["👍", "❤️", "😂", "🎉", "🤔", "👀", "🚀", "✅"];


### PR DESCRIPTION
Replaces the body of `renderInline` in `desktop/src/apps/MessagesApp.tsx` with a `react-markdown` element using `remark-gfm`. `renderContent` is unchanged, so fenced code blocks still split out and render through the shared `CodeBlock` component.

Component mapping: `p` keeps tight chat spacing, `a` opens in a new tab with `text-blue-400 underline`, inline `code` keeps the previous `bg-white/10` styling while block `code` (with a `language-*` class, although the fence-splitter means we should rarely see it) is left untouched for the surrounding `pre` to handle, `ul`/`ol` get `list-disc`/`list-decimal pl-5`, `blockquote` uses a subtle left border, and `h1` through `h4` collapse into a bold paragraph since real heading sizes break inside chat bubbles.

Verified: `npx tsc -b` from `desktop/` is clean, `npm run build` from `desktop/` succeeds (MessagesApp bundle now includes the markdown chunk). No existing tests touch `renderContent` or MessagesApp rendering, so no vitest run was required by rule 9.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Messages now render with improved markdown formatting support, including code blocks, lists, blockquotes, and other markdown elements for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->