### PR TITLE
feat(decisions): human-in-the-loop inbox backend (store + API)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -313,6 +313,10 @@ async def client(app, tmp_data_dir):
     if project_task_store._db is not None:
         await project_task_store.close()
     await project_task_store.init()
+    decision_store = app.state.decision_store
+    if decision_store._db is not None:
+        await decision_store.close()
+    await decision_store.init()
     app.state.projects_root.mkdir(parents=True, exist_ok=True)
     canvas_store = app.state.canvas_store
     if canvas_store._db is not None:

--- a/tests/test_decision_store.py
+++ b/tests/test_decision_store.py
@@ -1,0 +1,80 @@
+import pytest
+import pytest_asyncio
+
+from tinyagentos.decisions.decision_store import DecisionStore
+
+
+@pytest_asyncio.fixture
+async def store(tmp_path):
+    s = DecisionStore(tmp_path / "decisions.db")
+    await s.init()
+    yield s
+    await s.close()
+
+
+@pytest.mark.asyncio
+async def test_create_and_get(store):
+    d = await store.create(
+        "@taOS-dev", "Build X first?", "single_select",
+        options=[{"label": "A", "value": "a", "recommended": True, "rationale": "best"},
+                 {"label": "B", "value": "b"}],
+        context="why", project_id="prj-1", user_id="u1",
+    )
+    assert d["id"].startswith("dec-")
+    assert d["status"] == "pending"
+    assert d["options"][0]["recommended"] is True
+    got = await store.get(d["id"])
+    assert got["question"] == "Build X first?"
+
+
+@pytest.mark.asyncio
+async def test_invalid_type_rejected(store):
+    with pytest.raises(ValueError):
+        await store.create("@a", "q", "bogus_type")
+
+
+@pytest.mark.asyncio
+async def test_list_filters(store):
+    await store.create("@a", "q1", "approve_deny", project_id="p1", user_id="u1")
+    b = await store.create("@a", "q2", "free_text", project_id="p2", user_id="u1")
+    await store.answer(b["id"], "done", "u1")
+    assert len(await store.list()) == 2
+    assert len(await store.list(status="pending")) == 1
+    assert len(await store.list(status="answered")) == 1
+    assert len(await store.list(project_id="p1")) == 1
+    assert len(await store.list(user_id="u1")) == 2
+
+
+@pytest.mark.asyncio
+async def test_answer_then_cannot_reanswer(store):
+    d = await store.create("@a", "q", "approve_deny", user_id="u1")
+    upd = await store.answer(d["id"], "approve", "u1")
+    assert upd["status"] == "answered"
+    assert upd["answer"]["value"] == "approve"
+    assert upd["answer"]["answered_by"] == "u1"
+    # second answer on a non-pending decision is rejected
+    assert await store.answer(d["id"], "deny", "u1") is None
+
+
+@pytest.mark.asyncio
+async def test_answer_unknown_returns_none(store):
+    assert await store.answer("dec-missing", "x", "u1") is None
+
+
+@pytest.mark.asyncio
+async def test_supersede(store):
+    d = await store.create("@a", "q", "single_select",
+                           options=[{"label": "x", "value": "x"}], user_id="u1")
+    assert await store.supersede(d["id"]) is True
+    assert (await store.get(d["id"]))["status"] == "superseded"
+
+
+@pytest.mark.asyncio
+async def test_branching_fields_reserved(store):
+    d = await store.create("@a", "q", "free_text", user_id="u1",
+                           parent_decision_id="dec-parent", checkpoint_ref="abc123",
+                           timeline_id="t1")
+    got = await store.get(d["id"])
+    assert got["parent_decision_id"] == "dec-parent"
+    assert got["checkpoint_ref"] == "abc123"
+    assert got["timeline_id"] == "t1"

--- a/tests/test_routes_decisions.py
+++ b/tests/test_routes_decisions.py
@@ -1,0 +1,61 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_post_list_get_answer_flow(client):
+    resp = await client.post("/api/decisions", json={
+        "from_agent": "@taOS-dev",
+        "question": "Which engine?",
+        "type": "single_select",
+        "options": [{"label": "Excalidraw", "value": "excalidraw", "recommended": True, "rationale": "MIT"},
+                    {"label": "Konva", "value": "konva"}],
+        "context": "canvas replacement",
+        "project_id": "prj-x",
+    })
+    assert resp.status_code == 200
+    d = resp.json()
+    assert d["id"].startswith("dec-") and d["status"] == "pending"
+
+    resp = await client.get("/api/decisions?status=pending")
+    assert resp.status_code == 200
+    assert any(x["id"] == d["id"] for x in resp.json()["items"])
+
+    resp = await client.get(f"/api/decisions/{d['id']}")
+    assert resp.status_code == 200
+    assert resp.json()["question"] == "Which engine?"
+
+    resp = await client.post(f"/api/decisions/{d['id']}/answer", json={"value": "excalidraw"})
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "answered"
+    assert resp.json()["answer"]["value"] == "excalidraw"
+
+    # cannot answer twice
+    resp = await client.post(f"/api/decisions/{d['id']}/answer", json={"value": "konva"})
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_select_requires_options(client):
+    resp = await client.post("/api/decisions", json={
+        "from_agent": "@a", "question": "q", "type": "single_select", "options": [],
+    })
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_free_text_and_approve_deny_need_no_options(client):
+    for t in ("free_text", "approve_deny"):
+        resp = await client.post("/api/decisions", json={"from_agent": "@a", "question": "q", "type": t})
+        assert resp.status_code == 200, t
+
+
+@pytest.mark.asyncio
+async def test_invalid_type_400(client):
+    resp = await client.post("/api/decisions", json={"from_agent": "@a", "question": "q", "type": "nope"})
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_get_unknown_404(client):
+    resp = await client.get("/api/decisions/dec-missing")
+    assert resp.status_code == 404

--- a/tests/test_routes_decisions.py
+++ b/tests/test_routes_decisions.py
@@ -59,3 +59,32 @@ async def test_invalid_type_400(client):
 async def test_get_unknown_404(client):
     resp = await client.get("/api/decisions/dec-missing")
     assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_answer_must_match_options(client):
+    resp = await client.post("/api/decisions", json={
+        "from_agent": "@a", "question": "q", "type": "single_select",
+        "options": [{"label": "A", "value": "a"}, {"label": "B", "value": "b"}],
+    })
+    d = resp.json()
+    # A value outside the declared options is rejected.
+    resp = await client.post(f"/api/decisions/{d['id']}/answer", json={"value": "zzz"})
+    assert resp.status_code == 400
+    # The decision is still answerable with a valid option.
+    resp = await client.post(f"/api/decisions/{d['id']}/answer", json={"value": "a"})
+    assert resp.status_code == 200
+    assert resp.json()["answer"]["value"] == "a"
+
+
+@pytest.mark.asyncio
+async def test_multi_select_answer_must_be_subset(client):
+    resp = await client.post("/api/decisions", json={
+        "from_agent": "@a", "question": "q", "type": "multi_select",
+        "options": [{"label": "A", "value": "a"}, {"label": "B", "value": "b"}],
+    })
+    d = resp.json()
+    resp = await client.post(f"/api/decisions/{d['id']}/answer", json={"value": ["a", "nope"]})
+    assert resp.status_code == 400
+    resp = await client.post(f"/api/decisions/{d['id']}/answer", json={"value": ["a", "b"]})
+    assert resp.status_code == 200

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -366,6 +366,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         data_dir / "projects.db", broker=project_event_broker, audit=board_audit_store
     )
     project_canvas_store = ProjectCanvasStoreImpl(data_dir / "projects.db", broker=project_event_broker)
+    from tinyagentos.decisions.decision_store import DecisionStore
+    decision_store = DecisionStore(data_dir / "decisions.db")
     projects_root = data_dir / "projects"
     chat_hub = ChatHub()
     canvas_store = CanvasStore(data_dir / "canvas.db")
@@ -465,6 +467,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         app.state.board_audit = board_audit_store
         await project_task_store.init()
         await project_canvas_store.init()
+        await decision_store.init()
+        app.state.decision_store = decision_store
         projects_root.mkdir(parents=True, exist_ok=True)
         await canvas_store.init()
         await desktop_settings.init()
@@ -717,6 +721,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         app.state.project_event_broker = project_event_broker
         app.state.desktop_command_broker = desktop_command_broker
         app.state.project_canvas_store = project_canvas_store
+        app.state.decision_store = decision_store
         app.state.projects_root = projects_root
         app.state.chat_hub = chat_hub
         from tinyagentos.chat.group_policy import GroupPolicy
@@ -1358,6 +1363,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     app.state.project_event_broker = project_event_broker
     app.state.desktop_command_broker = desktop_command_broker
     app.state.project_canvas_store = project_canvas_store
+    app.state.decision_store = decision_store
     app.state.beads_bridge = None
     app.state.canvas_snapshotter = None
     projects_root.mkdir(parents=True, exist_ok=True)

--- a/tinyagentos/decisions/decision_store.py
+++ b/tinyagentos/decisions/decision_store.py
@@ -1,0 +1,150 @@
+"""SQLite-backed store for the Decisions app: the human-in-the-loop inbox.
+
+A decision is a choice an agent needs from the user (single/multi select,
+approve/deny, or free text). It queues until answered, so an agent can move on
+and pick up the answer later. The branching fields (checkpoint_ref,
+parent_decision_id, timeline_id) are reserved in v1 and unused; they exist so
+fork-and-replay can be added later without a schema rewrite.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+from tinyagentos.base_store import BaseStore
+from tinyagentos.projects.ids import new_id
+
+DECISION_TYPES = ("single_select", "multi_select", "approve_deny", "free_text")
+PRIORITIES = ("normal", "blocking")
+
+DECISIONS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS decisions (
+    id                 TEXT PRIMARY KEY,
+    from_agent         TEXT NOT NULL,
+    project_id         TEXT,
+    user_id            TEXT NOT NULL DEFAULT '',
+    question           TEXT NOT NULL,
+    type               TEXT NOT NULL,
+    options            TEXT NOT NULL DEFAULT '[]',
+    context            TEXT NOT NULL DEFAULT '',
+    priority           TEXT NOT NULL DEFAULT 'normal',
+    status             TEXT NOT NULL DEFAULT 'pending',
+    answer             TEXT,
+    created_at         REAL NOT NULL,
+    answered_at        REAL,
+    deadline           REAL,
+    checkpoint_ref     TEXT,
+    parent_decision_id TEXT,
+    timeline_id        TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_decisions_status ON decisions(status, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_decisions_project ON decisions(project_id, status);
+CREATE INDEX IF NOT EXISTS idx_decisions_user ON decisions(user_id, status);
+"""
+
+_JSON_FIELDS = ("options", "answer")
+
+
+def _row_to_decision(row, description) -> dict:
+    d = dict(zip([c[0] for c in description], row))
+    for f in _JSON_FIELDS:
+        if d.get(f) is not None:
+            d[f] = json.loads(d[f])
+    return d
+
+
+class DecisionStore(BaseStore):
+    SCHEMA = DECISIONS_SCHEMA
+
+    async def create(
+        self,
+        from_agent: str,
+        question: str,
+        type: str,
+        *,
+        options: list[dict] | None = None,
+        context: str = "",
+        priority: str = "normal",
+        project_id: str | None = None,
+        user_id: str = "",
+        deadline: float | None = None,
+        parent_decision_id: str | None = None,
+        checkpoint_ref: str | None = None,
+        timeline_id: str | None = None,
+    ) -> dict:
+        if type not in DECISION_TYPES:
+            raise ValueError(f"invalid decision type: {type!r}")
+        if priority not in PRIORITIES:
+            raise ValueError(f"invalid priority: {priority!r}")
+        did = new_id("dec")
+        now = time.time()
+        await self._db.execute(
+            """INSERT INTO decisions
+               (id, from_agent, project_id, user_id, question, type, options, context,
+                priority, status, created_at, deadline, parent_decision_id,
+                checkpoint_ref, timeline_id)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?, ?)""",
+            (did, from_agent, project_id, user_id, question, type,
+             json.dumps(options or []), context, priority, now, deadline,
+             parent_decision_id, checkpoint_ref, timeline_id),
+        )
+        await self._db.commit()
+        return await self.get(did)
+
+    async def get(self, decision_id: str) -> dict | None:
+        async with self._db.execute(
+            "SELECT * FROM decisions WHERE id = ?", (decision_id,)
+        ) as cur:
+            row = await cur.fetchone()
+            if row is None:
+                return None
+            return _row_to_decision(row, cur.description)
+
+    async def list(
+        self,
+        *,
+        status: str | None = None,
+        project_id: str | None = None,
+        user_id: str | None = None,
+    ) -> list[dict]:
+        conds, params = [], []
+        if status is not None:
+            conds.append("status = ?"); params.append(status)
+        if project_id is not None:
+            conds.append("project_id = ?"); params.append(project_id)
+        if user_id is not None:
+            conds.append("user_id = ?"); params.append(user_id)
+        where = (" WHERE " + " AND ".join(conds)) if conds else ""
+        async with self._db.execute(
+            f"SELECT * FROM decisions{where} ORDER BY created_at DESC", params
+        ) as cur:
+            rows = await cur.fetchall()
+            desc = cur.description
+        return [_row_to_decision(r, desc) for r in rows]
+
+    async def answer(self, decision_id: str, value, answered_by: str) -> dict | None:
+        """Record an answer. Returns the updated decision, or None if the
+        decision does not exist or is not pending (already answered/expired)."""
+        now = time.time()
+        ans = json.dumps({"value": value, "answered_by": answered_by, "answered_at": now})
+        cur = await self._db.execute(
+            """UPDATE decisions
+               SET status = 'answered', answer = ?, answered_at = ?
+               WHERE id = ? AND status = 'pending'""",
+            (ans, now, decision_id),
+        )
+        await self._db.commit()
+        if cur.rowcount != 1:
+            return None
+        return await self.get(decision_id)
+
+    async def supersede(self, decision_id: str) -> bool:
+        """L1 revisit: mark a decision superseded (a later decision replaces it).
+        Returns True if a pending/answered decision was superseded."""
+        cur = await self._db.execute(
+            "UPDATE decisions SET status = 'superseded' WHERE id = ? AND status IN ('pending','answered')",
+            (decision_id,),
+        )
+        await self._db.commit()
+        return cur.rowcount == 1

--- a/tinyagentos/decisions/decision_store.py
+++ b/tinyagentos/decisions/decision_store.py
@@ -107,6 +107,7 @@ class DecisionStore(BaseStore):
         status: str | None = None,
         project_id: str | None = None,
         user_id: str | None = None,
+        limit: int = 200,
     ) -> list[dict]:
         conds, params = [], []
         if status is not None:
@@ -116,8 +117,11 @@ class DecisionStore(BaseStore):
         if user_id is not None:
             conds.append("user_id = ?"); params.append(user_id)
         where = (" WHERE " + " AND ".join(conds)) if conds else ""
+        # Bound the result set so a long-lived inbox cannot return everything.
+        limit = max(1, min(int(limit), 500))
         async with self._db.execute(
-            f"SELECT * FROM decisions{where} ORDER BY created_at DESC", params
+            f"SELECT * FROM decisions{where} ORDER BY created_at DESC LIMIT ?",
+            [*params, limit],
         ) as cur:
             rows = await cur.fetchall()
             desc = cur.description
@@ -125,7 +129,8 @@ class DecisionStore(BaseStore):
 
     async def answer(self, decision_id: str, value, answered_by: str) -> dict | None:
         """Record an answer. Returns the updated decision, or None if the
-        decision does not exist or is not pending (already answered/expired)."""
+        decision does not exist or is not pending (already answered or
+        superseded)."""
         now = time.time()
         ans = json.dumps({"value": value, "answered_by": answered_by, "answered_at": now})
         cur = await self._db.execute(

--- a/tinyagentos/projects/ids.py
+++ b/tinyagentos/projects/ids.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import secrets
 
-ID_PREFIXES = ("prj", "tsk", "cmt", "rel", "cve")
+ID_PREFIXES = ("prj", "tsk", "cmt", "rel", "cve", "dec")
 _ALPHABET = "abcdefghijklmnopqrstuvwxyz234567"
 
 

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -51,6 +51,9 @@ def register_all_routers(app):
     from tinyagentos.routes.github_sync import router as github_sync_router
     app.include_router(github_sync_router)
 
+    from tinyagentos.routes.decisions import router as decisions_router
+    app.include_router(decisions_router)
+
     from tinyagentos.routes.store_install import router as store_install_router
     app.include_router(store_install_router)
 

--- a/tinyagentos/routes/decisions.py
+++ b/tinyagentos/routes/decisions.py
@@ -1,0 +1,119 @@
+"""Decisions API: the human-in-the-loop inbox.
+
+An agent posts a decision (a choice it needs from the user); it queues until
+answered. Consent and explicitly-blocking decisions raise a higher-priority
+notification; everything else is a normal badge + notification.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from tinyagentos.auth_context import CurrentUser, current_user
+from tinyagentos.decisions.decision_store import DECISION_TYPES, PRIORITIES
+
+router = APIRouter()
+
+
+class OptionIn(BaseModel):
+    label: str
+    value: str | None = None
+    recommended: bool = False
+    rationale: str = ""
+
+
+class DecisionIn(BaseModel):
+    from_agent: str
+    question: str
+    type: str
+    options: list[OptionIn] = []
+    context: str = ""
+    priority: str = "normal"
+    project_id: str | None = None
+    deadline: float | None = None
+    parent_decision_id: str | None = None
+    checkpoint_ref: str | None = None
+    timeline_id: str | None = None
+
+
+class AnswerIn(BaseModel):
+    value: object
+    answered_by: str = ""
+
+
+@router.post("/api/decisions")
+async def create_decision(body: DecisionIn, request: Request, user: CurrentUser = Depends(current_user)):
+    if body.type not in DECISION_TYPES:
+        return JSONResponse({"error": f"type must be one of {DECISION_TYPES}"}, status_code=400)
+    if body.priority not in PRIORITIES:
+        return JSONResponse({"error": f"priority must be one of {PRIORITIES}"}, status_code=400)
+    if body.type in ("single_select", "multi_select") and not body.options:
+        return JSONResponse({"error": "select types require options"}, status_code=400)
+
+    store = request.app.state.decision_store
+    decision = await store.create(
+        from_agent=body.from_agent,
+        question=body.question,
+        type=body.type,
+        options=[o.model_dump() for o in body.options],
+        context=body.context,
+        priority=body.priority,
+        project_id=body.project_id,
+        user_id=user.user_id,
+        deadline=body.deadline,
+        parent_decision_id=body.parent_decision_id,
+        checkpoint_ref=body.checkpoint_ref,
+        timeline_id=body.timeline_id,
+    )
+
+    notifs = getattr(request.app.state, "notifications", None)
+    if notifs is not None:
+        # Best effort: a notification failure must not fail the queued decision.
+        try:
+            await notifs.add(
+                title="Decision needed",
+                message=f"{body.from_agent} needs a decision: {body.question[:120]}",
+                level="warning" if body.priority == "blocking" else "info",
+                source="decisions",
+            )
+        except Exception:
+            pass
+    return decision
+
+
+@router.get("/api/decisions")
+async def list_decisions(
+    request: Request,
+    status: str | None = None,
+    project_id: str | None = None,
+    user: CurrentUser = Depends(current_user),
+):
+    store = request.app.state.decision_store
+    # Non-admins see only their own decisions; admins see all.
+    uid = None if user.is_admin else user.user_id
+    items = await store.list(status=status, project_id=project_id, user_id=uid)
+    return {"items": items}
+
+
+@router.get("/api/decisions/{decision_id}")
+async def get_decision(decision_id: str, request: Request, user: CurrentUser = Depends(current_user)):
+    store = request.app.state.decision_store
+    d = await store.get(decision_id)
+    if d is None or (not user.is_admin and d["user_id"] != user.user_id):
+        return JSONResponse({"error": "not found"}, status_code=404)
+    return d
+
+
+@router.post("/api/decisions/{decision_id}/answer")
+async def answer_decision(decision_id: str, body: AnswerIn, request: Request, user: CurrentUser = Depends(current_user)):
+    store = request.app.state.decision_store
+    existing = await store.get(decision_id)
+    if existing is None or (not user.is_admin and existing["user_id"] != user.user_id):
+        return JSONResponse({"error": "not found"}, status_code=404)
+    answered_by = body.answered_by or user.user_id or "user"
+    updated = await store.answer(decision_id, body.value, answered_by)
+    if updated is None:
+        return JSONResponse({"error": "already answered or not pending"}, status_code=409)
+    return updated

--- a/tinyagentos/routes/decisions.py
+++ b/tinyagentos/routes/decisions.py
@@ -88,12 +88,13 @@ async def list_decisions(
     request: Request,
     status: str | None = None,
     project_id: str | None = None,
+    limit: int = 200,
     user: CurrentUser = Depends(current_user),
 ):
     store = request.app.state.decision_store
     # Non-admins see only their own decisions; admins see all.
     uid = None if user.is_admin else user.user_id
-    items = await store.list(status=status, project_id=project_id, user_id=uid)
+    items = await store.list(status=status, project_id=project_id, user_id=uid, limit=limit)
     return {"items": items}
 
 
@@ -112,6 +113,25 @@ async def answer_decision(decision_id: str, body: AnswerIn, request: Request, us
     existing = await store.get(decision_id)
     if existing is None or (not user.is_admin and existing["user_id"] != user.user_id):
         return JSONResponse({"error": "not found"}, status_code=404)
+
+    # For select types, the answer must reference the declared options so a
+    # stale or malformed client cannot record an arbitrary value.
+    dtype = existing.get("type")
+    if dtype in ("single_select", "multi_select"):
+        valid = {
+            o.get("value")
+            for o in (existing.get("options") or [])
+            if o.get("value") is not None
+        }
+        if valid:
+            if dtype == "single_select":
+                if body.value not in valid:
+                    return JSONResponse({"error": "answer is not one of the options"}, status_code=400)
+            else:
+                vals = body.value if isinstance(body.value, list) else None
+                if vals is None or any(v not in valid for v in vals):
+                    return JSONResponse({"error": "answer must be a subset of the options"}, status_code=400)
+
     answered_by = body.answered_by or user.user_id or "user"
     updated = await store.answer(decision_id, body.value, answered_by)
     if updated is None:


### PR DESCRIPTION
## What
First slice of the Decisions app (Jay greenlit; all four types confirmed): the backend.

- `DecisionStore` (SQLite, BaseStore): create / get / list (by status/project/user) / answer / supersede. Decision types: single_select, multi_select, approve_deny, free_text. Branching fields (checkpoint_ref, parent_decision_id, timeline_id) reserved for later fork-and-replay.
- `/api/decisions`: POST (create + raise a notification, warning-level for blocking), GET list (`?status=&project_id=`, scoped to the user; admin sees all), GET one (404/owner-hidden), POST `/{id}/answer` (single-shot, 409 if not pending).
- Wired into app state + conftest; new `dec-` id prefix.

## Decisions baked in (from Jay)
All four types in v1; consent + explicitly-blocking get the higher-priority notification; the rest are normal. Per-project archive + mock-first UI are the next slices.

## Tests
12 (7 store + 5 route): create/get, invalid type, list filters, answer-then-409, unknown-answer none, supersede, reserved branching fields, full POST/list/get/answer flow, select-requires-options, free-text/approve-deny need no options, unknown 404. No regression in projects/github-sync route tests (45 pass).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a Decisions API to create, list, retrieve, and answer decisions in a human-in-the-loop inbox.
  * Implemented decision validation and state transitions (pending → answered → superseded), with status/project/user filtering.
  * Added support for select-option integrity (single- and multi-select must match declared options) and ownership-based access for non-admin users.

* **Tests**
  * Added async unit and route integration tests covering store behavior, validations, and HTTP responses (including re-answer and unknown-id handling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->