### PR TITLE
fix(chat): anchor channel settings panel so it does not overlap the workspace preview

### DIFF
--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -2658,7 +2658,7 @@ export function MessagesApp({
   /* ---------------------------------------------------------------- */
 
   return (
-    <div className="flex flex-col h-full bg-shell-base text-white overflow-hidden">
+    <div className="relative flex flex-col h-full bg-shell-base text-white overflow-hidden">
       {/* Toolbar — hidden on mobile when a channel is selected */}
       {showToolbar && (
         <div className="relative flex items-center px-3 py-2.5 border-b border-white/[0.06] shrink-0">

--- a/desktop/src/apps/chat/ChannelSettingsPanel.tsx
+++ b/desktop/src/apps/chat/ChannelSettingsPanel.tsx
@@ -63,7 +63,7 @@ export function ChannelSettingsPanel({
     <aside
       role="complementary"
       aria-label="Channel settings"
-      className="fixed top-0 right-0 h-full w-[360px] bg-shell-surface border-l border-white/10 shadow-xl flex flex-col z-40"
+      className="absolute top-0 right-0 h-full w-[360px] bg-shell-surface border-l border-white/10 shadow-xl flex flex-col z-40"
     >
       <header className="flex items-center justify-between px-4 py-3 border-b border-white/10">
         <h2 className="text-sm font-semibold">Channel settings</h2>


### PR DESCRIPTION
The channel settings panel was positioned fixed to the viewport, so when the Messages app is embedded in the Projects Workspace split-pane it overlapped the right live-preview pane. Anchors it to its chat container instead (absolute within a relative MessagesApp root), keeping it inside the chat area in both the standalone window and the Workspace split. Two-line change, dogfooded from a real report. Board card tsk-2qk24n.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted CSS positioning in messaging interface components for improved layout rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->