### PR TITLE
feat(apps): utility-app design polish (Activity, Media Player)

### DIFF
--- a/desktop/src/apps/ActivityApp.tsx
+++ b/desktop/src/apps/ActivityApp.tsx
@@ -172,9 +172,10 @@ function formatMb(mb: number | null | undefined): string {
 }
 
 function colourForLoad(pct: number): string {
-  if (pct < 50) return "#43e97b";
-  if (pct < 80) return "#febc2e";
-  return "#ff5f57";
+  // Token-backed traffic-light scale so the bar tracks the theme.
+  if (pct < 50) return "var(--color-traffic-maximize)";
+  if (pct < 80) return "var(--color-traffic-minimize)";
+  return "var(--color-traffic-close)";
 }
 
 function LoadBar({ value, label, unit = "%" }: { value: number; label?: string; unit?: string }) {

--- a/desktop/src/apps/MediaPlayerApp.tsx
+++ b/desktop/src/apps/MediaPlayerApp.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import Plyr from "plyr";
 import "plyr/dist/plyr.css";
+import { Film, FolderOpen } from "lucide-react";
 
 export function MediaPlayerApp({ windowId: _windowId }: { windowId: string }) {
   const videoRef = useRef<HTMLVideoElement>(null);
@@ -51,35 +52,47 @@ export function MediaPlayerApp({ windowId: _windowId }: { windowId: string }) {
   }, [mediaUrl]);
 
   return (
-    <div className="flex flex-col h-full bg-[#1a1a2e] select-none">
+    <div className="flex h-full flex-col bg-shell-bg text-shell-text select-none">
       {!mediaUrl ? (
-        <div className="flex flex-col items-center justify-center flex-1 gap-4 p-8">
-          <div className="text-shell-text-secondary text-lg">
-            No media loaded
+        <div className="flex flex-1 flex-col items-center justify-center gap-5 p-8">
+          <div className="flex flex-col items-center gap-4 rounded-2xl border border-shell-border bg-shell-surface px-10 py-9 text-center shadow-[var(--shadow-card)]">
+            <span className="flex h-14 w-14 items-center justify-center rounded-2xl border border-shell-border bg-white/5 text-shell-text-tertiary">
+              <Film size={26} />
+            </span>
+            <div className="flex flex-col gap-1">
+              <h2 className="text-[15px] font-semibold tracking-[-0.01em] text-shell-text">
+                No media loaded
+              </h2>
+              <p className="text-[12.5px] text-shell-text-secondary">
+                Pick a video or audio file to start playing.
+              </p>
+            </div>
+            <label
+              className="flex h-9 cursor-pointer items-center justify-center gap-1.5 rounded-xl bg-accent px-4 text-[12px] font-semibold text-white transition-all hover:brightness-105 focus-within:outline-none focus-within:ring-2 focus-within:ring-accent/40"
+              aria-label="Choose media file"
+            >
+              <FolderOpen size={15} />
+              Open File
+              <input
+                type="file"
+                accept="video/*,audio/*"
+                onChange={handleFileSelect}
+                className="hidden"
+              />
+            </label>
           </div>
-          <label
-            className="px-4 py-2 rounded-lg bg-accent text-white cursor-pointer hover:bg-accent/90 transition-colors"
-            aria-label="Choose media file"
-          >
-            Open File
-            <input
-              type="file"
-              accept="video/*,audio/*"
-              onChange={handleFileSelect}
-              className="hidden"
-            />
-          </label>
         </div>
       ) : (
-        <div className="flex flex-col h-full">
-          <div className="flex items-center gap-2 px-3 py-2 bg-[#12122a] border-b border-white/10">
-            <span className="text-shell-text text-sm truncate flex-1">
+        <div className="flex h-full min-h-0 flex-col">
+          <div className="flex flex-none items-center gap-2 border-b border-shell-border bg-shell-bg-deep px-3 py-2">
+            <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-shell-text">
               {fileName}
             </span>
             <label
-              className="px-3 py-1 rounded text-xs bg-shell-surface text-shell-text-secondary cursor-pointer hover:bg-shell-surface/80 transition-colors"
+              className="flex h-7 cursor-pointer items-center gap-1.5 rounded-lg border border-shell-border bg-shell-surface px-2.5 text-[11.5px] font-semibold text-shell-text-secondary transition-colors hover:bg-white/10 hover:text-shell-text hover:border-shell-border-strong focus-within:outline-none focus-within:ring-2 focus-within:ring-accent/40"
               aria-label="Choose a different media file"
             >
+              <FolderOpen size={13} />
               Open
               <input
                 type="file"
@@ -89,11 +102,14 @@ export function MediaPlayerApp({ windowId: _windowId }: { windowId: string }) {
               />
             </label>
           </div>
-          <div className="flex-1 flex items-center justify-center bg-black min-h-0">
+          <div
+            className="flex min-h-0 flex-1 items-center justify-center bg-shell-bg-deep"
+            style={{ paddingBottom: "env(safe-area-inset-bottom, 0px)" }}
+          >
             <video
               ref={videoRef}
               src={mediaUrl}
-              className="max-w-full max-h-full"
+              className="max-h-full max-w-full"
               aria-label="Media player"
             />
           </div>


### PR DESCRIPTION
Audits two utility apps against the Store/Images design bar and polishes only where genuinely off-spec.

Media Player was off the bar. It used hardcoded indigo hex surfaces (bg-[#1a1a2e], bg-[#12122a]) that do not auto-invert in the light theme and clash with the neutral-graphite house palette, plus a flat un-elevated empty state and no mobile safe-area handling. Changes:
- Empty state is now a glassy rounded-2xl card on shell tokens with a Film icon, a heading, and a one-line hint, matching the Images empty-state DNA.
- Every surface moved onto theme tokens (shell-bg, shell-bg-deep, shell-surface, shell-border) so both themes read correctly and high-contrast.
- Toolbar and Open buttons gained tasteful token-driven hover and focus states.
- The player viewport pads for env(safe-area-inset-bottom) so it clears the mobile dock at 390px; the header truncates and the layout reflows with no horizontal overflow.

Activity was already on the bar (Card primitives, shell tokens, auto-inverting white/N utilities, good hierarchy). Its only real gap was the load-bar colour helper returning raw hex; it now points at the traffic-light theme tokens so the bars track the active theme. No other changes were made to it.

Functionality, data, and props are unchanged in both apps. No hardcoded hex remains in either touched file. tsc --noEmit passes clean and npm run build succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Activity App: Load bar colors now align with the app's theme for a cohesive look.
  * Media Player App: Redesigned interface with updated icons, improved empty state layout, and optimized video player display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->