### PR TITLE
fix(office-suite): persist kind on document update (gitar fix-forward)

### DIFF
--- a/tests/test_routes_office.py
+++ b/tests/test_routes_office.py
@@ -108,3 +108,22 @@ async def test_update_rejects_invalid_kind(client):
 async def test_delete_missing_doc_returns_404(client):
     resp = await client.delete("/api/office/docs/missing-id")
     assert resp.status_code == 404
+
+@pytest.mark.asyncio
+async def test_update_persists_valid_kind(client):
+    resp = await client.post(
+        "/api/office/docs",
+        json={"kind": "write", "title": "Doc", "content": "body"},
+    )
+    doc_id = resp.json()["id"]
+
+    resp = await client.put(
+        f"/api/office/docs/{doc_id}",
+        json={"kind": "calc", "title": "Doc", "content": "body"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["kind"] == "calc"
+
+    # The change is persisted, not just echoed.
+    resp = await client.get(f"/api/office/docs/{doc_id}")
+    assert resp.json()["kind"] == "calc"

--- a/tinyagentos/office_docs.py
+++ b/tinyagentos/office_docs.py
@@ -90,12 +90,22 @@ class OfficeDocStore(BaseStore):
             "updated_at": row[5],
         }
 
-    async def update(self, doc_id: str, title: str, content: str) -> dict | None:
+    async def update(
+        self, doc_id: str, title: str, content: str, kind: str | None = None
+    ) -> dict | None:
         now = int(time.time())
-        await self._db.execute(
-            "UPDATE documents SET title = ?, content = ?, updated_at = ? WHERE id = ?",
-            (title, content, now, doc_id),
-        )
+        if kind is not None:
+            if kind not in VALID_KINDS:
+                raise ValueError(f"kind must be one of {', '.join(sorted(VALID_KINDS))}")
+            await self._db.execute(
+                "UPDATE documents SET kind = ?, title = ?, content = ?, updated_at = ? WHERE id = ?",
+                (kind, title, content, now, doc_id),
+            )
+        else:
+            await self._db.execute(
+                "UPDATE documents SET title = ?, content = ?, updated_at = ? WHERE id = ?",
+                (title, content, now, doc_id),
+            )
         await self._db.commit()
         return await self.get(doc_id)
 

--- a/tinyagentos/routes/office.py
+++ b/tinyagentos/routes/office.py
@@ -68,6 +68,7 @@ async def update_doc(request: Request, doc_id: str):
     if existing is None:
         return JSONResponse({"error": "not found"}, status_code=404)
 
+    kind = None
     if "kind" in body:
         kind = _validate_kind(body.get("kind"))
         if kind is None:
@@ -82,7 +83,7 @@ async def update_doc(request: Request, doc_id: str):
     if not isinstance(content, str):
         return JSONResponse({"error": "content must be a string"}, status_code=400)
 
-    doc = await store.update(doc_id=doc_id, title=title, content=content)
+    doc = await store.update(doc_id=doc_id, title=title, content=content, kind=kind)
     return doc
 
 


### PR DESCRIPTION
Fix-forward for a gitar-bot finding on the merged Office Suite PR #1011.

**Bug fixed:** `update_doc` validated the `kind` field (400 on invalid) but never passed it to `OfficeDocStore.update`, so a valid kind change was silently dropped. Now threaded through and persisted; a test asserts the change survives a re-fetch.

**Also reviewed from the same gitar batch, no change made (with rationale):**
- *office_docs.create SELECT-then-INSERT not atomic*: ids come from a high-entropy `_new_doc_id()` and the id column is the primary key, so a real collision is astronomically unlikely and would fail the INSERT anyway. Left as-is.
- *Office mutating routes lack verify_csrf*: this is a **systemic** posture, not office-specific. `verify_csrf` is currently applied to only 1 of 78 route files (auth.py), and the `taos_session` cookie is already `HttpOnly; SameSite=Strict`, which blocks cross-site sends at the browser level. Spot-adding the double-submit layer to office alone would be inconsistent. Flagging for a project-level decision on whether to roll out `verify_csrf` across all mutating routes (touches every route + its tests) rather than fixing it piecemeal here.

Tests: `tests/test_routes_office.py` 9 passed.