### PR TITLE
projects: one active claim per agent (board flow protection)

### DIFF
--- a/tests/projects/test_task_store.py
+++ b/tests/projects/test_task_store.py
@@ -67,6 +67,38 @@ async def test_atomic_claim_only_one_winner(store):
 
 
 @pytest.mark.asyncio
+async def test_agent_cannot_hold_two_active_claims(store):
+    a = await store.create_task(project_id="p", title="A", created_by="u")
+    b = await store.create_task(project_id="p", title="B", created_by="u")
+    first = await store.claim_task(a["id"], claimer_id="agent-1")
+    second = await store.claim_task(b["id"], claimer_id="agent-1")
+    assert first is True
+    assert second is False
+    assert (await store.get_task(b["id"]))["status"] == "open"
+    assert await store.held_task("agent-1") == a["id"]
+
+
+@pytest.mark.asyncio
+async def test_can_claim_again_after_release(store):
+    a = await store.create_task(project_id="p", title="A", created_by="u")
+    b = await store.create_task(project_id="p", title="B", created_by="u")
+    await store.claim_task(a["id"], claimer_id="agent-1")
+    await store.release_task(a["id"], releaser_id="agent-1")
+    assert await store.held_task("agent-1") is None
+    assert await store.claim_task(b["id"], claimer_id="agent-1") is True
+
+
+@pytest.mark.asyncio
+async def test_can_claim_again_after_close(store):
+    a = await store.create_task(project_id="p", title="A", created_by="u")
+    b = await store.create_task(project_id="p", title="B", created_by="u")
+    await store.claim_task(a["id"], claimer_id="agent-1")
+    await store.close_task(a["id"], closed_by="agent-1", reason="done")
+    assert await store.held_task("agent-1") is None
+    assert await store.claim_task(b["id"], claimer_id="agent-1") is True
+
+
+@pytest.mark.asyncio
 async def test_release_task(store):
     t = await store.create_task(project_id="p", title="A", created_by="u")
     await store.claim_task(t["id"], claimer_id="agent-1")

--- a/tests/test_routes_projects.py
+++ b/tests/test_routes_projects.py
@@ -140,6 +140,25 @@ async def test_ready_endpoint(client):
 
 
 @pytest.mark.asyncio
+async def test_claim_blocked_while_agent_holds_active_task(client):
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+    a = (await client.post(f"/api/projects/{pid}/tasks", json={"title": "A"})).json()
+    b = (await client.post(f"/api/projects/{pid}/tasks", json={"title": "B"})).json()
+
+    assert (await client.post(f"/api/projects/{pid}/tasks/{a['id']}/claim", json={"claimer_id": "agent-1"})).status_code == 200
+
+    resp = await client.post(f"/api/projects/{pid}/tasks/{b['id']}/claim", json={"claimer_id": "agent-1"})
+    assert resp.status_code == 409
+    body = resp.json()
+    assert body["error"] == "agent already holds an active task"
+    assert body["held_task"] == a["id"]
+
+    # releasing the first frees the agent to claim the second
+    await client.post(f"/api/projects/{pid}/tasks/{a['id']}/release", json={"releaser_id": "agent-1"})
+    assert (await client.post(f"/api/projects/{pid}/tasks/{b['id']}/claim", json={"claimer_id": "agent-1"})).status_code == 200
+
+
+@pytest.mark.asyncio
 async def test_claim_release_close(client):
     pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
     t = (await client.post(f"/api/projects/{pid}/tasks", json={"title": "A"})).json()

--- a/tinyagentos/projects/task_store.py
+++ b/tinyagentos/projects/task_store.py
@@ -231,13 +231,31 @@ class ProjectTaskStore(BaseStore):
         if existing is not None:
             await self._publish(existing["project_id"], "task.updated", {"id": task_id, "patch": patch})
 
+    async def held_task(self, claimer_id: str) -> str | None:
+        """Return the id of the active ('claimed') task this agent currently
+        holds, or None. Used to enforce one active claim per agent."""
+        async with self._db.execute(
+            "SELECT id FROM project_tasks WHERE claimed_by = ? AND status = 'claimed' LIMIT 1",
+            (claimer_id,),
+        ) as cur:
+            row = await cur.fetchone()
+        return row[0] if row else None
+
     async def claim_task(self, task_id: str, claimer_id: str) -> bool:
         now = time.time()
+        # Flow protection: an agent must complete (close) or release a task
+        # before claiming another. The NOT EXISTS guard makes the one-active-
+        # claim rule atomic, so concurrent claims by the same agent can't race
+        # past it.
         cursor = await self._db.execute(
             """UPDATE project_tasks
                SET claimed_by = ?, claimed_at = ?, status = 'claimed', updated_at = ?
-               WHERE id = ? AND claimed_by IS NULL AND status = 'open'""",
-            (claimer_id, now, now, task_id),
+               WHERE id = ? AND claimed_by IS NULL AND status = 'open'
+                 AND NOT EXISTS (
+                     SELECT 1 FROM project_tasks held
+                     WHERE held.claimed_by = ? AND held.status = 'claimed'
+                 )""",
+            (claimer_id, now, now, task_id, claimer_id),
         )
         await self._db.commit()
         changed = cursor.rowcount == 1

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -556,6 +556,18 @@ async def claim_task(
         return JSONResponse({"error": "not found"}, status_code=404)
     ok = await store.claim_task(task_id, payload.claimer_id)
     if not ok:
+        # Distinguish "task taken by someone else" from "you already hold an
+        # active task" so the agent knows to finish or release it first.
+        held = await store.held_task(payload.claimer_id)
+        if held is not None and held != task_id:
+            return JSONResponse(
+                {
+                    "error": "agent already holds an active task",
+                    "held_task": held,
+                    "detail": "complete or release your current task before claiming another",
+                },
+                status_code=409,
+            )
         return JSONResponse({"error": "already claimed"}, status_code=409)
     _beads_mark_dirty(request, project_id)
     await pstore.log_activity(project_id, payload.claimer_id, "task.claimed", {"task_id": task_id})


### PR DESCRIPTION
## Why
The board accumulated ~118 'claimed' cards versus a handful of live agents. Lanes could claim a new card without ever completing or releasing the previous one, so crashed/aborted runs leaked claims that wedged forever.

## What
- `task_store.claim_task` now refuses to claim when the same agent already holds an active ('claimed') task. The guard is a `NOT EXISTS` subclause inside the same atomic UPDATE, so concurrent claims by one agent cannot race past it.
- New `task_store.held_task(claimer_id)` helper returns the agent's current active card (or None).
- The claim route distinguishes 'taken by someone else' from 'you already hold a task' and returns a 409 naming the held task so the agent knows to finish or release it first.

## Invariant
At most one 'claimed' card per agent at a time. A card with an open PR stays 'claimed' until the merge gate closes it, so a lane intentionally holds its single claim until then.

## Tests
- store: cannot hold two active claims; can re-claim after release; can re-claim after close
- route: 409 + held_task payload, then succeeds after release

## Operational follow-up (separate)
Executor lane (`~/.taos-team`) gets a release-on-exit trap + `release` subcommand so crashes return the card to the pool. The existing stale 'claimed' cards still need a one-time backfill release.