### PR TITLE
test(project-canvas): fix DB isolation (real db_path attr)

### DIFF
--- a/tests/test_routes_project_canvas.py
+++ b/tests/test_routes_project_canvas.py
@@ -19,9 +19,11 @@ def _ensure_canvas_store(client, tmp_path_factory):
             asyncio.get_event_loop().run_until_complete(store.close())
         except Exception:
             pass
-    # Use a fresh DB per test session via tmp_path
+    # Use a fresh DB per test session via tmp_path. BaseStore reads self.db_path
+    # (a Path) in init(); the previous override set a non-existent `_db_path`
+    # string attr, so init() silently fell back to the production canvas DB.
     tmp_dir = tmp_path_factory.mktemp("canvas_test")
-    store._db_path = str(tmp_dir / "test_projects.db")
+    store.db_path = tmp_dir / "test_projects.db"
     asyncio.get_event_loop().run_until_complete(store.init())
     yield
     try:


### PR DESCRIPTION
Folds the #1119 gitar must-fix finding (completes task #113 with #1133).

The autouse fixture in tests/test_routes_project_canvas.py set `store._db_path` (a non-existent attribute) as a string, but `BaseStore.init()` reads `self.db_path` (a `Path`). So the override was a silent no-op and the suite ran against the **production** canvas DB.

Fix: assign `store.db_path = tmp_dir / "test_projects.db"` (a Path), matching BaseStore.

Verified: 18 passed / 1 skipped; a probe confirms init() now targets the temp DB and never creates the production path.