### PR TITLE
feat: add taosctl scheduler command group

### DIFF
--- a/tests/test_taosctl_scheduler.py
+++ b/tests/test_taosctl_scheduler.py
@@ -1,0 +1,61 @@
+"""Tests for the taosctl scheduler command group."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tinyagentos.cli.taosctl import __main__ as cli_main
+
+
+class _FakeClient:
+    def __init__(self, *a, **k):
+        self.calls = []
+        self.base_url = "http://x"
+        self.token = "t"
+
+    def get(self, path, params=None):
+        self.calls.append(("GET", path, params))
+        return {"ok": True}
+
+
+def _run(monkeypatch, argv, fake):
+    monkeypatch.setattr(cli_main, "TaosClient", lambda **k: fake)
+    return cli_main.main(argv)
+
+
+def test_scheduler_stats_hits_stats_endpoint(monkeypatch, capsys):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["--json", "scheduler", "stats"], fake)
+    assert rc == 0
+    assert ("GET", "/api/scheduler/stats", None) in fake.calls
+
+
+def test_scheduler_tasks_hits_tasks_endpoint(monkeypatch, capsys):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["--json", "scheduler", "tasks"], fake)
+    assert rc == 0
+    assert ("GET", "/api/scheduler/tasks", None) in fake.calls
+
+
+def test_scheduler_tasks_passes_limit_param(monkeypatch, capsys):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["--json", "scheduler", "tasks", "--limit", "50"], fake)
+    assert rc == 0
+    calls_for_tasks = [c for c in fake.calls if c[1] == "/api/scheduler/tasks"]
+    assert len(calls_for_tasks) == 1
+    assert calls_for_tasks[0][2] == {"limit": 50}
+
+
+def test_scheduler_backends_hits_backends_endpoint(monkeypatch, capsys):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["--json", "scheduler", "backends"], fake)
+    assert rc == 0
+    assert ("GET", "/api/scheduler/backends", None) in fake.calls
+
+
+def test_scheduler_verbs_return_data(monkeypatch, capsys):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["--json", "scheduler", "stats"], fake)
+    data = json.loads(capsys.readouterr().out)
+    assert data == {"ok": True}

--- a/tinyagentos/cli/taosctl/commands/scheduler.py
+++ b/tinyagentos/cli/taosctl/commands/scheduler.py
@@ -1,0 +1,42 @@
+"""taosctl scheduler -- inspect scheduler state and backends.
+
+All current scheduler endpoints are reads (observability only); there are no
+create / update / delete surfaces, so no POST / PATCH / DELETE verbs yet.
+Skipped (not simple JSON body endpoints):
+  N/A -- the route file has no POST/PATCH/DELETE handlers at all.
+"""
+from __future__ import annotations
+
+from urllib.parse import quote
+
+NOUN = "scheduler"
+
+
+def register(subparsers) -> None:
+    p = subparsers.add_parser(NOUN, help="Inspect scheduler state and backends")
+    verbs = p.add_subparsers(dest="verb", required=True, metavar="<verb>")
+
+    sp = verbs.add_parser("stats", help="Live scheduler stats")
+    sp.set_defaults(func=_stats)
+
+    tp = verbs.add_parser("tasks", help="Recent task history")
+    tp.add_argument("--limit", type=int, default=None, help="Max tasks (1-500)")
+    tp.set_defaults(func=_tasks)
+
+    bp = verbs.add_parser("backends", help="Live backend catalog")
+    bp.set_defaults(func=_backends)
+
+
+def _stats(args, client):
+    return client.get("/api/scheduler/stats")
+
+
+def _tasks(args, client):
+    params = {}
+    if args.limit is not None:
+        params["limit"] = args.limit
+    return client.get("/api/scheduler/tasks", params=params or None)
+
+
+def _backends(args, client):
+    return client.get("/api/scheduler/backends")


### PR DESCRIPTION
Autonomous build of board card tsk-dg6ijg.

Add scheduler noun module wrapping the three GET-only endpoints from
routes/scheduler.py (stats, tasks, backends). All current scheduler
endpoints are reads (observability only), so no create/update/delete
verbs are included. Tests cover each verb hitting the correct path.

Files:
 tests/test_taosctl_scheduler.py               | 61 +++++++++++++++++++++++++++
 tinyagentos/cli/taosctl/commands/scheduler.py | 42 ++++++++++++++++++
 2 files changed, 103 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `scheduler` command group with three read-only endpoints: `stats`, `tasks`, and `backends`.
  * The `tasks` endpoint supports an optional `--limit` parameter to control result size.

* **Tests**
  * Added comprehensive test coverage for the new scheduler command group.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->