### PR TITLE
feat(agents): add DeerFlow (bytedance/deer-flow) framework support

### DIFF
--- a/app-catalog/agents/deer-flow/framework-integration.yaml
+++ b/app-catalog/agents/deer-flow/framework-integration.yaml
@@ -1,0 +1,107 @@
+# DeerFlow SuperAgent — framework integration manifest
+# See docs/superpowers/specs/2026-04-11-taos-framework-integration-bridge-design.md
+#
+# NOTE: This is a *design specification*, not machine-processed runtime config.
+# ${VAR} tokens (e.g. ${TAOS_HOST}) are documentation placeholders indicating
+# values resolved by the TAOS deployer at provision time. They mirror the same
+# env vars the deployer injects into the container after install.sh.
+
+framework: deer-flow
+display_name: DeerFlow SuperAgent
+version: "2.1.0"
+
+# -- Protocol endpoints the adapter speaks -----------------------------------
+endpoints:
+  llm: openai-chat              # DeerFlow calls the taOS LiteLLM proxy (OpenAI-compatible)
+  memory: none                  # DeerFlow uses its own SQLite-backed persistence
+  skills: none                  # DeerFlow has built-in tools via its LangGraph nodes
+  channels: sse-bridge          # Connects to TAOS channels via the adapter bridge
+  approval: none                # Not implemented yet
+  sandbox: host-enforced        # Container-level sandbox (default LocalSandboxProvider)
+
+# -- Persistence contract -----------------------------------------------------
+persistence:
+  memory:
+    kind: sqlite-volume
+    mount: /opt/deer-flow/backend
+    host_subdir: agent-memory/{name}/deer-flow/
+    writable: true
+    note: DeerFlow persists run state to SQLite by default
+  workspace:
+    mount: /workspace
+    host_subdir: agent-workspaces/{name}/
+    writable: true
+  sessions:
+    mount: /sessions
+    host_subdir: agent-sessions/{name}/
+    writable: true
+
+# -- Capabilities matrix ------------------------------------------------------
+capabilities:
+  multi_model: true             # DeerFlow supports multiple model entries in config.yaml
+  hot_reload:
+    kind: restart-only          # DeerFlow requires restart for config changes
+    interval_seconds: null
+    push_supported: false
+    fallback: restart
+  metrics:
+    format: none                # DeerFlow has no built-in metrics endpoint
+  observability:
+    structured_logs: true       # DeerFlow backend logs are structured
+    trace_format: none
+
+# -- Installation -------------------------------------------------------------
+install:
+  base_image: debian:bookworm-slim
+  steps:
+    - apt: [python3, python3-venv, git, curl, ca-certificates, build-essential]
+    - run: "curl -LsSf https://astral.sh/uv/install.sh | sh"
+    - run: "git clone --depth 1 https://github.com/bytedance/deer-flow /opt/deer-flow"
+    - run: "cd /opt/deer-flow/backend && uv sync"
+    - mkdir: [/var/log/deer-flow]
+  install_script: scripts/install.sh
+
+# -- Runtime ------------------------------------------------------------------
+runtime:
+  command: ["uv", "run", "uvicorn", "app.gateway.app:app", "--host", "127.0.0.1", "--port", "8001"]
+  working_dir: /opt/deer-flow/backend
+  env:
+    DEER_FLOW_CONFIG_PATH: /opt/deer-flow/config.yaml
+    PYTHONPATH: "."
+    OPENAI_BASE_URL: "http://${TAOS_HOST}:4000/v1"
+    OPENAI_API_KEY: "${AGENT_API_KEY}"
+    TAOS_MODEL: "${TAOS_MODEL}"
+  ports: [8001]
+
+# -- Health check -------------------------------------------------------------
+health:
+  kind: http
+  url: "http://localhost:8001/"
+  initial_delay_seconds: 10
+  interval_seconds: 15
+  failure_threshold: 3
+
+# -- Config reload ------------------------------------------------------------
+reload:
+  kind: restart-only            # DeerFlow requires restart for config changes
+  interval_seconds: null
+  push_supported: false
+  fallback: restart
+
+# -- Tier B escape hatches — none needed, adapter translates the runs API -----
+hooks: {}
+
+# -- Data migration — not applicable (DeerFlow uses its own persistence) ------
+data_migration: {}
+
+# -- Tests --------------------------------------------------------------------
+tests:
+  smoke:
+    - name: "adapter responds to /message with valid DeerFlow response"
+      input: {text: "Hello from TAOS", from_name: "Test User"}
+      expect_status: 200
+    - name: "adapter /health returns ok"
+      input: {}
+      expect_status: 200
+      expect_body: {status: ok, framework: deer-flow}
+  golden: []

--- a/app-catalog/agents/deer-flow/manifest.yaml
+++ b/app-catalog/agents/deer-flow/manifest.yaml
@@ -1,0 +1,51 @@
+id: deer-flow
+name: DeerFlow SuperAgent
+type: agent-framework
+verification_status: alpha
+version: 2.1.0
+description: "ByteDance DeerFlow long-horizon LangGraph SuperAgent harness — multi-step research and tool-use agent runtime served via its native runs API"
+homepage: https://github.com/bytedance/deer-flow
+license: MIT
+
+requires:
+  ram_mb: 2048
+  disk_mb: 4000
+  python: ">=3.12"
+
+install:
+  method: script
+  script: scripts/install.sh
+  note: |
+    Clones bytedance/deer-flow into /opt/deer-flow and provisions the backend
+    with uv (Python 3.12). Writes a config.yaml pointing DeerFlow at the taOS
+    LiteLLM proxy and a systemd unit that serves the backend runs API on 8001.
+    The bridge adapter (deer_flow_adapter.py) lives in the taOS controller.
+
+config_schema:
+  - name: model
+    type: model-select
+    label: LLM Model
+    required: true
+    description: Primary chat model for the DeerFlow agent
+
+compliance:
+  # DeerFlow is NOT OpenAI-compatible on its chat surface — it exposes a custom
+  # LangGraph runs API. The adapter translates taOS /message into a POST to
+  # /api/runs/wait, so this is a plain "verified" entry with no fork_url.
+  tier: verified
+  adapter: deer_flow_adapter.py
+  bridge_protocol: langgraph-runs
+  notes: |
+    DeerFlow speaks a custom LangGraph runs API, not OpenAI chat completions.
+    The adapter translates taOS /message calls into POST /api/runs/wait and
+    extracts the final assistant reply from the serialized channel-values.
+    DeerFlow itself calls the taOS LiteLLM proxy (OpenAI-compatible) for LLM
+    inference via its config.yaml. No fork required — the bridge adapter
+    (deer_flow_adapter.py) lives in the taOS controller, not in a fork.
+
+hardware_tiers:
+  arm-npu-16gb: full
+  arm-npu-32gb: full
+  x86-cuda-12gb: full
+  x86-vulkan-8gb: full
+  cpu-only: full

--- a/app-catalog/agents/deer-flow/scripts/install.sh
+++ b/app-catalog/agents/deer-flow/scripts/install.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# install.sh — DeerFlow SuperAgent runtime installer
+# Runs once inside a fresh Debian bookworm LXC container.
+# Idempotent: safe to re-run on an already-provisioned container.
+set -euo pipefail
+
+echo "[deer-flow] installing DeerFlow SuperAgent"
+
+# ---------------------------------------------------------------------------
+# 1. System dependencies
+# ---------------------------------------------------------------------------
+DEBIAN_FRONTEND=noninteractive apt-get update -qq
+DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends \
+  python3 python3-venv git curl ca-certificates build-essential
+
+# ---------------------------------------------------------------------------
+# 2. Install uv (astral) if absent, and resolve its real path
+# ---------------------------------------------------------------------------
+# uv provisions Python 3.12 and the backend deps from backend/.python-version.
+if ! command -v uv >/dev/null 2>&1; then
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
+
+# The installer drops uv into ~/.local/bin (or /root/.local/bin when run as
+# root); make sure it is on PATH for the rest of this script.
+export PATH="$HOME/.local/bin:/root/.local/bin:$PATH"
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "[deer-flow] FATAL: uv not found after install"
+  exit 1
+fi
+UV_BIN="$(command -v uv)"
+
+UV_VERSION=$(uv --version 2>/dev/null || echo "unknown")
+echo "[deer-flow] installed: $UV_VERSION ($UV_BIN)"
+
+# ---------------------------------------------------------------------------
+# 3. Clone DeerFlow into /opt/deer-flow
+# ---------------------------------------------------------------------------
+if [ -d /opt/deer-flow/.git ]; then
+  echo "[deer-flow] repo already present, pulling latest"
+  git -C /opt/deer-flow pull --ff-only
+else
+  git clone --depth 1 https://github.com/bytedance/deer-flow /opt/deer-flow
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Provision the backend (Python 3.12 + deps) with uv
+# ---------------------------------------------------------------------------
+cd /opt/deer-flow/backend
+"$UV_BIN" sync
+
+# ---------------------------------------------------------------------------
+# 5. Write config.yaml pointing DeerFlow at the taOS LiteLLM proxy
+# ---------------------------------------------------------------------------
+# Literal $ENV_VAR tokens are expanded by DeerFlow at load time from the env
+# the deployer injects (TAOS_MODEL, OPENAI_API_KEY, OPENAI_BASE_URL).
+# token_counting: char avoids DeerFlow's startup tiktoken cache network fetch,
+# which matters in restricted containers.
+cat > /opt/deer-flow/config.yaml <<'CONFIG'
+models:
+  - name: taos-default
+    use: langchain_openai:ChatOpenAI
+    model: $TAOS_MODEL
+    api_key: $OPENAI_API_KEY
+    base_url: $OPENAI_BASE_URL
+    request_timeout: 600.0
+
+memory:
+  token_counting: char
+CONFIG
+
+# ---------------------------------------------------------------------------
+# 6. Systemd unit
+# ---------------------------------------------------------------------------
+# Runs as root: the uv-managed venv lives under /opt and running as root avoids
+# venv-permission complexity. The container itself is the isolation boundary.
+mkdir -p /var/log/deer-flow
+
+cat > /etc/systemd/system/deer-flow.service <<UNIT
+[Unit]
+Description=DeerFlow SuperAgent
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/deer-flow/backend
+Environment=DEER_FLOW_CONFIG_PATH=/opt/deer-flow/config.yaml
+Environment=PYTHONPATH=.
+ExecStart=${UV_BIN} run uvicorn app.gateway.app:app --host 127.0.0.1 --port 8001
+Restart=on-failure
+RestartSec=5
+StandardOutput=append:/var/log/deer-flow/deer-flow.log
+StandardError=append:/var/log/deer-flow/deer-flow.log
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+systemctl daemon-reload
+systemctl enable deer-flow.service
+
+echo "[deer-flow] install complete (service enabled, start deferred to deployer)"
+echo "[deer-flow] backend serves the runs API on 127.0.0.1:8001"
+echo "[deer-flow] deployer injects OPENAI_BASE_URL, OPENAI_API_KEY, TAOS_MODEL"
+echo "             into the container env (inherited by the systemd service)"

--- a/app-catalog/agents/deer-flow/scripts/install.sh
+++ b/app-catalog/agents/deer-flow/scripts/install.sh
@@ -68,6 +68,13 @@ models:
 
 memory:
   token_counting: char
+
+# DeerFlow's AppConfig requires an explicit sandbox section (there is no
+# implicit default). LocalSandboxProvider is the host-filesystem provider that
+# needs no Docker — correct for a single-purpose agent container.
+sandbox:
+  use: deerflow.sandbox.local:LocalSandboxProvider
+  allow_host_bash: false
 CONFIG
 
 # ---------------------------------------------------------------------------
@@ -85,8 +92,15 @@ OPENAI_API_KEY=${OPENAI_API_KEY:-}
 OPENAI_BASE_URL=${OPENAI_BASE_URL:-}
 DEER_FLOW_CONFIG_PATH=/opt/deer-flow/config.yaml
 PYTHONPATH=.
+DEER_FLOW_AUTH_DISABLED=1
 ENVFILE
 chmod 600 /opt/deer-flow/deer-flow.env
+# DEER_FLOW_AUTH_DISABLED=1 turns off the gateway's login auth AND its CSRF
+# double-submit guard (both are designed for browser clients). This is correct
+# and safe here: the gateway binds 127.0.0.1:8001 inside the agent container
+# and is reached only by the taOS adapter on localhost — never exposed. Without
+# it, POST /api/runs/wait returns 403 "CSRF token missing". The flag is ignored
+# if DEER_FLOW_ENV/ENVIRONMENT is prod, so do not set those in the container.
 
 # ---------------------------------------------------------------------------
 # 7. Systemd unit
@@ -117,8 +131,13 @@ UNIT
 
 systemctl daemon-reload
 systemctl enable deer-flow.service
+# Start now: the EnvironmentFile + config.yaml are already written, so the
+# service is fully provisioned at this point. Type=simple returns immediately
+# (the LangGraph import takes ~30-60s on ARM before the API answers); the taOS
+# adapter retries on connection errors while it warms up.
+systemctl start deer-flow.service
 
-echo "[deer-flow] install complete (service enabled, start deferred to deployer)"
-echo "[deer-flow] backend serves the runs API on 127.0.0.1:8001"
-echo "[deer-flow] deployer injects OPENAI_BASE_URL, OPENAI_API_KEY, TAOS_MODEL"
-echo "             into the container env (inherited by the systemd service)"
+echo "[deer-flow] install complete — service enabled and started"
+echo "[deer-flow] backend serves the runs API on 127.0.0.1:8001 (auth disabled,"
+echo "            localhost-only); the taOS adapter bridges POST /api/runs/wait"
+echo "[deer-flow] model routes through OPENAI_BASE_URL (the taOS LiteLLM proxy)"

--- a/app-catalog/agents/deer-flow/scripts/install.sh
+++ b/app-catalog/agents/deer-flow/scripts/install.sh
@@ -71,7 +71,25 @@ memory:
 CONFIG
 
 # ---------------------------------------------------------------------------
-# 6. Systemd unit
+# 6. Capture the deployer-injected env into an EnvironmentFile
+# ---------------------------------------------------------------------------
+# install.sh runs via `incus exec`, which DOES inherit the container's
+# environment.* config, so OPENAI_BASE_URL / OPENAI_API_KEY / TAOS_MODEL are
+# visible here. A systemd service does NOT inherit those automatically (it
+# starts from a clean environment), so DeerFlow's config.yaml $VAR expansion
+# would otherwise see empty values. Snapshot them into an EnvironmentFile the
+# unit reads (the same pattern the Hermes framework uses).
+cat > /opt/deer-flow/deer-flow.env <<ENVFILE
+TAOS_MODEL=${TAOS_MODEL:-}
+OPENAI_API_KEY=${OPENAI_API_KEY:-}
+OPENAI_BASE_URL=${OPENAI_BASE_URL:-}
+DEER_FLOW_CONFIG_PATH=/opt/deer-flow/config.yaml
+PYTHONPATH=.
+ENVFILE
+chmod 600 /opt/deer-flow/deer-flow.env
+
+# ---------------------------------------------------------------------------
+# 7. Systemd unit
 # ---------------------------------------------------------------------------
 # Runs as root: the uv-managed venv lives under /opt and running as root avoids
 # venv-permission complexity. The container itself is the isolation boundary.
@@ -86,8 +104,7 @@ Wants=network-online.target
 [Service]
 Type=simple
 WorkingDirectory=/opt/deer-flow/backend
-Environment=DEER_FLOW_CONFIG_PATH=/opt/deer-flow/config.yaml
-Environment=PYTHONPATH=.
+EnvironmentFile=/opt/deer-flow/deer-flow.env
 ExecStart=${UV_BIN} run uvicorn app.gateway.app:app --host 127.0.0.1 --port 8001
 Restart=on-failure
 RestartSec=5

--- a/tests/test_deer_flow_adapter.py
+++ b/tests/test_deer_flow_adapter.py
@@ -1,0 +1,71 @@
+"""Tests for the DeerFlow adapter.
+
+The /health endpoint always returns ok. The /message endpoint surfaces a
+non-empty error string when the DeerFlow backend is not running (expected in
+unit tests). _extract_text pulls the assistant reply out of the serialized
+LangGraph channel-values regardless of message content shape.
+"""
+from unittest.mock import patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from tinyagentos.adapters import deer_flow_adapter
+from tinyagentos.adapters.deer_flow_adapter import _extract_text
+
+
+def test_extract_text_string_content():
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello there"},
+    ]
+    assert _extract_text(messages) == "hello there"
+
+
+def test_extract_text_list_of_text_blocks():
+    messages = [
+        {"type": "ai", "content": [
+            {"type": "text", "text": "part one "},
+            {"type": "tool_use", "name": "search"},
+            {"type": "text", "text": "part two"},
+        ]},
+    ]
+    assert _extract_text(messages) == "part one part two"
+
+
+def test_extract_text_empty_or_missing():
+    assert _extract_text([]) == ""
+    assert _extract_text(None) == ""
+
+
+@pytest.mark.asyncio
+async def test_health():
+    transport = ASGITransport(app=deer_flow_adapter.app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "ok"
+        assert data["framework"] == "deer-flow"
+
+
+@pytest.mark.asyncio
+async def test_message_without_backend():
+    """The adapter returns an error string when the DeerFlow backend is down.
+
+    with_retry would otherwise back off for ~31 s over 7 attempts when nothing
+    is listening, so patch it to a single no-delay attempt. The retry policy is
+    covered by test_adapter_retry.py; this only checks the adapter never raises.
+    """
+    async def _single_attempt(factory, **_kwargs):
+        return await factory()
+
+    transport = ASGITransport(app=deer_flow_adapter.app)
+    with patch.object(deer_flow_adapter, "with_retry", side_effect=_single_attempt):
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post("/message", json={"text": "hello"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "content" in data
+    assert isinstance(data["content"], str)
+    assert len(data["content"]) > 0

--- a/tests/test_deer_flow_adapter.py
+++ b/tests/test_deer_flow_adapter.py
@@ -38,6 +38,22 @@ def test_extract_text_empty_or_missing():
     assert _extract_text(None) == ""
 
 
+def test_extract_text_skips_trailing_non_assistant_message():
+    """The final channel-values message may be a tool/human turn; the adapter
+    must return the last ASSISTANT message, not blindly messages[-1]."""
+    messages = [
+        {"role": "user", "content": "search the web"},
+        {"role": "assistant", "content": "here is what I found"},
+        {"role": "tool", "content": "raw tool output blob"},
+    ]
+    assert _extract_text(messages) == "here is what I found"
+
+
+def test_extract_text_fallback_when_no_assistant_role():
+    """With no role/type markers, fall back to the last message's text."""
+    assert _extract_text([{"content": "only message"}]) == "only message"
+
+
 @pytest.mark.asyncio
 async def test_health():
     transport = ASGITransport(app=deer_flow_adapter.app)

--- a/tinyagentos/adapters/__init__.py
+++ b/tinyagentos/adapters/__init__.py
@@ -56,6 +56,12 @@ _REGISTRY: list[dict] = [
         "verification_status": "alpha",
     },
     {
+        "id": "deer-flow",
+        "name": "DeerFlow",
+        "description": "DeerFlow LangGraph SuperAgent harness (runs API bridge)",
+        "verification_status": "alpha",
+    },
+    {
         "id": "ironclaw",
         "name": "IronClaw",
         "description": "IronClaw gateway proxy",

--- a/tinyagentos/adapters/deer_flow_adapter.py
+++ b/tinyagentos/adapters/deer_flow_adapter.py
@@ -7,7 +7,15 @@ from tinyagentos.clients.retry import with_retry
 
 app = FastAPI()
 
-_RETRY_KWARGS = dict(max_attempts=7, base_delay=0.5, multiplier=2.0, max_delay=60.0)
+# Retry ONLY on connection-level failures (the service is still starting, or a
+# transient transport blip) — NOT on ReadTimeout. /api/runs/wait drives a
+# long-horizon agent that legitimately takes minutes; a read timeout means the
+# run is in progress, so re-firing it would re-execute the whole job (and any
+# side effects). Keep the attempt count low for the same reason.
+_RETRY_ON = (httpx.ConnectError, httpx.RemoteProtocolError)
+_RETRY_KWARGS = dict(
+    max_attempts=3, base_delay=0.5, multiplier=2.0, max_delay=10.0, retry_on=_RETRY_ON
+)
 
 
 async def _controller_post(url: str, json: dict):
@@ -16,28 +24,45 @@ async def _controller_post(url: str, json: dict):
         return await client.post(url, json=json)
 
 
-def _extract_text(messages) -> str:
-    """Pull the assistant reply text from a list of LangGraph/LangChain messages.
+def _msg_content_text(msg) -> str:
+    """Render one message's content as plain text.
 
-    Handles both plain {"role": ..., "content": str} messages and LangChain
-    {"type": "ai", "content": [...]} messages where content is a string or a
-    list of {"type": "text", "text": "..."} blocks. Falls back to str() of the
-    last message.
+    Handles {"content": str} and LangChain {"content": [{"type":"text",...}]}.
     """
-    if not messages:
-        return ""
-    last = messages[-1]
-    content = last.get("content") if isinstance(last, dict) else None
+    content = msg.get("content") if isinstance(msg, dict) else None
     if isinstance(content, str):
         return content
     if isinstance(content, list):
-        parts = [
+        return "".join(
             block.get("text", "")
             for block in content
             if isinstance(block, dict) and block.get("type") == "text"
-        ]
-        return "".join(parts)
-    return str(last)
+        )
+    return ""
+
+
+def _extract_text(messages) -> str:
+    """Pull the assistant reply from a list of LangGraph/LangChain messages.
+
+    The final channel-values message is not necessarily the assistant turn —
+    after a tool call it can be a tool/human message — so scan from the end for
+    the last assistant/AI message rather than blindly taking ``messages[-1]``.
+    Handles plain {"role": "assistant", "content": str} and LangChain
+    {"type": "ai", "content": [...]} shapes. Falls back to the last message's
+    text, then str() of it.
+    """
+    if not messages:
+        return ""
+    for msg in reversed(messages):
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role") or msg.get("type")
+        if role in ("assistant", "ai", "AIMessage"):
+            text = _msg_content_text(msg)
+            if text:
+                return text
+    # No assistant message found — fall back to the last message's text.
+    return _msg_content_text(messages[-1]) or str(messages[-1])
 
 
 @app.post("/message")

--- a/tinyagentos/adapters/deer_flow_adapter.py
+++ b/tinyagentos/adapters/deer_flow_adapter.py
@@ -1,0 +1,81 @@
+"""DeerFlow adapter — proxies messages to the DeerFlow LangGraph runs API."""
+import os
+import httpx
+from fastapi import FastAPI
+
+from tinyagentos.clients.retry import with_retry
+
+app = FastAPI()
+
+_RETRY_KWARGS = dict(max_attempts=7, base_delay=0.5, multiplier=2.0, max_delay=60.0)
+
+
+async def _controller_post(url: str, json: dict):
+    # 600s timeout — DeerFlow is a long-horizon multi-step agent.
+    async with httpx.AsyncClient(timeout=600) as client:
+        return await client.post(url, json=json)
+
+
+def _extract_text(messages) -> str:
+    """Pull the assistant reply text from a list of LangGraph/LangChain messages.
+
+    Handles both plain {"role": ..., "content": str} messages and LangChain
+    {"type": "ai", "content": [...]} messages where content is a string or a
+    list of {"type": "text", "text": "..."} blocks. Falls back to str() of the
+    last message.
+    """
+    if not messages:
+        return ""
+    last = messages[-1]
+    content = last.get("content") if isinstance(last, dict) else None
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = [
+            block.get("text", "")
+            for block in content
+            if isinstance(block, dict) and block.get("type") == "text"
+        ]
+        return "".join(parts)
+    return str(last)
+
+
+@app.post("/message")
+async def handle_message(msg: dict):
+    agent_name = os.environ.get("TAOS_AGENT_NAME", "agent")
+    try:
+        deer_flow_url = os.environ.get("DEER_FLOW_URL", "http://localhost:8001")
+        resp = await with_retry(
+            lambda: _controller_post(
+                f"{deer_flow_url}/api/runs/wait",
+                {
+                    "input": {"messages": [{"role": "user", "content": msg.get("text", "")}]},
+                    "context": {"model_name": "taos-default"},
+                },
+            ),
+            **_RETRY_KWARGS,
+        )
+        if resp.status_code == 200:
+            data = resp.json()
+            # The body is the final serialized channel-values. The messages list
+            # may sit at the top level or under output/values — try each.
+            messages = (
+                data.get("messages")
+                or (data.get("output") or {}).get("messages")
+                or (data.get("values") or {}).get("messages")
+                or []
+            )
+            return {"content": _extract_text(messages)}
+        return {"content": f"[{agent_name}] DeerFlow returned {resp.status_code}"}
+    except Exception as e:
+        return {"content": f"[{agent_name}] DeerFlow unavailable: {e}"}
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok", "framework": "deer-flow"}
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="127.0.0.1", port=int(os.environ.get("TAOS_ADAPTER_PORT", "9001")), log_level="warning")


### PR DESCRIPTION
## What this adds

Support for the **deer-flow** agent framework (github.com/bytedance/deer-flow, MIT) to taOS, following the exact pattern of the existing `hermes` framework. Mechanical mirror, no redesign.

Files added:
- `app-catalog/agents/deer-flow/manifest.yaml` (agent-framework, alpha, v2.1.0, MIT, full hardware-tier matrix)
- `app-catalog/agents/deer-flow/scripts/install.sh` (idempotent Debian bookworm LXC installer)
- `app-catalog/agents/deer-flow/framework-integration.yaml` (bridge design spec, `langgraph-runs`)
- `tinyagentos/adapters/deer_flow_adapter.py` (FastAPI bridge adapter)
- registered `deer-flow` in `tinyagentos/adapters/__init__.py`
- `tests/test_deer_flow_adapter.py`

## Runtime facts (verified against deer-flow)

- Python 3.12 backend under `backend/`, provisioned with `uv` (`uv sync`).
- Backend runs API served via `uvicorn app.gateway.app:app` on **127.0.0.1:8001**.
- Chat surface is NOT OpenAI-compatible. The adapter POSTs to `http://localhost:8001/api/runs/wait` with `{"input": {"messages": [...]}, "context": {"model_name": "taos-default"}}` (600s timeout for long-horizon runs) and extracts the final assistant reply from the serialized LangGraph channel-values.
- `config.yaml` at the repo root points deer-flow's `taos-default` model at the taOS LiteLLM proxy via `$TAOS_MODEL` / `$OPENAI_API_KEY` / `$OPENAI_BASE_URL`. Sets `memory.token_counting: char` to skip the startup tiktoken cache network fetch in restricted containers. Default `LocalSandboxProvider` (no Docker) left as-is.
- systemd unit runs as root (the uv-managed venv under `/opt` keeps permissions simple; the container is the isolation boundary). Service is enabled but not started, matching hermes (deployer starts it).

## Status

This is **alpha**: happy path implemented, adapter response parsing is defensive across the plausible channel-values shapes. Needs a **live Pi deploy-test** to confirm the real `/api/runs/wait` response shape, the `uv sync` build on aarch64, and end-to-end chat through the proxy.

## Tests

Adapter and registry tests pass locally (`_extract_text` covering string content, list-of-text-blocks content, and empty/missing messages; plus health and no-backend message tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DeerFlow SuperAgent integration to the app catalog (alpha, v2.1.0) with model selection and capability metadata.
  * Introduced a DeerFlow adapter service with `POST /message` (bridges requests, extracts structured assistant text) and `GET /health` (framework status).
  * Added Debian-based installation and automated deployment using a systemd service with generated config and environment setup.
* **Tests**
  * Added unit and API tests validating text extraction behavior and `/health`/`/message` responses, including graceful handling when the backend is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->