### PR TITLE
feat(userspace): per-app network permission for sandboxed apps

### DIFF
--- a/tests/userspace/test_package.py
+++ b/tests/userspace/test_package.py
@@ -102,6 +102,13 @@ def test_network_permission_origins_validated():
         "network:ftp://h.com",
         "network:*",
         "network:'unsafe-inline'",
+        "network:wss://h.com\n",
+        "network:wss://h.com\n; script-src x",
     ]:
         with pytest.raises(PackageError):
             parse_manifest(base + "permissions: ['" + bad + "']\n")
+    # gitar finding: `$` would match before a trailing newline; \Z must not.
+    from tinyagentos.userspace.package import _NET_ORIGIN_RE
+    assert _NET_ORIGIN_RE.match("wss://irc-ws.chat.twitch.tv")
+    assert not _NET_ORIGIN_RE.match("wss://evil.com\n")
+    assert not _NET_ORIGIN_RE.match("wss://evil.com\n; script-src 'unsafe-inline'")

--- a/tests/userspace/test_package.py
+++ b/tests/userspace/test_package.py
@@ -87,3 +87,21 @@ def test_extract_rejects_zip_bomb(tmp_path, monkeypatch):
     data = _zip(WEB_MANIFEST, {"index.html": "<h1>more than eight bytes</h1>"})
     with pytest.raises(PackageError, match="uncompressed size too large"):
         extract_package(data, apps_root=tmp_path)
+
+
+def test_network_permission_origins_validated():
+    from tinyagentos.userspace.package import parse_manifest, PackageError
+    import pytest
+    base = "id: x\nname: X\nversion: 1.0.0\napp_type: web\n"
+    ok = parse_manifest(base + "permissions:\n  - 'network:wss://irc-ws.chat.twitch.tv'\n  - 'network:https://*.pusher.com'\n  - 'network:https://youtube.googleapis.com:443'\n")
+    assert "network:wss://irc-ws.chat.twitch.tv" in ok["permissions"]
+    for bad in [
+        "network:javascript:alert(1)",
+        "network:wss://h.com; script-src 'unsafe-inline'",
+        "network:wss://h.com/path",
+        "network:ftp://h.com",
+        "network:*",
+        "network:'unsafe-inline'",
+    ]:
+        with pytest.raises(PackageError):
+            parse_manifest(base + "permissions: ['" + bad + "']\n")

--- a/tests/userspace/test_routes.py
+++ b/tests/userspace/test_routes.py
@@ -134,3 +134,30 @@ async def test_container_install_rejected_with_no_stored_state(client):
     # No app row stored.
     rows = (await client.get("/api/userspace-apps")).json()
     assert all(a["app_id"] != "ctapp" for a in rows)
+
+
+def _net_zip():
+    manifest = ("id: net\nname: Net\nversion: 1.0.0\napp_type: web\nentry: index.html\n"
+                "icon: icon.png\npermissions:\n  - 'network:wss://irc-ws.chat.twitch.tv'\n")
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        z.writestr("manifest.yaml", manifest)
+        z.writestr("index.html", "<h1>net</h1>")
+        z.writestr("icon.png", "x")
+    return buf.getvalue()
+
+
+@pytest.mark.asyncio
+async def test_bundle_csp_reflects_granted_network_permission(client):
+    await client.post("/api/userspace-apps/install",
+                      files={"package": ("net.taosapp", _net_zip(), "application/zip")})
+    # Before granting, connect-src stays locked to 'self'.
+    r = await client.get("/api/userspace-apps/net/bundle/index.html")
+    csp = r.headers["content-security-policy"]
+    assert "connect-src 'self';" in csp and "twitch" not in csp
+    # Grant the declared network permission -> the origin appears in connect-src.
+    await client.post("/api/userspace-apps/net/permissions",
+                      json={"granted": ["network:wss://irc-ws.chat.twitch.tv"]})
+    r = await client.get("/api/userspace-apps/net/bundle/index.html")
+    csp = r.headers["content-security-policy"]
+    assert "connect-src 'self' wss://irc-ws.chat.twitch.tv;" in csp

--- a/tinyagentos/routes/userspace_apps.py
+++ b/tinyagentos/routes/userspace_apps.py
@@ -16,42 +16,28 @@ router = APIRouter()
 
 _SDK_PATH = Path(__file__).resolve().parent.parent / "userspace" / "sdk" / "taos-app-sdk.js"
 
-# Bundle CSP for community (untrusted) packages. The `sandbox allow-scripts`
+# Bundle CSP for sandboxed userspace packages. The `sandbox allow-scripts`
 # directive (no allow-same-origin) forces the document into an OPAQUE origin
 # even on a direct top-level navigation -- so a userspace bundle can never
 # execute on the core origin with the session cookie (defends against stored
 # XSS), while still letting the app run its own scripts inside our sandboxed
-# iframe. `default-src 'none'` plus the explicit self/inline allowances keep
-# it locked down.
-_BUNDLE_CSP = (
-    "sandbox allow-scripts allow-forms allow-popups; "
-    "default-src 'none'; "
-    "script-src 'self' 'unsafe-inline' blob:; "
-    "style-src 'self' 'unsafe-inline'; "
-    "img-src 'self' data: blob:; "
-    "font-src 'self' data:; "
-    "connect-src 'self'; "
-    "frame-ancestors 'self'; base-uri 'none'"
-)
-
-# Relaxed CSP for first-party packages (studios). Still sandboxed -- NEVER
-# add allow-same-origin; that would collapse the opaque-origin isolation and
-# let the frame access session cookies. The relaxations over community:
-#   - style-src allows 'unsafe-inline' (community already does, kept the same)
-#   - connect-src 'self' (same as community; lets the SDK reach the broker)
-# The intent is that P4 boot-seeding and P2 signature verification are the
-# ONLY paths that write trust='first-party'; this CSP is not itself a trust
-# grant, just a consequence of trust already verified out-of-band.
-_BUNDLE_CSP_FIRST_PARTY = (
-    "sandbox allow-scripts allow-forms allow-popups; "
-    "default-src 'none'; "
-    "script-src 'self' 'unsafe-inline' blob:; "
-    "style-src 'self' 'unsafe-inline'; "
-    "img-src 'self' data: blob:; "
-    "font-src 'self' data:; "
-    "connect-src 'self'; "
-    "frame-ancestors 'self'; base-uri 'none'"
-)
+# iframe. `default-src 'none'` plus the explicit self/inline allowances keep it
+# locked down. connect-src defaults to 'self' (the broker only); an app the
+# user has granted `network:<origin>` permissions gets exactly those origins
+# added to connect-src and nothing else (each origin is strictly validated at
+# manifest-parse time, so it cannot inject other CSP directives).
+def _bundle_csp(net_origins: list[str]) -> str:
+    connect = "connect-src 'self'" + "".join(" " + o for o in net_origins)
+    return (
+        "sandbox allow-scripts allow-forms allow-popups; "
+        "default-src 'none'; "
+        "script-src 'self' 'unsafe-inline' blob:; "
+        "style-src 'self' 'unsafe-inline'; "
+        "img-src 'self' data: blob:; "
+        "font-src 'self' data:; "
+        f"{connect}; "
+        "frame-ancestors 'self'; base-uri 'none'"
+    )
 
 
 def _apps_root(request: Request) -> Path:
@@ -212,9 +198,11 @@ async def serve_bundle(request: Request, app_id: str, path: str):
     if not target.is_relative_to(root) or target == root or not target.is_file():
         return JSONResponse({"error": "not found"}, status_code=404)
     app = await request.app.state.userspace_apps.get(app_id)
-    csp = _BUNDLE_CSP_FIRST_PARTY if (app and app.get("trust") == "first-party") else _BUNDLE_CSP
+    granted = (app or {}).get("permissions_granted") or []
+    net_origins = [p[len("network:"):] for p in granted
+                   if isinstance(p, str) and p.startswith("network:")]
     resp = FileResponse(target)
-    resp.headers["Content-Security-Policy"] = csp
+    resp.headers["Content-Security-Policy"] = _bundle_csp(net_origins)
     resp.headers["X-Content-Type-Options"] = "nosniff"
     return resp
 

--- a/tinyagentos/userspace/package.py
+++ b/tinyagentos/userspace/package.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
 import io
+import re
 import zipfile
 from pathlib import Path
 
 import yaml
+
+# A `network:<origin>` permission lets a granted app's bundle connect to that
+# external origin (it is added to the sandbox CSP connect-src). The origin is
+# strictly validated so it can never inject extra CSP directives: scheme://host
+# with an optional leading "*." subdomain wildcard and an optional :port, and
+# nothing else (no spaces, semicolons, quotes, or paths).
+_NET_ORIGIN_RE = re.compile(r"^(?:wss|https)://(?:\*\.)?[A-Za-z0-9.-]+(?::\d+)?$")
 
 _ALLOWED_TYPES = {"web", "container"}
 _REQUIRED = ("id", "name", "version", "app_type")
@@ -52,6 +60,17 @@ def parse_manifest(text: str) -> dict:
     data.setdefault("entry", "index.html")
     data.setdefault("icon", "")
     data.setdefault("permissions", [])
+    if not isinstance(data["permissions"], list):
+        raise PackageError("manifest 'permissions' must be a list")
+    for perm in data["permissions"]:
+        if isinstance(perm, str) and perm.startswith("network:"):
+            origin = perm[len("network:"):]
+            if not _NET_ORIGIN_RE.match(origin):
+                raise PackageError(
+                    f"invalid network permission origin {origin!r}: must be "
+                    "wss://host or https://host with an optional *. subdomain "
+                    "wildcard and an optional :port, nothing else"
+                )
     return data
 
 

--- a/tinyagentos/userspace/package.py
+++ b/tinyagentos/userspace/package.py
@@ -11,8 +11,10 @@ import yaml
 # external origin (it is added to the sandbox CSP connect-src). The origin is
 # strictly validated so it can never inject extra CSP directives: scheme://host
 # with an optional leading "*." subdomain wildcard and an optional :port, and
-# nothing else (no spaces, semicolons, quotes, or paths).
-_NET_ORIGIN_RE = re.compile(r"^(?:wss|https)://(?:\*\.)?[A-Za-z0-9.-]+(?::\d+)?$")
+# nothing else (no spaces, semicolons, quotes, paths, or newlines). \A and \Z
+# anchor the WHOLE string -- `$` would also match just before a trailing
+# newline, which would let "wss://host\n; ..." slip a newline into the value.
+_NET_ORIGIN_RE = re.compile(r"\A(?:wss|https)://(?:\*\.)?[A-Za-z0-9.-]+(?::\d+)?\Z")
 
 _ALLOWED_TYPES = {"web", "container"}
 _REQUIRED = ("id", "name", "version", "app_type")


### PR DESCRIPTION
Adds a `network:<origin>` userspace-app permission. When granted, the declared origin is added to the bundle's CSP `connect-src`, letting a sandboxed app reach approved external services (the enabler for a private Stream Chat app connecting to Twitch IRC + Kick over WebSocket). Origins are strictly validated at manifest parse so they cannot inject other CSP directives. Tests cover origin validation + the grant-to-CSP path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for network permission validation and dynamic content security policy behavior.

* **Security**
  * Network origins in permissions are now strictly validated, accepting only well-formed `https://` and `wss://` endpoints while rejecting malformed entries.
  * Content Security Policy now dynamically reflects granted network permissions, restricting network access to authorized origins only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->