### PR TITLE
fix(deps): cap fastapi <0.137 (0.137.0 include_router regression)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,10 @@ description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"
 dependencies = [
-    "fastapi>=0.115.0",
+    # Cap below 0.137: fastapi 0.137.0 regressed include_router so that a
+    # mounted APIRouter contributes none of its routes to the app, leaving
+    # create_app() with an empty API surface. 0.136.3 is the last good release.
+    "fastapi>=0.115.0,<0.137",
     "uvicorn[standard]>=0.30.0",
     "httpx>=0.27.0",
     "jinja2>=3.1.0",


### PR DESCRIPTION
## Problem

`dev` has been red for 5 consecutive CI runs (since the post-#886 docs commits). The failing tests are all route-registration assertions: `create_app()` comes up with an almost-empty `/api` surface, e.g.

```
AssertionError: expected routes missing (router not registered?):
['/api/agents', '/api/canvas', '/api/chat/channels/{channel_id}',
 '/api/cluster/workers', '/api/memory/stats', '/api/models',
 '/api/settings/platform', '/api/store/app/{app_id}']
```

The commits that turned dev red are **docs-only**, so the breakage is environmental: a floated dependency.

## Root cause

**fastapi 0.137.0 regressed `include_router`.** A mounted `APIRouter` contributes none of its routes to the app. The pin was open-ended (`fastapi>=0.115.0`), so CI's fresh install floated to 0.137.0.

Minimal reproduction:

```python
from fastapi import FastAPI, APIRouter
r = APIRouter()
@r.get('/a')
def a(): return {}
@r.get('/b')
def b(): return {}
app = FastAPI(); app.include_router(r)
# 0.137.0 -> []          (broken)
# 0.136.3 -> ['/a','/b'] (correct)
```

Bisected: fastapi 0.135.3 + starlette 1.3.1 -> 650 routes (works); fastapi 0.137.0 -> 92 routes, `/api/agents` missing (broken). starlette is not implicated.

## Fix

Cap `fastapi>=0.115.0,<0.137`. 0.136.3 is the last good release. Verified: `tests/test_register_all_routers.py` passes 4/4 under 0.136.3.

Unblocks dev and the open theme PRs (#891 / #895 / #899), which were only red because they inherit dev.