### PR TITLE
feat(deploy): framework-aware prebuilt base image (Hermes fast-path)

### DIFF
--- a/.github/workflows/build-agent-images.yml
+++ b/.github/workflows/build-agent-images.yml
@@ -5,6 +5,7 @@ on:
     branches: [master, fix/agent-creation-flow]
     paths:
       - 'app-catalog/agents/openclaw/**'
+      - 'tinyagentos/scripts/install_hermes.sh'
       - '.github/workflows/build-agent-images.yml'
   repository_dispatch:
     types: [openclaw-fork-published]
@@ -21,14 +22,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Two list dimensions form the cross-product (3 bases x 2 arches = 6
+        # jobs). base: which framework prerequisites to bake on top of the
+        # common deps. "openclaw" keeps its historical alias for back-compat;
+        # "generic" is taos-base (common deps only) for any framework;
+        # "hermes" adds the NousResearch hermes-agent prerequisites.
+        base: [openclaw, generic, hermes]
+        arch: [x64, arm64]
+        # include maps each arch to its runner without adding extra jobs
+        # (the keys here already exist as a matrix dimension).
         include:
-          - runner: ubuntu-latest
-            arch: x64
+          - arch: x64
+            runner: ubuntu-latest
             debarch: amd64
-          - runner: ubuntu-24.04-arm
-            arch: arm64
+          - arch: arm64
+            runner: ubuntu-24.04-arm
             debarch: arm64
     runs-on: ${{ matrix.runner }}
+    env:
+      # Map the "openclaw"/"generic"/"hermes" base label to its published alias.
+      ALIAS: ${{ matrix.base == 'openclaw' && 'taos-openclaw-base' || (matrix.base == 'generic' && 'taos-base' || 'taos-hermes-base') }}
     steps:
       - uses: actions/checkout@v7
 
@@ -76,11 +89,9 @@ jobs:
           sudo incus exec build-base -- ip route || true
           sudo iptables -L FORWARD -n -v | head -20 || true
 
-      - name: Install dependencies + openclaw inside the base container
-        env:
-          ARCH: ${{ matrix.arch }}
+      - name: Install common dependencies inside the base container
         run: |
-          sudo incus exec build-base --env ARCH="$ARCH" -- bash -eux <<'BASH'
+          sudo incus exec build-base -- bash -eux <<'BASH'
           export DEBIAN_FRONTEND=noninteractive
           apt-get update -qq
           apt-get install -y -qq --no-install-recommends \
@@ -92,6 +103,16 @@ jobs:
           curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
           apt-get install -y -qq --no-install-recommends nodejs
 
+          # Recycle-bin scaffolding (install.sh Layer 1).
+          mkdir -p /var/recycle-bin/files /var/recycle-bin/info
+          chmod 1777 /var/recycle-bin /var/recycle-bin/files /var/recycle-bin/info
+          BASH
+
+      - name: Bake openclaw into the base container
+        if: matrix.base == 'openclaw'
+        run: |
+          sudo incus exec build-base -- bash -eux <<'BASH'
+          export DEBIAN_FRONTEND=noninteractive
           # Upstream OpenClaw from npm (latest) — no fork. The deploy-time
           # install.sh also installs openclaw@latest, so this just warms the
           # base image with a current build.
@@ -100,12 +121,47 @@ jobs:
           # Sanity check
           test -f /usr/lib/node_modules/openclaw/dist/entry.js \
             || test -f /usr/lib/node_modules/openclaw/dist/entry.mjs
+          BASH
 
-          # Recycle-bin scaffolding (install.sh Layer 1).
-          mkdir -p /var/recycle-bin/files /var/recycle-bin/info
-          chmod 1777 /var/recycle-bin /var/recycle-bin/files /var/recycle-bin/info
+      - name: Bake Hermes prerequisites into the base container
+        if: matrix.base == 'hermes'
+        run: |
+          # Mirrors the heavy, agent-independent steps in
+          # tinyagentos/scripts/install_hermes.sh (uv, the NousResearch
+          # hermes-agent installer with --skip-setup, and the pyyaml/httpx
+          # deps the config patch needs). Per-agent config (.env, config.yaml,
+          # systemd unit, bridge) stays at deploy time -- only prerequisites
+          # are baked so a hermes deploy from this image needs no live install.
+          sudo incus exec build-base -- bash -eux <<'BASH'
+          export DEBIAN_FRONTEND=noninteractive
+          export PATH="/root/.local/bin:$PATH"
 
-          # Shrink the image footprint.
+          # uv (idempotent), matching install_hermes.sh.
+          if ! command -v uv >/dev/null 2>&1 && [ ! -x /root/.local/bin/uv ]; then
+            curl -LsSf https://astral.sh/uv/install.sh | sh
+          fi
+          echo 'export PATH="/root/.local/bin:$PATH"' >> /root/.bashrc
+
+          # NousResearch hermes-agent prerequisites (no setup; config is per-agent).
+          curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh \
+            | bash -s -- --skip-setup
+
+          # Deps the deploy-time config patch step relies on.
+          pip3 install --break-system-packages --quiet pyyaml httpx
+
+          # Sanity check: the hermes binary must be resolvable.
+          HERMES_BIN=""
+          for c in /root/.local/bin/hermes /root/.hermes/hermes-agent/.venv/bin/hermes /root/.hermes/hermes-agent/venv/bin/hermes; do
+            [ -L "$c" -o -x "$c" ] && HERMES_BIN="$c" && break
+          done
+          [ -z "$HERMES_BIN" ] && HERMES_BIN=$(command -v hermes || true)
+          [ -z "$HERMES_BIN" ] && { echo "ERROR: hermes binary not found after bake"; exit 2; }
+          echo "hermes baked at $HERMES_BIN"
+          BASH
+
+      - name: Shrink the image footprint
+        run: |
+          sudo incus exec build-base -- bash -eux <<'BASH'
           apt-get clean
           rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*.deb /tmp/* /root/.npm
           BASH
@@ -115,15 +171,15 @@ jobs:
           ARCH: ${{ matrix.arch }}
         run: |
           sudo incus stop build-base
-          sudo incus publish build-base --alias taos-openclaw-base \
-            description="taOS openclaw base image ($ARCH)"
-          sudo incus image export taos-openclaw-base "./taos-openclaw-base-linux-$ARCH"
-          ls -la "./taos-openclaw-base-linux-$ARCH"*
+          sudo incus publish build-base --alias "$ALIAS" \
+            description="taOS $ALIAS image ($ARCH)"
+          sudo incus image export "$ALIAS" "./$ALIAS-linux-$ARCH"
+          ls -la "./$ALIAS-linux-$ARCH"*
 
       - uses: actions/upload-artifact@v7
         with:
-          name: taos-openclaw-base-${{ matrix.arch }}
-          path: taos-openclaw-base-linux-${{ matrix.arch }}.tar.gz
+          name: ${{ env.ALIAS }}-${{ matrix.arch }}
+          path: ${{ env.ALIAS }}-linux-${{ matrix.arch }}.tar.gz
           if-no-files-found: error
 
   release:
@@ -134,11 +190,11 @@ jobs:
     steps:
       - uses: actions/download-artifact@v8
         with:
-          pattern: taos-openclaw-base-*
+          pattern: taos-*-base-*
           merge-multiple: true
 
       - name: List downloaded assets
-        run: ls -la taos-openclaw-base-linux-*.tar.gz
+        run: ls -la taos-*-base-linux-*.tar.gz
 
       - name: Compute build identifier
         id: id
@@ -156,20 +212,25 @@ jobs:
           repository: jaylfc/tinyagentos-images
           token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           tag_name: rolling-images
-          name: "taOS openclaw base image (${{ steps.id.outputs.ts }} - ${{ steps.id.outputs.sha }})"
+          name: "taOS agent base images (${{ steps.id.outputs.ts }} - ${{ steps.id.outputs.sha }})"
           body: |
-            Pre-built LXC base image for openclaw agents.
+            Pre-built LXC base images for taOS agents.
 
             Consumers (taOS deployer): import once with
-            `curl -fsSL <url> | incus image import - --alias taos-openclaw-base`.
+            `curl -fsSL <url> | incus image import - --alias <alias>`.
 
             Assets:
-            - `taos-openclaw-base-linux-arm64.tar.gz`
-            - `taos-openclaw-base-linux-x64.tar.gz`
+            - `taos-openclaw-base-linux-{arm64,x64}.tar.gz` -- openclaw warmed
+            - `taos-base-linux-{arm64,x64}.tar.gz` -- generic common deps
+            - `taos-hermes-base-linux-{arm64,x64}.tar.gz` -- Hermes prerequisites
 
             Source commit: ${{ github.sha }}
           files: |
             taos-openclaw-base-linux-arm64.tar.gz
             taos-openclaw-base-linux-x64.tar.gz
+            taos-base-linux-arm64.tar.gz
+            taos-base-linux-x64.tar.gz
+            taos-hermes-base-linux-arm64.tar.gz
+            taos-hermes-base-linux-x64.tar.gz
           make_latest: true
           prerelease: false

--- a/tests/test_agent_image.py
+++ b/tests/test_agent_image.py
@@ -4,8 +4,10 @@ import pytest
 
 from tinyagentos.agent_image import (
     BASE_IMAGE_ALIAS,
+    GENERIC_BASE_ALIAS,
     RELEASE_BASE_URL,
     arch_suffix,
+    base_image_alias,
     base_image_url,
     ensure_image_present,
     is_image_present,
@@ -25,6 +27,33 @@ class TestArch:
             assert arch_suffix() == "arm64"
         with patch("tinyagentos.agent_image.platform.machine", return_value="x86_64"):
             assert arch_suffix() == "x64"
+
+
+class TestBaseImageAlias:
+    def test_openclaw_keeps_historical_alias(self):
+        # Back-compat: openclaw must still resolve to the published alias.
+        assert base_image_alias("openclaw") == "taos-openclaw-base"
+        assert base_image_alias("openclaw") == BASE_IMAGE_ALIAS
+
+    def test_hermes_has_dedicated_alias(self):
+        assert base_image_alias("hermes") == "taos-hermes-base"
+
+    def test_unknown_framework_falls_back_to_generic(self):
+        assert base_image_alias("smolagents") == GENERIC_BASE_ALIAS
+        assert base_image_alias("smolagents") == "taos-base"
+        assert base_image_alias("anything-else") == "taos-base"
+
+    def test_url_default_framework_keeps_openclaw_alias(self):
+        # Existing arch-only callers must be unaffected by the new param.
+        assert base_image_url("arm64") == base_image_url("arm64", framework=None)
+        assert BASE_IMAGE_ALIAS in base_image_url("arm64")
+
+    def test_url_framework_selects_alias(self):
+        hermes_url = base_image_url("arm64", framework="hermes")
+        assert "taos-hermes-base" in hermes_url
+        assert "arm64" in hermes_url
+        generic_url = base_image_url("x64", framework="smolagents")
+        assert "taos-base-linux-x64" in generic_url
 
 
 def _fake_proc(returncode: int = 0, stdout: bytes = b""):

--- a/tests/test_agent_image.py
+++ b/tests/test_agent_image.py
@@ -6,9 +6,12 @@ from tinyagentos.agent_image import (
     BASE_IMAGE_ALIAS,
     GENERIC_BASE_ALIAS,
     RELEASE_BASE_URL,
+    all_base_image_aliases,
     arch_suffix,
     base_image_alias,
     base_image_url,
+    base_image_url_for_alias,
+    ensure_all_base_images_present,
     ensure_image_present,
     is_image_present,
 )
@@ -54,6 +57,18 @@ class TestBaseImageAlias:
         assert "arm64" in hermes_url
         generic_url = base_image_url("x64", framework="smolagents")
         assert "taos-base-linux-x64" in generic_url
+
+    def test_url_for_alias_uses_alias_directly(self):
+        url = base_image_url_for_alias("taos-hermes-base", "arm64")
+        assert url == f"{RELEASE_BASE_URL}/taos-hermes-base-linux-arm64.tar.gz"
+
+    def test_all_base_image_aliases_covers_dedicated_and_generic(self):
+        aliases = all_base_image_aliases()
+        assert "taos-openclaw-base" in aliases
+        assert "taos-hermes-base" in aliases
+        assert GENERIC_BASE_ALIAS in aliases
+        # No duplicates.
+        assert len(aliases) == len(set(aliases))
 
 
 def _fake_proc(returncode: int = 0, stdout: bytes = b""):
@@ -156,3 +171,66 @@ class TestEnsureImagePresent:
         ), patch("asyncio.create_subprocess_exec", new=_launch):
             ok = await ensure_image_present(url="http://example.test/img.tar.gz")
         assert ok is False
+
+    @pytest.mark.asyncio
+    async def test_default_url_derives_from_alias_not_openclaw(self):
+        # Regression: a non-openclaw alias with no explicit url must download
+        # that alias's tarball, not the openclaw one.
+        curl_proc = _fake_proc(0, b"")
+        incus_proc = _fake_proc(0, b"imported\n")
+        seen_urls = []
+
+        async def _launch(*args, **kwargs):
+            if args and args[0] == "curl":
+                seen_urls.append(args[-1])
+                return curl_proc
+            return incus_proc
+
+        with patch(
+            "tinyagentos.agent_image.is_image_present", new=AsyncMock(return_value=False)
+        ), patch("asyncio.create_subprocess_exec", new=_launch), \
+             patch("tinyagentos.agent_image._bake_scripts_into_image", new=AsyncMock()):
+            ok = await ensure_image_present("taos-hermes-base")
+        assert ok is True
+        assert seen_urls, "curl should have been invoked"
+        assert "taos-hermes-base" in seen_urls[0]
+        assert "taos-openclaw-base" not in seen_urls[0]
+
+
+class TestEnsureAllBaseImagesPresent:
+    @pytest.mark.asyncio
+    async def test_imports_every_alias(self):
+        imported = []
+
+        async def fake_ensure(alias):
+            imported.append(alias)
+            return True
+
+        with patch(
+            "tinyagentos.agent_image.ensure_image_present",
+            new=AsyncMock(side_effect=fake_ensure),
+        ):
+            results = await ensure_all_base_images_present()
+        assert set(imported) == set(all_base_image_aliases())
+        assert "taos-openclaw-base" in imported
+        assert "taos-hermes-base" in imported
+        assert GENERIC_BASE_ALIAS in imported
+        assert all(results.values())
+
+    @pytest.mark.asyncio
+    async def test_one_failure_does_not_abort_the_rest(self):
+        async def fake_ensure(alias):
+            if alias == "taos-hermes-base":
+                raise RuntimeError("network down")
+            return True
+
+        with patch(
+            "tinyagentos.agent_image.ensure_image_present",
+            new=AsyncMock(side_effect=fake_ensure),
+        ):
+            results = await ensure_all_base_images_present()
+        # Every alias was attempted; only the failing one is False.
+        assert set(results) == set(all_base_image_aliases())
+        assert results["taos-hermes-base"] is False
+        assert results["taos-openclaw-base"] is True
+        assert results[GENERIC_BASE_ALIAS] is True

--- a/tests/test_deployer.py
+++ b/tests/test_deployer.py
@@ -1233,3 +1233,89 @@ class TestMasterKeyFallback:
             result = await deploy_agent(req)
         assert result["success"] is False
         assert "fallback is disabled" in result["error"]
+
+
+class TestFrameworkAwareBaseImage:
+    """Framework-aware prebuilt base image selection (Hermes fast-path)."""
+
+    @staticmethod
+    async def _run(framework, present_aliases, tmp_path):
+        """Deploy *framework* with is_image_present True only for the aliases
+        in *present_aliases*. Return (launch_image, env, recorded_exec_cmds)."""
+        req = _req(name="fwbase", framework=framework, data_dir=tmp_path)
+        recorded = []
+
+        async def mock_exec(name, cmd, **kwargs):
+            cmd_str = " ".join(cmd)
+            recorded.append(cmd_str)
+            if "hostname -I" in cmd_str:
+                return (0, "10.0.0.7")
+            return (0, "ok")
+
+        async def fake_present(alias):
+            return alias in present_aliases
+
+        with patch("tinyagentos.deployer.create_container", new_callable=AsyncMock) as mock_create, \
+             patch("tinyagentos.deployer.is_image_present", side_effect=fake_present), \
+             patch("tinyagentos.deployer.exec_in_container", side_effect=mock_exec), \
+             patch("tinyagentos.deployer.push_file", new_callable=AsyncMock, return_value=(0, "")), \
+             patch("tinyagentos.deployer.add_proxy_device", new_callable=AsyncMock, return_value={"success": True, "output": ""}):
+            mock_create.return_value = {"success": True, "name": "taos-agent-fwbase"}
+            await deploy_agent(req)
+            launch_image = mock_create.call_args.kwargs["image"]
+            env = mock_create.call_args.kwargs["env"]
+        return launch_image, env, recorded
+
+    @pytest.mark.asyncio
+    async def test_openclaw_uses_its_dedicated_base(self, tmp_path):
+        launch, env, recorded = await self._run(
+            "openclaw", {"taos-openclaw-base"}, tmp_path
+        )
+        assert launch == "taos-openclaw-base"
+        assert env.get("TAOS_BASE_IMAGE_PRESENT") == "1"
+        assert not any("apt-get install" in c for c in recorded)
+
+    @pytest.mark.asyncio
+    async def test_hermes_uses_its_dedicated_base(self, tmp_path):
+        launch, env, recorded = await self._run(
+            "hermes", {"taos-hermes-base"}, tmp_path
+        )
+        assert launch == "taos-hermes-base"
+        assert env.get("TAOS_BASE_IMAGE_PRESENT") == "1"
+        assert not any("apt-get install" in c for c in recorded)
+
+    @pytest.mark.asyncio
+    async def test_hermes_falls_back_to_generic_base(self, tmp_path):
+        # No dedicated hermes base on this host, but the generic one is present.
+        launch, env, recorded = await self._run(
+            "hermes", {"taos-base"}, tmp_path
+        )
+        assert launch == "taos-base"
+        assert env.get("TAOS_BASE_IMAGE_PRESENT") == "1"
+        # Generic base already has the common deps -- apt is skipped.
+        assert not any("apt-get install" in c for c in recorded)
+
+    @pytest.mark.asyncio
+    async def test_unknown_framework_uses_generic_base(self, tmp_path):
+        launch, env, recorded = await self._run(
+            "smolagents", {"taos-base"}, tmp_path
+        )
+        assert launch == "taos-base"
+        assert env.get("TAOS_BASE_IMAGE_PRESENT") == "1"
+        assert not any("apt-get install" in c for c in recorded)
+
+    @pytest.mark.asyncio
+    async def test_cold_fallback_when_no_base_present(self, tmp_path):
+        launch, env, recorded = await self._run("hermes", set(), tmp_path)
+        assert launch == "images:debian/bookworm"
+        assert "TAOS_BASE_IMAGE_PRESENT" not in env
+        # Cold host still runs the full apt install.
+        assert any("apt-get install" in c for c in recorded)
+
+    @pytest.mark.asyncio
+    async def test_dedicated_base_preferred_over_generic(self, tmp_path):
+        # Both present -- the framework-specific alias must win.
+        launch, _env, _recorded = await self._run(
+            "hermes", {"taos-hermes-base", "taos-base"}, tmp_path
+        )
+        assert launch == "taos-hermes-base"

--- a/tinyagentos/agent_image.py
+++ b/tinyagentos/agent_image.py
@@ -122,7 +122,36 @@ def base_image_url(arch: str | None = None, framework: str | None = None) -> str
     get that framework's dedicated base, or the generic ``taos-base`` fallback.
     """
     alias = base_image_alias(framework) if framework is not None else BASE_IMAGE_ALIAS
+    return base_image_url_for_alias(alias, arch)
+
+
+def base_image_url_for_alias(alias: str, arch: str | None = None) -> str:
+    """URL of the published tarball for a base-image ``alias`` directly.
+
+    Aliases map 1:1 onto asset names in the images release, so this is the
+    single source of truth the alias-keyed prefetch path uses to avoid
+    importing the wrong tarball under an alias (e.g. the openclaw tarball
+    under ``taos-hermes-base``).
+    """
     return f"{RELEASE_BASE_URL}/{alias}-linux-{arch or arch_suffix()}.tar.gz"
+
+
+def all_base_image_aliases() -> list[str]:
+    """Aliases that prefetch should import: every dedicated-base framework's
+    alias plus the generic ``taos-base``.
+
+    Ordered, de-duplicated, deterministic. The deployer's fast-path tries a
+    framework's dedicated base then the generic one, so both must be present
+    on a fresh host for the fast-path to trigger for any framework.
+    """
+    aliases: list[str] = []
+    for framework in sorted(FRAMEWORKS_WITH_DEDICATED_BASE):
+        alias = base_image_alias(framework)
+        if alias not in aliases:
+            aliases.append(alias)
+    if GENERIC_BASE_ALIAS not in aliases:
+        aliases.append(GENERIC_BASE_ALIAS)
+    return aliases
 
 
 async def is_image_present(alias: str = BASE_IMAGE_ALIAS) -> bool:
@@ -232,7 +261,9 @@ async def ensure_image_present(
     """
     if await is_image_present(alias):
         return True
-    import_url = url or base_image_url()
+    # Derive the URL from the alias so a non-openclaw alias never imports the
+    # openclaw tarball (an explicit url still wins for tests / overrides).
+    import_url = url or base_image_url_for_alias(alias)
     _prefetch_state.update(
         status="downloading",
         started_at=_dt.datetime.now(_dt.timezone.utc).isoformat(),
@@ -300,6 +331,27 @@ async def ensure_image_present(
             pass
 
 
+async def ensure_all_base_images_present() -> dict[str, bool]:
+    """Import every base image the deployer fast-path can use.
+
+    Imports each alias from :func:`all_base_image_aliases` (the dedicated-base
+    frameworks plus the generic ``taos-base``) so the fast-path can trigger
+    for any framework on a fresh host -- not just openclaw. Each import is
+    independent and non-fatal: a failure on one alias is logged and the rest
+    still run. Returns an ``{alias: ok}`` map.
+
+    Intended as the one-time boot bootstrap (called when prefetch is enabled).
+    """
+    results: dict[str, bool] = {}
+    for alias in all_base_image_aliases():
+        try:
+            results[alias] = await ensure_image_present(alias)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("agent_image: ensure %s failed: %s", alias, exc)
+            results[alias] = False
+    return results
+
+
 __all__ = [
     "BASE_IMAGE_ALIAS",
     "GENERIC_BASE_ALIAS",
@@ -311,6 +363,9 @@ __all__ = [
     "register_prefetch_endpoint",
     "arch_suffix",
     "base_image_url",
+    "base_image_url_for_alias",
+    "all_base_image_aliases",
     "is_image_present",
     "ensure_image_present",
+    "ensure_all_base_images_present",
 ]

--- a/tinyagentos/agent_image.py
+++ b/tinyagentos/agent_image.py
@@ -40,6 +40,31 @@ RELEASE_BASE_URL = (
     "https://github.com/jaylfc/tinyagentos-images/releases/download/rolling-images"
 )
 
+# Generic base alias usable by any framework. It bakes the common deps
+# (python3/node/npm/build-essential/git/curl/etc) without any single
+# framework's package, so a deploy from it still skips the cold apt run.
+GENERIC_BASE_ALIAS = "taos-base"
+
+# Frameworks that have a dedicated prebuilt base image (alias
+# "taos-<framework>-base"). openclaw keeps its historical alias for
+# back-compat. Hermes' base additionally bakes the NousResearch
+# hermes-agent prerequisites so a hermes deploy needs only config.
+FRAMEWORKS_WITH_DEDICATED_BASE = frozenset({"openclaw", "hermes"})
+
+
+def base_image_alias(framework: str) -> str:
+    """Return the prebuilt base-image alias for ``framework``.
+
+    Frameworks listed in :data:`FRAMEWORKS_WITH_DEDICATED_BASE` get a
+    dedicated ``taos-<framework>-base`` alias (openclaw keeps its
+    historical ``taos-openclaw-base``). Everything else maps to the
+    generic ``taos-base``. The deployer tries the dedicated alias first
+    and falls back to the generic one, then to a cold image.
+    """
+    if framework in FRAMEWORKS_WITH_DEDICATED_BASE:
+        return f"taos-{framework}-base"
+    return GENERIC_BASE_ALIAS
+
 
 def is_prefetch_enabled() -> bool:
     """Return True if the user has opted in to base image prefetching.
@@ -88,9 +113,16 @@ def arch_suffix() -> str:
     return machine or "unknown"
 
 
-def base_image_url(arch: str | None = None) -> str:
-    """URL of the published image tarball for ``arch`` (defaults to host arch)."""
-    return f"{RELEASE_BASE_URL}/{BASE_IMAGE_ALIAS}-linux-{arch or arch_suffix()}.tar.gz"
+def base_image_url(arch: str | None = None, framework: str | None = None) -> str:
+    """URL of the published image tarball for ``arch`` (defaults to host arch).
+
+    ``framework`` selects which base alias the URL points at. When omitted
+    the historical ``taos-openclaw-base`` alias is used so existing callers
+    (which only pass ``arch``) keep their behaviour. Pass a framework name to
+    get that framework's dedicated base, or the generic ``taos-base`` fallback.
+    """
+    alias = base_image_alias(framework) if framework is not None else BASE_IMAGE_ALIAS
+    return f"{RELEASE_BASE_URL}/{alias}-linux-{arch or arch_suffix()}.tar.gz"
 
 
 async def is_image_present(alias: str = BASE_IMAGE_ALIAS) -> bool:
@@ -270,6 +302,9 @@ async def ensure_image_present(
 
 __all__ = [
     "BASE_IMAGE_ALIAS",
+    "GENERIC_BASE_ALIAS",
+    "FRAMEWORKS_WITH_DEDICATED_BASE",
+    "base_image_alias",
     "RELEASE_BASE_URL",
     "is_prefetch_enabled",
     "get_prefetch_state",

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -77,7 +77,7 @@ from tinyagentos.computer_use import ComputerUseManager
 from tinyagentos.webhook_notifier import WebhookNotifier
 from tinyagentos.llm_proxy import LLMProxy
 from tinyagentos.litellm_migrate import migrate as _litellm_migrate
-from tinyagentos.agent_image import ensure_image_present as _ensure_agent_image_present
+from tinyagentos.agent_image import ensure_all_base_images_present as _ensure_agent_images_present
 from tinyagentos.agent_image import is_prefetch_enabled as _is_prefetch_enabled
 from tinyagentos.agent_image import register_prefetch_endpoint
 from tinyagentos.auto_update import AutoUpdateService
@@ -779,7 +779,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         try:
             if _is_prefetch_enabled():
                 _create_supervised_task(
-                    _ensure_agent_image_present(), app.state._background_tasks
+                    _ensure_agent_images_present(), app.state._background_tasks
                 )
             else:
                 logger.debug(

--- a/tinyagentos/deployer.py
+++ b/tinyagentos/deployer.py
@@ -25,7 +25,11 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from tinyagentos.secrets import SecretsStore
 
-from tinyagentos.agent_image import BASE_IMAGE_ALIAS, is_image_present
+from tinyagentos.agent_image import (
+    GENERIC_BASE_ALIAS,
+    base_image_alias,
+    is_image_present,
+)
 from tinyagentos.containers import (
     create_container, exec_in_container, push_file,
     start_container, stop_container, destroy_container,
@@ -370,19 +374,33 @@ async def deploy_agent(req: DeployRequest) -> dict:
             )
 
     # Pre-built base image fast-path — see tinyagentos/agent_image.py.
-    # When the cached image is imported locally we launch from it and
-    # install.sh skips the openclaw/apt steps; on a cold host we fall
-    # back to images:debian/bookworm and install.sh does the full run.
+    # Framework-aware selection: prefer the framework's dedicated base
+    # (taos-<framework>-base), then the generic taos-base, then a cold
+    # images:debian/bookworm. Any base (specific or generic) already has
+    # the common deps baked in, so we skip the slow apt run below. This is
+    # what lets non-openclaw agents (especially Hermes on ARM/Pi) avoid the
+    # ~900s cold install. openclaw still resolves to taos-openclaw-base.
     base_image_ready = False
-    if req.framework == "openclaw":
-        try:
-            base_image_ready = await is_image_present(BASE_IMAGE_ALIAS)
-        except Exception:
-            base_image_ready = False
-    launch_image = BASE_IMAGE_ALIAS if base_image_ready else "images:debian/bookworm"
+    launch_image = "images:debian/bookworm"
+    if req.framework and req.framework != "none":
+        # Build the candidate list, de-duplicating when the framework has no
+        # dedicated base (base_image_alias already returns GENERIC_BASE_ALIAS).
+        specific_alias = base_image_alias(req.framework)
+        candidates = [specific_alias]
+        if specific_alias != GENERIC_BASE_ALIAS:
+            candidates.append(GENERIC_BASE_ALIAS)
+        for alias in candidates:
+            try:
+                present = await is_image_present(alias)
+            except Exception:
+                present = False
+            if present:
+                base_image_ready = True
+                launch_image = alias
+                break
     if base_image_ready:
         env["TAOS_BASE_IMAGE_PRESENT"] = "1"
-        logger.info(f"Deploy {req.name}: using cached base image {BASE_IMAGE_ALIAS}")
+        logger.info(f"Deploy {req.name}: using cached base image {launch_image}")
     else:
         logger.info(f"Deploy {req.name}: cached base image not present, using {launch_image}")
 

--- a/tinyagentos/scripts/install_hermes.sh
+++ b/tinyagentos/scripts/install_hermes.sh
@@ -20,16 +20,30 @@ fi
 export PATH="/root/.local/bin:$PATH"
 echo 'export PATH="/root/.local/bin:$PATH"' >> /root/.bashrc
 
-if [ ! -d /root/.hermes/hermes-agent ]; then
-    log "running Hermes installer (--skip-setup)"
-    curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --skip-setup
-fi
+# Detect an existing hermes install first so a prebaked base image (which
+# already has the binary, e.g. taos-hermes-base) skips the slow installer.
+# /root/.hermes/hermes-agent does not exist in this installer layout, so we
+# probe the real binary paths instead. On a cold container nothing matches
+# and the installer runs as before.
+find_hermes() {
+    local c
+    for c in /root/.local/bin/hermes /usr/local/bin/hermes \
+             /root/.hermes/hermes-agent/.venv/bin/hermes \
+             /root/.hermes/hermes-agent/venv/bin/hermes; do
+        [ -L "$c" -o -x "$c" ] && { echo "$c"; return 0; }
+    done
+    command -v hermes 2>/dev/null && return 0
+    return 1
+}
 
-HERMES_BIN=""
-for c in /root/.local/bin/hermes /root/.hermes/hermes-agent/.venv/bin/hermes /root/.hermes/hermes-agent/venv/bin/hermes; do
-    [ -L "$c" -o -x "$c" ] && HERMES_BIN="$c" && break
-done
-[ -z "$HERMES_BIN" ] && HERMES_BIN=$(command -v hermes || true)
+HERMES_BIN="$(find_hermes || true)"
+if [ -z "$HERMES_BIN" ]; then
+    log "hermes not present -- running Hermes installer (--skip-setup)"
+    curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --skip-setup
+    HERMES_BIN="$(find_hermes || true)"
+else
+    log "hermes already installed (base image) -- skipping installer"
+fi
 [ -z "$HERMES_BIN" ] && { log "ERROR: hermes binary not found"; exit 2; }
 log "hermes at $HERMES_BIN"
 


### PR DESCRIPTION
----
## Summary by Gitar

- **Base image infrastructure:**
  - Added `GENERIC_BASE_ALIAS` (`taos-base`) and framework-specific aliases for `hermes` and `openclaw`.
  - Updated `base_image_url` to support framework-specific resolution while maintaining back-compat.
- **Deployment logic:**
  - Implemented framework-aware base image selection, prioritizing dedicated bases over generic ones to skip slow `apt` installs.
- **CI/CD updates:**
  - Updated `build-agent-images.yml` to support a cross-product matrix (3 bases × 2 architectures) and include `hermes` prerequisite baking.
- **Testing:**
  - Added `TestFrameworkAwareBaseImage` and `TestBaseImageAlias` to verify alias resolution and deployment fallback logic.

<sub>This will update automatically on new commits.</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple prebuilt base images, including framework-specific images for OpenClaw and Hermes plus a generic fallback.
  * Expanded image builds and releases to cover both x64 and arm64 for all supported base image types.
* **Bug Fixes**
  * Improved base-image selection so deployments now prefer a matching framework image, then a generic image, before falling back to a fresh Debian base.
  * Updated release artifacts and downloads to include all published base images consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up commit (prefetch + idempotent Hermes install)

Two correctness fixes folded in so the fast-path actually triggers on a fresh host:

- **Prefetch all bases**: boot prefetch previously imported only `taos-openclaw-base`, so `taos-hermes-base` / `taos-base` were never present and the fast-path could not fire for non-openclaw agents. Added `ensure_all_base_images_present()` (iterates the dedicated-base frameworks + generic) wired into the prefetch bootstrap in `app.py`. Also fixed an alias bug: `ensure_image_present` defaulted the download URL to the openclaw tarball regardless of alias; it now derives the URL from the alias via `base_image_url_for_alias()`.
- **Idempotent Hermes install**: `install_hermes.sh` gated the installer on `/root/.hermes/hermes-agent`, a path absent in this installer layout, so a deploy from a prebaked hermes base re-ran the slow upstream installer. It now detects the real hermes binary (its existing candidate paths plus `/usr/local/bin/hermes` and `command -v`) and skips the installer when present. Stays idempotent and still installs on a cold container.

### Known follow-up (deferred, not fixed here)

The workflow's Hermes bake step duplicates the prerequisite commands from `tinyagentos/scripts/install_hermes.sh` (uv, the NousResearch installer, pyyaml/httpx). This is a drift risk: if the install script's prerequisites change, the bake step must be updated in lockstep. A future cleanup could have the bake step source the heavy steps from a shared snippet rather than copying them. Left as-is for now to keep this PR surgical.
