### PR TITLE
feat(messages): Messages app redesign

### DIFF
--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -1511,7 +1511,7 @@ export function MessagesApp({
           <button
             type="button"
             onClick={openAgentsApp}
-            style={{ marginTop: 4, fontSize: 13, padding: "8px 16px", borderRadius: 10, background: "rgba(59,130,246,0.2)", border: "1px solid rgba(59,130,246,0.3)", color: "rgba(147,197,253,0.9)", cursor: "pointer" }}
+            style={{ marginTop: 4, fontSize: 13, padding: "8px 16px", borderRadius: 10, background: "var(--color-accent-soft)", border: "1px solid var(--color-accent-line)", color: "var(--color-accent-strong)", cursor: "pointer" }}
           >
             Open Agents
           </button>
@@ -1570,9 +1570,13 @@ export function MessagesApp({
                 >
                   {agentMember ? (
                     <MessageAvatar size={38} authorId={agentMember} displayName={agentMember} kind="agent" />
+                  ) : isA2A ? (
+                    <div style={{ width: 38, height: 38, borderRadius: 11, display: "flex", alignItems: "center", justifyContent: "center", background: "var(--color-accent-soft)", border: "1px solid var(--color-accent-line)", color: "var(--color-accent-strong)", flexShrink: 0 }}>
+                      <Bot size={18} aria-hidden />
+                    </div>
                   ) : (
                     <div style={{ width: 38, height: 38, borderRadius: 11, display: "flex", alignItems: "center", justifyContent: "center", background: "var(--color-shell-surface-active)", color: "var(--color-shell-text-secondary)", flexShrink: 0 }}>
-                      {isA2A ? <Bot size={18} aria-hidden /> : ch.type === "group" ? <Users size={18} aria-hidden /> : <Hash size={18} aria-hidden />}
+                      {ch.type === "group" ? <Users size={18} aria-hidden /> : <Hash size={18} aria-hidden />}
                     </div>
                   )}
                   <div style={{ flex: 1, minWidth: 0 }}>
@@ -1593,7 +1597,7 @@ export function MessagesApp({
                     )}
                   </div>
                   {count > 0 && (
-                    <span style={{ background: "#3b82f6", color: "#fff", fontSize: 10, fontWeight: 700, borderRadius: 9999, minWidth: 18, height: 18, display: "flex", alignItems: "center", justifyContent: "center", padding: "0 5px", flexShrink: 0 }}>
+                    <span style={{ background: "var(--color-unread)", color: "#fff", fontSize: 10, fontWeight: 700, borderRadius: 9999, minWidth: 18, height: 18, display: "flex", alignItems: "center", justifyContent: "center", padding: "0 5px", flexShrink: 0 }}>
                       {count}
                     </span>
                   )}
@@ -1648,9 +1652,9 @@ export function MessagesApp({
                             gap: 10,
                             width: "100%",
                             padding: "14px 16px",
-                            background: selectedChannel === ch.id ? "rgba(59,130,246,0.15)" : "none",
+                            background: selectedChannel === ch.id ? "var(--color-shell-surface-active)" : "none",
                             border: "none",
-                            borderBottom: idx === arr.length - 1 ? "none" : "1px solid rgba(255,255,255,0.06)",
+                            borderBottom: idx === arr.length - 1 ? "none" : "1px solid var(--color-shell-border)",
                             cursor: "pointer",
                             color: "inherit",
                             textAlign: "left",
@@ -1667,11 +1671,11 @@ export function MessagesApp({
                             {ch.name}
                           </span>
                           {(unread[ch.id] ?? 0) > 0 && (
-                            <span style={{ background: "#3b82f6", color: "#fff", fontSize: 10, fontWeight: 700, borderRadius: 9999, minWidth: 18, height: 18, display: "flex", alignItems: "center", justifyContent: "center", padding: "0 4px" }}>
+                            <span style={{ background: "var(--color-unread)", color: "#fff", fontSize: 10, fontWeight: 700, borderRadius: 9999, minWidth: 18, height: 18, display: "flex", alignItems: "center", justifyContent: "center", padding: "0 4px" }}>
                               {unread[ch.id]}
                             </span>
                           )}
-                          <ChevronRight size={16} style={{ color: "rgba(255,255,255,0.25)", flexShrink: 0 }} />
+                          <ChevronRight size={16} style={{ color: "var(--color-shell-text-tertiary)", flexShrink: 0 }} />
                         </button>
                       ))}
                     </div>
@@ -1717,7 +1721,7 @@ export function MessagesApp({
                       type="button"
                       onClick={() => setSelectedChannel(ch.id)}
                       aria-label={`Archived channel ${ch.name}`}
-                      style={{ flex: 1, display: "flex", alignItems: "center", gap: 8, padding: "12px 8px 12px 16px", background: selectedChannel === ch.id ? "rgba(59,130,246,0.12)" : "none", border: "none", cursor: "pointer", color: "inherit", textAlign: "left" as const, minWidth: 0 }}
+                      style={{ flex: 1, display: "flex", alignItems: "center", gap: 8, padding: "12px 8px 12px 16px", background: selectedChannel === ch.id ? "var(--color-shell-surface-active)" : "none", border: "none", cursor: "pointer", color: "inherit", textAlign: "left" as const, minWidth: 0 }}
                     >
                       <Archive size={11} aria-hidden="true" style={{ color: "rgba(255,255,255,0.4)", flexShrink: 0 }} />
                       <span style={{ flex: 1, fontSize: 14, color: "rgba(255,255,255,0.7)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{ch.name}</span>
@@ -1808,30 +1812,46 @@ export function MessagesApp({
             {!collapsedSections[section.label] && section.items.length === 0 && (
               <div className="px-3 py-1 text-[11px] text-white/20 italic">None yet</div>
             )}
-            {visibleInSection(section.items, section.label).map((ch) => (
-              <Button
-                key={ch.id}
-                variant={selectedChannel === ch.id ? "secondary" : "ghost"}
-                onClick={() => setSelectedChannel(ch.id)}
-                className="w-full justify-start h-auto py-1.5 px-3 text-[13px] rounded-none font-normal"
-                aria-label={`Channel ${ch.name}`}
-                title={ch.settings?.kind === "a2a" ? "Agent coordination — mention @<slug> to hand off." : undefined}
-              >
-                {ch.settings?.kind === "a2a" && (
-                  <Bot
-                    size={14}
-                    aria-hidden
-                    style={{ color: "rgba(255,255,255,0.6)", flexShrink: 0 }}
-                  />
-                )}
-                <span className="truncate flex-1 text-left">{ch.name}</span>
-                {(unread[ch.id] ?? 0) > 0 && (
-                  <span className="shrink-0 bg-blue-500 text-white text-[10px] font-bold rounded-full min-w-[18px] h-[18px] flex items-center justify-center px-1">
-                    {unread[ch.id]}
-                  </span>
-                )}
-              </Button>
-            ))}
+            <div className="px-2 flex flex-col gap-px">
+              {visibleInSection(section.items, section.label).map((ch) => {
+                const isA2A = ch.settings?.kind === "a2a";
+                const agentMember = ch.type === "dm" ? (ch.members ?? []).find((m) => m !== "user") : undefined;
+                const count = unread[ch.id] ?? 0;
+                return (
+                  <button
+                    key={ch.id}
+                    type="button"
+                    onClick={() => setSelectedChannel(ch.id)}
+                    aria-pressed={selectedChannel === ch.id}
+                    className={`w-full flex items-center gap-2.5 px-2.5 py-2 rounded-[10px] text-left transition-colors ${
+                      selectedChannel === ch.id ? "bg-shell-surface-active" : "hover:bg-shell-surface-hover"
+                    }`}
+                    aria-label={`Channel ${ch.name}`}
+                    title={isA2A ? "Agent coordination — mention @<slug> to hand off." : undefined}
+                  >
+                    {agentMember ? (
+                      <MessageAvatar size={30} authorId={agentMember} displayName={agentMember} kind="agent" />
+                    ) : isA2A ? (
+                      <span className="shrink-0 grid place-items-center w-[30px] h-[30px] rounded-[9px] bg-accent-soft border border-accent-line text-accent-strong">
+                        <Bot size={15} aria-hidden />
+                      </span>
+                    ) : (
+                      <span className="shrink-0 grid place-items-center w-[30px] h-[30px] rounded-[9px] bg-shell-surface-active text-shell-text-secondary">
+                        {ch.type === "group" ? <Users size={15} aria-hidden /> : <Hash size={15} aria-hidden />}
+                      </span>
+                    )}
+                    <span className={`truncate flex-1 text-[14px] tracking-tight ${count > 0 ? "font-bold text-shell-text" : "font-semibold text-shell-text"}`}>
+                      {ch.name}
+                    </span>
+                    {count > 0 && (
+                      <span className="shrink-0 bg-unread text-white text-[10px] font-bold rounded-full min-w-[18px] h-[18px] flex items-center justify-center px-1 tabular-nums">
+                        {count}
+                      </span>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
           </div>
         ))}
 
@@ -1959,7 +1979,7 @@ export function MessagesApp({
           type="button"
           onClick={scrollToLatest}
           aria-label="Jump to latest"
-          className="absolute right-4 bottom-24 z-20 flex items-center gap-1.5 px-3 h-9 rounded-full bg-zinc-800 border border-white/15 text-white/80 hover:text-white shadow-lg hover:bg-zinc-700 transition-colors"
+          className="absolute right-4 bottom-24 z-20 flex items-center gap-1.5 px-3 h-9 rounded-full bg-shell-surface-active border border-shell-border-strong text-shell-text/80 hover:text-shell-text shadow-lg hover:bg-shell-surface-hover backdrop-blur-xl transition-colors"
         >
           <ChevronDown size={16} aria-hidden="true" />
           {newCount > 0 && <span className="text-[11px] font-semibold">{newCount} new</span>}
@@ -2237,12 +2257,10 @@ export function MessagesApp({
                       }}
                     >
                       <span
-                        className={`${isMobile ? "text-[14px]" : "text-[15px]"} font-semibold ${
+                        className={`${isMobile ? "text-[14px]" : "text-[15px]"} font-bold tracking-tight ${
                           isDeadAgent
                             ? "line-through text-shell-text-tertiary"
-                            : isAgent
-                              ? "text-sky-500"
-                              : "text-shell-text"
+                            : "text-shell-text"
                         }`}
                         style={isDeadAgent ? { opacity: 0.55 } : undefined}
                         title={authorTooltip}
@@ -2250,7 +2268,7 @@ export function MessagesApp({
                         {displayAuthor(msg, { currentUserId, currentUserDisplayName })}
                       </span>
                       {isAgent && !isDeadAgent && (
-                        <span className="text-[10px] uppercase tracking-wide bg-sky-500/15 text-sky-600 px-1.5 py-0.5 rounded font-semibold flex items-center gap-0.5">
+                        <span className="text-[10px] uppercase tracking-wide bg-accent-soft text-accent-strong border border-accent-line px-1.5 py-0.5 rounded font-semibold flex items-center gap-0.5">
                           <Bot size={10} aria-hidden="true" /> Agent
                         </span>
                       )}
@@ -2283,9 +2301,9 @@ export function MessagesApp({
                       )}
                       {msg.state === "streaming" && (
                         <span className="ml-1 inline-flex gap-0.5">
-                          <span className="w-1 h-1 bg-blue-400 rounded-full animate-bounce [animation-delay:0ms]" />
-                          <span className="w-1 h-1 bg-blue-400 rounded-full animate-bounce [animation-delay:150ms]" />
-                          <span className="w-1 h-1 bg-blue-400 rounded-full animate-bounce [animation-delay:300ms]" />
+                          <span className="w-1 h-1 bg-accent rounded-full animate-bounce [animation-delay:0ms]" />
+                          <span className="w-1 h-1 bg-accent rounded-full animate-bounce [animation-delay:150ms]" />
+                          <span className="w-1 h-1 bg-accent rounded-full animate-bounce [animation-delay:300ms]" />
                         </span>
                       )}
                       {msg.state === "error" && (
@@ -2331,12 +2349,12 @@ export function MessagesApp({
                             aria-pressed={mine}
                             className={`text-[12px] rounded-full px-2 py-0.5 flex items-center gap-1 border transition-colors ${
                               mine
-                                ? "bg-sky-500/15 border-sky-500/40 text-sky-600"
+                                ? "bg-accent-soft border-accent-line text-accent-strong"
                                 : "bg-shell-surface border-shell-border hover:bg-shell-surface-hover text-shell-text-secondary"
                             }`}
                           >
                             <span>{emoji}</span>
-                            <span className={mine ? "text-sky-600 font-medium" : "text-shell-text-tertiary"}>{users.length}</span>
+                            <span className={mine ? "text-accent-strong font-medium" : "text-shell-text-tertiary"}>{users.length}</span>
                           </button>
                         );
                       })}
@@ -2420,7 +2438,7 @@ export function MessagesApp({
                       data-emoji-popover="1"
                       role="dialog"
                       aria-label="Emoji reactions"
-                      className="fixed z-50 bg-zinc-800 border border-white/10 rounded-lg shadow-xl p-2 w-[300px] h-[360px] flex flex-col gap-2"
+                      className="fixed z-50 bg-shell-bg border border-shell-border-strong rounded-lg shadow-xl p-2 w-[300px] h-[360px] flex flex-col gap-2 backdrop-blur-xl"
                       style={{ top, left }}
                     >
                       <div className="flex gap-1 shrink-0">
@@ -2471,7 +2489,7 @@ export function MessagesApp({
           {/* prefill banner */}
           {prefillBanner && (
             <div
-              className="mx-4 mb-1 px-3 py-2 rounded-lg bg-blue-500/10 border border-blue-500/20 text-[12px] text-blue-300/90 flex items-center gap-2 shrink-0"
+              className="mx-4 mb-1 px-3 py-2 rounded-lg bg-accent-soft border border-accent-line text-[12px] text-accent-strong flex items-center gap-2 shrink-0"
               role="status"
               aria-label={`Composer prefilled from prompt: ${prefillBanner.promptName}`}
             >
@@ -2523,9 +2541,9 @@ export function MessagesApp({
               style={{
                 padding: "10px 14px",
                 fontSize: 12,
-                color: "rgba(255,255,255,0.55)",
-                background: "rgba(255,255,255,0.03)",
-                border: "1px solid rgba(255,255,255,0.06)",
+                color: "var(--color-shell-text-secondary)",
+                background: "var(--color-accent-soft)",
+                border: "1px solid var(--color-accent-line)",
                 borderRadius: 12,
                 margin: "8px 12px",
               }}
@@ -2576,7 +2594,7 @@ export function MessagesApp({
                   ))}
                 </div>
               )}
-              <div className={`flex items-end gap-2 rounded-xl border px-2 py-1.5 ${isCurrentArchived ? "bg-white/[0.02] border-white/[0.04] opacity-50" : "bg-white/[0.06] border-white/[0.08]"}`}>
+              <div className={`flex items-end gap-2 rounded-2xl border px-2 py-1.5 ${isCurrentArchived ? "bg-white/[0.02] border-white/[0.04] opacity-50" : "bg-shell-surface border-shell-border-strong"}`}>
                 <Button
                   variant="ghost"
                   size="icon"
@@ -2916,7 +2934,7 @@ export function MessagesApp({
           aria-label="Canvas viewer"
         >
           <div
-            className="w-[90vw] h-[85vh] max-w-5xl rounded-xl border border-white/10 overflow-hidden bg-zinc-900 flex flex-col"
+            className="w-[90vw] h-[85vh] max-w-5xl rounded-xl border border-white/10 overflow-hidden bg-shell-bg flex flex-col"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="flex items-center justify-between px-4 py-2 border-b border-white/10 shrink-0">
@@ -2954,7 +2972,7 @@ export function MessagesApp({
             aria-label="New channel"
           >
             <div
-              className="absolute bottom-0 left-0 right-0 bg-zinc-900 border-t border-white/[0.08] rounded-t-2xl p-4 space-y-3"
+              className="absolute bottom-0 left-0 right-0 bg-shell-bg border-t border-white/[0.08] rounded-t-2xl p-4 space-y-3"
               onClick={(e) => e.stopPropagation()}
             >
               <div className="flex items-center justify-between mb-1">
@@ -2979,7 +2997,7 @@ export function MessagesApp({
                   id="new-channel-type-mobile"
                   value={newChannel.type}
                   onChange={(e) => setNewChannel((s) => ({ ...s, type: e.target.value as "topic" | "group" }))}
-                  className="w-full bg-white/[0.06] border border-white/10 rounded-lg px-3 py-2 text-sm text-white outline-none focus:border-blue-500/50"
+                  className="w-full bg-white/[0.06] border border-white/10 rounded-lg px-3 py-2 text-sm text-white outline-none focus:border-accent-line"
                   aria-label="Channel type"
                 >
                   <option value="topic">Topic</option>
@@ -3003,7 +3021,7 @@ export function MessagesApp({
           </div>
         ) : (
           <div className="absolute inset-0 bg-black/60 flex items-center justify-center z-50 p-4">
-            <Card className="w-full max-w-[380px] max-h-full flex flex-col shadow-2xl bg-zinc-900">
+            <Card className="w-full max-w-[380px] max-h-full flex flex-col shadow-2xl bg-shell-bg">
               <CardHeader className="flex flex-row items-center justify-between gap-2 p-0 px-4 py-3 border-b border-white/[0.06]">
                 <CardTitle className="text-sm font-medium">New Channel</CardTitle>
                 <Button
@@ -3033,7 +3051,7 @@ export function MessagesApp({
                     id="new-channel-type"
                     value={newChannel.type}
                     onChange={(e) => setNewChannel((s) => ({ ...s, type: e.target.value as "topic" | "group" }))}
-                    className="w-full bg-white/[0.06] border border-white/10 rounded-lg px-3 py-2 text-sm text-white outline-none focus:border-blue-500/50"
+                    className="w-full bg-white/[0.06] border border-white/10 rounded-lg px-3 py-2 text-sm text-white outline-none focus:border-accent-line"
                     aria-label="Channel type"
                   >
                     <option value="topic">Topic</option>

--- a/desktop/src/apps/chat/A2aBusPanel.tsx
+++ b/desktop/src/apps/chat/A2aBusPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from "react";
-import { Radio, ChevronRight, Bot } from "lucide-react";
+import { Radio, ChevronRight, Bot, Lock } from "lucide-react";
 
 /*
  * Read-only viewer for the external taOSmd A2A coordination bus.
@@ -112,32 +112,34 @@ export function A2aBusSection({
   // Hide the whole group until the first fetch resolves so it never flashes.
   if (!loaded) return null;
 
+  // The bus reads as its own protected rail: a tinted accent-soft container
+  // with an accent hairline, distinct from the plain project channels.
   return (
-    <div className="mt-2">
+    <div className="mx-2.5 mt-2.5 rounded-2xl bg-accent-soft border border-accent-line p-1.5">
       <button
         type="button"
         onClick={() => setExpanded((v) => !v)}
         aria-expanded={expanded}
         aria-controls="a2a-bus-channels"
-        className="flex items-center gap-1.5 px-3 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-wider text-white/30 hover:text-white/50 transition-colors w-full text-left"
+        className="flex items-center gap-1.5 px-2 pt-1 pb-1.5 text-[10.5px] font-bold uppercase tracking-wide text-accent-strong hover:opacity-80 transition-opacity w-full text-left"
       >
         <ChevronRight
           size={11}
           aria-hidden="true"
           className={`transition-transform ${expanded ? "rotate-90" : ""}`}
         />
-        <Radio size={11} aria-hidden="true" />
+        <Radio size={12} aria-hidden="true" />
         Coordination Bus
       </button>
       {expanded && (
         <div id="a2a-bus-channels">
           {!available ? (
-            <div className="px-3 py-2">
-              <p className="text-[11px] text-white/40">Coordination bus offline</p>
-              <p className="text-[10px] text-white/25 mt-0.5">No bus service reachable.</p>
+            <div className="px-2 py-2">
+              <p className="text-[11px] text-shell-text-secondary">Coordination bus offline</p>
+              <p className="text-[10px] text-shell-text-tertiary mt-0.5">No bus service reachable.</p>
             </div>
           ) : channels.length === 0 ? (
-            <div className="px-3 py-1 text-[11px] text-white/20 italic">No channels yet</div>
+            <div className="px-2 py-1 text-[11px] text-shell-text-tertiary italic">No channels yet</div>
           ) : (
             channels.map((ch) => (
               <button
@@ -147,14 +149,23 @@ export function A2aBusSection({
                 aria-pressed={selected === ch.channel}
                 aria-label={`Coordination channel ${ch.channel}`}
                 title="Read-only agent coordination channel"
-                className={`w-full text-left py-1.5 px-3 text-[13px] flex items-center gap-2 transition-colors ${
-                  selected === ch.channel ? "bg-white/10" : "hover:bg-white/5"
+                className={`w-full text-left py-1.5 px-2 rounded-[10px] text-[13px] flex items-center gap-2.5 transition-colors ${
+                  selected === ch.channel ? "bg-shell-surface-active" : "hover:bg-shell-surface-hover"
                 }`}
               >
-                <Radio size={14} aria-hidden className="shrink-0 text-white/50" />
-                <span className="truncate flex-1">{ch.channel}</span>
-                <span className="shrink-0 text-[10px] text-white/30 tabular-nums">
-                  {(ch.members?.length ?? 0)} · {busRelativeTime(ch.last_ts, nowMs)}
+                <span className="shrink-0 grid place-items-center w-[30px] h-[30px] rounded-[9px] bg-accent-soft border border-accent-line text-accent-strong">
+                  <Radio size={15} aria-hidden />
+                </span>
+                <span className="flex-1 min-w-0">
+                  <span className="flex items-baseline gap-2">
+                    <span className="truncate flex-1 font-semibold text-shell-text">{ch.channel}</span>
+                    <span className="shrink-0 text-[10.5px] text-shell-text-tertiary tabular-nums">
+                      {(ch.members?.length ?? 0)} · {busRelativeTime(ch.last_ts, nowMs)}
+                    </span>
+                  </span>
+                </span>
+                <span className="shrink-0 inline-flex items-center gap-1 text-[9.5px] font-bold uppercase tracking-wide text-accent-strong">
+                  <Lock size={10} aria-hidden /> RO
                 </span>
               </button>
             ))
@@ -226,11 +237,13 @@ export function A2aBusMessageView({ channel }: { channel: string }) {
   return (
     <div className="relative flex-1 flex flex-col min-w-0 h-full">
       {/* header */}
-      <div className="px-4 py-2.5 border-b border-white/[0.06] flex items-center gap-3 shrink-0">
-        <Radio size={16} className="text-white/40" aria-hidden="true" />
+      <div className="px-4 py-2.5 border-b border-shell-border flex items-center gap-3 shrink-0">
+        <span className="shrink-0 grid place-items-center w-8 h-8 rounded-[9px] bg-accent-soft border border-accent-line text-accent-strong">
+          <Radio size={15} aria-hidden="true" />
+        </span>
         <div className="min-w-0">
-          <div className="text-sm font-semibold text-white/90 truncate">{channel}</div>
-          <div className="text-[11px] text-white/40">Coordination bus · read-only</div>
+          <div className="text-[15px] font-bold tracking-tight text-shell-text truncate">{channel}</div>
+          <div className="text-[11.5px] text-shell-text-secondary">Coordination bus · read-only</div>
         </div>
       </div>
 
@@ -242,34 +255,40 @@ export function A2aBusMessageView({ channel }: { channel: string }) {
           </div>
         ) : !available ? (
           <div className="h-full flex flex-col items-center justify-center text-center gap-2 px-6">
-            <Radio size={32} className="text-white/15" aria-hidden="true" />
-            <p className="text-sm font-medium text-white/60">Coordination bus offline</p>
-            <p className="text-[12px] text-white/30">
+            <Radio size={32} className="text-shell-text-tertiary" aria-hidden="true" />
+            <p className="text-sm font-medium text-shell-text-secondary">Coordination bus offline</p>
+            <p className="text-[12px] text-shell-text-tertiary">
               The bus service is not reachable right now.
             </p>
           </div>
         ) : messages.length === 0 ? (
           <div className="h-full flex flex-col items-center justify-center text-center gap-2 px-6">
-            <Bot size={32} className="text-white/15" aria-hidden="true" />
-            <p className="text-sm font-medium text-white/60">No messages yet</p>
-            <p className="text-[12px] text-white/30">
+            <Bot size={32} className="text-shell-text-tertiary" aria-hidden="true" />
+            <p className="text-sm font-medium text-shell-text-secondary">No messages yet</p>
+            <p className="text-[12px] text-shell-text-tertiary">
               Agent coordination will appear here.
             </p>
           </div>
         ) : (
-          <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-4">
             {messages.map((m) => (
-              <div key={m.id} className="flex flex-col gap-0.5">
-                <div className="flex items-baseline gap-2">
-                  <span className="text-[13px] font-semibold text-white/85 truncate">
-                    {m.from}
-                  </span>
-                  <span className="text-[10px] text-white/30 tabular-nums shrink-0">
-                    {busRelativeTime(m.ts, nowMs)}
-                  </span>
-                </div>
-                <div className="text-[13px] text-white/75 whitespace-pre-wrap break-words">
-                  {m.body}
+              <div key={m.id} className="flex gap-3">
+                <span className="shrink-0 grid place-items-center w-9 h-9 rounded-[11px] bg-accent-soft border border-accent-line text-accent-strong">
+                  <Bot size={16} aria-hidden />
+                </span>
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-baseline gap-2 mb-0.5">
+                    <span className="text-[13.5px] font-bold tracking-tight text-shell-text truncate">
+                      {m.from}
+                    </span>
+                    <span className="text-[10.5px] text-accent-strong font-semibold shrink-0">@{m.from}</span>
+                    <span className="text-[10.5px] text-shell-text-tertiary tabular-nums shrink-0">
+                      {busRelativeTime(m.ts, nowMs)}
+                    </span>
+                  </div>
+                  <div className="text-[14px] leading-[1.5] text-shell-text whitespace-pre-wrap break-words">
+                    {m.body}
+                  </div>
                 </div>
               </div>
             ))}
@@ -277,13 +296,19 @@ export function A2aBusMessageView({ channel }: { channel: string }) {
         )}
       </div>
 
-      {/* read-only footer. Bottom inset keeps it clear of the phone home
-          indicator / dock edge; env() is 0 on desktop so layout is unchanged. */}
+      {/* read-only footer — tinted accent banner, no composer. Bottom inset
+          keeps it clear of the phone home indicator / dock edge; env() is 0 on
+          desktop so layout is unchanged. */}
       <div
-        className="px-4 py-2 border-t border-white/[0.06] text-[11px] text-white/35 shrink-0"
-        style={{ paddingBottom: "calc(0.5rem + env(safe-area-inset-bottom, 0px))" }}
+        className="flex items-center gap-2.5 px-4 py-2.5 border-t border-shell-border bg-accent-soft text-[12px] text-shell-text-secondary shrink-0"
+        style={{ paddingBottom: "calc(0.625rem + env(safe-area-inset-bottom, 0px))" }}
       >
-        Read-only. The coordination bus is managed by the agents.
+        <Lock size={14} aria-hidden="true" className="shrink-0 text-accent-strong" />
+        <span>
+          <span className="font-semibold text-accent-strong">Read-only.</span>{" "}
+          The coordination bus is managed by the agents. Mention{" "}
+          <code className="font-mono text-[11.5px]">@slug</code> in a project channel to hand off.
+        </span>
       </div>
     </div>
   );

--- a/desktop/src/apps/chat/A2aBusPanel.tsx
+++ b/desktop/src/apps/chat/A2aBusPanel.tsx
@@ -278,10 +278,9 @@ export function A2aBusMessageView({ channel }: { channel: string }) {
                 </span>
                 <div className="min-w-0 flex-1">
                   <div className="flex items-baseline gap-2 mb-0.5">
-                    <span className="text-[13.5px] font-bold tracking-tight text-shell-text truncate">
+                    <span className="text-[13.5px] font-bold tracking-tight text-accent-strong truncate">
                       {m.from}
                     </span>
-                    <span className="text-[10.5px] text-accent-strong font-semibold shrink-0">@{m.from}</span>
                     <span className="text-[10.5px] text-shell-text-tertiary tabular-nums shrink-0">
                       {busRelativeTime(m.ts, nowMs)}
                     </span>

--- a/desktop/src/theme/theme-config.ts
+++ b/desktop/src/theme/theme-config.ts
@@ -14,6 +14,8 @@ export const ALLOWED_TOKENS = new Set<string>([
   "--color-shell-text","--color-shell-text-secondary","--color-shell-text-tertiary",
   "--color-traffic-close","--color-traffic-minimize","--color-traffic-maximize",
   "--color-accent","--color-accent-glow",
+  "--color-accent-soft","--color-accent-line","--color-accent-strong",
+  "--color-unread","--color-bubble-self",
   "--color-dock-bg","--color-dock-border","--color-topbar-bg",
   "--color-snap-preview","--color-snap-border",
   "--spacing-topbar-h","--spacing-dock-h","--spacing-dock-padding",

--- a/desktop/src/theme/tokens.css
+++ b/desktop/src/theme/tokens.css
@@ -26,6 +26,14 @@
   /* Accent — cool neutral grey, no purple/indigo */
   --color-accent: #8b92a3;
   --color-accent-glow: rgba(139, 146, 163, 0.3);
+  /* Slate accent fills — tinted surfaces + hairlines for accented UI
+     (Messages thread bubbles, the read-only Coordination Bus rail).
+     Restrained slate, never purple. The unread badge is a slate-blue. */
+  --color-accent-soft: rgba(139, 146, 163, 0.16);
+  --color-accent-line: rgba(139, 146, 163, 0.38);
+  --color-accent-strong: #c3c8d4;
+  --color-unread: #5b8def;
+  --color-bubble-self: rgba(139, 146, 163, 0.14);
 
   /* Dock + top bar — neutral graphite frosted chrome */
   --color-dock-bg: rgba(29, 29, 31, 0.92);
@@ -93,6 +101,18 @@
 :root[data-scheme="light"] [class~="text-white/25"] { color: rgba(0, 0, 0, 0.40); }
 :root[data-scheme="light"] [class~="text-white/20"] { color: rgba(0, 0, 0, 0.40); }
 :root[data-scheme="light"] [class~="text-white/15"] { color: rgba(0, 0, 0, 0.38); }
+
+/* Slate accent fills — light-scheme values (mirror the approved Messages
+   mockup): a touch cooler/darker so tinted surfaces and the unread badge
+   read correctly on the light graphite background. */
+:root[data-scheme="light"] {
+  --color-accent: #6b7280;
+  --color-accent-soft: rgba(107, 114, 128, 0.13);
+  --color-accent-line: rgba(107, 114, 128, 0.34);
+  --color-accent-strong: #4b5160;
+  --color-unread: #3b6fd4;
+  --color-bubble-self: rgba(107, 114, 128, 0.12);
+}
 
 /* Hover overlays: re-assert the inverted fill on :hover so the affordance
    does not flatten under the base-state override. */

--- a/tinyagentos/themes/schema.py
+++ b/tinyagentos/themes/schema.py
@@ -11,6 +11,8 @@ _COLOR_TOKENS = {
     "--color-shell-text", "--color-shell-text-secondary", "--color-shell-text-tertiary",
     "--color-traffic-close", "--color-traffic-minimize", "--color-traffic-maximize",
     "--color-accent", "--color-accent-glow",
+    "--color-accent-soft", "--color-accent-line", "--color-accent-strong",
+    "--color-unread", "--color-bubble-self",
     "--color-dock-bg", "--color-dock-border", "--color-topbar-bg",
     "--color-snap-preview", "--color-snap-border",
 }


### PR DESCRIPTION
Reskins the Messages app to the approved Store/Images design bar (Jay signed off on the static mockup). This is a visual reskin, not a behavior change. All existing functionality is preserved: project-scoped channels, direct messages, topic and group channels, internal a2a handoff channels, the read-only Coordination Bus view, the composer, message threads, and the mobile split view.

What changed:

Lifted the slate accent and graphite-glass DNA from the mockup into the real React tree. The Coordination Bus now reads as its own protected rail in the sidebar, a tinted accent-soft container with an accent hairline, radio-glyph avatar tiles, and an RO lock marker on each channel. Its detail pane gets the same treatment with avatar message rows and a tinted read-only banner in place of a composer. Desktop sidebar channel rows became rounded rows with avatar tiles (agent avatar for DMs, accent glyph for a2a, neutral glyph for topics and groups), matching the mockup hierarchy. Agent name styling, the Agent badge, reactions, the unread badge, the prefill banner, the streaming dots, the scroll-to-bottom pill, the emoji popover, and the create-channel modals all moved to the slate accent and shell tokens.

Tokens:

Added five shared semantic accent tokens to theme/tokens.css (accent-soft, accent-line, accent-strong, unread as a slate-blue not purple, and bubble-self) with light-scheme overrides that mirror the mockup. No hardcoded hex was introduced in the app components. The accent is slate throughout, no purple.

Theme and mobile:

Correct in both dark and light. At 390px the sidebar collapses to the thread via the existing MobileSplitView, the composer clears the dock through env(safe-area-inset-bottom), and there is no horizontal overflow. The recently merged A2A bus view and the mobile safe-area handling are untouched at the behavior level.

Verification:

tsc clean. Build succeeds. The new utility classes compile to real CSS in both schemes. Chat unit tests pass (the only failing tests in the suite are pre-existing AgentsApp failures unrelated to this change).