### PR TITLE
tsk-dfmzqd  [OPEN]  Userspace manifest: support app_type 'tui' (CLI co

### DIFF
--- a/tests/userspace/test_package.py
+++ b/tests/userspace/test_package.py
@@ -112,3 +112,57 @@ def test_network_permission_origins_validated():
     assert _NET_ORIGIN_RE.match("wss://irc-ws.chat.twitch.tv")
     assert not _NET_ORIGIN_RE.match("wss://evil.com\n")
     assert not _NET_ORIGIN_RE.match("wss://evil.com\n; script-src 'unsafe-inline'")
+
+
+def test_parse_valid_tui_manifest():
+    m = parse_manifest(
+        "id: mycli\nname: MyCLI\nversion: 1.0.0\napp_type: tui\ncommand: opencode\n"
+    )
+    assert m["id"] == "mycli"
+    assert m["app_type"] == "tui"
+    assert m["command"] == "opencode"
+    assert m["args"] == []
+    assert m["needs_project_dir"] is True
+    assert m["env"] == {}
+
+
+def test_parse_tui_manifest_with_optional_fields():
+    m = parse_manifest(
+        "id: mycli\nname: MyCLI\nversion: 1.0.0\napp_type: tui\n"
+        "command: claude\n"
+        "args: ['--verbose', '--fast']\n"
+        "needs_project_dir: false\n"
+        "env:\n  FOO: bar\n  BAZ: qux\n"
+    )
+    assert m["command"] == "claude"
+    assert m["args"] == ["--verbose", "--fast"]
+    assert m["needs_project_dir"] is False
+    assert m["env"] == {"FOO": "bar", "BAZ": "qux"}
+
+
+def test_tui_manifest_missing_command_rejected():
+    with pytest.raises(PackageError, match="command"):
+        parse_manifest(
+            "id: mycli\nname: MyCLI\nversion: 1.0.0\napp_type: tui\n"
+        )
+
+
+def test_tui_manifest_empty_command_rejected():
+    with pytest.raises(PackageError, match="command"):
+        parse_manifest(
+            "id: mycli\nname: MyCLI\nversion: 1.0.0\napp_type: tui\ncommand: ''\n"
+        )
+
+
+def test_unknown_app_type_rejected():
+    with pytest.raises(PackageError, match="not allowed"):
+        parse_manifest(
+            "id: x\nname: X\nversion: 1.0.0\napp_type: native\nentry: x\n"
+        )
+
+
+def test_web_manifest_still_parses():
+    m = parse_manifest(WEB_MANIFEST)
+    assert m["id"] == "todo"
+    assert m["app_type"] == "web"
+    assert m["permissions"] == ["app.net"]

--- a/tinyagentos/userspace/package.py
+++ b/tinyagentos/userspace/package.py
@@ -16,7 +16,7 @@ import yaml
 # newline, which would let "wss://host\n; ..." slip a newline into the value.
 _NET_ORIGIN_RE = re.compile(r"\A(?:wss|https)://(?:\*\.)?[A-Za-z0-9.-]+(?::\d+)?\Z")
 
-_ALLOWED_TYPES = {"web", "container"}
+_ALLOWED_TYPES = {"web", "container", "tui"}
 _REQUIRED = ("id", "name", "version", "app_type")
 
 # Zip-bomb defenses: cap the declared uncompressed total, per-member size, and count.
@@ -59,6 +59,24 @@ def parse_manifest(text: str) -> dict:
             or not all(isinstance(p, int) and not isinstance(p, bool) for p in ports)
         ):
             raise PackageError("container app requires container.ports as a non-empty list of ints")
+    if data["app_type"] == "tui":
+        command = data.get("command")
+        if not command or not isinstance(command, str) or not command.strip():
+            raise PackageError("tui app requires a non-empty 'command' field")
+        data["command"] = command.strip()
+        args = data.get("args", [])
+        if not isinstance(args, list) or not all(isinstance(a, str) for a in args):
+            raise PackageError("tui app 'args' must be a list of strings")
+        data["args"] = args
+        data.setdefault("needs_project_dir", True)
+        if not isinstance(data["needs_project_dir"], bool):
+            raise PackageError("tui app 'needs_project_dir' must be a boolean")
+        env = data.get("env", {})
+        if not isinstance(env, dict) or not all(
+            isinstance(k, str) and isinstance(v, str) for k, v in env.items()
+        ):
+            raise PackageError("tui app 'env' must be a map of string to string")
+        data["env"] = env
     data.setdefault("entry", "index.html")
     data.setdefault("icon", "")
     data.setdefault("permissions", [])


### PR DESCRIPTION
Autonomous build of board card tsk-dfmzqd.



Files:
 docs/STATUS.md                   |  5 +---
 tests/userspace/test_package.py  | 54 ++++++++++++++++++++++++++++++++++++++++
 tinyagentos/userspace/package.py | 20 ++++++++++++++-
 3 files changed, 74 insertions(+), 5 deletions(-)