### PR TITLE
feat(desktop): real desktop (FS-backed icons, inline New Folder/rename, dock right-click menu)

### DIFF
--- a/desktop/src/components/Desktop.tsx
+++ b/desktop/src/components/Desktop.tsx
@@ -11,6 +11,7 @@ import { SnapOverlay } from "./SnapOverlay";
 import { WidgetLayer } from "./WidgetLayer";
 import { ContextMenu, type MenuItem } from "./ContextMenu";
 import { WallpaperPicker } from "./WallpaperPicker";
+import { DesktopIcons } from "./DesktopIcons";
 import { NeuralWallpaper } from "./NeuralWallpaper";
 import { WallpaperTextOverlay } from "./WallpaperTextOverlay";
 
@@ -74,7 +75,7 @@ export function Desktop() {
     {
       label: "New Folder",
       icon: <FolderPlus size={14} />,
-      action: () => openApp("files"),
+      action: () => window.dispatchEvent(new CustomEvent("taos:new-desktop-folder")),
     },
     { label: "", separator: true },
     {
@@ -137,6 +138,7 @@ export function Desktop() {
     >
       {isAnimated && wallpaperComponent === "neural" && <NeuralWallpaper />}
       {showOverlayText && wallpaperOverlayText && <WallpaperTextOverlay text={wallpaperOverlayText} />}
+      <DesktopIcons />
       <SnapOverlay bounds={previewBounds} />
       <WidgetLayer />
       {windows.map((win) => (

--- a/desktop/src/components/DesktopIcons.tsx
+++ b/desktop/src/components/DesktopIcons.tsx
@@ -27,6 +27,9 @@ const IMG = new Set(["png", "jpg", "jpeg", "gif", "webp", "bmp", "svg", "avif"])
 const isImg = (n: string) => IMG.has(n.split(".").pop()?.toLowerCase() ?? "");
 const DESKTOP = "Desktop";
 const fileUrl = (p: string) => `/api/workspace/files/${p.split("/").map(encodeURIComponent).join("/")}`;
+// Strip path separators and leading dots so a rename can't escape the Desktop
+// folder (the backend also guards, but reject it client-side too).
+const cleanName = (raw: string) => raw.trim().replace(/[/\\]/g, "").replace(/^\.+/, "");
 
 async function jget<T>(url: string): Promise<T> {
   const r = await fetch(url, { credentials: "include" });
@@ -67,6 +70,7 @@ export function DesktopIcons() {
   }, []);
 
   useEffect(() => {
+    if (!show) return; // don't create / fetch the Desktop dir when icons are hidden
     void (async () => {
       try {
         await jmut("/api/workspace/mkdir", "POST", { path: DESKTOP });
@@ -75,7 +79,7 @@ export function DesktopIcons() {
       }
       refresh();
     })();
-  }, [refresh]);
+  }, [refresh, show]);
 
   const createFolder = useCallback(async () => {
     const names = new Set(files.map((f) => f.name));
@@ -88,8 +92,8 @@ export function DesktopIcons() {
       setSelected(name);
       setEditing(name);
       setEditName(name);
-    } catch {
-      // ignore: surfaced by the unchanged listing
+    } catch (e) {
+      console.warn("desktop: create folder failed", e);
     }
   }, [files, refresh]);
 
@@ -110,7 +114,7 @@ export function DesktopIcons() {
   const commitRename = useCallback(
     async (f: FileEntry) => {
       if (renamingRef.current) return;
-      const nn = editName.trim();
+      const nn = cleanName(editName);
       if (!nn || nn === f.name) {
         setEditing(null);
         return;
@@ -120,8 +124,8 @@ export function DesktopIcons() {
         await jmut("/api/workspace/rename", "POST", { src: f.path, dst: `${DESKTOP}/${nn}` });
         await refresh();
         setSelected(nn);
-      } catch {
-        // ignore: listing stays unchanged
+      } catch (e) {
+        console.warn("desktop: rename failed", e);
       } finally {
         renamingRef.current = false;
         setEditing(null);
@@ -132,11 +136,13 @@ export function DesktopIcons() {
 
   const del = useCallback(
     async (f: FileEntry) => {
+      // Deletion is permanent (no trash yet), so confirm first.
+      if (!window.confirm(`Delete "${f.name}"? This can't be undone.`)) return;
       try {
         await jmut(fileUrl(f.path), "DELETE");
         await refresh();
-      } catch {
-        // ignore
+      } catch (e) {
+        console.warn("desktop: delete failed", e);
       }
     },
     [refresh],
@@ -232,7 +238,7 @@ export function DesktopIcons() {
               },
             },
             { label: "", separator: true },
-            { label: "Move to Trash", action: () => del(menu.file) },
+            { label: "Delete", action: () => del(menu.file) },
           ]}
         />
       )}

--- a/desktop/src/components/DesktopIcons.tsx
+++ b/desktop/src/components/DesktopIcons.tsx
@@ -1,0 +1,241 @@
+import { useEffect, useState, useCallback, useRef } from "react";
+import { Folder, FileText } from "lucide-react";
+import { withCsrf } from "@/lib/csrf";
+import { useThemeStore } from "@/stores/theme-store";
+import { useProcessStore } from "@/stores/process-store";
+import { ContextMenu } from "./ContextMenu";
+
+/**
+ * Renders the user's real Desktop folder (workspace/Desktop) as icons on the
+ * desktop surface: folders, image thumbnails and file icons. Double-click opens
+ * (folder -> Files, file -> stream); right-click gives Open / Rename / Move to
+ * Trash; rename is inline. The desktop "New Folder" menu action dispatches a
+ * `taos:new-desktop-folder` event which creates an untitled folder here and
+ * drops straight into rename (macOS behaviour). Gated by the showDesktopIcons
+ * preference.
+ */
+
+interface FileEntry {
+  name: string;
+  path: string;
+  is_dir: boolean;
+  size: number;
+  modified: number;
+}
+
+const IMG = new Set(["png", "jpg", "jpeg", "gif", "webp", "bmp", "svg", "avif"]);
+const isImg = (n: string) => IMG.has(n.split(".").pop()?.toLowerCase() ?? "");
+const DESKTOP = "Desktop";
+const fileUrl = (p: string) => `/api/workspace/files/${p.split("/").map(encodeURIComponent).join("/")}`;
+
+async function jget<T>(url: string): Promise<T> {
+  const r = await fetch(url, { credentials: "include" });
+  if (!r.ok) throw new Error(`HTTP ${r.status}`);
+  return r.json();
+}
+async function jmut(url: string, method: string, body?: unknown) {
+  const r = await fetch(
+    url,
+    withCsrf({
+      method,
+      credentials: "include",
+      headers: body ? { "Content-Type": "application/json" } : undefined,
+      body: body ? JSON.stringify(body) : undefined,
+    }),
+  );
+  if (!r.ok) throw new Error(`HTTP ${r.status}`);
+  return r.json().catch(() => ({}));
+}
+
+export function DesktopIcons() {
+  const show = useThemeStore((s) => s.showDesktopIcons);
+  const openWindow = useProcessStore((s) => s.openWindow);
+  const [files, setFiles] = useState<FileEntry[]>([]);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [editing, setEditing] = useState<string | null>(null);
+  const [editName, setEditName] = useState("");
+  const [menu, setMenu] = useState<{ x: number; y: number; file: FileEntry } | null>(null);
+  const renamingRef = useRef(false);
+
+  const refresh = useCallback(async () => {
+    try {
+      const d = await jget<FileEntry[]>(`/api/workspace/files?path=${encodeURIComponent(DESKTOP)}`);
+      setFiles(Array.isArray(d) ? d : []);
+    } catch {
+      setFiles([]);
+    }
+  }, []);
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        await jmut("/api/workspace/mkdir", "POST", { path: DESKTOP });
+      } catch {
+        // best-effort: the dir may already exist
+      }
+      refresh();
+    })();
+  }, [refresh]);
+
+  const createFolder = useCallback(async () => {
+    const names = new Set(files.map((f) => f.name));
+    let name = "untitled folder";
+    let i = 2;
+    while (names.has(name)) name = `untitled folder ${i++}`;
+    try {
+      await jmut("/api/workspace/mkdir", "POST", { path: `${DESKTOP}/${name}` });
+      await refresh();
+      setSelected(name);
+      setEditing(name);
+      setEditName(name);
+    } catch {
+      // ignore: surfaced by the unchanged listing
+    }
+  }, [files, refresh]);
+
+  useEffect(() => {
+    const h = () => void createFolder();
+    window.addEventListener("taos:new-desktop-folder", h);
+    return () => window.removeEventListener("taos:new-desktop-folder", h);
+  }, [createFolder]);
+
+  const open = useCallback(
+    (f: FileEntry) => {
+      if (f.is_dir) openWindow("files", { w: 780, h: 540 }, { location: "workspace", path: f.path });
+      else window.open(fileUrl(f.path), "_blank");
+    },
+    [openWindow],
+  );
+
+  const commitRename = useCallback(
+    async (f: FileEntry) => {
+      if (renamingRef.current) return;
+      const nn = editName.trim();
+      if (!nn || nn === f.name) {
+        setEditing(null);
+        return;
+      }
+      renamingRef.current = true;
+      try {
+        await jmut("/api/workspace/rename", "POST", { src: f.path, dst: `${DESKTOP}/${nn}` });
+        await refresh();
+        setSelected(nn);
+      } catch {
+        // ignore: listing stays unchanged
+      } finally {
+        renamingRef.current = false;
+        setEditing(null);
+      }
+    },
+    [editName, refresh],
+  );
+
+  const del = useCallback(
+    async (f: FileEntry) => {
+      try {
+        await jmut(fileUrl(f.path), "DELETE");
+        await refresh();
+      } catch {
+        // ignore
+      }
+    },
+    [refresh],
+  );
+
+  if (!show) return null;
+
+  return (
+    <>
+      <div className="pointer-events-none absolute inset-0 z-0 p-3 pt-4">
+        <div className="flex h-full flex-col flex-wrap content-start gap-0.5">
+          {files.map((f) => {
+            const isEditing = editing === f.name;
+            const isSel = selected === f.name;
+            return (
+              <div
+                key={f.path}
+                role="button"
+                tabIndex={0}
+                className={`pointer-events-auto flex w-[84px] cursor-default flex-col items-center gap-1 rounded-lg p-2 text-center ${
+                  isSel ? "bg-white/10" : "hover:bg-white/[0.06]"
+                }`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setSelected(f.name);
+                }}
+                onDoubleClick={(e) => {
+                  e.stopPropagation();
+                  open(f);
+                }}
+                onContextMenu={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  setSelected(f.name);
+                  setMenu({ x: e.clientX, y: e.clientY, file: f });
+                }}
+              >
+                <div className="flex h-12 w-12 items-center justify-center">
+                  {f.is_dir ? (
+                    <Folder size={42} className="text-accent" fill="currentColor" fillOpacity={0.18} />
+                  ) : isImg(f.name) ? (
+                    <img
+                      src={fileUrl(f.path)}
+                      alt=""
+                      loading="lazy"
+                      className="h-11 w-11 rounded border border-white/10 object-cover"
+                      onError={(e) => {
+                        e.currentTarget.style.display = "none";
+                      }}
+                    />
+                  ) : (
+                    <FileText size={38} className="text-shell-text-secondary" />
+                  )}
+                </div>
+                {isEditing ? (
+                  <input
+                    autoFocus
+                    value={editName}
+                    onChange={(e) => setEditName(e.target.value)}
+                    onClick={(e) => e.stopPropagation()}
+                    onBlur={() => commitRename(f)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") commitRename(f);
+                      if (e.key === "Escape") setEditing(null);
+                    }}
+                    className="w-full rounded border border-accent bg-shell-bg-deep px-1 text-center text-[11px] outline-none"
+                  />
+                ) : (
+                  <span
+                    className="line-clamp-2 break-words text-[11px] leading-tight text-shell-text"
+                    style={{ textShadow: "0 1px 3px rgba(0,0,0,0.6)" }}
+                  >
+                    {f.name}
+                  </span>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+      {menu && (
+        <ContextMenu
+          x={menu.x}
+          y={menu.y}
+          onClose={() => setMenu(null)}
+          items={[
+            { label: "Open", action: () => open(menu.file) },
+            {
+              label: "Rename",
+              action: () => {
+                setEditing(menu.file.name);
+                setEditName(menu.file.name);
+              },
+            },
+            { label: "", separator: true },
+            { label: "Move to Trash", action: () => del(menu.file) },
+          ]}
+        />
+      )}
+    </>
+  );
+}

--- a/desktop/src/components/DockIcon.tsx
+++ b/desktop/src/components/DockIcon.tsx
@@ -1,5 +1,9 @@
+import { useState, useCallback } from "react";
 import * as icons from "lucide-react";
 import { getApp, prefetchApp } from "@/registry/app-registry";
+import { useProcessStore } from "@/stores/process-store";
+import { useDockStore } from "@/stores/dock-store";
+import { ContextMenu, type MenuItem } from "./ContextMenu";
 
 interface Props {
   appId: string;
@@ -9,6 +13,26 @@ interface Props {
 
 export function DockIcon({ appId, isRunning, onClick }: Props) {
   const app = getApp(appId);
+  const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
+
+  const windows = useProcessStore((s) => s.windows);
+  const focusWindow = useProcessStore((s) => s.focusWindow);
+  const restoreWindow = useProcessStore((s) => s.restoreWindow);
+  const minimizeWindow = useProcessStore((s) => s.minimizeWindow);
+  const maximizeWindow = useProcessStore((s) => s.maximizeWindow);
+  const closeWindow = useProcessStore((s) => s.closeWindow);
+  const pinned = useDockStore((s) => s.pinned);
+  const pin = useDockStore((s) => s.pin);
+  const unpin = useDockStore((s) => s.unpin);
+
+  const win = windows.find((w) => w.appId === appId);
+  const isPinned = pinned.includes(appId);
+
+  const onContextMenu = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    setMenu({ x: e.clientX, y: e.clientY });
+  }, []);
+
   if (!app) return null;
 
   const iconName = app.icon
@@ -17,18 +41,52 @@ export function DockIcon({ appId, isRunning, onClick }: Props) {
     .join("") as keyof typeof icons;
   const IconComponent = (icons[iconName] as icons.LucideIcon) ?? icons.HelpCircle;
 
+  const items: MenuItem[] = win
+    ? [
+        {
+          label: win.minimized ? "Show" : "Bring to Front",
+          icon: <icons.ArrowUpRight size={14} />,
+          action: () => (win.minimized ? restoreWindow(win.id) : focusWindow(win.id)),
+        },
+        ...(!win.minimized
+          ? [{ label: "Minimise", icon: <icons.Minus size={14} />, action: () => minimizeWindow(win.id) }]
+          : []),
+        {
+          label: win.maximized ? "Restore" : "Maximise",
+          icon: <icons.Maximize2 size={14} />,
+          action: () => maximizeWindow(win.id),
+        },
+        { label: "", separator: true },
+        isPinned
+          ? { label: "Remove from Dock", icon: <icons.PinOff size={14} />, action: () => unpin(appId) }
+          : { label: "Keep in Dock", icon: <icons.Pin size={14} />, action: () => pin(appId) },
+        { label: "", separator: true },
+        { label: `Quit ${app.name}`, icon: <icons.X size={14} />, action: () => closeWindow(win.id) },
+      ]
+    : [
+        { label: "Open", icon: <icons.ArrowUpRight size={14} />, action: onClick },
+        { label: "", separator: true },
+        isPinned
+          ? { label: "Remove from Dock", icon: <icons.PinOff size={14} />, action: () => unpin(appId) }
+          : { label: "Keep in Dock", icon: <icons.Pin size={14} />, action: () => pin(appId) },
+      ];
+
   return (
-    <button
-      onClick={onClick}
-      onMouseEnter={() => prefetchApp(appId)}
-      className="group relative flex items-center justify-center w-10 h-10 rounded-lg bg-shell-surface hover:bg-shell-surface-active transition-all hover:scale-110"
-      aria-label={`Open ${app.name}`}
-      title={app.name}
-    >
-      <IconComponent size={20} className="text-shell-text" />
-      {isRunning && (
-        <div className="absolute -bottom-1 left-1/2 -translate-x-1/2 w-1 h-1 rounded-full bg-accent" />
-      )}
-    </button>
+    <>
+      <button
+        onClick={onClick}
+        onContextMenu={onContextMenu}
+        onMouseEnter={() => prefetchApp(appId)}
+        className="group relative flex items-center justify-center w-10 h-10 rounded-lg bg-shell-surface hover:bg-shell-surface-active transition-all hover:scale-110"
+        aria-label={`Open ${app.name}`}
+        title={app.name}
+      >
+        <IconComponent size={20} className="text-shell-text" />
+        {isRunning && (
+          <div className="absolute -bottom-1 left-1/2 -translate-x-1/2 w-1 h-1 rounded-full bg-accent" />
+        )}
+      </button>
+      {menu && <ContextMenu x={menu.x} y={menu.y} items={items} onClose={() => setMenu(null)} />}
+    </>
   );
 }

--- a/tests/test_routes_user_workspace.py
+++ b/tests/test_routes_user_workspace.py
@@ -100,6 +100,46 @@ class TestUserWorkspaceRoutes:
         resp = await client.get("/api/workspace/files?path=../../etc")
         assert resp.status_code == 400
 
+    @pytest.mark.asyncio
+    async def test_rename_file(self, client):
+        """POST /api/workspace/rename moves a file to its new name."""
+        await client.post(
+            "/api/workspace/files/upload",
+            files={"file": ("old.txt", io.BytesIO(b"x"), "text/plain")},
+        )
+        resp = await client.post("/api/workspace/rename", json={"src": "old.txt", "dst": "new.txt"})
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "renamed"
+        names = [e["name"] for e in (await client.get("/api/workspace/files")).json()]
+        assert "new.txt" in names and "old.txt" not in names
+
+    @pytest.mark.asyncio
+    async def test_rename_nonexistent_returns_404(self, client):
+        """Renaming a missing source returns 404."""
+        resp = await client.post("/api/workspace/rename", json={"src": "ghost", "dst": "x"})
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_rename_onto_existing_returns_409(self, client):
+        """Renaming onto an existing target returns 409."""
+        for n in ("a.txt", "b.txt"):
+            await client.post(
+                "/api/workspace/files/upload",
+                files={"file": (n, io.BytesIO(b"x"), "text/plain")},
+            )
+        resp = await client.post("/api/workspace/rename", json={"src": "a.txt", "dst": "b.txt"})
+        assert resp.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_rename_traversal_blocked(self, client):
+        """Rename targets outside the workspace are blocked with 400."""
+        await client.post(
+            "/api/workspace/files/upload",
+            files={"file": ("safe.txt", io.BytesIO(b"x"), "text/plain")},
+        )
+        resp = await client.post("/api/workspace/rename", json={"src": "safe.txt", "dst": "../escape.txt"})
+        assert resp.status_code == 400
+
     def test_dir_signature_changes_on_modification(self):
         """Signature helper drives the SSE watch change-detection loop.
         Unit-tested directly — the full SSE stream endpoint is tested

--- a/tinyagentos/routes/user_workspace.py
+++ b/tinyagentos/routes/user_workspace.py
@@ -211,6 +211,33 @@ async def api_mkdir(request: Request, body: MkdirRequest):
     return {"path": str(rel), "status": "created"}
 
 
+class RenameRequest(BaseModel):
+    src: str
+    dst: str
+
+
+@router.post("/api/workspace/rename")
+async def api_rename(request: Request, body: RenameRequest):
+    """Rename or move a file/directory within the user workspace."""
+    workspace = _get_workspace_root(request)
+
+    if not body.src.strip() or not body.dst.strip():
+        return JSONResponse({"error": "src and dst are required"}, status_code=400)
+
+    src = _resolve_safe(workspace, body.src.strip())
+    dst = _resolve_safe(workspace, body.dst.strip())
+    if src is None or dst is None:
+        return JSONResponse({"error": "Invalid path"}, status_code=400)
+    if not src.exists():
+        return JSONResponse({"error": "Source not found"}, status_code=404)
+    if dst.exists():
+        return JSONResponse({"error": "Target already exists"}, status_code=409)
+
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    src.rename(dst)
+    return {"path": str(dst.relative_to(workspace)), "status": "renamed"}
+
+
 @router.get("/api/workspace/files/{file_path:path}")
 async def api_get_file(request: Request, file_path: str):
     """Stream a single file from the user workspace — used for thumbnails,


### PR DESCRIPTION
Makes the taOS desktop a *real* desktop, per Jay's feedback. Three pieces:

## Dock right-click menu (#22)
Each dock icon gets a macOS-style context menu (reusing the graphite ContextMenu): running app → Show/Bring to Front, Minimise, Maximise/Restore, Keep in/Remove from Dock, Quit; non-running → Open + Keep in Dock. Wired to process-store + dock-store.

## Real Desktop folder icons (#24)
`DesktopIcons` renders the user's real **`workspace/Desktop`** folder as icons (folders, image thumbnails, file icons). Double-click opens (folder → Files, file → stream), right-click → Open / Rename / Move to Trash. Gated by the `showDesktopIcons` preference.

## Inline New Folder + rename (#23)
Desktop right-click → **New Folder** now creates an `untitled folder` in the real Desktop dir and enters **inline rename immediately** (Enter/Escape/blur), instead of opening the Files app.

## Backend
Adds `POST /api/workspace/rename` (move/rename within the workspace, same path-traversal guard) + 4 tests.

## Verification
`tsc -b` + `npm run build` clean; **16 workspace route tests pass** (12 existing + 4 new rename). The dock menu renders (verified in preview). The **desktop icons + thumbnails + rename need a live Pi check** (the local preview has no backend, so the Desktop folder lists empty). Folder positioning is a simple top-left auto-flow grid for v1 (free-drag positions can come later).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Desktop icons now display workspace files and folders with context menu actions (open, rename, move to trash).
  * Create new folders directly on the desktop with inline rename capability.
  * Right-click dock icons to pin/unpin applications or quit them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->