### PR TITLE
feat(taosgo): account-proxy the cluster-join consent endpoints

### DIFF
--- a/tests/test_routes_account_proxy.py
+++ b/tests/test_routes_account_proxy.py
@@ -144,3 +144,78 @@ async def test_redirect_location_is_relayed(client, monkeypatch):
     r = await client.get("/api/account/me", follow_redirects=False)
     assert r.status_code == 302
     assert r.headers.get("location") == "https://taos.my/login"
+
+
+@pytest.mark.asyncio
+async def test_cluster_join_request_forwards(client, monkeypatch):
+    """/api/account/cluster/join/request forwards to {base}/api/cluster/join/request
+    with the body and the session cookie passed through."""
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "https://taos.my")
+    captured: dict[str, str] = {}
+
+    async def handler(method, url, **kw):
+        captured["method"] = method
+        captured["url"] = url
+        captured["cookie"] = kw.get("headers", {}).get("Cookie", "")
+        return _FakeResp(
+            content=b'{"request_id":"r1","status":"pending","expires_at":"2026-01-01T00:00:00Z"}',
+            headers={"content-type": "application/json"},
+        )
+
+    _patch_upstream(monkeypatch, handler)
+    # Do NOT override the cookie header: the `client` fixture carries the taOS
+    # controller session that the /api/account/* proxy (rightly) requires, and
+    # that session cookie is what gets forwarded upstream.
+    r = await client.post(
+        "/api/account/cluster/join/request",
+        json={"device_name": "Mac", "ttl": "10m"},
+    )
+    assert r.status_code == 200
+    assert r.json()["request_id"] == "r1"
+    assert captured["url"] == "https://taos.my/api/cluster/join/request"
+    assert captured["method"] == "POST"
+    assert captured["cookie"]  # the session cookie was passed through
+
+
+@pytest.mark.asyncio
+async def test_cluster_join_poll_forwards_rid(client, monkeypatch):
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "https://taos.my")
+    captured: dict[str, str] = {}
+
+    async def handler(method, url, **kw):
+        captured["url"] = url
+        return _FakeResp(content=b'{"status":"pending"}', headers={"content-type": "application/json"})
+
+    _patch_upstream(monkeypatch, handler)
+    r = await client.get("/api/account/cluster/join/requests/req-ABC_123/poll")
+    assert r.status_code == 200
+    assert captured["url"] == "https://taos.my/api/cluster/join/requests/req-ABC_123/poll"
+
+
+@pytest.mark.asyncio
+async def test_cluster_join_rejects_bad_request_id(client, monkeypatch):
+    """A request_id that could inject path/query never reaches the upstream: a
+    malformed token is rejected at the validator (400), and an encoded-slash
+    traversal attempt fails to match the route (404). Either way, no upstream
+    call is made (path-traversal / SSRF guard)."""
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "https://taos.my")
+    called = {"n": 0}
+
+    async def handler(method, url, **kw):
+        called["n"] += 1
+        return _FakeResp()
+
+    _patch_upstream(monkeypatch, handler)
+    # The encoded-slash case is blocked at routing (404); the others reach the
+    # validator and are rejected (400). Neither reaches the upstream.
+    for bad in ["..%2f..%2fauth%2fme", "r1;evil", "r1%20x", "x" * 65]:
+        r = await client.post(f"/api/account/cluster/join/requests/{bad}/approve")
+        assert r.status_code in (400, 404), bad
+    assert called["n"] == 0
+
+
+@pytest.mark.asyncio
+async def test_cluster_join_503_when_unconfigured(client, monkeypatch):
+    monkeypatch.delenv("TAOS_ACCOUNT_BASE_URL", raising=False)
+    r = await client.get("/api/account/cluster/join/requests")
+    assert r.status_code == 503

--- a/tinyagentos/routes/account_proxy.py
+++ b/tinyagentos/routes/account_proxy.py
@@ -11,6 +11,7 @@ renders its 'service unavailable' state, so the client ships ahead of taos.my.
 from __future__ import annotations
 
 import os
+import re
 
 import httpx
 from fastapi import APIRouter, Request, Response
@@ -73,13 +74,12 @@ def _rewrite_set_cookie(value: str, secure_ok: bool) -> str:
     return "; ".join(kept)
 
 
-async def _forward(request: Request, action: str) -> Response:
+async def _forward_to(request: Request, method: str, path: str) -> Response:
     base = _base_url()
     if base is None:
         return JSONResponse(
             {"error": "account service not configured"}, status_code=503
         )
-    method, path = _ACTIONS[action]
     headers: dict[str, str] = {}
     cookie = request.headers.get("cookie")
     if cookie:
@@ -125,6 +125,20 @@ async def _forward(request: Request, action: str) -> Response:
     return resp
 
 
+async def _forward(request: Request, action: str) -> Response:
+    method, path = _ACTIONS[action]
+    return await _forward_to(request, method, path)
+
+
+# A join request_id reaches the upstream URL path, so it must be a simple opaque
+# token, never something that can inject path segments or query (../, %2f, ?).
+_RID_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+
+
+def _valid_rid(rid: str) -> bool:
+    return bool(_RID_RE.match(rid))
+
+
 @router.get("/api/account/me")
 async def account_me(request: Request):
     return await _forward(request, "me")
@@ -143,3 +157,43 @@ async def account_register(request: Request):
 @router.post("/api/account/logout")
 async def account_logout(request: Request):
     return await _forward(request, "logout")
+
+
+# --- taOSgo cluster-join (consent-join) proxy ---
+# Same cookie-passthrough pattern as the auth actions above: the taOS client
+# calls same-origin /api/account/cluster/join/* and we forward to the taos.my
+# /api/cluster/join/* endpoints (taos-website PR #35) so the session cookie
+# round-trips through this origin. The signed-in worker app POSTs a join request;
+# the user approves/denies from inside taOS; the app polls for the preauth key.
+_JOIN_BASE = "/api/cluster/join"
+
+
+@router.post("/api/account/cluster/join/request")
+async def cluster_join_request(request: Request):
+    return await _forward_to(request, "POST", f"{_JOIN_BASE}/request")
+
+
+@router.get("/api/account/cluster/join/requests")
+async def cluster_join_requests(request: Request):
+    return await _forward_to(request, "GET", f"{_JOIN_BASE}/requests")
+
+
+@router.post("/api/account/cluster/join/requests/{rid}/approve")
+async def cluster_join_approve(request: Request, rid: str):
+    if not _valid_rid(rid):
+        return JSONResponse({"error": "invalid request id"}, status_code=400)
+    return await _forward_to(request, "POST", f"{_JOIN_BASE}/requests/{rid}/approve")
+
+
+@router.post("/api/account/cluster/join/requests/{rid}/deny")
+async def cluster_join_deny(request: Request, rid: str):
+    if not _valid_rid(rid):
+        return JSONResponse({"error": "invalid request id"}, status_code=400)
+    return await _forward_to(request, "POST", f"{_JOIN_BASE}/requests/{rid}/deny")
+
+
+@router.get("/api/account/cluster/join/requests/{rid}/poll")
+async def cluster_join_poll(request: Request, rid: str):
+    if not _valid_rid(rid):
+        return JSONResponse({"error": "invalid request id"}, status_code=400)
+    return await _forward_to(request, "GET", f"{_JOIN_BASE}/requests/{rid}/poll")


### PR DESCRIPTION
First core slice of the taOSgo cluster-worker-over-relay flow (consent-join, per Jay's decision). Forwards same-origin `/api/account/cluster/join/*` to the taos.my `/api/cluster/join/*` endpoints (taos-website PR #35) so the in-taOS approve/deny UX and the worker app's join request round-trip the session cookie through this origin, no CORS.

- request (POST), requests list (GET), approve/deny (POST, {rid}), poll (GET, {rid}).
- `request_id` validated against `^[A-Za-z0-9_-]{1,64}$` before it reaches the upstream URL (path-traversal / SSRF guard); encoded-slash attempts fail to route (404).
- Forward core refactored to `_forward_to(method, path)`; existing auth-action routes unchanged.
- These routes inherit the taOS controller session requirement (you log into taOS, then your taos.my account inside it), consistent with the other /api/account/* routes.
- 4 new tests; full account_proxy suite 11 green.

Unblocked half of my taOSgo core side; the menubar Go app + the approve/deny UI consume these. End-to-end mint still gated on website-dev standing up Headscale.

----
## Summary by Gitar

- **Desktop performance:**
  - Added `usePerfAutoDetect` to automatically enable `Reduce effects` on low-end hardware based on a 1-second FPS probe.
  - Implemented an inline script in `index.html` to apply `data-perf` attributes before the first paint to prevent visual flashing.
- **Testing:**
  - Added unit tests for the performance detection hook in `use-perf-autodetect.test.ts`.

<sub>This will update automatically on new commits.</sub>