### PR TITLE
feat(messages): A2A coordination bus read-only view (#45)

### DIFF
--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -80,6 +80,11 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import Picker, { Theme } from "emoji-picker-react";
 import { SearchPanel } from "./chat/SearchPanel";
+import {
+  A2aBusSection,
+  A2aBusMessageView,
+  useBusChannels,
+} from "./chat/A2aBusPanel";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -394,6 +399,11 @@ export function MessagesApp({
   const [liveAgents, setLiveAgents] = useState<LiveAgent[]>([]);
   const [archivedAgents, setArchivedAgents] = useState<ArchivedAgentEntry[]>([]);
   const [selectedChannel, setSelectedChannel] = useState<string | null>(null);
+  // External taOSmd coordination bus (read-only). Selecting a bus channel is a
+  // separate mode from the internal project channels: when busSelected is set,
+  // the detail pane shows the read-only bus viewer instead of the chat panel.
+  const [busSelected, setBusSelected] = useState<string | null>(null);
+  const bus = useBusChannels();
   const [messages, setMessages] = useState<Message[]>([]);
   const [unread, setUnread] = useState<Record<string, number>>({});
   const unreadRef = useRef<Record<string, number>>({});
@@ -790,6 +800,16 @@ export function MessagesApp({
     if (!channels.some((c) => c.id === selectedChannel)) return;
     writeLastChannel(scope.projectId, selectedChannel);
   }, [scope?.projectId, selectedChannel, channels]);
+
+  /* ---- bus / project-channel selection are mutually exclusive ---- */
+  useEffect(() => {
+    if (selectedChannel) setBusSelected(null);
+  }, [selectedChannel]);
+
+  const selectBusChannel = useCallback((channel: string) => {
+    setSelectedChannel(null);
+    setBusSelected(channel);
+  }, []);
 
   /* ---- fetch project list for sidebar grouping (standalone mode only) ---- */
   useEffect(() => {
@@ -1726,6 +1746,15 @@ export function MessagesApp({
           </div>
         </div>
       )}
+
+      {/* External taOSmd coordination bus (read-only) */}
+      <A2aBusSection
+        channels={bus.channels}
+        available={bus.available}
+        loaded={bus.loaded}
+        selected={busSelected}
+        onSelect={selectBusChannel}
+      />
     </div>
   ) : (
     /* Desktop: compact sidebar */
@@ -1900,6 +1929,15 @@ export function MessagesApp({
             </div>
           </div>
         )}
+
+        {/* External taOSmd coordination bus (read-only) */}
+        <A2aBusSection
+          channels={bus.channels}
+          available={bus.available}
+          loaded={bus.loaded}
+          selected={busSelected}
+          onSelect={selectBusChannel}
+        />
       </div>
     </div>
   );
@@ -1908,7 +1946,9 @@ export function MessagesApp({
   /*  Message area                                                     */
   /* ---------------------------------------------------------------- */
 
-  const messageAreaUI = (
+  const messageAreaUI = busSelected ? (
+    <A2aBusMessageView channel={busSelected} />
+  ) : (
     <div className="relative flex-1 flex flex-col min-w-0 h-full">
       {selectedChannel && !atBottom && (
         <button
@@ -2640,10 +2680,10 @@ export function MessagesApp({
       {/* Master-detail — MobileSplitView handles mobile single-pane + desktop split */}
       <div className="flex-1 min-h-0 overflow-hidden">
         <MobileSplitView
-          selectedId={selectedChannel}
-          onBack={() => setSelectedChannel(null)}
+          selectedId={selectedChannel ?? busSelected}
+          onBack={() => { setSelectedChannel(null); setBusSelected(null); }}
           listTitle="Messages"
-          detailTitle={currentChannel?.name}
+          detailTitle={busSelected ?? currentChannel?.name}
           listWidth={240}
           list={channelListUI}
           detail={messageAreaUI}

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -801,13 +801,17 @@ export function MessagesApp({
     writeLastChannel(scope.projectId, selectedChannel);
   }, [scope?.projectId, selectedChannel, channels]);
 
-  /* ---- bus / project-channel selection are mutually exclusive ---- */
+  /* ---- bus / project-channel selection are mutually exclusive ----
+   * Modeled as render precedence: while busSelected is set the bus viewer
+   * wins, otherwise the project channel shows. Picking a project channel
+   * clears busSelected (project view takes over); picking a bus channel keeps
+   * selectedChannel intact so returning from the bus restores it.
+   */
   useEffect(() => {
     if (selectedChannel) setBusSelected(null);
   }, [selectedChannel]);
 
   const selectBusChannel = useCallback((channel: string) => {
-    setSelectedChannel(null);
     setBusSelected(channel);
   }, []);
 

--- a/desktop/src/apps/chat/A2aBusPanel.tsx
+++ b/desktop/src/apps/chat/A2aBusPanel.tsx
@@ -35,6 +35,14 @@ export interface BusMessage {
   reply_to: number | null;
 }
 
+/*
+ * Kept local: the existing relative-time helpers in chat/ (AllThreadsList,
+ * SearchPanel) and lib/cluster.ts are unexported copies with incompatible
+ * shapes -- they call Date.now() internally and return the verbose "Xm ago"
+ * form. This view needs a passed-in nowMs (a 60s-ticking state value powers the
+ * re-render) and the compact "Xm" form for the tabular timestamp column, so
+ * there is no reusable helper to fold into here.
+ */
 function busRelativeTime(ts: number | undefined, nowMs: number): string {
   if (!ts) return "";
   const ms = ts < 1e12 ? ts * 1000 : ts;
@@ -196,11 +204,24 @@ export function A2aBusMessageView({ channel }: { channel: string }) {
     return () => clearInterval(id);
   }, []);
 
-  // Keep the newest message in view (chat log: newest at bottom).
+  // Stick to the bottom (newest message) only when the user is already there,
+  // so an 8s poll never yanks them away from history they scrolled up to read.
+  const nearBottomRef = useRef(true);
   useEffect(() => {
     const el = scrollRef.current;
-    if (el) el.scrollTop = el.scrollHeight;
+    if (el && nearBottomRef.current) el.scrollTop = el.scrollHeight;
   }, [messages.length]);
+
+  // Reset stickiness on channel change so a fresh load pins to the bottom.
+  useEffect(() => {
+    nearBottomRef.current = true;
+  }, [channel]);
+
+  const handleScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    nearBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
+  }, []);
 
   return (
     <div className="relative flex-1 flex flex-col min-w-0 h-full">
@@ -214,7 +235,7 @@ export function A2aBusMessageView({ channel }: { channel: string }) {
       </div>
 
       {/* messages */}
-      <div ref={scrollRef} className="flex-1 overflow-y-auto px-4 py-3">
+      <div ref={scrollRef} onScroll={handleScroll} className="flex-1 overflow-y-auto px-4 py-3">
         {!loaded ? (
           <div className="h-full flex items-center justify-center text-white/20 text-sm">
             Loading…

--- a/desktop/src/apps/chat/A2aBusPanel.tsx
+++ b/desktop/src/apps/chat/A2aBusPanel.tsx
@@ -1,0 +1,265 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import { Radio, ChevronRight, Bot } from "lucide-react";
+
+/*
+ * Read-only viewer for the external taOSmd A2A coordination bus.
+ *
+ * The coordination bus is a SEPARATE service (taosmd serve) where cross-product
+ * agents (@taOS, @taOSmd, @hermes) coordinate. This is DISTINCT from taOS's own
+ * internal per-project a2a channels. Everything here is read-only: the controller
+ * exposes a read-only proxy (/api/a2a/bus/*) and this panel only fetches; there
+ * is no compose box and no write path.
+ *
+ * Two pieces live here:
+ *   - A2aBusSection: the collapsible sidebar group listing bus channels.
+ *   - A2aBusMessageView: the detail pane shown when a bus channel is selected.
+ * State is isolated from the project-channel logic in MessagesApp.
+ */
+
+const POLL_MS = 8000;
+
+export interface BusChannel {
+  channel: string;
+  members?: string[];
+  message_count?: number;
+  created_ts?: number;
+  last_ts?: number;
+}
+
+export interface BusMessage {
+  id: number;
+  ts: number;
+  from: string;
+  body: string;
+  thread: string;
+  reply_to: number | null;
+}
+
+function busRelativeTime(ts: number | undefined, nowMs: number): string {
+  if (!ts) return "";
+  const ms = ts < 1e12 ? ts * 1000 : ts;
+  const mins = Math.floor((nowMs - ms) / 60000);
+  if (mins < 1) return "now";
+  if (mins < 60) return `${mins}m`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h`;
+  return new Date(ms).toLocaleDateString(undefined, { day: "numeric", month: "short" });
+}
+
+/**
+ * Hook owning the bus channel list + availability, polled every 8s.
+ */
+export function useBusChannels() {
+  const [channels, setChannels] = useState<BusChannel[]>([]);
+  const [available, setAvailable] = useState<boolean>(true);
+  const [loaded, setLoaded] = useState(false);
+
+  const fetchChannels = useCallback(async () => {
+    try {
+      const res = await fetch("/api/a2a/bus/channels");
+      const data = await res.json();
+      setChannels(Array.isArray(data.channels) ? data.channels : []);
+      setAvailable(data.available !== false);
+    } catch {
+      setChannels([]);
+      setAvailable(false);
+    } finally {
+      setLoaded(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchChannels();
+    const id = setInterval(fetchChannels, POLL_MS);
+    return () => clearInterval(id);
+  }, [fetchChannels]);
+
+  return { channels, available, loaded };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Sidebar group                                                      */
+/* ------------------------------------------------------------------ */
+
+export function A2aBusSection({
+  channels,
+  available,
+  loaded,
+  selected,
+  onSelect,
+}: {
+  channels: BusChannel[];
+  available: boolean;
+  loaded: boolean;
+  selected: string | null;
+  onSelect: (channel: string) => void;
+}) {
+  const [expanded, setExpanded] = useState(true);
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNowMs(Date.now()), 60000);
+    return () => clearInterval(id);
+  }, []);
+
+  // Hide the whole group until the first fetch resolves so it never flashes.
+  if (!loaded) return null;
+
+  return (
+    <div className="mt-2">
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        aria-controls="a2a-bus-channels"
+        className="flex items-center gap-1.5 px-3 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-wider text-white/30 hover:text-white/50 transition-colors w-full text-left"
+      >
+        <ChevronRight
+          size={11}
+          aria-hidden="true"
+          className={`transition-transform ${expanded ? "rotate-90" : ""}`}
+        />
+        <Radio size={11} aria-hidden="true" />
+        Coordination Bus
+      </button>
+      {expanded && (
+        <div id="a2a-bus-channels">
+          {!available ? (
+            <div className="px-3 py-2">
+              <p className="text-[11px] text-white/40">Coordination bus offline</p>
+              <p className="text-[10px] text-white/25 mt-0.5">No bus service reachable.</p>
+            </div>
+          ) : channels.length === 0 ? (
+            <div className="px-3 py-1 text-[11px] text-white/20 italic">No channels yet</div>
+          ) : (
+            channels.map((ch) => (
+              <button
+                key={ch.channel}
+                type="button"
+                onClick={() => onSelect(ch.channel)}
+                aria-pressed={selected === ch.channel}
+                aria-label={`Coordination channel ${ch.channel}`}
+                title="Read-only agent coordination channel"
+                className={`w-full text-left py-1.5 px-3 text-[13px] flex items-center gap-2 transition-colors ${
+                  selected === ch.channel ? "bg-white/10" : "hover:bg-white/5"
+                }`}
+              >
+                <Radio size={14} aria-hidden className="shrink-0 text-white/50" />
+                <span className="truncate flex-1">{ch.channel}</span>
+                <span className="shrink-0 text-[10px] text-white/30 tabular-nums">
+                  {(ch.members?.length ?? 0)} · {busRelativeTime(ch.last_ts, nowMs)}
+                </span>
+              </button>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Detail pane                                                        */
+/* ------------------------------------------------------------------ */
+
+export function A2aBusMessageView({ channel }: { channel: string }) {
+  const [messages, setMessages] = useState<BusMessage[]>([]);
+  const [available, setAvailable] = useState(true);
+  const [loaded, setLoaded] = useState(false);
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  const fetchMessages = useCallback(async () => {
+    try {
+      const res = await fetch(
+        `/api/a2a/bus/messages?channel=${encodeURIComponent(channel)}&limit=100`,
+      );
+      const data = await res.json();
+      setMessages(Array.isArray(data.messages) ? data.messages : []);
+      setAvailable(data.available !== false);
+    } catch {
+      setMessages([]);
+      setAvailable(false);
+    } finally {
+      setLoaded(true);
+    }
+  }, [channel]);
+
+  useEffect(() => {
+    setLoaded(false);
+    fetchMessages();
+    const id = setInterval(fetchMessages, POLL_MS);
+    return () => clearInterval(id);
+  }, [fetchMessages]);
+
+  useEffect(() => {
+    const id = setInterval(() => setNowMs(Date.now()), 60000);
+    return () => clearInterval(id);
+  }, []);
+
+  // Keep the newest message in view (chat log: newest at bottom).
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [messages.length]);
+
+  return (
+    <div className="relative flex-1 flex flex-col min-w-0 h-full">
+      {/* header */}
+      <div className="px-4 py-2.5 border-b border-white/[0.06] flex items-center gap-3 shrink-0">
+        <Radio size={16} className="text-white/40" aria-hidden="true" />
+        <div className="min-w-0">
+          <div className="text-sm font-semibold text-white/90 truncate">{channel}</div>
+          <div className="text-[11px] text-white/40">Coordination bus · read-only</div>
+        </div>
+      </div>
+
+      {/* messages */}
+      <div ref={scrollRef} className="flex-1 overflow-y-auto px-4 py-3">
+        {!loaded ? (
+          <div className="h-full flex items-center justify-center text-white/20 text-sm">
+            Loading…
+          </div>
+        ) : !available ? (
+          <div className="h-full flex flex-col items-center justify-center text-center gap-2 px-6">
+            <Radio size={32} className="text-white/15" aria-hidden="true" />
+            <p className="text-sm font-medium text-white/60">Coordination bus offline</p>
+            <p className="text-[12px] text-white/30">
+              The bus service is not reachable right now.
+            </p>
+          </div>
+        ) : messages.length === 0 ? (
+          <div className="h-full flex flex-col items-center justify-center text-center gap-2 px-6">
+            <Bot size={32} className="text-white/15" aria-hidden="true" />
+            <p className="text-sm font-medium text-white/60">No messages yet</p>
+            <p className="text-[12px] text-white/30">
+              Agent coordination will appear here.
+            </p>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {messages.map((m) => (
+              <div key={m.id} className="flex flex-col gap-0.5">
+                <div className="flex items-baseline gap-2">
+                  <span className="text-[13px] font-semibold text-white/85 truncate">
+                    {m.from}
+                  </span>
+                  <span className="text-[10px] text-white/30 tabular-nums shrink-0">
+                    {busRelativeTime(m.ts, nowMs)}
+                  </span>
+                </div>
+                <div className="text-[13px] text-white/75 whitespace-pre-wrap break-words">
+                  {m.body}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* read-only footer */}
+      <div className="px-4 py-2 border-t border-white/[0.06] text-[11px] text-white/35 shrink-0">
+        Read-only. The coordination bus is managed by the agents.
+      </div>
+    </div>
+  );
+}

--- a/tests/test_a2a_bus.py
+++ b/tests/test_a2a_bus.py
@@ -1,0 +1,137 @@
+"""Tests for the read-only taOSmd A2A coordination bus proxy (routes/a2a_bus.py).
+
+The outbound bus calls are mocked with respx (already in dev deps). The bus URL
+defaults to http://127.0.0.1:7900; we pin it via TAOS_A2A_BUS_URL so the mocked
+routes match deterministically.
+"""
+from __future__ import annotations
+
+import pytest
+import respx
+from httpx import Response
+
+from tinyagentos.app import create_app
+
+_BUS = "http://bus.test"
+
+
+@pytest.fixture(autouse=True)
+def _pin_bus_url(monkeypatch):
+    monkeypatch.setenv("TAOS_A2A_BUS_URL", _BUS)
+
+
+def test_bus_routes_registered():
+    """Both read-only bus endpoints are registered; no send/post path exists."""
+    app = create_app()
+    paths = {getattr(r, "path", "") for r in app.routes}
+    assert "/api/a2a/bus/channels" in paths
+    assert "/api/a2a/bus/messages" in paths
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_channels_proxied_and_sorted(client):
+    """Channels are proxied and sorted by last_ts descending, available:true."""
+    respx.get(f"{_BUS}/a2a/channels").mock(
+        return_value=Response(
+            200,
+            json={
+                "channels": [
+                    {"channel": "old", "members": ["a"], "message_count": 1,
+                     "created_ts": 1.0, "last_ts": 100.0},
+                    {"channel": "new", "members": ["a", "b"], "message_count": 5,
+                     "created_ts": 2.0, "last_ts": 300.0},
+                    {"channel": "mid", "members": ["b"], "message_count": 2,
+                     "created_ts": 3.0, "last_ts": 200.0},
+                ]
+            },
+        )
+    )
+
+    resp = await client.get("/api/a2a/bus/channels")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["available"] is True
+    assert [c["channel"] for c in body["channels"]] == ["new", "mid", "old"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_channels_bus_unreachable_is_offline(client):
+    """Bus connection error -> available:false, empty list, HTTP 200."""
+    respx.get(f"{_BUS}/a2a/channels").mock(
+        side_effect=httpx_connect_error()
+    )
+
+    resp = await client.get("/api/a2a/bus/channels")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["available"] is False
+    assert body["channels"] == []
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_channels_bus_non_200_is_offline(client):
+    """Bus 500 -> available:false, empty list, HTTP 200."""
+    respx.get(f"{_BUS}/a2a/channels").mock(return_value=Response(500))
+
+    resp = await client.get("/api/a2a/bus/channels")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["available"] is False
+    assert body["channels"] == []
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_messages_maps_channel_to_thread_and_clamps_limit(client):
+    """channel maps to the bus thread param and limit is clamped to 500."""
+    route = respx.get(f"{_BUS}/a2a/messages").mock(
+        return_value=Response(
+            200,
+            json={
+                "messages": [
+                    {"id": 1, "ts": 10.0, "from": "@taOS", "body": "hi",
+                     "thread": "ops", "reply_to": None},
+                ]
+            },
+        )
+    )
+
+    resp = await client.get("/api/a2a/bus/messages", params={"channel": "ops", "limit": 9999})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["available"] is True
+    assert body["messages"][0]["from"] == "@taOS"
+
+    sent = route.calls.last.request
+    assert sent.url.params["thread"] == "ops"
+    assert sent.url.params["limit"] == "500"
+
+
+@pytest.mark.asyncio
+async def test_messages_missing_channel_is_400(client):
+    """No channel -> 400 with an error payload, no bus call attempted."""
+    resp = await client.get("/api/a2a/bus/messages")
+    assert resp.status_code == 400
+    assert resp.json() == {"error": "channel required"}
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_messages_bus_error_is_offline(client):
+    """Bus error on messages -> available:false, empty list, HTTP 200."""
+    respx.get(f"{_BUS}/a2a/messages").mock(side_effect=httpx_connect_error())
+
+    resp = await client.get("/api/a2a/bus/messages", params={"channel": "ops"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["available"] is False
+    assert body["messages"] == []
+
+
+def httpx_connect_error():
+    import httpx
+
+    return httpx.ConnectError("connection refused")

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -63,6 +63,9 @@ def register_all_routers(app):
     from tinyagentos.routes.images_edit import router as images_edit_router
     app.include_router(images_edit_router)
 
+    from tinyagentos.routes.a2a_bus import router as a2a_bus_router
+    app.include_router(a2a_bus_router)
+
     from tinyagentos.routes.scheduler import router as scheduler_router
     app.include_router(scheduler_router)
 

--- a/tinyagentos/routes/a2a_bus.py
+++ b/tinyagentos/routes/a2a_bus.py
@@ -1,0 +1,93 @@
+# tinyagentos/routes/a2a_bus.py
+"""Read-only proxy for the external taOSmd A2A coordination bus.
+
+The taOSmd coordination bus (``taosmd serve``) is a SEPARATE service co-located
+with the controller (default http://127.0.0.1:7900). It is where cross-product
+agents (@taOS, @taOSmd, @hermes) coordinate. This is DISTINCT from taOS's own
+internal per-project a2a channels (tinyagentos/projects/a2a.py).
+
+These endpoints are a thin READ-ONLY proxy: the Messages app can list bus
+channels and read messages, but there is no send/post path here. The bus is
+unauthenticated on the LAN; the URL is resolved from ``TAOS_A2A_BUS_URL``.
+
+Bus API (verified live):
+  GET {bus}/a2a/channels
+      -> {"channels":[{"channel","members","message_count","created_ts","last_ts"}, ...]}
+  GET {bus}/a2a/messages?thread={channel}&limit={n}
+      -> {"messages":[{"id","ts","from","body","thread","reply_to"}, ...]}
+"""
+from __future__ import annotations
+
+import logging
+import os
+
+import httpx
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+_DEFAULT_BUS_URL = "http://127.0.0.1:7900"
+
+
+def _bus_url() -> str:
+    """Resolve the bus base URL from the environment, trailing slash stripped."""
+    return os.environ.get("TAOS_A2A_BUS_URL", _DEFAULT_BUS_URL).rstrip("/")
+
+
+@router.get("/api/a2a/bus/channels")
+async def bus_channels():
+    """List coordination-bus channels, sorted by last activity (newest first).
+
+    On any bus error (timeout / connection refused / non-200) this returns an
+    empty list with ``available: false`` and HTTP 200, so the frontend can show
+    a clean offline state rather than crashing.
+    """
+    bus = _bus_url()
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.get(f"{bus}/a2a/channels")
+            resp.raise_for_status()
+            data = resp.json()
+    except Exception as exc:  # noqa: BLE001 (degrade to an offline state)
+        logger.warning("A2A bus channels fetch failed (%s): %s", bus, exc)
+        return JSONResponse({"channels": [], "available": False}, status_code=200)
+
+    channels = data.get("channels", []) if isinstance(data, dict) else []
+    channels = sorted(
+        channels,
+        key=lambda c: c.get("last_ts", 0) or 0,
+        reverse=True,
+    )
+    return {"channels": channels, "available": True}
+
+
+@router.get("/api/a2a/bus/messages")
+async def bus_messages(channel: str = "", limit: int = 100):
+    """Read messages from one bus channel, oldest-first as the bus returns them.
+
+    ``channel`` is required and maps to the bus ``thread`` query param. ``limit``
+    is clamped to 1..500. On a bus error this returns an empty list with
+    ``available: false`` and HTTP 200.
+    """
+    if not channel:
+        return JSONResponse({"error": "channel required"}, status_code=400)
+
+    limit = max(1, min(500, limit))
+    bus = _bus_url()
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.get(
+                f"{bus}/a2a/messages",
+                params={"thread": channel, "limit": limit},
+            )
+            resp.raise_for_status()
+            data = resp.json()
+    except Exception as exc:  # noqa: BLE001 (degrade to an offline state)
+        logger.warning("A2A bus messages fetch failed (%s): %s", bus, exc)
+        return JSONResponse({"messages": [], "available": False}, status_code=200)
+
+    messages = data.get("messages", []) if isinstance(data, dict) else []
+    return {"messages": messages, "available": True}


### PR DESCRIPTION
Surfaces the external taOSmd A2A coordination bus in the Messages app as a read-only viewer (approach B: a read-only controller proxy plus a read-only Messages section). This is distinct from taOS's internal per-project a2a channels, which are untouched.

## Backend (tinyagentos/routes/a2a_bus.py)
A thin read-only proxy for the bus, registered in routes/__init__.py:

- GET /api/a2a/bus/channels proxies GET {bus}/a2a/channels, sorts channels by last_ts descending, returns {"channels": [...], "available": true}.
- GET /api/a2a/bus/messages takes channel (required) and limit (default 100, clamped 1..500), maps channel to the bus thread param, returns {"messages": [...], "available": true}. Missing channel returns 400.
- On any bus error (timeout, connection refused, non-200) both endpoints degrade to available:false with an empty list and HTTP 200, logged at warning. There is no send or post path.

The bus base URL is resolved from the TAOS_A2A_BUS_URL environment variable (default http://127.0.0.1:7900), trailing slash stripped.

## Frontend (Messages app)
A new collapsible "Coordination Bus" group in the Messages sidebar (desktop and mobile), visually distinct from project channels with a Radio icon, showing channel name, member count, and relative last activity. It fetches on mount and polls every 8s. Selecting a bus channel opens a read-only viewer: from handle, body (line breaks preserved, plain text), and relative timestamp, newest at the bottom, polled every 8s. The viewer has no compose box, just a muted footer ("Read-only. The coordination bus is managed by the agents."). When the bus is unavailable it shows a clean "Coordination bus offline" empty state. Styling uses the existing semantic tokens and white/N utilities already in the app, so it inverts correctly in both themes. The bus mode is isolated from the existing project-channel state and the internal settings.kind a2a logic.

## Tests
tests/test_a2a_bus.py (7 tests, all passing) using respx to mock the outbound bus calls: route registration, channels proxied and sorted by last_ts desc with available:true, bus unreachable and non-200 both degrade to available:false with HTTP 200, channel maps to thread with limit clamped to 500, and missing channel returns 400.

Verification: pytest 7 passed, tsc --noEmit clean, npm run build succeeds.