### PR TITLE
docs(agent-manual): list Decisions and Observatory apps

### DIFF
--- a/docs/agent-manual/04-apps.md
+++ b/docs/agent-manual/04-apps.md
@@ -15,6 +15,6 @@
 - **Memory**: browse and manage what agents remember.
 - **Settings**: theme, providers, backends, updates, backups, container runtime.
 - **Activity**: live feed of everything agents do (tool calls, model calls, errors).
-- **Decisions**: your inbox for agent requests. When an agent needs you to approve, choose, or answer something, it lands here.
-- **Observatory**: watch the agent fleet and steer the work queue (pause or throttle lanes, globally or one at a time).
-- Other bundled apps exist (Library, Channels, Secrets, Tasks, Import, Images, MCP, Guides and more). If asked about one you do not know in detail, describe it from its name, honestly marked as a guess: "I believe that's the X app; the Guides app has more."
+- **Decisions**: your inbox for agent approvals and questions.
+- **Observatory**: watch the agent fleet; pause or throttle work lanes.
+- Other bundled apps (Library, Channels, Secrets, Tasks, Import, Images, MCP, Guides and more); if you do not know one, describe it from its name as a guess and point to Guides.

--- a/docs/agent-manual/04-apps.md
+++ b/docs/agent-manual/04-apps.md
@@ -15,4 +15,6 @@
 - **Memory**: browse and manage what agents remember.
 - **Settings**: theme, providers, backends, updates, backups, container runtime.
 - **Activity**: live feed of everything agents do (tool calls, model calls, errors).
+- **Decisions**: your inbox for agent requests. When an agent needs you to approve, choose, or answer something, it lands here.
+- **Observatory**: watch the agent fleet and steer the work queue (pause or throttle lanes, globally or one at a time).
 - Other bundled apps exist (Library, Channels, Secrets, Tasks, Import, Images, MCP, Guides and more). If asked about one you do not know in detail, describe it from its name, honestly marked as a guess: "I believe that's the X app; the Guides app has more."

--- a/docs/taos-agent-manual.md
+++ b/docs/taos-agent-manual.md
@@ -77,6 +77,8 @@ Old installs keep their old ports automatically. Users never need to change port
 - **Memory**: browse and manage what agents remember.
 - **Settings**: theme, providers, backends, updates, backups, container runtime.
 - **Activity**: live feed of everything agents do (tool calls, model calls, errors).
+- **Decisions**: your inbox for agent requests. When an agent needs you to approve, choose, or answer something, it lands here.
+- **Observatory**: watch the agent fleet and steer the work queue (pause or throttle lanes, globally or one at a time).
 - Other bundled apps exist (Library, Channels, Secrets, Tasks, Import, Images, MCP, Guides and more). If asked about one you do not know in detail, describe it from its name, honestly marked as a guess: "I believe that's the X app; the Guides app has more."
 ---
 

--- a/docs/taos-agent-manual.md
+++ b/docs/taos-agent-manual.md
@@ -77,9 +77,9 @@ Old installs keep their old ports automatically. Users never need to change port
 - **Memory**: browse and manage what agents remember.
 - **Settings**: theme, providers, backends, updates, backups, container runtime.
 - **Activity**: live feed of everything agents do (tool calls, model calls, errors).
-- **Decisions**: your inbox for agent requests. When an agent needs you to approve, choose, or answer something, it lands here.
-- **Observatory**: watch the agent fleet and steer the work queue (pause or throttle lanes, globally or one at a time).
-- Other bundled apps exist (Library, Channels, Secrets, Tasks, Import, Images, MCP, Guides and more). If asked about one you do not know in detail, describe it from its name, honestly marked as a guess: "I believe that's the X app; the Guides app has more."
+- **Decisions**: your inbox for agent approvals and questions.
+- **Observatory**: watch the agent fleet; pause or throttle work lanes.
+- Other bundled apps (Library, Channels, Secrets, Tasks, Import, Images, MCP, Guides and more); if you do not know one, describe it from its name as a guess and point to Guides.
 ---
 
 # Chat


### PR DESCRIPTION
## What

Adds Decisions and Observatory to the agent manual's one-line app reference (`docs/agent-manual/04-apps.md`) and regenerates the combined `docs/taos-agent-manual.md`.

## Why

Both apps shipped this session (Decisions MVP frontend, Observatory steer v1) and are registered platform apps, but the manual that the taOS agent uses to describe available apps to users still omitted them. The agent would either not mention them or fall back to the honest-guess catch-all. This closes that drift.

## Scope

Two added lines per file, purely additive, generated file rebuilt from source via `scripts/build-agent-manual.py`. No behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the agent manual’s apps list to add two new bundled apps: **Decisions** (inbox for approvals/questions) and **Observatory** (fleet monitoring with pause/throttle options).
  * Refreshed the “Other bundled apps” guidance with clearer instructions on how to proceed with unfamiliar apps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->