### PR TITLE
fix(account-proxy): trust-gate X-Forwarded-Proto + harden header relay

### DIFF
--- a/tests/test_routes_account_proxy.py
+++ b/tests/test_routes_account_proxy.py
@@ -99,10 +99,12 @@ async def test_account_me_503_when_upstream_unreachable(client, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_secure_kept_when_x_forwarded_proto_https(client, monkeypatch):
+async def test_secure_kept_when_x_forwarded_proto_https_and_trusted(client, monkeypatch):
     """Behind a TLS-terminating proxy the request scheme is http but the browser
-    leg is https (X-Forwarded-Proto), so the cookie Secure attr must be kept."""
+    leg is https (X-Forwarded-Proto). When the deployment trusts that header
+    (TAOS_TRUST_FORWARDED_PROTO), the cookie Secure attr must be kept."""
     monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "https://taos.my")
+    monkeypatch.setenv("TAOS_TRUST_FORWARDED_PROTO", "1")
 
     async def handler(method, url, **kw):
         return _FakeResp(
@@ -112,6 +114,23 @@ async def test_secure_kept_when_x_forwarded_proto_https(client, monkeypatch):
     _patch_upstream(monkeypatch, handler)
     r = await client.get("/api/account/me", headers={"x-forwarded-proto": "https"})
     assert "secure" in r.headers.get("set-cookie", "").lower()
+
+
+@pytest.mark.asyncio
+async def test_x_forwarded_proto_ignored_when_untrusted(client, monkeypatch):
+    """Without the trust opt-in, X-Forwarded-Proto is client-spoofable, so it is
+    ignored and Secure is dropped over the plain-http test connection."""
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "https://taos.my")
+    monkeypatch.delenv("TAOS_TRUST_FORWARDED_PROTO", raising=False)
+
+    async def handler(method, url, **kw):
+        return _FakeResp(
+            headers={"content-type": "application/json", "set-cookie": "s=1; Path=/; Secure"}
+        )
+
+    _patch_upstream(monkeypatch, handler)
+    r = await client.get("/api/account/me", headers={"x-forwarded-proto": "https"})
+    assert "secure" not in r.headers.get("set-cookie", "").lower()
 
 
 @pytest.mark.asyncio

--- a/tinyagentos/routes/account_proxy.py
+++ b/tinyagentos/routes/account_proxy.py
@@ -35,6 +35,27 @@ def _base_url() -> str | None:
     return base.rstrip("/") or None
 
 
+def _trust_forwarded_proto() -> bool:
+    """X-Forwarded-Proto is client-spoofable unless a trusted proxy sets it. Only
+    honor it when the deployment opts in (the taOSgo relay, which terminates TLS
+    and forwards over http, sets TAOS_TRUST_FORWARDED_PROTO=1)."""
+    return os.environ.get("TAOS_TRUST_FORWARDED_PROTO", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+
+
+def _append_header(resp: Response, name: str, value: str) -> None:
+    """Append a raw response header, skipping values that are not latin-1
+    encodable. HTTP/1.1 header bytes are latin-1; a non-encodable relayed value
+    would otherwise raise UnicodeEncodeError and break the whole response."""
+    try:
+        resp.raw_headers.append((name.encode("latin-1"), value.encode("latin-1")))
+    except UnicodeEncodeError:
+        pass
+
+
 def _rewrite_set_cookie(value: str, secure_ok: bool) -> str:
     """Rescope an upstream Set-Cookie to this proxy origin so the browser
     accepts it: drop the Domain attribute (the cookie was issued for taos.my but
@@ -85,9 +106,12 @@ async def _forward(request: Request, action: str) -> Response:
         status_code=upstream.status_code,
         media_type=upstream.headers.get("content-type"),
     )
-    # Honor X-Forwarded-Proto so the cookie Secure attr survives a TLS-terminating
-    # proxy (the taOSgo relay terminates HTTPS and forwards to us over http).
-    fwd = request.headers.get("x-forwarded-proto", "").split(",")[0].strip().lower()
+    # Derive Secure from the real connection scheme, and from X-Forwarded-Proto
+    # only when the deployment trusts it (the TLS-terminating taOSgo relay
+    # forwards over http). Untrusted, the header is client-spoofable so ignore it.
+    fwd = ""
+    if _trust_forwarded_proto():
+        fwd = request.headers.get("x-forwarded-proto", "").split(",")[0].strip().lower()
     secure_ok = request.url.scheme == "https" or fwd == "https"
     # Relay the session cookie (rescoped to this origin) plus a small allowlist of
     # response headers so redirects (Location) and auth challenges survive.
@@ -95,11 +119,9 @@ async def _forward(request: Request, action: str) -> Response:
     for name, value in upstream.headers.multi_items():
         low = name.lower()
         if low == "set-cookie":
-            resp.raw_headers.append(
-                (b"set-cookie", _rewrite_set_cookie(value, secure_ok).encode("latin-1"))
-            )
+            _append_header(resp, "set-cookie", _rewrite_set_cookie(value, secure_ok))
         elif low in _RELAY:
-            resp.raw_headers.append((low.encode("latin-1"), value.encode("latin-1")))
+            _append_header(resp, low, value)
     return resp
 
 


### PR DESCRIPTION
Folds two post-merge gitar findings on #1133 (per the bot-review severity gate).

**Security** - X-Forwarded-Proto is client-spoofable unless the controller sits behind a trusted proxy. Previously it was honored unconditionally, so a client on a direct (non-relay) connection could send `X-Forwarded-Proto: https` and force the session cookie's `Secure` attr over plain http. Now gated behind `TAOS_TRUST_FORWARDED_PROTO` (the TLS-terminating taOSgo relay deployment sets it); otherwise Secure derives from the real connection scheme only.

**Edge case** - relayed header values are `encode("latin-1")`d; a non-latin-1 value would raise `UnicodeEncodeError` and break the whole response. Added `_append_header` which skips non-encodable values, applied to both the rescoped cookie and the allowlist (Location / Cache-Control / WWW-Authenticate).

Tests: trusted X-Forwarded-Proto keeps Secure; untrusted ignores it (Secure dropped); existing relay/cookie tests still pass (7 passed).