### PR TITLE
feat(contacts): bring Contacts up to the Store design bar

### DIFF
--- a/desktop/src/apps/ContactsApp.tsx
+++ b/desktop/src/apps/ContactsApp.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Plus, Search, Trash2, User, X, Edit } from "lucide-react";
+import { Plus, Search, Trash2, User, X, Edit, Mail, Phone, FileText, ChevronRight } from "lucide-react";
 import { Button, Input, Textarea, Label, Card, CardContent } from "@/components/ui";
 import { MobileSplitView } from "@/components/mobile/MobileSplitView";
 import { useIsMobile } from "@/hooks/use-is-mobile";
@@ -23,6 +23,60 @@ const emptyContact = (): Contact => ({
   phone: "",
   notes: "",
 });
+
+/* ------------------------------------------------------------------ */
+/*  Avatar — glossy gradient identity tile                            */
+/* ------------------------------------------------------------------ */
+
+/** Stable hue (0-359) hashed from an arbitrary string. */
+function hueFromString(input: string): number {
+  let hash = 0;
+  for (let i = 0; i < input.length; i++) {
+    hash = (hash * 31 + input.charCodeAt(i)) | 0;
+  }
+  return Math.abs(hash) % 360;
+}
+
+/** Up to two initials from a contact name. */
+function initialsFor(name: string): string {
+  const parts = name.trim().split(/[\s._-]+/).filter(Boolean);
+  if (parts.length === 0) return "";
+  if (parts.length === 1) return (parts[0] ?? "").slice(0, 2).toUpperCase();
+  return ((parts[0]?.[0] ?? "") + (parts[1]?.[0] ?? "")).toUpperCase();
+}
+
+/** A contact-identity tile: a glossy gradient square tinted with a stable
+ *  per-contact hue (genuinely-semantic — identity colour, like AgentRow's
+ *  per-agent colour), holding the contact's initials. Falls back to a neutral
+ *  person glyph when there is no name yet. */
+function ContactAvatar({ name, size = 36 }: { name: string; size?: number }) {
+  const initials = initialsFor(name);
+  const hue = hueFromString(name || "?");
+  const fontPx = Math.round(size * 0.4);
+  return (
+    <span
+      className="relative inline-flex items-center justify-center rounded-xl border border-shell-border shrink-0 overflow-hidden font-semibold text-white"
+      style={{
+        width: size,
+        height: size,
+        fontSize: fontPx,
+        background: `linear-gradient(150deg, hsl(${hue} 62% 56%), hsl(${(hue + 28) % 360} 58% 44%))`,
+      }}
+      aria-hidden="true"
+    >
+      {/* Glossy top sheen */}
+      <span
+        className="absolute inset-x-0 top-0 h-1/2"
+        style={{ background: "linear-gradient(180deg, rgba(255,255,255,0.22), transparent)" }}
+      />
+      {initials ? (
+        <span className="relative leading-none">{initials}</span>
+      ) : (
+        <User size={Math.round(size * 0.5)} className="relative text-white/85" />
+      )}
+    </span>
+  );
+}
 
 /* ------------------------------------------------------------------ */
 /*  Contact form — bottom sheet on mobile, modal on desktop            */
@@ -58,8 +112,8 @@ function ContactForm({
       <Card
         className={
           isMobile
-            ? "w-full max-h-[92%] overflow-y-auto bg-shell-surface shadow-2xl"
-            : "w-full max-w-md max-h-full overflow-y-auto bg-shell-surface shadow-2xl"
+            ? "w-full max-h-[92%] overflow-y-auto bg-shell-surface border-shell-border shadow-2xl"
+            : "w-full max-w-md max-h-full overflow-y-auto bg-shell-surface border-shell-border shadow-2xl"
         }
         style={isMobile ? { borderRadius: "20px 20px 0 0" } : undefined}
         onClick={(e) => e.stopPropagation()}
@@ -67,9 +121,9 @@ function ContactForm({
         <CardContent className="p-5 space-y-4">
           {/* Header */}
           <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <User size={16} className="text-accent" />
-              <h2 className="text-sm font-semibold">{isNew ? "New Contact" : "Edit Contact"}</h2>
+            <div className="flex items-center gap-2.5">
+              <ContactAvatar name={editing.name} size={32} />
+              <h2 className="text-sm font-semibold text-shell-text">{isNew ? "New Contact" : "Edit Contact"}</h2>
             </div>
             <Button variant="ghost" size="icon" onClick={onCancel} aria-label="Close form" className="h-7 w-7">
               <X size={16} />
@@ -137,6 +191,23 @@ function ContactForm({
 /*  Contact detail pane                                                */
 /* ------------------------------------------------------------------ */
 
+/** One labelled detail field rendered as a card row with a leading icon. */
+function DetailField({ icon, label, value, mono }: { icon: React.ReactNode; label: string; value: string; mono?: boolean }) {
+  return (
+    <Card className="rounded-xl border-shell-border bg-shell-surface p-3">
+      <CardContent className="p-0 flex items-start gap-3">
+        <span className="mt-0.5 inline-flex h-7 w-7 items-center justify-center rounded-lg bg-shell-surface-active text-shell-text-secondary shrink-0">
+          {icon}
+        </span>
+        <div className="min-w-0">
+          <div className="text-[10px] uppercase tracking-wide text-shell-text-tertiary mb-0.5">{label}</div>
+          <div className={`text-sm text-shell-text break-words ${mono ? "font-mono tabular-nums" : ""}`}>{value}</div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
 function ContactDetail({
   contact,
   onEdit,
@@ -152,12 +223,10 @@ function ContactDetail({
     <div className="flex flex-col h-full min-h-0 overflow-hidden">
       {/* Header — desktop only; mobile nav bar from MobileSplitView shows the name */}
       {!isMobile && (
-        <div className="flex items-start justify-between gap-3 px-4 py-3 border-b border-white/5 shrink-0">
-          <div className="flex items-center gap-3">
-            <div className="w-10 h-10 rounded-full bg-shell-surface flex items-center justify-center shrink-0">
-              <User size={18} className="text-shell-text-secondary" />
-            </div>
-            <h2 className="text-sm font-semibold text-shell-text">{contact.name}</h2>
+        <div className="flex items-start justify-between gap-3 px-4 py-3 border-b border-shell-border shrink-0">
+          <div className="flex items-center gap-3 min-w-0">
+            <ContactAvatar name={contact.name} size={40} />
+            <h2 className="text-sm font-semibold text-shell-text truncate">{contact.name}</h2>
           </div>
           <div className="flex items-center gap-1 shrink-0">
             <Button size="sm" variant="outline" onClick={onEdit} aria-label={`Edit ${contact.name}`}>
@@ -168,7 +237,7 @@ function ContactDetail({
               size="sm"
               variant="outline"
               onClick={onDelete}
-              className="hover:bg-red-500/15 hover:text-red-300"
+              className="hover:bg-red-500/15 hover:text-red-400"
               aria-label={`Delete ${contact.name}`}
             >
               <Trash2 size={13} />
@@ -180,12 +249,10 @@ function ContactDetail({
 
       {/* Mobile: avatar + action row */}
       {isMobile && (
-        <div className="shrink-0 px-4 py-3 border-b border-white/5">
-          <div className="flex items-center gap-3 mb-3">
-            <div className="w-12 h-12 rounded-full bg-shell-surface flex items-center justify-center shrink-0">
-              <User size={22} className="text-shell-text-secondary" />
-            </div>
-            <span className="text-base font-semibold text-shell-text">{contact.name}</span>
+        <div className="shrink-0 px-4 py-3 border-b border-shell-border">
+          <div className="flex items-center gap-3 mb-3 min-w-0">
+            <ContactAvatar name={contact.name} size={48} />
+            <span className="text-base font-semibold text-shell-text truncate">{contact.name}</span>
           </div>
           <div className="flex gap-2">
             <Button size="sm" variant="outline" onClick={onEdit} className="flex-1" aria-label={`Edit ${contact.name}`}>
@@ -196,7 +263,7 @@ function ContactDetail({
               size="sm"
               variant="outline"
               onClick={onDelete}
-              className="flex-1 hover:bg-red-500/15 hover:text-red-300"
+              className="flex-1 hover:bg-red-500/15 hover:text-red-400"
               aria-label={`Delete ${contact.name}`}
             >
               <Trash2 size={13} />
@@ -208,27 +275,18 @@ function ContactDetail({
 
       {/* Body */}
       <div className="flex-1 overflow-y-auto p-4 space-y-3">
-        {contact.email && (
-          <Card className="p-3">
-            <CardContent className="p-0">
-              <div className="text-[10px] uppercase tracking-wide text-shell-text-tertiary mb-1">Email</div>
-              <div className="text-sm text-shell-text">{contact.email}</div>
-            </CardContent>
-          </Card>
-        )}
-        {contact.phone && (
-          <Card className="p-3">
-            <CardContent className="p-0">
-              <div className="text-[10px] uppercase tracking-wide text-shell-text-tertiary mb-1">Phone</div>
-              <div className="text-sm text-shell-text">{contact.phone}</div>
-            </CardContent>
-          </Card>
-        )}
+        {contact.email && <DetailField icon={<Mail size={14} />} label="Email" value={contact.email} />}
+        {contact.phone && <DetailField icon={<Phone size={14} />} label="Phone" value={contact.phone} mono />}
         {contact.notes && (
-          <Card className="p-3">
-            <CardContent className="p-0">
-              <div className="text-[10px] uppercase tracking-wide text-shell-text-tertiary mb-1">Notes</div>
-              <div className="text-sm text-shell-text whitespace-pre-wrap">{contact.notes}</div>
+          <Card className="rounded-xl border-shell-border bg-shell-surface p-3">
+            <CardContent className="p-0 flex items-start gap-3">
+              <span className="mt-0.5 inline-flex h-7 w-7 items-center justify-center rounded-lg bg-shell-surface-active text-shell-text-secondary shrink-0">
+                <FileText size={14} />
+              </span>
+              <div className="min-w-0">
+                <div className="text-[10px] uppercase tracking-wide text-shell-text-tertiary mb-0.5">Notes</div>
+                <div className="text-sm text-shell-text whitespace-pre-wrap break-words">{contact.notes}</div>
+              </div>
             </CardContent>
           </Card>
         )}
@@ -237,6 +295,45 @@ function ContactDetail({
         )}
       </div>
     </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Contact list row — shared card treatment                          */
+/* ------------------------------------------------------------------ */
+
+function ContactRow({
+  contact,
+  selected,
+  onSelect,
+  showChevron,
+}: {
+  contact: Contact;
+  selected: boolean;
+  onSelect: () => void;
+  showChevron?: boolean;
+}) {
+  const cardCls = [
+    "group w-full flex items-center gap-3 rounded-xl px-3 py-2.5 text-left",
+    "border transition-[background-color,box-shadow,transform] duration-200",
+    "hover:-translate-y-0.5 hover:shadow-[var(--shadow-card-hover)]",
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50",
+    selected
+      ? "bg-shell-surface-active border-shell-border-strong shadow-[var(--shadow-card)]"
+      : "bg-shell-surface border-shell-border hover:bg-shell-surface-hover",
+  ].join(" ");
+
+  return (
+    <button type="button" onClick={onSelect} aria-label={`Select ${contact.name}`} className={cardCls}>
+      <ContactAvatar name={contact.name} size={36} />
+      <div className="min-w-0 flex-1">
+        <div className="text-sm font-medium text-shell-text truncate">{contact.name}</div>
+        {contact.email && <div className="text-xs text-shell-text-secondary truncate">{contact.email}</div>}
+      </div>
+      {showChevron && (
+        <ChevronRight size={16} className="text-shell-text-tertiary shrink-0" aria-hidden="true" />
+      )}
+    </button>
   );
 }
 
@@ -301,11 +398,17 @@ export function ContactsApp({ windowId: _windowId }: { windowId: string }) {
     <div className="flex flex-col h-full min-h-0 overflow-hidden bg-shell-bg-deep text-shell-text select-none relative">
       {/* Toolbar */}
       {showToolbar && (
-        <div className="flex items-center justify-between px-4 py-3 border-b border-white/5 shrink-0">
-          <div className="flex items-center gap-2 min-w-0">
-            <User size={18} className="text-accent shrink-0" />
-            <h1 className="text-sm font-semibold">Contacts</h1>
-            <span className="text-xs text-shell-text-tertiary">{contacts.length} saved</span>
+        <div className="flex items-center justify-between px-4 py-3 border-b border-shell-border shrink-0">
+          <div className="flex items-center gap-2.5 min-w-0">
+            <span className="inline-flex h-8 w-8 items-center justify-center rounded-xl bg-shell-surface-active text-accent shrink-0">
+              <User size={16} />
+            </span>
+            <div className="min-w-0">
+              <h1 className="text-sm font-semibold text-shell-text leading-tight">Contacts</h1>
+              <span className="text-xs text-shell-text-tertiary">
+                {contacts.length} {contacts.length === 1 ? "contact" : "contacts"}
+              </span>
+            </div>
           </div>
           <Button size="sm" onClick={handleAdd} aria-label="Add contact">
             <Plus size={14} />
@@ -349,86 +452,36 @@ export function ContactsApp({ windowId: _windowId }: { windowId: string }) {
 
             {/* Empty states */}
             {filtered.length === 0 && (
-              <p className="text-shell-text-tertiary text-xs text-center mt-8 px-4">
-                {contacts.length === 0 ? "No contacts yet" : "No results"}
-              </p>
-            )}
-
-            {/* iOS 26 grouped list on mobile */}
-            {filtered.length > 0 && isMobile && (
-              <div style={{ padding: "4px 0 16px" }}>
-                <div
-                  style={{
-                    margin: "0 12px",
-                    borderRadius: 16,
-                    background: "rgba(255,255,255,0.05)",
-                    border: "1px solid rgba(255,255,255,0.08)",
-                    overflow: "hidden",
-                  }}
-                >
-                  {filtered.map((c, idx, arr) => (
-                    <button
-                      key={c.id}
-                      type="button"
-                      onClick={() => setSelectedId(c.id)}
-                      aria-label={`Select ${c.name}`}
-                      style={{
-                        display: "flex",
-                        alignItems: "center",
-                        gap: 10,
-                        width: "100%",
-                        padding: "14px 16px",
-                        background: "none",
-                        border: "none",
-                        borderBottom: idx === arr.length - 1 ? "none" : "1px solid rgba(255,255,255,0.06)",
-                        cursor: "pointer",
-                        color: "inherit",
-                        textAlign: "left",
-                      }}
-                    >
-                      <div style={{ width: 32, height: 32, borderRadius: "50%", background: "rgba(255,255,255,0.08)", display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>
-                        <User size={14} style={{ color: "rgba(255,255,255,0.5)" }} />
-                      </div>
-                      <div style={{ flex: 1, minWidth: 0 }}>
-                        <div style={{ fontSize: 15, fontWeight: 600, color: "rgba(255,255,255,0.95)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                          {c.name}
-                        </div>
-                        {c.email && (
-                          <div style={{ fontSize: 12, color: "rgba(255,255,255,0.45)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                            {c.email}
-                          </div>
-                        )}
-                      </div>
-                      <svg width="8" height="14" viewBox="0 0 8 14" fill="none" style={{ color: "rgba(255,255,255,0.3)", flexShrink: 0 }}>
-                        <path d="M1 1L7 7L1 13" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-                      </svg>
-                    </button>
-                  ))}
-                </div>
+              <div className="flex flex-col items-center text-center px-6 mt-10">
+                <span className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-shell-surface border border-shell-border text-shell-text-tertiary mb-3">
+                  {contacts.length === 0 ? <User size={22} /> : <Search size={22} />}
+                </span>
+                <p className="text-sm font-medium text-shell-text">
+                  {contacts.length === 0 ? "No contacts yet" : "No results"}
+                </p>
+                <p className="text-xs text-shell-text-tertiary mt-1">
+                  {contacts.length === 0 ? "Add your first contact to get started." : "Try a different search."}
+                </p>
+                {contacts.length === 0 && (
+                  <Button size="sm" onClick={handleAdd} className="mt-4" aria-label="Add contact">
+                    <Plus size={14} />
+                    Add Contact
+                  </Button>
+                )}
               </div>
             )}
 
-            {/* Desktop list */}
-            {filtered.length > 0 && !isMobile && (
-              <div className="p-2 space-y-1">
+            {/* Contact rows */}
+            {filtered.length > 0 && (
+              <div className="px-3 pb-4 space-y-1.5">
                 {filtered.map((c) => (
-                  <Button
+                  <ContactRow
                     key={c.id}
-                    variant={selectedId === c.id ? "secondary" : "ghost"}
-                    onClick={() => setSelectedId(c.id)}
-                    className="w-full justify-start h-auto py-2.5 px-3 rounded-lg font-normal"
-                    aria-label={`Select ${c.name}`}
-                  >
-                    <div className="w-8 h-8 rounded-full bg-shell-surface flex items-center justify-center shrink-0">
-                      <User size={14} className="text-shell-text-secondary" />
-                    </div>
-                    <div className="min-w-0 flex-1 text-left">
-                      <div className="text-sm font-medium truncate">{c.name}</div>
-                      {c.email && (
-                        <div className="text-xs text-shell-text-secondary truncate">{c.email}</div>
-                      )}
-                    </div>
-                  </Button>
+                    contact={c}
+                    selected={!isMobile && selectedId === c.id}
+                    onSelect={() => setSelectedId(c.id)}
+                    showChevron={isMobile}
+                  />
                 ))}
               </div>
             )}
@@ -442,8 +495,12 @@ export function ContactsApp({ windowId: _windowId }: { windowId: string }) {
               onDelete={() => handleDelete(selected.id)}
             />
           ) : !isMobile ? (
-            <div className="flex-1 flex items-center justify-center h-full text-shell-text-tertiary text-sm">
-              Select a contact or add a new one
+            <div className="flex-1 flex flex-col items-center justify-center h-full text-center px-6">
+              <span className="inline-flex h-14 w-14 items-center justify-center rounded-2xl bg-shell-surface border border-shell-border text-shell-text-tertiary mb-4">
+                <User size={26} />
+              </span>
+              <p className="text-sm font-medium text-shell-text">No contact selected</p>
+              <p className="text-xs text-shell-text-tertiary mt-1">Select a contact or add a new one.</p>
             </div>
           ) : null
         }


### PR DESCRIPTION
Visual and theme-compliance pass over the Contacts app to match the Store/Agents design DNA. No functional or data-model changes.

## What changed
- **Glossy gradient identity avatar** with a stable per-contact hue + initials, mirroring AgentRow's IdentityTile (falls back to a person glyph when unnamed).
- **List items are now surface cards**: rounded-xl, border-shell-border, hover lift (-translate-y-0.5 + hover shadow), focus ring; chevron affordance on mobile. One unified ContactRow replaces the separate inline-styled mobile grouped list and the desktop button list.
- **Detail fields as icon-led cards** for email, phone and notes.
- **Cleaner header** with an identity tile and a pluralised contact count.
- **Tasteful empty states** for no-contacts (with a CTA), no-results, and no-selection.

## Theme compliance
- Replaced every hardcoded rgba theme colour (the 8 in the old mobile list) and the inline-styled list with semantic shell tokens (`bg-shell-surface`, `border-shell-border`, `text-shell-text*`, `text-accent`) and auto-inverting `white/N` utilities.
- **Hex/rgba theme-colour literals: 8 before, 1 after.** The single remaining `rgba(255,255,255,0.22)` is the gloss sheen on the coloured avatar tile — an additive white highlight on a saturated identity gradient (same pattern as the Store framework tiles / AgentRow's `${color}22` tint), so it is intentionally scheme-independent and never touches the theme background.
- Verified correct in dark and light (avatar identity colour and destructive red are genuinely-semantic and stay dynamic).

## Verify
`cd desktop && npx tsc -b --noEmit` passes (exit 0), no new errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style & Design Updates**
  * Contact avatars now feature stable identity tiles derived from contact names with initials fallback
  * Contact detail cards redesigned with improved styling for email and phone information
  * Contact list rendering consolidated for consistent appearance across all views
  * Contact headers updated to display new identity tiles instead of plain icons
  * Empty state and no-selection messages updated with refreshed layout

<!-- end of auto-generated comment: release notes by coderabbit.ai -->