### PR TITLE
feat(#107): universal standalone-PWA shell (opt-in pwa flag + generic app.html + dynamic manifest + title-bar Install)

### DIFF
--- a/desktop/app.html
+++ b/desktop/app.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, user-scalable=no" />
+    <title>taOS</title>
+
+    <!-- Favicon -->
+    <link rel="icon" type="image/x-icon" href="/static/favicon.ico" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/static/icon-32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/static/icon-16.png" />
+
+    <!-- PWA manifest is injected at runtime by app-standalone-main.tsx -->
+    <meta name="theme-color" content="#141415" />
+
+    <!-- iOS PWA -->
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="taOS" />
+    <link rel="apple-touch-icon" href="/static/icon-180.png" />
+
+    <!-- iOS splash screens (reuse 512 icon on #141415 background; iOS scales it) -->
+    <link rel="apple-touch-startup-image" href="/static/icon-512.png" />
+
+    <meta name="mobile-web-app-capable" content="yes" />
+
+    <style>
+      html, body {
+        margin: 0;
+        padding: 0;
+        overflow: hidden;
+        height: 100%;
+        width: 100%;
+        /* Theme-aware dark canvas so Safari tints its chrome + safe areas dark. */
+        background: var(--color-shell-bg, #141415);
+        color-scheme: dark;
+        -webkit-user-select: none;
+        user-select: none;
+        -webkit-tap-highlight-color: transparent;
+      }
+      input, textarea, [contenteditable="true"] {
+        -webkit-user-select: text;
+        user-select: text;
+      }
+      #root { height: 100%; width: 100%; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/app-standalone-main.tsx"></script>
+  </body>
+</html>

--- a/desktop/src/AppStandalone.test.tsx
+++ b/desktop/src/AppStandalone.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ComponentType } from "react";
+
+// The registry mock is defined per-test via vi.mock hoisting; we override
+// getApp inside each test group instead.
+
+const FakeApp = ({ windowId }: { windowId: string }) => (
+  <div data-testid="fake-app" data-window={windowId}>
+    app content
+  </div>
+);
+
+// Default registry mock: messages is pwa-enabled, unknown is not present.
+vi.mock("./registry/app-registry", () => ({
+  getApp: vi.fn((id: string) => {
+    if (id === "messages") {
+      return {
+        id: "messages",
+        name: "Messages",
+        pwa: true,
+        component: () => Promise.resolve({ default: FakeApp as ComponentType<{ windowId: string }> }),
+      };
+    }
+    return undefined;
+  }),
+}));
+
+// InstallPromptBanner has side-effects (window.matchMedia, beforeinstallprompt)
+// that are not relevant to these tests; stub it out.
+vi.mock("./shell/InstallPromptBanner", () => ({
+  InstallPromptBanner: () => null,
+}));
+
+import { AppStandalone } from "./AppStandalone";
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("AppStandalone", () => {
+  it("renders the app component for a known pwa-enabled app", async () => {
+    render(<AppStandalone appId="messages" />);
+    await flush();
+    expect(screen.getByTestId("fake-app")).toBeTruthy();
+    expect(screen.getByTestId("fake-app").getAttribute("data-window")).toBe("standalone-messages");
+  });
+
+  it("renders nothing when the app id is not in the registry", () => {
+    render(<AppStandalone appId="does-not-exist" />);
+    expect(screen.queryByTestId("fake-app")).toBeNull();
+  });
+});

--- a/desktop/src/AppStandalone.tsx
+++ b/desktop/src/AppStandalone.tsx
@@ -1,0 +1,36 @@
+import { Suspense, lazy } from "react";
+import { getApp } from "./registry/app-registry";
+import { InstallPromptBanner } from "./shell/InstallPromptBanner";
+import type { ComponentType } from "react";
+
+interface Props {
+  appId: string;
+}
+
+export function AppStandalone({ appId }: Props) {
+  const manifest = getApp(appId);
+
+  // Guard: caller should verify pwa:true before mounting this component.
+  if (!manifest) return null;
+
+  const AppComponent = lazy(
+    () =>
+      manifest.component() as Promise<{ default: ComponentType<{ windowId: string }> }>,
+  );
+
+  return (
+    <div
+      className="h-screen w-screen flex flex-col overflow-hidden"
+      style={{ backgroundColor: "var(--color-shell-bg)", paddingTop: "env(safe-area-inset-top, 0px)" }}
+    >
+      <InstallPromptBanner />
+      <Suspense fallback={
+        <div className="flex items-center justify-center h-full" style={{ color: "rgba(255,255,255,0.4)" }}>
+          Loading...
+        </div>
+      }>
+        <AppComponent windowId={`standalone-${appId}`} />
+      </Suspense>
+    </div>
+  );
+}

--- a/desktop/src/app-standalone-main.tsx
+++ b/desktop/src/app-standalone-main.tsx
@@ -1,0 +1,58 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { AppStandalone } from "./AppStandalone";
+import { AppShell } from "./components/AppShell";
+import { restoreActiveTheme, installWebkitRepaintGuards } from "./stores/theme-store";
+import { getApp } from "./registry/app-registry";
+import "./theme/tokens.css";
+
+// Apply the user's persisted theme on boot, same as chat-main.tsx.
+void restoreActiveTheme();
+// WebKit blanks backdrop-filter surfaces when the tab is backgrounded then
+// shown again; re-composite on return (same fix the desktop shell installs).
+installWebkitRepaintGuards();
+
+const params = new URLSearchParams(location.search);
+const appId = params.get("app") ?? "";
+const manifest = appId ? getApp(appId) : undefined;
+
+if (!manifest?.pwa) {
+  // Unknown or non-PWA app: show a minimal not-installable message.
+  document.title = "Not installable";
+  createRoot(document.getElementById("root")!).render(
+    <StrictMode>
+      <div
+        style={{
+          height: "100%",
+          width: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          color: "rgba(255,255,255,0.5)",
+          fontSize: "0.9rem",
+          fontFamily: "system-ui, sans-serif",
+          background: "#141415",
+        }}
+      >
+        This app is not available as a standalone PWA.
+      </div>
+    </StrictMode>,
+  );
+} else {
+  // Inject the dynamic manifest link so the browser picks up the correct
+  // name, icons, and start_url for this specific app.
+  const link = document.createElement("link");
+  link.rel = "manifest";
+  link.href = `/manifest?app=${encodeURIComponent(appId)}`;
+  document.head.appendChild(link);
+
+  document.title = manifest.name;
+
+  createRoot(document.getElementById("root")!).render(
+    <StrictMode>
+      <AppShell>
+        <AppStandalone appId={appId} />
+      </AppShell>
+    </StrictMode>,
+  );
+}

--- a/desktop/src/components/Window.tsx
+++ b/desktop/src/components/Window.tsx
@@ -269,7 +269,24 @@ function WindowImpl({ win, onDrag, onDragStop }: Props) {
           <div className="flex-1 text-center text-xs text-shell-text-secondary truncate">
             {app?.name ?? win.appId}
           </div>
-          <div className="w-12" />
+          <div className="w-12 flex items-center justify-end">
+            {app?.pwa && !isMobile && (
+              <button
+                className="flex items-center justify-center w-5 h-5 rounded opacity-50 hover:opacity-90 hover:bg-shell-surface-hover transition-opacity"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  window.open(`/app.html?app=${encodeURIComponent(win.appId)}`, "_blank");
+                }}
+                aria-label={`Install ${app.name} as app`}
+                title={`Install ${app.name}`}
+              >
+                <svg width="11" height="11" viewBox="0 0 11 11" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M5.5 1v6M2.5 5l3 3 3-3" />
+                  <path d="M1 9h9" />
+                </svg>
+              </button>
+            )}
+          </div>
         </div>
 
         {/* Content */}

--- a/desktop/src/registry/app-registry.test.ts
+++ b/desktop/src/registry/app-registry.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { getOrRegisterServiceApp, prefetchApp, resolveApp } from "./app-registry";
+import { getApp, getOrRegisterServiceApp, getAllApps, prefetchApp, resolveApp } from "./app-registry";
 
 describe("resolveApp (deep-navigation token resolver)", () => {
   it("resolves an exact app id", () => {
@@ -25,6 +25,19 @@ describe("resolveApp (deep-navigation token resolver)", () => {
     expect(resolveApp("does-not-exist")).toBeUndefined();
     expect(resolveApp("")).toBeUndefined();
     expect(resolveApp("   ")).toBeUndefined();
+  });
+});
+
+describe("pwa flag", () => {
+  it("messages has pwa:true", () => {
+    expect(getApp("messages")?.pwa).toBe(true);
+  });
+
+  it("pwa is absent or falsy on all other apps", () => {
+    const others = getAllApps().filter((a) => a.id !== "messages");
+    for (const app of others) {
+      expect(app.pwa, `${app.id} should not have pwa:true`).toBeFalsy();
+    }
   });
 });
 

--- a/desktop/src/registry/app-registry.ts
+++ b/desktop/src/registry/app-registry.ts
@@ -18,11 +18,17 @@ export interface AppManifest {
    * persisted server-side (installed_apps, kind=frontend-app).
    */
   optional?: boolean;
+  /**
+   * Opt-in flag: only pwa:true apps are installable as standalone PWAs and
+   * get the title-bar Install button plus a dynamic manifest served by the
+   * backend. A fuller DRY source (shared with the backend) is a follow-up.
+   */
+  pwa?: boolean;
 }
 
 const apps: AppManifest[] = [
   // Platform apps
-  { id: "messages", name: "Messages", icon: "message-circle", category: "platform", component: () => import("@/apps/MessagesApp").then((m) => ({ default: m.MessagesApp })), defaultSize: { w: 900, h: 600 }, minSize: { w: 400, h: 300 }, singleton: true, pinned: true, launchpadOrder: 1 },
+  { id: "messages", name: "Messages", icon: "message-circle", category: "platform", component: () => import("@/apps/MessagesApp").then((m) => ({ default: m.MessagesApp })), defaultSize: { w: 900, h: 600 }, minSize: { w: 400, h: 300 }, singleton: true, pinned: true, launchpadOrder: 1, pwa: true },
   { id: "mail", name: "Mail", icon: "mail", category: "platform", component: () => import("@/apps/MailApp").then((m) => ({ default: m.MailApp })), defaultSize: { w: 1200, h: 800 }, minSize: { w: 720, h: 480 }, singleton: true, pinned: true, launchpadOrder: 1.25 },
   { id: "projects", name: "Projects", icon: "folder-kanban", category: "platform", component: () => import("@/apps/ProjectsApp").then((m) => ({ default: m.ProjectsApp })), defaultSize: { w: 1100, h: 720 }, minSize: { w: 700, h: 500 }, singleton: true, pinned: true, launchpadOrder: 1.5 },
   { id: "agents", name: "Agents", icon: "bot", category: "platform", component: () => import("@/apps/AgentsApp").then((m) => ({ default: m.AgentsApp })), defaultSize: { w: 1000, h: 650 }, minSize: { w: 500, h: 400 }, singleton: true, pinned: true, launchpadOrder: 2 },

--- a/desktop/vite.config.ts
+++ b/desktop/vite.config.ts
@@ -33,6 +33,7 @@ export default defineConfig({
       input: {
         main: path.resolve(__dirname, "index.html"),
         chat: path.resolve(__dirname, "chat.html"),
+        app: path.resolve(__dirname, "app.html"),
         sw: path.resolve(__dirname, "src/sw.ts"),
       },
       output: {

--- a/tests/test_manifest_route.py
+++ b/tests/test_manifest_route.py
@@ -1,0 +1,40 @@
+"""Tests for the dynamic PWA manifest endpoint (GET /manifest?app=<id>)."""
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_manifest_messages_returns_200(client):
+    resp = await client.get("/manifest?app=messages")
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_manifest_messages_has_correct_shape(client):
+    resp = await client.get("/manifest?app=messages")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["display"] == "standalone"
+    assert data["start_url"] == "/app.html?app=messages"
+    assert "name" in data
+    assert "short_name" in data
+    assert "icons" in data
+    assert len(data["icons"]) >= 2
+
+
+@pytest.mark.asyncio
+async def test_manifest_unknown_app_returns_404(client):
+    resp = await client.get("/manifest?app=unknown-app")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_manifest_non_pwa_app_returns_404(client):
+    # "files" is a real app that does not have pwa:true
+    resp = await client.get("/manifest?app=files")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_manifest_missing_param_returns_404(client):
+    resp = await client.get("/manifest?app=")
+    assert resp.status_code == 404

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -300,3 +300,6 @@ def register_all_routers(app):
     app.include_router(office_router)
     from tinyagentos.routes.coding import router as coding_router
     app.include_router(coding_router)
+
+    from tinyagentos.routes.manifest import router as manifest_router
+    app.include_router(manifest_router)

--- a/tinyagentos/routes/manifest.py
+++ b/tinyagentos/routes/manifest.py
@@ -1,0 +1,64 @@
+"""Dynamic PWA manifest endpoint.
+
+GET /manifest?app=<id> returns a Web App Manifest JSON for apps that are
+flagged pwa:true on the frontend. This mirrors the frontend pwa:true flag in
+app-registry.ts; a fuller DRY source shared between frontend and backend is a
+follow-up.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import JSONResponse
+
+router = APIRouter()
+
+# Maps app id -> manifest metadata for each pwa:true app in app-registry.ts.
+# Mirrors the frontend pwa:true flag; a shared source-of-truth is a follow-up.
+_PWA_APPS: dict[str, dict] = {
+    "messages": {
+        "name": "taOS talk",
+        "short_name": "taOS talk",
+        "theme_color": "#141415",
+        "background_color": "#141415",
+    },
+}
+
+
+@router.get("/manifest")
+async def get_manifest(app: str) -> JSONResponse:
+    """Return a Web App Manifest for a PWA-enabled app.
+
+    Returns 404 for unknown or non-PWA app ids.
+    """
+    meta = _PWA_APPS.get(app)
+    if not meta:
+        raise HTTPException(status_code=404, detail="App not found or not PWA-enabled")
+
+    manifest = {
+        "name": meta["name"],
+        "short_name": meta["short_name"],
+        "id": f"/app.html?app={app}",
+        "start_url": f"/app.html?app={app}",
+        "scope": "/",
+        "display": "standalone",
+        "theme_color": meta["theme_color"],
+        "background_color": meta["background_color"],
+        "icons": [
+            {
+                "src": "/static/icon-192.png",
+                "sizes": "192x192",
+                "type": "image/png",
+                "purpose": "any maskable",
+            },
+            {
+                "src": "/static/icon-512.png",
+                "sizes": "512x512",
+                "type": "image/png",
+                "purpose": "any maskable",
+            },
+        ],
+    }
+    return JSONResponse(
+        content=manifest,
+        headers={"Content-Type": "application/manifest+json"},
+    )


### PR DESCRIPTION
Implements #107 v1: any opted-in app becomes installable as a standalone PWA, generalizing the existing chat PWA.

What it adds:
- `pwa?: boolean` opt-in flag on AppManifest (app-registry.ts); set on `messages` as the proven demo.
- Generic `app.html` + `app-standalone-main.tsx`: reads `?app=<id>`, validates it is a pwa:true app (else a clean not-installable message), injects `<link rel=manifest href=/manifest?app=<id>>` at runtime, sets the title, and mounts the app in the shared AppShell (so it gets backend-status, error boundary, and service-worker registration).
- `AppStandalone.tsx`: generic analog of ChatStandalone, lazy-loads the app inside InstallPromptBanner.
- Backend `GET /manifest?app=<id>`: returns a proper Web App Manifest (display=standalone, start_url=/app.html?app=<id>, 192/512 icons) for pwa apps, 404 otherwise. Source of truth is a small server-side map mirroring the frontend flag, with a DRY-follow-up note.
- Title-bar Install button (Window.tsx): shown only for pwa:true apps on desktop, opens the standalone URL (where InstallPromptBanner / the iOS guide handles the actual install). Gated, accessible, encodeURIComponent.
- vite multi-entry gains `app.html`.

Tests: app-registry pwa flag, AppStandalone routing (known mounts / unknown renders nothing), and the /manifest endpoint (200 shape + 404s). 11 vitest + 5 pytest pass; `npm run build` clean.

Reviewed by me (bots are paused): backend manifest shape and 404 logic correct, runtime injection validates pwa + encodes the id, AppShell is the providers wrapper not desktop chrome, Install button correctly gated and accessible.

NOTE for Jay: code-correct and tested, but pixel-unverified (I cannot self-verify the frontend). Needs your visual check on the Pi after the next dev update: the Install button on a Messages window title bar, and the /app.html?app=messages standalone page. Ready to promote to master once you are happy. Follow-up: a shared frontend/backend source for the pwa app list (currently mirrored).