### PR TITLE
feat(notifications): expose per-event mute prefs over HTTP

### DIFF
--- a/tests/test_notifications_prefs.py
+++ b/tests/test_notifications_prefs.py
@@ -42,6 +42,9 @@ async def test_put_unknown_event_type_returns_404(client):
 
 @pytest.mark.asyncio
 async def test_put_invalid_or_missing_body_returns_400(client):
+    r = await client.put("/api/notifications/prefs/worker.join")
+    assert r.status_code == 400
+
     r = await client.put(
         "/api/notifications/prefs/worker.join",
         content=b"{not valid json",

--- a/tests/test_notifications_prefs.py
+++ b/tests/test_notifications_prefs.py
@@ -1,0 +1,59 @@
+import pytest
+
+from tinyagentos.notifications import NotificationStore
+
+
+@pytest.mark.asyncio
+async def test_get_prefs_returns_all_event_types_default_unmuted(client):
+    r = await client.get("/api/notifications/prefs")
+    assert r.status_code == 200
+    prefs = r.json()
+    assert len(prefs) == len(NotificationStore.EVENT_TYPES)
+    for pref in prefs:
+        assert pref["event_type"] in NotificationStore.EVENT_TYPES
+        assert pref["muted"] is False
+
+
+@pytest.mark.asyncio
+async def test_put_valid_event_sets_muted_and_get_reflects(client):
+    event_type = "worker.join"
+    r = await client.put(
+        f"/api/notifications/prefs/{event_type}",
+        json={"muted": True},
+    )
+    assert r.status_code == 200
+    assert r.json() == {"event_type": event_type, "muted": True}
+
+    r = await client.get("/api/notifications/prefs")
+    assert r.status_code == 200
+    worker = next(p for p in r.json() if p["event_type"] == event_type)
+    assert worker["muted"] is True
+
+
+@pytest.mark.asyncio
+async def test_put_unknown_event_type_returns_404(client):
+    r = await client.put(
+        "/api/notifications/prefs/not.a.real.event",
+        json={"muted": True},
+    )
+    assert r.status_code == 404
+    assert r.json()["error"] == "unknown_event_type"
+
+
+@pytest.mark.asyncio
+async def test_put_invalid_or_missing_body_returns_400(client):
+    r = await client.put(
+        "/api/notifications/prefs/worker.join",
+        content=b"{not valid json",
+        headers={"Content-Type": "application/json"},
+    )
+    assert r.status_code == 400
+
+    r = await client.put("/api/notifications/prefs/worker.join", json={})
+    assert r.status_code == 400
+
+    r = await client.put(
+        "/api/notifications/prefs/worker.join",
+        json={"muted": "yes"},
+    )
+    assert r.status_code == 400

--- a/tests/test_notifications_prefs.py
+++ b/tests/test_notifications_prefs.py
@@ -9,14 +9,14 @@ async def test_get_prefs_returns_all_event_types_default_unmuted(client):
     assert r.status_code == 200
     prefs = r.json()
     assert len(prefs) == len(NotificationStore.EVENT_TYPES)
+    assert {p["event_type"] for p in prefs} == set(NotificationStore.EVENT_TYPES)
     for pref in prefs:
-        assert pref["event_type"] in NotificationStore.EVENT_TYPES
         assert pref["muted"] is False
 
 
 @pytest.mark.asyncio
 async def test_put_valid_event_sets_muted_and_get_reflects(client):
-    event_type = "worker.join"
+    event_type = next(iter(NotificationStore.EVENT_TYPES))
     r = await client.put(
         f"/api/notifications/prefs/{event_type}",
         json={"muted": True},

--- a/tinyagentos/routes/notifications.py
+++ b/tinyagentos/routes/notifications.py
@@ -61,3 +61,28 @@ async def mark_all_read(request: Request):
     store = request.app.state.notifications
     await store.mark_all_read()
     return {"ok": True}
+
+
+@router.get("/api/notifications/prefs")
+async def get_notification_prefs(request: Request):
+    store = request.app.state.notifications
+    return await store.get_event_prefs()
+
+
+@router.put("/api/notifications/prefs/{event_type}")
+async def set_notification_pref(request: Request, event_type: str):
+    store = request.app.state.notifications
+    if event_type not in store.EVENT_TYPES:
+        return JSONResponse({"error": "unknown_event_type"}, status_code=404)
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse({"error": "Invalid JSON body"}, status_code=400)
+    if not isinstance(body, dict) or "muted" not in body:
+        return JSONResponse({"error": "muted required"}, status_code=400)
+    muted_raw = body["muted"]
+    if not isinstance(muted_raw, bool):
+        return JSONResponse({"error": "muted must be a boolean"}, status_code=400)
+    muted = bool(muted_raw)
+    await store.set_event_muted(event_type, muted)
+    return {"event_type": event_type, "muted": muted}

--- a/tinyagentos/routes/notifications.py
+++ b/tinyagentos/routes/notifications.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import time
 
 from fastapi import APIRouter, Request
@@ -76,7 +77,7 @@ async def set_notification_pref(request: Request, event_type: str):
         return JSONResponse({"error": "unknown_event_type"}, status_code=404)
     try:
         body = await request.json()
-    except Exception:
+    except json.JSONDecodeError:
         return JSONResponse({"error": "Invalid JSON body"}, status_code=400)
     if not isinstance(body, dict) or "muted" not in body:
         return JSONResponse({"error": "muted required"}, status_code=400)


### PR DESCRIPTION
Adds `GET /api/notifications/prefs` and `PUT /api/notifications/prefs/{event_type}` so a Settings UI can read and toggle the existing per-event notification mute preferences. Backend + tests only; the store methods (`get_event_prefs` / `set_event_muted`) already existed.

Validation: unknown event_type -> 404; invalid/missing/non-bool body -> 400. Four tests cover the GET defaults, PUT+GET round-trip, unknown event, and bad bodies.

Part of the build-team wave-1 hardening/backend set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced notification preference management APIs enabling users to retrieve all notification preferences and update the muted status for individual event types with comprehensive validation and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->