### PR TITLE
feat(taosctl): add music command group

### DIFF
--- a/tests/test_taosctl_music.py
+++ b/tests/test_taosctl_music.py
@@ -1,0 +1,66 @@
+"""Tests for the taosctl music command group."""
+from __future__ import annotations
+
+import pytest
+
+from tinyagentos.cli.taosctl import client as cli_client
+from tinyagentos.cli.taosctl import __main__ as cli_main
+
+
+class _FakeClient:
+    def __init__(self, *a, **k):
+        self.calls = []
+        self.base_url = "http://x"
+        self.token = "t"
+        self._raise = None
+
+    def get(self, path, params=None):
+        self.calls.append(("GET", path))
+        if self._raise:
+            raise self._raise
+        if path == "/api/music":
+            return {"tracks": [{"filename": "song.wav", "prompt": "lofi"}]}
+        if path == "/api/music/status":
+            return {"available": True, "backend": "musicgpt", "mode": "http"}
+        return {}
+
+    def post(self, path, body=None, params=None):
+        self.calls.append(("POST", path))
+        if self._raise:
+            raise self._raise
+        return {"status": "ok"}
+
+
+def _run(monkeypatch, argv, fake):
+    monkeypatch.setattr(cli_main, "TaosClient", lambda **k: fake)
+    return cli_main.main(argv)
+
+
+def test_music_list_calls_endpoint(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["music", "list"], fake)
+    assert rc == 0
+    assert ("GET", "/api/music") in fake.calls
+
+
+def test_music_status_calls_endpoint(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["music", "status"], fake)
+    assert rc == 0
+    assert ("GET", "/api/music/status") in fake.calls
+
+
+def test_music_api_error_maps_to_exit_2(monkeypatch, capsys):
+    fake = _FakeClient()
+    fake._raise = cli_client.ApiError(500, "backend unavailable")
+    rc = _run(monkeypatch, ["music", "list"], fake)
+    assert rc == 2
+    assert "backend unavailable" in capsys.readouterr().err
+
+
+def test_music_transport_error_maps_to_exit_1(monkeypatch, capsys):
+    fake = _FakeClient()
+    fake._raise = cli_client.TransportError("cannot reach http://x: refused")
+    rc = _run(monkeypatch, ["music", "status"], fake)
+    assert rc == 1
+    assert "cannot reach" in capsys.readouterr().err

--- a/tinyagentos/cli/taosctl/commands/music.py
+++ b/tinyagentos/cli/taosctl/commands/music.py
@@ -1,0 +1,27 @@
+"""taosctl music -- inspect and control music generation."""
+from __future__ import annotations
+
+from urllib.parse import quote
+
+NOUN = "music"
+
+
+def register(subparsers) -> None:
+    p = subparsers.add_parser(NOUN, help="Inspect and control music generation")
+    verbs = p.add_subparsers(dest="verb", required=True, metavar="<verb>")
+
+    lp = verbs.add_parser("list", help="List generated tracks")
+    lp.set_defaults(func=_list)
+
+    sp = verbs.add_parser("status", help="Show music backend status")
+    sp.set_defaults(func=_status)
+
+    # POST /api/music/compose skipped: requires a complex body (prompt, duration).
+
+
+def _list(args, client):
+    return client.get("/api/music")
+
+
+def _status(args, client):
+    return client.get("/api/music/status")


### PR DESCRIPTION
Autonomous build of board card tsk-men2v5.

Add taosctl music with list and status verbs wrapping GET /api/music
and GET /api/music/status. Mirrors the agents/authentication pattern
(module-level NOUN, register() wiring verb subparsers via
set_defaults(func=handler), small handlers calling client.get).

Files:
 tests/test_taosctl_music.py               | 66 +++++++++++++++++++++++++++++++
 tinyagentos/cli/taosctl/commands/music.py | 27 +++++++++++++
 2 files changed, 93 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `music` command to taosctl with `list` and `status` subcommands for querying and viewing music information
* **Tests**
  * Added test coverage for the new music command functionality, including API error handling and exit code validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->