### PR TITLE
feat(desktop): programmatic desktop control API (window.taosDesktop)

### DIFF
--- a/desktop/src/components/Desktop.tsx
+++ b/desktop/src/components/Desktop.tsx
@@ -5,6 +5,7 @@ import { useThemeStore } from "@/stores/theme-store";
 import { useWidgetStore } from "@/stores/widget-store";
 import { useSnapZones } from "@/hooks/use-snap-zones";
 import { useDeepNavigation } from "@/hooks/use-deep-navigation";
+import { useDesktopControl } from "@/hooks/use-desktop-control";
 import { getApp } from "@/registry/app-registry";
 import { Window } from "./Window";
 import { SnapOverlay } from "./SnapOverlay";
@@ -69,6 +70,7 @@ export function Desktop() {
   // Deep-navigation API: `?app=` URL param on load + `taos:open-app` event at
   // runtime (lets the taOS agent drive the desktop). See the hook for details.
   useDeepNavigation(openWindow);
+  useDesktopControl();
 
   const menuItems: MenuItem[] = [
     {

--- a/desktop/src/hooks/use-desktop-control.ts
+++ b/desktop/src/hooks/use-desktop-control.ts
@@ -1,0 +1,201 @@
+import { useEffect } from "react";
+import { useProcessStore, type SnapPosition } from "@/stores/process-store";
+import { resolveApp } from "@/registry/app-registry";
+
+/**
+ * Programmatic desktop control for the taOS agent (and for deterministic
+ * screenshots / tests). Exposes `window.taosDesktop` and a `taos:window`
+ * CustomEvent so a window's lifecycle and layout can be driven without clicking:
+ *
+ *   window.taosDesktop.getLayout()            // screen size + every window's bounds/state
+ *   window.taosDesktop.run({ action, ... })   // drive one window op
+ *   window.dispatchEvent(new CustomEvent("taos:window", { detail: { action, ... } }))
+ *
+ * Actions: open, close, focus, minimize, restore, maximize, move, resize, snap,
+ * arrange (preset: tile-2 | tile-3 | center | cascade). Targeting precedence:
+ * explicit windowId, else first window for appId, else the focused/topmost one.
+ * This is the agent-tool side of the deep-navigation API (#836) and complements
+ * `taos:open-app`.
+ */
+
+export interface DesktopLayout {
+  screen: { width: number; height: number; ratio: number };
+  windows: Array<{
+    id: string;
+    appId: string;
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+    minimized: boolean;
+    maximized: boolean;
+    snapped: SnapPosition;
+    focused: boolean;
+    zIndex: number;
+  }>;
+}
+
+export interface WindowOp {
+  action:
+    | "open"
+    | "close"
+    | "focus"
+    | "minimize"
+    | "restore"
+    | "maximize"
+    | "move"
+    | "resize"
+    | "snap"
+    | "arrange";
+  windowId?: string;
+  appId?: string;
+  props?: Record<string, unknown>;
+  x?: number;
+  y?: number;
+  w?: number;
+  h?: number;
+  snap?: SnapPosition;
+  preset?: "tile-2" | "tile-3" | "center" | "cascade";
+}
+
+const TOP = 36; // below the 32px top bar
+const DOCK = 88; // above the dock
+
+function workArea() {
+  const W = window.innerWidth;
+  const H = window.innerHeight;
+  return { W, H, x: 8, y: TOP, w: W - 16, h: H - TOP - DOCK };
+}
+
+function getLayout(): DesktopLayout {
+  const { windows } = useProcessStore.getState();
+  return {
+    screen: { width: window.innerWidth, height: window.innerHeight, ratio: +(window.innerWidth / window.innerHeight).toFixed(3) },
+    windows: windows.map((w) => ({
+      id: w.id,
+      appId: w.appId,
+      x: w.position.x,
+      y: w.position.y,
+      w: w.size.w,
+      h: w.size.h,
+      minimized: w.minimized,
+      maximized: w.maximized,
+      snapped: w.snapped,
+      focused: w.focused,
+      zIndex: w.zIndex,
+    })),
+  };
+}
+
+function resolveId(op: WindowOp): string | undefined {
+  const { windows } = useProcessStore.getState();
+  if (op.windowId) return op.windowId;
+  if (op.appId) return windows.find((w) => w.appId === op.appId)?.id;
+  return [...windows].sort((a, b) => b.zIndex - a.zIndex)[0]?.id;
+}
+
+function arrange(preset: WindowOp["preset"]) {
+  const s = useProcessStore.getState();
+  const wins = [...s.windows].filter((w) => !w.minimized).sort((a, b) => a.zIndex - b.zIndex);
+  if (wins.length === 0) return;
+  const a = workArea();
+  const place = (id: string, x: number, y: number, w: number, h: number) => {
+    s.snapWindow(id, null);
+    s.updatePosition(id, Math.round(x), Math.round(y));
+    s.updateSize(id, Math.round(w), Math.round(h));
+  };
+  if (preset === "tile-2") {
+    const half = (a.w - 8) / 2;
+    place(wins[0]!.id, a.x, a.y, half, a.h);
+    if (wins[1]) place(wins[1].id, a.x + half + 8, a.y, half, a.h);
+  } else if (preset === "tile-3") {
+    const third = (a.w - 16) / 3;
+    wins.slice(0, 3).forEach((w, i) => place(w.id, a.x + i * (third + 8), a.y, third, a.h));
+  } else if (preset === "center") {
+    const w = Math.min(a.w, 1100);
+    const h = Math.min(a.h, 720);
+    wins.forEach((win) => place(win.id, a.x + (a.w - w) / 2, a.y + (a.h - h) / 2, w, h));
+  } else if (preset === "cascade") {
+    const w = Math.min(a.w * 0.62, 900);
+    const h = Math.min(a.h * 0.7, 620);
+    wins.forEach((win, i) => place(win.id, a.x + 40 + i * 36, a.y + 20 + i * 32, w, h));
+  }
+}
+
+function run(op: WindowOp): string | void {
+  const s = useProcessStore.getState();
+  switch (op.action) {
+    case "open": {
+      const app = op.appId ? resolveApp(op.appId) : undefined;
+      if (!app) return;
+      const size = op.w != null && op.h != null ? { w: op.w, h: op.h } : app.defaultSize;
+      const id = s.openWindow(app.id, size, op.props);
+      if (op.x != null && op.y != null) s.updatePosition(id, op.x, op.y);
+      return id;
+    }
+    case "move": {
+      const id = resolveId(op);
+      if (id && op.x != null && op.y != null) s.updatePosition(id, op.x, op.y);
+      return;
+    }
+    case "resize": {
+      const id = resolveId(op);
+      if (id && op.w != null && op.h != null) s.updateSize(id, op.w, op.h);
+      return;
+    }
+    case "maximize": {
+      const id = resolveId(op);
+      if (id) s.maximizeWindow(id);
+      return;
+    }
+    case "minimize": {
+      const id = resolveId(op);
+      if (id) s.minimizeWindow(id);
+      return;
+    }
+    case "restore": {
+      const id = resolveId(op);
+      if (id) s.restoreWindow(id);
+      return;
+    }
+    case "focus": {
+      const id = resolveId(op);
+      if (id) s.focusWindow(id);
+      return;
+    }
+    case "close": {
+      const id = resolveId(op);
+      if (id) s.closeWindow(id);
+      return;
+    }
+    case "snap": {
+      const id = resolveId(op);
+      if (id) s.snapWindow(id, op.snap ?? null);
+      return;
+    }
+    case "arrange":
+      arrange(op.preset);
+      return;
+  }
+}
+
+declare global {
+  interface Window {
+    taosDesktop?: { getLayout: () => DesktopLayout; run: (op: WindowOp) => string | void };
+  }
+}
+
+export function useDesktopControl(): void {
+  useEffect(() => {
+    const onWindow = (e: Event) => {
+      const detail = (e as CustomEvent).detail as WindowOp | undefined;
+      if (detail?.action) run(detail);
+    };
+    window.addEventListener("taos:window", onWindow);
+    window.taosDesktop = { getLayout, run };
+    return () => {
+      window.removeEventListener("taos:window", onWindow);
+      delete window.taosDesktop;
+    };
+  }, []);
+}

--- a/desktop/src/hooks/use-desktop-control.ts
+++ b/desktop/src/hooks/use-desktop-control.ts
@@ -69,22 +69,38 @@ function workArea() {
 
 function getLayout(): DesktopLayout {
   const { windows } = useProcessStore.getState();
+  const area = workArea();
   return {
     screen: { width: window.innerWidth, height: window.innerHeight, ratio: +(window.innerWidth / window.innerHeight).toFixed(3) },
-    windows: windows.map((w) => ({
-      id: w.id,
-      appId: w.appId,
-      x: w.position.x,
-      y: w.position.y,
-      w: w.size.w,
-      h: w.size.h,
-      minimized: w.minimized,
-      maximized: w.maximized,
-      snapped: w.snapped,
-      focused: w.focused,
-      zIndex: w.zIndex,
-    })),
+    windows: windows.map((w) => {
+      // A maximized window fills the work area regardless of its stored bounds;
+      // report the rendered geometry so callers see where it actually is.
+      const m = w.maximized;
+      return {
+        id: w.id,
+        appId: w.appId,
+        x: m ? area.x : w.position.x,
+        y: m ? area.y : w.position.y,
+        w: m ? area.w : w.size.w,
+        h: m ? area.h : w.size.h,
+        minimized: w.minimized,
+        maximized: w.maximized,
+        snapped: w.snapped,
+        focused: w.focused,
+        zIndex: w.zIndex,
+      };
+    }),
   };
+}
+
+// Clear maximized / snapped state so an explicit move/resize actually applies
+// (the Window derives its rendered geometry from those, ignoring stored bounds).
+function freePlacement(id: string) {
+  const s = useProcessStore.getState();
+  const win = s.windows.find((w) => w.id === id);
+  if (!win) return;
+  if (win.snapped) s.snapWindow(id, null);
+  if (win.maximized) s.maximizeWindow(id); // maximizeWindow toggles; this un-maximizes
 }
 
 function resolveId(op: WindowOp): string | undefined {
@@ -100,7 +116,7 @@ function arrange(preset: WindowOp["preset"]) {
   if (wins.length === 0) return;
   const a = workArea();
   const place = (id: string, x: number, y: number, w: number, h: number) => {
-    s.snapWindow(id, null);
+    freePlacement(id);
     s.updatePosition(id, Math.round(x), Math.round(y));
     s.updateSize(id, Math.round(w), Math.round(h));
   };
@@ -135,17 +151,24 @@ function run(op: WindowOp): string | void {
     }
     case "move": {
       const id = resolveId(op);
-      if (id && op.x != null && op.y != null) s.updatePosition(id, op.x, op.y);
+      if (id && op.x != null && op.y != null) {
+        freePlacement(id);
+        s.updatePosition(id, op.x, op.y);
+      }
       return;
     }
     case "resize": {
       const id = resolveId(op);
-      if (id && op.w != null && op.h != null) s.updateSize(id, op.w, op.h);
+      if (id && op.w != null && op.h != null) {
+        freePlacement(id);
+        s.updateSize(id, op.w, op.h);
+      }
       return;
     }
     case "maximize": {
       const id = resolveId(op);
-      if (id) s.maximizeWindow(id);
+      const win = id ? s.windows.find((w) => w.id === id) : undefined;
+      if (win && !win.maximized) s.maximizeWindow(win.id); // always maximizes, never toggles off
       return;
     }
     case "minimize": {

--- a/docs/desktop-control.md
+++ b/docs/desktop-control.md
@@ -1,0 +1,67 @@
+# Desktop control API
+
+Programmatic control of the taOS desktop: query the layout and drive window
+lifecycle / placement without clicking. This is the agent-tool side of the
+deep-navigation API (issue #836) and the foundation for agent-arranged layouts
+and deterministic screenshots / tests.
+
+Implemented by `desktop/src/hooks/use-desktop-control.ts`, mounted once in
+`Desktop.tsx`. It exposes a global and a CustomEvent.
+
+## Global: `window.taosDesktop`
+
+```js
+// Read the current layout: screen size + ratio and every window's bounds/state.
+window.taosDesktop.getLayout();
+// => {
+//   screen: { width, height, ratio },
+//   windows: [{ id, appId, x, y, w, h, minimized, maximized, snapped, focused, zIndex }]
+// }
+
+// Run a single window operation (returns the new window id for "open").
+window.taosDesktop.run({ action: "open", appId: "chat" });
+```
+
+## Event: `taos:window`
+
+Same payload as `run`, for fire-and-forget control from anywhere:
+
+```js
+window.dispatchEvent(new CustomEvent("taos:window", { detail: { action: "arrange", preset: "tile-3" } }));
+```
+
+## Operations
+
+| action | fields | effect |
+| --- | --- | --- |
+| `open` | `appId`, optional `x`,`y`,`w`,`h`,`props` | open (or focus) an app, optionally placed/sized |
+| `close` / `focus` / `minimize` / `restore` / `maximize` | target | window lifecycle |
+| `move` | target, `x`,`y` | reposition |
+| `resize` | target, `w`,`h` | resize |
+| `snap` | target, `snap` (left/right/top-left/top-right/bottom-left/bottom-right/null) | snap-tile |
+| `arrange` | `preset` (`tile-2` / `tile-3` / `center` / `cascade`) | arrange all open windows |
+
+**Targeting precedence:** explicit `windowId`, else the first window for `appId`,
+else the focused / topmost window.
+
+The presets respect the work area (below the 32px top bar, above the dock).
+
+## Screenshots / tests
+
+Drive a deterministic layout from Playwright instead of clicking:
+
+```js
+await page.evaluate(() => {
+  window.taosDesktop.run({ action: "open", appId: "chat" });
+  window.taosDesktop.run({ action: "open", appId: "projects" });
+  window.taosDesktop.run({ action: "open", appId: "store" });
+  window.taosDesktop.run({ action: "arrange", preset: "tile-3" });
+});
+const layout = await page.evaluate(() => window.taosDesktop.getLayout());
+```
+
+## Follow-up
+
+The controller-side agent tool (`desktop_get_layout` / `desktop_arrange`) that
+lets the taOS agent call this over the agent bridge, and the matching agent
+manual entry, are a separate change (see [[agent-desktop-control]] in memory).


### PR DESCRIPTION
Exposes a programmatic control surface for the desktop — the agent-tool side of the deep-navigation API (#836), and the foundation for agent-arranged layouts + deterministic screenshots/tests.

## API
- `window.taosDesktop.getLayout()` → screen size + ratio + every window's bounds/state
- `window.taosDesktop.run({ action, ... })` and a `taos:window` CustomEvent
- Actions: open, close, focus, minimize, restore, maximize, move, resize, snap, **arrange** (tile-2 / tile-3 / center / cascade)
- Targeting: explicit windowId → first window for appId → focused/topmost

All wired to the existing `process-store` actions; presets respect the work area. Docs: `docs/desktop-control.md`.

## Why
Lets the taOS agent drive the desktop, and gives me deterministic multi-window screenshots (verified: opened 3 apps + `arrange tile-3` via the API, `getLayout` returns clean tiled bounds) instead of fragile Playwright clicking.

## Verification
tsc + build clean. Drove the API live in build+preview: opened Agents/Files/Settings + tiled them; `getLayout()` returned the 3 windows at correct thirds.

## Follow-ups (tracked)
- Controller agent-tool wrapper (`desktop_get_layout` / `desktop_arrange`) + agent-manual entry so the agent can call this over the bridge.
- UI: investigate a faint double-header strip seen above the title bar on tiled windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added programmatic desktop window management API enabling dynamic window control operations (open, close, focus, minimize, maximize, move, resize, snap, arrange).
  * Support for window arrangement presets (tile layouts, center, cascade).

* **Documentation**
  * Added comprehensive guide for the desktop control API with usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->