### PR TITLE
feat(taosctl): add secrets command group

### DIFF
--- a/tests/test_taosctl_secrets.py
+++ b/tests/test_taosctl_secrets.py
@@ -1,0 +1,136 @@
+"""Tests for the taosctl secrets command group."""
+from __future__ import annotations
+
+import pytest
+
+from tinyagentos.cli.taosctl import client as cli_client
+from tinyagentos.cli.taosctl import __main__ as cli_main
+from tinyagentos.cli.taosctl.commands import iter_noun_modules
+
+
+class _FakeClient:
+    def __init__(self, *a, **k):
+        self.calls = []
+        self.base_url = "http://x"
+        self.token = "t"
+        self._raise = None
+
+    def get(self, path, params=None):
+        self.calls.append(("GET", path))
+        if self._raise:
+            raise self._raise
+        return {"items": [{"name": "db-pass", "category": "general"}]}
+
+    def post(self, path, body=None, params=None, json=None):
+        self.calls.append(("POST", path))
+        if self._raise:
+            raise self._raise
+        return {"id": "db-pass", "status": "created"}
+
+    def patch(self, path, body=None, json=None):
+        self.calls.append(("PUT", path))
+        if self._raise:
+            raise self._raise
+        return {"status": "updated"}
+
+    def delete(self, path, params=None):
+        self.calls.append(("DELETE", path))
+        if self._raise:
+            raise self._raise
+        return {"status": "deleted"}
+
+
+def _run(monkeypatch, argv, fake):
+    monkeypatch.setattr(cli_main, "TaosClient", lambda **k: fake)
+    return cli_main.main(argv)
+
+
+def test_secrets_noun_is_discovered():
+    nouns = {m.NOUN for m in iter_noun_modules()}
+    assert "secrets" in nouns
+
+
+def test_secrets_list_calls_endpoint(monkeypatch, capsys):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["secrets", "list"], fake)
+    assert rc == 0
+    assert ("GET", "/api/secrets") in fake.calls
+
+
+def test_secrets_list_with_category(monkeypatch, capsys):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["secrets", "list", "--category", "db"], fake)
+    assert rc == 0
+    assert ("GET", "/api/secrets") in fake.calls
+
+
+def test_secrets_get_calls_endpoint(monkeypatch, capsys):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["--json", "secrets", "get", "db-pass"], fake)
+    assert rc == 0
+    assert ("GET", "/api/secrets/db-pass") in fake.calls
+
+
+def test_secrets_get_url_encodes_name(monkeypatch, capsys):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["--json", "secrets", "get", "a/b c"], fake)
+    assert rc == 0
+    assert ("GET", "/api/secrets/a%2Fb%20c") in fake.calls
+
+
+def test_secrets_create_calls_endpoint(monkeypatch, capsys):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["--json", "secrets", "create", "new-pass", "s3cret"], fake)
+    assert rc == 0
+    assert ("POST", "/api/secrets") in fake.calls
+
+
+def test_secrets_create_with_options(monkeypatch, capsys):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["--json", "secrets", "create", "new-pass", "s3cret", "--category", "db", "--description", "main db"], fake)
+    assert rc == 0
+    assert ("POST", "/api/secrets") in fake.calls
+
+
+def test_secrets_update_calls_endpoint(monkeypatch, capsys):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["--json", "secrets", "update", "db-pass", "--value", "new-val"], fake)
+    assert rc == 0
+    assert ("PUT", "/api/secrets/db-pass") in fake.calls
+
+
+def test_secrets_update_url_encodes_name(monkeypatch, capsys):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["--json", "secrets", "update", "a/b", "--category", "x"], fake)
+    assert rc == 0
+    assert ("PUT", "/api/secrets/a%2Fb") in fake.calls
+
+
+def test_secrets_delete_calls_endpoint(monkeypatch, capsys):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["--json", "secrets", "delete", "db-pass"], fake)
+    assert rc == 0
+    assert ("DELETE", "/api/secrets/db-pass") in fake.calls
+
+
+def test_secrets_delete_url_encodes_name(monkeypatch, capsys):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["--json", "secrets", "delete", "x y"], fake)
+    assert rc == 0
+    assert ("DELETE", "/api/secrets/x%20y") in fake.calls
+
+
+def test_secrets_api_error_maps_to_exit_2(monkeypatch, capsys):
+    fake = _FakeClient()
+    fake._raise = cli_client.ApiError(404, "no such secret")
+    rc = _run(monkeypatch, ["secrets", "get", "ghost"], fake)
+    assert rc == 2
+    assert "no such secret" in capsys.readouterr().err
+
+
+def test_secrets_transport_error_maps_to_exit_1(monkeypatch, capsys):
+    fake = _FakeClient()
+    fake._raise = cli_client.TransportError("cannot reach http://x: refused")
+    rc = _run(monkeypatch, ["secrets", "list"], fake)
+    assert rc == 1
+    assert "cannot reach" in capsys.readouterr().err

--- a/tests/test_taosctl_secrets.py
+++ b/tests/test_taosctl_secrets.py
@@ -27,7 +27,7 @@ class _FakeClient:
             raise self._raise
         return {"id": "db-pass", "status": "created"}
 
-    def patch(self, path, body=None, json=None):
+    def put(self, path, body=None, json=None):
         self.calls.append(("PUT", path))
         if self._raise:
             raise self._raise

--- a/tinyagentos/cli/taosctl/client.py
+++ b/tinyagentos/cli/taosctl/client.py
@@ -97,6 +97,9 @@ class TaosClient:
         # `body` wins if both are given.
         return self.request("POST", path, params=params, body=body if body is not None else json)
 
+    def put(self, path: str, body: Optional[Any] = None, json: Optional[Any] = None) -> Any:
+        return self.request("PUT", path, body=body if body is not None else json)
+
     def patch(self, path: str, body: Optional[Any] = None, json: Optional[Any] = None) -> Any:
         return self.request("PATCH", path, body=body if body is not None else json)
 

--- a/tinyagentos/cli/taosctl/commands/secrets.py
+++ b/tinyagentos/cli/taosctl/commands/secrets.py
@@ -1,0 +1,76 @@
+"""taosctl secrets -- inspect and manage secrets."""
+from __future__ import annotations
+
+from urllib.parse import quote
+
+NOUN = "secrets"
+
+
+def register(subparsers) -> None:
+    p = subparsers.add_parser(NOUN, help="Inspect and manage secrets")
+    verbs = p.add_subparsers(dest="verb", required=True, metavar="<verb>")
+
+    lp = verbs.add_parser("list", help="List all secrets")
+    lp.add_argument("--category", help="Filter by category", default=None)
+    lp.set_defaults(func=_list)
+
+    gp = verbs.add_parser("get", help="Get one secret by name")
+    gp.add_argument("name", help="Secret name")
+    gp.set_defaults(func=_get)
+
+    cp = verbs.add_parser("create", help="Create a secret")
+    cp.add_argument("name", help="Secret name")
+    cp.add_argument("value", help="Secret value")
+    cp.add_argument("--category", default="general", help="Category (default: general)")
+    cp.add_argument("--description", default="", help="Description")
+    cp.set_defaults(func=_create)
+
+    up = verbs.add_parser("update", help="Update a secret")
+    up.add_argument("name", help="Secret name")
+    up.add_argument("--value", default=None, help="New value")
+    up.add_argument("--category", default=None, help="New category")
+    up.add_argument("--description", default=None, help="New description")
+    up.set_defaults(func=_update)
+
+    dp = verbs.add_parser("delete", help="Delete a secret")
+    dp.add_argument("name", help="Secret name")
+    dp.set_defaults(func=_delete)
+
+    # Skipped: GET /api/secrets/categories (no simple verb mapping)
+    # Skipped: GET /api/secrets/agent/{agent_name} (agent-scoped listing)
+
+
+def _list(args, client):
+    params = {}
+    if args.category:
+        params["category"] = args.category
+    return client.get("/api/secrets", params=params or None)
+
+
+def _get(args, client):
+    return client.get(f"/api/secrets/{quote(args.name, safe='')}")
+
+
+def _create(args, client):
+    body = {
+        "name": args.name,
+        "value": args.value,
+        "category": args.category,
+        "description": args.description,
+    }
+    return client.post("/api/secrets", json=body)
+
+
+def _update(args, client):
+    body = {}
+    if args.value is not None:
+        body["value"] = args.value
+    if args.category is not None:
+        body["category"] = args.category
+    if args.description is not None:
+        body["description"] = args.description
+    return client.patch(f"/api/secrets/{quote(args.name, safe='')}", json=body)
+
+
+def _delete(args, client):
+    return client.delete(f"/api/secrets/{quote(args.name, safe='')}")

--- a/tinyagentos/cli/taosctl/commands/secrets.py
+++ b/tinyagentos/cli/taosctl/commands/secrets.py
@@ -69,7 +69,7 @@ def _update(args, client):
         body["category"] = args.category
     if args.description is not None:
         body["description"] = args.description
-    return client.patch(f"/api/secrets/{quote(args.name, safe='')}", json=body)
+    return client.put(f"/api/secrets/{quote(args.name, safe='')}", json=body)
 
 
 def _delete(args, client):


### PR DESCRIPTION
Autonomous build of board card tsk-3sg5ps.

Add taosctl secrets with list, get, create, update, and delete verbs
wrapping the /api/secrets endpoints. Mirrors the agents command
structure with auto-discovery via NOUN + register().

Files:
 tests/test_taosctl_secrets.py               | 136 ++++++++++++++++++++++++++++
 tinyagentos/cli/taosctl/commands/secrets.py |  76 ++++++++++++++++
 2 files changed, 212 insertions(+)