### PR TITLE
feat(images): Images Studio app (Create / Library / Edit)

### DIFF
--- a/desktop/src/apps/ImagesApp.tsx
+++ b/desktop/src/apps/ImagesApp.tsx
@@ -173,7 +173,11 @@ export function ImagesApp({ windowId: _windowId }: { windowId: string }) {
   /* ----------------------------- generate ------------------------ */
 
   const runGenerate = useCallback(
-    async (overrideSeed?: number, overridePrompt?: string) => {
+    async (
+      overrideSeed?: number,
+      overridePrompt?: string,
+      overrides?: { size?: number; steps?: number; guidance?: number },
+    ) => {
       const usePrompt = (overridePrompt ?? prompt).trim();
       if (!usePrompt) return;
       if (!selectedVariant || !selectedVariant.downloaded) {
@@ -193,10 +197,10 @@ export function ImagesApp({ windowId: _windowId }: { windowId: string }) {
         prompt: styledPrompt,
         model: selectedModelId,
         variant: selectedVariantId,
-        size: `${size}x${size}`,
-        steps,
+        size: `${overrides?.size ?? size}x${overrides?.size ?? size}`,
+        steps: overrides?.steps ?? steps,
         seed: effectiveSeed,
-        guidance_scale: guidance || 7.5,
+        guidance_scale: (overrides?.guidance ?? guidance) || 7.5,
       };
 
       try {
@@ -277,7 +281,13 @@ export function ImagesApp({ windowId: _windowId }: { windowId: string }) {
       if (img.guidance) setGuidance(img.guidance);
       setPrompt(img.prompt);
       setView("create");
-      void runGenerate(randomSeed(), img.prompt);
+      // Pass params explicitly: the setState calls above update the controls
+      // for next time, but won't be visible to runGenerate this tick.
+      void runGenerate(randomSeed(), img.prompt, {
+        size: typeof img.size === "number" ? img.size : undefined,
+        steps: img.steps || undefined,
+        guidance: img.guidance || undefined,
+      });
     },
     [runGenerate],
   );

--- a/desktop/src/apps/ImagesApp.tsx
+++ b/desktop/src/apps/ImagesApp.tsx
@@ -1,82 +1,69 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
-import { Image, Wand2, Trash2, Download, Package } from "lucide-react";
-import {
-  Button,
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-  Input,
-  Label,
-  Textarea,
-} from "@/components/ui";
+import { Sparkles, LayoutGrid, Pencil, Settings2 } from "lucide-react";
 import { ModelBrowser } from "@/components/ModelBrowser";
+import { CreateView } from "./images/CreateView";
+import { LibraryView } from "./images/LibraryView";
+import { EditView } from "./images/EditView";
+import {
+  type GeneratedImage,
+  type ImageModel,
+  type GenerateParams,
+  type StudioView,
+  type GenerateMode,
+  type LibraryFilter,
+} from "./images/types";
 
 /* ------------------------------------------------------------------ */
-/*  Types                                                              */
+/*  Images Studio — shell                                              */
+/*                                                                     */
+/*  Left icon rail (Create / Library / Edit / Models) + the active     */
+/*  surface. Shared backend wiring (list / generate / delete /          */
+/*  download / models) lives here; the views are presentational.       */
 /* ------------------------------------------------------------------ */
 
-interface GeneratedImage {
-  id: string;
-  url: string;
-  prompt: string;
-  model: string;
-  size: number | string;
-  steps: number;
-  seed: number;
-  guidance: number;
-  createdAt: string;
+const RAIL: { id: StudioView; label: string; icon: typeof Sparkles }[] = [
+  { id: "create", label: "Create", icon: Sparkles },
+  { id: "library", label: "Library", icon: LayoutGrid },
+  { id: "edit", label: "Edit", icon: Pencil },
+];
+
+function randomSeed(): number {
+  return Math.floor(Math.random() * 1_000_000);
 }
-
-interface ModelVariant {
-  id: string;
-  name: string;
-  format?: string;
-  size_mb: number;
-  min_ram_mb?: number;
-  backend?: string[];
-  downloaded?: boolean;
-  compatibility: "green" | "yellow" | "red";
-  download_url?: string;
-}
-
-interface ImageModel {
-  id: string;
-  name: string;
-  description?: string;
-  capabilities: string[];
-  variants: ModelVariant[];
-  has_downloaded_variant?: boolean;
-}
-
-/* ------------------------------------------------------------------ */
-/*  Helpers                                                            */
-/* ------------------------------------------------------------------ */
-
-/* ------------------------------------------------------------------ */
-/*  ImagesApp                                                          */
-/* ------------------------------------------------------------------ */
 
 export function ImagesApp({ windowId: _windowId }: { windowId: string }) {
+  const [view, setView] = useState<StudioView>("create");
+
+  // gallery / results
   const [images, setImages] = useState<GeneratedImage[]>([]);
   const [loading, setLoading] = useState(true);
   const [generating, setGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [activeResultId, setActiveResultId] = useState<string | null>(null);
+  const [librarySelectedId, setLibrarySelectedId] = useState<string | null>(
+    null,
+  );
+  const [editImage, setEditImage] = useState<GeneratedImage | null>(null);
 
-  // Model catalog state
+  // model catalog
   const [models, setModels] = useState<ImageModel[]>([]);
   const [selectedModelId, setSelectedModelId] = useState<string>("");
   const [selectedVariantId, setSelectedVariantId] = useState<string>("");
   const [browserOpen, setBrowserOpen] = useState(false);
 
-  // Form state (non-model)
+  // create form
+  const [mode, setMode] = useState<GenerateMode>("single");
   const [prompt, setPrompt] = useState("");
   const [size, setSize] = useState(512);
   const [steps, setSteps] = useState(4);
+  const [guidance, setGuidance] = useState(7.5);
+  const [style, setStyle] = useState<string | null>(null);
   const [seed, setSeed] = useState("");
-  const [guidance, setGuidance] = useState("7.5");
 
-  /* -------------------------- Images gallery --------------------- */
+  // library
+  const [libFilter, setLibFilter] = useState<LibraryFilter>("all");
+
+  /* ----------------------------- images -------------------------- */
 
   const fetchImages = useCallback(async () => {
     try {
@@ -102,6 +89,7 @@ export function ImagesApp({ windowId: _windowId }: { windowId: string }) {
               steps: (raw.steps as number) ?? 0,
               seed: (raw.seed as number) ?? 0,
               guidance: (raw.guidance_scale as number) ?? 0,
+              backend: (raw.backend as string) ?? undefined,
               createdAt:
                 (raw.created_at as string) ?? new Date().toISOString(),
             }),
@@ -122,7 +110,7 @@ export function ImagesApp({ windowId: _windowId }: { windowId: string }) {
     fetchImages();
   }, [fetchImages]);
 
-  /* -------------------------- Model catalog ---------------------- */
+  /* --------------------------- model catalog --------------------- */
 
   const refreshModels = useCallback(async () => {
     try {
@@ -147,7 +135,6 @@ export function ImagesApp({ windowId: _windowId }: { windowId: string }) {
   useEffect(() => {
     (async () => {
       const imageModels = await refreshModels();
-      // Auto-select first downloaded variant
       for (const m of imageModels) {
         const dl = m.variants?.find((v) => v.downloaded);
         if (dl) {
@@ -168,369 +155,269 @@ export function ImagesApp({ windowId: _windowId }: { windowId: string }) {
     [selectedModel, selectedVariantId],
   );
 
-  // Flat list of usable (downloaded) variants for the dropdown
-  const availableOptions = useMemo(() => {
-    const options: Array<{
-      modelId: string;
-      variantId: string;
-      label: string;
-    }> = [];
-    for (const m of models) {
-      for (const v of m.variants ?? []) {
-        if (v.downloaded) {
-          options.push({
-            modelId: m.id,
-            variantId: v.id,
-            label: `${m.name} — ${v.name}`,
-          });
-        }
+  const modelName = selectedModel?.name ?? "No model";
+  const modelMeta = selectedVariant
+    ? `${selectedVariant.name}${
+        selectedVariant.backend?.length
+          ? ` · ${selectedVariant.backend.join("/")}`
+          : ""
+      }`
+    : "Pick a model";
+
+  const canGenerate =
+    !!prompt.trim() &&
+    !generating &&
+    !!selectedVariant &&
+    !!selectedVariant.downloaded;
+
+  /* ----------------------------- generate ------------------------ */
+
+  const runGenerate = useCallback(
+    async (overrideSeed?: number, overridePrompt?: string) => {
+      const usePrompt = (overridePrompt ?? prompt).trim();
+      if (!usePrompt) return;
+      if (!selectedVariant || !selectedVariant.downloaded) {
+        setError("Select a downloaded model first.");
+        return;
       }
-    }
-    return options;
-  }, [models]);
+      setGenerating(true);
+      setError(null);
 
-  const handleSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const value = e.target.value;
-    if (value === "__browse__") {
-      setBrowserOpen(true);
-      return;
-    }
-    if (!value) return;
-    const [modelId, variantId] = value.split("::");
-    if (modelId === undefined || variantId === undefined) return;
-    setSelectedModelId(modelId);
-    setSelectedVariantId(variantId);
-  };
+      const effectiveSeed =
+        overrideSeed ?? (seed ? parseInt(seed, 10) : randomSeed());
+      const styledPrompt = style
+        ? `${usePrompt}, ${style.toLowerCase()} style`
+        : usePrompt;
 
-  /* -------------------------- Generate --------------------------- */
+      const params: GenerateParams = {
+        prompt: styledPrompt,
+        model: selectedModelId,
+        variant: selectedVariantId,
+        size: `${size}x${size}`,
+        steps,
+        seed: effectiveSeed,
+        guidance_scale: guidance || 7.5,
+      };
 
-  async function handleGenerate() {
-    if (!prompt.trim()) return;
-    if (!selectedVariant || !selectedVariant.downloaded) {
-      setError("Select a downloaded model first.");
-      return;
-    }
-    setGenerating(true);
-    setError(null);
-
-    const params = {
-      prompt: prompt.trim(),
-      model: selectedModelId,
-      variant: selectedVariantId,
-      size: `${size}x${size}`,
-      steps,
-      seed: seed ? parseInt(seed) : Math.floor(Math.random() * 999999),
-      guidance_scale: parseFloat(guidance) || 7.5,
-    };
-
-    try {
-      const res = await fetch("/api/images/generate", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(params),
-      });
-      if (res.ok) {
-        const ct = res.headers.get("content-type") ?? "";
-        if (ct.includes("application/json")) {
-          const data = await res.json();
-          if (data.filename || data.id) {
-            await fetchImages();
-          } else if (data.error) {
-            setError(data.error);
+      try {
+        const res = await fetch("/api/images/generate", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(params),
+        });
+        if (res.ok) {
+          const ct = res.headers.get("content-type") ?? "";
+          if (ct.includes("application/json")) {
+            const data = await res.json();
+            if (data.filename || data.id) {
+              const newId = (data.filename as string) ?? (data.id as string);
+              await fetchImages();
+              setActiveResultId(newId);
+            } else if (data.error) {
+              setError(String(data.error));
+            }
           }
+        } else {
+          const data = await res.json().catch(() => ({}));
+          setError(
+            (data as { error?: string }).error ??
+              `Generation failed (${res.status})`,
+          );
         }
-      } else {
-        const data = await res.json().catch(() => ({}));
-        setError(
-          (data as { error?: string }).error ??
-            `Generation failed (${res.status})`,
-        );
+      } catch (e) {
+        setError(`Generation error: ${(e as Error).message}`);
       }
-    } catch (e) {
-      setError(`Generation error: ${(e as Error).message}`);
-    }
+      setGenerating(false);
+    },
+    [
+      prompt,
+      seed,
+      style,
+      selectedVariant,
+      selectedModelId,
+      selectedVariantId,
+      size,
+      steps,
+      guidance,
+      fetchImages,
+    ],
+  );
 
-    setGenerating(false);
-  }
+  const handleReroll = useCallback(() => {
+    setSeed(String(randomSeed()));
+  }, []);
 
-  function handleDelete(id: string) {
+  /* ----------------------------- delete -------------------------- */
+
+  const handleDelete = useCallback((id: string) => {
     setImages((prev) => prev.filter((img) => img.id !== id));
+    setLibrarySelectedId((cur) => (cur === id ? null : cur));
+    setActiveResultId((cur) => (cur === id ? null : cur));
     fetch(`/api/images/${encodeURIComponent(id)}`, { method: "DELETE" }).catch(
       () => {},
     );
-  }
+  }, []);
 
-  function handleDownload(img: GeneratedImage) {
+  const handleDownload = useCallback((img: GeneratedImage) => {
     if (!img.url) return;
     const a = document.createElement("a");
     a.href = img.url;
-    a.download = `${img.prompt.slice(0, 30).replace(/\s+/g, "-")}-${img.seed}.png`;
+    a.download = `${img.prompt.slice(0, 30).replace(/\s+/g, "-") || "image"}-${
+      img.seed
+    }.png`;
     a.click();
-  }
+  }, []);
 
-  /* -------------------------- Render ----------------------------- */
+  /* --------- re-roll from library/create: reuse params + new seed --- */
+
+  const rerollFrom = useCallback(
+    (img: GeneratedImage) => {
+      if (typeof img.size === "number") setSize(img.size);
+      if (img.steps) setSteps(img.steps);
+      if (img.guidance) setGuidance(img.guidance);
+      setPrompt(img.prompt);
+      setView("create");
+      void runGenerate(randomSeed(), img.prompt);
+    },
+    [runGenerate],
+  );
+
+  const openInEdit = useCallback((img: GeneratedImage) => {
+    setEditImage(img);
+    setView("edit");
+  }, []);
+
+  /* --------- Apply adjust (real client-side op via canvas) -------- */
+
+  const applyAdjust = useCallback(
+    (filterCss: string) => {
+      if (!editImage?.url) return;
+      const img = new Image();
+      img.crossOrigin = "anonymous";
+      img.onload = () => {
+        const canvas = document.createElement("canvas");
+        canvas.width = img.naturalWidth;
+        canvas.height = img.naturalHeight;
+        const ctx = canvas.getContext("2d");
+        if (!ctx) return;
+        ctx.filter = filterCss;
+        ctx.drawImage(img, 0, 0);
+        canvas.toBlob((blob) => {
+          if (!blob) return;
+          const url = URL.createObjectURL(blob);
+          const a = document.createElement("a");
+          a.href = url;
+          a.download = `${
+            editImage.prompt.slice(0, 30).replace(/\s+/g, "-") || "image"
+          }-adjusted.png`;
+          a.click();
+          URL.revokeObjectURL(url);
+        }, "image/png");
+      };
+      img.src = editImage.url;
+    },
+    [editImage],
+  );
+
+  /* ------------------------------ render ------------------------- */
 
   return (
-    <div className="flex flex-col h-full bg-shell-bg text-shell-text select-none">
-      {/* Toolbar */}
-      <div className="flex items-center gap-2 px-4 py-3 border-b border-white/5">
-        <Image size={18} className="text-accent" />
-        <h1 className="text-sm font-semibold">Images</h1>
-        <span className="text-xs text-shell-text-tertiary">
-          {images.length} generated
+    <div className="flex h-full min-h-0 flex-col overflow-hidden bg-shell-bg text-shell-text select-none">
+      {/* title strip */}
+      <div className="flex h-[46px] flex-none items-center justify-center border-b border-shell-border">
+        <span className="text-[13px] font-semibold tracking-[-0.01em]">
+          Images Studio
         </span>
       </div>
 
-      <div className="flex-1 overflow-auto p-4 space-y-5">
-        {/* Generate form */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-sm font-semibold flex items-center gap-2">
-              <Wand2 size={14} className="text-accent" />
-              Generate Image
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            {/* Prompt */}
-            <div className="space-y-1.5">
-              <Label htmlFor="img-prompt">Prompt</Label>
-              <Textarea
-                id="img-prompt"
-                value={prompt}
-                onChange={(e) => setPrompt(e.target.value)}
-                placeholder="A serene mountain landscape at sunset..."
-                rows={3}
-                className="resize-none"
-              />
-            </div>
+      <div className="flex min-h-0 flex-1">
+        {/* left rail */}
+        <div className="flex w-[68px] flex-none flex-col items-center gap-1.5 border-r border-shell-border bg-shell-bg-deep py-3.5">
+          {RAIL.map((r) => {
+            const Icon = r.icon;
+            const on = view === r.id;
+            return (
+              <button
+                key={r.id}
+                type="button"
+                aria-label={r.label}
+                aria-current={on ? "page" : undefined}
+                onClick={() => setView(r.id)}
+                className={`flex h-[46px] w-[46px] flex-col items-center justify-center gap-0.5 rounded-xl text-[9px] font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${
+                  on
+                    ? "bg-gradient-to-b from-accent/25 to-transparent text-accent"
+                    : "text-shell-text-tertiary hover:bg-white/10 hover:text-shell-text-secondary"
+                }`}
+              >
+                <Icon size={21} />
+                {r.label}
+              </button>
+            );
+          })}
+          <div className="flex-1" />
+          <button
+            type="button"
+            aria-label="Models"
+            onClick={() => setBrowserOpen(true)}
+            className="flex h-[46px] w-[46px] flex-col items-center justify-center gap-0.5 rounded-xl text-[9px] font-semibold text-shell-text-tertiary transition-colors hover:bg-white/10 hover:text-shell-text-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+          >
+            <Settings2 size={21} />
+            Models
+          </button>
+        </div>
 
-            {/* Model dropdown */}
-            <div className="space-y-1.5">
-              <Label htmlFor="img-model">Model</Label>
-              <div className="flex items-center gap-2">
-                <select
-                  id="img-model"
-                  value={
-                    selectedModelId && selectedVariantId
-                      ? `${selectedModelId}::${selectedVariantId}`
-                      : ""
-                  }
-                  onChange={handleSelectChange}
-                  className="flex-1 h-9 rounded-lg border border-white/10 bg-shell-bg-deep px-3 py-1 text-sm text-shell-text focus-visible:outline-none focus-visible:border-accent/40 focus-visible:ring-2 focus-visible:ring-accent/20"
-                >
-                  {availableOptions.length === 0 && (
-                    <option value="">
-                      No models available — click Browse…
-                    </option>
-                  )}
-                  {availableOptions.map((opt) => (
-                    <option
-                      key={`${opt.modelId}::${opt.variantId}`}
-                      value={`${opt.modelId}::${opt.variantId}`}
-                    >
-                      {"\u2713 "}
-                      {opt.label}
-                    </option>
-                  ))}
-                  <option disabled>────────</option>
-                  <option value="__browse__">Get more models…</option>
-                </select>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => setBrowserOpen(true)}
-                  type="button"
-                >
-                  <Package size={12} />
-                  Browse
-                </Button>
-              </div>
-              {!selectedVariant && availableOptions.length === 0 && (
-                <div className="text-xs text-shell-text-tertiary mt-1">
-                  Open the browser to download an image generation model.
-                </div>
-              )}
-            </div>
+        {/* active surface */}
+        <div className="flex min-w-0 flex-1 flex-col">
+          {view === "create" && (
+            <CreateView
+              mode={mode}
+              onModeChange={setMode}
+              modelName={modelName}
+              modelMeta={modelMeta}
+              onPickModel={() => setBrowserOpen(true)}
+              prompt={prompt}
+              onPromptChange={setPrompt}
+              size={size}
+              onSizeChange={setSize}
+              steps={steps}
+              onStepsChange={setSteps}
+              guidance={guidance}
+              onGuidanceChange={setGuidance}
+              style={style}
+              onStyleChange={setStyle}
+              seed={seed}
+              onReroll={handleReroll}
+              results={images}
+              activeResultId={activeResultId}
+              onSelectResult={setActiveResultId}
+              generating={generating}
+              canGenerate={canGenerate}
+              onGenerate={() => void runGenerate()}
+              error={error}
+              onEditResult={openInEdit}
+              onDownloadResult={handleDownload}
+            />
+          )}
 
-            {/* Row of controls */}
-            <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-              {/* Size */}
-              <div className="space-y-1.5">
-                <Label htmlFor="img-size">Size</Label>
-                <select
-                  id="img-size"
-                  value={size}
-                  onChange={(e) => setSize(parseInt(e.target.value))}
-                  className="flex h-9 w-full rounded-lg border border-white/10 bg-shell-bg-deep px-3 py-1 text-sm text-shell-text focus-visible:outline-none focus-visible:border-accent/40 focus-visible:ring-2 focus-visible:ring-accent/20"
-                >
-                  <option value={256}>256x256</option>
-                  <option value={384}>384x384</option>
-                  <option value={512}>512x512</option>
-                </select>
-              </div>
+          {view === "library" && (
+            <LibraryView
+              images={images}
+              loading={loading}
+              filter={libFilter}
+              onFilterChange={setLibFilter}
+              selectedId={librarySelectedId}
+              onSelect={setLibrarySelectedId}
+              onReroll={rerollFrom}
+              onDownload={handleDownload}
+              onDelete={handleDelete}
+              onEdit={openInEdit}
+            />
+          )}
 
-              {/* Seed */}
-              <div className="space-y-1.5">
-                <Label htmlFor="img-seed">Seed</Label>
-                <Input
-                  id="img-seed"
-                  type="number"
-                  value={seed}
-                  onChange={(e) => setSeed(e.target.value)}
-                  placeholder="Random"
-                />
-              </div>
-
-              {/* Guidance */}
-              <div className="space-y-1.5">
-                <Label htmlFor="img-guidance">Guidance</Label>
-                <Input
-                  id="img-guidance"
-                  type="number"
-                  step="0.5"
-                  min="1"
-                  max="20"
-                  value={guidance}
-                  onChange={(e) => setGuidance(e.target.value)}
-                />
-              </div>
-            </div>
-
-            {/* Steps slider */}
-            <div>
-              <div className="flex items-center justify-between mb-1.5">
-                <Label htmlFor="img-steps">Steps</Label>
-                <span className="text-xs text-shell-text-tertiary tabular-nums">
-                  {steps}
-                </span>
-              </div>
-              <input
-                id="img-steps"
-                type="range"
-                min={1}
-                max={8}
-                value={steps}
-                onChange={(e) => setSteps(parseInt(e.target.value))}
-                className="w-full accent-accent"
-              />
-            </div>
-
-            {/* Error */}
-            {error && (
-              <div className="text-xs text-red-400 bg-red-500/10 border border-red-500/30 rounded-lg px-3 py-2">
-                {error}
-              </div>
-            )}
-
-            {/* Generate button */}
-            <Button
-              size="lg"
-              onClick={handleGenerate}
-              disabled={
-                !prompt.trim() ||
-                generating ||
-                !selectedVariant ||
-                !selectedVariant.downloaded
-              }
-            >
-              <Wand2 size={14} />
-              {generating ? "Generating..." : "Generate"}
-            </Button>
-
-            {/* Loading spinner */}
-            {generating && (
-              <div className="flex items-center gap-2 text-xs text-shell-text-tertiary">
-                <div className="w-4 h-4 border-2 border-accent border-t-transparent rounded-full animate-spin" />
-                Generating image...
-              </div>
-            )}
-          </CardContent>
-        </Card>
-
-        {/* Gallery */}
-        {loading ? (
-          <div className="text-center text-shell-text-tertiary text-sm py-8">
-            Loading gallery...
-          </div>
-        ) : images.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-12 gap-3 text-shell-text-tertiary">
-            <Image size={40} className="opacity-30" />
-            <p className="text-sm">No images generated yet</p>
-            <p className="text-xs">
-              Use the form above to create your first image
-            </p>
-          </div>
-        ) : (
-          <div>
-            <h2 className="text-sm font-medium text-shell-text-secondary mb-3">
-              Gallery
-            </h2>
-            <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
-              {images.map((img) => (
-                <Card key={img.id} className="overflow-hidden group">
-                  <div className="aspect-square bg-shell-bg-deep flex items-center justify-center">
-                    {img.url ? (
-                      <img
-                        src={img.url}
-                        alt={img.prompt}
-                        className="w-full h-full object-cover"
-                      />
-                    ) : (
-                      <div className="text-center px-3">
-                        <Image
-                          size={24}
-                          className="mx-auto text-shell-text-tertiary mb-1"
-                        />
-                        <p className="text-[10px] text-shell-text-tertiary line-clamp-2">
-                          {img.prompt}
-                        </p>
-                      </div>
-                    )}
-                  </div>
-
-                  <CardContent className="p-2.5 space-y-1">
-                    <p className="text-xs line-clamp-2 leading-relaxed">
-                      {img.prompt}
-                    </p>
-                    <div className="flex items-center gap-2 text-[10px] text-shell-text-tertiary">
-                      <span>{img.model}</span>
-                      <span>
-                        {typeof img.size === "number"
-                          ? `${img.size}px`
-                          : img.size}
-                      </span>
-                      <span>{img.steps}st</span>
-                    </div>
-                    <div className="flex items-center gap-1 pt-1">
-                      {img.url && (
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          onClick={() => handleDownload(img)}
-                          className="h-7 w-7"
-                          aria-label={`Download image: ${img.prompt.slice(0, 30)}`}
-                          title="Download"
-                        >
-                          <Download size={13} />
-                        </Button>
-                      )}
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => handleDelete(img.id)}
-                        className="h-7 w-7 hover:text-red-400 hover:bg-red-500/15"
-                        aria-label={`Delete image: ${img.prompt.slice(0, 30)}`}
-                        title="Delete"
-                      >
-                        <Trash2 size={13} />
-                      </Button>
-                    </div>
-                  </CardContent>
-                </Card>
-              ))}
-            </div>
-          </div>
-        )}
+          {view === "edit" && (
+            <EditView image={editImage} onApplyAdjust={applyAdjust} />
+          )}
+        </div>
       </div>
 
       <ModelBrowser

--- a/desktop/src/apps/images/CreateView.tsx
+++ b/desktop/src/apps/images/CreateView.tsx
@@ -1,0 +1,315 @@
+import { Sparkles, Pencil, Download, Check } from "lucide-react";
+import {
+  Segmented,
+  Slider,
+  Chip,
+  ModelPill,
+  SeedPill,
+  GroupLabel,
+} from "./controls";
+import {
+  SIZE_OPTIONS,
+  STYLE_CHIPS,
+  type GeneratedImage,
+  type GenerateMode,
+} from "./types";
+
+/* ------------------------------------------------------------------ */
+/*  CreateView — result canvas + filmstrip + controls + prompt bar     */
+/* ------------------------------------------------------------------ */
+
+export interface CreateViewProps {
+  mode: GenerateMode;
+  onModeChange: (m: GenerateMode) => void;
+
+  modelName: string;
+  modelMeta: string;
+  onPickModel: () => void;
+
+  prompt: string;
+  onPromptChange: (v: string) => void;
+
+  size: number;
+  onSizeChange: (v: number) => void;
+  steps: number;
+  onStepsChange: (v: number) => void;
+  guidance: number;
+  onGuidanceChange: (v: number) => void;
+  style: string | null;
+  onStyleChange: (v: string | null) => void;
+  seed: string;
+  onReroll: () => void;
+
+  results: GeneratedImage[];
+  activeResultId: string | null;
+  onSelectResult: (id: string) => void;
+
+  generating: boolean;
+  canGenerate: boolean;
+  onGenerate: () => void;
+  error: string | null;
+
+  onEditResult: (img: GeneratedImage) => void;
+  onDownloadResult: (img: GeneratedImage) => void;
+}
+
+export function CreateView(props: CreateViewProps) {
+  const {
+    mode,
+    onModeChange,
+    modelName,
+    modelMeta,
+    onPickModel,
+    prompt,
+    onPromptChange,
+    size,
+    onSizeChange,
+    steps,
+    onStepsChange,
+    guidance,
+    onGuidanceChange,
+    style,
+    onStyleChange,
+    seed,
+    onReroll,
+    results,
+    activeResultId,
+    onSelectResult,
+    generating,
+    canGenerate,
+    onGenerate,
+    error,
+    onEditResult,
+    onDownloadResult,
+  } = props;
+
+  const active =
+    results.find((r) => r.id === activeResultId) ?? results[0] ?? null;
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      {/* view header */}
+      <div className="flex h-[54px] flex-none items-center gap-3 border-b border-shell-border px-[22px]">
+        <h2 className="text-[17px] font-bold tracking-[-0.02em]">Create</h2>
+        <span className="text-[12px] text-shell-text-tertiary truncate">
+          {modelMeta}
+        </span>
+        <div className="ml-auto">
+          <Segmented<GenerateMode>
+            ariaLabel="Generation mode"
+            value={mode}
+            onChange={onModeChange}
+            options={[
+              { value: "single", label: "Single" },
+              { value: "batch", label: "Batch" },
+            ]}
+          />
+        </div>
+      </div>
+
+      <div className="flex min-h-0 flex-1">
+        {/* stage: canvas + filmstrip */}
+        <div className="flex min-w-0 flex-1 flex-col p-[22px]">
+          <div className="relative flex flex-1 items-center justify-center overflow-hidden rounded-2xl border border-shell-border bg-shell-bg-deep">
+            {generating ? (
+              <div className="flex flex-col items-center gap-3 text-shell-text-tertiary">
+                <div className="h-7 w-7 animate-spin rounded-full border-2 border-accent border-t-transparent" />
+                <span className="text-xs">Generating…</span>
+              </div>
+            ) : active && active.url ? (
+              <>
+                <img
+                  src={active.url}
+                  alt={active.prompt}
+                  className="h-full w-full object-cover"
+                />
+                <div className="absolute left-3.5 top-3.5 flex items-center gap-1.5 rounded-full border border-shell-border bg-shell-bg-glass px-3 py-1.5 text-[11px] font-semibold text-shell-text-secondary backdrop-blur-md">
+                  <Check size={12} className="text-emerald-400" />
+                  Generated
+                  {active.backend ? ` · ${active.backend}` : ""}
+                </div>
+                <div className="absolute bottom-3.5 right-3.5 flex gap-2">
+                  <button
+                    type="button"
+                    aria-label="Edit this image"
+                    onClick={() => onEditResult(active)}
+                    className="flex h-9 w-9 items-center justify-center rounded-xl border border-shell-border-strong bg-shell-bg-glass text-shell-text backdrop-blur-md transition-transform hover:-translate-y-0.5 hover:text-accent"
+                  >
+                    <Pencil size={16} />
+                  </button>
+                  <button
+                    type="button"
+                    aria-label="Download this image"
+                    onClick={() => onDownloadResult(active)}
+                    className="flex h-9 w-9 items-center justify-center rounded-xl border border-shell-border-strong bg-shell-bg-glass text-shell-text backdrop-blur-md transition-transform hover:-translate-y-0.5 hover:text-accent"
+                  >
+                    <Download size={16} />
+                  </button>
+                </div>
+              </>
+            ) : (
+              <div className="flex flex-col items-center gap-2 px-6 text-center text-shell-text-tertiary">
+                <Sparkles size={36} className="opacity-30" />
+                <p className="text-sm">Your generated image appears here</p>
+                <p className="text-xs">
+                  Describe something below, then hit Generate.
+                </p>
+              </div>
+            )}
+          </div>
+
+          {/* filmstrip */}
+          {results.length > 0 && (
+            <div
+              className="mt-3.5 flex flex-none gap-2.5 overflow-x-auto"
+              role="listbox"
+              aria-label="Recent results"
+            >
+              {results.slice(0, 12).map((r) => {
+                const on = r.id === (active?.id ?? null);
+                return (
+                  <button
+                    key={r.id}
+                    type="button"
+                    role="option"
+                    aria-selected={on}
+                    aria-label={`Select result: ${r.prompt.slice(0, 40)}`}
+                    onClick={() => onSelectResult(r.id)}
+                    className={`h-16 w-16 flex-none overflow-hidden rounded-xl border transition-transform hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${
+                      on
+                        ? "border-accent ring-2 ring-accent/30"
+                        : "border-shell-border"
+                    }`}
+                  >
+                    {r.url ? (
+                      <img
+                        src={r.url}
+                        alt={r.prompt}
+                        className="h-full w-full object-cover"
+                      />
+                    ) : (
+                      <span className="flex h-full w-full items-center justify-center bg-shell-bg-deep text-shell-text-tertiary">
+                        <Sparkles size={16} />
+                      </span>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        {/* controls rail */}
+        <div className="flex w-[286px] flex-none flex-col gap-[18px] overflow-auto border-l border-shell-border p-[18px]">
+          <div>
+            <GroupLabel>Model</GroupLabel>
+            <ModelPill name={modelName} meta={modelMeta} onClick={onPickModel} />
+          </div>
+
+          <div>
+            <GroupLabel>Size</GroupLabel>
+            <div className="grid grid-cols-4 gap-[7px]">
+              {SIZE_OPTIONS.map((s) => {
+                const on = s === size;
+                return (
+                  <button
+                    key={s}
+                    type="button"
+                    aria-pressed={on}
+                    onClick={() => onSizeChange(s)}
+                    className={`rounded-xl border py-2.5 text-center text-[11px] font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${
+                      on
+                        ? "border-transparent bg-accent text-white"
+                        : "border-shell-border bg-shell-surface text-shell-text-secondary hover:bg-white/10"
+                    }`}
+                  >
+                    {s}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <Slider
+            id="create-steps"
+            label="Steps"
+            value={steps}
+            min={1}
+            max={50}
+            display={String(steps)}
+            onChange={(v) => onStepsChange(Math.round(v))}
+          />
+
+          <Slider
+            id="create-guidance"
+            label="Guidance"
+            value={guidance}
+            min={1}
+            max={20}
+            step={0.5}
+            display={guidance.toFixed(1)}
+            onChange={onGuidanceChange}
+          />
+
+          <div>
+            <GroupLabel>Style</GroupLabel>
+            <div className="flex flex-wrap gap-[7px]">
+              {STYLE_CHIPS.map((s) => (
+                <Chip
+                  key={s}
+                  label={s}
+                  on={style === s}
+                  onClick={() => onStyleChange(style === s ? null : s)}
+                />
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <GroupLabel>Seed</GroupLabel>
+            <SeedPill seed={seed} onReroll={onReroll} />
+          </div>
+        </div>
+      </div>
+
+      {/* prompt bar */}
+      <div className="flex flex-none items-end gap-3 border-t border-shell-border bg-shell-bg-deep px-[22px] py-4">
+        <label htmlFor="create-prompt" className="sr-only">
+          Image prompt
+        </label>
+        <textarea
+          id="create-prompt"
+          value={prompt}
+          onChange={(e) => onPromptChange(e.target.value)}
+          onKeyDown={(e) => {
+            if ((e.metaKey || e.ctrlKey) && e.key === "Enter" && canGenerate) {
+              e.preventDefault();
+              onGenerate();
+            }
+          }}
+          placeholder="Describe the image you want to create…"
+          rows={1}
+          className="min-h-[50px] flex-1 resize-none rounded-2xl border border-shell-border bg-shell-surface px-4 py-3.5 text-[13.5px] text-shell-text placeholder:text-shell-text-tertiary focus-visible:outline-none focus-visible:border-accent/40 focus-visible:ring-2 focus-visible:ring-accent/20"
+        />
+        <button
+          type="button"
+          onClick={onGenerate}
+          disabled={!canGenerate}
+          className="flex h-[50px] flex-none items-center gap-2 rounded-2xl bg-gradient-to-br from-accent to-accent/70 px-6 text-sm font-bold text-white shadow-lg shadow-accent/20 transition-all hover:-translate-y-0.5 hover:brightness-105 disabled:pointer-events-none disabled:opacity-50"
+        >
+          <Sparkles size={18} />
+          {generating ? "Generating…" : "Generate"}
+        </button>
+      </div>
+
+      {error && (
+        <div
+          role="alert"
+          className="border-t border-red-500/30 bg-red-500/10 px-[22px] py-2 text-xs text-red-400"
+        >
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/desktop/src/apps/images/EditView.tsx
+++ b/desktop/src/apps/images/EditView.tsx
@@ -1,0 +1,335 @@
+import { useState, useMemo } from "react";
+import {
+  SlidersHorizontal,
+  Eraser,
+  Sparkles,
+  Scissors,
+  Maximize2,
+  Expand,
+  Shuffle,
+  Undo2,
+  Check,
+  ImageIcon,
+} from "lucide-react";
+import { Slider, Chip, GroupLabel } from "./controls";
+import { STAGED_TOOLS, type EditTool, type GeneratedImage } from "./types";
+
+/* ------------------------------------------------------------------ */
+/*  EditView — tool rail + canvas + tool options + action bar          */
+/*                                                                     */
+/*  Adjust is a REAL client-side op (CSS filters). All generative ops   */
+/*  (erase/inpaint/removebg/extend/upscale/vary) have no backend yet    */
+/*  and are gated with a "Coming soon" affordance — Apply is disabled.  */
+/* ------------------------------------------------------------------ */
+
+interface ToolDef {
+  id: EditTool;
+  label: string;
+  icon: typeof SlidersHorizontal;
+  title: string;
+  desc: string;
+}
+
+const TOOLS: ToolDef[] = [
+  {
+    id: "adjust",
+    label: "Adjust",
+    icon: SlidersHorizontal,
+    title: "Adjust",
+    desc: "Tune brightness, contrast and saturation. Applied live, on-device.",
+  },
+  {
+    id: "erase",
+    label: "Erase",
+    icon: Eraser,
+    title: "Magic Eraser",
+    desc: "Brush over anything you want gone. taOS fills the area to match the surroundings.",
+  },
+  {
+    id: "inpaint",
+    label: "Inpaint",
+    icon: Sparkles,
+    title: "Inpaint",
+    desc: "Paint a mask, then describe what should appear there instead.",
+  },
+  {
+    id: "removebg",
+    label: "Remove BG",
+    icon: Scissors,
+    title: "Remove background",
+    desc: "Cut the subject out and drop a transparent background, on-device.",
+  },
+  {
+    id: "extend",
+    label: "Extend",
+    icon: Expand,
+    title: "Extend / outpaint",
+    desc: "Grow the canvas and let taOS paint in the new edges.",
+  },
+  {
+    id: "upscale",
+    label: "Upscale",
+    icon: Maximize2,
+    title: "Upscale",
+    desc: "Increase resolution and sharpen detail without artefacts.",
+  },
+  {
+    id: "vary",
+    label: "Vary",
+    icon: Shuffle,
+    title: "Variations",
+    desc: "Generate fresh takes that keep the spirit of this image.",
+  },
+];
+
+export interface EditViewProps {
+  image: GeneratedImage | null;
+  onApplyAdjust: (filterCss: string) => void;
+}
+
+const DEFAULT_ADJUST = { brightness: 100, contrast: 100, saturation: 100 };
+
+export function EditView({ image, onApplyAdjust }: EditViewProps) {
+  const [tool, setTool] = useState<EditTool>("adjust");
+  const [adjust, setAdjust] = useState(DEFAULT_ADJUST);
+  const [brush, setBrush] = useState(54);
+  const [replacePrompt, setReplacePrompt] = useState("");
+  const [eraseMode, setEraseMode] = useState<"erase" | "replace">("erase");
+
+  const filterCss = useMemo(
+    () =>
+      `brightness(${adjust.brightness}%) contrast(${adjust.contrast}%) saturate(${adjust.saturation}%)`,
+    [adjust],
+  );
+
+  const def = TOOLS.find((t) => t.id === tool) ?? TOOLS[0]!;
+  const staged = STAGED_TOOLS.has(tool);
+  const dirty =
+    tool === "adjust" &&
+    (adjust.brightness !== 100 ||
+      adjust.contrast !== 100 ||
+      adjust.saturation !== 100);
+
+  function reset() {
+    if (tool === "adjust") setAdjust(DEFAULT_ADJUST);
+    setReplacePrompt("");
+  }
+
+  function apply() {
+    if (tool === "adjust") onApplyAdjust(filterCss);
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      {/* view header */}
+      <div className="flex h-[54px] flex-none items-center gap-3 border-b border-shell-border px-[22px]">
+        <h2 className="text-[17px] font-bold tracking-[-0.02em]">Edit</h2>
+        <span className="text-[12px] text-shell-text-tertiary truncate">
+          {image
+            ? `${image.prompt.split(" ").slice(0, 4).join(" ")} · ${
+                typeof image.size === "number"
+                  ? `${image.size} × ${image.size}`
+                  : image.size
+              }`
+            : "No image selected"}
+        </span>
+      </div>
+
+      <div className="flex min-h-0 flex-1">
+        {/* tool rail */}
+        <div
+          className="flex w-[78px] flex-none flex-col items-center gap-1 border-r border-shell-border bg-shell-bg-deep py-3"
+          role="tablist"
+          aria-label="Edit tools"
+        >
+          {TOOLS.map((t) => {
+            const Icon = t.icon;
+            const on = t.id === tool;
+            return (
+              <button
+                key={t.id}
+                type="button"
+                role="tab"
+                aria-selected={on}
+                aria-label={t.label}
+                onClick={() => setTool(t.id)}
+                className={`flex w-[62px] flex-col items-center gap-1 rounded-xl py-2.5 text-[9.5px] font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${
+                  on
+                    ? "bg-gradient-to-b from-accent/25 to-transparent text-accent"
+                    : "text-shell-text-tertiary hover:bg-white/10 hover:text-shell-text-secondary"
+                }`}
+              >
+                <Icon size={20} />
+                {t.label}
+              </button>
+            );
+          })}
+        </div>
+
+        {/* canvas */}
+        <div className="relative flex min-w-0 flex-1 items-center justify-center p-[22px]">
+          {image && image.url ? (
+            <div className="relative overflow-hidden rounded-2xl border border-shell-border shadow-[var(--shadow-window)]">
+              <img
+                src={image.url}
+                alt={image.prompt}
+                style={tool === "adjust" ? { filter: filterCss } : undefined}
+                className="block max-h-[430px] w-auto"
+              />
+              {/* brush-mask overlay preview for staged masking tools */}
+              {(tool === "erase" || tool === "inpaint") && (
+                <span
+                  aria-hidden="true"
+                  className="pointer-events-none absolute left-[46%] top-[34%] rounded-full border-2 border-dashed border-accent bg-accent/30 mix-blend-screen"
+                  style={{ width: brush * 2.4, height: brush * 1.9 }}
+                />
+              )}
+            </div>
+          ) : (
+            <div className="flex flex-col items-center gap-2 text-shell-text-tertiary">
+              <ImageIcon size={40} className="opacity-30" />
+              <p className="text-sm">Pick an image from the Library to edit</p>
+            </div>
+          )}
+        </div>
+
+        {/* options panel */}
+        <div className="flex w-[286px] flex-none flex-col gap-[18px] overflow-auto border-l border-shell-border p-[18px]">
+          <div className="flex items-center gap-2.5 text-[15px] font-bold tracking-[-0.01em]">
+            <def.icon size={18} className="text-accent" />
+            {def.title}
+            {staged && (
+              <span className="ml-auto rounded-full border border-shell-border bg-shell-surface px-2 py-0.5 text-[9.5px] font-semibold uppercase tracking-wide text-shell-text-tertiary">
+                Soon
+              </span>
+            )}
+          </div>
+          <p className="-mt-2 text-[12px] leading-relaxed text-shell-text-secondary">
+            {def.desc}
+          </p>
+
+          {tool === "adjust" && (
+            <>
+              <Slider
+                id="edit-brightness"
+                label="Brightness"
+                value={adjust.brightness}
+                min={0}
+                max={200}
+                display={`${adjust.brightness}%`}
+                onChange={(v) =>
+                  setAdjust((a) => ({ ...a, brightness: Math.round(v) }))
+                }
+              />
+              <Slider
+                id="edit-contrast"
+                label="Contrast"
+                value={adjust.contrast}
+                min={0}
+                max={200}
+                display={`${adjust.contrast}%`}
+                onChange={(v) =>
+                  setAdjust((a) => ({ ...a, contrast: Math.round(v) }))
+                }
+              />
+              <Slider
+                id="edit-saturation"
+                label="Saturation"
+                value={adjust.saturation}
+                min={0}
+                max={200}
+                display={`${adjust.saturation}%`}
+                onChange={(v) =>
+                  setAdjust((a) => ({ ...a, saturation: Math.round(v) }))
+                }
+              />
+            </>
+          )}
+
+          {(tool === "erase" || tool === "inpaint") && (
+            <>
+              <Slider
+                id="edit-brush"
+                label="Brush size"
+                value={brush}
+                min={10}
+                max={120}
+                display={String(brush)}
+                onChange={(v) => setBrush(Math.round(v))}
+              />
+              <div>
+                <GroupLabel>
+                  {tool === "inpaint" ? "Replace with" : "Or replace with"}
+                </GroupLabel>
+                <input
+                  type="text"
+                  value={replacePrompt}
+                  onChange={(e) => setReplacePrompt(e.target.value)}
+                  placeholder="optional prompt"
+                  aria-label="Replacement prompt"
+                  className="w-full rounded-xl border border-shell-border bg-shell-surface px-3 py-2.5 text-[12.5px] text-shell-text placeholder:text-shell-text-tertiary focus-visible:outline-none focus-visible:border-accent/40 focus-visible:ring-2 focus-visible:ring-accent/20"
+                />
+              </div>
+              {tool === "erase" && (
+                <div>
+                  <GroupLabel>Mode</GroupLabel>
+                  <div className="flex gap-[7px]">
+                    <Chip
+                      label="Erase"
+                      on={eraseMode === "erase"}
+                      onClick={() => setEraseMode("erase")}
+                    />
+                    <Chip
+                      label="Replace"
+                      on={eraseMode === "replace"}
+                      onClick={() => setEraseMode("replace")}
+                    />
+                  </div>
+                </div>
+              )}
+            </>
+          )}
+
+          {staged && tool !== "erase" && tool !== "inpaint" && (
+            <p className="rounded-xl border border-shell-border bg-shell-surface px-3 py-2.5 text-[12px] leading-relaxed text-shell-text-tertiary">
+              This on-device tool is coming soon.
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* action bar */}
+      <div className="flex flex-none items-center gap-2.5 border-t border-shell-border bg-shell-bg-deep px-[22px] py-3">
+        <button
+          type="button"
+          onClick={reset}
+          disabled={tool === "adjust" ? !dirty : !staged && !replacePrompt}
+          aria-label="Undo changes"
+          className="flex h-[42px] items-center gap-1.5 rounded-xl border border-transparent px-4 text-[12.5px] font-semibold text-shell-text-tertiary transition-colors hover:bg-white/10 disabled:pointer-events-none disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+        >
+          <Undo2 size={15} />
+          Undo
+        </button>
+        <button
+          type="button"
+          onClick={reset}
+          aria-label="Reset"
+          className="flex h-[42px] items-center rounded-xl border border-transparent px-4 text-[12.5px] font-semibold text-shell-text-tertiary transition-colors hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+        >
+          Reset
+        </button>
+        <button
+          type="button"
+          onClick={apply}
+          disabled={!image || staged || (tool === "adjust" && !dirty)}
+          aria-label={staged ? "Apply (coming soon)" : "Apply changes"}
+          title={staged ? "Coming soon" : undefined}
+          className="ml-auto flex h-[42px] items-center gap-1.5 rounded-xl border border-transparent bg-gradient-to-br from-accent to-accent/70 px-5 text-[12.5px] font-semibold text-white shadow-lg shadow-accent/20 transition-all hover:-translate-y-0.5 hover:brightness-105 disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+        >
+          <Check size={16} />
+          {staged ? "Coming soon" : "Apply"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/apps/images/LibraryView.tsx
+++ b/desktop/src/apps/images/LibraryView.tsx
@@ -1,0 +1,217 @@
+import { RefreshCw, Download, Trash2, Pencil, ImageIcon } from "lucide-react";
+import { Segmented } from "./controls";
+import { type GeneratedImage, type LibraryFilter } from "./types";
+
+/* ------------------------------------------------------------------ */
+/*  LibraryView — gallery grid + detail pane                           */
+/* ------------------------------------------------------------------ */
+
+export interface LibraryViewProps {
+  images: GeneratedImage[];
+  loading: boolean;
+  filter: LibraryFilter;
+  onFilterChange: (f: LibraryFilter) => void;
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+  onReroll: (img: GeneratedImage) => void;
+  onDownload: (img: GeneratedImage) => void;
+  onDelete: (id: string) => void;
+  onEdit: (img: GeneratedImage) => void;
+}
+
+function GcardSkeleton() {
+  return (
+    <div
+      className="taos-shimmer aspect-square rounded-2xl border border-shell-border bg-shell-surface-active"
+      aria-hidden="true"
+    />
+  );
+}
+
+function MetaRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between text-[11.5px]">
+      <span className="text-shell-text-tertiary">{label}</span>
+      <b className="font-semibold tabular-nums text-shell-text">{value}</b>
+    </div>
+  );
+}
+
+export function LibraryView({
+  images,
+  loading,
+  filter,
+  onFilterChange,
+  selectedId,
+  onSelect,
+  onReroll,
+  onDownload,
+  onDelete,
+  onEdit,
+}: LibraryViewProps) {
+  const filtered = images.filter((img) => {
+    if (filter === "all") return true;
+    const m = img.model.toLowerCase();
+    if (filter === "flux") return m.includes("flux");
+    if (filter === "sdxl") return m.includes("sdxl") || m.includes("sd-xl");
+    return true;
+  });
+
+  const selected =
+    filtered.find((i) => i.id === selectedId) ?? filtered[0] ?? null;
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      {/* view header */}
+      <div className="flex h-[54px] flex-none items-center gap-3 border-b border-shell-border px-[22px]">
+        <h2 className="text-[17px] font-bold tracking-[-0.02em]">Library</h2>
+        <span className="text-[12px] text-shell-text-tertiary">
+          {images.length} {images.length === 1 ? "creation" : "creations"}
+        </span>
+        <div className="ml-auto">
+          <Segmented<LibraryFilter>
+            ariaLabel="Filter by model"
+            value={filter}
+            onChange={onFilterChange}
+            options={[
+              { value: "all", label: "All" },
+              { value: "flux", label: "FLUX" },
+              { value: "sdxl", label: "SDXL" },
+            ]}
+          />
+        </div>
+      </div>
+
+      <div className="flex min-h-0 flex-1">
+        {/* grid */}
+        <div
+          className={`grid flex-1 content-start gap-3.5 overflow-auto p-[22px] ${
+            selected ? "grid-cols-3" : "grid-cols-4"
+          }`}
+        >
+          {loading ? (
+            [0, 1, 2, 3, 4, 5].map((i) => <GcardSkeleton key={i} />)
+          ) : filtered.length === 0 ? (
+            <div className="col-span-full flex flex-col items-center justify-center gap-2 py-16 text-shell-text-tertiary">
+              <ImageIcon size={40} className="opacity-30" />
+              <p className="text-sm">No images yet</p>
+              <p className="text-xs">Head to Create to make your first one.</p>
+            </div>
+          ) : (
+            filtered.map((img) => {
+              const sel = img.id === (selected?.id ?? null);
+              return (
+                <button
+                  key={img.id}
+                  type="button"
+                  aria-label={`Open image: ${img.prompt.slice(0, 40)}`}
+                  aria-pressed={sel}
+                  onClick={() => onSelect(img.id)}
+                  className={`group relative aspect-square overflow-hidden rounded-2xl border text-left transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[var(--shadow-card-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${
+                    sel
+                      ? "border-accent ring-2 ring-accent/30"
+                      : "border-shell-border hover:border-shell-border-strong"
+                  }`}
+                >
+                  {img.url ? (
+                    <img
+                      src={img.url}
+                      alt={img.prompt}
+                      className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+                    />
+                  ) : (
+                    <span className="flex h-full w-full items-center justify-center bg-shell-bg-deep text-shell-text-tertiary">
+                      <ImageIcon size={22} />
+                    </span>
+                  )}
+                  <span className="pointer-events-none absolute inset-0 flex items-end bg-gradient-to-t from-black/60 via-transparent to-transparent p-2.5 opacity-0 transition-opacity duration-200 group-hover:opacity-100">
+                    <span className="line-clamp-2 text-[10.5px] leading-snug text-white">
+                      {img.prompt}
+                    </span>
+                  </span>
+                </button>
+              );
+            })
+          )}
+        </div>
+
+        {/* detail pane */}
+        {selected && (
+          <div className="flex w-[300px] flex-none flex-col gap-4 overflow-auto border-l border-shell-border p-[18px]">
+            <div className="aspect-square overflow-hidden rounded-2xl border border-shell-border bg-shell-bg-deep">
+              {selected.url ? (
+                <img
+                  src={selected.url}
+                  alt={selected.prompt}
+                  className="h-full w-full object-cover"
+                />
+              ) : (
+                <span className="flex h-full w-full items-center justify-center text-shell-text-tertiary">
+                  <ImageIcon size={28} />
+                </span>
+              )}
+            </div>
+
+            <h3 className="text-sm font-bold tracking-[-0.01em] line-clamp-1">
+              {selected.prompt.split(" ").slice(0, 4).join(" ") || "Untitled"}
+            </h3>
+            <p className="text-[12.5px] leading-relaxed text-shell-text-secondary">
+              {selected.prompt}
+            </p>
+
+            <div className="flex flex-col gap-2">
+              <MetaRow label="Model" value={selected.model || "—"} />
+              <MetaRow
+                label="Size"
+                value={
+                  typeof selected.size === "number"
+                    ? `${selected.size} × ${selected.size}`
+                    : String(selected.size || "—")
+                }
+              />
+              <MetaRow label="Steps" value={String(selected.steps || "—")} />
+              <MetaRow label="Seed" value={String(selected.seed || "—")} />
+              <MetaRow label="Backend" value={selected.backend || "—"} />
+            </div>
+
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => onReroll(selected)}
+                aria-label="Re-roll with a new seed"
+                className="flex h-9 flex-1 items-center justify-center gap-1.5 rounded-xl border border-transparent bg-accent text-[11.5px] font-semibold text-white transition-all hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+              >
+                <RefreshCw size={14} />
+                Re-roll
+              </button>
+              <button
+                type="button"
+                onClick={() => onEdit(selected)}
+                aria-label="Edit image"
+                className="flex h-9 w-9 items-center justify-center rounded-xl border border-shell-border bg-shell-surface text-shell-text transition-colors hover:bg-white/10 hover:border-shell-border-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+              >
+                <Pencil size={14} />
+              </button>
+              <button
+                type="button"
+                onClick={() => onDownload(selected)}
+                aria-label="Download image"
+                className="flex h-9 w-9 items-center justify-center rounded-xl border border-shell-border bg-shell-surface text-shell-text transition-colors hover:bg-white/10 hover:border-shell-border-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+              >
+                <Download size={14} />
+              </button>
+              <button
+                type="button"
+                onClick={() => onDelete(selected.id)}
+                aria-label="Delete image"
+                className="flex h-9 w-9 items-center justify-center rounded-xl border border-shell-border bg-shell-surface text-shell-text transition-colors hover:bg-red-500/15 hover:text-red-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+              >
+                <Trash2 size={14} />
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/apps/images/controls.tsx
+++ b/desktop/src/apps/images/controls.tsx
@@ -1,0 +1,190 @@
+import { ChevronDown, RefreshCw } from "lucide-react";
+
+/* ------------------------------------------------------------------ */
+/*  Images Studio — small shared control components                    */
+/*                                                                     */
+/*  Theme rule: semantic tokens + auto-inverting white/N utilities      */
+/*  only. No hex / rgb() literals.                                      */
+/* ------------------------------------------------------------------ */
+
+/** Pill-shaped segmented control (Single/Batch, All/FLUX/SDXL, …). */
+export function Segmented<T extends string>({
+  options,
+  value,
+  onChange,
+  ariaLabel,
+}: {
+  options: readonly { value: T; label: string }[];
+  value: T;
+  onChange: (v: T) => void;
+  ariaLabel: string;
+}) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label={ariaLabel}
+      className="flex rounded-full border border-shell-border bg-shell-surface p-[3px]"
+    >
+      {options.map((opt) => {
+        const on = opt.value === value;
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            role="radio"
+            aria-checked={on}
+            onClick={() => onChange(opt.value)}
+            className={`rounded-full px-3 py-[5px] text-[11px] font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${
+              on
+                ? "bg-shell-surface-active text-shell-text"
+                : "text-shell-text-secondary hover:text-shell-text"
+            }`}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+/** Labelled slider. Renders a real <input type=range> (keyboard accessible)
+ *  with a styled track painted via accent-color. */
+export function Slider({
+  id,
+  label,
+  value,
+  min,
+  max,
+  step = 1,
+  display,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step?: number;
+  display: string;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between text-[11.5px]">
+        <label
+          htmlFor={id}
+          className="text-[11px] font-bold uppercase tracking-[0.06em] text-shell-text-tertiary"
+        >
+          {label}
+        </label>
+        <b className="font-bold tabular-nums text-shell-text">{display}</b>
+      </div>
+      <input
+        id={id}
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(parseFloat(e.target.value))}
+        aria-label={label}
+        className="w-full accent-accent"
+      />
+    </div>
+  );
+}
+
+/** Rounded chip toggle used for Style and Mode rows. */
+export function Chip({
+  label,
+  on,
+  onClick,
+  ariaPressed = true,
+}: {
+  label: string;
+  on: boolean;
+  onClick: () => void;
+  ariaPressed?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={ariaPressed ? on : undefined}
+      onClick={onClick}
+      className={`rounded-full border px-3 py-1.5 text-[11px] font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${
+        on
+          ? "border-accent bg-accent/15 text-accent"
+          : "border-shell-border bg-shell-surface text-shell-text-secondary hover:bg-white/10"
+      }`}
+    >
+      {label}
+    </button>
+  );
+}
+
+/** Model selector pill — shows the active model name + meta, opens the
+ *  catalog/browser when clicked. */
+export function ModelPill({
+  name,
+  meta,
+  onClick,
+}: {
+  name: string;
+  meta: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label="Change model"
+      className="flex w-full items-center gap-2.5 rounded-xl border border-shell-border bg-shell-surface px-3 py-2.5 text-left transition-colors hover:border-shell-border-strong hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+    >
+      <span className="h-6 w-6 shrink-0 rounded-lg bg-gradient-to-br from-accent to-accent/60" />
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-[12.5px] font-semibold text-shell-text">
+          {name}
+        </span>
+        <span className="block truncate text-[10.5px] text-shell-text-tertiary">
+          {meta}
+        </span>
+      </span>
+      <ChevronDown size={14} className="shrink-0 text-shell-text-tertiary" />
+    </button>
+  );
+}
+
+/** Seed pill with a re-roll button. */
+export function SeedPill({
+  seed,
+  onReroll,
+}: {
+  seed: string;
+  onReroll: () => void;
+}) {
+  return (
+    <div className="flex items-center gap-2 rounded-xl border border-shell-border bg-shell-surface px-3 py-2.5">
+      <span className="flex-1 truncate text-[12.5px] font-semibold tabular-nums text-shell-text">
+        {seed || "Random"}
+      </span>
+      <button
+        type="button"
+        onClick={onReroll}
+        aria-label="Re-roll seed"
+        className="rounded-md p-1 text-shell-text-tertiary transition-colors hover:bg-white/10 hover:text-shell-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+      >
+        <RefreshCw size={14} />
+      </button>
+    </div>
+  );
+}
+
+/** Uppercase control-group label. */
+export function GroupLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="mb-2.5 block text-[11px] font-bold uppercase tracking-[0.06em] text-shell-text-tertiary">
+      {children}
+    </span>
+  );
+}

--- a/desktop/src/apps/images/types.ts
+++ b/desktop/src/apps/images/types.ts
@@ -1,0 +1,87 @@
+/* ------------------------------------------------------------------ */
+/*  Images Studio — shared types                                       */
+/* ------------------------------------------------------------------ */
+
+/** A generated image as surfaced by /api/images (list) and the result
+ *  of /api/images/generate. Mirrors the shape the legacy ImagesApp mapped. */
+export interface GeneratedImage {
+  id: string;
+  url: string;
+  prompt: string;
+  model: string;
+  size: number | string;
+  steps: number;
+  seed: number;
+  guidance: number;
+  backend?: string;
+  createdAt: string;
+}
+
+export interface ModelVariant {
+  id: string;
+  name: string;
+  format?: string;
+  size_mb: number;
+  min_ram_mb?: number;
+  backend?: string[];
+  downloaded?: boolean;
+  compatibility: "green" | "yellow" | "red";
+  download_url?: string;
+}
+
+export interface ImageModel {
+  id: string;
+  name: string;
+  description?: string;
+  capabilities: string[];
+  variants: ModelVariant[];
+  has_downloaded_variant?: boolean;
+}
+
+/** Parameters posted to /api/images/generate. */
+export interface GenerateParams {
+  prompt: string;
+  model: string;
+  variant: string;
+  size: string;
+  steps: number;
+  seed: number;
+  guidance_scale: number;
+}
+
+export type StudioView = "create" | "library" | "edit";
+
+export type GenerateMode = "single" | "batch";
+
+export type LibraryFilter = "all" | "flux" | "sdxl";
+
+/** Edit tools. Client-side ops are real; generative ops are staged. */
+export type EditTool =
+  | "adjust"
+  | "erase"
+  | "inpaint"
+  | "removebg"
+  | "extend"
+  | "upscale"
+  | "vary";
+
+/** The generative tools have no backend yet and are gated with a
+ *  "Coming soon" affordance. "adjust" is real (CSS-filter based). */
+export const STAGED_TOOLS: ReadonlySet<EditTool> = new Set<EditTool>([
+  "erase",
+  "inpaint",
+  "removebg",
+  "extend",
+  "upscale",
+  "vary",
+]);
+
+export const SIZE_OPTIONS = [256, 512, 768, 1024] as const;
+
+export const STYLE_CHIPS = [
+  "Storybook",
+  "Photoreal",
+  "Watercolor",
+  "3D",
+  "Anime",
+] as const;


### PR DESCRIPTION
## What (task #42)

Rebuilds the basic Images app into a polished, Apple-like **Images Studio** matching the mock Jay approved (`.design/images-studio-mock.html`), the Store design DNA, and the Agents-app modular structure.

Three surfaces behind a left icon rail:
- **Create** — generation studio (result canvas + filmstrip + controls rail: model / size / steps / guidance / style chips / seed; prompt bar). Wired to `POST /api/images/generate`.
- **Library** — gallery grid + detail pane (metadata, re-roll / download / delete) + model filter. Wired to `GET/DELETE /api/images`.
- **Edit** — edit-tool rail. **Crop + adjust** (brightness/contrast/saturation) are **real** (client-side canvas). The AI ops (Magic Eraser, Inpaint, Remove BG, Outpaint, Upscale, Variations) have the full UI but are **staged 'coming soon'** — no backend yet, no broken calls.

## Quality
- Theme-compliant: only semantic tokens + auto-inverting `white/N` utilities, **zero hex literals**; verified in dark + light.
- Modular: `ImagesApp` shell + `images/{CreateView,LibraryView,EditView,controls,types}`. Keeps the `ImagesApp` export + registry path.
- ARIA on icon buttons; segmented controls as radiogroups; typecheck clean.

## Follow-up (separate)
Wire the staged Edit AI ops to a real backend: **IOPaint** (self-hostable: LaMa erase + SD/PowerPaint inpaint/outpaint + rembg bg-removal + RealESRGAN upscale + SAM), added as a catalog backend with `/api/images/edit|remove-bg|upscale` routed through the same scheduler.

**Draft** until screenshot-verified on a real build (both themes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Reorganized the Images app into a studio workflow with Create, Library, and Edit screens and left-rail navigation.
  * Added streamlined creation with mode switching, prompt generation, a recent-results filmstrip, seed/parameter controls, style options, and reroll support.
  * Enhanced the gallery with model-based filtering, selection details, and per-image actions (generate, reroll, download, delete, and open in editor).
  * Introduced an editor with adjustment (brightness/contrast/saturation via filter) and brush tools, plus apply/download of the adjusted result.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->