### PR TITLE
feat(observatory): queue-control pause API (global + per-lane)

### DIFF
--- a/tests/test_routes_observatory.py
+++ b/tests/test_routes_observatory.py
@@ -1,0 +1,51 @@
+import pytest
+
+from tinyagentos.auth_context import CurrentUser, current_user
+
+
+@pytest.mark.asyncio
+async def test_pause_defaults_to_unpaused(client):
+    resp = await client.get("/api/observatory/pause")
+    assert resp.status_code == 200
+    assert resp.json() == {"global": False, "lanes": {}}
+
+
+@pytest.mark.asyncio
+async def test_global_pause_round_trips(client):
+    resp = await client.post("/api/observatory/pause", json={"scope": "global", "paused": True})
+    assert resp.status_code == 200
+    assert resp.json()["global"] is True
+    # A fresh read reflects it (persisted).
+    resp = await client.get("/api/observatory/pause")
+    assert resp.json()["global"] is True
+    # Resume.
+    resp = await client.post("/api/observatory/pause", json={"scope": "global", "paused": False})
+    assert resp.json()["global"] is False
+
+
+@pytest.mark.asyncio
+async def test_per_lane_pause_and_resume(client):
+    lane = "@taOS-dev-kilo-owl-alpha"
+    resp = await client.post("/api/observatory/pause", json={"scope": lane, "paused": True})
+    assert resp.json()["lanes"].get(lane) is True
+    assert resp.json()["global"] is False  # lane pause does not touch global
+    # Unpausing removes the lane entry rather than leaving a False.
+    resp = await client.post("/api/observatory/pause", json={"scope": lane, "paused": False})
+    assert lane not in resp.json()["lanes"]
+
+
+@pytest.mark.asyncio
+async def test_empty_scope_rejected(client):
+    resp = await client.post("/api/observatory/pause", json={"scope": "  ", "paused": True})
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_non_admin_cannot_pause(app, client):
+    # Override the auth dependency to a non-admin user for this request.
+    app.dependency_overrides[current_user] = lambda: CurrentUser(user_id="bob", is_admin=False)
+    try:
+        resp = await client.post("/api/observatory/pause", json={"scope": "global", "paused": True})
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.pop(current_user, None)

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -54,6 +54,9 @@ def register_all_routers(app):
     from tinyagentos.routes.decisions import router as decisions_router
     app.include_router(decisions_router)
 
+    from tinyagentos.routes.observatory import router as observatory_router
+    app.include_router(observatory_router)
+
     from tinyagentos.routes.store_install import router as store_install_router
     app.include_router(store_install_router)
 

--- a/tinyagentos/routes/observatory.py
+++ b/tinyagentos/routes/observatory.py
@@ -1,0 +1,80 @@
+"""Observatory: queue-control (pause) for the agent dispatch fleet.
+
+The "steer" half of the Observatory spec. A controller-owned pause flag that
+the owl dispatch loop (and off-box lanes) read each iteration to decide whether
+to dispatch new work. Global pause is the panic button; per-lane pause lets one
+lane drain while another keeps going. State is a JSON file in data_dir so it
+survives controller restarts and is not a local tmux concern.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from tinyagentos.auth_context import CurrentUser, current_user
+
+router = APIRouter()
+
+_DEFAULT_STATE: dict = {"global": False, "lanes": {}}
+
+
+def _state_path(request: Request) -> Path:
+    return Path(request.app.state.data_dir) / "observatory_pause.json"
+
+
+def _read_state(request: Request) -> dict:
+    p = _state_path(request)
+    if not p.exists():
+        return {"global": False, "lanes": {}}
+    try:
+        data = json.loads(p.read_text())
+    except (OSError, ValueError):
+        return {"global": False, "lanes": {}}
+    # Normalise shape so a hand-edited or partial file cannot break readers.
+    return {
+        "global": bool(data.get("global", False)),
+        "lanes": {str(k): bool(v) for k, v in (data.get("lanes") or {}).items() if v},
+    }
+
+
+def _write_state(request: Request, state: dict) -> None:
+    p = _state_path(request)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(state))
+
+
+class PauseBody(BaseModel):
+    scope: str  # "global" or a lane handle (e.g. "@taOS-dev-kilo-owl-alpha")
+    paused: bool
+
+
+@router.get("/api/observatory/pause")
+async def get_pause(request: Request, user: CurrentUser = Depends(current_user)):
+    """Current pause state. Any authenticated caller (and the dispatch loop,
+    which polls this each iteration) may read it."""
+    return _read_state(request)
+
+
+@router.post("/api/observatory/pause")
+async def set_pause(body: PauseBody, request: Request, user: CurrentUser = Depends(current_user)):
+    """Pause or resume the queue globally or for a single lane. Admin only,
+    since it steers the whole fleet."""
+    if not user.is_admin:
+        raise HTTPException(status_code=403, detail="forbidden")
+    scope = body.scope.strip()
+    if not scope:
+        return JSONResponse({"error": "scope required"}, status_code=400)
+    state = _read_state(request)
+    if scope == "global":
+        state["global"] = body.paused
+    elif body.paused:
+        state["lanes"][scope] = True
+    else:
+        state["lanes"].pop(scope, None)
+    _write_state(request, state)
+    return state


### PR DESCRIPTION
First Observatory slice (the steer half): a controller-owned pause flag that the owl dispatch loop polls each iteration to decide whether to dispatch new work. Productizes the throttle that was a buried shell edit during the taosctl flood.

- `GET /api/observatory/pause` -> `{global, lanes}` (any authed caller + the dispatch loop).
- `POST /api/observatory/pause {scope, paused}` (admin only): `scope=global` is the panic button; a lane handle pauses just that lane (entry removed on resume).
- State persists to `data_dir/observatory_pause.json` so it survives restarts and off-box lanes can honour it.

5 tests (defaults, global round-trip, per-lane pause/resume, empty-scope 400, non-admin 403). Next slices: dispatch-loop honors the flag, then the Observatory app UI (fleet view + steer dials).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added observatory pause control for agent dispatch fleet, enabling global or per-lane pause operations
  * Pause state persists across sessions; admin users can modify pause settings while authenticated users can view current status

* **Tests**
  * Added comprehensive test coverage for pause endpoint including authentication and authorization validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->