### PR TITLE
feat(taosctl): validate pagination args across command groups

### DIFF
--- a/tests/test_taosctl_argtypes.py
+++ b/tests/test_taosctl_argtypes.py
@@ -1,0 +1,70 @@
+"""Tests for the shared taosctl argparse validators and their wiring.
+
+Unit-tests positive_int/nonneg_int, then confirms a representative command group
+rejects non-positive --limit / negative --offset at parse time (exit 2) without
+forwarding the invalid value, while valid values still dispatch.
+"""
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from tinyagentos.cli.taosctl import __main__ as cli_main
+from tinyagentos.cli.taosctl.argtypes import nonneg_int, positive_int
+
+
+def test_positive_int_accepts_positive():
+    assert positive_int("3") == 3
+
+
+@pytest.mark.parametrize("bad", ["0", "-1"])
+def test_positive_int_rejects_non_positive(bad):
+    with pytest.raises(argparse.ArgumentTypeError):
+        positive_int(bad)
+
+
+def test_nonneg_int_accepts_zero_and_positive():
+    assert nonneg_int("0") == 0
+    assert nonneg_int("5") == 5
+
+
+def test_nonneg_int_rejects_negative():
+    with pytest.raises(argparse.ArgumentTypeError):
+        nonneg_int("-1")
+
+
+class _FakeClient:
+    def __init__(self, *a, **k):
+        self.calls = []
+        self.base_url = "http://x"
+        self.token = "t"
+
+    def get(self, path, params=None):
+        self.calls.append(("GET", path, params))
+        return {"ok": True}
+
+
+def _run(monkeypatch, argv, fake):
+    monkeypatch.setattr(cli_main, "TaosClient", lambda **k: fake)
+    return cli_main.main(argv)
+
+
+def test_memory_list_rejects_zero_limit(monkeypatch):
+    fake = _FakeClient()
+    with pytest.raises(SystemExit):
+        _run(monkeypatch, ["memory", "list", "--limit", "0"], fake)
+    assert fake.calls == []
+
+
+def test_memory_list_rejects_negative_offset(monkeypatch):
+    fake = _FakeClient()
+    with pytest.raises(SystemExit):
+        _run(monkeypatch, ["memory", "list", "--offset", "-1"], fake)
+    assert fake.calls == []
+
+
+def test_memory_list_accepts_valid_paging(monkeypatch):
+    fake = _FakeClient()
+    assert _run(monkeypatch, ["memory", "list", "--limit", "10", "--offset", "0"], fake) == 0
+    assert fake.calls and fake.calls[0][0] == "GET"

--- a/tinyagentos/cli/taosctl/argtypes.py
+++ b/tinyagentos/cli/taosctl/argtypes.py
@@ -1,0 +1,26 @@
+"""Shared argparse `type=` validators for taosctl command groups.
+
+Pagination arguments (`--limit`, `--offset`) are uniform across the command
+groups: a limit must be a positive count and an offset a non-negative index.
+Validating at parse time rejects 0/negative input in the CLI instead of
+forwarding a guaranteed-invalid value to the server.
+"""
+from __future__ import annotations
+
+import argparse
+
+
+def positive_int(value: str) -> int:
+    """An integer > 0 (e.g. a result limit). Rejects 0 and negatives."""
+    iv = int(value)
+    if iv <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return iv
+
+
+def nonneg_int(value: str) -> int:
+    """An integer >= 0 (e.g. a pagination offset). Rejects negatives."""
+    iv = int(value)
+    if iv < 0:
+        raise argparse.ArgumentTypeError("must be a non-negative integer")
+    return iv

--- a/tinyagentos/cli/taosctl/commands/benchmarks.py
+++ b/tinyagentos/cli/taosctl/commands/benchmarks.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 from urllib.parse import quote
 
+from tinyagentos.cli.taosctl.argtypes import positive_int
+
 NOUN = "benchmarks"
 
 
@@ -22,7 +24,7 @@ def register(subparsers) -> None:
 
     wp = verbs.add_parser("worker", help="Benchmark results for one worker")
     wp.add_argument("worker_id")
-    wp.add_argument("--limit", type=int, default=100)
+    wp.add_argument("--limit", type=positive_int, default=100)
     wp.set_defaults(func=_worker)
 
     lp = verbs.add_parser("leaderboard", help="Capability leaderboard across workers")

--- a/tinyagentos/cli/taosctl/commands/browsing_history.py
+++ b/tinyagentos/cli/taosctl/commands/browsing_history.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from tinyagentos.cli.taosctl.argtypes import positive_int
+
 NOUN = "browsing_history"
 
 
@@ -11,7 +13,7 @@ def register(subparsers) -> None:
 
     lp = verbs.add_parser("list", help="List browsing history")
     lp.add_argument("--source-type", dest="source_type", default=None, help="Filter by source type")
-    lp.add_argument("--limit", type=int, default=None, help="Max items to return")
+    lp.add_argument("--limit", type=positive_int, default=None, help="Max items to return")
     lp.set_defaults(func=_list)
 
     cp = verbs.add_parser("clear", help="Clear browsing history")

--- a/tinyagentos/cli/taosctl/commands/catalog.py
+++ b/tinyagentos/cli/taosctl/commands/catalog.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 from urllib.parse import quote
 
+from tinyagentos.cli.taosctl.argtypes import positive_int
+
 NOUN = "catalog"
 
 
@@ -34,7 +36,7 @@ def register(subparsers) -> None:
 
     qp = verbs.add_parser("search", help="Search sessions by topic")
     qp.add_argument("query")
-    qp.add_argument("--limit", type=int, default=20)
+    qp.add_argument("--limit", type=positive_int, default=20)
     qp.set_defaults(func=_search)
 
     ses = verbs.add_parser("session", help="Get one indexed session by id")
@@ -46,7 +48,7 @@ def register(subparsers) -> None:
     ctx.set_defaults(func=_context)
 
     rc = verbs.add_parser("recent", help="Recently indexed sessions")
-    rc.add_argument("--limit", type=int, default=20)
+    rc.add_argument("--limit", type=positive_int, default=20)
     rc.set_defaults(func=_recent)
 
     ip = verbs.add_parser("index", help="Index sessions (a date or a date range)")

--- a/tinyagentos/cli/taosctl/commands/jobs.py
+++ b/tinyagentos/cli/taosctl/commands/jobs.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 from urllib.parse import quote
 
+from tinyagentos.cli.taosctl.argtypes import positive_int
+
 NOUN = "jobs"
 
 
@@ -15,7 +17,7 @@ def register(subparsers) -> None:
 
     lp = verbs.add_parser("list", help="List recent jobs")
     lp.add_argument("--status", help="Filter by status", default=None)
-    lp.add_argument("--limit", help="Max results", type=int, default=50)
+    lp.add_argument("--limit", help="Max results", type=positive_int, default=50)
     lp.set_defaults(func=_list)
 
     gp = verbs.add_parser("get", help="Get one job by id")

--- a/tinyagentos/cli/taosctl/commands/knowledge.py
+++ b/tinyagentos/cli/taosctl/commands/knowledge.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 from urllib.parse import quote
 
+from tinyagentos.cli.taosctl.argtypes import positive_int
+
 NOUN = "knowledge"
 
 
@@ -38,7 +40,7 @@ def register(subparsers) -> None:
     qp = verbs.add_parser("search", help="Search the knowledge base")
     qp.add_argument("query", help="Search query")
     qp.add_argument("--mode", default="keyword", help="keyword (default) or semantic")
-    qp.add_argument("--limit", type=int, default=20)
+    qp.add_argument("--limit", type=positive_int, default=20)
     qp.set_defaults(func=_search)
 
     ip = verbs.add_parser("ingest", help="Ingest a URL or text into the knowledge base")

--- a/tinyagentos/cli/taosctl/commands/mail.py
+++ b/tinyagentos/cli/taosctl/commands/mail.py
@@ -9,6 +9,8 @@ import getpass
 import os
 from urllib.parse import quote
 
+from tinyagentos.cli.taosctl.argtypes import positive_int
+
 NOUN = "mail"
 
 
@@ -44,7 +46,7 @@ def register(subparsers) -> None:
     mp = verbs.add_parser("messages", help="List messages in an account folder")
     mp.add_argument("account_id", help="Account id")
     mp.add_argument("--folder", default="INBOX", help="Folder name")
-    mp.add_argument("--limit", type=int, default=50, help="Max messages")
+    mp.add_argument("--limit", type=positive_int, default=50, help="Max messages")
     mp.set_defaults(func=_messages)
 
     gp = verbs.add_parser("get", help="Get a single message by uid")

--- a/tinyagentos/cli/taosctl/commands/memory.py
+++ b/tinyagentos/cli/taosctl/commands/memory.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 from urllib.parse import quote
 
+from tinyagentos.cli.taosctl.argtypes import positive_int, nonneg_int
+
 NOUN = "memory"
 
 
@@ -20,15 +22,15 @@ def register(subparsers) -> None:
     lp = verbs.add_parser("list", help="List memory chunks (browse)")
     lp.add_argument("--agent", help="Agent name (omit for user scope)")
     lp.add_argument("--collection", help="Collection filter")
-    lp.add_argument("--limit", type=int, default=20, help="Max results")
-    lp.add_argument("--offset", type=int, default=0, help="Offset")
+    lp.add_argument("--limit", type=positive_int, default=20, help="Max results")
+    lp.add_argument("--offset", type=nonneg_int, default=0, help="Offset")
     lp.set_defaults(func=_list)
 
     sp = verbs.add_parser("search", help="Search memory (keyword or semantic)")
     sp.add_argument("query", help="Search query")
     sp.add_argument("--agent", help="Agent name (omit for user scope)")
     sp.add_argument("--collection", help="Collection filter")
-    sp.add_argument("--limit", type=int, default=20, help="Max results")
+    sp.add_argument("--limit", type=positive_int, default=20, help="Max results")
     sp.add_argument("--mode", choices=["keyword", "semantic"], default="keyword",
                     help="Search mode (default: keyword)")
     sp.add_argument("--conversation-id", help="W3C trace conversation id")

--- a/tinyagentos/cli/taosctl/commands/scheduler.py
+++ b/tinyagentos/cli/taosctl/commands/scheduler.py
@@ -7,6 +7,8 @@ Skipped (not simple JSON body endpoints):
 """
 from __future__ import annotations
 
+from tinyagentos.cli.taosctl.argtypes import positive_int
+
 NOUN = "scheduler"
 
 
@@ -18,7 +20,7 @@ def register(subparsers) -> None:
     sp.set_defaults(func=_stats)
 
     tp = verbs.add_parser("tasks", help="Recent task history")
-    tp.add_argument("--limit", type=int, default=None, help="Max tasks (1-500)")
+    tp.add_argument("--limit", type=positive_int, default=None, help="Max tasks (1-500)")
     tp.set_defaults(func=_tasks)
 
     bp = verbs.add_parser("backends", help="Live backend catalog")

--- a/tinyagentos/cli/taosctl/commands/search.py
+++ b/tinyagentos/cli/taosctl/commands/search.py
@@ -1,6 +1,8 @@
 """taosctl search -- query the global search index."""
 from __future__ import annotations
 
+from tinyagentos.cli.taosctl.argtypes import positive_int
+
 NOUN = "search"
 
 
@@ -10,7 +12,7 @@ def register(subparsers) -> None:
 
     lp = verbs.add_parser("list", help="Search across all platform data")
     lp.add_argument("q", help="Search query string")
-    lp.add_argument("--limit", type=int, default=5, help="Max results (default: 5)")
+    lp.add_argument("--limit", type=positive_int, default=5, help="Max results (default: 5)")
     lp.set_defaults(func=_list)
 
 

--- a/tinyagentos/cli/taosctl/commands/templates.py
+++ b/tinyagentos/cli/taosctl/commands/templates.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from urllib.parse import quote
 
+from tinyagentos.cli.taosctl.argtypes import positive_int, nonneg_int
+
 NOUN = "templates"
 
 
@@ -13,8 +15,8 @@ def register(subparsers) -> None:
     lp = verbs.add_parser("list", help="List agent templates")
     lp.add_argument("--category", help="Filter by category")
     lp.add_argument("--source", help="Filter by source")
-    lp.add_argument("--limit", type=int, default=50, help="Page size (default 50)")
-    lp.add_argument("--offset", type=int, default=0, help="Page offset (default 0)")
+    lp.add_argument("--limit", type=positive_int, default=50, help="Page size (default 50)")
+    lp.add_argument("--offset", type=nonneg_int, default=0, help="Page offset (default 0)")
     lp.set_defaults(func=_list)
 
     gp = verbs.add_parser("get", help="Get one template by ID")


### PR DESCRIPTION
Adds a shared `tinyagentos/cli/taosctl/argtypes.py` (`positive_int` for `--limit`, `nonneg_int` for `--offset`) and applies it across the merged command groups so non-positive limits and negative offsets fail at parse time instead of being forwarded to the server as guaranteed-invalid calls.

Generalizes the per-command validator CodeRabbit flagged on the dashboard group (#1399) into one shared helper, applied consistently across the pagination surface.

## Touched groups
catalog, knowledge, memory, search, templates, jobs, benchmarks, mail, scheduler, browsing_history. Each `--limit` -> `positive_int`, each `--offset` -> `nonneg_int`. Ports, seeds, durations, and intervals are left alone (different semantics).

## Tests
New `tests/test_taosctl_argtypes.py` unit-tests both validators and confirms a representative group (`memory list`) rejects `--limit 0` / `--offset -1` without dispatching, while valid paging still dispatches. Full taosctl suite: 264 passed (incl. route-coverage gate).

## Follow-up
The dashboard group (#1399, gating) carries an inline `_positive_int`; once it merges it can be deduped to import the shared helper.