### PR TITLE
feat(app-permissions): request-consent endpoint

### DIFF
--- a/tests/test_routes_app_permissions.py
+++ b/tests/test_routes_app_permissions.py
@@ -123,3 +123,43 @@ async def test_revoke_removes_from_granted(client):
     assert resp.status_code == 200
     data = (await client.get("/api/apps/a/permissions")).json()
     assert "files.write" not in data["granted"]
+
+
+@pytest.mark.asyncio
+async def test_request_consent_creates_decision_for_gated_caps(client):
+    resp = await client.post(
+        "/api/apps/stream-chat/request-consent",
+        json={"capabilities": ["app.kv", "app.net", "app.memory"]},
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    # Free caps (app.kv) are auto-granted, so only the gated caps need consent.
+    assert data["pending"] == ["app.net", "app.memory"]
+    dec = data["decision"]
+    assert dec["type"] == "multi_select"
+    assert dec["metadata"] == {
+        "kind": "app_grant", "app_id": "stream-chat",
+        "capabilities": ["app.net", "app.memory"],
+    }
+    # Answering the consent Decision writes the grants (the #1429 side-effect).
+    resp = await client.post(f"/api/decisions/{dec['id']}/answer", json={"value": ["app.net"]})
+    assert resp.status_code == 200
+    data = (await client.get("/api/apps/stream-chat/permissions")).json()
+    assert data["granted"] == ["app.net"]
+
+
+@pytest.mark.asyncio
+async def test_request_consent_noop_when_all_free_or_decided(client):
+    # All free caps: nothing to consent to.
+    resp = await client.post("/api/apps/a/request-consent", json={"capabilities": ["app.kv"]})
+    assert resp.json() == {"decision": None, "pending": []}
+    # Already-decided gated caps are not re-prompted.
+    await client.post("/api/apps/a/permissions", json={"capability": "app.net", "decision": "denied"})
+    resp = await client.post("/api/apps/a/request-consent", json={"capabilities": ["app.net"]})
+    assert resp.json() == {"decision": None, "pending": []}
+
+
+@pytest.mark.asyncio
+async def test_request_consent_rejects_unknown_capability(client):
+    resp = await client.post("/api/apps/a/request-consent", json={"capabilities": ["app.bogus"]})
+    assert resp.status_code == 400

--- a/tinyagentos/routes/app_permissions.py
+++ b/tinyagentos/routes/app_permissions.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel
 
 from tinyagentos.auth_context import CurrentUser, current_user
 from tinyagentos.userspace.capabilities import (
+    FREE_CAPS,
     NET_PREFIX,
     describe_capability,
     is_known_capability,
@@ -110,3 +111,55 @@ async def revoke_app_permission(
         return JSONResponse({"error": "capability required"}, status_code=400)
     await store.revoke(user.user_id, app_id, cap)
     return {"ok": True}
+
+
+class RequestConsentIn(BaseModel):
+    capabilities: list[str]
+
+
+@router.post("/api/apps/{app_id}/request-consent")
+async def request_app_consent(
+    app_id: str, body: RequestConsentIn, request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    """Raise an app-grant consent Decision for the capabilities that need it.
+
+    The shared entry point for both grant-on-install and lazy first-use:
+    validate the requested capabilities against the closed vocabulary, drop the
+    free caps (granted without consent) and any the user has already decided on
+    for this app, and if any remain create a multi_select consent Decision
+    routed to the app_grants ledger on answer (see _apply_app_grant). Returns
+    {decision, pending}; decision is null when nothing needs consent."""
+    grants = request.app.state.app_grants
+    caps: list[str] = []
+    for raw in body.capabilities or []:
+        cap = raw.strip()
+        if not cap or not is_known_capability(cap):
+            return JSONResponse({"error": f"unknown capability: {cap}"}, status_code=400)
+        if cap.startswith(NET_PREFIX) and not is_valid_network_grant(cap):
+            return JSONResponse({"error": f"invalid network origin: {cap}"}, status_code=400)
+        caps.append(cap)
+
+    # Free caps are granted without consent; caps the user already granted or
+    # denied for this app are not re-prompted (the Permissions app revisits).
+    decided = {g["capability"] for g in await grants.list_grants(user.user_id, app_id)}
+    pending = [c for c in caps if c not in FREE_CAPS and c not in decided]
+    if not pending:
+        return {"decision": None, "pending": []}
+
+    store = request.app.state.decision_store
+    decision = await store.create(user_id=user.user_id, **app_grant_decision_payload(app_id, pending))
+
+    notifs = getattr(request.app.state, "notifications", None)
+    if notifs is not None:
+        # Best effort: a notification failure must not fail the queued decision.
+        try:
+            await notifs.add(
+                title="Permission needed",
+                message=f"{app_id} is requesting permissions",
+                level="warning",
+                source="decisions",
+            )
+        except Exception:
+            pass
+    return {"decision": decision, "pending": pending}


### PR DESCRIPTION
## What

`POST /api/apps/{app_id}/request-consent` — the shared primitive both the grant-on-install flow and the lazy-first-use path will call to raise an app-grant consent Decision (#56, building on #1429).

- Validates requested capabilities against the closed vocabulary (rejects unknown / malformed network origins, 400).
- Drops **free caps** (granted without consent) and caps the user has **already decided** on for the app (no re-nagging; the Permissions app revisits).
- If any remain, creates the multi_select consent Decision via `app_grant_decision_payload` (routed to the `app_grants` ledger on answer by #1429's `_apply_app_grant`) and raises a notification.
- Returns `{decision, pending}`; `decision` is null when nothing needs consent.

## Deferred (your fork-34 answer = live-verify on the Pi)
Wiring this into the actual install endpoint (the dual-consent reconciliation with the existing needs_consent surface) and the consent card UI stay for the live session. This PR is just the clean, reusable backend seam.

## Tests
Creates a Decision for gated caps only (free skipped); end-to-end answer writes the grant; no-op when all-free or already-decided; unknown capability rejected. 66 related tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an app consent request flow for gated capabilities.
  * Requests now return only capabilities that actually need approval, with a decision payload for reviewing multiple items at once.
* **Bug Fixes**
  * Free capabilities are ignored automatically.
  * Already-decided capabilities no longer trigger duplicate consent requests.
  * Invalid or unknown capability requests now return a clear error.
* **Tests**
  * Added coverage for mixed capability requests, approval handling, no-op cases, and invalid input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->