### PR TITLE
fix(frameworks): show Hermes as beta in the Deploy Agent wizard

### DIFF
--- a/tinyagentos/adapters/__init__.py
+++ b/tinyagentos/adapters/__init__.py
@@ -52,8 +52,8 @@ _REGISTRY: list[dict] = [
     {
         "id": "hermes",
         "name": "Hermes",
-        "description": "Hermes OpenAI-compatible API bridge (bridge wiring not yet complete)",
-        "verification_status": "alpha",
+        "description": "Hermes Agent Gateway (NousResearch) bridge over the OpenAI-compatible API",
+        "verification_status": "beta",
     },
     {
         "id": "deer-flow",


### PR DESCRIPTION
## Problem
The Deploy Agent wizard's Framework step showed only OpenClaw (Beta); Hermes was missing entirely, even after updating and reloading the Pi/PWA.

## Root cause
The wizard fetches `GET /api/frameworks`, which returns the adapter registry in `tinyagentos/adapters/__init__.py` (`_REGISTRY`), NOT the `frameworks.py` catalog. In that registry Hermes was `verification_status: "alpha"`, and the wizard hides alpha frameworks unless 'Show experimental' is ticked. OpenClaw was `beta`, so only it appeared. (The two registries had drifted: `frameworks.py` already marked Hermes beta, but that file does not back this endpoint.)

## Fix
Promote Hermes to `beta` in the adapter registry and refresh its stale description ("bridge wiring not yet complete" predates Hermes running in LXC on the Pi). DeployWizard already ranks Hermes 0 / OpenClaw 1, so the wizard now lists Hermes (Beta) first, then OpenClaw (Beta), by default with no toggle.

## Verification
- `tests/test_routes_frameworks.py` + `tests/test_frameworks.py`: 50 passed. `test_frameworks_at_least_one_alpha` still satisfied by the remaining alpha adapters; `test_frameworks_openclaw_is_beta` unaffected.

Closes the live deploy-wizard bug Jay reported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Hermes adapter’s displayed description to better reflect its integration and changed its status from **alpha** to **beta**.
  * The updated adapter details now appear in framework listings, so users will see the revised information when browsing available options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->