### PR TITLE
release: 1.0.0-beta.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.5] - 2026-06-20
+
+### Added
+- Browser app redesigned to the current design bar with a collapsible sidebar.
+- Coding Studio: workspace-scoped agent file edits with a build loop and inline diff review.
+
+### Changed
+- CI runs the test matrix on GitHub-hosted runners, cancels superseded runs per ref, and auto-merges low-risk Dependabot patch and minor updates on green.
+
+### Fixed
+- Streamed browser now connects over Tailscale and other non-LAN addresses: WebRTC advertises the single connecting-host IP, fixing the white screen the previous comma-separated NAT mapping caused.
+- The "connecting" overlay can no longer hang over a session that is already live.
+- Hardened the streamed-browser iframe sandbox and several store and coding-studio endpoints: IDOR guard on submission reads, symlink-safe workspace writes, and an admin gate on install-registry mutations.
+- Store submissions return 400 on invalid input instead of 500.
+- Security: dompurify updated to 3.4.11; cryptography and pydantic-settings advisories cleared.
+- Install: the core install no longer aborts when optional components fail, and drops to the service user without assuming sudo (WSL robustness).
+
 ## [1.0.0-beta.3] - 2026-06-16
 
 ### Added

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinyagentos-desktop",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinyagentos-desktop",
-      "version": "1.0.0-beta.3",
+      "version": "1.0.0-beta.5",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.5"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.4.1"
+__version__ = "1.0.0-beta.5"

--- a/uv.lock
+++ b/uv.lock
@@ -3574,7 +3574,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b3"
+version = "1.0.0b5"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Version bump + CHANGELOG for the dev to master promotion.

- Bumps pyproject, desktop/package.json, `__init__.py` and both lockfiles to 1.0.0-beta.5.
- Resolves prior version drift (pyproject/package.json were stuck at beta.3 while tags reached beta.4.1). beta.4.x is not PEP 440-valid, so this moves to beta.5, valid in both semver and PEP 440.
- CHANGELOG section covers this promotion: browser redesign + collapsible sidebar, the Tailscale/WebRTC white-screen fix, the connecting-overlay fix, store/coding-studio security hardening, dompurify + advisory clears, and the WSL install robustness work.

Follow-up after merge: promote dev to master, then tag v1.0.0-beta.5 and cut the GitHub Release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release v1.0.0-beta.5

* **New Features**
  * Browser UI redesign with collapsible sidebar
  * Coding Studio workflow enhancements with inline diff review
  * CI improvements with automated test matrix and low-risk auto-merging

* **Bug Fixes**
  * Fixed browser connectivity over non-LAN addresses
  * Prevented connecting overlay hang on live sessions
  * Enhanced security hardening for endpoints
  * Corrected Store submission error handling
  * Improved installation robustness

* **Chores**
  * Version bump to v1.0.0-beta.5

<!-- end of auto-generated comment: release notes by coderabbit.ai -->