### PR TITLE
feat(taosctl): knowledge command group (tsk-7evpnv)

### DIFF
--- a/tests/test_taosctl_knowledge.py
+++ b/tests/test_taosctl_knowledge.py
@@ -1,0 +1,122 @@
+"""Tests for the taosctl knowledge command group: each verb hits the right path."""
+from __future__ import annotations
+
+import pytest
+
+from tinyagentos.cli.taosctl import __main__ as cli_main
+
+
+class _FakeClient:
+    def __init__(self, *a, **k):
+        self.calls = []
+        self.base_url = "http://x"
+        self.token = "t"
+
+    def get(self, path, params=None):
+        self.calls.append(("GET", path, params))
+        return {"items": [{"id": "k1"}]}
+
+    def post(self, path, body=None, params=None, json=None):
+        self.calls.append(("POST", path, body))
+        return {"id": "k1", "status": "pending"}
+
+    def delete(self, path, params=None):
+        self.calls.append(("DELETE", path, params))
+        return {"ok": True}
+
+
+def _run(monkeypatch, argv, fake):
+    monkeypatch.setattr(cli_main, "TaosClient", lambda **k: fake)
+    return cli_main.main(argv)
+
+
+def _paths(fake):
+    return [(m, p) for (m, p, *_rest) in fake.calls]
+
+
+def test_list_items(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["knowledge", "list"], fake) == 0
+    assert ("GET", "/api/knowledge/items") in _paths(fake)
+
+
+def test_get_item(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["knowledge", "get", "k1"], fake) == 0
+    assert ("GET", "/api/knowledge/items/k1") in _paths(fake)
+
+
+def test_snapshots(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["knowledge", "snapshots", "k1"], fake) == 0
+    assert ("GET", "/api/knowledge/items/k1/snapshots") in _paths(fake)
+
+
+def test_delete_item(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["knowledge", "delete", "k1"], fake) == 0
+    assert ("DELETE", "/api/knowledge/items/k1") in _paths(fake)
+
+
+def test_search_passes_query_params(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["knowledge", "search", "neural", "--mode", "semantic", "--limit", "5"], fake) == 0
+    method, path, params = fake.calls[0]
+    assert (method, path) == ("GET", "/api/knowledge/search")
+    assert params == {"q": "neural", "mode": "semantic", "limit": 5}
+
+
+def test_ingest_posts_body(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(
+        monkeypatch,
+        ["knowledge", "ingest", "--url", "https://e.com", "--category", "a", "--category", "b"],
+        fake,
+    )
+    assert rc == 0
+    method, path, body = fake.calls[0]
+    assert (method, path) == ("POST", "/api/knowledge/ingest")
+    assert body["url"] == "https://e.com"
+    assert body["categories"] == ["a", "b"]
+
+
+def test_rules_list(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["knowledge", "rules"], fake) == 0
+    assert ("GET", "/api/knowledge/rules") in _paths(fake)
+
+
+def test_add_rule_posts_fields(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["knowledge", "add-rule", "--pattern", "ml*", "--category", "ai"], fake)
+    assert rc == 0
+    method, path, body = fake.calls[0]
+    assert (method, path) == ("POST", "/api/knowledge/rules")
+    assert body == {"pattern": "ml*", "match_on": "title", "category": "ai"}
+
+
+def test_delete_rule(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["knowledge", "delete-rule", "r1"], fake) == 0
+    assert ("DELETE", "/api/knowledge/rules/r1") in _paths(fake)
+
+
+def test_subscriptions_list(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["knowledge", "subscriptions"], fake) == 0
+    assert ("GET", "/api/knowledge/subscriptions") in _paths(fake)
+
+
+def test_subscribe_posts_body(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["knowledge", "subscribe", "--agent", "alpha", "--category", "ai", "--auto-ingest"], fake)
+    assert rc == 0
+    method, path, body = fake.calls[0]
+    assert (method, path) == ("POST", "/api/knowledge/subscriptions")
+    assert body == {"agent_name": "alpha", "category": "ai", "auto_ingest": True}
+
+
+def test_unsubscribe_targets_agent_and_category(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["knowledge", "unsubscribe", "alpha", "ai"], fake) == 0
+    assert ("DELETE", "/api/knowledge/subscriptions/alpha/ai") in _paths(fake)

--- a/tinyagentos/cli/taosctl/commands/knowledge.py
+++ b/tinyagentos/cli/taosctl/commands/knowledge.py
@@ -1,0 +1,146 @@
+"""taosctl knowledge -- inspect and manage the knowledge base from the shell.
+
+Wraps tinyagentos/routes/knowledge.py so agents and scripts can drive ingest,
+search, items, category rules, and subscriptions without the web UI. Follows the
+reference shape in commands/agents.py: a NOUN, a register() that wires verb
+subparsers, and small handlers that call the client and return data for the
+framework to render.
+
+All endpoints on the knowledge router take query params or small JSON bodies, so
+every one is wired here; there are no multipart/streaming endpoints to skip.
+"""
+from __future__ import annotations
+
+from urllib.parse import quote
+
+NOUN = "knowledge"
+
+
+def register(subparsers) -> None:
+    p = subparsers.add_parser(NOUN, help="Inspect and manage the knowledge base")
+    verbs = p.add_subparsers(dest="verb", required=True, metavar="<verb>")
+
+    lp = verbs.add_parser("list", help="List knowledge items")
+    lp.set_defaults(func=_list)
+
+    gp = verbs.add_parser("get", help="Get one knowledge item by id")
+    gp.add_argument("item_id", help="Knowledge item id")
+    gp.set_defaults(func=_get)
+
+    sp = verbs.add_parser("snapshots", help="List snapshots for an item")
+    sp.add_argument("item_id", help="Knowledge item id")
+    sp.set_defaults(func=_snapshots)
+
+    dp = verbs.add_parser("delete", help="Delete a knowledge item")
+    dp.add_argument("item_id", help="Knowledge item id")
+    dp.set_defaults(func=_delete)
+
+    qp = verbs.add_parser("search", help="Search the knowledge base")
+    qp.add_argument("query", help="Search query")
+    qp.add_argument("--mode", default="keyword", help="keyword (default) or semantic")
+    qp.add_argument("--limit", type=int, default=20)
+    qp.set_defaults(func=_search)
+
+    ip = verbs.add_parser("ingest", help="Ingest a URL or text into the knowledge base")
+    ip.add_argument("--url", default=None)
+    ip.add_argument("--title", default=None)
+    ip.add_argument("--text", default=None)
+    ip.add_argument("--category", action="append", dest="categories", default=None,
+                    help="category to tag (repeatable)")
+    ip.add_argument("--source", default=None)
+    ip.set_defaults(func=_ingest)
+
+    rp = verbs.add_parser("rules", help="List category rules")
+    rp.set_defaults(func=_rules)
+
+    arp = verbs.add_parser("add-rule", help="Create a category rule")
+    arp.add_argument("--pattern", required=True)
+    arp.add_argument("--match-on", default="title")
+    arp.add_argument("--category", required=True)
+    arp.set_defaults(func=_add_rule)
+
+    drp = verbs.add_parser("delete-rule", help="Delete a category rule")
+    drp.add_argument("rule_id", help="Rule id")
+    drp.set_defaults(func=_delete_rule)
+
+    subp = verbs.add_parser("subscriptions", help="List agent category subscriptions")
+    subp.set_defaults(func=_subscriptions)
+
+    subset = verbs.add_parser("subscribe", help="Upsert an agent subscription for a category")
+    subset.add_argument("--agent", required=True)
+    subset.add_argument("--category", required=True)
+    subset.add_argument("--auto-ingest", action="store_true")
+    subset.set_defaults(func=_subscribe)
+
+    unsub = verbs.add_parser("unsubscribe", help="Remove an agent subscription")
+    unsub.add_argument("agent_name", help="Agent name")
+    unsub.add_argument("category", help="Category")
+    unsub.set_defaults(func=_unsubscribe)
+
+
+def _list(args, client):
+    return client.get("/api/knowledge/items")
+
+
+def _get(args, client):
+    return client.get(f"/api/knowledge/items/{quote(args.item_id, safe='')}")
+
+
+def _snapshots(args, client):
+    return client.get(f"/api/knowledge/items/{quote(args.item_id, safe='')}/snapshots")
+
+
+def _delete(args, client):
+    return client.delete(f"/api/knowledge/items/{quote(args.item_id, safe='')}")
+
+
+def _search(args, client):
+    return client.get(
+        "/api/knowledge/search",
+        params={"q": args.query, "mode": args.mode, "limit": args.limit},
+    )
+
+
+def _ingest(args, client):
+    return client.post(
+        "/api/knowledge/ingest",
+        {
+            "url": args.url,
+            "title": args.title,
+            "text": args.text,
+            "categories": args.categories or [],
+            "source": args.source,
+        },
+    )
+
+
+def _rules(args, client):
+    return client.get("/api/knowledge/rules")
+
+
+def _add_rule(args, client):
+    return client.post(
+        "/api/knowledge/rules",
+        {"pattern": args.pattern, "match_on": args.match_on, "category": args.category},
+    )
+
+
+def _delete_rule(args, client):
+    return client.delete(f"/api/knowledge/rules/{quote(args.rule_id, safe='')}")
+
+
+def _subscriptions(args, client):
+    return client.get("/api/knowledge/subscriptions")
+
+
+def _subscribe(args, client):
+    return client.post(
+        "/api/knowledge/subscriptions",
+        {"agent_name": args.agent, "category": args.category, "auto_ingest": args.auto_ingest},
+    )
+
+
+def _unsubscribe(args, client):
+    return client.delete(
+        f"/api/knowledge/subscriptions/{quote(args.agent_name, safe='')}/{quote(args.category, safe='')}"
+    )


### PR DESCRIPTION
## What

Adds a `taosctl knowledge` command group wrapping `routes/knowledge.py`, so agents and scripts can drive the knowledge base from the shell (agent-native coverage).

Verbs: `list`, `get <id>`, `snapshots <id>`, `delete <id>`, `search <q> [--mode --limit]`, `ingest [--url --title --text --category... --source]`, `rules`, `add-rule`, `delete-rule <id>`, `subscriptions`, `subscribe`, `unsubscribe <agent> <category>`. Every endpoint on the router takes query params or a small JSON body, so all are wired (no multipart/streaming to skip).

Follows the `commands/agents.py` noun shape (module-level NOUN, register() wiring verb subparsers, small handlers returning data); auto-discovered, no shared file touched.

## Tests

12 endpoint tests (`tests/test_taosctl_knowledge.py`) assert each verb hits the correct path with the right method and body/params; the existing taosctl auto-discovery suite and the route-coverage gate both pass (every command path maps to a real route). New files only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `taosctl knowledge` command group with subcommands for list, get, search, ingest, delete, snapshots, rules management, and subscription management.

* **Tests**
  * Added comprehensive test coverage for the knowledge command group and its subcommands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->