### PR TITLE
feat(#106): in-OS feedback app (bug/feature submit with screenshot)

### DIFF
--- a/desktop/src/apps/FeedbackApp.test.tsx
+++ b/desktop/src/apps/FeedbackApp.test.tsx
@@ -1,0 +1,189 @@
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { FeedbackApp } from "./FeedbackApp";
+
+/* ------------------------------------------------------------------ */
+/*  Fetch mock helpers                                                 */
+/* ------------------------------------------------------------------ */
+
+function mockFetch(responses: Record<string, { ok: boolean; status?: number; body: unknown }>) {
+  return vi.fn().mockImplementation((input: string, init?: RequestInit) => {
+    const method = (init?.method ?? "GET").toUpperCase();
+    const key = `${method} ${input}`;
+    const hit = responses[key] ?? responses[input] ?? responses["*"];
+    if (!hit) throw new Error(`Unmocked fetch: ${key}`);
+    return Promise.resolve({
+      ok: hit.ok,
+      status: hit.status ?? (hit.ok ? 200 : 422),
+      json: () => Promise.resolve(hit.body),
+    });
+  });
+}
+
+async function flush() {
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 0));
+  });
+}
+
+/* ------------------------------------------------------------------ */
+/*  Tests                                                              */
+/* ------------------------------------------------------------------ */
+
+describe("FeedbackApp", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders the form with Bug Report selected by default", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch({ "GET /api/feedback": { ok: true, body: [] } }),
+    );
+    render(<FeedbackApp windowId="w1" />);
+    await flush();
+
+    expect(screen.getByRole("group", { name: /feedback type/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /bug report/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /feature request/i })).toBeTruthy();
+    expect(screen.getByLabelText(/title/i)).toBeTruthy();
+    expect(screen.getByRole("button", { name: /submit/i })).toBeTruthy();
+  });
+
+  it("toggles between bug and feature types", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch({ "GET /api/feedback": { ok: true, body: [] } }),
+    );
+    render(<FeedbackApp windowId="w1" />);
+    await flush();
+
+    const bugBtn = screen.getByRole("button", { name: /bug report/i });
+    const featureBtn = screen.getByRole("button", { name: /feature request/i });
+
+    // Bug is default
+    expect(bugBtn.getAttribute("aria-pressed")).toBe("true");
+    expect(featureBtn.getAttribute("aria-pressed")).toBe("false");
+
+    // Click feature
+    fireEvent.click(featureBtn);
+    expect(bugBtn.getAttribute("aria-pressed")).toBe("false");
+    expect(featureBtn.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("shows validation error when title is empty and submit is clicked", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch({ "GET /api/feedback": { ok: true, body: [] } }),
+    );
+    render(<FeedbackApp windowId="w1" />);
+    await flush();
+
+    fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+    await flush();
+
+    expect(screen.getByRole("alert").textContent).toMatch(/title is required/i);
+  });
+
+  it("posts to /api/feedback on valid submit and shows success", async () => {
+    const fetchMock = mockFetch({
+      "GET /api/feedback": { ok: true, body: [] },
+      "POST /api/feedback": {
+        ok: true,
+        status: 201,
+        body: {
+          id: "abc",
+          type: "bug",
+          title: "Login broken",
+          body: "",
+          app: "",
+          created_at: new Date().toISOString(),
+          has_screenshot: false,
+        },
+      },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    render(<FeedbackApp windowId="w1" />);
+    await flush();
+
+    fireEvent.change(screen.getByLabelText(/title/i), {
+      target: { value: "Login broken" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+    await flush();
+
+    // Should show success message
+    await waitFor(() =>
+      expect(screen.getByRole("status").textContent).toMatch(/thanks for the feedback/i),
+    );
+
+    // POST should have been called with the right body
+    const postCall = fetchMock.mock.calls.find(
+      (c) => (c[1] as RequestInit)?.method === "POST",
+    );
+    expect(postCall).toBeTruthy();
+    const sentBody = JSON.parse((postCall![1] as RequestInit).body as string);
+    expect(sentBody.type).toBe("bug");
+    expect(sentBody.title).toBe("Login broken");
+  });
+
+  it("shows error message when the server returns a failure", async () => {
+    const fetchMock = mockFetch({
+      "GET /api/feedback": { ok: true, body: [] },
+      "POST /api/feedback": {
+        ok: false,
+        status: 422,
+        body: { detail: "title must not be empty" },
+      },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    render(<FeedbackApp windowId="w1" />);
+    await flush();
+
+    fireEvent.change(screen.getByLabelText(/title/i), {
+      target: { value: "  x  " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+    await flush();
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert").textContent).toMatch(/title must not be empty/i),
+    );
+  });
+
+  it("renders past submissions returned by GET /api/feedback", async () => {
+    const items = [
+      {
+        id: "1",
+        type: "bug",
+        title: "Dark mode flicker",
+        body: "",
+        app: "",
+        created_at: new Date(Date.now() - 3600_000).toISOString(),
+        has_screenshot: true,
+      },
+      {
+        id: "2",
+        type: "feature",
+        title: "Export to PDF",
+        body: "",
+        app: "",
+        created_at: new Date(Date.now() - 86400_000 * 2).toISOString(),
+        has_screenshot: false,
+      },
+    ];
+    vi.stubGlobal(
+      "fetch",
+      mockFetch({ "GET /api/feedback": { ok: true, body: items } }),
+    );
+    render(<FeedbackApp windowId="w1" />);
+    await flush();
+
+    await waitFor(() => {
+      expect(screen.getByText("Dark mode flicker")).toBeTruthy();
+      expect(screen.getByText("Export to PDF")).toBeTruthy();
+    });
+    // Screenshot indicator for item 1
+    expect(screen.getByText(/has screenshot/i)).toBeTruthy();
+  });
+});

--- a/desktop/src/apps/FeedbackApp.tsx
+++ b/desktop/src/apps/FeedbackApp.tsx
@@ -1,0 +1,373 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import { Flag, ImagePlus, X, CheckCircle2, AlertCircle, Clock } from "lucide-react";
+import { Button, Input, Label, Textarea } from "@/components/ui";
+
+type FeedbackType = "bug" | "feature";
+
+interface FeedbackItem {
+  id: string;
+  type: FeedbackType;
+  title: string;
+  body: string;
+  app: string;
+  created_at: string;
+  has_screenshot: boolean;
+}
+
+function relativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  return `${days}d ago`;
+}
+
+function TypeToggle({
+  value,
+  onChange,
+}: {
+  value: FeedbackType;
+  onChange: (v: FeedbackType) => void;
+}) {
+  return (
+    <div
+      className="inline-flex rounded-lg border border-shell-border bg-shell-bg-deep p-0.5"
+      role="group"
+      aria-label="Feedback type"
+    >
+      {(["bug", "feature"] as const).map((t) => (
+        <button
+          key={t}
+          type="button"
+          onClick={() => onChange(t)}
+          className={[
+            "rounded-md px-4 py-1.5 text-sm font-medium transition-colors",
+            value === t
+              ? "bg-shell-surface text-shell-text shadow-sm"
+              : "text-shell-text-secondary hover:text-shell-text",
+          ].join(" ")}
+          aria-pressed={value === t}
+        >
+          {t === "bug" ? "Bug Report" : "Feature Request"}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function ScreenshotPicker({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  function readFile(file: File) {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const result = e.target?.result;
+      if (typeof result === "string") onChange(result);
+    };
+    reader.readAsDataURL(file);
+  }
+
+  function handleFile(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (file) readFile(file);
+    e.target.value = "";
+  }
+
+  function handlePaste(e: React.ClipboardEvent<HTMLDivElement>) {
+    for (const item of Array.from(e.clipboardData.items)) {
+      if (item.type.startsWith("image/")) {
+        const file = item.getAsFile();
+        if (file) {
+          readFile(file);
+          e.preventDefault();
+          return;
+        }
+      }
+    }
+  }
+
+  if (value) {
+    return (
+      <div className="relative inline-block" onPaste={handlePaste}>
+        <img
+          src={value}
+          alt="Screenshot preview"
+          className="max-h-40 rounded-lg border border-shell-border object-contain"
+        />
+        <button
+          type="button"
+          onClick={() => onChange("")}
+          className="absolute -right-2 -top-2 rounded-full bg-shell-bg-deep p-0.5 text-shell-text-secondary ring-1 ring-shell-border hover:text-shell-text"
+          aria-label="Remove screenshot"
+        >
+          <X size={14} />
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="flex items-center gap-2"
+      onPaste={handlePaste}
+      tabIndex={0}
+      aria-label="Screenshot paste target"
+    >
+      <input
+        ref={fileRef}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        onChange={handleFile}
+        aria-label="Choose screenshot file"
+      />
+      <button
+        type="button"
+        onClick={() => fileRef.current?.click()}
+        className="flex items-center gap-1.5 rounded-lg border border-dashed border-shell-border px-3 py-2 text-sm text-shell-text-secondary hover:border-shell-border-strong hover:text-shell-text transition-colors"
+      >
+        <ImagePlus size={14} />
+        Add screenshot
+      </button>
+      <span className="text-xs text-shell-text-tertiary">or paste from clipboard</span>
+    </div>
+  );
+}
+
+function TypeBadge({ type }: { type: FeedbackType }) {
+  return (
+    <span
+      className={[
+        "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium",
+        type === "bug"
+          ? "bg-red-500/10 text-red-400"
+          : "bg-blue-500/10 text-blue-400",
+      ].join(" ")}
+    >
+      {type === "bug" ? "Bug" : "Feature"}
+    </span>
+  );
+}
+
+export function FeedbackApp({ windowId: _windowId }: { windowId: string }) {
+  const [fbType, setFbType] = useState<FeedbackType>("bug");
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  const [screenshot, setScreenshot] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [history, setHistory] = useState<FeedbackItem[]>([]);
+  const [loadingHistory, setLoadingHistory] = useState(true);
+
+  const loadHistory = useCallback(async () => {
+    try {
+      const res = await fetch("/api/feedback");
+      if (res.ok) {
+        setHistory(await res.json());
+      }
+    } catch {
+      // History is non-critical; silently skip on network error.
+    } finally {
+      setLoadingHistory(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadHistory();
+  }, [loadHistory]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setSuccess(false);
+
+    const trimmedTitle = title.trim();
+    if (!trimmedTitle) {
+      setError("Title is required.");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const res = await fetch("/api/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          type: fbType,
+          title: trimmedTitle,
+          body,
+          screenshot,
+        }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        const detail = data?.detail;
+        const msg =
+          typeof detail === "string"
+            ? detail
+            : Array.isArray(detail)
+              ? detail.map((d: { msg?: string }) => d.msg).join(", ")
+              : "Submission failed. Please try again.";
+        setError(msg);
+        return;
+      }
+
+      setSuccess(true);
+      setTitle("");
+      setBody("");
+      setScreenshot("");
+      await loadHistory();
+    } catch {
+      setError("Could not reach the server.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden bg-shell-bg">
+      {/* Header */}
+      <div className="flex items-center gap-2 border-b border-shell-border px-5 py-4">
+        <Flag size={18} className="text-accent" />
+        <h1 className="text-base font-semibold text-shell-text">Feedback</h1>
+      </div>
+
+      <div className="flex flex-1 flex-col gap-0 overflow-y-auto">
+        {/* Form section */}
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4 px-5 py-5">
+          {/* Type toggle */}
+          <div className="flex flex-col gap-1.5">
+            <Label className="text-xs font-medium text-shell-text-secondary">Type</Label>
+            <TypeToggle value={fbType} onChange={setFbType} />
+          </div>
+
+          {/* Title */}
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="fb-title" className="text-xs font-medium text-shell-text-secondary">
+              Title <span className="text-red-400">*</span>
+            </Label>
+            <Input
+              id="fb-title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder={
+                fbType === "bug"
+                  ? "Short description of the issue"
+                  : "What feature would you like?"
+              }
+              maxLength={300}
+              className="bg-shell-surface border-shell-border text-shell-text placeholder:text-shell-text-tertiary"
+              aria-required="true"
+            />
+          </div>
+
+          {/* Description */}
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="fb-body" className="text-xs font-medium text-shell-text-secondary">
+              Description
+            </Label>
+            <Textarea
+              id="fb-body"
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              placeholder={
+                fbType === "bug"
+                  ? "Steps to reproduce, what you expected, what actually happened..."
+                  : "Describe the feature and why it would be useful..."
+              }
+              rows={4}
+              maxLength={20000}
+              className="resize-none bg-shell-surface border-shell-border text-shell-text placeholder:text-shell-text-tertiary"
+            />
+          </div>
+
+          {/* Screenshot */}
+          <div className="flex flex-col gap-1.5">
+            <Label className="text-xs font-medium text-shell-text-secondary">
+              Screenshot (optional)
+            </Label>
+            <ScreenshotPicker value={screenshot} onChange={setScreenshot} />
+          </div>
+
+          {/* Feedback messages */}
+          {success && (
+            <div
+              className="flex items-center gap-2 rounded-lg border border-green-500/20 bg-green-500/10 px-4 py-3 text-sm text-green-400"
+              role="status"
+            >
+              <CheckCircle2 size={16} className="shrink-0" />
+              Thanks for the feedback!
+            </div>
+          )}
+          {error && (
+            <div
+              className="flex items-center gap-2 rounded-lg border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm text-red-400"
+              role="alert"
+            >
+              <AlertCircle size={16} className="shrink-0" />
+              {error}
+            </div>
+          )}
+
+          <div className="flex justify-end">
+            <Button type="submit" disabled={submitting} className="min-w-[100px]">
+              {submitting ? "Sending..." : "Submit"}
+            </Button>
+          </div>
+        </form>
+
+        {/* Past submissions */}
+        <div className="border-t border-shell-border px-5 py-4">
+          <h2 className="mb-3 text-xs font-medium uppercase tracking-wide text-shell-text-tertiary">
+            Your submissions
+          </h2>
+
+          {loadingHistory ? (
+            <p className="text-sm text-shell-text-tertiary">Loading...</p>
+          ) : history.length === 0 ? (
+            <p className="text-sm text-shell-text-tertiary">No submissions yet.</p>
+          ) : (
+            <ul className="flex flex-col gap-2">
+              {history.map((item) => (
+                <li
+                  key={item.id}
+                  className="flex items-start gap-3 rounded-lg border border-shell-border bg-shell-surface px-4 py-3"
+                >
+                  <div className="flex flex-1 flex-col gap-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <TypeBadge type={item.type} />
+                      <span className="truncate text-sm font-medium text-shell-text">
+                        {item.title}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-2 text-xs text-shell-text-tertiary">
+                      <Clock size={11} className="shrink-0" />
+                      {relativeTime(item.created_at)}
+                      {item.has_screenshot && (
+                        <span className="text-shell-text-secondary">
+                          &middot; has screenshot
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/registry/app-registry.ts
+++ b/desktop/src/registry/app-registry.ts
@@ -59,6 +59,7 @@ const apps: AppManifest[] = [
   { id: "github-browser", name: "GitHub", icon: "github", category: "platform", component: () => import("@/apps/GitHubApp").then((m) => ({ default: m.GitHubApp })), defaultSize: { w: 1000, h: 650 }, minSize: { w: 550, h: 400 }, singleton: true, pinned: false, launchpadOrder: 15, optional: true },
   { id: "x-monitor", name: "X", icon: "at-sign", category: "platform", component: () => import("@/apps/XApp").then((m) => ({ default: m.XApp })), defaultSize: { w: 1000, h: 650 }, minSize: { w: 550, h: 400 }, singleton: true, pinned: false, launchpadOrder: 15.5, optional: true },
   { id: "agent-browsers", name: "Browsers", icon: "globe", category: "platform", component: () => import("@/apps/AgentBrowsersApp").then((m) => ({ default: m.AgentBrowsersApp })), defaultSize: { w: 1000, h: 650 }, minSize: { w: 550, h: 400 }, singleton: true, pinned: false, launchpadOrder: 16 },
+  { id: "feedback", name: "Feedback", icon: "flag", category: "platform", component: () => import("@/apps/FeedbackApp").then((m) => ({ default: m.FeedbackApp })), defaultSize: { w: 700, h: 560 }, minSize: { w: 420, h: 400 }, singleton: true, pinned: false, launchpadOrder: 16.5 },
 
   // OS apps
   { id: "weather", name: "Weather", icon: "cloud", category: "os", component: () => import("@/apps/WeatherApp").then((m) => ({ default: m.WeatherApp })), defaultSize: { w: 800, h: 600 }, minSize: { w: 400, h: 400 }, singleton: true, pinned: false, launchpadOrder: 19 },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -318,6 +318,10 @@ async def client(app, tmp_data_dir):
     if office_docs._db is not None:
         await office_docs.close()
     await office_docs.init()
+    feedback_store = app.state.feedback_store
+    if feedback_store._db is not None:
+        await feedback_store.close()
+    await feedback_store.init()
     # BrowserApp v2 stores
     from tinyagentos.routes.desktop_browser.store import BrowserStore, BrowserCookieStore
     _browser_store = BrowserStore(tmp_data_dir / "browser.sqlite3")
@@ -369,6 +373,7 @@ async def client(app, tmp_data_dir):
     await notif_store.close()
     await store.close()
     await office_docs.close()
+    await feedback_store.close()
     await app.state.qmd_client.close()
     await app.state.http_client.aclose()
     await _browser_store.close()

--- a/tests/test_feedback_route.py
+++ b/tests/test_feedback_route.py
@@ -1,0 +1,155 @@
+"""Tests for POST/GET /api/feedback endpoints."""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+
+from tinyagentos.feedback_store import FeedbackStore, MAX_SCREENSHOT_LEN
+
+
+# ---------------------------------------------------------------------------
+# Store-level unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def store(tmp_path):
+    s = FeedbackStore(tmp_path / "feedback.db")
+    await s.init()
+    yield s
+    await s.close()
+
+
+@pytest.mark.asyncio
+async def test_store_create_and_list(store):
+    item = await store.create(
+        user_id="u1",
+        type="bug",
+        title="Something broke",
+        body="Details here",
+    )
+    assert item["id"]
+    assert item["type"] == "bug"
+    assert item["created_at"]
+
+    items = await store.list_for_user("u1")
+    assert len(items) == 1
+    assert items[0]["id"] == item["id"]
+    # List endpoint must NOT include the screenshot blob
+    assert "screenshot" not in items[0]
+    assert "has_screenshot" in items[0]
+    assert items[0]["has_screenshot"] is False
+
+
+@pytest.mark.asyncio
+async def test_store_get_by_id_includes_screenshot(store):
+    await store.create(
+        user_id="u1",
+        type="feature",
+        title="Dark mode",
+        body="",
+        screenshot="data:image/png;base64,abc123",
+    )
+    items = await store.list_for_user("u1")
+    full = await store.get_by_id(items[0]["id"], "u1")
+    assert full is not None
+    assert full["screenshot"] == "data:image/png;base64,abc123"
+    assert full["has_screenshot"] is True
+
+
+@pytest.mark.asyncio
+async def test_store_user_isolation(store):
+    await store.create(user_id="u1", type="bug", title="User 1 bug", body="")
+    await store.create(user_id="u2", type="feature", title="User 2 feature", body="")
+
+    u1_items = await store.list_for_user("u1")
+    u2_items = await store.list_for_user("u2")
+    assert len(u1_items) == 1
+    assert len(u2_items) == 1
+    assert u1_items[0]["title"] == "User 1 bug"
+    assert u2_items[0]["title"] == "User 2 feature"
+
+
+# ---------------------------------------------------------------------------
+# Route-level tests via the async HTTP client
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_post_feedback_creates_submission(client):
+    resp = await client.post(
+        "/api/feedback",
+        json={"type": "bug", "title": "Login fails", "body": "Cannot sign in"},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["type"] == "bug"
+    assert data["title"] == "Login fails"
+    assert "id" in data
+    assert "created_at" in data
+    assert "screenshot" not in data
+    assert data["has_screenshot"] is False
+
+
+@pytest.mark.asyncio
+async def test_get_feedback_lists_submissions(client):
+    await client.post(
+        "/api/feedback",
+        json={"type": "feature", "title": "Add dark mode", "body": ""},
+    )
+    resp = await client.get("/api/feedback")
+    assert resp.status_code == 200
+    items = resp.json()
+    assert len(items) >= 1
+    assert items[0]["title"] == "Add dark mode"
+    assert "screenshot" not in items[0]
+
+
+@pytest.mark.asyncio
+async def test_get_feedback_by_id_returns_screenshot(client):
+    screenshot = "data:image/png;base64," + "A" * 100
+    post_resp = await client.post(
+        "/api/feedback",
+        json={"type": "bug", "title": "Visual glitch", "body": "", "screenshot": screenshot},
+    )
+    item_id = post_resp.json()["id"]
+
+    resp = await client.get(f"/api/feedback/{item_id}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["screenshot"] == screenshot
+    assert data["has_screenshot"] is True
+
+
+@pytest.mark.asyncio
+async def test_invalid_type_rejected(client):
+    resp = await client.post(
+        "/api/feedback",
+        json={"type": "complaint", "title": "Bad type", "body": ""},
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_empty_title_rejected(client):
+    resp = await client.post(
+        "/api/feedback",
+        json={"type": "bug", "title": "   ", "body": ""},
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_oversized_screenshot_rejected(client):
+    big_screenshot = "data:image/png;base64," + "A" * (MAX_SCREENSHOT_LEN + 1)
+    resp = await client.post(
+        "/api/feedback",
+        json={"type": "bug", "title": "Big screenshot", "body": "", "screenshot": big_screenshot},
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_get_unknown_id_returns_404(client):
+    resp = await client.get("/api/feedback/does-not-exist")
+    assert resp.status_code == 404

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -85,6 +85,7 @@ from tinyagentos.chat.channel_store import ChatChannelStore
 from tinyagentos.chat.hub import ChatHub
 from tinyagentos.chat.canvas import CanvasStore
 from tinyagentos.desktop_settings import DesktopSettingsStore
+from tinyagentos.feedback_store import FeedbackStore
 from tinyagentos.user_memory import UserMemoryStore
 from tinyagentos.user_personas import UserPersonaStore
 from tinyagentos.installed_apps import InstalledAppsStore
@@ -342,6 +343,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     user_memory = UserMemoryStore(data_dir / "user_memory.db")
     user_personas = UserPersonaStore(data_dir / "user_personas.db")
     installed_apps = InstalledAppsStore(data_dir / "installed_apps.db")
+    feedback_store = FeedbackStore(data_dir / "feedback.db")
     from tinyagentos.userspace.store import UserspaceAppStore
     from tinyagentos.userspace.data_store import UserspaceDataStore
     userspace_apps = UserspaceAppStore(data_dir / "userspace_apps.db")
@@ -427,6 +429,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await desktop_settings.init()
         await user_memory.init()
         await installed_apps.init()
+        await feedback_store.init()
+        app.state.feedback_store = feedback_store
         await userspace_apps.init()
         app.state.userspace_apps = userspace_apps
         await userspace_data.init()
@@ -1137,6 +1141,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await knowledge_graph.close()
         await archive.close()
         await installed_apps.close()
+        await feedback_store.close()
         await userspace_apps.close()
         await userspace_data.close()
         await office_docs.close()
@@ -1313,6 +1318,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     app.state.user_memory = user_memory
     app.state.user_personas = user_personas
     app.state.installed_apps = installed_apps
+    app.state.feedback_store = feedback_store
     app.state.userspace_apps = userspace_apps
     app.state.userspace_data = userspace_data
     app.state.office_docs = office_docs

--- a/tinyagentos/feedback_store.py
+++ b/tinyagentos/feedback_store.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+from tinyagentos.base_store import BaseStore
+
+# Maximum allowed screenshot size (base64 data-URL string length, not raw bytes).
+# A 2 MB raw image becomes ~2.73 MB as base64; 4 MB covers that with headroom.
+MAX_SCREENSHOT_LEN = 4_000_000
+
+# Maximum body text length.
+MAX_BODY_LEN = 20_000
+
+
+class FeedbackStore(BaseStore):
+    SCHEMA = """
+    CREATE TABLE IF NOT EXISTS feedback (
+        id TEXT NOT NULL PRIMARY KEY,
+        user_id TEXT NOT NULL,
+        type TEXT NOT NULL,
+        title TEXT NOT NULL,
+        body TEXT NOT NULL DEFAULT '',
+        screenshot TEXT NOT NULL DEFAULT '',
+        app TEXT NOT NULL DEFAULT '',
+        created_at TEXT NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS feedback_user_created
+        ON feedback (user_id, created_at DESC);
+    """
+
+    async def create(
+        self,
+        *,
+        user_id: str,
+        type: str,
+        title: str,
+        body: str,
+        screenshot: str = "",
+        app: str = "",
+    ) -> dict:
+        assert self._db is not None
+        item_id = str(uuid.uuid4())
+        created_at = datetime.now(timezone.utc).isoformat()
+        await self._db.execute(
+            """
+            INSERT INTO feedback (id, user_id, type, title, body, screenshot, app, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (item_id, user_id, type, title, body, screenshot, app, created_at),
+        )
+        await self._db.commit()
+        return {
+            "id": item_id,
+            "user_id": user_id,
+            "type": type,
+            "title": title,
+            "body": body,
+            "screenshot": screenshot,
+            "app": app,
+            "created_at": created_at,
+        }
+
+    async def list_for_user(self, user_id: str) -> list[dict]:
+        """Return all submissions for a user, most recent first, without screenshot blobs."""
+        assert self._db is not None
+        cursor = await self._db.execute(
+            """
+            SELECT id, user_id, type, title, body, app, created_at,
+                   (screenshot != '') AS has_screenshot
+            FROM feedback
+            WHERE user_id = ?
+            ORDER BY created_at DESC
+            """,
+            (user_id,),
+        )
+        rows = await cursor.fetchall()
+        return [
+            {
+                "id": r[0],
+                "user_id": r[1],
+                "type": r[2],
+                "title": r[3],
+                "body": r[4],
+                "app": r[5],
+                "created_at": r[6],
+                "has_screenshot": bool(r[7]),
+            }
+            for r in rows
+        ]
+
+    async def get_by_id(self, item_id: str, user_id: str) -> dict | None:
+        """Return a single feedback item including the screenshot, scoped to the user."""
+        assert self._db is not None
+        cursor = await self._db.execute(
+            """
+            SELECT id, user_id, type, title, body, screenshot, app, created_at
+            FROM feedback
+            WHERE id = ? AND user_id = ?
+            """,
+            (item_id, user_id),
+        )
+        row = await cursor.fetchone()
+        if row is None:
+            return None
+        return {
+            "id": row[0],
+            "user_id": row[1],
+            "type": row[2],
+            "title": row[3],
+            "body": row[4],
+            "screenshot": row[5],
+            "app": row[6],
+            "created_at": row[7],
+            "has_screenshot": bool(row[5]),
+        }

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -296,6 +296,9 @@ def register_all_routers(app):
     from tinyagentos.routes.userspace_apps import router as userspace_apps_router
     app.include_router(userspace_apps_router)
 
+    from tinyagentos.routes.feedback import router as feedback_router
+    app.include_router(feedback_router)
+
     from tinyagentos.routes.office import router as office_router
     app.include_router(office_router)
     from tinyagentos.routes.coding import router as coding_router

--- a/tinyagentos/routes/feedback.py
+++ b/tinyagentos/routes/feedback.py
@@ -1,0 +1,115 @@
+"""Routes for the in-OS Feedback feature.
+
+POST /api/feedback  -- submit a bug report or feature request
+GET  /api/feedback  -- list the current user's past submissions (no screenshot blob)
+GET  /api/feedback/{id} -- fetch a single submission including its screenshot
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, field_validator
+
+from tinyagentos.auth import get_current_user
+from tinyagentos.feedback_store import MAX_BODY_LEN, MAX_SCREENSHOT_LEN
+
+router = APIRouter()
+
+VALID_TYPES = {"bug", "feature"}
+
+
+class FeedbackSubmit(BaseModel):
+    type: str
+    title: str
+    body: str = ""
+    screenshot: str = ""
+    app: str = ""
+
+    @field_validator("type")
+    @classmethod
+    def validate_type(cls, v: str) -> str:
+        if v not in VALID_TYPES:
+            raise ValueError(f"type must be one of {sorted(VALID_TYPES)}")
+        return v
+
+    @field_validator("title")
+    @classmethod
+    def validate_title(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("title must not be empty")
+        if len(v) > 300:
+            raise ValueError("title is too long (max 300 chars)")
+        return v
+
+    @field_validator("body")
+    @classmethod
+    def validate_body(cls, v: str) -> str:
+        if len(v) > MAX_BODY_LEN:
+            raise ValueError(f"body exceeds the maximum length of {MAX_BODY_LEN} characters")
+        return v
+
+    @field_validator("screenshot")
+    @classmethod
+    def validate_screenshot(cls, v: str) -> str:
+        if v and len(v) > MAX_SCREENSHOT_LEN:
+            raise ValueError(
+                f"screenshot is too large (max {MAX_SCREENSHOT_LEN // 1_000_000} MB)"
+            )
+        return v
+
+
+@router.post("/api/feedback", status_code=201)
+async def submit_feedback(
+    payload: FeedbackSubmit,
+    request: Request,
+    current_user: dict[str, Any] = Depends(get_current_user),
+) -> dict:
+    """Create a new feedback submission for the authenticated user."""
+    store = request.app.state.feedback_store
+    item = await store.create(
+        user_id=current_user["id"],
+        type=payload.type,
+        title=payload.title,
+        body=payload.body,
+        screenshot=payload.screenshot,
+        app=payload.app,
+    )
+    # Return without the screenshot blob to keep the response light.
+    return {
+        "id": item["id"],
+        "type": item["type"],
+        "title": item["title"],
+        "body": item["body"],
+        "app": item["app"],
+        "created_at": item["created_at"],
+        "has_screenshot": bool(item["screenshot"]),
+    }
+
+
+@router.get("/api/feedback")
+async def list_feedback(
+    request: Request,
+    current_user: dict[str, Any] = Depends(get_current_user),
+) -> list[dict]:
+    """List the current user's feedback submissions, most recent first.
+
+    Screenshots are omitted; use GET /api/feedback/{id} to retrieve one.
+    """
+    store = request.app.state.feedback_store
+    return await store.list_for_user(current_user["id"])
+
+
+@router.get("/api/feedback/{item_id}")
+async def get_feedback(
+    item_id: str,
+    request: Request,
+    current_user: dict[str, Any] = Depends(get_current_user),
+) -> dict:
+    """Return a single feedback submission including its screenshot."""
+    store = request.app.state.feedback_store
+    item = await store.get_by_id(item_id, current_user["id"])
+    if item is None:
+        raise HTTPException(status_code=404, detail="Feedback item not found")
+    return item


### PR DESCRIPTION
Implements #856 / board #106 v1: submit a bug report or feature request from inside taOS, with an optional screenshot.

- Backend: `tinyagentos/feedback_store.py` (aiosqlite, per-user, screenshot capped ~4MB, body capped 20k) + `tinyagentos/routes/feedback.py` (`POST /api/feedback`, `GET /api/feedback` list without the blob, `GET /api/feedback/{id}` full). Auth via the existing get_current_user; Pydantic validators reject bad type, empty title, oversized body/screenshot. Wired into the app lifespan + tests fixture the same way as the other stores.
- Frontend: `FeedbackApp.tsx` (Bug/Feature toggle, title + description, screenshot via file picker OR clipboard paste with thumbnail, submit with success/error states, a list of past submissions) registered in app-registry (id feedback, flag icon). It is a self-contained lazy-loaded app, so it does not touch the desktop shell.
- Tests: 10 pytest (store + route, incl. validation 422s, user isolation, 404) + 6 vitest (render, toggle, validation, submit, error, history). All pass; npm run build green.

Reviewed by me (bots paused): auth correct, validation thorough, store lifecycle matches existing pattern, no desktop-shell coupling.

NOTE for Jay: pixel-unverified by me; a quick look at the Feedback app after the next Pi update would confirm the form + screenshot paste. Follow-ups (deferred): public website tracker + voting, and log auto-capture.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Feedback app for submitting bug reports and feature requests
  * Support for attaching screenshots via file upload or clipboard pasting
  * View history of your previously submitted feedback items with timestamps and type indicators
  * Real-time form validation and user-friendly error messages
  * Success confirmations for submitted feedback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->