### PR TITLE
feat(messages): full emoji picker for reactions

### DIFF
--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -1916,8 +1916,11 @@ export function MessagesApp({
                       const vw = window.innerWidth;
                       const vh = window.innerHeight;
                       const r = showEmoji.rect;
-                      const top = Math.max(8, Math.min(r.top, vh - POPOVER_H - 8));
-                      const left = Math.max(8, Math.min(r.right - POPOVER_W, vw - POPOVER_W - 8));
+                      // Upper bounds are clamped to >=8 so a viewport smaller
+                      // than the popover (with margins) cannot produce a
+                      // negative limit and let Math.min return a value < 8.
+                      const top = Math.max(8, Math.min(r.top, Math.max(8, vh - POPOVER_H - 8)));
+                      const left = Math.max(8, Math.min(r.right - POPOVER_W, Math.max(8, vw - POPOVER_W - 8)));
                       return (
                     <div
                       data-emoji-popover="1"

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -68,6 +68,7 @@ import { displayAuthor } from "./chat/format-author";
 import { useProcessStore } from "@/stores/process-store";
 import { getApp } from "@/registry/app-registry";
 import { CodeBlock } from "@/components/CodeBlock";
+import Picker, { Theme } from "emoji-picker-react";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -1878,16 +1879,26 @@ export function MessagesApp({
 
                   {/* emoji picker */}
                   {showEmoji === msg.id && (
-                    <div className="absolute right-2 top-5 bg-zinc-800 border border-white/10 rounded-lg shadow-xl p-2 flex gap-1 z-10">
-                      {EMOJI_PICKER.map((em) => (
-                        <button
-                          key={em}
-                          onClick={() => toggleReaction(msg.id, em)}
-                          className="text-lg hover:bg-white/10 rounded p-0.5 transition-colors"
-                        >
-                          {em}
-                        </button>
-                      ))}
+                    <div className="absolute right-2 top-5 bg-zinc-800 border border-white/10 rounded-lg shadow-xl p-2 z-10 w-[300px] h-[360px] flex flex-col gap-2">
+                      <div className="flex gap-1 shrink-0">
+                        {EMOJI_PICKER.map((em) => (
+                          <button
+                            key={em}
+                            onClick={() => toggleReaction(msg.id, em)}
+                            className="text-lg hover:bg-white/10 rounded p-0.5 transition-colors"
+                          >
+                            {em}
+                          </button>
+                        ))}
+                      </div>
+                      <div className="flex-1 min-h-0 [&_.EmojiPickerReact]:h-full [&_.EmojiPickerReact]:w-full">
+                        <Picker
+                          theme={Theme.DARK}
+                          onEmojiClick={(d) => {
+                            toggleReaction(msg.id, d.emoji);
+                          }}
+                        />
+                      </div>
                     </div>
                   )}
                 </div>

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -1910,12 +1910,21 @@ export function MessagesApp({
 
                   {/* emoji picker — rendered in a portal to avoid clipping by the scrollable list */}
                   {showEmoji && showEmoji.messageId === msg.id && createPortal(
+                    (() => {
+                      const POPOVER_W = 300;
+                      const POPOVER_H = 360;
+                      const vw = window.innerWidth;
+                      const vh = window.innerHeight;
+                      const r = showEmoji.rect;
+                      const top = Math.max(8, Math.min(r.top, vh - POPOVER_H - 8));
+                      const left = Math.max(8, Math.min(r.right - POPOVER_W, vw - POPOVER_W - 8));
+                      return (
                     <div
                       data-emoji-popover="1"
                       role="dialog"
                       aria-label="Emoji reactions"
                       className="fixed z-50 bg-zinc-800 border border-white/10 rounded-lg shadow-xl p-2 w-[300px] h-[360px] flex flex-col gap-2"
-                      style={{ top: showEmoji.rect.top, left: showEmoji.rect.right - 300 }}
+                      style={{ top, left }}
                     >
                       <div className="flex gap-1 shrink-0">
                         {EMOJI_PICKER.map((em) => (
@@ -1938,7 +1947,9 @@ export function MessagesApp({
                           }}
                         />
                       </div>
-                    </div>,
+                    </div>
+                      );
+                    })(),
                     document.body,
                   )}
                 </div>

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from "react";
+import { createPortal } from "react-dom";
 import {
   MessageCircle,
   Hash,
@@ -316,7 +317,7 @@ export function MessagesApp({
   const [input, setInput] = useState("");
   const [wsStatus, setWsStatus] = useState<WsStatus>("disconnected");
   const [showCreate, setShowCreate] = useState(false);
-  const [showEmoji, setShowEmoji] = useState<string | null>(null); // message id
+  const [showEmoji, setShowEmoji] = useState<{ messageId: string; rect: DOMRect } | null>(null); // message id + anchor
   const [viewingCanvas, setViewingCanvas] = useState<{ url: string; title?: string } | null>(null);
   const [newChannel, setNewChannel] = useState({ name: "", type: "topic" as "topic" | "group", description: "" });
   const [prefillBanner, setPrefillBanner] = useState<{ promptName: string; agentName?: string } | null>(null);
@@ -573,6 +574,27 @@ export function MessagesApp({
 
     wsRef.current = ws;
   }, []);
+
+  /* ---- emoji popover: escape and outside click ---- */
+  useEffect(() => {
+    if (!showEmoji) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setShowEmoji(null);
+    }
+    function onPointer(e: MouseEvent) {
+      const t = e.target as HTMLElement | null;
+      if (!t) return;
+      if (t.closest("[data-emoji-popover='1']")) return;
+      if (t.closest(`[data-message-id="${showEmoji!.messageId}"]`)) return;
+      setShowEmoji(null);
+    }
+    document.addEventListener("keydown", onKey);
+    document.addEventListener("mousedown", onPointer);
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.removeEventListener("mousedown", onPointer);
+    };
+  }, [showEmoji]);
 
   /* ---- init ---- */
   useEffect(() => {
@@ -1834,7 +1856,16 @@ export function MessagesApp({
                     return (
                       <div className="absolute top-0 right-2 -translate-y-1/2 z-10">
                         <MessageHoverActions
-                          onReact={() => setShowEmoji(showEmoji === msg.id ? null : msg.id)}
+                          onReact={() => {
+                            if (showEmoji && showEmoji.messageId === msg.id) {
+                              setShowEmoji(null);
+                              return;
+                            }
+                            const row = document.querySelector(`[data-message-id="${msg.id}"]`) as HTMLElement | null;
+                            const rect = row?.getBoundingClientRect();
+                            if (!rect) return;
+                            setShowEmoji({ messageId: msg.id, rect });
+                          }}
                           onReplyInThread={() => handleOpenThreadFor(msg.channel_id ?? selectedChannel ?? "", msg.id)}
                           onOverflow={(e) => {
                             e.preventDefault();
@@ -1877,9 +1908,15 @@ export function MessagesApp({
                     />
                   )}
 
-                  {/* emoji picker */}
-                  {showEmoji === msg.id && (
-                    <div className="absolute right-2 top-5 bg-zinc-800 border border-white/10 rounded-lg shadow-xl p-2 z-10 w-[300px] h-[360px] flex flex-col gap-2">
+                  {/* emoji picker — rendered in a portal to avoid clipping by the scrollable list */}
+                  {showEmoji && showEmoji.messageId === msg.id && createPortal(
+                    <div
+                      data-emoji-popover="1"
+                      role="dialog"
+                      aria-label="Emoji reactions"
+                      className="fixed z-50 bg-zinc-800 border border-white/10 rounded-lg shadow-xl p-2 w-[300px] h-[360px] flex flex-col gap-2"
+                      style={{ top: showEmoji.rect.top, left: showEmoji.rect.right - 300 }}
+                    >
                       <div className="flex gap-1 shrink-0">
                         {EMOJI_PICKER.map((em) => (
                           <button
@@ -1891,15 +1928,18 @@ export function MessagesApp({
                           </button>
                         ))}
                       </div>
-                      <div className="flex-1 min-h-0 [&_.EmojiPickerReact]:h-full [&_.EmojiPickerReact]:w-full">
+                      <div className="flex-1 min-h-0">
                         <Picker
                           theme={Theme.DARK}
+                          width="100%"
+                          height="100%"
                           onEmojiClick={(d) => {
                             toggleReaction(msg.id, d.emoji);
                           }}
                         />
                       </div>
-                    </div>
+                    </div>,
+                    document.body,
                   )}
                 </div>
               );


### PR DESCRIPTION
In `desktop/src/apps/MessagesApp.tsx` the reaction popover now hosts both the original 8-emoji quick-react row and a full picker inside the same container. The container is `w-[300px] h-[360px]` flex column with the quick row pinned to the top and the picker filling the rest. The full picker is the bare `Picker` from `emoji-picker-react` (already installed), wrapped in a div that targets the library's root class `.EmojiPickerReact` with `h-full w-full` so the picker fills the column. Selection calls the same `toggleReaction(msg.id, d.emoji)` the strip uses, so toggling on and off works the same way as before.

Used the bare `Picker` import (`Theme.DARK`, `onEmojiClick`) rather than the existing `EmojiPickerField` wrapper because the wrapper is a button plus popover and this popover is already opened by the message hover actions row. The library-level `Picker` is what the existing component renders internally.

Verified: `npx tsc -b` is clean, `npm run build` from `desktop/` succeeds (an `emoji-picker-react.esm-*.js` chunk now shows up in the bundle). No tests reference this popover.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added emoji reactions to messages with an integrated emoji picker interface.

* **Style**
  * Updated emoji picker UI layout and styling for improved presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->