### PR TITLE
perf(update): skip npm install when dependencies are unchanged

### DIFF
--- a/tests/test_desktop_rebuild.py
+++ b/tests/test_desktop_rebuild.py
@@ -204,3 +204,61 @@ async def test_rebuild_success(tmp_path, monkeypatch):
     assert result.rebuilt is True
     assert result.success is True
     assert "successfully" in result.message.lower()
+
+
+# ---------------------------------------------------------------------------
+# npm-install gate: only reinstall when package-lock.json changes
+# ---------------------------------------------------------------------------
+
+from tinyagentos.desktop_rebuild import (
+    _deps_install_needed,
+    _record_deps_install,
+    _lockfile_hash,
+)
+
+
+def _mk_desktop(tmp_path, *, lock="{}", node_modules=True):
+    d = tmp_path / "desktop"
+    d.mkdir(parents=True, exist_ok=True)
+    if lock is not None:
+        (d / "package-lock.json").write_text(lock)
+    if node_modules:
+        (d / "node_modules").mkdir(exist_ok=True)
+    return d
+
+
+def test_deps_needed_when_node_modules_missing(tmp_path):
+    d = _mk_desktop(tmp_path, node_modules=False)
+    assert _deps_install_needed(d) is True
+
+
+def test_deps_needed_when_no_lockfile(tmp_path):
+    d = _mk_desktop(tmp_path, lock=None)
+    assert _deps_install_needed(d) is True
+
+
+def test_deps_needed_when_no_marker(tmp_path):
+    """node_modules + lockfile but never recorded → must install."""
+    d = _mk_desktop(tmp_path)
+    assert _deps_install_needed(d) is True
+
+
+def test_deps_skipped_after_record(tmp_path):
+    d = _mk_desktop(tmp_path, lock='{"v":1}')
+    _record_deps_install(d)
+    assert _deps_install_needed(d) is False
+
+
+def test_deps_needed_again_when_lockfile_changes(tmp_path):
+    d = _mk_desktop(tmp_path, lock='{"v":1}')
+    _record_deps_install(d)
+    assert _deps_install_needed(d) is False
+    # A dependency bump rewrites package-lock.json → hash changes → reinstall.
+    (d / "package-lock.json").write_text('{"v":2}')
+    assert _deps_install_needed(d) is True
+
+
+def test_lockfile_hash_none_without_file(tmp_path):
+    d = tmp_path / "desktop"
+    d.mkdir()
+    assert _lockfile_hash(d) is None

--- a/tinyagentos/desktop_rebuild.py
+++ b/tinyagentos/desktop_rebuild.py
@@ -8,11 +8,17 @@ regardless of platform (systemd/Pi, Docker, Mac .app, dev host).
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
 from dataclasses import dataclass
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+# Marker recording the package-lock.json hash of the last successful
+# `npm install`. Lives inside node_modules so it is naturally per-install
+# (wiped whenever node_modules is) and never tracked by git.
+_DEPS_MARKER = "node_modules/.taos-deps-lock"
 
 
 @dataclass(frozen=True)
@@ -48,6 +54,45 @@ def _is_bundle_stale(project_root: Path) -> bool:
         if path.is_file() and path.stat().st_mtime > bundle_mtime:
             return True
     return False
+
+
+def _lockfile_hash(desktop_dir: Path) -> str | None:
+    """SHA-256 of desktop/package-lock.json, or None if it doesn't exist."""
+    lock = desktop_dir / "package-lock.json"
+    if not lock.is_file():
+        return None
+    return hashlib.sha256(lock.read_bytes()).hexdigest()
+
+
+def _deps_install_needed(desktop_dir: Path) -> bool:
+    """True if ``npm install`` must run before a build.
+
+    Skips the install only when node_modules already exists and the
+    package-lock.json hash matches the last successful install. Any of
+    {no node_modules, no lockfile to compare, lockfile changed, marker
+    unreadable} forces the install — so the gate never trades correctness
+    for speed.
+    """
+    if not (desktop_dir / "node_modules").is_dir():
+        return True
+    current = _lockfile_hash(desktop_dir)
+    if current is None:
+        return True  # no lockfile to trust — always install
+    try:
+        return (desktop_dir / _DEPS_MARKER).read_text().strip() != current
+    except OSError:
+        return True
+
+
+def _record_deps_install(desktop_dir: Path) -> None:
+    """Record the current package-lock hash after a successful npm install."""
+    current = _lockfile_hash(desktop_dir)
+    if current is None:
+        return
+    try:
+        (desktop_dir / _DEPS_MARKER).write_text(current)
+    except OSError as exc:  # node_modules vanished mid-build, read-only fs, etc.
+        logger.warning("Could not write deps marker (%s) — next update reinstalls.", exc)
 
 
 async def rebuild_desktop_bundle_if_stale(
@@ -88,17 +133,22 @@ async def rebuild_desktop_bundle_if_stale(
     logger.info("Desktop source is ahead of bundle — rebuilding...")
 
     try:
-        proc = await asyncio.create_subprocess_exec(
-            "npm", "install", "--silent",
-            cwd=str(desktop_dir),
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        _, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout_seconds)
-        if proc.returncode != 0:
-            msg = f"npm install failed (rc={proc.returncode}): {stderr.decode(errors='replace')[-500:]}"
-            logger.error(msg)
-            return RebuildResult(rebuilt=True, success=False, message=msg)
+        if _deps_install_needed(desktop_dir):
+            logger.info("Dependencies changed or missing — running npm install...")
+            proc = await asyncio.create_subprocess_exec(
+                "npm", "install", "--silent",
+                cwd=str(desktop_dir),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            _, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout_seconds)
+            if proc.returncode != 0:
+                msg = f"npm install failed (rc={proc.returncode}): {stderr.decode(errors='replace')[-500:]}"
+                logger.error(msg)
+                return RebuildResult(rebuilt=True, success=False, message=msg)
+            _record_deps_install(desktop_dir)
+        else:
+            logger.info("Dependencies unchanged — skipping npm install.")
 
         proc = await asyncio.create_subprocess_exec(
             "npm", "run", "build",


### PR DESCRIPTION
First step of the update-speed work (the ~90s update is the on-device SPA rebuild, since the bundle is not committed). The forced rebuild ran 'npm install' every update even when no dependency changed -- a big slice of the cost on ARM. Gate it on a package-lock.json hash marker kept inside node_modules (per-install, never committed): reinstall only when node_modules is missing, there is no lockfile, the lockfile changed, or the marker is unreadable; otherwise skip straight to the build. Any uncertainty forces the install, so correctness is preserved. Adds 6 unit tests for the gate (17/17 pass). Follow-up: ship the CI-built bundle prebuilt so the Pi stops compiling on update at all.