### PR TITLE
feat(taOSgo): host /api/account proxy to taos.my (P1 connector)

### DIFF
--- a/tests/test_routes_account_proxy.py
+++ b/tests/test_routes_account_proxy.py
@@ -1,0 +1,70 @@
+import httpx
+import pytest
+
+_UPSTREAM = "https://taos.my"
+
+
+def _patch_upstream(monkeypatch, handler):
+    """Patch httpx.AsyncClient.request so ONLY the proxy's upstream call (an
+    absolute taos.my URL) is intercepted; the test client's own ASGI calls
+    (relative URLs) pass through to the real request."""
+    orig = httpx.AsyncClient.request
+
+    async def routed(self, method, url, **kw):
+        if str(url).startswith(_UPSTREAM):
+            return await handler(method, str(url), **kw)
+        return await orig(self, method, url, **kw)
+
+    monkeypatch.setattr("httpx.AsyncClient.request", routed)
+
+
+@pytest.mark.asyncio
+async def test_account_me_503_when_unconfigured(client, monkeypatch):
+    """No upstream configured -> the proxy reports unavailable so the Account
+    pane shows its 'service unavailable' state."""
+    monkeypatch.delenv("TAOS_ACCOUNT_BASE_URL", raising=False)
+    r = await client.get("/api/account/me")
+    assert r.status_code == 503
+    assert "not configured" in r.json().get("error", "")
+
+
+@pytest.mark.asyncio
+async def test_account_me_forwards_and_relays_cookie(client, monkeypatch):
+    """When configured, /api/account/me forwards to {base}/api/auth/me and the
+    upstream Set-Cookie (the taos.my session) is relayed back to the browser."""
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "https://taos.my/")
+    captured: dict[str, str] = {}
+
+    class FakeResp:
+        status_code = 200
+        headers = httpx.Headers({"set-cookie": "taosgo_session=abc; Path=/"})
+
+        def json(self):
+            return {"user_id": "u1", "email": "a@b.c", "taosgo": {"status": "none"}}
+
+    async def handler(method, url, **kw):
+        captured["method"] = method
+        captured["url"] = url
+        return FakeResp()
+
+    _patch_upstream(monkeypatch, handler)
+    r = await client.get("/api/account/me")
+    assert r.status_code == 200
+    assert r.json()["email"] == "a@b.c"
+    # Trailing slash on the base is stripped; the auth path is appended once.
+    assert captured["url"] == "https://taos.my/api/auth/me"
+    assert captured["method"] == "GET"
+    assert "taosgo_session=abc" in r.headers.get("set-cookie", "")
+
+
+@pytest.mark.asyncio
+async def test_account_me_503_when_upstream_unreachable(client, monkeypatch):
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "https://taos.my")
+
+    async def handler(method, url, **kw):
+        raise httpx.ConnectError("down")
+
+    _patch_upstream(monkeypatch, handler)
+    r = await client.get("/api/account/me")
+    assert r.status_code == 503
+    assert "unreachable" in r.json().get("error", "")

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -299,6 +299,9 @@ def register_all_routers(app):
     from tinyagentos.routes.feedback import router as feedback_router
     app.include_router(feedback_router)
 
+    from tinyagentos.routes.account_proxy import router as account_proxy_router
+    app.include_router(account_proxy_router)
+
     from tinyagentos.routes.office import router as office_router
     app.include_router(office_router)
     from tinyagentos.routes.coding import router as coding_router

--- a/tinyagentos/routes/account_proxy.py
+++ b/tinyagentos/routes/account_proxy.py
@@ -1,0 +1,93 @@
+"""Proxy for the taOSgo account service (taos.my) -- taOSgo Phase 1.
+
+The taOS client (Settings > Account, the off-network screen) calls same-origin
+/api/account/* so the taos.my base URL stays server-side and there is no CORS.
+We forward to {TAOS_ACCOUNT_BASE_URL}/api/auth/* with cookie pass-through both
+ways, so the taos.my session cookie round-trips through this host origin.
+
+If TAOS_ACCOUNT_BASE_URL is unset the proxy returns 503 and the Account pane
+renders its 'service unavailable' state, so the client ships ahead of taos.my.
+"""
+from __future__ import annotations
+
+import os
+
+import httpx
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+router = APIRouter()
+
+# Only these account actions are proxied. The upstream base is operator config
+# (env), never user input, so there is no open-proxy / SSRF surface.
+_ACTIONS: dict[str, tuple[str, str]] = {
+    "me": ("GET", "/api/auth/me"),
+    "login": ("POST", "/api/auth/login"),
+    "register": ("POST", "/api/auth/register"),
+    "logout": ("POST", "/api/auth/logout"),
+}
+
+_TIMEOUT = httpx.Timeout(15.0)
+
+
+def _base_url() -> str | None:
+    base = os.environ.get("TAOS_ACCOUNT_BASE_URL", "").strip()
+    return base.rstrip("/") or None
+
+
+async def _forward(request: Request, action: str) -> JSONResponse:
+    base = _base_url()
+    if base is None:
+        return JSONResponse(
+            {"error": "account service not configured"}, status_code=503
+        )
+    method, path = _ACTIONS[action]
+    headers: dict[str, str] = {}
+    cookie = request.headers.get("cookie")
+    if cookie:
+        headers["Cookie"] = cookie
+    body: bytes | None = None
+    if method == "POST":
+        body = await request.body()
+        ctype = request.headers.get("content-type")
+        if ctype:
+            headers["Content-Type"] = ctype
+    try:
+        async with httpx.AsyncClient(timeout=_TIMEOUT) as http:
+            upstream = await http.request(
+                method, base + path, content=body, headers=headers
+            )
+    except httpx.HTTPError:
+        return JSONResponse(
+            {"error": "account service unreachable"}, status_code=503
+        )
+    try:
+        payload = upstream.json()
+    except ValueError:
+        payload = {}
+    resp = JSONResponse(payload, status_code=upstream.status_code)
+    # Pass the upstream session cookie back to the browser (scoped to this host).
+    for name, value in upstream.headers.multi_items():
+        if name.lower() == "set-cookie":
+            resp.raw_headers.append((b"set-cookie", value.encode("latin-1")))
+    return resp
+
+
+@router.get("/api/account/me")
+async def account_me(request: Request):
+    return await _forward(request, "me")
+
+
+@router.post("/api/account/login")
+async def account_login(request: Request):
+    return await _forward(request, "login")
+
+
+@router.post("/api/account/register")
+async def account_register(request: Request):
+    return await _forward(request, "register")
+
+
+@router.post("/api/account/logout")
+async def account_logout(request: Request):
+    return await _forward(request, "logout")


### PR DESCRIPTION
The connector between the shipped Settings > Account pane (#1105) and @taOS-website-dev's taos.my auth backend, per ~/tinyagentos-private/taosgo/SPEC.md.

The client calls same-origin `/api/account/{me,login,register,logout}`; the host forwards to `{TAOS_ACCOUNT_BASE_URL}/api/auth/*` with cookie pass-through both ways, so the taos.my base URL stays server-side (no CORS) and the session cookie round-trips through this origin. Only those four actions are proxied and the upstream base is env config, never user input, so there is no open-proxy / SSRF surface. With `TAOS_ACCOUNT_BASE_URL` unset every call returns 503, which the Account pane already renders as its 'service unavailable' state, so this ships ahead of taos.my and connects the moment that lands and the env is set. 3 tests (unconfigured 503, forward + Set-Cookie relay, upstream-unreachable 503).