### PR TITLE
feat(agent-registry): notify on agent rename via PATCH

### DIFF
--- a/tests/test_agent_alias.py
+++ b/tests/test_agent_alias.py
@@ -1,0 +1,107 @@
+"""Tests for the agent rename (alias) endpoint.
+
+Covers:
+  - PATCH display_name updates the stored value and GET reflects it.
+  - PATCH with the same display_name is a no-op (no notification emitted).
+  - PATCH on an unknown canonical_id returns 404.
+"""
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest_asyncio.fixture
+async def client(app, tmp_data_dir):
+    """Async client with agent_registry store initialised, authenticated as admin."""
+    registry_store = app.state.agent_registry
+    if registry_store._db is None:
+        await registry_store.init()
+
+    notif_store = app.state.notifications
+    if notif_store._db is not None:
+        await notif_store.close()
+    await notif_store.init()
+
+    app.state.auth.setup_user("admin", "Test Admin", "", "testpass")
+    record = app.state.auth.find_user("admin")
+    uid = record["id"] if record else ""
+    token = app.state.auth.create_session(user_id=uid, long_lived=True)
+    app.state._startup_complete = True
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        cookies={"taos_session": token},
+    ) as c:
+        yield c
+
+    await registry_store.close()
+    await notif_store.close()
+
+
+@pytest.mark.asyncio
+async def test_rename_updates_display_name(client):
+    """Renaming an agent updates display_name and GET reflects the change."""
+    reg = await client.post(
+        "/api/agents/registry/register",
+        json={"framework": "openclaw", "display_name": "Original Name"},
+    )
+    assert reg.status_code == 200, reg.text
+    canonical_id = reg.json()["canonical_id"]
+
+    patch = await client.patch(
+        f"/api/agents/registry/{canonical_id}",
+        json={"display_name": "Renamed Agent"},
+    )
+    assert patch.status_code == 200, patch.text
+    assert patch.json()["display_name"] == "Renamed Agent"
+
+    get_resp = await client.get(f"/api/agents/registry/{canonical_id}")
+    assert get_resp.status_code == 200, get_resp.text
+    assert get_resp.json()["display_name"] == "Renamed Agent"
+
+    notifs = await client.get("/api/notifications")
+    assert notifs.status_code == 200, notifs.text
+    items = notifs.json() if isinstance(notifs.json(), list) else notifs.json().get("notifications", [])
+    assert any(
+        n.get("source") == "agent_registry" and "Renamed Agent" in n.get("message", "")
+        for n in items
+    ), f"expected agent_registry rename notification, got: {items}"
+
+
+@pytest.mark.asyncio
+async def test_rename_same_value_is_noop(client):
+    """PATCH with the same display_name does not emit a notification."""
+    reg = await client.post(
+        "/api/agents/registry/register",
+        json={"framework": "openclaw", "display_name": "Same Name"},
+    )
+    assert reg.status_code == 200, reg.text
+    canonical_id = reg.json()["canonical_id"]
+
+    await client.post("/api/notifications/read-all")
+
+    patch = await client.patch(
+        f"/api/agents/registry/{canonical_id}",
+        json={"display_name": "Same Name"},
+    )
+    assert patch.status_code == 200, patch.text
+    assert patch.json()["display_name"] == "Same Name"
+
+    notifs = await client.get("/api/notifications")
+    assert notifs.status_code == 200, notifs.text
+    items = notifs.json() if isinstance(notifs.json(), list) else notifs.json().get("notifications", [])
+    agent_notifs = [n for n in items if n.get("source") == "agent_registry"]
+    assert len(agent_notifs) == 0, f"expected no agent_registry notifications, got: {agent_notifs}"
+
+
+@pytest.mark.asyncio
+async def test_rename_unknown_agent_returns_404(client):
+    """PATCH on a non-existent canonical_id returns 404."""
+    patch = await client.patch(
+        "/api/agents/registry/nonexistent-20260101-000000",
+        json={"display_name": "New Name"},
+    )
+    assert patch.status_code == 404, patch.text

--- a/tinyagentos/routes/agent_registry.py
+++ b/tinyagentos/routes/agent_registry.py
@@ -388,16 +388,25 @@ async def patch_registry_entry(
         role=body.role,
         capabilities=body.capabilities,
     )
+    if updated is None:
+        # The entry was revoked/removed between the get and the update; do not
+        # emit a rename notification for a row that no longer exists.
+        return JSONResponse({"error": "not found"}, status_code=404)
     new_name = body.display_name
     if new_name is not None and new_name != old_name:
         notif_store = getattr(request.app.state, "notifications", None)
         if notif_store is not None:
-            await notif_store.add(
-                title="Agent renamed",
-                message=f"Agent {canonical_id} renamed from {old_name!r} to {new_name!r}",
-                level="info",
-                source="agent_registry",
-            )
+            # Best effort: the rename has already persisted, so a notification
+            # failure must not turn a successful update into a 500.
+            try:
+                await notif_store.add(
+                    title="Agent renamed",
+                    message=f"Agent {canonical_id} renamed from {old_name!r} to {new_name!r}",
+                    level="info",
+                    source="agent_registry",
+                )
+            except Exception:
+                logger.warning("rename notification failed for %s", canonical_id, exc_info=True)
     return updated
 
 

--- a/tinyagentos/routes/agent_registry.py
+++ b/tinyagentos/routes/agent_registry.py
@@ -380,6 +380,7 @@ async def patch_registry_entry(
     if record is None:
         return JSONResponse({"error": "not found"}, status_code=404)
     require_owner_or_admin(user, record["user_id"])
+    old_name = record.get("display_name") or ""
     updated = await store.update(
         canonical_id,
         display_name=body.display_name,
@@ -387,6 +388,16 @@ async def patch_registry_entry(
         role=body.role,
         capabilities=body.capabilities,
     )
+    new_name = body.display_name
+    if new_name is not None and new_name != old_name:
+        notif_store = getattr(request.app.state, "notifications", None)
+        if notif_store is not None:
+            await notif_store.add(
+                title="Agent renamed",
+                message=f"Agent {canonical_id} renamed from {old_name!r} to {new_name!r}",
+                level="info",
+                source="agent_registry",
+            )
     return updated
 
 


### PR DESCRIPTION
Autonomous build of board card tsk-7l6mb4.

Add notify-on-change to the existing PATCH /api/agents/registry/{id} route.
When display_name actually changes (old != new), a notification is emitted
through the notification store on app.state. Renaming to the same value is
a no-op (no notification). Unknown canonical_id still returns 404.

Tests cover: rename updates display_name and GET reflects it, same-value
rename is a no-op, unknown id returns 404.

Files:
 tests/test_agent_alias.py            | 107 +++++++++++++++++++++++++++++++++++
 tinyagentos/routes/agent_registry.py |  11 ++++
 2 files changed, 118 insertions(+)