### PR TITLE
feat(observatory): global concurrency cap in the steer row

### DIFF
--- a/desktop/src/apps/ObservatoryApp.test.tsx
+++ b/desktop/src/apps/ObservatoryApp.test.tsx
@@ -135,7 +135,7 @@ describe("ObservatoryApp", () => {
     });
   });
 
-  it("clears the cap to null from the lowest step", async () => {
+  it("clears the cap to null via the Clear button", async () => {
     const fetchMock = mockFetch({
       "GET /api/observatory/fleet": { ok: true, body: fleetBody },
       "GET /api/observatory/throttle": { ok: true, body: { global: 1, lanes: {} } },
@@ -148,7 +148,12 @@ describe("ObservatoryApp", () => {
       expect(screen.getByLabelText(/concurrency cap value/i).textContent).toBe("1"),
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /lower concurrency cap/i }));
+    // The lower button floors at 1 (disabled there); removal is the explicit Clear.
+    expect(
+      (screen.getByRole("button", { name: /lower concurrency cap/i }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+    fireEvent.click(screen.getByRole("button", { name: /^clear$/i }));
     await flush();
 
     const post = fetchMock.mock.calls.find(
@@ -158,6 +163,25 @@ describe("ObservatoryApp", () => {
       scope: "global",
       max_concurrent: null,
     });
+  });
+
+  it("disables raising the cap at the ceiling", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch({
+        "GET /api/observatory/fleet": { ok: true, body: fleetBody },
+        "GET /api/observatory/throttle": { ok: true, body: { global: 50, lanes: {} } },
+      }),
+    );
+    render(<ObservatoryApp windowId="w1" />);
+    await flush();
+    await waitFor(() =>
+      expect(screen.getByLabelText(/concurrency cap value/i).textContent).toBe("50"),
+    );
+    expect(
+      (screen.getByRole("button", { name: /raise concurrency cap/i }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
   });
 
   it("shows the idle empty state when no agents are working", async () => {

--- a/desktop/src/apps/ObservatoryApp.test.tsx
+++ b/desktop/src/apps/ObservatoryApp.test.tsx
@@ -7,7 +7,12 @@ function mockFetch(
 ) {
   return vi.fn().mockImplementation((input: string, init?: RequestInit) => {
     const method = (init?.method ?? "GET").toUpperCase();
-    const hit = responses[`${method} ${input}`] ?? responses[input] ?? responses["*"];
+    let hit = responses[`${method} ${input}`] ?? responses[input] ?? responses["*"];
+    // The app loads the throttle state alongside the fleet; default it to
+    // "no cap" so tests that only care about the fleet need not mock it.
+    if (!hit && method === "GET" && input === "/api/observatory/throttle") {
+      hit = { ok: true, body: { global: null, lanes: {} } };
+    }
     if (!hit) throw new Error(`Unmocked fetch: ${method} ${input}`);
     return Promise.resolve({
       ok: hit.ok,
@@ -90,6 +95,69 @@ describe("ObservatoryApp", () => {
     );
     const sent = JSON.parse((post![1] as RequestInit).body as string);
     expect(sent).toEqual({ scope: "@taOS-dev-kilo-owl-alpha", paused: true });
+  });
+
+  it("renders the loaded global concurrency cap", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch({
+        "GET /api/observatory/fleet": { ok: true, body: fleetBody },
+        "GET /api/observatory/throttle": { ok: true, body: { global: 4, lanes: {} } },
+      }),
+    );
+    render(<ObservatoryApp windowId="w1" />);
+    await flush();
+    await waitFor(() =>
+      expect(screen.getByLabelText(/concurrency cap value/i).textContent).toBe("4"),
+    );
+  });
+
+  it("raises the cap and posts the new value to the throttle endpoint", async () => {
+    const fetchMock = mockFetch({
+      "GET /api/observatory/fleet": { ok: true, body: fleetBody },
+      "GET /api/observatory/throttle": { ok: true, body: { global: null, lanes: {} } },
+      "POST /api/observatory/throttle": { ok: true, body: { global: 1, lanes: {} } },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    render(<ObservatoryApp windowId="w1" />);
+    await flush();
+
+    fireEvent.click(screen.getByRole("button", { name: /raise concurrency cap/i }));
+    await flush();
+
+    const post = fetchMock.mock.calls.find(
+      (c) => (c[1] as RequestInit)?.method === "POST",
+    );
+    expect(post![0]).toBe("/api/observatory/throttle");
+    expect(JSON.parse((post![1] as RequestInit).body as string)).toEqual({
+      scope: "global",
+      max_concurrent: 1,
+    });
+  });
+
+  it("clears the cap to null from the lowest step", async () => {
+    const fetchMock = mockFetch({
+      "GET /api/observatory/fleet": { ok: true, body: fleetBody },
+      "GET /api/observatory/throttle": { ok: true, body: { global: 1, lanes: {} } },
+      "POST /api/observatory/throttle": { ok: true, body: { global: null, lanes: {} } },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    render(<ObservatoryApp windowId="w1" />);
+    await flush();
+    await waitFor(() =>
+      expect(screen.getByLabelText(/concurrency cap value/i).textContent).toBe("1"),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /lower concurrency cap/i }));
+    await flush();
+
+    const post = fetchMock.mock.calls.find(
+      (c) => (c[1] as RequestInit)?.method === "POST",
+    );
+    expect(JSON.parse((post![1] as RequestInit).body as string)).toEqual({
+      scope: "global",
+      max_concurrent: null,
+    });
   });
 
   it("shows the idle empty state when no agents are working", async () => {

--- a/desktop/src/apps/ObservatoryApp.tsx
+++ b/desktop/src/apps/ObservatoryApp.tsx
@@ -24,8 +24,10 @@ const EMPTY_PAUSE: PauseState = { global: false, lanes: {} };
 // Global concurrency cap: how many cards the fleet may hold in flight at once
 // (the dispatch loop reads it as MAX_OPEN_PRS). null = no override, the loop
 // default applies. Pause is the on/off switch; this is the volume knob.
+const MAX_CAP = 50; // sane ceiling so the stepper cannot post runaway values
 function coerceCap(v: unknown): number | null {
-  return typeof v === "number" && Number.isFinite(v) && v > 0 ? Math.floor(v) : null;
+  if (typeof v !== "number" || !Number.isFinite(v) || v <= 0) return null;
+  return Math.min(MAX_CAP, Math.floor(v));
 }
 
 export function ObservatoryApp({ windowId: _windowId }: { windowId: string }) {
@@ -156,8 +158,8 @@ export function ObservatoryApp({ windowId: _windowId }: { windowId: string }) {
         <div className="flex items-center gap-1.5">
           <button
             type="button"
-            onClick={() => setGlobalCap(cap && cap > 1 ? cap - 1 : null)}
-            disabled={busy === "cap" || cap == null}
+            onClick={() => cap != null && cap > 1 && setGlobalCap(cap - 1)}
+            disabled={busy === "cap" || cap == null || cap <= 1}
             aria-label="Lower concurrency cap"
             className="flex h-7 w-7 items-center justify-center rounded-md border border-shell-border text-shell-text-secondary transition-colors hover:text-shell-text hover:border-shell-border-strong disabled:cursor-not-allowed disabled:opacity-40"
           >
@@ -171,8 +173,8 @@ export function ObservatoryApp({ windowId: _windowId }: { windowId: string }) {
           </span>
           <button
             type="button"
-            onClick={() => setGlobalCap((cap ?? 0) + 1)}
-            disabled={busy === "cap"}
+            onClick={() => setGlobalCap(Math.min(MAX_CAP, (cap ?? 0) + 1))}
+            disabled={busy === "cap" || (cap != null && cap >= MAX_CAP)}
             aria-label="Raise concurrency cap"
             className="flex h-7 w-7 items-center justify-center rounded-md border border-shell-border text-shell-text-secondary transition-colors hover:text-shell-text hover:border-shell-border-strong disabled:cursor-not-allowed disabled:opacity-40"
           >

--- a/desktop/src/apps/ObservatoryApp.tsx
+++ b/desktop/src/apps/ObservatoryApp.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
-import { Radar, Pause, Play, Loader2, CircleDot } from "lucide-react";
+import { Radar, Pause, Play, Loader2, CircleDot, Minus, Plus } from "lucide-react";
 import { Switch } from "@/components/ui";
 
 interface HeldCard {
@@ -21,22 +21,37 @@ interface PauseState {
 
 const EMPTY_PAUSE: PauseState = { global: false, lanes: {} };
 
+// Global concurrency cap: how many cards the fleet may hold in flight at once
+// (the dispatch loop reads it as MAX_OPEN_PRS). null = no override, the loop
+// default applies. Pause is the on/off switch; this is the volume knob.
+function coerceCap(v: unknown): number | null {
+  return typeof v === "number" && Number.isFinite(v) && v > 0 ? Math.floor(v) : null;
+}
+
 export function ObservatoryApp({ windowId: _windowId }: { windowId: string }) {
   const [agents, setAgents] = useState<FleetAgent[]>([]);
   const [pause, setPause] = useState<PauseState>(EMPTY_PAUSE);
+  const [cap, setCap] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState<string | null>(null);
 
   const load = useCallback(async (opts?: { silent?: boolean }) => {
     if (!opts?.silent) setLoading(true);
     try {
-      const res = await fetch("/api/observatory/fleet");
-      if (res.ok) {
-        const data = await res.json();
+      const [fleetRes, throttleRes] = await Promise.all([
+        fetch("/api/observatory/fleet"),
+        fetch("/api/observatory/throttle"),
+      ]);
+      if (fleetRes.ok) {
+        const data = await fleetRes.json();
         setAgents(Array.isArray(data.agents) ? data.agents : []);
         setPause(
           data.paused && typeof data.paused === "object" ? data.paused : EMPTY_PAUSE,
         );
+      }
+      if (throttleRes.ok) {
+        const data = await throttleRes.json();
+        setCap(coerceCap(data?.global));
       }
     } catch {
       // Non-critical: keep the last-loaded view.
@@ -80,6 +95,26 @@ export function ObservatoryApp({ windowId: _windowId }: { windowId: string }) {
     [load],
   );
 
+  const setGlobalCap = useCallback(
+    async (next: number | null) => {
+      setBusy("cap");
+      setCap(next); // optimistic; reconciled on the next poll
+      try {
+        await fetch("/api/observatory/throttle", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ scope: "global", max_concurrent: next }),
+        });
+        await load({ silent: true });
+      } catch {
+        await load({ silent: true });
+      } finally {
+        setBusy(null);
+      }
+    },
+    [load],
+  );
+
   return (
     <div className="flex h-full flex-col overflow-hidden bg-shell-bg">
       {/* Header + global steer */}
@@ -112,6 +147,52 @@ export function ObservatoryApp({ windowId: _windowId }: { windowId: string }) {
           Dispatch is paused. In-flight work finishes; no new cards are claimed.
         </div>
       )}
+
+      {/* Steer: global concurrency cap (volume knob alongside the pause switch) */}
+      <div className="flex items-center gap-3 border-b border-shell-border px-5 py-2.5">
+        <span className="text-xs font-medium uppercase tracking-wide text-shell-text-tertiary">
+          Concurrency cap
+        </span>
+        <div className="flex items-center gap-1.5">
+          <button
+            type="button"
+            onClick={() => setGlobalCap(cap && cap > 1 ? cap - 1 : null)}
+            disabled={busy === "cap" || cap == null}
+            aria-label="Lower concurrency cap"
+            className="flex h-7 w-7 items-center justify-center rounded-md border border-shell-border text-shell-text-secondary transition-colors hover:text-shell-text hover:border-shell-border-strong disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            <Minus size={14} />
+          </button>
+          <span
+            className="min-w-[3.5rem] text-center text-sm font-medium text-shell-text tabular-nums"
+            aria-label="Concurrency cap value"
+          >
+            {cap == null ? "No cap" : cap}
+          </span>
+          <button
+            type="button"
+            onClick={() => setGlobalCap((cap ?? 0) + 1)}
+            disabled={busy === "cap"}
+            aria-label="Raise concurrency cap"
+            className="flex h-7 w-7 items-center justify-center rounded-md border border-shell-border text-shell-text-secondary transition-colors hover:text-shell-text hover:border-shell-border-strong disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            <Plus size={14} />
+          </button>
+        </div>
+        {cap != null && (
+          <button
+            type="button"
+            onClick={() => setGlobalCap(null)}
+            disabled={busy === "cap"}
+            className="text-xs text-shell-text-tertiary transition-colors hover:text-shell-text"
+          >
+            Clear
+          </button>
+        )}
+        <span className="ml-auto text-xs text-shell-text-tertiary">
+          Max cards the fleet holds at once
+        </span>
+      </div>
 
       {/* Fleet (Observe) */}
       <div className="flex-1 overflow-y-auto px-5 py-4">


### PR DESCRIPTION
## What

Surfaces the throttle/concurrency dial in the Observatory app. The throttle backend (#1365) and its taosctl group already shipped, and Jay's pending-decision #3 puts throttle dials in the Observatory queue-control v1 target, but the UI only exposed pause.

## Behaviour

- A **Concurrency cap** stepper in the steer row loads `/api/observatory/throttle` alongside the fleet poll and shows the current global cap, or `No cap`.
- + / - adjust it and POST `{ scope: 'global', max_concurrent }`; stepping below 1 (or the explicit Clear) posts `max_concurrent: null` to drop the override (the dispatch loop falls back to its default).
- Optimistic update, reconciled on the next 5s poll, matching the pause control.

Per-lane throttle is a deliberate follow-up; this slice is the global dial.

## Tests

- `ObservatoryApp.test.tsx`: 3 new cases (renders the loaded cap, raise + posts the value, clear-to-null at the lowest step) plus the existing 5. All 8 green; `tsc -b` clean. The mock helper defaults the throttle GET to no-cap so fleet-only tests are unaffected.

## Verification note

Behaviourally verified via vitest. Visual check against the running app deferred to a live session, consistent with the recent read-only desktop slices.