### PR TITLE
let a chat channel be assigned to a project after creation, and let th

### DIFF
--- a/tests/test_channel_project.py
+++ b/tests/test_channel_project.py
@@ -1,0 +1,75 @@
+"""Tests for channel project tagging: set_project and project_id filter."""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+
+from tinyagentos.chat.channel_store import ChatChannelStore
+
+
+@pytest_asyncio.fixture
+async def store(tmp_path):
+    s = ChatChannelStore(tmp_path / "chat.db")
+    await s.init()
+    yield s
+    await s.close()
+
+
+async def _create(store, name="general", project_id="", **kw):
+    return await store.create_channel(
+        name=name, type="text", created_by="user1", project_id=project_id, **kw
+    )
+
+
+@pytest.mark.asyncio
+async def test_set_project_updates_row(store):
+    ch = await _create(store, name="ch1", project_id="")
+    assert ch["project_id"] == ""
+
+    await store.set_project(ch["id"], "prj-alpha")
+
+    updated = await store.get_channel(ch["id"])
+    assert updated["project_id"] == "prj-alpha"
+
+
+@pytest.mark.asyncio
+async def test_set_project_can_clear(store):
+    ch = await _create(store, name="ch1", project_id="prj-beta")
+    assert ch["project_id"] == "prj-beta"
+
+    await store.set_project(ch["id"], "")
+
+    updated = await store.get_channel(ch["id"])
+    assert updated["project_id"] == ""
+
+
+@pytest.mark.asyncio
+async def test_list_channels_filtered_by_project(store):
+    a = await _create(store, name="a", project_id="prj-1")
+    b = await _create(store, name="b", project_id="prj-2")
+    c = await _create(store, name="c", project_id="prj-1")
+
+    result = await store.list_channels(project_id="prj-1")
+    ids = [ch["id"] for ch in result]
+    assert a["id"] in ids
+    assert c["id"] in ids
+    assert b["id"] not in ids
+
+
+@pytest.mark.asyncio
+async def test_list_channels_no_filter_returns_all(store):
+    await _create(store, name="a", project_id="prj-1")
+    await _create(store, name="b", project_id="prj-2")
+    await _create(store, name="c", project_id="")
+
+    result = await store.list_channels()
+    assert len(result) == 3
+
+
+@pytest.mark.asyncio
+async def test_list_channels_empty_project_id_returns_all(store):
+    await _create(store, name="a", project_id="prj-1")
+    await _create(store, name="b", project_id="")
+
+    result = await store.list_channels(project_id="")
+    assert len(result) == 2

--- a/tinyagentos/chat/channel_store.py
+++ b/tinyagentos/chat/channel_store.py
@@ -137,7 +137,7 @@ class ChatChannelStore(BaseStore):
             conditions.append("members LIKE ?")
             params.append(f'%"{member_id}"%')
 
-        if project_id is not None:
+        if project_id is not None and project_id != "":
             conditions.append("project_id = ?")
             params.append(project_id)
 
@@ -182,6 +182,13 @@ class ChatChannelStore(BaseStore):
         params.append(channel_id)
         await self._db.execute(
             f"UPDATE chat_channels SET {', '.join(sets)} WHERE id = ?", params
+        )
+        await self._db.commit()
+
+    async def set_project(self, channel_id: str, project_id: str) -> None:
+        await self._db.execute(
+            "UPDATE chat_channels SET project_id = ? WHERE id = ?",
+            (project_id, channel_id),
         )
         await self._db.commit()
 

--- a/tinyagentos/routes/chat_admin.py
+++ b/tinyagentos/routes/chat_admin.py
@@ -1,9 +1,30 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Query, Request
 from fastapi.responses import JSONResponse
 
 router = APIRouter()
+
+
+@router.get("/api/chat/channels")
+async def list_channels(request: Request, project_id: str | None = Query(default=None)):
+    ch_store = request.app.state.chat_channels
+    if project_id is not None and project_id.strip() == "":
+        project_id = None
+    channels = await ch_store.list_channels(project_id=project_id)
+    return channels
+
+
+@router.put("/api/chat/channels/{channel_id}/project")
+async def set_channel_project(request: Request, channel_id: str):
+    body = await request.json()
+    ch_store = request.app.state.chat_channels
+    channel = await ch_store.get_channel(channel_id)
+    if not channel:
+        return JSONResponse({"error": "Channel not found"}, status_code=404)
+    project_id = body.get("project_id", "")
+    await ch_store.set_project(channel_id, project_id)
+    return {"status": "updated", "project_id": project_id}
 
 
 @router.post("/api/chat/channels")


### PR DESCRIPTION
Autonomous build of board card tsk-vhbddt.



Files:
 tests/test_channel_project.py     | 75 +++++++++++++++++++++++++++++++++++++++
 tinyagentos/chat/channel_store.py |  9 ++++-
 tinyagentos/routes/chat_admin.py  | 23 +++++++++++-
 3 files changed, 105 insertions(+), 2 deletions(-)

----
## Summary by Gitar

- **API endpoints:**
  - Added `/api/chat/channels` to list channels with optional `project_id` filtering.
  - Added `/api/chat/channels/{channel_id}/project` to update a channel's associated project.
- **Database store:**
  - Implemented `set_project` in `ChatChannelStore` to persist project updates.
  - Updated `list_channels` filtering logic to handle empty `project_id` strings correctly.
- **Testing:**
  - Added comprehensive test suite `tests/test_channel_project.py` covering project assignment, clearing, and filtering logic.

<sub>This will update automatically on new commits.</sub>