### PR TITLE
add taosctl guides command group

### DIFF
--- a/tests/test_taosctl_guides.py
+++ b/tests/test_taosctl_guides.py
@@ -1,0 +1,74 @@
+"""Tests for taosctl guides command group: dispatch, arg parsing, and exit codes."""
+from __future__ import annotations
+
+import pytest
+
+from tinyagentos.cli.taosctl import __main__ as cli_main
+
+
+class _FakeClient:
+    def __init__(self, *a, **k):
+        self.calls = []
+        self.base_url = "http://x"
+        self.token = "t"
+        self._raise = None
+
+    def get(self, path, params=None):
+        self.calls.append(("GET", path))
+        if self._raise:
+            raise self._raise
+        if "/api/guides/recommendations" in path:
+            return {"hardware": params["hardware"], "use_case": params["use_case"], "recommendations": []}
+        if "/api/guides/tiers" in path:
+            return {"tiers": {"pi-16gb": {"label": "Raspberry Pi 16 GB"}}}
+        if "/api/guides/use-cases" in path:
+            return {"use_cases": {"chat": {"label": "Chat"}}}
+        return {}
+
+    def post(self, path, body=None, params=None):
+        self.calls.append(("POST", path))
+
+    def patch(self, path, body=None):
+        self.calls.append(("PATCH", path))
+
+    def delete(self, path, params=None):
+        self.calls.append(("DELETE", path))
+
+
+def _run(monkeypatch, argv, fake):
+    monkeypatch.setattr(cli_main, "TaosClient", lambda **k: fake)
+    return cli_main.main(argv)
+
+
+def test_guides_recommendations_calls_endpoint(monkeypatch, capsys):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["guides", "recommendations", "nvidia-12gb", "coding"], fake)
+    assert rc == 0
+    assert ("GET", "/api/guides/recommendations") in fake.calls
+    out = capsys.readouterr().out
+    assert "nvidia-12gb" in out
+
+
+def test_guides_tiers_calls_endpoint(monkeypatch, capsys):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["--json", "guides", "tiers"], fake)
+    assert rc == 0
+    assert ("GET", "/api/guides/tiers") in fake.calls
+    out = capsys.readouterr().out
+    assert "pi-16gb" in out
+
+
+def test_guides_use_cases_calls_endpoint(monkeypatch, capsys):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["--json", "guides", "use-cases"], fake)
+    assert rc == 0
+    assert ("GET", "/api/guides/use-cases") in fake.calls
+    out = capsys.readouterr().out
+    assert "chat" in out
+
+
+def test_guides_is_discovered():
+    from tinyagentos.cli.taosctl.commands import iter_noun_modules
+
+    nouns = {m.NOUN for m in iter_noun_modules()}
+    assert "guides" in nouns

--- a/tinyagentos/cli/taosctl/commands/guides.py
+++ b/tinyagentos/cli/taosctl/commands/guides.py
@@ -1,0 +1,35 @@
+"""taosctl guides -- query hardware guides and model recommendations."""
+from __future__ import annotations
+
+NOUN = "guides"
+
+
+def register(subparsers) -> None:
+    p = subparsers.add_parser(NOUN, help="Query hardware guides and model recommendations")
+    verbs = p.add_subparsers(dest="verb", required=True, metavar="<verb>")
+
+    rp = verbs.add_parser("recommendations", help="Model recommendations for a hardware tier and use case")
+    rp.add_argument("hardware", help="Hardware tier, e.g. pi-16gb, nvidia-12gb, cpu-only")
+    rp.add_argument("use_case", help="Use case, e.g. chat, coding, embedding, vision, voice")
+    rp.set_defaults(func=_recommendations)
+
+    tp = verbs.add_parser("tiers", help="List hardware tiers with labels and descriptions")
+    tp.set_defaults(func=_tiers)
+
+    up = verbs.add_parser("use-cases", help="List use cases with labels and descriptions")
+    up.set_defaults(func=_use_cases)
+
+
+def _recommendations(args, client):
+    return client.get(
+        "/api/guides/recommendations",
+        params={"hardware": args.hardware, "use_case": args.use_case},
+    )
+
+
+def _tiers(args, client):
+    return client.get("/api/guides/tiers")
+
+
+def _use_cases(args, client):
+    return client.get("/api/guides/use-cases")


### PR DESCRIPTION
Autonomous build of board card tsk-7364tg.

New files:
- tinyagentos/cli/taosctl/commands/guides.py: maps guides endpoints to
  verbs (recommendations, tiers, use-cases) following the agents.py pattern
- tests/test_taosctl_guides.py: fake-client tests asserting each verb hits
  the correct endpoint path

Files:
 tests/test_taosctl_guides.py                  | 74 +++++++++++++++++++++++++++
 tinyagentos/cli/taosctl/commands/guides.py    | 35 +++++++++++++
 tinyagentos/cli/taosctl/commands/scheduler.py |  2 +
 3 files changed, 111 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `taosctl guides` command group with three new subcommands: `recommendations`, `tiers`, and `use-cases` for accessing curated guide information based on hardware and use case parameters.

* **Tests**
  * Added test suite validating the guides command functionality and ensuring correct API endpoint invocations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->