### PR TITLE
fix(chat-pwa): apply persisted theme on boot (respect light/dark)

### DIFF
--- a/desktop/src/chat-main.tsx
+++ b/desktop/src/chat-main.tsx
@@ -2,7 +2,13 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { ChatStandalone } from "./ChatStandalone";
 import { AppShell } from "./components/AppShell";
+import { restoreActiveTheme } from "./stores/theme-store";
 import "./theme/tokens.css";
+
+// Apply the user's persisted theme (light/dark/etc.) on boot, the same as the
+// desktop shell does in App.tsx. Without this the standalone chat PWA always
+// renders the base dark tokens and ignores the user's chosen theme.
+void restoreActiveTheme();
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>


### PR DESCRIPTION
While verifying the mobile chat polish on the Pi, found the standalone **taOS talk PWA (`/chat-pwa`) never applies the user's selected theme** — `chat-main.tsx` only imported `tokens.css`, so it always rendered base dark and ignored light mode (pre-existing, not from #880).

Fix: call `restoreActiveTheme()` on PWA boot, exactly as the desktop shell does in `App.tsx`. Now `/chat-pwa` respects the user's theme like the in-OS view does.

tsc + build clean. Will verify light + dark on the Pi after merge.