### PR TITLE
refactor(taosctl): dashboard uses shared positive_int validator

### DIFF
--- a/tinyagentos/cli/taosctl/commands/dashboard.py
+++ b/tinyagentos/cli/taosctl/commands/dashboard.py
@@ -10,17 +10,11 @@ setup flow, not a shell verb).
 """
 from __future__ import annotations
 
-import argparse
 from urllib.parse import quote
 
+from tinyagentos.cli.taosctl.argtypes import positive_int
+
 NOUN = "dashboard"
-
-
-def _positive_int(value: str) -> int:
-    iv = int(value)
-    if iv <= 0:
-        raise argparse.ArgumentTypeError("must be a positive integer")
-    return iv
 
 
 def register(subparsers) -> None:
@@ -47,7 +41,7 @@ def register(subparsers) -> None:
     bp.set_defaults(func=_backends)
 
     ap = verbs.add_parser("activity", help="Recent dashboard activity")
-    ap.add_argument("--limit", type=_positive_int, default=15)
+    ap.add_argument("--limit", type=positive_int, default=15)
     ap.set_defaults(func=_activity)
 
     mp = verbs.add_parser("metrics", help="Query a named time-series metric")


### PR DESCRIPTION
Follow-up to #1401. The dashboard group carried an inline `_positive_int`; now that the shared `tinyagentos/cli/taosctl/argtypes.positive_int` is on dev, this removes the duplicate and imports the shared helper. Behaviour is unchanged (`activity --limit` still rejects non-positive values at parse time). 22 tests pass (dashboard + argtypes + route-coverage gate).