### PR TITLE
fix(canvas): contain crashes so a bad element does not take down Projects

### DIFF
--- a/desktop/src/apps/ProjectsApp/canvas/CanvasBoard.tsx
+++ b/desktop/src/apps/ProjectsApp/canvas/CanvasBoard.tsx
@@ -131,13 +131,21 @@ function hydrateEditor(
     if (toRemove.length) editor.deleteShapes(toRemove.map((s) => s.id) as any);
 
     for (const el of elements) {
-      const id = `shape:${el.id}` as TLShape["id"];
-      const existingShape = editor.getShape(id);
-      const newShape = elementToShape(el, projectSlug);
-      if (existingShape) {
-        editor.updateShape(newShape);
-      } else {
-        editor.createShape(newShape);
+      // Isolate each element: a single malformed shape (bad payload, a props
+      // shape tldraw's validator rejects, a version-skewed tldraw_shape) must
+      // not throw out of editor.run and take down the whole canvas. Skip it and
+      // keep going; the rest of the board still renders.
+      try {
+        const id = `shape:${el.id}` as TLShape["id"];
+        const existingShape = editor.getShape(id);
+        const newShape = elementToShape(el, projectSlug);
+        if (existingShape) {
+          editor.updateShape(newShape);
+        } else {
+          editor.createShape(newShape);
+        }
+      } catch (err) {
+        console.warn("canvas: skipping unrenderable element", el.id, err);
       }
     }
   });

--- a/desktop/src/apps/ProjectsApp/canvas/CanvasView.tsx
+++ b/desktop/src/apps/ProjectsApp/canvas/CanvasView.tsx
@@ -1,11 +1,17 @@
 import { CanvasBoard } from "./CanvasBoard";
+import { AppErrorBoundary } from "@/components/AppErrorBoundary";
 
 export function CanvasView({
   projectId, projectSlug,
 }: { projectId: string; projectSlug: string }) {
   return (
     <div style={{ height: "100%", padding: 0 }}>
-      <CanvasBoard projectId={projectId} projectSlug={projectSlug} />
+      {/* Contain any canvas/tldraw render crash to a fallback instead of taking
+          down the whole Projects app. Keyed by project so switching projects
+          gives a fresh boundary. */}
+      <AppErrorBoundary key={projectId}>
+        <CanvasBoard projectId={projectId} projectSlug={projectSlug} />
+      </AppErrorBoundary>
     </div>
   );
 }


### PR DESCRIPTION
## What
Jay hit a Projects canvas crash on open (frontend tldraw render error; backend healthy -- elements/stream/POST all 200/201). There was no error boundary, so the crash propagated.

## Fixes
- **hydrateEditor** isolates each element in try/catch -- a single malformed shape (bad payload, props the tldraw validator rejects, a version-skewed tldraw_shape) is skipped (warn) instead of throwing out of editor.run and crashing the whole canvas.
- **CanvasView** wraps CanvasBoard in AppErrorBoundary (keyed by project) so any remaining render crash shows a fallback instead of taking down the Projects app.

Defence-in-depth; the per-element isolation is the likely root-cause fix, the boundary is the safety net. Root-cause confirmation still wants the exact console error (awaiting Jay).

tsc + build clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved canvas stability by handling rendering errors gracefully—problematic elements are now skipped instead of halting the entire canvas load.
  * Added error isolation to prevent canvas rendering issues from affecting the rest of the Projects app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->