### PR TITLE
feat(decisions): route decision notifications to the Decisions app

### DIFF
--- a/desktop/src/lib/server-notifications.test.ts
+++ b/desktop/src/lib/server-notifications.test.ts
@@ -117,6 +117,10 @@ describe("server-notifications", () => {
       expect(sourceToTarget("app.failed")).toEqual({ action: "store" });
     });
 
+    it("routes decision notifications to the Decisions app", () => {
+      expect(sourceToTarget("decisions")).toEqual({ action: "decisions" });
+    });
+
     it("returns no action for unknown sources", () => {
       expect(sourceToTarget("something.else")).toEqual({});
       expect(sourceToTarget("")).toEqual({});

--- a/desktop/src/lib/server-notifications.ts
+++ b/desktop/src/lib/server-notifications.ts
@@ -55,6 +55,8 @@ export function sourceToTarget(
     case "app.installed":
     case "app.failed":
       return { action: "store" };
+    case "decisions":
+      return { action: "decisions" };
     default:
       return {};
   }


### PR DESCRIPTION
Completes the Decisions delivery mechanism: the backend raises a `source='decisions'` notification when an agent posts a decision, but `sourceToTarget` had no case, so the actionable notification did nothing. Maps `decisions` -> the Decisions app so clicking the notification deep-links there (per decisions-design: notifications are how a decision reaches Jay, the click opens the right place). +1 test; 19 pass.