### PR TITLE
litellm: default to the in-house per-agent key store

### DIFF
--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -311,11 +311,20 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     # Authorize per-agent virtual keys against taOS's own SQLite key store via
     # LiteLLM's custom_auth hook, instead of its Postgres/prisma virtual-key
     # table. Lets per-agent keys work with NO DATABASE_URL and no prisma (the
-    # ARM / no-Postgres fix) and gives every install real per-agent isolation
-    # uniformly. ON by default now; create a ``.litellm_disable_inhouse_keys``
-    # marker to fall back to the Postgres path + shared master key (e.g. to keep
-    # using LiteLLM's native virtual-key table on a Postgres-backed install).
-    inhouse_keys = not (data_dir / ".litellm_disable_inhouse_keys").exists()
+    # ARM / no-Postgres fix) and gives every install real per-agent isolation.
+    # Default ON whenever there is NO Postgres configured (the common case,
+    # incl. every ARM install). A Postgres-backed install already has per-agent
+    # keys via LiteLLM's native table, so defer to it rather than silently
+    # switching on upgrade (which would orphan its already-minted keys and 401
+    # running agents). Force in-house even with Postgres via a
+    # ``.litellm_force_inhouse_keys`` marker; disable entirely via
+    # ``.litellm_disable_inhouse_keys``.
+    if (data_dir / ".litellm_disable_inhouse_keys").exists():
+        inhouse_keys = False
+    elif (data_dir / ".litellm_force_inhouse_keys").exists():
+        inhouse_keys = True
+    else:
+        inhouse_keys = db_url is None
     # Read the local auth token so LLMProxy can forward it to LiteLLM's
     # subprocess — otherwise the taOS callback can't POST llm_call events
     # back to /api/trace and the 401s fill the log instead of trace rows.

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -308,12 +308,14 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     # docs/design/framework-agnostic-runtime.md.
     db_url_path = data_dir / ".litellm_db_url"
     db_url = db_url_path.read_text().strip() if db_url_path.exists() else None
-    # Opt-in: authorize per-agent virtual keys against taOS's own SQLite key
-    # store via LiteLLM's custom_auth hook, instead of its Postgres/prisma
-    # virtual-key table. Lets per-agent keys work with NO DATABASE_URL and no
-    # prisma (the ARM / no-Postgres fix). Off by default; the released
-    # master-key fallback covers routing-only installs until this is enabled.
-    inhouse_keys = (data_dir / ".litellm_inhouse_keys").exists()
+    # Authorize per-agent virtual keys against taOS's own SQLite key store via
+    # LiteLLM's custom_auth hook, instead of its Postgres/prisma virtual-key
+    # table. Lets per-agent keys work with NO DATABASE_URL and no prisma (the
+    # ARM / no-Postgres fix) and gives every install real per-agent isolation
+    # uniformly. ON by default now; create a ``.litellm_disable_inhouse_keys``
+    # marker to fall back to the Postgres path + shared master key (e.g. to keep
+    # using LiteLLM's native virtual-key table on a Postgres-backed install).
+    inhouse_keys = not (data_dir / ".litellm_disable_inhouse_keys").exists()
     # Read the local auth token so LLMProxy can forward it to LiteLLM's
     # subprocess — otherwise the taOS callback can't POST llm_call events
     # back to /api/trace and the 401s fill the log instead of trace rows.


### PR DESCRIPTION
Per Jay: make the in-house LiteLLM key store the default for all installs (was opt-in behind a marker).

The controller now mints per-agent virtual keys in the in-house SQLite store and authorizes them via the custom_auth hook by default, so every install gets uniform per-agent isolation that works with no DATABASE_URL and no prisma (the ARM fix proven on the Pi). Opt out with a `.litellm_disable_inhouse_keys` marker to keep LiteLLM's Postgres virtual-key table on a Postgres-backed install. The deployer master-key fallback stays as a last-resort safety net.

One-line gate flip in app.py. 100 keystore/proxy/deployer tests green. Already validated end-to-end on the Pi (aarch64) earlier this session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified default configuration for per-agent virtual key authorization. Users requiring the previous behavior can disable this feature via a configuration marker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->