### PR TITLE
feat(agent): project data tools (create_project, add_task, canvas_add_image)

### DIFF
--- a/docs/agent-manual/09-os-control.md
+++ b/docs/agent-manual/09-os-control.md
@@ -13,6 +13,18 @@ Tools available to you:
 - **arrange_windows** — tidy the open windows. `preset`: `tile-2`, `tile-3`,
   `center`, or `cascade`.
 
+You can also build inside a project, and the user watches it happen live (these
+update the open Projects app in real time):
+
+- **create_project** — create a project. Args: `name`, optional `description`.
+  Returns a `project_id` to use in the next calls.
+- **add_task** — add a to-do task to a project's board. Args: `project_id`, `title`.
+- **canvas_add_image** — place a generated image on a project's ideas board. Args:
+  `project_id`, `file_id` (from `generate_image`), optional `alt`.
+
+A typical flow: open the Projects app, create_project, add a few tasks, generate
+an image, then canvas_add_image it onto the board.
+
 These drive the user's own desktop in their session. Use them to make your work
 visible: open the relevant app so the user can watch, then carry out the task with
 that app's own tools and your other skills.

--- a/docs/taos-agent-manual.md
+++ b/docs/taos-agent-manual.md
@@ -155,6 +155,18 @@ Tools available to you:
 - **arrange_windows** — tidy the open windows. `preset`: `tile-2`, `tile-3`,
   `center`, or `cascade`.
 
+You can also build inside a project, and the user watches it happen live (these
+update the open Projects app in real time):
+
+- **create_project** — create a project. Args: `name`, optional `description`.
+  Returns a `project_id` to use in the next calls.
+- **add_task** — add a to-do task to a project's board. Args: `project_id`, `title`.
+- **canvas_add_image** — place a generated image on a project's ideas board. Args:
+  `project_id`, `file_id` (from `generate_image`), optional `alt`.
+
+A typical flow: open the Projects app, create_project, add a few tasks, generate
+an image, then canvas_add_image it onto the board.
+
 These drive the user's own desktop in their session. Use them to make your work
 visible: open the relevant app so the user can watch, then carry out the task with
 that app's own tools and your other skills.

--- a/tests/test_project_tools.py
+++ b/tests/test_project_tools.py
@@ -11,12 +11,18 @@ from tinyagentos.tools.project_tools import (
 
 
 class _FakeProjectStore:
-    def __init__(self):
+    def __init__(self, owner="user-1"):
         self.calls = []
+        self._owner = owner
 
     async def create_project(self, **kw):
         self.calls.append(kw)
         return {"id": "proj_1", "name": kw["name"]}
+
+    async def get_project(self, project_id):
+        if project_id == "missing":
+            return None
+        return {"id": project_id, "user_id": self._owner}
 
 
 class _FakeTaskStore:
@@ -37,14 +43,16 @@ class _FakeCanvasStore:
         return {"id": "el_1"}
 
 
-def _req(user_id="user-1"):
+def _req(user_id="user-1", owner="user-1", is_admin=False):
     state = types.SimpleNamespace(
-        project_store=_FakeProjectStore(),
+        project_store=_FakeProjectStore(owner=owner),
         project_task_store=_FakeTaskStore(),
         project_canvas_store=_FakeCanvasStore(),
     )
     app = types.SimpleNamespace(state=state)
-    return types.SimpleNamespace(app=app, state=types.SimpleNamespace(user_id=user_id))
+    return types.SimpleNamespace(
+        app=app, state=types.SimpleNamespace(user_id=user_id, is_admin=is_admin)
+    )
 
 
 def test_slugify():
@@ -93,6 +101,36 @@ async def test_canvas_add_image():
     assert call["author_kind"] == "agent" and call["author_id"] == "user-1"
     el = call["element"]
     assert el["kind"] == "image" and el["payload"]["file_id"] == "img_cover"
+
+
+@pytest.mark.asyncio
+async def test_add_task_denied_on_other_users_project():
+    """Writing to a project the caller does not own is refused."""
+    req = _req(user_id="attacker", owner="victim")
+    res = await execute_add_task({"project_id": "proj_1", "title": "x"}, req)
+    assert res.get("error") == "not your project"
+    assert req.app.state.project_task_store.calls == []
+
+
+@pytest.mark.asyncio
+async def test_canvas_add_image_denied_on_other_users_project():
+    req = _req(user_id="attacker", owner="victim")
+    res = await execute_canvas_add_image({"project_id": "proj_1", "file_id": "f"}, req)
+    assert res.get("error") == "not your project"
+    assert req.app.state.project_canvas_store.calls == []
+
+
+@pytest.mark.asyncio
+async def test_admin_may_write_any_project():
+    req = _req(user_id="admin", owner="someone", is_admin=True)
+    res = await execute_add_task({"project_id": "proj_1", "title": "ok"}, req)
+    assert res["ok"]
+
+
+@pytest.mark.asyncio
+async def test_add_task_missing_project():
+    res = await execute_add_task({"project_id": "missing", "title": "x"}, _req())
+    assert res.get("error") == "project not found"
 
 
 @pytest.mark.asyncio

--- a/tests/test_project_tools.py
+++ b/tests/test_project_tools.py
@@ -1,0 +1,102 @@
+import types
+
+import pytest
+
+from tinyagentos.tools.project_tools import (
+    execute_create_project,
+    execute_add_task,
+    execute_canvas_add_image,
+    _slugify,
+)
+
+
+class _FakeProjectStore:
+    def __init__(self):
+        self.calls = []
+
+    async def create_project(self, **kw):
+        self.calls.append(kw)
+        return {"id": "proj_1", "name": kw["name"]}
+
+
+class _FakeTaskStore:
+    def __init__(self):
+        self.calls = []
+
+    async def create_task(self, **kw):
+        self.calls.append(kw)
+        return {"id": "task_1", "title": kw["title"]}
+
+
+class _FakeCanvasStore:
+    def __init__(self):
+        self.calls = []
+
+    async def add_element(self, **kw):
+        self.calls.append(kw)
+        return {"id": "el_1"}
+
+
+def _req(user_id="user-1"):
+    state = types.SimpleNamespace(
+        project_store=_FakeProjectStore(),
+        project_task_store=_FakeTaskStore(),
+        project_canvas_store=_FakeCanvasStore(),
+    )
+    app = types.SimpleNamespace(state=state)
+    return types.SimpleNamespace(app=app, state=types.SimpleNamespace(user_id=user_id))
+
+
+def test_slugify():
+    assert _slugify("Luna and the Lighthouse") == "luna-and-the-lighthouse"
+    assert _slugify("  ") == "project"
+    assert _slugify("Hello!! World") == "hello-world"
+
+
+@pytest.mark.asyncio
+async def test_create_project():
+    req = _req()
+    res = await execute_create_project({"name": "Luna and the Lighthouse"}, req)
+    assert res["ok"] and res["project_id"] == "proj_1"
+    call = req.app.state.project_store.calls[0]
+    assert call["name"] == "Luna and the Lighthouse"
+    assert call["slug"] == "luna-and-the-lighthouse"
+    assert call["created_by"] == "user-1" and call["user_id"] == "user-1"
+
+
+@pytest.mark.asyncio
+async def test_create_project_requires_name():
+    assert "error" in await execute_create_project({}, _req())
+
+
+@pytest.mark.asyncio
+async def test_add_task():
+    req = _req()
+    res = await execute_add_task({"project_id": "proj_1", "title": "Outline the story"}, req)
+    assert res["ok"] and res["task_id"] == "task_1"
+    call = req.app.state.project_task_store.calls[0]
+    assert call["project_id"] == "proj_1" and call["title"] == "Outline the story"
+
+
+@pytest.mark.asyncio
+async def test_add_task_requires_fields():
+    assert "error" in await execute_add_task({"project_id": "p"}, _req())
+
+
+@pytest.mark.asyncio
+async def test_canvas_add_image():
+    req = _req()
+    res = await execute_canvas_add_image({"project_id": "proj_1", "file_id": "img_cover", "alt": "cover"}, req)
+    assert res["ok"] and res["element_id"] == "el_1"
+    call = req.app.state.project_canvas_store.calls[0]
+    assert call["project_id"] == "proj_1"
+    assert call["author_kind"] == "agent" and call["author_id"] == "user-1"
+    el = call["element"]
+    assert el["kind"] == "image" and el["payload"]["file_id"] == "img_cover"
+
+
+@pytest.mark.asyncio
+async def test_tools_refuse_without_user():
+    assert "error" in await execute_create_project({"name": "x"}, _req(user_id=None))
+    assert "error" in await execute_add_task({"project_id": "p", "title": "t"}, _req(user_id=None))
+    assert "error" in await execute_canvas_add_image({"project_id": "p", "file_id": "f"}, _req(user_id=None))

--- a/tinyagentos/routes/skill_exec.py
+++ b/tinyagentos/routes/skill_exec.py
@@ -195,6 +195,36 @@ async def _skill_arrange_windows(args: dict, request: Request) -> dict:
         return {"error": str(exc)}
 
 
+async def _skill_create_project(args: dict, request: Request) -> dict:
+    """Create a project the user can see."""
+    try:
+        from tinyagentos.tools.project_tools import execute_create_project
+
+        return await execute_create_project(args, request)
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
+async def _skill_add_task(args: dict, request: Request) -> dict:
+    """Add a task to a project's board (streams live)."""
+    try:
+        from tinyagentos.tools.project_tools import execute_add_task
+
+        return await execute_add_task(args, request)
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
+async def _skill_canvas_add_image(args: dict, request: Request) -> dict:
+    """Place a generated image on a project's canvas (streams live)."""
+    try:
+        from tinyagentos.tools.project_tools import execute_canvas_add_image
+
+        return await execute_canvas_add_image(args, request)
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
 SKILL_IMPLEMENTATIONS = {
     "memory_search": _skill_memory_search,
     "file_read": _skill_file_read,
@@ -206,6 +236,9 @@ SKILL_IMPLEMENTATIONS = {
     "list_image_models": _skill_list_image_models,
     "open_app": _skill_open_app,
     "arrange_windows": _skill_arrange_windows,
+    "create_project": _skill_create_project,
+    "add_task": _skill_add_task,
+    "canvas_add_image": _skill_canvas_add_image,
 }
 
 

--- a/tinyagentos/skills.py
+++ b/tinyagentos/skills.py
@@ -291,6 +291,82 @@ class SkillStore(BaseStore):
                 "install_method": "builtin",
                 "install_target": "tinyagentos.tools.desktop_tools",
             },
+            {
+                "id": "create_project",
+                "name": "Create Project",
+                "category": "projects",
+                "description": "Create a project for the user",
+                "tool_schema": {
+                    "name": "create_project",
+                    "description": "Create a project and return its id.",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string", "description": "Project title."},
+                            "description": {"type": "string", "description": "Short summary."},
+                        },
+                        "required": ["name"],
+                    },
+                },
+                "frameworks": {
+                    "smolagents": "adapter", "openclaw": "adapter", "pocketflow": "adapter",
+                    "langroid": "adapter", "hermes": "adapter", "agent-zero": "adapter",
+                    "openai-agents-sdk": "adapter", "generic": "adapter",
+                },
+                "install_method": "builtin",
+                "install_target": "tinyagentos.tools.project_tools",
+            },
+            {
+                "id": "add_task",
+                "name": "Add Task",
+                "category": "projects",
+                "description": "Add a task to a project's board",
+                "tool_schema": {
+                    "name": "add_task",
+                    "description": "Add a to-do task to a project board (appears live).",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {
+                            "project_id": {"type": "string", "description": "Id from create_project."},
+                            "title": {"type": "string", "description": "Task title."},
+                        },
+                        "required": ["project_id", "title"],
+                    },
+                },
+                "frameworks": {
+                    "smolagents": "adapter", "openclaw": "adapter", "pocketflow": "adapter",
+                    "langroid": "adapter", "hermes": "adapter", "agent-zero": "adapter",
+                    "openai-agents-sdk": "adapter", "generic": "adapter",
+                },
+                "install_method": "builtin",
+                "install_target": "tinyagentos.tools.project_tools",
+            },
+            {
+                "id": "canvas_add_image",
+                "name": "Add Image to Canvas",
+                "category": "projects",
+                "description": "Place a generated image on a project's canvas",
+                "tool_schema": {
+                    "name": "canvas_add_image",
+                    "description": "Place a generated image (by file_id from generate_image) on a project's ideas board.",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {
+                            "project_id": {"type": "string", "description": "Id from create_project."},
+                            "file_id": {"type": "string", "description": "Image file id from generate_image."},
+                            "alt": {"type": "string", "description": "Alt text."},
+                        },
+                        "required": ["project_id", "file_id"],
+                    },
+                },
+                "frameworks": {
+                    "smolagents": "adapter", "openclaw": "adapter", "pocketflow": "adapter",
+                    "langroid": "adapter", "hermes": "adapter", "agent-zero": "adapter",
+                    "openai-agents-sdk": "adapter", "generic": "adapter",
+                },
+                "install_method": "builtin",
+                "install_target": "tinyagentos.tools.project_tools",
+            },
         ]
 
         for skill in defaults:

--- a/tinyagentos/tools/project_tools.py
+++ b/tinyagentos/tools/project_tools.py
@@ -18,6 +18,18 @@ def _user_id(request: Request) -> str | None:
     return getattr(request.state, "user_id", None) or None
 
 
+async def _owned_project(request: Request, project_id: str, user_id: str):
+    """Return (project, None) if the caller owns project_id (or is admin), else
+    (None, error_dict). Prevents writing tasks/images into another user's project."""
+    project = await request.app.state.project_store.get_project(project_id)
+    if not project:
+        return None, {"error": "project not found"}
+    is_admin = bool(getattr(request.state, "is_admin", False))
+    if not is_admin and project.get("user_id") != user_id:
+        return None, {"error": "not your project"}
+    return project, None
+
+
 def _slugify(name: str) -> str:
     s = re.sub(r"[^a-z0-9]+", "-", (name or "").lower()).strip("-")
     return s or "project"
@@ -49,6 +61,9 @@ async def execute_add_task(args: dict, request: Request) -> dict:
     user_id = _user_id(request)
     if not user_id:
         return {"error": "no authenticated user"}
+    _, err = await _owned_project(request, project_id, user_id)
+    if err:
+        return err
     store = request.app.state.project_task_store
     task = await store.create_task(project_id=project_id, title=title, created_by=user_id)
     return {"ok": True, "task_id": task["id"], "title": task["title"]}
@@ -62,6 +77,9 @@ async def execute_canvas_add_image(args: dict, request: Request) -> dict:
     user_id = _user_id(request)
     if not user_id:
         return {"error": "no authenticated user"}
+    _, err = await _owned_project(request, project_id, user_id)
+    if err:
+        return err
     store = request.app.state.project_canvas_store
     el = await store.add_element(
         project_id=project_id,

--- a/tinyagentos/tools/project_tools.py
+++ b/tinyagentos/tools/project_tools.py
@@ -56,8 +56,8 @@ async def execute_create_project(args: dict, request: Request) -> dict:
 async def execute_add_task(args: dict, request: Request) -> dict:
     project_id = (args or {}).get("project_id")
     title = (args or {}).get("title")
-    if not project_id or not title:
-        return {"error": "add_task requires 'project_id' and 'title'"}
+    if not isinstance(project_id, str) or not project_id or not isinstance(title, str) or not title:
+        return {"error": "add_task requires 'project_id' and 'title' strings"}
     user_id = _user_id(request)
     if not user_id:
         return {"error": "no authenticated user"}
@@ -72,8 +72,13 @@ async def execute_add_task(args: dict, request: Request) -> dict:
 async def execute_canvas_add_image(args: dict, request: Request) -> dict:
     project_id = (args or {}).get("project_id")
     file_id = (args or {}).get("file_id")
-    if not project_id or not file_id:
-        return {"error": "canvas_add_image requires 'project_id' and 'file_id'"}
+    if not isinstance(project_id, str) or not project_id or not isinstance(file_id, str) or not file_id:
+        return {"error": "canvas_add_image requires 'project_id' and 'file_id' strings"}
+    try:
+        x = float((args or {}).get("x", 80))
+        y = float((args or {}).get("y", 80))
+    except (TypeError, ValueError):
+        return {"error": "x and y must be numbers"}
     user_id = _user_id(request)
     if not user_id:
         return {"error": "no authenticated user"}
@@ -85,8 +90,8 @@ async def execute_canvas_add_image(args: dict, request: Request) -> dict:
         project_id=project_id,
         element={
             "kind": "image",
-            "x": float((args or {}).get("x", 80)),
-            "y": float((args or {}).get("y", 80)),
+            "x": x,
+            "y": y,
             "w": 240.0,
             "h": 240.0,
             "payload": {"file_id": file_id, "alt": (args or {}).get("alt", ""), "mime": "image/png"},

--- a/tinyagentos/tools/project_tools.py
+++ b/tinyagentos/tools/project_tools.py
@@ -1,0 +1,79 @@
+"""Agent tools that build inside a project: create a project, add tasks to its
+board, and place a generated image on its canvas.
+
+These call the existing project/task/canvas stores IN-PROCESS (the same methods
+the REST routes use), so their effects stream live to an open Projects app via
+the existing project_event_broker SSE — the user watches the board fill and the
+artwork land with no extra plumbing. Pairs with the desktop tools (open_app) so
+the agent opens Projects, then builds in it visibly.
+"""
+from __future__ import annotations
+
+import re
+
+from fastapi import Request
+
+
+def _user_id(request: Request) -> str | None:
+    return getattr(request.state, "user_id", None) or None
+
+
+def _slugify(name: str) -> str:
+    s = re.sub(r"[^a-z0-9]+", "-", (name or "").lower()).strip("-")
+    return s or "project"
+
+
+async def execute_create_project(args: dict, request: Request) -> dict:
+    name = (args or {}).get("name")
+    if not name or not isinstance(name, str):
+        return {"error": "create_project requires a 'name' string"}
+    user_id = _user_id(request)
+    if not user_id:
+        return {"error": "no authenticated user"}
+    store = request.app.state.project_store
+    project = await store.create_project(
+        name=name,
+        slug=_slugify(name),
+        created_by=user_id,
+        description=(args or {}).get("description", "") or "",
+        user_id=user_id,
+    )
+    return {"ok": True, "project_id": project["id"], "name": project["name"]}
+
+
+async def execute_add_task(args: dict, request: Request) -> dict:
+    project_id = (args or {}).get("project_id")
+    title = (args or {}).get("title")
+    if not project_id or not title:
+        return {"error": "add_task requires 'project_id' and 'title'"}
+    user_id = _user_id(request)
+    if not user_id:
+        return {"error": "no authenticated user"}
+    store = request.app.state.project_task_store
+    task = await store.create_task(project_id=project_id, title=title, created_by=user_id)
+    return {"ok": True, "task_id": task["id"], "title": task["title"]}
+
+
+async def execute_canvas_add_image(args: dict, request: Request) -> dict:
+    project_id = (args or {}).get("project_id")
+    file_id = (args or {}).get("file_id")
+    if not project_id or not file_id:
+        return {"error": "canvas_add_image requires 'project_id' and 'file_id'"}
+    user_id = _user_id(request)
+    if not user_id:
+        return {"error": "no authenticated user"}
+    store = request.app.state.project_canvas_store
+    el = await store.add_element(
+        project_id=project_id,
+        element={
+            "kind": "image",
+            "x": float((args or {}).get("x", 80)),
+            "y": float((args or {}).get("y", 80)),
+            "w": 240.0,
+            "h": 240.0,
+            "payload": {"file_id": file_id, "alt": (args or {}).get("alt", ""), "mime": "image/png"},
+        },
+        author_kind="agent",
+        author_id=user_id,
+    )
+    return {"ok": True, "element_id": el["id"]}


### PR DESCRIPTION
## What
Phase 3 of agent OS control: the agent can now **build inside a project**, not just open apps. Completes the storybook-demo flow: open Projects → `create_project` → `add_task` ×N → `generate_image` → `canvas_add_image`.

## How
- `tinyagentos/tools/project_tools.py`: `create_project` / `add_task` / `canvas_add_image` call the existing `project_store` / `project_task_store` / `project_canvas_store` **in-process** (same methods the REST routes use). Because those stores publish to `project_event_broker`, the effects **stream live** to an open Projects app via its existing SSE — the board fills and the artwork lands while the user watches. No new transport.
- Scoped to `request.state.user_id` (refuse if unauthenticated), consistent with the desktop tools.
- Wired into `skill_exec` + seeded in `skills.py` (category `projects`, idempotent backfill so existing installs get them).
- Agent manual `09-os-control` updated + recompiled.

## Tests
8 tool tests (create/add/image happy paths + slugify + field validation + no-user refuse); 24 related (project_tools + desktop_tools + skills + manual-compiled) green; app constructs.

## Note
`canvas_add_image` takes a `file_id` from `generate_image`; the exact generate→file_id handoff will be confirmed when the storybook flow is run end-to-end on the Pi.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added built-in project tools for agents to create projects (with automatic slug generation)
  * Agents can add tasks and place image elements onto project canvases with real-time updates visible in the Projects app
  * Enforced project ownership/admin permissions when modifying project contents
* **Documentation**
  * Expanded the project/OS control manual with a typical end-to-end workflow and tool usage guidance
* **Tests**
  * Added comprehensive tests covering success and error cases for project creation, task creation, and canvas image insertion
<!-- end of auto-generated comment: release notes by coderabbit.ai -->