### PR TITLE
canvas: agent tools for ideas-board kinds + open the emission gate

### DIFF
--- a/tests/projects/test_canvas_mcp_tools.py
+++ b/tests/projects/test_canvas_mcp_tools.py
@@ -94,6 +94,21 @@ async def test_canvas_add_mindmap_edge_links_endpoints(env):
     assert el["kind"] == "mindmap_edge"
     assert el["payload"]["from"] == a["element"]["id"]
     assert el["payload"]["to"] == b["element"]["id"]
+    # The edge bbox spans its endpoints (centers), not a 1x1 box at the origin.
+    assert el["w"] > 1
+
+
+@pytest.mark.asyncio
+async def test_canvas_add_mindmap_edge_rejects_unknown_endpoint(env):
+    p, ctx, _ = env
+    a = await ct.canvas_add_text(
+        ctx, project_id=p["id"], agent_id="agent-1", text="a", x=0, y=0,
+    )
+    res = await ct.canvas_add_mindmap_edge(
+        ctx, project_id=p["id"], agent_id="agent-1",
+        from_id=a["element"]["id"], to_id="cve-does-not-exist",
+    )
+    assert res.get("error") == "not_found"
 
 
 @pytest.mark.asyncio

--- a/tinyagentos/projects/canvas/mcp_tools.py
+++ b/tinyagentos/projects/canvas/mcp_tools.py
@@ -133,14 +133,28 @@ async def canvas_add_mindmap_edge(
     ctx: CanvasToolContext, *, project_id: str, agent_id: str,
     from_id: str, to_id: str,
 ) -> dict:
-    # An edge connects two existing elements by id. Its own geometry is
-    # nominal: the renderer derives the line from the endpoints' anchors.
+    # An edge connects two existing elements by id. Reject dangling edges at
+    # creation rather than discovering them at render time, and span the edge's
+    # own bbox across the endpoints so it does not drag the snapshot bounds to
+    # the origin.
+    a = await ctx.canvas_store.get_element(from_id, project_id=project_id)
+    b = await ctx.canvas_store.get_element(to_id, project_id=project_id)
+    if a is None or b is None:
+        missing = from_id if a is None else to_id
+        return {
+            "error": "not_found",
+            "message": f"endpoint element {missing} not found in project {project_id}",
+        }
+    ax, ay = a["x"] + a["w"] / 2, a["y"] + a["h"] / 2
+    bx, by = b["x"] + b["w"] / 2, b["y"] + b["h"] / 2
     el = await ctx.canvas_store.add_element(
         project_id=project_id,
         author_kind="agent", author_id=agent_id,
         element={
-            "kind": "mindmap_edge", "x": 0.0, "y": 0.0,
-            "w": 1.0, "h": 1.0, "payload": {"from": from_id, "to": to_id},
+            "kind": "mindmap_edge",
+            "x": min(ax, bx), "y": min(ay, by),
+            "w": max(1.0, abs(ax - bx)), "h": max(1.0, abs(ay - by)),
+            "payload": {"from": from_id, "to": to_id},
         },
     )
     return {"element": el}


### PR DESCRIPTION
Lands the agent half of the infinite ideas board (#68 "agent + user read/write"), following the store kinds (#1355), snapshot renderer (#1357), and frontend mapping (#1358).

## What
- Four new agent canvas tools in `mcp_tools.py`: `canvas_add_text`, `canvas_add_mermaid`, `canvas_add_flowchart`, `canvas_add_mindmap_edge`, mirroring the existing add_note/link/image handlers.
- `_AGENT_ALLOWED_KINDS` opened to text/mermaid/flowchart/mindmap_edge. `user_shape` stays user-only (freeform shapes are hand-drawn, not agent-painted).

## Notes
- The gate I added in #1355 ("agent emission stays gated until the tools land") is now lifted, since the tools exist. Per-project edit permission (`can_edit_canvas`) still governs update/delete exactly as before; add is unchanged in that respect (matches note/link/image).
- `mindmap_edge` connects two elements by id; its own geometry is nominal (the renderer derives the line from the endpoints in a later visual slice).

## Tests
- Gate-lock test inverted: agents CAN now emit the new kinds; user_shape stays forbidden.
- New mcp tool tests for text/mermaid/flowchart/mindmap_edge. 28 passed locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for mindmap edge connections to prevent invalid node references.
  * Enhanced edge geometry calculation for more accurate rendering based on endpoint positions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->