### PR TITLE
feat(perf): reduce-effects mode for low-end devices (#58)

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -136,6 +136,7 @@ export function App() {
   const wallpaperComponent = useThemeStore((s) => s.wallpaperComponent);
   const wallpaperOverlayText = useThemeStore((s) => s.wallpaperOverlayText);
   const showOverlayText = useThemeStore((s) => s.showOverlayText);
+  const reduceEffects = useThemeStore((s) => s.reduceEffects);
   const isAnimatedWallpaper = wallpaperKind === "animated";
   const useLightWallpaper = scheme === "light" && !!wallpaperLightImage;
   const effWallpaperImage = useLightWallpaper ? wallpaperLightImage : wallpaperImage;
@@ -202,6 +203,15 @@ export function App() {
     // again (switching back into taOS); re-composite them on return.
     installWebkitRepaintGuards();
   }, []);
+
+  // Apply reduce-effects / performance mode (#58) as a root attribute so the CSS
+  // in tokens.css can strip blur, big shadows and continuous animations on
+  // low-end devices. Reactive so the Settings toggle takes effect immediately.
+  useEffect(() => {
+    const root = document.documentElement;
+    if (reduceEffects) root.setAttribute("data-perf", "reduced");
+    else root.removeAttribute("data-perf");
+  }, [reduceEffects]);
 
   // Welcome notification — shown once per install, gated on a
   // localStorage flag so reload / refresh / re-mount don't replay it.

--- a/desktop/src/apps/SettingsApp.tsx
+++ b/desktop/src/apps/SettingsApp.tsx
@@ -23,6 +23,7 @@ import {
   Switch,
 } from "@/components/ui";
 import { useShortcuts } from "@/hooks/use-shortcut-registry";
+import { useThemeStore } from "@/stores/theme-store";
 import { ThemesPanel } from "@/apps/SettingsApp/ThemesPanel";
 import { safeFetch, ProgressBar, RestartProgressModal } from "@/apps/SettingsApp/_shared";
 import { UpdatesSection } from "@/apps/SettingsApp/UpdatesPanel";
@@ -549,6 +550,10 @@ function AccessibilitySection() {
   const [focusMode, setFocusMode] = useState(
     () => localStorage.getItem("taos-focus-mode") ?? "keyboard"
   );
+  // Reduce-effects / performance mode lives in the theme store (#58) so App.tsx
+  // applies the data-perf root attribute reactively. The toggle just flips it.
+  const reduceEffects = useThemeStore((s) => s.reduceEffects);
+  const setReduceEffects = useThemeStore((s) => s.setReduceEffects);
 
   const toggleReduceMotion = () => {
     const next = !reduceMotion;
@@ -594,6 +599,21 @@ function AccessibilitySection() {
             checked={reduceMotion}
             onCheckedChange={toggleReduceMotion}
             aria-label="Reduce motion"
+          />
+        </Card>
+
+        <Card className="p-4 flex items-center justify-between gap-3">
+          <div className="flex-1 min-w-0">
+            <Label htmlFor="reduce-effects" className="text-sm font-medium text-shell-text">
+              Reduce effects
+            </Label>
+            <p className="text-xs text-shell-text-tertiary mt-0.5">Turn off background blur and heavy shadows for smoother performance on older or low-powered devices</p>
+          </div>
+          <Switch
+            id="reduce-effects"
+            checked={reduceEffects}
+            onCheckedChange={setReduceEffects}
+            aria-label="Reduce effects"
           />
         </Card>
 

--- a/desktop/src/stores/__tests__/reduce-effects.test.ts
+++ b/desktop/src/stores/__tests__/reduce-effects.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useThemeStore } from "../theme-store";
+
+const KEY = "taos-reduce-effects";
+
+beforeEach(() => {
+  localStorage.removeItem(KEY);
+  useThemeStore.setState({ reduceEffects: false } as never);
+});
+
+describe("reduce-effects / performance mode (#58)", () => {
+  it("setReduceEffects(true) flips state and persists 'on'", () => {
+    useThemeStore.getState().setReduceEffects(true);
+    expect(useThemeStore.getState().reduceEffects).toBe(true);
+    expect(localStorage.getItem(KEY)).toBe("on");
+  });
+
+  it("setReduceEffects(false) clears state and persists 'off'", () => {
+    useThemeStore.getState().setReduceEffects(true);
+    useThemeStore.getState().setReduceEffects(false);
+    expect(useThemeStore.getState().reduceEffects).toBe(false);
+    expect(localStorage.getItem(KEY)).toBe("off");
+  });
+});

--- a/desktop/src/stores/theme-store.ts
+++ b/desktop/src/stores/theme-store.ts
@@ -168,6 +168,18 @@ function loadWallpaperParams(): WallpaperParams {
   return { ...DEFAULT_WALLPAPER_PARAMS };
 }
 
+// Reduce-effects / performance mode (#58): kills GPU-heavy compositing (backdrop
+// blur, big shadows, continuous animations) for low-end devices. Persisted; the
+// data-perf root attribute (applied in App.tsx) drives the CSS in tokens.css.
+const REDUCE_EFFECTS_KEY = "taos-reduce-effects";
+function loadReduceEffects(): boolean {
+  try {
+    return localStorage.getItem(REDUCE_EFFECTS_KEY) === "on";
+  } catch {
+    return false;
+  }
+}
+
 interface ThemeStore {
   wallpaperId: string;
   wallpaperImage: string;
@@ -185,6 +197,7 @@ interface ThemeStore {
   showOverlayText: boolean;
   wallpaperParams: WallpaperParams;
   showDesktopIcons: boolean;
+  reduceEffects: boolean;
   structure: Record<string, { variant?: string } & Record<string, unknown>>;
   effects: { module: string; params?: Record<string, unknown> }[];
 
@@ -200,6 +213,7 @@ interface ThemeStore {
   toggleOverlayText: () => void;
   setWallpaperParam: (key: keyof WallpaperParams, value: number) => void;
   toggleDesktopIcons: () => void;
+  setReduceEffects: (on: boolean) => void;
   getWallpapers: () => Wallpaper[];
 }
 
@@ -218,6 +232,7 @@ export const useThemeStore = create<ThemeStore>((set) => ({
   showOverlayText: loadSloganPref(),
   wallpaperParams: loadWallpaperParams(),
   showDesktopIcons: true,
+  reduceEffects: loadReduceEffects(),
   structure: {},
   effects: [],
 
@@ -264,6 +279,15 @@ export const useThemeStore = create<ThemeStore>((set) => ({
 
   toggleDesktopIcons() {
     set((s) => ({ showDesktopIcons: !s.showDesktopIcons }));
+  },
+
+  setReduceEffects(on) {
+    try {
+      localStorage.setItem(REDUCE_EFFECTS_KEY, on ? "on" : "off");
+    } catch {
+      // best-effort
+    }
+    set({ reduceEffects: on });
   },
 
   getWallpapers: () => WALLPAPERS,

--- a/desktop/src/theme/tokens.css
+++ b/desktop/src/theme/tokens.css
@@ -135,6 +135,37 @@
   backdrop-filter: none !important;
 }
 
+/* Reduce-effects / performance mode (#58)
+   =======================================
+   Toggled in Settings (and, later, auto-enabled on low-end GPUs). On weak
+   hardware the GPU-heavy compositing -- pervasive backdrop blur (~90 frosted
+   surfaces), large soft shadows, and continuous animations -- tanks the
+   framerate. data-perf="reduced" on :root strips those while leaving layout,
+   colour and contrast intact, so the desktop stays legible but cheap to paint. */
+:root[data-perf="reduced"] * {
+  -webkit-backdrop-filter: none !important;
+  backdrop-filter: none !important;
+}
+:root[data-perf="reduced"] {
+  /* Surfaces that leaned on the blur to be legible get an opaque glass bg. */
+  --color-shell-bg-glass: rgb(22, 22, 24);
+  /* Flatten the big, blur-radius-heavy shadows to cheap 1px ones. */
+  --shadow-window: 0 1px 2px rgba(0, 0, 0, 0.5);
+  --shadow-window-unfocused: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --shadow-dock: 0 1px 3px rgba(0, 0, 0, 0.4);
+  --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --shadow-card-hover: 0 1px 3px rgba(0, 0, 0, 0.4);
+}
+:root[data-scheme="light"][data-perf="reduced"] {
+  --color-shell-bg-glass: rgb(245, 245, 247);
+}
+/* Stop the continuously-running animations (the per-frame GPU drain). */
+:root[data-perf="reduced"] .taos-status-pulse,
+:root[data-perf="reduced"] .taos-shimmer,
+:root[data-perf="reduced"] .taos-card-enter {
+  animation: none !important;
+}
+
 /* Wallpaper sizing
    ----------------
    Desktop fills the viewport (cover crops edges if aspect mismatches).


### PR DESCRIPTION
Opt-in **Reduce effects** toggle (Settings -> Accessibility) for low-end hardware. A user on an older laptop (GTX 1060, Edge) reported UI lag; the cause is the pervasive backdrop blur (~90 frosted surfaces) + large soft shadows + continuous animations.

**How it works**
- `reduceEffects` flag in the theme store (persisted under `taos-reduce-effects`)
- App.tsx applies `data-perf="reduced"` on the document root, reactively
- tokens.css keys off that attribute to: kill `backdrop-filter` globally, opaque the shared glass bg (so blur-reliant surfaces stay legible), flatten the big shadow tokens to 1px, and stop the continuous animations (status pulse / shimmer / card-enter)

**Safety:** every rule is scoped to `[data-perf="reduced"]` and the attribute is only set when the toggle is on (default off), so the default desktop renders **identically** to before. Build green (tsc + vite); unit test covers the store persistence.

**Verification gap:** the control-API screenshot needs a live desktop session, which I don't have headlessly, so the ON-state appearance isn't pixel-verified here. The reporting user toggling it on is the live test; happy to screenshot on the Pi with a browser open if you want before merge.

**Fast-follow:** auto-enable on low-end GPUs via a client-side FPS probe on first run.