### PR TITLE
test: add vitest suite for theme-store actions and state transitions

### DIFF
--- a/desktop/src/stores/theme-store.test.ts
+++ b/desktop/src/stores/theme-store.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useThemeStore } from "./theme-store";
+
+const reset = () => {
+  useThemeStore.setState({
+    wallpaperId: "graphite",
+    wallpaperImage: "url('/static/wallpaper-graphite.png')",
+    wallpaperMobileImage: "url('/static/wallpaper-graphite-mobile.png')",
+    wallpaperFallback: "#141415",
+    wallpaperLightImage: "url('/static/wallpaper-graphite-light.png')",
+    wallpaperLightMobileImage: "url('/static/wallpaper-graphite-light-mobile.png')",
+    wallpaperLightFallback: "#eef0f3",
+    wallpaperKind: "image",
+    wallpaperComponent: null,
+    wallpaperOverlayText: null,
+    showOverlayText: true,
+    wallpaperParams: { density: 200, speed: 0.5, glow: 6 },
+    showDesktopIcons: true,
+    reduceEffects: false,
+    structure: {},
+    effects: [],
+    activeThemeId: "default",
+    wallpaperByTheme: {},
+    themeDefaultWallpaper: {},
+    wallpaperIdByTheme: {},
+  });
+};
+
+describe("theme-store", () => {
+  beforeEach(() => {
+    reset();
+    localStorage.clear();
+  });
+
+  it("setWallpaper updates wallpaper fields for a known wallpaper id", () => {
+    useThemeStore.getState().setWallpaper("neural-live");
+    const s = useThemeStore.getState();
+    expect(s.wallpaperId).toBe("neural-live");
+    expect(s.wallpaperImage).toBe("");
+    expect(s.wallpaperKind).toBe("animated");
+    expect(s.wallpaperComponent).toBe("particles");
+    expect(s.wallpaperOverlayText).toBe("taOS");
+    expect(s.wallpaperFallback).toBe("#141415");
+  });
+
+  it("setWallpaper records the choice under the active theme for later restore", () => {
+    useThemeStore.setState({ activeThemeId: "custom-a" });
+    useThemeStore.getState().setWallpaper("aurora");
+    expect(useThemeStore.getState().wallpaperIdByTheme["custom-a"]).toBe("aurora");
+  });
+
+  it("setWallpaper ignores an unknown wallpaper id and leaves state untouched", () => {
+    const before = useThemeStore.getState();
+    useThemeStore.getState().setWallpaper("does-not-exist");
+    const after = useThemeStore.getState();
+    expect(after.wallpaperId).toBe(before.wallpaperId);
+    expect(after.wallpaperImage).toBe(before.wallpaperImage);
+    expect(after.wallpaperFallback).toBe(before.wallpaperFallback);
+  });
+
+  it("toggleOverlayText flips the flag and persists the pref", () => {
+    const initial = useThemeStore.getState().showOverlayText;
+    useThemeStore.getState().toggleOverlayText();
+    expect(useThemeStore.getState().showOverlayText).toBe(!initial);
+    expect(localStorage.getItem("taos-wallpaper-slogan")).toBe(initial ? "off" : "on");
+
+    useThemeStore.getState().toggleOverlayText();
+    expect(useThemeStore.getState().showOverlayText).toBe(initial);
+    expect(localStorage.getItem("taos-wallpaper-slogan")).toBe(initial ? "on" : "off");
+  });
+
+  it("setWallpaperParam updates only the requested key and persists all params", () => {
+    useThemeStore.getState().setWallpaperParam("density", 50);
+    const params = useThemeStore.getState().wallpaperParams;
+    expect(params.density).toBe(50);
+    expect(params.speed).toBe(0.5);
+    expect(params.glow).toBe(6);
+    expect(JSON.parse(localStorage.getItem("taos-wallpaper-params")!)).toEqual({
+      density: 50,
+      speed: 0.5,
+      glow: 6,
+    });
+  });
+
+  it("toggleDesktopIcons flips the boolean", () => {
+    const before = useThemeStore.getState().showDesktopIcons;
+    useThemeStore.getState().toggleDesktopIcons();
+    expect(useThemeStore.getState().showDesktopIcons).toBe(!before);
+    useThemeStore.getState().toggleDesktopIcons();
+    expect(useThemeStore.getState().showDesktopIcons).toBe(before);
+  });
+
+  it("setReduceEffects sets the flag and persists the pref", () => {
+    useThemeStore.getState().setReduceEffects(true);
+    expect(useThemeStore.getState().reduceEffects).toBe(true);
+    expect(localStorage.getItem("taos-reduce-effects")).toBe("on");
+
+    useThemeStore.getState().setReduceEffects(false);
+    expect(useThemeStore.getState().reduceEffects).toBe(false);
+    expect(localStorage.getItem("taos-reduce-effects")).toBe("off");
+  });
+
+  it("getWallpapers returns the full wallpaper catalogue with stable ids", () => {
+    const list = useThemeStore.getState().getWallpapers();
+    expect(list.length).toBeGreaterThan(0);
+    const ids = list.map((w) => w.id);
+    expect(ids).toContain("graphite");
+    expect(ids).toContain("neural-live");
+    expect(ids).toContain("default");
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("reset: showDesktopIcons defaults to true after explicit false then reset", () => {
+    useThemeStore.getState().toggleDesktopIcons();
+    expect(useThemeStore.getState().showDesktopIcons).toBe(false);
+    reset();
+    expect(useThemeStore.getState().showDesktopIcons).toBe(true);
+  });
+});


### PR DESCRIPTION
Autonomous build of board card tsk-h6bapx.



Files:
 desktop/src/stores/theme-store.test.ts | 119 +++++++++++++++++++++++++++++++++
 1 file changed, 119 insertions(+)