### PR TITLE
chore: stop tracking desktop/node_modules (ignore it)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,9 @@ data/browser_cookie_key.hex
 # (a tracked copy dirties the tree and blocks the in-app git-pull update).
 desktop/tsconfig.tsbuildinfo
 
+# never track installed deps
+desktop/node_modules/
+
 # Local-only operational playbook (contains LAN IP + ops detail; agents read it from the working tree)
 docs/AGENT_HANDOFF.md
 docs/audit/

--- a/.gitignore
+++ b/.gitignore
@@ -94,7 +94,7 @@ data/browser_cookie_key.hex
 desktop/tsconfig.tsbuildinfo
 
 # never track installed deps
-desktop/node_modules/
+desktop/node_modules
 
 # Local-only operational playbook (contains LAN IP + ops detail; agents read it from the working tree)
 docs/AGENT_HANDOFF.md

--- a/desktop/node_modules
+++ b/desktop/node_modules
@@ -1,1 +1,0 @@
-/Volumes/NVMe/Users/jay/Development/tinyagentos/desktop/node_modules


### PR DESCRIPTION
desktop/node_modules was committed as a self-referential symlink (git mode 120000), which repeatedly dirtied the tree and broke rebases/pulls. Removes the tracked symlink from the index and adds `desktop/node_modules/` to .gitignore. No working-tree files deleted. Wave-1 build-team card.