### PR TITLE
fix(update): do not treat code/config files under docs/ as docs-only

### DIFF
--- a/tests/test_docs_only_update.py
+++ b/tests/test_docs_only_update.py
@@ -49,8 +49,11 @@ def repo(tmp_path):
 def test_is_documentation_path():
     assert is_documentation_path("docs/STATUS.md") is True
     assert is_documentation_path("README.md") is True
+    assert is_documentation_path("notes.txt") is True
+    assert is_documentation_path("guide.rst") is True
     assert is_documentation_path("tinyagentos/foo.py") is False
-    assert is_documentation_path("notes.txt") is False
+    assert is_documentation_path("docs/scripts/foo.py") is False
+    assert is_documentation_path("docs/config.yaml") is False
 
 
 def test_changes_are_docs_only_true_for_docs_dir(repo):

--- a/tinyagentos/auto_update.py
+++ b/tinyagentos/auto_update.py
@@ -200,12 +200,30 @@ async def resolve_tracked_branch(settings_store, project_dir: Path) -> str:
     return await update_tracking_branch(project_dir)
 
 
+_DOC_EXTENSIONS = (".md", ".markdown", ".rst", ".txt")
+_CODE_EXTENSIONS = (
+    ".py", ".ts", ".tsx", ".js", ".jsx", ".json",
+    ".yaml", ".yml", ".sh", ".toml", ".cfg", ".ini",
+)
+
+
 def is_documentation_path(path: str) -> bool:
-    """True when *path* is documentation-only (under docs/ or a .md file)."""
+    """True when *path* is documentation-only.
+
+    A path counts as documentation if it ends in a doc extension anywhere, or
+    lives under ``docs/`` without a code/config extension. When unsure, False.
+    """
     p = path.strip().replace("\\", "/")
     if not p:
         return False
-    return p.startswith("docs/") or p.endswith(".md")
+    lower = p.lower()
+    if any(lower.endswith(ext) for ext in _DOC_EXTENSIONS):
+        return True
+    if p.startswith("docs/"):
+        if any(lower.endswith(ext) for ext in _CODE_EXTENSIONS):
+            return False
+        return True
+    return False
 
 
 async def changes_are_docs_only(


### PR DESCRIPTION
Hardens is_documentation_path (gitar edge case on #982): explicit doc vs code/config extension lists, so a .py/.json/etc under docs/ is no longer misclassified as documentation and cannot wrongly suppress a real update. Doc extensions (.md/.markdown/.rst/.txt) recognized anywhere; unsure defaults to False. Test updated. Built autonomously by @grok (tsk-k5scnj).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved documentation file detection to recognize additional documentation formats (such as `.txt` and `.rst` files).
  * Enhanced logic to correctly exclude non-documentation files (like scripts and configuration files) within documentation folders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->