### PR TITLE
feat(taosctl): add projects command group

### DIFF
--- a/tests/test_taosctl_projects.py
+++ b/tests/test_taosctl_projects.py
@@ -1,0 +1,74 @@
+"""Tests for the taosctl projects command group."""
+from __future__ import annotations
+
+from tinyagentos.cli.taosctl import __main__ as cli_main
+
+
+class _FakeClient:
+    def __init__(self, *a, **k):
+        self.calls = []
+        self.base_url = "http://x"
+        self.token = "t"
+
+    def get(self, path, params=None):
+        self.calls.append(("GET", path))
+        return {"items": [{"id": "p1", "name": "alpha"}]}
+
+    def post(self, path, json=None):
+        self.calls.append(("POST", path))
+        return {"id": "p2", "name": (json or {}).get("name", "x")}
+
+    def patch(self, path, json=None):
+        self.calls.append(("PATCH", path))
+        return {"id": "p1", "name": json.get("name", "x")}
+
+    def delete(self, path):
+        self.calls.append(("DELETE", path))
+        return {"id": "p1", "status": "deleted"}
+
+
+def _run(monkeypatch, argv, fake):
+    monkeypatch.setattr(cli_main, "TaosClient", lambda **k: fake)
+    return cli_main.main(argv)
+
+
+def test_projects_list_hits_correct_endpoint(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["projects", "list"], fake)
+    assert rc == 0
+    assert ("GET", "/api/projects") in fake.calls
+
+
+def test_projects_get_targets_by_id(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["projects", "get", "p1"], fake)
+    assert rc == 0
+    assert ("GET", "/api/projects/p1") in fake.calls
+
+
+def test_projects_create_sends_post_with_body(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["projects", "create", "alpha", "alpha-slug"], fake)
+    assert rc == 0
+    assert ("POST", "/api/projects") in fake.calls
+
+
+def test_projects_update_sends_patch_with_fields(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["projects", "update", "p1", "--name", "beta"], fake)
+    assert rc == 0
+    assert ("PATCH", "/api/projects/p1") in fake.calls
+
+
+def test_projects_delete_hits_correct_endpoint(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["projects", "delete", "p1"], fake)
+    assert rc == 0
+    assert ("DELETE", "/api/projects/p1") in fake.calls
+
+
+def test_projects_archive_hits_correct_endpoint(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["projects", "archive", "p1"], fake)
+    assert rc == 0
+    assert ("POST", "/api/projects/p1/archive") in fake.calls

--- a/tinyagentos/cli/taosctl/commands/projects.py
+++ b/tinyagentos/cli/taosctl/commands/projects.py
@@ -1,0 +1,66 @@
+"""taosctl projects -- inspect and manage projects."""
+from __future__ import annotations
+
+NOUN = "projects"
+
+
+def register(subparsers) -> None:
+    p = subparsers.add_parser(NOUN, help="Inspect and manage projects")
+    verbs = p.add_subparsers(dest="verb", required=True, metavar="<verb>")
+
+    lp = verbs.add_parser("list", help="List projects")
+    lp.set_defaults(func=_list)
+
+    gp = verbs.add_parser("get", help="Get one project by id")
+    gp.add_argument("id", help="Project id")
+    gp.set_defaults(func=_get)
+
+    cp = verbs.add_parser("create", help="Create a project")
+    cp.add_argument("name", help="Project name")
+    cp.add_argument("slug", help="URL-friendly slug")
+    cp.add_argument("--description", default="", help="Short description")
+    cp.set_defaults(func=_create)
+
+    up = verbs.add_parser("update", help="Update a project")
+    up.add_argument("id", help="Project id")
+    up.add_argument("--name", default=None, help="New name")
+    up.add_argument("--description", default=None, help="New description")
+    up.set_defaults(func=_update)
+
+    dp = verbs.add_parser("delete", help="Delete a project")
+    dp.add_argument("id", help="Project id")
+    dp.set_defaults(func=_delete)
+
+    ap = verbs.add_parser("archive", help="Archive a project")
+    ap.add_argument("id", help="Project id")
+    ap.set_defaults(func=_archive)
+
+
+def _list(args, client):
+    return client.get("/api/projects")
+
+
+def _get(args, client):
+    return client.get(f"/api/projects/{args.id}")
+
+
+def _create(args, client):
+    body = {"name": args.name, "slug": args.slug, "description": args.description}
+    return client.post("/api/projects", json=body)
+
+
+def _update(args, client):
+    body = {}
+    if args.name is not None:
+        body["name"] = args.name
+    if args.description is not None:
+        body["description"] = args.description
+    return client.patch(f"/api/projects/{args.id}", json=body)
+
+
+def _delete(args, client):
+    return client.delete(f"/api/projects/{args.id}")
+
+
+def _archive(args, client):
+    return client.post(f"/api/projects/{args.id}/archive")


### PR DESCRIPTION
Autonomous build of board card tsk-e3e4md.

Adds  with list, get, create, update, delete, and
archive verbs wrapping the /api/projects endpoints. Mirrors the agents
command pattern: module-level NOUN, register(subparsers) wiring verb
handlers, and a small fake-client test file asserting each verb hits
the correct endpoint.

Files:
 tests/test_taosctl_projects.py               | 74 ++++++++++++++++++++++++++++
 tinyagentos/cli/taosctl/commands/projects.py | 66 +++++++++++++++++++++++++
 2 files changed, 140 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `projects` command group to the CLI with subcommands for managing projects: list all projects, get a specific project by ID, create new projects, update existing projects, delete projects, and archive projects.

* **Tests**
  * Added comprehensive test coverage for all projects command subcommands to ensure proper API endpoint targeting and HTTP verb usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->