### PR TITLE
fix(#107): Install button opens a dismissable install-helper panel (no more trap)

### DIFF
--- a/desktop/src/components/InstallHelperPanel.test.tsx
+++ b/desktop/src/components/InstallHelperPanel.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { InstallHelperPanel } from "./InstallHelperPanel";
+
+describe("InstallHelperPanel", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "location", {
+      value: { origin: "http://localhost:3000" },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders with appId and appName in heading", () => {
+    render(
+      <InstallHelperPanel appId="myapp" appName="My App" onClose={vi.fn()} />
+    );
+    expect(screen.getByText("Install My App")).toBeInTheDocument();
+  });
+
+  it("shows the correct install URL", () => {
+    render(
+      <InstallHelperPanel appId="myapp" appName="My App" onClose={vi.fn()} />
+    );
+    expect(
+      screen.getByDisplayValue("http://localhost:3000/app.html?app=myapp")
+    ).toBeInTheDocument();
+  });
+
+  it("Copy button writes URL to clipboard", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", {
+      ...navigator,
+      clipboard: { writeText },
+      userAgent: "Chrome",
+      platform: "Win32",
+      maxTouchPoints: 0,
+    });
+
+    render(
+      <InstallHelperPanel appId="myapp" appName="My App" onClose={vi.fn()} />
+    );
+
+    fireEvent.click(screen.getByText("Copy"));
+    expect(writeText).toHaveBeenCalledWith(
+      expect.stringContaining("/app.html?app=myapp")
+    );
+  });
+
+  it("onClose fires when Done button is clicked", () => {
+    const onClose = vi.fn();
+    render(
+      <InstallHelperPanel appId="myapp" appName="My App" onClose={onClose} />
+    );
+    fireEvent.click(screen.getByText("Done"));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/desktop/src/components/InstallHelperPanel.tsx
+++ b/desktop/src/components/InstallHelperPanel.tsx
@@ -1,0 +1,168 @@
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+
+interface Props {
+  appId: string;
+  appName: string;
+  onClose: () => void;
+}
+
+function isIOS(): boolean {
+  return (
+    /iphone|ipad|ipod/i.test(navigator.userAgent) ||
+    (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1)
+  );
+}
+
+export function InstallHelperPanel({ appId, appName, onClose }: Props) {
+  const [copied, setCopied] = useState(false);
+
+  const url = `${window.location.origin}/app.html?app=${encodeURIComponent(appId)}`;
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [onClose]);
+
+  function handleCopy() {
+    navigator.clipboard.writeText(url).catch(() => {
+      const el = document.getElementById("install-helper-url-input") as HTMLInputElement | null;
+      el?.select();
+    });
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  const platformHint = isIOS()
+    ? "In Safari, tap the Share button, then Add to Home Screen."
+    : "In Chrome, open the menu and choose Install app or Add to Home screen.";
+
+  // Portal to body so the fixed overlay is not mispositioned when mounted
+  // inside a transformed ancestor (the desktop window uses CSS transforms).
+  return createPortal(
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 200,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "rgba(0,0,0,0.5)",
+        padding: "1rem",
+      }}
+      onClick={onClose}
+      onKeyDown={(e) => { if (e.key === "Escape") onClose(); }}
+      tabIndex={-1}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="install-helper-title"
+    >
+      <div
+        style={{
+          background: "var(--color-shell-surface, #1c1c1f)",
+          border: "1px solid rgba(255,255,255,0.1)",
+          borderRadius: "12px",
+          boxShadow: "0 24px 64px rgba(0,0,0,0.5)",
+          width: "100%",
+          maxWidth: "420px",
+          padding: "1.25rem 1.5rem 1.5rem",
+          display: "flex",
+          flexDirection: "column",
+          gap: "0.75rem",
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2
+          id="install-helper-title"
+          style={{
+            margin: 0,
+            fontSize: "0.875rem",
+            fontWeight: 600,
+            color: "var(--color-shell-text, #fff)",
+          }}
+        >
+          Install {appName}
+        </h2>
+
+        <p
+          style={{
+            margin: 0,
+            fontSize: "0.8125rem",
+            color: "var(--color-shell-text-secondary, rgba(255,255,255,0.55))",
+            lineHeight: 1.5,
+          }}
+        >
+          To use {appName} as its own app, open the link below in your browser,
+          then add it to your home screen.
+        </p>
+
+        <input
+          id="install-helper-url-input"
+          readOnly
+          value={url}
+          style={{
+            fontFamily: "ui-monospace, monospace",
+            fontSize: "0.75rem",
+            background: "rgba(0,0,0,0.25)",
+            border: "1px solid rgba(255,255,255,0.1)",
+            borderRadius: "6px",
+            padding: "0.5rem 0.625rem",
+            color: "var(--color-shell-text, #fff)",
+            width: "100%",
+            boxSizing: "border-box",
+          }}
+          onClick={(e) => (e.target as HTMLInputElement).select()}
+          aria-label="Install URL"
+        />
+
+        <p
+          style={{
+            margin: 0,
+            fontSize: "0.8125rem",
+            color: "var(--color-shell-text-secondary, rgba(255,255,255,0.55))",
+            lineHeight: 1.5,
+          }}
+        >
+          {platformHint}
+        </p>
+
+        <div style={{ display: "flex", gap: "0.5rem", justifyContent: "flex-end", marginTop: "0.25rem" }}>
+          <button
+            onClick={handleCopy}
+            style={{
+              fontSize: "0.8125rem",
+              padding: "0.4rem 0.875rem",
+              borderRadius: "6px",
+              border: "1px solid rgba(255,255,255,0.15)",
+              background: "rgba(255,255,255,0.07)",
+              color: "var(--color-shell-text, #fff)",
+              cursor: "pointer",
+              minWidth: "64px",
+            }}
+          >
+            {copied ? "Copied!" : "Copy"}
+          </button>
+          <button
+            onClick={onClose}
+            style={{
+              fontSize: "0.8125rem",
+              padding: "0.4rem 0.875rem",
+              borderRadius: "6px",
+              border: "none",
+              background: "rgba(255,255,255,0.15)",
+              color: "var(--color-shell-text, #fff)",
+              cursor: "pointer",
+            }}
+          >
+            Done
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/desktop/src/components/Window.tsx
+++ b/desktop/src/components/Window.tsx
@@ -6,6 +6,7 @@ import { getApp } from "@/registry/app-registry";
 import { getSnapBounds } from "@/hooks/use-snap-zones";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { WindowContent } from "./WindowContent";
+import { InstallHelperPanel } from "./InstallHelperPanel";
 
 interface Props {
   win: WindowState;
@@ -30,6 +31,7 @@ function WindowImpl({ win, onDrag, onDragStop }: Props) {
   const app = getApp(win.appId);
   const preSnapRef = useRef<{ x: number; y: number; w: number; h: number } | null>(null);
   const isMobile = useIsMobile();
+  const [installOpen, setInstallOpen] = useState(false);
   const reduceMotion = useReducedMotion();
   // GPU drag hint: only promote the inner chrome to its own layer while the
   // user is actively dragging/resizing. Permanent will-change bloats GPU
@@ -275,7 +277,7 @@ function WindowImpl({ win, onDrag, onDragStop }: Props) {
                 className="flex items-center justify-center w-5 h-5 rounded opacity-50 hover:opacity-90 hover:bg-shell-surface-hover transition-opacity"
                 onClick={(e) => {
                   e.stopPropagation();
-                  window.open(`/app.html?app=${encodeURIComponent(win.appId)}`, "_blank");
+                  setInstallOpen(true);
                 }}
                 aria-label={`Install ${app.name} as app`}
                 title={`Install ${app.name}`}
@@ -285,6 +287,13 @@ function WindowImpl({ win, onDrag, onDragStop }: Props) {
                   <path d="M1 9h9" />
                 </svg>
               </button>
+            )}
+            {installOpen && app && (
+              <InstallHelperPanel
+                appId={win.appId}
+                appName={app.name}
+                onClose={() => setInstallOpen(false)}
+              />
             )}
           </div>
         </div>

--- a/desktop/src/components/mobile/MobileAppWindow.tsx
+++ b/desktop/src/components/mobile/MobileAppWindow.tsx
@@ -1,6 +1,7 @@
-import { Suspense, lazy, useMemo } from "react";
+import { Suspense, lazy, useMemo, useState } from "react";
 import { X, Minus } from "lucide-react";
 import { getApp } from "@/registry/app-registry";
+import { InstallHelperPanel } from "../InstallHelperPanel";
 
 interface Props {
   appId: string;
@@ -11,6 +12,7 @@ interface Props {
 
 export function MobileAppWindow({ appId, windowId, onClose, onMinimise }: Props) {
   const app = getApp(appId);
+  const [installOpen, setInstallOpen] = useState(false);
   const LazyComponent = useMemo(() => {
     if (!app) return null;
     return lazy(app.component);
@@ -72,7 +74,7 @@ export function MobileAppWindow({ appId, windowId, onClose, onMinimise }: Props)
             Add to Home Screen guide lives. */}
         {app.pwa ? (
           <button
-            onClick={() => window.open(`/app.html?app=${encodeURIComponent(appId)}`, "_blank")}
+            onClick={() => setInstallOpen(true)}
             aria-label={`Install ${app.name} as app`}
             className="flex items-center justify-center shrink-0 active:opacity-60"
             style={{ width: "44px" }}
@@ -96,6 +98,14 @@ export function MobileAppWindow({ appId, windowId, onClose, onMinimise }: Props)
           <div style={{ width: "44px" }} />
         )}
       </div>
+
+      {installOpen && (
+        <InstallHelperPanel
+          appId={appId}
+          appName={app.name}
+          onClose={() => setInstallOpen(false)}
+        />
+      )}
 
       {/* App content. Use the theme bg token (graphite); a hardcoded
           rgba(15,15,35) here read as an indigo flash on the dark theme. */}


### PR DESCRIPTION
Jay reported the mobile Install button trapped him in a fullscreen page with no way back: window.open(/app.html) inside an installed PWA just navigates within the PWA (iOS cannot open Safari from a PWA, and a PWA cannot install another PWA). Per Jay's choice, the button now opens a dismissable install-helper panel instead: the install URL with a Copy button and platform-aware Add to Home Screen instructions (iOS Share -> Add to Home Screen, otherwise Chrome menu -> Install), with a Done button + backdrop/Escape dismiss so the user is never stranded.

The new InstallHelperPanel component portals to document.body (so the fixed overlay is not mispositioned inside the desktop window's transformed Rnd container) and is wired into both Window.tsx (desktop title bar) and MobileAppWindow.tsx (mobile title bar). Note: this was re-integrated cleanly off current dev after a subagent's first attempt landed on a 229-commit-stale base.

Tests: InstallHelperPanel 4/4 pass; npm run build green; the 3 changed files typecheck clean.

NOTE for Jay: pixel-unverified on mobile by me; a quick look after the next Pi update would confirm the panel + Copy + dismiss.