### PR TITLE
feat(desktop): controller→browser command channel for agent OS control (transport)

### DIFF
--- a/desktop/src/components/Desktop.tsx
+++ b/desktop/src/components/Desktop.tsx
@@ -6,6 +6,7 @@ import { useWidgetStore } from "@/stores/widget-store";
 import { useSnapZones } from "@/hooks/use-snap-zones";
 import { useDeepNavigation } from "@/hooks/use-deep-navigation";
 import { useDesktopControl } from "@/hooks/use-desktop-control";
+import { useDesktopCommandStream } from "@/hooks/use-desktop-command-stream";
 import { getApp } from "@/registry/app-registry";
 import { Window } from "./Window";
 import { SnapOverlay } from "./SnapOverlay";
@@ -72,6 +73,10 @@ export function Desktop() {
   // runtime (lets the taOS agent drive the desktop). See the hook for details.
   useDeepNavigation(openWindow);
   useDesktopControl();
+  // Backend -> browser command channel: lets the taOS agent drive this desktop
+  // (open apps, move/arrange windows) by pushing commands the controller streams
+  // here. Re-dispatches to the taos:open-app / taos:window receivers above.
+  useDesktopCommandStream();
 
   const menuItems: MenuItem[] = [
     {

--- a/desktop/src/hooks/use-desktop-command-stream.test.ts
+++ b/desktop/src/hooks/use-desktop-command-stream.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useDesktopCommandStream } from "./use-desktop-command-stream";
+
+// Minimal EventSource stub: capture the instance so a test can push messages.
+class FakeEventSource {
+  static last: FakeEventSource | null = null;
+  url: string;
+  onmessage: ((e: { data: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  closed = false;
+  constructor(url: string) {
+    this.url = url;
+    FakeEventSource.last = this;
+  }
+  push(data: string) {
+    this.onmessage?.({ data });
+  }
+  close() {
+    this.closed = true;
+  }
+}
+
+describe("useDesktopCommandStream", () => {
+  beforeEach(() => {
+    FakeEventSource.last = null;
+    vi.stubGlobal("EventSource", FakeEventSource as unknown as typeof EventSource);
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("subscribes to the desktop command stream", () => {
+    renderHook(() => useDesktopCommandStream());
+    expect(FakeEventSource.last?.url).toBe("/api/desktop/stream");
+  });
+
+  it("re-dispatches open-app commands as a taos:open-app event", () => {
+    renderHook(() => useDesktopCommandStream());
+    const seen: unknown[] = [];
+    const handler = (e: Event) => seen.push((e as CustomEvent).detail);
+    window.addEventListener("taos:open-app", handler);
+    FakeEventSource.last!.push(JSON.stringify({ kind: "open-app", payload: { app: "projects" } }));
+    window.removeEventListener("taos:open-app", handler);
+    expect(seen).toEqual([{ app: "projects" }]);
+  });
+
+  it("re-dispatches window commands as a taos:window event", () => {
+    renderHook(() => useDesktopCommandStream());
+    const seen: unknown[] = [];
+    const handler = (e: Event) => seen.push((e as CustomEvent).detail);
+    window.addEventListener("taos:window", handler);
+    FakeEventSource.last!.push(JSON.stringify({ kind: "window", payload: { action: "arrange", preset: "tile-2" } }));
+    window.removeEventListener("taos:window", handler);
+    expect(seen).toEqual([{ action: "arrange", preset: "tile-2" }]);
+  });
+
+  it("ignores malformed payloads without throwing", () => {
+    renderHook(() => useDesktopCommandStream());
+    expect(() => FakeEventSource.last!.push("not json")).not.toThrow();
+  });
+
+  it("closes the stream on unmount", () => {
+    const { unmount } = renderHook(() => useDesktopCommandStream());
+    const es = FakeEventSource.last!;
+    unmount();
+    expect(es.closed).toBe(true);
+  });
+});

--- a/desktop/src/hooks/use-desktop-command-stream.ts
+++ b/desktop/src/hooks/use-desktop-command-stream.ts
@@ -17,12 +17,15 @@ export function useDesktopCommandStream(): void {
   useEffect(() => {
     const es = new EventSource("/api/desktop/stream");
     es.onmessage = (msg) => {
-      let cmd: { kind?: string; payload?: Record<string, unknown> };
+      let cmd: { kind?: string; payload?: Record<string, unknown> } | null;
       try {
         cmd = JSON.parse(msg.data);
       } catch {
         return;
       }
+      // JSON.parse can legally return null (or a non-object); guard before
+      // reading .kind so a stray payload can't throw and kill the listener.
+      if (!cmd || typeof cmd !== "object") return;
       if (cmd.kind === "open-app") {
         window.dispatchEvent(new CustomEvent("taos:open-app", { detail: cmd.payload ?? {} }));
       } else if (cmd.kind === "window") {

--- a/desktop/src/hooks/use-desktop-command-stream.ts
+++ b/desktop/src/hooks/use-desktop-command-stream.ts
@@ -1,0 +1,38 @@
+import { useEffect } from "react";
+
+/**
+ * Subscribes to the controller's desktop-command SSE channel and re-dispatches
+ * each command as the CustomEvents the desktop already understands:
+ *
+ *   { kind: "open-app", payload: { app, props } } -> `taos:open-app`
+ *   { kind: "window",   payload: WindowOp }       -> `taos:window`
+ *
+ * This is the browser end of the agent-OS-control transport: the taOS agent
+ * pushes commands server-side (POST /api/desktop/command), the controller fans
+ * them to the user's desktop over /api/desktop/stream, and they land on the
+ * existing use-deep-navigation / use-desktop-control receivers. The browser
+ * auto-reconnects on transient errors (same as the canvas stream).
+ */
+export function useDesktopCommandStream(): void {
+  useEffect(() => {
+    const es = new EventSource("/api/desktop/stream");
+    es.onmessage = (msg) => {
+      let cmd: { kind?: string; payload?: Record<string, unknown> };
+      try {
+        cmd = JSON.parse(msg.data);
+      } catch {
+        return;
+      }
+      if (cmd.kind === "open-app") {
+        window.dispatchEvent(new CustomEvent("taos:open-app", { detail: cmd.payload ?? {} }));
+      } else if (cmd.kind === "window") {
+        window.dispatchEvent(new CustomEvent("taos:window", { detail: cmd.payload ?? {} }));
+      }
+    };
+    es.onerror = () => {
+      // Transient errors: the browser reconnects automatically. On a hard close
+      // the effect's cleanup runs and a remount opens a fresh subscription.
+    };
+    return () => es.close();
+  }, []);
+}

--- a/docs/desktop-control.md
+++ b/docs/desktop-control.md
@@ -87,9 +87,13 @@ So a command pushed server-side lands on the same `useDeepNavigation` /
 `useDesktopControl` handlers a local caller would hit — no new app logic.
 
 ```bash
-# Open the Projects app on the calling user's desktop:
-curl -X POST /api/desktop/command \
+# Open the Projects app on the calling user's desktop. The command is scoped to
+# the authenticated session (AuthMiddleware -> request.state.user_id), so pass
+# the caller's session cookie; without auth it resolves to the inert "system"
+# channel that no real desktop subscribes to.
+curl -X POST http://<host>:6969/api/desktop/command \
   -H 'Content-Type: application/json' \
+  -b 'taos_session=<session-cookie>' \
   -d '{"kind":"open-app","payload":{"app":"projects"}}'
 ```
 

--- a/docs/desktop-control.md
+++ b/docs/desktop-control.md
@@ -60,8 +60,44 @@ await page.evaluate(() => {
 const layout = await page.evaluate(() => window.taosDesktop.getLayout());
 ```
 
+## Controller → browser transport (backend command channel)
+
+`window.taosDesktop` and the `taos:window` / `taos:open-app` events run in the
+browser. To let the **controller** (and through it, the taOS agent) drive a
+specific user's desktop, the backend streams commands to the browser over SSE.
+
+- **Backend broker:** `tinyagentos/desktop_control/broker.py` —
+  `DesktopCommandBroker`, one channel per `user_id`, **no replay** (a command is a
+  one-shot side effect; replaying buffered commands to a reconnecting desktop
+  would re-open closed apps).
+- **Routes:** `tinyagentos/routes/desktop_control.py`
+  - `GET /api/desktop/stream` — SSE; the desktop subscribes (scoped to the
+    caller's `user_id`), receives each command as `data: {kind, payload, ts}`.
+  - `POST /api/desktop/command` — body `{kind, payload}`; emits to the caller's
+    own desktop(s). Returns `{delivered: N}` (0 = no desktop connected). Privileged:
+    only the agent runtime / authed server-side callers push here, never arbitrary
+    clients; a user only ever drives their own desktop.
+- **Browser receiver:** `desktop/src/hooks/use-desktop-command-stream.ts`
+  (mounted in `Desktop.tsx`) subscribes to the stream and re-dispatches each
+  command to the existing receivers:
+  - `{ kind: "open-app", payload: { app, props } }` → `taos:open-app`
+  - `{ kind: "window",   payload: WindowOp }`       → `taos:window`
+
+So a command pushed server-side lands on the same `useDeepNavigation` /
+`useDesktopControl` handlers a local caller would hit — no new app logic.
+
+```bash
+# Open the Projects app on the calling user's desktop:
+curl -X POST /api/desktop/command \
+  -H 'Content-Type: application/json' \
+  -d '{"kind":"open-app","payload":{"app":"projects"}}'
+```
+
 ## Follow-up
 
-The controller-side agent tool (`desktop_get_layout` / `desktop_arrange`) that
-lets the taOS agent call this over the agent bridge, and the matching agent
-manual entry, are a separate change (see [[agent-desktop-control]] in memory).
+Built (this PR): the controller→browser transport above. **Next:** the agent MCP
+tools (`open_app`, `arrange_windows`, plus the data tools that wrap existing
+project/canvas/image routes) that call `POST /api/desktop/command`, and the
+matching agent-manual entry — they land together so the manual only advertises
+capabilities the agent can actually invoke. `getLayout` over the channel (a
+browser→backend read round-trip) is deferred until screen-aware arrange needs it.

--- a/tests/test_desktop_control.py
+++ b/tests/test_desktop_control.py
@@ -48,6 +48,24 @@ async def test_no_replay_for_late_subscriber():
 
 
 @pytest.mark.asyncio
+async def test_overflow_drops_oldest_keeps_newest():
+    """A stalled desktop's bounded queue drops the OLDEST command, never grows
+    unbounded, and still surfaces the most recent commands."""
+    broker = DesktopCommandBroker()
+    q = await broker.subscribe("user-1")
+    n = DesktopCommandBroker._MAX_QUEUE + 5
+    for i in range(n):
+        await broker.emit("user-1", DesktopCommand(kind="open-app", payload={"app": f"app-{i}"}))
+    assert q.qsize() == DesktopCommandBroker._MAX_QUEUE
+    # The newest command must still be in the queue (oldest were dropped).
+    apps = []
+    while not q.empty():
+        apps.append(q.get_nowait().payload["app"])
+    assert apps[-1] == f"app-{n - 1}"
+    assert f"app-0" not in apps
+
+
+@pytest.mark.asyncio
 async def test_emit_with_no_subscribers_returns_zero():
     broker = DesktopCommandBroker()
     assert await broker.emit("nobody", DesktopCommand(kind="window", payload={"action": "arrange"})) == 0

--- a/tests/test_desktop_control.py
+++ b/tests/test_desktop_control.py
@@ -1,0 +1,145 @@
+import asyncio
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from tinyagentos.desktop_control.broker import DesktopCommand, DesktopCommandBroker
+from tinyagentos.routes.desktop_control import router
+
+
+# --------------------------------------------------------------------------- #
+# Broker unit tests                                                            #
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_emit_fans_out_to_subscribers():
+    broker = DesktopCommandBroker()
+    a = await broker.subscribe("user-1")
+    b = await broker.subscribe("user-1")
+    reached = await broker.emit("user-1", DesktopCommand(kind="open-app", payload={"app": "projects"}))
+    assert reached == 2
+    cmd_a = await asyncio.wait_for(a.get(), timeout=0.5)
+    cmd_b = await asyncio.wait_for(b.get(), timeout=0.5)
+    assert cmd_a.kind == "open-app" and cmd_a.payload["app"] == "projects"
+    assert cmd_b.payload["app"] == "projects"
+
+
+@pytest.mark.asyncio
+async def test_emit_isolated_per_user():
+    broker = DesktopCommandBroker()
+    a = await broker.subscribe("user-1")
+    b = await broker.subscribe("user-2")
+    await broker.emit("user-1", DesktopCommand(kind="open-app", payload={"app": "files"}))
+    got = await asyncio.wait_for(a.get(), timeout=0.5)
+    assert got.payload["app"] == "files"
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(b.get(), timeout=0.1)
+
+
+@pytest.mark.asyncio
+async def test_no_replay_for_late_subscriber():
+    """A command must NOT be re-delivered to a desktop that connects later, or
+    closed apps would re-open on reconnect."""
+    broker = DesktopCommandBroker()
+    await broker.emit("user-1", DesktopCommand(kind="open-app", payload={"app": "chat"}))
+    late = await broker.subscribe("user-1")
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(late.get(), timeout=0.1)
+
+
+@pytest.mark.asyncio
+async def test_emit_with_no_subscribers_returns_zero():
+    broker = DesktopCommandBroker()
+    assert await broker.emit("nobody", DesktopCommand(kind="window", payload={"action": "arrange"})) == 0
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe_stops_delivery():
+    broker = DesktopCommandBroker()
+    q = await broker.subscribe("user-1")
+    await broker.unsubscribe("user-1", q)
+    assert await broker.emit("user-1", DesktopCommand(kind="open-app", payload={"app": "x"})) == 0
+
+
+# --------------------------------------------------------------------------- #
+# Route tests                                                                  #
+# --------------------------------------------------------------------------- #
+def _make_app() -> FastAPI:
+    app = FastAPI()
+    app.state.desktop_command_broker = DesktopCommandBroker()
+    app.include_router(router)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_post_command_validates_kind():
+    app = _make_app()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post("/api/desktop/command", json={"kind": "bogus", "payload": {}})
+        assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_post_command_no_desktop_delivers_zero():
+    app = _make_app()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post("/api/desktop/command", json={"kind": "open-app", "payload": {"app": "projects"}})
+        assert r.status_code == 200
+        assert r.json()["delivered"] == 0
+
+
+@pytest.mark.asyncio
+async def test_stream_receives_emitted_command():
+    """Drive the SSE endpoint over raw ASGI, subscribe, then emit and collect."""
+    app = _make_app()
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "GET",
+        "headers": [(b"accept", b"text/event-stream")],
+        "scheme": "http",
+        "path": "/api/desktop/stream",
+        "raw_path": b"/api/desktop/stream",
+        "query_string": b"",
+        "server": ("testserver", 80),
+        "client": ("127.0.0.1", 1234),
+        "root_path": "",
+    }
+    lines: list[str] = []
+    done = asyncio.Event()
+
+    async def receive():
+        await done.wait()
+        return {"type": "http.disconnect"}
+
+    async def send(message):
+        if message["type"] == "http.response.body":
+            body = message.get("body", b"")
+            for line in body.decode().split("\n"):
+                s = line.rstrip("\r")
+                if s.startswith("data:"):
+                    lines.append(s)
+                    done.set()
+
+    task = asyncio.create_task(app(scope, receive, send))
+    # Give the stream a moment to subscribe (no replay, so emit must come after).
+    await asyncio.sleep(0.2)
+    reached = await app.state.desktop_command_broker.emit(
+        "system", DesktopCommand(kind="open-app", payload={"app": "projects"})
+    )
+    assert reached == 1, "the SSE subscriber should be the sole 'system' desktop"
+    try:
+        await asyncio.wait_for(done.wait(), timeout=3.0)
+    finally:
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):
+            pass
+
+    import json
+    assert lines, "no data: line received"
+    evt = json.loads(lines[0][5:].strip())
+    assert evt["kind"] == "open-app"
+    assert evt["payload"]["app"] == "projects"

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -327,6 +327,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     from tinyagentos.projects.canvas.snapshotter import CanvasSnapshotter
     project_store = ProjectStore(data_dir / "projects.db")
     project_event_broker = ProjectEventBroker()
+    from tinyagentos.desktop_control import DesktopCommandBroker
+    desktop_command_broker = DesktopCommandBroker()
     project_task_store = ProjectTaskStore(data_dir / "projects.db", broker=project_event_broker)
     project_canvas_store = ProjectCanvasStoreImpl(data_dir / "projects.db", broker=project_event_broker)
     projects_root = data_dir / "projects"
@@ -634,6 +636,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         app.state.project_store = project_store
         app.state.project_task_store = project_task_store
         app.state.project_event_broker = project_event_broker
+        app.state.desktop_command_broker = desktop_command_broker
         app.state.project_canvas_store = project_canvas_store
         app.state.projects_root = projects_root
         app.state.chat_hub = chat_hub
@@ -1221,6 +1224,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     app.state.project_store = project_store
     app.state.project_task_store = project_task_store
     app.state.project_event_broker = project_event_broker
+    app.state.desktop_command_broker = desktop_command_broker
     app.state.project_canvas_store = project_canvas_store
     app.state.beads_bridge = None
     app.state.canvas_snapshotter = None

--- a/tinyagentos/desktop_control/__init__.py
+++ b/tinyagentos/desktop_control/__init__.py
@@ -1,0 +1,3 @@
+from tinyagentos.desktop_control.broker import DesktopCommand, DesktopCommandBroker
+
+__all__ = ["DesktopCommand", "DesktopCommandBroker"]

--- a/tinyagentos/desktop_control/broker.py
+++ b/tinyagentos/desktop_control/broker.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class DesktopCommand:
+    """A single instruction for a user's desktop (open an app, move a window…).
+
+    `kind` is the wire discriminator the browser switches on:
+      "open-app" -> dispatched as a `taos:open-app` CustomEvent
+      "window"   -> dispatched as a `taos:window` CustomEvent (a WindowOp)
+    `payload` carries the event detail verbatim.
+    """
+
+    kind: str
+    payload: dict[str, Any]
+    ts: float = field(default_factory=time.time)
+
+
+class DesktopCommandBroker:
+    """In-memory pub/sub for desktop commands, one channel per user_id.
+
+    Mirrors ProjectEventBroker but with NO replay buffer: a command is a
+    one-shot side effect (open this app, move that window). Replaying buffered
+    commands to a freshly-connected desktop would re-open apps the user already
+    closed, so a new subscriber starts from empty and only sees commands emitted
+    after it connects.
+
+    Single-worker assumption: publishers (agent tools) and subscribers (the
+    desktop SSE stream) share one process, same as the canvas broker.
+    """
+
+    def __init__(self) -> None:
+        self._queues: dict[str, list[asyncio.Queue[DesktopCommand]]] = {}
+        self._lock = asyncio.Lock()
+
+    async def subscribe(self, user_id: str) -> asyncio.Queue[DesktopCommand]:
+        queue: asyncio.Queue[DesktopCommand] = asyncio.Queue()
+        async with self._lock:
+            self._queues.setdefault(user_id, []).append(queue)
+        return queue
+
+    async def unsubscribe(self, user_id: str, queue: asyncio.Queue[DesktopCommand]) -> None:
+        async with self._lock:
+            qs = self._queues.get(user_id, [])
+            if queue in qs:
+                qs.remove(queue)
+            if not qs:
+                self._queues.pop(user_id, None)
+
+    async def emit(self, user_id: str, command: DesktopCommand) -> int:
+        """Fan a command out to every open desktop for `user_id`.
+
+        Returns the number of live subscribers it reached (0 means the user has
+        no desktop connected right now — the caller may want to surface that).
+        """
+        async with self._lock:
+            qs = list(self._queues.get(user_id, []))
+            for q in qs:
+                q.put_nowait(command)
+        return len(qs)

--- a/tinyagentos/desktop_control/broker.py
+++ b/tinyagentos/desktop_control/broker.py
@@ -34,12 +34,18 @@ class DesktopCommandBroker:
     desktop SSE stream) share one process, same as the canvas broker.
     """
 
+    # Per-subscriber queues are bounded so a stalled/dead SSE consumer can't grow
+    # memory without limit. On overflow we drop the OLDEST command (a desktop
+    # that far behind has already missed the UI state these describe; the newest
+    # commands are the ones worth keeping).
+    _MAX_QUEUE = 128
+
     def __init__(self) -> None:
         self._queues: dict[str, list[asyncio.Queue[DesktopCommand]]] = {}
         self._lock = asyncio.Lock()
 
     async def subscribe(self, user_id: str) -> asyncio.Queue[DesktopCommand]:
-        queue: asyncio.Queue[DesktopCommand] = asyncio.Queue()
+        queue: asyncio.Queue[DesktopCommand] = asyncio.Queue(maxsize=self._MAX_QUEUE)
         async with self._lock:
             self._queues.setdefault(user_id, []).append(queue)
         return queue
@@ -61,5 +67,10 @@ class DesktopCommandBroker:
         async with self._lock:
             qs = list(self._queues.get(user_id, []))
             for q in qs:
+                if q.full():
+                    try:
+                        q.get_nowait()  # drop the oldest to make room for the newest
+                    except asyncio.QueueEmpty:
+                        pass
                 q.put_nowait(command)
         return len(qs)

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -120,6 +120,9 @@ def register_all_routers(app):
     from tinyagentos.routes.project_canvas import router as project_canvas_router
     app.include_router(project_canvas_router)
 
+    from tinyagentos.routes.desktop_control import router as desktop_control_router
+    app.include_router(desktop_control_router)
+
     from tinyagentos.routes.shared_folders import router as shared_folders_router
     app.include_router(shared_folders_router)
 

--- a/tinyagentos/routes/desktop_control.py
+++ b/tinyagentos/routes/desktop_control.py
@@ -1,0 +1,73 @@
+"""Controller -> browser command channel for agent-driven desktop control.
+
+The desktop subscribes to GET /api/desktop/stream (SSE) and re-dispatches each
+command as the existing `taos:open-app` / `taos:window` CustomEvents (see
+desktop/src/hooks/use-desktop-command-stream.ts). Agent tools push commands via
+POST /api/desktop/command, scoped to the calling user so a user only ever drives
+their own desktop. This is the backend half of the agent-OS-control layer (#836);
+the browser receivers already exist and are tested.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any, Literal
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse, StreamingResponse
+from pydantic import BaseModel, Field
+
+from tinyagentos.desktop_control.broker import DesktopCommand
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+def _user_id(request: Request) -> str:
+    user = getattr(request.state, "user", None)
+    if user and isinstance(user, dict) and "id" in user:
+        return user["id"]
+    return "system"
+
+
+class CommandIn(BaseModel):
+    kind: Literal["open-app", "window"]
+    payload: dict[str, Any] = Field(default_factory=dict)
+
+
+@router.post("/api/desktop/command")
+async def post_command(body: CommandIn, request: Request):
+    """Push one command to the calling user's desktop(s). Returns how many open
+    desktops received it (0 = the user has no desktop connected right now)."""
+    broker = request.app.state.desktop_command_broker
+    delivered = await broker.emit(
+        _user_id(request),
+        DesktopCommand(kind=body.kind, payload=body.payload),
+    )
+    return {"delivered": delivered}
+
+
+@router.get("/api/desktop/stream")
+async def desktop_stream(request: Request):
+    """SSE stream of desktop commands for the calling user."""
+    broker = request.app.state.desktop_command_broker
+    user_id = _user_id(request)
+    queue = await broker.subscribe(user_id)
+
+    async def gen():
+        try:
+            while True:
+                if await request.is_disconnected():
+                    return
+                try:
+                    cmd = await asyncio.wait_for(queue.get(), timeout=10.0)
+                except asyncio.TimeoutError:
+                    yield ":keepalive\n\n"
+                    continue
+                data = json.dumps({"kind": cmd.kind, "payload": cmd.payload, "ts": cmd.ts})
+                yield f"data: {data}\n\n"
+        finally:
+            await broker.unsubscribe(user_id, queue)
+
+    return StreamingResponse(gen(), media_type="text/event-stream")

--- a/tinyagentos/routes/desktop_control.py
+++ b/tinyagentos/routes/desktop_control.py
@@ -25,10 +25,13 @@ router = APIRouter()
 
 
 def _user_id(request: Request) -> str:
-    user = getattr(request.state, "user", None)
-    if user and isinstance(user, dict) and "id" in user:
-        return user["id"]
-    return "system"
+    # AuthMiddleware sets request.state.user_id (a string id or None). Scoping
+    # the command channel by the authenticated user is SECURITY-CRITICAL here:
+    # if every caller collapsed to one id, an agent acting for user A could
+    # drive user B's desktop. Unauthenticated/exempt requests have no desktop to
+    # drive, so the "system" fallback is inert rather than a shared channel.
+    uid = getattr(request.state, "user_id", None)
+    return uid if uid else "system"
 
 
 class CommandIn(BaseModel):
@@ -70,4 +73,10 @@ async def desktop_stream(request: Request):
         finally:
             await broker.unsubscribe(user_id, queue)
 
-    return StreamingResponse(gen(), media_type="text/event-stream")
+    # no-cache + X-Accel-Buffering stop nginx/proxies from buffering the stream
+    # (which would delay or coalesce commands the user is waiting to see act).
+    return StreamingResponse(
+        gen(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no", "Connection": "keep-alive"},
+    )


### PR DESCRIPTION
## What

Phase 1 of the **agent-OS-control transport** — the linchpin for the offline agent-driven storybook demo. Lets the controller (and through it the taOS agent) open apps and drive windows on a specific user's desktop.

The desktop subscribes to an SSE command stream and re-dispatches each command to the **existing** `taos:open-app` / `taos:window` receivers (from #874 / deep-nav), so there's no new app logic — just the missing backend→browser hop.

## How
- **`DesktopCommandBroker`** (`tinyagentos/desktop_control/broker.py`): per-`user_id` pub/sub, mirrors the canvas broker but with **no replay** — a command is a one-shot side effect; replaying buffered commands to a reconnecting desktop would re-open closed apps.
- **Routes** (`tinyagentos/routes/desktop_control.py`):
  - `GET /api/desktop/stream` — SSE, scoped to the caller's `user_id`.
  - `POST /api/desktop/command` — body `{kind, payload}`; emits to the caller's **own** desktop(s) only. Returns `{delivered: N}`.
- **Browser receiver** (`use-desktop-command-stream.ts`, mounted in `Desktop.tsx`): re-dispatches `open-app`→`taos:open-app`, `window`→`taos:window`.

## Security
`POST /command` emits only to `_user_id(request)` — a caller can only ever drive **their own** desktop; no cross-user vector. Sits behind the existing API auth/onboarding middleware.

## Tests
- 8 backend (broker fan-out, per-user isolation, **no-replay**, unsubscribe, route validation, real SSE delivery over ASGI)
- 5 frontend (subscribe, re-dispatch both kinds, malformed payload, unmount close)
- `tsc` + `vite build` clean; app constructs with both routes registered.

## Not in this PR (next)
Agent MCP tools (`open_app`/`arrange_windows` + data tools wrapping existing project/canvas/image routes) that POST commands, plus the agent-manual entry — they land **together** so the manual only advertises capabilities the agent can actually invoke. The live agent-drives-desktop **visual** is a Pi-verify (same bar as #874).

Spec: agent-OS-control + storybook demo (private).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added agent-driven desktop control to trigger opening apps and managing windows through a live backend-to-browser command stream.
  * Introduced REST endpoints to submit commands and to subscribe to an SSE stream for real-time delivery.
  * Browser now converts streamed commands into the existing desktop event handlers.

* **Bug Fixes**
  * Malformed incoming stream messages are safely ignored.

* **Tests**
  * Added coverage for per-user isolation, no-replay behavior, bounded buffering, unsubscribe behavior, and route validation.

* **Documentation**
  * Documented the controller-to-browser command channel and provided a curl usage example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->