### PR TITLE
feat(apps): per-app versioning + Updates UI surface (#89 P1)

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinyagentos-desktop",
-  "version": "1.0.0-beta",
+  "version": "1.0.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinyagentos-desktop",
-      "version": "1.0.0-beta",
+      "version": "1.0.0-beta.3",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/desktop/src/apps/SettingsApp/UpdatesPanel.test.tsx
+++ b/desktop/src/apps/SettingsApp/UpdatesPanel.test.tsx
@@ -4,19 +4,22 @@ import { UpdatesPanel } from "./UpdatesPanel";
 
 const jResp = (b: any) => Promise.resolve({ ok: true, json: async () => b } as any);
 
+const BASE_FETCH = async (url: string) => {
+  if (url === "/api/preferences/auto-update") return jResp({ check_enabled: true });
+  if (url === "/api/settings/update-check")
+    return jResp({ has_updates: false, current_version: "1.0.0-beta.2", current_commit: "abc x" });
+  if (url === "/api/settings/update-status") return jResp({ current_sha: "abc", pending_restart_sha: null });
+  if (url === "/api/settings/branches") return jResp({ branches: ["master", "dev"], current: "dev" });
+  if (url === "/api/settings/update-channel") return jResp({ status: "switching", branch: "master" });
+  if (url === "/api/apps/optional/catalog") return jResp({ apps: [] });
+  return jResp({});
+};
+
 beforeEach(() => {
-  global.fetch = vi.fn(async (url: string) => {
-    if (url === "/api/preferences/auto-update") return jResp({ check_enabled: true });
-    if (url === "/api/settings/update-check")
-      return jResp({ has_updates: false, current_version: "1.0.0-beta.2", current_commit: "abc x" });
-    if (url === "/api/settings/update-status") return jResp({ current_sha: "abc", pending_restart_sha: null });
-    if (url === "/api/settings/branches") return jResp({ branches: ["master", "dev"], current: "dev" });
-    if (url === "/api/settings/update-channel") return jResp({ status: "switching", branch: "master" });
-    return jResp({});
-  }) as any;
+  global.fetch = vi.fn(BASE_FETCH) as any;
 });
 
-describe("UpdatesPanel — version display", () => {
+describe("UpdatesPanel -- version display", () => {
   it("shows current version prominently when up to date", async () => {
     render(<UpdatesPanel />);
     await waitFor(() => expect(screen.getByText("1.0.0-beta.2")).toBeInTheDocument());
@@ -34,6 +37,7 @@ describe("UpdatesPanel — version display", () => {
           new_commit: "xyz uvwx",
         });
       if (url === "/api/settings/update-status") return jResp({ current_sha: "abc", pending_restart_sha: null });
+      if (url === "/api/apps/optional/catalog") return jResp({ apps: [] });
       return jResp({});
     });
     render(<UpdatesPanel />);
@@ -42,7 +46,7 @@ describe("UpdatesPanel — version display", () => {
   });
 });
 
-describe("UpdatesPanel — branch selector", () => {
+describe("UpdatesPanel -- branch selector", () => {
   it("hides the branch selector until Advanced is expanded", async () => {
     render(<UpdatesPanel />);
     expect(screen.queryByRole("combobox", { name: /branch/i })).toBeNull();
@@ -61,5 +65,49 @@ describe("UpdatesPanel — branch selector", () => {
     await waitFor(() =>
       expect((global.fetch as any).mock.calls.find((c: any[]) => c[0] === "/api/settings/update-channel")).toBeTruthy()
     );
+  });
+});
+
+describe("UpdatesPanel -- optional apps section", () => {
+  it("renders nothing in the Apps section when no optional apps are installed", async () => {
+    (global.fetch as any) = vi.fn(async (url: string) => {
+      if (url === "/api/apps/optional/catalog") return jResp({ apps: [
+        { id: "reddit", version: "1.0.0", trust: "first-party", source: "core", installed: false, update_available: false },
+      ]});
+      return jResp(await BASE_FETCH(url).then((r) => r.json()));
+    });
+    render(<UpdatesPanel />);
+    await waitFor(() => {
+      expect(screen.getByText("No optional apps installed.")).toBeInTheDocument();
+    });
+  });
+
+  it("renders an installed app row with its version and Core badge", async () => {
+    (global.fetch as any) = vi.fn(async (url: string) => {
+      if (url === "/api/apps/optional/catalog") return jResp({ apps: [
+        { id: "reddit", version: "1.0.0", trust: "first-party", source: "core", installed: true, update_available: false },
+      ]});
+      return jResp(await BASE_FETCH(url).then((r) => r.json()));
+    });
+    render(<UpdatesPanel />);
+    await waitFor(() => expect(screen.getByText("Reddit")).toBeInTheDocument());
+    expect(screen.getByText("1.0.0")).toBeInTheDocument();
+    expect(screen.getByText("Core")).toBeInTheDocument();
+    expect(screen.getByText("Up to date")).toBeInTheDocument();
+  });
+
+  it("shows update available copy when catalog flags it", async () => {
+    (global.fetch as any) = vi.fn(async (url: string) => {
+      if (url === "/api/apps/optional/catalog") return jResp({ apps: [
+        { id: "reddit", version: "1.0.0", trust: "first-party", source: "core", installed: true, update_available: true },
+      ]});
+      return jResp(await BASE_FETCH(url).then((r) => r.json()));
+    });
+    render(<UpdatesPanel />);
+    await waitFor(() =>
+      expect(screen.getByText(/Update available, included in the next system update/i)).toBeInTheDocument()
+    );
+    // Should have a button/link to trigger the system update flow.
+    expect(screen.getByRole("button", { name: /scroll to system update/i })).toBeInTheDocument();
   });
 });

--- a/desktop/src/apps/SettingsApp/UpdatesPanel.tsx
+++ b/desktop/src/apps/SettingsApp/UpdatesPanel.tsx
@@ -1,7 +1,9 @@
 import { useState, useEffect, useCallback, useRef } from "react";
-import { Settings, RefreshCw, AlertCircle, Check, ChevronDown, ChevronRight } from "lucide-react";
+import { Settings, RefreshCw, AlertCircle, Check, ChevronDown, ChevronRight, Package } from "lucide-react";
+import * as LucideIcons from "lucide-react";
 import { Button, Card, Label, Switch } from "@/components/ui";
 import { RestartProgressModal } from "@/apps/SettingsApp/_shared";
+import { OPTIONAL_APPS } from "@/registry/optional-apps";
 
 interface UpdateInfo {
   has_updates: boolean;
@@ -27,6 +29,76 @@ interface BranchInfo {
   current: string;
 }
 
+interface OptionalAppCatalogEntry {
+  id: string;
+  version: string;
+  trust: string;
+  source: "core" | string;
+  installed: boolean;
+  update_available: boolean;
+}
+
+// Render a lucide icon by kebab-case name (matches the format used in optional-apps registry).
+function AppIconGlyph({ iconName, size = 16 }: { iconName: string; size?: number }) {
+  const pascal = iconName
+    .split("-")
+    .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+    .join("");
+  const Glyph = (LucideIcons[pascal as keyof typeof LucideIcons] as LucideIcons.LucideIcon) ?? Package;
+  return <Glyph size={size} />;
+}
+
+// A single optional app row in the Updates panel. Keyed by `source` so a
+// future "package" source can add its own Update button without touching this
+// component layout.
+function OptionalAppRow({
+  entry,
+  displayName,
+  iconName,
+  onScrollToSystem,
+}: {
+  entry: OptionalAppCatalogEntry;
+  displayName: string;
+  iconName: string;
+  onScrollToSystem: () => void;
+}) {
+  return (
+    <div className="flex items-center gap-3 py-2.5">
+      <div className="w-8 h-8 rounded-lg bg-shell-surface-active flex items-center justify-center shrink-0 text-shell-text-secondary">
+        <AppIconGlyph iconName={iconName} size={15} />
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="text-sm font-medium text-shell-text truncate">{displayName}</span>
+          <span className="font-mono text-[10px] text-shell-text-tertiary">{entry.version}</span>
+          {entry.source === "core" && (
+            <span className="text-[9px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded bg-shell-surface-active text-shell-text-tertiary border border-shell-border-strong">
+              Core
+            </span>
+          )}
+        </div>
+        {entry.source === "core" && entry.update_available ? (
+          <div className="flex items-center gap-1.5 mt-0.5">
+            <span className="text-[11px] text-amber-300/80">
+              Update available, included in the next system update
+            </span>
+            <button
+              type="button"
+              onClick={onScrollToSystem}
+              className="text-[11px] text-accent underline underline-offset-2 hover:text-shell-text-secondary transition-colors"
+              aria-label="Scroll to system update"
+            >
+              Install now
+            </button>
+          </div>
+        ) : (
+          <span className="text-[11px] text-shell-text-tertiary mt-0.5">Up to date</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
 export function UpdatesPanel() {
   const [checking, setChecking] = useState(false);
   const [applying, setApplying] = useState(false);
@@ -36,6 +108,7 @@ export function UpdatesPanel() {
   const [prefs, setPrefs] = useState<AutoUpdatePrefs>({ check_enabled: true });
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus | null>(null);
   const [showRestartModal, setShowRestartModal] = useState(false);
+  const [optionalCatalog, setOptionalCatalog] = useState<OptionalAppCatalogEntry[]>([]);
 
   // Advanced / branch selector state
   const [advancedOpen, setAdvancedOpen] = useState(false);
@@ -45,6 +118,7 @@ export function UpdatesPanel() {
   const [showSwitchConfirm, setShowSwitchConfirm] = useState(false);
   const branchFetched = useRef(false);
   const confirmBtnRef = useRef<HTMLButtonElement>(null);
+  const systemCardRef = useRef<HTMLDivElement>(null);
 
   // Focus management for the confirm dialog: move focus into the dialog when it
   // opens and return it to the previously focused control when it closes, so
@@ -78,6 +152,13 @@ export function UpdatesPanel() {
       try {
         const r3 = await fetch("/api/settings/update-status");
         if (r3.ok) setUpdateStatus(await r3.json());
+      } catch { /* ignore */ }
+      try {
+        const r4 = await fetch("/api/apps/optional/catalog");
+        if (r4.ok) {
+          const data = await r4.json();
+          if (data && Array.isArray(data.apps)) setOptionalCatalog(data.apps);
+        }
       } catch { /* ignore */ }
     })();
   }, []);
@@ -121,7 +202,7 @@ export function UpdatesPanel() {
     try {
       const res = await fetch("/api/settings/update", { method: "POST" });
       if (res.ok) {
-        // Server always restarts after a successful install — show the modal.
+        // Server always restarts after a successful install -- show the modal.
         setShowRestartModal(true);
       } else {
         const err = await res.json().catch(() => ({}));
@@ -208,7 +289,14 @@ export function UpdatesPanel() {
     setSwitching(false);
   };
 
+  const scrollToSystem = useCallback(() => {
+    systemCardRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+  }, []);
+
   const hasPendingRestart = !!updateStatus?.pending_restart_sha;
+
+  // Only show installed optional apps that have a matching registry entry for display metadata.
+  const installedOptional = optionalCatalog.filter((e) => e.installed);
 
   return (
     <section aria-label="System updates">
@@ -226,7 +314,7 @@ export function UpdatesPanel() {
         </div>
       )}
 
-      <Card className="p-4 space-y-4">
+      <Card ref={systemCardRef} className="p-4 space-y-4">
         <div className="flex items-center gap-3">
           <div className="p-2 rounded-lg bg-white/5 text-sky-400">
             <Settings size={20} />
@@ -385,6 +473,29 @@ export function UpdatesPanel() {
           )}
         </div>
       </Card>
+
+      {/* Apps section: installed optional apps with version + source badge */}
+      <div className="mt-6">
+        <h3 className="text-sm font-semibold text-shell-text mb-3">Apps</h3>
+        {installedOptional.length === 0 ? (
+          <p className="text-[12px] text-shell-text-tertiary">No optional apps installed.</p>
+        ) : (
+          <Card className="px-4 py-1 divide-y divide-shell-border">
+            {installedOptional.map((entry) => {
+              const meta = OPTIONAL_APPS.find((a) => a.id === entry.id);
+              return (
+                <OptionalAppRow
+                  key={entry.id}
+                  entry={entry}
+                  displayName={meta?.name ?? entry.id}
+                  iconName={meta?.icon ?? "package"}
+                  onScrollToSystem={scrollToSystem}
+                />
+              );
+            })}
+          </Card>
+        )}
+      </div>
 
       {/* Branch-switch confirm dialog */}
       {showSwitchConfirm && (

--- a/desktop/src/apps/SettingsApp/UpdatesPanel.tsx
+++ b/desktop/src/apps/SettingsApp/UpdatesPanel.tsx
@@ -3,7 +3,7 @@ import { Settings, RefreshCw, AlertCircle, Check, ChevronDown, ChevronRight, Pac
 import * as LucideIcons from "lucide-react";
 import { Button, Card, Label, Switch } from "@/components/ui";
 import { RestartProgressModal } from "@/apps/SettingsApp/_shared";
-import { OPTIONAL_APPS } from "@/registry/optional-apps";
+import { getApp } from "@/registry/app-registry";
 
 interface UpdateInfo {
   has_updates: boolean;
@@ -295,7 +295,8 @@ export function UpdatesPanel() {
 
   const hasPendingRestart = !!updateStatus?.pending_restart_sha;
 
-  // Only show installed optional apps that have a matching registry entry for display metadata.
+  // Installed optional apps; display name/icon come from the app registry
+  // (getApp covers every optional app, including the studios).
   const installedOptional = optionalCatalog.filter((e) => e.installed);
 
   return (
@@ -482,7 +483,7 @@ export function UpdatesPanel() {
         ) : (
           <Card className="px-4 py-1 divide-y divide-shell-border">
             {installedOptional.map((entry) => {
-              const meta = OPTIONAL_APPS.find((a) => a.id === entry.id);
+              const meta = getApp(entry.id);
               return (
                 <OptionalAppRow
                   key={entry.id}

--- a/desktop/src/apps/StoreApp/index.tsx
+++ b/desktop/src/apps/StoreApp/index.tsx
@@ -19,7 +19,7 @@ import { TaosAppsSection } from "./TaosAppsSection";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { MobileStore } from "./MobileStore";
 import { AppIcon, StoreCover } from "./AppIcon";
-import { OPTIONAL_APPS } from "@/registry/optional-apps";
+import { getApp } from "@/registry/app-registry";
 import { StudiosView } from "./StudiosView";
 
 /* ------------------------------------------------------------------
@@ -1151,40 +1151,40 @@ export function StoreApp({ windowId: _windowId }: { windowId: string }) {
                   <p className="text-[12px] text-shell-text-tertiary mt-0.5">{filtered.length} apps</p>
                 </div>
               </div>
+              {activeNav === "updates" && (() => {
+                const updatableOptional = optionalCatalog.filter((e) => e.installed && e.update_available);
+                if (updatableOptional.length === 0) return null;
+                return (
+                  <div className="mb-4">
+                    <h3 className="text-[13px] font-semibold text-shell-text mb-2">taOS Apps</h3>
+                    <div className="flex flex-col gap-1">
+                      {updatableOptional.map((entry) => {
+                        const meta = getApp(entry.id);
+                        return (
+                          <div key={entry.id} className="flex items-center gap-3 px-3 py-2.5 rounded-xl bg-shell-surface border border-shell-border">
+                            <span className="text-[12.5px] font-medium text-shell-text">{meta?.name ?? entry.id}</span>
+                            <span className="font-mono text-[10px] text-shell-text-tertiary">{entry.version}</span>
+                            <span className="text-[9px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded bg-shell-surface-active text-shell-text-tertiary border border-shell-border-strong">Core</span>
+                            <span className="ml-auto text-[11px] text-amber-300/80">Included in next system update</span>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                );
+              })()}
               {searching && filtered.length === 0 ? (
                 <div className="flex flex-col items-center justify-center h-40 text-shell-text-tertiary text-sm gap-2">
                   <Package className="w-8 h-8" />
                   <span>No matches for &ldquo;{search.trim()}&rdquo;</span>
                 </div>
               ) : activeNav === "updates" && filtered.length === 0 ? (
-                <>
-                  {(() => {
-                    const updatableOptional = optionalCatalog.filter((e) => e.installed && e.update_available);
-                    return updatableOptional.length > 0 ? (
-                      <div className="mb-4">
-                        <h3 className="text-[13px] font-semibold text-shell-text mb-2">taOS Apps</h3>
-                        <div className="flex flex-col gap-1">
-                          {updatableOptional.map((entry) => {
-                            const meta = OPTIONAL_APPS.find((a) => a.id === entry.id);
-                            return (
-                              <div key={entry.id} className="flex items-center gap-3 px-3 py-2.5 rounded-xl bg-shell-surface border border-shell-border">
-                                <span className="text-[12.5px] font-medium text-shell-text">{meta?.name ?? entry.id}</span>
-                                <span className="font-mono text-[10px] text-shell-text-tertiary">{entry.version}</span>
-                                <span className="text-[9px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded bg-shell-surface-active text-shell-text-tertiary border border-shell-border-strong">Core</span>
-                                <span className="ml-auto text-[11px] text-amber-300/80">Included in next system update</span>
-                              </div>
-                            );
-                          })}
-                        </div>
-                      </div>
-                    ) : (
-                      <div className="flex flex-col items-center justify-center h-40 text-shell-text-tertiary text-sm gap-2">
-                        <Package className="w-8 h-8" />
-                        <span>You&rsquo;re all up to date</span>
-                      </div>
-                    );
-                  })()}
-                </>
+                optionalCatalog.some((e) => e.installed && e.update_available) ? null : (
+                  <div className="flex flex-col items-center justify-center h-40 text-shell-text-tertiary text-sm gap-2">
+                    <Package className="w-8 h-8" />
+                    <span>You&rsquo;re all up to date</span>
+                  </div>
+                )
               ) : activeNav === "installed" && filtered.length === 0 ? (
                 <div className="flex flex-col items-center justify-center h-40 text-shell-text-tertiary text-sm gap-2">
                   <Package className="w-8 h-8" />

--- a/desktop/src/apps/StoreApp/index.tsx
+++ b/desktop/src/apps/StoreApp/index.tsx
@@ -19,6 +19,7 @@ import { TaosAppsSection } from "./TaosAppsSection";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { MobileStore } from "./MobileStore";
 import { AppIcon, StoreCover } from "./AppIcon";
+import { OPTIONAL_APPS } from "@/registry/optional-apps";
 import { StudiosView } from "./StudiosView";
 
 /* ------------------------------------------------------------------
@@ -841,6 +842,7 @@ export function StoreApp({ windowId: _windowId }: { windowId: string }) {
   const [selectedDevices, setSelectedDevices] = useState<string[]>([]);
   const [selectedBackends, setSelectedBackends] = useState<string[]>([]);
   const [compatMap, setCompatMap] = useState<Map<string, ResolveResponse>>(new Map());
+  const [optionalCatalog, setOptionalCatalog] = useState<Array<{ id: string; version: string; installed: boolean; update_available: boolean }>>([]);
 
   const userId = typeof window !== "undefined" ? window.localStorage.getItem("taos.user.id") || "anon" : "anon";
   const profileId = typeof window !== "undefined" ? window.localStorage.getItem("taos.profile.id") || "default" : "default";
@@ -928,6 +930,7 @@ export function StoreApp({ windowId: _windowId }: { windowId: string }) {
     fetchLatestFrameworks().then(setLatest).catch(() => {});
     fetch("/api/agents").then((r) => r.ok ? r.json() : []).then((j) => setAgentList(Array.isArray(j) ? j : (j?.agents ?? []))).catch(() => {});
     fetch("/api/cluster/install-targets", { headers: { Accept: "application/json" } }).then((r) => r.ok ? r.json() : null).then((data) => { if (Array.isArray(data)) setInstallTargets(data); }).catch(() => {});
+    fetch("/api/apps/optional/catalog", { headers: { Accept: "application/json" } }).then((r) => r.ok ? r.json() : null).then((data) => { if (data?.apps) setOptionalCatalog(data.apps); }).catch(() => {});
     refreshInstalled();
   }, [refreshInstalled]);
 
@@ -1154,10 +1157,34 @@ export function StoreApp({ windowId: _windowId }: { windowId: string }) {
                   <span>No matches for &ldquo;{search.trim()}&rdquo;</span>
                 </div>
               ) : activeNav === "updates" && filtered.length === 0 ? (
-                <div className="flex flex-col items-center justify-center h-40 text-shell-text-tertiary text-sm gap-2">
-                  <Package className="w-8 h-8" />
-                  <span>You&rsquo;re all up to date</span>
-                </div>
+                <>
+                  {(() => {
+                    const updatableOptional = optionalCatalog.filter((e) => e.installed && e.update_available);
+                    return updatableOptional.length > 0 ? (
+                      <div className="mb-4">
+                        <h3 className="text-[13px] font-semibold text-shell-text mb-2">taOS Apps</h3>
+                        <div className="flex flex-col gap-1">
+                          {updatableOptional.map((entry) => {
+                            const meta = OPTIONAL_APPS.find((a) => a.id === entry.id);
+                            return (
+                              <div key={entry.id} className="flex items-center gap-3 px-3 py-2.5 rounded-xl bg-shell-surface border border-shell-border">
+                                <span className="text-[12.5px] font-medium text-shell-text">{meta?.name ?? entry.id}</span>
+                                <span className="font-mono text-[10px] text-shell-text-tertiary">{entry.version}</span>
+                                <span className="text-[9px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded bg-shell-surface-active text-shell-text-tertiary border border-shell-border-strong">Core</span>
+                                <span className="ml-auto text-[11px] text-amber-300/80">Included in next system update</span>
+                              </div>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="flex flex-col items-center justify-center h-40 text-shell-text-tertiary text-sm gap-2">
+                        <Package className="w-8 h-8" />
+                        <span>You&rsquo;re all up to date</span>
+                      </div>
+                    );
+                  })()}
+                </>
               ) : activeNav === "installed" && filtered.length === 0 ? (
                 <div className="flex flex-col items-center justify-center h-40 text-shell-text-tertiary text-sm gap-2">
                   <Package className="w-8 h-8" />

--- a/desktop/src/apps/StoreApp/updates-optional.test.tsx
+++ b/desktop/src/apps/StoreApp/updates-optional.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * Tests for the optional app versioning integration in the Store updates tab.
+ *
+ * The StoreApp renders the optional catalog as a distinct section inside the
+ * "updates" view. This test suite verifies:
+ *   - The catalog endpoint is fetched on mount.
+ *   - Installed optional apps with update_available=true appear in the updates tab.
+ *   - The "all up to date" empty state is shown when nothing needs updating.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import { StoreApp } from "./index";
+
+// Minimal fetch stubs for all endpoints the StoreApp calls on mount.
+function makeFetch(optionalCatalogApps: Array<{
+  id: string; version: string; installed: boolean; update_available: boolean;
+  trust?: string; source?: string;
+}>) {
+  return vi.fn(async (url: string) => {
+    if (url === "/api/store/catalog") {
+      return new Response("[]", { status: 200, headers: { "content-type": "application/json" } });
+    }
+    if (url === "/api/store/installed-v2") {
+      return new Response(JSON.stringify({ installed: [] }), { status: 200, headers: { "content-type": "application/json" } });
+    }
+    if (url === "/api/agents") {
+      return new Response("[]", { status: 200, headers: { "content-type": "application/json" } });
+    }
+    if (url === "/api/cluster/install-targets") {
+      return new Response(JSON.stringify([{ name: "local", label: "Local", type: "local" }]), { status: 200, headers: { "content-type": "application/json" } });
+    }
+    if (url === "/api/apps/optional/catalog") {
+      return new Response(
+        JSON.stringify({
+          apps: optionalCatalogApps.map((a) => ({
+            trust: "first-party", source: "core", ...a,
+          })),
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    // framework API + other endpoints: 404 is fine (caught silently)
+    return new Response(null, { status: 404 });
+  });
+}
+
+beforeEach(() => {
+  // jsdom doesn't implement scrollTo
+  if (!Element.prototype.scrollTo) {
+    Element.prototype.scrollTo = (() => {}) as typeof Element.prototype.scrollTo;
+  }
+  if (!window.matchMedia) {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((q: string) => ({
+        matches: false, media: q, onchange: null,
+        addListener: vi.fn(), removeListener: vi.fn(),
+        addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
+      })),
+    });
+  }
+});
+
+afterEach(() => { cleanup(); vi.restoreAllMocks(); });
+
+describe("Store updates tab -- optional app versioning", () => {
+  it("fetches the optional catalog on mount", async () => {
+    const mockFetch = makeFetch([]);
+    global.fetch = mockFetch as any;
+    render(<StoreApp windowId="test" />);
+    await waitFor(() =>
+      expect(mockFetch.mock.calls.some(([url]: [string]) => url === "/api/apps/optional/catalog")).toBe(true)
+    );
+  });
+
+  it("shows all up to date empty state when no optional apps need updates", async () => {
+    global.fetch = makeFetch([
+      { id: "reddit", version: "1.0.0", installed: true, update_available: false },
+    ]) as any;
+    render(<StoreApp windowId="test" />);
+    // Navigate to updates tab
+    const updatesBtn = await screen.findByRole("button", { name: /updates/i });
+    fireEvent.click(updatesBtn);
+    await waitFor(() => expect(screen.getByText(/all up to date/i)).toBeInTheDocument());
+  });
+
+  it("shows an installed optional app with update_available in the updates tab", async () => {
+    global.fetch = makeFetch([
+      { id: "reddit", version: "1.0.0", installed: true, update_available: true },
+    ]) as any;
+    render(<StoreApp windowId="test" />);
+    const updatesBtn = await screen.findByRole("button", { name: /updates/i });
+    fireEvent.click(updatesBtn);
+    await waitFor(() => expect(screen.getByText("Reddit")).toBeInTheDocument());
+    expect(screen.getByText(/included in next system update/i)).toBeInTheDocument();
+    // Core badge should be visible
+    expect(screen.getByText("Core")).toBeInTheDocument();
+  });
+});

--- a/tests/test_apps_installed.py
+++ b/tests/test_apps_installed.py
@@ -211,3 +211,81 @@ class TestOptionalApps:
         resp = await client.get("/api/apps/installed")
         ids = {i["app_id"] for i in resp.json()}
         assert "github-browser" not in ids
+
+
+class TestOptionalAppCatalog:
+    @pytest.mark.asyncio
+    async def test_catalog_returns_all_allowlisted_apps(self, apps_client):
+        """Catalog must include every id in OPTIONAL_FRONTEND_APPS with source=core."""
+        from tinyagentos.routes.apps import OPTIONAL_FRONTEND_APPS
+        client, _ = apps_client
+        resp = await client.get("/api/apps/optional/catalog")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "apps" in data
+        returned_ids = {a["id"] for a in data["apps"]}
+        assert returned_ids == OPTIONAL_FRONTEND_APPS
+        for app in data["apps"]:
+            assert app["source"] == "core"
+            assert "version" in app
+            assert "trust" in app
+            assert "installed" in app
+            assert "update_available" in app
+
+    @pytest.mark.asyncio
+    async def test_install_records_app_versions_version(self, apps_client):
+        """Installing an app should record the APP_VERSIONS version in the DB."""
+        from tinyagentos.routes.apps import APP_VERSIONS
+        client, store = apps_client
+        resp = await client.post("/api/apps/optional/reddit/install")
+        assert resp.status_code == 200
+        rows = await store.list_installed()
+        row = next((r for r in rows if r["app_id"] == "reddit"), None)
+        assert row is not None
+        assert row["version"] == APP_VERSIONS["reddit"]
+
+    @pytest.mark.asyncio
+    async def test_update_available_false_for_fresh_install(self, apps_client):
+        """A freshly installed app records the current version, so update_available=false."""
+        client, _ = apps_client
+        await client.post("/api/apps/optional/youtube-library/install")
+        resp = await client.get("/api/apps/optional/catalog")
+        app = next(a for a in resp.json()["apps"] if a["id"] == "youtube-library")
+        assert app["installed"] is True
+        assert app["update_available"] is False
+
+    @pytest.mark.asyncio
+    async def test_update_available_true_when_recorded_version_is_older(self, apps_client):
+        """update_available flips true when the stored version is behind APP_VERSIONS."""
+        from tinyagentos.routes.apps import APP_VERSIONS
+        import json
+        client, store = apps_client
+        # Seed the DB with an older version directly.
+        await store._db.execute(
+            "INSERT OR REPLACE INTO installed_apps (app_id, installed_at, version, metadata) VALUES (?, ?, ?, ?)",
+            ("x-monitor", 1000.0, "0.9.0", json.dumps({"kind": "frontend-app"})),
+        )
+        await store._db.commit()
+        resp = await client.get("/api/apps/optional/catalog")
+        app = next(a for a in resp.json()["apps"] if a["id"] == "x-monitor")
+        assert app["installed"] is True
+        # APP_VERSIONS["x-monitor"] is "1.0.0" which is > "0.9.0"
+        assert app["update_available"] is True
+        assert app["version"] == APP_VERSIONS["x-monitor"]
+
+    @pytest.mark.asyncio
+    async def test_catalog_does_not_leak_unknown_ids(self, apps_client):
+        """Catalog must never return ids outside the allowlist."""
+        from tinyagentos.routes.apps import OPTIONAL_FRONTEND_APPS
+        import json
+        client, store = apps_client
+        # Inject a foreign row directly (bypassing the install endpoint).
+        await store._db.execute(
+            "INSERT OR REPLACE INTO installed_apps (app_id, installed_at, version, metadata) VALUES (?, ?, ?, ?)",
+            ("totally-random-app", 1000.0, "1.0.0", json.dumps({"kind": "frontend-app"})),
+        )
+        await store._db.commit()
+        resp = await client.get("/api/apps/optional/catalog")
+        returned_ids = {a["id"] for a in resp.json()["apps"]}
+        assert "totally-random-app" not in returned_ids
+        assert returned_ids == OPTIONAL_FRONTEND_APPS

--- a/tinyagentos/routes/apps.py
+++ b/tinyagentos/routes/apps.py
@@ -62,17 +62,21 @@ APP_TRUST: dict[str, str] = {
 }
 
 
-def _semver_tuple(version: str) -> tuple[int, ...]:
-    """Parse a semver string into a comparable tuple of ints.
+def _semver_tuple(version: str) -> tuple[int, int, int]:
+    """Parse a semver string into a fixed-length (major, minor, patch) tuple.
 
-    Strips leading 'v' and ignores pre-release/build suffixes for ordering.
-    Returns (0,) on any parse failure so comparisons degrade gracefully.
+    Strips a leading 'v' and ignores pre-release/build suffixes for ordering,
+    and pads to three components so "1.0" and "1.0.0" compare equal. Returns
+    (0, 0, 0) on any parse failure so comparisons degrade gracefully without
+    masking a real update.
     """
     v = version.lstrip("v").split("-")[0].split("+")[0]
     try:
-        return tuple(int(p) for p in v.split("."))
+        parts = [int(p) for p in v.split(".")]
     except ValueError:
-        return (0,)
+        return (0, 0, 0)
+    parts = (parts + [0, 0, 0])[:3]
+    return (parts[0], parts[1], parts[2])
 
 
 def _resolve_icon(manifest_icon: str, manifest_dir) -> str:

--- a/tinyagentos/routes/apps.py
+++ b/tinyagentos/routes/apps.py
@@ -1,6 +1,6 @@
 """Desktop service icon API.
 
-GET /api/apps/installed — list installed services that have a recorded
+GET /api/apps/installed -- list installed services that have a recorded
 runtime location (host + port). These are the apps that get desktop icons
 and can be opened in a taOS web-app window via the service proxy.
 
@@ -34,15 +34,55 @@ OPTIONAL_FRONTEND_APPS = {
 }
 _FRONTEND_APP_KIND = "frontend-app"
 
+# In-core version for each optional app. When an app becomes a real .taosapp
+# package, the package version will win instead of this value.
+APP_VERSIONS: dict[str, str] = {
+    "reddit": "1.0.0",
+    "youtube-library": "1.0.0",
+    "github-browser": "1.0.0",
+    "x-monitor": "1.0.0",
+    "coding-studio": "1.0.0",
+    "design-studio": "1.0.0",
+    "music-studio": "1.0.0",
+    "app-studio": "1.0.0",
+    "office-suite": "1.0.0",
+}
+
+# Trust level for each optional app (all current optional apps are first-party).
+APP_TRUST: dict[str, str] = {
+    "reddit": "first-party",
+    "youtube-library": "first-party",
+    "github-browser": "first-party",
+    "x-monitor": "first-party",
+    "coding-studio": "first-party",
+    "design-studio": "first-party",
+    "music-studio": "first-party",
+    "app-studio": "first-party",
+    "office-suite": "first-party",
+}
+
+
+def _semver_tuple(version: str) -> tuple[int, ...]:
+    """Parse a semver string into a comparable tuple of ints.
+
+    Strips leading 'v' and ignores pre-release/build suffixes for ordering.
+    Returns (0,) on any parse failure so comparisons degrade gracefully.
+    """
+    v = version.lstrip("v").split("-")[0].split("+")[0]
+    try:
+        return tuple(int(p) for p in v.split("."))
+    except ValueError:
+        return (0,)
+
 
 def _resolve_icon(manifest_icon: str, manifest_dir) -> str:
     """Resolve the manifest's icon field to a URL string.
 
     Accepts:
-    - Absolute URL paths like /static/app-icons/gitea.svg  → returned as-is.
-    - http/https URLs                                        → returned as-is.
+    - Absolute URL paths like /static/app-icons/gitea.svg  -> returned as-is.
+    - http/https URLs                                        -> returned as-is.
     - Relative paths (e.g. icons/gitea.svg) relative to
-      the manifest dir — not currently served, so fall back
+      the manifest dir -- not currently served, so fall back
       to the generic icon.
     Returns the generic icon if the field is empty.
     """
@@ -50,7 +90,7 @@ def _resolve_icon(manifest_icon: str, manifest_dir) -> str:
         return _GENERIC_ICON
     if manifest_icon.startswith("/") or manifest_icon.startswith("http"):
         return manifest_icon
-    # Relative path — would need extra static-mount work; use generic for now.
+    # Relative path -- would need extra static-mount work; use generic for now.
     return _GENERIC_ICON
 
 
@@ -87,10 +127,10 @@ async def list_installed_apps(request: Request):
         app_id: str = row["app_id"]
         loc = await installed_apps.get_runtime_location(app_id)
         if loc is None:
-            # No runtime location → not accessible via proxy → skip.
+            # No runtime location -- not accessible via proxy -- skip.
             continue
         if not loc.get("runtime_host") or not loc.get("runtime_port"):
-            # Incomplete runtime record — not proxy-routable yet.
+            # Incomplete runtime record -- not proxy-routable yet.
             continue
 
         # Best-effort manifest lookup for display metadata.
@@ -134,7 +174,7 @@ async def list_installed_apps(request: Request):
 
 
 # --------------------------------------------------------------------------- #
-# Optional frontend apps (Reddit / YouTube / GitHub / X) — Store install state.
+# Optional frontend apps -- Store install state and versioned catalog.
 # --------------------------------------------------------------------------- #
 
 
@@ -159,9 +199,73 @@ async def list_installed_optional_apps(request: Request):
     return {"installed": installed}
 
 
+@router.get("/api/apps/optional/catalog")
+async def optional_app_catalog(request: Request):
+    """Return version and install state for every allowlisted optional app.
+
+    Shape::
+
+        {
+            "apps": [
+                {
+                    "id": "reddit",
+                    "version": "1.0.0",
+                    "trust": "first-party",
+                    "source": "core",
+                    "installed": true,
+                    "update_available": false
+                },
+                ...
+            ]
+        }
+
+    ``source`` is always "core" for in-bundle apps. A future .taosapp package
+    source would appear here alongside an independent Update button without any
+    UI rework.
+
+    ``update_available`` is true only when the app is installed AND the version
+    recorded at install time is older than APP_VERSIONS (semver comparison).
+    Freshly installed apps always record the current APP_VERSIONS version, so
+    update_available will be false unless an older install row pre-dates a
+    version bump.
+    """
+    store = getattr(request.app.state, "installed_apps", None)
+
+    # Build an index of installed rows keyed by app_id for O(1) lookup.
+    installed_index: dict[str, dict] = {}
+    if store is not None:
+        rows = await store.list_installed()
+        for r in rows:
+            aid = r["app_id"]
+            if aid in OPTIONAL_FRONTEND_APPS and (r.get("metadata") or {}).get("kind") == _FRONTEND_APP_KIND:
+                installed_index[aid] = r
+
+    result = []
+    for app_id in sorted(OPTIONAL_FRONTEND_APPS):
+        current_version = APP_VERSIONS.get(app_id, "1.0.0")
+        row = installed_index.get(app_id)
+        is_installed = row is not None
+        update_available = False
+        if is_installed and row is not None:
+            recorded = row.get("version") or ""
+            if recorded:
+                update_available = _semver_tuple(recorded) < _semver_tuple(current_version)
+
+        result.append({
+            "id": app_id,
+            "version": current_version,
+            "trust": APP_TRUST.get(app_id, "first-party"),
+            "source": "core",
+            "installed": is_installed,
+            "update_available": update_available,
+        })
+
+    return {"apps": result}
+
+
 @router.post("/api/apps/optional/{app_id}/install")
 async def install_optional_app(app_id: str, request: Request):
-    """Mark an optional frontend app installed. Instant — no service is spawned.
+    """Mark an optional frontend app installed. Instant -- no service is spawned.
 
     Rejected unless app_id is in the OPTIONAL_FRONTEND_APPS allowlist so this
     endpoint can't seed arbitrary install rows.
@@ -171,7 +275,11 @@ async def install_optional_app(app_id: str, request: Request):
     store = getattr(request.app.state, "installed_apps", None)
     if store is None:
         return JSONResponse({"error": "install store unavailable"}, status_code=503)
-    await store.install(app_id, metadata={"kind": _FRONTEND_APP_KIND})
+    await store.install(
+        app_id,
+        version=APP_VERSIONS.get(app_id, "1.0.0"),
+        metadata={"kind": _FRONTEND_APP_KIND},
+    )
     return {"status": "installed", "app_id": app_id}
 
 


### PR DESCRIPTION
Phase 1 of userspace app packages (#89, Track A "rails first"): make optional-app versions real and visible, structured for future independent per-app updates. No package format or dynamic code loading yet.

## Backend (routes/apps.py)
- APP_VERSIONS + APP_TRUST maps: the source of truth for in-core optional apps (a real .taosapp package version wins later).
- GET /api/apps/optional/catalog returns per-app {id, version, trust, source: "core", installed, update_available}; allowlist-bounded; semver-aware update_available.
- install_optional_app now records the app version.

## Frontend
- Settings/Updates (authoritative): new "Apps" section under the taOS core row. Each installed app shows its version + a Core badge. Rows are keyed by source, so a future "package" source gets its own independent Update button with no layout rework. A Core app's "update" routes to the system update (honest: in-core code updates with the OS).
- Store/Updates (mirror): updatable optional apps surface in the Updates tab.

## Tests
Backend: catalog shape, install records version, update_available flips on an older install row, allowlist isolation (5). Frontend: UpdatesPanel rows + empty state (3), Store updates tab (3). tsc clean, build green, 17 backend + 10 vitest pass locally.

## Honest semantics
While the studios are in-core, their update path IS the system update. P1 surfaces versions + the row structure; it does not fake independent updates. Independent per-app updates land when studios become real .taosapp packages in later phases.

Part of #89.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for optional in-bundle apps to be tracked and surfaced in Settings’ Updates panel, including version details and update status.
  * Installed optional apps now show “Core”/included indicators and an “Install now” action that jumps to the system update section.
  * Store app “updates” view now highlights optional apps with available updates and adjusts the empty-state messaging accordingly.
* **Tests**
  * Added/extended coverage for optional app catalog behavior and UI rendering for update-available vs up-to-date cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->