### PR TITLE
feat(github): Device-Flow connect for GitHub identities in Secrets (#858 phase 1)

### DIFF
--- a/desktop/src/apps/SecretsApp.tsx
+++ b/desktop/src/apps/SecretsApp.tsx
@@ -9,6 +9,7 @@ import {
   Input,
   Label,
 } from "@/components/ui";
+import { GitHubConnect } from "./secrets/GitHubConnect";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -345,6 +346,9 @@ export function SecretsApp({ windowId: _windowId }: { windowId: string }) {
 
       {/* Content */}
       <div className="flex-1 overflow-auto">
+        <div className="p-4">
+          <GitHubConnect />
+        </div>
         {loading ? (
           <div className="flex items-center justify-center h-full text-shell-text-tertiary text-sm">
             Loading secrets...

--- a/desktop/src/apps/secrets/GitHubConnect.tsx
+++ b/desktop/src/apps/secrets/GitHubConnect.tsx
@@ -52,7 +52,7 @@ export function GitHubConnect() {
 
   const beginPolling = useCallback(
     (deviceCode: string, intervalSec: number, expiresInSec: number) => {
-      const intervalMs = Math.max(intervalSec, 1) * 1000;
+      let intervalMs = Math.max(intervalSec, 1) * 1000;
 
       const tick = async () => {
         const result = await pollDeviceFlow(deviceCode);
@@ -75,7 +75,10 @@ export function GitHubConnect() {
           });
           return;
         }
-        // pending -> schedule the next poll
+        // pending -> back off by 5s on slow_down (RFC 8628 §3.5), then poll again
+        if ("slow_down" in result && result.slow_down) {
+          intervalMs += 5000;
+        }
         pollTimer.current = setTimeout(tick, intervalMs);
       };
 

--- a/desktop/src/apps/secrets/GitHubConnect.tsx
+++ b/desktop/src/apps/secrets/GitHubConnect.tsx
@@ -1,0 +1,244 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import { Github, Copy, Check, ExternalLink, Trash2, Plus, Loader2 } from "lucide-react";
+import { Button, Card, CardContent } from "@/components/ui";
+import {
+  startDeviceFlow,
+  pollDeviceFlow,
+  listIdentities,
+  deleteIdentity,
+  type GitHubIdentity,
+} from "@/lib/github";
+
+type FlowState =
+  | { phase: "idle" }
+  | { phase: "starting" }
+  | {
+      phase: "awaiting";
+      userCode: string;
+      verificationUri: string;
+      deviceCode: string;
+    }
+  | { phase: "error"; message: string };
+
+/* ------------------------------------------------------------------ */
+/*  GitHubConnect                                                      */
+/* ------------------------------------------------------------------ */
+
+export function GitHubConnect() {
+  const [identities, setIdentities] = useState<GitHubIdentity[]>([]);
+  const [flow, setFlow] = useState<FlowState>({ phase: "idle" });
+  const [copied, setCopied] = useState(false);
+
+  // Refs so the polling loop can be cancelled cleanly on unmount / restart.
+  const pollTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const expiryTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const refreshIdentities = useCallback(async () => {
+    setIdentities(await listIdentities());
+  }, []);
+
+  useEffect(() => {
+    refreshIdentities();
+  }, [refreshIdentities]);
+
+  const stopPolling = useCallback(() => {
+    if (pollTimer.current) clearTimeout(pollTimer.current);
+    if (expiryTimer.current) clearTimeout(expiryTimer.current);
+    pollTimer.current = null;
+    expiryTimer.current = null;
+  }, []);
+
+  useEffect(() => stopPolling, [stopPolling]);
+
+  const beginPolling = useCallback(
+    (deviceCode: string, intervalSec: number, expiresInSec: number) => {
+      const intervalMs = Math.max(intervalSec, 1) * 1000;
+
+      const tick = async () => {
+        const result = await pollDeviceFlow(deviceCode);
+        if (result.status === "connected") {
+          stopPolling();
+          setFlow({ phase: "idle" });
+          await refreshIdentities();
+          return;
+        }
+        if (result.status === "error") {
+          stopPolling();
+          setFlow({
+            phase: "error",
+            message:
+              result.error === "expired_token"
+                ? "The code expired. Please try again."
+                : result.error === "access_denied"
+                  ? "Authorization was denied."
+                  : "Could not connect. Please try again.",
+          });
+          return;
+        }
+        // pending -> schedule the next poll
+        pollTimer.current = setTimeout(tick, intervalMs);
+      };
+
+      pollTimer.current = setTimeout(tick, intervalMs);
+      expiryTimer.current = setTimeout(() => {
+        stopPolling();
+        setFlow({ phase: "error", message: "The code expired. Please try again." });
+      }, expiresInSec * 1000);
+    },
+    [refreshIdentities, stopPolling],
+  );
+
+  const handleConnect = useCallback(async () => {
+    stopPolling();
+    setCopied(false);
+    setFlow({ phase: "starting" });
+    try {
+      const start = await startDeviceFlow();
+      setFlow({
+        phase: "awaiting",
+        userCode: start.user_code,
+        verificationUri: start.verification_uri,
+        deviceCode: start.device_code,
+      });
+      beginPolling(start.device_code, start.interval, start.expires_in);
+    } catch {
+      setFlow({ phase: "error", message: "Could not start the connect flow. Please try again." });
+    }
+  }, [beginPolling, stopPolling]);
+
+  const handleCancel = useCallback(() => {
+    stopPolling();
+    setFlow({ phase: "idle" });
+  }, [stopPolling]);
+
+  const handleCopy = useCallback(async (code: string) => {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      /* clipboard may be unavailable; ignore */
+    }
+  }, []);
+
+  const handleRemove = useCallback(
+    async (id: string) => {
+      if (await deleteIdentity(id)) await refreshIdentities();
+    },
+    [refreshIdentities],
+  );
+
+  return (
+    <Card className="bg-shell-surface border-white/5">
+      <CardContent className="p-5 space-y-4">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Github size={18} className="text-shell-text" />
+            <h2 className="text-sm font-semibold text-shell-text">GitHub</h2>
+            <span className="text-xs text-shell-text-tertiary">
+              {identities.length} connected
+            </span>
+          </div>
+          {flow.phase !== "awaiting" && flow.phase !== "starting" && (
+            <Button size="sm" onClick={handleConnect} aria-label="Connect GitHub account">
+              <Plus size={14} />
+              Connect GitHub account
+            </Button>
+          )}
+        </div>
+
+        {/* Flow card */}
+        {flow.phase === "starting" && (
+          <div className="flex items-center gap-2 text-sm text-shell-text-secondary">
+            <Loader2 size={14} className="animate-spin" />
+            Starting...
+          </div>
+        )}
+
+        {flow.phase === "awaiting" && (
+          <div className="rounded-lg border border-white/10 bg-shell-bg-deep p-4 space-y-4">
+            <p className="text-sm text-shell-text-secondary">
+              Enter this code on GitHub to authorize taOS:
+            </p>
+            <div className="flex items-center gap-3">
+              <span className="font-mono text-2xl tracking-widest text-shell-text select-all">
+                {flow.userCode}
+              </span>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => handleCopy(flow.userCode)}
+                aria-label="Copy code"
+                title="Copy code"
+                className="h-8 w-8"
+              >
+                {copied ? <Check size={15} className="text-emerald-400" /> : <Copy size={15} />}
+              </Button>
+            </div>
+            <div className="flex items-center gap-2">
+              <Button asChild size="sm">
+                <a href={flow.verificationUri} target="_blank" rel="noopener noreferrer">
+                  <ExternalLink size={14} />
+                  Open github.com/login/device
+                </a>
+              </Button>
+              <Button variant="secondary" size="sm" onClick={handleCancel}>
+                Cancel
+              </Button>
+            </div>
+            <div className="flex items-center gap-2 text-xs text-shell-text-tertiary">
+              <Loader2 size={12} className="animate-spin" />
+              Waiting for you to authorize on GitHub...
+            </div>
+          </div>
+        )}
+
+        {flow.phase === "error" && (
+          <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-300">
+            {flow.message}
+          </div>
+        )}
+
+        {/* Connected identities */}
+        {identities.length > 0 && (
+          <ul className="space-y-2" aria-label="Connected GitHub accounts">
+            {identities.map((id) => (
+              <li
+                key={id.id}
+                className="flex items-center justify-between rounded-lg border border-white/5 bg-shell-bg-deep px-3 py-2"
+              >
+                <div className="flex items-center gap-2.5 min-w-0">
+                  {id.avatar_url ? (
+                    <img
+                      src={id.avatar_url}
+                      alt=""
+                      className="h-7 w-7 rounded-full shrink-0"
+                    />
+                  ) : (
+                    <div className="h-7 w-7 rounded-full bg-white/10 flex items-center justify-center shrink-0">
+                      <Github size={14} className="text-shell-text-tertiary" />
+                    </div>
+                  )}
+                  <span className="text-sm font-medium text-shell-text truncate">
+                    {id.login}
+                  </span>
+                </div>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => handleRemove(id.id)}
+                  className="h-7 w-7 hover:text-red-400 hover:bg-red-500/15"
+                  aria-label={`Remove ${id.login}`}
+                  title="Remove"
+                >
+                  <Trash2 size={14} />
+                </Button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/desktop/src/lib/github.ts
+++ b/desktop/src/lib/github.ts
@@ -69,7 +69,7 @@ export interface DeviceStart {
 }
 
 export type DevicePoll =
-  | { status: "pending" }
+  | { status: "pending"; slow_down?: boolean }
   | { status: "connected"; identity: GitHubIdentity }
   | { status: "error"; error: string };
 

--- a/desktop/src/lib/github.ts
+++ b/desktop/src/lib/github.ts
@@ -1,3 +1,5 @@
+import { withCsrf } from "./csrf";
+
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
 /* ------------------------------------------------------------------ */
@@ -50,6 +52,26 @@ export interface GitHubAuthStatus {
   username?: string;
   method?: string;
 }
+
+export interface GitHubIdentity {
+  id: string;
+  login: string;
+  avatar_url: string;
+  created_at: number;
+}
+
+export interface DeviceStart {
+  user_code: string;
+  verification_uri: string;
+  device_code: string;
+  interval: number;
+  expires_in: number;
+}
+
+export type DevicePoll =
+  | { status: "pending" }
+  | { status: "connected"; identity: GitHubIdentity }
+  | { status: "error"; error: string };
 
 /* ------------------------------------------------------------------ */
 /*  Helpers                                                            */
@@ -196,4 +218,42 @@ export async function saveToLibrary(url: string): Promise<{ id: string; status: 
     categories: [],
     source: "github-browser",
   }, null);
+}
+
+/* ------------------------------------------------------------------ */
+/*  OAuth Device Flow (Connect GitHub)                                 */
+/* ------------------------------------------------------------------ */
+
+export async function startDeviceFlow(): Promise<DeviceStart> {
+  const res = await fetch(
+    "/api/github/oauth/device/start",
+    withCsrf({ method: "POST", headers: { Accept: "application/json" } }),
+  );
+  if (!res.ok) throw new Error("Failed to start GitHub connect");
+  return res.json();
+}
+
+export async function pollDeviceFlow(deviceCode: string): Promise<DevicePoll> {
+  const res = await fetch(
+    "/api/github/oauth/device/poll",
+    withCsrf({
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify({ device_code: deviceCode }),
+    }),
+  );
+  if (!res.ok) return { status: "error", error: "poll_failed" };
+  return res.json();
+}
+
+export async function listIdentities(): Promise<GitHubIdentity[]> {
+  return fetchJson<GitHubIdentity[]>("/api/github/identities", []);
+}
+
+export async function deleteIdentity(id: string): Promise<boolean> {
+  const res = await fetch(
+    `/api/github/identities/${encodeURIComponent(id)}`,
+    withCsrf({ method: "DELETE", headers: { Accept: "application/json" } }),
+  );
+  return res.ok;
 }

--- a/tests/test_github_oauth.py
+++ b/tests/test_github_oauth.py
@@ -111,7 +111,22 @@ async def test_device_poll_slow_down_is_pending(client_factory):
     gh = _make_response({"error": "slow_down"})
     c = await client_factory(post_effects=[gh])
     resp = await c.post("/api/github/oauth/device/poll", json={"device_code": "DEV123"})
-    assert resp.json()["status"] == "pending"
+    body = resp.json()
+    assert body["status"] == "pending"
+    # The frontend backs off its poll interval when slow_down is signalled.
+    assert body.get("slow_down") is True
+
+
+@pytest.mark.asyncio
+async def test_reconnect_same_login_updates_not_duplicates(store):
+    first = await store.add("octocat", "a1", "gho_token1", "repo")
+    second = await store.add("octocat", "a2", "gho_token2", "repo")
+    # Same login -> same row refreshed in place, no duplicate.
+    assert first["id"] == second["id"]
+    assert second["avatar_url"] == "a2"
+    identities = await store.list()
+    assert len(identities) == 1
+    assert await store.get_token(first["id"]) == "gho_token2"
 
 
 @pytest.mark.asyncio

--- a/tests/test_github_oauth.py
+++ b/tests/test_github_oauth.py
@@ -1,0 +1,206 @@
+"""Tests for the GitHub OAuth device-flow routes + identities store.
+
+A minimal FastAPI app with only the github_oauth router mounted, plus a real
+GitHubIdentitiesStore on a tmp_path DB, so the tests run fast without the full
+create_app initialisation.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from tinyagentos.github_identities import GitHubIdentitiesStore
+from tinyagentos.routes.github_oauth import router as github_oauth_router
+
+
+def _make_response(data, status_code: int = 200):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json = MagicMock(return_value=data)
+    resp.text = json.dumps(data) if isinstance(data, (dict, list)) else str(data)
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+@pytest_asyncio.fixture
+async def store(tmp_path):
+    s = GitHubIdentitiesStore(tmp_path / "github_identities.db")
+    await s.init()
+    yield s
+    await s.close()
+
+
+def _build_app(store, *, post_effects=(), get_effects=()):
+    app = FastAPI()
+    app.include_router(github_oauth_router)
+    http = MagicMock()
+    http.post = AsyncMock(side_effect=list(post_effects)) if post_effects else AsyncMock()
+    http.get = AsyncMock(side_effect=list(get_effects)) if get_effects else AsyncMock()
+    app.state.http_client = http
+    app.state.github_identities = store
+    return app
+
+
+@pytest_asyncio.fixture
+async def client_factory(store):
+    clients = []
+
+    async def _make(**kwargs):
+        app = _build_app(store, **kwargs)
+        transport = ASGITransport(app=app)
+        c = AsyncClient(transport=transport, base_url="http://test")
+        clients.append(c)
+        return c
+
+    yield _make
+    for c in clients:
+        await c.aclose()
+
+
+# ---------------------------------------------------------------------------
+# device/start
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_device_start_returns_user_code(client_factory):
+    gh = _make_response({
+        "device_code": "DEV123",
+        "user_code": "WXYZ-1234",
+        "verification_uri": "https://github.com/login/device",
+        "interval": 5,
+        "expires_in": 900,
+    })
+    c = await client_factory(post_effects=[gh])
+    resp = await c.post("/api/github/oauth/device/start")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["user_code"] == "WXYZ-1234"
+    assert data["device_code"] == "DEV123"
+    assert data["verification_uri"] == "https://github.com/login/device"
+    assert data["interval"] == 5
+
+
+@pytest.mark.asyncio
+async def test_device_start_bad_response_returns_502(client_factory):
+    gh = _make_response({"error": "invalid_client", "error_description": "Bad client"})
+    c = await client_factory(post_effects=[gh])
+    resp = await c.post("/api/github/oauth/device/start")
+    assert resp.status_code == 502
+
+
+# ---------------------------------------------------------------------------
+# device/poll
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_device_poll_pending(client_factory):
+    gh = _make_response({"error": "authorization_pending"})
+    c = await client_factory(post_effects=[gh])
+    resp = await c.post("/api/github/oauth/device/poll", json={"device_code": "DEV123"})
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_device_poll_slow_down_is_pending(client_factory):
+    gh = _make_response({"error": "slow_down"})
+    c = await client_factory(post_effects=[gh])
+    resp = await c.post("/api/github/oauth/device/poll", json={"device_code": "DEV123"})
+    assert resp.json()["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_device_poll_connected_stores_identity(client_factory, store):
+    token_resp = _make_response({"access_token": "gho_secrettoken", "scope": "repo,read:user"})
+    user_resp = _make_response({"login": "octocat", "avatar_url": "https://avatars/octocat.png"})
+    c = await client_factory(post_effects=[token_resp], get_effects=[user_resp])
+
+    resp = await c.post("/api/github/oauth/device/poll", json={"device_code": "DEV123"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "connected"
+    assert data["identity"]["login"] == "octocat"
+    assert data["identity"]["avatar_url"] == "https://avatars/octocat.png"
+    # No token must ever appear in the response payload.
+    assert "token" not in json.dumps(data)
+
+    # The token was stored encrypted and is retrievable internally.
+    identities = await store.list()
+    assert len(identities) == 1
+    identity_id = identities[0]["id"]
+    assert await store.get_token(identity_id) == "gho_secrettoken"
+
+
+@pytest.mark.asyncio
+async def test_device_poll_expired_is_error(client_factory):
+    gh = _make_response({"error": "expired_token"})
+    c = await client_factory(post_effects=[gh])
+    resp = await c.post("/api/github/oauth/device/poll", json={"device_code": "DEV123"})
+    data = resp.json()
+    assert data["status"] == "error"
+    assert data["error"] == "expired_token"
+
+
+# ---------------------------------------------------------------------------
+# identities list / delete
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_identities_list_excludes_token(client_factory, store):
+    await store.add("octocat", "https://avatars/octocat.png", "gho_secrettoken", "repo")
+    c = await client_factory()
+    resp = await c.get("/api/github/identities")
+    assert resp.status_code == 200
+    items = resp.json()
+    assert len(items) == 1
+    assert set(items[0].keys()) == {"id", "login", "avatar_url", "created_at"}
+    assert "token" not in json.dumps(items)
+    assert "gho_secrettoken" not in json.dumps(items)
+
+
+@pytest.mark.asyncio
+async def test_delete_identity(client_factory, store):
+    identity = await store.add("octocat", "", "gho_secrettoken", "repo")
+    c = await client_factory()
+    resp = await c.delete(f"/api/github/identities/{identity['id']}")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "deleted"
+    assert await store.list() == []
+
+
+@pytest.mark.asyncio
+async def test_delete_identity_invalid_uuid_returns_400(client_factory):
+    c = await client_factory()
+    resp = await c.delete("/api/github/identities/not-a-uuid")
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_delete_identity_not_found_returns_404(client_factory):
+    import uuid as _uuid
+    c = await client_factory()
+    resp = await c.delete(f"/api/github/identities/{_uuid.uuid4()}")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Store: token encryption at rest
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_token_encrypted_at_rest(store):
+    identity = await store.add("octocat", "", "gho_plaintexttoken", "repo")
+    async with store._db.execute(
+        "SELECT token FROM github_identities WHERE id = ?", (identity["id"],)
+    ) as cur:
+        row = await cur.fetchone()
+    # Raw DB value must NOT be the plaintext token.
+    assert row[0] != "gho_plaintexttoken"
+    assert "gho_plaintexttoken" not in row[0]
+    # And get_token decrypts it back.
+    assert await store.get_token(identity["id"]) == "gho_plaintexttoken"

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -58,6 +58,7 @@ from tinyagentos.scheduler import BackendCatalog, HistoryStore, ScoreCache, Task
 from tinyagentos.scheduler.discovery import build_scheduler as build_resource_scheduler
 from tinyagentos.torrent_settings import TorrentSettingsStore
 from tinyagentos.relationships import RelationshipManager
+from tinyagentos.github_identities import GitHubIdentitiesStore
 from tinyagentos.secrets import SecretsStore
 from tinyagentos.training import TrainingManager
 from tinyagentos.conversion import ConversionManager
@@ -260,6 +261,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     torrent_settings_store = TorrentSettingsStore(data_dir / "torrent_settings.json")
     download_manager = DownloadManager(torrent_settings_store=torrent_settings_store)
     secrets_store = SecretsStore(data_dir / "secrets.db")
+    github_identities_store = GitHubIdentitiesStore(data_dir / "github_identities.db")
     relationship_mgr = RelationshipManager(data_dir / "relationships.db")
     channel_store = ChannelStore(data_dir / "channels.db")
     scheduler = TaskScheduler(data_dir / "scheduler.db")
@@ -388,6 +390,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await notif_store.init()
         await qmd_client.init()
         await secrets_store.init()
+        await github_identities_store.init()
         await relationship_mgr.init()
         await channel_store.init()
         await scheduler.init()
@@ -595,6 +598,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         app.state.download_manager = download_manager
         app.state.torrent_settings_store = torrent_settings_store
         app.state.secrets = secrets_store
+        app.state.github_identities = github_identities_store
         app.state.relationships = relationship_mgr
         app.state.channels = channel_store
         app.state.fallback = fallback
@@ -1185,6 +1189,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     app.state.http_client = http_client
     app.state.download_manager = download_manager
     app.state.secrets = secrets_store
+    app.state.github_identities = github_identities_store
     app.state.relationships = relationship_mgr
     app.state.channels = channel_store
     app.state.fallback = fallback

--- a/tinyagentos/github_identities.py
+++ b/tinyagentos/github_identities.py
@@ -1,0 +1,89 @@
+"""Store for connected GitHub identities (OAuth device-flow tokens).
+
+Tokens are encrypted at rest with the exact same Fernet helper the
+``SecretsStore`` uses (``.secrets_key`` in the data dir) — no new crypto is
+introduced. The token is NEVER returned by :meth:`list`; only
+:meth:`get_token` (an internal helper) exposes the plaintext.
+"""
+from __future__ import annotations
+
+import time
+import uuid
+from pathlib import Path
+
+from tinyagentos.base_store import BaseStore
+from tinyagentos.secrets import _decrypt, _encrypt
+
+GITHUB_IDENTITIES_SCHEMA = """
+CREATE TABLE IF NOT EXISTS github_identities (
+    id TEXT PRIMARY KEY,
+    login TEXT NOT NULL,
+    avatar_url TEXT NOT NULL DEFAULT '',
+    token TEXT NOT NULL,
+    scopes TEXT NOT NULL DEFAULT '',
+    created_at INTEGER NOT NULL
+);
+"""
+
+
+class GitHubIdentitiesStore(BaseStore):
+    SCHEMA = GITHUB_IDENTITIES_SCHEMA
+
+    def __init__(self, db_path: Path):
+        super().__init__(db_path)
+        # Reuse the secrets key dir (same .secrets_key) so tokens use the same
+        # encryption key as the rest of taOS.
+        self._key_dir: Path = Path(db_path).parent
+
+    async def add(
+        self,
+        login: str,
+        avatar_url: str,
+        token: str,
+        scopes: str = "",
+    ) -> dict:
+        """Store a new identity. Returns the public fields (never the token)."""
+        identity_id = str(uuid.uuid4())
+        now = int(time.time())
+        encrypted = _encrypt(token, self._key_dir)
+        await self._db.execute(
+            "INSERT INTO github_identities (id, login, avatar_url, token, scopes, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (identity_id, login, avatar_url, encrypted, scopes, now),
+        )
+        await self._db.commit()
+        return {
+            "id": identity_id,
+            "login": login,
+            "avatar_url": avatar_url,
+            "created_at": now,
+        }
+
+    async def list(self) -> list[dict]:
+        """Return all identities WITHOUT tokens (id/login/avatar_url/created_at)."""
+        async with self._db.execute(
+            "SELECT id, login, avatar_url, created_at FROM github_identities "
+            "ORDER BY created_at DESC"
+        ) as cursor:
+            rows = await cursor.fetchall()
+        return [
+            {"id": r[0], "login": r[1], "avatar_url": r[2], "created_at": r[3]}
+            for r in rows
+        ]
+
+    async def get_token(self, identity_id: str) -> str | None:
+        """Internal: return the decrypted token for *identity_id* or None."""
+        async with self._db.execute(
+            "SELECT token FROM github_identities WHERE id = ?", (identity_id,)
+        ) as cursor:
+            row = await cursor.fetchone()
+        if not row:
+            return None
+        return _decrypt(row[0], self._key_dir)
+
+    async def delete(self, identity_id: str) -> bool:
+        cursor = await self._db.execute(
+            "DELETE FROM github_identities WHERE id = ?", (identity_id,)
+        )
+        await self._db.commit()
+        return cursor.rowcount > 0

--- a/tinyagentos/github_identities.py
+++ b/tinyagentos/github_identities.py
@@ -42,10 +42,32 @@ class GitHubIdentitiesStore(BaseStore):
         token: str,
         scopes: str = "",
     ) -> dict:
-        """Store a new identity. Returns the public fields (never the token)."""
+        """Store an identity. Returns the public fields (never the token).
+
+        Reconnecting an already-connected account (same login) refreshes the
+        token in place rather than creating a duplicate row.
+        """
+        encrypted = _encrypt(token, self._key_dir)
+        async with self._db.execute(
+            "SELECT id, created_at FROM github_identities WHERE login = ?", (login,)
+        ) as cursor:
+            existing = await cursor.fetchone()
+        if existing:
+            identity_id, created_at = existing[0], existing[1]
+            await self._db.execute(
+                "UPDATE github_identities SET avatar_url = ?, token = ?, scopes = ? "
+                "WHERE id = ?",
+                (avatar_url, encrypted, scopes, identity_id),
+            )
+            await self._db.commit()
+            return {
+                "id": identity_id,
+                "login": login,
+                "avatar_url": avatar_url,
+                "created_at": created_at,
+            }
         identity_id = str(uuid.uuid4())
         now = int(time.time())
-        encrypted = _encrypt(token, self._key_dir)
         await self._db.execute(
             "INSERT INTO github_identities (id, login, avatar_url, token, scopes, created_at) "
             "VALUES (?, ?, ?, ?, ?, ?)",

--- a/tinyagentos/github_oauth.py
+++ b/tinyagentos/github_oauth.py
@@ -1,0 +1,31 @@
+"""GitHub OAuth Device Flow configuration.
+
+taOS is self-hosted; instances have no fixed OAuth callback URL, so we use
+GitHub's OAuth *Device Flow*, which needs only the public Client ID (no client
+secret). Public OAuth Client IDs are safe to ship in source — they are
+exposed to every browser that starts the flow and carry no privilege on their
+own.
+"""
+from __future__ import annotations
+
+import os
+
+# The single taOS OAuth App Client ID. Public and safe in source.
+# Override per-instance with the GITHUB_OAUTH_CLIENT_ID env var.
+DEFAULT_CLIENT_ID = "Ov23licVGSIqagQLXAqb"
+
+# Device-flow scopes: repo access + read the authenticated user's profile.
+DEVICE_FLOW_SCOPE = "repo read:user"
+
+# GitHub endpoints.
+DEVICE_CODE_URL = "https://github.com/login/device/code"
+ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token"
+USER_URL = "https://api.github.com/user"
+
+# device_code grant type per RFC 8628.
+DEVICE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code"
+
+
+def client_id() -> str:
+    """Return the configured GitHub OAuth Client ID."""
+    return os.environ.get("GITHUB_OAUTH_CLIENT_ID", DEFAULT_CLIENT_ID)

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -184,6 +184,9 @@ def register_all_routers(app):
     from tinyagentos.routes.github import router as github_router
     app.include_router(github_router)
 
+    from tinyagentos.routes.github_oauth import router as github_oauth_router
+    app.include_router(github_oauth_router)
+
     from tinyagentos.routes.youtube import router as youtube_router
     app.include_router(youtube_router)
 

--- a/tinyagentos/routes/github_oauth.py
+++ b/tinyagentos/routes/github_oauth.py
@@ -1,0 +1,199 @@
+"""API routes for the GitHub OAuth Device Flow ("Connect GitHub").
+
+taOS instances have no fixed callback URL, so we use GitHub's OAuth Device
+Flow (RFC 8628), which needs only the public Client ID — no client secret.
+
+Routes (all under /api/github/):
+- POST /oauth/device/start  -> begin the flow, return the user_code + URLs
+- POST /oauth/device/poll   -> poll once for the token; store identity on success
+- GET  /identities          -> list connected identities (NO tokens)
+- DELETE /identities/{id}    -> remove an identity
+
+SECURITY: tokens are encrypted at rest (Fernet, shared secrets key) and are
+NEVER logged or returned by any endpoint.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from tinyagentos.github_oauth import (
+    ACCESS_TOKEN_URL,
+    DEVICE_CODE_URL,
+    DEVICE_FLOW_SCOPE,
+    DEVICE_GRANT_TYPE,
+    USER_URL,
+    client_id,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+_TIMEOUT = 10.0
+_JSON = {"Accept": "application/json"}
+
+# Token-endpoint errors that mean "keep waiting" vs. "give up".
+_PENDING_ERRORS = {"authorization_pending", "slow_down"}
+_TERMINAL_ERRORS = {"expired_token", "access_denied", "unsupported_grant_type"}
+
+
+class DevicePollBody(BaseModel):
+    device_code: str
+
+
+def _http(request: Request):
+    return request.app.state.http_client
+
+
+def _identities_store(request: Request):
+    return getattr(request.app.state, "github_identities", None)
+
+
+# ---------------------------------------------------------------------------
+# Device flow: start
+# ---------------------------------------------------------------------------
+
+@router.post("/api/github/oauth/device/start")
+async def device_start(request: Request):
+    """Begin the device flow. Returns user_code, verification_uri, device_code."""
+    http = _http(request)
+    try:
+        resp = await http.post(
+            DEVICE_CODE_URL,
+            data={"client_id": client_id(), "scope": DEVICE_FLOW_SCOPE},
+            headers=_JSON,
+            timeout=_TIMEOUT,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as exc:
+        logger.exception("github device/start failed: %s", exc)
+        return JSONResponse(
+            {"error": "Failed to start GitHub device flow"}, status_code=502
+        )
+
+    if "device_code" not in data or "user_code" not in data:
+        # GitHub returns {error: ...} on bad client_id etc. Never echo secrets.
+        logger.warning("github device/start unexpected response: %s", data.get("error"))
+        return JSONResponse(
+            {"error": data.get("error_description") or "GitHub did not return a device code"},
+            status_code=502,
+        )
+
+    # device_code is returned to the client so it can poll; this is standard
+    # per the protocol and is not a long-lived credential.
+    return {
+        "user_code": data["user_code"],
+        "verification_uri": data.get("verification_uri", "https://github.com/login/device"),
+        "device_code": data["device_code"],
+        "interval": data.get("interval", 5),
+        "expires_in": data.get("expires_in", 900),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Device flow: poll (single poll per call; frontend drives the loop)
+# ---------------------------------------------------------------------------
+
+@router.post("/api/github/oauth/device/poll")
+async def device_poll(request: Request, body: DevicePollBody):
+    """Poll the token endpoint once for *device_code*.
+
+    - access_token -> fetch the user, store the identity, status="connected"
+    - authorization_pending / slow_down -> status="pending"
+    - expired_token / access_denied -> status="error"
+    """
+    http = _http(request)
+    try:
+        resp = await http.post(
+            ACCESS_TOKEN_URL,
+            data={
+                "client_id": client_id(),
+                "device_code": body.device_code,
+                "grant_type": DEVICE_GRANT_TYPE,
+            },
+            headers=_JSON,
+            timeout=_TIMEOUT,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as exc:
+        logger.exception("github device/poll failed: %s", exc)
+        return JSONResponse(
+            {"status": "error", "error": "poll_failed"}, status_code=502
+        )
+
+    access_token = data.get("access_token")
+    if access_token:
+        scopes = data.get("scope", "")
+        try:
+            user_resp = await http.get(
+                USER_URL,
+                headers={"Accept": "application/json", "Authorization": f"Bearer {access_token}"},
+                timeout=_TIMEOUT,
+            )
+            user_resp.raise_for_status()
+            user = user_resp.json()
+        except Exception as exc:
+            # Do NOT log the token. Only log that the user lookup failed.
+            logger.exception("github user lookup after device flow failed: %s", exc)
+            return JSONResponse(
+                {"status": "error", "error": "user_lookup_failed"}, status_code=502
+            )
+
+        store = _identities_store(request)
+        if store is None:
+            logger.error("github_identities store not configured")
+            return JSONResponse(
+                {"status": "error", "error": "store_unavailable"}, status_code=500
+            )
+
+        identity = await store.add(
+            login=user.get("login", ""),
+            avatar_url=user.get("avatar_url", ""),
+            token=access_token,
+            scopes=scopes,
+        )
+        return {"status": "connected", "identity": identity}
+
+    error = data.get("error", "")
+    if error in _PENDING_ERRORS:
+        return {"status": "pending"}
+    if error in _TERMINAL_ERRORS:
+        return {"status": "error", "error": error}
+    # Unknown error shape — surface generically without leaking detail.
+    return {"status": "error", "error": error or "unknown"}
+
+
+# ---------------------------------------------------------------------------
+# Identities: list / delete (NO tokens ever returned)
+# ---------------------------------------------------------------------------
+
+@router.get("/api/github/identities")
+async def list_identities(request: Request):
+    store = _identities_store(request)
+    if store is None:
+        return []
+    return await store.list()
+
+
+@router.delete("/api/github/identities/{identity_id}")
+async def delete_identity(request: Request, identity_id: str):
+    # Validate the path param is a UUID before touching the store.
+    try:
+        uuid.UUID(identity_id)
+    except ValueError:
+        return JSONResponse({"error": "Invalid identity id"}, status_code=400)
+
+    store = _identities_store(request)
+    if store is None:
+        return JSONResponse({"error": "Store unavailable"}, status_code=500)
+    deleted = await store.delete(identity_id)
+    if not deleted:
+        return JSONResponse({"error": "Identity not found"}, status_code=404)
+    return {"status": "deleted"}

--- a/tinyagentos/routes/github_oauth.py
+++ b/tinyagentos/routes/github_oauth.py
@@ -162,6 +162,10 @@ async def device_poll(request: Request, body: DevicePollBody):
         return {"status": "connected", "identity": identity}
 
     error = data.get("error", "")
+    if error == "slow_down":
+        # RFC 8628 §3.5: the client must back off. Signal the frontend to add
+        # to its poll interval.
+        return {"status": "pending", "slow_down": True}
     if error in _PENDING_ERRORS:
         return {"status": "pending"}
     if error in _TERMINAL_ERRORS:


### PR DESCRIPTION
Phase 1 of GitHub agent support (#858): the "Connect GitHub" flow via OAuth **Device Flow**. Per the spec; I reviewed the security-critical paths.

## What
- **Device Flow** (no client secret on instances): `POST /api/github/oauth/device/start` + `/poll` (single poll per call, frontend drives the loop on `interval`). Public Client ID via `GITHUB_OAUTH_CLIENT_ID` (default the taOS app id), in `github_oauth.py`.
- **Encrypted identity store** (`github_identities.py`): reuses the existing secrets Fernet helper + `.secrets_key`. Multiple identities supported.
- **Endpoints**: device start/poll, `GET /api/github/identities` (id/login/avatar only), `DELETE /api/github/identities/{id}` (UUID-validated).
- **Secrets app UI** (`GitHubConnect.tsx`): Connect button -> large monospace `user_code` + copy + "Open github.com/login/device", polls until connected with a waiting state; lists connected identities (avatar + login) with remove. Shell tokens (dark + light), `withCsrf`, cancellable polling.

## Security (reviewed)
- Tokens **encrypted at rest** (existing Fernet, shared key); **never logged** (explicit in the poll/user paths); **never returned** by any endpoint (`list` selects only id/login/avatar/created_at).
- No client secret anywhere (device flow). Routes inherit the global Auth + CSRF middleware.
- `app.state.http_client` (10s timeouts); UUID validation on delete.

## Verified
- `pytest tests/test_github_oauth.py` -> 11 passed (device start, poll pending/slow_down/connected/expired, token-not-in-JSON, encrypted-at-rest, delete 400/404).
- tsc + build green.

Next phases (#858): time-scoped sharing + consent picker, agent access-request + runtime token injection, then the fork->PR ops.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * GitHub account connection functionality now available in the Secrets app with a dedicated connection interface
  * Securely connect GitHub accounts using a streamlined device-code authentication flow
  * View all linked GitHub identities with profile avatars and connection dates
  * Manage connections by adding new GitHub accounts or removing previous ones as needed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->