### PR TITLE
chore(deps): bump dompurify to 3.4.11 (security)

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -6613,9 +6613,9 @@
       "peer": true
     },
     "node_modules/dompurify": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
-      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"


### PR DESCRIPTION
Clears the single genuinely-outstanding Dependabot security alert (dompurify <=3.4.10, medium XSS). In-range patch under the existing `^3.4.0` constraint; npm reports 0 vulnerabilities after.

The other 6 open alerts (5 litellm crit/high, 1 fastapi-sso medium) are stale on master only: dev already pins litellm 1.89.2 and fastapi-sso 0.21.0, both well past their patched versions. They clear on the next dev to master promotion.