### PR TITLE
app permissions: per-app capability grant API (#56 slice 3a)

### DIFF
--- a/tests/test_routes_app_permissions.py
+++ b/tests/test_routes_app_permissions.py
@@ -1,0 +1,85 @@
+"""Endpoint tests for routes/app_permissions.py (#56)."""
+import asyncio
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _ensure_app_grants_store(client, tmp_path_factory):
+    """Init app.state.app_grants on a fresh DB; the test client registers the
+    store but does not run the lifespan that init()s it (production does)."""
+    store = client._transport.app.state.app_grants
+    if store._db is not None:
+        try:
+            asyncio.get_event_loop().run_until_complete(store.close())
+        except Exception:
+            pass
+    tmp_dir = tmp_path_factory.mktemp("app_grants_test")
+    store.db_path = tmp_dir / "app_grants.db"
+    asyncio.get_event_loop().run_until_complete(store.init())
+    yield
+    try:
+        asyncio.get_event_loop().run_until_complete(store.close())
+    except Exception:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_permissions_empty_by_default(client):
+    resp = await client.get("/api/apps/stream-chat/permissions")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["app_id"] == "stream-chat"
+    assert data["grants"] == []
+    assert data["granted"] == []
+
+
+@pytest.mark.asyncio
+async def test_grant_then_listed_as_granted(client):
+    resp = await client.post(
+        "/api/apps/stream-chat/permissions",
+        json={"capability": "app.kv", "decision": "granted"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["grant"]["capability"] == "app.kv"
+    data = (await client.get("/api/apps/stream-chat/permissions")).json()
+    assert data["granted"] == ["app.kv"]
+
+
+@pytest.mark.asyncio
+async def test_denied_capability_not_in_granted(client):
+    await client.post(
+        "/api/apps/a/permissions", json={"capability": "network", "decision": "denied"}
+    )
+    data = (await client.get("/api/apps/a/permissions")).json()
+    assert "network" not in data["granted"]
+    assert len(data["grants"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_invalid_decision_returns_400(client):
+    resp = await client.post(
+        "/api/apps/a/permissions", json={"capability": "app.kv", "decision": "maybe"}
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_empty_capability_returns_400(client):
+    resp = await client.post(
+        "/api/apps/a/permissions", json={"capability": "  ", "decision": "granted"}
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_revoke_removes_from_granted(client):
+    await client.post(
+        "/api/apps/a/permissions", json={"capability": "files.write", "decision": "granted"}
+    )
+    resp = await client.post(
+        "/api/apps/a/permissions/revoke", json={"capability": "files.write"}
+    )
+    assert resp.status_code == 200
+    data = (await client.get("/api/apps/a/permissions")).json()
+    assert "files.write" not in data["granted"]

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -258,6 +258,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     auth_requests_store = AuthRequestsStore(data_dir / "auth_requests.db")
     from tinyagentos.agent_grants_store import AgentGrantsStore
     agent_grants_store = AgentGrantsStore(data_dir / "agent_grants.db")
+    from tinyagentos.app_grants_store import AppGrantsStore
+    app_grants_store = AppGrantsStore(data_dir / "app_grants.db")
     from tinyagentos.cluster.pairing_store import ClusterPairingStore
     cluster_pairing_store = ClusterPairingStore(data_dir / "cluster_pairing.db")
     from tinyagentos.cluster.capability_map import CapabilityMap
@@ -439,6 +441,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         app.state.auth_requests = auth_requests_store
         await agent_grants_store.init()
         app.state.agent_grants = agent_grants_store
+        await app_grants_store.init()
+        app.state.app_grants = app_grants_store
         await cluster_pairing_store.init()
         app.state.cluster_pairing = cluster_pairing_store
         await capability_map_store.init()
@@ -1241,6 +1245,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await qmd_client.close()
         await http_client.aclose()
         await agent_grants_store.close()
+        await app_grants_store.close()
         await auth_requests_store.close()
         await cluster_pairing_store.close()
         await agent_registry_store.close()
@@ -1414,6 +1419,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     app.state.agent_registry_keypair = agent_registry_keypair
     app.state.auth_requests = auth_requests_store
     app.state.agent_grants = agent_grants_store
+    app.state.app_grants = app_grants_store
     app.state.cluster_pairing = cluster_pairing_store
     app.state.capability_map = capability_map_store
 

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -328,3 +328,6 @@ def register_all_routers(app):
 
     from tinyagentos.routes.manifest import router as manifest_router
     app.include_router(manifest_router)
+
+    from tinyagentos.routes.app_permissions import router as app_permissions_router
+    app.include_router(app_permissions_router)

--- a/tinyagentos/routes/app_permissions.py
+++ b/tinyagentos/routes/app_permissions.py
@@ -1,0 +1,71 @@
+"""Per-app capability grant API (app permission system, #56).
+
+The API surface over AppGrantsStore: a user reviews, grants/denies, and revokes
+the capabilities an installed app holds. Decision 6 (manifest declares + runtime
+grants via the Decisions/consent flow); this is the runtime-grant layer.
+
+Vocabulary-agnostic: capability names are passed through as strings. Validating
+them against the closed APP_CAPABILITIES vocabulary is a separate slice (pending
+Jay's v1 vocabulary, pending-decisions item 23), so this surface does not gate
+on that open question. Grants are scoped to the calling user.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from tinyagentos.auth_context import CurrentUser, current_user
+
+router = APIRouter()
+
+
+class GrantIn(BaseModel):
+    capability: str
+    decision: str = "granted"  # "granted" or "denied"
+
+
+class RevokeIn(BaseModel):
+    capability: str
+
+
+@router.get("/api/apps/{app_id}/permissions")
+async def list_app_permissions(
+    app_id: str, request: Request, user: CurrentUser = Depends(current_user)
+):
+    """The current user's capability decisions for an app, plus the granted set."""
+    store = request.app.state.app_grants
+    grants = await store.list_grants(user.user_id, app_id)
+    granted = sorted(await store.granted_capabilities(user.user_id, app_id))
+    return {"app_id": app_id, "grants": grants, "granted": granted}
+
+
+@router.post("/api/apps/{app_id}/permissions")
+async def set_app_permission(
+    app_id: str, body: GrantIn, request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    """Grant or deny a capability for an app on behalf of the calling user."""
+    store = request.app.state.app_grants
+    cap = body.capability.strip()
+    if not cap:
+        return JSONResponse({"error": "capability required"}, status_code=400)
+    try:
+        rec = await store.set_decision(user.user_id, app_id, cap, decision=body.decision)
+    except ValueError as e:
+        return JSONResponse({"error": str(e)}, status_code=400)
+    return {"grant": rec}
+
+
+@router.post("/api/apps/{app_id}/permissions/revoke")
+async def revoke_app_permission(
+    app_id: str, body: RevokeIn, request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    """Revoke a capability (records a denial, keeps the row)."""
+    store = request.app.state.app_grants
+    cap = body.capability.strip()
+    if not cap:
+        return JSONResponse({"error": "capability required"}, status_code=400)
+    await store.revoke(user.user_id, app_id, cap)
+    return {"ok": True}


### PR DESCRIPTION
Slice 3a of the app permission system (#56, decision 6), building on the merged AppGrantsStore (#1369). The runtime-grant API surface.

## What
- `routes/app_permissions.py`: `GET /api/apps/{app_id}/permissions` (the user's decisions + the granted set), `POST` (grant/deny a capability), `POST .../revoke`. Scoped to the calling user.
- Registers `AppGrantsStore` on `app.state` (mirrors the agent_grants wiring: instantiate + lifespan init/close + sync register) and includes the router.

## Vocabulary-independent
- Capability names pass through as strings; validating them against the closed `APP_CAPABILITIES` vocabulary is a later slice pending Jay's v1 vocabulary (pending-decisions item 23). So this surface does not gate on that open question.

## Not in this slice
- The manifest-validation slice (vocabulary, item 23), the grant-on-install Decision flow, SDK enforcement, and the Permissions app UI.

## Tests
- empty by default; grant -> appears in granted; deny -> excluded; invalid decision 400; empty capability 400; revoke removes from granted. 6 passed. The client fixture exercising create_app also confirms the app.state registration does not break startup.