### PR TITLE
fix: make auth-requests-store ordering test deterministic

### DIFF
--- a/tests/test_auth_requests_store.py
+++ b/tests/test_auth_requests_store.py
@@ -84,7 +84,8 @@ async def test_list_pending_returns_only_pending_ordered_by_created_ts(tmp_path)
     counter = count()
 
     def _now(tz=None):
-        return base + timedelta(seconds=next(counter))
+        ts = base + timedelta(seconds=next(counter))
+        return ts.replace(tzinfo=timezone.utc)
 
     with patch("tinyagentos.auth_requests_store.datetime") as mock_dt:
         mock_dt.now.side_effect = _now


### PR DESCRIPTION
Autonomous build of board card tsk-eld44w.

Explicitly set tzinfo=timezone.utc on mocked datetime.now return values
to ensure created_ts ordering is guaranteed regardless of wall-clock
resolution.

Files:
 tests/test_auth_requests_store.py | 3 ++-
 1 file changed, 2 insertions(+), 1 deletion(-)