### PR TITLE
fix(canvas): coerce element payloads so malformed agent writes still render

### DIFF
--- a/desktop/src/apps/ProjectsApp/__tests__/element-to-shape.test.ts
+++ b/desktop/src/apps/ProjectsApp/__tests__/element-to-shape.test.ts
@@ -64,4 +64,56 @@ describe("elementToShape", () => {
     expect(s.meta.taos_author_id).toBe("bot");
     expect(s.meta.taos_author_kind).toBe("agent");
   });
+
+  // The backend only validates `kind`, not the payload shape, so an agent can
+  // store note/link/image elements whose payload would fail tldraw's strict
+  // props schema. elementToShape must coerce those to valid, renderable props
+  // instead of producing a shape that throws a ValidationError and vanishes.
+  describe("payload coercion (malformed agent writes still render)", () => {
+    it("note: fills a missing field with its default", () => {
+      const s = elementToShape(makeElement({ kind: "note", payload: { text: "hi", color: "blue" } }), "slug");
+      expect(s.props.taos_payload).toEqual({ text: "hi", color: "blue", font_size: 14 });
+    });
+
+    it("note: coerces a numeric string font_size to a number", () => {
+      const s = elementToShape(makeElement({ kind: "note", payload: { text: "x", color: "blue", font_size: "18" } }), "slug");
+      expect(s.props.taos_payload.font_size).toBe(18);
+    });
+
+    it("note: empty payload falls back to all defaults", () => {
+      const s = elementToShape(makeElement({ kind: "note", payload: {} }), "slug");
+      expect(s.props.taos_payload).toEqual({ text: "", color: "yellow", font_size: 14 });
+    });
+
+    it("link: missing/empty fields coerce to typed defaults", () => {
+      const s = elementToShape(makeElement({ kind: "link", payload: { url: "https://x.test" } }), "slug");
+      expect(s.props.taos_payload).toEqual({
+        url: "https://x.test",
+        title: "",
+        description: "",
+        preview_image_url: "",
+        favicon_url: "",
+        fetched_at: 0,
+      });
+    });
+
+    it("image: missing mime falls back to image/png", () => {
+      const s = elementToShape(makeElement({ kind: "image", payload: { file_id: "f1" } }), "slug");
+      expect(s.props.taos_payload).toEqual({ file_id: "f1", alt: "", mime: "image/png" });
+    });
+
+    it("coerces non-numeric geometry to numeric defaults", () => {
+      const s = elementToShape(
+        makeElement({ kind: "note", x: "5" as unknown as number, w: null as unknown as number, payload: {} }),
+        "slug",
+      );
+      expect(s.x).toBe(5);
+      expect(s.props.w).toBe(100);
+    });
+
+    it("coerces a non-enum author_kind to 'user'", () => {
+      const s = elementToShape(makeElement({ kind: "note", author_kind: "system" as unknown as "user", payload: {} }), "slug");
+      expect(s.props.taos_author_kind).toBe("user");
+    });
+  });
 });

--- a/desktop/src/apps/ProjectsApp/canvas/element-to-shape.ts
+++ b/desktop/src/apps/ProjectsApp/canvas/element-to-shape.ts
@@ -3,11 +3,20 @@ import { CanvasElement } from "./canvas-api";
 // Maps a backend CanvasElement to a tldraw shape descriptor.
 // Kept free of tldraw runtime imports so it can be unit tested in isolation.
 //
-// note/link/image use custom shape utils that declare the taos_* fields in
-// their own props schema, so those fields go in props. Any other kind falls
-// back to taos-generic, which only declares geometry props; its taos_* data
-// goes in shape.meta (tldraw allows arbitrary meta) to avoid a ValidationError.
-// Built-in tldraw shapes are never used here, so they never receive taos_* props.
+// note/link/image use custom shape utils whose props schema is STRICT: tldraw
+// validates every field's type at editor.createShape. The backend only
+// validates `kind`, so an agent can store a note/link/image whose payload is
+// missing a field or has the wrong type (e.g. font_size as the string "14", or
+// an empty payload). Feeding that raw payload into props makes tldraw throw a
+// ValidationError, so the element vanishes from the canvas (and, before the
+// per-element guard in CanvasBoard, took the whole board down). To keep
+// imperfect agent-authored content renderable, every payload field is coerced
+// to its declared type with a sensible default before it reaches props.
+//
+// Any other kind falls back to taos-generic, which only declares geometry
+// props; its taos_* data goes in shape.meta (tldraw allows arbitrary meta) to
+// avoid a ValidationError. Built-in tldraw shapes are never used here, so they
+// never receive taos_* props.
 
 export function shapeType(kind: string): string {
   if (kind === "note") return "taos-note";
@@ -16,21 +25,84 @@ export function shapeType(kind: string): string {
   return "taos-generic";
 }
 
+// --- Coercion helpers (pure, no tldraw imports so this stays unit-testable) ---
+
+function num(v: unknown, fallback: number): number {
+  if (typeof v === "number" && Number.isFinite(v)) return v;
+  if (typeof v === "string") {
+    const n = parseFloat(v);
+    if (Number.isFinite(n)) return n;
+  }
+  return fallback;
+}
+
+function str(v: unknown, fallback = ""): string {
+  if (typeof v === "string") return v;
+  if (typeof v === "number" || typeof v === "boolean") return String(v);
+  return fallback;
+}
+
+function authorKind(v: unknown): "user" | "agent" {
+  return v === "agent" ? "agent" : "user";
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function notePayload(p: any) {
+  return {
+    text: str(p?.text, ""),
+    color: str(p?.color, "yellow"),
+    font_size: num(p?.font_size, 14),
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function linkPayload(p: any) {
+  return {
+    url: str(p?.url),
+    title: str(p?.title),
+    description: str(p?.description),
+    preview_image_url: str(p?.preview_image_url),
+    favicon_url: str(p?.favicon_url),
+    fetched_at: num(p?.fetched_at, 0),
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function imagePayload(p: any) {
+  return {
+    file_id: str(p?.file_id),
+    alt: str(p?.alt),
+    mime: str(p?.mime, "image/png"),
+  };
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function elementToShape(el: CanvasElement, projectSlug: string): any {
-  const taosMeta = {
-    taos_kind: el.kind,
-    taos_payload: el.payload,
-    taos_author_id: el.author_id,
-    taos_author_kind: el.author_kind,
-  };
+  // Geometry is validated too (T.number), so coerce it as well: a malformed
+  // element still places on the board instead of throwing.
+  const x = num(el.x, 0);
+  const y = num(el.y, 0);
+  const w = num(el.w, 100);
+  const h = num(el.h, 100);
+  const rotation = num(el.rotation, 0);
 
   if (el.kind === "note" || el.kind === "link" || el.kind === "image") {
-    const baseProps = { w: el.w, h: el.h, ...taosMeta };
+    const taosFields = {
+      taos_kind: el.kind,
+      taos_payload:
+        el.kind === "note"
+          ? notePayload(el.payload)
+          : el.kind === "link"
+            ? linkPayload(el.payload)
+            : imagePayload(el.payload),
+      taos_author_id: str(el.author_id, "user"),
+      taos_author_kind: authorKind(el.author_kind),
+    };
+    const baseProps = { w, h, ...taosFields };
     return {
       id: `shape:${el.id}`,
       type: shapeType(el.kind),
-      x: el.x, y: el.y, rotation: el.rotation,
+      x, y, rotation,
       props: el.kind === "image"
         ? { ...baseProps, project_slug: projectSlug }
         : baseProps,
@@ -40,8 +112,14 @@ export function elementToShape(el: CanvasElement, projectSlug: string): any {
   return {
     id: `shape:${el.id}`,
     type: "taos-generic",
-    x: el.x, y: el.y, rotation: el.rotation,
-    props: { w: el.w, h: el.h },
-    meta: taosMeta,
+    x, y, rotation,
+    props: { w, h },
+    // Generic props are unvalidated, so the raw payload round-trips untouched.
+    meta: {
+      taos_kind: el.kind,
+      taos_payload: el.payload,
+      taos_author_id: el.author_id,
+      taos_author_kind: el.author_kind,
+    },
   };
 }


### PR DESCRIPTION
## Problem

The Projects canvas renders `note`/`link`/`image` elements through tldraw custom shapes whose props schema is **strict** (every field type-checked at `editor.createShape`). The backend only validates an element's `kind` (the `mermaid` kind I tested got rejected 422), **not** its `payload`. So an agent can store a note/link/image whose payload is missing a field, has the wrong type, or is empty, and the server happily accepts it (201).

Feeding that raw payload into tldraw props throws a `ValidationError`, so the element **silently vanishes** from the canvas. Before the per-element guard (#949) it threw out of `editor.run()` and took the **whole board** down (the "canvas crashed" report).

## Root cause (reproduced live on the Pi)

Writing notes with a missing / string / empty `font_size` produced, via SSE re-hydrate:

```
ValidationError: At shape(type = taos-note).props.taos_payload.font_size: Expected number, got undefined
ValidationError: At shape(type = taos-note).props.taos_payload.font_size: Expected number, got a string
ValidationError: At shape(type = taos-note).props.taos_payload.text:      Expected string, got undefined
```

Each was caught by #949's per-element guard and **skipped** (logged `canvas: skipping unrenderable element`), i.e. the element was accepted by the server but never shown.

## Fix

`elementToShape` now **coerces** every payload field to its declared type with a sensible default (and coerces geometry + `author_kind` too), so imperfect agent-authored content renders as a proper note/link/image instead of disappearing. Pure, tldraw-free coercion helpers keep the module unit-testable. Backend left permissive on purpose: be liberal in what we accept, render something useful (this also fixes already-stored bad data and version skew).

## Tests

Added coercion cases to `element-to-shape.test.ts` (missing field, numeric-string `font_size`, empty payload, link/image defaults, non-numeric geometry, non-enum `author_kind`). 13/13 pass; `tsc --noEmit` clean.

## Scope

Two files, frontend only. Complements #949 (which contained the crash); this removes the underlying cause so the guard rarely fires.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced data handling for notes, links, and images to gracefully manage malformed backend data with automatic normalization and sensible default values.

* **Tests**
  * Added test coverage for data coercion scenarios, including payload normalization and geometry fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->