### PR TITLE
feat(account): default account base URL to taos.my (core feature)

### DIFF
--- a/tests/test_routes_account_proxy.py
+++ b/tests/test_routes_account_proxy.py
@@ -26,11 +26,24 @@ class _FakeResp:
 
 
 @pytest.mark.asyncio
-async def test_account_me_503_when_unconfigured(client, monkeypatch):
-    monkeypatch.delenv("TAOS_ACCOUNT_BASE_URL", raising=False)
+async def test_account_me_503_when_explicitly_blanked(client, monkeypatch):
+    # An explicit blank override disables the proxy (the dev/off-taos.my state).
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "")
     r = await client.get("/api/account/me")
     assert r.status_code == 503
     assert "not configured" in r.json().get("error", "")
+
+
+def test_base_url_defaults_to_taos_my(monkeypatch):
+    from tinyagentos.routes.account_proxy import _base_url
+    # Unset (the normal instance) uses the production account service.
+    monkeypatch.delenv("TAOS_ACCOUNT_BASE_URL", raising=False)
+    assert _base_url() == "https://taos.my"
+    # An explicit blank disables it; a real override is honored (trailing / trimmed).
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "")
+    assert _base_url() is None
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "https://staging.taos.my/")
+    assert _base_url() == "https://staging.taos.my"
 
 
 @pytest.mark.asyncio
@@ -215,7 +228,8 @@ async def test_cluster_join_rejects_bad_request_id(client, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_cluster_join_503_when_unconfigured(client, monkeypatch):
-    monkeypatch.delenv("TAOS_ACCOUNT_BASE_URL", raising=False)
+async def test_cluster_join_503_when_explicitly_blanked(client, monkeypatch):
+    # Unset now defaults to taos.my; an explicit blank disables the proxy (503).
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "")
     r = await client.get("/api/account/cluster/join/requests")
     assert r.status_code == 503

--- a/tinyagentos/routes/account_proxy.py
+++ b/tinyagentos/routes/account_proxy.py
@@ -5,8 +5,9 @@ The taOS client (Settings > Account, the off-network screen) calls same-origin
 We forward to {TAOS_ACCOUNT_BASE_URL}/api/auth/* with cookie pass-through both
 ways, so the taos.my session cookie round-trips through this host origin.
 
-If TAOS_ACCOUNT_BASE_URL is unset the proxy returns 503 and the Account pane
-renders its 'service unavailable' state, so the client ships ahead of taos.my.
+The taOS online account is a core feature for every instance, so the base URL
+defaults to https://taos.my; TAOS_ACCOUNT_BASE_URL stays an override for local or
+staging testing. (A blank override still yields a 503 'service unavailable'.)
 """
 from __future__ import annotations
 
@@ -31,9 +32,20 @@ _ACTIONS: dict[str, tuple[str, str]] = {
 _TIMEOUT = httpx.Timeout(15.0)
 
 
+# The taOS online account lives at taos.my for every instance; it is a core
+# product feature, not per-deployment config. Default to it; the env var is an
+# override for local/staging only.
+_DEFAULT_ACCOUNT_BASE_URL = "https://taos.my"
+
+
 def _base_url() -> str | None:
-    base = os.environ.get("TAOS_ACCOUNT_BASE_URL", "").strip()
-    return base.rstrip("/") or None
+    raw = os.environ.get("TAOS_ACCOUNT_BASE_URL")
+    if raw is None:
+        # Unset: use the production account service. This is the normal path.
+        return _DEFAULT_ACCOUNT_BASE_URL
+    # An explicit (possibly blank) override: blank disables the proxy (503),
+    # which dev/test use to exercise the unavailable state.
+    return raw.strip().rstrip("/") or None
 
 
 def _trust_forwarded_proto() -> bool:


### PR DESCRIPTION
## What
The account proxy now defaults to `https://taos.my` when `TAOS_ACCOUNT_BASE_URL` is unset, instead of returning 503. The online account is a core taOS feature for everyone, not per-deployment config. The env var stays an override for local/staging; an explicit blank still disables the proxy (the dev / off-taos.my state).

## Why
Jay: the account base should be hardcoded, the online account is core for everyone. On stock instances the var was never set, so the Account pane showed 'service not reachable' (the screenshot). website-dev confirmed taos.my is already live on Coolify, so defaulting to it makes accounts work out of the box.

## Note
Audited the proxy against website-dev's CSRF constraint (must not send a browser Origin on proxied POSTs): the proxy builds a fresh header set (Cookie + Content-Type only), so it already complies, no change needed.

## Tests
Updated the two 503-when-unset tests to use an explicit blank (the new disable path); added a _base_url default/override/disable unit test. Full account_proxy suite green.