### PR TITLE
test: add vitest tests for use-installed-optional-apps hook

### DIFF
--- a/desktop/src/hooks/use-installed-optional-apps.test.ts
+++ b/desktop/src/hooks/use-installed-optional-apps.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useInstalledOptionalApps } from "./use-installed-optional-apps";
+import { onAppEvent, emitAppEvent, APP_OPTIONAL_CHANGED } from "@/lib/app-event-bus";
+
+describe("useInstalledOptionalApps", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns an empty set before the fetch resolves", () => {
+    let resolveJson: (value: { installed: string[] }) => void;
+    (fetch as ReturnType<typeof vi.fn>).mockReturnValueOnce(
+      new Promise(() => { /* pending */ }),
+    );
+
+    const { result } = renderHook(() => useInstalledOptionalApps());
+    expect(result.current).toBeInstanceOf(Set);
+    expect(result.current.size).toBe(0);
+  });
+
+  it("fetches installed optional apps and returns them as a Set", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ installed: ["reddit", "youtube"] }),
+    });
+
+    const { result } = renderHook(() => useInstalledOptionalApps());
+
+    await waitFor(() => expect(result.current.size).toBe(2));
+    expect(result.current.has("reddit")).toBe(true);
+    expect(result.current.has("youtube")).toBe(true);
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/apps/optional/installed",
+      expect.objectContaining({ headers: { Accept: "application/json" } }),
+    );
+  });
+
+  it("returns an empty set when the response is not ok", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+    });
+
+    const { result } = renderHook(() => useInstalledOptionalApps());
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalled();
+    });
+    expect(result.current).toBeInstanceOf(Set);
+    expect(result.current.size).toBe(0);
+  });
+
+  it("returns an empty set when fetch rejects", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error("network failure"),
+    );
+
+    const { result } = renderHook(() => useInstalledOptionalApps());
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalled();
+    });
+    expect(result.current).toBeInstanceOf(Set);
+    expect(result.current.size).toBe(0);
+  });
+
+  it("re-fetches when APP_OPTIONAL_CHANGED event fires", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ installed: ["reddit"] }),
+    });
+
+    const { result } = renderHook(() => useInstalledOptionalApps());
+
+    await waitFor(() => expect(result.current.has("reddit")).toBe(true));
+
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ installed: ["reddit", "github", "x"] }),
+    });
+
+    emitAppEvent(APP_OPTIONAL_CHANGED, "github");
+
+    await waitFor(() => expect(result.current.size).toBe(3));
+    expect(result.current.has("github")).toBe(true);
+    expect(result.current.has("x")).toBe(true);
+  });
+
+  it("returns an empty set when the response has no installed field", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({}),
+    });
+
+    const { result } = renderHook(() => useInstalledOptionalApps());
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalled();
+    });
+    expect(result.current).toBeInstanceOf(Set);
+    expect(result.current.size).toBe(0);
+  });
+});


### PR DESCRIPTION
Autonomous build of board card tsk-l4doto.



Files:
 .../src/hooks/use-installed-optional-apps.test.ts  | 108 +++++++++++++++++++++
 1 file changed, 108 insertions(+)

----
## Summary by Gitar

- **Testing:**
  - Added `use-installed-optional-apps.test.ts` to provide comprehensive unit test coverage for the `useInstalledOptionalApps` hook.
  - Included test scenarios for initial loading states, successful API response handling, error handling, and reactive re-fetching triggered by `APP_OPTIONAL_CHANGED` events.

<sub>This will update automatically on new commits.</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for the installed optional apps functionality, verifying correct behavior during data fetching, error handling, and event-driven updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->