### PR TITLE
fix(controller): stop the 45s restart hang (bounded shutdown + loopback drain)

### DIFF
--- a/tests/test_prepare_shutdown_loopback.py
+++ b/tests/test_prepare_shutdown_loopback.py
@@ -1,0 +1,95 @@
+"""Tests for the loopback exemption on /api/system/prepare-shutdown (task #64).
+
+The systemd graceful-stop hook POSTs this endpoint from localhost with no
+session cookie, so it was getting 401 and the in-app drain never ran. The
+auth middleware now exempts the path for loopback callers only; remote callers
+still hit the normal session gate.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from tinyagentos.auth_middleware import AuthMiddleware
+
+
+class _StubAuth:
+    """Minimal AuthManager stand-in: configured, but no valid sessions."""
+
+    def is_configured(self) -> bool:
+        return True
+
+    def validate_local_token(self, token: str) -> bool:
+        return False
+
+    def validate_session(self, token: str):
+        return None
+
+    def get_primary_user(self):
+        return None
+
+    def get_user_by_id(self, user_id: str):
+        return None
+
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+    app.state.auth = _StubAuth()
+    app.add_middleware(AuthMiddleware)
+
+    @app.post("/api/system/prepare-shutdown")
+    async def _prepare_shutdown():
+        return {"status": "ready"}
+
+    @app.get("/api/agents")
+    async def _agents():
+        return {"agents": []}
+
+    return app
+
+
+@pytest.mark.asyncio
+async def test_prepare_shutdown_allowed_from_loopback():
+    """A loopback POST reaches the route without a session (drain works)."""
+    app = _make_app()
+    transport = ASGITransport(app=app, client=("127.0.0.1", 5555))
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/api/system/prepare-shutdown")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ready"}
+
+
+@pytest.mark.asyncio
+async def test_prepare_shutdown_allowed_from_ipv6_loopback():
+    """::1 is loopback too and must be allowed."""
+    app = _make_app()
+    transport = ASGITransport(app=app, client=("::1", 5555))
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/api/system/prepare-shutdown")
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_prepare_shutdown_rejected_from_remote():
+    """A non-loopback caller still hits the auth gate and gets 401."""
+    app = _make_app()
+    transport = ASGITransport(app=app, client=("203.0.113.5", 5555))
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/api/system/prepare-shutdown",
+            headers={"accept": "application/json"},
+        )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_other_routes_still_gated_from_loopback():
+    """The exemption is path-scoped: other APIs stay gated even on loopback."""
+    app = _make_app()
+    transport = ASGITransport(app=app, client=("127.0.0.1", 5555))
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/api/agents", headers={"accept": "application/json"}
+        )
+    assert resp.status_code == 401

--- a/tests/test_task_utils_shutdown.py
+++ b/tests/test_task_utils_shutdown.py
@@ -1,0 +1,102 @@
+"""Tests for the bounded background-task shutdown helper (task #64).
+
+The controller restart was slow because the FastAPI lifespan SHUTDOWN phase
+gathered background tasks without a timeout: a loop that did not unwind on
+cancel blocked the process until systemd SIGKILLed it at TimeoutStopUSec
+(~45s). cancel_and_wait caps that wait so shutdown stays a few seconds.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from tinyagentos.task_utils import _create_supervised_task, cancel_and_wait
+
+
+@pytest.mark.asyncio
+async def test_cancel_and_wait_cancels_tracked_tasks_promptly():
+    """Tracked background loops are cancelled and awaited within the budget."""
+    tasks: set = set()
+
+    async def _loop() -> None:
+        while True:
+            await asyncio.sleep(3600)
+
+    _create_supervised_task(_loop(), tasks)
+    _create_supervised_task(_loop(), tasks)
+    snapshot = list(tasks)
+
+    stragglers = await asyncio.wait_for(cancel_and_wait(snapshot, timeout=5.0), timeout=2.0)
+
+    assert stragglers == []
+    for t in snapshot:
+        assert t.done()
+        assert t.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_cancel_and_wait_returns_promptly_on_uncancellable_task(caplog):
+    """A task that refuses to unwind must not block shutdown past the budget.
+
+    Models a background loop that swallows cancellation and keeps running.
+    cancel_and_wait must return within the budget and report the straggler by
+    name rather than hang (the bug that stranded restarts for ~45s). Uses
+    asyncio.wait, which does not await cancellation of still-pending tasks.
+    """
+    import logging
+
+    flag = {"stop": False}
+
+    async def _stubborn() -> None:
+        while not flag["stop"]:
+            try:
+                await asyncio.sleep(3600)
+            except asyncio.CancelledError:
+                # Refuse to die until the test flips the flag.
+                continue
+
+    task = asyncio.create_task(_stubborn(), name="stubborn")
+    await asyncio.sleep(0)  # let it reach the sleep
+
+    loop = asyncio.get_running_loop()
+    start = loop.time()
+    with caplog.at_level(logging.WARNING, logger="tinyagentos.task_utils"):
+        stragglers = await cancel_and_wait([task], timeout=0.2)
+    elapsed = loop.time() - start
+
+    # Returned within the budget (well under the original 45s strand) and named
+    # the straggler rather than hanging.
+    assert elapsed < 2.0
+    assert stragglers == [task]
+    assert not task.done()
+    assert any("did not exit" in r.message for r in caplog.records)
+    assert any("stubborn" in r.message for r in caplog.records)
+
+    # Cleanup: let the loop exit so the test's event loop can close.
+    flag["stop"] = True
+    task.cancel()
+    try:
+        await asyncio.wait_for(task, timeout=1.0)
+    except (asyncio.TimeoutError, asyncio.CancelledError):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_cancel_and_wait_empty_set_is_noop():
+    """No tracked tasks → returns immediately with nothing pending."""
+    assert await cancel_and_wait(set(), timeout=5.0) == []
+
+
+@pytest.mark.asyncio
+async def test_cancel_and_wait_ignores_already_done_tasks():
+    """Already-finished tasks are not re-cancelled and never block."""
+
+    async def _quick() -> None:
+        return None
+
+    task = asyncio.create_task(_quick())
+    await task
+    assert task.done()
+
+    assert await cancel_and_wait([task], timeout=5.0) == []

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -102,7 +102,7 @@ PROJECT_DIR = Path(__file__).parent.parent
 _STARTUP_EXEMPT_PATHS = frozenset({"/api/health", "/api/version"})
 _STARTUP_EXEMPT_PREFIXES = ("/static/", "/desktop/", "/chat-pwa/", "/ws/", "/auth/", "/setup", "/shortcut/")
 
-from tinyagentos.task_utils import _create_supervised_task  # noqa: E402
+from tinyagentos.task_utils import _create_supervised_task, cancel_and_wait  # noqa: E402
 
 
 def _resolve_browser_cookie_key(data_dir: "Path") -> str:
@@ -1031,13 +1031,17 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         # gracefully drain here. Only true system halt (system-shutdown) and
         # explicit agent pause/stop go through the orchestrator.
 
-        # Cancel supervised background tasks (fire-and-forget loops etc.)
-        _bg = getattr(app.state, "_background_tasks", set())
-        for _t in list(_bg):
-            if not _t.done():
-                _t.cancel()
-        if _bg:
-            await asyncio.gather(*_bg, return_exceptions=True)
+        # Cancel supervised background tasks (fire-and-forget loops etc.) plus
+        # the local-heartbeat loop under ONE bounded budget. An unbounded gather
+        # here is what stranded shutdown in the FastAPI lifespan: if any loop did
+        # not unwind promptly on cancel, the context manager blocked until systemd
+        # SIGKILLed the process at TimeoutStopUSec (~45s). cancel_and_wait caps the
+        # wait and logs any straggler by name instead of blocking forever.
+        _bg = set(getattr(app.state, "_background_tasks", set()))
+        _hb_task = getattr(app.state, "local_heartbeat_task", None)
+        if _hb_task is not None:
+            _bg.add(_hb_task)
+        await cancel_and_wait(_bg, timeout=5.0)
 
         # Unregister mDNS first so the goodbye packet goes out before other
         # services start tearing down (and potentially blocking the loop).
@@ -1052,15 +1056,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
             await c.stop()
         await score_cache.stop()
         await backend_catalog.stop()
-        _hb_task = getattr(app.state, "local_heartbeat_task", None)
-        if _hb_task is not None:
-            _hb_task.cancel()
-            # Await it so the loop has actually exited before teardown moves on
-            # (cancel() alone doesn't guarantee the coroutine has unwound).
-            try:
-                await _hb_task
-            except asyncio.CancelledError:
-                pass
+        # local_heartbeat_task is cancelled+awaited above under the bounded
+        # cancel_and_wait budget alongside the supervised background tasks.
         await cluster_manager.stop()
         llm_proxy.stop()
         try:

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import ipaddress
+
 from fastapi import Request
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -50,6 +52,30 @@ _CLUSTER_PAIRING_ANNOUNCE = "/api/cluster/pairing/announce"
 _CLUSTER_PAIRING_CLAIM = "/api/cluster/pairing/claim"
 _CLUSTER_WORKERS = "/api/cluster/workers"
 _CLUSTER_HEARTBEAT = "/api/cluster/heartbeat"
+
+# Local-only shutdown drain: the systemd ExecStop hook (taos-graceful-stop)
+# POSTs this from localhost with no session cookie and no token, so it was
+# getting 401 and the in-app drain never ran. We exempt it ONLY for loopback
+# callers (127.0.0.1 / ::1) so a remote caller still hits the normal auth gate.
+_PREPARE_SHUTDOWN = "/api/system/prepare-shutdown"
+
+
+def _is_loopback_client(request: Request) -> bool:
+    """Return True when the request originates from the loopback interface.
+
+    request.client.host is the immediate peer address; for a direct localhost
+    connection that is 127.0.0.1 or ::1. taOS binds to 127.0.0.1 by default and
+    has no trusted reverse proxy in front of it, so we do NOT honour
+    X-Forwarded-For here: a remote caller cannot spoof loopback by setting a
+    header.
+    """
+    client = request.client
+    if client is None:
+        return False
+    try:
+        return ipaddress.ip_address(client.host).is_loopback
+    except ValueError:
+        return False
 
 
 def _is_exempt(method: str, path: str) -> bool:
@@ -107,6 +133,19 @@ class AuthMiddleware(BaseHTTPMiddleware):
             request.state.user_id = None
             request.state.is_admin = False
             request.state.via = "exempt"
+            return await call_next(request)
+
+        # Loopback-only shutdown drain: POST /api/system/prepare-shutdown from
+        # the local systemd stop hook (curl on 127.0.0.1, no session/token).
+        # Remote callers fall through to the normal session gate below.
+        if (
+            request.method == "POST"
+            and path == _PREPARE_SHUTDOWN
+            and _is_loopback_client(request)
+        ):
+            request.state.user_id = None
+            request.state.is_admin = False
+            request.state.via = "loopback"
             return await call_next(request)
 
         # Local token (Authorization: Bearer <token>) is accepted as a

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -61,13 +61,16 @@ _PREPARE_SHUTDOWN = "/api/system/prepare-shutdown"
 
 
 def _is_loopback_client(request: Request) -> bool:
-    """Return True when the request originates from the loopback interface.
+    """Return True only when the request's immediate TCP peer is loopback.
 
-    request.client.host is the immediate peer address; for a direct localhost
-    connection that is 127.0.0.1 or ::1. taOS binds to 127.0.0.1 by default and
-    has no trusted reverse proxy in front of it, so we do NOT honour
-    X-Forwarded-For here: a remote caller cannot spoof loopback by setting a
-    header.
+    The controller binds 0.0.0.0, so it IS reachable remotely; the safety here
+    does not come from the bind address. request.client.host is the immediate
+    peer of the TCP connection (set by the ASGI server from the socket), which a
+    remote caller cannot make 127.0.0.1 / ::1 -- they would have to be connecting
+    over the loopback interface, i.e. already on the host. We deliberately do NOT
+    consult X-Forwarded-For (taOS runs no trusted reverse proxy that would set
+    it), so a remote caller cannot spoof loopback with a header. If a trusted
+    proxy is ever placed in front, this check must be revisited.
     """
     client = request.client
     if client is None:

--- a/tinyagentos/task_utils.py
+++ b/tinyagentos/task_utils.py
@@ -2,7 +2,8 @@
 
 Provides _create_supervised_task, a thin wrapper around asyncio.create_task
 that tracks the task in a caller-supplied set and logs any unhandled
-exceptions via a done callback.
+exceptions via a done callback, plus cancel_and_wait, a bounded shutdown
+helper that cancels tracked tasks without blocking the process forever.
 """
 from __future__ import annotations
 
@@ -39,3 +40,40 @@ def _create_supervised_task(
     task.add_done_callback(_on_done)
     task_set.add(task)
     return task
+
+
+async def cancel_and_wait(
+    tasks,
+    *,
+    timeout: float = 5.0,
+) -> list[asyncio.Task]:
+    """Cancel *tasks* and wait for them to exit under a bounded *timeout*.
+
+    Used at lifespan shutdown so a misbehaving background loop cannot block the
+    process indefinitely (systemd then SIGKILLs after TimeoutStopUSec, which is
+    what made controller restarts take ~45s). Cancellation is requested on every
+    not-yet-done task, then we wait with asyncio.wait(timeout=...).
+
+    asyncio.wait (unlike asyncio.wait_for + gather) does NOT await the
+    cancellation of tasks that are still pending when the deadline passes, so a
+    task that refuses to unwind cannot make this call hang. Any straggler is
+    logged by name and returned; we proceed rather than block forever.
+
+    Returns the list of tasks that were still running when the timeout elapsed
+    (empty when everything exited cleanly).
+    """
+    pending = [t for t in tasks if not t.done()]
+    for t in pending:
+        t.cancel()
+    if not pending:
+        return []
+    _, still_pending = await asyncio.wait(pending, timeout=timeout)
+    stragglers = list(still_pending)
+    if stragglers:
+        logger.warning(
+            "shutdown: %d background task(s) did not exit within %.1fs: %s",
+            len(stragglers),
+            timeout,
+            ", ".join(t.get_name() for t in stragglers) or "<unnamed>",
+        )
+    return stragglers


### PR DESCRIPTION
Closes #64. Investigated from the Pi journal: a real restart took ~51s, of which ~45s was the OLD process hung in the FastAPI lifespan SHUTDOWN (background tasks not cancelled) until systemd SIGKILLed it at TimeoutStopUSec=45s. The graceful-stop drain also got a 401 (auth), so it was a no-op.

## Fix
- task_utils.cancel_and_wait(tasks, timeout=5): cancels all tracked background tasks and waits with a bounded timeout (asyncio.wait, not gather-on-uncooperative-task), logging stragglers by name and proceeding.
- app.py lifespan shutdown folds the whole _background_tasks set + local_heartbeat into one bounded cancel_and_wait (replacing the previous unbounded gather that could block forever).
- auth_middleware: loopback-only exemption for POST /api/system/prepare-shutdown (request.client.host is_loopback; no X-Forwarded-For trust), so the local graceful-stop hook actually drains while remote callers still get 401.

Background tasks now bounded-cancelled: framework-version probe, ephemeral sweep, browser reap, agent-image prefetch, litellm bringup, store_popularity warmer, local heartbeat.

## Verify
8 new tests (shutdown helper + loopback drain) pass; 315 related tests pass; ruff clean; create_app builds 661 routes. TimeoutStopUSec unchanged (just never hit now). Expected: ~50s restarts to ~5s. Live Pi verify after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The shutdown preparation endpoint (`POST /api/system/prepare-shutdown`) can now be called from localhost (IPv4/IPv6) without authentication, supporting local system integrations.
* **Bug Fixes**
  * Improved shutdown reliability by cancelling background work with a bounded timeout to avoid hangs during service teardown.
* **Tests**
  * Added tests confirming the localhost-only auth bypass behavior and that shutdown cancellation completes correctly, including handling unresponsive tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->