### PR TITLE
add taosctl shortcuts command group for listing agent shortcuts

### DIFF
--- a/tests/test_taosctl_shortcuts.py
+++ b/tests/test_taosctl_shortcuts.py
@@ -1,0 +1,61 @@
+"""Tests for the taosctl shortcuts command group."""
+from __future__ import annotations
+
+from tinyagentos.cli.taosctl import client as cli_client
+from tinyagentos.cli.taosctl import __main__ as cli_main
+
+
+class _FakeClient:
+    def __init__(self, *a, **k):
+        self.calls = []
+        self.base_url = "http://x"
+        self.token = "t"
+        self._raise = None
+
+    def get(self, path, params=None):
+        self.calls.append(("GET", path))
+        if self._raise:
+            raise self._raise
+        return {"items": [{"idx": 0, "kind": "shell", "label": "bash", "icon": "terminal"}]}
+
+
+def _run(monkeypatch, argv, fake):
+    monkeypatch.setattr(cli_main, "TaosClient", lambda **k: fake)
+    return cli_main.main(argv)
+
+
+def test_shortcuts_list_calls_endpoint(monkeypatch, capsys):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["shortcuts", "list", "my-agent"], fake)
+    assert rc == 0
+    assert ("GET", "/api/agents/my-agent/shortcuts") in fake.calls
+
+
+def test_shortcuts_list_url_encodes_agent_id(monkeypatch, capsys):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["shortcuts", "list", "a/b c"], fake)
+    assert rc == 0
+    assert ("GET", "/api/agents/a%2Fb%20c/shortcuts") in fake.calls
+
+
+def test_shortcuts_list_outputs_data(monkeypatch, capsys):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["shortcuts", "list", "alpha"], fake)
+    assert rc == 0
+    assert "bash" in capsys.readouterr().out
+
+
+def test_shortcuts_api_error_maps_to_exit_2(monkeypatch, capsys):
+    fake = _FakeClient()
+    fake._raise = cli_client.ApiError(404, "no such agent")
+    rc = _run(monkeypatch, ["shortcuts", "list", "ghost"], fake)
+    assert rc == 2
+    assert "no such agent" in capsys.readouterr().err
+
+
+def test_shortcuts_transport_error_maps_to_exit_1(monkeypatch, capsys):
+    fake = _FakeClient()
+    fake._raise = cli_client.TransportError("cannot reach http://x: refused")
+    rc = _run(monkeypatch, ["shortcuts", "list", "alpha"], fake)
+    assert rc == 1
+    assert "cannot reach" in capsys.readouterr().err

--- a/tinyagentos/cli/taosctl/commands/shortcuts.py
+++ b/tinyagentos/cli/taosctl/commands/shortcuts.py
@@ -1,0 +1,24 @@
+"""taosctl shortcuts -- list agent shortcuts.
+
+Reference noun: shows the pattern every other noun module follows (a NOUN, a
+register() that wires verb subparsers, and small handlers that call the client
+and return data for the framework to render).
+"""
+from __future__ import annotations
+
+from urllib.parse import quote
+
+NOUN = "shortcuts"
+
+
+def register(subparsers) -> None:
+    p = subparsers.add_parser(NOUN, help="List agent shortcuts")
+    verbs = p.add_subparsers(dest="verb", required=True, metavar="<verb>")
+
+    lp = verbs.add_parser("list", help="List shortcuts for an agent")
+    lp.add_argument("agent_id", help="Agent name or id")
+    lp.set_defaults(func=_list)
+
+
+def _list(args, client):
+    return client.get(f"/api/agents/{quote(args.agent_id, safe='')}/shortcuts")


### PR DESCRIPTION
Autonomous build of board card tsk-dbjpzf.



Files:
 tests/test_taosctl_apps.py                    | 18 +++-----
 tests/test_taosctl_shortcuts.py               | 61 +++++++++++++++++++++++++++
 tinyagentos/cli/taosctl/commands/apps.py      |  7 +--
 tinyagentos/cli/taosctl/commands/shortcuts.py | 24 +++++++++++
 4 files changed, 93 insertions(+), 17 deletions(-)

----
## Summary by Gitar

- **New CLI command:**
  - Added `taosctl shortcuts` command group for listing agent shortcuts via `/api/agents/{agent_id}/shortcuts`.
- **Testing:**
  - Implemented unit tests in `tests/test_taosctl_shortcuts.py` covering endpoint calling, URL encoding for agent IDs, and CLI error mapping.

<sub>This will update automatically on new commits.</sub>