### PR TITLE
feat(notifications): click a notification to open the relevant app/section

### DIFF
--- a/desktop/src/apps/SettingsApp.tsx
+++ b/desktop/src/apps/SettingsApp.tsx
@@ -722,8 +722,14 @@ function DesktopDockSection() {
 /*  Main SettingsApp                                                   */
 /* ------------------------------------------------------------------ */
 
-export function SettingsApp({ windowId: _windowId }: { windowId: string }) {
-  const [section, setSection] = useState<Section>("system");
+function isSection(value: string | undefined): value is Section {
+  return value != null && SECTIONS.some((s) => s.id === value);
+}
+
+export function SettingsApp({ windowId: _windowId, section: initialSection }: { windowId: string; section?: string }) {
+  const [section, setSection] = useState<Section>(() =>
+    isSection(initialSection) ? initialSection : "system"
+  );
   const [mobileShowSection, setMobileShowSection] = useState(false);
 
   const isMobile = typeof window !== "undefined" && window.innerWidth < 640;

--- a/desktop/src/components/NotificationCentre.test.tsx
+++ b/desktop/src/components/NotificationCentre.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NotificationCentre } from "./NotificationCentre";
+import type { Notification } from "@/stores/notification-store";
+
+const openWindow = vi.fn();
+const markRead = vi.fn();
+const closeCentre = vi.fn();
+const markAllRead = vi.fn();
+const clearAll = vi.fn();
+const dismiss = vi.fn();
+
+let notifications: Notification[] = [];
+
+vi.mock("@/stores/notification-store", () => ({
+  useNotificationStore: () => ({
+    notifications,
+    centreOpen: true,
+    closeCentre,
+    markRead,
+    markAllRead,
+    clearAll,
+    dismiss,
+  }),
+}));
+
+vi.mock("@/stores/process-store", () => ({
+  useProcessStore: (sel: (s: { openWindow: typeof openWindow }) => unknown) =>
+    sel({ openWindow }),
+}));
+
+vi.mock("@/lib/server-notifications", () => ({
+  markServerRead: vi.fn(),
+  markAllServerRead: vi.fn(),
+}));
+
+vi.mock("./SetupChecklist", () => ({ SetupChecklist: () => null }));
+
+function notif(over: Partial<Notification>): Notification {
+  return {
+    id: "srv-1",
+    source: "system",
+    title: "Title",
+    body: "Body",
+    level: "info",
+    read: false,
+    timestamp: Date.now(),
+    ...over,
+  };
+}
+
+describe("NotificationCentre click routing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    notifications = [];
+  });
+
+  it("opens the target app with meta props, marks read, and closes on an action click", () => {
+    notifications = [
+      notif({ id: "srv-9", title: "Disk low", action: "settings", meta: { section: "storage" } }),
+    ];
+    render(<NotificationCentre />);
+
+    fireEvent.click(screen.getByText("Disk low"));
+
+    expect(openWindow).toHaveBeenCalledTimes(1);
+    const [appId, , props] = openWindow.mock.calls[0];
+    expect(appId).toBe("settings");
+    expect(props).toEqual({ section: "storage" });
+    expect(markRead).toHaveBeenCalledWith("srv-9");
+    expect(closeCentre).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes undefined props when the action has no meta", () => {
+    notifications = [notif({ id: "srv-5", title: "Worker joined", action: "cluster" })];
+    render(<NotificationCentre />);
+
+    fireEvent.click(screen.getByText("Worker joined"));
+
+    const [appId, , props] = openWindow.mock.calls[0];
+    expect(appId).toBe("cluster");
+    expect(props).toBeUndefined();
+    expect(closeCentre).toHaveBeenCalledTimes(1);
+  });
+
+  it("only marks read (no navigation) for action-less notifications", () => {
+    notifications = [notif({ id: "srv-2", title: "Plain note" })];
+    render(<NotificationCentre />);
+
+    fireEvent.click(screen.getByText("Plain note"));
+
+    expect(openWindow).not.toHaveBeenCalled();
+    expect(closeCentre).not.toHaveBeenCalled();
+    expect(markRead).toHaveBeenCalledWith("srv-2");
+  });
+});

--- a/desktop/src/components/NotificationCentre.tsx
+++ b/desktop/src/components/NotificationCentre.tsx
@@ -1,8 +1,12 @@
 import { useState } from "react";
 import { X, Bell, CheckCheck, Trash2 } from "lucide-react";
-import { useNotificationStore } from "@/stores/notification-store";
+import { useNotificationStore, type Notification } from "@/stores/notification-store";
+import { useProcessStore } from "@/stores/process-store";
+import { getApp } from "@/registry/app-registry";
 import { markServerRead, markAllServerRead } from "@/lib/server-notifications";
 import { SetupChecklist } from "./SetupChecklist";
+
+const FALLBACK_SIZE = { w: 900, h: 640 };
 
 function formatTime(ts: number): string {
   const delta = Date.now() - ts;
@@ -14,6 +18,7 @@ function formatTime(ts: number): string {
 
 export function NotificationCentre() {
   const { notifications, centreOpen, closeCentre, markRead, markAllRead, clearAll, dismiss } = useNotificationStore();
+  const openWindow = useProcessStore((s) => s.openWindow);
   const [checklistDismissed, setChecklistDismissed] = useState(false);
 
   // Optimistic local mark-read, plus a best-effort backend write for server
@@ -21,6 +26,21 @@ export function NotificationCentre() {
   const handleMarkRead = (id: string) => {
     markRead(id);
     void markServerRead(id);
+  };
+
+  // Clicking an actionable notification opens its target app (with any meta as
+  // launch props), marks it read, and closes the centre. Action-less items just
+  // get marked read in place.
+  const handleItemClick = (n: Notification) => {
+    if (n.action) {
+      const size = getApp(n.action)?.defaultSize ?? FALLBACK_SIZE;
+      const props = n.meta && Object.keys(n.meta).length ? n.meta : undefined;
+      openWindow(n.action, size, props);
+      handleMarkRead(n.id);
+      closeCentre();
+      return;
+    }
+    handleMarkRead(n.id);
   };
 
   const handleMarkAllRead = () => {
@@ -97,8 +117,8 @@ export function NotificationCentre() {
             notifications.map((n) => (
               <button
                 key={n.id}
-                onClick={() => handleMarkRead(n.id)}
-                className={`w-full text-left px-4 py-3 border-b border-white/5 hover:bg-white/5 transition-colors ${!n.read ? "bg-accent/5" : ""}`}
+                onClick={() => handleItemClick(n)}
+                className={`w-full text-left px-4 py-3 border-b border-white/5 hover:bg-white/5 transition-colors ${!n.read ? "bg-accent/5" : ""} ${n.action ? "cursor-pointer" : ""}`}
               >
                 <div className="flex items-start justify-between gap-2">
                   <div className="min-w-0 flex-1">

--- a/desktop/src/lib/server-notifications.test.ts
+++ b/desktop/src/lib/server-notifications.test.ts
@@ -3,6 +3,7 @@ import {
   fetchServerNotifications,
   markServerRead,
   markAllServerRead,
+  sourceToTarget,
 } from "./server-notifications";
 
 const originalFetch = global.fetch;
@@ -87,6 +88,58 @@ describe("server-notifications", () => {
       const [, init] = fetchMock.mock.calls[0];
       const headers = (init?.headers ?? {}) as Record<string, string>;
       expect(Object.keys(headers).map((k) => k.toLowerCase())).not.toContain("hx-request");
+    });
+  });
+
+  describe("sourceToTarget", () => {
+    it("routes update/lifecycle to the Settings updates section", () => {
+      expect(sourceToTarget("system.update")).toEqual({ action: "settings", meta: { section: "updates" } });
+      expect(sourceToTarget("system.lifecycle")).toEqual({ action: "settings", meta: { section: "updates" } });
+    });
+
+    it("routes disk_quota to the Settings storage section", () => {
+      expect(sourceToTarget("disk_quota")).toEqual({ action: "settings", meta: { section: "storage" } });
+    });
+
+    it("routes worker/backend events to the Cluster app with no meta", () => {
+      for (const src of ["worker.join", "worker.online", "worker.leave", "backend.up", "backend.down"]) {
+        expect(sourceToTarget(src)).toEqual({ action: "cluster" });
+      }
+    });
+
+    it("routes training events to the Agents app", () => {
+      expect(sourceToTarget("training.complete")).toEqual({ action: "agents" });
+      expect(sourceToTarget("training.failed")).toEqual({ action: "agents" });
+    });
+
+    it("routes app events to the Store app", () => {
+      expect(sourceToTarget("app.installed")).toEqual({ action: "store" });
+      expect(sourceToTarget("app.failed")).toEqual({ action: "store" });
+    });
+
+    it("returns no action for unknown sources", () => {
+      expect(sourceToTarget("something.else")).toEqual({});
+      expect(sourceToTarget("")).toEqual({});
+    });
+  });
+
+  describe("mapRow action/meta wiring", () => {
+    it("sets action and meta from the source mapping", async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        headers: { get: () => "application/json" },
+        json: async () => [
+          { id: 1, timestamp: 1, level: "warning", title: "Disk", message: "full", read: false, source: "disk_quota" },
+          { id: 2, timestamp: 2, level: "info", title: "Worker", message: "joined", read: false, source: "worker.join" },
+          { id: 3, timestamp: 3, level: "info", title: "Other", message: "x", read: false, source: "mystery" },
+        ],
+      });
+      const items = await fetchServerNotifications();
+      expect(items[0]).toMatchObject({ action: "settings", meta: { section: "storage" } });
+      expect(items[1].action).toBe("cluster");
+      expect(items[1].meta).toBeUndefined();
+      expect(items[2].action).toBeUndefined();
+      expect(items[2].meta).toBeUndefined();
     });
   });
 

--- a/desktop/src/lib/server-notifications.ts
+++ b/desktop/src/lib/server-notifications.ts
@@ -28,10 +28,43 @@ const VALID_LEVELS: ReadonlySet<Notification["level"]> = new Set([
   "error",
 ]);
 
+/**
+ * Map a backend event `source` to the app a click on the notification should
+ * open. Sources that have no relevant destination return an empty object, which
+ * leaves the notification non-navigable. `action` is an app id understood by the
+ * process store; `meta` carries an optional launch prop (e.g. a Settings section).
+ */
+export function sourceToTarget(
+  source: string,
+): { action?: string; meta?: Record<string, string> } {
+  switch (source) {
+    case "system.update":
+    case "system.lifecycle":
+      return { action: "settings", meta: { section: "updates" } };
+    case "disk_quota":
+      return { action: "settings", meta: { section: "storage" } };
+    case "worker.join":
+    case "worker.online":
+    case "worker.leave":
+    case "backend.up":
+    case "backend.down":
+      return { action: "cluster" };
+    case "training.complete":
+    case "training.failed":
+      return { action: "agents" };
+    case "app.installed":
+    case "app.failed":
+      return { action: "store" };
+    default:
+      return {};
+  }
+}
+
 function mapRow(row: ServerNotificationRow): Notification {
   const level = VALID_LEVELS.has(row.level as Notification["level"])
     ? (row.level as Notification["level"])
     : "info";
+  const { action, meta } = sourceToTarget(row.source);
   return {
     id: `srv-${row.id}`,
     source: row.source || "system",
@@ -40,6 +73,8 @@ function mapRow(row: ServerNotificationRow): Notification {
     level,
     read: row.read,
     timestamp: row.timestamp * 1000,
+    ...(action ? { action } : {}),
+    ...(meta ? { meta } : {}),
   };
 }
 


### PR DESCRIPTION
Follow-up to #939 (Jay request). Clicking a notification now routes to where it belongs.

## Mapping (backend source -> target)
- system.update / system.lifecycle -> Settings > Updates
- disk_quota -> Settings > Storage
- worker.join/online/leave, backend.up/down -> Cluster
- training.complete/failed -> Agents
- app.installed/failed -> Store
- anything else -> no navigation (just mark read)

## How
- server-notifications.ts: sourceToTarget() sets action + meta on each mapped Notification (existing mapping untouched).
- NotificationCentre.tsx: action items open via openWindow(appId, registry defaultSize, meta-as-props), then mark read + close; action-less items keep mark-read-in-place; actionable items show cursor-pointer.
- SettingsApp.tsx: honors an optional 'section' launch prop (mirrors the FilesApp rootPath prop mechanism), validated against section ids, falling back to default.

## Verify
tsc clean, build succeeds, 21 tests pass (sourceToTarget per-source + NotificationCentre click opens correct app with props + closes). Live Pi check (click the real Update/Worker notifications) after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notifications are now interactive—clicking them opens the relevant app section
  * Notifications automatically route to appropriate destinations based on type (Settings for system updates, cluster view for infrastructure issues, agents for training events)
  * Settings can open directly to a specific section

* **Tests**
  * Added coverage for notification interaction and routing behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->