### PR TITLE
feat(app-perms): validate grants against the capability vocabulary

### DIFF
--- a/tests/test_routes_app_permissions.py
+++ b/tests/test_routes_app_permissions.py
@@ -48,11 +48,12 @@ async def test_grant_then_listed_as_granted(client):
 
 @pytest.mark.asyncio
 async def test_denied_capability_not_in_granted(client):
+    cap = "network:https://example.com"
     await client.post(
-        "/api/apps/a/permissions", json={"capability": "network", "decision": "denied"}
+        "/api/apps/a/permissions", json={"capability": cap, "decision": "denied"}
     )
     data = (await client.get("/api/apps/a/permissions")).json()
-    assert "network" not in data["granted"]
+    assert cap not in data["granted"]
     assert len(data["grants"]) == 1
 
 
@@ -62,6 +63,31 @@ async def test_invalid_decision_returns_400(client):
         "/api/apps/a/permissions", json={"capability": "app.kv", "decision": "maybe"}
     )
     assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_grant_unknown_capability_returns_400(client):
+    # The grant API now validates against the closed capability vocabulary, so a
+    # typo'd or made-up capability cannot be recorded in the ledger.
+    resp = await client.post(
+        "/api/apps/a/permissions",
+        json={"capability": "files.read", "decision": "granted"},
+    )
+    assert resp.status_code == 400
+    assert "unknown capability" in resp.json()["error"]
+    # Nothing was recorded.
+    data = (await client.get("/api/apps/a/permissions")).json()
+    assert data["grants"] == []
+
+
+@pytest.mark.asyncio
+async def test_grant_network_origin_capability_allowed(client):
+    # The parametrized network:<origin> form is a known capability.
+    resp = await client.post(
+        "/api/apps/a/permissions",
+        json={"capability": "network:https://api.example.com", "decision": "granted"},
+    )
+    assert resp.status_code == 200, resp.text
 
 
 @pytest.mark.asyncio

--- a/tinyagentos/routes/app_permissions.py
+++ b/tinyagentos/routes/app_permissions.py
@@ -4,10 +4,11 @@ The API surface over AppGrantsStore: a user reviews, grants/denies, and revokes
 the capabilities an installed app holds. Decision 6 (manifest declares + runtime
 grants via the Decisions/consent flow); this is the runtime-grant layer.
 
-Vocabulary-agnostic: capability names are passed through as strings. Validating
-them against the closed APP_CAPABILITIES vocabulary is a separate slice (pending
-Jay's v1 vocabulary, pending-decisions item 23), so this surface does not gate
-on that open question. Grants are scoped to the calling user.
+Grants are validated against the closed capability vocabulary in
+tinyagentos/userspace/capabilities.py (the same source of truth the broker
+enforces and the package parser validates manifests against), so a grant can
+never record a typo'd or made-up capability. Grants are scoped to the calling
+user.
 """
 from __future__ import annotations
 
@@ -16,6 +17,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from tinyagentos.auth_context import CurrentUser, current_user
+from tinyagentos.userspace.capabilities import is_known_capability
 
 router = APIRouter()
 
@@ -50,6 +52,10 @@ async def set_app_permission(
     cap = body.capability.strip()
     if not cap:
         return JSONResponse({"error": "capability required"}, status_code=400)
+    if not is_known_capability(cap):
+        return JSONResponse(
+            {"error": f"unknown capability: {cap}"}, status_code=400
+        )
     try:
         rec = await store.set_decision(user.user_id, app_id, cap, decision=body.decision)
     except ValueError as e:


### PR DESCRIPTION
The per-app permission grant API (`POST /api/apps/{id}/permissions`) deferred capability-string validation pending the v1 vocabulary. That vocabulary is now settled (the closed set in `userspace/capabilities.py`, #1389), so this slice closes the gap: a grant for an unknown or typo'd capability returns 400 instead of recording a meaningless ledger row.

## Changes
- `routes/app_permissions.py`: validate `capability` via `is_known_capability` (accepts bare namespaces + the `network:<origin>` form); 400 on unknown. Updated the module docstring (no longer vocabulary-agnostic).
- Corrected an existing test that used the bare `network` (not a valid capability; the valid form is `network:<origin>`).
- New tests: unknown capability rejected with nothing recorded; `network:<origin>` accepted.

## Tests
8 passed in tests/test_routes_app_permissions.py.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * App permission grant requests with unknown or unrecognized capabilities are now properly rejected with HTTP 400 error responses.

* **Tests**
  * Enhanced test coverage for capability validation logic and support for network-scoped origin capabilities in grant decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->