### PR TITLE
fix: harden npm-ci fallback (gitar #1197) + detect WSL memory cap

### DIFF
--- a/tests/test_desktop_rebuild.py
+++ b/tests/test_desktop_rebuild.py
@@ -206,6 +206,40 @@ async def test_rebuild_success(tmp_path, monkeypatch):
     assert "successfully" in result.message.lower()
 
 
+@pytest.mark.asyncio
+async def test_rebuild_falls_back_to_npm_install_when_ci_fails(tmp_path, monkeypatch):
+    """npm ci failure falls back to npm install, restores the lockfile, then builds."""
+    src_dir = tmp_path / "desktop" / "src"
+    src_dir.mkdir(parents=True)
+    (src_dir / "App.tsx").write_text("// stale")
+    (tmp_path / "desktop" / "package.json").write_text('{"name":"x"}')
+
+    calls = []
+
+    class Proc:
+        def __init__(self, rc):
+            self.returncode = rc
+
+        async def communicate(self):
+            return b"", b""
+
+    async def fake_exec(*args, **kwargs):
+        calls.append(args)
+        if args[0] == "npm" and args[1] == "ci":
+            return Proc(1)  # ci fails -> fallback path
+        return Proc(0)  # npm install, git checkout, npm run build all succeed
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+    result = await rebuild_desktop_bundle_if_stale(tmp_path)
+    assert result.rebuilt is True
+    assert result.success is True
+    cmds = [(a[0], a[1]) for a in calls]
+    assert ("npm", "ci") in cmds
+    assert ("npm", "install") in cmds  # fallback ran
+    assert ("git", "checkout") in cmds  # lockfile restored after install
+
+
 # ---------------------------------------------------------------------------
 # npm-install gate: only reinstall when package-lock.json changes
 # ---------------------------------------------------------------------------

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -261,3 +261,25 @@ class TestHardwareRefreshEndpoint:
         assert cache_path.exists()
         saved = json.loads(cache_path.read_text())
         assert saved["ram_mb"] == fresh["ram_mb"]
+
+
+class TestWslDetection:
+    def test_detect_wsl_via_env(self, monkeypatch):
+        monkeypatch.setenv("WSL_DISTRO_NAME", "Ubuntu")
+        assert hardware_mod._detect_wsl() is True
+
+    def test_no_wsl_on_clean_host(self, monkeypatch):
+        monkeypatch.delenv("WSL_DISTRO_NAME", raising=False)
+        monkeypatch.delenv("WSL_INTEROP", raising=False)
+        # A normal Linux/mac host has no microsoft marker (or no /proc/version).
+        assert hardware_mod._detect_wsl() is False
+
+    def test_detect_hardware_explains_wsl_cap(self, monkeypatch):
+        monkeypatch.setenv("WSL_DISTRO_NAME", "Ubuntu")
+        monkeypatch.setattr(hardware_mod, "_detect_ram", lambda: 8192)
+        prof = detect_hardware()
+        assert prof.wsl is True
+        assert ".wslconfig" in prof.mem_note
+        assert "8GB" in prof.mem_note
+        # ram_mb itself is left untouched (8GB really is what the VM has)
+        assert prof.ram_mb == 8192

--- a/tinyagentos/desktop_rebuild.py
+++ b/tinyagentos/desktop_rebuild.py
@@ -167,15 +167,26 @@ async def rebuild_desktop_bundle_if_stale(
                     msg = f"npm install failed (rc={proc.returncode}): {stderr.decode(errors='replace')[-500:]}"
                     logger.error(msg)
                     return RebuildResult(rebuilt=True, success=False, message=msg)
-                # Discard the lockfile rewrite npm install just made so the
-                # working tree is clean for the next git-pull update.
-                restore = await asyncio.create_subprocess_exec(
-                    "git", "checkout", "--", "package-lock.json",
-                    cwd=str(desktop_dir),
-                    stdout=asyncio.subprocess.DEVNULL,
-                    stderr=asyncio.subprocess.DEVNULL,
-                )
-                await restore.communicate()
+                # Discard the lockfile rewrite npm install just made so the tree
+                # is clean for the next git-pull update. If this restore fails we
+                # only warn: apply_update() also restores the lockfile before
+                # every pull, so a dirty lockfile is double-covered there.
+                try:
+                    restore = await asyncio.create_subprocess_exec(
+                        "git", "checkout", "--", "package-lock.json",
+                        cwd=str(desktop_dir),
+                        stdout=asyncio.subprocess.DEVNULL,
+                        stderr=asyncio.subprocess.PIPE,
+                    )
+                    _, rerr = await restore.communicate()
+                    if restore.returncode != 0:
+                        logger.warning(
+                            "could not restore package-lock.json after npm install "
+                            "(rc=%s): %s",
+                            restore.returncode, rerr.decode(errors="replace")[-200:],
+                        )
+                except FileNotFoundError:
+                    logger.warning("git not found; could not restore package-lock.json")
             _record_deps_install(desktop_dir)
         else:
             logger.info("Dependencies unchanged — skipping npm install.")

--- a/tinyagentos/hardware.py
+++ b/tinyagentos/hardware.py
@@ -78,6 +78,12 @@ class HardwareProfile:
     gpu: GpuInfo = field(default_factory=GpuInfo)
     disk: DiskInfo = field(default_factory=DiskInfo)
     os: OsInfo = field(default_factory=OsInfo)
+    # True when running inside WSL, where ram_mb is the WSL VM cap (50% of the
+    # Windows host by default) rather than the real machine RAM. mem_note carries
+    # a user-facing explanation + how to raise it. ram_mb is left as-is (it IS
+    # what the VM has); these only contextualize it so users are not confused.
+    wsl: bool = False
+    mem_note: str = ""
 
     @property
     def profile_id(self) -> str:
@@ -112,6 +118,8 @@ class HardwareProfile:
             gpu=GpuInfo(**data.get("gpu", {})),
             disk=DiskInfo(**data.get("disk", {})),
             os=OsInfo(**data.get("os", {})),
+            wsl=data.get("wsl", False),
+            mem_note=data.get("mem_note", ""),
         )
 
 
@@ -197,6 +205,20 @@ def _detect_ram() -> int:
     except OSError:
         pass
     return 0
+
+
+def _detect_wsl() -> bool:
+    """True when running inside WSL. The RAM seen here is the WSL VM cap (50% of
+    the Windows host by default), not the real machine, so a 16GB host shows
+    ~8GB. We surface this so the limit is explained rather than confusing."""
+    import os
+    if os.environ.get("WSL_DISTRO_NAME") or os.environ.get("WSL_INTEROP"):
+        return True
+    try:
+        version = Path("/proc/version").read_text().lower()
+        return "microsoft" in version or "wsl" in version
+    except OSError:
+        return False
 
 
 def _path_exists_safe(p: Path) -> bool:
@@ -590,13 +612,26 @@ def _detect_os() -> OsInfo:
 
 def detect_hardware() -> HardwareProfile:
     """Detect all hardware and return a profile."""
+    ram_mb = _detect_ram()
+    wsl = _detect_wsl()
+    mem_note = ""
+    if wsl:
+        gb = max(1, round(ram_mb / 1024))
+        mem_note = (
+            f"Running under WSL, which limits Linux to about {gb}GB "
+            "(50% of the Windows host by default). To use more, set "
+            "memory= in C:\\Users\\<you>\\.wslconfig then run "
+            "'wsl --shutdown'."
+        )
     return HardwareProfile(
         cpu=_detect_cpu(),
-        ram_mb=_detect_ram(),
+        ram_mb=ram_mb,
         npu=_detect_npu(),
         gpu=_detect_gpu(),
         disk=_detect_disk(),
         os=_detect_os(),
+        wsl=wsl,
+        mem_note=mem_note,
     )
 
 


### PR DESCRIPTION
Two small fixes, both requested for dev then master now.

## 1. Harden the npm-ci fallback (folds gitar's #1197 findings)
The fallback path in `desktop_rebuild.py` (npm ci fails -> npm install -> restore lockfile) now: captures stderr and **checks the result** of the `git checkout -- package-lock.json` restore (warns instead of silently leaving the lockfile dirty), and **catches FileNotFoundError**. Adds a test for the full fallback path. Double-covered anyway by apply_update's pre-pull restore.

## 2. Detect WSL and explain the memory cap
A user on a 16GB machine saw taOS report an 8GB limit "because of docker". Root cause: **WSL2 caps its Linux VM at 50% of the Windows host by default** (8GB on 16GB); `/proc/meminfo` reports the VM, and Docker Desktop on Windows uses the same WSL2 backend. taOS had no WSL awareness, so it showed 8GB with no context.
- `_detect_wsl()` (via `WSL_DISTRO_NAME`/`WSL_INTEROP` env or `/proc/version` 'microsoft').
- `wsl` flag + `mem_note` advisory on `HardwareProfile` pointing at `.wslconfig` `memory=` + `wsl --shutdown`.
- `ram_mb` is left unchanged (8GB really is what the VM has); this only contextualizes it.
- Exposed via the hardware profile API. Frontend surfacing of `mem_note` is a fast follow.

Tests: 21 pass (3 WSL + 18 desktop_rebuild). Native Linux + Pi unaffected by the WSL path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows Subsystem for Linux (WSL) detection with memory configuration tracking in hardware profiles.

* **Bug Fixes**
  * Improved robustness of desktop bundle rebuild fallback sequence with enhanced error handling and logging for package restoration.

* **Tests**
  * Added test coverage for WSL detection behavior and npm package manager fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->