### PR TITLE
docs: extend studios list (Coding + App Studio)

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Hidden internal gateway that unifies all inference providers behind a single Ope
 Features unlock automatically based on your hardware and cluster. Solo Pi sees core features. Add a GPU worker and image generation, video, and training appear. No configuration, the platform just knows what's possible.
 
 ### Creative Studios
-Dedicated studio apps for every kind of project, each built to the same design bar as the Store and running entirely on your own cluster. Two ship today, with Design, Music, and Office studios on the way.
+Dedicated studio apps for every kind of project, each built to the same design bar as the Store and running entirely on your own cluster. Two ship today, with Coding, App, Design, Music, and Office studios on the way (App Studio is taOS's own app builder, so agents and users can build and share new apps).
 
 <p align="center">
   <img src="docs/images/images-studio.jpg" alt="Images Studio -- generate from a prompt and edit on a local GPU" width="49%">


### PR DESCRIPTION
Docs-only README copy: add Coding Studio and App Studio to the Creative Studios coming list. No code or version change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Creative Studios roadmap: Two studio apps are shipping today, with Coding and App studios now planned alongside Design, Music, and Office.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->