### PR TITLE
fix(theme): graphite popover + widget backgrounds (kill old indigo)

### DIFF
--- a/desktop/src/components/AgentKillSwitch.tsx
+++ b/desktop/src/components/AgentKillSwitch.tsx
@@ -121,7 +121,7 @@ export function AgentKillSwitch() {
             align="end"
             sideOffset={6}
             className="z-50 min-w-[200px] rounded-xl border border-shell-border p-1.5 shadow-2xl backdrop-blur-xl"
-            style={{ backgroundColor: "rgba(28,26,44,0.96)" }}
+            style={{ backgroundColor: "var(--color-dock-bg)" }}
           >
             <div className="px-3 pt-1.5 pb-1 text-[10px] uppercase tracking-wide text-shell-text-tertiary">
               Stop agents

--- a/desktop/src/components/ContextMenu.tsx
+++ b/desktop/src/components/ContextMenu.tsx
@@ -100,7 +100,7 @@ export function ContextMenu({ x, y, items, onClose }: Props) {
       style={{
         left: adjustedX,
         top: adjustedY,
-        backgroundColor: "rgba(30, 31, 50, 0.95)",
+        backgroundColor: "var(--color-dock-bg)",
         backdropFilter: "blur(20px)",
         boxShadow: "0 8px 32px rgba(0,0,0,0.5)",
       }}

--- a/desktop/src/components/ModelBrowser.tsx
+++ b/desktop/src/components/ModelBrowser.tsx
@@ -308,7 +308,7 @@ export function ModelBrowser({
     >
       <div
         className="w-full max-w-4xl h-full max-h-full flex flex-col rounded-2xl border border-white/10 overflow-hidden"
-        style={{ backgroundColor: "rgba(26, 27, 46, 0.98)" }}
+        style={{ backgroundColor: "var(--color-dock-bg)" }}
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}

--- a/desktop/src/components/NotificationCentre.tsx
+++ b/desktop/src/components/NotificationCentre.tsx
@@ -34,14 +34,14 @@ export function NotificationCentre() {
         style={
           isMobile
             ? {
-                backgroundColor: "rgba(26, 27, 46, 0.97)",
+                backgroundColor: "var(--color-dock-bg)",
                 backdropFilter: "blur(20px)",
                 boxShadow: "0 12px 48px rgba(0,0,0,0.5)",
                 top: "calc(env(safe-area-inset-top, 0px) + 52px)",
                 bottom: "calc(40px + env(safe-area-inset-bottom, 0px) * 0.35 + 16px)",
               }
             : {
-                backgroundColor: "rgba(26, 27, 46, 0.97)",
+                backgroundColor: "var(--color-dock-bg)",
                 backdropFilter: "blur(20px)",
                 boxShadow: "0 12px 48px rgba(0,0,0,0.5)",
               }

--- a/desktop/src/components/NotificationToast.tsx
+++ b/desktop/src/components/NotificationToast.tsx
@@ -279,7 +279,7 @@ function ToastItem({ notif }: { notif: Notification }) {
   return (
     <div
       className={`flex items-start gap-3 p-3 rounded-xl border backdrop-blur-lg shadow-xl w-80 ${LEVEL_COLORS[notif.level]}`}
-      style={{ backgroundColor: "rgba(26, 27, 46, 0.9)" }}
+      style={{ backgroundColor: "var(--color-dock-bg)" }}
       role="alert"
       aria-live="assertive"
     >

--- a/desktop/src/components/SearchPalette.tsx
+++ b/desktop/src/components/SearchPalette.tsx
@@ -205,7 +205,7 @@ export function SearchPalette({ open, onClose, onOpenApp }: Props) {
       <div
         className="w-full max-w-[560px] max-h-[50vh] rounded-xl border border-shell-border-strong overflow-hidden flex flex-col"
         style={{
-          backgroundColor: "rgba(26, 27, 46, 0.97)",
+          backgroundColor: "var(--color-dock-bg)",
           boxShadow: "0 16px 64px rgba(0,0,0,0.5)",
         }}
         onClick={(e) => e.stopPropagation()}

--- a/desktop/src/components/TopBar.tsx
+++ b/desktop/src/components/TopBar.tsx
@@ -52,7 +52,7 @@ function PowerMenu() {
           align="end"
           sideOffset={6}
           className="z-50 min-w-[180px] rounded-xl border border-white/10 bg-shell-surface p-1.5 shadow-2xl backdrop-blur-xl"
-          style={{ backgroundColor: "rgba(28,26,44,0.96)" }}
+          style={{ backgroundColor: "var(--color-dock-bg)" }}
         >
           <DropdownMenu.Item
             className={menuItem}

--- a/desktop/src/components/WidgetLayer.tsx
+++ b/desktop/src/components/WidgetLayer.tsx
@@ -124,7 +124,7 @@ export function WidgetLayer() {
               <div
                 style={{
                   height: "100%",
-                  background: "rgba(20, 20, 35, 0.65)",
+                  background: "rgba(22, 22, 24, 0.65)",
                   backdropFilter: "blur(12px)",
                   WebkitBackdropFilter: "blur(12px)",
                   borderRadius: 12,
@@ -204,7 +204,7 @@ export function WidgetLayer() {
             width: 40,
             height: 40,
             borderRadius: "50%",
-            background: "rgba(20, 20, 35, 0.7)",
+            background: "rgba(22, 22, 24, 0.7)",
             backdropFilter: "blur(12px)",
             WebkitBackdropFilter: "blur(12px)",
             border: "1px solid rgba(255,255,255,0.15)",
@@ -216,11 +216,11 @@ export function WidgetLayer() {
             transition: "transform 0.15s, background 0.15s",
           }}
           onMouseEnter={(e) => {
-            e.currentTarget.style.background = "rgba(40, 40, 60, 0.85)";
+            e.currentTarget.style.background = "rgba(44, 44, 48, 0.85)";
             e.currentTarget.style.transform = "scale(1.1)";
           }}
           onMouseLeave={(e) => {
-            e.currentTarget.style.background = "rgba(20, 20, 35, 0.7)";
+            e.currentTarget.style.background = "rgba(22, 22, 24, 0.7)";
             e.currentTarget.style.transform = "scale(1)";
           }}
         >
@@ -235,7 +235,7 @@ export function WidgetLayer() {
               position: "absolute",
               bottom: 50,
               right: 0,
-              background: "rgba(20, 20, 35, 0.9)",
+              background: "rgba(22, 22, 24, 0.9)",
               backdropFilter: "blur(16px)",
               WebkitBackdropFilter: "blur(16px)",
               border: "1px solid rgba(255,255,255,0.15)",

--- a/desktop/src/components/mobile/MobileAppWindow.tsx
+++ b/desktop/src/components/mobile/MobileAppWindow.tsx
@@ -25,7 +25,7 @@ export function MobileAppWindow({ appId, windowId, onClose, onMinimise }: Props)
         className="flex items-center px-3 gap-2 shrink-0"
         style={{
           height: "32px",
-          background: "rgba(30, 30, 60, 0.9)",
+          background: "rgba(28, 28, 31, 0.9)",
           borderBottom: "1px solid rgba(255,255,255,0.08)",
         }}
       >

--- a/desktop/src/components/mobile/MobileBottomNav.tsx
+++ b/desktop/src/components/mobile/MobileBottomNav.tsx
@@ -14,7 +14,7 @@ export function MobileBottomNav({ onBack, onHome, onSearch, onSwitcher, hasActiv
       className="shrink-0 flex items-center justify-around"
       style={{
         height: 48,
-        backgroundColor: "rgba(20, 20, 42, 0.98)",
+        backgroundColor: "var(--color-dock-bg)",
         borderTop: "1px solid rgba(255, 255, 255, 0.1)",
         backdropFilter: "blur(20px)",
         WebkitBackdropFilter: "blur(20px)",


### PR DESCRIPTION
The new macOS graphite theme (#868) shipped, but several popovers + widgets still hardcoded the old blue-indigo base, so they clashed.

## Fixed → `var(--color-dock-bg)` (frosted graphite chrome token, theme-aware)
- Desktop right-click **context menu** (the one flagged)
- Top-bar dropdown, agent **kill-switch** menu
- **Notification** toast + centre, **Search palette**, **Model browser**, mobile bottom nav

## Also neutralised navy → graphite (kept frosted alpha)
- Widget card backgrounds + mobile app-window (`rgba(20,20,35)`/`(30,30,60)` → neutral graphite)

## Verified
Real build + preview: desktop context menu now renders `rgba(29,29,31,0.92)` (was indigo). tsc clean.

Note: a fuller **widget redesign** (clock/agents widgets too big, resizable, reusable for the Desktop/Dash switcher) is tracked separately; this PR only de-indigos the backgrounds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated background color styling across multiple interface components, including dropdowns, modals, notification toasts, navigation bars, and widget panels, to ensure consistent visual appearance throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->