### PR TITLE
feat(observatory): fleet phase-2 -- idle registered agents

### DIFF
--- a/tests/test_routes_observatory.py
+++ b/tests/test_routes_observatory.py
@@ -77,3 +77,39 @@ async def test_fleet_shows_working_agent_with_held_card(app, client):
     assert mine[0]["state"] == "working"
     assert mine[0]["holds"]["task_id"] == task["id"]
     assert mine[0]["holds"]["title"] == "Build the thing"
+
+
+@pytest.mark.asyncio
+async def test_fleet_includes_idle_registered_agents(app, client):
+    reg = app.state.agent_registry
+    if reg._db is None:
+        await reg.init()
+    await reg.register(framework="opencode", display_name="Side Agent",
+                       handle="@side-agent", user_id="admin")
+    resp = await client.get("/api/observatory/fleet")
+    assert resp.status_code == 200
+    agents = resp.json()["agents"]
+    idle = [a for a in agents if a["handle"] == "@side-agent"]
+    assert len(idle) == 1
+    assert idle[0]["state"] == "idle"
+    assert idle[0]["holds"] is None
+
+
+@pytest.mark.asyncio
+async def test_registered_agent_with_a_claim_is_working_not_idle(app, client):
+    pstore = app.state.project_store
+    tstore = app.state.project_task_store
+    reg = app.state.agent_registry
+    if reg._db is None:
+        await reg.init()
+    await reg.register(framework="opencode", display_name="Busy Agent",
+                       handle="@busy-agent", user_id="admin")
+    proj = await pstore.create_project(name="Obs2", slug="obs-idle", created_by="admin", user_id="admin")
+    task = await tstore.create_task(proj["id"], title="Do work", created_by="admin")
+    await tstore.claim_task(task["id"], "@busy-agent")
+
+    resp = await client.get("/api/observatory/fleet")
+    rows = [a for a in resp.json()["agents"] if a["handle"] == "@busy-agent"]
+    # The agent appears once, as working (not duplicated as idle).
+    assert len(rows) == 1
+    assert rows[0]["state"] == "working"

--- a/tinyagentos/routes/observatory.py
+++ b/tinyagentos/routes/observatory.py
@@ -85,9 +85,10 @@ async def get_fleet(request: Request, user: CurrentUser = Depends(current_user))
     """The Observe half: which agents are working and what they hold right now.
 
     Derives state from the board: an agent that holds a claimed task is
-    'working' on it. Admins see every project; other users see their own.
-    The current pause state is returned alongside so the UI can show both in
-    one read. Trace-timeline and PR-in-review enrichment are phase 2.
+    'working' on it, and a registered agent that holds none is 'idle'. Admins
+    see every project + agent; other users see their own. The current pause
+    state is returned alongside so the UI can show both in one read.
+    Trace-timeline and PR-in-review enrichment are phase 2.
     """
     pstore = request.app.state.project_store
     tstore = request.app.state.project_task_store
@@ -97,6 +98,7 @@ async def get_fleet(request: Request, user: CurrentUser = Depends(current_user))
         projects = await pstore.list_for_user(user.user_id, status=None)
 
     agents: list[dict] = []
+    working: set[str] = set()
     for proj in projects:
         pid = proj.get("id")
         if not pid:
@@ -105,6 +107,7 @@ async def get_fleet(request: Request, user: CurrentUser = Depends(current_user))
             handle = t.get("claimed_by")
             if not handle:
                 continue
+            working.add(handle)
             agents.append({
                 "handle": handle,
                 "state": "working",
@@ -114,5 +117,25 @@ async def get_fleet(request: Request, user: CurrentUser = Depends(current_user))
                     "title": t.get("title"),
                 },
             })
+
+    # Registered agents holding no card are idle; surface them so the fleet
+    # shows the full active roster, not just the busy lanes. Best-effort: a
+    # missing or erroring registry must not break the working view.
+    registry = getattr(request.app.state, "agent_registry", None)
+    if registry is not None:
+        try:
+            if user.is_admin:
+                registered = await registry.list_all(status="active")
+            else:
+                registered = await registry.list_for_user(user.user_id, status="active")
+        except Exception:
+            registered = []
+        for rec in registered:
+            handle = (rec.get("handle") or "").strip()
+            if not handle or handle in working:
+                continue
+            working.add(handle)
+            agents.append({"handle": handle, "state": "idle", "holds": None})
+
     agents.sort(key=lambda a: a["handle"])
     return {"agents": agents, "paused": _read_state(request)}


### PR DESCRIPTION
Observatory Observe phase-2: the fleet view now shows the full active roster, not just busy lanes.

`GET /api/observatory/fleet` adds registered agents (from agent_registry) that hold no claimed card as `idle` entries (holds: null). Admins see all registered agents; other users see their own. Best-effort: a missing/erroring registry never breaks the working view, and an agent holding a claim stays `working` (deduped, not also listed idle).

2 new tests (idle registered agent surfaces; a registered agent with a claim is working not idle); 9 observatory tests pass. Builds on the merged fleet endpoint (#1343).