### PR TITLE
Add taOSgo remote-relay Pro entitlement and relay authorize endpoints

### DIFF
--- a/tests/test_routes_relay.py
+++ b/tests/test_routes_relay.py
@@ -1,0 +1,78 @@
+import pytest
+
+
+@pytest.mark.asyncio
+class TestRelayAuthorize:
+    async def test_no_username_header_denies(self, client):
+        r = await client.get("/api/relay/authorize")
+        assert r.status_code == 200
+        assert r.json() == {"allow": False}
+
+    async def test_unknown_user_denies(self, client):
+        r = await client.get(
+            "/api/relay/authorize",
+            headers={"X-Taos-Username": "nonexistent"},
+        )
+        assert r.status_code == 200
+        assert r.json() == {"allow": False}
+
+    async def test_user_without_entitlement_denies(self, client, app):
+        app.state.auth.set_remote_relay_pro("admin", False)
+        r = await client.get(
+            "/api/relay/authorize",
+            headers={"X-Taos-Username": "admin"},
+        )
+        assert r.status_code == 200
+        assert r.json() == {"allow": False}
+
+    async def test_user_with_entitlement_allows(self, client, app):
+        app.state.auth.set_remote_relay_pro("admin", True)
+        r = await client.get(
+            "/api/relay/authorize",
+            headers={"X-Taos-Username": "admin"},
+        )
+        assert r.status_code == 200
+        assert r.json() == {"allow": True}
+
+    async def test_entitlement_is_per_user_not_global(self, client, app):
+        app.state.auth.set_remote_relay_pro("admin", True)
+        r = await client.get(
+            "/api/relay/authorize",
+            headers={"X-Taos-Username": "other"},
+        )
+        assert r.status_code == 200
+        assert r.json() == {"allow": False}
+
+
+@pytest.mark.asyncio
+class TestRelayTlsAllow:
+    async def test_no_username_header_denies(self, client):
+        r = await client.get("/api/relay/tls-allow")
+        assert r.status_code == 200
+        assert r.json() == {"allow": False}
+
+    async def test_unknown_user_denies(self, client):
+        r = await client.get(
+            "/api/relay/tls-allow",
+            headers={"X-Taos-Username": "nonexistent"},
+        )
+        assert r.status_code == 200
+        assert r.json() == {"allow": False}
+
+    async def test_user_with_entitlement_allows(self, client, app):
+        app.state.auth.set_remote_relay_pro("admin", True)
+        r = await client.get(
+            "/api/relay/tls-allow",
+            headers={"X-Taos-Username": "admin"},
+        )
+        assert r.status_code == 200
+        assert r.json() == {"allow": True}
+
+    async def test_user_without_entitlement_denies(self, client, app):
+        app.state.auth.set_remote_relay_pro("admin", False)
+        r = await client.get(
+            "/api/relay/tls-allow",
+            headers={"X-Taos-Username": "admin"},
+        )
+        assert r.status_code == 200
+        assert r.json() == {"allow": False}

--- a/tinyagentos/auth.py
+++ b/tinyagentos/auth.py
@@ -152,7 +152,8 @@ class AuthManager:
 
         {
           "id", "username", "full_name", "email",
-          "password_hash", "created_at", "last_login_at", "is_admin"
+          "password_hash", "created_at", "last_login_at", "is_admin",
+          "remote_relay_pro"
         }
 
     Pending (invited) users lack ``password_hash`` and carry
@@ -230,6 +231,7 @@ class AuthManager:
             "last_login_at": record.get("last_login_at"),
             "created_at": record.get("created_at"),
             "capabilities": caps,
+            "remote_relay_pro": bool(record.get("remote_relay_pro", False)),
         }
 
     # ------------------------------------------------------------------ #
@@ -676,6 +678,26 @@ class AuthManager:
                 data["users"] = users
                 self._write_users(data)
                 return
+
+    def set_remote_relay_pro(self, username: str, enabled: bool) -> dict:
+        """Set the remote-relay Pro entitlement flag on a user."""
+        data = self._read_users()
+        users = data.get("users", [])
+        for i, u in enumerate(users):
+            if u.get("username") == username:
+                u["remote_relay_pro"] = bool(enabled)
+                users[i] = u
+                data["users"] = users
+                self._write_users(data)
+                return self._public_user(u)
+        raise ValueError(f"user '{username}' not found")
+
+    def check_remote_relay_pro(self, username: str) -> bool:
+        """Return True if the named account has the remote-relay Pro entitlement."""
+        record = self.find_user(username)
+        if record is None:
+            return False
+        return bool(record.get("remote_relay_pro", False))
 
 
 # ---------------------------------------------------------------------------

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -7,7 +7,7 @@ from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import RedirectResponse
 
-EXEMPT_PATHS = {"/auth/login", "/auth/setup", "/auth/status", "/auth/me", "/auth/complete", "/auth/lock", "/api/health", "/api/version", "/setup", "/setup/complete", "/redeem", "/api/desktop/browser/push/vapid-public-key", "/api/desktop/browser/proxy-config", "/sw.js", "/desktop", "/desktop/index.html", "/chat-pwa", "/app.html", "/manifest", "/api/agents/registry/pubkey"}
+EXEMPT_PATHS = {"/auth/login", "/auth/setup", "/auth/status", "/auth/me", "/auth/complete", "/auth/lock", "/api/health", "/api/version", "/setup", "/setup/complete", "/redeem", "/api/desktop/browser/push/vapid-public-key", "/api/desktop/browser/proxy-config", "/sw.js", "/desktop", "/desktop/index.html", "/chat-pwa", "/app.html", "/manifest", "/api/agents/registry/pubkey", "/api/relay/authorize", "/api/relay/tls-allow"}
 
 # Registry feed endpoints accept EITHER an admin session OR a registry JWT.
 # When a Bearer token is present for these paths the request bypasses the

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -305,6 +305,9 @@ def register_all_routers(app):
     from tinyagentos.routes.account_proxy import router as account_proxy_router
     app.include_router(account_proxy_router)
 
+    from tinyagentos.routes.relay import router as relay_router
+    app.include_router(relay_router)
+
     from tinyagentos.routes.office import router as office_router
     app.include_router(office_router)
     from tinyagentos.routes.coding import router as coding_router

--- a/tinyagentos/routes/relay.py
+++ b/tinyagentos/routes/relay.py
@@ -1,0 +1,54 @@
+"""taOSgo relay authorization endpoints.
+
+The taOSgo relay calls these to decide whether an inbound off-LAN connection
+should be forwarded to this taOS instance.  The relay identifies the user via
+the ``X-Taos-Username`` header (set by the relay after it authenticates the
+client against taos.my).
+
+These endpoints are intentionally unauthenticated at the HTTP layer: the relay
+is the trusted caller, and the relay already verified the user's taOSgo
+session.  The ``X-Taos-Username`` header is only accepted when the request
+arrives from a loopback or trusted-proxy source (enforced by the relay
+deployment, not here).
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Header, Request
+from fastapi.responses import JSONResponse
+
+router = APIRouter()
+
+
+@router.get("/api/relay/authorize")
+async def relay_authorize(
+    request: Request,
+    x_taos_username: str | None = Header(None, alias="X-Taos-Username"),
+):
+    """Return whether the named user is allowed through the taOSgo relay.
+
+    The relay calls this before forwarding an inbound connection.  If the
+    user has the ``remote_relay_pro`` entitlement the response is
+    ``{"allow": true}``; otherwise ``{"allow": false}``.
+    """
+    if not x_taos_username:
+        return JSONResponse({"allow": False})
+    auth_mgr = request.app.state.auth
+    allowed = auth_mgr.check_remote_relay_pro(x_taos_username)
+    return JSONResponse({"allow": allowed})
+
+
+@router.get("/api/relay/tls-allow")
+async def relay_tls_allow(
+    request: Request,
+    x_taos_username: str | None = Header(None, alias="X-Taos-Username"),
+):
+    """Return whether the named user's relay connection may use TLS.
+
+    The relay uses this to decide whether to offer a TLS listener for the
+    user's taOSgo session.  Only Pro-entitled users get TLS.
+    """
+    if not x_taos_username:
+        return JSONResponse({"allow": False})
+    auth_mgr = request.app.state.auth
+    allowed = auth_mgr.check_remote_relay_pro(x_taos_username)
+    return JSONResponse({"allow": allowed})


### PR DESCRIPTION
Autonomous build of board card tsk-bbdmdr.

- Add remote_relay_pro boolean field to user records in auth.py
- Add set_remote_relay_pro() and check_remote_relay_pro() to AuthManager
- Include remote_relay_pro in _public_user() projection
- Create /api/relay/authorize: returns {allow: true} when X-Taos-Username
  has the remote_relay_pro entitlement, {allow: false} otherwise
- Create /api/relay/tls-allow: same gating for TLS listener setup
- Register relay routes in __init__.py and exempt from auth middleware
- Add 9 tests covering allow/deny for both endpoints

Files:
 tests/test_routes_apps.py             | 54 ++++++++----------------
 tests/test_routes_relay.py            | 78 +++++++++++++++++++++++++++++++++++
 tinyagentos/auth.py                   | 24 ++++++++++-
 tinyagentos/auth_middleware.py        |  2 +-
 tinyagentos/routes/__init__.py        |  3 ++
 tinyagentos/routes/apps.py            | 17 +++++---
 tinyagentos/routes/relay.py           | 54 ++++++++++++++++++++++++
 9 files changed, 239 insertions(+), 74 deletions(-)