### PR TITLE
docs(agent): extra answer templates

### DIFF
--- a/docs/agent-manual/08-answer-templates.md
+++ b/docs/agent-manual/08-answer-templates.md
@@ -17,3 +17,13 @@
 **"Is my data private?"** — Yes. Everything runs on your hardware. Agents, chats, files, and memory stay local. Only two things ever leave: cloud model calls IF you added a cloud provider, and one anonymous update ping you can turn off.
 
 **"Something failed to install."** — taOS is in beta and some app and model manifests have not been tried on every hardware combination. Open an issue with the name of the thing and the error text; manifest fixes usually ship the same day.
+
+**"How do I add another machine to the cluster?"** Open the Cluster app on your main taOS, then on the other machine run the worker script from the Cluster app's add-machine instructions. The new machine shows a six digit pairing code; approve it in the Cluster app and it joins the mesh.
+
+**"What models can I run on my hardware?"** Open the Models app: the catalog marks what fits your detected hardware. Small boards run quantized 1 to 3 billion parameter models well; an 8GB board handles 7B quantized; GPUs and Apple Silicon open up larger models. Cloud models work on anything once you add a provider key.
+
+**"How do I back up taOS?"** Your data lives in the data directory of the install (agents, chats, memory, settings). Settings has a backups section; copying the whole data directory while taOS is stopped is also a complete backup.
+
+**"Where do I report a bug?"** github.com/jaylfc/tinyagentos/issues, with the error text and what hardware you are on. If something broke right after an update, mention that; there is a known-breakages log the developers check first.
+
+**"Can taOS work fully offline?"** Yes. With local models installed (rkllama or Ollama backends), every part of taOS runs on your network with no internet. Internet is only needed to download models, install apps from the store, check for updates, and use cloud model providers.

--- a/docs/taos-agent-manual.md
+++ b/docs/taos-agent-manual.md
@@ -128,3 +128,13 @@ Match the user's symptom against that log before reasoning from scratch. Known c
 **"Is my data private?"** — Yes. Everything runs on your hardware. Agents, chats, files, and memory stay local. Only two things ever leave: cloud model calls IF you added a cloud provider, and one anonymous update ping you can turn off.
 
 **"Something failed to install."** — taOS is in beta and some app and model manifests have not been tried on every hardware combination. Open an issue with the name of the thing and the error text; manifest fixes usually ship the same day.
+
+**"How do I add another machine to the cluster?"** Open the Cluster app on your main taOS, then on the other machine run the worker script from the Cluster app's add-machine instructions. The new machine shows a six digit pairing code; approve it in the Cluster app and it joins the mesh.
+
+**"What models can I run on my hardware?"** Open the Models app: the catalog marks what fits your detected hardware. Small boards run quantized 1 to 3 billion parameter models well; an 8GB board handles 7B quantized; GPUs and Apple Silicon open up larger models. Cloud models work on anything once you add a provider key.
+
+**"How do I back up taOS?"** Your data lives in the data directory of the install (agents, chats, memory, settings). Settings has a backups section; copying the whole data directory while taOS is stopped is also a complete backup.
+
+**"Where do I report a bug?"** github.com/jaylfc/tinyagentos/issues, with the error text and what hardware you are on. If something broke right after an update, mention that; there is a known-breakages log the developers check first.
+
+**"Can taOS work fully offline?"** Yes. With local models installed (rkllama or Ollama backends), every part of taOS runs on your network with no internet. Internet is only needed to download models, install apps from the store, check for updates, and use cloud model providers.


### PR DESCRIPTION
Job 14. Appends 5 answer templates to docs/agent-manual/08-answer-templates.md (cluster machine, models per hardware, backup, bug reports, offline), then rebuilds docs/taos-agent-manual.md via scripts/build-agent-manual.py. Both files committed together; tests/test_agent_manual_compiled.py passes (4). Verbatim text per the job; no em dashes added.