### PR TITLE
fix(github): issue metadata date + view-wide escape-to-back

### DIFF
--- a/desktop/src/apps/GitHubApp.tsx
+++ b/desktop/src/apps/GitHubApp.tsx
@@ -268,6 +268,24 @@ export function GitHubApp({ windowId: _windowId }: { windowId: string }) {
     setDetailReleases([]);
   }, []);
 
+  /* Escape returns to the list from anywhere in an open detail view.
+     Skips list view (no detail open) and editable targets (inputs,
+     textareas, contentEditable) so it never hijacks closing a field. */
+  useEffect(() => {
+    if (!detail) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      const target = e.target as HTMLElement | null;
+      if (target) {
+        const tag = target.tagName;
+        if (tag === "INPUT" || tag === "TEXTAREA" || target.isContentEditable) return;
+      }
+      goBack();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [detail, goBack]);
+
   /* ---------- selectedId for MobileSplitView ---------- */
   const selectedId = useMemo((): string | null => {
     if (!detail) return null;
@@ -651,7 +669,6 @@ export function GitHubApp({ windowId: _windowId }: { windowId: string }) {
                 type="button"
                 className={styles.back}
                 onClick={goBack}
-                onKeyDown={(e) => e.key === "Escape" && goBack()}
                 aria-label="Back to list"
               >
                 <ChevronLeft size={14} aria-hidden="true" />
@@ -762,7 +779,6 @@ export function GitHubApp({ windowId: _windowId }: { windowId: string }) {
                 type="button"
                 className={styles.back}
                 onClick={goBack}
-                onKeyDown={(e) => e.key === "Escape" && goBack()}
                 aria-label="Back to list"
               >
                 <ChevronLeft size={14} aria-hidden="true" />
@@ -848,7 +864,7 @@ export function GitHubApp({ windowId: _windowId }: { windowId: string }) {
                     { label: "Author", value: issue.author },
                     { label: "Repo", value: issue.repo },
                     { label: "Type", value: issue.is_pull_request ? "Pull Request" : "Issue" },
-                    { label: "Created", value: issue.created_at },
+                    { label: "Created", value: formatDate(issue.created_at) },
                   ].map(({ label, value }) => (
                     <div key={label} className={styles.metaRow}>
                       <span className={styles.metaKey}>{label}</span>
@@ -907,7 +923,6 @@ export function GitHubApp({ windowId: _windowId }: { windowId: string }) {
                 type="button"
                 className={styles.back}
                 onClick={goBack}
-                onKeyDown={(e) => e.key === "Escape" && goBack()}
                 aria-label="Back to list"
               >
                 <ChevronLeft size={14} aria-hidden="true" />


### PR DESCRIPTION
Follow-up to two quality findings in the GitHub app detail view (already merged to dev).

First, the issue detail Metadata tab rendered issue.created_at as a raw ISO string. It now passes through the existing formatDate helper used everywhere else in the app, so the Created row reads like the rest of the dates (relative for recent items, locale date otherwise).

Second, Escape-to-go-back was wired as an onKeyDown handler on each back button, so it only worked while that button was focused. It is now a window keydown listener registered by a useEffect that runs only while a detail target is open. It ignores Escape when an input, textarea, or contentEditable element is focused so it never hijacks closing a field, and it is inactive on the list view. The redundant per-button onKeyDown handlers were removed to avoid double-handling.

Surgical change to GitHubApp.tsx only. No new motion. tsc clean, build passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added global Escape key navigation to exit detail views, with intelligent handling to avoid interference with text input fields.
  * Issue detail view now displays creation date in human-readable format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->