### PR TITLE
feat(taOSgo): core-side foundation -- Account section + off-network screen (P1 + P5)

### DIFF
--- a/desktop/src/apps/SettingsApp.tsx
+++ b/desktop/src/apps/SettingsApp.tsx
@@ -14,6 +14,7 @@ import {
   Monitor,
   Users,
   Palette,
+  UserCircle,
 } from "lucide-react";
 import {
   Button,
@@ -26,12 +27,13 @@ import { ThemesPanel } from "@/apps/SettingsApp/ThemesPanel";
 import { safeFetch, ProgressBar, RestartProgressModal } from "@/apps/SettingsApp/_shared";
 import { UpdatesSection } from "@/apps/SettingsApp/UpdatesPanel";
 import { UsersSection } from "@/apps/SettingsApp/UsersPanel";
+import { AccountSection } from "@/apps/SettingsApp/AccountPanel";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
 /* ------------------------------------------------------------------ */
 
-type Section = "system" | "storage" | "memory" | "backup" | "updates" | "advanced" | "shortcuts" | "accessibility" | "desktop" | "users" | "themes";
+type Section = "account" | "system" | "storage" | "memory" | "backup" | "updates" | "advanced" | "shortcuts" | "accessibility" | "desktop" | "users" | "themes";
 
 interface SectionDef {
   id: Section;
@@ -60,6 +62,7 @@ interface StorageItem {
 /* ------------------------------------------------------------------ */
 
 const SECTIONS: SectionDef[] = [
+  { id: "account", label: "Account", icon: UserCircle },
   { id: "system", label: "System Info", icon: Info },
   { id: "storage", label: "Storage", icon: HardDrive },
   { id: "memory", label: "Memory", icon: Brain },
@@ -735,6 +738,7 @@ export function SettingsApp({ windowId: _windowId, section: initialSection }: { 
   const isMobile = typeof window !== "undefined" && window.innerWidth < 640;
 
   const content: Record<Section, ReactNode> = {
+    account: <AccountSection />,
     system: <SystemInfoSection />,
     storage: <StorageSection />,
     memory: <MemorySection />,

--- a/desktop/src/apps/SettingsApp/AccountPanel.test.tsx
+++ b/desktop/src/apps/SettingsApp/AccountPanel.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { AccountSection } from "./AccountPanel";
+
+describe("AccountSection", () => {
+  afterEach(() => { vi.restoreAllMocks(); });
+  beforeEach(() => { vi.restoreAllMocks(); });
+
+  it("shows the sign-in / create-account form when signed out (401)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 401 }),
+    );
+    render(<AccountSection />);
+    expect(await screen.findByLabelText("Email")).toBeInTheDocument();
+    expect(screen.getByLabelText("Password")).toBeInTheDocument();
+    expect(screen.getByText("Create account")).toBeInTheDocument();
+  });
+
+  it("shows an unavailable state when the account service cannot be reached", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network"));
+    render(<AccountSection />);
+    expect(
+      await screen.findByText(/account service is not reachable/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Retry")).toBeInTheDocument();
+  });
+
+  it("shows the signed-in view with email + taOSgo status", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          user_id: "u1",
+          email: "jay@example.com",
+          taosgo: { status: "none" },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    render(<AccountSection />);
+    expect(await screen.findByText("jay@example.com")).toBeInTheDocument();
+    expect(screen.getByText("taOSgo")).toBeInTheDocument();
+    expect(screen.getByText("Not subscribed")).toBeInTheDocument();
+    expect(screen.getByText("Start 7-day free trial")).toBeInTheDocument();
+  });
+
+  it("surfaces a backend error message on failed sign-in", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(null, { status: 401 })) // initial /me
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: "Invalid credentials" }), {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    render(<AccountSection />);
+    fireEvent.change(await screen.findByLabelText("Email"), {
+      target: { value: "jay@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText("Password"), {
+      target: { value: "password1" },
+    });
+    // Two controls read "Sign in" (the mode tab and the submit button); the
+    // submit is the last one.
+    fireEvent.click(screen.getAllByRole("button", { name: "Sign in" }).at(-1)!);
+    await waitFor(() =>
+      expect(screen.getByText("Invalid credentials")).toBeInTheDocument(),
+    );
+  });
+});

--- a/desktop/src/apps/SettingsApp/AccountPanel.tsx
+++ b/desktop/src/apps/SettingsApp/AccountPanel.tsx
@@ -1,0 +1,236 @@
+import { useState, useEffect, useCallback, type FormEvent } from "react";
+import { LogOut, AlertCircle, ShieldCheck, Plane } from "lucide-react";
+import { Button, Card, Input, Label } from "@/components/ui";
+import {
+  fetchAccount,
+  login,
+  register,
+  logout,
+  isAuthError,
+  type AccountState,
+  type Account,
+  type TaosgoStatus,
+} from "@/lib/account-client";
+
+const TAOSGO_STATUS: Record<TaosgoStatus, { label: string; tone: string }> = {
+  none: { label: "Not subscribed", tone: "text-shell-text-tertiary" },
+  trialing: { label: "Free trial", tone: "text-sky-400" },
+  active: { label: "Active", tone: "text-emerald-400" },
+  past_due: { label: "Payment due", tone: "text-amber-400" },
+};
+
+function formatDate(iso?: string | null): string | null {
+  if (!iso) return null;
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime())
+    ? null
+    : d.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
+}
+
+/* ------------------------------------------------------------------ */
+/*  taOSgo subscription card                                          */
+/* ------------------------------------------------------------------ */
+
+function TaosgoCard({ account }: { account: Account }) {
+  const { status } = account.taosgo;
+  const meta = TAOSGO_STATUS[status];
+  const trialEnds = formatDate(account.taosgo.trial_ends_at);
+  const renews = formatDate(account.taosgo.current_period_end);
+
+  return (
+    <Card className="p-4">
+      <div className="flex items-center justify-between gap-3 mb-2">
+        <div className="flex items-center gap-2">
+          <Plane size={16} className="text-sky-400" />
+          <h3 className="text-sm font-medium">taOSgo</h3>
+        </div>
+        <span className={`text-xs font-medium ${meta.tone}`}>{meta.label}</span>
+      </div>
+      <p className="text-xs text-shell-text-tertiary mb-3">
+        Secure access to your taOS from any browser, anywhere, with nothing to install.
+      </p>
+      {status === "trialing" && trialEnds && (
+        <p className="text-xs text-shell-text-secondary mb-3">Trial ends {trialEnds}.</p>
+      )}
+      {status === "active" && renews && (
+        <p className="text-xs text-shell-text-secondary mb-3">Renews {renews}.</p>
+      )}
+      {status === "none" ? (
+        <Button size="sm" onClick={() => { window.location.href = "https://taos.my/taosgo"; }}>
+          Start 7-day free trial
+        </Button>
+      ) : (
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => { window.location.href = "https://taos.my/account/billing"; }}
+        >
+          Manage subscription
+        </Button>
+      )}
+    </Card>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Signed-in view                                                    */
+/* ------------------------------------------------------------------ */
+
+function SignedIn({ account, onSignOut }: { account: Account; onSignOut: () => void }) {
+  return (
+    <div className="space-y-3">
+      <Card className="p-4 flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-sm font-medium truncate">{account.email}</p>
+          <p className="text-xs text-shell-text-tertiary mt-0.5">Signed in to your taOS account</p>
+        </div>
+        <Button variant="outline" size="sm" onClick={onSignOut} aria-label="Sign out">
+          <LogOut size={14} /> Sign out
+        </Button>
+      </Card>
+      <TaosgoCard account={account} />
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Signed-out view (sign in / register)                              */
+/* ------------------------------------------------------------------ */
+
+function SignedOut({ onSignedIn }: { onSignedIn: (account: Account) => void }) {
+  const [mode, setMode] = useState<"signin" | "register">("signin");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async (e: FormEvent) => {
+    e.preventDefault();
+    setBusy(true);
+    setError(null);
+    const result = await (mode === "signin" ? login : register)(email.trim(), password);
+    setBusy(false);
+    if (isAuthError(result)) setError(result.message);
+    else onSignedIn(result);
+  };
+
+  return (
+    <Card className="p-4">
+      <div className="flex gap-2 mb-4" role="group" aria-label="Account action">
+        <Button
+          variant={mode === "signin" ? "secondary" : "outline"}
+          size="sm"
+          onClick={() => { setMode("signin"); setError(null); }}
+          aria-pressed={mode === "signin"}
+        >
+          Sign in
+        </Button>
+        <Button
+          variant={mode === "register" ? "secondary" : "outline"}
+          size="sm"
+          onClick={() => { setMode("register"); setError(null); }}
+          aria-pressed={mode === "register"}
+        >
+          Create account
+        </Button>
+      </div>
+
+      <form onSubmit={submit} className="space-y-3">
+        <div>
+          <Label htmlFor="account-email" className="text-xs text-shell-text-secondary">Email</Label>
+          <Input
+            id="account-email"
+            type="email"
+            autoComplete="email"
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="you@example.com"
+            className="mt-1"
+          />
+        </div>
+        <div>
+          <Label htmlFor="account-password" className="text-xs text-shell-text-secondary">Password</Label>
+          <Input
+            id="account-password"
+            type="password"
+            autoComplete={mode === "signin" ? "current-password" : "new-password"}
+            required
+            minLength={8}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder={mode === "register" ? "At least 8 characters" : "Your password"}
+            className="mt-1"
+          />
+        </div>
+
+        {error && (
+          <p className="text-xs text-amber-400 flex items-center gap-1.5" role="alert">
+            <AlertCircle size={12} /> {error}
+          </p>
+        )}
+
+        <Button type="submit" size="sm" disabled={busy} className="w-full">
+          {busy ? "Please wait..." : mode === "signin" ? "Sign in" : "Create account"}
+        </Button>
+      </form>
+
+      <p className="text-xs text-shell-text-tertiary mt-3 flex items-center gap-1.5">
+        <ShieldCheck size={12} /> Your taOS account unlocks taOSgo and syncs across your devices.
+      </p>
+    </Card>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Account section                                                   */
+/* ------------------------------------------------------------------ */
+
+export function AccountSection() {
+  const [state, setState] = useState<AccountState>({ kind: "loading" });
+
+  const load = useCallback(async () => {
+    setState(await fetchAccount());
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  const handleSignOut = async () => {
+    await logout();
+    setState({ kind: "signed-out" });
+  };
+
+  return (
+    <section aria-label="Account">
+      <h2 className="text-lg font-semibold mb-2">Account</h2>
+      <p className="text-sm text-shell-text-tertiary mb-5">
+        Sign in to your taOS account to manage taOSgo and sync settings across your devices.
+      </p>
+
+      {state.kind === "loading" && (
+        <p className="text-sm text-shell-text-tertiary">Loading...</p>
+      )}
+
+      {state.kind === "unavailable" && (
+        <Card className="p-4">
+          <p className="text-sm flex items-center gap-2">
+            <AlertCircle size={14} className="text-amber-400" />
+            The account service is not reachable right now.
+          </p>
+          <p className="text-xs text-shell-text-tertiary mt-1">
+            Accounts run on taos.my; try again once you are connected.
+          </p>
+          <Button variant="outline" size="sm" onClick={load} className="mt-3">Retry</Button>
+        </Card>
+      )}
+
+      {state.kind === "signed-out" && (
+        <SignedOut onSignedIn={(account) => setState({ kind: "signed-in", account })} />
+      )}
+
+      {state.kind === "signed-in" && (
+        <SignedIn account={state.account} onSignOut={handleSignOut} />
+      )}
+    </section>
+  );
+}

--- a/desktop/src/apps/SettingsApp/AccountPanel.tsx
+++ b/desktop/src/apps/SettingsApp/AccountPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, type FormEvent } from "react";
+import { useState, useEffect, useCallback, useRef, type FormEvent } from "react";
 import { LogOut, AlertCircle, ShieldCheck, Plane } from "lucide-react";
 import { Button, Card, Input, Label } from "@/components/ui";
 import {
@@ -103,12 +103,15 @@ function SignedOut({ onSignedIn }: { onSignedIn: (account: Account) => void }) {
   const [password, setPassword] = useState("");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const mounted = useRef(true);
+  useEffect(() => () => { mounted.current = false; }, []);
 
   const submit = async (e: FormEvent) => {
     e.preventDefault();
     setBusy(true);
     setError(null);
     const result = await (mode === "signin" ? login : register)(email.trim(), password);
+    if (!mounted.current) return;
     setBusy(false);
     if (isAuthError(result)) setError(result.message);
     else onSignedIn(result);
@@ -188,16 +191,19 @@ function SignedOut({ onSignedIn }: { onSignedIn: (account: Account) => void }) {
 
 export function AccountSection() {
   const [state, setState] = useState<AccountState>({ kind: "loading" });
+  const mounted = useRef(true);
+  useEffect(() => () => { mounted.current = false; }, []);
 
   const load = useCallback(async () => {
-    setState(await fetchAccount());
+    const next = await fetchAccount();
+    if (mounted.current) setState(next);
   }, []);
 
   useEffect(() => { load(); }, [load]);
 
   const handleSignOut = async () => {
     await logout();
-    setState({ kind: "signed-out" });
+    if (mounted.current) setState({ kind: "signed-out" });
   };
 
   return (

--- a/desktop/src/components/LoginGate.test.tsx
+++ b/desktop/src/components/LoginGate.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { LoginGate } from "./LoginGate";
+
+describe("LoginGate host reachability", () => {
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it("shows the off-network screen when /auth/status is unreachable", async () => {
+    // A thrown fetch is a network failure (host unreachable), not an HTTP error.
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network down"));
+    render(
+      <LoginGate>
+        <div>the desktop shell</div>
+      </LoginGate>,
+    );
+    expect(await screen.findByText("Can't reach your taOS")).toBeInTheDocument();
+    // The broken shell must NOT render behind it.
+    expect(screen.queryByText("the desktop shell")).not.toBeInTheDocument();
+  });
+
+  it("renders the app shell when authenticated and reachable", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ configured: true, authenticated: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    render(
+      <LoginGate>
+        <div>the desktop shell</div>
+      </LoginGate>,
+    );
+    await waitFor(() =>
+      expect(screen.getByText("the desktop shell")).toBeInTheDocument(),
+    );
+  });
+});

--- a/desktop/src/components/LoginGate.tsx
+++ b/desktop/src/components/LoginGate.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { Lock } from "lucide-react";
 import { OnboardingScreen } from "./OnboardingScreen";
+import { OffNetworkScreen } from "./OffNetworkScreen";
 import { SESSION_EXPIRED_EVENT } from "@/lib/auth-guard";
 
 interface Props {
@@ -12,6 +13,7 @@ type AuthStatus =
   | { phase: "onboarding" }
   | { phase: "invite"; username: string; inviteCode: string; multiUser: boolean }
   | { phase: "login"; legacy: boolean; multiUser: boolean }
+  | { phase: "unreachable" }
   | { phase: "ready" };
 
 export function LoginGate({ children }: Props) {
@@ -48,7 +50,10 @@ export function LoginGate({ children }: Props) {
         setStatus({ phase: "login", legacy: !data.user, multiUser: !!data.multi_user });
       }
     } catch {
-      setStatus({ phase: "ready" });
+      // A thrown fetch (network failure, not an HTTP error) means the host is
+      // unreachable -- e.g. the PWA was opened off the host's network. Offer
+      // taOSgo rather than load the shell into a broken, data-less state.
+      setStatus({ phase: "unreachable" });
     }
   }, []);
 
@@ -117,6 +122,10 @@ export function LoginGate({ children }: Props) {
         Loading...
       </div>
     );
+  }
+
+  if (status.phase === "unreachable") {
+    return <OffNetworkScreen onRetry={refreshStatus} />;
   }
 
   if (status.phase === "onboarding") {

--- a/desktop/src/components/OffNetworkScreen.test.tsx
+++ b/desktop/src/components/OffNetworkScreen.test.tsx
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { OffNetworkScreen } from "./OffNetworkScreen";
+
+describe("OffNetworkScreen", () => {
+  it("renders the unreachable message and the taOSgo call to action", () => {
+    render(<OffNetworkScreen onRetry={vi.fn()} />);
+    expect(screen.getByText("Can't reach your taOS")).toBeInTheDocument();
+    const cta = screen.getByRole("link", { name: /get taosgo/i });
+    expect(cta).toHaveAttribute("href", "https://taos.my/taosgo");
+  });
+
+  it("calls onRetry when Try again is clicked", async () => {
+    const onRetry = vi.fn().mockResolvedValue(undefined);
+    render(<OffNetworkScreen onRetry={onRetry} />);
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+    await waitFor(() => expect(onRetry).toHaveBeenCalledTimes(1));
+  });
+});

--- a/desktop/src/components/OffNetworkScreen.tsx
+++ b/desktop/src/components/OffNetworkScreen.tsx
@@ -1,0 +1,72 @@
+import { useState } from "react";
+import { CloudOff, Plane, RefreshCw } from "lucide-react";
+
+interface Props {
+  /** Re-run the host reachability check. Should resolve when the check completes. */
+  onRetry: () => Promise<void> | void;
+}
+
+/**
+ * Shown when the taOS host cannot be reached from the current network (e.g. the
+ * PWA was opened off the host's LAN). Rather than load the shell into a broken,
+ * data-less state, we offer the way back in: taOSgo for secure access from
+ * anywhere, plus a retry for a transient blip.
+ */
+export function OffNetworkScreen({ onRetry }: Props) {
+  const [checking, setChecking] = useState(false);
+
+  const retry = async () => {
+    setChecking(true);
+    try {
+      await onRetry();
+    } finally {
+      setChecking(false);
+    }
+  };
+
+  return (
+    <div
+      className="h-screen w-screen flex items-center justify-center p-4"
+      style={{ background: "var(--color-shell-bg)" }}
+    >
+      <div
+        className="w-full max-w-sm p-6 rounded-2xl border border-white/10 text-center"
+        style={{ backgroundColor: "rgba(255,255,255,0.04)", backdropFilter: "blur(20px)" }}
+      >
+        <div
+          className="w-14 h-14 rounded-2xl flex items-center justify-center mx-auto mb-4"
+          style={{ background: "linear-gradient(135deg, #8b92a3, #5b6170)" }}
+        >
+          <CloudOff size={24} className="text-white" />
+        </div>
+
+        <h1 className="text-lg font-semibold text-shell-text">Can't reach your taOS</h1>
+        <p className="text-sm text-shell-text-secondary mt-2 leading-relaxed">
+          Your taOS isn't reachable from this network. taOSgo gives you secure access
+          from anywhere, with nothing to install.
+        </p>
+
+        <a
+          href="https://taos.my/taosgo"
+          className="mt-5 w-full inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg bg-accent text-white text-sm font-medium hover:brightness-110 transition-all"
+        >
+          <Plane size={15} /> Get taOSgo
+        </a>
+
+        <button
+          type="button"
+          onClick={retry}
+          disabled={checking}
+          className="mt-2 w-full inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg border border-white/10 text-sm text-shell-text hover:bg-white/5 disabled:opacity-50 transition-colors"
+        >
+          <RefreshCw size={14} className={checking ? "animate-spin" : ""} />
+          {checking ? "Checking..." : "Try again"}
+        </button>
+
+        <p className="text-xs text-shell-text-tertiary mt-4">
+          On your own Tailscale network? Reach your taOS through your tailnet.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/lib/account-client.ts
+++ b/desktop/src/lib/account-client.ts
@@ -1,0 +1,110 @@
+/**
+ * Client for the taOS account / identity service (taOSgo P1).
+ *
+ * Calls are same-origin against the host at /api/account/*, which the controller
+ * proxies to taos.my. Same-origin keeps the taos.my base URL server-side and
+ * avoids CORS, and lets the host attach host-linking context later.
+ *
+ * The backend proxy may not exist yet; every call degrades to a clear state
+ * (signed-out / unavailable) rather than throwing, so the UI ships ahead of it.
+ */
+
+export type TaosgoStatus = "none" | "trialing" | "active" | "past_due";
+
+export interface TaosgoEntitlement {
+  status: TaosgoStatus;
+  trial_ends_at?: string | null;
+  current_period_end?: string | null;
+}
+
+export interface Account {
+  user_id: string;
+  email: string;
+  taosgo: TaosgoEntitlement;
+}
+
+export type AccountState =
+  | { kind: "loading" }
+  | { kind: "signed-out" }
+  | { kind: "signed-in"; account: Account }
+  | { kind: "unavailable" };
+
+export interface AuthError {
+  message: string;
+}
+
+const BASE = "/api/account";
+
+async function call(path: string, body?: unknown): Promise<Response> {
+  return fetch(`${BASE}${path}`, {
+    method: body !== undefined ? "POST" : "GET",
+    headers: body !== undefined ? { "Content-Type": "application/json" } : undefined,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+    credentials: "include",
+  });
+}
+
+export async function fetchAccount(): Promise<AccountState> {
+  let r: Response;
+  try {
+    r = await call("/me");
+  } catch {
+    return { kind: "unavailable" };
+  }
+  if (r.status === 401) return { kind: "signed-out" };
+  if (!r.ok) return { kind: "unavailable" };
+  try {
+    return { kind: "signed-in", account: (await r.json()) as Account };
+  } catch {
+    return { kind: "unavailable" };
+  }
+}
+
+async function authAction(
+  path: string,
+  email: string,
+  password: string,
+): Promise<Account | AuthError> {
+  let r: Response;
+  try {
+    r = await call(path, { email, password });
+  } catch {
+    return { message: "Could not reach the account service. Check your connection." };
+  }
+  if (r.status === 404 || r.status === 503) {
+    return { message: "The account service is not available yet." };
+  }
+  if (!r.ok) {
+    let msg = `Request failed (${r.status}).`;
+    try {
+      const d = (await r.json()) as { error?: string; detail?: string };
+      if (d?.error || d?.detail) msg = String(d.error || d.detail);
+    } catch {
+      /* keep the status-code default */
+    }
+    return { message: msg };
+  }
+  try {
+    return (await r.json()) as Account;
+  } catch {
+    return { message: "Unexpected response from the account service." };
+  }
+}
+
+export const login = (email: string, password: string) =>
+  authAction("/login", email, password);
+
+export const register = (email: string, password: string) =>
+  authAction("/register", email, password);
+
+export async function logout(): Promise<void> {
+  try {
+    await call("/logout", {});
+  } catch {
+    /* signing out client-side is enough even if the call fails */
+  }
+}
+
+export function isAuthError(x: Account | AuthError): x is AuthError {
+  return (x as AuthError).message !== undefined;
+}

--- a/desktop/src/lib/account-client.ts
+++ b/desktop/src/lib/account-client.ts
@@ -35,6 +35,21 @@ export interface AuthError {
 
 const BASE = "/api/account";
 
+/** Validate an unknown payload is a well-formed Account before the UI trusts it.
+ *  The backend is external (taos.my); a malformed /me must not crash the render. */
+function isAccount(x: unknown): x is Account {
+  if (!x || typeof x !== "object") return false;
+  const o = x as Record<string, unknown>;
+  const t = o.taosgo as Record<string, unknown> | undefined;
+  return (
+    typeof o.user_id === "string" &&
+    typeof o.email === "string" &&
+    !!t &&
+    typeof t === "object" &&
+    typeof t.status === "string"
+  );
+}
+
 async function call(path: string, body?: unknown): Promise<Response> {
   return fetch(`${BASE}${path}`, {
     method: body !== undefined ? "POST" : "GET",
@@ -54,7 +69,10 @@ export async function fetchAccount(): Promise<AccountState> {
   if (r.status === 401) return { kind: "signed-out" };
   if (!r.ok) return { kind: "unavailable" };
   try {
-    return { kind: "signed-in", account: (await r.json()) as Account };
+    const data: unknown = await r.json();
+    return isAccount(data)
+      ? { kind: "signed-in", account: data }
+      : { kind: "unavailable" };
   } catch {
     return { kind: "unavailable" };
   }
@@ -85,7 +103,10 @@ async function authAction(
     return { message: msg };
   }
   try {
-    return (await r.json()) as Account;
+    const data: unknown = await r.json();
+    return isAccount(data)
+      ? data
+      : { message: "Unexpected response from the account service." };
   } catch {
     return { message: "Unexpected response from the account service." };
   }


### PR DESCRIPTION
Core-side foundation for taOSgo, per ~/tinyagentos-private/taosgo/SPEC.md. Two cohesive pieces:

**Settings > Account (P1 identity, core half).** macOS-Settings-style Account pane at the top of Settings: signed-out shows sign in / create account (email + password, mode toggle, inline errors); signed-in shows account email + taOSgo subscription status (none/trialing/active/past_due) + manage/start-trial + sign out; plus loading and 'service unavailable' states. New `account-client.ts` calls same-origin `/api/account/*` (host proxies to taos.my, keeping that URL server-side and avoiding CORS); every call degrades gracefully so the UI ships ahead of the backend.

**Off-network screen (P5 client UX).** When `/auth/status` throws (a network failure, not an HTTP error) the host is unreachable -- typically the PWA opened off the host network. LoginGate used to fall through to the ready shell and load every app into a broken, data-less state; now it shows 'Can't reach your taOS' with a taOSgo CTA (taos.my/taosgo), a Try again retry, and a quiet DIY-Tailscale note. HTTP errors still fall through unchanged.

Connecting pieces still to land (sequenced after @taOS-website-dev's taos.my auth): the host `/api/account` proxy. 8 tests across the account panel, off-network screen, and LoginGate wiring; full SPA build passes.