### PR TITLE
feat(taosctl): add store command group for app catalog management

### DIFF
--- a/tests/test_taosctl_store.py
+++ b/tests/test_taosctl_store.py
@@ -1,0 +1,108 @@
+"""Tests for the taosctl store command group."""
+from __future__ import annotations
+
+from tinyagentos.cli.taosctl import __main__ as cli_main
+
+
+class _FakeClient:
+    def __init__(self, *a, **k):
+        self.calls = []
+        self.base_url = "http://x"
+        self.token = "t"
+
+    def get(self, path, params=None):
+        self.calls.append(("GET", path, params))
+        return {"items": []}
+
+    def post(self, path, body=None, json=None):
+        self.calls.append(("POST", path, json or body))
+        return {"status": "ok"}
+
+
+def _run(monkeypatch, argv, fake):
+    monkeypatch.setattr(cli_main, "TaosClient", lambda **k: fake)
+    return cli_main.main(argv)
+
+
+def test_store_list_calls_catalog(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["store", "list"], fake)
+    assert rc == 0
+    assert ("GET", "/api/store/catalog", None) in fake.calls
+
+
+def test_store_list_with_type_filter(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["store", "list", "--type", "model"], fake)
+    assert rc == 0
+    assert any(c[0] == "GET" and c[1] == "/api/store/catalog" and c[2] == {"type": "model"} for c in fake.calls)
+
+
+def test_store_list_with_query(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["store", "list", "--query", "llama"], fake)
+    assert rc == 0
+    assert any(c[0] == "GET" and c[1] == "/api/store/catalog" and c[2] == {"query": "llama"} for c in fake.calls)
+
+
+def test_store_installed_calls_endpoint(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["store", "installed"], fake)
+    assert rc == 0
+    assert ("GET", "/api/store/installed", None) in fake.calls
+
+
+def test_store_get_calls_app_endpoint(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["store", "get", "llama-cpp"], fake)
+    assert rc == 0
+    assert ("GET", "/api/store/app/llama-cpp", None) in fake.calls
+
+
+def test_store_get_url_encodes_app_id(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["store", "get", "a/b c"], fake)
+    assert rc == 0
+    assert ("GET", "/api/store/app/a%2Fb%20c", None) in fake.calls
+
+
+def test_store_popularity_calls_endpoint(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["store", "popularity"], fake)
+    assert rc == 0
+    assert ("GET", "/api/store/popularity", None) in fake.calls
+
+
+def test_store_popularity_with_type_filter(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["store", "popularity", "--type", "plugin"], fake)
+    assert rc == 0
+    assert any(c[0] == "GET" and c[1] == "/api/store/popularity" and c[2] == {"type": "plugin"} for c in fake.calls)
+
+
+def test_store_install_posts_app_id(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["store", "install", "llama-cpp"], fake)
+    assert rc == 0
+    assert ("POST", "/api/store/install", {"app_id": "llama-cpp"}) in fake.calls
+
+
+def test_store_install_with_variant(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["store", "install", "llama-cpp", "--variant-id", "7b-q4"], fake)
+    assert rc == 0
+    assert ("POST", "/api/store/install", {"app_id": "llama-cpp", "variant_id": "7b-q4"}) in fake.calls
+
+
+def test_store_uninstall_posts_app_id(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["store", "uninstall", "llama-cpp"], fake)
+    assert rc == 0
+    assert ("POST", "/api/store/uninstall", {"app_id": "llama-cpp"}) in fake.calls
+
+
+def test_store_sync_calls_endpoint(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["store", "sync"], fake)
+    assert rc == 0
+    assert ("POST", "/api/store/sync", None) in fake.calls

--- a/tinyagentos/cli/taosctl/commands/store.py
+++ b/tinyagentos/cli/taosctl/commands/store.py
@@ -1,0 +1,81 @@
+"""taosctl store -- inspect and manage the app store catalog."""
+from __future__ import annotations
+
+from urllib.parse import quote
+
+NOUN = "store"
+
+
+def register(subparsers) -> None:
+    p = subparsers.add_parser(NOUN, help="Inspect and manage the app store catalog")
+    verbs = p.add_subparsers(dest="verb", required=True, metavar="<verb>")
+
+    lp = verbs.add_parser("list", help="List all apps in the catalog")
+    lp.add_argument("--type", default=None, help="Filter by app type")
+    lp.add_argument("--query", default=None, help="Filter by name/description")
+    lp.set_defaults(func=_list)
+
+    ip = verbs.add_parser("installed", help="List currently installed apps")
+    ip.set_defaults(func=_installed)
+
+    gp = verbs.add_parser("get", help="Get one app by id")
+    gp.add_argument("app_id", help="App id")
+    gp.set_defaults(func=_get)
+
+    pp = verbs.add_parser("popularity", help="List popularity data per app")
+    pp.add_argument("--type", default=None, help="Filter by app type")
+    pp.set_defaults(func=_popularity)
+
+    inp = verbs.add_parser("install", help="Install an app from the catalog")
+    inp.add_argument("app_id", help="App id")
+    inp.add_argument("--variant-id", default=None, help="Model variant id")
+    inp.set_defaults(func=_install)
+
+    unp = verbs.add_parser("uninstall", help="Uninstall an installed app")
+    unp.add_argument("app_id", help="App id")
+    unp.set_defaults(func=_uninstall)
+
+    sp = verbs.add_parser("sync", help="Sync the app catalog from the git repository")
+    sp.set_defaults(func=_sync)
+
+    # POST /api/store/resolve -- skipped: complex nested body (manifest_id,
+    # variant_id, target_remote, force) that does not map cleanly to argparse.
+
+
+def _list(args, client):
+    params = {}
+    if args.type:
+        params["type"] = args.type
+    if args.query:
+        params["query"] = args.query
+    return client.get("/api/store/catalog", params=params or None)
+
+
+def _installed(args, client):
+    return client.get("/api/store/installed")
+
+
+def _get(args, client):
+    return client.get(f"/api/store/app/{quote(args.app_id, safe='')}")
+
+
+def _popularity(args, client):
+    params = {}
+    if args.type:
+        params["type"] = args.type
+    return client.get("/api/store/popularity", params=params or None)
+
+
+def _install(args, client):
+    body = {"app_id": args.app_id}
+    if args.variant_id:
+        body["variant_id"] = args.variant_id
+    return client.post("/api/store/install", json=body)
+
+
+def _uninstall(args, client):
+    return client.post("/api/store/uninstall", json={"app_id": args.app_id})
+
+
+def _sync(args, client):
+    return client.post("/api/store/sync")


### PR DESCRIPTION
Autonomous build of board card tsk-o34mhq.

Adds taosctl store with verbs: list, installed, get, popularity, install,
uninstall, sync. Each handler calls the corresponding store API endpoint
and returns data for the framework to render. Mirrors the agents.py
command pattern exactly.

Files:
 tests/test_taosctl_store.py               | 108 ++++++++++++++++++++++++++++++
 tinyagentos/cli/taosctl/commands/store.py |  81 ++++++++++++++++++++++
 2 files changed, 189 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added app store management features to browse available apps with filtering options, view installed applications, retrieve app details, check popularity rankings, install and uninstall apps, and synchronize the app catalog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->