### PR TITLE
fix(board): remove auto purple gradient cover from kanban cards

### DIFF
--- a/desktop/src/apps/ProjectsApp/board/TaskCardCover.tsx
+++ b/desktop/src/apps/ProjectsApp/board/TaskCardCover.tsx
@@ -52,6 +52,5 @@ export function inferCoverKind(task: { labels: string[]; priority: number }): Co
     const k = lbl.slice("cover:".length) as CoverKind;
     if (["gradient", "code", "terminal", "screenshot", "none"].includes(k)) return k;
   }
-  if (task.priority <= 1) return "gradient";
   return "none";
 }


### PR DESCRIPTION
Some kanban task cards showed a purple-to-cyan gradient banner while others did not, because inferCoverKind auto-assigned the gradient cover to any task with priority <= 1. Removing that one auto-rule makes every default card render identically. The cover feature itself is untouched and still works for explicit cover: labels (the promo-hero use), so nothing is orphaned. tsc clean; the TaskCardCover component tests are unaffected since they exercise the component by explicit kind, not the heuristic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated task card cover determination to use explicit labels instead of priority-based logic, with "none" as the default when no cover label is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->