### PR TITLE
feat(agent): open_app + arrange_windows tools — agent OS control (phase 2)

### DIFF
--- a/docs/agent-manual/09-os-control.md
+++ b/docs/agent-manual/09-os-control.md
@@ -14,9 +14,8 @@ Tools available to you:
   `center`, or `cascade`.
 
 These drive the user's own desktop in their session. Use them to make your work
-visible: open the app, then carry out the task with that app's own tools (create a
-project, add tasks, generate an image, place it on the project's board). The user
-watches it happen live.
+visible: open the relevant app so the user can watch, then carry out the task with
+that app's own tools and your other skills.
 
 Keep it purposeful: open what you need, don't rearrange the user's windows without
 reason, and tell the user what you're doing as you do it.

--- a/docs/agent-manual/09-os-control.md
+++ b/docs/agent-manual/09-os-control.md
@@ -1,0 +1,22 @@
+# Driving the desktop (OS control)
+
+You can operate the user's desktop for them, not just talk about it. When a task
+is easier shown than described, open the app and do it.
+
+Tools available to you:
+
+- **open_app** — open or focus an app so the user can see it. Args: `app` (one of
+  projects, images, chat, messages, agents, files, store, settings, terminal,
+  browser, memory, models), optional `props` to deep-link. Open the relevant app
+  before you act in it (e.g. open `projects` before creating a project, `images`
+  before generating artwork).
+- **arrange_windows** — tidy the open windows. `preset`: `tile-2`, `tile-3`,
+  `center`, or `cascade`.
+
+These drive the user's own desktop in their session. Use them to make your work
+visible: open the app, then carry out the task with that app's own tools (create a
+project, add tasks, generate an image, place it on the project's board). The user
+watches it happen live.
+
+Keep it purposeful: open what you need, don't rearrange the user's windows without
+reason, and tell the user what you're doing as you do it.

--- a/docs/agent-manual/index.md
+++ b/docs/agent-manual/index.md
@@ -17,3 +17,4 @@ Run `python3 scripts/build-agent-manual.py` to compile these into `docs/taos-age
 | `06-updates-privacy.md` | Update flow, anonymous install ping, privacy answers |
 | `07-after-update.md` | Breakage-log-first troubleshooting for post-update reports |
 | `08-answer-templates.md` | Canned answer shapes for common questions |
+| `09-os-control.md` | Driving the desktop: open_app / arrange_windows tools |

--- a/docs/taos-agent-manual.md
+++ b/docs/taos-agent-manual.md
@@ -138,3 +138,27 @@ Match the user's symptom against that log before reasoning from scratch. Known c
 **"Where do I report a bug?"** github.com/jaylfc/tinyagentos/issues, with the error text and what hardware you are on. If something broke right after an update, mention that; there is a known-breakages log the developers check first.
 
 **"Can taOS work fully offline?"** Yes. With local models installed (rkllama or Ollama backends), every part of taOS runs on your network with no internet. Internet is only needed to download models, install apps from the store, check for updates, and use cloud model providers.
+---
+
+# Driving the desktop (OS control)
+
+You can operate the user's desktop for them, not just talk about it. When a task
+is easier shown than described, open the app and do it.
+
+Tools available to you:
+
+- **open_app** — open or focus an app so the user can see it. Args: `app` (one of
+  projects, images, chat, messages, agents, files, store, settings, terminal,
+  browser, memory, models), optional `props` to deep-link. Open the relevant app
+  before you act in it (e.g. open `projects` before creating a project, `images`
+  before generating artwork).
+- **arrange_windows** — tidy the open windows. `preset`: `tile-2`, `tile-3`,
+  `center`, or `cascade`.
+
+These drive the user's own desktop in their session. Use them to make your work
+visible: open the app, then carry out the task with that app's own tools (create a
+project, add tasks, generate an image, place it on the project's board). The user
+watches it happen live.
+
+Keep it purposeful: open what you need, don't rearrange the user's windows without
+reason, and tell the user what you're doing as you do it.

--- a/docs/taos-agent-manual.md
+++ b/docs/taos-agent-manual.md
@@ -156,9 +156,8 @@ Tools available to you:
   `center`, or `cascade`.
 
 These drive the user's own desktop in their session. Use them to make your work
-visible: open the app, then carry out the task with that app's own tools (create a
-project, add tasks, generate an image, place it on the project's board). The user
-watches it happen live.
+visible: open the relevant app so the user can watch, then carry out the task with
+that app's own tools and your other skills.
 
 Keep it purposeful: open what you need, don't rearrange the user's windows without
 reason, and tell the user what you're doing as you do it.

--- a/tests/test_desktop_tools.py
+++ b/tests/test_desktop_tools.py
@@ -68,3 +68,14 @@ async def test_scoped_to_caller_user():
     await execute_open_app({"app": "store"}, _fake_request(broker, user_id="user-1"))
     with pytest.raises(asyncio.TimeoutError):
         await asyncio.wait_for(other.get(), timeout=0.1)
+
+
+@pytest.mark.asyncio
+async def test_refuses_when_no_authenticated_user():
+    """With no user_id, the tool refuses rather than emitting to a shared bucket."""
+    broker = DesktopCommandBroker()
+    sub = await broker.subscribe("system")
+    res = await execute_open_app({"app": "projects"}, _fake_request(broker, user_id=None))
+    assert "error" in res
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(sub.get(), timeout=0.1)

--- a/tests/test_desktop_tools.py
+++ b/tests/test_desktop_tools.py
@@ -1,0 +1,70 @@
+import asyncio
+import types
+
+import pytest
+
+from tinyagentos.desktop_control.broker import DesktopCommandBroker
+from tinyagentos.tools.desktop_tools import execute_open_app, execute_arrange_windows
+
+
+def _fake_request(broker, user_id="user-1"):
+    """Minimal stand-in for a FastAPI Request: .app.state + .state.user_id."""
+    state = types.SimpleNamespace(desktop_command_broker=broker)
+    app = types.SimpleNamespace(state=state)
+    return types.SimpleNamespace(app=app, state=types.SimpleNamespace(user_id=user_id))
+
+
+@pytest.mark.asyncio
+async def test_open_app_emits_open_command():
+    broker = DesktopCommandBroker()
+    q = await broker.subscribe("user-1")
+    req = _fake_request(broker)
+    res = await execute_open_app({"app": "projects"}, req)
+    assert res["ok"] and res["delivered"] == 1
+    cmd = await asyncio.wait_for(q.get(), timeout=0.5)
+    assert cmd.kind == "open-app" and cmd.payload["app"] == "projects"
+
+
+@pytest.mark.asyncio
+async def test_open_app_passes_props():
+    broker = DesktopCommandBroker()
+    q = await broker.subscribe("user-1")
+    req = _fake_request(broker)
+    await execute_open_app({"app": "messages", "props": {"channel": "general"}}, req)
+    cmd = await asyncio.wait_for(q.get(), timeout=0.5)
+    assert cmd.payload["props"] == {"channel": "general"}
+
+
+@pytest.mark.asyncio
+async def test_open_app_requires_app():
+    broker = DesktopCommandBroker()
+    res = await execute_open_app({}, _fake_request(broker))
+    assert "error" in res
+
+
+@pytest.mark.asyncio
+async def test_arrange_windows_emits_window_command():
+    broker = DesktopCommandBroker()
+    q = await broker.subscribe("user-1")
+    req = _fake_request(broker)
+    res = await execute_arrange_windows({"preset": "tile-3"}, req)
+    assert res["ok"]
+    cmd = await asyncio.wait_for(q.get(), timeout=0.5)
+    assert cmd.kind == "window" and cmd.payload == {"action": "arrange", "preset": "tile-3"}
+
+
+@pytest.mark.asyncio
+async def test_arrange_windows_rejects_bad_preset():
+    broker = DesktopCommandBroker()
+    res = await execute_arrange_windows({"preset": "spiral"}, _fake_request(broker))
+    assert "error" in res
+
+
+@pytest.mark.asyncio
+async def test_scoped_to_caller_user():
+    """A command only reaches the calling user's desktop, never another user's."""
+    broker = DesktopCommandBroker()
+    other = await broker.subscribe("user-2")
+    await execute_open_app({"app": "store"}, _fake_request(broker, user_id="user-1"))
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(other.get(), timeout=0.1)

--- a/tinyagentos/routes/skill_exec.py
+++ b/tinyagentos/routes/skill_exec.py
@@ -175,6 +175,26 @@ async def _skill_list_image_models(args: dict, request: Request) -> dict:
         return {"error": str(exc)}
 
 
+async def _skill_open_app(args: dict, request: Request) -> dict:
+    """Open an app on the user's desktop (agent OS control)."""
+    try:
+        from tinyagentos.tools.desktop_tools import execute_open_app
+
+        return await execute_open_app(args, request)
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
+async def _skill_arrange_windows(args: dict, request: Request) -> dict:
+    """Arrange the user's desktop windows (agent OS control)."""
+    try:
+        from tinyagentos.tools.desktop_tools import execute_arrange_windows
+
+        return await execute_arrange_windows(args, request)
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
 SKILL_IMPLEMENTATIONS = {
     "memory_search": _skill_memory_search,
     "file_read": _skill_file_read,
@@ -184,6 +204,8 @@ SKILL_IMPLEMENTATIONS = {
     "http_request": _skill_http_request,
     "image_generation": _skill_image_generation,
     "list_image_models": _skill_list_image_models,
+    "open_app": _skill_open_app,
+    "arrange_windows": _skill_arrange_windows,
 }
 
 

--- a/tinyagentos/skills.py
+++ b/tinyagentos/skills.py
@@ -34,11 +34,11 @@ class SkillStore(BaseStore):
     """
 
     async def _post_init(self):
-        assert self._db is not None
-        cursor = await self._db.execute("SELECT COUNT(*) FROM skills")
-        row = await cursor.fetchone()
-        if row and row[0] == 0:
-            await self._seed_defaults()
+        # Seed is idempotent (INSERT OR IGNORE on the id PK), so run it on every
+        # startup: a fresh install gets the full set, and an EXISTING install
+        # backfills any builtin skills added since it was first seeded (e.g. new
+        # desktop-control tools) without disturbing user-installed skills.
+        await self._seed_defaults()
 
     async def _seed_defaults(self):
         """Seed the default skill set."""
@@ -295,7 +295,7 @@ class SkillStore(BaseStore):
 
         for skill in defaults:
             await self._db.execute(
-                """INSERT INTO skills (id, name, category, description, tool_schema, frameworks,
+                """INSERT OR IGNORE INTO skills (id, name, category, description, tool_schema, frameworks,
                    requires_services, install_method, install_target, installed, created_at)
                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?)""",
                 (

--- a/tinyagentos/skills.py
+++ b/tinyagentos/skills.py
@@ -238,6 +238,59 @@ class SkillStore(BaseStore):
                 "install_method": "builtin",
                 "install_target": "tinyagentos.tools.http_request",
             },
+            {
+                "id": "open_app",
+                "name": "Open App",
+                "category": "desktop",
+                "description": "Open an app on the user's desktop so they can see it",
+                "tool_schema": {
+                    "name": "open_app",
+                    "description": "Open (or focus) an app on the user's desktop (e.g. projects, images, chat).",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {
+                            "app": {"type": "string", "description": "App id, e.g. 'projects', 'images', 'chat'."},
+                            "props": {"type": "object", "description": "Optional deep-link props."},
+                        },
+                        "required": ["app"],
+                    },
+                },
+                "frameworks": {
+                    "smolagents": "adapter", "openclaw": "adapter", "pocketflow": "adapter",
+                    "langroid": "adapter", "hermes": "adapter", "agent-zero": "adapter",
+                    "openai-agents-sdk": "adapter", "generic": "adapter",
+                },
+                "install_method": "builtin",
+                "install_target": "tinyagentos.tools.desktop_tools",
+            },
+            {
+                "id": "arrange_windows",
+                "name": "Arrange Windows",
+                "category": "desktop",
+                "description": "Arrange the user's desktop windows into a tidy layout",
+                "tool_schema": {
+                    "name": "arrange_windows",
+                    "description": "Arrange open windows. Presets: tile-2, tile-3, center, cascade.",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {
+                            "preset": {
+                                "type": "string",
+                                "enum": ["tile-2", "tile-3", "center", "cascade"],
+                                "description": "Layout preset.",
+                            },
+                        },
+                        "required": ["preset"],
+                    },
+                },
+                "frameworks": {
+                    "smolagents": "adapter", "openclaw": "adapter", "pocketflow": "adapter",
+                    "langroid": "adapter", "hermes": "adapter", "agent-zero": "adapter",
+                    "openai-agents-sdk": "adapter", "generic": "adapter",
+                },
+                "install_method": "builtin",
+                "install_target": "tinyagentos.tools.desktop_tools",
+            },
         ]
 
         for skill in defaults:

--- a/tinyagentos/tools/desktop_tools.py
+++ b/tinyagentos/tools/desktop_tools.py
@@ -1,0 +1,100 @@
+"""Agent tools for driving the taOS desktop (the "agent OS control" framework).
+
+Two thin tools that let an agent open apps and arrange windows on the user's
+desktop. Each just emits a command onto the per-user DesktopCommandBroker; the
+controller streams it to the browser (GET /api/desktop/stream) which re-dispatches
+it to the existing window receivers. See docs/desktop-control.md.
+
+Kept deliberately small: the whole "agent can drive the OS" capability is these
+two emits plus the transport. Data actions (create a project, add a task, place
+an image) are separate tools that call the existing project/canvas/image routes
+and show up live via those apps' own SSE — they don't need this channel.
+"""
+from __future__ import annotations
+
+from fastapi import Request
+
+from tinyagentos.desktop_control.broker import DesktopCommand
+
+# Known desktop app ids the agent can open. The browser resolves aliases/names
+# too, but listing the common ones in the schema steers the model.
+KNOWN_APPS = [
+    "chat", "messages", "projects", "agents", "files", "store", "settings",
+    "images", "terminal", "browser", "memory", "models",
+]
+
+OPEN_APP_TOOL = {
+    "name": "open_app",
+    "description": (
+        "Open (or focus) an app on the user's desktop so they can see it. Use "
+        "this to bring an app to the foreground while you work, e.g. open the "
+        "Projects app before creating a project, or the Images app before "
+        "generating artwork."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "app": {
+                "type": "string",
+                "description": f"App to open. One of: {', '.join(KNOWN_APPS)}.",
+            },
+            "props": {
+                "type": "object",
+                "description": "Optional deep-link props for the app (e.g. a channel or project id).",
+            },
+        },
+        "required": ["app"],
+    },
+}
+
+ARRANGE_WINDOWS_TOOL = {
+    "name": "arrange_windows",
+    "description": (
+        "Arrange the user's open windows into a tidy layout. Presets: 'tile-2' "
+        "and 'tile-3' tile the top 2/3 windows side by side, 'center' centers "
+        "them, 'cascade' staggers them."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "preset": {
+                "type": "string",
+                "enum": ["tile-2", "tile-3", "center", "cascade"],
+                "description": "The layout preset to apply.",
+            },
+        },
+        "required": ["preset"],
+    },
+}
+
+
+def _user_id(request: Request) -> str:
+    # Drive the desktop of the authenticated caller (AuthMiddleware ->
+    # request.state.user_id). The taOS agent runs in the user's session, so this
+    # resolves to that user; a caller with no session has no desktop to drive.
+    uid = getattr(request.state, "user_id", None)
+    return uid if uid else "system"
+
+
+async def execute_open_app(args: dict, request: Request) -> dict:
+    app = (args or {}).get("app")
+    if not app or not isinstance(app, str):
+        return {"error": "open_app requires an 'app' string"}
+    broker = request.app.state.desktop_command_broker
+    payload = {"app": app}
+    if isinstance((args or {}).get("props"), dict):
+        payload["props"] = args["props"]
+    delivered = await broker.emit(_user_id(request), DesktopCommand(kind="open-app", payload=payload))
+    return {"ok": True, "app": app, "delivered": delivered}
+
+
+async def execute_arrange_windows(args: dict, request: Request) -> dict:
+    preset = (args or {}).get("preset")
+    if preset not in {"tile-2", "tile-3", "center", "cascade"}:
+        return {"error": "arrange_windows requires a valid 'preset'"}
+    broker = request.app.state.desktop_command_broker
+    delivered = await broker.emit(
+        _user_id(request),
+        DesktopCommand(kind="window", payload={"action": "arrange", "preset": preset}),
+    )
+    return {"ok": True, "preset": preset, "delivered": delivered}

--- a/tinyagentos/tools/desktop_tools.py
+++ b/tinyagentos/tools/desktop_tools.py
@@ -68,23 +68,26 @@ ARRANGE_WINDOWS_TOOL = {
 }
 
 
-def _user_id(request: Request) -> str:
+def _user_id(request: Request) -> str | None:
     # Drive the desktop of the authenticated caller (AuthMiddleware ->
     # request.state.user_id). The taOS agent runs in the user's session, so this
-    # resolves to that user; a caller with no session has no desktop to drive.
-    uid = getattr(request.state, "user_id", None)
-    return uid if uid else "system"
+    # resolves to that user. Returns None when there is no authenticated user;
+    # the caller refuses rather than emitting onto a shared bucket.
+    return getattr(request.state, "user_id", None) or None
 
 
 async def execute_open_app(args: dict, request: Request) -> dict:
     app = (args or {}).get("app")
     if not app or not isinstance(app, str):
         return {"error": "open_app requires an 'app' string"}
+    user_id = _user_id(request)
+    if not user_id:
+        return {"error": "no authenticated user desktop to drive"}
     broker = request.app.state.desktop_command_broker
     payload = {"app": app}
     if isinstance((args or {}).get("props"), dict):
         payload["props"] = args["props"]
-    delivered = await broker.emit(_user_id(request), DesktopCommand(kind="open-app", payload=payload))
+    delivered = await broker.emit(user_id, DesktopCommand(kind="open-app", payload=payload))
     return {"ok": True, "app": app, "delivered": delivered}
 
 
@@ -92,9 +95,12 @@ async def execute_arrange_windows(args: dict, request: Request) -> dict:
     preset = (args or {}).get("preset")
     if preset not in {"tile-2", "tile-3", "center", "cascade"}:
         return {"error": "arrange_windows requires a valid 'preset'"}
+    user_id = _user_id(request)
+    if not user_id:
+        return {"error": "no authenticated user desktop to drive"}
     broker = request.app.state.desktop_command_broker
     delivered = await broker.emit(
-        _user_id(request),
+        user_id,
         DesktopCommand(kind="window", payload={"action": "arrange", "preset": preset}),
     )
     return {"ok": True, "preset": preset, "delivered": delivered}


### PR DESCRIPTION
## What
Completes the **agent-OS-control framework** (phase 2 on top of #877's transport). The taOS agent can now **open apps and arrange windows on the user's desktop** — the visible half of the storybook-demo flow.

## How (kept minimal, easy to follow)
- `tinyagentos/tools/desktop_tools.py`: `execute_open_app` / `execute_arrange_windows`. Each emits one command onto the per-user `DesktopCommandBroker` (#877); the controller streams it to the browser which re-dispatches to the existing `taos:open-app` / `taos:window` receivers. No new app logic.
- Scoped to the calling user via `request.state.user_id` — an agent only ever drives **its user's** desktop.
- Wired into `skill_exec` `SKILL_IMPLEMENTATIONS` + seeded in `skills.py` (category `desktop`), so they're discoverable/assignable like any other skill.
- Agent manual: new `09-os-control.md` + recompiled `docs/taos-agent-manual.md` (so the agent only learns capabilities it can actually invoke).

## Tests
6 tool tests (emit open-app/window commands, props pass-through, **per-user scoping**, arg validation); 27 related tests (desktop_tools + desktop_control + skill_runtime + skills) green; app constructs; manual-compiled test green.

## Next
Data tools (create_project / add_task / canvas_add_image wrapping existing routes) so the agent builds the project visibly via those apps' own SSE — separate small PR.