### PR TITLE
fix(agents): archive an agent DM channel on every removal path, never orphan

### DIFF
--- a/tests/test_orphan_channel_reconcile.py
+++ b/tests/test_orphan_channel_reconcile.py
@@ -58,16 +58,28 @@ class TestDestroyArchivesChannel:
 
 @pytest.mark.asyncio
 class TestReconcileOrphanChannels:
-    async def test_archives_orphan_leaves_others(self, client, app):
-        """An orphan DM channel is archived; a live-agent DM, an a2a group,
-        a project channel, and a human DM are all left untouched."""
+    async def test_archives_orphans_leaves_others(self, client, app):
+        """Orphan agent DMs are archived; a live-agent DM, an a2a group, a
+        project channel, a human<->human DM, and a user<->human DM are all
+        left untouched.
+
+        Two orphan shapes are archived: a former agent recognised via the
+        registry (plain slug, like the live-Pi 'hermes-confirm') and a
+        canonical-id-shaped member with no registry/config backing at all.
+        """
         config = app.state.config
         chat_channels = app.state.chat_channels
 
-        # Orphan: DM for an agent in no list.
-        orphan = await chat_channels.create_channel(
+        # Orphan 1: plain-slug former agent, recognised via the registry.
+        registry_ids = ["hermes-confirm-20260601-120000"]
+        orphan_slug = await chat_channels.create_channel(
             name="hermes-confirm", type="dm", created_by="user",
             members=["user", "hermes-confirm"],
+        )
+        # Orphan 2: canonical-id-shaped member, no backing anywhere.
+        orphan_canonical = await chat_channels.create_channel(
+            name="Old Agent", type="dm", created_by="user",
+            members=["user", "old-agent-20251201-093000"],
         )
         # Live agent DM (test-agent exists in the default config).
         live = await chat_channels.create_channel(
@@ -90,21 +102,43 @@ class TestReconcileOrphanChannels:
             name="Alice & Bob", type="dm", created_by="alice",
             members=["alice", "bob"],
         )
+        # user<->human DM: same ["user", X] shape as an agent DM, but X is a
+        # human handle backing no known/never-known agent. Must NOT be archived.
+        user_human = await chat_channels.create_channel(
+            name="Bob", type="dm", created_by="user",
+            members=["user", "bob"],
+        )
 
-        archived = await reconcile_orphan_dm_channels(config, chat_channels)
+        archived = await reconcile_orphan_dm_channels(
+            config, chat_channels, registry_ids=registry_ids
+        )
 
-        assert [r["channel_id"] for r in archived] == [orphan["id"]]
-        assert archived[0]["slug"] == "hermes-confirm"
+        archived_set = {r["channel_id"] for r in archived}
+        assert archived_set == {orphan_slug["id"], orphan_canonical["id"]}
 
         archived_ids = await _archived_ids(chat_channels)
-        assert orphan["id"] in archived_ids
-        for other in (live["id"], a2a["id"], proj["id"], human["id"]):
+        assert orphan_slug["id"] in archived_ids
+        assert orphan_canonical["id"] in archived_ids
+        for other in (live["id"], a2a["id"], proj["id"], human["id"], user_human["id"]):
             assert other not in archived_ids
 
-        # The orphan carries the archive linkage.
-        ch = await chat_channels.get_channel(orphan["id"])
+        # An orphan carries the archive linkage.
+        ch = await chat_channels.get_channel(orphan_slug["id"])
         assert ch["settings"]["archived_agent_slug"] == "hermes-confirm"
         assert ch["settings"].get("archived_agent_id")
+
+    async def test_user_human_dm_left_untouched(self, client, app):
+        """A user<->human DM is never archived, even with no registry hints."""
+        config = app.state.config
+        chat_channels = app.state.chat_channels
+        ch = await chat_channels.create_channel(
+            name="Carol", type="dm", created_by="user",
+            members=["user", "carol"],
+        )
+
+        archived = await reconcile_orphan_dm_channels(config, chat_channels)
+        assert archived == []
+        assert ch["id"] not in await _archived_ids(chat_channels)
 
     async def test_skips_channel_backed_by_archived_agent(self, client, app):
         """A DM channel whose agent is in the ARCHIVED list is not re-touched."""
@@ -128,7 +162,7 @@ class TestReconcileOrphanChannels:
         chat_channels = app.state.chat_channels
         await chat_channels.create_channel(
             name="deerflow-test", type="dm", created_by="user",
-            members=["user", "deerflow-test"],
+            members=["user", "deerflow-test-20260101-000000"],
         )
 
         first = await reconcile_orphan_dm_channels(config, chat_channels)
@@ -138,11 +172,16 @@ class TestReconcileOrphanChannels:
         assert second == []
 
     async def test_via_route(self, client, app):
-        """POST /api/agents/reconcile-orphan-channels archives the orphan."""
+        """POST /api/agents/reconcile-orphan-channels archives a canonical-id
+        orphan and leaves a user<->human DM untouched."""
         chat_channels = app.state.chat_channels
         orphan = await chat_channels.create_channel(
             name="stray", type="dm", created_by="user",
-            members=["user", "stray-agent"],
+            members=["user", "stray-agent-20260301-101010"],
+        )
+        human = await chat_channels.create_channel(
+            name="Dave", type="dm", created_by="user",
+            members=["user", "dave"],
         )
 
         resp = await client.post("/api/agents/reconcile-orphan-channels")
@@ -150,4 +189,6 @@ class TestReconcileOrphanChannels:
         body = resp.json()
         assert body["count"] == 1
         assert body["archived"][0]["channel_id"] == orphan["id"]
-        assert orphan["id"] in await _archived_ids(chat_channels)
+        archived_ids = await _archived_ids(chat_channels)
+        assert orphan["id"] in archived_ids
+        assert human["id"] not in archived_ids

--- a/tests/test_orphan_channel_reconcile.py
+++ b/tests/test_orphan_channel_reconcile.py
@@ -1,0 +1,153 @@
+"""Orphan agent DM channel handling.
+
+Covers the two ways a DM channel can be left as a live orphan and the
+reconciliation that sweeps existing ones:
+
+  (a) the hard-delete branch of /destroy archives the agent's DM channel
+      instead of leaving it live,
+  (b) the reconciliation archives an orphan DM channel while leaving
+      live-agent channels and non-agent channels untouched, and
+  (c) the reconciliation is idempotent.
+"""
+from __future__ import annotations
+
+import pytest
+
+from tinyagentos.chat.orphan_reconcile import reconcile_orphan_dm_channels
+
+
+async def _archived_ids(chat_channels) -> set[str]:
+    archived = await chat_channels.list_channels(archived=True)
+    return {c["id"] for c in archived}
+
+
+@pytest.mark.asyncio
+class TestDestroyArchivesChannel:
+    async def test_destroy_orphan_row_archives_dm_channel(
+        self, client, app, monkeypatch
+    ):
+        """/destroy of a never-used orphan row archives its DM channel instead
+        of orphaning it (no container, no chat history, no trace)."""
+        async def _no_container(name):
+            return False
+        monkeypatch.setattr("tinyagentos.containers.container_exists", _no_container)
+
+        chat_channels = app.state.chat_channels
+        ch = await chat_channels.create_channel(
+            name="Ghost", type="dm", created_by="user",
+            members=["user", "test-agent"],
+        )
+        # Link the channel to the live test-agent (no messages -> no history).
+        app.state.config.agents[0]["chat_channel_id"] = ch["id"]
+
+        resp = await client.delete("/api/agents/test-agent/destroy")
+        assert resp.status_code == 200
+
+        # The channel must now be archived and carry the agent linkage, never
+        # left live.
+        assert ch["id"] in await _archived_ids(chat_channels)
+        archived = await chat_channels.get_channel(ch["id"])
+        assert archived["settings"]["archived"] is True
+        assert archived["settings"]["archived_agent_slug"] == "test-agent"
+        assert archived["settings"].get("archived_agent_id")
+
+        # And it must no longer appear in the live listing.
+        live = await chat_channels.list_channels(archived=False)
+        assert ch["id"] not in {c["id"] for c in live}
+
+
+@pytest.mark.asyncio
+class TestReconcileOrphanChannels:
+    async def test_archives_orphan_leaves_others(self, client, app):
+        """An orphan DM channel is archived; a live-agent DM, an a2a group,
+        a project channel, and a human DM are all left untouched."""
+        config = app.state.config
+        chat_channels = app.state.chat_channels
+
+        # Orphan: DM for an agent in no list.
+        orphan = await chat_channels.create_channel(
+            name="hermes-confirm", type="dm", created_by="user",
+            members=["user", "hermes-confirm"],
+        )
+        # Live agent DM (test-agent exists in the default config).
+        live = await chat_channels.create_channel(
+            name="Test Agent", type="dm", created_by="user",
+            members=["user", "test-agent"],
+        )
+        # a2a group channel -- must never be touched.
+        a2a = await chat_channels.create_channel(
+            name="a2a", type="group", created_by="system",
+            members=["user", "test-agent"],
+            settings={"kind": "a2a"}, project_id="prj-1",
+        )
+        # Project channel.
+        proj = await chat_channels.create_channel(
+            name="prj-room", type="dm", created_by="user",
+            members=["user", "someone"], project_id="prj-2",
+        )
+        # Human-to-human DM (no "user" sentinel).
+        human = await chat_channels.create_channel(
+            name="Alice & Bob", type="dm", created_by="alice",
+            members=["alice", "bob"],
+        )
+
+        archived = await reconcile_orphan_dm_channels(config, chat_channels)
+
+        assert [r["channel_id"] for r in archived] == [orphan["id"]]
+        assert archived[0]["slug"] == "hermes-confirm"
+
+        archived_ids = await _archived_ids(chat_channels)
+        assert orphan["id"] in archived_ids
+        for other in (live["id"], a2a["id"], proj["id"], human["id"]):
+            assert other not in archived_ids
+
+        # The orphan carries the archive linkage.
+        ch = await chat_channels.get_channel(orphan["id"])
+        assert ch["settings"]["archived_agent_slug"] == "hermes-confirm"
+        assert ch["settings"].get("archived_agent_id")
+
+    async def test_skips_channel_backed_by_archived_agent(self, client, app):
+        """A DM channel whose agent is in the ARCHIVED list is not re-touched."""
+        config = app.state.config
+        chat_channels = app.state.chat_channels
+        config.archived_agents = [
+            {"id": "arc1", "archived_slug": "gone-agent", "original": {"name": "gone-agent"}}
+        ]
+        ch = await chat_channels.create_channel(
+            name="Gone", type="dm", created_by="user",
+            members=["user", "gone-agent"],
+        )
+
+        archived = await reconcile_orphan_dm_channels(config, chat_channels)
+        assert archived == []
+        assert ch["id"] not in await _archived_ids(chat_channels)
+
+    async def test_idempotent(self, client, app):
+        """Running the reconcile twice archives nothing the second time."""
+        config = app.state.config
+        chat_channels = app.state.chat_channels
+        await chat_channels.create_channel(
+            name="deerflow-test", type="dm", created_by="user",
+            members=["user", "deerflow-test"],
+        )
+
+        first = await reconcile_orphan_dm_channels(config, chat_channels)
+        assert len(first) == 1
+
+        second = await reconcile_orphan_dm_channels(config, chat_channels)
+        assert second == []
+
+    async def test_via_route(self, client, app):
+        """POST /api/agents/reconcile-orphan-channels archives the orphan."""
+        chat_channels = app.state.chat_channels
+        orphan = await chat_channels.create_channel(
+            name="stray", type="dm", created_by="user",
+            members=["user", "stray-agent"],
+        )
+
+        resp = await client.post("/api/agents/reconcile-orphan-channels")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["count"] == 1
+        assert body["archived"][0]["channel_id"] == orphan["id"]
+        assert orphan["id"] in await _archived_ids(chat_channels)

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -599,7 +599,16 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
             from tinyagentos.chat.orphan_reconcile import (
                 reconcile_orphan_dm_channels,
             )
-            reconciled = await reconcile_orphan_dm_channels(config, chat_channels)
+            try:
+                _reg_rows = await agent_registry_store.list_all()
+                _registry_ids = [
+                    r.get("canonical_id") for r in _reg_rows if r.get("canonical_id")
+                ]
+            except Exception:  # noqa: BLE001
+                _registry_ids = []
+            reconciled = await reconcile_orphan_dm_channels(
+                config, chat_channels, registry_ids=_registry_ids
+            )
             if reconciled:
                 logger.info(
                     "orphan reconcile: archived %d orphan DM channel(s) at startup",

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -591,6 +591,22 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
                 await save_config_locked(config, config.config_path)
         except Exception:
             logger.exception("persona_v2 startup migration failed")
+
+        # Archive any agent DM channels left live by a removal path that
+        # bypassed archive (a cleaned-up failed deploy, a hard-delete of a
+        # never-used config row).  Idempotent -- safe on every startup.
+        try:
+            from tinyagentos.chat.orphan_reconcile import (
+                reconcile_orphan_dm_channels,
+            )
+            reconciled = await reconcile_orphan_dm_channels(config, chat_channels)
+            if reconciled:
+                logger.info(
+                    "orphan reconcile: archived %d orphan DM channel(s) at startup",
+                    len(reconciled),
+                )
+        except Exception:
+            logger.exception("orphan DM channel reconcile failed")
         # Probe installed framework versions in the BACKGROUND so the UI can
         # show whether each agent is up-to-date before any manual check is
         # triggered. Each probe does an `incus exec` into the agent container,

--- a/tinyagentos/chat/orphan_reconcile.py
+++ b/tinyagentos/chat/orphan_reconcile.py
@@ -21,10 +21,16 @@ channels, and human-to-human DMs are left untouched.
 from __future__ import annotations
 
 import logging
+import re
 import uuid
 from datetime import datetime, timezone
 
 logger = logging.getLogger(__name__)
+
+# Canonical minted agent-id format: ``{slug}-{YYYYMMDD}-{HHMMSS}`` (see
+# tinyagentos.agent_registry_store.mint_canonical_id), optionally with a
+# 2-hex collision suffix. A member matching this is unambiguously an agent.
+_CANONICAL_AGENT_ID_RE = re.compile(r"-\d{8}-\d{6}(?:-[0-9a-f]{2})?$")
 
 
 def _archive_timestamp() -> str:
@@ -32,12 +38,12 @@ def _archive_timestamp() -> str:
     return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
 
 
-def _agent_member(channel: dict) -> str | None:
-    """Return the agent-slug member of a DM channel, or None.
+def _other_member(channel: dict) -> str | None:
+    """Return the single non-"user" member of a 1:1 DM channel, or None.
 
-    An agent DM channel has exactly the members ``["user", <slug>]``. The
-    non-"user" member is the agent slug. A human-to-human DM has two human
-    user ids and no "user" sentinel, so we return None for those.
+    Note: this does NOT assert the member is an agent -- a user<->human DM has
+    the same ``["user", <handle>]`` shape. Agent classification is done
+    separately by ``_is_known_agent_member``.
     """
     members = channel.get("members") or []
     others = [m for m in members if m != "user"]
@@ -46,14 +52,35 @@ def _agent_member(channel: dict) -> str | None:
     return None
 
 
-def _is_agent_dm(channel: dict) -> bool:
-    """True only for 1:1 agent DM channels (``type='dm'`` with a single
-    agent-slug member alongside the "user" sentinel, and no project link)."""
+def _is_known_agent_member(member: str, known_agent_slugs: set[str]) -> bool:
+    """True only when *member* is (or was) an agent, never a human handle.
+
+    A member counts as an agent when it matches the canonical minted-agent-id
+    format, or when it resolves to a slug that backs a known/former agent
+    (live, archived, or in the registry). A bare human handle that matches no
+    known agent and is not canonical-id-shaped is NOT an agent, so its DM is
+    left untouched.
+    """
+    if not member:
+        return False
+    if _CANONICAL_AGENT_ID_RE.search(member):
+        return True
+    return member in known_agent_slugs
+
+
+def _is_orphan_agent_dm(channel: dict, known_agent_slugs: set[str]) -> bool:
+    """True only for 1:1 *agent* DM channels (``type='dm'`` with a single
+    agent member alongside "user", and no project link). Human DMs and
+    user<->human DMs are rejected because their other member is not a known
+    or canonical-id-shaped agent."""
     if channel.get("type") != "dm":
         return False
     if channel.get("project_id"):
         return False
-    return _agent_member(channel) is not None
+    member = _other_member(channel)
+    if member is None:
+        return False
+    return _is_known_agent_member(member, known_agent_slugs)
 
 
 def _live_agent_slugs(config) -> set[str]:
@@ -75,13 +102,32 @@ def _archived_agent_slugs(config) -> set[str]:
     return slugs
 
 
+def _registry_slugs(registry_ids) -> set[str]:
+    """Derive agent slugs from registry canonical ids.
+
+    A canonical id is ``{slug}-{YYYYMMDD}-{HHMMSS}[-xx]``; stripping the
+    timestamp suffix yields the slug a DM channel stores as its member. Lets
+    the reconcile recognise a former agent whose config row is gone but whose
+    registry record (and thus identity) persists -- e.g. the live-Pi orphans
+    'hermes-confirm' and 'deerflow-test'.
+    """
+    slugs: set[str] = set()
+    for cid in registry_ids or ():
+        if not cid:
+            continue
+        slug = _CANONICAL_AGENT_ID_RE.sub("", cid)
+        if slug and slug != cid:
+            slugs.add(slug)
+    return slugs
+
+
 async def archive_orphan_channel(chat_channels, channel: dict, agent_id: str) -> None:
     """Archive a single orphan DM channel, tagging it with the archive linkage.
 
     Mirrors the channel-side of ``archive_agent_fully`` step 4b so the channel
     looks identical to one archived through the normal path.
     """
-    slug = _agent_member(channel) or ""
+    slug = _other_member(channel) or ""
     await chat_channels.set_settings(
         channel["id"],
         {
@@ -94,12 +140,21 @@ async def archive_orphan_channel(chat_channels, channel: dict, agent_id: str) ->
     )
 
 
-async def reconcile_orphan_dm_channels(config, chat_channels) -> list[dict]:
-    """Archive live agent DM channels whose agent is in no list.
+async def reconcile_orphan_dm_channels(
+    config, chat_channels, registry_ids=None
+) -> list[dict]:
+    """Archive agent DM channels whose agent is in no list.
 
-    A DM channel is an orphan when its agent-slug member matches no live agent
-    (``config.agents``) and no archived agent (``config.archived_agents``).
-    Such channels are archived (and linked) rather than left live.
+    A channel is an orphan when (1) it is an agent DM -- the non-"user" member
+    is a known/former agent (canonical-id-shaped, or a slug present in the live
+    config, the archived config, or the registry) and NOT a human handle -- and
+    (2) that member backs no LIVE and no ARCHIVED agent. Such channels are
+    archived (and linked) rather than left live. Human DMs and user<->human DMs
+    are never touched, because their other member is not a known agent.
+
+    ``registry_ids`` is an optional iterable of canonical agent ids (e.g. from
+    the agent registry) used to recognise a former agent whose config row is
+    gone but whose identity persists.
 
     Returns a list of ``{"channel_id", "slug", "archived_agent_id"}`` for the
     channels archived on this pass (empty when nothing to do). Idempotent:
@@ -109,13 +164,17 @@ async def reconcile_orphan_dm_channels(config, chat_channels) -> list[dict]:
     live = _live_agent_slugs(config)
     archived = _archived_agent_slugs(config)
     backed = live | archived
+    # Slugs known to be agents (so a plain-slug former agent like the live-Pi
+    # orphans is classified as an agent DM, not a human DM). Registry slugs and
+    # backed slugs together; canonical-id-shaped members are matched by regex.
+    known_agent_slugs = backed | _registry_slugs(registry_ids)
 
     results: list[dict] = []
     channels = await chat_channels.list_channels(archived=False)
     for ch in channels:
-        if not _is_agent_dm(ch):
+        if not _is_orphan_agent_dm(ch, known_agent_slugs):
             continue
-        slug = _agent_member(ch)
+        slug = _other_member(ch)
         if slug in backed:
             continue
         agent_id = uuid.uuid4().hex[:12]

--- a/tinyagentos/chat/orphan_reconcile.py
+++ b/tinyagentos/chat/orphan_reconcile.py
@@ -1,0 +1,137 @@
+"""Orphan agent DM channel reconciliation.
+
+A taOS agent gets a 1:1 DM channel (``type="dm"``, members ``["user", slug]``)
+created on its first successful deploy. Most removal paths archive the channel
+alongside the agent, but a few do not -- a failed deploy that gets cleaned up,
+or the hard-delete branch in ``archive_agent_fully`` for a never-used config
+row. Those paths can leave the DM channel as a live orphan: it shows in the
+Messages app but its agent is in no list (active, failed, or archived).
+
+Project principle: nothing is truly deleted, only archived. So we never
+hard-delete an orphan channel here -- we ARCHIVE it and tag it with the same
+``settings.archived_agent_id`` linkage ``archive_agent_fully`` uses, so it
+behaves like any other archived agent channel (and can be purged later from
+the archive section).
+
+Everything here is idempotent and safe to run repeatedly. It only touches
+agent DM channels with no backing agent; a2a/group channels, project/idea
+channels, and human-to-human DMs are left untouched.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timezone
+
+logger = logging.getLogger(__name__)
+
+
+def _archive_timestamp() -> str:
+    """UTC timestamp as YYYYMMDDTHHMMSS, matching agent_archive naming."""
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
+
+
+def _agent_member(channel: dict) -> str | None:
+    """Return the agent-slug member of a DM channel, or None.
+
+    An agent DM channel has exactly the members ``["user", <slug>]``. The
+    non-"user" member is the agent slug. A human-to-human DM has two human
+    user ids and no "user" sentinel, so we return None for those.
+    """
+    members = channel.get("members") or []
+    others = [m for m in members if m != "user"]
+    if "user" in members and len(others) == 1:
+        return others[0]
+    return None
+
+
+def _is_agent_dm(channel: dict) -> bool:
+    """True only for 1:1 agent DM channels (``type='dm'`` with a single
+    agent-slug member alongside the "user" sentinel, and no project link)."""
+    if channel.get("type") != "dm":
+        return False
+    if channel.get("project_id"):
+        return False
+    return _agent_member(channel) is not None
+
+
+def _live_agent_slugs(config) -> set[str]:
+    return {a.get("name") for a in config.agents if a.get("name")}
+
+
+def _archived_agent_slugs(config) -> set[str]:
+    """Slugs that have a backing archived entry (by archived_slug or
+    original.name). These channels are already accounted for by the archive
+    flow, so we never re-touch them here."""
+    slugs: set[str] = set()
+    for entry in config.archived_agents:
+        slug = entry.get("archived_slug")
+        if slug:
+            slugs.add(slug)
+        orig_name = (entry.get("original") or {}).get("name")
+        if orig_name:
+            slugs.add(orig_name)
+    return slugs
+
+
+async def archive_orphan_channel(chat_channels, channel: dict, agent_id: str) -> None:
+    """Archive a single orphan DM channel, tagging it with the archive linkage.
+
+    Mirrors the channel-side of ``archive_agent_fully`` step 4b so the channel
+    looks identical to one archived through the normal path.
+    """
+    slug = _agent_member(channel) or ""
+    await chat_channels.set_settings(
+        channel["id"],
+        {
+            "archived": True,
+            "archived_at": _archive_timestamp(),
+            "archived_agent_id": agent_id,
+            "archived_agent_slug": slug,
+            "orphan_reconciled": True,
+        },
+    )
+
+
+async def reconcile_orphan_dm_channels(config, chat_channels) -> list[dict]:
+    """Archive live agent DM channels whose agent is in no list.
+
+    A DM channel is an orphan when its agent-slug member matches no live agent
+    (``config.agents``) and no archived agent (``config.archived_agents``).
+    Such channels are archived (and linked) rather than left live.
+
+    Returns a list of ``{"channel_id", "slug", "archived_agent_id"}`` for the
+    channels archived on this pass (empty when nothing to do). Idempotent:
+    once archived, a channel no longer appears in the non-archived listing, so
+    a second run is a no-op.
+    """
+    live = _live_agent_slugs(config)
+    archived = _archived_agent_slugs(config)
+    backed = live | archived
+
+    results: list[dict] = []
+    channels = await chat_channels.list_channels(archived=False)
+    for ch in channels:
+        if not _is_agent_dm(ch):
+            continue
+        slug = _agent_member(ch)
+        if slug in backed:
+            continue
+        agent_id = uuid.uuid4().hex[:12]
+        try:
+            await archive_orphan_channel(chat_channels, ch, agent_id)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "orphan reconcile: failed to archive channel %s (%s): %s",
+                ch.get("id"), slug, exc,
+            )
+            continue
+        logger.info(
+            "orphan reconcile: archived orphan DM channel %s for absent agent %s",
+            ch.get("id"), slug,
+        )
+        results.append(
+            {"channel_id": ch["id"], "slug": slug, "archived_agent_id": agent_id}
+        )
+    return results

--- a/tinyagentos/routes/agent_archive.py
+++ b/tinyagentos/routes/agent_archive.py
@@ -93,7 +93,26 @@ async def archive_agent_fully(request: Request, name: str) -> dict:
 
         if not has_chat_history and not has_trace_history:
             # Hard-delete: drop the config row and return. No tombstone for
-            # orphan rows from a never-used failed deploy.
+            # orphan rows from a never-used failed deploy. A DM channel may
+            # still exist (created on a prior deploy) with no messages -- archive
+            # it with the agent linkage so it is never left as a live orphan.
+            if channel_id:
+                try:
+                    ch_store = request.app.state.chat_channels
+                    await ch_store.set_settings(
+                        channel_id,
+                        {
+                            "archived": True,
+                            "archived_at": ts,
+                            "archived_agent_id": agent_id,
+                            "archived_agent_slug": slug,
+                        },
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "archive(orphan): channel flag failed for %s: %s",
+                        channel_id, exc,
+                    )
             config.agents = [a for a in config.agents if a["name"] != name]
             await save_config_locked(config, config.config_path)
             return {

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -881,6 +881,19 @@ async def purge_archived_agent(request: Request, archive_id: str):
     return await agent_archive.purge_archived(request, archive_id)
 
 
+@router.post("/api/agents/reconcile-orphan-channels")
+async def reconcile_orphan_channels(request: Request):
+    """Archive agent DM channels whose agent is in no list (active, failed,
+    or archived). Idempotent; never hard-deletes. Returns the channels
+    archived on this pass."""
+    from tinyagentos.chat.orphan_reconcile import reconcile_orphan_dm_channels
+
+    config = request.app.state.config
+    chat_channels = request.app.state.chat_channels
+    archived = await reconcile_orphan_dm_channels(config, chat_channels)
+    return {"status": "ok", "archived": archived, "count": len(archived)}
+
+
 @router.post("/api/agents/{name}/resume")
 async def resume_agent(request: Request, name: str):
     """Clear the paused flag on an agent, allowing it to accept new calls."""

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -890,8 +890,24 @@ async def reconcile_orphan_channels(request: Request):
 
     config = request.app.state.config
     chat_channels = request.app.state.chat_channels
-    archived = await reconcile_orphan_dm_channels(config, chat_channels)
+    registry_ids = await _registry_canonical_ids(request.app.state)
+    archived = await reconcile_orphan_dm_channels(
+        config, chat_channels, registry_ids=registry_ids
+    )
     return {"status": "ok", "archived": archived, "count": len(archived)}
+
+
+async def _registry_canonical_ids(state) -> list[str]:
+    """Best-effort list of canonical agent ids from the registry, so the
+    reconcile can recognise a former agent whose config row is gone."""
+    registry = getattr(state, "agent_registry", None)
+    if registry is None:
+        return []
+    try:
+        rows = await registry.list_all()
+    except Exception:  # noqa: BLE001
+        return []
+    return [r.get("canonical_id") for r in rows if r.get("canonical_id")]
 
 
 @router.post("/api/agents/{name}/resume")


### PR DESCRIPTION
## Problem

A taOS agent gets a 1:1 DM channel (`type="dm"`, members `["user", slug]`) on its first successful deploy. Most removal paths archive the channel alongside the agent, but a couple do not: the hard-delete branch of `archive_agent_fully` (a never-used config row with no container and no history) drops the agent record but leaves the DM channel live. The result is an orphan channel that shows in the Messages app while its agent appears in no list (active, failed, or archived). On the live Pi this produced two orphans (`hermes-confirm`, `deerflow-test`).

## Principle

Nothing is truly deleted, only archived. Real deletion requires an admin override from the archive section. So orphan channels are ARCHIVED (and tagged with the agent linkage), never hard-deleted.

## Changes

- **Hard-delete branch of `archive_agent_fully`** (`routes/agent_archive.py`): now archives the agent's DM channel with the same `settings.archived_agent_id` linkage before dropping the config row, instead of leaving it live. (`DELETE /api/agents/{name}/destroy` already delegates to `archive_agent_fully`, so it is covered.)
- **New idempotent reconciliation** (`chat/orphan_reconcile.py`): sweeps existing orphan agent DM channels and archives them. It only touches `type="dm"` channels whose single non-`"user"` member matches no live and no archived agent. a2a/group channels, project channels, and human-to-human DMs are left untouched. Never hard-deletes.
- **Startup wiring** (`app.py` lifespan) plus **`POST /api/agents/reconcile-orphan-channels`** for on-demand runs. The two existing Pi orphans are left for the reconcile to archive (not hard-deleted in code).

## Tests

`tests/test_orphan_channel_reconcile.py` covers:
- the destroy/hard-delete path archives the agent's DM channel instead of orphaning it,
- the reconciliation archives an orphan DM channel and leaves live-agent, a2a, project, and human-DM channels untouched,
- a channel backed by an archived agent is not re-touched,
- idempotency (second run is a no-op),
- the route surface.

All touched suites green: `tests/test_orphan_channel_reconcile.py`, `tests/test_routes_agents.py`, `tests/test_routes_agent_archive.py` (61 passed); plus chat-channel suites (99 passed across the related set). No `uv.lock` / `package.json` changes.