### PR TITLE
fix(browser): scope prefers-color-scheme matchMedia override to exact queries

### DIFF
--- a/tinyagentos/routes/desktop_browser/copilot.js
+++ b/tinyagentos/routes/desktop_browser/copilot.js
@@ -31,8 +31,14 @@
       if (!orig) return;
       window.matchMedia = function (q) {
         var qs = String(q);
-        if (/prefers-color-scheme/i.test(qs)) {
-          var wantDark = /dark/i.test(qs);
+        // Only override a query that is EXACTLY a prefers-color-scheme test with
+        // a dark/light value. Compound queries (e.g. "(min-width: 600px) and
+        // (prefers-color-scheme: dark)") or valueless ones fall through to the
+        // real matchMedia so their other conditions evaluate correctly --
+        // keying off just the colour-scheme term there returns wrong matches.
+        var m = /^\s*\(\s*prefers-color-scheme\s*:\s*(dark|light)\s*\)\s*$/i.exec(qs);
+        if (m) {
+          var wantDark = m[1].toLowerCase() === 'dark';
           var matches = wantDark ? isDark : !isDark;
           return {
             media: qs, matches: matches, onchange: null,


### PR DESCRIPTION
Gitar 💡 follow-up on #947. The proxied-site `matchMedia` patch matched any query containing `prefers-color-scheme` and keyed only on the dark/light term, so a compound query (`(min-width:600px) and (prefers-color-scheme: dark)`) or a valueless one returned wrong matches. Now only an exact `(prefers-color-scheme: dark|light)` query is overridden; everything else falls through to the real `matchMedia`. Regex + JS-syntax verified (copilot.js is served as-is, not bundled).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed color scheme preference emulation to correctly handle complex queries, preventing incorrect color scheme matches when multiple conditions are specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->