### PR TITLE
fix: reopen clears claimer + taosctl body kwarg + strict --enabled

### DIFF
--- a/tests/projects/test_task_store.py
+++ b/tests/projects/test_task_store.py
@@ -100,6 +100,7 @@ async def test_close_task_records_metadata(store):
 @pytest.mark.asyncio
 async def test_reopen_task_returns_closed_task_to_open_pool(store):
     t = await store.create_task(project_id="p", title="A", created_by="u")
+    await store.claim_task(t["id"], claimer_id="agent-1")
     await store.close_task(t["id"], closed_by="agent-1", reason="oops")
     assert await store.reopen_task(t["id"], reopened_by="jay") is True
     reopened = await store.get_task(t["id"])
@@ -107,6 +108,9 @@ async def test_reopen_task_returns_closed_task_to_open_pool(store):
     assert reopened["closed_by"] is None
     assert reopened["closed_at"] is None
     assert reopened["close_reason"] is None
+    # reopened task must return to the claimable pool, so the old claimer clears
+    assert reopened["claimed_by"] is None
+    assert reopened["claimed_at"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_taosctl_projects.py
+++ b/tests/test_taosctl_projects.py
@@ -14,13 +14,15 @@ class _FakeClient:
         self.calls.append(("GET", path))
         return {"items": [{"id": "p1", "name": "alpha"}]}
 
-    def post(self, path, json=None):
+    def post(self, path, body=None, params=None):
         self.calls.append(("POST", path))
-        return {"id": "p2", "name": (json or {}).get("name", "x")}
+        self.last_body = body
+        return {"id": "p2", "name": (body or {}).get("name", "x")}
 
-    def patch(self, path, json=None):
+    def patch(self, path, body=None):
         self.calls.append(("PATCH", path))
-        return {"id": "p1", "name": json.get("name", "x")}
+        self.last_body = body
+        return {"id": "p1", "name": (body or {}).get("name", "x")}
 
     def delete(self, path):
         self.calls.append(("DELETE", path))
@@ -51,6 +53,7 @@ def test_projects_create_sends_post_with_body(monkeypatch):
     rc = _run(monkeypatch, ["projects", "create", "alpha", "alpha-slug"], fake)
     assert rc == 0
     assert ("POST", "/api/projects") in fake.calls
+    assert fake.last_body == {"name": "alpha", "slug": "alpha-slug", "description": ""}
 
 
 def test_projects_update_sends_patch_with_fields(monkeypatch):
@@ -58,6 +61,7 @@ def test_projects_update_sends_patch_with_fields(monkeypatch):
     rc = _run(monkeypatch, ["projects", "update", "p1", "--name", "beta"], fake)
     assert rc == 0
     assert ("PATCH", "/api/projects/p1") in fake.calls
+    assert fake.last_body == {"name": "beta"}
 
 
 def test_projects_delete_hits_correct_endpoint(monkeypatch):

--- a/tests/test_taosctl_tasks.py
+++ b/tests/test_taosctl_tasks.py
@@ -1,6 +1,8 @@
 """Tests for the taosctl tasks command group."""
 from __future__ import annotations
 
+import pytest
+
 from tinyagentos.cli.taosctl import __main__ as cli_main
 
 
@@ -74,6 +76,14 @@ def test_tasks_update_hits_correct_endpoint(monkeypatch):
     ], fake)
     assert rc == 0
     assert ("PUT", "/api/tasks/42") in fake.calls
+
+
+def test_tasks_update_rejects_invalid_enabled(monkeypatch):
+    fake = _FakeClient()
+    with pytest.raises(SystemExit):
+        _run(monkeypatch, ["tasks", "update", "42", "--enabled", "maybe"], fake)
+    # an unrecognised value must error, not silently disable the task
+    assert ("PUT", "/api/tasks/42") not in fake.calls
 
 
 def test_tasks_delete_hits_correct_endpoint(monkeypatch):

--- a/tinyagentos/cli/taosctl/commands/projects.py
+++ b/tinyagentos/cli/taosctl/commands/projects.py
@@ -46,7 +46,7 @@ def _get(args, client):
 
 def _create(args, client):
     body = {"name": args.name, "slug": args.slug, "description": args.description}
-    return client.post("/api/projects", json=body)
+    return client.post("/api/projects", body=body)
 
 
 def _update(args, client):
@@ -55,7 +55,7 @@ def _update(args, client):
         body["name"] = args.name
     if args.description is not None:
         body["description"] = args.description
-    return client.patch(f"/api/projects/{args.id}", json=body)
+    return client.patch(f"/api/projects/{args.id}", body=body)
 
 
 def _delete(args, client):

--- a/tinyagentos/cli/taosctl/commands/tasks.py
+++ b/tinyagentos/cli/taosctl/commands/tasks.py
@@ -78,7 +78,13 @@ def _update(args, client):
     if args.description is not None:
         body["description"] = args.description
     if args.enabled is not None:
-        body["enabled"] = args.enabled.lower() in ("true", "1", "yes")
+        v = args.enabled.strip().lower()
+        if v in ("true", "1", "yes"):
+            body["enabled"] = True
+        elif v in ("false", "0", "no"):
+            body["enabled"] = False
+        else:
+            raise SystemExit(f"--enabled expects true or false, got: {args.enabled}")
     return client.request("PUT", f"/api/tasks/{args.id}", body=body)
 
 

--- a/tinyagentos/projects/task_store.py
+++ b/tinyagentos/projects/task_store.py
@@ -254,7 +254,8 @@ class ProjectTaskStore(BaseStore):
         now = time.time()
         cursor = await self._db.execute(
             """UPDATE project_tasks
-               SET status = 'open', closed_by = NULL, closed_at = NULL, close_reason = NULL, updated_at = ?
+               SET status = 'open', closed_by = NULL, closed_at = NULL, close_reason = NULL,
+                   claimed_by = NULL, claimed_at = NULL, updated_at = ?
                WHERE id = ? AND status = 'closed'""",
             (now, task_id),
         )


### PR DESCRIPTION
Fix-forward for gitar findings surfaced on merged code (repo watch).

**Bugs (must-fix)**
- `reopen_task` did not clear `claimed_by`/`claimed_at`, so a reopened task kept its old claimer and never returned to the claimable pool (defeating reopen). The docstring already promised this; the code now matches. Test claims the task before close so it actually exercises the path.
- taosctl `projects create/update` called `client.post/patch(..., json=body)` but `TaosClient` takes `body=` (no `json` param), so the payload was silently dropped. The projects test fake mirrored the buggy `json=` signature, which is why CI stayed green; the fake now matches the real client and the tests assert the request body.

**Edge case**
- taosctl `tasks update --enabled <x>` coerced any unrecognised value (e.g. `maybe`) to `false`. It now rejects invalid values instead of silently disabling the task.

Tests: 28 pass (task_store reopen, taosctl projects, taosctl tasks).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `--enabled` flag in task update command now accepts additional input formats (`true/false`, `yes/no`, `1/0`) with improved validation.

* **Bug Fixes**
  * Task reopening now properly clears all claim metadata, ensuring reopened tasks return to unassigned status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->