### PR TITLE
fix(github): scope escape-to-back to the GitHub app window

### DIFF
--- a/desktop/src/apps/GitHubApp.tsx
+++ b/desktop/src/apps/GitHubApp.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import {
   Github,
   Star,
@@ -151,6 +151,10 @@ export function GitHubApp({ windowId: _windowId }: { windowId: string }) {
   const [, setView] = useState<View>("list");
   const [detail, setDetail] = useState<DetailTarget | null>(null);
 
+  /* root container ref — scopes the Escape-to-back handler to this app's
+     own subtree so it never fires while another window/app is focused */
+  const rootRef = useRef<HTMLDivElement>(null);
+
   /* ---------- sidebar state ---------- */
   const [activeSection, setActiveSection] = useState<SidebarSection>("starred");
   const [contentType, setContentType] = useState<ContentType>("repos");
@@ -270,12 +274,20 @@ export function GitHubApp({ windowId: _windowId }: { windowId: string }) {
 
   /* Escape returns to the list from anywhere in an open detail view.
      Skips list view (no detail open) and editable targets (inputs,
-     textareas, contentEditable) so it never hijacks closing a field. */
+     textareas, contentEditable) so it never hijacks closing a field.
+     Scoped to this app's own DOM subtree: taOS is a multi-window desktop,
+     so the handler must bail when focus is in another window/app. */
   useEffect(() => {
     if (!detail) return;
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key !== "Escape") return;
+      const root = rootRef.current;
+      if (!root) return;
       const target = e.target as HTMLElement | null;
+      // Only act when focus / the event originates within the GitHub app.
+      const insideApp =
+        (target ? root.contains(target) : false) || root.contains(document.activeElement);
+      if (!insideApp) return;
       if (target) {
         const tag = target.tagName;
         if (tag === "INPUT" || tag === "TEXTAREA" || target.isContentEditable) return;
@@ -1176,6 +1188,8 @@ export function GitHubApp({ windowId: _windowId }: { windowId: string }) {
 
   return (
     <div
+      ref={rootRef}
+      tabIndex={-1}
       className={`${styles.root} flex flex-col h-full min-h-0 overflow-hidden bg-shell-bg text-shell-text select-none relative`}
     >
       {/* Mobile-only toolbar — hidden when detail is shown (MobileSplitView nav handles it).


### PR DESCRIPTION
The Escape-to-go-back handler in the GitHub app registered its keydown listener on the global window whenever a detail target was open. Because taOS is a multi-window desktop, that listener fired regardless of which window was focused, so pressing Escape inside another app window wrongly triggered the GitHub app's goBack.

This scopes the handling to the GitHub app's own DOM subtree. The root container now carries a ref (and tabIndex of -1 so it sits in the focus path), and before calling goBack the handler verifies the event originated within the app by checking that the root contains the event target or document.activeElement. If focus is outside the app, it bails.

The existing guards are preserved: it still skips INPUT, TEXTAREA, and contentEditable targets, still only runs while a detail (repo, issue, or release) is open, and still cleans up on unmount or when the detail closes.

Scope: GitHubApp.tsx only. No other behavior changes. tsc --noEmit is clean and npm run build succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Escape key behavior to only trigger back navigation when interacting within the GitHub app, preventing unintended navigation when focus is elsewhere.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->