### PR TITLE
ci: parallelize tests with pytest-xdist (-n auto)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,10 @@ jobs:
       # The real build is exercised in the spa-build job below.
 
       - name: Run tests
-        run: pytest tests/ -v --tb=short --ignore=tests/e2e
+        # Run across all runner cores. The serial suite (4845 tests) took
+        # ~22 min; -n auto cuts it to a few minutes so "merge on green" is
+        # practical. Dropped -v so xdist worker output stays readable.
+        run: pytest tests/ --tb=short --ignore=tests/e2e -n auto
 
       - name: Verify app starts
         run: python -c "from tinyagentos.app import create_app; print('OK')"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23.0",
     "pytest-timeout>=2.3.0",
+    "pytest-xdist>=3.5.0",
     "httpx",
     "respx>=0.21.0",
     "websockets>=12.0",


### PR DESCRIPTION
## Why
The CI test job was not hanging, it was slow. Recent runs show test (3.12)/(3.13) completing successfully but taking ~21-24 minutes each: 4845 tests, two Python versions, serial, with -v. That made "merge on green" impractical (I was merging before they finished).

## Change
- Add pytest-xdist to the dev extra.
- Run tests with -n auto so the suite uses all runner cores. Expected ~22 min -> a few minutes.
- Drop -v (4845 verbose lines interleave badly under xdist; --tb=short still gives failure detail).

The per-test timeout (120s, thread method) already guards a genuinely stuck test, so a single bad test fails fast and named rather than eating the whole budget.

## Validation
This PR's own test jobs are the proof: if they go green in a few minutes instead of ~22, the fix works. If any test is not parallel-safe (shared port/temp/db), it will surface here and I will scope or group those tests.