### PR TITLE
feat(coding-studio): coding workspace backend (lifecycle + file API + git init)

### DIFF
--- a/tests/test_coding_workspaces.py
+++ b/tests/test_coding_workspaces.py
@@ -92,6 +92,40 @@ async def test_delete_removes_workspace(coding_client):
 
 
 @pytest.mark.asyncio
+async def test_list_root_files(coding_client):
+    client, _app = coding_client
+    r = await client.post("/api/coding/workspaces", json={"name": "root-list"})
+    ws = r.json()
+
+    r = await client.put(
+        f"/api/coding/workspaces/{ws['id']}/file",
+        json={"path": "readme.txt", "content": "hi"},
+    )
+    assert r.status_code == 200
+
+    r = await client.get(f"/api/coding/workspaces/{ws['id']}/files")
+    assert r.status_code == 200
+    names = {e["name"] for e in r.json()}
+    assert "readme.txt" in names
+
+
+@pytest.mark.asyncio
+async def test_read_binary_file_rejected(coding_client):
+    client, app = coding_client
+    r = await client.post("/api/coding/workspaces", json={"name": "binary"})
+    ws = r.json()
+    workspace_dir = app.state.data_dir / "coding-workspaces" / ws["id"]
+    (workspace_dir / "blob.bin").write_bytes(b"\xff\xfe\x00\x01")
+
+    r = await client.get(
+        f"/api/coding/workspaces/{ws['id']}/file",
+        params={"path": "blob.bin"},
+    )
+    assert r.status_code == 400
+    assert r.json()["error"] == "binary file"
+
+
+@pytest.mark.asyncio
 async def test_unknown_workspace_returns_404(coding_client):
     client, _app = coding_client
     wid = "cws-nosuch"

--- a/tests/test_coding_workspaces.py
+++ b/tests/test_coding_workspaces.py
@@ -1,0 +1,108 @@
+import pytest
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture
+async def coding_client(app, client):
+    store = app.state.coding_workspaces
+    if store._db is not None:
+        await store.close()
+    await store.init()
+    yield client, app
+
+
+@pytest.mark.asyncio
+async def test_create_list_git_repo(coding_client):
+    client, app = coding_client
+    r = await client.post("/api/coding/workspaces", json={"name": "demo"})
+    assert r.status_code == 200, r.text
+    ws = r.json()
+    assert ws["id"]
+    assert ws["name"] == "demo"
+    assert (app.state.data_dir / "coding-workspaces" / ws["id"]).is_dir()
+    assert (app.state.data_dir / "coding-workspaces" / ws["id"] / ".git").exists()
+
+    r = await client.get("/api/coding/workspaces")
+    assert r.status_code == 200
+    assert any(row["id"] == ws["id"] for row in r.json())
+
+
+@pytest.mark.asyncio
+async def test_write_read_and_tree(coding_client):
+    client, _app = coding_client
+    r = await client.post("/api/coding/workspaces", json={"name": "files"})
+    ws = r.json()
+
+    r = await client.put(
+        f"/api/coding/workspaces/{ws['id']}/file",
+        json={"path": "src/hello.txt", "content": "hello world"},
+    )
+    assert r.status_code == 200, r.text
+
+    r = await client.get(f"/api/coding/workspaces/{ws['id']}/file", params={"path": "src/hello.txt"})
+    assert r.status_code == 200
+    assert r.json()["content"] == "hello world"
+
+    r = await client.get(f"/api/coding/workspaces/{ws['id']}/files", params={"subpath": "src"})
+    assert r.status_code == 200
+    names = {e["name"]: e["is_dir"] for e in r.json()}
+    assert names["hello.txt"] is False
+
+
+@pytest.mark.asyncio
+async def test_path_traversal_rejected(coding_client):
+    client, _app = coding_client
+    r = await client.post("/api/coding/workspaces", json={"name": "jail"})
+    ws = r.json()
+    wid = ws["id"]
+
+    for params in (
+        {"path": "../secret"},
+        {"path": "/etc/passwd"},
+        {"subpath": ".."},
+        {"subpath": "/etc"},
+    ):
+        if "path" in params:
+            r = await client.get(f"/api/coding/workspaces/{wid}/file", params=params)
+        else:
+            r = await client.get(f"/api/coding/workspaces/{wid}/files", params=params)
+        assert r.status_code == 400, params
+
+    r = await client.put(
+        f"/api/coding/workspaces/{wid}/file",
+        json={"path": "../escape.txt", "content": "nope"},
+    )
+    assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_delete_removes_workspace(coding_client):
+    client, app = coding_client
+    r = await client.post("/api/coding/workspaces", json={"name": "temp"})
+    ws = r.json()
+    workspace_dir = app.state.data_dir / "coding-workspaces" / ws["id"]
+    assert workspace_dir.is_dir()
+
+    r = await client.delete(f"/api/coding/workspaces/{ws['id']}")
+    assert r.status_code == 200
+
+    r = await client.get("/api/coding/workspaces")
+    assert all(row["id"] != ws["id"] for row in r.json())
+    assert not workspace_dir.exists()
+
+
+@pytest.mark.asyncio
+async def test_unknown_workspace_returns_404(coding_client):
+    client, _app = coding_client
+    wid = "cws-nosuch"
+    r = await client.get(f"/api/coding/workspaces/{wid}/files")
+    assert r.status_code == 404
+    r = await client.get(f"/api/coding/workspaces/{wid}/file", params={"path": "a.txt"})
+    assert r.status_code == 404
+    r = await client.put(
+        f"/api/coding/workspaces/{wid}/file",
+        json={"path": "a.txt", "content": "x"},
+    )
+    assert r.status_code == 404
+    r = await client.delete(f"/api/coding/workspaces/{wid}")
+    assert r.status_code == 404

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -50,6 +50,7 @@ from tinyagentos.channels import ChannelStore
 from tinyagentos.download_manager import DownloadManager
 from tinyagentos.metrics import MetricsStore
 from tinyagentos.notifications import NotificationStore
+from tinyagentos.coding_workspaces import CodingWorkspaceStore
 from tinyagentos.qmd_client import QmdClient
 from tinyagentos.backend_adapters import check_backend_health
 from tinyagentos.benchmark import BenchmarkStore
@@ -344,6 +345,10 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     from tinyagentos.userspace.data_store import UserspaceDataStore
     userspace_apps = UserspaceAppStore(data_dir / "userspace_apps.db")
     userspace_data = UserspaceDataStore(data_dir / "userspace_data.db")
+    coding_workspaces_store = CodingWorkspaceStore(
+        data_dir / "coding_workspaces.db",
+        data_dir / "coding-workspaces",
+    )
     skills = SkillStore(data_dir / "skills.db")
     from tinyagentos.themes.store import ThemeStore
     themes = ThemeStore(data_dir / "themes.sqlite3")
@@ -424,6 +429,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         app.state.userspace_apps = userspace_apps
         await userspace_data.init()
         app.state.userspace_data = userspace_data
+        await coding_workspaces_store.init()
+        app.state.coding_workspaces = coding_workspaces_store
         try:
             from tinyagentos.userspace.seed import seed_bundled_apps
             await seed_bundled_apps(userspace_apps, data_dir / "apps")
@@ -672,6 +679,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         app.state.installed_apps = installed_apps
         app.state.userspace_apps = userspace_apps
         app.state.userspace_data = userspace_data
+        app.state.coding_workspaces = coding_workspaces_store
         app.state.skills = skills
         app.state.benchmark_store = benchmark_store
         app.state.score_cache = score_cache
@@ -1126,6 +1134,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await installed_apps.close()
         await userspace_apps.close()
         await userspace_data.close()
+        await coding_workspaces_store.close()
         await user_memory.close()
         await desktop_settings.close()
         await canvas_store.close()
@@ -1300,6 +1309,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     app.state.installed_apps = installed_apps
     app.state.userspace_apps = userspace_apps
     app.state.userspace_data = userspace_data
+    app.state.coding_workspaces = coding_workspaces_store
     app.state.skills = skills
     app.state.themes = themes
     app.state.knowledge_store = knowledge_store

--- a/tinyagentos/coding_workspaces.py
+++ b/tinyagentos/coding_workspaces.py
@@ -61,22 +61,25 @@ class CodingWorkspaceStore(BaseStore):
         if not workspace_dir.is_relative_to(root):
             raise RuntimeError("invalid workspace path")
         workspace_dir.mkdir(parents=True, exist_ok=False)
-        await self._git_init(workspace_dir)
-
-        now = int(time.time())
-        row = {
-            "id": wid,
-            "name": name,
-            "path": str(workspace_dir),
-            "created_at": now,
-        }
-        await self._db.execute(
-            """INSERT INTO coding_workspaces (id, name, path, created_at)
-               VALUES (?, ?, ?, ?)""",
-            (row["id"], row["name"], row["path"], row["created_at"]),
-        )
-        await self._db.commit()
-        return row
+        try:
+            await self._git_init(workspace_dir)
+            now = int(time.time())
+            row = {
+                "id": wid,
+                "name": name,
+                "path": str(workspace_dir),
+                "created_at": now,
+            }
+            await self._db.execute(
+                """INSERT INTO coding_workspaces (id, name, path, created_at)
+                   VALUES (?, ?, ?, ?)""",
+                (row["id"], row["name"], row["path"], row["created_at"]),
+            )
+            await self._db.commit()
+            return row
+        except Exception:
+            shutil.rmtree(workspace_dir, ignore_errors=True)
+            raise
 
     async def list(self) -> list[dict]:
         async with self._db.execute(
@@ -103,13 +106,15 @@ class CodingWorkspaceStore(BaseStore):
         if row is None:
             return False
 
+        workspace_dir = Path(row["path"]).resolve()
+        root = self.workspaces_root.resolve()
+        if workspace_dir.is_relative_to(root) and workspace_dir != root and workspace_dir.exists():
+            shutil.rmtree(workspace_dir)
+            if workspace_dir.exists():
+                raise RuntimeError("workspace directory still exists after removal")
+
         await self._db.execute(
             "DELETE FROM coding_workspaces WHERE id = ?", (workspace_id,)
         )
         await self._db.commit()
-
-        workspace_dir = Path(row["path"]).resolve()
-        root = self.workspaces_root.resolve()
-        if workspace_dir.is_relative_to(root) and workspace_dir != root and workspace_dir.exists():
-            shutil.rmtree(workspace_dir, ignore_errors=True)
         return True

--- a/tinyagentos/coding_workspaces.py
+++ b/tinyagentos/coding_workspaces.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import asyncio
+import secrets
+import shutil
+import time
+from pathlib import Path
+
+from tinyagentos.base_store import BaseStore
+
+_ALPHABET = "abcdefghijklmnopqrstuvwxyz234567"
+
+CODING_WORKSPACES_SCHEMA = """
+CREATE TABLE IF NOT EXISTS coding_workspaces (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    path TEXT NOT NULL,
+    created_at INTEGER NOT NULL
+);
+"""
+
+
+def _new_workspace_id() -> str:
+    suffix = "".join(secrets.choice(_ALPHABET) for _ in range(6))
+    return f"cws-{suffix}"
+
+
+class CodingWorkspaceStore(BaseStore):
+    SCHEMA = CODING_WORKSPACES_SCHEMA
+
+    def __init__(self, db_path: Path, workspaces_root: Path):
+        super().__init__(db_path)
+        self.workspaces_root = workspaces_root
+
+    async def _git_init(self, workspace_dir: Path) -> None:
+        proc = await asyncio.create_subprocess_exec(
+            "git",
+            "init",
+            cwd=str(workspace_dir),
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        await proc.wait()
+        if proc.returncode != 0:
+            raise RuntimeError("git init failed")
+
+    async def create(self, name: str) -> dict:
+        self.workspaces_root.mkdir(parents=True, exist_ok=True)
+        for _ in range(8):
+            wid = _new_workspace_id()
+            async with self._db.execute(
+                "SELECT 1 FROM coding_workspaces WHERE id = ?", (wid,)
+            ) as cur:
+                if await cur.fetchone() is None:
+                    break
+        else:
+            raise RuntimeError("could not allocate workspace id")
+
+        workspace_dir = (self.workspaces_root / wid).resolve()
+        root = self.workspaces_root.resolve()
+        if not workspace_dir.is_relative_to(root):
+            raise RuntimeError("invalid workspace path")
+        workspace_dir.mkdir(parents=True, exist_ok=False)
+        await self._git_init(workspace_dir)
+
+        now = int(time.time())
+        row = {
+            "id": wid,
+            "name": name,
+            "path": str(workspace_dir),
+            "created_at": now,
+        }
+        await self._db.execute(
+            """INSERT INTO coding_workspaces (id, name, path, created_at)
+               VALUES (?, ?, ?, ?)""",
+            (row["id"], row["name"], row["path"], row["created_at"]),
+        )
+        await self._db.commit()
+        return row
+
+    async def list(self) -> list[dict]:
+        async with self._db.execute(
+            "SELECT id, name, path, created_at FROM coding_workspaces ORDER BY created_at ASC"
+        ) as cur:
+            rows = await cur.fetchall()
+        return [
+            {"id": r[0], "name": r[1], "path": r[2], "created_at": r[3]}
+            for r in rows
+        ]
+
+    async def get(self, workspace_id: str) -> dict | None:
+        async with self._db.execute(
+            "SELECT id, name, path, created_at FROM coding_workspaces WHERE id = ?",
+            (workspace_id,),
+        ) as cur:
+            row = await cur.fetchone()
+        if row is None:
+            return None
+        return {"id": row[0], "name": row[1], "path": row[2], "created_at": row[3]}
+
+    async def delete(self, workspace_id: str) -> bool:
+        row = await self.get(workspace_id)
+        if row is None:
+            return False
+
+        await self._db.execute(
+            "DELETE FROM coding_workspaces WHERE id = ?", (workspace_id,)
+        )
+        await self._db.commit()
+
+        workspace_dir = Path(row["path"]).resolve()
+        root = self.workspaces_root.resolve()
+        if workspace_dir.is_relative_to(root) and workspace_dir != root and workspace_dir.exists():
+            shutil.rmtree(workspace_dir, ignore_errors=True)
+        return True

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -292,3 +292,6 @@ def register_all_routers(app):
 
     from tinyagentos.routes.userspace_apps import router as userspace_apps_router
     app.include_router(userspace_apps_router)
+
+    from tinyagentos.routes.coding import router as coding_router
+    app.include_router(coding_router)

--- a/tinyagentos/routes/coding.py
+++ b/tinyagentos/routes/coding.py
@@ -24,11 +24,16 @@ def _invalid_rel_path(rel: str) -> bool:
     return ".." in Path(rel).parts
 
 
-def _resolve_jailed(root: Path, rel: str) -> Path | None:
+_MAX_READ_BYTES = 1_000_000
+
+
+def _resolve_jailed(root: Path, rel: str, *, allow_root: bool = False) -> Path | None:
     if _invalid_rel_path(rel):
         return None
-    target = (root / rel).resolve()
-    if not target.is_relative_to(root) or target == root:
+    target = (root / rel).resolve() if rel else root.resolve()
+    if not target.is_relative_to(root):
+        return None
+    if target == root and not allow_root:
         return None
     return target
 
@@ -38,7 +43,11 @@ async def _workspace_root(request: Request, workspace_id: str) -> tuple[Path | N
     row = await store.get(workspace_id)
     if row is None:
         return None, JSONResponse({"error": "workspace not found"}, status_code=404)
-    return Path(row["path"]).resolve(), None
+    root = store.workspaces_root.resolve()
+    workspace = Path(row["path"]).resolve()
+    if not workspace.is_relative_to(root) or workspace == root:
+        return None, JSONResponse({"error": "workspace not found"}, status_code=404)
+    return workspace, None
 
 
 @router.post("/api/coding/workspaces")
@@ -62,7 +71,7 @@ async def list_files(request: Request, workspace_id: str, subpath: str = ""):
     root, err = await _workspace_root(request, workspace_id)
     if err is not None:
         return err
-    target = _resolve_jailed(root, subpath)
+    target = _resolve_jailed(root, subpath, allow_root=True)
     if target is None:
         return JSONResponse({"error": "invalid path"}, status_code=400)
     if not target.is_dir():
@@ -83,7 +92,13 @@ async def read_file(request: Request, workspace_id: str, path: str):
         return JSONResponse({"error": "invalid path"}, status_code=400)
     if not target.is_file():
         return JSONResponse({"error": "not found"}, status_code=404)
-    return {"path": path, "content": target.read_text()}
+    if target.stat().st_size > _MAX_READ_BYTES:
+        return JSONResponse({"error": "file too large"}, status_code=400)
+    try:
+        content = target.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return JSONResponse({"error": "binary file"}, status_code=400)
+    return {"path": path, "content": content}
 
 
 @router.put("/api/coding/workspaces/{workspace_id}/file")

--- a/tinyagentos/routes/coding.py
+++ b/tinyagentos/routes/coding.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+router = APIRouter()
+
+
+class CreateWorkspaceBody(BaseModel):
+    name: str
+
+
+class WriteFileBody(BaseModel):
+    path: str
+    content: str
+
+
+def _invalid_rel_path(rel: str) -> bool:
+    if rel.startswith("/") or "://" in rel or rel.startswith("//"):
+        return True
+    return ".." in Path(rel).parts
+
+
+def _resolve_jailed(root: Path, rel: str) -> Path | None:
+    if _invalid_rel_path(rel):
+        return None
+    target = (root / rel).resolve()
+    if not target.is_relative_to(root) or target == root:
+        return None
+    return target
+
+
+async def _workspace_root(request: Request, workspace_id: str) -> tuple[Path | None, JSONResponse | None]:
+    store = request.app.state.coding_workspaces
+    row = await store.get(workspace_id)
+    if row is None:
+        return None, JSONResponse({"error": "workspace not found"}, status_code=404)
+    return Path(row["path"]).resolve(), None
+
+
+@router.post("/api/coding/workspaces")
+async def create_workspace(request: Request, body: CreateWorkspaceBody):
+    name = (body.name or "").strip()
+    if not name:
+        return JSONResponse({"error": "name is required"}, status_code=400)
+    store = request.app.state.coding_workspaces
+    row = await store.create(name)
+    return row
+
+
+@router.get("/api/coding/workspaces")
+async def list_workspaces(request: Request):
+    store = request.app.state.coding_workspaces
+    return await store.list()
+
+
+@router.get("/api/coding/workspaces/{workspace_id}/files")
+async def list_files(request: Request, workspace_id: str, subpath: str = ""):
+    root, err = await _workspace_root(request, workspace_id)
+    if err is not None:
+        return err
+    target = _resolve_jailed(root, subpath)
+    if target is None:
+        return JSONResponse({"error": "invalid path"}, status_code=400)
+    if not target.is_dir():
+        return JSONResponse({"error": "not found"}, status_code=404)
+    entries = []
+    for child in sorted(target.iterdir(), key=lambda p: (not p.is_dir(), p.name.lower())):
+        entries.append({"name": child.name, "is_dir": child.is_dir()})
+    return entries
+
+
+@router.get("/api/coding/workspaces/{workspace_id}/file")
+async def read_file(request: Request, workspace_id: str, path: str):
+    root, err = await _workspace_root(request, workspace_id)
+    if err is not None:
+        return err
+    target = _resolve_jailed(root, path)
+    if target is None:
+        return JSONResponse({"error": "invalid path"}, status_code=400)
+    if not target.is_file():
+        return JSONResponse({"error": "not found"}, status_code=404)
+    return {"path": path, "content": target.read_text()}
+
+
+@router.put("/api/coding/workspaces/{workspace_id}/file")
+async def write_file(request: Request, workspace_id: str, body: WriteFileBody):
+    root, err = await _workspace_root(request, workspace_id)
+    if err is not None:
+        return err
+    rel = body.path or ""
+    target = _resolve_jailed(root, rel)
+    if target is None:
+        return JSONResponse({"error": "invalid path"}, status_code=400)
+    if target == root or target.is_dir():
+        return JSONResponse({"error": "invalid path"}, status_code=400)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(body.content)
+    return {"path": rel, "ok": True}
+
+
+@router.delete("/api/coding/workspaces/{workspace_id}")
+async def delete_workspace(request: Request, workspace_id: str):
+    store = request.app.state.coding_workspaces
+    removed = await store.delete(workspace_id)
+    if not removed:
+        return JSONResponse({"error": "workspace not found"}, status_code=404)
+    return {"ok": True}


### PR DESCRIPTION
Foundation for Coding Studio: a server-side coding workspace (git-initialized project dir) with a path-jailed file API.

- `CodingWorkspaceStore`: create (random id + dir + `git init`), list, get, delete (re-validates path under the workspaces root before rmtree).
- `routes/coding.py`: create/list/delete workspaces + jailed file tree/read/write. Path jail uses resolve() + is_relative_to(root), rejecting `..`, absolute, scheme, and symlink escapes.
- Wired into app.py (init/state/close) and the router registry. 108-line test covering create, git repo presence, read/write round-trip, traversal rejection, delete, and 404s.

First card of the Coding Studio epic; the git-review API, Plan/Pair/Execute modes, and editor/diff/terminal views build on this.