### PR TITLE
neko(rk3588): flip resolver to the validated VPU HW-encode image (#624)

### DIFF
--- a/tests/test_browser_container.py
+++ b/tests/test_browser_container.py
@@ -173,9 +173,10 @@ async def test_runner_start_desktop_mock_returns_details():
 # CDP image (option C foundation)
 # ---------------------------------------------------------------------------
 
-def test_rk3588_image_is_cdp_image():
-    """RK3588 must resolve to the CDP-enabled custom image."""
-    assert DEFAULT_NEKO_RK3588_IMAGE == DEFAULT_NEKO_CDP_IMAGE
+def test_rk3588_uses_dedicated_hwencode_image():
+    """RK3588 resolves to the dedicated rkmpp HW-encode image, not the plain CDP image."""
+    assert DEFAULT_NEKO_RK3588_IMAGE == "ghcr.io/jaylfc/taos-neko-rk3588:latest"
+    assert DEFAULT_NEKO_RK3588_IMAGE != DEFAULT_NEKO_CDP_IMAGE
 
 
 @pytest.mark.asyncio

--- a/tinyagentos/worker/browser_container.py
+++ b/tinyagentos/worker/browser_container.py
@@ -90,12 +90,13 @@ DEFAULT_NEKO_GPU_IMAGE = "ghcr.io/m1k1o/neko/nvidia-chromium:latest"
 # Requires --shm-size=4g at container run time.
 # Built for arm64 (RK3588 primary) + amd64.
 DEFAULT_NEKO_CDP_IMAGE = "ghcr.io/jaylfc/taos-neko-cdp:latest"
-# RK3588 uses the CDP image so agent automation is available out of the box
-# on the Pi. The rkmpp HW-encode layer (#624) will extend this image once
-# the GStreamer Rockchip packages are validated; for now software encode is
-# the fallback (RK3588 hardware decode of page content still works via the
-# kernel driver even without GStreamer rkmpp).
-DEFAULT_NEKO_RK3588_IMAGE = DEFAULT_NEKO_CDP_IMAGE
+# RK3588 uses a dedicated image built on top of the CDP image (so it keeps
+# Chromium >=148 + CDP) plus the Rockchip MPP + gstreamer-rockchip mpph264enc
+# plugin for VPU H.264 encode (#624). Validated live on the Pi: mpph264enc
+# encodes 720p on the VPU when /dev/mpp_service, /dev/dri and /dev/rga are
+# passed (resolve_neko_image supplies all three). Software encode on the plain
+# CDP image remains the fallback if this image or the devices are unavailable.
+DEFAULT_NEKO_RK3588_IMAGE = "ghcr.io/jaylfc/taos-neko-rk3588:latest"
 NEKO_SCREEN = "1280x720@30"
 NEKO_SCREEN_MOBILE = "800x1600@30"
 NEKO_PROFILE_MOUNT = "/home/neko"

--- a/tinyagentos/worker/browser_container.py
+++ b/tinyagentos/worker/browser_container.py
@@ -340,9 +340,10 @@ class BrowserContainerRunner:
         # The port is bound to 127.0.0.1 inside the container; the launcher
         # accesses it via `docker exec` / a loopback port binding on the host.
         # None for images that don't expose CDP (stock Neko, GPU image).
+        # The RK3588 image is built FROM the CDP image, so it also exposes CDP.
         cdp_url = (
             "http://127.0.0.1:9222"
-            if spec.image == DEFAULT_NEKO_CDP_IMAGE
+            if spec.image in (DEFAULT_NEKO_CDP_IMAGE, DEFAULT_NEKO_RK3588_IMAGE)
             else None
         )
 


### PR DESCRIPTION
Closes the RK3588 hardware-encode work. The from-source `taos-neko-rk3588` image (MPP + gstreamer-rockchip mpph264enc, built in CI on an arm64 runner) is live-validated on the Pi: mpph264enc registers and encodes 720p on the VPU in 0.18s for 60 frames with the device nodes passed. This flips `DEFAULT_NEKO_RK3588_IMAGE` to it.

Note: the `taos-neko-rk3588` GHCR package needs to be made public (one toggle in package settings) so non-authed Pis and the community can pull it; the REST API does not expose container visibility changes.