### PR TITLE
feat(messages): date separators in the message list

### DIFF
--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -255,6 +255,17 @@ function renderInline(text: string, keyPrefix: string) {
 
 const EMOJI_PICKER = ["👍", "❤️", "😂", "🎉", "🤔", "👀", "🚀", "✅"];
 
+function dayLabel(ts: string | number): string {
+  const d = new Date(ts);
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const that = new Date(d.getFullYear(), d.getMonth(), d.getDate());
+  const diffDays = Math.round((today.getTime() - that.getTime()) / 86400000);
+  if (diffDays === 0) return "Today";
+  if (diffDays === 1) return "Yesterday";
+  return d.toLocaleDateString(undefined, { weekday: "short", day: "numeric", month: "short" });
+}
+
 /* ------------------------------------------------------------------ */
 /*  MessagesApp                                                        */
 /* ------------------------------------------------------------------ */
@@ -1686,6 +1697,9 @@ export function MessagesApp({
               const isAgent = msg.author_type === "agent";
               const prev = i > 0 ? messages[i - 1] : undefined;
               const showAuthor = !prev || prev.author_id !== msg.author_id;
+              const prevDay = prev ? new Date(prev.created_at).toDateString() : null;
+              const currDay = new Date(msg.created_at).toDateString();
+              const showDaySeparator = prevDay !== currDay;
               const authorState = resolveAuthorDisplayState(
                 msg.author_id,
                 msg.author_type,
@@ -1700,8 +1714,15 @@ export function MessagesApp({
                     ? "Agent removed"
                     : undefined;
               return (
+                <React.Fragment key={msg.id}>
+                {showDaySeparator && (
+                  <div className="flex items-center gap-3 my-4 select-none">
+                    <div className="flex-1 h-px bg-white/10" />
+                    <span className="text-[11px] text-white/40 font-medium">{dayLabel(msg.created_at)}</span>
+                    <div className="flex-1 h-px bg-white/10" />
+                  </div>
+                )}
                 <div
-                  key={msg.id}
                   data-message-id={msg.id}
                   className={`group relative px-3 py-1 rounded-md transition-colors hover:bg-white/[0.03] ${
                     isAgent && !isDeadAgent ? "bg-blue-500/[0.04]" : ""
@@ -1891,6 +1912,7 @@ export function MessagesApp({
                     </div>
                   )}
                 </div>
+                </React.Fragment>
               );
             })}
             <div ref={messagesEndRef} />

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -1697,9 +1697,9 @@ export function MessagesApp({
               const isAgent = msg.author_type === "agent";
               const prev = i > 0 ? messages[i - 1] : undefined;
               const showAuthor = !prev || prev.author_id !== msg.author_id;
-              const prevDay = prev ? new Date(prev.created_at).toDateString() : null;
-              const currDay = new Date(msg.created_at).toDateString();
-              const showDaySeparator = prevDay !== currDay;
+              const prevDay = prev ? new Date(toMs(prev.created_at)).toDateString() : null;
+              const currDay = new Date(toMs(msg.created_at)).toDateString();
+              const showDaySeparator = prev ? prevDay !== currDay : false;
               const authorState = resolveAuthorDisplayState(
                 msg.author_id,
                 msg.author_type,

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -258,11 +258,14 @@ const EMOJI_PICKER = ["👍", "❤️", "😂", "🎉", "🤔", "👀", "🚀", 
 function dayLabel(ts: string | number): string {
   const d = new Date(toMs(ts));
   const now = new Date();
-  // Use UTC day arithmetic so a one-day gap is always 86400000ms, even
-  // across DST transitions where a local-day can be 23 or 25 hours.
-  const todayMs = Date.UTC(now.getFullYear(), now.getMonth(), now.getDate());
-  const thatMs = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
-  const diffDays = Math.round((todayMs - thatMs) / 86400000);
+  // Compare local calendar days, not UTC. Build local-midnight Dates for
+  // both, then divide by 86400000ms. A local day is 23-25 hours across
+  // DST, so the division can still produce fractional values; use
+  // Math.round so a one-calendar-day difference is reported as exactly
+  // 1 day. (A diff of 0.96 days is still a single calendar-day gap
+  // before noon, and a diff of 1.04 days is one calendar day after.)
+  const localMidnight = (x: Date) => new Date(x.getFullYear(), x.getMonth(), x.getDate());
+  const diffDays = Math.round((localMidnight(now).getTime() - localMidnight(d).getTime()) / 86400000);
   if (diffDays === 0) return "Today";
   if (diffDays === 1) return "Yesterday";
   return d.toLocaleDateString(undefined, { weekday: "short", day: "numeric", month: "short" });

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -256,11 +256,13 @@ function renderInline(text: string, keyPrefix: string) {
 const EMOJI_PICKER = ["👍", "❤️", "😂", "🎉", "🤔", "👀", "🚀", "✅"];
 
 function dayLabel(ts: string | number): string {
-  const d = new Date(ts);
+  const d = new Date(toMs(ts));
   const now = new Date();
-  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  const that = new Date(d.getFullYear(), d.getMonth(), d.getDate());
-  const diffDays = Math.round((today.getTime() - that.getTime()) / 86400000);
+  // Use UTC day arithmetic so a one-day gap is always 86400000ms, even
+  // across DST transitions where a local-day can be 23 or 25 hours.
+  const todayMs = Date.UTC(now.getFullYear(), now.getMonth(), now.getDate());
+  const thatMs = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+  const diffDays = Math.round((todayMs - thatMs) / 86400000);
   if (diffDays === 0) return "Today";
   if (diffDays === 1) return "Yesterday";
   return d.toLocaleDateString(undefined, { weekday: "short", day: "numeric", month: "short" });


### PR DESCRIPTION
In `desktop/src/apps/MessagesApp.tsx` the message render loop now inserts a centered "Today / Yesterday / weekday-day-month" divider whenever the calendar day changes between two consecutive messages. Added a module-scope `dayLabel(ts)` helper (string or number, same shape as `Message.created_at`) and a `showDaySeparator` check that compares `new Date(...).toDateString()` of the current message against the previous one. The separator is rendered before the existing message row inside a `React.Fragment` keyed by `msg.id` so React doesn't see an unkeyed child. `showAuthor` logic and the row markup are untouched.

Verified: `npx tsc -b` is clean, `npm run build` from `desktop/` succeeds. No existing tests touch this loop.