### PR TITLE
test(shibaclaw): mock retry backoff (was sleeping ~90s in CI)

### DIFF
--- a/tests/test_shibaclaw_adapter.py
+++ b/tests/test_shibaclaw_adapter.py
@@ -11,6 +11,19 @@ import tinyagentos.adapters.shibaclaw_adapter as sc_mod
 from tinyagentos.adapters.shibaclaw_adapter import app
 
 
+@pytest.fixture(autouse=True)
+def _instant_retry_backoff(monkeypatch):
+    # with_retry backs off with asyncio.sleep between attempts. The retry tests
+    # exhaust all 7 attempts, so without this each would sleep ~31s of real time.
+    # Make the backoff instant; the retry COUNT is unchanged.
+    import asyncio
+
+    async def _no_sleep(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+
+
 # ---------------------------------------------------------------------------
 # health endpoint
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fix-forward for a gitar Performance finding on #1082. The shibaclaw retry tests genuinely exhaust all 7 `with_retry` attempts, and `with_retry` backs off with real `asyncio.sleep`, so the three retry tests slept ~31s each (~90s total) on every CI run. An autouse fixture mocks `asyncio.sleep` to a no-op so the backoff is instant; the retry COUNT assertions (call_count == 7) are unchanged. Suite drops from ~90s to under a second.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test execution speed by optimizing retry and backoff behavior during test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->