### PR TITLE
fix(messages): show newly created channels in the project list immediately

### DIFF
--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -1262,7 +1262,7 @@ export function MessagesApp({
       });
       if (res.ok) {
         const ch = await res.json();
-        setChannels((prev) => [...prev, ch]);
+        await fetchChannels();
         setSelectedChannel(ch.id);
         setShowCreate(false);
         setNewChannel({ name: "", type: "topic", description: "" });
@@ -1399,11 +1399,15 @@ export function MessagesApp({
   };
 
   /* ---- group channels by type ---- */
-  const isRoot = (c: Channel) => !c.project_id;
+  // Standalone Messages: root channels (no project_id) go in the DM/Topics/Groups
+  // sections; project channels nest under Projects. Project-scoped Messages shows
+  // only that project's channels in the type sections (Projects nest is hidden).
+  const inSidebarSection = (c: Channel) =>
+    scope?.projectId ? c.project_id === scope.projectId : !c.project_id;
   const grouped = {
-    dm: channels.filter((c) => c.type === "dm" && isRoot(c)),
-    topic: channels.filter((c) => c.type === "topic" && isRoot(c)),
-    group: channels.filter((c) => c.type === "group" && isRoot(c)),
+    dm: channels.filter((c) => c.type === "dm" && inSidebarSection(c)),
+    topic: channels.filter((c) => c.type === "topic" && inSidebarSection(c)),
+    group: channels.filter((c) => c.type === "group" && inSidebarSection(c)),
   };
 
   const allChannels = [...channels, ...archivedChannels];


### PR DESCRIPTION
A channel created inside the project-scoped Messages did not appear in the sidebar until reload. Root cause: the sidebar grouping filtered on isRoot (no project_id), which excludes project channels entirely, so project-scoped channels were never shown in Topics/Groups. Scopes the sidebar filter to the current project (root channels in standalone Messages, project channels in project Messages) and refetches the channel list on create so the new channel shows immediately. Dogfooded card tsk-khz7cc, fixed autonomously by @grok.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed channel list refresh behavior when creating new channels.
  * Improved channel sidebar organization to properly display channels based on viewing mode context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->