### PR TITLE
fix(flux-fill): loopback bind by default

### DIFF
--- a/scripts/install-flux-fill.sh
+++ b/scripts/install-flux-fill.sh
@@ -38,14 +38,16 @@ set -euo pipefail
 FLUX_FILL_PORT="${TAOS_FLUX_FILL_PORT:-38298}"
 
 # Host interface that Docker publishes the backend on.
-# SECURITY: sd-server has NO authentication. By default we publish on 0.0.0.0
-# because the taOS controller dials this backend over the tailnet from another
-# host, so 127.0.0.1 would break that cross-host call. This is only safe while
-# the host sits on a private tailnet or a firewalled LAN. Operators running on
-# an exposed host MUST set TAOS_FLUX_FILL_BIND to a specific private interface
-# IP (e.g. the tailnet address) so the unauthenticated server is not reachable
-# from public interfaces. (Mirrors the bind note in install-sd-cpp.sh.)
-FLUX_FILL_BIND="${TAOS_FLUX_FILL_BIND:-0.0.0.0}"
+# SECURITY: sd-server has NO authentication. This backend is for taOS's OWN use
+# only, so by default we publish on 127.0.0.1 (loopback). Docker then exposes the
+# port on loopback alone, so the unauthenticated server is never reachable over
+# the network. This is the safe default and resolves the prior 0.0.0.0 exposure.
+# Operators running taOS in a SPLIT/cluster layout (controller on one host, GPU
+# on another) who need cross-host access must EITHER set TAOS_FLUX_FILL_BIND to a
+# specific private interface IP (e.g. a tailnet address) OR, preferably, keep the
+# loopback default and reach the server via an SSH tunnel. Do not default to
+# 0.0.0.0. (Mirrors the bind note in install-sd-cpp.sh.)
+FLUX_FILL_BIND="${TAOS_FLUX_FILL_BIND:-127.0.0.1}"
 FLUX_FILL_CONTAINER="${TAOS_FLUX_FILL_CONTAINER:-taos-sdcpp-fill}"
 FLUX_FILL_IMAGE="${TAOS_FLUX_FILL_IMAGE:-taos-sdcpp:cuda}"
 MODELS_DIR="${TAOS_FLUX_FILL_MODELS_DIR:-$HOME/.cache/taos-sdcpp/models}"


### PR DESCRIPTION
The FLUX Fill image-edit server (leejet sd-server, no authentication) previously published on 0.0.0.0 by default to support cross-host calls. This server is for taOS's own use only, so exposing it on every interface was unnecessary risk and triggered a security finding about the 0.0.0.0 bind.

This change makes the default bind 127.0.0.1 (loopback). Docker now publishes the port on loopback alone, so the unauthenticated server is never reachable over the network. The TAOS_FLUX_FILL_BIND override is unchanged.

Operators running taOS in a split or cluster layout (controller on one host, GPU on another) who need cross-host access can either set TAOS_FLUX_FILL_BIND to a specific private interface IP (for example a tailnet address) or, preferably, keep the loopback default and reach the server over an SSH tunnel. The SECURITY comment block in the script documents this posture.

The docker -p mapping still works with the loopback default: Docker publishes on 127.0.0.1. The flux-fill manifest has no bind or default_url field, so no manifest change was needed.

Verification: bash -n passes; scripts/audit-manifests.py reports only the pre-existing unrelated ltx-video issue and no new failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated installer configuration for improved security: the unauthenticated service endpoint now defaults to binding to localhost only, restricting access to the local machine. Users can override this setting via environment variable configuration for deployments requiring network access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->