### PR TITLE
feat(browser): redesign chrome to the Store/Images bar (#66)

### DIFF
--- a/desktop/src/apps/BrowserApp/AddressBar.tsx
+++ b/desktop/src/apps/BrowserApp/AddressBar.tsx
@@ -266,7 +266,7 @@ export function AddressBar({ windowId }: AddressBarProps) {
             setSelectedIndex((i) => Math.max(i - 1, -1));
           }
         }}
-        className={`w-full bg-shell-bg-deep text-shell-text px-2 py-0.5 rounded text-xs border border-shell-border-subtle focus:border-accent focus:outline-none ${
+        className={`w-full bg-transparent text-[13px] text-shell-text placeholder:text-shell-text-tertiary focus:outline-none ${
           activeTab?.readerAvailable && activeTab.url !== "about:blank"
             ? "pr-14"
             : activeTab?.readerAvailable || activeTab?.url !== "about:blank"

--- a/desktop/src/apps/BrowserApp/AgentPresencePill.test.tsx
+++ b/desktop/src/apps/BrowserApp/AgentPresencePill.test.tsx
@@ -134,7 +134,7 @@ describe("AgentPresencePill", () => {
     );
     await waitFor(() => {
       const btn = screen.getByRole("button");
-      expect(btn.className).toContain("bg-shell-hover");
+      expect(btn.className).toContain("bg-accent-glow");
     });
   });
 

--- a/desktop/src/apps/BrowserApp/AgentPresencePill.tsx
+++ b/desktop/src/apps/BrowserApp/AgentPresencePill.tsx
@@ -125,8 +125,8 @@ export function AgentPresencePill({
       aria-expanded={panelIsOpen}
       onClick={() => togglePanel(windowId, tabId, firstAgentId)}
       className={[
-        "flex items-center relative p-0.5 rounded-full border border-shell-border-subtle",
-        panelIsOpen ? "bg-shell-hover" : "bg-shell-bg-deep hover:bg-shell-hover",
+        "flex items-center relative h-[32px] px-1.5 rounded-full border border-accent-line transition-colors",
+        panelIsOpen ? "bg-accent-glow" : "bg-accent-soft hover:bg-accent-glow",
       ].join(" ")}
     >
       {/* Stacked avatars */}

--- a/desktop/src/apps/BrowserApp/BrowserApp.tsx
+++ b/desktop/src/apps/BrowserApp/BrowserApp.tsx
@@ -1,13 +1,15 @@
 /**
  * BrowserApp v2 — top-level container.
  *
- * Mounted by WindowContent for each browser window. Composes:
- *   - Chrome      (browser-specific nav row + profile chip)
- *   - TabStrip    (compact tab strip with embedded AddressBar in active tab)
- *   - AddressBar  (URL input + suggest popover) — for now rendered ABOVE
- *                 TabStrip; PR 5 may move it inside the active tab per
- *                 the Q8 layout A "compact unified bar" mockup.
+ * Mounted by WindowContent for each browser window. Composes (top to bottom):
+ *   - TabStrip    (tab strip + Proxy/Streamed engine toggle)
+ *   - Chrome      (toolbar: nav buttons, pill omnibox with AddressBar, agent
+ *                  presence pill, settings, profile chip)
+ *   - BookmarksBar
  *   - TabRenderer (iframe pool + discard scheduler)
+ *
+ * On mobile, a single bottom bar hosts the window switcher, the AddressBar
+ * omnibox, and the tab overview.
  *
  * On mount, auto-creates the window entry in browser-store with the
  * default profile if it doesn't exist. Idempotent — preserves any
@@ -119,21 +121,23 @@ export function BrowserApp({ windowId }: BrowserAppProps) {
           )}
         </div>
 
-        <div className="flex items-center gap-1 px-2 py-1 bg-shell-surface border-t border-shell-border-subtle">
+        <div className="flex items-center gap-1 px-2 py-1 bg-shell-surface border-t border-shell-border">
           <button
             type="button"
             aria-label="Browser windows"
             onClick={() => setWindowChooserOpen(true)}
-            className="p-1.5 rounded hover:bg-shell-hover"
+            className="p-1.5 rounded hover:bg-white/[0.06]"
           >
             <Layers size={14} />
           </button>
-          <AddressBar windowId={windowId} />
+          <div className="flex flex-1 min-w-0 items-center h-9 px-3 rounded-full bg-shell-bg-deep border border-shell-border focus-within:border-accent/40">
+            <AddressBar windowId={windowId} />
+          </div>
           <button
             type="button"
             aria-label="Tab overview"
             onClick={() => setTabOverviewOpen(true)}
-            className="p-1.5 rounded hover:bg-shell-hover"
+            className="p-1.5 rounded hover:bg-white/[0.06]"
           >
             <ListChecks size={14} />
           </button>
@@ -145,12 +149,9 @@ export function BrowserApp({ windowId }: BrowserAppProps) {
 
   return (
     <div className="relative flex flex-col h-full bg-shell-bg overflow-hidden">
-      <Chrome windowId={windowId} />
-      <div className="flex items-center gap-1 px-2 py-1 bg-shell-surface border-b border-shell-border-subtle">
-        <AddressBar windowId={windowId} />
-      </div>
-      <BookmarksBar windowId={windowId} profileId={win.profileId} />
       <TabStrip windowId={windowId} />
+      <Chrome windowId={windowId} />
+      <BookmarksBar windowId={windowId} profileId={win.profileId} />
       <TabRenderer windowId={windowId} />
       {findOpen && (
         <FindInPage

--- a/desktop/src/apps/BrowserApp/BrowserModeToggle.test.tsx
+++ b/desktop/src/apps/BrowserApp/BrowserModeToggle.test.tsx
@@ -1,0 +1,107 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import { BrowserModeToggle } from "./BrowserModeToggle";
+import { useBrowserStore } from "@/stores/browser-store";
+
+const originalFetch = global.fetch;
+const WIN_ID = "win-1";
+
+function activeTabId() {
+  return useBrowserStore.getState().getWindow(WIN_ID)!.activeTabId;
+}
+
+beforeEach(() => {
+  useBrowserStore.setState({ windows: {} });
+  useBrowserStore.getState().createWindow(WIN_ID, "personal");
+  const tabId = activeTabId();
+  useBrowserStore.getState().navigateTab(WIN_ID, tabId, "https://example.com/");
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+  cleanup();
+});
+
+describe("BrowserModeToggle - segmented engine control", () => {
+  it("renders Proxy and Streamed radios with Proxy selected by default", () => {
+    render(<BrowserModeToggle windowId={WIN_ID} />);
+    const proxy = screen.getByRole("radio", { name: /proxy browser/i });
+    const streamed = screen.getByRole("radio", { name: /streamed browser/i });
+    expect(proxy.getAttribute("aria-checked")).toBe("true");
+    expect(streamed.getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("marks Streamed selected when the active tab has a liveSession", () => {
+    useBrowserStore.getState().setTabLiveSession(WIN_ID, activeTabId(), {
+      nekoUrl: "http://neko.local:8080/room",
+      streamToken: "tok-1",
+    });
+    render(<BrowserModeToggle windowId={WIN_ID} />);
+    expect(
+      screen.getByRole("radio", { name: /streamed browser/i }).getAttribute("aria-checked"),
+    ).toBe("true");
+  });
+
+  it("clicking Streamed posts a session and sets liveSession on a running response", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: async () => ({
+        session: {
+          id: "sess-1",
+          status: "running",
+          neko_url: "http://neko.local:8080/room",
+          stream_token: "tok-xyz",
+        },
+      }),
+    } as Response);
+
+    const tabId = activeTabId();
+    render(<BrowserModeToggle windowId={WIN_ID} />);
+    fireEvent.click(screen.getByRole("radio", { name: /streamed browser/i }));
+
+    await waitFor(() => {
+      const tab = useBrowserStore
+        .getState()
+        .getWindow(WIN_ID)!
+        .tabs.find((t) => t.id === tabId);
+      expect(tab?.liveSession).toEqual({
+        nekoUrl: "http://neko.local:8080/room",
+        streamToken: "tok-xyz",
+      });
+    });
+  });
+
+  it("clicking Proxy clears an existing liveSession", () => {
+    const tabId = activeTabId();
+    useBrowserStore.getState().setTabLiveSession(WIN_ID, tabId, {
+      nekoUrl: "http://neko.local:8080/room",
+      streamToken: "tok-1",
+    });
+    render(<BrowserModeToggle windowId={WIN_ID} />);
+    fireEvent.click(screen.getByRole("radio", { name: /proxy browser/i }));
+    const tab = useBrowserStore
+      .getState()
+      .getWindow(WIN_ID)!
+      .tabs.find((t) => t.id === tabId);
+    expect(tab?.liveSession).toBeUndefined();
+  });
+
+  it("shows a gate hint when the host has no capable node (409)", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 409,
+      json: async () => ({ error: "no_capable_node" }),
+    } as Response);
+
+    render(<BrowserModeToggle windowId={WIN_ID} />);
+    fireEvent.click(screen.getByRole("radio", { name: /streamed browser/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert").textContent).toMatch(
+        /streamed browser needs a more capable device/i,
+      );
+    });
+  });
+});

--- a/desktop/src/apps/BrowserApp/BrowserModeToggle.tsx
+++ b/desktop/src/apps/BrowserApp/BrowserModeToggle.tsx
@@ -143,9 +143,13 @@ export function BrowserModeToggle({ windowId }: BrowserModeToggleProps) {
       const body = await resp.json();
       session = body.session ?? body;
     } catch {
-      setPhase("idle");
+      if (!cancelledRef.current) setPhase("idle");
       return;
     }
+
+    // Re-check after the JSON-parse await as well: a Proxy click or unmount
+    // during that await must still cancel before we commit the live session.
+    if (cancelledRef.current) return;
 
     if (session.status === "running" && session.neko_url && session.stream_token) {
       setTabLiveSession(windowId, tabId, {

--- a/desktop/src/apps/BrowserApp/BrowserModeToggle.tsx
+++ b/desktop/src/apps/BrowserApp/BrowserModeToggle.tsx
@@ -1,0 +1,229 @@
+/**
+ * BrowserModeToggle - Proxy / Streamed segmented control for the active tab.
+ *
+ * Two browser engines back a tab:
+ *  - Proxy:    the URL-rewriting iframe browser (default). No liveSession.
+ *  - Streamed: a real Chromium session streamed from the host over WebRTC
+ *              (the existing Neko/liveSession path). The active tab carries a
+ *              `liveSession` while streamed.
+ *
+ * This control surfaces that engine choice as a segmented toggle in the tab
+ * strip and drives the existing escalation lifecycle:
+ *  - Streamed: POST /api/browser/sessions, poll until running, then
+ *              store.setTabLiveSession(...) - identical to EscalateButton.
+ *  - Proxy:    store.setTabLiveSession(..., null) drops the stream and the tab
+ *              falls back to the proxied iframe.
+ *
+ * A 409 with `no_capable_node` means the taOS has no device able to run a real
+ * browser; we show a small inline gate hint, matching EscalateButton.
+ */
+import { useCallback, useRef, useState } from "react";
+import { Globe, MonitorPlay } from "lucide-react";
+import { useBrowserStore } from "@/stores/browser-store";
+
+interface BrowserModeToggleProps {
+  windowId: string;
+}
+
+interface BrowserSession {
+  id: string;
+  status: string;
+  neko_url: string | null;
+  stream_token?: string | null;
+}
+
+type Phase = "idle" | "starting" | "polling" | "no_node";
+
+const POLL_INTERVAL_MS = 1500;
+const POLL_MAX_TRIES = 20;
+
+export function BrowserModeToggle({ windowId }: BrowserModeToggleProps) {
+  const win = useBrowserStore((s) => s.windows[windowId]);
+  const setTabLiveSession = useBrowserStore((s) => s.setTabLiveSession);
+
+  const [phase, setPhase] = useState<Phase>("idle");
+  const pollRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const triesRef = useRef(0);
+  const cancelledRef = useRef(false);
+
+  const activeTab = win?.tabs.find((t) => t.id === win.activeTabId);
+  const isStreamed = !!activeTab?.liveSession;
+
+  const poll = useCallback(
+    (sessionId: string, tabId: string) => {
+      if (cancelledRef.current) return;
+      triesRef.current += 1;
+      if (triesRef.current > POLL_MAX_TRIES) {
+        setPhase("idle");
+        return;
+      }
+      fetch(`/api/browser/sessions/${encodeURIComponent(sessionId)}`, {
+        credentials: "include",
+      })
+        .then(async (resp) => {
+          if (cancelledRef.current) return;
+          if (!resp.ok) {
+            setPhase("idle");
+            return;
+          }
+          const session: BrowserSession = await resp.json();
+          if (session.status === "running" && session.neko_url && session.stream_token) {
+            setTabLiveSession(windowId, tabId, {
+              nekoUrl: session.neko_url,
+              streamToken: session.stream_token,
+            });
+            setPhase("idle");
+          } else {
+            pollRef.current = setTimeout(() => poll(sessionId, tabId), POLL_INTERVAL_MS);
+          }
+        })
+        .catch(() => {
+          if (!cancelledRef.current) setPhase("idle");
+        });
+    },
+    [setTabLiveSession, windowId],
+  );
+
+  const goStreamed = useCallback(async () => {
+    if (!activeTab || phase !== "idle") return;
+    const tabId = activeTab.id;
+    cancelledRef.current = false;
+    triesRef.current = 0;
+    setPhase("starting");
+
+    let resp: Response;
+    try {
+      resp = await fetch("/api/browser/sessions", {
+        method: "POST",
+        credentials: "include",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ url: activeTab.url }),
+      });
+    } catch {
+      setPhase("idle");
+      return;
+    }
+
+    if (resp.status === 409) {
+      let body: { error?: string } = {};
+      try {
+        body = await resp.json();
+      } catch {
+        /* ignore */
+      }
+      setPhase(body.error === "no_capable_node" ? "no_node" : "idle");
+      return;
+    }
+
+    if (!resp.ok) {
+      setPhase("idle");
+      return;
+    }
+
+    let session: BrowserSession;
+    try {
+      const body = await resp.json();
+      session = body.session ?? body;
+    } catch {
+      setPhase("idle");
+      return;
+    }
+
+    if (session.status === "running" && session.neko_url && session.stream_token) {
+      setTabLiveSession(windowId, tabId, {
+        nekoUrl: session.neko_url,
+        streamToken: session.stream_token,
+      });
+      setPhase("idle");
+      return;
+    }
+
+    setPhase("polling");
+    poll(session.id, tabId);
+  }, [activeTab, phase, poll, setTabLiveSession, windowId]);
+
+  const goProxy = useCallback(() => {
+    if (!activeTab) return;
+    cancelledRef.current = true;
+    if (pollRef.current) {
+      clearTimeout(pollRef.current);
+      pollRef.current = null;
+    }
+    setPhase("idle");
+    if (activeTab.liveSession) {
+      setTabLiveSession(windowId, activeTab.id, null);
+    }
+  }, [activeTab, setTabLiveSession, windowId]);
+
+  if (!activeTab) return null;
+
+  const busy = phase === "starting" || phase === "polling";
+
+  const segBase =
+    "flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[10.5px] font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40";
+
+  return (
+    <div className="relative">
+      <div
+        role="radiogroup"
+        aria-label="Browser engine"
+        className="flex items-center rounded-full border border-shell-border bg-shell-surface p-[3px]"
+      >
+        <button
+          type="button"
+          role="radio"
+          aria-checked={!isStreamed}
+          aria-label="Proxy browser"
+          title="URL-rewriting proxy browser"
+          onClick={goProxy}
+          className={[
+            segBase,
+            !isStreamed
+              ? "bg-shell-surface-active text-shell-text"
+              : "text-shell-text-secondary hover:text-shell-text",
+          ].join(" ")}
+        >
+          <Globe size={11} aria-hidden="true" />
+          Proxy
+        </button>
+        <button
+          type="button"
+          role="radio"
+          aria-checked={isStreamed}
+          aria-label="Streamed browser"
+          title="Real Chromium streamed from the host over WebRTC"
+          disabled={busy}
+          onClick={goStreamed}
+          className={[
+            segBase,
+            isStreamed
+              ? "bg-shell-surface-active text-shell-text"
+              : "text-shell-text-secondary hover:text-shell-text",
+            busy ? "opacity-60" : "",
+          ].join(" ")}
+        >
+          <MonitorPlay size={11} aria-hidden="true" />
+          {busy ? "Starting…" : "Streamed"}
+        </button>
+      </div>
+
+      {phase === "no_node" && (
+        <div
+          role="alert"
+          className="absolute right-0 top-full z-50 mt-1.5 w-64 rounded-lg border border-shell-border-strong bg-shell-bg-glass px-3 py-2 text-[11px] leading-relaxed text-shell-text-secondary shadow-window backdrop-blur-md"
+        >
+          A streamed browser needs a more capable device on your taOS. Add one to
+          enable this.
+          <button
+            type="button"
+            aria-label="Dismiss"
+            onClick={() => setPhase("idle")}
+            className="ml-2 font-semibold text-shell-text hover:text-accent"
+          >
+            OK
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/desktop/src/apps/BrowserApp/BrowserModeToggle.tsx
+++ b/desktop/src/apps/BrowserApp/BrowserModeToggle.tsx
@@ -17,7 +17,7 @@
  * A 409 with `no_capable_node` means the taOS has no device able to run a real
  * browser; we show a small inline gate hint, matching EscalateButton.
  */
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Globe, MonitorPlay } from "lucide-react";
 import { useBrowserStore } from "@/stores/browser-store";
 
@@ -48,6 +48,19 @@ export function BrowserModeToggle({ windowId }: BrowserModeToggleProps) {
 
   const activeTab = win?.tabs.find((t) => t.id === win.activeTabId);
   const isStreamed = !!activeTab?.liveSession;
+
+  // Stop any in-flight poll if this instance unmounts (tab closed, strip
+  // re-rendered away). Without this the pending setTimeout keeps firing poll(),
+  // which fetches and calls setPhase on a dead component.
+  useEffect(() => {
+    return () => {
+      cancelledRef.current = true;
+      if (pollRef.current) {
+        clearTimeout(pollRef.current);
+        pollRef.current = null;
+      }
+    };
+  }, []);
 
   const poll = useCallback(
     (sessionId: string, tabId: string) => {
@@ -103,6 +116,11 @@ export function BrowserModeToggle({ windowId }: BrowserModeToggleProps) {
       setPhase("idle");
       return;
     }
+
+    // The user may have clicked Proxy while the POST was in flight (goProxy sets
+    // cancelledRef + phase=idle). Honour that cancellation instead of forcing
+    // the tab back into a streamed session it no longer wants.
+    if (cancelledRef.current) return;
 
     if (resp.status === 409) {
       let body: { error?: string } = {};

--- a/desktop/src/apps/BrowserApp/Chrome.tsx
+++ b/desktop/src/apps/BrowserApp/Chrome.tsx
@@ -1,25 +1,41 @@
 /**
- * BrowserApp v2 — Chrome.
+ * BrowserApp v2 - Chrome (toolbar).
  *
- * Browser-specific nav row rendered INSIDE the window, ABOVE the tab strip.
- * Contains back / forward / refresh buttons and the profile chip.
+ * The unified browser toolbar rendered INSIDE the window, BELOW the tab strip.
+ * Left to right: back / forward / reload / home nav buttons, the pill omnibox
+ * (AddressBar, fronted by a connection-security lock), an agent-presence pill +
+ * add-agent affordance, menu and settings buttons, and the profile chip whose
+ * dropdown lists the user's and agents' profiles.
  *
  * NOTE: The OS-level traffic lights (close / minimize / maximize) live in
  * `desktop/src/components/Window.tsx` — every window in taOS gets them
  * automatically. This component does NOT render its own traffic lights.
+ *
+ * The Proxy/Streamed engine toggle lives in the tab strip (BrowserModeToggle),
+ * not here.
  */
 import { useState, useEffect, useRef } from "react";
-import { ArrowLeft, ArrowRight, RotateCw, Settings } from "lucide-react";
+import {
+  ArrowLeft,
+  ArrowRight,
+  RotateCw,
+  Home,
+  Lock,
+  ChevronDown,
+  Settings,
+} from "lucide-react";
 import { useBrowserStore } from "@/stores/browser-store";
 import { useBrowserAgentStore } from "@/stores/browser-agent-store";
 import { listProfiles, type Profile } from "@/lib/browser-profile-api";
+import { AddressBar } from "./AddressBar";
 import { ProfileSwitcher } from "./ProfileSwitcher";
 import { ProfileManager } from "./ProfileManager";
 import { SettingsPanel } from "./SettingsPanel";
 import { AgentPickerPopover } from "./AgentPickerPopover";
 import { AgentPresencePill } from "./AgentPresencePill";
 import { CoPilotBanner } from "./CoPilotBanner";
-import { EscalateButton } from "./EscalateButton";
+
+const HOME_URL = "about:blank";
 
 interface ChromeProps {
   windowId: string;
@@ -76,14 +92,20 @@ export function Chrome({ windowId }: ChromeProps) {
 
   const canGoBack = activeTab.historyIndex > 0;
   const canGoForward = activeTab.historyIndex < activeTab.history.length - 1;
+  // Connection security: the proxy serves over https. Treat an https URL as
+  // secure; about:blank / new-tab pages show no lock.
+  const isSecure = /^https:\/\//i.test(activeTab.url);
+  const hasUrl = !!activeTab.url && activeTab.url !== "about:blank";
 
   const handleRefresh = () => {
-    // Re-navigate to the current URL — bumps the iframe to reload (TabRenderer
-    // listens for navigateTab in PR 4 Task 8).
+    // Re-navigate to the current URL to bump the iframe to reload.
     if (activeTab.url) {
       navigateTab(windowId, activeTab.id, activeTab.url);
     }
   };
+
+  const navBtn =
+    "flex h-[34px] w-[34px] items-center justify-center rounded-[9px] text-shell-text-secondary transition-colors hover:bg-white/[0.06] hover:text-shell-text disabled:text-shell-text-tertiary disabled:hover:bg-transparent disabled:cursor-default";
 
   return (
     <div className="flex flex-col">
@@ -95,167 +117,184 @@ export function Chrome({ windowId }: ChromeProps) {
           agentId={drivingAgentId}
         />
       )}
-    <div
-      className="flex items-center gap-2 px-2 py-1 bg-shell-surface border-b border-shell-border-subtle"
-      role="toolbar"
-      aria-label="Browser navigation"
-    >
-      {/* Nav buttons */}
-      <button
-        type="button"
-        aria-label="Back"
-        onClick={() => goBack(windowId, activeTab.id)}
-        disabled={!canGoBack}
-        className="p-1 rounded hover:bg-shell-hover disabled:opacity-40 disabled:cursor-not-allowed"
+      <div
+        className="flex items-center gap-2 px-3 h-[50px] bg-shell-surface border-b border-shell-border"
+        role="toolbar"
+        aria-label="Browser navigation"
       >
-        <ArrowLeft size={16} />
-      </button>
-
-      <button
-        type="button"
-        aria-label="Forward"
-        onClick={() => goForward(windowId, activeTab.id)}
-        disabled={!canGoForward}
-        className="p-1 rounded hover:bg-shell-hover disabled:opacity-40 disabled:cursor-not-allowed"
-      >
-        <ArrowRight size={16} />
-      </button>
-
-      <button
-        type="button"
-        aria-label="Refresh"
-        onClick={handleRefresh}
-        className="p-1 rounded hover:bg-shell-hover"
-      >
-        <RotateCw size={16} />
-      </button>
-
-      {/* Escalate to full browser (Neko session) */}
-      <div className="relative flex items-center">
-        <EscalateButton tabUrl={activeTab.url} tabId={activeTab.id} windowId={windowId} />
-      </div>
-
-      {/* Spacer pushes the profile chip to the right */}
-      <div className="flex-1" />
-
-      {/* Agent chip / picker */}
-      <div className="relative flex items-center gap-1">
-        {activeTab.pinnedAgentIds.length > 0 && (
-          <AgentPresencePill
-            windowId={windowId}
-            tabId={activeTab.id}
-            pinnedAgentIds={activeTab.pinnedAgentIds}
-            triggerRef={agentChipRef}
-          />
-        )}
-        {/* "+ agent" affordance — always visible (until at cap) so users can
-             add a 2nd/3rd/4th agent without remembering Cmd+Shift+A. */}
-        {activeTab.pinnedAgentIds.length < 4 && (
-          <button
-            ref={agentChipRef}
-            type="button"
-            aria-label="Add agent"
-            aria-haspopup="listbox"
-            aria-expanded={pickerOpen}
-            onClick={() => {
-              setSettingsOpen(false);
-              setSwitcherOpen(false);
-              setManagerOpen(false);
-              setPickerOpen((p) => !p);
-            }}
-            className={
-              activeTab.pinnedAgentIds.length === 0
-                ? "flex items-center gap-1 px-2 py-0.5 rounded-full bg-shell-bg-deep border border-shell-border-subtle text-xs hover:bg-shell-hover"
-                : "flex items-center justify-center w-5 h-5 rounded-full bg-shell-bg-deep border border-shell-border-subtle text-xs hover:bg-shell-hover"
-            }
-            title={activeTab.pinnedAgentIds.length === 0 ? undefined : "Add agent"}
-          >
-            {activeTab.pinnedAgentIds.length === 0 ? "+ agent" : "+"}
-          </button>
-        )}
-        {pickerOpen && (
-          <AgentPickerPopover
-            windowId={windowId}
-            tabId={activeTab.id}
-            profileId={win.profileId}
-            pinnedAgentIds={activeTab.pinnedAgentIds}
-            onClose={() => setPickerOpen(false)}
-            triggerRef={agentChipRef}
-          />
-        )}
-      </div>
-
-      {/* Settings button */}
-      <div className="relative">
+        {/* Nav buttons */}
         <button
           type="button"
-          aria-label="Settings"
-          title="Settings"
-          aria-haspopup="dialog"
-          aria-expanded={settingsOpen}
-          onClick={() => {
-            setSwitcherOpen(false);
-            setManagerOpen(false);
-            setPickerOpen(false);
-            setSettingsOpen((s) => !s);
-          }}
-          className="p-1 rounded hover:bg-shell-hover"
+          aria-label="Back"
+          onClick={() => goBack(windowId, activeTab.id)}
+          disabled={!canGoBack}
+          className={navBtn}
         >
-          <Settings size={16} />
+          <ArrowLeft size={18} />
         </button>
-        {settingsOpen && (
-          <SettingsPanel profileId={currentProfileId} onClose={() => setSettingsOpen(false)} />
-        )}
-      </div>
 
-      {/* Profile chip — clicking opens the ProfileSwitcher dropdown */}
-      <div className="relative">
-        {(() => {
-          const activeProfile = profiles?.find((p) => p.profile_id === win.profileId);
-          const chipColor = activeProfile?.color ?? "#8b92a3";
-          const chipName = activeProfile?.name ?? win.profileId;
-          return (
+        <button
+          type="button"
+          aria-label="Forward"
+          onClick={() => goForward(windowId, activeTab.id)}
+          disabled={!canGoForward}
+          className={navBtn}
+        >
+          <ArrowRight size={18} />
+        </button>
+
+        <button
+          type="button"
+          aria-label="Refresh"
+          onClick={handleRefresh}
+          className={navBtn}
+        >
+          <RotateCw size={18} />
+        </button>
+
+        <button
+          type="button"
+          aria-label="Home"
+          title="Home"
+          onClick={() => navigateTab(windowId, activeTab.id, HOME_URL)}
+          className={navBtn}
+        >
+          <Home size={18} />
+        </button>
+
+        {/* Omnibox: pill wrapper around the address bar with a security lock. */}
+        <div className="flex flex-1 min-w-0 items-center gap-2 h-[36px] px-3.5 rounded-full bg-shell-bg-deep border border-shell-border transition-colors hover:border-shell-border-strong focus-within:border-accent/40 focus-within:ring-2 focus-within:ring-accent/20">
+          {hasUrl && (
+            <Lock
+              size={13}
+              aria-label={isSecure ? "Connection is secure" : "Connection is not secure"}
+              className={`shrink-0 ${isSecure ? "text-[var(--color-traffic-maximize)]" : "text-shell-text-tertiary"}`}
+            />
+          )}
+          <AddressBar windowId={windowId} />
+        </div>
+
+        {/* Agent presence pill + "+ agent" affordance */}
+        <div className="relative flex items-center gap-1">
+          {activeTab.pinnedAgentIds.length > 0 && (
+            <AgentPresencePill
+              windowId={windowId}
+              tabId={activeTab.id}
+              pinnedAgentIds={activeTab.pinnedAgentIds}
+              triggerRef={agentChipRef}
+            />
+          )}
+          {/* "+ agent" affordance: always visible (until at cap) so users can
+               add a 2nd/3rd/4th agent without remembering Cmd+Shift+A. */}
+          {activeTab.pinnedAgentIds.length < 4 && (
             <button
+              ref={agentChipRef}
               type="button"
+              aria-label="Add agent"
+              aria-haspopup="listbox"
+              aria-expanded={pickerOpen}
               onClick={() => {
                 setSettingsOpen(false);
+                setSwitcherOpen(false);
                 setManagerOpen(false);
-                setPickerOpen(false);
-                setSwitcherOpen((s) => !s);
+                setPickerOpen((p) => !p);
               }}
-              className="flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-shell-bg-deep border border-shell-border-subtle text-xs hover:bg-shell-hover"
-              aria-label={`Profile: ${win.profileId}`}
-              aria-haspopup="menu"
-              aria-expanded={switcherOpen}
+              className={
+                activeTab.pinnedAgentIds.length === 0
+                  ? "flex h-[32px] items-center gap-1.5 rounded-full border border-accent-line bg-accent-soft px-3 text-[11.5px] font-semibold text-accent-strong transition-colors hover:bg-accent-glow"
+                  : "flex h-5 w-5 items-center justify-center rounded-full border border-shell-border bg-shell-bg-deep text-xs text-shell-text-secondary transition-colors hover:bg-white/[0.06] hover:text-shell-text"
+              }
+              title={activeTab.pinnedAgentIds.length === 0 ? undefined : "Add agent"}
             >
-              <span
-                className="inline-block w-2 h-2 rounded-full"
-                style={{ backgroundColor: chipColor }}
-                aria-hidden="true"
-              />
-              <span className="capitalize">{chipName}</span>
+              {activeTab.pinnedAgentIds.length === 0 ? "+ agent" : "+"}
             </button>
-          );
-        })()}
-        {switcherOpen && (
-          <ProfileSwitcher
-            windowId={windowId}
-            onClose={() => setSwitcherOpen(false)}
-            onManage={() => {
+          )}
+          {pickerOpen && (
+            <AgentPickerPopover
+              windowId={windowId}
+              tabId={activeTab.id}
+              profileId={win.profileId}
+              pinnedAgentIds={activeTab.pinnedAgentIds}
+              onClose={() => setPickerOpen(false)}
+              triggerRef={agentChipRef}
+            />
+          )}
+        </div>
+
+        {/* Settings button */}
+        <div className="relative">
+          <button
+            type="button"
+            aria-label="Settings"
+            title="Settings"
+            aria-haspopup="dialog"
+            aria-expanded={settingsOpen}
+            onClick={() => {
               setSwitcherOpen(false);
-              setManagerOpen(true);
+              setManagerOpen(false);
+              setPickerOpen(false);
+              setSettingsOpen((s) => !s);
             }}
+            className={navBtn}
+          >
+            <Settings size={18} />
+          </button>
+          {settingsOpen && (
+            <SettingsPanel profileId={currentProfileId} onClose={() => setSettingsOpen(false)} />
+          )}
+        </div>
+
+        {/* Profile chip: clicking opens the ProfileSwitcher dropdown */}
+        <div className="relative">
+          {(() => {
+            const activeProfile = profiles?.find((p) => p.profile_id === win.profileId);
+            const chipColor = activeProfile?.color ?? "#8b92a3";
+            const chipName = activeProfile?.name ?? win.profileId;
+            const initial = (chipName?.[0] ?? "?").toUpperCase();
+            return (
+              <button
+                type="button"
+                onClick={() => {
+                  setSettingsOpen(false);
+                  setManagerOpen(false);
+                  setPickerOpen(false);
+                  setSwitcherOpen((s) => !s);
+                }}
+                className="flex h-[34px] items-center gap-2 rounded-full border border-shell-border bg-shell-bg-deep pl-1.5 pr-2.5 transition-colors hover:bg-white/[0.06] hover:border-shell-border-strong"
+                aria-label={`Profile: ${win.profileId}`}
+                aria-haspopup="menu"
+                aria-expanded={switcherOpen}
+              >
+                <span
+                  className="flex h-[22px] w-[22px] items-center justify-center rounded-full text-[10px] font-bold text-white"
+                  style={{ backgroundColor: chipColor }}
+                  aria-hidden="true"
+                >
+                  {initial}
+                </span>
+                <span className="text-xs font-semibold capitalize text-shell-text">{chipName}</span>
+                <ChevronDown size={12} className="text-shell-text-tertiary" aria-hidden="true" />
+              </button>
+            );
+          })()}
+          {switcherOpen && (
+            <ProfileSwitcher
+              windowId={windowId}
+              onClose={() => setSwitcherOpen(false)}
+              onManage={() => {
+                setSwitcherOpen(false);
+                setManagerOpen(true);
+              }}
+            />
+          )}
+        </div>
+        {managerOpen && (
+          <ProfileManager
+            activeProfileId={win.profileId}
+            onClose={() => setManagerOpen(false)}
           />
         )}
       </div>
-      {managerOpen && (
-        <ProfileManager
-          activeProfileId={win.profileId}
-          onClose={() => setManagerOpen(false)}
-        />
-      )}
-    </div>
     </div>
   );
 }
-

--- a/desktop/src/apps/BrowserApp/ProfileSwitcher.tsx
+++ b/desktop/src/apps/BrowserApp/ProfileSwitcher.tsx
@@ -64,19 +64,20 @@ export function ProfileSwitcher({
       ref={ref}
       role="menu"
       aria-label="Switch profile"
-      className="absolute z-[60] min-w-[220px] rounded-md bg-shell-surface border border-shell-border shadow-lg py-1 text-xs"
+      className="absolute right-0 z-[60] mt-1.5 w-[262px] rounded-xl border border-shell-border-strong bg-shell-bg-glass p-1.5 text-xs shadow-window backdrop-blur-xl"
     >
-      <div className="px-2 py-1 text-shell-text-tertiary uppercase tracking-wide text-[10px]">
+      <div className="px-2.5 pb-1.5 pt-1.5 text-[10px] font-bold uppercase tracking-[0.07em] text-shell-text-tertiary">
         Profiles
       </div>
 
       {profiles === null ? (
-        <div className="px-2 py-1 opacity-60 italic">Loading…</div>
+        <div className="px-2.5 py-1.5 italic text-shell-text-tertiary">Loading…</div>
       ) : profiles.length === 0 ? (
-        <div className="px-2 py-1 opacity-60 italic">No profiles</div>
+        <div className="px-2.5 py-1.5 italic text-shell-text-tertiary">No profiles</div>
       ) : (
         profiles.map((p) => {
           const isActive = p.profile_id === win.profileId;
+          const initial = (p.name?.[0] ?? "?").toUpperCase();
           return (
             <button
               key={p.profile_id}
@@ -87,26 +88,35 @@ export function ProfileSwitcher({
                 if (!isActive) switchProfile(windowId, p.profile_id);
                 onClose();
               }}
-              className="w-full text-left px-2 py-1 hover:bg-shell-hover flex items-center gap-2"
+              className="flex w-full items-center gap-2.5 rounded-[9px] px-2.5 py-2 text-left transition-colors hover:bg-white/[0.06]"
             >
               <span
-                className="inline-block w-2 h-2 rounded-full shrink-0"
+                className="flex h-[26px] w-[26px] shrink-0 items-center justify-center rounded-full text-[11px] font-bold text-white"
                 style={{ backgroundColor: p.color ?? "#8b92a3" }}
                 aria-hidden="true"
-              />
-              <span className="capitalize flex-1">{p.name}</span>
+              >
+                {initial}
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-[13px] font-semibold capitalize text-shell-text">
+                  {p.name}
+                </span>
+                <span className="block truncate text-[11px] text-shell-text-secondary">
+                  {isActive ? "Signed in" : "Isolated cookies and storage"}
+                </span>
+              </span>
               {isActive && (
-                <Check size={12} className="opacity-70" aria-label="Active" />
+                <Check size={15} className="shrink-0 text-accent-strong" aria-label="Active" />
               )}
             </button>
           );
         })
       )}
 
-      <div className="border-t border-shell-border-subtle my-1" />
+      <div className="my-1.5 mx-1 h-px bg-shell-border" />
 
       {creating ? (
-        <div className="px-2 py-1 flex gap-1">
+        <div className="px-2 py-1">
           <input
             type="text"
             aria-label="New profile name"
@@ -121,7 +131,7 @@ export function ProfileSwitcher({
               }
             }}
             placeholder="Profile name"
-            className="flex-1 bg-shell-bg-deep border border-shell-border-subtle rounded px-1.5 py-0.5 text-xs outline-none focus:border-accent"
+            className="w-full rounded-lg border border-shell-border bg-shell-bg-deep px-2 py-1.5 text-xs text-shell-text outline-none focus:border-accent/40"
           />
         </div>
       ) : (
@@ -129,9 +139,9 @@ export function ProfileSwitcher({
           type="button"
           role="menuitem"
           onClick={() => setCreating(true)}
-          className="w-full text-left px-2 py-1 hover:bg-shell-hover flex items-center gap-1.5"
+          className="flex w-full items-center gap-2.5 rounded-[9px] px-2.5 py-2 text-left font-semibold text-shell-text-secondary transition-colors hover:bg-white/[0.06] hover:text-shell-text"
         >
-          <Plus size={12} />
+          <Plus size={15} />
           New profile
         </button>
       )}
@@ -144,10 +154,10 @@ export function ProfileSwitcher({
             onManage();
             onClose();
           }}
-          className="w-full text-left px-2 py-1 hover:bg-shell-hover flex items-center gap-1.5"
+          className="flex w-full items-center gap-2.5 rounded-[9px] px-2.5 py-2 text-left font-semibold text-shell-text-secondary transition-colors hover:bg-white/[0.06] hover:text-shell-text"
         >
-          <Settings size={12} />
-          Manage profiles…
+          <Settings size={15} />
+          Manage profiles
         </button>
       )}
     </div>

--- a/desktop/src/apps/BrowserApp/SettingsPanel.tsx
+++ b/desktop/src/apps/BrowserApp/SettingsPanel.tsx
@@ -92,7 +92,7 @@ export function SettingsPanel({ profileId, onClose }: SettingsPanelProps) {
       ref={ref}
       role="dialog"
       aria-label="Browser settings"
-      className="absolute right-0 top-full mt-1 z-[60] w-72 rounded-lg border border-shell-border-subtle bg-shell-surface shadow-xl p-4 flex flex-col gap-4"
+      className="absolute right-0 top-full mt-1.5 z-[60] w-72 rounded-xl border border-shell-border-strong bg-shell-bg-glass shadow-window backdrop-blur-xl p-4 flex flex-col gap-4"
     >
       {/* Header */}
       <div className="flex items-center justify-between">
@@ -101,7 +101,7 @@ export function SettingsPanel({ profileId, onClose }: SettingsPanelProps) {
           type="button"
           aria-label="Close settings"
           onClick={onClose}
-          className="p-1 rounded hover:bg-shell-hover text-shell-text-secondary"
+          className="p-1 rounded hover:bg-white/[0.06] text-shell-text-secondary"
         >
           <X size={14} />
         </button>
@@ -145,7 +145,7 @@ export function SettingsPanel({ profileId, onClose }: SettingsPanelProps) {
           max={50}
           value={maxLiveTabs}
           onChange={(e) => setMaxLiveTabs(Number(e.target.value))}
-          className="bg-shell-bg-deep text-shell-text text-xs px-2 py-1 rounded border border-shell-border-subtle focus:border-accent focus:outline-none w-20"
+          className="bg-shell-bg-deep text-shell-text text-xs px-2 py-1 rounded border border-shell-border focus:border-accent focus:outline-none w-20"
         />
       </div>
 
@@ -158,7 +158,7 @@ export function SettingsPanel({ profileId, onClose }: SettingsPanelProps) {
           id="search-engine-select"
           value={searchEngine}
           onChange={(e) => setSearchEngine(e.target.value)}
-          className="bg-shell-bg-deep text-shell-text text-xs px-2 py-1 rounded border border-shell-border-subtle focus:border-accent focus:outline-none"
+          className="bg-shell-bg-deep text-shell-text text-xs px-2 py-1 rounded border border-shell-border focus:border-accent focus:outline-none"
         >
           {(Object.keys(SEARCH_ENGINES) as SearchEngine[]).map((engine) => (
             <option key={engine} value={engine}>
@@ -169,7 +169,7 @@ export function SettingsPanel({ profileId, onClose }: SettingsPanelProps) {
       </div>
 
       {/* Agent capabilities */}
-      <div className="border-t border-shell-border-subtle pt-3">
+      <div className="border-t border-shell-border pt-3">
         <button
           type="button"
           onClick={() => setCapsOpen(true)}
@@ -188,7 +188,7 @@ export function SettingsPanel({ profileId, onClose }: SettingsPanelProps) {
       )}
 
       {/* Site permissions */}
-      <div className="border-t border-shell-border-subtle pt-3">
+      <div className="border-t border-shell-border pt-3">
         <button
           type="button"
           onClick={() => setSitePermsOpen(true)}
@@ -207,7 +207,7 @@ export function SettingsPanel({ profileId, onClose }: SettingsPanelProps) {
       )}
 
       {/* Notifications */}
-      <div className="border-t border-shell-border-subtle pt-3 flex flex-col gap-2">
+      <div className="border-t border-shell-border pt-3 flex flex-col gap-2">
         <span className="text-xs text-shell-text-secondary">Notifications</span>
         <button
           type="button"
@@ -216,9 +216,9 @@ export function SettingsPanel({ profileId, onClose }: SettingsPanelProps) {
           className={[
             "w-full text-left text-xs px-2 py-1.5 rounded border transition-colors",
             notifPermission === "granted"
-              ? "border-shell-border-subtle text-shell-text-secondary cursor-default"
+              ? "border-shell-border text-shell-text-secondary cursor-default"
               : notifPermission === "denied"
-              ? "border-shell-border-subtle text-shell-text-secondary cursor-default opacity-60"
+              ? "border-shell-border text-shell-text-secondary cursor-default opacity-60"
               : "border-accent text-accent hover:bg-accent/10 cursor-pointer",
           ].join(" ")}
         >

--- a/desktop/src/apps/BrowserApp/TabStrip.tsx
+++ b/desktop/src/apps/BrowserApp/TabStrip.tsx
@@ -2,12 +2,14 @@
  * BrowserApp v2 — TabStrip.
  *
  * Compact tab strip per Q8 layout A:
- *  - Pinned tabs (favicon-only, ~32px wide) on the left, in their own group
+ *  - Pinned tabs (favicon-only, ~38px wide) on the left, in their own group
  *  - Inactive unpinned tabs (favicon + truncated title, ~140px wide)
- *  - Active tab is wider (~360px); for PR 4 the URL renders as plain text
- *    inside it. PR 4 Task 7 (AddressBar) replaces the URL text with an
- *    embedded input field.
- *  - `+` button at the right edge opens a new tab.
+ *  - Active tab is wider (~360px); the URL renders inside the toolbar omnibox.
+ *  - `+` button opens a new tab.
+ *  - A Proxy/Streamed segmented toggle sits at the right of the strip. Proxy is
+ *    the URL-rewriting iframe browser; Streamed escalates the active tab to a
+ *    real Chromium session streamed from the host over WebRTC (the existing
+ *    Neko/liveSession path).
  *
  * Each tab exposes:
  *  - role="tab" + aria-selected
@@ -22,6 +24,7 @@ import { Plus, X, Globe } from "lucide-react";
 import { useBrowserStore } from "@/stores/browser-store";
 import { useBrowserAgentStore } from "@/stores/browser-agent-store";
 import { MoveTabMenu } from "./MoveTabMenu";
+import { BrowserModeToggle } from "./BrowserModeToggle";
 import type { Tab } from "./types";
 
 interface TabStripProps {
@@ -50,7 +53,7 @@ export function TabStrip({ windowId }: TabStripProps) {
     <div
       role="tablist"
       aria-label="Browser tabs"
-      className="flex items-end gap-1 px-2 pt-1 bg-shell-bg border-b border-shell-border-subtle min-h-[36px]"
+      className="flex items-end gap-1 px-3 pt-1.5 bg-shell-bg-deep border-b border-shell-border min-h-[42px]"
     >
       {ordered.map((tab) => (
         <TabItem
@@ -71,10 +74,15 @@ export function TabStrip({ windowId }: TabStripProps) {
         type="button"
         aria-label="New tab"
         onClick={() => addTab(windowId)}
-        className="ml-1 p-1 rounded hover:bg-shell-hover"
+        className="mb-1 ml-0.5 flex h-[30px] w-[30px] items-center justify-center rounded-lg text-shell-text-secondary transition-colors hover:bg-white/[0.06] hover:text-shell-text"
       >
-        <Plus size={14} />
+        <Plus size={15} />
       </button>
+
+      {/* Proxy / Streamed segmented toggle, pushed to the right edge. */}
+      <div className="mb-1 ml-auto self-center">
+        <BrowserModeToggle windowId={windowId} />
+      </div>
 
       {contextMenu && (
         <MoveTabMenu
@@ -100,7 +108,7 @@ interface TabItemProps {
 function TabItem({ windowId, tab, isActive, onActivate, onClose, onContextMenu }: TabItemProps) {
   const titleText = tab.title || tab.url || "New tab";
 
-  // Green underline when any pinned agent on this tab is in driving state
+  // Slate accent underline when any pinned agent on this tab is in driving state.
   const tabDriving = useBrowserAgentStore((s) => {
     for (const aid of tab.pinnedAgentIds ?? []) {
       if (s.drivingState[`${windowId}:${tab.id}:${aid}`] === "driving") return true;
@@ -108,10 +116,12 @@ function TabItem({ windowId, tab, isActive, onActivate, onClose, onContextMenu }
     return false;
   });
 
-  // Width per Q8 layout A. Pinned: 32px (favicon-only). Inactive: 140px.
-  // Active: 360px (will host the embedded AddressBar in Task 7).
+  const hasAgent = (tab.pinnedAgentIds?.length ?? 0) > 0;
+
+  // Width per Q8 layout A. Pinned: 38px (favicon-only). Inactive: 140px.
+  // Active: 360px.
   const widthClass = tab.pinned
-    ? "w-[32px]"
+    ? "w-[38px] justify-center"
     : isActive
     ? "w-[360px]"
     : "w-[140px]";
@@ -126,23 +136,29 @@ function TabItem({ windowId, tab, isActive, onActivate, onClose, onContextMenu }
       onContextMenu={onContextMenu}
       className={[
         widthClass,
-        "group",
-        "h-[28px] px-2 flex items-center gap-1.5 rounded-t cursor-pointer",
-        "border-t border-l border-r border-shell-border-subtle",
+        "group relative",
+        "h-[31px] px-2.5 flex items-center gap-2 rounded-t-[9px] cursor-pointer",
+        "border border-b-0 transition-colors",
         isActive
-          ? "bg-shell-surface text-shell-text"
-          : "bg-shell-bg-deep text-shell-text-secondary hover:bg-shell-hover",
-        tabDriving ? "border-b-2 border-green-500" : "",
+          ? "bg-shell-surface text-shell-text border-shell-border-strong"
+          : "border-transparent text-shell-text-secondary hover:bg-white/[0.06] hover:text-shell-text",
+        // Agent-owned session tab: slate accent line on the bottom edge,
+        // brighter while the agent is actively driving.
+        tabDriving
+          ? "shadow-[inset_0_-2px_0_var(--color-accent-strong)]"
+          : hasAgent
+          ? "shadow-[inset_0_-2px_0_var(--color-accent-line)]"
+          : "",
       ].join(" ")}
     >
       {/* Drag handle — Task 11 wires drag events on this child */}
       <div
         data-drag-handle
-        className="flex items-center gap-1.5 flex-1 min-w-0"
+        className="flex items-center gap-2 flex-1 min-w-0"
       >
-        <Globe size={12} className="shrink-0 opacity-60" aria-hidden="true" />
+        <Globe size={13} className="shrink-0 opacity-50" aria-hidden="true" />
         {!tab.pinned && (
-          <span className="truncate text-xs flex-1">{titleText}</span>
+          <span className="truncate text-[12.5px] font-medium flex-1">{titleText}</span>
         )}
       </div>
 
@@ -154,9 +170,12 @@ function TabItem({ windowId, tab, isActive, onActivate, onClose, onContextMenu }
             e.stopPropagation();
             onClose();
           }}
-          className="opacity-0 group-hover:opacity-100 hover:opacity-100 hover:bg-shell-hover rounded p-0.5 shrink-0"
+          className={[
+            "flex h-[17px] w-[17px] items-center justify-center rounded-[5px] shrink-0 text-shell-text-tertiary transition-opacity hover:bg-white/[0.08] hover:text-shell-text",
+            isActive ? "opacity-100" : "opacity-0 group-hover:opacity-100",
+          ].join(" ")}
         >
-          <X size={12} />
+          <X size={11} />
         </button>
       )}
     </div>


### PR DESCRIPTION
Jay-approved mock (.design/browser-redesign-mock.html). Restyles the Browser app chrome to the design bar; browser/proxy/stream logic untouched.

## What changed (presentation + structure)
- Tab strip: rounded-top tabs, favicon chips, an agent-driving accent underline; hosts a new Proxy/Streamed segmented engine toggle (BrowserModeToggle).
- Toolbar/omnibox: added Home; AddressBar wrapped in a pill with a connection-security lock (green on https).
- Profile chip + dropdown: avatar rows + subtitles + active check + New/Manage.
- Settings popover + AgentPresencePill retokenized. Replaced dead shell-hover/shell-border-subtle utilities with real tokens.

## Proxy vs Streamed
Modeled on the real engine choice: Proxy = the URL-rewriting iframe; Streamed = a tab with a liveSession, wired to the existing escalate lifecycle (POST /api/browser/sessions -> poll -> setTabLiveSession), with the no_capable_node gate hint.

## Verify
tsc clean, build succeeds. Touched-component suites 35/35 green; 7 failures are PRE-EXISTING on origin/dev (keyboard/AddressBar/ProfileSwitcher), verified via stash, not from this change. Live Pi verify after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added browser mode toggle to switch between Proxy and Streamed engine modes.

* **UI Updates**
  * Enhanced toolbar with security indicator and improved navigation controls.
  * Refreshed profile switcher with clearer layout and status indicators.
  * Updated tab strip appearance with refined visual indicators.
  * Adjusted styling for address bar, settings panel, and agent controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->