### PR TITLE
Add route tests for agent auth-requests read endpoints

### DIFF
--- a/tests/test_routes_agent_auth_requests.py
+++ b/tests/test_routes_agent_auth_requests.py
@@ -1,0 +1,65 @@
+import pytest
+
+
+class _FakeAuthRequestsStore:
+    async def list_pending(self):
+        return []
+
+    async def get(self, request_id):
+        return None
+
+
+class TestAgentAuthRequestsList:
+    @pytest.mark.asyncio
+    async def test_list_returns_200_with_requests_key(self, client, monkeypatch):
+        store = _FakeAuthRequestsStore()
+        monkeypatch.setattr(client._transport.app.state, "auth_requests", store)
+        resp = await client.get("/api/agents/auth-requests")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "requests" in data
+        assert isinstance(data["requests"], list)
+
+    @pytest.mark.asyncio
+    async def test_list_returns_pending_requests(self, client, monkeypatch):
+        sample = [
+            {
+                "id": "abc123",
+                "identity_claim": "test-agent",
+                "framework": "langchain",
+                "requested_scopes": ["memory_read"],
+                "requested_skills": [],
+                "reason": "testing",
+                "duration_secs": None,
+                "project_id": None,
+                "status": "pending",
+                "canonical_id": None,
+                "token": None,
+                "granted_scopes": None,
+                "created_ts": "2026-01-01T00:00:00+00:00",
+                "decided_ts": None,
+                "decided_by": None,
+            }
+        ]
+
+        class _Store(_FakeAuthRequestsStore):
+            async def list_pending(self):
+                return sample
+
+        monkeypatch.setattr(
+            client._transport.app.state, "auth_requests", _Store(),
+        )
+        resp = await client.get("/api/agents/auth-requests")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["requests"]) == 1
+        assert data["requests"][0]["status"] == "pending"
+
+
+class TestAgentAuthRequestsGet:
+    @pytest.mark.asyncio
+    async def test_get_unknown_id_returns_404(self, client, monkeypatch):
+        store = _FakeAuthRequestsStore()
+        monkeypatch.setattr(client._transport.app.state, "auth_requests", store)
+        resp = await client.get("/api/agents/auth-requests/nonexistent123")
+        assert resp.status_code == 404


### PR DESCRIPTION
Autonomous build of board card tsk-2c5prn.



Files:
 tests/test_routes_agent_auth_requests.py | 65 ++++++++++++++++++++++++++++++++
 1 file changed, 65 insertions(+)

----
## Summary by Gitar

- **Test coverage:**
  - Added `TestAgentAuthRequestsList` to verify `/api/agents/auth-requests` endpoint response structure and data.
  - Added `TestAgentAuthRequestsGet` to verify 404 handling for unknown IDs in `/api/agents/auth-requests/{request_id}`.

<sub>This will update automatically on new commits.</sub>