### PR TITLE
feat(audit): project-scoped activity feed + project_id/detail columns (#105)

### DIFF
--- a/tests/test_board_audit.py
+++ b/tests/test_board_audit.py
@@ -70,3 +70,62 @@ async def test_get_returns_event_or_none(tmp_path):
     assert (await s.get(eid))["event"] == "open"
     assert await s.get("ba-missing") is None
     await s.close()
+
+
+@pytest.mark.asyncio
+async def test_recent_for_project_scoped_and_newest_first(tmp_path):
+    s = await _log(tmp_path)
+    await s.record("tsk-a", "task.created", project_id="prj-1", to_status="open")
+    await s.record("tsk-b", "task.created", project_id="prj-2", to_status="open")
+    await s.record("tsk-a", "task.closed", project_id="prj-1", to_status="closed")
+    feed = await s.recent_for_project("prj-1")
+    # Only prj-1 events, newest first.
+    assert [e["event"] for e in feed] == ["task.closed", "task.created"]
+    assert all(e["project_id"] == "prj-1" for e in feed)
+    await s.close()
+
+
+@pytest.mark.asyncio
+async def test_recent_for_project_respects_limit(tmp_path):
+    s = await _log(tmp_path)
+    for i in range(5):
+        await s.record(f"tsk-{i}", "task.created", project_id="prj-1", to_status="open")
+    assert len(await s.recent_for_project("prj-1", limit=2)) == 2
+    await s.close()
+
+
+@pytest.mark.asyncio
+async def test_record_stores_detail_json(tmp_path):
+    s = await _log(tmp_path)
+    eid = await s.record("tsk-1", "task.created", project_id="prj-1", detail={"title": "Ship it"})
+    ev = await s.get(eid)
+    assert ev["detail"] == {"title": "Ship it"}
+    await s.close()
+
+
+@pytest.mark.asyncio
+async def test_post_init_migrates_old_schema(tmp_path):
+    """An existing board_audit table without project_id/detail is upgraded in place."""
+    import aiosqlite
+
+    db = tmp_path / "old.db"
+    async with aiosqlite.connect(str(db)) as conn:
+        await conn.execute(
+            "CREATE TABLE board_audit (id TEXT PRIMARY KEY, task_id TEXT NOT NULL, "
+            "event TEXT NOT NULL, actor TEXT NOT NULL DEFAULT '', from_status TEXT, "
+            "to_status TEXT, ts TEXT NOT NULL)"
+        )
+        await conn.execute(
+            "INSERT INTO board_audit (id, task_id, event, ts) VALUES ('ba-old', 'tsk-z', 'task.created', '2026-01-01T00:00:00+00:00')"
+        )
+        await conn.commit()
+
+    s = BoardAuditLog(db)
+    await s.init()  # _post_init should ALTER in the new columns
+    ev = await s.get("ba-old")
+    assert ev["project_id"] == ""
+    assert ev["detail"] == {}
+    # New writes carry project_id and are queryable by the feed.
+    await s.record("tsk-new", "task.created", project_id="prj-9", to_status="open")
+    assert len(await s.recent_for_project("prj-9")) == 1
+    await s.close()

--- a/tests/test_board_audit_wiring.py
+++ b/tests/test_board_audit_wiring.py
@@ -70,3 +70,28 @@ async def test_failed_transition_is_not_audited(client):
     events = (await client.get(f"/api/projects/{pid}/tasks/{tid}/audit")).json()["events"]
     # Only the creation event; the failed reopen left no trace.
     assert [e["event"] for e in events] == ["task.created"]
+
+
+@pytest.mark.asyncio
+async def test_project_audit_feed_is_scoped(client):
+    """The project-wide feed returns only that project's events, newest first."""
+    p1 = (await client.post("/api/projects", json={"name": "P1", "slug": "p1"})).json()["id"]
+    p2 = (await client.post("/api/projects", json={"name": "P2", "slug": "p2"})).json()["id"]
+    t1 = (await client.post(f"/api/projects/{p1}/tasks", json={"title": "A"})).json()["id"]
+    await client.post(f"/api/projects/{p2}/tasks", json={"title": "B"})
+    await client.post(f"/api/projects/{p1}/tasks/{t1}/claim", json={"claimer_id": "agent-1"})
+
+    feed = (await client.get(f"/api/projects/{p1}/audit")).json()["events"]
+    events = [e["event"] for e in feed]
+    # Newest first: claim then create; nothing from p2.
+    assert events == ["task.claimed", "task.created"]
+    assert all(e["project_id"] == p1 for e in feed)
+
+
+@pytest.mark.asyncio
+async def test_project_audit_feed_limit_clamped(client):
+    p1 = (await client.post("/api/projects", json={"name": "P1", "slug": "p1"})).json()["id"]
+    await client.post(f"/api/projects/{p1}/tasks", json={"title": "A"})
+    await client.post(f"/api/projects/{p1}/tasks", json={"title": "B"})
+    feed = (await client.get(f"/api/projects/{p1}/audit", params={"limit": 1})).json()["events"]
+    assert len(feed) == 1

--- a/tinyagentos/board_audit.py
+++ b/tinyagentos/board_audit.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import json
 import secrets
 
 from tinyagentos.base_store import BaseStore
@@ -11,17 +12,22 @@ BOARD_AUDIT_SCHEMA = """
 CREATE TABLE IF NOT EXISTS board_audit (
     id TEXT PRIMARY KEY,
     task_id TEXT NOT NULL,
+    project_id TEXT NOT NULL DEFAULT '',
     event TEXT NOT NULL,
     actor TEXT NOT NULL DEFAULT '',
     from_status TEXT,
     to_status TEXT,
+    detail TEXT NOT NULL DEFAULT '{}',
     ts TEXT NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_board_audit_task ON board_audit(task_id);
 CREATE INDEX IF NOT EXISTS idx_board_audit_ts ON board_audit(ts);
 """
+# The project_id index is created in _post_init (not SCHEMA): on an existing
+# board_audit table that predates the column, running it here would fail before
+# the guarded ALTER had a chance to add the column.
 
-_COLS = "id, task_id, event, actor, from_status, to_status, ts"
+_COLS = "id, task_id, project_id, event, actor, from_status, to_status, detail, ts"
 
 
 def _now_iso() -> str:
@@ -34,8 +40,8 @@ def _new_id() -> str:
 
 def _row(r) -> dict:
     return {
-        "id": r[0], "task_id": r[1], "event": r[2], "actor": r[3],
-        "from_status": r[4], "to_status": r[5], "ts": r[6],
+        "id": r[0], "task_id": r[1], "project_id": r[2], "event": r[3], "actor": r[4],
+        "from_status": r[5], "to_status": r[6], "detail": json.loads(r[7] or "{}"), "ts": r[8],
     }
 
 
@@ -46,9 +52,33 @@ class BoardAuditLog(BaseStore):
     change is recorded and never updated or deleted. There is deliberately no
     public mutate or delete method. History is returned in insertion order
     (SQLite rowid) so it is stable even when two events share a timestamp.
+
+    Each row carries the owning project_id (so a project-scoped activity feed
+    never leaks another project's events) and a free-form JSON ``detail`` blob
+    for event-specific context that does not fit the status columns.
     """
 
     SCHEMA = BOARD_AUDIT_SCHEMA
+
+    async def _post_init(self) -> None:
+        # project_id + detail were added after the initial board_audit ship.
+        # Guarded ALTER so existing databases gain them without a destructive
+        # migration (SQLite lacks ADD COLUMN IF NOT EXISTS before 3.37).
+        cols = {row[1] for row in await (await self._db.execute("PRAGMA table_info(board_audit)")).fetchall()}
+        if "project_id" not in cols:
+            await self._db.execute(
+                "ALTER TABLE board_audit ADD COLUMN project_id TEXT NOT NULL DEFAULT ''"
+            )
+        if "detail" not in cols:
+            await self._db.execute(
+                "ALTER TABLE board_audit ADD COLUMN detail TEXT NOT NULL DEFAULT '{}'"
+            )
+        # The column is guaranteed present now (fresh via SCHEMA or just ALTERed),
+        # so the project_id index can be created idempotently for both paths.
+        await self._db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_board_audit_project ON board_audit(project_id)"
+        )
+        await self._db.commit()
 
     async def record(
         self,
@@ -58,6 +88,8 @@ class BoardAuditLog(BaseStore):
         from_status: str | None = None,
         to_status: str | None = None,
         ts: str | None = None,
+        project_id: str = "",
+        detail: dict | None = None,
     ) -> str:
         if not task_id:
             raise ValueError("task_id is required")
@@ -66,8 +98,9 @@ class BoardAuditLog(BaseStore):
         eid = _new_id()
         when = ts or _now_iso()
         await self._db.execute(
-            f"INSERT INTO board_audit ({_COLS}) VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (eid, task_id, event, actor, from_status, to_status, when),
+            f"INSERT INTO board_audit ({_COLS}) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (eid, task_id, project_id, event, actor, from_status, to_status,
+             json.dumps(detail or {}), when),
         )
         await self._db.commit()
         return eid
@@ -76,6 +109,15 @@ class BoardAuditLog(BaseStore):
         async with self._db.execute(
             f"SELECT {_COLS} FROM board_audit WHERE task_id = ? ORDER BY rowid ASC",
             (task_id,),
+        ) as cur:
+            rows = await cur.fetchall()
+        return [_row(r) for r in rows]
+
+    async def recent_for_project(self, project_id: str, limit: int = 100) -> list[dict]:
+        """Newest-first activity feed for one project (capped)."""
+        async with self._db.execute(
+            f"SELECT {_COLS} FROM board_audit WHERE project_id = ? ORDER BY rowid DESC LIMIT ?",
+            (project_id, limit),
         ) as cur:
             rows = await cur.fetchall()
         return [_row(r) for r in rows]

--- a/tinyagentos/projects/task_store.py
+++ b/tinyagentos/projects/task_store.py
@@ -113,11 +113,13 @@ class ProjectTaskStore(BaseStore):
         actor: str,
         from_status: str | None,
         to_status: str | None,
+        project_id: str = "",
     ) -> None:
         """Append a status transition to the board audit log (best effort).
 
         The audit log lives in its own store; a failure to record must never
-        roll back or break the task mutation that already committed.
+        roll back or break the task mutation that already committed. project_id
+        is recorded so the project-scoped activity feed never crosses projects.
         """
         if self._audit is None:
             return
@@ -128,6 +130,7 @@ class ProjectTaskStore(BaseStore):
                 actor=actor,
                 from_status=from_status,
                 to_status=to_status,
+                project_id=project_id,
             )
         except Exception:
             logger.warning("board audit record failed for task %s", task_id, exc_info=True)
@@ -158,7 +161,7 @@ class ProjectTaskStore(BaseStore):
         await self._db.commit()
         new_task = await self.get_task(tid)
         await self._publish(project_id, "task.created", {"id": new_task["id"], "task": new_task})
-        await self._record_audit(tid, "task.created", created_by, None, "open")
+        await self._record_audit(tid, "task.created", created_by, None, "open", project_id=project_id)
         return new_task
 
     async def get_task(self, task_id: str) -> dict | None:
@@ -242,7 +245,10 @@ class ProjectTaskStore(BaseStore):
             existing = await self.get_task(task_id)
             if existing is not None:
                 await self._publish(existing["project_id"], "task.claimed", {"id": task_id, "claimed_by": claimer_id})
-            await self._record_audit(task_id, "task.claimed", claimer_id, "open", "claimed")
+            await self._record_audit(
+                task_id, "task.claimed", claimer_id, "open", "claimed",
+                project_id=existing["project_id"] if existing else "",
+            )
         return changed
 
     async def release_task(self, task_id: str, releaser_id: str) -> bool:
@@ -263,7 +269,10 @@ class ProjectTaskStore(BaseStore):
                     "task.released",
                     {"id": task_id, "releaser_id": releaser_id},
                 )
-            await self._record_audit(task_id, "task.released", releaser_id, "claimed", "open")
+            await self._record_audit(
+                task_id, "task.released", releaser_id, "claimed", "open",
+                project_id=existing["project_id"] if existing else "",
+            )
         return changed
 
     async def close_task(
@@ -289,7 +298,10 @@ class ProjectTaskStore(BaseStore):
             # than a separate pre-read (which would have a TOCTOU gap). close does
             # not clear claimed_by, so a set claimer means it was 'claimed'.
             from_status = "claimed" if existing and existing.get("claimed_by") else "open"
-            await self._record_audit(task_id, "task.closed", closed_by, from_status, "closed")
+            await self._record_audit(
+                task_id, "task.closed", closed_by, from_status, "closed",
+                project_id=existing["project_id"] if existing else "",
+            )
         return changed
 
     async def reopen_task(self, task_id: str, reopened_by: str) -> bool:
@@ -310,7 +322,10 @@ class ProjectTaskStore(BaseStore):
             existing = await self.get_task(task_id)
             if existing is not None:
                 await self._publish(existing["project_id"], "task.reopened", {"id": task_id, "reopened_by": reopened_by})
-            await self._record_audit(task_id, "task.reopened", reopened_by, "closed", "open")
+            await self._record_audit(
+                task_id, "task.reopened", reopened_by, "closed", "open",
+                project_id=existing["project_id"] if existing else "",
+            )
         return changed
 
     async def add_relationship(

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -654,6 +654,28 @@ async def reopen_task(
     return await store.get_task(task_id)
 
 
+@router.get("/api/projects/{project_id}/audit")
+async def project_audit_feed(
+    project_id: str,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+    limit: int = 100,
+):
+    """Project-wide board activity feed, newest first (owner-gated, #105).
+
+    Scoped to the project so it never surfaces another project's events. limit
+    is clamped to a sane ceiling to keep the response bounded.
+    """
+    pstore = request.app.state.project_store
+    project_or_err = await _get_owned_project(pstore, project_id, user)
+    if isinstance(project_or_err, JSONResponse):
+        return project_or_err
+    audit = getattr(request.app.state, "board_audit", None)
+    capped = max(1, min(limit, 500))
+    events = await audit.recent_for_project(project_id, capped) if audit is not None else []
+    return {"project_id": project_id, "events": events}
+
+
 @router.get("/api/projects/{project_id}/tasks/{task_id}/audit")
 async def task_audit_history(
     project_id: str,


### PR DESCRIPTION
Append-only audit epic slice 2: a board-wide activity feed, scoped so it never leaks another project's events.

## What
- `board_audit` gains a `project_id` column and a free-form JSON `detail` column. Fresh DBs get them from SCHEMA; existing DBs are upgraded by a guarded `_post_init` ALTER (PRAGMA table_info check, additive only, no data loss). The `project_id` index moved to `_post_init` so it is never created before the column exists.
- `record()` accepts `project_id` + `detail`; `ProjectTaskStore` threads the owning project_id through create/claim/release/close/reopen.
- `recent_for_project(project_id, limit)` returns a newest-first, capped feed.
- `GET /api/projects/{project_id}/audit` exposes it, owner-gated via the same ownership check as the rest of the projects routes, scoped to the project, `limit` clamped to 1..500.

This was the slice I held last round on the privacy/migration concern: project_id scoping closes the cross-project leak, and the migration is additive-only on a brand-new (unreleased) table.

## Tests
8 added: store scoping + limit + detail JSON + **old-schema migration** (creates a pre-column table, asserts the ALTER upgrades it in place), plus route-level cross-project isolation and limit clamp. Lifecycle + task-store suites green; compileall clean.

Guardrails: additive idempotent migration (no destructive change), no new auth (reuses project ownership), no installer/boot changes.