### PR TITLE
ui(deploy): redesign persona picker to taOS design bar + tidy step rail

### DIFF
--- a/desktop/src/apps/__tests__/MemoryStep.test.tsx
+++ b/desktop/src/apps/__tests__/MemoryStep.test.tsx
@@ -172,8 +172,10 @@ describe("MemoryWizardStep", () => {
     const deployBtn = await screen.findByRole("button", { name: /new agent/i });
     fireEvent.click(deployBtn);
 
+    // The compact step rail renders every step as a labelled dot (title +
+    // aria-label) but only shows the active step's text, so query the dot.
     await waitFor(() => {
-      expect(screen.getByText("Memory")).toBeDefined();
+      expect(screen.getByTitle("Memory")).toBeDefined();
     });
   });
 
@@ -195,7 +197,7 @@ describe("MemoryWizardStep", () => {
     await waitFor(() => {
       const steps = ["Persona", "Name & Color", "Framework", "Model", "Memory", "Permissions", "Failure Policy", "Review"];
       for (const s of steps) {
-        expect(screen.getByText(s)).toBeDefined();
+        expect(screen.getByTitle(s)).toBeDefined();
       }
     });
   });

--- a/desktop/src/apps/agents/DeployWizard.tsx
+++ b/desktop/src/apps/agents/DeployWizard.tsx
@@ -929,15 +929,15 @@ export function DeployWizard({
               >
                 {i < step ? <Check size={12} /> : i + 1}
               </div>
-              <span
-                className={`text-[11px] hidden sm:inline ${
-                  i === step ? "text-shell-text" : "text-shell-text-tertiary"
-                }`}
-              >
-                {label}
-              </span>
+              {/* Only the active step shows its label, so the rail never
+                  wraps. Completed/upcoming steps are compact numbered dots. */}
+              {i === step && (
+                <span className="text-[11px] font-medium text-shell-text whitespace-nowrap ml-0.5">
+                  {label}
+                </span>
+              )}
               {i < STEPS.length - 1 && (
-                <div className="w-4 h-px bg-white/10 mx-0.5" />
+                <div className={`w-4 h-px mx-1 ${i < step ? "bg-accent/30" : "bg-white/10"}`} />
               )}
             </div>
           ))}

--- a/desktop/src/apps/agents/DeployWizard.tsx
+++ b/desktop/src/apps/agents/DeployWizard.tsx
@@ -919,6 +919,9 @@ export function DeployWizard({
           {STEPS.map((label, i) => (
             <div key={label} className="flex items-center gap-1">
               <div
+                title={label}
+                aria-label={label}
+                aria-current={i === step ? "step" : undefined}
                 className={`w-6 h-6 rounded-full flex items-center justify-center text-[10px] font-medium transition-colors ${
                   i < step
                     ? "bg-accent/20 text-accent"

--- a/desktop/src/components/persona-picker/PersonaBrowse.tsx
+++ b/desktop/src/components/persona-picker/PersonaBrowse.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { Search, Check } from "lucide-react";
 import { fetchLibrary, fetchPersonaDetail } from "@/lib/personas-api";
 import type { PersonaSource, PersonaSummary, PersonaSelection } from "./types";
 
@@ -9,6 +10,31 @@ const SOURCE_OPTIONS: { value: PersonaSource | ""; label: string }[] = [
   { value: "prompt-library", label: "prompt-library" },
   { value: "user", label: "My library" },
 ];
+
+// Short human label for a source tag.
+const SOURCE_LABEL: Record<string, string> = {
+  builtin: "Built-in",
+  "awesome-openclaw": "OpenClaw",
+  "prompt-library": "Library",
+  user: "Mine",
+};
+
+// Deterministic accent ring per persona so the avatar chips read as a set
+// without introducing off-theme colors. Hue derived from the id.
+function avatarHue(seed: string): number {
+  let h = 0;
+  for (let i = 0; i < seed.length; i++) h = (h * 31 + seed.charCodeAt(i)) % 360;
+  return h;
+}
+
+function initials(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  const first = parts[0] ?? "";
+  if (parts.length === 0) return "?";
+  if (parts.length === 1) return (first.slice(0, 2) || "?").toUpperCase();
+  const last = parts[parts.length - 1] ?? "";
+  return ((first[0] ?? "") + (last[0] ?? "")).toUpperCase() || "?";
+}
 
 export function PersonaBrowse({ onSelect }: { onSelect: (s: PersonaSelection) => void }) {
   const [source, setSource] = useState<PersonaSource | "">("");
@@ -58,96 +84,141 @@ export function PersonaBrowse({ onSelect }: { onSelect: (s: PersonaSelection) =>
     });
   }
 
+  const inputClass =
+    "h-9 w-full rounded-lg border border-white/10 bg-shell-bg-deep px-3 text-sm text-shell-text " +
+    "placeholder:text-shell-text-tertiary focus-visible:outline-none focus-visible:border-accent/40 " +
+    "focus-visible:ring-2 focus-visible:ring-accent/20 transition-colors";
+
   return (
-    <div className="flex gap-3 min-h-0">
-      {/* Left: list */}
-      <div className="flex flex-col gap-2 w-56 shrink-0">
-        <input
-          type="search"
-          aria-label="Search personas"
-          placeholder="Search…"
-          value={q}
-          onChange={(e) => setQ(e.target.value)}
-          className="w-full rounded border border-white/20 bg-white/5 px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-blue-400"
-        />
+    <div className="flex gap-3 min-h-0 h-[19rem]">
+      {/* Left: search + list */}
+      <div className="flex flex-col gap-2 w-60 shrink-0 min-h-0">
+        <div className="relative">
+          <Search
+            size={14}
+            className="absolute left-2.5 top-1/2 -translate-y-1/2 text-shell-text-tertiary pointer-events-none"
+          />
+          <input
+            type="search"
+            aria-label="Search personas"
+            placeholder="Search personas"
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            className={inputClass + " pl-8"}
+          />
+        </div>
         <select
           aria-label="Filter by source"
           value={source}
           onChange={(e) => setSource(e.target.value as PersonaSource | "")}
-          className="w-full rounded border border-white/20 bg-white/5 px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-blue-400"
+          className={inputClass}
         >
           {SOURCE_OPTIONS.map((o) => (
-            <option key={o.value} value={o.value}>
+            <option key={o.value} value={o.value} className="bg-shell-surface">
               {o.label}
             </option>
           ))}
         </select>
 
         {error && (
-          <div role="alert" className="rounded bg-red-900/40 px-2 py-1 text-xs text-red-300">
+          <div role="alert" className="rounded-lg border border-red-500/20 bg-red-500/10 px-2.5 py-1.5 text-xs text-red-300">
             {error}
           </div>
         )}
 
-        <ul
-          aria-label="Persona list"
-          className="flex flex-col gap-1 overflow-y-auto"
-        >
+        <ul aria-label="Persona list" className="flex flex-col gap-1 overflow-y-auto pr-0.5 -mr-0.5 min-h-0">
           {loading && (
-            <li className="py-4 text-center text-sm opacity-50">Loading…</li>
+            <li className="py-6 text-center text-sm text-shell-text-tertiary">Loading...</li>
           )}
           {!loading && personas.length === 0 && !error && (
-            <li className="py-4 text-center text-sm opacity-50">No personas found.</li>
+            <li className="py-6 text-center text-sm text-shell-text-tertiary">No personas found.</li>
           )}
-          {personas.map((p) => (
-            <li key={`${p.source}:${p.id}`}>
-              <button
-                onClick={() => handleSelect(p)}
-                aria-pressed={selected?.id === p.id && selected?.source === p.source}
-                className={`w-full rounded px-2 py-1.5 text-left text-sm transition-colors ${
-                  selected?.id === p.id && selected?.source === p.source
-                    ? "bg-blue-600/40 text-blue-200"
-                    : "hover:bg-white/10"
-                }`}
-              >
-                <div className="font-medium truncate">{p.name}</div>
-                <div className="text-xs opacity-50 capitalize">{p.source}</div>
-              </button>
-            </li>
-          ))}
+          {personas.map((p) => {
+            const active = selected?.id === p.id && selected?.source === p.source;
+            const hue = avatarHue(`${p.source}:${p.id}`);
+            return (
+              <li key={`${p.source}:${p.id}`}>
+                <button
+                  onClick={() => handleSelect(p)}
+                  aria-pressed={active}
+                  className={`group w-full flex items-center gap-2.5 rounded-lg px-2 py-2 text-left transition-colors ${
+                    active
+                      ? "bg-accent/10 ring-1 ring-accent/40"
+                      : "hover:bg-white/5"
+                  }`}
+                >
+                  <span
+                    className="shrink-0 grid place-items-center w-8 h-8 rounded-lg text-[11px] font-semibold text-white/90"
+                    style={{
+                      background: `linear-gradient(135deg, hsl(${hue} 55% 42%), hsl(${(hue + 40) % 360} 55% 32%))`,
+                    }}
+                    aria-hidden
+                  >
+                    {initials(p.name)}
+                  </span>
+                  <span className="min-w-0 flex-1">
+                    <span className="block text-sm font-medium text-shell-text truncate">{p.name}</span>
+                    <span className="block text-[10px] uppercase tracking-wide text-shell-text-tertiary">
+                      {SOURCE_LABEL[p.source] ?? p.source}
+                    </span>
+                  </span>
+                  {active && <Check size={14} className="shrink-0 text-accent" />}
+                </button>
+              </li>
+            );
+          })}
         </ul>
       </div>
 
       {/* Right: preview panel */}
-      <div className="flex flex-1 flex-col gap-2 min-w-0">
+      <div className="flex flex-1 flex-col min-w-0 rounded-lg border border-white/5 bg-shell-bg-deep/60 p-3">
         {!selected && (
-          <p className="text-sm opacity-40 mt-4">Select a persona to preview it.</p>
+          <div className="flex flex-1 flex-col items-center justify-center text-center gap-1.5 text-shell-text-tertiary">
+            <div className="grid place-items-center w-10 h-10 rounded-xl border border-white/10 bg-white/5">
+              <Search size={16} />
+            </div>
+            <p className="text-sm">Select a persona to preview it.</p>
+          </div>
         )}
 
         {selected && (
           <>
-            <h3 className="font-semibold text-sm">{selected.name}</h3>
-            <span className="text-xs opacity-50 capitalize">{selected.source}</span>
+            <div className="flex items-center gap-2.5 mb-2.5 shrink-0">
+              <span
+                className="shrink-0 grid place-items-center w-9 h-9 rounded-lg text-xs font-semibold text-white/90"
+                style={{
+                  background: `linear-gradient(135deg, hsl(${avatarHue(`${selected.source}:${selected.id}`)} 55% 42%), hsl(${(avatarHue(`${selected.source}:${selected.id}`) + 40) % 360} 55% 32%))`,
+                }}
+                aria-hidden
+              >
+                {initials(selected.name)}
+              </span>
+              <div className="min-w-0">
+                <h3 className="text-sm font-semibold text-shell-text truncate">{selected.name}</h3>
+                <span className="inline-block mt-0.5 px-1.5 py-0.5 rounded text-[10px] font-medium bg-white/5 text-shell-text-secondary">
+                  {SOURCE_LABEL[selected.source] ?? selected.source}
+                </span>
+              </div>
+            </div>
 
             {detailError && (
-              <div role="alert" className="rounded bg-red-900/40 px-2 py-1 text-xs text-red-300">
+              <div role="alert" className="rounded-lg border border-red-500/20 bg-red-500/10 px-2.5 py-1.5 text-xs text-red-300">
                 {detailError}
               </div>
             )}
 
-            {detailLoading && (
-              <p className="text-sm opacity-40">Loading…</p>
-            )}
+            {detailLoading && <p className="text-sm text-shell-text-tertiary">Loading...</p>}
 
             {detail && (
               <>
-                <pre className="flex-1 overflow-y-auto whitespace-pre-wrap rounded bg-black/30 p-2 text-xs leading-relaxed font-mono">
+                <pre className="flex-1 min-h-0 overflow-y-auto whitespace-pre-wrap rounded-lg border border-white/5 bg-shell-bg p-2.5 text-xs leading-relaxed font-mono text-shell-text-secondary">
                   {detail.soul_md || "(no persona content)"}
                 </pre>
                 <button
                   onClick={handleUse}
-                  className="self-start rounded bg-blue-600 px-3 py-1.5 text-sm font-medium hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                  className="mt-2.5 self-start inline-flex items-center gap-1.5 rounded-lg bg-accent px-3.5 py-2 text-sm font-medium text-white hover:bg-accent/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 transition-colors"
                 >
+                  <Check size={14} />
                   Use this persona
                 </button>
               </>


### PR DESCRIPTION
First slice of the deploy-wizard redesign (the surface in Jay's screenshot).

## What was wrong
The persona step (PersonaBrowse) used raw `blue-400/600` and `white/20` colors instead of the taOS `accent` / `shell-*` tokens the rest of the app uses, with a flat list and a raw black `<pre>` preview. It read as off-theme and unfinished. The step rail also wrapped ("Name & Color" on two lines).

## Changes
- **PersonaBrowse** rebuilt on taOS tokens: search input with inline icon, per-persona gradient initial avatars, source badges, accent selection state (+ check), and a framed preview panel with the accent primary "Use this persona" button. Logic unchanged.
- **Step rail**: only the active step shows its label (no more wrapping); completed connectors use the accent tint.

## Note
Local vite dev is broken in this env, so I could not screenshot-verify. Visual check pending on the Pi / preview build. tsc clean; no behavior change.

Follow-ups (not in this PR): polish the remaining steps (Name & Color, Framework, Model cards) to the same bar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI/UX Improvements**
  * Refined wizard step indicator: active step now shows its label while completed/upcoming steps stay compact; connector styling updates for clearer progress.
  * Improved persona selection experience with iconography, initials-based avatar chips, active-item checkmarks, and a refreshed preview panel layout.
* **Accessibility**
  * Added accessibility attributes to wizard step dots to better convey current step state.
* **Tests**
  * Updated Memory wizard step tests to locate step UI elements via accessibility `title` attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->