### PR TITLE
feat(audit): append-only board audit log (#105)

### DIFF
--- a/tests/test_board_audit.py
+++ b/tests/test_board_audit.py
@@ -1,0 +1,72 @@
+import pytest
+
+from tinyagentos.board_audit import BoardAuditLog
+
+
+async def _log(tmp_path):
+    s = BoardAuditLog(tmp_path / "audit.db")
+    await s.init()
+    return s
+
+
+@pytest.mark.asyncio
+async def test_record_and_history_ordered(tmp_path):
+    s = await _log(tmp_path)
+    e1 = await s.record("tsk-1", "claimed", actor="@kilo", from_status="open", to_status="claimed", ts="2026-01-01T00:00:00+00:00")
+    e2 = await s.record("tsk-1", "merged", actor="@taOS-dev", from_status="claimed", to_status="done", ts="2026-01-01T00:00:00+00:00")
+    hist = await s.history("tsk-1")
+    assert [h["id"] for h in hist] == [e1, e2]  # insertion order, stable even on equal ts
+    assert hist[0]["event"] == "claimed" and hist[0]["actor"] == "@kilo"
+    assert hist[1]["to_status"] == "done"
+    await s.close()
+
+
+@pytest.mark.asyncio
+async def test_append_only_no_mutate_or_delete(tmp_path):
+    s = await _log(tmp_path)
+    await s.record("tsk-1", "open")
+    # The store exposes no update/delete API: recording the same task again keeps both.
+    await s.record("tsk-1", "open")
+    assert len(await s.history("tsk-1")) == 2
+    assert not hasattr(s, "delete")
+    assert not hasattr(s, "update")
+    await s.close()
+
+
+@pytest.mark.asyncio
+async def test_history_scoped_per_task(tmp_path):
+    s = await _log(tmp_path)
+    await s.record("tsk-1", "open")
+    await s.record("tsk-2", "open")
+    assert len(await s.history("tsk-1")) == 1
+    assert await s.history("tsk-missing") == []
+    await s.close()
+
+
+@pytest.mark.asyncio
+async def test_all_since_filters_by_ts(tmp_path):
+    s = await _log(tmp_path)
+    await s.record("tsk-1", "old", ts="2026-01-01T00:00:00+00:00")
+    await s.record("tsk-1", "new", ts="2026-06-01T00:00:00+00:00")
+    recent = await s.all_since("2026-03-01T00:00:00+00:00")
+    assert [r["event"] for r in recent] == ["new"]
+    await s.close()
+
+
+@pytest.mark.asyncio
+async def test_record_requires_task_and_event(tmp_path):
+    s = await _log(tmp_path)
+    with pytest.raises(ValueError):
+        await s.record("", "open")
+    with pytest.raises(ValueError):
+        await s.record("tsk-1", "")
+    await s.close()
+
+
+@pytest.mark.asyncio
+async def test_get_returns_event_or_none(tmp_path):
+    s = await _log(tmp_path)
+    eid = await s.record("tsk-1", "open")
+    assert (await s.get(eid))["event"] == "open"
+    assert await s.get("ba-missing") is None
+    await s.close()

--- a/tinyagentos/board_audit.py
+++ b/tinyagentos/board_audit.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import datetime
+import secrets
+
+from tinyagentos.base_store import BaseStore
+
+_ALPHABET = "abcdefghijklmnopqrstuvwxyz234567"
+
+BOARD_AUDIT_SCHEMA = """
+CREATE TABLE IF NOT EXISTS board_audit (
+    id TEXT PRIMARY KEY,
+    task_id TEXT NOT NULL,
+    event TEXT NOT NULL,
+    actor TEXT NOT NULL DEFAULT '',
+    from_status TEXT,
+    to_status TEXT,
+    ts TEXT NOT NULL
+);
+"""
+
+_COLS = "id, task_id, event, actor, from_status, to_status, ts"
+
+
+def _now_iso() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+
+def _new_id() -> str:
+    return "ba-" + "".join(secrets.choice(_ALPHABET) for _ in range(8))
+
+
+def _row(r) -> dict:
+    return {
+        "id": r[0], "task_id": r[1], "event": r[2], "actor": r[3],
+        "from_status": r[4], "to_status": r[5], "ts": r[6],
+    }
+
+
+class BoardAuditLog(BaseStore):
+    """Append-only audit trail of board task state changes (#105).
+
+    The seed of the nothing-is-ever-deleted / Time Machine story: every status
+    change is recorded and never updated or deleted. There is deliberately no
+    public mutate or delete method. History is returned in insertion order
+    (SQLite rowid) so it is stable even when two events share a timestamp.
+    """
+
+    SCHEMA = BOARD_AUDIT_SCHEMA
+
+    async def record(
+        self,
+        task_id: str,
+        event: str,
+        actor: str = "",
+        from_status: str | None = None,
+        to_status: str | None = None,
+        ts: str | None = None,
+    ) -> str:
+        if not task_id:
+            raise ValueError("task_id is required")
+        if not event:
+            raise ValueError("event is required")
+        eid = _new_id()
+        when = ts or _now_iso()
+        await self._db.execute(
+            f"INSERT INTO board_audit ({_COLS}) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (eid, task_id, event, actor, from_status, to_status, when),
+        )
+        await self._db.commit()
+        return eid
+
+    async def history(self, task_id: str) -> list[dict]:
+        async with self._db.execute(
+            f"SELECT {_COLS} FROM board_audit WHERE task_id = ? ORDER BY rowid ASC",
+            (task_id,),
+        ) as cur:
+            rows = await cur.fetchall()
+        return [_row(r) for r in rows]
+
+    async def all_since(self, ts: str) -> list[dict]:
+        async with self._db.execute(
+            f"SELECT {_COLS} FROM board_audit WHERE ts >= ? ORDER BY rowid ASC", (ts,)
+        ) as cur:
+            rows = await cur.fetchall()
+        return [_row(r) for r in rows]
+
+    async def get(self, event_id: str) -> dict | None:
+        async with self._db.execute(
+            f"SELECT {_COLS} FROM board_audit WHERE id = ?", (event_id,)
+        ) as cur:
+            r = await cur.fetchone()
+        return _row(r) if r else None

--- a/tinyagentos/board_audit.py
+++ b/tinyagentos/board_audit.py
@@ -17,6 +17,8 @@ CREATE TABLE IF NOT EXISTS board_audit (
     to_status TEXT,
     ts TEXT NOT NULL
 );
+CREATE INDEX IF NOT EXISTS idx_board_audit_task ON board_audit(task_id);
+CREATE INDEX IF NOT EXISTS idx_board_audit_ts ON board_audit(ts);
 """
 
 _COLS = "id, task_id, event, actor, from_status, to_status, ts"


### PR DESCRIPTION
Second epic foundation (after the capability map): the append-only audit trail for board task state changes, the seed of the nothing-is-ever-deleted / Time Machine epic (#103).

BoardAuditLog (BaseStore-backed): record(task_id, event, actor, from_status, to_status, ts) -> id, append-only with no public mutate or delete; history(task_id) in stable insertion order (rowid, so equal timestamps do not flake); all_since(ts); get(id). 6 tests green.

Held for your review per the feature-PR policy. Follow-up slices: wire record() into the task status-change path, then a reopen/undo endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added audit logging system for task state changes, capturing timestamps, actors, and status transitions.
  * Query task audit history and retrieve events by timestamp range.

* **Tests**
  * Added comprehensive test suite validating audit log recording, retrieval, and querying functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->