### PR TITLE
feat(install): prebuilt SPA bundle, no local build on install (#117)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,9 @@ jobs:
 
   spa-build:
     runs-on: ubuntu-latest
+    # Needs write access to manage the rolling 'bundle-latest' release below.
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
 
@@ -139,3 +142,27 @@ jobs:
         run: |
           cd desktop
           npx vitest run
+
+      # On master, publish the freshly-built SPA as a prebuilt bundle so the
+      # installer can download it instead of running the memory-heavy vite build
+      # locally (which OOMs on small machines like an 8GB WSL and used to leave
+      # installs silently stuck on the old UI). The bundle is keyed by the git
+      # tree SHA of desktop/, so it stays valid across every commit that doesn't
+      # touch the frontend. Rolling 'bundle-latest' prerelease, assets clobbered.
+      - name: Publish prebuilt desktop bundle
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tree=$(git rev-parse HEAD:desktop)
+          tar -C static -czf desktop-bundle.tar.gz desktop
+          printf '%s\n' "$tree" > desktop-tree.txt
+          notes="Auto-built SPA bundle for the latest master, matching desktop/ tree ${tree}. The installer downloads this when the tree matches, skipping the local vite build."
+          if gh release view bundle-latest >/dev/null 2>&1; then
+            gh release upload bundle-latest desktop-bundle.tar.gz desktop-tree.txt --clobber
+            gh release edit bundle-latest --notes "$notes"
+          else
+            gh release create bundle-latest --prerelease \
+              --title "Prebuilt desktop bundle (rolling)" --notes "$notes" \
+              desktop-bundle.tar.gz desktop-tree.txt
+          fi

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -1159,20 +1159,60 @@ ensure_litellm_postgres() {
 ensure_litellm_postgres
 
 # --- desktop SPA bundle --------------------------------------------------
-# Build the frontend unconditionally on every install / upgrade. The bundle
-# is not committed to git (static/desktop/ is gitignored) so this is the
-# only step that produces it. Skipping or making this conditional would
-# leave new installs with no UI. ~50s on a Pi; essentially free on a laptop.
+# The bundle is not committed to git (static/desktop/ is gitignored), so it has
+# to come from somewhere on every install / upgrade. Prefer a PREBUILT bundle
+# published by CI (keyed by the git tree SHA of desktop/, so it is valid for
+# every commit that does not touch the frontend) and download it -- this skips
+# the vite build, which needs ~2-4GB and OOMs on small machines (e.g. an 8GB
+# WSL), where a failed build used to leave the install silently stuck on the
+# old UI. Fall back to a local build only when no matching prebuilt is available.
 
-if command -v npm >/dev/null 2>&1; then
-    log "building desktop SPA (cd desktop && npm install && npm run build)"
-    (cd "$INSTALL_DIR/desktop" && npm install --silent && npm run build) \
-        || die "desktop SPA build failed — see output above"
-    log "desktop bundle built into static/desktop/"
-else
-    warn "npm not found on PATH — desktop UI bundle was not built"
-    warn "  install Node.js (>=22), then run: cd desktop && npm install && npm run build"
-    warn "  see: https://nodejs.org/en/download"
+_bundle_base="https://github.com/jaylfc/taOS/releases/download/bundle-latest"
+_desktop_tree="$(git -C "$INSTALL_DIR" rev-parse HEAD:desktop 2>/dev/null || echo "")"
+_prebuilt_done=0
+if [[ -n "$_desktop_tree" ]]; then
+    _remote_tree="$(curl -fsSL --max-time 20 "$_bundle_base/desktop-tree.txt" 2>/dev/null | tr -d '[:space:]')"
+    if [[ -n "$_remote_tree" && "$_remote_tree" == "$_desktop_tree" ]]; then
+        log "fetching prebuilt desktop bundle (matches source; no local build needed)"
+        rm -rf /tmp/taos-bundle-stage && mkdir -p /tmp/taos-bundle-stage
+        # Stage + verify in /tmp first, then swap, so a failed download/extract
+        # never leaves the install with no UI.
+        if curl -fsSL --max-time 120 "$_bundle_base/desktop-bundle.tar.gz" -o /tmp/taos-desktop-bundle.tar.gz \
+           && tar -C /tmp/taos-bundle-stage -xzf /tmp/taos-desktop-bundle.tar.gz \
+           && [[ -f /tmp/taos-bundle-stage/desktop/index.html ]]; then
+            rm -rf "$INSTALL_DIR/static/desktop"
+            mkdir -p "$INSTALL_DIR/static"
+            mv /tmp/taos-bundle-stage/desktop "$INSTALL_DIR/static/desktop"
+            # Match the repo owner so a later in-app rebuild (run as that user) can
+            # still write here; only meaningful when installing as root.
+            _own="$(stat -c '%U' "$INSTALL_DIR" 2>/dev/null || stat -f '%Su' "$INSTALL_DIR" 2>/dev/null || echo "")"
+            if [[ "$(id -u)" == "0" && -n "$_own" && "$_own" != "root" ]]; then
+                chown -R "$_own":"$_own" "$INSTALL_DIR/static/desktop" 2>/dev/null || true
+            fi
+            _prebuilt_done=1
+            log "prebuilt desktop bundle installed into static/desktop/"
+        else
+            warn "prebuilt bundle download/extract failed; falling back to a local build"
+        fi
+        rm -rf /tmp/taos-bundle-stage /tmp/taos-desktop-bundle.tar.gz
+    fi
+fi
+
+if [[ "$_prebuilt_done" == "0" ]]; then
+    if command -v npm >/dev/null 2>&1; then
+        log "building desktop SPA locally (no matching prebuilt bundle for this source)"
+        if ! (cd "$INSTALL_DIR/desktop" && npm install --silent && npm run build); then
+            die "desktop SPA build failed. This almost always means the machine ran out of memory: the vite build needs roughly 2-4GB free. On WSL the Linux VM is capped at about half of Windows RAM by default, so add to C:\\Users\\<you>\\.wslconfig:
+    [wsl2]
+    memory=12GB
+then run 'wsl --shutdown' in PowerShell, reopen, and re-run this installer. IMPORTANT: your UI was NOT updated -- the previous version keeps being served until the build succeeds."
+        fi
+        log "desktop bundle built into static/desktop/"
+    else
+        warn "npm not found on PATH -- desktop UI bundle was not built"
+        warn "  install Node.js (>=22), then re-run this installer"
+        warn "  see: https://nodejs.org/en/download"
+    fi
 fi
 
 # --- migrate: remove stale user-level qmd-serve.service (April 2026 rkllama unit) ---


### PR DESCRIPTION
Stops end users building the SPA locally on every install/upgrade, which was OOM-ing on small machines (8GB WSL) and silently leaving them on the old UI -- the 'ran the installer, still on an old version' report.

**Cause:** the bundle is gitignored and releases shipped no prebuilt asset, so install-server.sh ran `npm run build || die` on every run. The vite build needs ~2-4GB; on a memory-capped WSL it gets OOM-killed, and since the git source update happens *before* the build, a failed build leaves new source + the old bundle still served.

**Fix:**
- **CI** (`spa-build`, master pushes only) publishes the freshly-built `static/desktop` to a rolling `bundle-latest` prerelease, keyed by `git rev-parse HEAD:desktop` (the tree SHA of the frontend) so it's valid for every commit that doesn't touch `desktop/`.
- **install-server.sh** computes its own `HEAD:desktop` SHA, and if it matches the published one, downloads + stage-swaps the bundle (verified `index.html`, atomic-ish swap, owner-corrected) and skips the build. Local build is the fallback only, now failing **loudly** with the memory cause + the `.wslconfig memory=12GB` fix + a clear 'your UI was NOT updated'.

**Sequencing:** activates once on master -- the publish step is master-gated and the `curl | bash` installer is fetched from master. Until then installs local-build (with the loud failure). The PR's own CI exercises the SPA build; the publish step only runs post-merge on master.

**Fast-follow:** give the in-app update path (`desktop_rebuild.py`) the same prebuilt preference. Validated: YAML + `bash -n` clean; tree-SHA computes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Desktop UI now installs faster by using prebuilt bundles when available.

* **Improvements**
  * Enhanced installation process with bundle validation and integrity checks.
  * Expanded troubleshooting guidance for memory-related installation issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->