### PR TITLE
fix(taosctl): knowledge ingest body + delete-rule int

### DIFF
--- a/tests/test_taosctl_knowledge.py
+++ b/tests/test_taosctl_knowledge.py
@@ -78,6 +78,18 @@ def test_ingest_posts_body(monkeypatch):
     assert (method, path) == ("POST", "/api/knowledge/ingest")
     assert body["url"] == "https://e.com"
     assert body["categories"] == ["a", "b"]
+    # Unset optional str fields are omitted, not sent as None (the server types
+    # them as str and would 422 on None).
+    assert "title" not in body and "text" not in body and "source" not in body
+
+
+def test_ingest_requires_url(monkeypatch):
+    import pytest
+
+    fake = _FakeClient()
+    with pytest.raises(SystemExit):
+        _run(monkeypatch, ["knowledge", "ingest", "--text", "hi"], fake)
+    assert fake.calls == []
 
 
 def test_rules_list(monkeypatch):
@@ -97,8 +109,19 @@ def test_add_rule_posts_fields(monkeypatch):
 
 def test_delete_rule(monkeypatch):
     fake = _FakeClient()
-    assert _run(monkeypatch, ["knowledge", "delete-rule", "r1"], fake) == 0
-    assert ("DELETE", "/api/knowledge/rules/r1") in _paths(fake)
+    assert _run(monkeypatch, ["knowledge", "delete-rule", "7"], fake) == 0
+    assert ("DELETE", "/api/knowledge/rules/7") in _paths(fake)
+
+
+def test_delete_rule_rejects_non_int(monkeypatch):
+    import pytest
+
+    fake = _FakeClient()
+    # The route declares rule_id: int; argparse type=int rejects a non-int at the
+    # CLI (exit 2) instead of round-tripping a guaranteed 422.
+    with pytest.raises(SystemExit):
+        _run(monkeypatch, ["knowledge", "delete-rule", "abc"], fake)
+    assert fake.calls == []
 
 
 def test_subscriptions_list(monkeypatch):

--- a/tinyagentos/cli/taosctl/commands/knowledge.py
+++ b/tinyagentos/cli/taosctl/commands/knowledge.py
@@ -41,8 +41,8 @@ def register(subparsers) -> None:
     qp.add_argument("--limit", type=int, default=20)
     qp.set_defaults(func=_search)
 
-    ip = verbs.add_parser("ingest", help="Ingest a URL or text into the knowledge base")
-    ip.add_argument("--url", default=None)
+    ip = verbs.add_parser("ingest", help="Ingest a URL into the knowledge base")
+    ip.add_argument("--url", required=True, help="Source URL (required by the server)")
     ip.add_argument("--title", default=None)
     ip.add_argument("--text", default=None)
     ip.add_argument("--category", action="append", dest="categories", default=None,
@@ -60,7 +60,7 @@ def register(subparsers) -> None:
     arp.set_defaults(func=_add_rule)
 
     drp = verbs.add_parser("delete-rule", help="Delete a category rule")
-    drp.add_argument("rule_id", help="Rule id")
+    drp.add_argument("rule_id", type=int, help="Rule id (integer)")
     drp.set_defaults(func=_delete_rule)
 
     subp = verbs.add_parser("subscriptions", help="List agent category subscriptions")
@@ -102,16 +102,19 @@ def _search(args, client):
 
 
 def _ingest(args, client):
-    return client.post(
-        "/api/knowledge/ingest",
-        {
-            "url": args.url,
-            "title": args.title,
-            "text": args.text,
-            "categories": args.categories or [],
-            "source": args.source,
-        },
-    )
+    # Send only the fields the caller supplied. The server's IngestRequest types
+    # title/text/source as str (not optional), so sending None for an unset field
+    # fails validation; omitting it lets the server apply its default.
+    body = {"url": args.url}
+    if args.title is not None:
+        body["title"] = args.title
+    if args.text is not None:
+        body["text"] = args.text
+    if args.categories:
+        body["categories"] = args.categories
+    if args.source is not None:
+        body["source"] = args.source
+    return client.post("/api/knowledge/ingest", body)
 
 
 def _rules(args, client):
@@ -126,7 +129,7 @@ def _add_rule(args, client):
 
 
 def _delete_rule(args, client):
-    return client.delete(f"/api/knowledge/rules/{quote(args.rule_id, safe='')}")
+    return client.delete(f"/api/knowledge/rules/{args.rule_id}")
 
 
 def _subscriptions(args, client):


### PR DESCRIPTION
Fix-forward for two gitar findings on the merged #1393 (knowledge command group):

- ⚠️ **Bug**: `ingest` sent `None` for every unset optional field, but the server's `IngestRequest` requires `url` and types `title/text/source` as `str`, so every `ingest` call 422'd. Now `--url` is required and the body includes only the fields the caller supplied (the server applies its defaults).
- 💡 **Edge Case**: `delete-rule` forwarded a string id, but the route declares `rule_id: int`. Now `--rule_id` is `type=int`, so a non-int fails at the CLI instead of a guaranteed 422.

gitar is budget-paused so it posted these after #1393 had already gated and merged; this fixes them forward on dev. Tests added for required-url, omitted-None fields, and non-int rejection; route-coverage gate passes.