### PR TITLE
feat(images-edit): FLUX Fill quality-tier client

### DIFF
--- a/tests/test_routes_images_edit.py
+++ b/tests/test_routes_images_edit.py
@@ -1,10 +1,26 @@
 """Tests for the tier-aware image-editing routes (routes/images_edit.py)."""
+import base64
+import io
 from types import SimpleNamespace
 
+import httpx
 import pytest
+import respx
+from PIL import Image
 
 from tinyagentos.app import create_app
-from tinyagentos.routes.images_edit import _get_edit_backend
+from tinyagentos.routes.images_edit import (
+    EditRequest,
+    FluxFillClient,
+    _get_edit_backend,
+    edit_image,
+)
+
+
+def _png_b64(width=8, height=8, color=(20, 120, 200)) -> str:
+    buf = io.BytesIO()
+    Image.new("RGB", (width, height), color).save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode()
 
 
 def _backend(name, btype, priority=10):
@@ -75,3 +91,129 @@ def test_no_catalog_returns_none():
     """No live catalog (scheduler not started) → None, never raises."""
     req = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(backend_catalog=None)))
     assert _get_edit_backend(req, "upscale", "fast") is None
+
+
+# --------------------------------------------------------------------------- #
+#  FluxFillClient (A1111 img2img inpaint)                                      #
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+@respx.mock
+async def test_flux_fill_inpaint_posts_a1111_img2img():
+    """inpaint() POSTs base64 init_images + mask to /sdapi/v1/img2img and
+    decodes images[0] from the JSON response back to PNG bytes."""
+    result_b64 = _png_b64(color=(255, 0, 0))
+    route = respx.post("http://flux:7864/sdapi/v1/img2img").mock(
+        return_value=httpx.Response(200, json={"images": [result_b64]})
+    )
+
+    client = FluxFillClient("http://flux:7864")
+    out = await client.inpaint(_png_b64(), _png_b64(width=8, height=8, color=(0, 0, 0)), prompt="a cat")
+
+    assert route.called
+    sent = route.calls.last.request
+    import json
+
+    payload = json.loads(sent.content)
+    assert sent.url.path == "/sdapi/v1/img2img"
+    assert isinstance(payload["init_images"], list) and len(payload["init_images"]) == 1
+    # init_images[0] and mask are valid base64 PNGs.
+    assert Image.open(io.BytesIO(base64.b64decode(payload["init_images"][0]))).format == "PNG"
+    assert Image.open(io.BytesIO(base64.b64decode(payload["mask"]))).format == "PNG"
+    assert payload["prompt"] == "a cat"
+    assert payload["cfg_scale"] == pytest.approx(30.0)
+    # Returned bytes are the decoded result PNG.
+    assert out == base64.b64decode(result_b64)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_flux_fill_outpaint_pads_canvas():
+    """Outpaint pre-pads the init image + mask larger than the source, since
+    sd.cpp img2img does not natively grow the canvas."""
+    src_b64 = _png_b64(width=16, height=16)
+    respx.post("http://flux:7864/sdapi/v1/img2img").mock(
+        return_value=httpx.Response(200, json={"images": [_png_b64()]})
+    )
+
+    client = FluxFillClient("http://flux:7864")
+    await client.inpaint(src_b64, _png_b64(width=16, height=16, color=(0, 0, 0)), outpaint=True)
+
+    import json
+
+    payload = json.loads(respx.calls.last.request.content)
+    padded = Image.open(io.BytesIO(base64.b64decode(payload["init_images"][0])))
+    mask = Image.open(io.BytesIO(base64.b64decode(payload["mask"])))
+    assert padded.size[0] > 16 and padded.size[1] > 16
+    assert mask.size == padded.size
+    # The outpaint mask border is white (paint) and the centre is black (keep).
+    assert mask.convert("L").getpixel((0, 0)) == 255
+    assert mask.convert("L").getpixel((mask.size[0] // 2, mask.size[1] // 2)) == 0
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_flux_fill_missing_images_raises():
+    """A response without images raises, which edit_image maps to an error."""
+    respx.post("http://flux:7864/sdapi/v1/img2img").mock(
+        return_value=httpx.Response(200, json={"images": []})
+    )
+    client = FluxFillClient("http://flux:7864")
+    with pytest.raises(Exception):
+        await client.inpaint(_png_b64(), _png_b64())
+
+
+# --------------------------------------------------------------------------- #
+#  edit_image dispatch → FluxFillClient on the quality tier                    #
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+@respx.mock
+async def test_edit_image_quality_routes_to_flux_fill(tmp_path):
+    """A healthy flux-fill backend on the quality tier dispatches to
+    FluxFillClient (POST /sdapi/v1/img2img) and saves the returned bytes."""
+    # Workspace: config_path.parent/workspace/images/generated/
+    images_dir = tmp_path / "workspace" / "images" / "generated"
+    images_dir.mkdir(parents=True)
+    src_bytes = base64.b64decode(_png_b64())
+    (images_dir / "src.png").write_bytes(src_bytes)
+
+    result_b64 = _png_b64(color=(7, 8, 9))
+    route = respx.post("http://flux/sdapi/v1/img2img").mock(
+        return_value=httpx.Response(200, json={"images": [result_b64]})
+    )
+
+    catalog = _FakeCatalog({"image-editing": [_backend("flux", "flux-fill")]})
+    state = SimpleNamespace(backend_catalog=catalog, config_path=str(tmp_path / "config.json"))
+    request = SimpleNamespace(app=SimpleNamespace(state=state))
+
+    body = EditRequest(image_ref="src.png", op="inpaint", mask=_png_b64(), prompt="sky", tier="quality")
+    result = await edit_image(request, body)
+
+    assert route.called
+    assert result["status"] == "edited"
+    saved = (images_dir / result["filename"]).read_bytes()
+    assert saved == base64.b64decode(result_b64)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_edit_image_quality_falls_back_to_iopaint(tmp_path):
+    """With no flux-fill backend, the quality tier still uses iopaint
+    (POST /api/v1/inpaint), leaving the fast path untouched."""
+    images_dir = tmp_path / "workspace" / "images" / "generated"
+    images_dir.mkdir(parents=True)
+    (images_dir / "src.png").write_bytes(base64.b64decode(_png_b64()))
+
+    result_png = base64.b64decode(_png_b64(color=(1, 2, 3)))
+    route = respx.post("http://io/api/v1/inpaint").mock(
+        return_value=httpx.Response(200, content=result_png, headers={"content-type": "image/png"})
+    )
+
+    catalog = _FakeCatalog({"image-editing": [_backend("io", "iopaint")]})
+    state = SimpleNamespace(backend_catalog=catalog, config_path=str(tmp_path / "config.json"))
+    request = SimpleNamespace(app=SimpleNamespace(state=state))
+
+    body = EditRequest(image_ref="src.png", op="inpaint", mask=_png_b64(), tier="quality")
+    result = await edit_image(request, body)
+
+    assert route.called
+    assert (images_dir / result["filename"]).read_bytes() == result_png

--- a/tests/test_routes_images_edit.py
+++ b/tests/test_routes_images_edit.py
@@ -107,7 +107,7 @@ async def test_flux_fill_inpaint_posts_a1111_img2img():
     )
 
     client = FluxFillClient("http://flux:7864")
-    out = await client.inpaint(_png_b64(), _png_b64(width=8, height=8, color=(0, 0, 0)), prompt="a cat")
+    out = await client.inpaint(_png_b64(width=37, height=53), _png_b64(width=37, height=53, color=(0, 0, 0)), prompt="a cat")
 
     assert route.called
     sent = route.calls.last.request
@@ -119,6 +119,9 @@ async def test_flux_fill_inpaint_posts_a1111_img2img():
     # init_images[0] and mask are valid base64 PNGs.
     assert Image.open(io.BytesIO(base64.b64decode(payload["init_images"][0]))).format == "PNG"
     assert Image.open(io.BytesIO(base64.b64decode(payload["mask"]))).format == "PNG"
+    # width/height are pinned to the source image so the server does not fall
+    # back to a default 512x512 size and wrongly resize the result.
+    assert (payload["width"], payload["height"]) == (37, 53)
     assert payload["prompt"] == "a cat"
     assert payload["cfg_scale"] == pytest.approx(30.0)
     # Returned bytes are the decoded result PNG.
@@ -145,6 +148,8 @@ async def test_flux_fill_outpaint_pads_canvas():
     mask = Image.open(io.BytesIO(base64.b64decode(payload["mask"])))
     assert padded.size[0] > 16 and padded.size[1] > 16
     assert mask.size == padded.size
+    # width/height match the padded canvas actually sent, not the 16x16 source.
+    assert (payload["width"], payload["height"]) == padded.size
     # The outpaint mask border is white (paint) and the centre is black (keep).
     assert mask.convert("L").getpixel((0, 0)) == 255
     assert mask.convert("L").getpixel((mask.size[0] // 2, mask.size[1] // 2)) == 0

--- a/tinyagentos/routes/images_edit.py
+++ b/tinyagentos/routes/images_edit.py
@@ -283,9 +283,19 @@ class FluxFillClient:
         else:
             mask_b64 = _strip_data_uri(mask_b64)
 
+        # A1111-compatible servers (sd.cpp sd-server) fall back to a default
+        # 512x512 size when width/height are omitted, which wrongly resizes any
+        # non-512 image. Pin them to the dimensions of the image actually sent in
+        # ``init_images`` (the padded canvas in the outpaint case).
+        src_w, src_h = Image.open(
+            io.BytesIO(base64.b64decode(_strip_data_uri(image_b64)))
+        ).size
+
         payload: dict = {
             "init_images": [image_b64],
             "mask": mask_b64,
+            "width": src_w,
+            "height": src_h,
             "prompt": prompt,
             "steps": steps,
             "cfg_scale": guidance,

--- a/tinyagentos/routes/images_edit.py
+++ b/tinyagentos/routes/images_edit.py
@@ -15,6 +15,7 @@ Backends:
 from __future__ import annotations
 
 import base64
+import io
 import json
 import logging
 import time
@@ -23,6 +24,7 @@ from typing import Literal, Optional
 from uuid import uuid4
 
 import httpx
+from PIL import Image
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
@@ -197,6 +199,118 @@ class IOPaintClient:
 
 
 # --------------------------------------------------------------------------- #
+#  FLUX Fill adapter (A1111-style sd.cpp server, async httpx client)           #
+# --------------------------------------------------------------------------- #
+def _strip_data_uri(b64: str) -> str:
+    """Drop a leading ``data:image/...;base64,`` prefix if present."""
+    if b64.startswith("data:") and "," in b64:
+        return b64.split(",", 1)[1]
+    return b64
+
+
+# Fraction of the image's own size to grow each side by when outpainting.
+_OUTPAINT_MARGIN = 0.25
+
+
+class FluxFillClient:
+    """Thin async client for a FLUX.1-Fill server behind an A1111-style sd.cpp
+    HTTP API (same family as the ``sd-cpp`` image-generation backend).
+
+    Inpaint/outpaint go through ``POST /sdapi/v1/img2img`` with an A1111 inpaint
+    payload: the source goes in ``init_images``, the mask in ``mask``, and the
+    response carries a base64 PNG in ``images[0]``.
+
+    The mirror of :class:`IOPaintClient.inpaint` so ``edit_image`` can call
+    either with identical arguments.
+    """
+
+    def __init__(self, base_url: str, *, timeout: float = 300.0):
+        self.base = base_url.rstrip("/")
+        self.timeout = timeout
+
+    @staticmethod
+    def _pad_for_outpaint(image_b64: str, mask_b64: str) -> tuple[str, str]:
+        """Grow the canvas for outpaint: pad the source with edge-replicated
+        borders and build a mask whose new border is white (to be painted) and
+        whose original region is black (to be kept). Returns (image_b64, mask_b64).
+
+        sd.cpp img2img does not natively extend the canvas, so (consistent with
+        the IOPaint extender path) we pre-pad before sending.
+        """
+        src = Image.open(io.BytesIO(base64.b64decode(_strip_data_uri(image_b64)))).convert("RGB")
+        w, h = src.size
+        mx = max(1, int(round(w * _OUTPAINT_MARGIN)))
+        my = max(1, int(round(h * _OUTPAINT_MARGIN)))
+        new_w, new_h = w + 2 * mx, h + 2 * my
+
+        # Edge-replicate the source into the larger canvas so diffusion has
+        # plausible context to extend from.
+        padded = Image.new("RGB", (new_w, new_h))
+        padded.paste(src, (mx, my))
+        left = src.crop((0, 0, 1, h)).resize((mx, h))
+        right = src.crop((w - 1, 0, w, h)).resize((mx, h))
+        padded.paste(left, (0, my))
+        padded.paste(right, (mx + w, my))
+        top = padded.crop((0, my, new_w, my + 1)).resize((new_w, my))
+        bottom = padded.crop((0, my + h - 1, new_w, my + h)).resize((new_w, my))
+        padded.paste(top, (0, 0))
+        padded.paste(bottom, (0, my + h))
+
+        # White border = paint, black centre = keep.
+        mask = Image.new("L", (new_w, new_h), 255)
+        mask.paste(0, (mx, my, mx + w, my + h))
+
+        def _png_b64(img: Image.Image) -> str:
+            buf = io.BytesIO()
+            img.save(buf, format="PNG")
+            return base64.b64encode(buf.getvalue()).decode()
+
+        return _png_b64(padded), _png_b64(mask)
+
+    async def inpaint(
+        self,
+        image_b64: str,
+        mask_b64: str,
+        *,
+        prompt: str = "",
+        outpaint: bool = False,
+        steps: int = 28,
+        guidance: float = 30.0,
+        denoising_strength: float = 0.85,
+    ) -> bytes:
+        if outpaint:
+            image_b64, mask_b64 = self._pad_for_outpaint(image_b64, mask_b64)
+        else:
+            mask_b64 = _strip_data_uri(mask_b64)
+
+        payload: dict = {
+            "init_images": [image_b64],
+            "mask": mask_b64,
+            "prompt": prompt,
+            "steps": steps,
+            "cfg_scale": guidance,
+            "denoising_strength": denoising_strength,
+            # 1 = fill the masked region (vs. original/latent noise/nothing).
+            "inpainting_fill": 1,
+            # Process the masked region at full resolution for sharper fills.
+            "inpaint_full_res": True,
+            "inpaint_full_res_padding": 32,
+            # 0 = inpaint the white (masked) area, matching our mask convention.
+            "inpainting_mask_invert": 0,
+            "sampler_name": "euler_a",
+            "seed": -1,
+        }
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            resp = await client.post(f"{self.base}/sdapi/v1/img2img", json=payload)
+            resp.raise_for_status()
+            data = resp.json()
+        images = data.get("images") if isinstance(data, dict) else None
+        if not images:
+            raise RuntimeError("FLUX Fill server returned no images")
+        return base64.b64decode(_strip_data_uri(images[0]))
+
+
+# --------------------------------------------------------------------------- #
 #  Error helpers                                                               #
 # --------------------------------------------------------------------------- #
 _NO_BACKEND = {
@@ -238,21 +352,21 @@ async def edit_image(request: Request, body: EditRequest):
     if backend is None:
         return JSONResponse(_NO_BACKEND, status_code=503)
     url, backend_type, _name = backend
-    if backend_type != "iopaint":
-        # Only the IOPaint client is implemented today; flux-fill (the quality
-        # inpaint/outpaint tier) is routed by the catalog but its client is a
-        # follow-up. _get_edit_backend already falls back to iopaint when no
-        # flux-fill backend is healthy, so this only triggers if one exists.
+
+    image_b64 = base64.b64encode(source.read_bytes()).decode()
+    # flux-fill = the quality GPU diffusion tier (A1111 img2img inpaint); iopaint
+    # = the fast CPU/NPU tier (LaMa). _get_edit_backend falls back to iopaint
+    # when no flux-fill backend is healthy, so anything else is unexpected.
+    if backend_type == "flux-fill":
+        client: IOPaintClient | FluxFillClient = FluxFillClient(url)
+    elif backend_type == "iopaint":
+        client = IOPaintClient(url)
+    else:
         return JSONResponse(
-            {
-                "error": f"Edit backend '{backend_type}' has no client wired yet "
-                "(FLUX Fill pending); try the fast tier."
-            },
+            {"error": f"Edit backend '{backend_type}' has no client wired yet."},
             status_code=503,
         )
 
-    image_b64 = base64.b64encode(source.read_bytes()).decode()
-    client = IOPaintClient(url)
     try:
         result_bytes = await client.inpaint(
             image_b64,


### PR DESCRIPTION
Wires the FLUX Fill client so the Images Studio quality-tier edit backend works. Previously a chosen flux-fill backend returned a 503 (FLUX Fill pending); now it runs the edit.

FluxFillClient mirrors IOPaintClient. Its inpaint method builds an A1111-style img2img inpaint request and POSTs to /sdapi/v1/img2img on the FLUX Fill sd.cpp server (same family as the sd-cpp image-generation backend). The source goes into init_images as base64, the mask into mask, with inpainting_fill, inpaint_full_res, denoising_strength, prompt, steps, and cfg_scale from the guidance value. The response carries a base64 PNG in images[0], which is decoded and returned. A generous httpx timeout covers GPU diffusion latency.

Outpaint is handled by pre-padding the canvas before sending, consistent with how the IOPaint path grows the canvas via its extender. The source is edge-replicated into a larger image and a mask is built whose new border is white (paint) and original region is black (keep), since sd.cpp img2img does not natively extend the canvas.

In edit_image the dispatch now selects FluxFillClient for backend type flux-fill and IOPaintClient for iopaint, calling inpaint with identical arguments and saving the result exactly as before. The iopaint path is unchanged, and the existing tier fallback (flux-fill to iopaint when no flux-fill backend is healthy) still holds.

Tests extend the existing edit-backend suite: the quality tier with a healthy flux-fill backend routes to FluxFillClient and POSTs base64 init_images plus mask to /sdapi/v1/img2img, the returned bytes are saved, outpaint pads the canvas, missing images raise, and the iopaint fallback is preserved. All edit-route tests pass and create_app succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FLUX.1-Fill backend support for image editing operations with intelligent automatic backend selection.
  * Introduced outpaint functionality enabling automatic padding and canvas growth for extended image areas.

* **Tests**
  * Expanded test coverage for image editing with comprehensive backend integration tests and fallback behavior validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->