### PR TITLE
feat(desktop): agent-callable screenshot + capture flash effect

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -39,6 +39,7 @@
         "highlight.js": "^11.11.1",
         "lucide-react": "^0.500.0",
         "mathjs": "^15.2.0",
+        "modern-screenshot": "^4.7.0",
         "motion": "^12.40.0",
         "plyr": "^3.8.4",
         "react": "^19.2.7",
@@ -7983,6 +7984,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/modern-screenshot": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/modern-screenshot/-/modern-screenshot-4.7.0.tgz",
+      "integrity": "sha512-9YxN+ddPSMMlhylOv25VHzXrl9u67QRxoh7+SEewGtgUw7t6hHTrjptSDJUSne9oG4Xk/h2cwG15nIt4Hc9ujg==",
+      "license": "MIT"
     },
     "node_modules/motion": {
       "version": "12.40.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -43,6 +43,7 @@
     "highlight.js": "^11.11.1",
     "lucide-react": "^0.500.0",
     "mathjs": "^15.2.0",
+    "modern-screenshot": "^4.7.0",
     "motion": "^12.40.0",
     "plyr": "^3.8.4",
     "react": "^19.2.7",

--- a/desktop/src/components/Desktop.tsx
+++ b/desktop/src/components/Desktop.tsx
@@ -16,6 +16,7 @@ import { WallpaperPicker } from "./WallpaperPicker";
 import { DesktopIcons } from "./DesktopIcons";
 import { ParticlesWallpaper } from "./ParticlesWallpaper";
 import { WallpaperTextOverlay } from "./WallpaperTextOverlay";
+import { ScreenshotFlash } from "./ScreenshotFlash";
 
 type ContextMenuState = {
   x: number;
@@ -145,6 +146,7 @@ export function Desktop() {
     >
       {isAnimated && wallpaperComponent === "particles" && <ParticlesWallpaper />}
       {showOverlayText && wallpaperOverlayText && <WallpaperTextOverlay text={wallpaperOverlayText} />}
+      <ScreenshotFlash />
       <DesktopIcons />
       <SnapOverlay bounds={previewBounds} />
       <WidgetLayer />

--- a/desktop/src/components/ScreenshotFlash.tsx
+++ b/desktop/src/components/ScreenshotFlash.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useRef, useState } from "react";
+import { SCREENSHOT_FLASH_EVENT } from "@/hooks/use-desktop-command-stream";
+
+/**
+ * A subtle screen effect played when a desktop screenshot is captured (agent or
+ * user). A quick aperture-style flash: a soft white veil fades in and out while
+ * a thin inset frame pulses, evoking a camera shutter without being jarring.
+ *
+ * Marked data-screenshot-exclude so it never appears in the captured image even
+ * though it is on-screen during the (sub-second) rasterisation.
+ *
+ * Respects prefers-reduced-motion: a single brief opacity blip, no scale.
+ */
+export function ScreenshotFlash() {
+  const [active, setActive] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const onFlash = () => {
+      setActive(false);
+      // Force a reflow so re-triggering restarts the animation.
+      requestAnimationFrame(() => setActive(true));
+      if (timer.current) clearTimeout(timer.current);
+      timer.current = setTimeout(() => setActive(false), 600);
+    };
+    window.addEventListener(SCREENSHOT_FLASH_EVENT, onFlash);
+    return () => {
+      window.removeEventListener(SCREENSHOT_FLASH_EVENT, onFlash);
+      if (timer.current) clearTimeout(timer.current);
+    };
+  }, []);
+
+  if (!active) return null;
+
+  return (
+    <div
+      data-screenshot-exclude="true"
+      aria-hidden="true"
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 2147483646,
+        pointerEvents: "none",
+      }}
+    >
+      <div className="taos-shot-veil" />
+      <div className="taos-shot-frame" />
+      <style>{`
+        @keyframes taos-shot-veil {
+          0% { opacity: 0; }
+          12% { opacity: 0.55; }
+          100% { opacity: 0; }
+        }
+        @keyframes taos-shot-frame {
+          0% { opacity: 0; transform: scale(1.012); }
+          15% { opacity: 1; transform: scale(1); }
+          100% { opacity: 0; transform: scale(1); }
+        }
+        .taos-shot-veil {
+          position: absolute; inset: 0;
+          background: radial-gradient(120% 120% at 50% 50%, #ffffff 0%, #ffffff 60%, rgba(255,255,255,0.6) 100%);
+          animation: taos-shot-veil 600ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+        }
+        .taos-shot-frame {
+          position: absolute; inset: 10px;
+          border: 2px solid rgba(255,255,255,0.85);
+          border-radius: 14px;
+          box-shadow: 0 0 0 1px rgba(0,0,0,0.15), inset 0 0 40px rgba(255,255,255,0.25);
+          animation: taos-shot-frame 600ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .taos-shot-veil { animation-duration: 300ms; }
+          .taos-shot-veil { background: rgba(255,255,255,0.9); }
+          .taos-shot-frame { display: none; }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/desktop/src/components/TaosAssistantPanel.tsx
+++ b/desktop/src/components/TaosAssistantPanel.tsx
@@ -23,6 +23,7 @@ import {
   grantScreenCapture,
   hasScreenCapture,
   revokeScreenCapture,
+  SCREEN_CAPTURE_CHANGED_EVENT,
 } from "@/lib/screen-capture";
 import { useProcessStore } from "@/stores/process-store";
 
@@ -481,12 +482,18 @@ function AttachButton({ onClick, disabled }: { onClick: () => void; disabled: bo
  */
 function ScreenCaptureGrantButton() {
   const [granted, setGranted] = useState(hasScreenCapture());
+  // Stay in sync when the share ends from anywhere (native browser bar, another
+  // control), not just our own click.
+  useEffect(() => {
+    const sync = () => setGranted(hasScreenCapture());
+    window.addEventListener(SCREEN_CAPTURE_CHANGED_EVENT, sync);
+    return () => window.removeEventListener(SCREEN_CAPTURE_CHANGED_EVENT, sync);
+  }, []);
   const toggle = useCallback(async () => {
     if (hasScreenCapture()) {
       revokeScreenCapture();
-      setGranted(false);
     } else {
-      setGranted(await grantScreenCapture());
+      await grantScreenCapture();
     }
   }, []);
   return (

--- a/desktop/src/components/TaosAssistantPanel.tsx
+++ b/desktop/src/components/TaosAssistantPanel.tsx
@@ -6,6 +6,7 @@ import {
   Settings,
   Paperclip,
   Camera,
+  MonitorUp,
   ExternalLink,
   Copy,
   Check,
@@ -18,6 +19,11 @@ import {
   uploadChatAttachment,
   type AttachmentRecord,
 } from "@/lib/taos-agent-api";
+import {
+  grantScreenCapture,
+  hasScreenCapture,
+  revokeScreenCapture,
+} from "@/lib/screen-capture";
 import { useProcessStore } from "@/stores/process-store";
 
 export interface PendingAttachment {
@@ -339,6 +345,8 @@ export function TaosAssistantPanelInner({ embedded = false }: { embedded?: boole
         <div className="flex items-end gap-1 rounded-2xl border border-shell-border bg-shell-bg-deep px-2 py-1.5 transition-colors focus-within:border-accent/50">
           <AttachButton onClick={handleFileUpload} disabled={noModel || streaming} />
           <ScreenshotButton onClick={handleScreenshot} disabled={noModel || streaming} />
+          <ScreenCaptureGrantButton />
+
           <textarea
             ref={textareaRef}
             value={input}
@@ -461,6 +469,43 @@ function AttachButton({ onClick, disabled }: { onClick: () => void; disabled: bo
       className="grid place-items-center h-8 w-8 rounded-lg text-shell-text-tertiary hover:bg-shell-surface-hover hover:text-shell-text-secondary transition-colors shrink-0 disabled:opacity-40"
     >
       <Paperclip size={16} />
+    </button>
+  );
+}
+
+/**
+ * One-time screen-capture grant. getDisplayMedia needs a user gesture, so the
+ * user clicks this once; the stream then persists and agent screenshots
+ * (/api/desktop/screenshot) grab full-fidelity frames (incl. cross-origin
+ * iframes) with no further prompt. Click again to stop sharing.
+ */
+function ScreenCaptureGrantButton() {
+  const [granted, setGranted] = useState(hasScreenCapture());
+  const toggle = useCallback(async () => {
+    if (hasScreenCapture()) {
+      revokeScreenCapture();
+      setGranted(false);
+    } else {
+      setGranted(await grantScreenCapture());
+    }
+  }, []);
+  return (
+    <button
+      onClick={toggle}
+      aria-label={granted ? "Stop agent screen capture" : "Allow agent screen capture"}
+      title={
+        granted
+          ? "Agent screen capture ON -- click to stop sharing"
+          : "Allow agents to capture full-fidelity screenshots of this screen"
+      }
+      className={[
+        "grid place-items-center h-8 w-8 rounded-lg transition-colors shrink-0",
+        granted
+          ? "text-accent hover:bg-shell-surface-hover"
+          : "text-shell-text-tertiary hover:bg-shell-surface-hover hover:text-shell-text-secondary",
+      ].join(" ")}
+    >
+      <MonitorUp size={16} />
     </button>
   );
 }

--- a/desktop/src/hooks/use-desktop-command-stream.ts
+++ b/desktop/src/hooks/use-desktop-command-stream.ts
@@ -23,8 +23,6 @@ export const SCREENSHOT_FLASH_EVENT = "taos:screenshot-flash";
  * appear blank; the desktop chrome and native apps capture fully.
  */
 async function captureAndReport(requestId: string): Promise<void> {
-  // Flash first so the effect is visible in the capture's run, then rasterise.
-  window.dispatchEvent(new CustomEvent(SCREENSHOT_FLASH_EVENT));
   let body: { request_id: string; image?: string; error?: string };
   try {
     // Prefer a live screen-capture grant (full fidelity incl. cross-origin
@@ -49,6 +47,11 @@ async function captureAndReport(requestId: string): Promise<void> {
   } catch (e) {
     body = { request_id: requestId, error: e instanceof Error ? e.message : "capture failed" };
   }
+  // Flash AFTER the frame is captured so the white veil never leaks into a
+  // full-fidelity getDisplayMedia frame (that path captures the real composited
+  // screen, where an on-screen overlay is not excludable like the DOM-raster
+  // filter is). Still reads as a shutter: capture is sub-second.
+  window.dispatchEvent(new CustomEvent(SCREENSHOT_FLASH_EVENT));
   try {
     await fetch("/api/desktop/screenshot-result", {
       method: "POST",

--- a/desktop/src/hooks/use-desktop-command-stream.ts
+++ b/desktop/src/hooks/use-desktop-command-stream.ts
@@ -13,6 +13,43 @@ import { useEffect } from "react";
  * existing use-deep-navigation / use-desktop-control receivers. The browser
  * auto-reconnects on transient errors (same as the canvas stream).
  */
+/** Event the ScreenshotFlash overlay listens for to play the capture effect. */
+export const SCREENSHOT_FLASH_EVENT = "taos:screenshot-flash";
+
+/**
+ * Rasterise the live desktop and POST it back to resolve an agent screenshot
+ * request. Plays a subtle flash effect around the capture. DOM rasterisation
+ * cannot read cross-origin iframes (the Browser's proxied page), so those
+ * appear blank; the desktop chrome and native apps capture fully.
+ */
+async function captureAndReport(requestId: string): Promise<void> {
+  // Flash first so the effect is visible in the capture's run, then rasterise.
+  window.dispatchEvent(new CustomEvent(SCREENSHOT_FLASH_EVENT));
+  let body: { request_id: string; image?: string; error?: string };
+  try {
+    const { domToPng } = await import("modern-screenshot");
+    // Full viewport: top bar + desktop + dock.
+    const dataUrl = await domToPng(document.body, {
+      backgroundColor: getComputedStyle(document.body).backgroundColor || "#000",
+      // Skip the capture overlay/flash node itself.
+      filter: (node) =>
+        !(node instanceof HTMLElement && node.dataset.screenshotExclude === "true"),
+    });
+    body = { request_id: requestId, image: dataUrl };
+  } catch (e) {
+    body = { request_id: requestId, error: e instanceof Error ? e.message : "capture failed" };
+  }
+  try {
+    await fetch("/api/desktop/screenshot-result", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  } catch {
+    /* the agent side will time out and report it */
+  }
+}
+
 export function useDesktopCommandStream(): void {
   useEffect(() => {
     const es = new EventSource("/api/desktop/stream");
@@ -30,6 +67,9 @@ export function useDesktopCommandStream(): void {
         window.dispatchEvent(new CustomEvent("taos:open-app", { detail: cmd.payload ?? {} }));
       } else if (cmd.kind === "window") {
         window.dispatchEvent(new CustomEvent("taos:window", { detail: cmd.payload ?? {} }));
+      } else if (cmd.kind === "screenshot") {
+        const requestId = (cmd.payload?.request_id as string) ?? "";
+        if (requestId) void captureAndReport(requestId);
       }
     };
     es.onerror = () => {

--- a/desktop/src/hooks/use-desktop-command-stream.ts
+++ b/desktop/src/hooks/use-desktop-command-stream.ts
@@ -27,14 +27,24 @@ async function captureAndReport(requestId: string): Promise<void> {
   window.dispatchEvent(new CustomEvent(SCREENSHOT_FLASH_EVENT));
   let body: { request_id: string; image?: string; error?: string };
   try {
-    const { domToPng } = await import("modern-screenshot");
-    // Full viewport: top bar + desktop + dock.
-    const dataUrl = await domToPng(document.body, {
-      backgroundColor: getComputedStyle(document.body).backgroundColor || "#000",
-      // Skip the capture overlay/flash node itself.
-      filter: (node) =>
-        !(node instanceof HTMLElement && node.dataset.screenshotExclude === "true"),
-    });
+    // Prefer a live screen-capture grant (full fidelity incl. cross-origin
+    // iframes like the Browser's proxied page); fall back to DOM rasterisation
+    // (chrome + native apps only) when no grant is active.
+    const { hasScreenCapture, grabScreenFrame } = await import("@/lib/screen-capture");
+    let dataUrl: string | null = null;
+    if (hasScreenCapture()) {
+      dataUrl = await grabScreenFrame();
+    }
+    if (!dataUrl) {
+      const { domToPng } = await import("modern-screenshot");
+      // Full viewport: top bar + desktop + dock.
+      dataUrl = await domToPng(document.body, {
+        backgroundColor: getComputedStyle(document.body).backgroundColor || "#000",
+        // Skip the capture overlay/flash node itself.
+        filter: (node) =>
+          !(node instanceof HTMLElement && node.dataset.screenshotExclude === "true"),
+      });
+    }
     body = { request_id: requestId, image: dataUrl };
   } catch (e) {
     body = { request_id: requestId, error: e instanceof Error ? e.message : "capture failed" };

--- a/desktop/src/lib/screen-capture.ts
+++ b/desktop/src/lib/screen-capture.ts
@@ -18,6 +18,17 @@
 let _stream: MediaStream | null = null;
 let _video: HTMLVideoElement | null = null;
 
+/**
+ * Fired on window whenever the capture grant changes (granted, or stopped --
+ * including when the user ends the share from the browser's native bar). UI
+ * controls listen to stay in sync rather than only updating on their own click.
+ */
+export const SCREEN_CAPTURE_CHANGED_EVENT = "taos:screen-capture-changed";
+
+function _emitChange(): void {
+  window.dispatchEvent(new CustomEvent(SCREEN_CAPTURE_CHANGED_EVENT));
+}
+
 /** True when a live capture stream is available for frame grabs. */
 export function hasScreenCapture(): boolean {
   return !!_stream && _stream.getVideoTracks().some((t) => t.readyState === "live");
@@ -57,17 +68,20 @@ export async function grantScreenCapture(): Promise<boolean> {
     /* autoplay of a muted stream rarely fails; frames still grab from currentTime */
   }
   _video = video;
+  _emitChange();
   return true;
 }
 
 /** Stop the capture grant and release the stream. */
 export function revokeScreenCapture(): void {
+  const had = !!_stream;
   _stream?.getTracks().forEach((t) => t.stop());
   _stream = null;
   if (_video) {
     _video.srcObject = null;
     _video = null;
   }
+  if (had) _emitChange();
 }
 
 /**

--- a/desktop/src/lib/screen-capture.ts
+++ b/desktop/src/lib/screen-capture.ts
@@ -1,0 +1,113 @@
+/**
+ * Persistent screen-capture grant for full-fidelity agent screenshots.
+ *
+ * getDisplayMedia needs a user gesture and shows a prompt, and the browser will
+ * not let an agent call it headlessly. But the MediaStream it returns is
+ * persistent: the user grants ONCE (one gesture, one prompt) and we keep the
+ * stream alive, then grab frames from it on demand with no further prompt. This
+ * captures the real composited screen -- including cross-origin iframes (the
+ * Browser's proxied page) that DOM rasterisation cannot read.
+ *
+ * The user stays in control: the browser shows a sharing indicator and can stop
+ * the share at any time (we listen for 'ended' and clear the grant). A truly
+ * invisible/persistent grant that survives reload needs a native wrapper or a
+ * browser extension; this is the standard-web ceiling and covers agent-driven
+ * on-demand capture during a session.
+ */
+
+let _stream: MediaStream | null = null;
+let _video: HTMLVideoElement | null = null;
+
+/** True when a live capture stream is available for frame grabs. */
+export function hasScreenCapture(): boolean {
+  return !!_stream && _stream.getVideoTracks().some((t) => t.readyState === "live");
+}
+
+/**
+ * Prompt the user to grant screen capture (once per session). Returns true on
+ * grant. Safe to call again to re-grant after the user stopped sharing.
+ */
+export async function grantScreenCapture(): Promise<boolean> {
+  if (hasScreenCapture()) return true;
+  const md = navigator.mediaDevices;
+  if (!md?.getDisplayMedia) return false;
+  let stream: MediaStream;
+  try {
+    stream = await md.getDisplayMedia({
+      video: { frameRate: { ideal: 4, max: 10 } },
+      audio: false,
+      // Bias toward the taOS tab so a single click captures the desktop.
+      ...({ preferCurrentTab: true } as Record<string, unknown>),
+    });
+  } catch {
+    return false; // user cancelled or denied
+  }
+  _stream = stream;
+  const track = stream.getVideoTracks()[0];
+  if (track) {
+    track.addEventListener("ended", revokeScreenCapture);
+  }
+  const video = document.createElement("video");
+  video.muted = true;
+  video.playsInline = true;
+  video.srcObject = stream;
+  try {
+    await video.play();
+  } catch {
+    /* autoplay of a muted stream rarely fails; frames still grab from currentTime */
+  }
+  _video = video;
+  return true;
+}
+
+/** Stop the capture grant and release the stream. */
+export function revokeScreenCapture(): void {
+  _stream?.getTracks().forEach((t) => t.stop());
+  _stream = null;
+  if (_video) {
+    _video.srcObject = null;
+    _video = null;
+  }
+}
+
+/**
+ * Grab one frame from the live capture stream as a PNG data URL, or null when
+ * no capture is granted / no frame is available. Prefers ImageCapture
+ * (crisp, no scaling) and falls back to drawing the video element to a canvas.
+ */
+export async function grabScreenFrame(): Promise<string | null> {
+  if (!hasScreenCapture() || !_stream) return null;
+  const track = _stream.getVideoTracks()[0];
+  if (!track) return null;
+
+  // Preferred path: ImageCapture.grabFrame -> ImageBitmap -> canvas.
+  const ImageCaptureCtor = (window as unknown as { ImageCapture?: new (t: MediaStreamTrack) => { grabFrame(): Promise<ImageBitmap> } }).ImageCapture;
+  if (ImageCaptureCtor) {
+    try {
+      const bitmap = await new ImageCaptureCtor(track).grabFrame();
+      const canvas = document.createElement("canvas");
+      canvas.width = bitmap.width;
+      canvas.height = bitmap.height;
+      const ctx = canvas.getContext("2d");
+      if (ctx) {
+        ctx.drawImage(bitmap, 0, 0);
+        return canvas.toDataURL("image/png");
+      }
+    } catch {
+      /* fall through to the video path */
+    }
+  }
+
+  // Fallback: draw the playing <video> to a canvas.
+  if (_video && _video.videoWidth > 0) {
+    const canvas = document.createElement("canvas");
+    canvas.width = _video.videoWidth;
+    canvas.height = _video.videoHeight;
+    const ctx = canvas.getContext("2d");
+    if (ctx) {
+      ctx.drawImage(_video, 0, 0, canvas.width, canvas.height);
+      return canvas.toDataURL("image/png");
+    }
+  }
+  return null;
+}

--- a/tests/test_desktop_screenshot.py
+++ b/tests/test_desktop_screenshot.py
@@ -1,0 +1,34 @@
+"""Tests for the agent-callable desktop screenshot round-trip."""
+
+import pytest
+
+from tinyagentos.desktop_control.broker import DesktopCommandBroker
+
+
+class TestResultRegistry:
+    @pytest.mark.asyncio
+    async def test_register_resolve(self):
+        b = DesktopCommandBroker()
+        fut = b.register_result("r1")
+        assert not fut.done()
+        assert b.resolve_result("r1", {"image": "data:..."}) is True
+        assert await fut == {"image": "data:..."}
+
+    @pytest.mark.asyncio
+    async def test_resolve_unknown_returns_false(self):
+        b = DesktopCommandBroker()
+        assert b.resolve_result("missing", {}) is False
+
+    @pytest.mark.asyncio
+    async def test_discard_prevents_resolve(self):
+        b = DesktopCommandBroker()
+        b.register_result("r2")
+        b.discard_result("r2")
+        assert b.resolve_result("r2", {}) is False
+
+    @pytest.mark.asyncio
+    async def test_double_resolve_is_false(self):
+        b = DesktopCommandBroker()
+        b.register_result("r3")
+        assert b.resolve_result("r3", {"image": "x"}) is True
+        assert b.resolve_result("r3", {"image": "y"}) is False

--- a/tests/test_desktop_screenshot.py
+++ b/tests/test_desktop_screenshot.py
@@ -9,7 +9,7 @@ class TestResultRegistry:
     @pytest.mark.asyncio
     async def test_register_resolve(self):
         b = DesktopCommandBroker()
-        fut = b.register_result("r1")
+        fut = b.register_result("r1", "u1")
         assert not fut.done()
         assert b.resolve_result("r1", {"image": "data:..."}) is True
         assert await fut == {"image": "data:..."}
@@ -22,13 +22,22 @@ class TestResultRegistry:
     @pytest.mark.asyncio
     async def test_discard_prevents_resolve(self):
         b = DesktopCommandBroker()
-        b.register_result("r2")
+        b.register_result("r2", "u1")
         b.discard_result("r2")
         assert b.resolve_result("r2", {}) is False
 
     @pytest.mark.asyncio
     async def test_double_resolve_is_false(self):
         b = DesktopCommandBroker()
-        b.register_result("r3")
+        b.register_result("r3", "u1")
         assert b.resolve_result("r3", {"image": "x"}) is True
         assert b.resolve_result("r3", {"image": "y"}) is False
+
+
+class TestResultOwnership:
+    @pytest.mark.asyncio
+    async def test_wrong_user_cannot_resolve(self):
+        b = DesktopCommandBroker()
+        b.register_result("ro", "owner")
+        assert b.resolve_result("ro", {"image": "x"}, user_id="attacker") is False
+        assert b.resolve_result("ro", {"image": "x"}, user_id="owner") is True

--- a/tinyagentos/desktop_control/broker.py
+++ b/tinyagentos/desktop_control/broker.py
@@ -43,6 +43,29 @@ class DesktopCommandBroker:
     def __init__(self) -> None:
         self._queues: dict[str, list[asyncio.Queue[DesktopCommand]]] = {}
         self._lock = asyncio.Lock()
+        # Pending screenshot (and other request/response) round-trips, keyed by
+        # request_id. The agent endpoint registers a future, emits a command
+        # carrying the request_id, and awaits; the desktop POSTs the result back
+        # which resolves the future.
+        self._results: dict[str, asyncio.Future[Any]] = {}
+
+    def register_result(self, request_id: str) -> asyncio.Future[Any]:
+        """Register a pending result future for request_id and return it."""
+        loop = asyncio.get_event_loop()
+        fut: asyncio.Future[Any] = loop.create_future()
+        self._results[request_id] = fut
+        return fut
+
+    def resolve_result(self, request_id: str, value: Any) -> bool:
+        """Resolve a pending result. Returns False if no one is waiting."""
+        fut = self._results.get(request_id)
+        if fut is None or fut.done():
+            return False
+        fut.set_result(value)
+        return True
+
+    def discard_result(self, request_id: str) -> None:
+        self._results.pop(request_id, None)
 
     async def subscribe(self, user_id: str) -> asyncio.Queue[DesktopCommand]:
         queue: asyncio.Queue[DesktopCommand] = asyncio.Queue(maxsize=self._MAX_QUEUE)

--- a/tinyagentos/desktop_control/broker.py
+++ b/tinyagentos/desktop_control/broker.py
@@ -48,16 +48,23 @@ class DesktopCommandBroker:
         # carrying the request_id, and awaits; the desktop POSTs the result back
         # which resolves the future.
         self._results: dict[str, asyncio.Future[Any]] = {}
+        # Owner user_id per pending request, so a result can only be resolved by
+        # the user who initiated it (defence in depth on top of the unguessable
+        # request_id, which is only ever delivered to that user's desktops).
+        self._result_owner: dict[str, str] = {}
 
-    def register_result(self, request_id: str) -> asyncio.Future[Any]:
+    def register_result(self, request_id: str, owner_user_id: str) -> asyncio.Future[Any]:
         """Register a pending result future for request_id and return it."""
-        loop = asyncio.get_event_loop()
-        fut: asyncio.Future[Any] = loop.create_future()
+        fut: asyncio.Future[Any] = asyncio.get_running_loop().create_future()
         self._results[request_id] = fut
+        self._result_owner[request_id] = owner_user_id
         return fut
 
-    def resolve_result(self, request_id: str, value: Any) -> bool:
-        """Resolve a pending result. Returns False if no one is waiting."""
+    def resolve_result(self, request_id: str, value: Any, *, user_id: str | None = None) -> bool:
+        """Resolve a pending result. Returns False if no one is waiting, or if
+        user_id is given and does not own the request."""
+        if user_id is not None and self._result_owner.get(request_id) != user_id:
+            return False
         fut = self._results.get(request_id)
         if fut is None or fut.done():
             return False
@@ -66,6 +73,7 @@ class DesktopCommandBroker:
 
     def discard_result(self, request_id: str) -> None:
         self._results.pop(request_id, None)
+        self._result_owner.pop(request_id, None)
 
     async def subscribe(self, user_id: str) -> asyncio.Queue[DesktopCommand]:
         queue: asyncio.Queue[DesktopCommand] = asyncio.Queue(maxsize=self._MAX_QUEUE)

--- a/tinyagentos/routes/desktop_control.py
+++ b/tinyagentos/routes/desktop_control.py
@@ -53,10 +53,16 @@ async def post_command(body: CommandIn, request: Request):
     return {"delivered": delivered}
 
 
+# Upper bound on an uploaded screenshot payload (base64 of the PNG). A 4K-ish
+# desktop PNG is well under this; the cap stops a rogue desktop from buffering
+# an unbounded body into memory.
+_MAX_SCREENSHOT_B64 = 24 * 1024 * 1024  # ~24 MB base64 (~18 MB image)
+
+
 class ScreenshotResultIn(BaseModel):
     request_id: str
     # data URL ("data:image/png;base64,....") or bare base64 of a PNG.
-    image: str
+    image: str = ""
     error: str = ""
 
 
@@ -75,7 +81,7 @@ async def take_screenshot(request: Request):
     broker = request.app.state.desktop_command_broker
     user_id = _user_id(request)
     request_id = uuid.uuid4().hex
-    fut = broker.register_result(request_id)
+    fut = broker.register_result(request_id, user_id)
     try:
         delivered = await broker.emit(
             user_id,
@@ -109,11 +115,16 @@ async def take_screenshot(request: Request):
 async def screenshot_result(body: ScreenshotResultIn, request: Request):
     """A desktop uploads its captured screenshot, resolving the waiting request.
 
-    Scoped implicitly: only this user's desktops ever receive the screenshot
-    command (which carries the request_id), so only they know a valid id."""
+    Scoped two ways: only this user's desktops ever receive the screenshot
+    command (which carries the request_id), and resolve_result re-checks that
+    the calling user owns the request before resolving."""
+    if len(body.image) > _MAX_SCREENSHOT_B64:
+        return JSONResponse({"error": "screenshot too large"}, status_code=413)
     broker = request.app.state.desktop_command_broker
     payload = {"error": body.error} if body.error else {"image": body.image}
-    resolved = broker.resolve_result(body.request_id, payload)
+    resolved = broker.resolve_result(
+        body.request_id, payload, user_id=_user_id(request),
+    )
     return {"resolved": resolved}
 
 

--- a/tinyagentos/routes/desktop_control.py
+++ b/tinyagentos/routes/desktop_control.py
@@ -10,12 +10,14 @@ the browser receivers already exist and are tested.
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
 import logging
+import uuid
 from typing import Any, Literal
 
 from fastapi import APIRouter, Request
-from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.responses import JSONResponse, Response, StreamingResponse
 from pydantic import BaseModel, Field
 
 from tinyagentos.desktop_control.broker import DesktopCommand
@@ -49,6 +51,70 @@ async def post_command(body: CommandIn, request: Request):
         DesktopCommand(kind=body.kind, payload=body.payload),
     )
     return {"delivered": delivered}
+
+
+class ScreenshotResultIn(BaseModel):
+    request_id: str
+    # data URL ("data:image/png;base64,....") or bare base64 of a PNG.
+    image: str
+    error: str = ""
+
+
+@router.post("/api/desktop/screenshot")
+async def take_screenshot(request: Request):
+    """Capture the calling user's live desktop and return a PNG.
+
+    Emits a `screenshot` command to every open desktop for the user; the first
+    desktop to respond uploads its rasterised canvas to
+    POST /api/desktop/screenshot-result, which resolves this request. 504 if no
+    desktop is connected or none responds within the deadline.
+
+    Note: DOM rasterisation cannot read cross-origin iframes (e.g. the Browser's
+    proxied page) -- the desktop chrome and native apps capture fully.
+    """
+    broker = request.app.state.desktop_command_broker
+    user_id = _user_id(request)
+    request_id = uuid.uuid4().hex
+    fut = broker.register_result(request_id)
+    try:
+        delivered = await broker.emit(
+            user_id,
+            DesktopCommand(kind="screenshot", payload={"request_id": request_id}),
+        )
+        if delivered == 0:
+            return JSONResponse(
+                {"error": "no desktop connected"}, status_code=409,
+            )
+        try:
+            result = await asyncio.wait_for(fut, timeout=20.0)
+        except asyncio.TimeoutError:
+            return JSONResponse(
+                {"error": "desktop did not respond in time"}, status_code=504,
+            )
+    finally:
+        broker.discard_result(request_id)
+
+    if isinstance(result, dict) and result.get("error"):
+        return JSONResponse({"error": result["error"]}, status_code=502)
+    data_url: str = result.get("image", "") if isinstance(result, dict) else ""
+    b64 = data_url.split(",", 1)[1] if data_url.startswith("data:") else data_url
+    try:
+        png = base64.b64decode(b64)
+    except Exception:
+        return JSONResponse({"error": "invalid image payload"}, status_code=502)
+    return Response(content=png, media_type="image/png")
+
+
+@router.post("/api/desktop/screenshot-result")
+async def screenshot_result(body: ScreenshotResultIn, request: Request):
+    """A desktop uploads its captured screenshot, resolving the waiting request.
+
+    Scoped implicitly: only this user's desktops ever receive the screenshot
+    command (which carries the request_id), so only they know a valid id."""
+    broker = request.app.state.desktop_command_broker
+    payload = {"error": body.error} if body.error else {"image": body.image}
+    resolved = broker.resolve_result(body.request_id, payload)
+    return {"resolved": resolved}
 
 
 @router.get("/api/desktop/stream")


### PR DESCRIPTION
## What
Adds the missing piece next to `open_app` / `arrange_windows`: an **agent-callable screenshot** so an agent can visually verify the OS it drives, plus a subtle **shutter flash** effect on capture.

## How
- `POST /api/desktop/screenshot` emits a `screenshot` command to every open desktop for the user and awaits the result (broker gains a request_id → future result registry).
- The desktop's command-stream handler rasterises the viewport with `modern-screenshot` and POSTs it to `POST /api/desktop/screenshot-result`, which resolves the request and returns a PNG.
- `ScreenshotFlash` plays a white-veil + inset-frame shutter effect (reduced-motion aware), marked `data-screenshot-exclude` so it never lands in the image.
- Broadcasts to all the user's connected desktops, so an agent action shows on every session.

## Limitation
DOM rasterisation cannot read cross-origin iframes (the Browser's proxied page) — desktop chrome + native apps capture fully. Full-pixel capture incl. web content stays on the user-gesture `getDisplayMedia` path (assistant panel).

## Tests
Broker result-registry tests (register/resolve/discard/double-resolve). tsc + build clean. New dep: modern-screenshot.

## Follow-up
Wire a `take_screenshot` skill/tool for the in-OS taOS agent (the HTTP endpoint already makes it callable).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added desktop screenshot capture and retrieval via new API endpoints, including PNG validation and timeout handling
  * Introduced a screen-capture grant toggle in the assistant panel to enable higher-fidelity captures
  * Added a brief full-screen flash overlay to indicate when a screenshot was triggered
  * Enforced per-request and per-user authorization for screenshot result delivery
* **Chores**
  * Added modern-screenshot dependency for fallback frame capture
* **Tests**
  * Added pytest coverage for screenshot result registration, resolution, discard behavior, and ownership checks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->