### PR TITLE
feat(coding-studio): agent build loop + diff review (slice 1)

### DIFF
--- a/desktop/src/apps/codingstudio/BuildView.tsx
+++ b/desktop/src/apps/codingstudio/BuildView.tsx
@@ -650,7 +650,7 @@ Keep responses concise and practical.`;
               </div>
             )}
 
-            {steps.map((step, idx) => (
+            {steps.map((step) => (
               <div
                 key={streaming ? "stream-output" : step.id}
                 className="rounded-[12px] border border-shell-border bg-shell-surface px-4 py-3"

--- a/desktop/src/apps/codingstudio/BuildView.tsx
+++ b/desktop/src/apps/codingstudio/BuildView.tsx
@@ -487,6 +487,16 @@ Keep responses concise and practical.`;
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ paths: [path] }),
       });
+      if (res.status === 207) {
+        const data = await res.json();
+        const failed: string[] = data.failed ?? [];
+        if (failed.length > 0) {
+          setBuildError(`Revert failed for: ${failed.join(", ")}`);
+        } else {
+          setDiffEntries((prev) => prev.filter((e) => e.path !== path));
+        }
+        return;
+      }
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       setDiffEntries((prev) => prev.filter((e) => e.path !== path));
     } catch (err) {
@@ -529,6 +539,16 @@ Keep responses concise and practical.`;
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ paths }),
       });
+      if (res.status === 207) {
+        const data = await res.json();
+        const failed: string[] = data.failed ?? [];
+        const reverted: string[] = data.reverted ?? [];
+        setDiffEntries((prev) => prev.filter((e) => !reverted.includes(e.path)));
+        if (failed.length > 0) {
+          setBuildError(`Revert failed for: ${failed.join(", ")}`);
+        }
+        return;
+      }
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       setDiffEntries([]);
     } catch (err) {
@@ -630,9 +650,9 @@ Keep responses concise and practical.`;
               </div>
             )}
 
-            {steps.map((step) => (
+            {steps.map((step, idx) => (
               <div
-                key={step.id}
+                key={streaming ? "stream-output" : step.id}
                 className="rounded-[12px] border border-shell-border bg-shell-surface px-4 py-3"
               >
                 <pre className="whitespace-pre-wrap break-words text-[12px] leading-relaxed text-shell-text-secondary">

--- a/desktop/src/apps/codingstudio/BuildView.tsx
+++ b/desktop/src/apps/codingstudio/BuildView.tsx
@@ -1,384 +1,741 @@
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   Sparkles,
-  Folder,
-  FileText,
-  ClipboardCheck,
-  Check,
-  Circle,
+  Loader2,
+  AlertCircle,
+  CheckCircle2,
+  XCircle,
+  Plus,
   ChevronDown,
-  Play,
+  ChevronRight,
+  Check,
+  X,
+  GitBranch,
 } from "lucide-react";
+import { streamTaosAgentChat } from "../appstudio/stream-chat";
 
-const CODE_LINES = [
-  {
-    n: 1,
-    jsx: (
-      <>
-        <span style={{ color: "#8e9cd6" }}>import</span>
-        {" { useTodos } "}
-        <span style={{ color: "#8e9cd6" }}>from</span>
-        {" "}
-        <span style={{ color: "#8fb89a" }}>{"'./useTodos'"}</span>
-      </>
-    ),
-  },
-  {
-    n: 2,
-    jsx: (
-      <>
-        <span style={{ color: "#8e9cd6" }}>import</span>
-        {" { TodoList } "}
-        <span style={{ color: "#8e9cd6" }}>from</span>
-        {" "}
-        <span style={{ color: "#8fb89a" }}>{"'./TodoList'"}</span>
-      </>
-    ),
-  },
-  {
-    n: 3,
-    jsx: (
-      <span style={{ color: "rgba(255,255,255,0.32)" }}>
-        {"// added by taOS - persists to localStorage"}
-      </span>
-    ),
-  },
-  { n: 4, jsx: <></> },
-  {
-    n: 5,
-    jsx: (
-      <>
-        <span style={{ color: "#8e9cd6" }}>export default function</span>
-        {" "}
-        <span style={{ color: "#9fb0d2" }}>App</span>
-        {"() {"}
-      </>
-    ),
-  },
-  {
-    n: 6,
-    jsx: (
-      <>
-        {"  "}
-        <span style={{ color: "#8e9cd6" }}>const</span>
-        {" { todos, add, toggle, remaining } = "}
-        <span style={{ color: "#9fb0d2" }}>useTodos</span>
-        {"()"}
-      </>
-    ),
-  },
-  {
-    n: 7,
-    jsx: (
-      <>
-        {"  "}
-        <span style={{ color: "#8e9cd6" }}>return</span>
-        {" ("}
-      </>
-    ),
-  },
-  {
-    n: 8,
-    jsx: (
-      <>
-        {"    <"}
-        <span style={{ color: "#cf9a93" }}>main</span>
-        {" "}
-        <span style={{ color: "#9fb0d2" }}>className</span>
-        {"="}
-        <span style={{ color: "#8fb89a" }}>"app"</span>
-        {">"}
-      </>
-    ),
-  },
-  {
-    n: 9,
-    jsx: (
-      <>
-        {"      <"}
-        <span style={{ color: "#cf9a93" }}>header</span>
-        {">My Tasks <"}
-        <span style={{ color: "#cf9a93" }}>small</span>
-        {">{remaining} left</"}
-        <span style={{ color: "#cf9a93" }}>small</span>
-        {"></"}
-        <span style={{ color: "#cf9a93" }}>header</span>
-        {">"}
-      </>
-    ),
-  },
-  {
-    n: 10,
-    jsx: (
-      <>
-        {"      <"}
-        <span style={{ color: "#cf9a93" }}>TodoList</span>
-        {" "}
-        <span style={{ color: "#9fb0d2" }}>items</span>
-        {"={todos} "}
-        <span style={{ color: "#9fb0d2" }}>onToggle</span>
-        {"={toggle} />"}
-      </>
-    ),
-  },
-  {
-    n: 11,
-    jsx: (
-      <>
-        {"      <"}
-        <span style={{ color: "#cf9a93" }}>AddTodo</span>
-        {" "}
-        <span style={{ color: "#9fb0d2" }}>onAdd</span>
-        {"={add} />"}
-      </>
-    ),
-  },
-  {
-    n: 12,
-    jsx: (
-      <>
-        {"    </"}
-        <span style={{ color: "#cf9a93" }}>main</span>
-        {">"}
-      </>
-    ),
-  },
-  { n: 13, jsx: <>{"  )"}</> },
-  { n: 14, jsx: <>{"}"}</> },
-];
+/* ------------------------------------------------------------------ */
+/*  Types                                                               */
+/* ------------------------------------------------------------------ */
 
-const BUILD_STEPS = [
-  { status: "done" as const, title: "Scaffold Vite + React + TS", meta: "7 files - 1.4s" },
-  { status: "done" as const, title: "Write TodoList + AddTodo", meta: "components/ - 2 files" },
-  { status: "running" as const, title: "Add useTodos hook", meta: "wiring localStorage persistence..." },
-  { status: "queued" as const, title: "Install dependencies", meta: "npm i - queued" },
-  { status: "queued" as const, title: "Start dev server + preview", meta: "queued" },
-];
+interface Workspace {
+  id: string;
+  name: string;
+  path: string;
+  created_at: string;
+}
 
-function StepIcon({ status }: { status: "done" | "running" | "queued" }) {
-  if (status === "done") {
-    return (
-      <div className="flex h-5 w-5 flex-none items-center justify-center rounded-full bg-green-500/15 text-green-400">
-        <Check size={12} strokeWidth={3} />
-      </div>
-    );
-  }
-  if (status === "running") {
-    return (
-      <div className="flex h-5 w-5 flex-none items-center justify-center rounded-full bg-amber-500/15 text-amber-400">
-        <div className="h-3 w-3 animate-spin rounded-full border-2 border-amber-400 border-r-transparent" />
-      </div>
-    );
-  }
+interface DiffEntry {
+  path: string;
+  status: "added" | "modified" | "deleted";
+  patch: string;
+}
+
+type StepKind = "info" | "error" | "done";
+
+interface BuildStep {
+  id: number;
+  kind: StepKind;
+  text: string;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Workspace selector (mirrors CodeView pattern)                       */
+/* ------------------------------------------------------------------ */
+
+function WorkspaceSelector({
+  workspaces,
+  loading,
+  error,
+  value,
+  onChange,
+  onNew,
+}: {
+  workspaces: Workspace[];
+  loading: boolean;
+  error: string | null;
+  value: Workspace | null;
+  onChange: (ws: Workspace | null) => void;
+  onNew: () => void;
+}) {
   return (
-    <div className="flex h-5 w-5 flex-none items-center justify-center rounded-full bg-shell-surface-active text-shell-text-tertiary">
-      <Circle size={12} />
+    <div className="flex items-center gap-2">
+      {loading ? (
+        <span className="text-[12px] text-shell-text-tertiary">Loading...</span>
+      ) : (
+        <>
+          {error && (
+            <span className="flex items-center gap-1 text-[12px] text-red-400">
+              <AlertCircle size={13} />
+              {error}
+            </span>
+          )}
+          <select
+            aria-label="Select workspace"
+            value={value?.id ?? ""}
+            onChange={(e) => {
+              const ws = workspaces.find((w) => w.id === e.target.value) ?? null;
+              onChange(ws);
+            }}
+            className="h-[28px] rounded-[9px] border border-shell-border bg-shell-surface px-2 text-[12px] text-shell-text focus:outline-none focus:ring-1 focus:ring-accent/40"
+          >
+            <option value="">-- select workspace --</option>
+            {workspaces.map((ws) => (
+              <option key={ws.id} value={ws.id}>
+                {ws.name}
+              </option>
+            ))}
+          </select>
+        </>
+      )}
+      <button
+        type="button"
+        onClick={onNew}
+        aria-label="New workspace"
+        className="flex h-[28px] items-center gap-1.5 rounded-[9px] border border-shell-border bg-shell-surface px-2.5 text-[12px] text-shell-text-secondary hover:bg-shell-surface-active focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent/40"
+      >
+        <Plus size={13} />
+        New workspace
+      </button>
     </div>
   );
 }
 
-export function BuildView() {
-  return (
-    <>
-      <style>{`@keyframes blink{50%{opacity:0}}`}</style>
+/* ------------------------------------------------------------------ */
+/*  Diff patch display (read-only, styled +/- lines)                    */
+/* ------------------------------------------------------------------ */
 
+function PatchView({ patch }: { patch: string }) {
+  const lines = patch.split("\n");
+  return (
+    <div
+      className="overflow-auto rounded-[10px] bg-shell-bg-deep p-2 font-mono text-[11px] leading-[1.65]"
+      style={{ maxHeight: 220 }}
+    >
+      {lines.map((line, i) => {
+        let cls = "text-shell-text-secondary";
+        if (line.startsWith("+") && !line.startsWith("+++")) cls = "text-green-400";
+        if (line.startsWith("-") && !line.startsWith("---")) cls = "text-red-400";
+        if (line.startsWith("@@")) cls = "text-blue-400";
+        return (
+          <div key={i} className={cls}>
+            {line || " "}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Diff review panel                                                   */
+/* ------------------------------------------------------------------ */
+
+function DiffReview({
+  entries,
+  accepting,
+  reverting,
+  onAccept,
+  onRevert,
+  onAcceptAll,
+  onRevertAll,
+}: {
+  entries: DiffEntry[];
+  accepting: Set<string>;
+  reverting: Set<string>;
+  onAccept: (path: string) => void;
+  onRevert: (path: string) => void;
+  onAcceptAll: () => void;
+  onRevertAll: () => void;
+}) {
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
+
+  const toggle = (path: string) =>
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      return next;
+    });
+
+  if (entries.length === 0) {
+    return (
+      <div className="flex items-center gap-2 rounded-[12px] border border-shell-border bg-shell-surface px-4 py-3 text-[12px] text-shell-text-tertiary">
+        <CheckCircle2 size={15} className="text-green-400" />
+        No uncommitted changes
+      </div>
+    );
+  }
+
+  const statusColor = (s: DiffEntry["status"]) => {
+    if (s === "added") return "text-green-400";
+    if (s === "deleted") return "text-red-400";
+    return "text-amber-400";
+  };
+
+  const statusLabel = (s: DiffEntry["status"]) => {
+    if (s === "added") return "A";
+    if (s === "deleted") return "D";
+    return "M";
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-2">
+        <span className="text-[12px] font-semibold text-shell-text">
+          {entries.length} changed file{entries.length !== 1 ? "s" : ""}
+        </span>
+        <div className="ml-auto flex gap-2">
+          <button
+            type="button"
+            onClick={onRevertAll}
+            aria-label="Reject all changes"
+            className="flex h-[26px] items-center gap-1.5 rounded-[8px] border border-red-500/30 bg-red-500/10 px-2.5 text-[11px] font-semibold text-red-300 hover:bg-red-500/20 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-red-400/40"
+          >
+            <X size={12} />
+            Reject all
+          </button>
+          <button
+            type="button"
+            onClick={onAcceptAll}
+            aria-label="Accept all changes"
+            className="flex h-[26px] items-center gap-1.5 rounded-[8px] border border-green-500/30 bg-green-500/10 px-2.5 text-[11px] font-semibold text-green-300 hover:bg-green-500/20 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-green-400/40"
+          >
+            <Check size={12} />
+            Accept all
+          </button>
+        </div>
+      </div>
+
+      {entries.map((entry) => {
+        const open = expanded.has(entry.path);
+        const busy = accepting.has(entry.path) || reverting.has(entry.path);
+        return (
+          <div
+            key={entry.path}
+            className="rounded-[12px] border border-shell-border bg-shell-surface"
+          >
+            <div className="flex items-center gap-2 px-3 py-2.5">
+              <button
+                type="button"
+                onClick={() => toggle(entry.path)}
+                aria-label={open ? "Collapse diff" : "Expand diff"}
+                className="flex flex-none items-center text-shell-text-tertiary"
+              >
+                {open ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+              </button>
+              <span className={`w-4 flex-none text-center text-[11px] font-bold ${statusColor(entry.status)}`}>
+                {statusLabel(entry.status)}
+              </span>
+              <span className="min-w-0 flex-1 truncate font-mono text-[12px] text-shell-text">
+                {entry.path}
+              </span>
+              <div className="flex flex-none gap-1.5">
+                <button
+                  type="button"
+                  onClick={() => onRevert(entry.path)}
+                  disabled={busy}
+                  aria-label={`Reject changes to ${entry.path}`}
+                  className="flex h-[24px] items-center gap-1 rounded-[7px] border border-red-500/30 bg-red-500/10 px-2 text-[10.5px] font-semibold text-red-300 hover:bg-red-500/20 disabled:opacity-40 focus-visible:outline-none"
+                >
+                  {reverting.has(entry.path) ? (
+                    <Loader2 size={11} className="animate-spin" />
+                  ) : (
+                    <XCircle size={11} />
+                  )}
+                  Reject
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onAccept(entry.path)}
+                  disabled={busy}
+                  aria-label={`Accept changes to ${entry.path}`}
+                  className="flex h-[24px] items-center gap-1 rounded-[7px] border border-green-500/30 bg-green-500/10 px-2 text-[10.5px] font-semibold text-green-300 hover:bg-green-500/20 disabled:opacity-40 focus-visible:outline-none"
+                >
+                  {accepting.has(entry.path) ? (
+                    <Loader2 size={11} className="animate-spin" />
+                  ) : (
+                    <CheckCircle2 size={11} />
+                  )}
+                  Accept
+                </button>
+              </div>
+            </div>
+            {open && entry.patch && (
+              <div className="border-t border-shell-border px-3 pb-3 pt-2">
+                <PatchView patch={entry.patch} />
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  BuildView                                                            */
+/* ------------------------------------------------------------------ */
+
+let _stepId = 0;
+const nextId = () => ++_stepId;
+
+export function BuildView() {
+  // Workspaces
+  const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
+  const [wsLoading, setWsLoading] = useState(true);
+  const [wsError, setWsError] = useState<string | null>(null);
+  const [activeWs, setActiveWs] = useState<Workspace | null>(null);
+
+  // Build
+  const [prompt, setPrompt] = useState("");
+  const [streaming, setStreaming] = useState(false);
+  const [model, setModel] = useState<string | null>(null);
+  const [steps, setSteps] = useState<BuildStep[]>([]);
+  const [buildError, setBuildError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+  const mountedRef = useRef(true);
+  const logEndRef = useRef<HTMLDivElement>(null);
+
+  // Diff review
+  const [diffEntries, setDiffEntries] = useState<DiffEntry[]>([]);
+  const [diffLoading, setDiffLoading] = useState(false);
+  const [accepting, setAccepting] = useState<Set<string>>(new Set());
+  const [reverting, setReverting] = useState<Set<string>>(new Set());
+  const [tab, setTab] = useState<"chat" | "diff">("chat");
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      abortRef.current?.abort();
+    };
+  }, []);
+
+  // Load workspaces
+  const loadWorkspaces = useCallback(async () => {
+    setWsLoading(true);
+    setWsError(null);
+    try {
+      const res = await fetch("/api/coding/workspaces");
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data: Workspace[] = await res.json();
+      setWorkspaces(data);
+    } catch (err) {
+      setWsError(err instanceof Error ? err.message : "Failed to load workspaces");
+    } finally {
+      setWsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void loadWorkspaces(); }, [loadWorkspaces]);
+
+  // Load agent model
+  useEffect(() => {
+    fetch("/api/taos-agent/settings")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => { if (data?.model !== undefined) setModel(data.model); })
+      .catch(() => {});
+  }, []);
+
+  // Scroll log to bottom as steps arrive
+  useEffect(() => {
+    if (!streaming) return;
+    logEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [steps, streaming]);
+
+  // Create workspace
+  const createWorkspace = useCallback(async () => {
+    const name = window.prompt("Workspace name:");
+    if (!name?.trim()) return;
+    try {
+      const res = await fetch("/api/coding/workspaces", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: name.trim() }),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const ws: Workspace = await res.json();
+      setWorkspaces((prev) => [...prev, ws]);
+      setActiveWs(ws);
+    } catch (err) {
+      setWsError(err instanceof Error ? err.message : "Failed to create workspace");
+    }
+  }, []);
+
+  // Fetch diff from backend
+  const fetchDiff = useCallback(async (wsId: string) => {
+    setDiffLoading(true);
+    try {
+      const res = await fetch(`/api/coding/workspaces/${wsId}/diff`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data: DiffEntry[] = await res.json();
+      setDiffEntries(data);
+    } catch {
+      setDiffEntries([]);
+    } finally {
+      setDiffLoading(false);
+    }
+  }, []);
+
+  // Handle build submit
+  const handleBuild = useCallback(async () => {
+    if (streaming || !model || !activeWs) return;
+    const text = prompt.trim();
+    if (!text) return;
+
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setSteps([]);
+    setBuildError(null);
+    setStreaming(true);
+    setTab("chat");
+
+    // The agent cannot directly edit arbitrary workspace files via its tool
+    // (it would need a filesystem MCP or shell tool scoped to the workspace path).
+    // Instead, we give the agent the workspace path context and ask it to emit
+    // file contents as fenced code blocks. The user can then paste them via
+    // the Code view. This is documented in the PR as the current limitation.
+    // See: agent-scoping note in PR body.
+    const systemContext = `You are a coding assistant for taOS Coding Studio.
+The user has selected workspace: "${activeWs.name}" (id: ${activeWs.id}).
+Workspace path on the server is managed by taOS. You cannot write files directly.
+Respond with clear, actionable steps and code. Use fenced code blocks with filenames.
+Keep responses concise and practical.`;
+
+    const userMessage = `${systemContext}\n\nUser request: ${text}`;
+
+    const outputChunks: string[] = [];
+
+    try {
+      await streamTaosAgentChat(
+        [{ role: "user", content: userMessage }],
+        (delta) => {
+          if (!mountedRef.current) return;
+          outputChunks.push(delta);
+          const full = outputChunks.join("");
+          // Emit full response as rolling steps (paragraph chunks)
+          setSteps([
+            { id: nextId(), kind: "info", text: full },
+          ]);
+        },
+        (message) => {
+          if (!mountedRef.current) return;
+          setBuildError(message);
+        },
+        { signal: controller.signal },
+      );
+    } catch (e) {
+      if (!(e instanceof DOMException && e.name === "AbortError") && mountedRef.current) {
+        setBuildError(String(e));
+      }
+    } finally {
+      if (abortRef.current === controller) abortRef.current = null;
+      if (mountedRef.current) {
+        setStreaming(false);
+        // After build completes, auto-refresh diff
+        void fetchDiff(activeWs.id);
+        setTab("diff");
+      }
+    }
+  }, [prompt, streaming, model, activeWs, fetchDiff]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+        e.preventDefault();
+        void handleBuild();
+      }
+    },
+    [handleBuild],
+  );
+
+  // Switch to diff tab and refresh
+  const openDiff = useCallback(() => {
+    setTab("diff");
+    if (activeWs) void fetchDiff(activeWs.id);
+  }, [activeWs, fetchDiff]);
+
+  // Accept a single file's changes
+  const acceptFile = useCallback(async (path: string) => {
+    if (!activeWs) return;
+    setAccepting((prev) => new Set([...prev, path]));
+    try {
+      const res = await fetch(`/api/coding/workspaces/${activeWs.id}/accept`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ paths: [path] }),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setDiffEntries((prev) => prev.filter((e) => e.path !== path));
+    } catch (err) {
+      setBuildError(err instanceof Error ? err.message : "Accept failed");
+    } finally {
+      setAccepting((prev) => { const n = new Set(prev); n.delete(path); return n; });
+    }
+  }, [activeWs]);
+
+  // Revert a single file's changes
+  const revertFile = useCallback(async (path: string) => {
+    if (!activeWs) return;
+    setReverting((prev) => new Set([...prev, path]));
+    try {
+      const res = await fetch(`/api/coding/workspaces/${activeWs.id}/revert`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ paths: [path] }),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setDiffEntries((prev) => prev.filter((e) => e.path !== path));
+    } catch (err) {
+      setBuildError(err instanceof Error ? err.message : "Revert failed");
+    } finally {
+      setReverting((prev) => { const n = new Set(prev); n.delete(path); return n; });
+    }
+  }, [activeWs]);
+
+  // Accept all
+  const acceptAll = useCallback(async () => {
+    if (!activeWs || diffEntries.length === 0) return;
+    const paths = diffEntries.map((e) => e.path);
+    const allSet = new Set(paths);
+    setAccepting(allSet);
+    try {
+      const res = await fetch(`/api/coding/workspaces/${activeWs.id}/accept`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ paths }),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setDiffEntries([]);
+    } catch (err) {
+      setBuildError(err instanceof Error ? err.message : "Accept all failed");
+    } finally {
+      setAccepting(new Set());
+    }
+  }, [activeWs, diffEntries]);
+
+  // Revert all
+  const revertAll = useCallback(async () => {
+    if (!activeWs || diffEntries.length === 0) return;
+    const paths = diffEntries.map((e) => e.path);
+    const allSet = new Set(paths);
+    setReverting(allSet);
+    try {
+      const res = await fetch(`/api/coding/workspaces/${activeWs.id}/revert`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ paths }),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setDiffEntries([]);
+    } catch (err) {
+      setBuildError(err instanceof Error ? err.message : "Revert all failed");
+    } finally {
+      setReverting(new Set());
+    }
+  }, [activeWs, diffEntries]);
+
+  const noModel = !model;
+  const noWorkspace = !activeWs;
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
       {/* view header */}
       <div
         className="flex flex-none items-center gap-3 border-b border-shell-border px-[22px]"
         style={{ height: "54px" }}
       >
         <h2 className="text-[17px] font-bold tracking-[-0.02em]">Build</h2>
-        <span className="text-[12px] text-shell-text-tertiary">
-          todo-app - Node + React - runs on fedora-gpu
-        </span>
+
+        <WorkspaceSelector
+          workspaces={workspaces}
+          loading={wsLoading}
+          error={wsError}
+          value={activeWs}
+          onChange={setActiveWs}
+          onNew={createWorkspace}
+        />
+
         <div className="ml-auto flex rounded-full border border-shell-border bg-shell-surface p-[3px]">
-          <span className="cursor-pointer rounded-full bg-shell-surface-active px-[13px] py-[5px] text-[11px] font-semibold text-shell-text">
+          <button
+            type="button"
+            aria-pressed={tab === "chat"}
+            onClick={() => setTab("chat")}
+            className={`rounded-full px-[13px] py-[5px] text-[11px] font-semibold transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent/40 ${
+              tab === "chat"
+                ? "bg-shell-surface-active text-shell-text"
+                : "text-shell-text-secondary hover:text-shell-text"
+            }`}
+          >
             Chat
-          </span>
-          <span className="cursor-pointer px-[13px] py-[5px] text-[11px] font-semibold text-shell-text-secondary">
+          </button>
+          <button
+            type="button"
+            aria-pressed={tab === "diff"}
+            onClick={openDiff}
+            className={`relative rounded-full px-[13px] py-[5px] text-[11px] font-semibold transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent/40 ${
+              tab === "diff"
+                ? "bg-shell-surface-active text-shell-text"
+                : "text-shell-text-secondary hover:text-shell-text"
+            }`}
+          >
             Diff
-          </span>
+            {diffEntries.length > 0 && (
+              <span className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full bg-accent text-[9px] font-bold text-white">
+                {diffEntries.length}
+              </span>
+            )}
+          </button>
         </div>
       </div>
 
-      {/* three-column body */}
-      <div className="flex min-h-0 flex-1">
-        {/* column 1: file tree */}
-        <div className="w-[190px] flex-none overflow-auto border-r border-shell-border bg-shell-bg-deep px-2 py-2.5">
-          <div className="px-2 pb-2 pt-1 text-[10.5px] font-bold uppercase tracking-[0.06em] text-shell-text-tertiary">
-            todo-app
-          </div>
+      {/* main area */}
+      <div className="flex min-h-0 flex-1 flex-col overflow-auto px-[22px] py-5">
+        {tab === "chat" ? (
+          <div className="flex min-h-0 flex-1 flex-col gap-3">
+            {/* no workspace banner */}
+            {noWorkspace && (
+              <div className="rounded-[12px] border border-shell-border bg-shell-surface px-4 py-3 text-[12px] text-shell-text-tertiary">
+                Select or create a workspace above to get started.
+              </div>
+            )}
 
-          {/* src folder */}
-          <div className="flex cursor-pointer items-center gap-1.5 rounded-lg px-2 py-[5px] text-[12.5px] text-shell-text-secondary hover:bg-shell-surface">
-            <Folder size={13} className="flex-none text-shell-text-tertiary" />
-            src
-          </div>
+            {/* no model banner */}
+            {!noWorkspace && noModel && (
+              <div className="rounded-[12px] border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-[12px] text-amber-300">
+                No model selected. Go to taOS Assistant settings to pick a model.
+              </div>
+            )}
 
-          {/* App.tsx - active */}
-          <div className="flex cursor-pointer items-center gap-1.5 rounded-lg bg-shell-surface-active px-2 py-[5px] pl-5 text-[12.5px] text-shell-text hover:bg-shell-surface-active">
-            <FileText size={13} className="flex-none text-shell-text-tertiary" />
-            App.tsx
-            <div className="ml-auto h-1.5 w-1.5 flex-none rounded-full bg-amber-400" />
-          </div>
-
-          <div className="flex cursor-pointer items-center gap-1.5 rounded-lg px-2 py-[5px] pl-5 text-[12.5px] text-shell-text-secondary hover:bg-shell-surface">
-            <FileText size={13} className="flex-none text-shell-text-tertiary" />
-            TodoList.tsx
-          </div>
-
-          <div className="flex cursor-pointer items-center gap-1.5 rounded-lg px-2 py-[5px] pl-5 text-[12.5px] text-shell-text-secondary hover:bg-shell-surface">
-            <FileText size={13} className="flex-none text-shell-text-tertiary" />
-            useTodos.ts
-          </div>
-
-          <div className="flex cursor-pointer items-center gap-1.5 rounded-lg px-2 py-[5px] pl-5 text-[12.5px] text-shell-text-secondary hover:bg-shell-surface">
-            <FileText size={13} className="flex-none text-shell-text-tertiary" />
-            styles.css
-          </div>
-
-          {/* root files */}
-          <div className="flex cursor-pointer items-center gap-1.5 rounded-lg px-2 py-[5px] text-[12.5px] text-shell-text-secondary hover:bg-shell-surface">
-            <FileText size={13} className="flex-none text-shell-text-tertiary" />
-            index.html
-          </div>
-
-          <div className="flex cursor-pointer items-center gap-1.5 rounded-lg px-2 py-[5px] text-[12.5px] text-shell-text-secondary hover:bg-shell-surface">
-            <FileText size={13} className="flex-none text-shell-text-tertiary" />
-            package.json
-          </div>
-
-          <div className="flex cursor-pointer items-center gap-1.5 rounded-lg px-2 py-[5px] text-[12.5px] text-shell-text-secondary hover:bg-shell-surface">
-            <FileText size={13} className="flex-none text-shell-text-tertiary" />
-            vite.config.ts
-          </div>
-        </div>
-
-        {/* column 2: editor */}
-        <div className="flex min-w-0 flex-1 flex-col">
-          {/* tabs bar */}
-          <div className="flex h-[38px] flex-none items-stretch border-b border-shell-border bg-shell-bg-deep">
-            <div className="flex cursor-pointer items-center gap-2 border-r border-shell-border bg-shell-bg px-4 text-[12px] text-shell-text shadow-[inset_0_-2px_0_0_var(--color-accent,#8b92a3)]">
-              App.tsx
-              <span className="text-[13px] opacity-50">x</span>
-            </div>
-            <div className="flex cursor-pointer items-center gap-2 bg-transparent px-4 text-[12px] text-shell-text-tertiary">
-              useTodos.ts
-              <span className="text-[13px] opacity-50">x</span>
-            </div>
-          </div>
-
-          {/* code area */}
-          <div className="flex-1 overflow-auto py-3.5 font-mono text-[12.5px] leading-[1.62]">
-            {CODE_LINES.map(({ n, jsx }) => (
+            {/* error */}
+            {buildError && (
               <div
-                key={n}
-                className={`flex px-0${n === 10 ? " bg-shell-surface" : ""}`}
+                className="rounded-[12px] border border-red-500/30 bg-red-500/10 px-4 py-3 text-[12px] text-red-300"
+                role="alert"
               >
-                <span className="w-[46px] flex-none select-none pr-4 text-right text-shell-text-tertiary opacity-60">
-                  {n}
-                </span>
-                <span className="whitespace-pre text-shell-text">
-                  {jsx}
-                  {n === 10 && (
+                {buildError}
+              </div>
+            )}
+
+            {/* steps / output */}
+            {steps.length === 0 && !streaming && !buildError && (
+              <div className="flex flex-1 items-center justify-center">
+                <p className="max-w-[320px] text-center text-[12.5px] leading-relaxed text-shell-text-tertiary">
+                  Describe what you want to build. The agent will respond with a plan and code.
+                  When it edits files, switch to the Diff tab to review and accept or reject changes.
+                </p>
+              </div>
+            )}
+
+            {steps.map((step) => (
+              <div
+                key={step.id}
+                className="rounded-[12px] border border-shell-border bg-shell-surface px-4 py-3"
+              >
+                <pre className="whitespace-pre-wrap break-words text-[12px] leading-relaxed text-shell-text-secondary">
+                  {step.text}
+                  {streaming && (
                     <span
                       aria-hidden
-                      className="inline-block w-[2px] h-[15px] bg-accent align-[-3px]"
-                      style={{ animation: "blink 1s steps(1) infinite" }}
+                      className="ml-0.5 inline-block h-3.5 w-0.5 animate-pulse bg-accent align-[-1px]"
                     />
                   )}
+                </pre>
+              </div>
+            ))}
+
+            {streaming && steps.length === 0 && (
+              <div className="flex items-center gap-2 text-[12px] text-shell-text-tertiary">
+                <Loader2 size={14} className="animate-spin" />
+                Thinking...
+              </div>
+            )}
+
+            <div ref={logEndRef} />
+          </div>
+        ) : (
+          <div className="flex min-h-0 flex-1 flex-col gap-3">
+            <div className="flex items-center gap-2">
+              <GitBranch size={15} className="text-accent" />
+              <span className="text-[13px] font-semibold">Diff review</span>
+              {activeWs && (
+                <span className="text-[12px] text-shell-text-tertiary">
+                  {activeWs.name}
                 </span>
+              )}
+              {activeWs && (
+                <button
+                  type="button"
+                  onClick={() => void fetchDiff(activeWs.id)}
+                  disabled={diffLoading}
+                  aria-label="Refresh diff"
+                  className="ml-auto flex h-[26px] items-center gap-1.5 rounded-[8px] border border-shell-border bg-shell-surface px-2.5 text-[11px] text-shell-text-secondary hover:bg-shell-surface-active disabled:opacity-50 focus-visible:outline-none"
+                >
+                  {diffLoading ? (
+                    <Loader2 size={11} className="animate-spin" />
+                  ) : (
+                    "Refresh"
+                  )}
+                </button>
+              )}
+            </div>
+
+            {!activeWs ? (
+              <div className="rounded-[12px] border border-shell-border bg-shell-surface px-4 py-3 text-[12px] text-shell-text-tertiary">
+                Select a workspace to view its diff.
               </div>
-            ))}
-          </div>
-
-          {/* terminal strip */}
-          <div className="h-[96px] flex-none overflow-auto border-t border-shell-border bg-shell-bg-deep px-4 py-2.5 font-mono">
-            <div className="text-[11.5px] leading-[1.7]">
-              <span className="text-accent">~/todo-app</span>
-              {" $ npm run dev"}
-            </div>
-            <div className="text-[11.5px] leading-[1.7]">
-              <span className="text-green-400">VITE v5.4</span>
-              {" ready in 412 ms"}
-            </div>
-            <div className="text-[11.5px] leading-[1.7]">
-              {"> Local: "}
-              <span className="text-blue-400">http://todo-app.taos.local</span>
-              {" "}
-              <span className="text-green-400">live</span>
-            </div>
-          </div>
-        </div>
-
-        {/* column 3: build log */}
-        <div className="flex w-[296px] flex-none flex-col border-l border-shell-border">
-          {/* header */}
-          <div className="flex items-center gap-2 px-[18px] pb-2.5 pt-4 text-[13px] font-bold tracking-[-0.01em]">
-            <ClipboardCheck size={16} className="text-accent" />
-            Build log
-          </div>
-
-          {/* steps */}
-          <div className="flex flex-1 flex-col gap-0.5 overflow-auto px-3.5 pb-3.5 pt-0.5">
-            {BUILD_STEPS.map((step) => (
-              <div
-                key={step.title}
-                className="flex gap-[11px] rounded-[11px] px-2.5 py-[9px] hover:bg-shell-surface"
-              >
-                <StepIcon status={step.status} />
-                <div>
-                  <div className="text-[12.5px] font-semibold text-shell-text">{step.title}</div>
-                  <div className="mt-0.5 text-[11px] leading-[1.4] text-shell-text-tertiary">
-                    {step.meta}
-                  </div>
-                </div>
+            ) : diffLoading ? (
+              <div className="flex items-center gap-2 text-[12px] text-shell-text-tertiary">
+                <Loader2 size={13} className="animate-spin" />
+                Loading diff...
               </div>
-            ))}
-          </div>
-
-          {/* footer */}
-          <div className="flex flex-none flex-col gap-3 border-t border-shell-border p-3.5">
-            {/* model pill */}
-            <div className="flex cursor-pointer items-center gap-2.5 rounded-[13px] border border-shell-border bg-shell-surface px-3 py-2.5">
-              <div
-                className="h-[26px] w-[26px] flex-none rounded-[8px]"
-                style={{ background: "linear-gradient(135deg,#7c8ba1,#aab4c9)" }}
+            ) : (
+              <DiffReview
+                entries={diffEntries}
+                accepting={accepting}
+                reverting={reverting}
+                onAccept={acceptFile}
+                onRevert={revertFile}
+                onAcceptAll={acceptAll}
+                onRevertAll={revertAll}
               />
-              <div>
-                <div className="text-[12.5px] font-semibold">Qwen2.5-Coder 7B</div>
-                <div className="text-[10.5px] text-shell-text-tertiary">local - fedora-gpu</div>
-              </div>
-              <ChevronDown size={14} className="ml-auto text-shell-text-tertiary" />
-            </div>
-
-            {/* open preview button */}
-            <div className="flex h-[42px] cursor-pointer items-center justify-center gap-2 rounded-[13px] border border-shell-border bg-shell-surface text-[12.5px] font-semibold hover:bg-shell-surface-active">
-              <Play size={15} />
-              Open live preview
-            </div>
+            )}
           </div>
-        </div>
+        )}
       </div>
 
       {/* prompt bar */}
       <div className="flex flex-none items-end gap-3 border-t border-shell-border bg-shell-bg-deep px-[22px] py-4">
         <textarea
-          rows={1}
-          placeholder="Describe a feature or paste an error..."
-          className="min-h-[50px] flex-1 resize-none rounded-[15px] border border-shell-border bg-shell-surface px-4 py-3.5 text-[13.5px] text-shell-text-tertiary placeholder:text-shell-text-tertiary focus:outline-none focus:ring-1 focus:ring-accent/40"
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          onKeyDown={handleKeyDown}
+          rows={2}
+          disabled={streaming}
+          placeholder={
+            noWorkspace
+              ? "Select a workspace first..."
+              : "Describe what you want to build or change... (Cmd+Enter to send)"
+          }
+          className="min-h-[50px] flex-1 resize-none rounded-[15px] border border-shell-border bg-shell-surface px-4 py-3 text-[13.5px] text-shell-text-secondary placeholder:text-shell-text-tertiary focus-visible:border-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/20 disabled:opacity-60"
         />
         <button
           type="button"
-          className="flex h-[50px] flex-none cursor-pointer items-center gap-2 rounded-[15px] border-0 px-6 text-[14px] font-bold text-white"
+          onClick={() => void handleBuild()}
+          disabled={streaming || !prompt.trim() || noModel || noWorkspace}
+          aria-label="Run build"
+          className="flex h-[50px] flex-none items-center gap-[9px] rounded-[15px] border-none px-6 text-[14px] font-bold text-white disabled:cursor-not-allowed disabled:opacity-50"
           style={{
-            background: "linear-gradient(135deg,#a9b0c2,#8b92a3)",
-            boxShadow: "0 8px 22px -8px rgba(139,146,163,0.35)",
+            background: "linear-gradient(135deg,var(--color-accent),var(--color-accent))",
           }}
         >
-          <Sparkles size={18} />
-          Build
+          {streaming ? <Loader2 size={18} className="animate-spin" /> : <Sparkles size={18} />}
+          {streaming ? "Building..." : "Build"}
         </button>
       </div>
-    </>
+    </div>
   );
 }

--- a/tests/test_coding_diff.py
+++ b/tests/test_coding_diff.py
@@ -1,0 +1,219 @@
+"""Tests for coding workspace diff / accept / revert endpoints."""
+
+import pytest
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture
+async def ws(app, client):
+    """Create a fresh workspace and return (client, workspace_id, workspace_dir)."""
+    store = app.state.coding_workspaces
+    if store._db is not None:
+        await store.close()
+    await store.init()
+
+    r = await client.post("/api/coding/workspaces", json={"name": "diff-test"})
+    assert r.status_code == 200, r.text
+    data = r.json()
+    ws_id = data["id"]
+    ws_dir = app.state.data_dir / "coding-workspaces" / ws_id
+    yield client, ws_id, ws_dir
+
+
+# ---------------------------------------------------------------------------
+# diff
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_diff_empty_workspace(ws):
+    client, ws_id, _ = ws
+    r = await client.get(f"/api/coding/workspaces/{ws_id}/diff")
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+@pytest.mark.asyncio
+async def test_diff_shows_untracked_file(ws):
+    client, ws_id, ws_dir = ws
+    (ws_dir / "hello.py").write_text("print('hello')\n")
+
+    r = await client.get(f"/api/coding/workspaces/{ws_id}/diff")
+    assert r.status_code == 200
+    entries = r.json()
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["path"] == "hello.py"
+    assert entry["status"] == "added"
+    assert "+print('hello')" in entry["patch"]
+
+
+@pytest.mark.asyncio
+async def test_diff_shows_modified_tracked_file(ws):
+    client, ws_id, ws_dir = ws
+    # Write + commit initial version
+    await client.put(
+        f"/api/coding/workspaces/{ws_id}/file",
+        json={"path": "app.py", "content": "x = 1\n"},
+    )
+    import asyncio
+    proc = await asyncio.create_subprocess_exec(
+        "git", "add", ".", cwd=str(ws_dir),
+        stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL
+    )
+    await proc.wait()
+    proc = await asyncio.create_subprocess_exec(
+        "git", "-c", "user.email=test@test.com", "-c", "user.name=test",
+        "commit", "-m", "initial",
+        cwd=str(ws_dir),
+        stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL
+    )
+    await proc.wait()
+
+    # Modify
+    (ws_dir / "app.py").write_text("x = 2\n")
+
+    r = await client.get(f"/api/coding/workspaces/{ws_id}/diff")
+    assert r.status_code == 200
+    entries = {e["path"]: e for e in r.json()}
+    assert "app.py" in entries
+    assert entries["app.py"]["status"] == "modified"
+    patch = entries["app.py"]["patch"]
+    assert "-x = 1" in patch
+    assert "+x = 2" in patch
+
+
+@pytest.mark.asyncio
+async def test_diff_unknown_workspace_returns_404(ws):
+    client, _ws_id, _ = ws
+    r = await client.get("/api/coding/workspaces/cws-notreal/diff")
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# accept
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_accept_commits_untracked_file(ws):
+    client, ws_id, ws_dir = ws
+    import asyncio
+
+    # Need a git identity for the commit
+    proc = await asyncio.create_subprocess_exec(
+        "git", "-c", "user.email=t@t.com", "-c", "user.name=t",
+        "config", "user.email", "t@t.com",
+        cwd=str(ws_dir), stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL
+    )
+    await proc.wait()
+    proc = await asyncio.create_subprocess_exec(
+        "git", "config", "user.name", "tester",
+        cwd=str(ws_dir), stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL
+    )
+    await proc.wait()
+
+    (ws_dir / "main.py").write_text("print('hi')\n")
+
+    r = await client.post(
+        f"/api/coding/workspaces/{ws_id}/accept",
+        json={"paths": ["main.py"]},
+    )
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert data["ok"] is True
+    assert "main.py" in data["committed"]
+
+    # Diff should now be empty (file committed)
+    r = await client.get(f"/api/coding/workspaces/{ws_id}/diff")
+    paths = [e["path"] for e in r.json()]
+    assert "main.py" not in paths
+
+
+@pytest.mark.asyncio
+async def test_accept_invalid_path_rejected(ws):
+    client, ws_id, _ = ws
+    r = await client.post(
+        f"/api/coding/workspaces/{ws_id}/accept",
+        json={"paths": ["../escape.py"]},
+    )
+    assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_accept_empty_paths_rejected(ws):
+    client, ws_id, _ = ws
+    r = await client.post(
+        f"/api/coding/workspaces/{ws_id}/accept",
+        json={"paths": []},
+    )
+    assert r.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# revert
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_revert_deletes_untracked_file(ws):
+    client, ws_id, ws_dir = ws
+    (ws_dir / "temp.py").write_text("# temp\n")
+    assert (ws_dir / "temp.py").exists()
+
+    r = await client.post(
+        f"/api/coding/workspaces/{ws_id}/revert",
+        json={"paths": ["temp.py"]},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["ok"] is True
+    assert not (ws_dir / "temp.py").exists()
+
+
+@pytest.mark.asyncio
+async def test_revert_restores_tracked_file(ws):
+    client, ws_id, ws_dir = ws
+    import asyncio
+
+    await client.put(
+        f"/api/coding/workspaces/{ws_id}/file",
+        json={"path": "src.py", "content": "original\n"},
+    )
+    for cmd in [
+        ["git", "add", "."],
+        ["git", "-c", "user.email=t@t.com", "-c", "user.name=t", "commit", "-m", "base"],
+    ]:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd, cwd=str(ws_dir),
+            stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL
+        )
+        await proc.wait()
+
+    # Corrupt the file
+    (ws_dir / "src.py").write_text("corrupted\n")
+    assert (ws_dir / "src.py").read_text() == "corrupted\n"
+
+    r = await client.post(
+        f"/api/coding/workspaces/{ws_id}/revert",
+        json={"paths": ["src.py"]},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["ok"] is True
+    assert (ws_dir / "src.py").read_text() == "original\n"
+
+
+@pytest.mark.asyncio
+async def test_revert_invalid_path_rejected(ws):
+    client, ws_id, _ = ws
+    r = await client.post(
+        f"/api/coding/workspaces/{ws_id}/revert",
+        json={"paths": ["/etc/passwd"]},
+    )
+    assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_revert_unknown_workspace_returns_404(ws):
+    client, _ws_id, _ = ws
+    r = await client.post(
+        "/api/coding/workspaces/cws-notreal/revert",
+        json={"paths": ["x.py"]},
+    )
+    assert r.status_code == 404

--- a/tinyagentos/routes/coding.py
+++ b/tinyagentos/routes/coding.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 from pathlib import Path
 
@@ -18,6 +19,31 @@ class CreateWorkspaceBody(BaseModel):
 class WriteFileBody(BaseModel):
     path: str
     content: str
+
+
+class PathsBody(BaseModel):
+    paths: list[str]
+
+
+# ---------------------------------------------------------------------------
+# Git helpers
+# ---------------------------------------------------------------------------
+
+async def _git(cwd: Path, *args: str) -> tuple[int, str, str]:
+    """Run a git command in *cwd*; return (returncode, stdout, stderr)."""
+    proc = await asyncio.create_subprocess_exec(
+        "git",
+        *args,
+        cwd=str(cwd),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    out, err = await proc.communicate()
+    return (
+        proc.returncode or 0,
+        out.decode("utf-8", "replace"),
+        err.decode("utf-8", "replace"),
+    )
 
 
 def _invalid_rel_path(rel: str) -> bool:
@@ -133,3 +159,189 @@ async def delete_workspace(request: Request, workspace_id: str):
     if not removed:
         return JSONResponse({"error": "workspace not found"}, status_code=404)
     return {"ok": True}
+
+
+# ---------------------------------------------------------------------------
+# Diff / accept / revert
+# ---------------------------------------------------------------------------
+
+@router.get("/api/coding/workspaces/{workspace_id}/diff")
+async def workspace_diff(request: Request, workspace_id: str):
+    """Return uncommitted changes as a list of {path, status, patch} objects.
+
+    status is one of: added | modified | deleted
+    patch is unified diff text (empty string for deleted files with no tracked content).
+    """
+    root, err = await _workspace_root(request, workspace_id)
+    if err is not None:
+        return err
+
+    # Collect status of every changed entry (tracked + untracked)
+    rc, out, _e = await _git(root, "status", "--porcelain")
+    if rc != 0:
+        return JSONResponse({"error": "git status failed"}, status_code=500)
+
+    entries: list[dict] = []
+    for line in out.splitlines():
+        if len(line) < 4:
+            continue
+        xy = line[:2]
+        rel_path = line[3:].strip()
+        # Handle renames: "R old -> new" (porcelain v1 uses " -> " separator)
+        if " -> " in rel_path:
+            rel_path = rel_path.split(" -> ", 1)[1]
+
+        x, y = xy[0], xy[1]
+        untracked = xy == "??"
+
+        if untracked:
+            file_status = "added"
+        elif x == "D" or y == "D":
+            file_status = "deleted"
+        elif x == "A" or y == "A":
+            file_status = "added"
+        else:
+            file_status = "modified"
+
+        # Jail the path
+        target = _resolve_jailed(root, rel_path)
+        if target is None:
+            continue
+
+        if untracked:
+            # Diff against empty (show full content as +lines)
+            if target.is_file():
+                try:
+                    content = target.read_text(encoding="utf-8", errors="replace")
+                except OSError:
+                    content = ""
+                lines = content.splitlines(keepends=True)
+                patch_lines = [f"+{l}" for l in lines]
+                patch = (
+                    f"--- /dev/null\n+++ b/{rel_path}\n@@ -0,0 +1,{len(lines)} @@\n"
+                    + "".join(patch_lines)
+                )
+            else:
+                patch = ""
+        elif file_status == "deleted":
+            rc2, patch, _ = await _git(root, "diff", "HEAD", "--", rel_path)
+            if rc2 != 0:
+                patch = ""
+        else:
+            rc2, patch, _ = await _git(root, "diff", "HEAD", "--", rel_path)
+            if rc2 != 0:
+                # May be staged but not yet committed (new index entry)
+                rc2, patch, _ = await _git(root, "diff", "--cached", "--", rel_path)
+            if rc2 != 0:
+                patch = ""
+
+        entries.append({"path": rel_path, "status": file_status, "patch": patch})
+
+    return entries
+
+
+@router.post("/api/coding/workspaces/{workspace_id}/accept")
+async def accept_changes(request: Request, workspace_id: str, body: PathsBody):
+    """Stage and commit the given paths (accept the agent's edits)."""
+    root, err = await _workspace_root(request, workspace_id)
+    if err is not None:
+        return err
+
+    safe_paths: list[str] = []
+    for p in body.paths:
+        target = _resolve_jailed(root, p)
+        if target is None:
+            return JSONResponse({"error": f"invalid path: {p}"}, status_code=400)
+        safe_paths.append(p)
+
+    if not safe_paths:
+        return JSONResponse({"error": "no paths provided"}, status_code=400)
+
+    rc, _o, se = await _git(root, "add", "--", *safe_paths)
+    if rc != 0:
+        logger.warning("git add failed: %s", se)
+        return JSONResponse({"error": "git add failed", "detail": se}, status_code=500)
+
+    rc, _o, se = await _git(
+        root, "commit", "-m", f"agent: accept changes to {len(safe_paths)} file(s)",
+        "--allow-empty"
+    )
+    if rc != 0:
+        logger.warning("git commit failed: %s", se)
+        return JSONResponse({"error": "git commit failed", "detail": se}, status_code=500)
+
+    return {"ok": True, "committed": safe_paths}
+
+
+@router.post("/api/coding/workspaces/{workspace_id}/revert")
+async def revert_changes(request: Request, workspace_id: str, body: PathsBody):
+    """Discard changes to the given paths (reject the agent's edits)."""
+    root, err = await _workspace_root(request, workspace_id)
+    if err is not None:
+        return err
+
+    safe_paths: list[str] = []
+    for p in body.paths:
+        target = _resolve_jailed(root, p)
+        if target is None:
+            return JSONResponse({"error": f"invalid path: {p}"}, status_code=400)
+        safe_paths.append(p)
+
+    if not safe_paths:
+        return JSONResponse({"error": "no paths provided"}, status_code=400)
+
+    reverted: list[str] = []
+    errors: list[str] = []
+
+    # Determine status for each path to decide how to discard
+    rc, status_out, _ = await _git(root, "status", "--porcelain", "--", *safe_paths)
+
+    untracked: set[str] = set()
+    tracked: list[str] = []
+
+    for line in status_out.splitlines():
+        if len(line) < 4:
+            continue
+        xy = line[:2]
+        path = line[3:].strip()
+        if " -> " in path:
+            path = path.split(" -> ", 1)[1]
+        if xy == "??":
+            untracked.add(path)
+        else:
+            tracked.append(path)
+
+    # Tracked: restore via git checkout
+    if tracked:
+        rc, _o, se = await _git(root, "checkout", "--", *tracked)
+        if rc != 0:
+            # Try unstaging first (staged new file), then checkout
+            await _git(root, "reset", "HEAD", "--", *tracked)
+            rc2, _o, se2 = await _git(root, "checkout", "--", *tracked)
+            if rc2 != 0:
+                errors.extend(tracked)
+                logger.warning("git checkout failed for %s: %s", tracked, se2)
+            else:
+                reverted.extend(tracked)
+        else:
+            reverted.extend(tracked)
+
+    # Untracked: delete
+    for p in safe_paths:
+        if p in untracked:
+            target = _resolve_jailed(root, p)
+            if target and target.exists():
+                try:
+                    target.unlink()
+                    reverted.append(p)
+                except OSError as exc:
+                    errors.append(p)
+                    logger.warning("unlink failed for %s: %s", p, exc)
+
+    if errors:
+        return JSONResponse(
+            {"ok": False, "reverted": reverted, "failed": errors},
+            status_code=207,
+        )
+
+    return {"ok": True, "reverted": reverted}

--- a/tinyagentos/routes/coding.py
+++ b/tinyagentos/routes/coding.py
@@ -176,21 +176,31 @@ async def workspace_diff(request: Request, workspace_id: str):
     if err is not None:
         return err
 
-    # Collect status of every changed entry (tracked + untracked)
-    rc, out, _e = await _git(root, "status", "--porcelain")
+    # Collect status of every changed entry (tracked + untracked).
+    # Use -z for NUL-separated output so filenames with spaces/quotes are safe.
+    rc, out, _e = await _git(root, "status", "--porcelain=v1", "-z")
     if rc != 0:
         return JSONResponse({"error": "git status failed"}, status_code=500)
 
     entries: list[dict] = []
-    for line in out.splitlines():
-        if len(line) < 4:
+    # -z output: entries are "<XY> <path>\0"; renames are "<XY> <new>\0<old>\0".
+    raw_tokens = out.split("\0")
+    status_entries: list[tuple[str, str]] = []
+    i = 0
+    while i < len(raw_tokens):
+        token = raw_tokens[i]
+        if len(token) < 4:
+            i += 1
             continue
-        xy = line[:2]
-        rel_path = line[3:].strip()
-        # Handle renames: "R old -> new" (porcelain v1 uses " -> " separator)
-        if " -> " in rel_path:
-            rel_path = rel_path.split(" -> ", 1)[1]
+        xy = token[:2]
+        rel_path = token[3:]
+        if xy[0] in ("R", "C"):
+            i += 2  # skip old-path token
+        else:
+            i += 1
+        status_entries.append((xy, rel_path))
 
+    for xy, rel_path in status_entries:
         x, y = xy[0], xy[1]
         untracked = xy == "??"
 
@@ -262,9 +272,21 @@ async def accept_changes(request: Request, workspace_id: str, body: PathsBody):
         logger.warning("git add failed: %s", se)
         return JSONResponse({"error": "git add failed", "detail": se}, status_code=500)
 
+    # Check if anything was actually staged before committing.
+    rc_st, st_out, _ = await _git(root, "status", "--porcelain=v1", "-z")
+    staged = any(
+        len(t) >= 4 and t[0] not in (" ", "?")
+        for t in st_out.split("\0")
+    )
+    if not staged:
+        return {"ok": True, "committed": [], "note": "nothing to commit"}
+
     rc, _o, se = await _git(
-        root, "commit", "-m", f"agent: accept changes to {len(safe_paths)} file(s)",
-        "--allow-empty"
+        root,
+        "-c", "user.name=taOS",
+        "-c", "user.email=taos@localhost",
+        "commit",
+        "-m", f"agent: accept changes to {len(safe_paths)} file(s)",
     )
     if rc != 0:
         logger.warning("git commit failed: %s", se)
@@ -294,18 +316,24 @@ async def revert_changes(request: Request, workspace_id: str, body: PathsBody):
     errors: list[str] = []
 
     # Determine status for each path to decide how to discard
-    rc, status_out, _ = await _git(root, "status", "--porcelain", "--", *safe_paths)
+    rc, status_out, _ = await _git(root, "status", "--porcelain=v1", "-z", "--", *safe_paths)
 
     untracked: set[str] = set()
     tracked: list[str] = []
 
-    for line in status_out.splitlines():
-        if len(line) < 4:
+    raw_tokens = status_out.split("\0")
+    i = 0
+    while i < len(raw_tokens):
+        token = raw_tokens[i]
+        if len(token) < 4:
+            i += 1
             continue
-        xy = line[:2]
-        path = line[3:].strip()
-        if " -> " in path:
-            path = path.split(" -> ", 1)[1]
+        xy = token[:2]
+        path = token[3:]
+        if xy[0] in ("R", "C"):
+            i += 2
+        else:
+            i += 1
         if xy == "??":
             untracked.add(path)
         else:


### PR DESCRIPTION
## Summary

- **Real BuildView**: replaces the hardcoded mock with a live workspace selector (reuses CodeView's pattern), a prompt bar wired to `streamTaosAgentChat`, and a streaming step log.
- **Diff review tab**: after every build run the UI automatically switches to a Diff tab showing all uncommitted changes in the workspace. Each file shows status badge (A/M/D), expandable unified diff with +/- line colouring, and per-file Accept / Reject buttons. Accept all / Reject all also available.
- **Backend diff/accept/revert**: three new endpoints on `/api/coding/workspaces/{id}/diff|accept|revert` using git under the hood. All paths jail-checked via the existing `_resolve_jailed` helper. Accept stages + commits; Revert uses `git checkout --` for tracked files and `unlink` for untracked.
- **Tests**: 11 new backend tests (`tests/test_coding_diff.py`); combined coding test count 21/21 green. `tsc --noEmit` clean. 6 CodingStudio frontend Vitest tests passing.

## Agent-scoping approach

`streamTaosAgentChat` POSTs to `/api/taos-agent/chat` which drives the taOS agent (same as AppStudio). The agent has no filesystem MCP tool scoped to the coding workspace, so it cannot write files directly. The current approach: workspace name + id are injected into the user message as context; the agent responds with code in fenced blocks; the user pastes them via the Code view. This is the v1 limitation.

**What is stubbed / needs live verification:**
- Direct agent-to-file writes (agent cannot write to an arbitrary workspace path via the current `/api/taos-agent/chat` endpoint; a future slice would add a workspace-scoped file-write tool or MCP)
- Diff is populated by any manual file writes via the Code view or future tool calls; the full round-trip (agent edits file -> diff appears -> accept commits) works end-to-end when files are written via `/api/coding/workspaces/{id}/file`

## Test results

```
Backend (uv run pytest test_coding_workspaces.py test_coding_diff.py -q):
21 passed in 8.32s

Frontend (npx vitest run CodingStudioApp.test.tsx):
Test Files  1 passed (1)
Tests  6 passed (6)

TypeScript:
tsc --noEmit  [no output = no errors]
```

## Closes

Part of #86 (slice 1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Coding studio build view now fully functional with workspace management
  * Added real-time chat streaming for build interactions
  * Implemented diff review system with accept and revert capabilities for file changes
  * Added tab-based navigation between chat and diff views with automatic diff refresh after builds

* **Tests**
  * Comprehensive test coverage for diff, accept, and revert operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->