### PR TITLE
fix(taosctl): client accepts json= as alias for body= (retires a recurring bug class)

### DIFF
--- a/tests/test_taosctl_client.py
+++ b/tests/test_taosctl_client.py
@@ -29,6 +29,7 @@ def _capture(monkeypatch):
     def fake_urlopen(req, timeout=None):
         seen["url"] = req.full_url
         seen["method"] = req.get_method()
+        seen["data"] = req.data
         return _FakeResp()
 
     monkeypatch.setattr(cli_client.urllib.request, "urlopen", fake_urlopen)
@@ -55,3 +56,28 @@ def test_get_drops_none_valued_params(monkeypatch):
     c = cli_client.TaosClient(url="http://x", token=None)
     c.get("/api/things", params={"a": "1", "b": None})
     assert seen["url"] == "http://x/api/things?a=1"
+
+
+def test_post_accepts_json_as_alias_for_body(monkeypatch):
+    # Callers habitually pass json= (the requests/httpx convention); the client
+    # treats it as the body so that habit is not a silent bug.
+    seen = _capture(monkeypatch)
+    c = cli_client.TaosClient(url="http://x", token=None)
+    c.post("/api/memory/search", json={"q": "hello"})
+    assert seen["method"] == "POST"
+    assert seen["data"] == b'{"q": "hello"}'
+
+
+def test_post_body_wins_over_json_when_both_given(monkeypatch):
+    seen = _capture(monkeypatch)
+    c = cli_client.TaosClient(url="http://x", token=None)
+    c.post("/api/x", body={"from": "body"}, json={"from": "json"})
+    assert seen["data"] == b'{"from": "body"}'
+
+
+def test_patch_accepts_json_alias(monkeypatch):
+    seen = _capture(monkeypatch)
+    c = cli_client.TaosClient(url="http://x", token=None)
+    c.patch("/api/x/1", json={"name": "n"})
+    assert seen["method"] == "PATCH"
+    assert seen["data"] == b'{"name": "n"}'

--- a/tinyagentos/cli/taosctl/client.py
+++ b/tinyagentos/cli/taosctl/client.py
@@ -90,11 +90,15 @@ class TaosClient:
     def get(self, path: str, params: Optional[dict] = None) -> Any:
         return self.request("GET", path, params=params)
 
-    def post(self, path: str, body: Optional[Any] = None, params: Optional[dict] = None) -> Any:
-        return self.request("POST", path, params=params, body=body)
+    def post(self, path: str, body: Optional[Any] = None, params: Optional[dict] = None,
+             json: Optional[Any] = None) -> Any:
+        # `json` is accepted as an alias for `body`: it is the conventional kwarg
+        # for a JSON payload in requests/httpx, so callers reach for it by habit.
+        # `body` wins if both are given.
+        return self.request("POST", path, params=params, body=body if body is not None else json)
 
-    def patch(self, path: str, body: Optional[Any] = None) -> Any:
-        return self.request("PATCH", path, body=body)
+    def patch(self, path: str, body: Optional[Any] = None, json: Optional[Any] = None) -> Any:
+        return self.request("PATCH", path, body=body if body is not None else json)
 
     def delete(self, path: str, params: Optional[dict] = None) -> Any:
         return self.request("DELETE", path, params=params)


### PR DESCRIPTION
The `json=` kwarg has now caused a `TypeError` twice in generated noun commands (projects #1047, memory #1068) because `json=` is the standard requests/httpx convention for a JSON body, so callers reach for it by habit while `TaosClient` only accepted `body=`. The per-noun test fakes mirror `json=`, so CI stays green while the real client breaks (the recurring mock-masks-bug trap).

Rather than fix-forward each noun forever, `post` and `patch` now accept `json=` as an alias for `body=` (`body` wins if both are given). This makes the in-flight memory noun (#1068) and any future POST noun correct on merge, and matches the convention agents expect. `body=` stays the documented kwarg.

Adds direct client tests (json alias on post + patch, body-wins precedence). Tests: 20 pass across client + projects + apps.