### PR TITLE
fix(desktop): log the real error in the app error boundary

### DIFF
--- a/desktop/src/components/AppErrorBoundary.tsx
+++ b/desktop/src/components/AppErrorBoundary.tsx
@@ -12,7 +12,7 @@
  * (We don't pretend to handle arbitrary failures; that's the job of
  * the surrounding observability stack and per-app error states.)
  */
-import { Component, type ReactNode } from "react";
+import { Component, type ErrorInfo, type ReactNode } from "react";
 import { Loader2, RefreshCw, AlertCircle } from "lucide-react";
 import { BackendUnavailableError } from "@/lib/taos-fetch";
 
@@ -44,7 +44,14 @@ export class AppErrorBoundary extends Component<Props, State> {
     return { mode: classify(err) };
   }
 
-  componentDidCatch() {
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    // The generic fallback intentionally hides the error from the user, but it
+    // must not be swallowed: log the error and the component stack so a crash
+    // is diagnosable from the console and reachable by the observability stack.
+    // Skip the "waiting"/"chunk" modes -- those are expected, handled states.
+    if (this.state.mode === "generic") {
+      console.error("[AppErrorBoundary]", error, info?.componentStack ?? "");
+    }
     if (this.state.mode === "chunk" && !this.reloadTimer) {
       this.reloadTimer = setTimeout(() => window.location.reload(), 5_000);
     }

--- a/desktop/src/components/__tests__/AppErrorBoundary.test.tsx
+++ b/desktop/src/components/__tests__/AppErrorBoundary.test.tsx
@@ -84,4 +84,30 @@ describe("<AppErrorBoundary />", () => {
     expect(screen.queryByText(/taOS was updated/i)).toBeNull();
     expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
   });
+
+  it("logs the real error + component stack for a generic crash (diagnosable)", () => {
+    render(
+      <AppErrorBoundary>
+        <Thrower err={new ReferenceError("boom")} />
+      </AppErrorBoundary>
+    );
+    // The boundary surfaces the underlying error rather than swallowing it.
+    const logged = consoleErr.mock.calls.some(
+      (args) =>
+        args[0] === "[AppErrorBoundary]" &&
+        args[1] instanceof Error &&
+        (args[1] as Error).message === "boom",
+    );
+    expect(logged).toBe(true);
+  });
+
+  it("does not log for the expected waiting state", () => {
+    render(
+      <AppErrorBoundary>
+        <Thrower err={new BackendUnavailableError()} />
+      </AppErrorBoundary>
+    );
+    const loggedOurs = consoleErr.mock.calls.some((args) => args[0] === "[AppErrorBoundary]");
+    expect(loggedOurs).toBe(false);
+  });
 });


### PR DESCRIPTION
## Problem

The top-level AppErrorBoundary's `componentDidCatch()` took no arguments and logged nothing. When an unexpected error hit the generic "Something went wrong" fallback, the actual error and component stack were discarded, so the crash left **no console trace** and nothing for the observability stack to pick up. (Surfaced while debugging a live 'Something went wrong' crash on the Pi that was undiagnosable for exactly this reason.)

## Fix

Log `error` + `info.componentStack` in `componentDidCatch` for the `generic` mode only. The expected, handled states (`waiting` for backend reconnect, `chunk` for stale-deploy reload) stay quiet to avoid noise. No UI/behavior change.

## Tests

Added two cases: a generic crash logs the real error + stack; the waiting state does not log. Both AppErrorBoundary suites green (13 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error boundary behavior so real errors are logged with more useful diagnostic details.
  * Prevented unnecessary logging when the app is in an expected waiting state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->