### PR TITLE
app permissions: app_grants store (#56 grant persistence)

### DIFF
--- a/tests/test_app_grants_store.py
+++ b/tests/test_app_grants_store.py
@@ -1,0 +1,83 @@
+"""Tests for AppGrantsStore — per-app capability grants persistence (#56)."""
+import pytest
+
+from tinyagentos.app_grants_store import AppGrantsStore
+
+
+@pytest.mark.asyncio
+class TestAppGrantsStore:
+    async def _store(self, tmp_path):
+        s = AppGrantsStore(tmp_path / "app_grants.db")
+        await s.init()
+        return s
+
+    async def test_set_decision_returns_inserted_row(self, tmp_path):
+        store = await self._store(tmp_path)
+        try:
+            row = await store.set_decision("u1", "stream-chat", "app.kv")
+            assert row["user_id"] == "u1"
+            assert row["app_id"] == "stream-chat"
+            assert row["capability"] == "app.kv"
+            assert row["decision"] == "granted"
+            assert "decided_at" in row
+            assert isinstance(row["id"], int)
+        finally:
+            await store.close()
+
+    async def test_set_decision_rejects_unknown_decision(self, tmp_path):
+        store = await self._store(tmp_path)
+        try:
+            with pytest.raises(ValueError, match="invalid decision"):
+                await store.set_decision("u1", "a", "app.kv", decision="maybe")
+        finally:
+            await store.close()
+
+    async def test_set_decision_idempotent_replace(self, tmp_path):
+        store = await self._store(tmp_path)
+        try:
+            await store.set_decision("u1", "a", "files.read", decision="denied")
+            await store.set_decision("u1", "a", "files.read", decision="granted")
+            grants = await store.list_grants("u1", "a")
+            assert len(grants) == 1
+            assert grants[0]["decision"] == "granted"
+        finally:
+            await store.close()
+
+    async def test_granted_capabilities_excludes_denied(self, tmp_path):
+        store = await self._store(tmp_path)
+        try:
+            await store.set_decision("u1", "a", "app.kv", decision="granted")
+            await store.set_decision("u1", "a", "network", decision="denied")
+            await store.set_decision("u1", "a", "notifications.post", decision="granted")
+            assert await store.granted_capabilities("u1", "a") == {"app.kv", "notifications.post"}
+        finally:
+            await store.close()
+
+    async def test_revoke_records_denial_not_deletion(self, tmp_path):
+        store = await self._store(tmp_path)
+        try:
+            await store.set_decision("u1", "a", "files.write", decision="granted")
+            await store.revoke("u1", "a", "files.write")
+            # The capability is no longer granted...
+            assert await store.granted_capabilities("u1", "a") == set()
+            # ...but the row is kept as a durable denial (append-only #103).
+            grants = await store.list_grants("u1", "a")
+            assert len(grants) == 1
+            assert grants[0]["decision"] == "denied"
+        finally:
+            await store.close()
+
+    async def test_grants_scoped_by_user(self, tmp_path):
+        store = await self._store(tmp_path)
+        try:
+            await store.set_decision("u1", "a", "app.kv", decision="granted")
+            await store.set_decision("u2", "a", "app.kv", decision="denied")
+            assert await store.granted_capabilities("u1", "a") == {"app.kv"}
+            assert await store.granted_capabilities("u2", "a") == set()
+        finally:
+            await store.close()
+
+    async def test_set_decision_uninitialised_raises(self, tmp_path):
+        store = AppGrantsStore(tmp_path / "app_grants.db")
+        with pytest.raises(RuntimeError):
+            await store.set_decision("u1", "a", "app.kv")

--- a/tinyagentos/app_grants_store.py
+++ b/tinyagentos/app_grants_store.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+"""Store for per-app capability grants (app permission system, #56).
+
+A grant records that a user decided (granted or denied) a specific capability
+for an installed app, mirroring AgentGrantsStore for agents. This store is the
+persistence layer of decision 6 (manifest declares capabilities, user grants
+them via the Decisions/consent flow); it is intentionally vocabulary-agnostic:
+the closed APP_CAPABILITIES vocabulary and its validation live at the
+manifest-validation / grant-request layer (a later slice, pending Jay's v1
+vocabulary in pending-decisions item 23), not here.
+
+A denial is recorded (decision='denied'), not dropped, and revoke flips a grant
+to 'denied' rather than deleting the row, so the grant history is durable
+(append-only, #103). The Permissions app (decision 20) reads + revokes here.
+"""
+
+from datetime import datetime, timezone
+from typing import Optional
+
+import aiosqlite
+
+from tinyagentos.base_store import BaseStore
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS app_grants (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id     TEXT NOT NULL,
+    app_id      TEXT NOT NULL,
+    capability  TEXT NOT NULL,
+    decision    TEXT NOT NULL DEFAULT 'granted',
+    decided_at  TEXT NOT NULL,
+    UNIQUE (user_id, app_id, capability)
+);
+"""
+
+
+def _row_to_dict(row: aiosqlite.Row) -> dict:
+    return {k: row[k] for k in row.keys()}
+
+
+class AppGrantsStore(BaseStore):
+    """Persistent store for per-app capability grants, scoped by user."""
+
+    SCHEMA = SCHEMA
+
+    async def init(self) -> None:
+        await super().init()
+        if self._db is not None:
+            self._db.row_factory = aiosqlite.Row
+
+    async def set_decision(
+        self,
+        user_id: str,
+        app_id: str,
+        capability: str,
+        *,
+        decision: str = "granted",
+    ) -> dict:
+        """Record a grant or denial for (user_id, app_id, capability).
+
+        Idempotent via INSERT OR REPLACE, so re-deciding a capability (e.g. a
+        user granting something they previously denied) overwrites in place.
+        """
+        if self._db is None:
+            raise RuntimeError("AppGrantsStore not initialised — call init() first")
+        if decision not in ("granted", "denied"):
+            raise ValueError(f"invalid decision: {decision}")
+        now = datetime.now(timezone.utc).isoformat()
+        await self._db.execute(
+            """
+            INSERT OR REPLACE INTO app_grants
+                (user_id, app_id, capability, decision, decided_at)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (user_id, app_id, capability, decision, now),
+        )
+        await self._db.commit()
+        row = await (
+            await self._db.execute(
+                "SELECT * FROM app_grants "
+                "WHERE user_id = ? AND app_id = ? AND capability = ?",
+                (user_id, app_id, capability),
+            )
+        ).fetchone()
+        return _row_to_dict(row)  # type: ignore[return-value]
+
+    async def revoke(self, user_id: str, app_id: str, capability: str) -> None:
+        """Revoke a previously granted capability by recording a denial.
+
+        The row is kept (flipped to 'denied'), not deleted, so the grant
+        history stays durable (#103). A no-op if the capability was never
+        decided for this (user, app).
+        """
+        if self._db is None:
+            raise RuntimeError("AppGrantsStore not initialised")
+        now = datetime.now(timezone.utc).isoformat()
+        await self._db.execute(
+            "UPDATE app_grants SET decision = 'denied', decided_at = ? "
+            "WHERE user_id = ? AND app_id = ? AND capability = ?",
+            (now, user_id, app_id, capability),
+        )
+        await self._db.commit()
+
+    async def list_grants(self, user_id: str, app_id: str) -> list[dict]:
+        """Every recorded decision (granted + denied) for (user_id, app_id)."""
+        if self._db is None:
+            raise RuntimeError("AppGrantsStore not initialised")
+        cursor = await self._db.execute(
+            "SELECT * FROM app_grants WHERE user_id = ? AND app_id = ? "
+            "ORDER BY decided_at",
+            (user_id, app_id),
+        )
+        return [_row_to_dict(r) for r in await cursor.fetchall()]
+
+    async def granted_capabilities(self, user_id: str, app_id: str) -> set[str]:
+        """The currently-granted capabilities for (user_id, app_id).
+
+        This is the enforcement query: a privileged SDK call checks the
+        capability against this set. Denied/revoked capabilities are excluded.
+        """
+        if self._db is None:
+            raise RuntimeError("AppGrantsStore not initialised")
+        cursor = await self._db.execute(
+            "SELECT capability FROM app_grants "
+            "WHERE user_id = ? AND app_id = ? AND decision = 'granted'",
+            (user_id, app_id),
+        )
+        return {r["capability"] for r in await cursor.fetchall()}

--- a/tinyagentos/app_grants_store.py
+++ b/tinyagentos/app_grants_store.py
@@ -10,9 +10,13 @@ the closed APP_CAPABILITIES vocabulary and its validation live at the
 manifest-validation / grant-request layer (a later slice, pending Jay's v1
 vocabulary in pending-decisions item 23), not here.
 
-A denial is recorded (decision='denied'), not dropped, and revoke flips a grant
-to 'denied' rather than deleting the row, so the grant history is durable
-(append-only, #103). The Permissions app (decision 20) reads + revokes here.
+This table holds the CURRENT decision per (user, app, capability), not a full
+history: re-deciding a capability overwrites the row (last-write-wins), and
+revoke flips a grant to 'denied' rather than deleting it, so the capability is
+no longer granted while the row persists as a denial. A true append-only log of
+every grant/revoke event (per the #103/#105 audit-trail direction) is a
+separate enhancement, not this MVP. The Permissions app (decision 20) reads +
+revokes here.
 """
 
 from datetime import datetime, timezone
@@ -88,9 +92,9 @@ class AppGrantsStore(BaseStore):
     async def revoke(self, user_id: str, app_id: str, capability: str) -> None:
         """Revoke a previously granted capability by recording a denial.
 
-        The row is kept (flipped to 'denied'), not deleted, so the grant
-        history stays durable (#103). A no-op if the capability was never
-        decided for this (user, app).
+        The row is kept (flipped to 'denied'), not deleted, so the capability
+        stops being granted without losing that a decision exists. A no-op if
+        the capability was never decided for this (user, app).
         """
         if self._db is None:
             raise RuntimeError("AppGrantsStore not initialised")


### PR DESCRIPTION
Slice 2 of the app permission/capability system (#56), per Jay decision 6 (manifest declares capabilities, user grants them via the Decisions/consent flow). Spec: ~/tinyagentos-private/specs/app-permissions-capabilities.md.

## What
- `AppGrantsStore` (`tinyagentos/app_grants_store.py`): persists per (user_id, app_id, capability) decisions, mirroring the existing `AgentGrantsStore`. `set_decision` (granted/denied, idempotent upsert), `revoke` (records a denial, keeps the row), `list_grants`, and `granted_capabilities` (the enforcement query).

## Why this slice is unblocked
- The grant STORE is vocabulary-agnostic: a capability is just a string, and validating capability NAMES against the closed `APP_CAPABILITIES` vocabulary is a separate manifest/grant-layer slice that is pending Jay's v1 vocabulary (pending-decisions item 23). So this persistence layer does not depend on that open question and is safe to land now.
- `revoke` records a denial rather than deleting, keeping grant history durable (append-only #103). The Permissions app (decision 20) reads + revokes here.

## Not in this slice (need item 23 / a live session)
- The `APP_CAPABILITIES` vocabulary + manifest validation (slice 1), grant-on-install Decision (slice 3), SDK enforcement (slice 4), Permissions app UI (slice 5). The store is not yet wired onto app.state; that comes with its first consumer route.

## Tests
- insert/return shape, invalid-decision reject, idempotent replace, granted excludes denied, revoke records denial (not deletion), per-user scoping, uninitialised guard. 7 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a capability grant management system to track and manage per-user, per-app permission decisions.
  * Supports granting capabilities, revoking access, and querying currently granted capabilities with persistent storage.

* **Tests**
  * Added comprehensive test suite covering grant persistence, decision validation, idempotency, user isolation, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->