### PR TITLE
feat(deploy): resolve agent-granted secrets into env at deploy

### DIFF
--- a/tests/test_deploy_secrets.py
+++ b/tests/test_deploy_secrets.py
@@ -85,6 +85,35 @@ class TestDeploySecretsInjection:
         assert env["LITELLM_API_KEY"] != "evil-override"
 
     @pytest.mark.asyncio
+    async def test_secret_to_secret_collision_keeps_first_and_warns(self, tmp_path, caplog):
+        # "my-token" and "my_token" both sanitize to MY_TOKEN (a non-platform
+        # env name). The deterministic winner is the name that sorts first
+        # ("my-token"); the other is skipped rather than silently overwriting
+        # the injected value.
+        assert _secret_env_name("my-token") == _secret_env_name("my_token") == "MY_TOKEN"
+        store = FakeSecretsStore([
+            {"name": "my_token", "value": "second"},
+            {"name": "my-token", "value": "first"},
+        ])
+        req = _req(data_dir=tmp_path, secrets_store=store)
+        with caplog.at_level("WARNING"):
+            env = await _run_deploy(req, tmp_path)
+
+        # Deterministic first winner kept; colliding value never applied.
+        assert env["MY_TOKEN"] == "first"
+        assert env["MY_TOKEN"] != "second"
+
+        # Warning names both secrets and the env var; never logs a value.
+        collision_warnings = [
+            r.getMessage() for r in caplog.records
+            if r.levelname == "WARNING" and "MY_TOKEN" in r.getMessage()
+        ]
+        assert collision_warnings, "expected a collision warning"
+        msg = collision_warnings[-1]
+        assert "my-token" in msg and "my_token" in msg
+        assert "first" not in msg and "second" not in msg
+
+    @pytest.mark.asyncio
     async def test_no_secrets_store_behaves_as_before(self, tmp_path):
         req = _req(data_dir=tmp_path)  # secrets_store defaults to None
         env = await _run_deploy(req, tmp_path)

--- a/tests/test_deploy_secrets.py
+++ b/tests/test_deploy_secrets.py
@@ -1,0 +1,94 @@
+from pathlib import Path
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from tinyagentos.deployer import deploy_agent, DeployRequest, _secret_env_name
+
+
+def _req(**overrides) -> DeployRequest:
+    defaults = dict(
+        name="test",
+        framework="smolagents",
+        model=None,
+        data_dir=Path("/tmp/taos-test-data"),
+    )
+    defaults.update(overrides)
+    return DeployRequest(**defaults)
+
+
+class FakeSecretsStore:
+    """Minimal stand-in for SecretsStore.get_agent_secrets."""
+
+    def __init__(self, secrets):
+        self._secrets = secrets
+        self.calls = []
+
+    async def get_agent_secrets(self, agent_name):
+        self.calls.append(agent_name)
+        return list(self._secrets)
+
+
+async def _run_deploy(req, tmp_path):
+    async def mock_exec(name, cmd, **kwargs):
+        if "hostname -I" in " ".join(cmd):
+            return (0, "10.0.0.5")
+        return (0, "ok")
+
+    with patch("tinyagentos.deployer.create_container", new_callable=AsyncMock) as mock_create, \
+         patch("tinyagentos.deployer.exec_in_container", side_effect=mock_exec), \
+         patch("tinyagentos.deployer.push_file", new_callable=AsyncMock, return_value=(0, "")), \
+         patch("tinyagentos.deployer.add_proxy_device", new_callable=AsyncMock, return_value={"success": True, "output": ""}):
+        mock_create.return_value = {"success": True, "name": "taos-agent-test"}
+        result = await deploy_agent(req)
+        assert result["success"] is True
+        return mock_create.call_args.kwargs["env"]
+
+
+class TestSecretEnvName:
+    def test_exact_passthrough(self):
+        assert _secret_env_name("OPENROUTER_API_KEY") == "OPENROUTER_API_KEY"
+
+    def test_lowercase_and_spaces(self):
+        assert _secret_env_name("my secret 2") == "MY_SECRET_2"
+
+    def test_special_chars(self):
+        assert _secret_env_name("api-key.v1") == "API_KEY_V1"
+
+    def test_leading_digit_prefixed(self):
+        assert _secret_env_name("1password") == "_1PASSWORD"
+
+
+class TestDeploySecretsInjection:
+    @pytest.mark.asyncio
+    async def test_injects_granted_secrets(self, tmp_path):
+        store = FakeSecretsStore([
+            {"name": "OPENROUTER_API_KEY", "value": "sk-xxx"},
+            {"name": "my secret 2", "value": "v2"},
+        ])
+        req = _req(data_dir=tmp_path, secrets_store=store)
+        env = await _run_deploy(req, tmp_path)
+
+        assert env["OPENROUTER_API_KEY"] == "sk-xxx"
+        assert env["MY_SECRET_2"] == "v2"
+        assert store.calls == ["test"]
+
+    @pytest.mark.asyncio
+    async def test_collision_does_not_clobber_platform_var(self, tmp_path):
+        # LITELLM_API_KEY is a platform var the deployer always sets (default "").
+        store = FakeSecretsStore([
+            {"name": "LITELLM_API_KEY", "value": "evil-override"},
+        ])
+        req = _req(data_dir=tmp_path, secrets_store=store)
+        env = await _run_deploy(req, tmp_path)
+
+        assert env["LITELLM_API_KEY"] != "evil-override"
+
+    @pytest.mark.asyncio
+    async def test_no_secrets_store_behaves_as_before(self, tmp_path):
+        req = _req(data_dir=tmp_path)  # secrets_store defaults to None
+        env = await _run_deploy(req, tmp_path)
+
+        # No injected secret; platform vars still present.
+        assert env["TAOS_AGENT_NAME"] == "test"
+        assert "OPENROUTER_API_KEY" not in env

--- a/tinyagentos/deployer.py
+++ b/tinyagentos/deployer.py
@@ -294,16 +294,35 @@ async def deploy_agent(req: DeployRequest) -> dict:
     if req.secrets_store is not None:
         agent_secrets = await req.secrets_store.get_agent_secrets(req.name)
         injected: list[str] = []
-        for secret in agent_secrets:
+        # Snapshot the platform var names set above so injecting a secret does
+        # not make a later secret look like it collides with a platform var.
+        platform_vars = set(env)
+        # Track which env name each granted secret claimed so two distinct
+        # secret names that sanitize to the same identifier (e.g. "api-key"
+        # and "api_key" both map to API_KEY) do not silently overwrite each
+        # other. Sort by secret name for a deterministic winner: the first
+        # name keeps the env var, the colliding one is skipped with a warning.
+        claimed_by: dict[str, str] = {}
+        for secret in sorted(agent_secrets, key=lambda s: s["name"]):
             env_name = _secret_env_name(secret["name"])
-            if env_name in env:
+            if env_name in platform_vars:
                 logger.warning(
                     "Deploy %s: secret %r maps to env %s which is already a "
                     "platform variable — skipping to avoid clobbering it",
                     req.name, secret["name"], env_name,
                 )
                 continue
+            if env_name in claimed_by:
+                logger.warning(
+                    "Deploy %s: secrets %r and %r both map to env %s; "
+                    "keeping %r and skipping %r (rename one to resolve the "
+                    "collision)",
+                    req.name, claimed_by[env_name], secret["name"], env_name,
+                    claimed_by[env_name], secret["name"],
+                )
+                continue
             env[env_name] = secret["value"]
+            claimed_by[env_name] = secret["name"]
             injected.append(env_name)
         if injected:
             logger.info(

--- a/tinyagentos/deployer.py
+++ b/tinyagentos/deployer.py
@@ -16,9 +16,14 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import secrets
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tinyagentos.secrets import SecretsStore
 
 from tinyagentos.agent_image import BASE_IMAGE_ALIAS, is_image_present
 from tinyagentos.containers import (
@@ -69,6 +74,21 @@ def _explain_container_failure(raw_error: object) -> str:
             f"Underlying error: {text}"
         )
     return f"Container creation failed: {text}"
+
+def _secret_env_name(name: str) -> str:
+    """Sanitize a secret name into a valid POSIX env identifier.
+
+    Uppercase, replace any char outside [A-Z0-9_] with ``_``, and prefix an
+    underscore when the result starts with a digit (env names can't start
+    with one). A secret literally named ``OPENROUTER_API_KEY`` therefore maps
+    to env ``OPENROUTER_API_KEY`` exactly, which is what external frameworks
+    (e.g. Hermes) expect.
+    """
+    sanitized = re.sub(r"[^A-Z0-9_]", "_", name.upper())
+    if sanitized and sanitized[0].isdigit():
+        sanitized = "_" + sanitized
+    return sanitized
+
 
 _TAOSMD_BEGIN = "<!-- taosmd:rules-begin -->"
 _TAOSMD_END = "<!-- taosmd:rules-end -->"
@@ -129,6 +149,11 @@ class DeployRequest:
     # Per §10.10: default 40 GiB rootfs quota. Overridable per-agent at
     # deploy time. None disables quota (unlimited, e.g. for dev/test).
     root_size_gib: int = 40
+    # Optional resolver for agent-granted secrets. When set, deploy_agent
+    # calls ``get_agent_secrets(name)`` and injects each granted secret into
+    # the container environment. Optional (None) so existing callers/tests
+    # are unaffected. Typed loosely to avoid a runtime import cycle.
+    secrets_store: "SecretsStore | None" = None
 
 
 async def deploy_agent(req: DeployRequest) -> dict:
@@ -259,6 +284,32 @@ async def deploy_agent(req: DeployRequest) -> dict:
         env["OPENAI_API_KEY"] = ""
     if "LITELLM_API_KEY" not in env:
         env["LITELLM_API_KEY"] = ""
+
+    # Agent-granted secrets — injected as env vars so frameworks pick them up
+    # at startup (e.g. OPENROUTER_API_KEY for Hermes). Each secret name is
+    # sanitized to a POSIX env identifier and injected with NO extra prefix.
+    # Collision safety: never overwrite a platform var the deployer already
+    # set (TAOS_*/LITELLM_*/OPENAI_*/bridge) — a user secret must not be able
+    # to clobber those. Secret VALUES are never logged.
+    if req.secrets_store is not None:
+        agent_secrets = await req.secrets_store.get_agent_secrets(req.name)
+        injected: list[str] = []
+        for secret in agent_secrets:
+            env_name = _secret_env_name(secret["name"])
+            if env_name in env:
+                logger.warning(
+                    "Deploy %s: secret %r maps to env %s which is already a "
+                    "platform variable — skipping to avoid clobbering it",
+                    req.name, secret["name"], env_name,
+                )
+                continue
+            env[env_name] = secret["value"]
+            injected.append(env_name)
+        if injected:
+            logger.info(
+                "Deploy %s: injected %d agent secret(s): %s",
+                req.name, len(injected), ", ".join(injected),
+            )
 
     # Pre-built base image fast-path — see tinyagentos/agent_image.py.
     # When the cached image is imported locally we launch from it and

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -555,6 +555,7 @@ async def deploy_agent_endpoint(request: Request, body: DeployAgentRequest):
         from tinyagentos.deployer import deploy_agent, DeployRequest
         data_dir = request.app.state.data_dir
         llm_proxy = getattr(request.app.state, "llm_proxy", None)
+        secrets_store = getattr(request.app.state, "secrets", None)
 
         async def _background_deploy():
             try:
@@ -572,6 +573,7 @@ async def deploy_agent_endpoint(request: Request, body: DeployAgentRequest):
                         "registry": request.app.state.registry,
                     },
                     can_read_user_memory=body.can_read_user_memory,
+                    secrets_store=secrets_store,
                 ))
                 agent = find_agent(config, body.name)
                 if result.get("success"):


### PR DESCRIPTION
## The gap

When an agent is deployed, `deploy_agent` builds the container environment with platform variables (TAOS_AGENT_NAME, TAOS_MODEL, LITELLM_API_KEY, OPENAI_API_KEY, bridge URLs, and so on) but never injected the secrets a user had granted that agent through the Secrets app per-agent allowlist. As a result, external frameworks such as Hermes that read provider keys from the environment (for example OPENROUTER_API_KEY) found nothing, even after the operator granted the secret. This is a migration prerequisite.

## What changed

`DeployRequest` gains an optional `secrets_store` field (defaults to None, typed under TYPE_CHECKING to avoid a runtime import cycle), so existing callers and tests are unaffected. After the platform env vars are set and before the container is created, `deploy_agent` now calls `get_agent_secrets(name)` on the store when one is provided and injects each granted secret into the container environment. The deploy route passes `request.app.state.secrets` in, guarded with getattr so contexts without a secrets store still default to None.

## Env naming rule

Each secret name is sanitized to a valid POSIX env identifier by a small `_secret_env_name` helper: uppercase, replace any character outside [A-Z0-9_] with an underscore, and prefix an underscore when the result would start with a digit. No extra prefix is added, so a secret named `OPENROUTER_API_KEY` resolves to env `OPENROUTER_API_KEY` exactly, which is what external frameworks expect. A secret named `my secret 2` becomes `MY_SECRET_2`.

## Collision safety

A user secret can never clobber a platform variable. If a secret's sanitized name is already a key in the env dict (the deployer sets LITELLM_API_KEY, OPENAI_API_KEY, the TAOS_ family, bridge vars, and so on before this step), the secret is skipped and a warning is logged naming the secret. The count of injected secrets is logged at info, by name only.

## Secrets are never logged

Values are never written to any log line. Only sanitized env names and counts appear in logs.

## Tests

`tests/test_deploy_secrets.py` covers the env naming rule (passthrough, lowercasing, special chars, leading digit), injection of granted secrets into the create_container env, the collision case where a secret named LITELLM_API_KEY does not overwrite the platform value, and that deploy with no secrets store behaves exactly as before. `tests/test_deploy_secrets.py` plus `tests/test_deployer.py` are green (55 passed), and `create_app()` constructs cleanly.

Scope is kept tight to deployer.py and routes/agents.py plus the new test file. The Secrets store, the Secrets app UI, and install scripts are untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for injecting secrets into agent container deployments as environment variables
  * Automatic secret name sanitization with collision protection to preserve platform variables

* **Tests**
  * Added comprehensive test suite for secret injection functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->