### PR TITLE
feat(models): register arctic-embed-s embedding model

### DIFF
--- a/app-catalog/models/snowflake-arctic-embed-s/manifest.yaml
+++ b/app-catalog/models/snowflake-arctic-embed-s/manifest.yaml
@@ -1,0 +1,62 @@
+id: snowflake-arctic-embed-s
+name: Snowflake Arctic Embed S
+type: model
+version: 1.0.0
+description: Snowflake's 33M English embedding, 384-dim, CPU-friendly, strong retrieval
+homepage: https://huggingface.co/Snowflake/snowflake-arctic-embed-s
+license: Apache-2.0
+capabilities:
+- embedding
+variants:
+- id: q4_k_m
+  name: Q4_K_M GGUF (27MB)
+  format: gguf
+  size_mb: 27
+  min_ram_mb: 256
+  download_url: https://huggingface.co/ChristianAzinn/snowflake-arctic-embed-s-gguf/resolve/main/snowflake-arctic-embed-s--Q4_K_M.GGUF
+  requires:
+    backends:
+    - id: ollama
+      targets:
+      - apple-silicon
+      - x86-cuda
+      - x86-vulkan
+      - arm-vulkan
+      - cpu
+      min_ram_mb: 256
+    - id: llama-cpp
+      targets:
+      - x86-vulkan
+      - arm-vulkan
+      - cpu
+      min_ram_mb: 256
+- id: f16
+  name: F16 GGUF (64MB)
+  format: gguf
+  size_mb: 64
+  min_ram_mb: 512
+  download_url: https://huggingface.co/ChristianAzinn/snowflake-arctic-embed-s-gguf/resolve/main/snowflake-arctic-embed-s-f16.GGUF
+  requires:
+    backends:
+    - id: ollama
+      targets:
+      - apple-silicon
+      - x86-cuda
+      - x86-vulkan
+      - arm-vulkan
+      - cpu
+      min_ram_mb: 512
+    - id: llama-cpp
+      targets:
+      - x86-vulkan
+      - arm-vulkan
+      - cpu
+      min_ram_mb: 512
+hardware_tiers:
+  arm-cpu-8gb:
+    recommended: q4_k_m
+  arm-npu-16gb:
+    recommended: q4_k_m
+  cpu-only:
+    recommended: q4_k_m
+context_window: 512


### PR DESCRIPTION
Registers Snowflake Arctic Embed S in the OS model store so it shows up as an installable embedding model in the Models app. This is the taOSmd #417 follow-up (#27): arctic-embed-s won the embedder bake-off, beating MiniLM by +0.157 R@K on retrieval, so it should be available to register and serve.

What this adds:

A new catalog manifest at app-catalog/models/snowflake-arctic-embed-s/manifest.yaml. It mirrors the existing embedding entries exactly (same schema as bge-small-en-v1.5 and snowflake-arctic-embed-m): id, name, type model, version, description, homepage, Apache-2.0 license, capabilities embedding, two GGUF variants (q4_k_m at 27MB and f16 at 64MB), hardware_tiers, and context_window 512.

Metadata is taken from the model card and config.json: 384 embedding dimensions, 33M parameters, 512 context window, English text embedding, CPU-friendly, retrieval-strong.

Serving is wired the same way as the other GGUF embedding models. Each variant requires the ollama and llama-cpp backends (both already exist as service manifests), with target and min_ram_mb values matching the bge-small pattern. So the model is actually installable and servable, not just listed.

GGUF artifacts are sourced from ChristianAzinn/snowflake-arctic-embed-s-gguf. Both download URLs were verified to resolve (HTTP 200).

Verification:

python -c 'from tinyagentos.app import create_app; create_app()' succeeds.

python scripts/audit-manifests.py reports no new issues (only the pre-existing ltx-video context_window issue, which is unrelated).

tests/test_routes_models.py, tests/test_model_sources.py, tests/catalog, and tests/test_catalog_sync.py all pass (75 passed).

Registry lookup confirms the entry loads with capabilities embedding and both variants, identical to the other arctic-embed and bge embedding models.

No frontend changes were needed: the Models app reads the catalog generically, so the new entry surfaces automatically.