### PR TITLE
fix(update): npm ci so rebuild never dirties package-lock.json (broken in-app update)

### DIFF
--- a/tinyagentos/desktop_rebuild.py
+++ b/tinyagentos/desktop_rebuild.py
@@ -134,18 +134,48 @@ async def rebuild_desktop_bundle_if_stale(
 
     try:
         if _deps_install_needed(desktop_dir):
-            logger.info("Dependencies changed or missing — running npm install...")
+            # Use `npm ci`, not `npm install`: ci installs exactly from the
+            # committed package-lock.json and NEVER rewrites it. `npm install`
+            # rewrites the lockfile, which leaves the tracked desktop/package-
+            # lock.json dirty and makes the next in-app `git pull` update abort
+            # with "local changes would be overwritten by merge" (the deadlock a
+            # user hit when their installed version predated the #852 restore).
+            logger.info("Dependencies changed or missing — running npm ci...")
             proc = await asyncio.create_subprocess_exec(
-                "npm", "install", "--silent",
+                "npm", "ci", "--silent",
                 cwd=str(desktop_dir),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
             _, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout_seconds)
             if proc.returncode != 0:
-                msg = f"npm install failed (rc={proc.returncode}): {stderr.decode(errors='replace')[-500:]}"
-                logger.error(msg)
-                return RebuildResult(rebuilt=True, success=False, message=msg)
+                # `npm ci` fails if package.json and the lockfile are out of sync
+                # (rare). Fall back to `npm install`, then restore the lockfile so
+                # the tree stays clean for the next update.
+                logger.warning(
+                    "npm ci failed (rc=%s), falling back to npm install: %s",
+                    proc.returncode, stderr.decode(errors="replace")[-300:],
+                )
+                proc = await asyncio.create_subprocess_exec(
+                    "npm", "install", "--silent",
+                    cwd=str(desktop_dir),
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                _, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout_seconds)
+                if proc.returncode != 0:
+                    msg = f"npm install failed (rc={proc.returncode}): {stderr.decode(errors='replace')[-500:]}"
+                    logger.error(msg)
+                    return RebuildResult(rebuilt=True, success=False, message=msg)
+                # Discard the lockfile rewrite npm install just made so the
+                # working tree is clean for the next git-pull update.
+                restore = await asyncio.create_subprocess_exec(
+                    "git", "checkout", "--", "package-lock.json",
+                    cwd=str(desktop_dir),
+                    stdout=asyncio.subprocess.DEVNULL,
+                    stderr=asyncio.subprocess.DEVNULL,
+                )
+                await restore.communicate()
             _record_deps_install(desktop_dir)
         else:
             logger.info("Dependencies unchanged — skipping npm install.")


### PR DESCRIPTION
## User-reported bug
A user's in-app Install Update fails with:
```
error: Your local changes to the following files would be overwritten by merge: desktop/package-lock.json
Aborting Updating d01d4f0..34d43fa
```

## Root cause
`rebuild_desktop_bundle_if_stale` runs `npm install`, which **rewrites** the tracked `desktop/package-lock.json`. That leaves it dirty, so the next `git pull --ff-only` aborts ("local changes would be overwritten by merge") and the update silently fails. The restore-before-pull guard added in #852 mitigates it on current installs, but a user whose installed version predates #852 is stuck: their old updater does a naive pull and can't reach the fix through the broken updater (an update deadlock).

## Fix
Use `npm ci` instead of `npm install` in the rebuild. `npm ci` installs exactly from the committed lockfile and never rewrites it, so the working tree stays clean for the next pull. Falls back to `npm install` (then restores the lockfile) only if `npm ci` fails on a package.json/lock mismatch.

Combined with #852's restore guard, the lockfile can no longer block updates. Stuck users on a pre-#852 install get a one-time manual recovery (relayed separately).

Tests: existing test_desktop_rebuild.py (17) pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced desktop rebuild process with improved dependency installation handling and error reporting for more reliable builds.

* **Chores**
  * Optimized build system to maintain cleaner working directory state during dependency management operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->