### PR TITLE
feat(coding-studio): workspace-scoped agent file edits (slice 2)

### DIFF
--- a/desktop/src/apps/codingstudio/BuildView.tsx
+++ b/desktop/src/apps/codingstudio/BuildView.tsx
@@ -11,6 +11,7 @@ import {
   Check,
   X,
   GitBranch,
+  FolderDown,
 } from "lucide-react";
 import { streamTaosAgentChat } from "../appstudio/stream-chat";
 
@@ -37,6 +38,75 @@ interface BuildStep {
   id: number;
   kind: StepKind;
   text: string;
+}
+
+interface ParsedBlock {
+  path: string;
+  lang: string;
+  content: string;
+}
+
+type ApplyStatus = "idle" | "applying" | "applied" | "error";
+
+interface BlockApplyState {
+  status: ApplyStatus;
+  error?: string;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Parse fenced code blocks from agent output                          */
+/*                                                                      */
+/*  Supported annotation formats (first line after opening fence):      */
+/*    // path: src/App.tsx                                              */
+/*    # path: src/App.tsx                                               */
+/*    // src/App.tsx                                                     */
+/*    path: src/App.tsx                                                  */
+/*  Or the language token itself as a filename hint when it contains    */
+/*  a slash: ```src/components/Button.tsx                               */
+/* ------------------------------------------------------------------ */
+
+const PATH_ANNOTATION_RE = /^(?:\/\/|#)?\s*(?:path:\s*)?(\S+\.\w+)\s*$/;
+
+function parseCodeBlocks(text: string): ParsedBlock[] {
+  const blocks: ParsedBlock[] = [];
+  // Match ```lang\n...``` with optional lang that may be a path
+  const fenceRe = /```(\S*)\n([\s\S]*?)```/g;
+  let m: RegExpExecArray | null;
+  while ((m = fenceRe.exec(text)) !== null) {
+    const langToken = m[1] ?? "";
+    const rawBody = m[2] ?? "";
+    let detectedPath: string | null = null;
+    let content = rawBody;
+
+    // Check if the lang token itself is a file path (contains a dot and
+    // possibly a slash, e.g. ```src/App.tsx)
+    if (langToken.includes(".") && (langToken.includes("/") || /\.\w{1,6}$/.test(langToken))) {
+      detectedPath = langToken;
+    }
+
+    // Inspect first line of body for a path annotation
+    if (!detectedPath) {
+      const firstLine = rawBody.split("\n")[0] ?? "";
+      const annotMatch = PATH_ANNOTATION_RE.exec(firstLine.trim());
+      if (annotMatch) {
+        detectedPath = annotMatch[1] ?? null;
+        // Strip the annotation line from content
+        content = rawBody.slice(firstLine.length + 1);
+      }
+    }
+
+    if (!detectedPath) continue;
+
+    // Skip paths that look like shell commands or URLs
+    if (detectedPath.startsWith("http") || detectedPath.startsWith("$")) continue;
+
+    blocks.push({
+      path: detectedPath,
+      lang: langToken.includes("/") ? "" : langToken,
+      content,
+    });
+  }
+  return blocks;
 }
 
 /* ------------------------------------------------------------------ */
@@ -119,7 +189,7 @@ function PatchView({ patch }: { patch: string }) {
         if (line.startsWith("@@")) cls = "text-blue-400";
         return (
           <div key={i} className={cls}>
-            {line || " "}
+            {line || " "}
           </div>
         );
       })}
@@ -274,6 +344,121 @@ function DiffReview({
 }
 
 /* ------------------------------------------------------------------ */
+/*  Apply-blocks panel: shows detected files + apply button            */
+/* ------------------------------------------------------------------ */
+
+function ApplyBlocksPanel({
+  blocks,
+  workspaceId,
+  onApplied,
+}: {
+  blocks: ParsedBlock[];
+  workspaceId: string;
+  onApplied: () => void;
+}) {
+  const [states, setStates] = useState<Record<string, BlockApplyState>>({});
+  const [applying, setApplying] = useState(false);
+
+  const handleApply = useCallback(async () => {
+    setApplying(true);
+    const next: Record<string, BlockApplyState> = {};
+    for (const b of blocks) next[b.path] = { status: "applying" };
+    setStates(next);
+
+    try {
+      const res = await fetch(`/api/coding/workspaces/${workspaceId}/apply-blocks`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          blocks: blocks.map((b) => ({ path: b.path, content: b.content })),
+        }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        const msg = (data as { error?: string }).error ?? `HTTP ${res.status}`;
+        const errStates: Record<string, BlockApplyState> = {};
+        for (const b of blocks) errStates[b.path] = { status: "error", error: msg };
+        setStates(errStates);
+        return;
+      }
+      const data = (await res.json()) as { applied: string[] };
+      const applied = new Set(data.applied);
+      const doneStates: Record<string, BlockApplyState> = {};
+      for (const b of blocks) {
+        doneStates[b.path] = applied.has(b.path)
+          ? { status: "applied" }
+          : { status: "error", error: "not confirmed by server" };
+      }
+      setStates(doneStates);
+      onApplied();
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      const errStates: Record<string, BlockApplyState> = {};
+      for (const b of blocks) errStates[b.path] = { status: "error", error: msg };
+      setStates(errStates);
+    } finally {
+      setApplying(false);
+    }
+  }, [blocks, workspaceId, onApplied]);
+
+  const allDone = blocks.length > 0 && blocks.every((b) => states[b.path]?.status === "applied");
+
+  return (
+    <div className="flex flex-col gap-2 rounded-[12px] border border-accent/30 bg-accent/5 p-3">
+      <div className="flex items-center gap-2">
+        <FolderDown size={14} className="text-accent" />
+        <span className="text-[12px] font-semibold text-shell-text">
+          {blocks.length} file{blocks.length !== 1 ? "s" : ""} detected in response
+        </span>
+        {!allDone && (
+          <button
+            type="button"
+            onClick={() => void handleApply()}
+            disabled={applying}
+            aria-label="Apply files to workspace"
+            className="ml-auto flex h-[26px] items-center gap-1.5 rounded-[8px] border border-accent/40 bg-accent/20 px-3 text-[11px] font-semibold text-accent hover:bg-accent/30 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent/40"
+          >
+            {applying ? <Loader2 size={11} className="animate-spin" /> : <FolderDown size={11} />}
+            Apply to workspace
+          </button>
+        )}
+        {allDone && (
+          <span className="ml-auto flex items-center gap-1 text-[11px] font-semibold text-green-400">
+            <CheckCircle2 size={12} />
+            Applied
+          </span>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-1">
+        {blocks.map((b) => {
+          const st = states[b.path];
+          return (
+            <div
+              key={b.path}
+              className="flex items-center gap-2 rounded-[8px] bg-shell-bg-deep px-2.5 py-1.5"
+            >
+              {st?.status === "applying" && <Loader2 size={11} className="flex-none animate-spin text-accent" />}
+              {st?.status === "applied" && <CheckCircle2 size={11} className="flex-none text-green-400" />}
+              {st?.status === "error" && <XCircle size={11} className="flex-none text-red-400" />}
+              {(!st || st.status === "idle") && (
+                <span className="h-[11px] w-[11px] flex-none" />
+              )}
+              <span className="min-w-0 flex-1 truncate font-mono text-[11px] text-shell-text-secondary">
+                {b.path}
+              </span>
+              {st?.status === "error" && st.error && (
+                <span className="text-[10px] text-red-400">{st.error}</span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
 /*  BuildView                                                            */
 /* ------------------------------------------------------------------ */
 
@@ -296,6 +481,9 @@ export function BuildView() {
   const abortRef = useRef<AbortController | null>(null);
   const mountedRef = useRef(true);
   const logEndRef = useRef<HTMLDivElement>(null);
+
+  // Detected code blocks from last completed stream
+  const [parsedBlocks, setParsedBlocks] = useState<ParsedBlock[]>([]);
 
   // Diff review
   const [diffEntries, setDiffEntries] = useState<DiffEntry[]>([]);
@@ -378,6 +566,14 @@ export function BuildView() {
     }
   }, []);
 
+  // Called after apply-blocks writes files; refresh diff and switch tab
+  const handleApplied = useCallback(() => {
+    if (activeWs) {
+      void fetchDiff(activeWs.id);
+      setTab("diff");
+    }
+  }, [activeWs, fetchDiff]);
+
   // Handle build submit
   const handleBuild = useCallback(async () => {
     if (streaming || !model || !activeWs) return;
@@ -390,19 +586,17 @@ export function BuildView() {
 
     setSteps([]);
     setBuildError(null);
+    setParsedBlocks([]);
     setStreaming(true);
     setTab("chat");
 
-    // The agent cannot directly edit arbitrary workspace files via its tool
-    // (it would need a filesystem MCP or shell tool scoped to the workspace path).
-    // Instead, we give the agent the workspace path context and ask it to emit
-    // file contents as fenced code blocks. The user can then paste them via
-    // the Code view. This is documented in the PR as the current limitation.
-    // See: agent-scoping note in PR body.
     const systemContext = `You are a coding assistant for taOS Coding Studio.
 The user has selected workspace: "${activeWs.name}" (id: ${activeWs.id}).
-Workspace path on the server is managed by taOS. You cannot write files directly.
-Respond with clear, actionable steps and code. Use fenced code blocks with filenames.
+When you write files, use fenced code blocks and annotate the filename on the first line of the block like this:
+\`\`\`tsx
+// path: src/App.tsx
+<file content here>
+\`\`\`
 Keep responses concise and practical.`;
 
     const userMessage = `${systemContext}\n\nUser request: ${text}`;
@@ -416,7 +610,6 @@ Keep responses concise and practical.`;
           if (!mountedRef.current) return;
           outputChunks.push(delta);
           const full = outputChunks.join("");
-          // Emit full response as rolling steps (paragraph chunks)
           setSteps([
             { id: nextId(), kind: "info", text: full },
           ]);
@@ -435,9 +628,15 @@ Keep responses concise and practical.`;
       if (abortRef.current === controller) abortRef.current = null;
       if (mountedRef.current) {
         setStreaming(false);
-        // After build completes, auto-refresh diff
-        void fetchDiff(activeWs.id);
-        setTab("diff");
+        const full = outputChunks.join("");
+        const blocks = parseCodeBlocks(full);
+        setParsedBlocks(blocks);
+        // Only auto-switch to diff tab if no blocks were detected;
+        // when blocks are present the user should apply them first.
+        if (blocks.length === 0) {
+          void fetchDiff(activeWs.id);
+          setTab("diff");
+        }
       }
     }
   }, [prompt, streaming, model, activeWs, fetchDiff]);
@@ -645,7 +844,8 @@ Keep responses concise and practical.`;
               <div className="flex flex-1 items-center justify-center">
                 <p className="max-w-[320px] text-center text-[12.5px] leading-relaxed text-shell-text-tertiary">
                   Describe what you want to build. The agent will respond with a plan and code.
-                  When it edits files, switch to the Diff tab to review and accept or reject changes.
+                  When it emits files, an Apply button appears below to write them to the workspace.
+                  Switch to the Diff tab to review and accept or reject changes.
                 </p>
               </div>
             )}
@@ -672,6 +872,15 @@ Keep responses concise and practical.`;
                 <Loader2 size={14} className="animate-spin" />
                 Thinking...
               </div>
+            )}
+
+            {/* Apply-blocks panel: shown after stream completes if files were detected */}
+            {!streaming && parsedBlocks.length > 0 && activeWs && (
+              <ApplyBlocksPanel
+                blocks={parsedBlocks}
+                workspaceId={activeWs.id}
+                onApplied={handleApplied}
+              />
             )}
 
             <div ref={logEndRef} />

--- a/tests/test_coding_apply_blocks.py
+++ b/tests/test_coding_apply_blocks.py
@@ -1,0 +1,173 @@
+"""Tests for POST /api/coding/workspaces/{id}/apply-blocks."""
+
+import pytest
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture
+async def ws(app, client):
+    store = app.state.coding_workspaces
+    if store._db is not None:
+        await store.close()
+    await store.init()
+
+    r = await client.post("/api/coding/workspaces", json={"name": "apply-test"})
+    assert r.status_code == 200, r.text
+    data = r.json()
+    ws_id = data["id"]
+    ws_dir = app.state.data_dir / "coding-workspaces" / ws_id
+    yield client, ws_id, ws_dir
+
+
+# ---------------------------------------------------------------------------
+# happy path
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_apply_single_block(ws):
+    client, ws_id, ws_dir = ws
+    r = await client.post(
+        f"/api/coding/workspaces/{ws_id}/apply-blocks",
+        json={"blocks": [{"path": "src/App.tsx", "content": "export default function App() {}\n"}]},
+    )
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert data["applied"] == ["src/App.tsx"]
+    assert (ws_dir / "src" / "App.tsx").read_text() == "export default function App() {}\n"
+
+
+@pytest.mark.asyncio
+async def test_apply_multiple_blocks(ws):
+    client, ws_id, ws_dir = ws
+    blocks = [
+        {"path": "index.ts", "content": "console.log('hi');\n"},
+        {"path": "lib/util.ts", "content": "export const x = 1;\n"},
+    ]
+    r = await client.post(
+        f"/api/coding/workspaces/{ws_id}/apply-blocks",
+        json={"blocks": blocks},
+    )
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert set(data["applied"]) == {"index.ts", "lib/util.ts"}
+    assert (ws_dir / "index.ts").exists()
+    assert (ws_dir / "lib" / "util.ts").exists()
+
+
+@pytest.mark.asyncio
+async def test_apply_overwrites_existing_file(ws):
+    client, ws_id, ws_dir = ws
+    (ws_dir / "main.py").write_text("old content\n")
+    r = await client.post(
+        f"/api/coding/workspaces/{ws_id}/apply-blocks",
+        json={"blocks": [{"path": "main.py", "content": "new content\n"}]},
+    )
+    assert r.status_code == 200, r.text
+    assert (ws_dir / "main.py").read_text() == "new content\n"
+
+
+@pytest.mark.asyncio
+async def test_apply_blocks_shows_in_diff(ws):
+    client, ws_id, ws_dir = ws
+    await client.post(
+        f"/api/coding/workspaces/{ws_id}/apply-blocks",
+        json={"blocks": [{"path": "hello.py", "content": "print('hello')\n"}]},
+    )
+    r = await client.get(f"/api/coding/workspaces/{ws_id}/diff")
+    assert r.status_code == 200
+    paths = [e["path"] for e in r.json()]
+    assert "hello.py" in paths
+
+
+# ---------------------------------------------------------------------------
+# jail / path validation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_apply_blocks_rejects_traversal(ws):
+    client, ws_id, _ = ws
+    r = await client.post(
+        f"/api/coding/workspaces/{ws_id}/apply-blocks",
+        json={"blocks": [{"path": "../escape.py", "content": "bad\n"}]},
+    )
+    assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_apply_blocks_rejects_absolute_path(ws):
+    client, ws_id, _ = ws
+    r = await client.post(
+        f"/api/coding/workspaces/{ws_id}/apply-blocks",
+        json={"blocks": [{"path": "/etc/passwd", "content": "bad\n"}]},
+    )
+    assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_apply_blocks_rejects_empty_list(ws):
+    client, ws_id, _ = ws
+    r = await client.post(
+        f"/api/coding/workspaces/{ws_id}/apply-blocks",
+        json={"blocks": []},
+    )
+    assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_apply_blocks_all_or_nothing_on_bad_path(ws):
+    """If any path is invalid the entire request is rejected; no files are written."""
+    client, ws_id, ws_dir = ws
+    r = await client.post(
+        f"/api/coding/workspaces/{ws_id}/apply-blocks",
+        json={
+            "blocks": [
+                {"path": "ok.py", "content": "x = 1\n"},
+                {"path": "../escape.py", "content": "bad\n"},
+            ]
+        },
+    )
+    assert r.status_code == 400
+    # The good file must NOT have been written
+    assert not (ws_dir / "ok.py").exists()
+
+
+@pytest.mark.asyncio
+async def test_apply_blocks_unknown_workspace(ws):
+    client, _ws_id, _ = ws
+    r = await client.post(
+        "/api/coding/workspaces/cws-notreal/apply-blocks",
+        json={"blocks": [{"path": "x.py", "content": "x\n"}]},
+    )
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# _resolve_jailed helper (unit-level via the route module)
+# ---------------------------------------------------------------------------
+
+def test_resolve_jailed_rejects_dotdot(tmp_path):
+    from tinyagentos.routes.coding import _resolve_jailed
+    assert _resolve_jailed(tmp_path, "../outside.py") is None
+
+
+def test_resolve_jailed_rejects_absolute(tmp_path):
+    from tinyagentos.routes.coding import _resolve_jailed
+    assert _resolve_jailed(tmp_path, "/etc/passwd") is None
+
+
+def test_resolve_jailed_allows_nested(tmp_path):
+    from tinyagentos.routes.coding import _resolve_jailed
+    result = _resolve_jailed(tmp_path, "src/nested/file.py")
+    assert result is not None
+    assert result == (tmp_path / "src" / "nested" / "file.py").resolve()
+
+
+def test_resolve_jailed_rejects_root_without_flag(tmp_path):
+    from tinyagentos.routes.coding import _resolve_jailed
+    assert _resolve_jailed(tmp_path, "") is None
+
+
+def test_resolve_jailed_allows_root_with_flag(tmp_path):
+    from tinyagentos.routes.coding import _resolve_jailed
+    result = _resolve_jailed(tmp_path, "", allow_root=True)
+    assert result == tmp_path.resolve()

--- a/tinyagentos/routes/coding.py
+++ b/tinyagentos/routes/coding.py
@@ -25,6 +25,15 @@ class PathsBody(BaseModel):
     paths: list[str]
 
 
+class ApplyBlock(BaseModel):
+    path: str
+    content: str
+
+
+class ApplyBlocksBody(BaseModel):
+    blocks: list[ApplyBlock]
+
+
 # ---------------------------------------------------------------------------
 # Git helpers
 # ---------------------------------------------------------------------------
@@ -373,3 +382,51 @@ async def revert_changes(request: Request, workspace_id: str, body: PathsBody):
         )
 
     return {"ok": True, "reverted": reverted}
+
+
+# ---------------------------------------------------------------------------
+# Apply agent code blocks
+# ---------------------------------------------------------------------------
+
+@router.post("/api/coding/workspaces/{workspace_id}/apply-blocks")
+async def apply_blocks(request: Request, workspace_id: str, body: ApplyBlocksBody):
+    """Write a batch of files into the workspace, jailed to its directory.
+
+    Each block must supply a relative ``path`` and ``content`` string.
+    Paths are validated by ``_resolve_jailed``; any traversal attempt causes
+    the entire request to be rejected before any file is written.
+
+    Returns::
+
+        {
+            "applied": ["src/App.tsx", ...],
+            "skipped": []           # blocks whose path was invalid
+        }
+    """
+    root, err = await _workspace_root(request, workspace_id)
+    if err is not None:
+        return err
+
+    if not body.blocks:
+        return JSONResponse({"error": "no blocks provided"}, status_code=400)
+
+    # Validate all paths before writing anything so a bad path mid-list
+    # does not leave the workspace in a partially-written state.
+    resolved: list[tuple[str, Path, str]] = []
+    for block in body.blocks:
+        rel = (block.path or "").strip()
+        target = _resolve_jailed(root, rel)
+        if target is None or target == root or target.is_dir():
+            return JSONResponse(
+                {"error": f"invalid path: {block.path!r}"},
+                status_code=400,
+            )
+        resolved.append((rel, target, block.content))
+
+    applied: list[str] = []
+    for rel, target, content in resolved:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+        applied.append(rel)
+
+    return {"applied": applied}

--- a/tinyagentos/routes/coding.py
+++ b/tinyagentos/routes/coding.py
@@ -70,6 +70,10 @@ def _resolve_jailed(root: Path, rel: str, *, allow_root: bool = False) -> Path |
     target = (root / rel).resolve() if rel else root.resolve()
     if not target.is_relative_to(root):
         return None
+    # Never allow paths into the workspace .git directory: writing there (e.g. a
+    # hooks/ script) would be code execution on the next git operation.
+    if ".git" in target.relative_to(root).parts:
+        return None
     if target == root and not allow_root:
         return None
     return target


### PR DESCRIPTION
## Path taken: apply-blocks fallback

The taOS agent chat route (`POST /api/taos-agent/chat`) streams raw text through `OpenCodeAdapter` with no tool-calling loop. There is no `kind=tool_call` frame -- only `delta`, `error`, and `done`. Full agent tool-calling is the next slice (see bottom).

## What this adds

### Backend -- `tinyagentos/routes/coding.py`

New endpoint: `POST /api/coding/workspaces/{id}/apply-blocks`

- Accepts `{"blocks": [{"path": "src/App.tsx", "content": "..."}]}`
- Validates **all** paths via `_resolve_jailed` before writing any file (all-or-nothing: a bad path rejects the entire request)
- Writes files to the workspace git working tree, creating parent dirs as needed
- Returns `{"applied": ["src/App.tsx", ...]}`
- The workspace is git-tracked so `GET /api/coding/workspaces/{id}/diff` immediately reflects the writes

### How the jail works

Every path goes through `_resolve_jailed(workspace_root, rel)` which:
1. Rejects absolute paths, `://`, `//` prefixes, any `..` in path components
2. Resolves the full path and asserts it is `is_relative_to(workspace_root)`
3. Rejects the root itself (prevents writing to a directory)
4. Returns `None` on any failure → 400

### Frontend -- `desktop/src/apps/codingstudio/BuildView.tsx`

- `parseCodeBlocks(text)` parser extracts fenced blocks with filename annotations from agent output. Supported formats:
  - `// path: src/App.tsx` (first line of block body)
  - `# path: src/App.tsx`
  - Lang token itself is a file path (e.g. ` ```src/App.tsx`)
- `ApplyBlocksPanel` component: shown below the agent response when blocks are detected; lists each file with per-file status (idle / applying / applied / error); single "Apply to workspace" button POSTs to the new endpoint
- After apply succeeds: auto-refreshes diff and switches to Diff tab
- Agent system prompt updated to instruct the model to emit `// path:` annotations

## Files changed

- `tinyagentos/routes/coding.py` -- added `ApplyBlock`, `ApplyBlocksBody` models + `apply_blocks` endpoint
- `desktop/src/apps/codingstudio/BuildView.tsx` -- block parser, `ApplyBlocksPanel` component, wiring
- `tests/test_coding_apply_blocks.py` -- 14 new tests (happy path, jail bypass, all-or-nothing, unit tests for `_resolve_jailed`)

## Test output

```
25 passed in 7.99s
```

Full list:
- `test_apply_single_block` PASSED
- `test_apply_multiple_blocks` PASSED
- `test_apply_overwrites_existing_file` PASSED
- `test_apply_blocks_shows_in_diff` PASSED
- `test_apply_blocks_rejects_traversal` PASSED
- `test_apply_blocks_rejects_absolute_path` PASSED
- `test_apply_blocks_rejects_empty_list` PASSED
- `test_apply_blocks_all_or_nothing_on_bad_path` PASSED
- `test_apply_blocks_unknown_workspace` PASSED
- `test_resolve_jailed_rejects_dotdot` PASSED
- `test_resolve_jailed_rejects_absolute` PASSED
- `test_resolve_jailed_allows_nested` PASSED
- `test_resolve_jailed_rejects_root_without_flag` PASSED
- `test_resolve_jailed_allows_root_with_flag` PASSED
- All 11 existing `test_coding_diff.py` tests PASSED

## TypeScript

The worktree has no `node_modules` (shared with parent repo). Running tsc across the full project produces pre-existing `Cannot find module 'react'` and `Cannot find namespace 'React'` errors everywhere -- including the original `BuildView.tsx` on `origin/dev`. The one real type error I introduced (`string | undefined` not assignable to `string | null`) was fixed. No new structural type errors in the changed files.

## Live verification needed

- Confirm that a model which emits `// path: src/App.tsx` annotations in its fenced blocks triggers the Apply panel
- Confirm files land in the workspace and appear in the Diff tab

## Next slice: full agent tool-calling

The right long-term path is adding `read_file` / `write_file` / `list_files` as MCP tools or OpenAI-style function-calling tools to the agent, jailed to the workspace dir. This slice delivers the apply-blocks bridge so file edits work end-to-end today.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agent-generated code blocks can now be applied directly to your workspace
  * An "Apply to workspace" panel appears when code is detected, with per-file status tracking and validation
  * Successfully applied changes are automatically reflected in the diff view
  * Built-in path validation prevents invalid file operations and surfaces clear error feedback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->