### PR TITLE
fix(consent): de-dupe request-consent caps + log ledger failures

### DIFF
--- a/tests/test_routes_app_permissions.py
+++ b/tests/test_routes_app_permissions.py
@@ -163,3 +163,18 @@ async def test_request_consent_noop_when_all_free_or_decided(client):
 async def test_request_consent_rejects_unknown_capability(client):
     resp = await client.post("/api/apps/a/request-consent", json={"capabilities": ["app.bogus"]})
     assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_request_consent_dedups_capabilities(client):
+    # A repeated capability must not create a colliding option (whose value the
+    # dedup suffixer would rewrite to a non-capability like "app.net (2)").
+    resp = await client.post(
+        "/api/apps/dup-app/request-consent",
+        json={"capabilities": ["app.net", "app.net", "app.memory"]},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["pending"] == ["app.net", "app.memory"]
+    values = [o["value"] for o in data["decision"]["options"]]
+    assert values == ["app.net", "app.memory"]

--- a/tinyagentos/routes/app_permissions.py
+++ b/tinyagentos/routes/app_permissions.py
@@ -142,8 +142,14 @@ async def request_app_consent(
 
     # Free caps are granted without consent; caps the user already granted or
     # denied for this app are not re-prompted (the Permissions app revisits).
+    # De-duplicate while preserving order: a repeated cap would otherwise become
+    # a colliding option whose value the dedup suffixer rewrites to a non-cap.
     decided = {g["capability"] for g in await grants.list_grants(user.user_id, app_id)}
-    pending = [c for c in caps if c not in FREE_CAPS and c not in decided]
+    pending: list[str] = []
+    for c in caps:
+        if c in FREE_CAPS or c in decided or c in pending:
+            continue
+        pending.append(c)
     if not pending:
         return {"decision": None, "pending": []}
 

--- a/tinyagentos/routes/decisions.py
+++ b/tinyagentos/routes/decisions.py
@@ -7,6 +7,7 @@ notification; everything else is a normal badge + notification.
 
 from __future__ import annotations
 
+import logging
 import os
 
 import httpx
@@ -16,6 +17,8 @@ from pydantic import BaseModel, Field, model_validator
 
 from tinyagentos.auth_context import CurrentUser, current_user
 from tinyagentos.decisions.decision_store import DECISION_TYPES, PRIORITIES
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -275,4 +278,11 @@ async def _apply_app_grant(request: Request, decision: dict, value) -> None:
                 decision="granted" if cap in granted else "denied",
             )
     except Exception:
-        pass
+        # Best-effort: the answer is already persisted, so a ledger write must
+        # not fail the request. Log it rather than swallow silently so a broken
+        # grant write is diagnosable (the user can re-grant via the Permissions
+        # app).
+        logger.warning(
+            "app_grant ledger write failed for app %s (decision %s)",
+            app_id, decision.get("id"), exc_info=True,
+        )


### PR DESCRIPTION
Fix-forward of two gitar findings on the merged consent-flow backend (#1429/#1430):

- **#1430 Edge-Case (must-fix):** `request_app_consent` did not de-duplicate input capabilities. A repeated cap became a colliding consent option, and the #1428 option-value dedup then rewrote the second to a non-capability value (`app.net (2)`), which could not be granted. Now de-duped while preserving order.
- **#1429 Quality:** `_apply_app_grant` swallowed every app_grants ledger error silently. Now logs a warning with the app + decision id so a broken grant write is diagnosable (same lesson as #1427), while staying best-effort.

Test added: repeated capability yields a single, valid option. 41 related tests pass.