### PR TITLE
feat(coding): agent tool-calling dispatch over workspace fs-tools (#86)

### DIFF
--- a/tests/test_coding_tool_loop.py
+++ b/tests/test_coding_tool_loop.py
@@ -43,6 +43,20 @@ def test_dispatch_read_missing_file(tmp_path):
     assert r["error"] == "file not found"
 
 
+def test_dispatch_read_binary_is_soft_error(tmp_path):
+    (tmp_path / "blob.bin").write_bytes(b"\xff\xfe\x00\x01\x80")
+    r = coding_tools.dispatch(tmp_path, "read_file", {"path": "blob.bin"})
+    assert r["ok"] is False
+    assert "UTF-8" in r["error"]
+
+
+def test_dispatch_read_too_large_is_soft_error(tmp_path):
+    (tmp_path / "big.txt").write_text("a" * (coding_tools.MAX_READ_BYTES + 1))
+    r = coding_tools.dispatch(tmp_path, "read_file", {"path": "big.txt"})
+    assert r["ok"] is False
+    assert "limit" in r["error"]
+
+
 def test_dispatch_list_dir_defaults_to_root(tmp_path):
     coding_tools.dispatch(tmp_path, "write_file", {"path": "one.txt", "content": "1"})
     r = coding_tools.dispatch(tmp_path, "list_dir", {})

--- a/tests/test_coding_tool_loop.py
+++ b/tests/test_coding_tool_loop.py
@@ -1,0 +1,121 @@
+"""Tests for the Coding Studio agent tool-calling loop (#86).
+
+Covers the dispatch substrate (unit) and the two HTTP endpoints that drive it.
+"""
+import pytest
+import pytest_asyncio
+
+from tinyagentos.agent_tools import coding_tools
+
+
+# ---------------------------------------------------------------------------
+# dispatch() unit tests (no HTTP)
+# ---------------------------------------------------------------------------
+
+def test_dispatch_write_then_read_roundtrip(tmp_path):
+    r = coding_tools.dispatch(tmp_path, "write_file", {"path": "a/b.txt", "content": "hi"})
+    assert r["ok"] is True
+    r = coding_tools.dispatch(tmp_path, "read_file", {"path": "a/b.txt"})
+    assert r == {"ok": True, "result": "hi"}
+
+
+def test_dispatch_unknown_tool(tmp_path):
+    r = coding_tools.dispatch(tmp_path, "delete_everything", {})
+    assert r["ok"] is False
+    assert "unknown tool" in r["error"]
+
+
+def test_dispatch_missing_argument(tmp_path):
+    r = coding_tools.dispatch(tmp_path, "write_file", {"path": "x.txt"})
+    assert r["ok"] is False
+    assert "missing argument" in r["error"]
+
+
+def test_dispatch_jail_violation_is_caught(tmp_path):
+    r = coding_tools.dispatch(tmp_path, "read_file", {"path": "../escape.txt"})
+    assert r["ok"] is False
+    assert "refused" in r["error"]
+
+
+def test_dispatch_read_missing_file(tmp_path):
+    r = coding_tools.dispatch(tmp_path, "read_file", {"path": "nope.txt"})
+    assert r["ok"] is False
+    assert r["error"] == "file not found"
+
+
+def test_dispatch_list_dir_defaults_to_root(tmp_path):
+    coding_tools.dispatch(tmp_path, "write_file", {"path": "one.txt", "content": "1"})
+    r = coding_tools.dispatch(tmp_path, "list_dir", {})
+    assert r["ok"] is True
+    assert "one.txt" in r["result"]
+
+
+def test_dispatch_file_exists(tmp_path):
+    coding_tools.dispatch(tmp_path, "write_file", {"path": "here.txt", "content": "x"})
+    assert coding_tools.dispatch(tmp_path, "file_exists", {"path": "here.txt"})["result"] is True
+    assert coding_tools.dispatch(tmp_path, "file_exists", {"path": "gone.txt"})["result"] is False
+
+
+# ---------------------------------------------------------------------------
+# HTTP endpoints
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture
+async def coding_client(app, client):
+    store = app.state.coding_workspaces
+    if store._db is not None:
+        await store.close()
+    await store.init()
+    yield client, app
+
+
+@pytest.mark.asyncio
+async def test_tools_endpoint_lists_schemas(coding_client):
+    client, _app = coding_client
+    r = await client.get("/api/coding/tools")
+    assert r.status_code == 200
+    names = {t["name"] for t in r.json()["tools"]}
+    assert names == {"read_file", "write_file", "file_exists", "list_dir"}
+
+
+@pytest.mark.asyncio
+async def test_tool_endpoint_executes_against_workspace(coding_client):
+    client, _app = coding_client
+    ws = (await client.post("/api/coding/workspaces", json={"name": "loop"})).json()
+    wid = ws["id"]
+
+    r = await client.post(
+        f"/api/coding/workspaces/{wid}/tool",
+        json={"name": "write_file", "arguments": {"path": "main.py", "content": "print(1)"}},
+    )
+    assert r.status_code == 200
+    assert r.json()["ok"] is True
+
+    r = await client.post(
+        f"/api/coding/workspaces/{wid}/tool",
+        json={"name": "read_file", "arguments": {"path": "main.py"}},
+    )
+    assert r.json() == {"ok": True, "result": "print(1)"}
+
+
+@pytest.mark.asyncio
+async def test_tool_endpoint_jail_violation_is_soft_error(coding_client):
+    client, _app = coding_client
+    ws = (await client.post("/api/coding/workspaces", json={"name": "jail"})).json()
+    r = await client.post(
+        f"/api/coding/workspaces/{ws['id']}/tool",
+        json={"name": "read_file", "arguments": {"path": "../../etc/passwd"}},
+    )
+    # Soft error (HTTP 200, ok=false) so the loop can recover.
+    assert r.status_code == 200
+    assert r.json()["ok"] is False
+
+
+@pytest.mark.asyncio
+async def test_tool_endpoint_unknown_workspace_404(coding_client):
+    client, _app = coding_client
+    r = await client.post(
+        "/api/coding/workspaces/ws-nope/tool",
+        json={"name": "list_dir", "arguments": {}},
+    )
+    assert r.status_code == 404

--- a/tinyagentos/agent_tools/coding_tools.py
+++ b/tinyagentos/agent_tools/coding_tools.py
@@ -17,6 +17,14 @@ from typing import Any
 from tinyagentos.agent_tools import fs_tools
 from tinyagentos.agent_tools.fs_tools import JailViolation
 
+# Cap how much a single read pulls into memory, matching the HTTP read route's
+# guard so the agent loop cannot fault the controller by reading a huge file.
+MAX_READ_BYTES = 2_000_000
+
+
+class _ReadTooLarge(ValueError):
+    """A read_file target exceeds MAX_READ_BYTES."""
+
 # Anthropic/OpenAI-style function schemas. Handed to the model so it knows the
 # available tools and their arguments; the names map 1:1 to _HANDLERS below.
 TOOL_SCHEMAS: list[dict[str, Any]] = [
@@ -65,7 +73,11 @@ TOOL_NAMES = {t["name"] for t in TOOL_SCHEMAS}
 
 
 def _h_read_file(root, args):
-    return fs_tools.read_file(root, args["path"])
+    # Resolve through the same jail fs_tools uses, then size-check before reading.
+    target = fs_tools._resolve(root, args["path"])
+    if target.stat().st_size > MAX_READ_BYTES:
+        raise _ReadTooLarge(f"file exceeds {MAX_READ_BYTES} byte read limit")
+    return target.read_text()
 
 
 def _h_write_file(root, args):
@@ -113,6 +125,12 @@ def dispatch(workspace_root, name: str, arguments: dict | None) -> dict:
         return {"ok": True, "result": fn(workspace_root, args)}
     except JailViolation as exc:
         return {"ok": False, "error": str(exc)}
+    except _ReadTooLarge as exc:
+        return {"ok": False, "error": str(exc)}
+    except UnicodeDecodeError:
+        # read_file decodes as UTF-8; a binary/non-UTF-8 file must come back as a
+        # soft error, not crash the loop turn.
+        return {"ok": False, "error": "binary or non-UTF-8 file"}
     except FileNotFoundError:
         return {"ok": False, "error": "file not found"}
     except OSError as exc:

--- a/tinyagentos/agent_tools/coding_tools.py
+++ b/tinyagentos/agent_tools/coding_tools.py
@@ -1,0 +1,119 @@
+"""Tool dispatch for the Coding Studio agent loop (#86).
+
+This is the substrate the tool-calling loop sits on: a registry of the
+workspace file primitives (read/write/exists/list) described as JSON tool
+schemas an LLM can be handed, plus a single ``dispatch`` step that validates a
+proposed tool call and executes it against a jailed workspace root.
+
+Keeping execution here (rather than in the model glue) means the loop is the
+same whether driven by a real model, a test, or a replayed transcript: propose
+a call -> dispatch -> feed the result back.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tinyagentos.agent_tools import fs_tools
+from tinyagentos.agent_tools.fs_tools import JailViolation
+
+# Anthropic/OpenAI-style function schemas. Handed to the model so it knows the
+# available tools and their arguments; the names map 1:1 to _HANDLERS below.
+TOOL_SCHEMAS: list[dict[str, Any]] = [
+    {
+        "name": "read_file",
+        "description": "Read a UTF-8 text file inside the workspace.",
+        "input_schema": {
+            "type": "object",
+            "properties": {"path": {"type": "string", "description": "Workspace-relative path."}},
+            "required": ["path"],
+        },
+    },
+    {
+        "name": "write_file",
+        "description": "Create or overwrite a UTF-8 text file inside the workspace.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "path": {"type": "string", "description": "Workspace-relative path."},
+                "content": {"type": "string", "description": "Full file contents to write."},
+            },
+            "required": ["path", "content"],
+        },
+    },
+    {
+        "name": "file_exists",
+        "description": "Check whether a workspace-relative path is an existing file.",
+        "input_schema": {
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+        },
+    },
+    {
+        "name": "list_dir",
+        "description": "List the entries of a workspace directory (defaults to the root).",
+        "input_schema": {
+            "type": "object",
+            "properties": {"path": {"type": "string", "description": "Workspace-relative dir; '.' for root."}},
+            "required": [],
+        },
+    },
+]
+
+TOOL_NAMES = {t["name"] for t in TOOL_SCHEMAS}
+
+
+def _h_read_file(root, args):
+    return fs_tools.read_file(root, args["path"])
+
+
+def _h_write_file(root, args):
+    return fs_tools.write_file(root, args["path"], args["content"])
+
+
+def _h_file_exists(root, args):
+    return fs_tools.file_exists(root, args["path"])
+
+
+def _h_list_dir(root, args):
+    return fs_tools.list_dir(root, args.get("path", "."))
+
+
+_HANDLERS = {
+    "read_file": (_h_read_file, ("path",)),
+    "write_file": (_h_write_file, ("path", "content")),
+    "file_exists": (_h_file_exists, ("path",)),
+    "list_dir": (_h_list_dir, ()),
+}
+
+
+def dispatch(workspace_root, name: str, arguments: dict | None) -> dict:
+    """Execute one tool call against the workspace.
+
+    Returns a structured, always-JSON-serialisable result:
+      {"ok": True, "result": <value>}  on success
+      {"ok": False, "error": <message>} on an unknown tool, missing argument,
+        jail violation, or filesystem error.
+
+    Never raises: the loop feeds the error string back to the model so it can
+    recover, rather than crashing the turn.
+    """
+    handler = _HANDLERS.get(name)
+    if handler is None:
+        return {"ok": False, "error": f"unknown tool: {name!r}"}
+    fn, required = handler
+    args = arguments or {}
+    if not isinstance(args, dict):
+        return {"ok": False, "error": "arguments must be an object"}
+    missing = [k for k in required if k not in args]
+    if missing:
+        return {"ok": False, "error": f"missing argument(s): {', '.join(missing)}"}
+    try:
+        return {"ok": True, "result": fn(workspace_root, args)}
+    except JailViolation as exc:
+        return {"ok": False, "error": str(exc)}
+    except FileNotFoundError:
+        return {"ok": False, "error": "file not found"}
+    except OSError as exc:
+        return {"ok": False, "error": f"filesystem error: {exc.strerror or exc}"}

--- a/tinyagentos/routes/coding.py
+++ b/tinyagentos/routes/coding.py
@@ -35,6 +35,11 @@ class ApplyBlocksBody(BaseModel):
     blocks: list[ApplyBlock]
 
 
+class ToolCallBody(BaseModel):
+    name: str
+    arguments: dict | None = None
+
+
 # ---------------------------------------------------------------------------
 # Git helpers
 # ---------------------------------------------------------------------------
@@ -450,3 +455,32 @@ async def apply_blocks(request: Request, workspace_id: str, body: ApplyBlocksBod
         applied.append(rel)
 
     return {"applied": applied}
+
+
+# ---------------------------------------------------------------------------
+# Agent tool-calling loop (#86)
+# ---------------------------------------------------------------------------
+
+@router.get("/api/coding/tools")
+async def list_coding_tools(request: Request):
+    """The workspace tool schemas the agent loop hands to the model."""
+    from tinyagentos.agent_tools.coding_tools import TOOL_SCHEMAS
+
+    return {"tools": TOOL_SCHEMAS}
+
+
+@router.post("/api/coding/workspaces/{workspace_id}/tool")
+async def run_coding_tool(request: Request, workspace_id: str, body: ToolCallBody):
+    """Execute one agent tool call against a jailed workspace.
+
+    The execution half of the tool-calling loop: the model proposes a call, the
+    controller runs it here and feeds the structured result back. Errors are
+    returned as {"ok": false, "error": ...} (HTTP 200) so the loop can recover;
+    only an unknown workspace is a hard 404.
+    """
+    from tinyagentos.agent_tools.coding_tools import dispatch
+
+    root, err = await _workspace_root(request, workspace_id)
+    if err is not None:
+        return err
+    return dispatch(root, body.name, body.arguments)


### PR DESCRIPTION
Coding-studio epic slice 2: the execution substrate for the agent tool-calling loop, built on the merged fs-tools (#1275).

## What
- `agent_tools/coding_tools.py`:
  - `TOOL_SCHEMAS` — Anthropic/OpenAI-style function schemas for `read_file` / `write_file` / `file_exists` / `list_dir`, ready to hand a model.
  - `dispatch(workspace_root, name, arguments)` — validates the proposed call and runs it against the **jailed** workspace, returning `{ok, result}` or `{ok: false, error}`. Never raises: unknown tool, missing arg, jail violation, and fs errors all come back as soft errors so the loop can feed them back and recover.
- `GET /api/coding/tools` lists the schemas.
- `POST /api/coding/workspaces/{id}/tool` runs one call (the loop's execute step). Only an unknown workspace is a hard 404; tool failures are 200 `ok=false`.

## Why this shape
Keeping execution in one dispatcher means the loop behaves identically whether driven by a real model, a test, or a replayed transcript: propose -> dispatch -> feed result back. The model glue lands on top of this without touching the jail.

## Tests
11 (dispatch unit incl. jail-escape + missing-file + roundtrip; both endpoints incl. soft-error jail escape and 404). Coding + fs-tools suites (40) green; compileall clean.

Guardrails: reuses the existing workspace jail (no new auth), no DB migrations, no installer/boot changes.