### PR TITLE
add taosctl canvas command group

### DIFF
--- a/tests/test_taosctl_canvas.py
+++ b/tests/test_taosctl_canvas.py
@@ -1,0 +1,65 @@
+"""Tests for the taosctl canvas command group."""
+from __future__ import annotations
+
+from tinyagentos.cli.taosctl import __main__ as cli_main
+
+
+class _FakeClient:
+    def __init__(self, *a, **k):
+        self.calls = []
+        self.base_url = "http://x"
+        self.token = "t"
+
+    def get(self, path, params=None):
+        self.calls.append(("GET", path))
+        return {"canvases": []}
+
+    def delete(self, path, params=None):
+        self.calls.append(("DELETE", path))
+        return {"status": "deleted"}
+
+
+def _run(monkeypatch, argv, fake):
+    monkeypatch.setattr(cli_main, "TaosClient", lambda **k: fake)
+    return cli_main.main(argv)
+
+
+def test_canvas_list_calls_endpoint(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["canvas", "list"], fake)
+    assert rc == 0
+    assert ("GET", "/api/canvas") in fake.calls
+
+
+def test_canvas_get_targets_by_id(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["--json", "canvas", "get", "abc123"], fake)
+    assert rc == 0
+    assert ("GET", "/api/canvas/abc123") in fake.calls
+
+
+def test_canvas_get_url_encodes_id(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["--json", "canvas", "get", "a/b c"], fake)
+    assert rc == 0
+    assert ("GET", "/api/canvas/a%2Fb%20c") in fake.calls
+
+
+def test_canvas_delete_targets_by_id(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["--json", "canvas", "delete", "abc123"], fake)
+    assert rc == 0
+    assert ("DELETE", "/api/canvas/abc123") in fake.calls
+
+
+def test_canvas_delete_url_encodes_id(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["--json", "canvas", "delete", "x/y"], fake)
+    assert rc == 0
+    assert ("DELETE", "/api/canvas/x%2Fy") in fake.calls
+
+
+def test_canvas_noun_is_discovered(monkeypatch):
+    from tinyagentos.cli.taosctl.commands import iter_noun_modules
+    nouns = {m.NOUN for m in iter_noun_modules()}
+    assert "canvas" in nouns

--- a/tinyagentos/cli/taosctl/commands/canvas.py
+++ b/tinyagentos/cli/taosctl/commands/canvas.py
@@ -1,0 +1,34 @@
+"""taosctl canvas -- inspect and manage canvas pages."""
+from __future__ import annotations
+
+from urllib.parse import quote
+
+NOUN = "canvas"
+
+
+def register(subparsers) -> None:
+    p = subparsers.add_parser(NOUN, help="Inspect and manage canvas pages")
+    verbs = p.add_subparsers(dest="verb", required=True, metavar="<verb>")
+
+    lp = verbs.add_parser("list", help="List all canvases")
+    lp.set_defaults(func=_list)
+
+    gp = verbs.add_parser("get", help="Get one canvas by id")
+    gp.add_argument("id", help="Canvas id")
+    gp.set_defaults(func=_get)
+
+    dp = verbs.add_parser("delete", help="Delete a canvas by id")
+    dp.add_argument("id", help="Canvas id")
+    dp.set_defaults(func=_delete)
+
+
+def _list(args, client):
+    return client.get("/api/canvas")
+
+
+def _get(args, client):
+    return client.get(f"/api/canvas/{quote(args.id, safe='')}")
+
+
+def _delete(args, client):
+    return client.delete(f"/api/canvas/{quote(args.id, safe='')}")


### PR DESCRIPTION
Autonomous build of board card tsk-s2gg56.

Wraps the canvas REST endpoints (list, get, delete) as taosctl subcommands,
mirroring the agents noun pattern with auto-discovery via register().

Files:
 tests/test_taosctl_canvas.py               | 65 ++++++++++++++++++++++++++++++
 tinyagentos/cli/taosctl/commands/canvas.py | 34 ++++++++++++++++
 2 files changed, 99 insertions(+)