### PR TITLE
fix(taOSgo): account proxy -- relay body verbatim + rescope Set-Cookie

### DIFF
--- a/tests/test_routes_account_proxy.py
+++ b/tests/test_routes_account_proxy.py
@@ -18,10 +18,15 @@ def _patch_upstream(monkeypatch, handler):
     monkeypatch.setattr("httpx.AsyncClient.request", routed)
 
 
+class _FakeResp:
+    def __init__(self, content=b"{}", status=200, headers=None):
+        self.content = content
+        self.status_code = status
+        self.headers = httpx.Headers(headers or {})
+
+
 @pytest.mark.asyncio
 async def test_account_me_503_when_unconfigured(client, monkeypatch):
-    """No upstream configured -> the proxy reports unavailable so the Account
-    pane shows its 'service unavailable' state."""
     monkeypatch.delenv("TAOS_ACCOUNT_BASE_URL", raising=False)
     r = await client.get("/api/account/me")
     assert r.status_code == 503
@@ -29,32 +34,55 @@ async def test_account_me_503_when_unconfigured(client, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_account_me_forwards_and_relays_cookie(client, monkeypatch):
-    """When configured, /api/account/me forwards to {base}/api/auth/me and the
-    upstream Set-Cookie (the taos.my session) is relayed back to the browser."""
+async def test_account_me_forwards_body_and_relays_cookie(client, monkeypatch):
+    """/api/account/me forwards to {base}/api/auth/me; the upstream body and
+    content-type pass through verbatim and the session cookie is relayed."""
     monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "https://taos.my/")
     captured: dict[str, str] = {}
-
-    class FakeResp:
-        status_code = 200
-        headers = httpx.Headers({"set-cookie": "taosgo_session=abc; Path=/"})
-
-        def json(self):
-            return {"user_id": "u1", "email": "a@b.c", "taosgo": {"status": "none"}}
 
     async def handler(method, url, **kw):
         captured["method"] = method
         captured["url"] = url
-        return FakeResp()
+        return _FakeResp(
+            content=b'{"user_id":"u1","email":"a@b.c","taosgo":{"status":"none"}}',
+            headers={
+                "content-type": "application/json",
+                "set-cookie": "taosgo_session=abc; Path=/",
+            },
+        )
 
     _patch_upstream(monkeypatch, handler)
     r = await client.get("/api/account/me")
     assert r.status_code == 200
     assert r.json()["email"] == "a@b.c"
-    # Trailing slash on the base is stripped; the auth path is appended once.
     assert captured["url"] == "https://taos.my/api/auth/me"
     assert captured["method"] == "GET"
     assert "taosgo_session=abc" in r.headers.get("set-cookie", "")
+
+
+@pytest.mark.asyncio
+async def test_set_cookie_rescoped_to_proxy_origin(client, monkeypatch):
+    """A taos.my cookie carrying Domain + Secure must be rescoped to this
+    origin, or the browser rejects it: Domain is stripped, and Secure is
+    dropped because the test client speaks http. Other attrs are preserved."""
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "https://taos.my")
+
+    async def handler(method, url, **kw):
+        return _FakeResp(
+            content=b"{}",
+            headers={
+                "content-type": "application/json",
+                "set-cookie": "taosgo_session=abc; Path=/; Domain=taos.my; Secure; HttpOnly",
+            },
+        )
+
+    _patch_upstream(monkeypatch, handler)
+    r = await client.get("/api/account/me")
+    sc = r.headers.get("set-cookie", "")
+    assert "taosgo_session=abc" in sc
+    assert "domain=" not in sc.lower()
+    assert "secure" not in sc.lower()
+    assert "HttpOnly" in sc
 
 
 @pytest.mark.asyncio

--- a/tinyagentos/routes/account_proxy.py
+++ b/tinyagentos/routes/account_proxy.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import os
 
 import httpx
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Request, Response
 from fastapi.responses import JSONResponse
 
 router = APIRouter()
@@ -35,7 +35,24 @@ def _base_url() -> str | None:
     return base.rstrip("/") or None
 
 
-async def _forward(request: Request, action: str) -> JSONResponse:
+def _rewrite_set_cookie(value: str, secure_ok: bool) -> str:
+    """Rescope an upstream Set-Cookie to this proxy origin so the browser
+    accepts it: drop the Domain attribute (the cookie was issued for taos.my but
+    the browser is talking to this host), and drop Secure when the proxy
+    connection is not HTTPS, since a Secure cookie is rejected over plain HTTP."""
+    kept: list[str] = []
+    for part in value.split(";"):
+        p = part.strip()
+        low = p.lower()
+        if low.startswith("domain="):
+            continue
+        if low == "secure" and not secure_ok:
+            continue
+        kept.append(p)
+    return "; ".join(kept)
+
+
+async def _forward(request: Request, action: str) -> Response:
     base = _base_url()
     if base is None:
         return JSONResponse(
@@ -61,15 +78,20 @@ async def _forward(request: Request, action: str) -> JSONResponse:
         return JSONResponse(
             {"error": "account service unreachable"}, status_code=503
         )
-    try:
-        payload = upstream.json()
-    except ValueError:
-        payload = {}
-    resp = JSONResponse(payload, status_code=upstream.status_code)
-    # Pass the upstream session cookie back to the browser (scoped to this host).
+    # Relay the upstream body + content-type verbatim (do not assume JSON), so
+    # error pages, redirects, and non-JSON bodies pass through unmangled.
+    resp = Response(
+        content=upstream.content,
+        status_code=upstream.status_code,
+        media_type=upstream.headers.get("content-type"),
+    )
+    # Relay the session cookie, rescoped to this origin so the browser keeps it.
+    secure_ok = request.url.scheme == "https"
     for name, value in upstream.headers.multi_items():
         if name.lower() == "set-cookie":
-            resp.raw_headers.append((b"set-cookie", value.encode("latin-1")))
+            resp.raw_headers.append(
+                (b"set-cookie", _rewrite_set_cookie(value, secure_ok).encode("latin-1"))
+            )
     return resp
 
 


### PR DESCRIPTION
Folds two gitar Bug findings on #1110 before taos.my is wired in. (1) The upstream Set-Cookie was relayed verbatim; a taos.my cookie's Domain/Secure attrs would make the browser reject it through this origin, so the whole session round-trip would fail. Now: strip Domain (bind the cookie to this origin) and drop Secure when the proxy connection is not HTTPS. (2) The response was always re-serialized as JSONResponse, mangling non-JSON upstream bodies, error pages, and redirects. Now: relay the upstream body + content-type verbatim. Adds a Set-Cookie-rescope test; 4 tests pass.