### PR TITLE
ci: auto-merge dependabot patch/minor on green

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,31 @@
+name: Dependabot auto-merge
+
+# Auto-merges grouped patch/minor Dependabot PRs once required checks pass.
+# Majors and Python (uv) updates are left for manual review.
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for npm / actions patch & minor
+        if: >-
+          (steps.meta.outputs.package-ecosystem == 'npm' ||
+           steps.meta.outputs.package-ecosystem == 'github_actions') &&
+          (steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+           steps.meta.outputs.update-type == 'version-update:semver-minor')
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a `pull_request_target` workflow that enables GitHub auto-merge for Dependabot PRs that are:

- npm (`/desktop`) or github-actions ecosystem, AND
- semver patch or minor.

Majors and Python (uv) updates are deliberately excluded and come to manual review, per the agreed cadence.

Uses `dependabot/fetch-metadata@v2`; PR URL passed via `env:` (GitHub-generated, no injection surface). Needs `dev` branch protection with required checks (test 3.12/3.13, spa-build, lint) for the auto-merge queue, applied separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated merging of Dependabot pull requests for routine npm and GitHub Actions dependency updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->