### PR TITLE
canvas: render ideas-board kinds distinctly in the snapshot

### DIFF
--- a/tests/projects/test_canvas_render.py
+++ b/tests/projects/test_canvas_render.py
@@ -4,7 +4,12 @@ from pathlib import Path
 import pytest
 from PIL import Image
 
-from tinyagentos.projects.canvas.render import render_snapshot_png
+from tinyagentos.projects.canvas.render import (
+    render_snapshot_png,
+    _label_for,
+    _KIND_FILL,
+    _KIND_OUTLINE,
+)
 
 
 def test_render_empty_canvas_returns_blank_png(tmp_path):
@@ -29,3 +34,55 @@ def test_render_with_note(tmp_path):
     img = Image.open(out)
     assert img.size[0] >= 600
     assert img.size[1] >= 400
+
+
+# ---------------------------------------------------------------------------
+# Ideas-board kinds (#68): distinct colours + meaningful labels in the
+# vision-agent snapshot.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("kind", ["text", "mermaid", "flowchart", "mindmap_edge"])
+def test_ideas_board_kinds_have_distinct_colours(kind):
+    # Each new kind must have its own colour, not fall back to user_shape's.
+    assert kind in _KIND_FILL
+    assert kind in _KIND_OUTLINE
+    assert _KIND_FILL[kind] != _KIND_FILL["user_shape"]
+
+
+def test_label_for_text_uses_payload_text():
+    el = {"kind": "text", "payload": {"text": "an idea"}}
+    assert _label_for(el) == "an idea"
+
+
+def test_label_for_mermaid_uses_first_source_line():
+    el = {"kind": "mermaid", "payload": {"source": "graph TD;\nA-->B"}}
+    assert _label_for(el) == "graph TD;"
+
+
+def test_label_for_mindmap_edge_shows_endpoints():
+    el = {"kind": "mindmap_edge", "payload": {"from": "a", "to": "b"}}
+    assert _label_for(el) == "a -> b"
+
+
+def test_label_for_mindmap_edge_without_endpoints_falls_back():
+    el = {"kind": "mindmap_edge", "payload": {}}
+    assert _label_for(el) == "mindmap_edge"
+
+
+def test_render_ideas_board_kinds_smoke(tmp_path):
+    out = tmp_path / "snap.png"
+    elements = [
+        {"id": "t", "kind": "text", "x": 0, "y": 0, "w": 120, "h": 60,
+         "rotation": 0, "z_index": 0, "author_id": "u", "author_kind": "user",
+         "payload": {"text": "idea"}},
+        {"id": "m", "kind": "mermaid", "x": 130, "y": 0, "w": 200, "h": 120,
+         "rotation": 0, "z_index": 0, "author_id": "u", "author_kind": "user",
+         "payload": {"source": "graph TD; X-->Y"}},
+        {"id": "e", "kind": "mindmap_edge", "x": 0, "y": 130, "w": 150, "h": 20,
+         "rotation": 0, "z_index": 0, "author_id": "u", "author_kind": "user",
+         "payload": {"from": "t", "to": "m"}},
+    ]
+    render_snapshot_png(elements=elements, output_path=out)
+    assert out.exists()
+    assert Image.open(out).size[0] > 0

--- a/tinyagentos/projects/canvas/render.py
+++ b/tinyagentos/projects/canvas/render.py
@@ -21,12 +21,22 @@ _KIND_FILL = {
     "link":   (190, 215, 255, 255),
     "image":  (220, 220, 220, 255),
     "user_shape": (245, 245, 245, 255),
+    # Ideas-board kinds, each a distinct hue so a vision agent can tell them
+    # apart in the low-fidelity snapshot.
+    "text":         (215, 240, 205, 255),
+    "mermaid":      (255, 224, 178, 255),
+    "flowchart":    (200, 232, 240, 255),
+    "mindmap_edge": (245, 215, 225, 255),
 }
 _KIND_OUTLINE = {
     "note":   (200, 180, 60, 255),
     "link":   (90, 130, 220, 255),
     "image":  (140, 140, 140, 255),
     "user_shape": (180, 180, 180, 255),
+    "text":         (120, 180, 90, 255),
+    "mermaid":      (220, 150, 60, 255),
+    "flowchart":    (70, 160, 185, 255),
+    "mindmap_edge": (200, 110, 140, 255),
 }
 
 
@@ -49,6 +59,15 @@ def _label_for(el: dict) -> str:
         return str(payload.get("title") or payload.get("url") or "")[:60]
     if kind == "image":
         return str(payload.get("alt", "image"))[:40]
+    if kind == "text":
+        return str(payload.get("text", ""))[:60]
+    if kind in ("mermaid", "flowchart"):
+        source = str(payload.get("source", "")).strip().splitlines()
+        return (source[0] if source else kind)[:60]
+    if kind == "mindmap_edge":
+        src = payload.get("from")
+        dst = payload.get("to")
+        return f"{src} -> {dst}" if src and dst else kind
     return kind
 
 


### PR DESCRIPTION
Follow-on to #1355 (which made the canvas store accept the ideas-board kinds). The low-fidelity server-side snapshot renderer (`render.py`, used by `snapshot.png` + the vision-agent canvas readout) only knew note/link/image/user_shape, so text/mermaid/flowchart/mindmap_edge rendered as an undifferentiated grey `user_shape` box labelled with the raw kind string.

## What
- Distinct fill/outline per new kind (greens/oranges/cyans/rose, no purple per branding).
- `_label_for` now returns content: text -> its text, mermaid/flowchart -> first source line, mindmap_edge -> `from -> to`.

## Notes
- Independent of #1355: `render.py` renders whatever elements it is handed, so this lands cleanly on dev on its own (different files, no conflict). The kinds only reach the API once #1355 merges.

## Tests
- Label logic per kind + fallback; distinct-colour assertions; render smoke for the new kinds. 11 passed locally.