### PR TITLE
canvas: map ideas-board kinds to Konva render nodes

### DIFF
--- a/desktop/src/apps/ProjectsApp/__tests__/element-to-konva.test.ts
+++ b/desktop/src/apps/ProjectsApp/__tests__/element-to-konva.test.ts
@@ -44,6 +44,28 @@ describe("elementToNode", () => {
     expect(elementToNode(el({ kind: "wat" as never })).type).toBe("shape");
   });
 
+  it("maps a text node with its content and defaults", () => {
+    const n = elementToNode(el({ kind: "text" as never, payload: { text: "an idea", font_size: 20 } }));
+    expect(n).toMatchObject({ type: "text", text: "an idea", fontSize: 20, color: "#1e293b" });
+  });
+
+  it("maps mermaid and flowchart to their source", () => {
+    expect(elementToNode(el({ kind: "mermaid" as never, payload: { source: "graph TD; A-->B" } })))
+      .toMatchObject({ type: "mermaid", source: "graph TD; A-->B" });
+    expect(elementToNode(el({ kind: "flowchart" as never, payload: { source: "flowchart LR; a-->b" } })))
+      .toMatchObject({ type: "flowchart", source: "flowchart LR; a-->b" });
+  });
+
+  it("maps a mindmap_edge to its endpoints", () => {
+    const n = elementToNode(el({ kind: "mindmap_edge" as never, payload: { from: "cve-a", to: "cve-b" } }));
+    expect(n).toMatchObject({ type: "mindmap_edge", from: "cve-a", to: "cve-b" });
+  });
+
+  it("coerces a missing diagram source to empty string", () => {
+    expect(elementToNode(el({ kind: "mermaid" as never, payload: {} })))
+      .toMatchObject({ type: "mermaid", source: "" });
+  });
+
   it("coerces malformed geometry + payload to defaults instead of crashing", () => {
     const n = elementToNode(el({
       kind: "note",

--- a/desktop/src/apps/ProjectsApp/__tests__/element-to-konva.test.ts
+++ b/desktop/src/apps/ProjectsApp/__tests__/element-to-konva.test.ts
@@ -45,24 +45,24 @@ describe("elementToNode", () => {
   });
 
   it("maps a text node with its content and defaults", () => {
-    const n = elementToNode(el({ kind: "text" as never, payload: { text: "an idea", font_size: 20 } }));
+    const n = elementToNode(el({ kind: "text", payload: { text: "an idea", font_size: 20 } }));
     expect(n).toMatchObject({ type: "text", text: "an idea", fontSize: 20, color: "#1e293b" });
   });
 
   it("maps mermaid and flowchart to their source", () => {
-    expect(elementToNode(el({ kind: "mermaid" as never, payload: { source: "graph TD; A-->B" } })))
+    expect(elementToNode(el({ kind: "mermaid", payload: { source: "graph TD; A-->B" } })))
       .toMatchObject({ type: "mermaid", source: "graph TD; A-->B" });
-    expect(elementToNode(el({ kind: "flowchart" as never, payload: { source: "flowchart LR; a-->b" } })))
+    expect(elementToNode(el({ kind: "flowchart", payload: { source: "flowchart LR; a-->b" } })))
       .toMatchObject({ type: "flowchart", source: "flowchart LR; a-->b" });
   });
 
   it("maps a mindmap_edge to its endpoints", () => {
-    const n = elementToNode(el({ kind: "mindmap_edge" as never, payload: { from: "cve-a", to: "cve-b" } }));
+    const n = elementToNode(el({ kind: "mindmap_edge", payload: { from: "cve-a", to: "cve-b" } }));
     expect(n).toMatchObject({ type: "mindmap_edge", from: "cve-a", to: "cve-b" });
   });
 
   it("coerces a missing diagram source to empty string", () => {
-    expect(elementToNode(el({ kind: "mermaid" as never, payload: {} })))
+    expect(elementToNode(el({ kind: "mermaid", payload: {} })))
       .toMatchObject({ type: "mermaid", source: "" });
   });
 

--- a/desktop/src/apps/ProjectsApp/canvas/canvas-api.ts
+++ b/desktop/src/apps/ProjectsApp/canvas/canvas-api.ts
@@ -1,4 +1,13 @@
-export type CanvasElementKind = "note" | "link" | "image" | "user_shape";
+export type CanvasElementKind =
+  | "note"
+  | "link"
+  | "image"
+  | "user_shape"
+  // Ideas-board kinds (#68), matching the backend store + REST.
+  | "text"
+  | "mermaid"
+  | "flowchart"
+  | "mindmap_edge";
 
 export interface CanvasElement {
   id: string;

--- a/desktop/src/apps/ProjectsApp/canvas/element-to-konva.ts
+++ b/desktop/src/apps/ProjectsApp/canvas/element-to-konva.ts
@@ -20,6 +20,13 @@ export type CanvasNode =
   | (BaseNode & { type: "note"; text: string; color: string; fontSize: number })
   | (BaseNode & { type: "link"; url: string; title: string; description: string })
   | (BaseNode & { type: "image"; fileId: string; alt: string; mime: string })
+  // Ideas-board kinds (#68). text is plain text without a card; mermaid and
+  // flowchart carry diagram source rendered client-side in a later slice;
+  // mindmap_edge connects two elements by id.
+  | (BaseNode & { type: "text"; text: string; fontSize: number; color: string })
+  | (BaseNode & { type: "mermaid"; source: string })
+  | (BaseNode & { type: "flowchart"; source: string })
+  | (BaseNode & { type: "mindmap_edge"; from: string; to: string })
   | (BaseNode & { type: "shape" });
 
 function num(v: unknown, fallback: number): number {
@@ -69,6 +76,20 @@ export function elementToNode(el: CanvasElement): CanvasNode {
         alt: str(p.alt),
         mime: str(p.mime, "image/png"),
       };
+    case "text":
+      return {
+        ...base,
+        type: "text",
+        text: str(p.text, ""),
+        fontSize: num(p.font_size, 16),
+        color: str(p.color, "#1e293b"),
+      };
+    case "mermaid":
+      return { ...base, type: "mermaid", source: str(p.source) };
+    case "flowchart":
+      return { ...base, type: "flowchart", source: str(p.source) };
+    case "mindmap_edge":
+      return { ...base, type: "mindmap_edge", from: str(p.from), to: str(p.to) };
     default:
       // user_shape and any unknown kind render as a generic box.
       return { ...base, type: "shape" };


### PR DESCRIPTION
Slice 3 frontend (mapping) of the tldraw->Konva migration (#16/#68/#75), stacking on the now-merged slice 1 (#1353) and backend kinds (#1355).

## What
- `element-to-konva.ts`: the `CanvasNode` union + `elementToNode` now cover `text`, `mermaid`, `flowchart`, `mindmap_edge` (the kinds the store began accepting in #1355). Same defensive type-coercion as existing kinds.

## Scope / safety
- Pure mapping only. The `KonvaBoard` `NodeView` has a generic-box `default` branch (no `never` exhaustiveness assert), so the new node types fall back to a placeholder box and nothing breaks. Dedicated rendering (mermaid/flowchart need a client-side diagram render to an image node, mindmap_edge a connector line) is a later slice that needs live-session screenshot verification.
- The Konva board is not yet wired in (swap is slice 4), so this changes no live UI.

## Tests
- 4 new mapping cases (text defaults, mermaid/flowchart source, mindmap_edge endpoints, missing-source coercion). 10 passed locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Canvas now supports text elements with customizable font sizes and colors.
  * Canvas rendering expanded to include mermaid and flowchart diagram support.
  * Canvas now renders mindmap edge connections.
  * Enhanced element rendering with improved default styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->