### PR TITLE
feat(mail): Mail app phase 1 (IMAP/SMTP accounts, list/read/send) (#60)

### DIFF
--- a/desktop/src/apps/MailApp/MailApp.module.css
+++ b/desktop/src/apps/MailApp/MailApp.module.css
@@ -1,0 +1,1061 @@
+/* ==================================================================
+   Mail app, Store / Images / GitHub visual bar
+   ------------------------------------------------------------------
+   All colour comes from the live semantic theme tokens
+   (--color-shell-*, --color-accent). The active theme overwrites those
+   tokens per scheme at runtime (see theme-store.applyThemeConfig), so
+   dark and light both resolve correctly with no hardcoded hex here.
+   Soft accent / status tints are mixed from the tokens with color-mix.
+   ================================================================== */
+
+.root {
+  /* local aliases so the rules below read like the approved mock */
+  --ml-bg: var(--color-shell-bg);
+  --ml-bg-deep: var(--color-shell-bg-deep);
+  --ml-surface: var(--color-shell-surface);
+  --ml-surface-hover: var(--color-shell-surface-hover);
+  --ml-surface-active: var(--color-shell-surface-active);
+  --ml-border: var(--color-shell-border);
+  --ml-border-strong: var(--color-shell-border-strong);
+  --ml-text: var(--color-shell-text);
+  --ml-text-2: var(--color-shell-text-secondary);
+  --ml-text-3: var(--color-shell-text-tertiary);
+  --ml-accent: var(--color-accent);
+  --ml-accent-strong: var(--color-accent-strong);
+  --ml-accent-glow: var(--color-accent-glow);
+  --ml-accent-soft: var(--color-accent-soft);
+  --ml-accent-line: var(--color-accent-line);
+  --ml-unread: var(--color-unread);
+  --ml-topbar: var(--color-topbar-bg);
+  --ml-flag: color-mix(in srgb, #ffb340 82%, var(--color-shell-text));
+  --ml-on-accent: #15161a;
+  --ml-shadow: var(--shadow-card-hover);
+  --ml-radius-lg: 16px;
+  --ml-radius-md: 13px;
+  --ml-radius-sm: 10px;
+
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  background: var(--ml-bg);
+  color: var(--ml-text);
+  font-size: 13px;
+}
+
+/* app header bar (Store/Images-style top strip) */
+.appbar {
+  flex: none;
+  height: 46px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0 16px;
+  border-bottom: 1px solid var(--ml-border);
+}
+.appbar h1 {
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+.appbarRight {
+  margin-left: auto;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+.composebtn {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--ml-on-accent);
+  background: linear-gradient(135deg, var(--ml-accent-strong), var(--ml-accent));
+  border: none;
+  border-radius: 999px;
+  padding: 6px 14px;
+  cursor: pointer;
+  box-shadow: 0 6px 16px -8px var(--ml-accent-glow);
+  transition: all 0.15s;
+}
+.composebtn:hover {
+  transform: translateY(-1px);
+  filter: brightness(1.05);
+}
+
+.body {
+  flex: 1;
+  display: flex;
+  min-height: 0;
+}
+
+/* ============ LEFT SIDEBAR ============ */
+.sidebar {
+  width: 240px;
+  flex: none;
+  border-right: 1px solid var(--ml-border);
+  display: flex;
+  flex-direction: column;
+  background: var(--ml-bg-deep);
+}
+
+/* account switcher */
+.acct {
+  flex: none;
+  border-bottom: 1px solid var(--ml-border);
+  padding: 10px;
+}
+.acctCur {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 9px;
+  border-radius: var(--ml-radius-md);
+  cursor: pointer;
+  transition: all 0.15s;
+  border: 1px solid transparent;
+  width: 100%;
+  background: none;
+  text-align: left;
+  color: inherit;
+  font: inherit;
+}
+.acctCur:hover {
+  background: var(--ml-surface-hover);
+  border-color: var(--ml-border);
+}
+.av {
+  border-radius: 50%;
+  flex: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  color: var(--ml-on-accent);
+  letter-spacing: -0.02em;
+}
+.avUser {
+  background: linear-gradient(135deg, var(--ml-accent), var(--ml-accent-strong));
+}
+.avAgent {
+  background: color-mix(in srgb, var(--ml-accent) 30%, var(--ml-bg-deep));
+  color: var(--ml-text);
+}
+.acctCur .av {
+  width: 34px;
+  height: 34px;
+  font-size: 14px;
+}
+.acctBody {
+  min-width: 0;
+  flex: 1;
+}
+.acctName {
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.acctAddr {
+  font-size: 11px;
+  color: var(--ml-text-3);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-top: 1px;
+}
+.acctChev {
+  color: var(--ml-text-3);
+  transition: transform 0.2s;
+  display: flex;
+}
+.open .acctChev {
+  transform: rotate(180deg);
+}
+
+/* account dropdown */
+.acctMenu {
+  margin-top: 6px;
+  padding: 5px;
+  background: var(--ml-surface);
+  border: 1px solid var(--ml-border);
+  border-radius: var(--ml-radius-md);
+}
+.acctGrp {
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--ml-text-3);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  padding: 8px 9px 5px;
+}
+.acctRow {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 7px 9px;
+  border-radius: var(--ml-radius-sm);
+  cursor: pointer;
+  transition: all 0.15s;
+  width: 100%;
+  background: none;
+  border: none;
+  text-align: left;
+  color: inherit;
+  font: inherit;
+}
+.acctRow:hover {
+  background: var(--ml-surface-hover);
+}
+.acctRow.sel {
+  background: var(--ml-surface-active);
+}
+.acctRow .av {
+  width: 26px;
+  height: 26px;
+  font-size: 11px;
+}
+.acctRowBody {
+  min-width: 0;
+  flex: 1;
+}
+.acctRowName {
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.acctRowAddr {
+  font-size: 10.5px;
+  color: var(--ml-text-3);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-top: 1px;
+}
+.pillAgent {
+  font-size: 9px;
+  font-weight: 700;
+  color: var(--ml-accent-strong);
+  background: var(--ml-accent-soft);
+  border: 1px solid var(--ml-accent-line);
+  border-radius: 999px;
+  padding: 1px 6px;
+  letter-spacing: 0.03em;
+  flex: none;
+}
+.acctCheck {
+  margin-left: auto;
+  color: var(--ml-accent-strong);
+  flex: none;
+  display: flex;
+}
+/* Phase-2 affordance: agent accounts group is disabled / coming soon */
+.acctGroupDisabled .acctRow {
+  cursor: default;
+  opacity: 0.55;
+}
+.acctGroupDisabled .acctRow:hover {
+  background: none;
+}
+.comingSoon {
+  margin-left: auto;
+  font-size: 9px;
+  font-weight: 700;
+  color: var(--ml-text-3);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  flex: none;
+}
+.acctAdd {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 9px;
+  margin-top: 3px;
+  border-top: 1px solid var(--ml-border);
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--ml-text-2);
+  cursor: pointer;
+  border-radius: var(--ml-radius-sm);
+  width: 100%;
+  background: none;
+  border-left: none;
+  border-right: none;
+  border-bottom: none;
+  text-align: left;
+}
+.acctAdd:hover {
+  color: var(--ml-text);
+}
+
+/* folder list */
+.folders {
+  flex: 1;
+  overflow: auto;
+  padding: 8px 8px 4px;
+}
+.fgrpLbl {
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--ml-text-3);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  padding: 10px 9px 6px;
+}
+.fold {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  padding: 8px 10px;
+  border-radius: var(--ml-radius-md);
+  cursor: pointer;
+  transition: all 0.15s;
+  margin-bottom: 1px;
+  color: var(--ml-text-2);
+  width: 100%;
+  background: none;
+  border: none;
+  text-align: left;
+  font: inherit;
+}
+.fold:hover {
+  background: var(--ml-surface-hover);
+  color: var(--ml-text);
+}
+.fold.on {
+  background: var(--ml-surface-active);
+  color: var(--ml-text);
+}
+.fold.on .foldIco {
+  color: var(--ml-accent-strong);
+}
+.foldIco {
+  flex: none;
+  display: flex;
+  color: var(--ml-text-3);
+}
+.foldName {
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.foldCount {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--ml-text-2);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ============ MIDDLE: MESSAGE LIST ============ */
+.list {
+  width: 360px;
+  flex: none;
+  border-right: 1px solid var(--ml-border);
+  display: flex;
+  flex-direction: column;
+  background: var(--ml-bg);
+  min-width: 0;
+}
+.listHead {
+  flex: none;
+  padding: 12px 14px 0;
+  border-bottom: 1px solid var(--ml-border);
+}
+.listTitle {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 11px;
+}
+.listTitle h2 {
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+.listTitle .sub {
+  font-size: 11.5px;
+  color: var(--ml-text-3);
+  font-variant-numeric: tabular-nums;
+}
+.search {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  background: var(--ml-surface);
+  border: 1px solid var(--ml-border);
+  border-radius: var(--ml-radius-md);
+  padding: 9px 12px;
+  margin-bottom: 11px;
+}
+.search svg {
+  color: var(--ml-text-3);
+  flex: none;
+}
+.search input {
+  flex: 1;
+  background: none;
+  border: none;
+  outline: none;
+  color: var(--ml-text);
+  font-size: 13px;
+  font-family: inherit;
+}
+.search input::placeholder {
+  color: var(--ml-text-3);
+}
+.tabs {
+  display: flex;
+  gap: 2px;
+  padding: 0 0 1px;
+}
+.tab {
+  position: relative;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--ml-text-3);
+  padding: 8px 12px 11px;
+  cursor: pointer;
+  white-space: nowrap;
+  background: none;
+  border: none;
+  transition: color 0.15s;
+  font-family: inherit;
+}
+.tab:hover {
+  color: var(--ml-text-2);
+}
+.tab.on {
+  color: var(--ml-text);
+}
+.tab.on::after {
+  content: "";
+  position: absolute;
+  left: 12px;
+  right: 12px;
+  bottom: -1px;
+  height: 2px;
+  border-radius: 2px;
+  background: var(--ml-accent-strong);
+}
+.tab .n {
+  font-size: 10.5px;
+  color: var(--ml-text-3);
+  margin-left: 5px;
+  font-variant-numeric: tabular-nums;
+}
+
+.rows {
+  flex: 1;
+  overflow: auto;
+}
+.row {
+  display: flex;
+  gap: 11px;
+  padding: 12px 14px;
+  cursor: pointer;
+  position: relative;
+  border-bottom: 1px solid var(--ml-border);
+  transition: background 0.12s;
+  width: 100%;
+  background: none;
+  border-left: none;
+  border-right: none;
+  border-top: none;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+}
+.row:hover {
+  background: var(--ml-surface-hover);
+}
+.row.on {
+  background: var(--ml-surface-active);
+}
+.row.on::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: var(--ml-accent-strong);
+}
+.row .av {
+  width: 38px;
+  height: 38px;
+  font-size: 14px;
+  flex: none;
+  margin-top: 2px;
+}
+.rowMain {
+  min-width: 0;
+  flex: 1;
+}
+.rowTop {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+.rowFrom {
+  font-size: 13.5px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--ml-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+}
+.row.unread .rowFrom {
+  font-weight: 700;
+}
+.rowTime {
+  font-size: 11px;
+  color: var(--ml-text-3);
+  flex: none;
+  font-variant-numeric: tabular-nums;
+}
+.rowSubj {
+  font-size: 12.5px;
+  color: var(--ml-text);
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.row.unread .rowSubj {
+  font-weight: 600;
+}
+.rowSnip {
+  font-size: 12px;
+  color: var(--ml-text-3);
+  margin-top: 2px;
+  line-height: 1.35;
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.rowMeta {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin-top: 6px;
+}
+.udot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--ml-unread);
+  flex: none;
+}
+.mini {
+  color: var(--ml-text-3);
+  display: flex;
+  align-items: center;
+}
+.mini.flag {
+  color: var(--ml-flag);
+}
+
+/* ============ RIGHT: READING PANE ============ */
+.read {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--ml-bg);
+}
+.readToolbar {
+  flex: none;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0 16px;
+  border-bottom: 1px solid var(--ml-border);
+}
+.tbtn {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  height: 32px;
+  padding: 0 11px;
+  border-radius: 9px;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--ml-text-2);
+  background: transparent;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: all 0.15s;
+  font-family: inherit;
+}
+.tbtn:hover {
+  background: var(--ml-surface-hover);
+  color: var(--ml-text);
+  border-color: var(--ml-border);
+}
+.tbtn.pri {
+  color: var(--ml-text);
+  background: var(--ml-surface);
+  border-color: var(--ml-border);
+}
+.tbSep {
+  width: 1px;
+  height: 20px;
+  background: var(--ml-border);
+  margin: 0 4px;
+}
+.iconbtn {
+  width: 30px;
+  height: 30px;
+  border-radius: 9px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--ml-text-2);
+  background: transparent;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.iconbtn:hover {
+  background: var(--ml-surface-hover);
+  color: var(--ml-text);
+  border-color: var(--ml-border);
+}
+.readToolbar .right {
+  margin-left: auto;
+  display: flex;
+  gap: 2px;
+  position: relative;
+}
+
+.readScroll {
+  flex: 1;
+  overflow: auto;
+  padding: 24px 30px;
+}
+.readSubj {
+  font-size: 21px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.25;
+}
+.readFrom {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 18px;
+  padding-bottom: 18px;
+  border-bottom: 1px solid var(--ml-border);
+}
+.readFrom .av {
+  width: 42px;
+  height: 42px;
+  font-size: 16px;
+  flex: none;
+}
+.rfBody {
+  min-width: 0;
+  flex: 1;
+}
+.rfName {
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.rfAddr {
+  font-size: 12px;
+  color: var(--ml-text-3);
+  margin-top: 1px;
+}
+.rfTo {
+  font-size: 11.5px;
+  color: var(--ml-text-3);
+  margin-top: 3px;
+}
+.rfTo b {
+  color: var(--ml-text-2);
+  font-weight: 600;
+}
+.readDate {
+  font-size: 11.5px;
+  color: var(--ml-text-3);
+  flex: none;
+  text-align: right;
+  line-height: 1.5;
+  font-variant-numeric: tabular-nums;
+}
+
+.readBody {
+  padding: 22px 0 8px;
+  font-size: 14px;
+  line-height: 1.65;
+  color: var(--ml-text);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.attach {
+  display: flex;
+  gap: 11px;
+  flex-wrap: wrap;
+  margin-top: 6px;
+  padding-top: 18px;
+  border-top: 1px solid var(--ml-border);
+}
+.attLbl {
+  flex-basis: 100%;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--ml-text-3);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 2px;
+}
+.att {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: var(--ml-surface);
+  border: 1px solid var(--ml-border);
+  border-radius: var(--ml-radius-md);
+  padding: 9px 13px 9px 10px;
+}
+.attIco {
+  width: 34px;
+  height: 34px;
+  border-radius: 9px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+  background: color-mix(in srgb, var(--ml-accent) 30%, var(--ml-bg-deep));
+  color: var(--ml-text);
+}
+.attName {
+  font-size: 12.5px;
+  font-weight: 600;
+}
+.attSize {
+  font-size: 11px;
+  color: var(--ml-text-3);
+  margin-top: 1px;
+  font-variant-numeric: tabular-nums;
+}
+
+/* empty + loading states */
+.empty {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  color: var(--ml-text-3);
+  text-align: center;
+  padding: 32px;
+}
+.empty p {
+  font-size: 13px;
+  max-width: 280px;
+}
+.error {
+  margin: 16px;
+  padding: 12px 14px;
+  border-radius: var(--ml-radius-md);
+  background: color-mix(in srgb, #e5484d 14%, transparent);
+  border: 1px solid color-mix(in srgb, #e5484d 32%, transparent);
+  color: color-mix(in srgb, #e5484d 72%, var(--ml-text));
+  font-size: 12.5px;
+}
+.skel {
+  height: 64px;
+  margin: 8px 14px;
+  border-radius: var(--ml-radius-md);
+  background: var(--ml-surface);
+}
+
+/* share / send-to stub menu */
+.menu {
+  position: absolute;
+  right: 0;
+  top: 36px;
+  min-width: 180px;
+  padding: 5px;
+  background: var(--ml-bg);
+  border: 1px solid var(--ml-border-strong);
+  border-radius: var(--ml-radius-md);
+  box-shadow: var(--ml-shadow);
+  z-index: 20;
+}
+.menuItem {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  width: 100%;
+  padding: 8px 10px;
+  border-radius: var(--ml-radius-sm);
+  background: none;
+  border: none;
+  color: var(--ml-text-2);
+  font: inherit;
+  font-size: 12.5px;
+  text-align: left;
+  cursor: pointer;
+}
+.menuItem:hover {
+  background: var(--ml-surface-hover);
+  color: var(--ml-text);
+}
+.menuNote {
+  padding: 6px 10px 4px;
+  font-size: 10.5px;
+  color: var(--ml-text-3);
+}
+
+/* ============ COMPOSE OVERLAY ============ */
+.scrim {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  padding: 0 22px 22px;
+  z-index: 10;
+}
+.compose {
+  width: 620px;
+  max-width: 100%;
+  height: 560px;
+  max-height: 100%;
+  background: var(--ml-bg);
+  border: 1px solid var(--ml-border-strong);
+  border-radius: var(--ml-radius-lg);
+  box-shadow: var(--ml-shadow);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.cmpHead {
+  flex: none;
+  height: 46px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0 14px 0 18px;
+  background: var(--ml-topbar);
+  border-bottom: 1px solid var(--ml-border);
+}
+.cmpHead h3 {
+  font-size: 13.5px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+.cmpHead .right {
+  margin-left: auto;
+  display: flex;
+  gap: 2px;
+}
+.cmpFields {
+  flex: none;
+  display: flex;
+  flex-direction: column;
+}
+.cmpField {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 11px 18px;
+  border-bottom: 1px solid var(--ml-border);
+}
+.cmpField .k {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--ml-text-3);
+  width: 56px;
+  flex: none;
+}
+.cmpField input {
+  flex: 1;
+  min-width: 0;
+  background: none;
+  border: none;
+  outline: none;
+  color: var(--ml-text);
+  font-size: 13px;
+  font-family: inherit;
+}
+.cmpField input::placeholder {
+  color: var(--ml-text-3);
+}
+.fromStatic {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  flex: 1;
+  min-width: 0;
+}
+.fromStatic .av {
+  width: 24px;
+  height: 24px;
+  font-size: 10.5px;
+  flex: none;
+}
+.faName {
+  font-size: 12.5px;
+  font-weight: 600;
+}
+.faAddr {
+  font-size: 11px;
+  color: var(--ml-text-3);
+}
+.sendasHint {
+  font-size: 10.5px;
+  color: var(--ml-text-3);
+  padding: 8px 18px;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  background: var(--ml-accent-soft);
+  border-bottom: 1px solid var(--ml-border);
+}
+.sendasHint svg {
+  color: var(--ml-accent-strong);
+  flex: none;
+}
+.cmpBody {
+  flex: 1;
+  padding: 16px 18px;
+  font-size: 13.5px;
+  line-height: 1.6;
+  color: var(--ml-text);
+  background: none;
+  border: none;
+  outline: none;
+  resize: none;
+  font-family: inherit;
+}
+.cmpBody::placeholder {
+  color: var(--ml-text-3);
+}
+.cmpBar {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 13px 18px;
+  border-top: 1px solid var(--ml-border);
+  background: var(--ml-bg-deep);
+}
+.sendBtn {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 38px;
+  padding: 0 18px;
+  border-radius: var(--ml-radius-md);
+  border: none;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--ml-on-accent);
+  background: linear-gradient(135deg, var(--ml-accent-strong), var(--ml-accent));
+  cursor: pointer;
+  box-shadow: 0 8px 20px -8px var(--ml-accent-glow);
+  transition: all 0.15s;
+  font-family: inherit;
+}
+.sendBtn:hover:not(:disabled) {
+  transform: translateY(-1px);
+  filter: brightness(1.05);
+}
+.sendBtn:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+.cmpTool {
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--ml-text-2);
+  background: transparent;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.cmpTool:hover {
+  background: var(--ml-surface-hover);
+  color: var(--ml-text);
+  border-color: var(--ml-border);
+}
+.cmpBar .spacer {
+  flex: 1;
+}
+.cmpTool.discard:hover {
+  color: #ff6b63;
+  border-color: rgba(255, 107, 99, 0.25);
+}
+
+/* ============ MOBILE ============ */
+.mobileBack {
+  display: none;
+}
+@media (max-width: 767px) {
+  .sidebar {
+    display: none;
+  }
+  .list {
+    width: 100%;
+  }
+  .read {
+    display: none;
+  }
+  .root.mobileReading .list {
+    display: none;
+  }
+  .root.mobileReading .read {
+    display: flex;
+  }
+  .mobileBack {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    background: none;
+    border: none;
+    color: var(--ml-text-2);
+    font: inherit;
+    font-size: 12.5px;
+    font-weight: 600;
+    cursor: pointer;
+  }
+  .compose {
+    width: 100%;
+    height: 100%;
+  }
+  .scrim {
+    padding: 0;
+  }
+}

--- a/desktop/src/apps/MailApp/MailApp.test.tsx
+++ b/desktop/src/apps/MailApp/MailApp.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { MailApp } from "./index";
+import * as mailApi from "@/lib/mail";
+import * as useIsMobileModule from "@/hooks/use-is-mobile";
+
+vi.mock("@/lib/mail");
+vi.mock("@/hooks/use-is-mobile");
+
+const account: mailApi.MailAccount = {
+  id: "acct-1",
+  display_name: "Jay Lawrence",
+  email_address: "jay@taos.my",
+  imap_host: "imap.taos.my",
+  imap_port: 993,
+  imap_security: "ssl",
+  smtp_host: "smtp.taos.my",
+  smtp_port: 587,
+  smtp_security: "starttls",
+  username: "jay@taos.my",
+  created_at: 0,
+  updated_at: 0,
+};
+
+const envelopes: mailApi.MailEnvelope[] = [
+  {
+    uid: "1",
+    from_name: "Dhaval Patel",
+    from_addr: "dhaval@example.com",
+    to: "jay@taos.my",
+    subject: "AssetOpsBench integration",
+    date: "Mon, 15 Jun 2026 09:24:00 +0000",
+    snippet: "Thanks for the quick turnaround on the connector.",
+    unread: true,
+    flagged: false,
+    has_attachment: true,
+  },
+  {
+    uid: "2",
+    from_name: "Coolify",
+    from_addr: "noreply@coolify.io",
+    to: "jay@taos.my",
+    subject: "Deployment succeeded",
+    date: "Mon, 14 Jun 2026 09:24:00 +0000",
+    snippet: "Build finished in 42s.",
+    unread: false,
+    flagged: true,
+    has_attachment: false,
+  },
+];
+
+describe("MailApp", () => {
+  beforeEach(() => {
+    vi.mocked(useIsMobileModule.useIsMobile).mockReturnValue(false);
+    vi.mocked(mailApi.fetchAccounts).mockResolvedValue([account]);
+    vi.mocked(mailApi.fetchFolders).mockResolvedValue(["INBOX", "Sent"]);
+    vi.mocked(mailApi.fetchMessages).mockResolvedValue(envelopes);
+    vi.mocked(mailApi.fetchMessage).mockResolvedValue({
+      uid: "1",
+      from_name: "Dhaval Patel",
+      from_addr: "dhaval@example.com",
+      to: "jay@taos.my",
+      cc: "",
+      subject: "AssetOpsBench integration",
+      date: "Mon, 15 Jun 2026 09:24:00 +0000",
+      body_text: "Benchmark harness runs clean.",
+      body_html: "",
+      attachments: [{ filename: "notes.pdf", content_type: "application/pdf", size: 248000 }],
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the message list from the backend", async () => {
+    render(<MailApp windowId="w1" />);
+    expect(await screen.findByText("AssetOpsBench integration")).toBeInTheDocument();
+    expect(screen.getByText("Coolify")).toBeInTheDocument();
+  });
+
+  it("filters to unread when the Unread tab is selected", async () => {
+    render(<MailApp windowId="w1" />);
+    await screen.findByText("AssetOpsBench integration");
+    fireEvent.click(screen.getByRole("tab", { name: /Unread/ }));
+    expect(screen.getByText("AssetOpsBench integration")).toBeInTheDocument();
+    expect(screen.queryByText("Deployment succeeded")).not.toBeInTheDocument();
+  });
+
+  it("opens a message into the reading pane", async () => {
+    render(<MailApp windowId="w1" />);
+    fireEvent.click(await screen.findByText("AssetOpsBench integration"));
+    expect(await screen.findByText("Benchmark harness runs clean.")).toBeInTheDocument();
+    expect(screen.getByText("notes.pdf")).toBeInTheDocument();
+  });
+
+  it("shows the add-account form when there are no accounts", async () => {
+    vi.mocked(mailApi.fetchAccounts).mockResolvedValue([]);
+    render(<MailApp windowId="w1" />);
+    expect(await screen.findByText("Add a mail account")).toBeInTheDocument();
+  });
+
+  it("exposes a share / send-to entry point in the reading toolbar", async () => {
+    render(<MailApp windowId="w1" />);
+    fireEvent.click(await screen.findByText("AssetOpsBench integration"));
+    await screen.findByText("Benchmark harness runs clean.");
+    const shareBtn = screen.getByTitle("Share / Send to");
+    fireEvent.click(shareBtn);
+    expect(await screen.findByText("Send to a person or agent")).toBeInTheDocument();
+  });
+
+  it("sends a composed message via the backend", async () => {
+    vi.mocked(mailApi.sendMessage).mockResolvedValue();
+    render(<MailApp windowId="w1" />);
+    await screen.findByText("AssetOpsBench integration");
+    fireEvent.click(screen.getByLabelText("Compose new message"));
+    fireEvent.change(await screen.findByLabelText("To"), {
+      target: { value: "someone@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText("Subject"), { target: { value: "Hi" } });
+    fireEvent.click(screen.getByText("Send"));
+    await waitFor(() =>
+      expect(mailApi.sendMessage).toHaveBeenCalledWith("acct-1", {
+        to: "someone@example.com",
+        subject: "Hi",
+        body: "",
+        cc: "",
+      }),
+    );
+  });
+});

--- a/desktop/src/apps/MailApp/index.tsx
+++ b/desktop/src/apps/MailApp/index.tsx
@@ -1,0 +1,994 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Archive,
+  ChevronDown,
+  CornerUpLeft,
+  CornerUpRight,
+  FileText,
+  Forward,
+  Inbox,
+  Mail,
+  MoreHorizontal,
+  Paperclip,
+  Plus,
+  Search,
+  Send,
+  Share2,
+  Star,
+  Trash2,
+  X,
+} from "lucide-react";
+import { useIsMobile } from "@/hooks/use-is-mobile";
+import {
+  addAccount,
+  deleteAccount,
+  fetchAccounts,
+  fetchFolders,
+  fetchMessage,
+  fetchMessages,
+  sendMessage,
+  type MailAccount,
+  type MailDetail,
+  type MailEnvelope,
+  type NewAccount,
+} from "@/lib/mail";
+import styles from "./MailApp.module.css";
+
+/* ------------------------------------------------------------------ */
+/*  Constants + helpers                                                */
+/* ------------------------------------------------------------------ */
+
+type Filter = "all" | "unread" | "flagged";
+
+// Canonical folders shown for every account. The IMAP server's own folder list
+// (from fetchFolders) is also surfaced, but these five are always present and
+// map to the common special-use mailboxes.
+const CANONICAL_FOLDERS: { id: string; label: string }[] = [
+  { id: "INBOX", label: "Inbox" },
+  { id: "Sent", label: "Sent" },
+  { id: "Drafts", label: "Drafts" },
+  { id: "Archive", label: "Archive" },
+  { id: "Trash", label: "Trash" },
+];
+
+const FOLDER_ICON: Record<string, typeof Inbox> = {
+  INBOX: Inbox,
+  Sent: Send,
+  Drafts: FileText,
+  Archive: Archive,
+  Trash: Trash2,
+};
+
+function initials(name: string, addr: string): string {
+  const src = (name || addr || "?").trim();
+  const parts = src.split(/\s+/).filter(Boolean);
+  if (parts.length >= 2) {
+    return ((parts[0]?.[0] ?? "") + (parts[1]?.[0] ?? "")).toUpperCase();
+  }
+  return src.slice(0, 2).toUpperCase();
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1048576) return `${(bytes / 1024).toFixed(0)} KB`;
+  return `${(bytes / 1048576).toFixed(1)} MB`;
+}
+
+function formatTime(iso: string): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  const now = new Date();
+  const sameDay = d.toDateString() === now.toDateString();
+  if (sameDay) {
+    return d.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+  }
+  const diffDays = Math.floor((now.getTime() - d.getTime()) / 86400000);
+  if (diffDays === 1) return "Yesterday";
+  if (diffDays < 7) return d.toLocaleDateString([], { weekday: "short" });
+  return d.toLocaleDateString([], { month: "short", day: "numeric" });
+}
+
+/* ------------------------------------------------------------------ */
+/*  Main component                                                     */
+/* ------------------------------------------------------------------ */
+
+export function MailApp({ windowId: _windowId }: { windowId: string }) {
+  const isMobile = useIsMobile();
+
+  const [accounts, setAccounts] = useState<MailAccount[]>([]);
+  const [accountsLoaded, setAccountsLoaded] = useState(false);
+  const [activeAccountId, setActiveAccountId] = useState<string | null>(null);
+  const [acctMenuOpen, setAcctMenuOpen] = useState(false);
+  const [showAddForm, setShowAddForm] = useState(false);
+
+  const [serverFolders, setServerFolders] = useState<string[]>([]);
+  const [activeFolder, setActiveFolder] = useState("INBOX");
+
+  const [messages, setMessages] = useState<MailEnvelope[]>([]);
+  const [messagesLoading, setMessagesLoading] = useState(false);
+  const [listError, setListError] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const [filter, setFilter] = useState<Filter>("all");
+
+  const [selectedUid, setSelectedUid] = useState<string | null>(null);
+  const [detail, setDetail] = useState<MailDetail | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+
+  const [composeOpen, setComposeOpen] = useState(false);
+  const [shareOpen, setShareOpen] = useState(false);
+  const [mobileReading, setMobileReading] = useState(false);
+
+  const activeAccount = useMemo(
+    () => accounts.find((a) => a.id === activeAccountId) ?? null,
+    [accounts, activeAccountId],
+  );
+
+  /* ---- load accounts ---- */
+  const loadAccounts = useCallback(async () => {
+    try {
+      const list = await fetchAccounts();
+      setAccounts(list);
+      setActiveAccountId((prev) => prev ?? (list[0]?.id ?? null));
+      if (list.length === 0) setShowAddForm(true);
+    } catch {
+      setAccounts([]);
+    } finally {
+      setAccountsLoaded(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadAccounts();
+  }, [loadAccounts]);
+
+  /* ---- load folders + messages for the active account/folder ---- */
+  useEffect(() => {
+    if (!activeAccountId) return;
+    let cancelled = false;
+    void fetchFolders(activeAccountId)
+      .then((f) => {
+        if (!cancelled) setServerFolders(f);
+      })
+      .catch(() => {
+        if (!cancelled) setServerFolders([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [activeAccountId]);
+
+  const loadMessages = useCallback(async () => {
+    if (!activeAccountId) return;
+    setMessagesLoading(true);
+    setListError(null);
+    try {
+      const list = await fetchMessages(activeAccountId, activeFolder);
+      setMessages(list);
+    } catch (e) {
+      setMessages([]);
+      setListError(e instanceof Error ? e.message : "Failed to load mail");
+    } finally {
+      setMessagesLoading(false);
+    }
+  }, [activeAccountId, activeFolder]);
+
+  useEffect(() => {
+    setSelectedUid(null);
+    setDetail(null);
+    void loadMessages();
+  }, [loadMessages]);
+
+  /* ---- load a single message ---- */
+  const openMessage = useCallback(
+    async (uid: string) => {
+      if (!activeAccountId) return;
+      setSelectedUid(uid);
+      setShareOpen(false);
+      if (isMobile) setMobileReading(true);
+      setDetailLoading(true);
+      setDetail(null);
+      try {
+        const d = await fetchMessage(activeAccountId, uid, activeFolder);
+        setDetail(d);
+      } catch {
+        setDetail(null);
+      } finally {
+        setDetailLoading(false);
+      }
+    },
+    [activeAccountId, activeFolder, isMobile],
+  );
+
+  /* ---- filtered list ---- */
+  const visibleMessages = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return messages.filter((m) => {
+      if (filter === "unread" && !m.unread) return false;
+      if (filter === "flagged" && !m.flagged) return false;
+      if (!q) return true;
+      return (
+        m.from_name.toLowerCase().includes(q) ||
+        m.from_addr.toLowerCase().includes(q) ||
+        m.subject.toLowerCase().includes(q) ||
+        m.snippet.toLowerCase().includes(q)
+      );
+    });
+  }, [messages, search, filter]);
+
+  const unreadCount = messages.filter((m) => m.unread).length;
+  const flaggedCount = messages.filter((m) => m.flagged).length;
+  const activeFolderLabel =
+    CANONICAL_FOLDERS.find((f) => f.id === activeFolder)?.label ?? activeFolder;
+
+  /* ---- compose / send ---- */
+  const handleSent = useCallback(() => {
+    setComposeOpen(false);
+    void loadMessages();
+  }, [loadMessages]);
+
+  if (!accountsLoaded) {
+    return (
+      <div className={styles.root}>
+        <div className={styles.empty}>
+          <Mail size={36} aria-hidden="true" />
+          <p>Loading mail…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (showAddForm || accounts.length === 0) {
+    return (
+      <div className={styles.root}>
+        <div className={styles.appbar}>
+          <Mail size={16} aria-hidden="true" />
+          <h1>Mail</h1>
+        </div>
+        <AddAccountForm
+          onCancel={accounts.length > 0 ? () => setShowAddForm(false) : undefined}
+          onAdded={async () => {
+            setShowAddForm(false);
+            setActiveAccountId(null);
+            await loadAccounts();
+          }}
+        />
+      </div>
+    );
+  }
+
+  const rootClass = `${styles.root} ${isMobile && mobileReading ? styles.mobileReading : ""}`;
+
+  return (
+    <div className={rootClass}>
+      <div className={styles.appbar}>
+        <Mail size={16} aria-hidden="true" />
+        <h1>Mail</h1>
+        <div className={styles.appbarRight}>
+          <button
+            className={styles.composebtn}
+            onClick={() => setComposeOpen(true)}
+            aria-label="Compose new message"
+          >
+            <Plus size={14} aria-hidden="true" />
+            Compose
+          </button>
+        </div>
+      </div>
+
+      <div className={styles.body}>
+        {/* ---- sidebar ---- */}
+        <aside className={styles.sidebar} aria-label="Mailboxes">
+          <div className={`${styles.acct} ${acctMenuOpen ? styles.open : ""}`}>
+            <button
+              className={styles.acctCur}
+              onClick={() => setAcctMenuOpen((v) => !v)}
+              aria-expanded={acctMenuOpen}
+              aria-label="Switch account"
+            >
+              <div className={`${styles.av} ${styles.avUser}`}>
+                {initials(activeAccount?.display_name ?? "", activeAccount?.email_address ?? "")}
+              </div>
+              <div className={styles.acctBody}>
+                <div className={styles.acctName}>{activeAccount?.display_name}</div>
+                <div className={styles.acctAddr}>{activeAccount?.email_address}</div>
+              </div>
+              <span className={styles.acctChev}>
+                <ChevronDown size={15} aria-hidden="true" />
+              </span>
+            </button>
+
+            {acctMenuOpen && (
+              <div className={styles.acctMenu}>
+                <div className={styles.acctGrp}>Your accounts</div>
+                {accounts.map((a) => (
+                  <button
+                    key={a.id}
+                    className={`${styles.acctRow} ${a.id === activeAccountId ? styles.sel : ""}`}
+                    onClick={() => {
+                      setActiveAccountId(a.id);
+                      setActiveFolder("INBOX");
+                      setAcctMenuOpen(false);
+                    }}
+                  >
+                    <div className={`${styles.av} ${styles.avUser}`}>
+                      {initials(a.display_name, a.email_address)}
+                    </div>
+                    <div className={styles.acctRowBody}>
+                      <div className={styles.acctRowName}>{a.display_name}</div>
+                      <div className={styles.acctRowAddr}>{a.email_address}</div>
+                    </div>
+                    {a.id === activeAccountId && (
+                      <span className={styles.acctCheck}>
+                        <Star size={13} aria-hidden="true" />
+                      </span>
+                    )}
+                  </button>
+                ))}
+
+                {/* Phase-2 affordance: agent accounts + send-as. Disabled. */}
+                <div className={styles.acctGrp}>Agent accounts</div>
+                <div className={styles.acctGroupDisabled}>
+                  <div className={styles.acctRow} aria-disabled="true">
+                    <div className={`${styles.av} ${styles.avAgent}`}>A</div>
+                    <div className={styles.acctRowBody}>
+                      <div className={styles.acctRowName}>
+                        Send as agent <span className={styles.pillAgent}>Agent</span>
+                      </div>
+                      <div className={styles.acctRowAddr}>Coming in a later release</div>
+                    </div>
+                    <span className={styles.comingSoon}>Soon</span>
+                  </div>
+                </div>
+
+                <button
+                  className={styles.acctAdd}
+                  onClick={() => {
+                    setAcctMenuOpen(false);
+                    setShowAddForm(true);
+                  }}
+                >
+                  <Plus size={14} aria-hidden="true" />
+                  Add mail account
+                </button>
+                {activeAccount && (
+                  <button
+                    className={styles.acctAdd}
+                    onClick={async () => {
+                      if (!activeAccount) return;
+                      await deleteAccount(activeAccount.id);
+                      setActiveAccountId(null);
+                      setAcctMenuOpen(false);
+                      await loadAccounts();
+                    }}
+                  >
+                    <Trash2 size={14} aria-hidden="true" />
+                    Remove this account
+                  </button>
+                )}
+              </div>
+            )}
+          </div>
+
+          <nav className={styles.folders} aria-label="Folders">
+            {CANONICAL_FOLDERS.map((f) => {
+              const Icon = FOLDER_ICON[f.id] ?? Inbox;
+              return (
+                <button
+                  key={f.id}
+                  className={`${styles.fold} ${activeFolder === f.id ? styles.on : ""}`}
+                  onClick={() => setActiveFolder(f.id)}
+                  aria-current={activeFolder === f.id}
+                >
+                  <span className={styles.foldIco}>
+                    <Icon size={17} aria-hidden="true" />
+                  </span>
+                  <span className={styles.foldName}>{f.label}</span>
+                  {f.id === "INBOX" && unreadCount > 0 && (
+                    <span className={styles.foldCount}>{unreadCount}</span>
+                  )}
+                </button>
+              );
+            })}
+
+            {serverFolders.filter(
+              (sf) => !CANONICAL_FOLDERS.some((c) => c.id.toLowerCase() === sf.toLowerCase()),
+            ).length > 0 && (
+              <>
+                <div className={styles.fgrpLbl}>All mailboxes</div>
+                {serverFolders
+                  .filter(
+                    (sf) =>
+                      !CANONICAL_FOLDERS.some((c) => c.id.toLowerCase() === sf.toLowerCase()),
+                  )
+                  .map((sf) => (
+                    <button
+                      key={sf}
+                      className={`${styles.fold} ${activeFolder === sf ? styles.on : ""}`}
+                      onClick={() => setActiveFolder(sf)}
+                      aria-current={activeFolder === sf}
+                    >
+                      <span className={styles.foldIco}>
+                        <Inbox size={17} aria-hidden="true" />
+                      </span>
+                      <span className={styles.foldName}>{sf}</span>
+                    </button>
+                  ))}
+              </>
+            )}
+          </nav>
+        </aside>
+
+        {/* ---- message list ---- */}
+        <section className={styles.list} aria-label="Message list">
+          <div className={styles.listHead}>
+            <div className={styles.listTitle}>
+              <h2>{activeFolderLabel}</h2>
+              <span className={styles.sub}>
+                {unreadCount > 0 ? `${unreadCount} unread` : `${messages.length} messages`}
+              </span>
+            </div>
+            <div className={styles.search}>
+              <Search size={15} aria-hidden="true" />
+              <input
+                type="search"
+                placeholder="Search mail"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                aria-label="Search mail"
+              />
+            </div>
+            <div className={styles.tabs} role="tablist" aria-label="Filter messages">
+              {(
+                [
+                  ["all", "All", messages.length],
+                  ["unread", "Unread", unreadCount],
+                  ["flagged", "Flagged", flaggedCount],
+                ] as [Filter, string, number][]
+              ).map(([id, label, n]) => (
+                <button
+                  key={id}
+                  role="tab"
+                  aria-selected={filter === id}
+                  className={`${styles.tab} ${filter === id ? styles.on : ""}`}
+                  onClick={() => setFilter(id)}
+                >
+                  {label}
+                  <span className={styles.n}>{n}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className={styles.rows} role="list">
+            {messagesLoading ? (
+              <>
+                <div className={styles.skel} aria-hidden="true" />
+                <div className={styles.skel} aria-hidden="true" />
+                <div className={styles.skel} aria-hidden="true" />
+                <span className="sr-only" role="status" aria-live="polite">
+                  Loading messages
+                </span>
+              </>
+            ) : listError ? (
+              <div className={styles.error} role="alert">
+                {listError}
+              </div>
+            ) : visibleMessages.length === 0 ? (
+              <div className={styles.empty}>
+                <Inbox size={32} aria-hidden="true" />
+                <p>{search || filter !== "all" ? "No matching messages" : "No messages here"}</p>
+              </div>
+            ) : (
+              visibleMessages.map((m) => (
+                <button
+                  key={m.uid}
+                  role="listitem"
+                  className={`${styles.row} ${m.uid === selectedUid ? styles.on : ""} ${m.unread ? styles.unread : ""}`}
+                  onClick={() => void openMessage(m.uid)}
+                >
+                  <div className={`${styles.av} ${styles.avUser}`}>
+                    {initials(m.from_name, m.from_addr)}
+                  </div>
+                  <div className={styles.rowMain}>
+                    <div className={styles.rowTop}>
+                      <span className={styles.rowFrom}>{m.from_name || m.from_addr}</span>
+                      <span className={styles.rowTime}>{formatTime(m.date)}</span>
+                    </div>
+                    <div className={styles.rowSubj}>{m.subject || "(no subject)"}</div>
+                    <div className={styles.rowSnip}>{m.snippet}</div>
+                    {(m.unread || m.flagged || m.has_attachment) && (
+                      <div className={styles.rowMeta}>
+                        {m.unread && <span className={styles.udot} aria-label="Unread" />}
+                        {m.flagged && (
+                          <span className={`${styles.mini} ${styles.flag}`}>
+                            <Star size={13} aria-label="Flagged" />
+                          </span>
+                        )}
+                        {m.has_attachment && (
+                          <span className={styles.mini}>
+                            <Paperclip size={13} aria-label="Has attachment" />
+                          </span>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                </button>
+              ))
+            )}
+          </div>
+        </section>
+
+        {/* ---- reading pane ---- */}
+        <section className={styles.read} aria-label="Message">
+          <div className={styles.readToolbar}>
+            {isMobile && (
+              <button className={styles.mobileBack} onClick={() => setMobileReading(false)}>
+                <CornerUpLeft size={15} aria-hidden="true" />
+                Back
+              </button>
+            )}
+            {/* TODO(phase-2): wire Reply / Reply all / Forward to a prefilled
+                compose. Phase 1 ships the compose surface and send only. */}
+            <button className={`${styles.tbtn} ${styles.pri}`} disabled={!detail}>
+              <CornerUpLeft size={15} aria-hidden="true" />
+              Reply
+            </button>
+            <button className={styles.tbtn} disabled={!detail}>
+              <CornerUpRight size={15} aria-hidden="true" />
+              Reply all
+            </button>
+            <button className={styles.tbtn} disabled={!detail}>
+              <Forward size={15} aria-hidden="true" />
+              Forward
+            </button>
+            <div className={styles.tbSep} />
+            <button className={styles.iconbtn} title="Archive" disabled={!detail}>
+              <Archive size={16} aria-hidden="true" />
+            </button>
+            <button className={styles.iconbtn} title="Delete" disabled={!detail}>
+              <Trash2 size={16} aria-hidden="true" />
+            </button>
+            <div className={styles.right}>
+              {/* Share / Send to: entry point only. Full share sheet is task #69. */}
+              <button
+                className={styles.iconbtn}
+                title="Share / Send to"
+                disabled={!detail}
+                onClick={() => setShareOpen((v) => !v)}
+                aria-expanded={shareOpen}
+              >
+                <Share2 size={16} aria-hidden="true" />
+              </button>
+              <button className={styles.iconbtn} title="More" disabled={!detail}>
+                <MoreHorizontal size={16} aria-hidden="true" />
+              </button>
+              {shareOpen && (
+                <div className={styles.menu} role="menu">
+                  <div className={styles.menuNote}>Share / Send to</div>
+                  <button className={styles.menuItem} role="menuitem" disabled>
+                    <Share2 size={14} aria-hidden="true" />
+                    Send to a person or agent
+                  </button>
+                  <div className={styles.menuNote}>Full share sheet coming soon</div>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {detailLoading ? (
+            <div className={styles.empty}>
+              <Mail size={32} aria-hidden="true" />
+              <p>Loading message…</p>
+            </div>
+          ) : !detail ? (
+            <div className={styles.empty}>
+              <Mail size={36} aria-hidden="true" />
+              <p>Select a message to read it here.</p>
+            </div>
+          ) : (
+            <div className={styles.readScroll}>
+              <div className={styles.readSubj}>{detail.subject || "(no subject)"}</div>
+              <div className={styles.readFrom}>
+                <div className={`${styles.av} ${styles.avUser}`}>
+                  {initials(detail.from_name, detail.from_addr)}
+                </div>
+                <div className={styles.rfBody}>
+                  <div className={styles.rfName}>{detail.from_name || detail.from_addr}</div>
+                  <div className={styles.rfAddr}>{detail.from_addr}</div>
+                  <div className={styles.rfTo}>
+                    to <b>{detail.to}</b>
+                    {detail.cc ? (
+                      <>
+                        , cc <b>{detail.cc}</b>
+                      </>
+                    ) : null}
+                  </div>
+                </div>
+                <div className={styles.readDate}>{detail.date}</div>
+              </div>
+
+              <div className={styles.readBody}>{detail.body_text || detail.body_html}</div>
+
+              {detail.attachments.length > 0 && (
+                <div className={styles.attach}>
+                  <div className={styles.attLbl}>
+                    {detail.attachments.length} attachment
+                    {detail.attachments.length === 1 ? "" : "s"}
+                  </div>
+                  {detail.attachments.map((a, i) => (
+                    <div className={styles.att} key={`${a.filename}-${i}`}>
+                      <div className={styles.attIco}>
+                        <FileText size={17} aria-hidden="true" />
+                      </div>
+                      <div>
+                        <div className={styles.attName}>{a.filename}</div>
+                        <div className={styles.attSize}>{formatBytes(a.size)}</div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </section>
+      </div>
+
+      {composeOpen && activeAccount && (
+        <ComposeOverlay
+          account={activeAccount}
+          onClose={() => setComposeOpen(false)}
+          onSent={handleSent}
+        />
+      )}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Compose overlay                                                    */
+/* ------------------------------------------------------------------ */
+
+function ComposeOverlay({
+  account,
+  onClose,
+  onSent,
+}: {
+  account: MailAccount;
+  onClose: () => void;
+  onSent: () => void;
+}) {
+  const [to, setTo] = useState("");
+  const [cc, setCc] = useState("");
+  const [showCc, setShowCc] = useState(false);
+  const [subject, setSubject] = useState("");
+  const [body, setBody] = useState("");
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const send = useCallback(async () => {
+    if (!to.trim() || sending) return;
+    setSending(true);
+    setError(null);
+    try {
+      await sendMessage(account.id, { to, subject, body, cc });
+      onSent();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to send");
+      setSending(false);
+    }
+  }, [account.id, to, cc, subject, body, sending, onSent]);
+
+  return (
+    <div
+      className={styles.scrim}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className={styles.compose} role="dialog" aria-label="New message">
+        <div className={styles.cmpHead}>
+          <h3>New message</h3>
+          <div className={styles.right}>
+            <button className={styles.iconbtn} title="Close" onClick={onClose} aria-label="Close">
+              <X size={16} aria-hidden="true" />
+            </button>
+          </div>
+        </div>
+
+        <div className={styles.cmpFields}>
+          {/* From: account selector is static in Phase 1 (one user account at a
+              time). The agent send-as switcher is a Phase 2 affordance below. */}
+          <div className={styles.cmpField}>
+            <span className={styles.k}>From</span>
+            <div className={styles.fromStatic}>
+              <div className={`${styles.av} ${styles.avUser}`}>
+                {initials(account.display_name, account.email_address)}
+              </div>
+              <div>
+                <div className={styles.faName}>{account.display_name}</div>
+                <div className={styles.faAddr}>{account.email_address}</div>
+              </div>
+            </div>
+          </div>
+          {/* Phase-2 affordance: send as an agent. Shown, not wired. */}
+          <div className={styles.sendasHint}>
+            <Mail size={13} aria-hidden="true" />
+            Sending as an agent is coming in a later release
+          </div>
+          <div className={styles.cmpField}>
+            <span className={styles.k}>To</span>
+            <input
+              placeholder="Recipients"
+              value={to}
+              onChange={(e) => setTo(e.target.value)}
+              aria-label="To"
+            />
+            {!showCc && (
+              <button
+                className={styles.menuItem}
+                style={{ width: "auto", padding: "2px 6px" }}
+                onClick={() => setShowCc(true)}
+              >
+                Cc
+              </button>
+            )}
+          </div>
+          {showCc && (
+            <div className={styles.cmpField}>
+              <span className={styles.k}>Cc</span>
+              <input
+                placeholder="Cc recipients"
+                value={cc}
+                onChange={(e) => setCc(e.target.value)}
+                aria-label="Cc"
+              />
+            </div>
+          )}
+          <div className={styles.cmpField}>
+            <span className={styles.k}>Subject</span>
+            <input
+              placeholder="Subject"
+              value={subject}
+              onChange={(e) => setSubject(e.target.value)}
+              aria-label="Subject"
+            />
+          </div>
+        </div>
+
+        <textarea
+          className={styles.cmpBody}
+          placeholder="Write your message…"
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          aria-label="Message body"
+        />
+
+        {error && (
+          <div className={styles.error} role="alert">
+            {error}
+          </div>
+        )}
+
+        <div className={styles.cmpBar}>
+          <button
+            className={styles.sendBtn}
+            onClick={() => void send()}
+            disabled={!to.trim() || sending}
+          >
+            <Send size={15} aria-hidden="true" />
+            {sending ? "Sending…" : "Send"}
+          </button>
+          {/* TODO(phase-2): attachment upload pass-through in compose. */}
+          <button className={styles.cmpTool} title="Attach file" disabled>
+            <Paperclip size={17} aria-hidden="true" />
+          </button>
+          <div className={styles.spacer} />
+          <button
+            className={`${styles.cmpTool} ${styles.discard}`}
+            title="Discard draft"
+            onClick={onClose}
+          >
+            <Trash2 size={17} aria-hidden="true" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Add-account form                                                   */
+/* ------------------------------------------------------------------ */
+
+function AddAccountForm({
+  onAdded,
+  onCancel,
+}: {
+  onAdded: () => void | Promise<void>;
+  onCancel?: () => void;
+}) {
+  const [form, setForm] = useState<NewAccount>({
+    display_name: "",
+    email_address: "",
+    imap_host: "",
+    imap_port: 993,
+    imap_security: "ssl",
+    smtp_host: "",
+    smtp_port: 587,
+    smtp_security: "starttls",
+    username: "",
+    password: "",
+  });
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const set = (k: keyof NewAccount, v: string | number) =>
+    setForm((f) => ({ ...f, [k]: v }));
+
+  const submit = useCallback(async () => {
+    if (saving) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await addAccount({
+        ...form,
+        username: form.username || form.email_address,
+        display_name: form.display_name || form.email_address,
+      });
+      await onAdded();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to add account");
+      setSaving(false);
+    }
+  }, [form, saving, onAdded]);
+
+  return (
+    <div className={styles.readScroll} style={{ maxWidth: 520, margin: "0 auto", width: "100%" }}>
+      <div className={styles.readSubj}>Add a mail account</div>
+      <p className={styles.menuNote} style={{ padding: "8px 0 16px" }}>
+        Your password is stored encrypted in the Secrets vault, never in the
+        accounts table.
+      </p>
+
+      {error && (
+        <div className={styles.error} role="alert" style={{ margin: "0 0 14px" }}>
+          {error}
+        </div>
+      )}
+
+      <Field label="Display name">
+        <input
+          value={form.display_name}
+          onChange={(e) => set("display_name", e.target.value)}
+          placeholder="Jay Lawrence"
+        />
+      </Field>
+      <Field label="Email address">
+        <input
+          type="email"
+          value={form.email_address}
+          onChange={(e) => set("email_address", e.target.value)}
+          placeholder="jay@example.com"
+        />
+      </Field>
+      <Field label="Username">
+        <input
+          value={form.username}
+          onChange={(e) => set("username", e.target.value)}
+          placeholder="Defaults to the email address"
+        />
+      </Field>
+      <Field label="Password">
+        <input
+          type="password"
+          value={form.password}
+          onChange={(e) => set("password", e.target.value)}
+          placeholder="App password recommended"
+        />
+      </Field>
+      <Field label="IMAP host">
+        <input
+          value={form.imap_host}
+          onChange={(e) => set("imap_host", e.target.value)}
+          placeholder="imap.example.com"
+        />
+      </Field>
+      <Field label="IMAP port">
+        <input
+          type="number"
+          value={form.imap_port}
+          onChange={(e) => set("imap_port", Number(e.target.value))}
+        />
+      </Field>
+      <Field label="IMAP security">
+        <SecuritySelect value={form.imap_security} onChange={(v) => set("imap_security", v)} />
+      </Field>
+      <Field label="SMTP host">
+        <input
+          value={form.smtp_host}
+          onChange={(e) => set("smtp_host", e.target.value)}
+          placeholder="smtp.example.com"
+        />
+      </Field>
+      <Field label="SMTP port">
+        <input
+          type="number"
+          value={form.smtp_port}
+          onChange={(e) => set("smtp_port", Number(e.target.value))}
+        />
+      </Field>
+      <Field label="SMTP security">
+        <SecuritySelect value={form.smtp_security} onChange={(v) => set("smtp_security", v)} />
+      </Field>
+
+      <div style={{ display: "flex", gap: 8, marginTop: 18 }}>
+        <button
+          className={styles.sendBtn}
+          onClick={() => void submit()}
+          disabled={saving || !form.email_address || !form.imap_host || !form.smtp_host || !form.password}
+        >
+          <Plus size={15} aria-hidden="true" />
+          {saving ? "Adding…" : "Add account"}
+        </button>
+        {onCancel && (
+          <button className={styles.tbtn} onClick={onCancel}>
+            Cancel
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label
+      style={{ display: "block", marginBottom: 10 }}
+      className={styles.search}
+    >
+      <span
+        style={{
+          display: "block",
+          fontSize: 11,
+          fontWeight: 600,
+          textTransform: "uppercase",
+          letterSpacing: "0.05em",
+          marginBottom: 2,
+        }}
+        className={styles.faAddr}
+      >
+        {label}
+      </span>
+      {children}
+    </label>
+  );
+}
+
+function SecuritySelect({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      style={{
+        flex: 1,
+        background: "none",
+        border: "none",
+        outline: "none",
+        color: "inherit",
+        font: "inherit",
+        fontSize: 13,
+      }}
+    >
+      <option value="ssl">SSL / TLS</option>
+      <option value="starttls">STARTTLS</option>
+      <option value="none">None</option>
+    </select>
+  );
+}

--- a/desktop/src/lib/mail.ts
+++ b/desktop/src/lib/mail.ts
@@ -1,0 +1,171 @@
+import { withCsrf } from "./csrf";
+
+/* ------------------------------------------------------------------ */
+/*  Types                                                              */
+/* ------------------------------------------------------------------ */
+
+export interface MailAccount {
+  id: string;
+  display_name: string;
+  email_address: string;
+  imap_host: string;
+  imap_port: number;
+  imap_security: string;
+  smtp_host: string;
+  smtp_port: number;
+  smtp_security: string;
+  username: string;
+  created_at: number;
+  updated_at: number;
+}
+
+export interface NewAccount {
+  display_name: string;
+  email_address: string;
+  imap_host: string;
+  imap_port: number;
+  imap_security: string;
+  smtp_host: string;
+  smtp_port: number;
+  smtp_security: string;
+  username: string;
+  password: string;
+}
+
+export interface MailEnvelope {
+  uid: string;
+  from_name: string;
+  from_addr: string;
+  to: string;
+  subject: string;
+  date: string;
+  snippet: string;
+  unread: boolean;
+  flagged: boolean;
+  has_attachment: boolean;
+}
+
+export interface MailAttachment {
+  filename: string;
+  content_type: string;
+  size: number;
+}
+
+export interface MailDetail {
+  uid: string;
+  from_name: string;
+  from_addr: string;
+  to: string;
+  cc: string;
+  subject: string;
+  date: string;
+  body_text: string;
+  body_html: string;
+  attachments: MailAttachment[];
+}
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+async function ensureOk(r: Response): Promise<void> {
+  if (r.ok) return;
+  let body: { error?: string } | null = null;
+  try {
+    body = await r.json();
+  } catch {
+    /* ignore */
+  }
+  throw new Error(body?.error || `HTTP ${r.status}`);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Account CRUD                                                       */
+/* ------------------------------------------------------------------ */
+
+export async function fetchAccounts(): Promise<MailAccount[]> {
+  const r = await fetch("/api/mail/accounts", {
+    headers: { Accept: "application/json" },
+  });
+  await ensureOk(r);
+  return r.json();
+}
+
+export async function addAccount(account: NewAccount): Promise<MailAccount> {
+  const r = await fetch(
+    "/api/mail/accounts",
+    withCsrf({
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(account),
+    }),
+  );
+  await ensureOk(r);
+  return r.json();
+}
+
+export async function deleteAccount(accountId: string): Promise<void> {
+  const r = await fetch(
+    `/api/mail/accounts/${encodeURIComponent(accountId)}`,
+    withCsrf({ method: "DELETE" }),
+  );
+  await ensureOk(r);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Folders + messages                                                */
+/* ------------------------------------------------------------------ */
+
+export async function fetchFolders(accountId: string): Promise<string[]> {
+  const r = await fetch(
+    `/api/mail/accounts/${encodeURIComponent(accountId)}/folders`,
+    { headers: { Accept: "application/json" } },
+  );
+  await ensureOk(r);
+  const data = await r.json();
+  return Array.isArray(data?.folders) ? data.folders : [];
+}
+
+export async function fetchMessages(
+  accountId: string,
+  folder: string,
+  limit = 50,
+): Promise<MailEnvelope[]> {
+  const params = new URLSearchParams({ folder, limit: String(limit) });
+  const r = await fetch(
+    `/api/mail/accounts/${encodeURIComponent(accountId)}/messages?${params}`,
+    { headers: { Accept: "application/json" } },
+  );
+  await ensureOk(r);
+  const data = await r.json();
+  return Array.isArray(data?.messages) ? data.messages : [];
+}
+
+export async function fetchMessage(
+  accountId: string,
+  uid: string,
+  folder: string,
+): Promise<MailDetail> {
+  const params = new URLSearchParams({ folder });
+  const r = await fetch(
+    `/api/mail/accounts/${encodeURIComponent(accountId)}/messages/${encodeURIComponent(uid)}?${params}`,
+    { headers: { Accept: "application/json" } },
+  );
+  await ensureOk(r);
+  return r.json();
+}
+
+export async function sendMessage(
+  accountId: string,
+  payload: { to: string; subject: string; body: string; cc?: string },
+): Promise<void> {
+  const r = await fetch(
+    `/api/mail/accounts/${encodeURIComponent(accountId)}/send`,
+    withCsrf({
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    }),
+  );
+  await ensureOk(r);
+}

--- a/desktop/src/registry/app-registry.ts
+++ b/desktop/src/registry/app-registry.ts
@@ -16,6 +16,7 @@ export interface AppManifest {
 const apps: AppManifest[] = [
   // Platform apps
   { id: "messages", name: "Messages", icon: "message-circle", category: "platform", component: () => import("@/apps/MessagesApp").then((m) => ({ default: m.MessagesApp })), defaultSize: { w: 900, h: 600 }, minSize: { w: 400, h: 300 }, singleton: true, pinned: true, launchpadOrder: 1 },
+  { id: "mail", name: "Mail", icon: "mail", category: "platform", component: () => import("@/apps/MailApp").then((m) => ({ default: m.MailApp })), defaultSize: { w: 1200, h: 800 }, minSize: { w: 720, h: 480 }, singleton: true, pinned: true, launchpadOrder: 1.25 },
   { id: "projects", name: "Projects", icon: "folder-kanban", category: "platform", component: () => import("@/apps/ProjectsApp").then((m) => ({ default: m.ProjectsApp })), defaultSize: { w: 1100, h: 720 }, minSize: { w: 700, h: 500 }, singleton: true, pinned: true, launchpadOrder: 1.5 },
   { id: "agents", name: "Agents", icon: "bot", category: "platform", component: () => import("@/apps/AgentsApp").then((m) => ({ default: m.AgentsApp })), defaultSize: { w: 1000, h: 650 }, minSize: { w: 500, h: 400 }, singleton: true, pinned: true, launchpadOrder: 2 },
   { id: "files", name: "Files", icon: "folder", category: "platform", component: () => import("@/apps/FilesApp").then((m) => ({ default: m.FilesApp })), defaultSize: { w: 900, h: 550 }, minSize: { w: 400, h: 300 }, singleton: true, pinned: true, launchpadOrder: 3 },

--- a/tests/test_mail_client.py
+++ b/tests/test_mail_client.py
@@ -1,6 +1,24 @@
 from email.message import EmailMessage
 
-from tinyagentos.mail_client import parse_detail, parse_envelope
+import pytest
+
+from tinyagentos.mail_client import (
+    MailFolderError,
+    _validate_folder,
+    parse_detail,
+    parse_envelope,
+)
+
+
+class TestValidateFolder:
+    def test_accepts_normal_names(self):
+        assert _validate_folder("INBOX") == "INBOX"
+        assert _validate_folder("[Gmail]/Sent Mail") == "[Gmail]/Sent Mail"
+
+    @pytest.mark.parametrize("bad", ['IN"BOX', "a\r\nLOGOUT", "x\x00y", ""])
+    def test_rejects_injection_chars(self, bad):
+        with pytest.raises(MailFolderError):
+            _validate_folder(bad)
 
 
 def _plain_message():

--- a/tests/test_mail_client.py
+++ b/tests/test_mail_client.py
@@ -1,0 +1,94 @@
+from email.message import EmailMessage
+
+from tinyagentos.mail_client import parse_detail, parse_envelope
+
+
+def _plain_message():
+    msg = EmailMessage()
+    msg["From"] = "Dhaval Patel <dhaval@example.com>"
+    msg["To"] = "jay@taos.my"
+    msg["Subject"] = "AssetOpsBench integration"
+    msg["Date"] = "Mon, 15 Jun 2026 09:24:00 +0000"
+    msg.set_content("Thanks for the quick turnaround on the connector.\nBenchmark runs clean.")
+    return msg
+
+
+class TestParseEnvelope:
+    def test_basic_fields(self):
+        msg = _plain_message()
+        env = parse_envelope("42", msg, flags=b"")
+        assert env.uid == "42"
+        assert env.from_name == "Dhaval Patel"
+        assert env.from_addr == "dhaval@example.com"
+        assert env.subject == "AssetOpsBench integration"
+        assert "Thanks for the quick turnaround" in env.snippet
+        # No \\Seen flag means unread.
+        assert env.unread is True
+        assert env.flagged is False
+        assert env.has_attachment is False
+
+    def test_seen_and_flagged_flags(self):
+        env = parse_envelope("1", _plain_message(), flags=b"(\\Seen \\Flagged)")
+        assert env.unread is False
+        assert env.flagged is True
+
+    def test_encoded_subject_is_decoded(self):
+        msg = _plain_message()
+        del msg["Subject"]
+        # RFC 2047 encoded-word for "Hello"
+        msg["Subject"] = "=?utf-8?q?Hello?="
+        env = parse_envelope("2", msg, flags=b"")
+        assert env.subject == "Hello"
+
+    def test_detects_attachment(self):
+        msg = _plain_message()
+        msg.add_attachment(
+            b"%PDF-1.4 fake",
+            maintype="application",
+            subtype="pdf",
+            filename="notes.pdf",
+        )
+        env = parse_envelope("3", msg, flags=b"")
+        assert env.has_attachment is True
+
+    def test_missing_from_is_safe(self):
+        msg = EmailMessage()
+        msg["Subject"] = "no sender"
+        msg.set_content("body")
+        env = parse_envelope("4", msg, flags=b"")
+        assert env.from_addr == ""
+        assert env.subject == "no sender"
+
+
+class TestParseDetail:
+    def test_body_text(self):
+        detail = parse_detail("42", _plain_message())
+        assert "Benchmark runs clean" in detail.body_text
+        assert detail.from_addr == "dhaval@example.com"
+        assert detail.to == "jay@taos.my"
+        assert detail.attachments == []
+
+    def test_attachments_listed(self):
+        msg = _plain_message()
+        msg.add_attachment(
+            b"binarydata-1234",
+            maintype="application",
+            subtype="pdf",
+            filename="report.pdf",
+        )
+        detail = parse_detail("5", msg)
+        assert len(detail.attachments) == 1
+        att = detail.attachments[0]
+        assert att.filename == "report.pdf"
+        assert att.content_type == "application/pdf"
+        assert att.size == len(b"binarydata-1234")
+
+    def test_html_body(self):
+        msg = EmailMessage()
+        msg["From"] = "a@b.com"
+        msg["Subject"] = "html"
+        msg.set_content("plain fallback")
+        msg.add_alternative("<p>rich</p>", subtype="html")
+        detail = parse_detail("6", msg)
+        assert "rich" in detail.body_html
+        assert "plain fallback" in detail.body_text

--- a/tests/test_mail_store.py
+++ b/tests/test_mail_store.py
@@ -1,0 +1,101 @@
+import pytest
+import pytest_asyncio
+
+from tinyagentos.mail_store import MailAccountStore
+from tinyagentos.secrets import SecretsStore
+
+
+@pytest_asyncio.fixture
+async def store(tmp_path):
+    s = MailAccountStore(tmp_path / "mail.db")
+    await s.init()
+    yield s
+    await s.close()
+
+
+@pytest_asyncio.fixture
+async def secrets(tmp_path):
+    s = SecretsStore(tmp_path / "secrets.db")
+    await s.init()
+    yield s
+    await s.close()
+
+
+def _account_kwargs(**overrides):
+    base = dict(
+        user_id="user-1",
+        display_name="Jay",
+        email_address="jay@example.com",
+        imap_host="imap.example.com",
+        imap_port=993,
+        imap_security="ssl",
+        smtp_host="smtp.example.com",
+        smtp_port=587,
+        smtp_security="starttls",
+        username="jay@example.com",
+        secret_name="mail:account:pending:password",
+    )
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.asyncio
+class TestMailAccountStore:
+    async def test_add_and_get(self, store):
+        acct = await store.add(**_account_kwargs())
+        assert acct["id"]
+        assert acct["email_address"] == "jay@example.com"
+        assert acct["imap_port"] == 993
+
+        fetched = await store.get(acct["id"], "user-1")
+        assert fetched is not None
+        assert fetched["id"] == acct["id"]
+        assert fetched["username"] == "jay@example.com"
+
+    async def test_list_scoped_by_user(self, store):
+        await store.add(**_account_kwargs(user_id="user-1"))
+        await store.add(**_account_kwargs(user_id="user-2", email_address="b@x.com"))
+
+        u1 = await store.list_for_user("user-1")
+        u2 = await store.list_for_user("user-2")
+        assert len(u1) == 1
+        assert len(u2) == 1
+        assert u1[0]["email_address"] == "jay@example.com"
+        assert u2[0]["email_address"] == "b@x.com"
+
+    async def test_get_rejects_other_user(self, store):
+        acct = await store.add(**_account_kwargs(user_id="user-1"))
+        assert await store.get(acct["id"], "user-2") is None
+
+    async def test_delete_scoped(self, store):
+        acct = await store.add(**_account_kwargs(user_id="user-1"))
+        # Wrong user cannot delete.
+        assert await store.delete(acct["id"], "user-2") is False
+        assert await store.get(acct["id"], "user-1") is not None
+        # Owner can delete.
+        assert await store.delete(acct["id"], "user-1") is True
+        assert await store.get(acct["id"], "user-1") is None
+
+    async def test_no_plaintext_password_column(self, store):
+        """The accounts table must never carry a password; only a secret
+        pointer. Verify the schema has no password-like column."""
+        async with store._db.execute("PRAGMA table_info(mail_accounts)") as cur:
+            cols = [row[1] for row in await cur.fetchall()]
+        assert "secret_name" in cols
+        assert "password" not in cols
+        assert "value" not in cols
+
+    async def test_secret_indirection(self, store, secrets):
+        """The store keeps only a secret name; the real password lives in the
+        SecretsStore and is fetched back through it."""
+        acct = await store.add(**_account_kwargs())
+        secret_name = MailAccountStore.secret_name_for(acct["id"])
+        await secrets.add(name=secret_name, value="hunter2", category="credentials")
+
+        # The account row holds the pointer, not the value.
+        row = await store.get(acct["id"], "user-1")
+        assert row["secret_name"] == "mail:account:pending:password"  # as inserted
+        # Resolving the canonical secret returns the plaintext only via secrets.
+        rec = await secrets.get(secret_name)
+        assert rec is not None
+        assert rec["value"] == "hunter2"

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -60,6 +60,7 @@ from tinyagentos.torrent_settings import TorrentSettingsStore
 from tinyagentos.relationships import RelationshipManager
 from tinyagentos.github_identities import GitHubIdentitiesStore
 from tinyagentos.secrets import SecretsStore
+from tinyagentos.mail_store import MailAccountStore
 from tinyagentos.training import TrainingManager
 from tinyagentos.conversion import ConversionManager
 from tinyagentos.agent_messages import AgentMessageStore
@@ -261,6 +262,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     torrent_settings_store = TorrentSettingsStore(data_dir / "torrent_settings.json")
     download_manager = DownloadManager(torrent_settings_store=torrent_settings_store)
     secrets_store = SecretsStore(data_dir / "secrets.db")
+    mail_store = MailAccountStore(data_dir / "mail.db")
     github_identities_store = GitHubIdentitiesStore(data_dir / "github_identities.db")
     relationship_mgr = RelationshipManager(data_dir / "relationships.db")
     channel_store = ChannelStore(data_dir / "channels.db")
@@ -392,6 +394,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await notif_store.init()
         await qmd_client.init()
         await secrets_store.init()
+        await mail_store.init()
+        app.state.mail_store = mail_store
         await github_identities_store.init()
         await relationship_mgr.init()
         await channel_store.init()
@@ -1137,6 +1141,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await browser_cookie_store.close()
         await browser_store.close()
         await secrets_store.close()
+        await mail_store.close()
         await notif_store.close()
         await app.state.system_events.close()
         await metrics_store.close()

--- a/tinyagentos/mail_client.py
+++ b/tinyagentos/mail_client.py
@@ -1,0 +1,362 @@
+"""IMAP/SMTP client for the Mail app.
+
+Mirrors the stdlib imaplib/smtplib approach already used by
+``tinyagentos/channel_hub/email_connector.py`` (no new third-party dependency),
+but exposes a richer, request-scoped API (list folders, list a folder's
+envelopes, fetch one message body + attachments, send a composed message).
+
+All blocking socket IO runs through ``asyncio.to_thread`` so it never blocks
+the event loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import email
+import imaplib
+import smtplib
+from dataclasses import dataclass, field
+from email.header import decode_header, make_header
+from email.message import Message
+from email.mime.base import MIMEBase
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from email.utils import parseaddr
+
+# Common IMAP special-use folder names mapped to our canonical folder ids.
+# Servers vary, so the route layer also passes the raw IMAP folder name through.
+CANONICAL_FOLDERS = ["INBOX", "Sent", "Drafts", "Archive", "Trash"]
+
+
+@dataclass
+class MailAccountConfig:
+    """Connection details for a single account. The password is resolved from
+    the SecretsStore by the caller and passed in here; it is never persisted by
+    this module."""
+
+    imap_host: str
+    imap_port: int
+    imap_security: str
+    smtp_host: str
+    smtp_port: int
+    smtp_security: str
+    username: str
+    password: str
+    email_address: str
+
+
+@dataclass
+class MessageEnvelope:
+    uid: str
+    from_name: str
+    from_addr: str
+    to: str
+    subject: str
+    date: str
+    snippet: str
+    unread: bool
+    flagged: bool
+    has_attachment: bool
+
+
+@dataclass
+class Attachment:
+    filename: str
+    content_type: str
+    size: int
+
+
+@dataclass
+class MessageDetail:
+    uid: str
+    from_name: str
+    from_addr: str
+    to: str
+    cc: str
+    subject: str
+    date: str
+    body_text: str
+    body_html: str
+    attachments: list[Attachment] = field(default_factory=list)
+
+
+def _decode(value: str | None) -> str:
+    """Decode an RFC 2047 encoded header into a plain unicode string."""
+    if not value:
+        return ""
+    try:
+        return str(make_header(decode_header(value)))
+    except Exception:
+        return value
+
+
+def parse_envelope(uid: str, msg: Message, flags: bytes | str = b"") -> MessageEnvelope:
+    """Parse an ``email.message.Message`` (header-only fetch is enough) plus the
+    IMAP FLAGS blob into a MessageEnvelope. Pure and synchronous so it can be
+    unit-tested without a live server."""
+    flags_str = flags.decode("utf-8", "replace") if isinstance(flags, bytes) else (flags or "")
+    raw_from = _decode(msg.get("From", ""))
+    from_name, from_addr = parseaddr(raw_from)
+    from_name = from_name or from_addr
+
+    snippet = ""
+    has_attachment = False
+    if msg.is_multipart():
+        for part in msg.walk():
+            disp = str(part.get("Content-Disposition", ""))
+            if "attachment" in disp.lower() or part.get_filename():
+                has_attachment = True
+            if not snippet and part.get_content_type() == "text/plain":
+                snippet = _payload_text(part)
+    else:
+        snippet = _payload_text(msg)
+
+    snippet = " ".join(snippet.split())[:200]
+
+    return MessageEnvelope(
+        uid=uid,
+        from_name=from_name,
+        from_addr=from_addr,
+        to=_decode(msg.get("To", "")),
+        subject=_decode(msg.get("Subject", "")),
+        date=_decode(msg.get("Date", "")),
+        snippet=snippet,
+        unread="\\Seen" not in flags_str,
+        flagged="\\Flagged" in flags_str,
+        has_attachment=has_attachment,
+    )
+
+
+def parse_detail(uid: str, msg: Message) -> MessageDetail:
+    """Parse a full RFC822 message into a MessageDetail (body + attachments)."""
+    body_text = ""
+    body_html = ""
+    attachments: list[Attachment] = []
+
+    if msg.is_multipart():
+        for part in msg.walk():
+            ctype = part.get_content_type()
+            disp = str(part.get("Content-Disposition", "")).lower()
+            filename = part.get_filename()
+            if filename or "attachment" in disp:
+                payload = part.get_payload(decode=True) or b""
+                attachments.append(
+                    Attachment(
+                        filename=_decode(filename) or "attachment",
+                        content_type=ctype,
+                        size=len(payload),
+                    )
+                )
+            elif ctype == "text/plain" and not body_text:
+                body_text = _payload_text(part)
+            elif ctype == "text/html" and not body_html:
+                body_html = _payload_text(part)
+    else:
+        if msg.get_content_type() == "text/html":
+            body_html = _payload_text(msg)
+        else:
+            body_text = _payload_text(msg)
+
+    raw_from = _decode(msg.get("From", ""))
+    from_name, from_addr = parseaddr(raw_from)
+    return MessageDetail(
+        uid=uid,
+        from_name=from_name or from_addr,
+        from_addr=from_addr,
+        to=_decode(msg.get("To", "")),
+        cc=_decode(msg.get("Cc", "")),
+        subject=_decode(msg.get("Subject", "")),
+        date=_decode(msg.get("Date", "")),
+        body_text=body_text,
+        body_html=body_html,
+        attachments=attachments,
+    )
+
+
+def _payload_text(part: Message) -> str:
+    payload = part.get_payload(decode=True)
+    if payload is None:
+        return ""
+    charset = part.get_content_charset() or "utf-8"
+    try:
+        return payload.decode(charset, errors="replace")
+    except (LookupError, UnicodeDecodeError):
+        return payload.decode("utf-8", errors="replace")
+
+
+# --------------------------------------------------------------------------- #
+# Blocking IMAP/SMTP primitives (run via asyncio.to_thread).
+# --------------------------------------------------------------------------- #
+
+
+def _imap_connect(cfg: MailAccountConfig) -> imaplib.IMAP4:
+    if cfg.imap_security == "ssl":
+        conn: imaplib.IMAP4 = imaplib.IMAP4_SSL(cfg.imap_host, cfg.imap_port)
+    else:
+        conn = imaplib.IMAP4(cfg.imap_host, cfg.imap_port)
+        if cfg.imap_security == "starttls":
+            conn.starttls()
+    conn.login(cfg.username, cfg.password)
+    return conn
+
+
+def _list_folders_blocking(cfg: MailAccountConfig) -> list[str]:
+    conn = _imap_connect(cfg)
+    try:
+        typ, data = conn.list()
+        folders: list[str] = []
+        if typ == "OK":
+            for raw in data:
+                if not raw:
+                    continue
+                line = raw.decode("utf-8", "replace") if isinstance(raw, bytes) else str(raw)
+                # Format: (\HasNoChildren) "/" "INBOX"  -- take the quoted tail.
+                if '"' in line:
+                    folders.append(line.split('"')[-2])
+                else:
+                    folders.append(line.split()[-1])
+        return folders
+    finally:
+        _safe_logout(conn)
+
+
+def _list_messages_blocking(
+    cfg: MailAccountConfig, folder: str, limit: int
+) -> list[MessageEnvelope]:
+    conn = _imap_connect(cfg)
+    try:
+        conn.select(f'"{folder}"', readonly=True)
+        typ, data = conn.search(None, "ALL")
+        if typ != "OK" or not data or not data[0]:
+            return []
+        ids = data[0].split()
+        ids = ids[-limit:][::-1]  # newest first
+        envelopes: list[MessageEnvelope] = []
+        for num in ids:
+            typ, msg_data = conn.fetch(
+                num, "(FLAGS BODY.PEEK[HEADER] BODY.PEEK[TEXT]<0.4096>)"
+            )
+            if typ != "OK" or not msg_data:
+                continue
+            raw_bytes = b""
+            flags = b""
+            for item in msg_data:
+                if isinstance(item, tuple) and len(item) == 2:
+                    raw_bytes += item[1]
+                    flags += item[0] if isinstance(item[0], bytes) else b""
+            msg = email.message_from_bytes(raw_bytes)
+            uid = num.decode() if isinstance(num, bytes) else str(num)
+            envelopes.append(parse_envelope(uid, msg, flags))
+        return envelopes
+    finally:
+        _safe_logout(conn)
+
+
+def _get_message_blocking(
+    cfg: MailAccountConfig, folder: str, uid: str
+) -> MessageDetail | None:
+    conn = _imap_connect(cfg)
+    try:
+        conn.select(f'"{folder}"', readonly=True)
+        typ, msg_data = conn.fetch(uid, "(RFC822)")
+        if typ != "OK" or not msg_data or not msg_data[0]:
+            return None
+        raw_email = msg_data[0][1]
+        msg = email.message_from_bytes(raw_email)
+        return parse_detail(uid, msg)
+    finally:
+        _safe_logout(conn)
+
+
+def _build_outgoing(
+    cfg: MailAccountConfig,
+    to: str,
+    subject: str,
+    body: str,
+    cc: str = "",
+    attachments: list[tuple[str, bytes, str]] | None = None,
+) -> MIMEMultipart:
+    msg = MIMEMultipart()
+    msg["From"] = cfg.email_address or cfg.username
+    msg["To"] = to
+    if cc:
+        msg["Cc"] = cc
+    msg["Subject"] = subject
+    msg.attach(MIMEText(body, "plain"))
+    for filename, content, content_type in attachments or []:
+        maintype, _, subtype = content_type.partition("/")
+        part = MIMEBase(maintype or "application", subtype or "octet-stream")
+        part.set_payload(content)
+        from email.encoders import encode_base64
+
+        encode_base64(part)
+        part.add_header("Content-Disposition", "attachment", filename=filename)
+        msg.attach(part)
+    return msg
+
+
+def _send_blocking(
+    cfg: MailAccountConfig,
+    to: str,
+    subject: str,
+    body: str,
+    cc: str = "",
+    attachments: list[tuple[str, bytes, str]] | None = None,
+) -> None:
+    msg = _build_outgoing(cfg, to, subject, body, cc=cc, attachments=attachments)
+    recipients = [r.strip() for r in (to + ("," + cc if cc else "")).split(",") if r.strip()]
+    if cfg.smtp_security == "ssl":
+        server: smtplib.SMTP = smtplib.SMTP_SSL(cfg.smtp_host, cfg.smtp_port)
+    else:
+        server = smtplib.SMTP(cfg.smtp_host, cfg.smtp_port)
+        if cfg.smtp_security == "starttls":
+            server.starttls()
+    try:
+        server.login(cfg.username, cfg.password)
+        server.sendmail(cfg.email_address or cfg.username, recipients, msg.as_string())
+    finally:
+        try:
+            server.quit()
+        except Exception:
+            pass
+
+
+def _safe_logout(conn: imaplib.IMAP4) -> None:
+    try:
+        conn.logout()
+    except Exception:
+        pass
+
+
+# --------------------------------------------------------------------------- #
+# Async wrappers.
+# --------------------------------------------------------------------------- #
+
+
+async def list_folders(cfg: MailAccountConfig) -> list[str]:
+    return await asyncio.to_thread(_list_folders_blocking, cfg)
+
+
+async def list_messages(
+    cfg: MailAccountConfig, folder: str, limit: int = 50
+) -> list[MessageEnvelope]:
+    return await asyncio.to_thread(_list_messages_blocking, cfg, folder, limit)
+
+
+async def get_message(
+    cfg: MailAccountConfig, folder: str, uid: str
+) -> MessageDetail | None:
+    return await asyncio.to_thread(_get_message_blocking, cfg, folder, uid)
+
+
+async def send_message(
+    cfg: MailAccountConfig,
+    to: str,
+    subject: str,
+    body: str,
+    cc: str = "",
+    attachments: list[tuple[str, bytes, str]] | None = None,
+) -> None:
+    await asyncio.to_thread(
+        _send_blocking, cfg, to, subject, body, cc, attachments
+    )

--- a/tinyagentos/mail_client.py
+++ b/tinyagentos/mail_client.py
@@ -27,6 +27,27 @@ from email.utils import parseaddr
 # Servers vary, so the route layer also passes the raw IMAP folder name through.
 CANONICAL_FOLDERS = ["INBOX", "Sent", "Drafts", "Archive", "Trash"]
 
+# Upper bound on how many envelopes a single list call will fetch. Each id is a
+# separate IMAP round trip, so an unbounded limit lets one request tie up the
+# connection (and the to_thread worker) indefinitely.
+MAX_MESSAGE_LIMIT = 200
+
+
+class MailFolderError(ValueError):
+    """Raised when a folder name is unsafe to interpolate into an IMAP command."""
+
+
+def _validate_folder(folder: str) -> str:
+    """Reject folder names that could break out of the quoted IMAP argument.
+
+    ``folder`` is an untrusted query-string value interpolated into
+    ``conn.select(f'"{folder}"')``. A double-quote or CR/LF would let a caller
+    inject extra IMAP protocol tokens on their own authenticated connection, so
+    we forbid those characters outright rather than try to escape them."""
+    if not folder or any(c in folder for c in ('"', "\r", "\n", "\x00")):
+        raise MailFolderError(f"invalid folder name: {folder!r}")
+    return folder
+
 
 @dataclass
 class MailAccountConfig:
@@ -223,18 +244,23 @@ def _list_folders_blocking(cfg: MailAccountConfig) -> list[str]:
 def _list_messages_blocking(
     cfg: MailAccountConfig, folder: str, limit: int
 ) -> list[MessageEnvelope]:
+    _validate_folder(folder)
+    limit = max(1, min(limit, MAX_MESSAGE_LIMIT))
     conn = _imap_connect(cfg)
     try:
         conn.select(f'"{folder}"', readonly=True)
-        typ, data = conn.search(None, "ALL")
+        # UID SEARCH/FETCH so the identifier surfaced to the client is a stable
+        # IMAP UID, not a sequence number (which the server renumbers when
+        # messages are expunged, breaking a later open/delete by that id).
+        typ, data = conn.uid("SEARCH", None, "ALL")
         if typ != "OK" or not data or not data[0]:
             return []
         ids = data[0].split()
         ids = ids[-limit:][::-1]  # newest first
         envelopes: list[MessageEnvelope] = []
         for num in ids:
-            typ, msg_data = conn.fetch(
-                num, "(FLAGS BODY.PEEK[HEADER] BODY.PEEK[TEXT]<0.4096>)"
+            typ, msg_data = conn.uid(
+                "FETCH", num, "(FLAGS BODY.PEEK[HEADER] BODY.PEEK[TEXT]<0.4096>)"
             )
             if typ != "OK" or not msg_data:
                 continue
@@ -255,10 +281,12 @@ def _list_messages_blocking(
 def _get_message_blocking(
     cfg: MailAccountConfig, folder: str, uid: str
 ) -> MessageDetail | None:
+    _validate_folder(folder)
     conn = _imap_connect(cfg)
     try:
         conn.select(f'"{folder}"', readonly=True)
-        typ, msg_data = conn.fetch(uid, "(RFC822)")
+        # Fetch by UID to match the stable id handed out by list_messages.
+        typ, msg_data = conn.uid("FETCH", uid, "(RFC822)")
         if typ != "OK" or not msg_data or not msg_data[0]:
             return None
         raw_email = msg_data[0][1]

--- a/tinyagentos/mail_store.py
+++ b/tinyagentos/mail_store.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import time
+import uuid
+
+from tinyagentos.base_store import BaseStore
+
+MAIL_SCHEMA = """
+CREATE TABLE IF NOT EXISTS mail_accounts (
+    id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL DEFAULT '',
+    display_name TEXT NOT NULL DEFAULT '',
+    email_address TEXT NOT NULL,
+    imap_host TEXT NOT NULL,
+    imap_port INTEGER NOT NULL DEFAULT 993,
+    imap_security TEXT NOT NULL DEFAULT 'ssl',
+    smtp_host TEXT NOT NULL,
+    smtp_port INTEGER NOT NULL DEFAULT 587,
+    smtp_security TEXT NOT NULL DEFAULT 'starttls',
+    username TEXT NOT NULL,
+    secret_name TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_mail_accounts_user
+    ON mail_accounts(user_id);
+"""
+
+
+def _row_to_account(row) -> dict:
+    """Map an aiosqlite row to an account dict. The password is never stored
+    here; only ``secret_name`` (a pointer into SecretsStore) is kept."""
+    return {
+        "id": row[0],
+        "user_id": row[1],
+        "display_name": row[2],
+        "email_address": row[3],
+        "imap_host": row[4],
+        "imap_port": row[5],
+        "imap_security": row[6],
+        "smtp_host": row[7],
+        "smtp_port": row[8],
+        "smtp_security": row[9],
+        "username": row[10],
+        "secret_name": row[11],
+        "created_at": row[12],
+        "updated_at": row[13],
+    }
+
+
+_COLUMNS = (
+    "id, user_id, display_name, email_address, imap_host, imap_port, "
+    "imap_security, smtp_host, smtp_port, smtp_security, username, "
+    "secret_name, created_at, updated_at"
+)
+
+
+class MailAccountStore(BaseStore):
+    """Per-user metadata for configured email accounts.
+
+    The account password is NOT stored in this table. The caller stores the
+    password in the SecretsStore and passes the resulting ``secret_name`` here,
+    so this store only ever holds a pointer to the credential.
+    """
+
+    SCHEMA = MAIL_SCHEMA
+
+    @staticmethod
+    def secret_name_for(account_id: str) -> str:
+        """Canonical SecretsStore key for an account's password."""
+        return f"mail:account:{account_id}:password"
+
+    async def add(
+        self,
+        *,
+        user_id: str,
+        display_name: str,
+        email_address: str,
+        imap_host: str,
+        imap_port: int,
+        imap_security: str,
+        smtp_host: str,
+        smtp_port: int,
+        smtp_security: str,
+        username: str,
+        secret_name: str,
+    ) -> dict:
+        account_id = str(uuid.uuid4())
+        now = int(time.time())
+        await self._db.execute(
+            f"INSERT INTO mail_accounts ({_COLUMNS}) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                account_id,
+                user_id,
+                display_name,
+                email_address,
+                imap_host,
+                imap_port,
+                imap_security,
+                smtp_host,
+                smtp_port,
+                smtp_security,
+                username,
+                secret_name,
+                now,
+                now,
+            ),
+        )
+        await self._db.commit()
+        account = await self.get(account_id, user_id)
+        assert account is not None  # just inserted
+        return account
+
+    async def list_for_user(self, user_id: str) -> list[dict]:
+        async with self._db.execute(
+            f"SELECT {_COLUMNS} FROM mail_accounts "
+            "WHERE user_id = ? ORDER BY created_at ASC",
+            (user_id,),
+        ) as cursor:
+            rows = await cursor.fetchall()
+        return [_row_to_account(r) for r in rows]
+
+    async def get(self, account_id: str, user_id: str) -> dict | None:
+        """Fetch a single account scoped to its owner. Returns None if the
+        account does not exist or belongs to a different user."""
+        async with self._db.execute(
+            f"SELECT {_COLUMNS} FROM mail_accounts WHERE id = ? AND user_id = ?",
+            (account_id, user_id),
+        ) as cursor:
+            row = await cursor.fetchone()
+        return _row_to_account(row) if row else None
+
+    async def delete(self, account_id: str, user_id: str) -> bool:
+        cursor = await self._db.execute(
+            "DELETE FROM mail_accounts WHERE id = ? AND user_id = ?",
+            (account_id, user_id),
+        )
+        await self._db.commit()
+        return cursor.rowcount > 0

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -87,6 +87,9 @@ def register_all_routers(app):
     from tinyagentos.routes.secrets import router as secrets_router
     app.include_router(secrets_router)
 
+    from tinyagentos.routes.mail import router as mail_router
+    app.include_router(mail_router)
+
     from tinyagentos.routes.desktop_browser import router as desktop_browser_router
     app.include_router(desktop_browser_router)
 

--- a/tinyagentos/routes/mail.py
+++ b/tinyagentos/routes/mail.py
@@ -1,0 +1,230 @@
+"""Mail app API routes (Phase 1).
+
+Multi-account email client: account CRUD, IMAP folder + message listing,
+single-message fetch, and SMTP send. Account passwords go through the
+SecretsStore (this layer never persists plaintext credentials).
+
+Per-user scoping: every account row is keyed by the authenticated user_id and
+every handler refuses accounts that belong to a different user.
+
+Deferred to Phase 2 (see TODOs): the agent-account send-as profile switcher,
+OAuth (Gmail/Outlook), the full Share sheet (task #69), and push/IDLE new-mail.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from tinyagentos import mail_client
+from tinyagentos.auth_context import CurrentUser, current_user
+from tinyagentos.mail_client import MailAccountConfig
+from tinyagentos.mail_store import MailAccountStore
+
+router = APIRouter()
+
+
+class AccountCreate(BaseModel):
+    display_name: str = ""
+    email_address: str
+    imap_host: str
+    imap_port: int = 993
+    imap_security: str = "ssl"
+    smtp_host: str
+    smtp_port: int = 587
+    smtp_security: str = "starttls"
+    username: str
+    password: str
+
+
+class SendBody(BaseModel):
+    to: str
+    subject: str = ""
+    body: str = ""
+    cc: str = ""
+
+
+def _public_account(account: dict) -> dict:
+    """Strip the internal secret pointer from an account before returning it."""
+    return {k: v for k, v in account.items() if k not in ("secret_name", "user_id")}
+
+
+async def _resolve_config(
+    request: Request, account: dict
+) -> MailAccountConfig | None:
+    """Load the account password from the SecretsStore and build a connection
+    config. Returns None when the secret is missing (account misconfigured)."""
+    secrets = request.app.state.secrets
+    rec = await secrets.get(account["secret_name"])
+    if not rec or not rec.get("value"):
+        return None
+    return MailAccountConfig(
+        imap_host=account["imap_host"],
+        imap_port=account["imap_port"],
+        imap_security=account["imap_security"],
+        smtp_host=account["smtp_host"],
+        smtp_port=account["smtp_port"],
+        smtp_security=account["smtp_security"],
+        username=account["username"],
+        password=rec["value"],
+        email_address=account["email_address"],
+    )
+
+
+@router.get("/api/mail/accounts")
+async def list_accounts(request: Request, user: CurrentUser = Depends(current_user)):
+    store: MailAccountStore = request.app.state.mail_store
+    accounts = await store.list_for_user(user.user_id)
+    return [_public_account(a) for a in accounts]
+
+
+@router.post("/api/mail/accounts")
+async def add_account(
+    request: Request,
+    body: AccountCreate,
+    user: CurrentUser = Depends(current_user),
+):
+    store: MailAccountStore = request.app.state.mail_store
+    secrets = request.app.state.secrets
+
+    # Insert metadata first so we have the account id to key the secret on, then
+    # store the password in the SecretsStore. The account row only ever holds
+    # the secret name, never the plaintext password.
+    account = await store.add(
+        user_id=user.user_id,
+        display_name=body.display_name or body.email_address,
+        email_address=body.email_address,
+        imap_host=body.imap_host,
+        imap_port=body.imap_port,
+        imap_security=body.imap_security,
+        smtp_host=body.smtp_host,
+        smtp_port=body.smtp_port,
+        smtp_security=body.smtp_security,
+        username=body.username,
+        secret_name=MailAccountStore.secret_name_for("pending"),
+    )
+    secret_name = MailAccountStore.secret_name_for(account["id"])
+    await secrets.add(
+        name=secret_name,
+        value=body.password,
+        category="credentials",
+        description=f"Mail account password for {body.email_address}",
+    )
+    # Re-point the row at the real secret name now that we have the account id.
+    await store._db.execute(  # noqa: SLF001 -- internal store connection
+        "UPDATE mail_accounts SET secret_name = ? WHERE id = ? AND user_id = ?",
+        (secret_name, account["id"], user.user_id),
+    )
+    await store._db.commit()  # noqa: SLF001
+    account["secret_name"] = secret_name
+    return JSONResponse(_public_account(account), status_code=201)
+
+
+@router.delete("/api/mail/accounts/{account_id}")
+async def delete_account(
+    request: Request,
+    account_id: str,
+    user: CurrentUser = Depends(current_user),
+):
+    store: MailAccountStore = request.app.state.mail_store
+    secrets = request.app.state.secrets
+    account = await store.get(account_id, user.user_id)
+    if not account:
+        return JSONResponse({"error": "account not found"}, status_code=404)
+    await secrets.delete(account["secret_name"])
+    await store.delete(account_id, user.user_id)
+    return {"status": "deleted"}
+
+
+@router.get("/api/mail/accounts/{account_id}/folders")
+async def list_folders(
+    request: Request,
+    account_id: str,
+    user: CurrentUser = Depends(current_user),
+):
+    store: MailAccountStore = request.app.state.mail_store
+    account = await store.get(account_id, user.user_id)
+    if not account:
+        return JSONResponse({"error": "account not found"}, status_code=404)
+    cfg = await _resolve_config(request, account)
+    if cfg is None:
+        return JSONResponse({"error": "account credential missing"}, status_code=400)
+    try:
+        folders = await mail_client.list_folders(cfg)
+    except Exception as exc:
+        return JSONResponse({"error": f"imap error: {exc}"}, status_code=502)
+    return {"folders": folders}
+
+
+@router.get("/api/mail/accounts/{account_id}/messages")
+async def list_messages(
+    request: Request,
+    account_id: str,
+    folder: str = "INBOX",
+    limit: int = 50,
+    user: CurrentUser = Depends(current_user),
+):
+    store: MailAccountStore = request.app.state.mail_store
+    account = await store.get(account_id, user.user_id)
+    if not account:
+        return JSONResponse({"error": "account not found"}, status_code=404)
+    cfg = await _resolve_config(request, account)
+    if cfg is None:
+        return JSONResponse({"error": "account credential missing"}, status_code=400)
+    try:
+        envelopes = await mail_client.list_messages(cfg, folder, limit=limit)
+    except Exception as exc:
+        return JSONResponse({"error": f"imap error: {exc}"}, status_code=502)
+    return {"messages": [asdict(e) for e in envelopes]}
+
+
+@router.get("/api/mail/accounts/{account_id}/messages/{uid}")
+async def get_message(
+    request: Request,
+    account_id: str,
+    uid: str,
+    folder: str = "INBOX",
+    user: CurrentUser = Depends(current_user),
+):
+    store: MailAccountStore = request.app.state.mail_store
+    account = await store.get(account_id, user.user_id)
+    if not account:
+        return JSONResponse({"error": "account not found"}, status_code=404)
+    cfg = await _resolve_config(request, account)
+    if cfg is None:
+        return JSONResponse({"error": "account credential missing"}, status_code=400)
+    try:
+        detail = await mail_client.get_message(cfg, folder, uid)
+    except Exception as exc:
+        return JSONResponse({"error": f"imap error: {exc}"}, status_code=502)
+    if detail is None:
+        return JSONResponse({"error": "message not found"}, status_code=404)
+    return asdict(detail)
+
+
+@router.post("/api/mail/accounts/{account_id}/send")
+async def send(
+    request: Request,
+    account_id: str,
+    body: SendBody,
+    user: CurrentUser = Depends(current_user),
+):
+    # TODO(phase-2): agent send-as -- allow an agent account to send on behalf
+    # of the user once the consent/relationship layer lands.
+    store: MailAccountStore = request.app.state.mail_store
+    account = await store.get(account_id, user.user_id)
+    if not account:
+        return JSONResponse({"error": "account not found"}, status_code=404)
+    cfg = await _resolve_config(request, account)
+    if cfg is None:
+        return JSONResponse({"error": "account credential missing"}, status_code=400)
+    try:
+        # TODO(phase-2): attachment upload pass-through (multipart) -- the
+        # client supports it; the route only sends a text body for now.
+        await mail_client.send_message(cfg, body.to, body.subject, body.body, cc=body.cc)
+    except Exception as exc:
+        return JSONResponse({"error": f"smtp error: {exc}"}, status_code=502)
+    return {"status": "sent"}

--- a/tinyagentos/routes/mail.py
+++ b/tinyagentos/routes/mail.py
@@ -107,18 +107,29 @@ async def add_account(
         secret_name=MailAccountStore.secret_name_for("pending"),
     )
     secret_name = MailAccountStore.secret_name_for(account["id"])
-    await secrets.add(
-        name=secret_name,
-        value=body.password,
-        category="credentials",
-        description=f"Mail account password for {body.email_address}",
-    )
-    # Re-point the row at the real secret name now that we have the account id.
-    await store._db.execute(  # noqa: SLF001 -- internal store connection
-        "UPDATE mail_accounts SET secret_name = ? WHERE id = ? AND user_id = ?",
-        (secret_name, account["id"], user.user_id),
-    )
-    await store._db.commit()  # noqa: SLF001
+    # If storing the secret or re-pointing the row fails, roll back the account
+    # row instead of leaving it pointing at a non-existent secret (which would
+    # make every later op return "account credential missing" with no way to fix
+    # it but delete and re-add).
+    try:
+        await secrets.add(
+            name=secret_name,
+            value=body.password,
+            category="credentials",
+            description=f"Mail account password for {body.email_address}",
+        )
+        await store._db.execute(  # noqa: SLF001 -- internal store connection
+            "UPDATE mail_accounts SET secret_name = ? WHERE id = ? AND user_id = ?",
+            (secret_name, account["id"], user.user_id),
+        )
+        await store._db.commit()  # noqa: SLF001
+    except Exception:
+        await store.delete(account["id"], user.user_id)
+        try:
+            await secrets.delete(secret_name)
+        except Exception:
+            pass
+        raise
     account["secret_name"] = secret_name
     return JSONResponse(_public_account(account), status_code=201)
 
@@ -176,6 +187,8 @@ async def list_messages(
         return JSONResponse({"error": "account credential missing"}, status_code=400)
     try:
         envelopes = await mail_client.list_messages(cfg, folder, limit=limit)
+    except mail_client.MailFolderError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
     except Exception as exc:
         return JSONResponse({"error": f"imap error: {exc}"}, status_code=502)
     return {"messages": [asdict(e) for e in envelopes]}
@@ -198,6 +211,8 @@ async def get_message(
         return JSONResponse({"error": "account credential missing"}, status_code=400)
     try:
         detail = await mail_client.get_message(cfg, folder, uid)
+    except mail_client.MailFolderError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
     except Exception as exc:
         return JSONResponse({"error": f"imap error: {exc}"}, status_code=502)
     if detail is None:


### PR DESCRIPTION
Jay-approved mock (.design/mail-app-mock.html). Phase 1 of the Mail app.

## What works end to end
Add an email account (IMAP+SMTP) -> list folders -> list messages -> open a message (body + attachments) -> compose + SMTP send. Real backend (mail_client over stdlib imaplib/smtplib, blocking IO via asyncio.to_thread); the frontend renders accounts/folders/list/reading-pane/compose against /api/mail/*. No faked data.

## Security
Account rows never store the password: on add it goes to the Secrets store (key mail:account:{id}:password); the account holds only the secret name, resolved per IMAP/SMTP op. A test asserts no password column. Routes gated by the auth middleware; accounts keyed per user.

## Shutdown
The new MailAccountStore(BaseStore) is closed in the lifespan shutdown (+ the BaseStore backstop), so it does not reintroduce a connection-thread restart hang.

## Deferred (phase 2, clean TODOs, shown disabled)
Reply/forward compose prefill, attachment-on-send (text body sends now), agent-account send-as / From switcher (visible+disabled), OAuth, the full Share sheet (#69, entry-point stub left), push/IDLE.

## Verify
Backend: ruff clean (new files), pytest 14 passed (store+client) + secrets-lifespan 12 passed, 7 /api/mail routes registered. Frontend: tsc clean, build succeeds, MailApp vitest 6 passed. Live Pi verify after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Mail app with support for managing multiple email accounts and viewing inbox messages
  * Added message filtering by read/unread and flagged status
  * Enabled message composition and sending with recipient and subject fields
  * Included attachment viewing and download in message reading pane
  * Implemented mobile-responsive interface with intuitive navigation
  * Added account management interface for adding and removing email accounts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->