### PR TITLE
feat(projects): GitHub issue -> board card sync

### DIFF
--- a/tests/test_github_sync.py
+++ b/tests/test_github_sync.py
@@ -87,7 +87,7 @@ async def test_route_sync_creates_cards_and_persists_repo(client, monkeypatch):
 
     async def fake_fetch(repo, state, token):
         assert repo == "owner/name"
-        return [_issue(1, "open issue", "open"), _issue(2, "done", "closed"), _issue(3, pr=True)]
+        return [_issue(1, "open issue", "open"), _issue(2, "done", "closed"), _issue(3, pr=True)], False
 
     monkeypatch.setattr(gh, "_fetch_issues", fake_fetch)
     pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
@@ -96,6 +96,7 @@ async def test_route_sync_creates_cards_and_persists_repo(client, monkeypatch):
     assert resp.status_code == 200
     body = resp.json()
     assert body["created"] == 2 and body["closed"] == 1 and body["skipped"] == 1
+    assert body["truncated"] is False
 
     # repo is remembered: a second call may omit it
     resp2 = await client.post(f"/api/projects/{pid}/github/sync", json={})
@@ -108,6 +109,28 @@ async def test_route_requires_repo(client):
     pid = (await client.post("/api/projects", json={"name": "B", "slug": "b"})).json()["id"]
     resp = await client.post(f"/api/projects/{pid}/github/sync", json={})
     assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_route_rejects_malformed_repo(client):
+    pid = (await client.post("/api/projects", json={"name": "C", "slug": "c"})).json()["id"]
+    for bad in ["../escape", "owneronly", "a/b/c", "owner/na me"]:
+        resp = await client.post(f"/api/projects/{pid}/github/sync", json={"repo": bad})
+        assert resp.status_code == 400, bad
+
+
+@pytest.mark.asyncio
+async def test_route_reports_truncation(client, monkeypatch):
+    import tinyagentos.routes.github_sync as gh
+
+    async def fake_fetch(repo, state, token):
+        return [_issue(1, "x", "open")], True
+
+    monkeypatch.setattr(gh, "_fetch_issues", fake_fetch)
+    pid = (await client.post("/api/projects", json={"name": "D", "slug": "d"})).json()["id"]
+    resp = await client.post(f"/api/projects/{pid}/github/sync", json={"repo": "o/n"})
+    assert resp.status_code == 200
+    assert resp.json()["truncated"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_github_sync.py
+++ b/tests/test_github_sync.py
@@ -1,0 +1,125 @@
+import pytest
+import pytest_asyncio
+
+from tinyagentos.projects.task_store import ProjectTaskStore
+from tinyagentos.github_sync import (
+    issue_marker,
+    is_pull_request,
+    sync_issues_to_board,
+)
+
+
+@pytest_asyncio.fixture
+async def store(tmp_path):
+    s = ProjectTaskStore(tmp_path / "tasks.db")
+    await s.init()
+    yield s
+    await s.close()
+
+
+def _issue(number, title="t", state="open", labels=None, pr=False, body="", url=""):
+    d = {
+        "number": number,
+        "title": title,
+        "state": state,
+        "labels": labels or [],
+        "body": body,
+        "html_url": url,
+    }
+    if pr:
+        d["pull_request"] = {"url": "x"}
+    return d
+
+
+def test_is_pull_request():
+    assert is_pull_request(_issue(1, pr=True))
+    assert not is_pull_request(_issue(1))
+
+
+@pytest.mark.asyncio
+async def test_creates_open_and_closed_cards(store):
+    issues = [
+        _issue(1, "open one", "open"),
+        _issue(2, "closed one", "closed"),
+    ]
+    res = await sync_issues_to_board(store, "p", issues)
+    assert res == {"created": 2, "closed": 1, "reopened": 0, "skipped": 0}
+    tasks = await store.list_tasks("p")
+    by_marker = {m: t for t in tasks for m in t["labels"] if m.startswith("gh-issue-")}
+    assert by_marker[issue_marker(1)]["status"] == "open"
+    assert by_marker[issue_marker(2)]["status"] == "closed"
+
+
+@pytest.mark.asyncio
+async def test_skips_pull_requests(store):
+    res = await sync_issues_to_board(store, "p", [_issue(5, pr=True)])
+    assert res["skipped"] == 1
+    assert res["created"] == 0
+    assert await store.list_tasks("p") == []
+
+
+@pytest.mark.asyncio
+async def test_idempotent_no_duplicates(store):
+    issues = [_issue(1, "x", "open")]
+    await sync_issues_to_board(store, "p", issues)
+    res = await sync_issues_to_board(store, "p", issues)
+    assert res["created"] == 0
+    assert len([t for t in await store.list_tasks("p") if issue_marker(1) in t["labels"]]) == 1
+
+
+@pytest.mark.asyncio
+async def test_closing_and_reopening_tracks_issue_state(store):
+    await sync_issues_to_board(store, "p", [_issue(1, "x", "open")])
+    # issue closed upstream
+    res = await sync_issues_to_board(store, "p", [_issue(1, "x", "closed")])
+    assert res["closed"] == 1
+    card = (await store.list_tasks("p"))[0]
+    assert card["status"] == "closed"
+    # issue reopened upstream
+    res = await sync_issues_to_board(store, "p", [_issue(1, "x", "open")])
+    assert res["reopened"] == 1
+    assert (await store.list_tasks("p"))[0]["status"] == "open"
+
+
+@pytest.mark.asyncio
+async def test_route_sync_creates_cards_and_persists_repo(client, monkeypatch):
+    import tinyagentos.routes.github_sync as gh
+
+    async def fake_fetch(repo, state, token):
+        assert repo == "owner/name"
+        return [_issue(1, "open issue", "open"), _issue(2, "done", "closed"), _issue(3, pr=True)]
+
+    monkeypatch.setattr(gh, "_fetch_issues", fake_fetch)
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+
+    resp = await client.post(f"/api/projects/{pid}/github/sync", json={"repo": "owner/name"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["created"] == 2 and body["closed"] == 1 and body["skipped"] == 1
+
+    # repo is remembered: a second call may omit it
+    resp2 = await client.post(f"/api/projects/{pid}/github/sync", json={})
+    assert resp2.status_code == 200
+    assert resp2.json()["created"] == 0  # idempotent
+
+
+@pytest.mark.asyncio
+async def test_route_requires_repo(client):
+    pid = (await client.post("/api/projects", json={"name": "B", "slug": "b"})).json()["id"]
+    resp = await client.post(f"/api/projects/{pid}/github/sync", json={})
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_route_unknown_project_404(client):
+    resp = await client.post("/api/projects/prj-missing/github/sync", json={"repo": "o/n"})
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_issue_labels_and_url_carried_onto_card(store):
+    issues = [_issue(1, "x", "open", labels=[{"name": "bug"}, "perf"], body="do it", url="http://gh/1")]
+    await sync_issues_to_board(store, "p", issues)
+    card = (await store.list_tasks("p"))[0]
+    assert "github" in card["labels"] and "bug" in card["labels"] and "perf" in card["labels"]
+    assert "http://gh/1" in card["body"]

--- a/tinyagentos/github_sync.py
+++ b/tinyagentos/github_sync.py
@@ -80,16 +80,16 @@ async def sync_issues_to_board(
             )
             created += 1
             if state == "closed":
-                await task_store.close_task(new["id"], closed_by=created_by, reason="issue closed on GitHub")
-                closed += 1
+                if await task_store.close_task(new["id"], closed_by=created_by, reason="issue closed on GitHub"):
+                    closed += 1
             continue
 
         status = card.get("status")
         if state == "closed" and status != "closed":
-            await task_store.close_task(card["id"], closed_by=created_by, reason="issue closed on GitHub")
-            closed += 1
+            if await task_store.close_task(card["id"], closed_by=created_by, reason="issue closed on GitHub"):
+                closed += 1
         elif state == "open" and status == "closed":
-            await task_store.reopen_task(card["id"], reopened_by=created_by)
-            reopened += 1
+            if await task_store.reopen_task(card["id"], reopened_by=created_by):
+                reopened += 1
 
     return {"created": created, "closed": closed, "reopened": reopened, "skipped": skipped}

--- a/tinyagentos/github_sync.py
+++ b/tinyagentos/github_sync.py
@@ -1,0 +1,95 @@
+"""Sync GitHub issues onto a project board as cards.
+
+One-way, idempotent: each issue maps to exactly one card, keyed by a
+``gh-issue-{number}`` label. Re-running updates state instead of duplicating.
+Pull requests are skipped on purpose: PRs are implementation artifacts that link
+to a card via the ``exec/<task-id>`` branch convention, not work items in their
+own right. The upsert logic here is pure (it takes a list of issue dicts), so it
+is fully testable without network access; the HTTP fetch lives in the route.
+"""
+
+from __future__ import annotations
+
+GH_LABEL_PREFIX = "gh-issue-"
+SYNC_ACTOR = "github-sync"
+
+
+def issue_marker(number: int) -> str:
+    return f"{GH_LABEL_PREFIX}{number}"
+
+
+def is_pull_request(issue: dict) -> bool:
+    # GitHub's issues API returns PRs too; they carry a 'pull_request' key.
+    return "pull_request" in issue
+
+
+def _issue_label_names(issue: dict) -> list[str]:
+    out = []
+    for lab in issue.get("labels") or []:
+        name = lab.get("name") if isinstance(lab, dict) else lab
+        if name:
+            out.append(str(name))
+    return out
+
+
+async def sync_issues_to_board(
+    task_store,
+    project_id: str,
+    issues: list[dict],
+    created_by: str = SYNC_ACTOR,
+) -> dict:
+    """Upsert GitHub issues as board cards. Returns a counts summary.
+
+    - new open issue  -> create an open card
+    - new closed issue -> create a card and close it
+    - issue closed since last sync -> close the existing card
+    - issue reopened since last sync -> reopen the existing card
+    - pull requests -> skipped
+    """
+    existing = await task_store.list_tasks(project_id)
+    by_marker: dict[str, dict] = {}
+    for t in existing:
+        for lab in t.get("labels") or []:
+            if lab.startswith(GH_LABEL_PREFIX):
+                by_marker[lab] = t
+
+    created = closed = reopened = skipped = 0
+    for issue in issues:
+        if is_pull_request(issue):
+            skipped += 1
+            continue
+        num = issue.get("number")
+        if num is None:
+            skipped += 1
+            continue
+        marker = issue_marker(int(num))
+        state = (issue.get("state") or "open").lower()
+        card = by_marker.get(marker)
+
+        if card is None:
+            body = (issue.get("body") or "").strip()
+            url = issue.get("html_url") or ""
+            full_body = (body + ("\n\n" if body and url else "") + url).strip()
+            labels = ["github", marker, *_issue_label_names(issue)]
+            new = await task_store.create_task(
+                project_id=project_id,
+                title=issue.get("title") or f"Issue #{num}",
+                created_by=created_by,
+                body=full_body,
+                labels=labels,
+            )
+            created += 1
+            if state == "closed":
+                await task_store.close_task(new["id"], closed_by=created_by, reason="issue closed on GitHub")
+                closed += 1
+            continue
+
+        status = card.get("status")
+        if state == "closed" and status != "closed":
+            await task_store.close_task(card["id"], closed_by=created_by, reason="issue closed on GitHub")
+            closed += 1
+        elif state == "open" and status == "closed":
+            await task_store.reopen_task(card["id"], reopened_by=created_by)
+            reopened += 1
+
+    return {"created": created, "closed": closed, "reopened": reopened, "skipped": skipped}

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -48,6 +48,9 @@ def register_all_routers(app):
     from tinyagentos.routes import projects as projects_routes
     app.include_router(projects_routes.router)
 
+    from tinyagentos.routes.github_sync import router as github_sync_router
+    app.include_router(github_sync_router)
+
     from tinyagentos.routes.store_install import router as store_install_router
     app.include_router(store_install_router)
 

--- a/tinyagentos/routes/github_sync.py
+++ b/tinyagentos/routes/github_sync.py
@@ -15,6 +15,9 @@ from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
+import asyncio
+import re
+
 from tinyagentos.auth_context import CurrentUser, current_user
 from tinyagentos.github_sync import sync_issues_to_board
 from fastapi import Depends
@@ -23,6 +26,10 @@ router = APIRouter()
 
 _GITHUB_API = "https://api.github.com"
 _MAX_PAGES = 10  # cap at 1000 issues per sync
+_REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+# Serialize syncs per project so two concurrent calls cannot both read the same
+# pre-existing set and create duplicate cards for one issue.
+_sync_locks: dict[str, asyncio.Lock] = {}
 
 
 class GithubSyncIn(BaseModel):
@@ -31,11 +38,13 @@ class GithubSyncIn(BaseModel):
     token: str | None = None
 
 
-async def _fetch_issues(repo: str, state: str, token: str | None) -> list[dict]:
+async def _fetch_issues(repo: str, state: str, token: str | None) -> tuple[list[dict], bool]:
+    """Return (issues, truncated). truncated is True if the page cap was hit."""
     headers = {"Accept": "application/vnd.github+json"}
     if token:
         headers["Authorization"] = f"Bearer {token}"
     issues: list[dict] = []
+    truncated = False
     async with httpx.AsyncClient(timeout=30) as client:
         for page in range(1, _MAX_PAGES + 1):
             resp = await client.get(
@@ -44,14 +53,18 @@ async def _fetch_issues(repo: str, state: str, token: str | None) -> list[dict]:
                 headers=headers,
             )
             if resp.status_code != 200:
-                raise RuntimeError(f"GitHub fetch failed: {resp.status_code} {resp.text[:200]}")
+                # Do not echo GitHub's response body back to the caller; it can
+                # carry token-scoped hints or unrelated detail. Surface the code.
+                raise RuntimeError(f"GitHub fetch failed: HTTP {resp.status_code}")
             batch = resp.json()
             if not batch:
                 break
             issues.extend(batch)
             if len(batch) < 100:
                 break
-    return issues
+            if page == _MAX_PAGES:
+                truncated = True
+    return issues, truncated
 
 
 @router.post("/api/projects/{project_id}/github/sync")
@@ -72,18 +85,22 @@ async def github_sync(
         return JSONResponse(
             {"error": "no repo configured; pass 'repo' as owner/name"}, status_code=400
         )
+    if not _REPO_RE.match(repo) or ".." in repo:
+        return JSONResponse({"error": "repo must be 'owner/name'"}, status_code=400)
 
     try:
-        issues = await _fetch_issues(repo, body.state, body.token)
+        issues, truncated = await _fetch_issues(repo, body.state, body.token)
     except RuntimeError as exc:
         return JSONResponse({"error": str(exc)}, status_code=502)
 
     task_store = request.app.state.project_task_store
-    result = await sync_issues_to_board(task_store, project_id, issues)
+    lock = _sync_locks.setdefault(project_id, asyncio.Lock())
+    async with lock:
+        result = await sync_issues_to_board(task_store, project_id, issues)
 
     # Remember the repo so later syncs can omit it.
     if body.repo and settings.get("github_repo") != body.repo:
         settings["github_repo"] = body.repo
         await pstore.update_project(project_id, settings=settings)
 
-    return {"repo": repo, **result}
+    return {"repo": repo, "truncated": truncated, **result}

--- a/tinyagentos/routes/github_sync.py
+++ b/tinyagentos/routes/github_sync.py
@@ -1,0 +1,89 @@
+"""Route: sync a GitHub repo's issues onto a project board.
+
+POST /api/projects/{project_id}/github/sync
+  body: { "repo": "owner/name", "state": "all"|"open" (default "all"),
+          "token": optional PAT for private repos }
+
+The repo is remembered in the project's settings, so later calls can omit it.
+Only issues are synced; pull requests are skipped (see github_sync module).
+"""
+
+from __future__ import annotations
+
+import httpx
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from tinyagentos.auth_context import CurrentUser, current_user
+from tinyagentos.github_sync import sync_issues_to_board
+from fastapi import Depends
+
+router = APIRouter()
+
+_GITHUB_API = "https://api.github.com"
+_MAX_PAGES = 10  # cap at 1000 issues per sync
+
+
+class GithubSyncIn(BaseModel):
+    repo: str | None = None
+    state: str = "all"
+    token: str | None = None
+
+
+async def _fetch_issues(repo: str, state: str, token: str | None) -> list[dict]:
+    headers = {"Accept": "application/vnd.github+json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    issues: list[dict] = []
+    async with httpx.AsyncClient(timeout=30) as client:
+        for page in range(1, _MAX_PAGES + 1):
+            resp = await client.get(
+                f"{_GITHUB_API}/repos/{repo}/issues",
+                params={"state": state, "per_page": 100, "page": page},
+                headers=headers,
+            )
+            if resp.status_code != 200:
+                raise RuntimeError(f"GitHub fetch failed: {resp.status_code} {resp.text[:200]}")
+            batch = resp.json()
+            if not batch:
+                break
+            issues.extend(batch)
+            if len(batch) < 100:
+                break
+    return issues
+
+
+@router.post("/api/projects/{project_id}/github/sync")
+async def github_sync(
+    project_id: str,
+    body: GithubSyncIn,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    pstore = request.app.state.project_store
+    project = await pstore.get_project(project_id)
+    if project is None or (not user.is_admin and user.user_id != project["user_id"]):
+        return JSONResponse({"error": "not found"}, status_code=404)
+
+    settings = project.get("settings") or {}
+    repo = body.repo or settings.get("github_repo")
+    if not repo:
+        return JSONResponse(
+            {"error": "no repo configured; pass 'repo' as owner/name"}, status_code=400
+        )
+
+    try:
+        issues = await _fetch_issues(repo, body.state, body.token)
+    except RuntimeError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=502)
+
+    task_store = request.app.state.project_task_store
+    result = await sync_issues_to_board(task_store, project_id, issues)
+
+    # Remember the repo so later syncs can omit it.
+    if body.repo and settings.get("github_repo") != body.repo:
+        settings["github_repo"] = body.repo
+        await pstore.update_project(project_id, settings=settings)
+
+    return {"repo": repo, **result}


### PR DESCRIPTION
## Why
Per the projects-board direction: the board is the canonical work surface, and GitHub issues are planned work that should surface as cards. PRs are NOT mirrored (they are implementation artifacts that link to a card via exec/<task-id>); only issues sync.

## What
- `github_sync.py`: pure, idempotent upsert. Each issue -> one card keyed by a `gh-issue-{number}` label. Re-runs update state (close/reopen) instead of duplicating. PRs skipped.
- `POST /api/projects/{id}/github/sync` {repo, state?, token?}: paginated GitHub fetch (public unauth or PAT for private), then upsert. Repo remembered in `project.settings.github_repo` so later calls can omit it.

## Tests
9 tests: create open/closed cards, skip PRs, idempotent re-run, close+reopen tracking, label/url carry-over, plus route tests (happy path + repo persistence, 400 no-repo, 404 unknown project).

## Notes / follow-ups
- One-way (GitHub -> board) by design for v1. Board edits do not push back.
- Phase 2 (separate): on PR merge, comment on the linked card; optional background poller / per-project schedule. This PR is the manual/triggered sync foundation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added GitHub issue synchronization that automatically creates and updates project board cards from GitHub issues
* Sync endpoint with repository validation and pagination support
* Automatic label propagation and issue URL tracking
* Idempotent processing to prevent duplicate cards
* Automatic card state management based on GitHub issue status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->