### PR TITLE
fix(agents): kill switch surfaces failures (Gitar review follow-up on #857)

### DIFF
--- a/desktop/src/components/AgentKillSwitch.test.tsx
+++ b/desktop/src/components/AgentKillSwitch.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { AgentKillSwitch } from "./AgentKillSwitch";
 
@@ -7,6 +7,9 @@ import { AgentKillSwitch } from "./AgentKillSwitch";
 describe("AgentKillSwitch", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve([]) })) as unknown as typeof fetch);
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it("renders the top-bar trigger with an accessible label", () => {

--- a/desktop/src/components/AgentKillSwitch.test.tsx
+++ b/desktop/src/components/AgentKillSwitch.test.tsx
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { AgentKillSwitch } from "./AgentKillSwitch";
+
+// Radix portals + pointer-event opening are flaky under jsdom, so this covers
+// the render contract; the open/confirm/kill paths are exercised manually.
+describe("AgentKillSwitch", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve([]) })) as unknown as typeof fetch);
+  });
+
+  it("renders the top-bar trigger with an accessible label", () => {
+    render(<AgentKillSwitch />);
+    const trigger = screen.getByRole("button", { name: "Stop agents" });
+    expect(trigger).toBeInTheDocument();
+  });
+
+  it("does not open a confirmation dialog before any action", () => {
+    render(<AgentKillSwitch />);
+    // The destructive confirm dialog is only mounted once a target is chosen.
+    expect(screen.queryByText(/Kill all agents\?/)).toBeNull();
+  });
+});

--- a/desktop/src/components/AgentKillSwitch.tsx
+++ b/desktop/src/components/AgentKillSwitch.tsx
@@ -161,7 +161,15 @@ export function AgentKillSwitch() {
         </DropdownMenu.Portal>
       </DropdownMenu.Root>
 
-      <Dialog.Root open={pending !== null} onOpenChange={(o) => !o && setPending(null)}>
+      <Dialog.Root
+        open={pending !== null}
+        onOpenChange={(o) => {
+          if (!o) {
+            setPending(null);
+            setFailed(false);
+          }
+        }}
+      >
         <Dialog.Portal>
           <Dialog.Overlay className="fixed inset-0 z-[60] bg-black/50 backdrop-blur-sm" />
           <Dialog.Content
@@ -186,7 +194,10 @@ export function AgentKillSwitch() {
             )}
             <div className="mt-5 flex justify-end gap-2">
               <button
-                onClick={() => setPending(null)}
+                onClick={() => {
+                  setPending(null);
+                  setFailed(false);
+                }}
                 disabled={busy}
                 className="px-3.5 py-2 rounded-lg text-sm font-medium text-shell-text-secondary hover:bg-shell-surface-hover transition-colors disabled:opacity-50"
               >

--- a/desktop/src/components/AgentKillSwitch.tsx
+++ b/desktop/src/components/AgentKillSwitch.tsx
@@ -36,7 +36,17 @@ async function postStop(path: string): Promise<boolean> {
 export function AgentKillSwitch() {
   const [agents, setAgents] = useState<RunningAgent[]>([]);
   const [pending, setPending] = useState<Pending>(null);
+  // Retains the last target so the dialog title does not flash "Kill ?" during
+  // the close animation (pending goes null before the content unmounts).
+  const [shown, setShown] = useState<Exclude<Pending, null> | null>(null);
   const [busy, setBusy] = useState(false);
+  const [failed, setFailed] = useState(false);
+
+  const openConfirm = useCallback((p: Exclude<Pending, null>) => {
+    setShown(p);
+    setFailed(false);
+    setPending(p);
+  }, []);
 
   // Refresh the running-agent list each time the menu opens (cheap, and keeps
   // the list current without a global store).
@@ -63,6 +73,7 @@ export function AgentKillSwitch() {
   const confirmKill = useCallback(async () => {
     if (!pending) return;
     setBusy(true);
+    setFailed(false);
     const ok =
       pending.mode === "all"
         ? await postStop("/api/agents/bulk/stop")
@@ -73,8 +84,12 @@ export function AgentKillSwitch() {
       setAgents((prev) =>
         pending.mode === "all" ? [] : prev.filter((a) => a.name !== pending.name),
       );
+      setPending(null);
+    } else {
+      // Surface the failure and keep the dialog open instead of closing as if
+      // the kill succeeded.
+      setFailed(true);
     }
-    setPending(null);
   }, [pending]);
 
   const menuItem =
@@ -82,9 +97,9 @@ export function AgentKillSwitch() {
   const dangerItem = `${menuItem} text-red-400 hover:bg-red-500/15 focus:bg-red-500/15`;
   const plainItem = `${menuItem} text-shell-text-secondary hover:bg-shell-surface-hover hover:text-shell-text focus:bg-shell-surface-hover focus:text-shell-text`;
 
-  const dialogTitle = pending?.mode === "all" ? "Kill all agents?" : `Kill ${pending?.mode === "one" ? pending.label : ""}?`;
+  const dialogTitle = shown?.mode === "all" ? "Kill all agents?" : `Kill ${shown?.mode === "one" ? shown.label : ""}?`;
   const dialogBody =
-    pending?.mode === "all"
+    shown?.mode === "all"
       ? "Every running agent will be stopped immediately. In-flight work is lost. You can start them again from the Agents app."
       : "This agent will be stopped immediately. In-flight work is lost. You can start it again from the Agents app.";
 
@@ -114,7 +129,7 @@ export function AgentKillSwitch() {
 
             <DropdownMenu.Item
               className={agents.length === 0 ? `${dangerItem} opacity-40 pointer-events-none` : dangerItem}
-              onSelect={() => agents.length > 0 && setPending({ mode: "all" })}
+              onSelect={() => agents.length > 0 && openConfirm({ mode: "all" })}
             >
               <OctagonX size={14} />
               <span className="flex-1">Kill all agents</span>
@@ -134,7 +149,7 @@ export function AgentKillSwitch() {
                   <DropdownMenu.Item
                     key={a.name}
                     className={plainItem}
-                    onSelect={() => setPending({ mode: "one", name: a.name, label })}
+                    onSelect={() => openConfirm({ mode: "one", name: a.name, label })}
                   >
                     <CircleStop size={14} className="text-shell-text-tertiary shrink-0" />
                     <span className="flex-1 truncate">{label}</span>
@@ -164,6 +179,11 @@ export function AgentKillSwitch() {
                 </Dialog.Description>
               </div>
             </div>
+            {failed && (
+              <p role="alert" className="mt-3 text-sm text-red-400">
+                Could not stop {shown?.mode === "all" ? "the agents" : "the agent"}. Please try again.
+              </p>
+            )}
             <div className="mt-5 flex justify-end gap-2">
               <button
                 onClick={() => setPending(null)}
@@ -177,7 +197,7 @@ export function AgentKillSwitch() {
                 disabled={busy}
                 className="px-3.5 py-2 rounded-lg text-sm font-semibold bg-red-500 text-white hover:bg-red-600 transition-colors disabled:opacity-50"
               >
-                {busy ? "Stopping..." : pending?.mode === "all" ? "Kill all" : "Kill agent"}
+                {busy ? "Stopping..." : failed ? "Try again" : shown?.mode === "all" ? "Kill all" : "Kill agent"}
               </button>
             </div>
           </Dialog.Content>


### PR DESCRIPTION
Addresses Gitar's review on the just-merged #857:
- **Bug (silent failure):** a failed stop request closed the confirm dialog as if it had worked. Now it keeps the dialog open and shows an error with a **Try again** action.
- **Nit (title flash):** the dialog title could flash `Kill ?` during the close animation; the target is now retained in a `shown` state for stable rendering.
- **Coverage:** added a render/contract test for `AgentKillSwitch`.

tsc + build green; the new test passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed flickering in the kill switch confirmation dialog during close animations
  * Improved error handling for failed kill actions with clear failure messages
  * Added retry functionality with "Try again" button when operations fail
  * Enhanced state management for more reliable kill confirmation workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->