### PR TITLE
fix(install): make libtorrent optional so fresh installs do not abort

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,11 +25,6 @@ dependencies = [
     # Project canvas board renders low-fidelity PNG snapshots for vision
     # agents (tinyagentos/projects/canvas/render.py).
     "Pillow>=10.0",
-    # Model torrent mesh — every instance is a potential peer so
-    # downloads distribute across the swarm rather than hammering a
-    # single mirror. Worker install scripts install the OS-level
-    # libtorrent-rasterbar as a prerequisite on each platform.
-    "libtorrent>=2.0.9",
     "lxml>=5.0.0",
     "readability-lxml>=0.8.1",
     # Memory system — published to PyPI
@@ -47,6 +42,13 @@ dependencies = [
 [project.optional-dependencies]
 worker = ["pystray>=0.19.0", "Pillow>=10.0"]
 proxy = ["litellm[proxy]>=1.89.3", "prisma>=0.11.0"]
+# Model torrent mesh (optional): every instance is a potential peer so model
+# downloads distribute across the swarm. libtorrent has no PyPI wheel on most
+# platforms (it is the OS-level libtorrent-rasterbar / python3-libtorrent
+# package), so making it a CORE dependency aborted fresh installs that lack a
+# wheel (e.g. WSL). The code already treats it as optional: torrent_downloader
+# guards the import and falls back to a direct download when it is absent.
+torrent = ["libtorrent>=2.0.9"]
 dev = [
     "pytest>=9.1.1",
     "pytest-asyncio>=0.23.0",

--- a/uv.lock
+++ b/uv.lock
@@ -3582,7 +3582,6 @@ dependencies = [
     { name = "fastapi" },
     { name = "httpx" },
     { name = "jinja2" },
-    { name = "libtorrent" },
     { name = "lxml" },
     { name = "pillow" },
     { name = "psutil" },
@@ -3615,6 +3614,9 @@ proxy = [
     { name = "litellm", extra = ["proxy"] },
     { name = "prisma" },
 ]
+torrent = [
+    { name = "libtorrent" },
+]
 worker = [
     { name = "pillow" },
     { name = "pystray" },
@@ -3628,7 +3630,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "httpx", marker = "extra == 'dev'" },
     { name = "jinja2", specifier = ">=3.1.0" },
-    { name = "libtorrent", specifier = ">=2.0.9" },
+    { name = "libtorrent", marker = "extra == 'torrent'", specifier = ">=2.0.9" },
     { name = "litellm", extras = ["proxy"], marker = "extra == 'proxy'", specifier = ">=1.89.3" },
     { name = "lxml", specifier = ">=5.0.0" },
     { name = "pillow", specifier = ">=10.0" },
@@ -3654,7 +3656,7 @@ requires-dist = [
     { name = "websockets", marker = "extra == 'dev'", specifier = ">=12.0" },
     { name = "zeroconf", specifier = ">=0.140" },
 ]
-provides-extras = ["worker", "proxy", "dev", "e2e"]
+provides-extras = ["worker", "proxy", "torrent", "dev", "e2e"]
 
 [[package]]
 name = "tokenizers"


### PR DESCRIPTION
A WSL user hit this on a clean reinstall:
```
ERROR: Could not find a version that satisfies the requirement libtorrent>=2.0.9 (from versions: none)
ERROR: No matching distribution found for libtorrent>=2.0.9
```
libtorrent has no PyPI wheel on most platforms (it is the OS-level `libtorrent-rasterbar` / `python3-libtorrent` package), yet it was a CORE dependency, so `pip install -e .[proxy]` (the installer path) aborted the whole controller install.

The code is already written for libtorrent to be optional: `torrent_downloader` guards the import (`TORRENT_AVAILABLE`), `DownloadManager` falls back to a direct download when it is absent, and the torrent tests `pytest.skip` when it is not installed. This just aligns the dependency declaration with that design.

- Moved `libtorrent>=2.0.9` out of core `dependencies` into a `torrent` optional extra.
- Regenerated uv.lock (libtorrent now resolves only under `extra: torrent`).
- Torrent mesh still works where the OS package is present (worker scripts install it); hosts without it use direct download.
- CI unaffected: torrent tests skip without libtorrent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Made `libtorrent` an optional dependency. Users needing torrent mesh functionality can install it separately, while it's no longer required for basic package usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->