### PR TITLE
feat(agents): Import Agent wizard (Hermes bundle upload) -- UI slice

### DIFF
--- a/desktop/src/apps/AgentsApp.tsx
+++ b/desktop/src/apps/AgentsApp.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { useIsMobile } from "@/hooks/use-is-mobile";
-import { Bot, Plus, HardDrive, MessageSquare } from "lucide-react";
+import { Bot, Plus, HardDrive, MessageSquare, Upload } from "lucide-react";
 import { fetchLatestFrameworks, LatestVersion } from "@/lib/framework-api";
 import type { AgentShortcut } from "@/hooks/use-agent-shortcuts";
 import { useProcessStore } from "@/stores/process-store";
@@ -13,6 +13,7 @@ import { AgentRow } from "./agents/AgentRow";
 import { AgentDetailPanel, type DetailTab } from "./agents/AgentDetailPanel";
 import { TaosAgentDetailPanel } from "./agents/TaosAgentDetailPanel";
 import { DeployWizard } from "./agents/DeployWizard";
+import { ImportWizard } from "./agents/ImportWizard";
 import { ArchivedAgentsPanel } from "./agents/ArchivedAgents";
 import { RegistryPanel } from "./agents/RegistryPanel";
 import { fetchTaosAgentConfig } from "@/lib/taos-agent-api";
@@ -59,6 +60,7 @@ export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
   const [archived, setArchived] = useState<ArchivedAgent[]>([]);
   const [loading, setLoading] = useState(true);
   const [wizardOpen, setWizardOpen] = useState(false);
+  const [importWizardOpen, setImportWizardOpen] = useState(false);
   const [detail, setDetail] = useState<{ name: string; tab: DetailTab } | null>(null);
   const [taosDetailOpen, setTaosDetailOpen] = useState(false);
   const [diskStates, setDiskStates] = useState<Record<string, DiskState>>({});
@@ -401,6 +403,14 @@ export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
     }
   }
 
+  function handleImportWizardClose(imported?: boolean) {
+    setImportWizardOpen(false);
+    if (imported) {
+      fetchAgents();
+      fetchArchived();
+    }
+  }
+
   // Full-window detail view for a regular agent
   if (detail) {
     const agent = agents.find((a) => a.name === detail.name);
@@ -432,6 +442,7 @@ export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
             />
           </div>
           <DeployWizard open={wizardOpen} onClose={handleWizardClose} />
+          <ImportWizard open={importWizardOpen} onClose={handleImportWizardClose} />
         </div>
       );
     }
@@ -459,6 +470,7 @@ export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
           <TaosAgentDetailPanel onClose={() => setTaosDetailOpen(false)} fullHeight />
         </div>
         <DeployWizard open={wizardOpen} onClose={handleWizardClose} />
+        <ImportWizard open={importWizardOpen} onClose={handleImportWizardClose} />
       </div>
     );
   }
@@ -474,16 +486,27 @@ export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
             {agents.length} deployed
           </span>
         </div>
-        <Button
-          onClick={() => setWizardOpen(true)}
-          size="sm"
-          className="text-white shadow-lg hover:shadow-xl hover:-translate-y-0.5 hover:brightness-110 border-0 shrink-0"
-          style={{ background: "linear-gradient(135deg, #8b92a3, #5b6170)" }}
-          aria-label="Deploy new agent"
-        >
-          <Plus size={14} />
-          Deploy Agent
-        </Button>
+        <div className="flex items-center gap-2 shrink-0">
+          <Button
+            onClick={() => setImportWizardOpen(true)}
+            size="sm"
+            variant="outline"
+            aria-label="Import an existing agent"
+          >
+            <Upload size={14} />
+            Import Agent
+          </Button>
+          <Button
+            onClick={() => setWizardOpen(true)}
+            size="sm"
+            className="text-white shadow-lg hover:shadow-xl hover:-translate-y-0.5 hover:brightness-110 border-0"
+            style={{ background: "linear-gradient(135deg, #8b92a3, #5b6170)" }}
+            aria-label="Deploy new agent"
+          >
+            <Plus size={14} />
+            Deploy Agent
+          </Button>
+        </div>
       </div>
 
       {/* Content */}
@@ -640,6 +663,7 @@ export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
 
       {/* Deploy wizard overlay */}
       <DeployWizard open={wizardOpen} onClose={handleWizardClose} />
+      <ImportWizard open={importWizardOpen} onClose={handleImportWizardClose} />
     </div>
   );
 }

--- a/desktop/src/apps/agents/ImportWizard.tsx
+++ b/desktop/src/apps/agents/ImportWizard.tsx
@@ -1,0 +1,531 @@
+import { useState, useEffect, useRef } from "react";
+import { Upload, X, ChevronRight, ChevronLeft, Check, Plus, FileArchive, Copy, ExternalLink } from "lucide-react";
+import { Button, Card, Input, Label } from "@/components/ui";
+import { slugifyClient, isValidSlug, SLUG_REGEX } from "@/lib/slug";
+import {
+  validateBundleFile,
+  buildImportFormData,
+  formatBundleSize,
+  ACCEPTED_BUNDLE_EXTENSIONS,
+  type SecretRow,
+} from "./importBundle";
+
+/* ------------------------------------------------------------------ */
+/*  ImportWizard                                                        */
+/*                                                                     */
+/*  Mirrors DeployWizard's shell, step chrome and token usage. UI +    */
+/*  client-side only: the final Import POSTs a multipart bundle to the  */
+/*  placeholder /api/agents/import endpoint (backend is a later slice). */
+/* ------------------------------------------------------------------ */
+
+const FILE_ACCEPT = ACCEPTED_BUNDLE_EXTENSIONS.join(",");
+
+// Command the user runs in their existing Hermes CLI to produce the bundle.
+const HERMES_EXPORT_CMD = "hermes profile export <agent-name>";
+const HERMES_DOCS_URL =
+  "https://hermes-agent.nousresearch.com/docs/user-guide/profile-distributions";
+
+export function ImportWizard({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: (imported?: boolean) => void;
+}) {
+  const [step, setStep] = useState(0);
+
+  // Step 1: Bundle file
+  const [bundle, setBundle] = useState<File | null>(null);
+  const [dragging, setDragging] = useState(false);
+  const [cmdCopied, setCmdCopied] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  // Step 2: Details
+  const [name, setName] = useState("");
+  const [customSlug, setCustomSlug] = useState<string | null>(null);
+  const [editingSlug, setEditingSlug] = useState(false);
+  const [model, setModel] = useState("");
+  const [secrets, setSecrets] = useState<SecretRow[]>([]);
+
+  const [importing, setImporting] = useState(false);
+  const [importError, setImportError] = useState<string | null>(null);
+
+  // Reset when opened
+  useEffect(() => {
+    if (open) {
+      setStep(0);
+      setBundle(null);
+      setDragging(false);
+      setCmdCopied(false);
+      setName("");
+      setCustomSlug(null);
+      setEditingSlug(false);
+      setModel("");
+      setSecrets([]);
+      setImporting(false);
+      setImportError(null);
+    }
+  }, [open]);
+
+  if (!open) return null;
+
+  const STEPS = ["Framework", "Bundle", "Details", "Review"];
+  const totalSteps = STEPS.length;
+  const reviewStep = totalSteps - 1;
+
+  const bundleCheck = validateBundleFile(bundle);
+
+  const canNext = () => {
+    if (step === 0) return true; // Hermes locked in
+    if (step === 1) return bundleCheck.ok;
+    if (step === 2) {
+      if (name.trim().length === 0) return false;
+      if (customSlug !== null && !isValidSlug(customSlug)) return false;
+      return true;
+    }
+    return true;
+  };
+
+  function handleFiles(files: FileList | null) {
+    const f = files && files[0] ? files[0] : null;
+    if (f) setBundle(f);
+  }
+
+  async function handleCopyCmd() {
+    try {
+      if (navigator.clipboard && window.isSecureContext) {
+        await navigator.clipboard.writeText(HERMES_EXPORT_CMD);
+        setCmdCopied(true);
+        setTimeout(() => setCmdCopied(false), 2000);
+      }
+    } catch { /* clipboard unavailable: the command stays visible to copy by hand */ }
+  }
+
+  function updateSecret(i: number, patch: Partial<SecretRow>) {
+    setSecrets((prev) => prev.map((row, j) => (j === i ? { ...row, ...patch } : row)));
+  }
+
+  async function handleImport() {
+    const check = validateBundleFile(bundle);
+    if (!check.ok || !bundle) {
+      setImportError(check.error ?? "Select a valid bundle.");
+      return;
+    }
+    setImporting(true);
+    setImportError(null);
+    try {
+      const fd = buildImportFormData({
+        framework: "hermes",
+        bundle,
+        name: customSlug || name.trim(),
+        model,
+        secrets,
+      });
+      const res = await fetch("/api/agents/import", {
+        method: "POST",
+        credentials: "include",
+        body: fd,
+      });
+      if (!res.ok) {
+        let msg = `Import failed (${res.status})`;
+        try {
+          const err = await res.json();
+          if (err?.error) msg = String(err.error);
+        } catch { /* non-JSON error body: keep status message */ }
+        setImportError(msg);
+        setImporting(false);
+        return;
+      }
+      onClose(true);
+    } catch (e) {
+      setImportError(e instanceof Error ? e.message : "Network error");
+      setImporting(false);
+    }
+  }
+
+  return (
+    <div
+      className="absolute inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
+      style={{
+        paddingTop: "calc(1rem + env(safe-area-inset-top, 0px))",
+        paddingBottom: "calc(1rem + env(safe-area-inset-bottom, 0px))",
+      }}
+      onClick={() => onClose()}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Import Agent"
+    >
+      <div
+        className="w-full max-w-lg max-h-full min-h-0 bg-shell-surface rounded-xl border border-white/10 shadow-2xl overflow-hidden flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-white/5 shrink-0">
+          <div className="flex items-center gap-2">
+            <Upload size={16} className="text-accent" />
+            <h2 className="text-sm font-semibold">Import Agent</h2>
+          </div>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            onClick={() => onClose()}
+            aria-label="Close wizard"
+          >
+            <X size={16} />
+          </Button>
+        </div>
+
+        {/* Step indicators */}
+        <div className="flex items-center gap-1 px-5 py-3 border-b border-white/5 shrink-0 overflow-x-auto">
+          {STEPS.map((label, i) => (
+            <div key={label} className="flex items-center gap-1">
+              <div
+                className={`w-6 h-6 rounded-full flex items-center justify-center text-[10px] font-medium transition-colors ${
+                  i < step
+                    ? "bg-accent/20 text-accent"
+                    : i === step
+                      ? "bg-accent text-white"
+                      : "bg-white/5 text-shell-text-tertiary"
+                }`}
+              >
+                {i < step ? <Check size={12} /> : i + 1}
+              </div>
+              <span
+                className={`text-[11px] hidden sm:inline ${
+                  i === step ? "text-shell-text" : "text-shell-text-tertiary"
+                }`}
+              >
+                {label}
+              </span>
+              {i < STEPS.length - 1 && <div className="w-4 h-px bg-white/10 mx-0.5" />}
+            </div>
+          ))}
+        </div>
+
+        {/* Body */}
+        <div className="px-5 py-5 flex-1 min-h-0 overflow-y-auto">
+          {/* Step 0: Framework (Hermes locked) */}
+          {step === 0 && (
+            <div className="space-y-2">
+              <span className="block text-xs text-shell-text-secondary mb-2">Source Framework</span>
+              <div className="w-full text-left px-4 py-3 rounded-lg border border-accent bg-accent/10">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium">Hermes</span>
+                  <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-500/20 text-amber-400 leading-none">
+                    Beta
+                  </span>
+                </div>
+                <div className="text-xs mt-0.5 text-shell-text-secondary">
+                  Import a profile bundle exported with <code>hermes profile export</code>.
+                </div>
+              </div>
+              <p className="text-xs text-shell-text-tertiary mt-3">
+                More frameworks are coming. For now, only Hermes bundles can be imported.
+              </p>
+            </div>
+          )}
+
+          {/* Step 1: Bundle upload */}
+          {step === 1 && (
+            <div className="space-y-3">
+              <span className="block text-xs text-shell-text-secondary mb-2">Profile Bundle</span>
+
+              {/* How to get your bundle */}
+              <div className="rounded-lg border border-white/10 bg-shell-bg-deep px-4 py-3 space-y-2.5">
+                <div className="text-xs font-medium text-shell-text">How to get your bundle</div>
+                <p className="text-xs text-shell-text-secondary leading-relaxed">
+                  taOS imports a Hermes profile export bundle. In your existing Hermes CLI, run the
+                  command below to produce a portable archive (.tar.gz / .zip), then upload it here.
+                </p>
+                <div className="flex items-center gap-2 px-2.5 py-1.5 rounded-md border border-white/10 bg-shell-surface">
+                  <code className="flex-1 min-w-0 text-xs font-mono text-shell-text truncate">
+                    {HERMES_EXPORT_CMD}
+                  </code>
+                  <button
+                    type="button"
+                    onClick={handleCopyCmd}
+                    className="flex items-center gap-1 text-xs text-shell-text-tertiary hover:text-shell-text transition-colors shrink-0"
+                    aria-label="Copy export command"
+                  >
+                    {cmdCopied ? <Check size={13} /> : <Copy size={13} />}
+                    {cmdCopied ? "Copied" : "Copy"}
+                  </button>
+                </div>
+                <p className="text-xs text-shell-text-tertiary leading-relaxed">
+                  Your API keys are not in the bundle by design, so you'll add those in the Secrets step.
+                </p>
+                <a
+                  href={HERMES_DOCS_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-xs text-blue-400 hover:underline"
+                >
+                  Learn more
+                  <ExternalLink size={12} />
+                </a>
+              </div>
+
+              <div
+                role="button"
+                tabIndex={0}
+                aria-label="Choose a profile bundle, or drop a file here"
+                onClick={() => fileInputRef.current?.click()}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    fileInputRef.current?.click();
+                  }
+                }}
+                onDragOver={(e) => {
+                  e.preventDefault();
+                  setDragging(true);
+                }}
+                onDragLeave={() => setDragging(false)}
+                onDrop={(e) => {
+                  e.preventDefault();
+                  setDragging(false);
+                  handleFiles(e.dataTransfer.files);
+                }}
+                className={`flex flex-col items-center justify-center gap-2 px-4 py-8 rounded-lg border border-dashed text-center cursor-pointer transition-colors ${
+                  dragging
+                    ? "border-accent bg-accent/10"
+                    : "border-white/15 bg-shell-bg-deep hover:bg-white/5"
+                }`}
+              >
+                <Upload size={22} className="text-shell-text-tertiary" />
+                <div className="text-sm text-shell-text">
+                  Drop your bundle here, or <span className="text-blue-400">browse</span>
+                </div>
+                <div className="text-xs text-shell-text-tertiary">
+                  {ACCEPTED_BUNDLE_EXTENSIONS.join(", ")} · up to 200 MB
+                </div>
+              </div>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept={FILE_ACCEPT}
+                className="sr-only"
+                aria-hidden="true"
+                tabIndex={-1}
+                onChange={(e) => handleFiles(e.target.files)}
+              />
+
+              {bundle && (
+                <div className="flex items-center gap-2 px-3 py-2.5 rounded-lg border border-accent/30 bg-accent/5">
+                  <FileArchive size={16} className="text-accent shrink-0" />
+                  <div className="min-w-0 flex-1">
+                    <div className="text-sm font-medium truncate">{bundle.name}</div>
+                    <div className="text-xs text-shell-text-tertiary">{formatBundleSize(bundle.size)}</div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => setBundle(null)}
+                    className="text-shell-text-tertiary hover:text-red-400 transition-colors shrink-0"
+                    aria-label="Remove selected bundle"
+                  >
+                    <X size={14} />
+                  </button>
+                </div>
+              )}
+
+              {bundle && !bundleCheck.ok && bundleCheck.error && (
+                <p className="text-xs text-red-400" role="alert">{bundleCheck.error}</p>
+              )}
+
+              <p className="text-xs text-shell-text-tertiary">
+                Secrets are not included in the bundle by design, so you'll supply them in the next step.
+              </p>
+            </div>
+          )}
+
+          {/* Step 2: Details */}
+          {step === 2 && (
+            <Card className="p-0 border-0 bg-transparent shadow-none space-y-4">
+              <div>
+                <Label htmlFor="import-agent-name" className="mb-1.5 block">
+                  Agent Name
+                </Label>
+                <Input
+                  id="import-agent-name"
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="my-agent"
+                  autoFocus
+                />
+                {(() => {
+                  const derivedSlug = slugifyClient(name);
+                  const slug = customSlug ?? derivedSlug;
+                  const slugInvalid = customSlug !== null && !isValidSlug(customSlug);
+                  return (
+                    <>
+                      <div className="text-xs opacity-60 mt-1">
+                        Slug: <code>{slug || "—"}</code>{" "}
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setCustomSlug(customSlug ?? derivedSlug);
+                            setEditingSlug(true);
+                          }}
+                          className="text-blue-400 hover:underline"
+                        >
+                          edit
+                        </button>
+                      </div>
+                      {editingSlug && (
+                        <Input
+                          value={customSlug ?? derivedSlug}
+                          onChange={(e) => setCustomSlug(e.target.value)}
+                          onBlur={() => setEditingSlug(false)}
+                          className="mt-1 text-sm"
+                          aria-label="Edit slug"
+                          pattern={SLUG_REGEX.source}
+                        />
+                      )}
+                      {slugInvalid && (
+                        <p className="mt-1 text-xs text-red-400">
+                          Slug must match <code>[a-z0-9][a-z0-9-]&#123;0,62&#125;</code>
+                        </p>
+                      )}
+                    </>
+                  );
+                })()}
+              </div>
+
+              <div>
+                <Label htmlFor="import-agent-model" className="mb-1.5 block">
+                  Model
+                  <span className="ml-1.5 font-normal text-shell-text-tertiary">(optional)</span>
+                </Label>
+                <Input
+                  id="import-agent-model"
+                  type="text"
+                  value={model}
+                  onChange={(e) => setModel(e.target.value)}
+                  placeholder="Leave empty to keep the bundle's model"
+                  aria-describedby="import-agent-model-desc"
+                />
+                <p id="import-agent-model-desc" className="mt-1 text-xs text-shell-text-tertiary">
+                  Override the chat model, or leave blank to use the one recorded in the bundle.
+                </p>
+              </div>
+
+              <div>
+                <Label className="mb-1.5 block">
+                  Secrets
+                  <span className="ml-1.5 font-normal text-shell-text-tertiary">
+                    (env vars required by the bundle)
+                  </span>
+                </Label>
+                <div className="space-y-1.5">
+                  {secrets.map((row, i) => (
+                    <div key={i} className="flex items-center gap-2">
+                      <Input
+                        value={row.key}
+                        onChange={(e) => updateSecret(i, { key: e.target.value })}
+                        placeholder="ENV_VAR_NAME"
+                        className="flex-1 text-sm font-mono"
+                        aria-label={`Secret name ${i + 1}`}
+                      />
+                      <Input
+                        value={row.value}
+                        onChange={(e) => updateSecret(i, { value: e.target.value })}
+                        placeholder="value"
+                        type="password"
+                        className="flex-1 text-sm"
+                        aria-label={`Secret value ${i + 1}`}
+                      />
+                      <button
+                        type="button"
+                        onClick={() => setSecrets((prev) => prev.filter((_, j) => j !== i))}
+                        className="text-shell-text-tertiary hover:text-red-400 transition-colors shrink-0"
+                        aria-label={`Remove secret ${i + 1}`}
+                      >
+                        <X size={14} />
+                      </button>
+                    </div>
+                  ))}
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setSecrets((prev) => [...prev, { key: "", value: "" }])}
+                    className="w-full"
+                  >
+                    <Plus size={13} />
+                    Add secret
+                  </Button>
+                </div>
+              </div>
+            </Card>
+          )}
+
+          {/* Step 3: Review */}
+          {step === 3 && (
+            <div className="space-y-3">
+              <span className="block text-xs text-shell-text-secondary mb-2">Review Import</span>
+              <div className="rounded-lg bg-shell-bg-deep border border-white/5 divide-y divide-white/5">
+                {[
+                  ["Framework", "Hermes"],
+                  ["Bundle", bundle ? `${bundle.name} (${formatBundleSize(bundle.size)})` : "—"],
+                  ["Name", customSlug || name.trim() || "—"],
+                  ["Model", model.trim() || "From bundle"],
+                  ["Secrets", `${secrets.filter((r) => r.key.trim()).length} provided`],
+                ].map(([label, value]) => (
+                  <div key={label} className="flex items-center justify-between px-4 py-2.5 gap-3">
+                    <span className="text-xs text-shell-text-secondary shrink-0">{label}</span>
+                    <span className="text-sm font-medium truncate text-right">{value}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Error */}
+        {importError && (
+          <div className="mx-5 mb-3 px-3 py-2 rounded-lg bg-red-500/15 border border-red-500/30 text-xs text-red-300 flex items-start justify-between gap-2">
+            <span role="alert" className="min-w-0">{importError}</span>
+            <button
+              type="button"
+              onClick={() => setImportError(null)}
+              className="text-red-300/70 hover:text-red-200 shrink-0"
+              aria-label="Dismiss error"
+            >
+              <X size={13} />
+            </button>
+          </div>
+        )}
+
+        {/* Footer */}
+        <div className="flex items-center justify-between px-5 py-3 border-t border-white/5 shrink-0">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => (step === 0 ? onClose() : setStep(step - 1))}
+          >
+            <ChevronLeft size={14} />
+            {step === 0 ? "Cancel" : "Back"}
+          </Button>
+
+          {step < reviewStep ? (
+            <Button size="sm" onClick={() => setStep(step + 1)} disabled={!canNext()}>
+              Next
+              <ChevronRight size={14} />
+            </Button>
+          ) : (
+            <Button
+              size="sm"
+              onClick={handleImport}
+              disabled={importing}
+              className="bg-emerald-600 hover:bg-emerald-500 text-white"
+            >
+              <Upload size={13} />
+              {importing ? "Importing..." : "Import Agent"}
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/apps/agents/importBundle.test.ts
+++ b/desktop/src/apps/agents/importBundle.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import {
+  validateBundleFile,
+  buildImportFormData,
+  secretsRowsToObject,
+  formatBundleSize,
+  MAX_BUNDLE_BYTES,
+  type SecretRow,
+} from "./importBundle";
+
+function makeFile(name: string, size: number): File {
+  // A File backed by a Blob of the requested byte length.
+  const blob = new Blob([new Uint8Array(size)]);
+  return new File([blob], name, { type: "application/octet-stream" });
+}
+
+describe("validateBundleFile", () => {
+  it("rejects a missing file", () => {
+    const r = validateBundleFile(null);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/select/i);
+  });
+
+  it("rejects an empty file", () => {
+    const r = validateBundleFile(makeFile("agent.zip", 0));
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/empty/i);
+  });
+
+  it("rejects an unsupported extension", () => {
+    const r = validateBundleFile(makeFile("agent.txt", 10));
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/unsupported/i);
+  });
+
+  it("rejects a file over the size cap", () => {
+    // Avoid allocating 200MB+: stub a File-like object with an oversized size.
+    const big = { name: "agent.zip", size: MAX_BUNDLE_BYTES + 1 } as File;
+    const r = validateBundleFile(big);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/too large/i);
+  });
+
+  it("accepts .zip, .tar.gz and .tgz", () => {
+    expect(validateBundleFile(makeFile("agent.zip", 10)).ok).toBe(true);
+    expect(validateBundleFile(makeFile("agent.tar.gz", 10)).ok).toBe(true);
+    expect(validateBundleFile(makeFile("agent.tgz", 10)).ok).toBe(true);
+  });
+
+  it("matches extensions case-insensitively", () => {
+    expect(validateBundleFile(makeFile("AGENT.ZIP", 10)).ok).toBe(true);
+  });
+});
+
+describe("secretsRowsToObject", () => {
+  it("drops blank keys and trims them", () => {
+    const rows: SecretRow[] = [
+      { key: "  OPENAI_API_KEY  ", value: "sk-1" },
+      { key: "", value: "ignored" },
+      { key: "   ", value: "also-ignored" },
+    ];
+    expect(secretsRowsToObject(rows)).toEqual({ OPENAI_API_KEY: "sk-1" });
+  });
+
+  it("keeps the last value on duplicate keys", () => {
+    const rows: SecretRow[] = [
+      { key: "TOKEN", value: "a" },
+      { key: "TOKEN", value: "b" },
+    ];
+    expect(secretsRowsToObject(rows)).toEqual({ TOKEN: "b" });
+  });
+});
+
+describe("formatBundleSize", () => {
+  it("formats bytes, KB and MB", () => {
+    expect(formatBundleSize(512)).toBe("512 B");
+    expect(formatBundleSize(2048)).toBe("2.0 KB");
+    expect(formatBundleSize(5 * 1024 * 1024)).toBe("5.0 MB");
+  });
+});
+
+describe("buildImportFormData", () => {
+  it("assembles the multipart payload with framework, file, name, model and secrets JSON", () => {
+    const bundle = makeFile("agent.tar.gz", 16);
+    const fd = buildImportFormData({
+      framework: "hermes",
+      bundle,
+      name: "  My Agent  ",
+      model: "  gpt-4o  ",
+      secrets: [
+        { key: "API_KEY", value: "secret" },
+        { key: "", value: "skip" },
+      ],
+    });
+
+    expect(fd.get("framework")).toBe("hermes");
+    expect(fd.get("name")).toBe("My Agent");
+    expect(fd.get("model")).toBe("gpt-4o");
+    expect(fd.get("secrets")).toBe(JSON.stringify({ API_KEY: "secret" }));
+
+    const file = fd.get("bundle");
+    expect(file).toBeInstanceOf(File);
+    expect((file as File).name).toBe("agent.tar.gz");
+  });
+
+  it("omits an empty model field", () => {
+    const fd = buildImportFormData({
+      framework: "hermes",
+      bundle: makeFile("a.zip", 4),
+      name: "x",
+      model: "   ",
+      secrets: [],
+    });
+    expect(fd.has("model")).toBe(false);
+    expect(fd.get("secrets")).toBe("{}");
+  });
+});

--- a/desktop/src/apps/agents/importBundle.ts
+++ b/desktop/src/apps/agents/importBundle.ts
@@ -1,0 +1,86 @@
+/* ------------------------------------------------------------------ */
+/*  Import Agent: pure client-side helpers                             */
+/*                                                                     */
+/*  Bundle file validation and FormData payload assembly for the       */
+/*  Import wizard. Kept framework-free so they are unit-testable        */
+/*  (mirrors MessagesApp.a2aSelection.ts).                             */
+/* ------------------------------------------------------------------ */
+
+/** Accepted bundle extensions produced by `hermes profile export`. */
+export const ACCEPTED_BUNDLE_EXTENSIONS = [".zip", ".tar.gz", ".tgz"] as const;
+
+/** Client-side size cap. The real limit is enforced by the backend later. */
+export const MAX_BUNDLE_BYTES = 200 * 1024 * 1024; // 200 MB
+
+export interface BundleValidation {
+  ok: boolean;
+  error: string | null;
+}
+
+/** A single secret env-var row entered by the user. */
+export interface SecretRow {
+  key: string;
+  value: string;
+}
+
+/**
+ * Validate a chosen bundle file: must be non-empty, within the size cap, and
+ * carry an accepted extension. Returns the first failure, or ok.
+ */
+export function validateBundleFile(file: File | null): BundleValidation {
+  if (!file) return { ok: false, error: "Select a profile bundle to import." };
+  if (file.size === 0) return { ok: false, error: "The selected file is empty." };
+  if (file.size > MAX_BUNDLE_BYTES) {
+    return { ok: false, error: `Bundle is too large (max ${MAX_BUNDLE_BYTES / (1024 * 1024)} MB).` };
+  }
+  const lower = file.name.toLowerCase();
+  const hasExt = ACCEPTED_BUNDLE_EXTENSIONS.some((ext) => lower.endsWith(ext));
+  if (!hasExt) {
+    return { ok: false, error: `Unsupported file type. Use ${ACCEPTED_BUNDLE_EXTENSIONS.join(", ")}.` };
+  }
+  return { ok: true, error: null };
+}
+
+/** Human-readable file size, e.g. "12.3 MB". */
+export function formatBundleSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/**
+ * Collapse secret rows into a `{ KEY: value }` object. Blank keys are dropped
+ * and trimmed; on duplicate keys the last non-empty value wins.
+ */
+export function secretsRowsToObject(rows: SecretRow[]): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const row of rows) {
+    const key = row.key.trim();
+    if (!key) continue;
+    out[key] = row.value;
+  }
+  return out;
+}
+
+export interface ImportPayloadInput {
+  framework: string;
+  bundle: File;
+  name: string;
+  model: string;
+  secrets: SecretRow[];
+}
+
+/**
+ * Build the multipart FormData POSTed to /api/agents/import. Secrets are
+ * serialized as a JSON string under the `secrets` field. The agent name is
+ * trimmed; an empty model is omitted.
+ */
+export function buildImportFormData(input: ImportPayloadInput): FormData {
+  const fd = new FormData();
+  fd.append("framework", input.framework);
+  fd.append("bundle", input.bundle);
+  fd.append("name", input.name.trim());
+  if (input.model.trim()) fd.append("model", input.model.trim());
+  fd.append("secrets", JSON.stringify(secretsRowsToObject(input.secrets)));
+  return fd;
+}


### PR DESCRIPTION
## Summary

Slice 1 of the Import Agent feature (UI shell, mock-first). Adds an **Import Agent** button beside the existing **Deploy Agent** button in the Agents app, opening a new `ImportWizard` for bringing an existing Hermes agent into taOS by uploading its profile export bundle in the browser.

This slice is UI + client-side only. The backend import endpoint is a separate later slice, so the final Import action POSTs to a placeholder `/api/agents/import` (multipart) and surfaces success/error.

## What's included

- **AgentsApp toolbar**: `Import Agent` (outline) button next to `Deploy Agent`, plus an `importWizardOpen` state and `ImportWizard` mounts mirroring the three existing `DeployWizard` mount points. Surgical: no DeployWizard refactor.
- **ImportWizard.tsx**: mirrors DeployWizard's modal shell, step-indicator chrome, footer nav, and theme-aware tokens (`shell-surface`, `shell-bg-deep`, `accent`, `white/10` borders) so it is consistent across light/dark/indigo. Steps:
  1. **Framework**: Hermes shown selected and locked with a Beta badge and a "more frameworks coming" note.
  2. **Bundle**: drag-and-drop + browse file picker (`accept=.zip,.tar.gz,.tgz`), file name + size once selected, client-side validation (non-empty, 200 MB cap, accepted extension). Includes a compact **How to get your bundle** callout with the copyable `hermes profile export <agent-name>` command, a note that secrets are excluded by design, and a "Learn more" link to the Hermes profile-distributions docs (new tab).
  3. **Details**: agent name (reuses `slugifyClient` / `isValidSlug` / `SLUG_REGEX` slug validation from DeployWizard), optional model override, and a free-form Secrets section (add/remove env-var rows).
  4. **Review + Import**: summary; Import builds multipart `FormData` (framework=hermes, bundle, name, model, secrets JSON) and POSTs to `/api/agents/import` with `credentials: "include"`. Dismissible inline error on failure (including the expected 404/501 until the backend exists); on success, closes and refreshes the agent list via the same `fetchAgents`/`fetchArchived` path Deploy uses. No `<form>` submit; button `onClick` only.
- **importBundle.ts**: extracted pure helpers (`validateBundleFile`, `secretsRowsToObject`, `buildImportFormData`, `formatBundleSize`) mirroring the `MessagesApp.a2aSelection.ts` pattern.
- **importBundle.test.ts**: 11 vitest cases covering file validation (missing/empty/size cap/extension/case-insensitive) and FormData payload assembly (name trim, model omission, secrets JSON).

## Notes

- DeployWizard's name/slug validation is imported and reused. Its model picker (`ModelPickerFlow`) is tightly coupled to a live `/api/models` cluster fetch and a `selectedModel`-id model, so for this slice the import wizard uses a simple optional model text override; richer model selection can come when the backend import slice lands.
- The `"—"` empty-state glyph in the slug line and review table mirrors DeployWizard's existing convention for visual consistency.

## Verification

- `vitest run src/apps/agents/importBundle.test.ts`: 11/11 passing.
- `tsc --noEmit`: clean for touched files (pre-existing unrelated `@excalidraw` dependency noise ignored).
- `package.json` / lockfiles untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TooGjpNYPpUHsWxKanaT9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Import Agent” workflow with a guided multi-step wizard.
  * Users can upload an agent bundle by browsing or drag-and-drop, review details, add secrets, and complete the import.
  * Added copy-to-clipboard support for the import command and clearer bundle/file details.

* **Bug Fixes**
  * Improved validation and error handling for bundle uploads and import submissions.
  * Imported agents now refresh in the list automatically after a successful import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->