### PR TITLE
feat(taosctl): benchmarks command group (tsk-ptiuu4)

### DIFF
--- a/tests/test_taosctl_benchmarks.py
+++ b/tests/test_taosctl_benchmarks.py
@@ -1,0 +1,52 @@
+"""Tests for the taosctl benchmarks command group: each verb hits the right path."""
+from __future__ import annotations
+
+from tinyagentos.cli.taosctl import __main__ as cli_main
+
+
+class _FakeClient:
+    def __init__(self, *a, **k):
+        self.calls = []
+        self.base_url = "http://x"
+        self.token = "t"
+
+    def get(self, path, params=None):
+        self.calls.append(("GET", path, params))
+        return {"items": []}
+
+
+def _run(monkeypatch, argv, fake):
+    monkeypatch.setattr(cli_main, "TaosClient", lambda **k: fake)
+    return cli_main.main(argv)
+
+
+def test_worker_passes_limit(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["benchmarks", "worker", "w1", "--limit", "10"], fake) == 0
+    method, path, params = fake.calls[0]
+    assert (method, path) == ("GET", "/api/workers/w1/benchmark")
+    assert params == {"limit": 10}
+
+
+def test_worker_default_limit(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["benchmarks", "worker", "w1"], fake) == 0
+    method, path, params = fake.calls[0]
+    assert (method, path) == ("GET", "/api/workers/w1/benchmark")
+    assert params == {"limit": 100}
+
+
+def test_leaderboard_no_metric(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["benchmarks", "leaderboard", "chat"], fake) == 0
+    method, path, params = fake.calls[0]
+    assert (method, path) == ("GET", "/api/benchmarks/capability/chat")
+    assert params is None
+
+
+def test_leaderboard_with_metric(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["benchmarks", "leaderboard", "chat", "--metric", "tps"], fake) == 0
+    method, path, params = fake.calls[0]
+    assert (method, path) == ("GET", "/api/benchmarks/capability/chat")
+    assert params == {"metric": "tps"}

--- a/tinyagentos/cli/taosctl/commands/benchmarks.py
+++ b/tinyagentos/cli/taosctl/commands/benchmarks.py
@@ -1,0 +1,48 @@
+"""taosctl benchmarks -- read worker benchmark results and capability leaderboards.
+
+Wraps the read endpoints in tinyagentos/routes/benchmarks.py so agents and
+scripts can inspect benchmark data from the shell. Follows the reference shape
+in commands/agents.py.
+
+Skipped: POST /api/workers/{id}/benchmark/results takes a nested BenchmarkReport
+(a worker_id plus a list of per-task BenchmarkResult objects). It is a
+worker-to-controller submission with a complex nested body, not a shell verb, so
+it is not wired here.
+"""
+from __future__ import annotations
+
+from urllib.parse import quote
+
+NOUN = "benchmarks"
+
+
+def register(subparsers) -> None:
+    p = subparsers.add_parser(NOUN, help="Read worker benchmarks and capability leaderboards")
+    verbs = p.add_subparsers(dest="verb", required=True, metavar="<verb>")
+
+    wp = verbs.add_parser("worker", help="Benchmark results for one worker")
+    wp.add_argument("worker_id")
+    wp.add_argument("--limit", type=int, default=100)
+    wp.set_defaults(func=_worker)
+
+    lp = verbs.add_parser("leaderboard", help="Capability leaderboard across workers")
+    lp.add_argument("capability")
+    lp.add_argument("--metric", default=None, help="Filter/sort by a specific metric")
+    lp.set_defaults(func=_leaderboard)
+
+
+def _worker(args, client):
+    return client.get(
+        f"/api/workers/{quote(args.worker_id, safe='')}/benchmark",
+        params={"limit": args.limit},
+    )
+
+
+def _leaderboard(args, client):
+    params = {}
+    if args.metric is not None:
+        params["metric"] = args.metric
+    return client.get(
+        f"/api/benchmarks/capability/{quote(args.capability, safe='')}",
+        params=params or None,
+    )


### PR DESCRIPTION
## What

Adds `taosctl benchmarks` wrapping the read endpoints of `routes/benchmarks.py`, so agents and scripts can read benchmark data from the shell.

Verbs: `worker <worker_id> [--limit]` (results for one worker), `leaderboard <capability> [--metric]` (capability ranking).

Skipped (documented in the module): `POST /api/workers/{id}/benchmark/results` takes a nested BenchmarkReport (worker id plus a list of per-task results). It is a worker-to-controller submission with a complex nested body, not a shell verb.

## Tests

4 endpoint tests assert paths/methods/params (default and explicit limit, with and without metric); the taosctl auto-discovery suite and route-coverage gate pass. New files only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `benchmarks worker` command to fetch worker benchmark results with configurable limit parameter.
  * Added `benchmarks leaderboard` command to view capability leaderboards with optional metric filtering.

* **Tests**
  * Added test coverage for benchmarks command operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->