### PR TITLE
feat(agent): agent-controlled image generation (canvas wiring + cluster tier awareness)

### DIFF
--- a/docs/agent-manual/09-os-control.md
+++ b/docs/agent-manual/09-os-control.md
@@ -21,6 +21,11 @@ update the open Projects app in real time):
 - **add_task** — add a to-do task to a project's board. Args: `project_id`, `title`.
 - **canvas_add_image** — place a generated image on a project's ideas board. Args:
   `project_id`, `image_ref` (the `image_ref` returned by `generate_image`), optional `alt`.
+- **describe_image_capabilities** — see the hardware tiers (this host + any cluster
+  workers, e.g. an NVIDIA box) and which image tools/models each has loaded. Use it
+  to pick the right model before `generate_image`: an NPU model for a fast draft, a
+  GPU model for a quality cover. The system loads/unloads and queues for you — you
+  just choose the model.
 
 A typical flow: open the Projects app, create_project, add a few tasks, call
 generate_image and keep its `image_ref`, then canvas_add_image(project_id, image_ref)

--- a/docs/agent-manual/09-os-control.md
+++ b/docs/agent-manual/09-os-control.md
@@ -20,10 +20,11 @@ update the open Projects app in real time):
   Returns a `project_id` to use in the next calls.
 - **add_task** — add a to-do task to a project's board. Args: `project_id`, `title`.
 - **canvas_add_image** — place a generated image on a project's ideas board. Args:
-  `project_id`, `file_id` (from `generate_image`), optional `alt`.
+  `project_id`, `image_ref` (the `image_ref` returned by `generate_image`), optional `alt`.
 
-A typical flow: open the Projects app, create_project, add a few tasks, generate
-an image, then canvas_add_image it onto the board.
+A typical flow: open the Projects app, create_project, add a few tasks, call
+generate_image and keep its `image_ref`, then canvas_add_image(project_id, image_ref)
+to drop it on the board.
 
 These drive the user's own desktop in their session. Use them to make your work
 visible: open the relevant app so the user can watch, then carry out the task with

--- a/docs/agent-manual/10-image-prompting.md
+++ b/docs/agent-manual/10-image-prompting.md
@@ -1,0 +1,89 @@
+<!-- How to write good prompts for the generate_image tool. -->
+
+# Generating good images
+
+When you call `generate_image`, the quality of the result depends mostly on the
+prompt. A vague prompt gives a generic image; a specific, well-ordered one gives
+what the user actually asked for. Spend a sentence getting it right rather than
+regenerating five times.
+
+## Structure a prompt
+
+Lead with the subject, then layer detail. A reliable order:
+
+1. **Subject** — what it is. "a small red sailboat", "a friendly cartoon fox".
+2. **Descriptors** — appearance, colour, material, mood. "weathered wooden hull,
+   bright red sail".
+3. **Setting / background** — where it is. "on a calm blue lake at sunrise".
+4. **Composition** — framing and viewpoint. "wide shot, centred, low angle".
+5. **Style** — the look. "watercolour children's book illustration", "flat vector
+   art", "photorealistic", "oil painting". Naming a concrete style matters more
+   than any other single word.
+6. **Lighting / quality** — "soft warm light, gentle shadows, highly detailed".
+
+Example: `a friendly cartoon fox reading a book under a tree, autumn leaves,
+warm soft light, watercolour children's book illustration, centred, highly detailed`.
+
+## Principles
+
+- **Be specific, not long.** Concrete nouns and adjectives beat a wall of vague
+  words. "golden retriever puppy on grass" beats "a nice cute lovely beautiful
+  amazing dog".
+- **Front-load what matters.** Earlier words carry more weight. Put the subject
+  and the must-have details first.
+- **One clear scene.** Don't pack several unrelated ideas into one prompt; the
+  model blends them into mush. Generate separate images instead.
+- **Name the style explicitly.** If the user wants a storybook look, say
+  "children's book illustration" or "storybook watercolour". If they want a logo,
+  say "flat minimalist vector logo".
+- **Match the user's intent.** Ask yourself what they pictured and describe that,
+  not a generic version of it. For a book cover, say "book cover, title space at
+  the top, central character".
+
+## Use negative_prompt to remove faults
+
+`negative_prompt` lists what to avoid (comma-separated). It is the fix for common
+defects:
+
+- General cleanup: `blurry, low quality, jpeg artifacts, watermark, text, signature`.
+- People/animals: add `deformed hands, extra fingers, extra limbs, mutated`.
+- Keep a clean style: add `cluttered, busy background` if you want simplicity.
+
+Reach for it when a first result has a recurring flaw rather than rewriting the
+whole prompt.
+
+## Parameters (what the tool exposes)
+
+- **size** — `256x256`, `384x384`, or `512x512`. Use 512x512 for the final
+  artwork; a smaller size is only worth it for a quick rough draft.
+- **steps** — 1 to 8 (default 4). These backends are tuned for few-step
+  generation; 4 is a good balance, 6 to 8 for a bit more detail. More is not
+  always better here.
+- **guidance_scale** — 1 to 20 (default 7.5). How strictly the image follows the
+  prompt. Lower (2 to 5) is looser and more artistic; higher (8 to 12) sticks to
+  the prompt harder. Raise it when the model ignores a detail you asked for;
+  lower it if results look over-baked or harsh.
+- **seed** — omit for a fresh random image. To make small edits to an image the
+  user liked, reuse its returned `seed` and tweak the prompt so the composition
+  stays close.
+- **model** — call `describe_image_capabilities` first and pick a model that fits
+  the task: a fast NPU draft model for iterating, a GPU model for the final cover.
+  Omit it to let the scheduler choose.
+
+## Picking a model by intent
+
+Different model families respond to prompts differently:
+
+- **FLUX-style models** follow natural-language sentences well and render text
+  reasonably. Write a full descriptive sentence.
+- **SDXL-style models** respond well to comma-separated descriptive phrases and
+  strong style keywords.
+- **Text in the image** (a title, a sign, a label) is unreliable on most models;
+  prefer a model noted for text if one is loaded, keep the text very short, and
+  put it in quotes, e.g. `a poster with the title "Brave Little Fox"`.
+
+## Iterate deliberately
+
+If the first image is close but not right, change one thing at a time: adjust the
+style word, add a missing detail, or add a negative term for the defect, keeping
+the same seed. Tell the user what you changed so they can steer.

--- a/docs/agent-manual/index.md
+++ b/docs/agent-manual/index.md
@@ -18,3 +18,4 @@ Run `python3 scripts/build-agent-manual.py` to compile these into `docs/taos-age
 | `07-after-update.md` | Breakage-log-first troubleshooting for post-update reports |
 | `08-answer-templates.md` | Canned answer shapes for common questions |
 | `09-os-control.md` | Driving the desktop: open_app / arrange_windows tools |
+| `10-image-prompting.md` | Writing good prompts for the generate_image tool |

--- a/docs/taos-agent-manual.md
+++ b/docs/taos-agent-manual.md
@@ -162,10 +162,11 @@ update the open Projects app in real time):
   Returns a `project_id` to use in the next calls.
 - **add_task** — add a to-do task to a project's board. Args: `project_id`, `title`.
 - **canvas_add_image** — place a generated image on a project's ideas board. Args:
-  `project_id`, `file_id` (from `generate_image`), optional `alt`.
+  `project_id`, `image_ref` (the `image_ref` returned by `generate_image`), optional `alt`.
 
-A typical flow: open the Projects app, create_project, add a few tasks, generate
-an image, then canvas_add_image it onto the board.
+A typical flow: open the Projects app, create_project, add a few tasks, call
+generate_image and keep its `image_ref`, then canvas_add_image(project_id, image_ref)
+to drop it on the board.
 
 These drive the user's own desktop in their session. Use them to make your work
 visible: open the relevant app so the user can watch, then carry out the task with

--- a/docs/taos-agent-manual.md
+++ b/docs/taos-agent-manual.md
@@ -163,6 +163,11 @@ update the open Projects app in real time):
 - **add_task** — add a to-do task to a project's board. Args: `project_id`, `title`.
 - **canvas_add_image** — place a generated image on a project's ideas board. Args:
   `project_id`, `image_ref` (the `image_ref` returned by `generate_image`), optional `alt`.
+- **describe_image_capabilities** — see the hardware tiers (this host + any cluster
+  workers, e.g. an NVIDIA box) and which image tools/models each has loaded. Use it
+  to pick the right model before `generate_image`: an NPU model for a fast draft, a
+  GPU model for a quality cover. The system loads/unloads and queues for you — you
+  just choose the model.
 
 A typical flow: open the Projects app, create_project, add a few tasks, call
 generate_image and keep its `image_ref`, then canvas_add_image(project_id, image_ref)

--- a/docs/taos-agent-manual.md
+++ b/docs/taos-agent-manual.md
@@ -179,3 +179,92 @@ that app's own tools and your other skills.
 
 Keep it purposeful: open what you need, don't rearrange the user's windows without
 reason, and tell the user what you're doing as you do it.
+---
+
+# Generating good images
+
+When you call `generate_image`, the quality of the result depends mostly on the
+prompt. A vague prompt gives a generic image; a specific, well-ordered one gives
+what the user actually asked for. Spend a sentence getting it right rather than
+regenerating five times.
+
+## Structure a prompt
+
+Lead with the subject, then layer detail. A reliable order:
+
+1. **Subject** — what it is. "a small red sailboat", "a friendly cartoon fox".
+2. **Descriptors** — appearance, colour, material, mood. "weathered wooden hull,
+   bright red sail".
+3. **Setting / background** — where it is. "on a calm blue lake at sunrise".
+4. **Composition** — framing and viewpoint. "wide shot, centred, low angle".
+5. **Style** — the look. "watercolour children's book illustration", "flat vector
+   art", "photorealistic", "oil painting". Naming a concrete style matters more
+   than any other single word.
+6. **Lighting / quality** — "soft warm light, gentle shadows, highly detailed".
+
+Example: `a friendly cartoon fox reading a book under a tree, autumn leaves,
+warm soft light, watercolour children's book illustration, centred, highly detailed`.
+
+## Principles
+
+- **Be specific, not long.** Concrete nouns and adjectives beat a wall of vague
+  words. "golden retriever puppy on grass" beats "a nice cute lovely beautiful
+  amazing dog".
+- **Front-load what matters.** Earlier words carry more weight. Put the subject
+  and the must-have details first.
+- **One clear scene.** Don't pack several unrelated ideas into one prompt; the
+  model blends them into mush. Generate separate images instead.
+- **Name the style explicitly.** If the user wants a storybook look, say
+  "children's book illustration" or "storybook watercolour". If they want a logo,
+  say "flat minimalist vector logo".
+- **Match the user's intent.** Ask yourself what they pictured and describe that,
+  not a generic version of it. For a book cover, say "book cover, title space at
+  the top, central character".
+
+## Use negative_prompt to remove faults
+
+`negative_prompt` lists what to avoid (comma-separated). It is the fix for common
+defects:
+
+- General cleanup: `blurry, low quality, jpeg artifacts, watermark, text, signature`.
+- People/animals: add `deformed hands, extra fingers, extra limbs, mutated`.
+- Keep a clean style: add `cluttered, busy background` if you want simplicity.
+
+Reach for it when a first result has a recurring flaw rather than rewriting the
+whole prompt.
+
+## Parameters (what the tool exposes)
+
+- **size** — `256x256`, `384x384`, or `512x512`. Use 512x512 for the final
+  artwork; a smaller size is only worth it for a quick rough draft.
+- **steps** — 1 to 8 (default 4). These backends are tuned for few-step
+  generation; 4 is a good balance, 6 to 8 for a bit more detail. More is not
+  always better here.
+- **guidance_scale** — 1 to 20 (default 7.5). How strictly the image follows the
+  prompt. Lower (2 to 5) is looser and more artistic; higher (8 to 12) sticks to
+  the prompt harder. Raise it when the model ignores a detail you asked for;
+  lower it if results look over-baked or harsh.
+- **seed** — omit for a fresh random image. To make small edits to an image the
+  user liked, reuse its returned `seed` and tweak the prompt so the composition
+  stays close.
+- **model** — call `describe_image_capabilities` first and pick a model that fits
+  the task: a fast NPU draft model for iterating, a GPU model for the final cover.
+  Omit it to let the scheduler choose.
+
+## Picking a model by intent
+
+Different model families respond to prompts differently:
+
+- **FLUX-style models** follow natural-language sentences well and render text
+  reasonably. Write a full descriptive sentence.
+- **SDXL-style models** respond well to comma-separated descriptive phrases and
+  strong style keywords.
+- **Text in the image** (a title, a sign, a label) is unreliable on most models;
+  prefer a model noted for text if one is loaded, keep the text very short, and
+  put it in quotes, e.g. `a poster with the title "Brave Little Fox"`.
+
+## Iterate deliberately
+
+If the first image is close but not right, change one thing at a time: adjust the
+style word, add a missing detail, or add a negative term for the defect, keeping
+the same seed. Tell the user what you changed so they can steer.

--- a/tests/test_cluster_tools.py
+++ b/tests/test_cluster_tools.py
@@ -79,3 +79,25 @@ async def test_empty_state_is_safe():
     res = await execute_describe_image_capabilities({}, _req())
     assert res["tiers"][0]["node"] == "local"
     assert res["tiers"][0]["image_backends"] == []
+
+
+@pytest.mark.asyncio
+async def test_object_hardware_profile_is_json_safe():
+    """A real hardware_profile is an object with nested objects; the summary must
+    stay JSON-serialisable (else the tool 500s when returned as JSON)."""
+    import json
+
+    class _Gpu:
+        def __repr__(self):
+            return "RTX 3060 12GB"
+
+    class _HW:
+        gpu = _Gpu()
+        npu = None
+        cpu = "x86"
+        vram = 12
+
+    res = await execute_describe_image_capabilities({}, _req(hardware=_HW()))
+    hw = res["tiers"][0]["hardware"]
+    assert hw["gpu"] == "RTX 3060 12GB" and hw["cpu"] == "x86" and hw["vram"] == 12
+    json.dumps(res)  # must not raise

--- a/tests/test_cluster_tools.py
+++ b/tests/test_cluster_tools.py
@@ -1,0 +1,81 @@
+import types
+
+import pytest
+
+from tinyagentos.tools.cluster_tools import execute_describe_image_capabilities
+
+
+class _Backend:
+    def __init__(self, name, type_, models, lifecycle="running"):
+        self.name = name
+        self.type = type_
+        self.models = models
+        self.lifecycle_state = lifecycle
+
+
+class _Catalog:
+    def __init__(self, backends):
+        self._b = backends
+
+    def backends_with_capability(self, cap):
+        return self._b if cap == "image-generation" else []
+
+
+class _Worker:
+    def __init__(self, name, hardware, backends, status="online"):
+        self.name = name
+        self.hardware = hardware
+        self.backends = backends
+        self.status = status
+
+
+class _Cluster:
+    def __init__(self, workers):
+        self._w = workers
+
+    def get_workers(self):
+        return self._w
+
+
+def _req(catalog=None, cluster=None, hardware=None):
+    state = types.SimpleNamespace(
+        backend_catalog=catalog, cluster_manager=cluster, hardware_profile=hardware
+    )
+    return types.SimpleNamespace(app=types.SimpleNamespace(state=state))
+
+
+@pytest.mark.asyncio
+async def test_local_image_backends_listed_with_tier_and_loaded():
+    catalog = _Catalog([_Backend("sd", "sd-cpp", [{"id": "sdxl"}], "running")])
+    res = await execute_describe_image_capabilities({}, _req(catalog=catalog, hardware={"gpu": "RTX 3060", "vram": "12GB"}))
+    local = res["tiers"][0]
+    assert local["node"] == "local"
+    assert local["hardware"]["gpu"] == "RTX 3060"
+    be = local["image_backends"][0]
+    assert be["type"] == "sd-cpp" and be["tier"] == "cpu/gpu" and be["loaded"] is True
+    assert be["models"] == ["sdxl"]
+
+
+@pytest.mark.asyncio
+async def test_cluster_workers_included():
+    worker = _Worker("nvidia-box", {"gpu": "3060", "vram": "12GB"},
+                     [{"name": "sd", "type": "sd-cpp", "capabilities": ["image-generation"], "models": ["sdxl"]}])
+    res = await execute_describe_image_capabilities({}, _req(cluster=_Cluster([worker])))
+    nodes = [t["node"] for t in res["tiers"]]
+    assert "nvidia-box" in nodes
+    w = next(t for t in res["tiers"] if t["node"] == "nvidia-box")
+    assert w["image_backends"][0]["type"] == "sd-cpp"
+
+
+@pytest.mark.asyncio
+async def test_offline_worker_skipped():
+    worker = _Worker("down", {}, [], status="offline")
+    res = await execute_describe_image_capabilities({}, _req(cluster=_Cluster([worker])))
+    assert all(t["node"] != "down" for t in res["tiers"])
+
+
+@pytest.mark.asyncio
+async def test_empty_state_is_safe():
+    res = await execute_describe_image_capabilities({}, _req())
+    assert res["tiers"][0]["node"] == "local"
+    assert res["tiers"][0]["image_backends"] == []

--- a/tests/test_cluster_tools.py
+++ b/tests/test_cluster_tools.py
@@ -81,6 +81,28 @@ async def test_empty_state_is_safe():
     assert res["tiers"][0]["image_backends"] == []
 
 
+class _BadBackend:
+    """A backend whose .models raises when iterated for ids."""
+    name = "bad"
+    type = "sd-cpp"
+    lifecycle_state = "running"
+
+    @property
+    def models(self):
+        raise RuntimeError("boom")
+
+
+@pytest.mark.asyncio
+async def test_one_malformed_backend_does_not_drop_the_rest():
+    catalog = _Catalog([
+        _BadBackend(),
+        _Backend("good", "sd-cpp", [{"id": "sdxl"}], "running"),
+    ])
+    res = await execute_describe_image_capabilities({}, _req(catalog=catalog))
+    names = [b["name"] for b in res["tiers"][0]["image_backends"]]
+    assert "good" in names  # the healthy backend survives the bad one
+
+
 @pytest.mark.asyncio
 async def test_object_hardware_profile_is_json_safe():
     """A real hardware_profile is an object with nested objects; the summary must

--- a/tests/test_image_tool.py
+++ b/tests/test_image_tool.py
@@ -161,6 +161,9 @@ async def test_image_generation_forwards_new_params():
     mock_resp.status_code = 200
     mock_resp.content = fake_png
     mock_resp.raise_for_status = MagicMock()
+    # Scheduler route returns JSON metadata (filename + path), which the tool
+    # now requires to honour the image_ref contract.
+    mock_resp.json = MagicMock(return_value={"filename": "gen.png", "path": "/api/images/files/gen.png"})
 
     captured_payload: dict = {}
     captured_url: dict = {}
@@ -205,6 +208,9 @@ async def test_image_generation_default_routes_via_scheduler():
     mock_resp.status_code = 200
     mock_resp.content = fake_png
     mock_resp.raise_for_status = MagicMock()
+    # Scheduler route returns JSON metadata (filename + path), which the tool
+    # now requires to honour the image_ref contract.
+    mock_resp.json = MagicMock(return_value={"filename": "gen.png", "path": "/api/images/files/gen.png"})
 
     captured: dict = {}
 
@@ -245,6 +251,9 @@ async def test_image_generation_blank_model_treated_as_omitted():
     mock_resp.status_code = 200
     mock_resp.content = fake_png
     mock_resp.raise_for_status = MagicMock()
+    # Scheduler route returns JSON metadata (filename + path), which the tool
+    # now requires to honour the image_ref contract.
+    mock_resp.json = MagicMock(return_value={"filename": "gen.png", "path": "/api/images/files/gen.png"})
 
     captured: dict = {}
 

--- a/tests/test_project_tools.py
+++ b/tests/test_project_tools.py
@@ -22,7 +22,7 @@ class _FakeProjectStore:
     async def get_project(self, project_id):
         if project_id == "missing":
             return None
-        return {"id": project_id, "user_id": self._owner}
+        return {"id": project_id, "user_id": self._owner, "slug": "luna"}
 
 
 class _FakeTaskStore:
@@ -43,16 +43,28 @@ class _FakeCanvasStore:
         return {"id": "el_1"}
 
 
-def _req(user_id="user-1", owner="user-1", is_admin=False):
+def _req(user_id="user-1", owner="user-1", is_admin=False, base=None):
     state = types.SimpleNamespace(
         project_store=_FakeProjectStore(owner=owner),
         project_task_store=_FakeTaskStore(),
         project_canvas_store=_FakeCanvasStore(),
     )
+    if base is not None:
+        # config_path.parent is the data dir; projects live under projects_root.
+        state.config_path = str(base / "config.json")
+        state.projects_root = base / "projects"
     app = types.SimpleNamespace(state=state)
     return types.SimpleNamespace(
         app=app, state=types.SimpleNamespace(user_id=user_id, is_admin=is_admin)
     )
+
+
+def _seed_generated_image(base, name="img_cover.png"):
+    """Create a fake generated image where generate_image would have saved it."""
+    d = base / "workspace" / "images" / "generated"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / name).write_bytes(b"\x89PNG\r\n\x1a\n fake")
+    return name
 
 
 def test_slugify():
@@ -92,15 +104,26 @@ async def test_add_task_requires_fields():
 
 
 @pytest.mark.asyncio
-async def test_canvas_add_image():
-    req = _req()
-    res = await execute_canvas_add_image({"project_id": "proj_1", "file_id": "img_cover", "alt": "cover"}, req)
+async def test_canvas_add_image(tmp_path):
+    ref = _seed_generated_image(tmp_path)
+    req = _req(base=tmp_path)
+    res = await execute_canvas_add_image({"project_id": "proj_1", "image_ref": ref, "alt": "cover"}, req)
     assert res["ok"] and res["element_id"] == "el_1"
+    # the generated image was copied into the project's canvas files
+    canvas_dir = tmp_path / "projects" / "luna" / "files" / "canvas"
+    copied = list(canvas_dir.glob("*.png"))
+    assert len(copied) == 1
     call = req.app.state.project_canvas_store.calls[0]
-    assert call["project_id"] == "proj_1"
     assert call["author_kind"] == "agent" and call["author_id"] == "user-1"
     el = call["element"]
-    assert el["kind"] == "image" and el["payload"]["file_id"] == "img_cover"
+    assert el["kind"] == "image" and el["payload"]["file_id"] == copied[0].name
+
+
+@pytest.mark.asyncio
+async def test_canvas_add_image_missing_file(tmp_path):
+    req = _req(base=tmp_path)
+    res = await execute_canvas_add_image({"project_id": "proj_1", "image_ref": "nope.png"}, req)
+    assert "error" in res and "not found" in res["error"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_project_tools.py
+++ b/tests/test_project_tools.py
@@ -138,7 +138,7 @@ async def test_add_task_denied_on_other_users_project():
 @pytest.mark.asyncio
 async def test_canvas_add_image_denied_on_other_users_project():
     req = _req(user_id="attacker", owner="victim")
-    res = await execute_canvas_add_image({"project_id": "proj_1", "file_id": "f"}, req)
+    res = await execute_canvas_add_image({"project_id": "proj_1", "image_ref": "f"}, req)
     assert res.get("error") == "not your project"
     assert req.app.state.project_canvas_store.calls == []
 
@@ -160,4 +160,4 @@ async def test_add_task_missing_project():
 async def test_tools_refuse_without_user():
     assert "error" in await execute_create_project({"name": "x"}, _req(user_id=None))
     assert "error" in await execute_add_task({"project_id": "p", "title": "t"}, _req(user_id=None))
-    assert "error" in await execute_canvas_add_image({"project_id": "p", "file_id": "f"}, _req(user_id=None))
+    assert "error" in await execute_canvas_add_image({"project_id": "p", "image_ref": "f"}, _req(user_id=None))

--- a/tinyagentos/routes/skill_exec.py
+++ b/tinyagentos/routes/skill_exec.py
@@ -225,6 +225,16 @@ async def _skill_canvas_add_image(args: dict, request: Request) -> dict:
         return {"error": str(exc)}
 
 
+async def _skill_describe_image_capabilities(args: dict, request: Request) -> dict:
+    """Describe the cluster's image-gen tiers + tools (agent OS control)."""
+    try:
+        from tinyagentos.tools.cluster_tools import execute_describe_image_capabilities
+
+        return await execute_describe_image_capabilities(args, request)
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
 SKILL_IMPLEMENTATIONS = {
     "memory_search": _skill_memory_search,
     "file_read": _skill_file_read,
@@ -239,6 +249,7 @@ SKILL_IMPLEMENTATIONS = {
     "create_project": _skill_create_project,
     "add_task": _skill_add_task,
     "canvas_add_image": _skill_canvas_add_image,
+    "describe_image_capabilities": _skill_describe_image_capabilities,
 }
 
 

--- a/tinyagentos/skills.py
+++ b/tinyagentos/skills.py
@@ -367,6 +367,24 @@ class SkillStore(BaseStore):
                 "install_method": "builtin",
                 "install_target": "tinyagentos.tools.project_tools",
             },
+            {
+                "id": "describe_image_capabilities",
+                "name": "Describe Image Capabilities",
+                "category": "media",
+                "description": "See the cluster's image-generation tiers and tools (NPU/GPU/CPU)",
+                "tool_schema": {
+                    "name": "describe_image_capabilities",
+                    "description": "List the hardware tiers (this host + cluster workers) and which image-generation tools/models each has loaded, so you can pick the best one before generate_image.",
+                    "input_schema": {"type": "object", "properties": {}},
+                },
+                "frameworks": {
+                    "smolagents": "adapter", "openclaw": "adapter", "pocketflow": "adapter",
+                    "langroid": "adapter", "hermes": "adapter", "agent-zero": "adapter",
+                    "openai-agents-sdk": "adapter", "generic": "adapter",
+                },
+                "install_method": "builtin",
+                "install_target": "tinyagentos.tools.cluster_tools",
+            },
         ]
 
         for skill in defaults:

--- a/tinyagentos/skills.py
+++ b/tinyagentos/skills.py
@@ -400,6 +400,24 @@ class SkillStore(BaseStore):
                     time.time(),
                 ),
             )
+            # INSERT OR IGNORE leaves an existing row untouched, so an install
+            # seeded by an earlier release keeps its stale tool_schema (e.g. the
+            # pre-image_ref canvas_add_image contract). Refresh the code-owned
+            # fields for builtin skills so existing installs converge on the
+            # current definition. Scoped to install_method='builtin' so a user's
+            # installed/customised skills are never overwritten.
+            await self._db.execute(
+                """UPDATE skills
+                   SET name = ?, category = ?, description = ?, tool_schema = ?,
+                       frameworks = ?, requires_services = ?, install_target = ?
+                   WHERE id = ? AND install_method = 'builtin'""",
+                (
+                    skill["name"], skill["category"], skill["description"],
+                    json.dumps(skill["tool_schema"]), json.dumps(skill["frameworks"]),
+                    json.dumps(skill.get("requires_services", [])),
+                    skill["install_target"], skill["id"],
+                ),
+            )
         await self._db.commit()
 
     async def list_skills(self, category: str | None = None) -> list[dict]:

--- a/tinyagentos/skills.py
+++ b/tinyagentos/skills.py
@@ -348,15 +348,15 @@ class SkillStore(BaseStore):
                 "description": "Place a generated image on a project's canvas",
                 "tool_schema": {
                     "name": "canvas_add_image",
-                    "description": "Place a generated image (by file_id from generate_image) on a project's ideas board.",
+                    "description": "Place a generated image on a project's ideas board.",
                     "input_schema": {
                         "type": "object",
                         "properties": {
                             "project_id": {"type": "string", "description": "Id from create_project."},
-                            "file_id": {"type": "string", "description": "Image file id from generate_image."},
+                            "image_ref": {"type": "string", "description": "The image_ref returned by generate_image."},
                             "alt": {"type": "string", "description": "Alt text."},
                         },
-                        "required": ["project_id", "file_id"],
+                        "required": ["project_id", "image_ref"],
                     },
                 },
                 "frameworks": {

--- a/tinyagentos/tools/cluster_tools.py
+++ b/tinyagentos/tools/cluster_tools.py
@@ -40,7 +40,10 @@ def _hw_summary(hw) -> dict:
     """Best-effort, JSON-safe summary of a hardware profile (object or dict)."""
     if hw is None:
         return {}
-    keys = ("cpu", "gpu", "npu", "vram", "ram", "tier", "platform")
+    # HardwareProfile stores total RAM as `ram_mb`; include both that and the
+    # generic `ram`/`vram` keys so dict- and dataclass-shaped profiles both
+    # surface memory, the main tier-selection signal.
+    keys = ("cpu", "gpu", "npu", "vram", "ram", "ram_mb", "tier", "platform")
     if isinstance(hw, dict):
         return {k: _json_safe(hw.get(k)) for k in keys if hw.get(k) is not None}
     return {k: _json_safe(getattr(hw, k)) for k in keys if getattr(hw, k, None) is not None}

--- a/tinyagentos/tools/cluster_tools.py
+++ b/tinyagentos/tools/cluster_tools.py
@@ -49,21 +49,34 @@ def _hw_summary(hw) -> dict:
     return {k: _json_safe(getattr(hw, k)) for k in keys if getattr(hw, k, None) is not None}
 
 
+def _model_id(m):
+    """Best-effort model identifier from a dict-or-str model entry."""
+    if isinstance(m, dict):
+        return m.get("id") or m.get("name")
+    return m
+
+
 def _image_backends_from_catalog(catalog) -> list[dict]:
     out = []
     if not catalog:
         return out
     try:
-        for be in catalog.backends_with_capability("image-generation"):
+        backends = catalog.backends_with_capability("image-generation")
+    except Exception:
+        return out
+    # Guard each backend independently: one malformed entry must not drop the
+    # whole capability list (the agent relies on this menu to pick a tier).
+    for be in backends or []:
+        try:
             out.append({
                 "name": be.name,
                 "type": be.type,
                 "tier": _TIER.get(be.type, "unknown"),
                 "loaded": getattr(be, "lifecycle_state", "running") == "running",
-                "models": [m.get("id") or m.get("name") for m in (be.models or [])][:10],
+                "models": [_model_id(m) for m in (be.models or [])][:10],
             })
-    except Exception:
-        pass
+        except Exception:
+            continue
     return out
 
 
@@ -79,7 +92,7 @@ def _image_backends_from_worker(worker) -> list[dict]:
                 "tier": _TIER.get(b.get("type"), "unknown"),
                 # mirror the 'loaded' field local backends report; None = unknown
                 "loaded": b.get("loaded") if "loaded" in b else (ls == "running" if ls else None),
-                "models": [m.get("id") or m.get("name") if isinstance(m, dict) else m for m in (b.get("models") or [])][:10],
+                "models": [_model_id(m) for m in (b.get("models") or [])][:10],
             })
     return out
 
@@ -94,7 +107,13 @@ async def execute_describe_image_capabilities(args: dict, request: Request) -> d
     cluster = getattr(state, "cluster_manager", None)
     if cluster is not None:
         try:
-            for w in cluster.get_workers():
+            workers = cluster.get_workers()
+        except Exception:
+            workers = []
+        # Guard each worker independently so one bad worker entry doesn't drop
+        # the rest of the cluster from the menu.
+        for w in workers or []:
+            try:
                 if getattr(w, "status", "online") != "online":
                     continue
                 tiers.append({
@@ -102,8 +121,8 @@ async def execute_describe_image_capabilities(args: dict, request: Request) -> d
                     "hardware": _hw_summary(getattr(w, "hardware", None)),
                     "image_backends": _image_backends_from_worker(w),
                 })
-        except Exception:
-            pass
+            except Exception:
+                continue
     return {
         "tiers": tiers,
         "hint": "Pick a model on the tier that fits the task (npu = fast draft, gpu = best quality), then call generate_image with that model. The system loads/unloads and queues for you.",

--- a/tinyagentos/tools/cluster_tools.py
+++ b/tinyagentos/tools/cluster_tools.py
@@ -24,17 +24,26 @@ _TIER = {
 }
 
 
+def _json_safe(v):
+    """Coerce a value to something JSON-serialisable (the tool result is
+    returned as JSON, so nested dataclasses/objects would 500)."""
+    if v is None or isinstance(v, (str, int, float, bool)):
+        return v
+    if isinstance(v, dict):
+        return {str(k): _json_safe(x) for k, x in v.items()}
+    if isinstance(v, (list, tuple)):
+        return [_json_safe(x) for x in v]
+    return str(v)
+
+
 def _hw_summary(hw) -> dict:
-    """Best-effort dict summary of a hardware profile (object or dict)."""
+    """Best-effort, JSON-safe summary of a hardware profile (object or dict)."""
     if hw is None:
         return {}
+    keys = ("cpu", "gpu", "npu", "vram", "ram", "tier", "platform")
     if isinstance(hw, dict):
-        return {k: hw.get(k) for k in ("cpu", "gpu", "npu", "vram", "ram", "tier", "platform") if k in hw}
-    return {
-        k: getattr(hw, k)
-        for k in ("cpu", "gpu", "npu", "vram", "ram", "tier", "platform")
-        if getattr(hw, k, None) is not None
-    }
+        return {k: _json_safe(hw.get(k)) for k in keys if hw.get(k) is not None}
+    return {k: _json_safe(getattr(hw, k)) for k in keys if getattr(hw, k, None) is not None}
 
 
 def _image_backends_from_catalog(catalog) -> list[dict]:
@@ -60,10 +69,13 @@ def _image_backends_from_worker(worker) -> list[dict]:
     for b in (getattr(worker, "backends", None) or []):
         caps = b.get("capabilities") or []
         if "image-generation" in caps or b.get("type") in ("sd-cpp", "rkllama", "comfyui"):
+            ls = b.get("lifecycle_state")
             out.append({
                 "name": b.get("name"),
                 "type": b.get("type"),
                 "tier": _TIER.get(b.get("type"), "unknown"),
+                # mirror the 'loaded' field local backends report; None = unknown
+                "loaded": b.get("loaded") if "loaded" in b else (ls == "running" if ls else None),
                 "models": [m.get("id") or m.get("name") if isinstance(m, dict) else m for m in (b.get("models") or [])][:10],
             })
     return out

--- a/tinyagentos/tools/cluster_tools.py
+++ b/tinyagentos/tools/cluster_tools.py
@@ -1,0 +1,95 @@
+"""Agent tool: describe the cluster's image-generation capabilities.
+
+Gives the agent read-only awareness of what hardware tiers exist (this host's
+NPU/GPU/CPU plus any cluster workers like an NVIDIA box) and which image tools
+live on each tier, including what's loaded right now. The agent uses this to
+pick the best tool by intent — a fast NPU draft vs the good GPU model for a
+cover — and to tell the user what it's doing.
+
+The agent does NOT manage queues/load/unload; the scheduler + lifecycle manager
+do that. This tool is the menu, not the controls.
+"""
+from __future__ import annotations
+
+from fastapi import Request
+
+# Map a backend type to the hardware tier it runs on, for the agent's benefit.
+_TIER = {
+    "rkllama": "npu",
+    "rk-llama-cpp": "npu",
+    "ezrknpu": "npu",
+    "sd-cpp": "cpu/gpu",
+    "comfyui": "gpu",
+    "ollama": "gpu/cpu",
+}
+
+
+def _hw_summary(hw) -> dict:
+    """Best-effort dict summary of a hardware profile (object or dict)."""
+    if hw is None:
+        return {}
+    if isinstance(hw, dict):
+        return {k: hw.get(k) for k in ("cpu", "gpu", "npu", "vram", "ram", "tier", "platform") if k in hw}
+    return {
+        k: getattr(hw, k)
+        for k in ("cpu", "gpu", "npu", "vram", "ram", "tier", "platform")
+        if getattr(hw, k, None) is not None
+    }
+
+
+def _image_backends_from_catalog(catalog) -> list[dict]:
+    out = []
+    if not catalog:
+        return out
+    try:
+        for be in catalog.backends_with_capability("image-generation"):
+            out.append({
+                "name": be.name,
+                "type": be.type,
+                "tier": _TIER.get(be.type, "unknown"),
+                "loaded": getattr(be, "lifecycle_state", "running") == "running",
+                "models": [m.get("id") or m.get("name") for m in (be.models or [])][:10],
+            })
+    except Exception:
+        pass
+    return out
+
+
+def _image_backends_from_worker(worker) -> list[dict]:
+    out = []
+    for b in (getattr(worker, "backends", None) or []):
+        caps = b.get("capabilities") or []
+        if "image-generation" in caps or b.get("type") in ("sd-cpp", "rkllama", "comfyui"):
+            out.append({
+                "name": b.get("name"),
+                "type": b.get("type"),
+                "tier": _TIER.get(b.get("type"), "unknown"),
+                "models": [m.get("id") or m.get("name") if isinstance(m, dict) else m for m in (b.get("models") or [])][:10],
+            })
+    return out
+
+
+async def execute_describe_image_capabilities(args: dict, request: Request) -> dict:
+    state = request.app.state
+    tiers = [{
+        "node": "local",
+        "hardware": _hw_summary(getattr(state, "hardware_profile", None)),
+        "image_backends": _image_backends_from_catalog(getattr(state, "backend_catalog", None)),
+    }]
+    cluster = getattr(state, "cluster_manager", None)
+    if cluster is not None:
+        try:
+            for w in cluster.get_workers():
+                if getattr(w, "status", "online") != "online":
+                    continue
+                tiers.append({
+                    "node": w.name,
+                    "hardware": _hw_summary(getattr(w, "hardware", None)),
+                    "image_backends": _image_backends_from_worker(w),
+                })
+        except Exception:
+            pass
+    return {
+        "tiers": tiers,
+        "hint": "Pick a model on the tier that fits the task (npu = fast draft, gpu = best quality), then call generate_image with that model. The system loads/unloads and queues for you.",
+    }

--- a/tinyagentos/tools/image_tool.py
+++ b/tinyagentos/tools/image_tool.py
@@ -204,9 +204,12 @@ async def execute_image_generation(
             resp.raise_for_status()
             # The scheduler route saves the PNG and returns JSON metadata.
             data = resp.json()
+            filename = data.get("filename")
+            if not filename:
+                return {"success": False, "error": f"image backend returned no filename: {str(data)[:200]}"}
             return {
                 "success": True,
-                "image_ref": data.get("filename", ""),
+                "image_ref": filename,
                 "url": data.get("path", ""),
                 "seed": data.get("seed", seed),
                 "model": data.get("model", model or ""),

--- a/tinyagentos/tools/image_tool.py
+++ b/tinyagentos/tools/image_tool.py
@@ -174,6 +174,13 @@ async def execute_image_generation(
 
     Returns dict with 'success', 'image_ref' (the saved filename, usable by
     canvas_add_image), 'url' (web path to the PNG), and 'error' if failed.
+
+    Note: the connect-failure fallback (used only when the controller itself
+    is unreachable, e.g. an LXC agent that can't see localhost:6969) returns
+    'image_b64' instead of 'image_ref' -- it has no controller workspace to
+    save into. In-process tool calls always take the scheduler path above and
+    get an 'image_ref', so canvas_add_image works; a caller relying on the
+    fallback must handle the bytes itself.
     """
     import httpx
     import random
@@ -205,7 +212,7 @@ async def execute_image_generation(
             # The scheduler route saves the PNG and returns JSON metadata.
             data = resp.json()
             filename = data.get("filename")
-            if not filename:
+            if not isinstance(filename, str) or not filename:
                 return {"success": False, "error": f"image backend returned no filename: {str(data)[:200]}"}
             return {
                 "success": True,

--- a/tinyagentos/tools/image_tool.py
+++ b/tinyagentos/tools/image_tool.py
@@ -10,7 +10,15 @@ IMAGE_GENERATION_TOOL = {
         "properties": {
             "prompt": {
                 "type": "string",
-                "description": "Text description of the image to generate",
+                "description": (
+                    "Text description of the image. Lead with the subject, then "
+                    "layer descriptors, setting, composition, and an explicit style "
+                    "(e.g. 'children's book watercolour', 'flat vector', "
+                    "'photorealistic'). Be specific, not long; front-load what "
+                    "matters; keep to one clear scene. Example: 'a friendly cartoon "
+                    "fox reading under a tree, autumn leaves, warm soft light, "
+                    "watercolour children's book illustration, centred'."
+                ),
             },
             "size": {
                 "type": "string",

--- a/tinyagentos/tools/image_tool.py
+++ b/tinyagentos/tools/image_tool.py
@@ -172,10 +172,9 @@ async def execute_image_generation(
     fallback omits the model field so the local backend uses whatever
     checkpoint it has loaded rather than a pinned model name.
 
-    Returns dict with 'success', 'image_b64' (base64 PNG), and 'error'
-    if failed.
+    Returns dict with 'success', 'image_ref' (the saved filename, usable by
+    canvas_add_image), 'url' (web path to the PNG), and 'error' if failed.
     """
-    import base64
     import httpx
     import random
 
@@ -203,14 +202,15 @@ async def execute_image_generation(
         async with httpx.AsyncClient(timeout=120) as client:
             resp = await client.post(target_url, json=payload)
             resp.raise_for_status()
-            # /api/images/generate returns raw PNG bytes
-            image_bytes = resp.content
+            # The scheduler route saves the PNG and returns JSON metadata.
+            data = resp.json()
             return {
                 "success": True,
-                "image_b64": base64.b64encode(image_bytes).decode(),
-                "seed": seed,
-                "model": model or "",
-                "size": size,
+                "image_ref": data.get("filename", ""),
+                "url": data.get("path", ""),
+                "seed": data.get("seed", seed),
+                "model": data.get("model", model or ""),
+                "size": data.get("size", size),
             }
     except httpx.ConnectError:
         controller_unreachable = True  # fall through to direct path below

--- a/tinyagentos/tools/project_tools.py
+++ b/tinyagentos/tools/project_tools.py
@@ -103,8 +103,17 @@ async def execute_canvas_add_image(args: dict, request: Request) -> dict:
     src = _data_dir(request) / "workspace" / "images" / "generated" / Path(image_ref).name
     if not src.is_file():
         return {"error": f"image not found: {image_ref}"}
+    # The slug is the on-disk directory AND the key the canvas render route
+    # (/api/projects/{slug}/files/canvas/{file_id}) reads back, so it must stay
+    # the project's real slug. New projects slugify safely, but reject a legacy
+    # row or fallback id that carries separators rather than escape projects_root.
     slug = project.get("slug") or project_id
-    canvas_dir = Path(request.app.state.projects_root) / slug / "files" / "canvas"
+    if slug != _slugify(slug):
+        return {"error": f"unsafe project slug: {slug!r}"}
+    projects_root = Path(request.app.state.projects_root).resolve()
+    canvas_dir = (projects_root / slug / "files" / "canvas").resolve()
+    if not canvas_dir.is_relative_to(projects_root):
+        return {"error": "resolved canvas path escapes projects_root"}
     canvas_dir.mkdir(parents=True, exist_ok=True)
     file_id = f"{uuid4().hex}{src.suffix or '.png'}"
     (canvas_dir / file_id).write_bytes(src.read_bytes())

--- a/tinyagentos/tools/project_tools.py
+++ b/tinyagentos/tools/project_tools.py
@@ -81,9 +81,8 @@ async def execute_add_task(args: dict, request: Request) -> dict:
 
 async def execute_canvas_add_image(args: dict, request: Request) -> dict:
     project_id = (args or {}).get("project_id")
-    # `image_ref` is the filename returned by generate_image; accept the legacy
-    # `file_id` key too for callers that already have a canvas file id.
-    image_ref = (args or {}).get("image_ref") or (args or {}).get("file_id")
+    # `image_ref` is the filename returned by generate_image (a workspace file).
+    image_ref = (args or {}).get("image_ref")
     if not isinstance(project_id, str) or not project_id or not isinstance(image_ref, str) or not image_ref:
         return {"error": "canvas_add_image requires 'project_id' and 'image_ref' strings"}
     try:

--- a/tinyagentos/tools/project_tools.py
+++ b/tinyagentos/tools/project_tools.py
@@ -10,12 +10,22 @@ the agent opens Projects, then builds in it visibly.
 from __future__ import annotations
 
 import re
+from pathlib import Path
+from uuid import uuid4
 
 from fastapi import Request
 
 
 def _user_id(request: Request) -> str | None:
     return getattr(request.state, "user_id", None) or None
+
+
+def _data_dir(request: Request) -> Path:
+    """Workspace data dir, resolved the same way images.py does."""
+    config_path = getattr(request.app.state, "config_path", None)
+    if config_path is not None:
+        return Path(config_path).parent
+    return Path(__file__).parent.parent.parent / "data"
 
 
 async def _owned_project(request: Request, project_id: str, user_id: str):
@@ -71,9 +81,11 @@ async def execute_add_task(args: dict, request: Request) -> dict:
 
 async def execute_canvas_add_image(args: dict, request: Request) -> dict:
     project_id = (args or {}).get("project_id")
-    file_id = (args or {}).get("file_id")
-    if not isinstance(project_id, str) or not project_id or not isinstance(file_id, str) or not file_id:
-        return {"error": "canvas_add_image requires 'project_id' and 'file_id' strings"}
+    # `image_ref` is the filename returned by generate_image; accept the legacy
+    # `file_id` key too for callers that already have a canvas file id.
+    image_ref = (args or {}).get("image_ref") or (args or {}).get("file_id")
+    if not isinstance(project_id, str) or not project_id or not isinstance(image_ref, str) or not image_ref:
+        return {"error": "canvas_add_image requires 'project_id' and 'image_ref' strings"}
     try:
         x = float((args or {}).get("x", 80))
         y = float((args or {}).get("y", 80))
@@ -82,9 +94,22 @@ async def execute_canvas_add_image(args: dict, request: Request) -> dict:
     user_id = _user_id(request)
     if not user_id:
         return {"error": "no authenticated user"}
-    _, err = await _owned_project(request, project_id, user_id)
+    project, err = await _owned_project(request, project_id, user_id)
     if err:
         return err
+
+    # Copy the generated image (saved by generate_image under the workspace) into
+    # the project's canvas files, where the canvas renders it from
+    # /api/projects/{slug}/files/canvas/{file_id}. `.name` strips any path part.
+    src = _data_dir(request) / "workspace" / "images" / "generated" / Path(image_ref).name
+    if not src.is_file():
+        return {"error": f"image not found: {image_ref}"}
+    slug = project.get("slug") or project_id
+    canvas_dir = Path(request.app.state.projects_root) / slug / "files" / "canvas"
+    canvas_dir.mkdir(parents=True, exist_ok=True)
+    file_id = f"{uuid4().hex}{src.suffix or '.png'}"
+    (canvas_dir / file_id).write_bytes(src.read_bytes())
+
     store = request.app.state.project_canvas_store
     el = await store.add_element(
         project_id=project_id,
@@ -99,4 +124,4 @@ async def execute_canvas_add_image(args: dict, request: Request) -> dict:
         author_kind="agent",
         author_id=user_id,
     )
-    return {"ok": True, "element_id": el["id"]}
+    return {"ok": True, "element_id": el["id"], "file_id": file_id}


### PR DESCRIPTION
The image half of the storybook demo: the agent generates art, picks the right tool for the cluster, and the art lands live on the project's ideas board.

**1. generate_image → canvas (the contract fix):**
- `generate_image` was b64-encoding the route's JSON as PNG bytes (garbage); now returns `image_ref` (filename) + `url`. No consumer used image_b64.
- `canvas_add_image` now takes `image_ref` and copies the workspace PNG into the project's canvas files (where `ImageShape` renders it), then creates the element. Ownership-checked.

**2. `describe_image_capabilities` (cluster tier awareness):**
- Read-only tool: the agent sees the hardware tiers (this host's NPU/GPU/CPU + cluster workers like the 3060 box) and which image tools/models each has loaded, so it picks the best model by intent (npu draft vs gpu cover). The system owns load/unload/queue.

**Split (the right separation):** agent knows the menu + chooses; system manages the plumbing. Not in scope (separate greenlight): cross-worker routing so the Pi can offload generation to the 3060 (the `TaskRouter` exists but isn't auto-invoked).

Manual + skill schemas updated; project_tools/image_tool/cluster_tools tests green (26).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `describe_image_capabilities` skill to list available image-generation backends and hardware tiers across local and cluster resources.

* **Bug Fixes**
  * Updated `canvas_add_image` to use `image_ref` (from `generate_image`) instead of `file_id` for placing generated images on project boards.

* **Documentation**
  * Updated image placement workflow documentation to reflect the new `image_ref` parameter usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->