### PR TITLE
feat(providers): DeepSeek provider

### DIFF
--- a/desktop/src/apps/ProvidersApp.tsx
+++ b/desktop/src/apps/ProvidersApp.tsx
@@ -18,7 +18,7 @@ import { useIsMobile } from "@/hooks/use-is-mobile";
 /* ------------------------------------------------------------------ */
 
 /** Fallback constants used before the API call completes. */
-const FALLBACK_CLOUD_TYPES = ["openai", "anthropic", "openrouter", "kilocode", "openai-compatible"] as const;
+const FALLBACK_CLOUD_TYPES = ["openai", "anthropic", "openrouter", "kilocode", "deepseek", "openai-compatible"] as const;
 const FALLBACK_LOCAL_TYPES = ["rkllama", "ollama", "llama-cpp", "vllm", "exo", "mlx", "sd-cpp"] as const;
 
 /** Active cloud types — seeded with fallback, updated from /api/providers/types.
@@ -34,6 +34,7 @@ const DEFAULT_URLS: Partial<Record<ProviderType, string>> = {
   anthropic: "https://api.anthropic.com/v1",
   openrouter: "https://openrouter.ai/api/v1",
   kilocode: "https://api.kilo.ai/api/gateway",
+  deepseek: "https://api.deepseek.com",
   ollama: "http://localhost:11434",
   rkllama: "http://localhost:8080",
   "llama-cpp": "http://localhost:8080",
@@ -71,6 +72,12 @@ const CLOUD_PROVIDER_META: Record<string, CloudProviderMeta> = {
     description: "500+ models, smart routing",
     url: "https://api.kilo.ai/api/gateway",
     keyPlaceholder: "kilo-...",
+  },
+  deepseek: {
+    label: "DeepSeek",
+    description: "DeepSeek V4 Pro, Flash, Reasoner",
+    url: "https://api.deepseek.com",
+    keyPlaceholder: "sk-...",
   },
   "openai-compatible": {
     label: "OpenAI-Compatible",

--- a/desktop/src/lib/models.ts
+++ b/desktop/src/lib/models.ts
@@ -121,7 +121,7 @@ export interface CloudProvider {
   source?: string;
 }
 
-export const CLOUD_PROVIDER_TYPES = ["openai", "anthropic", "openrouter", "kilocode", "openai-compatible"] as const;
+export const CLOUD_PROVIDER_TYPES = ["openai", "anthropic", "openrouter", "kilocode", "deepseek", "openai-compatible"] as const;
 
 /** Flatten /api/providers cloud providers into AggregatedModel entries. */
 export function cloudProvidersToAggregated(providers: CloudProvider[]): AggregatedModel[] {

--- a/tinyagentos/backend_adapters.py
+++ b/tinyagentos/backend_adapters.py
@@ -189,6 +189,7 @@ _ADAPTERS: dict[str, BackendAdapter] = {
     "anthropic": CloudAPIAdapter(),
     "openrouter": CloudAPIAdapter(),
     "kilocode": CloudAPIAdapter(),
+    "deepseek": CloudAPIAdapter(),
     "openai-compatible": CloudAPIAdapter(),
     "sd-cpp": StableDiffusionCppAdapter(),
     "iopaint": IOPaintAdapter(),

--- a/tinyagentos/providers/__init__.py
+++ b/tinyagentos/providers/__init__.py
@@ -30,6 +30,7 @@ ALL_TYPES: set[str] = {
     "anthropic",
     "openrouter",
     "kilocode",
+    "deepseek",
     "openai-compatible",
     # -- local image-generation backends --
     "sd-cpp",
@@ -43,6 +44,7 @@ CLOUD_TYPES: set[str] = {
     "anthropic",
     "openrouter",
     "kilocode",
+    "deepseek",
     "openai-compatible",
 }
 
@@ -69,6 +71,7 @@ BACKEND_TYPE_MAP: dict[str, str] = {
     "anthropic": "anthropic",
     "openrouter": "openrouter",
     "kilocode": "openai",  # kilocode is OpenAI-compatible; api_base set explicitly
+    "deepseek": "deepseek",  # native LiteLLM provider; api_base set to official base
     "openai-compatible": "openai",  # user-supplied OpenAI-compatible endpoint
 }
 

--- a/tinyagentos/routes/providers.py
+++ b/tinyagentos/routes/providers.py
@@ -26,6 +26,7 @@ PROVIDER_URL_DEFAULTS: dict[str, str] = {
     "openai": "https://api.openai.com/v1",
     "anthropic": "https://api.anthropic.com/v1",
     "openrouter": "https://openrouter.ai/api/v1",
+    "deepseek": "https://api.deepseek.com",
 }
 
 # Seed model list for cloud providers that don't expose an openly-listable
@@ -34,6 +35,17 @@ PROVIDER_URL_DEFAULTS: dict[str, str] = {
 # so we keep that as a safety net.
 PROVIDER_DEFAULT_MODELS: dict[str, list[dict]] = {
     "kilocode": [{"id": "kilo-auto/free"}],
+    # DeepSeek's /models endpoint needs an API key, so a fresh add without a
+    # working key won't auto-discover. Seed the current catalog so the entry
+    # registers routable models either way. deepseek-v4-pro / deepseek-v4-flash
+    # are the V4 generation ids; deepseek-chat / deepseek-reasoner are the
+    # compatibility aliases (deprecated 2026/07/24).
+    "deepseek": [
+        {"id": "deepseek-v4-pro"},
+        {"id": "deepseek-v4-flash"},
+        {"id": "deepseek-chat"},
+        {"id": "deepseek-reasoner"},
+    ],
 }
 
 


### PR DESCRIPTION
Adds DeepSeek as a first-class cloud model provider.

Base URL: the official https://api.deepseek.com (no /v1 suffix; DeepSeek serves the OpenAI-compatible API at the bare host). This is the official-DeepSeek path, not the ark/Volcengine gateway that Hermes happens to use locally.

Model ids seeded: deepseek-v4-pro and deepseek-v4-flash (the V4 generation), plus deepseek-chat and deepseek-reasoner (compatibility aliases, scheduled for deprecation 2026/07/24). DeepSeek's /models endpoint requires an API key, so a fresh add without a working key will not auto-discover; the seed list guarantees the provider registers routable models. With a valid key, live /models discovery replaces the seed as it does for every other cloud provider.

API key: no key is hardcoded. The provider references the user-supplied key the same way every other cloud provider does, through api_key_secret resolved to os.environ/<secret_name> in the LiteLLM config and injected from the taOS secrets store on reload. The conventional env var name is DEEPSEEK_API_KEY.

Registration: deepseek is a native LiteLLM provider, so it maps to the deepseek/ prefix in BACKEND_TYPE_MAP / CHAT_BACKEND_TYPE_MAP and LiteLLM emits deepseek/<model> entries with api_base set to the official base. Changes mirror the existing openrouter/kilocode entries exactly:

- tinyagentos/providers/__init__.py: deepseek added to ALL_TYPES, CLOUD_TYPES, and the two routing maps (prefix deepseek).
- tinyagentos/routes/providers.py: base URL default https://api.deepseek.com and a seed model list (mirrors the kilocode seed pattern).
- tinyagentos/backend_adapters.py: deepseek wired to CloudAPIAdapter (probes /models; 401 without a key reads as online).
- desktop/src/apps/ProvidersApp.tsx: DeepSeek added to FALLBACK_CLOUD_TYPES, DEFAULT_URLS, and CLOUD_PROVIDER_META so it appears in the Add Provider wizard.
- desktop/src/lib/models.ts: deepseek added to CLOUD_PROVIDER_TYPES so its models flatten into the picker.

Verification: create_app() imports clean; provider test suites (test_routes_providers, test_provider_refresh, test_provider_lifecycle_api) pass 39/39.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added DeepSeek as a supported cloud provider with automatic model discovery and pre-configured API defaults for seamless integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->