### PR TITLE
fix(logging): rowid tie-breaker for client-log ring buffer (#137)

### DIFF
--- a/tests/test_client_log_store.py
+++ b/tests/test_client_log_store.py
@@ -57,3 +57,21 @@ async def test_ring_buffer_caps_total_rows(store, monkeypatch):
     msgs = [i["message"] for i in items]
     assert "m5" in msgs
     assert "m0" not in msgs
+
+
+@pytest.mark.asyncio
+async def test_prune_and_order_use_rowid_when_timestamps_tie(store, monkeypatch):
+    monkeypatch.setattr("tinyagentos.client_log_store.MAX_ROWS", 3)
+    for i in range(5):
+        await store.create(user_id="u1", level="debug", message=f"m{i}")
+    # Force m0..m4 to share one created_at so the timestamp cannot disambiguate
+    # them; only the rowid tie-breaker keeps the prune + ordering deterministic.
+    await store._db.execute(
+        "UPDATE client_logs SET created_at = '2026-01-01T00:00:00+00:00'")
+    await store._db.commit()
+    # This 6th insert triggers the prune; a rowid-based ring buffer must keep the
+    # last-inserted three (m3, m4, m5), not an arbitrary trio of the tied rows.
+    await store.create(user_id="u1", level="debug", message="m5")
+    msgs = [i["message"] for i in await store.list_recent(limit=100)]
+    assert len(msgs) == 3
+    assert msgs == ["m5", "m4", "m3"]

--- a/tinyagentos/client_log_store.py
+++ b/tinyagentos/client_log_store.py
@@ -88,13 +88,14 @@ class ClientLogStore(BaseStore):
                 row["created_at"],
             ),
         )
-        # Ring-buffer prune: drop everything older than the newest MAX_ROWS.
+        # Ring-buffer prune: keep only the most recently inserted MAX_ROWS rows.
+        # Retain by rowid (monotonic insert order), not created_at: the timestamp
+        # is a coarse ISO string, so same-microsecond rows under a crash loop tie
+        # and make the prune non-deterministic. rowid is the indexed primary key,
+        # so this also avoids the per-insert full-table NOT IN scan.
         await self._db.execute(
-            """
-            DELETE FROM client_logs WHERE id NOT IN (
-                SELECT id FROM client_logs ORDER BY created_at DESC LIMIT ?
-            )
-            """,
+            "DELETE FROM client_logs WHERE rowid <= "
+            "(SELECT MAX(rowid) FROM client_logs) - ?",
             (MAX_ROWS,),
         )
         await self._db.commit()
@@ -110,12 +111,12 @@ class ClientLogStore(BaseStore):
         if level:
             cursor = await self._db.execute(
                 f"SELECT {cols} FROM client_logs WHERE level = ? "
-                "ORDER BY created_at DESC LIMIT ?",
+                "ORDER BY created_at DESC, rowid DESC LIMIT ?",
                 (level, limit),
             )
         else:
             cursor = await self._db.execute(
-                f"SELECT {cols} FROM client_logs ORDER BY created_at DESC LIMIT ?",
+                f"SELECT {cols} FROM client_logs ORDER BY created_at DESC, rowid DESC LIMIT ?",
                 (limit,),
             )
         rows = await cursor.fetchall()


### PR DESCRIPTION
## What
Fix-forward of the gitar Edge-Case on the merged #1436: `client_log_store` used `created_at` (a coarse ISO string) as the sole sort key for both list ordering and the ring-buffer prune. Same-microsecond rows (a crash loop) tie, making the prune non-deterministic (an arbitrary trio survives) and the list order unstable.

## Fix
- list_recent: `ORDER BY created_at DESC, rowid DESC` -- rowid (monotonic insert order) breaks ties deterministically.
- prune: `DELETE WHERE rowid <= (SELECT MAX(rowid)) - MAX_ROWS` -- keeps the last-inserted MAX_ROWS deterministically, via the indexed rowid PK. This also folds the deferred gitar Performance nit (no more per-insert full-table NOT IN scan).

## Tests
New: insert 5 rows, force a shared created_at, then a 6th insert -- asserts the last-inserted three survive in rowid order (proves rowid, not created_at, drives prune + ordering under ties). Full client-log store + route suites green (12).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log retention so the newest entries are kept consistently, even when multiple logs share the same timestamp.
  * Recent logs now appear in a more predictable order, making the log view more reliable during fast or repeated updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->