### PR TITLE
fix(taosctl): canvas get targets the real read route (/data)

### DIFF
--- a/tests/test_taosctl_canvas.py
+++ b/tests/test_taosctl_canvas.py
@@ -35,14 +35,14 @@ def test_canvas_get_targets_by_id(monkeypatch):
     fake = _FakeClient()
     rc = _run(monkeypatch, ["--json", "canvas", "get", "abc123"], fake)
     assert rc == 0
-    assert ("GET", "/api/canvas/abc123") in fake.calls
+    assert ("GET", "/api/canvas/abc123/data") in fake.calls
 
 
 def test_canvas_get_url_encodes_id(monkeypatch):
     fake = _FakeClient()
     rc = _run(monkeypatch, ["--json", "canvas", "get", "a/b c"], fake)
     assert rc == 0
-    assert ("GET", "/api/canvas/a%2Fb%20c") in fake.calls
+    assert ("GET", "/api/canvas/a%2Fb%20c/data") in fake.calls
 
 
 def test_canvas_delete_targets_by_id(monkeypatch):

--- a/tinyagentos/cli/taosctl/commands/canvas.py
+++ b/tinyagentos/cli/taosctl/commands/canvas.py
@@ -27,7 +27,9 @@ def _list(args, client):
 
 
 def _get(args, client):
-    return client.get(f"/api/canvas/{quote(args.id, safe='')}")
+    # The single-canvas read route is /api/canvas/{id}/data; the bare
+    # /api/canvas/{id} path only has a DELETE handler.
+    return client.get(f"/api/canvas/{quote(args.id, safe='')}/data")
 
 
 def _delete(args, client):

--- a/tinyagentos/cli/taosctl/commands/music.py
+++ b/tinyagentos/cli/taosctl/commands/music.py
@@ -1,8 +1,6 @@
 """taosctl music -- inspect and control music generation."""
 from __future__ import annotations
 
-from urllib.parse import quote
-
 NOUN = "music"
 
 


### PR DESCRIPTION
Fix-forward for a gitar Bug on merged code (#1067, on the Pi). `canvas get <id>` called `GET /api/canvas/{id}`, but that exact path only has a DELETE handler; the single-canvas read route is `GET /api/canvas/{id}/data`, so the command 404'd. Repointed to `/data`. Also folds in gitar's deferrable nit: removed an unused `quote` import from the music noun.

This was a verification miss on my part last sweep (I confirmed the DELETE on that path existed and assumed a GET did too); the lesson is to verify exact method+path. Tests: 10 pass (canvas + music).