### PR TITLE
feat(memory): arctic-embed-s as the recommended embedder default

### DIFF
--- a/app-catalog/catalog.yaml
+++ b/app-catalog/catalog.yaml
@@ -315,6 +315,11 @@ apps:
     version: 1.0.0
     name: BGE M3 (Multilingual)
     description: "100+ language embedding — dense, sparse, multi-vector"
+  - id: snowflake-arctic-embed-s
+    type: model
+    version: 1.0.0
+    name: Snowflake Arctic Embed S
+    description: "33M English embedding, 384-dim, CPU-friendly — taOSmd recommended default"
   - id: mxbai-embed-large
     type: model
     version: 1.0.0

--- a/tests/test_routes_taosmd.py
+++ b/tests/test_routes_taosmd.py
@@ -28,7 +28,7 @@ class TestTiers:
         resp = await client.get("/api/taosmd/tiers")
         data = resp.json()
         assert "nomic-embed-text-v1.5" in data["lite"]["models"]
-        assert "bge-m3" in data["standard"]["models"]
+        assert "snowflake-arctic-embed-s" in data["standard"]["models"]
         assert "bge-m3" in data["heavy"]["models"]
         assert "qwen3-reranker-0.6b" in data["heavy"]["models"]
 

--- a/tinyagentos/routes/taosmd.py
+++ b/tinyagentos/routes/taosmd.py
@@ -39,7 +39,9 @@ MEMORY_TIERS: dict[str, dict] = {
     "standard": {
         "label": "Standard",
         "description": "Recommended balance for most users",
-        "models": ["bge-m3"],
+        # arctic-embed-s is taOSmd's recommended default embedder (F-010:
+        # +0.057 judged retrieval / +0.157 R@K over MiniLM, 384-dim, CPU-friendly).
+        "models": ["snowflake-arctic-embed-s"],
         "min_ram_mb": 4096,
         "needs_accel": False,
     },


### PR DESCRIPTION
Makes snowflake-arctic-embed-s the taOS default embedder for new memory setups, aligning with taOSmd's recommendation (F-010: +0.057 judged retrieval / +0.157 R@K over MiniLM, 384-dim, CPU-friendly; it is also taOSmd's shipped config default).

## Changes
- Standard (Recommended) memory tier now provisions `snowflake-arctic-embed-s` (was bge-m3).
- Registered `snowflake-arctic-embed-s` in `app-catalog/catalog.yaml` (the manifest existed under app-catalog/models/ but was unreferenced, so it could not be installed via the catalog resolver).
- Lite (nomic) and Heavy (bge-m3 + reranker) unchanged.
- Updated the tier mapping test.

## Scope
This covers NEW memory setups. Existing deployed agents keep their current store until re-indexed (a MiniLM/bge store and an arctic query are incompatible vector spaces, so the switch requires re-embedding). That migration is being coordinated with @taOSmd-dev separately.

Verified: arctic ONNX already present on the Pi; taosmd==0.3.0 confirmed latest. 14 taosmd-route tests pass.