### PR TITLE
tests: add route tests for GET /api/memory/model endpoint

### DIFF
--- a/tests/test_routes_librarian.py
+++ b/tests/test_routes_librarian.py
@@ -1,0 +1,27 @@
+import types
+
+import pytest
+
+
+class TestMemoryModelEndpoint:
+    @pytest.mark.asyncio
+    async def test_get_memory_model_returns_200_with_keys(self, client, monkeypatch):
+        fake = types.SimpleNamespace(get_memory_model=lambda: "qwen3-8b")
+        monkeypatch.setattr("tinyagentos.routes.librarian.taosmd", fake)
+        resp = await client.get("/api/memory/model")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "model" in data
+        assert "supported" in data
+        assert data["supported"] is True
+        assert data["model"] == "qwen3-8b"
+
+    @pytest.mark.asyncio
+    async def test_get_memory_model_unsupported_returns_none(self, client, monkeypatch):
+        fake = types.SimpleNamespace()
+        monkeypatch.setattr("tinyagentos.routes.librarian.taosmd", fake)
+        resp = await client.get("/api/memory/model")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["model"] is None
+        assert data["supported"] is False


### PR DESCRIPTION
Autonomous build of board card tsk-4ltt4g.



Files:
 tests/test_routes_librarian.py | 27 +++++++++++++++++++++++++++
 1 file changed, 27 insertions(+)