### PR TITLE
test: add colocated vitest test for account-client

### DIFF
--- a/desktop/src/lib/account-client.test.ts
+++ b/desktop/src/lib/account-client.test.ts
@@ -1,0 +1,247 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchAccount, login, register, logout, isAuthError } from "./account-client";
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe("fetchAccount", () => {
+  it("returns signed-in state with account on 200", async () => {
+    const account = {
+      user_id: "u-1",
+      email: "a@b.test",
+      taosgo: { status: "active" },
+    };
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => account,
+    });
+    global.fetch = fetchMock;
+
+    const result = await fetchAccount();
+    expect(result).toEqual({ kind: "signed-in", account });
+
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/account/me");
+    expect(opts.method).toBe("GET");
+    expect(opts.credentials).toBe("include");
+  });
+
+  it("returns signed-out on 401", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 401 });
+    expect(await fetchAccount()).toEqual({ kind: "signed-out" });
+  });
+
+  it("returns unavailable on 500", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+    expect(await fetchAccount()).toEqual({ kind: "unavailable" });
+  });
+
+  it("returns unavailable on network error", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("network failure"));
+    expect(await fetchAccount()).toEqual({ kind: "unavailable" });
+  });
+
+  it("returns unavailable when body is not a valid account", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ user_id: 123 }),
+    });
+    expect(await fetchAccount()).toEqual({ kind: "unavailable" });
+  });
+
+  it("returns unavailable when json parse fails", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new Error("bad json");
+      },
+    });
+    expect(await fetchAccount()).toEqual({ kind: "unavailable" });
+  });
+});
+
+describe("login", () => {
+  it("returns account on 200", async () => {
+    const account = {
+      user_id: "u-1",
+      email: "a@b.test",
+      taosgo: { status: "active" },
+    };
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => account,
+    });
+    global.fetch = fetchMock;
+
+    const result = await login("a@b.test", "pw");
+    expect(result).toEqual(account);
+
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/account/login");
+    expect(opts.method).toBe("POST");
+    expect(opts.headers["Content-Type"]).toBe("application/json");
+    expect(opts.credentials).toBe("include");
+    expect(JSON.parse(opts.body)).toEqual({ email: "a@b.test", password: "pw" });
+  });
+
+  it("returns AuthError on 401", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({ error: "Invalid credentials" }),
+    });
+    const result = await login("a@b.test", "pw");
+    expect(isAuthError(result)).toBe(true);
+    if (isAuthError(result)) {
+      expect(result.message).toBe("Invalid credentials");
+    }
+  });
+
+  it("returns AuthError on 404", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 404 });
+    const result = await login("a@b.test", "pw");
+    expect(isAuthError(result)).toBe(true);
+    if (isAuthError(result)) {
+      expect(result.message).toBe("The account service is not available yet.");
+    }
+  });
+
+  it("returns AuthError on 503", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 503 });
+    const result = await login("a@b.test", "pw");
+    expect(isAuthError(result)).toBe(true);
+    if (isAuthError(result)) {
+      expect(result.message).toBe("The account service is not available yet.");
+    }
+  });
+
+  it("returns AuthError on network error", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("offline"));
+    const result = await login("a@b.test", "pw");
+    expect(isAuthError(result)).toBe(true);
+    if (isAuthError(result)) {
+      expect(result.message).toBe("Could not reach the account service. Check your connection.");
+    }
+  });
+
+  it("returns AuthError when response body is not a valid account", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ user_id: 123 }),
+    });
+    const result = await login("a@b.test", "pw");
+    expect(isAuthError(result)).toBe(true);
+    if (isAuthError(result)) {
+      expect(result.message).toBe("Unexpected response from the account service.");
+    }
+  });
+
+  it("returns AuthError using detail when error is absent", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ detail: "bad input" }),
+    });
+    const result = await login("a@b.test", "pw");
+    expect(isAuthError(result)).toBe(true);
+    if (isAuthError(result)) {
+      expect(result.message).toBe("bad input");
+    }
+  });
+
+  it("returns AuthError with status code default when body parse fails", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => {
+        throw new Error("bad json");
+      },
+    });
+    const result = await login("a@b.test", "pw");
+    expect(isAuthError(result)).toBe(true);
+    if (isAuthError(result)) {
+      expect(result.message).toBe("Request failed (400).");
+    }
+  });
+});
+
+describe("register", () => {
+  it("returns account on 200", async () => {
+    const account = {
+      user_id: "u-2",
+      email: "new@b.test",
+      taosgo: { status: "trialing", trial_ends_at: "2026-07-01" },
+    };
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => account,
+    });
+    global.fetch = fetchMock;
+
+    const result = await register("new@b.test", "pw");
+    expect(result).toEqual(account);
+
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/account/register");
+    expect(opts.method).toBe("POST");
+    expect(opts.credentials).toBe("include");
+    expect(JSON.parse(opts.body)).toEqual({ email: "new@b.test", password: "pw" });
+  });
+
+  it("returns AuthError on 401", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({ error: "Email already in use" }),
+    });
+    const result = await register("new@b.test", "pw");
+    expect(isAuthError(result)).toBe(true);
+    if (isAuthError(result)) {
+      expect(result.message).toBe("Email already in use");
+    }
+  });
+
+  it("returns AuthError on network error", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("offline"));
+    const result = await register("new@b.test", "pw");
+    expect(isAuthError(result)).toBe(true);
+    if (isAuthError(result)) {
+      expect(result.message).toBe("Could not reach the account service. Check your connection.");
+    }
+  });
+});
+
+describe("logout", () => {
+  it("posts to /logout with empty body", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    global.fetch = fetchMock;
+
+    await logout();
+
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/account/logout");
+    expect(opts.method).toBe("POST");
+    expect(opts.credentials).toBe("include");
+    expect(JSON.parse(opts.body)).toEqual({});
+  });
+
+  it("does not throw on network error", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("offline"));
+    await expect(logout()).resolves.toBeUndefined();
+  });
+
+  it("does not throw on non-ok response", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+    await expect(logout()).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
Autonomous build of board card tsk-jrd6k4.



Files:
 desktop/src/lib/account-client.test.ts | 247 +++++++++++++++++++++++++++++++++
 1 file changed, 247 insertions(+)

----
## Summary by Gitar

- **Added tests:**
  - Added comprehensive Vitest unit tests for `account-client` covering `fetchAccount`, `login`, `register`, and `logout` functionality.
  - Included edge case handling for network failures, non-200 status codes, and invalid JSON responses using `global.fetch` mocks.


<sub>This will update automatically on new commits.</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for account authentication operations, including login, registration, logout, and account fetching with validation of success cases and various error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->