### PR TITLE
feat(userspace): surface and launch installed userspace apps in the Launchpad (#89)

### DIFF
--- a/desktop/src/components/Launchpad.tsx
+++ b/desktop/src/components/Launchpad.tsx
@@ -7,6 +7,7 @@ import { LaunchpadIcon } from "./LaunchpadIcon";
 import { ServiceIcon } from "./ServiceIcon";
 import { useInstalledServices } from "@/hooks/use-installed-services";
 import { useInstalledOptionalApps } from "@/hooks/use-installed-optional-apps";
+import { useInstalledUserspaceApps } from "@/hooks/use-installed-userspace-apps";
 
 interface Props {
   open: boolean;
@@ -28,6 +29,7 @@ export function Launchpad({ open, onClose, onOpenApp }: Props) {
   const { openWindow } = useProcessStore();
   const installedServices = useInstalledServices();
   const installedOptional = useInstalledOptionalApps();
+  const installedUserspace = useInstalledUserspaceApps();
 
   // Register Escape at overlay priority so it beats any system shortcuts when open
   useShortcut("Escape", () => { if (openRef.current) onClose(); }, "Close launchpad", "overlay");
@@ -35,12 +37,11 @@ export function Launchpad({ open, onClose, onOpenApp }: Props) {
   const isMobile = typeof window !== "undefined" && window.innerWidth < 640;
 
   const apps = useMemo(() => {
-    // Installed services render once under the Services section below (from
-    // /api/apps/installed). Exclude any dynamically-registered service:* apps
-    // from the registry grouping so they don't also appear under a built-in
-    // category (e.g. SearXNG showing under both Platform and Services).
+    // Installed services and userspace apps render in their own sections below.
+    // Exclude dynamically-registered service:* and userspace:* entries from the
+    // registry grouping so they don't also appear under a built-in category.
     const all = getLaunchableApps(installedOptional).filter(
-      (a) => !a.id.startsWith("service:"),
+      (a) => !a.id.startsWith("service:") && !a.id.startsWith("userspace:"),
     );
     if (!query.trim()) return all;
     const q = query.toLowerCase();
@@ -79,6 +80,13 @@ export function Launchpad({ open, onClose, onOpenApp }: Props) {
     const q = query.toLowerCase();
     return installedServices.filter((s) => s.display_name.toLowerCase().includes(q));
   }, [installedServices, query]);
+
+  // Filter userspace apps by search query if one is active
+  const filteredUserspace = useMemo(() => {
+    if (!query.trim()) return installedUserspace;
+    const q = query.toLowerCase();
+    return installedUserspace.filter((a) => a.name.toLowerCase().includes(q));
+  }, [installedUserspace, query]);
 
   if (!open) return null;
 
@@ -137,6 +145,19 @@ export function Launchpad({ open, onClose, onOpenApp }: Props) {
               </div>
             </div>
           ))}
+
+          {filteredUserspace.length > 0 && (
+            <div>
+              <h3 className="text-xs font-medium text-shell-text-tertiary uppercase tracking-wide mb-4 px-1">
+                Apps
+              </h3>
+              <div className="grid gap-2 sm:gap-3" style={{ gridTemplateColumns: "repeat(auto-fill, minmax(100px, 1fr))" }}>
+                {filteredUserspace.map((app) => (
+                  <LaunchpadIcon key={app.id} app={app} onClick={() => handleLaunch(app.id)} />
+                ))}
+              </div>
+            </div>
+          )}
 
           {filteredServices.length > 0 && (
             <div>

--- a/desktop/src/hooks/use-installed-userspace-apps.ts
+++ b/desktop/src/hooks/use-installed-userspace-apps.ts
@@ -1,0 +1,43 @@
+import { useState, useEffect, useCallback } from "react";
+import type { AppManifest } from "@/registry/app-registry";
+import { syncUserspaceApps } from "@/registry/app-registry";
+import { fetchUserspaceApps, USERSPACE_APPS_CHANGED } from "@/lib/userspace-apps";
+import { onAppEvent } from "@/lib/app-event-bus";
+
+/**
+ * Fetches installed userspace (.taosapp) packages from /api/userspace-apps,
+ * syncs them into the app registry, and returns the manifest list.
+ * Re-fetches automatically when a USERSPACE_APPS_CHANGED event fires on the
+ * shared EventBus (e.g. after a successful Store install or uninstall).
+ * Returns an empty list while loading or on error.
+ */
+export function useInstalledUserspaceApps(): AppManifest[] {
+  const [apps, setApps] = useState<AppManifest[]>([]);
+
+  const refresh = useCallback(() => {
+    let cancelled = false;
+    fetchUserspaceApps()
+      .then((list) => {
+        if (!cancelled) {
+          syncUserspaceApps(list);
+          setApps(list);
+        }
+      })
+      .catch(() => {
+        // Silently ignore -- Apps section just won't appear
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  // Initial fetch
+  useEffect(() => {
+    return refresh();
+  }, [refresh]);
+
+  // Re-fetch when a userspace app is installed, updated, or removed
+  useEffect(() => {
+    return onAppEvent(USERSPACE_APPS_CHANGED, () => { refresh(); });
+  }, [refresh]);
+
+  return apps;
+}

--- a/desktop/src/hooks/use-installed-userspace-apps.ts
+++ b/desktop/src/hooks/use-installed-userspace-apps.ts
@@ -34,9 +34,19 @@ export function useInstalledUserspaceApps(): AppManifest[] {
     return refresh();
   }, [refresh]);
 
-  // Re-fetch when a userspace app is installed, updated, or removed
+  // Re-fetch when a userspace app is installed, updated, or removed.
+  // Cancel any in-flight fetch before starting a new one (and on unmount) so a
+  // slower, older response cannot overwrite newer data or setState after unmount.
   useEffect(() => {
-    return onAppEvent(USERSPACE_APPS_CHANGED, () => { refresh(); });
+    let cancel: () => void = () => {};
+    const off = onAppEvent(USERSPACE_APPS_CHANGED, () => {
+      cancel();
+      cancel = refresh();
+    });
+    return () => {
+      cancel();
+      off();
+    };
   }, [refresh]);
 
   return apps;

--- a/desktop/src/lib/userspace-apps.ts
+++ b/desktop/src/lib/userspace-apps.ts
@@ -1,5 +1,11 @@
 import type { AppManifest } from "@/registry/app-registry";
 
+/**
+ * Event name emitted when the installed userspace-app list changes (install,
+ * uninstall, or enable/disable). Mirrors APP_INSTALLED from app-event-bus.
+ */
+export const USERSPACE_APPS_CHANGED = "taos:userspace-apps-changed";
+
 export interface UserspaceAppRow {
   app_id: string;
   name: string;
@@ -15,7 +21,9 @@ export interface UserspaceAppRow {
 export function toAppManifest(row: UserspaceAppRow): AppManifest {
   const trust = row.trust ?? "community";
   return {
-    id: row.app_id,
+    // Registry id is namespaced (mirrors "service:") so a community app cannot
+    // shadow a built-in app id. The broker/bundle still use the raw app_id.
+    id: `userspace:${row.app_id}`,
     name: row.name,
     icon: "layout-grid",
     category: "userspace",

--- a/desktop/src/registry/app-registry.ts
+++ b/desktop/src/registry/app-registry.ts
@@ -190,3 +190,22 @@ export function getOrRegisterServiceApp(
   apps.push(manifest);
   return manifest;
 }
+
+/**
+ * Replace the full set of registered userspace app manifests in one atomic
+ * operation. Removes every existing "userspace:*" entry then pushes all the
+ * provided manifests. Call this after fetching /api/userspace-apps so that
+ * getApp() resolves userspace ids for openWindow, Dock, and prefetch without
+ * any additional lookups.
+ */
+export function syncUserspaceApps(manifests: AppManifest[]): void {
+  // Remove stale userspace entries in place (keeps the const binding intact)
+  for (let i = apps.length - 1; i >= 0; i--) {
+    if (apps[i]?.id.startsWith("userspace:")) {
+      apps.splice(i, 1);
+    }
+  }
+  for (const m of manifests) {
+    apps.push(m);
+  }
+}

--- a/desktop/src/registry/app-registry.ts
+++ b/desktop/src/registry/app-registry.ts
@@ -192,20 +192,31 @@ export function getOrRegisterServiceApp(
 }
 
 /**
- * Replace the full set of registered userspace app manifests in one atomic
- * operation. Removes every existing "userspace:*" entry then pushes all the
- * provided manifests. Call this after fetching /api/userspace-apps so that
- * getApp() resolves userspace ids for openWindow, Dock, and prefetch without
- * any additional lookups.
+ * Reconcile the registered userspace app manifests against a fresh list.
+ *
+ * Preserves the object identity of already-registered manifests so that open
+ * userspace windows are not remounted on every sync. Only removes entries no
+ * longer present in the incoming list and only appends genuinely new ids.
+ * When an id is removed its prefetch-cache entries are also cleared so a
+ * reinstall triggers a fresh prefetch.
  */
 export function syncUserspaceApps(manifests: AppManifest[]): void {
-  // Remove stale userspace entries in place (keeps the const binding intact)
+  const incoming = new Map(manifests.map((m) => [m.id, m]));
+  // Drop userspace entries no longer present, and clear their prefetch state
   for (let i = apps.length - 1; i >= 0; i--) {
-    if (apps[i]?.id.startsWith("userspace:")) {
+    const id = apps[i]?.id;
+    if (id?.startsWith("userspace:") && !incoming.has(id)) {
       apps.splice(i, 1);
+      prefetched.delete(id);
+      prefetchFailed.delete(id);
     }
   }
+  // Add only new ids, preserving the identity of already-registered manifests
+  // so open userspace windows are not remounted on every sync.
+  const present = new Set(
+    apps.filter((a) => a.id.startsWith("userspace:")).map((a) => a.id),
+  );
   for (const m of manifests) {
-    apps.push(m);
+    if (!present.has(m.id)) apps.push(m);
   }
 }


### PR DESCRIPTION
Wires the userspace app runtime into the desktop launcher so installed .taosapp packages (the seeded first-party welcome app, plus any community apps) actually appear and open into sandboxed windows. This is the launcher slice of #89; Store-side install/manage UI is a separate follow-up.

## What changed
- `toAppManifest` namespaces the registry id as `userspace:<app_id>` so a community app cannot shadow a built-in app id (e.g. "files"); the broker and bundle URLs still use the raw `app_id`. Mirrors the existing `service:` convention.
- New `syncUserspaceApps(manifests)` in the registry keeps `getApp()` authoritative for `openWindow`, the Dock, and `prefetchApp`.
- New `useInstalledUserspaceApps()` hook mirrors `useInstalledServices`: fetches `/api/userspace-apps`, registers the manifests, and refreshes on a `USERSPACE_APPS_CHANGED` event so a later Store install/uninstall reflects live.
- The Launchpad gains an "Apps" section (styled like "Services") that lists and launches userspace apps. Userspace ids are excluded from the built-in category grouping to avoid double-listing.

## Scope held back deliberately
- No Dock pinning, no Store install/manage UI, no permission-consent prompt; those land in the next PR.

## Verification
- `tsc -b` and `vite build` pass; no em dashes; author jaylfc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Launchpad now displays installed userspace apps in a dedicated "Apps" section.
  * Added search and filtering capability for userspace apps.
  * Userspace apps are managed separately from system services for improved organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->