### PR TITLE
feat(taosctl): add shared_folders command group

### DIFF
--- a/tests/test_taosctl_shared_folders.py
+++ b/tests/test_taosctl_shared_folders.py
@@ -1,0 +1,90 @@
+"""Tests for the taosctl shared_folders command group."""
+from __future__ import annotations
+
+from tinyagentos.cli.taosctl import __main__ as cli_main
+
+
+class _FakeClient:
+    def __init__(self, *a, **k):
+        self.calls = []
+        self.base_url = "http://x"
+        self.token = "t"
+
+    def get(self, path, params=None):
+        self.calls.append(("GET", path))
+        if params:
+            self.last_params = params
+        return {"items": [{"id": "1", "name": "docs"}]}
+
+    def post(self, path, body=None, params=None):
+        self.calls.append(("POST", path))
+        self.last_body = body
+        return {"id": "2", "name": (body or {}).get("name", "x")}
+
+    def delete(self, path):
+        self.calls.append(("DELETE", path))
+        return {"id": "1", "status": "deleted"}
+
+
+def _run(monkeypatch, argv, fake):
+    monkeypatch.setattr(cli_main, "TaosClient", lambda **k: fake)
+    return cli_main.main(argv)
+
+
+def test_shared_folders_list_hits_correct_endpoint(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["shared_folders", "list"], fake)
+    assert rc == 0
+    assert ("GET", "/api/shared-folders") in fake.calls
+
+
+def test_shared_folders_list_with_agent_name_param(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["shared_folders", "list", "--agent-name", "alpha"], fake)
+    assert rc == 0
+    assert ("GET", "/api/shared-folders") in fake.calls
+    assert fake.last_params == {"agent_name": "alpha"}
+
+
+def test_shared_folders_get_targets_by_id(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["shared_folders", "get", "1"], fake)
+    assert rc == 0
+    assert ("GET", "/api/shared-folders/1") in fake.calls
+
+
+def test_shared_folders_create_sends_post_with_body(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["shared_folders", "create", "docs"], fake)
+    assert rc == 0
+    assert ("POST", "/api/shared-folders") in fake.calls
+    assert fake.last_body == {"name": "docs", "description": ""}
+
+
+def test_shared_folders_create_with_agents(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["shared_folders", "create", "docs", "--agents", "a,b"], fake)
+    assert rc == 0
+    assert fake.last_body == {"name": "docs", "description": "", "agents": ["a", "b"]}
+
+
+def test_shared_folders_delete_hits_correct_endpoint(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["shared_folders", "delete", "1"], fake)
+    assert rc == 0
+    assert ("DELETE", "/api/shared-folders/1") in fake.calls
+
+
+def test_shared_folders_files_hits_correct_endpoint(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["shared_folders", "files", "docs"], fake)
+    assert rc == 0
+    assert ("GET", "/api/shared-folders/docs/files") in fake.calls
+
+
+def test_shared_folders_grant_hits_correct_endpoint(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["shared_folders", "grant", "1", "alpha"], fake)
+    assert rc == 0
+    assert ("POST", "/api/shared-folders/1/access") in fake.calls
+    assert fake.last_body == {"agent_name": "alpha", "permission": "readwrite"}

--- a/tinyagentos/cli/taosctl/commands/shared_folders.py
+++ b/tinyagentos/cli/taosctl/commands/shared_folders.py
@@ -1,0 +1,72 @@
+"""taosctl shared_folders -- inspect and manage shared folders."""
+from __future__ import annotations
+
+from urllib.parse import quote
+
+NOUN = "shared_folders"
+
+
+def register(subparsers) -> None:
+    p = subparsers.add_parser(NOUN, help="Inspect and manage shared folders")
+    verbs = p.add_subparsers(dest="verb", required=True, metavar="<verb>")
+
+    lp = verbs.add_parser("list", help="List shared folders")
+    lp.add_argument("--agent-name", default=None, help="Filter by agent name")
+    lp.set_defaults(func=_list)
+
+    gp = verbs.add_parser("get", help="Get one shared folder by id")
+    gp.add_argument("id", help="Folder id")
+    gp.set_defaults(func=_get)
+
+    cp = verbs.add_parser("create", help="Create a shared folder")
+    cp.add_argument("name", help="Folder name")
+    cp.add_argument("--description", default="", help="Short description")
+    cp.add_argument("--agents", default=None, help="Comma-separated agent names")
+    cp.set_defaults(func=_create)
+
+    dp = verbs.add_parser("delete", help="Delete a shared folder")
+    dp.add_argument("id", help="Folder id")
+    dp.set_defaults(func=_delete)
+
+    fp = verbs.add_parser("files", help="List files in a shared folder")
+    fp.add_argument("name", help="Folder name")
+    fp.set_defaults(func=_files)
+
+    # POST /api/shared-folders/{name}/upload -- skipped (file upload / multipart)
+
+    ap = verbs.add_parser("grant", help="Grant access to a shared folder")
+    ap.add_argument("folder_id", help="Folder id")
+    ap.add_argument("agent_name", help="Agent name")
+    ap.add_argument("--permission", default="readwrite", help="Permission level")
+    ap.set_defaults(func=_grant)
+
+
+def _list(args, client):
+    params = {}
+    if args.agent_name:
+        params["agent_name"] = args.agent_name
+    return client.get("/api/shared-folders", params=params or None)
+
+
+def _get(args, client):
+    return client.get(f"/api/shared-folders/{quote(args.id, safe='')}")
+
+
+def _create(args, client):
+    body = {"name": args.name, "description": args.description}
+    if args.agents:
+        body["agents"] = [a.strip() for a in args.agents.split(",")]
+    return client.post("/api/shared-folders", body=body)
+
+
+def _delete(args, client):
+    return client.delete(f"/api/shared-folders/{quote(args.id, safe='')}")
+
+
+def _files(args, client):
+    return client.get(f"/api/shared-folders/{quote(args.name, safe='')}/files")
+
+
+def _grant(args, client):
+    body = {"agent_name": args.agent_name, "permission": args.permission}
+    return client.post(f"/api/shared-folders/{quote(args.folder_id, safe='')}/access", body=body)


### PR DESCRIPTION
Autonomous build of board card tsk-7agq3m.

Add taosctl shared_folders with list, get, create, delete, files, and
grant verbs wrapping the /api/shared-folders endpoints. Skips the
upload endpoint (multipart file upload). Includes tests mirroring the
existing taosctl test pattern.

Files:
 tests/test_taosctl_shared_folders.py               | 90 ++++++++++++++++++++++
 tinyagentos/cli/taosctl/commands/shared_folders.py | 72 +++++++++++++++++
 2 files changed, 162 insertions(+)