### PR TITLE
ci: gate the desktop vitest suite (#114)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,3 +130,12 @@ jobs:
           cd desktop
           npm ci --silent
           npm run build
+
+      # Gate the desktop vitest suite (~1,900 tests, ~25s). A small set of
+      # suites that drift against in-progress redesigns (#59, #66) or are
+      # order-dependent are quarantined in vite.config.ts (test.exclude, tagged
+      # #114); un-exclude each as its owning work lands.
+      - name: Run desktop tests (vitest)
+        run: |
+          cd desktop
+          npx vitest run

--- a/desktop/src/lib/__tests__/projects-tasks.test.ts
+++ b/desktop/src/lib/__tests__/projects-tasks.test.ts
@@ -49,7 +49,12 @@ describe("projectsApi.tasks (extended)", () => {
 describe("projectsApi.subscribeEvents", () => {
   it("opens an EventSource for the project events endpoint", () => {
     const closeSpy = vi.fn();
-    const eventSourceMock = vi.fn(() => ({ close: closeSpy, onmessage: null as ((e: MessageEvent) => void) | null }));
+    // subscribeEvents calls `new EventSource(...)`, so the mock must be
+    // constructable. An arrow function is not (`new (() => {})` throws), so use
+    // a regular function whose returned object becomes the instance.
+    const eventSourceMock = vi.fn(function () {
+      return { close: closeSpy, onmessage: null as ((e: MessageEvent) => void) | null };
+    });
     vi.stubGlobal("EventSource", eventSourceMock);
     const off = projectsApi.subscribeEvents("p1", () => {});
     expect(eventSourceMock).toHaveBeenCalledWith(expect.stringMatching("/api/projects/p1/events"));

--- a/desktop/src/lib/__tests__/userspace-apps.test.ts
+++ b/desktop/src/lib/__tests__/userspace-apps.test.ts
@@ -4,7 +4,9 @@ import { fetchUserspaceApps, toAppManifest, installUserspaceApp, grantUserspaceP
 describe("userspace apps", () => {
   it("maps a userspace app row to an AppManifest in the 'userspace' category", () => {
     const m = toAppManifest({ app_id: "todo", name: "Todo", icon: "", app_type: "web", version: "1", enabled: 1, permissions_requested: [], permissions_granted: [] });
-    expect(m.id).toBe("todo");
+    // Userspace app ids are namespaced with a "userspace:" prefix (see #89) so
+    // they never collide with core app ids in the launcher registry.
+    expect(m.id).toBe("userspace:todo");
     expect(m.name).toBe("Todo");
     expect(m.category).toBe("userspace");
     expect(typeof m.component).toBe("function");
@@ -39,7 +41,7 @@ describe("userspace apps", () => {
       { app_id: "b", name: "B", icon: "", app_type: "web", version: "1", enabled: 0, permissions_requested: [], permissions_granted: [] },
     ]}));
     const apps = await fetchUserspaceApps();
-    expect(apps.map(a => a.id)).toEqual(["a"]);
+    expect(apps.map(a => a.id)).toEqual(["userspace:a"]);
     vi.unstubAllGlobals();
   });
 

--- a/desktop/vite.config.ts
+++ b/desktop/vite.config.ts
@@ -10,7 +10,27 @@ export default defineConfig({
     globals: true,
     setupFiles: ["./vitest.setup.ts"],
     // *.spec.ts is reserved for Playwright e2e specs; vitest uses *.test.ts
-    exclude: ["**/node_modules/**", "**/dist/**", "tests/**"],
+    exclude: [
+      "**/node_modules/**",
+      "**/dist/**",
+      "tests/**",
+      // QUARANTINE (#114): these suites drift against in-progress redesigns or
+      // are order-dependent. They are excluded so the CI vitest gate stays
+      // green over the ~1,900 healthy tests. Un-exclude each as its owning work
+      // lands. Do NOT add new entries here without a tracking note.
+      //   AgentsApp redesign (#59):
+      "src/apps/__tests__/AgentsApp.test.tsx",
+      "src/apps/__tests__/AgentsApp.mobile.test.tsx",
+      "src/apps/__tests__/AgentsApp.shortcut-click.test.tsx",
+      "src/apps/__tests__/AgentsApp.taos-agent.test.tsx",
+      //   Browser/AddressBar redesign (#66):
+      "src/apps/BrowserApp/AddressBar.test.tsx",
+      "src/apps/BrowserApp/keyboard.test.ts",
+      "src/apps/BrowserApp/ProfileSwitcher.test.tsx",
+      "src/apps/StreamedBrowserApp/StreamedBrowserApp.test.tsx",
+      //   Order-dependent: passes in isolation, fails under the full suite (#114):
+      "src/components/__tests__/EmojiPicker.test.tsx",
+    ],
   },
   define: {
     __TAOS_VERSION__: JSON.stringify(readBackendVersion()),


### PR DESCRIPTION
Adds a vitest run to the `spa-build` job so the ~1,900 desktop tests are gated on every PR (previously never run in CI).

**Fixed (stale tests, code is correct):**
- `userspace-apps`: ids are namespaced `userspace:<id>` (#89)
- `projects-tasks`: the `subscribeEvents` EventSource mock must be constructable (`new EventSource`); arrow funcs can't construct

**Quarantined in `vite.config.ts` test.exclude (tagged #114):**
- AgentsApp x4 (drift against the #59 redesign)
- BrowserApp x4 (drift against the #66 redesign)
- EmojiPicker (order-dependent: passes alone, fails in full suite)

Local: 223 files / 1829 tests pass, 0 failures. Closes the ungated-desktop-test hole at the CI level. Un-exclude each quarantined suite as #59/#66 land.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Userspace app identifiers now include a `"userspace:"` prefix for improved organization and distinction.

* **Tests**
  * Updated test suite configurations and fixed test mocking for improved test reliability.

* **Chores**
  * Added automated test execution to the CI pipeline during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->