### PR TITLE
fix(store): make the rkllama service install entry actually work (#844)

### DIFF
--- a/scripts/install-rkllama.sh
+++ b/scripts/install-rkllama.sh
@@ -25,8 +25,13 @@ PORT="${TAOS_RKLLAMA_PORT:-7833}"
 LEGACY_PORT=8080
 
 # 1. Idempotent short-circuit: a live rkllama already satisfies the install.
+#    Require an rkllama/Ollama-shaped /api/tags body (a "models" key), not just
+#    any HTTP 200 -- another local service on these ports must not be mistaken
+#    for an installed rkllama. Mirrors _port_responds_with_rkllama() in the
+#    Python installer.
 for p in "$PORT" "$LEGACY_PORT"; do
-    if curl -fsS --max-time 2 "http://localhost:${p}/api/tags" >/dev/null 2>&1; then
+    body="$(curl -fsS --max-time 2 "http://localhost:${p}/api/tags" 2>/dev/null || true)"
+    if printf '%s' "$body" | grep -q '"models"'; then
         echo "rkllama already running on port ${p} — nothing to install"
         exit 0
     fi

--- a/scripts/install-rkllama.sh
+++ b/scripts/install-rkllama.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Store entrypoint for the rkllama (RK3588 NPU LLM) service.
+#
+# This is the script the App Store's `rkllama` service manifest points at
+# (install.method: script). The store's ScriptInstaller invokes it
+# non-interactively as `bash install-rkllama.sh <project_dir>`, so this
+# wrapper must be headless, idempotent, and must never report success
+# without actually installing.
+#
+# It is a thin wrapper over the verified NPU installer (install-rknpu.sh):
+#   1. If rkllama already answers locally, exit 0 (idempotent no-op).
+#   2. Otherwise delegate to install-rknpu.sh in headless mode. We set
+#      TAOS_RKNPU_SETUP=1 explicitly so install-rknpu.sh does NOT take its
+#      "non-interactive shell, nothing to confirm -> exit 0" path, which
+#      would otherwise return success while installing nothing.
+#
+# install-rknpu.sh handles board detection (it dies on non-RK3588 hosts)
+# and uses sudo only for the privileged librknnrt + systemd steps; in a
+# store context without a TTY those sudo calls fail loudly (non-zero),
+# which ScriptInstaller correctly surfaces as an install failure.
+set -euo pipefail
+
+PROJECT_DIR="${1:-$(pwd)}"
+PORT="${TAOS_RKLLAMA_PORT:-7833}"
+LEGACY_PORT=8080
+
+# 1. Idempotent short-circuit: a live rkllama already satisfies the install.
+for p in "$PORT" "$LEGACY_PORT"; do
+    if curl -fsS --max-time 2 "http://localhost:${p}/api/tags" >/dev/null 2>&1; then
+        echo "rkllama already running on port ${p} — nothing to install"
+        exit 0
+    fi
+done
+
+NPU_SCRIPT="${PROJECT_DIR}/scripts/install-rknpu.sh"
+if [[ ! -f "$NPU_SCRIPT" ]]; then
+    echo "install-rkllama.sh: expected NPU installer at ${NPU_SCRIPT}" >&2
+    exit 1
+fi
+
+# 2. Delegate to the verified installer in headless mode. TAOS_RKNPU_SETUP=1
+#    skips the interactive confirmation AND the false-success exit-0 path.
+echo "rkllama not detected — running NPU installer (${NPU_SCRIPT})"
+exec env TAOS_RKNPU_SETUP=1 TAOS_RKLLAMA_PORT="${PORT}" \
+    bash "$NPU_SCRIPT" --yes

--- a/tests/test_rkllama_installer.py
+++ b/tests/test_rkllama_installer.py
@@ -6,9 +6,12 @@ roundtrip to /api/pull is exercised manually on the Pi (see PR description).
 """
 from __future__ import annotations
 
+import httpx
 import pytest
+import respx
 
 from tinyagentos.installers.rkllama_installer import (
+    RkllamaInstaller,
     parse_hf_resolve_url,
     resolve_rkllama_url,
     rkllama_is_running,
@@ -117,3 +120,93 @@ class TestResolveRkllamaUrl:
 
     def test_ip_address_7833(self):
         assert resolve_rkllama_url("192.168.1.10") == "http://192.168.1.10:7833"
+
+
+_VARIANT = {
+    "id": "qwen2.5-3b",
+    "download_url": (
+        "https://huggingface.co/c01zaut/Qwen2.5-3B-Instruct-rk3588-1.1.1/"
+        "resolve/main/Qwen2.5-3B-Instruct-rk3588-w8a8.rkllm"
+    ),
+}
+
+
+class TestInstallVerification:
+    """install() must only report success once /api/tags confirms the model.
+
+    A 200 from /api/pull alone is necessary but not sufficient -- a model the
+    agent can't load is worse than a clear error, so an unconfirmable pull
+    fails rather than returning a false success.
+    """
+
+    def _installer(self):
+        # Pass an explicit URL so __init__ doesn't probe the network.
+        return RkllamaInstaller(rkllama_url="http://localhost:7833")
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_success_when_tags_lists_model(self):
+        respx.post("http://localhost:7833/api/pull").mock(
+            return_value=httpx.Response(200, text='{"status":"success"}\n')
+        )
+        respx.get("http://localhost:7833/api/tags").mock(
+            return_value=httpx.Response(200, json={"models": [{"name": "rkllama-x"}]})
+        )
+        res = await self._installer().install("rkllama-x", {}, variant=_VARIANT)
+        assert res["success"] is True
+        assert res["model_name"] == "rkllama-x"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_failure_when_model_absent_from_tags(self):
+        respx.post("http://localhost:7833/api/pull").mock(
+            return_value=httpx.Response(200, text='{"status":"success"}\n')
+        )
+        respx.get("http://localhost:7833/api/tags").mock(
+            return_value=httpx.Response(200, json={"models": [{"name": "other"}]})
+        )
+        res = await self._installer().install("rkllama-x", {}, variant=_VARIANT)
+        assert res["success"] is False
+        assert "not in" in res["error"]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_failure_when_tags_unreachable(self, monkeypatch):
+        # Previously this path returned a false success. Now an unreachable
+        # /api/tags (after retries) is a clean failure.
+        monkeypatch.setattr(rkllama_installer.asyncio, "sleep", _no_sleep)
+        respx.post("http://localhost:7833/api/pull").mock(
+            return_value=httpx.Response(200, text='{"status":"success"}\n')
+        )
+        respx.get("http://localhost:7833/api/tags").mock(
+            side_effect=httpx.ConnectError("refused")
+        )
+        res = await self._installer().install("rkllama-x", {}, variant=_VARIANT)
+        assert res["success"] is False
+        assert "could not be reached" in res["error"]
+
+
+async def _no_sleep(*_a, **_k):
+    return None
+
+
+class TestRkllamaServiceManifest:
+    """The rkllama service manifest (install.method: script) must point at a
+    script that actually exists. ScriptInstaller resolves install.script
+    relative to the repo root (its cwd), so a missing file means the store
+    install fails with 'script not found'. This is the #844 regression guard.
+    """
+
+    def test_install_script_exists(self):
+        import pathlib
+        import yaml
+
+        repo = pathlib.Path(__file__).resolve().parent.parent
+        manifest = yaml.safe_load(
+            (repo / "app-catalog" / "services" / "rkllama" / "manifest.yaml").read_text()
+        )
+        install = manifest.get("install") or {}
+        assert install.get("method") == "script"
+        script = install.get("script")
+        assert script, "rkllama manifest declares no install.script"
+        assert (repo / script).is_file(), f"rkllama install script missing: {script}"

--- a/tests/test_rkllama_installer.py
+++ b/tests/test_rkllama_installer.py
@@ -158,7 +158,8 @@ class TestInstallVerification:
 
     @respx.mock
     @pytest.mark.asyncio
-    async def test_failure_when_model_absent_from_tags(self):
+    async def test_failure_when_model_absent_from_tags(self, monkeypatch):
+        monkeypatch.setattr(rkllama_installer.asyncio, "sleep", _no_sleep)
         respx.post("http://localhost:7833/api/pull").mock(
             return_value=httpx.Response(200, text='{"status":"success"}\n')
         )
@@ -167,7 +168,7 @@ class TestInstallVerification:
         )
         res = await self._installer().install("rkllama-x", {}, variant=_VARIANT)
         assert res["success"] is False
-        assert "not in" in res["error"]
+        assert "could not confirm" in res["error"]
 
     @respx.mock
     @pytest.mark.asyncio
@@ -183,7 +184,41 @@ class TestInstallVerification:
         )
         res = await self._installer().install("rkllama-x", {}, variant=_VARIANT)
         assert res["success"] is False
-        assert "could not be reached" in res["error"]
+        assert "could not confirm" in res["error"]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_failure_when_tags_returns_non_json(self, monkeypatch):
+        # A 200 with a non-JSON body must be treated as a failed check, not
+        # raise an uncaught JSONDecodeError out of install().
+        monkeypatch.setattr(rkllama_installer.asyncio, "sleep", _no_sleep)
+        respx.post("http://localhost:7833/api/pull").mock(
+            return_value=httpx.Response(200, text='{"status":"success"}\n')
+        )
+        respx.get("http://localhost:7833/api/tags").mock(
+            return_value=httpx.Response(200, text="<html>nginx</html>")
+        )
+        res = await self._installer().install("rkllama-x", {}, variant=_VARIANT)
+        assert res["success"] is False
+        assert "could not confirm" in res["error"]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_retries_then_succeeds_when_model_appears_late(self, monkeypatch):
+        # Registration can lag the pull's 200; the verify loop retries on an
+        # absent model and succeeds once it appears.
+        monkeypatch.setattr(rkllama_installer.asyncio, "sleep", _no_sleep)
+        respx.post("http://localhost:7833/api/pull").mock(
+            return_value=httpx.Response(200, text='{"status":"success"}\n')
+        )
+        respx.get("http://localhost:7833/api/tags").mock(
+            side_effect=[
+                httpx.Response(200, json={"models": []}),
+                httpx.Response(200, json={"models": [{"name": "rkllama-x"}]}),
+            ]
+        )
+        res = await self._installer().install("rkllama-x", {}, variant=_VARIANT)
+        assert res["success"] is True
 
 
 async def _no_sleep(*_a, **_k):

--- a/tinyagentos/installers/rkllama_installer.py
+++ b/tinyagentos/installers/rkllama_installer.py
@@ -14,6 +14,7 @@ URL), so we don't need any extra fields on the manifest.
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
 import socket
@@ -184,12 +185,18 @@ class RkllamaInstaller(AppInstaller):
             }
 
         # Verify the model now appears in /api/tags so we know rkllama
-        # successfully registered it.
-        try:
-            async with httpx.AsyncClient(timeout=10) as client:
-                tags = await client.get(f"{self.rkllama_url}/api/tags")
-                tags.raise_for_status()
-                names = {m.get("name") for m in tags.json().get("models", [])}
+        # successfully registered it. The pull returning 200 is necessary but
+        # not sufficient: only /api/tags confirms the weight is loadable. We
+        # retry a few times to tolerate a transient blip, but if the check
+        # never succeeds we report failure rather than a false success -- a
+        # model the agent can't actually load is worse than a clear error.
+        last_exc: httpx.HTTPError | None = None
+        for attempt in range(3):
+            try:
+                async with httpx.AsyncClient(timeout=10) as client:
+                    tags = await client.get(f"{self.rkllama_url}/api/tags")
+                    tags.raise_for_status()
+                    names = {m.get("name") for m in tags.json().get("models", [])}
                 if app_id not in names:
                     return {
                         "success": False,
@@ -198,11 +205,24 @@ class RkllamaInstaller(AppInstaller):
                             f"/api/tags. Known models: {sorted(names)[:5]}"
                         ),
                     }
-        except httpx.HTTPError as exc:
-            logger.warning(
-                "rkllama install: /api/tags verification failed: %s", exc
-            )
-            # Non-fatal -- pull succeeded; verification problem is likely transient.
+                break  # verified
+            except httpx.HTTPError as exc:
+                last_exc = exc
+                logger.warning(
+                    "rkllama install: /api/tags verification attempt %d/3 failed: %s",
+                    attempt + 1, exc,
+                )
+                if attempt < 2:
+                    await asyncio.sleep(1.0 * (attempt + 1))
+        else:
+            # Exhausted retries without ever confirming the model.
+            return {
+                "success": False,
+                "error": (
+                    f"rkllama pull returned 200 but /api/tags could not be reached "
+                    f"to confirm {app_id!r} installed: {last_exc}. Retry the install."
+                ),
+            }
 
         return {"success": True, "app_id": app_id, "model_name": app_id}
 

--- a/tinyagentos/installers/rkllama_installer.py
+++ b/tinyagentos/installers/rkllama_installer.py
@@ -187,43 +187,50 @@ class RkllamaInstaller(AppInstaller):
         # Verify the model now appears in /api/tags so we know rkllama
         # successfully registered it. The pull returning 200 is necessary but
         # not sufficient: only /api/tags confirms the weight is loadable. We
-        # retry a few times to tolerate a transient blip, but if the check
-        # never succeeds we report failure rather than a false success -- a
-        # model the agent can't actually load is worse than a clear error.
-        last_exc: httpx.HTTPError | None = None
+        # retry a few times to tolerate a transient blip AND registration lag
+        # (the model can take a moment to appear after pull returns), but if the
+        # check never confirms the model we report failure rather than a false
+        # success -- a model the agent can't actually load is worse than a clear
+        # error. Malformed/unexpected /api/tags bodies are treated as a failed
+        # check, not allowed to raise out of the installer.
+        last_problem = "verification did not run"
+        verified = False
         for attempt in range(3):
             try:
                 async with httpx.AsyncClient(timeout=10) as client:
                     tags = await client.get(f"{self.rkllama_url}/api/tags")
                     tags.raise_for_status()
-                    names = {m.get("name") for m in tags.json().get("models", [])}
-                if app_id not in names:
-                    return {
-                        "success": False,
-                        "error": (
-                            f"rkllama pull returned 200 but {app_id!r} is not in "
-                            f"/api/tags. Known models: {sorted(names)[:5]}"
-                        ),
-                    }
-                break  # verified
-            except httpx.HTTPError as exc:
-                last_exc = exc
-                logger.warning(
-                    "rkllama install: /api/tags verification attempt %d/3 failed: %s",
-                    attempt + 1, exc,
+                    payload = tags.json()
+            except (httpx.HTTPError, ValueError) as exc:
+                # ValueError covers a 200 with a non-JSON body (json.JSONDecodeError).
+                last_problem = f"/api/tags unreachable or not JSON: {exc}"
+            else:
+                models = payload.get("models") if isinstance(payload, dict) else None
+                names = (
+                    {m.get("name") for m in models if isinstance(m, dict)}
+                    if isinstance(models, list)
+                    else set()
                 )
-                if attempt < 2:
-                    await asyncio.sleep(1.0 * (attempt + 1))
-        else:
-            # Exhausted retries without ever confirming the model.
+                if app_id in names:
+                    verified = True
+                    break
+                known = sorted(n for n in names if n)[:5]
+                last_problem = f"{app_id!r} not yet in /api/tags (known: {known})"
+            logger.warning(
+                "rkllama install: /api/tags verification attempt %d/3: %s",
+                attempt + 1, last_problem,
+            )
+            if attempt < 2:
+                await asyncio.sleep(1.0 * (attempt + 1))
+
+        if not verified:
             return {
                 "success": False,
                 "error": (
-                    f"rkllama pull returned 200 but /api/tags could not be reached "
-                    f"to confirm {app_id!r} installed: {last_exc}. Retry the install."
+                    f"rkllama pull returned 200 but could not confirm {app_id!r} "
+                    f"installed after 3 checks: {last_problem}. Retry the install."
                 ),
             }
-
         return {"success": True, "app_id": app_id, "model_name": app_id}
 
     async def uninstall(self, app_id: str) -> dict:


### PR DESCRIPTION
## Why

`rkllama` is the RK3588 NPU LLM backend our Orange Pi target audience needs from first boot. Its store entry was broken: the service manifest declared

```yaml
install:
  method: script
  script: scripts/install-rkllama.sh
```

but `scripts/install-rkllama.sh` never existed (only `scripts/install-rknpu.sh` did). `ScriptInstaller` resolves `install.script` relative to the repo root, so clicking **Install** in the App Store failed immediately with `script not found`. Fixes #844.

## What

**1. Add `scripts/install-rkllama.sh`** — an idempotent, headless wrapper the store's `ScriptInstaller` can run non-interactively:
- short-circuits to `exit 0` when a live rkllama already answers (port 7833, or legacy 8080) — re-running is a clean no-op;
- otherwise delegates to the verified `install-rknpu.sh` with `TAOS_RKNPU_SETUP=1` set **explicitly**. That env var matters: without it, `install-rknpu.sh` takes its *"non-interactive shell, nothing to confirm → exit 0"* path and would report success while installing nothing.

The heavy NPU runtime install stays behind a store-triggered script that clones upstream at install time rather than being bundled, which keeps the arms-length, source-available posture intact.

**2. Harden `RkllamaInstaller` `/api/tags` verification** — a `200` from `/api/pull` is necessary but not sufficient; only `/api/tags` confirms the weight is loadable. Previously an unreachable `/api/tags` was swallowed and `install()` returned a **false success**. Now it retries a few times and, if the check never confirms the model, returns `success: False` with an actionable error. A model the agent can't load is worse than a clear failure.

## Tests

- `install()` verification: confirmed / absent-from-tags / unreachable-after-retries (the last previously false-passed).
- Regression guard: asserts the rkllama manifest's `install.script` actually exists on disk.

```
python3 -m pytest tests/test_rkllama_installer.py tests/installers/ -q
112 passed
```

## Note (out of scope, follow-up)

While auditing I found ~19 other catalog manifests (`stable-diffusion-cpp`, `wan2gp`, `dify`, several agents, etc.) that reference `install.method: script` scripts which also don't exist at the repo root. They're tracked separately; this PR is scoped to the rkllama path the target audience hits first.

----
## Summary by Gitar

- **New Agent Tools:**
  - Added `describe_image_capabilities` tool in `tinyagentos/tools/cluster_tools.py` to expose hardware tiers (NPU/GPU/CPU) and model availability to the agent.
  - Updated documentation in `docs/` and skill definitions in `tinyagentos/skills.py` to include the new tool.
- **Tool Enhancements:**
  - Refactored `canvas_add_image` in `tinyagentos/tools/project_tools.py` to use `image_ref` instead of `file_id`, and added file copying logic from the workspace to the project canvas directory.
  - Updated `image_tool.py` to return an `image_ref` (the saved filename) rather than base64 bytes, improving memory handling for generated assets.


<sub>This will update automatically on new commits.</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RKLLAMA service installer with idempotent startup behavior and configurable port support.

* **Bug Fixes**
  * Improved installation verification to more reliably confirm model availability with automatic retries and enhanced error handling.

* **Tests**
  * Added comprehensive test coverage for installer verification behavior and manifest validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->