### PR TITLE
feat(game-studio): Game Studio app shell (phase 1)

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -50,6 +50,7 @@
         "rehype-slug": "^6.0.0",
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.6.0",
+        "three": "0.180.0",
         "zustand": "^5.0.14"
       },
       "devDependencies": {
@@ -59,6 +60,7 @@
         "@testing-library/react": "^16.3.2",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.0.0",
+        "@types/three": "0.180.0",
         "@vitejs/plugin-react": "^6.0.2",
         "jsdom": "^29.1.1",
         "tailwindcss": "^4.0.0",
@@ -758,6 +760,13 @@
       "engines": {
         "node": ">=20.19.0"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
@@ -5157,6 +5166,13 @@
         "@tsparticles/engine": "3.9.1"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -5281,6 +5297,29 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.180.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.180.0.tgz",
+      "integrity": "sha512-ykFtgCqNnY0IPvDro7h+9ZeLY+qjgUWv+qEvUt84grhenO60Hqd4hScHE7VTB9nOQ/3QM8lkbNE+4vKjEpUxKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
+        "@webgpu/types": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~0.22.0"
+      }
+    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
@@ -5298,6 +5337,13 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
@@ -5586,6 +5632,13 @@
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.38.tgz",
       "integrity": "sha512-FTW0AFZNaK5/mOqvGBwVfUlNLU38TiQn4+DQgIFUnrBBJQ1crMJ82yeGQLV5jyKFsO8yRukpbuP7x+nRbH6aug==",
       "license": "MIT"
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.70",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.70.tgz",
+      "integrity": "sha512-LFiNHHKMvmAEvwVew3JLJmTdShhbdwRFSImUshGhE2mGE8ybQzIo63l5uRp+YKnNx+8Qno8Kf6gN+DKMreIJCA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@xterm/addon-fit": {
       "version": "0.11.0",
@@ -6163,6 +6216,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/flairup": {
       "version": "1.0.0",
@@ -7298,6 +7358,13 @@
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/meshoptimizer": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.22.0.tgz",
+      "integrity": "sha512-IebiK79sqIy+E4EgOr+CAw+Ke8hAspXKzBd0JdgEmPHiAwmvEj2S4h1rfvo+o/BnfEYd/jAOg5IeeIjzlzSnDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/micromark": {
       "version": "4.0.2",
@@ -9076,6 +9143,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/three": {
+      "version": "0.180.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.180.0.tgz",
+      "integrity": "sha512-o+qycAMZrh+TsE01GqWUxUIKR1AL0S8pq7zDkYOQw8GqfX8b8VoCKYUoHbhiX5j+7hr8XsuHDVU6+gkQJQKg9w==",
+      "license": "MIT"
     },
     "node_modules/tiny-emitter": {
       "version": "2.1.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -54,6 +54,7 @@
     "rehype-slug": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.6.0",
+    "three": "0.180.0",
     "zustand": "^5.0.14"
   },
   "devDependencies": {
@@ -63,6 +64,7 @@
     "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.0.0",
+    "@types/three": "0.180.0",
     "@vitejs/plugin-react": "^6.0.2",
     "jsdom": "^29.1.1",
     "tailwindcss": "^4.0.0",

--- a/desktop/src/apps/GameStudioApp.tsx
+++ b/desktop/src/apps/GameStudioApp.tsx
@@ -1,0 +1,120 @@
+import { useState } from "react";
+import { Sparkles, Play, Share2 } from "lucide-react";
+import { CreateView } from "./gamestudio/CreateView";
+import { PlayView } from "./gamestudio/PlayView";
+import { ShareView } from "./gamestudio/ShareView";
+import { DEFAULT_TEMPLATE } from "./gamestudio/templates";
+import { OFFLINE_MODELS, type StudioView, type Template } from "./gamestudio/types";
+
+/* ------------------------------------------------------------------ */
+/*  Game Studio — shell (phase 1)                                      */
+/*                                                                     */
+/*  Make a game from a prompt, test it live, share it to the Store.    */
+/*  Left icon rail (Create / Play / Share) + the active surface, the   */
+/*  same shape as Images Studio.                                        */
+/*                                                                      */
+/*  Phase 1 ships the shell + a genuinely-working three.js preview.    */
+/*  Offline AI generation, the skill pack and the store-publish        */
+/*  backend are later phases and are surfaced as honest "coming"        */
+/*  affordances, never faked. Registered as a normal app for now;       */
+/*  it should become an optional install in a follow-up (#53).          */
+/* ------------------------------------------------------------------ */
+
+const RAIL: { id: StudioView; label: string; icon: typeof Sparkles }[] = [
+  { id: "create", label: "Create", icon: Sparkles },
+  { id: "play", label: "Play", icon: Play },
+  { id: "share", label: "Share", icon: Share2 },
+];
+
+export function GameStudioApp({ windowId: _windowId }: { windowId: string }) {
+  const [view, setView] = useState<StudioView>("create");
+
+  // Create-form state (illustrative in phase 1; the template drives Play).
+  const [prompt, setPrompt] = useState("");
+  const [genres, setGenres] = useState<Set<string>>(new Set(["Platformer"]));
+  const [model, setModel] = useState<string>(OFFLINE_MODELS[0]);
+
+  // The template loaded into Play & Test + Share. Defaults to the first so
+  // the Play stage always has a real scene to render.
+  const [active, setActive] = useState<Template>(DEFAULT_TEMPLATE);
+
+  const toggleGenre = (g: string) =>
+    setGenres((prev) => {
+      const next = new Set(prev);
+      if (next.has(g)) next.delete(g);
+      else next.add(g);
+      return next;
+    });
+
+  const useTemplate = (t: Template) => {
+    setActive(t);
+    setView("play");
+  };
+
+  return (
+    <div className="flex h-full min-h-0 flex-col overflow-hidden bg-shell-bg text-shell-text select-none">
+      {/* scoped: custom select chevron matching the rest of the shell */}
+      <style>{`
+        .gs-select {
+          -webkit-appearance: none; appearance: none;
+          background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%238b92a3' stroke-width='2.5'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
+          background-repeat: no-repeat; background-position: right 12px center; padding-right: 32px;
+        }
+      `}</style>
+
+      {/* title strip */}
+      <div className="flex h-[46px] flex-none items-center justify-center border-b border-shell-border">
+        <span className="text-[13px] font-semibold tracking-[-0.01em]">Game Studio</span>
+      </div>
+
+      <div className="flex min-h-0 flex-1">
+        {/* left rail */}
+        <nav
+          aria-label="Game Studio views"
+          className="flex w-[68px] flex-none flex-col items-center gap-1.5 border-r border-shell-border bg-shell-bg-deep py-3.5"
+        >
+          {RAIL.map((r) => {
+            const Icon = r.icon;
+            const on = view === r.id;
+            return (
+              <button
+                key={r.id}
+                type="button"
+                aria-label={r.label}
+                aria-current={on ? "page" : undefined}
+                onClick={() => setView(r.id)}
+                className={`flex h-[46px] w-[46px] flex-col items-center justify-center gap-0.5 rounded-xl text-[9px] font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${
+                  on
+                    ? "bg-gradient-to-b from-accent/25 to-transparent text-accent"
+                    : "text-shell-text-tertiary hover:bg-white/10 hover:text-shell-text-secondary"
+                }`}
+              >
+                <Icon size={21} />
+                {r.label}
+              </button>
+            );
+          })}
+        </nav>
+
+        {/* active surface */}
+        <div className="flex min-w-0 flex-1 flex-col">
+          {view === "create" && (
+            <CreateView
+              prompt={prompt}
+              onPromptChange={setPrompt}
+              genres={genres}
+              onToggleGenre={toggleGenre}
+              model={model}
+              onModelChange={setModel}
+              onUseTemplate={useTemplate}
+            />
+          )}
+
+          {view === "play" && <PlayView key={active.id} template={active} />}
+
+          {view === "share" && <ShareView template={active} />}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/apps/gamestudio/CreateView.tsx
+++ b/desktop/src/apps/gamestudio/CreateView.tsx
@@ -1,0 +1,210 @@
+import { useState } from "react";
+import { Play, Sparkles, Info } from "lucide-react";
+import { TEMPLATES } from "./templates";
+import {
+  GENRES,
+  OFFLINE_MODELS,
+  ART_STYLES,
+  DIFFICULTIES,
+  type Template,
+} from "./types";
+
+/* ------------------------------------------------------------------ */
+/*  CreateView — prompt box + genre/template chips + template gallery  */
+/*                                                                     */
+/*  Honesty: offline generation is a later phase. "Generate game" does */
+/*  not fake a build; it surfaces a clear "offline generation is        */
+/*  coming" note and points at the templates, which load real scenes.  */
+/*  The model selector is labelled but inert (note attached).           */
+/* ------------------------------------------------------------------ */
+
+export interface CreateViewProps {
+  prompt: string;
+  onPromptChange: (v: string) => void;
+  genres: Set<string>;
+  onToggleGenre: (g: string) => void;
+  model: string;
+  onModelChange: (m: string) => void;
+  /** Loads the template's real demo scene into the Play view. */
+  onUseTemplate: (t: Template) => void;
+}
+
+export function CreateView(props: CreateViewProps) {
+  const { prompt, onPromptChange, genres, onToggleGenre, model, onModelChange, onUseTemplate } =
+    props;
+  const [showComing, setShowComing] = useState(false);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+      <div
+        className="flex flex-col gap-[18px] p-[22px]"
+        style={{ paddingBottom: "calc(22px + env(safe-area-inset-bottom, 0px))" }}
+      >
+        <header>
+          <h2 className="text-[17px] font-bold tracking-[-0.02em]">
+            Describe the game you want to make
+          </h2>
+          <p className="mt-1 text-[12.5px] text-shell-text-secondary">
+            Type an idea or start from a template. A template loads a live 3D preview you can play
+            right away.
+          </p>
+        </header>
+
+        {/* prompt + controls card */}
+        <section className="rounded-2xl border border-shell-border bg-shell-surface p-4 shadow-card">
+          <label htmlFor="gs-prompt" className="sr-only">
+            Game idea
+          </label>
+          <textarea
+            id="gs-prompt"
+            value={prompt}
+            onChange={(e) => onPromptChange(e.target.value)}
+            rows={3}
+            placeholder="A neon endless runner where a fox dodges traffic across rooftops at night, with a double-jump and a coin combo meter."
+            className="w-full resize-none rounded-xl border border-shell-border bg-shell-bg-deep px-3.5 py-3 text-[13px] text-shell-text placeholder:text-shell-text-tertiary focus-visible:border-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/20"
+          />
+
+          {/* genre chips (multi-select, illustrative) */}
+          <div className="mt-3 flex flex-wrap gap-2" role="group" aria-label="Genre">
+            {GENRES.map((g) => {
+              const on = genres.has(g);
+              return (
+                <button
+                  key={g}
+                  type="button"
+                  aria-pressed={on}
+                  onClick={() => onToggleGenre(g)}
+                  className={`rounded-full border px-3 py-1.5 text-[12px] font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${
+                    on
+                      ? "border-accent/40 bg-accent-soft text-shell-text"
+                      : "border-shell-border bg-shell-surface text-shell-text-secondary hover:bg-white/10 hover:text-shell-text"
+                  }`}
+                >
+                  {g}
+                </button>
+              );
+            })}
+          </div>
+
+          {/* model / style / difficulty — labelled, mostly inert in phase 1 */}
+          <div className="mt-3.5 grid grid-cols-1 gap-2.5 sm:grid-cols-3">
+            <Field label="Model (offline)">
+              <select
+                value={model}
+                onChange={(e) => onModelChange(e.target.value)}
+                className="gs-select w-full rounded-xl border border-shell-border bg-shell-bg-deep px-3 py-2.5 text-[13px] text-shell-text focus-visible:border-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/20"
+              >
+                {OFFLINE_MODELS.map((m) => (
+                  <option key={m}>{m}</option>
+                ))}
+              </select>
+            </Field>
+            <Field label="Art style">
+              <select
+                disabled
+                className="gs-select w-full cursor-not-allowed rounded-xl border border-shell-border bg-shell-bg-deep px-3 py-2.5 text-[13px] text-shell-text-secondary opacity-70"
+              >
+                {ART_STYLES.map((s) => (
+                  <option key={s}>{s}</option>
+                ))}
+              </select>
+            </Field>
+            <Field label="Difficulty">
+              <select
+                disabled
+                defaultValue="Normal"
+                className="gs-select w-full cursor-not-allowed rounded-xl border border-shell-border bg-shell-bg-deep px-3 py-2.5 text-[13px] text-shell-text-secondary opacity-70"
+              >
+                {DIFFICULTIES.map((d) => (
+                  <option key={d}>{d}</option>
+                ))}
+              </select>
+            </Field>
+          </div>
+
+          <div className="mt-4 flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              onClick={() => setShowComing(true)}
+              className="flex h-[44px] items-center gap-2 rounded-full bg-gradient-to-br from-accent to-accent/70 px-5 text-[13px] font-bold text-white shadow-lg shadow-accent/20 transition-all hover:-translate-y-0.5 hover:brightness-105"
+            >
+              <Sparkles size={17} />
+              Generate with AI
+            </button>
+            <span className="text-[11px] text-shell-text-tertiary">
+              Offline generation arrives in a later phase. Start from a template below to play now.
+            </span>
+          </div>
+
+          {showComing && (
+            <div
+              role="status"
+              className="mt-3 flex items-start gap-2.5 rounded-xl border border-accent/30 bg-accent-soft px-3.5 py-3"
+            >
+              <Info size={16} className="mt-0.5 flex-none text-accent" />
+              <div className="text-[12.5px] leading-relaxed text-shell-text-secondary">
+                <span className="font-semibold text-shell-text">Offline generation is coming.</span>{" "}
+                In a later phase a local model turns this prompt into a playable build on your taOS.
+                For now, pick a template below: it loads a real, interactive 3D scene into Play &amp;
+                Test.
+              </div>
+            </div>
+          )}
+        </section>
+
+        {/* template gallery */}
+        <section>
+          <h2 className="text-[16px] font-bold tracking-[-0.01em]">Start from a template</h2>
+          <p className="mb-3.5 mt-1 text-[12.5px] text-shell-text-secondary">
+            Each template loads a live three.js scene you can play, test and share.
+          </p>
+          <div className="grid grid-cols-[repeat(auto-fill,minmax(220px,1fr))] gap-3.5">
+            {TEMPLATES.map((t) => (
+              <TemplateCard key={t.id} template={t} onUse={() => onUseTemplate(t)} />
+            ))}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <span className="mb-1.5 block text-[12px] font-semibold text-shell-text-secondary">
+        {label}
+      </span>
+      {children}
+    </div>
+  );
+}
+
+function TemplateCard({ template, onUse }: { template: Template; onUse: () => void }) {
+  return (
+    <div className="flex flex-col overflow-hidden rounded-2xl border border-shell-border bg-shell-surface shadow-card transition-all hover:-translate-y-0.5 hover:border-shell-border-strong hover:shadow-card-hover">
+      <div className="relative h-[104px]" style={{ background: template.cover }}>
+        <span className="absolute left-2.5 top-2.5 rounded-full bg-black/40 px-2 py-1 text-[10px] font-bold uppercase tracking-wide text-white/85 backdrop-blur-sm">
+          {template.genre}
+        </span>
+      </div>
+      <div className="flex flex-1 flex-col gap-1.5 p-3.5">
+        <div className="text-[13.5px] font-bold">{template.title}</div>
+        <p className="flex-1 text-[11.5px] leading-relaxed text-shell-text-secondary">
+          {template.desc}
+        </p>
+        <div className="mt-1 flex items-center justify-between">
+          <span className="text-[11px] text-shell-text-tertiary">Building block</span>
+          <button
+            type="button"
+            onClick={onUse}
+            className="flex items-center gap-1.5 rounded-full border border-shell-border bg-shell-surface-active px-3 py-1.5 text-[11.5px] font-bold text-shell-text transition-colors hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+          >
+            <Play size={12} />
+            Use
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/apps/gamestudio/PlayView.tsx
+++ b/desktop/src/apps/gamestudio/PlayView.tsx
@@ -1,0 +1,326 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Play,
+  Pause,
+  RotateCcw,
+  Maximize2,
+  Monitor,
+  Smartphone,
+  Glasses,
+  LogOut,
+  ListTree,
+  Loader2,
+  Check,
+  Clock,
+} from "lucide-react";
+import { useGameScene } from "./useGameScene";
+import { BUILD_LOG } from "./templates";
+import type { DevicePreview, Template } from "./types";
+
+/* ------------------------------------------------------------------ */
+/*  PlayView — the real three.js preview stage                         */
+/*                                                                     */
+/*  HARD REQUIREMENT (Jay): whenever the stage is fullscreen, an        */
+/*  always-visible "Exit to taOS" pill is layered on top, and Escape    */
+/*  exits fullscreen on desktop. The user is never trapped.             */
+/*                                                                      */
+/*  Real: WebGLRenderer scene, play/pause, WASD + drag controls, a      */
+/*  live FPS overlay, the Fullscreen API, device resize (Desktop /      */
+/*  Mobile). Stubbed-but-honest: XR is a labelled affordance (real      */
+/*  WebXR is a later phase); the build log is an illustrative preview   */
+/*  of the future agent trace.                                          */
+/* ------------------------------------------------------------------ */
+
+const DEVICE_SIZES: Record<DevicePreview, { maxW: number | null; aspect: string }> = {
+  desktop: { maxW: null, aspect: "16 / 10" },
+  mobile: { maxW: 300, aspect: "9 / 16" },
+  xr: { maxW: 560, aspect: "16 / 8" },
+};
+
+export interface PlayViewProps {
+  template: Template;
+}
+
+export function PlayView({ template }: PlayViewProps) {
+  const scene = useGameScene(template.scene);
+  const { hostRef, playing, togglePlay, setPlaying, fps, reset, supported } = scene;
+
+  const stageRef = useRef<HTMLDivElement | null>(null);
+  const [device, setDevice] = useState<DevicePreview>("desktop");
+  const [isFs, setIsFs] = useState(false);
+
+  // Track native fullscreen state. The Exit pill + Esc both call exitFs.
+  useEffect(() => {
+    const onChange = () => setIsFs(document.fullscreenElement === stageRef.current);
+    document.addEventListener("fullscreenchange", onChange);
+    return () => document.removeEventListener("fullscreenchange", onChange);
+  }, []);
+
+  const enterFs = useCallback(() => {
+    const el = stageRef.current;
+    el?.requestFullscreen?.().catch(() => {});
+  }, []);
+
+  const exitFs = useCallback(() => {
+    if (document.fullscreenElement) document.exitFullscreen?.().catch(() => {});
+  }, []);
+
+  const toggleFs = useCallback(() => {
+    if (document.fullscreenElement) exitFs();
+    else enterFs();
+  }, [enterFs, exitFs]);
+
+  // Escape exits fullscreen on desktop. The browser fires its own Esc for
+  // native fullscreen too; this guarantees the affordance and keeps the
+  // app's own state in sync, so the user is never trapped.
+  useEffect(() => {
+    if (!isFs) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") exitFs();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [isFs, exitFs]);
+
+  const size = DEVICE_SIZES[device];
+  const isXr = device === "xr";
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+      <div className="flex flex-col gap-3.5 p-[22px]">
+        {/* heading */}
+        <div className="flex flex-wrap items-baseline gap-2.5">
+          <h2 className="text-[17px] font-bold tracking-[-0.02em]">{template.title}</h2>
+          <span className="text-[11px] text-shell-text-tertiary">
+            {template.genre} · live preview · auto-saved
+          </span>
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-[1fr_312px]">
+          {/* ---- stage + transport ---- */}
+          <div className="flex flex-col gap-3">
+            <div
+              className="relative mx-auto w-full overflow-hidden rounded-2xl border border-shell-border-strong bg-[#0a0d14] shadow-card"
+              style={{
+                aspectRatio: isFs ? undefined : size.aspect,
+                maxWidth: isFs ? undefined : (size.maxW ?? undefined),
+                height: isFs ? "100%" : undefined,
+              }}
+              ref={stageRef}
+            >
+              {/* three.js canvas host */}
+              <div ref={hostRef} className="absolute inset-0 h-full w-full" />
+
+              {/* honest fallback if WebGL is unavailable */}
+              {!supported && (
+                <div className="absolute inset-0 flex items-center justify-center px-6 text-center text-[12.5px] text-white/70">
+                  This device could not start WebGL, so the 3D preview is unavailable here.
+                </div>
+              )}
+
+              {/* XR is a labelled affordance in phase 1 (real WebXR later) */}
+              {isXr && (
+                <div className="pointer-events-none absolute inset-x-0 bottom-0 z-10 bg-gradient-to-t from-black/65 to-transparent px-3 pb-3 pt-8">
+                  <span className="rounded-full bg-black/55 px-2.5 py-1 text-[10.5px] font-semibold text-white/85 backdrop-blur-sm">
+                    XR preview framing · real WebXR headset support arrives in a later phase
+                  </span>
+                </div>
+              )}
+
+              {/* PERSISTENT Exit to taOS — always visible while fullscreen.
+                  Slate glass pill, pinned top-left, safe-area aware. */}
+              {isFs && (
+                <button
+                  type="button"
+                  onClick={exitFs}
+                  aria-label="Exit to taOS"
+                  className="absolute z-50 inline-flex items-center gap-1.5 rounded-full border border-accent/45 bg-[rgba(16,18,24,0.62)] px-3 py-1.5 text-[12px] font-bold text-white shadow-lg backdrop-blur-md transition-all hover:-translate-y-0.5 hover:bg-[rgba(28,32,42,0.82)]"
+                  style={{
+                    top: "max(12px, env(safe-area-inset-top, 12px))",
+                    left: "max(12px, env(safe-area-inset-left, 12px))",
+                  }}
+                >
+                  <LogOut size={15} className="-scale-x-100" />
+                  Exit to taOS
+                  <span className="ml-0.5 rounded border border-white/25 px-1.5 py-px text-[9.5px] font-bold tracking-wide text-white/60">
+                    ESC
+                  </span>
+                </button>
+              )}
+
+              {/* live FPS / debug HUD (real, from the rAF loop) */}
+              <div
+                className="absolute z-40 flex items-center gap-1.5 rounded-lg border border-white/10 bg-black/45 px-2.5 py-1.5 font-mono text-[10.5px] text-emerald-200/90 backdrop-blur-sm"
+                style={{ top: isFs ? "62px" : "10px", left: "10px" }}
+              >
+                <span>
+                  <b className="font-bold text-white">{fps}</b> fps
+                </span>
+                <span className="text-white/25">|</span>
+                <span>
+                  <b className="font-bold text-white">{playing ? "running" : "paused"}</b>
+                </span>
+              </div>
+
+              {/* viewport controls (top-right) */}
+              <div className="absolute right-2.5 top-2.5 z-40 flex gap-1.5">
+                <button
+                  type="button"
+                  onClick={reset}
+                  aria-label="Reset scene"
+                  className="grid h-[30px] w-[30px] place-items-center rounded-lg border border-white/10 bg-black/45 text-white backdrop-blur-sm transition-colors hover:bg-black/65"
+                >
+                  <RotateCcw size={15} />
+                </button>
+                <button
+                  type="button"
+                  onClick={toggleFs}
+                  aria-label="Toggle fullscreen"
+                  className="grid h-[30px] w-[30px] place-items-center rounded-lg border border-white/10 bg-black/45 text-white backdrop-blur-sm transition-colors hover:bg-black/65"
+                >
+                  <Maximize2 size={15} />
+                </button>
+              </div>
+
+              {/* play overlay before first Play */}
+              {!playing && (
+                <button
+                  type="button"
+                  onClick={() => setPlaying(true)}
+                  aria-label="Play scene"
+                  className="absolute inset-0 z-30 grid place-items-center"
+                >
+                  <span className="grid h-[66px] w-[66px] place-items-center rounded-full border border-white/30 bg-white/15 shadow-xl backdrop-blur-sm transition-transform hover:scale-105">
+                    <Play size={26} className="translate-x-0.5 text-white" />
+                  </span>
+                </button>
+              )}
+
+              <div
+                className="pointer-events-none absolute bottom-3 left-3 z-20 text-[12px] font-semibold text-white/90"
+                style={{ textShadow: "0 1px 6px rgba(0,0,0,0.6)" }}
+              >
+                {template.title}
+                <span className="block text-[10.5px] font-medium text-white/60">
+                  drag to orbit · WASD to move
+                </span>
+              </div>
+            </div>
+
+            {/* transport + device preview */}
+            <div className="flex flex-wrap items-center gap-2.5">
+              <div className="flex gap-1.5">
+                <button
+                  type="button"
+                  onClick={reset}
+                  aria-label="Restart"
+                  className="grid h-9 w-9 place-items-center rounded-xl border border-shell-border bg-shell-surface-active text-shell-text transition-colors hover:bg-white/10"
+                >
+                  <RotateCcw size={15} />
+                </button>
+                <button
+                  type="button"
+                  onClick={togglePlay}
+                  className="flex h-9 items-center gap-1.5 rounded-full border border-shell-border bg-shell-surface-active px-4 text-[12.5px] font-bold text-shell-text transition-colors hover:bg-white/10"
+                >
+                  {playing ? <Pause size={15} /> : <Play size={15} />}
+                  {playing ? "Pause" : "Play"}
+                </button>
+              </div>
+
+              <div
+                className="ml-auto inline-flex gap-0.5 rounded-full border border-shell-border bg-shell-surface p-[3px]"
+                role="group"
+                aria-label="Device preview"
+              >
+                {(
+                  [
+                    { id: "desktop", label: "Desktop", Icon: Monitor },
+                    { id: "mobile", label: "Mobile", Icon: Smartphone },
+                    { id: "xr", label: "XR", Icon: Glasses },
+                  ] as const
+                ).map(({ id, label, Icon }) => {
+                  const on = device === id;
+                  return (
+                    <button
+                      key={id}
+                      type="button"
+                      aria-pressed={on}
+                      onClick={() => setDevice(id)}
+                      className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-[12px] font-semibold transition-colors ${
+                        on
+                          ? "bg-shell-surface-active text-shell-text"
+                          : "text-shell-text-secondary hover:text-shell-text"
+                      }`}
+                    >
+                      <Icon size={13} />
+                      {label}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            {isXr && (
+              <p className="text-[11.5px] leading-relaxed text-shell-text-secondary">
+                <span className="font-semibold text-shell-text">XR / VR.</span> Phase 1 shows the
+                headset framing only. Real WebXR play, with a world-pinned Exit to taOS panel in
+                view, lands in a later phase.
+              </p>
+            )}
+          </div>
+
+          {/* ---- build log / skills panel (illustrative) ---- */}
+          <aside className="overflow-hidden rounded-2xl border border-shell-border bg-shell-surface shadow-card">
+            <div className="flex items-center gap-2 border-b border-shell-border px-3.5 py-3">
+              <ListTree size={15} className="text-accent" />
+              <h3 className="text-[13px] font-bold">Build log</h3>
+              <span className="ml-auto text-[11px] text-shell-text-tertiary">preview</span>
+            </div>
+            <div className="max-h-[470px] overflow-auto p-1.5">
+              {BUILD_LOG.map((step, i) => (
+                <div
+                  key={i}
+                  className={`grid grid-cols-[26px_1fr] gap-2 rounded-xl px-2.5 py-2 hover:bg-shell-surface ${
+                    step.director ? "border-l-2 border-accent/30" : ""
+                  }`}
+                >
+                  <span
+                    className={`mt-0.5 grid h-[22px] w-[22px] place-items-center rounded-lg ${
+                      step.state === "done"
+                        ? "bg-emerald-500/15 text-emerald-400"
+                        : step.state === "run"
+                          ? "bg-accent-soft text-accent"
+                          : "bg-shell-surface text-shell-text-tertiary"
+                    }`}
+                  >
+                    {step.state === "done" ? (
+                      <Check size={13} />
+                    ) : step.state === "run" ? (
+                      <Loader2 size={13} className="animate-spin motion-reduce:animate-none" />
+                    ) : (
+                      <Clock size={13} />
+                    )}
+                  </span>
+                  <div>
+                    <div className="text-[12px] font-bold">{step.who}</div>
+                    <div className="mt-0.5 text-[11.5px] leading-snug text-shell-text-secondary">
+                      {step.what}
+                    </div>
+                    <span className="mt-1 inline-block rounded-full bg-shell-surface-active px-1.5 py-0.5 text-[9.5px] font-bold uppercase tracking-wide text-shell-text-secondary">
+                      {step.tag}
+                    </span>
+                  </div>
+                </div>
+              ))}
+              <p className="px-2.5 pb-1 pt-2 text-[11px] leading-relaxed text-shell-text-tertiary">
+                An illustrative trace of the agent build pipeline. Live build steps arrive with
+                offline generation in a later phase.
+              </p>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/apps/gamestudio/ShareView.tsx
+++ b/desktop/src/apps/gamestudio/ShareView.tsx
@@ -1,0 +1,219 @@
+import { useState } from "react";
+import { Share2, Check, Lock, Globe, Info } from "lucide-react";
+import type { Template, Visibility } from "./types";
+
+/* ------------------------------------------------------------------ */
+/*  ShareView — publish card + test checklist                          */
+/*                                                                     */
+/*  Honesty: real store-publish is a later phase (ties to the optional- */
+/*  install / Store work). "Share to Store" does not fake success; it   */
+/*  surfaces a clear "publishing flows through the Store, coming" note. */
+/* ------------------------------------------------------------------ */
+
+const CHECKS = [
+  "Runs on desktop",
+  "Runs on mobile",
+  "Fullscreen works, with an Exit to taOS control",
+  "Holds frame rate on this device",
+] as const;
+
+export interface ShareViewProps {
+  template: Template;
+}
+
+export function ShareView({ template }: ShareViewProps) {
+  const [title, setTitle] = useState(template.title);
+  const [description, setDescription] = useState(template.desc);
+  const [visibility, setVisibility] = useState<Visibility>("community");
+  const [showComing, setShowComing] = useState(false);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+      <div
+        className="flex flex-col gap-3.5 p-[22px]"
+        style={{ paddingBottom: "calc(22px + env(safe-area-inset-bottom, 0px))" }}
+      >
+        <header>
+          <h2 className="text-[17px] font-bold tracking-[-0.02em]">Publish to the Store</h2>
+          <p className="mt-1 text-[12.5px] text-shell-text-secondary">
+            Share "{title}" with your taOS Store. Community games are reviewed before they go public.
+          </p>
+        </header>
+
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-[1.1fr_0.9fr]">
+          {/* publish form */}
+          <div className="flex flex-col gap-4 rounded-2xl border border-shell-border bg-shell-surface p-4 shadow-card">
+            <div
+              className="relative h-[150px] overflow-hidden rounded-2xl border border-shell-border-strong"
+              style={{ background: template.cover }}
+            >
+              <span className="absolute left-2.5 top-2.5 rounded-full bg-black/40 px-2 py-1 text-[10px] font-bold uppercase tracking-wide text-white/85 backdrop-blur-sm">
+                {template.genre}
+              </span>
+              <span
+                className="absolute bottom-2.5 left-3 text-[17px] font-extrabold text-white"
+                style={{ textShadow: "0 2px 10px rgba(0,0,0,0.6)" }}
+              >
+                {title || "Untitled"}
+              </span>
+            </div>
+
+            <Field label="Game title">
+              <input
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                className="w-full rounded-xl border border-shell-border bg-shell-bg-deep px-3.5 py-2.5 text-[13px] text-shell-text focus-visible:border-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/20"
+              />
+            </Field>
+
+            <Field label="Description">
+              <textarea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                rows={3}
+                className="w-full resize-none rounded-xl border border-shell-border bg-shell-bg-deep px-3.5 py-2.5 text-[13px] text-shell-text focus-visible:border-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/20"
+              />
+            </Field>
+
+            <Field label="Visibility">
+              <div className="flex gap-2">
+                <VisibilityOption
+                  on={visibility === "private"}
+                  onClick={() => setVisibility("private")}
+                  Icon={Lock}
+                  title="Private"
+                  desc="Only you and people you invite can play it."
+                />
+                <VisibilityOption
+                  on={visibility === "community"}
+                  onClick={() => setVisibility("community")}
+                  Icon={Globe}
+                  title="Community"
+                  desc="Submit to the Store for everyone to find and install."
+                />
+              </div>
+            </Field>
+
+            <div className="flex flex-wrap items-center gap-3">
+              <button
+                type="button"
+                onClick={() => setShowComing(true)}
+                className="flex h-[44px] items-center gap-2 rounded-full bg-gradient-to-br from-accent to-accent/70 px-5 text-[13px] font-bold text-white shadow-lg shadow-accent/20 transition-all hover:-translate-y-0.5 hover:brightness-105"
+              >
+                <Share2 size={17} />
+                Share to Store
+              </button>
+              <span className="text-[11px] text-shell-text-tertiary">
+                A reviewer checks community games before they go public.
+              </span>
+            </div>
+
+            {showComing && (
+              <div
+                role="status"
+                className="flex items-start gap-2.5 rounded-xl border border-accent/30 bg-accent-soft px-3.5 py-3"
+              >
+                <Info size={16} className="mt-0.5 flex-none text-accent" />
+                <div className="text-[12.5px] leading-relaxed text-shell-text-secondary">
+                  <span className="font-semibold text-shell-text">
+                    Publishing flows through the Store, coming soon.
+                  </span>{" "}
+                  A later phase packages the game and submits it to your taOS Store for review and
+                  install. Nothing is published yet.
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* test checklist + meta */}
+          <div className="flex flex-col gap-4">
+            <div className="rounded-2xl border border-shell-border bg-shell-surface shadow-card">
+              <div className="flex items-center gap-2 px-4 pt-3.5">
+                <Check size={15} className="text-accent" />
+                <h3 className="text-[13px] font-bold">Tested in Play</h3>
+              </div>
+              <div className="p-4">
+                <ul className="flex flex-col gap-2">
+                  {CHECKS.map((c) => (
+                    <li key={c} className="flex items-center gap-2.5 text-[12.5px]">
+                      <span className="grid h-5 w-5 flex-none place-items-center rounded-md bg-emerald-500/15 text-emerald-400">
+                        <Check size={12} />
+                      </span>
+                      {c}
+                    </li>
+                  ))}
+                </ul>
+                <div className="my-4 h-px bg-shell-border" />
+                <p className="text-[11px] leading-relaxed text-shell-text-tertiary">
+                  Run the game in Play &amp; Test any time before you publish. These are the checks a
+                  later phase will gate publishing on.
+                </p>
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-shell-border bg-shell-surface p-4 shadow-card">
+              <dl className="flex flex-col gap-2.5 text-[12.5px]">
+                <MetaRow label="Engine" value="taOS Game Runtime" />
+                <MetaRow label="Preview" value="three.js (WebGL)" />
+                <MetaRow label="Plays on" value="Desktop · Mobile · XR" />
+              </dl>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <span className="mb-1.5 block text-[12px] font-semibold text-shell-text-secondary">
+        {label}
+      </span>
+      {children}
+    </div>
+  );
+}
+
+function VisibilityOption({
+  on,
+  onClick,
+  Icon,
+  title,
+  desc,
+}: {
+  on: boolean;
+  onClick: () => void;
+  Icon: typeof Lock;
+  title: string;
+  desc: string;
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={on}
+      onClick={onClick}
+      className={`flex-1 rounded-xl border p-3 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${
+        on
+          ? "border-accent/40 bg-accent-soft"
+          : "border-shell-border bg-shell-surface hover:bg-white/10"
+      }`}
+    >
+      <div className="flex items-center gap-1.5 text-[12.5px] font-bold">
+        <Icon size={14} className="text-accent" />
+        {title}
+      </div>
+      <div className="mt-1 text-[11px] leading-snug text-shell-text-secondary">{desc}</div>
+    </button>
+  );
+}
+
+function MetaRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex justify-between">
+      <dt className="text-shell-text-secondary">{label}</dt>
+      <dd>{value}</dd>
+    </div>
+  );
+}

--- a/desktop/src/apps/gamestudio/templates.ts
+++ b/desktop/src/apps/gamestudio/templates.ts
@@ -1,0 +1,132 @@
+import type { Template, BuildStep } from "./types";
+
+/* ------------------------------------------------------------------ */
+/*  Starter templates + the illustrative build log                     */
+/*                                                                     */
+/*  Templates mirror the approved mock. Each carries a `scene` that the */
+/*  Play view renders with real three.js. Phase 1 ships two interactive */
+/*  scenes (runner, orbit); the others reuse the runner scene under     */
+/*  their own title, so "Use template" always loads a live 3D preview.  */
+/* ------------------------------------------------------------------ */
+
+export const TEMPLATES: Template[] = [
+  {
+    id: "pixel-platformer",
+    title: "Pixel Platformer",
+    genre: "Platformer",
+    desc: "Run, jump and stomp across handcrafted levels with springs and moving platforms.",
+    cover:
+      "radial-gradient(120% 120% at 30% 20%, #1f5a3a, transparent 60%), linear-gradient(140deg,#12261b,#0c1712)",
+    scene: "runner",
+  },
+  {
+    id: "neon-runner",
+    title: "Neon Runner",
+    genre: "Endless Runner",
+    desc: "Auto-run through a synthwave city. Dodge, slide and chase the high score.",
+    cover:
+      "radial-gradient(120% 120% at 70% 25%, #3a4a7a, transparent 60%), linear-gradient(140deg,#16213a,#0c1120)",
+    scene: "runner",
+  },
+  {
+    id: "keep-defense",
+    title: "Keep Defense",
+    genre: "Tower Defense",
+    desc: "Place towers along the path and hold the line against waves of raiders.",
+    cover:
+      "radial-gradient(120% 120% at 40% 30%, #16607a, transparent 60%), linear-gradient(140deg,#0e2230,#0a1620)",
+    scene: "orbit",
+  },
+  {
+    id: "arena-top-down",
+    title: "Arena Top-Down",
+    genre: "Top-down Shooter",
+    desc: "Twin-stick survival in a tight arena with pickups and rising difficulty.",
+    cover:
+      "radial-gradient(120% 120% at 60% 25%, #2a3f7a, transparent 60%), linear-gradient(140deg,#141a2b,#0d1119)",
+    scene: "orbit",
+  },
+  {
+    id: "drift-circuit",
+    title: "Drift Circuit",
+    genre: "Racing",
+    desc: "Three low-poly tracks, drift boost and ghost laps to beat.",
+    cover:
+      "radial-gradient(120% 120% at 35% 25%, #1f4d63, transparent 60%), linear-gradient(140deg,#10222a,#0b161b)",
+    scene: "runner",
+  },
+  {
+    id: "block-puzzle",
+    title: "Block Puzzle",
+    genre: "Puzzle",
+    desc: "Rotate and drop pieces to clear lines. Endless and daily modes.",
+    cover:
+      "radial-gradient(120% 120% at 60% 25%, #5a3a1f, transparent 60%), linear-gradient(140deg,#231811,#16100a)",
+    scene: "orbit",
+  },
+  {
+    id: "corridor-fps",
+    title: "Corridor FPS",
+    genre: "FPS",
+    desc: "A short first-person shooting gallery with three rooms and a boss.",
+    cover:
+      "radial-gradient(120% 120% at 40% 30%, #1f5a3a, transparent 60%), linear-gradient(140deg,#10261b,#0a1712)",
+    scene: "runner",
+  },
+  {
+    id: "orbit-tap",
+    title: "Orbit Tap",
+    genre: "XR / VR",
+    desc: "A room-scale tap-the-orb warm-up built for headsets and hand tracking.",
+    cover:
+      "radial-gradient(120% 120% at 65% 25%, #2a3f7a, transparent 60%), linear-gradient(140deg,#141a2b,#0d1119)",
+    scene: "orbit",
+  },
+];
+
+/** The template the Play stage loads before the user picks one, so the
+ *  3D preview always has a real scene to render. */
+export const DEFAULT_TEMPLATE: Template = TEMPLATES[0]!;
+
+/** Illustrative build trace shown beside the Play stage. Static in phase 1:
+ *  it pictures the future agent pipeline (a director splitting a prompt across
+ *  specialist blocks), and is clearly labelled as a preview, not a live run. */
+export const BUILD_LOG: BuildStep[] = [
+  {
+    who: "Director",
+    what: "Reads the prompt, picks a template and splits the work across five specialist blocks.",
+    tag: "routing",
+    state: "done",
+    director: true,
+  },
+  {
+    who: "Gameplay",
+    what: "Wires the run loop, jump and lane swap, following the movement guide for the genre.",
+    tag: "gameplay",
+    state: "done",
+  },
+  {
+    who: "Graphics",
+    what: "Places low-poly geometry, materials and lighting in the scene you can preview here.",
+    tag: "graphics",
+    state: "run",
+  },
+  {
+    who: "UI",
+    what: "Score, combo meter, a pause sheet and a game-over card.",
+    tag: "ui",
+    state: "queue",
+  },
+  {
+    who: "Audio",
+    what: "Footsteps, pickups and a loop from the free pack.",
+    tag: "audio",
+    state: "queue",
+  },
+  {
+    who: "QA",
+    what: "Runs the game on desktop, mobile and fullscreen and checks it holds frame rate.",
+    tag: "qa",
+    state: "queue",
+  },
+];

--- a/desktop/src/apps/gamestudio/types.ts
+++ b/desktop/src/apps/gamestudio/types.ts
@@ -1,0 +1,78 @@
+/* ------------------------------------------------------------------ */
+/*  Game Studio — shared types                                         */
+/*                                                                     */
+/*  Phase 1 ships the app shell + a real three.js preview. AI          */
+/*  generation, the skill pack and asset backends arrive in later      */
+/*  phases; the types here describe the shell, the demo scenes and     */
+/*  the honest "later phase" affordances, not a generation pipeline.   */
+/* ------------------------------------------------------------------ */
+
+export type StudioView = "create" | "play" | "share";
+
+/** Device preview the Play stage emulates. XR is a labelled affordance in
+ *  phase 1 (real WebXR is a later phase); Desktop/Mobile resize the stage. */
+export type DevicePreview = "desktop" | "mobile" | "xr";
+
+/** A demo scene the three.js preview can load. Each template maps to one.
+ *  Phase 1 ships two genuinely interactive scenes (runner, orbit); the rest
+ *  fall back to the runner scene with their own label, so "Use template"
+ *  always loads something real rather than faking a bespoke build. */
+export type SceneKind = "runner" | "orbit";
+
+/** Genre chips shown on the Create view. Multi-select, illustrative; they do
+ *  not drive generation in phase 1. */
+export const GENRES = [
+  "Platformer",
+  "Endless Runner",
+  "Tower Defense",
+  "Top-down Shooter",
+  "Racing",
+  "Puzzle",
+  "FPS",
+  "XR / VR Experience",
+] as const;
+
+export type Genre = (typeof GENRES)[number];
+
+/** Offline model selector options. Labelled-but-inert in phase 1: offline
+ *  generation is a later phase, so picking a model changes the label only. */
+export const OFFLINE_MODELS = [
+  "Gemma 4 E4B (offline)",
+  "Qwen3 4B (offline)",
+  "Llama 3.2 3B (offline)",
+] as const;
+
+export const ART_STYLES = [
+  "Low-poly 3D",
+  "Pixel art",
+  "Flat vector",
+  "Hand-drawn",
+] as const;
+
+export const DIFFICULTIES = ["Casual", "Normal", "Hard"] as const;
+
+/** A starter template. Selecting one loads its demo scene into the Play view. */
+export interface Template {
+  id: string;
+  title: string;
+  genre: string;
+  desc: string;
+  /** CSS background for the card cover + the publish cover. */
+  cover: string;
+  /** Which real three.js scene the Play view loads for this template. */
+  scene: SceneKind;
+}
+
+/** A build-log entry. Static/illustrative in phase 1: it represents the
+ *  future agent build trace (a director routes a prompt across specialist
+ *  blocks), not a live pipeline. */
+export interface BuildStep {
+  who: string;
+  what: string;
+  tag: string;
+  state: "done" | "run" | "queue";
+  director?: boolean;
+}
+
+/** Visibility for the Share view publish card. */
+export type Visibility = "private" | "community";

--- a/desktop/src/apps/gamestudio/useGameScene.ts
+++ b/desktop/src/apps/gamestudio/useGameScene.ts
@@ -1,0 +1,362 @@
+import { useEffect, useRef, useState } from "react";
+import * as THREE from "three";
+import type { SceneKind } from "./types";
+
+/* ------------------------------------------------------------------ */
+/*  useGameScene — the real three.js preview                           */
+/*                                                                     */
+/*  This is the genuinely-working part of phase 1. It mounts a          */
+/*  WebGLRenderer (standard materials, no WebGPU/TSL) into a host div,  */
+/*  builds a lit demo scene, drives a requestAnimationFrame loop, and   */
+/*  exposes play/pause, a real FPS readout and a scene reset.           */
+/*                                                                      */
+/*  Controls: WASD / arrow keys move the hero on the runner scene;      */
+/*  pointer-drag orbits the camera on both scenes. prefers-reduced-     */
+/*  motion freezes idle drift but keeps the loop responsive to input.   */
+/* ------------------------------------------------------------------ */
+
+export interface GameSceneHandle {
+  /** Attach to the host element the canvas mounts into. */
+  hostRef: React.RefObject<HTMLDivElement | null>;
+  playing: boolean;
+  setPlaying: (v: boolean) => void;
+  togglePlay: () => void;
+  /** Live frames-per-second from the rAF loop (real, integer). */
+  fps: number;
+  /** Reset the hero + camera to the scene's start pose. */
+  reset: () => void;
+  /** WebGL availability — false renders an honest fallback instead of a blank stage. */
+  supported: boolean;
+}
+
+const prefersReducedMotion = (): boolean =>
+  typeof window !== "undefined" &&
+  window.matchMedia?.("(prefers-reduced-motion: reduce)").matches === true;
+
+export function useGameScene(scene: SceneKind): GameSceneHandle {
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  const [playing, setPlayingState] = useState(false);
+  const [fps, setFps] = useState(60);
+  const [supported, setSupported] = useState(true);
+
+  // Mutable engine refs kept out of React state so the loop never re-renders.
+  const playingRef = useRef(false);
+  const keysRef = useRef<Set<string>>(new Set());
+  const resetRef = useRef<() => void>(() => {});
+  const setPlayingRef = useRef<(v: boolean) => void>(() => {});
+
+  const setPlaying = (v: boolean) => {
+    playingRef.current = v;
+    setPlayingState(v);
+  };
+  setPlayingRef.current = setPlaying;
+  const togglePlay = () => setPlayingRef.current(!playingRef.current);
+  const reset = () => resetRef.current();
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+
+    let renderer: THREE.WebGLRenderer;
+    try {
+      renderer = new THREE.WebGLRenderer({ antialias: true, alpha: false });
+    } catch {
+      setSupported(false);
+      return;
+    }
+    setSupported(true);
+
+    const reduced = prefersReducedMotion();
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+    renderer.shadowMap.enabled = true;
+    renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+    host.appendChild(renderer.domElement);
+    renderer.domElement.style.width = "100%";
+    renderer.domElement.style.height = "100%";
+    renderer.domElement.style.display = "block";
+
+    const sceneObj = new THREE.Scene();
+    sceneObj.background = new THREE.Color("#0a0d14");
+    sceneObj.fog = new THREE.Fog("#0a0d14", 14, 42);
+
+    const camera = new THREE.PerspectiveCamera(55, 16 / 10, 0.1, 100);
+
+    // ---- lighting (lit standard materials) ----
+    sceneObj.add(new THREE.AmbientLight("#5a6680", 0.65));
+    const key = new THREE.DirectionalLight("#cfd6ff", 1.15);
+    key.position.set(6, 12, 8);
+    key.castShadow = true;
+    key.shadow.mapSize.set(1024, 1024);
+    key.shadow.camera.near = 1;
+    key.shadow.camera.far = 50;
+    sceneObj.add(key);
+    const rim = new THREE.DirectionalLight("#8b92a3", 0.5);
+    rim.position.set(-8, 5, -6);
+    sceneObj.add(rim);
+
+    // ---- ground plane ----
+    const ground = new THREE.Mesh(
+      new THREE.PlaneGeometry(60, 120),
+      new THREE.MeshStandardMaterial({
+        color: "#141d33",
+        roughness: 0.95,
+        metalness: 0.05,
+      }),
+    );
+    ground.rotation.x = -Math.PI / 2;
+    ground.receiveShadow = true;
+    sceneObj.add(ground);
+
+    const grid = new THREE.GridHelper(60, 30, "#3a4a7a", "#1d2740");
+    (grid.material as THREE.Material).transparent = true;
+    (grid.material as THREE.Material).opacity = 0.4;
+    sceneObj.add(grid);
+
+    // ---- hero: a lit low-poly cube the player can drive ----
+    const hero = new THREE.Mesh(
+      new THREE.BoxGeometry(1.1, 1.1, 1.1),
+      new THREE.MeshStandardMaterial({
+        color: "#ff8a3d",
+        roughness: 0.4,
+        metalness: 0.1,
+        emissive: "#3a1c08",
+      }),
+    );
+    hero.castShadow = true;
+    hero.position.set(0, 0.55, 0);
+    sceneObj.add(hero);
+
+    // ---- scene-specific props ----
+    const movers: THREE.Mesh[] = [];
+    const coins: THREE.Mesh[] = [];
+
+    if (scene === "runner") {
+      // Oncoming low-poly obstacles + spinning coins down a runway.
+      const obstacleColors = ["#c8503e", "#3d7fb5", "#41d0a3", "#b57ad0"];
+      for (let i = 0; i < 7; i++) {
+        const m = new THREE.Mesh(
+          new THREE.BoxGeometry(1.4, 1.4, 1.4),
+          new THREE.MeshStandardMaterial({
+            color: obstacleColors[i % obstacleColors.length],
+            roughness: 0.5,
+            metalness: 0.1,
+          }),
+        );
+        m.castShadow = true;
+        m.position.set((i % 3) * 3 - 3, 0.7, -8 - i * 6);
+        sceneObj.add(m);
+        movers.push(m);
+      }
+      const coinMat = new THREE.MeshStandardMaterial({
+        color: "#ffd35c",
+        roughness: 0.3,
+        metalness: 0.4,
+        emissive: "#5a4a10",
+      });
+      for (let i = 0; i < 6; i++) {
+        const c = new THREE.Mesh(
+          new THREE.CylinderGeometry(0.45, 0.45, 0.12, 18),
+          coinMat,
+        );
+        c.castShadow = true;
+        c.rotation.x = Math.PI / 2;
+        c.position.set((i % 3) * 3 - 3, 0.9, -4 - i * 5);
+        sceneObj.add(c);
+        coins.push(c);
+      }
+    } else {
+      // Orbit scene: a ring of floating low-poly orbs around the hero.
+      const orbColors = ["#41d0a3", "#3d7fb5", "#ffd35c", "#b57ad0", "#ff8a3d"];
+      for (let i = 0; i < 8; i++) {
+        const a = (i / 8) * Math.PI * 2;
+        const orb = new THREE.Mesh(
+          new THREE.IcosahedronGeometry(0.7, 0),
+          new THREE.MeshStandardMaterial({
+            color: orbColors[i % orbColors.length],
+            roughness: 0.35,
+            metalness: 0.15,
+            flatShading: true,
+          }),
+        );
+        orb.castShadow = true;
+        orb.position.set(Math.cos(a) * 5, 1.4 + Math.sin(a * 2) * 0.6, Math.sin(a) * 5);
+        sceneObj.add(orb);
+        movers.push(orb);
+      }
+    }
+
+    // ---- camera orbit state (pointer-drag) ----
+    const cam = { theta: scene === "runner" ? 0 : 0.5, phi: 0.9, radius: 12 };
+    const applyCamera = () => {
+      const r = cam.radius;
+      const tx = scene === "runner" ? hero.position.x * 0.4 : 0;
+      camera.position.set(
+        tx + r * Math.sin(cam.phi) * Math.sin(cam.theta),
+        r * Math.cos(cam.phi),
+        scene === "runner"
+          ? hero.position.z + r * Math.sin(cam.phi) * Math.cos(cam.theta) + 6
+          : r * Math.sin(cam.phi) * Math.cos(cam.theta),
+      );
+      camera.lookAt(
+        tx,
+        1,
+        scene === "runner" ? hero.position.z - 2 : 0,
+      );
+    };
+    applyCamera();
+
+    let dragging = false;
+    let lastX = 0;
+    let lastY = 0;
+    const onPointerDown = (e: PointerEvent) => {
+      dragging = true;
+      lastX = e.clientX;
+      lastY = e.clientY;
+      renderer.domElement.setPointerCapture?.(e.pointerId);
+    };
+    const onPointerMove = (e: PointerEvent) => {
+      if (!dragging) return;
+      cam.theta -= (e.clientX - lastX) * 0.006;
+      cam.phi = Math.min(1.35, Math.max(0.25, cam.phi - (e.clientY - lastY) * 0.005));
+      lastX = e.clientX;
+      lastY = e.clientY;
+    };
+    const onPointerUp = () => {
+      dragging = false;
+    };
+    renderer.domElement.addEventListener("pointerdown", onPointerDown);
+    renderer.domElement.addEventListener("pointermove", onPointerMove);
+    window.addEventListener("pointerup", onPointerUp);
+
+    // ---- reset ----
+    const startHero = hero.position.clone();
+    const startCam = { ...cam };
+    resetRef.current = () => {
+      hero.position.copy(startHero);
+      cam.theta = startCam.theta;
+      cam.phi = startCam.phi;
+      cam.radius = startCam.radius;
+      applyCamera();
+      renderer.render(sceneObj, camera);
+    };
+
+    // ---- resize to host ----
+    const resize = () => {
+      const w = host.clientWidth || 1;
+      const h = host.clientHeight || 1;
+      renderer.setSize(w, h, false);
+      camera.aspect = w / h;
+      camera.updateProjectionMatrix();
+    };
+    resize();
+    const ro = new ResizeObserver(resize);
+    ro.observe(host);
+
+    // ---- main loop ----
+    const clock = new THREE.Clock();
+    let raf = 0;
+    let frames = 0;
+    let fpsAccum = 0;
+
+    const tick = () => {
+      raf = requestAnimationFrame(tick);
+      const dt = Math.min(clock.getDelta(), 0.05);
+
+      // FPS sampling once per ~500ms from real frame timing.
+      frames++;
+      fpsAccum += dt;
+      if (fpsAccum >= 0.5) {
+        setFps(Math.round(frames / fpsAccum));
+        frames = 0;
+        fpsAccum = 0;
+      }
+
+      if (playingRef.current) {
+        const keys = keysRef.current;
+        const speed = 7 * dt;
+        if (scene === "runner") {
+          // WASD / arrows steer the hero across lanes + along the runway.
+          if (keys.has("a") || keys.has("arrowleft")) hero.position.x -= speed;
+          if (keys.has("d") || keys.has("arrowright")) hero.position.x += speed;
+          if (keys.has("w") || keys.has("arrowup")) hero.position.z -= speed;
+          if (keys.has("s") || keys.has("arrowdown")) hero.position.z += speed;
+          hero.position.x = Math.max(-6, Math.min(6, hero.position.x));
+          hero.rotation.y += dt * 1.2;
+
+          // Obstacles roll toward the hero; recycle past the camera.
+          for (const m of movers) {
+            m.position.z += 9 * dt;
+            m.rotation.x += dt;
+            if (m.position.z > hero.position.z + 8) m.position.z -= 48;
+          }
+          for (const c of coins) {
+            c.rotation.z += dt * 3;
+            c.position.z += 9 * dt;
+            if (c.position.z > hero.position.z + 8) c.position.z -= 40;
+          }
+        } else {
+          // Orbit scene: WASD nudges the hero; orbs bob + circle.
+          if (keys.has("a") || keys.has("arrowleft")) hero.position.x -= speed;
+          if (keys.has("d") || keys.has("arrowright")) hero.position.x += speed;
+          if (keys.has("w") || keys.has("arrowup")) hero.position.z -= speed;
+          if (keys.has("s") || keys.has("arrowdown")) hero.position.z += speed;
+          hero.rotation.y += dt * 0.8;
+          const t = clock.elapsedTime;
+          movers.forEach((orb, i) => {
+            orb.rotation.x += dt * 0.6;
+            orb.rotation.y += dt * 0.4;
+            orb.position.y = 1.4 + Math.sin(t * 1.4 + i) * 0.5;
+          });
+        }
+
+        // Idle camera drift, suppressed under reduced-motion.
+        if (!reduced && !dragging && scene === "orbit") cam.theta += dt * 0.12;
+      }
+
+      applyCamera();
+      renderer.render(sceneObj, camera);
+    };
+    // Render one frame immediately so the stage is never blank before Play.
+    tick();
+
+    return () => {
+      cancelAnimationFrame(raf);
+      ro.disconnect();
+      renderer.domElement.removeEventListener("pointerdown", onPointerDown);
+      renderer.domElement.removeEventListener("pointermove", onPointerMove);
+      window.removeEventListener("pointerup", onPointerUp);
+      sceneObj.traverse((obj) => {
+        const mesh = obj as THREE.Mesh;
+        if (mesh.geometry) mesh.geometry.dispose();
+        const mat = mesh.material as THREE.Material | THREE.Material[] | undefined;
+        if (Array.isArray(mat)) mat.forEach((m) => m.dispose());
+        else mat?.dispose();
+      });
+      renderer.dispose();
+      if (renderer.domElement.parentNode === host) {
+        host.removeChild(renderer.domElement);
+      }
+    };
+  }, [scene]);
+
+  // Keyboard capture for WASD / arrows while the stage is mounted.
+  useEffect(() => {
+    const keys = keysRef.current;
+    const down = (e: KeyboardEvent) => {
+      const k = e.key.toLowerCase();
+      if (["w", "a", "s", "d", "arrowup", "arrowdown", "arrowleft", "arrowright"].includes(k)) {
+        keys.add(k);
+        if (playingRef.current) e.preventDefault();
+      }
+    };
+    const up = (e: KeyboardEvent) => keys.delete(e.key.toLowerCase());
+    window.addEventListener("keydown", down);
+    window.addEventListener("keyup", up);
+    return () => {
+      window.removeEventListener("keydown", down);
+      window.removeEventListener("keyup", up);
+    };
+  }, []);
+
+  return { hostRef, playing, setPlaying, togglePlay, fps, reset, supported };
+}

--- a/desktop/src/apps/gamestudio/useGameScene.ts
+++ b/desktop/src/apps/gamestudio/useGameScene.ts
@@ -228,6 +228,42 @@ export function useGameScene(scene: SceneKind): GameSceneHandle {
     renderer.domElement.addEventListener("pointermove", onPointerMove);
     window.addEventListener("pointerup", onPointerUp);
 
+    // ---- keyboard capture for WASD / arrows ----
+    // Listeners live on the canvas (made focusable) so movement keys are only
+    // intercepted while the user is genuinely focused on the game, never OS-wide.
+    const MOVE_KEYS = ["w", "a", "s", "d", "arrowup", "arrowdown", "arrowleft", "arrowright"];
+    const canvas = renderer.domElement;
+    canvas.tabIndex = 0;
+    canvas.style.outline = "none";
+    // Focus the canvas on pointer-down so a click hands movement input to the game.
+    const focusCanvas = () => canvas.focus();
+    canvas.addEventListener("pointerdown", focusCanvas);
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      const k = e.key.toLowerCase();
+      if (MOVE_KEYS.includes(k)) {
+        keysRef.current.add(k);
+        // Only swallow the key while actively playing; the canvas already holds
+        // focus to receive this event, so page scroll/shortcuts stay free elsewhere.
+        if (playingRef.current) e.preventDefault();
+      }
+    };
+    const onKeyUp = (e: KeyboardEvent) => {
+      keysRef.current.delete(e.key.toLowerCase());
+    };
+    // Release every held key when focus is lost, so a key held during a
+    // tab/window switch can never stick and drive the character forever.
+    const clearKeys = () => keysRef.current.clear();
+    const onVisibility = () => {
+      if (document.hidden) clearKeys();
+    };
+    canvas.addEventListener("keydown", onKeyDown);
+    canvas.addEventListener("keyup", onKeyUp);
+    canvas.addEventListener("blur", clearKeys);
+    canvas.addEventListener("pointerleave", clearKeys);
+    window.addEventListener("blur", clearKeys);
+    document.addEventListener("visibilitychange", onVisibility);
+
     // ---- reset ----
     const startHero = hero.position.clone();
     const startCam = { ...cam };
@@ -325,6 +361,14 @@ export function useGameScene(scene: SceneKind): GameSceneHandle {
       renderer.domElement.removeEventListener("pointerdown", onPointerDown);
       renderer.domElement.removeEventListener("pointermove", onPointerMove);
       window.removeEventListener("pointerup", onPointerUp);
+      canvas.removeEventListener("pointerdown", focusCanvas);
+      canvas.removeEventListener("keydown", onKeyDown);
+      canvas.removeEventListener("keyup", onKeyUp);
+      canvas.removeEventListener("blur", clearKeys);
+      canvas.removeEventListener("pointerleave", clearKeys);
+      window.removeEventListener("blur", clearKeys);
+      document.removeEventListener("visibilitychange", onVisibility);
+      keysRef.current.clear();
       sceneObj.traverse((obj) => {
         const mesh = obj as THREE.Mesh;
         if (mesh.geometry) mesh.geometry.dispose();
@@ -338,25 +382,6 @@ export function useGameScene(scene: SceneKind): GameSceneHandle {
       }
     };
   }, [scene]);
-
-  // Keyboard capture for WASD / arrows while the stage is mounted.
-  useEffect(() => {
-    const keys = keysRef.current;
-    const down = (e: KeyboardEvent) => {
-      const k = e.key.toLowerCase();
-      if (["w", "a", "s", "d", "arrowup", "arrowdown", "arrowleft", "arrowright"].includes(k)) {
-        keys.add(k);
-        if (playingRef.current) e.preventDefault();
-      }
-    };
-    const up = (e: KeyboardEvent) => keys.delete(e.key.toLowerCase());
-    window.addEventListener("keydown", down);
-    window.addEventListener("keyup", up);
-    return () => {
-      window.removeEventListener("keydown", down);
-      window.removeEventListener("keyup", up);
-    };
-  }, []);
 
   return { hostRef, playing, setPlaying, togglePlay, fps, reset, supported };
 }

--- a/desktop/src/registry/app-registry.ts
+++ b/desktop/src/registry/app-registry.ts
@@ -57,6 +57,7 @@ const apps: AppManifest[] = [
   { id: "chess", name: "Chess", icon: "crown", category: "game", component: () => import("@/apps/ChessApp").then((m) => ({ default: m.ChessApp })), defaultSize: { w: 700, h: 700 }, minSize: { w: 500, h: 500 }, singleton: true, pinned: false, launchpadOrder: 40 },
   { id: "wordle", name: "Wordle", icon: "spell-check", category: "game", component: () => import("@/apps/WordleApp").then((m) => ({ default: m.WordleApp })), defaultSize: { w: 500, h: 650 }, minSize: { w: 400, h: 550 }, singleton: true, pinned: false, launchpadOrder: 41 },
   { id: "crosswords", name: "Crosswords", icon: "grid-3x3", category: "game", component: () => import("@/apps/CrosswordsApp").then((m) => ({ default: m.CrosswordsApp })), defaultSize: { w: 700, h: 600 }, minSize: { w: 500, h: 450 }, singleton: true, pinned: false, launchpadOrder: 42 },
+  { id: "game-studio", name: "Game Studio", icon: "gamepad-2", category: "game", component: () => import("@/apps/GameStudioApp").then((m) => ({ default: m.GameStudioApp })), defaultSize: { w: 1080, h: 760 }, minSize: { w: 640, h: 520 }, singleton: true, pinned: false, launchpadOrder: 42.5 },
 ];
 
 export function getApp(id: string): AppManifest | undefined {


### PR DESCRIPTION
Phase 1 of the Game Studio app: the real React app shell built from the approved mock, plus a genuinely working three.js preview. AI generation, the skill pack and the asset/publish backends are later phases and are surfaced as honest "coming" affordances rather than faked.

## What phase 1 delivers

A new app at desktop/src/apps/GameStudioApp.tsx with a gamestudio/ subfolder for the views, registered in the app registry as a normal game app (id game-studio). Note: a follow-up (#53) should make heavy apps like this an optional install; for now it registers normally.

Three views behind a left icon rail, the same shape as Images Studio:

- Create: prompt box, multi-select genre chips, a labelled offline-model selector, and a template gallery. Selecting a template loads its real demo scene into Play. "Generate with AI" does not fake a build; it shows an honest "offline generation is coming" note and points at the templates.
- Play and Test (the centerpiece, real): a live three.js WebGLRenderer stage with standard materials (no WebGPU/TSL), a ground plane, lit low-poly primitives, shadows, and a requestAnimationFrame loop. Two interactive scenes (a runner and an orbit scene) with pointer-drag orbit and WASD/arrow controls, play/pause, scene reset, and a live FPS overlay read from the rAF loop. Device preview switch (Desktop / Mobile / XR): Desktop and Mobile resize the stage; XR is a labelled framing affordance with a note that real WebXR lands later. A build-log side panel shows an illustrative preview of the future agent build trace.
- Share: a publish card (title, cover, genre, description, Private/Community visibility, a test-passed checklist). "Share to Store" does not fake success; it shows an honest "publishing flows through the Store, coming" state (ties to #53).

## Pinned three.js revision

three is pinned to 0.180.0 and @types/three to 0.180.0 (exact, matched major.minor). three.js loads only in the Game Studio chunk, so it does not weigh on the rest of the desktop.

## Exit-to-taOS guarantee

Whenever the Play stage is fullscreen (via the Fullscreen API), an always-visible "Exit to taOS" control is layered on top: a slate glass pill pinned to the top corner, safe-area aware, at the highest z-index so it sits above the HUD, controls and play overlay. Clicking it exits fullscreen. Escape also exits fullscreen on desktop. On mobile the same pill is a persistent safe-area touch target. The user is never trapped in a fullscreen game.

## What is stubbed for later phases

- Offline AI generation (Create): honest "coming" note, no fake build.
- Store publishing (Share): honest "coming" note, no fake success.
- Real WebXR play (Play): XR is a labelled framing affordance only.
- The build log is a static, clearly-labelled preview of the future agent trace.
- The art-style and difficulty selectors are inert placeholders.

## Design and verification

Semantic shell tokens only (color-shell-*, accent slate, no purple), rounded glass surfaces, correct in both dark and light. Works at 390px: the Create maker and a fullscreen play state with the exit control and safe-area insets. Respects prefers-reduced-motion (idle camera drift and the spinner are suppressed).

tsc --noEmit is clean and npm run build succeeds. The three.js engine path was verified in headless Chromium: a WebGLRenderer (WebGL 2.0) built lit standard-material geometry with shadows and rendered animation frames with no JS errors, which is the same path useGameScene uses.