### PR TITLE
llm-proxy: in-house per-agent key store (custom_auth, no Postgres)

### DIFF
--- a/tests/test_litellm_keystore.py
+++ b/tests/test_litellm_keystore.py
@@ -139,3 +139,16 @@ async def test_hook_out_of_scope_model_403(monkeypatch, tmp_path):
     with pytest.raises(HTTPException) as exc:
         await auth.user_api_key_auth(_FakeRequest({"model": "claude-3"}), token)
     assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_hook_empty_allowlist_is_deny_all(monkeypatch, tmp_path):
+    """An empty allowlist must 403 every model, not fall through to allow-all
+    (which is how LiteLLM reads UserAPIKeyAuth(models=[]))."""
+    from fastapi import HTTPException
+    path = tmp_path / "keys.db"
+    token = LiteLLMKeyStore(path).mint("agent-a", None)  # stored as []
+    auth = _reload_auth(monkeypatch, path)
+    with pytest.raises(HTTPException) as exc:
+        await auth.user_api_key_auth(_FakeRequest({"model": "anything"}), token)
+    assert exc.value.status_code == 403

--- a/tests/test_litellm_keystore.py
+++ b/tests/test_litellm_keystore.py
@@ -1,0 +1,141 @@
+"""Tests for the in-house LiteLLM key store + custom_auth hook."""
+import importlib
+import sys
+import types
+
+import pytest
+
+from tinyagentos.litellm_keystore import (
+    LiteLLMKeyStore,
+    default_keystore_path,
+)
+
+
+def test_mint_and_lookup(tmp_path):
+    store = LiteLLMKeyStore(tmp_path / "keys.db")
+    token = store.mint("agent-a", ["gpt-4o", "default"])
+    assert token.startswith("sk-taos-")
+    rec = store.lookup(token)
+    assert rec == {"agent": "agent-a", "allowed_models": ["gpt-4o", "default"]}
+
+
+def test_lookup_unknown_returns_none(tmp_path):
+    store = LiteLLMKeyStore(tmp_path / "keys.db")
+    assert store.lookup("sk-taos-nope") is None
+
+
+def test_empty_allowlist_stored_as_deny_all(tmp_path):
+    store = LiteLLMKeyStore(tmp_path / "keys.db")
+    token = store.mint("agent-a", None)
+    assert store.lookup(token)["allowed_models"] == []
+
+
+def test_set_models_rescopes(tmp_path):
+    store = LiteLLMKeyStore(tmp_path / "keys.db")
+    token = store.mint("agent-a", ["a"])
+    assert store.set_models(token, ["b", "c"]) is True
+    assert store.lookup(token)["allowed_models"] == ["b", "c"]
+    assert store.set_models("sk-taos-missing", ["x"]) is False
+
+
+def test_delete_and_delete_agent(tmp_path):
+    store = LiteLLMKeyStore(tmp_path / "keys.db")
+    t1 = store.mint("agent-a", ["a"])
+    t2 = store.mint("agent-a", ["b"])
+    t3 = store.mint("agent-b", ["c"])
+    assert store.delete(t1) is True
+    assert store.lookup(t1) is None
+    assert store.delete_agent("agent-a") == 1  # t2 remains
+    assert store.lookup(t2) is None
+    assert store.lookup(t3) is not None  # other agent untouched
+
+
+def test_cross_process_handle_sees_writes(tmp_path):
+    """A second handle (the hook's reader) sees the controller's writes."""
+    path = tmp_path / "keys.db"
+    writer = LiteLLMKeyStore(path)
+    token = writer.mint("agent-a", ["m"])
+    reader = LiteLLMKeyStore(path)
+    assert reader.lookup(token)["agent"] == "agent-a"
+
+
+def test_default_keystore_path(tmp_path):
+    assert default_keystore_path(tmp_path) == tmp_path / ".litellm_keys.db"
+
+
+# --- custom_auth hook ---------------------------------------------------
+
+
+class _FakeRequest:
+    def __init__(self, body):
+        self._body = body
+
+    async def json(self):
+        return self._body
+
+
+def _stub_litellm(monkeypatch):
+    """Inject a minimal ``litellm.proxy._types.UserAPIKeyAuth`` so the hook
+    runs without the (container-only) litellm package installed."""
+    class _UserAPIKeyAuth:
+        def __init__(self, **kw):
+            self.api_key = kw.get("api_key")
+            self.key_alias = kw.get("key_alias")
+            self.models = kw.get("models", [])
+            self.metadata = kw.get("metadata", {})
+
+    litellm = types.ModuleType("litellm")
+    proxy = types.ModuleType("litellm.proxy")
+    _types = types.ModuleType("litellm.proxy._types")
+    _types.UserAPIKeyAuth = _UserAPIKeyAuth
+    proxy._types = _types
+    litellm.proxy = proxy
+    monkeypatch.setitem(sys.modules, "litellm", litellm)
+    monkeypatch.setitem(sys.modules, "litellm.proxy", proxy)
+    monkeypatch.setitem(sys.modules, "litellm.proxy._types", _types)
+
+
+def _reload_auth(monkeypatch, keystore_path, master="sk-master"):
+    monkeypatch.setenv("TAOS_LITELLM_KEYSTORE", str(keystore_path))
+    monkeypatch.setenv("LITELLM_MASTER_KEY", master)
+    _stub_litellm(monkeypatch)
+    import tinyagentos.litellm_auth as auth
+    importlib.reload(auth)  # reset the cached module-level store
+    return auth
+
+
+@pytest.mark.asyncio
+async def test_hook_master_key_passthrough(monkeypatch, tmp_path):
+    auth = _reload_auth(monkeypatch, tmp_path / "keys.db")
+    result = await auth.user_api_key_auth(_FakeRequest({"model": "x"}), "sk-master")
+    assert result.api_key == "sk-master"
+
+
+@pytest.mark.asyncio
+async def test_hook_unknown_key_401(monkeypatch, tmp_path):
+    from fastapi import HTTPException
+    auth = _reload_auth(monkeypatch, tmp_path / "keys.db")
+    with pytest.raises(HTTPException) as exc:
+        await auth.user_api_key_auth(_FakeRequest({"model": "x"}), "sk-taos-bad")
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_hook_valid_key_in_scope(monkeypatch, tmp_path):
+    path = tmp_path / "keys.db"
+    token = LiteLLMKeyStore(path).mint("agent-a", ["gpt-4o"])
+    auth = _reload_auth(monkeypatch, path)
+    result = await auth.user_api_key_auth(_FakeRequest({"model": "gpt-4o"}), token)
+    assert result.metadata["agent"] == "agent-a"
+    assert "gpt-4o" in result.models
+
+
+@pytest.mark.asyncio
+async def test_hook_out_of_scope_model_403(monkeypatch, tmp_path):
+    from fastapi import HTTPException
+    path = tmp_path / "keys.db"
+    token = LiteLLMKeyStore(path).mint("agent-a", ["gpt-4o"])
+    auth = _reload_auth(monkeypatch, path)
+    with pytest.raises(HTTPException) as exc:
+        await auth.user_api_key_auth(_FakeRequest({"model": "claude-3"}), token)
+    assert exc.value.status_code == 403

--- a/tests/test_llm_proxy.py
+++ b/tests/test_llm_proxy.py
@@ -519,6 +519,16 @@ class TestInhouseKeys:
         assert proxy._keystore().lookup(key)["agent"] == "agent-a"
 
     @pytest.mark.asyncio
+    async def test_create_key_no_models_scopes_to_default(self, tmp_path):
+        """Parity with the Postgres path's ``models or ["default"]``: an agent
+        deployed without an explicit model is scoped to the default alias, not
+        an empty allowlist (which the auth hook deny-alls)."""
+        proxy = LLMProxy(port=14006, config_dir=tmp_path, data_dir=tmp_path,
+                         inhouse_keys=True)
+        key = await proxy.create_agent_key("agent-a", None)
+        assert proxy._keystore().lookup(key)["allowed_models"] == ["default"]
+
+    @pytest.mark.asyncio
     async def test_update_and_delete_key_inhouse(self, tmp_path):
         proxy = LLMProxy(port=14005, config_dir=tmp_path, data_dir=tmp_path,
                          inhouse_keys=True)

--- a/tests/test_llm_proxy.py
+++ b/tests/test_llm_proxy.py
@@ -477,3 +477,53 @@ class TestLLMProxyOwnership:
         key = await p.create_agent_key("routing-only")
         assert key is None
         assert called is False
+
+
+class TestInhouseKeys:
+    """In-house key mode: per-agent keys minted in a local SQLite store via
+    the custom_auth hook, so virtual keys work with no DATABASE_URL (the ARM /
+    no-Postgres fix). Opt-in; default behavior is unchanged."""
+
+    def test_config_emits_custom_auth_when_inhouse(self):
+        result = generate_litellm_config([], inhouse_keys=True)
+        gs = result["general_settings"]
+        assert gs["custom_auth"] == "taos_auth.user_api_key_auth"
+        assert gs["custom_auth_run_common_checks"] is False
+
+    def test_config_no_custom_auth_by_default(self):
+        result = generate_litellm_config([])
+        assert "custom_auth" not in result["general_settings"]
+
+    @pytest.mark.asyncio
+    async def test_write_config_writes_auth_shim_when_inhouse(self, tmp_path):
+        proxy = LLMProxy(port=14002, config_dir=tmp_path, inhouse_keys=True)
+        await proxy.write_config([])
+        shim = tmp_path / "taos_auth.py"
+        assert shim.exists()
+        assert "from tinyagentos.litellm_auth import user_api_key_auth" in shim.read_text()
+
+    @pytest.mark.asyncio
+    async def test_write_config_no_auth_shim_by_default(self, tmp_path):
+        proxy = LLMProxy(port=14003, config_dir=tmp_path)
+        await proxy.write_config([])
+        assert not (tmp_path / "taos_auth.py").exists()
+
+    @pytest.mark.asyncio
+    async def test_create_key_mints_locally_without_db(self, tmp_path):
+        """Minting works with no DB and no running proxy in in-house mode."""
+        proxy = LLMProxy(port=14004, config_dir=tmp_path, data_dir=tmp_path,
+                         inhouse_keys=True)
+        key = await proxy.create_agent_key("agent-a", ["gpt-4o"])
+        assert key and key.startswith("sk-taos-")
+        # the same key authorizes via the shared store
+        assert proxy._keystore().lookup(key)["agent"] == "agent-a"
+
+    @pytest.mark.asyncio
+    async def test_update_and_delete_key_inhouse(self, tmp_path):
+        proxy = LLMProxy(port=14005, config_dir=tmp_path, data_dir=tmp_path,
+                         inhouse_keys=True)
+        key = await proxy.create_agent_key("agent-a", ["a"])
+        assert await proxy.update_agent_key(key, ["b", "c"]) is True
+        assert proxy._keystore().lookup(key)["allowed_models"] == ["b", "c"]
+        assert await proxy.delete_agent_key(key) is True
+        assert proxy._keystore().lookup(key) is None

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -308,6 +308,12 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     # docs/design/framework-agnostic-runtime.md.
     db_url_path = data_dir / ".litellm_db_url"
     db_url = db_url_path.read_text().strip() if db_url_path.exists() else None
+    # Opt-in: authorize per-agent virtual keys against taOS's own SQLite key
+    # store via LiteLLM's custom_auth hook, instead of its Postgres/prisma
+    # virtual-key table. Lets per-agent keys work with NO DATABASE_URL and no
+    # prisma (the ARM / no-Postgres fix). Off by default; the released
+    # master-key fallback covers routing-only installs until this is enabled.
+    inhouse_keys = (data_dir / ".litellm_inhouse_keys").exists()
     # Read the local auth token so LLMProxy can forward it to LiteLLM's
     # subprocess — otherwise the taOS callback can't POST llm_call events
     # back to /api/trace and the 401s fill the log instead of trace rows.
@@ -324,6 +330,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         # at the proxy because no alias exists for that model_name.
         registry=registry,
         data_dir=data_dir,
+        inhouse_keys=inhouse_keys,
     )
     channel_hub_router = MessageRouter()
     adapter_manager = AdapterManager(channel_hub_router)

--- a/tinyagentos/litellm_auth.py
+++ b/tinyagentos/litellm_auth.py
@@ -1,0 +1,102 @@
+"""LiteLLM custom_auth hook backed by taOS's in-house key store.
+
+Wired via ``general_settings.custom_auth`` in the generated LiteLLM config
+(through a config-dir ``taos_auth.py`` shim, like the callback). This lets
+LiteLLM authorize per-agent keys against ``LiteLLMKeyStore`` instead of its
+Postgres ``LiteLLM_VerificationToken`` table, so virtual keys work with NO
+``DATABASE_URL`` and no prisma (the ARM / no-Postgres fix).
+
+The hook reads two env vars exported by ``LLMProxy.start`` into the
+subprocess:
+  - ``LITELLM_MASTER_KEY``   -> admin passthrough
+  - ``TAOS_LITELLM_KEYSTORE`` -> path to the SQLite key store
+
+Per-agent model scoping is enforced HERE (read the requested model from the
+body and reject out-of-scope calls) so correctness does not depend on
+LiteLLM's historically-flaky post-auth model-allowlist path. The returned
+object also carries the allowlist + metadata so LiteLLM's own enforcement
+and taOS's usage callback both work.
+"""
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+_store = None
+_store_path = None
+
+
+def _keystore():
+    """Lazily open (and cache) the keystore from the env-provided path."""
+    global _store, _store_path
+    path = os.environ.get("TAOS_LITELLM_KEYSTORE")
+    if not path:
+        return None
+    if _store is None or _store_path != path:
+        from tinyagentos.litellm_keystore import LiteLLMKeyStore
+        _store = LiteLLMKeyStore(path)
+        _store_path = path
+    return _store
+
+
+async def _requested_model(request) -> str | None:
+    """Best-effort read of the model from the request body (for scope check).
+
+    Never raises: a body we cannot parse just means we skip the in-hook model
+    check and rely on the returned allowlist.
+    """
+    try:
+        body = await request.json()
+    except Exception:
+        return None
+    if isinstance(body, dict):
+        m = body.get("model")
+        return m if isinstance(m, str) else None
+    return None
+
+
+async def user_api_key_auth(request, api_key: str):
+    """Authorize an incoming key against the taOS key store.
+
+    Returns a ``UserAPIKeyAuth`` on success; raises ``fastapi.HTTPException``
+    (401/403) otherwise. The master key is admin (full access).
+    """
+    from fastapi import HTTPException
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    master = os.environ.get("LITELLM_MASTER_KEY")
+    if master and api_key == master:
+        # Admin / proxy operations: full access.
+        return UserAPIKeyAuth(api_key=api_key)
+
+    store = _keystore()
+    if store is None:
+        # Misconfiguration: in-house auth selected but no store path. Refuse
+        # rather than silently allow.
+        logger.error("litellm_auth: TAOS_LITELLM_KEYSTORE not set; rejecting key")
+        raise HTTPException(status_code=401, detail="auth store unavailable")
+
+    rec = store.lookup(api_key)
+    if rec is None:
+        raise HTTPException(status_code=401, detail="invalid key")
+
+    agent = rec["agent"]
+    allowed = rec["allowed_models"] or []
+
+    # Defense in depth: enforce the per-agent model allowlist in-hook so
+    # correctness does not depend on LiteLLM's post-auth enforcement.
+    requested = await _requested_model(request)
+    if requested and allowed and requested not in allowed:
+        raise HTTPException(
+            status_code=403,
+            detail=f"model {requested!r} is not permitted for this agent",
+        )
+
+    return UserAPIKeyAuth(
+        api_key=api_key,
+        key_alias=f"taos-{agent}",
+        models=list(allowed),
+        metadata={"agent": agent, "managed_by": "tinyagentos"},
+    )

--- a/tinyagentos/litellm_auth.py
+++ b/tinyagentos/litellm_auth.py
@@ -86,9 +86,18 @@ async def user_api_key_auth(request, api_key: str):
     allowed = rec["allowed_models"] or []
 
     # Defense in depth: enforce the per-agent model allowlist in-hook so
-    # correctness does not depend on LiteLLM's post-auth enforcement.
+    # correctness does not depend on LiteLLM's post-auth enforcement (which
+    # is disabled here via custom_auth_run_common_checks=False). An empty
+    # allowlist is deny-all per the keystore's mint() contract — do NOT
+    # short-circuit it, because returning UserAPIKeyAuth(models=[]) would be
+    # read by LiteLLM as "no restriction" (allow-all), the opposite intent.
     requested = await _requested_model(request)
-    if requested and allowed and requested not in allowed:
+    if not allowed:
+        raise HTTPException(
+            status_code=403,
+            detail="no models are permitted for this agent",
+        )
+    if requested and requested not in allowed:
         raise HTTPException(
             status_code=403,
             detail=f"model {requested!r} is not permitted for this agent",

--- a/tinyagentos/litellm_config.py
+++ b/tinyagentos/litellm_config.py
@@ -215,6 +215,7 @@ def generate_litellm_config(
     registry=None,
     master_key: str | None = None,
     discovered: dict[str, list[str]] | None = None,
+    inhouse_keys: bool = False,
 ) -> dict:
     """Generate LiteLLM config from TinyAgentOS backend list.
 
@@ -389,6 +390,19 @@ def generate_litellm_config(
                     aliased_embedding_claimed = True
 
     resolved_master_key = master_key if master_key is not None else get_litellm_master_key()
+    general_settings = {
+        "master_key": resolved_master_key,
+        "background_health_checks": False,
+        "disable_spend_logs": True,
+    }
+    if inhouse_keys:
+        # Authorize per-agent keys against taOS's SQLite key store via the
+        # custom_auth hook instead of LiteLLM's Postgres virtual-key table.
+        # The loader resolves this dotted path relative to the config dir, so
+        # write_config writes a sibling ``taos_auth.py`` re-exporting the hook.
+        # No DATABASE_URL is needed (the ARM / no-Postgres fix).
+        general_settings["custom_auth"] = "taos_auth.user_api_key_auth"
+        general_settings["custom_auth_run_common_checks"] = False
     return {
         "model_list": model_list,
         "router_settings": {
@@ -397,11 +411,7 @@ def generate_litellm_config(
             "timeout": 120,
             "enable_pre_call_checks": False,
         },
-        "general_settings": {
-            "master_key": resolved_master_key,
-            "background_health_checks": False,
-            "disable_spend_logs": True,
-        },
+        "general_settings": general_settings,
         # LiteLLM's proxy reads custom logger classes from
         # ``litellm_settings.callbacks``. The loader (get_instance_fn) resolves
         # the dotted path relative to the config file's directory — so the

--- a/tinyagentos/litellm_keystore.py
+++ b/tinyagentos/litellm_keystore.py
@@ -1,0 +1,115 @@
+"""In-house per-agent LiteLLM key store.
+
+The alternative to LiteLLM's Postgres/prisma virtual-key table. The
+controller mints a random per-agent token here with its allowed model
+list; the LiteLLM ``custom_auth`` hook (``tinyagentos.litellm_auth``)
+reads the same store to authorize incoming requests. Both processes open
+the same SQLite file, so this works with NO ``DATABASE_URL`` and no prisma
+(the whole point: virtual keys on ARM / no-Postgres installs).
+
+Scope intentionally tiny: mint, lookup, re-scope, delete. Spend/budget
+tracking stays in taOS's existing trace/observability layer, not here.
+"""
+from __future__ import annotations
+
+import json
+import secrets
+import sqlite3
+import time
+from pathlib import Path
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS agent_keys (
+    token           TEXT PRIMARY KEY,
+    agent           TEXT NOT NULL,
+    allowed_models  TEXT NOT NULL,
+    created_ts      REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_agent_keys_agent ON agent_keys(agent);
+"""
+
+# taos-prefixed so the key is recognisable in logs and never collides with
+# LiteLLM's own sk- keys.
+_TOKEN_PREFIX = "sk-taos-"
+
+
+class LiteLLMKeyStore:
+    """SQLite-backed per-agent key store, safe for cross-process read/write.
+
+    The controller writes (mint/rescope/delete); the LiteLLM subprocess's
+    auth hook only reads. WAL mode keeps a concurrent reader from blocking
+    on a writer.
+    """
+
+    def __init__(self, path: str | Path):
+        self.path = str(path)
+        self._init()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.path, timeout=5)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA busy_timeout=5000")
+        return conn
+
+    def _init(self) -> None:
+        Path(self.path).parent.mkdir(parents=True, exist_ok=True)
+        with self._connect() as conn:
+            conn.executescript(_SCHEMA)
+
+    def mint(self, agent: str, allowed_models: list[str] | None) -> str:
+        """Create a fresh token for an agent scoped to allowed_models.
+
+        An empty/None allowlist is stored as ``[]`` (deny-all rather than a
+        bogus "default" alias) so the hook can enforce it explicitly.
+        """
+        token = _TOKEN_PREFIX + secrets.token_urlsafe(32)
+        models_json = json.dumps(list(allowed_models or []))
+        with self._connect() as conn:
+            conn.execute(
+                "INSERT INTO agent_keys (token, agent, allowed_models, created_ts) "
+                "VALUES (?, ?, ?, ?)",
+                (token, agent, models_json, time.time()),
+            )
+        return token
+
+    def lookup(self, token: str) -> dict | None:
+        """Return ``{agent, allowed_models}`` for a token, or None if unknown."""
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT agent, allowed_models FROM agent_keys WHERE token = ?",
+                (token,),
+            ).fetchone()
+        if row is None:
+            return None
+        try:
+            models = json.loads(row["allowed_models"])
+        except (ValueError, TypeError):
+            models = []
+        return {"agent": row["agent"], "allowed_models": models}
+
+    def set_models(self, token: str, allowed_models: list[str]) -> bool:
+        """Re-scope a token's allowed models in place. Returns True if it existed."""
+        with self._connect() as conn:
+            cur = conn.execute(
+                "UPDATE agent_keys SET allowed_models = ? WHERE token = ?",
+                (json.dumps(list(allowed_models or [])), token),
+            )
+            return cur.rowcount > 0
+
+    def delete(self, token: str) -> bool:
+        """Remove a token. Returns True if it existed."""
+        with self._connect() as conn:
+            cur = conn.execute("DELETE FROM agent_keys WHERE token = ?", (token,))
+            return cur.rowcount > 0
+
+    def delete_agent(self, agent: str) -> int:
+        """Remove all tokens for an agent (e.g. on undeploy). Returns count."""
+        with self._connect() as conn:
+            cur = conn.execute("DELETE FROM agent_keys WHERE agent = ?", (agent,))
+            return cur.rowcount
+
+
+def default_keystore_path(data_dir: str | Path) -> Path:
+    """Canonical keystore path for a controller data dir."""
+    return Path(data_dir) / ".litellm_keys.db"

--- a/tinyagentos/llm_proxy.py
+++ b/tinyagentos/llm_proxy.py
@@ -85,10 +85,17 @@ class LLMProxy:
         local_token: str | None = None,
         registry=None,
         data_dir: Path | None = None,
+        inhouse_keys: bool = False,
     ):
         self.port = port
         self.config_dir = config_dir or Path("/tmp/taos-litellm")
         self.database_url = database_url
+        # In-house key mode: mint/scope per-agent keys in a local SQLite store
+        # and authorize them via the custom_auth hook, instead of LiteLLM's
+        # Postgres/prisma virtual-key table. Lets virtual keys work with NO
+        # DATABASE_URL (the ARM / no-Postgres fix). Opt-in; the router,
+        # streaming, master key, and usage callback are unaffected.
+        self.inhouse_keys = inhouse_keys
         # Local auth token for taOS callbacks (POST /api/trace). Exported
         # to the LiteLLM subprocess as ``TAOS_LOCAL_TOKEN`` so the custom
         # logger in ``tinyagentos.litellm_callback`` can authenticate to
@@ -105,6 +112,18 @@ class LLMProxy:
         # When None, an in-memory key is used (acceptable in tests / routing-only mode).
         self._data_dir = data_dir
         self._process: subprocess.Popen | None = None
+        self._keystore_cache = None
+
+    def _keystore(self):
+        """Lazily open the in-house key store (controller side)."""
+        if self._keystore_cache is None:
+            from tinyagentos.litellm_keystore import (
+                LiteLLMKeyStore,
+                default_keystore_path,
+            )
+            base = self._data_dir or self.config_dir
+            self._keystore_cache = LiteLLMKeyStore(default_keystore_path(base))
+        return self._keystore_cache
 
     @property
     def url(self) -> str:
@@ -140,6 +159,7 @@ class LLMProxy:
             registry=self._registry,
             master_key=get_litellm_master_key(self._data_dir),
             discovered=discovered,
+            inhouse_keys=self.inhouse_keys,
         )
         config_path = self.config_dir / "litellm_config.yaml"
 
@@ -151,6 +171,12 @@ class LLMProxy:
             "from tinyagentos.litellm_callback import taos_callback "
             "as proxy_handler_instance\n"
         )
+        if self.inhouse_keys:
+            # Sibling shim so LiteLLM's config-dir-relative importer can load
+            # the custom_auth hook (general_settings.custom_auth: taos_auth...).
+            (self.config_dir / "taos_auth.py").write_text(
+                "from tinyagentos.litellm_auth import user_api_key_auth\n"
+            )
         return config_path
 
     async def start(
@@ -254,10 +280,18 @@ class LLMProxy:
         existing_path = env.get("PATH", "")
         if venv_bin not in existing_path.split(os.pathsep):
             env["PATH"] = venv_bin + os.pathsep + existing_path if existing_path else venv_bin
-        # DATABASE_URL enables Postgres-backed virtual keys. Without it
-        # LiteLLM still routes chat/embeddings fine but /key/generate
-        # returns a server error.
-        if self.database_url:
+        if self.inhouse_keys:
+            # In-house key mode: the custom_auth hook authorizes per-agent
+            # tokens from this SQLite store. Point the subprocess at it and do
+            # NOT export DATABASE_URL, so LiteLLM never starts prisma (the ARM
+            # fix). The router still works fully without a DB.
+            from tinyagentos.litellm_keystore import default_keystore_path
+            base = self._data_dir or self.config_dir
+            env["TAOS_LITELLM_KEYSTORE"] = str(default_keystore_path(base))
+        elif self.database_url:
+            # DATABASE_URL enables Postgres-backed virtual keys. Without it
+            # LiteLLM still routes chat/embeddings fine but /key/generate
+            # returns a server error.
             env["DATABASE_URL"] = self.database_url
         # Resolve every api_key_secret into a real env var so the
         # os.environ/<name> markers in the generated config resolve to
@@ -339,7 +373,17 @@ class LLMProxy:
 
     async def create_agent_key(self, agent_name: str, models: list[str] | None = None,
                                 max_budget: float | None = None) -> str | None:
-        """Create a per-agent virtual key via LiteLLM API."""
+        """Create a per-agent virtual key.
+
+        In-house mode mints a token in the local key store (no DB, works on
+        ARM). Otherwise it calls LiteLLM's Postgres-backed /key/generate.
+        """
+        if self.inhouse_keys:
+            try:
+                return self._keystore().mint(agent_name, models)
+            except Exception as e:
+                logger.warning("inhouse key mint failed for %s: %s", agent_name, e)
+                return None
         if not self.is_running():
             return None
         # LiteLLM virtual keys require a Postgres DB. Without one,
@@ -380,6 +424,15 @@ class LLMProxy:
         use. Returns True on success. No-op (False) in routing-only mode (no DB)
         — there are no per-agent keys to scope there.
         """
+        if self.inhouse_keys:
+            if not key or not models:
+                logger.warning("update_agent_key (inhouse) needs key + models; refusing")
+                return False
+            try:
+                return self._keystore().set_models(key, models)
+            except Exception as e:
+                logger.warning("inhouse key re-scope failed: %s", e)
+                return False
         if not self.is_running() or not self.database_url or not key:
             return False
         if not models:
@@ -407,6 +460,14 @@ class LLMProxy:
 
     async def delete_agent_key(self, key: str) -> bool:
         """Delete a per-agent virtual key."""
+        if self.inhouse_keys:
+            if not key:
+                return False
+            try:
+                return self._keystore().delete(key)
+            except Exception as e:
+                logger.warning("inhouse key delete failed: %s", e)
+                return False
         if not self.is_running():
             return False
         try:

--- a/tinyagentos/llm_proxy.py
+++ b/tinyagentos/llm_proxy.py
@@ -378,7 +378,7 @@ class LLMProxy:
         In-house mode mints a token in the local key store (no DB, works on
         ARM). Otherwise it calls LiteLLM's Postgres-backed /key/generate.
         """
-        if self.inhouse_keys:
+        if getattr(self, "inhouse_keys", False):
             try:
                 # Mirror the Postgres path's ``models or ["default"]`` so an
                 # agent deployed without an explicit model is scoped to the
@@ -428,7 +428,7 @@ class LLMProxy:
         use. Returns True on success. No-op (False) in routing-only mode (no DB)
         — there are no per-agent keys to scope there.
         """
-        if self.inhouse_keys:
+        if getattr(self, "inhouse_keys", False):
             if not key or not models:
                 logger.warning("update_agent_key (inhouse) needs key + models; refusing")
                 return False
@@ -464,7 +464,7 @@ class LLMProxy:
 
     async def delete_agent_key(self, key: str) -> bool:
         """Delete a per-agent virtual key."""
-        if self.inhouse_keys:
+        if getattr(self, "inhouse_keys", False):
             if not key:
                 return False
             try:

--- a/tinyagentos/llm_proxy.py
+++ b/tinyagentos/llm_proxy.py
@@ -380,7 +380,11 @@ class LLMProxy:
         """
         if self.inhouse_keys:
             try:
-                return self._keystore().mint(agent_name, models)
+                # Mirror the Postgres path's ``models or ["default"]`` so an
+                # agent deployed without an explicit model is scoped to the
+                # default chat alias (still usable), not minted with an empty
+                # allowlist that the auth hook would then deny-all.
+                return self._keystore().mint(agent_name, models or ["default"])
             except Exception as e:
                 logger.warning("inhouse key mint failed for %s: %s", agent_name, e)
                 return None


### PR DESCRIPTION
## What

Opt-in key mode that mints per-agent virtual keys in a local SQLite store and authorizes them through LiteLLM's \`custom_auth\` hook, instead of LiteLLM's Postgres/prisma virtual-key table.

This is the durable fix for the ARM / no-Postgres deploy regression: \`prisma-client-py\` 0.15.0's query engine won't start on the Pi, so \`/key/generate\` fails and per-agent keys can't be minted. With this mode the router keeps working and per-agent keys are minted locally, with **no DATABASE_URL and no prisma**.

## How

- \`litellm_keystore.py\` — SQLite \`mint\` / \`lookup\` / \`set_models\` / \`delete\` / \`delete_agent\`. WAL + busy_timeout for cross-process controller-write / hook-read.
- \`litellm_auth.py\` — the \`custom_auth\` hook. Master key passes through (admin); otherwise looks up the token and enforces the per-agent model allowlist in-hook (401 unknown key, 403 out-of-scope model), returning \`UserAPIKeyAuth\` with the allowlist + metadata so the usage callback still attributes spend per agent.
- \`llm_proxy.py\` — \`inhouse_keys\` flag routes \`create/update/delete_agent_key\` through the keystore, writes the \`taos_auth.py\` shim next to the config, exports \`TAOS_LITELLM_KEYSTORE\`, and skips \`DATABASE_URL\` so prisma never starts.
- \`litellm_config.py\` — emits \`general_settings.custom_auth\` when in-house.
- \`app.py\` — gates the flag on a \`.litellm_inhouse_keys\` marker file.

## Safety

Behind a flag, **default off**. Current behavior (master-key fallback for routing-only installs) is unchanged unless the marker file is present. Not yet enabled on any host.

## Tests

- \`test_litellm_keystore.py\` — store round-trips + the hook (master passthrough, 401 unknown, 403 out-of-scope, in-scope success). litellm stubbed so the hook runs in CI without the container-only package.
- \`test_llm_proxy.py\` — config emits \`custom_auth\`, shim written, and create/update/delete mint locally with no DB and no running proxy.

187 of 187 targeted tests green (keystore + proxy + config + deployer).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an opt-in “in-house key mode” for LiteLLM authorization using TinyAgentOS’s SQLite-backed keystore.
  * Introduced a LiteLLM `custom_auth` hook that supports master-key passthrough and enforces per-agent model scoping (denies requests when a token’s scope is empty or missing the requested model).
  * Enables local per-agent API key management with model scoping; activated by creating `.litellm_inhouse_keys` in the data directory.

* **Tests**
  * Added keystore and auth-hook test coverage, plus proxy tests for in-house key mode behavior (token minting, scoping, updates, deletions, and persistence).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->