### PR TITLE
feat(files): file-manager context menu (copy/cut/paste/delete)

### DIFF
--- a/desktop/src/apps/FilesApp.tsx
+++ b/desktop/src/apps/FilesApp.tsx
@@ -232,24 +232,16 @@ function workspaceDeleteUrl(location: "workspace" | string, path: string): strin
 }
 
 function workspaceCopyUrl(location: "workspace" | string): string | null {
+  // Only the user workspace exposes a copy endpoint on the backend. Agent /
+  // project / shared-folder locations do not, so copy/cut/paste stays disabled
+  // there to avoid runtime 404s.
   if (location === "workspace") return `/api/workspace/copy`;
-  if (isAgentLocation(location)) {
-    return `/api/agents/${encodeURIComponent(agentSlug(location))}/workspace/copy`;
-  }
-  if (isProjectLocation(location)) {
-    return `/api/projects/${encodeURIComponent(projectSlug(location))}/copy`;
-  }
   return null;
 }
 
 function workspaceRenameUrl(location: "workspace" | string): string | null {
+  // Only the user workspace exposes a rename endpoint on the backend.
   if (location === "workspace") return `/api/workspace/rename`;
-  if (isAgentLocation(location)) {
-    return `/api/agents/${encodeURIComponent(agentSlug(location))}/workspace/rename`;
-  }
-  if (isProjectLocation(location)) {
-    return `/api/projects/${encodeURIComponent(projectSlug(location))}/rename`;
-  }
   return null;
 }
 
@@ -262,6 +254,28 @@ function workspaceStatsUrl(location: "workspace" | string): string | null {
     return `/api/projects/${encodeURIComponent(projectSlug(location))}/stats`;
   }
   return null;
+}
+
+// Split a file name into its base and extension. Directories (and dotfiles
+// with no extension) keep the whole name as the base so the " copy" suffix
+// lands before any real extension.
+function splitNameExt(name: string): { base: string; ext: string } {
+  const dot = name.lastIndexOf(".");
+  if (dot <= 0) return { base: name, ext: "" };
+  return { base: name.slice(0, dot), ext: name.slice(dot) };
+}
+
+// Pick a name that does not collide with anything already in the listing.
+// Produces "foo copy.txt", then "foo copy 2.txt", "foo copy 3.txt", ...
+function nextCopyName(name: string, taken: Set<string>): string {
+  const { base, ext } = splitNameExt(name);
+  let candidate = `${base} copy${ext}`;
+  let n = 2;
+  while (taken.has(candidate)) {
+    candidate = `${base} copy ${n}${ext}`;
+    n += 1;
+  }
+  return candidate;
 }
 
 function getFileIcon(name: string, isDir: boolean) {
@@ -722,9 +736,25 @@ export function FilesApp({
     if (!clipboard) return;
     // Cross-location paste is not supported in v1.
     if (clipboard.location !== location) return;
-    const dst = currentPath ? `${currentPath}/${clipboard.name}` : clipboard.name;
     const url = clipboard.mode === "copy" ? workspaceCopyUrl(location) : workspaceRenameUrl(location);
     if (!url) return;
+
+    let name = clipboard.name;
+    let dst = currentPath ? `${currentPath}/${name}` : name;
+
+    if (dst === clipboard.path) {
+      // Pasting into the same directory the item came from.
+      if (clipboard.mode === "cut") {
+        // Moving onto itself is a no-op.
+        setClipboard(null);
+        return;
+      }
+      // Copy: duplicate in place under a non-colliding name.
+      const taken = new Set(files.map((f) => f.name));
+      name = nextCopyName(clipboard.name, taken);
+      dst = currentPath ? `${currentPath}/${name}` : name;
+    }
+
     try {
       await apiFetch(url, {
         method: "POST",
@@ -736,7 +766,7 @@ export function FilesApp({
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : "Paste failed");
     }
-  }, [clipboard, currentPath, fetchFiles, location]);
+  }, [clipboard, currentPath, fetchFiles, files, location]);
 
   /* ---- Drag and drop ---- */
   const onDragEnter = useCallback((e: React.DragEvent) => {

--- a/desktop/src/apps/FilesApp.tsx
+++ b/desktop/src/apps/FilesApp.tsx
@@ -23,8 +23,14 @@ import {
   Recycle,
   RotateCcw,
   Bot,
+  Copy,
+  Scissors,
+  ClipboardPaste,
+  Pencil,
+  FolderOpen,
 } from "lucide-react";
 import { Button, Card, Toolbar, ToolbarGroup, ToolbarSpacer } from "@/components/ui";
+import { ContextMenu, type MenuItem } from "@/components/ContextMenu";
 import { MobileSplitView } from "@/components/mobile/MobileSplitView";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { resolveAgentEmoji } from "@/lib/agent-emoji";
@@ -225,6 +231,28 @@ function workspaceDeleteUrl(location: "workspace" | string, path: string): strin
   return null;
 }
 
+function workspaceCopyUrl(location: "workspace" | string): string | null {
+  if (location === "workspace") return `/api/workspace/copy`;
+  if (isAgentLocation(location)) {
+    return `/api/agents/${encodeURIComponent(agentSlug(location))}/workspace/copy`;
+  }
+  if (isProjectLocation(location)) {
+    return `/api/projects/${encodeURIComponent(projectSlug(location))}/copy`;
+  }
+  return null;
+}
+
+function workspaceRenameUrl(location: "workspace" | string): string | null {
+  if (location === "workspace") return `/api/workspace/rename`;
+  if (isAgentLocation(location)) {
+    return `/api/agents/${encodeURIComponent(agentSlug(location))}/workspace/rename`;
+  }
+  if (isProjectLocation(location)) {
+    return `/api/projects/${encodeURIComponent(projectSlug(location))}/rename`;
+  }
+  return null;
+}
+
 function workspaceStatsUrl(location: "workspace" | string): string | null {
   if (location === "workspace") return `/api/workspace/stats`;
   if (isAgentLocation(location)) {
@@ -272,6 +300,8 @@ interface FileRowProps {
   deleteConfirm: string | null;
   handleDelete: (path: string) => void;
   setDeleteConfirm: (path: string | null) => void;
+  onContextMenu: (e: React.MouseEvent, f: FileEntry) => void;
+  isCut: boolean;
 }
 
 function FileRow({
@@ -283,6 +313,8 @@ function FileRow({
   deleteConfirm,
   handleDelete,
   setDeleteConfirm,
+  onContextMenu,
+  isCut,
 }: FileRowProps) {
   const Icon = getFileIcon(f.name, f.is_dir);
   const relPath = f.path || (currentPath ? `${currentPath}/${f.name}` : f.name);
@@ -314,7 +346,8 @@ function FileRow({
     <tr
       key={f.path || f.name}
       data-file-row
-      className="border-b border-white/5 hover:bg-shell-surface/50 transition-colors group"
+      onContextMenu={(e) => onContextMenu(e, f)}
+      className={`border-b border-white/5 hover:bg-shell-surface/50 transition-colors group ${isCut ? "opacity-50" : ""}`}
       {...dragHandlers}
     >
       <td className="px-3 py-2">
@@ -417,6 +450,13 @@ export function FilesApp({
   const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null);
   // null = showing sidebar (list pane); non-null = showing file browser (detail pane)
   const [selectedLocation, setSelectedLocation] = useState<string | null>(rootPath ?? null);
+
+  // Clipboard for cut/copy/paste. Cross-location paste is out of scope for v1.
+  const [clipboard, setClipboard] = useState<
+    { mode: "cut" | "copy"; location: string; path: string; name: string } | null
+  >(null);
+  // Context menu anchor + payload. file === null targets the empty list area.
+  const [menu, setMenu] = useState<{ x: number; y: number; file: FileEntry | null } | null>(null);
 
   // Recycle bin
   const [recycleItems, setRecycleItems] = useState<RecycleItem[]>([]);
@@ -658,6 +698,45 @@ export function FilesApp({
       setError(msg);
     }
   }, [currentPath, fetchFiles, location]);
+
+  const handleRename = useCallback(async (file: FileEntry) => {
+    const renameUrl = workspaceRenameUrl(location);
+    if (!renameUrl) return;
+    const next = prompt("Rename to:", file.name);
+    const trimmed = next?.trim();
+    if (!trimmed || trimmed === file.name) return;
+    const dst = currentPath ? `${currentPath}/${trimmed}` : trimmed;
+    try {
+      await apiFetch(renameUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ src: file.path, dst }),
+      });
+      fetchFiles(currentPath);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Rename failed");
+    }
+  }, [currentPath, fetchFiles, location]);
+
+  const handlePaste = useCallback(async () => {
+    if (!clipboard) return;
+    // Cross-location paste is not supported in v1.
+    if (clipboard.location !== location) return;
+    const dst = currentPath ? `${currentPath}/${clipboard.name}` : clipboard.name;
+    const url = clipboard.mode === "copy" ? workspaceCopyUrl(location) : workspaceRenameUrl(location);
+    if (!url) return;
+    try {
+      await apiFetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ src: clipboard.path, dst }),
+      });
+      if (clipboard.mode === "cut") setClipboard(null);
+      fetchFiles(currentPath);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Paste failed");
+    }
+  }, [clipboard, currentPath, fetchFiles, location]);
 
   /* ---- Drag and drop ---- */
   const onDragEnter = useCallback((e: React.DragEvent) => {
@@ -1249,6 +1328,12 @@ export function FilesApp({
         onDragLeave={onDragLeave}
         onDragOver={onDragOver}
         onDrop={onDrop}
+        onContextMenu={(e) => {
+          // Only the empty list background; rows/cards stopPropagation.
+          if (!isWritable) return;
+          e.preventDefault();
+          setMenu({ x: e.clientX, y: e.clientY, file: null });
+        }}
       >
         {/* Drop overlay */}
         {dragging && (
@@ -1292,7 +1377,14 @@ export function FilesApp({
               return (
                 <Card
                   key={f.path || f.name}
-                  className="group relative bg-transparent border-transparent hover:bg-shell-surface hover:border-white/[0.06] transition-colors"
+                  onContextMenu={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    setMenu({ x: e.clientX, y: e.clientY, file: f });
+                  }}
+                  className={`group relative bg-transparent border-transparent hover:bg-shell-surface hover:border-white/[0.06] transition-colors ${
+                    clipboard?.mode === "cut" && clipboard.location === location && clipboard.path === f.path ? "opacity-50" : ""
+                  }`}
                 >
                 <button
                   onClick={() => {
@@ -1406,6 +1498,12 @@ export function FilesApp({
                   deleteConfirm={deleteConfirm}
                   handleDelete={handleDelete}
                   setDeleteConfirm={setDeleteConfirm}
+                  onContextMenu={(e, file) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    setMenu({ x: e.clientX, y: e.clientY, file });
+                  }}
+                  isCut={clipboard?.mode === "cut" && clipboard.location === location && clipboard.path === f.path}
                 />
               ))}
             </tbody>
@@ -1415,6 +1513,79 @@ export function FilesApp({
       </div>
     </div>
   );
+
+  /* ---- Context menu ---- */
+  const openFile = useCallback((f: FileEntry) => {
+    if (f.is_dir) {
+      navigateTo(f.path || (currentPath ? `${currentPath}/${f.name}` : f.name));
+    } else if (isWritable) {
+      window.open(fileUrl(location, f.path || f.name), "_blank");
+    }
+  }, [navigateTo, currentPath, isWritable, location]);
+
+  const copySupported = workspaceCopyUrl(location) !== null;
+  const moveSupported = workspaceRenameUrl(location) !== null;
+  const pasteAcrossLocation = clipboard !== null && clipboard.location !== location;
+  const pasteOpSupported = clipboard?.mode === "cut" ? moveSupported : copySupported;
+  const canPaste = clipboard !== null && !pasteAcrossLocation && pasteOpSupported;
+
+  const buildFileMenu = (f: FileEntry): MenuItem[] => {
+    const items: MenuItem[] = [
+      {
+        label: "Open",
+        icon: f.is_dir ? <FolderOpen size={14} /> : <FileText size={14} />,
+        action: () => openFile(f),
+      },
+    ];
+    if (!f.is_dir && isWritable) {
+      items.push({
+        label: "Download",
+        icon: <Download size={14} />,
+        action: () => window.open(fileUrl(location, f.path || f.name), "_blank"),
+      });
+    }
+    if (isWritable) {
+      items.push(
+        { label: "", separator: true },
+        { label: "Rename", icon: <Pencil size={14} />, action: () => handleRename(f) },
+        {
+          label: "Cut",
+          icon: <Scissors size={14} />,
+          disabled: !moveSupported,
+          action: () => setClipboard({ mode: "cut", location, path: f.path, name: f.name }),
+        },
+        {
+          label: "Copy",
+          icon: <Copy size={14} />,
+          disabled: !copySupported,
+          action: () => setClipboard({ mode: "copy", location, path: f.path, name: f.name }),
+        },
+        { label: "", separator: true },
+        {
+          label: "Delete",
+          icon: <Trash2 size={14} className="text-red-400" />,
+          action: () => handleDelete(f.path),
+        },
+      );
+    }
+    return items;
+  };
+
+  const buildEmptyMenu = (): MenuItem[] => {
+    if (!isWritable) return [];
+    const pasteLabel = pasteAcrossLocation ? "Paste (unavailable here)" : "Paste";
+    return [
+      { label: "New Folder", icon: <FolderPlus size={14} />, action: handleNewFolder },
+      {
+        label: pasteLabel,
+        icon: <ClipboardPaste size={14} />,
+        disabled: !canPaste,
+        action: handlePaste,
+      },
+      { label: "", separator: true },
+      { label: "Upload", icon: <Upload size={14} />, action: () => fileInputRef.current?.click() },
+    ];
+  };
 
   /* ---- Root layout ---- */
   return (
@@ -1428,6 +1599,14 @@ export function FilesApp({
         detailTitle={locationTitle}
         listWidth={208}
       />
+      {menu && (
+        <ContextMenu
+          x={menu.x}
+          y={menu.y}
+          onClose={() => setMenu(null)}
+          items={menu.file ? buildFileMenu(menu.file) : buildEmptyMenu()}
+        />
+      )}
     </div>
   );
 }

--- a/tests/test_routes_user_workspace.py
+++ b/tests/test_routes_user_workspace.py
@@ -154,6 +154,25 @@ class TestUserWorkspaceRoutes:
         assert "dup.txt" in names and "orig.txt" in names
 
     @pytest.mark.asyncio
+    async def test_copy_in_place_with_copy_suffix(self, client):
+        """Duplicating a file in the same directory under a "copy" name works.
+
+        The Files app picks a non-colliding "<base> copy<ext>" destination when
+        pasting into the source directory; the backend must accept that dst.
+        """
+        await client.post(
+            "/api/workspace/files/upload",
+            files={"file": ("note.txt", io.BytesIO(b"dup in place"), "text/plain")},
+        )
+        resp = await client.post(
+            "/api/workspace/copy", json={"src": "note.txt", "dst": "note copy.txt"}
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "copied"
+        names = [e["name"] for e in (await client.get("/api/workspace/files")).json()]
+        assert "note.txt" in names and "note copy.txt" in names
+
+    @pytest.mark.asyncio
     async def test_copy_directory_tree(self, client):
         """Copying a directory copies its contents recursively."""
         await client.post("/api/workspace/mkdir", json={"path": "srcdir"})

--- a/tests/test_routes_user_workspace.py
+++ b/tests/test_routes_user_workspace.py
@@ -140,6 +140,55 @@ class TestUserWorkspaceRoutes:
         resp = await client.post("/api/workspace/rename", json={"src": "safe.txt", "dst": "../escape.txt"})
         assert resp.status_code == 400
 
+    @pytest.mark.asyncio
+    async def test_copy_file(self, client):
+        """POST /api/workspace/copy duplicates a file, leaving the source intact."""
+        await client.post(
+            "/api/workspace/files/upload",
+            files={"file": ("orig.txt", io.BytesIO(b"copy me"), "text/plain")},
+        )
+        resp = await client.post("/api/workspace/copy", json={"src": "orig.txt", "dst": "dup.txt"})
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "copied"
+        names = [e["name"] for e in (await client.get("/api/workspace/files")).json()]
+        assert "dup.txt" in names and "orig.txt" in names
+
+    @pytest.mark.asyncio
+    async def test_copy_directory_tree(self, client):
+        """Copying a directory copies its contents recursively."""
+        await client.post("/api/workspace/mkdir", json={"path": "srcdir"})
+        await client.post(
+            "/api/workspace/files/upload?path=srcdir",
+            files={"file": ("inner.txt", io.BytesIO(b"nested"), "text/plain")},
+        )
+        resp = await client.post("/api/workspace/copy", json={"src": "srcdir", "dst": "dstdir"})
+        assert resp.status_code == 200
+        names = [e["name"] for e in (await client.get("/api/workspace/files?path=dstdir")).json()]
+        assert "inner.txt" in names
+
+    @pytest.mark.asyncio
+    async def test_copy_onto_existing_returns_409(self, client):
+        """Copying onto an existing target returns 409."""
+        for n in ("c.txt", "d.txt"):
+            await client.post(
+                "/api/workspace/files/upload",
+                files={"file": (n, io.BytesIO(b"x"), "text/plain")},
+            )
+        resp = await client.post("/api/workspace/copy", json={"src": "c.txt", "dst": "d.txt"})
+        assert resp.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_copy_nonexistent_returns_404(self, client):
+        """Copying a missing source returns 404."""
+        resp = await client.post("/api/workspace/copy", json={"src": "ghost", "dst": "x"})
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_copy_traversal_blocked(self, client):
+        """Copy sources/targets outside the workspace are blocked with 400."""
+        resp = await client.post("/api/workspace/copy", json={"src": "../../etc", "dst": "stolen.txt"})
+        assert resp.status_code == 400
+
     def test_dir_signature_changes_on_modification(self):
         """Signature helper drives the SSE watch change-detection loop.
         Unit-tested directly — the full SSE stream endpoint is tested

--- a/tinyagentos/routes/user_workspace.py
+++ b/tinyagentos/routes/user_workspace.py
@@ -261,10 +261,11 @@ async def api_copy(request: Request, body: CopyRequest):
         return JSONResponse({"error": "Target already exists"}, status_code=409)
 
     dst.parent.mkdir(parents=True, exist_ok=True)
+    # Run the blocking copy off the event loop so large trees do not stall it.
     if src.is_dir():
-        shutil.copytree(src, dst)
+        await asyncio.to_thread(shutil.copytree, src, dst)
     else:
-        shutil.copy2(src, dst)
+        await asyncio.to_thread(shutil.copy2, src, dst)
     return {"path": str(dst.relative_to(workspace)), "status": "copied"}
 
 

--- a/tinyagentos/routes/user_workspace.py
+++ b/tinyagentos/routes/user_workspace.py
@@ -238,6 +238,36 @@ async def api_rename(request: Request, body: RenameRequest):
     return {"path": str(dst.relative_to(workspace)), "status": "renamed"}
 
 
+class CopyRequest(BaseModel):
+    src: str
+    dst: str
+
+
+@router.post("/api/workspace/copy")
+async def api_copy(request: Request, body: CopyRequest):
+    """Copy a file or directory tree within the user workspace."""
+    workspace = _get_workspace_root(request)
+
+    if not body.src.strip() or not body.dst.strip():
+        return JSONResponse({"error": "src and dst are required"}, status_code=400)
+
+    src = _resolve_safe(workspace, body.src.strip())
+    dst = _resolve_safe(workspace, body.dst.strip())
+    if src is None or dst is None:
+        return JSONResponse({"error": "Invalid path"}, status_code=400)
+    if not src.exists():
+        return JSONResponse({"error": "Source not found"}, status_code=404)
+    if dst.exists():
+        return JSONResponse({"error": "Target already exists"}, status_code=409)
+
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    if src.is_dir():
+        shutil.copytree(src, dst)
+    else:
+        shutil.copy2(src, dst)
+    return {"path": str(dst.relative_to(workspace)), "status": "copied"}
+
+
 @router.get("/api/workspace/files/{file_path:path}")
 async def api_get_file(request: Request, file_path: str):
     """Stream a single file from the user workspace — used for thumbnails,


### PR DESCRIPTION
Adds right-click context menus to the taOS Files app.

Backend: new POST /api/workspace/copy endpoint (CopyRequest with src and dst) that mirrors the existing rename endpoint. It resolves both paths through _resolve_safe (400 on invalid or empty), 404 when the source is missing, 409 when the destination exists, creates the destination parent directory, and copies via shutil.copytree for directories or shutil.copy2 for files. Returns the relative destination path with status copied.

Context menu actions: right-clicking a file or folder row (list and grid views) opens a menu with Open, Download (files only), Rename, Cut, Copy, and Delete. Right-clicking the empty list background opens New Folder, Paste, and Upload. The menu reuses the shared ContextMenu component (the same one used by Desktop, DesktopIcons, and DockIcon) and the existing delete, mkdir, and upload flows. Rename and Paste are wired through the existing apiFetch path.

Clipboard model: component state holds mode (cut or copy), location, path, and name. Copy sets mode copy, Cut sets mode cut (cut rows render at reduced opacity). Paste into the current directory computes the destination as cwd plus the clipboard name. Copy mode posts to /api/workspace/copy, cut mode posts to /api/workspace/rename (the existing endpoint already moves across directories) and clears the clipboard on success. Both refresh the listing and surface 409 or other errors via the app's existing inline error banner.

Scope: copy, cut, and paste are fully supported for the user workspace in v1. Per-agent and project locations get open, download, delete, and rename where the backend supports them, and the copy or paste actions are disabled when no copy or rename endpoint exists for that location. Cross-location paste is disabled with a tooltip (out of scope for v1). Shared folders remain read-only. No new backend endpoints were invented for other locations.

Tests: five new backend tests in tests/test_routes_user_workspace.py cover copying a file (destination appears, source remains), copying a directory tree, 409 on existing destination, 404 on missing source, and a path-escape rejection. Full file is 21 passed. tsc and the desktop build both pass clean.