### PR TITLE
feat(taosctl): add video command group

### DIFF
--- a/tests/test_taosctl_video.py
+++ b/tests/test_taosctl_video.py
@@ -1,0 +1,123 @@
+"""Tests for the taosctl video command: dispatch, endpoint paths, and error mapping."""
+from __future__ import annotations
+
+import pytest
+
+from tinyagentos.cli.taosctl import __main__ as cli_main
+
+
+class _FakeClient:
+    def __init__(self, *a, **k):
+        self.calls = []
+        self.base_url = "http://x"
+        self.token = "t"
+        self._raise = None
+
+    def get(self, path, params=None):
+        self.calls.append(("GET", path))
+        if self._raise:
+            raise self._raise
+        return {"videos": []}
+
+    def post(self, path, body=None, params=None):
+        self.calls.append(("POST", path, body))
+        if self._raise:
+            raise self._raise
+        return {"status": "generated"}
+
+    def delete(self, path, params=None):
+        self.calls.append(("DELETE", path))
+        if self._raise:
+            raise self._raise
+        return {"status": "deleted"}
+
+
+def _run(monkeypatch, argv, fake):
+    monkeypatch.setattr(cli_main, "TaosClient", lambda **k: fake)
+    return cli_main.main(argv)
+
+
+def test_video_list_calls_endpoint(monkeypatch, capsys):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["video", "list"], fake)
+    assert rc == 0
+    assert ("GET", "/api/video") in fake.calls
+
+
+def test_video_generate_posts_prompt(monkeypatch, capsys):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["video", "generate", "a cat"], fake)
+    assert rc == 0
+    assert fake.calls[0][0] == "POST"
+    assert fake.calls[0][1] == "/api/video/generate"
+    assert fake.calls[0][2]["prompt"] == "a cat"
+
+
+def test_video_generate_url_encodes_prompt_with_spaces(monkeypatch, capsys):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["video", "generate", "a cat dancing"], fake)
+    assert rc == 0
+    assert fake.calls[0][2]["prompt"] == "a cat dancing"
+
+
+def test_video_generate_includes_optional_args(monkeypatch, capsys):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, [
+        "video", "generate", "sunset",
+        "--model", "wan2.1-14b",
+        "--duration", "10",
+        "--resolution", "720x1280",
+        "--seed", "42",
+    ], fake)
+    assert rc == 0
+    body = fake.calls[0][2]
+    assert body == {
+        "prompt": "sunset",
+        "model": "wan2.1-14b",
+        "duration": 10,
+        "resolution": "720x1280",
+        "seed": 42,
+    }
+
+
+def test_video_generate_default_body(monkeypatch, capsys):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["video", "generate", "test"], fake)
+    assert rc == 0
+    body = fake.calls[0][2]
+    assert body["model"] == "wan2.1-1.3b"
+    assert body["duration"] == 5
+    assert body["resolution"] == "480x832"
+    assert body["seed"] is None
+
+
+def test_video_delete_calls_endpoint(monkeypatch, capsys):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["video", "delete", "12345_1.mp4"], fake)
+    assert rc == 0
+    assert ("DELETE", "/api/video/12345_1.mp4") in fake.calls
+
+
+def test_video_delete_url_encodes_filename(monkeypatch, capsys):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["video", "delete", "a b c.mp4"], fake)
+    assert rc == 0
+    assert ("DELETE", "/api/video/a%20b%20c.mp4") in fake.calls
+
+
+def test_video_api_error_maps_to_exit_2(monkeypatch, capsys):
+    from tinyagentos.cli.taosctl.client import ApiError
+    fake = _FakeClient()
+    fake._raise = ApiError(503, "No video backend")
+    rc = _run(monkeypatch, ["video", "generate", "fail"], fake)
+    assert rc == 2
+    assert "No video backend" in capsys.readouterr().err
+
+
+def test_video_transport_error_maps_to_exit_1(monkeypatch, capsys):
+    from tinyagentos.cli.taosctl.client import TransportError
+    fake = _FakeClient()
+    fake._raise = TransportError("cannot reach http://x: refused")
+    rc = _run(monkeypatch, ["video", "list"], fake)
+    assert rc == 1
+    assert "cannot reach" in capsys.readouterr().err

--- a/tinyagentos/cli/taosctl/commands/video.py
+++ b/tinyagentos/cli/taosctl/commands/video.py
@@ -1,0 +1,45 @@
+"""taosctl video -- list and manage generated videos."""
+from __future__ import annotations
+
+from urllib.parse import quote
+
+NOUN = "video"
+
+
+def register(subparsers) -> None:
+    p = subparsers.add_parser(NOUN, help="List and manage generated videos")
+    verbs = p.add_subparsers(dest="verb", required=True, metavar="<verb>")
+
+    lp = verbs.add_parser("list", help="List generated videos")
+    lp.set_defaults(func=_list)
+
+    gp = verbs.add_parser("generate", help="Generate a video from a prompt")
+    gp.add_argument("prompt", help="Text prompt for the video")
+    gp.add_argument("--model", default="wan2.1-1.3b", help="Model id")
+    gp.add_argument("--duration", type=int, default=5, help="Duration in seconds")
+    gp.add_argument("--resolution", default="480x832", help="Resolution WxH")
+    gp.add_argument("--seed", type=int, default=None, help="Random seed")
+    gp.set_defaults(func=_generate)
+
+    dp = verbs.add_parser("delete", help="Delete a generated video")
+    dp.add_argument("filename", help="Video filename")
+    dp.set_defaults(func=_delete)
+
+
+def _list(args, client):
+    return client.get("/api/video")
+
+
+def _generate(args, client):
+    body = {
+        "prompt": args.prompt,
+        "model": args.model,
+        "duration": args.duration,
+        "resolution": args.resolution,
+        "seed": args.seed,
+    }
+    return client.post("/api/video/generate", body=body)
+
+
+def _delete(args, client):
+    return client.delete(f"/api/video/{quote(args.filename, safe='')}")


### PR DESCRIPTION
Autonomous build of board card tsk-7trwtz.

Add taosctl video with list, generate, and delete verbs wrapping
tinyagentos/routes/video.py endpoints. Mirrors agents.py pattern
for auto-discovery and handler style.

Files:
 tests/test_taosctl_video.py               | 123 ++++++++++++++++++++++++++++++
 tinyagentos/cli/taosctl/commands/video.py |  45 +++++++++++
 2 files changed, 168 insertions(+)