### PR TITLE
feat(taosctl): recycle command group (tsk-u5fqqn)

### DIFF
--- a/tests/test_taosctl_recycle.py
+++ b/tests/test_taosctl_recycle.py
@@ -60,6 +60,17 @@ def test_restore_by_original_path(monkeypatch):
     assert body == {"original_path": "/x/y.txt"}
 
 
+def test_restore_requires_a_target(monkeypatch):
+    import pytest
+
+    fake = _FakeClient()
+    # No --id and no --original-path: the required mutex group rejects it at the
+    # CLI (exit 2) before any request, so the server never sees an empty body.
+    with pytest.raises(SystemExit):
+        _run(monkeypatch, ["recycle", "restore", "alpha"], fake)
+    assert fake.calls == []
+
+
 def test_purge(monkeypatch):
     fake = _FakeClient()
     assert _run(monkeypatch, ["recycle", "purge", "alpha", "item7"], fake) == 0

--- a/tests/test_taosctl_recycle.py
+++ b/tests/test_taosctl_recycle.py
@@ -1,0 +1,66 @@
+"""Tests for the taosctl recycle command group: each verb hits the right path."""
+from __future__ import annotations
+
+from tinyagentos.cli.taosctl import __main__ as cli_main
+
+
+class _FakeClient:
+    def __init__(self, *a, **k):
+        self.calls = []
+        self.base_url = "http://x"
+        self.token = "t"
+
+    def get(self, path, params=None):
+        self.calls.append(("GET", path, None))
+        return {"items": []}
+
+    def post(self, path, body=None, params=None, json=None):
+        self.calls.append(("POST", path, body))
+        return {"ok": True}
+
+    def delete(self, path, params=None):
+        self.calls.append(("DELETE", path, None))
+        return {"ok": True}
+
+
+def _run(monkeypatch, argv, fake):
+    monkeypatch.setattr(cli_main, "TaosClient", lambda **k: fake)
+    return cli_main.main(argv)
+
+
+def _paths(fake):
+    return [(m, p) for (m, p, *_rest) in fake.calls]
+
+
+def test_list_for_agent(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["recycle", "list", "alpha"], fake) == 0
+    assert ("GET", "/api/agents/alpha/recycle") in _paths(fake)
+
+
+def test_list_all(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["recycle", "list-all"], fake) == 0
+    assert ("GET", "/api/recycle") in _paths(fake)
+
+
+def test_restore_by_id(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["recycle", "restore", "alpha", "--id", "abc"], fake) == 0
+    method, path, body = fake.calls[0]
+    assert (method, path) == ("POST", "/api/agents/alpha/recycle/restore")
+    assert body == {"id": "abc"}
+
+
+def test_restore_by_original_path(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["recycle", "restore", "alpha", "--original-path", "/x/y.txt"], fake) == 0
+    method, path, body = fake.calls[0]
+    assert (method, path) == ("POST", "/api/agents/alpha/recycle/restore")
+    assert body == {"original_path": "/x/y.txt"}
+
+
+def test_purge(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["recycle", "purge", "alpha", "item7"], fake) == 0
+    assert ("DELETE", "/api/agents/alpha/recycle/item7") in _paths(fake)

--- a/tinyagentos/cli/taosctl/commands/recycle.py
+++ b/tinyagentos/cli/taosctl/commands/recycle.py
@@ -25,8 +25,11 @@ def register(subparsers) -> None:
 
     rp = verbs.add_parser("restore", help="Restore a recycle item")
     rp.add_argument("name", help="Agent name")
-    rp.add_argument("--id", dest="item_id", default=None, help="Encoded item id")
-    rp.add_argument("--original-path", default=None, help="Original path to restore")
+    # Exactly one target is required: an empty restore body 400s server-side, so
+    # enforce the choice at the CLI instead of letting the request fail.
+    target = rp.add_mutually_exclusive_group(required=True)
+    target.add_argument("--id", dest="item_id", default=None, help="Encoded item id")
+    target.add_argument("--original-path", default=None, help="Original path to restore")
     rp.set_defaults(func=_restore)
 
     pp = verbs.add_parser("purge", help="Permanently delete a recycle item")

--- a/tinyagentos/cli/taosctl/commands/recycle.py
+++ b/tinyagentos/cli/taosctl/commands/recycle.py
@@ -1,0 +1,58 @@
+"""taosctl recycle -- inspect and restore agent recycle bins from the shell.
+
+Wraps tinyagentos/routes/recycle.py so agents and scripts can list deleted
+items, restore them, and purge them without the web UI. Follows the reference
+shape in commands/agents.py. All endpoints take a path id or a small JSON body;
+none are multipart/streaming.
+"""
+from __future__ import annotations
+
+from urllib.parse import quote
+
+NOUN = "recycle"
+
+
+def register(subparsers) -> None:
+    p = subparsers.add_parser(NOUN, help="Inspect and restore agent recycle bins")
+    verbs = p.add_subparsers(dest="verb", required=True, metavar="<verb>")
+
+    lp = verbs.add_parser("list", help="List recycle items for one agent")
+    lp.add_argument("name", help="Agent name")
+    lp.set_defaults(func=_list)
+
+    ap = verbs.add_parser("list-all", help="List recycle items across all agents")
+    ap.set_defaults(func=_list_all)
+
+    rp = verbs.add_parser("restore", help="Restore a recycle item")
+    rp.add_argument("name", help="Agent name")
+    rp.add_argument("--id", dest="item_id", default=None, help="Encoded item id")
+    rp.add_argument("--original-path", default=None, help="Original path to restore")
+    rp.set_defaults(func=_restore)
+
+    pp = verbs.add_parser("purge", help="Permanently delete a recycle item")
+    pp.add_argument("name", help="Agent name")
+    pp.add_argument("item_id", help="Item id")
+    pp.set_defaults(func=_purge)
+
+
+def _list(args, client):
+    return client.get(f"/api/agents/{quote(args.name, safe='')}/recycle")
+
+
+def _list_all(args, client):
+    return client.get("/api/recycle")
+
+
+def _restore(args, client):
+    body = {}
+    if args.item_id is not None:
+        body["id"] = args.item_id
+    if args.original_path is not None:
+        body["original_path"] = args.original_path
+    return client.post(f"/api/agents/{quote(args.name, safe='')}/recycle/restore", body)
+
+
+def _purge(args, client):
+    return client.delete(
+        f"/api/agents/{quote(args.name, safe='')}/recycle/{quote(args.item_id, safe='')}"
+    )


### PR DESCRIPTION
## What

Adds `taosctl recycle` wrapping `routes/recycle.py`, so agents and scripts can inspect and restore agent recycle bins from the shell.

Verbs: `list <agent>`, `list-all`, `restore <agent> [--id | --original-path]`, `purge <agent> <item_id>`.

Follows the `commands/agents.py` noun shape; auto-discovered, no shared file touched.

## Tests

5 endpoint tests assert paths/methods/bodies (restore by id and by original-path); the taosctl auto-discovery suite and route-coverage gate pass. New files only.