### PR TITLE
fix(#107): no-cache headers on /app.html + /chat-pwa shells

### DIFF
--- a/tests/test_routes_desktop.py
+++ b/tests/test_routes_desktop.py
@@ -57,6 +57,8 @@ def test_app_html_served_without_auth(client, monkeypatch, tmp_path):
     monkeypatch.setattr("tinyagentos.routes.desktop.SPA_DIR", fake_dir)
     r = client.get("/app.html?app=messages")
     assert r.status_code == 200
+    # The shell HTML must revalidate so an updated bundle is not served stale.
+    assert "no-cache" in r.headers.get("Cache-Control", "")
     assert "text/html" in r.headers.get("content-type", "")
 
 

--- a/tinyagentos/routes/desktop.py
+++ b/tinyagentos/routes/desktop.py
@@ -105,7 +105,7 @@ async def serve_chat_pwa():
     """Serve the standalone chat PWA."""
     chat_html = SPA_DIR / "chat.html"
     if chat_html.exists():
-        return FileResponse(chat_html, media_type="text/html")
+        return FileResponse(chat_html, media_type="text/html", headers=_HTML_NO_CACHE)
     return JSONResponse({"error": "Chat PWA not built"}, status_code=404)
 
 
@@ -115,7 +115,7 @@ async def serve_chat_pwa_assets(rest: str = ""):
     # Assets are at /desktop/assets/... due to base path — this route just serves index
     chat_html = SPA_DIR / "chat.html"
     if chat_html.exists():
-        return FileResponse(chat_html, media_type="text/html")
+        return FileResponse(chat_html, media_type="text/html", headers=_HTML_NO_CACHE)
     return JSONResponse({"error": "Chat PWA not built"}, status_code=404)
 
 
@@ -126,7 +126,7 @@ async def serve_app_pwa():
     same as the chat PWA)."""
     app_html = SPA_DIR / "app.html"
     if app_html.exists():
-        return FileResponse(app_html, media_type="text/html")
+        return FileResponse(app_html, media_type="text/html", headers=_HTML_NO_CACHE)
     return JSONResponse({"error": "App PWA shell not built"}, status_code=404)
 
 


### PR DESCRIPTION
Fix-forward for a gitar Bug on #1095. The /app.html PWA shell (and the pre-existing /chat-pwa) were served with a plain FileResponse and no cache-control headers, so a browser or service worker could keep serving a stale shell after an update -- the same stale-bundle class users have hit. Serve all three (the two /chat-pwa routes + /app.html) with the existing _HTML_NO_CACHE dict (no-cache, no-store, must-revalidate) exactly as index.html is served. Test asserts the header on /app.html. Desktop route tests pass.