### PR TITLE
feat(music-studio): compose backend + wire ComposeView

### DIFF
--- a/desktop/src/apps/MusicStudioApp.tsx
+++ b/desktop/src/apps/MusicStudioApp.tsx
@@ -43,6 +43,12 @@ export function MusicStudioApp({ windowId: _windowId }: { windowId: string }) {
     refreshBackendStatus();
   }, [refreshBackendStatus]);
 
+  useEffect(() => {
+    if (view === "compose") {
+      refreshBackendStatus();
+    }
+  }, [view, refreshBackendStatus]);
+
   const needsBackend = !backendAvailable;
   const canGenerate = !!composePrompt.trim() && !generating && backendAvailable;
 

--- a/desktop/src/apps/MusicStudioApp.tsx
+++ b/desktop/src/apps/MusicStudioApp.tsx
@@ -1,7 +1,7 @@
-import { useState } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { LayoutList, Sparkles, Music2, LayoutGrid, Download } from "lucide-react";
 import { StudioView } from "./musicstudio/StudioView";
-import { ComposeView } from "./musicstudio/ComposeView";
+import { ComposeView, type ComposedTrack } from "./musicstudio/ComposeView";
 import { SoundsView } from "./musicstudio/SoundsView";
 
 type MusicView = "studio" | "compose" | "sounds" | "mixer" | "export";
@@ -16,15 +16,86 @@ const RAIL_MAIN: { id: MusicView; label: string; icon: typeof LayoutList }[] = [
 export function MusicStudioApp({ windowId: _windowId }: { windowId: string }) {
   const [view, setView] = useState<MusicView>("studio");
 
+  const [composePrompt, setComposePrompt] = useState("");
+  const [composeStyle, setComposeStyle] = useState<string | null>(null);
+  const [composeResults, setComposeResults] = useState<ComposedTrack[]>([]);
+  const [generating, setGenerating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [backendAvailable, setBackendAvailable] = useState(false);
+
+  const refreshBackendStatus = useCallback(async () => {
+    try {
+      const res = await fetch("/api/music/status", {
+        headers: { Accept: "application/json" },
+      });
+      if (!res.ok) return false;
+      const data = await res.json();
+      const available = Boolean(data.available);
+      setBackendAvailable(available);
+      return available;
+    } catch {
+      setBackendAvailable(false);
+      return false;
+    }
+  }, []);
+
+  useEffect(() => {
+    refreshBackendStatus();
+  }, [refreshBackendStatus]);
+
+  const needsBackend = !backendAvailable;
+  const canGenerate = !!composePrompt.trim() && !generating && backendAvailable;
+
+  const runCompose = useCallback(async () => {
+    const usePrompt = composePrompt.trim();
+    if (!usePrompt || !backendAvailable) return;
+
+    setGenerating(true);
+    setError(null);
+
+    const styledPrompt = composeStyle
+      ? `${usePrompt}, ${composeStyle.toLowerCase()} style`
+      : usePrompt;
+
+    try {
+      const res = await fetch("/api/music/compose", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ prompt: styledPrompt, duration: 10 }),
+      });
+
+      const data = await res.json().catch(() => ({}));
+      if (res.ok && data.filename) {
+        const track: ComposedTrack = {
+          id: data.filename as string,
+          url: (data.path as string) ?? `/data/workspace/music/generated/${data.filename}`,
+          prompt: styledPrompt,
+          duration: (data.duration as number) ?? 10,
+        };
+        setComposeResults((prev) => [track, ...prev]);
+      } else {
+        setError((data as { error?: string }).error ?? `Generation failed (${res.status})`);
+      }
+    } catch (e) {
+      setError(`Generation error: ${(e as Error).message}`);
+    }
+
+    setGenerating(false);
+  }, [composePrompt, composeStyle, backendAvailable]);
+
+  const openStore = useCallback(() => {
+    window.dispatchEvent(
+      new CustomEvent("taos:open-app", { detail: { app: "store" } }),
+    );
+  }, []);
+
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden bg-shell-bg text-shell-text select-none">
-      {/* title strip */}
       <div className="flex h-[46px] flex-none items-center justify-center border-b border-shell-border">
         <span className="text-[13px] font-semibold tracking-[-0.01em]">Music Studio</span>
       </div>
 
       <div className="flex min-h-0 flex-1">
-        {/* left rail */}
         <nav
           aria-label="Music Studio views"
           className="flex w-[68px] flex-none flex-col items-center gap-1.5 border-r border-shell-border bg-shell-bg-deep py-3.5"
@@ -68,10 +139,23 @@ export function MusicStudioApp({ windowId: _windowId }: { windowId: string }) {
           </button>
         </nav>
 
-        {/* active surface */}
         <div className="flex min-w-0 flex-1 flex-col">
           {view === "studio" && <StudioView />}
-          {view === "compose" && <ComposeView />}
+          {view === "compose" && (
+            <ComposeView
+              prompt={composePrompt}
+              onPromptChange={setComposePrompt}
+              style={composeStyle}
+              onStyleChange={setComposeStyle}
+              results={composeResults}
+              generating={generating}
+              canGenerate={canGenerate}
+              error={error}
+              needsBackend={needsBackend}
+              onGenerate={runCompose}
+              onOpenStore={openStore}
+            />
+          )}
           {view === "sounds" && <SoundsView />}
           {view === "mixer" && (
             <div className="flex flex-1 items-center justify-center text-shell-text-secondary text-[13px]">

--- a/desktop/src/apps/musicstudio/ComposeView.tsx
+++ b/desktop/src/apps/musicstudio/ComposeView.tsx
@@ -1,23 +1,43 @@
-import { Sparkles, Play } from "lucide-react";
+import { Loader2, Play, Sparkles } from "lucide-react";
 
 const STYLE_CHIPS = ["Lo-fi", "Cinematic", "House", "Ambient", "Drum and bass", "Hip-hop"];
 
-interface GeneratedResult {
-  bpm: number;
-  duration: string;
-  bars: number[];
+export interface ComposedTrack {
+  id: string;
+  url: string;
+  prompt: string;
+  duration: number;
 }
 
-const RESULTS: GeneratedResult[] = [
-  { bpm: 92, duration: "0:48", bars: [30, 60, 45, 80, 50, 70, 40, 90, 55, 65, 35, 75, 50, 60] },
-  { bpm: 90, duration: "1:02", bars: [50, 40, 70, 55, 85, 45, 60, 50, 75, 40, 65, 55, 80, 45] },
-  { bpm: 94, duration: "0:54", bars: [40, 55, 50, 65, 45, 75, 55, 60, 50, 70, 45, 80, 50, 60] },
-];
+export interface ComposeViewProps {
+  prompt: string;
+  onPromptChange: (value: string) => void;
+  style: string | null;
+  onStyleChange: (value: string | null) => void;
+  results: ComposedTrack[];
+  generating: boolean;
+  canGenerate: boolean;
+  error: string | null;
+  needsBackend: boolean;
+  onGenerate: () => void;
+  onOpenStore: () => void;
+}
 
-export function ComposeView() {
+export function ComposeView({
+  prompt,
+  onPromptChange,
+  style,
+  onStyleChange,
+  results,
+  generating,
+  canGenerate,
+  error,
+  needsBackend,
+  onGenerate,
+  onOpenStore,
+}: ComposeViewProps) {
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      {/* view header */}
       <div
         className="flex flex-none items-center gap-3 border-b border-shell-border px-[22px]"
         style={{ height: "54px" }}
@@ -29,7 +49,6 @@ export function ComposeView() {
       </div>
 
       <div className="flex flex-1 flex-col items-center overflow-auto p-[26px]">
-        {/* hero */}
         <div className="mb-[22px] max-w-[620px] text-center">
           <h3 className="text-[23px] font-extrabold tracking-[-0.02em]">
             Hum it, or just describe it.
@@ -40,45 +59,76 @@ export function ComposeView() {
           </p>
         </div>
 
-        {/* prompt bar */}
         <div className="mb-3.5 flex w-full max-w-[620px] gap-2.5">
-          <div className="flex-1 rounded-[14px] border border-shell-border bg-shell-surface px-4 py-3.5 text-[13.5px] text-shell-text-tertiary">
-            a warm lo-fi beat, 90 bpm, dusty drums, rhodes chords, vinyl crackle...
-          </div>
+          <textarea
+            value={prompt}
+            onChange={(e) => onPromptChange(e.target.value)}
+            placeholder="a warm lo-fi beat, 90 bpm, dusty drums, rhodes chords, vinyl crackle..."
+            rows={2}
+            className="flex-1 resize-none rounded-[14px] border border-shell-border bg-shell-surface px-4 py-3.5 text-[13.5px] text-shell-text outline-none placeholder:text-shell-text-tertiary focus-visible:ring-2 focus-visible:ring-accent/40"
+          />
           <button
             type="button"
-            className="flex cursor-pointer items-center gap-2 rounded-[14px] border-0 px-[22px] text-[14px] font-bold text-white"
+            disabled={!canGenerate}
+            onClick={onGenerate}
+            className="flex cursor-pointer items-center gap-2 rounded-[14px] border-0 px-[22px] text-[14px] font-bold text-white transition-opacity disabled:cursor-not-allowed disabled:opacity-50"
             style={{
               background: "linear-gradient(135deg, var(--color-accent-strong, #a9b0c2), var(--color-accent, #8b92a3))",
             }}
           >
-            <Sparkles size={17} />
-            Generate
+            {generating ? <Loader2 size={17} className="animate-spin" /> : <Sparkles size={17} />}
+            {generating ? "Generating..." : "Generate"}
           </button>
         </div>
 
-        {/* style chips */}
-        <div className="mb-[26px] flex flex-wrap justify-center gap-2">
-          {STYLE_CHIPS.map((chip, i) => (
+        {needsBackend && (
+          <div className="mb-4 w-full max-w-[620px] rounded-[12px] border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-[13px] text-amber-100">
+            <p>Install a music generation backend (musicgpt, musicgen, or stable-audio-open) to compose tracks.</p>
             <button
-              key={chip}
               type="button"
-              className={`rounded-full border px-3.5 py-[7px] text-[11.5px] font-semibold ${
-                i === 0
-                  ? "border-accent bg-accent/20 text-accent"
-                  : "border-shell-border bg-shell-surface text-shell-text-secondary"
-              }`}
+              onClick={onOpenStore}
+              className="mt-2 text-[12px] font-semibold text-accent underline-offset-2 hover:underline"
             >
-              {chip}
+              Open Store
             </button>
-          ))}
+          </div>
+        )}
+
+        {error && (
+          <div className="mb-4 w-full max-w-[620px] rounded-[12px] border border-red-500/30 bg-red-500/10 px-4 py-3 text-[13px] text-red-100">
+            {error}
+          </div>
+        )}
+
+        <div className="mb-[26px] flex flex-wrap justify-center gap-2">
+          {STYLE_CHIPS.map((chip) => {
+            const active = style === chip;
+            return (
+              <button
+                key={chip}
+                type="button"
+                onClick={() => onStyleChange(active ? null : chip)}
+                className={`rounded-full border px-3.5 py-[7px] text-[11.5px] font-semibold ${
+                  active
+                    ? "border-accent bg-accent/20 text-accent"
+                    : "border-shell-border bg-shell-surface text-shell-text-secondary"
+                }`}
+              >
+                {chip}
+              </button>
+            );
+          })}
         </div>
 
-        {/* generated results */}
         <div className="flex w-full max-w-[660px] flex-col gap-[11px]">
-          {RESULTS.map((result, i) => (
+          {results.length === 0 && !generating && (
+            <p className="text-center text-[12.5px] text-shell-text-tertiary">
+              Generated tracks will appear here.
+            </p>
+          )}
+          {results.map((result) => (
             <div
-              key={i}
+              key={result.id}
               className="flex cursor-pointer items-center gap-3.5 rounded-[14px] border border-shell-border bg-shell-surface px-[15px] py-[13px] hover:bg-shell-surface-active"
             >
               <div
@@ -88,20 +138,14 @@ export function ComposeView() {
                 <Play size={16} fill="currentColor" />
               </div>
 
-              <div className="flex flex-1 items-center gap-[2px]" style={{ height: "30px" }}>
-                {result.bars.map((h, bi) => (
-                  <span
-                    key={bi}
-                    className="flex-1 rounded-[1px] opacity-55"
-                    style={{ height: `${h}%`, background: "var(--color-shell-text-tertiary, rgba(255,255,255,0.40))" }}
-                  />
-                ))}
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-[12.5px] font-semibold text-shell-text">{result.prompt}</p>
+                <audio controls preload="none" src={result.url} className="mt-2 h-8 w-full" />
               </div>
 
               <span className="whitespace-nowrap text-[11px] text-shell-text-tertiary">
-                {result.bpm} BPM - {result.duration}
+                {result.duration}s
               </span>
-              <span className="text-[11.5px] font-bold text-accent">Open</span>
             </div>
           ))}
         </div>

--- a/tests/test_routes_music.py
+++ b/tests/test_routes_music.py
@@ -37,7 +37,8 @@ async def music_client(music_app):
 @pytest.mark.asyncio
 class TestMusicCompose:
     async def test_compose_no_backend_returns_503(self, music_client):
-        resp = await music_client.post("/api/music/compose", json={"prompt": "lofi beat"})
+        with patch("tinyagentos.routes.music.shutil.which", return_value=None):
+            resp = await music_client.post("/api/music/compose", json={"prompt": "lofi beat"})
         assert resp.status_code == 503
         assert "error" in resp.json()
 
@@ -57,7 +58,10 @@ class TestMusicCompose:
             request=mock_request,
         )
 
-        with patch("tinyagentos.routes.music.httpx.AsyncClient") as MockClient:
+        with (
+            patch("tinyagentos.routes.music._http_backend_reachable", new=AsyncMock(return_value=True)),
+            patch("tinyagentos.routes.music.httpx.AsyncClient") as MockClient,
+        ):
             mock_instance = AsyncMock()
             mock_instance.post.return_value = mock_response
             mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
@@ -88,7 +92,8 @@ class TestMusicCompose:
 
     async def test_status_reports_config_backend(self, music_app, music_client):
         music_app.state.config.server["music_backend_url"] = "http://localhost:9000"
-        resp = await music_client.get("/api/music/status")
+        with patch("tinyagentos.routes.music._http_backend_reachable", new=AsyncMock(return_value=True)):
+            resp = await music_client.get("/api/music/status")
         assert resp.status_code == 200
         data = resp.json()
         assert data["available"] is True

--- a/tests/test_routes_music.py
+++ b/tests/test_routes_music.py
@@ -106,7 +106,8 @@ class TestMusicCompose:
         (stable_dir / "python").write_text("")
         music_app.state.apps_dir = str(apps_dir)
 
-        resp = await music_client.get("/api/music/status")
+        with patch("tinyagentos.routes.music.shutil.which", return_value=None):
+            resp = await music_client.get("/api/music/status")
         assert resp.status_code == 200
         data = resp.json()
         assert "stable-audio-open" not in data["installed"]

--- a/tests/test_routes_music.py
+++ b/tests/test_routes_music.py
@@ -1,0 +1,103 @@
+import base64
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient, Request as HttpxRequest, Response
+
+from tinyagentos.app import create_app
+
+
+@pytest.fixture
+def music_app(tmp_data_dir):
+    app = create_app(data_dir=tmp_data_dir)
+    app.state.data_dir = str(tmp_data_dir)
+    return app
+
+
+@pytest_asyncio.fixture
+async def music_client(music_app):
+    store = music_app.state.metrics
+    if store._db is not None:
+        await store.close()
+    await store.init()
+    await music_app.state.qmd_client.init()
+    music_app.state.auth.setup_user("admin", "Test Admin", "", "testpass")
+    _rec = music_app.state.auth.find_user("admin")
+    _token = music_app.state.auth.create_session(user_id=_rec["id"] if _rec else "", long_lived=True)
+    transport = ASGITransport(app=music_app)
+    async with AsyncClient(transport=transport, base_url="http://test", cookies={"taos_session": _token}) as c:
+        yield c
+    await store.close()
+    await music_app.state.qmd_client.close()
+    await music_app.state.http_client.aclose()
+
+
+@pytest.mark.asyncio
+class TestMusicCompose:
+    async def test_compose_no_backend_returns_503(self, music_client):
+        resp = await music_client.post("/api/music/compose", json={"prompt": "lofi beat"})
+        assert resp.status_code == 503
+        assert "error" in resp.json()
+
+    async def test_compose_empty_prompt_returns_400(self, music_app, music_client):
+        music_app.state.config.server["music_backend_url"] = "http://localhost:9000"
+        resp = await music_client.post("/api/music/compose", json={"prompt": "   "})
+        assert resp.status_code == 400
+
+    async def test_compose_with_mocked_http_backend(self, music_app, music_client):
+        music_app.state.config.server["music_backend_url"] = "http://localhost:9000"
+
+        fake_wav = base64.b64encode(b"fake-wav-data").decode()
+        mock_request = HttpxRequest("POST", "http://localhost:9000/v1/audio/generations")
+        mock_response = Response(
+            status_code=200,
+            json={"data": [{"b64_json": fake_wav}]},
+            request=mock_request,
+        )
+
+        with patch("tinyagentos.routes.music.httpx.AsyncClient") as MockClient:
+            mock_instance = AsyncMock()
+            mock_instance.post.return_value = mock_response
+            mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+            mock_instance.__aexit__ = AsyncMock(return_value=False)
+            MockClient.return_value = mock_instance
+
+            resp = await music_client.post("/api/music/compose", json={
+                "prompt": "warm lo-fi beat",
+                "duration": 8,
+            })
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "generated"
+        assert data["prompt"] == "warm lo-fi beat"
+        assert data["duration"] == 8
+        assert data["filename"].endswith(".wav")
+
+        music_dir = music_app.state.config_path.parent / "workspace" / "music" / "generated"
+        saved = list(music_dir.glob("*.wav"))
+        assert len(saved) == 1
+        assert saved[0].read_bytes() == b"fake-wav-data"
+
+        meta_files = list(music_dir.glob("*.json"))
+        assert len(meta_files) == 1
+        meta = json.loads(meta_files[0].read_text())
+        assert meta["prompt"] == "warm lo-fi beat"
+
+    async def test_status_reports_config_backend(self, music_app, music_client):
+        music_app.state.config.server["music_backend_url"] = "http://localhost:9000"
+        resp = await music_client.get("/api/music/status")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["available"] is True
+        assert data["mode"] == "http"
+
+
+@pytest.mark.asyncio
+class TestMusicList:
+    async def test_list_empty(self, music_client):
+        resp = await music_client.get("/api/music")
+        assert resp.status_code == 200
+        assert resp.json()["tracks"] == []

--- a/tests/test_routes_music.py
+++ b/tests/test_routes_music.py
@@ -94,6 +94,19 @@ class TestMusicCompose:
         assert data["available"] is True
         assert data["mode"] == "http"
 
+    async def test_status_ignores_stable_audio_venv(self, music_app, music_client, tmp_path):
+        apps_dir = tmp_path / "apps"
+        stable_dir = apps_dir / "stable-audio-open" / "venv" / "bin"
+        stable_dir.mkdir(parents=True)
+        (stable_dir / "python").write_text("")
+        music_app.state.apps_dir = str(apps_dir)
+
+        resp = await music_client.get("/api/music/status")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "stable-audio-open" not in data["installed"]
+        assert data["available"] is False
+
 
 @pytest.mark.asyncio
 class TestMusicList:

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -60,6 +60,9 @@ def register_all_routers(app):
     from tinyagentos.routes.images import router as images_router
     app.include_router(images_router)
 
+    from tinyagentos.routes.music import router as music_router
+    app.include_router(music_router)
+
     from tinyagentos.routes.images_edit import router as images_edit_router
     app.include_router(images_edit_router)
 

--- a/tinyagentos/routes/music.py
+++ b/tinyagentos/routes/music.py
@@ -1,0 +1,370 @@
+# tinyagentos/routes/music.py
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+import shutil
+import time
+import uuid
+from pathlib import Path
+
+import httpx
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+MUSIC_SERVICE_IDS = ("musicgpt", "musicgen", "stable-audio-open")
+DEFAULT_MUSICGPT_PORT = 30264
+
+
+class ComposeRequest(BaseModel):
+    prompt: str
+    duration: int = Field(default=10, ge=1, le=30)
+
+
+def _music_dir(request: Request) -> Path:
+    """Return workspace/music/generated, creating it if needed."""
+    config_path = getattr(request.app.state, "config_path", None)
+    if config_path is not None:
+        data_dir = Path(config_path).parent
+    else:
+        data_dir = Path(__file__).parent.parent.parent / "data"
+    d = data_dir / "workspace" / "music" / "generated"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _music_url_path(filename: str) -> str:
+    return f"/data/workspace/music/generated/{filename}"
+
+
+def _apps_dir(request: Request) -> Path | None:
+    apps_dir = getattr(request.app.state, "apps_dir", None)
+    if apps_dir is not None:
+        return Path(apps_dir)
+    data_dir = getattr(request.app.state, "data_dir", None)
+    if data_dir is not None:
+        return Path(data_dir) / "apps"
+    return None
+
+
+def _service_python(request: Request, app_id: str) -> Path | None:
+    root = _apps_dir(request)
+    if root is None:
+        return None
+    py = root / app_id / "venv" / "bin" / "python"
+    return py if py.exists() else None
+
+
+async def _store_ready(store: object | None) -> bool:
+    return store is not None and getattr(store, "_db", None) is not None
+
+
+async def _is_service_installed(request: Request, app_id: str) -> bool:
+    store = getattr(request.app.state, "installed_apps", None)
+    if await _store_ready(store) and await store.is_installed(app_id):
+        return True
+    registry = getattr(request.app.state, "registry", None)
+    if registry is not None and registry.is_installed(app_id):
+        return True
+    installation = getattr(request.app.state, "installation_state", None)
+    if installation is not None and installation.is_installed(app_id):
+        return True
+    if app_id == "musicgpt" and shutil.which("musicgpt"):
+        return True
+    if app_id in ("musicgen", "stable-audio-open") and _service_python(request, app_id):
+        return True
+    return False
+
+
+async def _resolve_music_backend(
+    request: Request,
+) -> tuple[str | None, str | None, str]:
+    """Return (backend_id, backend_url, mode).
+
+    mode is one of: http, musicgpt-cli, musicgen-cli
+    """
+    config = request.app.state.config
+    override = config.server.get("music_backend_url")
+    if override:
+        return "music-backend", str(override), "http"
+
+    store = getattr(request.app.state, "installed_apps", None)
+    if await _store_ready(store):
+        for app_id in MUSIC_SERVICE_IDS:
+            if not await store.is_installed(app_id):
+                continue
+            loc = await store.get_runtime_location(app_id)
+            if loc and loc.get("runtime_host") and loc.get("runtime_port"):
+                host = loc["runtime_host"]
+                port = loc["runtime_port"]
+                return app_id, f"http://{host}:{port}", "http"
+            if app_id == "musicgpt":
+                return app_id, f"http://127.0.0.1:{DEFAULT_MUSICGPT_PORT}", "http"
+
+    for app_id in MUSIC_SERVICE_IDS:
+        if not await _is_service_installed(request, app_id):
+            continue
+        if app_id == "musicgpt" and shutil.which("musicgpt"):
+            return app_id, None, "musicgpt-cli"
+        if app_id == "musicgen" and _service_python(request, "musicgen"):
+            return app_id, None, "musicgen-cli"
+
+    return None, None, ""
+
+
+def _list_tracks(music_dir: Path) -> list[dict]:
+    results = []
+    for ext in ("*.wav", "*.mp3"):
+        for audio in music_dir.glob(ext):
+            meta_path = audio.with_suffix(".json")
+            metadata: dict = {}
+            if meta_path.exists():
+                try:
+                    metadata = json.loads(meta_path.read_text())
+                except (json.JSONDecodeError, OSError):
+                    pass
+            results.append({
+                "filename": audio.name,
+                "path": _music_url_path(audio.name),
+                "size_bytes": audio.stat().st_size,
+                "prompt": metadata.get("prompt", ""),
+                "duration": metadata.get("duration", 0),
+                "backend": metadata.get("backend", ""),
+            })
+    results.sort(key=lambda x: x["filename"], reverse=True)
+    return results
+
+
+async def _compose_via_http(
+    backend_url: str,
+    *,
+    prompt: str,
+    duration: int,
+) -> bytes:
+    payload = {
+        "prompt": prompt,
+        "duration": duration,
+        "response_format": "b64_json",
+    }
+    async with httpx.AsyncClient(timeout=300) as client:
+        resp = await client.post(
+            f"{backend_url.rstrip('/')}/v1/audio/generations",
+            json=payload,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+    try:
+        entry = data["data"][0]
+    except (KeyError, IndexError) as exc:
+        raise RuntimeError("Unexpected response format from music backend") from exc
+
+    b64 = entry.get("b64_json") or entry.get("b64_wav")
+    if b64:
+        return base64.b64decode(b64)
+
+    url = entry.get("url")
+    if not url:
+        raise RuntimeError("Music backend returned neither b64 data nor url")
+
+    async with httpx.AsyncClient(timeout=300) as client:
+        dl = await client.get(url)
+        dl.raise_for_status()
+        return dl.content
+
+
+async def _compose_via_musicgpt_cli(
+    *,
+    prompt: str,
+    duration: int,
+    output_path: Path,
+) -> None:
+    binary = shutil.which("musicgpt")
+    if not binary:
+        raise RuntimeError("musicgpt binary not found on PATH")
+
+    proc = await asyncio.create_subprocess_exec(
+        binary,
+        prompt,
+        "--secs",
+        str(duration),
+        "--output",
+        str(output_path),
+        "--no-playback",
+        "--no-interactive",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    _stdout, stderr = await proc.communicate()
+    if proc.returncode != 0:
+        detail = stderr.decode(errors="replace").strip() or f"exit code {proc.returncode}"
+        raise RuntimeError(f"musicgpt failed: {detail}")
+    if not output_path.exists():
+        raise RuntimeError("musicgpt did not produce an output file")
+
+
+_MUSICGEN_SCRIPT = """
+import sys
+from pathlib import Path
+
+prompt = sys.argv[1]
+duration = float(sys.argv[2])
+output = Path(sys.argv[3])
+
+from audiocraft.models import MusicGen
+
+model = MusicGen.get_pretrained("facebook/musicgen-small")
+model.set_generation_params(duration=duration)
+wav = model.generate([prompt])
+import scipy.io.wavfile
+scipy.io.wavfile.write(str(output), model.sample_rate, wav[0].cpu().numpy().T)
+"""
+
+
+async def _compose_via_musicgen_cli(
+    request: Request,
+    *,
+    prompt: str,
+    duration: int,
+    output_path: Path,
+) -> None:
+    python = _service_python(request, "musicgen")
+    if python is None:
+        raise RuntimeError("musicgen venv not found")
+
+    proc = await asyncio.create_subprocess_exec(
+        str(python),
+        "-c",
+        _MUSICGEN_SCRIPT,
+        prompt,
+        str(duration),
+        str(output_path),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    _stdout, stderr = await proc.communicate()
+    if proc.returncode != 0:
+        detail = stderr.decode(errors="replace").strip() or f"exit code {proc.returncode}"
+        raise RuntimeError(f"musicgen failed: {detail}")
+    if not output_path.exists():
+        raise RuntimeError("musicgen did not produce an output file")
+
+
+@router.get("/api/music/status")
+async def music_status(request: Request):
+    """Report whether a music generation backend is available."""
+    backend_id, backend_url, mode = await _resolve_music_backend(request)
+    installed = []
+    for app_id in MUSIC_SERVICE_IDS:
+        if await _is_service_installed(request, app_id):
+            installed.append(app_id)
+    return {
+        "available": backend_id is not None,
+        "backend": backend_id,
+        "mode": mode or None,
+        "backend_url": backend_url,
+        "installed": installed,
+    }
+
+
+@router.post("/api/music/compose")
+async def compose_music(request: Request, body: ComposeRequest):
+    """Generate audio from a text prompt using an installed music backend."""
+    prompt = body.prompt.strip()
+    if not prompt:
+        return JSONResponse({"error": "prompt is required"}, status_code=400)
+
+    backend_id, backend_url, mode = await _resolve_music_backend(request)
+    if not backend_id:
+        return JSONResponse(
+            {
+                "error": (
+                    "No music generation backend installed. "
+                    "Install musicgpt, musicgen, or stable-audio-open from the Store."
+                ),
+            },
+            status_code=503,
+        )
+
+    music_dir = _music_dir(request)
+    timestamp = int(time.time())
+    track_id = uuid.uuid4().hex[:8]
+    filename = f"{timestamp}_{track_id}.wav"
+    output_path = music_dir / filename
+
+    try:
+        if mode == "http":
+            assert backend_url is not None
+            audio_bytes = await _compose_via_http(
+                backend_url,
+                prompt=prompt,
+                duration=body.duration,
+            )
+            output_path.write_bytes(audio_bytes)
+        elif mode == "musicgpt-cli":
+            await _compose_via_musicgpt_cli(
+                prompt=prompt,
+                duration=body.duration,
+                output_path=output_path,
+            )
+            audio_bytes = output_path.read_bytes()
+        elif mode == "musicgen-cli":
+            await _compose_via_musicgen_cli(
+                request,
+                prompt=prompt,
+                duration=body.duration,
+                output_path=output_path,
+            )
+            audio_bytes = output_path.read_bytes()
+        else:
+            return JSONResponse(
+                {"error": f"Backend {backend_id!r} is installed but not runnable yet."},
+                status_code=503,
+            )
+    except httpx.ConnectError:
+        return JSONResponse(
+            {"error": "Cannot connect to music backend. Is it running?"},
+            status_code=503,
+        )
+    except httpx.TimeoutException:
+        return JSONResponse(
+            {"error": "Music generation timed out. The backend may be busy."},
+            status_code=504,
+        )
+    except httpx.HTTPStatusError as exc:
+        return JSONResponse(
+            {"error": f"Music backend returned error: {exc.response.status_code}"},
+            status_code=502,
+        )
+    except Exception as exc:
+        logger.exception("music compose failed")
+        return JSONResponse({"error": str(exc)}, status_code=500)
+
+    metadata = {
+        "prompt": prompt,
+        "duration": body.duration,
+        "backend": backend_id,
+        "filename": filename,
+    }
+    (music_dir / f"{timestamp}_{track_id}.json").write_text(json.dumps(metadata, indent=2))
+
+    return {
+        "status": "generated",
+        "filename": filename,
+        "path": _music_url_path(filename),
+        "size_bytes": len(audio_bytes),
+        **metadata,
+    }
+
+
+@router.get("/api/music")
+async def list_music(request: Request):
+    """List generated music tracks, newest first."""
+    return {"tracks": _list_tracks(_music_dir(request))}

--- a/tinyagentos/routes/music.py
+++ b/tinyagentos/routes/music.py
@@ -283,6 +283,22 @@ async def compose_music(request: Request, body: ComposeRequest):
 
     backend_id, backend_url, mode = await _resolve_music_backend(request)
     if not backend_id:
+        installed = [
+            app_id
+            for app_id in MUSIC_SERVICE_IDS
+            if await _is_service_installed(request, app_id)
+        ]
+        if installed:
+            names = ", ".join(installed)
+            return JSONResponse(
+                {
+                    "error": (
+                        f"Music backend(s) installed ({names}) but not runnable yet. "
+                        "Start the service runtime or install musicgpt/musicgen."
+                    ),
+                },
+                status_code=503,
+            )
         return JSONResponse(
             {
                 "error": (
@@ -314,7 +330,6 @@ async def compose_music(request: Request, body: ComposeRequest):
                 duration=body.duration,
                 output_path=output_path,
             )
-            audio_bytes = output_path.read_bytes()
         elif mode == "musicgen-cli":
             await _compose_via_musicgen_cli(
                 request,
@@ -322,7 +337,6 @@ async def compose_music(request: Request, body: ComposeRequest):
                 duration=body.duration,
                 output_path=output_path,
             )
-            audio_bytes = output_path.read_bytes()
         else:
             return JSONResponse(
                 {"error": f"Backend {backend_id!r} is installed but not runnable yet."},
@@ -343,9 +357,12 @@ async def compose_music(request: Request, body: ComposeRequest):
             {"error": f"Music backend returned error: {exc.response.status_code}"},
             status_code=502,
         )
-    except Exception as exc:
+    except Exception:
         logger.exception("music compose failed")
-        return JSONResponse({"error": str(exc)}, status_code=500)
+        return JSONResponse(
+            {"error": "Music generation failed. Check server logs for details."},
+            status_code=500,
+        )
 
     metadata = {
         "prompt": prompt,
@@ -359,7 +376,7 @@ async def compose_music(request: Request, body: ComposeRequest):
         "status": "generated",
         "filename": filename,
         "path": _music_url_path(filename),
-        "size_bytes": len(audio_bytes),
+        "size_bytes": output_path.stat().st_size,
         **metadata,
     }
 

--- a/tinyagentos/routes/music.py
+++ b/tinyagentos/routes/music.py
@@ -9,6 +9,7 @@ import shutil
 import time
 import uuid
 from pathlib import Path
+from urllib.parse import urlparse
 
 import httpx
 from fastapi import APIRouter, Request
@@ -84,6 +85,29 @@ async def _is_service_installed(request: Request, app_id: str) -> bool:
     return False
 
 
+async def _http_backend_reachable(backend_url: str) -> bool:
+    """Return True when an HTTP music backend responds on a lightweight probe."""
+    base = backend_url.rstrip("/")
+    async with httpx.AsyncClient(timeout=3) as client:
+        for path in ("/health", "/v1/models", "/"):
+            try:
+                resp = await client.get(f"{base}{path}")
+                if resp.status_code < 500:
+                    return True
+            except httpx.TransportError:
+                continue
+    return False
+
+
+def _same_backend_host(download_url: str, backend_url: str) -> bool:
+    """Only follow backend-provided URLs that stay on the trusted backend host."""
+    dl = urlparse(download_url)
+    be = urlparse(backend_url)
+    if dl.scheme not in ("http", "https") or not dl.hostname:
+        return False
+    return dl.hostname == be.hostname
+
+
 async def _resolve_music_backend(
     request: Request,
 ) -> tuple[str | None, str | None, str]:
@@ -94,7 +118,9 @@ async def _resolve_music_backend(
     config = request.app.state.config
     override = config.server.get("music_backend_url")
     if override:
-        return "music-backend", str(override), "http"
+        url = str(override)
+        if await _http_backend_reachable(url):
+            return "music-backend", url, "http"
 
     store = getattr(request.app.state, "installed_apps", None)
     if await _store_ready(store):
@@ -105,9 +131,13 @@ async def _resolve_music_backend(
             if loc and loc.get("runtime_host") and loc.get("runtime_port"):
                 host = loc["runtime_host"]
                 port = loc["runtime_port"]
-                return app_id, f"http://{host}:{port}", "http"
+                url = f"http://{host}:{port}"
+                if await _http_backend_reachable(url):
+                    return app_id, url, "http"
             if app_id == "musicgpt":
-                return app_id, f"http://127.0.0.1:{DEFAULT_MUSICGPT_PORT}", "http"
+                url = f"http://127.0.0.1:{DEFAULT_MUSICGPT_PORT}"
+                if await _http_backend_reachable(url):
+                    return app_id, url, "http"
 
     for app_id in MUSIC_SERVICE_IDS:
         if not await _is_service_installed(request, app_id):
@@ -174,6 +204,8 @@ async def _compose_via_http(
     url = entry.get("url")
     if not url:
         raise RuntimeError("Music backend returned neither b64 data nor url")
+    if not _same_backend_host(url, backend_url):
+        raise RuntimeError("Music backend returned an untrusted download URL")
 
     async with httpx.AsyncClient(timeout=300) as client:
         dl = await client.get(url)
@@ -200,7 +232,7 @@ async def _compose_via_musicgpt_cli(
         str(output_path),
         "--no-playback",
         "--no-interactive",
-        stdout=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.DEVNULL,
         stderr=asyncio.subprocess.PIPE,
     )
     _stdout, stderr = await proc.communicate()
@@ -247,7 +279,7 @@ async def _compose_via_musicgen_cli(
         prompt,
         str(duration),
         str(output_path),
-        stdout=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.DEVNULL,
         stderr=asyncio.subprocess.PIPE,
     )
     _stdout, stderr = await proc.communicate()
@@ -343,6 +375,24 @@ async def compose_music(request: Request, body: ComposeRequest):
                 {"error": f"Backend {backend_id!r} is installed but not runnable yet."},
                 status_code=503,
             )
+
+        metadata = {
+            "prompt": prompt,
+            "duration": body.duration,
+            "backend": backend_id,
+            "filename": filename,
+        }
+        (music_dir / f"{timestamp}_{track_id}.json").write_text(
+            json.dumps(metadata, indent=2),
+        )
+
+        return {
+            "status": "generated",
+            "filename": filename,
+            "path": _music_url_path(filename),
+            "size_bytes": output_path.stat().st_size,
+            **metadata,
+        }
     except httpx.ConnectError:
         return JSONResponse(
             {"error": "Cannot connect to music backend. Is it running?"},
@@ -364,22 +414,6 @@ async def compose_music(request: Request, body: ComposeRequest):
             {"error": "Music generation failed. Check server logs for details."},
             status_code=500,
         )
-
-    metadata = {
-        "prompt": prompt,
-        "duration": body.duration,
-        "backend": backend_id,
-        "filename": filename,
-    }
-    (music_dir / f"{timestamp}_{track_id}.json").write_text(json.dumps(metadata, indent=2))
-
-    return {
-        "status": "generated",
-        "filename": filename,
-        "path": _music_url_path(filename),
-        "size_bytes": output_path.stat().st_size,
-        **metadata,
-    }
 
 
 @router.get("/api/music")

--- a/tinyagentos/routes/music.py
+++ b/tinyagentos/routes/music.py
@@ -19,7 +19,8 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
-MUSIC_SERVICE_IDS = ("musicgpt", "musicgen", "stable-audio-open")
+# stable-audio-open is cataloged but has no runnable compose path yet.
+MUSIC_SERVICE_IDS = ("musicgpt", "musicgen")
 DEFAULT_MUSICGPT_PORT = 30264
 
 
@@ -78,7 +79,7 @@ async def _is_service_installed(request: Request, app_id: str) -> bool:
         return True
     if app_id == "musicgpt" and shutil.which("musicgpt"):
         return True
-    if app_id in ("musicgen", "stable-audio-open") and _service_python(request, app_id):
+    if app_id == "musicgen" and _service_python(request, app_id):
         return True
     return False
 
@@ -303,7 +304,7 @@ async def compose_music(request: Request, body: ComposeRequest):
             {
                 "error": (
                     "No music generation backend installed. "
-                    "Install musicgpt, musicgen, or stable-audio-open from the Store."
+                    "Install musicgpt or musicgen from the Store."
                 ),
             },
             status_code=503,

--- a/tinyagentos/routes/music.py
+++ b/tinyagentos/routes/music.py
@@ -99,13 +99,23 @@ async def _http_backend_reachable(backend_url: str) -> bool:
     return False
 
 
+def _normalized_origin(url: str) -> tuple[str, str, int] | None:
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https") or not parsed.hostname:
+        return None
+    port = parsed.port
+    if port is None:
+        port = 443 if parsed.scheme == "https" else 80
+    return (parsed.scheme.lower(), parsed.hostname.lower(), port)
+
+
 def _same_backend_host(download_url: str, backend_url: str) -> bool:
-    """Only follow backend-provided URLs that stay on the trusted backend host."""
-    dl = urlparse(download_url)
-    be = urlparse(backend_url)
-    if dl.scheme not in ("http", "https") or not dl.hostname:
+    """Only follow backend-provided URLs that match the trusted backend origin."""
+    dl_origin = _normalized_origin(download_url)
+    be_origin = _normalized_origin(backend_url)
+    if dl_origin is None or be_origin is None:
         return False
-    return dl.hostname == be.hostname
+    return dl_origin == be_origin
 
 
 async def _resolve_music_backend(


### PR DESCRIPTION
Music Studio MVP: a compose API proxying the installed music backend (musicgen/stable-audio); ComposeView streams to /api/music/compose with loading/error/install states. Adds routes/music.py + test. Studio MVP card tsk-vt6rkf. NOTE: touches routes/__init__.py, may need rebase after the coding-workspaces router landed.