### PR TITLE
fix(containers): undeploy never orphans containers in restricted projects

### DIFF
--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, patch, call
 from tinyagentos.containers import (
     list_containers, create_container, set_root_quota, set_env,
     start_container, stop_container, destroy_container,
+    container_exists,
     _parse_memory, ContainerInfo,
 )
 
@@ -221,11 +222,41 @@ class TestContainerLifecycle:
     @pytest.mark.asyncio
     async def test_destroy(self):
         with patch("tinyagentos.containers._run", new_callable=AsyncMock) as mock_run:
-            mock_run.return_value = (0, "")
+            # 1st call resolves the project (empty list -> ambient fallback),
+            # then stop --force, then delete --force.
+            mock_run.side_effect = [(0, "[]"), (0, ""), (0, "")]
             result = await destroy_container("taos-agent-test")
             assert result["success"] is True
-            # Should have called stop --force then delete --force
-            assert mock_run.call_count == 2
+            assert mock_run.call_count == 3
+            # No --project flag when the container is not found in any project.
+            stop_cmd = mock_run.call_args_list[1].args[0]
+            assert "--project" not in stop_cmd
+
+    @pytest.mark.asyncio
+    async def test_destroy_targets_restricted_project(self):
+        """A container living in a restricted project (user-999) must be
+        destroyed there, not left orphaned because the ambient project is
+        'default'."""
+        listing = json.dumps([{"name": "taos-agent-x", "project": "user-999"}])
+        with patch("tinyagentos.containers._run", new_callable=AsyncMock) as mock_run:
+            mock_run.side_effect = [(0, listing), (0, ""), (0, "")]
+            result = await destroy_container("taos-agent-x")
+            assert result["success"] is True
+            stop_cmd = mock_run.call_args_list[1].args[0]
+            del_cmd = mock_run.call_args_list[2].args[0]
+            assert stop_cmd[:4] == ["incus", "stop", "--project", "user-999"]
+            assert del_cmd[:4] == ["incus", "delete", "--project", "user-999"]
+
+    @pytest.mark.asyncio
+    async def test_container_exists_finds_in_any_project(self):
+        listing = json.dumps([
+            {"name": "taos-agent-a", "project": "default"},
+            {"name": "taos-agent-b", "project": "user-999"},
+        ])
+        with patch("tinyagentos.containers._run", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = (0, listing)
+            assert await container_exists("taos-agent-b") is True
+            assert await container_exists("taos-agent-missing") is False
 
 
 class TestAddProxyDeviceSelfHeal:

--- a/tinyagentos/containers/__init__.py
+++ b/tinyagentos/containers/__init__.py
@@ -40,24 +40,38 @@ async def _run(cmd: list[str], timeout: int = 120) -> tuple[int, str]:
 # ``patch("tinyagentos.containers._run")`` correctly intercepts them.
 # ---------------------------------------------------------------------------
 
+async def _resolve_container_project(name: str) -> str | None:
+    """Return the incus project a container lives in, or None if not found.
+
+    Searches ALL projects the client can see (``--all-projects``), not just the
+    ambient default. Multi-user installs place agent containers in a restricted
+    project (e.g. ``user-999``) while other agents sit in ``default``; a lookup
+    scoped to the ambient project alone misses the others, which is how undeploy
+    left orphaned containers behind. Errors return None (treated as "unknown").
+    """
+    code, output = await _run(["incus", "list", "--all-projects", "-f", "json"])
+    if code != 0:
+        return None
+    try:
+        instances = json.loads(output)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    for inst in instances:
+        if isinstance(inst, dict) and inst.get("name") == name:
+            return inst.get("project") or "default"
+    return None
+
+
 async def container_exists(name: str) -> bool:
     """Return True iff a container with the given name is known to the runtime.
 
-    Uses ``incus list --format=csv -c n --filter=name=<name>`` and checks
-    the output for an exact name match. Errors (incus not installed, daemon
-    down, malformed output) are treated as "unknown" and return False so
-    callers can take the safer no-container path rather than blocking on
-    cleanup of an orphan config row.
+    Searches across ALL projects (see ``_resolve_container_project``) so a
+    container in a restricted project (e.g. ``user-999``) is not mistaken for an
+    absent one. Errors (incus not installed, daemon down, malformed output) are
+    treated as "unknown" and return False so callers can take the safer
+    no-container path rather than blocking on cleanup of an orphan config row.
     """
-    code, output = await _run(
-        ["incus", "list", "--format=csv", "-c", "n", f"--filter=name={name}"]
-    )
-    if code != 0:
-        return False
-    for line in output.splitlines():
-        if line.strip() == name:
-            return True
-    return False
+    return (await _resolve_container_project(name)) is not None
 
 
 async def list_containers(prefix: str = "taos-agent-") -> list[ContainerInfo]:
@@ -224,9 +238,17 @@ async def restart_container(name: str) -> dict:
 
 
 async def destroy_container(name: str) -> dict:
-    """Stop and delete a container."""
-    await _run(["incus", "stop", name, "--force"])
-    code, output = await _run(["incus", "delete", name, "--force"])
+    """Stop and delete a container, in whatever project it lives in.
+
+    Resolves the container's actual project first so an agent in a restricted
+    project (e.g. ``user-999``) is destroyed rather than left orphaned when the
+    ambient project is ``default``. Falls back to the ambient project when the
+    lookup finds nothing (preserves the original behavior for fresh installs).
+    """
+    proj = await _resolve_container_project(name)
+    proj_args = ["--project", proj] if proj else []
+    await _run(["incus", "stop", *proj_args, name, "--force"])
+    code, output = await _run(["incus", "delete", *proj_args, name, "--force"])
     return {"success": code == 0, "output": output}
 
 


### PR DESCRIPTION
## Problem

Found during the DeerFlow Pi deploy-test: undeploying an agent whose container lives in a restricted incus project (e.g. `user-999`, used for multi-user isolation) only deleted the agent's config row and left the LXC container **running and orphaned**.

Root cause: `container_exists` and `destroy_container` ran `incus` against the ambient default project only. On the Pi, agent containers are split across projects (`default` for most, `user-999` for the restricted multi-user ones). A lookup scoped to the ambient project reported the `user-999` container as absent, so `archive_agent_fully` took the "orphan config row (no container)" path and hard-deleted just the row.

Confirmed on the Pi: `taos-agent-hermes-confirm` and a leftover `taos-agent-kvtest-agent` were both orphaned in `user-999` this way (the latter cleaned up).

## Fix

Add `_resolve_container_project()` which finds a container across **all** visible projects via `incus list --all-projects` and returns its project. Then:
- `container_exists` checks across all projects (no longer misses `user-999`).
- `destroy_container` resolves the container's actual project and passes `--project <proj>` to `stop` + `delete`, falling back to the ambient project when not found (preserves fresh-install behavior).

Project-agnostic by design, so it does not depend on the host's manually-provisioned incus default project.

## Tests

- `destroy_container` threads `--project user-999` for a container found there.
- ambient fallback (no `--project`) when the container is not found in any project.
- `container_exists` finds a container in a non-default project and returns False for a missing one.

125 targeted tests green (containers + deployer + agent routes + archive routes).

## Follow-up (not in this PR)

`stop_container` / `start_container` / `restart_container` / `exec_in_container` are still ambient-project only, so managing a running `user-999` agent from the UI (stop/restart) would have the same blind spot. Worth a follow-up to thread the resolved project through those too. The existing `taos-agent-hermes-confirm` in `user-999` should be reconciled or cleaned once this lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Container detection and management operations now work reliably across all projects, including restricted (non-ambient) ones.
  * Improved container existence checking to accurately detect containers regardless of their project location.

* **Tests**
  * Expanded test coverage for container lifecycle operations, including verification of correct project targeting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->