### PR TITLE
feat(taosctl): office command group (tsk-udnvfo)

### DIFF
--- a/tests/test_taosctl_office.py
+++ b/tests/test_taosctl_office.py
@@ -1,0 +1,80 @@
+"""Tests for the taosctl office command group: each verb hits the right path."""
+from __future__ import annotations
+
+from tinyagentos.cli.taosctl import __main__ as cli_main
+
+
+class _FakeClient:
+    def __init__(self, *a, **k):
+        self.calls = []
+        self.base_url = "http://x"
+        self.token = "t"
+
+    def get(self, path, params=None):
+        self.calls.append(("GET", path, None))
+        return {"items": [{"id": "d1"}]}
+
+    def post(self, path, body=None, params=None, json=None):
+        self.calls.append(("POST", path, body))
+        return {"id": "d1"}
+
+    def put(self, path, body=None, json=None):
+        self.calls.append(("PUT", path, body))
+        return {"id": "d1"}
+
+    def delete(self, path, params=None):
+        self.calls.append(("DELETE", path, None))
+        return {"ok": True}
+
+
+def _run(monkeypatch, argv, fake):
+    monkeypatch.setattr(cli_main, "TaosClient", lambda **k: fake)
+    return cli_main.main(argv)
+
+
+def _paths(fake):
+    return [(m, p) for (m, p, *_rest) in fake.calls]
+
+
+def test_create_posts_body(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["office", "create", "--kind", "write", "--title", "Notes"], fake) == 0
+    method, path, body = fake.calls[0]
+    assert (method, path) == ("POST", "/api/office/docs")
+    assert body == {"kind": "write", "title": "Notes", "content": ""}
+
+
+def test_create_rejects_bad_kind(monkeypatch):
+    fake = _FakeClient()
+    # argparse choices rejects an invalid kind before any client call (exit 2).
+    import pytest
+
+    with pytest.raises(SystemExit):
+        _run(monkeypatch, ["office", "create", "--kind", "bogus", "--title", "x"], fake)
+    assert fake.calls == []
+
+
+def test_list(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["office", "list"], fake) == 0
+    assert ("GET", "/api/office/docs") in _paths(fake)
+
+
+def test_get(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["office", "get", "d1"], fake) == 0
+    assert ("GET", "/api/office/docs/d1") in _paths(fake)
+
+
+def test_update_sends_only_supplied_fields(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["office", "update", "d1", "--title", "Renamed"], fake) == 0
+    method, path, body = fake.calls[0]
+    assert (method, path) == ("PUT", "/api/office/docs/d1")
+    assert body == {"title": "Renamed"}
+
+
+def test_delete(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["office", "delete", "d1"], fake) == 0
+    assert ("DELETE", "/api/office/docs/d1") in _paths(fake)

--- a/tinyagentos/cli/taosctl/commands/office.py
+++ b/tinyagentos/cli/taosctl/commands/office.py
@@ -1,0 +1,75 @@
+"""taosctl office -- manage Office Suite documents from the shell.
+
+Wraps tinyagentos/routes/office.py (CRUD on /api/office/docs) so agents and
+scripts can create, list, read, update, and delete documents (write, calc, db,
+slides) without the web UI. Follows the reference shape in commands/agents.py.
+All endpoints take a small JSON body or a path id; none are multipart/streaming.
+"""
+from __future__ import annotations
+
+from urllib.parse import quote
+
+NOUN = "office"
+
+KINDS = ("write", "calc", "db", "slides")
+
+
+def register(subparsers) -> None:
+    p = subparsers.add_parser(NOUN, help="Manage Office Suite documents")
+    verbs = p.add_subparsers(dest="verb", required=True, metavar="<verb>")
+
+    cp = verbs.add_parser("create", help="Create a document")
+    cp.add_argument("--kind", required=True, choices=KINDS)
+    cp.add_argument("--title", required=True)
+    cp.add_argument("--content", default="")
+    cp.set_defaults(func=_create)
+
+    lp = verbs.add_parser("list", help="List documents")
+    lp.set_defaults(func=_list)
+
+    gp = verbs.add_parser("get", help="Get one document by id")
+    gp.add_argument("doc_id")
+    gp.set_defaults(func=_get)
+
+    up = verbs.add_parser("update", help="Update a document (only the fields you pass)")
+    up.add_argument("doc_id")
+    up.add_argument("--kind", choices=KINDS, default=None)
+    up.add_argument("--title", default=None)
+    up.add_argument("--content", default=None)
+    up.set_defaults(func=_update)
+
+    dp = verbs.add_parser("delete", help="Delete a document")
+    dp.add_argument("doc_id")
+    dp.set_defaults(func=_delete)
+
+
+def _create(args, client):
+    return client.post(
+        "/api/office/docs",
+        {"kind": args.kind, "title": args.title, "content": args.content},
+    )
+
+
+def _list(args, client):
+    return client.get("/api/office/docs")
+
+
+def _get(args, client):
+    return client.get(f"/api/office/docs/{quote(args.doc_id, safe='')}")
+
+
+def _update(args, client):
+    # Partial update: send only the fields the caller actually supplied so the
+    # route keeps the existing value for the rest.
+    body = {}
+    if args.kind is not None:
+        body["kind"] = args.kind
+    if args.title is not None:
+        body["title"] = args.title
+    if args.content is not None:
+        body["content"] = args.content
+    return client.put(f"/api/office/docs/{quote(args.doc_id, safe='')}", body)
+
+
+def _delete(args, client):
+    return client.delete(f"/api/office/docs/{quote(args.doc_id, safe='')}")


### PR DESCRIPTION
## What

Adds `taosctl office` wrapping `routes/office.py` (CRUD on `/api/office/docs`), so agents and scripts can manage Office Suite documents from the shell.

Verbs: `create --kind {write,calc,db,slides} --title [--content]`, `list`, `get <id>`, `update <id> [--kind --title --content]` (partial, sends only supplied fields), `delete <id>`.

Follows the `commands/agents.py` noun shape; auto-discovered, no shared file touched.

## Tests

6 endpoint tests assert paths/methods/bodies (including partial-update and argparse `choices` rejecting a bad kind before any client call); the taosctl auto-discovery suite and route-coverage gate pass. New files only.