### PR TITLE
feat(coding): workspace-jailed fs tool primitives (#86)

### DIFF
--- a/tests/test_fs_tools.py
+++ b/tests/test_fs_tools.py
@@ -1,0 +1,59 @@
+import os
+
+import pytest
+
+from tinyagentos.agent_tools.fs_tools import (
+    read_file, write_file, file_exists, list_dir, JailViolation,
+)
+
+
+def _ws(tmp_path):
+    root = tmp_path / "workspace"
+    root.mkdir()
+    return root
+
+
+def test_write_then_read_roundtrip(tmp_path):
+    root = _ws(tmp_path)
+    n = write_file(root, "sub/dir/file.txt", "hello")
+    assert n == 5
+    assert read_file(root, "sub/dir/file.txt") == "hello"
+    assert file_exists(root, "sub/dir/file.txt") is True
+    assert file_exists(root, "nope.txt") is False
+
+
+def test_escape_via_dotdot_is_refused(tmp_path):
+    root = _ws(tmp_path)
+    (tmp_path / "secret.txt").write_text("top secret")
+    with pytest.raises(JailViolation):
+        read_file(root, "../secret.txt")
+    with pytest.raises(JailViolation):
+        write_file(root, "../escaped.txt", "x")
+    assert file_exists(root, "../secret.txt") is False
+
+
+def test_git_path_is_refused(tmp_path):
+    root = _ws(tmp_path)
+    with pytest.raises(JailViolation):
+        write_file(root, ".git/hooks/pre-commit", "#!/bin/sh\necho pwned")
+    with pytest.raises(JailViolation):
+        read_file(root, ".git/config")
+
+
+def test_symlink_escape_is_refused(tmp_path):
+    root = _ws(tmp_path)
+    (tmp_path / "outside.txt").write_text("secret")
+    os.symlink(tmp_path / "outside.txt", root / "link.txt")
+    with pytest.raises(JailViolation):
+        read_file(root, "link.txt")
+
+
+def test_list_dir(tmp_path):
+    root = _ws(tmp_path)
+    write_file(root, "a.txt", "1")
+    write_file(root, "b.txt", "2")
+    write_file(root, "sub/c.txt", "3")
+    assert list_dir(root) == ["a.txt", "b.txt", "sub"]
+    assert list_dir(root, "sub") == ["c.txt"]
+    with pytest.raises(JailViolation):
+        list_dir(root, "../")

--- a/tinyagentos/agent_tools/__init__.py
+++ b/tinyagentos/agent_tools/__init__.py
@@ -1,0 +1,1 @@
+"""Agent execution primitives (workspace-jailed file tools, etc.)."""

--- a/tinyagentos/agent_tools/fs_tools.py
+++ b/tinyagentos/agent_tools/fs_tools.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tinyagentos.routes.coding import _resolve_jailed
+
+
+class JailViolation(ValueError):
+    """Raised when a path escapes the workspace, targets .git, or is otherwise refused.
+
+    These are the file primitives the Coding Studio agent calls for live edits.
+    Every path is resolved through the same workspace jail the coding routes use
+    (_resolve_jailed), so an escape via ``..``, an absolute path, a symlink that
+    resolves outside the workspace, or anything under ``.git`` is refused.
+    """
+
+
+def _resolve(workspace_root, rel_path: str, *, allow_root: bool = False) -> Path:
+    root = Path(workspace_root).resolve()
+    target = _resolve_jailed(root, rel_path, allow_root=allow_root)
+    if target is None:
+        raise JailViolation(f"path refused (escapes workspace or targets .git): {rel_path!r}")
+    return target
+
+
+def read_file(workspace_root, rel_path: str) -> str:
+    return _resolve(workspace_root, rel_path).read_text()
+
+
+def write_file(workspace_root, rel_path: str, content: str) -> int:
+    target = _resolve(workspace_root, rel_path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    return target.write_text(content)
+
+
+def file_exists(workspace_root, rel_path: str) -> bool:
+    try:
+        return _resolve(workspace_root, rel_path).is_file()
+    except JailViolation:
+        return False
+
+
+def list_dir(workspace_root, rel_path: str = ".") -> list[str]:
+    target = _resolve(workspace_root, rel_path, allow_root=True)
+    if not target.is_dir():
+        raise JailViolation(f"not a directory: {rel_path!r}")
+    return sorted(p.name for p in target.iterdir())


### PR DESCRIPTION
Third epic foundation: the filesystem primitives the Coding Studio agent will call for live edits, the first slice toward a real tool-calling loop.

read_file / write_file / file_exists / list_dir, each routed through the coding routes' existing `_resolve_jailed` jail, so an escape via `..`, an absolute path, a symlink resolving outside the workspace, or anything under `.git` raises JailViolation. 5 tests green including those security cases.

Held for your review. Follow-up: the tool-calling loop in the taos-agent runtime that wires these into the model's tool calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace-jailed file system operations for reading, writing, checking file existence, and listing directories with built-in security protections against path traversal attempts and reserved path access.

* **Tests**
  * Added comprehensive test suite covering file operations and security boundary validations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->