### PR TITLE
feat(projects): per-project Decisions archive tab

### DIFF
--- a/desktop/src/apps/ProjectsApp/ProjectDecisions.test.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectDecisions.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen, act, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ProjectDecisions } from "./ProjectDecisions";
+
+function mockFetch(
+  responses: Record<string, { ok: boolean; status?: number; body: unknown }>,
+) {
+  return vi.fn().mockImplementation((input: string) => {
+    const hit = responses[input] ?? responses["*"];
+    if (!hit) throw new Error(`Unmocked fetch: ${input}`);
+    return Promise.resolve({
+      ok: hit.ok,
+      status: hit.status ?? (hit.ok ? 200 : 500),
+      json: () => Promise.resolve(hit.body),
+    });
+  });
+}
+
+async function flush() {
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 0));
+  });
+}
+
+const answered = {
+  id: "dec-1",
+  from_agent: "@taOS-dev",
+  question: "Which canvas engine should replace tldraw?",
+  status: "answered",
+  options: [{ label: "Excalidraw", value: "excalidraw" }],
+  answer: { value: "excalidraw" },
+  created_at: Date.now() / 1000,
+};
+
+const pending = {
+  id: "dec-2",
+  from_agent: "@taOSmd-dev",
+  question: "Promote a node to control plane?",
+  status: "pending",
+  options: [],
+  created_at: Date.now() / 1000,
+};
+
+describe("ProjectDecisions", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fetches decisions scoped to the project id", async () => {
+    const fetchMock = mockFetch({
+      "/api/decisions?project_id=prj-7": { ok: true, body: { items: [] } },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    render(<ProjectDecisions projectId="prj-7" />);
+    await flush();
+    expect(fetchMock).toHaveBeenCalledWith("/api/decisions?project_id=prj-7");
+  });
+
+  it("renders the project's decisions with status and the chosen answer", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch({
+        "/api/decisions?project_id=prj-7": {
+          ok: true,
+          body: { items: [answered, pending] },
+        },
+      }),
+    );
+    render(<ProjectDecisions projectId="prj-7" />);
+    await flush();
+
+    await waitFor(() =>
+      expect(screen.getByText(/which canvas engine/i)).toBeTruthy(),
+    );
+    expect(screen.getByText(/promote a node/i)).toBeTruthy();
+    // The answered decision resolves its option value to the label.
+    expect(screen.getByText(/answer: excalidraw/i)).toBeTruthy();
+    expect(screen.getByText("@taOS-dev")).toBeTruthy();
+    expect(screen.getByText("answered")).toBeTruthy();
+    expect(screen.getByText("pending")).toBeTruthy();
+  });
+
+  it("shows an empty state when the project has no decisions", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch({
+        "/api/decisions?project_id=prj-7": { ok: true, body: { items: [] } },
+      }),
+    );
+    render(<ProjectDecisions projectId="prj-7" />);
+    await flush();
+    await waitFor(() =>
+      expect(screen.getByText(/no decisions for this project/i)).toBeTruthy(),
+    );
+  });
+
+  it("encodes the project id into the query", async () => {
+    const fetchMock = mockFetch({
+      "*": { ok: true, body: { items: [] } },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    render(<ProjectDecisions projectId="a/b c" />);
+    await flush();
+    expect(fetchMock).toHaveBeenCalledWith("/api/decisions?project_id=a%2Fb%20c");
+  });
+});

--- a/desktop/src/apps/ProjectsApp/ProjectDecisions.test.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectDecisions.test.tsx
@@ -94,6 +94,41 @@ describe("ProjectDecisions", () => {
     );
   });
 
+  it("shows an error (not the empty state) when the fetch fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch({
+        "/api/decisions?project_id=prj-7": { ok: false, status: 500, body: {} },
+      }),
+    );
+    render(<ProjectDecisions projectId="prj-7" />);
+    await flush();
+    await waitFor(() =>
+      expect(screen.getByText(/could not load decisions/i)).toBeTruthy(),
+    );
+    expect(screen.queryByText(/no decisions for this project/i)).toBeNull();
+  });
+
+  it("shows the recorded answer for a superseded decision too", async () => {
+    const superseded = {
+      ...answered,
+      id: "dec-3",
+      status: "superseded",
+      question: "Superseded engine pick",
+    };
+    vi.stubGlobal(
+      "fetch",
+      mockFetch({
+        "/api/decisions?project_id=prj-7": { ok: true, body: { items: [superseded] } },
+      }),
+    );
+    render(<ProjectDecisions projectId="prj-7" />);
+    await flush();
+    await waitFor(() =>
+      expect(screen.getByText(/answer: excalidraw/i)).toBeTruthy(),
+    );
+  });
+
   it("encodes the project id into the query", async () => {
     const fetchMock = mockFetch({
       "*": { ok: true, body: { items: [] } },

--- a/desktop/src/apps/ProjectsApp/ProjectDecisions.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectDecisions.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useState } from "react";
+
+// Per-project Decisions archive (Decisions spec MVP item 4): a read-only,
+// project-scoped view of the decision history so the workspace shows not just
+// what was done but why it went the way it did. It is a filtered read of
+// GET /api/decisions?project_id=; answering happens in the Decisions app, not
+// here. Kept self-contained (its own minimal types/helpers) so it does not
+// couple the Projects app to the Decisions app internals.
+
+type DecisionStatus = "pending" | "answered" | "expired" | "superseded";
+
+interface DecisionOption {
+  label: string;
+  value: string;
+}
+
+interface Decision {
+  id: string;
+  from_agent: string;
+  question: string;
+  status: DecisionStatus;
+  options: DecisionOption[];
+  answer?: { value: string | string[] } | null;
+  created_at: number | string;
+}
+
+// created_at is an epoch-seconds REAL on the backend but may serialise as an
+// ISO string; normalise both to milliseconds.
+function toMillis(ts: number | string): number {
+  if (typeof ts === "number") return ts < 1e12 ? ts * 1000 : ts;
+  const parsed = Date.parse(ts);
+  return Number.isNaN(parsed) ? Date.now() : parsed;
+}
+
+function relativeTime(ts: number | string): string {
+  const diff = Date.now() - toMillis(ts);
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+function answerText(d: Decision): string {
+  const value = d.answer?.value;
+  if (value == null) return "";
+  const values = Array.isArray(value) ? value : [value];
+  return values
+    .map((v) => d.options.find((o) => o.value === v)?.label ?? v)
+    .join(", ");
+}
+
+// The list endpoint returns { items: [...] }; tolerate a bare array too.
+function asDecisionList(data: unknown): Decision[] {
+  if (Array.isArray(data)) return data as Decision[];
+  if (data && Array.isArray((data as { items?: unknown }).items)) {
+    return (data as { items: Decision[] }).items;
+  }
+  return [];
+}
+
+const STATUS_STYLE: Record<DecisionStatus, string> = {
+  pending: "bg-amber-500/10 text-amber-400",
+  answered: "bg-accent/10 text-accent",
+  superseded: "bg-shell-bg-deep text-shell-text-tertiary",
+  expired: "bg-shell-bg-deep text-shell-text-tertiary",
+};
+
+export function ProjectDecisions({ projectId }: { projectId: string }) {
+  const [items, setItems] = useState<Decision[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    fetch(`/api/decisions?project_id=${encodeURIComponent(projectId)}`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (!cancelled && data != null) setItems(asDecisionList(data));
+      })
+      .catch(() => {
+        // Network error: leave whatever was last loaded in place.
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId]);
+
+  if (loading) {
+    return <p className="text-sm text-shell-text-tertiary">Loading decisions...</p>;
+  }
+
+  if (items.length === 0) {
+    return (
+      <p className="text-sm text-shell-text-secondary">
+        No decisions for this project yet.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="flex flex-col gap-2" aria-label="Project decisions">
+      {items.map((d) => {
+        const handle = d.from_agent.startsWith("@")
+          ? d.from_agent
+          : `@${d.from_agent}`;
+        const answer = d.status === "answered" ? answerText(d) : "";
+        return (
+          <li
+            key={d.id}
+            className="flex flex-col gap-1.5 rounded-xl border border-shell-border bg-shell-surface p-3.5"
+          >
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="inline-flex items-center rounded-full bg-accent/10 px-2 py-0.5 text-xs font-medium text-accent">
+                {handle}
+              </span>
+              <span
+                className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium capitalize ${STATUS_STYLE[d.status]}`}
+              >
+                {d.status}
+              </span>
+              <span className="ml-auto text-xs text-shell-text-tertiary">
+                {relativeTime(d.created_at)}
+              </span>
+            </div>
+            <p className="text-sm font-medium text-shell-text">{d.question}</p>
+            {answer && (
+              <p className="text-xs text-shell-text-secondary">Answer: {answer}</p>
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+export default ProjectDecisions;

--- a/desktop/src/apps/ProjectsApp/ProjectDecisions.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectDecisions.tsx
@@ -33,7 +33,9 @@ function toMillis(ts: number | string): number {
 }
 
 function relativeTime(ts: number | string): string {
-  const diff = Date.now() - toMillis(ts);
+  // Clamp to 0 so a row a moment in the future (client/server clock skew) does
+  // not render as "-1m ago".
+  const diff = Math.max(0, Date.now() - toMillis(ts));
   const mins = Math.floor(diff / 60_000);
   if (mins < 1) return "just now";
   if (mins < 60) return `${mins}m ago`;
@@ -70,17 +72,27 @@ const STATUS_STYLE: Record<DecisionStatus, string> = {
 export function ProjectDecisions({ projectId }: { projectId: string }) {
   const [items, setItems] = useState<Decision[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
+    // Reset on project switch so the previous project's decisions never linger,
+    // and so a failure is shown as an error rather than a stale or empty list.
     setLoading(true);
+    setError(false);
+    setItems([]);
     fetch(`/api/decisions?project_id=${encodeURIComponent(projectId)}`)
-      .then((r) => (r.ok ? r.json() : null))
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json();
+      })
       .then((data) => {
-        if (!cancelled && data != null) setItems(asDecisionList(data));
+        if (!cancelled) setItems(asDecisionList(data));
       })
       .catch(() => {
-        // Network error: leave whatever was last loaded in place.
+        // A non-ok response or network error must read as a failure, not as an
+        // empty project.
+        if (!cancelled) setError(true);
       })
       .finally(() => {
         if (!cancelled) setLoading(false);
@@ -92,6 +104,14 @@ export function ProjectDecisions({ projectId }: { projectId: string }) {
 
   if (loading) {
     return <p className="text-sm text-shell-text-tertiary">Loading decisions...</p>;
+  }
+
+  if (error) {
+    return (
+      <p className="text-sm text-red-400" role="alert">
+        Could not load decisions for this project.
+      </p>
+    );
   }
 
   if (items.length === 0) {
@@ -108,7 +128,9 @@ export function ProjectDecisions({ projectId }: { projectId: string }) {
         const handle = d.from_agent.startsWith("@")
           ? d.from_agent
           : `@${d.from_agent}`;
-        const answer = d.status === "answered" ? answerText(d) : "";
+        // Show the recorded answer whenever there is one, including a
+        // superseded decision (it was answered before being replaced).
+        const answer = answerText(d);
         return (
           <li
             key={d.id}

--- a/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
@@ -3,6 +3,7 @@ import { projectsApi, type Project, type ProjectMember } from "@/lib/projects";
 import { ProjectTaskList } from "./ProjectTaskList";
 import { ProjectMembers } from "./ProjectMembers";
 import { ProjectActivity } from "./ProjectActivity";
+import { ProjectDecisions } from "./ProjectDecisions";
 import { ProjectBoard } from "./board/ProjectBoard";
 import { TaskModal } from "./board/TaskModal";
 import { FilesApp } from "@/apps/FilesApp";
@@ -16,8 +17,8 @@ import { ProjectFab } from "./mobile/ProjectFab";
 import { TaskCreateSheet } from "./mobile/TaskCreateSheet";
 import styles from "./ProjectsApp.module.css";
 
-type Tab = "workspace" | "board" | "canvas" | "tasks" | "files" | "messages" | "members" | "activity";
-const TABS: Tab[] = ["workspace", "board", "canvas", "tasks", "files", "messages", "members", "activity"];
+type Tab = "workspace" | "board" | "canvas" | "tasks" | "files" | "messages" | "members" | "activity" | "decisions";
+const TABS: Tab[] = ["workspace", "board", "canvas", "tasks", "files", "messages", "members", "activity", "decisions"];
 
 interface AgentSummary {
   id: string;
@@ -58,7 +59,7 @@ export function ProjectWorkspace({ project, onChanged }: { project: Project; onC
   // Mobile pill order: surface Messages right after Workspace so it is reachable
   // without scrolling (on mobile Messages is its own full page, not a squeezed
   // pane inside Workspace).
-  const mobileTabOrder: Tab[] = ["workspace", "messages", "board", "tasks", "canvas", "files", "members", "activity"];
+  const mobileTabOrder: Tab[] = ["workspace", "messages", "board", "tasks", "canvas", "files", "members", "activity", "decisions"];
   const tabPills = mobileTabOrder.map((t) => ({
     id: t,
     label: t.charAt(0).toUpperCase() + t.slice(1),
@@ -218,6 +219,7 @@ export function ProjectWorkspace({ project, onChanged }: { project: Project; onC
         )}
         {tab === "members" && <ProjectMembers project={project} onChanged={onChanged} />}
         {tab === "activity" && <ProjectActivity projectId={project.id} />}
+        {tab === "decisions" && <ProjectDecisions projectId={project.id} />}
       </div>
 
       {isMobile && (tab === "tasks" || tab === "board") && (


### PR DESCRIPTION
## What

Decisions spec MVP item 4: the Projects workspace gets a read-only **Decisions** tab showing that project's decision history, so the board records not just what was done but why it went the way it did.

## Behaviour

- A new `decisions` tab in the project workspace (desktop nav + mobile pill, via the existing generic tab pattern).
- `ProjectDecisions` panel does a filtered read of `GET /api/decisions?project_id=` and renders each decision read-only: asking agent, status (pending/answered/superseded), the chosen answer (option value resolved to its label), and relative time.
- Loading and empty states. Answering still happens in the Decisions app; this surface is archive-only per the spec.
- `cancelled`-flag effect so no state update fires after the panel unmounts (the same class of issue caught on the Decisions history view).

## Tests

- `ProjectDecisions.test.tsx`: 4 cases (project-scoped fetch, render with status + resolved answer, empty state, project-id query encoding).
- Full ProjectsApp suite green (127 tests); `tsc -b` clean.

## Verification note

Behaviourally verified via vitest (jsdom). Visual check against the running app is deferred to a live session, consistent with the canvas read-only slices and the Decisions history view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a **Decisions** tab in the project workspace to view decision history.
  * Decision cards now show agent, status, question, relative time, and the resolved answer when available (including superseded decisions).

* **Bug Fixes**
  * Improved loading/error behavior so failed requests show an error state instead of keeping stale results.

* **Tests**
  * Added coverage for query scoping (including URL-encoded project IDs), rendering states, and fetch error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->