### PR TITLE
fix: post-merge gitar findings (#926/#927/#929)

### DIFF
--- a/desktop/src/stores/__tests__/restore-theme.test.ts
+++ b/desktop/src/stores/__tests__/restore-theme.test.ts
@@ -1,9 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { restoreActiveTheme, useThemeStore } from "../theme-store";
+import { restoreActiveTheme, keepTheme, useThemeStore } from "../theme-store";
 
 beforeEach(() => {
   document.documentElement.removeAttribute("style");
-  useThemeStore.setState({ activeThemeId: "default" });
+  useThemeStore.setState({
+    activeThemeId: "default",
+    wallpaperByTheme: {},
+    wallpaperIdByTheme: {},
+    wallpaperId: "graphite",
+  });
 });
 
 afterEach(() => {
@@ -38,5 +43,34 @@ describe("restoreActiveTheme", () => {
   it("does not throw on fetch failure", async () => {
     vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network"));
     await expect(restoreActiveTheme()).resolves.toBeUndefined();
+  });
+});
+
+describe("wallpaper restore on theme switch", () => {
+  beforeEach(() => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("{}"));
+  });
+
+  it("applies a theme's defaultWallpaperId when it declares one", () => {
+    keepTheme("indigo", { tokens: {}, defaultWallpaperId: "neural-live" });
+    expect(useThemeStore.getState().wallpaperId).toBe("neural-live");
+  });
+
+  it("restores the global default when switching to a theme with no default (not the previous theme's wallpaper)", () => {
+    // Indigo set neural-live; switching to Dark/Light (no defaultWallpaperId)
+    // must not leave neural-live stuck.
+    keepTheme("indigo", { tokens: {}, defaultWallpaperId: "neural-live" });
+    expect(useThemeStore.getState().wallpaperId).toBe("neural-live");
+    keepTheme("default", { tokens: {} });
+    expect(useThemeStore.getState().wallpaperId).toBe("graphite");
+  });
+
+  it("restores the user's explicit per-theme wallpaper choice over the default", () => {
+    keepTheme("default", { tokens: {} });
+    useThemeStore.getState().setWallpaper("ocean"); // user picks Ocean for Dark
+    keepTheme("indigo", { tokens: {}, defaultWallpaperId: "neural-live" });
+    expect(useThemeStore.getState().wallpaperId).toBe("neural-live");
+    keepTheme("default", { tokens: {} }); // back to Dark -> Ocean restored
+    expect(useThemeStore.getState().wallpaperId).toBe("ocean");
   });
 });

--- a/desktop/src/stores/__tests__/restore-theme.test.ts
+++ b/desktop/src/stores/__tests__/restore-theme.test.ts
@@ -74,3 +74,46 @@ describe("wallpaper restore on theme switch", () => {
     expect(useThemeStore.getState().wallpaperId).toBe("ocean");
   });
 });
+
+describe("restoreActiveTheme does not clobber the persisted wallpaper", () => {
+  // On boot, wallpaperIdByTheme is empty (in-memory) and useSessionPersistence
+  // restores the user's persisted wallpaper. restoreActiveTheme must not race
+  // that restore back to the global default for a theme with no defaultWallpaperId.
+  it("leaves a user's custom wallpaper untouched when the restored theme declares no default", async () => {
+    // The Light builtin theme has a `wallpaper` but no `defaultWallpaperId`.
+    vi.spyOn(globalThis, "fetch").mockImplementation((input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/api/preferences/themes")) {
+        return Promise.resolve(new Response(JSON.stringify({ active_theme_id: "light" })));
+      }
+      return Promise.resolve(new Response(JSON.stringify([])));
+    });
+    // Stand in for useSessionPersistence having restored the persisted choice.
+    useThemeStore.getState().setWallpaper("ocean");
+    expect(useThemeStore.getState().wallpaperId).toBe("ocean");
+
+    await restoreActiveTheme();
+
+    expect(useThemeStore.getState().activeThemeId).toBe("light");
+    // NOT reset to the global graphite default.
+    expect(useThemeStore.getState().wallpaperId).toBe("ocean");
+  });
+
+  it("still applies the theme's declared defaultWallpaperId on restore", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation((input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/api/preferences/themes")) {
+        return Promise.resolve(new Response(JSON.stringify({ active_theme_id: "indigo" })));
+      }
+      // Provide an Indigo-like theme that declares neural-live.
+      return Promise.resolve(
+        new Response(JSON.stringify([{ theme_id: "indigo", config: { tokens: {}, defaultWallpaperId: "neural-live" } }])),
+      );
+    });
+
+    await restoreActiveTheme();
+
+    expect(useThemeStore.getState().activeThemeId).toBe("indigo");
+    expect(useThemeStore.getState().wallpaperId).toBe("neural-live");
+  });
+});

--- a/desktop/src/stores/theme-store.ts
+++ b/desktop/src/stores/theme-store.ts
@@ -120,6 +120,24 @@ const WALLPAPERS: Wallpaper[] = [
 // Default wallpaper for taOS Dark: the animated graphite field.
 const DEFAULT_WP = WALLPAPERS.find((w) => w.id === "graphite") ?? WALLPAPERS[0]!;
 
+// Live store fields that describe a wallpaper, derived from its definition.
+// Shared by the user-facing setWallpaper (which also records the choice) and
+// the theme-switch default applier (which must not record a user choice).
+function wallpaperFields(wp: Wallpaper, id: string) {
+  return {
+    wallpaperId: id,
+    wallpaperImage: wp.image,
+    wallpaperMobileImage: wp.mobileImage ?? wp.image,
+    wallpaperFallback: wp.fallback,
+    wallpaperLightImage: wp.lightImage ?? "",
+    wallpaperLightMobileImage: wp.lightMobileImage ?? wp.lightImage ?? "",
+    wallpaperLightFallback: wp.lightFallback ?? wp.fallback,
+    wallpaperKind: wp.kind ?? "image",
+    wallpaperComponent: wp.component ?? null,
+    wallpaperOverlayText: wp.overlayText ?? null,
+  } as const;
+}
+
 // The slogan-overlay toggle persists locally so a clean desktop survives a
 // reload. Best-effort: any storage failure falls back to "on".
 const SLOGAN_KEY = "taos-wallpaper-slogan";
@@ -173,6 +191,10 @@ interface ThemeStore {
   activeThemeId: string;
   wallpaperByTheme: Record<string, string>;
   themeDefaultWallpaper: Record<string, string>;
+  // Per-theme memory of the wallpaper id the user last picked while that theme
+  // was active. Lets a theme switch restore the wallpaper that was in use for
+  // the target theme rather than inheriting the previous theme's wallpaper.
+  wallpaperIdByTheme: Record<string, string>;
 
   setWallpaper: (id: string) => void;
   toggleOverlayText: () => void;
@@ -202,22 +224,17 @@ export const useThemeStore = create<ThemeStore>((set) => ({
   activeThemeId: "default",
   wallpaperByTheme: {},
   themeDefaultWallpaper: {},
+  wallpaperIdByTheme: {},
 
   setWallpaper(id) {
     const wp = WALLPAPERS.find((w) => w.id === id);
     if (wp) {
-      set({
-        wallpaperId: id,
-        wallpaperImage: wp.image,
-        wallpaperMobileImage: wp.mobileImage ?? wp.image,
-        wallpaperFallback: wp.fallback,
-        wallpaperLightImage: wp.lightImage ?? "",
-        wallpaperLightMobileImage: wp.lightMobileImage ?? wp.lightImage ?? "",
-        wallpaperLightFallback: wp.lightFallback ?? wp.fallback,
-        wallpaperKind: wp.kind ?? "image",
-        wallpaperComponent: wp.component ?? null,
-        wallpaperOverlayText: wp.overlayText ?? null,
-      });
+      set((s) => ({
+        ...wallpaperFields(wp, id),
+        // An explicit pick is remembered for the active theme so switching away
+        // and back restores it instead of the target theme's default.
+        wallpaperIdByTheme: { ...s.wallpaperIdByTheme, [s.activeThemeId]: id },
+      }));
     }
   },
 
@@ -361,14 +378,28 @@ export function setWallpaperForActiveTheme(value: string) {
   useThemeStore.setState({ wallpaperByTheme: { ...wallpaperByTheme, [activeThemeId]: value } });
 }
 
-// Apply a theme's default wallpaper id to the live desktop, but only when the
-// user hasn't already picked a wallpaper for that theme (so an explicit choice
-// is never clobbered). Used when keeping/restoring a theme that declares one.
+// Apply the right wallpaper to the live desktop when switching to a theme.
+// Symmetric so switching back from a theme that set its own wallpaper (e.g.
+// Indigo -> neural-live) doesn't leave the previous theme's wallpaper stuck:
+//   1. a wallpaper the user explicitly picked for the target theme wins, else
+//   2. the target theme's declared defaultWallpaperId, else
+//   3. the global default wallpaper (never the previous theme's).
 function applyThemeDefaultWallpaper(themeId: string, cfg: ThemeConfig) {
-  if (!cfg.defaultWallpaperId) return;
-  const { wallpaperByTheme } = useThemeStore.getState();
-  if (wallpaperByTheme[themeId]) return; // user override wins
-  useThemeStore.getState().setWallpaper(cfg.defaultWallpaperId);
+  const state = useThemeStore.getState();
+  // Explicit user choice for this theme always wins.
+  const remembered = state.wallpaperIdByTheme[themeId];
+  const target = remembered ?? cfg.defaultWallpaperId ?? DEFAULT_WP.id;
+  if (target === state.wallpaperId) return; // already showing it
+  const wp = WALLPAPERS.find((w) => w.id === target);
+  if (!wp) return;
+  if (remembered) {
+    // Restoring the user's own pick: setWallpaper keeps the memory consistent.
+    state.setWallpaper(target);
+  } else {
+    // Applying a default must not be recorded as an explicit user choice, so a
+    // later genuine pick (or a changed theme default) still takes effect.
+    useThemeStore.setState(wallpaperFields(wp, target));
+  }
 }
 
 export function resolveWallpaper(): string {

--- a/desktop/src/stores/theme-store.ts
+++ b/desktop/src/stores/theme-store.ts
@@ -379,20 +379,40 @@ export function setWallpaperForActiveTheme(value: string) {
 }
 
 // Apply the right wallpaper to the live desktop when switching to a theme.
-// Symmetric so switching back from a theme that set its own wallpaper (e.g.
-// Indigo -> neural-live) doesn't leave the previous theme's wallpaper stuck:
-//   1. a wallpaper the user explicitly picked for the target theme wins, else
-//   2. the target theme's declared defaultWallpaperId, else
-//   3. the global default wallpaper (never the previous theme's).
-function applyThemeDefaultWallpaper(themeId: string, cfg: ThemeConfig) {
+//
+// This runs in two contexts with different correctness needs:
+//
+//   * Live switch (keepTheme): the user is actively changing themes, so it is
+//     safe and desirable to be symmetric -- switching away from a theme that
+//     set its own wallpaper (e.g. Indigo -> neural-live) back to Dark/Light
+//     must not leave neural-live stuck. Resolution order:
+//       1. a wallpaper the user explicitly picked for the target theme, else
+//       2. the target theme's declared defaultWallpaperId, else
+//       3. the global default wallpaper (never the previous theme's).
+//
+//   * Restore (restoreActiveTheme, on boot): the user's chosen wallpaper is
+//     persisted separately (PUT /api/desktop/settings) and restored by
+//     useSessionPersistence. The per-theme memory (wallpaperIdByTheme) is
+//     in-memory only and empty at boot, so a global-default fallback would race
+//     that restore and reset a custom wallpaper back to graphite. On restore we
+//     therefore only act on a positive reason -- the target theme's declared
+//     defaultWallpaperId -- and never force the global default, leaving the
+//     persisted wallpaper untouched.
+function applyThemeDefaultWallpaper(themeId: string, cfg: ThemeConfig, opts?: { restore?: boolean }) {
   const state = useThemeStore.getState();
   // Explicit user choice for this theme always wins.
   const remembered = state.wallpaperIdByTheme[themeId];
-  const target = remembered ?? cfg.defaultWallpaperId ?? DEFAULT_WP.id;
+  // On restore there is no in-memory memory to trust and the global default
+  // must never override the separately-persisted wallpaper, so the theme's own
+  // declared default is the only positive reason to change anything.
+  const target = opts?.restore
+    ? cfg.defaultWallpaperId
+    : (remembered ?? cfg.defaultWallpaperId ?? DEFAULT_WP.id);
+  if (!target) return; // no positive reason to change the wallpaper
   if (target === state.wallpaperId) return; // already showing it
   const wp = WALLPAPERS.find((w) => w.id === target);
   if (!wp) return;
-  if (remembered) {
+  if (target === remembered) {
     // Restoring the user's own pick: setWallpaper keeps the memory consistent.
     state.setWallpaper(target);
   } else {
@@ -448,7 +468,7 @@ export async function restoreActiveTheme(): Promise<void> {
         ...(cfg.wallpaper ? { [themeId]: cfg.wallpaper } : {}),
       },
     });
-    applyThemeDefaultWallpaper(themeId, cfg);
+    applyThemeDefaultWallpaper(themeId, cfg, { restore: true });
   } catch {
     // best-effort: ignore
   }

--- a/scripts/install-flux-fill.sh
+++ b/scripts/install-flux-fill.sh
@@ -112,7 +112,16 @@ fetch() {
                 log "$name already complete (${actual} bytes) - skipping download"
                 return 0
             fi
-            log "$name incomplete (${actual:-0}/${expected} bytes) - resuming"
+            # `wget -c` only resumes when the on-disk file is SHORTER than the
+            # remote. A file that is the same length-or-longer can't be a valid
+            # partial (it's corrupt/oversized), and -c would leave it untouched
+            # forever. Delete it first so the next wget re-downloads cleanly.
+            if [[ "${actual:-0}" -ge "$expected" ]]; then
+                log "$name oversized/corrupt (${actual:-0} >= ${expected} bytes) - removing and re-downloading"
+                rm -f "$dest"
+            else
+                log "$name incomplete (${actual:-0}/${expected} bytes) - resuming"
+            fi
         fi
     fi
     log "downloading $name"


### PR DESCRIPTION
Addresses three gitar warnings left unaddressed on already-merged backlog PRs.

## Fixes

**1. Model download URL (#926) - `app-catalog/models/snowflake-arctic-embed-s/manifest.yaml`**
gitar flagged inconsistent filename conventions across the two GGUF variants (Q4_K_M uses a double-dash, f16 a single-dash), suggesting one URL could 404. Verified both against the source repo `ChristianAzinn/snowflake-arctic-embed-s-gguf`: the repo itself publishes those exact inconsistent names, so both committed URLs are correct and return HTTP 200 after redirect, with sizes matching the manifest. No manifest change was needed.

Verified download URLs (final HTTP status after redirect):
- `https://huggingface.co/ChristianAzinn/snowflake-arctic-embed-s-gguf/resolve/main/snowflake-arctic-embed-s--Q4_K_M.GGUF` -> 200 (28,810,528 bytes, ~27 MB)
- `https://huggingface.co/ChristianAzinn/snowflake-arctic-embed-s-gguf/resolve/main/snowflake-arctic-embed-s-f16.GGUF` -> 200 (67,308,160 bytes, ~64 MB)

**2. Theme wallpaper restore (#927) - `desktop/src/stores/theme-store.ts`**
`applyThemeDefaultWallpaper` only ever set a wallpaper for a theme that declared `defaultWallpaperId` (Indigo -> neural-live) and early-returned otherwise, so switching back to Dark or Light left the neural wallpaper stuck. Made it symmetric: on a theme switch it restores the user's remembered per-theme wallpaper if any, else the target theme's `defaultWallpaperId`, else the global default wallpaper. Added a per-theme wallpaper-id memory recorded by `setWallpaper`; applying a default no longer counts as an explicit user choice. Dark/Light token palettes untouched. New tests cover the indigo->dark restore and the explicit-choice-wins path.

**3. Installer refetch (#929) - `scripts/install-flux-fill.sh`**
`wget -c` only resumes when the on-disk file is shorter than the remote, so a corrupt oversized file was never repaired. The size-mismatch branch now deletes the file first when its size is greater-or-equal to the expected Content-Length, then downloads fresh; smaller files still resume with `wget -c`, and a complete file stays a fast no-op.

## Verification
- `npx tsc --noEmit`: clean
- `npm run build`: succeeds
- store/theme tests: 16/16 pass (incl. 3 new restore-behaviour tests); the one unrelated pre-existing `safety-regression.test.tsx` failure is present on the base branch too
- `bash -n scripts/install-flux-fill.sh`: passes
- `scripts/audit-manifests.py`: no new failures (only the pre-existing unrelated `ltx-video` context_window issue)