### PR TITLE
feat(taosctl): add agent-registry command group

### DIFF
--- a/tests/test_taosctl_agent_registry.py
+++ b/tests/test_taosctl_agent_registry.py
@@ -1,0 +1,119 @@
+"""Tests for the taosctl agent-registry command group: each verb hits the right path."""
+from __future__ import annotations
+
+import pytest
+
+from tinyagentos.cli.taosctl import __main__ as cli_main
+
+
+class _FakeClient:
+    def __init__(self, *a, **k):
+        self.calls = []
+        self.base_url = "http://x"
+        self.token = "t"
+
+    def get(self, path, params=None):
+        self.calls.append(("GET", path, params))
+        return {"ok": True}
+
+    def post(self, path, body=None, params=None, json=None):
+        self.calls.append(("POST", path, body))
+        return {"ok": True}
+
+    def patch(self, path, body=None, json=None):
+        self.calls.append(("PATCH", path, body))
+        return {"ok": True}
+
+    def delete(self, path, params=None):
+        self.calls.append(("DELETE", path, params))
+        return {"ok": True}
+
+
+def _run(monkeypatch, argv, fake):
+    monkeypatch.setattr(cli_main, "TaosClient", lambda **k: fake)
+    return cli_main.main(argv)
+
+
+def _paths(fake):
+    return [(m, p) for (m, p, *_rest) in fake.calls]
+
+
+def test_list_no_status(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["agent-registry", "list"], fake) == 0
+    method, path, params = fake.calls[0]
+    assert (method, path) == ("GET", "/api/agents/registry")
+    assert params is None
+
+
+def test_list_with_status(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["agent-registry", "list", "--status", "pending"], fake) == 0
+    method, path, params = fake.calls[0]
+    assert params == {"status": "pending"}
+
+
+def test_get(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["agent-registry", "get", "alpha-20260101-000000"], fake) == 0
+    assert ("GET", "/api/agents/registry/alpha-20260101-000000") in _paths(fake)
+
+
+def test_pubkey(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["agent-registry", "pubkey"], fake) == 0
+    assert ("GET", "/api/agents/registry/pubkey") in _paths(fake)
+
+
+def test_revoked(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["agent-registry", "revoked"], fake) == 0
+    assert ("GET", "/api/agents/registry/revoked") in _paths(fake)
+
+
+def test_inactive(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["agent-registry", "inactive"], fake) == 0
+    assert ("GET", "/api/agents/registry/inactive") in _paths(fake)
+
+
+def test_grants_all(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["agent-registry", "grants"], fake) == 0
+    method, path, params = fake.calls[0]
+    assert (method, path) == ("GET", "/api/agents/registry/grants")
+    assert params is None
+
+
+def test_grants_filtered(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["agent-registry", "grants", "--canonical-id", "alpha"], fake) == 0
+    method, path, params = fake.calls[0]
+    assert params == {"canonical_id": "alpha"}
+
+
+def test_update_sends_only_supplied(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(
+        monkeypatch,
+        ["agent-registry", "update", "alpha", "--display-name", "Alpha", "--capability", "app.llm"],
+        fake,
+    )
+    assert rc == 0
+    method, path, body = fake.calls[0]
+    assert (method, path) == ("PATCH", "/api/agents/registry/alpha")
+    assert body == {"display_name": "Alpha", "capabilities": ["app.llm"]}
+    assert "handle" not in body and "role" not in body
+
+
+def test_revoke(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["agent-registry", "revoke", "alpha"], fake) == 0
+    assert ("DELETE", "/api/agents/registry/alpha") in _paths(fake)
+
+
+@pytest.mark.parametrize("verb", ["approve", "reject", "suspend", "reactivate"])
+def test_lifecycle_transitions(monkeypatch, verb):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["agent-registry", verb, "alpha"], fake) == 0
+    assert ("POST", f"/api/agents/registry/alpha/{verb}") in _paths(fake)

--- a/tests/test_taosctl_agent_registry.py
+++ b/tests/test_taosctl_agent_registry.py
@@ -106,6 +106,15 @@ def test_update_sends_only_supplied(monkeypatch):
     assert "handle" not in body and "role" not in body
 
 
+def test_update_with_no_fields_errors_without_calling(monkeypatch):
+    fake = _FakeClient()
+    # No fields supplied: must not send an empty-body PATCH; exits non-zero so
+    # scripts can detect the mistake.
+    with pytest.raises(SystemExit):
+        _run(monkeypatch, ["agent-registry", "update", "alpha"], fake)
+    assert fake.calls == []
+
+
 def test_revoke(monkeypatch):
     fake = _FakeClient()
     assert _run(monkeypatch, ["agent-registry", "revoke", "alpha"], fake) == 0

--- a/tinyagentos/cli/taosctl/commands/agent_registry.py
+++ b/tinyagentos/cli/taosctl/commands/agent_registry.py
@@ -1,0 +1,136 @@
+"""taosctl agent-registry -- inspect and govern the canonical agent registry.
+
+Wraps the read, update, and lifecycle endpoints in
+tinyagentos/routes/agent_registry.py so admins and scripts can list, inspect,
+rename, revoke, and run governance transitions (approve/reject/suspend/
+reactivate) on registered agent identities without the web UI. Distinct from the
+``agents`` group, which drives deploy/lifecycle on /api/agents.
+
+Skipped: POST /api/agents/registry/register, a signed-pubkey enrolment flow that
+expects a cryptographically prepared payload, not a shell verb.
+"""
+from __future__ import annotations
+
+from urllib.parse import quote
+
+NOUN = "agent-registry"
+
+
+def register(subparsers) -> None:
+    p = subparsers.add_parser(NOUN, help="Inspect and govern the canonical agent registry")
+    verbs = p.add_subparsers(dest="verb", required=True, metavar="<verb>")
+
+    lp = verbs.add_parser("list", help="List registry entries (own, or all for admins)")
+    lp.add_argument("--status", default=None, help="Filter by status (e.g. pending, active)")
+    lp.set_defaults(func=_list)
+
+    gp = verbs.add_parser("get", help="Get one registry entry by canonical id")
+    gp.add_argument("canonical_id")
+    gp.set_defaults(func=_get)
+
+    pk = verbs.add_parser("pubkey", help="Fetch the registry signing public key")
+    pk.set_defaults(func=_pubkey)
+
+    rv = verbs.add_parser("revoked", help="Global revocation feed")
+    rv.set_defaults(func=_revoked)
+
+    iv = verbs.add_parser("inactive", help="Inactive (non-active) entries")
+    iv.set_defaults(func=_inactive)
+
+    gr = verbs.add_parser("grants", help="Active grants, optionally for one agent")
+    gr.add_argument("--canonical-id", default=None, help="Narrow to a single agent")
+    gr.set_defaults(func=_grants)
+
+    up = verbs.add_parser("update", help="Update mutable metadata on an entry")
+    up.add_argument("canonical_id")
+    up.add_argument("--display-name", default=None)
+    up.add_argument("--handle", default=None)
+    up.add_argument("--role", default=None)
+    up.add_argument("--capability", action="append", dest="capabilities", default=None,
+                    help="capability to set (repeatable; replaces the list)")
+    up.set_defaults(func=_update)
+
+    rk = verbs.add_parser("revoke", help="Revoke an entry (sets revoked_at)")
+    rk.add_argument("canonical_id")
+    rk.set_defaults(func=_revoke)
+
+    ap = verbs.add_parser("approve", help="Approve a pending agent (admin)")
+    ap.add_argument("canonical_id")
+    ap.set_defaults(func=_approve)
+
+    rj = verbs.add_parser("reject", help="Reject a pending agent (admin)")
+    rj.add_argument("canonical_id")
+    rj.set_defaults(func=_reject)
+
+    sp = verbs.add_parser("suspend", help="Suspend an active agent (admin)")
+    sp.add_argument("canonical_id")
+    sp.set_defaults(func=_suspend)
+
+    ra = verbs.add_parser("reactivate", help="Reactivate a suspended agent (admin)")
+    ra.add_argument("canonical_id")
+    ra.set_defaults(func=_reactivate)
+
+
+def _cid(args):
+    return quote(args.canonical_id, safe="")
+
+
+def _list(args, client):
+    params = {"status": args.status} if args.status else None
+    return client.get("/api/agents/registry", params=params)
+
+
+def _get(args, client):
+    return client.get(f"/api/agents/registry/{_cid(args)}")
+
+
+def _pubkey(args, client):
+    return client.get("/api/agents/registry/pubkey")
+
+
+def _revoked(args, client):
+    return client.get("/api/agents/registry/revoked")
+
+
+def _inactive(args, client):
+    return client.get("/api/agents/registry/inactive")
+
+
+def _grants(args, client):
+    params = {"canonical_id": args.canonical_id} if args.canonical_id else None
+    return client.get("/api/agents/registry/grants", params=params)
+
+
+def _update(args, client):
+    # Send only supplied fields; the route's PatchRegistryRequest treats every
+    # field as optional and leaves omitted ones untouched.
+    body = {}
+    if args.display_name is not None:
+        body["display_name"] = args.display_name
+    if args.handle is not None:
+        body["handle"] = args.handle
+    if args.role is not None:
+        body["role"] = args.role
+    if args.capabilities is not None:
+        body["capabilities"] = args.capabilities
+    return client.patch(f"/api/agents/registry/{_cid(args)}", body)
+
+
+def _revoke(args, client):
+    return client.delete(f"/api/agents/registry/{_cid(args)}")
+
+
+def _approve(args, client):
+    return client.post(f"/api/agents/registry/{_cid(args)}/approve")
+
+
+def _reject(args, client):
+    return client.post(f"/api/agents/registry/{_cid(args)}/reject")
+
+
+def _suspend(args, client):
+    return client.post(f"/api/agents/registry/{_cid(args)}/suspend")
+
+
+def _reactivate(args, client):
+    return client.post(f"/api/agents/registry/{_cid(args)}/reactivate")

--- a/tinyagentos/cli/taosctl/commands/agent_registry.py
+++ b/tinyagentos/cli/taosctl/commands/agent_registry.py
@@ -11,6 +11,7 @@ expects a cryptographically prepared payload, not a shell verb.
 """
 from __future__ import annotations
 
+import sys
 from urllib.parse import quote
 
 NOUN = "agent-registry"
@@ -113,6 +114,15 @@ def _update(args, client):
         body["role"] = args.role
     if args.capabilities is not None:
         body["capabilities"] = args.capabilities
+    if not body:
+        # No fields supplied: skip the no-op PATCH and exit non-zero so scripts
+        # can detect the mistake instead of getting a silent empty-body call.
+        print(
+            "no fields supplied; pass at least one of "
+            "--display-name/--handle/--role/--capability",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
     return client.patch(f"/api/agents/registry/{_cid(args)}", body)
 
 


### PR DESCRIPTION
Wraps the read, update, and governance endpoints in `tinyagentos/routes/agent_registry.py` as `taosctl agent-registry` verbs, so admins and scripts can drive the canonical agent identity registry from the shell.

Distinct from the `agents` group, which drives `/api/agents` deploy/lifecycle. This group governs the identity registry.

## Verbs
- `list [--status]` -> GET /api/agents/registry
- `get <id>` -> GET /api/agents/registry/{canonical_id}
- `pubkey` -> GET /api/agents/registry/pubkey
- `revoked` -> GET /api/agents/registry/revoked
- `inactive` -> GET /api/agents/registry/inactive
- `grants [--canonical-id]` -> GET /api/agents/registry/grants
- `update <id> [--display-name/--handle/--role/--capability]` -> PATCH (sends only supplied fields)
- `revoke <id>` -> DELETE /api/agents/registry/{canonical_id}
- `approve|reject|suspend|reactivate <id>` -> POST .../{transition} (admin)

## Skipped
- `POST /api/agents/registry/register` -- a signed-pubkey enrolment flow expecting a cryptographically prepared payload, not a shell verb.

## Tests
New `tests/test_taosctl_agent_registry.py` (14 tests) plus base `test_taosctl.py` and the `test_taosctl_route_coverage.py` gate all pass (31 passed).