### PR TITLE
feat(broker): P1a - broker routes + service wiring + request notification

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -253,6 +253,10 @@ async def client(app, tmp_data_dir):
     if secrets_store._db is not None:
         await secrets_store.close()
     await secrets_store.init()
+    broker_store = app.state.broker_store
+    if broker_store._db is not None:
+        await broker_store.close()
+    await broker_store.init()
     scheduler = app.state.scheduler
     if scheduler._db is not None:
         await scheduler.close()
@@ -375,6 +379,7 @@ async def client(app, tmp_data_dir):
     await channel_store.close()
     await scheduler.close()
     await secrets_store.close()
+    await broker_store.close()
     await notif_store.close()
     await store.close()
     await office_docs.close()

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -148,3 +148,22 @@ async def test_empty_scope_grant_still_authorizes(tmp_path):
     gid = await svc.request_access("agent-a", "exa", scopes=[])
     await svc.approve(gid, 3600, now=NOW)
     assert await svc.is_authorized("agent-a", "exa", now=NOW) is True
+
+
+@pytest.mark.asyncio
+async def test_approve_rejects_non_pending_grant(tmp_path):
+    """A denied or revoked grant can never be resurrected by approve."""
+    svc, _ = await _service(tmp_path)
+    # denied -> approve refused
+    gid = await svc.request_access("agent-x", "exa")
+    await svc.deny(gid)
+    with pytest.raises(ValueError):
+        await svc.approve(gid, 3600)
+    assert await svc.is_authorized("agent-x", "exa") is False
+    # revoked -> approve refused
+    gid2 = await svc.request_access("agent-y", "exa")
+    await svc.approve(gid2, 3600)
+    await svc.revoke(gid2)
+    with pytest.raises(ValueError):
+        await svc.approve(gid2, 3600)
+    assert await svc.is_authorized("agent-y", "exa") is False

--- a/tests/test_routes_broker.py
+++ b/tests/test_routes_broker.py
@@ -1,0 +1,126 @@
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+async def _request_grant(client, provider_id="exa", agent="agent-x", **kw):
+    body = {"provider_id": provider_id, "agent_identity": agent, **kw}
+    resp = await client.post("/api/broker/request", json=body)
+    return resp
+
+
+@pytest.mark.asyncio
+class TestBrokerRoutes:
+    async def test_providers_lists_seeded(self, client):
+        resp = await client.get("/api/broker/providers")
+        assert resp.status_code == 200
+        providers = resp.json()
+        ids = {p["id"] for p in providers}
+        assert "exa" in ids
+        assert "openai" in ids
+        exa = next(p for p in providers if p["id"] == "exa")
+        assert exa["kind"] == "mcp"
+        assert exa["default_scopes"] == ["search"]
+
+    async def test_request_creates_pending_and_notifies(self, client, app):
+        resp = await _request_grant(client, reason="needs search")
+        assert resp.status_code == 200
+        grant_id = resp.json()["grant_id"]
+        assert grant_id
+
+        grants = (await client.get("/api/broker/grants")).json()
+        match = next(g for g in grants if g["id"] == grant_id)
+        assert match["status"] == "pending"
+
+        notifs = await app.state.notifications.list()
+        broker_notifs = [n for n in notifs if n["source"] == "broker"]
+        assert len(broker_notifs) >= 1
+        assert "agent-x" in broker_notifs[0]["message"]
+        assert "needs search" in broker_notifs[0]["message"]
+
+    async def test_request_unknown_provider_400(self, client):
+        resp = await _request_grant(client, provider_id="does-not-exist")
+        assert resp.status_code == 400
+        assert "does-not-exist" in resp.json()["error"]
+
+    async def test_request_missing_agent_identity_400(self, client):
+        resp = await client.post("/api/broker/request", json={"provider_id": "exa"})
+        assert resp.status_code == 400
+        assert "agent_identity" in resp.json()["error"]
+
+    async def test_approve_makes_grant_active(self, client):
+        grant_id = (await _request_grant(client)).json()["grant_id"]
+        resp = await client.post(
+            f"/api/broker/grants/{grant_id}/approve", json={"window_seconds": 3600}
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "active"
+
+        active = (await client.get("/api/broker/grants?status=active")).json()
+        assert any(g["id"] == grant_id for g in active)
+
+    async def test_approve_bad_window_400(self, client):
+        grant_id = (await _request_grant(client)).json()["grant_id"]
+        resp = await client.post(
+            f"/api/broker/grants/{grant_id}/approve", json={"window_seconds": 0}
+        )
+        assert resp.status_code == 400
+
+    async def test_approve_unknown_grant_400(self, client):
+        resp = await client.post(
+            "/api/broker/grants/nope/approve", json={"window_seconds": 60}
+        )
+        assert resp.status_code == 400
+
+    async def test_http_proxy_approve_mints_token(self, client):
+        grant_id = (await _request_grant(client, provider_id="openai")).json()["grant_id"]
+        resp = await client.post(
+            f"/api/broker/grants/{grant_id}/approve", json={"window_seconds": 3600}
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data.get("token")
+        assert data["token"].startswith("sk-taos-secret-")
+
+    async def test_mcp_approve_no_token(self, client):
+        grant_id = (await _request_grant(client, provider_id="exa")).json()["grant_id"]
+        resp = await client.post(
+            f"/api/broker/grants/{grant_id}/approve", json={"window_seconds": 3600}
+        )
+        assert resp.status_code == 200
+        assert "token" not in resp.json()
+
+    async def test_deny(self, client):
+        grant_id = (await _request_grant(client)).json()["grant_id"]
+        resp = await client.post(f"/api/broker/grants/{grant_id}/deny")
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+        grants = (await client.get("/api/broker/grants")).json()
+        match = next(g for g in grants if g["id"] == grant_id)
+        assert match["status"] == "denied"
+
+    async def test_revoke(self, client):
+        grant_id = (await _request_grant(client)).json()["grant_id"]
+        await client.post(
+            f"/api/broker/grants/{grant_id}/approve", json={"window_seconds": 3600}
+        )
+        resp = await client.post(f"/api/broker/grants/{grant_id}/revoke")
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+        grants = (await client.get("/api/broker/grants")).json()
+        match = next(g for g in grants if g["id"] == grant_id)
+        assert match["status"] == "revoked"
+
+    async def test_grants_filter_by_agent(self, client):
+        await _request_grant(client, agent="agent-a")
+        await _request_grant(client, agent="agent-b")
+        grants = (await client.get("/api/broker/grants?agent_identity=agent-a")).json()
+        assert grants
+        assert all(g["agent_identity"] == "agent-a" for g in grants)
+
+    async def test_requires_auth(self, app):
+        # No taos_session cookie -> the session guard middleware rejects the
+        # request, same as it does for the secrets routes.
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as c:
+            resp = await c.get("/api/broker/providers")
+        assert resp.status_code in (401, 403)

--- a/tests/test_routes_broker.py
+++ b/tests/test_routes_broker.py
@@ -124,3 +124,24 @@ class TestBrokerRoutes:
         async with AsyncClient(transport=transport, base_url="http://test") as c:
             resp = await c.get("/api/broker/providers")
         assert resp.status_code in (401, 403)
+
+
+@pytest.mark.asyncio
+async def test_deny_revoke_unknown_grant_404(client):
+    """deny/revoke on an unknown grant id return 404 (consistent with approve)."""
+    r1 = await client.post("/api/broker/grants/tsk-nope/deny")
+    assert r1.status_code == 404
+    r2 = await client.post("/api/broker/grants/tsk-nope/revoke")
+    assert r2.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_approve_denied_grant_400(client):
+    """A denied grant cannot be resurrected via the approve route."""
+    gid = (await _request_grant(client)).json()["grant_id"]
+    deny = await client.post(f"/api/broker/grants/{gid}/deny")
+    assert deny.status_code == 200
+    resp = await client.post(
+        f"/api/broker/grants/{gid}/approve", json={"window_seconds": 3600}
+    )
+    assert resp.status_code == 400

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -62,6 +62,8 @@ from tinyagentos.scheduler.discovery import build_scheduler as build_resource_sc
 from tinyagentos.torrent_settings import TorrentSettingsStore
 from tinyagentos.relationships import RelationshipManager
 from tinyagentos.github_identities import GitHubIdentitiesStore
+from tinyagentos.broker import BrokerService, BrokerStore
+from tinyagentos.broker.store import default_broker_path
 from tinyagentos.secrets import SecretsStore
 from tinyagentos.mail_store import MailAccountStore
 from tinyagentos.training import TrainingManager
@@ -269,6 +271,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     torrent_settings_store = TorrentSettingsStore(data_dir / "torrent_settings.json")
     download_manager = DownloadManager(torrent_settings_store=torrent_settings_store)
     secrets_store = SecretsStore(data_dir / "secrets.db")
+    broker_store = BrokerStore(default_broker_path(data_dir))
+    broker_service = BrokerService(broker_store)
     mail_store = MailAccountStore(data_dir / "mail.db")
     github_identities_store = GitHubIdentitiesStore(data_dir / "github_identities.db")
     relationship_mgr = RelationshipManager(data_dir / "relationships.db")
@@ -430,6 +434,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await notif_store.init()
         await qmd_client.init()
         await secrets_store.init()
+        await broker_store.init()
         await mail_store.init()
         app.state.mail_store = mail_store
         await github_identities_store.init()
@@ -661,6 +666,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         app.state.download_manager = download_manager
         app.state.torrent_settings_store = torrent_settings_store
         app.state.secrets = secrets_store
+        app.state.broker = broker_service
+        app.state.broker_store = broker_store
         app.state.github_identities = github_identities_store
         app.state.relationships = relationship_mgr
         app.state.channels = channel_store
@@ -1210,6 +1217,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await browser_cookie_store.close()
         await browser_store.close()
         await secrets_store.close()
+        await broker_store.close()
         await mail_store.close()
         await notif_store.close()
         await app.state.system_events.close()
@@ -1302,6 +1310,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     app.state.http_client = http_client
     app.state.download_manager = download_manager
     app.state.secrets = secrets_store
+    app.state.broker = broker_service
+    app.state.broker_store = broker_store
     app.state.github_identities = github_identities_store
     app.state.relationships = relationship_mgr
     app.state.channels = channel_store

--- a/tinyagentos/broker/service.py
+++ b/tinyagentos/broker/service.py
@@ -54,9 +54,13 @@ class BrokerService:
         """Approve a grant for a bounded window.
 
         Sets status=active, granted_at=now, expires_at=now+window (capped at
-        MAX_WINDOW_SECONDS). Raises ValueError if window_seconds <= 0 or the
-        grant is unknown. For http-proxy providers, also mints and returns a
-        virtual cred token under the "token" key.
+        MAX_WINDOW_SECONDS). Raises ValueError if window_seconds <= 0, the grant
+        is unknown, or the grant is not currently ``pending``. For http-proxy
+        providers, also mints and returns a virtual cred token under "token".
+
+        Only a pending grant can be approved, so an approve call can never
+        resurrect a grant the user previously denied or revoked (nor re-activate
+        an expired one).
         """
         if window_seconds <= 0:
             raise ValueError("window_seconds must be > 0")
@@ -67,6 +71,10 @@ class BrokerService:
         grant = await self.store.get_grant(grant_id)
         if grant is None:
             raise ValueError(f"unknown grant_id: {grant_id!r}")
+        if grant["status"] != "pending":
+            raise ValueError(
+                f"grant {grant_id!r} is {grant['status']}, not pending; cannot approve"
+            )
 
         expires_at = now + window
         await self.store.set_grant_status(

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -90,6 +90,9 @@ def register_all_routers(app):
     from tinyagentos.routes.secrets import router as secrets_router
     app.include_router(secrets_router)
 
+    from tinyagentos.routes.broker import router as broker_router
+    app.include_router(broker_router)
+
     from tinyagentos.routes.mail import router as mail_router
     app.include_router(mail_router)
 

--- a/tinyagentos/routes/broker.py
+++ b/tinyagentos/routes/broker.py
@@ -99,11 +99,17 @@ async def approve_grant(request: Request, grant_id: str, body: ApproveRequest):
 async def deny_grant(request: Request, grant_id: str):
     broker = request.app.state.broker
     ok = await broker.deny(grant_id)
-    return {"ok": ok}
+    # ok is False only when no grant matched the id; return 404 for consistency
+    # with approve (which 400s on an unknown id) instead of a 200 {"ok": false}.
+    if not ok:
+        return JSONResponse({"error": f"unknown grant_id: {grant_id!r}"}, status_code=404)
+    return {"ok": True}
 
 
 @router.post("/api/broker/grants/{grant_id}/revoke")
 async def revoke_grant(request: Request, grant_id: str):
     broker = request.app.state.broker
     ok = await broker.revoke(grant_id)
-    return {"ok": ok}
+    if not ok:
+        return JSONResponse({"error": f"unknown grant_id: {grant_id!r}"}, status_code=404)
+    return {"ok": True}

--- a/tinyagentos/routes/broker.py
+++ b/tinyagentos/routes/broker.py
@@ -1,0 +1,109 @@
+"""Secrets Broker routes (P1a).
+
+API surface over :class:`tinyagentos.broker.BrokerService`. Backend only:
+list providers, request access (which raises a desktop notification for the
+operator), and the approve / deny / revoke grant lifecycle. The consent UI
+(Secrets grant surface + Permissions app) is P1b. Auth is enforced by the
+same session middleware that guards the secrets routes, so these routes carry
+no per-route guard of their own.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from tinyagentos.broker.providers import PROVIDERS
+
+router = APIRouter()
+
+
+class AccessRequest(BaseModel):
+    provider_id: str
+    scopes: Optional[list[str]] = None
+    reason: Optional[str] = None
+    agent_identity: Optional[str] = None
+
+
+class ApproveRequest(BaseModel):
+    window_seconds: float
+
+
+@router.get("/api/broker/providers")
+async def list_providers(request: Request):
+    return [
+        {
+            "id": p.id,
+            "display_name": p.display_name,
+            "kind": p.kind,
+            "default_scopes": list(p.default_scopes),
+        }
+        for p in PROVIDERS.values()
+    ]
+
+
+@router.post("/api/broker/request")
+async def request_access(request: Request, body: AccessRequest):
+    if not body.agent_identity:
+        return JSONResponse(
+            {"error": "agent_identity is required"}, status_code=400
+        )
+    broker = request.app.state.broker
+    try:
+        grant_id = await broker.request_access(
+            agent_identity=body.agent_identity,
+            provider_id=body.provider_id,
+            scopes=body.scopes,
+            reason=body.reason,
+        )
+    except ValueError as e:
+        return JSONResponse({"error": str(e)}, status_code=400)
+
+    message = f"{body.agent_identity} requests {body.provider_id}"
+    if body.reason:
+        message += f" - {body.reason}"
+    await request.app.state.notifications.add(
+        title="Agent access request",
+        message=message,
+        level="warning",
+        source="broker",
+    )
+    return {"grant_id": grant_id}
+
+
+@router.get("/api/broker/grants")
+async def list_grants(
+    request: Request,
+    agent_identity: str | None = None,
+    status: str | None = None,
+):
+    broker = request.app.state.broker
+    return await broker.store.list_grants(
+        agent_identity=agent_identity, status=status
+    )
+
+
+@router.post("/api/broker/grants/{grant_id}/approve")
+async def approve_grant(request: Request, grant_id: str, body: ApproveRequest):
+    broker = request.app.state.broker
+    try:
+        grant = await broker.approve(grant_id, body.window_seconds)
+    except ValueError as e:
+        return JSONResponse({"error": str(e)}, status_code=400)
+    return grant
+
+
+@router.post("/api/broker/grants/{grant_id}/deny")
+async def deny_grant(request: Request, grant_id: str):
+    broker = request.app.state.broker
+    ok = await broker.deny(grant_id)
+    return {"ok": ok}
+
+
+@router.post("/api/broker/grants/{grant_id}/revoke")
+async def revoke_grant(request: Request, grant_id: str):
+    broker = request.app.state.broker
+    ok = await broker.revoke(grant_id)
+    return {"ok": ok}


### PR DESCRIPTION
## P1a: Secrets Broker routes + service wiring + request notification

Backend only. Stacked on P0 (#1310), base branch `feat/secrets-broker-p0`.

P0 added the grant ledger (`BrokerStore`), provider registry, and `BrokerService` lifecycle. P1a wires that service into the controller and exposes the API surface.

### What this adds
- **Service wiring** (`app.py`): construct `BrokerStore(default_broker_path(data_dir))` wrapped in `BrokerService`, init/close it in the lifespan alongside the other stores, and set `app.state.broker` + `app.state.broker_store`. Router registered via `register_all_routers`.
- **Routes** (`routes/broker.py`), gated by the same session auth middleware as the secrets routes:
  - `GET /api/broker/providers` - list `{id, display_name, kind, default_scopes}`.
  - `POST /api/broker/request` `{provider_id, scopes?, reason?, agent_identity?}` - creates a pending grant, raises a `broker`-source desktop notification, returns `{grant_id}`. Missing `agent_identity` or unknown provider returns 400.
  - `GET /api/broker/grants?agent_identity=&status=` - list grants.
  - `POST /api/broker/grants/{id}/approve` `{window_seconds}` - returns the grant (with a minted virtual token for http-proxy providers). Bad window / unknown grant returns 400.
  - `POST /api/broker/grants/{id}/deny` and `.../revoke` - return `{ok}`.
- **Tests** (`tests/test_routes_broker.py`): 13 route tests covering request + notification, validation 400s, approve/active filter, http-proxy token vs mcp no-token, deny, revoke, agent filtering, and auth rejection.

### Not in this PR
- The consent UI (Secrets grant surface + Permissions app) is **P1b**.
- The MCP server and the real HTTP proxy to providers are P2/P3.

The agent-identity here comes from the request body as the API surface; the consent-handshake identity wiring lands later.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Broker subsystem for managing access requests and provider authorization
  * API endpoints for listing providers, requesting access, approving/denying/revoking grants
  * Grant filtering by agent identity and status
  * Enhanced validation preventing reactivation of denied or revoked grants

* **Tests**
  * Comprehensive test coverage for broker API endpoints and functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->