### PR TITLE
test(browser): deterministic PageContextMenu arrow-nav test

### DIFF
--- a/desktop/src/apps/BrowserApp/PageContextMenu.test.tsx
+++ b/desktop/src/apps/BrowserApp/PageContextMenu.test.tsx
@@ -146,17 +146,28 @@ describe("PageContextMenu", () => {
     });
 
     const menu = container.firstChild as HTMLElement;
-    // Initially Alpha should be focused (first item)
-    const items = screen.getAllByRole("menuitem");
-    expect(items[0].getAttribute("aria-current")).toBe("true");
+    // Initially Alpha should be focused (first item). Assert via waitFor so the
+    // focus-reset effect that fires when agents finish loading is fully flushed
+    // before we read aria-current (it would otherwise race the keydown below).
+    await waitFor(() => {
+      const items = screen.getAllByRole("menuitem");
+      expect(items[0].getAttribute("aria-current")).toBe("true");
+    });
 
-    fireEvent.keyDown(menu, { key: "ArrowDown" });
+    // Wrap the keydown in act() so the setFocusedIdx update and any pending
+    // load effect settle deterministically before the assertion, rather than
+    // racing the 1s waitFor under loaded CI runners.
+    await act(async () => {
+      fireEvent.keyDown(menu, { key: "ArrowDown" });
+    });
     await waitFor(() => {
       const updated = screen.getAllByRole("menuitem");
       expect(updated[1].getAttribute("aria-current")).toBe("true");
     });
 
-    fireEvent.keyDown(menu, { key: "ArrowUp" });
+    await act(async () => {
+      fireEvent.keyDown(menu, { key: "ArrowUp" });
+    });
     await waitFor(() => {
       const updated = screen.getAllByRole("menuitem");
       expect(updated[0].getAttribute("aria-current")).toBe("true");


### PR DESCRIPTION
## Problem

`PageContextMenu.test.tsx > ArrowDown/Up navigate between entries` intermittently times out in CI (observed on an unrelated doc-only PR: the post-ArrowDown `waitFor` hit ~1039ms, the 1s default). Because it runs in the `spa-build` job's vitest step, a flake there fails the required gate and blocks every open PR. dev is otherwise green (2061 tests pass locally on a clean `npm ci`).

## Cause

The component resets focus to index 0 in a `useEffect` keyed on `agents.length` when the async agent list finishes loading. Under loaded CI runners that reset can interleave with the `setFocusedIdx` update from the test's ArrowDown keydown, occasionally clobbering focus back to 0 so `items[1]` never reaches `aria-current=true` within the timeout.

## Fix

Test-only, no component behaviour change:
- Assert the initial `aria-current` via `waitFor` so the load/reset effect is flushed before the first read.
- Wrap each `fireEvent.keyDown` in `act(async ...)` so the state update and any pending effect settle deterministically before the following assertion.

Stable across 5 repeated local runs; full suite stays green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of context menu navigation tests by resolving timing issues in focus state assertions and keyboard interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->