### PR TITLE
release: 1.0.0-beta.7 (install hotfix: libtorrent optional)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.7] - 2026-06-21
+
+### Fixed
+- Install: libtorrent is no longer a core dependency, so a fresh install no longer aborts with "No matching distribution found for libtorrent>=2.0.9" on platforms without a libtorrent wheel (e.g. WSL). It is now an optional `torrent` extra; the model torrent mesh is enabled only where the OS-level package is present, and hosts without it fall back to a direct download.
+
 ## [1.0.0-beta.6] - 2026-06-21
 
 ### Added

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinyagentos-desktop",
-  "version": "1.0.0-beta.6",
+  "version": "1.0.0-beta.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinyagentos-desktop",
-      "version": "1.0.0-beta.6",
+      "version": "1.0.0-beta.7",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.6",
+  "version": "1.0.0-beta.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.7"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"
@@ -25,11 +25,6 @@ dependencies = [
     # Project canvas board renders low-fidelity PNG snapshots for vision
     # agents (tinyagentos/projects/canvas/render.py).
     "Pillow>=10.0",
-    # Model torrent mesh — every instance is a potential peer so
-    # downloads distribute across the swarm rather than hammering a
-    # single mirror. Worker install scripts install the OS-level
-    # libtorrent-rasterbar as a prerequisite on each platform.
-    "libtorrent>=2.0.9",
     "lxml>=5.0.0",
     "readability-lxml>=0.8.1",
     # Memory system — published to PyPI
@@ -47,6 +42,11 @@ dependencies = [
 [project.optional-dependencies]
 worker = ["pystray>=0.19.0", "Pillow>=10.0"]
 proxy = ["litellm[proxy]>=1.89.3", "prisma>=0.11.0"]
+# Model torrent mesh (optional): libtorrent has no PyPI wheel on most platforms
+# (OS-level libtorrent-rasterbar / python3-libtorrent), so it must not be a core
+# dependency or fresh installs abort. torrent_downloader guards the import and
+# falls back to a direct download when it is absent.
+torrent = ["libtorrent>=2.0.9"]
 dev = [
     "pytest>=9.1.1",
     "pytest-asyncio>=0.23.0",

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.6"
+__version__ = "1.0.0-beta.7"

--- a/uv.lock
+++ b/uv.lock
@@ -3574,7 +3574,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b6"
+version = "1.0.0b7"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
@@ -3582,7 +3582,6 @@ dependencies = [
     { name = "fastapi" },
     { name = "httpx" },
     { name = "jinja2" },
-    { name = "libtorrent" },
     { name = "lxml" },
     { name = "pillow" },
     { name = "psutil" },
@@ -3615,6 +3614,9 @@ proxy = [
     { name = "litellm", extra = ["proxy"] },
     { name = "prisma" },
 ]
+torrent = [
+    { name = "libtorrent" },
+]
 worker = [
     { name = "pillow" },
     { name = "pystray" },
@@ -3628,7 +3630,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "httpx", marker = "extra == 'dev'" },
     { name = "jinja2", specifier = ">=3.1.0" },
-    { name = "libtorrent", specifier = ">=2.0.9" },
+    { name = "libtorrent", marker = "extra == 'torrent'", specifier = ">=2.0.9" },
     { name = "litellm", extras = ["proxy"], marker = "extra == 'proxy'", specifier = ">=1.89.3" },
     { name = "lxml", specifier = ">=5.0.0" },
     { name = "pillow", specifier = ">=10.0" },
@@ -3654,7 +3656,7 @@ requires-dist = [
     { name = "websockets", marker = "extra == 'dev'", specifier = ">=12.0" },
     { name = "zeroconf", specifier = ">=0.140" },
 ]
-provides-extras = ["worker", "proxy", "dev", "e2e"]
+provides-extras = ["worker", "proxy", "torrent", "dev", "e2e"]
 
 [[package]]
 name = "tokenizers"


### PR DESCRIPTION
Install hotfix promoted straight to master because the live installer clones the default branch and beta.6 aborts on a fresh install.

A WSL user hit `No matching distribution found for libtorrent>=2.0.9` on a clean reinstall. libtorrent was a CORE dependency but has no PyPI wheel on most platforms (it is the OS-level `libtorrent-rasterbar` / `python3-libtorrent` package), so `pip install -e .[proxy]` aborted the whole controller install.

- Moved `libtorrent` to a `torrent` optional extra (the code already guards the import and falls back to direct download; torrent tests skip when absent).
- Bumped to beta.7 (beta.6.1 is not PEP 440 valid). uv.lock relocked.
- Same fix is on dev via #1291.

Once green, merge + tag v1.0.0-beta.7 + GitHub release so the installer works for fresh users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * libtorrent is no longer a required core dependency and is now available as an optional extra, preventing installation failures on platforms lacking available wheels.

* **Chores**
  * Version bumped to 1.0.0-beta.7

<!-- end of auto-generated comment: release notes by coderabbit.ai -->