### PR TITLE
fix(userspace): pin install fetch to validated IP (DNS-rebind SSRF #971)

### DIFF
--- a/tests/userspace/test_broker.py
+++ b/tests/userspace/test_broker.py
@@ -43,6 +43,19 @@ async def test_table_capabilities(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_missing_required_arg_returns_clean_error(tmp_path):
+    # a capability that indexes args directly must return a clean error, not a 500
+    s = await _store(tmp_path)
+    out = await handle_capability("todo", "app.kv.get", {},
+                                  granted=[], data_store=s, app_dir=tmp_path / "todo", services={})
+    assert out == {"error": "missing_arg", "arg": "key"}
+    out2 = await handle_capability("todo", "app.table.delete", {"table": "t"},
+                                   granted=[], data_store=s, app_dir=tmp_path / "todo", services={})
+    assert out2 == {"error": "missing_arg", "arg": "id"}
+    await s.close()
+
+
+@pytest.mark.asyncio
 async def test_gated_capability_allowed_when_granted(tmp_path):
     s = await _store(tmp_path)
 

--- a/tests/userspace/test_routes.py
+++ b/tests/userspace/test_routes.py
@@ -1,6 +1,6 @@
 import io, zipfile
 import pytest
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 import httpx
 
 WEB_MANIFEST = "id: todo\nname: Todo\nversion: 1.0.0\napp_type: web\nentry: index.html\nicon: icon.png\npermissions: [app.net]\n"
@@ -63,7 +63,8 @@ async def test_install_malformed_json_returns_400(client):
 @pytest.mark.asyncio
 async def test_install_upstream_fetch_failure_returns_502(client):
     # Finding 2: httpx connectivity failure on source_url must return 502.
-    with patch("tinyagentos.routes.userspace_apps.is_safe_public_url", return_value=True):
+    with patch("tinyagentos.routes.userspace_apps.resolve_safe_public_ip",
+               return_value="93.184.216.34"):
         with patch("httpx.AsyncClient.get", new_callable=AsyncMock,
                    side_effect=httpx.ConnectError("refused")):
             r = await client.post(
@@ -72,6 +73,38 @@ async def test_install_upstream_fetch_failure_returns_502(client):
             )
     assert r.status_code == 502
     assert "upstream" in r.json()["error"].lower() or "fetch" in r.json()["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_install_pins_connection_to_resolved_ip(client):
+    # SSRF #971: the fetch must connect to the validated IP (closing the
+    # DNS-rebind TOCTOU window), keeping the original Host header + TLS SNI so
+    # the client never re-resolves the hostname to a different (internal) IP.
+    captured = {}
+
+    async def _fake_get(self, url, **kwargs):
+        captured["url"] = url
+        captured["headers"] = kwargs.get("headers")
+        captured["extensions"] = kwargs.get("extensions")
+        resp = Mock()
+        resp.raise_for_status = Mock(return_value=None)
+        resp.content = _zip()
+        return resp
+
+    with patch("tinyagentos.routes.userspace_apps.resolve_safe_public_ip",
+               return_value="93.184.216.34"):
+        with patch("httpx.AsyncClient.get", new=_fake_get):
+            r = await client.post(
+                "/api/userspace-apps/install",
+                json={"source_url": "http://example.com/app.taosapp"},
+            )
+    assert r.status_code == 200, r.text
+    # connected to the pinned IP, NOT the hostname
+    assert "93.184.216.34" in captured["url"]
+    assert "example.com" not in captured["url"]
+    # original host preserved for vhost routing + cert validation
+    assert captured["headers"]["Host"] == "example.com"
+    assert captured["extensions"]["sni_hostname"] == "example.com"
 
 
 def _container_zip():

--- a/tests/userspace/test_url_guard.py
+++ b/tests/userspace/test_url_guard.py
@@ -1,4 +1,7 @@
-from tinyagentos.userspace.url_guard import is_safe_public_url
+import socket
+from unittest.mock import patch
+
+from tinyagentos.userspace.url_guard import is_safe_public_url, resolve_safe_public_ip
 
 
 def test_blocks_link_local_metadata_endpoint():
@@ -24,3 +27,37 @@ def test_allows_public_ip():
 def test_rejects_garbage():
     assert is_safe_public_url("not a url") is False
     assert is_safe_public_url("http://") is False
+
+
+def _gai(ip):
+    # mimic socket.getaddrinfo: list of (family, type, proto, canonname, sockaddr)
+    return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (ip, 0))]
+
+
+def test_resolve_returns_pinned_ip_for_public_literal():
+    assert resolve_safe_public_ip("https://8.8.8.8/app.taosapp") == "8.8.8.8"
+
+
+def test_resolve_rejects_private_and_non_http():
+    assert resolve_safe_public_ip("http://169.254.169.254/latest") is None
+    assert resolve_safe_public_ip("http://127.0.0.1/x") is None
+    assert resolve_safe_public_ip("ftp://8.8.8.8/x") is None
+
+
+def test_resolve_returns_validated_ip_for_public_hostname():
+    with patch("socket.getaddrinfo", return_value=_gai("93.184.216.34")):
+        assert resolve_safe_public_ip("https://example.com/x") == "93.184.216.34"
+        assert is_safe_public_url("https://example.com/x") is True
+
+
+def test_resolve_rejects_hostname_resolving_to_private():
+    # the DNS-rebinding case: a hostname that resolves to an internal IP
+    with patch("socket.getaddrinfo", return_value=_gai("10.1.2.3")):
+        assert resolve_safe_public_ip("https://evil.example/x") is None
+        assert is_safe_public_url("https://evil.example/x") is False
+
+
+def test_resolve_rejects_mixed_public_and_private():
+    # if ANY resolved address is non-public, reject the whole host
+    with patch("socket.getaddrinfo", return_value=_gai("93.184.216.34") + _gai("10.0.0.1")):
+        assert resolve_safe_public_ip("https://example.com/x") is None

--- a/tinyagentos/routes/userspace_apps.py
+++ b/tinyagentos/routes/userspace_apps.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import shutil
 from pathlib import Path
+from urllib.parse import urlparse
 
 import httpx
 from fastapi import APIRouter, Request, UploadFile, File
@@ -9,7 +10,7 @@ from fastapi.responses import JSONResponse, FileResponse, Response
 
 from tinyagentos.userspace.broker import handle_capability, GATED_CAPS
 from tinyagentos.userspace.package import extract_package, PackageError
-from tinyagentos.userspace.url_guard import is_safe_public_url
+from tinyagentos.userspace.url_guard import resolve_safe_public_ip
 
 router = APIRouter()
 
@@ -86,17 +87,31 @@ async def install_app(request: Request, package: UploadFile | None = File(defaul
         url = body.get("source_url")
         if not url:
             return JSONResponse({"error": "source_url or package required"}, status_code=400)
-        # SSRF guard: only fetch public http(s) hosts, and do not follow
-        # redirects (a 3xx could bounce to a blocked internal address).
-        if not is_safe_public_url(url):
+        # SSRF guard: resolve + validate the host ONCE, then pin the connection
+        # to that validated IP. Re-resolving at fetch time would reopen a
+        # DNS-rebinding TOCTOU window. follow_redirects stays off so a 3xx
+        # cannot bounce to a blocked host.
+        pinned_ip = resolve_safe_public_ip(url)
+        if pinned_ip is None:
             return JSONResponse(
                 {"error": "source_url is not allowed -- only public http(s) hosts "
                           "(no private, loopback, link-local or reserved addresses)"},
                 status_code=400,
             )
+        _u = urlparse(url)
+        _ip_host = f"[{pinned_ip}]" if ":" in pinned_ip else pinned_ip
+        _netloc = _ip_host if not _u.port else f"{_ip_host}:{_u.port}"
+        _pinned_url = _u._replace(netloc=_netloc).geturl()
+        _host_header = _u.hostname if not _u.port else f"{_u.hostname}:{_u.port}"
         try:
             async with httpx.AsyncClient(timeout=120, follow_redirects=False) as c:
-                resp = await c.get(url)
+                # Connect to the pinned IP; keep the original Host header + TLS
+                # SNI so vhost routing and certificate validation still work.
+                resp = await c.get(
+                    _pinned_url,
+                    headers={"Host": _host_header},
+                    extensions={"sni_hostname": _u.hostname},
+                )
                 resp.raise_for_status()
                 data = resp.content
         except httpx.HTTPStatusError as exc:

--- a/tinyagentos/userspace/broker.py
+++ b/tinyagentos/userspace/broker.py
@@ -33,6 +33,18 @@ async def handle_capability(app_id, capability, args, *, granted, data_store, ap
 
     args = args or {}
 
+    # Validate required args up front so a missing key returns a clean error
+    # instead of an uncaught KeyError (a 500). Only caps that index args
+    # directly are listed; the rest use args.get with defaults.
+    _required = {
+        "app.kv.get": ("key",), "app.kv.set": ("key",), "app.kv.delete": ("key",),
+        "app.table.insert": ("table",), "app.table.query": ("table",),
+        "app.table.delete": ("table", "id"),
+    }
+    for _arg in _required.get(capability, ()):
+        if _arg not in args:
+            return {"error": "missing_arg", "arg": _arg}
+
     if capability == "app.kv.get":
         return {"result": await data_store.kv_get(app_id, args["key"])}
     if capability == "app.kv.set":

--- a/tinyagentos/userspace/url_guard.py
+++ b/tinyagentos/userspace/url_guard.py
@@ -16,32 +16,54 @@ from urllib.parse import urlparse
 _ALLOWED_SCHEMES = {"http", "https"}
 
 
-def is_safe_public_url(url: str) -> bool:
-    """True only if url is http(s) and every resolved IP is a public address.
+def _is_blocked_ip(ip) -> bool:
+    return bool(
+        ip.is_private or ip.is_loopback or ip.is_link_local
+        or ip.is_reserved or ip.is_unspecified or ip.is_multicast
+    )
+
+
+def resolve_safe_public_ip(url: str) -> str | None:
+    """Resolve url's host ONCE and return a validated public IP to connect to,
+    or None if the url is not http(s) or any resolved address is non-public.
 
     Rejects private, loopback, link-local, reserved, unspecified and multicast
     addresses (covers 127/8, ::1, 10/8, 172.16/12, 192.168/16, 169.254/16,
-    0.0.0.0, etc.).
+    0.0.0.0, etc.). The caller MUST connect to this pinned IP (keeping the
+    original Host header and TLS SNI) rather than letting the HTTP client
+    re-resolve the hostname -- re-resolution reopens a DNS-rebinding TOCTOU
+    window where the resolved-and-validated address differs from the one
+    actually connected to.
     """
     try:
         parsed = urlparse(url)
     except ValueError:
-        return False
+        return None
     if parsed.scheme not in _ALLOWED_SCHEMES or not parsed.hostname:
-        return False
+        return None
     try:
         infos = socket.getaddrinfo(parsed.hostname, parsed.port or None)
     except (socket.gaierror, UnicodeError, OSError):
-        return False
+        return None
     if not infos:
-        return False
+        return None
+    chosen: str | None = None
     for info in infos:
-        sockaddr = info[4]
         try:
-            ip = ip_address(sockaddr[0])
+            ip = ip_address(info[4][0])
         except ValueError:
-            return False
-        if (ip.is_private or ip.is_loopback or ip.is_link_local
-                or ip.is_reserved or ip.is_unspecified or ip.is_multicast):
-            return False
-    return True
+            return None
+        if _is_blocked_ip(ip):
+            return None
+        if chosen is None:
+            chosen = str(ip)
+    return chosen
+
+
+def is_safe_public_url(url: str) -> bool:
+    """True only if url is http(s) and every resolved IP is a public address.
+
+    Thin wrapper over resolve_safe_public_ip; prefer that function at the call
+    site so the connection can be pinned to the validated IP.
+    """
+    return resolve_safe_public_ip(url) is not None


### PR DESCRIPTION
## What

Closes the DNS-rebind SSRF (#971) on the install-from-URL path.

`POST /api/userspace-apps/install` validated `source_url` against private/
loopback/link-local ranges, then let httpx **re-resolve** the hostname when it
actually fetched. A host that resolved to a public address during the check
could resolve to an internal address at connect time (a classic DNS-rebind
TOCTOU), so the guard could be bypassed to hit cloud metadata, localhost, or
LAN services.

## How

- `url_guard.resolve_safe_public_ip(url)` resolves the host **once** and returns
  a validated public IP (rejects private, loopback, link-local, reserved,
  unspecified, multicast; rejects if **any** resolved address is non-public).
- The install fetch connects to that **pinned IP** and carries the original
  `Host` header + TLS `sni_hostname`, so vhost routing and certificate
  validation still work, but the client never re-resolves the name.
- `follow_redirects` stays off so a 3xx cannot bounce to a blocked host.
- `is_safe_public_url` is kept as a thin wrapper over the resolver.

Also centralises required-arg validation in the userspace broker: capabilities
that index `args` directly now return `{"error": "missing_arg", "arg": ...}`
instead of raising an uncaught `KeyError` (a 500).

## Tests

- `resolve_safe_public_ip`: public literal -> pinned IP; private/loopback/
  metadata/non-http -> None; public hostname -> validated IP; **hostname that
  resolves to a private IP -> None** (the rebind case); mixed public+private ->
  None.
- Route-level: the install fetch connects to the pinned IP (not the hostname)
  with the original Host + SNI preserved; connect failure still returns 502.
- Broker: missing required arg returns a clean `missing_arg` error.

77 userspace tests pass locally.
