### PR TITLE
release: 1.0.0-beta.9 (install hotfix: recreate stale 3.14 venv)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.9] - 2026-06-21
+
+### Fixed
+- Install: a re-install over an existing virtualenv built with an unsupported Python (e.g. a 3.14 venv from an attempt before beta.8) reused that venv and failed with "requires a different Python: 3.14.x not in <3.14,>=3.11". The installer now detects an out-of-range venv interpreter and recreates the venv with a supported 3.11 to 3.13 Python.
+
 ## [1.0.0-beta.8] - 2026-06-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ curl -fsSL https://raw.githubusercontent.com/jaylfc/taOS/master/scripts/install-
 
 Run without `sudo` to install as a user-mode systemd unit instead. The script is idempotent, safe to re-run on an existing install. Supports env-var overrides for install path, branch, and port.
 
+Tested on WSL2 (Windows 11) with the default Ubuntu image, including the current Python 3.14 default: the installer provisions a compatible Python automatically, so a clean box needs nothing more than the one line above.
+
 **Manual / development:**
 
 ```bash

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinyagentos-desktop",
-  "version": "1.0.0-beta.8",
+  "version": "1.0.0-beta.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinyagentos-desktop",
-      "version": "1.0.0-beta.8",
+      "version": "1.0.0-beta.9",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.8",
+  "version": "1.0.0-beta.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 # Upper-capped at <3.14 because litellm (the proxy extra, the agent/model proxy

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -1050,6 +1050,18 @@ ensure_uv() {
     command -v uv >/dev/null 2>&1
 }
 
+# Self-heal a stale venv: a re-install over a .venv built with an unsupported
+# Python (e.g. a 3.14 venv from an attempt before this fix) would otherwise be
+# reused, and `pip install -e .` fails the requires-python <3.14 check. Recreate
+# it if its interpreter is out of the supported [3.11,3.14) range.
+if [[ -d .venv ]]; then
+    _vv=$(.venv/bin/python -c 'import sys;print(sys.version_info[0]*100+sys.version_info[1])' 2>/dev/null || echo 0)
+    if [ "$_vv" -lt 311 ] || [ "$_vv" -ge 314 ]; then
+        warn "existing .venv uses an unsupported Python ($_vv); recreating with a 3.11-3.13 interpreter"
+        rm -rf .venv
+    fi
+fi
+
 if [[ ! -d .venv ]]; then
     PYBIN="$(pick_system_python || true)"
     if [[ -n "$PYBIN" ]]; then

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.8"
+__version__ = "1.0.0-beta.9"

--- a/uv.lock
+++ b/uv.lock
@@ -2884,7 +2884,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b8"
+version = "1.0.0b9"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Third install hotfix, completing the WSL fresh-install chain. Jay's re-install (Python 3.14.4) got past beta.8's requires-python cap but failed:
```
ERROR: Package 'tinyagentos' requires a different Python: 3.14.4 not in '<3.14,>=3.11'
```
The beta.8 interpreter-selection only runs when CREATING a fresh venv; an existing 3.14 `.venv` (from an earlier attempt) was reused. Now the installer detects an out-of-range venv interpreter and recreates it. Same fix on dev via #1295.

Workaround meanwhile: `sudo rm -rf <install>/.venv` then re-run the installer.

Once green: merge + tag v1.0.0-beta.9 + GitHub release.