### PR TITLE
fix(desktop): hide NPU card with no NPU + default widgets off until redesign

### DIFF
--- a/desktop/src/apps/ActivityApp.tsx
+++ b/desktop/src/apps/ActivityApp.tsx
@@ -369,8 +369,10 @@ export function ActivityApp({ windowId: _windowId }: { windowId: string }) {
           </CardContent>
         </Card>
 
-        {/* NPU */}
-        {(npu.cores || npu.type) && (
+        {/* NPU -- only when one is actually present. type "none" (or absent)
+            means no NPU, so the whole card is hidden rather than showing a
+            debugfs-permission message on hardware that has no NPU at all. */}
+        {npu.type && npu.type !== "none" && (
           <Card className="col-span-12 md:col-span-6 p-4">
             <CardContent className="p-0">
               <div className="flex items-center justify-between mb-3">

--- a/desktop/src/stores/widget-store.ts
+++ b/desktop/src/stores/widget-store.ts
@@ -95,7 +95,9 @@ const initial = readCache();
 
 export const useWidgetStore = create<WidgetStore>((set, get) => ({
   widgets: initial?.widgets ?? DEFAULT_WIDGETS,
-  showWidgets: initial?.showWidgets ?? true,
+  // Off by default until the widgets are overhauled/redesigned. A user who has
+  // already enabled them keeps their choice (persisted showWidgets is restored).
+  showWidgets: initial?.showWidgets ?? false,
   hydrated: false,
 
   addWidget(type) {


### PR DESCRIPTION
Two small desktop UX-default fixes from live testing on the fresh WSL install.

1. **NPU card hidden when no NPU present.** On a machine with no NPU (e.g. the WSL x86 box), the Activity NPU card showed `Per-core stats require debugfs access. Run as root or grant cap_dac_read_search.` -- a permission hint on hardware that has no NPU. The card rendered on `(npu.cores || npu.type)`, but a no-NPU host reports `type: 'none'` (truthy). Now gated on a real NPU (`type && type !== 'none'`), matching the existing `hardwareLabel` check. Real NPU devices still show it.

2. **Desktop widgets off by default** until they are overhauled/redesigned. `showWidgets` defaults to `false` for fresh state; users who already enabled them keep their persisted choice.