### PR TITLE
fix(catalog): auto-register iopaint + flux-fill edit backends

### DIFF
--- a/app-catalog/models/ltx-video/manifest.yaml
+++ b/app-catalog/models/ltx-video/manifest.yaml
@@ -5,6 +5,8 @@ version: 0.9.5
 description: "Lightricks open video gen — 2B params, real-time generation on H100, 24 fps, 768×512. Apache-2.0 weights, fastest open video model in its class."
 homepage: https://huggingface.co/Lightricks/LTX-Video
 license: Apache-2.0
+# T5 text-encoder prompt limit (diffusers LTXPipeline max_sequence_length default).
+context_window: 128
 capabilities:
 - video-generation
 - image-to-video

--- a/app-catalog/services/flux-fill/manifest.yaml
+++ b/app-catalog/services/flux-fill/manifest.yaml
@@ -18,6 +18,10 @@ install:
   method: script
   script: scripts/install-flux-fill.sh
 
+lifecycle:
+  backend_type: flux-fill
+  default_url: http://127.0.0.1:38298
+
 # GPU / CUDA only. The encoders run on CPU so a 12GB card fits the model with
 # headroom; smaller cards and non-CUDA hosts use the iopaint editing tier.
 hardware_tiers:

--- a/app-catalog/services/iopaint/manifest.yaml
+++ b/app-catalog/services/iopaint/manifest.yaml
@@ -1,6 +1,6 @@
 id: iopaint
 name: IOPaint
-type: iopaint
+type: service
 category: image-gen
 version: 1.6.0
 description: "AI image editing — erase objects, inpaint, remove backgrounds and upscale. Runs on CPU including ARM."
@@ -16,6 +16,10 @@ requires:
 install:
   method: script
   script: scripts/install-iopaint.sh
+
+lifecycle:
+  backend_type: iopaint
+  default_url: http://127.0.0.1:30493
 
 hardware_tiers:
   arm-npu-16gb: degraded

--- a/tests/test_config_auto_register.py
+++ b/tests/test_config_auto_register.py
@@ -296,3 +296,30 @@ default_url: http://localhost:8080
     config = AppConfig()
     added = auto_register_from_manifest(manifest, config)  # no hardware_profile kwarg
     assert added is True
+
+
+_CATALOG = Path(__file__).resolve().parents[1] / "app-catalog" / "services"
+
+
+@pytest.mark.parametrize(
+    "service, backend_type, url",
+    [
+        ("iopaint", "iopaint", "http://127.0.0.1:30493"),
+        ("flux-fill", "flux-fill", "http://127.0.0.1:38298"),
+    ],
+)
+def test_shipped_image_edit_manifests_register(service, backend_type, url):
+    """The real iopaint/flux-fill catalog manifests must register a backend
+    entry on install, otherwise the Images Studio edit tier has no backend
+    with the image-editing capability and every edit request returns 503.
+
+    Both carry the backend type via lifecycle.backend_type on the catalog
+    (type: service) path; regressing the lifecycle block silently breaks the
+    edit tier."""
+    manifest = _CATALOG / service / "manifest.yaml"
+    config = AppConfig()
+    added = auto_register_from_manifest(manifest, config)
+    assert added is True
+    entry = config.backends[-1]
+    assert entry["type"] == backend_type
+    assert entry["url"] == url


### PR DESCRIPTION
## The gap

The Images Studio edit tier (erase, inpaint, outpaint, remove background, upscale) is served by two installable backends, IOPaint and FLUX.1-Fill. Their service manifests shipped without a lifecycle block, so when a user installed either one, auto_register_from_manifest in tinyagentos/config.py derived an empty backend_type and added no entry to config.backends.

With no registered backend, the scheduler catalog reported no image-editing capability, and /api/images/edit, /api/images/remove-bg and /api/images/upscale returned 503 No image-editing backend installed on every install. The capability map, the valid backend types, the adapters and the tier routing in routes/images_edit.py were all already correct. The only missing link was the manifest lifecycle block that feeds registration.

## The fix

auto_register_from_manifest reads the backend type and URL from lifecycle.backend_type and lifecycle.default_url for catalog manifests (those with type: service). Both manifests now carry that block.

IOPaint additionally declared type: iopaint. On the flat path that was read as the backend type but with no default_url, so even a registered entry would have had an empty URL. It is now type: service with the backend type carried by lifecycle.backend_type, and a local default_url on its deterministic high-pool port (30493). FLUX.1-Fill gets the same lifecycle block on port 38298 and stays GPU and CUDA gated by its existing hardware_tiers.

After this, installing either backend registers an entry, the catalog reports the image-editing capability, and edits route to the right tier with the existing health filtering.

## ltx-video

While in the catalog, populated context_window on the ltx-video model manifest, the only failure reported by scripts/audit-manifests.py. Set to 128, the T5 text-encoder prompt limit (the diffusers LTX pipeline max_sequence_length default), matching how the sibling text-conditioned diffusion manifests carry their encoder token limit.

## Verification

- scripts/audit-manifests.py reports clean, no failures.
- create_app() imports and builds without error.
- A new parametrized regression test asserts the shipped iopaint and flux-fill manifests each register a backend entry with the correct type and URL.
- tests/test_config_auto_register.py and tests/test_routes_images_edit.py pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated service configurations for flux-fill and iopaint, adding lifecycle settings with backend type identifiers and network endpoint configurations.
  * Enhanced model configuration settings for ltx-video.

* **Tests**
  * Added test coverage to ensure service manifests auto-register correctly with their expected backend types and network endpoint configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->