### PR TITLE
feat(taosctl): add frameworks command group

### DIFF
--- a/tests/test_taosctl_frameworks.py
+++ b/tests/test_taosctl_frameworks.py
@@ -1,0 +1,60 @@
+"""Tests for the taosctl frameworks command: dispatch, endpoint paths, and exit
+codes. Mirrors the structure in tests/test_taosctl.py.
+"""
+from __future__ import annotations
+
+from tinyagentos.cli.taosctl import client as cli_client
+from tinyagentos.cli.taosctl import __main__ as cli_main
+
+
+class _FakeClient:
+    def __init__(self, *a, **k):
+        self.calls = []
+        self.base_url = "http://x"
+        self.token = "t"
+        self._raise = None
+
+    def get(self, path, params=None):
+        self.calls.append(("GET", path))
+        if self._raise:
+            raise self._raise
+        return {"items": [{"name": "crewai", "verified": True}]}
+
+
+def _run(monkeypatch, argv, fake):
+    monkeypatch.setattr(cli_main, "TaosClient", lambda **k: fake)
+    return cli_main.main(argv)
+
+
+def test_frameworks_list_calls_endpoint_and_succeeds(monkeypatch, capsys):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["frameworks", "list"], fake)
+    assert rc == 0
+    assert ("GET", "/api/frameworks") in fake.calls
+    assert "crewai" in capsys.readouterr().out
+
+
+def test_frameworks_list_json_output(monkeypatch, capsys):
+    import json
+
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["--json", "frameworks", "list"], fake)
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["items"][0]["name"] == "crewai"
+
+
+def test_frameworks_api_error_maps_to_exit_2(monkeypatch, capsys):
+    fake = _FakeClient()
+    fake._raise = cli_client.ApiError(500, "internal error")
+    rc = _run(monkeypatch, ["frameworks", "list"], fake)
+    assert rc == 2
+    assert "internal error" in capsys.readouterr().err
+
+
+def test_frameworks_transport_error_maps_to_exit_1(monkeypatch, capsys):
+    fake = _FakeClient()
+    fake._raise = cli_client.TransportError("cannot reach http://x: refused")
+    rc = _run(monkeypatch, ["frameworks", "list"], fake)
+    assert rc == 1
+    assert "cannot reach" in capsys.readouterr().err

--- a/tinyagentos/cli/taosctl/commands/frameworks.py
+++ b/tinyagentos/cli/taosctl/commands/frameworks.py
@@ -1,0 +1,24 @@
+"""taosctl frameworks -- inspect and manage agent frameworks.
+
+Reference noun: follows the same shape as agents.py and projects.py.
+"""
+from __future__ import annotations
+
+NOUN = "frameworks"
+
+
+def register(subparsers) -> None:
+    p = subparsers.add_parser(NOUN, help="Inspect and manage agent frameworks")
+    verbs = p.add_subparsers(dest="verb", required=True, metavar="<verb>")
+
+    lp = verbs.add_parser("list", help="List all registered frameworks")
+    lp.set_defaults(func=_list)
+
+    # GET /api/frameworks/{id} -- not yet implemented in routes/frameworks.py
+    # POST /api/frameworks -- not yet implemented in routes/frameworks.py
+    # PATCH /api/frameworks/{id} -- not yet implemented in routes/frameworks.py
+    # DELETE /api/frameworks/{id} -- not yet implemented in routes/frameworks.py
+
+
+def _list(args, client):
+    return client.get("/api/frameworks")


### PR DESCRIPTION
Autonomous build of board card tsk-d2rlmm.

Add taosctl frameworks command wrapping the /api/frameworks endpoint.
Exposes a list verb that calls GET /api/frameworks. Other CRUD
verbs are deferred until the corresponding routes exist in
routes/frameworks.py.

Tests: 4 new tests in test_taosctl_frameworks.py covering list,
JSON output, API error exit code, and transport error exit code.

Files:
 tests/test_taosctl_frameworks.py               | 60 ++++++++++++++++++++++++++
 tinyagentos/cli/taosctl/commands/frameworks.py | 24 +++++++++++
 2 files changed, 84 insertions(+)