### PR TITLE
fix: send explicit --limit even when it equals the default

### DIFF
--- a/tests/test_taosctl_browsing_history.py
+++ b/tests/test_taosctl_browsing_history.py
@@ -47,6 +47,13 @@ def test_browsing_history_list_with_params(monkeypatch, capsys):
     assert ("GET", "/api/browsing-history", {"source_type": "web", "limit": 10}) in fake.calls
 
 
+def test_browsing_history_list_explicit_default_limit(monkeypatch, capsys):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["browsing_history", "list", "--limit", "50"], fake)
+    assert rc == 0
+    assert ("GET", "/api/browsing-history", {"limit": 50}) in fake.calls
+
+
 def test_browsing_history_clear_calls_endpoint(monkeypatch, capsys):
     fake = _FakeClient()
     rc = _run(monkeypatch, ["browsing_history", "clear"], fake)

--- a/tinyagentos/cli/taosctl/commands/browsing_history.py
+++ b/tinyagentos/cli/taosctl/commands/browsing_history.py
@@ -11,7 +11,7 @@ def register(subparsers) -> None:
 
     lp = verbs.add_parser("list", help="List browsing history")
     lp.add_argument("--source-type", dest="source_type", default=None, help="Filter by source type")
-    lp.add_argument("--limit", type=int, default=50, help="Max items to return")
+    lp.add_argument("--limit", type=int, default=None, help="Max items to return")
     lp.set_defaults(func=_list)
 
     cp = verbs.add_parser("clear", help="Clear browsing history")
@@ -23,7 +23,7 @@ def _list(args, client):
     params = {}
     if args.source_type is not None:
         params["source_type"] = args.source_type
-    if args.limit != 50:
+    if args.limit is not None:
         params["limit"] = args.limit
     return client.get("/api/browsing-history", params=params or None)
 


### PR DESCRIPTION
Autonomous build of board card tsk-jeyncg.

Default argparse --limit to None instead of 50, and include limit in
query params only when it is not None. This ensures any explicit
--limit value (including 50) is sent to the backend, while omitting
--limit lets the backend default apply.

Files:
 tests/test_taosctl_browsing_history.py               | 7 +++++++
 tinyagentos/cli/taosctl/commands/browsing_history.py | 4 ++--
 2 files changed, 9 insertions(+), 2 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the browsing history list command to optimize API requests by only sending the limit parameter when explicitly specified by the user, rather than always including it.

* **Tests**
  * Added test case to verify proper handling of explicitly provided limit parameters in browsing history list command requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->