### PR TITLE
feat(coding): litellm-backed model_step for the tool-calling loop (#86)

### DIFF
--- a/tests/test_coding_model.py
+++ b/tests/test_coding_model.py
@@ -1,0 +1,114 @@
+"""Tests for the litellm-backed model_step adapter (#86).
+
+A fake completion_fn stands in for litellm so the conversion + parsing logic is
+exercised without a live model or network.
+"""
+import json
+
+import pytest
+
+from tinyagentos.agent_tools import coding_loop, coding_model
+
+
+def test_to_openai_tools_shape():
+    tools = coding_model.to_openai_tools()
+    names = {t["function"]["name"] for t in tools}
+    assert names == {"read_file", "write_file", "file_exists", "list_dir"}
+    assert all(t["type"] == "function" for t in tools)
+    # parameters carry the input_schema verbatim.
+    read = next(t for t in tools if t["function"]["name"] == "read_file")
+    assert read["function"]["parameters"]["required"] == ["path"]
+
+
+def test_transcript_to_messages_maps_shapes():
+    transcript = [
+        {"role": "user", "content": "go"},
+        {"role": "assistant", "tool_calls": [{"id": "c1", "name": "list_dir", "arguments": {"path": "."}}]},
+        {"role": "tool", "tool_call_id": "c1", "name": "list_dir", "result": {"ok": True, "result": ["a"]}},
+    ]
+    msgs = coding_model.transcript_to_messages(transcript, system="be helpful")
+    assert msgs[0] == {"role": "system", "content": "be helpful"}
+    assert msgs[1]["content"] == "go"
+    # assistant tool_calls become OpenAI function tool_calls with stringified args.
+    tc = msgs[2]["tool_calls"][0]
+    assert tc["function"]["name"] == "list_dir"
+    assert json.loads(tc["function"]["arguments"]) == {"path": "."}
+    # tool result is JSON-encoded into content.
+    assert json.loads(msgs[3]["content"]) == {"ok": True, "result": ["a"]}
+
+
+class _Obj:
+    """Minimal object-style stand-in for a litellm response."""
+
+    def __init__(self, d):
+        self.__dict__.update(d)
+
+
+def test_parse_completion_object_style_tool_call():
+    resp = _Obj(
+        {
+            "choices": [
+                _Obj(
+                    {
+                        "message": _Obj(
+                            {
+                                "content": None,
+                                "tool_calls": [
+                                    _Obj(
+                                        {
+                                            "id": "c1",
+                                            "function": _Obj(
+                                                {"name": "write_file", "arguments": '{"path":"a.txt","content":"hi"}'}
+                                            ),
+                                        }
+                                    )
+                                ],
+                            }
+                        )
+                    }
+                )
+            ]
+        }
+    )
+    step = coding_model.parse_completion(resp)
+    assert step["type"] == "tool_calls"
+    assert step["calls"][0] == {"id": "c1", "name": "write_file", "arguments": {"path": "a.txt", "content": "hi"}}
+
+
+def test_parse_completion_dict_style_final():
+    resp = {"choices": [{"message": {"content": "all done", "tool_calls": None}}]}
+    assert coding_model.parse_completion(resp) == {"type": "final", "text": "all done"}
+
+
+def test_parse_completion_tolerates_bad_arguments():
+    resp = {"choices": [{"message": {"tool_calls": [{"id": "c1", "function": {"name": "list_dir", "arguments": "not-json"}}]}}]}
+    step = coding_model.parse_completion(resp)
+    assert step["calls"][0]["arguments"] == {}
+
+
+@pytest.mark.asyncio
+async def test_model_step_drives_loop_end_to_end(tmp_path):
+    """A scripted completion_fn + the real loop writes then reads a file."""
+    # Two model turns: first a write tool call, then a final answer.
+    scripted = [
+        {"choices": [{"message": {"tool_calls": [
+            {"id": "c1", "function": {"name": "write_file", "arguments": '{"path":"hello.py","content":"print(1)"}'}}
+        ]}}]},
+        {"choices": [{"message": {"content": "wrote hello.py", "tool_calls": None}}]},
+    ]
+    seen = {"models": [], "tools": None}
+
+    async def fake_completion(model, messages, tools):
+        seen["models"].append(model)
+        seen["tools"] = tools
+        return scripted.pop(0)
+
+    step = coding_model.make_litellm_model_step("openai/gpt-x", completion_fn=fake_completion)
+    out = await coding_loop.run_tool_loop(tmp_path, step)
+
+    assert out["stopped"] == "final"
+    assert out["final"] == "wrote hello.py"
+    assert (tmp_path / "hello.py").read_text() == "print(1)"
+    # The model was actually called with the workspace tools.
+    assert seen["models"] == ["openai/gpt-x", "openai/gpt-x"]
+    assert {t["function"]["name"] for t in seen["tools"]} == {"read_file", "write_file", "file_exists", "list_dir"}

--- a/tests/test_coding_model.py
+++ b/tests/test_coding_model.py
@@ -112,3 +112,15 @@ async def test_model_step_drives_loop_end_to_end(tmp_path):
     # The model was actually called with the workspace tools.
     assert seen["models"] == ["openai/gpt-x", "openai/gpt-x"]
     assert {t["function"]["name"] for t in seen["tools"]} == {"read_file", "write_file", "file_exists", "list_dir"}
+
+
+def test_parse_completion_empty_choices_is_safe_final():
+    assert coding_model.parse_completion({"choices": []}) == {"type": "final", "text": ""}
+
+
+def test_parse_completion_missing_choices_is_safe_final():
+    assert coding_model.parse_completion({}) == {"type": "final", "text": ""}
+
+
+def test_parse_completion_null_message_is_safe_final():
+    assert coding_model.parse_completion({"choices": [{"message": None}]}) == {"type": "final", "text": ""}

--- a/tinyagentos/agent_tools/coding_model.py
+++ b/tinyagentos/agent_tools/coding_model.py
@@ -101,9 +101,19 @@ def _message_field(message, key):
 
 
 def parse_completion(response) -> dict:
-    """Turn a chat-completion response into the loop's step shape."""
-    choices = response["choices"] if isinstance(response, dict) else response.choices
-    message = choices[0]["message"] if isinstance(choices[0], dict) else choices[0].message
+    """Turn a chat-completion response into the loop's step shape.
+
+    A content-filtered or error-shaped response can come back with no choices or
+    no message; fall back to an empty final answer rather than raising, so the
+    loop's never-raise contract holds.
+    """
+    choices = (response["choices"] if isinstance(response, dict) else getattr(response, "choices", None)) or []
+    if not choices:
+        return {"type": "final", "text": ""}
+    first = choices[0]
+    message = first["message"] if isinstance(first, dict) else getattr(first, "message", None)
+    if message is None:
+        return {"type": "final", "text": ""}
     tool_calls = _message_field(message, "tool_calls")
     if tool_calls:
         calls = []

--- a/tinyagentos/agent_tools/coding_model.py
+++ b/tinyagentos/agent_tools/coding_model.py
@@ -1,0 +1,147 @@
+"""A concrete ``model_step`` for the coding tool-calling loop (#86).
+
+The loop engine (coding_loop.run_tool_loop) is model-agnostic; this module
+supplies the real driver: it converts the loop transcript to OpenAI-style chat
+messages, hands the model the workspace tools, calls the completion, and parses
+the reply back into the loop's step shape ({"type": "tool_calls"|"final"}).
+
+The completion call is injectable (``completion_fn``) so this is testable
+without a live model or a network round trip; the default lazily imports
+litellm so importing this module never requires litellm to be installed.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from tinyagentos.agent_tools.coding_tools import TOOL_SCHEMAS
+
+
+def to_openai_tools(schemas: list[dict[str, Any]] | None = None) -> list[dict]:
+    """Convert the Anthropic-style tool schemas to OpenAI function-tool format."""
+    out = []
+    for s in schemas if schemas is not None else TOOL_SCHEMAS:
+        out.append(
+            {
+                "type": "function",
+                "function": {
+                    "name": s["name"],
+                    "description": s.get("description", ""),
+                    "parameters": s.get("input_schema", {"type": "object", "properties": {}}),
+                },
+            }
+        )
+    return out
+
+
+def transcript_to_messages(transcript: list[dict], system: str | None = None) -> list[dict]:
+    """Render the loop transcript as OpenAI chat messages.
+
+    Maps the loop's internal message shapes:
+      {"role": "user"|"assistant", "content": ...}            -> passthrough
+      {"role": "assistant", "tool_calls": [{id,name,arguments}]} -> assistant w/ tool_calls
+      {"role": "tool", "tool_call_id", "name", "result": {...}}  -> tool message (JSON result)
+    """
+    messages: list[dict] = []
+    if system:
+        messages.append({"role": "system", "content": system})
+    for m in transcript:
+        role = m.get("role")
+        if role == "assistant" and "tool_calls" in m:
+            messages.append(
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": c.get("id"),
+                            "type": "function",
+                            "function": {
+                                "name": c.get("name"),
+                                "arguments": json.dumps(c.get("arguments") or {}),
+                            },
+                        }
+                        for c in m["tool_calls"]
+                    ],
+                }
+            )
+        elif role == "tool":
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": m.get("tool_call_id"),
+                    "name": m.get("name"),
+                    "content": json.dumps(m.get("result")),
+                }
+            )
+        else:
+            messages.append({"role": role, "content": m.get("content", "")})
+    return messages
+
+
+def _parse_arguments(raw) -> dict:
+    """Tool-call arguments arrive as a JSON string from the model; tolerate dicts."""
+    if isinstance(raw, dict):
+        return raw
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+        return parsed if isinstance(parsed, dict) else {}
+    except (json.JSONDecodeError, TypeError):
+        return {}
+
+
+def _message_field(message, key):
+    """Read a field off either an object-style or dict-style completion message."""
+    if isinstance(message, dict):
+        return message.get(key)
+    return getattr(message, key, None)
+
+
+def parse_completion(response) -> dict:
+    """Turn a chat-completion response into the loop's step shape."""
+    choices = response["choices"] if isinstance(response, dict) else response.choices
+    message = choices[0]["message"] if isinstance(choices[0], dict) else choices[0].message
+    tool_calls = _message_field(message, "tool_calls")
+    if tool_calls:
+        calls = []
+        for tc in tool_calls:
+            fn = tc["function"] if isinstance(tc, dict) else tc.function
+            calls.append(
+                {
+                    "id": (tc.get("id") if isinstance(tc, dict) else getattr(tc, "id", None)),
+                    "name": (fn["name"] if isinstance(fn, dict) else fn.name),
+                    "arguments": _parse_arguments(
+                        fn["arguments"] if isinstance(fn, dict) else fn.arguments
+                    ),
+                }
+            )
+        return {"type": "tool_calls", "calls": calls}
+    return {"type": "final", "text": _message_field(message, "content") or ""}
+
+
+async def _default_completion(model: str, messages: list[dict], tools: list[dict]):
+    # Lazy import so this module never hard-requires litellm at import time.
+    import litellm
+
+    return await litellm.acompletion(model=model, messages=messages, tools=tools)
+
+
+def make_litellm_model_step(model: str, *, system: str | None = None, completion_fn=None):
+    """Build a model_step for run_tool_loop backed by a chat-completions model.
+
+    completion_fn(model, messages, tools) -> response is injectable (defaults to
+    litellm.acompletion). The returned async callable takes the loop transcript
+    and returns the next step.
+    """
+    call = completion_fn or _default_completion
+    tools = to_openai_tools()
+
+    async def model_step(transcript: list[dict]) -> dict:
+        messages = transcript_to_messages(transcript, system=system)
+        response = await call(model, messages, tools)
+        return parse_completion(response)
+
+    return model_step

--- a/tinyagentos/agent_tools/coding_model.py
+++ b/tinyagentos/agent_tools/coding_model.py
@@ -107,11 +107,11 @@ def parse_completion(response) -> dict:
     no message; fall back to an empty final answer rather than raising, so the
     loop's never-raise contract holds.
     """
-    choices = (response["choices"] if isinstance(response, dict) else getattr(response, "choices", None)) or []
+    choices = (response.get("choices") if isinstance(response, dict) else getattr(response, "choices", None)) or []
     if not choices:
         return {"type": "final", "text": ""}
     first = choices[0]
-    message = first["message"] if isinstance(first, dict) else getattr(first, "message", None)
+    message = (first.get("message") if isinstance(first, dict) else getattr(first, "message", None))
     if message is None:
         return {"type": "final", "text": ""}
     tool_calls = _message_field(message, "tool_calls")


### PR DESCRIPTION
Coding epic slice 4 (the piece that makes it run for real). Supplies the concrete `model_step` for the loop engine (#1280) so the coding agent drives a real chat-completions model against a jailed workspace.

> Stacked on #1280: this PR is based on `feat/coding-tool-loop-engine` so the diff shows only the model_step. It retargets to `dev` once #1280 merges.

## What
- `to_openai_tools()` — the workspace tool schemas in OpenAI function-tool format.
- `transcript_to_messages()` — loop transcript -> OpenAI chat messages (assistant `tool_calls` + `tool` result messages).
- `parse_completion()` — a completion reply -> the loop's step shape (`tool_calls`|`final`), tolerating object- or dict-shaped responses and bad / JSON-string arguments.
- `make_litellm_model_step(model, system=, completion_fn=)` — the `model_step`. `completion_fn` is injectable and defaults to a **lazily-imported** `litellm.acompletion`, so importing this module never hard-requires litellm and tests run with no model or network.

## Tests
7, incl. an **end-to-end loop run** driven by a scripted completion that writes then reads a workspace file (asserts the file lands and the model was called with the workspace tools). Coding loop/dispatch suites green together; compileall clean.

Guardrails: pure adapter over the existing loop + jailed dispatch, no new auth, no DB, no installer/boot.