### PR TITLE
feat(taosctl): add memory command group for agent memory management

### DIFF
--- a/tests/test_taosctl_memory.py
+++ b/tests/test_taosctl_memory.py
@@ -1,0 +1,109 @@
+"""Tests for the taosctl memory command group: dispatch, endpoint paths, and
+exit codes via a fake client driven through tinyagentos.cli.taosctl.__main__."""
+from __future__ import annotations
+
+from tinyagentos.cli.taosctl import client as cli_client
+from tinyagentos.cli.taosctl import __main__ as cli_main
+
+
+class _FakeClient:
+    def __init__(self, *a, **k):
+        self.calls = []
+        self.base_url = "http://x"
+        self.token = "t"
+        self._raise = None
+
+    def get(self, path, params=None):
+        self.calls.append(("GET", path))
+        if self._raise:
+            raise self._raise
+        return {"chunks": []}
+
+    def post(self, path, json=None):
+        self.calls.append(("POST", path))
+        if self._raise:
+            raise self._raise
+        return {"results": []}
+
+    def delete(self, path, params=None):
+        self.calls.append(("DELETE", path))
+        if self._raise:
+            raise self._raise
+        return {"status": "ok"}
+
+
+def _run(monkeypatch, argv, fake):
+    monkeypatch.setattr(cli_main, "TaosClient", lambda **k: fake)
+    return cli_main.main(argv)
+
+
+def test_memory_list_calls_browse(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["memory", "list"], fake)
+    assert rc == 0
+    assert ("GET", "/api/memory/browse") in fake.calls
+
+
+def test_memory_list_with_agent(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["memory", "list", "--agent", "alpha"], fake)
+    assert rc == 0
+    assert ("GET", "/api/memory/browse") in fake.calls
+
+
+def test_memory_search_calls_search(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["memory", "search", "hello world"], fake)
+    assert rc == 0
+    assert ("POST", "/api/memory/search") in fake.calls
+
+
+def test_memory_search_with_mode(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["memory", "search", "q", "--mode", "semantic"], fake)
+    assert rc == 0
+    assert ("POST", "/api/memory/search") in fake.calls
+
+
+def test_memory_collections_calls_endpoint(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["memory", "collections", "alpha"], fake)
+    assert rc == 0
+    assert ("GET", "/api/memory/collections/alpha") in fake.calls
+
+
+def test_memory_collections_url_encodes_agent(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["memory", "collections", "a/b c"], fake)
+    assert rc == 0
+    assert ("GET", "/api/memory/collections/a%2Fb%20c") in fake.calls
+
+
+def test_memory_delete_calls_endpoint(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["memory", "delete", "abc123"], fake)
+    assert rc == 0
+    assert ("DELETE", "/api/memory/chunk/abc123") in fake.calls
+
+
+def test_memory_delete_url_encodes_hash(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["memory", "delete", "ab/c d"], fake)
+    assert rc == 0
+    assert ("DELETE", "/api/memory/chunk/ab%2Fc%20d") in fake.calls
+
+
+def test_memory_api_error_maps_to_exit_2(monkeypatch, capsys):
+    fake = _FakeClient()
+    fake._raise = cli_client.ApiError(502, "qmd unavailable")
+    rc = _run(monkeypatch, ["memory", "list"], fake)
+    assert rc == 2
+    assert "qmd unavailable" in capsys.readouterr().err
+
+
+def test_memory_transport_error_maps_to_exit_1(monkeypatch, capsys):
+    fake = _FakeClient()
+    fake._raise = cli_client.TransportError("cannot reach http://x: refused")
+    rc = _run(monkeypatch, ["memory", "list"], fake)
+    assert rc == 1
+    assert "cannot reach" in capsys.readouterr().err

--- a/tinyagentos/cli/taosctl/commands/memory.py
+++ b/tinyagentos/cli/taosctl/commands/memory.py
@@ -1,0 +1,92 @@
+"""taosctl memory -- inspect and manage agent memory.
+
+Maps the memory REST endpoints to verbs:
+  list         -> GET  /api/memory/browse
+  search       -> POST /api/memory/search  (keyword or semantic)
+  collections  -> GET  /api/memory/collections/{agent}
+  delete       -> DELETE /api/memory/chunk/{hash}
+"""
+from __future__ import annotations
+
+from urllib.parse import quote
+
+NOUN = "memory"
+
+
+def register(subparsers) -> None:
+    p = subparsers.add_parser(NOUN, help="Inspect and manage agent memory")
+    verbs = p.add_subparsers(dest="verb", required=True, metavar="<verb>")
+
+    lp = verbs.add_parser("list", help="List memory chunks (browse)")
+    lp.add_argument("--agent", help="Agent name (omit for user scope)")
+    lp.add_argument("--collection", help="Collection filter")
+    lp.add_argument("--limit", type=int, default=20, help="Max results")
+    lp.add_argument("--offset", type=int, default=0, help="Offset")
+    lp.set_defaults(func=_list)
+
+    sp = verbs.add_parser("search", help="Search memory (keyword or semantic)")
+    sp.add_argument("query", help="Search query")
+    sp.add_argument("--agent", help="Agent name (omit for user scope)")
+    sp.add_argument("--collection", help="Collection filter")
+    sp.add_argument("--limit", type=int, default=20, help="Max results")
+    sp.add_argument("--mode", choices=["keyword", "semantic"], default="keyword",
+                    help="Search mode (default: keyword)")
+    sp.add_argument("--conversation-id", help="W3C trace conversation id")
+    sp.set_defaults(func=_search)
+
+    cp = verbs.add_parser("collections", help="List collections for an agent")
+    cp.add_argument("agent_name", help="Agent name")
+    cp.add_argument("--conversation-id", help="W3C trace conversation id")
+    cp.set_defaults(func=_collections)
+
+    dp = verbs.add_parser("delete", help="Delete a memory chunk by hash")
+    dp.add_argument("content_hash", help="Chunk content hash")
+    dp.add_argument("--agent", help="Agent name (omit for user scope)")
+    dp.add_argument("--conversation-id", help="W3C trace conversation id")
+    dp.set_defaults(func=_delete)
+
+
+def _list(args, client):
+    params: dict = {"limit": args.limit, "offset": args.offset}
+    if args.agent:
+        params["agent"] = args.agent
+    if args.collection:
+        params["collection"] = args.collection
+    return client.get("/api/memory/browse", params=params)
+
+
+def _search(args, client):
+    payload: dict = {
+        "query": args.query,
+        "mode": args.mode,
+        "limit": args.limit,
+    }
+    if args.agent:
+        payload["agent"] = args.agent
+    if args.collection:
+        payload["collection"] = args.collection
+    if args.conversation_id:
+        payload["conversation_id"] = args.conversation_id
+    return client.post("/api/memory/search", json=payload)
+
+
+def _collections(args, client):
+    params: dict = {}
+    if args.conversation_id:
+        params["conversation_id"] = args.conversation_id
+    return client.get(
+        f"/api/memory/collections/{quote(args.agent_name, safe='')}",
+        params=params,
+    )
+
+
+def _delete(args, client):
+    params: dict = {}
+    if args.agent:
+        params["agent"] = args.agent
+    if args.conversation_id:
+        params["conversation_id"] = args.conversation_id
+    return client.delete(
+        f"/api/memory/chunk/{quote(args.content_hash, safe='')}",
+        params=params,
+    )


### PR DESCRIPTION
Autonomous build of board card tsk-dtqrlv.

Adds taosctl memory with list/search/collections/delete verbs wrapping
tinyagentos/routes/memory.py endpoints. Includes test_taosctl_memory.py
with 10 tests covering dispatch, URL encoding, and error exit codes.

Files:
 tests/test_taosctl_memory.py               | 109 +++++++++++++++++++++++++++++
 tinyagentos/cli/taosctl/commands/memory.py |  92 ++++++++++++++++++++++++
 2 files changed, 201 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `taosctl memory` command suite for managing and inspecting agent memory
  * Provides subcommands to browse memory entries, search content, view memory collections, and delete chunks
  * Supports filtering by agent identifier, collection type, conversation ID, with configurable limit and offset parameters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->