### PR TITLE
test(taosctl): static gate for client methods + route coverage

### DIFF
--- a/tests/test_routes_tasks.py
+++ b/tests/test_routes_tasks.py
@@ -49,6 +49,23 @@ class TestTasksPage:
         resp = await client.put(f"/api/tasks/{task_id}", json={"name": "Updated"})
         assert resp.status_code == 200
 
+    async def test_get_task(self, client):
+        resp = await client.post("/api/tasks", json={
+            "name": "Fetch Me", "schedule": "0 * * * *", "command": "echo",
+        })
+        task_id = resp.json()["id"]
+        resp = await client.get(f"/api/tasks/{task_id}")
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "Fetch Me"
+
+    async def test_get_nonexistent_task(self, client):
+        resp = await client.get("/api/tasks/9999")
+        assert resp.status_code == 404
+
+    async def test_get_task_does_not_shadow_presets(self, client):
+        resp = await client.get("/api/tasks/presets")
+        assert resp.status_code == 200
+
     async def test_delete_task(self, client):
         resp = await client.post("/api/tasks", json={
             "name": "To Delete", "schedule": "0 * * * *", "command": "rm",

--- a/tests/test_taosctl_route_coverage.py
+++ b/tests/test_taosctl_route_coverage.py
@@ -1,0 +1,110 @@
+"""Static gate: every taosctl command must call a real client method on a real route.
+
+The taosctl command groups are thin wrappers over server API routes. Two classes
+of bug slip past the per-command unit tests (which mock the client): calling a
+client method that does not exist (e.g. client.put when the client has no put),
+and calling an API path that no server route serves (always 404). This test
+parses the command files with ast and checks both against the source of truth:
+TaosClient's methods and the app's registered routes.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+import yaml
+
+from tinyagentos.app import create_app
+from tinyagentos.cli.taosctl.client import TaosClient
+
+COMMANDS_DIR = pathlib.Path("tinyagentos/cli/taosctl/commands")
+HTTP_METHODS = {"get", "post", "put", "patch", "delete"}
+
+
+def _client_methods() -> set[str]:
+    return {m for m in HTTP_METHODS if callable(getattr(TaosClient, m, None))}
+
+
+def _norm(path: str) -> str:
+    """Drop the query string and collapse every {param} to {} so a command path
+    and a route template compare equal regardless of the param name."""
+    path = path.split("?", 1)[0]
+    out, depth = [], 0
+    for ch in path:
+        if ch == "{":
+            depth += 1
+            if depth == 1:
+                out.append("{}")
+        elif ch == "}":
+            depth = max(0, depth - 1)
+        elif depth == 0:
+            out.append(ch)
+    return "".join(out).rstrip("/") or "/"
+
+
+def _literal_path(node: ast.AST) -> str | None:
+    """Return the normalized path if the arg is a str literal or an f-string,
+    else None (dynamic paths are skipped, not failed)."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return _norm(node.value)
+    if isinstance(node, ast.JoinedStr):
+        parts = []
+        for v in node.values:
+            if isinstance(v, ast.Constant) and isinstance(v.value, str):
+                parts.append(v.value)
+            else:
+                parts.append("{}")  # an interpolated path param
+        return _norm("".join(parts))
+    return None
+
+
+def _client_calls():
+    """Yield (file, lineno, method, path_or_None) for every client.<method>(...) call."""
+    for pyfile in sorted(COMMANDS_DIR.glob("*.py")):
+        tree = ast.parse(pyfile.read_text(), filename=str(pyfile))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            fn = node.func
+            if not (isinstance(fn, ast.Attribute) and isinstance(fn.value, ast.Name)
+                    and fn.value.id == "client" and fn.attr in HTTP_METHODS):
+                continue
+            path = _literal_path(node.args[0]) if node.args else None
+            yield pyfile.name, node.lineno, fn.attr, path
+
+
+@pytest.fixture(scope="module")
+def routes(tmp_path_factory):
+    tmp = tmp_path_factory.mktemp("taosctl_routes")
+    (tmp / "config.yaml").write_text(yaml.dump({
+        "server": {"host": "0.0.0.0", "port": 6969},
+        "backends": [], "qmd": {"url": "http://localhost:7832"}, "agents": [],
+        "metrics": {"poll_interval": 30, "retention_days": 30},
+    }))
+    (tmp / ".setup_complete").touch()
+    app = create_app(data_dir=tmp)
+    pairs = set()
+    for r in app.routes:
+        for m in getattr(r, "methods", None) or []:
+            pairs.add((m.lower(), _norm(getattr(r, "path", ""))))
+    return pairs
+
+
+def test_client_methods_exist():
+    valid = _client_methods()
+    bad = [f"{f}:{ln} client.{m}()" for f, ln, m, _ in _client_calls() if m not in valid]
+    assert not bad, "taosctl calls a client method that does not exist: " + "; ".join(bad)
+
+
+def test_command_paths_have_routes(routes):
+    missing = []
+    for f, ln, method, path in _client_calls():
+        if path is None:
+            continue  # dynamic path, cannot check statically
+        if (method, path) not in routes:
+            missing.append(f"{f}:{ln} {method.upper()} {path}")
+    assert not missing, (
+        "taosctl calls API paths with no matching server route:\n  " + "\n  ".join(missing)
+    )

--- a/tinyagentos/routes/tasks.py
+++ b/tinyagentos/routes/tasks.py
@@ -65,6 +65,15 @@ async def apply_preset(request: Request, preset_id: int, body: PresetApply):
     return {"status": "applied", "tasks_created": count}
 
 
+@router.get("/api/tasks/{task_id}")
+async def get_task(request: Request, task_id: int):
+    scheduler = request.app.state.scheduler
+    task = await scheduler.get_task(task_id)
+    if task is None:
+        return JSONResponse({"error": "Task not found"}, status_code=404)
+    return task
+
+
 @router.put("/api/tasks/{task_id}")
 async def update_task(request: Request, task_id: int, body: TaskUpdate):
     scheduler = request.app.state.scheduler

--- a/tinyagentos/scheduler/task_scheduler.py
+++ b/tinyagentos/scheduler/task_scheduler.py
@@ -80,6 +80,17 @@ class TaskScheduler(BaseStore):
                      "command": r[4], "description": r[5], "enabled": bool(r[6]),
                      "last_run": r[7], "next_run": r[8]} for r in await cursor.fetchall()]
 
+    async def get_task(self, task_id: int) -> dict | None:
+        sql = ("SELECT id, name, agent_name, schedule, command, description, enabled, last_run, next_run "
+               "FROM scheduled_tasks WHERE id = ?")
+        async with self._db.execute(sql, (task_id,)) as cursor:
+            r = await cursor.fetchone()
+        if r is None:
+            return None
+        return {"id": r[0], "name": r[1], "agent_name": r[2], "schedule": r[3],
+                "command": r[4], "description": r[5], "enabled": bool(r[6]),
+                "last_run": r[7], "next_run": r[8]}
+
     async def update_task(self, task_id: int, **kwargs):
         for field in ["name", "schedule", "command", "description"]:
             if field in kwargs:


### PR DESCRIPTION
## Why
The owl lanes are generating taosctl command-group PRs, several of which gitar flagged for calling non-existent server routes or client methods (e.g. settings 'set-*' calling client.put which does not exist; notifications/themes 'get' hitting 404 routes). The per-command unit tests mock the client, so this whole class slips through, and gitar is now budget-paused.

## What
A static test (tests/test_taosctl_route_coverage.py) that, with ast:
- asserts every `client.<method>()` in the command files uses a real TaosClient method
- asserts every literal/f-string API path maps to a registered server route (params normalized, dynamic paths skipped)

It builds the real app to collect routes, so it stays in sync automatically.

## Pre-existing bug it caught
`taosctl tasks get` called `GET /api/tasks/{id}` with no handler. Added the natural endpoint (`scheduler.get_task` + route), placed after `/api/tasks/presets` so the typed int param does not shadow it. Tests added for get / 404 / preset-no-shadow.

## Impact
Going forward this fails CI on any taosctl command that targets a dead route or missing method, replacing the lost gitar coverage for this pattern. The current broken owl PRs (#1318/#1319/#1320/#1322 etc) will fail this gate until fixed.