### PR TITLE
feat(desktop): Observatory app (fleet view + queue pause)

### DIFF
--- a/desktop/src/apps/ObservatoryApp.test.tsx
+++ b/desktop/src/apps/ObservatoryApp.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ObservatoryApp } from "./ObservatoryApp";
+
+function mockFetch(
+  responses: Record<string, { ok: boolean; status?: number; body: unknown }>,
+) {
+  return vi.fn().mockImplementation((input: string, init?: RequestInit) => {
+    const method = (init?.method ?? "GET").toUpperCase();
+    const hit = responses[`${method} ${input}`] ?? responses[input] ?? responses["*"];
+    if (!hit) throw new Error(`Unmocked fetch: ${method} ${input}`);
+    return Promise.resolve({
+      ok: hit.ok,
+      status: hit.status ?? (hit.ok ? 200 : 422),
+      json: () => Promise.resolve(hit.body),
+    });
+  });
+}
+
+async function flush() {
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 0));
+  });
+}
+
+const fleetBody = {
+  agents: [
+    {
+      handle: "@taOS-dev-kilo-owl-alpha",
+      state: "working",
+      holds: { task_id: "tsk-1", project_id: "prj-x", title: "Add tests" },
+    },
+  ],
+  paused: { global: false, lanes: {} },
+};
+
+describe("ObservatoryApp", () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it("renders the fleet with the held card", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch({ "GET /api/observatory/fleet": { ok: true, body: fleetBody } }),
+    );
+    render(<ObservatoryApp windowId="w1" />);
+    await flush();
+    await waitFor(() =>
+      expect(screen.getByText("@taOS-dev-kilo-owl-alpha")).toBeTruthy(),
+    );
+    expect(screen.getByText(/Add tests/)).toBeTruthy();
+  });
+
+  it("posts a global pause when the queue toggle is clicked", async () => {
+    const fetchMock = mockFetch({
+      "GET /api/observatory/fleet": { ok: true, body: fleetBody },
+      "POST /api/observatory/pause": { ok: true, body: { global: true, lanes: {} } },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    render(<ObservatoryApp windowId="w1" />);
+    await flush();
+
+    fireEvent.click(screen.getByRole("button", { name: /pause queue/i }));
+    await flush();
+
+    const post = fetchMock.mock.calls.find(
+      (c) => (c[1] as RequestInit)?.method === "POST",
+    );
+    expect(post![0]).toBe("/api/observatory/pause");
+    const sent = JSON.parse((post![1] as RequestInit).body as string);
+    expect(sent).toEqual({ scope: "global", paused: true });
+  });
+
+  it("posts a per-lane pause from the lane switch", async () => {
+    const fetchMock = mockFetch({
+      "GET /api/observatory/fleet": { ok: true, body: fleetBody },
+      "POST /api/observatory/pause": {
+        ok: true,
+        body: { global: false, lanes: { "@taOS-dev-kilo-owl-alpha": true } },
+      },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    render(<ObservatoryApp windowId="w1" />);
+    await flush();
+
+    fireEvent.click(screen.getByRole("switch", { name: /pause lane/i }));
+    await flush();
+
+    const post = fetchMock.mock.calls.find(
+      (c) => (c[1] as RequestInit)?.method === "POST",
+    );
+    const sent = JSON.parse((post![1] as RequestInit).body as string);
+    expect(sent).toEqual({ scope: "@taOS-dev-kilo-owl-alpha", paused: true });
+  });
+
+  it("shows the idle empty state when no agents are working", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch({
+        "GET /api/observatory/fleet": {
+          ok: true,
+          body: { agents: [], paused: { global: false, lanes: {} } },
+        },
+      }),
+    );
+    render(<ObservatoryApp windowId="w1" />);
+    await flush();
+    await waitFor(() => expect(screen.getByText(/all lanes idle/i)).toBeTruthy());
+  });
+});

--- a/desktop/src/apps/ObservatoryApp.test.tsx
+++ b/desktop/src/apps/ObservatoryApp.test.tsx
@@ -107,3 +107,20 @@ describe("ObservatoryApp", () => {
     await waitFor(() => expect(screen.getByText(/all lanes idle/i)).toBeTruthy());
   });
 });
+
+describe("ObservatoryApp polling", () => {
+  it("re-fetches the fleet on an interval so status stays live", async () => {
+    vi.useFakeTimers();
+    const fetchMock = mockFetch({
+      "GET /api/observatory/fleet": { ok: true, body: fleetBody },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    render(<ObservatoryApp windowId="w1" />);
+    await act(async () => { await Promise.resolve(); });
+    const initial = fetchMock.mock.calls.length;
+    expect(initial).toBeGreaterThanOrEqual(1);
+    await act(async () => { vi.advanceTimersByTime(5000); await Promise.resolve(); });
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(initial);
+    vi.useRealTimers();
+  });
+});

--- a/desktop/src/apps/ObservatoryApp.tsx
+++ b/desktop/src/apps/ObservatoryApp.tsx
@@ -47,6 +47,9 @@ export function ObservatoryApp({ windowId: _windowId }: { windowId: string }) {
 
   useEffect(() => {
     load();
+    // Poll so the fleet + pause state stay live without a manual refresh.
+    const id = setInterval(() => load({ silent: true }), 5000);
+    return () => clearInterval(id);
   }, [load]);
 
   const setScope = useCallback(

--- a/desktop/src/apps/ObservatoryApp.tsx
+++ b/desktop/src/apps/ObservatoryApp.tsx
@@ -1,0 +1,172 @@
+import { useState, useEffect, useCallback } from "react";
+import { Radar, Pause, Play, Loader2, CircleDot } from "lucide-react";
+import { Switch } from "@/components/ui";
+
+interface HeldCard {
+  task_id: string;
+  project_id: string;
+  title: string | null;
+}
+
+interface FleetAgent {
+  handle: string;
+  state: string;
+  holds: HeldCard | null;
+}
+
+interface PauseState {
+  global: boolean;
+  lanes: Record<string, boolean>;
+}
+
+const EMPTY_PAUSE: PauseState = { global: false, lanes: {} };
+
+export function ObservatoryApp({ windowId: _windowId }: { windowId: string }) {
+  const [agents, setAgents] = useState<FleetAgent[]>([]);
+  const [pause, setPause] = useState<PauseState>(EMPTY_PAUSE);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState<string | null>(null);
+
+  const load = useCallback(async (opts?: { silent?: boolean }) => {
+    if (!opts?.silent) setLoading(true);
+    try {
+      const res = await fetch("/api/observatory/fleet");
+      if (res.ok) {
+        const data = await res.json();
+        setAgents(Array.isArray(data.agents) ? data.agents : []);
+        setPause(
+          data.paused && typeof data.paused === "object" ? data.paused : EMPTY_PAUSE,
+        );
+      }
+    } catch {
+      // Non-critical: keep the last-loaded view.
+    } finally {
+      if (!opts?.silent) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const setScope = useCallback(
+    async (scope: string, paused: boolean) => {
+      setBusy(scope);
+      // Optimistic: reflect the toggle immediately, reconcile on refresh.
+      setPause((prev) =>
+        scope === "global"
+          ? { ...prev, global: paused }
+          : {
+              ...prev,
+              lanes: { ...prev.lanes, [scope]: paused },
+            },
+      );
+      try {
+        await fetch("/api/observatory/pause", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ scope, paused }),
+        });
+        await load({ silent: true });
+      } catch {
+        await load({ silent: true });
+      } finally {
+        setBusy(null);
+      }
+    },
+    [load],
+  );
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden bg-shell-bg">
+      {/* Header + global steer */}
+      <div className="flex items-center gap-2 border-b border-shell-border px-5 py-4">
+        <Radar size={18} className="text-accent" />
+        <h1 className="text-base font-semibold text-shell-text">Observatory</h1>
+        <button
+          type="button"
+          onClick={() => setScope("global", !pause.global)}
+          disabled={busy === "global"}
+          aria-pressed={pause.global}
+          className={[
+            "ml-auto flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors",
+            pause.global
+              ? "bg-amber-500/15 text-amber-400 hover:bg-amber-500/25"
+              : "border border-shell-border text-shell-text-secondary hover:text-shell-text hover:border-shell-border-strong",
+          ].join(" ")}
+        >
+          {pause.global ? <Play size={15} /> : <Pause size={15} />}
+          {pause.global ? "Resume queue" : "Pause queue"}
+        </button>
+      </div>
+
+      {pause.global && (
+        <div
+          className="flex items-center gap-2 border-b border-amber-500/20 bg-amber-500/10 px-5 py-2 text-sm text-amber-400"
+          role="status"
+        >
+          <Pause size={14} className="shrink-0" />
+          Dispatch is paused. In-flight work finishes; no new cards are claimed.
+        </div>
+      )}
+
+      {/* Fleet (Observe) */}
+      <div className="flex-1 overflow-y-auto px-5 py-4">
+        <h2 className="mb-3 text-xs font-medium uppercase tracking-wide text-shell-text-tertiary">
+          Fleet
+        </h2>
+        {loading ? (
+          <p className="flex items-center gap-2 text-sm text-shell-text-tertiary">
+            <Loader2 size={14} className="animate-spin" />
+            Loading...
+          </p>
+        ) : agents.length === 0 ? (
+          <div className="flex flex-col items-center gap-2 py-16 text-center">
+            <Radar size={28} className="text-shell-text-tertiary" />
+            <p className="text-sm text-shell-text-secondary">All lanes idle.</p>
+          </div>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {agents.map((a) => {
+              const lanePaused = !!pause.lanes[a.handle];
+              return (
+                <li
+                  key={a.handle + (a.holds?.task_id ?? "")}
+                  className="flex items-center gap-3 rounded-xl border border-shell-border bg-shell-surface px-4 py-3"
+                >
+                  <CircleDot
+                    size={14}
+                    className={lanePaused ? "shrink-0 text-amber-400" : "shrink-0 text-green-400"}
+                  />
+                  <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                    <span className="truncate text-sm font-medium text-shell-text">
+                      {a.handle}
+                    </span>
+                    {a.holds ? (
+                      <span className="truncate text-xs text-shell-text-secondary">
+                        {lanePaused ? "paused" : "working"} &middot; {a.holds.title ?? a.holds.task_id}
+                      </span>
+                    ) : (
+                      <span className="text-xs text-shell-text-tertiary">
+                        {lanePaused ? "paused" : a.state}
+                      </span>
+                    )}
+                  </div>
+                  <label className="flex shrink-0 items-center gap-1.5 text-xs text-shell-text-tertiary">
+                    Pause
+                    <Switch
+                      checked={lanePaused}
+                      disabled={busy === a.handle}
+                      onCheckedChange={(v: boolean) => setScope(a.handle, v)}
+                      aria-label={`Pause lane ${a.handle}`}
+                    />
+                  </label>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/registry/app-registry.ts
+++ b/desktop/src/registry/app-registry.ts
@@ -61,6 +61,7 @@ const apps: AppManifest[] = [
   { id: "agent-browsers", name: "Browsers", icon: "globe", category: "platform", component: () => import("@/apps/AgentBrowsersApp").then((m) => ({ default: m.AgentBrowsersApp })), defaultSize: { w: 1000, h: 650 }, minSize: { w: 550, h: 400 }, singleton: true, pinned: false, launchpadOrder: 16 },
   { id: "feedback", name: "Feedback", icon: "flag", category: "platform", component: () => import("@/apps/FeedbackApp").then((m) => ({ default: m.FeedbackApp })), defaultSize: { w: 700, h: 560 }, minSize: { w: 420, h: 400 }, singleton: true, pinned: false, launchpadOrder: 16.5 },
   { id: "decisions", name: "Decisions", icon: "inbox", category: "platform", component: () => import("@/apps/DecisionsApp").then((m) => ({ default: m.DecisionsApp })), defaultSize: { w: 640, h: 620 }, minSize: { w: 420, h: 400 }, singleton: true, pinned: false, launchpadOrder: 16.6 },
+  { id: "observatory", name: "Observatory", icon: "radar", category: "platform", component: () => import("@/apps/ObservatoryApp").then((m) => ({ default: m.ObservatoryApp })), defaultSize: { w: 620, h: 600 }, minSize: { w: 420, h: 400 }, singleton: true, pinned: false, launchpadOrder: 16.7 },
 
   // OS apps
   { id: "weather", name: "Weather", icon: "cloud", category: "os", component: () => import("@/apps/WeatherApp").then((m) => ({ default: m.WeatherApp })), defaultSize: { w: 800, h: 600 }, minSize: { w: 400, h: 400 }, singleton: true, pinned: false, launchpadOrder: 19 },


### PR DESCRIPTION
The Observatory app UI, surfacing the fleet view (#1343) and queue-control pause (#1341) in one window.

- Fleet (Observe): each working agent with a live status dot and the card it holds, from `GET /api/observatory/fleet`.
- Steer: a prominent global Pause/Resume queue button + a per-lane pause switch on each agent, posting to `/api/observatory/pause` with optimistic toggles. A banner shows when dispatch is paused; idle empty state otherwise.
- Registered as a platform app (`observatory`, launchpad order 16.7).

4 vitest cases (fleet render, global pause POST, per-lane pause POST, idle state); tsc clean. Reads endpoints from #1341 (merged) + #1343 (fleet, in CI) so it lights up once both are on the controller.