### PR TITLE
feat(taosctl): add tasks command group for scheduled task management

### DIFF
--- a/tests/test_taosctl_tasks.py
+++ b/tests/test_taosctl_tasks.py
@@ -1,0 +1,90 @@
+"""Tests for the taosctl tasks command group."""
+from __future__ import annotations
+
+from tinyagentos.cli.taosctl import __main__ as cli_main
+
+
+class _FakeClient:
+    def __init__(self, *a, **k):
+        self.calls = []
+        self.base_url = "http://x"
+        self.token = "t"
+
+    def get(self, path, params=None):
+        self.calls.append(("GET", path))
+        return {"items": []}
+
+    def post(self, path, body=None, params=None):
+        self.calls.append(("POST", path))
+        return {"status": "ok"}
+
+    def request(self, method, path, body=None, params=None):
+        self.calls.append((method, path))
+        return {"status": "ok"}
+
+    def delete(self, path):
+        self.calls.append(("DELETE", path))
+        return {"status": "ok"}
+
+
+def _run(monkeypatch, argv, fake):
+    monkeypatch.setattr(cli_main, "TaosClient", lambda **k: fake)
+    return cli_main.main(argv)
+
+
+def test_tasks_list_hits_correct_endpoint(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["tasks", "list"], fake)
+    assert rc == 0
+    assert ("GET", "/api/tasks") in fake.calls
+
+
+def test_tasks_list_passes_agent_filter(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["tasks", "list", "--agent", "myagent"], fake)
+    assert rc == 0
+    assert ("GET", "/api/tasks") in fake.calls
+
+
+def test_tasks_get_hits_correct_endpoint(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["tasks", "get", "42"], fake)
+    assert rc == 0
+    assert ("GET", "/api/tasks/42") in fake.calls
+
+
+def test_tasks_create_hits_correct_endpoint(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, [
+        "tasks", "create",
+        "--name", "test",
+        "--schedule", "* * * * *",
+        "--command", "echo hi",
+    ], fake)
+    assert rc == 0
+    assert ("POST", "/api/tasks") in fake.calls
+
+
+def test_tasks_update_hits_correct_endpoint(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, [
+        "tasks", "update", "42",
+        "--name", "renamed",
+        "--enabled", "false",
+    ], fake)
+    assert rc == 0
+    assert ("PUT", "/api/tasks/42") in fake.calls
+
+
+def test_tasks_delete_hits_correct_endpoint(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["tasks", "delete", "42"], fake)
+    assert rc == 0
+    assert ("DELETE", "/api/tasks/42") in fake.calls
+
+
+def test_tasks_toggle_hits_correct_endpoint(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["tasks", "toggle", "42"], fake)
+    assert rc == 0
+    assert ("POST", "/api/tasks/42/toggle") in fake.calls

--- a/tinyagentos/cli/taosctl/commands/tasks.py
+++ b/tinyagentos/cli/taosctl/commands/tasks.py
@@ -1,0 +1,90 @@
+"""taosctl tasks -- inspect and manage scheduled tasks."""
+from __future__ import annotations
+
+NOUN = "tasks"
+
+
+def register(subparsers) -> None:
+    p = subparsers.add_parser(NOUN, help="Inspect and manage scheduled tasks")
+    verbs = p.add_subparsers(dest="verb", required=True, metavar="<verb>")
+
+    lp = verbs.add_parser("list", help="List all tasks")
+    lp.add_argument("--agent", help="Filter by agent name")
+    lp.set_defaults(func=_list)
+
+    gp = verbs.add_parser("get", help="Get one task by id")
+    gp.add_argument("id", help="Task id")
+    gp.set_defaults(func=_get)
+
+    cp = verbs.add_parser("create", help="Create a new task")
+    cp.add_argument("--name", required=True, help="Task name")
+    cp.add_argument("--schedule", required=True, help="Cron expression")
+    cp.add_argument("--command", required=True, help="Command to run")
+    cp.add_argument("--agent-name", help="Agent to run as")
+    cp.add_argument("--description", default="", help="Task description")
+    cp.set_defaults(func=_create)
+
+    up = verbs.add_parser("update", help="Update an existing task")
+    up.add_argument("id", help="Task id")
+    up.add_argument("--name", help="Task name")
+    up.add_argument("--schedule", help="Cron expression")
+    up.add_argument("--command", help="Command to run")
+    up.add_argument("--description", help="Task description")
+    up.add_argument("--enabled", help="true or false")
+    up.set_defaults(func=_update)
+
+    dp = verbs.add_parser("delete", help="Delete a task")
+    dp.add_argument("id", help="Task id")
+    dp.set_defaults(func=_delete)
+
+    tp = verbs.add_parser("toggle", help="Toggle a task enabled/disabled")
+    tp.add_argument("id", help="Task id")
+    tp.set_defaults(func=_toggle)
+
+    # Skipped: GET /api/tasks/presets (list_presets) -- no matching verb needed yet
+    # Skipped: POST /api/tasks/presets/{id}/apply (apply_preset) -- complex nested body
+
+
+def _list(args, client):
+    params = {}
+    if args.agent:
+        params["agent"] = args.agent
+    return client.get("/api/tasks", params=params or None)
+
+
+def _get(args, client):
+    return client.get(f"/api/tasks/{args.id}")
+
+
+def _create(args, client):
+    body = {
+        "name": args.name,
+        "schedule": args.schedule,
+        "command": args.command,
+        "agent_name": args.agent_name,
+        "description": args.description,
+    }
+    return client.post("/api/tasks", body=body)
+
+
+def _update(args, client):
+    body = {}
+    if args.name is not None:
+        body["name"] = args.name
+    if args.schedule is not None:
+        body["schedule"] = args.schedule
+    if args.command is not None:
+        body["command"] = args.command
+    if args.description is not None:
+        body["description"] = args.description
+    if args.enabled is not None:
+        body["enabled"] = args.enabled.lower() in ("true", "1", "yes")
+    return client.request("PUT", f"/api/tasks/{args.id}", body=body)
+
+
+def _delete(args, client):
+    return client.delete(f"/api/tasks/{args.id}")
+
+
+def _toggle(args, client):
+    return client.post(f"/api/tasks/{args.id}/toggle")


### PR DESCRIPTION
Autonomous build of board card tsk-enbwdq.

Adds taosctl tasks with list, get, create, update, delete, and toggle
verbs wrapping the /api/tasks REST endpoints. Auto-discovers via the
commands package without touching shared files.

Files:
 tests/test_taosctl_tasks.py               | 90 +++++++++++++++++++++++++++++++
 tinyagentos/cli/taosctl/commands/tasks.py | 90 +++++++++++++++++++++++++++++++
 2 files changed, 180 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `taosctl tasks` command group for managing scheduled tasks, including operations to list, retrieve, create, update, delete, and toggle task status.
  * Task creation allows specifying name, schedule, command, agent name, and description.
  * Added `--agent` filter option to filter tasks by agent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->