### PR TITLE
feat(decisions): L1 supersede + history lineage

### DIFF
--- a/tests/test_routes_decisions.py
+++ b/tests/test_routes_decisions.py
@@ -88,3 +88,52 @@ async def test_multi_select_answer_must_be_subset(client):
     assert resp.status_code == 400
     resp = await client.post(f"/api/decisions/{d['id']}/answer", json={"value": ["a", "b"]})
     assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_create_with_parent_supersedes_it(client):
+    # Original decision.
+    r = await client.post("/api/decisions", json={
+        "from_agent": "@taOS-dev", "question": "Canvas engine?", "type": "single_select",
+        "options": [{"label": "Konva", "value": "konva"}], "project_id": "prj-x",
+    })
+    old = r.json()
+    # A replacement that revisits it going forward.
+    r = await client.post("/api/decisions", json={
+        "from_agent": "@taOS-dev", "question": "Canvas engine (revisited)?", "type": "single_select",
+        "options": [{"label": "Excalidraw", "value": "excalidraw"}], "project_id": "prj-x",
+        "parent_decision_id": old["id"],
+    })
+    new = r.json()
+    assert r.status_code == 200
+    assert new["parent_decision_id"] == old["id"]
+    # The old decision is now superseded.
+    r = await client.get(f"/api/decisions/{old['id']}")
+    assert r.json()["status"] == "superseded"
+
+
+@pytest.mark.asyncio
+async def test_create_with_unknown_parent_rejected(client):
+    r = await client.post("/api/decisions", json={
+        "from_agent": "@taOS-dev", "question": "q", "type": "free_text",
+        "parent_decision_id": "dec-missing",
+    })
+    assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_history_returns_lineage_oldest_first(client):
+    ids = []
+    parent = None
+    for i in range(3):
+        body = {"from_agent": "@taOS-dev", "question": f"q{i}", "type": "free_text"}
+        if parent:
+            body["parent_decision_id"] = parent
+        r = await client.post("/api/decisions", json=body)
+        parent = r.json()["id"]
+        ids.append(parent)
+    # History of the newest walks back through both ancestors.
+    r = await client.get(f"/api/decisions/{ids[-1]}/history")
+    assert r.status_code == 200
+    chain = [d["id"] for d in r.json()["items"]]
+    assert chain == ids  # oldest first

--- a/tinyagentos/routes/decisions.py
+++ b/tinyagentos/routes/decisions.py
@@ -53,6 +53,15 @@ async def create_decision(body: DecisionIn, request: Request, user: CurrentUser 
         return JSONResponse({"error": "select types require options"}, status_code=400)
 
     store = request.app.state.decision_store
+
+    # L1 revisit/supersede: a decision may replace an earlier one going forward.
+    # Validate the parent belongs to this user before we create + supersede it.
+    parent_id = body.parent_decision_id
+    if parent_id:
+        parent = await store.get(parent_id)
+        if parent is None or (not user.is_admin and parent["user_id"] != user.user_id):
+            return JSONResponse({"error": "parent_decision_id not found"}, status_code=400)
+
     decision = await store.create(
         from_agent=body.from_agent,
         question=body.question,
@@ -63,10 +72,14 @@ async def create_decision(body: DecisionIn, request: Request, user: CurrentUser 
         project_id=body.project_id,
         user_id=user.user_id,
         deadline=body.deadline,
-        parent_decision_id=body.parent_decision_id,
+        parent_decision_id=parent_id,
         checkpoint_ref=body.checkpoint_ref,
         timeline_id=body.timeline_id,
     )
+
+    # Mark the parent superseded only after the replacement is persisted.
+    if parent_id:
+        await store.supersede(parent_id)
 
     notifs = getattr(request.app.state, "notifications", None)
     if notifs is not None:
@@ -105,6 +118,29 @@ async def get_decision(decision_id: str, request: Request, user: CurrentUser = D
     if d is None or (not user.is_admin and d["user_id"] != user.user_id):
         return JSONResponse({"error": "not found"}, status_code=404)
     return d
+
+
+@router.get("/api/decisions/{decision_id}/history")
+async def decision_history(decision_id: str, request: Request, user: CurrentUser = Depends(current_user)):
+    """The supersession lineage for a decision, oldest first: walk the
+    parent_decision_id chain (L1). Cycle-guarded."""
+    store = request.app.state.decision_store
+    chain: list[dict] = []
+    seen: set[str] = set()
+    cur_id: str | None = decision_id
+    while cur_id and cur_id not in seen:
+        seen.add(cur_id)
+        d = await store.get(cur_id)
+        if d is None:
+            break
+        if not user.is_admin and d["user_id"] != user.user_id:
+            return JSONResponse({"error": "not found"}, status_code=404)
+        chain.append(d)
+        cur_id = d.get("parent_decision_id")
+    if not chain:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    chain.reverse()
+    return {"items": chain}
 
 
 @router.post("/api/decisions/{decision_id}/answer")


### PR DESCRIPTION
decisions-design L1 (revisit / supersede), building on the merged Decisions backend (#1331).

- Posting a decision with `parent_decision_id` marks the parent superseded once the replacement persists (status -> superseded), so a revised decision informs future work without retroactive redo. The parent is validated (exists + owned by the user) first; an unknown/foreign parent returns 400.
- New `GET /api/decisions/{id}/history`: the supersession lineage, oldest-first, by walking the `parent_decision_id` chain (cycle-guarded, owner-scoped).

This is the L1 layer the L2 fork-and-replay Time Machine builds on. 3 new tests (supersede-on-create, unknown-parent rejection, lineage order); 17 decisions tests pass.