### PR TITLE
feat(taosctl): add browsing_history command group

### DIFF
--- a/tests/test_taosctl_browsing_history.py
+++ b/tests/test_taosctl_browsing_history.py
@@ -1,0 +1,77 @@
+"""Tests for the taosctl browsing_history command group."""
+
+from __future__ import annotations
+
+import pytest
+
+from tinyagentos.cli.taosctl import client as cli_client
+from tinyagentos.cli.taosctl import __main__ as cli_main
+
+
+class _FakeClient:
+    def __init__(self, *a, **k):
+        self.calls = []
+        self.base_url = "http://x"
+        self.token = "t"
+        self._raise = None
+
+    def get(self, path, params=None):
+        self.calls.append(("GET", path, params))
+        if self._raise:
+            raise self._raise
+        return {"items": [], "count": 0}
+
+    def delete(self, path, params=None):
+        self.calls.append(("DELETE", path, params))
+        if self._raise:
+            raise self._raise
+        return {"deleted": 0}
+
+
+def _run(monkeypatch, argv, fake):
+    monkeypatch.setattr(cli_main, "TaosClient", lambda **k: fake)
+    return cli_main.main(argv)
+
+
+def test_browsing_history_list_calls_endpoint(monkeypatch, capsys):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["browsing_history", "list"], fake)
+    assert rc == 0
+    assert ("GET", "/api/browsing-history", None) in fake.calls
+
+
+def test_browsing_history_list_with_params(monkeypatch, capsys):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["browsing_history", "list", "--source-type", "web", "--limit", "10"], fake)
+    assert rc == 0
+    assert ("GET", "/api/browsing-history", {"source_type": "web", "limit": 10}) in fake.calls
+
+
+def test_browsing_history_clear_calls_endpoint(monkeypatch, capsys):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["browsing_history", "clear"], fake)
+    assert rc == 0
+    assert ("DELETE", "/api/browsing-history", None) in fake.calls
+
+
+def test_browsing_history_clear_with_source_type(monkeypatch, capsys):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["browsing_history", "clear", "--source-type", "web"], fake)
+    assert rc == 0
+    assert ("DELETE", "/api/browsing-history", {"source_type": "web"}) in fake.calls
+
+
+def test_browsing_history_api_error_maps_to_exit_2(monkeypatch, capsys):
+    fake = _FakeClient()
+    fake._raise = cli_client.ApiError(500, "server error")
+    rc = _run(monkeypatch, ["browsing_history", "list"], fake)
+    assert rc == 2
+    assert "server error" in capsys.readouterr().err
+
+
+def test_browsing_history_transport_error_maps_to_exit_1(monkeypatch, capsys):
+    fake = _FakeClient()
+    fake._raise = cli_client.TransportError("cannot reach http://x: refused")
+    rc = _run(monkeypatch, ["browsing_history", "list"], fake)
+    assert rc == 1
+    assert "cannot reach" in capsys.readouterr().err

--- a/tinyagentos/cli/taosctl/commands/browsing_history.py
+++ b/tinyagentos/cli/taosctl/commands/browsing_history.py
@@ -1,0 +1,35 @@
+"""taosctl browsing_history -- inspect and manage browsing history."""
+
+from __future__ import annotations
+
+NOUN = "browsing_history"
+
+
+def register(subparsers) -> None:
+    p = subparsers.add_parser(NOUN, help="Inspect and manage browsing history")
+    verbs = p.add_subparsers(dest="verb", required=True, metavar="<verb>")
+
+    lp = verbs.add_parser("list", help="List browsing history")
+    lp.add_argument("--source-type", dest="source_type", default=None, help="Filter by source type")
+    lp.add_argument("--limit", type=int, default=50, help="Max items to return")
+    lp.set_defaults(func=_list)
+
+    cp = verbs.add_parser("clear", help="Clear browsing history")
+    cp.add_argument("--source-type", dest="source_type", default=None, help="Clear only a specific source type")
+    cp.set_defaults(func=_clear)
+
+
+def _list(args, client):
+    params = {}
+    if args.source_type is not None:
+        params["source_type"] = args.source_type
+    if args.limit != 50:
+        params["limit"] = args.limit
+    return client.get("/api/browsing-history", params=params or None)
+
+
+def _clear(args, client):
+    params = {}
+    if args.source_type is not None:
+        params["source_type"] = args.source_type
+    return client.delete("/api/browsing-history", params=params or None)


### PR DESCRIPTION
Autonomous build of board card tsk-gvtj7q.

Add taosctl browsing_history with list and clear verbs wrapping
GET /api/browsing-history and DELETE /api/browsing-history.
Skip the record endpoint (complex Pydantic body).

Files:
 tests/test_taosctl_browsing_history.py             | 77 ++++++++++++++++++++++
 .../cli/taosctl/commands/browsing_history.py       | 35 ++++++++++
 2 files changed, 112 insertions(+)