### PR TITLE
fix(desktop): window move + resize jitter + off-screen recovery

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -283,7 +283,12 @@ export function App() {
               Return to fullscreen
             </button>
           )}
-          <div className={`transition-all duration-500 ${launched ? "opacity-100 scale-100" : "opacity-0 scale-95"}`}>
+          {/* Keep the entrance zoom (scale-95 -> none animates), but do NOT
+              retain a transform once launched: a `transform` on this ancestor
+              (even scale(1)) makes a containing block for every position:fixed
+              descendant, which pins the dock to the top and renders context
+              menus in the wrong corner. Steady state must be transform-free. */}
+          <div className={`transition-all duration-500 ${launched ? "opacity-100" : "opacity-0 scale-95"}`}>
             <div className="h-screen w-screen flex flex-col overflow-hidden bg-shell-bg text-shell-text">
               <EffectsLayer />
               <TopBar onSearchOpen={toggleSearch} onAssistantOpen={toggleAssistant} />

--- a/desktop/src/components/ContextMenu.tsx
+++ b/desktop/src/components/ContextMenu.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 
 export interface MenuItem {
@@ -103,7 +104,11 @@ export function ContextMenu({ x, y, items, onClose }: Props) {
   // Roving tabindex: track which navigable (non-separator, non-disabled) item is active
   let navigableCounter = -1;
 
-  return (
+  // Portal to <body> so the menu is never trapped inside a transformed ancestor
+  // (e.g. the dock's -translate-x-1/2). A transform on any ancestor makes a
+  // containing block for position:fixed, which would offset the menu away from
+  // the cursor. Rendered on body, its fixed coordinates are viewport-relative.
+  return createPortal(
     <div
       ref={menuRef}
       role="menu"
@@ -158,6 +163,7 @@ export function ContextMenu({ x, y, items, onClose }: Props) {
           </button>
         );
       })}
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/desktop/src/components/DockIcon.tsx
+++ b/desktop/src/components/DockIcon.tsx
@@ -20,6 +20,7 @@ export function DockIcon({ appId, isRunning, onClick }: Props) {
   const restoreWindow = useProcessStore((s) => s.restoreWindow);
   const minimizeWindow = useProcessStore((s) => s.minimizeWindow);
   const maximizeWindow = useProcessStore((s) => s.maximizeWindow);
+  const recenterWindow = useProcessStore((s) => s.recenterWindow);
   const closeWindow = useProcessStore((s) => s.closeWindow);
   const pinned = useDockStore((s) => s.pinned);
   const pin = useDockStore((s) => s.pin);
@@ -55,6 +56,11 @@ export function DockIcon({ appId, isRunning, onClick }: Props) {
           label: win.maximized ? "Restore" : "Maximise",
           icon: <icons.Maximize2 size={14} />,
           action: () => maximizeWindow(win.id),
+        },
+        {
+          label: "Center Window",
+          icon: <icons.LocateFixed size={14} />,
+          action: () => recenterWindow(win.id),
         },
         { label: "", separator: true },
         isPinned

--- a/desktop/src/components/Window.tsx
+++ b/desktop/src/components/Window.tsx
@@ -25,7 +25,7 @@ function WindowImpl({ win, onDrag, onDragStop }: Props) {
   const minimizeWindow = useProcessStore((s) => s.minimizeWindow);
   const maximizeWindow = useProcessStore((s) => s.maximizeWindow);
   const updatePosition = useProcessStore((s) => s.updatePosition);
-  const updateSize = useProcessStore((s) => s.updateSize);
+  const updateBounds = useProcessStore((s) => s.updateBounds);
   const snapWindow = useProcessStore((s) => s.snapWindow);
   const app = getApp(win.appId);
   const preSnapRef = useRef<{ x: number; y: number; w: number; h: number } | null>(null);
@@ -106,12 +106,37 @@ function WindowImpl({ win, onDrag, onDragStop }: Props) {
     [onDragStop, snapWindow, updatePosition, win.id, win.size],
   );
 
-  const handleResizeStop = useCallback(
-    (_e: unknown, _dir: unknown, ref: HTMLElement) => {
-      setDragging(false);
-      updateSize(win.id, ref.offsetWidth, ref.offsetHeight);
+  // Feed react-rnd's live position+size back every resize tick. react-rnd's
+  // position prop is controlled, and resizing from a top/left edge changes the
+  // position; without live feedback react-rnd's own internal re-render re-reads
+  // the stale stored position and the window jumps sideways mid-resize. Keeping
+  // the controlled props in lockstep with react-rnd's reported bounds keeps the
+  // resize smooth from every edge.
+  const handleResize = useCallback(
+    (
+      _e: unknown,
+      _dir: unknown,
+      ref: HTMLElement,
+      _delta: unknown,
+      position: { x: number; y: number },
+    ) => {
+      updateBounds(win.id, position.x, position.y, ref.offsetWidth, ref.offsetHeight);
     },
-    [updateSize, win.id],
+    [updateBounds, win.id],
+  );
+
+  const handleResizeStop = useCallback(
+    (
+      _e: unknown,
+      _dir: unknown,
+      ref: HTMLElement,
+      _delta: unknown,
+      position: { x: number; y: number },
+    ) => {
+      setDragging(false);
+      updateBounds(win.id, position.x, position.y, ref.offsetWidth, ref.offsetHeight);
+    },
+    [updateBounds, win.id],
   );
 
   const minSize = app?.minSize ?? { w: 300, h: 200 };
@@ -153,6 +178,7 @@ function WindowImpl({ win, onDrag, onDragStop }: Props) {
       onDrag={handleDrag}
       onDragStop={handleDragStop}
       onResizeStart={() => setDragging(true)}
+      onResize={handleResize}
       onResizeStop={handleResizeStop}
       onMouseDown={() => focusWindow(win.id)}
       bounds="parent"

--- a/desktop/src/components/Window.tsx
+++ b/desktop/src/components/Window.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { memo, useCallback, useRef, useState } from "react";
 import { Rnd } from "react-rnd";
 import { motion, useReducedMotion } from "motion/react";
 import { useProcessStore, type WindowState, type SnapPosition } from "@/stores/process-store";
@@ -13,9 +13,20 @@ interface Props {
   onDragStop: () => SnapPosition;
 }
 
-export function Window({ win, onDrag, onDragStop }: Props) {
-  const { focusWindow, closeWindow, removeWindow, minimizeWindow, maximizeWindow, updatePosition, updateSize, snapWindow } =
-    useProcessStore();
+function WindowImpl({ win, onDrag, onDragStop }: Props) {
+  // Select each action individually. Destructuring useProcessStore() with no
+  // selector subscribes the window to EVERY store change, so any unrelated
+  // store write would re-render it mid-drag and react-rnd would reset its
+  // controlled position. Action references are stable, so these never trigger
+  // a re-render on their own.
+  const focusWindow = useProcessStore((s) => s.focusWindow);
+  const closeWindow = useProcessStore((s) => s.closeWindow);
+  const removeWindow = useProcessStore((s) => s.removeWindow);
+  const minimizeWindow = useProcessStore((s) => s.minimizeWindow);
+  const maximizeWindow = useProcessStore((s) => s.maximizeWindow);
+  const updatePosition = useProcessStore((s) => s.updatePosition);
+  const updateSize = useProcessStore((s) => s.updateSize);
+  const snapWindow = useProcessStore((s) => s.snapWindow);
   const app = getApp(win.appId);
   const preSnapRef = useRef<{ x: number; y: number; w: number; h: number } | null>(null);
   const isMobile = useIsMobile();
@@ -248,3 +259,9 @@ export function Window({ win, onDrag, onDragStop }: Props) {
     </Rnd>
   );
 }
+
+// Memoized so unrelated desktop re-renders (snap-zone preview, the live
+// wallpaper, the agent command stream) do not re-render every window during a
+// drag. Props are stable: `win` only changes when this window's own state
+// changes, and onDrag/onDragStop are stabilized in useSnapZones.
+export const Window = memo(WindowImpl);

--- a/desktop/src/components/__tests__/ContextMenu.test.tsx
+++ b/desktop/src/components/__tests__/ContextMenu.test.tsx
@@ -30,8 +30,8 @@ describe("ContextMenu keyboard navigation", () => {
   });
 
   it("ArrowDown moves focus to next enabled item", () => {
-    const { container } = renderMenu();
-    const menu = container.firstChild as HTMLElement;
+    renderMenu();
+    const menu = screen.getByRole("menu");
     fireEvent.keyDown(menu, { key: "ArrowDown" });
     const items = screen.getAllByRole("menuitem");
     // Skip disabled "Delete", so ArrowDown from Copy → Paste
@@ -39,8 +39,8 @@ describe("ContextMenu keyboard navigation", () => {
   });
 
   it("ArrowDown wraps from last to first enabled item", () => {
-    const { container } = renderMenu();
-    const menu = container.firstChild as HTMLElement;
+    renderMenu();
+    const menu = screen.getByRole("menu");
     // Navigate to last enabled item (Rename)
     fireEvent.keyDown(menu, { key: "End" });
     fireEvent.keyDown(menu, { key: "ArrowDown" });
@@ -49,8 +49,8 @@ describe("ContextMenu keyboard navigation", () => {
   });
 
   it("ArrowUp moves focus to previous enabled item", () => {
-    const { container } = renderMenu();
-    const menu = container.firstChild as HTMLElement;
+    renderMenu();
+    const menu = screen.getByRole("menu");
     fireEvent.keyDown(menu, { key: "ArrowDown" }); // Paste
     fireEvent.keyDown(menu, { key: "ArrowUp" });   // back to Copy
     const items = screen.getAllByRole("menuitem");
@@ -58,8 +58,8 @@ describe("ContextMenu keyboard navigation", () => {
   });
 
   it("Home moves focus to first enabled item", () => {
-    const { container } = renderMenu();
-    const menu = container.firstChild as HTMLElement;
+    renderMenu();
+    const menu = screen.getByRole("menu");
     fireEvent.keyDown(menu, { key: "ArrowDown" });
     fireEvent.keyDown(menu, { key: "Home" });
     const items = screen.getAllByRole("menuitem");
@@ -67,8 +67,8 @@ describe("ContextMenu keyboard navigation", () => {
   });
 
   it("End moves focus to last enabled item", () => {
-    const { container } = renderMenu();
-    const menu = container.firstChild as HTMLElement;
+    renderMenu();
+    const menu = screen.getByRole("menu");
     fireEvent.keyDown(menu, { key: "End" });
     // Rename is last enabled (Delete is disabled)
     const items = screen.getAllByRole("menuitem");
@@ -77,15 +77,15 @@ describe("ContextMenu keyboard navigation", () => {
 
   it("Escape calls onClose", () => {
     const onClose = vi.fn();
-    const { container } = renderMenu(onClose);
-    const menu = container.firstChild as HTMLElement;
+    renderMenu(onClose);
+    const menu = screen.getByRole("menu");
     fireEvent.keyDown(menu, { key: "Escape" });
     expect(onClose).toHaveBeenCalled();
   });
 
   it("disabled item is skipped by arrow navigation", () => {
-    const { container } = renderMenu();
-    const menu = container.firstChild as HTMLElement;
+    renderMenu();
+    const menu = screen.getByRole("menu");
     // ArrowDown from Copy → Paste, ArrowDown again → Rename (skipping disabled Delete)
     fireEvent.keyDown(menu, { key: "ArrowDown" }); // Paste
     fireEvent.keyDown(menu, { key: "ArrowDown" }); // Rename (skips Delete)
@@ -106,8 +106,8 @@ describe("ContextMenu keyboard navigation", () => {
       { label: "Copy", action: vi.fn(), disabled: true },
       { label: "Paste", action: vi.fn(), disabled: true },
     ];
-    const { container } = render(<ContextMenu x={100} y={100} items={allDisabled} onClose={vi.fn()} />);
-    const menu = container.firstChild as HTMLElement;
+    render(<ContextMenu x={100} y={100} items={allDisabled} onClose={vi.fn()} />);
+    const menu = screen.getByRole("menu");
     // None of these should throw or attempt to focus undefined
     expect(() => fireEvent.keyDown(menu, { key: "ArrowDown" })).not.toThrow();
     expect(() => fireEvent.keyDown(menu, { key: "ArrowUp" })).not.toThrow();
@@ -115,8 +115,9 @@ describe("ContextMenu keyboard navigation", () => {
     expect(() => fireEvent.keyDown(menu, { key: "End" })).not.toThrow();
     // Escape still calls onClose even with all disabled
     const onClose = vi.fn();
-    const { container: c2 } = render(<ContextMenu x={100} y={100} items={allDisabled} onClose={onClose} />);
-    fireEvent.keyDown(c2.firstChild as HTMLElement, { key: "Escape" });
+    render(<ContextMenu x={100} y={100} items={allDisabled} onClose={onClose} />);
+    const menus = screen.getAllByRole("menu");
+    fireEvent.keyDown(menus[menus.length - 1], { key: "Escape" });
     expect(onClose).toHaveBeenCalled();
   });
 
@@ -160,8 +161,8 @@ describe("ContextMenu keyboard navigation", () => {
   });
 
   it("ArrowDown when focus is outside list moves to first enabled item", () => {
-    const { container } = renderMenu();
-    const menu = container.firstChild as HTMLElement;
+    renderMenu();
+    const menu = screen.getByRole("menu");
     // Move focus to a focusable element outside the menu
     const outside = document.createElement("button");
     document.body.appendChild(outside);
@@ -174,8 +175,8 @@ describe("ContextMenu keyboard navigation", () => {
   });
 
   it("ArrowUp when focus is outside list moves to last enabled item", () => {
-    const { container } = renderMenu();
-    const menu = container.firstChild as HTMLElement;
+    renderMenu();
+    const menu = screen.getByRole("menu");
     const outside = document.createElement("button");
     document.body.appendChild(outside);
     outside.focus();

--- a/desktop/src/hooks/use-snap-zones.ts
+++ b/desktop/src/hooks/use-snap-zones.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import type { SnapPosition } from "@/stores/process-store";
 
 const EDGE_THRESHOLD = 16;
@@ -55,16 +55,28 @@ export function getSnapBounds(snap: SnapPosition, vp: Viewport): { x: number; y:
 
 export function useSnapZones(viewport: Viewport) {
   const [preview, setPreview] = useState<SnapPosition>(null);
+  // Refs so onDrag/onDragStop keep a STABLE identity across renders. react-rnd's
+  // position prop is controlled, so a Window re-render mid-drag re-applies the
+  // stored position and yanks the window back ("jumping"). Stable callbacks let
+  // <Window> be memoized and skip those re-renders while a drag is in flight.
+  const previewRef = useRef<SnapPosition>(null);
+  const viewportRef = useRef(viewport);
+  viewportRef.current = viewport;
 
   const onDrag = useCallback((x: number, y: number) => {
-    setPreview(detectSnapZone(x, y, viewport));
-  }, [viewport]);
+    const zone = detectSnapZone(x, y, viewportRef.current);
+    previewRef.current = zone;
+    // Only flip state when the zone actually changes, so crossing the same zone
+    // repeatedly does not re-render the desktop on every pointer move.
+    setPreview((prev) => (prev === zone ? prev : zone));
+  }, []);
 
-  const onDragStop = useCallback(() => {
-    const result = preview;
+  const onDragStop = useCallback((): SnapPosition => {
+    const result = previewRef.current;
+    previewRef.current = null;
     setPreview(null);
     return result;
-  }, [preview]);
+  }, []);
 
   return { preview, previewBounds: getSnapBounds(preview, viewport), onDrag, onDragStop };
 }

--- a/desktop/src/stores/process-store.ts
+++ b/desktop/src/stores/process-store.ts
@@ -35,11 +35,48 @@ interface ProcessStore {
   minimizeWindow: (id: string) => void;
   restoreWindow: (id: string) => void;
   maximizeWindow: (id: string) => void;
+  recenterWindow: (id: string) => void;
   updatePosition: (id: string, x: number, y: number) => void;
   updateSize: (id: string, w: number, h: number) => void;
   updateBounds: (id: string, x: number, y: number, w: number, h: number) => void;
   snapWindow: (id: string, snap: SnapPosition) => void;
   runningAppIds: () => string[];
+}
+
+// Compute on-screen-safe bounds for a window. Used when restoring or
+// un-maximizing so a window that drifted off-screen (or is larger than the
+// current desktop) comes back at a usable size, recentered if it is no longer
+// reachable. The desktop area sits below the 32px top bar and above the ~84px
+// dock reservation, matching Window.tsx. Idempotent for windows already
+// comfortably on-screen. Pass a far-off position to force a recenter.
+function safeBounds(
+  position: { x: number; y: number },
+  size: { w: number; h: number },
+): { position: { x: number; y: number }; size: { w: number; h: number } } {
+  const topBarH = 32;
+  const dockH = 84;
+  const margin = 16;
+  const vw = typeof window !== "undefined" ? window.innerWidth : 1280;
+  const vh = typeof window !== "undefined" ? window.innerHeight : 800;
+  const deskW = vw;
+  const deskH = vh - topBarH - dockH;
+
+  // Never larger than the desktop (minus margins); never below a usable minimum.
+  const w = Math.max(300, Math.min(size.w, deskW - margin * 2));
+  const h = Math.max(200, Math.min(size.h, deskH - margin * 2));
+
+  let { x, y } = position;
+  // "Reachable" means enough of the title bar is on the desktop to grab it.
+  const GRAB = 80;
+  const reachable = x <= deskW - GRAB && x + w >= GRAB && y >= 0 && y <= deskH - topBarH;
+  if (!reachable) {
+    x = Math.round((deskW - w) / 2);
+    y = Math.round((deskH - h) / 2);
+  }
+  // Final clamp keeps even a reachable-but-oversized window fully in view.
+  x = Math.max(margin, Math.min(x, Math.max(margin, deskW - w - margin)));
+  y = Math.max(0, Math.min(y, Math.max(0, deskH - h - margin)));
+  return { position: { x, y }, size: { w, h } };
 }
 
 let idCounter = 0;
@@ -124,20 +161,45 @@ export const useProcessStore = create<ProcessStore>((set, get) => ({
   restoreWindow(id) {
     const z = get().nextZIndex;
     set((s) => ({
-      windows: s.windows.map((w) =>
-        w.id === id
-          ? { ...w, minimized: false, focused: true, zIndex: z }
-          : { ...w, focused: false }
-      ),
+      windows: s.windows.map((w) => {
+        if (w.id !== id) return { ...w, focused: false };
+        // Showing a window again: if it drifted off-screen while hidden, pull
+        // it back into view. A maximized window keeps its stored bounds for
+        // when it is later un-maximized.
+        const safe = w.maximized ? {} : safeBounds(w.position, w.size);
+        return { ...w, ...safe, minimized: false, focused: true, zIndex: z };
+      }),
       nextZIndex: z + 1,
     }));
   },
 
   maximizeWindow(id) {
     set((s) => ({
-      windows: s.windows.map((w) =>
-        w.id === id ? { ...w, maximized: !w.maximized } : w
-      ),
+      windows: s.windows.map((w) => {
+        if (w.id !== id) return w;
+        if (!w.maximized) {
+          // Maximizing implies showing the window, even from a minimized state.
+          return { ...w, maximized: true, minimized: false };
+        }
+        // Un-maximizing: make sure the restored bounds are on-screen.
+        const safe = safeBounds(w.position, w.size);
+        return { ...w, ...safe, maximized: false };
+      }),
+    }));
+  },
+
+  recenterWindow(id) {
+    const z = get().nextZIndex;
+    set((s) => ({
+      windows: s.windows.map((w) => {
+        if (w.id !== id) return { ...w, focused: false };
+        // Force a recenter (far-off position guarantees safeBounds recenters),
+        // and ensure the window is shown and not maximized so the user can see
+        // and move it. The recovery path for a window lost off-screen.
+        const safe = safeBounds({ x: -1e6, y: -1e6 }, w.size);
+        return { ...w, ...safe, minimized: false, maximized: false, focused: true, zIndex: z };
+      }),
+      nextZIndex: z + 1,
     }));
   },
 

--- a/desktop/src/stores/process-store.ts
+++ b/desktop/src/stores/process-store.ts
@@ -37,6 +37,7 @@ interface ProcessStore {
   maximizeWindow: (id: string) => void;
   updatePosition: (id: string, x: number, y: number) => void;
   updateSize: (id: string, w: number, h: number) => void;
+  updateBounds: (id: string, x: number, y: number, w: number, h: number) => void;
   snapWindow: (id: string, snap: SnapPosition) => void;
   runningAppIds: () => string[];
 }
@@ -152,6 +153,18 @@ export const useProcessStore = create<ProcessStore>((set, get) => ({
     set((s) => ({
       windows: s.windows.map((win) =>
         win.id === id ? { ...win, size: { w, h } } : win
+      ),
+    }));
+  },
+
+  // Position and size in ONE update. A resize from a top/left edge moves the
+  // window's x/y as well as its w/h; committing them separately renders one
+  // frame with the new size but the old position, which reads as a jump. This
+  // applies both atomically.
+  updateBounds(id, x, y, w, h) {
+    set((s) => ({
+      windows: s.windows.map((win) =>
+        win.id === id ? { ...win, position: { x, y }, size: { w, h } } : win
       ),
     }));
   },


### PR DESCRIPTION
Confirmed on the Pi by Jay (move + resize smooth; windows recoverable).

## Move jitter
react-rnd's position prop is controlled, so any desktop re-render mid-drag re-applied the stored position and yanked the window back. The snap-zone preview (fired every pointer move), the live wallpaper, and the agent command stream re-render the desktop continuously. Fix: stabilize the snap-zone onDrag/onDragStop callbacks (refs) + only flip preview when the zone changes; memoize Window + subscribe to process-store actions individually instead of the whole store.

## Resize jump
The resize handler saved only the new size and ignored react-rnd's position arg, so a top/left-edge resize moved x/y then re-applied the stale stored position (jumped right on horizontal, left on vertical). Fix: feed react-rnd's live position+size back via onResize, commit both atomically via a new updateBounds action, persist final bounds on resize stop.

## Off-screen recovery
A window dragged/resized off-screen could not be recovered. Fix: safeBounds() recomputes the desktop area and recenters a window on restore / un-maximize when its title bar is unreachable; maximize now un-minimizes; new recenterWindow action + a 'Center Window' item in the dock right-click menu.

tsc clean; window + store + hook tests pass. Frontend only, no dep change.