### PR TITLE
feat(design-studio): wire Magic view to image generation

### DIFF
--- a/desktop/src/apps/DesignStudioApp.test.tsx
+++ b/desktop/src/apps/DesignStudioApp.test.tsx
@@ -57,13 +57,13 @@ describe("DesignStudioApp", () => {
     }
   });
 
-  it("switches to Magic view and shows prompt bar and result tiles", () => {
+  it("switches to Magic view and shows prompt bar and style chips", () => {
     renderApp();
     fireEvent.click(screen.getByRole("button", { name: "Magic" }));
     expect(screen.getByRole("button", { name: "Magic" }).getAttribute("aria-current")).toBe("page");
     expect(screen.getByText("Describe the design you need.")).toBeDefined();
-    expect(screen.getByText("Bold, centered")).toBeDefined();
-    expect(screen.getByText("Split layout")).toBeDefined();
+    expect(screen.getByRole("button", { name: "Generate" })).toBeDefined();
+    expect(screen.getByPlaceholderText(/launch poster/i)).toBeDefined();
     expect(screen.getAllByText("Editorial").length).toBeGreaterThan(0);
   });
 });

--- a/desktop/src/apps/DesignStudioApp.tsx
+++ b/desktop/src/apps/DesignStudioApp.tsx
@@ -1,10 +1,15 @@
-import { useState } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { PenLine, LayoutGrid, Plus, Sparkles, Circle } from "lucide-react";
+import { ModelBrowser } from "@/components/ModelBrowser";
 import { DesignView } from "./designstudio/DesignView";
 import { TemplatesView } from "./designstudio/TemplatesView";
 import { MagicView } from "./designstudio/MagicView";
-
-type DesignStudioView = "design" | "templates" | "elements" | "magic";
+import {
+  type CanvasElement,
+  type DesignStudioView,
+  type GeneratedImage,
+} from "./designstudio/types";
+import type { ImageModel } from "./images/types";
 
 const RAIL: { id: DesignStudioView; label: string; icon: typeof PenLine }[] = [
   { id: "design", label: "Design", icon: PenLine },
@@ -13,18 +18,158 @@ const RAIL: { id: DesignStudioView; label: string; icon: typeof PenLine }[] = [
   { id: "magic", label: "Magic", icon: Sparkles },
 ];
 
+function randomSeed(): number {
+  return Math.floor(Math.random() * 1_000_000);
+}
+
 export function DesignStudioApp({ windowId: _windowId }: { windowId: string }) {
   const [view, setView] = useState<DesignStudioView>("design");
+  const [canvasElements, setCanvasElements] = useState<CanvasElement[]>([]);
+
+  const [magicPrompt, setMagicPrompt] = useState("");
+  const [magicStyle, setMagicStyle] = useState<string | null>(null);
+  const [magicResults, setMagicResults] = useState<GeneratedImage[]>([]);
+  const [generating, setGenerating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [models, setModels] = useState<ImageModel[]>([]);
+  const [selectedModelId, setSelectedModelId] = useState("");
+  const [selectedVariantId, setSelectedVariantId] = useState("");
+  const [browserOpen, setBrowserOpen] = useState(false);
+
+  const refreshModels = useCallback(async () => {
+    try {
+      const res = await fetch("/api/models", {
+        headers: { Accept: "application/json" },
+      });
+      if (!res.ok) return [] as ImageModel[];
+      const data = await res.json();
+      if (!data || !Array.isArray(data.models)) return [] as ImageModel[];
+      const imageModels: ImageModel[] = data.models.filter(
+        (m: ImageModel) =>
+          Array.isArray(m.capabilities) &&
+          m.capabilities.includes("image-generation"),
+      );
+      setModels(imageModels);
+      return imageModels;
+    } catch {
+      return [] as ImageModel[];
+    }
+  }, []);
+
+  useEffect(() => {
+    (async () => {
+      const imageModels = await refreshModels();
+      for (const m of imageModels) {
+        const dl = m.variants?.find((v) => v.downloaded);
+        if (dl) {
+          setSelectedModelId(m.id);
+          setSelectedVariantId(dl.id);
+          return;
+        }
+      }
+    })();
+  }, [refreshModels]);
+
+  const selectedModel = useMemo(
+    () => models.find((m) => m.id === selectedModelId),
+    [models, selectedModelId],
+  );
+  const selectedVariant = useMemo(
+    () => selectedModel?.variants.find((v) => v.id === selectedVariantId),
+    [selectedModel, selectedVariantId],
+  );
+
+  const needsModel = !selectedVariant?.downloaded;
+  const canGenerate =
+    !!magicPrompt.trim() && !generating && !!selectedVariant?.downloaded;
+
+  const placeOnCanvas = useCallback((img: GeneratedImage) => {
+    const offset = canvasElements.length * 12;
+    const element: CanvasElement = {
+      id: img.id,
+      type: "image",
+      url: img.url,
+      prompt: img.prompt,
+      x: 24 + offset,
+      y: 280 + offset,
+      width: 312,
+      height: 140,
+    };
+    setCanvasElements((prev) => [...prev, element]);
+    setView("design");
+  }, [canvasElements.length]);
+
+  const runGenerate = useCallback(async () => {
+    const usePrompt = magicPrompt.trim();
+    if (!usePrompt) return;
+    if (!selectedVariant?.downloaded) {
+      setError("Install an image generation model first.");
+      return;
+    }
+
+    setGenerating(true);
+    setError(null);
+
+    const styledPrompt = magicStyle
+      ? `${usePrompt}, ${magicStyle.toLowerCase()} style`
+      : usePrompt;
+
+    try {
+      const res = await fetch("/api/images/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          prompt: styledPrompt,
+          model: selectedModelId,
+          size: "512x512",
+          steps: 4,
+          seed: randomSeed(),
+          guidance_scale: 7.5,
+        }),
+      });
+
+      if (res.ok) {
+        const ct = res.headers.get("content-type") ?? "";
+        if (ct.includes("application/json")) {
+          const data = await res.json();
+          if (data.filename || data.id) {
+            const id = (data.filename as string) ?? (data.id as string);
+            const url = (data.path as string) ?? `/data/workspace/images/generated/${id}`;
+            const img: GeneratedImage = { id, url, prompt: styledPrompt };
+            setMagicResults((prev) => [img, ...prev]);
+            placeOnCanvas(img);
+          } else if (data.error) {
+            setError(String(data.error));
+          }
+        }
+      } else {
+        const data = await res.json().catch(() => ({}));
+        setError(
+          (data as { error?: string }).error ??
+            `Generation failed (${res.status})`,
+        );
+      }
+    } catch (e) {
+      setError(`Generation error: ${(e as Error).message}`);
+    }
+
+    setGenerating(false);
+  }, [
+    magicPrompt,
+    magicStyle,
+    selectedVariant,
+    selectedModelId,
+    placeOnCanvas,
+  ]);
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden bg-shell-bg text-shell-text select-none">
-      {/* title strip */}
       <div className="flex h-[46px] flex-none items-center justify-center border-b border-shell-border">
         <span className="text-[13px] font-semibold tracking-[-0.01em]">Design Studio</span>
       </div>
 
       <div className="flex min-h-0 flex-1">
-        {/* left rail */}
         <nav
           aria-label="Design Studio views"
           className="flex w-[68px] flex-none flex-col items-center gap-1.5 border-r border-shell-border bg-shell-bg-deep py-3.5"
@@ -61,14 +206,40 @@ export function DesignStudioApp({ windowId: _windowId }: { windowId: string }) {
           </button>
         </nav>
 
-        {/* active surface */}
         <div className="flex min-w-0 flex-1 flex-col">
-          {view === "design" && <DesignView />}
+          {view === "design" && <DesignView canvasElements={canvasElements} />}
           {view === "templates" && <TemplatesView />}
-          {view === "elements" && <DesignView />}
-          {view === "magic" && <MagicView />}
+          {view === "elements" && <DesignView canvasElements={canvasElements} />}
+          {view === "magic" && (
+            <MagicView
+              prompt={magicPrompt}
+              onPromptChange={setMagicPrompt}
+              style={magicStyle}
+              onStyleChange={setMagicStyle}
+              results={magicResults}
+              generating={generating}
+              canGenerate={canGenerate}
+              error={error}
+              needsModel={needsModel}
+              onGenerate={() => void runGenerate()}
+              onPickModel={() => setBrowserOpen(true)}
+              onUseResult={placeOnCanvas}
+            />
+          )}
         </div>
       </div>
+
+      <ModelBrowser
+        open={browserOpen}
+        onClose={() => setBrowserOpen(false)}
+        capability="image-generation"
+        onModelDownloaded={async (modelId, variantId) => {
+          await refreshModels();
+          setSelectedModelId(modelId);
+          setSelectedVariantId(variantId);
+          setError(null);
+        }}
+      />
     </div>
   );
 }

--- a/desktop/src/apps/DesignStudioApp.tsx
+++ b/desktop/src/apps/DesignStudioApp.tsx
@@ -131,16 +131,24 @@ export function DesignStudioApp({ windowId: _windowId }: { windowId: string }) {
 
       if (res.ok) {
         const ct = res.headers.get("content-type") ?? "";
-        if (ct.includes("application/json")) {
-          const data = await res.json();
-          if (data.filename || data.id) {
-            const id = (data.filename as string) ?? (data.id as string);
-            const url = (data.path as string) ?? `/data/workspace/images/generated/${id}`;
-            const img: GeneratedImage = { id, url, prompt: styledPrompt };
-            setMagicResults((prev) => [img, ...prev]);
-            placeOnCanvas(img);
-          } else if (data.error) {
-            setError(String(data.error));
+        if (!ct.includes("application/json")) {
+          setError("Generation returned an unexpected response format.");
+        } else {
+          try {
+            const data = await res.json();
+            if (data.filename || data.id) {
+              const id = (data.filename as string) ?? (data.id as string);
+              const url = (data.path as string) ?? `/data/workspace/images/generated/${id}`;
+              const img: GeneratedImage = { id, url, prompt: styledPrompt };
+              setMagicResults((prev) => [img, ...prev]);
+              placeOnCanvas(img);
+            } else if (data.error) {
+              setError(String(data.error));
+            } else {
+              setError("Generation succeeded but returned no image data.");
+            }
+          } catch {
+            setError("Generation returned invalid JSON.");
           }
         }
       } else {

--- a/desktop/src/apps/DesignStudioApp.tsx
+++ b/desktop/src/apps/DesignStudioApp.tsx
@@ -31,6 +31,7 @@ export function DesignStudioApp({ windowId: _windowId }: { windowId: string }) {
   const [magicResults, setMagicResults] = useState<GeneratedImage[]>([]);
   const [generating, setGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [errorNeedsModel, setErrorNeedsModel] = useState(false);
 
   const [models, setModels] = useState<ImageModel[]>([]);
   const [selectedModelId, setSelectedModelId] = useState("");
@@ -110,6 +111,7 @@ export function DesignStudioApp({ windowId: _windowId }: { windowId: string }) {
 
     setGenerating(true);
     setError(null);
+    setErrorNeedsModel(false);
 
     const styledPrompt = magicStyle
       ? `${usePrompt}, ${magicStyle.toLowerCase()} style`
@@ -122,6 +124,7 @@ export function DesignStudioApp({ windowId: _windowId }: { windowId: string }) {
         body: JSON.stringify({
           prompt: styledPrompt,
           model: selectedModelId,
+          variant: selectedVariantId,
           size: "512x512",
           steps: 4,
           seed: randomSeed(),
@@ -153,6 +156,7 @@ export function DesignStudioApp({ windowId: _windowId }: { windowId: string }) {
         }
       } else {
         const data = await res.json().catch(() => ({}));
+        setErrorNeedsModel(res.status === 502 || res.status === 503);
         setError(
           (data as { error?: string }).error ??
             `Generation failed (${res.status})`,
@@ -168,6 +172,7 @@ export function DesignStudioApp({ windowId: _windowId }: { windowId: string }) {
     magicStyle,
     selectedVariant,
     selectedModelId,
+    selectedVariantId,
     placeOnCanvas,
   ]);
 
@@ -228,6 +233,7 @@ export function DesignStudioApp({ windowId: _windowId }: { windowId: string }) {
               generating={generating}
               canGenerate={canGenerate}
               error={error}
+              errorNeedsModel={errorNeedsModel}
               needsModel={needsModel}
               onGenerate={() => void runGenerate()}
               onPickModel={() => setBrowserOpen(true)}
@@ -246,6 +252,7 @@ export function DesignStudioApp({ windowId: _windowId }: { windowId: string }) {
           setSelectedModelId(modelId);
           setSelectedVariantId(variantId);
           setError(null);
+          setErrorNeedsModel(false);
         }}
       />
     </div>

--- a/desktop/src/apps/DesignStudioApp.tsx
+++ b/desktop/src/apps/DesignStudioApp.tsx
@@ -86,20 +86,22 @@ export function DesignStudioApp({ windowId: _windowId }: { windowId: string }) {
     !!magicPrompt.trim() && !generating && !!selectedVariant?.downloaded;
 
   const placeOnCanvas = useCallback((img: GeneratedImage) => {
-    const offset = canvasElements.length * 12;
-    const element: CanvasElement = {
-      id: img.id,
-      type: "image",
-      url: img.url,
-      prompt: img.prompt,
-      x: 24 + offset,
-      y: 280 + offset,
-      width: 312,
-      height: 140,
-    };
-    setCanvasElements((prev) => [...prev, element]);
+    setCanvasElements((prev) => {
+      const offset = prev.length * 12;
+      const element: CanvasElement = {
+        id: `${img.id}-${prev.length}-${Date.now()}`,
+        type: "image",
+        url: img.url,
+        prompt: img.prompt,
+        x: 24 + offset,
+        y: 280 + offset,
+        width: 312,
+        height: 140,
+      };
+      return [...prev, element];
+    });
     setView("design");
-  }, [canvasElements.length]);
+  }, []);
 
   const runGenerate = useCallback(async () => {
     const usePrompt = magicPrompt.trim();

--- a/desktop/src/apps/designstudio/DesignView.tsx
+++ b/desktop/src/apps/designstudio/DesignView.tsx
@@ -1,4 +1,5 @@
 import { Type, Square, Circle, Image, Plus, Star, Sparkles, AlignLeft, Italic, Underline, Undo, Download } from "lucide-react";
+import type { CanvasElement } from "./types";
 
 const ELEMENT_TILES: { label: string; icon: typeof Type }[] = [
   { label: "Text", icon: Type },
@@ -28,7 +29,11 @@ const COLOR_SWATCHES = [
 
 const MAGIC_CHIPS = ["Make it bolder", "Match brand", "Rewrite copy"];
 
-export function DesignView() {
+export interface DesignViewProps {
+  canvasElements?: CanvasElement[];
+}
+
+export function DesignView({ canvasElements = [] }: DesignViewProps) {
   return (
     <>
       {/* view header */}
@@ -165,6 +170,24 @@ export function DesignView() {
               >
                 Get started
               </div>
+
+              {canvasElements.map((el) =>
+                el.type === "image" ? (
+                  <img
+                    key={el.id}
+                    src={el.url}
+                    alt={el.prompt}
+                    className="absolute object-cover"
+                    style={{
+                      left: el.x,
+                      top: el.y,
+                      width: el.width,
+                      height: el.height,
+                      borderRadius: "6px",
+                    }}
+                  />
+                ) : null,
+              )}
 
               {/* selection box */}
               <div

--- a/desktop/src/apps/designstudio/MagicView.tsx
+++ b/desktop/src/apps/designstudio/MagicView.tsx
@@ -10,6 +10,7 @@ export interface MagicViewProps {
   generating: boolean;
   canGenerate: boolean;
   error: string | null;
+  errorNeedsModel: boolean;
   needsModel: boolean;
   onGenerate: () => void;
   onPickModel: () => void;
@@ -25,6 +26,7 @@ export function MagicView({
   generating,
   canGenerate,
   error,
+  errorNeedsModel,
   needsModel,
   onGenerate,
   onPickModel,
@@ -91,7 +93,7 @@ export function MagicView({
         {error && (
           <div className="mb-4 w-full max-w-[640px] rounded-[12px] border border-red-500/30 bg-red-500/10 px-4 py-3 text-[13px] text-red-200">
             {error}
-            {(error.includes("backend") || error.includes("model") || error.includes("503")) && (
+            {errorNeedsModel && (
               <button
                 type="button"
                 onClick={onPickModel}

--- a/desktop/src/apps/designstudio/MagicView.tsx
+++ b/desktop/src/apps/designstudio/MagicView.tsx
@@ -56,6 +56,7 @@ export function MagicView({
 
         <div className="mb-[26px] flex w-full max-w-[640px] gap-2.5">
           <textarea
+            aria-label="Design prompt"
             value={prompt}
             onChange={(e) => onPromptChange(e.target.value)}
             placeholder="a launch poster for taOS Studios, bold, dark, confident..."

--- a/desktop/src/apps/designstudio/MagicView.tsx
+++ b/desktop/src/apps/designstudio/MagicView.tsx
@@ -1,97 +1,157 @@
-import { Sparkles } from "lucide-react";
+import { Loader2, Sparkles } from "lucide-react";
+import { MAGIC_STYLE_CHIPS, type GeneratedImage } from "./types";
 
-const STYLE_CHIPS = ["Bold", "Minimal", "Editorial", "Playful", "Dark", "Corporate"];
+export interface MagicViewProps {
+  prompt: string;
+  onPromptChange: (v: string) => void;
+  style: string | null;
+  onStyleChange: (v: string | null) => void;
+  results: GeneratedImage[];
+  generating: boolean;
+  canGenerate: boolean;
+  error: string | null;
+  needsModel: boolean;
+  onGenerate: () => void;
+  onPickModel: () => void;
+  onUseResult: (img: GeneratedImage) => void;
+}
 
-const RESULTS: { label: string; gradient: string }[] = [
-  {
-    label: "Bold, centered",
-    gradient:
-      "radial-gradient(130% 120% at 20% 12%, #5a6b86, transparent 55%), linear-gradient(150deg, #2c3142, #171a24)",
-  },
-  {
-    label: "Split layout",
-    gradient:
-      "radial-gradient(130% 120% at 80% 18%, #3d8f7a, transparent 55%), linear-gradient(150deg, #16302a, #0e1c18)",
-  },
-  {
-    label: "Editorial",
-    gradient:
-      "radial-gradient(130% 120% at 30% 80%, #c98b5b, transparent 55%), linear-gradient(150deg, #2a2018, #15100b)",
-  },
-];
-
-export function MagicView() {
+export function MagicView({
+  prompt,
+  onPromptChange,
+  style,
+  onStyleChange,
+  results,
+  generating,
+  canGenerate,
+  error,
+  needsModel,
+  onGenerate,
+  onPickModel,
+  onUseResult,
+}: MagicViewProps) {
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      {/* view header */}
       <div
         className="flex flex-none items-center gap-3 border-b border-shell-border px-[22px]"
         style={{ height: "54px" }}
       >
         <h2 className="text-[17px] font-bold tracking-[-0.02em]">Magic design</h2>
-        <span className="text-[12px] text-shell-text-tertiary">Describe it, get a full layout</span>
+        <span className="text-[12px] text-shell-text-tertiary">
+          Describe it, generate an image for the canvas
+        </span>
       </div>
 
-      {/* scrollable body */}
       <div className="flex flex-1 flex-col items-center overflow-auto px-[26px] pb-[26px] pt-[26px]">
-        {/* hero */}
         <div className="mb-6 w-full max-w-[640px] text-center">
           <h3 className="text-[24px] font-extrabold tracking-[-0.02em]">
             Describe the design you need.
           </h3>
           <p className="mt-2 text-[13.5px] leading-[1.5] text-shell-text-secondary">
-            An agent on your cluster lays it out with your brand kit, fonts, and colors. Pick one and keep editing on the canvas.
+            Generate an image on your cluster, then place it on the canvas and keep editing.
           </p>
         </div>
 
-        {/* prompt bar */}
         <div className="mb-[26px] flex w-full max-w-[640px] gap-2.5">
-          <div className="flex-1 rounded-[14px] border border-shell-border-strong bg-shell-surface px-4 py-3.5 text-[13.5px] text-shell-text-tertiary">
-            a launch poster for taOS Studios, bold, dark, confident...
-          </div>
+          <textarea
+            value={prompt}
+            onChange={(e) => onPromptChange(e.target.value)}
+            placeholder="a launch poster for taOS Studios, bold, dark, confident..."
+            rows={2}
+            className="flex-1 resize-none rounded-[14px] border border-shell-border-strong bg-shell-surface px-4 py-3.5 text-[13.5px] text-shell-text outline-none placeholder:text-shell-text-tertiary focus-visible:ring-2 focus-visible:ring-accent/40"
+          />
           <button
             type="button"
-            className="flex items-center gap-2 rounded-[14px] px-[22px] py-3.5 text-[14px] font-bold text-white"
+            disabled={!canGenerate}
+            onClick={onGenerate}
+            className="flex items-center gap-2 rounded-[14px] px-[22px] py-3.5 text-[14px] font-bold text-white transition-opacity disabled:cursor-not-allowed disabled:opacity-50"
             style={{
               background: "linear-gradient(135deg,#a9b0c2,#8b92a3)",
               border: "none",
             }}
           >
-            <Sparkles size={17} />
-            Generate
+            {generating ? <Loader2 size={17} className="animate-spin" /> : <Sparkles size={17} />}
+            {generating ? "Generating..." : "Generate"}
           </button>
         </div>
 
-        {/* style chips */}
-        <div className="mb-6 flex w-full max-w-[640px] flex-wrap gap-2">
-          {STYLE_CHIPS.map((chip) => (
+        {needsModel && (
+          <div className="mb-4 w-full max-w-[640px] rounded-[12px] border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-[13px] text-amber-100">
+            <p>Install an image generation model to use Magic.</p>
             <button
-              key={chip}
               type="button"
-              className="rounded-full border border-shell-border bg-shell-surface px-[14px] py-[7px] text-[12px] font-semibold text-shell-text-secondary transition-colors hover:border-shell-border-strong hover:text-shell-text"
+              onClick={onPickModel}
+              className="mt-2 rounded-[9px] border border-shell-border bg-shell-surface px-3 py-1.5 text-[12px] font-semibold text-shell-text-secondary hover:text-shell-text"
             >
-              {chip}
+              Browse models
             </button>
-          ))}
+          </div>
+        )}
+
+        {error && (
+          <div className="mb-4 w-full max-w-[640px] rounded-[12px] border border-red-500/30 bg-red-500/10 px-4 py-3 text-[13px] text-red-200">
+            {error}
+            {(error.includes("backend") || error.includes("model") || error.includes("503")) && (
+              <button
+                type="button"
+                onClick={onPickModel}
+                className="mt-2 block rounded-[9px] border border-shell-border bg-shell-surface px-3 py-1.5 text-[12px] font-semibold text-shell-text-secondary hover:text-shell-text"
+              >
+                Install a model
+              </button>
+            )}
+          </div>
+        )}
+
+        <div className="mb-6 flex w-full max-w-[640px] flex-wrap gap-2">
+          {MAGIC_STYLE_CHIPS.map((chip) => {
+            const on = style === chip;
+            return (
+              <button
+                key={chip}
+                type="button"
+                onClick={() => onStyleChange(on ? null : chip)}
+                className={`rounded-full border px-[14px] py-[7px] text-[12px] font-semibold transition-colors ${
+                  on
+                    ? "border-accent bg-accent/20 text-shell-text"
+                    : "border-shell-border bg-shell-surface text-shell-text-secondary hover:border-shell-border-strong hover:text-shell-text"
+                }`}
+              >
+                {chip}
+              </button>
+            );
+          })}
         </div>
 
-        {/* generated result tiles */}
-        <div className="grid w-full max-w-[760px] grid-cols-3 gap-[14px]">
-          {RESULTS.map(({ label, gradient }) => (
-            <div
-              key={label}
-              className="relative cursor-pointer overflow-hidden rounded-[12px] border border-shell-border transition-all hover:-translate-y-[3px]"
-              style={{ aspectRatio: "0.8", background: gradient }}
-            >
-              <div
-                className="absolute bottom-0 left-0 right-0 px-[11px] py-[9px] text-[11px] text-white"
-                style={{ background: "linear-gradient(transparent, rgba(0,0,0,0.6))" }}
+        {generating && results.length === 0 && (
+          <div className="flex flex-col items-center gap-3 py-8 text-shell-text-tertiary">
+            <div className="h-8 w-8 animate-spin rounded-full border-2 border-accent border-t-transparent" />
+            <span className="text-[13px]">Generating your design...</span>
+          </div>
+        )}
+
+        {results.length > 0 && (
+          <div className="grid w-full max-w-[760px] grid-cols-3 gap-[14px]">
+            {results.map((img) => (
+              <button
+                key={img.id}
+                type="button"
+                onClick={() => onUseResult(img)}
+                className="relative cursor-pointer overflow-hidden rounded-[12px] border border-shell-border transition-all hover:-translate-y-[3px] hover:border-accent/50"
+                style={{ aspectRatio: "0.8" }}
               >
-                {label}
-              </div>
-            </div>
-          ))}
-        </div>
+                <img src={img.url} alt={img.prompt} className="h-full w-full object-cover" />
+                <div
+                  className="absolute bottom-0 left-0 right-0 px-[11px] py-[9px] text-left text-[11px] text-white"
+                  style={{ background: "linear-gradient(transparent, rgba(0,0,0,0.6))" }}
+                >
+                  {img.prompt.slice(0, 48)}
+                  {img.prompt.length > 48 ? "..." : ""}
+                </div>
+              </button>
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/desktop/src/apps/designstudio/types.ts
+++ b/desktop/src/apps/designstudio/types.ts
@@ -1,0 +1,34 @@
+/* ------------------------------------------------------------------ */
+/*  Design Studio -- shared types                                      */
+/* ------------------------------------------------------------------ */
+
+export type DesignStudioView = "design" | "templates" | "elements" | "magic";
+
+export interface GeneratedImage {
+  id: string;
+  url: string;
+  prompt: string;
+}
+
+/** An image layer placed on the design canvas artboard. */
+export interface CanvasImageElement {
+  id: string;
+  type: "image";
+  url: string;
+  prompt: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export type CanvasElement = CanvasImageElement;
+
+export const MAGIC_STYLE_CHIPS = [
+  "Bold",
+  "Minimal",
+  "Editorial",
+  "Playful",
+  "Dark",
+  "Corporate",
+] as const;


### PR DESCRIPTION
Design Studio MVP: MagicView generates via /api/images/generate and places images on the DesignView canvas with loading/error/install states. Reuses the existing images backend. Studio MVP card tsk-tehmqv.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Magic view now includes functional prompt input, style selection, and a working Generate button to create images.
  * Generated images display as interactive results that can be placed on the canvas.
  * Model browser integration with automatic model discovery and installation prompts when needed.
  * Design canvas now displays placed images with proper positioning and sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->