### PR TITLE
fix(mobile): content/action bars clear the dock on phone

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -306,7 +306,7 @@ export function App() {
     <ShortcutProvider>
       <SystemShortcuts toggleSearch={toggleSearch} toggleLaunchpad={toggleLaunchpad} toggleAssistant={toggleAssistant} />
       <LoginGate>
-    <div className={`taos-wallpaper relative h-screen w-screen flex flex-col text-shell-text${isBrowserMobile ? " taos-browser" : ""}`} style={{ backgroundColor: effWallpaperFallback, ["--wallpaper-desktop" as never]: isAnimatedWallpaper ? "none" : effWallpaperImage, ["--wallpaper-mobile" as never]: isAnimatedWallpaper ? "none" : effWallpaperMobile }}>
+    <div className={`taos-wallpaper taos-mobile-root relative h-screen w-screen flex flex-col text-shell-text${isBrowserMobile ? " taos-browser" : ""}`} style={{ backgroundColor: effWallpaperFallback, ["--wallpaper-desktop" as never]: isAnimatedWallpaper ? "none" : effWallpaperImage, ["--wallpaper-mobile" as never]: isAnimatedWallpaper ? "none" : effWallpaperMobile }}>
       {isAnimatedWallpaper && wallpaperComponent === "particles" && <ParticlesWallpaper />}
       {showOverlayText && wallpaperOverlayText && <WallpaperTextOverlay text={wallpaperOverlayText} />}
       <EffectsLayer />

--- a/desktop/src/apps/WeatherApp.tsx
+++ b/desktop/src/apps/WeatherApp.tsx
@@ -319,8 +319,13 @@ export function WeatherApp() {
         </div>
       </div>
 
-      {/* Main content */}
-      <div className="flex-1 overflow-y-auto p-5">
+      {/* Main content. Extra bottom inset so the last forecast row clears the
+          phone home indicator / dock edge. env(safe-area-inset-bottom) is 0 on
+          desktop, so the layout is unchanged there. */}
+      <div
+        className="flex-1 overflow-y-auto p-5"
+        style={{ paddingBottom: "calc(1.25rem + env(safe-area-inset-bottom, 0px))" }}
+      >
         {!viewing && (
           <div className="flex h-full flex-col items-center justify-center gap-3 text-shell-text-secondary">
             <MapPin size={48} className="opacity-30" />

--- a/desktop/src/apps/chat/A2aBusPanel.tsx
+++ b/desktop/src/apps/chat/A2aBusPanel.tsx
@@ -277,8 +277,12 @@ export function A2aBusMessageView({ channel }: { channel: string }) {
         )}
       </div>
 
-      {/* read-only footer */}
-      <div className="px-4 py-2 border-t border-white/[0.06] text-[11px] text-white/35 shrink-0">
+      {/* read-only footer. Bottom inset keeps it clear of the phone home
+          indicator / dock edge; env() is 0 on desktop so layout is unchanged. */}
+      <div
+        className="px-4 py-2 border-t border-white/[0.06] text-[11px] text-white/35 shrink-0"
+        style={{ paddingBottom: "calc(0.5rem + env(safe-area-inset-bottom, 0px))" }}
+      >
         Read-only. The coordination bus is managed by the agents.
       </div>
     </div>

--- a/desktop/src/apps/images/CreateView.tsx
+++ b/desktop/src/apps/images/CreateView.tsx
@@ -107,10 +107,13 @@ export function CreateView(props: CreateViewProps) {
         </div>
       </div>
 
-      <div className="flex min-h-0 flex-1">
+      {/* Phone-width viewports stack the stage over the controls rail (and
+          scroll) so neither is squeezed off-screen; md+ keeps the desktop
+          side-by-side row. */}
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto md:flex-row md:overflow-hidden">
         {/* stage: canvas + filmstrip */}
         <div className="flex min-w-0 flex-1 flex-col p-[22px]">
-          <div className="relative flex flex-1 items-center justify-center overflow-hidden rounded-2xl border border-shell-border bg-shell-bg-deep">
+          <div className="relative flex min-h-[260px] flex-1 items-center justify-center overflow-hidden rounded-2xl border border-shell-border bg-shell-bg-deep">
             {generating ? (
               <div className="flex flex-col items-center gap-3 text-shell-text-tertiary">
                 <div className="h-7 w-7 animate-spin rounded-full border-2 border-accent border-t-transparent" />
@@ -200,7 +203,7 @@ export function CreateView(props: CreateViewProps) {
         </div>
 
         {/* controls rail */}
-        <div className="flex w-[286px] flex-none flex-col gap-[18px] overflow-auto border-l border-shell-border p-[18px]">
+        <div className="flex w-full flex-none flex-col gap-[18px] overflow-auto border-t border-shell-border p-[18px] md:w-[286px] md:border-l md:border-t-0">
           <div>
             <GroupLabel>Model</GroupLabel>
             <ModelPill name={modelName} meta={modelMeta} onClick={onPickModel} />
@@ -272,8 +275,14 @@ export function CreateView(props: CreateViewProps) {
         </div>
       </div>
 
-      {/* prompt bar */}
-      <div className="flex flex-none items-end gap-3 border-t border-shell-border bg-shell-bg-deep px-[22px] py-4">
+      {/* prompt bar. Extra bottom inset so the textarea + Generate button
+          clear the phone home indicator / dock edge instead of sitting flush
+          under it. On desktop env(safe-area-inset-bottom) is 0, so the layout
+          is unchanged there. */}
+      <div
+        className="flex flex-none items-end gap-3 border-t border-shell-border bg-shell-bg-deep px-[22px] py-4"
+        style={{ paddingBottom: "calc(1rem + env(safe-area-inset-bottom, 0px))" }}
+      >
         <label htmlFor="create-prompt" className="sr-only">
           Image prompt
         </label>

--- a/desktop/src/components/ContextMenu.tsx
+++ b/desktop/src/components/ContextMenu.tsx
@@ -82,9 +82,19 @@ export function ContextMenu({ x, y, items, onClose }: Props) {
     }
   };
 
-  // Ensure menu stays within viewport
-  const adjustedX = Math.min(x, window.innerWidth - 220);
-  const adjustedY = Math.min(y, window.innerHeight - items.length * 36 - 20);
+  // Ensure menu stays within the viewport on both axes. Clamp the far edge
+  // (so it never overflows right/bottom) AND the near edge (so a tap near the
+  // left/top never produces a negative, off-screen position). On phones the
+  // bottom dock occupies roughly 96px of the viewport, so reserve that plus
+  // the home-indicator inset as the bottom margin.
+  const MENU_W = 220;
+  const MARGIN = 8;
+  const BOTTOM_RESERVE = 96; // dock + breathing room on mobile
+  const menuH = items.length * 36 + 12;
+  const maxX = window.innerWidth - MENU_W - MARGIN;
+  const maxY = window.innerHeight - menuH - BOTTOM_RESERVE;
+  const adjustedX = Math.max(MARGIN, Math.min(x, maxX));
+  const adjustedY = Math.max(MARGIN, Math.min(y, maxY));
 
   // Roving tabindex: track which navigable (non-separator, non-disabled) item is active
   let navigableCounter = -1;

--- a/desktop/src/components/mobile/MobileDock.tsx
+++ b/desktop/src/components/mobile/MobileDock.tsx
@@ -24,11 +24,14 @@ export function MobileDock({ onOpenApp, onToggleSwitcher, onOpenLaunchpad, activ
   const dockApps = useMobileHomeStore((s) => s.dockApps);
   const windows = useProcessStore((s) => s.windows);
 
-  // In PWA mode the home indicator is handled by env(safe-area-inset-bottom)
-  // on the viewport, so 24 px of padding is enough to clear it.
-  // In browser mode safe-area-inset-bottom is 0, so we need extra room to
-  // keep the dock above Safari's ~50 px URL/tab bar.
-  const dockPaddingBottom = isBrowserMobile ? 54 : 24;
+  // The dock is the bottom-most element in the mobile column, so it owns the
+  // home-indicator / browser-chrome clearance for everything above it. We add
+  // env(safe-area-inset-bottom) on TOP of a base gap so the dock (and the app
+  // content that ends just above it) always clears the home indicator. In PWA
+  // mode the inset is non-zero (notch devices); in browser mode it is 0, so we
+  // add extra room to keep the dock above Safari's ~50 px URL/tab bar.
+  const dockBaseGap = isBrowserMobile ? 54 : 12;
+  const dockPaddingBottom = `calc(env(safe-area-inset-bottom, 0px) + ${dockBaseGap}px)`;
 
   return (
     <div

--- a/desktop/src/theme/tokens.css
+++ b/desktop/src/theme/tokens.css
@@ -231,13 +231,24 @@
    the viewport so the dock sits above the tab bar instead of behind it.
    The PWA layout is UNCHANGED — this only activates with .taos-browser.
    ================================================================== */
+/* Every mobile/tablet shell uses the dynamic viewport height so the bottom of
+   the column (the dock, and the app content/action bar that ends just above
+   it) is never pushed below the visible viewport. Tailwind's h-screen resolves
+   to 100vh, which on iOS includes the area behind the collapsing URL bar /
+   home indicator; 100dvh tracks the actual visible viewport. The 100vh line is
+   the fallback for browsers without dvh. Per-component safe-area insets still
+   handle the home-indicator clearance. */
+.taos-mobile-root {
+  height: 100vh !important;
+  height: 100dvh !important;
+}
+
 .taos-browser {
   /* Note: safe-area insets are applied inline on individual components
      (ChatStandalone, BottomSheet, OnboardingScreen, ModelPickerModal, …),
      not on this element, and env(safe-area-inset-*) is already 0 in browser
-     (non-standalone) mode — so a padding reset here would be a no-op. We only
-     fix the viewport height: use dvh so Safari's collapsing URL bar doesn't
-     leave a gap, with 100vh as the fallback for browsers without dvh. */
+     (non-standalone) mode, so a padding reset here would be a no-op. The
+     viewport-height fix lives on .taos-mobile-root (shared with PWA mode). */
   height: 100vh !important;
   height: 100dvh !important;
 }


### PR DESCRIPTION
## Root cause

The phone shell (App.tsx mobile branch) is a flex column: MobileTopBar / content (flex-1) / MobileDock. The mobile path does not use Window.tsx at all, so its dockH reservation is irrelevant here. Two real problems put app content and bottom action bars under the dock:

1. The MobileDock is the bottom-most element and owns clearance for everything above it, but its bottom padding was a fixed 24px (PWA) / 54px (browser) with NO env(safe-area-inset-bottom). On notch/home-indicator devices the dock and the content ending just above it were pushed into the home-indicator zone.
2. The root mobile container used Tailwind h-screen (100vh). The 100dvh override existed only for browser mode (.taos-browser), so PWA mode kept 100vh, which on iOS includes the area behind the collapsing URL bar / home indicator and can exceed the visible viewport, pushing the bottom of the column off-screen.

This is case (a)+(c) from the investigation: the dock-clearance was underestimated (no safe-area inset) and the column height could exceed the visible viewport, so action bars sitting at the very bottom edge fell behind the dock.

## The fix

- MobileDock: bottom padding is now calc(env(safe-area-inset-bottom, 0px) + baseGap) so the dock and the content above it always clear the home indicator. Base gap is 12px PWA / 54px browser.
- tokens.css: a shared .taos-mobile-root class applies 100dvh (with 100vh fallback) to every mobile shell, not just browser mode, so the column never exceeds the visible viewport. Desktop is untouched.
- Images CreateView: the prompt bar (textarea + Generate) gets calc(1rem + env(safe-area-inset-bottom, 0px)) bottom padding so it can never sit flush under the dock. Also made the Create body stack the stage over the controls rail and scroll on phone-width viewports (md+ keeps the desktop two-column row), fixing the 286px rail squeezing the canvas off-screen.
- ContextMenu (used by FilesApp and the desktop): viewport clamping now bounds BOTH axes with a minimum margin and reserves the bottom dock area, so a tap near an edge no longer opens the menu off-screen or behind the dock on mobile.
- WeatherApp scroll area and the A2A bus read-only footer get matching safe-area bottom insets so their last row / footer clears the dock edge.

env(safe-area-inset-bottom) is 0 on desktop, so all desktop layouts are unchanged. No new transitions were added, so prefers-reduced-motion is unaffected.

## Apps / files touched

- desktop/src/components/mobile/MobileDock.tsx
- desktop/src/theme/tokens.css
- desktop/src/App.tsx
- desktop/src/apps/images/CreateView.tsx
- desktop/src/components/ContextMenu.tsx
- desktop/src/apps/WeatherApp.tsx
- desktop/src/apps/chat/A2aBusPanel.tsx

## Verification

- npx tsc --noEmit: clean
- npm run build: succeeds
- Relevant tests pass (ContextMenu, DockVariants, Window, mobile-home: 24 tests green)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced mobile and tablet support with improved safe-area padding to prevent content overlap with notches, home indicators, and docks.
  * Improved responsive layouts that adapt better between phone and desktop viewports.

* **Bug Fixes**
  * Fixed context menu positioning on mobile devices to ensure it stays fully visible on-screen.
  * Corrected viewport height handling for better display across iOS and Android devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->