### PR TITLE
fix(models): taOS agent chooser lists same models as deploy picker (DeepSeek)

### DIFF
--- a/desktop/src/components/TaosAgentCard.tsx
+++ b/desktop/src/components/TaosAgentCard.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { ModelPickerModal } from "@/components/ModelPickerModal";
 import type { AgentModel } from "@/components/ModelPickerFlow";
+import { loadAgentModels } from "@/lib/models";
 import {
   fetchTaosAgentConfig,
   setTaosAgentModel,
@@ -51,12 +52,12 @@ export function TaosAgentCard() {
   async function ensureModelsLoaded() {
     if (modelsLoaded) return;
     try {
-      const res = await fetch("/api/providers/models?refresh=true", {
-        headers: { Accept: "application/json" },
-      });
-      const data = res.ok ? await res.json() : { data: [] };
-      setModels((data.data ?? []).map((m: { id: string }) => ({
-        id: m.id, name: m.id, hostKind: "cloud" as const,
+      // Use the same unified loader as the agent deploy picker so the taOS
+      // agent chooser lists exactly the same models (controller-catalog,
+      // cluster-worker, and cloud-provider models keyed back to a provider).
+      const aggregated = await loadAgentModels();
+      setModels(aggregated.map((m) => ({
+        id: m.id, name: m.name, host: m.host, hostKind: m.hostKind,
       })));
     } catch { /* leave empty */ }
     finally { setModelsLoaded(true); }

--- a/desktop/src/components/TaosAssistantSettings.test.tsx
+++ b/desktop/src/components/TaosAssistantSettings.test.tsx
@@ -5,20 +5,10 @@ import { TaosAssistantSettings } from "./TaosAssistantSettings";
 import { useTaosAgentStore } from "@/stores/taos-agent-store";
 
 vi.mock("@/lib/models", () => ({
-  fetchClusterWorkers: vi.fn(),
-  fetchCloudProviders: vi.fn(),
-  workersToAggregated: vi.fn(),
-  cloudProvidersToAggregated: vi.fn(),
-  localProvidersToAggregated: vi.fn(),
+  loadAgentModels: vi.fn(),
 }));
 
-import {
-  fetchClusterWorkers,
-  fetchCloudProviders,
-  workersToAggregated,
-  cloudProvidersToAggregated,
-  localProvidersToAggregated,
-} from "@/lib/models";
+import { loadAgentModels } from "@/lib/models";
 
 const mockFetch = vi.fn();
 
@@ -52,11 +42,7 @@ describe("TaosAssistantSettings", () => {
   beforeEach(() => {
     resetStore();
     setupFetch();
-    vi.mocked(fetchClusterWorkers).mockResolvedValue([]);
-    vi.mocked(fetchCloudProviders).mockResolvedValue([]);
-    vi.mocked(workersToAggregated).mockReturnValue([]);
-    vi.mocked(cloudProvidersToAggregated).mockReturnValue([]);
-    vi.mocked(localProvidersToAggregated).mockReturnValue([]);
+    vi.mocked(loadAgentModels).mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -107,24 +93,20 @@ describe("TaosAssistantSettings", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it("fetches models on open and passes loaded state to ModelPickerFlow", async () => {
-    vi.mocked(fetchClusterWorkers).mockResolvedValue([]);
-    vi.mocked(fetchCloudProviders).mockResolvedValue([]);
+  it("loads the unified agent model list on open", async () => {
     render(<TaosAssistantSettings open={true} onClose={vi.fn()} />);
 
     await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalledWith("/api/models");
+      expect(loadAgentModels).toHaveBeenCalledTimes(1);
     });
-    expect(fetchClusterWorkers).toHaveBeenCalledTimes(1);
-    expect(fetchCloudProviders).toHaveBeenCalledTimes(1);
   });
 
   it("sends PATCH to /api/taos-agent/settings with selected model and closes", async () => {
     const onClose = vi.fn();
     useTaosAgentStore.setState({ model: "old-model" });
 
-    vi.mocked(localProvidersToAggregated).mockReturnValue([
-      { id: "llama-3", name: "Llama 3", host: "controller", hostKind: "controller" },
+    vi.mocked(loadAgentModels).mockResolvedValue([
+      { key: "controller:llama-3", id: "llama-3", name: "Llama 3", host: "controller", hostKind: "controller" },
     ]);
 
     render(<TaosAssistantSettings open={true} onClose={onClose} />);

--- a/desktop/src/components/TaosAssistantSettings.tsx
+++ b/desktop/src/components/TaosAssistantSettings.tsx
@@ -1,13 +1,7 @@
 import { useState, useEffect } from "react";
 import { X } from "lucide-react";
 import { ModelPickerFlow, type AgentModel } from "./ModelPickerFlow";
-import {
-  fetchClusterWorkers,
-  fetchCloudProviders,
-  workersToAggregated,
-  cloudProvidersToAggregated,
-  localProvidersToAggregated,
-} from "@/lib/models";
+import { loadAgentModels } from "@/lib/models";
 import { useTaosAgentStore } from "@/stores/taos-agent-store";
 
 interface Props {
@@ -26,45 +20,15 @@ export function TaosAssistantSettings({ open, onClose }: Props) {
 
     async function load() {
       try {
-        const [localRes, workers, providers] = await Promise.all([
-          fetch("/api/models").then((r) => r.ok ? r.json() : { models: [] }),
-          fetchClusterWorkers(),
-          fetchCloudProviders(),
-        ]);
+        // Same unified loader the agent deploy picker uses, so the taOS
+        // agent chooser lists exactly the same models. hostKind is
+        // preserved per model, so ModelPickerFlow's source-select screen
+        // still separates local / worker / cloud clearly.
+        const aggregated = await loadAgentModels();
         if (cancelled) return;
-
-        // Use models[].id (manifest id, e.g. "gemma-4-e2b-gguf") rather
-        // than downloaded_files[].filename ("gemma-4-e2b-gguf.gguf").
-        // The chat path passes whatever id we set here straight to the
-        // LiteLLM proxy as the model_name; #433 registered aliases by
-        // manifest id, so sending the filename 400s. AgentsApp uses
-        // the same models[] source and works correctly.
-        type ApiModel = { id: string; name?: string; has_downloaded_variant?: boolean };
-        const apiModels: ApiModel[] = Array.isArray(localRes?.models) ? localRes.models : [];
-        const local = apiModels
-          .filter((m) => m.has_downloaded_variant === true)
-          .map((m) => ({
-            id: m.id,
-            name: m.name ?? m.id,
-            host: "controller" as const,
-            hostKind: "controller" as const,
-          }));
-        const worker = workersToAggregated(workers);
-        const cloud = cloudProvidersToAggregated(providers);
-        // Providers configured directly on the controller (a local ollama,
-        // a manually-added llama-cpp, etc.) are neither cloud nor a remote
-        // worker — they were silently dropped from the picker before #356
-        // surfaced the gap.
-        const localProviders = localProvidersToAggregated(providers);
-
-        const all: AgentModel[] = [
-          ...local,
-          ...localProviders.map((m: { id: string; name: string; host: string; hostKind: "controller" | "worker" | "cloud" }) => ({ id: m.id, name: m.name, host: m.host, hostKind: m.hostKind })),
-          ...worker.map((m: { id: string; name: string; host: string; hostKind: "controller" | "worker" | "cloud" }) => ({ id: m.id, name: m.name, host: m.host, hostKind: m.hostKind })),
-          ...cloud.map((m: { id: string; name: string; host: string; hostKind: "controller" | "worker" | "cloud" }) => ({ id: m.id, name: m.name, host: m.host, hostKind: m.hostKind })),
-        ];
-
-        setModels(all as AgentModel[]);
+        setModels(aggregated.map((m) => ({
+          id: m.id, name: m.name, host: m.host, hostKind: m.hostKind,
+        })));
       } catch {
         // non-fatal — models just won't show
       } finally {

--- a/desktop/src/lib/models.test.ts
+++ b/desktop/src/lib/models.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { fetchClusterWorkers, fetchCloudProviders } from "./models";
+import { fetchClusterWorkers, fetchCloudProviders, loadAgentModels } from "./models";
 
 const originalFetch = global.fetch;
 
@@ -131,5 +131,61 @@ describe("fetchCloudProviders", () => {
   it("returns [] on network error", async () => {
     global.fetch = vi.fn().mockRejectedValue(new Error("offline"));
     expect(await fetchCloudProviders()).toEqual([]);
+  });
+});
+
+describe("loadAgentModels", () => {
+  function mockApis(opts: {
+    catalog?: unknown[];
+    providers?: unknown[];
+    litellm?: { id: string }[];
+  }) {
+    const { catalog = [], providers = [], litellm = [] } = opts;
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      const json = (body: unknown) => Promise.resolve({
+        ok: true,
+        headers: { get: () => "application/json" },
+        json: async () => body,
+      });
+      if (url === "/api/models") return json({ models: catalog });
+      if (url === "/api/cluster/workers") return json([]);
+      if (url === "/api/providers") return json(providers);
+      if (url.startsWith("/api/providers/models")) return json({ data: litellm });
+      return json({});
+    });
+  }
+
+  it("includes a cloud-provider model present in both /api/providers and /v1/models", async () => {
+    mockApis({
+      providers: [{ name: "deepseek-test", type: "deepseek", models: [{ id: "deepseek-chat" }] }],
+      litellm: [{ id: "deepseek-chat" }],
+    });
+    const out = await loadAgentModels();
+    const ds = out.find((m) => m.id === "deepseek-chat");
+    expect(ds).toBeDefined();
+    expect(ds?.hostKind).toBe("cloud");
+    expect(ds?.host).toBe("deepseek-test");
+  });
+
+  it("drops LiteLLM ids that map to no configured provider (internal aliases)", async () => {
+    mockApis({
+      providers: [{ name: "deepseek-test", type: "deepseek", models: [{ id: "deepseek-chat" }] }],
+      litellm: [{ id: "deepseek-chat" }, { id: "default" }, { id: "some-internal-alias" }],
+    });
+    const out = await loadAgentModels();
+    expect(out.find((m) => m.id === "deepseek-chat")).toBeDefined();
+    expect(out.find((m) => m.id === "default")).toBeUndefined();
+    expect(out.find((m) => m.id === "some-internal-alias")).toBeUndefined();
+  });
+
+  it("includes downloaded controller-catalog models as hostKind controller", async () => {
+    mockApis({
+      catalog: [{ id: "gemma-4-e2b-gguf", name: "Gemma 4", has_downloaded_variant: true },
+                { id: "not-downloaded", has_downloaded_variant: false }],
+    });
+    const out = await loadAgentModels();
+    const g = out.find((m) => m.id === "gemma-4-e2b-gguf");
+    expect(g?.hostKind).toBe("controller");
+    expect(out.find((m) => m.id === "not-downloaded")).toBeUndefined();
   });
 });

--- a/desktop/src/lib/models.ts
+++ b/desktop/src/lib/models.ts
@@ -240,6 +240,97 @@ export async function fetchCloudProviders(): Promise<CloudProvider[]> {
   }
 }
 
+/**
+ * Build the unified agent model list exactly the way the agent deploy
+ * wizard does, so every model chooser (deploy wizard, taOS agent settings)
+ * shows the same set: downloaded controller-catalog models, cluster-worker
+ * models, and cloud-provider models from LiteLLM's /v1/models keyed back to
+ * their provider via /api/providers.
+ *
+ * The cloud lane intersects LiteLLM's authoritative /v1/models with the
+ * provider map so each entry lands under the right source (cloud / worker /
+ * controller) and aliases LiteLLM exposes for routing are dropped.
+ */
+export async function loadAgentModels(): Promise<AggregatedModel[]> {
+  const out: AggregatedModel[] = [];
+
+  // 1) Downloaded controller-catalog models.
+  try {
+    const res = await fetch("/api/models", { headers: { Accept: "application/json" } });
+    const ct = res.headers.get("content-type") ?? "";
+    if (res.ok && ct.includes("application/json")) {
+      const data = await res.json();
+      const list: Record<string, unknown>[] = Array.isArray(data)
+        ? data
+        : Array.isArray(data?.models) ? data.models : [];
+      for (const m of list.filter((m) => m.has_downloaded_variant === true)) {
+        out.push({
+          key: `controller:${String(m.id)}`,
+          id: String(m.id),
+          name: String(m.name ?? m.id),
+          host: "controller",
+          hostKind: "controller",
+        });
+      }
+    }
+  } catch { /* leave controller models empty */ }
+
+  // 2) Cluster-worker-hosted models.
+  try {
+    const workers = await fetchClusterWorkers();
+    out.push(...workersToAggregated(workers));
+  } catch { /* leave worker models empty */ }
+
+  // 3) Cloud-provider models: LiteLLM /v1/models keyed back to a provider.
+  try {
+    const [modelsRes, providers] = await Promise.all([
+      fetch("/api/providers/models?refresh=true", { headers: { Accept: "application/json" } }),
+      fetchCloudProviders(),
+    ]);
+    const providerByModelId = new Map<string, { name: string; kind: ModelHostKind }>();
+    for (const p of providers) {
+      const isCloud = (CLOUD_PROVIDER_TYPES as readonly string[]).includes(p.type ?? "");
+      const isNetwork = typeof p.source === "string" && p.source.startsWith("worker:");
+      const kind: ModelHostKind = isCloud ? "cloud" : isNetwork ? "worker" : "controller";
+      const pname = p.name ?? p.type ?? "provider";
+      for (const m of Array.isArray(p.models) ? p.models : []) {
+        const mid = m.id ?? m.name;
+        if (mid && !providerByModelId.has(mid)) providerByModelId.set(mid, { name: pname, kind });
+      }
+    }
+    const mct = modelsRes.headers.get("content-type") ?? "";
+    if (modelsRes.ok && mct.includes("application/json")) {
+      const body = await modelsRes.json();
+      const data: { id?: string }[] = Array.isArray(body?.data) ? body.data : [];
+      for (const entry of data) {
+        const mid = entry?.id;
+        if (!mid || typeof mid !== "string") continue;
+        if (mid === "default" || mid === "taos-embedding-default") continue;
+        const provider = providerByModelId.get(mid);
+        if (!provider) continue; // LiteLLM internal alias, not a real provider model
+        out.push({
+          key: `${provider.kind}:${provider.name}:${mid}`,
+          id: mid,
+          name: `${mid} (${provider.name})`,
+          host: provider.name,
+          hostKind: provider.kind,
+        });
+      }
+    }
+  } catch { /* leave cloud models empty */ }
+
+  // Dedupe on (hostKind, host, id); first writer wins (controller over worker).
+  const seen = new Set<string>();
+  const union: AggregatedModel[] = [];
+  for (const m of out) {
+    const k = `${m.hostKind}:${m.host}:${m.id}`;
+    if (seen.has(k)) continue;
+    seen.add(k);
+    union.push(m);
+  }
+  return union;
+}
+
 /** Teal host badge class matching the Loaded Models widget. */
 export const HOST_BADGE_CLASS =
   "text-[9px] px-1.5 py-0.5 rounded-full bg-teal-500/15 text-teal-200 font-semibold whitespace-nowrap";

--- a/tests/test_routes_providers.py
+++ b/tests/test_routes_providers.py
@@ -182,6 +182,40 @@ class TestProviderAPI:
         ]
         assert "kilo-auto/free" in kilo_ids
 
+    async def test_list_providers_surfaces_seeded_models_when_probe_empty(self, client, app):
+        """A cloud provider whose live /models probe returns nothing (e.g.
+        DeepSeek, whose endpoint 401s without a key the probe can't reach)
+        must still report its config-seeded models, so the agent model picker
+        does not filter them out. Regression for the Discord report: 'added
+        deepseek but no deepseek model shows in the picker'."""
+        app.state.config.backends.append({
+            "name": "deepseek-test",
+            "type": "deepseek",
+            "url": "https://api.deepseek.com",
+            "models": [{"id": "deepseek-v4-pro"}, {"id": "deepseek-chat"}],
+        })
+
+        class _EmptyHealth:
+            async def health(self, *_a, **_k):
+                # ok connection, but no models returned without auth
+                return {"status": "ok", "response_ms": 5, "models": []}
+
+        with patch(
+            "tinyagentos.routes.providers.get_adapter",
+            return_value=_EmptyHealth(),
+        ), patch(
+            "tinyagentos.routes.providers._resolve_api_key_for_backend",
+            new=AsyncMock(return_value=None),
+        ):
+            resp = await client.get("/api/providers")
+        assert resp.status_code == 200
+        entry = next(
+            p for p in resp.json() if p.get("name") == "deepseek-test"
+        )
+        ids = [m.get("id") or m.get("name") for m in entry["models"]]
+        assert "deepseek-v4-pro" in ids
+        assert "deepseek-chat" in ids
+
 
 @pytest.mark.asyncio
 class TestModelsPassthrough:

--- a/tinyagentos/routes/providers.py
+++ b/tinyagentos/routes/providers.py
@@ -430,6 +430,14 @@ async def list_providers(request: Request):
                 discovered = await _discover_provider_models(backend["url"], api_key)
                 if discovered:
                     models = [{"name": m.get("id", ""), "size_mb": 0} for m in discovered]
+        # Last resort: surface the models stored on the backend in config.
+        # add_provider seeds these (a /models probe or the per-type
+        # PROVIDER_DEFAULT_MODELS fallback), so a provider whose live probe
+        # needs an API key it can't reach here — e.g. DeepSeek, whose /models
+        # endpoint 401s without auth — still reports its routable models to the
+        # picker instead of an empty list that gets filtered out client-side.
+        if not models and backend.get("models"):
+            models = backend["models"]
         lifecycle_state = catalog.get_lifecycle_state(backend["name"]) if catalog else "running"
         entry = {
             **backend,


### PR DESCRIPTION
## Problem (Discord report)
A user added DeepSeek as a provider (with API key). DeepSeek models showed in the **Hermes agent deploy** picker but NOT in the **taOS agent** model chooser.

## Root cause
The taOS agent chooser and the agent deploy wizard built their model lists with **different code paths**:
- Deploy wizard: LiteLLM `/v1/models` (authoritative routed set) keyed back to providers via `/api/providers`, split into local/worker/cloud lanes.
- taOS agent (`TaosAgentCard` / `TaosAssistantSettings`): a different assembly that could miss or mis-tag cloud-provider models.

Separately, `/api/providers` could ship a cloud entry with `models: []` when the keyless `/models` probe 401'd, so seeded models never reached the picker.

## Fix
1. **Backend** (`routes/providers.py`): `list_providers` now falls back to the models stored on the backend in config when the live probe and key re-probe both come up empty. Extends the #356 re-probe.
2. **Frontend** (`lib/models.ts`): new shared `loadAgentModels()` that builds the **exact** union the deploy wizard uses. Both taOS agent surfaces now call it, so they list the same models. Per-model `hostKind` is preserved, so ModelPickerFlow's **local / worker / cloud source-select screen stays** and is correctly populated (previously TaosAgentCard tagged everything "cloud", so there was no separation).

## Tests
- `test_list_providers_surfaces_seeded_models_when_probe_empty` (backend).
- `loadAgentModels` unit tests: cloud model surfaces with hostKind cloud, internal aliases dropped, controller-catalog filtering.
- `TaosAssistantSettings` tests updated to the shared loader.
- Full desktop suite 2029 passed; backend providers suite 30 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Provider-configured models now display in the agent model picker even when live model probes are unavailable, preventing empty selections.

* **Improvements**
  * Enhanced model discovery to consistently aggregate available models across all configured sources (controller, cluster workers, and cloud providers).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->