### PR TITLE
fix(chat): show channel topic in settings, falling back to description when empty

### DIFF
--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -2754,7 +2754,7 @@ export function MessagesApp({
             id: currentChannel.id,
             name: currentChannel.name,
             type: currentChannel.type,
-            topic: currentChannel.topic ?? "",
+            topic: currentChannel.topic ?? currentChannel.description ?? "",
             members: currentChannel.members ?? [],
             settings: currentChannel.settings ?? {},
           }}


### PR DESCRIPTION
The channel settings Topic field was empty even when the chat header showed text, because the header surfaces the channel description while settings binds the (empty) topic field. This makes the settings Topic value fall back to description when topic is unset, so the two displays agree. Stopgap for the reported symptom; the deeper topic-vs-description field consistency (create flow sets description, settings edits topic) is filed as a follow-up. Dogfooded card tsk-owqeck, fixed autonomously by @grok.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed channel settings panel to display the channel description as a fallback when a topic is not explicitly set, instead of showing an empty field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->