### PR TITLE
fix(theme): repaint backdrop-filter layers on theme switch (Safari blacked-out elements)

### DIFF
--- a/desktop/src/stores/theme-store.ts
+++ b/desktop/src/stores/theme-store.ts
@@ -146,6 +146,24 @@ function schemeFromBg(bg: string | undefined): "light" | "dark" {
   return luminance > 0.55 ? "light" : "dark";
 }
 
+// Safari/WebKit leaves backdrop-filter elements (dock, top bar, modals,
+// widgets) on stale GPU compositing layers when the theme custom properties
+// on :root change at runtime: the layer keeps its old raster until something
+// forces a re-composite (scroll, resize, screenshot), so on a theme switch it
+// can flash black on the live screen even though screenshots look correct
+// (the screenshot path forces a full raster). Dropping backdrop-filter for a
+// frame via [data-theme-switching] (see tokens.css) forces WebKit to rebuild
+// every backdrop layer against the new tokens. No-op outside the browser.
+function forceCompositingRepaint() {
+  if (typeof document === "undefined" || typeof requestAnimationFrame === "undefined") return;
+  const root = document.documentElement;
+  root.setAttribute("data-theme-switching", "");
+  void root.offsetHeight; // flush the filter:none state before restoring it
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => root.removeAttribute("data-theme-switching"));
+  });
+}
+
 export function applyThemeConfig(cfg: ThemeConfig) {
   revertTheme();
   const root = document.documentElement;
@@ -157,6 +175,7 @@ export function applyThemeConfig(cfg: ThemeConfig) {
   }
   root.dataset.scheme = schemeFromBg(cfg.tokens?.["--color-shell-bg"]);
   useThemeStore.setState({ structure: cfg.structure || {}, effects: cfg.effects || [] });
+  forceCompositingRepaint();
 }
 
 export function revertTheme() {
@@ -165,6 +184,7 @@ export function revertTheme() {
   _applied = [];
   root.dataset.scheme = "dark"; // base shell is dark
   useThemeStore.setState({ structure: {}, effects: [] });
+  forceCompositingRepaint();
 }
 
 export function setWallpaperForActiveTheme(value: string) {

--- a/desktop/src/stores/theme-store.ts
+++ b/desktop/src/stores/theme-store.ts
@@ -155,17 +155,23 @@ function schemeFromBg(bg: string | undefined): "light" | "dark" {
 // frame via [data-theme-switching] (see tokens.css) forces WebKit to rebuild
 // every backdrop layer against the new tokens. No-op outside the browser.
 function forceCompositingRepaint() {
-  if (typeof document === "undefined" || typeof requestAnimationFrame === "undefined") return;
+  if (typeof document === "undefined") return;
   const root = document.documentElement;
   root.setAttribute("data-theme-switching", "");
   void root.offsetHeight; // flush the filter:none state before restoring it
-  requestAnimationFrame(() => {
-    requestAnimationFrame(() => root.removeAttribute("data-theme-switching"));
-  });
+  const clear = () => root.removeAttribute("data-theme-switching");
+  // Two nested rAFs let one frame paint with the filter off before restoring it.
+  if (typeof requestAnimationFrame === "function") {
+    requestAnimationFrame(() => requestAnimationFrame(clear));
+  }
+  // rAF is paused on a hidden/background tab, which would otherwise leave the
+  // attribute (and the backdrop-filter:none rule) stuck until the tab is shown.
+  // A timer guarantees cleanup regardless; removeAttribute is idempotent.
+  setTimeout(clear, 250);
 }
 
 export function applyThemeConfig(cfg: ThemeConfig) {
-  revertTheme();
+  revertTheme({ silent: true }); // applyThemeConfig owns the single repaint below
   const root = document.documentElement;
   for (const [k, v] of Object.entries(cfg.tokens || {})) {
     if (ALLOWED_TOKENS.has(k) && typeof v === "string") {
@@ -178,13 +184,15 @@ export function applyThemeConfig(cfg: ThemeConfig) {
   forceCompositingRepaint();
 }
 
-export function revertTheme() {
+export function revertTheme(opts?: { silent?: boolean }) {
   const root = document.documentElement;
   for (const k of _applied) root.style.removeProperty(k);
   _applied = [];
   root.dataset.scheme = "dark"; // base shell is dark
   useThemeStore.setState({ structure: {}, effects: [] });
-  forceCompositingRepaint();
+  // Skip when called from applyThemeConfig (which repaints once after applying
+  // the new tokens) so a theme switch does not force two reflows.
+  if (!opts?.silent) forceCompositingRepaint();
 }
 
 export function setWallpaperForActiveTheme(value: string) {

--- a/desktop/src/theme/tokens.css
+++ b/desktop/src/theme/tokens.css
@@ -97,6 +97,21 @@
 :root[data-scheme="light"] [class~="hover:bg-white/10"]:hover { background-color: rgba(0, 0, 0, 0.07); }
 :root[data-scheme="light"] [class~="hover:bg-white/[0.06]"]:hover { background-color: rgba(0, 0, 0, 0.05); }
 
+/* Safari backdrop-filter repaint guard
+   ====================================
+   WebKit keeps backdrop-filter elements on cached GPU layers and does not
+   re-rasterize them when the theme custom properties on :root change at
+   runtime, so a dark<->light switch can leave the dock, top bar, modals and
+   widgets rendering black on the live screen (screenshots force a full raster
+   and look fine, which masks the bug). theme-store.ts sets
+   [data-theme-switching] for one frame on every theme apply/revert; dropping
+   the filter for that frame forces WebKit to rebuild each layer against the
+   new tokens. Imperceptible (~1 frame) and a no-op in Chrome/Firefox. */
+:root[data-theme-switching] * {
+  -webkit-backdrop-filter: none !important;
+  backdrop-filter: none !important;
+}
+
 /* Wallpaper sizing
    ----------------
    Desktop fills the viewport (cover crops edges if aspect mismatches).


### PR DESCRIPTION
## Problem

Switching to Light mode in Safari leaves some elements (dock, top bar, modals, widgets) rendering **black** on the live screen, even though **screenshots of the same view look correct**.

## Root cause

WebKit keeps every `backdrop-filter` element on its own cached GPU compositing layer. When `applyThemeConfig()` mutates the `--color-*` custom properties on `:root`, Safari invalidates the layer inputs but does **not** re-rasterize the layer until something forces a re-composite (scroll, resize, or a screenshot). So the live layer shows stale/empty content (black), while the screenshot path forces a full raster and looks fine. Chrome/Firefox re-raster eagerly and never showed the bug.

Related WebKit fragility: [WebKit #226532](https://bugs.webkit.org/show_bug.cgi?id=226532) (region won't repaint), [mdn/browser-compat-data #25914](https://github.com/mdn/browser-compat-data/issues/25914) (CSS vars unsupported inside `-webkit-backdrop-filter`).

## Fix

`applyThemeConfig` / `revertTheme` now set `[data-theme-switching]` on `:root` for a single frame. A scoped CSS rule drops `backdrop-filter` while that attribute is present, forcing WebKit to rebuild each backdrop layer against the new tokens, then the attribute is removed on the next animation frame. Imperceptible (~1 frame) and a no-op in Chrome/Firefox.

- `desktop/src/stores/theme-store.ts` — `forceCompositingRepaint()` at the single theme-apply chokepoint.
- `desktop/src/theme/tokens.css` — the one-frame `[data-theme-switching]` filter-off rule.

## Verification

`npx tsc -b` clean; theme-apply tests pass. **This bug is invisible to screenshots (including Playwright/WebKit), so it can only be confirmed by a live Safari load** — needs a manual dark<->light toggle in Safari on next pull.