### PR TITLE
feat(cluster): stale-node offline sweep (non-destructive) (#897)

### DIFF
--- a/tests/test_capability_map.py
+++ b/tests/test_capability_map.py
@@ -117,3 +117,22 @@ async def test_upsert_requires_node_id(tmp_path):
     with pytest.raises(ValueError):
         await s.upsert({"hostname": "x"})
     await s.close()
+
+
+@pytest.mark.asyncio
+async def test_mark_stale_offline_preserves_row(tmp_path):
+    s = CapabilityMap(tmp_path / "cap.db")
+    await s.init()
+    # Fresh online node (recent last_seen) + a stale online one + a draining one.
+    await s.upsert({"node_id": "fresh", "status": "online"})
+    await s.upsert({"node_id": "stale", "status": "online", "last_seen": 1})
+    await s.upsert({"node_id": "drain", "status": "draining", "last_seen": 1})
+    flipped = await s.mark_stale_offline(older_than_s=60)
+    assert flipped == 1
+    assert (await s.get("stale"))["status"] == "offline"
+    assert (await s.get("fresh"))["status"] == "online"
+    # draining is an admin intent; a stale sweep must not touch it.
+    assert (await s.get("drain"))["status"] == "draining"
+    # The row is preserved, not deleted.
+    assert await s.get("stale") is not None
+    await s.close()

--- a/tests/test_routes_cluster_capability.py
+++ b/tests/test_routes_cluster_capability.py
@@ -167,3 +167,18 @@ async def test_prune_drops_stale(client, app):
     resp = await client.get("/api/cluster/capability")
     assert all(n["node_id"] != "node-a" for n in resp.json()["nodes"])
     await app.state.capability_map.close()
+
+
+@pytest.mark.asyncio
+async def test_sweep_offlines_stale_online_nodes(client, app):
+    """The sweep endpoint flips stale online nodes offline, keeping the row."""
+    await app.state.capability_map.init()
+    await app.state.capability_map.upsert({"node_id": "n-live", "status": "online"})
+    await app.state.capability_map.upsert({"node_id": "n-gone", "status": "online", "last_seen": 1})
+    resp = await client.post("/api/cluster/capability/sweep", json={"older_than_s": 60})
+    assert resp.status_code == 200
+    assert resp.json()["offlined"] == 1
+    nodes = {n["node_id"]: n["status"] for n in (await client.get("/api/cluster/capability")).json()["nodes"]}
+    assert nodes["n-gone"] == "offline"
+    assert nodes["n-live"] == "online"
+    await app.state.capability_map.close()

--- a/tinyagentos/cluster/capability_map.py
+++ b/tinyagentos/cluster/capability_map.py
@@ -108,3 +108,23 @@ class CapabilityMap(BaseStore):
             count = cur.rowcount
         await self._db.commit()
         return count
+
+    async def mark_stale_offline(self, older_than_s: int) -> int:
+        """Mark nodes that stopped heartbeating as offline (row preserved).
+
+        The non-destructive counterpart to prune_stale: an 'online' node whose
+        last_seen is older than the cutoff is flipped to 'offline' so the
+        scheduler stops placing work on it, but the row (and its hardware) stays
+        for history and for when it comes back. 'draining' is an admin intent
+        and is left untouched; only 'online' nodes go stale-offline. Returns the
+        number of nodes flipped.
+        """
+        cutoff = int(time.time()) - older_than_s
+        async with self._db.execute(
+            "UPDATE capability_map SET status = 'offline' "
+            "WHERE status = 'online' AND last_seen < ?",
+            (cutoff,),
+        ) as cur:
+            count = cur.rowcount
+        await self._db.commit()
+        return count

--- a/tinyagentos/routes/cluster_capability.py
+++ b/tinyagentos/routes/cluster_capability.py
@@ -119,3 +119,16 @@ async def capability_prune(request: Request, body: PruneRequest):
         return JSONResponse({"error": "capability map unavailable"}, status_code=503)
     removed = await store.prune_stale(body.older_than_s)
     return {"pruned": removed}
+
+
+@router.post("/api/cluster/capability/sweep")
+async def capability_sweep(request: Request, body: PruneRequest):
+    """Admin — flip online nodes with no recent heartbeat to offline (row kept)."""
+    ok, err = _require_admin(request)
+    if not ok:
+        return err
+    store = _store(request)
+    if store is None:
+        return JSONResponse({"error": "capability map unavailable"}, status_code=503)
+    flipped = await store.mark_stale_offline(body.older_than_s)
+    return {"offlined": flipped}


### PR DESCRIPTION
Cluster epic slice 3: mark unreachable nodes offline without losing them.

`CapabilityMap.mark_stale_offline(older_than_s)` is the non-destructive counterpart to `prune_stale`: an `online` node whose `last_seen` is older than the cutoff is flipped to `offline` (scheduler stops placing work on it) while the row and its hardware are preserved for history and for when the node returns. `draining` is an admin decision and is left untouched; only `online` nodes go stale-offline.

Exposed as `POST /api/cluster/capability/sweep` (admin). prune_stale stays as the eventual hard cleanup; sweep is the soft, reversible first step.

## Tests
2 (store: stale online -> offline, fresh + draining untouched, row preserved; route: sweep endpoint offlines stale and keeps live online). Capability suites green; compileall clean.

Guardrails: admin-gated reuse, no migration, no installer/boot.