### PR TITLE
feat(store): de-seed X/Reddit/YouTube/GitHub from the default store (#70)

### DIFF
--- a/desktop/src/registry/optional-apps.ts
+++ b/desktop/src/registry/optional-apps.ts
@@ -1,8 +1,13 @@
 /**
- * Presentation metadata for the optional, Store-installable frontend apps
- * (Reddit / YouTube / GitHub / X). The registry (app-registry.ts) owns the
- * runtime manifest (component, sizing); this owns how they look in the Store's
- * "taOS Apps" section. ids must match the registry entries marked `optional`.
+ * Presentation metadata for optional, Store-installable frontend apps. The
+ * registry (app-registry.ts) owns the runtime manifest (component, sizing);
+ * this owns how they look in the Store's "taOS Apps" section. ids must match
+ * the registry entries marked `optional`.
+ *
+ * The platform social apps (Reddit / YouTube / GitHub / X) were DE-SEEDED from
+ * the default Store: they are unfinished and now live as the operator's private
+ * App Studio drafts, to be finished + published on stream rather than offered to
+ * every user. Their registry manifests + components remain for that reseed.
  */
 
 export interface OptionalAppMeta {
@@ -18,33 +23,5 @@ export interface OptionalAppMeta {
   cover: string;
 }
 
-export const OPTIONAL_APPS: OptionalAppMeta[] = [
-  {
-    id: "reddit",
-    name: "Reddit",
-    icon: "scroll-text",
-    tagline: "Browse subreddits, posts, and comments inside taOS.",
-    cover: "linear-gradient(135deg, #ff4500 0%, #cc3700 100%)",
-  },
-  {
-    id: "youtube-library",
-    name: "YouTube",
-    icon: "play-circle",
-    tagline: "A focused video library and watch surface.",
-    cover: "linear-gradient(135deg, #ff0033 0%, #b3001f 100%)",
-  },
-  {
-    id: "github-browser",
-    name: "GitHub",
-    icon: "github",
-    tagline: "Track repos, issues, and pull requests at a glance.",
-    cover: "linear-gradient(135deg, #2b3137 0%, #14161a 100%)",
-  },
-  {
-    id: "x-monitor",
-    name: "X",
-    icon: "at-sign",
-    tagline: "Monitor timelines and posts from X.",
-    cover: "linear-gradient(135deg, #1a1a1a 0%, #000000 100%)",
-  },
-];
+// Empty after the social-app de-seed. New optional Store apps get added here.
+export const OPTIONAL_APPS: OptionalAppMeta[] = [];

--- a/tests/test_apps_installed.py
+++ b/tests/test_apps_installed.py
@@ -175,24 +175,24 @@ class TestOptionalApps:
         assert resp.json() == {"installed": []}
 
         # Install an allowlisted optional app.
-        resp = await client.post("/api/apps/optional/reddit/install")
+        resp = await client.post("/api/apps/optional/coding-studio/install")
         assert resp.status_code == 200
-        assert resp.json()["app_id"] == "reddit"
+        assert resp.json()["app_id"] == "coding-studio"
 
         resp = await client.get("/api/apps/optional/installed")
-        assert resp.json()["installed"] == ["reddit"]
+        assert resp.json()["installed"] == ["coding-studio"]
 
     @pytest.mark.asyncio
     async def test_uninstall_removes(self, apps_client):
         client, _ = apps_client
-        await client.post("/api/apps/optional/x-monitor/install")
+        await client.post("/api/apps/optional/coding-studio/install")
         resp = await client.get("/api/apps/optional/installed")
-        assert "x-monitor" in resp.json()["installed"]
+        assert "coding-studio" in resp.json()["installed"]
 
-        resp = await client.post("/api/apps/optional/x-monitor/uninstall")
+        resp = await client.post("/api/apps/optional/coding-studio/uninstall")
         assert resp.status_code == 200
         resp = await client.get("/api/apps/optional/installed")
-        assert "x-monitor" not in resp.json()["installed"]
+        assert "coding-studio" not in resp.json()["installed"]
 
     @pytest.mark.asyncio
     async def test_unknown_app_rejected(self, apps_client):
@@ -207,10 +207,10 @@ class TestOptionalApps:
         """Installed optional frontend apps must NOT show as proxy services
         (they have no runtime location)."""
         client, _ = apps_client
-        await client.post("/api/apps/optional/github-browser/install")
+        await client.post("/api/apps/optional/coding-studio/install")
         resp = await client.get("/api/apps/installed")
         ids = {i["app_id"] for i in resp.json()}
-        assert "github-browser" not in ids
+        assert "coding-studio" not in ids
 
 
 class TestOptionalAppCatalog:
@@ -237,20 +237,20 @@ class TestOptionalAppCatalog:
         """Installing an app should record the APP_VERSIONS version in the DB."""
         from tinyagentos.routes.apps import APP_VERSIONS
         client, store = apps_client
-        resp = await client.post("/api/apps/optional/reddit/install")
+        resp = await client.post("/api/apps/optional/coding-studio/install")
         assert resp.status_code == 200
         rows = await store.list_installed()
-        row = next((r for r in rows if r["app_id"] == "reddit"), None)
+        row = next((r for r in rows if r["app_id"] == "coding-studio"), None)
         assert row is not None
-        assert row["version"] == APP_VERSIONS["reddit"]
+        assert row["version"] == APP_VERSIONS["coding-studio"]
 
     @pytest.mark.asyncio
     async def test_update_available_false_for_fresh_install(self, apps_client):
         """A freshly installed app records the current version, so update_available=false."""
         client, _ = apps_client
-        await client.post("/api/apps/optional/youtube-library/install")
+        await client.post("/api/apps/optional/coding-studio/install")
         resp = await client.get("/api/apps/optional/catalog")
-        app = next(a for a in resp.json()["apps"] if a["id"] == "youtube-library")
+        app = next(a for a in resp.json()["apps"] if a["id"] == "coding-studio")
         assert app["installed"] is True
         assert app["update_available"] is False
 
@@ -263,15 +263,15 @@ class TestOptionalAppCatalog:
         # Seed the DB with an older version directly.
         await store._db.execute(
             "INSERT OR REPLACE INTO installed_apps (app_id, installed_at, version, metadata) VALUES (?, ?, ?, ?)",
-            ("x-monitor", 1000.0, "0.9.0", json.dumps({"kind": "frontend-app"})),
+            ("coding-studio", 1000.0, "0.9.0", json.dumps({"kind": "frontend-app"})),
         )
         await store._db.commit()
         resp = await client.get("/api/apps/optional/catalog")
-        app = next(a for a in resp.json()["apps"] if a["id"] == "x-monitor")
+        app = next(a for a in resp.json()["apps"] if a["id"] == "coding-studio")
         assert app["installed"] is True
-        # APP_VERSIONS["x-monitor"] is "1.0.0" which is > "0.9.0"
+        # APP_VERSIONS["coding-studio"] is "1.0.0" which is > "0.9.0"
         assert app["update_available"] is True
-        assert app["version"] == APP_VERSIONS["x-monitor"]
+        assert app["version"] == APP_VERSIONS["coding-studio"]
 
     @pytest.mark.asyncio
     async def test_catalog_does_not_leak_unknown_ids(self, apps_client):

--- a/tests/test_routes_apps.py
+++ b/tests/test_routes_apps.py
@@ -108,21 +108,21 @@ class TestOptionalInstalled:
 
     @pytest.mark.asyncio
     async def test_install_then_listed(self, client):
-        resp = await client.post("/api/apps/optional/reddit/install")
+        resp = await client.post("/api/apps/optional/coding-studio/install")
         assert resp.status_code == 200
-        assert resp.json()["app_id"] == "reddit"
+        assert resp.json()["app_id"] == "coding-studio"
         resp = await client.get("/api/apps/optional/installed")
-        assert resp.json()["installed"] == ["reddit"]
+        assert resp.json()["installed"] == ["coding-studio"]
 
     @pytest.mark.asyncio
     async def test_uninstall_removes(self, client):
-        await client.post("/api/apps/optional/x-monitor/install")
+        await client.post("/api/apps/optional/coding-studio/install")
         resp = await client.get("/api/apps/optional/installed")
-        assert "x-monitor" in resp.json()["installed"]
-        resp = await client.post("/api/apps/optional/x-monitor/uninstall")
+        assert "coding-studio" in resp.json()["installed"]
+        resp = await client.post("/api/apps/optional/coding-studio/uninstall")
         assert resp.status_code == 200
         resp = await client.get("/api/apps/optional/installed")
-        assert "x-monitor" not in resp.json()["installed"]
+        assert "coding-studio" not in resp.json()["installed"]
 
     @pytest.mark.asyncio
     async def test_unknown_app_rejected_install(self, client):
@@ -136,10 +136,10 @@ class TestOptionalInstalled:
 
     @pytest.mark.asyncio
     async def test_optional_app_not_in_installed_services(self, client):
-        await client.post("/api/apps/optional/github-browser/install")
+        await client.post("/api/apps/optional/coding-studio/install")
         resp = await client.get("/api/apps/installed")
         ids = {i["app_id"] for i in resp.json()}
-        assert "github-browser" not in ids
+        assert "coding-studio" not in ids
 
 
 class TestOptionalCatalog:
@@ -166,18 +166,18 @@ class TestOptionalCatalog:
     async def test_install_records_version(self, client):
         from tinyagentos.routes.apps import APP_VERSIONS
         store = client._transport.app.state.installed_apps
-        resp = await client.post("/api/apps/optional/reddit/install")
+        resp = await client.post("/api/apps/optional/coding-studio/install")
         assert resp.status_code == 200
         rows = await store.list_installed()
-        row = next((r for r in rows if r["app_id"] == "reddit"), None)
+        row = next((r for r in rows if r["app_id"] == "coding-studio"), None)
         assert row is not None
-        assert row["version"] == APP_VERSIONS["reddit"]
+        assert row["version"] == APP_VERSIONS["coding-studio"]
 
     @pytest.mark.asyncio
     async def test_update_available_false_for_fresh_install(self, client):
-        await client.post("/api/apps/optional/youtube-library/install")
+        await client.post("/api/apps/optional/coding-studio/install")
         resp = await client.get("/api/apps/optional/catalog")
-        app = next(a for a in resp.json()["apps"] if a["id"] == "youtube-library")
+        app = next(a for a in resp.json()["apps"] if a["id"] == "coding-studio")
         assert app["installed"] is True
         assert app["update_available"] is False
 
@@ -187,14 +187,14 @@ class TestOptionalCatalog:
         store = client._transport.app.state.installed_apps
         await store._db.execute(
             "INSERT OR REPLACE INTO installed_apps (app_id, installed_at, version, metadata) VALUES (?, ?, ?, ?)",
-            ("x-monitor", 1000.0, "0.9.0", json.dumps({"kind": "frontend-app"})),
+            ("coding-studio", 1000.0, "0.9.0", json.dumps({"kind": "frontend-app"})),
         )
         await store._db.commit()
         resp = await client.get("/api/apps/optional/catalog")
-        app = next(a for a in resp.json()["apps"] if a["id"] == "x-monitor")
+        app = next(a for a in resp.json()["apps"] if a["id"] == "coding-studio")
         assert app["installed"] is True
         assert app["update_available"] is True
-        assert app["version"] == APP_VERSIONS["x-monitor"]
+        assert app["version"] == APP_VERSIONS["coding-studio"]
 
     @pytest.mark.asyncio
     async def test_catalog_does_not_leak_unknown_ids(self, client):
@@ -208,3 +208,23 @@ class TestOptionalCatalog:
         returned_ids = {a["id"] for a in resp.json()["apps"]}
         assert "unknown-app" not in returned_ids
         assert returned_ids == OPTIONAL_FRONTEND_APPS
+
+
+class TestSocialAppsDeseeded:
+    """The platform social apps were removed from the default store."""
+
+    def test_social_apps_not_in_allowlist(self):
+        for app_id in ("reddit", "x-monitor", "github-browser", "youtube-library"):
+            assert app_id not in OPTIONAL_FRONTEND_APPS
+
+    @pytest.mark.asyncio
+    async def test_social_app_install_404(self, client):
+        for app_id in ("reddit", "x-monitor", "github-browser", "youtube-library"):
+            resp = await client.post(f"/api/apps/optional/{app_id}/install")
+            assert resp.status_code == 404, app_id
+
+    @pytest.mark.asyncio
+    async def test_social_apps_absent_from_catalog(self, client):
+        resp = await client.get("/api/apps/optional/catalog")
+        ids = {a["id"] for a in resp.json()["apps"]}
+        assert ids.isdisjoint({"reddit", "x-monitor", "github-browser", "youtube-library"})

--- a/tinyagentos/routes/apps.py
+++ b/tinyagentos/routes/apps.py
@@ -26,10 +26,13 @@ _GENERIC_ICON = "/static/app-icons/generic-service.svg"
 # runtime location). The frontend owns name/icon/cover; the backend only tracks
 # which ids are installed, gated to this allowlist so the endpoint can't be used
 # to write arbitrary install rows.
+# The platform social apps (reddit, youtube-library, github-browser, x-monitor)
+# were DE-SEEDED from the default store: they are unfinished and now live as the
+# operator's private App Studio drafts to be finished + published on stream, not
+# offered to every user. The Creative Studios remain installable optional apps.
 OPTIONAL_FRONTEND_APPS = {
-    "reddit", "youtube-library", "github-browser", "x-monitor",
-    # Creative Studios install the same way: a frontend-only optional app whose
-    # install row just flips the launcher visibility, no service spawned.
+    # Creative Studios: a frontend-only optional app whose install row just
+    # flips the launcher visibility, no service spawned.
     "coding-studio", "design-studio", "music-studio", "app-studio", "office-suite",
 }
 _FRONTEND_APP_KIND = "frontend-app"
@@ -37,10 +40,6 @@ _FRONTEND_APP_KIND = "frontend-app"
 # In-core version for each optional app. When an app becomes a real .taosapp
 # package, the package version will win instead of this value.
 APP_VERSIONS: dict[str, str] = {
-    "reddit": "1.0.0",
-    "youtube-library": "1.0.0",
-    "github-browser": "1.0.0",
-    "x-monitor": "1.0.0",
     "coding-studio": "1.0.0",
     "design-studio": "1.0.0",
     "music-studio": "1.0.0",
@@ -50,10 +49,6 @@ APP_VERSIONS: dict[str, str] = {
 
 # Trust level for each optional app (all current optional apps are first-party).
 APP_TRUST: dict[str, str] = {
-    "reddit": "first-party",
-    "youtube-library": "first-party",
-    "github-browser": "first-party",
-    "x-monitor": "first-party",
     "coding-studio": "first-party",
     "design-studio": "first-party",
     "music-studio": "first-party",


### PR DESCRIPTION
First slice of the social-apps reorg (Jay's livestream prep). Mirrors the Stream Chat de-seed precedent.

## What
The four platform apps (Reddit / YouTube / GitHub / X) are unfinished and should not be offered to every user. This removes them from the **default store**:
- `tinyagentos/routes/apps.py`: dropped from `OPTIONAL_FRONTEND_APPS` / `APP_VERSIONS` / `APP_TRUST` so they are no longer installable via `/api/apps/optional/*` (install now 404s).
- `desktop/src/registry/optional-apps.ts`: `OPTIONAL_APPS` emptied so the Store 'taOS Apps' section no longer lists them.
- The registry manifests + React components are **kept** so the next slice can reseed them as the operator's private App Studio drafts.
- Creative Studios (coding/design/music/app/office) remain installable.

## Coordination
This is the tinyagentos half. The username/blacklist/subdomain half (reserve `taos` for Jay -> taos.taos.my, add reserved names) lives in the **taos-website** repo and is handed to @taOS-website-dev via A2A + cards tsk-maufqg / tsk-qu4aej on prj-utbsh7.

## Next slices (mine, follow-up PRs)
- App Studio ownership: add owner_id/status/visibility to the userspace app store + seed the four as Jay's private *unfinished* drafts.
- Wire the App Studio -> store publish flow (PublishView -> store_submissions draft->pending->published, which already exists).

## Tests
Repointed the optional-app test fixtures to `coding-studio`; added a de-seed assertion class (not allowlisted, install 404, absent from catalog). 40 backend app tests + 25 frontend optional/store/launchpad tests green; compileall clean.

Guardrails: no new auth, no DB migration, no installer/boot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed social media applications (Reddit, YouTube, GitHub, X) from the optional app store. These apps are now exclusively available through private operator channels as draft versions rather than as default installable options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->