### PR TITLE
feat(update): skip the 'Update available' notification for docs-only commits

### DIFF
--- a/tests/test_docs_only_update.py
+++ b/tests/test_docs_only_update.py
@@ -1,0 +1,189 @@
+"""Docs-only commits must not surface as 'Update available'."""
+import asyncio
+import subprocess
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tinyagentos.auto_update import (
+    AutoUpdateService,
+    changes_are_docs_only,
+    is_documentation_path,
+)
+
+
+def _git(cwd, *args):
+    subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def _sha(cwd, ref="HEAD"):
+    return subprocess.run(
+        ["git", "rev-parse", ref],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+@pytest.fixture
+def repo(tmp_path):
+    r = tmp_path / "repo"
+    r.mkdir()
+    _git(r, "init", "-q")
+    _git(r, "config", "user.email", "t@t")
+    _git(r, "config", "user.name", "t")
+    _git(r, "checkout", "-q", "-b", "master")
+    (r / "code.py").write_text("v1")
+    _git(r, "add", ".")
+    _git(r, "commit", "-qm", "base")
+    return r
+
+
+def test_is_documentation_path():
+    assert is_documentation_path("docs/STATUS.md") is True
+    assert is_documentation_path("README.md") is True
+    assert is_documentation_path("tinyagentos/foo.py") is False
+    assert is_documentation_path("notes.txt") is False
+
+
+def test_changes_are_docs_only_true_for_docs_dir(repo):
+    old = _sha(repo)
+    (repo / "docs").mkdir()
+    (repo / "docs" / "STATUS.md").write_text("handoff")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "docs only")
+    new = _sha(repo)
+    assert asyncio.run(changes_are_docs_only(repo, old, new)) is True
+
+
+def test_changes_are_docs_only_true_for_root_md(repo):
+    old = _sha(repo)
+    (repo / "README.md").write_text("# taOS")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "readme")
+    new = _sha(repo)
+    assert asyncio.run(changes_are_docs_only(repo, old, new)) is True
+
+
+def test_changes_are_docs_only_false_for_code(repo):
+    old = _sha(repo)
+    (repo / "code.py").write_text("v2")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "code change")
+    new = _sha(repo)
+    assert asyncio.run(changes_are_docs_only(repo, old, new)) is False
+
+
+def test_changes_are_docs_only_false_for_mixed(repo):
+    old = _sha(repo)
+    (repo / "docs").mkdir()
+    (repo / "docs" / "STATUS.md").write_text("note")
+    (repo / "code.py").write_text("v2")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "mixed")
+    new = _sha(repo)
+    assert asyncio.run(changes_are_docs_only(repo, old, new)) is False
+
+
+@pytest.mark.asyncio
+async def test_update_check_hides_docs_only_diff(client, monkeypatch):
+    import asyncio as _asyncio
+
+    import tinyagentos.routes.settings as s
+
+    class _FakeProc:
+        def __init__(self, out=b""):
+            self._out = out
+
+        async def communicate(self):
+            return self._out, b""
+
+    async def fake_resolve(store, project_dir):
+        return "dev"
+
+    async def fake_exec(*args, **kwargs):
+        if args[1] == "rev-parse":
+            ref = args[2]
+            if ref == "HEAD":
+                return _FakeProc(b"aaa1111\n")
+            return _FakeProc(b"bbb2222\n")
+        if args[1] == "log":
+            return _FakeProc(b"abc def\n")
+        return _FakeProc()
+
+    async def fake_strictly_ahead(project_dir, local_sha, remote_sha):
+        return True
+
+    async def fake_docs_only(project_dir, local_sha, remote_sha):
+        return True
+
+    monkeypatch.setattr(s, "resolve_tracked_branch", fake_resolve, raising=False)
+    monkeypatch.setattr(_asyncio, "create_subprocess_exec", fake_exec, raising=False)
+    monkeypatch.setattr(
+        "tinyagentos.auto_update.remote_is_strictly_ahead",
+        fake_strictly_ahead,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "tinyagentos.auto_update.changes_are_docs_only",
+        fake_docs_only,
+        raising=False,
+    )
+
+    r = await client.get("/api/settings/update-check")
+    assert r.status_code == 200
+    assert r.json()["has_updates"] is False
+
+
+@pytest.mark.asyncio
+async def test_auto_update_skips_docs_only_notification(monkeypatch):
+    monkeypatch.delenv("TAOS_NO_UPDATE_PING", raising=False)
+
+    REMOTE = "aabbccdd" * 5
+    CURRENT = "11111111" * 5
+
+    notif_count = []
+
+    async def _fake_notify(current, new_commit):
+        notif_count.append(new_commit)
+
+    settings = MagicMock()
+    settings.get_preference = AsyncMock(
+        return_value={
+            "check_enabled": True,
+            "update_ping_enabled": False,
+            "last_notified_commit": None,
+        }
+    )
+    settings.save_preference = AsyncMock()
+
+    svc = AutoUpdateService(
+        project_dir=None,
+        notif_store=MagicMock(),
+        settings_store=settings,
+        app_state=None,
+    )
+    svc._notify_available = _fake_notify
+
+    with patch.object(svc, "_probe_remote", AsyncMock(return_value=REMOTE)):
+        with patch.object(svc, "_current_commit", AsyncMock(return_value=CURRENT)):
+            with patch(
+                "tinyagentos.auto_update.remote_is_strictly_ahead",
+                AsyncMock(return_value=True),
+            ):
+                with patch(
+                    "tinyagentos.auto_update.changes_are_docs_only",
+                    AsyncMock(return_value=True),
+                ):
+                    with patch("tinyagentos.auto_update.poll_frameworks", AsyncMock()):
+                        with patch("tinyagentos.frameworks.FRAMEWORKS", {}):
+                            await svc._run_once()
+
+    assert len(notif_count) == 0

--- a/tinyagentos/auto_update.py
+++ b/tinyagentos/auto_update.py
@@ -200,6 +200,34 @@ async def resolve_tracked_branch(settings_store, project_dir: Path) -> str:
     return await update_tracking_branch(project_dir)
 
 
+def is_documentation_path(path: str) -> bool:
+    """True when *path* is documentation-only (under docs/ or a .md file)."""
+    p = path.strip().replace("\\", "/")
+    if not p:
+        return False
+    return p.startswith("docs/") or p.endswith(".md")
+
+
+async def changes_are_docs_only(
+    project_dir: Path, current: str, remote: str
+) -> bool:
+    """True when every file changed between *current* and *remote* is documentation."""
+    if not current or not remote or current == remote:
+        return False
+    if project_dir is None or not Path(project_dir).exists():
+        return False
+    rc, out = await _run(
+        ["git", "diff", "--name-only", f"{current}..{remote}"],
+        project_dir,
+    )
+    if rc != 0:
+        return False
+    paths = [line.strip() for line in out.splitlines() if line.strip()]
+    if not paths:
+        return False
+    return all(is_documentation_path(p) for p in paths)
+
+
 async def remote_is_strictly_ahead(project_dir: Path, current: str, remote: str) -> bool:
     """True only if ``current`` is a strict ancestor of ``remote`` -- i.e. the
     remote is genuinely newer. Prevents offering an older or divergent commit
@@ -299,6 +327,13 @@ class AutoUpdateService:
             # flag an older/divergent commit (e.g. master's tip while we run
             # ahead on dev) as available.
             if await remote_is_strictly_ahead(self._project_dir, current, new_commit):
+                if await changes_are_docs_only(self._project_dir, current, new_commit):
+                    logger.debug(
+                        "auto-update: skipping docs-only diff %s..%s",
+                        (current or "")[:7],
+                        new_commit[:7],
+                    )
+                    return
                 # Skip re-notifying for a commit we've already flagged.
                 if prefs.get("last_notified_commit") != new_commit:
                     await self._notify_available(current, new_commit)

--- a/tinyagentos/routes/settings.py
+++ b/tinyagentos/routes/settings.py
@@ -502,7 +502,7 @@ async def check_for_updates(request: Request):
     import asyncio
     import re
     from tinyagentos import __version__
-    from tinyagentos.auto_update import remote_is_strictly_ahead
+    from tinyagentos.auto_update import changes_are_docs_only, remote_is_strictly_ahead
     project_dir = str(Path(__file__).parent.parent.parent)
 
     # Track the user's selected branch (Updates → Advanced selector), or the
@@ -537,6 +537,8 @@ async def check_for_updates(request: Request):
     # Only a real update when the remote is strictly ahead of us — never offer
     # an older or divergent commit.
     has_updates = await remote_is_strictly_ahead(project_dir, local_sha, remote_sha)
+    if has_updates and await changes_are_docs_only(Path(project_dir), local_sha, remote_sha):
+        has_updates = False
 
     async def _log1(ref: str) -> str:
         p = await asyncio.create_subprocess_exec(


### PR DESCRIPTION
A docs-only commit on the tracked branch (e.g. a STATUS.md handoff note) was surfacing as 'Update available' on dev/test boxes. Adds is_documentation_path + changes_are_docs_only (git diff --name-only, all paths under docs/ or ending .md) and skips the notification in both the AutoUpdateService notifier and the /api/settings/update-check endpoint. Code or mixed diffs still notify. Includes a 189-line test suite. Built autonomously by @grok (tsk-ydfagg) -- its first backend task.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Documentation-only updates no longer generate update notifications. Changes affecting only documentation files (docs/ directory or README files) will be silently applied without alerting users to updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->