### PR TITLE
feat(logging): front-end crash capture + in-OS Logs viewer (#106)

### DIFF
--- a/desktop/src/apps/SettingsApp.tsx
+++ b/desktop/src/apps/SettingsApp.tsx
@@ -15,6 +15,7 @@ import {
   Users,
   Palette,
   UserCircle,
+  ScrollText,
 } from "lucide-react";
 import {
   Button,
@@ -29,12 +30,13 @@ import { safeFetch, ProgressBar, RestartProgressModal } from "@/apps/SettingsApp
 import { UpdatesSection } from "@/apps/SettingsApp/UpdatesPanel";
 import { UsersSection } from "@/apps/SettingsApp/UsersPanel";
 import { AccountSection } from "@/apps/SettingsApp/AccountPanel";
+import { LogsSection } from "@/apps/SettingsApp/LogsPanel";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
 /* ------------------------------------------------------------------ */
 
-type Section = "account" | "system" | "storage" | "memory" | "backup" | "updates" | "advanced" | "shortcuts" | "accessibility" | "desktop" | "users" | "themes";
+type Section = "account" | "system" | "storage" | "memory" | "backup" | "updates" | "advanced" | "shortcuts" | "accessibility" | "desktop" | "users" | "themes" | "logs";
 
 interface SectionDef {
   id: Section;
@@ -75,6 +77,7 @@ const SECTIONS: SectionDef[] = [
   { id: "desktop", label: "Desktop & Dock", icon: Monitor },
   { id: "users", label: "Users", icon: Users },
   { id: "themes", label: "Themes", icon: Palette },
+  { id: "logs", label: "Logs", icon: ScrollText },
 ];
 
 const PLACEHOLDER_SYSTEM: SystemInfo = {
@@ -770,6 +773,7 @@ export function SettingsApp({ windowId: _windowId, section: initialSection }: { 
     desktop: <DesktopDockSection />,
     users: <UsersSection />,
     themes: <ThemesPanel />,
+    logs: <LogsSection />,
   };
 
   const handleSelectSection = (id: Section) => {

--- a/desktop/src/apps/SettingsApp/LogsPanel.test.tsx
+++ b/desktop/src/apps/SettingsApp/LogsPanel.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { LogsSection } from "./LogsPanel";
+
+function jsonResponse(obj: unknown) {
+  return new Response(JSON.stringify(obj), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("LogsSection", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("renders captured logs", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({
+        items: [
+          {
+            id: "1", level: "fatal", message: "Messages crashed",
+            source: "AppErrorBoundary", url: "/desktop", stack: "at x",
+            created_at: "2026-06-25T12:00:00Z",
+          },
+        ],
+      }),
+    );
+    render(<LogsSection />);
+    expect(await screen.findByText("Messages crashed")).toBeInTheDocument();
+    // "fatal" appears twice: the filter button and the log's level badge.
+    expect(screen.getAllByText("fatal").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByText(/AppErrorBoundary/)).toBeInTheDocument();
+  });
+
+  it("shows the empty state when there are no logs", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({ items: [] }));
+    render(<LogsSection />);
+    expect(await screen.findByText("No logs captured yet.")).toBeInTheDocument();
+  });
+
+  it("re-fetches with the level query when a filter is chosen", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse({ items: [] }));
+    render(<LogsSection />);
+    await screen.findByText("No logs captured yet.");
+    fireEvent.click(screen.getByRole("button", { name: "error" }));
+    await waitFor(() => {
+      const urls = fetchSpy.mock.calls.map((c) => String(c[0]));
+      expect(urls.some((u) => u.includes("/api/client-logs?level=error"))).toBe(true);
+    });
+  });
+});

--- a/desktop/src/apps/SettingsApp/LogsPanel.tsx
+++ b/desktop/src/apps/SettingsApp/LogsPanel.tsx
@@ -1,0 +1,116 @@
+import { useState, useEffect, useCallback } from "react";
+import { ScrollText, RefreshCw } from "lucide-react";
+import { Button, Card } from "@/components/ui";
+import { safeFetch } from "@/apps/SettingsApp/_shared";
+
+interface ClientLog {
+  id: string;
+  level: string;
+  message: string;
+  source: string;
+  url: string;
+  stack: string;
+  created_at: string;
+}
+
+const LEVELS = ["all", "fatal", "error", "warn", "info", "debug"] as const;
+type LevelFilter = (typeof LEVELS)[number];
+
+const LEVEL_TONE: Record<string, string> = {
+  fatal: "text-red-400",
+  error: "text-red-400",
+  warn: "text-amber-400",
+  info: "text-sky-400",
+  debug: "text-shell-text-tertiary",
+};
+
+function formatTime(iso: string): string {
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleString();
+}
+
+/** Read-only viewer for the errors and crashes captured from this device
+ *  (GET /api/client-logs, admin only). The point is to chase a bug you hit in
+ *  an app without opening a console -- a PWA has none. */
+export function LogsSection() {
+  const [logs, setLogs] = useState<ClientLog[]>([]);
+  const [level, setLevel] = useState<LevelFilter>("all");
+  const [loading, setLoading] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    const q = level === "all" ? "" : `?level=${level}`;
+    const data = await safeFetch<{ items: ClientLog[] }>(
+      `/api/client-logs${q}`, { items: [] },
+    );
+    setLogs(Array.isArray(data.items) ? data.items : []);
+    setLoading(false);
+  }, [level]);
+
+  useEffect(() => { load(); }, [load]);
+
+  return (
+    <section aria-label="Logs">
+      <div className="flex items-center justify-between mb-2">
+        <h2 className="text-lg font-semibold">Logs</h2>
+        <Button variant="outline" size="sm" onClick={load} aria-label="Refresh logs">
+          <RefreshCw size={14} /> Refresh
+        </Button>
+      </div>
+      <p className="text-sm text-shell-text-tertiary mb-4">
+        Errors and crashes captured from this device, newest first. Use these to chase a bug you hit in an app.
+      </p>
+
+      <div className="flex gap-2 mb-3 flex-wrap" role="group" aria-label="Filter by level">
+        {LEVELS.map((l) => (
+          <Button
+            key={l}
+            variant={level === l ? "secondary" : "outline"}
+            size="sm"
+            onClick={() => setLevel(l)}
+            aria-pressed={level === l}
+          >
+            {l}
+          </Button>
+        ))}
+      </div>
+
+      {loading && <p className="text-sm text-shell-text-tertiary">Loading...</p>}
+
+      {!loading && logs.length === 0 && (
+        <Card className="p-4">
+          <p className="text-sm flex items-center gap-2 text-shell-text-tertiary">
+            <ScrollText size={14} /> No logs captured yet.
+          </p>
+        </Card>
+      )}
+
+      {!loading && logs.length > 0 && (
+        <div className="space-y-2">
+          {logs.map((log) => (
+            <Card key={log.id} className="p-3">
+              <div className="flex items-center justify-between gap-2">
+                <span className={`text-xs font-medium uppercase ${LEVEL_TONE[log.level] ?? ""}`}>
+                  {log.level}
+                </span>
+                <span className="text-xs text-shell-text-tertiary">{formatTime(log.created_at)}</span>
+              </div>
+              <p className="text-sm mt-1 break-words">{log.message}</p>
+              {(log.source || log.url) && (
+                <p className="text-xs text-shell-text-tertiary mt-0.5 truncate">
+                  {[log.source, log.url].filter(Boolean).join(" · ")}
+                </p>
+              )}
+              {log.stack && (
+                <details className="mt-1">
+                  <summary className="text-xs text-shell-text-tertiary cursor-pointer">Stack</summary>
+                  <pre className="text-xs text-shell-text-tertiary mt-1 whitespace-pre-wrap break-words">{log.stack}</pre>
+                </details>
+              )}
+            </Card>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/desktop/src/components/AppErrorBoundary.test.tsx
+++ b/desktop/src/components/AppErrorBoundary.test.tsx
@@ -56,6 +56,24 @@ describe("AppErrorBoundary", () => {
     expect(screen.getByText("Something went wrong.")).toBeInTheDocument();
   });
 
+  it("reports a generic crash to the server (#106)", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 201 }));
+    render(
+      <AppErrorBoundary>
+        <ThrowOnRender error={new Error("crash-report-unique-xyz")} />
+      </AppErrorBoundary>,
+    );
+    const posted = fetchSpy.mock.calls.find(([url]) => url === "/api/client-logs");
+    expect(posted).toBeTruthy();
+    const body = JSON.parse(String((posted![1] as RequestInit)?.body));
+    expect(body.level).toBe("fatal");
+    expect(body.message).toBe("crash-report-unique-xyz");
+    expect(body.source).toBe("AppErrorBoundary");
+  });
+
   it("does not render children after an error is caught", () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
     render(

--- a/desktop/src/components/AppErrorBoundary.tsx
+++ b/desktop/src/components/AppErrorBoundary.tsx
@@ -15,6 +15,7 @@
 import { Component, type ErrorInfo, type ReactNode } from "react";
 import { Loader2, RefreshCw, AlertCircle } from "lucide-react";
 import { BackendUnavailableError } from "@/lib/taos-fetch";
+import { reportClientLog } from "@/lib/client-log";
 
 type Mode = "ok" | "waiting" | "chunk" | "generic";
 
@@ -51,6 +52,14 @@ export class AppErrorBoundary extends Component<Props, State> {
     // Skip the "waiting"/"chunk" modes -- those are expected, handled states.
     if (this.state.mode === "generic") {
       console.error("[AppErrorBoundary]", error, info?.componentStack ?? "");
+      // Also ship it server-side: a PWA user has no console, so this is the only
+      // way the crash becomes visible to us (#106).
+      reportClientLog("fatal", error.message || error.name, {
+        source: "AppErrorBoundary",
+        stack: [error.stack, info?.componentStack]
+          .filter(Boolean)
+          .join("\n--- componentStack ---\n"),
+      });
     }
     if (this.state.mode === "chunk" && !this.reloadTimer) {
       this.reloadTimer = setTimeout(() => window.location.reload(), 5_000);

--- a/desktop/src/lib/client-log.test.ts
+++ b/desktop/src/lib/client-log.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { reportClientLog } from "./client-log";
+
+describe("reportClientLog", () => {
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it("POSTs the log to /api/client-logs", () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 201 }));
+    reportClientLog("error", "boom-unique-1", { source: "Test", stack: "at x" });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe("/api/client-logs");
+    expect((init as RequestInit)?.method).toBe("POST");
+    const body = JSON.parse(String((init as RequestInit)?.body));
+    expect(body.level).toBe("error");
+    expect(body.message).toBe("boom-unique-1");
+    expect(body.source).toBe("Test");
+    expect(body.stack).toBe("at x");
+  });
+
+  it("never throws when fetch rejects", () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network"));
+    expect(() => reportClientLog("error", "boom-unique-2")).not.toThrow();
+  });
+
+  it("drops an empty message", () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 201 }));
+    reportClientLog("error", "   ".trim());
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("dedupes an identical report within the window", () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 201 }));
+    reportClientLog("warn", "dupe-unique-3", { source: "S" });
+    reportClientLog("warn", "dupe-unique-3", { source: "S" });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/desktop/src/lib/client-log.ts
+++ b/desktop/src/lib/client-log.ts
@@ -1,0 +1,71 @@
+/**
+ * Ship browser-side errors and logs to the controller (#106).
+ *
+ * A PWA has no devtools console the user (or we) can read, so a front-end crash
+ * is otherwise invisible. reportClientLog POSTs to /api/client-logs; it is
+ * strictly best-effort and never throws or blocks. installGlobalErrorReporting
+ * wires window.onerror + unhandledrejection so uncaught failures are captured
+ * too. The server bounds storage (ring buffer) and rate-limits per user; a small
+ * client-side dedupe keeps a render loop from hammering the endpoint.
+ */
+import { withCsrf } from "./csrf";
+
+export type ClientLogLevel = "fatal" | "error" | "warn" | "info" | "debug";
+
+const MAX_MESSAGE = 4000;
+const MAX_STACK = 16000;
+const DEDUPE_MS = 3000;
+const recent = new Map<string, number>();
+
+export function reportClientLog(
+  level: ClientLogLevel,
+  message: string,
+  extra?: { source?: string; stack?: string; url?: string },
+): void {
+  try {
+    const msg = String(message ?? "").slice(0, MAX_MESSAGE);
+    if (!msg) return;
+    const source = extra?.source ?? "";
+    const key = `${level}:${source}:${msg}`;
+    const now = Date.now();
+    const last = recent.get(key);
+    if (last !== undefined && now - last < DEDUPE_MS) return;
+    if (recent.size > 100) recent.clear();
+    recent.set(key, now);
+
+    const body = JSON.stringify({
+      level,
+      message: msg,
+      source,
+      url: extra?.url ?? (typeof location !== "undefined" ? location.pathname : ""),
+      stack: (extra?.stack ?? "").slice(0, MAX_STACK),
+    });
+    const init = withCsrf({
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body,
+    });
+    void fetch("/api/client-logs", init).catch(() => {});
+  } catch {
+    // Logging must never break the app.
+  }
+}
+
+let installed = false;
+
+export function installGlobalErrorReporting(): void {
+  if (installed || typeof window === "undefined") return;
+  installed = true;
+  window.addEventListener("error", (e) => {
+    reportClientLog("error", e.message || "window.onerror", {
+      source: e.filename || "window.error",
+      stack: e.error?.stack,
+    });
+  });
+  window.addEventListener("unhandledrejection", (e) => {
+    const reason = (e as PromiseRejectionEvent).reason;
+    const message = reason?.message ?? String(reason ?? "unhandledrejection");
+    reportClientLog("error", message, { source: "unhandledrejection", stack: reason?.stack });
+  });
+}

--- a/desktop/src/main.tsx
+++ b/desktop/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { App } from "./App";
 import { AppShell } from "./components/AppShell";
 import { installAuthGuard } from "./lib/auth-guard";
+import { installGlobalErrorReporting } from "./lib/client-log";
 import "./theme/tokens.css";
 
 // Wrap window.fetch so any 401 from /api/* triggers a session-expired
@@ -10,6 +11,10 @@ import "./theme/tokens.css";
 // a stale cookie (e.g. after a controller reinstall) left the SPA
 // rendering empty data instead of prompting for re-login.
 installAuthGuard();
+
+// Ship uncaught errors + rejections to the controller so a PWA crash is
+// diagnosable server-side (a PWA has no console the user can open).
+installGlobalErrorReporting();
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>


### PR DESCRIPTION
## What
The front-end half of #106: the desktop now ships browser-side errors to the controller so a PWA crash (where no one can open a console) is captured server-side.

- `lib/client-log.ts`: `reportClientLog(level, message, extra)` -- best-effort (never throws/blocks), CSRF-aware via withCsrf, length-capped, with a short client-side dedupe so a render loop does not hammer the endpoint (the server also rate-limits per user). `installGlobalErrorReporting()` hooks `window.onerror` + `unhandledrejection`.
- `main.tsx`: installs the global handlers at startup (next to installAuthGuard).
- `AppErrorBoundary`: the generic-crash branch now also reports the error + componentStack as level `fatal` (in addition to console.error).

## Why
Jay: a PWA has no console the user or we can read. This is the capture loop on top of the backend store/endpoint (#1436) -- once both land and the Pi updates, a crash like the Messages app failure records itself and is readable via GET /api/client-logs.

## Tests
client-log: posts to /api/client-logs, never throws on fetch reject, drops empty message, dedupes within window. AppErrorBoundary: a generic crash posts a level-fatal report. 11/11 green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Logs section in Settings to view captured client logs.
  * Added log filtering by severity, refresh controls, and expanded details for messages, timestamps, sources, and stack traces.

* **Bug Fixes**
  * Improved handling of app crashes and unhandled errors by sending fatal logs for better troubleshooting.
  * Added safeguards so logging is best-effort and won’t interrupt normal app use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->