### PR TITLE
feat(app-studio): wire BuildView to the taos-agent build flow

### DIFF
--- a/desktop/src/apps/AppStudioApp.tsx
+++ b/desktop/src/apps/AppStudioApp.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { SHOW_BUILD_VIEW_EVENT } from "./appstudio/build-state";
 import { Sparkles, LayoutGrid, Share2, CircleDot } from "lucide-react";
 import { BuildView } from "./appstudio/BuildView";
 import { TemplatesView } from "./appstudio/TemplatesView";
@@ -29,6 +30,12 @@ const RAIL_BOTTOM: { id: AppStudioView; label: string; icon: typeof Sparkles }[]
 
 export function AppStudioApp({ windowId: _windowId }: { windowId: string }) {
   const [view, setView] = useState<AppStudioView>("build");
+
+  useEffect(() => {
+    const onShowBuild = () => setView("build");
+    window.addEventListener(SHOW_BUILD_VIEW_EVENT, onShowBuild);
+    return () => window.removeEventListener(SHOW_BUILD_VIEW_EVENT, onShowBuild);
+  }, []);
 
   function RailButton({ id, label, icon: Icon }: { id: AppStudioView; label: string; icon: typeof Sparkles }) {
     const on = view === id;

--- a/desktop/src/apps/appstudio/BuildView.tsx
+++ b/desktop/src/apps/appstudio/BuildView.tsx
@@ -1,4 +1,7 @@
+import { useCallback, useEffect, useRef, useState } from "react";
 import { CheckCircle2, Folder, Bell, Loader2, Sparkles } from "lucide-react";
+import { PROMPT_SEEDED_EVENT, takePendingPrompt } from "./build-state";
+import { streamTaosAgentChat } from "./stream-chat";
 
 /* ------------------------------------------------------------------ */
 /*  BuildView -- sandbox preview + build log + prompt bar              */
@@ -11,18 +14,84 @@ const CHORES = [
   { who: "M", task: "Water the plants", sub: "Mara · Wed", pts: 2, done: false },
 ];
 
-const STEPS = [
-  { label: "App shell + routing", sub: "taOS SDK window", done: true },
-  { label: "Chore list + points", sub: "data model + UI", done: true },
-  { label: "Family members", sub: "reading workspace contacts...", done: false },
-];
-
 const CAPS = [
   { icon: Folder, label: "Workspace files" },
   { icon: Bell, label: "Send notifications" },
 ];
 
+const DEFAULT_PROMPT = "give each person a weekly points total and a little leaderboard";
+
 export function BuildView() {
+  const [prompt, setPrompt] = useState(DEFAULT_PROMPT);
+  const [output, setOutput] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [streaming, setStreaming] = useState(false);
+  const [model, setModel] = useState<string | null>(null);
+  const logEndRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const seeded = takePendingPrompt();
+    if (seeded) setPrompt(seeded);
+
+    const onSeeded = (e: Event) => {
+      const detail = (e as CustomEvent<string>).detail;
+      if (detail) setPrompt(detail);
+    };
+    window.addEventListener(PROMPT_SEEDED_EVENT, onSeeded);
+    return () => window.removeEventListener(PROMPT_SEEDED_EVENT, onSeeded);
+  }, []);
+
+  useEffect(() => {
+    fetch("/api/taos-agent/settings")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (data?.model !== undefined) setModel(data.model);
+      })
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    logEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [output, error, streaming]);
+
+  const handleBuild = useCallback(async () => {
+    if (streaming) return;
+    const text = prompt.trim();
+    if (!text) return;
+
+    setOutput("");
+    setError(null);
+    setStreaming(true);
+
+    const buildPrompt =
+      `Help me build a taOS SDK app in App Studio. User request: ${text}`;
+
+    try {
+      await streamTaosAgentChat(
+        [{ role: "user", content: buildPrompt }],
+        (delta) => setOutput((prev) => prev + delta),
+        (message) => setError(message),
+      );
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setStreaming(false);
+    }
+  }, [prompt, streaming]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+        e.preventDefault();
+        void handleBuild();
+      }
+    },
+    [handleBuild],
+  );
+
+  const noModel = !model;
+  const showIdleLog = !streaming && !output && !error;
+
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       {/* view header */}
@@ -122,39 +191,40 @@ export function BuildView() {
         {/* build log panel */}
         <div className="flex w-[300px] flex-none flex-col border-l border-shell-border">
           <div className="flex items-center gap-2 px-[18px] pb-2 pt-4 text-[13px] font-bold">
-            <CheckCircle2 size={16} className="text-accent" />
+            {streaming ? (
+              <Loader2 size={16} className="animate-spin text-accent" />
+            ) : (
+              <CheckCircle2 size={16} className="text-accent" />
+            )}
             Build log
           </div>
 
-          <div className="flex flex-col gap-0.5 px-[14px] pb-2">
-            {STEPS.map((s) => (
+          <div className="min-h-0 flex-1 overflow-auto px-[14px] pb-2">
+            {showIdleLog && (
+              <p className="px-1 py-2 text-[12px] text-shell-text-tertiary">
+                Describe your app below and press Build to stream the agent&apos;s plan and output here.
+              </p>
+            )}
+            {error && (
               <div
-                key={s.label}
-                className="flex gap-[11px] rounded-[11px] p-[8px_10px]"
+                className="mb-2 rounded-[11px] border border-red-500/30 bg-red-500/10 px-3 py-2 text-[12px] text-red-300"
+                role="alert"
               >
-                <div className="mt-[1px] flex h-5 w-5 flex-none items-center justify-center rounded-full">
-                  {s.done ? (
-                    <span
-                      className="flex h-5 w-5 items-center justify-center rounded-full"
-                      style={{ background: "rgba(95,191,120,0.16)", color: "#5fbf78" }}
-                    >
-                      <CheckCircle2 size={12} />
-                    </span>
-                  ) : (
-                    <span
-                      className="flex h-5 w-5 items-center justify-center rounded-full"
-                      style={{ background: "rgba(205,171,130,0.16)" }}
-                    >
-                      <Loader2 size={12} className="animate-spin" style={{ color: "#cdab82" }} />
-                    </span>
-                  )}
-                </div>
-                <div>
-                  <div className="text-[12.5px] font-semibold">{s.label}</div>
-                  <div className="mt-0.5 text-[11px] text-shell-text-tertiary">{s.sub}</div>
-                </div>
+                {error}
               </div>
-            ))}
+            )}
+            {output && (
+              <pre className="whitespace-pre-wrap break-words rounded-[11px] bg-shell-surface p-[10px] text-[12px] leading-relaxed text-shell-text-secondary">
+                {output}
+              </pre>
+            )}
+            {streaming && !output && !error && (
+              <div className="flex items-center gap-2 px-1 py-2 text-[12px] text-shell-text-tertiary">
+                <Loader2 size={14} className="animate-spin" />
+                Building...
+              </div>
+            )}
+            <div ref={logEndRef} />
           </div>
 
           {/* capabilities */}
@@ -181,8 +251,12 @@ export function BuildView() {
                 style={{ background: "linear-gradient(135deg,#7c8ba1,#aab4c9)" }}
               />
               <div>
-                <div className="text-[12px] font-semibold">Qwen2.5-Coder 7B</div>
-                <div className="text-[10px] text-shell-text-tertiary">local &middot; fedora-gpu</div>
+                <div className="text-[12px] font-semibold">
+                  {model ?? "No model selected"}
+                </div>
+                <div className="text-[10px] text-shell-text-tertiary">
+                  {noModel ? "choose a model in taOS Assistant settings" : "taOS agent"}
+                </div>
               </div>
             </div>
           </div>
@@ -191,16 +265,24 @@ export function BuildView() {
 
       {/* prompt bar */}
       <div className="flex flex-none items-center gap-3 border-t border-shell-border bg-shell-bg-deep px-[22px] py-4">
-        <div className="flex min-h-[50px] flex-1 items-center rounded-[15px] border border-shell-border bg-shell-surface px-4 py-3 text-[13.5px] text-shell-text-secondary">
-          give each person a weekly points total and a little leaderboard
-        </div>
+        <textarea
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          onKeyDown={handleKeyDown}
+          rows={2}
+          disabled={streaming}
+          placeholder="Describe what your app should do..."
+          className="flex min-h-[50px] flex-1 resize-none items-center rounded-[15px] border border-shell-border bg-shell-surface px-4 py-3 text-[13.5px] text-shell-text-secondary placeholder:text-shell-text-tertiary focus-visible:border-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/20 disabled:opacity-60"
+        />
         <button
           type="button"
-          className="flex h-[50px] flex-none items-center gap-[9px] rounded-[15px] border-none px-6 text-[14px] font-bold text-white"
+          onClick={() => void handleBuild()}
+          disabled={streaming || !prompt.trim()}
+          className="flex h-[50px] flex-none items-center gap-[9px] rounded-[15px] border-none px-6 text-[14px] font-bold text-white disabled:cursor-not-allowed disabled:opacity-50"
           style={{ background: "linear-gradient(135deg,var(--color-accent),var(--color-accent))" }}
         >
-          <Sparkles size={18} />
-          Build
+          {streaming ? <Loader2 size={18} className="animate-spin" /> : <Sparkles size={18} />}
+          {streaming ? "Building..." : "Build"}
         </button>
       </div>
     </div>

--- a/desktop/src/apps/appstudio/BuildView.tsx
+++ b/desktop/src/apps/appstudio/BuildView.tsx
@@ -30,9 +30,14 @@ export function BuildView() {
   const logEndRef = useRef<HTMLDivElement>(null);
   const outputChunksRef = useRef<string[]>([]);
   const abortRef = useRef<AbortController | null>(null);
+  const mountedRef = useRef(true);
 
   useEffect(() => {
-    return () => abortRef.current?.abort();
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      abortRef.current?.abort();
+    };
   }, []);
 
   useEffect(() => {
@@ -83,19 +88,23 @@ export function BuildView() {
       await streamTaosAgentChat(
         [{ role: "user", content: buildPrompt }],
         (delta) => {
+          if (!mountedRef.current) return;
           outputChunksRef.current.push(delta);
           setOutput(outputChunksRef.current.join(""));
         },
-        (message) => setError(message),
+        (message) => {
+          if (!mountedRef.current) return;
+          setError(message);
+        },
         { signal: controller.signal },
       );
     } catch (e) {
-      if (!(e instanceof DOMException && e.name === "AbortError")) {
+      if (!(e instanceof DOMException && e.name === "AbortError") && mountedRef.current) {
         setError(String(e));
       }
     } finally {
       if (abortRef.current === controller) abortRef.current = null;
-      setStreaming(false);
+      if (mountedRef.current) setStreaming(false);
     }
   }, [prompt, streaming, model]);
 

--- a/desktop/src/apps/appstudio/BuildView.tsx
+++ b/desktop/src/apps/appstudio/BuildView.tsx
@@ -29,6 +29,11 @@ export function BuildView() {
   const [model, setModel] = useState<string | null>(null);
   const logEndRef = useRef<HTMLDivElement>(null);
   const outputChunksRef = useRef<string[]>([]);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    return () => abortRef.current?.abort();
+  }, []);
 
   useEffect(() => {
     const seeded = takePendingPrompt();
@@ -59,6 +64,10 @@ export function BuildView() {
 
   const handleBuild = useCallback(async () => {
     if (streaming || !model) return;
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
     const text = prompt.trim();
     if (!text) return;
 
@@ -78,10 +87,14 @@ export function BuildView() {
           setOutput(outputChunksRef.current.join(""));
         },
         (message) => setError(message),
+        { signal: controller.signal },
       );
     } catch (e) {
-      setError(String(e));
+      if (!(e instanceof DOMException && e.name === "AbortError")) {
+        setError(String(e));
+      }
     } finally {
+      if (abortRef.current === controller) abortRef.current = null;
       setStreaming(false);
     }
   }, [prompt, streaming, model]);

--- a/desktop/src/apps/appstudio/BuildView.tsx
+++ b/desktop/src/apps/appstudio/BuildView.tsx
@@ -28,6 +28,7 @@ export function BuildView() {
   const [streaming, setStreaming] = useState(false);
   const [model, setModel] = useState<string | null>(null);
   const logEndRef = useRef<HTMLDivElement>(null);
+  const outputChunksRef = useRef<string[]>([]);
 
   useEffect(() => {
     const seeded = takePendingPrompt();
@@ -51,14 +52,17 @@ export function BuildView() {
   }, []);
 
   useEffect(() => {
-    logEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [output, error, streaming]);
+    if (!streaming || error) {
+      logEndRef.current?.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [streaming, error]);
 
   const handleBuild = useCallback(async () => {
-    if (streaming) return;
+    if (streaming || !model) return;
     const text = prompt.trim();
     if (!text) return;
 
+    outputChunksRef.current = [];
     setOutput("");
     setError(null);
     setStreaming(true);
@@ -69,7 +73,10 @@ export function BuildView() {
     try {
       await streamTaosAgentChat(
         [{ role: "user", content: buildPrompt }],
-        (delta) => setOutput((prev) => prev + delta),
+        (delta) => {
+          outputChunksRef.current.push(delta);
+          setOutput(outputChunksRef.current.join(""));
+        },
         (message) => setError(message),
       );
     } catch (e) {
@@ -77,7 +84,7 @@ export function BuildView() {
     } finally {
       setStreaming(false);
     }
-  }, [prompt, streaming]);
+  }, [prompt, streaming, model]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -277,7 +284,7 @@ export function BuildView() {
         <button
           type="button"
           onClick={() => void handleBuild()}
-          disabled={streaming || !prompt.trim()}
+          disabled={streaming || !prompt.trim() || noModel}
           className="flex h-[50px] flex-none items-center gap-[9px] rounded-[15px] border-none px-6 text-[14px] font-bold text-white disabled:cursor-not-allowed disabled:opacity-50"
           style={{ background: "linear-gradient(135deg,var(--color-accent),var(--color-accent))" }}
         >

--- a/desktop/src/apps/appstudio/TemplatesView.tsx
+++ b/desktop/src/apps/appstudio/TemplatesView.tsx
@@ -1,4 +1,6 @@
+import { useState } from "react";
 import { Sparkles, CheckSquare, AlignLeft, Columns2, Gamepad2, MessageSquare, Image, Clock, LayoutDashboard } from "lucide-react";
+import { seedBuildPrompt } from "./build-state";
 
 /* ------------------------------------------------------------------ */
 /*  TemplatesView -- hero + template grid                              */
@@ -62,7 +64,15 @@ const TEMPLATES: TplCard[] = [
   },
 ];
 
+function templatePrompt(t: TplCard): string {
+  return `Build a ${t.label} taOS app. ${t.desc}`;
+}
+
 export function TemplatesView() {
+  const [heroPrompt, setHeroPrompt] = useState(
+    "a shared shopping list the whole house can add to from their phones...",
+  );
+
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       {/* view header */}
@@ -91,11 +101,15 @@ export function TemplatesView() {
             and you can publish it to your Store or share it with family.
           </p>
           <div className="mt-[15px] flex gap-[10px]">
-            <div className="flex-1 rounded-[13px] border border-shell-border bg-shell-surface px-[15px] py-3 text-[13px] text-shell-text-tertiary">
-              a shared shopping list the whole house can add to from their phones...
-            </div>
+            <textarea
+              value={heroPrompt}
+              onChange={(e) => setHeroPrompt(e.target.value)}
+              rows={2}
+              className="flex-1 resize-none rounded-[13px] border border-shell-border bg-shell-surface px-[15px] py-3 text-[13px] text-shell-text-secondary placeholder:text-shell-text-tertiary focus-visible:border-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/20"
+            />
             <button
               type="button"
+              onClick={() => seedBuildPrompt(heroPrompt)}
               className="flex items-center gap-[9px] rounded-[15px] px-[22px] text-[14px] font-bold text-white"
               style={{ background: "linear-gradient(135deg,var(--color-accent),var(--color-accent))" }}
             >
@@ -103,6 +117,9 @@ export function TemplatesView() {
               Build
             </button>
           </div>
+          <p className="mt-2 text-[11px] text-shell-text-tertiary">
+            Switches to the Build tab to use your prompt.
+          </p>
         </div>
 
         {/* section label */}
@@ -118,6 +135,7 @@ export function TemplatesView() {
               <button
                 key={t.label}
                 type="button"
+                onClick={() => seedBuildPrompt(templatePrompt(t))}
                 className="flex cursor-pointer flex-col gap-[9px] rounded-[15px] border border-shell-border bg-shell-surface p-[15px] text-left transition-all hover:-translate-y-[3px] hover:border-shell-border-strong"
               >
                 <div

--- a/desktop/src/apps/appstudio/build-state.ts
+++ b/desktop/src/apps/appstudio/build-state.ts
@@ -1,6 +1,7 @@
 /** Shared prompt seeding between TemplatesView and BuildView. */
 
 export const PROMPT_SEEDED_EVENT = "appstudio:prompt-seeded";
+export const SHOW_BUILD_VIEW_EVENT = "appstudio:show-build";
 
 let pendingPrompt: string | null = null;
 
@@ -9,6 +10,7 @@ export function seedBuildPrompt(text: string): void {
   if (!trimmed) return;
   pendingPrompt = trimmed;
   window.dispatchEvent(new CustomEvent(PROMPT_SEEDED_EVENT, { detail: trimmed }));
+  window.dispatchEvent(new CustomEvent(SHOW_BUILD_VIEW_EVENT));
 }
 
 export function takePendingPrompt(): string | null {

--- a/desktop/src/apps/appstudio/build-state.ts
+++ b/desktop/src/apps/appstudio/build-state.ts
@@ -1,0 +1,18 @@
+/** Shared prompt seeding between TemplatesView and BuildView. */
+
+export const PROMPT_SEEDED_EVENT = "appstudio:prompt-seeded";
+
+let pendingPrompt: string | null = null;
+
+export function seedBuildPrompt(text: string): void {
+  const trimmed = text.trim();
+  if (!trimmed) return;
+  pendingPrompt = trimmed;
+  window.dispatchEvent(new CustomEvent(PROMPT_SEEDED_EVENT, { detail: trimmed }));
+}
+
+export function takePendingPrompt(): string | null {
+  const prompt = pendingPrompt;
+  pendingPrompt = null;
+  return prompt;
+}

--- a/desktop/src/apps/appstudio/stream-chat.ts
+++ b/desktop/src/apps/appstudio/stream-chat.ts
@@ -1,0 +1,40 @@
+/** Stream NDJSON deltas from POST /api/taos-agent/chat (same pattern as TaosAssistantPanel). */
+
+export async function streamTaosAgentChat(
+  messages: { role: string; content: string }[],
+  onDelta: (delta: string) => void,
+  onError: (message: string) => void,
+): Promise<void> {
+  const resp = await fetch("/api/taos-agent/chat", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ messages }),
+  });
+
+  if (!resp.ok || !resp.body) {
+    onError(await resp.text().catch(() => "Unknown error"));
+    return;
+  }
+
+  const reader = resp.body.getReader();
+  const decoder = new TextDecoder();
+  let buf = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buf += decoder.decode(value, { stream: true });
+    const lines = buf.split("\n");
+    buf = lines.pop() ?? "";
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      try {
+        const obj = JSON.parse(line) as { error?: string; delta?: string };
+        if (obj.error) onError(String(obj.error));
+        else if (obj.delta) onDelta(obj.delta);
+      } catch {
+        // skip malformed NDJSON
+      }
+    }
+  }
+}

--- a/desktop/src/apps/appstudio/stream-chat.ts
+++ b/desktop/src/apps/appstudio/stream-chat.ts
@@ -20,12 +20,7 @@ export async function streamTaosAgentChat(
   const decoder = new TextDecoder();
   let buf = "";
 
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    buf += decoder.decode(value, { stream: true });
-    const lines = buf.split("\n");
-    buf = lines.pop() ?? "";
+  const flushLines = (lines: string[]) => {
     for (const line of lines) {
       if (!line.trim()) continue;
       try {
@@ -36,5 +31,17 @@ export async function streamTaosAgentChat(
         // skip malformed NDJSON
       }
     }
+  };
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buf += decoder.decode(value, { stream: true });
+    const lines = buf.split("\n");
+    buf = lines.pop() ?? "";
+    flushLines(lines);
   }
+
+  buf += decoder.decode();
+  if (buf.trim()) flushLines([buf]);
 }

--- a/desktop/src/apps/appstudio/stream-chat.ts
+++ b/desktop/src/apps/appstudio/stream-chat.ts
@@ -32,17 +32,21 @@ export async function streamTaosAgentChat(
   const decoder = new TextDecoder();
   let buf = "";
 
-  const flushLines = (lines: string[]) => {
+  const flushLines = (lines: string[]): boolean => {
     for (const line of lines) {
       if (!line.trim()) continue;
       try {
         const obj = JSON.parse(line) as { error?: string; delta?: string };
-        if (obj.error) onError(String(obj.error));
-        else if (obj.delta) onDelta(obj.delta);
+        if (obj.error) {
+          onError(String(obj.error));
+          return true;
+        }
+        if (obj.delta) onDelta(obj.delta);
       } catch {
         // skip malformed NDJSON
       }
     }
+    return false;
   };
 
   while (true) {
@@ -51,9 +55,9 @@ export async function streamTaosAgentChat(
     buf += decoder.decode(value, { stream: true });
     const lines = buf.split("\n");
     buf = lines.pop() ?? "";
-    flushLines(lines);
+    if (flushLines(lines)) return;
   }
 
   buf += decoder.decode();
-  if (buf.trim()) flushLines([buf]);
+  if (buf.trim() && flushLines([buf])) return;
 }

--- a/desktop/src/apps/appstudio/stream-chat.ts
+++ b/desktop/src/apps/appstudio/stream-chat.ts
@@ -55,7 +55,10 @@ export async function streamTaosAgentChat(
     buf += decoder.decode(value, { stream: true });
     const lines = buf.split("\n");
     buf = lines.pop() ?? "";
-    if (flushLines(lines)) return;
+    if (flushLines(lines)) {
+      reader.cancel();
+      return;
+    }
   }
 
   buf += decoder.decode();

--- a/desktop/src/apps/appstudio/stream-chat.ts
+++ b/desktop/src/apps/appstudio/stream-chat.ts
@@ -4,15 +4,27 @@ export async function streamTaosAgentChat(
   messages: { role: string; content: string }[],
   onDelta: (delta: string) => void,
   onError: (message: string) => void,
+  opts?: { signal?: AbortSignal },
 ): Promise<void> {
   const resp = await fetch("/api/taos-agent/chat", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ messages }),
+    signal: opts?.signal,
   });
 
   if (!resp.ok || !resp.body) {
-    onError(await resp.text().catch(() => "Unknown error"));
+    const raw = await resp.text().catch(() => "");
+    let message = raw.trim();
+    if (message.startsWith("{")) {
+      try {
+        const parsed = JSON.parse(message) as { error?: string };
+        if (parsed.error?.trim()) message = parsed.error.trim();
+      } catch {
+        // keep raw text fallback
+      }
+    }
+    onError(message || `Request failed (${resp.status})`);
     return;
   }
 


### PR DESCRIPTION
App Studio MVP: BuildView streams /api/taos-agent/chat into a build log; TemplatesView seeds prompts. Frontend wiring to the existing agent endpoint. Studio MVP card tsk-nmqmfq.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prompts are now editable in the build view as a text field.
  * Selecting a template automatically seeds the build prompt.
  * Build output now streams in real time with a dedicated streaming log view.
  * Add Ctrl/Meta+Enter to start a build.
* **Improvements**
  * Build is disabled while streaming, when the prompt is empty, or when no model is selected.
  * Clear error alerts and updated log behavior during streaming.
  * Switching back to the build view happens automatically when triggered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->