### PR TITLE
ui(deploy): polish remaining wizard steps to taOS design bar

### DIFF
--- a/desktop/src/apps/agents/DeployWizard.tsx
+++ b/desktop/src/apps/agents/DeployWizard.tsx
@@ -188,7 +188,7 @@ export function MemoryWizardStep({
             <button
               type="button"
               onClick={() => setMemoryPickerMode("picker")}
-              className="text-xs text-blue-400 hover:underline"
+              className="text-xs text-accent hover:underline"
             >
               Change
             </button>
@@ -219,7 +219,7 @@ export function MemoryWizardStep({
         <button
           type="button"
           onClick={() => setMemoryPlugin("taosmd")}
-          className="text-xs text-blue-400 hover:underline"
+          className="text-xs text-accent hover:underline"
         >
           Enable memory
         </button>
@@ -986,7 +986,7 @@ export function DeployWizard({
                             setCustomSlug(customSlug ?? derivedSlug);
                             setEditingSlug(true);
                           }}
-                          className="text-blue-400 hover:underline"
+                          className="text-accent hover:underline"
                         >
                           edit
                         </button>
@@ -1069,37 +1069,55 @@ export function DeployWizard({
                 .map((fw) => {
                   const isAlpha = fw.verification_status === "alpha";
                   const selectable = !isAlpha || showExperimental;
+                  const isSelected = selectedFramework === fw.id;
                   return (
                     <button
                       key={fw.id}
                       onClick={() => selectable ? setSelectedFramework(fw.id) : undefined}
                       disabled={!selectable}
                       aria-disabled={!selectable}
-                      className={`w-full text-left px-4 py-3 rounded-lg border transition-colors ${
+                      className={`group w-full text-left px-3.5 py-3 rounded-lg border transition-colors ${
                         !selectable
                           ? "border-white/5 bg-shell-bg-deep opacity-40 cursor-not-allowed"
-                          : selectedFramework === fw.id
+                          : isSelected
                             ? "border-accent bg-accent/10"
-                            : "border-white/5 bg-shell-bg-deep hover:bg-white/5"
+                            : "border-white/10 bg-shell-bg-deep hover:bg-white/5"
                       }`}
                     >
-                      <div className="flex items-center gap-2">
-                        <span className={`text-sm font-medium ${isAlpha ? "text-shell-text-tertiary" : ""}`}>
-                          {fw.name}
-                        </span>
-                        {fw.verification_status === "beta" && (
-                          <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-500/20 text-amber-400 leading-none">
-                            Beta
-                          </span>
-                        )}
-                        {fw.verification_status === "alpha" && (
-                          <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-zinc-500/20 text-zinc-400 leading-none">
-                            Alpha · Testing
-                          </span>
-                        )}
-                      </div>
-                      <div className={`text-xs mt-0.5 ${isAlpha ? "text-shell-text-tertiary" : "text-shell-text-secondary"}`}>
-                        {fw.description}
+                      <div className="flex items-start gap-3">
+                        <div
+                          className={`shrink-0 mt-0.5 flex h-8 w-8 items-center justify-center rounded-lg border text-sm font-semibold uppercase ${
+                            isSelected
+                              ? "border-accent/40 bg-accent/10 text-accent"
+                              : "border-white/10 bg-shell-bg text-shell-text-secondary"
+                          }`}
+                          aria-hidden="true"
+                        >
+                          {fw.name.charAt(0)}
+                        </div>
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-center gap-2">
+                            <span className={`text-sm font-medium ${isAlpha ? "text-shell-text-tertiary" : ""}`}>
+                              {fw.name}
+                            </span>
+                            {fw.verification_status === "beta" && (
+                              <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-500/20 text-amber-400 leading-none">
+                                Beta
+                              </span>
+                            )}
+                            {fw.verification_status === "alpha" && (
+                              <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-zinc-500/20 text-zinc-400 leading-none">
+                                Alpha · Testing
+                              </span>
+                            )}
+                            {isSelected && (
+                              <Check size={14} className="ml-auto shrink-0 text-accent" aria-hidden="true" />
+                            )}
+                          </div>
+                          <div className={`text-xs mt-0.5 ${isAlpha ? "text-shell-text-tertiary" : "text-shell-text-secondary"}`}>
+                            {fw.description}
+                          </div>
+                        </div>
                       </div>
                     </button>
                   );
@@ -1230,7 +1248,7 @@ export function DeployWizard({
                 className={`flex items-start gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
                   canReadUserMemory
                     ? "border-accent bg-accent/10"
-                    : "border-white/5 bg-shell-bg-deep hover:bg-white/5"
+                    : "border-white/10 bg-shell-bg-deep hover:bg-white/5"
                 }`}
               >
                 <input
@@ -1242,7 +1260,12 @@ export function DeployWizard({
                   aria-describedby="agent-user-memory-desc"
                 />
                 <div className="flex-1">
-                  <div className="text-sm font-medium">Allow this agent to read your memory</div>
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium">Allow this agent to read your memory</span>
+                    {canReadUserMemory && (
+                      <Check size={14} className="ml-auto shrink-0 text-accent" aria-hidden="true" />
+                    )}
+                  </div>
                   <div
                     id="agent-user-memory-desc"
                     className="text-xs text-shell-text-secondary mt-0.5"
@@ -1286,7 +1309,7 @@ export function DeployWizard({
                 </Label>
                 <div className="space-y-1.5">
                   {fallbackModels.filter(Boolean).map((m, i) => (
-                    <div key={i} className="flex items-center gap-2 px-3 py-2 rounded-lg border border-white/5 bg-shell-bg-deep">
+                    <div key={i} className="flex items-center gap-2 px-3 py-2 rounded-lg border border-white/10 bg-shell-bg-deep">
                       <span className="flex-1 text-sm truncate">
                         {models.find(mo => mo.id === m)?.name ?? m}
                       </span>


### PR DESCRIPTION
Continues the deploy-agent wizard redesign (first slice, the persona picker, landed in #1304). Brings the remaining steps up to the taOS design bar using only the established token vocabulary.

## What changed
`desktop/src/apps/agents/DeployWizard.tsx` only. Styling only, no logic, handlers, prop names, aria-labels or step flow touched.

- Memory step + slug-edit affordance: replaced raw `text-blue-400` links with `text-accent`.
- Framework step: each framework is now an intentional selectable card with an initial-letter avatar tile, consistent `border-white/10` idle borders, accent-tinted selected state and a `Check` marker. The existing beta/alpha verification pills and descriptions are preserved.
- Permissions + fallback-model rows: lifted idle borders to `border-white/10` and added a `Check` on the selected permission for a consistent selected state.
- The Model step keeps `ModelPickerFlow` untouched; only surrounding chrome already used the token vocabulary.

## Verification
- `npx tsc --noEmit` passes clean.
- `AgentsApp.test.tsx` is excluded from the repo's vitest gate on dev (order-dependent suite), so it was not run, matching baseline.
- No raw blue-/indigo-/purple-/white/20 tokens remain in the file.