### PR TITLE
feat(theme): Indigo third theme

### DIFF
--- a/desktop/src/stores/theme-store.ts
+++ b/desktop/src/stores/theme-store.ts
@@ -361,6 +361,16 @@ export function setWallpaperForActiveTheme(value: string) {
   useThemeStore.setState({ wallpaperByTheme: { ...wallpaperByTheme, [activeThemeId]: value } });
 }
 
+// Apply a theme's default wallpaper id to the live desktop, but only when the
+// user hasn't already picked a wallpaper for that theme (so an explicit choice
+// is never clobbered). Used when keeping/restoring a theme that declares one.
+function applyThemeDefaultWallpaper(themeId: string, cfg: ThemeConfig) {
+  if (!cfg.defaultWallpaperId) return;
+  const { wallpaperByTheme } = useThemeStore.getState();
+  if (wallpaperByTheme[themeId]) return; // user override wins
+  useThemeStore.getState().setWallpaper(cfg.defaultWallpaperId);
+}
+
 export function resolveWallpaper(): string {
   const { activeThemeId, wallpaperByTheme, themeDefaultWallpaper } = useThemeStore.getState();
   return wallpaperByTheme[activeThemeId] ?? themeDefaultWallpaper[activeThemeId] ?? "";
@@ -407,6 +417,7 @@ export async function restoreActiveTheme(): Promise<void> {
         ...(cfg.wallpaper ? { [themeId]: cfg.wallpaper } : {}),
       },
     });
+    applyThemeDefaultWallpaper(themeId, cfg);
   } catch {
     // best-effort: ignore
   }
@@ -421,6 +432,7 @@ export function keepTheme(themeId: string, cfg: ThemeConfig) {
       ...(cfg.wallpaper ? { [themeId]: cfg.wallpaper } : {}),
     },
   });
+  applyThemeDefaultWallpaper(themeId, cfg);
   // persist active theme id
   void fetch("/api/preferences/themes", {
     method: "PUT",

--- a/desktop/src/theme/__tests__/builtin-themes.test.ts
+++ b/desktop/src/theme/__tests__/builtin-themes.test.ts
@@ -4,14 +4,22 @@ import { BUILTIN_THEMES } from "../builtin-themes";
 import { ALLOWED_TOKENS } from "../theme-config";
 
 describe("builtin themes", () => {
-  it("includes an undeletable taOS Dark (default) and taOS Light", () => {
+  it("includes an undeletable taOS Dark (default), taOS Light and taOS Indigo", () => {
     const ids = BUILTIN_THEMES.map((t) => t.theme_id);
     expect(ids).toContain("default");
     expect(ids).toContain("light");
+    expect(ids).toContain("indigo");
     expect(BUILTIN_THEMES.find((t) => t.theme_id === "default")!.builtin).toBe(true);
   });
   it("only uses allowlisted tokens", () => {
     for (const t of BUILTIN_THEMES)
       for (const k of Object.keys(t.config.tokens)) expect(ALLOWED_TOKENS.has(k)).toBe(true);
+  });
+  it("defaults indigo to the neural (particles) wallpaper", () => {
+    const indigo = BUILTIN_THEMES.find((t) => t.theme_id === "indigo")!;
+    expect(indigo.config.defaultWallpaperId).toBe("neural-live");
+    // dark + light keep their own wallpaper defaults (no neural override).
+    expect(BUILTIN_THEMES.find((t) => t.theme_id === "default")!.config.defaultWallpaperId).toBeUndefined();
+    expect(BUILTIN_THEMES.find((t) => t.theme_id === "light")!.config.defaultWallpaperId).toBeUndefined();
   });
 });

--- a/desktop/src/theme/builtin-themes.ts
+++ b/desktop/src/theme/builtin-themes.ts
@@ -55,4 +55,49 @@ export const BUILTIN_THEMES: BuiltinTheme[] = [
       wallpaper: "linear-gradient(160deg, #eef0f3 0%, #e6e9ee 45%, #dee2e8 100%)",
     },
   },
+  {
+    theme_id: "indigo",
+    name: "taOS Indigo",
+    builtin: true,
+    config: {
+      tokens: {
+        // Deep indigo graphite body + a darker sidebar layer. Desaturated and
+        // blue-leaning, not a saturated AI-purple. Body text at 0.85 reads 12.5:1.
+        "--color-shell-bg": "#1a1b2b",
+        "--color-shell-bg-deep": "#131420",
+        // Indigo-tinted surface fills — additive light with a faint blue cast so
+        // raised surfaces feel of-a-piece with the base rather than neutral grey.
+        "--color-shell-surface": "rgba(150, 158, 230, 0.05)",
+        "--color-shell-surface-hover": "rgba(150, 158, 230, 0.08)",
+        "--color-shell-surface-active": "rgba(150, 158, 230, 0.11)",
+        "--color-shell-border": "rgba(150, 158, 230, 0.09)",
+        "--color-shell-border-strong": "rgba(150, 158, 230, 0.16)",
+        // Text: 12.5:1 / 5.2:1 / 4.0:1 on the #1a1b2b body.
+        "--color-shell-text": "rgba(255, 255, 255, 0.85)",
+        "--color-shell-text-secondary": "rgba(255, 255, 255, 0.5)",
+        "--color-shell-text-tertiary": "rgba(255, 255, 255, 0.42)",
+        // Refined periwinkle indigo accent (6:1 on the body), with matching
+        // tinted fills, hairline, and a brighter strong variant (10.5:1).
+        "--color-accent": "#8b93e6",
+        "--color-accent-glow": "rgba(139, 147, 230, 0.3)",
+        "--color-accent-soft": "rgba(139, 147, 230, 0.16)",
+        "--color-accent-line": "rgba(139, 147, 230, 0.4)",
+        "--color-accent-strong": "#c4c8f5",
+        "--color-unread": "#7c8af0",
+        "--color-bubble-self": "rgba(139, 147, 230, 0.16)",
+        // Frosted indigo-graphite chrome for the dock + top bar.
+        "--color-dock-bg": "rgba(20, 21, 33, 0.92)",
+        "--color-dock-border": "rgba(150, 158, 230, 0.1)",
+        "--color-topbar-bg": "rgba(20, 21, 33, 0.92)",
+        "--color-snap-preview": "rgba(139, 147, 230, 0.16)",
+        "--color-snap-border": "rgba(139, 147, 230, 0.45)",
+      },
+      structure: {},
+      effects: [],
+      requires: ["assistant", "launcher"],
+      // Indigo defaults to the original neural/particles animated wallpaper; the
+      // user can still override it from the wallpaper picker.
+      defaultWallpaperId: "neural-live",
+    },
+  },
 ];

--- a/desktop/src/theme/theme-config.ts
+++ b/desktop/src/theme/theme-config.ts
@@ -4,6 +4,9 @@ export interface ThemeConfig {
   effects: { module: string; params?: Record<string, unknown> }[];
   requires: string[];
   wallpaper?: string | null;
+  // Optional id of a registered wallpaper (see WALLPAPERS in theme-store) that
+  // this theme defaults to when kept, unless the user already chose one for it.
+  defaultWallpaperId?: string;
 }
 
 // Client-side allowlist — mirrors tinyagentos/themes/schema.py _ALL_TOKENS.


### PR DESCRIPTION
Adds an opt-in third theme, taOS Indigo, alongside the existing Dark and Light themes. It is fully opt-in: Dark stays the default and neither Dark nor Light is changed.

The palette is a deep indigo graphite base with indigo-tinted surfaces, borders and chrome, and a refined periwinkle indigo accent. It is desaturated and blue-leaning rather than a saturated purple. Body text reads 12.5:1 on the body colour, secondary 5.2:1 and tertiary 4.0:1, matching the Dark theme contrast structure, and the accent reads 6:1 on the body.

The theme is registered in BUILTIN_THEMES, which is the same data source the Themes panel renders from, so it appears automatically as a third selectable card and persists through the existing keep/revert and preferences flow. Every token it sets is already in the shared allowlist (ALLOWED_TOKENS and the python schema _ALL_TOKENS), so no schema change was needed and the theme guard tests stay green.

Selecting Indigo defaults its wallpaper to the original neural particle-network animated wallpaper. The ThemeConfig gains an optional defaultWallpaperId, and on keep or restore the store applies that wallpaper to the live desktop unless the user has already chosen one for that theme, so an explicit choice is never clobbered. The neural wallpaper is theme-aware and inverts with the active scheme. Dark and Light keep their current wallpaper defaults.

tsc is clean, the production build succeeds, and the theme and store tests pass (11 of 11), including a new assertion that Indigo defaults to the neural wallpaper while Dark and Light do not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new built-in "taOS Indigo" theme with neural-live wallpaper as the default selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->