### PR TITLE
feat(launcher): name the userspace section 'My Apps'

### DIFF
--- a/desktop/src/components/Launchpad.tsx
+++ b/desktop/src/components/Launchpad.tsx
@@ -150,7 +150,7 @@ export function Launchpad({ open, onClose, onOpenApp }: Props) {
           {filteredUserspace.length > 0 && (
             <div>
               <h3 className="text-xs font-medium text-shell-text-tertiary uppercase tracking-wide mb-4 px-1">
-                Apps
+                My Apps
               </h3>
               <div className="grid gap-2 sm:gap-3" style={{ gridTemplateColumns: "repeat(auto-fill, minmax(100px, 1fr))" }}>
                 {filteredUserspace.map((app) => (


### PR DESCRIPTION
Apps a user makes (App Studio) or installs from the Store register as userspace:* and already render in their own Launchpad section. The heading just said 'Apps'; rename it to 'My Apps' so the launcher clearly marks where a user's own apps live. One-line heading change, no test pinned the old text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Renamed the installed applications section from "Apps" to "My Apps" in the Launchpad for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->