### PR TITLE
agent-as-a-model: consent-key store (MVP slice 1, decision 19)

### DIFF
--- a/tests/test_agent_model_key_store.py
+++ b/tests/test_agent_model_key_store.py
@@ -1,0 +1,101 @@
+"""Tests for AgentModelKeyStore — Agent-as-a-Model consent keys (decision 19)."""
+import hashlib
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tinyagentos.agent_model_key_store import AgentModelKeyStore
+
+
+@pytest.mark.asyncio
+class TestAgentModelKeyStore:
+    async def _store(self, tmp_path):
+        s = AgentModelKeyStore(tmp_path / "amk.db")
+        await s.init()
+        return s
+
+    async def test_mint_returns_token_and_record(self, tmp_path):
+        store = await self._store(tmp_path)
+        try:
+            token, rec = await store.mint("u1", ["agent-a"], ["memory_read"])
+            assert token.startswith("sk-taosagent-")
+            assert rec["issuing_user"] == "u1"
+            assert rec["agent_ids"] == ["agent-a"]
+            assert rec["scopes"] == ["memory_read"]
+            assert rec["revoked"] is False
+            # The plaintext token and its hash are never surfaced in the record.
+            assert "key_hash" not in rec
+            assert token not in str(rec)
+        finally:
+            await store.close()
+
+    async def test_mint_stores_only_the_hash(self, tmp_path):
+        store = await self._store(tmp_path)
+        try:
+            token, _ = await store.mint("u1", ["agent-a"], [])
+            row = await (
+                await store._db.execute("SELECT key_hash FROM agent_model_keys")
+            ).fetchone()
+            assert row["key_hash"] == hashlib.sha256(token.encode()).hexdigest()
+            assert row["key_hash"] != token  # plaintext is not stored
+        finally:
+            await store.close()
+
+    async def test_mint_requires_an_agent(self, tmp_path):
+        store = await self._store(tmp_path)
+        try:
+            with pytest.raises(ValueError, match="at least one agent"):
+                await store.mint("u1", [], ["memory_read"])
+        finally:
+            await store.close()
+
+    async def test_resolve_valid_token(self, tmp_path):
+        store = await self._store(tmp_path)
+        try:
+            token, _ = await store.mint("u1", ["agent-a", "agent-b"], ["memory_read"])
+            rec = await store.resolve(token)
+            assert rec is not None
+            assert rec["issuing_user"] == "u1"
+            assert rec["agent_ids"] == ["agent-a", "agent-b"]
+        finally:
+            await store.close()
+
+    async def test_resolve_unknown_token_is_none(self, tmp_path):
+        store = await self._store(tmp_path)
+        try:
+            assert await store.resolve("sk-taosagent-nope") is None
+        finally:
+            await store.close()
+
+    async def test_revoke_kills_the_key(self, tmp_path):
+        store = await self._store(tmp_path)
+        try:
+            token, rec = await store.mint("u1", ["agent-a"], [])
+            assert await store.revoke(rec["id"]) is True
+            assert await store.resolve(token) is None
+            # Revoking again is a no-op.
+            assert await store.revoke(rec["id"]) is False
+        finally:
+            await store.close()
+
+    async def test_expired_token_does_not_resolve(self, tmp_path):
+        store = await self._store(tmp_path)
+        try:
+            past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+            token, _ = await store.mint("u1", ["agent-a"], [], expires_at=past)
+            assert await store.resolve(token) is None
+        finally:
+            await store.close()
+
+    async def test_list_for_user_excludes_secrets(self, tmp_path):
+        store = await self._store(tmp_path)
+        try:
+            await store.mint("u1", ["agent-a"], ["memory_read"], rate_cap=60)
+            await store.mint("u2", ["agent-z"], [])
+            keys = await store.list_for_user("u1")
+            assert len(keys) == 1
+            assert keys[0]["issuing_user"] == "u1"
+            assert keys[0]["rate_cap"] == 60
+            assert "key_hash" not in keys[0]
+        finally:
+            await store.close()

--- a/tests/test_agent_model_key_store.py
+++ b/tests/test_agent_model_key_store.py
@@ -87,6 +87,41 @@ class TestAgentModelKeyStore:
         finally:
             await store.close()
 
+    async def test_expiry_normalizes_z_suffix(self, tmp_path):
+        store = await self._store(tmp_path)
+        try:
+            future_z = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat().replace("+00:00", "Z")
+            token, _ = await store.mint("u1", ["agent-a"], [], expires_at=future_z)
+            assert await store.resolve(token) is not None  # future -> still valid
+            past_z = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat().replace("+00:00", "Z")
+            t2, _ = await store.mint("u1", ["agent-a"], [], expires_at=past_z)
+            assert await store.resolve(t2) is None  # past -> expired
+        finally:
+            await store.close()
+
+    async def test_expiry_honours_real_utc_not_lexical_offset(self, tmp_path):
+        store = await self._store(tmp_path)
+        try:
+            # 12:00+05:00 is 07:00 UTC. If it is already past in UTC the key must
+            # NOT resolve, even though "12:00" lexically looks later than now.
+            past_utc_via_offset = (
+                (datetime.now(timezone.utc) - timedelta(hours=2))
+                .astimezone(timezone(timedelta(hours=5)))
+                .isoformat()
+            )
+            token, _ = await store.mint("u1", ["agent-a"], [], expires_at=past_utc_via_offset)
+            assert await store.resolve(token) is None
+        finally:
+            await store.close()
+
+    async def test_naive_expiry_is_rejected(self, tmp_path):
+        store = await self._store(tmp_path)
+        try:
+            with pytest.raises(ValueError, match="timezone-aware"):
+                await store.mint("u1", ["agent-a"], [], expires_at="2026-06-10T12:00:00")
+        finally:
+            await store.close()
+
     async def test_list_for_user_excludes_secrets(self, tmp_path):
         store = await self._store(tmp_path)
         try:

--- a/tinyagentos/agent_model_key_store.py
+++ b/tinyagentos/agent_model_key_store.py
@@ -53,6 +53,21 @@ def _hash(token: str) -> str:
     return hashlib.sha256(token.encode()).hexdigest()
 
 
+def _normalize_ts(value: str) -> str:
+    """Canonicalise a caller-supplied expiry to a UTC isoformat string.
+
+    Expiry is enforced by comparing against datetime.now(timezone.utc).isoformat(),
+    a lexicographic compare that is only sound when both sides are the same UTC
+    format. A 'Z' suffix, a non-UTC offset, or a naive timestamp would otherwise
+    sort wrong and silently mis-honour a security-critical key expiry, so parse
+    the input, require it be timezone-aware, and store the canonical UTC form.
+    """
+    dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if dt.tzinfo is None:
+        raise ValueError("expires_at must be timezone-aware (e.g. ...+00:00 or ...Z)")
+    return dt.astimezone(timezone.utc).isoformat()
+
+
 def _row_to_dict(row: aiosqlite.Row) -> dict:
     d = {k: row[k] for k in row.keys()}
     for f in ("agent_ids", "scopes"):
@@ -92,9 +107,11 @@ class AgentModelKeyStore(BaseStore):
             raise RuntimeError("AgentModelKeyStore not initialised — call init() first")
         if not agent_ids:
             raise ValueError("a consent key must grant at least one agent")
+        if expires_at is not None:
+            expires_at = _normalize_ts(expires_at)
         token = _TOKEN_PREFIX + secrets.token_urlsafe(32)
         now = datetime.now(timezone.utc).isoformat()
-        await self._db.execute(
+        cur = await self._db.execute(
             """
             INSERT INTO agent_model_keys
                 (key_hash, issuing_user, agent_ids, scopes, rate_cap, created_at, expires_at)
@@ -108,7 +125,7 @@ class AgentModelKeyStore(BaseStore):
         await self._db.commit()
         row = await (
             await self._db.execute(
-                "SELECT * FROM agent_model_keys WHERE key_hash = ?", (_hash(token),)
+                "SELECT * FROM agent_model_keys WHERE id = ?", (cur.lastrowid,)
             )
         ).fetchone()
         rec = _row_to_dict(row)  # type: ignore[arg-type]

--- a/tinyagentos/agent_model_key_store.py
+++ b/tinyagentos/agent_model_key_store.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+"""Consent-key store for Agent-as-a-Model (decision 19).
+
+The key IS the consent grant: an external OpenAI-compatible caller presents a
+bearer token that maps to {issuing_user, agent_ids, scopes, optional expiry,
+optional rate cap}. A key can only be minted through the user-mediated consent
+flow, and revoking the grant kills the key, so there is no raw model
+passthrough.
+
+Security: the bearer token is shown to the user exactly once at mint time; only
+its SHA-256 hash is stored, so a database leak never exposes live keys. This is
+deliberately stricter than the internal LiteLLMKeyStore (which stores its
+routing tokens in plaintext for the cross-process auth hook); these keys are
+exposed to third parties.
+
+MVP cut item 1 of ~/tinyagentos-private/specs/agent-as-a-model.md. The /v1
+endpoint, scope enforcement, and rate limiting build on top of this; they are
+NOT in this slice.
+"""
+
+import hashlib
+import json
+import secrets
+from datetime import datetime, timezone
+from typing import Optional
+
+import aiosqlite
+
+from tinyagentos.base_store import BaseStore
+
+# Recognisable in logs, never collides with LiteLLM's sk- or the internal
+# sk-taos- routing keys.
+_TOKEN_PREFIX = "sk-taosagent-"
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS agent_model_keys (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    key_hash      TEXT NOT NULL UNIQUE,
+    issuing_user  TEXT NOT NULL,
+    agent_ids     TEXT NOT NULL,
+    scopes        TEXT NOT NULL,
+    rate_cap      INTEGER,
+    created_at    TEXT NOT NULL,
+    expires_at    TEXT,
+    revoked       INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_amk_user ON agent_model_keys(issuing_user);
+"""
+
+
+def _hash(token: str) -> str:
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+def _row_to_dict(row: aiosqlite.Row) -> dict:
+    d = {k: row[k] for k in row.keys()}
+    for f in ("agent_ids", "scopes"):
+        try:
+            d[f] = json.loads(d[f])
+        except (ValueError, TypeError):
+            d[f] = []
+    d["revoked"] = bool(d["revoked"])
+    return d
+
+
+class AgentModelKeyStore(BaseStore):
+    """Persistent store of Agent-as-a-Model consent keys (hash + binding)."""
+
+    SCHEMA = SCHEMA
+
+    async def init(self) -> None:
+        await super().init()
+        if self._db is not None:
+            self._db.row_factory = aiosqlite.Row
+
+    async def mint(
+        self,
+        issuing_user: str,
+        agent_ids: list[str],
+        scopes: list[str],
+        *,
+        rate_cap: Optional[int] = None,
+        expires_at: Optional[str] = None,
+    ) -> tuple[str, dict]:
+        """Mint a new consent key. Returns (plaintext_token, record).
+
+        The plaintext is returned ONCE for the caller to show the user; only
+        its hash is stored. The record excludes any secret.
+        """
+        if self._db is None:
+            raise RuntimeError("AgentModelKeyStore not initialised — call init() first")
+        if not agent_ids:
+            raise ValueError("a consent key must grant at least one agent")
+        token = _TOKEN_PREFIX + secrets.token_urlsafe(32)
+        now = datetime.now(timezone.utc).isoformat()
+        await self._db.execute(
+            """
+            INSERT INTO agent_model_keys
+                (key_hash, issuing_user, agent_ids, scopes, rate_cap, created_at, expires_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                _hash(token), issuing_user, json.dumps(list(agent_ids)),
+                json.dumps(list(scopes or [])), rate_cap, now, expires_at,
+            ),
+        )
+        await self._db.commit()
+        row = await (
+            await self._db.execute(
+                "SELECT * FROM agent_model_keys WHERE key_hash = ?", (_hash(token),)
+            )
+        ).fetchone()
+        rec = _row_to_dict(row)  # type: ignore[arg-type]
+        rec.pop("key_hash", None)  # never surface the hash to callers
+        return token, rec
+
+    async def resolve(self, token: str) -> Optional[dict]:
+        """Resolve a presented bearer token to its binding.
+
+        Returns None if the token is unknown, revoked, or expired, so an
+        unauthorised caller is rejected without leaking which condition failed.
+        """
+        if self._db is None:
+            raise RuntimeError("AgentModelKeyStore not initialised")
+        now = datetime.now(timezone.utc).isoformat()
+        row = await (
+            await self._db.execute(
+                "SELECT * FROM agent_model_keys "
+                "WHERE key_hash = ? AND revoked = 0 "
+                "AND (expires_at IS NULL OR expires_at > ?)",
+                (_hash(token), now),
+            )
+        ).fetchone()
+        if row is None:
+            return None
+        rec = _row_to_dict(row)
+        rec.pop("key_hash", None)
+        return rec
+
+    async def revoke(self, key_id: int) -> bool:
+        """Revoke a key by its row id. Returns True if a row was revoked."""
+        if self._db is None:
+            raise RuntimeError("AgentModelKeyStore not initialised")
+        cur = await self._db.execute(
+            "UPDATE agent_model_keys SET revoked = 1 WHERE id = ? AND revoked = 0",
+            (key_id,),
+        )
+        await self._db.commit()
+        return cur.rowcount > 0
+
+    async def list_for_user(self, issuing_user: str) -> list[dict]:
+        """Keys a user issued, newest first, without any secret material.
+
+        Feeds the settings / Permissions surface where a user reviews and
+        revokes their issued agent-as-a-model keys.
+        """
+        if self._db is None:
+            raise RuntimeError("AgentModelKeyStore not initialised")
+        cursor = await self._db.execute(
+            "SELECT * FROM agent_model_keys WHERE issuing_user = ? "
+            "ORDER BY created_at DESC",
+            (issuing_user,),
+        )
+        out = []
+        for r in await cursor.fetchall():
+            rec = _row_to_dict(r)
+            rec.pop("key_hash", None)
+            out.append(rec)
+        return out


### PR DESCRIPTION
MVP cut item 1 of Agent-as-a-Model (spec: ~/tinyagentos-private/specs/agent-as-a-model.md), per Jay decision 19 ("build once consent exists; do not half-build without the auth model"). The consent flow exists (`agent_auth_requests`), so this builds the auth model: the consent key.

## What
- `AgentModelKeyStore`: a bearer key that IS the consent grant, mapping an external caller to {issuing_user, agent_ids, scopes, expiry, rate_cap}. `mint` (returns the plaintext once + a record), `resolve` (token -> binding, rejecting unknown/revoked/expired), `revoke`, `list_for_user`.

## Security
- The token is shown once at mint; only its SHA-256 hash is stored, so a DB leak never exposes live keys. This is stricter than the internal `LiteLLMKeyStore` (plaintext, for its cross-process routing hook) because these keys are exposed to third parties.
- `resolve` returns None for unknown/revoked/expired without leaking which condition failed. No record or list ever surfaces the hash or plaintext.

## Scope
- Auth model ONLY. The `/v1/models` + `/v1/chat/completions` endpoint, scope enforcement, and per-key rate limiting are later slices that build on this. Per the spec, the endpoint must not ship without this binding. Not yet wired onto app.state (lands with the consent-mint route).

## Tests
- mint shape + token prefix + no-secret-leak; stores only the hash; requires an agent; resolve valid/unknown; revoke kills the key (idempotent); expired does not resolve; list excludes secrets. 8 passed.