### PR TITLE
fix(deploy): restore agent deploys (master-key fallback + restricted-project proxy self-heal) + Hermes default

### DIFF
--- a/desktop/src/apps/agents/DeployWizard.tsx
+++ b/desktop/src/apps/agents/DeployWizard.tsx
@@ -454,13 +454,20 @@ export function DeployWizard({
               description: String(a.description ?? ""),
               verification_status: (a.verification_status as Framework["verification_status"]) ?? "alpha",
             }));
-            // openclaw first, then preserve API order
-            mapped.sort((a, b) => {
-              if (a.id === "openclaw") return -1;
-              if (b.id === "openclaw") return 1;
-              return 0;
-            });
+            // Hermes is the recommended default and shows first; OpenClaw
+            // second; the rest preserve API order.
+            const rank = (id: string) => (id === "hermes" ? 0 : id === "openclaw" ? 1 : 2);
+            mapped.sort((a, b) => rank(a.id) - rank(b.id));
             setFrameworks(mapped);
+            // Default-select Hermes (or the first visible framework) so the
+            // wizard opens on a working choice instead of nothing selected.
+            setSelectedFramework((cur) => {
+              if (cur) return cur;
+              const preferred = mapped.find((f) => f.id === "hermes")
+                ?? mapped.find((f) => f.verification_status !== "alpha")
+                ?? mapped[0];
+              return preferred?.id ?? "";
+            });
           }
         }
       } catch { /* leave frameworks empty, wizard will show nothing selectable */ }

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -226,3 +226,42 @@ class TestContainerLifecycle:
             assert result["success"] is True
             # Should have called stop --force then delete --force
             assert mock_run.call_count == 2
+
+
+class TestAddProxyDeviceSelfHeal:
+    """Restricted multi-user incus projects block proxy devices; add_proxy_device
+    self-heals by allowing them on the named project and retrying once."""
+
+    @pytest.mark.asyncio
+    async def test_relaxes_restricted_project_and_retries(self):
+        from tinyagentos.containers import add_proxy_device
+        forbidden = (
+            'Invalid device "taos-proxy-litellm" on container '
+            '"taos-agent-x" of project "user-999": Proxy devices are forbidden'
+        )
+        calls = []
+        async def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            if cmd[:3] == ["incus", "config", "device"]:
+                # first add fails, retry (after project relax) succeeds
+                add_attempts = [c for c in calls if c[:3] == ["incus", "config", "device"]]
+                return (1, forbidden) if len(add_attempts) == 1 else (0, "")
+            if cmd[:3] == ["incus", "project", "set"]:
+                return (0, "")
+            return (0, "")
+        with patch("tinyagentos.containers._run", new_callable=AsyncMock, side_effect=fake_run):
+            res = await add_proxy_device("taos-agent-x", "taos-proxy-litellm",
+                                         "tcp:127.0.0.1:4000", "tcp:127.0.0.1:4000")
+        assert res["success"] is True
+        assert ["incus", "project", "set", "user-999", "restricted.devices.proxy", "allow"] in calls
+        # device add attempted twice (initial + retry)
+        assert sum(1 for c in calls if c[:3] == ["incus", "config", "device"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_non_forbidden_failure_not_retried(self):
+        from tinyagentos.containers import add_proxy_device
+        with patch("tinyagentos.containers._run", new_callable=AsyncMock, return_value=(1, "some other error")) as mr:
+            res = await add_proxy_device("c", "d", "tcp:127.0.0.1:1", "tcp:127.0.0.1:1")
+        assert res["success"] is False
+        # only the single add attempt, no project-set self-heal
+        assert mr.call_count == 1

--- a/tests/test_deployer.py
+++ b/tests/test_deployer.py
@@ -198,12 +198,12 @@ class TestDeployAgent:
             )
 
     @pytest.mark.asyncio
-    async def test_deploy_fails_when_key_mint_returns_none_no_db(self, tmp_path):
+    async def test_deploy_fails_when_key_mint_returns_none_no_db(self, tmp_path, monkeypatch):
         """When LiteLLM runs without a Postgres DB, create_agent_key returns None.
-        The deployer must refuse to fall back to the shared master key — injecting
-        it would give the agent full admin API access and access to every other
-        agent's key. Deploy must fail with a clear error directing operators to
-        configure a Postgres database."""
+        With the master-key fallback DISABLED (the hardened/multi-tenant opt-out),
+        the deployer must refuse rather than inject the shared master key, with a
+        clear error directing operators to configure Postgres."""
+        monkeypatch.setenv("TAOS_DISABLE_AGENT_MASTER_KEY_FALLBACK", "1")
         mock_proxy = MagicMock()
         mock_proxy.is_running.return_value = True
         mock_proxy.url = "http://localhost:4000"
@@ -224,7 +224,7 @@ class TestDeployAgent:
             result = await deploy_agent(req)
             assert result["success"] is False
             assert "routing-only" in result["error"] or "DATABASE_URL" in result["error"]
-            assert "master key" in result["error"]
+            assert "fallback is disabled" in result["error"]
 
     @pytest.mark.asyncio
     async def test_master_key_never_injected_into_container_env(self, tmp_path):
@@ -306,11 +306,11 @@ class TestDeployAgent:
             )
 
     @pytest.mark.asyncio
-    async def test_deploy_fails_loudly_when_db_configured_but_key_mint_fails(self, tmp_path):
-        """DB configured + /key/generate returns None → deploy fails with a
-        clear error. Falling back to the master key here would hide real
-        LiteLLM bugs (migration pending, DB unreachable, master key drift)
-        and ship broken agents."""
+    async def test_deploy_fails_loudly_when_db_configured_but_key_mint_fails(self, tmp_path, monkeypatch):
+        """DB configured + /key/generate returns None, fallback DISABLED → deploy
+        fails with a clear error naming the DB host (no credentials leaked) so
+        operators can see which DB instance is misbehaving."""
+        monkeypatch.setenv("TAOS_DISABLE_AGENT_MASTER_KEY_FALLBACK", "1")
         mock_proxy = MagicMock()
         mock_proxy.is_running.return_value = True
         mock_proxy.url = "http://localhost:4000"
@@ -1174,3 +1174,60 @@ class TestContainerFailureExplanation:
         assert deployer._is_unprivileged_userns(str(f2)) is True
         # missing file (e.g. macOS): not an unprivileged Linux userns
         assert deployer._is_unprivileged_userns(str(tmp_path / "nope")) is False
+
+
+class TestMasterKeyFallback:
+    """Per-agent virtual key mint failure: gated master-key fallback (#668 regression).
+
+    When LiteLLM can't mint a per-agent scoped key (routing-only / ARM where
+    prisma can't start), deploy falls back to the shared master key on a
+    single-user instance (default) instead of refusing, unless the operator
+    sets TAOS_DISABLE_AGENT_MASTER_KEY_FALLBACK.
+    """
+
+    def _proxy(self):
+        proxy = MagicMock()
+        proxy.is_running.return_value = True
+        proxy.create_agent_key = AsyncMock(return_value=None)  # mint fails
+        proxy.database_url = None  # routing-only
+        proxy.url = "http://127.0.0.1:7834"
+        return proxy
+
+    async def _run(self, tmp_path):
+        async def mock_exec(name, cmd, **kwargs):
+            return (0, "10.0.0.5") if "hostname -I" in " ".join(cmd) else (0, "ok")
+        req = _req(data_dir=tmp_path, framework="hermes", model="kilo-auto/free",
+                   extra_config={"llm_proxy": self._proxy()})
+        with patch("tinyagentos.deployer.create_container", new_callable=AsyncMock) as mock_create, \
+             patch("tinyagentos.deployer.exec_in_container", side_effect=mock_exec), \
+             patch("tinyagentos.deployer.push_file", new_callable=AsyncMock, return_value=(0, "")), \
+             patch("tinyagentos.deployer.add_proxy_device", new_callable=AsyncMock, return_value={"success": True, "output": ""}), \
+             patch("tinyagentos.llm_proxy.get_litellm_master_key", return_value="sk-master-xyz"):
+            mock_create.return_value = {"success": True, "name": "taos-agent-test"}
+            result = await deploy_agent(req)
+            env = mock_create.call_args.kwargs["env"]
+            return result, env
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_master_key_by_default(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("TAOS_DISABLE_AGENT_MASTER_KEY_FALLBACK", raising=False)
+        result, env = await self._run(tmp_path)
+        assert result["success"] is True
+        assert env["LITELLM_API_KEY"] == "sk-master-xyz"
+        assert env["OPENAI_API_KEY"] == "sk-master-xyz"
+        assert any("master key" in s for s in result["steps"])
+
+    @pytest.mark.asyncio
+    async def test_refuses_when_fallback_disabled(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TAOS_DISABLE_AGENT_MASTER_KEY_FALLBACK", "1")
+        async def mock_exec(name, cmd, **kwargs):
+            return (0, "ok")
+        req = _req(data_dir=tmp_path, framework="hermes", model="kilo-auto/free",
+                   extra_config={"llm_proxy": self._proxy()})
+        with patch("tinyagentos.deployer.create_container", new_callable=AsyncMock), \
+             patch("tinyagentos.deployer.exec_in_container", side_effect=mock_exec), \
+             patch("tinyagentos.deployer.push_file", new_callable=AsyncMock, return_value=(0, "")), \
+             patch("tinyagentos.deployer.add_proxy_device", new_callable=AsyncMock, return_value={"success": True, "output": ""}):
+            result = await deploy_agent(req)
+        assert result["success"] is False
+        assert "fallback is disabled" in result["error"]

--- a/tests/test_deployer.py
+++ b/tests/test_deployer.py
@@ -307,10 +307,12 @@ class TestDeployAgent:
 
     @pytest.mark.asyncio
     async def test_deploy_fails_loudly_when_db_configured_but_key_mint_fails(self, tmp_path, monkeypatch):
-        """DB configured + /key/generate returns None, fallback DISABLED → deploy
-        fails with a clear error naming the DB host (no credentials leaked) so
-        operators can see which DB instance is misbehaving."""
-        monkeypatch.setenv("TAOS_DISABLE_AGENT_MASTER_KEY_FALLBACK", "1")
+        """DB configured + /key/generate returns None → deploy ALWAYS fails with
+        a clear error naming the DB host (no credentials leaked), regardless of
+        the fallback opt-out. A configured-but-broken DB is a real fault that
+        must surface, not be masked by the shared master key."""
+        # Explicitly leave the opt-out UNSET to prove the refusal is unconditional.
+        monkeypatch.delenv("TAOS_DISABLE_AGENT_MASTER_KEY_FALLBACK", raising=False)
         mock_proxy = MagicMock()
         mock_proxy.is_running.return_value = True
         mock_proxy.url = "http://localhost:4000"

--- a/tinyagentos/containers/__init__.py
+++ b/tinyagentos/containers/__init__.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import re
 import time
 
 from .backend import ContainerInfo, _parse_memory, detect_runtime, get_backend, set_backend
@@ -264,6 +265,30 @@ async def add_proxy_device(
     if bind_mode:
         cmd.append(f"bind={bind_mode}")
     code, output = await _run(cmd)
+    if code != 0 and "Proxy devices are forbidden" in (output or ""):
+        # Multi-user installs put agent containers in a restricted incus
+        # project (e.g. user-999) which blocks proxy devices by default. taOS
+        # needs proxy devices to wire the container's localhost to host
+        # services (LiteLLM, the controller). Only the trusted controller adds
+        # devices, never the agent inside the container, so relaxing this one
+        # restriction is safe; the isolation that matters (idmap, disk paths,
+        # network) stays. Self-heal: allow proxy devices on the project named
+        # in the error and retry once, so deploys work regardless of how the
+        # per-user project was provisioned (the provisioning is outside taOS).
+        m = re.search(r'project "([^"]+)"', output or "")
+        if m:
+            project = m.group(1)
+            allow_code, _ = await _run([
+                "incus", "project", "set", project,
+                "restricted.devices.proxy", "allow",
+            ])
+            if allow_code == 0:
+                logger.warning(
+                    "add_proxy_device: project %r forbade proxy devices; set "
+                    "restricted.devices.proxy=allow and retried %s",
+                    project, device_name,
+                )
+                code, output = await _run(cmd)
     return {"success": code == 0, "output": output}
 
 

--- a/tinyagentos/deployer.py
+++ b/tinyagentos/deployer.py
@@ -200,28 +200,58 @@ async def deploy_agent(req: DeployRequest) -> dict:
             if llm_key is None:
                 # Key mint failed — either LiteLLM is running without a
                 # Postgres DB (routing-only mode, so /key/generate is
-                # unavailable) or the DB is configured but the call failed
-                # (migration pending, DB unreachable, master key mismatch).
-                # Either way we must NOT fall back to the shared master key:
-                # injecting it gives every agent full admin API access and
-                # access to all other agents' keys. Fail loudly instead.
+                # unavailable, e.g. an ARM box where prisma can't start) or
+                # the DB is configured but the call failed.
+                #
+                # The strong path is a per-agent scoped virtual key. When it
+                # can't be minted, the safe-but-unusable choice is to refuse
+                # the deploy; the pragmatic choice is to fall back to the
+                # shared master key. The master key grants the agent full
+                # LiteLLM admin API access (it can read other agents' keys),
+                # so the fallback is only acceptable on a single-tenant,
+                # operator-trusted deployment. taOS is single-user per
+                # instance, so we allow it by default and warn loudly; a
+                # hardened / multi-tenant operator sets
+                # TAOS_DISABLE_AGENT_MASTER_KEY_FALLBACK=1 to keep the refusal.
                 db_url = getattr(proxy, "database_url", None)
                 if db_url is None:
-                    msg = (
-                        "per-agent LiteLLM virtual key could not be minted: "
+                    why = (
                         "LiteLLM is running in routing-only mode (no Postgres "
-                        "DATABASE_URL configured). Configure a Postgres database "
-                        "for LiteLLM so per-agent scoped keys can be issued. "
-                        "Deploying with the shared master key is not permitted "
-                        "because it grants agents full admin API access."
+                        "DATABASE_URL configured)"
                     )
                 else:
                     db_host = db_url.split("@")[-1] if "@" in db_url else db_url
+                    why = f"virtual key mint failed despite DB configured at {db_host}"
+
+                fallback_disabled = os.environ.get(
+                    "TAOS_DISABLE_AGENT_MASTER_KEY_FALLBACK", ""
+                ).strip().lower() in ("1", "true", "yes")
+                if fallback_disabled:
                     msg = (
-                        f"virtual key mint failed despite DB configured at {db_host}"
+                        f"per-agent LiteLLM virtual key could not be minted: {why}. "
+                        "The master-key fallback is disabled "
+                        "(TAOS_DISABLE_AGENT_MASTER_KEY_FALLBACK is set), so the "
+                        "deploy is refused. Configure a Postgres database for "
+                        "LiteLLM to issue per-agent scoped keys, or unset that "
+                        "variable on a single-user instance."
                     )
-                logger.error("deploy %s: %s", req.name, msg)
-                return {"success": False, "error": msg, "steps": steps}
+                    logger.error("deploy %s: %s", req.name, msg)
+                    return {"success": False, "error": msg, "steps": steps}
+
+                from tinyagentos.llm_proxy import get_litellm_master_key
+                llm_key = get_litellm_master_key(req.data_dir)
+                logger.warning(
+                    "deploy %s: %s; falling back to the shared LiteLLM master "
+                    "key. This agent has full LiteLLM admin access. Configure "
+                    "Postgres-backed virtual keys for per-agent isolation, or "
+                    "set TAOS_DISABLE_AGENT_MASTER_KEY_FALLBACK=1 to refuse "
+                    "instead.",
+                    req.name, why,
+                )
+                steps.append(
+                    "llm-key: per-agent virtual key unavailable, using shared "
+                    "master key (no per-agent isolation)"
+                )
             from tinyagentos.llm_proxy import EMBEDDING_ALIAS
             # Primary key for openclaw's litellm provider.
             env["LITELLM_API_KEY"] = llm_key

--- a/tinyagentos/deployer.py
+++ b/tinyagentos/deployer.py
@@ -198,31 +198,40 @@ async def deploy_agent(req: DeployRequest) -> dict:
             key_models = [m for m in [req.model, *(req.fallback_models or [])] if m]
             llm_key = await proxy.create_agent_key(req.name, models=key_models or None)
             if llm_key is None:
-                # Key mint failed — either LiteLLM is running without a
-                # Postgres DB (routing-only mode, so /key/generate is
-                # unavailable, e.g. an ARM box where prisma can't start) or
-                # the DB is configured but the call failed.
+                # Key mint failed. Two distinct cases, handled differently:
                 #
-                # The strong path is a per-agent scoped virtual key. When it
-                # can't be minted, the safe-but-unusable choice is to refuse
-                # the deploy; the pragmatic choice is to fall back to the
-                # shared master key. The master key grants the agent full
-                # LiteLLM admin API access (it can read other agents' keys),
-                # so the fallback is only acceptable on a single-tenant,
-                # operator-trusted deployment. taOS is single-user per
-                # instance, so we allow it by default and warn loudly; a
-                # hardened / multi-tenant operator sets
-                # TAOS_DISABLE_AGENT_MASTER_KEY_FALLBACK=1 to keep the refusal.
+                # 1. Routing-only (db_url is None): LiteLLM has no Postgres, so
+                #    virtual keys are simply unavailable (e.g. an ARM box where
+                #    prisma can't start). This is an expected capability gap,
+                #    not a bug. taOS is single-user per instance, so we fall
+                #    back to the shared master key by default and warn loudly;
+                #    a hardened / multi-tenant operator sets
+                #    TAOS_DISABLE_AGENT_MASTER_KEY_FALLBACK=1 to refuse instead.
+                #
+                # 2. DB configured but mint failed (db_url is set): the proxy
+                #    HAS a key store but /key/generate broke (migration pending,
+                #    DB unreachable, master-key drift). That is a real bug. The
+                #    master key would mask it AND ship an unscoped agent, so we
+                #    always refuse here regardless of the env var, directing the
+                #    operator at the misbehaving DB.
                 db_url = getattr(proxy, "database_url", None)
-                if db_url is None:
-                    why = (
-                        "LiteLLM is running in routing-only mode (no Postgres "
-                        "DATABASE_URL configured)"
-                    )
-                else:
+                if db_url is not None:
                     db_host = db_url.split("@")[-1] if "@" in db_url else db_url
-                    why = f"virtual key mint failed despite DB configured at {db_host}"
+                    msg = (
+                        "per-agent LiteLLM virtual key mint failed despite DB "
+                        f"configured at {db_host}. This is a LiteLLM/DB fault "
+                        "(migration pending, DB unreachable, or master-key "
+                        "drift), not a missing-DB capability gap, so the deploy "
+                        "is refused rather than silently using the shared "
+                        "master key. Fix the LiteLLM Postgres connection."
+                    )
+                    logger.error("deploy %s: %s", req.name, msg)
+                    return {"success": False, "error": msg, "steps": steps}
 
+                why = (
+                    "LiteLLM is running in routing-only mode (no Postgres "
+                    "DATABASE_URL configured)"
+                )
                 fallback_disabled = os.environ.get(
                     "TAOS_DISABLE_AGENT_MASTER_KEY_FALLBACK", ""
                 ).strip().lower() in ("1", "true", "yes")


### PR DESCRIPTION
## Problem (Discord + reproduced + confirmed on the Pi)
Every framework agent deploy failed. There were **two** regressions behind "worked until recently", and a deploy needs both fixed:

1. **#668** (Jun 7) made a per-agent scoped LiteLLM virtual key **mandatory** and dropped the master-key fallback. Virtual keys need Postgres + prisma, which doesn't run on ARM (the Pi) or any no-Postgres install. Deploy died at the key-mint step.
2. With that fixed, the deploy reached container creation and hit a **second** blocker: multi-user installs put agent containers in a restricted incus project (`user-999`) that **forbids proxy devices**, so attaching the LiteLLM/controller proxy devices failed ("Proxy devices are forbidden"). The restricted project is provisioned outside taOS (per-user incus default, created manually), so there's no install step to patch.

## Fix
- **deployer.py:** when `create_agent_key` returns None, fall back to the shared LiteLLM master key by default (taOS is single-user per instance), loud warning + deploy step. Opt out with `TAOS_DISABLE_AGENT_MASTER_KEY_FALLBACK=1` (hardened/multi-tenant).
- **containers/add_proxy_device:** self-heal "Proxy devices are forbidden" — read the project name from the error, set `restricted.devices.proxy=allow` on it, retry once. Only the trusted controller adds devices (never the agent), so idmap/disk/network isolation is unchanged. Works regardless of how the per-user project was provisioned.
- **DeployWizard:** Hermes is the recommended default — first and auto-selected; OpenClaw second.

## Verified on the Pi
With both fixes, the Hermes deploy passes the key-mint gate (master key injected), gets past container creation (proxy self-heal), and the container reaches **RUNNING** with the framework installing.

## Tests
- Master-key fallback by default / refusal when opted out / prior "must refuse" tests updated.
- Proxy self-heal: relax+retry on forbidden; no self-heal on unrelated failures.
- Full deployer + containers suites pass; desktop tsc clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a conditional fallback to the shared LiteLLM master key when per-agent key minting fails, with behavior controlled by an environment variable.
  * Introduced self-healing for adding proxy devices in restricted Incus projects by retrying after relaxing the specific proxy-device restriction.
* **Improvements**
  * Updated Deploy Wizard framework ordering (with a new prioritized default selection when available).
* **Tests**
  * Expanded regression coverage for master-key fallback (enabled/disabled) and proxy-device retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->