### PR TITLE
feat(theme): macOS-dark graphite palette + live neural wallpaper (#865)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,4 @@ docs/AGENT_HANDOFF.md
 docs/audit/
 .understand-anything/
 docs/agent-jobs/
+.design/

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useEffect } from "react";
 import { TopBar } from "@/components/TopBar";
 import { Desktop } from "@/components/Desktop";
 import { Dock } from "@/components/Dock";
+import { NeuralWallpaper } from "@/components/NeuralWallpaper";
 import { Launchpad } from "@/components/Launchpad";
 import { SearchPalette } from "@/components/SearchPalette";
 import { ShortcutProvider, useShortcut } from "@/hooks/use-shortcut-registry";
@@ -125,6 +126,9 @@ export function App() {
   const wallpaperImage = useThemeStore((s) => s.wallpaperImage);
   const wallpaperMobileImage = useThemeStore((s) => s.wallpaperMobileImage);
   const wallpaperFallback = useThemeStore((s) => s.wallpaperFallback);
+  const wallpaperKind = useThemeStore((s) => s.wallpaperKind);
+  const showWallpaperWordmark = useThemeStore((s) => s.showWallpaperWordmark);
+  const isNeuralWallpaper = wallpaperKind === "neural";
   const windows = useProcessStore((s) => s.windows);
   const openWindow = useProcessStore((s) => s.openWindow);
   const closeWindow = useProcessStore((s) => s.closeWindow);
@@ -288,11 +292,12 @@ export function App() {
     <ShortcutProvider>
       <SystemShortcuts toggleSearch={toggleSearch} toggleLaunchpad={toggleLaunchpad} toggleAssistant={toggleAssistant} />
       <LoginGate>
-    <div className={`taos-wallpaper h-screen w-screen flex flex-col text-shell-text${isBrowserMobile ? " taos-browser" : ""}`} style={{ backgroundColor: wallpaperFallback, ["--wallpaper-desktop" as never]: wallpaperImage, ["--wallpaper-mobile" as never]: wallpaperMobileImage }}>
+    <div className={`taos-wallpaper relative h-screen w-screen flex flex-col text-shell-text${isBrowserMobile ? " taos-browser" : ""}`} style={{ backgroundColor: wallpaperFallback, ["--wallpaper-desktop" as never]: isNeuralWallpaper ? "none" : wallpaperImage, ["--wallpaper-mobile" as never]: isNeuralWallpaper ? "none" : wallpaperMobileImage }}>
+      {isNeuralWallpaper && <NeuralWallpaper wordmark={showWallpaperWordmark} />}
       <EffectsLayer />
       {/* Install banner — shown in browser mode, hidden in PWA */}
       {isBrowserMobile && <InstallPromptBanner />}
-      <div className={`flex-1 flex flex-col overflow-hidden transition-all duration-500 ${launched ? "opacity-100 scale-100" : "opacity-0 scale-95"}`}>
+      <div className={`relative z-[1] flex-1 flex flex-col overflow-hidden transition-all duration-500 ${launched ? "opacity-100 scale-100" : "opacity-0 scale-95"}`}>
         <MobileTopBar
           onHome={handleMobileHome}
           onSearch={() => { setCardSwitcherOpen(false); setSearchOpen((v) => !v); }}

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -3,6 +3,7 @@ import { TopBar } from "@/components/TopBar";
 import { Desktop } from "@/components/Desktop";
 import { Dock } from "@/components/Dock";
 import { NeuralWallpaper } from "@/components/NeuralWallpaper";
+import { WallpaperTextOverlay } from "@/components/WallpaperTextOverlay";
 import { Launchpad } from "@/components/Launchpad";
 import { SearchPalette } from "@/components/SearchPalette";
 import { ShortcutProvider, useShortcut } from "@/hooks/use-shortcut-registry";
@@ -127,8 +128,10 @@ export function App() {
   const wallpaperMobileImage = useThemeStore((s) => s.wallpaperMobileImage);
   const wallpaperFallback = useThemeStore((s) => s.wallpaperFallback);
   const wallpaperKind = useThemeStore((s) => s.wallpaperKind);
-  const showWallpaperWordmark = useThemeStore((s) => s.showWallpaperWordmark);
-  const isNeuralWallpaper = wallpaperKind === "neural";
+  const wallpaperComponent = useThemeStore((s) => s.wallpaperComponent);
+  const wallpaperOverlayText = useThemeStore((s) => s.wallpaperOverlayText);
+  const showOverlayText = useThemeStore((s) => s.showOverlayText);
+  const isAnimatedWallpaper = wallpaperKind === "animated";
   const windows = useProcessStore((s) => s.windows);
   const openWindow = useProcessStore((s) => s.openWindow);
   const closeWindow = useProcessStore((s) => s.closeWindow);
@@ -292,8 +295,9 @@ export function App() {
     <ShortcutProvider>
       <SystemShortcuts toggleSearch={toggleSearch} toggleLaunchpad={toggleLaunchpad} toggleAssistant={toggleAssistant} />
       <LoginGate>
-    <div className={`taos-wallpaper relative h-screen w-screen flex flex-col text-shell-text${isBrowserMobile ? " taos-browser" : ""}`} style={{ backgroundColor: wallpaperFallback, ["--wallpaper-desktop" as never]: isNeuralWallpaper ? "none" : wallpaperImage, ["--wallpaper-mobile" as never]: isNeuralWallpaper ? "none" : wallpaperMobileImage }}>
-      {isNeuralWallpaper && <NeuralWallpaper wordmark={showWallpaperWordmark} />}
+    <div className={`taos-wallpaper relative h-screen w-screen flex flex-col text-shell-text${isBrowserMobile ? " taos-browser" : ""}`} style={{ backgroundColor: wallpaperFallback, ["--wallpaper-desktop" as never]: isAnimatedWallpaper ? "none" : wallpaperImage, ["--wallpaper-mobile" as never]: isAnimatedWallpaper ? "none" : wallpaperMobileImage }}>
+      {isAnimatedWallpaper && wallpaperComponent === "neural" && <NeuralWallpaper />}
+      {showOverlayText && wallpaperOverlayText && <WallpaperTextOverlay text={wallpaperOverlayText} />}
       <EffectsLayer />
       {/* Install banner — shown in browser mode, hidden in PWA */}
       {isBrowserMobile && <InstallPromptBanner />}

--- a/desktop/src/components/Desktop.tsx
+++ b/desktop/src/components/Desktop.tsx
@@ -11,6 +11,7 @@ import { SnapOverlay } from "./SnapOverlay";
 import { WidgetLayer } from "./WidgetLayer";
 import { ContextMenu, type MenuItem } from "./ContextMenu";
 import { WallpaperPicker } from "./WallpaperPicker";
+import { NeuralWallpaper } from "./NeuralWallpaper";
 
 type ContextMenuState = {
   x: number;
@@ -23,6 +24,9 @@ export function Desktop() {
   const wallpaperImage = useThemeStore((s) => s.wallpaperImage);
   const wallpaperMobileImage = useThemeStore((s) => s.wallpaperMobileImage);
   const wallpaperFallback = useThemeStore((s) => s.wallpaperFallback);
+  const wallpaperKind = useThemeStore((s) => s.wallpaperKind);
+  const showWallpaperWordmark = useThemeStore((s) => s.showWallpaperWordmark);
+  const isNeural = wallpaperKind === "neural";
   const { showWidgets, toggleWidgets } = useWidgetStore();
   const [contextMenu, setContextMenu] = useState<ContextMenuState>(null);
   const [wallpaperPickerOpen, setWallpaperPickerOpen] = useState(false);
@@ -115,10 +119,11 @@ export function Desktop() {
   return (
     <div
       className="taos-wallpaper relative flex-1 overflow-hidden"
-      style={{ backgroundColor: wallpaperFallback, ["--wallpaper-desktop" as never]: wallpaperImage, ["--wallpaper-mobile" as never]: wallpaperMobileImage }}
+      style={{ backgroundColor: wallpaperFallback, ["--wallpaper-desktop" as never]: isNeural ? "none" : wallpaperImage, ["--wallpaper-mobile" as never]: isNeural ? "none" : wallpaperMobileImage }}
       onContextMenu={handleContextMenu}
       data-desktop-surface
     >
+      {isNeural && <NeuralWallpaper wordmark={showWallpaperWordmark} />}
       <SnapOverlay bounds={previewBounds} />
       <WidgetLayer />
       {windows.map((win) => (

--- a/desktop/src/components/Desktop.tsx
+++ b/desktop/src/components/Desktop.tsx
@@ -12,6 +12,7 @@ import { WidgetLayer } from "./WidgetLayer";
 import { ContextMenu, type MenuItem } from "./ContextMenu";
 import { WallpaperPicker } from "./WallpaperPicker";
 import { NeuralWallpaper } from "./NeuralWallpaper";
+import { WallpaperTextOverlay } from "./WallpaperTextOverlay";
 
 type ContextMenuState = {
   x: number;
@@ -25,8 +26,10 @@ export function Desktop() {
   const wallpaperMobileImage = useThemeStore((s) => s.wallpaperMobileImage);
   const wallpaperFallback = useThemeStore((s) => s.wallpaperFallback);
   const wallpaperKind = useThemeStore((s) => s.wallpaperKind);
-  const showWallpaperWordmark = useThemeStore((s) => s.showWallpaperWordmark);
-  const isNeural = wallpaperKind === "neural";
+  const wallpaperComponent = useThemeStore((s) => s.wallpaperComponent);
+  const wallpaperOverlayText = useThemeStore((s) => s.wallpaperOverlayText);
+  const showOverlayText = useThemeStore((s) => s.showOverlayText);
+  const isAnimated = wallpaperKind === "animated";
   const { showWidgets, toggleWidgets } = useWidgetStore();
   const [contextMenu, setContextMenu] = useState<ContextMenuState>(null);
   const [wallpaperPickerOpen, setWallpaperPickerOpen] = useState(false);
@@ -119,11 +122,12 @@ export function Desktop() {
   return (
     <div
       className="taos-wallpaper relative flex-1 overflow-hidden"
-      style={{ backgroundColor: wallpaperFallback, ["--wallpaper-desktop" as never]: isNeural ? "none" : wallpaperImage, ["--wallpaper-mobile" as never]: isNeural ? "none" : wallpaperMobileImage }}
+      style={{ backgroundColor: wallpaperFallback, ["--wallpaper-desktop" as never]: isAnimated ? "none" : wallpaperImage, ["--wallpaper-mobile" as never]: isAnimated ? "none" : wallpaperMobileImage }}
       onContextMenu={handleContextMenu}
       data-desktop-surface
     >
-      {isNeural && <NeuralWallpaper wordmark={showWallpaperWordmark} />}
+      {isAnimated && wallpaperComponent === "neural" && <NeuralWallpaper />}
+      {showOverlayText && wallpaperOverlayText && <WallpaperTextOverlay text={wallpaperOverlayText} />}
       <SnapOverlay bounds={previewBounds} />
       <WidgetLayer />
       {windows.map((win) => (

--- a/desktop/src/components/NeuralWallpaper.tsx
+++ b/desktop/src/components/NeuralWallpaper.tsx
@@ -47,7 +47,14 @@ export function NeuralWallpaper() {
     let raf = 0;
     let running = false;
 
-    const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    // Gradients depend only on w/h, so they are built once per resize in build()
+    // and reused every frame rather than reallocated ~180x/sec (Pi GC churn).
+    let bgGrad: CanvasGradient | null = null;
+    let glowGrad: CanvasGradient | null = null;
+    let vignetteGrad: CanvasGradient | null = null;
+
+    const motionQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    let reduceMotion = motionQuery.matches;
 
     function build() {
       const rect = canvas!.getBoundingClientRect();
@@ -56,6 +63,19 @@ export function NeuralWallpaper() {
       canvas!.width = Math.round(w * dpr);
       canvas!.height = Math.round(h * dpr);
       ctx!.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+      bgGrad = ctx!.createLinearGradient(0, 0, w, h);
+      bgGrad.addColorStop(0, "#26262a");
+      bgGrad.addColorStop(0.42, "#1d1d1f");
+      bgGrad.addColorStop(1, "#101011");
+      glowGrad = ctx!.createRadialGradient(w * 0.5, h * 0.46, 0, w * 0.5, h * 0.46, Math.max(w, h) * 0.6);
+      glowGrad.addColorStop(0, "rgba(255,255,255,0.06)");
+      glowGrad.addColorStop(0.5, "rgba(255,255,255,0.015)");
+      glowGrad.addColorStop(1, "rgba(255,255,255,0)");
+      vignetteGrad = ctx!.createRadialGradient(w * 0.5, h * 0.48, Math.min(w, h) * 0.3, w * 0.5, h * 0.48, Math.max(w, h) * 0.75);
+      vignetteGrad.addColorStop(0, "rgba(0,0,0,0)");
+      vignetteGrad.addColorStop(1, "rgba(0,0,0,0.42)");
+
       const count = Math.max(40, Math.min(260, Math.round((w * h) / 14000)));
       nodes = Array.from({ length: count }, () => ({
         x: Math.random() * w,
@@ -69,27 +89,20 @@ export function NeuralWallpaper() {
     }
 
     function background() {
-      const g = ctx!.createLinearGradient(0, 0, w, h);
-      g.addColorStop(0, "#26262a");
-      g.addColorStop(0.42, "#1d1d1f");
-      g.addColorStop(1, "#101011");
-      ctx!.fillStyle = g;
+      ctx!.fillStyle = bgGrad!;
       ctx!.fillRect(0, 0, w, h);
-      const rg = ctx!.createRadialGradient(w * 0.5, h * 0.46, 0, w * 0.5, h * 0.46, Math.max(w, h) * 0.6);
-      rg.addColorStop(0, "rgba(255,255,255,0.06)");
-      rg.addColorStop(0.5, "rgba(255,255,255,0.015)");
-      rg.addColorStop(1, "rgba(255,255,255,0)");
-      ctx!.fillStyle = rg;
+      ctx!.fillStyle = glowGrad!;
       ctx!.fillRect(0, 0, w, h);
     }
 
     function vignette() {
-      const vg = ctx!.createRadialGradient(w * 0.5, h * 0.48, Math.min(w, h) * 0.3, w * 0.5, h * 0.48, Math.max(w, h) * 0.75);
-      vg.addColorStop(0, "rgba(0,0,0,0)");
-      vg.addColorStop(1, "rgba(0,0,0,0.42)");
-      ctx!.fillStyle = vg;
+      ctx!.fillStyle = vignetteGrad!;
       ctx!.fillRect(0, 0, w, h);
     }
+
+    const LINK_RGB = `rgb(${LINK})`;
+    const NODE_RGB = `rgb(${NODE})`;
+    const ACCENT_RGB = `rgb(${ACCENT})`;
 
     function frame(t: number) {
       background();
@@ -101,6 +114,10 @@ export function NeuralWallpaper() {
         if (n.y < -20) n.y = h + 20;
         else if (n.y > h + 20) n.y = -20;
       }
+      // Links: one fixed strokeStyle, per-pair opacity via globalAlpha (no
+      // per-pair rgba string allocation in this O(n^2) hot loop).
+      ctx!.strokeStyle = LINK_RGB;
+      ctx!.lineWidth = 0.7;
       for (let i = 0; i < nodes.length; i++) {
         const a = nodes[i]!;
         for (let j = i + 1; j < nodes.length; j++) {
@@ -109,9 +126,7 @@ export function NeuralWallpaper() {
           const dy = a.y - b.y;
           const d2 = dx * dx + dy * dy;
           if (d2 < LINK_DIST * LINK_DIST) {
-            const o = (1 - Math.sqrt(d2) / LINK_DIST) * 0.5;
-            ctx!.strokeStyle = `rgba(${LINK},${o.toFixed(3)})`;
-            ctx!.lineWidth = 0.7;
+            ctx!.globalAlpha = (1 - Math.sqrt(d2) / LINK_DIST) * 0.5;
             ctx!.beginPath();
             ctx!.moveTo(a.x, a.y);
             ctx!.lineTo(b.x, b.y);
@@ -119,20 +134,24 @@ export function NeuralWallpaper() {
           }
         }
       }
+      ctx!.globalAlpha = 1;
       for (const n of nodes) {
         const tw = 0.6 + 0.4 * Math.sin(t * 0.0014 + n.tw);
         if (n.active) {
-          ctx!.fillStyle = `rgba(${ACCENT},${(0.85 * tw).toFixed(3)})`;
+          ctx!.fillStyle = ACCENT_RGB;
+          ctx!.globalAlpha = 0.85 * tw;
           ctx!.shadowColor = `rgba(${ACCENT},0.7)`;
           ctx!.shadowBlur = 8;
         } else {
-          ctx!.fillStyle = `rgba(${NODE},${(0.6 * tw).toFixed(3)})`;
+          ctx!.fillStyle = NODE_RGB;
+          ctx!.globalAlpha = 0.6 * tw;
           ctx!.shadowBlur = 0;
         }
         ctx!.beginPath();
         ctx!.arc(n.x, n.y, n.r, 0, Math.PI * 2);
         ctx!.fill();
       }
+      ctx!.globalAlpha = 1;
       ctx!.shadowBlur = 0;
       vignette();
       raf = requestAnimationFrame(frame);
@@ -140,15 +159,21 @@ export function NeuralWallpaper() {
 
     function staticFrame() {
       background();
+      ctx!.fillStyle = NODE_RGB;
+      ctx!.globalAlpha = 0.6;
       for (const n of nodes) {
-        ctx!.fillStyle = `rgba(${NODE},0.6)`;
         ctx!.beginPath();
         ctx!.arc(n.x, n.y, n.r, 0, Math.PI * 2);
         ctx!.fill();
       }
+      ctx!.globalAlpha = 1;
       vignette();
     }
 
+    function render() {
+      if (reduceMotion) staticFrame();
+      else start();
+    }
     function start() {
       if (running || reduceMotion) return;
       running = true;
@@ -160,8 +185,7 @@ export function NeuralWallpaper() {
     }
 
     build();
-    if (reduceMotion) staticFrame();
-    else start();
+    render();
 
     const ro = new ResizeObserver(() => {
       stop();
@@ -177,10 +201,20 @@ export function NeuralWallpaper() {
     };
     document.addEventListener("visibilitychange", onVisibility);
 
+    // React to the OS reduced-motion setting changing mid-session.
+    const onMotionChange = () => {
+      reduceMotion = motionQuery.matches;
+      stop();
+      if (reduceMotion) staticFrame();
+      else if (!document.hidden) start();
+    };
+    motionQuery.addEventListener("change", onMotionChange);
+
     return () => {
       stop();
       ro.disconnect();
       document.removeEventListener("visibilitychange", onVisibility);
+      motionQuery.removeEventListener("change", onMotionChange);
     };
   }, []);
 

--- a/desktop/src/components/NeuralWallpaper.tsx
+++ b/desktop/src/components/NeuralWallpaper.tsx
@@ -1,0 +1,202 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Live "neural" wallpaper — an adaptive canvas of drifting nodes and proximity
+ * links over a graphite field, inspired by the original taOS neural wallpaper
+ * but calmed to a neutral macOS-dark palette. Renders at native resolution for
+ * any aspect ratio (16:10, ultrawide 32:10, mobile portrait) from one source,
+ * so no per-resolution image assets are needed.
+ *
+ * Perf: density scales with viewport area, the loop pauses while the tab/app is
+ * hidden, and prefers-reduced-motion renders a single static frame. The canvas
+ * fills its (positioned) parent via ResizeObserver.
+ */
+
+const NODE = "236,237,240"; // soft silver
+const LINK = "150,156,170"; // cool graphite
+const ACCENT = "174,180,196"; // faint highlight on "active" nodes
+const LINK_DIST = 150;
+
+interface Node {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  r: number;
+  active: boolean;
+  tw: number;
+}
+
+export function NeuralWallpaper({ wordmark = true }: { wordmark?: boolean }) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const dpr = Math.min(window.devicePixelRatio || 1, 2);
+    let w = 0;
+    let h = 0;
+    let nodes: Node[] = [];
+    let raf = 0;
+    let running = false;
+
+    const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+    function build() {
+      const rect = canvas!.getBoundingClientRect();
+      w = Math.max(1, Math.round(rect.width));
+      h = Math.max(1, Math.round(rect.height));
+      canvas!.width = Math.round(w * dpr);
+      canvas!.height = Math.round(h * dpr);
+      ctx!.setTransform(dpr, 0, 0, dpr, 0, 0);
+      const count = Math.max(40, Math.min(260, Math.round((w * h) / 14000)));
+      nodes = Array.from({ length: count }, () => ({
+        x: Math.random() * w,
+        y: Math.random() * h,
+        vx: (Math.random() - 0.5) * 0.22,
+        vy: (Math.random() - 0.5) * 0.22,
+        r: Math.random() * 1.4 + 0.7,
+        active: Math.random() < 0.16,
+        tw: Math.random() * Math.PI * 2,
+      }));
+    }
+
+    function background() {
+      const g = ctx!.createLinearGradient(0, 0, w, h);
+      g.addColorStop(0, "#26262a");
+      g.addColorStop(0.42, "#1d1d1f");
+      g.addColorStop(1, "#101011");
+      ctx!.fillStyle = g;
+      ctx!.fillRect(0, 0, w, h);
+      const rg = ctx!.createRadialGradient(w * 0.5, h * 0.46, 0, w * 0.5, h * 0.46, Math.max(w, h) * 0.6);
+      rg.addColorStop(0, "rgba(255,255,255,0.06)");
+      rg.addColorStop(0.5, "rgba(255,255,255,0.015)");
+      rg.addColorStop(1, "rgba(255,255,255,0)");
+      ctx!.fillStyle = rg;
+      ctx!.fillRect(0, 0, w, h);
+    }
+
+    function vignette() {
+      const vg = ctx!.createRadialGradient(w * 0.5, h * 0.48, Math.min(w, h) * 0.3, w * 0.5, h * 0.48, Math.max(w, h) * 0.75);
+      vg.addColorStop(0, "rgba(0,0,0,0)");
+      vg.addColorStop(1, "rgba(0,0,0,0.42)");
+      ctx!.fillStyle = vg;
+      ctx!.fillRect(0, 0, w, h);
+    }
+
+    function frame(t: number) {
+      background();
+      for (const n of nodes) {
+        n.x += n.vx;
+        n.y += n.vy;
+        if (n.x < -20) n.x = w + 20;
+        else if (n.x > w + 20) n.x = -20;
+        if (n.y < -20) n.y = h + 20;
+        else if (n.y > h + 20) n.y = -20;
+      }
+      for (let i = 0; i < nodes.length; i++) {
+        const a = nodes[i]!;
+        for (let j = i + 1; j < nodes.length; j++) {
+          const b = nodes[j]!;
+          const dx = a.x - b.x;
+          const dy = a.y - b.y;
+          const d2 = dx * dx + dy * dy;
+          if (d2 < LINK_DIST * LINK_DIST) {
+            const o = (1 - Math.sqrt(d2) / LINK_DIST) * 0.5;
+            ctx!.strokeStyle = `rgba(${LINK},${o.toFixed(3)})`;
+            ctx!.lineWidth = 0.7;
+            ctx!.beginPath();
+            ctx!.moveTo(a.x, a.y);
+            ctx!.lineTo(b.x, b.y);
+            ctx!.stroke();
+          }
+        }
+      }
+      for (const n of nodes) {
+        const tw = 0.6 + 0.4 * Math.sin(t * 0.0014 + n.tw);
+        if (n.active) {
+          ctx!.fillStyle = `rgba(${ACCENT},${(0.85 * tw).toFixed(3)})`;
+          ctx!.shadowColor = `rgba(${ACCENT},0.7)`;
+          ctx!.shadowBlur = 8;
+        } else {
+          ctx!.fillStyle = `rgba(${NODE},${(0.6 * tw).toFixed(3)})`;
+          ctx!.shadowBlur = 0;
+        }
+        ctx!.beginPath();
+        ctx!.arc(n.x, n.y, n.r, 0, Math.PI * 2);
+        ctx!.fill();
+      }
+      ctx!.shadowBlur = 0;
+      vignette();
+      raf = requestAnimationFrame(frame);
+    }
+
+    function staticFrame() {
+      background();
+      for (const n of nodes) {
+        ctx!.fillStyle = `rgba(${NODE},0.6)`;
+        ctx!.beginPath();
+        ctx!.arc(n.x, n.y, n.r, 0, Math.PI * 2);
+        ctx!.fill();
+      }
+      vignette();
+    }
+
+    function start() {
+      if (running || reduceMotion) return;
+      running = true;
+      raf = requestAnimationFrame(frame);
+    }
+    function stop() {
+      running = false;
+      cancelAnimationFrame(raf);
+    }
+
+    build();
+    if (reduceMotion) staticFrame();
+    else start();
+
+    const ro = new ResizeObserver(() => {
+      stop();
+      build();
+      if (reduceMotion) staticFrame();
+      else if (!document.hidden) start();
+    });
+    ro.observe(canvas);
+
+    const onVisibility = () => {
+      if (document.hidden) stop();
+      else start();
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+
+    return () => {
+      stop();
+      ro.disconnect();
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, []);
+
+  return (
+    <div className="absolute inset-0 z-0 overflow-hidden" aria-hidden="true">
+      <canvas ref={canvasRef} className="absolute inset-0 h-full w-full" />
+      {wordmark && (
+        <div className="pointer-events-none absolute inset-0 grid place-items-center">
+          <span
+            className="font-semibold tracking-tight"
+            style={{
+              fontSize: "clamp(64px, 11vmin, 240px)",
+              color: "rgba(236,236,238,0.96)",
+              textShadow: "0 0 40px rgba(180,186,200,0.25), 0 2px 30px rgba(0,0,0,0.4)",
+            }}
+          >
+            taOS
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/desktop/src/components/NeuralWallpaper.tsx
+++ b/desktop/src/components/NeuralWallpaper.tsx
@@ -1,11 +1,15 @@
 import { useEffect, useRef } from "react";
 
 /**
- * Live "neural" wallpaper — an adaptive canvas of drifting nodes and proximity
- * links over a graphite field, inspired by the original taOS neural wallpaper
- * but calmed to a neutral macOS-dark palette. Renders at native resolution for
- * any aspect ratio (16:10, ultrawide 32:10, mobile portrait) from one source,
- * so no per-resolution image assets are needed.
+ * "neural" animated wallpaper renderer — an adaptive canvas of drifting nodes
+ * and proximity links over a graphite field, inspired by the original taOS
+ * neural wallpaper but calmed to a neutral macOS-dark palette. Renders at
+ * native resolution for any aspect ratio (16:10, ultrawide 32:10, mobile
+ * portrait) from one source, so no per-resolution image assets are needed.
+ *
+ * One render component behind the generic animated-wallpaper kind. The optional
+ * slogan is a separate overlay (WallpaperTextOverlay), not part of the
+ * renderer, so it works over any wallpaper.
  *
  * Perf: density scales with viewport area, the loop pauses while the tab/app is
  * hidden, and prefers-reduced-motion renders a single static frame. The canvas
@@ -27,7 +31,7 @@ interface Node {
   tw: number;
 }
 
-export function NeuralWallpaper({ wordmark = true }: { wordmark?: boolean }) {
+export function NeuralWallpaper() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
   useEffect(() => {
@@ -183,20 +187,6 @@ export function NeuralWallpaper({ wordmark = true }: { wordmark?: boolean }) {
   return (
     <div className="absolute inset-0 z-0 overflow-hidden" aria-hidden="true">
       <canvas ref={canvasRef} className="absolute inset-0 h-full w-full" />
-      {wordmark && (
-        <div className="pointer-events-none absolute inset-0 grid place-items-center">
-          <span
-            className="font-semibold tracking-tight"
-            style={{
-              fontSize: "clamp(64px, 11vmin, 240px)",
-              color: "rgba(236,236,238,0.96)",
-              textShadow: "0 0 40px rgba(180,186,200,0.25), 0 2px 30px rgba(0,0,0,0.4)",
-            }}
-          >
-            taOS
-          </span>
-        </div>
-      )}
     </div>
   );
 }

--- a/desktop/src/components/WallpaperPicker.tsx
+++ b/desktop/src/components/WallpaperPicker.tsx
@@ -7,7 +7,7 @@ interface Props {
 }
 
 export function WallpaperPicker({ open, onClose }: Props) {
-  const { wallpaperId, setWallpaper, getWallpapers, wallpaperKind, showWallpaperWordmark, toggleWallpaperWordmark } =
+  const { wallpaperId, setWallpaper, getWallpapers, wallpaperOverlayText, showOverlayText, toggleOverlayText } =
     useThemeStore();
   const wallpapers = getWallpapers();
 
@@ -58,7 +58,7 @@ export function WallpaperPicker({ open, onClose }: Props) {
               <div
                 className="relative h-24 w-full"
                 style={
-                  wp.kind === "neural"
+                  wp.kind === "animated"
                     ? { background: "radial-gradient(120% 120% at 50% 46%, #2a2a2e 0%, #1d1d1f 45%, #101011 100%)" }
                     : {
                         backgroundImage: wp.image,
@@ -69,9 +69,9 @@ export function WallpaperPicker({ open, onClose }: Props) {
                       }
                 }
               >
-                {wp.kind === "neural" && (
+                {wp.overlayText && (
                   <span className="absolute inset-0 grid place-items-center text-[13px] font-semibold tracking-tight text-white/85">
-                    taOS
+                    {wp.overlayText}
                   </span>
                 )}
               </div>
@@ -86,23 +86,23 @@ export function WallpaperPicker({ open, onClose }: Props) {
             </button>
           ))}
         </div>
-        {wallpaperKind === "neural" && (
+        {wallpaperOverlayText && (
           <div className="flex items-center justify-between px-4 py-3 border-t border-shell-border shrink-0">
-            <label htmlFor="wp-wordmark" className="text-xs text-shell-text-secondary">
-              Show taOS wordmark
+            <label htmlFor="wp-slogan" className="text-xs text-shell-text-secondary">
+              Show slogan ({wallpaperOverlayText})
             </label>
             <button
-              id="wp-wordmark"
+              id="wp-slogan"
               role="switch"
-              aria-checked={showWallpaperWordmark}
-              onClick={toggleWallpaperWordmark}
+              aria-checked={showOverlayText}
+              onClick={toggleOverlayText}
               className={`relative h-5 w-9 rounded-full transition-colors ${
-                showWallpaperWordmark ? "bg-accent" : "bg-shell-surface-active"
+                showOverlayText ? "bg-accent" : "bg-shell-surface-active"
               }`}
             >
               <span
                 className={`absolute top-0.5 h-4 w-4 rounded-full bg-white transition-transform ${
-                  showWallpaperWordmark ? "translate-x-4" : "translate-x-0.5"
+                  showOverlayText ? "translate-x-4" : "translate-x-0.5"
                 }`}
               />
             </button>

--- a/desktop/src/components/WallpaperPicker.tsx
+++ b/desktop/src/components/WallpaperPicker.tsx
@@ -7,7 +7,8 @@ interface Props {
 }
 
 export function WallpaperPicker({ open, onClose }: Props) {
-  const { wallpaperId, setWallpaper, getWallpapers } = useThemeStore();
+  const { wallpaperId, setWallpaper, getWallpapers, wallpaperKind, showWallpaperWordmark, toggleWallpaperWordmark } =
+    useThemeStore();
   const wallpapers = getWallpapers();
 
   if (!open) return null;
@@ -26,7 +27,7 @@ export function WallpaperPicker({ open, onClose }: Props) {
         aria-modal="true"
         aria-label="Change Wallpaper"
         className="w-full max-w-[500px] max-h-full flex flex-col rounded-xl border border-shell-border-strong overflow-hidden"
-        style={{ backgroundColor: "rgba(26, 27, 46, 0.98)" }}
+        style={{ backgroundColor: "rgba(29, 29, 31, 0.98)" }}
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between px-4 py-3 border-b border-shell-border shrink-0">
@@ -55,15 +56,25 @@ export function WallpaperPicker({ open, onClose }: Props) {
               }`}
             >
               <div
-                className="h-24 w-full"
-                style={{
-                  backgroundImage: wp.image,
-                  backgroundColor: wp.fallback,
-                  backgroundSize: "cover",
-                  backgroundPosition: "center",
-                  backgroundRepeat: "no-repeat",
-                }}
-              />
+                className="relative h-24 w-full"
+                style={
+                  wp.kind === "neural"
+                    ? { background: "radial-gradient(120% 120% at 50% 46%, #2a2a2e 0%, #1d1d1f 45%, #101011 100%)" }
+                    : {
+                        backgroundImage: wp.image,
+                        backgroundColor: wp.fallback,
+                        backgroundSize: "cover",
+                        backgroundPosition: "center",
+                        backgroundRepeat: "no-repeat",
+                      }
+                }
+              >
+                {wp.kind === "neural" && (
+                  <span className="absolute inset-0 grid place-items-center text-[13px] font-semibold tracking-tight text-white/85">
+                    taOS
+                  </span>
+                )}
+              </div>
               <div className="px-2 py-1.5 text-xs text-shell-text-secondary text-left">
                 {wp.label}
               </div>
@@ -75,6 +86,28 @@ export function WallpaperPicker({ open, onClose }: Props) {
             </button>
           ))}
         </div>
+        {wallpaperKind === "neural" && (
+          <div className="flex items-center justify-between px-4 py-3 border-t border-shell-border shrink-0">
+            <label htmlFor="wp-wordmark" className="text-xs text-shell-text-secondary">
+              Show taOS wordmark
+            </label>
+            <button
+              id="wp-wordmark"
+              role="switch"
+              aria-checked={showWallpaperWordmark}
+              onClick={toggleWallpaperWordmark}
+              className={`relative h-5 w-9 rounded-full transition-colors ${
+                showWallpaperWordmark ? "bg-accent" : "bg-shell-surface-active"
+              }`}
+            >
+              <span
+                className={`absolute top-0.5 h-4 w-4 rounded-full bg-white transition-transform ${
+                  showWallpaperWordmark ? "translate-x-4" : "translate-x-0.5"
+                }`}
+              />
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/desktop/src/components/WallpaperTextOverlay.tsx
+++ b/desktop/src/components/WallpaperTextOverlay.tsx
@@ -1,0 +1,23 @@
+/**
+ * Generic wallpaper slogan overlay — centered text drawn above any wallpaper
+ * (animated or image). The text content and whether it shows are driven by the
+ * active wallpaper/theme and a user toggle; this component owns only the
+ * presentation. Colour / size / style / effects use sensible defaults for now
+ * and are intended to become configurable (per wallpaper/theme) in a follow-up.
+ */
+export function WallpaperTextOverlay({ text }: { text: string }) {
+  return (
+    <div className="pointer-events-none absolute inset-0 z-0 grid place-items-center" aria-hidden="true">
+      <span
+        className="font-semibold tracking-tight"
+        style={{
+          fontSize: "clamp(64px, 11vmin, 240px)",
+          color: "rgba(236,236,238,0.96)",
+          textShadow: "0 0 40px rgba(180,186,200,0.25), 0 2px 30px rgba(0,0,0,0.4)",
+        }}
+      >
+        {text}
+      </span>
+    </div>
+  );
+}

--- a/desktop/src/stores/theme-store.ts
+++ b/desktop/src/stores/theme-store.ts
@@ -11,25 +11,34 @@ import { BUILTIN_THEMES } from "@/theme/builtin-themes";
 interface Wallpaper {
   id: string;
   label: string;
-  image: string; // desktop background-image (empty for live wallpapers)
+  image: string; // desktop background-image (empty for animated wallpapers)
   mobileImage?: string; // portrait-cropped variant, falls back to `image` if absent
   fallback: string; // background-color used as a fallback colour behind the image
-  // "image" = CSS background (url/gradient); "neural" = the live adaptive canvas
-  // wallpaper component. Defaults to "image" when absent.
-  kind?: "image" | "neural";
+  // "image" = CSS background (url/gradient); "animated" = a live render component
+  // selected by `component`. Defaults to "image" when absent.
+  kind?: "image" | "animated";
+  // Render component id for animated wallpapers (e.g. "neural"). New animated
+  // wallpapers register a renderer and reference it here.
+  component?: string;
+  // Optional default slogan overlaid (centered) on top of this wallpaper. null /
+  // absent = no slogan. The overlay is generic, not tied to any wallpaper kind;
+  // the user can toggle it off. Styling (colour/size/effects) defaults for now.
+  overlayText?: string | null;
 }
 
 const WALLPAPERS: Wallpaper[] = [
   {
-    id: "neural-graphite",
-    label: "Neural (Graphite)",
+    id: "graphite",
+    label: "Graphite",
     image: "",
     fallback: "#141415",
-    kind: "neural",
+    kind: "animated",
+    component: "neural",
+    overlayText: "taOS",
   },
   {
     id: "default",
-    label: "Neural (Classic)",
+    label: "Classic",
     image: "url('/static/wallpaper.png')",
     mobileImage: "url('/static/wallpaper-mobile.png')",
     fallback: "#1a1b2e",
@@ -84,15 +93,15 @@ const WALLPAPERS: Wallpaper[] = [
   },
 ];
 
-// Default wallpaper for taOS Dark: the live neural graphite field.
-const DEFAULT_WP = WALLPAPERS.find((w) => w.id === "neural-graphite") ?? WALLPAPERS[0]!;
+// Default wallpaper for taOS Dark: the animated graphite field.
+const DEFAULT_WP = WALLPAPERS.find((w) => w.id === "graphite") ?? WALLPAPERS[0]!;
 
-// The wallpaper wordmark toggle persists locally so a clean desktop survives a
+// The slogan-overlay toggle persists locally so a clean desktop survives a
 // reload. Best-effort: any storage failure falls back to "on".
-const WORDMARK_KEY = "taos-wallpaper-wordmark";
-function loadWordmarkPref(): boolean {
+const SLOGAN_KEY = "taos-wallpaper-slogan";
+function loadSloganPref(): boolean {
   try {
-    return localStorage.getItem(WORDMARK_KEY) !== "off";
+    return localStorage.getItem(SLOGAN_KEY) !== "off";
   } catch {
     return true;
   }
@@ -103,8 +112,10 @@ interface ThemeStore {
   wallpaperImage: string;
   wallpaperMobileImage: string;
   wallpaperFallback: string;
-  wallpaperKind: "image" | "neural";
-  showWallpaperWordmark: boolean;
+  wallpaperKind: "image" | "animated";
+  wallpaperComponent: string | null;
+  wallpaperOverlayText: string | null;
+  showOverlayText: boolean;
   showDesktopIcons: boolean;
   structure: Record<string, { variant?: string } & Record<string, unknown>>;
   effects: { module: string; params?: Record<string, unknown> }[];
@@ -114,7 +125,7 @@ interface ThemeStore {
   themeDefaultWallpaper: Record<string, string>;
 
   setWallpaper: (id: string) => void;
-  toggleWallpaperWordmark: () => void;
+  toggleOverlayText: () => void;
   toggleDesktopIcons: () => void;
   getWallpapers: () => Wallpaper[];
 }
@@ -125,7 +136,9 @@ export const useThemeStore = create<ThemeStore>((set) => ({
   wallpaperMobileImage: DEFAULT_WP.mobileImage ?? DEFAULT_WP.image,
   wallpaperFallback: DEFAULT_WP.fallback,
   wallpaperKind: DEFAULT_WP.kind ?? "image",
-  showWallpaperWordmark: loadWordmarkPref(),
+  wallpaperComponent: DEFAULT_WP.component ?? null,
+  wallpaperOverlayText: DEFAULT_WP.overlayText ?? null,
+  showOverlayText: loadSloganPref(),
   showDesktopIcons: true,
   structure: {},
   effects: [],
@@ -143,19 +156,21 @@ export const useThemeStore = create<ThemeStore>((set) => ({
         wallpaperMobileImage: wp.mobileImage ?? wp.image,
         wallpaperFallback: wp.fallback,
         wallpaperKind: wp.kind ?? "image",
+        wallpaperComponent: wp.component ?? null,
+        wallpaperOverlayText: wp.overlayText ?? null,
       });
     }
   },
 
-  toggleWallpaperWordmark() {
+  toggleOverlayText() {
     set((s) => {
-      const next = !s.showWallpaperWordmark;
+      const next = !s.showOverlayText;
       try {
-        localStorage.setItem(WORDMARK_KEY, next ? "on" : "off");
+        localStorage.setItem(SLOGAN_KEY, next ? "on" : "off");
       } catch {
         // best-effort
       }
-      return { showWallpaperWordmark: next };
+      return { showOverlayText: next };
     });
   },
 

--- a/desktop/src/stores/theme-store.ts
+++ b/desktop/src/stores/theme-store.ts
@@ -11,15 +11,25 @@ import { BUILTIN_THEMES } from "@/theme/builtin-themes";
 interface Wallpaper {
   id: string;
   label: string;
-  image: string; // desktop background-image
+  image: string; // desktop background-image (empty for live wallpapers)
   mobileImage?: string; // portrait-cropped variant, falls back to `image` if absent
   fallback: string; // background-color used as a fallback colour behind the image
+  // "image" = CSS background (url/gradient); "neural" = the live adaptive canvas
+  // wallpaper component. Defaults to "image" when absent.
+  kind?: "image" | "neural";
 }
 
 const WALLPAPERS: Wallpaper[] = [
   {
+    id: "neural-graphite",
+    label: "Neural (Graphite)",
+    image: "",
+    fallback: "#141415",
+    kind: "neural",
+  },
+  {
     id: "default",
-    label: "Default",
+    label: "Neural (Classic)",
     image: "url('/static/wallpaper.png')",
     mobileImage: "url('/static/wallpaper-mobile.png')",
     fallback: "#1a1b2e",
@@ -74,11 +84,27 @@ const WALLPAPERS: Wallpaper[] = [
   },
 ];
 
+// Default wallpaper for taOS Dark: the live neural graphite field.
+const DEFAULT_WP = WALLPAPERS.find((w) => w.id === "neural-graphite") ?? WALLPAPERS[0]!;
+
+// The wallpaper wordmark toggle persists locally so a clean desktop survives a
+// reload. Best-effort: any storage failure falls back to "on".
+const WORDMARK_KEY = "taos-wallpaper-wordmark";
+function loadWordmarkPref(): boolean {
+  try {
+    return localStorage.getItem(WORDMARK_KEY) !== "off";
+  } catch {
+    return true;
+  }
+}
+
 interface ThemeStore {
   wallpaperId: string;
   wallpaperImage: string;
   wallpaperMobileImage: string;
   wallpaperFallback: string;
+  wallpaperKind: "image" | "neural";
+  showWallpaperWordmark: boolean;
   showDesktopIcons: boolean;
   structure: Record<string, { variant?: string } & Record<string, unknown>>;
   effects: { module: string; params?: Record<string, unknown> }[];
@@ -88,15 +114,18 @@ interface ThemeStore {
   themeDefaultWallpaper: Record<string, string>;
 
   setWallpaper: (id: string) => void;
+  toggleWallpaperWordmark: () => void;
   toggleDesktopIcons: () => void;
   getWallpapers: () => Wallpaper[];
 }
 
 export const useThemeStore = create<ThemeStore>((set) => ({
-  wallpaperId: "default",
-  wallpaperImage: WALLPAPERS[0]!.image,
-  wallpaperMobileImage: WALLPAPERS[0]!.mobileImage ?? WALLPAPERS[0]!.image,
-  wallpaperFallback: WALLPAPERS[0]!.fallback,
+  wallpaperId: DEFAULT_WP.id,
+  wallpaperImage: DEFAULT_WP.image,
+  wallpaperMobileImage: DEFAULT_WP.mobileImage ?? DEFAULT_WP.image,
+  wallpaperFallback: DEFAULT_WP.fallback,
+  wallpaperKind: DEFAULT_WP.kind ?? "image",
+  showWallpaperWordmark: loadWordmarkPref(),
   showDesktopIcons: true,
   structure: {},
   effects: [],
@@ -113,8 +142,21 @@ export const useThemeStore = create<ThemeStore>((set) => ({
         wallpaperImage: wp.image,
         wallpaperMobileImage: wp.mobileImage ?? wp.image,
         wallpaperFallback: wp.fallback,
+        wallpaperKind: wp.kind ?? "image",
       });
     }
+  },
+
+  toggleWallpaperWordmark() {
+    set((s) => {
+      const next = !s.showWallpaperWordmark;
+      try {
+        localStorage.setItem(WORDMARK_KEY, next ? "on" : "off");
+      } catch {
+        // best-effort
+      }
+      return { showWallpaperWordmark: next };
+    });
   },
 
   toggleDesktopIcons() {

--- a/desktop/src/theme/tokens.css
+++ b/desktop/src/theme/tokens.css
@@ -1,9 +1,9 @@
 @import "tailwindcss";
 
 @theme {
-  /* Background layers */
-  --color-shell-bg: #1a1b2e;
-  --color-shell-bg-deep: #151625;
+  /* Background layers — macOS-dark graphite (warm charcoal, neutral, no indigo) */
+  --color-shell-bg: #1d1d1f;
+  --color-shell-bg-deep: #171717;
   --color-shell-surface: rgba(255, 255, 255, 0.04);
   --color-shell-surface-hover: rgba(255, 255, 255, 0.06);
   --color-shell-surface-active: rgba(255, 255, 255, 0.08);
@@ -24,10 +24,10 @@
   --color-accent: #8b92a3;
   --color-accent-glow: rgba(139, 146, 163, 0.3);
 
-  /* Dock + top bar — dark gunmetal chrome */
-  --color-dock-bg: rgba(22, 25, 32, 0.92);
+  /* Dock + top bar — neutral graphite frosted chrome */
+  --color-dock-bg: rgba(29, 29, 31, 0.92);
   --color-dock-border: rgba(255, 255, 255, 0.08);
-  --color-topbar-bg: rgba(22, 25, 32, 0.92);
+  --color-topbar-bg: rgba(29, 29, 31, 0.92);
 
   /* Snap zones */
   --color-snap-preview: rgba(139, 146, 163, 0.15);


### PR DESCRIPTION
Closes #865 (theme palette). Retunes **taOS Dark** off the blue-indigo base to a neutral macOS graphite, and ships a **live, adaptive neural wallpaper** as the new default.

## Palette (warm-charcoal graphite)
| token | before | after |
|---|---|---|
| `--color-shell-bg` | `#1a1b2e` | `#1d1d1f` |
| `--color-shell-bg-deep` | `#151625` | `#171717` |
| `--color-dock-bg` / `--color-topbar-bg` | `rgba(22,25,32,.92)` | `rgba(29,29,31,.92)` |

Accent grey `#8b92a3`, traffic lights, surfaces, shadows: unchanged. No purple anywhere.

## Live neural wallpaper
`NeuralWallpaper.tsx` — an adaptive `<canvas>` (drifting nodes + proximity links over a graphite field), inspired by the original neural wallpaper but neutral. Renders at native resolution for **any aspect ratio from one source** (16:10, ultrawide 32:10, mobile portrait), so no per-resolution PNGs.

- Density scales with viewport area; loop **pauses while hidden** (Pi perf); `prefers-reduced-motion` → static frame.
- **"taOS" wordmark is optional** — toggled in the wallpaper picker, persisted locally (default on). The toggle only appears for neural wallpapers.

## Wiring
- `theme-store` gains a wallpaper `kind` (`image` | `neural`). New **Neural (Graphite)** is the taOS Dark default; the original PNG stays as **Neural (Classic)**.
- `Desktop.tsx` + mobile shell render the live wallpaper when active and suppress the CSS background image then.
- Picker shows a graphite preview swatch + the wordmark toggle.

## Mockups (approved)
Direction was approved via still-frame mockups (graphite chrome + neural wallpaper at 16:10 / 32:10 / mobile). The React component is a faithful port of that prototype.

## Verification
`npx tsc -b` clean; wallpaper + theme tests pass. The 3 failing tests in local subset runs (SafetyFloor x2, Launchpad) **fail identically on clean dev** — pre-existing test-isolation artifacts that pass in the full xdist CI run, unrelated to this change. **Live visual confirmation on the Pi pending** (the animated wallpaper + dark↔light is best checked in a running instance).

## Follow-up (not in this PR)
Live wallpapers as a **shareable package format + agent authoring guidelines** (so the taOS agent can create/package them) — brainstorming next, tracked separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added neural wallpaper mode featuring animated background with optional taOS wordmark toggle
  
* **Style**
  * Updated dark theme color palette for shell backgrounds and dock/top bar elements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->