### PR TITLE
fix(coding-workspaces): address gitar follow-up findings on #995

### DIFF
--- a/tests/test_coding_workspaces.py
+++ b/tests/test_coding_workspaces.py
@@ -122,7 +122,63 @@ async def test_read_binary_file_rejected(coding_client):
         params={"path": "blob.bin"},
     )
     assert r.status_code == 400
-    assert r.json()["error"] == "binary file"
+    assert r.json()["error"] == "binary_or_undecodable"
+
+
+@pytest.mark.asyncio
+async def test_list_root_empty_workspace(coding_client):
+    client, _app = coding_client
+    r = await client.post("/api/coding/workspaces", json={"name": "fresh-root"})
+    ws = r.json()
+
+    r = await client.get(f"/api/coding/workspaces/{ws['id']}/files")
+    assert r.status_code == 200
+    names = {e["name"] for e in r.json()}
+    assert ".git" in names
+
+    r = await client.get(f"/api/coding/workspaces/{ws['id']}/files", params={"subpath": ""})
+    assert r.status_code == 200
+
+    r = await client.get(f"/api/coding/workspaces/{ws['id']}/files", params={"subpath": "."})
+    assert r.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_read_oversized_file_rejected(coding_client):
+    client, app = coding_client
+    r = await client.post("/api/coding/workspaces", json={"name": "bigfile"})
+    ws = r.json()
+    workspace_dir = app.state.data_dir / "coding-workspaces" / ws["id"]
+    (workspace_dir / "huge.txt").write_bytes(b"x" * (2_000_001))
+
+    r = await client.get(
+        f"/api/coding/workspaces/{ws['id']}/file",
+        params={"path": "huge.txt"},
+    )
+    assert r.status_code == 400
+    assert r.json()["error"] == "file too large"
+
+
+@pytest.mark.asyncio
+async def test_git_init_failure_no_orphan_dir(coding_client, monkeypatch):
+    client, app = coding_client
+
+    async def _fake_git_init(self, workspace_dir):
+        raise RuntimeError("git init failed")
+
+    monkeypatch.setattr(
+        app.state.coding_workspaces.__class__, "_git_init", _fake_git_init
+    )
+
+    r = await client.post("/api/coding/workspaces", json={"name": "broken-git"})
+    assert r.status_code == 500
+
+    rows = app.state.coding_workspaces
+    listed = await rows.list()
+    assert all(row["name"] != "broken-git" for row in listed)
+
+    workspace_dirs = list((app.state.data_dir / "coding-workspaces").iterdir())
+    assert all(d.name != "broken-git" for d in workspace_dirs if d.is_dir())
 
 
 @pytest.mark.asyncio

--- a/tinyagentos/routes/coding.py
+++ b/tinyagentos/routes/coding.py
@@ -24,7 +24,7 @@ def _invalid_rel_path(rel: str) -> bool:
     return ".." in Path(rel).parts
 
 
-_MAX_READ_BYTES = 1_000_000
+_MAX_READ_BYTES = 2_000_000
 
 
 def _resolve_jailed(root: Path, rel: str, *, allow_root: bool = False) -> Path | None:
@@ -96,8 +96,8 @@ async def read_file(request: Request, workspace_id: str, path: str):
         return JSONResponse({"error": "file too large"}, status_code=400)
     try:
         content = target.read_text(encoding="utf-8")
-    except UnicodeDecodeError:
-        return JSONResponse({"error": "binary file"}, status_code=400)
+    except (UnicodeDecodeError, OSError):
+        return JSONResponse({"error": "binary_or_undecodable"}, status_code=400)
     return {"path": path, "content": content}
 
 


### PR DESCRIPTION
Autonomous build of board card tsk-lfkrkc.



Files:
 tests/test_coding_workspaces.py | 58 ++++++++++++++++++++++++++++++++++++++++-
 tinyagentos/routes/coding.py    |  6 ++---
 2 files changed, 60 insertions(+), 4 deletions(-)

----
## Summary by Gitar

- **Configuration updates:**
  - Increased `_MAX_READ_BYTES` to `2_000_000` bytes for file read operations.
- **Error handling:**
  - Updated `read_file` to catch `OSError` and report `binary_or_undecodable` instead of generic binary file errors.
- **Testing enhancements:**
  - Added test coverage for root directory listing, oversized file rejection, and cleanup on failed `git init` calls.

<sub>This will update automatically on new commits.</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased maximum file size limit to 2 MB for read operations.

* **Bug Fixes**
  * Improved error handling and messaging for binary and undecodable files during read operations.

* **Tests**
  * Extended workspace test coverage for file listing, oversized file rejection, and initialization failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->