### PR TITLE
feat(cluster): capability map store (foundation, #897)

### DIFF
--- a/tests/test_capability_map.py
+++ b/tests/test_capability_map.py
@@ -101,3 +101,19 @@ async def test_prune_stale(tmp_path):
     assert await s.get("old") is None
     assert await s.get("fresh") is not None
     await s.close()
+
+
+@pytest.mark.asyncio
+async def test_upsert_preserves_explicit_zero_last_seen(tmp_path):
+    s = await _store(tmp_path)
+    out = await s.upsert(_node(last_seen=0))
+    assert out["last_seen"] == 0
+    await s.close()
+
+
+@pytest.mark.asyncio
+async def test_upsert_requires_node_id(tmp_path):
+    s = await _store(tmp_path)
+    with pytest.raises(ValueError):
+        await s.upsert({"hostname": "x"})
+    await s.close()

--- a/tests/test_capability_map.py
+++ b/tests/test_capability_map.py
@@ -1,0 +1,103 @@
+import time
+
+import pytest
+
+from tinyagentos.cluster.capability_map import CapabilityMap
+
+
+async def _store(tmp_path):
+    s = CapabilityMap(tmp_path / "cap.db")
+    await s.init()
+    return s
+
+
+def _node(node_id="n1", status="online", last_seen=1000):
+    return {
+        "node_id": node_id,
+        "hostname": f"host-{node_id}",
+        "cpu": {"arch": "aarch64", "cores": 8, "soc": "rk3588"},
+        "ram_mb": 16384,
+        "gpu": {"type": "mali", "vram_mb": 0, "cuda": False, "vulkan": True},
+        "npu": {"type": "rknpu", "tops": 6},
+        "status": status,
+        "last_seen": last_seen,
+    }
+
+
+@pytest.mark.asyncio
+async def test_upsert_get_roundtrip(tmp_path):
+    s = await _store(tmp_path)
+    out = await s.upsert(_node())
+    assert out["node_id"] == "n1"
+    assert out["cpu"]["soc"] == "rk3588"
+    got = await s.get("n1")
+    assert got["gpu"]["vulkan"] is True
+    assert got["npu"]["tops"] == 6
+    assert got["ram_mb"] == 16384
+    await s.close()
+
+
+@pytest.mark.asyncio
+async def test_upsert_updates_not_duplicates(tmp_path):
+    s = await _store(tmp_path)
+    await s.upsert(_node(status="online"))
+    await s.upsert(_node(status="draining"))
+    assert (await s.get("n1"))["status"] == "draining"
+    assert len(await s.list()) == 1
+    await s.close()
+
+
+@pytest.mark.asyncio
+async def test_list_status_filter(tmp_path):
+    s = await _store(tmp_path)
+    await s.upsert(_node("n1", "online"))
+    await s.upsert(_node("n2", "offline"))
+    assert {n["node_id"] for n in await s.list(status="online")} == {"n1"}
+    assert len(await s.list()) == 2
+    await s.close()
+
+
+@pytest.mark.asyncio
+async def test_set_status(tmp_path):
+    s = await _store(tmp_path)
+    await s.upsert(_node())
+    out = await s.set_status("n1", "draining")
+    assert out["status"] == "draining"
+    assert await s.set_status("missing", "online") is None
+    await s.close()
+
+
+@pytest.mark.asyncio
+async def test_set_status_rejects_invalid(tmp_path):
+    s = await _store(tmp_path)
+    await s.upsert(_node())
+    with pytest.raises(ValueError):
+        await s.set_status("n1", "bogus")
+    await s.close()
+
+
+@pytest.mark.asyncio
+async def test_upsert_rejects_invalid_status(tmp_path):
+    s = await _store(tmp_path)
+    with pytest.raises(ValueError):
+        await s.upsert(_node(status="bogus"))
+    await s.close()
+
+
+@pytest.mark.asyncio
+async def test_get_unknown_returns_none(tmp_path):
+    s = await _store(tmp_path)
+    assert await s.get("nope") is None
+    await s.close()
+
+
+@pytest.mark.asyncio
+async def test_prune_stale(tmp_path):
+    s = await _store(tmp_path)
+    await s.upsert(_node("old", "online", last_seen=1000))
+    await s.upsert(_node("fresh", "online", last_seen=int(time.time())))
+    pruned = await s.prune_stale(older_than_s=3600)
+    assert pruned == 1
+    assert await s.get("old") is None
+    assert await s.get("fresh") is not None
+    await s.close()

--- a/tinyagentos/cluster/capability_map.py
+++ b/tinyagentos/cluster/capability_map.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+import time
+
+from tinyagentos.base_store import BaseStore
+
+CAPABILITY_MAP_SCHEMA = """
+CREATE TABLE IF NOT EXISTS capability_map (
+    node_id TEXT PRIMARY KEY,
+    hostname TEXT NOT NULL DEFAULT '',
+    cpu TEXT NOT NULL DEFAULT '{}',
+    ram_mb INTEGER NOT NULL DEFAULT 0,
+    gpu TEXT NOT NULL DEFAULT '{}',
+    npu TEXT NOT NULL DEFAULT '{}',
+    status TEXT NOT NULL DEFAULT 'offline',
+    last_seen INTEGER NOT NULL DEFAULT 0
+);
+"""
+
+VALID_STATUS = {"online", "offline", "draining"}
+_COLS = "node_id, hostname, cpu, ram_mb, gpu, npu, status, last_seen"
+
+
+def _row(r) -> dict:
+    return {
+        "node_id": r[0],
+        "hostname": r[1],
+        "cpu": json.loads(r[2] or "{}"),
+        "ram_mb": r[3],
+        "gpu": json.loads(r[4] or "{}"),
+        "npu": json.loads(r[5] or "{}"),
+        "status": r[6],
+        "last_seen": r[7],
+    }
+
+
+class CapabilityMap(BaseStore):
+    """Per-node hardware capability map for the cluster.
+
+    Records each node's CPU/GPU/NPU/RAM plus a live status (online/offline/
+    draining) and last_seen heartbeat. The foundation the scheduler and
+    placement logic read from. CPU/GPU/NPU are stored as JSON columns so the
+    shapes match HardwareProfile without a rigid schema.
+    """
+
+    SCHEMA = CAPABILITY_MAP_SCHEMA
+
+    async def upsert(self, node: dict) -> dict:
+        node_id = node["node_id"]
+        status = node.get("status", "offline")
+        if status not in VALID_STATUS:
+            raise ValueError(f"invalid status: {status!r}")
+        last_seen = int(node.get("last_seen") or time.time())
+        await self._db.execute(
+            f"""INSERT INTO capability_map ({_COLS})
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(node_id) DO UPDATE SET
+                    hostname=excluded.hostname, cpu=excluded.cpu,
+                    ram_mb=excluded.ram_mb, gpu=excluded.gpu, npu=excluded.npu,
+                    status=excluded.status, last_seen=excluded.last_seen""",
+            (
+                node_id, node.get("hostname", ""), json.dumps(node.get("cpu", {})),
+                int(node.get("ram_mb", 0)), json.dumps(node.get("gpu", {})),
+                json.dumps(node.get("npu", {})), status, last_seen,
+            ),
+        )
+        await self._db.commit()
+        return await self.get(node_id)
+
+    async def get(self, node_id: str) -> dict | None:
+        async with self._db.execute(
+            f"SELECT {_COLS} FROM capability_map WHERE node_id = ?", (node_id,)
+        ) as cur:
+            r = await cur.fetchone()
+        return _row(r) if r else None
+
+    async def list(self, status: str | None = None) -> list[dict]:
+        sql = f"SELECT {_COLS} FROM capability_map"
+        params: list = []
+        if status is not None:
+            sql += " WHERE status = ?"
+            params.append(status)
+        sql += " ORDER BY node_id ASC"
+        async with self._db.execute(sql, params) as cur:
+            rows = await cur.fetchall()
+        return [_row(r) for r in rows]
+
+    async def set_status(self, node_id: str, status: str) -> dict | None:
+        if status not in VALID_STATUS:
+            raise ValueError(f"invalid status: {status!r}")
+        if await self.get(node_id) is None:
+            return None
+        await self._db.execute(
+            "UPDATE capability_map SET status = ? WHERE node_id = ?", (status, node_id)
+        )
+        await self._db.commit()
+        return await self.get(node_id)
+
+    async def prune_stale(self, older_than_s: int) -> int:
+        cutoff = int(time.time()) - older_than_s
+        async with self._db.execute(
+            "DELETE FROM capability_map WHERE last_seen < ?", (cutoff,)
+        ) as cur:
+            count = cur.rowcount
+        await self._db.commit()
+        return count

--- a/tinyagentos/cluster/capability_map.py
+++ b/tinyagentos/cluster/capability_map.py
@@ -47,11 +47,14 @@ class CapabilityMap(BaseStore):
     SCHEMA = CAPABILITY_MAP_SCHEMA
 
     async def upsert(self, node: dict) -> dict:
-        node_id = node["node_id"]
+        node_id = node.get("node_id")
+        if not node_id:
+            raise ValueError("node requires a non-empty node_id")
         status = node.get("status", "offline")
         if status not in VALID_STATUS:
             raise ValueError(f"invalid status: {status!r}")
-        last_seen = int(node.get("last_seen") or time.time())
+        ls = node.get("last_seen")
+        last_seen = int(ls) if ls is not None else int(time.time())
         await self._db.execute(
             f"""INSERT INTO capability_map ({_COLS})
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)


### PR DESCRIPTION
First slice of the cluster/scheduler epic. Per-node hardware capability map (CPU/GPU/NPU/RAM + online/offline/draining status + last_seen) as a BaseStore-backed store: upsert/get/list(status)/set_status/prune_stale. CPU/GPU/NPU stored as JSON columns to match HardwareProfile shapes. 8 tests green.

Built by @taOS-dev: the free owl lane could not produce this (see the note in the PR body / STATUS) -- it handles test cards but returns empty branches on net-new feature modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CapabilityMap class with persistent SQLite storage for node hardware capabilities (CPU, GPU, NPU, RAM).
  * Supports upsert operations, retrieval by node ID, filtering by status, status updates, and pruning stale entries based on timestamps.
  * Includes validation for status values.

* **Tests**
  * Added comprehensive test coverage for CapabilityMap operations and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->