### PR TITLE
fix(update): reset desktop/package-lock.json before the ff-only pull (Install Update 500)

### DIFF
--- a/docs/UPDATE_BREAKAGE_LOG.md
+++ b/docs/UPDATE_BREAKAGE_LOG.md
@@ -15,6 +15,29 @@ Format per entry: date, change (PR), affected installs, symptom, check, fix.
 
 ---
 
+## 2026-06-13 — Install Update 500s when desktop/package-lock.json is dirty (#852)
+
+- **Affected:** any install whose desktop rebuild has run `npm install` (which
+  rewrites `desktop/package-lock.json`), AND where an incoming update also
+  changes that file. The esbuild bump (#849) changed package-lock.json, so
+  installs updating across that commit are the trigger.
+- **Symptom:** the update *check* shows updates available, but clicking Install
+  Update fails: `POST /api/settings/update` returns 500 with
+  `Update failed: ... Your local changes to desktop/package-lock.json would be
+  overwritten by merge`. No real divergence or conflict, just a rebuild-dirtied
+  lockfile blocking `git pull --ff-only`.
+- **Check:** `sudo -u taos git -C /opt/tinyagentos status --short` shows
+  `M desktop/package-lock.json`.
+- **Fix (in #852):** the apply-update endpoint now restores
+  `desktop/package-lock.json` (alongside `tsconfig.tsbuildinfo` + `static/desktop`)
+  before the pull, so it never blocks. No user action needed once on a build
+  with #852.
+- **Manual unblock on an install stuck before #852:**
+  `sudo -u taos git -C /opt/tinyagentos checkout -- desktop/package-lock.json`
+  then click Install Update again.
+
+---
+
 ## 2026-06-12 — LiteLLM host port default moved 4000 -> 7834 (#795, pinned in #805)
 
 - **Affected:** existing installs that have no `litellm_port` key under `server:`

--- a/tinyagentos/routes/settings.py
+++ b/tinyagentos/routes/settings.py
@@ -699,14 +699,18 @@ async def apply_update(request: Request):
     import asyncio
     project_dir = Path(__file__).parent.parent.parent
 
-    # systemd ExecStartPre rebuilds produce new content-hashed files in
-    # static/desktop/assets/ and modify desktop/tsconfig.tsbuildinfo on each
-    # restart, leaving the tree dirty. git pull --ff-only then refuses to
-    # overwrite the locals and the Install Update button always 500s. Wipe
-    # build outputs first — git pull restores them or the rebuild below
-    # regenerates them.
+    # The desktop rebuild leaves the tree dirty in three ways, and a dirty
+    # tracked file makes the next git pull --ff-only refuse to overwrite the
+    # local and the Install Update button 500s:
+    #   - static/desktop/assets/* : new content-hashed bundle files (npm build)
+    #   - desktop/tsconfig.tsbuildinfo : touched on every tsc build
+    #   - desktop/package-lock.json : npm install rewrites it (esp. when an
+    #     incoming update also changes it, e.g. the esbuild bump in #849)
+    # Restore all of them before pulling; the pull restores the committed
+    # versions or the rebuild below regenerates the build outputs.
     reset_proc = await asyncio.create_subprocess_exec(
-        "git", "checkout", "--", "desktop/tsconfig.tsbuildinfo", "static/desktop",
+        "git", "checkout", "--",
+        "desktop/tsconfig.tsbuildinfo", "desktop/package-lock.json", "static/desktop",
         stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL,
         cwd=str(project_dir),
     )


### PR DESCRIPTION
## Symptom
Jay's Pi could not update: `POST /api/settings/update` returned 500 on every attempt (the update *check* worked and showed updates available).

## Root cause
The desktop rebuild runs `npm install`, which rewrites `desktop/package-lock.json` and leaves it tracked-dirty. The apply-update endpoint restores `desktop/tsconfig.tsbuildinfo` + `static/desktop` before `git pull --ff-only`, but NOT `package-lock.json`. When an incoming update also changes that file (the esbuild bump in #849 did), the ff-only pull refuses to overwrite the local change and the endpoint 500s. No divergence, no real conflict, just a rebuild-dirtied lockfile.

## Fix
Add `desktop/package-lock.json` to the pre-pull `git checkout --` reset, alongside the build outputs it already restores. The pull then restores the committed lockfile and the rebuild regenerates it as needed.

Pi unblocked live (cleaned the stray lock, reset to its prior HEAD with a clean tree, verified the ff-only pull to origin/dev now succeeds). 22/22 settings route tests pass. Relates to #841 (surface update blockers in the UI).