### PR TITLE
release: 1.0.0-beta.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,20 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.11] - 2026-06-21
+
+### Fixed
+- Agent deploy: framework agents (Hermes, OpenClaw, etc.) failed to deploy on hosts that cannot mint per-agent LiteLLM virtual keys (ARM / Pi where prisma cannot start, and any install without Postgres). The deployer now falls back to the shared LiteLLM master key in genuine routing-only mode (single-user instances, with a loud warning; opt out via `TAOS_DISABLE_AGENT_MASTER_KEY_FALLBACK=1`). A DB-configured-but-broken mint still fails loudly so a real fault is never masked.
+- Agent deploy: containers in a restricted multi-user incus project (e.g. `user-999`) failed at creation because proxy devices were forbidden. `add_proxy_device` now self-heals by allowing proxy devices on the named project and retrying once.
+- Provider model picker: a newly-added cloud provider (e.g. DeepSeek) whose `/models` probe needs a key now surfaces its seeded models, and the taOS agent model chooser lists the same models as the agent deploy picker.
+- Activity NPU card hidden on hardware with no NPU; desktop widgets default off until redesigned.
+
+### Added
+- Cluster: free-tier manual worker pairing. A worker prints its LAN address and a PIN; the user adds it from Cluster > Add worker with no network discovery (taOSgo remains the automated path).
+
 ### Changed
-- Dev version reconciled with master and bumped to `1.0.0-beta.10` for the next release cycle. No runtime change; the WSL install fixes from beta.7 to beta.9 are carried unchanged.
+- Hermes is the recommended default agent framework (shown first and pre-selected in the deploy wizard); OpenClaw second.
+- Dev/master version reconciled (beta.6 drift fixed) and bumped to `1.0.0-beta.11`.
 
 ## [1.0.0-beta.9] - 2026-06-21
 

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinyagentos-desktop",
-  "version": "1.0.0-beta.10",
+  "version": "1.0.0-beta.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinyagentos-desktop",
-      "version": "1.0.0-beta.10",
+      "version": "1.0.0-beta.11",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.10",
+  "version": "1.0.0-beta.11",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.10"
+version = "1.0.0-beta.11"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 # Upper-capped at <3.14 because litellm (the proxy extra, the agent/model proxy

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.10"
+__version__ = "1.0.0-beta.11"

--- a/uv.lock
+++ b/uv.lock
@@ -2884,7 +2884,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b10"
+version = "1.0.0b11"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Version bump beta.10 -> beta.11 + CHANGELOG. Promotes deploy-fix (#1301) + manual pairing (#1298) + DeepSeek picker (#1299). No code change beyond version strings.