### PR TITLE
fix(pwa): iOS Add to Home Screen banner + sturdier copy fallback

### DIFF
--- a/desktop/src/components/InstallHelperPanel.tsx
+++ b/desktop/src/components/InstallHelperPanel.tsx
@@ -27,33 +27,25 @@ export function InstallHelperPanel({ appId, appName, onClose }: Props) {
     return () => window.removeEventListener("keydown", handler);
   }, [onClose]);
 
-  function fallbackCopy(text: string): boolean {
+  function fallbackCopy(): boolean {
     // Non-secure contexts (plain HTTP on a LAN / Tailscale IP) don't expose
-    // navigator.clipboard, so fall back to a temp textarea + execCommand,
-    // with the iOS-specific selection dance Safari requires.
-    const ta = document.createElement("textarea");
-    ta.value = text;
-    ta.setAttribute("readonly", "");
-    ta.style.position = "fixed";
-    ta.style.top = "0";
-    ta.style.opacity = "0";
-    document.body.appendChild(ta);
+    // navigator.clipboard. Operate on the already-visible URL input rather than
+    // a hidden textarea: iOS Safari refuses to copy from opacity:0 elements and
+    // will not select a readonly field, so toggle readonly off, select the real
+    // on-screen input, copy, then restore. The definitive fix is HTTPS (taOSgo
+    // or Tailscale Serve), where navigator.clipboard works directly.
+    const el = document.getElementById("install-helper-url-input") as HTMLInputElement | null;
+    if (!el) return false;
+    const wasReadOnly = el.readOnly;
     try {
-      if (isIOS()) {
-        const range = document.createRange();
-        range.selectNodeContents(ta);
-        const sel = window.getSelection();
-        sel?.removeAllRanges();
-        sel?.addRange(range);
-        ta.setSelectionRange(0, text.length);
-      } else {
-        ta.select();
-      }
+      el.readOnly = false;
+      el.focus();
+      el.setSelectionRange(0, el.value.length);
       return document.execCommand("copy");
     } catch {
       return false;
     } finally {
-      document.body.removeChild(ta);
+      el.readOnly = wasReadOnly;
     }
   }
 
@@ -67,7 +59,7 @@ export function InstallHelperPanel({ appId, appName, onClose }: Props) {
     } catch {
       ok = false;
     }
-    if (!ok) ok = fallbackCopy(url);
+    if (!ok) ok = fallbackCopy();
     if (ok) {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);

--- a/desktop/src/shell/InstallPromptBanner.test.tsx
+++ b/desktop/src/shell/InstallPromptBanner.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { InstallPromptBanner } from "./InstallPromptBanner";
+
+function mockMatchMedia(standalone = false) {
+  window.matchMedia = vi.fn().mockImplementation((q: string) => ({
+    matches: q.includes("standalone") ? standalone : false,
+    media: q,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    onchange: null,
+    dispatchEvent: vi.fn(),
+  }));
+}
+
+describe("InstallPromptBanner", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockMatchMedia(false);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  it("shows the Add to Home Screen instruction on iOS Safari (not installed)", () => {
+    vi.stubGlobal("navigator", {
+      userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) Safari",
+      platform: "iPhone",
+      maxTouchPoints: 5,
+      standalone: false,
+    });
+    render(<InstallPromptBanner />);
+    expect(screen.getByText(/Add to Home Screen/i)).toBeInTheDocument();
+  });
+
+  it("renders nothing once installed (standalone display mode)", () => {
+    mockMatchMedia(true);
+    vi.stubGlobal("navigator", {
+      userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) Safari",
+      platform: "iPhone",
+      maxTouchPoints: 5,
+      standalone: true,
+    });
+    const { container } = render(<InstallPromptBanner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing on a desktop browser with no install event", () => {
+    vi.stubGlobal("navigator", {
+      userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X) Chrome",
+      platform: "MacIntel",
+      maxTouchPoints: 0,
+      standalone: undefined,
+    });
+    const { container } = render(<InstallPromptBanner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/desktop/src/shell/InstallPromptBanner.tsx
+++ b/desktop/src/shell/InstallPromptBanner.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { Share } from "lucide-react";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 
 interface BeforeInstallPromptEvent extends Event {
@@ -9,9 +10,24 @@ interface BeforeInstallPromptEvent extends Event {
 const DISMISS_MS = 30 * 24 * 60 * 60 * 1000;
 const KEY = "taos-install-dismissed";
 
+function isIOS(): boolean {
+  return (
+    /iphone|ipad|ipod/i.test(navigator.userAgent) ||
+    (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1)
+  );
+}
+
+function isStandalone(): boolean {
+  return (
+    (window.navigator as unknown as { standalone?: boolean }).standalone === true ||
+    window.matchMedia("(display-mode: standalone)").matches
+  );
+}
+
 export function InstallPromptBanner() {
   const isMobile = useIsMobile();
   const [event, setEvent] = useState<BeforeInstallPromptEvent | null>(null);
+  const [ios, setIos] = useState(false);
   const [dismissed, setDismissed] = useState(false);
 
   useEffect(() => {
@@ -20,49 +36,75 @@ export function InstallPromptBanner() {
       setEvent(e as BeforeInstallPromptEvent);
     };
     window.addEventListener("beforeinstallprompt", onPrompt);
+    // iOS Safari never fires beforeinstallprompt and has no programmatic
+    // install, so detect it and show a manual Add to Home Screen instruction.
+    if (isIOS() && !isStandalone()) setIos(true);
     return () => window.removeEventListener("beforeinstallprompt", onPrompt);
   }, []);
 
-  if (!isMobile || !event || dismissed) return null;
-
-  if (typeof window !== "undefined") {
-    const mql = window.matchMedia("(display-mode: standalone)");
-    if (mql.matches) return null;
-  }
+  if (dismissed || isStandalone()) return null;
+  // Android shows on mobile via the install event; iOS shows on the device
+  // regardless of viewport width (iPadOS reports as desktop).
+  if (!isMobile && !ios) return null;
 
   const prev = localStorage.getItem(KEY);
   if (prev && Date.now() - Number(prev) < DISMISS_MS) return null;
 
-  const install = async () => {
-    try {
-      await event.prompt();
-      await event.userChoice;
-    } catch {
-      /* ignore */
-    }
-    setEvent(null);
-  };
-
-  const notNow = () => {
+  const dismiss = () => {
     localStorage.setItem(KEY, String(Date.now()));
     setDismissed(true);
   };
 
-  return (
-    <div
-      role="region"
-      aria-label="Install prompt"
-      className="flex items-center gap-3 px-4 py-2 bg-sky-500/20 border-b border-sky-500/30 text-sm"
-    >
-      <span className="flex-1">Install taOS talk for quick access</span>
-      <button
-        onClick={install}
-        className="px-3 py-1 bg-sky-500/40 text-sky-100 rounded hover:bg-sky-500/60"
-      >Install</button>
-      <button
-        onClick={notNow}
-        className="px-2 py-1 opacity-70 hover:opacity-100"
-      >Not now</button>
-    </div>
-  );
+  // Android Chrome: a real install prompt is available.
+  if (event) {
+    const install = async () => {
+      try {
+        await event.prompt();
+        await event.userChoice;
+      } catch {
+        /* ignore */
+      }
+      setEvent(null);
+    };
+    return (
+      <div
+        role="region"
+        aria-label="Install prompt"
+        className="flex items-center gap-3 px-4 py-2 bg-sky-500/20 border-b border-sky-500/30 text-sm"
+      >
+        <span className="flex-1">Install taOS for quick access</span>
+        <button
+          onClick={install}
+          className="px-3 py-1 bg-sky-500/40 text-sky-100 rounded hover:bg-sky-500/60"
+        >Install</button>
+        <button
+          onClick={dismiss}
+          className="px-2 py-1 opacity-70 hover:opacity-100"
+        >Not now</button>
+      </div>
+    );
+  }
+
+  // iOS Safari: no programmatic install, so instruct the manual gesture.
+  if (ios) {
+    return (
+      <div
+        role="region"
+        aria-label="Install instructions"
+        className="flex items-center gap-2 px-4 py-2 bg-sky-500/20 border-b border-sky-500/30 text-sm"
+      >
+        <span className="flex-1 inline-flex items-center gap-1 flex-wrap">
+          To install, tap
+          <Share size={14} className="inline align-text-bottom" aria-label="Share" />
+          then "Add to Home Screen".
+        </span>
+        <button
+          onClick={dismiss}
+          className="px-2 py-1 opacity-70 hover:opacity-100"
+        >Got it</button>
+      </div>
+    );
+  }
+
+  return null;
 }


### PR DESCRIPTION
From on-device iOS testing (Jay):

1. **No install hint on iOS.** `InstallPromptBanner` only listened for `beforeinstallprompt` (an Android Chrome event iOS Safari never fires, with no programmatic install). Visiting /app.html in iOS Safari therefore showed nothing. Now: detect iOS (not already installed) and show a manual 'tap Share, then Add to Home Screen' instruction; iPadOS (MacIntel) covered; shows regardless of viewport width. Android keeps its native install prompt.
2. **Copy unreliable on HTTP.** The execCommand fallback used an `opacity:0` temp textarea, which iOS Safari refuses to copy from. It now operates on the already-visible URL input (toggle readonly off, select, copy, restore). The real fix is HTTPS (taOSgo / Tailscale Serve), where `navigator.clipboard` works directly; this makes the HTTP fallback land more often on iOS in the meantime.

3 banner tests + the existing panel tests (8/8), SPA build green.