### PR TITLE
fix(#107): memoize standalone lazy (remount bug) + mobile Install button

### DIFF
--- a/desktop/src/AppStandalone.tsx
+++ b/desktop/src/AppStandalone.tsx
@@ -1,4 +1,4 @@
-import { Suspense, lazy } from "react";
+import { Suspense, lazy, useMemo } from "react";
 import { getApp } from "./registry/app-registry";
 import { InstallPromptBanner } from "./shell/InstallPromptBanner";
 import type { ComponentType } from "react";
@@ -10,13 +10,19 @@ interface Props {
 export function AppStandalone({ appId }: Props) {
   const manifest = getApp(appId);
 
-  // Guard: caller should verify pwa:true before mounting this component.
-  if (!manifest) return null;
-
-  const AppComponent = lazy(
+  // Create the lazy component ONCE per appId. Calling lazy() in the render body
+  // makes a new component type every render, which unmounts and remounts the
+  // app (losing its state) on any re-render.
+  const AppComponent = useMemo(
     () =>
-      manifest.component() as Promise<{ default: ComponentType<{ windowId: string }> }>,
+      manifest
+        ? lazy(() => manifest.component() as Promise<{ default: ComponentType<{ windowId: string }> }>)
+        : null,
+    [appId],
   );
+
+  // Guard: caller should verify pwa:true before mounting this component.
+  if (!manifest || !AppComponent) return null;
 
   return (
     <div

--- a/desktop/src/components/mobile/MobileAppWindow.tsx
+++ b/desktop/src/components/mobile/MobileAppWindow.tsx
@@ -66,8 +66,35 @@ export function MobileAppWindow({ appId, windowId, onClose, onMinimise }: Props)
           {app.name}
         </div>
 
-        {/* Right spacer for visual balance */}
-        <div style={{ width: "44px" }} />
+        {/* Right — Install (for pwa:true apps), else a spacer for balance. On
+            mobile there is no desktop title bar, so this is where a PWA app is
+            installed: it opens the standalone shell where the install prompt /
+            Add to Home Screen guide lives. */}
+        {app.pwa ? (
+          <button
+            onClick={() => window.open(`/app.html?app=${encodeURIComponent(appId)}`, "_blank")}
+            aria-label={`Install ${app.name} as app`}
+            className="flex items-center justify-center shrink-0 active:opacity-60"
+            style={{ width: "44px" }}
+          >
+            <svg
+              width="15"
+              height="15"
+              viewBox="0 0 15 15"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              style={{ color: "rgba(255,255,255,0.6)" }}
+            >
+              <path d="M7.5 1.5v7M4.5 6l3 3 3-3" />
+              <path d="M2.5 12.5h10" />
+            </svg>
+          </button>
+        ) : (
+          <div style={{ width: "44px" }} />
+        )}
       </div>
 
       {/* App content. Use the theme bg token (graphite); a hardcoded


### PR DESCRIPTION
Two #107 PWA-shell fixes:

1. **AppStandalone remount bug (gitar Bug on #1081):** lazy() was called in the render body, creating a new component type every render and remounting the app (losing state). Now memoized per appId, with the hook before the early return.

2. **Mobile had no install affordance (Jay, testing on phone):** the title-bar Install button is desktop-only, but on mobile Window.tsx takes a separate render path with no desktop title bar, so a PWA app could not be installed from a phone. Added an Install button to the mobile app title bar (MobileAppWindow) for pwa:true apps; it opens the standalone shell (/app.html?app=<id>) where the InstallPromptBanner / Add-to-Home-Screen guide handles the actual install.

Build verified by CI spa-build (local deps not installed). NOTE for Jay: pixel-unverified on mobile by me; please re-check on your phone after the next Pi update -- the Install icon should now appear in the Messages app title bar.