### PR TITLE
feat(agent-model): owner key-management API (mint/list/revoke)

### DIFF
--- a/tests/test_routes_agent_model_keys.py
+++ b/tests/test_routes_agent_model_keys.py
@@ -1,0 +1,82 @@
+"""Endpoint tests for routes/agent_model_keys.py (decision 19, owner surface)."""
+import asyncio
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _ensure_agent_model_key_store(client, tmp_path_factory):
+    """Init app.state.agent_model_keys on a fresh DB; the test client registers
+    the store but does not run the lifespan that init()s it (production does)."""
+    store = client._transport.app.state.agent_model_keys
+    if store._db is not None:
+        try:
+            asyncio.get_event_loop().run_until_complete(store.close())
+        except Exception:
+            pass
+    tmp_dir = tmp_path_factory.mktemp("agent_model_keys_test")
+    store.db_path = tmp_dir / "agent_model_keys.db"
+    asyncio.get_event_loop().run_until_complete(store.init())
+    yield
+    try:
+        asyncio.get_event_loop().run_until_complete(store.close())
+    except Exception:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_list_empty_by_default(client):
+    resp = await client.get("/api/agent-model-keys")
+    assert resp.status_code == 200
+    assert resp.json()["keys"] == []
+
+
+@pytest.mark.asyncio
+async def test_mint_returns_token_once_then_listed(client):
+    resp = await client.post(
+        "/api/agent-model-keys",
+        json={"agent_ids": ["assistant-20260101-000000"], "scopes": ["chat"]},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["key"].startswith("sk-taosagent-")
+    assert body["record"]["agent_ids"] == ["assistant-20260101-000000"]
+    assert "key_hash" not in body["record"]  # never surface the hash
+
+    listed = (await client.get("/api/agent-model-keys")).json()["keys"]
+    assert len(listed) == 1
+    assert "key" not in listed[0]  # the plaintext is never re-served
+
+
+@pytest.mark.asyncio
+async def test_mint_without_agent_ids_returns_400(client):
+    resp = await client.post(
+        "/api/agent-model-keys", json={"agent_ids": [], "scopes": []}
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_mint_naive_expiry_returns_400(client):
+    resp = await client.post(
+        "/api/agent-model-keys",
+        json={"agent_ids": ["a"], "expires_at": "2030-01-01T00:00:00"},
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_revoke_own_key(client):
+    rec = (
+        await client.post("/api/agent-model-keys", json={"agent_ids": ["a"]})
+    ).json()["record"]
+    resp = await client.post(f"/api/agent-model-keys/{rec['id']}/revoke")
+    assert resp.status_code == 200
+    listed = (await client.get("/api/agent-model-keys")).json()["keys"]
+    assert listed[0]["revoked"] is True
+
+
+@pytest.mark.asyncio
+async def test_revoke_unknown_key_returns_404(client):
+    resp = await client.post("/api/agent-model-keys/999999/revoke")
+    assert resp.status_code == 404

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -334,3 +334,6 @@ def register_all_routers(app):
 
     from tinyagentos.routes.agent_model_api import router as agent_model_api_router
     app.include_router(agent_model_api_router)
+
+    from tinyagentos.routes.agent_model_keys import router as agent_model_keys_router
+    app.include_router(agent_model_keys_router)

--- a/tinyagentos/routes/agent_model_keys.py
+++ b/tinyagentos/routes/agent_model_keys.py
@@ -1,0 +1,75 @@
+"""Owner-facing management API for Agent-as-a-Model consent keys (decision 19).
+
+The companion to routes/agent_model_api.py: that module is the OpenAI-compatible
+/v1 surface an external caller hits with a consent key; THIS module is the
+authenticated owner surface where a taOS user mints, reviews, and revokes the
+keys that expose their own agent(s). The owner is the issuer, so authenticating
+the request IS the consent; an external third party requesting access is the
+richer Decisions-mediated flow built on top of this, not this slice.
+
+Keys are scoped to the calling user: list and revoke only ever touch keys the
+user issued. mint returns the plaintext token exactly once (the store keeps only
+its hash), so the response is the sole opportunity to show it to the user.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from tinyagentos.auth_context import CurrentUser, current_user
+
+router = APIRouter()
+
+
+class MintIn(BaseModel):
+    agent_ids: list[str]
+    scopes: list[str] = []
+    rate_cap: Optional[int] = None
+    expires_at: Optional[str] = None  # ISO-8601, timezone-aware
+
+
+@router.get("/api/agent-model-keys")
+async def list_keys(request: Request, user: CurrentUser = Depends(current_user)):
+    """List the consent keys this user issued (newest first, no secret material)."""
+    store = request.app.state.agent_model_keys
+    return {"keys": await store.list_for_user(user.user_id)}
+
+
+@router.post("/api/agent-model-keys")
+async def mint_key(
+    body: MintIn, request: Request, user: CurrentUser = Depends(current_user)
+):
+    """Mint a consent key exposing the caller's agent(s). Returns the token ONCE."""
+    store = request.app.state.agent_model_keys
+    try:
+        token, rec = await store.mint(
+            user.user_id,
+            body.agent_ids,
+            body.scopes,
+            rate_cap=body.rate_cap,
+            expires_at=body.expires_at,
+        )
+    except ValueError as e:
+        return JSONResponse({"error": str(e)}, status_code=400)
+    # The token is shown exactly once; the stored record never carries it.
+    return {"key": token, "record": rec}
+
+
+@router.post("/api/agent-model-keys/{key_id}/revoke")
+async def revoke_key(
+    key_id: int, request: Request, user: CurrentUser = Depends(current_user)
+):
+    """Revoke one of the caller's own keys.
+
+    Ownership is enforced here because the store revokes by row id alone; a user
+    must never be able to revoke a key another user issued.
+    """
+    store = request.app.state.agent_model_keys
+    owned = {k["id"] for k in await store.list_for_user(user.user_id)}
+    if key_id not in owned:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    await store.revoke(key_id)
+    return {"ok": True}


### PR DESCRIPTION
## What

Owner-facing management API for Agent-as-a-Model consent keys (decision 19), the companion to the `/v1` OpenAI-compatible surface landed in #1376.

- `GET  /api/agent-model-keys` — list the caller's issued keys (newest first, no secret material)
- `POST /api/agent-model-keys` — mint a key exposing the caller's agent(s); returns the plaintext token **once**
- `POST /api/agent-model-keys/{id}/revoke` — revoke one of the caller's own keys

## Why

Completes the Agent-as-a-Model MVP loop: an owner mints a key here, an external OpenAI-compatible client then uses it at `/v1/models`. `current_user` auth is the consent (the owner is the issuer); the external-party-requests-access path is the richer Decisions-mediated flow built on top of this, not this slice.

## Notes

- Revoke enforces ownership explicitly because `AgentModelKeyStore.revoke(key_id)` scopes by row id alone; a user must never revoke another user's key (returns 404 otherwise).
- Token shown once at mint; only its SHA-256 hash is stored (store behaviour from #1372).
- Scoped to the calling user throughout (list/revoke only touch the user's own keys).

## Tests

6 endpoint tests (`tests/test_routes_agent_model_keys.py`): empty default, mint-returns-token-once + listed without secret, mint without agent_ids → 400, naive expiry → 400, revoke own key, revoke unknown → 404. All green locally.