### PR TITLE
feat(notifications): wire the desktop bell to the backend notification feed

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -24,6 +24,7 @@ import { LoginScreen } from "@/components/LoginScreen";
 import { NotificationToasts } from "@/components/NotificationToast";
 import { NotificationCentre } from "@/components/NotificationCentre";
 import { useNotificationStore } from "@/stores/notification-store";
+import { useServerNotifications } from "@/hooks/use-server-notifications";
 import { TaosAssistantPanel } from "@/components/TaosAssistantPanel";
 import { useTaosAgentStore } from "@/stores/taos-agent-store";
 import { InstallPromptBanner } from "@/shell/InstallPromptBanner";
@@ -188,6 +189,10 @@ export function App() {
   }, [setActiveWindowId]);
 
   useSessionPersistence();
+
+  // Sync the persistent backend notification feed into the bell (desktop and
+  // mobile both render NotificationCentre under this component).
+  useServerNotifications();
 
   // Re-apply the persisted active theme on app boot so a reload keeps the
   // user's chosen theme app-wide (not only when Settings is opened).

--- a/desktop/src/components/NotificationCentre.tsx
+++ b/desktop/src/components/NotificationCentre.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { X, Bell, CheckCheck, Trash2 } from "lucide-react";
 import { useNotificationStore } from "@/stores/notification-store";
+import { markServerRead, markAllServerRead } from "@/lib/server-notifications";
 import { SetupChecklist } from "./SetupChecklist";
 
 function formatTime(ts: number): string {
@@ -14,6 +15,18 @@ function formatTime(ts: number): string {
 export function NotificationCentre() {
   const { notifications, centreOpen, closeCentre, markRead, markAllRead, clearAll, dismiss } = useNotificationStore();
   const [checklistDismissed, setChecklistDismissed] = useState(false);
+
+  // Optimistic local mark-read, plus a best-effort backend write for server
+  // items so the read state persists across reloads. Network never blocks the UI.
+  const handleMarkRead = (id: string) => {
+    markRead(id);
+    void markServerRead(id);
+  };
+
+  const handleMarkAllRead = () => {
+    markAllRead();
+    void markAllServerRead();
+  };
 
   if (!centreOpen) return null;
 
@@ -56,7 +69,7 @@ export function NotificationCentre() {
           <div className="flex items-center gap-1">
             {notifications.length > 0 && (
               <>
-                <button onClick={markAllRead} className="p-1.5 rounded hover:bg-white/5" title="Mark all read">
+                <button onClick={handleMarkAllRead} className="p-1.5 rounded hover:bg-white/5" title="Mark all read">
                   <CheckCheck size={14} className="text-shell-text-tertiary" />
                 </button>
                 <button onClick={clearAll} className="p-1.5 rounded hover:bg-white/5" title="Clear all">
@@ -84,7 +97,7 @@ export function NotificationCentre() {
             notifications.map((n) => (
               <button
                 key={n.id}
-                onClick={() => markRead(n.id)}
+                onClick={() => handleMarkRead(n.id)}
                 className={`w-full text-left px-4 py-3 border-b border-white/5 hover:bg-white/5 transition-colors ${!n.read ? "bg-accent/5" : ""}`}
               >
                 <div className="flex items-start justify-between gap-2">

--- a/desktop/src/hooks/use-server-notifications.ts
+++ b/desktop/src/hooks/use-server-notifications.ts
@@ -23,10 +23,32 @@ export function useServerNotifications() {
     };
 
     void sync();
-    const interval = setInterval(() => void sync(), POLL_MS);
+    // Only poll while the tab is visible; a backgrounded tab does not need to
+    // keep hitting the endpoint, and it resyncs the moment it returns.
+    let interval: ReturnType<typeof setInterval> | null = null;
+    const startPolling = () => {
+      if (interval === null) interval = setInterval(() => void sync(), POLL_MS);
+    };
+    const stopPolling = () => {
+      if (interval !== null) {
+        clearInterval(interval);
+        interval = null;
+      }
+    };
+    const onVisibility = () => {
+      if (document.hidden) {
+        stopPolling();
+      } else {
+        void sync();
+        startPolling();
+      }
+    };
+    if (!document.hidden) startPolling();
+    document.addEventListener("visibilitychange", onVisibility);
     return () => {
       cancelled = true;
-      clearInterval(interval);
+      stopPolling();
+      document.removeEventListener("visibilitychange", onVisibility);
     };
   }, []);
 

--- a/desktop/src/hooks/use-server-notifications.ts
+++ b/desktop/src/hooks/use-server-notifications.ts
@@ -1,0 +1,44 @@
+import { useEffect } from "react";
+import { useNotificationStore } from "@/stores/notification-store";
+import { fetchServerNotifications } from "@/lib/server-notifications";
+
+const POLL_MS = 30_000;
+
+/**
+ * Keep the notification store in sync with the backend feed: fetch + merge on
+ * mount, poll every 30s, and refresh immediately whenever the notification
+ * centre transitions to open. Mount once under the desktop shell.
+ */
+export function useServerNotifications() {
+  const centreOpen = useNotificationStore((s) => s.centreOpen);
+
+  // Mount: initial sync + polling loop.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    let cancelled = false;
+    const sync = async () => {
+      const items = await fetchServerNotifications();
+      if (!cancelled) useNotificationStore.getState().mergeServerNotifications(items);
+    };
+
+    void sync();
+    const interval = setInterval(() => void sync(), POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, []);
+
+  // Refresh on open so the bell shows the latest without waiting for the poll.
+  useEffect(() => {
+    if (typeof window === "undefined" || !centreOpen) return;
+    let cancelled = false;
+    void fetchServerNotifications().then((items) => {
+      if (!cancelled) useNotificationStore.getState().mergeServerNotifications(items);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [centreOpen]);
+}

--- a/desktop/src/lib/server-notifications.test.ts
+++ b/desktop/src/lib/server-notifications.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  fetchServerNotifications,
+  markServerRead,
+  markAllServerRead,
+} from "./server-notifications";
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe("server-notifications", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  describe("fetchServerNotifications", () => {
+    it("maps backend rows: seconds->ms, srv- prefix, message->body, source fallback", async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        headers: { get: () => "application/json" },
+        json: async () => [
+          { id: 7, timestamp: 1000, level: "warning", title: "Disk low", message: "90% full", read: false, source: "disk_quota" },
+          { id: 8, timestamp: 2000, level: "info", title: "Worker", message: "joined", read: true, source: "" },
+        ],
+      });
+
+      const items = await fetchServerNotifications();
+
+      expect(items).toHaveLength(2);
+      expect(items[0]).toMatchObject({
+        id: "srv-7",
+        source: "disk_quota",
+        title: "Disk low",
+        body: "90% full",
+        level: "warning",
+        read: false,
+        timestamp: 1_000_000,
+      });
+      // Empty source falls back to "system".
+      expect(items[1].id).toBe("srv-8");
+      expect(items[1].source).toBe("system");
+      expect(items[1].timestamp).toBe(2_000_000);
+    });
+
+    it("maps an unknown level to info", async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        headers: { get: () => "application/json" },
+        json: async () => [
+          { id: 1, timestamp: 5, level: "critical", title: "X", message: "y", read: false, source: "system" },
+        ],
+      });
+      const items = await fetchServerNotifications();
+      expect(items[0].level).toBe("info");
+    });
+
+    it("returns [] when the request fails (non-ok)", async () => {
+      fetchMock.mockResolvedValue({ ok: false, headers: { get: () => "application/json" }, json: async () => [] });
+      expect(await fetchServerNotifications()).toEqual([]);
+    });
+
+    it("returns [] when fetch rejects", async () => {
+      fetchMock.mockRejectedValue(new Error("network down"));
+      expect(await fetchServerNotifications()).toEqual([]);
+    });
+
+    it("returns [] when the body is not JSON", async () => {
+      fetchMock.mockResolvedValue({ ok: true, headers: { get: () => "text/html" }, json: async () => "<div/>" });
+      expect(await fetchServerNotifications()).toEqual([]);
+    });
+
+    it("returns [] when the JSON body is not an array", async () => {
+      fetchMock.mockResolvedValue({ ok: true, headers: { get: () => "application/json" }, json: async () => ({ oops: 1 }) });
+      expect(await fetchServerNotifications()).toEqual([]);
+    });
+
+    it("never sends an hx-request header (gets JSON back)", async () => {
+      fetchMock.mockResolvedValue({ ok: true, headers: { get: () => "application/json" }, json: async () => [] });
+      await fetchServerNotifications();
+      const [, init] = fetchMock.mock.calls[0];
+      const headers = (init?.headers ?? {}) as Record<string, string>;
+      expect(Object.keys(headers).map((k) => k.toLowerCase())).not.toContain("hx-request");
+    });
+  });
+
+  describe("markServerRead", () => {
+    it("POSTs the numeric id for srv- ids", async () => {
+      fetchMock.mockResolvedValue({ ok: true });
+      await markServerRead("srv-42");
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe("/api/notifications/42/read");
+      expect(init?.method).toBe("POST");
+    });
+
+    it("is a no-op for client (notif-) ids", async () => {
+      await markServerRead("notif-3");
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("swallows fetch failures", async () => {
+      fetchMock.mockRejectedValue(new Error("boom"));
+      await expect(markServerRead("srv-1")).resolves.toBeUndefined();
+    });
+  });
+
+  describe("markAllServerRead", () => {
+    it("POSTs read-all", async () => {
+      fetchMock.mockResolvedValue({ ok: true });
+      await markAllServerRead();
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe("/api/notifications/read-all");
+      expect(init?.method).toBe("POST");
+    });
+  });
+});

--- a/desktop/src/lib/server-notifications.ts
+++ b/desktop/src/lib/server-notifications.ts
@@ -1,0 +1,91 @@
+import type { Notification } from "@/stores/notification-store";
+import { withCsrf } from "./csrf";
+
+/**
+ * Bridge between the persistent backend NotificationStore
+ * (GET/POST /api/notifications) and the client-side notification store.
+ *
+ * The backend serves JSON when the request is NOT an htmx request, so we never
+ * send the `hx-request` header. Rows are mapped into the frontend Notification
+ * shape with an "srv-" id prefix so they never collide with client "notif-N"
+ * ids, and second-precision timestamps are converted to milliseconds.
+ */
+
+interface ServerNotificationRow {
+  id: number;
+  timestamp: number; // unix seconds
+  level: string;
+  title: string;
+  message: string;
+  read: boolean;
+  source: string;
+}
+
+const VALID_LEVELS: ReadonlySet<Notification["level"]> = new Set([
+  "info",
+  "success",
+  "warning",
+  "error",
+]);
+
+function mapRow(row: ServerNotificationRow): Notification {
+  const level = VALID_LEVELS.has(row.level as Notification["level"])
+    ? (row.level as Notification["level"])
+    : "info";
+  return {
+    id: `srv-${row.id}`,
+    source: row.source || "system",
+    title: row.title,
+    body: row.message,
+    level,
+    read: row.read,
+    timestamp: row.timestamp * 1000,
+  };
+}
+
+/**
+ * Fetch the backend notification feed as frontend Notifications. Any fetch or
+ * parse failure resolves to an empty array; this never throws to the caller.
+ */
+export async function fetchServerNotifications(): Promise<Notification[]> {
+  try {
+    const res = await fetch("/api/notifications", {
+      headers: { Accept: "application/json" },
+    });
+    if (!res.ok) return [];
+    const ct = res.headers.get("content-type") ?? "";
+    if (!ct.includes("application/json")) return [];
+    const data = await res.json();
+    if (!Array.isArray(data)) return [];
+    return (data as ServerNotificationRow[]).map(mapRow);
+  } catch {
+    return [];
+  }
+}
+
+/** Numeric backend id from a prefixed "srv-N" id, or null for other ids. */
+function serverId(id: string): number | null {
+  if (!id.startsWith("srv-")) return null;
+  const n = Number(id.slice(4));
+  return Number.isInteger(n) ? n : null;
+}
+
+/** Mark a single server-origin notification read on the backend. No-op for client ids. */
+export async function markServerRead(id: string): Promise<void> {
+  const n = serverId(id);
+  if (n == null) return;
+  try {
+    await fetch(`/api/notifications/${n}/read`, withCsrf({ method: "POST" }));
+  } catch {
+    // best-effort; the optimistic local update already happened
+  }
+}
+
+/** Mark all server-origin notifications read on the backend. */
+export async function markAllServerRead(): Promise<void> {
+  try {
+    await fetch("/api/notifications/read-all", withCsrf({ method: "POST" }));
+  } catch {
+    // best-effort; the optimistic local update already happened
+  }
+}

--- a/desktop/src/stores/notification-store.test.ts
+++ b/desktop/src/stores/notification-store.test.ts
@@ -66,6 +66,20 @@ describe("mergeServerNotifications", () => {
     expect(ids).toEqual(["srv-1"]);
   });
 
+  it("does not resurrect a dismissed server item on the next poll", () => {
+    const store = useNotificationStore.getState();
+    // Unique id: dismissedServerIds is module-scoped and persists across tests.
+    store.mergeServerNotifications([srv(901, 100)]);
+    expect(useNotificationStore.getState().notifications.map((n) => n.id)).toContain("srv-901");
+
+    store.dismiss("srv-901");
+    expect(useNotificationStore.getState().notifications.map((n) => n.id)).not.toContain("srv-901");
+
+    // Backend still reports it (no server-side dismiss); it must stay hidden.
+    store.mergeServerNotifications([srv(901, 100)]);
+    expect(useNotificationStore.getState().notifications.map((n) => n.id)).not.toContain("srv-901");
+  });
+
   it("caps the merged list at 100 items", () => {
     const store = useNotificationStore.getState();
     const many = Array.from({ length: 150 }, (_, i) => srv(i, i));

--- a/desktop/src/stores/notification-store.test.ts
+++ b/desktop/src/stores/notification-store.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useNotificationStore, type Notification } from "./notification-store";
+
+function srv(id: number, ts: number, read = false): Notification {
+  return {
+    id: `srv-${id}`,
+    source: "system",
+    title: `t${id}`,
+    body: `b${id}`,
+    level: "info",
+    read,
+    timestamp: ts,
+  };
+}
+
+beforeEach(() => {
+  useNotificationStore.setState({ notifications: [], centreOpen: false });
+});
+
+describe("mergeServerNotifications", () => {
+  it("upserts server items newest-first without duplicates across two polls", () => {
+    const store = useNotificationStore.getState();
+
+    store.mergeServerNotifications([srv(1, 100), srv(2, 200)]);
+    let ids = useNotificationStore.getState().notifications.map((n) => n.id);
+    expect(ids).toEqual(["srv-2", "srv-1"]);
+
+    // Second poll returns the same two plus a newer one. No dupes.
+    store.mergeServerNotifications([srv(1, 100), srv(2, 200), srv(3, 300)]);
+    ids = useNotificationStore.getState().notifications.map((n) => n.id);
+    expect(ids).toEqual(["srv-3", "srv-2", "srv-1"]);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("preserves a server item marked read locally even if the poll says unread", () => {
+    const store = useNotificationStore.getState();
+    store.mergeServerNotifications([srv(1, 100, false)]);
+
+    // User reads it locally (optimistic), backend write may not have landed.
+    store.markRead("srv-1");
+    expect(useNotificationStore.getState().notifications[0].read).toBe(true);
+
+    // Next poll still reports it unread; local read must survive.
+    store.mergeServerNotifications([srv(1, 100, false)]);
+    expect(useNotificationStore.getState().notifications[0].read).toBe(true);
+  });
+
+  it("keeps client-origin (notif-) items untouched", () => {
+    const store = useNotificationStore.getState();
+    const clientId = store.addNotification({ source: "system", title: "welcome", body: "hi", level: "info" });
+
+    store.mergeServerNotifications([srv(1, 50)]);
+
+    const ids = useNotificationStore.getState().notifications.map((n) => n.id);
+    expect(ids).toContain(clientId);
+    expect(ids).toContain("srv-1");
+  });
+
+  it("replaces stale server items with the fresh list (removed ones drop out)", () => {
+    const store = useNotificationStore.getState();
+    store.mergeServerNotifications([srv(1, 100), srv(2, 200)]);
+
+    // A later poll no longer includes srv-2.
+    store.mergeServerNotifications([srv(1, 100)]);
+    const ids = useNotificationStore.getState().notifications.map((n) => n.id);
+    expect(ids).toEqual(["srv-1"]);
+  });
+
+  it("caps the merged list at 100 items", () => {
+    const store = useNotificationStore.getState();
+    const many = Array.from({ length: 150 }, (_, i) => srv(i, i));
+    store.mergeServerNotifications(many);
+    expect(useNotificationStore.getState().notifications).toHaveLength(100);
+  });
+});

--- a/desktop/src/stores/notification-store.ts
+++ b/desktop/src/stores/notification-store.ts
@@ -31,6 +31,12 @@ interface NotificationStore {
 
 let counter = 0;
 
+// Server items dismissed this session. The backend has no "dismiss" concept
+// (only read), so without this a dismissed server notification would be
+// re-added by the very next poll. Session-scoped: a hard reload re-shows
+// items that are still unread on the server, which is the intended behaviour.
+const dismissedServerIds = new Set<string>();
+
 export const useNotificationStore = create<NotificationStore>((set, get) => ({
   notifications: [],
   centreOpen: false,
@@ -55,9 +61,9 @@ export const useNotificationStore = create<NotificationStore>((set, get) => ({
       for (const n of s.notifications) {
         if (n.id.startsWith("srv-") && n.read) priorRead.set(n.id, true);
       }
-      const merged = items.map((n) =>
-        priorRead.get(n.id) ? { ...n, read: true } : n,
-      );
+      const merged = items
+        .filter((n) => !dismissedServerIds.has(n.id))
+        .map((n) => (priorRead.get(n.id) ? { ...n, read: true } : n));
       // Keep every client-origin item ("notif-N") untouched, drop the old
       // server items (replaced by the fresh list), de-dupe, sort newest-first.
       const client = s.notifications.filter((n) => !n.id.startsWith("srv-"));
@@ -78,11 +84,17 @@ export const useNotificationStore = create<NotificationStore>((set, get) => ({
   },
 
   dismiss(id) {
+    if (id.startsWith("srv-")) dismissedServerIds.add(id);
     set((s) => ({ notifications: s.notifications.filter((n) => n.id !== id) }));
   },
 
   clearAll() {
-    set({ notifications: [] });
+    set((s) => {
+      for (const n of s.notifications) {
+        if (n.id.startsWith("srv-")) dismissedServerIds.add(n.id);
+      }
+      return { notifications: [] };
+    });
   },
 
   toggleCentre() {

--- a/desktop/src/stores/notification-store.ts
+++ b/desktop/src/stores/notification-store.ts
@@ -19,6 +19,7 @@ interface NotificationStore {
   centreOpen: boolean;
 
   addNotification: (n: Omit<Notification, "id" | "read" | "timestamp">) => string;
+  mergeServerNotifications: (items: Notification[]) => void;
   markRead: (id: string) => void;
   markAllRead: () => void;
   dismiss: (id: string) => void;
@@ -44,6 +45,26 @@ export const useNotificationStore = create<NotificationStore>((set, get) => ({
     };
     set((s) => ({ notifications: [notif, ...s.notifications].slice(0, 100) }));
     return id;
+  },
+
+  mergeServerNotifications(items) {
+    set((s) => {
+      // Read state already applied locally for a server item must survive a
+      // poll, so the fresh row is OR-ed with the prior local read flag.
+      const priorRead = new Map<string, boolean>();
+      for (const n of s.notifications) {
+        if (n.id.startsWith("srv-") && n.read) priorRead.set(n.id, true);
+      }
+      const merged = items.map((n) =>
+        priorRead.get(n.id) ? { ...n, read: true } : n,
+      );
+      // Keep every client-origin item ("notif-N") untouched, drop the old
+      // server items (replaced by the fresh list), de-dupe, sort newest-first.
+      const client = s.notifications.filter((n) => !n.id.startsWith("srv-"));
+      const combined = [...merged, ...client];
+      combined.sort((a, b) => b.timestamp - a.timestamp);
+      return { notifications: combined.slice(0, 100) };
+    });
   },
 
   markRead(id) {


### PR DESCRIPTION
Closes the gap Jay flagged ("I see the bell but I never get any").

## Problem
Two disconnected notification systems. The backend NotificationStore (persistent SQLite) is fed by real events (worker join/leave, backend up/down, training, app install/fail, disk quota) and served at /api/notifications, but the React desktop bell read a client-only store that almost nothing populated, and never fetched the backend. So the bell stayed empty.

## Change (plumbing, no redesign)
- New lib/server-notifications.ts: fetch /api/notifications (JSON), map backend rows (seconds to ms, srv- id prefix, message to body, level whitelist) to the frontend Notification shape; mark-read / mark-all-read POST to the backend. Returns [] on any failure.
- notification-store.ts: mergeServerNotifications upserts server items (preserves locally-read, keeps client items, de-dupes, caps 100).
- use-server-notifications hook: fetch+merge on mount, 30s poll, immediate refresh on centre open.
- Wired into App.tsx; NotificationCentre mark-read/all now sync to the backend optimistically.
- 16 new unit tests (mapping, failure paths, merge semantics).

## Verify
tsc --noEmit clean, npm run build succeeds, 16/16 tests pass. Live Pi verification (trigger a worker/disk/deploy event and confirm it lands in the bell) to follow on deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Server notifications are now synchronized and displayed in the notification center.
* Mark individual notifications or all notifications as read; updates sync to the server.
* Notification center automatically refreshes every 30 seconds and when opened.
* Existing client-generated notifications work alongside server notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->