### PR TITLE
feat(messages): group agent DMs into Live / Suspended / Archived sections

### DIFF
--- a/desktop/src/apps/MessagesApp.agentSections.test.ts
+++ b/desktop/src/apps/MessagesApp.agentSections.test.ts
@@ -43,15 +43,30 @@ describe("bucketAgentChannels", () => {
     expect(result.suspended).toEqual([]);
   });
 
-  it("puts an orphaned DM (matches no agent in either list) under Archived", () => {
+  it("puts an orphaned DM (matches no loaded agent in either list) under Archived", () => {
     // This is the deleted-agent case: the agent is gone from /api/agents and
-    // /api/agents/archived, but its DM channel lingers. It must never appear
-    // as Live.
+    // /api/agents/archived, but its DM channel lingers. With a known agent
+    // present (lists loaded), the unmatched DM is a real orphan and must never
+    // appear as Live.
     const channels = [dm("ghost")];
-    const result = bucketAgentChannels(channels, [], []);
+    const live: AgentSectionLiveAgent[] = [{ name: "hermes", status: "running" }];
+    const result = bucketAgentChannels(channels, live, []);
     expect(result.archived.map((c) => c.name)).toEqual(["ghost"]);
-    expect(result.live).toEqual([]);
+    expect(result.live.map((c) => c.name)).toEqual([]);
     expect(result.suspended).toEqual([]);
+    expect(result.nonAgent).toEqual([]);
+  });
+
+  it("does NOT archive agent DMs while both lists are empty (not yet loaded)", () => {
+    // On first render /api/agents and /api/agents/archived have not resolved
+    // yet, so every agent DM matches nothing. These are almost certainly live
+    // agents and must not be dumped into Archived until the lists load -- they
+    // stay in their existing (nonAgent) Direct Messages placement.
+    const channels = [dm("hermes"), dm("scout")];
+    const result = bucketAgentChannels(channels, [], []);
+    expect(result.archived).toEqual([]);
+    expect(result.live).toEqual([]);
+    expect(result.nonAgent.map((c) => c.name)).toEqual(["hermes", "scout"]);
   });
 
   it("treats a non-running, non-paused live status (e.g. failed) as Archived", () => {

--- a/desktop/src/apps/MessagesApp.agentSections.test.ts
+++ b/desktop/src/apps/MessagesApp.agentSections.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import {
+  bucketAgentChannels,
+  type AgentSectionChannel,
+  type AgentSectionLiveAgent,
+  type AgentSectionArchivedAgent,
+} from "./MessagesApp.agentSections";
+
+const dm = (
+  name: string,
+  extra: Partial<AgentSectionChannel> = {},
+): AgentSectionChannel => ({
+  name,
+  members: ["user", name],
+  ...extra,
+});
+
+describe("bucketAgentChannels", () => {
+  it("puts running agents under Live", () => {
+    const channels = [dm("hermes")];
+    const live: AgentSectionLiveAgent[] = [{ name: "hermes", status: "running" }];
+    const result = bucketAgentChannels(channels, live, []);
+    expect(result.live.map((c) => c.name)).toEqual(["hermes"]);
+    expect(result.suspended).toEqual([]);
+    expect(result.archived).toEqual([]);
+  });
+
+  it("puts paused agents under Suspended", () => {
+    const channels = [dm("scout")];
+    const live: AgentSectionLiveAgent[] = [{ name: "scout", status: "paused" }];
+    const result = bucketAgentChannels(channels, live, []);
+    expect(result.suspended.map((c) => c.name)).toEqual(["scout"]);
+    expect(result.live).toEqual([]);
+    expect(result.archived).toEqual([]);
+  });
+
+  it("puts archived-list agents under Archived", () => {
+    const channels = [dm("oldbot")];
+    const archived: AgentSectionArchivedAgent[] = [{ archived_slug: "oldbot" }];
+    const result = bucketAgentChannels(channels, [], archived);
+    expect(result.archived.map((c) => c.name)).toEqual(["oldbot"]);
+    expect(result.live).toEqual([]);
+    expect(result.suspended).toEqual([]);
+  });
+
+  it("puts an orphaned DM (matches no agent in either list) under Archived", () => {
+    // This is the deleted-agent case: the agent is gone from /api/agents and
+    // /api/agents/archived, but its DM channel lingers. It must never appear
+    // as Live.
+    const channels = [dm("ghost")];
+    const result = bucketAgentChannels(channels, [], []);
+    expect(result.archived.map((c) => c.name)).toEqual(["ghost"]);
+    expect(result.live).toEqual([]);
+    expect(result.suspended).toEqual([]);
+  });
+
+  it("treats a non-running, non-paused live status (e.g. failed) as Archived", () => {
+    const channels = [dm("brokenbot")];
+    const live: AgentSectionLiveAgent[] = [{ name: "brokenbot", status: "failed" }];
+    const result = bucketAgentChannels(channels, live, []);
+    expect(result.archived.map((c) => c.name)).toEqual(["brokenbot"]);
+    expect(result.live).toEqual([]);
+  });
+
+  it("matches a channel against an agent by display name", () => {
+    // Channel names use the agent display_name while /api/agents reports a slug.
+    const channels = [dm("Hermes Confirm", { members: ["user", "hermes-confirm"] })];
+    const live: AgentSectionLiveAgent[] = [
+      { name: "hermes-confirm", display_name: "Hermes Confirm", status: "running" },
+    ];
+    const result = bucketAgentChannels(channels, live, []);
+    expect(result.live.map((c) => c.name)).toEqual(["Hermes Confirm"]);
+  });
+
+  it("matches a channel against an agent by its non-user member", () => {
+    const channels = [dm("Display Only", { members: ["user", "agent-slug"] })];
+    const live: AgentSectionLiveAgent[] = [{ name: "agent-slug", status: "running" }];
+    const result = bucketAgentChannels(channels, live, []);
+    expect(result.live.map((c) => c.name)).toEqual(["Display Only"]);
+  });
+
+  it("keeps a2a coordination channels under nonAgent", () => {
+    const channels = [dm("coord", { settings: { kind: "a2a" } })];
+    const result = bucketAgentChannels(channels, [], []);
+    expect(result.nonAgent.map((c) => c.name)).toEqual(["coord"]);
+    expect(result.archived).toEqual([]);
+  });
+
+  it("keeps a plain user DM (no agent member) under nonAgent", () => {
+    const channels = [{ name: "alice", members: ["user"] }];
+    const result = bucketAgentChannels(channels, [], []);
+    expect(result.nonAgent.map((c) => c.name)).toEqual(["alice"]);
+    expect(result.archived).toEqual([]);
+  });
+
+  it("buckets a mixed list across all sections", () => {
+    const channels = [
+      dm("live-one"),
+      dm("paused-one"),
+      dm("archived-one"),
+      dm("orphan-one"),
+      dm("coord", { settings: { kind: "a2a" } }),
+    ];
+    const live: AgentSectionLiveAgent[] = [
+      { name: "live-one", status: "running" },
+      { name: "paused-one", status: "paused" },
+    ];
+    const archived: AgentSectionArchivedAgent[] = [{ archived_slug: "archived-one" }];
+    const result = bucketAgentChannels(channels, live, archived);
+    expect(result.live.map((c) => c.name)).toEqual(["live-one"]);
+    expect(result.suspended.map((c) => c.name)).toEqual(["paused-one"]);
+    expect(result.archived.map((c) => c.name).sort()).toEqual(["archived-one", "orphan-one"]);
+    expect(result.nonAgent.map((c) => c.name)).toEqual(["coord"]);
+  });
+});

--- a/desktop/src/apps/MessagesApp.agentSections.ts
+++ b/desktop/src/apps/MessagesApp.agentSections.ts
@@ -1,0 +1,123 @@
+/**
+ * Lifecycle bucketing for agent DM channels in the Messages app.
+ *
+ * Agent DM channels are matched to an agent by name: the channel `name`
+ * (or its non-"user" member) equals the agent's name or display name. Each
+ * agent DM is sorted into one of three lifecycle buckets so live,
+ * suspended, and archived/deleted agents are visually separated in the
+ * channel list:
+ *
+ *   - "live"      -- agent present in /api/agents with status "running"
+ *   - "suspended" -- agent present in /api/agents with status "paused"
+ *   - "archived"  -- agent present in /api/agents/archived, OR an agent DM
+ *                   channel that matches no agent in either list (an
+ *                   orphaned / deleted-agent channel). Any other non-running,
+ *                   non-paused live status (e.g. "failed") also falls here.
+ *
+ * A DM channel is treated as an "agent DM" when it has a non-"user" member
+ * (the agent), or its kind marks it as one. Plain user-to-user DMs (no
+ * agent member) and a2a coordination channels are returned untouched under
+ * `nonAgent` and keep their existing placement.
+ *
+ * Pure function -- no side effects -- so it can be unit tested in isolation.
+ */
+
+export interface AgentSectionChannel {
+  name: string;
+  members?: string[];
+  settings?: { kind?: string };
+}
+
+export interface AgentSectionLiveAgent {
+  name: string;
+  display_name?: string;
+  status?: string;
+}
+
+export interface AgentSectionArchivedAgent {
+  archived_slug?: string;
+  original?: { name?: string; display_name?: string };
+}
+
+export interface AgentSections<C> {
+  live: C[];
+  suspended: C[];
+  archived: C[];
+  nonAgent: C[];
+}
+
+/** The agent identity a DM channel points at: its name or its non-"user" member. */
+function channelAgentKeys<C extends AgentSectionChannel>(ch: C): string[] {
+  const keys = [ch.name];
+  const member = (ch.members ?? []).find((m) => m !== "user");
+  if (member) keys.push(member);
+  return keys;
+}
+
+/**
+ * Bucket a list of DM channels into lifecycle sections.
+ *
+ * @param dmChannels  DM-type channels for the current sidebar scope.
+ * @param liveAgents  Agents from /api/agents (each may carry a `status`).
+ * @param archivedAgents  Agents from /api/agents/archived.
+ */
+export function bucketAgentChannels<C extends AgentSectionChannel>(
+  dmChannels: C[],
+  liveAgents: AgentSectionLiveAgent[],
+  archivedAgents: AgentSectionArchivedAgent[],
+): AgentSections<C> {
+  // Index live agents by every name a channel might match on.
+  const liveByKey = new Map<string, AgentSectionLiveAgent>();
+  for (const a of liveAgents) {
+    liveByKey.set(a.name, a);
+    if (a.display_name) liveByKey.set(a.display_name, a);
+  }
+
+  const archivedKeys = new Set<string>();
+  for (const a of archivedAgents) {
+    if (a.archived_slug) archivedKeys.add(a.archived_slug);
+    if (a.original?.name) archivedKeys.add(a.original.name);
+    if (a.original?.display_name) archivedKeys.add(a.original.display_name);
+  }
+
+  const sections: AgentSections<C> = {
+    live: [],
+    suspended: [],
+    archived: [],
+    nonAgent: [],
+  };
+
+  for (const ch of dmChannels) {
+    // a2a coordination channels are not agent DMs -- leave them in place.
+    if (ch.settings?.kind === "a2a") {
+      sections.nonAgent.push(ch);
+      continue;
+    }
+
+    const keys = channelAgentKeys(ch);
+    const hasAgentMember = (ch.members ?? []).some((m) => m !== "user");
+
+    const liveAgent = keys.map((k) => liveByKey.get(k)).find(Boolean);
+    if (liveAgent) {
+      if (liveAgent.status === "running") sections.live.push(ch);
+      else if (liveAgent.status === "paused") sections.suspended.push(ch);
+      // Any other live status (e.g. "failed") is treated as not-live and
+      // grouped under Archived rather than shown as Live.
+      else sections.archived.push(ch);
+      continue;
+    }
+
+    if (keys.some((k) => archivedKeys.has(k))) {
+      sections.archived.push(ch);
+      continue;
+    }
+
+    // A DM with an agent member that matches no known agent is an orphaned /
+    // deleted-agent channel -- it belongs under Archived, never Live. A DM
+    // with no agent member is a plain user DM and keeps its placement.
+    if (hasAgentMember) sections.archived.push(ch);
+    else sections.nonAgent.push(ch);
+  }
+
+  return sections;
+}

--- a/desktop/src/apps/MessagesApp.agentSections.ts
+++ b/desktop/src/apps/MessagesApp.agentSections.ts
@@ -87,6 +87,12 @@ export function bucketAgentChannels<C extends AgentSectionChannel>(
     nonAgent: [],
   };
 
+  // Until at least one agent list has loaded we cannot tell a live agent DM
+  // from an orphaned one, so a member-without-match must NOT be archived yet.
+  // While both lists are empty, treat unmatched agent DMs as non-archived
+  // (they keep their Direct Messages placement) and re-bucket once data loads.
+  const listsLoaded = liveAgents.length > 0 || archivedAgents.length > 0;
+
   for (const ch of dmChannels) {
     // a2a coordination channels are not agent DMs -- leave them in place.
     if (ch.settings?.kind === "a2a") {
@@ -113,9 +119,11 @@ export function bucketAgentChannels<C extends AgentSectionChannel>(
     }
 
     // A DM with an agent member that matches no known agent is an orphaned /
-    // deleted-agent channel -- it belongs under Archived, never Live. A DM
-    // with no agent member is a plain user DM and keeps its placement.
-    if (hasAgentMember) sections.archived.push(ch);
+    // deleted-agent channel -- it belongs under Archived, never Live. But
+    // only once the agent lists have loaded; before that, an unmatched agent
+    // DM is almost certainly live and must stay non-archived. A DM with no
+    // agent member is a plain user DM and keeps its placement.
+    if (hasAgentMember && listsLoaded) sections.archived.push(ch);
     else sections.nonAgent.push(ch);
   }
 

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -16,6 +16,8 @@ import {
   ChevronDown,
   PanelRight,
   Archive,
+  CircleDot,
+  PauseCircle,
   Trash2,
   RotateCcw,
   MessagesSquare,
@@ -72,6 +74,7 @@ import {
   readLastChannel,
   writeLastChannel,
 } from "./MessagesApp.a2aSelection";
+import { bucketAgentChannels } from "./MessagesApp.agentSections";
 import { displayAuthor } from "./chat/format-author";
 import { useProcessStore } from "@/stores/process-store";
 import { getApp } from "@/registry/app-registry";
@@ -1410,6 +1413,11 @@ export function MessagesApp({
     group: channels.filter((c) => c.type === "group" && inSidebarSection(c)),
   };
 
+  // Split DM channels into agent lifecycle buckets (Live / Suspended /
+  // Archived) so deleted-agent DMs no longer mix in with live ones. Plain
+  // user DMs and a2a channels stay under nonAgent (their original placement).
+  const dmSections = bucketAgentChannels(grouped.dm, liveAgents, archivedAgents);
+
   const allChannels = [...channels, ...archivedChannels];
   const currentChannel = allChannels.find((c) => c.id === selectedChannel);
   const isCurrentArchived = currentChannel?.settings?.archived === true;
@@ -1477,11 +1485,18 @@ export function MessagesApp({
   /*  Sections definition (shared between mobile + desktop lists)     */
   /* ---------------------------------------------------------------- */
 
+  // Agent DMs are grouped by lifecycle so live, suspended, and
+  // archived/deleted agents are visually separated. Empty buckets are
+  // omitted so the list stays compact. Plain user DMs and a2a channels
+  // (nonAgent) keep their original "Direct Messages" placement.
   const SECTIONS = [
-    { label: "Direct Messages", icon: <AtSign size={13} />, items: grouped.dm },
+    { label: "Live", icon: <CircleDot size={13} />, items: dmSections.live },
+    { label: "Suspended", icon: <PauseCircle size={13} />, items: dmSections.suspended },
+    { label: "Archived Agents", icon: <Archive size={13} />, items: dmSections.archived },
+    { label: "Direct Messages", icon: <AtSign size={13} />, items: dmSections.nonAgent },
     { label: "Topics", icon: <Hash size={13} />, items: grouped.topic },
     { label: "Groups", icon: <Users size={13} />, items: grouped.group },
-  ];
+  ].filter((s) => s.items.length > 0 || s.label === "Topics" || s.label === "Groups");
 
   const allEmpty =
     channelsLoaded &&


### PR DESCRIPTION
## What

Groups the Messages app agent DM list into lifecycle **sections** so live, suspended, and archived/deleted agents are visually separated. Fixes the confusion where deleted-agent DM channels appeared mixed in with live ones.

## How

- Each DM channel is resolved to an agent by name (channel name or its non-`user` member, matched against the agent `name`/`display_name`) and bucketed:
  - **Live** — agent in `/api/agents` with status `running`
  - **Suspended** — agent in `/api/agents` with status `paused`
  - **Archived Agents** — agent in `/api/agents/archived`, OR a DM with an agent member that matches no known agent (an orphaned / deleted-agent channel). Any other non-running, non-paused status (e.g. `failed`) also lands here, never under Live.
- Plain user-to-user DMs (no agent member) and a2a coordination channels keep their existing **Direct Messages** placement.
- Empty lifecycle sections are omitted (no header).
- Bucketing logic is extracted into a pure, unit-testable helper `MessagesApp.agentSections.ts`, mirroring the existing `MessagesApp.a2aSelection.ts` pattern.
- Read-only grouping only: no hard-delete control added (respects "nothing is truly deleted"; hard delete is a separate task).

## Styling

Section headers reuse the existing `SECTIONS` render path verbatim, so the small uppercase labels stay theme-aware (dark/light/indigo) with no new hardcoded colors. New icons (`CircleDot`, `PauseCircle`, `Archive`) inherit `currentColor`.

## Tests

`MessagesApp.agentSections.test.ts` — 10 cases covering running→Live, paused→Suspended, archived-list→Archived, orphan-channel→Archived, failed-status→Archived, display-name and member matching, a2a/plain-DM staying under nonAgent, and a mixed-list spread.

\`\`\`
npx vitest run src/apps/MessagesApp.agentSections.test.ts  ->  10 passed
\`\`\`

Full `desktop/src/apps` suite stays green (646 passed). Touched files typecheck clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Messages now groups agent-related direct messages into separate sidebar sections for live, suspended, and archived agents.
  * Plain direct messages remain in their own section, with empty agent sections hidden automatically.

* **Tests**
  * Added coverage for message grouping to verify agent and non-agent channels are placed in the correct section, including mixed and edge-case scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->