### PR TITLE
ci: run test job on self-hosted runners (VPS + Fedora)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,34 @@ on:
     - cron: "0 6 * * *"
 
 jobs:
+  # Pick the highest-priority available runner: the always-on VPS first, then
+  # the Fedora box, then GitHub-hosted as the never-hang fallback. Querying
+  # runner status needs a PAT with administration:read (secret RUNNER_ADMIN_PAT);
+  # without it this defaults to the self-hosted pool, which the always-on VPS
+  # services. The slow suite runs in a few minutes on a self-hosted box vs ~16
+  # on GitHub's shared runners.
+  pick-runner:
+    runs-on: ubuntu-latest
+    outputs:
+      on: ${{ steps.p.outputs.on }}
+    steps:
+      - id: p
+        env:
+          PAT: ${{ secrets.RUNNER_ADMIN_PAT }}
+        run: |
+          on='["self-hosted","taos-ci"]'
+          if [ -n "$PAT" ]; then
+            online=$(GH_TOKEN="$PAT" gh api "repos/${{ github.repository }}/actions/runners" \
+              --jq '[.runners[] | select(.status=="online") | .labels[].name]' 2>/dev/null || echo '[]')
+            if echo "$online" | grep -q '"vps"'; then on='["self-hosted","vps"]'
+            elif echo "$online" | grep -q '"fedora"'; then on='["self-hosted","fedora"]'
+            else on='"ubuntu-latest"'; fi
+          fi
+          echo "on=$on" >> "$GITHUB_OUTPUT"
+
   test:
-    # Self-hosted runners (the always-on VPS + the Fedora box, both labelled
-    # taos-ci) run the slow suite in a few minutes instead of ~16 on GitHub's
-    # shared runners, and the two share the label so the 3.12/3.13 matrix runs
-    # in parallel with redundancy if one box is offline. lint + spa-build stay
-    # on ubuntu-latest as a free, always-available fallback.
-    runs-on: [self-hosted, linux, x64, taos-ci]
+    needs: pick-runner
+    runs-on: ${{ fromJSON(needs.pick-runner.outputs.on) }}
     # 45 min cap accommodates the cron run that includes 3.11 (~30 min);
     # 3.12/3.13 PR runs finish in ~16 min, so this only kicks in if 3.11
     # ever drifts further.
@@ -35,15 +56,18 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python-version }}
-
+      # No actions/setup-python: it only ships prebuilt CPython for GitHub's
+      # ubuntu image, so on the self-hosted Fedora runner it fails with
+      # "version X not found for Fedora". uv provisions Python itself from
+      # distro-agnostic standalone builds, which works on Fedora, the Ubuntu
+      # VPS, and GitHub-hosted runners alike.
       - name: Set up uv
         uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
+
+      - name: Provision Python via uv
+        run: uv python install ${{ matrix.python-version }}
 
       # Install the exact versions recorded in uv.lock (--frozen errors out
       # if the lock is stale rather than silently re-resolving). This is the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,16 @@ on:
     - cron: "0 6 * * *"
 
 jobs:
-  # Pick the highest-priority available runner: the always-on VPS first, then
-  # the Fedora box, then GitHub-hosted as the never-hang fallback. Querying
-  # runner status needs a PAT with administration:read (secret RUNNER_ADMIN_PAT);
-  # without it this defaults to the self-hosted pool, which the always-on VPS
-  # services. The slow suite runs in a few minutes on a self-hosted box vs ~16
-  # on GitHub's shared runners.
+  # Route the matrix to the self-hosted POOL (VPS + Fedora, both labelled
+  # taos-ci) rather than pinning it to one box. The two boxes are ~tied per
+  # core (Fedora i5-10600 ~2.0s, VPS EPYC ~2.2s on the same microbench), so the
+  # fastest run is the two matrix legs in PARALLEL across both — pinning the
+  # whole matrix to a single runner would serialise the legs and be slower. The
+  # always-on, dedicated VPS is the anchor; Fedora joins the pool when it is up
+  # and adds a parallel lane. We only fall back to GitHub-hosted when BOTH
+  # self-hosted runners are offline, so CI never hangs. Reading runner status
+  # needs a PAT with administration:read (secret RUNNER_ADMIN_PAT); without it
+  # we stay on the pool, which the always-on VPS keeps serviceable.
   pick-runner:
     runs-on: ubuntu-latest
     outputs:
@@ -32,11 +36,10 @@ jobs:
         run: |
           on='["self-hosted","taos-ci"]'
           if [ -n "$PAT" ]; then
-            online=$(GH_TOKEN="$PAT" gh api "repos/${{ github.repository }}/actions/runners" \
-              --jq '[.runners[] | select(.status=="online") | .labels[].name]' 2>/dev/null || echo '[]')
-            if echo "$online" | grep -q '"vps"'; then on='["self-hosted","vps"]'
-            elif echo "$online" | grep -q '"fedora"'; then on='["self-hosted","fedora"]'
-            else on='"ubuntu-latest"'; fi
+            count=$(GH_TOKEN="$PAT" gh api "repos/${{ github.repository }}/actions/runners" \
+              --jq '[.runners[] | select(.status=="online") | select(any(.labels[].name; . == "taos-ci"))] | length' \
+              2>/dev/null || echo 1)
+            if [ "${count:-1}" -eq 0 ]; then on='"ubuntu-latest"'; fi
           fi
           echo "on=$on" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,12 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    # Self-hosted runners (the always-on VPS + the Fedora box, both labelled
+    # taos-ci) run the slow suite in a few minutes instead of ~16 on GitHub's
+    # shared runners, and the two share the label so the 3.12/3.13 matrix runs
+    # in parallel with redundancy if one box is offline. lint + spa-build stay
+    # on ubuntu-latest as a free, always-available fallback.
+    runs-on: [self-hosted, linux, x64, taos-ci]
     # 45 min cap accommodates the cron run that includes 3.11 (~30 min);
     # 3.12/3.13 PR runs finish in ~16 min, so this only kicks in if 3.11
     # ever drifts further.


### PR DESCRIPTION
Routes the slow python `test` job to two self-hosted runners (always-on VPS + Fedora, both `taos-ci`): suite runs in a few min instead of ~16, 3.12/3.13 in parallel, redundant if one box is offline. lint + spa-build stay on ubuntu-latest. Self-validates: its own test job runs on the runners. VPS runner runs as an unprivileged `ghrunner` user (isolated from root/Coolify).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration infrastructure to improve test execution efficiency and reliability through optimized runner configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->