### PR TITLE
feat(catalog): FLUX Fill quality-tier backend install

### DIFF
--- a/app-catalog/services/flux-fill/manifest.yaml
+++ b/app-catalog/services/flux-fill/manifest.yaml
@@ -1,0 +1,29 @@
+id: flux-fill
+name: FLUX.1-Fill
+type: service
+category: image-runtime
+version: 1.0.0
+description: "FLUX.1-Fill quality inpaint/outpaint tier - GPU image editing via an A1111-compatible sd.cpp server. Runs on-demand on a shared NVIDIA GPU."
+homepage: https://github.com/leejet/stable-diffusion.cpp
+license: MIT
+
+requires:
+  ram_mb: 8192
+  disk_mb: 12000
+  # Deterministic high-pool slot for app_id "flux-fill" (see port_allocator).
+  # Maps host -> container 7864 (the sd-server internal listen port).
+  ports: [38298]
+
+install:
+  method: script
+  script: scripts/install-flux-fill.sh
+
+# GPU / CUDA only. The encoders run on CPU so a 12GB card fits the model with
+# headroom; smaller cards and non-CUDA hosts use the iopaint editing tier.
+hardware_tiers:
+  arm-npu-16gb: unsupported
+  arm-npu-32gb: unsupported
+  x86-cuda-8gb: unsupported
+  x86-cuda-12gb: full
+  x86-cuda-24gb: full
+  cpu-only: unsupported

--- a/scripts/install-flux-fill.sh
+++ b/scripts/install-flux-fill.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+# tinyagentos installer for the FLUX.1-Fill GPU image-edit backend (id: flux-fill)
+# ---------------------------------------------------------------------------
+# This is the QUALITY inpaint/outpaint tier for the taOS Images Studio. It runs
+# a leejet/stable-diffusion.cpp `sd-server` (A1111-compatible: serves
+# /sdapi/v1/img2img) hosting the FLUX.1-Fill-dev model on an NVIDIA GPU. The
+# config captured here was MANUALLY VERIFIED WORKING on a 12GB RTX 3060: it
+# returns a real inpainted 512px image in ~73s.
+#
+# It reuses the same CUDA image and FLUX support files as the sd-cpp generation
+# backend (taos-sdcpp:cuda, built by scripts/install-sd-cpp.sh /
+# stable-diffusion.cpp with GGML_CUDA=ON and CMAKE_CUDA_ARCHITECTURES=86). The
+# server binds a HIGH-POOL port (38298 - the deterministic slot for app_id
+# "flux-fill", computed by tinyagentos.installers.port_allocator). The
+# container's internal port stays 7864; we map host->7864.
+#
+# CRITICAL GOTCHA (do not remove --clip-on-cpu / --vae-on-cpu):
+#   The FLUX text encoders MUST run on CPU or the 12GB card OOMs at inference.
+#   With --clip-on-cpu the GPU resident is ~6.5GB, leaving headroom; WITHOUT it
+#   inference OOMs while allocating the t5 graph. This is the key reason the
+#   verified run works on a 12GB card.
+#
+# Model source (non-gated mirror):
+#   flux1-fill-dev-Q4_K_S.gguf (6.8GB) from YarvixPA/FLUX.1-Fill-dev-gguf.
+#   The official black-forest-labs / city96 repos are GATED; an operator with an
+#   accepted HF license + token can substitute the gated source by overriding
+#   TAOS_FLUX_FILL_GGUF_URL.
+#
+# Encoders + VAE (ae.safetensors, clip_l.safetensors, t5xxl-Q3_K_M.gguf) are the
+# standard FLUX support files, shared with the sd-cpp generation backend's
+# models dir. They are fetched here only if missing.
+#
+# Pinned filenames - bump together when validating a newer FLUX Fill build.
+# GPU-host ONLY: the script exits early if no CUDA GPU is detected.
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+FLUX_FILL_PORT="${TAOS_FLUX_FILL_PORT:-38298}"
+FLUX_FILL_CONTAINER="${TAOS_FLUX_FILL_CONTAINER:-taos-sdcpp-fill}"
+FLUX_FILL_IMAGE="${TAOS_FLUX_FILL_IMAGE:-taos-sdcpp:cuda}"
+MODELS_DIR="${TAOS_FLUX_FILL_MODELS_DIR:-$HOME/.cache/taos-sdcpp/models}"
+
+# Pinned model + support file names (these are the filenames the verified run used).
+FLUX_FILL_GGUF="flux1-fill-dev-Q4_K_S.gguf"
+VAE_FILE="ae.safetensors"
+CLIP_L_FILE="clip_l.safetensors"
+T5XXL_FILE="t5xxl-Q3_K_M.gguf"
+
+# Non-gated source mirrors (override the GGUF URL to use an accepted-license gated source).
+FLUX_FILL_GGUF_URL="${TAOS_FLUX_FILL_GGUF_URL:-https://huggingface.co/YarvixPA/FLUX.1-Fill-dev-gguf/resolve/main/flux1-fill-dev-Q4_K_S.gguf}"
+VAE_URL="${TAOS_FLUX_VAE_URL:-https://huggingface.co/black-forest-labs/FLUX.1-schnell/resolve/main/ae.safetensors}"
+CLIP_L_URL="${TAOS_FLUX_CLIP_L_URL:-https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/clip_l.safetensors}"
+T5XXL_URL="${TAOS_FLUX_T5XXL_URL:-https://huggingface.co/city96/t5-v1_1-xxl-encoder-gguf/resolve/main/t5-v1_1-xxl-encoder-Q3_K_M.gguf}"
+
+log() { echo -e "\033[1;34m[flux-fill]\033[0m $*"; }
+die() { echo -e "\033[1;31m[flux-fill]\033[0m $*" >&2; exit 1; }
+
+# --- GPU guard: this backend is CUDA-only -----------------------------------
+if ! command -v nvidia-smi >/dev/null 2>&1 || ! nvidia-smi >/dev/null 2>&1; then
+    die "no CUDA GPU detected (nvidia-smi unavailable) - flux-fill is the GPU quality tier and requires an NVIDIA GPU. Use the iopaint backend on CPU/ARM hosts."
+fi
+command -v docker >/dev/null 2>&1 || die "docker not found - install Docker with the NVIDIA container toolkit first"
+
+# --- idempotency: skip if the container already answers on the port ---------
+if curl -fsS --max-time 3 "http://127.0.0.1:${FLUX_FILL_PORT}/sdapi/v1/options" >/dev/null 2>&1; then
+    log "flux-fill already serving on port ${FLUX_FILL_PORT} - nothing to do"
+    exit 0
+fi
+
+# --- ensure the CUDA image exists -------------------------------------------
+# Built by the sd-cpp docker setup (GGML_CUDA=ON, CMAKE_CUDA_ARCHITECTURES=86):
+#   FROM nvidia/cuda:*-devel -> clone leejet/stable-diffusion.cpp ->
+#   cmake -DGGML_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=86 -> runtime image with
+#   sd-server + sd-cli. We do not rebuild it here; we require it to be present.
+if ! docker image inspect "$FLUX_FILL_IMAGE" >/dev/null 2>&1; then
+    die "docker image '$FLUX_FILL_IMAGE' not found - build the sd.cpp CUDA image first (see scripts/install-sd-cpp.sh / the taos-sdcpp:cuda Dockerfile: GGML_CUDA=ON, CMAKE_CUDA_ARCHITECTURES=86)"
+fi
+
+# --- fetch the model + support files (idempotent; wget -c resumes) ----------
+mkdir -p "$MODELS_DIR"
+command -v wget >/dev/null 2>&1 || die "wget not found - install wget first"
+
+fetch() {
+    local name="$1" url="$2" dest="${MODELS_DIR}/$1"
+    if [[ -s "$dest" ]]; then
+        log "$name already present - skipping download"
+        return 0
+    fi
+    log "downloading $name"
+    wget -c -O "$dest" "$url" || die "download failed for $name ($url)"
+}
+
+fetch "$FLUX_FILL_GGUF" "$FLUX_FILL_GGUF_URL"   # 6.8GB FLUX.1-Fill-dev quant
+fetch "$VAE_FILE"       "$VAE_URL"              # shared FLUX VAE
+fetch "$CLIP_L_FILE"    "$CLIP_L_URL"           # shared FLUX clip_l encoder
+fetch "$T5XXL_FILE"     "$T5XXL_URL"            # shared FLUX t5xxl encoder
+
+# --- remove any stale stopped container with our name -----------------------
+if docker ps -a --format '{{.Names}}' | grep -qx "$FLUX_FILL_CONTAINER"; then
+    log "removing stale container $FLUX_FILL_CONTAINER"
+    docker rm -f "$FLUX_FILL_CONTAINER" >/dev/null
+fi
+
+# --- start the sd-server container (EXACT verified flags) -------------------
+# Encoders MUST stay on CPU (--clip-on-cpu --vae-on-cpu) or the 12GB card OOMs.
+# Host ${FLUX_FILL_PORT} -> container 7864 (the server's internal listen port).
+log "starting $FLUX_FILL_CONTAINER on port ${FLUX_FILL_PORT} (encoders pinned to CPU)"
+docker run -d --gpus all --name "$FLUX_FILL_CONTAINER" \
+    -p "${FLUX_FILL_PORT}:7864" \
+    -v "${MODELS_DIR}:/models" \
+    "$FLUX_FILL_IMAGE" \
+    sd-server --listen-ip 0.0.0.0 --listen-port 7864 \
+        --diffusion-model "/models/${FLUX_FILL_GGUF}" \
+        --vae "/models/${VAE_FILE}" \
+        --clip_l "/models/${CLIP_L_FILE}" \
+        --t5xxl "/models/${T5XXL_FILE}" \
+        --clip-on-cpu --vae-on-cpu \
+    || die "docker run failed"
+
+log "flux-fill started: container $FLUX_FILL_CONTAINER -> http://0.0.0.0:${FLUX_FILL_PORT}"
+log "A1111 img2img endpoint: http://0.0.0.0:${FLUX_FILL_PORT}/sdapi/v1/img2img"
+log "GPU resident ~6.5GB with encoders on CPU; first inference compiles graphs and is slow"
+log "done"


### PR DESCRIPTION
This adds the FLUX.1-Fill quality inpaint/outpaint tier for the Images Studio (#43): a reproducible install script plus a catalog manifest for a GPU-only image-edit backend.

This captures a setup that was manually verified working on the 3060 GPU box. The backend is a leejet/stable-diffusion.cpp sd-server (A1111-compatible, serves /sdapi/v1/img2img) running the FLUX.1-Fill-dev model. The exact config in the script returned a real inpainted 512px image in about 73s on a 12GB RTX 3060.

Key points:

- Encoders-on-CPU gotcha: the run keeps the FLUX text encoders on CPU (--clip-on-cpu --vae-on-cpu). With those flags the GPU resident is around 6.5GB, which leaves headroom on a 12GB card. Without them, inference OOMs while allocating the t5 graph. This is documented prominently in the script header and inline at the docker run.

- Non-gated mirror: the model file flux1-fill-dev-Q4_K_S.gguf (6.8GB) is fetched from the YarvixPA/FLUX.1-Fill-dev-gguf mirror because the official black-forest-labs / city96 repos are gated. An operator with an accepted HF license and token can substitute the gated source by overriding TAOS_FLUX_FILL_GGUF_URL.

- Shared support files: the FLUX VAE (ae.safetensors), clip_l, and t5xxl encoders are the standard FLUX files shared with the sd-cpp generation backend models dir. They are only fetched if missing.

- Runs on-demand on a shared GPU. The container reuses the taos-sdcpp:cuda image (GGML_CUDA=ON, CMAKE_CUDA_ARCHITECTURES=86) built by the sd.cpp docker setup; the script requires that image and exits with a clear message if it is missing. The script is idempotent (skips if the container already answers on the port), GPU-guarded (exits cleanly when no CUDA GPU is present), and downloads model files with wget -c. No model files are committed.

- Port: the manifest and script use the deterministic high-pool slot 38298 for app_id flux-fill (computed by the port allocator, mirroring the iopaint convention). Overridable via TAOS_FLUX_FILL_PORT. Host maps to the container internal port 7864.

Verification: bash -n passes; the manifest audit (scripts/audit-manifests.py) reports no new issues for this entry (the only flag is a pre-existing ltx-video context_window note unrelated to this change).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added flux-fill image generation service (FLUX.1-Fill) with automated installer
  * Includes GPU requirements validation and model caching
  * Supports NVIDIA GPUs with 12GB+ VRAM; specifies port configuration and resource allocation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->