### PR TITLE
fix(taosctl): apps get filters installed list (was hitting a missing route)

### DIFF
--- a/tests/test_taosctl_apps.py
+++ b/tests/test_taosctl_apps.py
@@ -1,6 +1,8 @@
 """Tests for the taosctl apps command group."""
 from __future__ import annotations
 
+import pytest
+
 from tinyagentos.cli.taosctl import client as cli_client
 from tinyagentos.cli.taosctl import __main__ as cli_main
 
@@ -16,9 +18,11 @@ class _FakeClient:
         self.calls.append(("GET", path))
         if self._raise:
             raise self._raise
+        if path == "/api/apps/installed":
+            return [{"app_id": "gitea-lxc", "display_name": "Gitea", "status": "running"}]
         return {"items": []}
 
-    def post(self, path, json=None):
+    def post(self, path, body=None, params=None):
         self.calls.append(("POST", path))
         if self._raise:
             raise self._raise
@@ -37,18 +41,18 @@ def test_apps_list_calls_installed_endpoint(monkeypatch):
     assert ("GET", "/api/apps/installed") in fake.calls
 
 
-def test_apps_get_targets_app_by_id(monkeypatch):
+def test_apps_get_filters_installed_list_by_id(monkeypatch):
+    # No single-app backend route exists, so get fetches the list and filters.
     fake = _FakeClient()
     rc = _run(monkeypatch, ["apps", "get", "gitea-lxc"], fake)
     assert rc == 0
-    assert ("GET", "/api/apps/installed/gitea-lxc") in fake.calls
+    assert ("GET", "/api/apps/installed") in fake.calls
 
 
-def test_apps_get_url_encodes_the_id(monkeypatch):
+def test_apps_get_unknown_id_errors(monkeypatch):
     fake = _FakeClient()
-    rc = _run(monkeypatch, ["apps", "get", "a/b c"], fake)
-    assert rc == 0
-    assert ("GET", "/api/apps/installed/a%2Fb%20c") in fake.calls
+    with pytest.raises(SystemExit):
+        _run(monkeypatch, ["apps", "get", "ghost-app"], fake)
 
 
 def test_apps_installed_calls_optional_endpoint(monkeypatch):

--- a/tinyagentos/cli/taosctl/commands/apps.py
+++ b/tinyagentos/cli/taosctl/commands/apps.py
@@ -42,7 +42,12 @@ def _list(args, client):
 
 
 def _get(args, client):
-    return client.get(f"/api/apps/installed/{quote(args.app_id, safe='')}")
+    # No single-app backend route exists; fetch the installed list and filter.
+    rows = client.get("/api/apps/installed")
+    for row in rows or []:
+        if row.get("app_id") == args.app_id:
+            return row
+    raise SystemExit(f"no installed app with id: {args.app_id}")
 
 
 def _installed(args, client):


### PR DESCRIPTION
Fix-forward for a gitar Bug on merged code (#1056, already on the Pi).

`taosctl apps get <id>` issued `GET /api/apps/installed/{id}`, but the backend only has the list route `GET /api/apps/installed` (no single-app endpoint), so the command 404'd for every id. It now fetches the installed list and filters by `app_id`, returning that one app or erroring cleanly when the id is unknown. Also aligned the apps test fake's `post` signature to the real `TaosClient` (`body=`, not `json=`).

Tests: 8 pass.