### PR TITLE
fix(test): add missing _make_registry helper (unblock dev)

### DIFF
--- a/tests/test_litellm_config.py
+++ b/tests/test_litellm_config.py
@@ -837,6 +837,14 @@ class TestDiscoverOllamaBackendsConcurrent:
 
 class TestLocalBackendModelsFromRegistry:
 
+    def _make_registry(self, installed, manifests):
+        class _Reg:
+            def list_installed(self):
+                return installed
+            def get(self, mid):
+                return manifests.get(mid)
+        return _Reg()
+
     def test_returns_empty_for_none_registry(self):
         backend = {"name": "local-foo"}
         assert _local_backend_models_from_registry(backend, None) == []


### PR DESCRIPTION
The other half of the blind-gate fallout: #1024's two litellm_config tests (test_deduplicates_matched_models, test_non_dict_variant_skipped) call self._make_registry, but TestLocalBackendModelsFromRegistry never defined it (the helper lives on a sibling class), so they errored with AttributeError and kept dev red. Adds the small helper to the class. 89/89 litellm_config tests pass.

----
## Summary by Gitar

- **New API routes:**
  - Implemented `coding` workspace management (create, list, file R/W, delete) and `music` composition endpoints (status, compose, list).
  - Added `office` document management (CRUD) and notification preference endpoints.
- **Frontend studio enhancements:**
  - Introduced `CodeView` with `CodeMirror` integration for workspace file editing.
  - Updated `WriteView` in `OfficeSuiteApp` to support document listing and editing.
  - Enhanced `DesignStudioApp` with image generation workflows via `MagicView` and model browser integration.
  - Refactored `BuildView` in `AppStudioApp` to support interactive prompt streaming for agent-based app generation.
- **Security & Infrastructure:**
  - Updated `_bundle_csp` in `userspace_apps.py` to dynamically include permitted network origins.
  - Added notification event emission on task updates (`claim`, `close`).
- **Test suite expansion:**
  - Added extensive unit test coverage for `litellm_config`, `system_stats`, `frameworks.py`, `auth_middleware`, and various routing logic.


<sub>This will update automatically on new commits.</sub>