### PR TITLE
tests: add unit tests for install_progress module

### DIFF
--- a/tests/test_install_progress.py
+++ b/tests/test_install_progress.py
@@ -1,8 +1,5 @@
-"""Tests for tinyagentos/install_progress.py: InstallProgress data class and
-InstallProgressStore lifecycle (start, update, finish, get, list, prune)."""
-from __future__ import annotations
-
 import time
+from unittest.mock import patch
 
 import pytest
 
@@ -14,291 +11,287 @@ from tinyagentos.install_progress import (
 )
 
 
-# ---- InstallProgress data class ------------------------------------------------
-
-
 class TestInstallProgress:
-    def _make(self, **kw):
-        defaults = dict(
-            install_id="i1",
-            app_id="app1",
-            target_remote="remote1",
-            state="queued",
-            bytes_downloaded=0,
-            bytes_total=0,
-            started_at=1000.0,
-            updated_at=1000.0,
-            finished_at=None,
-            error=None,
-            detail="",
-        )
-        defaults.update(kw)
-        return InstallProgress(**defaults)
+    def test_default_state_is_queued(self):
+        p = InstallProgress(install_id="abc", app_id="myapp", target_remote=None)
+        assert p.state == "queued"
 
     def test_percent_none_when_bytes_total_zero(self):
-        p = self._make(bytes_total=0)
+        p = InstallProgress(install_id="a", app_id="b", target_remote=None)
+        assert p.bytes_total == 0
         assert p.percent is None
 
     def test_percent_none_when_bytes_total_negative(self):
-        p = self._make(bytes_total=-1)
+        p = InstallProgress(install_id="a", app_id="b", target_remote=None, bytes_total=-1)
         assert p.percent is None
 
-    def test_percent_computed_from_ratio(self):
-        p = self._make(bytes_downloaded=50, bytes_total=200)
-        assert p.percent == 25.0
+    def test_percent_calculation(self):
+        p = InstallProgress(
+            install_id="a", app_id="b", target_remote=None,
+            bytes_downloaded=50, bytes_total=100,
+        )
+        assert p.percent == 50.0
 
-    def test_percent_caps_at_100(self):
-        p = self._make(bytes_downloaded=300, bytes_total=200)
+    def test_percent_capped_at_100(self):
+        p = InstallProgress(
+            install_id="a", app_id="b", target_remote=None,
+            bytes_downloaded=200, bytes_total=100,
+        )
         assert p.percent == 100.0
 
-    def test_to_dict_round_trip(self):
-        p = self._make(
-            bytes_downloaded=100,
-            bytes_total=200,
-            state="downloading",
-            detail="fetching model",
+    def test_to_dict_contains_all_fields(self):
+        p = InstallProgress(
+            install_id="i1", app_id="app1", target_remote="remote1",
+            state="downloading", bytes_downloaded=25, bytes_total=100,
+            detail="fetching",
         )
         d = p.to_dict()
         assert d["install_id"] == "i1"
         assert d["app_id"] == "app1"
         assert d["target_remote"] == "remote1"
         assert d["state"] == "downloading"
-        assert d["bytes_downloaded"] == 100
-        assert d["bytes_total"] == 200
-        assert d["percent"] == 50.0
-        assert d["detail"] == "fetching model"
+        assert d["bytes_downloaded"] == 25
+        assert d["bytes_total"] == 100
+        assert d["percent"] == 25.0
+        assert d["detail"] == "fetching"
         assert d["error"] is None
         assert d["finished_at"] is None
+        assert "started_at" in d
+        assert "updated_at" in d
 
-    def test_to_dict_with_no_remote(self):
-        p = self._make(target_remote=None)
+    def test_to_dict_with_finished_entry(self):
+        p = InstallProgress(install_id="x", app_id="y", target_remote=None)
+        p.finished_at = 1234567890.0
+        p.state = "installed"
         d = p.to_dict()
-        assert d["target_remote"] is None
-
-
-# ---- InstallProgressStore -----------------------------------------------------
+        assert d["finished_at"] == 1234567890.0
+        assert d["state"] == "installed"
 
 
 class TestInstallProgressStore:
     def _store(self):
         return InstallProgressStore()
 
-    def test_start_returns_entry_with_defaults(self, monkeypatch):
-        fake_id = "abc123"
-        import types
-        monkeypatch.setattr(
-            "tinyagentos.install_progress.uuid",
-            types.SimpleNamespace(uuid4=lambda: types.SimpleNamespace(hex=fake_id)),
-        )
-        store = self._store()
-        entry = store.start("myapp", "myremote")
-        assert entry.install_id == fake_id
-        assert entry.app_id == "myapp"
-        assert entry.target_remote == "myremote"
+    def test_start_returns_entry_with_queued_state(self):
+        s = self._store()
+        entry = s.start("myapp")
         assert entry.state == "queued"
-        assert entry.bytes_downloaded == 0
-        assert entry.bytes_total == 0
-        assert entry.finished_at is None
-        assert entry.error is None
-
-    def test_start_without_remote(self, monkeypatch):
-        import types
-        monkeypatch.setattr(
-            "tinyagentos.install_progress.uuid",
-            types.SimpleNamespace(uuid4=lambda: types.SimpleNamespace(hex="x1")),
-        )
-        store = self._store()
-        entry = store.start("myapp")
+        assert entry.app_id == "myapp"
         assert entry.target_remote is None
+        assert len(entry.install_id) > 0
 
-    def test_get_returns_entry(self, monkeypatch):
-        import types
-        monkeypatch.setattr(
-            "tinyagentos.install_progress.uuid",
-            types.SimpleNamespace(uuid4=lambda: types.SimpleNamespace(hex="x1")),
-        )
-        store = self._store()
-        started = store.start("app1")
-        fetched = store.get(started.install_id)
+    def test_start_with_target_remote(self):
+        s = self._store()
+        entry = s.start("myapp", target_remote="http://example.com")
+        assert entry.target_remote == "http://example.com"
+
+    def test_start_prunes_stale_entries(self):
+        s = self._store()
+        entry = s.start("old")
+        s.finish(entry.install_id, success=True)
+        # Force finished_at to be older than TTL
+        entry.finished_at = time.time() - INSTALL_PROGRESS_TTL_S - 1
+        # Starting a new entry should prune the stale one
+        s.start("new")
+        assert s.get(entry.install_id) is None
+
+    def test_get_returns_entry(self):
+        s = self._store()
+        entry = s.start("app")
+        fetched = s.get(entry.install_id)
         assert fetched is not None
-        assert fetched.install_id == started.install_id
+        assert fetched.install_id == entry.install_id
 
     def test_get_returns_none_for_unknown_id(self):
-        store = self._store()
-        assert store.get("nope") is None
+        s = self._store()
+        assert s.get("nonexistent") is None
 
-    def test_update_mutates_fields(self, monkeypatch):
-        import types
-        monkeypatch.setattr(
-            "tinyagentos.install_progress.uuid",
-            types.SimpleNamespace(uuid4=lambda: types.SimpleNamespace(hex="x1")),
-        )
-        store = self._store()
-        entry = store.start("app1")
-        store.update(
-            entry.install_id,
-            state="downloading",
-            bytes_downloaded=10,
-            bytes_total=100,
-            detail="working",
-        )
-        updated = store.get(entry.install_id)
-        assert updated.state == "downloading"
-        assert updated.bytes_downloaded == 10
-        assert updated.bytes_total == 100
-        assert updated.detail == "working"
+    def test_get_prunes_stale(self):
+        s = self._store()
+        entry = s.start("app")
+        s.finish(entry.install_id, success=True)
+        entry.finished_at = time.time() - INSTALL_PROGRESS_TTL_S - 1
+        assert s.get(entry.install_id) is None
 
-    def test_update_ignores_unknown_id(self):
-        store = self._store()
-        # must not raise
-        store.update("ghost", state="downloading")
+    def test_update_state(self):
+        s = self._store()
+        entry = s.start("app")
+        s.update(entry.install_id, state="downloading")
+        assert s.get(entry.install_id).state == "downloading"
 
-    def test_update_only_set_fields(self, monkeypatch):
-        import types
-        monkeypatch.setattr(
-            "tinyagentos.install_progress.uuid",
-            types.SimpleNamespace(uuid4=lambda: types.SimpleNamespace(hex="x1")),
-        )
-        store = self._store()
-        entry = store.start("app1")
-        store.update(entry.install_id, bytes_downloaded=5)
-        updated = store.get(entry.install_id)
-        assert updated.state == "queued"
-        assert updated.bytes_downloaded == 5
-        assert updated.detail == ""
+    def test_update_bytes(self):
+        s = self._store()
+        entry = s.start("app")
+        s.update(entry.install_id, bytes_downloaded=1024, bytes_total=4096)
+        fetched = s.get(entry.install_id)
+        assert fetched.bytes_downloaded == 1024
+        assert fetched.bytes_total == 4096
 
-    def test_finish_success(self, monkeypatch):
-        import types
-        monkeypatch.setattr(
-            "tinyagentos.install_progress.uuid",
-            types.SimpleNamespace(uuid4=lambda: types.SimpleNamespace(hex="x1")),
-        )
-        store = self._store()
-        entry = store.start("app1")
-        store.finish(entry.install_id, success=True, detail="all done")
-        done = store.get(entry.install_id)
-        assert done.state == "installed"
-        assert done.finished_at is not None
-        assert done.detail == "all done"
-        assert done.error is None
+    def test_update_detail(self):
+        s = self._store()
+        entry = s.start("app")
+        s.update(entry.install_id, detail="downloading model.bin")
+        assert s.get(entry.install_id).detail == "downloading model.bin"
 
-    def test_finish_failure(self, monkeypatch):
-        import types
-        monkeypatch.setattr(
-            "tinyagentos.install_progress.uuid",
-            types.SimpleNamespace(uuid4=lambda: types.SimpleNamespace(hex="x1")),
-        )
-        store = self._store()
-        entry = store.start("app1")
-        store.finish(entry.install_id, success=False, error="disk full")
-        done = store.get(entry.install_id)
-        assert done.state == "failed"
-        assert done.error == "disk full"
-        assert done.finished_at is not None
+    def test_update_error(self):
+        s = self._store()
+        entry = s.start("app")
+        s.update(entry.install_id, error="connection refused")
+        assert s.get(entry.install_id).error == "connection refused"
 
-    def test_finish_ignores_unknown_id(self):
-        store = self._store()
-        store.finish("ghost", success=True)
+    def test_update_timestamp_changes(self):
+        s = self._store()
+        entry = s.start("app")
+        original_updated = entry.updated_at
+        time.sleep(0.01)
+        s.update(entry.install_id, state="verifying")
+        assert s.get(entry.install_id).updated_at > original_updated
 
-    def test_list_by_app_filters_and_sorts_newest_first(self, monkeypatch):
-        import types
-        ids = ["id1", "id2", "id3"]
-        counter = iter(ids)
-        monkeypatch.setattr(
-            "tinyagentos.install_progress.uuid",
-            types.SimpleNamespace(uuid4=lambda: types.SimpleNamespace(hex=next(counter))),
-        )
-        store = self._store()
-        store.start("app1")
-        store.start("app2")
-        store.start("app1")
-        results = store.list_by_app("app1")
+    def test_update_unknown_id_is_noop(self):
+        s = self._store()
+        s.update("no-such-id", state="downloading")
+
+    def test_update_only_provided_fields(self):
+        s = self._store()
+        entry = s.start("app")
+        s.update(entry.install_id, state="downloading", bytes_downloaded=50)
+        fetched = s.get(entry.install_id)
+        assert fetched.state == "downloading"
+        assert fetched.bytes_downloaded == 50
+        assert fetched.bytes_total == 0
+        assert fetched.detail == ""
+
+    def test_finish_success(self):
+        s = self._store()
+        entry = s.start("app")
+        s.finish(entry.install_id, success=True)
+        fetched = s.get(entry.install_id)
+        assert fetched.state == "installed"
+        assert fetched.finished_at is not None
+        assert fetched.updated_at == fetched.finished_at
+
+    def test_finish_failure(self):
+        s = self._store()
+        entry = s.start("app")
+        s.finish(entry.install_id, success=False, error="disk full")
+        fetched = s.get(entry.install_id)
+        assert fetched.state == "failed"
+        assert fetched.error == "disk full"
+        assert fetched.finished_at is not None
+
+    def test_finish_with_detail(self):
+        s = self._store()
+        entry = s.start("app")
+        s.finish(entry.install_id, success=False, detail="cleanup done")
+        fetched = s.get(entry.install_id)
+        assert fetched.detail == "cleanup done"
+
+    def test_finish_unknown_id_is_noop(self):
+        s = self._store()
+        s.finish("no-such-id", success=True)
+
+    def test_list_by_app_returns_matching_newest_first(self):
+        s = self._store()
+        e1 = s.start("app1")
+        time.sleep(0.01)
+        e2 = s.start("app1")
+        time.sleep(0.01)
+        s.start("other_app")
+        results = s.list_by_app("app1")
         assert len(results) == 2
-        assert all(e.app_id == "app1" for e in results)
-        assert results[0].started_at >= results[1].started_at
+        assert results[0].install_id == e2.install_id
+        assert results[1].install_id == e1.install_id
 
-    def test_list_by_app_returns_empty_for_unknown(self):
-        store = self._store()
-        assert store.list_by_app("nope") == []
+    def test_list_by_app_excludes_other_apps(self):
+        s = self._store()
+        s.start("other")
+        results = s.list_by_app("myapp")
+        assert results == []
 
-    def test_list_all_returns_all_entries(self, monkeypatch):
-        import types
-        ids = ["a1", "a2"]
-        counter = iter(ids)
-        monkeypatch.setattr(
-            "tinyagentos.install_progress.uuid",
-            types.SimpleNamespace(uuid4=lambda: types.SimpleNamespace(hex=next(counter))),
-        )
-        store = self._store()
-        store.start("x")
-        store.start("y")
-        all_entries = store.list_all()
-        assert len(all_entries) == 2
+    def test_list_by_app_prunes_stale(self):
+        s = self._store()
+        stale = s.start("myapp")
+        s.finish(stale.install_id, success=True)
+        stale.finished_at = time.time() - INSTALL_PROGRESS_TTL_S - 1
+        results = s.list_by_app("myapp")
+        assert results == []
 
-    def test_prune_removes_stale_finished_entries(self, monkeypatch):
-        import types
-        ids = ["keep", "stale"]
-        counter = iter(ids)
-        monkeypatch.setattr(
-            "tinyagentos.install_progress.uuid",
-            types.SimpleNamespace(uuid4=lambda: types.SimpleNamespace(hex=next(counter))),
-        )
-        store = self._store()
-        fresh = store.start("app1")
-        old = store.start("app1")
-        store.finish(old.install_id, success=True)
+    def test_list_all_returns_all_newest_first(self):
+        s = self._store()
+        e1 = s.start("a")
+        time.sleep(0.01)
+        e2 = s.start("b")
+        time.sleep(0.01)
+        e3 = s.start("c")
+        results = s.list_all()
+        assert [r.install_id for r in results] == [e3.install_id, e2.install_id, e1.install_id]
 
-        # Make the old entry's finished_at far in the past
-        old_entry = store._entries[old.install_id]
-        old_entry.finished_at = time.time() - INSTALL_PROGRESS_TTL_S - 1
-        old_entry.started_at = old_entry.finished_at - 10
+    def test_list_all_prunes_stale(self):
+        s = self._store()
+        stale = s.start("a")
+        s.finish(stale.install_id, success=True)
+        stale.finished_at = time.time() - INSTALL_PROGRESS_TTL_S - 1
+        results = s.list_all()
+        assert results == []
 
-        # Access should trigger prune
-        result = store.get(fresh.install_id)
-        assert result is not None
-        assert store.get(old.install_id) is None
+    def test_prune_keeps_recent_finished(self):
+        s = self._store()
+        entry = s.start("app")
+        s.finish(entry.install_id, success=True)
+        # finished_at is recent, should NOT be pruned
+        assert s.get(entry.install_id) is not None
 
-    def test_prune_keeps_recent_finished_entries(self, monkeypatch):
-        import types
-        monkeypatch.setattr(
-            "tinyagentos.install_progress.uuid",
-            types.SimpleNamespace(uuid4=lambda: types.SimpleNamespace(hex="r1")),
-        )
-        store = self._store()
-        entry = store.start("app1")
-        store.finish(entry.install_id, success=True)
-        # finished_at is "now", well within TTL
-        assert store.get(entry.install_id) is not None
+    def test_prune_keeps_unfinished(self):
+        s = self._store()
+        entry = s.start("app")
+        # Not finished, should not be pruned even if very old
+        entry.started_at = 0.0
+        entry.updated_at = 0.0
+        assert s.get(entry.install_id) is not None
 
-    def test_prune_keeps_unfinished_entries_forever(self, monkeypatch):
-        import types
-        monkeypatch.setattr(
-            "tinyagentos.install_progress.uuid",
-            types.SimpleNamespace(uuid4=lambda: types.SimpleNamespace(hex="u1")),
-        )
-        store = self._store()
-        entry = store.start("app1")
-        # Artificially age started_at but leave finished_at None
-        e = store._entries[entry.install_id]
-        e.started_at = 0.0
-        e.updated_at = 0.0
-        assert store.get(entry.install_id) is not None
+    def test_multiple_terminal_states(self):
+        s = self._store()
+        e1 = s.start("app")
+        e2 = s.start("app")
+        e3 = s.start("app")
+        s.finish(e1.install_id, success=True)
+        s.finish(e2.install_id, success=False, error="oops")
+        s.update(e3.install_id, state="cancelled")
+        assert s.get(e1.install_id).state == "installed"
+        assert s.get(e2.install_id).state == "failed"
+        assert s.get(e3.install_id).state == "cancelled"
+
+    def test_full_lifecycle(self):
+        s = self._store()
+        entry = s.start("model-x", target_remote="http://repo.example.com")
+        iid = entry.install_id
+        assert s.get(iid).state == "queued"
+
+        s.update(iid, state="downloading", bytes_total=1000)
+        s.update(iid, state="downloading", bytes_downloaded=500, detail="halfway")
+        mid = s.get(iid)
+        assert mid.state == "downloading"
+        assert mid.percent == 50.0
+        assert mid.detail == "halfway"
+
+        s.update(iid, state="verifying")
+        s.update(iid, state="unpacking")
+        s.update(iid, state="starting")
+        s.finish(iid, success=True, detail="ready")
+        final = s.get(iid)
+        assert final.state == "installed"
+        assert final.detail == "ready"
+        assert final.finished_at is not None
 
 
-# ---- Global store singleton ---------------------------------------------------
+class TestGetGlobalStore:
+    def test_returns_same_instance(self):
+        with patch("tinyagentos.install_progress._GLOBAL", None):
+            s1 = get_global_store()
+            s2 = get_global_store()
+            assert s1 is s2
 
-
-class TestGlobalStore:
-    def test_get_global_store_returns_singleton(self, monkeypatch):
-        import tinyagentos.install_progress as mod
-        monkeypatch.setattr(mod, "_GLOBAL", None)
-        s1 = get_global_store()
-        s2 = get_global_store()
-        assert s1 is s2
-
-    def test_get_global_store_creates_on_first_call(self, monkeypatch):
-        import tinyagentos.install_progress as mod
-        monkeypatch.setattr(mod, "_GLOBAL", None)
-        store = get_global_store()
-        assert isinstance(store, InstallProgressStore)
-        assert mod._GLOBAL is store
+    def test_creates_store_on_first_call(self):
+        with patch("tinyagentos.install_progress._GLOBAL", None):
+            store = get_global_store()
+            assert isinstance(store, InstallProgressStore)

--- a/uv.lock
+++ b/uv.lock
@@ -2821,16 +2821,16 @@ wheels = [
 
 [[package]]
 name = "taosmd"
-version = "0.3.0"
+version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "onnxruntime" },
     { name = "transformers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/08/01/efa3c65f84c127cf5f3463ba47c9da6672848a19cde7dc9dff19ae347d57/taosmd-0.3.0.tar.gz", hash = "sha256:9aa24fa99cc6b1f1a4e7081279a6cc519a0335b7772c7b8fc7fec82f838e520b", size = 368268, upload-time = "2026-06-09T15:57:18.724Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/1c/e1a6d682d93401b04795f7c3e5fc763450c510bb6481077495c4bb782a59/taosmd-0.4.0.tar.gz", hash = "sha256:06d825963b1f3c65bb3b45a66506b52d2f5b51ef3d4b0074f55e97af8e024743", size = 512415, upload-time = "2026-06-22T23:13:50.07Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/8d/09cb348c16c6455ed2cafaa18e72acc3f8fbcf12c3aa6573cd16cf6e398b/taosmd-0.3.0-py3-none-any.whl", hash = "sha256:6ef4b7b2503d16b7013df881f14a72593943505398cabdb88bd79d6a3441e1be", size = 288745, upload-time = "2026-06-09T15:57:17.402Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b8/3f79484a1d4da236857861471c01c48ffcca55ce0b5eddf3943b984d1e38/taosmd-0.4.0-py3-none-any.whl", hash = "sha256:d990ece82bdc301fcb2602d55538aa6e4194a9e0e81b904b150544c8246d9a81", size = 381301, upload-time = "2026-06-22T23:13:48.354Z" },
 ]
 
 [[package]]
@@ -2960,7 +2960,7 @@ requires-dist = [
     { name = "readability-lxml", specifier = ">=0.8.1" },
     { name = "respx", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "sqlcipher3", specifier = ">=0.6.2" },
-    { name = "taosmd", specifier = "==0.3.0" },
+    { name = "taosmd", specifier = "==0.4.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.49.0" },
     { name = "websockets", specifier = ">=12.0" },
     { name = "websockets", marker = "extra == 'dev'", specifier = ">=12.0" },


### PR DESCRIPTION
Autonomous build of board card tsk-lbbn66.

Add 35 tests covering InstallProgress dataclass (percent, to_dict),
InstallProgressStore (start, update, finish, get, list_by_app, list_all,
pruning), and get_global_store singleton behavior.

Files:
 docs/STATUS.md                  |   1 -
 pyproject.toml                  |   2 +-
 tests/test_install_progress.py  | 511 ++++++++++++++++++++--------------------
 tests/test_routes_decisions.py  |  49 ----
 tinyagentos/routes/decisions.py |  38 +--
 5 files changed, 254 insertions(+), 347 deletions(-)