### PR TITLE
fix(projects): Messages is its own page on mobile (not a squeezed Workspace pane)

### DIFF
--- a/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
@@ -55,7 +55,11 @@ export function ProjectWorkspace({ project, onChanged }: { project: Project; onC
     );
   };
 
-  const tabPills = TABS.map((t) => ({
+  // Mobile pill order: surface Messages right after Workspace so it is reachable
+  // without scrolling (on mobile Messages is its own full page, not a squeezed
+  // pane inside Workspace).
+  const mobileTabOrder: Tab[] = ["workspace", "messages", "board", "tasks", "canvas", "files", "members", "activity"];
+  const tabPills = mobileTabOrder.map((t) => ({
     id: t,
     label: t.charAt(0).toUpperCase() + t.slice(1),
   }));

--- a/desktop/src/apps/ProjectsApp/ProjectWorkspacePane.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectWorkspacePane.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from "react";
 import type { Project } from "@/lib/projects";
 import { MessagesApp } from "@/apps/MessagesApp";
 import { CanvasView } from "./canvas/CanvasView";
+import { useIsMobile } from "../../hooks/use-is-mobile";
 import styles from "./ProjectsApp.module.css";
 
 type PreviewMode = "preview" | "code" | "canvas";
@@ -23,6 +24,7 @@ const MIN_LEFT = 360;
  * true streamed live build preview is #59 phase 2/3 (see TODO below).
  */
 export function ProjectWorkspacePane({ project }: { project: Project }) {
+  const isMobile = useIsMobile();
   const [mode, setMode] = useState<PreviewMode>("preview");
   const [rightWidth, setRightWidth] = useState(472);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -50,30 +52,36 @@ export function ProjectWorkspacePane({ project }: { project: Project }) {
 
   return (
     <div className={styles.ws} ref={containerRef}>
-      {/* LEFT: real project channel thread + composer */}
-      <div className={styles.wsLeft}>
-        <div className={styles.wsThread}>
-          <MessagesApp
-            key={project.id}
-            windowId={`project-workspace-messages-${project.id}`}
-            scope={{ projectId: project.id }}
+      {/* LEFT: real project channel thread + composer. Desktop only -- on mobile
+          the squeezed split made messages unreadable, so Messages is its own
+          full-page tab and the Workspace pane shows just the preview. */}
+      {!isMobile && (
+        <>
+          <div className={styles.wsLeft}>
+            <div className={styles.wsThread}>
+              <MessagesApp
+                key={project.id}
+                windowId={`project-workspace-messages-${project.id}`}
+                scope={{ projectId: project.id }}
+              />
+            </div>
+          </div>
+
+          {/* draggable resize divider */}
+          <div
+            className={styles.wsDivider}
+            role="separator"
+            aria-orientation="vertical"
+            aria-label="Resize panes"
+            onPointerDown={onDividerDown}
+            onPointerMove={onDividerMove}
+            onPointerUp={onDividerUp}
           />
-        </div>
-      </div>
+        </>
+      )}
 
-      {/* draggable resize divider */}
-      <div
-        className={styles.wsDivider}
-        role="separator"
-        aria-orientation="vertical"
-        aria-label="Resize panes"
-        onPointerDown={onDividerDown}
-        onPointerMove={onDividerMove}
-        onPointerUp={onDividerUp}
-      />
-
-      {/* RIGHT: preview / code / canvas */}
-      <div className={styles.wsRight} style={{ width: rightWidth }}>
+      {/* RIGHT: preview / code / canvas (full width on mobile) */}
+      <div className={styles.wsRight} style={isMobile ? { width: "100%", flex: 1 } : { width: rightWidth }}>
         <div className={styles.pvBar}>
           <div className={styles.seg} role="tablist" aria-label="Preview mode">
             {(["preview", "code", "canvas"] as PreviewMode[]).map((m) => (


### PR DESCRIPTION
The mobile Workspace tab rendered the desktop split (project MessagesApp left, live preview right), which on a phone collapsed into a stack that squashed the messages into an unreadable 'Messages / a2a' stub (see report).

- `ProjectWorkspacePane` now renders **preview-only on mobile** (drops the MessagesApp left pane + divider); the preview goes full-width. Desktop is unchanged (still the side-by-side split).
- Messages already had its own full-page tab (`tab === 'messages'` renders the whole MessagesApp); it was just scrolled off the mobile pill strip. The mobile pill order now puts **Messages second**, right after Workspace, so it is reachable without scrolling.

tsc clean. I could not screenshot locally (the vite build is in its known-broken state here), so spa-build validates compilation; visual confirm after the Pi update.