### PR TITLE
fix(decisions): default option value to label when omitted

### DIFF
--- a/tests/test_routes_decisions.py
+++ b/tests/test_routes_decisions.py
@@ -91,6 +91,33 @@ async def test_multi_select_answer_must_be_subset(client):
 
 
 @pytest.mark.asyncio
+async def test_select_options_without_value_default_to_label(client):
+    # An agent may declare options with only a label (value is optional in the
+    # API). Every option must still get a distinct, non-null value, otherwise
+    # the inbox cannot tell them apart (a multi_select would check all at once)
+    # and answer validation silently no-ops on an empty valid set.
+    resp = await client.post("/api/decisions", json={
+        "from_agent": "@a", "question": "pick apps", "type": "multi_select",
+        "options": [{"label": "Images"}, {"label": "Observatory"}, {"label": "Decisions"}],
+    })
+    assert resp.status_code == 200
+    d = resp.json()
+    values = [o["value"] for o in d["options"]]
+    assert values == ["Images", "Observatory", "Decisions"]
+    # Answer validation now has a populated valid set keyed on those values.
+    resp = await client.post(f"/api/decisions/{d['id']}/answer", json={"value": ["Images", "Decisions"]})
+    assert resp.status_code == 200
+    resp2 = await client.post("/api/decisions", json={
+        "from_agent": "@a", "question": "pick one", "type": "single_select",
+        "options": [{"label": "A"}, {"label": "B"}],
+    })
+    d2 = resp2.json()
+    # A label that was not declared is still rejected.
+    bad = await client.post(f"/api/decisions/{d2['id']}/answer", json={"value": "C"})
+    assert bad.status_code == 400
+
+
+@pytest.mark.asyncio
 async def test_answer_routes_back_to_bus_agent(client, monkeypatch):
     import tinyagentos.routes.decisions as dmod
 

--- a/tinyagentos/routes/decisions.py
+++ b/tinyagentos/routes/decisions.py
@@ -12,7 +12,7 @@ import os
 import httpx
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 
 from tinyagentos.auth_context import CurrentUser, current_user
 from tinyagentos.decisions.decision_store import DECISION_TYPES, PRIORITIES
@@ -64,6 +64,17 @@ class OptionIn(BaseModel):
     value: str | None = None
     recommended: bool = False
     rationale: str = ""
+
+    @model_validator(mode="after")
+    def _default_value_to_label(self) -> "OptionIn":
+        # value is optional for callers, but the whole stack keys on it: the
+        # inbox uses it as each option's identity (without it a multi_select
+        # checks every option at once) and answer validation builds its valid
+        # set from non-null values. Fall back to the label so every option has
+        # a distinct, non-null value.
+        if not (self.value and self.value.strip()):
+            self.value = self.label
+        return self
 
 
 class DecisionIn(BaseModel):


### PR DESCRIPTION
## Bug

Found live on the Pi: in a Decisions `multi_select` card, clicking any one option checked **all** of them.

## Root cause

A select option's `value` is optional in the API (`value: str | None = None`), but the entire stack keys on it:
- The inbox uses each option's `value` as its identity. With value-less options every option collapsed to the same `null`, so `multi.includes(null)` was true for all of them and one click checked the whole list.
- The answer route builds its valid set from non-null values (`{o.value for o ... if o.value is not None}`), so all-null options produced an empty set and validation was silently skipped.

## Fix

Default `value` to `label` in `OptionIn` (a `model_validator`) so every option always has a distinct, non-null value. This fixes option identity in the inbox and restores answer validation, with no frontend change needed (the Option type already requires a value, which the backend now guarantees).

## Tests

Added `test_select_options_without_value_default_to_label` (fails before, passes after). Full decisions route + taosctl + store suites green (37 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Select options that are created with only a label now automatically use that label as their value, so they can be selected and saved reliably.
  * Multi-select answers now validate correctly when using these defaulted option values.
  * Single-select answers now reject undeclared labels or values with a clear error response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->