### PR TITLE
feat(canvas): CanvasElement to Excalidraw skeleton mapping (slice 1)

### DIFF
--- a/desktop/src/apps/ProjectsApp/__tests__/element-to-excalidraw.test.ts
+++ b/desktop/src/apps/ProjectsApp/__tests__/element-to-excalidraw.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import { elementToSkeleton, elementsToSkeletons } from "../canvas/element-to-excalidraw";
+import type { CanvasElement } from "../canvas/canvas-api";
+
+function el(over: Partial<CanvasElement>): CanvasElement {
+  return {
+    id: "el1",
+    project_id: "prj",
+    kind: "note",
+    author_kind: "user",
+    author_id: "u",
+    x: 10,
+    y: 20,
+    w: 100,
+    h: 50,
+    rotation: 0,
+    z_index: 0,
+    payload: {},
+    created_at: 0,
+    updated_at: 0,
+    deleted_at: null,
+    ...over,
+  };
+}
+
+describe("elementToSkeleton", () => {
+  it("maps a note to a rectangle with a coloured background + label", () => {
+    const s = elementToSkeleton(el({ kind: "note", payload: { text: "hi", color: "blue", font_size: 18 } }));
+    expect(s).toMatchObject({
+      type: "rectangle",
+      id: "el1",
+      x: 10,
+      y: 20,
+      width: 100,
+      height: 50,
+      backgroundColor: "#a5d8ff",
+      label: { text: "hi", fontSize: 18 },
+    });
+  });
+
+  it("falls back to the yellow note background for an unknown colour", () => {
+    const s = elementToSkeleton(el({ kind: "note", payload: { color: "chartreuse" } }));
+    expect(s).toMatchObject({ type: "rectangle", backgroundColor: "#ffec99" });
+  });
+
+  it("maps a link to a rectangle labelled with its title", () => {
+    const s = elementToSkeleton(el({ kind: "link", payload: { url: "https://x.test", title: "X" } }));
+    expect(s).toMatchObject({ type: "rectangle", label: { text: "X" } });
+  });
+
+  it("labels a link with the url when it has no title", () => {
+    const s = elementToSkeleton(el({ kind: "link", payload: { url: "https://x.test" } }));
+    expect(s).toMatchObject({ type: "rectangle", label: { text: "https://x.test" } });
+  });
+
+  it("maps an image to an image skeleton carrying the file id", () => {
+    const s = elementToSkeleton(el({ kind: "image", payload: { file_id: "f1", alt: "pic" } }));
+    expect(s).toMatchObject({ type: "image", fileId: "f1" });
+  });
+
+  it("maps a text element with its font + colour", () => {
+    const s = elementToSkeleton(el({ kind: "text", payload: { text: "idea", font_size: 22, color: "#0f172a" } }));
+    expect(s).toMatchObject({ type: "text", text: "idea", fontSize: 22, strokeColor: "#0f172a" });
+  });
+
+  it("maps mermaid/flowchart to a rectangle labelled with the first source line", () => {
+    const m = elementToSkeleton(el({ kind: "mermaid", payload: { source: "\ngraph TD\n  A-->B" } }));
+    expect(m).toMatchObject({ type: "rectangle", label: { text: "graph TD" } });
+    const f = elementToSkeleton(el({ kind: "flowchart", payload: { source: "flowchart LR" } }));
+    expect(f).toMatchObject({ type: "rectangle", label: { text: "flowchart LR" } });
+  });
+
+  it("maps a mindmap_edge to an arrow bound to the from/to ids", () => {
+    const s = elementToSkeleton(el({ kind: "mindmap_edge", payload: { from: "a", to: "b" } }));
+    expect(s).toMatchObject({ type: "arrow", start: { id: "a" }, end: { id: "b" } });
+  });
+
+  it("maps an unknown kind to a generic rectangle", () => {
+    const s = elementToSkeleton(el({ kind: "user_shape" as CanvasElement["kind"] }));
+    expect(s.type).toBe("rectangle");
+  });
+
+  it("coerces malformed geometry to defaults instead of crashing", () => {
+    const s = elementToSkeleton(
+      el({ x: NaN as unknown as number, w: undefined as unknown as number, rotation: "x" as unknown as number }),
+    );
+    expect(s).toMatchObject({ x: 0, width: 100, angle: 0 });
+  });
+});
+
+describe("elementsToSkeletons", () => {
+  it("drops soft-deleted elements and sorts by z_index ascending", () => {
+    const out = elementsToSkeletons([
+      el({ id: "top", z_index: 5 }),
+      el({ id: "gone", deleted_at: 123 }),
+      el({ id: "bottom", z_index: 1 }),
+    ]);
+    expect(out.map((s) => s.id)).toEqual(["bottom", "top"]);
+  });
+});

--- a/desktop/src/apps/ProjectsApp/canvas/element-to-excalidraw.ts
+++ b/desktop/src/apps/ProjectsApp/canvas/element-to-excalidraw.ts
@@ -1,0 +1,152 @@
+import { CanvasElement } from "./canvas-api";
+
+// Engine-neutral mapping from a backend CanvasElement to an Excalidraw skeleton
+// element (the input shape `convertToExcalidrawElements` accepts). CanvasElement
+// stays canonical; this is the view-side projection. Mirrors element-to-konva,
+// but targets Excalidraw's schema so the board can render the same scene.
+//
+// The skeleton types below are a faithful subset of Excalidraw's
+// `ExcalidrawElementSkeleton`. Keeping them local means this pure mapping (and
+// its tests) carry no dependency on the heavy @excalidraw/excalidraw runtime,
+// which the board wires in a later slice; the output stays assignable to
+// `ExcalidrawElementSkeleton[]` when that slice imports the real type.
+//
+// The backend only validates `kind`, so every payload field is coerced to its
+// declared type with a sensible default: a malformed element still places on the
+// board instead of crashing the renderer.
+
+export interface SkeletonLabel {
+  text: string;
+  fontSize?: number;
+  strokeColor?: string;
+}
+
+export interface BaseSkeleton {
+  id: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  angle?: number;
+}
+
+export type ExcalidrawSkeleton =
+  | (BaseSkeleton & {
+      type: "rectangle" | "ellipse" | "diamond";
+      backgroundColor?: string;
+      strokeColor?: string;
+      label?: SkeletonLabel;
+    })
+  | (BaseSkeleton & {
+      type: "text";
+      text: string;
+      fontSize?: number;
+      strokeColor?: string;
+    })
+  | (BaseSkeleton & {
+      type: "image";
+      fileId: string;
+    })
+  | (BaseSkeleton & {
+      type: "arrow" | "line";
+      strokeColor?: string;
+      start?: { id: string };
+      end?: { id: string };
+    });
+
+function num(v: unknown, fallback: number): number {
+  return typeof v === "number" && Number.isFinite(v) ? v : fallback;
+}
+
+function str(v: unknown, fallback = ""): string {
+  if (typeof v === "string") return v;
+  if (typeof v === "number" || typeof v === "boolean") return String(v);
+  return fallback;
+}
+
+// First non-empty line of a diagram source, used as the placeholder label for
+// mermaid/flowchart until the diagram-render slice converts the real source.
+function firstLine(source: string, fallback: string): string {
+  const line = source.split("\n").map((s) => s.trim()).find((s) => s.length > 0);
+  return line || fallback;
+}
+
+// Sticky-note colour names map onto Excalidraw's background palette; unknown
+// names fall back to the yellow note default.
+const NOTE_BG: Record<string, string> = {
+  yellow: "#ffec99",
+  blue: "#a5d8ff",
+  green: "#b2f2bb",
+  red: "#ffc9c9",
+  pink: "#ffc9c9",
+  purple: "#d0bfff",
+  orange: "#ffd8a8",
+  gray: "#e9ecef",
+  grey: "#e9ecef",
+};
+
+function noteBackground(color: string): string {
+  return NOTE_BG[color.toLowerCase()] ?? NOTE_BG.yellow;
+}
+
+export function elementToSkeleton(el: CanvasElement): ExcalidrawSkeleton {
+  const base: BaseSkeleton = {
+    id: el.id,
+    x: num(el.x, 0),
+    y: num(el.y, 0),
+    width: num(el.w, 100),
+    height: num(el.h, 100),
+    angle: num(el.rotation, 0),
+  };
+  const p = (el.payload ?? {}) as Record<string, unknown>;
+
+  switch (el.kind) {
+    case "note":
+      return {
+        ...base,
+        type: "rectangle",
+        backgroundColor: noteBackground(str(p.color, "yellow")),
+        label: { text: str(p.text, ""), fontSize: num(p.font_size, 14) },
+      };
+    case "link":
+      return {
+        ...base,
+        type: "rectangle",
+        label: { text: str(p.title) || str(p.url) },
+      };
+    case "image":
+      return { ...base, type: "image", fileId: str(p.file_id) };
+    case "text":
+      return {
+        ...base,
+        type: "text",
+        text: str(p.text, ""),
+        fontSize: num(p.font_size, 16),
+        strokeColor: str(p.color, "#1e293b"),
+      };
+    case "mermaid":
+      return { ...base, type: "rectangle", label: { text: firstLine(str(p.source), "mermaid") } };
+    case "flowchart":
+      return { ...base, type: "rectangle", label: { text: firstLine(str(p.source), "flowchart") } };
+    case "mindmap_edge":
+      return {
+        ...base,
+        type: "arrow",
+        start: { id: str(p.from) },
+        end: { id: str(p.to) },
+      };
+    default:
+      // user_shape and any unknown kind render as a generic rectangle.
+      return { ...base, type: "rectangle" };
+  }
+}
+
+// Render order: skip soft-deleted elements, lowest z_index first so higher
+// z_index sits on top (Excalidraw draws in array order).
+export function elementsToSkeletons(elements: CanvasElement[]): ExcalidrawSkeleton[] {
+  return elements
+    .filter((el) => el.deleted_at == null)
+    .slice()
+    .sort((a, b) => num(a.z_index, 0) - num(b.z_index, 0))
+    .map(elementToSkeleton);
+}


### PR DESCRIPTION
First slice of the tldraw to Excalidraw migration (engine = Excalidraw, CanvasElement stays canonical with Excalidraw as the view).

`element-to-excalidraw.ts` is the pure projection from a backend CanvasElement to an Excalidraw skeleton element (the `convertToExcalidrawElements` input), mirroring the existing `element-to-konva` mapping:
- note → coloured rectangle + label
- link → rectangle labelled with title/url
- image → image skeleton carrying the file id
- text → text element
- mermaid/flowchart → rectangle labelled with the first source line (the diagram-render slice converts the real source later)
- mindmap_edge → arrow bound to the from/to element ids
- user_shape/unknown → generic rectangle

The skeleton types are a local faithful subset of `ExcalidrawElementSkeleton`, so this pure mapping carries no `@excalidraw/excalidraw` runtime dependency; the board slice (next) wires the real package and needs live screenshot verification.

## Tests
11 unit tests (per-kind mapping, colour fallback, z-index ordering, soft-delete filtering, malformed-geometry coercion). No live client needed.

## Next slices
2. ExcalidrawBoard.tsx (read-only) over this mapping, live-verified. 3. interactions → CanvasElement PATCH/POST. 4. mermaid/flowchart + mindmap arrows. 5. swap behind a flag. 6. remove tldraw + the superseded Konva layer.