### PR TITLE
fix(update): exclude ambiguous root .txt from docs-only suppression

### DIFF
--- a/tests/test_docs_only_update.py
+++ b/tests/test_docs_only_update.py
@@ -49,11 +49,15 @@ def repo(tmp_path):
 def test_is_documentation_path():
     assert is_documentation_path("docs/STATUS.md") is True
     assert is_documentation_path("README.md") is True
-    assert is_documentation_path("notes.txt") is True
     assert is_documentation_path("guide.rst") is True
+    assert is_documentation_path("docs/notes.txt") is True
     assert is_documentation_path("tinyagentos/foo.py") is False
     assert is_documentation_path("docs/scripts/foo.py") is False
     assert is_documentation_path("docs/config.yaml") is False
+    # A root-level .txt is ambiguous (e.g. requirements.txt / constraints.txt);
+    # fail safe to "not docs" so a real dependency change is never suppressed.
+    assert is_documentation_path("notes.txt") is False
+    assert is_documentation_path("requirements.txt") is False
 
 
 def test_changes_are_docs_only_true_for_docs_dir(repo):

--- a/tinyagentos/auto_update.py
+++ b/tinyagentos/auto_update.py
@@ -200,7 +200,11 @@ async def resolve_tracked_branch(settings_store, project_dir: Path) -> str:
     return await update_tracking_branch(project_dir)
 
 
-_DOC_EXTENSIONS = (".md", ".markdown", ".rst", ".txt")
+# .txt is deliberately excluded: a root-level .txt is ambiguous (e.g.
+# requirements.txt / constraints.txt), and misclassifying it as docs would
+# silently suppress a real dependency update. A .txt under docs/ is still
+# treated as docs via the docs/ branch below.
+_DOC_EXTENSIONS = (".md", ".markdown", ".rst")
 _CODE_EXTENSIONS = (
     ".py", ".ts", ".tsx", ".js", ".jsx", ".json",
     ".yaml", ".yml", ".sh", ".toml", ".cfg", ".ini",


### PR DESCRIPTION
Follow-up to the docs-only update-suppression feature (#983).

A root-level `.txt` (e.g. `requirements.txt`, `constraints.txt`) is ambiguous; classifying it as documentation would silently suppress a real dependency update. This keeps `.md`/`.markdown`/`.rst` as global doc extensions and the valuable `docs/*.py` code exclusion, while a `.txt` under `docs/` still counts as docs via the docs/ branch.

Tests cover `docs/notes.txt` (docs) and `notes.txt`/`requirements.txt` (not docs). 7 pass locally.