### PR TITLE
feat(userspace): app_grants ledger feeds the capability broker

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -330,6 +330,9 @@ async def client(app, tmp_data_dir):
     if office_docs._db is not None:
         await office_docs.close()
     await office_docs.init()
+    # app_grants ledger (per-app capability grants) is lifespan-owned; tests that
+    # bypass the lifespan must init it so the userspace broker can consult it.
+    await app.state.app_grants.init()
     feedback_store = app.state.feedback_store
     if feedback_store._db is not None:
         await feedback_store.close()

--- a/tests/test_routes_userspace_apps.py
+++ b/tests/test_routes_userspace_apps.py
@@ -565,3 +565,44 @@ async def test_broker_gated_cap_with_permission_allowed(client):
     # The result may be an error (e.g. network unreachable), but it must NOT
     # be permission_denied since we granted the capability.
     assert data.get("error") != "permission_denied"
+
+
+@pytest.mark.asyncio
+async def test_broker_gated_cap_allowed_via_app_grants_ledger(client):
+    # Decision 24: the broker stays the enforcer, but a per-user grant in the
+    # app_grants ledger feeds it -- even when the per-app permissions_granted set
+    # is empty. This proves the ledger authorises a gated capability.
+    app = client._transport.app
+    await _init_userspace_stores(app, app.state.data_dir)
+    store = app.state.userspace_apps
+    await _install_test_app(store, permissions=["app.net"])
+    # Intentionally do NOT call set_permissions_granted; the only authorisation
+    # comes from the ledger below.
+    uid = app.state.auth.find_user("admin")["id"]
+    await app.state.app_grants.set_decision(uid, "test-app", "app.net")
+    resp = await client.post(
+        "/api/userspace-apps/test-app/broker",
+        json={"capability": "app.net.fetch", "args": {"url": "http://example.com"}},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data.get("error") != "permission_denied"
+
+
+@pytest.mark.asyncio
+async def test_broker_gated_cap_denied_when_ledger_grant_absent(client):
+    # The ledger only authorises what the user actually granted: a different
+    # capability stays denied.
+    app = client._transport.app
+    await _init_userspace_stores(app, app.state.data_dir)
+    store = app.state.userspace_apps
+    await _install_test_app(store, permissions=["app.net", "app.memory"])
+    uid = app.state.auth.find_user("admin")["id"]
+    await app.state.app_grants.set_decision(uid, "test-app", "app.net")
+    # app.memory was requested but neither per-app-granted nor ledger-granted.
+    resp = await client.post(
+        "/api/userspace-apps/test-app/broker",
+        json={"capability": "app.memory.search", "args": {"query": "x"}},
+    )
+    assert resp.status_code == 200
+    assert resp.json().get("error") == "permission_denied"

--- a/tests/userspace/conftest.py
+++ b/tests/userspace/conftest.py
@@ -51,6 +51,9 @@ async def client(app, tmp_path):
     await userspace_data.init()
     app.state.userspace_data = userspace_data
 
+    # app_grants ledger is lifespan-owned; init it so the broker can consult it.
+    await app.state.app_grants.init()
+
     # Auth setup.
     app.state.auth.setup_user("admin", "Test Admin", "", "testpass")
     record = app.state.auth.find_user("admin")

--- a/tinyagentos/routes/userspace_apps.py
+++ b/tinyagentos/routes/userspace_apps.py
@@ -247,7 +247,16 @@ async def broker(request: Request, app_id: str):
     if app.get("trust") == "first-party":
         granted = set(GATED_CAPS)
     else:
+        # The userspace broker stays the runtime enforcer; the app_grants ledger
+        # feeds it (decision 24). A capability the current user granted this app
+        # via the consent flow also authorises it, on top of the per-app granted
+        # set. Additive and best-effort: no auth session or no ledger falls back
+        # to the per-app set, so nothing that worked before changes.
         granted = set(app["permissions_granted"])
+        uid = getattr(request.state, "user_id", None)
+        grants_store = getattr(request.app.state, "app_grants", None)
+        if uid and grants_store is not None:
+            granted |= await grants_store.granted_capabilities(uid, app_id)
     out = await handle_capability(
         app_id, body.get("capability", ""), body.get("args") or {},
         granted=granted,


### PR DESCRIPTION
Implements the app-permissions reconciliation (broker enforces, app_grants is the ledger feeding it).

## What
The userspace broker stays the runtime enforcer for gated capabilities (app.net/agent/llm/memory). The per-user `app_grants` ledger (built earlier this session) now feeds it: a capability the current user granted an app via the consent flow authorises it, on top of the per-app `permissions_granted` set.

## Why this shape
One vocabulary, one enforcer. The ledger records who-granted-what-when per (user, app, capability); the broker reads it at call time. The merge is **additive and best-effort**: with no auth session or no ledger, the broker falls back to the per-app granted set, so nothing that worked before changes. First-party apps keep their pre-authorised all-gated set.

## Changes
- `routes/userspace_apps.py`: broker route unions the per-user ledger grants into `granted` for community apps (reads `request.state.user_id` optionally, no new 401).
- `tests/conftest.py` + `tests/userspace/conftest.py`: init the lifespan-owned `app_grants` store (these fixtures bypass the lifespan; production inits it in app.py).
- New tests: ledger-granted authorisation passes; a capability with no ledger grant stays denied.

## Tests
159 passed across userspace + app_grants + app_permissions suites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced authorization for app gated capabilities by recognizing per-user grants in addition to app-wide permissions, enabling more granular access control.

* **Tests**
  * Added comprehensive tests validating per-user capability authorization logic for the app broker endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->