### PR TITLE
observatory: concurrency throttle dials (decision 3)

### DIFF
--- a/tests/test_routes_observatory.py
+++ b/tests/test_routes_observatory.py
@@ -52,6 +52,52 @@ async def test_non_admin_cannot_pause(app, client):
 
 
 @pytest.mark.asyncio
+async def test_throttle_defaults_to_no_caps(client):
+    resp = await client.get("/api/observatory/throttle")
+    assert resp.status_code == 200
+    assert resp.json() == {"global": None, "lanes": {}}
+
+
+@pytest.mark.asyncio
+async def test_global_throttle_round_trips(client):
+    resp = await client.post("/api/observatory/throttle", json={"scope": "global", "max_concurrent": 2})
+    assert resp.status_code == 200
+    assert resp.json()["global"] == 2
+    resp = await client.get("/api/observatory/throttle")
+    assert resp.json()["global"] == 2
+    # max_concurrent <= 0 (or null) clears the cap.
+    resp = await client.post("/api/observatory/throttle", json={"scope": "global", "max_concurrent": 0})
+    assert resp.json()["global"] is None
+
+
+@pytest.mark.asyncio
+async def test_per_lane_throttle_set_and_clear(client):
+    lane = "@taOS-dev-kilo-owl-alpha"
+    resp = await client.post("/api/observatory/throttle", json={"scope": lane, "max_concurrent": 3})
+    assert resp.json()["lanes"].get(lane) == 3
+    assert resp.json()["global"] is None
+    # Clearing (null) drops the lane entry rather than storing 0.
+    resp = await client.post("/api/observatory/throttle", json={"scope": lane, "max_concurrent": None})
+    assert lane not in resp.json()["lanes"]
+
+
+@pytest.mark.asyncio
+async def test_throttle_empty_scope_rejected(client):
+    resp = await client.post("/api/observatory/throttle", json={"scope": "  ", "max_concurrent": 2})
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_non_admin_cannot_throttle(app, client):
+    app.dependency_overrides[current_user] = lambda: CurrentUser(user_id="bob", is_admin=False)
+    try:
+        resp = await client.post("/api/observatory/throttle", json={"scope": "global", "max_concurrent": 1})
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.pop(current_user, None)
+
+
+@pytest.mark.asyncio
 async def test_fleet_empty_when_no_claims(client):
     resp = await client.get("/api/observatory/fleet")
     assert resp.status_code == 200

--- a/tinyagentos/routes/observatory.py
+++ b/tinyagentos/routes/observatory.py
@@ -44,13 +44,12 @@ def _read_state(request: Request) -> dict:
     }
 
 
-def _write_state(request: Request, state: dict) -> None:
-    p = _state_path(request)
+def _atomic_write(p: Path, state: dict) -> None:
     p.parent.mkdir(parents=True, exist_ok=True)
     # Write to a temp file in the same dir then atomically rename, so a crash
     # mid-write or a concurrent writer can never leave a truncated/corrupt file
     # (a reader always sees either the old or the new complete state).
-    fd, tmp = tempfile.mkstemp(dir=str(p.parent), prefix=".observatory_pause.", suffix=".tmp")
+    fd, tmp = tempfile.mkstemp(dir=str(p.parent), prefix="." + p.stem + ".", suffix=".tmp")
     try:
         with os.fdopen(fd, "w") as f:
             f.write(json.dumps(state))
@@ -61,6 +60,10 @@ def _write_state(request: Request, state: dict) -> None:
         except OSError:
             pass
         raise
+
+
+def _write_state(request: Request, state: dict) -> None:
+    _atomic_write(_state_path(request), state)
 
 
 class PauseBody(BaseModel):
@@ -92,6 +95,72 @@ async def set_pause(body: PauseBody, request: Request, user: CurrentUser = Depen
     else:
         state["lanes"].pop(scope, None)
     _write_state(request, state)
+    return state
+
+
+# --- Throttle dials (decision 3: concurrency). A per-lane (and global) cap on
+# how many cards a lane may have in flight at once, which the dispatch loop
+# reads each iteration as its MAX_OPEN_PRS. null/absent = no override (the
+# loop's built-in default applies). Pause is the on/off switch; throttle is the
+# volume knob. ---
+
+
+def _throttle_path(request: Request) -> Path:
+    return Path(request.app.state.data_dir) / "observatory_throttle.json"
+
+
+def _coerce_limit(v) -> int | None:
+    try:
+        n = int(v)
+    except (TypeError, ValueError):
+        return None
+    return n if n > 0 else None
+
+
+def _read_throttle(request: Request) -> dict:
+    p = _throttle_path(request)
+    if not p.exists():
+        return {"global": None, "lanes": {}}
+    try:
+        data = json.loads(p.read_text())
+    except (OSError, ValueError):
+        return {"global": None, "lanes": {}}
+    lanes = {}
+    for k, v in (data.get("lanes") or {}).items():
+        lim = _coerce_limit(v)
+        if lim is not None:
+            lanes[str(k)] = lim
+    return {"global": _coerce_limit(data.get("global")), "lanes": lanes}
+
+
+class ThrottleBody(BaseModel):
+    scope: str  # "global" or a lane handle
+    max_concurrent: int | None = None  # None or <= 0 clears the cap
+
+
+@router.get("/api/observatory/throttle")
+async def get_throttle(request: Request, user: CurrentUser = Depends(current_user)):
+    """Current concurrency caps. The dispatch loop polls this each iteration."""
+    return _read_throttle(request)
+
+
+@router.post("/api/observatory/throttle")
+async def set_throttle(body: ThrottleBody, request: Request, user: CurrentUser = Depends(current_user)):
+    """Set or clear a concurrency cap globally or for a single lane. Admin only."""
+    if not user.is_admin:
+        raise HTTPException(status_code=403, detail="forbidden")
+    scope = body.scope.strip()
+    if not scope:
+        return JSONResponse({"error": "scope required"}, status_code=400)
+    limit = _coerce_limit(body.max_concurrent)
+    state = _read_throttle(request)
+    if scope == "global":
+        state["global"] = limit
+    elif limit is not None:
+        state["lanes"][scope] = limit
+    else:
+        state["lanes"].pop(scope, None)
+    _atomic_write(_throttle_path(request), state)
     return state
 
 

--- a/tinyagentos/routes/observatory.py
+++ b/tinyagentos/routes/observatory.py
@@ -9,6 +9,7 @@ survives controller restarts and is not a local tmux concern.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import tempfile
@@ -23,6 +24,12 @@ from tinyagentos.auth_context import CurrentUser, current_user
 router = APIRouter()
 
 _DEFAULT_STATE: dict = {"global": False, "lanes": {}}
+
+# Serialise read-modify-write of the pause/throttle state files so two
+# concurrent admin POSTs cannot lose an update (each reads the same prior
+# state and the second os.replace clobbers the first). The writes are
+# infrequent admin actions, so a single in-process lock is sufficient.
+_write_lock = asyncio.Lock()
 
 
 def _state_path(request: Request) -> Path:
@@ -87,14 +94,15 @@ async def set_pause(body: PauseBody, request: Request, user: CurrentUser = Depen
     scope = body.scope.strip()
     if not scope:
         return JSONResponse({"error": "scope required"}, status_code=400)
-    state = _read_state(request)
-    if scope == "global":
-        state["global"] = body.paused
-    elif body.paused:
-        state["lanes"][scope] = True
-    else:
-        state["lanes"].pop(scope, None)
-    _write_state(request, state)
+    async with _write_lock:
+        state = _read_state(request)
+        if scope == "global":
+            state["global"] = body.paused
+        elif body.paused:
+            state["lanes"][scope] = True
+        else:
+            state["lanes"].pop(scope, None)
+        _write_state(request, state)
     return state
 
 
@@ -153,14 +161,15 @@ async def set_throttle(body: ThrottleBody, request: Request, user: CurrentUser =
     if not scope:
         return JSONResponse({"error": "scope required"}, status_code=400)
     limit = _coerce_limit(body.max_concurrent)
-    state = _read_throttle(request)
-    if scope == "global":
-        state["global"] = limit
-    elif limit is not None:
-        state["lanes"][scope] = limit
-    else:
-        state["lanes"].pop(scope, None)
-    _atomic_write(_throttle_path(request), state)
+    async with _write_lock:
+        state = _read_throttle(request)
+        if scope == "global":
+            state["global"] = limit
+        elif limit is not None:
+            state["lanes"][scope] = limit
+        else:
+            state["lanes"].pop(scope, None)
+        _atomic_write(_throttle_path(request), state)
     return state
 
 


### PR DESCRIPTION
Completes the Observatory v1 steer half per Jay decision 3 ("global pause + per-lane pause + throttle dials (concurrency/rate)"). Pause (on/off) shipped earlier; this adds the concurrency **volume knob**.

## What
- `GET/POST /api/observatory/throttle`: a global and per-lane max-concurrent cap the dispatch loop reads each iteration as its `MAX_OPEN_PRS`. Admin-gated, mirrors the pause API.
- State in `data_dir/observatory_throttle.json`, written atomically via a helper now shared with the pause writer.
- A cap of `null` or `<= 0` clears the override (the loop's built-in default applies).

## Notes
- Concurrency is the lever the dispatch loop uses today; rate-limiting (dispatches/min) is a later dial, noted in the code.
- The dispatch loop's local wiring (a throttle_check.py mirroring pause_check.py) is a ~/.taos-team change, not in this repo PR.
- The Observatory app's throttle UI control is a follow-up (needs a live session).

## Tests
- defaults to no caps; global + per-lane round-trip; clear via null/<=0; empty scope 400; non-admin 403. 14 observatory tests pass.