### PR TITLE
feat(messages): per-channel draft persistence

### DIFF
--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -255,6 +255,17 @@ function renderInline(text: string, keyPrefix: string) {
 
 const EMOJI_PICKER = ["👍", "❤️", "😂", "🎉", "🤔", "👀", "🚀", "✅"];
 
+const draftKey = (channelId: string) => `taos-chat-draft:${channelId}`;
+function loadDraft(channelId: string): string {
+  try { return localStorage.getItem(draftKey(channelId)) || ""; } catch { return ""; }
+}
+function saveDraft(channelId: string, text: string) {
+  try {
+    if (text) localStorage.setItem(draftKey(channelId), text);
+    else localStorage.removeItem(draftKey(channelId));
+  } catch { /* storage full or unavailable: drafts are best-effort */ }
+}
+
 /* ------------------------------------------------------------------ */
 /*  MessagesApp                                                        */
 /* ------------------------------------------------------------------ */
@@ -697,6 +708,13 @@ export function MessagesApp({
     // leave previous channel
     if (prevChannelRef.current && prevChannelRef.current !== selectedChannel && wsRef.current?.readyState === 1) {
       wsRef.current.send(JSON.stringify({ type: "leave", channel_id: prevChannelRef.current }));
+      // persist draft for the channel we are leaving
+      saveDraft(prevChannelRef.current, input);
+    }
+    // load draft for the new channel
+    if (prevChannelRef.current !== selectedChannel) {
+      setInput(loadDraft(selectedChannel));
+      if (inputRef.current) inputRef.current.style.height = "auto";
     }
     prevChannelRef.current = selectedChannel;
     // join new
@@ -707,7 +725,7 @@ export function MessagesApp({
     markRead(selectedChannel);
     setTypingHumans([]);
     setTypingAgents([]);
-  }, [selectedChannel, fetchMessages, markRead]);
+  }, [selectedChannel, fetchMessages, markRead]); // eslint-disable-line react-hooks/exhaustive-deps
 
   /* ---- deep-link scroll on ?msg=<id> — latch so it fires once per URL ---- */
   const deepLinkSeenRef = useRef<string | null>(null);
@@ -813,6 +831,7 @@ export function MessagesApp({
           return;
         }
         setInput("");
+        if (selectedChannel) saveDraft(selectedChannel, "");
         setPendingAttachments([]);
         if (inputRef.current) inputRef.current.style.height = "auto";
         autoScrollRef.current = true;
@@ -844,6 +863,7 @@ export function MessagesApp({
           if ((body as { handled?: string }).handled) {
             setSendError(null);
             setInput("");
+            if (selectedChannel) saveDraft(selectedChannel, "");
             autoScrollRef.current = true;
             if (inputRef.current) inputRef.current.style.height = "auto";
             return;
@@ -880,6 +900,7 @@ export function MessagesApp({
       }
     }
     setInput("");
+    if (selectedChannel) saveDraft(selectedChannel, "");
     autoScrollRef.current = true;
     if (inputRef.current) inputRef.current.style.height = "auto";
   };
@@ -887,6 +908,7 @@ export function MessagesApp({
   /* ---- typing indicator ---- */
   const handleInputChange = (val: string) => {
     setInput(val);
+    if (selectedChannel) saveDraft(selectedChannel, val);
     // auto-resize textarea
     if (inputRef.current) {
       inputRef.current.style.height = "auto";

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -255,6 +255,11 @@ function renderInline(text: string, keyPrefix: string) {
 
 const EMOJI_PICKER = ["👍", "❤️", "😂", "🎉", "🤔", "👀", "🚀", "✅"];
 
+// Best-effort per-channel draft storage. Drafts are user input that may
+// contain sensitive material; they are kept in localStorage (the same
+// mechanism Slack's web client uses) and not synced to the server. Stored
+// unencrypted at rest in the browser profile. Users on shared machines
+// should clear site data to remove drafts.
 const draftKey = (channelId: string) => `taos-chat-draft:${channelId}`;
 function loadDraft(channelId: string): string {
   try { return localStorage.getItem(draftKey(channelId)) || ""; } catch { return ""; }
@@ -704,12 +709,19 @@ export function MessagesApp({
 
   /* ---- channel selection ---- */
   useEffect(() => {
-    if (!selectedChannel) return;
-    // leave previous channel
-    if (prevChannelRef.current && prevChannelRef.current !== selectedChannel && wsRef.current?.readyState === 1) {
-      wsRef.current.send(JSON.stringify({ type: "leave", channel_id: prevChannelRef.current }));
-      // persist draft for the channel we are leaving
+    // Persist the draft for the channel we are leaving, regardless of socket
+    // state, so a switch while offline still saves the composer's contents.
+    if (prevChannelRef.current && prevChannelRef.current !== selectedChannel) {
       saveDraft(prevChannelRef.current, input);
+    }
+    if (!selectedChannel) {
+      // No new channel: clear refs and stop here.
+      prevChannelRef.current = null;
+      return;
+    }
+    // leave previous channel (websocket signaling only)
+    if (prevChannelRef.current && wsRef.current?.readyState === 1) {
+      wsRef.current.send(JSON.stringify({ type: "leave", channel_id: prevChannelRef.current }));
     }
     // load draft for the new channel
     if (prevChannelRef.current !== selectedChannel) {


### PR DESCRIPTION
In `desktop/src/apps/MessagesApp.tsx` the composer now keeps a draft per channel in `localStorage` under `taos-chat-draft:<channelId>`. Added three module-scope helpers: `draftKey`, `loadDraft` (try/catch returning empty string on error), and `saveDraft` (try/catch, removes the key when text is empty).

On channel change (the existing `useEffect` that joins and marks read) the previous channel id is taken from `prevChannelRef` and its draft is saved before the new draft is loaded into `input`. The effect deps are left unchanged (eslint disable) so the effect only runs on channel switch, not on every keystroke.

On every successful send (all three `setInput("")` paths inside `sendMessage`) the stored draft is cleared for the current channel. The input change handler now also calls `saveDraft` on each keystroke. Skipped the optional sidebar pencil indicator since channel row markup varies across the four sidebar layouts in this file and the job marks it optional.

Verified: `npx tsc -b` is clean, `npm run build` from `desktop/` succeeds.