### PR TITLE
feat(cli): taosctl, a kubectl-style CLI over the taOS REST API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ tinyagentos-worker = "tinyagentos.worker.__main__:main"
 taos = "tinyagentos.app:main"
 taos-gui = "tinyagentos.app:gui"
 taos-worker-ctl = "tinyagentos.cli.worker:main"
+taosctl = "tinyagentos.cli.taosctl.__main__:main"
 
 [tool.pytest.ini_options]
 # Per-test timeout: a single hung test fails fast and named instead of

--- a/tests/test_taosctl.py
+++ b/tests/test_taosctl.py
@@ -121,3 +121,21 @@ def test_render_table_unwraps_items_and_shows_rows(capsys):
     output.render({"items": [{"name": "x", "status": "ok"}]}, as_json=False)
     out = capsys.readouterr().out
     assert "NAME" in out and "x" in out and "ok" in out
+
+
+# ---- auth login writes the credential file owner-only ------------------------
+
+def test_auth_login_writes_config_owner_only(monkeypatch, tmp_path):
+    import argparse
+    import stat
+
+    from tinyagentos.cli.taosctl.commands import auth as auth_cmd
+
+    cfg = tmp_path / "sub" / "config.json"
+    monkeypatch.setattr(cli_client, "CONFIG_PATH", cfg)
+    monkeypatch.delenv("TAOS_URL", raising=False)
+    monkeypatch.delenv("TAOS_TOKEN", raising=False)
+    auth_cmd._login(argparse.Namespace(url="http://h:1", token="sekret"), None)
+    assert cfg.exists()
+    assert stat.S_IMODE(cfg.stat().st_mode) == 0o600
+    assert json.loads(cfg.read_text())["token"] == "sekret"

--- a/tests/test_taosctl.py
+++ b/tests/test_taosctl.py
@@ -1,0 +1,123 @@
+"""Tests for the taosctl CLI: config resolution, error mapping, command
+dispatch, exit codes, and output rendering."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tinyagentos.cli.taosctl import client as cli_client
+from tinyagentos.cli.taosctl import output
+from tinyagentos.cli.taosctl import __main__ as cli_main
+from tinyagentos.cli.taosctl.commands import iter_noun_modules
+
+
+# ---- config resolution -------------------------------------------------------
+
+def test_resolve_prefers_flags_over_env(monkeypatch, tmp_path):
+    monkeypatch.setattr(cli_client, "CONFIG_PATH", tmp_path / "none.json")
+    monkeypatch.setenv("TAOS_URL", "http://env:1")
+    monkeypatch.setenv("TAOS_TOKEN", "envtok")
+    url, tok = cli_client.resolve("http://flag:2", "flagtok")
+    assert url == "http://flag:2" and tok == "flagtok"
+
+
+def test_resolve_falls_back_to_env_then_default(monkeypatch, tmp_path):
+    monkeypatch.setattr(cli_client, "CONFIG_PATH", tmp_path / "none.json")
+    monkeypatch.delenv("TAOS_URL", raising=False)
+    monkeypatch.setenv("TAOS_TOKEN", "envtok")
+    url, tok = cli_client.resolve(None, None)
+    assert url == cli_client.DEFAULT_URL and tok == "envtok"
+
+
+def test_resolve_reads_config_file_when_no_flag_or_env(monkeypatch, tmp_path):
+    cfg = tmp_path / "config.json"
+    cfg.write_text(json.dumps({"url": "http://cfg:9", "token": "cfgtok"}))
+    monkeypatch.setattr(cli_client, "CONFIG_PATH", cfg)
+    monkeypatch.delenv("TAOS_URL", raising=False)
+    monkeypatch.delenv("TAOS_TOKEN", raising=False)
+    url, tok = cli_client.resolve(None, None)
+    assert url == "http://cfg:9" and tok == "cfgtok"
+
+
+# ---- error extraction --------------------------------------------------------
+
+def test_extract_error_uses_json_detail():
+    raw = json.dumps({"detail": "not your project"}).encode()
+    assert cli_client._extract_error(raw, 403) == "not your project"
+
+
+def test_extract_error_falls_back_to_status():
+    assert cli_client._extract_error(b"", 500) == "HTTP 500"
+
+
+# ---- discovery ---------------------------------------------------------------
+
+def test_agents_and_auth_nouns_are_discovered():
+    nouns = {m.NOUN for m in iter_noun_modules()}
+    assert {"agents", "auth"} <= nouns
+
+
+# ---- command dispatch + exit codes (fake client) -----------------------------
+
+class _FakeClient:
+    def __init__(self, *a, **k):
+        self.calls = []
+        self.base_url = "http://x"
+        self.token = "t"
+        self._raise = None
+
+    def get(self, path, params=None):
+        self.calls.append(("GET", path))
+        if self._raise:
+            raise self._raise
+        return {"items": [{"name": "alpha", "status": "running"}]}
+
+
+def _run(monkeypatch, argv, fake):
+    monkeypatch.setattr(cli_main, "TaosClient", lambda **k: fake)
+    return cli_main.main(argv)
+
+
+def test_agents_list_calls_endpoint_and_succeeds(monkeypatch, capsys):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["agents", "list"], fake)
+    assert rc == 0
+    assert ("GET", "/api/agents") in fake.calls
+    assert "alpha" in capsys.readouterr().out
+
+
+def test_agents_get_targets_named_agent(monkeypatch, capsys):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["--json", "agents", "get", "alpha"], fake)
+    assert rc == 0
+    assert ("GET", "/api/agents/alpha") in fake.calls
+
+
+def test_api_error_maps_to_exit_2(monkeypatch, capsys):
+    fake = _FakeClient()
+    fake._raise = cli_client.ApiError(404, "no such agent")
+    rc = _run(monkeypatch, ["agents", "get", "ghost"], fake)
+    assert rc == 2
+    assert "no such agent" in capsys.readouterr().err
+
+
+def test_transport_error_maps_to_exit_1(monkeypatch, capsys):
+    fake = _FakeClient()
+    fake._raise = cli_client.TransportError("cannot reach http://x: refused")
+    rc = _run(monkeypatch, ["agents", "list"], fake)
+    assert rc == 1
+    assert "cannot reach" in capsys.readouterr().err
+
+
+# ---- output rendering --------------------------------------------------------
+
+def test_render_json_emits_valid_json(capsys):
+    output.render({"a": 1, "b": [1, 2]}, as_json=True)
+    assert json.loads(capsys.readouterr().out) == {"a": 1, "b": [1, 2]}
+
+
+def test_render_table_unwraps_items_and_shows_rows(capsys):
+    output.render({"items": [{"name": "x", "status": "ok"}]}, as_json=False)
+    out = capsys.readouterr().out
+    assert "NAME" in out and "x" in out and "ok" in out

--- a/tinyagentos/cli/taosctl/__init__.py
+++ b/tinyagentos/cli/taosctl/__init__.py
@@ -1,0 +1,15 @@
+"""taosctl: a kubectl-style CLI over the taOS REST API.
+
+Shell-driveable surface so coding-CLI agents, scripts, and humans can do
+anything a taOS user can do without poking the UI. Subcommands map 1:1 to API
+verbs: ``taosctl <noun> <verb> [args]``. Noun modules live in
+``tinyagentos/cli/taosctl/commands/`` and are auto-discovered, so a new noun is
+a new file with no central registry edit (conflict-free to add in parallel).
+
+Run via the ``taosctl`` console script or directly:
+
+    python -m tinyagentos.cli.taosctl <noun> <verb> ...
+"""
+from __future__ import annotations
+
+__version__ = "0.1.0"

--- a/tinyagentos/cli/taosctl/__main__.py
+++ b/tinyagentos/cli/taosctl/__main__.py
@@ -1,0 +1,55 @@
+"""taosctl entry point: build the parser from auto-discovered noun modules,
+dispatch the chosen handler, render the result, and map failures to exit codes.
+
+Exit codes (per the agent-friendliness design):
+  0  success
+  1  transport / local error (could not reach the server, bad usage)
+  2  API error (server returned non-2xx; its message is printed to stderr)
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Optional
+
+from tinyagentos.cli.taosctl import __version__, output
+from tinyagentos.cli.taosctl.client import ApiError, TaosClient, TransportError
+from tinyagentos.cli.taosctl.commands import iter_noun_modules
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="taosctl",
+        description="kubectl-style CLI over the taOS REST API (taosctl <noun> <verb>).",
+    )
+    parser.add_argument("--version", action="version", version=f"taosctl {__version__}")
+    parser.add_argument("--url", help="Server base URL (else TAOS_URL or config)")
+    parser.add_argument("--token", help="API token (else TAOS_TOKEN or config)")
+    parser.add_argument("--json", action="store_true", help="Machine-readable JSON output")
+    nouns = parser.add_subparsers(dest="noun", required=True, metavar="<noun>")
+    for mod in sorted(iter_noun_modules(), key=lambda m: m.NOUN):
+        mod.register(nouns)
+    return parser
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if not getattr(args, "func", None):
+        parser.print_help(sys.stderr)
+        return 1
+    client = TaosClient(url=args.url, token=args.token)
+    try:
+        result = args.func(args, client)
+    except ApiError as exc:
+        output.error(f"API error ({exc.status}): {exc.message}")
+        return 2
+    except TransportError as exc:
+        output.error(str(exc))
+        return 1
+    output.render(result, as_json=args.json)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tinyagentos/cli/taosctl/client.py
+++ b/tinyagentos/cli/taosctl/client.py
@@ -1,0 +1,113 @@
+"""Authenticated HTTP client for taosctl. Stdlib only (urllib), so the CLI
+installs and runs anywhere with zero extra dependencies.
+
+Config resolution (first match wins) for base URL and token:
+  1. explicit --url / --token flags (passed in by __main__)
+  2. env TAOS_URL / TAOS_TOKEN  (how an agent container has its token injected)
+  3. ~/.config/taosctl/config.json  ({"url": ..., "token": ...})
+  4. url defaults to http://127.0.0.1:6969; token may be absent (anonymous)
+
+The token is sent as ``Authorization: Bearer <token>`` (the header the taOS
+auth middleware accepts in place of a session cookie).
+"""
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any, Optional
+
+DEFAULT_URL = "http://127.0.0.1:6969"
+CONFIG_PATH = Path(os.path.expanduser("~/.config/taosctl/config.json"))
+
+
+class ApiError(Exception):
+    """Raised on a non-2xx API response. Carries the HTTP status and the
+    server's actionable message (from the JSON error/detail field if present)."""
+
+    def __init__(self, status: int, message: str):
+        super().__init__(message)
+        self.status = status
+        self.message = message
+
+
+class TransportError(Exception):
+    """Raised on a local/transport failure (connection refused, DNS, etc.)."""
+
+
+def _load_config() -> dict:
+    try:
+        return json.loads(CONFIG_PATH.read_text())
+    except Exception:
+        return {}
+
+
+def resolve(url: Optional[str], token: Optional[str]) -> tuple[str, Optional[str]]:
+    cfg = _load_config()
+    base = url or os.environ.get("TAOS_URL") or cfg.get("url") or DEFAULT_URL
+    tok = token or os.environ.get("TAOS_TOKEN") or cfg.get("token")
+    return base.rstrip("/"), tok
+
+
+class TaosClient:
+    def __init__(self, url: Optional[str] = None, token: Optional[str] = None, timeout: float = 30.0):
+        self.base_url, self.token = resolve(url, token)
+        self.timeout = timeout
+
+    def request(self, method: str, path: str, params: Optional[dict] = None,
+                body: Optional[Any] = None) -> Any:
+        full = self.base_url + path
+        if params:
+            clean = {k: v for k, v in params.items() if v is not None}
+            if clean:
+                full = full + "?" + urllib.parse.urlencode(clean)
+        data = None
+        headers = {"Accept": "application/json"}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        if body is not None:
+            data = json.dumps(body).encode()
+            headers["Content-Type"] = "application/json"
+        req = urllib.request.Request(full, data=data, method=method.upper(), headers=headers)
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+                raw = resp.read()
+        except urllib.error.HTTPError as exc:
+            raw = exc.read() if exc.fp else b""
+            raise ApiError(exc.code, _extract_error(raw, exc.code)) from None
+        except urllib.error.URLError as exc:
+            raise TransportError(f"cannot reach {self.base_url}: {exc.reason}") from None
+        if not raw:
+            return None
+        try:
+            return json.loads(raw)
+        except ValueError:
+            return raw.decode(errors="replace")
+
+    def get(self, path: str, params: Optional[dict] = None) -> Any:
+        return self.request("GET", path, params=params)
+
+    def post(self, path: str, body: Optional[Any] = None, params: Optional[dict] = None) -> Any:
+        return self.request("POST", path, params=params, body=body)
+
+    def patch(self, path: str, body: Optional[Any] = None) -> Any:
+        return self.request("PATCH", path, body=body)
+
+    def delete(self, path: str) -> Any:
+        return self.request("DELETE", path)
+
+
+def _extract_error(raw: bytes, status: int) -> str:
+    try:
+        doc = json.loads(raw)
+        if isinstance(doc, dict):
+            for key in ("error", "detail", "message"):
+                if doc.get(key):
+                    return str(doc[key])
+    except Exception:
+        pass
+    text = raw.decode(errors="replace").strip()
+    return text or f"HTTP {status}"

--- a/tinyagentos/cli/taosctl/commands/__init__.py
+++ b/tinyagentos/cli/taosctl/commands/__init__.py
@@ -1,0 +1,28 @@
+"""Auto-discovery of taosctl noun modules.
+
+Every module in this package (except those starting with ``_``) is a noun. A
+noun module must expose:
+  NOUN: str                      -- the subcommand word, e.g. "agents"
+  register(subparsers) -> None   -- add its <noun> parser + verb subparsers,
+                                    each verb's handler set via
+                                    parser.set_defaults(func=handler), where
+                                    handler(args, client) -> data | None
+
+Adding a noun is adding a file here; no central list to edit, so parallel
+contributors never collide on a shared registry.
+"""
+from __future__ import annotations
+
+import importlib
+import pkgutil
+from typing import Iterator
+
+
+def iter_noun_modules() -> Iterator[object]:
+    import tinyagentos.cli.taosctl.commands as pkg
+    for info in pkgutil.iter_modules(pkg.__path__):
+        if info.name.startswith("_"):
+            continue
+        mod = importlib.import_module(f"{pkg.__name__}.{info.name}")
+        if hasattr(mod, "register") and hasattr(mod, "NOUN"):
+            yield mod

--- a/tinyagentos/cli/taosctl/commands/agents.py
+++ b/tinyagentos/cli/taosctl/commands/agents.py
@@ -1,0 +1,36 @@
+"""taosctl agents -- inspect and manage agents.
+
+Reference noun: shows the pattern every other noun module follows (a NOUN, a
+register() that wires verb subparsers, and small handlers that call the client
+and return data for the framework to render).
+"""
+from __future__ import annotations
+
+NOUN = "agents"
+
+
+def register(subparsers) -> None:
+    p = subparsers.add_parser(NOUN, help="Inspect and manage agents")
+    verbs = p.add_subparsers(dest="verb", required=True, metavar="<verb>")
+
+    lp = verbs.add_parser("list", help="List all agents")
+    lp.set_defaults(func=_list)
+
+    gp = verbs.add_parser("get", help="Get one agent by name")
+    gp.add_argument("name", help="Agent name")
+    gp.set_defaults(func=_get)
+
+    ap = verbs.add_parser("archived", help="List archived agents")
+    ap.set_defaults(func=_archived)
+
+
+def _list(args, client):
+    return client.get("/api/agents")
+
+
+def _get(args, client):
+    return client.get(f"/api/agents/{args.name}")
+
+
+def _archived(args, client):
+    return client.get("/api/agents/archived")

--- a/tinyagentos/cli/taosctl/commands/auth.py
+++ b/tinyagentos/cli/taosctl/commands/auth.py
@@ -1,0 +1,42 @@
+"""taosctl auth -- configure and check the CLI's connection to a taOS server."""
+from __future__ import annotations
+
+import json
+
+from tinyagentos.cli.taosctl import client as _client
+
+NOUN = "auth"
+
+
+def register(subparsers) -> None:
+    p = subparsers.add_parser(NOUN, help="Configure and check the connection")
+    verbs = p.add_subparsers(dest="verb", required=True, metavar="<verb>")
+
+    lp = verbs.add_parser("login", help="Save a server URL + token to the config file")
+    lp.add_argument("--url", help="Server base URL")
+    lp.add_argument("--token", help="API token (Bearer)")
+    lp.set_defaults(func=_login)
+
+    sp = verbs.add_parser("status", help="Show the resolved URL + whether a token is set")
+    sp.set_defaults(func=_status)
+
+    wp = verbs.add_parser("whoami", help="Verify the token by calling the server")
+    wp.set_defaults(func=_whoami)
+
+
+def _login(args, client):
+    url, token = _client.resolve(args.url, args.token)
+    _client.CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    _client.CONFIG_PATH.write_text(json.dumps({"url": url, "token": token}, indent=2))
+    return {"saved": str(_client.CONFIG_PATH), "url": url, "token_set": bool(token)}
+
+
+def _status(args, client):
+    return {"url": client.base_url, "token_set": bool(client.token)}
+
+
+def _whoami(args, client):
+    # No dedicated whoami endpoint; a successful authed call to /api/agents
+    # confirms the token is accepted by the server.
+    client.get("/api/agents")
+    return {"url": client.base_url, "authenticated": True}

--- a/tinyagentos/cli/taosctl/commands/auth.py
+++ b/tinyagentos/cli/taosctl/commands/auth.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import os
 
 from tinyagentos.cli.taosctl import client as _client
 
@@ -26,8 +27,13 @@ def register(subparsers) -> None:
 
 def _login(args, client):
     url, token = _client.resolve(args.url, args.token)
-    _client.CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
-    _client.CONFIG_PATH.write_text(json.dumps({"url": url, "token": token}, indent=2))
+    _client.CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    payload = json.dumps({"url": url, "token": token}, indent=2)
+    # The config holds a credential, so create it owner-only (0o600) and
+    # atomically, never world-readable between create and a later chmod.
+    fd = os.open(str(_client.CONFIG_PATH), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as fh:
+        fh.write(payload)
     return {"saved": str(_client.CONFIG_PATH), "url": url, "token_set": bool(token)}
 
 

--- a/tinyagentos/cli/taosctl/output.py
+++ b/tinyagentos/cli/taosctl/output.py
@@ -1,0 +1,64 @@
+"""Output rendering for taosctl. Default is human-readable; --json prints the
+raw machine-readable JSON. Data goes to stdout, diagnostics to stderr."""
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+
+def render(data: Any, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(data, indent=2, default=str))
+        return
+    if data is None:
+        return
+    # Unwrap the common {"items": [...]} list envelope.
+    if isinstance(data, dict) and "items" in data and isinstance(data["items"], list):
+        data = data["items"]
+    if isinstance(data, list):
+        _render_table(data)
+    elif isinstance(data, dict):
+        _render_kv(data)
+    else:
+        print(data)
+
+
+def _render_table(rows: list) -> None:
+    if not rows:
+        print("(none)")
+        return
+    if not all(isinstance(r, dict) for r in rows):
+        for r in rows:
+            print(r)
+        return
+    # Prefer a small set of identifying columns when present, else the first
+    # few keys of the first row.
+    preferred = ["id", "name", "slug", "status", "state", "title", "framework"]
+    first = rows[0]
+    cols = [c for c in preferred if c in first] or list(first.keys())[:5]
+    widths = {c: max(len(c), *(len(_cell(r.get(c))) for r in rows)) for c in cols}
+    header = "  ".join(c.upper().ljust(widths[c]) for c in cols)
+    print(header)
+    for r in rows:
+        print("  ".join(_cell(r.get(c)).ljust(widths[c]) for c in cols))
+
+
+def _render_kv(obj: dict) -> None:
+    width = max((len(k) for k in obj), default=0)
+    for k, v in obj.items():
+        if isinstance(v, (dict, list)):
+            v = json.dumps(v, default=str)
+        print(f"{k.ljust(width)}  {v}")
+
+
+def _cell(v: Any) -> str:
+    if v is None:
+        return "-"
+    if isinstance(v, (dict, list)):
+        return json.dumps(v, default=str)
+    return str(v)
+
+
+def error(msg: str) -> None:
+    print(f"taosctl: {msg}", file=sys.stderr)


### PR DESCRIPTION
Foundation for the agent-native shell surface that the coding-CLI agents, scripts, and humans can drive.

- `taosctl <noun> <verb>`, kubectl-style, mapping 1:1 to API verbs.
- Noun modules under `tinyagentos/cli/taosctl/commands/` are **auto-discovered**, so adding a noun is adding a file with no shared-registry edit (conflict-free fan-out for the per-app subcommand cards).
- Zero-dependency urllib client: token resolved from --flag / TAOS_TOKEN env / ~/.config/taosctl/config.json; sent as `Authorization: Bearer`. Exit codes 0 success / 1 transport / 2 API error (server message to stderr).
- Human table by default, `--json` for piping.
- Ships the `agents` (list/get/archived) + `auth` (login/status/whoami) nouns as the reference pattern. 12 tests, all green.

Next: fan out per-route-module noun cards to the build lanes. Rebuilt fresh on current dev (the 2026-05 Pass-1 branch is 700+ commits stale and stays closed).