### PR TITLE
ci: run test matrix on github-hosted runners (kill the 2-runner saturation)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,37 +29,13 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.ref != 'refs/heads/dev' }}
 
 jobs:
-  # Route the matrix to the self-hosted POOL (VPS + Fedora, both labelled
-  # taos-ci) rather than pinning it to one box. The two boxes are ~tied per
-  # core (Fedora i5-10600 ~2.0s, VPS EPYC ~2.2s on the same microbench), so the
-  # fastest run is the two matrix legs in PARALLEL across both — pinning the
-  # whole matrix to a single runner would serialise the legs and be slower. The
-  # always-on, dedicated VPS is the anchor; Fedora joins the pool when it is up
-  # and adds a parallel lane. We only fall back to GitHub-hosted when BOTH
-  # self-hosted runners are offline, so CI never hangs. Reading runner status
-  # needs a PAT with administration:read (secret RUNNER_ADMIN_PAT); without it
-  # we stay on the pool, which the always-on VPS keeps serviceable.
-  pick-runner:
-    runs-on: ubuntu-latest
-    outputs:
-      on: ${{ steps.p.outputs.on }}
-    steps:
-      - id: p
-        env:
-          PAT: ${{ secrets.RUNNER_ADMIN_PAT }}
-        run: |
-          on='["self-hosted","taos-ci"]'
-          if [ -n "$PAT" ]; then
-            count=$(GH_TOKEN="$PAT" gh api "repos/${{ github.repository }}/actions/runners" \
-              --jq '[.runners[] | select(.status=="online") | select(any(.labels[].name; . == "taos-ci"))] | length' \
-              2>/dev/null || echo 1)
-            if [ "${count:-1}" -eq 0 ]; then on='"ubuntu-latest"'; fi
-          fi
-          echo "on=$on" >> "$GITHUB_OUTPUT"
+  # The test matrix runs on GitHub-hosted runners. taOS is a public repo, so
+  # hosted Actions are free with high concurrency (~20 parallel jobs); many PRs
+  # run at once instead of queueing behind the 2 self-hosted boxes. The VPS +
+  # Fedora runners stay free for the kilo lane and GPU/bench work.
 
   test:
-    needs: pick-runner
-    runs-on: ${{ fromJSON(needs.pick-runner.outputs.on) }}
+    runs-on: ubuntu-latest
     # 45 min cap accommodates the cron run that includes 3.11 (~30 min);
     # 3.12/3.13 PR runs finish in ~16 min, so this only kicks in if 3.11
     # ever drifts further.


### PR DESCRIPTION
Only the `test` job used the self-hosted pool (lint/spa-build already run hosted), so every CI pile-up came from the test matrix queueing behind 2 boxes when multiple PRs run at once. taOS is a public repo, so github-hosted Actions are free with ~20-way concurrency. Moving `test` to ubuntu-latest removes the bottleneck and frees the VPS + Fedora for the kilo lane and GPU/bench work. Removes the now-unused pick-runner chooser. uv provisions Python on the hosted image (the only self-hosted-specific quirk was on Fedora, not ubuntu).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI infrastructure for test execution efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->