### PR TITLE
fix(update): stash dirty tracked tree instead of 500 on update

### DIFF
--- a/tests/test_update_stash.py
+++ b/tests/test_update_stash.py
@@ -1,0 +1,51 @@
+"""The update flow must not 500 on a dirty tracked source file: it stashes the
+local edit (recoverable) so `git pull --ff-only` can proceed."""
+
+import subprocess
+
+import pytest
+
+from tinyagentos.routes.settings import _stash_local_source_changes
+
+
+def _git(repo, *args):
+    subprocess.run(["git", *args], cwd=repo, check=True,
+                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+@pytest.fixture
+def repo(tmp_path):
+    _git(tmp_path, "init", "-q")
+    _git(tmp_path, "config", "user.email", "t@t")
+    _git(tmp_path, "config", "user.name", "t")
+    (tmp_path / "src.py").write_text("x = 1\n")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-qm", "init")
+    return tmp_path
+
+
+@pytest.mark.asyncio
+async def test_clean_tree_no_stash(repo):
+    assert await _stash_local_source_changes(repo) is False
+    out = subprocess.run(["git", "stash", "list"], cwd=repo, capture_output=True, text=True).stdout
+    assert out.strip() == ""
+
+
+@pytest.mark.asyncio
+async def test_dirty_tracked_file_is_stashed(repo):
+    (repo / "src.py").write_text("x = 2  # local edit\n")
+    assert await _stash_local_source_changes(repo) is True
+    # working tree is clean again (so ff-only pull would succeed)
+    status = subprocess.run(["git", "status", "--porcelain", "--untracked-files=no"],
+                            cwd=repo, capture_output=True, text=True).stdout
+    assert status.strip() == ""
+    # and the edit is recoverable, not lost
+    stash = subprocess.run(["git", "stash", "list"], cwd=repo, capture_output=True, text=True).stdout
+    assert "auto-update" in stash
+
+
+@pytest.mark.asyncio
+async def test_untracked_files_are_not_stashed(repo):
+    (repo / "data_dir_artifact").write_text("runtime\n")  # untracked
+    assert await _stash_local_source_changes(repo) is False
+    assert (repo / "data_dir_artifact").exists()  # left in place

--- a/tinyagentos/routes/settings.py
+++ b/tinyagentos/routes/settings.py
@@ -714,6 +714,33 @@ async def _pip_rebuild_restart(project_dir: Path, target_sha: str) -> tuple[int,
     return 0, ""
 
 
+async def _stash_local_source_changes(project_dir) -> bool:
+    """Stash any remaining tracked modifications so `git pull --ff-only` cannot
+    refuse the update. Build-artifact churn is restored by the caller before
+    this runs, so anything left is a real local source edit. We stash it (never
+    discard) and report it, instead of failing with a cryptic git error and
+    leaving the user stuck on the old version. Untracked files (data/, config)
+    are deliberately NOT stashed.
+
+    Returns True if something was stashed.
+    """
+    status_proc = await asyncio.create_subprocess_exec(
+        "git", "status", "--porcelain", "--untracked-files=no",
+        stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.DEVNULL,
+        cwd=str(project_dir),
+    )
+    status_out, _ = await status_proc.communicate()
+    if not (status_out and status_out.strip()):
+        return False
+    stash_proc = await asyncio.create_subprocess_exec(
+        "git", "stash", "push", "-m", "taOS auto-update: local source changes (recover with: git stash pop)",
+        stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL,
+        cwd=str(project_dir),
+    )
+    await stash_proc.communicate()
+    return True
+
+
 @router.post("/api/settings/update")
 async def apply_update(request: Request):
     """Pull latest TinyAgentOS code from GitHub."""
@@ -742,6 +769,11 @@ async def apply_update(request: Request):
         cwd=str(project_dir),
     )
     await clean_proc.communicate()
+
+    # Any tracked source edits left after the build-artifact restore would make
+    # the ff-only pull below refuse (HTTP 500, user stuck). Stash them first so
+    # the update applies; the change is recoverable via `git stash pop`.
+    stashed_local = await _stash_local_source_changes(project_dir)
 
     # Git pull — pull the branch this install tracks (master on stable, dev on
     # a dev/test box). Pulling a hard-coded master onto a dev box fails ff-only
@@ -788,7 +820,12 @@ async def apply_update(request: Request):
     return {
         "status": "restarting",
         "output": output.strip(),
-        "message": "Update applied. Restarting now…",
+        "stashed_local_changes": stashed_local,
+        "message": (
+            "Update applied. Local source changes were stashed (recover with `git stash pop`). Restarting now…"
+            if stashed_local
+            else "Update applied. Restarting now…"
+        ),
     }
 
 


### PR DESCRIPTION
## Why
The Install Update action (POST /api/settings/update) restores build-artifact churn before pulling, but a dirty tracked SOURCE file still makes git pull --ff-only refuse, returning a 500 with a raw git error and leaving the user stuck on the old version. Hit live while deploying #1314 to the Pi (a leftover deployer.py edit blocked it).

## What
A small `_stash_local_source_changes` helper: if anything tracked is still dirty after the build-artifact restore, stash it (recoverable via `git stash pop`, never discarded; untracked data/config left in place) so the ff-only pull proceeds. The response now reports `stashed_local_changes` and tells the user.

## Tests
3 tests against a real temp git repo: clean tree -> no stash; dirty tracked file -> stashed + tree clean + recoverable; untracked files -> not stashed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The settings update endpoint now automatically stashes uncommitted tracked changes before pulling updates, preventing synchronization failures. Recovery instructions are included in the response when a stash is performed.

* **Tests**
  * Added test coverage for the stashing functionality to verify behavior across repository states: clean repositories should not create stashes, dirty tracked files should be stashed, and untracked files should be left untouched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->