### PR TITLE
refactor(pwa): shared isIOS/isStandalone platform util

### DIFF
--- a/desktop/src/components/InstallHelperPanel.tsx
+++ b/desktop/src/components/InstallHelperPanel.tsx
@@ -1,17 +1,11 @@
 import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
+import { isIOS } from "@/lib/platform";
 
 interface Props {
   appId: string;
   appName: string;
   onClose: () => void;
-}
-
-function isIOS(): boolean {
-  return (
-    /iphone|ipad|ipod/i.test(navigator.userAgent) ||
-    (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1)
-  );
 }
 
 export function InstallHelperPanel({ appId, appName, onClose }: Props) {

--- a/desktop/src/lib/platform.ts
+++ b/desktop/src/lib/platform.ts
@@ -1,0 +1,17 @@
+/** Shared platform / install-state detection for the install UI. */
+
+/** True on iPhone, iPod, and iPadOS (which reports as MacIntel with touch). */
+export function isIOS(): boolean {
+  return (
+    /iphone|ipad|ipod/i.test(navigator.userAgent) ||
+    (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1)
+  );
+}
+
+/** True when the app is running as an installed PWA (home-screen / standalone). */
+export function isStandalone(): boolean {
+  return (
+    (window.navigator as unknown as { standalone?: boolean }).standalone === true ||
+    window.matchMedia("(display-mode: standalone)").matches
+  );
+}

--- a/desktop/src/shell/InstallPromptBanner.tsx
+++ b/desktop/src/shell/InstallPromptBanner.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Share } from "lucide-react";
 import { useIsMobile } from "@/hooks/use-is-mobile";
+import { isIOS, isStandalone } from "@/lib/platform";
 
 interface BeforeInstallPromptEvent extends Event {
   prompt: () => Promise<{ outcome: "accepted" | "dismissed" }>;
@@ -9,20 +10,6 @@ interface BeforeInstallPromptEvent extends Event {
 
 const DISMISS_MS = 30 * 24 * 60 * 60 * 1000;
 const KEY = "taos-install-dismissed";
-
-function isIOS(): boolean {
-  return (
-    /iphone|ipad|ipod/i.test(navigator.userAgent) ||
-    (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1)
-  );
-}
-
-function isStandalone(): boolean {
-  return (
-    (window.navigator as unknown as { standalone?: boolean }).standalone === true ||
-    window.matchMedia("(display-mode: standalone)").matches
-  );
-}
 
 export function InstallPromptBanner() {
   const isMobile = useIsMobile();


### PR DESCRIPTION
Folds the gitar Quality finding on #1107 (duplicated isIOS). Extracts isIOS() (plus isStandalone) into src/lib/platform.ts; InstallPromptBanner and InstallHelperPanel now import it instead of each defining their own. One source of truth for the iOS/iPadOS detection, no behaviour change. Existing component tests (8/8) cover both; build green.