### PR TITLE
agent-as-a-model: GET /v1/models + consent-key auth (slice 2a)

### DIFF
--- a/tests/test_routes_agent_model_api.py
+++ b/tests/test_routes_agent_model_api.py
@@ -1,0 +1,59 @@
+"""Endpoint tests for the Agent-as-a-Model /v1 surface (decision 19)."""
+import asyncio
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _ensure_amk_store(client, tmp_path_factory):
+    """Init app.state.agent_model_keys on a fresh DB; the test client registers
+    the store but does not run the lifespan that init()s it (production does)."""
+    store = client._transport.app.state.agent_model_keys
+    if store._db is not None:
+        try:
+            asyncio.get_event_loop().run_until_complete(store.close())
+        except Exception:
+            pass
+    tmp_dir = tmp_path_factory.mktemp("amk_test")
+    store.db_path = tmp_dir / "agent_model_keys.db"
+    asyncio.get_event_loop().run_until_complete(store.init())
+    yield
+    try:
+        asyncio.get_event_loop().run_until_complete(store.close())
+    except Exception:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_models_requires_a_key(client):
+    resp = await client.get("/v1/models")
+    assert resp.status_code == 401
+    assert resp.json()["error"]["code"] == "invalid_api_key"
+
+
+@pytest.mark.asyncio
+async def test_models_rejects_unknown_key(client):
+    resp = await client.get("/v1/models", headers={"Authorization": "Bearer sk-taosagent-nope"})
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_models_lists_consented_agents(client):
+    store = client._transport.app.state.agent_model_keys
+    token, _ = await store.mint("u1", ["agent-a", "agent-b"], ["memory_read"])
+    resp = await client.get("/v1/models", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["object"] == "list"
+    ids = [m["id"] for m in data["data"]]
+    assert ids == ["agent-a", "agent-b"]
+    assert all(m["object"] == "model" and m["owned_by"] == "taos-agent" for m in data["data"])
+
+
+@pytest.mark.asyncio
+async def test_models_revoked_key_is_rejected(client):
+    store = client._transport.app.state.agent_model_keys
+    token, rec = await store.mint("u1", ["agent-a"], [])
+    await store.revoke(rec["id"])
+    resp = await client.get("/v1/models", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 401

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -260,6 +260,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     agent_grants_store = AgentGrantsStore(data_dir / "agent_grants.db")
     from tinyagentos.app_grants_store import AppGrantsStore
     app_grants_store = AppGrantsStore(data_dir / "app_grants.db")
+    from tinyagentos.agent_model_key_store import AgentModelKeyStore
+    agent_model_key_store = AgentModelKeyStore(data_dir / "agent_model_keys.db")
     from tinyagentos.cluster.pairing_store import ClusterPairingStore
     cluster_pairing_store = ClusterPairingStore(data_dir / "cluster_pairing.db")
     from tinyagentos.cluster.capability_map import CapabilityMap
@@ -443,6 +445,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         app.state.agent_grants = agent_grants_store
         await app_grants_store.init()
         app.state.app_grants = app_grants_store
+        await agent_model_key_store.init()
+        app.state.agent_model_keys = agent_model_key_store
         await cluster_pairing_store.init()
         app.state.cluster_pairing = cluster_pairing_store
         await capability_map_store.init()
@@ -1246,6 +1250,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await http_client.aclose()
         await agent_grants_store.close()
         await app_grants_store.close()
+        await agent_model_key_store.close()
         await auth_requests_store.close()
         await cluster_pairing_store.close()
         await agent_registry_store.close()
@@ -1417,6 +1422,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     # ensures attribute-existence checks work during the pre-startup window.
     app.state.agent_registry = agent_registry_store
     app.state.agent_registry_keypair = agent_registry_keypair
+    app.state.agent_model_keys = agent_model_key_store
     app.state.auth_requests = auth_requests_store
     app.state.agent_grants = agent_grants_store
     app.state.app_grants = app_grants_store

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -331,3 +331,6 @@ def register_all_routers(app):
 
     from tinyagentos.routes.app_permissions import router as app_permissions_router
     app.include_router(app_permissions_router)
+
+    from tinyagentos.routes.agent_model_api import router as agent_model_api_router
+    app.include_router(agent_model_api_router)

--- a/tinyagentos/routes/agent_model_api.py
+++ b/tinyagentos/routes/agent_model_api.py
@@ -1,0 +1,68 @@
+"""Agent-as-a-Model OpenAI-compatible surface (decision 19).
+
+An external OpenAI-compatible client points at https://<taos>/v1 with a consent
+key (the bearer token IS the consent grant, minted only through the user
+consent flow) and gets THEIR agent(s) exposed as models. The key maps to
+{issuing_user, agent_ids, scopes, expiry, rate_cap} via AgentModelKeyStore.
+
+This slice is the AUTH-GATED surface: GET /v1/models lists the agents the
+caller's key is consented for, each as an OpenAI model entry. POST
+/v1/chat/completions (running a turn through the agent harness), scope
+enforcement, and rate limiting are later slices built on this binding. Per the
+spec, the endpoint must never resolve a model without a valid consent key, so
+the auth binding lands first.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+router = APIRouter()
+
+
+def _unauthorized() -> JSONResponse:
+    # OpenAI-shaped error so standard clients surface it correctly.
+    return JSONResponse(
+        {"error": {
+            "message": "invalid or missing consent key",
+            "type": "invalid_request_error",
+            "code": "invalid_api_key",
+        }},
+        status_code=401,
+    )
+
+
+async def resolve_consent_key(request: Request) -> dict | None:
+    """Resolve the Authorization: Bearer consent key to its binding, or None.
+
+    None covers a missing/malformed header, an unknown store, an empty token,
+    and a revoked/expired/unknown key (the store rejects those), so callers
+    cannot distinguish failure modes.
+    """
+    auth = request.headers.get("authorization", "")
+    if not auth.lower().startswith("bearer "):
+        return None
+    token = auth[7:].strip()
+    store = getattr(request.app.state, "agent_model_keys", None)
+    if store is None or not token:
+        return None
+    return await store.resolve(token)
+
+
+@router.get("/v1/models")
+async def list_models(request: Request):
+    """OpenAI /v1/models: the agents this consent key may address, as models."""
+    binding = await resolve_consent_key(request)
+    if binding is None:
+        return _unauthorized()
+    try:
+        created = int(datetime.fromisoformat(binding["created_at"]).timestamp())
+    except (KeyError, ValueError, TypeError):
+        created = 0
+    data = [
+        {"id": agent_id, "object": "model", "created": created, "owned_by": "taos-agent"}
+        for agent_id in binding.get("agent_ids", [])
+    ]
+    return {"object": "list", "data": data}


### PR DESCRIPTION
Builds on the merged consent-key store (#1372). The auth-gated OpenAI-compatible surface, per Jay decision 19 (the bearer key IS the consent grant). Spec: ~/tinyagentos-private/specs/agent-as-a-model.md.

## What
- `routes/agent_model_api.py`: `resolve_consent_key` (Authorization: Bearer -> AgentModelKeyStore.resolve -> binding, or None for missing/unknown/revoked/expired) and `GET /v1/models` returning the consented agents as OpenAI model entries (`{object:list, data:[{id, object:model, owned_by:taos-agent}]}`). OpenAI-shaped 401 for an invalid key.
- Registers `AgentModelKeyStore` on `app.state` (mirrors the app_grants wiring).

## Auth-first, per the spec
- The endpoint never resolves a model without a valid consent key. `POST /v1/chat/completions` (running a turn through the agent harness), scope enforcement, and rate limiting are later slices on top of this binding.

## Tests
- 401 without a key / unknown key / revoked key; 200 lists the consented agent_ids as models. 4 passed. The client fixture exercising create_app confirms the app.state registration does not break startup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added `/v1/models` endpoint with OpenAI-compatible API surface, requiring Bearer token authentication to list consented agent models.

* **Tests**
  * Added comprehensive test coverage for the new endpoint, including authentication validation, authorization checks, and key revocation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->