### PR TITLE
fix(#107): serve /app.html (mobile Install button 404'd to a black screen)

### DIFF
--- a/tests/test_routes_desktop.py
+++ b/tests/test_routes_desktop.py
@@ -48,6 +48,18 @@ def test_sw_js_returns_404_when_not_built(client, monkeypatch, tmp_path):
     assert r.status_code == 404
 
 
+def test_app_html_served_without_auth(client, monkeypatch, tmp_path):
+    """The generic standalone PWA shell /app.html is served (with the ?app=
+    query) and is auth-exempt -- the mobile Install button opens it."""
+    fake_dir = tmp_path / "fake-spa"
+    fake_dir.mkdir()
+    (fake_dir / "app.html").write_text("<!doctype html><title>app</title>")
+    monkeypatch.setattr("tinyagentos.routes.desktop.SPA_DIR", fake_dir)
+    r = client.get("/app.html?app=messages")
+    assert r.status_code == 200
+    assert "text/html" in r.headers.get("content-type", "")
+
+
 # ---------------------------------------------------------------------------
 # PWA shell pre-login accessibility
 # The service worker must be able to precache the shell HTML without a

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -7,7 +7,7 @@ from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import RedirectResponse
 
-EXEMPT_PATHS = {"/auth/login", "/auth/setup", "/auth/status", "/auth/me", "/auth/complete", "/auth/lock", "/api/health", "/api/version", "/setup", "/setup/complete", "/redeem", "/api/desktop/browser/push/vapid-public-key", "/api/desktop/browser/proxy-config", "/sw.js", "/desktop", "/desktop/index.html", "/chat-pwa", "/api/agents/registry/pubkey"}
+EXEMPT_PATHS = {"/auth/login", "/auth/setup", "/auth/status", "/auth/me", "/auth/complete", "/auth/lock", "/api/health", "/api/version", "/setup", "/setup/complete", "/redeem", "/api/desktop/browser/push/vapid-public-key", "/api/desktop/browser/proxy-config", "/sw.js", "/desktop", "/desktop/index.html", "/chat-pwa", "/app.html", "/manifest", "/api/agents/registry/pubkey"}
 
 # Registry feed endpoints accept EITHER an admin session OR a registry JWT.
 # When a Bearer token is present for these paths the request bypasses the

--- a/tinyagentos/routes/desktop.py
+++ b/tinyagentos/routes/desktop.py
@@ -119,6 +119,17 @@ async def serve_chat_pwa_assets(rest: str = ""):
     return JSONResponse({"error": "Chat PWA not built"}, status_code=404)
 
 
+@router.get("/app.html")
+async def serve_app_pwa():
+    """Serve the generic standalone app PWA shell. It reads ?app=<id> at runtime
+    and mounts that app full-screen (assets load from the /desktop/assets base,
+    same as the chat PWA)."""
+    app_html = SPA_DIR / "app.html"
+    if app_html.exists():
+        return FileResponse(app_html, media_type="text/html")
+    return JSONResponse({"error": "App PWA shell not built"}, status_code=404)
+
+
 @router.post("/api/desktop/browser/agent-command")
 async def browser_agent_command(request: Request):
     """Execute a natural language command on the current page using browser-use."""


### PR DESCRIPTION
Jay hit a black screen with {"detail":"Not Found"} when pressing the mobile Install button. The #107 PWA shell added app.html to the build and referenced /app.html?app=<id> in both the Install button and the dynamic manifest start_url, but no backend route served /app.html (the SPA HTML entries are served by explicit routes in routes/desktop.py, e.g. /chat-pwa, and /app.html was never wired). 

Fix: serve /app.html from routes/desktop.py mirroring the /chat-pwa handler (assets load from the same /desktop/assets base), and add /app.html + /manifest to the auth EXEMPT_PATHS so the standalone shell loads before the in-app login (the app enforces auth itself, same as the chat PWA). Adds a route test. 9 desktop route tests pass.