### PR TITLE
feat(taosctl): add mail command group wrapping mail API routes

### DIFF
--- a/tests/test_taosctl_mail.py
+++ b/tests/test_taosctl_mail.py
@@ -1,0 +1,134 @@
+"""Tests for the taosctl mail command group: verify each verb hits the correct
+endpoint path using a fake client driven through __main__.main()."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tinyagentos.cli.taosctl import __main__ as cli_main
+
+
+class _FakeClient:
+    def __init__(self, *a, **k):
+        self.calls = []
+        self.base_url = "http://x"
+        self.token = "t"
+        self._raise = None
+
+    def get(self, path, params=None):
+        self.calls.append(("GET", path, params))
+        if self._raise:
+            raise self._raise
+        return {}
+
+    def post(self, path, json=None, params=None):
+        self.calls.append(("POST", path, json))
+        if self._raise:
+            raise self._raise
+        return {}
+
+    def delete(self, path, params=None):
+        self.calls.append(("DELETE", path, params))
+        if self._raise:
+            raise self._raise
+        return {}
+
+
+def _run(monkeypatch, argv, fake):
+    monkeypatch.setattr(cli_main, "TaosClient", lambda **k: fake)
+    return cli_main.main(argv)
+
+
+def test_mail_list(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["mail", "list"], fake)
+    assert rc == 0
+    assert ("GET", "/api/mail/accounts", None) in fake.calls
+
+
+def test_mail_create(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, [
+        "mail", "create",
+        "--email", "u@x.dev",
+        "--imap-host", "imap.x.dev",
+        "--smtp-host", "smtp.x.dev",
+        "--username", "u",
+        "--password", "p",
+    ], fake)
+    assert rc == 0
+    call = next(c for c in fake.calls if c[0] == "POST")
+    assert call[1] == "/api/mail/accounts"
+    assert call[2]["email_address"] == "u@x.dev"
+
+
+def test_mail_delete(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["mail", "delete", "abc-123"], fake)
+    assert rc == 0
+    assert ("DELETE", "/api/mail/accounts/abc-123", None) in fake.calls
+
+
+def test_mail_delete_url_encodes_id(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["mail", "delete", "a/b c"], fake)
+    assert rc == 0
+    assert ("DELETE", "/api/mail/accounts/a%2Fb%20c", None) in fake.calls
+
+
+def test_mail_folders(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["mail", "folders", "acc-1"], fake)
+    assert rc == 0
+    assert ("GET", "/api/mail/accounts/acc-1/folders", None) in fake.calls
+
+
+def test_mail_messages(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["mail", "messages", "acc-1", "--folder", "Sent", "--limit", "10"], fake)
+    assert rc == 0
+    call = next(c for c in fake.calls if c[0] == "GET")
+    assert call[1] == "/api/mail/accounts/acc-1/messages"
+    assert call[2] == {"folder": "Sent", "limit": 10}
+
+
+def test_mail_get(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["mail", "get", "acc-1", "42", "--folder", "INBOX"], fake)
+    assert rc == 0
+    call = next(c for c in fake.calls if c[0] == "GET")
+    assert call[1] == "/api/mail/accounts/acc-1/messages/42"
+    assert call[2] == {"folder": "INBOX"}
+
+
+def test_mail_get_url_encodes_uid(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["mail", "get", "acc-1", "4 2/3"], fake)
+    assert rc == 0
+    call = next(c for c in fake.calls if c[0] == "GET")
+    assert call[1] == "/api/mail/accounts/acc-1/messages/4%202%2F3"
+
+
+def test_mail_send(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, [
+        "mail", "send", "acc-1",
+        "--to", "b@x.dev",
+        "--subject", "hi",
+        "--body", "hello",
+        "--cc", "c@x.dev",
+    ], fake)
+    assert rc == 0
+    call = next(c for c in fake.calls if c[0] == "POST")
+    assert call[1] == "/api/mail/accounts/acc-1/send"
+    assert call[2]["to"] == "b@x.dev"
+    assert call[2]["subject"] == "hi"
+    assert call[2]["body"] == "hello"
+    assert call[2]["cc"] == "c@x.dev"
+
+
+def test_mail_noun_is_discovered():
+    from tinyagentos.cli.taosctl.commands import iter_noun_modules
+    nouns = {m.NOUN for m in iter_noun_modules()}
+    assert "mail" in nouns

--- a/tests/test_taosctl_mail.py
+++ b/tests/test_taosctl_mail.py
@@ -132,3 +132,23 @@ def test_mail_noun_is_discovered():
     from tinyagentos.cli.taosctl.commands import iter_noun_modules
     nouns = {m.NOUN for m in iter_noun_modules()}
     assert "mail" in nouns
+
+
+def test_resolve_password_precedence(monkeypatch):
+    from tinyagentos.cli.taosctl.commands.mail import _resolve_password
+    import argparse
+
+    # explicit arg wins
+    a = argparse.Namespace(password="from-arg")
+    monkeypatch.setenv("TAOS_MAIL_PASSWORD", "from-env")
+    assert _resolve_password(a) == "from-arg"
+
+    # env var used when no arg (no command-line exposure)
+    b = argparse.Namespace(password=None)
+    assert _resolve_password(b) == "from-env"
+
+    # falls through to prompt when neither present
+    c = argparse.Namespace(password=None)
+    monkeypatch.delenv("TAOS_MAIL_PASSWORD", raising=False)
+    monkeypatch.setattr("getpass.getpass", lambda *_: "from-prompt")
+    assert _resolve_password(c) == "from-prompt"

--- a/tinyagentos/cli/taosctl/commands/mail.py
+++ b/tinyagentos/cli/taosctl/commands/mail.py
@@ -5,6 +5,8 @@ that call the client and return data for the framework to render).
 """
 from __future__ import annotations
 
+import getpass
+import os
 from urllib.parse import quote
 
 NOUN = "mail"
@@ -24,7 +26,10 @@ def register(subparsers) -> None:
     cp.add_argument("--smtp-host", required=True, help="SMTP server hostname")
     cp.add_argument("--smtp-port", type=int, default=587, help="SMTP port")
     cp.add_argument("--username", required=True, help="Account username")
-    cp.add_argument("--password", required=True, help="Account password")
+    cp.add_argument("--password", default=None,
+                    help="Account password. Prefer the TAOS_MAIL_PASSWORD env var or the "
+                         "interactive prompt; a password on the command line is visible to "
+                         "other processes.")
     cp.add_argument("--display-name", default="", help="Display name")
     cp.set_defaults(func=_create)
 
@@ -63,6 +68,18 @@ def _list(args, client):
     return client.get("/api/mail/accounts")
 
 
+def _resolve_password(args):
+    """Resolve the account password without requiring it on the command line
+    (which would be visible in the process list). Precedence: explicit --password,
+    then the TAOS_MAIL_PASSWORD env var, then an interactive prompt."""
+    if args.password is not None:
+        return args.password
+    env = os.environ.get("TAOS_MAIL_PASSWORD")
+    if env:
+        return env
+    return getpass.getpass("Account password: ")
+
+
 def _create(args, client):
     return client.post("/api/mail/accounts", json={
         "display_name": args.display_name,
@@ -72,7 +89,7 @@ def _create(args, client):
         "smtp_host": args.smtp_host,
         "smtp_port": args.smtp_port,
         "username": args.username,
-        "password": args.password,
+        "password": _resolve_password(args),
     })
 
 

--- a/tinyagentos/cli/taosctl/commands/mail.py
+++ b/tinyagentos/cli/taosctl/commands/mail.py
@@ -1,0 +1,105 @@
+"""taosctl mail -- inspect and manage mail accounts.
+
+Reference noun: mirrors the agents pattern (NOUN, register(), small handlers
+that call the client and return data for the framework to render).
+"""
+from __future__ import annotations
+
+from urllib.parse import quote
+
+NOUN = "mail"
+
+
+def register(subparsers) -> None:
+    p = subparsers.add_parser(NOUN, help="Inspect and manage mail accounts")
+    verbs = p.add_subparsers(dest="verb", required=True, metavar="<verb>")
+
+    lp = verbs.add_parser("list", help="List mail accounts")
+    lp.set_defaults(func=_list)
+
+    cp = verbs.add_parser("create", help="Add a mail account")
+    cp.add_argument("--email", required=True, help="Email address")
+    cp.add_argument("--imap-host", required=True, help="IMAP server hostname")
+    cp.add_argument("--imap-port", type=int, default=993, help="IMAP port")
+    cp.add_argument("--smtp-host", required=True, help="SMTP server hostname")
+    cp.add_argument("--smtp-port", type=int, default=587, help="SMTP port")
+    cp.add_argument("--username", required=True, help="Account username")
+    cp.add_argument("--password", required=True, help="Account password")
+    cp.add_argument("--display-name", default="", help="Display name")
+    cp.set_defaults(func=_create)
+
+    dp = verbs.add_parser("delete", help="Delete a mail account")
+    dp.add_argument("account_id", help="Account id")
+    dp.set_defaults(func=_delete)
+
+    fp = verbs.add_parser("folders", help="List IMAP folders for an account")
+    fp.add_argument("account_id", help="Account id")
+    fp.set_defaults(func=_folders)
+
+    mp = verbs.add_parser("messages", help="List messages in an account folder")
+    mp.add_argument("account_id", help="Account id")
+    mp.add_argument("--folder", default="INBOX", help="Folder name")
+    mp.add_argument("--limit", type=int, default=50, help="Max messages")
+    mp.set_defaults(func=_messages)
+
+    gp = verbs.add_parser("get", help="Get a single message by uid")
+    gp.add_argument("account_id", help="Account id")
+    gp.add_argument("uid", help="Message uid")
+    gp.add_argument("--folder", default="INBOX", help="Folder name")
+    gp.set_defaults(func=_get)
+
+    sp = verbs.add_parser("send", help="Send an email")
+    sp.add_argument("account_id", help="Account id")
+    sp.add_argument("--to", required=True, help="Recipient address")
+    sp.add_argument("--subject", default="", help="Subject line")
+    sp.add_argument("--body", default="", help="Message body")
+    sp.add_argument("--cc", default="", help="CC address")
+    sp.set_defaults(func=_send)
+
+    # TODO: agent send-as profile switcher (Phase 2, needs consent layer)
+
+
+def _list(args, client):
+    return client.get("/api/mail/accounts")
+
+
+def _create(args, client):
+    return client.post("/api/mail/accounts", json={
+        "display_name": args.display_name,
+        "email_address": args.email,
+        "imap_host": args.imap_host,
+        "imap_port": args.imap_port,
+        "smtp_host": args.smtp_host,
+        "smtp_port": args.smtp_port,
+        "username": args.username,
+        "password": args.password,
+    })
+
+
+def _delete(args, client):
+    return client.delete(f"/api/mail/accounts/{quote(args.account_id, safe='')}")
+
+
+def _folders(args, client):
+    return client.get(f"/api/mail/accounts/{quote(args.account_id, safe='')}/folders")
+
+
+def _messages(args, client):
+    return client.get(
+        f"/api/mail/accounts/{quote(args.account_id, safe='')}/messages",
+        params={"folder": args.folder, "limit": args.limit},
+    )
+
+
+def _get(args, client):
+    return client.get(
+        f"/api/mail/accounts/{quote(args.account_id, safe='')}/messages/{quote(args.uid, safe='')}",
+        params={"folder": args.folder},
+    )
+
+
+def _send(args, client):
+    return client.post(
+        f"/api/mail/accounts/{quote(args.account_id, safe='')}/send",
+        json={"to": args.to, "subject": args.subject, "body": args.body, "cc": args.cc},
+    )


### PR DESCRIPTION
Autonomous build of board card tsk-3uib7j.

Adds taosctl mail with verbs: list, create, delete, folders, messages,
get, send. Mirrors the agents.py pattern (NOUN, register(), small
handlers calling client.get/post/delete). Auto-discovered via
iter_noun_modules. Tests in test_taosctl_mail.py cover all verbs
with a fake client asserting correct endpoint paths.

Files:
 tests/test_taosctl_mail.py               | 134 +++++++++++++++++++++++++++++++
 tinyagentos/cli/taosctl/commands/mail.py | 105 ++++++++++++++++++++++++
 2 files changed, 239 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `taosctl mail` command group enabling email account management—list, create, and delete accounts; browse folders; retrieve and send messages with full IMAP/SMTP configuration support.

* **Tests**
  * Added comprehensive test suite validating mail command functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->