### PR TITLE
add POST /api/notifications/mark-all-read endpoint with count return

### DIFF
--- a/tests/test_notifications_mark_all.py
+++ b/tests/test_notifications_mark_all.py
@@ -1,0 +1,34 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_mark_all_read_returns_count(client):
+    store = client._transport.app.state.notifications
+    await store.add("A", "a")
+    await store.add("B", "b")
+    await store.add("C", "c")
+    assert await store.unread_count() == 3
+    resp = await client.post("/api/notifications/mark-all-read")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["marked"] == 3
+    assert await store.unread_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_mark_all_read_idempotent(client):
+    store = client._transport.app.state.notifications
+    await store.add("A", "a")
+    resp = await client.post("/api/notifications/mark-all-read")
+    assert resp.status_code == 200
+    assert resp.json()["marked"] == 1
+    resp = await client.post("/api/notifications/mark-all-read")
+    assert resp.status_code == 200
+    assert resp.json()["marked"] == 0
+
+
+@pytest.mark.asyncio
+async def test_mark_all_read_no_notifications(client):
+    resp = await client.post("/api/notifications/mark-all-read")
+    assert resp.status_code == 200
+    assert resp.json()["marked"] == 0

--- a/tinyagentos/notifications.py
+++ b/tinyagentos/notifications.py
@@ -79,9 +79,10 @@ class NotificationStore(BaseStore):
         await self._db.execute("UPDATE notifications SET read = 1 WHERE id = ?", (notif_id,))
         await self._db.commit()
 
-    async def mark_all_read(self) -> None:
-        await self._db.execute("UPDATE notifications SET read = 1")
+    async def mark_all_read(self) -> int:
+        cursor = await self._db.execute("UPDATE notifications SET read = 1 WHERE read = 0")
         await self._db.commit()
+        return cursor.rowcount
 
     async def cleanup(self, max_age_days: int = 30) -> int:
         cutoff = int(time.time()) - (max_age_days * 86400)

--- a/tinyagentos/routes/notifications.py
+++ b/tinyagentos/routes/notifications.py
@@ -64,6 +64,13 @@ async def mark_all_read(request: Request):
     return {"ok": True}
 
 
+@router.post("/api/notifications/mark-all-read")
+async def mark_all_read_counted(request: Request):
+    store = request.app.state.notifications
+    count = await store.mark_all_read()
+    return {"marked": count}
+
+
 @router.get("/api/notifications/prefs")
 async def get_notification_prefs(request: Request):
     store = request.app.state.notifications


### PR DESCRIPTION
Autonomous build of board card tsk-m7hwbe.

Update NotificationStore.mark_all_read() to return the rowcount from the
UPDATE query, and add a new POST /api/notifications/mark-all-read route
that calls it and returns {marked: <count>}. Existing /read-all route
left unchanged for backward compatibility.

Files:
 tests/test_notifications_mark_all.py | 34 ++++++++++++++++++++++++++++++++++
 tinyagentos/notifications.py         |  5 +++--
 tinyagentos/routes/notifications.py  |  7 +++++++
 3 files changed, 44 insertions(+), 2 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated notifications endpoint path to `/api/notifications/mark-all-read` 
  * Changed response format to include count of notifications marked as read

* **Tests**
  * Added test coverage for mark-all-read endpoint including idempotency and empty-state validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->