### PR TITLE
fix(projects): no external-member flash on load + hide canvas/lead toggles on external rows

### DIFF
--- a/desktop/src/apps/ProjectsApp/ProjectMembers.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectMembers.tsx
@@ -99,7 +99,7 @@ function MemberRow({
         </div>
       </div>
       <div className="flex flex-wrap items-center gap-2 md:flex-nowrap">
-        {(member.member_kind === "native" || member.member_kind === "clone") && (
+        {!isExternal && (member.member_kind === "native" || member.member_kind === "clone") && (
           <label
             style={{ display: "inline-flex", alignItems: "center", gap: 6 }}
             title="When off, this agent can add new elements but cannot modify or delete existing ones."
@@ -116,7 +116,7 @@ function MemberRow({
             <span className="text-xs">Can edit canvas</span>
           </label>
         )}
-        {(member.member_kind === "native" || member.member_kind === "clone") && (
+        {!isExternal && (member.member_kind === "native" || member.member_kind === "clone") && (
           <label
             style={{ display: "inline-flex", alignItems: "center", gap: 6 }}
             title="Lead agents see all messages in the project channel, even without being @mentioned."
@@ -155,6 +155,7 @@ export function ProjectMembers({ project, onChanged }: { project: Project; onCha
   const [members, setMembers] = useState<ProjectMember[]>([]);
   const [agents, setAgents] = useState<AgentSummary[]>([]);
   const [externalAgents, setExternalAgents] = useState<ExternalAgentSummary[]>([]);
+  const [externalRegistryLoaded, setExternalRegistryLoaded] = useState(false);
   const [dialogOpen, setDialogOpen] = useState(false);
 
   const refresh = () =>
@@ -195,19 +196,24 @@ export function ProjectMembers({ project, onChanged }: { project: Project; onCha
     fetch("/api/agents/registry", { credentials: "include" })
       .then((r) => (r.ok ? r.json() : []))
       .then((rows) => {
-        if (cancelled || !Array.isArray(rows)) return;
-        const active = rows.filter(
-          (entry: { origin?: string; status?: string }) =>
-            entry.origin === "external-selfjoin" && entry.status === "active",
-        );
-        setExternalAgents(
-          active.map((entry: { handle?: string; display_name?: string }) => ({
-            handle: entry.handle || "",
-            display_name: entry.display_name,
-          })),
-        );
+        if (cancelled) return;
+        if (Array.isArray(rows)) {
+          const active = rows.filter(
+            (entry: { origin?: string; status?: string }) =>
+              entry.origin === "external-selfjoin" && entry.status === "active",
+          );
+          setExternalAgents(
+            active.map((entry: { handle?: string; display_name?: string }) => ({
+              handle: entry.handle || "",
+              display_name: entry.display_name,
+            })),
+          );
+        }
+        setExternalRegistryLoaded(true);
       })
-      .catch(() => {});
+      .catch(() => {
+        if (!cancelled) setExternalRegistryLoaded(true);
+      });
     return () => {
       cancelled = true;
     };
@@ -235,12 +241,12 @@ export function ProjectMembers({ project, onChanged }: { project: Project; onCha
         main.push(m);
       } else if (byHandle.has(m.member_id)) {
         external.push(m);
-      } else {
+      } else if (externalRegistryLoaded) {
         main.push(m);
       }
     }
     return { mainMembers: main, externalMembers: external };
-  }, [members, byId, byHandle]);
+  }, [members, byId, byHandle, externalRegistryLoaded]);
 
   return (
     <section>


### PR DESCRIPTION
Fix-forward for two gitar nits on the external-agents members section: external members no longer flash in the main list before the registry resolves (gated on an externalRegistryLoaded flag), and external/connected rows no longer show the Can-edit-canvas / Lead toggles. ProjectMembers.tsx only. Built autonomously by @grok (tsk-uzqwra).

----
## Summary by Gitar

- **Project management:**
  - Fixed UI flash in `ProjectMembers` by gating external members behind `externalRegistryLoaded`.
  - Removed 'Can-edit-canvas' and 'Lead' toggles from external/connected rows in `ProjectMembers.tsx`.
- **App distribution:**
  - Added comprehensive userspace app infrastructure including `userspace_apps` route, package installation, broker for capability grants, and first-party vs. community CSP isolation.
  - Added catalog endpoint for optional frontend apps and integrated semver-based update detection.
- **New studios:**
  - Added 'Coding', 'Design', 'Music', 'App', and 'Office' studios to the `StoreApp` catalog.
  - Implemented foundational UI for `CodingStudio` (Build/Preview), `MusicStudio` (Arrangement/Piano roll), and `DesignStudio` (Artboard).
- **Security & Infrastructure:**
  - Implemented P3b trust-aware CSPs (tight sandbox for community, restricted for first-party) and SSRF protections for app source URLs.
  - Added robust test suite for trust boundaries, app seeding, and broker capabilities.

<sub>This will update automatically on new commits.</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed member row controls to display correctly based on member type—canvas permissions and lead-toggle checkboxes now appear only for internal members
  * Improved external member classification and agent registry data synchronization during initialization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->