### PR TITLE
fix(messages): remove duplicate channel name + dead space on mobile

### DIFF
--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -2709,7 +2709,10 @@ export function MessagesApp({
           selectedId={selectedChannel ?? busSelected}
           onBack={() => { setSelectedChannel(null); setBusSelected(null); }}
           listTitle="Messages"
-          detailTitle={busSelected ?? currentChannel?.name}
+          // On mobile the in-pane channel header already shows the channel name
+          // (and its toolbar), so suppressing the nav title removes the doubled
+          // name and the dead space it took up. Desktop keeps it.
+          detailTitle={isMobile ? undefined : (busSelected ?? currentChannel?.name)}
           listWidth={240}
           list={channelListUI}
           detail={messageAreaUI}


### PR DESCRIPTION
First targeted pass of the mobile Messages polish (#108). The channel name showed twice on mobile (the MobileSplitView nav title and the in-pane channel header), with dead space above. Suppress the nav detailTitle on mobile only; desktop unchanged. Next, per Jay: project channels + DMs in the list, and a clearer back-to-list. Verifying via screenshot since mobile isn't locally renderable here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detail title display in the Messages app on mobile devices to enhance the mobile user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->