### PR TITLE
feat(taosctl): add dashboard command group

### DIFF
--- a/tests/test_taosctl_dashboard.py
+++ b/tests/test_taosctl_dashboard.py
@@ -100,3 +100,12 @@ def test_metrics_default_range(monkeypatch):
     assert _run(monkeypatch, ["dashboard", "metrics", "cpu"], fake) == 0
     method, path, params = fake.calls[0]
     assert params == {"range": "24h"}
+
+
+def test_activity_rejects_non_positive_limit(monkeypatch):
+    fake = _FakeClient()
+    # argparse rejects 0/negative at parse time (exit 2) rather than forwarding
+    # an invalid limit to the server.
+    with pytest.raises(SystemExit):
+        _run(monkeypatch, ["dashboard", "activity", "--limit", "0"], fake)
+    assert fake.calls == []

--- a/tests/test_taosctl_dashboard.py
+++ b/tests/test_taosctl_dashboard.py
@@ -1,0 +1,102 @@
+"""Tests for the taosctl dashboard command group: each verb hits the right path."""
+from __future__ import annotations
+
+import pytest
+
+from tinyagentos.cli.taosctl import __main__ as cli_main
+
+
+class _FakeClient:
+    def __init__(self, *a, **k):
+        self.calls = []
+        self.base_url = "http://x"
+        self.token = "t"
+
+    def get(self, path, params=None):
+        self.calls.append(("GET", path, params))
+        return {"ok": True}
+
+
+def _run(monkeypatch, argv, fake):
+    monkeypatch.setattr(cli_main, "TaosClient", lambda **k: fake)
+    return cli_main.main(argv)
+
+
+def _paths(fake):
+    return [(m, p) for (m, p, *_rest) in fake.calls]
+
+
+def test_capabilities(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["dashboard", "capabilities"], fake) == 0
+    assert ("GET", "/api/capabilities") in _paths(fake)
+
+
+def test_health_plain(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["dashboard", "health"], fake) == 0
+    method, path, params = fake.calls[0]
+    assert (method, path) == ("GET", "/api/health")
+    assert params is None
+
+
+def test_health_detailed(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["dashboard", "health", "--detailed"], fake) == 0
+    method, path, params = fake.calls[0]
+    assert (method, path) == ("GET", "/api/health")
+    assert params == {"detailed": True}
+
+
+def test_version(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["dashboard", "version"], fake) == 0
+    assert ("GET", "/api/version") in _paths(fake)
+
+
+def test_system(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["dashboard", "system"], fake) == 0
+    assert ("GET", "/api/system") in _paths(fake)
+
+
+def test_cluster_summary(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["dashboard", "cluster-summary"], fake) == 0
+    assert ("GET", "/api/dashboard/cluster-summary") in _paths(fake)
+
+
+def test_backends(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["dashboard", "backends"], fake) == 0
+    assert ("GET", "/api/backends") in _paths(fake)
+
+
+def test_activity_default_limit(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["dashboard", "activity"], fake) == 0
+    method, path, params = fake.calls[0]
+    assert (method, path) == ("GET", "/api/dashboard/activity")
+    assert params == {"limit": 15}
+
+
+def test_activity_custom_limit(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["dashboard", "activity", "--limit", "5"], fake) == 0
+    method, path, params = fake.calls[0]
+    assert params == {"limit": 5}
+
+
+def test_metrics_passes_name_and_range(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["dashboard", "metrics", "cpu", "--range", "7d"], fake) == 0
+    method, path, params = fake.calls[0]
+    assert (method, path) == ("GET", "/api/metrics/cpu")
+    assert params == {"range": "7d"}
+
+
+def test_metrics_default_range(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["dashboard", "metrics", "cpu"], fake) == 0
+    method, path, params = fake.calls[0]
+    assert params == {"range": "24h"}

--- a/tinyagentos/cli/taosctl/commands/dashboard.py
+++ b/tinyagentos/cli/taosctl/commands/dashboard.py
@@ -10,9 +10,17 @@ setup flow, not a shell verb).
 """
 from __future__ import annotations
 
+import argparse
 from urllib.parse import quote
 
 NOUN = "dashboard"
+
+
+def _positive_int(value: str) -> int:
+    iv = int(value)
+    if iv <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return iv
 
 
 def register(subparsers) -> None:
@@ -39,7 +47,7 @@ def register(subparsers) -> None:
     bp.set_defaults(func=_backends)
 
     ap = verbs.add_parser("activity", help="Recent dashboard activity")
-    ap.add_argument("--limit", type=int, default=15)
+    ap.add_argument("--limit", type=_positive_int, default=15)
     ap.set_defaults(func=_activity)
 
     mp = verbs.add_parser("metrics", help="Query a named time-series metric")

--- a/tinyagentos/cli/taosctl/commands/dashboard.py
+++ b/tinyagentos/cli/taosctl/commands/dashboard.py
@@ -1,0 +1,83 @@
+"""taosctl dashboard -- read system, health, and cluster status from the shell.
+
+Wraps the read endpoints in tinyagentos/routes/dashboard.py so agents and
+scripts can check capabilities, health, version, system info, backends, the
+cluster summary, recent activity, and metrics without the web UI. Follows the
+reference shape in commands/agents.py.
+
+Skipped: GET / (an HTML redirect, not data) and POST /setup/complete (a one-time
+setup flow, not a shell verb).
+"""
+from __future__ import annotations
+
+from urllib.parse import quote
+
+NOUN = "dashboard"
+
+
+def register(subparsers) -> None:
+    p = subparsers.add_parser(NOUN, help="Read system, health, and cluster status")
+    verbs = p.add_subparsers(dest="verb", required=True, metavar="<verb>")
+
+    cp = verbs.add_parser("capabilities", help="Detected platform capabilities")
+    cp.set_defaults(func=_capabilities)
+
+    hp = verbs.add_parser("health", help="Service health")
+    hp.add_argument("--detailed", action="store_true", help="Per-service detail")
+    hp.set_defaults(func=_health)
+
+    vp = verbs.add_parser("version", help="Controller version")
+    vp.set_defaults(func=_version)
+
+    sp = verbs.add_parser("system", help="System info (host, resources)")
+    sp.set_defaults(func=_system)
+
+    csp = verbs.add_parser("cluster-summary", help="Cluster summary")
+    csp.set_defaults(func=_cluster_summary)
+
+    bp = verbs.add_parser("backends", help="Configured backends")
+    bp.set_defaults(func=_backends)
+
+    ap = verbs.add_parser("activity", help="Recent dashboard activity")
+    ap.add_argument("--limit", type=int, default=15)
+    ap.set_defaults(func=_activity)
+
+    mp = verbs.add_parser("metrics", help="Query a named time-series metric")
+    mp.add_argument("name")
+    mp.add_argument("--range", default="24h", help="Time range, e.g. 24h, 7d")
+    mp.set_defaults(func=_metrics)
+
+
+def _capabilities(args, client):
+    return client.get("/api/capabilities")
+
+
+def _health(args, client):
+    params = {"detailed": True} if args.detailed else None
+    return client.get("/api/health", params=params)
+
+
+def _version(args, client):
+    return client.get("/api/version")
+
+
+def _system(args, client):
+    return client.get("/api/system")
+
+
+def _cluster_summary(args, client):
+    return client.get("/api/dashboard/cluster-summary")
+
+
+def _backends(args, client):
+    return client.get("/api/backends")
+
+
+def _activity(args, client):
+    return client.get("/api/dashboard/activity", params={"limit": args.limit})
+
+
+def _metrics(args, client):
+    return client.get(
+        f"/api/metrics/{quote(args.name, safe='')}", params={"range": args.range}
+    )


### PR DESCRIPTION
Wraps the read endpoints in `tinyagentos/routes/dashboard.py` as `taosctl dashboard` verbs so agents and scripts can check system, health, and cluster status from the shell without the web UI.

## Verbs
- `capabilities` -> GET /api/capabilities
- `health [--detailed]` -> GET /api/health
- `version` -> GET /api/version
- `system` -> GET /api/system
- `cluster-summary` -> GET /api/dashboard/cluster-summary
- `backends` -> GET /api/backends
- `activity [--limit]` -> GET /api/dashboard/activity
- `metrics <name> [--range]` -> GET /api/metrics/{name}

## Skipped
- `GET /` (HTML redirect, not data)
- `POST /setup/complete` (one-time setup flow, not a shell verb)

## Tests
Follows the established command-group pattern (knowledge/catalog/office/recycle/benchmarks). New `tests/test_taosctl_dashboard.py` (11 tests) plus the base `test_taosctl.py` and `test_taosctl_route_coverage.py` gate all pass (28 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `taosctl dashboard` command with subcommands for viewing system and cluster status: `capabilities`, `health`, `version`, `system`, `cluster-summary`, `backends`, `activity`, and `metrics`.
  * Health command supports `--detailed` flag; activity supports `--limit`; metrics supports `--range`.

* **Tests**
  * Added test coverage for dashboard command routing and parameter handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->