### PR TITLE
fix(account-proxy): honor X-Forwarded-Proto + relay redirect Location

### DIFF
--- a/tests/test_routes_account_proxy.py
+++ b/tests/test_routes_account_proxy.py
@@ -96,3 +96,32 @@ async def test_account_me_503_when_upstream_unreachable(client, monkeypatch):
     r = await client.get("/api/account/me")
     assert r.status_code == 503
     assert "unreachable" in r.json().get("error", "")
+
+
+@pytest.mark.asyncio
+async def test_secure_kept_when_x_forwarded_proto_https(client, monkeypatch):
+    """Behind a TLS-terminating proxy the request scheme is http but the browser
+    leg is https (X-Forwarded-Proto), so the cookie Secure attr must be kept."""
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "https://taos.my")
+
+    async def handler(method, url, **kw):
+        return _FakeResp(
+            headers={"content-type": "application/json", "set-cookie": "s=1; Path=/; Secure"}
+        )
+
+    _patch_upstream(monkeypatch, handler)
+    r = await client.get("/api/account/me", headers={"x-forwarded-proto": "https"})
+    assert "secure" in r.headers.get("set-cookie", "").lower()
+
+
+@pytest.mark.asyncio
+async def test_redirect_location_is_relayed(client, monkeypatch):
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "https://taos.my")
+
+    async def handler(method, url, **kw):
+        return _FakeResp(content=b"", status=302, headers={"location": "https://taos.my/login"})
+
+    _patch_upstream(monkeypatch, handler)
+    r = await client.get("/api/account/me", follow_redirects=False)
+    assert r.status_code == 302
+    assert r.headers.get("location") == "https://taos.my/login"

--- a/tinyagentos/routes/account_proxy.py
+++ b/tinyagentos/routes/account_proxy.py
@@ -85,13 +85,21 @@ async def _forward(request: Request, action: str) -> Response:
         status_code=upstream.status_code,
         media_type=upstream.headers.get("content-type"),
     )
-    # Relay the session cookie, rescoped to this origin so the browser keeps it.
-    secure_ok = request.url.scheme == "https"
+    # Honor X-Forwarded-Proto so the cookie Secure attr survives a TLS-terminating
+    # proxy (the taOSgo relay terminates HTTPS and forwards to us over http).
+    fwd = request.headers.get("x-forwarded-proto", "").split(",")[0].strip().lower()
+    secure_ok = request.url.scheme == "https" or fwd == "https"
+    # Relay the session cookie (rescoped to this origin) plus a small allowlist of
+    # response headers so redirects (Location) and auth challenges survive.
+    _RELAY = {"location", "cache-control", "www-authenticate"}
     for name, value in upstream.headers.multi_items():
-        if name.lower() == "set-cookie":
+        low = name.lower()
+        if low == "set-cookie":
             resp.raw_headers.append(
                 (b"set-cookie", _rewrite_set_cookie(value, secure_ok).encode("latin-1"))
             )
+        elif low in _RELAY:
+            resp.raw_headers.append((low.encode("latin-1"), value.encode("latin-1")))
     return resp
 
 


### PR DESCRIPTION
Folds the two gitar must-fix findings on the account proxy (#1117 follow-up).

## Security — cookie Secure dropped behind the TLS-terminating relay
`secure_ok` was derived from `request.url.scheme` alone. Behind the taOSgo browser relay the controller is reached over http (TLS terminates at the relay), so Secure was stripped and the browser rejected the session cookie. Now reads the first hop of `X-Forwarded-Proto`, so Secure is kept when the browser leg is https.

## Bug — redirect Location swallowed
Only `Set-Cookie` was relayed from the upstream response, so 3xx redirects (Location) and auth challenges (WWW-Authenticate) from the account service were dropped. Added a small response-header allowlist (`location`, `cache-control`, `www-authenticate`) alongside the rescoped cookie.

## Tests
`tests/test_routes_account_proxy.py`: Secure kept under `X-Forwarded-Proto: https`; a 302 Location passed through verbatim. Full file: 6 passed.