### PR TITLE
add a `taosctl jobs` command group wrapping tinyagentos/routes/jobs

### DIFF
--- a/tinyagentos/cli/taosctl/commands/jobs.py
+++ b/tinyagentos/cli/taosctl/commands/jobs.py
@@ -1,0 +1,61 @@
+"""taosctl jobs -- inspect and manage scheduled jobs.
+
+Reference noun: mirrors the agents module pattern (NOUN, register(), small handlers).
+"""
+from __future__ import annotations
+
+from urllib.parse import quote
+
+NOUN = "jobs"
+
+
+def register(subparsers) -> None:
+    p = subparsers.add_parser(NOUN, help="Inspect and manage scheduled jobs")
+    verbs = p.add_subparsers(dest="verb", required=True, metavar="<verb>")
+
+    lp = verbs.add_parser("list", help="List recent jobs")
+    lp.add_argument("--status", help="Filter by status", default=None)
+    lp.add_argument("--limit", help="Max results", type=int, default=50)
+    lp.set_defaults(func=_list)
+
+    gp = verbs.add_parser("get", help="Get one job by id")
+    gp.add_argument("job_id", help="Job id")
+    gp.set_defaults(func=_get)
+
+    sp = verbs.add_parser("stats", help="Job queue statistics")
+    sp.set_defaults(func=_stats)
+
+    rp = verbs.add_parser("running", help="Currently running jobs")
+    rp.set_defaults(func=_running)
+
+    cp = verbs.add_parser("cancel", help="Cancel a pending job")
+    cp.add_argument("job_id", help="Job id")
+    cp.set_defaults(func=_cancel)
+
+    clp = verbs.add_parser("cleanup", help="Remove old completed/failed jobs")
+    clp.set_defaults(func=_cleanup)
+
+
+def _list(args, client):
+    params = {"status": args.status, "limit": args.limit}
+    return client.get("/api/jobs", params=params)
+
+
+def _get(args, client):
+    return client.get(f"/api/jobs/{quote(args.job_id, safe='')}")
+
+
+def _stats(args, client):
+    return client.get("/api/jobs/stats")
+
+
+def _running(args, client):
+    return client.get("/api/jobs/running")
+
+
+def _cancel(args, client):
+    return client.post(f"/api/jobs/{quote(args.job_id, safe='')}/cancel")
+
+
+def _cleanup(args, client):
+    return client.post("/api/jobs/cleanup")


### PR DESCRIPTION
Autonomous build of board card tsk-ixebki.



Files:
 tinyagentos/cli/taosctl/commands/jobs.py | 61 ++++++++++++++++++++++++++++++++
 1 file changed, 61 insertions(+)

----
## Summary by Gitar

- **New CLI command group:**
  - Added `taosctl jobs` command group to enable interaction with `/api/jobs` endpoints.
- **Implemented operations:**
  - Added support for `list`, `get`, `stats`, `running`, `cancel`, and `cleanup` subcommands in `tinyagentos/cli/taosctl/commands/jobs.py`.

<sub>This will update automatically on new commits.</sub>