### PR TITLE
feat(tasks): reopen a closed task (undo an accidental close)

### DIFF
--- a/tests/projects/test_task_store.py
+++ b/tests/projects/test_task_store.py
@@ -98,6 +98,25 @@ async def test_close_task_records_metadata(store):
 
 
 @pytest.mark.asyncio
+async def test_reopen_task_returns_closed_task_to_open_pool(store):
+    t = await store.create_task(project_id="p", title="A", created_by="u")
+    await store.close_task(t["id"], closed_by="agent-1", reason="oops")
+    assert await store.reopen_task(t["id"], reopened_by="jay") is True
+    reopened = await store.get_task(t["id"])
+    assert reopened["status"] == "open"
+    assert reopened["closed_by"] is None
+    assert reopened["closed_at"] is None
+    assert reopened["close_reason"] is None
+
+
+@pytest.mark.asyncio
+async def test_reopen_task_is_noop_when_not_closed(store):
+    t = await store.create_task(project_id="p", title="A", created_by="u")
+    assert await store.reopen_task(t["id"], reopened_by="jay") is False
+    assert (await store.get_task(t["id"]))["status"] == "open"
+
+
+@pytest.mark.asyncio
 async def test_add_relationship_and_list(store):
     a = await store.create_task(project_id="p", title="A", created_by="u")
     b = await store.create_task(project_id="p", title="B", created_by="u")

--- a/tinyagentos/projects/task_store.py
+++ b/tinyagentos/projects/task_store.py
@@ -247,6 +247,25 @@ class ProjectTaskStore(BaseStore):
                 await self._publish(existing["project_id"], "task.closed", {"id": task_id, "closed_by": closed_by})
         return changed
 
+    async def reopen_task(self, task_id: str, reopened_by: str) -> bool:
+        """Undo a close: a closed task returns to the open pool (claimer stays
+        cleared, so a free agent can pick it up again). Only acts on a closed
+        task; returns False otherwise."""
+        now = time.time()
+        cursor = await self._db.execute(
+            """UPDATE project_tasks
+               SET status = 'open', closed_by = NULL, closed_at = NULL, close_reason = NULL, updated_at = ?
+               WHERE id = ? AND status = 'closed'""",
+            (now, task_id),
+        )
+        await self._db.commit()
+        changed = cursor.rowcount == 1
+        if changed:
+            existing = await self.get_task(task_id)
+            if existing is not None:
+                await self._publish(existing["project_id"], "task.reopened", {"id": task_id, "reopened_by": reopened_by})
+        return changed
+
     async def add_relationship(
         self,
         project_id: str,

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -385,6 +385,10 @@ class CloseIn(BaseModel):
     reason: str | None = None
 
 
+class ReopenIn(BaseModel):
+    reopened_by: str | None = None
+
+
 class AddRelIn(BaseModel):
     to_task_id: str
     kind: str
@@ -620,6 +624,34 @@ async def close_task(
                 project_id, payload.closed_by, "task.qmd_index_failed", {"task_id": task_id}
             )
     return task
+
+
+@router.post("/api/projects/{project_id}/tasks/{task_id}/reopen")
+async def reopen_task(
+    project_id: str,
+    task_id: str,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+    payload: ReopenIn | None = None,
+):
+    pstore = request.app.state.project_store
+    project_or_err = await _get_owned_project(pstore, project_id, user)
+    if isinstance(project_or_err, JSONResponse):
+        return project_or_err
+    store = request.app.state.project_task_store
+    existing = await store.get_task(task_id)
+    if existing is None or existing["project_id"] != project_id:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    actor = (payload.reopened_by if payload and payload.reopened_by else None) or "user"
+    ok = await store.reopen_task(task_id, reopened_by=actor)
+    if not ok:
+        return JSONResponse({"error": "task is not closed"}, status_code=409)
+    _beads_mark_dirty(request, project_id)
+    await pstore.log_activity(project_id, actor, "task.reopened", {"task_id": task_id})
+    notifs = getattr(request.app.state, "notifications", None)
+    if notifs is not None:
+        await notifs.emit_event("task.reopened", "Task reopened", f"{task_id} reopened by {actor}")
+    return await store.get_task(task_id)
 
 
 @router.post("/api/projects/{project_id}/tasks/{task_id}/relationships")


### PR DESCRIPTION
Closing a task was a dead end: the PATCH task endpoint has no status field, so a closed task could not be reopened and an accidental close meant re-creating the card. This adds the missing capability.

- `ProjectTaskStore.reopen_task(task_id, reopened_by)`: closed -> open, clears closed_by/closed_at/close_reason, keeps claimer cleared so a free agent can re-claim. Emits `task.reopened`. 409 no-op if the task is not closed.
- `POST /api/projects/{pid}/tasks/{tid}/reopen`: owned-project + existence checks, logs activity, notifies. Optional `reopened_by` in the body.
- Store tests for both the reopen and the not-closed no-op.

First concrete slice of #105 (task audit trail + reopen/undo). The full per-action audit log follows.