### PR TITLE
feat(apps): make Reddit/YouTube/GitHub/X optional Store installs (#53)

### DIFF
--- a/desktop/src/apps/StoreApp/TaosAppsSection.tsx
+++ b/desktop/src/apps/StoreApp/TaosAppsSection.tsx
@@ -1,0 +1,108 @@
+import { useCallback, useState } from "react";
+import * as icons from "lucide-react";
+import { Check, Download, Loader2, Trash2 } from "lucide-react";
+import { OPTIONAL_APPS, type OptionalAppMeta } from "@/registry/optional-apps";
+import { useInstalledOptionalApps } from "@/hooks/use-installed-optional-apps";
+import { emitAppEvent, APP_OPTIONAL_CHANGED } from "@/lib/app-event-bus";
+
+/**
+ * "taOS Apps" — the optional, frontend-only apps (Reddit / YouTube / GitHub /
+ * X). Unlike service catalog apps these install instantly with no device
+ * target or progress: a single POST flips server-side install state, then we
+ * emit APP_OPTIONAL_CHANGED so the launchpad surfaces or hides the app at once.
+ */
+export function TaosAppsSection() {
+  const installed = useInstalledOptionalApps();
+
+  return (
+    <section className="mb-7" aria-labelledby="taos-apps-heading">
+      <div className="mb-3">
+        <h3 id="taos-apps-heading" className="text-[15px] font-bold text-shell-text">
+          taOS Apps
+        </h3>
+        <p className="text-[12px] text-shell-text-tertiary mt-0.5">
+          Optional first-party apps. Install the ones you want; remove them any time.
+        </p>
+      </div>
+      <div className="grid grid-cols-[repeat(auto-fill,minmax(240px,1fr))] gap-4">
+        {OPTIONAL_APPS.map((meta) => (
+          <OptionalAppCard key={meta.id} meta={meta} installed={installed.has(meta.id)} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function OptionalAppCard({ meta, installed }: { meta: OptionalAppMeta; installed: boolean }) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // lucide icon names are PascalCase exports; the registry stores kebab-case.
+  const pascal = meta.icon
+    .split("-")
+    .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+    .join("");
+  const Glyph = (icons[pascal as keyof typeof icons] as icons.LucideIcon) ?? icons.Package;
+
+  const toggle = useCallback(async () => {
+    setBusy(true);
+    setError(null);
+    const verb = installed ? "uninstall" : "install";
+    try {
+      const res = await fetch(`/api/apps/optional/${encodeURIComponent(meta.id)}/${verb}`, {
+        method: "POST",
+        headers: { Accept: "application/json" },
+      });
+      if (!res.ok) throw new Error(`${verb} failed (${res.status})`);
+      emitAppEvent(APP_OPTIONAL_CHANGED, meta.id);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Something went wrong");
+    } finally {
+      setBusy(false);
+    }
+  }, [installed, meta.id]);
+
+  return (
+    <div className="flex flex-col rounded-2xl border border-shell-border bg-shell-surface/60 overflow-hidden">
+      <div
+        className="h-20 relative shrink-0 flex items-center justify-center"
+        style={{ background: meta.cover }}
+      >
+        <Glyph size={28} className="text-white/90" />
+        {installed && (
+          <span className="absolute top-2 right-2 flex items-center gap-1 text-[10px] font-semibold px-2 py-0.5 rounded-full bg-black/35 backdrop-blur-sm text-white/90">
+            <Check className="w-3 h-3" /> Installed
+          </span>
+        )}
+      </div>
+      <div className="flex flex-col gap-2 p-3 flex-1">
+        <span className="text-[13px] font-semibold text-shell-text leading-snug">{meta.name}</span>
+        <p className="text-[11.5px] text-shell-text-secondary leading-relaxed flex-1">{meta.tagline}</p>
+        {error && (
+          <div role="alert" className="text-[11px] text-red-300 bg-red-500/10 border border-red-500/20 rounded px-2 py-1">
+            {error}
+          </div>
+        )}
+        <button
+          type="button"
+          onClick={toggle}
+          disabled={busy}
+          className={[
+            "flex items-center justify-center gap-1.5 h-8 rounded-lg text-[12px] font-semibold transition-colors disabled:opacity-60",
+            installed
+              ? "border border-shell-border text-shell-text-secondary hover:text-shell-text hover:bg-white/[0.04]"
+              : "bg-accent text-white hover:bg-accent/90",
+          ].join(" ")}
+        >
+          {busy ? (
+            <Loader2 className="w-3.5 h-3.5 animate-spin" />
+          ) : installed ? (
+            <><Trash2 className="w-3.5 h-3.5" /> Remove</>
+          ) : (
+            <><Download className="w-3.5 h-3.5" /> Install</>
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/apps/StoreApp/index.tsx
+++ b/desktop/src/apps/StoreApp/index.tsx
@@ -15,6 +15,7 @@ import { resolveModel, type ResolveResponse } from "./resolver-types";
 import { compatVisuals } from "./compat-visuals";
 import { loadFilter, saveFilter } from "./storage";
 import { emitAppEvent, APP_INSTALLED } from "@/lib/app-event-bus";
+import { TaosAppsSection } from "./TaosAppsSection";
 
 /* ------------------------------------------------------------------
    Dashboard-icons CDN helper
@@ -1164,6 +1165,7 @@ export function StoreApp({ windowId: _windowId }: { windowId: string }) {
             <DiscoverView apps={apps} onInstall={handleInstall} installTargets={installTargets} />
           ) : showGrid ? (
             <>
+              {activeNav === "apps" && !searching && <TaosAppsSection />}
               <div className="mb-4 flex items-baseline justify-between">
                 <div>
                   <h2 className="text-[17px] font-bold text-shell-text">{searching ? `Results for "${search.trim()}"` : NAV.find((n) => n.id === activeNav)?.label}</h2>

--- a/desktop/src/components/Launchpad.tsx
+++ b/desktop/src/components/Launchpad.tsx
@@ -1,11 +1,12 @@
 import { useState, useMemo, useRef } from "react";
 import { Search, X } from "lucide-react";
-import { getAllApps, getApp, getOrRegisterServiceApp } from "@/registry/app-registry";
+import { getLaunchableApps, getApp, getOrRegisterServiceApp } from "@/registry/app-registry";
 import { useProcessStore } from "@/stores/process-store";
 import { useShortcut } from "@/hooks/use-shortcut-registry";
 import { LaunchpadIcon } from "./LaunchpadIcon";
 import { ServiceIcon } from "./ServiceIcon";
 import { useInstalledServices } from "@/hooks/use-installed-services";
+import { useInstalledOptionalApps } from "@/hooks/use-installed-optional-apps";
 
 interface Props {
   open: boolean;
@@ -26,6 +27,7 @@ export function Launchpad({ open, onClose, onOpenApp }: Props) {
   openRef.current = open;
   const { openWindow } = useProcessStore();
   const installedServices = useInstalledServices();
+  const installedOptional = useInstalledOptionalApps();
 
   // Register Escape at overlay priority so it beats any system shortcuts when open
   useShortcut("Escape", () => { if (openRef.current) onClose(); }, "Close launchpad", "overlay");
@@ -37,11 +39,13 @@ export function Launchpad({ open, onClose, onOpenApp }: Props) {
     // /api/apps/installed). Exclude any dynamically-registered service:* apps
     // from the registry grouping so they don't also appear under a built-in
     // category (e.g. SearXNG showing under both Platform and Services).
-    const all = getAllApps().filter((a) => !a.id.startsWith("service:"));
+    const all = getLaunchableApps(installedOptional).filter(
+      (a) => !a.id.startsWith("service:"),
+    );
     if (!query.trim()) return all;
     const q = query.toLowerCase();
     return all.filter((a) => a.name.toLowerCase().includes(q));
-  }, [query]);
+  }, [query, installedOptional]);
 
   const grouped = useMemo(() => {
     const groups: Record<string, typeof apps> = {};

--- a/desktop/src/components/SearchPalette.tsx
+++ b/desktop/src/components/SearchPalette.tsx
@@ -1,8 +1,9 @@
 import { useState, useMemo, useEffect, useRef } from "react";
 import { Search, X } from "lucide-react";
-import { getAllApps, getApp } from "@/registry/app-registry";
+import { getLaunchableApps, getApp } from "@/registry/app-registry";
 import { useProcessStore } from "@/stores/process-store";
 import { useShortcut } from "@/hooks/use-shortcut-registry";
+import { useInstalledOptionalApps } from "@/hooks/use-installed-optional-apps";
 import * as icons from "lucide-react";
 
 interface Props {
@@ -28,6 +29,7 @@ export function SearchPalette({ open, onClose, onOpenApp }: Props) {
   openRef.current = open;
   const { openWindow } = useProcessStore();
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const installedOptional = useInstalledOptionalApps();
 
   // Register Escape at overlay priority so it beats any system shortcuts when open
   useShortcut("Escape", () => { if (openRef.current) onClose(); }, "Close search", "overlay");
@@ -41,7 +43,7 @@ export function SearchPalette({ open, onClose, onOpenApp }: Props) {
   }, [open]);
 
   const appResults = useMemo<SearchResult[]>(() => {
-    const all = getAllApps();
+    const all = getLaunchableApps(installedOptional);
     const q = query.toLowerCase().trim();
 
     return all
@@ -62,7 +64,7 @@ export function SearchPalette({ open, onClose, onOpenApp }: Props) {
           onClose();
         },
       }));
-  }, [query, openWindow, onClose, onOpenApp]);
+  }, [query, openWindow, onClose, onOpenApp, installedOptional]);
 
   const [memoryResults, setMemoryResults] = useState<SearchResult[]>([]);
 

--- a/desktop/src/components/__tests__/Launchpad.test.tsx
+++ b/desktop/src/components/__tests__/Launchpad.test.tsx
@@ -1,10 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, act } from "@testing-library/react";
 import type { InstalledService } from "@/hooks/use-installed-services";
-import { emitAppEvent, APP_INSTALLED } from "@/lib/app-event-bus";
+import { emitAppEvent, onAppEvent, APP_INSTALLED } from "@/lib/app-event-bus";
 
 // Mockable list of installed services returned by the hook.
 let mockServices: InstalledService[] = [];
+
+vi.mock("@/hooks/use-installed-optional-apps", () => ({
+  useInstalledOptionalApps: () => new Set<string>(),
+}));
 
 vi.mock("@/hooks/use-installed-services", () => ({
   useInstalledServices: () => mockServices,
@@ -21,10 +25,11 @@ vi.mock("@/stores/process-store", () => ({
   useProcessStore: () => ({ openWindow }),
 }));
 
-// Registry: getAllApps returns no core apps so the test isolates the Services
-// section; getApp/getOrRegisterServiceApp echo a minimal manifest.
+// Registry: getLaunchableApps returns no core apps so the test isolates the
+// Services section; getApp/getOrRegisterServiceApp echo a minimal manifest.
 vi.mock("@/registry/app-registry", () => ({
   getAllApps: () => [],
+  getLaunchableApps: () => [],
   getApp: (id: string) => ({ id, defaultSize: { w: 100, h: 100 } }),
   getOrRegisterServiceApp: (appId: string, displayName: string) => ({
     id: `service:${appId}`,
@@ -94,7 +99,6 @@ describe("Launchpad Services section", () => {
     // Verify the EventBus module works correctly in isolation:
     // emitting an event should invoke any registered listener.
     const listener = vi.fn();
-    const { onAppEvent } = require("@/lib/app-event-bus");
     const unsub = onAppEvent(APP_INSTALLED, listener);
     act(() => { emitAppEvent(APP_INSTALLED, "searxng"); });
     expect(listener).toHaveBeenCalledWith("searxng");

--- a/desktop/src/components/mobile/MobileHomePages.tsx
+++ b/desktop/src/components/mobile/MobileHomePages.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import * as icons from "lucide-react";
 import { useMobileHomeStore, type HomePage } from "@/stores/mobile-home-store";
 import { getApp } from "@/registry/app-registry";
+import { useInstalledOptionalApps } from "@/hooks/use-installed-optional-apps";
 import { GreetingWidget } from "@/components/widgets/GreetingWidget";
 import { ClockWidget } from "@/components/widgets/ClockWidget";
 import { AgentStatusWidget } from "@/components/widgets/AgentStatusWidget";
@@ -238,10 +239,31 @@ function PageContent({ page, onOpenApp }: { page: HomePage; onOpenApp: (appId: s
 }
 
 export function MobileHomePages({ onOpenApp }: Props) {
-  const pages = useMobileHomeStore((s) => s.pages);
+  const storePages = useMobileHomeStore((s) => s.pages);
   const activePageIndex = useMobileHomeStore((s) => s.activePageIndex);
   const setActivePage = useMobileHomeStore((s) => s.setActivePage);
+  const installedOptional = useInstalledOptionalApps();
   const touchStartX = React.useRef<number | null>(null);
+
+  // Optional apps (Reddit/YouTube/GitHub/X) are excluded from the default grid
+  // and only appear once installed from the Store. The mobile home is the only
+  // launcher on phones, so append any installed optional app that isn't already
+  // placed on a page to the last page, where it becomes reachable.
+  const pages = React.useMemo<HomePage[]>(() => {
+    if (installedOptional.size === 0) return storePages;
+    const placed = new Set(
+      storePages.flatMap((p) =>
+        p.items.filter((i) => i.type === "app").map((i) => (i as { appId: string }).appId),
+      ),
+    );
+    const missing = [...installedOptional].filter((id) => !placed.has(id));
+    if (missing.length === 0) return storePages;
+    const next = storePages.map((p) => ({ ...p, items: [...p.items] }));
+    const last = next[next.length - 1];
+    if (!last) return [{ items: missing.map((id) => ({ type: "app", appId: id })) }];
+    for (const id of missing) last.items.push({ type: "app", appId: id });
+    return next;
+  }, [storePages, installedOptional]);
 
   const activePage = pages[activePageIndex] ?? pages[0];
 

--- a/desktop/src/hooks/use-installed-optional-apps.ts
+++ b/desktop/src/hooks/use-installed-optional-apps.ts
@@ -1,0 +1,41 @@
+import { useCallback, useEffect, useState } from "react";
+import { onAppEvent, APP_OPTIONAL_CHANGED } from "@/lib/app-event-bus";
+
+/**
+ * Tracks which optional frontend apps (Reddit / YouTube / GitHub / X) the user
+ * has installed from the Store. Returns the set of installed app ids.
+ *
+ * Re-fetches whenever an APP_OPTIONAL_CHANGED event fires (Store install /
+ * remove), so the launchpad, search palette, and mobile home surface or hide
+ * the app immediately without a reload.
+ *
+ * The set is empty while loading or on error — optional apps stay hidden, which
+ * is the correct default (they are opt-in).
+ */
+export function useInstalledOptionalApps(): Set<string> {
+  const [installed, setInstalled] = useState<Set<string>>(() => new Set());
+
+  const fetchInstalled = useCallback(() => {
+    let cancelled = false;
+    fetch("/api/apps/optional/installed", { headers: { Accept: "application/json" } })
+      .then((r) => (r.ok ? r.json() : { installed: [] }))
+      .then((data: { installed?: string[] }) => {
+        if (!cancelled) setInstalled(new Set(data.installed ?? []));
+      })
+      .catch(() => {
+        // Leave the set as-is on error; optional apps simply stay hidden.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => fetchInstalled(), [fetchInstalled]);
+
+  useEffect(
+    () => onAppEvent(APP_OPTIONAL_CHANGED, () => fetchInstalled()),
+    [fetchInstalled],
+  );
+
+  return installed;
+}

--- a/desktop/src/lib/app-event-bus.ts
+++ b/desktop/src/lib/app-event-bus.ts
@@ -30,3 +30,10 @@ export function onAppEvent(
 
 /** Event name emitted on successful app install. */
 export const APP_INSTALLED = "app.installed";
+
+/**
+ * Emitted when an optional frontend app is installed or removed from the Store,
+ * so the launchpad / search / mobile home re-fetch their installed set and the
+ * app appears or disappears immediately. Detail is the affected app id.
+ */
+export const APP_OPTIONAL_CHANGED = "app.optional.changed";

--- a/desktop/src/registry/app-registry.ts
+++ b/desktop/src/registry/app-registry.ts
@@ -11,6 +11,13 @@ export interface AppManifest {
   singleton: boolean;
   pinned: boolean;
   launchpadOrder: number;
+  /**
+   * Optional apps ship in the build but are NOT installed by default. The
+   * desktop launcher (launchpad, search, mobile home) hides them until the
+   * user installs them from the Store's "taOS Apps" section. Install state is
+   * persisted server-side (installed_apps, kind=frontend-app).
+   */
+  optional?: boolean;
 }
 
 const apps: AppManifest[] = [
@@ -35,10 +42,10 @@ const apps: AppManifest[] = [
   { id: "import", name: "Import", icon: "upload", category: "platform", component: () => import("@/apps/ImportApp").then((m) => ({ default: m.ImportApp })), defaultSize: { w: 700, h: 450 }, minSize: { w: 400, h: 300 }, singleton: true, pinned: false, launchpadOrder: 12 },
   { id: "images", name: "Images", icon: "image", category: "platform", component: () => import("@/apps/ImagesApp").then((m) => ({ default: m.ImagesApp })), defaultSize: { w: 900, h: 600 }, minSize: { w: 500, h: 400 }, singleton: true, pinned: false, launchpadOrder: 13 },
   { id: "library", name: "Library", icon: "book-open", category: "platform", component: () => import("@/apps/LibraryApp").then((m) => ({ default: m.LibraryApp })), defaultSize: { w: 1000, h: 650 }, minSize: { w: 550, h: 400 }, singleton: true, pinned: true, launchpadOrder: 13.5 },
-  { id: "reddit", name: "Reddit", icon: "scroll-text", category: "platform", component: () => import("@/apps/RedditApp").then((m) => ({ default: m.RedditApp })), defaultSize: { w: 1000, h: 650 }, minSize: { w: 550, h: 400 }, singleton: true, pinned: false, launchpadOrder: 14 },
-  { id: "youtube-library", name: "YouTube", icon: "play-circle", category: "platform", component: () => import("@/apps/YouTubeApp").then((m) => ({ default: m.YouTubeApp })), defaultSize: { w: 1050, h: 700 }, minSize: { w: 600, h: 450 }, singleton: true, pinned: false, launchpadOrder: 14.5 },
-  { id: "github-browser", name: "GitHub", icon: "github", category: "platform", component: () => import("@/apps/GitHubApp").then((m) => ({ default: m.GitHubApp })), defaultSize: { w: 1000, h: 650 }, minSize: { w: 550, h: 400 }, singleton: true, pinned: false, launchpadOrder: 15 },
-  { id: "x-monitor", name: "X", icon: "at-sign", category: "platform", component: () => import("@/apps/XApp").then((m) => ({ default: m.XApp })), defaultSize: { w: 1000, h: 650 }, minSize: { w: 550, h: 400 }, singleton: true, pinned: false, launchpadOrder: 15.5 },
+  { id: "reddit", name: "Reddit", icon: "scroll-text", category: "platform", component: () => import("@/apps/RedditApp").then((m) => ({ default: m.RedditApp })), defaultSize: { w: 1000, h: 650 }, minSize: { w: 550, h: 400 }, singleton: true, pinned: false, launchpadOrder: 14, optional: true },
+  { id: "youtube-library", name: "YouTube", icon: "play-circle", category: "platform", component: () => import("@/apps/YouTubeApp").then((m) => ({ default: m.YouTubeApp })), defaultSize: { w: 1050, h: 700 }, minSize: { w: 600, h: 450 }, singleton: true, pinned: false, launchpadOrder: 14.5, optional: true },
+  { id: "github-browser", name: "GitHub", icon: "github", category: "platform", component: () => import("@/apps/GitHubApp").then((m) => ({ default: m.GitHubApp })), defaultSize: { w: 1000, h: 650 }, minSize: { w: 550, h: 400 }, singleton: true, pinned: false, launchpadOrder: 15, optional: true },
+  { id: "x-monitor", name: "X", icon: "at-sign", category: "platform", component: () => import("@/apps/XApp").then((m) => ({ default: m.XApp })), defaultSize: { w: 1000, h: 650 }, minSize: { w: 550, h: 400 }, singleton: true, pinned: false, launchpadOrder: 15.5, optional: true },
   { id: "agent-browsers", name: "Browsers", icon: "globe", category: "platform", component: () => import("@/apps/AgentBrowsersApp").then((m) => ({ default: m.AgentBrowsersApp })), defaultSize: { w: 1000, h: 650 }, minSize: { w: 550, h: 400 }, singleton: true, pinned: false, launchpadOrder: 16 },
 
   // OS apps
@@ -101,6 +108,20 @@ export function getAppsByCategory(category: AppManifest["category"]): AppManifes
 
 export function getAllApps(): AppManifest[] {
   return [...apps].sort((a, b) => a.launchpadOrder - b.launchpadOrder);
+}
+
+/** The optional (Store-installable) apps, in launchpad order. */
+export function getOptionalApps(): AppManifest[] {
+  return getAllApps().filter((a) => a.optional);
+}
+
+/**
+ * Apps the desktop launcher should surface: every always-on app plus the
+ * optional apps the user has installed. `installedOptional` is the set of
+ * installed optional app ids (from /api/apps/optional/installed).
+ */
+export function getLaunchableApps(installedOptional: Set<string>): AppManifest[] {
+  return getAllApps().filter((a) => !a.optional || installedOptional.has(a.id));
 }
 
 const prefetched = new Set<string>();

--- a/desktop/src/registry/optional-apps.ts
+++ b/desktop/src/registry/optional-apps.ts
@@ -1,0 +1,50 @@
+/**
+ * Presentation metadata for the optional, Store-installable frontend apps
+ * (Reddit / YouTube / GitHub / X). The registry (app-registry.ts) owns the
+ * runtime manifest (component, sizing); this owns how they look in the Store's
+ * "taOS Apps" section. ids must match the registry entries marked `optional`.
+ */
+
+export interface OptionalAppMeta {
+  /** Registry app id — must match an `optional: true` manifest. */
+  id: string;
+  /** Display name. */
+  name: string;
+  /** lucide-react icon name (rendered via the shared Icon component). */
+  icon: string;
+  /** One-line description for the Store card. */
+  tagline: string;
+  /** Brand-tinted CSS background for the card cover. */
+  cover: string;
+}
+
+export const OPTIONAL_APPS: OptionalAppMeta[] = [
+  {
+    id: "reddit",
+    name: "Reddit",
+    icon: "scroll-text",
+    tagline: "Browse subreddits, posts, and comments inside taOS.",
+    cover: "linear-gradient(135deg, #ff4500 0%, #cc3700 100%)",
+  },
+  {
+    id: "youtube-library",
+    name: "YouTube",
+    icon: "play-circle",
+    tagline: "A focused video library and watch surface.",
+    cover: "linear-gradient(135deg, #ff0033 0%, #b3001f 100%)",
+  },
+  {
+    id: "github-browser",
+    name: "GitHub",
+    icon: "github",
+    tagline: "Track repos, issues, and pull requests at a glance.",
+    cover: "linear-gradient(135deg, #2b3137 0%, #14161a 100%)",
+  },
+  {
+    id: "x-monitor",
+    name: "X",
+    icon: "at-sign",
+    tagline: "Monitor timelines and posts from X.",
+    cover: "linear-gradient(135deg, #1a1a1a 0%, #000000 100%)",
+  },
+];

--- a/desktop/src/stores/mobile-home-store.test.ts
+++ b/desktop/src/stores/mobile-home-store.test.ts
@@ -3,7 +3,7 @@ import { useMobileHomeStore } from "./mobile-home-store";
 import { getAllApps } from "@/registry/app-registry";
 
 describe("mobile-home-store", () => {
-  it("home grid includes every registered app", () => {
+  it("home grid includes every non-optional registered app", () => {
     const { pages } = useMobileHomeStore.getState();
     const allIdsInPages = new Set(
       pages.flatMap((p) =>
@@ -12,9 +12,15 @@ describe("mobile-home-store", () => {
           .map((i) => (i as { type: "app"; appId: string }).appId),
       ),
     );
-    const registryIds = getAllApps().map((a) => a.id);
-    for (const id of registryIds) {
+    // Optional apps (Reddit/YouTube/GitHub/X) ship uninstalled and are added
+    // from the Store, so they are intentionally absent from the default grid.
+    const defaultIds = getAllApps().filter((a) => !a.optional).map((a) => a.id);
+    for (const id of defaultIds) {
       expect(allIdsInPages.has(id), `missing app "${id}" in home grid`).toBe(true);
+    }
+    const optionalIds = getAllApps().filter((a) => a.optional).map((a) => a.id);
+    for (const id of optionalIds) {
+      expect(allIdsInPages.has(id), `optional app "${id}" should NOT be in default grid`).toBe(false);
     }
   });
 

--- a/desktop/src/stores/mobile-home-store.ts
+++ b/desktop/src/stores/mobile-home-store.ts
@@ -21,7 +21,11 @@ const DEFAULT_PAGES: HomePage[] = [
     ],
   },
   {
-    items: getAllApps().map((a) => ({ type: "app", appId: a.id }) as AppItem),
+    // Optional apps (Reddit/YouTube/GitHub/X) are excluded from the default
+    // home grid; they ship uninstalled and are added from the Store.
+    items: getAllApps()
+      .filter((a) => !a.optional)
+      .map((a) => ({ type: "app", appId: a.id }) as AppItem),
   },
 ];
 

--- a/tests/test_apps_installed.py
+++ b/tests/test_apps_installed.py
@@ -163,3 +163,51 @@ class TestMultipleApps:
         item = resp.json()[0]
         for key in ("app_id", "display_name", "icon", "url", "category", "backend", "status"):
             assert key in item, f"Missing key: {key}"
+
+
+class TestOptionalApps:
+    @pytest.mark.asyncio
+    async def test_install_then_listed(self, apps_client):
+        client, _ = apps_client
+        # Nothing installed initially.
+        resp = await client.get("/api/apps/optional/installed")
+        assert resp.status_code == 200
+        assert resp.json() == {"installed": []}
+
+        # Install an allowlisted optional app.
+        resp = await client.post("/api/apps/optional/reddit/install")
+        assert resp.status_code == 200
+        assert resp.json()["app_id"] == "reddit"
+
+        resp = await client.get("/api/apps/optional/installed")
+        assert resp.json()["installed"] == ["reddit"]
+
+    @pytest.mark.asyncio
+    async def test_uninstall_removes(self, apps_client):
+        client, _ = apps_client
+        await client.post("/api/apps/optional/x-monitor/install")
+        resp = await client.get("/api/apps/optional/installed")
+        assert "x-monitor" in resp.json()["installed"]
+
+        resp = await client.post("/api/apps/optional/x-monitor/uninstall")
+        assert resp.status_code == 200
+        resp = await client.get("/api/apps/optional/installed")
+        assert "x-monitor" not in resp.json()["installed"]
+
+    @pytest.mark.asyncio
+    async def test_unknown_app_rejected(self, apps_client):
+        client, _ = apps_client
+        resp = await client.post("/api/apps/optional/not-a-real-app/install")
+        assert resp.status_code == 404
+        resp = await client.post("/api/apps/optional/not-a-real-app/uninstall")
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_optional_apps_excluded_from_services_list(self, apps_client):
+        """Installed optional frontend apps must NOT show as proxy services
+        (they have no runtime location)."""
+        client, _ = apps_client
+        await client.post("/api/apps/optional/github-browser/install")
+        resp = await client.get("/api/apps/installed")
+        ids = {i["app_id"] for i in resp.json()}
+        assert "github-browser" not in ids

--- a/tinyagentos/routes/apps.py
+++ b/tinyagentos/routes/apps.py
@@ -12,10 +12,22 @@ a runtime location.
 from __future__ import annotations
 
 from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
 
 router = APIRouter()
 
 _GENERIC_ICON = "/static/app-icons/generic-service.svg"
+
+# Optional, frontend-only desktop apps that ship in the build but are NOT
+# installed by default. They live in the Store under "taOS Apps" and the
+# desktop launcher hides them until the user installs one. Install state is a
+# single row in installed_apps tagged kind="frontend-app" (no runtime/service is
+# spawned), so these never appear in /api/apps/installed (which requires a
+# runtime location). The frontend owns name/icon/cover; the backend only tracks
+# which ids are installed, gated to this allowlist so the endpoint can't be used
+# to write arbitrary install rows.
+OPTIONAL_FRONTEND_APPS = {"reddit", "youtube-library", "github-browser", "x-monitor"}
+_FRONTEND_APP_KIND = "frontend-app"
 
 
 def _resolve_icon(manifest_icon: str, manifest_dir) -> str:
@@ -114,3 +126,57 @@ async def list_installed_apps(request: Request):
         })
 
     return result
+
+
+# --------------------------------------------------------------------------- #
+# Optional frontend apps (Reddit / YouTube / GitHub / X) — Store install state.
+# --------------------------------------------------------------------------- #
+
+
+@router.get("/api/apps/optional/installed")
+async def list_installed_optional_apps(request: Request):
+    """Return the ids of optional frontend apps the user has installed.
+
+    Shape: {"installed": ["reddit", "x-monitor"]}. The desktop launcher unions
+    this with the always-on apps to decide what to show; the Store uses it to
+    render Install vs Remove. Unknown/legacy rows are ignored via the allowlist.
+    """
+    store = getattr(request.app.state, "installed_apps", None)
+    if store is None:
+        return {"installed": []}
+    rows = await store.list_installed()
+    installed = [
+        r["app_id"]
+        for r in rows
+        if r["app_id"] in OPTIONAL_FRONTEND_APPS
+        and (r.get("metadata") or {}).get("kind") == _FRONTEND_APP_KIND
+    ]
+    return {"installed": installed}
+
+
+@router.post("/api/apps/optional/{app_id}/install")
+async def install_optional_app(app_id: str, request: Request):
+    """Mark an optional frontend app installed. Instant — no service is spawned.
+
+    Rejected unless app_id is in the OPTIONAL_FRONTEND_APPS allowlist so this
+    endpoint can't seed arbitrary install rows.
+    """
+    if app_id not in OPTIONAL_FRONTEND_APPS:
+        return JSONResponse({"error": f"not an optional app: {app_id}"}, status_code=404)
+    store = getattr(request.app.state, "installed_apps", None)
+    if store is None:
+        return JSONResponse({"error": "install store unavailable"}, status_code=503)
+    await store.install(app_id, metadata={"kind": _FRONTEND_APP_KIND})
+    return {"status": "installed", "app_id": app_id}
+
+
+@router.post("/api/apps/optional/{app_id}/uninstall")
+async def uninstall_optional_app(app_id: str, request: Request):
+    """Remove an optional frontend app so it leaves the launcher again."""
+    if app_id not in OPTIONAL_FRONTEND_APPS:
+        return JSONResponse({"error": f"not an optional app: {app_id}"}, status_code=404)
+    store = getattr(request.app.state, "installed_apps", None)
+    if store is None:
+        return JSONResponse({"error": "install store unavailable"}, status_code=503)
+    await store.uninstall(app_id)
+    return {"status": "uninstalled", "app_id": app_id}


### PR DESCRIPTION
## What

Reddit, YouTube, GitHub, and X were always-on platform apps baked into the desktop. This makes them **optional**: they ship in the build but are not installed by default, and the user installs the ones they want from the Store's new **taOS Apps** section.

## How

- `AppManifest.optional` flag; the four are marked optional. New `getLaunchableApps(installedOptional)` returns always-on apps plus installed optional ones.
- Launchpad, SearchPalette, and the mobile home grid filter by install state via a new `useInstalledOptionalApps` hook (re-fetches on an `APP_OPTIONAL_CHANGED` event).
- Store gains a **taOS Apps** section (`TaosAppsSection`) with instant one-click Install/Remove -- no device target or progress, since these are frontend-only.
- Backend: `/api/apps/optional/installed` + per-app install/uninstall, backed by `installed_apps` (kind=`frontend-app`, no service spawned), gated to an allowlist. They never appear in `/api/apps/installed` (no runtime location).

## Behaviour change

On existing setups these four leave the launcher until installed from the Store. That is the intended "optional rather than installed by standard" behaviour.

## Tests

- Backend: install/uninstall/list + allowlist rejection + excluded-from-services (4 new, all green).
- Frontend: Launchpad + mobile-home tests updated for the new default; both suites pass.
- tsc clean, production build clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "taOS Apps" section in the Store to install and manage optional applications
  * Users can install or uninstall optional apps including Reddit, YouTube, GitHub, and X
  * Installed apps immediately appear in the launcher; uninstalled apps are removed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->