### PR TITLE
feat(account): show local signed-in identity in Account pane (#136)

### DIFF
--- a/desktop/src/apps/SettingsApp/AccountPanel.test.tsx
+++ b/desktop/src/apps/SettingsApp/AccountPanel.test.tsx
@@ -26,16 +26,24 @@ describe("AccountSection", () => {
   });
 
   it("shows the signed-in view with email + taOSgo status", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(
-        JSON.stringify({
-          user_id: "u1",
-          email: "jay@example.com",
-          taosgo: { status: "none" },
-        }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      ),
-    );
+    // URL-aware with a fresh Response per call: a shared Response instance has a
+    // single-use body, which the local /auth/status probe would consume before
+    // the cloud fetch reads it.
+    vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      if (String(input).includes("/auth/status")) {
+        return Promise.resolve(new Response(null, { status: 401 }));
+      }
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            user_id: "u1",
+            email: "jay@example.com",
+            taosgo: { status: "none" },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+    });
     render(<AccountSection />);
     expect(await screen.findByText("jay@example.com")).toBeInTheDocument();
     expect(screen.getByText("taOSgo")).toBeInTheDocument();
@@ -44,14 +52,22 @@ describe("AccountSection", () => {
   });
 
   it("surfaces a backend error message on failed sign-in", async () => {
-    vi.spyOn(globalThis, "fetch")
-      .mockResolvedValueOnce(new Response(null, { status: 401 })) // initial /me
-      .mockResolvedValueOnce(
+    // URL-aware so the local /auth/status probe does not consume the cloud
+    // account's mock sequence (initial signed-out, then a failed sign-in).
+    let accountCalls = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      if (String(input).includes("/auth/status")) {
+        return Promise.resolve(new Response(null, { status: 401 }));
+      }
+      accountCalls += 1;
+      if (accountCalls === 1) return Promise.resolve(new Response(null, { status: 401 }));
+      return Promise.resolve(
         new Response(JSON.stringify({ error: "Invalid credentials" }), {
           status: 400,
           headers: { "Content-Type": "application/json" },
         }),
       );
+    });
     render(<AccountSection />);
     fireEvent.change(await screen.findByLabelText("Email"), {
       target: { value: "jay@example.com" },
@@ -65,5 +81,30 @@ describe("AccountSection", () => {
     await waitFor(() =>
       expect(screen.getByText("Invalid credentials")).toBeInTheDocument(),
     );
+  });
+
+  it("shows the local 'this device' identity from /auth/status", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      if (String(input).includes("/auth/status")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              configured: true,
+              authenticated: true,
+              user: { username: "jay", full_name: "Jay", email: "jay@example.com", is_admin: true },
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+      // Cloud account unreachable, mirroring the real screenshot.
+      return Promise.reject(new Error("network"));
+    });
+    render(<AccountSection />);
+    // Local identity is shown even though the cloud account is unreachable.
+    expect(await screen.findByText("Jay")).toBeInTheDocument();
+    expect(screen.getByText(/@jay/)).toBeInTheDocument();
+    expect(screen.getByText("Signed in on this device")).toBeInTheDocument();
+    expect(screen.getByText(/account service is not reachable/i)).toBeInTheDocument();
   });
 });

--- a/desktop/src/apps/SettingsApp/AccountPanel.tsx
+++ b/desktop/src/apps/SettingsApp/AccountPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef, type FormEvent } from "react";
-import { LogOut, AlertCircle, ShieldCheck, Plane } from "lucide-react";
+import { LogOut, AlertCircle, ShieldCheck, Plane, UserCircle } from "lucide-react";
 import { Button, Card, Input, Label } from "@/components/ui";
 import {
   fetchAccount,
@@ -25,6 +25,59 @@ function formatDate(iso?: string | null): string | null {
   return Number.isNaN(d.getTime())
     ? null
     : d.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
+}
+
+/* ------------------------------------------------------------------ */
+/*  This-device (local) identity                                      */
+/* ------------------------------------------------------------------ */
+
+interface LocalUser {
+  username?: string;
+  full_name?: string;
+  email?: string;
+  is_admin?: boolean;
+}
+
+/** The account you are signed into on THIS device (the controller's own user),
+ *  read from /auth/status. Distinct from the taos.my cloud account below, and
+ *  shown even when the cloud account is unreachable so you always know who you
+ *  are signed in as. Renders nothing when signed out or the host is unreachable
+ *  (the cloud card already surfaces connectivity). */
+function LocalAccountCard() {
+  const [user, setUser] = useState<LocalUser | null>(null);
+  const mounted = useRef(true);
+  useEffect(() => () => { mounted.current = false; }, []);
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await fetch("/auth/status", { credentials: "include" });
+        if (!res.ok) return;
+        const data = await res.json();
+        if (mounted.current && data?.authenticated && data?.user) setUser(data.user);
+      } catch {
+        // Host unreachable; the cloud card surfaces connectivity, so stay quiet.
+      }
+    })();
+  }, []);
+
+  if (!user) return null;
+  const name = user.full_name?.trim() || user.username || "Signed in";
+  const meta = [
+    user.username ? `@${user.username}` : null,
+    user.email || null,
+    user.is_admin ? "Admin" : null,
+  ].filter(Boolean).join(" · ");
+
+  return (
+    <Card className="p-4 mb-3 flex items-center gap-3">
+      <UserCircle size={20} className="text-shell-text-secondary shrink-0" />
+      <div className="min-w-0">
+        <p className="text-sm font-medium truncate">{name}</p>
+        {meta && <p className="text-xs text-shell-text-tertiary mt-0.5 truncate">{meta}</p>}
+        <p className="text-xs text-shell-text-tertiary mt-0.5">Signed in on this device</p>
+      </div>
+    </Card>
+  );
 }
 
 /* ------------------------------------------------------------------ */
@@ -209,8 +262,11 @@ export function AccountSection() {
   return (
     <section aria-label="Account">
       <h2 className="text-lg font-semibold mb-2">Account</h2>
+
+      <LocalAccountCard />
+
       <p className="text-sm text-shell-text-tertiary mb-5">
-        Sign in to your taOS account to manage taOSgo and sync settings across your devices.
+        Sign in to your taOS cloud account to manage taOSgo and sync settings across your devices.
       </p>
 
       {state.kind === "loading" && (


### PR DESCRIPTION
## What
Adds a 'this device' identity card at the top of Settings -> Account, sourced from `/auth/status`, showing the local username / full name / email / admin flag. Renders independently of the taos.my cloud account, so you can always see who you are signed in as even when the cloud account is unreachable.

## Why
Jay 2026-06-25: 'I dont know what account I am in, it doesnt show me anywhere.' The pane only fetched the cloud account (`account-client` -> taos.my); the local identity from `/auth/status` was never surfaced. (Also confirms the password-only login is the single-primary-account model, so the earlier 'new account' was a password reset, not a duplicate.)

## Scope
Frontend only. Card renders nothing when signed out (401) or the host is unreachable. Cloud-account copy reworded to 'cloud account' for the two-tier distinction.

## Tests
New test: local identity shows even while the cloud account is unreachable. Existing AccountPanel tests made URL-aware (the local probe must not consume the cloud mock's single-use Response body). 5/5 green.