### PR TITLE
fix(install-panel): opaque background + working Copy on HTTP origins

### DIFF
--- a/desktop/src/components/InstallHelperPanel.test.tsx
+++ b/desktop/src/components/InstallHelperPanel.test.tsx
@@ -31,7 +31,7 @@ describe("InstallHelperPanel", () => {
     ).toBeInTheDocument();
   });
 
-  it("Copy button writes URL to clipboard", async () => {
+  it("Copy uses the clipboard API in a secure context", async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     vi.stubGlobal("navigator", {
       ...navigator,
@@ -39,6 +39,10 @@ describe("InstallHelperPanel", () => {
       userAgent: "Chrome",
       platform: "Win32",
       maxTouchPoints: 0,
+    });
+    Object.defineProperty(window, "isSecureContext", {
+      value: true,
+      configurable: true,
     });
 
     render(
@@ -49,6 +53,35 @@ describe("InstallHelperPanel", () => {
     expect(writeText).toHaveBeenCalledWith(
       expect.stringContaining("/app.html?app=myapp")
     );
+  });
+
+  it("Copy falls back to execCommand on a non-secure origin (HTTP)", async () => {
+    // Plain-HTTP origins (LAN / Tailscale IP) don't expose navigator.clipboard;
+    // the button must still copy via the execCommand fallback rather than throw.
+    vi.stubGlobal("navigator", {
+      ...navigator,
+      clipboard: undefined,
+      userAgent: "Chrome",
+      platform: "Win32",
+      maxTouchPoints: 0,
+    });
+    Object.defineProperty(window, "isSecureContext", {
+      value: false,
+      configurable: true,
+    });
+    const execCommand = vi.fn().mockReturnValue(true);
+    Object.defineProperty(document, "execCommand", {
+      value: execCommand,
+      configurable: true,
+      writable: true,
+    });
+
+    render(
+      <InstallHelperPanel appId="myapp" appName="My App" onClose={vi.fn()} />
+    );
+
+    fireEvent.click(screen.getByText("Copy"));
+    expect(execCommand).toHaveBeenCalledWith("copy");
   });
 
   it("onClose fires when Done button is clicked", () => {

--- a/desktop/src/components/InstallHelperPanel.tsx
+++ b/desktop/src/components/InstallHelperPanel.tsx
@@ -39,7 +39,7 @@ export function InstallHelperPanel({ appId, appName, onClose }: Props) {
     ta.style.opacity = "0";
     document.body.appendChild(ta);
     try {
-      if (/iphone|ipad|ipod/i.test(navigator.userAgent)) {
+      if (isIOS()) {
         const range = document.createRange();
         range.selectNodeContents(ta);
         const sel = window.getSelection();

--- a/desktop/src/components/InstallHelperPanel.tsx
+++ b/desktop/src/components/InstallHelperPanel.tsx
@@ -27,13 +27,57 @@ export function InstallHelperPanel({ appId, appName, onClose }: Props) {
     return () => window.removeEventListener("keydown", handler);
   }, [onClose]);
 
-  function handleCopy() {
-    navigator.clipboard.writeText(url).catch(() => {
+  function fallbackCopy(text: string): boolean {
+    // Non-secure contexts (plain HTTP on a LAN / Tailscale IP) don't expose
+    // navigator.clipboard, so fall back to a temp textarea + execCommand,
+    // with the iOS-specific selection dance Safari requires.
+    const ta = document.createElement("textarea");
+    ta.value = text;
+    ta.setAttribute("readonly", "");
+    ta.style.position = "fixed";
+    ta.style.top = "0";
+    ta.style.opacity = "0";
+    document.body.appendChild(ta);
+    try {
+      if (/iphone|ipad|ipod/i.test(navigator.userAgent)) {
+        const range = document.createRange();
+        range.selectNodeContents(ta);
+        const sel = window.getSelection();
+        sel?.removeAllRanges();
+        sel?.addRange(range);
+        ta.setSelectionRange(0, text.length);
+      } else {
+        ta.select();
+      }
+      return document.execCommand("copy");
+    } catch {
+      return false;
+    } finally {
+      document.body.removeChild(ta);
+    }
+  }
+
+  async function handleCopy() {
+    let ok = false;
+    try {
+      if (navigator.clipboard && window.isSecureContext) {
+        await navigator.clipboard.writeText(url);
+        ok = true;
+      }
+    } catch {
+      ok = false;
+    }
+    if (!ok) ok = fallbackCopy(url);
+    if (ok) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } else {
+      // Couldn't copy programmatically — select the visible field so the
+      // user can copy it by hand.
       const el = document.getElementById("install-helper-url-input") as HTMLInputElement | null;
-      el?.select();
-    });
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+      el?.focus();
+      el?.setSelectionRange(0, url.length);
+    }
   }
 
   const platformHint = isIOS()
@@ -51,7 +95,7 @@ export function InstallHelperPanel({ appId, appName, onClose }: Props) {
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
-        background: "rgba(0,0,0,0.5)",
+        background: "rgba(0,0,0,0.6)",
         padding: "1rem",
       }}
       onClick={onClose}
@@ -63,8 +107,11 @@ export function InstallHelperPanel({ appId, appName, onClose }: Props) {
     >
       <div
         style={{
-          background: "var(--color-shell-surface, #1c1c1f)",
-          border: "1px solid rgba(255,255,255,0.1)",
+          // Must be fully opaque: --color-shell-surface is a translucent
+          // elevation overlay (rgba white 0.04) and let the page show through.
+          // --color-shell-bg is the solid shell base and is theme-aware.
+          background: "var(--color-shell-bg, #1d1d1f)",
+          border: "1px solid rgba(255,255,255,0.12)",
           borderRadius: "12px",
           boxShadow: "0 24px 64px rgba(0,0,0,0.5)",
           width: "100%",


### PR DESCRIPTION
On-device testing of the install-helper panel surfaced two bugs (screenshot from Jay):

1. **Transparent dialog** -- the panel's background was `--color-shell-surface`, which is a translucent elevation overlay (rgba white 0.04), so the chat list showed through it. Switched to the opaque, theme-aware `--color-shell-bg` and deepened the scrim from 0.5 to 0.6.
2. **Copy button did nothing** -- the panel is served over plain HTTP (LAN / Tailscale IP), where `navigator.clipboard` is undefined, so `clipboard.writeText` threw synchronously and the handler was a no-op. Now: gate the clipboard path on a secure context, fall back to a temp-textarea + `execCommand('copy')` (with the iOS selection dance), and if even that fails, select the visible URL field so it can be copied by hand.

Tests cover both the secure-context clipboard path and the non-secure execCommand fallback (5/5 pass).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Copy-to-clipboard functionality now works reliably in non-HTTPS environments with automatic fallback when needed
  * Improved fallback experience when programmatic copy fails – URL input is focused for manual copying
  * Enhanced visual appearance of overlay and dialog styling for better consistency

* **Tests**
  * Extended test coverage for clipboard API behavior across different security contexts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->