### PR TITLE
feat(theme): theme chooser shows only taOS Dark + taOS Light (remove Matrix Terminal)

### DIFF
--- a/desktop/src/apps/SettingsApp/__tests__/ThemesPanel.test.tsx
+++ b/desktop/src/apps/SettingsApp/__tests__/ThemesPanel.test.tsx
@@ -20,10 +20,10 @@ describe("ThemesPanel", () => {
     expect(document.documentElement.style.getPropertyValue("--color-accent")).toBe("");
   });
 
-  it("shows built-in Default and Matrix Terminal even when server returns empty list", async () => {
+  it("shows built-in taOS Dark and taOS Light even when server returns empty list", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => [] }));
     render(<ThemesPanel />);
-    expect(await screen.findByText("Default")).toBeInTheDocument();
-    expect(screen.getByText("Matrix Terminal")).toBeInTheDocument();
+    expect(await screen.findByText("taOS Dark")).toBeInTheDocument();
+    expect(screen.getByText("taOS Light")).toBeInTheDocument();
   });
 });

--- a/desktop/src/stores/__tests__/restore-theme.test.ts
+++ b/desktop/src/stores/__tests__/restore-theme.test.ts
@@ -15,15 +15,15 @@ describe("restoreActiveTheme", () => {
     vi.spyOn(globalThis, "fetch").mockImplementation((input: RequestInfo | URL) => {
       const url = typeof input === "string" ? input : input.toString();
       if (url.includes("/api/preferences/themes")) {
-        return Promise.resolve(new Response(JSON.stringify({ active_theme_id: "matrix-terminal" })));
+        return Promise.resolve(new Response(JSON.stringify({ active_theme_id: "light" })));
       }
       return Promise.resolve(new Response(JSON.stringify([])));
     });
 
     await restoreActiveTheme();
 
-    expect(document.documentElement.style.getPropertyValue("--color-accent")).toBe("#00ff46");
-    expect(useThemeStore.getState().activeThemeId).toBe("matrix-terminal");
+    expect(document.documentElement.style.getPropertyValue("--color-accent")).toBe("#5b6472");
+    expect(useThemeStore.getState().activeThemeId).toBe("light");
   });
 
   it("is a no-op when no active theme is saved", async () => {

--- a/desktop/src/theme/__tests__/builtin-themes.test.ts
+++ b/desktop/src/theme/__tests__/builtin-themes.test.ts
@@ -4,10 +4,10 @@ import { BUILTIN_THEMES } from "../builtin-themes";
 import { ALLOWED_TOKENS } from "../theme-config";
 
 describe("builtin themes", () => {
-  it("includes an undeletable Default and a Matrix Terminal", () => {
+  it("includes an undeletable taOS Dark (default) and taOS Light", () => {
     const ids = BUILTIN_THEMES.map((t) => t.theme_id);
     expect(ids).toContain("default");
-    expect(ids).toContain("matrix-terminal");
+    expect(ids).toContain("light");
     expect(BUILTIN_THEMES.find((t) => t.theme_id === "default")!.builtin).toBe(true);
   });
   it("only uses allowlisted tokens", () => {

--- a/desktop/src/theme/builtin-themes.ts
+++ b/desktop/src/theme/builtin-themes.ts
@@ -10,13 +10,13 @@ export interface BuiltinTheme {
 export const BUILTIN_THEMES: BuiltinTheme[] = [
   {
     theme_id: "default",
-    name: "Default",
+    name: "taOS Dark",
     builtin: true,
     config: { tokens: {}, structure: {}, effects: [], requires: ["assistant", "launcher"], wallpaper: null },
   },
   {
     theme_id: "light",
-    name: "Light",
+    name: "taOS Light",
     builtin: true,
     config: {
       tokens: {
@@ -53,35 +53,6 @@ export const BUILTIN_THEMES: BuiltinTheme[] = [
       effects: [],
       requires: ["assistant", "launcher"],
       wallpaper: "linear-gradient(160deg, #eef0f3 0%, #e6e9ee 45%, #dee2e8 100%)",
-    },
-  },
-  {
-    theme_id: "matrix-terminal",
-    name: "Matrix Terminal",
-    builtin: true,
-    config: {
-      tokens: {
-        "--color-shell-bg": "#000800",
-        "--color-shell-bg-deep": "#000400",
-        "--color-shell-surface": "rgba(0, 255, 70, 0.06)",
-        "--color-shell-surface-hover": "rgba(0, 255, 70, 0.10)",
-        "--color-shell-surface-active": "rgba(0, 255, 70, 0.14)",
-        "--color-shell-border": "rgba(0, 255, 70, 0.18)",
-        "--color-shell-border-strong": "rgba(0, 255, 70, 0.35)",
-        "--color-shell-text": "#33ff66",
-        "--color-shell-text-secondary": "rgba(51, 255, 102, 0.7)",
-        "--color-shell-text-tertiary": "rgba(51, 255, 102, 0.45)",
-        "--color-accent": "#00ff46",
-        "--color-accent-glow": "rgba(0, 255, 70, 0.45)",
-        "--color-dock-bg": "rgba(0, 20, 0, 0.92)",
-        "--color-topbar-bg": "rgba(0, 20, 0, 0.92)",
-        "--font-ui": "'JetBrains Mono', 'SF Mono', ui-monospace, monospace",
-        "--font-mono": "'JetBrains Mono', 'SF Mono', ui-monospace, monospace",
-      },
-      structure: {},
-      effects: [{ module: "crt" }, { module: "scanlines" }, { module: "glow" }],
-      requires: ["assistant", "launcher"],
-      wallpaper: "radial-gradient(ellipse at center, #001a00 0%, #000400 100%)",
     },
   },
 ];


### PR DESCRIPTION
Per Jay: the Settings theme chooser should show just **taOS Light** and **taOS Dark**.

- Removed the **Matrix Terminal** builtin theme.
- Renamed **Default -> taOS Dark** and **Light -> taOS Light**.
- Updated the three theme tests that referenced `matrix-terminal` (builtin-themes, ThemesPanel, restore-theme).

tsc + build green; touched theme tests pass. (Pre-existing, unrelated: `safety-regression.test.tsx` fails on dev due to a stale `/assistant/i` aria-label assertion - not touched here.)