### PR TITLE
neko(rk3588): base the RK3588 image on the CDP image + document rkmpp packaging

### DIFF
--- a/.github/workflows/build-neko-rk3588-image.yml
+++ b/.github/workflows/build-neko-rk3588-image.yml
@@ -1,0 +1,41 @@
+name: Build Neko RK3588 image
+
+# Builds the RK3588 VPU-encode neko image (MPP + gstreamer-rockchip compiled
+# from source against trixie GStreamer 1.26) on a GitHub arm64 runner, so the
+# Pi is never used for the build. The Pi only does the final validation run.
+on:
+  push:
+    branches: [master, dev]
+    paths:
+      - 'app-catalog/streaming/neko-browser/Dockerfile.rk3588'
+      - '.github/workflows/build-neko-rk3588-image.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push (arm64)
+        uses: docker/build-push-action@v6
+        with:
+          context: app-catalog/streaming/neko-browser
+          file: app-catalog/streaming/neko-browser/Dockerfile.rk3588
+          platforms: linux/arm64
+          push: true
+          tags: |
+            ghcr.io/jaylfc/taos-neko-rk3588:latest
+            ghcr.io/jaylfc/taos-neko-rk3588:${{ github.sha }}
+          cache-from: type=gha,scope=neko-rk3588
+          cache-to: type=gha,mode=max,scope=neko-rk3588

--- a/.github/workflows/build-neko-rk3588-image.yml
+++ b/.github/workflows/build-neko-rk3588-image.yml
@@ -3,9 +3,15 @@ name: Build Neko RK3588 image
 # Builds the RK3588 VPU-encode neko image (MPP + gstreamer-rockchip compiled
 # from source against trixie GStreamer 1.26) on a GitHub arm64 runner, so the
 # Pi is never used for the build. The Pi only does the final validation run.
+# On a PR the image is built but NOT pushed (compile validation only); on
+# dev/master it is built and pushed to GHCR.
 on:
   push:
     branches: [master, dev]
+    paths:
+      - 'app-catalog/streaming/neko-browser/Dockerfile.rk3588'
+      - '.github/workflows/build-neko-rk3588-image.yml'
+  pull_request:
     paths:
       - 'app-catalog/streaming/neko-browser/Dockerfile.rk3588'
       - '.github/workflows/build-neko-rk3588-image.yml'
@@ -22,18 +28,19 @@ jobs:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
       - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push (arm64)
+      - name: Build (push only on dev/master)
         uses: docker/build-push-action@v6
         with:
           context: app-catalog/streaming/neko-browser
           file: app-catalog/streaming/neko-browser/Dockerfile.rk3588
           platforms: linux/arm64
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ghcr.io/jaylfc/taos-neko-rk3588:latest
             ghcr.io/jaylfc/taos-neko-rk3588:${{ github.sha }}

--- a/app-catalog/streaming/neko-browser/Dockerfile.rk3588
+++ b/app-catalog/streaming/neko-browser/Dockerfile.rk3588
@@ -1,40 +1,40 @@
-# taOS Neko Chromium for RK3588 (Orange Pi 5 Plus) — CDP + VPU H.264 encode.
+# taOS Neko Chromium for RK3588 — VPU H.264 encode via MPP + gstreamer-rockchip.
+# Multi-stage: stage 1 compiles Rockchip MPP, RGA and the gstreamer-rockchip
+# plugin against GStreamer 1.26 (trixie, matching the neko-cdp runtime, so the
+# plugin ABI lines up). Stage 2 layers the built libs onto the CDP image.
 #
-# SEPARATE, SoC-specific, arm64-only image. Built ON TOP of the taOS CDP image
-# so it inherits Chromium >=148 + the CDP DevTools enablement, then adds the
-# Rockchip MPP/RGA userspace + the GStreamer rkmpp plugin (mpph264enc) so WebRTC
-# encode runs on the VPU instead of the A76 cores. Generic arm64 and x86 nodes
-# keep using the plain CDP image (software encode); resolve_neko_image() picks
-# THIS image only when the SoC is rk3588/rk3576 and passes /dev/mpp_service,
-# /dev/dri, /dev/rga at docker run.
-#
-# Why a separate image (not one multi-arch image for every device): the Rockchip
-# MPP/RGA userspace and the mpph264enc rank boost are SoC-specific. Baking them
-# into the shared arm64 CDP image would bloat every arm64 pull (Graviton, Apple
-# Silicon, generic SBCs) and, worse, force NEKO_VIDEO_CODEC=h264 + mpph264enc
-# ranking on non-Rockchip arm64 where the VPU and device nodes do not exist,
-# breaking encode there. A separate image matches the per-SoC resolver design.
-FROM ghcr.io/jaylfc/taos-neko-cdp:latest
+# Built for the Rockchip VENDOR kernel (6.1.x-vendor-rk35xx) which exposes the
+# VPU via /dev/mpp_service (no V4L2). Shared publicly for the community (#624).
 
-# Rockchip MPP + RGA + GStreamer rkmpp plugin (mpph264enc).
-# NOTE (#624): these are NOT in Debian trixie or the Armbian-trixie repos. The
-# Pi (Debian trixie) only ships the rockchip KERNEL (linux-image-current-
-# rockchip64), not the multimedia userspace, so the plugin must be built from
-# source (MPP -> RGA -> gstreamer-rockchip) in a dedicated build stage. Until
-# that build lands, this RUN is a deliberate no-op (|| true) and the image
-# behaves exactly like the CDP image (software encode). The resolver flip
-# (DEFAULT_NEKO_RK3588_IMAGE -> this image) stays gated on a live Pi validation
-# that mpph264enc actually engages.
+# ---- stage 1: build the rockchip multimedia userspace --------------------
+FROM debian:trixie AS rkbuild
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        gstreamer1.0-rockchip librockchip-mpp1 librga2 \
-    && rm -rf /var/lib/apt/lists/* || true
+        git ca-certificates build-essential cmake meson ninja-build pkg-config \
+        libdrm-dev \
+        libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /src
+# MPP (Media Process Platform) — nyanmisaka's maintained fork builds cleanly.
+RUN git clone --depth=1 -b jellyfin-mpp https://github.com/nyanmisaka/mpp.git mpp \
+    && cmake -S mpp -B mpp/build -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release \
+         -DBUILD_SHARED_LIBS=ON -DBUILD_TEST=OFF \
+    && cmake --build mpp/build -j"$(nproc)" \
+    && cmake --install mpp/build
+# RGA (2D raster graphics accel).
+RUN git clone --depth=1 -b jellyfin-rga https://github.com/nyanmisaka/rk-mirrors.git rga \
+    && meson setup rga rga/build --prefix=/usr -Dlibdrm=false -Dlibrga_demo=false --buildtype=release \
+    && meson install -C rga/build
+# gstreamer-rockchip plugin (mpph264enc) — built against trixie GStreamer 1.26.
+RUN git clone --depth=1 https://github.com/JeffyCN/gstreamer-rockchip.git gst \
+    && meson setup gst gst/build --prefix=/usr --buildtype=release \
+    && meson install -C gst/build
 
-LABEL taos.app.id="neko-browser-rk3588" \
-      taos.streaming.encode="rkmpp" \
-      taos.hardware.soc="rk3588" \
-      taos.base="taos-neko-cdp"
-
-# Prefer the VPU encoder. Safe to bake here because this image only ever runs on
-# rk3588/rk3576 (the resolver guarantees it), where the VPU exists.
-ENV NEKO_VIDEO_CODEC=h264 \
-    GST_PLUGIN_FEATURE_RANK="mpph264enc:512"
+# ---- stage 2: layer onto the CDP image -----------------------------------
+FROM ghcr.io/jaylfc/taos-neko-cdp:latest
+COPY --from=rkbuild /usr/lib/librockchip_mpp.so* /usr/lib/aarch64-linux-gnu/
+COPY --from=rkbuild /usr/lib/librga.so* /usr/lib/aarch64-linux-gnu/
+COPY --from=rkbuild /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstrockchipmpp.so /usr/lib/aarch64-linux-gnu/gstreamer-1.0/
+RUN ldconfig
+LABEL taos.app.id="neko-browser-rk3588" taos.streaming.encode="rkmpp" \
+      taos.hardware.soc="rk3588" taos.base="taos-neko-cdp"
+ENV NEKO_VIDEO_CODEC=h264 GST_PLUGIN_FEATURE_RANK="mpph264enc:512"

--- a/app-catalog/streaming/neko-browser/Dockerfile.rk3588
+++ b/app-catalog/streaming/neko-browser/Dockerfile.rk3588
@@ -1,22 +1,40 @@
-# taOS Neko Chromium for RK3588 (Orange Pi 5 Plus) — HW decode + WebRTC encode via VPU.
-# Device nodes (/dev/mpp_service, /dev/dri, /dev/rga) are passed at `docker run`
-# by the host-tier resolver, not baked in. Software encode is the fallback when
-# this image/devices aren't available (see resolve_neko_image).
-# Multi-arch base (has a linux/arm64 variant — verified on the Pi). The old
-# `arm-chromium` tag does not exist.
-FROM ghcr.io/m1k1o/neko/chromium:latest
+# taOS Neko Chromium for RK3588 (Orange Pi 5 Plus) — CDP + VPU H.264 encode.
+#
+# SEPARATE, SoC-specific, arm64-only image. Built ON TOP of the taOS CDP image
+# so it inherits Chromium >=148 + the CDP DevTools enablement, then adds the
+# Rockchip MPP/RGA userspace + the GStreamer rkmpp plugin (mpph264enc) so WebRTC
+# encode runs on the VPU instead of the A76 cores. Generic arm64 and x86 nodes
+# keep using the plain CDP image (software encode); resolve_neko_image() picks
+# THIS image only when the SoC is rk3588/rk3576 and passes /dev/mpp_service,
+# /dev/dri, /dev/rga at docker run.
+#
+# Why a separate image (not one multi-arch image for every device): the Rockchip
+# MPP/RGA userspace and the mpph264enc rank boost are SoC-specific. Baking them
+# into the shared arm64 CDP image would bloat every arm64 pull (Graviton, Apple
+# Silicon, generic SBCs) and, worse, force NEKO_VIDEO_CODEC=h264 + mpph264enc
+# ranking on non-Rockchip arm64 where the VPU and device nodes do not exist,
+# breaking encode there. A separate image matches the per-SoC resolver design.
+FROM ghcr.io/jaylfc/taos-neko-cdp:latest
 
-# Rockchip MPP + RGA + Mali userspace for GStreamer rkmpp HW encode/decode.
+# Rockchip MPP + RGA + GStreamer rkmpp plugin (mpph264enc).
+# NOTE (#624): these are NOT in Debian trixie or the Armbian-trixie repos. The
+# Pi (Debian trixie) only ships the rockchip KERNEL (linux-image-current-
+# rockchip64), not the multimedia userspace, so the plugin must be built from
+# source (MPP -> RGA -> gstreamer-rockchip) in a dedicated build stage. Until
+# that build lands, this RUN is a deliberate no-op (|| true) and the image
+# behaves exactly like the CDP image (software encode). The resolver flip
+# (DEFAULT_NEKO_RK3588_IMAGE -> this image) stays gated on a live Pi validation
+# that mpph264enc actually engages.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        gstreamer1.0-rockchip \
-        librockchip-mpp1 \
-        librga2 \
+        gstreamer1.0-rockchip librockchip-mpp1 librga2 \
     && rm -rf /var/lib/apt/lists/* || true
 
-LABEL taos.app.id="neko-browser" \
+LABEL taos.app.id="neko-browser-rk3588" \
       taos.streaming.encode="rkmpp" \
-      taos.hardware.soc="rk3588"
+      taos.hardware.soc="rk3588" \
+      taos.base="taos-neko-cdp"
 
-# Prefer the VPU encoder; Neko reads its pipeline from env / its own config.
+# Prefer the VPU encoder. Safe to bake here because this image only ever runs on
+# rk3588/rk3576 (the resolver guarantees it), where the VPU exists.
 ENV NEKO_VIDEO_CODEC=h264 \
     GST_PLUGIN_FEATURE_RANK="mpph264enc:512"

--- a/app-catalog/streaming/neko-browser/Dockerfile.rk3588
+++ b/app-catalog/streaming/neko-browser/Dockerfile.rk3588
@@ -8,6 +8,7 @@
 
 # ---- stage 1: build the rockchip multimedia userspace --------------------
 FROM debian:trixie AS rkbuild
+ENV GIT_TERMINAL_PROMPT=0 LIBDIR=lib/aarch64-linux-gnu
 RUN apt-get update && apt-get install -y --no-install-recommends \
         git ca-certificates build-essential cmake meson ninja-build pkg-config \
         libdrm-dev \
@@ -16,25 +17,31 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /src
 # MPP (Media Process Platform) — nyanmisaka's maintained fork builds cleanly.
 RUN git clone --depth=1 -b jellyfin-mpp https://github.com/nyanmisaka/mpp.git mpp \
-    && cmake -S mpp -B mpp/build -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release \
-         -DBUILD_SHARED_LIBS=ON -DBUILD_TEST=OFF \
-    && cmake --build mpp/build -j"$(nproc)" \
-    && cmake --install mpp/build
+    && cmake -S mpp -B mpp/build -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_LIBDIR=$LIBDIR \
+         -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DBUILD_TEST=OFF \
+    && cmake --build mpp/build -j"$(nproc)" && cmake --install mpp/build
 # RGA (2D raster graphics accel).
 RUN git clone --depth=1 -b jellyfin-rga https://github.com/nyanmisaka/rk-mirrors.git rga \
-    && meson setup rga rga/build --prefix=/usr -Dlibdrm=false -Dlibrga_demo=false --buildtype=release \
+    && meson setup rga rga/build --prefix=/usr --libdir=$LIBDIR -Dlibdrm=false -Dlibrga_demo=false --buildtype=release \
     && meson install -C rga/build
-# gstreamer-rockchip plugin (mpph264enc) — built against trixie GStreamer 1.26.
-RUN git clone --depth=1 https://github.com/JeffyCN/gstreamer-rockchip.git gst \
-    && meson setup gst gst/build --prefix=/usr --buildtype=release \
+# gstreamer-rockchip plugin (mpph264enc) — BoxCloud streaming fork, against 1.26.
+RUN git clone --depth=1 https://github.com/BoxCloudIRL/gstreamer-rockchip.git gst \
+    && meson setup gst gst/build --prefix=/usr --libdir=$LIBDIR --buildtype=release \
     && meson install -C gst/build
+# Collect outputs into a staging dir (tolerant of exact naming); logged for debug.
+RUN mkdir -p /stage/gst \
+    && cp -a /usr/lib/aarch64-linux-gnu/librockchip_mpp.so* /stage/ 2>/dev/null || true \
+    && cp -a /usr/lib/aarch64-linux-gnu/librockchip_vpu.so* /stage/ 2>/dev/null || true \
+    && cp -a /usr/lib/aarch64-linux-gnu/librga.so* /stage/ 2>/dev/null || true \
+    && cp -a /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstrockchip*.so* /stage/gst/ 2>/dev/null || true \
+    && echo "=== staged libs ===" && ls -la /stage /stage/gst
 
 # ---- stage 2: layer onto the CDP image -----------------------------------
 FROM ghcr.io/jaylfc/taos-neko-cdp:latest
-COPY --from=rkbuild /usr/lib/librockchip_mpp.so* /usr/lib/aarch64-linux-gnu/
-COPY --from=rkbuild /usr/lib/librga.so* /usr/lib/aarch64-linux-gnu/
-COPY --from=rkbuild /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstrockchipmpp.so /usr/lib/aarch64-linux-gnu/gstreamer-1.0/
-RUN ldconfig
+COPY --from=rkbuild /stage/ /tmp/rkstage/
+RUN cp -a /tmp/rkstage/*.so* /usr/lib/aarch64-linux-gnu/ 2>/dev/null || true \
+    && cp -a /tmp/rkstage/gst/*.so* /usr/lib/aarch64-linux-gnu/gstreamer-1.0/ 2>/dev/null || true \
+    && rm -rf /tmp/rkstage && ldconfig
 LABEL taos.app.id="neko-browser-rk3588" taos.streaming.encode="rkmpp" \
       taos.hardware.soc="rk3588" taos.base="taos-neko-cdp"
 ENV NEKO_VIDEO_CODEC=h264 GST_PLUGIN_FEATURE_RANK="mpph264enc:512"


### PR DESCRIPTION
Part of #624 / task #125.

Decision (Jay): keep a SEPARATE `taos-neko-rk3588` image rather than one image for all devices. The Rockchip MPP/RGA userspace and the `mpph264enc` rank boost are SoC-specific; baking them into the shared arm64 CDP image would bloat every arm64 pull and force H264/mpph264enc onto non-Rockchip arm64 where the VPU and device nodes don't exist, breaking encode there. The resolver already selects per-SoC, so a separate image drops in.

This PR restructures `Dockerfile.rk3588` to base off the CDP image (so the eventual resolver flip preserves Chromium 148 + CDP) and documents the packaging reality. No functional change: rk3588 still resolves to the CDP image (software encode) until the from-source rkmpp layer is validated.

See the issue for the packaging findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container configuration to leverage RK3588-specific hardware accelerators for improved H.264 WebRTC streaming and video encoding performance.
  * Refreshed base image dependencies to optimize compatibility with RK3588/RK3576 VPU hardware.
  * Enhanced documentation with clearer guidance on hardware-specific setup requirements and runtime constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->