### PR TITLE
feat(apps): closed capability vocabulary + manifest validation (#56)

### DIFF
--- a/tests/test_app_capabilities.py
+++ b/tests/test_app_capabilities.py
@@ -1,0 +1,74 @@
+"""The closed userspace capability vocabulary + manifest validation (#56 slice 1)."""
+import pytest
+
+from tinyagentos.userspace.capabilities import (
+    FREE_CAPS,
+    GATED_CAPS,
+    KNOWN_CAPS,
+    is_known_capability,
+)
+from tinyagentos.userspace.package import PackageError, parse_manifest
+
+
+def test_known_caps_is_free_plus_gated_and_disjoint():
+    assert KNOWN_CAPS == FREE_CAPS | GATED_CAPS
+    assert FREE_CAPS.isdisjoint(GATED_CAPS)
+
+
+def test_broker_reexports_the_same_sets():
+    # The broker must enforce the exact vocabulary the parser validates against.
+    from tinyagentos.userspace import broker
+
+    assert broker.FREE_CAPS is FREE_CAPS
+    assert broker.GATED_CAPS is GATED_CAPS
+
+
+@pytest.mark.parametrize("cap", sorted(KNOWN_CAPS))
+def test_every_known_cap_is_recognised(cap):
+    assert is_known_capability(cap) is True
+
+
+def test_network_grant_is_recognised_regardless_of_origin_format():
+    # is_known_capability classifies the capability kind; origin format is the
+    # parser's job, so even a malformed origin is "known" at this layer.
+    assert is_known_capability("network:https://example.com") is True
+    assert is_known_capability("network:garbage") is True
+
+
+def test_unknown_and_non_string_caps_are_rejected():
+    assert is_known_capability("app.bogus") is False
+    assert is_known_capability("files.read") is False  # not the shipped scheme
+    assert is_known_capability(123) is False
+
+
+def _manifest(perms):
+    return f"id: a\nname: A\nversion: 1.0.0\napp_type: web\npermissions:\n" + "".join(
+        f"  - {p}\n" for p in perms
+    )
+
+
+def test_manifest_accepts_known_caps_and_network_origin():
+    data = parse_manifest(_manifest(["app.kv", "app.net", "network:https://api.example.com"]))
+    assert data["permissions"] == ["app.kv", "app.net", "network:https://api.example.com"]
+
+
+def test_manifest_rejects_unknown_capability():
+    with pytest.raises(PackageError, match="unknown capability"):
+        parse_manifest(_manifest(["app.kv", "app.bogus"]))
+
+
+def test_manifest_rejects_wrong_scheme_capability():
+    # A plausible-but-wrong name (the non-shipped scheme) must be rejected at
+    # parse time, not silently pass to fail later in the broker.
+    with pytest.raises(PackageError, match="unknown capability"):
+        parse_manifest(_manifest(["files.read"]))
+
+
+def test_manifest_still_rejects_malformed_network_origin():
+    with pytest.raises(PackageError, match="invalid network permission origin"):
+        parse_manifest(_manifest(["network:http://insecure.example.com"]))
+
+
+def test_manifest_rejects_non_string_permission():
+    with pytest.raises(PackageError, match="permission must be a string"):
+        parse_manifest("id: a\nname: A\nversion: 1.0.0\napp_type: web\npermissions:\n  - 42\n")

--- a/tinyagentos/userspace/broker.py
+++ b/tinyagentos/userspace/broker.py
@@ -3,15 +3,15 @@ from __future__ import annotations
 import httpx
 from pathlib import Path
 
+# The capability vocabulary lives in a shared leaf module so the manifest parser
+# validates against the exact same set the broker enforces. Re-exported here so
+# existing `from tinyagentos.userspace.broker import GATED_CAPS` callers keep working.
+from tinyagentos.userspace.capabilities import FREE_CAPS, GATED_CAPS
+
 # Headers an app may NOT set on a backend-proxy call -- these would let it
 # spoof identity/routing or exfiltrate the session.
 _BLOCKED_PROXY_HEADERS = {"host", "authorization", "cookie",
                           "x-forwarded-for", "x-forwarded-host", "x-forwarded-proto"}
-
-# Capability namespaces granted to every app without consent.
-FREE_CAPS = {"app.kv", "app.table", "app.files", "app.notify", "app.window"}
-# Capability namespaces that require an explicit granted permission.
-GATED_CAPS = {"app.net", "app.agent", "app.llm", "app.memory"}
 
 
 def _namespace(capability: str) -> str:

--- a/tinyagentos/userspace/capabilities.py
+++ b/tinyagentos/userspace/capabilities.py
@@ -1,0 +1,41 @@
+"""Closed capability vocabulary for userspace apps (#56, decision 6).
+
+The single source of truth for which capabilities a userspace app may declare in
+its manifest `permissions:` and request at runtime. The broker enforces these at
+call time; the package parser validates a manifest's declared permissions against
+the same set so an app can never ship a typo'd or made-up capability that only
+fails later at runtime.
+
+This is deliberately the EXISTING shipped vocabulary (the broker already gates on
+FREE_CAPS / GATED_CAPS), not a new naming scheme: introducing parallel names
+would break every installed app. A closed set is cheap to extend when a new
+capability is added to the broker.
+
+Forms:
+- A bare capability namespace, e.g. `app.kv` (free) or `app.net` (gated).
+- A parametrized `network:<origin>` grant, where <origin> is an https/wss origin
+  validated separately by the package parser before it reaches the sandbox CSP.
+"""
+from __future__ import annotations
+
+# Granted to every app without consent.
+FREE_CAPS = frozenset({"app.kv", "app.table", "app.files", "app.notify", "app.window"})
+# Require an explicit granted permission (runtime consent via the Decisions flow).
+GATED_CAPS = frozenset({"app.net", "app.agent", "app.llm", "app.memory"})
+# The whole closed set of bare capability namespaces.
+KNOWN_CAPS = FREE_CAPS | GATED_CAPS
+
+# Parametrized capability prefix: `network:<origin>` allowlists a single origin.
+NET_PREFIX = "network:"
+
+
+def is_known_capability(perm: str) -> bool:
+    """True if `perm` is a recognised capability the vocabulary permits.
+
+    Accepts a bare namespace in KNOWN_CAPS or a `network:<origin>` grant. The
+    <origin> portion's format is validated by the package parser, not here; this
+    only classifies whether the capability itself is one the system understands.
+    """
+    if not isinstance(perm, str):
+        return False
+    return perm in KNOWN_CAPS or perm.startswith(NET_PREFIX)

--- a/tinyagentos/userspace/package.py
+++ b/tinyagentos/userspace/package.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import yaml
 
-from tinyagentos.userspace.capabilities import KNOWN_CAPS, is_known_capability
+from tinyagentos.userspace.capabilities import KNOWN_CAPS, NET_PREFIX, is_known_capability
 
 # A `network:<origin>` permission lets a granted app's bundle connect to that
 # external origin (it is added to the sandbox CSP connect-src). The origin is
@@ -89,8 +89,8 @@ def parse_manifest(text: str) -> dict:
             raise PackageError(
                 f"manifest permission must be a string, got {type(perm).__name__}"
             )
-        if perm.startswith("network:"):
-            origin = perm[len("network:"):]
+        if perm.startswith(NET_PREFIX):
+            origin = perm[len(NET_PREFIX):]
             if not _NET_ORIGIN_RE.match(origin):
                 raise PackageError(
                     f"invalid network permission origin {origin!r}: must be "

--- a/tinyagentos/userspace/package.py
+++ b/tinyagentos/userspace/package.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 import yaml
 
+from tinyagentos.userspace.capabilities import KNOWN_CAPS, is_known_capability
+
 # A `network:<origin>` permission lets a granted app's bundle connect to that
 # external origin (it is added to the sandbox CSP connect-src). The origin is
 # strictly validated so it can never inject extra CSP directives: scheme://host
@@ -83,7 +85,11 @@ def parse_manifest(text: str) -> dict:
     if not isinstance(data["permissions"], list):
         raise PackageError("manifest 'permissions' must be a list")
     for perm in data["permissions"]:
-        if isinstance(perm, str) and perm.startswith("network:"):
+        if not isinstance(perm, str):
+            raise PackageError(
+                f"manifest permission must be a string, got {type(perm).__name__}"
+            )
+        if perm.startswith("network:"):
             origin = perm[len("network:"):]
             if not _NET_ORIGIN_RE.match(origin):
                 raise PackageError(
@@ -91,6 +97,11 @@ def parse_manifest(text: str) -> dict:
                     "wss://host or https://host with an optional *. subdomain "
                     "wildcard and an optional :port, nothing else"
                 )
+        elif not is_known_capability(perm):
+            raise PackageError(
+                f"unknown capability {perm!r}: allowed capabilities are "
+                f"{sorted(KNOWN_CAPS)} or a network:<origin> grant"
+            )
     return data
 
 


### PR DESCRIPTION
## What

Slice 1 of the app permission/capability system (#56, decision 6: manifest declares + runtime grants via the Decisions/consent flow).

- New leaf module `tinyagentos/userspace/capabilities.py`: the single source of truth for the closed capability vocabulary, with `FREE_CAPS`, `GATED_CAPS`, `KNOWN_CAPS`, and `is_known_capability()`.
- `broker.py` now imports the sets from there (re-exported, so existing `from ...broker import GATED_CAPS` keeps working).
- `package.py` `parse_manifest` validates each declared permission against the closed set: a `network:<origin>` grant (origin format validated as before) or a known bare capability. An unknown or typo'd capability is rejected at parse time with a clear error, instead of passing parse and only failing later in the broker.

## Vocabulary note

This uses the **existing shipped vocabulary** the broker already enforces (`app.kv/table/files/notify/window` free, `app.net/agent/llm/memory` gated, plus `network:<origin>`), not the names floated earlier in pending-decisions item 23. A parallel naming scheme would have broken every installed app, so formalizing the real set is the safe, non-breaking choice. A closed set is cheap to extend when a new broker capability is added.

## Tests

10 new tests (`tests/test_app_capabilities.py`): KNOWN_CAPS composition + disjointness, broker re-export identity, every known cap recognised, network grant classification, unknown/non-string rejection, and manifest parse accepts-known / rejects-unknown / rejects-wrong-scheme / still-rejects-bad-origin / rejects-non-string. 402 broker+package+userspace unit tests pass, no regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced manifest validation now rejects invalid or unknown permissions with clearer error messages listing allowed capabilities.
  * Network origin-based permissions are now formally validated during manifest parsing.
  * Non-string permission entries are properly rejected with detailed error feedback.

* **Tests**
  * Added comprehensive tests validating permission vocabulary and manifest parsing rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->