### PR TITLE
feat(observatory): fleet view (who is working on what)

### DIFF
--- a/tests/test_routes_observatory.py
+++ b/tests/test_routes_observatory.py
@@ -49,3 +49,31 @@ async def test_non_admin_cannot_pause(app, client):
         assert resp.status_code == 403
     finally:
         app.dependency_overrides.pop(current_user, None)
+
+
+@pytest.mark.asyncio
+async def test_fleet_empty_when_no_claims(client):
+    resp = await client.get("/api/observatory/fleet")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["agents"] == []
+    assert data["paused"] == {"global": False, "lanes": {}}
+
+
+@pytest.mark.asyncio
+async def test_fleet_shows_working_agent_with_held_card(app, client):
+    pstore = app.state.project_store
+    tstore = app.state.project_task_store
+    proj = await pstore.create_project(name="Obs", slug="obs-fleet", created_by="admin", user_id="admin")
+    task = await tstore.create_task(proj["id"], title="Build the thing", created_by="admin")
+    claimed = await tstore.claim_task(task["id"], "@taOS-dev-kilo-owl-alpha")
+    assert claimed is True
+
+    resp = await client.get("/api/observatory/fleet")
+    assert resp.status_code == 200
+    agents = resp.json()["agents"]
+    mine = [a for a in agents if a["handle"] == "@taOS-dev-kilo-owl-alpha"]
+    assert len(mine) == 1
+    assert mine[0]["state"] == "working"
+    assert mine[0]["holds"]["task_id"] == task["id"]
+    assert mine[0]["holds"]["title"] == "Build the thing"

--- a/tinyagentos/routes/observatory.py
+++ b/tinyagentos/routes/observatory.py
@@ -78,3 +78,41 @@ async def set_pause(body: PauseBody, request: Request, user: CurrentUser = Depen
         state["lanes"].pop(scope, None)
     _write_state(request, state)
     return state
+
+
+@router.get("/api/observatory/fleet")
+async def get_fleet(request: Request, user: CurrentUser = Depends(current_user)):
+    """The Observe half: which agents are working and what they hold right now.
+
+    Derives state from the board: an agent that holds a claimed task is
+    'working' on it. Admins see every project; other users see their own.
+    The current pause state is returned alongside so the UI can show both in
+    one read. Trace-timeline and PR-in-review enrichment are phase 2.
+    """
+    pstore = request.app.state.project_store
+    tstore = request.app.state.project_task_store
+    if user.is_admin:
+        projects = await pstore.list_projects(status=None)
+    else:
+        projects = await pstore.list_for_user(user.user_id, status=None)
+
+    agents: list[dict] = []
+    for proj in projects:
+        pid = proj.get("id")
+        if not pid:
+            continue
+        for t in await tstore.list_tasks(pid, status="claimed"):
+            handle = t.get("claimed_by")
+            if not handle:
+                continue
+            agents.append({
+                "handle": handle,
+                "state": "working",
+                "holds": {
+                    "task_id": t.get("id"),
+                    "project_id": pid,
+                    "title": t.get("title"),
+                },
+            })
+    agents.sort(key=lambda a: a["handle"])
+    return {"agents": agents, "paused": _read_state(request)}


### PR DESCRIPTION
The Observe half of the Observatory spec (stacked on #1341, which adds observatory.py + the pause API; merge #1341 first).

`GET /api/observatory/fleet` derives each agent's live state from the board: an agent holding a claimed task is `working` on it, with the held card surfaced (id, project, title). Admins see every project; other users see their own. The current pause state is returned alongside so the UI renders Observe + Steer in one read.

Phase 2 enrichment (deferred): per-agent trace timeline (over the existing trace_store endpoints), idle/registered agents from agent_registry, and PR-in-review state from GitHub. 2 tests (empty fleet, working agent with held card).