### PR TITLE
feat(observatory): stale-claim badge on the fleet view (#133)

### DIFF
--- a/tests/test_routes_observatory.py
+++ b/tests/test_routes_observatory.py
@@ -211,3 +211,24 @@ async def test_fleet_idle_agent_has_uniform_badge_shape(app, client):
     assert len(idle) == 1
     assert idle[0]["held_seconds"] is None
     assert idle[0]["stale"] is False
+
+
+@pytest.mark.asyncio
+async def test_fleet_clamps_held_seconds_under_clock_skew(app, client):
+    import time
+
+    pstore = app.state.project_store
+    tstore = app.state.project_task_store
+    proj = await pstore.create_project(name="ObsSkew", slug="obs-skew", created_by="admin", user_id="admin")
+    task = await tstore.create_task(proj["id"], title="Future card", created_by="admin")
+    await tstore.claim_task(task["id"], "@lane-skew")
+    # Claim stamped slightly in the future (clock skew) must not yield a negative age.
+    await tstore._db.execute(
+        "UPDATE project_tasks SET claimed_at = ? WHERE id = ?", (time.time() + 600, task["id"]))
+    await tstore._db.commit()
+
+    agents = (await client.get("/api/observatory/fleet")).json()["agents"]
+    mine = [a for a in agents if a["handle"] == "@lane-skew"]
+    assert len(mine) == 1
+    assert mine[0]["held_seconds"] == 0
+    assert mine[0]["stale"] is False

--- a/tests/test_routes_observatory.py
+++ b/tests/test_routes_observatory.py
@@ -159,3 +159,55 @@ async def test_registered_agent_with_a_claim_is_working_not_idle(app, client):
     # The agent appears once, as working (not duplicated as idle).
     assert len(rows) == 1
     assert rows[0]["state"] == "working"
+
+
+@pytest.mark.asyncio
+async def test_fleet_fresh_claim_has_held_seconds_and_is_not_stale(app, client):
+    pstore = app.state.project_store
+    tstore = app.state.project_task_store
+    proj = await pstore.create_project(name="ObsFresh", slug="obs-fresh", created_by="admin", user_id="admin")
+    task = await tstore.create_task(proj["id"], title="Fresh card", created_by="admin")
+    await tstore.claim_task(task["id"], "@lane-fresh")
+
+    agents = (await client.get("/api/observatory/fleet")).json()["agents"]
+    mine = [a for a in agents if a["handle"] == "@lane-fresh"]
+    assert len(mine) == 1
+    assert mine[0]["held_seconds"] is not None and mine[0]["held_seconds"] >= 0
+    assert mine[0]["stale"] is False
+
+
+@pytest.mark.asyncio
+async def test_fleet_flags_a_long_held_claim_as_stale(app, client):
+    from tinyagentos.routes.observatory import STALE_CLAIM_SECONDS
+    import time
+
+    pstore = app.state.project_store
+    tstore = app.state.project_task_store
+    proj = await pstore.create_project(name="ObsStale", slug="obs-stale", created_by="admin", user_id="admin")
+    task = await tstore.create_task(proj["id"], title="Wedged card", created_by="admin")
+    await tstore.claim_task(task["id"], "@lane-stale")
+    # Backdate the claim well past the threshold to exercise the stale path.
+    old = time.time() - (STALE_CLAIM_SECONDS + 600)
+    await tstore._db.execute(
+        "UPDATE project_tasks SET claimed_at = ? WHERE id = ?", (old, task["id"]))
+    await tstore._db.commit()
+
+    agents = (await client.get("/api/observatory/fleet")).json()["agents"]
+    mine = [a for a in agents if a["handle"] == "@lane-stale"]
+    assert len(mine) == 1
+    assert mine[0]["stale"] is True
+    assert mine[0]["held_seconds"] >= STALE_CLAIM_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_fleet_idle_agent_has_uniform_badge_shape(app, client):
+    reg = app.state.agent_registry
+    if reg._db is None:
+        await reg.init()
+    await reg.register(framework="opencode", display_name="Idle One",
+                       handle="@lane-idle", user_id="admin")
+    agents = (await client.get("/api/observatory/fleet")).json()["agents"]
+    idle = [a for a in agents if a["handle"] == "@lane-idle"]
+    assert len(idle) == 1
+    assert idle[0]["held_seconds"] is None
+    assert idle[0]["stale"] is False

--- a/tinyagentos/routes/observatory.py
+++ b/tinyagentos/routes/observatory.py
@@ -13,6 +13,7 @@ import asyncio
 import json
 import os
 import tempfile
+import time
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -24,6 +25,12 @@ from tinyagentos.auth_context import CurrentUser, current_user
 router = APIRouter()
 
 _DEFAULT_STATE: dict = {"global": False, "lanes": {}}
+
+# A working agent that has held its claimed card longer than this (seconds) is
+# flagged ``stale`` in the fleet view: it catches a hung or wedged lane the pause
+# switch would otherwise hide. Board-only signal (claim age); a richer
+# no-trace-progress check is phase 2 once the lane->trace-slug mapping is wired.
+STALE_CLAIM_SECONDS = 1800
 
 # Serialise read-modify-write of the pause/throttle state files so two
 # concurrent admin POSTs cannot lose an update (each reads the same prior
@@ -190,6 +197,7 @@ async def get_fleet(request: Request, user: CurrentUser = Depends(current_user))
     else:
         projects = await pstore.list_for_user(user.user_id, status=None)
 
+    now = time.time()
     agents: list[dict] = []
     working: set[str] = set()
     for proj in projects:
@@ -201,6 +209,10 @@ async def get_fleet(request: Request, user: CurrentUser = Depends(current_user))
             if not handle:
                 continue
             working.add(handle)
+            # Claim age drives the stale badge. claimed_at is a Unix epoch set on
+            # claim; guard a missing/None value (it must not break the view).
+            claimed_at = t.get("claimed_at")
+            held_seconds = int(now - claimed_at) if claimed_at else None
             agents.append({
                 "handle": handle,
                 "state": "working",
@@ -209,6 +221,8 @@ async def get_fleet(request: Request, user: CurrentUser = Depends(current_user))
                     "project_id": pid,
                     "title": t.get("title"),
                 },
+                "held_seconds": held_seconds,
+                "stale": held_seconds is not None and held_seconds >= STALE_CLAIM_SECONDS,
             })
 
     # Registered agents holding no card are idle; surface them so the fleet
@@ -228,7 +242,11 @@ async def get_fleet(request: Request, user: CurrentUser = Depends(current_user))
             if not handle or handle in working:
                 continue
             working.add(handle)
-            agents.append({"handle": handle, "state": "idle", "holds": None})
+            # Idle agents hold no card, so no claim age; keep the shape uniform.
+            agents.append({
+                "handle": handle, "state": "idle", "holds": None,
+                "held_seconds": None, "stale": False,
+            })
 
     agents.sort(key=lambda a: a["handle"])
     return {"agents": agents, "paused": _read_state(request)}

--- a/tinyagentos/routes/observatory.py
+++ b/tinyagentos/routes/observatory.py
@@ -210,9 +210,13 @@ async def get_fleet(request: Request, user: CurrentUser = Depends(current_user))
                 continue
             working.add(handle)
             # Claim age drives the stale badge. claimed_at is a Unix epoch set on
-            # claim; guard a missing/None value (it must not break the view).
+            # claim. Use `is not None` so an epoch-0 timestamp is not mistaken for
+            # missing, and clamp to >= 0 so clock skew (claimed_at slightly in the
+            # future) cannot report a negative age.
             claimed_at = t.get("claimed_at")
-            held_seconds = int(now - claimed_at) if claimed_at else None
+            held_seconds = (
+                max(0, int(now - claimed_at)) if claimed_at is not None else None
+            )
             agents.append({
                 "handle": handle,
                 "state": "working",


### PR DESCRIPTION
## What
Adds a board-only staleness signal to `GET /api/observatory/fleet`. Each working agent now carries `held_seconds` (age of its claimed card) and `stale` (true past `STALE_CLAIM_SECONDS` = 1800s). Idle agents keep the same shape (`held_seconds: null`, `stale: false`).

## Why
First non-gated slice of #133 (Observatory probe/badges). A hung or wedged lane holding a claim with no progress is exactly what the pause switch hides; the badge surfaces it. This is the board-only half of the decision-30 stale-claim signal (the no-trace-progress half needs the lane to trace-slug mapping and is phase 2).

## Scope
Purely additive to the fleet endpoint; pause/throttle untouched. claimed_at is guarded (missing/None never breaks the view).

## Tests
3 new (fresh claim not stale, backdated claim stale, idle uniform shape); full observatory route + taosctl suites green (17 + 13).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The Observe fleet view now includes how long each agent has been holding its current task.
  * Claimed tasks are flagged as **stale** once the hold time exceeds the threshold.
  * Idle agents now return a consistent payload format (including `held_seconds: null` and `stale: false`), with claim-age handling resilient to clock skew.
* **Tests**
  * Added integration coverage for fresh claims, stale claims, idle agents, and future-dated (clock-skew) claims in the fleet endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->