### PR TITLE
feat(broker): secrets-broker P0 - grant ledger + lifecycle

### DIFF
--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -1,0 +1,150 @@
+"""Tests for the Secrets Broker grant ledger + lifecycle service (P0)."""
+import pytest
+
+from tinyagentos.broker.providers import PROVIDERS, get_provider
+from tinyagentos.broker.service import MAX_WINDOW_SECONDS, BrokerService
+from tinyagentos.broker.store import BrokerStore
+
+# A fixed injectable "now" so expiry tests are deterministic.
+NOW = 1_000_000.0
+
+
+async def _service(tmp_path):
+    store = BrokerStore(tmp_path / "broker.db")
+    await store.init()
+    return BrokerService(store), store
+
+
+@pytest.mark.asyncio
+async def test_request_approve_authorizes_until_expiry(tmp_path):
+    svc, _ = await _service(tmp_path)
+    gid = await svc.request_access("agent-a", "exa")
+    await svc.approve(gid, 3600, now=NOW)
+
+    assert await svc.is_authorized("agent-a", "exa", now=NOW) is True
+    assert await svc.is_authorized("agent-a", "exa", now=NOW + 1800) is True
+    # After expiry the grant is no longer authorized (check-time enforcement).
+    assert await svc.is_authorized("agent-a", "exa", now=NOW + 3601) is False
+
+
+@pytest.mark.asyncio
+async def test_deny_blocks_authorization(tmp_path):
+    svc, _ = await _service(tmp_path)
+    gid = await svc.request_access("agent-a", "exa")
+    assert await svc.deny(gid) is True
+    assert await svc.is_authorized("agent-a", "exa", now=NOW) is False
+
+
+@pytest.mark.asyncio
+async def test_revoke_blocks_and_deletes_virtual_creds(tmp_path):
+    svc, store = await _service(tmp_path)
+    gid = await svc.request_access("agent-a", "openai")
+    result = await svc.approve(gid, 3600, now=NOW)
+    token = result["token"]
+    assert await store.lookup_virtual_cred(token) is not None
+
+    assert await svc.revoke(gid) is True
+    assert await svc.is_authorized("agent-a", "openai", now=NOW) is False
+    assert await store.lookup_virtual_cred(token) is None
+
+
+@pytest.mark.asyncio
+async def test_deny_by_default_no_grant(tmp_path):
+    svc, _ = await _service(tmp_path)
+    assert await svc.is_authorized("agent-a", "exa", now=NOW) is False
+
+
+@pytest.mark.asyncio
+async def test_approve_caps_window_at_seven_days(tmp_path):
+    svc, _ = await _service(tmp_path)
+    gid = await svc.request_access("agent-a", "exa")
+    result = await svc.approve(gid, MAX_WINDOW_SECONDS + 100_000, now=NOW)
+    assert result["expires_at"] == NOW + MAX_WINDOW_SECONDS
+    # Authorized at the cap boundary minus a tick, not beyond.
+    assert await svc.is_authorized("agent-a", "exa", now=NOW + MAX_WINDOW_SECONDS - 1) is True
+    assert await svc.is_authorized("agent-a", "exa", now=NOW + MAX_WINDOW_SECONDS + 1) is False
+
+
+@pytest.mark.asyncio
+async def test_approve_rejects_non_positive_window(tmp_path):
+    svc, _ = await _service(tmp_path)
+    gid = await svc.request_access("agent-a", "exa")
+    with pytest.raises(ValueError):
+        await svc.approve(gid, 0, now=NOW)
+    with pytest.raises(ValueError):
+        await svc.approve(gid, -5, now=NOW)
+
+
+@pytest.mark.asyncio
+async def test_request_access_unknown_provider_raises(tmp_path):
+    svc, _ = await _service(tmp_path)
+    with pytest.raises(ValueError):
+        await svc.request_access("agent-a", "not-a-provider")
+
+
+@pytest.mark.asyncio
+async def test_http_proxy_mints_and_authorizes_token(tmp_path):
+    svc, _ = await _service(tmp_path)
+    gid = await svc.request_access("agent-a", "openai")
+    result = await svc.approve(gid, 3600, now=NOW)
+    token = result["token"]
+    assert token.startswith("sk-taos-secret-")
+
+    ctx = await svc.authorize_token(token, now=NOW)
+    assert ctx == {
+        "agent_identity": "agent-a",
+        "provider_id": "openai",
+        "scopes": get_provider("openai").default_scopes,
+    }
+
+    # After revoke the token resolves to nothing.
+    await svc.revoke(gid)
+    assert await svc.authorize_token(token, now=NOW) is None
+
+
+@pytest.mark.asyncio
+async def test_authorize_token_none_after_expiry(tmp_path):
+    svc, _ = await _service(tmp_path)
+    gid = await svc.request_access("agent-a", "openai")
+    token = (await svc.approve(gid, 3600, now=NOW))["token"]
+    assert await svc.authorize_token(token, now=NOW) is not None
+    assert await svc.authorize_token(token, now=NOW + 3601) is None
+
+
+@pytest.mark.asyncio
+async def test_authorize_token_unknown_returns_none(tmp_path):
+    svc, _ = await _service(tmp_path)
+    assert await svc.authorize_token("sk-taos-secret-nope", now=NOW) is None
+
+
+@pytest.mark.asyncio
+async def test_sweep_expired_flips_active_grants(tmp_path):
+    svc, store = await _service(tmp_path)
+    gid = await svc.request_access("agent-a", "exa")
+    await svc.approve(gid, 3600, now=NOW)
+
+    # Nothing to sweep before expiry.
+    assert await svc.sweep_expired(now=NOW) == 0
+    # After expiry the active grant flips to expired and is counted once.
+    assert await svc.sweep_expired(now=NOW + 3601) == 1
+    grant = await store.get_grant(gid)
+    assert grant["status"] == "expired"
+    # Idempotent: a second sweep finds nothing.
+    assert await svc.sweep_expired(now=NOW + 3601) == 0
+
+
+@pytest.mark.asyncio
+async def test_mcp_provider_approve_mints_no_token(tmp_path):
+    svc, _ = await _service(tmp_path)
+    assert PROVIDERS["exa"].kind == "mcp"
+    gid = await svc.request_access("agent-a", "exa")
+    result = await svc.approve(gid, 3600, now=NOW)
+    assert "token" not in result
+
+
+@pytest.mark.asyncio
+async def test_empty_scope_grant_still_authorizes(tmp_path):
+    svc, _ = await _service(tmp_path)
+    gid = await svc.request_access("agent-a", "exa", scopes=[])
+    await svc.approve(gid, 3600, now=NOW)
+    assert await svc.is_authorized("agent-a", "exa", now=NOW) is True

--- a/tinyagentos/broker/__init__.py
+++ b/tinyagentos/broker/__init__.py
@@ -1,0 +1,21 @@
+"""taOS Secrets Broker (P0): grant ledger + lifecycle service.
+
+Backend-only. No MCP server, HTTP proxy, or routes yet. The broker hands
+external agents time-boxed, revocable, per-(agent, provider) access to
+third-party secrets, routed and audited through taOS. It never stores
+plaintext provider keys; those live in ``tinyagentos.secrets.SecretsStore``
+under each provider's ``secret_ref``.
+"""
+from __future__ import annotations
+
+from tinyagentos.broker.providers import PROVIDERS, Provider, get_provider
+from tinyagentos.broker.service import BrokerService
+from tinyagentos.broker.store import BrokerStore
+
+__all__ = [
+    "PROVIDERS",
+    "Provider",
+    "get_provider",
+    "BrokerService",
+    "BrokerStore",
+]

--- a/tinyagentos/broker/providers.py
+++ b/tinyagentos/broker/providers.py
@@ -1,0 +1,112 @@
+"""Curated provider registry for the Secrets Broker.
+
+Code-seeded plain data (no DB table in P0). Each provider declares how
+taOS reaches it (base_url, auth_style), which SecretsStore secret holds the
+real key (secret_ref), and the default scopes a grant gets when the caller
+does not name any. ``kind`` drives the lifecycle:
+
+  - "mcp"        : reached as an MCP server; the broker authorizes the call
+                   and injects the real key from SecretsStore at proxy time.
+  - "http-proxy" : reached over plain HTTP; approval mints a virtual token
+                   (sk-taos-secret-...) the agent presents instead of the
+                   real key, so the real key never leaves taOS.
+
+auth_style is one of {"bearer", "header:X-Api-Key", "query:api_key"} and is
+editable data, not behaviour. None of the fields are secrets.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class Provider:
+    id: str
+    display_name: str
+    kind: str  # "mcp" or "http-proxy"
+    base_url: str
+    auth_style: str  # "bearer" | "header:X-Api-Key" | "query:api_key"
+    secret_ref: str  # SecretsStore secret name holding the real key
+    default_scopes: list[str] = field(default_factory=list)
+    notes: str = ""
+
+
+_PROVIDER_LIST: list[Provider] = [
+    Provider(
+        id="exa",
+        display_name="Exa",
+        kind="mcp",
+        base_url="https://api.exa.ai",
+        auth_style="bearer",
+        secret_ref="EXA_API_KEY",
+        default_scopes=["search"],
+        notes="Neural search API.",
+    ),
+    Provider(
+        id="tavily",
+        display_name="Tavily",
+        kind="mcp",
+        base_url="https://api.tavily.com",
+        auth_style="bearer",
+        secret_ref="TAVILY_API_KEY",
+        default_scopes=["search"],
+        notes="Search API for agents.",
+    ),
+    Provider(
+        id="github",
+        display_name="GitHub",
+        kind="mcp",
+        base_url="https://api.github.com",
+        auth_style="bearer",
+        secret_ref="GITHUB_TOKEN",
+        default_scopes=["repos:read", "prs:read", "issues:read"],
+        notes="Repos, PRs, issues. Write scopes (repos:write, ...) opt-in.",
+    ),
+    Provider(
+        id="firecrawl",
+        display_name="Firecrawl",
+        kind="mcp",
+        base_url="https://api.firecrawl.dev",
+        auth_style="bearer",
+        secret_ref="FIRECRAWL_API_KEY",
+        default_scopes=["scrape", "crawl"],
+        notes="Web scrape and crawl.",
+    ),
+    Provider(
+        id="brave",
+        display_name="Brave Search",
+        kind="mcp",
+        base_url="https://api.search.brave.com",
+        auth_style="header:X-Api-Key",
+        secret_ref="BRAVE_API_KEY",
+        default_scopes=["search"],
+        notes="Brave web search API.",
+    ),
+    Provider(
+        id="jina",
+        display_name="Jina",
+        kind="mcp",
+        base_url="https://r.jina.ai",
+        auth_style="bearer",
+        secret_ref="JINA_API_KEY",
+        default_scopes=["reader", "embeddings"],
+        notes="Reader and embeddings.",
+    ),
+    Provider(
+        id="openai",
+        display_name="OpenAI",
+        kind="http-proxy",
+        base_url="https://api.openai.com/v1",
+        auth_style="bearer",
+        secret_ref="OPENAI_API_KEY",
+        default_scopes=["chat", "embeddings"],
+        notes="HTTP proxy over /v1/*; exercises the virtual-key fallback.",
+    ),
+]
+
+PROVIDERS: dict[str, Provider] = {p.id: p for p in _PROVIDER_LIST}
+
+
+def get_provider(provider_id: str) -> Provider | None:
+    """Return the :class:`Provider` for *provider_id*, or None if unknown."""
+    return PROVIDERS.get(provider_id)

--- a/tinyagentos/broker/service.py
+++ b/tinyagentos/broker/service.py
@@ -1,0 +1,133 @@
+"""Secrets Broker lifecycle service (P0).
+
+Wraps a :class:`BrokerStore` and the code-seeded provider registry. Enforces
+deny-by-default (no active grant -> not authorized) and expiry at check time
+(a grant past its expires_at is never authorized, even before a sweep flips
+its status). Notification dispatch and the external MCP/HTTP surfaces are
+P1+; this layer only manages the grant ledger.
+"""
+from __future__ import annotations
+
+import time
+
+from tinyagentos.broker.providers import PROVIDERS, get_provider
+from tinyagentos.broker.store import BrokerStore
+
+# Hard cap on a grant window: 7 days.
+MAX_WINDOW_SECONDS = 7 * 24 * 3600  # 604800
+
+
+class BrokerService:
+    def __init__(self, store: BrokerStore):
+        self.store = store
+
+    async def request_access(
+        self,
+        agent_identity: str,
+        provider_id: str,
+        scopes: list[str] | None = None,
+        reason: str | None = None,
+        request_id: str | None = None,
+    ) -> str:
+        """Create a pending grant for (agent, provider). Returns the grant id.
+
+        Raises ValueError if the provider is unknown. Defaults scopes to the
+        provider's default_scopes when none are named. Notification dispatch
+        is P1; this only records the pending request.
+        """
+        provider = get_provider(provider_id)
+        if provider is None:
+            raise ValueError(f"unknown provider_id: {provider_id!r}")
+        if scopes is None:
+            scopes = list(provider.default_scopes)
+        return await self.store.create_pending_grant(
+            agent_identity=agent_identity,
+            provider_id=provider_id,
+            scopes=scopes,
+            request_id=request_id,
+            note=reason,
+        )
+
+    async def approve(
+        self, grant_id: str, window_seconds: float, *, now: float | None = None
+    ) -> dict:
+        """Approve a grant for a bounded window.
+
+        Sets status=active, granted_at=now, expires_at=now+window (capped at
+        MAX_WINDOW_SECONDS). Raises ValueError if window_seconds <= 0 or the
+        grant is unknown. For http-proxy providers, also mints and returns a
+        virtual cred token under the "token" key.
+        """
+        if window_seconds <= 0:
+            raise ValueError("window_seconds must be > 0")
+        if now is None:
+            now = time.time()
+        window = min(float(window_seconds), float(MAX_WINDOW_SECONDS))
+
+        grant = await self.store.get_grant(grant_id)
+        if grant is None:
+            raise ValueError(f"unknown grant_id: {grant_id!r}")
+
+        expires_at = now + window
+        await self.store.set_grant_status(
+            grant_id, "active", granted_at=now, expires_at=expires_at
+        )
+
+        result = await self.store.get_grant(grant_id)
+        provider = PROVIDERS.get(grant["provider_id"])
+        if provider is not None and provider.kind == "http-proxy":
+            result["token"] = await self.store.mint_virtual_cred(grant_id)
+        return result
+
+    async def deny(self, grant_id: str) -> bool:
+        return await self.store.set_grant_status(grant_id, "denied")
+
+    async def revoke(self, grant_id: str) -> bool:
+        """Revoke a grant and delete any virtual creds minted for it."""
+        ok = await self.store.set_grant_status(grant_id, "revoked")
+        await self.store.delete_virtual_creds_for_grant(grant_id)
+        return ok
+
+    async def is_authorized(
+        self, agent_identity: str, provider_id: str, *, now: float | None = None
+    ) -> bool:
+        """True iff an active, unexpired grant exists for (agent, provider).
+
+        Scopes refine WHAT an authorized agent may do, not WHETHER it is
+        authorized, so an empty-scope active grant still authorizes access.
+        Deny-by-default: no active grant -> False.
+        """
+        if now is None:
+            now = time.time()
+        grant = await self.store.find_active_grant(agent_identity, provider_id, now)
+        return grant is not None
+
+    async def authorize_token(
+        self, token: str, *, now: float | None = None
+    ) -> dict | None:
+        """Resolve an http-proxy virtual token to its grant context.
+
+        Returns {agent_identity, provider_id, scopes} when the token maps to an
+        active, unexpired grant, else None.
+        """
+        if now is None:
+            now = time.time()
+        cred = await self.store.lookup_virtual_cred(token)
+        if cred is None:
+            return None
+        grant = await self.store.get_grant(cred["grant_id"])
+        if grant is None or grant["status"] != "active":
+            return None
+        expires_at = grant["expires_at"]
+        if expires_at is not None and expires_at <= now:
+            return None
+        return {
+            "agent_identity": grant["agent_identity"],
+            "provider_id": grant["provider_id"],
+            "scopes": grant["scopes"],
+        }
+
+    async def sweep_expired(self, now: float | None = None) -> int:
+        if now is None:
+            now = time.time()
+        return await self.store.sweep_expired(now)

--- a/tinyagentos/broker/store.py
+++ b/tinyagentos/broker/store.py
@@ -1,0 +1,230 @@
+"""SQLite-backed grant ledger for the Secrets Broker.
+
+Two tables: ``broker_grants`` (the per-(agent, provider) lifecycle record)
+and ``broker_virtual_creds`` (virtual tokens minted for http-proxy grants).
+Providers are code-seeded from ``providers.py`` and are NOT a DB table in P0
+(simpler; the registry is small and edited in code).
+
+Timestamps are epoch seconds (REAL). All SQL is parameterised. WAL +
+busy_timeout mirror the LiteLLM keystore so a concurrent reader does not
+block on a writer.
+"""
+from __future__ import annotations
+
+import json
+import secrets as _secrets
+import time
+import uuid
+from pathlib import Path
+
+from tinyagentos.base_store import BaseStore
+
+# Virtual-token prefix, mirroring the LiteLLM keystore convention.
+_TOKEN_PREFIX = "sk-taos-secret-"
+
+# status values: pending, active, denied, revoked, expired
+
+BROKER_SCHEMA = """
+CREATE TABLE IF NOT EXISTS broker_grants (
+    id                  TEXT PRIMARY KEY,
+    agent_identity      TEXT NOT NULL,
+    provider_id         TEXT NOT NULL,
+    scopes              TEXT NOT NULL DEFAULT '[]',
+    status              TEXT NOT NULL,
+    granted_at          REAL,
+    expires_at          REAL,
+    created_request_id  TEXT,
+    note                TEXT,
+    last_used_at        REAL
+);
+CREATE INDEX IF NOT EXISTS idx_broker_grants_lookup
+    ON broker_grants(agent_identity, provider_id, status);
+
+CREATE TABLE IF NOT EXISTS broker_virtual_creds (
+    token       TEXT PRIMARY KEY,
+    grant_id    TEXT NOT NULL,
+    created_at  REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_broker_virtual_creds_grant
+    ON broker_virtual_creds(grant_id);
+"""
+
+_GRANT_COLS = (
+    "id",
+    "agent_identity",
+    "provider_id",
+    "scopes",
+    "status",
+    "granted_at",
+    "expires_at",
+    "created_request_id",
+    "note",
+    "last_used_at",
+)
+
+
+def _grant_row_to_dict(row) -> dict:
+    d = dict(zip(_GRANT_COLS, row))
+    try:
+        d["scopes"] = json.loads(d["scopes"]) if d["scopes"] else []
+    except (ValueError, TypeError):
+        d["scopes"] = []
+    return d
+
+
+class BrokerStore(BaseStore):
+    SCHEMA = BROKER_SCHEMA
+
+    async def init(self) -> None:
+        await super().init()
+        # WAL + busy_timeout for cross-process safety (matches the keystore).
+        await self._db.execute("PRAGMA journal_mode=WAL")
+        await self._db.execute("PRAGMA busy_timeout=5000")
+        await self._db.commit()
+
+    # --- grants ---------------------------------------------------------
+
+    async def create_pending_grant(
+        self,
+        agent_identity: str,
+        provider_id: str,
+        scopes: list[str] | None,
+        request_id: str | None,
+        note: str | None,
+    ) -> str:
+        """Insert a pending grant (no granted_at/expires_at yet). Returns its id."""
+        grant_id = uuid.uuid4().hex
+        scopes_json = json.dumps(list(scopes or []))
+        await self._db.execute(
+            "INSERT INTO broker_grants "
+            "(id, agent_identity, provider_id, scopes, status, granted_at, "
+            "expires_at, created_request_id, note, last_used_at) "
+            "VALUES (?, ?, ?, ?, 'pending', NULL, NULL, ?, ?, NULL)",
+            (grant_id, agent_identity, provider_id, scopes_json, request_id, note),
+        )
+        await self._db.commit()
+        return grant_id
+
+    async def set_grant_status(
+        self,
+        grant_id: str,
+        status: str,
+        *,
+        expires_at: float | None = None,
+        granted_at: float | None = None,
+    ) -> bool:
+        """Update a grant's status (and optionally granted_at/expires_at).
+
+        granted_at/expires_at are only written when provided so a status flip
+        (e.g. -> expired) does not clobber the original approval timestamps.
+        """
+        sets = ["status = ?"]
+        params: list = [status]
+        if granted_at is not None:
+            sets.append("granted_at = ?")
+            params.append(granted_at)
+        if expires_at is not None:
+            sets.append("expires_at = ?")
+            params.append(expires_at)
+        params.append(grant_id)
+        cur = await self._db.execute(
+            f"UPDATE broker_grants SET {', '.join(sets)} WHERE id = ?", params
+        )
+        await self._db.commit()
+        return cur.rowcount > 0
+
+    async def get_grant(self, grant_id: str) -> dict | None:
+        async with self._db.execute(
+            f"SELECT {', '.join(_GRANT_COLS)} FROM broker_grants WHERE id = ?",
+            (grant_id,),
+        ) as cur:
+            row = await cur.fetchone()
+        return _grant_row_to_dict(row) if row else None
+
+    async def find_active_grant(
+        self, agent_identity: str, provider_id: str, now: float
+    ) -> dict | None:
+        """Return the active, unexpired grant for (agent, provider), or None."""
+        async with self._db.execute(
+            f"SELECT {', '.join(_GRANT_COLS)} FROM broker_grants "
+            "WHERE agent_identity = ? AND provider_id = ? AND status = 'active' "
+            "AND (expires_at IS NULL OR expires_at > ?) "
+            "ORDER BY granted_at DESC LIMIT 1",
+            (agent_identity, provider_id, now),
+        ) as cur:
+            row = await cur.fetchone()
+        return _grant_row_to_dict(row) if row else None
+
+    async def list_grants(
+        self, agent_identity: str | None = None, status: str | None = None
+    ) -> list[dict]:
+        sql = f"SELECT {', '.join(_GRANT_COLS)} FROM broker_grants"
+        clauses: list[str] = []
+        params: list = []
+        if agent_identity is not None:
+            clauses.append("agent_identity = ?")
+            params.append(agent_identity)
+        if status is not None:
+            clauses.append("status = ?")
+            params.append(status)
+        if clauses:
+            sql += " WHERE " + " AND ".join(clauses)
+        sql += " ORDER BY granted_at DESC, id"
+        async with self._db.execute(sql, params) as cur:
+            rows = await cur.fetchall()
+        return [_grant_row_to_dict(r) for r in rows]
+
+    async def touch_grant(self, grant_id: str, now: float) -> None:
+        await self._db.execute(
+            "UPDATE broker_grants SET last_used_at = ? WHERE id = ?",
+            (now, grant_id),
+        )
+        await self._db.commit()
+
+    async def sweep_expired(self, now: float) -> int:
+        """Flip active grants whose expires_at <= now to status=expired.
+
+        Returns the number of grants flipped.
+        """
+        cur = await self._db.execute(
+            "UPDATE broker_grants SET status = 'expired' "
+            "WHERE status = 'active' AND expires_at IS NOT NULL AND expires_at <= ?",
+            (now,),
+        )
+        await self._db.commit()
+        return cur.rowcount
+
+    # --- virtual creds --------------------------------------------------
+
+    async def mint_virtual_cred(self, grant_id: str) -> str:
+        token = _TOKEN_PREFIX + _secrets.token_urlsafe(32)
+        await self._db.execute(
+            "INSERT INTO broker_virtual_creds (token, grant_id, created_at) "
+            "VALUES (?, ?, ?)",
+            (token, grant_id, time.time()),
+        )
+        await self._db.commit()
+        return token
+
+    async def lookup_virtual_cred(self, token: str) -> dict | None:
+        async with self._db.execute(
+            "SELECT token, grant_id, created_at FROM broker_virtual_creds "
+            "WHERE token = ?",
+            (token,),
+        ) as cur:
+            row = await cur.fetchone()
+        if not row:
+            return None
+        return {"token": row[0], "grant_id": row[1], "created_at": row[2]}
+
+    async def delete_virtual_creds_for_grant(self, grant_id: str) -> int:
+        cur = await self._db.execute(
+            "DELETE FROM broker_virtual_creds WHERE grant_id = ?", (grant_id,)
+        )
+        await self._db.commit()
+        return cur.rowcount
+
+
+def default_broker_path(data_dir: str | Path) -> Path:
+    """Canonical broker db path for a controller data dir."""
+    return Path(data_dir) / ".broker.db"


### PR DESCRIPTION
## Secrets Broker P0: grant ledger + lifecycle (backend-only)

Phase 0 of the Secrets Broker. The broker lets external agents request time-boxed, revocable, per-(agent, provider) access to third-party secrets (Exa, Tavily, GitHub, etc.), routed and audited through taOS.

This PR is **backend-only**: the data model plus the lifecycle service. There is **no external surface** yet: no MCP server, no HTTP proxy, no routes, no UI. Those land in P1+.

### What P0 contains
- `tinyagentos/broker/providers.py` - curated, code-seeded provider registry (`exa`, `tavily`, `github`, `firecrawl`, `brave`, `jina`, `openai`). Each provider declares `kind` (`mcp` or `http-proxy`), `base_url`, `auth_style`, default scopes, and a `secret_ref` naming where the real key lives in `SecretsStore`.
- `tinyagentos/broker/store.py` - `BrokerStore(BaseStore)` over two tables, with WAL + busy_timeout and parameterised SQL.
- `tinyagentos/broker/service.py` - `BrokerService` lifecycle.

### Data model
- `broker_grants(id, agent_identity, provider_id, scopes, status, granted_at, expires_at, created_request_id, note, last_used_at)`, indexed on `(agent_identity, provider_id, status)`. status in {pending, active, denied, revoked, expired}.
- `broker_virtual_creds(token, grant_id, created_at)`, indexed on `grant_id`. Tokens are `sk-taos-secret-` + a urlsafe random suffix, minted only for `http-proxy` providers (the virtual-key fallback so the real key never leaves taOS).
- Providers are code-seeded, not a DB table in P0.

No plaintext provider keys are stored here. The broker holds only grants and virtual tokens; real keys stay in the existing `SecretsStore` under each provider's `secret_ref`.

### Lifecycle and semantics
- **Deny-by-default:** no active grant means not authorized.
- **Expiry enforced at check time:** a grant past its `expires_at` never authorizes, even before a sweep flips its status. `sweep_expired` is a housekeeping pass that flips lapsed `active` grants to `expired`.
- `approve` caps the window at 7 days (604800s) and rejects windows <= 0.
- Scopes refine WHAT an authorized agent may do, not WHETHER it is authorized, so an empty-scope active grant still authorizes provider access.
- `request_access` rejects unknown providers.

### Tests
`tests/test_broker.py` - 13 tests covering request/approve/expiry, deny, revoke (incl. virtual-cred cleanup), deny-by-default, window cap and validation, unknown provider, http-proxy token mint + `authorize_token` (active/revoked/expired/unknown), `sweep_expired` count + idempotency, and that mcp providers mint no token. All pass.

This is phase 0 of the Secrets Broker spec (kept private).
