### PR TITLE
feat(taosctl): catalog command group (tsk-3c5yah)

### DIFF
--- a/tests/test_taosctl_catalog.py
+++ b/tests/test_taosctl_catalog.py
@@ -1,0 +1,91 @@
+"""Tests for the taosctl catalog command group: each verb hits the right path."""
+from __future__ import annotations
+
+from tinyagentos.cli.taosctl import __main__ as cli_main
+
+
+class _FakeClient:
+    def __init__(self, *a, **k):
+        self.calls = []
+        self.base_url = "http://x"
+        self.token = "t"
+
+    def get(self, path, params=None):
+        self.calls.append(("GET", path, params))
+        return {"items": [{"id": 1}]}
+
+    def post(self, path, body=None, params=None, json=None):
+        self.calls.append(("POST", path, body))
+        return {"ok": True}
+
+
+def _run(monkeypatch, argv, fake):
+    monkeypatch.setattr(cli_main, "TaosClient", lambda **k: fake)
+    return cli_main.main(argv)
+
+
+def _paths(fake):
+    return [(m, p) for (m, p, *_rest) in fake.calls]
+
+
+def test_stats(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["catalog", "stats"], fake) == 0
+    assert ("GET", "/api/memory/catalog/stats") in _paths(fake)
+
+
+def test_date(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["catalog", "date", "2026-06-23"], fake) == 0
+    assert ("GET", "/api/memory/catalog/date/2026-06-23") in _paths(fake)
+
+
+def test_range_passes_params(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["catalog", "range", "2026-06-01", "2026-06-23"], fake) == 0
+    method, path, params = fake.calls[0]
+    assert (method, path) == ("GET", "/api/memory/catalog/range")
+    assert params == {"start": "2026-06-01", "end": "2026-06-23"}
+
+
+def test_search_passes_params(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["catalog", "search", "agents", "--limit", "5"], fake) == 0
+    method, path, params = fake.calls[0]
+    assert (method, path) == ("GET", "/api/memory/catalog/search")
+    assert params == {"q": "agents", "limit": 5}
+
+
+def test_session(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["catalog", "session", "42"], fake) == 0
+    assert ("GET", "/api/memory/catalog/session/42") in _paths(fake)
+
+
+def test_context(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["catalog", "context", "42"], fake) == 0
+    assert ("GET", "/api/memory/catalog/session/42/context") in _paths(fake)
+
+
+def test_recent(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["catalog", "recent", "--limit", "3"], fake) == 0
+    method, path, params = fake.calls[0]
+    assert (method, path) == ("GET", "/api/memory/catalog/recent")
+    assert params == {"limit": 3}
+
+
+def test_index_posts_body(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["catalog", "index", "--date", "2026-06-23", "--force"], fake) == 0
+    method, path, body = fake.calls[0]
+    assert (method, path) == ("POST", "/api/memory/catalog/index")
+    assert body["date"] == "2026-06-23"
+    assert body["force"] is True
+
+
+def test_rebuild_posts(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["catalog", "rebuild"], fake) == 0
+    assert ("POST", "/api/memory/catalog/rebuild") in _paths(fake)

--- a/tinyagentos/cli/taosctl/commands/catalog.py
+++ b/tinyagentos/cli/taosctl/commands/catalog.py
@@ -1,0 +1,104 @@
+"""taosctl catalog -- drive the session memory catalog from the shell.
+
+Wraps the catalog endpoints in tinyagentos/routes/catalog.py (all under
+/api/memory/catalog) so agents and scripts can look up indexed sessions, search
+topics, and trigger (re)indexing without the web UI. Follows the reference shape
+in commands/agents.py: a NOUN, a register() that wires verb subparsers, and
+small handlers that call the client and return data for the framework to render.
+
+Every endpoint takes query params or a small JSON body, so all are wired; there
+are no multipart/streaming endpoints to skip.
+"""
+from __future__ import annotations
+
+from urllib.parse import quote
+
+NOUN = "catalog"
+
+
+def register(subparsers) -> None:
+    p = subparsers.add_parser(NOUN, help="Inspect and (re)index the session memory catalog")
+    verbs = p.add_subparsers(dest="verb", required=True, metavar="<verb>")
+
+    sp = verbs.add_parser("stats", help="Catalog statistics")
+    sp.set_defaults(func=_stats)
+
+    dp = verbs.add_parser("date", help="Sessions for a date (YYYY-MM-DD)")
+    dp.add_argument("date")
+    dp.set_defaults(func=_date)
+
+    rp = verbs.add_parser("range", help="Sessions in a date range")
+    rp.add_argument("start", help="Start date (YYYY-MM-DD)")
+    rp.add_argument("end", help="End date (YYYY-MM-DD)")
+    rp.set_defaults(func=_range)
+
+    qp = verbs.add_parser("search", help="Search sessions by topic")
+    qp.add_argument("query")
+    qp.add_argument("--limit", type=int, default=20)
+    qp.set_defaults(func=_search)
+
+    ses = verbs.add_parser("session", help="Get one indexed session by id")
+    ses.add_argument("session_id")
+    ses.set_defaults(func=_session)
+
+    ctx = verbs.add_parser("context", help="Get the full context for a session")
+    ctx.add_argument("session_id")
+    ctx.set_defaults(func=_context)
+
+    rc = verbs.add_parser("recent", help="Recently indexed sessions")
+    rc.add_argument("--limit", type=int, default=20)
+    rc.set_defaults(func=_recent)
+
+    ip = verbs.add_parser("index", help="Index sessions (a date or a date range)")
+    ip.add_argument("--date", default=None, help="Single date YYYY-MM-DD")
+    ip.add_argument("--start-date", default=None)
+    ip.add_argument("--end-date", default=None)
+    ip.add_argument("--force", action="store_true", help="Re-index already-indexed sessions")
+    ip.set_defaults(func=_index)
+
+    rb = verbs.add_parser("rebuild", help="Rebuild the whole catalog from the archive")
+    rb.set_defaults(func=_rebuild)
+
+
+def _stats(args, client):
+    return client.get("/api/memory/catalog/stats")
+
+
+def _date(args, client):
+    return client.get(f"/api/memory/catalog/date/{quote(args.date, safe='')}")
+
+
+def _range(args, client):
+    return client.get("/api/memory/catalog/range", params={"start": args.start, "end": args.end})
+
+
+def _search(args, client):
+    return client.get("/api/memory/catalog/search", params={"q": args.query, "limit": args.limit})
+
+
+def _session(args, client):
+    return client.get(f"/api/memory/catalog/session/{quote(args.session_id, safe='')}")
+
+
+def _context(args, client):
+    return client.get(f"/api/memory/catalog/session/{quote(args.session_id, safe='')}/context")
+
+
+def _recent(args, client):
+    return client.get("/api/memory/catalog/recent", params={"limit": args.limit})
+
+
+def _index(args, client):
+    return client.post(
+        "/api/memory/catalog/index",
+        {
+            "date": args.date,
+            "start_date": args.start_date,
+            "end_date": args.end_date,
+            "force": args.force,
+        },
+    )
+
+
+def _rebuild(args, client):
+    return client.post("/api/memory/catalog/rebuild", {})


### PR DESCRIPTION
## What

Adds `taosctl catalog` wrapping the session memory catalog endpoints in `routes/catalog.py` (under `/api/memory/catalog`), so agents and scripts can drive the catalog from the shell.

Verbs: `stats`, `date <date>`, `range <start> <end>`, `search <q> [--limit]`, `session <id>`, `context <id>`, `recent [--limit]`, `index [--date --start-date --end-date --force]`, `rebuild`.

Follows the `commands/agents.py` noun shape; auto-discovered, no shared file touched.

## Tests

9 endpoint tests assert each verb hits the correct path/method/params; the taosctl auto-discovery suite and the route-coverage gate pass (every command path maps to a real route). New files only.