### PR TITLE
fix(update): harden docs-only classification (skip docs-commit update banner)

### DIFF
--- a/tests/test_docs_only_update.py
+++ b/tests/test_docs_only_update.py
@@ -49,11 +49,15 @@ def repo(tmp_path):
 def test_is_documentation_path():
     assert is_documentation_path("docs/STATUS.md") is True
     assert is_documentation_path("README.md") is True
-    assert is_documentation_path("notes.txt") is True
     assert is_documentation_path("guide.rst") is True
+    assert is_documentation_path("docs/notes.txt") is True
     assert is_documentation_path("tinyagentos/foo.py") is False
     assert is_documentation_path("docs/scripts/foo.py") is False
     assert is_documentation_path("docs/config.yaml") is False
+    # A root-level .txt is ambiguous (e.g. requirements.txt / constraints.txt);
+    # fail safe to "not docs" so a real dependency change is never suppressed.
+    assert is_documentation_path("notes.txt") is False
+    assert is_documentation_path("requirements.txt") is False
 
 
 def test_changes_are_docs_only_true_for_docs_dir(repo):

--- a/tests/test_docs_only_update.py
+++ b/tests/test_docs_only_update.py
@@ -49,8 +49,11 @@ def repo(tmp_path):
 def test_is_documentation_path():
     assert is_documentation_path("docs/STATUS.md") is True
     assert is_documentation_path("README.md") is True
+    assert is_documentation_path("notes.txt") is True
+    assert is_documentation_path("guide.rst") is True
     assert is_documentation_path("tinyagentos/foo.py") is False
-    assert is_documentation_path("notes.txt") is False
+    assert is_documentation_path("docs/scripts/foo.py") is False
+    assert is_documentation_path("docs/config.yaml") is False
 
 
 def test_changes_are_docs_only_true_for_docs_dir(repo):

--- a/tinyagentos/auto_update.py
+++ b/tinyagentos/auto_update.py
@@ -200,12 +200,30 @@ async def resolve_tracked_branch(settings_store, project_dir: Path) -> str:
     return await update_tracking_branch(project_dir)
 
 
+_DOC_EXTENSIONS = (".md", ".markdown", ".rst", ".txt")
+_CODE_EXTENSIONS = (
+    ".py", ".ts", ".tsx", ".js", ".jsx", ".json",
+    ".yaml", ".yml", ".sh", ".toml", ".cfg", ".ini",
+)
+
+
 def is_documentation_path(path: str) -> bool:
-    """True when *path* is documentation-only (under docs/ or a .md file)."""
+    """True when *path* is documentation-only.
+
+    A path counts as documentation if it ends in a doc extension anywhere, or
+    lives under ``docs/`` without a code/config extension. When unsure, False.
+    """
     p = path.strip().replace("\\", "/")
     if not p:
         return False
-    return p.startswith("docs/") or p.endswith(".md")
+    lower = p.lower()
+    if any(lower.endswith(ext) for ext in _DOC_EXTENSIONS):
+        return True
+    if p.startswith("docs/"):
+        if any(lower.endswith(ext) for ext in _CODE_EXTENSIONS):
+            return False
+        return True
+    return False
 
 
 async def changes_are_docs_only(

--- a/tinyagentos/auto_update.py
+++ b/tinyagentos/auto_update.py
@@ -200,7 +200,11 @@ async def resolve_tracked_branch(settings_store, project_dir: Path) -> str:
     return await update_tracking_branch(project_dir)
 
 
-_DOC_EXTENSIONS = (".md", ".markdown", ".rst", ".txt")
+# .txt is deliberately excluded: a root-level .txt is ambiguous (e.g.
+# requirements.txt / constraints.txt), and misclassifying it as docs would
+# silently suppress a real dependency update. A .txt under docs/ is still
+# treated as docs via the docs/ branch below.
+_DOC_EXTENSIONS = (".md", ".markdown", ".rst")
 _CODE_EXTENSIONS = (
     ".py", ".ts", ".tsx", ".js", ".jsx", ".json",
     ".yaml", ".yml", ".sh", ".toml", ".cfg", ".ini",


### PR DESCRIPTION
## What

Hardens documentation-path classification for the docs-only update-suppression
feature (skips the "Update available" banner when incoming commits touch only
docs). Original logic classified anything under `docs/` (including scripts) as
docs, and only `.md` files elsewhere.

## Changes

- A `.py`/config file under `docs/` is no longer misclassified as docs-only
  (it would have suppressed a real code update). `docs/` paths are docs only
  when they do not carry a code/config extension.
- Doc extensions recognised anywhere: `.md`, `.markdown`, `.rst`.
- `.txt` is deliberately NOT a global doc extension: a root-level `.txt`
  (requirements.txt, constraints.txt) is ambiguous, and treating it as docs
  would silently suppress a real dependency update. A `.txt` under `docs/`
  still counts as docs.

## Tests

`test_is_documentation_path` covers `docs/STATUS.md`, `README.md`, `guide.rst`,
`docs/notes.txt` (docs) and `tinyagentos/foo.py`, `docs/scripts/foo.py`,
`docs/config.yaml`, `notes.txt`, `requirements.txt` (not docs). 7 pass.

Includes a reviewer commit on top of the original (gate correction).
