### PR TITLE
feat(agent-model): /v1/chat/completions consent contract (turn pending)

### DIFF
--- a/tests/test_routes_agent_model_api.py
+++ b/tests/test_routes_agent_model_api.py
@@ -57,3 +57,68 @@ async def test_models_revoked_key_is_rejected(client):
     await store.revoke(rec["id"])
     resp = await client.get("/v1/models", headers={"Authorization": f"Bearer {token}"})
     assert resp.status_code == 401
+
+
+# --- POST /v1/chat/completions: the consent contract (turn execution pending) ---
+
+
+def _chat_body(model="agent-a"):
+    return {"model": model, "messages": [{"role": "user", "content": "hi"}]}
+
+
+@pytest.mark.asyncio
+async def test_chat_requires_a_key(client):
+    resp = await client.post("/v1/chat/completions", json=_chat_body())
+    assert resp.status_code == 401
+    assert resp.json()["error"]["code"] == "invalid_api_key"
+
+
+@pytest.mark.asyncio
+async def test_chat_rejects_model_not_in_scope(client):
+    store = client._transport.app.state.agent_model_keys
+    token, _ = await store.mint("u1", ["agent-a"], [])
+    resp = await client.post(
+        "/v1/chat/completions",
+        json=_chat_body(model="agent-z"),
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 404
+    assert resp.json()["error"]["code"] == "model_not_found"
+
+
+@pytest.mark.asyncio
+async def test_chat_rejects_empty_messages(client):
+    store = client._transport.app.state.agent_model_keys
+    token, _ = await store.mint("u1", ["agent-a"], [])
+    resp = await client.post(
+        "/v1/chat/completions",
+        json={"model": "agent-a", "messages": []},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_chat_contract_valid_returns_501_until_turn_implemented(client):
+    store = client._transport.app.state.agent_model_keys
+    token, _ = await store.mint("u1", ["agent-a"], [])
+    resp = await client.post(
+        "/v1/chat/completions",
+        json=_chat_body(model="agent-a"),
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 501
+    assert resp.json()["error"]["code"] == "not_implemented"
+
+
+@pytest.mark.asyncio
+async def test_chat_revoked_key_is_rejected(client):
+    store = client._transport.app.state.agent_model_keys
+    token, rec = await store.mint("u1", ["agent-a"], [])
+    await store.revoke(rec["id"])
+    resp = await client.post(
+        "/v1/chat/completions",
+        json=_chat_body(),
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 401

--- a/tests/test_routes_agent_model_api.py
+++ b/tests/test_routes_agent_model_api.py
@@ -122,3 +122,26 @@ async def test_chat_revoked_key_is_rejected(client):
         headers={"Authorization": f"Bearer {token}"},
     )
     assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_chat_auth_precedes_body_validation(client):
+    # An unauthenticated caller with a malformed body must get 401 (auth first),
+    # never a 422 that leaks the schema.
+    resp = await client.post("/v1/chat/completions", json={"bogus": True})
+    assert resp.status_code == 401
+    assert resp.json()["error"]["code"] == "invalid_api_key"
+
+
+@pytest.mark.asyncio
+async def test_chat_missing_model_is_openai_shaped_400(client):
+    store = client._transport.app.state.agent_model_keys
+    token, _ = await store.mint("u1", ["agent-a"], [])
+    resp = await client.post(
+        "/v1/chat/completions",
+        json={"messages": [{"role": "user", "content": "hi"}]},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 400
+    # OpenAI envelope, not FastAPI's default {"detail": [...]} 422.
+    assert resp.json()["error"]["type"] == "invalid_request_error"

--- a/tinyagentos/routes/agent_model_api.py
+++ b/tinyagentos/routes/agent_model_api.py
@@ -20,7 +20,6 @@ from datetime import datetime
 
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel
 
 router = APIRouter()
 
@@ -76,42 +75,52 @@ async def list_models(request: Request):
     return {"object": "list", "data": data}
 
 
-class _Message(BaseModel):
-    role: str
-    content: object = ""
-
-
-class ChatCompletionIn(BaseModel):
-    model: str
-    messages: list[_Message] = []
-    stream: bool = False
-
-
 @router.post("/v1/chat/completions")
-async def chat_completions(body: ChatCompletionIn, request: Request):
+async def chat_completions(request: Request):
     """OpenAI /v1/chat/completions for an agent-as-a-model.
 
     Enforces the consent contract: a valid key is required, and the requested
     model must be one of the agents that key is consented for. Running the turn
     through the agent's harness is the next slice (pending the seam choice), so a
     contract-valid request returns 501 rather than a fabricated completion.
+
+    The body is parsed manually AFTER the auth check (not via a Pydantic
+    parameter) for two reasons: auth must take precedence so an unauthenticated
+    caller always gets 401 rather than schema feedback, and every error stays in
+    the OpenAI envelope rather than FastAPI's default 422 {"detail": ...}.
     """
     binding = await resolve_consent_key(request)
     if binding is None:
         return _unauthorized()
-    if not body.messages:
+
+    def _bad_request(message: str) -> JSONResponse:
         return _openai_error(
-            "'messages' must contain at least one message",
+            message,
             type="invalid_request_error",
             code="invalid_request_error",
             status=400,
         )
-    if body.model not in binding.get("agent_ids", []):
+
+    try:
+        body = await request.json()
+    except Exception:
+        return _bad_request("request body must be valid JSON")
+    if not isinstance(body, dict):
+        return _bad_request("request body must be a JSON object")
+
+    model = body.get("model")
+    if not isinstance(model, str) or not model:
+        return _bad_request("you must provide a 'model' parameter")
+    messages = body.get("messages")
+    if not isinstance(messages, list) or not messages:
+        return _bad_request("'messages' must contain at least one message")
+
+    if model not in binding.get("agent_ids", []):
         # OpenAI returns 404 model_not_found for a model the key cannot address;
         # this doubles as scope enforcement (the key is only consented for its
         # agent_ids), without leaking whether the agent exists for another user.
         return _openai_error(
-            f"the model '{body.model}' does not exist or you do not have access to it",
+            f"the model '{model}' does not exist or you do not have access to it",
             type="invalid_request_error",
             code="model_not_found",
             status=404,

--- a/tinyagentos/routes/agent_model_api.py
+++ b/tinyagentos/routes/agent_model_api.py
@@ -5,12 +5,14 @@ key (the bearer token IS the consent grant, minted only through the user
 consent flow) and gets THEIR agent(s) exposed as models. The key maps to
 {issuing_user, agent_ids, scopes, expiry, rate_cap} via AgentModelKeyStore.
 
-This slice is the AUTH-GATED surface: GET /v1/models lists the agents the
-caller's key is consented for, each as an OpenAI model entry. POST
-/v1/chat/completions (running a turn through the agent harness), scope
-enforcement, and rate limiting are later slices built on this binding. Per the
-spec, the endpoint must never resolve a model without a valid consent key, so
-the auth binding lands first.
+GET /v1/models lists the agents the caller's key is consented for, each as an
+OpenAI model entry. POST /v1/chat/completions enforces the same consent contract
+(valid key, requested model in the key's agent_ids) but does NOT yet run the
+agent turn: that step drives the agent's harness and is the next slice, pending
+the turn-seam choice (see ~/.taos-team/pending-decisions.md), so a valid request
+returns 501. Scope (per-capability) enforcement and rate limiting also build on
+this binding. Per the spec, the endpoint must never resolve a model without a
+valid consent key, so the auth + scope contract lands first.
 """
 from __future__ import annotations
 
@@ -18,19 +20,25 @@ from datetime import datetime
 
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
+from pydantic import BaseModel
 
 router = APIRouter()
 
 
-def _unauthorized() -> JSONResponse:
-    # OpenAI-shaped error so standard clients surface it correctly.
+def _openai_error(message: str, *, type: str, code: str, status: int) -> JSONResponse:
+    """OpenAI-shaped error envelope so standard clients surface it correctly."""
     return JSONResponse(
-        {"error": {
-            "message": "invalid or missing consent key",
-            "type": "invalid_request_error",
-            "code": "invalid_api_key",
-        }},
-        status_code=401,
+        {"error": {"message": message, "type": type, "code": code}},
+        status_code=status,
+    )
+
+
+def _unauthorized() -> JSONResponse:
+    return _openai_error(
+        "invalid or missing consent key",
+        type="invalid_request_error",
+        code="invalid_api_key",
+        status=401,
     )
 
 
@@ -66,3 +74,52 @@ async def list_models(request: Request):
         for agent_id in binding.get("agent_ids", [])
     ]
     return {"object": "list", "data": data}
+
+
+class _Message(BaseModel):
+    role: str
+    content: object = ""
+
+
+class ChatCompletionIn(BaseModel):
+    model: str
+    messages: list[_Message] = []
+    stream: bool = False
+
+
+@router.post("/v1/chat/completions")
+async def chat_completions(body: ChatCompletionIn, request: Request):
+    """OpenAI /v1/chat/completions for an agent-as-a-model.
+
+    Enforces the consent contract: a valid key is required, and the requested
+    model must be one of the agents that key is consented for. Running the turn
+    through the agent's harness is the next slice (pending the seam choice), so a
+    contract-valid request returns 501 rather than a fabricated completion.
+    """
+    binding = await resolve_consent_key(request)
+    if binding is None:
+        return _unauthorized()
+    if not body.messages:
+        return _openai_error(
+            "'messages' must contain at least one message",
+            type="invalid_request_error",
+            code="invalid_request_error",
+            status=400,
+        )
+    if body.model not in binding.get("agent_ids", []):
+        # OpenAI returns 404 model_not_found for a model the key cannot address;
+        # this doubles as scope enforcement (the key is only consented for its
+        # agent_ids), without leaking whether the agent exists for another user.
+        return _openai_error(
+            f"the model '{body.model}' does not exist or you do not have access to it",
+            type="invalid_request_error",
+            code="model_not_found",
+            status=404,
+        )
+    # Contract satisfied; the turn execution is the next slice.
+    return _openai_error(
+        "agent turn execution is not yet implemented for this surface",
+        type="server_error",
+        code="not_implemented",
+        status=501,
+    )


### PR DESCRIPTION
## What

Adds `POST /v1/chat/completions` to the agent-as-a-model OpenAI-compatible surface (decision 19), continuing #1376 (`/v1/models`) and #1378 (owner key-mgmt).

It enforces the **consent contract**, which is invariant across all three turn-seam options flagged in pending-decisions:
- no/invalid/expired/revoked key → 401 `invalid_api_key`
- requested `model` not in the key's `agent_ids` → 404 `model_not_found` (this doubles as scope enforcement and does not leak whether the agent exists for another user)
- empty `messages` → 400
- contract satisfied → **501 `not_implemented`**

## Why 501

Running the turn drives the agent's harness (per-agent opencode server + LiteLLM), which needs a live agent stack and an architecture choice (the turn-seam decision is in `~/.taos-team/pending-decisions.md`). Landing the auth + scope contract first, with a clean 501 for the turn, mirrors how `/v1/models` landed auth-first in #1376 and is compatible with whichever seam is chosen. All errors are OpenAI-shaped so standard clients surface them correctly.

## Tests

5 new endpoint tests (9 total in the file, all green locally): key required, model-not-in-scope → 404, empty messages → 400, contract-valid → 501, revoked key → 401.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/v1/chat/completions` endpoint with OpenAI-compatible interface (currently returns `501 not_implemented`).

* **Tests**
  * Comprehensive test coverage for authentication, authorization, and request validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->