### PR TITLE
feat(notifications): archive on dismiss, add History view

### DIFF
--- a/desktop/src/components/NotificationCentre.test.tsx
+++ b/desktop/src/components/NotificationCentre.test.tsx
@@ -9,6 +9,8 @@ const closeCentre = vi.fn();
 const markAllRead = vi.fn();
 const clearAll = vi.fn();
 const dismiss = vi.fn();
+const archivedNotifications = vi.fn(() => []);
+const clearArchived = vi.fn();
 
 let notifications: Notification[] = [];
 
@@ -21,6 +23,8 @@ vi.mock("@/stores/notification-store", () => ({
     markAllRead,
     clearAll,
     dismiss,
+    archivedNotifications,
+    clearArchived,
   }),
 }));
 

--- a/desktop/src/components/NotificationCentre.tsx
+++ b/desktop/src/components/NotificationCentre.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { X, Bell, CheckCheck, Trash2 } from "lucide-react";
+import { X, Bell, CheckCheck, Trash2, History } from "lucide-react";
 import { useNotificationStore, type Notification } from "@/stores/notification-store";
 import { useProcessStore } from "@/stores/process-store";
 import { getApp } from "@/registry/app-registry";
@@ -16,10 +16,66 @@ function formatTime(ts: number): string {
   return `${Math.floor(delta / 86400_000)}d ago`;
 }
 
+function NotificationItem({
+  n,
+  onDismiss,
+  onItemClick,
+}: {
+  n: Notification;
+  onDismiss: (id: string) => void;
+  onItemClick: (n: Notification) => void;
+}) {
+  return (
+    <button
+      onClick={() => onItemClick(n)}
+      className={`w-full text-left px-4 py-3 border-b border-white/5 hover:bg-white/5 transition-colors ${!n.read ? "bg-accent/5" : ""} ${n.action ? "cursor-pointer" : ""}`}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            {!n.read && <div className="w-1.5 h-1.5 rounded-full bg-accent shrink-0" />}
+            <span className="text-xs font-medium text-shell-text truncate">{n.title}</span>
+          </div>
+          {n.body && <p className="text-xs text-shell-text-secondary mt-1 line-clamp-2">{n.body}</p>}
+          <div className="flex items-center gap-2 mt-1">
+            <span className="text-[10px] text-shell-text-tertiary">{formatTime(n.timestamp)}</span>
+            <span className="text-[10px] text-shell-text-tertiary">.</span>
+            <span className="text-[10px] text-shell-text-tertiary">{n.source}</span>
+          </div>
+        </div>
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onDismiss(n.id);
+          }}
+          className="p-0.5 rounded hover:bg-white/10 shrink-0"
+          aria-label={`Dismiss: ${n.title}`}
+        >
+          <X size={12} className="text-shell-text-tertiary" />
+        </button>
+      </div>
+    </button>
+  );
+}
+
 export function NotificationCentre() {
-  const { notifications, centreOpen, closeCentre, markRead, markAllRead, clearAll, dismiss } = useNotificationStore();
+  const {
+    notifications,
+    centreOpen,
+    closeCentre,
+    markRead,
+    markAllRead,
+    clearAll,
+    dismiss,
+    archivedNotifications,
+    clearArchived,
+  } = useNotificationStore();
   const openWindow = useProcessStore((s) => s.openWindow);
   const [checklistDismissed, setChecklistDismissed] = useState(false);
+  const [tab, setTab] = useState<"inbox" | "history">("inbox");
+
+  const active = notifications.filter((n) => !n.archived);
+  const archived = archivedNotifications();
 
   // Optimistic local mark-read, plus a best-effort backend write for server
   // items so the read state persists across reloads. Network never blocks the UI.
@@ -87,7 +143,7 @@ export function NotificationCentre() {
             <span className="text-sm font-medium text-shell-text">Notifications</span>
           </div>
           <div className="flex items-center gap-1">
-            {notifications.length > 0 && (
+            {tab === "inbox" && active.length > 0 && (
               <>
                 <button onClick={handleMarkAllRead} className="p-1.5 rounded hover:bg-white/5" title="Mark all read">
                   <CheckCheck size={14} className="text-shell-text-tertiary" />
@@ -97,55 +153,86 @@ export function NotificationCentre() {
                 </button>
               </>
             )}
+            {tab === "history" && archived.length > 0 && (
+              <button onClick={clearArchived} className="p-1.5 rounded hover:bg-white/5" title="Clear history">
+                <Trash2 size={14} className="text-shell-text-tertiary" />
+              </button>
+            )}
             <button onClick={closeCentre} className="p-1.5 rounded hover:bg-white/5" aria-label="Close notifications">
               <X size={14} className="text-shell-text-tertiary" />
             </button>
           </div>
         </div>
 
+        {/* Tabs */}
+        <div className="flex border-b border-white/10">
+          <button
+            onClick={() => setTab("inbox")}
+            className={`flex-1 px-4 py-2 text-xs font-medium transition-colors ${tab === "inbox" ? "text-accent border-b-2 border-accent" : "text-shell-text-tertiary hover:text-shell-text"}`}
+          >
+            Inbox{active.length > 0 ? ` (${active.length})` : ""}
+          </button>
+          <button
+            onClick={() => setTab("history")}
+            className={`flex-1 px-4 py-2 text-xs font-medium transition-colors flex items-center justify-center gap-1 ${tab === "history" ? "text-accent border-b-2 border-accent" : "text-shell-text-tertiary hover:text-shell-text"}`}
+          >
+            <History size={12} />
+            History{archived.length > 0 ? ` (${archived.length})` : ""}
+          </button>
+        </div>
+
         {/* List */}
         <div className="flex-1 overflow-y-auto">
-          {!checklistDismissed && (
-            <SetupChecklist onDismissed={() => setChecklistDismissed(true)} />
+          {tab === "inbox" && (
+            <>
+              {!checklistDismissed && (
+                <SetupChecklist onDismissed={() => setChecklistDismissed(true)} />
+              )}
+              {active.length === 0 ? (
+                <div className="px-4 py-12 text-center">
+                  <Bell size={24} className="mx-auto text-shell-text-tertiary mb-2" />
+                  <p className="text-xs text-shell-text-tertiary">No notifications</p>
+                </div>
+              ) : (
+                active.map((n) => (
+                  <NotificationItem
+                    key={n.id}
+                    n={n}
+                    onDismiss={dismiss}
+                    onItemClick={handleItemClick}
+                  />
+                ))
+              )}
+            </>
           )}
-          {notifications.length === 0 ? (
-            <div className="px-4 py-12 text-center">
-              <Bell size={24} className="mx-auto text-shell-text-tertiary mb-2" />
-              <p className="text-xs text-shell-text-tertiary">No notifications</p>
-            </div>
-          ) : (
-            notifications.map((n) => (
-              <button
-                key={n.id}
-                onClick={() => handleItemClick(n)}
-                className={`w-full text-left px-4 py-3 border-b border-white/5 hover:bg-white/5 transition-colors ${!n.read ? "bg-accent/5" : ""} ${n.action ? "cursor-pointer" : ""}`}
-              >
-                <div className="flex items-start justify-between gap-2">
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-2">
-                      {!n.read && <div className="w-1.5 h-1.5 rounded-full bg-accent shrink-0" />}
-                      <span className="text-xs font-medium text-shell-text truncate">{n.title}</span>
-                    </div>
-                    {n.body && <p className="text-xs text-shell-text-secondary mt-1 line-clamp-2">{n.body}</p>}
-                    <div className="flex items-center gap-2 mt-1">
-                      <span className="text-[10px] text-shell-text-tertiary">{formatTime(n.timestamp)}</span>
-                      <span className="text-[10px] text-shell-text-tertiary">·</span>
-                      <span className="text-[10px] text-shell-text-tertiary">{n.source}</span>
+          {tab === "history" && (
+            <>
+              {archived.length === 0 ? (
+                <div className="px-4 py-12 text-center">
+                  <History size={24} className="mx-auto text-shell-text-tertiary mb-2" />
+                  <p className="text-xs text-shell-text-tertiary">No archived notifications</p>
+                </div>
+              ) : (
+                archived.map((n) => (
+                  <div
+                    key={n.id}
+                    className="w-full text-left px-4 py-3 border-b border-white/5"
+                  >
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="min-w-0 flex-1">
+                        <span className="text-xs font-medium text-shell-text truncate">{n.title}</span>
+                        {n.body && <p className="text-xs text-shell-text-secondary mt-1 line-clamp-2">{n.body}</p>}
+                        <div className="flex items-center gap-2 mt-1">
+                          <span className="text-[10px] text-shell-text-tertiary">{formatTime(n.timestamp)}</span>
+                          <span className="text-[10px] text-shell-text-tertiary">.</span>
+                          <span className="text-[10px] text-shell-text-tertiary">{n.source}</span>
+                        </div>
+                      </div>
                     </div>
                   </div>
-                  <button
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      dismiss(n.id);
-                    }}
-                    className="p-0.5 rounded hover:bg-white/10 shrink-0"
-                    aria-label={`Dismiss: ${n.title}`}
-                  >
-                    <X size={12} className="text-shell-text-tertiary" />
-                  </button>
-                </div>
-              </button>
-            ))
+                ))
+              )}
+            </>
           )}
         </div>
       </div>

--- a/desktop/src/components/NotificationToast.test.tsx
+++ b/desktop/src/components/NotificationToast.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import { NotificationToasts } from "./NotificationToast";
 
 const mockDismiss = vi.fn();
@@ -63,5 +63,31 @@ describe("NotificationToasts", () => {
     render(<NotificationToasts />);
     fireEvent.click(screen.getByRole("button", { name: /dismiss notification/i }));
     await waitFor(() => expect(mockDismiss).toHaveBeenCalledWith("test-2"));
+  });
+
+  it("auto-expires the toast after 5s without archiving it", () => {
+    vi.useFakeTimers();
+    try {
+      mockNotifications.length = 0;
+      mockNotifications.push({
+        id: "test-3",
+        source: "system",
+        title: "Synced",
+        body: "Your files are up to date.",
+        level: "success",
+        read: false,
+        timestamp: Date.now(),
+      });
+      mockDismiss.mockClear();
+      render(<NotificationToasts />);
+      expect(screen.getByText("Synced")).toBeInTheDocument();
+      // Toast vanishes from view once the 5s timer fires...
+      act(() => vi.advanceTimersByTime(5000));
+      expect(screen.queryByText("Synced")).not.toBeInTheDocument();
+      // ...but auto-expiry must never archive (dismiss is the explicit action).
+      expect(mockDismiss).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/desktop/src/components/NotificationToast.tsx
+++ b/desktop/src/components/NotificationToast.tsx
@@ -332,7 +332,7 @@ export function NotificationToasts() {
   const byId = new Map(notifications.map((n) => [n.id, n] as const));
   const active = toastIds
     .map((id) => byId.get(id))
-    .filter((n): n is Notification => !!n && !n.read)
+    .filter((n): n is Notification => !!n && !n.read && !n.archived)
     .slice(0, 3);
 
   return (

--- a/desktop/src/components/NotificationToast.tsx
+++ b/desktop/src/components/NotificationToast.tsx
@@ -264,7 +264,7 @@ function extractTagged(text: string, tag: string): string | undefined {
 /*  ToastItem                                                          */
 /* ------------------------------------------------------------------ */
 
-function ToastItem({ notif }: { notif: Notification }) {
+function ToastItem({ notif, onExpire }: { notif: Notification; onExpire: () => void }) {
   const dismiss = useNotificationStore((s) => s.dismiss);
   const Icon = LEVEL_ICONS[notif.level];
   const isAgentPaused = notif.source === "agent.paused";
@@ -272,9 +272,12 @@ function ToastItem({ notif }: { notif: Notification }) {
   useEffect(() => {
     // Agent-paused toasts stay until the user explicitly acts on them.
     if (isAgentPaused) return;
-    const timer = setTimeout(() => dismiss(notif.id), 5000);
+    // Auto-expiry only hides the toast; it must NOT archive. Archiving is an
+    // explicit user action (the X button / "Keep paused"). Otherwise every
+    // toast that simply times out would silently fill the History view.
+    const timer = setTimeout(onExpire, 5000);
     return () => clearTimeout(timer);
-  }, [notif.id, dismiss, isAgentPaused]);
+  }, [notif.id, onExpire, isAgentPaused]);
 
   return (
     <div
@@ -342,7 +345,11 @@ export function NotificationToasts() {
       role="region"
     >
       {active.map((n) => (
-        <ToastItem key={n.id} notif={n} />
+        <ToastItem
+          key={n.id}
+          notif={n}
+          onExpire={() => setToastIds((prev) => prev.filter((id) => id !== n.id))}
+        />
       ))}
     </div>
   );

--- a/desktop/src/components/TopBar.tsx
+++ b/desktop/src/components/TopBar.tsx
@@ -99,7 +99,7 @@ function PowerMenu() {
 export function TopBar({ onSearchOpen, onAssistantOpen }: Props) {
   const clock = useClock();
   const { showWidgets, toggleWidgets } = useWidgetStore();
-  const unreadCount = useNotificationStore((s) => s.notifications.filter((n) => !n.read).length);
+  const unreadCount = useNotificationStore((s) => s.notifications.filter((n) => !n.read && !n.archived).length);
   const toggleCentre = useNotificationStore((s) => s.toggleCentre);
 
   return (

--- a/desktop/src/stores/notification-store.test.ts
+++ b/desktop/src/stores/notification-store.test.ts
@@ -73,11 +73,17 @@ describe("mergeServerNotifications", () => {
     expect(useNotificationStore.getState().notifications.map((n) => n.id)).toContain("srv-901");
 
     store.dismiss("srv-901");
-    expect(useNotificationStore.getState().notifications.map((n) => n.id)).not.toContain("srv-901");
+    // Dismissed item is archived, not removed from the store.
+    const all = useNotificationStore.getState().notifications;
+    const dismissed = all.find((n) => n.id === "srv-901");
+    expect(dismissed).toBeDefined();
+    expect(dismissed?.archived).toBe(true);
 
-    // Backend still reports it (no server-side dismiss); it must stay hidden.
+    // Backend still reports it (no server-side dismiss); it must stay hidden from active.
     store.mergeServerNotifications([srv(901, 100)]);
-    expect(useNotificationStore.getState().notifications.map((n) => n.id)).not.toContain("srv-901");
+    const afterPoll = useNotificationStore.getState().notifications;
+    const stillArchived = afterPoll.find((n) => n.id === "srv-901");
+    expect(stillArchived?.archived).toBe(true);
   });
 
   it("caps the merged list at 100 items", () => {
@@ -85,5 +91,77 @@ describe("mergeServerNotifications", () => {
     const many = Array.from({ length: 150 }, (_, i) => srv(i, i));
     store.mergeServerNotifications(many);
     expect(useNotificationStore.getState().notifications).toHaveLength(100);
+  });
+});
+
+describe("dismiss archives instead of removing", () => {
+  it("sets archived flag on dismiss", () => {
+    const store = useNotificationStore.getState();
+    const id = store.addNotification({ source: "system", title: "test", body: "body", level: "info" });
+
+    store.dismiss(id);
+
+    const all = useNotificationStore.getState().notifications;
+    expect(all).toHaveLength(1);
+    expect(all[0].archived).toBe(true);
+    expect(all[0].id).toBe(id);
+  });
+
+  it("excludes archived items from active notifications", () => {
+    const store = useNotificationStore.getState();
+    const id1 = store.addNotification({ source: "system", title: "keep", body: "active", level: "info" });
+    const id2 = store.addNotification({ source: "system", title: "archive", body: "gone", level: "info" });
+
+    store.dismiss(id2);
+
+    const active = useNotificationStore.getState().notifications.filter((n) => !n.archived);
+    expect(active).toHaveLength(1);
+    expect(active[0].id).toBe(id1);
+  });
+
+  it("archivedNotifications returns archived items newest-first", () => {
+    const store = useNotificationStore.getState();
+    store.addNotification({ source: "system", title: "old", body: "b", level: "info" });
+    const id2 = store.addNotification({ source: "system", title: "new", body: "b", level: "info" });
+
+    store.dismiss(id2);
+
+    const archived = store.archivedNotifications();
+    expect(archived).toHaveLength(1);
+    expect(archived[0].id).toBe(id2);
+    expect(archived[0].archived).toBe(true);
+  });
+
+  it("clearAll archives all notifications", () => {
+    const store = useNotificationStore.getState();
+    store.addNotification({ source: "system", title: "a", body: "b", level: "info" });
+    store.addNotification({ source: "system", title: "c", body: "d", level: "info" });
+
+    store.clearAll();
+
+    const all = useNotificationStore.getState().notifications;
+    expect(all).toHaveLength(2);
+    expect(all.every((n) => n.archived)).toBe(true);
+  });
+
+  it("clearArchived removes archived items permanently", () => {
+    const store = useNotificationStore.getState();
+    const id = store.addNotification({ source: "system", title: "test", body: "b", level: "info" });
+    store.dismiss(id);
+
+    store.clearArchived();
+
+    expect(useNotificationStore.getState().notifications).toHaveLength(0);
+  });
+
+  it("unreadCount excludes archived items", () => {
+    const store = useNotificationStore.getState();
+    const id1 = store.addNotification({ source: "system", title: "unread", body: "b", level: "info" });
+    store.addNotification({ source: "system", title: "to-archive", body: "b", level: "info" });
+
+    expect(store.unreadCount()).toBe(2);
+
+    store.dismiss(id1);
+    expect(store.unreadCount()).toBe(1);
   });
 });

--- a/desktop/src/stores/notification-store.ts
+++ b/desktop/src/stores/notification-store.ts
@@ -12,6 +12,8 @@ export interface Notification {
   timestamp: number;
   /** Extra typed payload for structured notifications like agent.paused. */
   meta?: Record<string, string>;
+  /** When true the notification has been dismissed/archived. */
+  archived?: boolean;
 }
 
 interface NotificationStore {
@@ -27,6 +29,8 @@ interface NotificationStore {
   toggleCentre: () => void;
   closeCentre: () => void;
   unreadCount: () => number;
+  archivedNotifications: () => Notification[];
+  clearArchived: () => void;
 }
 
 let counter = 0;
@@ -64,10 +68,13 @@ export const useNotificationStore = create<NotificationStore>((set, get) => ({
       const merged = items
         .filter((n) => !dismissedServerIds.has(n.id))
         .map((n) => (priorRead.get(n.id) ? { ...n, read: true } : n));
-      // Keep every client-origin item ("notif-N") untouched, drop the old
-      // server items (replaced by the fresh list), de-dupe, sort newest-first.
-      const client = s.notifications.filter((n) => !n.id.startsWith("srv-"));
-      const combined = [...merged, ...client];
+      // Keep every client-origin item ("notif-N") untouched, plus any archived
+      // server items (they must survive polls). Drop the old unarchived server
+      // items (replaced by the fresh list), de-dupe, sort newest-first.
+      const kept = s.notifications.filter(
+        (n) => !n.id.startsWith("srv-") || n.archived,
+      );
+      const combined = [...merged, ...kept];
       combined.sort((a, b) => b.timestamp - a.timestamp);
       return { notifications: combined.slice(0, 100) };
     });
@@ -85,7 +92,11 @@ export const useNotificationStore = create<NotificationStore>((set, get) => ({
 
   dismiss(id) {
     if (id.startsWith("srv-")) dismissedServerIds.add(id);
-    set((s) => ({ notifications: s.notifications.filter((n) => n.id !== id) }));
+    set((s) => ({
+      notifications: s.notifications.map((n) =>
+        n.id === id ? { ...n, archived: true } : n,
+      ),
+    }));
   },
 
   clearAll() {
@@ -93,7 +104,9 @@ export const useNotificationStore = create<NotificationStore>((set, get) => ({
       for (const n of s.notifications) {
         if (n.id.startsWith("srv-")) dismissedServerIds.add(n.id);
       }
-      return { notifications: [] };
+      return {
+        notifications: s.notifications.map((n) => ({ ...n, archived: true })),
+      };
     });
   },
 
@@ -106,6 +119,18 @@ export const useNotificationStore = create<NotificationStore>((set, get) => ({
   },
 
   unreadCount() {
-    return get().notifications.filter((n) => !n.read).length;
+    return get().notifications.filter((n) => !n.read && !n.archived).length;
+  },
+
+  archivedNotifications() {
+    return get().notifications
+      .filter((n) => n.archived)
+      .sort((a, b) => b.timestamp - a.timestamp);
+  },
+
+  clearArchived() {
+    set((s) => ({
+      notifications: s.notifications.filter((n) => !n.archived),
+    }));
   },
 }));


### PR DESCRIPTION
Autonomous build of board card tsk-dafnla.

Dismissing a notification now sets an archived flag instead of removing it
from the store. A new History tab in NotificationCentre lists archived
notifications read-only, newest first. clearAll archives all items;
clearArchived permanently removes archived items. Updated unreadCount,
toast active filter, and TopBar bell count to exclude archived items.
Added store tests for dismiss-to-archive transitions.

Files:
 desktop/src/components/NotificationCentre.test.tsx |   4 +
 desktop/src/components/NotificationCentre.tsx      | 169 ++++++++++++++++-----
 desktop/src/components/NotificationToast.tsx       |   2 +-
 desktop/src/components/TopBar.tsx                  |   2 +-
 desktop/src/stores/notification-store.test.ts      |  84 +++++++++-
 desktop/src/stores/notification-store.ts           |  39 ++++-
 6 files changed, 247 insertions(+), 53 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "History" tab in the notification center to view archived notifications.
  * Notifications are now archived when dismissed, rather than permanently removed.
  * Toast notifications automatically expire after 5 seconds without requiring user action.

* **Bug Fixes**
  * Unread notification badge now correctly counts only active notifications, excluding archived ones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->