### PR TITLE
fix(taosctl): shared_folders get filters list (was hitting a missing route)

### DIFF
--- a/tests/test_taosctl_shared_folders.py
+++ b/tests/test_taosctl_shared_folders.py
@@ -14,7 +14,10 @@ class _FakeClient:
         self.calls.append(("GET", path))
         if params:
             self.last_params = params
-        return {"items": [{"id": "1", "name": "docs"}]}
+        if path == "/api/shared-folders":
+            # The list endpoint returns a bare list of folders.
+            return [{"id": "1", "name": "docs"}]
+        return {"items": []}
 
     def post(self, path, body=None, params=None):
         self.calls.append(("POST", path))
@@ -46,11 +49,12 @@ def test_shared_folders_list_with_agent_name_param(monkeypatch):
     assert fake.last_params == {"agent_name": "alpha"}
 
 
-def test_shared_folders_get_targets_by_id(monkeypatch):
+def test_shared_folders_get_filters_list_by_id(monkeypatch):
+    # No single-folder GET route exists, so get fetches the list and filters.
     fake = _FakeClient()
     rc = _run(monkeypatch, ["shared_folders", "get", "1"], fake)
     assert rc == 0
-    assert ("GET", "/api/shared-folders/1") in fake.calls
+    assert ("GET", "/api/shared-folders") in fake.calls
 
 
 def test_shared_folders_create_sends_post_with_body(monkeypatch):

--- a/tinyagentos/cli/taosctl/commands/shared_folders.py
+++ b/tinyagentos/cli/taosctl/commands/shared_folders.py
@@ -49,7 +49,12 @@ def _list(args, client):
 
 
 def _get(args, client):
-    return client.get(f"/api/shared-folders/{quote(args.id, safe='')}")
+    # No single-folder GET route exists; fetch the list and filter by id.
+    rows = client.get("/api/shared-folders")
+    for row in rows or []:
+        if str(row.get("id")) == str(args.id):
+            return row
+    raise SystemExit(f"no shared folder with id: {args.id}")
 
 
 def _create(args, client):


### PR DESCRIPTION
Fix-forward for a gitar Bug on merged code (#1072). `shared_folders get <id>` issued `GET /api/shared-folders/{id}`, but the backend exposes no single-folder GET (only the list, plus files/create/delete/access). It now fetches the list and filters by id, erroring cleanly for an unknown id. The test fake mirrored the wrong shape ({items:[...]}); aligned it to the real list response (a bare list). Same invented-endpoint class as the earlier apps-get and canvas-get fixes. Tests: 8 pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the shared folders get command implementation to use a modified retrieval approach that fetches complete data and filters results locally for improved consistency.
* **Tests**
  * Updated test cases for shared folders operations to accurately reflect and verify the refactored command behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->