### PR TITLE
ci: cancel superseded runs per ref (stop runner-pool pileup)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,16 @@ on:
     # each release is a self-contained packaged download (see spa-build below).
     types: [published]
 
+# Cancel superseded runs of the same ref so a rapid series of pushes to a PR
+# branch does not stack up and starve the small self-hosted runner pool (this
+# bit us once: three superseded runs queued behind each other on two runners).
+# A PR push event carries ref refs/pull/<n>/merge, so successive pushes to the
+# same PR share a group and the older run is cancelled. master/dev are excluded
+# from cancellation: every promotion's CI (and its bundle publish) must finish.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.ref != 'refs/heads/dev' }}
+
 jobs:
   # Route the matrix to the self-hosted POOL (VPS + Fedora, both labelled
   # taos-ci) rather than pinning it to one box. The two boxes are ~tied per


### PR DESCRIPTION
Adds a `concurrency` block to ci.yml so successive pushes to the same PR cancel the older in-progress run instead of stacking up on the two self-hosted runners.

Context: promoting #1216 stalled because three superseded runs of the branch queued behind each other on the VPS+Fedora pool (no auto-cancel), compounded by a Fedora reboot and a VPS runner stuck busy on an orphaned worker. This is the durable prevention.

- group: `ci-${{ github.workflow }}-${{ github.ref }}` (a PR push carries ref refs/pull/<n>/merge, so same-PR pushes share a group)
- cancel-in-progress only for non-protected refs, so master/dev CI and the desktop-bundle publish always finish

Follow-up to the #1216 CI incident (task #119).