### PR TITLE
fix(cli): taosctl gitar findings (URL-encode name, no env-token persist)

### DIFF
--- a/tests/test_taosctl.py
+++ b/tests/test_taosctl.py
@@ -94,6 +94,13 @@ def test_agents_get_targets_named_agent(monkeypatch, capsys):
     assert ("GET", "/api/agents/alpha") in fake.calls
 
 
+def test_agents_get_url_encodes_the_name(monkeypatch, capsys):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["--json", "agents", "get", "a/b c"], fake)
+    assert rc == 0
+    assert ("GET", "/api/agents/a%2Fb%20c") in fake.calls
+
+
 def test_api_error_maps_to_exit_2(monkeypatch, capsys):
     fake = _FakeClient()
     fake._raise = cli_client.ApiError(404, "no such agent")
@@ -139,3 +146,19 @@ def test_auth_login_writes_config_owner_only(monkeypatch, tmp_path):
     assert cfg.exists()
     assert stat.S_IMODE(cfg.stat().st_mode) == 0o600
     assert json.loads(cfg.read_text())["token"] == "sekret"
+
+
+def test_auth_login_does_not_persist_env_only_token(monkeypatch, tmp_path):
+    import argparse
+
+    from tinyagentos.cli.taosctl.commands import auth as auth_cmd
+
+    cfg = tmp_path / "config.json"
+    monkeypatch.setattr(cli_client, "CONFIG_PATH", cfg)
+    monkeypatch.setenv("TAOS_TOKEN", "env-secret")
+    monkeypatch.delenv("TAOS_URL", raising=False)
+    # bare `auth login` (no --token): the env token must NOT be written to disk
+    auth_cmd._login(argparse.Namespace(url="http://h:1", token=None), None)
+    saved = json.loads(cfg.read_text())
+    assert saved["token"] is None
+    assert saved["url"] == "http://h:1"

--- a/tinyagentos/cli/taosctl/commands/agents.py
+++ b/tinyagentos/cli/taosctl/commands/agents.py
@@ -6,6 +6,8 @@ and return data for the framework to render).
 """
 from __future__ import annotations
 
+from urllib.parse import quote
+
 NOUN = "agents"
 
 
@@ -29,7 +31,7 @@ def _list(args, client):
 
 
 def _get(args, client):
-    return client.get(f"/api/agents/{args.name}")
+    return client.get(f"/api/agents/{quote(args.name, safe='')}")
 
 
 def _archived(args, client):

--- a/tinyagentos/cli/taosctl/commands/auth.py
+++ b/tinyagentos/cli/taosctl/commands/auth.py
@@ -26,7 +26,12 @@ def register(subparsers) -> None:
 
 
 def _login(args, client):
-    url, token = _client.resolve(args.url, args.token)
+    # Persist only what the user explicitly passes, falling back to the existing
+    # config file (NOT env vars). resolve() would pull in TAOS_TOKEN, which would
+    # silently write an env-only token to disk on a bare `auth login`.
+    existing = _client._load_config()
+    url = args.url or existing.get("url") or _client.DEFAULT_URL
+    token = args.token if args.token is not None else existing.get("token")
     _client.CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
     payload = json.dumps({"url": url, "token": token}, indent=2)
     # The config holds a credential, so create it owner-only (0o600) and


### PR DESCRIPTION
Two must-fix gitar findings on the merged taosctl (#1045):
- **Edge Case**: `agents get` interpolated the agent name unencoded; now uses urllib quote so a name with / or whitespace targets the right path.
- **Bug**: `auth login` resolved via env fallback, so a bare login could silently write an env-only TAOS_TOKEN to the config file. Now persists only explicit --url/--token merged with the existing config file (never env).

The earlier 0o600 permissions finding was already fixed pre-merge. Both fixes have tests; full taosctl suite green.