### PR TITLE
feat(cluster): populate capability map from worker registration (#897)

### DIFF
--- a/tests/test_routes_cluster_capability.py
+++ b/tests/test_routes_cluster_capability.py
@@ -167,3 +167,61 @@ async def test_prune_drops_stale(client, app):
     resp = await client.get("/api/cluster/capability")
     assert all(n["node_id"] != "node-a" for n in resp.json()["nodes"])
     await app.state.capability_map.close()
+
+
+@pytest.mark.asyncio
+async def test_worker_registration_populates_capability_map(client, app):
+    """A paired worker's HMAC registration records its hardware into the map."""
+    import json
+
+    await app.state.capability_map.init()
+    await app.state.cluster_pairing.init()
+    key = await pair_worker(client, app, "rig-1", "http://10.2.0.1:9000")
+    reg = json.dumps(
+        {
+            "name": "rig-1",
+            "url": "http://10.2.0.1:9000",
+            "platform": "linux",
+            "host_lan_ip": "10.2.0.9",
+            "hardware": {
+                "cpu": {"cores": 8},
+                "ram_mb": 16000,
+                "gpu": {"name": "rtx3060"},
+                "npu": {},
+            },
+        }
+    ).encode()
+    headers = sign_worker_request(key, "rig-1", "POST", "/api/cluster/workers", reg)
+    headers["Content-Type"] = "application/json"
+    resp = await client.post("/api/cluster/workers", content=reg, headers=headers)
+    assert resp.status_code == 200, resp.text
+
+    nodes = (await client.get("/api/cluster/capability")).json()["nodes"]
+    node = next((n for n in nodes if n["node_id"] == "rig-1"), None)
+    assert node is not None
+    assert node["status"] == "online"
+    assert node["ram_mb"] == 16000
+    assert node["gpu"] == {"name": "rtx3060"}
+    assert node["hostname"] == "10.2.0.9"
+    await app.state.capability_map.close()
+
+
+@pytest.mark.asyncio
+async def test_registration_does_not_revive_drained_node(client, app):
+    """If an admin drained a node, re-registration keeps it draining."""
+    import json
+
+    await app.state.capability_map.init()
+    await app.state.cluster_pairing.init()
+    key = await pair_worker(client, app, "rig-2", "http://10.2.0.2:9000")
+    await app.state.capability_map.upsert({"node_id": "rig-2", "status": "draining"})
+
+    reg = json.dumps({"name": "rig-2", "url": "http://10.2.0.2:9000", "platform": "linux"}).encode()
+    headers = sign_worker_request(key, "rig-2", "POST", "/api/cluster/workers", reg)
+    headers["Content-Type"] = "application/json"
+    resp = await client.post("/api/cluster/workers", content=reg, headers=headers)
+    assert resp.status_code == 200
+
+    node = await app.state.capability_map.get("rig-2")
+    assert node["status"] == "draining"
+    await app.state.capability_map.close()

--- a/tests/test_routes_cluster_capability.py
+++ b/tests/test_routes_cluster_capability.py
@@ -225,3 +225,33 @@ async def test_registration_does_not_revive_drained_node(client, app):
     node = await app.state.capability_map.get("rig-2")
     assert node["status"] == "draining"
     await app.state.capability_map.close()
+
+
+@pytest.mark.asyncio
+async def test_reregistration_without_hardware_preserves_stored(client, app):
+    """A re-register with empty hardware must not wipe previously-detected fields."""
+    import json
+
+    await app.state.capability_map.init()
+    await app.state.cluster_pairing.init()
+    key = await pair_worker(client, app, "rig-3", "http://10.3.0.1:9000")
+    # First register with full hardware.
+    reg1 = json.dumps({
+        "name": "rig-3", "url": "http://10.3.0.1:9000", "platform": "linux",
+        "hardware": {"cpu": {"cores": 12}, "ram_mb": 32000, "gpu": {"name": "rtx4090"}, "npu": {}},
+    }).encode()
+    h1 = sign_worker_request(key, "rig-3", "POST", "/api/cluster/workers", reg1)
+    h1["Content-Type"] = "application/json"
+    assert (await client.post("/api/cluster/workers", content=reg1, headers=h1)).status_code == 200
+
+    # Re-register with NO hardware (legacy/flat-mode worker).
+    reg2 = json.dumps({"name": "rig-3", "url": "http://10.3.0.1:9000", "platform": "linux"}).encode()
+    h2 = sign_worker_request(key, "rig-3", "POST", "/api/cluster/workers", reg2)
+    h2["Content-Type"] = "application/json"
+    assert (await client.post("/api/cluster/workers", content=reg2, headers=h2)).status_code == 200
+
+    node = await app.state.capability_map.get("rig-3")
+    assert node["ram_mb"] == 32000  # preserved
+    assert node["gpu"] == {"name": "rtx4090"}  # preserved
+    assert node["status"] == "online"
+    await app.state.capability_map.close()

--- a/tinyagentos/routes/cluster.py
+++ b/tinyagentos/routes/cluster.py
@@ -267,9 +267,40 @@ async def register_worker(request: Request, body: WorkerRegister):
         signing_key=signing_key,
     )
     await cluster.register_worker(info)
+    await _record_worker_capability(request.app, body.name, body.host_lan_ip, body.hardware)
     if body.pending_storage_backup:
         await _surface_storage_backup(request.app, body.name, body.pending_storage_backup)
     return {"status": "registered", "name": body.name}
+
+
+async def _record_worker_capability(app, name: str, host_lan_ip: str, hardware: dict) -> None:
+    """Populate the capability map from a registering worker (best effort).
+
+    The worker's detected hardware dict already carries cpu/ram_mb/gpu/npu, the
+    same shape the capability map stores, so registration doubles as a heartbeat
+    that marks the node online. A failure here must never fail registration; an
+    explicit admin set-status still owns 'draining'.
+    """
+    store = getattr(app.state, "capability_map", None)
+    if store is None:
+        return
+    hw = hardware or {}
+    try:
+        current = await store.get(name)
+        status = "draining" if current is not None and current["status"] == "draining" else "online"
+        await store.upsert(
+            {
+                "node_id": name,
+                "hostname": host_lan_ip or name,
+                "cpu": hw.get("cpu", {}),
+                "ram_mb": hw.get("ram_mb", 0),
+                "gpu": hw.get("gpu", {}),
+                "npu": hw.get("npu", {}),
+                "status": status,
+            }
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning("capability-map upsert on worker registration failed for %s", name)
 
 
 async def _surface_storage_backup(app, worker_name: str, marker: dict) -> None:

--- a/tinyagentos/routes/cluster.py
+++ b/tinyagentos/routes/cluster.py
@@ -288,14 +288,23 @@ async def _record_worker_capability(app, name: str, host_lan_ip: str, hardware: 
     try:
         current = await store.get(name)
         status = "draining" if current is not None and current["status"] == "draining" else "online"
+        # The store does a full-row overwrite, so a legacy/flat-mode worker that
+        # re-registers without hardware would wipe previously-detected fields.
+        # Carry forward each field the incoming hardware omits.
+        prev = current or {}
+
+        def _keep(key, default):
+            val = hw.get(key)
+            return val if val else prev.get(key, default)
+
         await store.upsert(
             {
                 "node_id": name,
-                "hostname": host_lan_ip or name,
-                "cpu": hw.get("cpu", {}),
-                "ram_mb": hw.get("ram_mb", 0),
-                "gpu": hw.get("gpu", {}),
-                "npu": hw.get("npu", {}),
+                "hostname": host_lan_ip or prev.get("hostname") or name,
+                "cpu": _keep("cpu", {}),
+                "ram_mb": _keep("ram_mb", 0),
+                "gpu": _keep("gpu", {}),
+                "npu": _keep("npu", {}),
                 "status": status,
             }
         )


### PR DESCRIPTION
Cluster epic slice 2: connects the capability map (#1239/#1276) to reality.

A paired worker's HMAC `POST /api/cluster/workers` registration now also records its detected hardware into the capability map and marks the node `online`. The worker's `hardware` dict already carries `cpu`/`ram_mb`/`gpu`/`npu` (the exact shape the map stores), so the map populates from live workers with **zero worker-side change**.

- Best-effort: a capability-map failure is logged and never fails registration.
- An admin's `draining` decision survives re-registration (only an explicit set-status clears it), consistent with the heartbeat rule from #1276.

## Tests
2 added (registration populates cpu/ram/gpu/hostname + online; drained node not revived by re-registration). Full cluster + pairing suites green; compileall clean.

Guardrails: reuses worker HMAC (no new auth), no DB migrations, no installer/boot changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added additional coverage for the worker registration flow into the cluster capability map, including hardware population, preservation of existing “draining” status, and ensuring re-registration without hardware does not clear stored hardware details.

* **Improvements**
  * Worker registration now best-effort updates capability-map entries with hardware details (RAM, GPU, hostname) and maintains node status logic so drained nodes remain draining; successful responses remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->