### PR TITLE
fix(agents): model chip on every agent + aligned row columns

### DIFF
--- a/desktop/src/apps/AgentsApp.tsx
+++ b/desktop/src/apps/AgentsApp.tsx
@@ -89,6 +89,7 @@ export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
                 status: String(a.status ?? "stopped") as Agent["status"],
                 vectors: Number(a.vectors ?? 0),
                 framework: a.framework ? String(a.framework) : undefined,
+                model: a.model ? String(a.model) : undefined,
                 paused: Boolean(a.paused),
                 on_worker_failure: (a.on_worker_failure as Agent["on_worker_failure"]) ?? "pause",
                 fallback_models: Array.isArray(a.fallback_models) ? (a.fallback_models as string[]) : [],

--- a/desktop/src/apps/agents/AgentRow.tsx
+++ b/desktop/src/apps/agents/AgentRow.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode } from "react";
 import { useIsMobile } from "@/hooks/use-is-mobile";
-import { ScrollText, Trash2, Server, Wrench, MessageSquare, PauseCircle, RotateCcw, HardDrive, Database, Cpu } from "lucide-react";
+import { ScrollText, Trash2, Server, Wrench, MessageSquare, PauseCircle, RotateCcw, HardDrive, Database } from "lucide-react";
 import { LatestVersion } from "@/lib/framework-api";
 import { resolveAgentEmoji } from "@/lib/agent-emoji";
 import { Button, Card } from "@/components/ui";
@@ -73,31 +73,17 @@ function PausedChip() {
   );
 }
 
-/** A single indicator chip (icon + value) for the indicators line. */
-function IndicatorChip({ icon, value, title }: { icon: ReactNode; value: string; title: string }) {
-  return (
-    <span
-      className="inline-flex items-center gap-1 max-w-full px-1.5 py-0.5 rounded-md bg-shell-surface border border-shell-border text-[10px] text-shell-text-tertiary font-mono"
-      title={title}
-    >
-      {icon}
-      <span className="truncate">{value}</span>
-    </span>
-  );
-}
-
-/** The indicators line under an agent's identity: model now, room for more
- *  (memory, region, ...) later. Renders nothing when there is nothing to show. */
+/** The model label under an agent's identity: plain muted text, no pill or
+ *  icon. Renders nothing when there is no model. */
 function IndicatorRow({ agent }: { agent: Agent }) {
   if (!agent.model) return null;
   return (
-    <div className="flex flex-wrap items-center gap-1 mt-1">
-      <IndicatorChip
-        icon={<Cpu size={10} className="shrink-0" aria-hidden="true" />}
-        value={agent.model}
-        title={`Model: ${agent.model}`}
-      />
-    </div>
+    <span
+      className="block mt-0.5 text-[11px] text-shell-text-tertiary font-mono truncate"
+      title={`Model: ${agent.model}`}
+    >
+      {agent.model}
+    </span>
   );
 }
 

--- a/desktop/src/apps/agents/AgentRow.tsx
+++ b/desktop/src/apps/agents/AgentRow.tsx
@@ -337,8 +337,10 @@ export function AgentRow({
         <span className="text-shell-text-secondary font-mono tabular-nums truncate">{agent.host}</span>
       </div>
 
-      {/* Status */}
-      <StatusIndicator status={agent.status} paused={agent.paused} />
+      {/* Status (fixed-width column so the metadata columns line up row to row) */}
+      <div className="w-24 shrink-0">
+        <StatusIndicator status={agent.status} paused={agent.paused} />
+      </div>
 
       {/* Vectors metric (de-emphasized) */}
       <span className="hidden sm:inline-flex items-center justify-end gap-1.5 w-28 text-right shrink-0">
@@ -349,8 +351,9 @@ export function AgentRow({
         <span className="text-[10px] text-shell-text-tertiary">vectors</span>
       </span>
 
-      {/* Actions */}
-      <div className="flex items-center gap-1 border-l border-shell-border pl-2 shrink-0">
+      {/* Actions: fixed-width + right-aligned so a protected agent's 3 icons
+          reserve the same column as a deployed agent's 4 (no column drift). */}
+      <div className="flex items-center justify-end gap-1 border-l border-shell-border pl-2 shrink-0 w-[152px]">
         {leftActions}
         {actionButtons}
       </div>


### PR DESCRIPTION
Follow-up polish on the Agents redesign (Jay's screenshots):
- **Model on every agent**: `/api/agents` already returns each agent's `model` (e.g. kilotest -> stepfun/..., naira -> nvidia/...); it just wasn't mapped. Now every agent shows the model indicator chip, not only the system agent.
- **Column alignment**: the actions column changed width (the protected system agent shows 3 icons vs 4 on deployed agents) and status had no fixed width, so the metadata columns drifted between rows. Status and actions are now fixed-width columns (actions right-aligned), so host / status / vectors / actions line up row to row.

tsc + build + AgentRow tests green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent cards now display model information.

* **Bug Fixes**
  * Fixed column alignment in desktop agent list layout to ensure consistent spacing across all rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->