### PR TITLE
feat(taosctl): add bookmarks command group

### DIFF
--- a/tests/test_taosctl_bookmarks.py
+++ b/tests/test_taosctl_bookmarks.py
@@ -1,0 +1,94 @@
+"""Tests for the taosctl bookmarks command group: dispatch, endpoint paths,
+URL-encoding, and error mapping."""
+from __future__ import annotations
+
+from tinyagentos.cli.taosctl import __main__ as cli_main
+
+
+class _FakeClient:
+    def __init__(self, *a, **k):
+        self.calls = []
+        self.base_url = "http://x"
+        self.token = "t"
+        self._raise = None
+
+    def get(self, path, params=None):
+        self.calls.append(("GET", path, params))
+        if self._raise:
+            raise self._raise
+        return {"bookmarks": []}
+
+    def post(self, path, body=None, params=None):
+        self.calls.append(("POST", path, body, params))
+        if self._raise:
+            raise self._raise
+        return {"bookmark_id": "bm-1"}
+
+    def delete(self, path, params=None):
+        self.calls.append(("DELETE", path, params))
+        if self._raise:
+            raise self._raise
+        return None
+
+
+def _run(monkeypatch, argv, fake):
+    monkeypatch.setattr(cli_main, "TaosClient", lambda **k: fake)
+    return cli_main.main(argv)
+
+
+def test_bookmarks_list_calls_endpoint(monkeypatch, capsys):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["bookmarks", "list", "--profile-id", "prof-1"], fake)
+    assert rc == 0
+    assert ("GET", "/api/desktop/browser/bookmarks", {"profile_id": "prof-1"}) in fake.calls
+
+
+def test_bookmarks_create_posts_body(monkeypatch, capsys):
+    fake = _FakeClient()
+    rc = _run(
+        monkeypatch,
+        ["bookmarks", "create", "--profile-id", "prof-1", "--url", "https://example.com", "--title", "Example"],
+        fake,
+    )
+    assert rc == 0
+    assert (
+        "POST",
+        "/api/desktop/browser/bookmarks",
+        {"profile_id": "prof-1", "url": "https://example.com", "title": "Example"},
+        None,
+    ) in fake.calls
+
+
+def test_bookmarks_delete_url_encodes_id(monkeypatch, capsys):
+    fake = _FakeClient()
+    rc = _run(
+        monkeypatch,
+        ["bookmarks", "delete", "bm/1 2", "--profile-id", "prof-1"],
+        fake,
+    )
+    assert rc == 0
+    assert (
+        "DELETE",
+        "/api/desktop/browser/bookmarks/bm%2F1%202",
+        {"profile_id": "prof-1"},
+    ) in fake.calls
+
+
+def test_bookmarks_api_error_maps_to_exit_2(monkeypatch, capsys):
+    from tinyagentos.cli.taosctl.client import ApiError
+
+    fake = _FakeClient()
+    fake._raise = ApiError(400, "bad request")
+    rc = _run(monkeypatch, ["bookmarks", "list", "--profile-id", "prof-1"], fake)
+    assert rc == 2
+    assert "bad request" in capsys.readouterr().err
+
+
+def test_bookmarks_transport_error_maps_to_exit_1(monkeypatch, capsys):
+    from tinyagentos.cli.taosctl.client import TransportError
+
+    fake = _FakeClient()
+    fake._raise = TransportError("cannot reach http://x: refused")
+    rc = _run(monkeypatch, ["bookmarks", "list", "--profile-id", "prof-1"], fake)
+    assert rc == 1
+    assert "cannot reach" in capsys.readouterr().err

--- a/tinyagentos/cli/taosctl/commands/bookmarks.py
+++ b/tinyagentos/cli/taosctl/commands/bookmarks.py
@@ -1,0 +1,52 @@
+"""taosctl bookmarks -- manage browser bookmarks.
+
+Reference noun: mirrors the agents pattern (NOUN, register(), small handlers).
+"""
+from __future__ import annotations
+
+from urllib.parse import quote
+
+NOUN = "bookmarks"
+
+
+def register(subparsers) -> None:
+    p = subparsers.add_parser(NOUN, help="Manage browser bookmarks")
+    verbs = p.add_subparsers(dest="verb", required=True, metavar="<verb>")
+
+    lp = verbs.add_parser("list", help="List bookmarks for a profile")
+    lp.add_argument("--profile-id", required=True, help="Browser profile ID")
+    lp.set_defaults(func=_list)
+
+    cp = verbs.add_parser("create", help="Add a new bookmark")
+    cp.add_argument("--profile-id", required=True, help="Browser profile ID")
+    cp.add_argument("--url", required=True, help="Bookmark URL")
+    cp.add_argument("--title", required=True, help="Bookmark title")
+    cp.set_defaults(func=_create)
+
+    dp = verbs.add_parser("delete", help="Remove a bookmark by ID")
+    dp.add_argument("bookmark_id", help="Bookmark ID")
+    dp.add_argument("--profile-id", required=True, help="Browser profile ID")
+    dp.set_defaults(func=_delete)
+
+
+def _list(args, client):
+    return client.get(
+        "/api/desktop/browser/bookmarks",
+        params={"profile_id": args.profile_id},
+    )
+
+
+def _create(args, client):
+    return client.post(
+        "/api/desktop/browser/bookmarks",
+        body={
+            "profile_id": args.profile_id,
+            "url": args.url,
+            "title": args.title,
+        },
+    )
+
+
+def _delete(args, client):
+    path = f"/api/desktop/browser/bookmarks/{quote(args.bookmark_id, safe='')}"
+    return client.delete(path, params={"profile_id": args.profile_id})


### PR DESCRIPTION
Autonomous build of board card tsk-46ynsf.

Add taosctl bookmarks with list/create/delete verbs wrapping
the desktop browser bookmark routes. Mirrors the agents command
pattern for auto-discovery. Tests cover endpoint dispatch,
URL-encoding, and error exit codes.

Files:
 tests/test_taosctl_bookmarks.py               | 94 +++++++++++++++++++++++++++
 tinyagentos/cli/taosctl/commands/bookmarks.py | 52 +++++++++++++++
 2 files changed, 146 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `taosctl bookmarks` command to manage browser bookmarks with support for listing, creating, and deleting bookmarks per profile

* **Tests**
  * Added test coverage for bookmarks command functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->