### PR TITLE
feat(game-studio): wire Create + Play to templates + games backend

### DIFF
--- a/desktop/src/apps/GameStudioApp.tsx
+++ b/desktop/src/apps/GameStudioApp.tsx
@@ -26,7 +26,7 @@ const RAIL: { id: StudioView; label: string; icon: typeof Sparkles }[] = [
   { id: "share", label: "Share", icon: Share2 },
 ];
 
-export function GameStudioApp({ windowId: _windowId }: { windowId: string }) {
+export function GameStudioApp({ windowId }: { windowId: string }) {
   const [view, setView] = useState<StudioView>("create");
 
   // Create-form state (illustrative in phase 1; the template drives Play).
@@ -100,6 +100,7 @@ export function GameStudioApp({ windowId: _windowId }: { windowId: string }) {
         <div className="flex min-w-0 flex-1 flex-col">
           {view === "create" && (
             <CreateView
+              windowId={windowId}
               prompt={prompt}
               onPromptChange={setPrompt}
               genres={genres}
@@ -110,7 +111,7 @@ export function GameStudioApp({ windowId: _windowId }: { windowId: string }) {
             />
           )}
 
-          {view === "play" && <PlayView key={active.id} template={active} />}
+          {view === "play" && <PlayView key={active.id} windowId={windowId} template={active} />}
 
           {view === "share" && <ShareView template={active} />}
         </div>

--- a/desktop/src/apps/gamestudio/CreateView.tsx
+++ b/desktop/src/apps/gamestudio/CreateView.tsx
@@ -22,6 +22,7 @@ import {
 /* ------------------------------------------------------------------ */
 
 export interface CreateViewProps {
+  windowId: string;
   prompt: string;
   onPromptChange: (v: string) => void;
   genres: Set<string>;
@@ -33,8 +34,16 @@ export interface CreateViewProps {
 }
 
 export function CreateView(props: CreateViewProps) {
-  const { prompt, onPromptChange, genres, onToggleGenre, model, onModelChange, onUseTemplate } =
-    props;
+  const {
+    windowId,
+    prompt,
+    onPromptChange,
+    genres,
+    onToggleGenre,
+    model,
+    onModelChange,
+    onUseTemplate,
+  } = props;
   const [creating, setCreating] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
   const [liveSteps, setLiveSteps] = useState<BuildStep[] | null>(null);
@@ -53,18 +62,18 @@ export function CreateView(props: CreateViewProps) {
 
     try {
       const { template, steps } = await runCreateGame(text, genres, setLiveSteps);
-      seedCreatedGame(template, text, steps);
+      seedCreatedGame(windowId, template, text, steps);
       onUseTemplate(template);
     } catch (e) {
       setCreateError(e instanceof Error ? e.message : String(e));
     } finally {
       setCreating(false);
     }
-  }, [creating, prompt, genres, onUseTemplate]);
+  }, [creating, prompt, genres, onUseTemplate, windowId]);
 
   const handleUseTemplate = useCallback(
     (t: Template) => {
-      seedCreatedGame(t, prompt, [
+      seedCreatedGame(windowId, t, prompt, [
         {
           who: "Director",
           what: `Loaded the ${t.title} starter template.`,
@@ -81,7 +90,7 @@ export function CreateView(props: CreateViewProps) {
       ]);
       onUseTemplate(t);
     },
-    [prompt, onUseTemplate],
+    [windowId, prompt, onUseTemplate],
   );
 
   return (

--- a/desktop/src/apps/gamestudio/CreateView.tsx
+++ b/desktop/src/apps/gamestudio/CreateView.tsx
@@ -1,21 +1,24 @@
-import { useState } from "react";
-import { Play, Sparkles, Info } from "lucide-react";
+import { useCallback, useState } from "react";
+import { Play, Sparkles, Info, Loader2 } from "lucide-react";
+import { runCreateGame } from "./create-game";
+import { seedCreatedGame } from "./game-state";
 import { TEMPLATES } from "./templates";
 import {
   GENRES,
   OFFLINE_MODELS,
   ART_STYLES,
   DIFFICULTIES,
+  type BuildStep,
   type Template,
 } from "./types";
 
 /* ------------------------------------------------------------------ */
-/*  CreateView — prompt box + genre/template chips + template gallery  */
+/*  CreateView -- prompt box + genre/template chips + template gallery */
 /*                                                                     */
-/*  Honesty: offline generation is a later phase. "Generate game" does */
-/*  not fake a build; it surfaces a clear "offline generation is        */
-/*  coming" note and points at the templates, which load real scenes.  */
-/*  The model selector is labelled but inert (note attached).           */
+/*  "Generate with AI" matches the prompt to a real starter template,  */
+/*  runs a short local build trace, and hands off to Play. Full offline */
+/*  model generation is still a later phase; templates always load a   */
+/*  live three.js scene. Chess prompts optionally consult games.py.    */
 /* ------------------------------------------------------------------ */
 
 export interface CreateViewProps {
@@ -32,7 +35,54 @@ export interface CreateViewProps {
 export function CreateView(props: CreateViewProps) {
   const { prompt, onPromptChange, genres, onToggleGenre, model, onModelChange, onUseTemplate } =
     props;
-  const [showComing, setShowComing] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [liveSteps, setLiveSteps] = useState<BuildStep[] | null>(null);
+
+  const handleGenerate = useCallback(async () => {
+    if (creating) return;
+    const text = prompt.trim();
+    if (!text) {
+      setCreateError("Describe your game idea first, or pick a template below.");
+      return;
+    }
+
+    setCreateError(null);
+    setCreating(true);
+    setLiveSteps(null);
+
+    try {
+      const { template, steps } = await runCreateGame(text, genres, setLiveSteps);
+      seedCreatedGame(template, text, steps);
+      onUseTemplate(template);
+    } catch (e) {
+      setCreateError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setCreating(false);
+    }
+  }, [creating, prompt, genres, onUseTemplate]);
+
+  const handleUseTemplate = useCallback(
+    (t: Template) => {
+      seedCreatedGame(t, prompt, [
+        {
+          who: "Director",
+          what: `Loaded the ${t.title} starter template.`,
+          tag: "routing",
+          state: "done",
+          director: true,
+        },
+        {
+          who: "Graphics",
+          what: `Mounted the ${t.scene} three.js scene in Play & Test.`,
+          tag: "graphics",
+          state: "done",
+        },
+      ]);
+      onUseTemplate(t);
+    },
+    [prompt, onUseTemplate],
+  );
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
@@ -125,28 +175,38 @@ export function CreateView(props: CreateViewProps) {
           <div className="mt-4 flex flex-wrap items-center gap-3">
             <button
               type="button"
-              onClick={() => setShowComing(true)}
-              className="flex h-[44px] items-center gap-2 rounded-full bg-gradient-to-br from-accent to-accent/70 px-5 text-[13px] font-bold text-white shadow-lg shadow-accent/20 transition-all hover:-translate-y-0.5 hover:brightness-105"
+              onClick={() => void handleGenerate()}
+              disabled={creating}
+              className="flex h-[44px] items-center gap-2 rounded-full bg-gradient-to-br from-accent to-accent/70 px-5 text-[13px] font-bold text-white shadow-lg shadow-accent/20 transition-all hover:-translate-y-0.5 hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-70"
             >
-              <Sparkles size={17} />
-              Generate with AI
+              {creating ? <Loader2 size={17} className="animate-spin" /> : <Sparkles size={17} />}
+              {creating ? "Building..." : "Generate with AI"}
             </button>
             <span className="text-[11px] text-shell-text-tertiary">
-              Offline generation arrives in a later phase. Start from a template below to play now.
+              Matches your prompt to a starter template and opens Play. Full offline model generation
+              arrives in a later phase.
             </span>
           </div>
 
-          {showComing && (
+          {createError && (
+            <div
+              role="alert"
+              className="mt-3 rounded-xl border border-red-500/30 bg-red-500/10 px-3.5 py-3 text-[12.5px] text-red-200"
+            >
+              {createError}
+            </div>
+          )}
+
+          {liveSteps && liveSteps.length > 0 && (
             <div
               role="status"
               className="mt-3 flex items-start gap-2.5 rounded-xl border border-accent/30 bg-accent-soft px-3.5 py-3"
             >
               <Info size={16} className="mt-0.5 flex-none text-accent" />
-              <div className="text-[12.5px] leading-relaxed text-shell-text-secondary">
-                <span className="font-semibold text-shell-text">Offline generation is coming.</span>{" "}
-                In a later phase a local model turns this prompt into a playable build on your taOS.
-                For now, pick a template below: it loads a real, interactive 3D scene into Play &amp;
-                Test.
+              <div className="min-w-0 flex-1 text-[12.5px] leading-relaxed text-shell-text-secondary">
+                <span className="font-semibold text-shell-text">Building your preview.</span>{" "}
+                {liveSteps.find((s) => s.state === "run")?.what ??
+                  liveSteps[liveSteps.length - 1]?.what}
               </div>
             </div>
           )}
@@ -160,7 +220,7 @@ export function CreateView(props: CreateViewProps) {
           </p>
           <div className="grid grid-cols-[repeat(auto-fill,minmax(220px,1fr))] gap-3.5">
             {TEMPLATES.map((t) => (
-              <TemplateCard key={t.id} template={t} onUse={() => onUseTemplate(t)} />
+              <TemplateCard key={t.id} template={t} onUse={() => handleUseTemplate(t)} />
             ))}
           </div>
         </section>

--- a/desktop/src/apps/gamestudio/PlayView.tsx
+++ b/desktop/src/apps/gamestudio/PlayView.tsx
@@ -39,10 +39,11 @@ const DEVICE_SIZES: Record<DevicePreview, { maxW: number | null; aspect: string 
 };
 
 export interface PlayViewProps {
+  windowId: string;
   template: Template;
 }
 
-export function PlayView({ template }: PlayViewProps) {
+export function PlayView({ windowId, template }: PlayViewProps) {
   const scene = useGameScene(template.scene);
   const { hostRef, playing, togglePlay, setPlaying, fps, reset, supported } = scene;
 
@@ -54,14 +55,19 @@ export function PlayView({ template }: PlayViewProps) {
 
   useEffect(() => {
     const applySnapshot = () => {
-      const { steps, prompt } = takeCreatedGame();
+      const { steps, prompt } = takeCreatedGame(windowId);
       if (steps?.length) setBuildLog(steps);
       if (prompt) setSourcePrompt(prompt);
     };
+    const onCreated = (e: Event) => {
+      const detail = (e as CustomEvent<{ windowId?: string }>).detail;
+      if (detail?.windowId !== windowId) return;
+      applySnapshot();
+    };
     applySnapshot();
-    window.addEventListener(GAME_CREATED_EVENT, applySnapshot);
-    return () => window.removeEventListener(GAME_CREATED_EVENT, applySnapshot);
-  }, [template.id]);
+    window.addEventListener(GAME_CREATED_EVENT, onCreated);
+    return () => window.removeEventListener(GAME_CREATED_EVENT, onCreated);
+  }, [template.id, windowId]);
 
   // Track native fullscreen state. The Exit pill + Esc both call exitFs.
   useEffect(() => {

--- a/desktop/src/apps/gamestudio/PlayView.tsx
+++ b/desktop/src/apps/gamestudio/PlayView.tsx
@@ -13,9 +13,10 @@ import {
   Check,
   Clock,
 } from "lucide-react";
+import { GAME_CREATED_EVENT, takeCreatedGame } from "./game-state";
 import { useGameScene } from "./useGameScene";
 import { BUILD_LOG } from "./templates";
-import type { DevicePreview, Template } from "./types";
+import type { BuildStep, DevicePreview, Template } from "./types";
 
 /* ------------------------------------------------------------------ */
 /*  PlayView — the real three.js preview stage                         */
@@ -48,6 +49,19 @@ export function PlayView({ template }: PlayViewProps) {
   const stageRef = useRef<HTMLDivElement | null>(null);
   const [device, setDevice] = useState<DevicePreview>("desktop");
   const [isFs, setIsFs] = useState(false);
+  const [buildLog, setBuildLog] = useState<BuildStep[]>(BUILD_LOG);
+  const [sourcePrompt, setSourcePrompt] = useState<string | null>(null);
+
+  useEffect(() => {
+    const applySnapshot = () => {
+      const { steps, prompt } = takeCreatedGame();
+      if (steps?.length) setBuildLog(steps);
+      if (prompt) setSourcePrompt(prompt);
+    };
+    applySnapshot();
+    window.addEventListener(GAME_CREATED_EVENT, applySnapshot);
+    return () => window.removeEventListener(GAME_CREATED_EVENT, applySnapshot);
+  }, [template.id]);
 
   // Track native fullscreen state. The Exit pill + Esc both call exitFs.
   useEffect(() => {
@@ -95,6 +109,11 @@ export function PlayView({ template }: PlayViewProps) {
             {template.genre} · live preview · auto-saved
           </span>
         </div>
+        {sourcePrompt && (
+          <p className="max-w-3xl text-[12px] leading-relaxed text-shell-text-secondary">
+            <span className="font-semibold text-shell-text">From your prompt:</span> {sourcePrompt}
+          </p>
+        )}
 
         <div className="grid grid-cols-1 gap-4 lg:grid-cols-[1fr_312px]">
           {/* ---- stage + transport ---- */}
@@ -275,10 +294,12 @@ export function PlayView({ template }: PlayViewProps) {
             <div className="flex items-center gap-2 border-b border-shell-border px-3.5 py-3">
               <ListTree size={15} className="text-accent" />
               <h3 className="text-[13px] font-bold">Build log</h3>
-              <span className="ml-auto text-[11px] text-shell-text-tertiary">preview</span>
+              <span className="ml-auto text-[11px] text-shell-text-tertiary">
+                {sourcePrompt ? "live" : "preview"}
+              </span>
             </div>
             <div className="max-h-[470px] overflow-auto p-1.5">
-              {BUILD_LOG.map((step, i) => (
+              {buildLog.map((step, i) => (
                 <div
                   key={i}
                   className={`grid grid-cols-[26px_1fr] gap-2 rounded-xl px-2.5 py-2 hover:bg-shell-surface ${
@@ -314,8 +335,9 @@ export function PlayView({ template }: PlayViewProps) {
                 </div>
               ))}
               <p className="px-2.5 pb-1 pt-2 text-[11px] leading-relaxed text-shell-text-tertiary">
-                An illustrative trace of the agent build pipeline. Live build steps arrive with
-                offline generation in a later phase.
+                {sourcePrompt
+                  ? "Steps from your latest create run. Full offline model generation arrives in a later phase."
+                  : "An illustrative trace of the agent build pipeline. Generate from Create or pick a template to load a live scene."}
               </p>
             </div>
           </aside>

--- a/desktop/src/apps/gamestudio/create-game.ts
+++ b/desktop/src/apps/gamestudio/create-game.ts
@@ -1,0 +1,129 @@
+import { matchTemplate, isChessPrompt } from "./match-template";
+import type { BuildStep, Template } from "./types";
+
+export interface CreateGameResult {
+  template: Template;
+  steps: BuildStep[];
+}
+
+type StepUpdater = (steps: BuildStep[]) => void;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function setStepState(steps: BuildStep[], index: number, state: BuildStep["state"]): BuildStep[] {
+  return steps.map((s, i) => (i === index ? { ...s, state } : s));
+}
+
+async function tryChessAgentNote(
+  prompt: string,
+  onUpdate: StepUpdater,
+  steps: BuildStep[],
+): Promise<BuildStep[]> {
+  if (!isChessPrompt(prompt)) return steps;
+
+  let agents: string[] = [];
+  try {
+    const res = await fetch("/api/agents");
+    if (res.ok) {
+      const data = (await res.json()) as { name?: string }[];
+      agents = Array.isArray(data)
+        ? data.map((a) => a?.name).filter((n): n is string => !!n)
+        : [];
+    }
+  } catch {
+    return steps;
+  }
+  if (agents.length === 0) return steps;
+
+  const agent = agents[0]!;
+  try {
+    const res = await fetch("/api/games/chess/move", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        agent_name: agent,
+        fen: "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+        legal_moves: ["e2e4", "d2d4", "g1f3", "b1c3"],
+        history: [],
+      }),
+    });
+    const data = (await res.json()) as { commentary?: string; move?: string };
+    const note = data.commentary?.trim();
+    if (!note) return steps;
+
+    const next = steps.map((s) =>
+      s.tag === "routing" && s.director
+        ? {
+            ...s,
+            what: `${s.what} Chess agent "${agent}" suggested opening ${data.move ?? "e2e4"}: ${note.slice(0, 120)}`,
+          }
+        : s,
+    );
+    onUpdate(next);
+    return next;
+  } catch {
+    return steps;
+  }
+}
+
+/** Run the local create pipeline: match a template, animate build steps, optional games.py chess consult. */
+export async function runCreateGame(
+  prompt: string,
+  genres: Set<string>,
+  onUpdate: StepUpdater,
+): Promise<CreateGameResult> {
+  const template = matchTemplate(prompt, genres);
+
+  let steps: BuildStep[] = [
+    {
+      who: "Director",
+      what: `Matched "${prompt.trim().slice(0, 80) || "your idea"}" to the ${template.title} template.`,
+      tag: "routing",
+      state: "run",
+      director: true,
+    },
+    {
+      who: "Gameplay",
+      what: `Wiring the ${template.genre.toLowerCase()} loop and controls for the preview stage.`,
+      tag: "gameplay",
+      state: "queue",
+    },
+    {
+      who: "Graphics",
+      what: `Loading the ${template.scene} three.js scene into Play & Test.`,
+      tag: "graphics",
+      state: "queue",
+    },
+    {
+      who: "QA",
+      what: "Checking WebGL, fullscreen exit, and WASD input on the preview stage.",
+      tag: "qa",
+      state: "queue",
+    },
+  ];
+  onUpdate(steps);
+
+  steps = await tryChessAgentNote(prompt, onUpdate, steps);
+  await delay(400);
+  steps = setStepState(steps, 0, "done");
+  steps = setStepState(steps, 1, "run");
+  onUpdate(steps);
+
+  await delay(500);
+  steps = setStepState(steps, 1, "done");
+  steps = setStepState(steps, 2, "run");
+  onUpdate(steps);
+
+  await delay(500);
+  steps = setStepState(steps, 2, "done");
+  steps = setStepState(steps, 3, "run");
+  onUpdate(steps);
+
+  await delay(350);
+  steps = setStepState(steps, 3, "done");
+  onUpdate(steps);
+
+  return { template, steps };
+}

--- a/desktop/src/apps/gamestudio/game-state.ts
+++ b/desktop/src/apps/gamestudio/game-state.ts
@@ -1,0 +1,42 @@
+/** Shared create -> play state between CreateView and PlayView. */
+
+import type { BuildStep, Template } from "./types";
+
+export const GAME_CREATED_EVENT = "gamestudio:game-created";
+
+let pendingPrompt: string | null = null;
+let pendingSteps: BuildStep[] | null = null;
+let pendingTemplate: Template | null = null;
+
+export function seedCreatedGame(
+  template: Template,
+  prompt: string,
+  steps: BuildStep[],
+): void {
+  pendingTemplate = template;
+  pendingPrompt = prompt.trim() || null;
+  pendingSteps = steps;
+  window.dispatchEvent(
+    new CustomEvent(GAME_CREATED_EVENT, { detail: { template, prompt, steps } }),
+  );
+}
+
+export function takeCreatedGame(): {
+  template: Template | null;
+  prompt: string | null;
+  steps: BuildStep[] | null;
+} {
+  const snapshot = {
+    template: pendingTemplate,
+    prompt: pendingPrompt,
+    steps: pendingSteps,
+  };
+  pendingTemplate = null;
+  pendingPrompt = null;
+  pendingSteps = null;
+  return snapshot;
+}
+
+export function peekCreatedSteps(): BuildStep[] | null {
+  return pendingSteps;
+}

--- a/desktop/src/apps/gamestudio/game-state.ts
+++ b/desktop/src/apps/gamestudio/game-state.ts
@@ -1,42 +1,48 @@
-/** Shared create -> play state between CreateView and PlayView. */
+/** Per-window create -> play state between CreateView and PlayView. */
 
 import type { BuildStep, Template } from "./types";
 
 export const GAME_CREATED_EVENT = "gamestudio:game-created";
 
-let pendingPrompt: string | null = null;
-let pendingSteps: BuildStep[] | null = null;
-let pendingTemplate: Template | null = null;
+type PendingGame = {
+  template: Template;
+  prompt: string | null;
+  steps: BuildStep[];
+};
+
+const pendingByWindow = new Map<string, PendingGame>();
 
 export function seedCreatedGame(
+  windowId: string,
   template: Template,
   prompt: string,
   steps: BuildStep[],
 ): void {
-  pendingTemplate = template;
-  pendingPrompt = prompt.trim() || null;
-  pendingSteps = steps;
+  pendingByWindow.set(windowId, {
+    template,
+    prompt: prompt.trim() || null,
+    steps,
+  });
   window.dispatchEvent(
-    new CustomEvent(GAME_CREATED_EVENT, { detail: { template, prompt, steps } }),
+    new CustomEvent(GAME_CREATED_EVENT, {
+      detail: { windowId, template, prompt, steps },
+    }),
   );
 }
 
-export function takeCreatedGame(): {
+export function takeCreatedGame(windowId: string): {
   template: Template | null;
   prompt: string | null;
   steps: BuildStep[] | null;
 } {
-  const snapshot = {
-    template: pendingTemplate,
-    prompt: pendingPrompt,
-    steps: pendingSteps,
+  const pending = pendingByWindow.get(windowId);
+  if (!pending) {
+    return { template: null, prompt: null, steps: null };
+  }
+  pendingByWindow.delete(windowId);
+  return {
+    template: pending.template,
+    prompt: pending.prompt,
+    steps: pending.steps,
   };
-  pendingTemplate = null;
-  pendingPrompt = null;
-  pendingSteps = null;
-  return snapshot;
-}
-
-export function peekCreatedSteps(): BuildStep[] | null {
-  return pendingSteps;
 }

--- a/desktop/src/apps/gamestudio/match-template.ts
+++ b/desktop/src/apps/gamestudio/match-template.ts
@@ -1,0 +1,75 @@
+import { TEMPLATES } from "./templates";
+import type { Template } from "./types";
+
+const RUNNER_HINTS = [
+  "runner",
+  "run",
+  "endless",
+  "platform",
+  "jump",
+  "racing",
+  "race",
+  "drift",
+  "fps",
+  "shooter",
+  "corridor",
+];
+
+const ORBIT_HINTS = [
+  "orbit",
+  "tower",
+  "defense",
+  "defence",
+  "puzzle",
+  "top-down",
+  "top down",
+  "arena",
+  "vr",
+  "xr",
+  "headset",
+];
+
+function scoreTemplate(template: Template, text: string): number {
+  let score = 0;
+  const genre = template.genre.toLowerCase();
+  const title = template.title.toLowerCase();
+
+  if (text.includes(genre)) score += 4;
+  if (text.includes(title)) score += 3;
+  for (const idPart of template.id.split("-")) {
+    if (idPart.length > 3 && text.includes(idPart)) score += 2;
+  }
+  for (const word of template.desc.toLowerCase().split(/\W+/)) {
+    if (word.length > 4 && text.includes(word)) score += 1;
+  }
+
+  if (RUNNER_HINTS.some((h) => text.includes(h)) && template.scene === "runner") {
+    score += 3;
+  }
+  if (ORBIT_HINTS.some((h) => text.includes(h)) && template.scene === "orbit") {
+    score += 3;
+  }
+
+  return score;
+}
+
+/** Pick the closest starter template for a prompt + genre chips. */
+export function matchTemplate(prompt: string, genres: Iterable<string>): Template {
+  const text = `${prompt} ${[...genres].join(" ")}`.toLowerCase().trim();
+  if (!text) return TEMPLATES[0]!;
+
+  let best = TEMPLATES[0]!;
+  let bestScore = -1;
+  for (const template of TEMPLATES) {
+    const score = scoreTemplate(template, text);
+    if (score > bestScore) {
+      bestScore = score;
+      best = template;
+    }
+  }
+  return best;
+}
+
+export function isChessPrompt(prompt: string): boolean {
+  return /\bchess\b/i.test(prompt);
+}


### PR DESCRIPTION
Game Studio MVP: Create matches prompts to templates and streams build steps to Play (three.js scene); chess prompts consult games.py. Frontend wiring. Studio MVP card tsk-endilr.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Real-time generation progress tracking with live build status during game creation
* Automatic template matching based on game prompts and selected genres
* Enhanced error handling with inline error alerts for failed generations
* AI-powered enhancements for chess-themed game creation with agent-suggested content
* Dynamic build log reflecting actual creation events and progress steps in real time

<!-- end of auto-generated comment: release notes by coderabbit.ai -->