### PR TITLE
fix(install): recreate a stale venv built with an unsupported Python

### DIFF
--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -1056,6 +1056,18 @@ ensure_uv() {
     command -v uv >/dev/null 2>&1
 }
 
+# Self-heal a stale venv: a re-install over a .venv built with an unsupported
+# Python (e.g. a 3.14 venv from an attempt before this fix) would otherwise be
+# reused, and `pip install -e .` fails the requires-python <3.14 check. Recreate
+# it if its interpreter is out of the supported [3.11,3.14) range.
+if [[ -d .venv ]]; then
+    _vv=$(.venv/bin/python -c 'import sys;print(sys.version_info[0]*100+sys.version_info[1])' 2>/dev/null || echo 0)
+    if [ "$_vv" -lt 311 ] || [ "$_vv" -ge 314 ]; then
+        warn "existing .venv uses an unsupported Python ($_vv); recreating with a 3.11-3.13 interpreter"
+        rm -rf .venv
+    fi
+fi
+
 if [[ ! -d .venv ]]; then
     PYBIN="$(pick_system_python || true)"
     if [[ -n "$PYBIN" ]]; then


### PR DESCRIPTION
Jay's WSL re-install (Python 3.14.4) got past beta.8's cap but failed:
```
ERROR: Package 'tinyagentos' requires a different Python: 3.14.4 not in '<3.14,>=3.11'
```
Root cause: a `.venv` already existed (built with 3.14 by an earlier attempt), and the beta.8 interpreter-selection only runs when CREATING a fresh venv, so the stale 3.14 venv was reused. Now the installer probes an existing `.venv`'s Python and recreates it if it is outside [3.11,3.14). Additive + safe (only touches an already-broken venv). Same fix to master as beta.9.