### PR TITLE
chore(git): untrack stray root node_modules + ignore it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,7 +93,9 @@ data/browser_cookie_key.hex
 # (a tracked copy dirties the tree and blocks the in-app git-pull update).
 desktop/tsconfig.tsbuildinfo
 
-# never track installed deps
+# never track installed deps (root-level node_modules can appear when a tool is
+# run from the repo root; ignore it everywhere so it is never swept into a commit)
+node_modules/
 desktop/node_modules
 
 # Local-only operational playbook (contains LAN IP + ops detail; agents read it from the working tree)

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "exec-tsk-q2dn7f",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
+++ b/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
@@ -1,1 +1,0 @@
-{"version":"4.1.9","results":[[":desktop/src/lib/slug.test.ts",{"duration":3.199249999999992,"failed":false}],[":desktop/src/components/NotificationToast.test.tsx",{"duration":2.5353749999999877,"failed":true}]]}


### PR DESCRIPTION
## Why
`origin/dev` tracks two stray root-level node_modules artifacts (`node_modules/.package-lock.json` and a vitest `results.json`). Every lane worktree branches off dev, so that directory rides into each one; the executor's `git add -A` then sweeps sibling node_modules files, escalating to the 99-file diff seen on #1129 and producing CONFLICTING exec PRs (#1122/#1129/#1131/#1132).

## Fix
- `git rm -r --cached node_modules` (untrack; files stay on disk)
- add a generic `node_modules/` rule to root `.gitignore` so a root-level install can never be committed again

No source changes. CI's fresh `npm ci` is unaffected.