### PR TITLE
feat(apps): Chess/Crosswords/Terminal chrome polish

### DIFF
--- a/desktop/src/apps/ChessApp.tsx
+++ b/desktop/src/apps/ChessApp.tsx
@@ -236,9 +236,9 @@ export function ChessApp({ windowId: _windowId }: { windowId: string }) {
       style={{
         display: "flex",
         height: "100%",
-        background: "#1a1a2e",
-        color: "#e0e0e0",
-        fontFamily: "'Segoe UI', system-ui, sans-serif",
+        background: "var(--color-shell-bg)",
+        color: "var(--color-shell-text)",
+        fontFamily: "system-ui, -apple-system, 'Segoe UI', sans-serif",
         overflow: "hidden",
       }}
     >
@@ -260,7 +260,11 @@ export function ChessApp({ windowId: _windowId }: { windowId: string }) {
             fontSize: 16,
             fontWeight: 600,
             marginBottom: 10,
-            color: isCheckmate ? "#ff6b6b" : isCheck ? "#ffa726" : "#e0e0e0",
+            color: isCheckmate
+              ? "var(--color-traffic-close)"
+              : isCheck
+                ? "var(--color-traffic-minimize)"
+                : "var(--color-shell-text)",
           }}
           role="status"
           aria-live="polite"
@@ -362,10 +366,10 @@ export function ChessApp({ windowId: _windowId }: { windowId: string }) {
             aria-label="Game mode"
             style={{
               padding: "6px 10px",
-              borderRadius: 4,
-              border: "1px solid #444",
-              background: "#2a2a3e",
-              color: "#e0e0e0",
+              borderRadius: 6,
+              border: "1px solid var(--color-shell-border-strong)",
+              background: "var(--color-shell-surface)",
+              color: "var(--color-shell-text)",
               fontSize: 13,
               cursor: "pointer",
             }}
@@ -384,10 +388,10 @@ export function ChessApp({ windowId: _windowId }: { windowId: string }) {
                 aria-label="Select agent opponent"
                 style={{
                   padding: "6px 10px",
-                  borderRadius: 4,
-                  border: "1px solid #444",
-                  background: "#2a2a3e",
-                  color: "#e0e0e0",
+                  borderRadius: 6,
+                  border: "1px solid var(--color-shell-border-strong)",
+                  background: "var(--color-shell-surface)",
+                  color: "var(--color-shell-text)",
                   fontSize: 13,
                   cursor: "pointer",
                   maxWidth: 160,
@@ -403,10 +407,10 @@ export function ChessApp({ windowId: _windowId }: { windowId: string }) {
               <span
                 style={{
                   padding: "6px 10px",
-                  borderRadius: 4,
-                  border: "1px dashed #444",
-                  background: "#201a1a",
-                  color: "#999",
+                  borderRadius: 6,
+                  border: "1px dashed var(--color-shell-border-strong)",
+                  background: "var(--color-shell-surface)",
+                  color: "var(--color-shell-text-secondary)",
                   fontSize: 12,
                   fontStyle: "italic",
                 }}
@@ -421,10 +425,10 @@ export function ChessApp({ windowId: _windowId }: { windowId: string }) {
             aria-label="New game"
             style={{
               padding: "6px 14px",
-              borderRadius: 4,
-              border: "1px solid #444",
-              background: "#2a2a3e",
-              color: "#e0e0e0",
+              borderRadius: 6,
+              border: "1px solid var(--color-shell-border-strong)",
+              background: "var(--color-shell-surface)",
+              color: "var(--color-shell-text)",
               fontSize: 13,
               cursor: "pointer",
             }}
@@ -437,10 +441,13 @@ export function ChessApp({ windowId: _windowId }: { windowId: string }) {
             aria-label="Undo move"
             style={{
               padding: "6px 14px",
-              borderRadius: 4,
-              border: "1px solid #444",
-              background: "#2a2a3e",
-              color: history.length === 0 || agentThinking ? "#666" : "#e0e0e0",
+              borderRadius: 6,
+              border: "1px solid var(--color-shell-border-strong)",
+              background: "var(--color-shell-surface)",
+              color:
+                history.length === 0 || agentThinking
+                  ? "var(--color-shell-text-tertiary)"
+                  : "var(--color-shell-text)",
               fontSize: 13,
               cursor: history.length === 0 || agentThinking ? "default" : "pointer",
             }}
@@ -454,10 +461,10 @@ export function ChessApp({ windowId: _windowId }: { windowId: string }) {
       <div
         style={{
           width: 180,
-          borderLeft: "1px solid #333",
+          borderLeft: "1px solid var(--color-shell-border)",
           display: "flex",
           flexDirection: "column",
-          background: "#16162a",
+          background: "var(--color-shell-bg-deep)",
         }}
       >
         <div
@@ -465,8 +472,8 @@ export function ChessApp({ windowId: _windowId }: { windowId: string }) {
             padding: "10px 12px",
             fontSize: 13,
             fontWeight: 600,
-            borderBottom: "1px solid #333",
-            color: "#aaa",
+            borderBottom: "1px solid var(--color-shell-border)",
+            color: "var(--color-shell-text-secondary)",
           }}
         >
           Moves
@@ -483,31 +490,45 @@ export function ChessApp({ windowId: _windowId }: { windowId: string }) {
           aria-label="Move history"
         >
           {history.length === 0 && (
-            <span style={{ color: "#555", fontStyle: "italic" }}>No moves yet</span>
+            <span style={{ color: "var(--color-shell-text-tertiary)", fontStyle: "italic" }}>
+              No moves yet
+            </span>
           )}
           {Array.from({ length: Math.ceil(history.length / 2) }).map((_, i) => (
             <div key={i} style={{ display: "flex", gap: 6 }}>
-              <span style={{ color: "#666", minWidth: 24 }}>{i + 1}.</span>
-              <span style={{ color: "#ddd", minWidth: 40 }}>{history[i * 2]}</span>
-              <span style={{ color: "#aaa" }}>{history[i * 2 + 1] ?? ""}</span>
+              <span style={{ color: "var(--color-shell-text-tertiary)", minWidth: 24 }}>
+                {i + 1}.
+              </span>
+              <span style={{ color: "var(--color-shell-text)", minWidth: 40 }}>
+                {history[i * 2]}
+              </span>
+              <span style={{ color: "var(--color-shell-text-secondary)" }}>
+                {history[i * 2 + 1] ?? ""}
+              </span>
             </div>
           ))}
         </div>
         {mode === "vs-agent" && agentCommentary && (
           <div
             style={{
-              borderTop: "1px solid #333",
+              borderTop: "1px solid var(--color-shell-border)",
               padding: "10px 12px",
               fontSize: 12,
-              color: "#bbb",
-              background: "#11111f",
+              color: "var(--color-shell-text)",
+              background: "var(--color-shell-surface)",
               maxHeight: 140,
               overflowY: "auto",
             }}
             role="note"
             aria-label="Agent commentary"
           >
-            <div style={{ color: "#888", fontWeight: 600, marginBottom: 4 }}>
+            <div
+              style={{
+                color: "var(--color-shell-text-secondary)",
+                fontWeight: 600,
+                marginBottom: 4,
+              }}
+            >
               {selectedAgent || "Agent"}
             </div>
             <div style={{ whiteSpace: "pre-wrap", lineHeight: 1.4 }}>

--- a/desktop/src/apps/CrosswordsApp.tsx
+++ b/desktop/src/apps/CrosswordsApp.tsx
@@ -297,9 +297,9 @@ export function CrosswordsApp({ windowId: _windowId }: { windowId: string }) {
         display: "flex",
         flexDirection: "column",
         height: "100%",
-        background: "#0f0f1a",
-        color: "#e5e7eb",
-        fontFamily: "system-ui, sans-serif",
+        background: "var(--color-shell-bg)",
+        color: "var(--color-shell-text)",
+        fontFamily: "system-ui, -apple-system, sans-serif",
         padding: 16,
         gap: 12,
         overflow: "auto",
@@ -428,7 +428,7 @@ export function CrosswordsApp({ windowId: _windowId }: { windowId: string }) {
                 textTransform: "uppercase",
                 letterSpacing: 1,
                 marginBottom: 8,
-                color: "#9ca3af",
+                color: "var(--color-shell-text-secondary)",
               }}
             >
               Across
@@ -469,7 +469,7 @@ export function CrosswordsApp({ windowId: _windowId }: { windowId: string }) {
                 textTransform: "uppercase",
                 letterSpacing: 1,
                 marginBottom: 8,
-                color: "#9ca3af",
+                color: "var(--color-shell-text-secondary)",
               }}
             >
               Down
@@ -509,8 +509,8 @@ export function CrosswordsApp({ windowId: _windowId }: { windowId: string }) {
         <div
           style={{
             fontSize: 13,
-            color: "#9ca3af",
-            borderTop: "1px solid #1f2937",
+            color: "var(--color-shell-text-secondary)",
+            borderTop: "1px solid var(--color-shell-border)",
             paddingTop: 8,
           }}
         >
@@ -531,9 +531,9 @@ export function CrosswordsApp({ windowId: _windowId }: { windowId: string }) {
 const btnStyle: React.CSSProperties = {
   padding: "6px 14px",
   borderRadius: 6,
-  border: "1px solid #374151",
-  background: "#1f2937",
-  color: "#e5e7eb",
+  border: "1px solid var(--color-shell-border-strong)",
+  background: "var(--color-shell-surface)",
+  color: "var(--color-shell-text)",
   fontSize: 13,
   fontWeight: 600,
   cursor: "pointer",


### PR DESCRIPTION
Judgment pass on the chrome around three game/terminal apps, bringing the toolbars, side panels, buttons and status text onto the Store/Images design DNA (graphite glass, slate accent, semantic shell tokens) while leaving every legitimate domain palette intact.

## Touched

**ChessApp** chrome moved to semantic tokens: container bg/text, the move-history sidebar (bg, header, rows, empty state), the agent commentary panel, the mode/agent selects, the New Game and Undo buttons, and the no-agents note. Check/checkmate status colors now map to the traffic tokens (amber check, red mate). Board square colors, valid-move dots, piece colors are untouched.

**CrosswordsApp** chrome moved to semantic tokens: container bg/text, the Across/Down clue headers, the active-clue status bar and its top border, and the shared Check / New Puzzle button style. Grid cell states (filled/active/highlight/correct/error), blocked-cell color, the in-cell clue number, and the active-clue highlight are untouched (puzzle domain).

## Left as-is

**TerminalApp** was already on the bar: it uses the shared UI kit (Button, Card, Toolbar, Input) plus shell-token text and the slate accent for chrome, and its xterm theme is the intrinsic terminal fg/bg + ANSI 16-color palette. No change.

## Verification

- 390px: no horizontal overflow. Chess board scales via min(100%, 480px) beside the fixed 180px sidebar; crossword grid is fixed-cell and wraps under the clues with the container scrolling.
- Works in dark and light via the shell tokens and the light-scheme compatibility layer.
- tsc --noEmit clean; npm run build succeeds. No build output committed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Chess and Crosswords app styling to use CSS theme variables across UI elements including buttons, panels, and text for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->