### PR TITLE
add taosctl apps command group for driving apps from the shell

### DIFF
--- a/tests/test_taosctl_apps.py
+++ b/tests/test_taosctl_apps.py
@@ -1,0 +1,88 @@
+"""Tests for the taosctl apps command group."""
+from __future__ import annotations
+
+from tinyagentos.cli.taosctl import client as cli_client
+from tinyagentos.cli.taosctl import __main__ as cli_main
+
+
+class _FakeClient:
+    def __init__(self, *a, **k):
+        self.calls = []
+        self.base_url = "http://x"
+        self.token = "t"
+        self._raise = None
+
+    def get(self, path, params=None):
+        self.calls.append(("GET", path))
+        if self._raise:
+            raise self._raise
+        return {"items": []}
+
+    def post(self, path, json=None):
+        self.calls.append(("POST", path))
+        if self._raise:
+            raise self._raise
+        return {"status": "ok"}
+
+
+def _run(monkeypatch, argv, fake):
+    monkeypatch.setattr(cli_main, "TaosClient", lambda **k: fake)
+    return cli_main.main(argv)
+
+
+def test_apps_list_calls_installed_endpoint(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["apps", "list"], fake)
+    assert rc == 0
+    assert ("GET", "/api/apps/installed") in fake.calls
+
+
+def test_apps_get_targets_app_by_id(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["apps", "get", "gitea-lxc"], fake)
+    assert rc == 0
+    assert ("GET", "/api/apps/installed/gitea-lxc") in fake.calls
+
+
+def test_apps_get_url_encodes_the_id(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["apps", "get", "a/b c"], fake)
+    assert rc == 0
+    assert ("GET", "/api/apps/installed/a%2Fb%20c") in fake.calls
+
+
+def test_apps_installed_calls_optional_endpoint(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["apps", "installed"], fake)
+    assert rc == 0
+    assert ("GET", "/api/apps/optional/installed") in fake.calls
+
+
+def test_apps_install_posts_to_optional_install(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["apps", "install", "reddit"], fake)
+    assert rc == 0
+    assert ("POST", "/api/apps/optional/reddit/install") in fake.calls
+
+
+def test_apps_uninstall_posts_to_optional_uninstall(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["apps", "uninstall", "reddit"], fake)
+    assert rc == 0
+    assert ("POST", "/api/apps/optional/reddit/uninstall") in fake.calls
+
+
+def test_apps_api_error_maps_to_exit_2(monkeypatch, capsys):
+    fake = _FakeClient()
+    fake._raise = cli_client.ApiError(404, "no such app")
+    rc = _run(monkeypatch, ["apps", "get", "ghost"], fake)
+    assert rc == 2
+    assert "no such app" in capsys.readouterr().err
+
+
+def test_apps_transport_error_maps_to_exit_1(monkeypatch, capsys):
+    fake = _FakeClient()
+    fake._raise = cli_client.TransportError("cannot reach http://x: refused")
+    rc = _run(monkeypatch, ["apps", "list"], fake)
+    assert rc == 1
+    assert "cannot reach" in capsys.readouterr().err

--- a/tinyagentos/cli/taosctl/commands/apps.py
+++ b/tinyagentos/cli/taosctl/commands/apps.py
@@ -1,0 +1,57 @@
+"""taosctl apps -- inspect and manage installed apps.
+
+Reference noun: shows the pattern every other noun module follows (a NOUN, a
+register() that wires verb subparsers, and small handlers that call the client
+and return data for the framework to render).
+"""
+from __future__ import annotations
+
+from urllib.parse import quote
+
+NOUN = "apps"
+
+
+def register(subparsers) -> None:
+    p = subparsers.add_parser(NOUN, help="Inspect and manage installed apps")
+    verbs = p.add_subparsers(dest="verb", required=True, metavar="<verb>")
+
+    lp = verbs.add_parser("list", help="List installed apps with a runtime location")
+    lp.set_defaults(func=_list)
+
+    gp = verbs.add_parser("get", help="Get one installed app by id")
+    gp.add_argument("app_id", help="App id")
+    gp.set_defaults(func=_get)
+
+    ip = verbs.add_parser("installed", help="List optional frontend app install state")
+    ip.set_defaults(func=_installed)
+
+    cp = verbs.add_parser("install", help="Install an optional frontend app")
+    cp.add_argument("app_id", help="Optional app id")
+    cp.set_defaults(func=_install)
+
+    up = verbs.add_parser("uninstall", help="Uninstall an optional frontend app")
+    up.add_argument("app_id", help="Optional app id")
+    up.set_defaults(func=_uninstall)
+
+    # POST/PATCH/DELETE with file upload, multipart, streaming, or complex
+    # nested bodies are skipped: create, update, delete of full app records.
+
+
+def _list(args, client):
+    return client.get("/api/apps/installed")
+
+
+def _get(args, client):
+    return client.get(f"/api/apps/installed/{quote(args.app_id, safe='')}")
+
+
+def _installed(args, client):
+    return client.get("/api/apps/optional/installed")
+
+
+def _install(args, client):
+    return client.post(f"/api/apps/optional/{quote(args.app_id, safe='')}/install")
+
+
+def _uninstall(args, client):
+    return client.post(f"/api/apps/optional/{quote(args.app_id, safe='')}/uninstall")


### PR DESCRIPTION
Autonomous build of board card tsk-6dbqtf.



Files:
 tests/test_taosctl_apps.py               | 88 ++++++++++++++++++++++++++++++++
 tinyagentos/cli/taosctl/commands/apps.py | 57 +++++++++++++++++++++
 2 files changed, 145 insertions(+)

----
## Summary by Gitar

- **New CLI Command Group:**
  - Added `taosctl apps` command group to inspect and manage applications.
  - Implemented `list`, `get`, `installed`, `install`, and `uninstall` verbs for app management.
- **Testing:**
  - Added comprehensive suite in `tests/test_taosctl_apps.py` to verify API calls, URL encoding, and error handling.


<sub>This will update automatically on new commits.</sub>