### PR TITLE
fix(coding-workspaces): robust git init + clean failure handling (unblocks CI)

### DIFF
--- a/tests/test_coding_workspaces.py
+++ b/tests/test_coding_workspaces.py
@@ -171,14 +171,18 @@ async def test_git_init_failure_no_orphan_dir(coding_client, monkeypatch):
     )
 
     r = await client.post("/api/coding/workspaces", json={"name": "broken-git"})
-    assert r.status_code == 500
+    assert r.status_code == 503
 
     rows = app.state.coding_workspaces
     listed = await rows.list()
     assert all(row["name"] != "broken-git" for row in listed)
 
-    workspace_dirs = list((app.state.data_dir / "coding-workspaces").iterdir())
-    assert all(d.name != "broken-git" for d in workspace_dirs if d.is_dir())
+    # The store rmtree's the workspace dir when git init fails, so no orphan dir
+    # (named by its generated id, never "broken-git") is left behind.
+    workspace_dirs = [
+        d for d in (app.state.data_dir / "coding-workspaces").iterdir() if d.is_dir()
+    ]
+    assert workspace_dirs == []
 
 
 @pytest.mark.asyncio

--- a/tinyagentos/coding_workspaces.py
+++ b/tinyagentos/coding_workspaces.py
@@ -33,16 +33,24 @@ class CodingWorkspaceStore(BaseStore):
         self.workspaces_root = workspaces_root
 
     async def _git_init(self, workspace_dir: Path) -> None:
-        proc = await asyncio.create_subprocess_exec(
-            "git",
-            "init",
-            cwd=str(workspace_dir),
-            stdout=asyncio.subprocess.DEVNULL,
-            stderr=asyncio.subprocess.DEVNULL,
-        )
-        await proc.wait()
-        if proc.returncode != 0:
-            raise RuntimeError("git init failed")
+        # git init can transiently fail under parallel CI/test load. Retry once
+        # and capture stderr so a real failure is diagnosable instead of an
+        # opaque "git init failed". -q suppresses the default-branch hint.
+        last_err = ""
+        for _ in range(2):
+            proc = await asyncio.create_subprocess_exec(
+                "git",
+                "init",
+                "-q",
+                cwd=str(workspace_dir),
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            _out, err = await proc.communicate()
+            if proc.returncode == 0:
+                return
+            last_err = (err or b"").decode("utf-8", "replace").strip()
+        raise RuntimeError(f"git init failed: {last_err or 'unknown error'}")
 
     async def create(self, name: str) -> dict:
         self.workspaces_root.mkdir(parents=True, exist_ok=True)

--- a/tinyagentos/routes/coding.py
+++ b/tinyagentos/routes/coding.py
@@ -56,7 +56,12 @@ async def create_workspace(request: Request, body: CreateWorkspaceBody):
     if not name:
         return JSONResponse({"error": "name is required"}, status_code=400)
     store = request.app.state.coding_workspaces
-    row = await store.create(name)
+    try:
+        row = await store.create(name)
+    except RuntimeError as exc:
+        # workspace creation (git init / id allocation) failed -- surface a
+        # clean error instead of letting it escape as an unhandled 500.
+        return JSONResponse({"error": str(exc)}, status_code=503)
     return row
 
 


### PR DESCRIPTION
The coding-workspace git-init-failure path escaped as an unhandled exception. httpx's ASGI transport re-raises app exceptions, so this intermittently reddened CI (`RuntimeError: git init failed` / 'unhandled errors in a TaskGroup') and blocked PRs like #1018.

- `_git_init`: retry once + capture stderr (`-q`) so a real failure is diagnosable and transient CI flakes self-heal.
- `create_workspace`: catch the RuntimeError, return a clean **503** instead of a 500 from an unhandled exception.
- Test: expect 503 and fix the orphan-dir assertion (the gitar finding) -- it checked for a dir named 'broken-git' that never exists (dirs are id-named); now asserts no orphan dir is left after the cleanup.

10/10 coding-workspace tests pass locally.