### PR TITLE
fix(decisions): de-duplicate colliding option values

### DIFF
--- a/tests/test_routes_decisions.py
+++ b/tests/test_routes_decisions.py
@@ -118,6 +118,26 @@ async def test_select_options_without_value_default_to_label(client):
 
 
 @pytest.mark.asyncio
+async def test_duplicate_labels_get_distinct_values(client):
+    # Two value-less options sharing a label must NOT collapse to one identity,
+    # otherwise the multi_select would check both at once again. Collisions are
+    # disambiguated with a suffix so every option keeps a distinct value.
+    resp = await client.post("/api/decisions", json={
+        "from_agent": "@a", "question": "pick", "type": "multi_select",
+        "options": [{"label": "Other"}, {"label": "Other"}, {"label": "Other"}],
+    })
+    assert resp.status_code == 200
+    d = resp.json()
+    values = [o["value"] for o in d["options"]]
+    assert len(set(values)) == 3, f"values must be distinct, got {values}"
+    # Selecting one colliding option does not implicitly select the others.
+    one = values[0]
+    resp = await client.post(f"/api/decisions/{d['id']}/answer", json={"value": [one]})
+    assert resp.status_code == 200
+    assert resp.json()["answer"]["value"] == [one]
+
+
+@pytest.mark.asyncio
 async def test_answer_routes_back_to_bus_agent(client, monkeypatch):
     import tinyagentos.routes.decisions as dmod
 

--- a/tinyagentos/routes/decisions.py
+++ b/tinyagentos/routes/decisions.py
@@ -90,6 +90,25 @@ class DecisionIn(BaseModel):
     checkpoint_ref: str | None = None
     timeline_id: str | None = None
 
+    @model_validator(mode="after")
+    def _dedupe_option_values(self) -> "DecisionIn":
+        # Per-option defaulting makes value fall back to label, but two options
+        # sharing a label (e.g. both "Other") would then collide and the inbox
+        # would treat them as one identity again. Keep the first occurrence and
+        # suffix later collisions so every option's value stays distinct; labels
+        # are untouched (display) since value is the identity the stack keys on.
+        seen: set[str] = set()
+        for opt in self.options:
+            base = opt.value or ""
+            value = base
+            n = 2
+            while value in seen:
+                value = f"{base} ({n})"
+                n += 1
+            opt.value = value
+            seen.add(value)
+        return self
+
 
 class AnswerIn(BaseModel):
     value: object


### PR DESCRIPTION
## Fix-forward (gitar Edge-Case on #1426)

#1426 defaulted a missing option `value` to its `label`, but gitar correctly flagged that two value-less options sharing a label (e.g. both "Other") still collapse to one identity, reintroducing the original bug for those options (the inbox keys on `value`, so a multi_select would check both at once, and answer validation would treat them as one).

## Fix

Add a `DecisionIn` `model_validator` that de-duplicates option values after the per-option label fallback: the first occurrence keeps its value, later collisions get a ` (2)`, ` (3)` suffix. Labels are untouched since `value` is the identity the stack keys on.

## Tests

Added `test_duplicate_labels_get_distinct_values` (three options all labeled "Other" get three distinct values; selecting one does not select the others). Full decisions route + taosctl + store suites green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of multiple-choice options with duplicate labels so each option is kept distinct.
  * Answering one of several similarly labeled options now selects only that specific choice, without affecting the others.
  * Ensures newly created choices have unique values even when a value isn’t explicitly provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->