### PR TITLE
feat(messages): empty states

### DIFF
--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -418,6 +418,9 @@ export function MessagesApp({
   const [showAllThreads, setShowAllThreads] = useState(false);
   const [showSearch, setShowSearch] = useState(false);
   const [showSwitcher, setShowSwitcher] = useState(false);
+  // Which channel's message fetch has completed, so the "empty channel"
+  // placeholder only shows after a real fetch (never mid-load or mid-switch).
+  const [fetchedChannel, setFetchedChannel] = useState<string | null>(null);
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
   const [currentUserDisplayName, setCurrentUserDisplayName] = useState<string | null>(null);
   const [projects, setProjects] = useState<Project[]>([]);
@@ -506,6 +509,7 @@ export function MessagesApp({
         const data = await res.json();
         const list: Message[] = data.messages ?? [];
         setMessages(list);
+        setFetchedChannel(channelId);
         autoScrollRef.current = true;
         const pending = pendingNewCountRef.current;
         pendingNewCountRef.current = 0;
@@ -1721,11 +1725,14 @@ export function MessagesApp({
   const messageAreaUI = (
     <div className="flex-1 flex flex-col min-w-0 h-full">
       {!selectedChannel ? (
-        /* empty state */
+        /* empty state: nothing selected yet */
         <div className="flex-1 flex items-center justify-center text-white/20">
-          <div className="text-center">
+          <div className="text-center px-6">
             <MessageCircle size={48} className="mx-auto mb-3 opacity-30" />
-            <p className="text-sm">Select a channel to start chatting</p>
+            <p className="text-sm mb-3">Pick a channel or start a DM</p>
+            <Button variant="outline" size="sm" onClick={() => setShowCreate(true)}>
+              New channel
+            </Button>
           </div>
         </div>
       ) : (
@@ -1880,9 +1887,18 @@ export function MessagesApp({
               shellFileDropTarget.dropHandlers.onDrop(e);
             }}
           >
-            {messages.length === 0 && (
-              <div className="flex items-center justify-center h-full text-white/20 text-sm">
-                No messages yet. Say something!
+            {messages.length === 0 && fetchedChannel === selectedChannel && (
+              <div className="flex flex-col items-center justify-center h-full text-white/25 text-center px-6">
+                <MessageCircle size={40} className="mb-3 opacity-30" />
+                <p className="text-sm">
+                  No messages yet. Say hello to{" "}
+                  {currentChannel?.type === "dm"
+                    ? `@${(currentChannel.members ?? []).find((m) => m !== "user") ?? "them"}`
+                    : currentChannel?.name
+                      ? `#${currentChannel.name}`
+                      : "this channel"}
+                  .
+                </p>
               </div>
             )}
             {messages.map((msg, i) => {

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -209,17 +209,14 @@ function toMs(ts: number | string): number {
   return new Date(ts).getTime();
 }
 
-function relativeTime(ts: number | string): string {
+function relativeTime(ts: number | string, nowMs: number = Date.now()): string {
   const ms = toMs(ts);
-  const diff = Date.now() - ms;
-  const mins = Math.floor(diff / 60000);
+  const mins = Math.floor((nowMs - ms) / 60000);
   if (mins < 1) return "now";
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  const days = Math.floor(hrs / 24);
-  if (days < 7) return `${days}d ago`;
-  return new Date(ms).toLocaleDateString();
+  if (mins < 60) return `${mins}m`;
+  // Older than an hour: show the clock time. The day context comes from the
+  // date separators rendered between message groups.
+  return new Date(ms).toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" });
 }
 
 function renderContent(text: string) {
@@ -431,6 +428,9 @@ export function MessagesApp({
   const [atBottom, setAtBottom] = useState(true);
   const [newCount, setNewCount] = useState(0);
   const prevMsgCountRef = useRef(0);
+  // One 60s tick for the whole list so relative timestamps ("3m") stay fresh
+  // without a reload. Only sub-hour labels depend on it; cheap re-render.
+  const [nowMs, setNowMs] = useState(() => Date.now());
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
   const [currentUserDisplayName, setCurrentUserDisplayName] = useState<string | null>(null);
   const [projects, setProjects] = useState<Project[]>([]);
@@ -917,6 +917,12 @@ export function MessagesApp({
     setNewCount(0);
     prevMsgCountRef.current = 0;
   }, [selectedChannel]);
+
+  /* ---- 60s tick to keep relative timestamps fresh ---- */
+  useEffect(() => {
+    const id = setInterval(() => setNowMs(Date.now()), 60000);
+    return () => clearInterval(id);
+  }, []);
 
   const handleScroll = () => {
     const el = messageListRef.current;
@@ -2071,7 +2077,10 @@ export function MessagesApp({
                           {authorState === "archived" ? "inactive" : "removed"}
                         </span>
                       )}
-                      <span className={`text-[11px] ${isDeadAgent ? "text-white/15" : "text-white/25"}`}>{relativeTime(msg.created_at)}</span>
+                      <span
+                        className={`text-[11px] ${isDeadAgent ? "text-white/15" : "text-white/25"}`}
+                        title={new Date(toMs(msg.created_at)).toLocaleString()}
+                      >{relativeTime(msg.created_at, nowMs)}</span>
                       {msg.edited_at && <span className="text-[10px] text-white/20">(edited)</span>}
                     </div>
                   )}

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -168,6 +168,8 @@ interface Message {
   author_id: string;
   author_type: "user" | "agent";
   content: string;
+  /** Parent message id when this message is a thread reply. */
+  thread_id?: string;
   content_type?: "text" | "canvas" | string;
   metadata?: {
     canvas_id?: string;
@@ -439,6 +441,15 @@ export function MessagesApp({
   const [currentUserDisplayName, setCurrentUserDisplayName] = useState<string | null>(null);
   const [projects, setProjects] = useState<Project[]>([]);
   const { openThread, openThreadFor, closeThread } = useThreadPanel();
+  // Live thread replies: messages whose thread_id matches the open thread,
+  // captured from the main WS so the panel updates without a reopen. The ref
+  // lets the (long-lived) WS closure read the current open thread id.
+  const [threadLiveReplies, setThreadLiveReplies] = useState<Message[]>([]);
+  const openThreadIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    openThreadIdRef.current = openThread?.parentId ?? null;
+    setThreadLiveReplies([]); // reset when the open thread changes or closes
+  }, [openThread?.parentId]);
 
   const wsRef = useRef<WebSocket | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -593,6 +604,13 @@ export function MessagesApp({
               if (prev.some((m) => m.id === data.id)) return prev;
               return [...prev, data as Message];
             });
+            // Live thread updates: if this is a reply in the open thread, feed
+            // it to the panel (de-duped by id).
+            if (data.thread_id && data.thread_id === openThreadIdRef.current) {
+              setThreadLiveReplies((prev) =>
+                prev.some((m) => m.id === data.id) ? prev : [...prev, data as Message],
+              );
+            }
             // bump unread if not the selected channel
             if (data.channel_id !== prevChannelRef.current) {
               setUnread((u) => ({ ...u, [data.channel_id]: (u[data.channel_id] ?? 0) + 1 }));
@@ -2607,6 +2625,7 @@ export function MessagesApp({
           parentId={openThread.parentId}
           onClose={closeThread}
           isFullscreen={isMobile}
+          liveReplies={threadLiveReplies}
           authorCtx={{ currentUserId, currentUserDisplayName }}
           onSend={async (content, attachments) => {
             const r = await fetch("/api/chat/messages", {

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -219,7 +219,7 @@ function relativeTime(ts: number | string, nowMs: number = Date.now()): string {
   return new Date(ms).toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" });
 }
 
-function renderContent(text: string) {
+export function renderContent(text: string) {
   // Split on fenced code blocks first, then apply inline markdown to non-code segments.
   const result: (string | React.ReactElement)[] = [];
   const fenceRegex = /```(?:[^\n]*)?\n([\s\S]*?)```/g;
@@ -242,7 +242,7 @@ function renderContent(text: string) {
   return result;
 }
 
-function renderInline(text: string, keyPrefix: string) {
+export function renderInline(text: string, keyPrefix: string) {
   return [
     <div key={keyPrefix}>
       <ReactMarkdown
@@ -315,7 +315,7 @@ function saveDraft(channelId: string, text: string) {
   } catch { /* storage full or unavailable: drafts are best-effort */ }
 }
 
-function dayLabel(ts: string | number): string {
+export function dayLabel(ts: string | number): string {
   const d = new Date(toMs(ts));
   const now = new Date();
   // Compare local calendar days, not UTC. Build local-midnight Dates for

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -1867,6 +1867,9 @@ export function MessagesApp({
                           el.scrollIntoView({ behavior: "smooth", block: "center" });
                           el.classList.add("data-highlight");
                           setTimeout(() => el.classList.remove("data-highlight"), 2000);
+                        } else {
+                          // Only ~50 messages load; a pin older than that is not in the DOM.
+                          setSendError("Message is older than the loaded history");
                         }
                       }}
                       onClose={() => setPinnedPopoverOpen(false)}

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -58,6 +58,7 @@ import { PinBadge } from "./chat/PinBadge";
 import { PinnedMessagesPopover, type PinnedMessage } from "./chat/PinnedMessagesPopover";
 import { AllThreadsList } from "./chat/AllThreadsList";
 import { ChannelSwitcher } from "./chat/ChannelSwitcher";
+import { useChatNotifications } from "./chat/useChatNotifications";
 import { PinRequestAffordance } from "./chat/PinRequestAffordance";
 import {
   pinMessage, unpinMessage, listPins,
@@ -451,6 +452,14 @@ export function MessagesApp({
     setThreadLiveReplies([]); // reset when the open thread changes or closes
   }, [openThread?.parentId]);
 
+  // Browser notifications for messages in background channels. Refs so the
+  // long-lived WS closure reads the current user id + channel list.
+  const { notify } = useChatNotifications();
+  const currentUserIdRef = useRef<string | null>(null);
+  const channelsRef = useRef<Channel[]>([]);
+  useEffect(() => { currentUserIdRef.current = currentUserId; }, [currentUserId]);
+  useEffect(() => { channelsRef.current = channels; }, [channels]);
+
   const wsRef = useRef<WebSocket | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const messageListRef = useRef<HTMLDivElement>(null);
@@ -611,9 +620,14 @@ export function MessagesApp({
                 prev.some((m) => m.id === data.id) ? prev : [...prev, data as Message],
               );
             }
-            // bump unread if not the selected channel
+            // bump unread + browser-notify if not the selected channel and not
+            // the user's own message.
             if (data.channel_id !== prevChannelRef.current) {
               setUnread((u) => ({ ...u, [data.channel_id]: (u[data.channel_id] ?? 0) + 1 }));
+              if (data.author_id && data.author_id !== currentUserIdRef.current) {
+                const chName = channelsRef.current.find((c) => c.id === data.channel_id)?.name ?? "a channel";
+                notify(`${data.author_id} in #${chName}`, data.content ?? "", () => setSelectedChannel(data.channel_id));
+              }
             }
             break;
 

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -431,6 +431,10 @@ export function MessagesApp({
   // One 60s tick for the whole list so relative timestamps ("3m") stay fresh
   // without a reload. Only sub-hour labels depend on it; cheap re-render.
   const [nowMs, setNowMs] = useState(() => Date.now());
+  // @mention autocomplete: the partial after "@" at the cursor + the @ index,
+  // or null when not in mention mode. mentionSel is the highlighted candidate.
+  const [mention, setMention] = useState<{ partial: string; atIndex: number } | null>(null);
+  const [mentionSel, setMentionSel] = useState(0);
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
   const [currentUserDisplayName, setCurrentUserDisplayName] = useState<string | null>(null);
   const [projects, setProjects] = useState<Project[]>([]);
@@ -1105,6 +1109,12 @@ export function MessagesApp({
   const handleInputChange = (val: string) => {
     setInput(val);
     if (selectedChannel) saveDraft(selectedChannel, val);
+    // @mention detection: is the cursor inside an @token (no whitespace, the
+    // @ at the start or after whitespace)? If so, enter mention mode.
+    const pos = inputRef.current?.selectionStart ?? val.length;
+    const m = val.slice(0, pos).match(/(?:^|\s)@([^\s@]*)$/);
+    const part = m ? (m[1] ?? "") : "";
+    setMention(m ? { partial: part, atIndex: pos - part.length - 1 } : null);
     // auto-resize textarea
     if (inputRef.current) {
       inputRef.current.style.height = "auto";
@@ -1124,6 +1134,8 @@ export function MessagesApp({
 
   /* ---- key handler ---- */
   const handleKeyDown = (e: React.KeyboardEvent) => {
+    // The mention popover (when open) owns Enter/Tab via a capture listener
+    // that stops propagation, so this send handler never sees those keys.
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       sendMessage();
@@ -1331,6 +1343,49 @@ export function MessagesApp({
   const allChannels = [...channels, ...archivedChannels];
   const currentChannel = allChannels.find((c) => c.id === selectedChannel);
   const isCurrentArchived = currentChannel?.settings?.archived === true;
+
+  /* ---- @mention autocomplete: candidates = channel members + "all" ---- */
+  const mentionCandidates: string[] = (() => {
+    if (!mention) return [];
+    const q = mention.partial.toLowerCase();
+    const pool = [...(currentChannel?.members ?? []).filter((m) => m !== "user"), "all"];
+    const pref = pool.filter((m) => m.toLowerCase().startsWith(q));
+    const sub = pool.filter((m) => !m.toLowerCase().startsWith(q) && m.toLowerCase().includes(q));
+    return [...pref, ...sub].slice(0, 6);
+  })();
+
+  const insertMention = (slug: string | undefined) => {
+    if (!mention || !slug) return;
+    const el = inputRef.current;
+    const pos = el?.selectionStart ?? input.length;
+    const next = input.slice(0, mention.atIndex) + "@" + slug + " " + input.slice(pos);
+    setInput(next);
+    setMention(null);
+    requestAnimationFrame(() => {
+      if (el) {
+        const caret = mention.atIndex + slug.length + 2; // past "@slug "
+        el.focus();
+        el.setSelectionRange(caret, caret);
+      }
+    });
+  };
+
+  useEffect(() => { setMentionSel(0); }, [mention?.partial]);
+
+  // Capture Arrow/Enter/Tab/Escape while the mention popover is open. Capture
+  // phase + stopPropagation so the composer's send handler never sees them.
+  useEffect(() => {
+    if (!mention || mentionCandidates.length === 0) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") { e.preventDefault(); e.stopPropagation(); setMention(null); return; }
+      if (e.key === "ArrowDown") { e.preventDefault(); e.stopPropagation(); setMentionSel((s) => Math.min(mentionCandidates.length - 1, s + 1)); return; }
+      if (e.key === "ArrowUp") { e.preventDefault(); e.stopPropagation(); setMentionSel((s) => Math.max(0, s - 1)); return; }
+      if (e.key === "Enter" || e.key === "Tab") { e.preventDefault(); e.stopPropagation(); insertMention(mentionCandidates[mentionSel]); }
+    };
+    document.addEventListener("keydown", onKey, true);
+    return () => document.removeEventListener("keydown", onKey, true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mention, mentionCandidates.join(","), mentionSel]);
 
   /* ---- project-grouped channels for sidebar (standalone mode) ---- */
   const projectGroups = (() => {
@@ -2354,6 +2409,27 @@ export function MessagesApp({
                   onClose={() => { /* leave input as-is; user can Esc or delete */ }}
                 />
               )}
+              {mention && mentionCandidates.length > 0 && !showSlash && (
+                <div
+                  role="listbox"
+                  aria-label="Mention a member"
+                  className="absolute bottom-full left-0 mb-2 w-full max-w-md bg-shell-surface border border-white/10 rounded-lg shadow-xl max-h-60 overflow-y-auto text-sm"
+                >
+                  {mentionCandidates.map((slug, i) => (
+                    <button
+                      key={slug}
+                      role="option"
+                      aria-selected={i === mentionSel}
+                      onMouseEnter={() => setMentionSel(i)}
+                      onMouseDown={(e) => { e.preventDefault(); insertMention(slug); }}
+                      className={`w-full text-left px-3 py-1.5 flex items-center gap-2 ${i === mentionSel ? "bg-white/10" : "hover:bg-white/5"}`}
+                    >
+                      <AtSign size={13} className="text-white/40" aria-hidden="true" />
+                      <span className="font-mono text-[13px]">@{slug}</span>
+                    </button>
+                  ))}
+                </div>
+              )}
               <div className={`flex items-end gap-2 rounded-xl border px-2 py-1.5 ${isCurrentArchived ? "bg-white/[0.02] border-white/[0.04] opacity-50" : "bg-white/[0.06] border-white/[0.08]"}`}>
                 <Button
                   variant="ghost"
@@ -2370,6 +2446,7 @@ export function MessagesApp({
                   value={input}
                   onChange={(e) => !isCurrentArchived && handleInputChange(e.target.value)}
                   onKeyDown={(e) => !isCurrentArchived && handleKeyDown(e)}
+                  onBlur={() => setMention(null)}
                   onPaste={(e) => {
                     if (!e.clipboardData) return;
                     const files = Array.from(e.clipboardData.files).filter((f) => f.type.startsWith("image/"));

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -13,6 +13,7 @@ import {
   Wifi,
   WifiOff,
   ChevronRight,
+  ChevronDown,
   PanelRight,
   Archive,
   Trash2,
@@ -421,6 +422,11 @@ export function MessagesApp({
   // Which channel's message fetch has completed, so the "empty channel"
   // placeholder only shows after a real fetch (never mid-load or mid-switch).
   const [fetchedChannel, setFetchedChannel] = useState<string | null>(null);
+  // Scroll-to-bottom affordance: whether the list is near the bottom, and how
+  // many messages have arrived while scrolled away (shown as a badge).
+  const [atBottom, setAtBottom] = useState(true);
+  const [newCount, setNewCount] = useState(0);
+  const prevMsgCountRef = useRef(0);
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
   const [currentUserDisplayName, setCurrentUserDisplayName] = useState<string | null>(null);
   const [projects, setProjects] = useState<Project[]>([]);
@@ -890,18 +896,39 @@ export function MessagesApp({
     return () => { alive = false; };
   }, [selectedChannel]);
 
-  /* ---- auto-scroll ---- */
+  /* ---- auto-scroll + new-message counter while scrolled away ---- */
   useEffect(() => {
+    const delta = messages.length - prevMsgCountRef.current;
+    prevMsgCountRef.current = messages.length;
     if (autoScrollRef.current) {
       messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+    } else if (delta > 0) {
+      setNewCount((c) => c + delta);
     }
   }, [messages]);
+
+  /* ---- reset scroll affordance on channel switch ---- */
+  useEffect(() => {
+    setAtBottom(true);
+    setNewCount(0);
+    prevMsgCountRef.current = 0;
+  }, [selectedChannel]);
 
   const handleScroll = () => {
     const el = messageListRef.current;
     if (!el) return;
-    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 60;
-    autoScrollRef.current = atBottom;
+    const nowAtBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 60;
+    autoScrollRef.current = nowAtBottom;
+    // Only flip state (avoids re-render storms on every scroll tick).
+    setAtBottom((prev) => (prev === nowAtBottom ? prev : nowAtBottom));
+    if (nowAtBottom) setNewCount(0);
+  };
+
+  const scrollToLatest = () => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+    autoScrollRef.current = true;
+    setAtBottom(true);
+    setNewCount(0);
   };
 
   /* ---- typing emitter + slash menu derived state ---- */
@@ -1723,7 +1750,18 @@ export function MessagesApp({
   /* ---------------------------------------------------------------- */
 
   const messageAreaUI = (
-    <div className="flex-1 flex flex-col min-w-0 h-full">
+    <div className="relative flex-1 flex flex-col min-w-0 h-full">
+      {selectedChannel && !atBottom && (
+        <button
+          type="button"
+          onClick={scrollToLatest}
+          aria-label="Jump to latest"
+          className="absolute right-4 bottom-24 z-20 flex items-center gap-1.5 px-3 h-9 rounded-full bg-zinc-800 border border-white/15 text-white/80 hover:text-white shadow-lg hover:bg-zinc-700 transition-colors"
+        >
+          <ChevronDown size={16} aria-hidden="true" />
+          {newCount > 0 && <span className="text-[11px] font-semibold">{newCount} new</span>}
+        </button>
+      )}
       {!selectedChannel ? (
         /* empty state: nothing selected yet */
         <div className="flex-1 flex items-center justify-center text-white/20">

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -1161,6 +1161,15 @@ export function MessagesApp({
   };
 
   /* ---- file upload ---- */
+  // Re-upload a File-based attachment (used by the retry affordance). Keeps the
+  // success/failure state updates identical to a first attempt.
+  const uploadFileAttachment = (id: string, file: File) => {
+    setPendingAttachments((p) => p.map((x) => (x.id === id ? { ...x, uploading: true, error: undefined } : x)));
+    uploadDiskFile(file, selectedChannel ?? undefined)
+      .then((rec) => setPendingAttachments((p) => p.map((x) => (x.id === id ? { ...x, record: rec, uploading: false, error: undefined } : x))))
+      .catch((err) => setPendingAttachments((p) => p.map((x) => (x.id === id ? { ...x, uploading: false, error: (err as Error).message } : x))));
+  };
+
   const handleFileUpload = async () => {
     const selections = await openFilePicker({
       sources: ["disk", "workspace", "agent-workspace"],
@@ -1170,7 +1179,7 @@ export function MessagesApp({
       const id = Math.random().toString(36).slice(2);
       const filename = sel.source === "disk" ? sel.file.name : sel.path.split("/").pop() || "";
       const size = sel.source === "disk" ? sel.file.size : 0;
-      setPendingAttachments((p) => [...p, { id, filename, size, uploading: true }]);
+      setPendingAttachments((p) => [...p, { id, filename, size, uploading: true, file: sel.source === "disk" ? sel.file : undefined }]);
       try {
         const rec = sel.source === "disk"
           ? await uploadDiskFile(sel.file, selectedChannel ?? undefined)
@@ -2033,7 +2042,7 @@ export function MessagesApp({
                 e.preventDefault();
                 for (const f of Array.from(e.dataTransfer.files)) {
                   const id = Math.random().toString(36).slice(2);
-                  setPendingAttachments((p) => [...p, { id, filename: f.name, size: f.size, uploading: true }]);
+                  setPendingAttachments((p) => [...p, { id, filename: f.name, size: f.size, uploading: true, file: f }]);
                   uploadDiskFile(f, selectedChannel ?? undefined)
                     .then((rec) => setPendingAttachments((p) => p.map((x) => x.id === id ? { ...x, record: rec, uploading: false } : x)))
                     .catch((err) => setPendingAttachments((p) => p.map((x) => x.id === id ? { ...x, uploading: false, error: (err as Error).message } : x)));
@@ -2385,7 +2394,16 @@ export function MessagesApp({
             items={pendingAttachments}
             onRemove={(id) => setPendingAttachments((p) => p.filter((x) => x.id !== id))}
             onRetry={(id) => {
-              setPendingAttachments((p) => p.map((x) => x.id === id ? { ...x, uploading: false, error: "retry not yet supported — remove and re-add" } : x));
+              const entry = pendingAttachments.find((x) => x.id === id);
+              if (!entry) return;
+              if (!entry.file) {
+                // Path-based attachment (no File kept): can only re-add.
+                setPendingAttachments((p) => p.map((x) => x.id === id ? { ...x, error: "Can't retry, remove and re-add" } : x));
+                return;
+              }
+              if ((entry.retries ?? 0) >= 3) return;
+              setPendingAttachments((p) => p.map((x) => x.id === id ? { ...x, retries: (x.retries ?? 0) + 1 } : x));
+              uploadFileAttachment(id, entry.file);
             }}
           />
 
@@ -2472,7 +2490,7 @@ export function MessagesApp({
                     e.preventDefault();
                     for (const f of files) {
                       const id = Math.random().toString(36).slice(2);
-                      setPendingAttachments((p) => [...p, { id, filename: f.name || "pasted.png", size: f.size, uploading: true }]);
+                      setPendingAttachments((p) => [...p, { id, filename: f.name || "pasted.png", size: f.size, uploading: true, file: f }]);
                       uploadDiskFile(f, selectedChannel ?? undefined)
                         .then((rec) => setPendingAttachments((p) => p.map((x) => x.id === id ? { ...x, record: rec, uploading: false } : x)))
                         .catch((err) => setPendingAttachments((p) => p.map((x) => x.id === id ? { ...x, uploading: false, error: (err as Error).message } : x)));

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -384,6 +384,10 @@ export function MessagesApp({
   });
   const [archivedChannels, setArchivedChannels] = useState<Channel[]>([]);
   const [archivedExpanded, setArchivedExpanded] = useState(false);
+  // Collapsible sidebar sections, keyed by section label / project id, persisted.
+  const [collapsedSections, setCollapsedSections] = useState<Record<string, boolean>>(() => {
+    try { return JSON.parse(localStorage.getItem("taos-chat-collapsed") || "{}"); } catch { return {}; }
+  });
   const [projectsExpanded, setProjectsExpanded] = useState(true);
   const [projectChannelExpanded, setProjectChannelExpanded] = useState<Record<string, boolean>>({});
   const [liveAgents, setLiveAgents] = useState<LiveAgent[]>([]);
@@ -931,6 +935,20 @@ export function MessagesApp({
     setNewCount(0);
   };
 
+  const toggleSection = (key: string) => {
+    setCollapsedSections((s) => {
+      const next = { ...s, [key]: !s[key] };
+      try { localStorage.setItem("taos-chat-collapsed", JSON.stringify(next)); } catch { /* best-effort */ }
+      return next;
+    });
+  };
+  // When a section is collapsed, still surface channels that are unread or
+  // currently selected (Slack behavior), so nothing important is hidden.
+  const visibleInSection = (items: Channel[], key: string) =>
+    collapsedSections[key]
+      ? items.filter((ch) => (unread[ch.id] ?? 0) > 0 || ch.id === selectedChannel)
+      : items;
+
   /* ---- typing emitter + slash menu derived state ---- */
   const emitTyping = useTypingEmitter(selectedChannel, "user");
   const showSlash = input.startsWith("/");
@@ -1373,11 +1391,19 @@ export function MessagesApp({
         </div>
       ) : SECTIONS.map((section) => (
         <div key={section.label} style={{ marginBottom: 20 }}>
-          <div style={{ fontSize: 12, textTransform: "uppercase", letterSpacing: 0.5, color: "rgba(255,255,255,0.45)", padding: "0 20px 6px", fontWeight: 600, display: "flex", alignItems: "center", gap: 6 }}>
+          <button
+            type="button"
+            onClick={() => toggleSection(section.label)}
+            aria-expanded={!collapsedSections[section.label]}
+            style={{ fontSize: 12, textTransform: "uppercase" as const, letterSpacing: 0.5, color: "rgba(255,255,255,0.45)", padding: "0 20px 6px", fontWeight: 600, display: "flex", alignItems: "center", gap: 6, background: "none", border: "none", cursor: "pointer", width: "100%" }}
+          >
+            <ChevronRight size={13} aria-hidden="true" style={{ transition: "transform 0.15s", transform: collapsedSections[section.label] ? "none" : "rotate(90deg)" }} />
             {section.icon} {section.label}
-          </div>
-          {section.items.length === 0 ? (
-            <div style={{ padding: "0 20px", fontSize: 12, color: "rgba(255,255,255,0.2)", fontStyle: "italic" }}>None yet</div>
+          </button>
+          {visibleInSection(section.items, section.label).length === 0 ? (
+            collapsedSections[section.label] ? null : (
+              <div style={{ padding: "0 20px", fontSize: 12, color: "rgba(255,255,255,0.2)", fontStyle: "italic" }}>None yet</div>
+            )
           ) : (
             <div
               style={{
@@ -1388,7 +1414,7 @@ export function MessagesApp({
                 overflow: "hidden",
               }}
             >
-              {section.items.map((ch, idx, arr) => (
+              {visibleInSection(section.items, section.label).map((ch, idx, arr) => (
                 <button
                   key={ch.id}
                   type="button"
@@ -1610,13 +1636,23 @@ export function MessagesApp({
           </div>
         ) : SECTIONS.map((section) => (
           <div key={section.label}>
-            <div className="px-3 pt-3 pb-1 text-[10px] font-semibold uppercase tracking-wider text-white/30 flex items-center gap-1.5">
+            <button
+              type="button"
+              onClick={() => toggleSection(section.label)}
+              aria-expanded={!collapsedSections[section.label]}
+              className="w-full px-3 pt-3 pb-1 text-[10px] font-semibold uppercase tracking-wider text-white/30 hover:text-white/50 flex items-center gap-1.5 transition-colors"
+            >
+              <ChevronRight
+                size={11}
+                aria-hidden="true"
+                className={`transition-transform ${collapsedSections[section.label] ? "" : "rotate-90"}`}
+              />
               {section.icon} {section.label}
-            </div>
-            {section.items.length === 0 && (
+            </button>
+            {!collapsedSections[section.label] && section.items.length === 0 && (
               <div className="px-3 py-1 text-[11px] text-white/20 italic">None yet</div>
             )}
-            {section.items.map((ch) => (
+            {visibleInSection(section.items, section.label).map((ch) => (
               <Button
                 key={ch.id}
                 variant={selectedChannel === ch.id ? "secondary" : "ghost"}

--- a/desktop/src/apps/chat/AttachmentsBar.tsx
+++ b/desktop/src/apps/chat/AttachmentsBar.tsx
@@ -8,6 +8,8 @@ export type PendingAttachment = {
   record?: AttachmentRecord;  // set once upload completes
   error?: string;
   uploading?: boolean;
+  file?: File;        // original file kept so a failed upload can be retried
+  retries?: number;   // retry attempts so far (capped at 3)
 };
 
 export function AttachmentsBar({
@@ -31,7 +33,11 @@ export function AttachmentsBar({
           <span className="opacity-50">{Math.max(1, Math.round(it.size / 1024))} KB</span>
           {it.uploading && <span className="opacity-70">…</span>}
           {it.error && (
-            <button aria-label="Retry upload" onClick={() => onRetry(it.id)} className="text-red-300">retry</button>
+            (it.retries ?? 0) < 3 && it.file ? (
+              <button aria-label="Retry upload" onClick={() => onRetry(it.id)} className="text-red-300">retry</button>
+            ) : (
+              <span title="Upload failed" className="text-red-400/70">failed</span>
+            )
           )}
           <button aria-label={`Remove ${it.filename}`} onClick={() => onRemove(it.id)} className="opacity-70 hover:opacity-100">×</button>
         </div>

--- a/desktop/src/apps/chat/ThreadPanel.tsx
+++ b/desktop/src/apps/chat/ThreadPanel.tsx
@@ -17,6 +17,7 @@ export function ThreadPanel({
   onClose,
   onSend,
   isFullscreen = false,
+  liveReplies = [],
   authorCtx = { currentUserId: null, currentUserDisplayName: null },
 }: {
   channelId: string;
@@ -24,6 +25,9 @@ export function ThreadPanel({
   onClose: () => void;
   onSend: (content: string, attachments: AttachmentRecord[]) => Promise<void>;
   isFullscreen?: boolean;
+  /** Replies that arrived over the WS while the panel is open. Merged with the
+   *  initial fetch, de-duplicated by id. */
+  liveReplies?: Msg[];
   authorCtx?: AuthorContext;
 }) {
   const [parent, setParent] = useState<Msg | null>(null);
@@ -33,6 +37,26 @@ export function ThreadPanel({
   const [sendError, setSendError] = useState<string | null>(null);
   const [sending, setSending] = useState(false);
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // Merge the fetched replies with any live ones, de-duped by id (a reply can
+  // appear in both the initial fetch and the WS stream).
+  const renderedReplies: Msg[] = (() => {
+    const seen = new Set<string>();
+    const out: Msg[] = [];
+    for (const m of [...msgs, ...liveReplies]) {
+      if (seen.has(m.id)) continue;
+      seen.add(m.id);
+      out.push(m);
+    }
+    return out;
+  })();
+
+  // Scroll to the bottom when a live reply lands.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [liveReplies.length]);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -104,14 +128,14 @@ export function ThreadPanel({
         >{isFullscreen ? "◀" : "✕"}</button>
       </div>
 
-      <div className="flex-1 overflow-y-auto px-4 py-3 flex flex-col gap-3">
+      <div ref={scrollRef} className="flex-1 overflow-y-auto px-4 py-3 flex flex-col gap-3">
         {parent && (
           <div className="pb-3 border-b border-white/10">
             <div className="text-xs text-white/50 mb-1">{displayAuthor(parent, authorCtx)}</div>
             <div className="text-sm">{parent.content}</div>
           </div>
         )}
-        {msgs.map((m) => (
+        {renderedReplies.map((m) => (
           <div key={m.id}>
             <div className="text-xs text-white/50 mb-0.5">{displayAuthor(m, authorCtx)}</div>
             <div className="text-sm">{m.content}</div>

--- a/desktop/src/apps/chat/ThreadPanel.tsx
+++ b/desktop/src/apps/chat/ThreadPanel.tsx
@@ -7,8 +7,7 @@ type Msg = {
   author_id: string;
   author_type?: "user" | "agent" | "system";
   content: string;
-  created_at?: number;
-  [key: string]: unknown;
+  created_at?: number | string;
 };
 
 export function ThreadPanel({

--- a/desktop/src/apps/chat/__tests__/render-helpers.test.tsx
+++ b/desktop/src/apps/chat/__tests__/render-helpers.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { renderContent, dayLabel } from "../../MessagesApp";
+
+describe("renderContent", () => {
+  it("passes plain text through", () => {
+    const { container } = render(<div>{renderContent("hello world")}</div>);
+    expect(container.textContent).toContain("hello world");
+  });
+
+  it("renders markdown bold, italic, and inline code", () => {
+    const { container } = render(<div>{renderContent("a **bold** b *italic* c `code`")}</div>);
+    expect(container.querySelector("strong")?.textContent).toBe("bold");
+    expect(container.querySelector("em")?.textContent).toBe("italic");
+    expect(container.querySelector("code")?.textContent).toBe("code");
+  });
+
+  it("renders a fenced block as a CodeBlock with a copy button", () => {
+    const text = "before\n```\nconst x = 1;\n```\nafter";
+    const { container } = render(<div>{renderContent(text)}</div>);
+    expect(container.textContent).toContain("const x = 1;");
+    expect(screen.getByRole("button", { name: /copy/i })).toBeInTheDocument();
+  });
+
+  it("preserves text on both sides of a fence in order", () => {
+    const text = "INTRO\n```\ncodeword\n```\nOUTRO";
+    const { container } = render(<div>{renderContent(text)}</div>);
+    const t = container.textContent || "";
+    expect(t.indexOf("INTRO")).toBeGreaterThanOrEqual(0);
+    expect(t.indexOf("codeword")).toBeGreaterThan(t.indexOf("INTRO"));
+    expect(t.indexOf("OUTRO")).toBeGreaterThan(t.indexOf("codeword"));
+  });
+
+  it("renders two fenced blocks as two copy buttons", () => {
+    const text = "```\nalpha\n```\nmid\n```\nbeta\n```";
+    render(<div>{renderContent(text)}</div>);
+    expect(screen.getAllByRole("button", { name: /copy/i })).toHaveLength(2);
+  });
+
+  it("does not emit React duplicate-key warnings", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const text = "a *one* b *two* c *three*\n```\ncode\n```\nd *four* e *five* f *six*";
+    render(<div>{renderContent(text)}</div>);
+    const keyWarned = spy.mock.calls.some((args) =>
+      args.some((a) => typeof a === "string" && a.includes("key")),
+    );
+    expect(keyWarned).toBe(false);
+    spy.mockRestore();
+  });
+
+  it("renders markdown lists and external links (react-markdown)", () => {
+    const { container: list } = render(<div>{renderContent("- one\n- two\n- three")}</div>);
+    expect(list.querySelectorAll("li").length).toBeGreaterThanOrEqual(3);
+
+    const { container: link } = render(<div>{renderContent("see [the site](https://example.com)")}</div>);
+    const a = link.querySelector("a");
+    expect(a?.getAttribute("href")).toBe("https://example.com");
+    expect(a?.getAttribute("target")).toBe("_blank");
+  });
+});
+
+describe("dayLabel", () => {
+  afterEach(() => vi.useRealTimers());
+
+  it("labels Today, Yesterday, and older dates", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-13T12:00:00"));
+    const today = new Date("2026-06-13T08:00:00").getTime();
+    const yesterday = new Date("2026-06-12T08:00:00").getTime();
+    const older = new Date("2026-06-01T08:00:00").getTime();
+    expect(dayLabel(today)).toBe("Today");
+    expect(dayLabel(yesterday)).toBe("Yesterday");
+    expect(dayLabel(older)).not.toBe("Today");
+    expect(dayLabel(older)).not.toBe("Yesterday");
+  });
+});

--- a/desktop/src/apps/chat/useChatNotifications.ts
+++ b/desktop/src/apps/chat/useChatNotifications.ts
@@ -1,0 +1,30 @@
+import { useCallback, useRef } from "react";
+
+/**
+ * Browser notifications for messages in channels the user is not viewing.
+ * Permission is requested lazily on the first notify, never on load. No
+ * notification fires while the window is focused (the in-app UI is enough).
+ */
+export function useChatNotifications() {
+  const asked = useRef(false);
+
+  const ensurePermission = useCallback(async (): Promise<boolean> => {
+    if (typeof Notification === "undefined") return false;
+    if (Notification.permission === "granted") return true;
+    if (Notification.permission === "denied" || asked.current) return false;
+    asked.current = true;
+    try { return (await Notification.requestPermission()) === "granted"; }
+    catch { return false; }
+  }, []);
+
+  const notify = useCallback(async (title: string, body: string, onClick: () => void) => {
+    if (!(await ensurePermission())) return;
+    if (document.hasFocus()) return; // window focused: in-app UI is enough
+    try {
+      const n = new Notification(title, { body: body.slice(0, 140) });
+      n.onclick = () => { window.focus(); onClick(); n.close(); };
+    } catch { /* notification constructor can throw on some platforms */ }
+  }, [ensurePermission]);
+
+  return { notify, ensurePermission };
+}


### PR DESCRIPTION
Job 24 from the agent-jobs pack. Friendly empty states in Messages (desktop/src/apps/MessagesApp.tsx only).

What changed:
- No channel selected: centered icon + "Pick a channel or start a DM" + a "New channel" button (opens the existing create-channel modal).
- Empty channel: centered icon + "No messages yet. Say hello to #<channel>" (or "@<agent>" for a DM). Gated on a new `fetchedChannel` marker set in fetchMessages, so the placeholder only renders after that channel's fetch has COMPLETED. This avoids a flash of the empty state during initial load and during rapid channel switches (messages from the previous channel stay until the new fetch resolves).

Not changed:
- The sidebar already has a friendly "No conversations yet" + "Open Agents" empty state, so I left it as-is rather than duplicate it (the job's third state already exists).

Verified: tsc -b clean, vite build succeeds, existing chat vitest suite passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the "no messages yet" placeholder from flickering during channel switches and loads.
  * Improved pin/jump behavior to surface an error when the target message is outside the loaded history.

* **New Features**
  * Added a “New channel” button and clearer empty-state prompt.
  * Collapsible sidebar sections with persisted state.
  * Jump-to-latest scroll affordance with unread count handling.
  * Composer `@mention` autocomplete (including "all") with keyboard navigation.
  * Shorter, regularly refreshed relative timestamps.
  * Live thread replies merged into threads and auto-scrolled into view.

* **Tests**
  * Added tests for message rendering, code blocks, links, and date labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->