### PR TITLE
docs: studios availability wording (in beta)

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Hidden internal gateway that unifies all inference providers behind a single Ope
 Features unlock automatically based on your hardware and cluster. Solo Pi sees core features. Add a GPU worker and image generation, video, and training appear. No configuration, the platform just knows what's possible.
 
 ### Creative Studios
-Dedicated studio apps for every kind of project, each a focused, native taOS workspace that runs entirely on your own cluster. Two ship today, with Coding, App, Design, Music, and Office studios on the way (App Studio is taOS's own app builder, so agents and users can build and share new apps).
+Dedicated studio apps for every kind of project, each a focused, native taOS workspace that runs entirely on your own cluster. Two are in beta, with Coding, App, Design, Music, and Office studios on the way (App Studio is taOS's own app builder, so agents and users can build and share new apps).
 
 <p align="center">
   <img src="docs/images/images-studio.jpg" alt="Images Studio -- generate from a prompt and edit on a local GPU" width="49%">


### PR DESCRIPTION
Reword the live studios from 'ship today' to 'in beta', matching the product's beta status. Docs-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Creative Studios section to reflect that currently available studio apps are now in beta.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

----
## Summary by Gitar

- **Documentation:**
  - Updated `STATUS.md` to reflect latest progress on Creative Studios and deployment status on the Pi.
- **Feature implementation:**
  - Integrated five optional studio applications (`Coding`, `Design`, `Music`, `App`, `Office`) with the Store catalog and install flow.
  - Added backend support for studio installation via `tinyagentos/routes/apps.py` and updated `app-registry.ts`.
- **UI/UX components:**
  - Implemented `StudiosView` with featured hero card, studio grid, community studio section, and shareable layout chips.
  - Added dedicated app shells and views (e.g., `BuildView`, `DesignView`, `StudioView`) for the new studios.
- **Testing:**
  - Added unit tests for `CodingStudioApp`, `AppStudioApp`, and `StudiosView` to verify navigation and interaction states.


<sub>This will update automatically on new commits.</sub>