### PR TITLE
canvas: accept ideas-board kinds (text/mermaid/flowchart/mindmap_edge)

### DIFF
--- a/tests/projects/test_canvas_store.py
+++ b/tests/projects/test_canvas_store.py
@@ -59,6 +59,30 @@ async def test_add_element_rejects_agent_user_shape(store):
         )
 
 
+@pytest.mark.parametrize("kind", ["text", "mermaid", "flowchart", "mindmap_edge"])
+@pytest.mark.asyncio
+async def test_user_can_add_ideas_board_kind(store, kind):
+    e = await store.add_element(
+        project_id="p",
+        element={"kind": kind, "x": 0, "y": 0, "w": 10, "h": 10, "payload": {"v": 1}},
+        author_kind="user", author_id="u",
+    )
+    assert e["kind"] == kind
+    assert e["payload"] == {"v": 1}
+
+
+@pytest.mark.parametrize("kind", ["text", "mermaid", "flowchart", "mindmap_edge"])
+@pytest.mark.asyncio
+async def test_agent_cannot_yet_emit_ideas_board_kind(store, kind):
+    # Agent emission of the new kinds stays gated until their canvas tools land.
+    with pytest.raises(ValueError, match="agents may not emit"):
+        await store.add_element(
+            project_id="p",
+            element={"kind": kind, "x": 0, "y": 0, "w": 1, "h": 1, "payload": {}},
+            author_kind="agent", author_id="agent-1",
+        )
+
+
 @pytest.mark.asyncio
 async def test_list_elements_excludes_other_projects(store):
     a = await store.add_element(

--- a/tests/test_routes_project_canvas.py
+++ b/tests/test_routes_project_canvas.py
@@ -154,6 +154,44 @@ async def test_create_user_shape_element_returns_201(client):
 
 
 # ---------------------------------------------------------------------------
+# Ideas-board kinds (#68): text, mermaid, flowchart, mindmap_edge.
+# Content travels in the free-form payload, so each just needs to round-trip.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "kind,payload",
+    [
+        ("text", {"text": "an idea", "font_size": 18}),
+        ("mermaid", {"source": "graph TD; A-->B"}),
+        ("flowchart", {"source": "flowchart LR; start-->end"}),
+        ("mindmap_edge", {"from": "cve-a", "to": "cve-b"}),
+    ],
+)
+@pytest.mark.asyncio
+async def test_create_ideas_board_kind_round_trips(client, kind, payload):
+    body = {"kind": kind, "x": 5, "y": 5, "w": 120, "h": 60, "payload": payload}
+    resp = await client.post("/api/projects/proj-1/canvas/elements", json=body)
+    assert resp.status_code == 201, resp.text
+    el = resp.json()["element"]
+    assert el["kind"] == kind
+    assert el["payload"] == payload
+
+
+@pytest.mark.asyncio
+async def test_ideas_board_kind_appears_in_list(client):
+    body = {
+        "kind": "mermaid",
+        "x": 0, "y": 0, "w": 200, "h": 120,
+        "payload": {"source": "graph TD; X-->Y"},
+    }
+    await client.post("/api/projects/proj-1/canvas/elements", json=body)
+    data = (await client.get("/api/projects/proj-1/canvas/elements")).json()
+    kinds = [e["kind"] for e in data["elements"]]
+    assert "mermaid" in kinds
+
+
+# ---------------------------------------------------------------------------
 # Update element
 # ---------------------------------------------------------------------------
 

--- a/tinyagentos/projects/canvas/store.py
+++ b/tinyagentos/projects/canvas/store.py
@@ -34,7 +34,15 @@ CREATE INDEX IF NOT EXISTS idx_canvas_updated ON project_canvas_elements(project
 """
 
 _CANVAS_JSON_FIELDS = ("payload",)
-_VALID_KINDS = {"note", "link", "image", "user_shape"}
+# Ideas-board kinds (text, mermaid, flowchart, mindmap_edge) carry their
+# content in the free-form payload, so they need no schema change beyond being
+# accepted here. Agent emission of these stays gated until the agent canvas
+# tools for them land (a deliberate later slice), so they are NOT yet added to
+# _AGENT_ALLOWED_KINDS.
+_VALID_KINDS = {
+    "note", "link", "image", "user_shape",
+    "text", "mermaid", "flowchart", "mindmap_edge",
+}
 _AGENT_ALLOWED_KINDS = {"note", "link", "image"}
 
 

--- a/tinyagentos/routes/project_canvas.py
+++ b/tinyagentos/routes/project_canvas.py
@@ -29,7 +29,10 @@ def _user_id(request: Request) -> str:
 
 
 class CreateElementIn(BaseModel):
-    kind: Literal["note", "link", "image", "user_shape"]
+    kind: Literal[
+        "note", "link", "image", "user_shape",
+        "text", "mermaid", "flowchart", "mindmap_edge",
+    ]
     x: float
     y: float
     w: float


### PR DESCRIPTION
Additive backend for the infinite ideas board (#68) and slice 3 of the tldraw->Konva canvas migration (#16/#75).

## What
- `ProjectCanvasStore._VALID_KINDS` and the REST `CreateElementIn.kind` Literal now accept four ideas-board kinds: `text`, `mermaid`, `flowchart`, `mindmap_edge`.
- Content rides in the existing free-form `payload` (mermaid/flowchart source, mindmap_edge from/to anchors), so there is no schema migration.

## Gating
- Agent emission of the new kinds is deliberately NOT opened: `_AGENT_ALLOWED_KINDS` is unchanged. Agents keep their note/link/image tools; new-kind agent emission lands with its own canvas tools in a later slice. A test locks this gate.

## Tests
- Route round-trip per new kind + appears-in-list (`test_routes_project_canvas.py`).
- Store: user can add each new kind; agent still cannot (`test_canvas_store.py`).
- 43 passed locally.

Surgical/additive; no behaviour change for existing kinds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Canvas now supports additional element types: text, mermaid diagrams, flowcharts, and mindmap edges.

* **Tests**
  * Added comprehensive test coverage for new canvas element types and API validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->