### PR TITLE
Add Exa search client to broker package

### DIFF
--- a/tests/test_broker_exa_client.py
+++ b/tests/test_broker_exa_client.py
@@ -1,0 +1,38 @@
+"""Tests for the Exa search client in tinyagentos.broker.clients.exa."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import respx
+from httpx import Response
+
+from tinyagentos.broker.clients.exa import _BASE_URL, exa_search
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_exa_search_returns_results():
+    route = respx.post(f"{_BASE_URL}/search").mock(
+        return_value=Response(200, json={"results": [{"title": "t", "url": "u"}]})
+    )
+    result = await exa_search("test-key", "hello", num_results=3)
+    assert result == [{"title": "t", "url": "u"}]
+
+    call = route.calls[0]
+    assert call.request.headers["Authorization"] == "Bearer test-key"
+    body = json.loads(call.request.content)
+    assert body["query"] == "hello"
+    assert body["numResults"] == 3
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_exa_search_non_200_raises():
+    respx.post(f"{_BASE_URL}/search").mock(
+        return_value=Response(500, text="internal error")
+    )
+    with pytest.raises(RuntimeError, match="500"):
+        await exa_search("key", "q")

--- a/tinyagentos/broker/clients/exa.py
+++ b/tinyagentos/broker/clients/exa.py
@@ -1,0 +1,26 @@
+"""Thin async Exa search client."""
+
+from __future__ import annotations
+
+import httpx
+
+_BASE_URL = "https://api.exa.ai"
+
+
+async def exa_search(api_key: str, query: str, num_results: int = 5) -> list[dict]:
+    """Search via the Exa neural search API.
+
+    Returns the raw ``results`` list from the API response.
+    Raises ``RuntimeError`` on non-200 status.
+    """
+    async with httpx.AsyncClient(timeout=30) as client:
+        resp = await client.post(
+            f"{_BASE_URL}/search",
+            headers={"Authorization": f"Bearer {api_key}"},
+            json={"query": query, "numResults": num_results},
+        )
+    if resp.status_code != 200:
+        raise RuntimeError(
+            f"Exa search failed: {resp.status_code} {resp.text[:200]}"
+        )
+    return resp.json().get("results", [])


### PR DESCRIPTION
Autonomous build of board card tsk-y6gfuq.

Creates tinyagentos/broker/clients/exa.py with exa_search() async
function that POSTs to api.exa.ai/search using httpx.AsyncClient.
Includes pytest-asyncio tests with respx mocking.

Files:
 tests/test_broker_exa_client.py        | 38 ++++++++++++++++++++++++++++++++++
 tinyagentos/broker/clients/__init__.py |  0
 tinyagentos/broker/clients/exa.py      | 26 +++++++++++++++++++++++
 3 files changed, 64 insertions(+)