### PR TITLE
fix(canvas): stabilize the Projects canvas (self-host tldraw assets, fix shape validation)

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -24,6 +24,7 @@
         "@radix-ui/react-switch": "^1.3.0",
         "@radix-ui/react-tabs": "^1.1.14",
         "@radix-ui/react-tooltip": "^1.2.9",
+        "@tldraw/assets": "4.5.12",
         "@tldraw/tldraw": "^4.5.10",
         "@tsparticles/engine": "^3.9.1",
         "@tsparticles/react": "^3.0.0",
@@ -4550,6 +4551,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tldraw/assets": {
+      "version": "4.5.12",
+      "resolved": "https://registry.npmjs.org/@tldraw/assets/-/assets-4.5.12.tgz",
+      "integrity": "sha512-To3WWslMuEZ0+QCxUIgCt/AS8B8jq9nRHXRJ5xOIA1JGS2WJ9nS5w78y96Kxtcqidy1y8GqxptraMy7OLQLOFw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@tldraw/utils": "4.5.12"
       }
     },
     "node_modules/@tldraw/editor": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -28,6 +28,7 @@
     "@radix-ui/react-switch": "^1.3.0",
     "@radix-ui/react-tabs": "^1.1.14",
     "@radix-ui/react-tooltip": "^1.2.9",
+    "@tldraw/assets": "4.5.12",
     "@tldraw/tldraw": "^4.5.10",
     "@tsparticles/engine": "^3.9.1",
     "@tsparticles/react": "^3.0.0",

--- a/desktop/src/apps/ProjectsApp/__tests__/element-to-shape.test.ts
+++ b/desktop/src/apps/ProjectsApp/__tests__/element-to-shape.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { elementToShape, shapeType } from "../canvas/element-to-shape";
+import { CanvasElement } from "../canvas/canvas-api";
+
+function makeElement(over: Partial<CanvasElement>): CanvasElement {
+  return {
+    id: "cve-1",
+    project_id: "p",
+    kind: "note",
+    author_kind: "user",
+    author_id: "u",
+    x: 10, y: 20, w: 100, h: 50, rotation: 0, z_index: 0,
+    payload: {},
+    created_at: 0, updated_at: 0, deleted_at: null,
+    ...over,
+  };
+}
+
+describe("shapeType", () => {
+  it("maps known kinds to custom shape types", () => {
+    expect(shapeType("note")).toBe("taos-note");
+    expect(shapeType("link")).toBe("taos-link");
+    expect(shapeType("image")).toBe("taos-image");
+  });
+  it("maps unknown kinds to the taos-generic fallback, never built-in geo", () => {
+    expect(shapeType("user_shape")).toBe("taos-generic");
+    expect(shapeType("whatever")).toBe("taos-generic");
+  });
+});
+
+describe("elementToShape", () => {
+  it("note: taos_* live in props, geometry preserved", () => {
+    const s = elementToShape(makeElement({ kind: "note", payload: { text: "hi", color: "yellow", font_size: 14 } }), "slug");
+    expect(s.type).toBe("taos-note");
+    expect(s.x).toBe(10);
+    expect(s.props.w).toBe(100);
+    expect(s.props.taos_kind).toBe("note");
+    expect(s.props.taos_payload).toEqual({ text: "hi", color: "yellow", font_size: 14 });
+    expect(s.meta).toBeUndefined();
+  });
+
+  it("image: includes project_slug in props", () => {
+    const s = elementToShape(makeElement({ kind: "image" }), "my-slug");
+    expect(s.type).toBe("taos-image");
+    expect(s.props.project_slug).toBe("my-slug");
+    expect(s.props.taos_kind).toBe("image");
+  });
+
+  it("link: taos_* live in props", () => {
+    const s = elementToShape(makeElement({ kind: "link" }), "slug");
+    expect(s.type).toBe("taos-link");
+    expect(s.props.taos_kind).toBe("link");
+  });
+
+  it("fallback: taos_* live in meta, props only carry geometry", () => {
+    const s = elementToShape(makeElement({ kind: "user_shape", author_kind: "agent", author_id: "bot", payload: { foo: 1 } }), "slug");
+    expect(s.type).toBe("taos-generic");
+    // props must NOT carry taos_* (built-in geo would reject; generic only declares w/h)
+    expect(s.props).toEqual({ w: 100, h: 50 });
+    expect(s.props.taos_kind).toBeUndefined();
+    // taos_* round-trip via meta
+    expect(s.meta.taos_kind).toBe("user_shape");
+    expect(s.meta.taos_payload).toEqual({ foo: 1 });
+    expect(s.meta.taos_author_id).toBe("bot");
+    expect(s.meta.taos_author_kind).toBe("agent");
+  });
+});

--- a/desktop/src/apps/ProjectsApp/canvas/CanvasBoard.tsx
+++ b/desktop/src/apps/ProjectsApp/canvas/CanvasBoard.tsx
@@ -1,13 +1,16 @@
 import { useEffect, useMemo, useRef } from "react";
 import { Tldraw, Editor, createTLStore, defaultShapeUtils, TLShape } from "@tldraw/tldraw";
+import { getAssetUrlsByMetaUrl } from "@tldraw/assets/urls";
 import "@tldraw/tldraw/tldraw.css";
 
 import { canvasApi, CanvasElement } from "./canvas-api";
+import { elementToShape } from "./element-to-shape";
 import { createCanvasStore } from "./canvas-store";
 import { subscribeCanvasStream } from "./canvas-sse";
 import { TaosNoteShapeUtil } from "./shapes/NoteShape";
 import { TaosLinkShapeUtil } from "./shapes/LinkShape";
 import { TaosImageShapeUtil } from "./shapes/ImageShape";
+import { TaosGenericShapeUtil } from "./shapes/GenericShape";
 import { useIsMobile } from "../../../hooks/use-is-mobile";
 
 interface CanvasBoardProps {
@@ -15,7 +18,18 @@ interface CanvasBoardProps {
   projectSlug: string;
 }
 
-const CUSTOM_SHAPE_UTILS = [TaosNoteShapeUtil, TaosLinkShapeUtil, TaosImageShapeUtil];
+const CUSTOM_SHAPE_UTILS = [
+  TaosNoteShapeUtil,
+  TaosLinkShapeUtil,
+  TaosImageShapeUtil,
+  TaosGenericShapeUtil,
+];
+
+// Self-host tldraw's fonts/translations/icons so they load same-origin.
+// taOS is offline-first and its CSP forbids cdn.tldraw.com; getAssetUrlsByMetaUrl
+// resolves every asset via import.meta.url, which Vite bundles to hashed
+// same-origin URLs that satisfy default-src/connect-src 'self'.
+const ASSET_URLS = getAssetUrlsByMetaUrl();
 
 export function CanvasBoard({ projectId, projectSlug }: CanvasBoardProps) {
   const isMobile = useIsMobile();
@@ -61,6 +75,7 @@ export function CanvasBoard({ projectId, projectSlug }: CanvasBoardProps) {
     <div style={{ position: "relative", width: "100%", height: "100%" }}>
       <Tldraw
         store={store}
+        assetUrls={ASSET_URLS}
         shapeUtils={[...defaultShapeUtils, ...CUSTOM_SHAPE_UTILS] as any}
         onMount={(editor) => {
           editorRef.current = editor;
@@ -121,51 +136,39 @@ function hydrateEditor(
   });
 }
 
-function elementToShape(el: CanvasElement, projectSlug: string): any {
-  const baseProps = {
-    w: el.w, h: el.h,
-    taos_kind: el.kind,
-    taos_payload: el.payload,
-    taos_author_id: el.author_id,
-    taos_author_kind: el.author_kind,
-  };
+// taos_* lives in props for note/link/image and in meta for taos-generic.
+// Read from whichever is present so round-tripping works for every kind.
+function readTaos(shape: TLShape) {
+  const props = shape.props as any;
+  const meta = shape.meta as any;
   return {
-    id: `shape:${el.id}`,
-    type: shapeType(el.kind),
-    x: el.x, y: el.y, rotation: el.rotation,
-    props: el.kind === "image"
-      ? { ...baseProps, project_slug: projectSlug }
-      : baseProps,
+    kind: props.taos_kind ?? meta.taos_kind,
+    payload: props.taos_payload ?? meta.taos_payload,
   };
-}
-
-function shapeType(kind: string): string {
-  if (kind === "note") return "taos-note";
-  if (kind === "link") return "taos-link";
-  if (kind === "image") return "taos-image";
-  return "geo";
 }
 
 async function pushAdd(projectId: string, shape: TLShape) {
   if (!shape.id.toString().startsWith("shape:")) return;
   const props: any = shape.props;
+  const { kind, payload } = readTaos(shape);
   await canvasApi.addElement(projectId, {
     id: shape.id.toString().replace(/^shape:/, ""),
-    kind: (props.taos_kind ?? "user_shape") as any,
+    kind: (kind ?? "user_shape") as any,
     x: shape.x, y: shape.y,
     w: props.w ?? 100, h: props.h ?? 100,
     rotation: shape.rotation,
-    payload: props.taos_payload ?? { tldraw_shape: shape },
+    payload: payload ?? { tldraw_shape: shape },
   });
 }
 
 async function pushUpdate(projectId: string, shape: TLShape) {
   const elementId = shape.id.toString().replace(/^shape:/, "");
   const props: any = shape.props;
+  const { payload } = readTaos(shape);
   await canvasApi.updateElement(projectId, elementId, {
     x: shape.x, y: shape.y,
     w: props.w, h: props.h,
     rotation: shape.rotation,
-    payload: props.taos_payload,
+    payload,
   });
 }

--- a/desktop/src/apps/ProjectsApp/canvas/CanvasView.tsx
+++ b/desktop/src/apps/ProjectsApp/canvas/CanvasView.tsx
@@ -4,7 +4,7 @@ export function CanvasView({
   projectId, projectSlug,
 }: { projectId: string; projectSlug: string }) {
   return (
-    <div style={{ height: "calc(100vh - 100px)", padding: 0 }}>
+    <div style={{ height: "100%", padding: 0 }}>
       <CanvasBoard projectId={projectId} projectSlug={projectSlug} />
     </div>
   );

--- a/desktop/src/apps/ProjectsApp/canvas/element-to-shape.ts
+++ b/desktop/src/apps/ProjectsApp/canvas/element-to-shape.ts
@@ -1,0 +1,47 @@
+import { CanvasElement } from "./canvas-api";
+
+// Maps a backend CanvasElement to a tldraw shape descriptor.
+// Kept free of tldraw runtime imports so it can be unit tested in isolation.
+//
+// note/link/image use custom shape utils that declare the taos_* fields in
+// their own props schema, so those fields go in props. Any other kind falls
+// back to taos-generic, which only declares geometry props; its taos_* data
+// goes in shape.meta (tldraw allows arbitrary meta) to avoid a ValidationError.
+// Built-in tldraw shapes are never used here, so they never receive taos_* props.
+
+export function shapeType(kind: string): string {
+  if (kind === "note") return "taos-note";
+  if (kind === "link") return "taos-link";
+  if (kind === "image") return "taos-image";
+  return "taos-generic";
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function elementToShape(el: CanvasElement, projectSlug: string): any {
+  const taosMeta = {
+    taos_kind: el.kind,
+    taos_payload: el.payload,
+    taos_author_id: el.author_id,
+    taos_author_kind: el.author_kind,
+  };
+
+  if (el.kind === "note" || el.kind === "link" || el.kind === "image") {
+    const baseProps = { w: el.w, h: el.h, ...taosMeta };
+    return {
+      id: `shape:${el.id}`,
+      type: shapeType(el.kind),
+      x: el.x, y: el.y, rotation: el.rotation,
+      props: el.kind === "image"
+        ? { ...baseProps, project_slug: projectSlug }
+        : baseProps,
+    };
+  }
+
+  return {
+    id: `shape:${el.id}`,
+    type: "taos-generic",
+    x: el.x, y: el.y, rotation: el.rotation,
+    props: { w: el.w, h: el.h },
+    meta: taosMeta,
+  };
+}

--- a/desktop/src/apps/ProjectsApp/canvas/shapes/GenericShape.tsx
+++ b/desktop/src/apps/ProjectsApp/canvas/shapes/GenericShape.tsx
@@ -1,0 +1,44 @@
+import { HTMLContainer, ShapeUtil, TLBaseShape, Rectangle2d, T } from "@tldraw/tldraw";
+
+// Fallback shape for any canvas kind that is not note/link/image.
+// Custom taos_* data lives in shape.meta (see CanvasBoard.elementToShape),
+// so this shape only declares geometry props. This keeps tldraw's built-in
+// geo shape out of the round-trip, which would otherwise reject foreign props.
+export type TaosGenericShape = TLBaseShape<
+  "taos-generic",
+  {
+    w: number;
+    h: number;
+  }
+>;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export class TaosGenericShapeUtil extends ShapeUtil<any> {
+  static override type = "taos-generic" as const;
+  static override props = {
+    w: T.number,
+    h: T.number,
+  };
+
+  override getDefaultProps(): TaosGenericShape["props"] {
+    return { w: 120, h: 120 };
+  }
+  override getGeometry(shape: TaosGenericShape) {
+    return new Rectangle2d({ width: shape.props.w, height: shape.props.h, isFilled: true });
+  }
+  override component(shape: TaosGenericShape) {
+    return (
+      <HTMLContainer
+        style={{
+          width: shape.props.w, height: shape.props.h,
+          background: "#f4f4f4", border: "1px solid #d0d0d0",
+          borderRadius: 4,
+        }}
+      />
+    );
+  }
+  override indicator(shape: TaosGenericShape) {
+    return <rect width={shape.props.w} height={shape.props.h} rx={4} />;
+  }
+  override canResize() { return false; }
+}


### PR DESCRIPTION
Task #68 stabilization (the broken canvas). Root causes found by observing the live Pi console (41 errors):

1. CSP blocked tldraw 4.5.12's CDN fonts + translations (taOS is offline-first). Self-host them: add @tldraw/assets@4.5.12 and pass assetUrls=getAssetUrlsByMetaUrl() to Tldraw, so Vite bundles them same-origin. Verified no runtime cdn.tldraw.com request.
2. ValidationError: the fallback mapped unknown kinds to the built-in geo shape with custom taos_* props it rejects. Add a custom taos-generic shape; store taos_* in shape.meta (built-in shapes never receive taos_* now). note/link/image utils already declare their props (audited).
3. Layout: CanvasView height calc(100vh-100px) -> 100% so it fills the Workspace pane.

## Verify
tsc clean, build succeeds, 24/24 ProjectsApp tests (6 new). DEPLOY NOTE: adds @tldraw/assets dep -> Pi redeploy must npm install before build. Live Pi console-clean verification after merge.

This is stabilization only; the infinite ideas-board overhaul (mermaid/mindmap/agent read-write) is the follow-up, mock-first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Canvas now self-hosts assets for improved loading performance
  * Enhanced shape rendering with better support for notes, links, images, and generic element types
  * Improved canvas viewport layout calculation

* **Bug Fixes**
  * Enhanced element data synchronization to better preserve metadata during canvas updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->