### PR TITLE
Add Tavily search client to broker package

### DIFF
--- a/tests/test_broker_tavily_client.py
+++ b/tests/test_broker_tavily_client.py
@@ -1,0 +1,54 @@
+"""Tests for the Tavily search client (respx-mocked)."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+from httpx import Response
+
+from tinyagentos.broker.clients.tavily import TAVILY_SEARCH_URL, tavily_search
+
+
+@pytest.mark.asyncio
+class TestTavilySearch:
+    @respx.mock
+    async def test_success_returns_results_list(self):
+        route = respx.post(TAVILY_SEARCH_URL).mock(
+            return_value=Response(200, json={"results": [{"title": "t", "url": "https://example.com"}]})
+        )
+        results = await tavily_search("test-key", "hello", num_results=3)
+        assert results == [{"title": "t", "url": "https://example.com"}]
+        assert route.called
+        import json as _json
+        body = _json.loads(route.calls[0].request.content)
+        assert body["api_key"] == "test-key"
+        assert body["query"] == "hello"
+        assert body["max_results"] == 3
+
+    @respx.mock
+    async def test_non_200_raises_runtime_error_with_status(self):
+        respx.post(TAVILY_SEARCH_URL).mock(
+            return_value=Response(500, text="internal error")
+        )
+        with pytest.raises(RuntimeError, match="500"):
+            await tavily_search("key", "q")
+
+    @respx.mock
+    async def test_default_num_results_is_5(self):
+        route = respx.post(TAVILY_SEARCH_URL).mock(
+            return_value=Response(200, json={"results": []})
+        )
+        await tavily_search("key", "q")
+        import json as _json
+        body = _json.loads(route.calls[0].request.content)
+        assert body["max_results"] == 5
+
+    @respx.mock
+    async def test_no_authorization_header(self):
+        route = respx.post(TAVILY_SEARCH_URL).mock(
+            return_value=Response(200, json={"results": []})
+        )
+        await tavily_search("secret-key", "q")
+        headers = route.calls[0].request.headers
+        assert "authorization" not in headers

--- a/tinyagentos/broker/clients/tavily.py
+++ b/tinyagentos/broker/clients/tavily.py
@@ -1,0 +1,35 @@
+"""Tavily search client: thin async wrapper around the Tavily search API."""
+
+from __future__ import annotations
+
+import httpx
+
+TAVILY_SEARCH_URL = "https://api.tavily.com/search"
+
+
+async def tavily_search(api_key: str, query: str, num_results: int = 5) -> list[dict]:
+    """Run a Tavily search and return the raw results list.
+
+    Args:
+        api_key: Tavily API key, sent in the JSON body (not a header).
+        query: Search query string.
+        num_results: Maximum number of results to return.
+
+    Returns:
+        A list of result dicts from the ``results`` key of the response.
+
+    Raises:
+        RuntimeError: If the API returns a non-200 status code.
+    """
+    payload = {
+        "api_key": api_key,
+        "query": query,
+        "max_results": num_results,
+    }
+    async with httpx.AsyncClient(timeout=30) as client:
+        resp = await client.post(TAVILY_SEARCH_URL, json=payload)
+    if resp.status_code != 200:
+        body = resp.text[:200]
+        raise RuntimeError(f"Tavily search failed: {resp.status_code} {body}")
+    data = resp.json()
+    return data.get("results", [])


### PR DESCRIPTION
Autonomous build of board card tsk-amjr2o.

Creates tinyagentos/broker/clients/tavily.py with tavily_search() async
function that POSTs to api.tavily.com/search with the API key in the JSON
body (no Authorization header). Includes respx-based tests in
tests/test_broker_tavily_client.py covering success, error, default params,
and header verification.

Files:
 tests/test_broker_tavily_client.py     | 54 ++++++++++++++++++++++++++++++++++
 tinyagentos/broker/clients/__init__.py |  0
 tinyagentos/broker/clients/tavily.py   | 35 ++++++++++++++++++++++
 3 files changed, 89 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Tavily search client with async HTTP functionality for querying the Tavily search API with configurable result limits.

* **Tests**
  * Added test suite for the Tavily search client verifying request handling, error responses, default parameters, and security aspects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->