### PR TITLE
fix(pwa): 100dvh in standalone shells (bottom dead space)

### DIFF
--- a/desktop/src/AppStandalone.tsx
+++ b/desktop/src/AppStandalone.tsx
@@ -26,8 +26,15 @@ export function AppStandalone({ appId }: Props) {
 
   return (
     <div
-      className="h-screen w-screen flex flex-col overflow-hidden"
-      style={{ backgroundColor: "var(--color-shell-bg)", paddingTop: "env(safe-area-inset-top, 0px)" }}
+      className="w-screen flex flex-col overflow-hidden"
+      style={{
+        // 100dvh exactly fills the visible standalone area; 100vh (h-screen)
+        // resolves to the larger viewport in an installed iOS PWA and leaves
+        // dead space at the bottom.
+        height: "100dvh",
+        backgroundColor: "var(--color-shell-bg)",
+        paddingTop: "env(safe-area-inset-top, 0px)",
+      }}
     >
       <InstallPromptBanner />
       <Suspense fallback={

--- a/desktop/src/ChatStandalone.tsx
+++ b/desktop/src/ChatStandalone.tsx
@@ -6,8 +6,15 @@ const MessagesApp = lazy(() => import("./apps/MessagesApp").then((m) => ({ defau
 export function ChatStandalone() {
   return (
     <div
-      className="h-screen w-screen flex flex-col overflow-hidden"
-      style={{ backgroundColor: "var(--color-shell-bg)", paddingTop: "env(safe-area-inset-top, 0px)" }}
+      className="w-screen flex flex-col overflow-hidden"
+      style={{
+        // 100dvh exactly fills the visible standalone area; 100vh (h-screen)
+        // resolves to the larger viewport in an installed iOS PWA and leaves
+        // dead space at the bottom.
+        height: "100dvh",
+        backgroundColor: "var(--color-shell-bg)",
+        paddingTop: "env(safe-area-inset-top, 0px)",
+      }}
     >
       <InstallPromptBanner />
       <Suspense fallback={


### PR DESCRIPTION
From on-device testing (Jay): the installed chat PWA shows dead space at the bottom. Cause: the standalone shells (ChatStandalone, AppStandalone) used `h-screen` (100vh), which in an installed iOS PWA resolves to the larger viewport and is taller than the `#root` height:100% chain, leaving a gap. Switch both to `height: 100dvh` (the dynamic viewport unit), which exactly fills the visible standalone area. Top safe-area padding unchanged; per-view bottom safe-area handling (message composer) untouched. Build green.