### PR TITLE
fix(browser): single connecting-host NAT1TO1 (comma list broke WebRTC with invalid 1:1 NAT mapping) (#73)

### DIFF
--- a/tests/routes/test_browser_sessions_routes.py
+++ b/tests/routes/test_browser_sessions_routes.py
@@ -770,7 +770,7 @@ async def test_get_agent_session_not_in_config_returns_404(app, tmp_path):
 # Host-aware neko_url rewrite (Tailscale fix)
 # ---------------------------------------------------------------------------
 
-from tinyagentos.routes.browser_sessions import _rewrite_neko_url
+from tinyagentos.routes.browser_sessions import _rewrite_neko_url, _connecting_host_ip
 
 
 class _FakeRequest:
@@ -890,3 +890,51 @@ async def test_get_session_over_tailscale_rewrites_neko_url(app, tmp_path):
     assert ":8800" in neko_url
 
     await bs.close()
+
+# ---------------------------------------------------------------------------
+# _connecting_host_ip helper
+# ---------------------------------------------------------------------------
+
+
+def test_connecting_host_ip_from_lan_ip_header():
+    """Host header with a LAN IP resolves to that IP."""
+    req = _FakeRequest(host="192.168.1.50:6969")
+    result = _connecting_host_ip(req)
+    assert result == "192.168.1.50"
+    assert result is not None
+    assert "," not in result
+
+
+def test_connecting_host_ip_from_tailscale_ip_header():
+    """Host header with a Tailscale IP resolves to that IP."""
+    req = _FakeRequest(host="100.64.0.5:6969")
+    result = _connecting_host_ip(req)
+    assert result == "100.64.0.5"
+    assert "," not in result
+
+
+def test_connecting_host_ip_no_header_returns_none():
+    """No Host header returns None so callers fall back to the node LAN IP."""
+    req = _FakeRequest()
+    assert _connecting_host_ip(req) is None
+
+
+def test_connecting_host_ip_forwarded_host_takes_precedence():
+    """X-Forwarded-Host takes precedence over Host, same as neko_url rewrite."""
+    req = _FakeRequest(host="192.168.1.50:6969", forwarded_host="100.64.0.9")
+    result = _connecting_host_ip(req)
+    assert result == "100.64.0.9"
+    assert "," not in result
+
+
+def test_connecting_host_ip_never_contains_comma():
+    """_connecting_host_ip must never return a comma-separated value."""
+    for req in [
+        _FakeRequest(host="192.168.1.50:6969"),
+        _FakeRequest(host="100.64.0.5"),
+        _FakeRequest(forwarded_host="100.64.0.9"),
+        _FakeRequest(),
+    ]:
+        result = _connecting_host_ip(req)
+        if result is not None:
+            assert "," not in result, f"_connecting_host_ip returned comma-separated: {result!r}"

--- a/tests/test_browser_container.py
+++ b/tests/test_browser_container.py
@@ -192,7 +192,7 @@ async def test_rk3588_runner_exposes_cdp_url():
 # ---------------------------------------------------------------------------
 
 from unittest.mock import patch
-from tinyagentos.worker.browser_container import build_nat1to1, _detect_tailscale_ip
+from tinyagentos.worker.browser_container import build_nat1to1, _detect_tailscale_ip, _resolve_connecting_ip
 
 
 def test_build_nat1to1_no_tailscale_returns_lan_ip():
@@ -202,11 +202,12 @@ def test_build_nat1to1_no_tailscale_returns_lan_ip():
     assert result == "192.168.1.50"
 
 
-def test_build_nat1to1_with_tailscale_returns_both_ips():
-    """When Tailscale is present, NAT1TO1 is '<lan-ip>,<tailscale-ip>'."""
+def test_build_nat1to1_with_tailscale_ip_not_used_when_connecting_ip_given():
+    """When connecting_host_ip is provided it is used directly; Tailscale state is irrelevant."""
     with patch("tinyagentos.worker.browser_container._detect_tailscale_ip", return_value="100.64.0.1"):
-        result = build_nat1to1("192.168.1.50")
-    assert result == "192.168.1.50,100.64.0.1"
+        result = build_nat1to1("192.168.1.50", connecting_host_ip="100.64.0.1")
+    assert result == "100.64.0.1"
+    assert "," not in result
 
 
 def test_build_nat1to1_tailscale_same_as_lan_no_duplicate():
@@ -237,12 +238,14 @@ def test_detect_tailscale_ip_no_binary_no_netifaces_returns_none():
     assert result is None
 
 
-def test_neko_run_args_includes_tailscale_ip_in_nat1to1():
-    """build_neko_run_args uses build_nat1to1 so the docker -e includes the Tailscale IP."""
+def test_neko_run_args_nat1to1_uses_connecting_ip_when_given():
+    """When nat1to1_ip is given, NEKO_WEBRTC_NAT1TO1 uses that single IP (no Tailscale append)."""
     with patch("tinyagentos.worker.browser_container._detect_tailscale_ip", return_value="100.64.0.1"):
-        argv = _args(node_ip="192.168.1.50")
-    nat_entry = "NEKO_WEBRTC_NAT1TO1=192.168.1.50,100.64.0.1"
-    assert nat_entry in argv
+        argv = _args(node_ip="192.168.1.50", nat1to1_ip="100.64.0.1")
+    assert "NEKO_WEBRTC_NAT1TO1=100.64.0.1" in argv
+    for arg in argv:
+        if "NAT1TO1" in arg:
+            assert "," not in arg, f"NAT1TO1 must never contain a comma, got: {arg}"
 
 
 def test_neko_run_args_nat1to1_lan_only_when_no_tailscale():
@@ -254,3 +257,53 @@ def test_neko_run_args_nat1to1_lan_only_when_no_tailscale():
     for arg in argv:
         if "NAT1TO1" in arg:
             assert "," not in arg
+
+# ---------------------------------------------------------------------------
+# _resolve_connecting_ip
+# ---------------------------------------------------------------------------
+
+def test_resolve_connecting_ip_ip_literal():
+    """IP literals are returned directly without DNS lookup."""
+    result = _resolve_connecting_ip("192.168.1.50:6969")
+    assert result == "192.168.1.50"
+
+
+def test_resolve_connecting_ip_localhost():
+    """localhost resolves to an IP (127.0.0.1)."""
+    result = _resolve_connecting_ip("localhost:6969")
+    assert result is not None
+    assert "." in result
+    assert "," not in result
+
+
+def test_resolve_connecting_ip_empty_returns_none():
+    """Empty string returns None."""
+    assert _resolve_connecting_ip("") is None
+
+
+def test_resolve_connecting_ip_bad_hostname_returns_none():
+    """Unresolvable hostname returns None."""
+    result = _resolve_connecting_ip("does-not-exist.invalid:6969")
+    assert result is None
+
+
+def test_build_nat1to1_never_returns_comma():
+    """NAT1TO1 must never contain a comma regardless of inputs."""
+    with patch("tinyagentos.worker.browser_container._detect_tailscale_ip", return_value="100.64.0.1"):
+        for args in [
+            ("192.168.1.50", None),
+            ("192.168.1.50", "100.64.0.1"),
+            ("192.168.1.50", "192.168.1.50"),
+        ]:
+            result = build_nat1to1(*args)
+            assert "," not in result, f"build_nat1to1{args!r} returned comma-separated: {result!r}"
+
+
+def test_neko_run_args_nat1to1_never_contains_comma():
+    """NAT1TO1 env var in docker args must never be a comma-separated list."""
+    for nat1to1_ip in [None, "192.168.1.50", "100.64.0.1"]:
+        with patch("tinyagentos.worker.browser_container._detect_tailscale_ip", return_value="100.64.0.1"):
+            argv = _args(node_ip="192.168.1.50", nat1to1_ip=nat1to1_ip)
+        for arg in argv:
+            if "NAT1TO1" in arg:
+                assert "," not in arg, f"NAT1TO1 must never contain a comma, got: {arg!r}"

--- a/tinyagentos/browser_sessions.py
+++ b/tinyagentos/browser_sessions.py
@@ -490,15 +490,18 @@ class BrowserSessionManager:
         return await self.create_session("user", owner_id, url, profile_name, mobile=mobile)
 
     async def start_on_host(self, session_id: str, *, profile_volume: str, runner,
-                             mobile: bool = False) -> dict:
+                             mobile: bool = False, nat1to1_ip: str | None = None) -> dict:
         """Start a Neko container in-process via BrowserContainerRunner (host-local).
 
         Mirrors start_on_worker but drives the runner directly. On failure marks
         the session 'error' and raises BrowserWorkerError.
+
+        ``nat1to1_ip`` is forwarded to the runner so the container is told to
+        advertise the single IP the client connected from for WebRTC NAT1TO1.
         """
         try:
             data = await runner.start(session_id=session_id, profile_volume=profile_volume,
-                                      mobile=mobile)
+                                      mobile=mobile, nat1to1_ip=nat1to1_ip)
         except Exception as exc:
             await self.mark_error(session_id)
             raise BrowserWorkerError(f"host browser start failed: {exc}") from exc

--- a/tinyagentos/routes/browser_sessions.py
+++ b/tinyagentos/routes/browser_sessions.py
@@ -10,6 +10,7 @@ Routes:
 """
 
 import logging
+import socket
 from typing import Any
 from urllib.parse import urlparse, urlunparse
 
@@ -73,6 +74,28 @@ def _apply_host_rewrite(session: dict, request: Request) -> dict:
     if not neko_url:
         return session
     return {**session, "neko_url": _rewrite_neko_url(neko_url, request)}
+
+
+def _connecting_host_ip(request: Request) -> str | None:
+    """Resolve the single IP the client connected with, for use as NEKO_WEBRTC_NAT1TO1.
+
+    Reads X-Forwarded-Host then Host (same precedence as _rewrite_neko_url).
+    Strips the port, then resolves the value: IP literals are returned as-is;
+    hostnames go through socket.gethostbyname.  Returns None on failure so
+    callers fall back to the node LAN IP.
+    """
+    client_host = (
+        request.headers.get("x-forwarded-host")
+        or request.headers.get("host")
+        or ""
+    )
+    hostname = client_host.split(":")[0].strip() if client_host else ""
+    if not hostname:
+        return None
+    try:
+        return socket.gethostbyname(hostname)
+    except Exception:
+        return None
 
 
 class CreateSessionBody(BaseModel):
@@ -226,7 +249,8 @@ async def get_my_session(
             if kind == "host":
                 runner = request.app.state.browser_container_runner
                 session = await mgr.start_on_host(session["id"], profile_volume=vol,
-                                                   runner=runner, mobile=mobile)
+                                                   runner=runner, mobile=mobile,
+                                                   nat1to1_ip=_connecting_host_ip(request))
             else:
                 worker = cluster.get_worker(node)
                 auth_token = getattr(request.app.state, "browser_worker_auth_token", None)

--- a/tinyagentos/worker/browser_container.py
+++ b/tinyagentos/worker/browser_container.py
@@ -11,6 +11,7 @@ import asyncio
 import logging
 import secrets
 import shutil
+import socket
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -50,17 +51,35 @@ def _detect_tailscale_ip() -> str | None:
     return None
 
 
-def build_nat1to1(node_ip: str) -> str:
-    """Build the NEKO_WEBRTC_NAT1TO1 value for this host.
+def _resolve_connecting_ip(host_header: str) -> str | None:
+    """Resolve the connecting host from a Host header value to an IPv4 string.
 
-    Always includes ``node_ip`` (the LAN IP).  When Tailscale is active, the
-    Tailscale IP is appended as a second comma-separated entry so WebRTC ICE
-    candidates are advertised on both LAN and Tailscale networks.  If
-    detection fails for any reason, falls back to just ``node_ip``.
+    Strips any port suffix.  If the result is already an IP literal it is
+    returned as-is.  If it is a hostname, socket.gethostbyname resolves it.
+    Returns None on any failure so callers can fall back to the LAN node_ip.
     """
-    ts_ip = _detect_tailscale_ip()
-    if ts_ip and ts_ip != node_ip:
-        return f"{node_ip},{ts_ip}"
+    hostname = host_header.split(":")[0].strip() if host_header else ""
+    if not hostname:
+        return None
+    try:
+        return socket.gethostbyname(hostname)
+    except Exception:
+        return None
+
+
+def build_nat1to1(node_ip: str, connecting_host_ip: str | None = None) -> str:
+    """Return the single IP to use for NEKO_WEBRTC_NAT1TO1.
+
+    neko/pion requires exactly ONE IP.  When ``connecting_host_ip`` is
+    provided (resolved from the client's Host/X-Forwarded-Host header at
+    session-create time) it is used directly, so WebRTC candidates match the
+    address the user actually connected from (LAN, Tailscale, etc.).
+
+    Falls back to ``node_ip`` when no connecting IP is available.
+    Never emits a comma-separated value.
+    """
+    if connecting_host_ip:
+        return connecting_host_ip
     return node_ip
 
 DEFAULT_NEKO_IMAGE = "ghcr.io/m1k1o/neko/chromium:latest"
@@ -143,6 +162,7 @@ def build_neko_run_args(
     device_args: list[str] | None = None,
     mobile: bool = False,
     shm_size: str = "4g",
+    nat1to1_ip: str | None = None,
 ) -> list[str]:
     """Return the full ``docker run`` argv (starting with 'docker') for a Neko
     Chromium session, per the validated spike recipe.
@@ -151,9 +171,13 @@ def build_neko_run_args(
     the mobile Chromium supervisord config so Chromium presents a mobile UA,
     touch events, and a 3x device scale factor.
 
-    ``shm_size`` controls ``--shm-size``. The default is ``"4g"`` — required
+    ``shm_size`` controls ``--shm-size``. The default is ``"4g"`` -- required
     by the CDP-enabled image (``DEFAULT_NEKO_CDP_IMAGE``) for stable page
     sessions; 4g is safe for all images and strictly better than the old 2g.
+
+    ``nat1to1_ip`` overrides the NEKO_WEBRTC_NAT1TO1 value.  Pass the IP the
+    connecting client used (from the Host header) so pion receives the single
+    IP it expects.  Falls back to ``node_ip`` when not provided.
     """
     if image is None:
         image = DEFAULT_NEKO_GPU_IMAGE if gpu else DEFAULT_NEKO_IMAGE
@@ -169,7 +193,7 @@ def build_neko_run_args(
         "-e", f"NEKO_MEMBER_MULTIUSER_USER_PASSWORD={user_pwd}",
         "-e", f"NEKO_MEMBER_MULTIUSER_ADMIN_PASSWORD={admin_pwd}",
         "-e", f"NEKO_WEBRTC_EPR={epr_lo}-{epr_hi}",
-        "-e", f"NEKO_WEBRTC_NAT1TO1={build_nat1to1(node_ip)}",
+        "-e", f"NEKO_WEBRTC_NAT1TO1={build_nat1to1(node_ip, nat1to1_ip)}",
         f"--shm-size={shm_size}",
         "-v", f"{profile_volume}:{NEKO_PROFILE_MOUNT}",
     ]
@@ -285,7 +309,8 @@ class BrowserContainerRunner:
             detail = stderr.decode().strip()
             raise BrowserContainerError(f"docker pull {image} failed: {detail}")
 
-    async def start(self, *, session_id: str, profile_volume: str, mobile: bool = False) -> dict:
+    async def start(self, *, session_id: str, profile_volume: str, mobile: bool = False,
+                   nat1to1_ip: str | None = None) -> dict:
         """Start a Neko container and return connection details.
 
         Returns a dict with keys: container_id, neko_url, cdp_url,
@@ -293,6 +318,10 @@ class BrowserContainerRunner:
 
         When ``mobile=True`` the container runs portrait (800x1600@30) with a
         mobile Chromium UA + touch events so sites serve mobile layouts.
+
+        ``nat1to1_ip`` is the single IP to advertise for WebRTC NAT1TO1 -- it
+        should be the IP the client connected from (resolved from the request
+        Host header).  Falls back to ``self.node_ip`` when not provided.
         """
         http_port, epr_lo, epr_hi = self._allocator.allocate()
         # Full session_id (a uuid hex) — avoids name collisions from a
@@ -334,6 +363,7 @@ class BrowserContainerRunner:
                 image=image,
                 device_args=spec.device_args,
                 mobile=mobile,
+                nat1to1_ip=nat1to1_ip,
             )
             try:
                 proc = await asyncio.create_subprocess_exec(


### PR DESCRIPTION
## Root cause

PR #1228 set `NEKO_WEBRTC_NAT1TO1` to a comma-separated `<LAN-IP>,<Tailscale-IP>` list. neko/pion rejects that with `invalid 1:1 NAT IP mapping` and discards the entire WebRTC setup, causing a 15s timeout and white screen on every browser session.

## Fix

`NEKO_WEBRTC_NAT1TO1` must be a **single IP**. Determine it from the host the user connected with at session-create time -- the same `X-Forwarded-Host` / `Host` header detection already used for the neko_url rewrite.

- IP literal in the header -> use directly
- Hostname -> resolve via `socket.gethostbyname` (try/except guarded)
- Header absent or unresolvable -> fall back to the node LAN `node_ip`
- Never emit a comma-separated value

## Changes

| File | Change |
|---|---|
| `tinyagentos/worker/browser_container.py` | Add `_resolve_connecting_ip()`, rework `build_nat1to1()` to accept `connecting_host_ip`, add `nat1to1_ip` param to `build_neko_run_args()` and `BrowserContainerRunner.start()` |
| `tinyagentos/browser_sessions.py` | Add `nat1to1_ip` param to `start_on_host()`, forward to `runner.start()` |
| `tinyagentos/routes/browser_sessions.py` | Add `_connecting_host_ip(request)` helper, pass it into `start_on_host` call |
| `tests/test_browser_container.py` | Replace old comma-list assertions; add `_resolve_connecting_ip` tests + no-comma invariant tests |
| `tests/routes/test_browser_sessions_routes.py` | Add `_connecting_host_ip` tests + no-comma invariant |

The neko_url host-rewrite from #1228 is preserved unchanged.

## Test results

70 passed, 0 failed.

Validated live -- single-IP NAT1TO1 streams video; the comma list caused pion 'invalid 1:1 NAT IP mapping'.