### PR TITLE
feat(update): in-app update prefers the prebuilt bundle (#117)

### DIFF
--- a/tests/test_desktop_rebuild.py
+++ b/tests/test_desktop_rebuild.py
@@ -153,25 +153,23 @@ async def test_rebuild_returns_true_on_npm_build_failure(tmp_path, monkeypatch):
     (src_dir / "App.tsx").write_text("// stale")
     (tmp_path / "desktop" / "package.json").write_text('{"name":"x"}')
 
-    call_count = [0]
-
-    class InstallProc:
-        returncode = 0
-
-        async def communicate(self):
-            return b"", b""
-
-    class BuildProc:
-        returncode = 1
+    class Proc:
+        def __init__(self, rc, err=b""):
+            self.returncode = rc
+            self._err = err
 
         async def communicate(self):
-            return b"", b"build error"
+            return b"", self._err
 
     async def fake_exec(*args, **kwargs):
-        call_count[0] += 1
-        if call_count[0] == 1:
-            return InstallProc()
-        return BuildProc()
+        # The prebuilt-bundle check probes `git rev-parse HEAD:desktop` first;
+        # return an empty SHA so it skips straight to the local npm build.
+        if args[0] == "git":
+            return Proc(0, b"")
+        # npm ci / npm install succeed; npm run build fails.
+        if args[0] == "npm" and args[1] == "run":
+            return Proc(1, b"build error")
+        return Proc(0)
 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
 
@@ -296,3 +294,75 @@ def test_lockfile_hash_none_without_file(tmp_path):
     d = tmp_path / "desktop"
     d.mkdir()
     assert _lockfile_hash(d) is None
+
+
+# ---------------------------------------------------------------------------
+# prebuilt bundle: download instead of building locally when the source matches
+# ---------------------------------------------------------------------------
+
+from tinyagentos.desktop_rebuild import _try_prebuilt_desktop_bundle
+
+
+def _git_proc(sha: str):
+    class GitProc:
+        returncode = 0
+
+        async def communicate(self):
+            return (sha + "\n").encode(), b""
+
+    async def fake_exec(*args, **kwargs):
+        return GitProc()
+
+    return fake_exec
+
+
+@pytest.mark.asyncio
+async def test_prebuilt_bundle_installed_on_tree_match(tmp_path, monkeypatch):
+    """Matching tree SHA -> bundle is downloaded + swapped into static/desktop/."""
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _git_proc("SHA123"))
+
+    import io
+    import tarfile
+
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        payload = b"<html>ok</html>"
+        info = tarfile.TarInfo("desktop/index.html")
+        info.size = len(payload)
+        tar.addfile(info, io.BytesIO(payload))
+    tarball = buf.getvalue()
+
+    async def fake_to_thread(_fn, url, **_kwargs):
+        return "SHA123" if url.endswith("desktop-tree.txt") else tarball
+
+    monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
+
+    assert await _try_prebuilt_desktop_bundle(tmp_path) is True
+    assert (tmp_path / "static" / "desktop" / "index.html").read_text() == "<html>ok</html>"
+
+
+@pytest.mark.asyncio
+async def test_prebuilt_bundle_skipped_on_tree_mismatch(tmp_path, monkeypatch):
+    """Mismatched tree SHA -> returns False and never downloads the bundle."""
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _git_proc("LOCAL"))
+
+    calls = []
+
+    async def fake_to_thread(_fn, url, **_kwargs):
+        calls.append(url)
+        return "REMOTE_DIFFERENT"
+
+    monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
+
+    assert await _try_prebuilt_desktop_bundle(tmp_path) is False
+    assert calls and all(c.endswith("desktop-tree.txt") for c in calls)
+
+
+@pytest.mark.asyncio
+async def test_prebuilt_bundle_skipped_when_git_missing(tmp_path, monkeypatch):
+    """No git on PATH -> returns False (falls back to a local build)."""
+    async def fake_exec(*args, **kwargs):
+        raise FileNotFoundError("git not found")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    assert await _try_prebuilt_desktop_bundle(tmp_path) is False

--- a/tinyagentos/desktop_rebuild.py
+++ b/tinyagentos/desktop_rebuild.py
@@ -95,6 +95,84 @@ def _record_deps_install(desktop_dir: Path) -> None:
         logger.warning("Could not write deps marker (%s) — next update reinstalls.", exc)
 
 
+_BUNDLE_BASE = "https://github.com/jaylfc/taOS/releases/download/bundle-latest"
+
+
+async def _try_prebuilt_desktop_bundle(project_root: Path) -> bool:
+    """Install the CI-published prebuilt SPA bundle when it matches this source.
+
+    The bundle is keyed by ``git rev-parse HEAD:desktop`` (the content hash of
+    the frontend tree), so it is valid for every commit that does not touch
+    desktop/. On a match we download + stage + swap it into static/desktop/ and
+    return True, letting the caller skip the memory-heavy vite build that OOMs
+    on small machines. Returns False -- fall back to a local build -- on any
+    mismatch, missing git, or network/extract failure. The artifact is our own
+    CI output, extracted with the path-safe ``data`` tar filter.
+    """
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "git", "-C", str(project_root), "rev-parse", "HEAD:desktop",
+            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.DEVNULL,
+        )
+        out, _ = await proc.communicate()
+    except FileNotFoundError:
+        return False  # git not on PATH
+    local_tree = out.decode(errors="replace").strip()
+    if proc.returncode != 0 or not local_tree:
+        return False
+
+    def _get(url: str, *, binary: bool):
+        import urllib.request
+        with urllib.request.urlopen(url, timeout=30) as resp:
+            data = resp.read()
+        return data if binary else data.decode(errors="replace").strip()
+
+    # Only download the (larger) bundle if the published tree matches ours.
+    try:
+        remote_tree = await asyncio.to_thread(_get, f"{_BUNDLE_BASE}/desktop-tree.txt", binary=False)
+    except Exception:
+        return False
+    if remote_tree != local_tree:
+        return False
+
+    logger.info("Downloading prebuilt desktop bundle (matches source; skipping local build).")
+    try:
+        blob = await asyncio.to_thread(_get, f"{_BUNDLE_BASE}/desktop-bundle.tar.gz", binary=True)
+    except Exception as exc:
+        logger.warning("Prebuilt bundle download failed (%s); building locally.", exc)
+        return False
+
+    import io
+    import shutil
+    import tarfile
+    import tempfile
+
+    stage = Path(tempfile.mkdtemp(prefix="taos-bundle-"))
+    try:
+        with tarfile.open(fileobj=io.BytesIO(blob), mode="r:gz") as tar:
+            try:
+                tar.extractall(stage, filter="data")  # py>=3.12 path-safe filter
+            except TypeError:
+                tar.extractall(stage)  # older python lacks the filter kwarg
+        staged = stage / "desktop"
+        if not (staged / "index.html").is_file():
+            logger.warning("Prebuilt bundle missing index.html; building locally.")
+            return False
+        static_dir = project_root / "static"
+        static_dir.mkdir(parents=True, exist_ok=True)
+        target = static_dir / "desktop"
+        if target.exists():
+            shutil.rmtree(target)
+        shutil.move(str(staged), str(target))
+        logger.info("Prebuilt desktop bundle installed into static/desktop/.")
+        return True
+    except Exception as exc:
+        logger.warning("Prebuilt bundle install failed (%s); building locally.", exc)
+        return False
+    finally:
+        shutil.rmtree(stage, ignore_errors=True)
+
+
 async def rebuild_desktop_bundle_if_stale(
     project_root: Path,
     *,
@@ -131,6 +209,16 @@ async def rebuild_desktop_bundle_if_stale(
         )
 
     logger.info("Desktop source is ahead of bundle — rebuilding...")
+
+    # Prefer the CI-published prebuilt bundle (keyed to this desktop/ source by
+    # its git tree SHA) so low-RAM hosts skip the memory-heavy vite build. Falls
+    # through to the local build below on any miss.
+    if await _try_prebuilt_desktop_bundle(project_root):
+        return RebuildResult(
+            rebuilt=True,
+            success=True,
+            message="Installed prebuilt desktop bundle (no local build needed).",
+        )
 
     try:
         if _deps_install_needed(desktop_dir):


### PR DESCRIPTION
Follow-up to #1204: the in-app / auto-update path (`desktop_rebuild.py`) still built the SPA locally, so it would OOM on the same low-RAM machines the install script now spares.

Mirrors the install-server.sh logic: before the local `npm run build`, try the CI-published prebuilt bundle (keyed by `git rev-parse HEAD:desktop`), download + stage + swap into `static/desktop/`, skipping npm on a match. Stdlib only (urllib + tarfile via `asyncio.to_thread`), tar extracted with the path-safe `data` filter, atomic-ish swap. Falls back to the local build on any mismatch / missing git / network failure.

Tests: 3 new (match installs bundle; mismatch never downloads it; no-git falls back) + reworked the build-failure test to dispatch by args. 21 pass locally.

With this on dev, the dev->master promotion carries the complete fix: both install paths stop building locally.