### PR TITLE
feat(taosctl): add templates command group

### DIFF
--- a/tests/test_taosctl_templates.py
+++ b/tests/test_taosctl_templates.py
@@ -1,0 +1,91 @@
+"""Tests for the taosctl templates command group."""
+from __future__ import annotations
+
+import pytest
+
+from tinyagentos.cli.taosctl import client as cli_client
+from tinyagentos.cli.taosctl import __main__ as cli_main
+
+
+class _FakeClient:
+    def __init__(self, *a, **k):
+        self.calls = []
+        self.base_url = "http://x"
+        self.token = "t"
+        self._raise = None
+
+    def get(self, path, params=None):
+        self.calls.append(("GET", path))
+        if self._raise:
+            raise self._raise
+        if path == "/api/templates":
+            return {"templates": [{"id": "base", "name": "Base"}], "total": 1}
+        if path == "/api/templates/stats":
+            return {"total": 42, "categories": 5}
+        if path == "/api/templates/sources":
+            return {"sources": [{"id": "builtin"}, {"id": "awesome-openclaw"}]}
+        return {"id": "base", "name": "Base", "system_prompt": "..."}
+
+
+def _run(monkeypatch, argv, fake):
+    monkeypatch.setattr(cli_main, "TaosClient", lambda **k: fake)
+    return cli_main.main(argv)
+
+
+def test_templates_list_calls_endpoint(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["templates", "list"], fake)
+    assert rc == 0
+    assert ("GET", "/api/templates") in fake.calls
+
+
+def test_templates_list_passes_query_params(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["templates", "list", "--category", "coding", "--source", "builtin", "--limit", "10", "--offset", "5"], fake)
+    assert rc == 0
+    assert fake.calls[0][0] == "GET"
+    assert fake.calls[0][1] == "/api/templates"
+
+
+def test_templates_get_calls_endpoint(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["templates", "get", "base"], fake)
+    assert rc == 0
+    assert ("GET", "/api/templates/base") in fake.calls
+
+
+def test_templates_get_url_encodes_id(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["templates", "get", "a/b c"], fake)
+    assert rc == 0
+    assert ("GET", "/api/templates/a%2Fb%20c") in fake.calls
+
+
+def test_templates_stats_calls_endpoint(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["templates", "stats"], fake)
+    assert rc == 0
+    assert ("GET", "/api/templates/stats") in fake.calls
+
+
+def test_templates_sources_calls_endpoint(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["templates", "sources"], fake)
+    assert rc == 0
+    assert ("GET", "/api/templates/sources") in fake.calls
+
+
+def test_templates_api_error_maps_to_exit_2(monkeypatch, capsys):
+    fake = _FakeClient()
+    fake._raise = cli_client.ApiError(404, "no such template")
+    rc = _run(monkeypatch, ["templates", "get", "ghost"], fake)
+    assert rc == 2
+    assert "no such template" in capsys.readouterr().err
+
+
+def test_templates_transport_error_maps_to_exit_1(monkeypatch, capsys):
+    fake = _FakeClient()
+    fake._raise = cli_client.TransportError("cannot reach http://x: refused")
+    rc = _run(monkeypatch, ["templates", "list"], fake)
+    assert rc == 1
+    assert "cannot reach" in capsys.readouterr().err

--- a/tinyagentos/cli/taosctl/commands/templates.py
+++ b/tinyagentos/cli/taosctl/commands/templates.py
@@ -1,0 +1,56 @@
+"""taosctl templates -- inspect and manage agent templates."""
+from __future__ import annotations
+
+from urllib.parse import quote
+
+NOUN = "templates"
+
+
+def register(subparsers) -> None:
+    p = subparsers.add_parser(NOUN, help="Inspect and manage agent templates")
+    verbs = p.add_subparsers(dest="verb", required=True, metavar="<verb>")
+
+    lp = verbs.add_parser("list", help="List agent templates")
+    lp.add_argument("--category", help="Filter by category")
+    lp.add_argument("--source", help="Filter by source")
+    lp.add_argument("--limit", type=int, default=50, help="Page size (default 50)")
+    lp.add_argument("--offset", type=int, default=0, help="Page offset (default 0)")
+    lp.set_defaults(func=_list)
+
+    gp = verbs.add_parser("get", help="Get one template by ID")
+    gp.add_argument("template_id", help="Template ID")
+    gp.set_defaults(func=_get)
+
+    sp = verbs.add_parser("stats", help="Show template count stats")
+    sp.set_defaults(func=_stats)
+
+    sop = verbs.add_parser("sources", help="List external template sources")
+    sop.set_defaults(func=_sources)
+
+    # SKIP: external source listing/fetching endpoints need async HTTP client
+    # access via request.app.state.http_client and are not suitable for a simple
+    # CLI wrapper. Skipped: /api/templates/external/{source_id},
+    # /api/templates/external/{source_id}/fetch, /api/personas/library.
+
+
+def _list(args, client):
+    params = {}
+    if args.category:
+        params["category"] = args.category
+    if args.source:
+        params["source"] = args.source
+    params["limit"] = args.limit
+    params["offset"] = args.offset
+    return client.get("/api/templates", params=params)
+
+
+def _get(args, client):
+    return client.get(f"/api/templates/{quote(args.template_id, safe='')}")
+
+
+def _stats(args, client):
+    return client.get("/api/templates/stats")
+
+
+def _sources(args, client):
+    return client.get("/api/templates/sources")


### PR DESCRIPTION
Autonomous build of board card tsk-doqntk.

Add taosctl templates command group wrapping the templates API endpoints.
Supports list (with category/source/limit/offset filters), get (by ID),
stats, and sources verbs. Mirrors the existing agents.py command pattern
with module-level NOUN, register() wiring verb subparsers, and small
handlers that call client.get() and return data.

Files:
 tests/test_taosctl_templates.py               | 91 +++++++++++++++++++++++++++
 tinyagentos/cli/taosctl/commands/templates.py | 56 +++++++++++++++++
 2 files changed, 147 insertions(+)