### PR TITLE
feat(windows): multi-window primitive (openWindow forceNew)

### DIFF
--- a/desktop/src/stores/process-store.test.ts
+++ b/desktop/src/stores/process-store.test.ts
@@ -64,4 +64,28 @@ describe("process-store openWindow", () => {
     expect(win.minimized).toBe(false);
     expect(win.focused).toBe(true);
   });
+
+  it("opens a second window for the same app when forceNew is set", () => {
+    const a = useProcessStore
+      .getState()
+      .openWindow("projects", { w: 900, h: 600 }, { projectId: "p1" });
+    const b = useProcessStore
+      .getState()
+      .openWindow("projects", { w: 900, h: 600 }, { projectId: "p2" }, { forceNew: true });
+    expect(b).not.toBe(a);
+    const wins = useProcessStore.getState().windows.filter((w) => w.appId === "projects");
+    expect(wins).toHaveLength(2);
+    // Each window keeps its own props, so two projects can show side by side.
+    expect(wins.find((w) => w.id === a)!.props).toEqual({ projectId: "p1" });
+    expect(wins.find((w) => w.id === b)!.props).toEqual({ projectId: "p2" });
+  });
+
+  it("still refocuses the existing window when forceNew is not set", () => {
+    const a = useProcessStore.getState().openWindow("projects", { w: 900, h: 600 });
+    const b = useProcessStore.getState().openWindow("projects", { w: 900, h: 600 });
+    expect(b).toBe(a);
+    expect(
+      useProcessStore.getState().windows.filter((w) => w.appId === "projects"),
+    ).toHaveLength(1);
+  });
 });

--- a/desktop/src/stores/process-store.ts
+++ b/desktop/src/stores/process-store.ts
@@ -28,7 +28,7 @@ interface ProcessStore {
   windows: WindowState[];
   nextZIndex: number;
 
-  openWindow: (appId: string, defaultSize: { w: number; h: number }, props?: Record<string, unknown>) => string;
+  openWindow: (appId: string, defaultSize: { w: number; h: number }, props?: Record<string, unknown>, opts?: { forceNew?: boolean }) => string;
   closeWindow: (id: string) => void;
   removeWindow: (id: string) => void;
   focusWindow: (id: string) => void;
@@ -85,8 +85,13 @@ export const useProcessStore = create<ProcessStore>((set, get) => ({
   windows: [],
   nextZIndex: 1,
 
-  openWindow(appId, defaultSize, props) {
-    const existing = get().windows.find((w) => w.appId === appId);
+  openWindow(appId, defaultSize, props, opts) {
+    // Single-instance by default: clicking an app focuses its existing window.
+    // forceNew skips that so an app can open a second window (e.g. a different
+    // project), keyed by its own props -- the basis for multi-window apps.
+    const existing = opts?.forceNew
+      ? undefined
+      : get().windows.find((w) => w.appId === appId);
     if (existing) {
       if (props) {
         set((s) => ({


### PR DESCRIPTION
Foundation for #111 (multi-window apps + dock New Window). `openWindow` is single-instance by default (clicking an app focuses its existing window); it now takes an optional `{ forceNew: true }` that skips the appId dedupe and opens a fresh window keyed by its own props, so e.g. two Projects windows can show different projects. No caller passes forceNew yet, so behaviour is unchanged -- the dock right-click 'New Window' and the per-app opt-in (registry `singleton: false` + reading per-window props) build on this. 2 new tests (forceNew opens a second window with independent props; default refocuses); 8/8 pass, build green.