### PR TITLE
fix(images-edit): reliability hardening

### DIFF
--- a/tests/test_routes_images_edit.py
+++ b/tests/test_routes_images_edit.py
@@ -1,6 +1,7 @@
 """Tests for the tier-aware image-editing routes (routes/images_edit.py)."""
 import base64
 import io
+from pathlib import Path
 from types import SimpleNamespace
 
 import httpx
@@ -222,3 +223,136 @@ async def test_edit_image_quality_falls_back_to_iopaint(tmp_path):
 
     assert route.called
     assert (images_dir / result["filename"]).read_bytes() == result_png
+
+
+# --------------------------------------------------------------------------- #
+#  IOPaint hardening: non-image 200, data-URI mask strip, backend surfacing    #
+# --------------------------------------------------------------------------- #
+def _edit_request_with_workspace(tmp_path, backends):
+    """Build a request whose workspace holds a single src.png + return its dir."""
+    images_dir = tmp_path / "workspace" / "images" / "generated"
+    images_dir.mkdir(parents=True)
+    (images_dir / "src.png").write_bytes(base64.b64decode(_png_b64()))
+    catalog = _FakeCatalog({"image-editing": list(backends)})
+    state = SimpleNamespace(backend_catalog=catalog, config_path=str(tmp_path / "config.json"))
+    request = SimpleNamespace(app=SimpleNamespace(state=state))
+    return request, images_dir
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_iopaint_non_image_200_is_an_error_not_a_saved_png(tmp_path):
+    """IOPaint answering 200 with a JSON error body must NOT be saved as a png;
+    it routes to an error response so the user doesn't get a fake success."""
+    respx.post("http://io/api/v1/inpaint").mock(
+        return_value=httpx.Response(
+            200,
+            json={"errors": "model not loaded"},
+            headers={"content-type": "application/json"},
+        )
+    )
+    request, images_dir = _edit_request_with_workspace(tmp_path, [_backend("io", "iopaint")])
+    body = EditRequest(image_ref="src.png", op="inpaint", mask=_png_b64(), tier="fast")
+    result = await edit_image(request, body)
+
+    # An error JSONResponse, not a saved-png success dict.
+    from fastapi.responses import JSONResponse as _JR
+
+    assert isinstance(result, _JR)
+    # No new png was written (only the source remains).
+    pngs = sorted(p.name for p in images_dir.glob("*.png"))
+    assert pngs == ["src.png"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_iopaint_strips_data_uri_mask(tmp_path):
+    """A data-URI mask is stripped to bare base64 before hitting IOPaint
+    (previously only FluxFill stripped it, so a data-URI corrupted IOPaint)."""
+    result_png = base64.b64decode(_png_b64(color=(4, 5, 6)))
+    route = respx.post("http://io/api/v1/inpaint").mock(
+        return_value=httpx.Response(200, content=result_png, headers={"content-type": "image/png"})
+    )
+    request, _ = _edit_request_with_workspace(tmp_path, [_backend("io", "iopaint")])
+
+    bare = _png_b64(color=(0, 0, 0))
+    data_uri_mask = f"data:image/png;base64,{bare}"
+    body = EditRequest(image_ref="src.png", op="inpaint", mask=data_uri_mask, tier="fast")
+    await edit_image(request, body)
+
+    import json as _json
+
+    payload = _json.loads(route.calls.last.request.content)
+    assert payload["mask"] == bare  # prefix dropped
+    assert not payload["mask"].startswith("data:")
+    assert not payload["image"].startswith("data:")
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_edit_response_surfaces_backend_and_degraded(tmp_path):
+    """The edit response carries the backend type that actually ran, and flags
+    a silent tier downgrade (quality requested, iopaint fell back -> degraded)."""
+    result_png = base64.b64decode(_png_b64(color=(1, 1, 1)))
+    respx.post("http://io/api/v1/inpaint").mock(
+        return_value=httpx.Response(200, content=result_png, headers={"content-type": "image/png"})
+    )
+    request, _ = _edit_request_with_workspace(tmp_path, [_backend("io", "iopaint")])
+
+    body = EditRequest(image_ref="src.png", op="inpaint", mask=_png_b64(), tier="quality")
+    result = await edit_image(request, body)
+
+    assert result["backend"] == "iopaint"
+    assert result["degraded"] is True  # quality asked for flux-fill, got iopaint
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_edit_response_not_degraded_when_tier_satisfied(tmp_path):
+    """When the chosen backend matches the tier's primary, degraded is False."""
+    result_png = base64.b64decode(_png_b64(color=(2, 2, 2)))
+    respx.post("http://io/api/v1/inpaint").mock(
+        return_value=httpx.Response(200, content=result_png, headers={"content-type": "image/png"})
+    )
+    request, _ = _edit_request_with_workspace(tmp_path, [_backend("io", "iopaint")])
+
+    body = EditRequest(image_ref="src.png", op="inpaint", mask=_png_b64(), tier="fast")
+    result = await edit_image(request, body)
+
+    assert result["backend"] == "iopaint"
+    assert result["degraded"] is False  # fast tier prefers iopaint
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_save_oserror_maps_to_clean_error(tmp_path):
+    """A disk write failure in _save_result surfaces as a 'Could not save result'
+    error, distinct from a backend-unreachable response (not a bare 500)."""
+    result_png = base64.b64decode(_png_b64(color=(3, 3, 3)))
+    respx.post("http://io/api/v1/inpaint").mock(
+        return_value=httpx.Response(200, content=result_png, headers={"content-type": "image/png"})
+    )
+    request, images_dir = _edit_request_with_workspace(tmp_path, [_backend("io", "iopaint")])
+
+    import json as _json
+
+    # Force the result write to fail with OSError.
+    real_write_bytes = Path.write_bytes
+
+    def _boom(self, data):
+        if self.parent == images_dir and self.suffix == ".png" and self.name != "src.png":
+            raise OSError(28, "No space left on device")
+        return real_write_bytes(self, data)
+
+    import unittest.mock as mock
+
+    body = EditRequest(image_ref="src.png", op="inpaint", mask=_png_b64(), tier="fast")
+    with mock.patch.object(Path, "write_bytes", _boom):
+        result = await edit_image(request, body)
+
+    from fastapi.responses import JSONResponse as _JR
+
+    assert isinstance(result, _JR)
+    assert result.status_code == 500
+    payload = _json.loads(bytes(result.body))
+    assert "Could not save result" in payload["error"]

--- a/tests/test_routes_images_edit.py
+++ b/tests/test_routes_images_edit.py
@@ -14,6 +14,7 @@ from tinyagentos.routes.images_edit import (
     EditRequest,
     FluxFillClient,
     _get_edit_backend,
+    _require_image,
     edit_image,
 )
 
@@ -321,6 +322,25 @@ async def test_edit_response_not_degraded_when_tier_satisfied(tmp_path):
 
     assert result["backend"] == "iopaint"
     assert result["degraded"] is False  # fast tier prefers iopaint
+
+
+def test_require_image_accepts_image_magic_without_image_content_type():
+    """A valid image whose content-type is not image/* (e.g. octet-stream) is
+    accepted by its magic signature rather than rejected as an error."""
+    png_bytes = base64.b64decode(_png_b64())
+    resp = httpx.Response(
+        200, content=png_bytes, headers={"content-type": "application/octet-stream"}
+    )
+    assert _require_image(resp) == png_bytes
+
+
+def test_require_image_rejects_json_text_200():
+    """A JSON/text 200 with no image magic is still rejected (IOPaint error)."""
+    resp = httpx.Response(
+        200, json={"errors": "model not loaded"}, headers={"content-type": "application/json"}
+    )
+    with pytest.raises(RuntimeError, match="non-image response"):
+        _require_image(resp)
 
 
 @pytest.mark.asyncio

--- a/tests/test_routes_user_workspace.py
+++ b/tests/test_routes_user_workspace.py
@@ -208,6 +208,28 @@ class TestUserWorkspaceRoutes:
         resp = await client.post("/api/workspace/copy", json={"src": "../../etc", "dst": "stolen.txt"})
         assert resp.status_code == 400
 
+    @pytest.mark.asyncio
+    async def test_copy_directory_into_itself_returns_400(self, client):
+        """Copying a directory into a path nested inside itself returns a clean
+        400, not a 500 from shutil.copytree."""
+        await client.post("/api/workspace/mkdir", json={"path": "selfdir"})
+        resp = await client.post(
+            "/api/workspace/copy", json={"src": "selfdir", "dst": "selfdir/nested"}
+        )
+        assert resp.status_code == 400
+        assert "itself" in resp.json()["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_move_directory_into_itself_returns_400(self, client):
+        """Renaming/moving a directory into a path nested inside itself returns a
+        clean 400, not a 500."""
+        await client.post("/api/workspace/mkdir", json={"path": "movedir"})
+        resp = await client.post(
+            "/api/workspace/rename", json={"src": "movedir", "dst": "movedir/inner"}
+        )
+        assert resp.status_code == 400
+        assert "itself" in resp.json()["error"].lower()
+
     def test_dir_signature_changes_on_modification(self):
         """Signature helper drives the SSE watch change-detection loop.
         Unit-tested directly — the full SSE stream endpoint is tested

--- a/tinyagentos/routes/images_edit.py
+++ b/tinyagentos/routes/images_edit.py
@@ -61,7 +61,7 @@ _TIER_PREFERENCE: dict[str, dict[str, list[str]]] = {
 class EditRequest(BaseModel):
     image_ref: str
     op: Literal["erase", "inpaint", "outpaint"]
-    mask: str  # base64 png (raw or data-URI; IOPaint strips the prefix)
+    mask: str  # base64 png (raw or data-URI; both backends strip the prefix)
     prompt: str = ""
     tier: Literal["fast", "quality"] = "fast"
 
@@ -119,27 +119,48 @@ def _resolve_source(request: Request, image_ref: str) -> Optional[Path]:
     return path if path.exists() else None
 
 
-def _save_result(request: Request, image_bytes: bytes, *, source_ref: str, op: str) -> dict:
+def _save_result(
+    request: Request,
+    image_bytes: bytes,
+    *,
+    source_ref: str,
+    op: str,
+    backend_type: Optional[str] = None,
+    degraded: bool = False,
+) -> dict:
     """Save result PNG into the generated dir, copying the source's prompt
-    metadata so the new image is browsable. Returns {url, image_ref, ...}."""
+    metadata so the new image is browsable. Returns {url, image_ref, ...}.
+
+    ``backend_type`` and ``degraded`` surface the backend that actually ran so
+    callers can tell when a requested tier was silently downgraded (e.g. the
+    quality/diffusion tier fell back to the iopaint LaMa eraser, which ignores
+    the prompt).
+    """
     images_dir = _images_dir(request)
     # Unique stem so two edits of the same op within one second don't collide
     # (int(time.time()) alone overwrote the earlier output).
     stem = f"{int(time.time())}_{op}_{uuid4().hex[:8]}"
     filename = f"{stem}.png"
-    (images_dir / filename).write_bytes(image_bytes)
 
-    # Carry forward source metadata where available.
-    metadata = {"prompt": "", "model": op, "size": "", "steps": 0, "seed": 0, "guidance_scale": 0}
-    src_meta = (images_dir / source_ref).with_suffix(".json")
-    if src_meta.exists():
-        try:
-            prev = json.loads(src_meta.read_text())
-            metadata["prompt"] = prev.get("prompt", "")
-        except (json.JSONDecodeError, OSError):
-            pass
-    metadata["model"] = f"edit:{op}"
-    (images_dir / f"{stem}.json").write_text(json.dumps(metadata, indent=2))
+    # The host disk can fail (full / permission) independently of the backend.
+    # Keep that distinct from "backend unreachable" so the frontend can label it.
+    try:
+        (images_dir / filename).write_bytes(image_bytes)
+
+        # Carry forward source metadata where available.
+        metadata = {"prompt": "", "model": op, "size": "", "steps": 0, "seed": 0, "guidance_scale": 0}
+        src_meta = (images_dir / source_ref).with_suffix(".json")
+        if src_meta.exists():
+            try:
+                prev = json.loads(src_meta.read_text())
+                metadata["prompt"] = prev.get("prompt", "")
+            except (json.JSONDecodeError, OSError):
+                pass
+        metadata["model"] = f"edit:{op}"
+        (images_dir / f"{stem}.json").write_text(json.dumps(metadata, indent=2))
+    except OSError as exc:
+        logger.exception("failed to save edit result")
+        raise RuntimeError(f"Could not save result: {exc}") from exc
 
     return {
         "status": "edited",
@@ -147,6 +168,8 @@ def _save_result(request: Request, image_bytes: bytes, *, source_ref: str, op: s
         "image_ref": filename,
         "url": _image_url_path(filename),
         "path": _image_url_path(filename),
+        "backend": backend_type,
+        "degraded": degraded,
     }
 
 
@@ -175,8 +198,10 @@ class IOPaintClient:
         outpaint: bool = False,
     ) -> bytes:
         payload: dict = {
-            "image": image_b64,
-            "mask": mask_b64,
+            # Strip any data-URI prefix so a data-URI mask/image works here too,
+            # matching FluxFillClient (EditRequest.mask is raw or data-URI).
+            "image": _strip_data_uri(image_b64),
+            "mask": _strip_data_uri(mask_b64),
             "prompt": prompt,
             "sd_seed": -1,
         }
@@ -186,16 +211,21 @@ class IOPaintClient:
         async with httpx.AsyncClient(timeout=self.timeout) as client:
             resp = await client.post(f"{self.base}/api/v1/inpaint", json=payload)
             resp.raise_for_status()
-            return resp.content
+            return _require_image(resp)
 
     async def run_plugin(self, name: str, image_b64: str, *, scale: float = 2.0) -> bytes:
-        payload = {"name": name, "image": image_b64, "scale": float(scale), "clicks": []}
+        payload = {
+            "name": name,
+            "image": _strip_data_uri(image_b64),
+            "scale": float(scale),
+            "clicks": [],
+        }
         async with httpx.AsyncClient(timeout=self.timeout) as client:
             resp = await client.post(
                 f"{self.base}/api/v1/run_plugin_gen_image", json=payload
             )
             resp.raise_for_status()
-            return resp.content
+            return _require_image(resp)
 
 
 # --------------------------------------------------------------------------- #
@@ -206,6 +236,19 @@ def _strip_data_uri(b64: str) -> str:
     if b64.startswith("data:") and "," in b64:
         return b64.split(",", 1)[1]
     return b64
+
+
+def _require_image(resp: httpx.Response) -> bytes:
+    """Return the response body only if it is actually an image.
+
+    IOPaint can answer HTTP 200 with a JSON/text error body (missing plugin,
+    bad args, model-load failure). Those bytes would otherwise be saved as a
+    ``.png`` and reported as success, handing the user a broken image. Reject
+    any non-image content-type so it routes into ``_backend_error_response``.
+    """
+    if not resp.headers.get("content-type", "").startswith("image/"):
+        raise RuntimeError(f"IOPaint returned non-image response: {resp.text[:300]}")
+    return resp.content
 
 
 # Fraction of the image's own size to grow each side by when outpainting.
@@ -344,6 +387,11 @@ def _backend_error_response(exc: Exception) -> JSONResponse:
             {"error": f"Editing backend returned error: {exc.response.status_code}"},
             status_code=502,
         )
+    # A failed disk write (full / permission) is a host problem, not the backend
+    # being unreachable; surface it distinctly so the frontend doesn't mislabel
+    # it as "could not reach the editing backend".
+    if isinstance(exc, RuntimeError) and str(exc).startswith("Could not save result"):
+        return JSONResponse({"error": str(exc)}, status_code=500)
     logger.exception("image edit failed")
     return JSONResponse({"error": f"Unexpected error: {exc}"}, status_code=500)
 
@@ -377,6 +425,13 @@ async def edit_image(request: Request, body: EditRequest):
             status_code=503,
         )
 
+    # The tier's first preference is the backend the user effectively asked for;
+    # anything else means _get_edit_backend fell back (e.g. quality → iopaint),
+    # which the response flags as degraded so the prompt-ignoring downgrade isn't
+    # silent.
+    primary = (_TIER_PREFERENCE.get("image-editing", {}).get(body.tier) or [None])[0]
+    degraded = backend_type != primary
+
     try:
         result_bytes = await client.inpaint(
             image_b64,
@@ -384,10 +439,16 @@ async def edit_image(request: Request, body: EditRequest):
             prompt=body.prompt,
             outpaint=body.op == "outpaint",
         )
+        return _save_result(
+            request,
+            result_bytes,
+            source_ref=body.image_ref,
+            op=body.op,
+            backend_type=backend_type,
+            degraded=degraded,
+        )
     except Exception as exc:  # noqa: BLE001 — mapped to a clean HTTP response
         return _backend_error_response(exc)
-
-    return _save_result(request, result_bytes, source_ref=body.image_ref, op=body.op)
 
 
 @router.post("/api/images/remove-bg")
@@ -406,10 +467,12 @@ async def remove_background(request: Request, body: RemoveBgRequest):
     client = IOPaintClient(url)
     try:
         result_bytes = await client.run_plugin("RemoveBG", image_b64)
+        return _save_result(
+            request, result_bytes, source_ref=body.image_ref, op="removebg",
+            backend_type=_backend_type,
+        )
     except Exception as exc:  # noqa: BLE001
         return _backend_error_response(exc)
-
-    return _save_result(request, result_bytes, source_ref=body.image_ref, op="removebg")
 
 
 @router.post("/api/images/upscale")
@@ -428,10 +491,12 @@ async def upscale_image(request: Request, body: UpscaleRequest):
     client = IOPaintClient(url)
     try:
         result_bytes = await client.run_plugin("RealESRGAN", image_b64, scale=float(body.scale))
+        return _save_result(
+            request, result_bytes, source_ref=body.image_ref, op="upscale",
+            backend_type=_backend_type,
+        )
     except Exception as exc:  # noqa: BLE001
         return _backend_error_response(exc)
-
-    return _save_result(request, result_bytes, source_ref=body.image_ref, op="upscale")
 
 
 @router.get("/api/images/edit/capabilities")

--- a/tinyagentos/routes/images_edit.py
+++ b/tinyagentos/routes/images_edit.py
@@ -238,17 +238,34 @@ def _strip_data_uri(b64: str) -> str:
     return b64
 
 
+def _looks_like_image(data: bytes) -> bool:
+    """True if *data* starts with a known image magic signature."""
+    return (
+        data.startswith(b"\x89PNG\r\n\x1a\n")  # PNG
+        or data.startswith(b"\xff\xd8\xff")  # JPEG
+        or (data[:4] == b"RIFF" and data[8:12] == b"WEBP")  # WEBP
+        or data.startswith(b"GIF8")  # GIF
+    )
+
+
 def _require_image(resp: httpx.Response) -> bytes:
     """Return the response body only if it is actually an image.
 
     IOPaint can answer HTTP 200 with a JSON/text error body (missing plugin,
     bad args, model-load failure). Those bytes would otherwise be saved as a
     ``.png`` and reported as success, handing the user a broken image. Reject
-    any non-image content-type so it routes into ``_backend_error_response``.
+    such a response so it routes into ``_backend_error_response``.
+
+    Some valid backends return image bytes without an ``image/*`` content-type
+    (or with ``application/octet-stream``), so accept the body when either the
+    content-type is an image or the bytes carry an image magic signature. Only
+    raise when it is clearly not an image (e.g. a JSON/text error body).
     """
-    if not resp.headers.get("content-type", "").startswith("image/"):
-        raise RuntimeError(f"IOPaint returned non-image response: {resp.text[:300]}")
-    return resp.content
+    content = resp.content
+    is_image_type = resp.headers.get("content-type", "").startswith("image/")
+    if is_image_type or _looks_like_image(content):
+        return content
+    raise RuntimeError(f"IOPaint returned non-image response: {resp.text[:300]}")
 
 
 # Fraction of the image's own size to grow each side by when outpainting.
@@ -425,12 +442,15 @@ async def edit_image(request: Request, body: EditRequest):
             status_code=503,
         )
 
-    # The tier's first preference is the backend the user effectively asked for;
-    # anything else means _get_edit_backend fell back (e.g. quality → iopaint),
-    # which the response flags as degraded so the prompt-ignoring downgrade isn't
-    # silent.
-    primary = (_TIER_PREFERENCE.get("image-editing", {}).get(body.tier) or [None])[0]
-    degraded = backend_type != primary
+    # Only a meaningful downgrade is flagged: a quality request that did NOT get
+    # the quality primary (flux-fill) fell back to the fast iopaint eraser, which
+    # ignores the prompt. Falling between fast-tier preferences is not a
+    # meaningful degrade, so fast requests (and quality served by flux-fill) are
+    # never flagged. The chosen backend type is surfaced in the response either way.
+    quality_primary = (
+        _TIER_PREFERENCE.get("image-editing", {}).get("quality") or [None]
+    )[0]
+    degraded = body.tier == "quality" and backend_type != quality_primary
 
     try:
         result_bytes = await client.inpaint(

--- a/tinyagentos/routes/user_workspace.py
+++ b/tinyagentos/routes/user_workspace.py
@@ -63,6 +63,16 @@ def _resolve_safe(workspace: Path, subpath: str) -> Path | None:
         return None
 
 
+def _is_within(dst: Path, src: Path) -> bool:
+    """True if *dst* is *src* itself or nested inside it.
+
+    Copying or moving a directory into a path under itself makes
+    ``shutil.copytree`` / ``Path.rename`` raise, which would otherwise escape
+    as a bare 500. Both paths are already resolved by ``_resolve_safe``.
+    """
+    return dst == src or dst.is_relative_to(src)
+
+
 class MkdirRequest(BaseModel):
     path: str
 
@@ -232,6 +242,10 @@ async def api_rename(request: Request, body: RenameRequest):
         return JSONResponse({"error": "Source not found"}, status_code=404)
     if dst.exists():
         return JSONResponse({"error": "Target already exists"}, status_code=409)
+    if _is_within(dst, src):
+        return JSONResponse(
+            {"error": "Cannot move a directory into itself"}, status_code=400
+        )
 
     dst.parent.mkdir(parents=True, exist_ok=True)
     src.rename(dst)
@@ -259,6 +273,10 @@ async def api_copy(request: Request, body: CopyRequest):
         return JSONResponse({"error": "Source not found"}, status_code=404)
     if dst.exists():
         return JSONResponse({"error": "Target already exists"}, status_code=409)
+    if _is_within(dst, src):
+        return JSONResponse(
+            {"error": "Cannot copy a directory into itself"}, status_code=400
+        )
 
     dst.parent.mkdir(parents=True, exist_ok=True)
     # Run the blocking copy off the event loop so large trees do not stall it.


### PR DESCRIPTION
Reliability and correctness hardening for the tier-aware image-editing backend, found by audit. All five fixes are surgical and preserve existing behavior.

Fix 1, mask data-URI inconsistency. EditRequest.mask is documented as raw or data-URI, but only FluxFillClient stripped a data:image/...;base64, prefix. IOPaintClient sent the prefixed string straight into the payload, so a data-URI mask corrupted or failed for IOPaint while working for FLUX, making the outcome dispatch-dependent. IOPaintClient now strips the prefix on both the image and the mask (and on run_plugin images), so both backends receive identical, prefix-free input.

Fix 2, silent fake-success on non-image responses. IOPaint can return HTTP 200 with a JSON or text error body (missing plugin, bad args, model-load failure). Those bytes were written as a .png and returned as a success, handing the user a broken image. After raise_for_status the response content-type is now checked, and a non-image body raises a RuntimeError that routes into the existing backend error response, matching the strictness FluxFill already had via its JSON images check.

Fix 3, unannounced tier downgrade. Selecting the quality tier with no healthy flux-fill backend silently falls back to iopaint (LaMa), which ignores the prompt, so the user believed diffusion ran. The fallback is kept (it is a deliberate availability feature), but the edit response now carries the backend type that actually ran plus a degraded flag, so the downgrade is no longer silent. A frontend banner is a separate follow-up.

Fix 4, save error mislabeled. The result writes in _save_result ran outside the endpoint try/except, so a full-disk or permission OSError on the host escaped as a bare 500 and the frontend showed could not reach the editing backend, which is wrong. The writes are now wrapped, log the exception, and raise a Could not save result error that maps to a distinct response separate from backend-unreachable.

Fix 5, copy or move a directory into itself returned a 500. In user_workspace, copying or moving a directory into a path nested inside itself made shutil.copytree or Path.rename raise an unhandled 500. A guard now returns a clean 400 when the destination is the source or nested inside it, keeping the existing path-traversal guard intact.

Tests extended in tests/test_routes_images_edit.py and tests/test_routes_user_workspace.py cover: IOPaint non-image 200 maps to an error and saves no png, the data-URI mask is stripped for IOPaint, the response surfaces the backend type and the degraded flag (set and unset), a save OSError yields a clean Could not save result error, and copy or move into self returns 400. All existing tests stay green.
