### PR TITLE
feat(messages): integrate emoji, date separators, unread divider, search (jobs 2,3,6,7)

### DIFF
--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -18,6 +18,7 @@ import {
   Trash2,
   RotateCcw,
   MessagesSquare,
+  Search,
 } from "lucide-react";
 import {
   Button,
@@ -74,6 +75,7 @@ import { CodeBlock } from "@/components/CodeBlock";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import Picker, { Theme } from "emoji-picker-react";
+import { SearchPanel } from "./chat/SearchPanel";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -413,6 +415,7 @@ export function MessagesApp({
   const [pinnedPopoverOpen, setPinnedPopoverOpen] = useState(false);
   const [pinnedMessages, setPinnedMessages] = useState<PinnedMessage[]>([]);
   const [showAllThreads, setShowAllThreads] = useState(false);
+  const [showSearch, setShowSearch] = useState(false);
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
   const [currentUserDisplayName, setCurrentUserDisplayName] = useState<string | null>(null);
   const [projects, setProjects] = useState<Project[]>([]);
@@ -904,11 +907,13 @@ export function MessagesApp({
   const handleOpenSettings = () => {
     closeThread();
     setShowAllThreads(false);
+    setShowSearch(false);
     setShowSettings(true);
   };
   const handleOpenThreadFor = (channelId: string, parentId: string) => {
     setShowSettings(false);
     setShowAllThreads(false);
+    setShowSearch(false);
     openThreadFor(channelId, parentId);
   };
 
@@ -1779,6 +1784,8 @@ export function MessagesApp({
                       setShowAllThreads(false);
                     } else {
                       closeThread();
+                      setShowSettings(false);
+                      setShowSearch(false);
                       setShowAllThreads(true);
                     }
                   }}
@@ -1789,6 +1796,26 @@ export function MessagesApp({
                   title="All threads"
                 >
                   <MessagesSquare size={14} aria-hidden="true" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (showSearch) {
+                      setShowSearch(false);
+                    } else {
+                      closeThread();
+                      setShowSettings(false);
+                      setShowAllThreads(false);
+                      setShowSearch(true);
+                    }
+                  }}
+                  className="ml-2 p-1 rounded hover:bg-white/10 text-white/60 hover:text-white"
+                  aria-label={showSearch ? "Hide search" : "Search messages"}
+                  aria-expanded={showSearch}
+                  aria-controls="search-panel"
+                  title="Search"
+                >
+                  <Search size={14} aria-hidden="true" />
                 </button>
               </div>
               {currentChannel?.description && (
@@ -2410,7 +2437,7 @@ export function MessagesApp({
       )}
 
       {/* ---- All Threads Panel ---- */}
-      {showAllThreads && selectedChannel && !openThread && !showSettings && (
+      {showAllThreads && selectedChannel && !openThread && !showSettings && !showSearch && (
         <AllThreadsList
           channelId={selectedChannel}
           onClose={() => setShowAllThreads(false)}
@@ -2418,6 +2445,33 @@ export function MessagesApp({
             setShowAllThreads(false);
             openThreadFor(selectedChannel, parentId);
           }}
+          authorCtx={{ currentUserId, currentUserDisplayName }}
+        />
+      )}
+
+      {/* ---- Search Panel ---- */}
+      {showSearch && !openThread && !showSettings && !showAllThreads && (
+        <SearchPanel
+          onJump={(channelId, messageId) => {
+            setShowSearch(false);
+            if (channelId !== selectedChannel) {
+              // Switching channel triggers fetchMessages; the scroll happens
+              // after the new messages render. If the target is not in the
+              // first 50 loaded messages, the scroll silently no-ops (the
+              // backend search hits are not paginated here).
+              setSelectedChannel(channelId);
+            }
+            setTimeout(() => {
+              const el = document.querySelector(`[data-message-id="${messageId}"]`) as HTMLElement | null;
+              if (el) {
+                el.scrollIntoView({ behavior: "smooth", block: "center" });
+                el.classList.add("data-highlight");
+                setTimeout(() => el.classList.remove("data-highlight"), 2000);
+              }
+            }, channelId !== selectedChannel ? 200 : 0);
+          }}
+          onClose={() => setShowSearch(false)}
+          channels={allChannels.map((c) => ({ id: c.id, name: c.name }))}
           authorCtx={{ currentUserId, currentUserDisplayName }}
         />
       )}

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -371,6 +371,9 @@ export function MessagesApp({
   const [selectedChannel, setSelectedChannel] = useState<string | null>(null);
   const [messages, setMessages] = useState<Message[]>([]);
   const [unread, setUnread] = useState<Record<string, number>>({});
+  const unreadRef = useRef<Record<string, number>>({});
+  const pendingNewCountRef = useRef(0);
+  const [newDividerAtId, setNewDividerAtId] = useState<string | null>(null);
   const [input, setInput] = useState("");
   const [wsStatus, setWsStatus] = useState<WsStatus>("disconnected");
   const [showCreate, setShowCreate] = useState(false);
@@ -480,8 +483,18 @@ export function MessagesApp({
       const res = await fetch(`/api/chat/channels/${channelId}/messages?limit=50`);
       if (res.ok) {
         const data = await res.json();
-        setMessages(data.messages ?? []);
+        const list: Message[] = data.messages ?? [];
+        setMessages(list);
         autoScrollRef.current = true;
+        const pending = pendingNewCountRef.current;
+        pendingNewCountRef.current = 0;
+        if (pending > 0 && list.length > 0) {
+          const idx = list.length - pending;
+          const atIdx = idx < 0 ? 0 : idx;
+          setNewDividerAtId(list[atIdx]?.id ?? null);
+        } else {
+          setNewDividerAtId(null);
+        }
       }
     } catch {
       /* offline */
@@ -668,6 +681,12 @@ export function MessagesApp({
     };
   }, [fetchChannels, fetchArchivedChannels, fetchAgentLists, connectWs]);
 
+  /* ---- keep unreadRef in sync with the unread state without re-running
+   * the channel-selection effect (which would re-capture the pending count). ---- */
+  useEffect(() => {
+    unreadRef.current = unread;
+  }, [unread]);
+
   /* ---- default-select A2A channel on first project visit ----
    * Also runs when the project switches: if the previously selected channel
    * is not in the new project's channel list, it's stale — fall back to
@@ -794,10 +813,14 @@ export function MessagesApp({
       if (inputRef.current) inputRef.current.style.height = "auto";
     }
     prevChannelRef.current = selectedChannel;
+    setNewDividerAtId(null);
     // join new
     if (wsRef.current?.readyState === 1) {
       wsRef.current.send(JSON.stringify({ type: "join", channel_id: selectedChannel }));
     }
+    // capture unread count before markRead clears it (read via ref so this
+    // effect does not re-run when markRead mutates the unread map).
+    pendingNewCountRef.current = unreadRef.current[selectedChannel] ?? 0;
     fetchMessages(selectedChannel);
     markRead(selectedChannel);
     setTypingHumans([]);
@@ -911,6 +934,7 @@ export function MessagesApp({
         }
         setInput("");
         if (selectedChannel) saveDraft(selectedChannel, "");
+        setNewDividerAtId(null);
         setPendingAttachments([]);
         if (inputRef.current) inputRef.current.style.height = "auto";
         autoScrollRef.current = true;
@@ -943,6 +967,7 @@ export function MessagesApp({
             setSendError(null);
             setInput("");
             if (selectedChannel) saveDraft(selectedChannel, "");
+            setNewDividerAtId(null);
             autoScrollRef.current = true;
             if (inputRef.current) inputRef.current.style.height = "auto";
             return;
@@ -980,6 +1005,7 @@ export function MessagesApp({
     }
     setInput("");
     if (selectedChannel) saveDraft(selectedChannel, "");
+    setNewDividerAtId(null);
     autoScrollRef.current = true;
     if (inputRef.current) inputRef.current.style.height = "auto";
   };
@@ -1819,8 +1845,19 @@ export function MessagesApp({
                     ? "Agent removed"
                     : undefined;
               return (
+                <React.Fragment key={msg.id}>
+                {newDividerAtId === msg.id && (
+                  <div
+                    role="separator"
+                    aria-label="New messages"
+                    className="flex items-center gap-3 my-3 select-none"
+                  >
+                    <div className="flex-1 h-px bg-red-400/40" />
+                    <span className="text-[11px] text-red-400 font-semibold">New</span>
+                    <div className="flex-1 h-px bg-red-400/40" />
+                  </div>
+                )}
                 <div
-                  key={msg.id}
                   data-message-id={msg.id}
                   className={`group relative px-3 py-1 rounded-md transition-colors hover:bg-white/[0.03] ${
                     isAgent && !isDeadAgent ? "bg-blue-500/[0.04]" : ""
@@ -2052,6 +2089,7 @@ export function MessagesApp({
                     document.body,
                   )}
                 </div>
+                </React.Fragment>
               );
             })}
             <div ref={messagesEndRef} />

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from "react";
+import { createPortal } from "react-dom";
 import {
   MessageCircle,
   Hash,
@@ -72,6 +73,7 @@ import { getApp } from "@/registry/app-registry";
 import { CodeBlock } from "@/components/CodeBlock";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import Picker, { Theme } from "emoji-picker-react";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -372,7 +374,7 @@ export function MessagesApp({
   const [input, setInput] = useState("");
   const [wsStatus, setWsStatus] = useState<WsStatus>("disconnected");
   const [showCreate, setShowCreate] = useState(false);
-  const [showEmoji, setShowEmoji] = useState<string | null>(null); // message id
+  const [showEmoji, setShowEmoji] = useState<{ messageId: string; rect: DOMRect } | null>(null); // message id + anchor
   const [viewingCanvas, setViewingCanvas] = useState<{ url: string; title?: string } | null>(null);
   const [newChannel, setNewChannel] = useState({ name: "", type: "topic" as "topic" | "group", description: "" });
   const [prefillBanner, setPrefillBanner] = useState<{ promptName: string; agentName?: string } | null>(null);
@@ -630,6 +632,27 @@ export function MessagesApp({
 
     wsRef.current = ws;
   }, []);
+
+  /* ---- emoji popover: escape and outside click ---- */
+  useEffect(() => {
+    if (!showEmoji) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setShowEmoji(null);
+    }
+    function onPointer(e: MouseEvent) {
+      const t = e.target as HTMLElement | null;
+      if (!t) return;
+      if (t.closest("[data-emoji-popover='1']")) return;
+      if (t.closest(`[data-message-id="${showEmoji!.messageId}"]`)) return;
+      setShowEmoji(null);
+    }
+    document.addEventListener("keydown", onKey);
+    document.addEventListener("mousedown", onPointer);
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.removeEventListener("mousedown", onPointer);
+    };
+  }, [showEmoji]);
 
   /* ---- init ---- */
   useEffect(() => {
@@ -1929,7 +1952,16 @@ export function MessagesApp({
                     return (
                       <div className="absolute top-0 right-2 -translate-y-1/2 z-10">
                         <MessageHoverActions
-                          onReact={() => setShowEmoji(showEmoji === msg.id ? null : msg.id)}
+                          onReact={() => {
+                            if (showEmoji && showEmoji.messageId === msg.id) {
+                              setShowEmoji(null);
+                              return;
+                            }
+                            const row = document.querySelector(`[data-message-id="${msg.id}"]`) as HTMLElement | null;
+                            const rect = row?.getBoundingClientRect();
+                            if (!rect) return;
+                            setShowEmoji({ messageId: msg.id, rect });
+                          }}
                           onReplyInThread={() => handleOpenThreadFor(msg.channel_id ?? selectedChannel ?? "", msg.id)}
                           onOverflow={(e) => {
                             e.preventDefault();
@@ -1972,19 +2004,52 @@ export function MessagesApp({
                     />
                   )}
 
-                  {/* emoji picker */}
-                  {showEmoji === msg.id && (
-                    <div className="absolute right-2 top-5 bg-zinc-800 border border-white/10 rounded-lg shadow-xl p-2 flex gap-1 z-10">
-                      {EMOJI_PICKER.map((em) => (
-                        <button
-                          key={em}
-                          onClick={() => toggleReaction(msg.id, em)}
-                          className="text-lg hover:bg-white/10 rounded p-0.5 transition-colors"
-                        >
-                          {em}
-                        </button>
-                      ))}
+                  {/* emoji picker — rendered in a portal to avoid clipping by the scrollable list */}
+                  {showEmoji && showEmoji.messageId === msg.id && createPortal(
+                    (() => {
+                      const POPOVER_W = 300;
+                      const POPOVER_H = 360;
+                      const vw = window.innerWidth;
+                      const vh = window.innerHeight;
+                      const r = showEmoji.rect;
+                      // Upper bounds are clamped to >=8 so a viewport smaller
+                      // than the popover (with margins) cannot produce a
+                      // negative limit and let Math.min return a value < 8.
+                      const top = Math.max(8, Math.min(r.top, Math.max(8, vh - POPOVER_H - 8)));
+                      const left = Math.max(8, Math.min(r.right - POPOVER_W, Math.max(8, vw - POPOVER_W - 8)));
+                      return (
+                    <div
+                      data-emoji-popover="1"
+                      role="dialog"
+                      aria-label="Emoji reactions"
+                      className="fixed z-50 bg-zinc-800 border border-white/10 rounded-lg shadow-xl p-2 w-[300px] h-[360px] flex flex-col gap-2"
+                      style={{ top, left }}
+                    >
+                      <div className="flex gap-1 shrink-0">
+                        {EMOJI_PICKER.map((em) => (
+                          <button
+                            key={em}
+                            onClick={() => toggleReaction(msg.id, em)}
+                            className="text-lg hover:bg-white/10 rounded p-0.5 transition-colors"
+                          >
+                            {em}
+                          </button>
+                        ))}
+                      </div>
+                      <div className="flex-1 min-h-0">
+                        <Picker
+                          theme={Theme.DARK}
+                          width="100%"
+                          height="100%"
+                          onEmojiClick={(d) => {
+                            toggleReaction(msg.id, d.emoji);
+                          }}
+                        />
+                      </div>
                     </div>
+                      );
+                    })(),
+                    document.body,
                   )}
                 </div>
               );

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -2456,19 +2456,25 @@ export function MessagesApp({
             setShowSearch(false);
             if (channelId !== selectedChannel) {
               // Switching channel triggers fetchMessages; the scroll happens
-              // after the new messages render. If the target is not in the
-              // first 50 loaded messages, the scroll silently no-ops (the
-              // backend search hits are not paginated here).
+              // once the new messages render (the rAF retry below waits for it).
               setSelectedChannel(channelId);
             }
-            setTimeout(() => {
+            // Poll across a few frames so a slow channel switch/render still
+            // lands instead of relying on a single fixed delay. If the target
+            // is not in the first 50 loaded messages it never appears, so the
+            // jump silently no-ops (search hits are not paginated here).
+            let attempts = 0;
+            const tryScroll = () => {
               const el = document.querySelector(`[data-message-id="${messageId}"]`) as HTMLElement | null;
               if (el) {
                 el.scrollIntoView({ behavior: "smooth", block: "center" });
                 el.classList.add("data-highlight");
                 setTimeout(() => el.classList.remove("data-highlight"), 2000);
+                return;
               }
-            }, channelId !== selectedChannel ? 200 : 0);
+              if (attempts++ < 40) requestAnimationFrame(tryScroll);
+            };
+            requestAnimationFrame(tryScroll);
           }}
           onClose={() => setShowSearch(false)}
           channels={allChannels.map((c) => ({ id: c.id, name: c.name }))}

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -314,6 +314,22 @@ function saveDraft(channelId: string, text: string) {
   } catch { /* storage full or unavailable: drafts are best-effort */ }
 }
 
+function dayLabel(ts: string | number): string {
+  const d = new Date(toMs(ts));
+  const now = new Date();
+  // Compare local calendar days, not UTC. Build local-midnight Dates for
+  // both, then divide by 86400000ms. A local day is 23-25 hours across
+  // DST, so the division can still produce fractional values; use
+  // Math.round so a one-calendar-day difference is reported as exactly
+  // 1 day. (A diff of 0.96 days is still a single calendar-day gap
+  // before noon, and a diff of 1.04 days is one calendar day after.)
+  const localMidnight = (x: Date) => new Date(x.getFullYear(), x.getMonth(), x.getDate());
+  const diffDays = Math.round((localMidnight(now).getTime() - localMidnight(d).getTime()) / 86400000);
+  if (diffDays === 0) return "Today";
+  if (diffDays === 1) return "Yesterday";
+  return d.toLocaleDateString(undefined, { weekday: "short", day: "numeric", month: "short" });
+}
+
 /* ------------------------------------------------------------------ */
 /*  MessagesApp                                                        */
 /* ------------------------------------------------------------------ */
@@ -1831,6 +1847,9 @@ export function MessagesApp({
               const isAgent = msg.author_type === "agent";
               const prev = i > 0 ? messages[i - 1] : undefined;
               const showAuthor = !prev || prev.author_id !== msg.author_id;
+              const prevDay = prev ? new Date(toMs(prev.created_at)).toDateString() : null;
+              const currDay = new Date(toMs(msg.created_at)).toDateString();
+              const showDaySeparator = !prev || prevDay !== currDay;
               const authorState = resolveAuthorDisplayState(
                 msg.author_id,
                 msg.author_type,
@@ -1846,6 +1865,13 @@ export function MessagesApp({
                     : undefined;
               return (
                 <React.Fragment key={msg.id}>
+                {showDaySeparator && (
+                  <div className="flex items-center gap-3 my-4 select-none">
+                    <div className="flex-1 h-px bg-white/10" />
+                    <span className="text-[11px] text-white/40 font-medium">{dayLabel(msg.created_at)}</span>
+                    <div className="flex-1 h-px bg-white/10" />
+                  </div>
+                )}
                 {newDividerAtId === msg.id && (
                   <div
                     role="separator"

--- a/desktop/src/apps/chat/SearchPanel.tsx
+++ b/desktop/src/apps/chat/SearchPanel.tsx
@@ -1,0 +1,178 @@
+import { useEffect, useRef, useState } from "react";
+import { displayAuthor, type AuthorContext } from "./format-author";
+
+type SearchHit = {
+  id: string;
+  channel_id: string;
+  author_id: string;
+  author_type?: "user" | "agent" | "system";
+  content: string;
+  created_at: number | string;
+};
+
+function relativeTime(ts: number | string): string {
+  const ms = typeof ts === "number" ? (ts < 1e12 ? ts * 1000 : ts) : new Date(ts).getTime();
+  const diff = Date.now() - ms;
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return "now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(ms).toLocaleDateString();
+}
+
+function snippet(content: string, max = 140): string {
+  if (content.length <= max) return content;
+  return content.slice(0, max - 1) + "…";
+}
+
+export function SearchPanel({
+  onJump,
+  onClose,
+  channels = [],
+  authorCtx = { currentUserId: null, currentUserDisplayName: null },
+}: {
+  onJump: (channelId: string, messageId: string) => void;
+  onClose: () => void;
+  channels?: { id: string; name: string }[];
+  authorCtx?: AuthorContext;
+}) {
+  const [query, setQuery] = useState("");
+  const [hits, setHits] = useState<SearchHit[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const acRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  useEffect(() => {
+    if (query.trim().length < 2) {
+      setHits([]);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+    const handle = setTimeout(() => {
+      acRef.current?.abort();
+      const ac = new AbortController();
+      acRef.current = ac;
+      setLoading(true);
+      setError(null);
+      fetch(`/api/chat/search?q=${encodeURIComponent(query)}`, {
+        credentials: "include",
+        signal: ac.signal,
+      })
+        .then((r) => {
+          if (!r.ok) throw new Error(`HTTP ${r.status}`);
+          return r.json();
+        })
+        .then((data: { results?: SearchHit[] }) => setHits(data.results ?? []))
+        .catch((e) => {
+          if ((e as Error).name === "AbortError") return;
+          setError(e instanceof Error ? e.message : "failed");
+        })
+        .finally(() => {
+          if (!ac.signal.aborted) setLoading(false);
+        });
+    }, 300);
+    return () => clearTimeout(handle);
+  }, [query]);
+
+  const grouped = new Map<string, SearchHit[]>();
+  for (const h of hits) {
+    const arr = grouped.get(h.channel_id) ?? [];
+    arr.push(h);
+    grouped.set(h.channel_id, arr);
+  }
+  const channelName = (id: string) => channels.find((c) => c.id === id)?.name ?? id;
+
+  return (
+    <aside
+      id="search-panel"
+      role="complementary"
+      aria-label="Search messages"
+      className="fixed top-0 right-0 h-full w-[360px] bg-shell-surface border-l border-white/10 shadow-xl flex flex-col z-40"
+    >
+      <header className="flex items-center justify-between px-4 py-3 border-b border-white/10 gap-2">
+        <h2 className="text-sm font-semibold">Search</h2>
+        <button
+          onClick={onClose}
+          aria-label="Close"
+          className="text-lg leading-none opacity-60 hover:opacity-100"
+        >
+          ×
+        </button>
+      </header>
+      <div className="px-3 py-2 border-b border-white/10">
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search messages…"
+          aria-label="Search messages"
+          className="w-full bg-shell-bg-deep border border-white/10 rounded px-2 py-1.5 text-sm outline-none focus:border-white/30"
+        />
+      </div>
+      <div className="flex-1 overflow-y-auto px-2 py-2 text-sm">
+        {query.trim().length < 2 && (
+          <div className="px-2 py-4 text-xs text-shell-text-tertiary">Type to search.</div>
+        )}
+        {error && (
+          <div
+            role="alert"
+            className="text-xs text-red-300 bg-red-500/10 border border-red-500/30 rounded px-2 py-2 mx-2"
+          >
+            {error}
+          </div>
+        )}
+        {query.trim().length >= 2 && !loading && !error && hits.length === 0 && (
+          <div className="px-2 py-4 text-xs text-shell-text-tertiary">No results.</div>
+        )}
+        {loading && query.trim().length >= 2 && (
+          <div className="px-2 py-4 text-xs text-shell-text-tertiary">Searching…</div>
+        )}
+        {[...grouped.entries()].map(([cid, list]) => (
+          <section key={cid} className="mb-2">
+            <h3 className="px-2 py-1 text-[11px] uppercase tracking-wide text-white/40">
+              {channelName(cid)}
+            </h3>
+            <ul>
+              {list.map((h) => (
+                <li key={h.id}>
+                  <button
+                    type="button"
+                    className="w-full text-left px-3 py-2 rounded hover:bg-white/5 flex flex-col gap-0.5"
+                    onClick={() => {
+                      onJump(h.channel_id, h.id);
+                    }}
+                  >
+                    <span className="text-[11px] text-shell-text-tertiary">
+                      @{displayAuthor(h, authorCtx)} · {relativeTime(h.created_at)}
+                    </span>
+                    <span className="text-xs text-shell-text-secondary line-clamp-3">
+                      {snippet(h.content)}
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ))}
+      </div>
+    </aside>
+  );
+}

--- a/desktop/src/apps/chat/SearchPanel.tsx
+++ b/desktop/src/apps/chat/SearchPanel.tsx
@@ -59,19 +59,24 @@ export function SearchPanel({
   }, [onClose]);
 
   useEffect(() => {
-    if (query.trim().length < 2) {
+    const q = query.trim();
+    if (q.length < 2) {
+      // Cancel any in-flight request so a late response can't repopulate
+      // results after the user has cleared the query.
+      acRef.current?.abort();
+      acRef.current = null;
       setHits([]);
       setLoading(false);
       setError(null);
       return;
     }
+    const ac = new AbortController();
     const handle = setTimeout(() => {
       acRef.current?.abort();
-      const ac = new AbortController();
       acRef.current = ac;
       setLoading(true);
       setError(null);
-      fetch(`/api/chat/search?q=${encodeURIComponent(query)}`, {
+      fetch(`/api/chat/search?q=${encodeURIComponent(q)}`, {
         credentials: "include",
         signal: ac.signal,
       })
@@ -88,7 +93,10 @@ export function SearchPanel({
           if (!ac.signal.aborted) setLoading(false);
         });
     }, 300);
-    return () => clearTimeout(handle);
+    return () => {
+      clearTimeout(handle);
+      ac.abort();
+    };
   }, [query]);
 
   const grouped = new Map<string, SearchHit[]>();


### PR DESCRIPTION
Integrates the four Messages-polish jobs that conflicted with each other on a single squash-merge into dev. Jobs 1, 4, 5 (markdown #826, drafts #829, threads #830) already merged cleanly; these four all edit MessagesApp.tsx in overlapping regions, so they were squashed onto current dev one at a time with conflicts resolved by hand, plus the two fixes review flagged.

Squashed commits (each keeps its original PR number):
- #827 full emoji picker for reactions
- #831 unread divider
- #828 date separators, with review fix: separator now renders above the first message (`showDaySeparator = !prev || prevDay !== currDay`)
- #832 chat search UI, with review fix: completed the one-right-panel mutex (opening search closes settings/threads and vice versa, in the header buttons, the panel render guards, and handleOpenSettings/handleOpenThreadFor)

Conflict resolutions: kept both imports/state for all features; in the three send paths kept both the draft-clear and the divider-clear; day separator and "New" divider render as separate blocks; threads and search render as two separate header buttons and two separate panels, mutually exclusive.

Verified locally: `tsc -b` clean, `vite build` succeeds, all 61 existing chat vitest tests pass.

Supersedes PRs #827, #828, #831, #832 (closing those; content lands here).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added message search panel with grouped results, jump-to-message and temporary highlight.
  * Introduced day separators in message threads for clearer chronology.
  * Enhanced emoji reaction picker positioning and close behavior (Esc and outside-click).

* **Bug Fixes**
  * Refined unread/new-message divider logic and unread-count synchronization for more accurate indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->