### PR TITLE
fix(test): safety-regression test failure

### DIFF
--- a/desktop/src/components/SafetyFloor.tsx
+++ b/desktop/src/components/SafetyFloor.tsx
@@ -28,7 +28,7 @@ export function SafetyFloor() {
   return (
     <div style={{ position: "fixed", zIndex: 10000, top: 4, right: 8, pointerEvents: "auto" }}>
       <button
-        aria-label="taOS agent"
+        aria-label="taOS assistant"
         onClick={openPanel}
         className="rounded-full p-2 bg-shell-surface-active hover:brightness-110 transition-[filter]"
       >


### PR DESCRIPTION
The safety-regression test (desktop/src/theme/__tests__/safety-regression.test.tsx) was failing on origin/dev, pre-existing and not from recent work. It queries for the assistant escape-hatch button with getByRole("button", { name: /assistant/i }), but the SafetyFloor component rendered its button with aria-label="taOS agent". The accessible name "taOS agent" does not contain the word "assistant", so the role query never matched and the assertion threw.

SafetyFloor is the system-owned, un-overridable assistant button of last resort: when the active theme hides the top bar, this fallback is the only way to reach the assistant, enforcing the requires: ["assistant"] safety contract. Two separate test files (the theme safety-regression suite and the component's own SafetyFloor.test) independently assert this button is discoverable by the accessible name "assistant". A safety affordance that cannot be found by its own purpose word is a genuine accessibility gap in the component, not a stale test.

So the fix is in the component, not the test. The button aria-label changed from "taOS agent" to "taOS assistant", which keeps the taOS branding while satisfying the accessibility contract the tests guard. The tests were left untouched and not weakened.

Verification: the target test now passes; the full theme and stores suites plus the SafetyFloor suite are green (132 tests); tsc --noEmit is clean; npm run build succeeds (only a pre-existing unrelated dynamic-import warning).