### PR TITLE
feat(messages): unread divider

### DIFF
--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -1728,7 +1728,11 @@ export function MessagesApp({
               return (
                 <React.Fragment key={msg.id}>
                 {newDividerAtId === msg.id && (
-                  <div className="flex items-center gap-3 my-3 select-none">
+                  <div
+                    role="separator"
+                    aria-label="New messages"
+                    className="flex items-center gap-3 my-3 select-none"
+                  >
                     <div className="flex-1 h-px bg-red-400/40" />
                     <span className="text-[11px] text-red-400 font-semibold">New</span>
                     <div className="flex-1 h-px bg-red-400/40" />

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -312,6 +312,7 @@ export function MessagesApp({
   const [selectedChannel, setSelectedChannel] = useState<string | null>(null);
   const [messages, setMessages] = useState<Message[]>([]);
   const [unread, setUnread] = useState<Record<string, number>>({});
+  const unreadRef = useRef<Record<string, number>>({});
   const pendingNewCountRef = useRef(0);
   const [newDividerAtId, setNewDividerAtId] = useState<string | null>(null);
   const [input, setInput] = useState("");
@@ -716,13 +717,14 @@ export function MessagesApp({
     if (wsRef.current?.readyState === 1) {
       wsRef.current.send(JSON.stringify({ type: "join", channel_id: selectedChannel }));
     }
-    // capture unread count before markRead clears it
-    pendingNewCountRef.current = unread[selectedChannel] ?? 0;
+    // capture unread count before markRead clears it (read via ref so this
+    // effect does not re-run when markRead mutates the unread map).
+    pendingNewCountRef.current = unreadRef.current[selectedChannel] ?? 0;
     fetchMessages(selectedChannel);
     markRead(selectedChannel);
     setTypingHumans([]);
     setTypingAgents([]);
-  }, [selectedChannel, fetchMessages, markRead, unread]);
+  }, [selectedChannel, fetchMessages, markRead]);
 
   /* ---- deep-link scroll on ?msg=<id> — latch so it fires once per URL ---- */
   const deepLinkSeenRef = useRef<string | null>(null);
@@ -828,6 +830,7 @@ export function MessagesApp({
           return;
         }
         setInput("");
+        setNewDividerAtId(null);
         setPendingAttachments([]);
         if (inputRef.current) inputRef.current.style.height = "auto";
         autoScrollRef.current = true;
@@ -859,6 +862,7 @@ export function MessagesApp({
           if ((body as { handled?: string }).handled) {
             setSendError(null);
             setInput("");
+            setNewDividerAtId(null);
             autoScrollRef.current = true;
             if (inputRef.current) inputRef.current.style.height = "auto";
             return;

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -600,6 +600,12 @@ export function MessagesApp({
     };
   }, [fetchChannels, fetchArchivedChannels, fetchAgentLists, connectWs]);
 
+  /* ---- keep unreadRef in sync with the unread state without re-running
+   * the channel-selection effect (which would re-capture the pending count). ---- */
+  useEffect(() => {
+    unreadRef.current = unread;
+  }, [unread]);
+
   /* ---- default-select A2A channel on first project visit ----
    * Also runs when the project switches: if the previously selected channel
    * is not in the new project's channel list, it's stale — fall back to

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -312,6 +312,8 @@ export function MessagesApp({
   const [selectedChannel, setSelectedChannel] = useState<string | null>(null);
   const [messages, setMessages] = useState<Message[]>([]);
   const [unread, setUnread] = useState<Record<string, number>>({});
+  const pendingNewCountRef = useRef(0);
+  const [newDividerAtId, setNewDividerAtId] = useState<string | null>(null);
   const [input, setInput] = useState("");
   const [wsStatus, setWsStatus] = useState<WsStatus>("disconnected");
   const [showCreate, setShowCreate] = useState(false);
@@ -420,8 +422,18 @@ export function MessagesApp({
       const res = await fetch(`/api/chat/channels/${channelId}/messages?limit=50`);
       if (res.ok) {
         const data = await res.json();
-        setMessages(data.messages ?? []);
+        const list: Message[] = data.messages ?? [];
+        setMessages(list);
         autoScrollRef.current = true;
+        const pending = pendingNewCountRef.current;
+        pendingNewCountRef.current = 0;
+        if (pending > 0 && list.length > 0) {
+          const idx = list.length - pending;
+          const atIdx = idx < 0 ? 0 : idx;
+          setNewDividerAtId(list[atIdx]?.id ?? null);
+        } else {
+          setNewDividerAtId(null);
+        }
       }
     } catch {
       /* offline */
@@ -699,15 +711,18 @@ export function MessagesApp({
       wsRef.current.send(JSON.stringify({ type: "leave", channel_id: prevChannelRef.current }));
     }
     prevChannelRef.current = selectedChannel;
+    setNewDividerAtId(null);
     // join new
     if (wsRef.current?.readyState === 1) {
       wsRef.current.send(JSON.stringify({ type: "join", channel_id: selectedChannel }));
     }
+    // capture unread count before markRead clears it
+    pendingNewCountRef.current = unread[selectedChannel] ?? 0;
     fetchMessages(selectedChannel);
     markRead(selectedChannel);
     setTypingHumans([]);
     setTypingAgents([]);
-  }, [selectedChannel, fetchMessages, markRead]);
+  }, [selectedChannel, fetchMessages, markRead, unread]);
 
   /* ---- deep-link scroll on ?msg=<id> — latch so it fires once per URL ---- */
   const deepLinkSeenRef = useRef<string | null>(null);
@@ -880,6 +895,7 @@ export function MessagesApp({
       }
     }
     setInput("");
+    setNewDividerAtId(null);
     autoScrollRef.current = true;
     if (inputRef.current) inputRef.current.style.height = "auto";
   };
@@ -1700,8 +1716,15 @@ export function MessagesApp({
                     ? "Agent removed"
                     : undefined;
               return (
+                <React.Fragment key={msg.id}>
+                {newDividerAtId === msg.id && (
+                  <div className="flex items-center gap-3 my-3 select-none">
+                    <div className="flex-1 h-px bg-red-400/40" />
+                    <span className="text-[11px] text-red-400 font-semibold">New</span>
+                    <div className="flex-1 h-px bg-red-400/40" />
+                  </div>
+                )}
                 <div
-                  key={msg.id}
                   data-message-id={msg.id}
                   className={`group relative px-3 py-1 rounded-md transition-colors hover:bg-white/[0.03] ${
                     isAgent && !isDeadAgent ? "bg-blue-500/[0.04]" : ""
@@ -1891,6 +1914,7 @@ export function MessagesApp({
                     </div>
                   )}
                 </div>
+                </React.Fragment>
               );
             })}
             <div ref={messagesEndRef} />


### PR DESCRIPTION
In `desktop/src/apps/MessagesApp.tsx` a red "New" divider now appears at the first unread message when a channel is opened with unread count greater than 0. The unread value is captured into a `pendingNewCountRef` immediately before `markRead` runs (so it survives the clear), and `fetchMessages` consumes that ref after the message list loads: it computes `list.length - pending`, clamps to 0, and stores the message id at that index in `newDividerAtId`. The render loop wraps each message in a `React.Fragment` and renders the divider markup (red-tinted lines, "New" label) right before the message whose id matches. `newDividerAtId` is cleared on every channel switch and after a successful send, so an outgoing message always dismisses the marker; incoming messages do not clear it.

Edge case: when the unread count exceeds the 50-message window the divider is placed before the first loaded message (clamped to index 0). When unread is 0, no divider is set.

Verified: `npx tsc -b` clean, `npm run build` from `desktop/` succeeds. Manual test plan: with two sessions, receive 2 messages in a background channel, open it, the divider sits above the 2 new messages. Switching away and back (now read) shows no divider.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a "New" divider in message lists to separate unread messages from previously read ones.
  * Divider correctly positions at the first new message after switching channels and after loading latest messages.
  * Divider is cleared after sending messages (including attachments and commands) and stays synchronized with unread counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->