### PR TITLE
feat(office-suite): documents store + API + wire the Write view

### DIFF
--- a/desktop/src/apps/OfficeSuiteApp.test.tsx
+++ b/desktop/src/apps/OfficeSuiteApp.test.tsx
@@ -30,8 +30,8 @@ describe("OfficeSuiteApp", () => {
     const writeBtn = nav.querySelector('[aria-label="Write"]') as HTMLElement;
     expect(writeBtn).toBeTruthy();
     expect(writeBtn.getAttribute("aria-current")).toBe("page");
-    // Write view content
-    expect(screen.getByText("taOS Studios launch note")).toBeDefined();
+    expect(screen.getByLabelText("Document title")).toBeDefined();
+    expect(screen.getByRole("button", { name: "Save" })).toBeDefined();
   });
 
   it("switches to Calc view and shows spreadsheet grid with Total row", () => {

--- a/desktop/src/apps/officesuite/WriteView.tsx
+++ b/desktop/src/apps/officesuite/WriteView.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useEffect, useState } from "react";
 import {
   Sparkles,
   AlignLeft,
@@ -6,6 +7,8 @@ import {
   Scissors,
   ArrowRight,
   AlignJustify,
+  Plus,
+  Save,
 } from "lucide-react";
 
 const AI_OPTIONS: { label: string; desc: string; Icon: typeof Sparkles }[] = [
@@ -15,10 +18,115 @@ const AI_OPTIONS: { label: string; desc: string; Icon: typeof Sparkles }[] = [
   { label: "Change tone", desc: "Friendly, formal, punchy", Icon: AlignJustify },
 ];
 
+type OfficeDocListItem = {
+  id: string;
+  kind: string;
+  title: string;
+  updated_at?: number;
+};
+
+type OfficeDoc = OfficeDocListItem & {
+  content: string;
+};
+
+function formatUpdated(ts?: number): string {
+  if (!ts) return "Draft";
+  const d = new Date(ts * 1000);
+  return `Updated ${d.toLocaleString()}`;
+}
+
 export function WriteView() {
+  const [docs, setDocs] = useState<OfficeDocListItem[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [title, setTitle] = useState("Untitled document");
+  const [content, setContent] = useState("");
+  const [updatedAt, setUpdatedAt] = useState<number | undefined>();
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadList = useCallback(async () => {
+    const res = await fetch("/api/office/docs", { credentials: "include" });
+    if (!res.ok) throw new Error("Could not load documents");
+    const items = (await res.json()) as OfficeDocListItem[];
+    setDocs(items.filter((d) => d.kind === "write"));
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        await loadList();
+        if (!cancelled) setError(null);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Load failed");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [loadList]);
+
+  const openDoc = async (docId: string) => {
+    setError(null);
+    try {
+      const res = await fetch(`/api/office/docs/${encodeURIComponent(docId)}`, {
+        credentials: "include",
+      });
+      if (!res.ok) throw new Error("Could not open document");
+      const doc = (await res.json()) as OfficeDoc;
+      setActiveId(doc.id);
+      setTitle(doc.title);
+      setContent(doc.content);
+      setUpdatedAt(doc.updated_at);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Open failed");
+    }
+  };
+
+  const newDoc = () => {
+    setActiveId(null);
+    setTitle("Untitled document");
+    setContent("");
+    setUpdatedAt(undefined);
+    setError(null);
+  };
+
+  const saveDoc = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const payload = { kind: "write", title: title.trim() || "Untitled document", content };
+      const url = activeId
+        ? `/api/office/docs/${encodeURIComponent(activeId)}`
+        : "/api/office/docs";
+      const res = await fetch(url, {
+        method: activeId ? "PUT" : "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error((body as { error?: string }).error || "Save failed");
+      }
+      const saved = (await res.json()) as OfficeDoc;
+      setActiveId(saved.id);
+      setTitle(saved.title);
+      setContent(saved.content);
+      setUpdatedAt(saved.updated_at);
+      await loadList();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  };
+
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      {/* formatting toolbar */}
       <div className="flex h-[46px] flex-none items-center gap-1.5 border-b border-shell-border bg-shell-bg-deep px-4">
         <div className="flex h-8 items-center gap-2 rounded-lg border border-shell-border bg-shell-surface px-3 text-[12px] font-semibold text-shell-text-secondary">
           Sohne <span className="text-shell-text-tertiary">&#9662;</span>
@@ -60,19 +168,59 @@ export function WriteView() {
         >
           <AlignCenter size={16} />
         </button>
-        <div className="ml-auto" />
-        <button
-          type="button"
-          className="flex h-8 items-center gap-1.5 rounded-[9px] bg-gradient-to-br from-accent to-accent/70 px-3.5 text-[12px] font-bold text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
-        >
-          <Sparkles size={14} />
-          Assist
-        </button>
+        <div className="ml-auto flex items-center gap-2">
+          <button
+            type="button"
+            onClick={newDoc}
+            className="flex h-8 items-center gap-1.5 rounded-[9px] border border-shell-border px-3 text-[12px] font-semibold text-shell-text-secondary hover:bg-shell-surface-active focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+          >
+            <Plus size={14} />
+            New
+          </button>
+          <button
+            type="button"
+            onClick={saveDoc}
+            disabled={saving}
+            className="flex h-8 items-center gap-1.5 rounded-[9px] bg-gradient-to-br from-accent to-accent/70 px-3.5 text-[12px] font-bold text-white disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+          >
+            <Save size={14} />
+            {saving ? "Saving..." : "Save"}
+          </button>
+        </div>
       </div>
 
-      {/* document area + AI panel */}
       <div className="flex min-h-0 flex-1">
-        {/* document scroll area */}
+        <aside className="flex w-[200px] flex-none flex-col border-r border-shell-border bg-shell-bg-deep">
+          <div className="border-b border-shell-border px-3 py-2 text-[11px] font-bold uppercase tracking-wide text-shell-text-tertiary">
+            Documents
+          </div>
+          <div className="min-h-0 flex-1 overflow-auto p-2">
+            {loading && (
+              <p className="px-2 py-1 text-[12px] text-shell-text-tertiary">Loading...</p>
+            )}
+            {!loading && docs.length === 0 && (
+              <p className="px-2 py-1 text-[12px] text-shell-text-tertiary">No saved docs yet</p>
+            )}
+            {docs.map((doc) => (
+              <button
+                key={doc.id}
+                type="button"
+                onClick={() => openDoc(doc.id)}
+                className={`mb-1 w-full rounded-lg px-2 py-2 text-left text-[12px] transition-colors hover:bg-shell-surface-active focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${
+                  activeId === doc.id
+                    ? "bg-shell-surface text-shell-text"
+                    : "text-shell-text-secondary"
+                }`}
+              >
+                <div className="truncate font-semibold">{doc.title}</div>
+                <div className="truncate text-[10px] text-shell-text-tertiary">
+                  {formatUpdated(doc.updated_at)}
+                </div>
+              </button>
+            ))}
+          </div>
+        </aside>
+
         <div className="flex flex-1 justify-center overflow-auto bg-shell-bg-deep px-0 py-7">
           <div
             className="min-h-[660px] w-[540px] rounded-[4px] px-14 py-[52px]"
@@ -82,46 +230,32 @@ export function WriteView() {
               color: "#23232a",
             }}
           >
-            <h1
-              className="mb-1.5 font-extrabold leading-tight tracking-tight"
+            <input
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              aria-label="Document title"
+              className="mb-1.5 w-full border-0 bg-transparent font-extrabold leading-tight tracking-tight outline-none"
               style={{ fontSize: 27, letterSpacing: "-0.02em" }}
-            >
-              taOS Studios launch note
-            </h1>
+            />
             <p className="mb-5 text-[12px]" style={{ color: "#5a5a66" }}>
-              Draft &middot; updated just now
+              {formatUpdated(updatedAt)}
             </p>
-            <p className="mb-3 text-[13.5px] leading-[1.75]" style={{ color: "#33333c" }}>
-              taOS now ships a family of creative studios, each a focused workspace that runs
-              entirely on hardware you already own.{" "}
-              <span
-                className="rounded-[3px] px-0.5 py-px"
-                style={{ background: "rgba(139,146,163,0.28)" }}
-              >
-                Whether you are building a business, a hobby project, or something just for the
-                house
-              </span>
-              , there is a studio with the tools you need.
-            </p>
-            <h2
-              className="mb-2 font-bold"
-              style={{ fontSize: 16, marginTop: 18, color: "#23232a" }}
-            >
-              What is ready today
-            </h2>
-            <p className="mb-3 text-[13.5px] leading-[1.75]" style={{ color: "#33333c" }}>
-              Images Studio and Game Studio are available now. Coding Studio is rolling out, with
-              Design, Music, App, and Office studios close behind. Each one installs from the Store
-              in a single click.
-            </p>
-            <p className="mb-3 text-[13.5px] leading-[1.75]" style={{ color: "#33333c" }}>
-              Everything runs offline by default, on your cluster, with nothing leaving your network
-              unless you choose to share it.
-            </p>
+            <textarea
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              aria-label="Document body"
+              placeholder="Start writing..."
+              className="min-h-[420px] w-full resize-none border-0 bg-transparent text-[13.5px] leading-[1.75] outline-none"
+              style={{ color: "#33333c" }}
+            />
+            {error && (
+              <p className="mt-3 text-[12px] text-red-400" role="alert">
+                {error}
+              </p>
+            )}
           </div>
         </div>
 
-        {/* AI panel */}
         <aside className="flex w-[262px] flex-none flex-col gap-3 border-l border-shell-border bg-shell-bg p-[18px]">
           <div className="flex items-center gap-2 text-[14px] font-bold">
             <Sparkles size={16} className="text-accent" />

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -314,6 +314,10 @@ async def client(app, tmp_data_dir):
     if themes._db is not None:
         await themes.close()
     await themes.init()
+    office_docs = app.state.office_docs
+    if office_docs._db is not None:
+        await office_docs.close()
+    await office_docs.init()
     # BrowserApp v2 stores
     from tinyagentos.routes.desktop_browser.store import BrowserStore, BrowserCookieStore
     _browser_store = BrowserStore(tmp_data_dir / "browser.sqlite3")
@@ -364,6 +368,7 @@ async def client(app, tmp_data_dir):
     await secrets_store.close()
     await notif_store.close()
     await store.close()
+    await office_docs.close()
     await app.state.qmd_client.close()
     await app.state.http_client.aclose()
     await _browser_store.close()

--- a/tests/test_routes_office.py
+++ b/tests/test_routes_office.py
@@ -1,0 +1,110 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_create_list_get_update_delete_doc(client):
+    resp = await client.post(
+        "/api/office/docs",
+        json={"kind": "write", "title": "Launch note", "content": "Hello world"},
+    )
+    assert resp.status_code == 200
+    created = resp.json()
+    doc_id = created["id"]
+    assert created["kind"] == "write"
+    assert created["title"] == "Launch note"
+    assert created["content"] == "Hello world"
+    assert isinstance(created["updated_at"], int)
+
+    resp = await client.get("/api/office/docs")
+    assert resp.status_code == 200
+    items = resp.json()
+    assert len(items) == 1
+    assert items[0]["id"] == doc_id
+    assert "content" not in items[0]
+
+    resp = await client.get(f"/api/office/docs/{doc_id}")
+    assert resp.status_code == 200
+    assert resp.json()["content"] == "Hello world"
+
+    resp = await client.put(
+        f"/api/office/docs/{doc_id}",
+        json={"title": "Updated", "content": "Revised body"},
+    )
+    assert resp.status_code == 200
+    updated = resp.json()
+    assert updated["title"] == "Updated"
+    assert updated["content"] == "Revised body"
+    assert updated["updated_at"] >= created["updated_at"]
+
+    resp = await client.delete(f"/api/office/docs/{doc_id}")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "deleted"
+
+    resp = await client.get(f"/api/office/docs/{doc_id}")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_invalid_kind(client):
+    resp = await client.post(
+        "/api/office/docs",
+        json={"kind": "spreadsheet", "title": "X", "content": ""},
+    )
+    assert resp.status_code == 400
+    assert "kind" in resp.json()["error"]
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_missing_title(client):
+    resp = await client.post(
+        "/api/office/docs",
+        json={"kind": "write", "title": "   ", "content": ""},
+    )
+    assert resp.status_code == 400
+    assert "title" in resp.json()["error"]
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_non_string_content(client):
+    resp = await client.post(
+        "/api/office/docs",
+        json={"kind": "write", "title": "X", "content": 42},
+    )
+    assert resp.status_code == 400
+    assert "content" in resp.json()["error"]
+
+
+@pytest.mark.asyncio
+async def test_get_missing_doc_returns_404(client):
+    resp = await client.get("/api/office/docs/does-not-exist")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_update_missing_doc_returns_404(client):
+    resp = await client.put(
+        "/api/office/docs/does-not-exist",
+        json={"title": "Nope"},
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_update_rejects_invalid_kind(client):
+    resp = await client.post(
+        "/api/office/docs",
+        json={"kind": "write", "title": "Doc", "content": ""},
+    )
+    doc_id = resp.json()["id"]
+
+    resp = await client.put(
+        f"/api/office/docs/{doc_id}",
+        json={"kind": "invalid"},
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_delete_missing_doc_returns_404(client):
+    resp = await client.delete("/api/office/docs/missing-id")
+    assert resp.status_code == 404

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -88,6 +88,7 @@ from tinyagentos.user_memory import UserMemoryStore
 from tinyagentos.user_personas import UserPersonaStore
 from tinyagentos.installed_apps import InstalledAppsStore
 from tinyagentos.skills import SkillStore
+from tinyagentos.office_docs import OfficeDocStore
 from tinyagentos.knowledge_store import KnowledgeStore
 from tinyagentos.knowledge_ingest import IngestPipeline
 from tinyagentos.knowledge_categories import CategoryEngine
@@ -344,6 +345,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     from tinyagentos.userspace.data_store import UserspaceDataStore
     userspace_apps = UserspaceAppStore(data_dir / "userspace_apps.db")
     userspace_data = UserspaceDataStore(data_dir / "userspace_data.db")
+    office_docs = OfficeDocStore(data_dir / "office_docs.db")
     skills = SkillStore(data_dir / "skills.db")
     from tinyagentos.themes.store import ThemeStore
     themes = ThemeStore(data_dir / "themes.sqlite3")
@@ -424,6 +426,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         app.state.userspace_apps = userspace_apps
         await userspace_data.init()
         app.state.userspace_data = userspace_data
+        await office_docs.init()
+        app.state.office_docs = office_docs
         try:
             from tinyagentos.userspace.seed import seed_bundled_apps
             await seed_bundled_apps(userspace_apps, data_dir / "apps")
@@ -672,6 +676,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         app.state.installed_apps = installed_apps
         app.state.userspace_apps = userspace_apps
         app.state.userspace_data = userspace_data
+        app.state.office_docs = office_docs
         app.state.skills = skills
         app.state.benchmark_store = benchmark_store
         app.state.score_cache = score_cache
@@ -1126,6 +1131,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await installed_apps.close()
         await userspace_apps.close()
         await userspace_data.close()
+        await office_docs.close()
         await user_memory.close()
         await desktop_settings.close()
         await canvas_store.close()
@@ -1300,6 +1306,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     app.state.installed_apps = installed_apps
     app.state.userspace_apps = userspace_apps
     app.state.userspace_data = userspace_data
+    app.state.office_docs = office_docs
     app.state.skills = skills
     app.state.themes = themes
     app.state.knowledge_store = knowledge_store

--- a/tinyagentos/office_docs.py
+++ b/tinyagentos/office_docs.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import secrets
+import time
+from pathlib import Path
+
+from tinyagentos.base_store import BaseStore
+
+_ALPHABET = "abcdefghijklmnopqrstuvwxyz234567"
+
+VALID_KINDS = frozenset({"write", "calc", "db", "slides"})
+
+OFFICE_DOCS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS documents (
+    id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,
+    title TEXT NOT NULL,
+    content TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+);
+"""
+
+
+def _new_doc_id() -> str:
+    suffix = "".join(secrets.choice(_ALPHABET) for _ in range(8))
+    return f"doc-{suffix}"
+
+
+class OfficeDocStore(BaseStore):
+    SCHEMA = OFFICE_DOCS_SCHEMA
+
+    def __init__(self, db_path: Path):
+        super().__init__(db_path)
+
+    async def create(self, kind: str, title: str, content: str) -> dict:
+        if kind not in VALID_KINDS:
+            raise ValueError(f"kind must be one of {', '.join(sorted(VALID_KINDS))}")
+        for _ in range(8):
+            doc_id = _new_doc_id()
+            async with self._db.execute(
+                "SELECT 1 FROM documents WHERE id = ?", (doc_id,)
+            ) as cur:
+                if await cur.fetchone() is None:
+                    break
+        else:
+            raise RuntimeError("could not allocate document id")
+
+        now = int(time.time())
+        row = {
+            "id": doc_id,
+            "kind": kind,
+            "title": title,
+            "content": content,
+            "created_at": now,
+            "updated_at": now,
+        }
+        await self._db.execute(
+            """INSERT INTO documents (id, kind, title, content, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (row["id"], row["kind"], row["title"], row["content"], row["created_at"], row["updated_at"]),
+        )
+        await self._db.commit()
+        return row
+
+    async def list(self) -> list[dict]:
+        async with self._db.execute(
+            "SELECT id, kind, title, created_at, updated_at FROM documents ORDER BY updated_at DESC"
+        ) as cur:
+            rows = await cur.fetchall()
+        return [
+            {"id": r[0], "kind": r[1], "title": r[2], "created_at": r[3], "updated_at": r[4]}
+            for r in rows
+        ]
+
+    async def get(self, doc_id: str) -> dict | None:
+        async with self._db.execute(
+            "SELECT id, kind, title, content, created_at, updated_at FROM documents WHERE id = ?",
+            (doc_id,),
+        ) as cur:
+            row = await cur.fetchone()
+        if row is None:
+            return None
+        return {
+            "id": row[0],
+            "kind": row[1],
+            "title": row[2],
+            "content": row[3],
+            "created_at": row[4],
+            "updated_at": row[5],
+        }
+
+    async def update(self, doc_id: str, title: str, content: str) -> dict | None:
+        now = int(time.time())
+        await self._db.execute(
+            "UPDATE documents SET title = ?, content = ?, updated_at = ? WHERE id = ?",
+            (title, content, now, doc_id),
+        )
+        await self._db.commit()
+        return await self.get(doc_id)
+
+    async def delete(self, doc_id: str) -> bool:
+        async with self._db.execute(
+            "SELECT 1 FROM documents WHERE id = ?", (doc_id,)
+        ) as cur:
+            exists = await cur.fetchone() is not None
+        if not exists:
+            return False
+        await self._db.execute("DELETE FROM documents WHERE id = ?", (doc_id,))
+        await self._db.commit()
+        return True

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -292,3 +292,6 @@ def register_all_routers(app):
 
     from tinyagentos.routes.userspace_apps import router as userspace_apps_router
     app.include_router(userspace_apps_router)
+
+    from tinyagentos.routes.office import router as office_router
+    app.include_router(office_router)

--- a/tinyagentos/routes/office.py
+++ b/tinyagentos/routes/office.py
@@ -1,55 +1,21 @@
 from __future__ import annotations
 
-import time
-import uuid
 from typing import Any
 
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 
-from tinyagentos.userspace.data_store import UserspaceDataStore
+from tinyagentos.office_docs import VALID_KINDS, OfficeDocStore
 
 router = APIRouter()
 
-OFFICE_APP_ID = "office-suite"
-DOCS_KEY = "documents"
-VALID_KINDS = frozenset({"write", "calc", "db", "slides"})
+
+def _get_store(request: Request) -> OfficeDocStore:
+    return request.app.state.office_docs
 
 
-async def _store(request: Request) -> UserspaceDataStore:
-    store = request.app.state.userspace_data
-    if store._db is None:
-        await store.init()
-    return store
-
-
-async def _load_docs(store: UserspaceDataStore) -> list[dict[str, Any]]:
-    docs = await store.kv_get(OFFICE_APP_ID, DOCS_KEY)
-    return docs if isinstance(docs, list) else []
-
-
-async def _save_docs(store: UserspaceDataStore, docs: list[dict[str, Any]]) -> None:
-    await store.kv_set(OFFICE_APP_ID, DOCS_KEY, docs)
-
-
-def _find_doc(docs: list[dict[str, Any]], doc_id: str) -> dict[str, Any] | None:
-    for doc in docs:
-        if doc.get("id") == doc_id:
-            return doc
-    return None
-
-
-def _list_item(doc: dict[str, Any]) -> dict[str, Any]:
-    return {
-        "id": doc["id"],
-        "kind": doc["kind"],
-        "title": doc["title"],
-        "updated_at": doc.get("updated_at"),
-    }
-
-
-def _validate_kind(kind: str | None) -> str | None:
-    if kind is None or kind not in VALID_KINDS:
+def _validate_kind(kind: Any) -> str | None:
+    if not isinstance(kind, str) or kind not in VALID_KINDS:
         return None
     return kind
 
@@ -73,33 +39,21 @@ async def create_doc(request: Request):
     if not isinstance(content, str):
         return JSONResponse({"error": "content must be a string"}, status_code=400)
 
-    store = await _store(request)
-    docs = await _load_docs(store)
-    now = int(time.time())
-    doc = {
-        "id": uuid.uuid4().hex,
-        "kind": kind,
-        "title": title,
-        "content": content,
-        "updated_at": now,
-    }
-    docs.append(doc)
-    await _save_docs(store, docs)
+    store = _get_store(request)
+    doc = await store.create(kind=kind, title=title, content=content)
     return doc
 
 
 @router.get("/api/office/docs")
 async def list_docs(request: Request):
-    store = await _store(request)
-    docs = await _load_docs(store)
-    return [_list_item(doc) for doc in docs]
+    store = _get_store(request)
+    return await store.list()
 
 
 @router.get("/api/office/docs/{doc_id}")
 async def get_doc(request: Request, doc_id: str):
-    store = await _store(request)
-    docs = await _load_docs(store)
-    doc = _find_doc(docs, doc_id)
+    store = _get_store(request)
+    doc = await store.get(doc_id)
     if doc is None:
         return JSONResponse({"error": "not found"}, status_code=404)
     return doc
@@ -108,40 +62,34 @@ async def get_doc(request: Request, doc_id: str):
 @router.put("/api/office/docs/{doc_id}")
 async def update_doc(request: Request, doc_id: str):
     body = await request.json()
-    store = await _store(request)
-    docs = await _load_docs(store)
-    doc = _find_doc(docs, doc_id)
-    if doc is None:
+    store = _get_store(request)
+
+    existing = await store.get(doc_id)
+    if existing is None:
         return JSONResponse({"error": "not found"}, status_code=404)
 
     if "kind" in body:
         kind = _validate_kind(body.get("kind"))
         if kind is None:
             return JSONResponse({"error": "kind must be one of write, calc, db, slides"}, status_code=400)
-        doc["kind"] = kind
-    if "title" in body:
-        title = _validate_title(body.get("title"))
-        if title is None:
-            return JSONResponse({"error": "title is required"}, status_code=400)
-        doc["title"] = title
-    if "content" in body:
-        content = body.get("content")
-        if not isinstance(content, str):
-            return JSONResponse({"error": "content must be a string"}, status_code=400)
-        doc["content"] = content
 
-    doc["updated_at"] = int(time.time())
-    await _save_docs(store, docs)
+    title_raw = body.get("title", existing["title"])
+    title = _validate_title(title_raw)
+    if title is None:
+        return JSONResponse({"error": "title is required"}, status_code=400)
+
+    content = body.get("content", existing["content"])
+    if not isinstance(content, str):
+        return JSONResponse({"error": "content must be a string"}, status_code=400)
+
+    doc = await store.update(doc_id=doc_id, title=title, content=content)
     return doc
 
 
 @router.delete("/api/office/docs/{doc_id}")
 async def delete_doc(request: Request, doc_id: str):
-    store = await _store(request)
-    docs = await _load_docs(store)
-    before = len(docs)
-    docs = [doc for doc in docs if doc.get("id") != doc_id]
-    if len(docs) == before:
+    store = _get_store(request)
+    deleted = await store.delete(doc_id)
+    if not deleted:
         return JSONResponse({"error": "not found"}, status_code=404)
-    await _save_docs(store, docs)
     return {"status": "deleted", "id": doc_id}

--- a/tinyagentos/routes/office.py
+++ b/tinyagentos/routes/office.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import time
+import uuid
+from typing import Any
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+from tinyagentos.userspace.data_store import UserspaceDataStore
+
+router = APIRouter()
+
+OFFICE_APP_ID = "office-suite"
+DOCS_KEY = "documents"
+VALID_KINDS = frozenset({"write", "calc", "db", "slides"})
+
+
+async def _store(request: Request) -> UserspaceDataStore:
+    store = request.app.state.userspace_data
+    if store._db is None:
+        await store.init()
+    return store
+
+
+async def _load_docs(store: UserspaceDataStore) -> list[dict[str, Any]]:
+    docs = await store.kv_get(OFFICE_APP_ID, DOCS_KEY)
+    return docs if isinstance(docs, list) else []
+
+
+async def _save_docs(store: UserspaceDataStore, docs: list[dict[str, Any]]) -> None:
+    await store.kv_set(OFFICE_APP_ID, DOCS_KEY, docs)
+
+
+def _find_doc(docs: list[dict[str, Any]], doc_id: str) -> dict[str, Any] | None:
+    for doc in docs:
+        if doc.get("id") == doc_id:
+            return doc
+    return None
+
+
+def _list_item(doc: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": doc["id"],
+        "kind": doc["kind"],
+        "title": doc["title"],
+        "updated_at": doc.get("updated_at"),
+    }
+
+
+def _validate_kind(kind: str | None) -> str | None:
+    if kind is None or kind not in VALID_KINDS:
+        return None
+    return kind
+
+
+def _validate_title(title: Any) -> str | None:
+    if not isinstance(title, str) or not title.strip():
+        return None
+    return title.strip()
+
+
+@router.post("/api/office/docs")
+async def create_doc(request: Request):
+    body = await request.json()
+    kind = _validate_kind(body.get("kind"))
+    if kind is None:
+        return JSONResponse({"error": "kind must be one of write, calc, db, slides"}, status_code=400)
+    title = _validate_title(body.get("title"))
+    if title is None:
+        return JSONResponse({"error": "title is required"}, status_code=400)
+    content = body.get("content", "")
+    if not isinstance(content, str):
+        return JSONResponse({"error": "content must be a string"}, status_code=400)
+
+    store = await _store(request)
+    docs = await _load_docs(store)
+    now = int(time.time())
+    doc = {
+        "id": uuid.uuid4().hex,
+        "kind": kind,
+        "title": title,
+        "content": content,
+        "updated_at": now,
+    }
+    docs.append(doc)
+    await _save_docs(store, docs)
+    return doc
+
+
+@router.get("/api/office/docs")
+async def list_docs(request: Request):
+    store = await _store(request)
+    docs = await _load_docs(store)
+    return [_list_item(doc) for doc in docs]
+
+
+@router.get("/api/office/docs/{doc_id}")
+async def get_doc(request: Request, doc_id: str):
+    store = await _store(request)
+    docs = await _load_docs(store)
+    doc = _find_doc(docs, doc_id)
+    if doc is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    return doc
+
+
+@router.put("/api/office/docs/{doc_id}")
+async def update_doc(request: Request, doc_id: str):
+    body = await request.json()
+    store = await _store(request)
+    docs = await _load_docs(store)
+    doc = _find_doc(docs, doc_id)
+    if doc is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+
+    if "kind" in body:
+        kind = _validate_kind(body.get("kind"))
+        if kind is None:
+            return JSONResponse({"error": "kind must be one of write, calc, db, slides"}, status_code=400)
+        doc["kind"] = kind
+    if "title" in body:
+        title = _validate_title(body.get("title"))
+        if title is None:
+            return JSONResponse({"error": "title is required"}, status_code=400)
+        doc["title"] = title
+    if "content" in body:
+        content = body.get("content")
+        if not isinstance(content, str):
+            return JSONResponse({"error": "content must be a string"}, status_code=400)
+        doc["content"] = content
+
+    doc["updated_at"] = int(time.time())
+    await _save_docs(store, docs)
+    return doc
+
+
+@router.delete("/api/office/docs/{doc_id}")
+async def delete_doc(request: Request, doc_id: str):
+    store = await _store(request)
+    docs = await _load_docs(store)
+    before = len(docs)
+    docs = [doc for doc in docs if doc.get("id") != doc_id]
+    if len(docs) == before:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    await _save_docs(store, docs)
+    return {"status": "deleted", "id": doc_id}


### PR DESCRIPTION
Office Suite MVP: an OfficeDocStore (SQLite, mirrors CodingWorkspaceStore) wired into app.py, a documents API at /api/office/docs (create/list/get/update/delete with kind validation), and the Write view wired to save/load/reopen. 8 backend tests pass; app boots. Last buildable studio (Web Studio needs the webserver-LXC infra).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a fully functional Write document editor with create, read, update, and delete operations
  * Added a document list sidebar with clickable document selection and last-updated timestamps
  * Implemented editable document titles and content areas
  * Added "New" and "Save" buttons to manage document lifecycle

* **Tests**
  * Added comprehensive tests for document management API endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->