### PR TITLE
feat(taosctl): add settings command group

### DIFF
--- a/tests/test_taosctl_settings.py
+++ b/tests/test_taosctl_settings.py
@@ -1,0 +1,165 @@
+"""Tests for taosctl settings command group: dispatch, endpoint paths, and
+argument wiring."""
+from __future__ import annotations
+
+import pytest
+
+from tinyagentos.cli.taosctl import __main__ as cli_main
+
+
+class _FakeClient:
+    def __init__(self, *a, **k):
+        self.calls = []
+        self.base_url = "http://x"
+        self.token = "t"
+
+    def get(self, path, params=None):
+        self.calls.append(("GET", path))
+        return {"ok": True}
+
+    def post(self, path, body=None, params=None, json=None):
+        payload = body if body is not None else json
+        self.calls.append(("POST", path, payload))
+        return {"ok": True}
+
+    def put(self, path, body=None, json=None):
+        payload = body if body is not None else json
+        self.calls.append(("PUT", path, payload))
+        return {"ok": True}
+
+    def delete(self, path, params=None):
+        self.calls.append(("DELETE", path))
+        return {"ok": True}
+
+
+def _run(monkeypatch, argv, fake):
+    monkeypatch.setattr(cli_main, "TaosClient", lambda **k: fake)
+    return cli_main.main(argv)
+
+
+def test_storage_hits_correct_endpoint(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["settings", "storage"], fake)
+    assert rc == 0
+    assert ("GET", "/api/settings/storage") in fake.calls
+
+
+def test_llm_proxy_hits_correct_endpoint(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["settings", "llm-proxy"], fake)
+    assert rc == 0
+    assert ("GET", "/api/settings/llm-proxy") in fake.calls
+
+
+def test_backup_schedule_hits_correct_endpoint(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["settings", "backup-schedule"], fake)
+    assert rc == 0
+    assert ("GET", "/api/settings/backup-schedule") in fake.calls
+
+
+def test_set_backup_schedule_sends_frequency(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["settings", "set-backup-schedule", "daily"], fake)
+    assert rc == 0
+    assert ("PUT", "/api/settings/backup-schedule", {"frequency": "daily"}) in fake.calls
+
+
+def test_webhooks_hits_correct_endpoint(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["settings", "webhooks"], fake)
+    assert rc == 0
+    assert ("GET", "/api/settings/webhooks") in fake.calls
+
+
+def test_add_webhook_sends_body(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["settings", "add-webhook", "--url", "https://hook.example.com", "--type", "generic"], fake)
+    assert rc == 0
+    assert ("POST", "/api/settings/webhooks", {"url": "https://hook.example.com", "type": "generic"}) in fake.calls
+
+
+def test_add_webhook_includes_optional_fields(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["settings", "add-webhook", "--url", "https://t.me/bot", "--type", "telegram", "--bot-token", "tok123", "--chat-id", "chat456"], fake)
+    assert rc == 0
+    call = next(c for c in fake.calls if c[0] == "POST")
+    assert call[2] == {"url": "https://t.me/bot", "type": "telegram", "bot_token": "tok123", "chat_id": "chat456"}
+
+
+def test_remove_webhook_hits_correct_endpoint(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["settings", "remove-webhook", "2"], fake)
+    assert rc == 0
+    assert ("DELETE", "/api/settings/webhooks/2") in fake.calls
+
+
+def test_notification_prefs_hits_correct_endpoint(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["settings", "notification-prefs"], fake)
+    assert rc == 0
+    assert ("GET", "/api/settings/notification-prefs") in fake.calls
+
+
+def test_container_runtime_hits_correct_endpoint(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["settings", "container-runtime"], fake)
+    assert rc == 0
+    assert ("GET", "/api/settings/container-runtime") in fake.calls
+
+
+def test_set_container_runtime_sends_runtime(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["settings", "set-container-runtime", "docker"], fake)
+    assert rc == 0
+    assert ("PUT", "/api/settings/container-runtime", {"runtime": "docker"}) in fake.calls
+
+
+def test_branches_hits_correct_endpoint(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["settings", "branches"], fake)
+    assert rc == 0
+    assert ("GET", "/api/settings/branches") in fake.calls
+
+
+def test_update_check_hits_correct_endpoint(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["settings", "update-check"], fake)
+    assert rc == 0
+    assert ("GET", "/api/settings/update-check") in fake.calls
+
+
+def test_update_status_hits_correct_endpoint(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["settings", "update-status"], fake)
+    assert rc == 0
+    assert ("GET", "/api/settings/update-status") in fake.calls
+
+
+def test_set_platform_sends_body(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["settings", "set-platform", "--poll-interval", "30", "--retention-days", "7"], fake)
+    assert rc == 0
+    assert ("PUT", "/api/settings/platform", {"poll_interval": 30, "retention_days": 7}) in fake.calls
+
+
+def test_set_platform_includes_catalog_repo(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["settings", "set-platform", "--poll-interval", "60", "--retention-days", "14", "--catalog-repo", "https://github.com/org/repo"], fake)
+    assert rc == 0
+    call = next(c for c in fake.calls if c[0] == "PUT" and "platform" in c[1])
+    assert call[2]["catalog_repo"] == "https://github.com/org/repo"
+
+
+def test_config_hits_correct_endpoint(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["settings", "config"], fake)
+    assert rc == 0
+    assert ("GET", "/api/config") in fake.calls
+
+
+def test_set_config_sends_yaml(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["settings", "set-config", "--yaml", "server:\n  port: 6969"], fake)
+    assert rc == 0
+    assert ("PUT", "/api/config", {"yaml": "server:\n  port: 6969"}) in fake.calls

--- a/tinyagentos/cli/taosctl/commands/settings.py
+++ b/tinyagentos/cli/taosctl/commands/settings.py
@@ -1,0 +1,147 @@
+"""taosctl settings -- inspect and manage server settings.
+
+Covers storage, webhooks, backup schedule, container runtime, update status,
+platform settings, and config. Skips endpoints that need file upload, streaming,
+or complex nested bodies (test-backend, backup, restore, webhooks/test,
+notification-prefs/{event_type}, update, update-check-now, rebuild-frontend,
+update-channel).
+"""
+from __future__ import annotations
+
+NOUN = "settings"
+
+
+def register(subparsers) -> None:
+    p = subparsers.add_parser(NOUN, help="Inspect and manage server settings")
+    verbs = p.add_subparsers(dest="verb", required=True, metavar="<verb>")
+
+    sp = verbs.add_parser("storage", help="Show storage usage")
+    sp.set_defaults(func=_storage)
+
+    lp = verbs.add_parser("llm-proxy", help="Show LLM proxy status")
+    lp.set_defaults(func=_llm_proxy)
+
+    bp = verbs.add_parser("backup-schedule", help="Show backup schedule")
+    bp.set_defaults(func=_backup_schedule)
+
+    sbp = verbs.add_parser("set-backup-schedule", help="Set backup schedule frequency")
+    sbp.add_argument("frequency", choices=["off", "daily", "weekly"], help="Backup frequency")
+    sbp.set_defaults(func=_set_backup_schedule)
+
+    wp = verbs.add_parser("webhooks", help="List configured webhooks")
+    wp.set_defaults(func=_webhooks)
+
+    awp = verbs.add_parser("add-webhook", help="Add a webhook endpoint")
+    awp.add_argument("--url", required=True, help="Webhook URL")
+    awp.add_argument("--type", default="generic", help="Webhook type")
+    awp.add_argument("--bot-token", default="", help="Bot token (Telegram etc.)")
+    awp.add_argument("--chat-id", default="", help="Chat ID (Telegram etc.)")
+    awp.set_defaults(func=_add_webhook)
+
+    rwp = verbs.add_parser("remove-webhook", help="Remove a webhook by index")
+    rwp.add_argument("index", type=int, help="Webhook index")
+    rwp.set_defaults(func=_remove_webhook)
+
+    np = verbs.add_parser("notification-prefs", help="Show notification preferences")
+    np.set_defaults(func=_notification_prefs)
+
+    cp = verbs.add_parser("container-runtime", help="Show container runtime status")
+    cp.set_defaults(func=_container_runtime)
+
+    scp = verbs.add_parser("set-container-runtime", help="Set container runtime preference")
+    scp.add_argument("runtime", choices=["auto", "apple", "lxc", "docker", "podman"], help="Runtime")
+    scp.set_defaults(func=_set_container_runtime)
+
+    brp = verbs.add_parser("branches", help="List remote branches and current tracking")
+    brp.set_defaults(func=_branches)
+
+    up = verbs.add_parser("update-check", help="Check for available updates")
+    up.set_defaults(func=_update_check)
+
+    usp = verbs.add_parser("update-status", help="Show current/pending update status")
+    usp.set_defaults(func=_update_status)
+
+    pp = verbs.add_parser("set-platform", help="Update platform settings")
+    pp.add_argument("--poll-interval", type=int, required=True, help="Metrics poll interval (seconds)")
+    pp.add_argument("--retention-days", type=int, required=True, help="Metrics retention (days)")
+    pp.add_argument("--catalog-repo", default="", help="Catalog repo URL")
+    pp.set_defaults(func=_set_platform)
+
+    gc = verbs.add_parser("config", help="Get current config as YAML")
+    gc.set_defaults(func=_config)
+
+    sc = verbs.add_parser("set-config", help="Validate and save config from YAML")
+    sc.add_argument("--yaml", required=True, help="Config YAML string")
+    sc.set_defaults(func=_set_config)
+
+
+def _storage(args, client):
+    return client.get("/api/settings/storage")
+
+
+def _llm_proxy(args, client):
+    return client.get("/api/settings/llm-proxy")
+
+
+def _backup_schedule(args, client):
+    return client.get("/api/settings/backup-schedule")
+
+
+def _set_backup_schedule(args, client):
+    return client.put("/api/settings/backup-schedule", body={"frequency": args.frequency})
+
+
+def _webhooks(args, client):
+    return client.get("/api/settings/webhooks")
+
+
+def _add_webhook(args, client):
+    body = {"url": args.url, "type": args.type}
+    if args.bot_token:
+        body["bot_token"] = args.bot_token
+    if args.chat_id:
+        body["chat_id"] = args.chat_id
+    return client.post("/api/settings/webhooks", body=body)
+
+
+def _remove_webhook(args, client):
+    return client.delete(f"/api/settings/webhooks/{args.index}")
+
+
+def _notification_prefs(args, client):
+    return client.get("/api/settings/notification-prefs")
+
+
+def _container_runtime(args, client):
+    return client.get("/api/settings/container-runtime")
+
+
+def _set_container_runtime(args, client):
+    return client.put("/api/settings/container-runtime", body={"runtime": args.runtime})
+
+
+def _branches(args, client):
+    return client.get("/api/settings/branches")
+
+
+def _update_check(args, client):
+    return client.get("/api/settings/update-check")
+
+
+def _update_status(args, client):
+    return client.get("/api/settings/update-status")
+
+
+def _set_platform(args, client):
+    body = {"poll_interval": args.poll_interval, "retention_days": args.retention_days}
+    if args.catalog_repo:
+        body["catalog_repo"] = args.catalog_repo
+    return client.put("/api/settings/platform", body=body)
+
+
+def _config(args, client):
+    return client.get("/api/config")
+
+
+def _set_config(args, client):
+    return client.put("/api/config", body={"yaml": args.yaml})


### PR DESCRIPTION
Autonomous build of board card tsk-dtw54e.

Add taosctl settings with verbs for storage, llm-proxy, backup-schedule,
webhooks, notification-prefs, container-runtime, branches, update-check,
update-status, platform settings, and config. Each verb maps to a
settings.py endpoint and returns data for the framework to render.

Files:
 tests/test_taosctl_settings.py               | 165 +++++++++++++++++++++++++++
 tinyagentos/cli/taosctl/commands/settings.py | 147 ++++++++++++++++++++++++
 2 files changed, 312 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added `taosctl settings` command group with subcommands for managing storage, LLM proxy, backup schedules, webhooks, notification preferences, container runtime, branches, platform settings, and configuration.

## Tests
* Added comprehensive test coverage for the `taosctl settings` command and its subcommands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->