### PR TITLE
fix(taosctl): client.delete threads query params (+ first direct client tests)

### DIFF
--- a/tests/test_taosctl_client.py
+++ b/tests/test_taosctl_client.py
@@ -1,0 +1,57 @@
+"""Direct unit tests for the taosctl HTTP client.
+
+The noun command tests use fake clients, so they cannot catch a real
+TaosClient signature or URL-building regression. These tests exercise the
+real client against a stubbed urlopen.
+"""
+from __future__ import annotations
+
+from tinyagentos.cli.taosctl import client as cli_client
+
+
+class _FakeResp:
+    def __init__(self, body=b'{"ok": true}'):
+        self._body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def read(self):
+        return self._body
+
+
+def _capture(monkeypatch):
+    seen = {}
+
+    def fake_urlopen(req, timeout=None):
+        seen["url"] = req.full_url
+        seen["method"] = req.get_method()
+        return _FakeResp()
+
+    monkeypatch.setattr(cli_client.urllib.request, "urlopen", fake_urlopen)
+    return seen
+
+
+def test_delete_threads_query_params_into_url(monkeypatch):
+    seen = _capture(monkeypatch)
+    c = cli_client.TaosClient(url="http://x", token=None)
+    c.delete("/api/bookmarks/b1", params={"profile_id": "p1"})
+    assert seen["method"] == "DELETE"
+    assert seen["url"] == "http://x/api/bookmarks/b1?profile_id=p1"
+
+
+def test_delete_without_params_has_no_query(monkeypatch):
+    seen = _capture(monkeypatch)
+    c = cli_client.TaosClient(url="http://x", token=None)
+    c.delete("/api/bookmarks/b1")
+    assert seen["url"] == "http://x/api/bookmarks/b1"
+
+
+def test_get_drops_none_valued_params(monkeypatch):
+    seen = _capture(monkeypatch)
+    c = cli_client.TaosClient(url="http://x", token=None)
+    c.get("/api/things", params={"a": "1", "b": None})
+    assert seen["url"] == "http://x/api/things?a=1"

--- a/tinyagentos/cli/taosctl/client.py
+++ b/tinyagentos/cli/taosctl/client.py
@@ -96,8 +96,8 @@ class TaosClient:
     def patch(self, path: str, body: Optional[Any] = None) -> Any:
         return self.request("PATCH", path, body=body)
 
-    def delete(self, path: str) -> Any:
-        return self.request("DELETE", path)
+    def delete(self, path: str, params: Optional[dict] = None) -> Any:
+        return self.request("DELETE", path, params=params)
 
 
 def _extract_error(raw: bytes, status: int) -> str:


### PR DESCRIPTION
Pre-empts a wrong-kwarg bug class in the in-flight noun fan-out. `TaosClient.delete` took only a path, so any noun whose DELETE needs a query arg (the bookmarks noun in #1061 deletes with `profile_id`) calls `client.delete(path, params=...)` and hits `TypeError`. The noun test fakes define `delete(self, path, params=None)`, so CI stays green while the real client breaks (same mock-masks-bug pattern as the earlier json= fixes).

`request()` already builds the query string for any method, so `delete` now threads `params` through, matching `get`/`post`. Adds tests/test_taosctl_client.py: the first tests that exercise the real client (delete with/without params, get dropping None values) rather than a fake, so this class of regression is caught directly going forward.

Tests: 25 pass across client + apps + projects + tasks.