### PR TITLE
feat(coding): model-agnostic tool-calling loop engine (#86)

### DIFF
--- a/tests/test_coding_loop.py
+++ b/tests/test_coding_loop.py
@@ -109,3 +109,34 @@ async def test_loop_passes_growing_transcript_to_model(tmp_path):
     assert seen_roles[0] == "user"
     assert "tool" in seen_roles
     assert out["final"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_loop_non_dict_step_stops_safely(tmp_path):
+    """model_step returning None / a list must not crash the loop."""
+    async def returns_none(transcript):
+        return None
+
+    out = await coding_loop.run_tool_loop(tmp_path, returns_none)
+    assert out["stopped"] == "final"
+    assert out["final"] is None
+    assert out["iterations"] == 1
+
+
+@pytest.mark.asyncio
+async def test_loop_malformed_call_entry_is_soft_error(tmp_path):
+    """A non-dict entry in calls surfaces as a soft error, loop continues."""
+    steps = [
+        {"type": "tool_calls", "calls": ["not-a-dict", None]},
+        {"type": "final", "text": "kept going"},
+    ]
+    seq = list(steps)
+
+    async def model_step(transcript):
+        return seq.pop(0) if seq else {"type": "final", "text": "done"}
+
+    out = await coding_loop.run_tool_loop(tmp_path, model_step)
+    assert out["final"] == "kept going"
+    tool_msgs = [m for m in out["transcript"] if m["role"] == "tool"]
+    assert all(m["result"]["ok"] is False for m in tool_msgs)
+    assert tool_msgs[0]["result"]["error"] == "malformed tool call"

--- a/tests/test_coding_loop.py
+++ b/tests/test_coding_loop.py
@@ -1,0 +1,111 @@
+"""Tests for the Coding Studio tool-calling loop engine (#86).
+
+The loop is model-agnostic: a scripted ``model_step`` stands in for the real
+model glue, so we can exercise the drive/dispatch/guard logic deterministically.
+"""
+import pytest
+
+from tinyagentos.agent_tools import coding_loop
+
+
+def _scripted(steps):
+    """Return a model_step that yields the given steps in order, then finals."""
+    seq = list(steps)
+    last_transcript = {}
+
+    async def model_step(transcript):
+        last_transcript["value"] = transcript
+        if seq:
+            return seq.pop(0)
+        return {"type": "final", "text": "done"}
+
+    model_step.last = last_transcript
+    return model_step
+
+
+@pytest.mark.asyncio
+async def test_loop_writes_then_reads_then_finishes(tmp_path):
+    """A two-tool plan runs against the workspace and the loop returns final."""
+    steps = [
+        {
+            "type": "tool_calls",
+            "calls": [
+                {"id": "c1", "name": "write_file", "arguments": {"path": "a.txt", "content": "hi"}},
+            ],
+        },
+        {
+            "type": "tool_calls",
+            "calls": [{"id": "c2", "name": "read_file", "arguments": {"path": "a.txt"}}],
+        },
+        {"type": "final", "text": "the file says hi"},
+    ]
+    out = await coding_loop.run_tool_loop(tmp_path, _scripted(steps))
+    assert out["stopped"] == "final"
+    assert out["final"] == "the file says hi"
+    assert out["iterations"] == 3
+    assert (tmp_path / "a.txt").read_text() == "hi"
+    # The read result is in the transcript for the model to have consumed.
+    tool_msgs = [m for m in out["transcript"] if m["role"] == "tool"]
+    assert tool_msgs[-1]["result"] == {"ok": True, "result": "hi"}
+
+
+@pytest.mark.asyncio
+async def test_loop_immediate_final(tmp_path):
+    out = await coding_loop.run_tool_loop(tmp_path, _scripted([{"type": "final", "text": "nothing to do"}]))
+    assert out["iterations"] == 1
+    assert out["final"] == "nothing to do"
+
+
+@pytest.mark.asyncio
+async def test_loop_tool_error_is_fed_back_not_raised(tmp_path):
+    """A failing tool call surfaces as a soft error in the transcript; loop continues."""
+    steps = [
+        {
+            "type": "tool_calls",
+            "calls": [{"id": "c1", "name": "read_file", "arguments": {"path": "../escape"}}],
+        },
+        {"type": "final", "text": "recovered"},
+    ]
+    out = await coding_loop.run_tool_loop(tmp_path, _scripted(steps))
+    assert out["final"] == "recovered"
+    tool_msg = next(m for m in out["transcript"] if m["role"] == "tool")
+    assert tool_msg["result"]["ok"] is False
+
+
+@pytest.mark.asyncio
+async def test_loop_respects_max_iterations(tmp_path):
+    """A model that never finishes is stopped by the iteration guard."""
+    # Always asks for a (harmless) list_dir, never finals.
+    async def never_done(transcript):
+        return {"type": "tool_calls", "calls": [{"id": "x", "name": "list_dir", "arguments": {}}]}
+
+    out = await coding_loop.run_tool_loop(tmp_path, never_done, max_iterations=3)
+    assert out["stopped"] == "max_iterations"
+    assert out["final"] is None
+    assert out["iterations"] == 3
+
+
+@pytest.mark.asyncio
+async def test_loop_unknown_step_shape_stops_safely(tmp_path):
+    async def garbage(transcript):
+        return {"type": "???"}
+
+    out = await coding_loop.run_tool_loop(tmp_path, garbage)
+    assert out["stopped"] == "final"
+    assert out["final"] is None
+    assert out["iterations"] == 1
+
+
+@pytest.mark.asyncio
+async def test_loop_passes_growing_transcript_to_model(tmp_path):
+    steps = [
+        {"type": "tool_calls", "calls": [{"id": "c1", "name": "list_dir", "arguments": {}}]},
+        {"type": "final", "text": "ok"},
+    ]
+    ms = _scripted(steps)
+    out = await coding_loop.run_tool_loop(tmp_path, ms, initial_transcript=[{"role": "user", "content": "go"}])
+    # By the final step the model saw the user msg, the assistant tool_calls, and the tool result.
+    seen_roles = [m["role"] for m in ms.last["value"]]
+    assert seen_roles[0] == "user"
+    assert "tool" in seen_roles
+    assert out["final"] == "ok"

--- a/tinyagentos/agent_tools/coding_loop.py
+++ b/tinyagentos/agent_tools/coding_loop.py
@@ -54,7 +54,9 @@ async def run_tool_loop(
     while iterations < max_iterations:
         iterations += 1
         step = await model_step(transcript)
-        kind = step.get("type")
+        # A misbehaving model_step that returns a non-mapping must not crash the
+        # loop (its whole contract is to stay resilient); treat it as a safe stop.
+        kind = step.get("type") if isinstance(step, dict) else None
 
         if kind == "final":
             text = step.get("text", "")
@@ -70,6 +72,18 @@ async def run_tool_loop(
             calls = step.get("calls") or []
             transcript.append({"role": "assistant", "tool_calls": calls})
             for call in calls:
+                # A non-dict call entry (bare string, None) must surface as a soft
+                # error, not crash the loop via .get on a non-mapping.
+                if not isinstance(call, dict):
+                    transcript.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": None,
+                            "name": None,
+                            "result": {"ok": False, "error": "malformed tool call"},
+                        }
+                    )
+                    continue
                 result = coding_tools.dispatch(
                     workspace_root, call.get("name"), call.get("arguments")
                 )

--- a/tinyagentos/agent_tools/coding_loop.py
+++ b/tinyagentos/agent_tools/coding_loop.py
@@ -1,0 +1,102 @@
+"""The Coding Studio agent tool-calling loop (#86).
+
+This is the loop the coding epic is named for. It sits on top of the dispatch
+step (coding_tools.dispatch) and is deliberately model-agnostic: it drives any
+``model_step`` callable that, given the running transcript, either asks for tool
+calls or returns a final answer. The model glue (Anthropic / litellm / a local
+model) provides ``model_step`` in a later slice; the loop, the tool execution,
+and the iteration guard live here so they are testable without a live model.
+
+Flow per turn:
+  model_step(transcript) -> {"type": "tool_calls", "calls": [...]} or
+                            {"type": "final", "text": "..."}
+  each call -> coding_tools.dispatch(workspace_root, name, arguments)
+            -> appended to the transcript as a tool_result
+  repeat until the model returns a final answer or max_iterations is reached.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable
+
+from tinyagentos.agent_tools import coding_tools
+
+# A model_step is an async callable: (transcript) -> step dict.
+ModelStep = Callable[[list[dict]], Awaitable[dict]]
+
+
+async def run_tool_loop(
+    workspace_root,
+    model_step: ModelStep,
+    *,
+    initial_transcript: list[dict] | None = None,
+    max_iterations: int = 8,
+) -> dict[str, Any]:
+    """Drive a tool-calling loop to completion against one workspace.
+
+    Returns:
+      {
+        "final": <str | None>,        # the model's final answer, or None if the
+                                      #   iteration guard tripped first
+        "iterations": <int>,          # model_step turns taken
+        "stopped": <"final"|"max_iterations">,
+        "transcript": [...],          # full message list, including tool results
+      }
+
+    The transcript grows with two message shapes the model glue produces/reads:
+      {"role": "assistant", "tool_calls": [{"id","name","arguments"}, ...]}
+      {"role": "tool", "tool_call_id": <id>, "name": <name>, "result": <dispatch dict>}
+    A final answer is recorded as {"role": "assistant", "content": <text>}.
+    """
+    transcript: list[dict] = list(initial_transcript or [])
+    iterations = 0
+
+    while iterations < max_iterations:
+        iterations += 1
+        step = await model_step(transcript)
+        kind = step.get("type")
+
+        if kind == "final":
+            text = step.get("text", "")
+            transcript.append({"role": "assistant", "content": text})
+            return {
+                "final": text,
+                "iterations": iterations,
+                "stopped": "final",
+                "transcript": transcript,
+            }
+
+        if kind == "tool_calls":
+            calls = step.get("calls") or []
+            transcript.append({"role": "assistant", "tool_calls": calls})
+            for call in calls:
+                result = coding_tools.dispatch(
+                    workspace_root, call.get("name"), call.get("arguments")
+                )
+                transcript.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": call.get("id"),
+                        "name": call.get("name"),
+                        "result": result,
+                    }
+                )
+            continue
+
+        # An unrecognised step shape is treated as a final, empty answer rather
+        # than looping forever on a misbehaving model_step.
+        transcript.append({"role": "assistant", "content": ""})
+        return {
+            "final": None,
+            "iterations": iterations,
+            "stopped": "final",
+            "transcript": transcript,
+        }
+
+    # Iteration guard tripped: the model never produced a final answer.
+    return {
+        "final": None,
+        "iterations": iterations,
+        "stopped": "max_iterations",
+        "transcript": transcript,
+    }


### PR DESCRIPTION
Coding epic slice 3: the actual tool-calling **loop** the epic is named for, sitting on top of the dispatch step (#1278).

`run_tool_loop(workspace_root, model_step, ...)` drives any async `model_step` that, given the running transcript, returns either `{type: tool_calls, calls: [...]}` or `{type: final, text}`. Each call runs through `coding_tools.dispatch` (jailed) and its result is appended to the transcript before the next turn.

Deliberately **model-agnostic**: the loop, tool execution, and guards live here and are testable now; the real model glue (Anthropic / litellm / a local model) plugs in as `model_step` in a follow-up slice without touching this logic.

Built-in safety:
- iteration guard (`max_iterations`) so a model that never finishes is stopped, returning `stopped: max_iterations`.
- soft-error feed-back: a failing tool call surfaces as `{ok: false, ...}` in the transcript and the loop continues (never raises).
- an unrecognised step shape stops safely instead of looping forever.

## Tests
6 with a scripted fake model: write->read->final, immediate final, tool-error recovery, max-iterations guard, garbage-step safety, growing-transcript visibility. coding tool/loop suites green; compileall clean.

Guardrails: pure logic over the existing jailed dispatch, no new auth, no DB, no installer/boot.