### PR TITLE
fix(consent): request-consent skips caps with a pending Decision

### DIFF
--- a/tests/test_routes_app_permissions.py
+++ b/tests/test_routes_app_permissions.py
@@ -178,3 +178,19 @@ async def test_request_consent_dedups_capabilities(client):
     assert data["pending"] == ["app.net", "app.memory"]
     values = [o["value"] for o in data["decision"]["options"]]
     assert values == ["app.net", "app.memory"]
+
+
+@pytest.mark.asyncio
+async def test_request_consent_skips_caps_with_pending_decision(client):
+    # First call raises a consent Decision for app.net.
+    r1 = await client.post("/api/apps/lazy-app/request-consent", json={"capabilities": ["app.net"]})
+    assert r1.json()["pending"] == ["app.net"]
+    dec_id = r1.json()["decision"]["id"]
+    # A second call (the lazy path re-firing before the user answers) must NOT
+    # create a duplicate pending consent card for the same app + cap.
+    r2 = await client.post("/api/apps/lazy-app/request-consent", json={"capabilities": ["app.net"]})
+    assert r2.json() == {"decision": None, "pending": []}
+    # Once answered, a later request for a DIFFERENT cap still raises its own card.
+    await client.post(f"/api/decisions/{dec_id}/answer", json={"value": ["app.net"]})
+    r3 = await client.post("/api/apps/lazy-app/request-consent", json={"capabilities": ["app.memory"]})
+    assert r3.json()["pending"] == ["app.memory"]

--- a/tinyagentos/routes/app_permissions.py
+++ b/tinyagentos/routes/app_permissions.py
@@ -142,18 +142,26 @@ async def request_app_consent(
 
     # Free caps are granted without consent; caps the user already granted or
     # denied for this app are not re-prompted (the Permissions app revisits).
+    decided = {g["capability"] for g in await grants.list_grants(user.user_id, app_id)}
+    # Caps that already have an unanswered app_grant Decision for this app: the
+    # lazy first-use path re-fires on every denied access until the user answers,
+    # so skip them or it would pile up duplicate pending consent cards.
+    store = request.app.state.decision_store
+    awaiting: set[str] = set()
+    for d in await store.list(status="pending", user_id=user.user_id):
+        meta = d.get("metadata") or {}
+        if meta.get("kind") == "app_grant" and meta.get("app_id") == app_id:
+            awaiting.update(meta.get("capabilities") or [])
     # De-duplicate while preserving order: a repeated cap would otherwise become
     # a colliding option whose value the dedup suffixer rewrites to a non-cap.
-    decided = {g["capability"] for g in await grants.list_grants(user.user_id, app_id)}
     pending: list[str] = []
     for c in caps:
-        if c in FREE_CAPS or c in decided or c in pending:
+        if c in FREE_CAPS or c in decided or c in awaiting or c in pending:
             continue
         pending.append(c)
     if not pending:
         return {"decision": None, "pending": []}
 
-    store = request.app.state.decision_store
     decision = await store.create(user_id=user.user_id, **app_grant_decision_payload(app_id, pending))
 
     notifs = getattr(request.app.state, "notifications", None)


### PR DESCRIPTION
## Gap

`request-consent` (#1430) de-dupes against granted/denied caps but not against caps that already have an **unanswered** app_grant Decision. The lazy first-use path (approved, timing = BOTH) re-fires on every denied capability access until the user answers, so repeated calls would pile up duplicate pending consent cards for the same app + cap.

## Fix

Before building the consent card, scan the user's pending app_grant Decisions for this app and exclude those capabilities (alongside the existing free-cap and already-decided filtering). Hardens the primitive before its callers (install flow + broker lazy-escalation) wire in during the live session.

## Test

Second call for the same cap before answering returns `{decision: null, pending: []}`; after answering, a request for a different cap still raises its own card. 34 related tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Consent requests now avoid creating duplicate pending prompts for the same app and capability when a decision is already awaiting action.
  * If only already-handled or pending capabilities remain, the app now returns no new consent card.
  * Requests for a different capability still generate a new pending consent prompt as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->