### PR TITLE
Add route tests for GET /api/cluster/remotes

### DIFF
--- a/tests/test_routes_cluster_migrate.py
+++ b/tests/test_routes_cluster_migrate.py
@@ -1,0 +1,39 @@
+import pytest
+
+
+class TestClusterRemotesRead:
+    @pytest.mark.asyncio
+    async def test_list_remotes_returns_200(self, client, monkeypatch):
+        async def fake_remote_list():
+            return []
+
+        monkeypatch.setattr(
+            "tinyagentos.routes.cluster_migrate.remote_list",
+            fake_remote_list,
+        )
+        resp = await client.get("/api/cluster/remotes")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    @pytest.mark.asyncio
+    async def test_list_remotes_returns_configured_remotes(self, client, monkeypatch):
+        fake_remotes = [
+            {"name": "host-b", "addr": "https://10.0.0.2:8443", "protocol": "simplestreams"},
+            {"name": "host-c", "addr": "https://10.0.0.3:8443", "protocol": "simplestreams"},
+        ]
+
+        async def fake_remote_list():
+            return fake_remotes
+
+        monkeypatch.setattr(
+            "tinyagentos.routes.cluster_migrate.remote_list",
+            fake_remote_list,
+        )
+        resp = await client.get("/api/cluster/remotes")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+        assert len(data) == 2
+        assert data[0]["name"] == "host-b"
+        assert data[0]["addr"] == "https://10.0.0.2:8443"
+        assert data[0]["protocol"] == "simplestreams"


### PR DESCRIPTION
Autonomous build of board card tsk-im776b.



Files:
 tests/test_routes_cluster_migrate.py | 39 ++++++++++++++++++++++++++++++++++++
 1 file changed, 39 insertions(+)

----
## Summary by Gitar

- **Test coverage:**
  - Added `tests/test_routes_cluster_migrate.py` to verify `GET /api/cluster/remotes` endpoint functionality.
  - Implemented unit tests covering empty remote lists and successful retrieval of configured remote nodes.

<sub>This will update automatically on new commits.</sub>