### PR TITLE
feat(projects): redesign to the Store/Images bar + new Workspace split-pane (phase 1)

### DIFF
--- a/desktop/src/apps/ProjectsApp/ProjectList.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectList.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import type { Project } from "@/lib/projects";
 import { CreateProjectDialog } from "./CreateProjectDialog";
+import styles from "./ProjectsApp.module.css";
 
 type Props = {
   projects: Project[];
@@ -9,30 +10,42 @@ type Props = {
   onCreated: () => void;
 };
 
+function mark(name: string): string {
+  const words = name.trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return "?";
+  if (words.length === 1) return words[0]!.slice(0, 2).toUpperCase();
+  return (words[0]![0]! + words[1]![0]!).toUpperCase();
+}
+
 export function ProjectList({ projects, selectedId, onSelect, onCreated }: Props) {
   const [dialogOpen, setDialogOpen] = useState(false);
   return (
-    <>
-      <header className="p-3 border-b border-zinc-800 flex items-center justify-between">
-        <h2 className="font-medium">Projects</h2>
+    <aside className={styles.sidebar}>
+      <header className={styles.sbHead}>
+        <h2>Projects</h2>
         <button
           type="button"
           aria-label="Create project"
-          className="text-sm px-2 py-1 rounded bg-zinc-800 hover:bg-zinc-700"
+          className={styles.newBtn}
           onClick={() => setDialogOpen(true)}
         >
-          + New
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2">
+            <path d="M12 5v14M5 12h14" />
+          </svg>
+          New
         </button>
       </header>
-      <ul className="flex-1 overflow-auto" aria-label="Projects">
+      <ul className={styles.sbList} aria-label="Projects">
         {projects.length === 0 ? (
-          <li className="flex flex-col items-center justify-center h-full px-4 py-12 text-center gap-3">
-            <p className="text-sm font-medium text-zinc-300">No projects yet</p>
-            <p className="text-xs text-zinc-500">Organise your work and agent conversations into projects.</p>
+          <li className={styles.sbEmpty}>
+            <p className={styles.sbEmptyTitle}>No projects yet</p>
+            <p className={styles.sbEmptySub}>
+              Organise your work and agent conversations into projects.
+            </p>
             <button
               type="button"
               onClick={() => setDialogOpen(true)}
-              className="mt-1 text-sm px-3 py-1.5 rounded bg-zinc-700 hover:bg-zinc-600 text-zinc-100"
+              className={styles.newBtn}
             >
               Create your first project
             </button>
@@ -44,12 +57,13 @@ export function ProjectList({ projects, selectedId, onSelect, onCreated }: Props
                 type="button"
                 aria-pressed={p.id === selectedId}
                 onClick={() => onSelect(p.id)}
-                className={`w-full text-left px-3 py-2 hover:bg-zinc-800 ${
-                  p.id === selectedId ? "bg-zinc-800" : ""
-                }`}
+                className={`${styles.pj} ${p.id === selectedId ? styles.pjOn : ""}`}
               >
-                <div className="font-medium">{p.name}</div>
-                <div className="text-xs text-zinc-500">{p.slug}</div>
+                <span className={styles.pjMark} aria-hidden>{mark(p.name)}</span>
+                <span className={styles.pjBody}>
+                  <span className={styles.pjName}>{p.name}</span>
+                  <span className={styles.pjMeta}>{p.slug}</span>
+                </span>
               </button>
             </li>
           ))
@@ -64,6 +78,6 @@ export function ProjectList({ projects, selectedId, onSelect, onCreated }: Props
           }}
         />
       )}
-    </>
+    </aside>
   );
 }

--- a/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react";
-import { projectsApi, type Project } from "@/lib/projects";
+import { useEffect, useMemo, useState } from "react";
+import { projectsApi, type Project, type ProjectMember } from "@/lib/projects";
 import { ProjectTaskList } from "./ProjectTaskList";
 import { ProjectMembers } from "./ProjectMembers";
 import { ProjectActivity } from "./ProjectActivity";
@@ -8,13 +8,22 @@ import { TaskModal } from "./board/TaskModal";
 import { FilesApp } from "@/apps/FilesApp";
 import { MessagesApp } from "@/apps/MessagesApp";
 import { CanvasView } from "./canvas/CanvasView";
+import { ProjectWorkspacePane } from "./ProjectWorkspacePane";
+import { derivePresence } from "./presence";
 import { useIsMobile } from "../../hooks/use-is-mobile";
 import { WorkspaceTabPills } from "../../components/mobile/WorkspaceTabPills";
 import { ProjectFab } from "./mobile/ProjectFab";
 import { TaskCreateSheet } from "./mobile/TaskCreateSheet";
+import styles from "./ProjectsApp.module.css";
 
-type Tab = "board" | "canvas" | "tasks" | "files" | "messages" | "members" | "activity";
-const TABS: Tab[] = ["board", "canvas", "tasks", "files", "messages", "members", "activity"];
+type Tab = "workspace" | "board" | "canvas" | "tasks" | "files" | "messages" | "members" | "activity";
+const TABS: Tab[] = ["workspace", "board", "canvas", "tasks", "files", "messages", "members", "activity"];
+
+interface AgentSummary {
+  id: string;
+  name: string;
+  display_name?: string;
+}
 
 function readTaskParam(): string | null {
   if (typeof window === "undefined") return null;
@@ -31,11 +40,13 @@ function setTaskParam(taskId: string | null) {
 
 export function ProjectWorkspace({ project, onChanged }: { project: Project; onChanged: () => void }) {
   const isMobile = useIsMobile();
-  const [tab, setTab] = useState<Tab>("tasks");
+  const [tab, setTab] = useState<Tab>("workspace");
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
   const [authResolved, setAuthResolved] = useState(false);
   const [openTaskId, setOpenTaskId] = useState<string | null>(() => readTaskParam());
   const [createSheetOpen, setCreateSheetOpen] = useState(false);
+  const [members, setMembers] = useState<ProjectMember[]>([]);
+  const [agents, setAgents] = useState<AgentSummary[]>([]);
 
   const handleCreateTask = async ({ title }: { title: string }) => {
     await projectsApi.tasks.create(project.id, { title });
@@ -58,61 +69,114 @@ export function ProjectWorkspace({ project, onChanged }: { project: Project; onC
     return () => { cancelled = true; };
   }, []);
 
+  // Members + agent roster drive the header presence row (static-but-real:
+  // derived from the existing member data, not live multiplayer presence).
+  useEffect(() => {
+    let cancelled = false;
+    projectsApi.members
+      .list(project.id)
+      .then((rows) => { if (!cancelled) setMembers(Array.isArray(rows) ? rows : []); })
+      .catch(() => { if (!cancelled) setMembers([]); });
+    return () => { cancelled = true; };
+  }, [project.id]);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/agents")
+      .then((r) => (r.ok ? r.json() : []))
+      .then((rows) => { if (!cancelled && Array.isArray(rows)) setAgents(rows); })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, []);
+
   useEffect(() => {
     const onPop = () => setOpenTaskId(readTaskParam());
     window.addEventListener("popstate", onPop);
     return () => window.removeEventListener("popstate", onPop);
   }, []);
 
+  const agentName = useMemo(() => {
+    const byId = new Map<string, AgentSummary>();
+    for (const a of agents) byId.set(a.id, a);
+    return (id: string) => {
+      const a = byId.get(id);
+      return a ? a.display_name || a.name : id;
+    };
+  }, [agents]);
+
+  const presence = useMemo(
+    () => derivePresence({ ownerInitial: "Y", members, agentName }),
+    [members, agentName],
+  );
+
   const openTask = (id: string) => { setTaskParam(id); setOpenTaskId(id); };
   const closeTask = () => { setTaskParam(null); setOpenTaskId(null); };
 
   return (
-    <div className="flex flex-col h-full">
-      <header className="flex flex-col gap-3 px-4 py-3 border-b border-zinc-800 md:flex-row md:items-center md:justify-between md:px-6 md:py-4">
-        <div className="min-w-0">
-          <h1 className="truncate text-lg font-semibold md:text-xl" title={project.name}>{project.name}</h1>
-          {project.description && (
-            <p className="mt-1 line-clamp-2 text-xs text-zinc-500 md:line-clamp-none" title={project.description}>{project.description}</p>
+    <div className="flex flex-col h-full min-h-0">
+      <header className={styles.header}>
+        <div className={styles.titleRow}>
+          <h1 title={project.name}>{project.name}</h1>
+          {!isMobile && presence.length > 0 && (
+            <div className={styles.presence}>
+              <div className={styles.stack}>
+                {presence.map((f) => (
+                  <span
+                    key={f.id}
+                    className={`${styles.av} ${f.kind === "agent" ? styles.avAgent : styles.avHuman}`}
+                    title={f.title}
+                  >
+                    {f.initial}
+                    <span className={styles.avRing} aria-hidden />
+                  </span>
+                ))}
+              </div>
+              <span className={styles.presenceLbl}>
+                {presence.length} {presence.length === 1 ? "here" : "here now"}
+              </span>
+            </div>
           )}
         </div>
+        {project.description && (
+          <p className={styles.desc} title={project.description}>{project.description}</p>
+        )}
+        {isMobile ? (
+          <WorkspaceTabPills
+            tabs={tabPills}
+            active={tab}
+            onSelect={(id) => setTab(id as Tab)}
+          />
+        ) : (
+          <nav className={styles.tabs} role="tablist">
+            {TABS.map((t) => (
+              <button
+                key={t}
+                type="button"
+                role="tab"
+                id={`workspace-tab-${t}`}
+                aria-selected={tab === t}
+                aria-controls={`workspace-tabpanel-${t}`}
+                onClick={() => setTab(t)}
+                className={`${styles.tab} ${tab === t ? styles.tabOn : ""}`}
+              >
+                {t}
+              </button>
+            ))}
+          </nav>
+        )}
       </header>
-      {isMobile ? (
-        <WorkspaceTabPills
-          tabs={tabPills}
-          active={tab}
-          onSelect={(id) => setTab(id as Tab)}
-        />
-      ) : (
-        <nav className="flex border-b border-zinc-800 px-2" role="tablist">
-          {TABS.map((t) => (
-            <button
-              key={t}
-              type="button"
-              role="tab"
-              id={`workspace-tab-${t}`}
-              aria-selected={tab === t}
-              aria-controls={`workspace-tabpanel-${t}`}
-              onClick={() => setTab(t)}
-              className={`px-3 py-2 text-sm capitalize ${
-                tab === t ? "border-b-2 border-blue-400" : "text-zinc-400"
-              }`}
-            >
-              {t}
-            </button>
-          ))}
-        </nav>
-      )}
+
       <div
-        className="flex-1 min-h-0 overflow-auto p-4"
+        className={tab === "workspace" ? styles.panel : styles.panelPad}
         role="tabpanel"
         id={`workspace-tabpanel-${tab}`}
         aria-labelledby={`workspace-tab-${tab}`}
       >
+        {tab === "workspace" && <ProjectWorkspacePane project={project} />}
         {tab === "board" && (
           <>
             {!authResolved ? (
-              <div className="text-sm text-zinc-500">Loading board…</div>
+              <div className="text-sm text-shell-text-secondary">Loading board…</div>
             ) : currentUserId ? (
               <ProjectBoard
                 projectId={project.id}
@@ -120,7 +184,7 @@ export function ProjectWorkspace({ project, onChanged }: { project: Project; onC
                 onOpenTask={openTask}
               />
             ) : (
-              <div className="text-sm text-zinc-500">Sign in required to view the board.</div>
+              <div className="text-sm text-shell-text-secondary">Sign in required to view the board.</div>
             )}
             {currentUserId && (
               <TaskModal
@@ -151,6 +215,7 @@ export function ProjectWorkspace({ project, onChanged }: { project: Project; onC
         {tab === "members" && <ProjectMembers project={project} onChanged={onChanged} />}
         {tab === "activity" && <ProjectActivity projectId={project.id} />}
       </div>
+
       {isMobile && (tab === "tasks" || tab === "board") && (
         <>
           <ProjectFab onClick={() => setCreateSheetOpen(true)} />

--- a/desktop/src/apps/ProjectsApp/ProjectWorkspacePane.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectWorkspacePane.tsx
@@ -1,0 +1,129 @@
+import { useState } from "react";
+import type { Project } from "@/lib/projects";
+import { MessagesApp } from "@/apps/MessagesApp";
+import { CanvasView } from "./canvas/CanvasView";
+import styles from "./ProjectsApp.module.css";
+
+type PreviewMode = "preview" | "code" | "canvas";
+
+/**
+ * The Workspace tab (task #59 hero): a split pane.
+ *
+ *   LEFT:  the project channel thread + composer. Reuses the existing
+ *          project-scoped MessagesApp (humans + agents, send logic, A2A bus),
+ *          so this is real data, not a mock.
+ *   RIGHT: a live-preview pane with a Preview | Code | Canvas segmented
+ *          toggle and a small toolbar.
+ *
+ * Phase 1 scope: the Canvas toggle embeds the real project canvas. Preview and
+ * Code render honest placeholders rather than faking a running app build. A
+ * true streamed live build preview is #59 phase 2/3 (see TODO below).
+ */
+export function ProjectWorkspacePane({ project }: { project: Project }) {
+  const [mode, setMode] = useState<PreviewMode>("preview");
+
+  return (
+    <div className={styles.ws}>
+      {/* LEFT: real project channel thread + composer */}
+      <div className={styles.wsLeft}>
+        <div className={styles.wsThread}>
+          <MessagesApp
+            key={project.id}
+            windowId={`project-workspace-messages-${project.id}`}
+            scope={{ projectId: project.id }}
+          />
+        </div>
+      </div>
+
+      {/* resize affordance (fixed sensible ratio in phase 1) */}
+      <div className={styles.wsDivider} aria-hidden />
+
+      {/* RIGHT: preview / code / canvas */}
+      <div className={styles.wsRight} style={{ width: 472 }}>
+        <div className={styles.pvBar}>
+          <div className={styles.seg} role="tablist" aria-label="Preview mode">
+            {(["preview", "code", "canvas"] as PreviewMode[]).map((m) => (
+              <button
+                key={m}
+                type="button"
+                role="tab"
+                aria-selected={mode === m}
+                className={mode === m ? styles.segOn : ""}
+                onClick={() => setMode(m)}
+              >
+                {m.charAt(0).toUpperCase() + m.slice(1)}
+              </button>
+            ))}
+          </div>
+          <div className={styles.pvLive} aria-hidden>
+            <span className={styles.pvPulse}><i /></span>
+            Live
+          </div>
+          <div className={styles.pvTools}>
+            {/* These toolbar actions are intentionally inert in phase 1: refresh,
+                device-size and open-in-window all hang off a real streamed build
+                preview, which is deferred. They are shown so the chrome matches
+                the approved mock without faking behavior. */}
+            <button type="button" className={styles.pvTool} title="Refresh preview" disabled aria-label="Refresh preview">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+                <path d="M3 12a9 9 0 0 1 15-6.7L21 8" /><path d="M21 3v5h-5" />
+                <path d="M21 12a9 9 0 0 1-15 6.7L3 16" /><path d="M3 21v-5h5" />
+              </svg>
+            </button>
+            <button type="button" className={styles.pvTool} title="Device size" disabled aria-label="Device size">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+                <rect x="7" y="3" width="10" height="18" rx="2" /><path d="M11 18h2" />
+              </svg>
+            </button>
+            <button type="button" className={styles.pvTool} title="Open in window" disabled aria-label="Open in window">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+                <path d="M14 4h6v6" /><path d="M20 4 10 14" />
+                <path d="M20 14v5a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1h5" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        {mode === "canvas" ? (
+          <div className={styles.pvCanvas}>
+            <CanvasView projectId={project.id} projectSlug={project.slug} />
+          </div>
+        ) : mode === "code" ? (
+          <div className={styles.pvStage}>
+            <PreviewPlaceholder
+              title="Code view"
+              body="When this project builds an app, its source will stream here alongside the live preview. Wiring the build pipeline is the next phase of the Workspace."
+            />
+          </div>
+        ) : (
+          <div className={styles.pvStage}>
+            {/* TODO(#59 phase 2/3): replace with a real streamed live build
+                preview (iframe / StreamedBrowser to the running app). Until the
+                project build pipeline is wired, show an honest placeholder
+                rather than a hardcoded fake running app. */}
+            <PreviewPlaceholder
+              title="Live preview"
+              body="A live preview of the app this project builds will render here. Until a build is running, there is nothing to show. Use the Canvas tab for the shared diagram."
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function PreviewPlaceholder({ title, body }: { title: string; body: string }) {
+  return (
+    <div className={styles.placeholder}>
+      <div className={styles.phIc}>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6">
+          <rect x="3" y="3" width="18" height="18" rx="3" />
+          <path d="M3 9h18M9 3v18" opacity=".5" />
+        </svg>
+      </div>
+      <h3>{title}</h3>
+      <p>{body}</p>
+      <span className={styles.tagb}>Phase 2</span>
+    </div>
+  );
+}

--- a/desktop/src/apps/ProjectsApp/ProjectsApp.module.css
+++ b/desktop/src/apps/ProjectsApp/ProjectsApp.module.css
@@ -1,0 +1,530 @@
+/* Projects app redesign (task #59).
+   Tokens come from theme/tokens.css so dark and light both work; no hardcoded
+   theme colors here beyond the board status hues, which mirror the existing
+   board tokens. */
+
+/* ---- left sidebar: project list ---- */
+.sidebar {
+  width: 248px;
+  flex: none;
+  display: flex;
+  flex-direction: column;
+  background: var(--color-shell-bg-deep);
+  border-right: 1px solid var(--color-shell-border);
+  height: 100%;
+  min-height: 0;
+}
+.sbHead {
+  height: 52px;
+  flex: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 16px;
+  border-bottom: 1px solid var(--color-shell-border);
+}
+.sbHead h2 {
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--color-shell-text);
+}
+.newBtn {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-shell-text-secondary);
+  background: var(--color-shell-surface);
+  border: 1px solid var(--color-shell-border);
+  border-radius: 999px;
+  padding: 5px 11px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.newBtn:hover {
+  background: var(--color-shell-surface-hover);
+  color: var(--color-shell-text);
+  border-color: var(--color-shell-border-strong);
+}
+.newBtn svg {
+  width: 13px;
+  height: 13px;
+}
+.sbList {
+  flex: 1;
+  overflow: auto;
+  padding: 8px;
+  list-style: none;
+  margin: 0;
+}
+.pj {
+  display: flex;
+  gap: 11px;
+  align-items: center;
+  width: 100%;
+  text-align: left;
+  padding: 9px 10px;
+  border: none;
+  background: transparent;
+  border-radius: 13px;
+  cursor: pointer;
+  transition: all 0.15s;
+  margin-bottom: 2px;
+  color: var(--color-shell-text);
+}
+.pj:hover {
+  background: var(--color-shell-surface-hover);
+}
+.pjOn {
+  background: var(--color-shell-surface-active);
+}
+.pjOn .pjMark {
+  box-shadow: 0 0 0 2px var(--color-accent-glow);
+}
+.pjMark {
+  width: 32px;
+  height: 32px;
+  border-radius: 9px;
+  flex: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 700;
+  color: #15161a;
+  background: linear-gradient(135deg, #7c8ba1, #aab4c9);
+}
+.pjBody {
+  min-width: 0;
+  flex: 1;
+}
+.pjName {
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.pjMeta {
+  font-size: 11px;
+  color: var(--color-shell-text-tertiary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-top: 1px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.pjDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--color-board-status-closed, #30d158);
+  flex: none;
+  box-shadow: 0 0 0 3px rgba(48, 209, 88, 0.15);
+}
+.sbEmpty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  padding: 32px 16px;
+  text-align: center;
+  gap: 12px;
+}
+.sbEmpty p {
+  margin: 0;
+}
+.sbEmptyTitle {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-shell-text);
+}
+.sbEmptySub {
+  font-size: 12px;
+  color: var(--color-shell-text-secondary);
+  line-height: 1.45;
+}
+
+/* ---- main column header ---- */
+.header {
+  flex: none;
+  padding: 14px 22px 0;
+  border-bottom: 1px solid var(--color-shell-border);
+}
+.titleRow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.titleRow h1 {
+  font-size: 19px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--color-shell-text);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.desc {
+  font-size: 12.5px;
+  color: var(--color-shell-text-secondary);
+  margin-top: 4px;
+  max-width: 680px;
+  line-height: 1.45;
+}
+
+/* presence row */
+.presence {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: none;
+}
+.stack {
+  display: flex;
+}
+.av {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 2px solid var(--color-shell-bg);
+  margin-left: -8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  font-weight: 700;
+  position: relative;
+}
+.av:first-child {
+  margin-left: 0;
+}
+.avHuman {
+  background: linear-gradient(135deg, #6f7d93, #9aa4b8);
+  color: #15161a;
+}
+.avAgent {
+  background: linear-gradient(135deg, #2c303b, #444a5b);
+  color: var(--color-shell-text);
+}
+.avRing {
+  position: absolute;
+  right: -1px;
+  bottom: -1px;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--color-board-status-closed, #30d158);
+  border: 2px solid var(--color-shell-bg);
+}
+.presenceLbl {
+  font-size: 11px;
+  color: var(--color-shell-text-tertiary);
+  font-weight: 600;
+}
+
+/* tabs */
+.tabs {
+  display: flex;
+  gap: 2px;
+  padding: 10px 0 0;
+  margin-top: 12px;
+  overflow-x: auto;
+}
+.tab {
+  position: relative;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-shell-text-tertiary);
+  padding: 8px 13px 12px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: color 0.15s;
+  border: none;
+  background: none;
+  text-transform: capitalize;
+}
+.tab:hover {
+  color: var(--color-shell-text-secondary);
+}
+.tabOn {
+  color: var(--color-shell-text);
+}
+.tabOn::after {
+  content: "";
+  position: absolute;
+  left: 11px;
+  right: 11px;
+  bottom: 0;
+  height: 2px;
+  border-radius: 2px;
+  background: var(--color-accent-strong);
+}
+
+/* panel host */
+.panel {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+.panelPad {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: 16px 22px;
+}
+
+/* =========================================================
+   WORKSPACE (hero) split pane
+   ========================================================= */
+.ws {
+  flex: 1;
+  display: flex;
+  min-height: 0;
+}
+.wsLeft {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.wsDivider {
+  width: 5px;
+  flex: none;
+  cursor: col-resize;
+  position: relative;
+  background: transparent;
+}
+.wsDivider::before {
+  content: "";
+  position: absolute;
+  left: 2px;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: var(--color-shell-border);
+}
+.wsDivider::after {
+  content: "";
+  position: absolute;
+  left: 1px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 3px;
+  height: 34px;
+  border-radius: 99px;
+  background: var(--color-shell-border-strong);
+}
+.wsRight {
+  flex: none;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: var(--color-shell-bg-deep);
+}
+
+/* left: thread host (MessagesApp scoped to the project) */
+.wsThread {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+/* right: preview pane */
+.pvBar {
+  height: 50px;
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0 16px;
+  border-bottom: 1px solid var(--color-shell-border);
+}
+.seg {
+  display: flex;
+  background: var(--color-shell-surface);
+  border: 1px solid var(--color-shell-border);
+  border-radius: 999px;
+  padding: 3px;
+}
+.seg button {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--color-shell-text-secondary);
+  padding: 5px 13px;
+  border-radius: 999px;
+  cursor: pointer;
+  border: none;
+  background: none;
+  transition: all 0.15s;
+}
+.segOn {
+  background: var(--color-shell-surface-active);
+  color: var(--color-shell-text) !important;
+}
+.pvLive {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 10.5px;
+  font-weight: 600;
+  color: var(--color-shell-text-secondary);
+}
+.pvPulse {
+  position: relative;
+  width: 7px;
+  height: 7px;
+}
+.pvPulse i {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: var(--color-board-status-closed, #30d158);
+}
+.pvPulse::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: var(--color-board-status-closed, #30d158);
+  animation: pvPulse 2.2s ease-out infinite;
+}
+@keyframes pvPulse {
+  0% { transform: scale(1); opacity: 0.6; }
+  100% { transform: scale(3); opacity: 0; }
+}
+.pvTools {
+  margin-left: auto;
+  display: flex;
+  gap: 5px;
+}
+.pvTool {
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-shell-text-tertiary);
+  cursor: pointer;
+  border: 1px solid var(--color-shell-border);
+  background: var(--color-shell-surface);
+  transition: all 0.15s;
+}
+.pvTool:hover {
+  background: var(--color-shell-surface-hover);
+  color: var(--color-shell-text-secondary);
+  border-color: var(--color-shell-border-strong);
+}
+.pvTool svg {
+  width: 15px;
+  height: 15px;
+}
+.pvStage {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: auto;
+}
+.pvCanvas {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+}
+
+/* honest preview placeholder */
+.placeholder {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  padding: 40px;
+  text-align: center;
+}
+.phIc {
+  width: 64px;
+  height: 64px;
+  border-radius: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-shell-surface);
+  border: 1px solid var(--color-shell-border);
+}
+.phIc svg {
+  width: 28px;
+  height: 28px;
+  color: var(--color-accent-strong);
+}
+.placeholder h3 {
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--color-shell-text);
+}
+.placeholder p {
+  font-size: 12.5px;
+  color: var(--color-shell-text-secondary);
+  max-width: 340px;
+  line-height: 1.5;
+}
+.tagb {
+  font-size: 10.5px;
+  font-weight: 600;
+  color: var(--color-accent-strong);
+  background: var(--color-accent-soft);
+  border: 1px solid var(--color-accent-line);
+  border-radius: 999px;
+  padding: 4px 12px;
+}
+
+/* code view */
+.codeStage {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: 16px;
+}
+.codeView {
+  font-family: "SF Mono", ui-monospace, Menlo, monospace;
+  font-size: 11.5px;
+  line-height: 1.65;
+  background: var(--color-shell-bg);
+  border: 1px solid var(--color-shell-border);
+  border-radius: 14px;
+  padding: 16px 18px;
+  color: var(--color-shell-text-secondary);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* =========================================================
+   Mobile: stack the split pane
+   ========================================================= */
+@media (max-width: 767px) {
+  .ws {
+    flex-direction: column;
+  }
+  .wsDivider {
+    display: none;
+  }
+  .wsRight {
+    width: 100% !important;
+    border-top: 1px solid var(--color-shell-border);
+    min-height: 280px;
+  }
+}

--- a/desktop/src/apps/ProjectsApp/__tests__/ProjectWorkspace.mobile.test.tsx
+++ b/desktop/src/apps/ProjectsApp/__tests__/ProjectWorkspace.mobile.test.tsx
@@ -8,7 +8,7 @@ vi.mock("../../../hooks/use-is-mobile", () => ({
 }));
 import { useIsMobile } from "../../../hooks/use-is-mobile";
 
-// Mock heavy children — we only care about the tab strip switch here.
+// Mock heavy children: we only care about the tab strip switch here.
 vi.mock("../board/ProjectBoard", () => ({ ProjectBoard: () => <div /> }));
 vi.mock("../board/TaskModal", () => ({ TaskModal: () => <div /> }));
 vi.mock("../canvas/CanvasView", () => ({ CanvasView: () => <div /> }));
@@ -17,6 +17,7 @@ vi.mock("../ProjectMembers", () => ({ ProjectMembers: () => <div /> }));
 vi.mock("../ProjectActivity", () => ({ ProjectActivity: () => <div /> }));
 vi.mock("@/apps/FilesApp", () => ({ FilesApp: () => <div /> }));
 vi.mock("@/apps/MessagesApp", () => ({ MessagesApp: () => <div /> }));
+vi.mock("../ProjectWorkspacePane", () => ({ ProjectWorkspacePane: () => <div data-testid="workspace-pane" /> }));
 
 const fakeProject: Project = {
   id: "p1",
@@ -62,10 +63,34 @@ describe("ProjectWorkspace tab strip", () => {
     expect(screen.queryByTestId("workspace-tab-pills-scroller")).not.toBeInTheDocument();
   });
 
+  it("defaults to the Workspace tab and renders the workspace pane", async () => {
+    (useIsMobile as ReturnType<typeof vi.fn>).mockReturnValue(false);
+    await act(async () => {
+      render(<ProjectWorkspace project={fakeProject} onChanged={() => {}} />);
+    });
+    expect(screen.getByRole("tab", { name: "workspace" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByTestId("workspace-pane")).toBeInTheDocument();
+  });
+
+  it("switches tabs when a tab is clicked", async () => {
+    (useIsMobile as ReturnType<typeof vi.fn>).mockReturnValue(false);
+    await act(async () => {
+      render(<ProjectWorkspace project={fakeProject} onChanged={() => {}} />);
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("tab", { name: "members" }));
+    });
+    expect(screen.getByRole("tab", { name: "members" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.queryByTestId("workspace-pane")).not.toBeInTheDocument();
+  });
+
   it("renders the FAB on mobile when the Tasks tab is active", async () => {
     (useIsMobile as ReturnType<typeof vi.fn>).mockReturnValue(true);
     await act(async () => {
       render(<ProjectWorkspace project={fakeProject} onChanged={() => {}} />);
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("tab", { name: "Tasks" }));
     });
     expect(screen.getByLabelText("Create task")).toBeInTheDocument();
   });

--- a/desktop/src/apps/ProjectsApp/__tests__/ProjectsApp.mobile.test.tsx
+++ b/desktop/src/apps/ProjectsApp/__tests__/ProjectsApp.mobile.test.tsx
@@ -42,10 +42,12 @@ describe("ProjectsApp mobile shell", () => {
     expect(screen.getByTestId("mobile-split-view")).toHaveAttribute("data-list-title", "Projects");
   });
 
-  it("renders side-by-side flex layout when useIsMobile is false", () => {
+  it("renders side-by-side layout (project-list sidebar + main) when useIsMobile is false", () => {
     (useIsMobile as ReturnType<typeof vi.fn>).mockReturnValue(false);
     render(<ProjectsApp windowId="test-window" />);
     expect(screen.queryByTestId("mobile-split-view")).not.toBeInTheDocument();
-    expect(document.querySelector("aside.w-72")).toBeInTheDocument();
+    // ProjectList (the 248px sidebar) and the main detail column render together.
+    expect(screen.getByTestId("project-list")).toBeInTheDocument();
+    expect(document.querySelector("main")).toBeInTheDocument();
   });
 });

--- a/desktop/src/apps/ProjectsApp/index.tsx
+++ b/desktop/src/apps/ProjectsApp/index.tsx
@@ -52,7 +52,7 @@ export function ProjectsApp({ windowId: _windowId }: { windowId: string }) {
       {selected ? (
         <ProjectWorkspace project={selected} onChanged={refresh} />
       ) : (
-        <div className="p-6 text-zinc-500">Select or create a project.</div>
+        <div className="p-6 text-shell-text-secondary">Select or create a project.</div>
       )}
     </>
   );
@@ -69,13 +69,12 @@ export function ProjectsApp({ windowId: _windowId }: { windowId: string }) {
     );
   }
 
-  // Desktop branch — byte-identical layout preserved
+  // Desktop branch: project-list sidebar + main column. ProjectList renders
+  // its own <aside> (the 248px sidebar), so this row just lays them out.
   return (
-    <div className="flex h-full w-full">
-      <aside className="w-72 border-r border-zinc-800 flex flex-col">
-        {listPane}
-      </aside>
-      <main className="flex-1 min-w-0">
+    <div className="flex h-full w-full bg-shell-bg text-shell-text">
+      {listPane}
+      <main className="flex-1 min-w-0 flex flex-col min-h-0">
         {detailPane}
       </main>
     </div>

--- a/desktop/src/apps/ProjectsApp/presence.ts
+++ b/desktop/src/apps/ProjectsApp/presence.ts
@@ -1,0 +1,46 @@
+import type { ProjectMember } from "@/lib/projects";
+
+export type PresenceFace = {
+  id: string;
+  initial: string;
+  kind: "human" | "agent";
+  title: string;
+};
+
+/**
+ * Derives the project-header presence row from existing data (task #59 phase 1).
+ *
+ * This is static-but-real: it uses the project owner + the real member roster
+ * (native/clone members are agents) rather than live multiplayer presence.
+ * Live cursors / true real-time presence are #59 phase 2 (deferred).
+ */
+export function derivePresence(opts: {
+  ownerInitial?: string;
+  members: ProjectMember[];
+  agentName: (memberId: string) => string;
+  max?: number;
+}): PresenceFace[] {
+  const { ownerInitial, members, agentName, max = 5 } = opts;
+  const faces: PresenceFace[] = [];
+
+  if (ownerInitial) {
+    faces.push({
+      id: "owner",
+      initial: ownerInitial.slice(0, 1).toUpperCase(),
+      kind: "human",
+      title: "You",
+    });
+  }
+
+  for (const m of members) {
+    const name = agentName(m.member_id);
+    faces.push({
+      id: m.member_id,
+      initial: (name || "?").slice(0, 1).toUpperCase(),
+      kind: m.member_kind === "native" || m.member_kind === "clone" ? "agent" : "human",
+      title: name,
+    });
+  }
+
+  return faces.slice(0, max);
+}


### PR DESCRIPTION
Jay-approved mock (.design/projects-redesign-mock.html). Phase 1 of #59.

## What's in
- Projects shell at the Store/Images design bar: 248px project-list sidebar, project header with a live presence row (real owner + members + agents), restyled 8-tab bar with a new **Workspace** tab as default. All token-driven (dark + light), mobile stacking.
- **Workspace split-pane**: LEFT reuses the real project-scoped Messages (thread + composer + A2A bus); RIGHT has a Preview | Code | Canvas toggle where Canvas embeds the real SSE-backed CanvasView.
- Board + other tabs sit under the new chrome (Board internals already token-styled).

## Honest scope (deferred to phase 2/3, marked TODO)
- Preview/Code panes are token-styled placeholders (toolbar disabled) - no faked running-app data. A true streamed live build preview + real-time multiplayer presence/cursors are phase 2/3.

## Verify
tsc clean, npm run build succeeds, 89 ProjectsApp tests pass. (20 pre-existing unrelated failures on dev confirmed via clean-tree run.) Live Pi verification after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a Workspace tab to projects with mode switching (preview, code, canvas).
  * Displayed team member presence indicators in the project header.
  * Introduced a new split-pane workspace editing panel.
  * Redesigned the project list sidebar layout.

* **Tests**
  * Updated test coverage for Workspace functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->