### PR TITLE
fix: Coding Studio + Design Studio gitar findings (fix-forward)

### DIFF
--- a/desktop/src/apps/codingstudio/CodeView.tsx
+++ b/desktop/src/apps/codingstudio/CodeView.tsx
@@ -226,8 +226,15 @@ export function CodeView() {
   const [treeError, setTreeError] = useState<string | null>(null);
 
   const [activePath, setActivePath] = useState<string | null>(null);
+  // fileContent: initial content passed to the editor on file open (drives editor recreation)
   const [fileContent, setFileContent] = useState<string>("");
+  // savedContent: last-saved baseline for dirty tracking (NOT passed to editor after initial load)
+  const [savedContent, setSavedContent] = useState<string>("");
   const [editedContent, setEditedContent] = useState<string>("");
+  // tracks the last-requested path so stale concurrent fetch responses are ignored
+  const latestRequestedPath = useRef<string | null>(null);
+  // ref so openFile callback can always read the current dirty state without stale closure
+  const isDirtyRef = useRef(false);
   const [fileLoading, setFileLoading] = useState(false);
   const [fileError, setFileError] = useState<string | null>(null);
 
@@ -301,6 +308,7 @@ export function CodeView() {
     setTree([]);
     setActivePath(null);
     setFileContent("");
+    setSavedContent("");
     setEditedContent("");
     setTreeError(null);
     setTreeLoading(true);
@@ -357,6 +365,13 @@ export function CodeView() {
   const openFile = useCallback(
     async (path: string) => {
       if (!activeWs) return;
+      if (isDirtyRef.current) {
+        const ok = window.confirm(
+          "You have unsaved changes. Discard them and open the new file?",
+        );
+        if (!ok) return;
+      }
+      latestRequestedPath.current = path;
       setActivePath(path);
       setFileLoading(true);
       setFileError(null);
@@ -368,9 +383,13 @@ export function CodeView() {
         );
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const data: { path: string; content: string } = await res.json();
+        // discard response if a newer openFile call has already taken over
+        if (latestRequestedPath.current !== path) return;
         setFileContent(data.content);
+        setSavedContent(data.content);
         setEditedContent(data.content);
       } catch (err) {
+        if (latestRequestedPath.current !== path) return;
         setFileError(err instanceof Error ? err.message : "Failed to load file");
         setFileLoading(false);
         return;
@@ -394,7 +413,9 @@ export function CodeView() {
         body: JSON.stringify({ path: activePath, content: editedContent }),
       });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      setFileContent(editedContent);
+      // update savedContent, not fileContent -- fileContent drives editor recreation
+      // so touching it after the initial load would destroy cursor position + undo history
+      setSavedContent(editedContent);
       setSavedOk(true);
       setTimeout(() => setSavedOk(false), 2000);
     } catch (err) {
@@ -404,7 +425,8 @@ export function CodeView() {
     }
   }, [activeWs, activePath, editedContent]);
 
-  const isDirty = editedContent !== fileContent;
+  const isDirty = editedContent !== savedContent;
+  isDirtyRef.current = isDirty;
 
   /* ── render ─────────────────────────────────────────────── */
 
@@ -421,28 +443,37 @@ export function CodeView() {
         <div className="flex items-center gap-2">
           {wsLoading ? (
             <span className="text-[12px] text-shell-text-tertiary">Loading...</span>
-          ) : wsError ? (
-            <span className="flex items-center gap-1 text-[12px] text-red-400">
-              <AlertCircle size={13} />
-              {wsError}
-            </span>
           ) : (
-            <select
-              aria-label="Select workspace"
-              value={activeWs?.id ?? ""}
-              onChange={(e) => {
-                const ws = workspaces.find((w) => w.id === e.target.value) ?? null;
-                setActiveWs(ws);
-              }}
-              className="h-[28px] rounded-[9px] border border-shell-border bg-shell-surface px-2 text-[12px] text-shell-text focus:outline-none focus:ring-1 focus:ring-accent/40"
-            >
-              <option value="">-- select workspace --</option>
-              {workspaces.map((ws) => (
-                <option key={ws.id} value={ws.id}>
-                  {ws.name}
-                </option>
-              ))}
-            </select>
+            <>
+              {wsError && (
+                <span className="flex items-center gap-1 text-[12px] text-red-400">
+                  <AlertCircle size={13} />
+                  {wsError}
+                </span>
+              )}
+              <select
+                aria-label="Select workspace"
+                value={activeWs?.id ?? ""}
+                onChange={(e) => {
+                  const ws = workspaces.find((w) => w.id === e.target.value) ?? null;
+                  if (isDirty) {
+                    const ok = window.confirm(
+                      "You have unsaved changes. Discard them and switch workspace?",
+                    );
+                    if (!ok) return;
+                  }
+                  setActiveWs(ws);
+                }}
+                className="h-[28px] rounded-[9px] border border-shell-border bg-shell-surface px-2 text-[12px] text-shell-text focus:outline-none focus:ring-1 focus:ring-accent/40"
+              >
+                <option value="">-- select workspace --</option>
+                {workspaces.map((ws) => (
+                  <option key={ws.id} value={ws.id}>
+                    {ws.name}
+                  </option>
+                ))}
+              </select>
+            </>
           )}
 
           <button


### PR DESCRIPTION
## Summary

Fix-forward for gitar-flagged bugs on PRs #1010 (Coding Studio) and #1002 (Design Studio).

## Findings and resolutions

**Finding 1 -- CodeView.tsx openFile() concurrent fetch race**

Confirmed. Clicking files in rapid succession fires parallel fetches; a slow earlier response arriving after a newer one would replace the editor content with the wrong file. Fixed by tracking `latestRequestedPath` in a ref. When a response arrives, it is silently discarded if `latestRequestedPath.current !== path`.

**Finding 2 -- CodeView.tsx saveFile() loses cursor position and undo history**

Confirmed. The original `saveFile` called `setFileContent(editedContent)` on success. `CodeEditor` recreates the whole editor in a `useEffect([content])`, so updating `fileContent` state post-save destroyed the undo stack and cursor position. Fixed by introducing a separate `savedContent` state as the dirty-tracking baseline. `saveFile` now calls `setSavedContent(editedContent)` instead of `setFileContent`, so `fileContent` (the prop that drives `useEffect([content])`) is never touched after the initial open, and the editor is not recreated. `isDirty = editedContent !== savedContent` retains correct behaviour.

**Finding 3 -- CodeView.tsx createWorkspace() error hides workspace picker**

Confirmed. The header used a ternary: loading spinner OR error span OR select. On `wsError`, the select was replaced by the error, leaving the user unable to switch workspaces. Fixed by rendering the error inline (conditionally) above the always-visible select, inside a React fragment. The picker is now always shown after the loading phase.

**Finding 4 -- CodeView.tsx file switch and workspace switch silently discard unsaved edits**

Confirmed. Neither `openFile` nor the workspace `<select>` onChange checked `isDirty`. Fixed: both now call `window.confirm` before proceeding when `isDirtyRef.current` is true. The ref keeps `openFile`'s closure stable without adding `isDirty` (a render-time value) as a dependency.

**Finding 5 -- DesignStudioApp.tsx runGenerate() silent ok-but-unusable response**

Does not reproduce on origin/dev. The current `runGenerate` already handles the full matrix: `content-type` check with an explicit error when non-JSON, a `try/catch` around `res.json()` with "returned invalid JSON" error, `data.error` surface, and a final else "returned no image data" message. No code change needed; noted here for the record.

## Test plan

- [ ] Build passes (`npm run build` in `desktop/` -- verified locally, clean output)
- [ ] Click two files quickly in Coding Studio, confirm only the second file's content loads
- [ ] Open a file, edit it, click a different file -- confirm discard prompt appears; cancel keeps the current file and edits intact
- [ ] Edit a file and save -- confirm the Save button goes dim, the amber dirty dot clears, and the cursor/scroll position are unchanged
- [ ] Trigger a workspace create failure (e.g. network off) -- confirm the error message appears alongside the workspace picker, not replacing it
- [ ] Have unsaved edits and switch workspaces via the dropdown -- confirm discard prompt appears

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added confirmation prompts when opening files or switching workspaces with unsaved changes present.
  * Cursor position and undo history are now preserved after saving files.
  * Workspace selector error messages display more prominently.
  * Improved handling of concurrent file load requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->