### PR TITLE
fix(observatory): poll no longer reverts an optimistic steer value mid-write

### DIFF
--- a/desktop/src/apps/ObservatoryApp.test.tsx
+++ b/desktop/src/apps/ObservatoryApp.test.tsx
@@ -315,4 +315,54 @@ describe("ObservatoryApp polling", () => {
     expect(fetchMock.mock.calls.length).toBeGreaterThan(initial);
     vi.useRealTimers();
   });
+
+  it("skips the background poll while a steer write is in flight", async () => {
+    vi.useFakeTimers();
+    let resolvePost: (() => void) | null = null;
+    const fetchMock = vi.fn().mockImplementation((input: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "POST" && input === "/api/observatory/pause") {
+        return new Promise((res) => {
+          resolvePost = () =>
+            res({ ok: true, status: 200, json: () => Promise.resolve({}) });
+        });
+      }
+      if (input === "/api/observatory/throttle") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ global: null, lanes: {} }),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(fleetBody),
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    render(<ObservatoryApp windowId="w1" />);
+    await act(async () => { await Promise.resolve(); });
+
+    // Start a pause write whose POST stays pending so inFlight stays non-zero.
+    fireEvent.click(screen.getByRole("button", { name: /pause queue/i }));
+    await act(async () => { await Promise.resolve(); });
+
+    const fleetCalls = () =>
+      fetchMock.mock.calls.filter((c) => c[0] === "/api/observatory/fleet").length;
+    const before = fleetCalls();
+
+    // The 5s tick must NOT background-fetch the fleet while the write is pending.
+    await act(async () => { vi.advanceTimersByTime(5000); await Promise.resolve(); });
+    expect(fleetCalls()).toBe(before);
+
+    // Once the write resolves, postSteer's reconcile fetches the fleet.
+    await act(async () => {
+      resolvePost?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(fleetCalls()).toBeGreaterThan(before);
+    vi.useRealTimers();
+  });
 });

--- a/desktop/src/apps/ObservatoryApp.test.tsx
+++ b/desktop/src/apps/ObservatoryApp.test.tsx
@@ -365,4 +365,50 @@ describe("ObservatoryApp polling", () => {
     expect(fleetCalls()).toBeGreaterThan(before);
     vi.useRealTimers();
   });
+
+  it("a finished write's reconcile does not revert another in-flight write", async () => {
+    let resolvePause: (() => void) | null = null;
+    const fetchMock = vi.fn().mockImplementation((input: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "POST" && input === "/api/observatory/pause") {
+        // The pause POST stays pending until we release it.
+        return new Promise((res) => {
+          resolvePause = () =>
+            res({ ok: true, status: 200, json: () => Promise.resolve({}) });
+        });
+      }
+      if (method === "POST" && input === "/api/observatory/throttle") {
+        // The cap POST resolves immediately, but the server read still reports
+        // no cap (as if the change has not propagated yet).
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({}) });
+      }
+      if (input === "/api/observatory/throttle") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ global: null, lanes: {} }),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(fleetBody),
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    render(<ObservatoryApp windowId="w1" />);
+    await flush();
+
+    // Start a cap raise (optimistic cap -> 1) AND a pause whose POST stays
+    // pending, so a write is still in flight when the cap write reconciles.
+    fireEvent.click(screen.getByRole("button", { name: /pause queue/i }));
+    fireEvent.click(screen.getByRole("button", { name: /raise concurrency cap/i }));
+    await flush();
+
+    // The cap write's reconcile read says "no cap", but the pause write is still
+    // in flight, so the optimistic cap must be preserved (not reverted to 0).
+    expect(screen.getByLabelText(/concurrency cap value/i).textContent).toBe("1");
+
+    await act(async () => { resolvePause?.(); await Promise.resolve(); });
+  });
 });

--- a/desktop/src/apps/ObservatoryApp.tsx
+++ b/desktop/src/apps/ObservatoryApp.tsx
@@ -95,6 +95,10 @@ export function ObservatoryApp({ windowId: _windowId }: { windowId: string }) {
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState<string | null>(null);
   const [steerError, setSteerError] = useState<string | null>(null);
+  // Count of steer writes in flight. The 5s background poll skips while this is
+  // non-zero so it cannot revert an optimistic value mid-request; the
+  // post-write reconcile updates authoritatively instead.
+  const inFlight = useRef(0);
 
   const load = useCallback(async (opts?: { silent?: boolean }) => {
     if (!opts?.silent) setLoading(true);
@@ -125,7 +129,11 @@ export function ObservatoryApp({ windowId: _windowId }: { windowId: string }) {
   useEffect(() => {
     load();
     // Poll so the fleet + pause state stay live without a manual refresh.
-    const id = setInterval(() => load({ silent: true }), 5000);
+    const id = setInterval(() => {
+      // Skip the poll while a steer write is in flight so it cannot revert an
+      // optimistic value mid-request; postSteer reconciles after the write.
+      if (inFlight.current === 0) load({ silent: true });
+    }, 5000);
     return () => clearInterval(id);
   }, [load]);
 
@@ -138,6 +146,7 @@ export function ObservatoryApp({ windowId: _windowId }: { windowId: string }) {
   const steerSeq = useRef(0);
   const postSteer = useCallback(
     async (url: string, body: object, failMsg: string) => {
+      inFlight.current += 1;
       const seq = ++steerSeq.current;
       try {
         const res = await fetch(url, {
@@ -150,6 +159,7 @@ export function ObservatoryApp({ windowId: _windowId }: { windowId: string }) {
         if (seq === steerSeq.current) setSteerError(failMsg);
       } finally {
         await load({ silent: true });
+        inFlight.current -= 1;
       }
     },
     [load],

--- a/desktop/src/apps/ObservatoryApp.tsx
+++ b/desktop/src/apps/ObservatoryApp.tsx
@@ -95,9 +95,11 @@ export function ObservatoryApp({ windowId: _windowId }: { windowId: string }) {
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState<string | null>(null);
   const [steerError, setSteerError] = useState<string | null>(null);
-  // Count of steer writes in flight. The 5s background poll skips while this is
-  // non-zero so it cannot revert an optimistic value mid-request; the
-  // post-write reconcile updates authoritatively instead.
+  // Count of steer writes in flight. The fleet list always refreshes, but the
+  // server's steer-state (pause/caps) is adopted only when this is 0, so an
+  // optimistic value is never reverted by a concurrent read -- neither the 5s
+  // background poll nor another write's reconcile. The reconcile after the last
+  // write (inFlight back to 0) is the one that adopts.
   const inFlight = useRef(0);
 
   const load = useCallback(async (opts?: { silent?: boolean }) => {
@@ -107,17 +109,23 @@ export function ObservatoryApp({ windowId: _windowId }: { windowId: string }) {
         fetch("/api/observatory/fleet"),
         fetch("/api/observatory/throttle"),
       ]);
-      if (fleetRes.ok) {
-        const data = await fleetRes.json();
-        setAgents(Array.isArray(data.agents) ? data.agents : []);
-        setPause(
-          data.paused && typeof data.paused === "object" ? data.paused : EMPTY_PAUSE,
-        );
+      const fleetData = fleetRes.ok ? await fleetRes.json() : null;
+      const throttleData = throttleRes.ok ? await throttleRes.json() : null;
+      if (fleetData) {
+        setAgents(Array.isArray(fleetData.agents) ? fleetData.agents : []);
       }
-      if (throttleRes.ok) {
-        const data = await throttleRes.json();
-        setCap(coerceCap(data?.global));
-        setLaneCaps(coerceLaneCaps(data?.lanes));
+      if (inFlight.current === 0) {
+        if (fleetData) {
+          setPause(
+            fleetData.paused && typeof fleetData.paused === "object"
+              ? fleetData.paused
+              : EMPTY_PAUSE,
+          );
+        }
+        if (throttleData) {
+          setCap(coerceCap(throttleData?.global));
+          setLaneCaps(coerceLaneCaps(throttleData?.lanes));
+        }
       }
     } catch {
       // Non-critical: keep the last-loaded view.
@@ -158,8 +166,11 @@ export function ObservatoryApp({ windowId: _windowId }: { windowId: string }) {
       } catch {
         if (seq === steerSeq.current) setSteerError(failMsg);
       } finally {
-        await load({ silent: true });
+        // Decrement first so this reconcile adopts the server steer-state only
+        // when it is the last write to finish; an earlier concurrent write's
+        // reconcile (inFlight still > 0) refreshes the fleet but not the caps.
         inFlight.current -= 1;
+        await load({ silent: true });
       }
     },
     [load],


### PR DESCRIPTION
## What

Folds the deferred gitar Edge-Case from #1420: the 5s background poll (`load()` over fleet + throttle) could land while a steer write was in flight and briefly revert the optimistic value (pause, global cap, or per-lane cap) before the POST completed.

## Change

- Track in-flight steer writes with an `inFlight` ref, incremented/decremented in the shared `postSteer`.
- The 5s interval skips a tick while `inFlight > 0`; `postSteer`'s existing reconcile `load()` updates authoritatively once the write resolves.
- Uniform across `setScope` / `setGlobalCap` / `setLaneCap` (all route through `postSteer`), so the three controls stay consistent.

## Tests

- New `ObservatoryApp.test.tsx` case: with a pending POST, a 5s tick issues no background fleet fetch; once the POST resolves, the reconcile fetch runs. Plus the existing 13. All 14 green; `tsc -b` clean.

## Verification note

Behaviourally verified via vitest; visual check deferred to a live session, as with the other desktop slices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Observatory background polling behavior during steer/pause requests so user-facing optimistic updates aren’t overwritten while a write is pending, and state sync resumes once the request completes.

* **Tests**
  * Added an automated test that verifies fleet polling is suppressed during an in-flight steer/pause POST and resumes afterward, using mocked requests and fake timers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->