### PR TITLE
feat(store): store popularity backend (GitHub stars)

### DIFF
--- a/tests/routes/test_store_popularity_route.py
+++ b/tests/routes/test_store_popularity_route.py
@@ -1,0 +1,101 @@
+"""Tests for popularity wiring on the Store catalog + /api/store/popularity."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tinyagentos import store_popularity as sp
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    sp._reset_cache_for_tests()
+    yield
+    sp._reset_cache_for_tests()
+
+
+def _fake_app(app_id: str, homepage: str):
+    a = MagicMock()
+    a.id = app_id
+    a.name = app_id
+    a.type = "plugin"
+    a.category = ""
+    a.version = "1.0.0"
+    a.description = ""
+    a.icon = ""
+    a.homepage = homepage
+    a.requires = {}
+    a.install = {}
+    a.hardware_tiers = {}
+    a.variants = []
+    return a
+
+
+def _patch_registry(app, apps):
+    reg = MagicMock()
+    reg.list_available = MagicMock(return_value=apps)
+    reg.is_installed = MagicMock(return_value=False)
+    app.state.registry = reg
+    app.state.installation_state = None
+
+
+def _patch_github(monkeypatch, stars: int | None):
+    """Make every GitHub repo lookup return ``stars`` (or 404 when None)."""
+    resp = MagicMock()
+    resp.status_code = 200 if stars is not None else 404
+    resp.json = MagicMock(
+        return_value={"stargazers_count": stars} if stars is not None else {}
+    )
+    fake = MagicMock()
+    fake.get = AsyncMock(return_value=resp)
+    fake.aclose = AsyncMock()
+    fake.__aenter__ = AsyncMock(return_value=fake)
+    fake.__aexit__ = AsyncMock(return_value=False)
+    monkeypatch.setattr(
+        "tinyagentos.routes.store.httpx.AsyncClient", lambda *a, **k: fake
+    )
+
+
+class TestStorePopularityRoute:
+    @pytest.mark.asyncio
+    async def test_catalog_surfaces_stars_and_popularity(self, client, monkeypatch):
+        app = client._transport.app
+        _patch_registry(app, [_fake_app("jellyfin", "https://github.com/jellyfin/jellyfin")])
+        _patch_github(monkeypatch, 35000)
+
+        res = await client.get("/api/store/catalog")
+        assert res.status_code == 200
+        entry = res.json()[0]
+        assert entry["repo"] == "jellyfin/jellyfin"
+        assert entry["stars"] == 35000
+        assert entry["popularity"] == {
+            "github_stars": 35000,
+            "installs": None,
+            "score": 35000.0,
+        }
+
+    @pytest.mark.asyncio
+    async def test_non_github_entry_gets_null_popularity(self, client, monkeypatch):
+        app = client._transport.app
+        _patch_registry(app, [_fake_app("excalidraw", "https://excalidraw.com")])
+        _patch_github(monkeypatch, 35000)  # never called for a non-github entry
+
+        res = await client.get("/api/store/catalog")
+        entry = res.json()[0]
+        assert entry["repo"] is None
+        assert entry["stars"] is None
+        assert entry["popularity"]["github_stars"] is None
+        assert entry["popularity"]["score"] == 0.0
+
+    @pytest.mark.asyncio
+    async def test_dedicated_popularity_endpoint(self, client, monkeypatch):
+        app = client._transport.app
+        _patch_registry(app, [_fake_app("jellyfin", "https://github.com/jellyfin/jellyfin")])
+        _patch_github(monkeypatch, 12345)
+
+        res = await client.get("/api/store/popularity")
+        assert res.status_code == 200
+        body = res.json()
+        assert body["jellyfin"]["github_stars"] == 12345
+        assert body["jellyfin"]["installs"] is None

--- a/tests/routes/test_store_popularity_route.py
+++ b/tests/routes/test_store_popularity_route.py
@@ -1,7 +1,8 @@
 """Tests for popularity wiring on the Store catalog + /api/store/popularity."""
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+import time
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -40,29 +41,30 @@ def _patch_registry(app, apps):
     app.state.installation_state = None
 
 
-def _patch_github(monkeypatch, stars: int | None):
-    """Make every GitHub repo lookup return ``stars`` (or 404 when None)."""
-    resp = MagicMock()
-    resp.status_code = 200 if stars is not None else 404
-    resp.json = MagicMock(
-        return_value={"stargazers_count": stars} if stars is not None else {}
-    )
-    fake = MagicMock()
-    fake.get = AsyncMock(return_value=resp)
-    fake.aclose = AsyncMock()
-    fake.__aenter__ = AsyncMock(return_value=fake)
-    fake.__aexit__ = AsyncMock(return_value=False)
-    monkeypatch.setattr(
-        "tinyagentos.routes.store.httpx.AsyncClient", lambda *a, **k: fake
-    )
+def _seed_stars(repo: str, stars: int) -> None:
+    """Pre-warm the cache the way the background warmer would."""
+    sp._star_cache[repo] = (time.time() + 3600, stars)
+
+
+def _explode_on_live_fetch(monkeypatch):
+    """Make any live GitHub call blow up, so a request-path fetch would fail.
+
+    The request path must read from cache only; if the catalog route ever
+    awaited GitHub, this would raise and the test would fail.
+    """
+    async def _boom(*a, **k):
+        raise AssertionError("request path must not call GitHub")
+
+    monkeypatch.setattr(sp, "fetch_stars", _boom)
 
 
 class TestStorePopularityRoute:
     @pytest.mark.asyncio
-    async def test_catalog_surfaces_stars_and_popularity(self, client, monkeypatch):
+    async def test_catalog_surfaces_cached_stars(self, client, monkeypatch):
         app = client._transport.app
         _patch_registry(app, [_fake_app("jellyfin", "https://github.com/jellyfin/jellyfin")])
-        _patch_github(monkeypatch, 35000)
+        _seed_stars("jellyfin/jellyfin", 35000)
+        _explode_on_live_fetch(monkeypatch)
 
         res = await client.get("/api/store/catalog")
         assert res.status_code == 200
@@ -76,10 +78,26 @@ class TestStorePopularityRoute:
         }
 
     @pytest.mark.asyncio
+    async def test_catalog_returns_immediately_without_github(self, client, monkeypatch):
+        # Cold cache: stars are null and NO GitHub call happens in the request
+        # path (a live call would raise via _explode_on_live_fetch).
+        app = client._transport.app
+        _patch_registry(app, [_fake_app("jellyfin", "https://github.com/jellyfin/jellyfin")])
+        _explode_on_live_fetch(monkeypatch)
+
+        res = await client.get("/api/store/catalog")
+        assert res.status_code == 200
+        entry = res.json()[0]
+        assert entry["repo"] == "jellyfin/jellyfin"
+        assert entry["stars"] is None
+        assert entry["popularity"]["github_stars"] is None
+        assert entry["popularity"]["score"] == 0.0
+
+    @pytest.mark.asyncio
     async def test_non_github_entry_gets_null_popularity(self, client, monkeypatch):
         app = client._transport.app
         _patch_registry(app, [_fake_app("excalidraw", "https://excalidraw.com")])
-        _patch_github(monkeypatch, 35000)  # never called for a non-github entry
+        _explode_on_live_fetch(monkeypatch)
 
         res = await client.get("/api/store/catalog")
         entry = res.json()[0]
@@ -92,7 +110,8 @@ class TestStorePopularityRoute:
     async def test_dedicated_popularity_endpoint(self, client, monkeypatch):
         app = client._transport.app
         _patch_registry(app, [_fake_app("jellyfin", "https://github.com/jellyfin/jellyfin")])
-        _patch_github(monkeypatch, 12345)
+        _seed_stars("jellyfin/jellyfin", 12345)
+        _explode_on_live_fetch(monkeypatch)
 
         res = await client.get("/api/store/popularity")
         assert res.status_code == 200

--- a/tests/test_store_popularity.py
+++ b/tests/test_store_popularity.py
@@ -1,6 +1,7 @@
 """Tests for store popularity: GitHub stars, caching, graceful degradation."""
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -15,11 +16,12 @@ def _clear_cache():
     sp._reset_cache_for_tests()
 
 
-def _client_returning(status_code: int, json_body: dict | None = None):
+def _client_returning(status_code: int, json_body: dict | None = None, headers: dict | None = None):
     """Build a fake httpx.AsyncClient whose .get returns the given response."""
     resp = MagicMock()
     resp.status_code = status_code
     resp.json = MagicMock(return_value=json_body or {})
+    resp.headers = headers or {}
     client = MagicMock()
     client.get = AsyncMock(return_value=resp)
     return client
@@ -28,6 +30,9 @@ def _client_returning(status_code: int, json_body: dict | None = None):
 class TestParseRepo:
     def test_github_repo_homepage(self):
         assert sp.parse_repo("https://github.com/jellyfin/jellyfin") == "jellyfin/jellyfin"
+
+    def test_www_github_host(self):
+        assert sp.parse_repo("https://www.github.com/owner/repo") == "owner/repo"
 
     def test_trailing_slash_and_git_suffix(self):
         assert sp.parse_repo("https://github.com/owner/repo/") == "owner/repo"
@@ -39,6 +44,19 @@ class TestParseRepo:
     def test_bare_profile_url(self):
         assert sp.parse_repo("https://github.com/owner") is None
 
+    def test_rejects_gist_subdomain(self):
+        assert sp.parse_repo("https://gist.github.com/owner/abc123") is None
+
+    def test_rejects_raw_githubusercontent(self):
+        assert sp.parse_repo("https://raw.githubusercontent.com/owner/repo/main/f") is None
+
+    def test_rejects_github_io_pages(self):
+        assert sp.parse_repo("https://owner.github.io/repo") is None
+
+    def test_rejects_github_com_gist_path(self):
+        # github.com/gist/... is not an owner/repo even on the right host.
+        assert sp.parse_repo("https://github.com/gist/abc") is None
+
     def test_empty(self):
         assert sp.parse_repo("") is None
         assert sp.parse_repo(None) is None
@@ -46,32 +64,77 @@ class TestParseRepo:
 
 class TestFetchStars:
     @pytest.mark.asyncio
-    async def test_github_homepage_gets_stars(self):
+    async def test_github_repo_gets_stars(self):
         client = _client_returning(200, {"stargazers_count": 72400})
-        pop = await sp.popularity_for_homepage(
-            "https://github.com/jellyfin/jellyfin", client=client
-        )
-        assert pop["github_stars"] == 72400
-        assert pop["installs"] is None
-        assert pop["score"] == 72400.0
+        stars = await sp.fetch_stars("jellyfin/jellyfin", client=client)
+        assert stars == 72400
         client.get.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_404_yields_null_without_raising(self):
-        client = _client_returning(404, {})
-        pop = await sp.popularity_for_homepage(
-            "https://github.com/owner/missing-repo", client=client
-        )
-        assert pop["github_stars"] is None
-        assert pop["score"] == 0.0
+    async def test_200_long_caches(self):
+        client = _client_returning(200, {"stargazers_count": 100})
+        await sp.fetch_stars("owner/repo", client=client)
+        expires_at, stars = sp._star_cache["owner/repo"]
+        assert stars == 100
+        # Long TTL: the entry is good for hours, not just the short retry window.
+        import time
+        assert expires_at - time.time() > sp._RETRY_TTL + 60
 
     @pytest.mark.asyncio
-    async def test_rate_limit_yields_null_without_raising(self):
+    async def test_404_yields_null_and_long_caches(self):
+        client = _client_returning(404, {})
+        stars = await sp.fetch_stars("owner/missing-repo", client=client)
+        assert stars is None
+        import time
+        expires_at, cached = sp._star_cache["owner/missing-repo"]
+        assert cached is None
+        assert expires_at - time.time() > sp._RETRY_TTL + 60  # genuine 404 = long
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_403_yields_null_with_short_ttl(self):
         client = _client_returning(403, {"message": "rate limit exceeded"})
-        pop = await sp.popularity_for_homepage(
-            "https://github.com/owner/repo", client=client
+        stars = await sp.fetch_stars("owner/repo", client=client)
+        assert stars is None
+        import time
+        expires_at, cached = sp._star_cache["owner/repo"]
+        assert cached is None
+        # SHORT retry TTL, not the long star TTL.
+        assert expires_at - time.time() <= sp._RETRY_TTL + 1
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_429_yields_null_with_short_ttl(self):
+        client = _client_returning(429, {})
+        stars = await sp.fetch_stars("owner/repo", client=client)
+        assert stars is None
+        import time
+        expires_at, _ = sp._star_cache["owner/repo"]
+        assert expires_at - time.time() <= sp._RETRY_TTL + 1
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_remaining_header_zero(self):
+        client = _client_returning(
+            403, {}, headers={"X-RateLimit-Remaining": "0"}
         )
-        assert pop["github_stars"] is None
+        stars = await sp.fetch_stars("owner/repo", client=client)
+        assert stars is None
+        # The warmer back-off window is armed.
+        assert sp._rate_limited_until > 0
+
+    @pytest.mark.asyncio
+    async def test_transient_refetched_on_next_pass(self):
+        # A transient 403 must NOT be cached for the long TTL: a follow-up
+        # fetch should re-hit GitHub (and succeed) rather than serve stale null.
+        rl = _client_returning(403, {"message": "rate limit exceeded"})
+        first = await sp.fetch_stars("owner/repo", client=rl)
+        assert first is None
+        # Manually expire the short retry entry to simulate the next pass.
+        import time
+        sp._star_cache["owner/repo"] = (time.time() - 1, None)
+        sp._rate_limited_until = 0.0
+        ok = _client_returning(200, {"stargazers_count": 42})
+        second = await sp.fetch_stars("owner/repo", client=ok)
+        assert second == 42
+        ok.get.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_network_error_yields_null_without_raising(self):
@@ -79,13 +142,9 @@ class TestFetchStars:
         client.get = AsyncMock(side_effect=RuntimeError("boom"))
         stars = await sp.fetch_stars("owner/repo", client=client)
         assert stars is None
-
-    @pytest.mark.asyncio
-    async def test_non_github_homepage_no_call_no_stars(self):
-        client = _client_returning(200, {"stargazers_count": 5})
-        pop = await sp.popularity_for_homepage("https://excalidraw.com", client=client)
-        assert pop["github_stars"] is None
-        client.get.assert_not_called()
+        import time
+        expires_at, _ = sp._star_cache["owner/repo"]
+        assert expires_at - time.time() <= sp._RETRY_TTL + 1  # transient = short
 
     @pytest.mark.asyncio
     async def test_caching_avoids_second_call_within_ttl(self):
@@ -94,6 +153,73 @@ class TestFetchStars:
         second = await sp.fetch_stars("owner/repo", client=client)
         assert first == second == 100
         client.get.assert_awaited_once()  # second call served from cache
+
+
+class TestCachedReads:
+    def test_cached_stars_none_when_unknown(self):
+        assert sp.cached_stars("owner/repo") is None
+
+    def test_popularity_for_homepage_cached_no_call(self):
+        # No cache entry -> github_stars None, and crucially no GitHub call.
+        pop = sp.popularity_for_homepage_cached("https://github.com/owner/repo")
+        assert pop["github_stars"] is None
+        assert pop["score"] == 0.0
+
+    def test_cached_stars_after_warm(self):
+        import time
+        sp._star_cache["owner/repo"] = (time.time() + 3600, 999)
+        assert sp.cached_stars("owner/repo") == 999
+        pop = sp.popularity_for_homepage_cached("https://github.com/owner/repo")
+        assert pop["github_stars"] == 999
+
+    def test_cached_stars_expired(self):
+        import time
+        sp._star_cache["owner/repo"] = (time.time() - 1, 5)
+        assert sp.cached_stars("owner/repo") is None
+
+
+class TestWarmer:
+    @pytest.mark.asyncio
+    async def test_warm_populates_cache(self):
+        client = _client_returning(200, {"stargazers_count": 7})
+        await sp.warm_popularity_cache(["a/b", "c/d"], client=client)
+        assert sp.cached_stars("a/b") == 7
+        assert sp.cached_stars("c/d") == 7
+
+    @pytest.mark.asyncio
+    async def test_warm_respects_concurrency_bound(self, monkeypatch):
+        # Track peak concurrency through fetch_stars; it must never exceed
+        # the warmer's semaphore bound.
+        live = 0
+        peak = 0
+
+        async def _fake_fetch(repo, *, client=None):
+            nonlocal live, peak
+            live += 1
+            peak = max(peak, live)
+            await asyncio.sleep(0.01)
+            live -= 1
+            return 1
+
+        monkeypatch.setattr(sp, "fetch_stars", _fake_fetch)
+        repos = [f"o/{i}" for i in range(20)]
+        await sp.warm_popularity_cache(repos)
+        assert peak <= sp._WARM_CONCURRENCY
+
+    @pytest.mark.asyncio
+    async def test_warm_backs_off_when_rate_limited(self, monkeypatch):
+        import time
+        sp._rate_limited_until = time.time() + 3600
+        called = False
+
+        async def _fake_fetch(repo, *, client=None):
+            nonlocal called
+            called = True
+            return 1
+
+        monkeypatch.setattr(sp, "fetch_stars", _fake_fetch)
+        await sp.warm_popularity_cache(["a/b"])
+        assert called is False  # backed off, no fetches issued
 
 
 class TestScore:
@@ -108,3 +234,17 @@ class TestScore:
         shape = sp.popularity_shape(100, installs=10)
         assert shape["installs"] == 10
         assert shape["score"] == 100.0 + 10 * 10.0
+
+
+class TestPersistence:
+    def test_round_trip(self, tmp_path):
+        import time
+        sp.configure_persistence(tmp_path)
+        sp._star_cache["owner/repo"] = (time.time() + 3600, 123)
+        sp._persist_cache()
+
+        # Simulate a restart: clear in-memory state, reconfigure, reload.
+        sp._reset_cache_for_tests()
+        assert sp.cached_stars("owner/repo") is None
+        sp.configure_persistence(tmp_path)
+        assert sp.cached_stars("owner/repo") == 123

--- a/tests/test_store_popularity.py
+++ b/tests/test_store_popularity.py
@@ -1,0 +1,110 @@
+"""Tests for store popularity: GitHub stars, caching, graceful degradation."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tinyagentos import store_popularity as sp
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    sp._reset_cache_for_tests()
+    yield
+    sp._reset_cache_for_tests()
+
+
+def _client_returning(status_code: int, json_body: dict | None = None):
+    """Build a fake httpx.AsyncClient whose .get returns the given response."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json = MagicMock(return_value=json_body or {})
+    client = MagicMock()
+    client.get = AsyncMock(return_value=resp)
+    return client
+
+
+class TestParseRepo:
+    def test_github_repo_homepage(self):
+        assert sp.parse_repo("https://github.com/jellyfin/jellyfin") == "jellyfin/jellyfin"
+
+    def test_trailing_slash_and_git_suffix(self):
+        assert sp.parse_repo("https://github.com/owner/repo/") == "owner/repo"
+        assert sp.parse_repo("https://github.com/owner/repo.git") == "owner/repo"
+
+    def test_non_github_homepage(self):
+        assert sp.parse_repo("https://excalidraw.com") is None
+
+    def test_bare_profile_url(self):
+        assert sp.parse_repo("https://github.com/owner") is None
+
+    def test_empty(self):
+        assert sp.parse_repo("") is None
+        assert sp.parse_repo(None) is None
+
+
+class TestFetchStars:
+    @pytest.mark.asyncio
+    async def test_github_homepage_gets_stars(self):
+        client = _client_returning(200, {"stargazers_count": 72400})
+        pop = await sp.popularity_for_homepage(
+            "https://github.com/jellyfin/jellyfin", client=client
+        )
+        assert pop["github_stars"] == 72400
+        assert pop["installs"] is None
+        assert pop["score"] == 72400.0
+        client.get.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_404_yields_null_without_raising(self):
+        client = _client_returning(404, {})
+        pop = await sp.popularity_for_homepage(
+            "https://github.com/owner/missing-repo", client=client
+        )
+        assert pop["github_stars"] is None
+        assert pop["score"] == 0.0
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_yields_null_without_raising(self):
+        client = _client_returning(403, {"message": "rate limit exceeded"})
+        pop = await sp.popularity_for_homepage(
+            "https://github.com/owner/repo", client=client
+        )
+        assert pop["github_stars"] is None
+
+    @pytest.mark.asyncio
+    async def test_network_error_yields_null_without_raising(self):
+        client = MagicMock()
+        client.get = AsyncMock(side_effect=RuntimeError("boom"))
+        stars = await sp.fetch_stars("owner/repo", client=client)
+        assert stars is None
+
+    @pytest.mark.asyncio
+    async def test_non_github_homepage_no_call_no_stars(self):
+        client = _client_returning(200, {"stargazers_count": 5})
+        pop = await sp.popularity_for_homepage("https://excalidraw.com", client=client)
+        assert pop["github_stars"] is None
+        client.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_caching_avoids_second_call_within_ttl(self):
+        client = _client_returning(200, {"stargazers_count": 100})
+        first = await sp.fetch_stars("owner/repo", client=client)
+        second = await sp.fetch_stars("owner/repo", client=client)
+        assert first == second == 100
+        client.get.assert_awaited_once()  # second call served from cache
+
+
+class TestScore:
+    def test_score_is_stars_today(self):
+        assert sp.popularity_shape(500)["score"] == 500.0
+
+    def test_score_with_no_signals_is_zero(self):
+        assert sp.popularity_shape(None)["score"] == 0.0
+
+    def test_installs_weighed_when_present_forward_compat(self):
+        # #15: installs fill in without a shape change; weighted above a star.
+        shape = sp.popularity_shape(100, installs=10)
+        assert shape["installs"] == 10
+        assert shape["score"] == 100.0 + 10 * 10.0

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -722,6 +722,30 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         app.state.health_monitor = monitor
         await monitor.start()
 
+        # Store popularity: warm the GitHub-star cache in the background so the
+        # /api/store catalog list reads stars from cache and never blocks on
+        # GitHub. The catalog has more github.com homepages than the
+        # unauthenticated rate limit allows in one pass, so the warmer walks
+        # them over several passes, backing off when GitHub signals the limit.
+        from tinyagentos import store_popularity
+        store_popularity.configure_persistence(data_dir)
+
+        async def _popularity_warm_loop(app: FastAPI) -> None:
+            import asyncio as _asyncio
+            while True:
+                try:
+                    repos = sorted({
+                        r for a in app.state.registry.list_available()
+                        if (r := store_popularity.parse_repo(getattr(a, "homepage", "") or ""))
+                    })
+                    if repos:
+                        await store_popularity.warm_popularity_cache(repos)
+                except Exception as _e:
+                    logger.warning("store popularity warm failed: %s", _e)
+                await _asyncio.sleep(600)
+
+        _create_supervised_task(_popularity_warm_loop(app), app.state._background_tasks)
+
         # Hourly auto-update checker. Polls the git remote, notifies the
         # user on new commits, optionally applies automatically (user
         # toggle via /api/preferences/auto-update).

--- a/tinyagentos/routes/store.py
+++ b/tinyagentos/routes/store.py
@@ -1,8 +1,10 @@
 # tinyagentos/routes/store.py
 from __future__ import annotations
 
+import asyncio
 from dataclasses import asdict
 
+import httpx
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
@@ -15,6 +17,35 @@ from tinyagentos.catalog.resolver import (
 )
 from tinyagentos.installers.base import get_installer
 from tinyagentos.routes.store_install import get_device_capability
+from tinyagentos.store_popularity import (
+    parse_repo,
+    popularity_for_homepage,
+    popularity_shape,
+)
+
+
+async def _popularity_by_app_id(apps) -> dict[str, dict]:
+    """Resolve the telemetry-ready popularity shape for each manifest.
+
+    Cached repos return instantly; uncached ones are fetched from GitHub
+    concurrently over one shared client so the Store list stays fast and a
+    slow/unreachable GitHub never blocks the response for long. Any failure
+    degrades that entry to github_stars=None (never raises). Entries without a
+    GitHub repo homepage get a popularity shape with github_stars=None too;
+    they need a github.com/owner/repo homepage in their manifest to get stars.
+    """
+    result: dict[str, dict] = {}
+    async with httpx.AsyncClient(timeout=8) as client:
+        async def _one(app):
+            try:
+                result[app.id] = await popularity_for_homepage(
+                    getattr(app, "homepage", "") or "", client=client
+                )
+            except Exception:
+                result[app.id] = popularity_shape(None)
+
+        await asyncio.gather(*(_one(a) for a in apps))
+    return result
 
 
 class InstallRequest(BaseModel):
@@ -125,6 +156,8 @@ async def list_catalog(request: Request, type: str | None = None):
             return registry.is_installed(app_id)
         return installation.state(app_id) in ("running", "installed")
 
+    popularity = await _popularity_by_app_id(apps)
+
     return [
         {
             "id": a.id, "name": a.name, "type": a.type, "category": a.category,
@@ -135,9 +168,29 @@ async def list_catalog(request: Request, type: str | None = None):
             "installed": _installed_flag(a.id),
             "state": (installation.state(a.id) if installation else ("installed" if registry.is_installed(a.id) else "not_installed")),
             "variants": _slim_variants(a),
+            # Popularity (telemetry-ready). repo + stars are flattened for the
+            # existing Store frontend; popularity carries the full shape so #15
+            # can fill installs without a breaking change.
+            "repo": parse_repo(getattr(a, "homepage", "") or ""),
+            "stars": popularity[a.id]["github_stars"],
+            "popularity": popularity[a.id],
         }
         for a in apps
     ]
+
+
+@router.get("/api/store/popularity")
+async def list_popularity(request: Request, type: str | None = None):
+    """Return the telemetry-ready popularity shape per app id.
+
+    {app_id: {"github_stars": int|null, "installs": int|null, "score": float}}
+
+    github_stars come from GitHub today; installs is null until #15 wires real
+    install telemetry. GitHub failures degrade to github_stars=null.
+    """
+    registry = request.app.state.registry
+    apps = registry.list_available(type_filter=type)
+    return await _popularity_by_app_id(apps)
 
 
 @router.get("/api/store/installed")

--- a/tinyagentos/routes/store.py
+++ b/tinyagentos/routes/store.py
@@ -1,10 +1,8 @@
 # tinyagentos/routes/store.py
 from __future__ import annotations
 
-import asyncio
 from dataclasses import asdict
 
-import httpx
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
@@ -19,33 +17,23 @@ from tinyagentos.installers.base import get_installer
 from tinyagentos.routes.store_install import get_device_capability
 from tinyagentos.store_popularity import (
     parse_repo,
-    popularity_for_homepage,
-    popularity_shape,
+    popularity_for_homepage_cached,
 )
 
 
-async def _popularity_by_app_id(apps) -> dict[str, dict]:
+def _popularity_by_app_id(apps) -> dict[str, dict]:
     """Resolve the telemetry-ready popularity shape for each manifest.
 
-    Cached repos return instantly; uncached ones are fetched from GitHub
-    concurrently over one shared client so the Store list stays fast and a
-    slow/unreachable GitHub never blocks the response for long. Any failure
-    degrades that entry to github_stars=None (never raises). Entries without a
-    GitHub repo homepage get a popularity shape with github_stars=None too;
-    they need a github.com/owner/repo homepage in their manifest to get stars.
+    Reads ONLY the in-memory star cache; it never calls GitHub, so the Store
+    list endpoint returns immediately and is never stalled by a slow or
+    rate-limited GitHub. Not-yet-warmed (or non-GitHub) entries get a
+    popularity shape with github_stars=None. A background warmer populates the
+    cache over time, respecting GitHub's unauthenticated rate limit.
     """
-    result: dict[str, dict] = {}
-    async with httpx.AsyncClient(timeout=8) as client:
-        async def _one(app):
-            try:
-                result[app.id] = await popularity_for_homepage(
-                    getattr(app, "homepage", "") or "", client=client
-                )
-            except Exception:
-                result[app.id] = popularity_shape(None)
-
-        await asyncio.gather(*(_one(a) for a in apps))
-    return result
+    return {
+        app.id: popularity_for_homepage_cached(getattr(app, "homepage", "") or "")
+        for app in apps
+    }
 
 
 class InstallRequest(BaseModel):
@@ -156,7 +144,7 @@ async def list_catalog(request: Request, type: str | None = None):
             return registry.is_installed(app_id)
         return installation.state(app_id) in ("running", "installed")
 
-    popularity = await _popularity_by_app_id(apps)
+    popularity = _popularity_by_app_id(apps)
 
     return [
         {
@@ -190,7 +178,7 @@ async def list_popularity(request: Request, type: str | None = None):
     """
     registry = request.app.state.registry
     apps = registry.list_available(type_filter=type)
-    return await _popularity_by_app_id(apps)
+    return _popularity_by_app_id(apps)
 
 
 @router.get("/api/store/installed")

--- a/tinyagentos/store_popularity.py
+++ b/tinyagentos/store_popularity.py
@@ -10,50 +10,94 @@ The popularity shape is telemetry-ready and forward-compatible:
     }
 
 GitHub stars are fetched unauthenticated from api.github.com (allowed by the
-network policy) and cached in-memory with a multi-hour TTL so the Store list
-endpoint never hammers GitHub. Any GitHub failure (rate-limit, 404, network)
-degrades the entry to github_stars=None and never raises.
+network policy). Unauthenticated calls share a ~60 req/hr/IP limit, so the
+catalog can have far more GitHub homepages than the limit allows in one pass.
+
+The request path NEVER calls GitHub. The Store list endpoint reads only the
+in-memory cache and returns immediately (null/absent for not-yet-warmed apps).
+A bounded background warmer (small concurrency) walks the uncached/stale repos
+over time, backing off when GitHub signals the rate limit, so we never hammer
+past the limit. With more repos than the hourly budget it takes a few passes to
+fully warm, which is correct; stars read null in the meantime.
+
+Caching distinguishes error classes so a momentary rate-limit does not blank a
+repo for hours:
+  - 200 success and a genuine 404 (repo gone) cache for the long TTL.
+  - transient failures (403/429 rate-limit, 5xx, timeouts, connection errors)
+    cache for a short retry TTL so the next warmer pass re-fetches them.
+
+The cache persists to ``data_dir/store_popularity.json`` so a cold start does
+not re-fetch everything. Any GitHub failure degrades the entry to
+github_stars=None and never raises.
 """
 
 from __future__ import annotations
 
+import asyncio
+import json
 import logging
-import re
 import time
+from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 import httpx
 
 logger = logging.getLogger(__name__)
 
-# Cache GitHub star lookups for a few hours. Stars move slowly; the Store list
-# endpoint is hit often, so a long TTL keeps it fast and well under the
-# unauthenticated rate limit (60 req/hr/IP).
-_STAR_TTL = 6 * 60 * 60  # 6 hours
+# Stars move slowly and the list endpoint is hit often, so 200s and genuine
+# 404s cache for hours. Transient failures use a short retry TTL so the warmer
+# picks them up on its next pass instead of blanking the repo for hours.
+_STAR_TTL = 6 * 60 * 60  # 6 hours: successful lookups and confirmed 404s
+_RETRY_TTL = 10 * 60  # 10 minutes: transient rate-limit / network failures
 
-# key (owner/repo) -> (timestamp, github_stars | None)
+# Background warmer: a few concurrent fetches at most, short per-request timeout.
+_WARM_CONCURRENCY = 4
+_FETCH_TIMEOUT = 8.0
+
+# key (owner/repo) -> (expires_at_wall_clock, github_stars | None)
+# expires_at is wall-clock (time.time()) so it survives the persisted JSON.
 _star_cache: dict[str, tuple[float, int | None]] = {}
 
-_GITHUB_HOST = "github.com"
+# When GitHub reports the rate limit is exhausted we record a wall-clock instant
+# until which the warmer must not call GitHub. 0.0 means "not blocked".
+_rate_limited_until: float = 0.0
+
+_cache_path: Path | None = None
+
+_GITHUB_HOSTS = {"github.com", "www.github.com"}
+# Path segments that are not user/repo owners even though they live on
+# github.com (gists, raw blobs, github pages org pages, etc).
+_NON_REPO_OWNERS = {"gist", "raw", "about", "features", "topics", "marketplace"}
 
 
 def parse_repo(homepage: str | None) -> str | None:
     """Return owner/repo if homepage points at a GitHub repo, else None.
 
-    Accepts the forms taOS manifests use, e.g.
-    https://github.com/owner/repo or https://github.com/owner/repo/.
-    Non-GitHub homepages (excalidraw.com, gitea.io, ...) and bare profile
-    URLs (github.com/owner) return None: only an owner/repo pair yields stars.
+    Parsed with urllib so only a real github.com (or www.github.com) host with
+    exactly owner/repo as the first two path segments yields a repo. Rejects
+    gist.github.com, raw.githubusercontent.com, *.github.io pages, and
+    host-only or owner-only URLs.
     """
-    if not homepage or _GITHUB_HOST not in homepage:
+    if not homepage:
         return None
-    m = re.search(r"github\.com/([^/\s]+)/([^/\s#?]+)", homepage)
-    if not m:
+    try:
+        parts = urlsplit(homepage if "//" in homepage else "//" + homepage)
+    except ValueError:
         return None
-    owner, repo = m.group(1), m.group(2)
+    host = (parts.hostname or "").lower()
+    if host not in _GITHUB_HOSTS:
+        return None
+    segments = [s for s in parts.path.split("/") if s]
+    if len(segments) < 2:
+        return None
+    owner, repo = segments[0], segments[1]
+    if owner.lower() in _NON_REPO_OWNERS:
+        return None
+    repo = repo.removesuffix(".git")
     if not owner or not repo:
         return None
-    return f"{owner}/{repo.removesuffix('.git')}"
+    return f"{owner}/{repo}"
 
 
 def _compute_score(github_stars: int | None, installs: int | None) -> float:
@@ -81,59 +125,196 @@ def popularity_shape(github_stars: int | None, installs: int | None = None) -> d
     }
 
 
-async def fetch_stars(repo: str, *, client: httpx.AsyncClient | None = None) -> int | None:
-    """Return the GitHub star count for owner/repo, or None on any failure.
+def cached_stars(repo: str | None) -> int | None:
+    """Return the cached star count for owner/repo without ever calling GitHub.
 
-    Cached for _STAR_TTL per repo. Rate-limit (403/429) and 404 both yield
-    None and are cached so we do not retry a known-bad repo on every request.
-    Never raises.
+    None when the repo is unknown or its cache entry has expired. This is what
+    the request path uses so the catalog list never blocks on a live fetch.
     """
+    if not repo:
+        return None
     cached = _star_cache.get(repo)
-    if cached is not None:
-        ts, stars = cached
-        if time.monotonic() - ts < _STAR_TTL:
-            return stars
+    if cached is None:
+        return None
+    expires_at, stars = cached
+    if time.time() >= expires_at:
+        return None
+    return stars
+
+
+def popularity_for_homepage_cached(homepage: str | None) -> dict[str, Any]:
+    """Resolve the popularity shape for a catalog entry from cache only.
+
+    Never calls GitHub: not-yet-warmed entries get github_stars=None. installs
+    is always None until #15.
+    """
+    return popularity_shape(cached_stars(parse_repo(homepage)))
+
+
+def _is_rate_limited(resp: httpx.Response) -> bool:
+    """True when the response signals the unauthenticated rate limit."""
+    if resp.status_code in (403, 429):
+        return True
+    return resp.headers.get("X-RateLimit-Remaining") == "0"
+
+
+async def fetch_stars(repo: str, *, client: httpx.AsyncClient | None = None) -> int | None:
+    """Fetch and cache the GitHub star count for owner/repo. Never raises.
+
+    Used by the background warmer (not the request path). A fresh cache entry
+    short-circuits the call. Caching is error-class aware:
+      - 200 success and a genuine 404 cache for the long TTL.
+      - 403/429 rate-limit (or X-RateLimit-Remaining: 0), 5xx, timeouts and
+        connection errors cache for the short retry TTL and return None, so the
+        next warmer pass retries instead of blanking the repo for hours.
+    A rate-limit also arms the warmer back-off window.
+    """
+    global _rate_limited_until
+    if _has_fresh_entry(repo):
+        return cached_stars(repo)
 
     owns_client = client is None
+    stars: int | None = None
+    ttl = _RETRY_TTL  # default: transient unless we prove otherwise
     try:
         if owns_client:
-            client = httpx.AsyncClient(timeout=8)
+            client = httpx.AsyncClient(timeout=_FETCH_TIMEOUT)
         assert client is not None
         resp = await client.get(
             f"https://api.github.com/repos/{repo}",
             headers={"Accept": "application/vnd.github+json"},
         )
         if resp.status_code == 200:
-            stars = resp.json().get("stargazers_count")
-            stars = int(stars) if isinstance(stars, (int, float)) else None
-        else:
-            # 403/429 rate-limit, 404 not-found, anything else: degrade to None.
+            raw = resp.json().get("stargazers_count")
+            stars = int(raw) if isinstance(raw, (int, float)) else None
+            ttl = _STAR_TTL
+        elif resp.status_code == 404:
+            # Repo genuinely gone: long-cache the None so we stop asking.
             stars = None
-    except Exception as exc:  # network error, bad JSON, etc.
+            ttl = _STAR_TTL
+        elif _is_rate_limited(resp):
+            # Transient: short retry TTL and back the warmer off until reset.
+            _rate_limited_until = _reset_at(resp)
+            stars = None
+            ttl = _RETRY_TTL
+        else:
+            # Other non-200 (5xx etc): transient, short retry TTL.
+            stars = None
+            ttl = _RETRY_TTL
+    except Exception as exc:  # network error, timeout, bad JSON, etc.
         logger.debug("GitHub star fetch failed for %s: %s", repo, exc)
         stars = None
+        ttl = _RETRY_TTL
     finally:
         if owns_client and client is not None:
             await client.aclose()
 
-    _star_cache[repo] = (time.monotonic(), stars)
+    _star_cache[repo] = (time.time() + ttl, stars)
+    _persist_cache()
     return stars
 
 
-async def popularity_for_homepage(
-    homepage: str | None, *, client: httpx.AsyncClient | None = None
-) -> dict[str, Any]:
-    """Resolve the popularity shape for a catalog entry from its homepage.
+def _reset_at(resp: httpx.Response) -> float:
+    """Wall-clock instant the rate limit resets, from X-RateLimit-Reset.
 
-    Entries whose homepage is not a GitHub repo get a popularity shape with
-    github_stars=None (no stars are fabricated). installs is always None until
-    #15.
+    Falls back to now + retry TTL when the header is missing or unparseable.
     """
-    repo = parse_repo(homepage)
-    stars = await fetch_stars(repo, client=client) if repo else None
-    return popularity_shape(stars)
+    raw = resp.headers.get("X-RateLimit-Reset")
+    try:
+        reset = float(raw)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return time.time() + _RETRY_TTL
+    # Never block longer than necessary; clamp absurd values.
+    return min(reset, time.time() + _STAR_TTL)
+
+
+def _has_fresh_entry(repo: str) -> bool:
+    """True when the repo has any unexpired cache entry (including a cached None)."""
+    cached = _star_cache.get(repo)
+    return cached is not None and time.time() < cached[0]
+
+
+async def warm_popularity_cache(
+    repos: list[str], *, client: httpx.AsyncClient | None = None
+) -> None:
+    """Populate the cache for the given repos with bounded concurrency.
+
+    Skips repos with a fresh entry and stops early when GitHub has signalled
+    the rate limit is exhausted (until its reset). Designed to be called on a
+    schedule by a background loop; one pass warms only as many repos as the
+    rate limit allows, which is correct.
+    """
+    stale = [r for r in repos if not _has_fresh_entry(r)]
+    if not stale:
+        return
+    if time.time() < _rate_limited_until:
+        return  # still backing off from a prior rate-limit signal
+
+    owns_client = client is None
+    sem = asyncio.Semaphore(_WARM_CONCURRENCY)
+
+    async def _one(repo: str) -> None:
+        if time.time() < _rate_limited_until:
+            return  # a sibling fetch hit the limit; stop spending budget
+        async with sem:
+            await fetch_stars(repo, client=client)
+
+    try:
+        if owns_client:
+            client = httpx.AsyncClient(timeout=_FETCH_TIMEOUT)
+        await asyncio.gather(*(_one(r) for r in stale))
+    finally:
+        if owns_client and client is not None:
+            await client.aclose()
+
+
+def configure_persistence(data_dir: Path) -> None:
+    """Point the cache at ``data_dir/store_popularity.json`` and load it.
+
+    Idempotent. Safe to call before the warmer starts so a cold boot reuses the
+    last warmed values instead of re-fetching everything.
+    """
+    global _cache_path
+    _cache_path = Path(data_dir) / "store_popularity.json"
+    _load_cache()
+
+
+def _load_cache() -> None:
+    if _cache_path is None or not _cache_path.exists():
+        return
+    try:
+        raw = json.loads(_cache_path.read_text())
+    except Exception as exc:
+        logger.debug("store popularity cache load failed: %s", exc)
+        return
+    if not isinstance(raw, dict):
+        return
+    for repo, entry in raw.items():
+        try:
+            expires_at, stars = entry
+            _star_cache[str(repo)] = (
+                float(expires_at),
+                int(stars) if stars is not None else None,
+            )
+        except (TypeError, ValueError):
+            continue
+
+
+def _persist_cache() -> None:
+    if _cache_path is None:
+        return
+    try:
+        _cache_path.parent.mkdir(parents=True, exist_ok=True)
+        _cache_path.write_text(
+            json.dumps({r: [exp, stars] for r, (exp, stars) in _star_cache.items()})
+        )
+    except Exception as exc:
+        logger.debug("store popularity cache persist failed: %s", exc)
 
 
 def _reset_cache_for_tests() -> None:
-    """Clear the star cache. For tests only."""
+    """Clear the star cache and rate-limit gate. For tests only."""
+    global _rate_limited_until, _cache_path
     _star_cache.clear()
+    _rate_limited_until = 0.0
+    _cache_path = None

--- a/tinyagentos/store_popularity.py
+++ b/tinyagentos/store_popularity.py
@@ -1,0 +1,139 @@
+"""Store app popularity, sourced from GitHub stars today and structured to
+accept real install telemetry later (#15).
+
+The popularity shape is telemetry-ready and forward-compatible:
+
+    {
+        "github_stars": int | None,   # live star count, None when unknown
+        "installs": int | None,       # None today; filled by #15 telemetry
+        "score": float,               # derived from whatever signals exist
+    }
+
+GitHub stars are fetched unauthenticated from api.github.com (allowed by the
+network policy) and cached in-memory with a multi-hour TTL so the Store list
+endpoint never hammers GitHub. Any GitHub failure (rate-limit, 404, network)
+degrades the entry to github_stars=None and never raises.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Cache GitHub star lookups for a few hours. Stars move slowly; the Store list
+# endpoint is hit often, so a long TTL keeps it fast and well under the
+# unauthenticated rate limit (60 req/hr/IP).
+_STAR_TTL = 6 * 60 * 60  # 6 hours
+
+# key (owner/repo) -> (timestamp, github_stars | None)
+_star_cache: dict[str, tuple[float, int | None]] = {}
+
+_GITHUB_HOST = "github.com"
+
+
+def parse_repo(homepage: str | None) -> str | None:
+    """Return owner/repo if homepage points at a GitHub repo, else None.
+
+    Accepts the forms taOS manifests use, e.g.
+    https://github.com/owner/repo or https://github.com/owner/repo/.
+    Non-GitHub homepages (excalidraw.com, gitea.io, ...) and bare profile
+    URLs (github.com/owner) return None: only an owner/repo pair yields stars.
+    """
+    if not homepage or _GITHUB_HOST not in homepage:
+        return None
+    m = re.search(r"github\.com/([^/\s]+)/([^/\s#?]+)", homepage)
+    if not m:
+        return None
+    owner, repo = m.group(1), m.group(2)
+    if not owner or not repo:
+        return None
+    return f"{owner}/{repo.removesuffix('.git')}"
+
+
+def _compute_score(github_stars: int | None, installs: int | None) -> float:
+    """Combine the available signals into a single popularity score.
+
+    Today only stars exist, so the score is the star count. When #15 lands
+    real install telemetry, installs weigh in here without changing the shape
+    or any caller. An entry with no signals scores 0.0.
+    """
+    score = 0.0
+    if github_stars:
+        score += float(github_stars)
+    if installs:
+        # Installs are a stronger signal than a star; weight them when present.
+        score += float(installs) * 10.0
+    return score
+
+
+def popularity_shape(github_stars: int | None, installs: int | None = None) -> dict[str, Any]:
+    """Build the telemetry-ready popularity dict from the known signals."""
+    return {
+        "github_stars": github_stars,
+        "installs": installs,
+        "score": _compute_score(github_stars, installs),
+    }
+
+
+async def fetch_stars(repo: str, *, client: httpx.AsyncClient | None = None) -> int | None:
+    """Return the GitHub star count for owner/repo, or None on any failure.
+
+    Cached for _STAR_TTL per repo. Rate-limit (403/429) and 404 both yield
+    None and are cached so we do not retry a known-bad repo on every request.
+    Never raises.
+    """
+    cached = _star_cache.get(repo)
+    if cached is not None:
+        ts, stars = cached
+        if time.monotonic() - ts < _STAR_TTL:
+            return stars
+
+    owns_client = client is None
+    try:
+        if owns_client:
+            client = httpx.AsyncClient(timeout=8)
+        assert client is not None
+        resp = await client.get(
+            f"https://api.github.com/repos/{repo}",
+            headers={"Accept": "application/vnd.github+json"},
+        )
+        if resp.status_code == 200:
+            stars = resp.json().get("stargazers_count")
+            stars = int(stars) if isinstance(stars, (int, float)) else None
+        else:
+            # 403/429 rate-limit, 404 not-found, anything else: degrade to None.
+            stars = None
+    except Exception as exc:  # network error, bad JSON, etc.
+        logger.debug("GitHub star fetch failed for %s: %s", repo, exc)
+        stars = None
+    finally:
+        if owns_client and client is not None:
+            await client.aclose()
+
+    _star_cache[repo] = (time.monotonic(), stars)
+    return stars
+
+
+async def popularity_for_homepage(
+    homepage: str | None, *, client: httpx.AsyncClient | None = None
+) -> dict[str, Any]:
+    """Resolve the popularity shape for a catalog entry from its homepage.
+
+    Entries whose homepage is not a GitHub repo get a popularity shape with
+    github_stars=None (no stars are fabricated). installs is always None until
+    #15.
+    """
+    repo = parse_repo(homepage)
+    stars = await fetch_stars(repo, client=client) if repo else None
+    return popularity_shape(stars)
+
+
+def _reset_cache_for_tests() -> None:
+    """Clear the star cache. For tests only."""
+    _star_cache.clear()

--- a/tinyagentos/store_popularity.py
+++ b/tinyagentos/store_popularity.py
@@ -305,9 +305,12 @@ def _persist_cache() -> None:
         return
     try:
         _cache_path.parent.mkdir(parents=True, exist_ok=True)
-        _cache_path.write_text(
+        # Atomic write: a crash mid-write must not corrupt the persisted cache.
+        tmp_path = _cache_path.with_name(_cache_path.name + ".tmp")
+        tmp_path.write_text(
             json.dumps({r: [exp, stars] for r, (exp, stars) in _star_cache.items()})
         )
+        tmp_path.replace(_cache_path)
     except Exception as exc:
         logger.debug("store popularity cache persist failed: %s", exc)
 


### PR DESCRIPTION
Adds a store popularity backend sourced from GitHub stars today and structured to accept real install telemetry later (#15).

What it does:
- New module tinyagentos/store_popularity.py parses owner/repo from a catalog entry's homepage when it points at github.com, fetches the star count unauthenticated from api.github.com (allowed by the network policy), and caches it in-memory with a 6 hour TTL so the Store list endpoint never hammers GitHub.
- The Store catalog endpoint (GET /api/store/catalog) now carries repo, stars, and a telemetry-ready popularity object on every entry. Stars are fetched concurrently over one shared httpx client so the list stays fast.
- New GET /api/store/popularity returns the popularity shape keyed by app id.

Telemetry-ready shape (forward-compatible, no breaking change when #15 lands):

    { "github_stars": int|null, "installs": int|null, "score": float }

installs is null today; score is derived from whatever signals exist (just stars now, stars plus weighted installs later).

Graceful degradation: any GitHub failure (rate-limit 403/429, 404, network error, bad JSON) degrades that entry to github_stars=null and never raises. Negative results are cached so a known-bad repo is not retried on every request. Entries whose homepage is not a github.com/owner/repo URL get a popularity shape with github_stars=null; no stars are fabricated. 137 of 266 catalog manifests already carry a github.com homepage, so they get real star counts; the rest need a repo homepage added to their manifest to surface stars.

Frontend: the Store frontend already reads repo and stars off the catalog response (and tolerates their absence), so no frontend change was needed.

Tests: tests/test_store_popularity.py (unit, mocked httpx) and tests/routes/test_store_popularity_route.py (endpoint) assert a github homepage gets stars plus a score, a 404 and a rate-limit both yield null without raising, caching avoids a second call within the TTL, and a non-github homepage gets null without a call. All green; existing store route tests unaffected; create_app() ok.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Store catalog items now include GitHub star counts and popularity metrics
  * Added new `/api/store/popularity` endpoint to query popularity information by app ID with optional type filtering
  * Implemented background cache system that periodically refreshes GitHub star data for improved catalog performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->