### PR TITLE
feat(agents): POST /api/agents/import -- import a Hermes agent from an uploaded profile bundle

### DIFF
--- a/tests/test_agents_import_hermes.py
+++ b/tests/test_agents_import_hermes.py
@@ -1,0 +1,218 @@
+"""Tests for POST /api/agents/import: Hermes profile-bundle import."""
+import asyncio
+import io
+
+import pytest
+
+
+def _bundle(content=b"PK\x03\x04 fake-bundle", filename="profile.zip"):
+    return {"bundle": (filename, io.BytesIO(content), "application/zip")}
+
+
+@pytest.mark.asyncio
+class TestHermesImportValidation:
+    async def test_non_hermes_framework_rejected(self, client):
+        resp = await client.post(
+            "/api/agents/import",
+            data={"framework": "smolagents", "name": "x"},
+            files=_bundle(),
+        )
+        assert resp.status_code == 400
+        assert "hermes" in resp.json()["error"].lower()
+
+    async def test_missing_bundle_rejected(self, client):
+        resp = await client.post(
+            "/api/agents/import",
+            data={"framework": "hermes", "name": "x"},
+        )
+        assert resp.status_code == 400
+        assert "bundle" in resp.json()["error"].lower()
+
+    async def test_bad_extension_rejected(self, client):
+        resp = await client.post(
+            "/api/agents/import",
+            data={"framework": "hermes", "name": "x"},
+            files=_bundle(filename="profile.txt"),
+        )
+        assert resp.status_code == 400
+        assert resp.json()["error"]
+
+    async def test_empty_bundle_rejected(self, client):
+        resp = await client.post(
+            "/api/agents/import",
+            data={"framework": "hermes", "name": "x"},
+            files=_bundle(content=b""),
+        )
+        assert resp.status_code == 400
+        assert "empty" in resp.json()["error"].lower()
+
+    async def test_oversize_bundle_rejected(self, client, monkeypatch):
+        from tinyagentos.routes import agent_import
+        monkeypatch.setattr(agent_import, "MAX_BUNDLE_BYTES", 8)
+        resp = await client.post(
+            "/api/agents/import",
+            data={"framework": "hermes", "name": "x"},
+            files=_bundle(content=b"way too many bytes here"),
+        )
+        assert resp.status_code == 400
+        assert "limit" in resp.json()["error"].lower()
+
+    async def test_invalid_name_rejected(self, client):
+        resp = await client.post(
+            "/api/agents/import",
+            data={"framework": "hermes", "name": "   "},
+            files=_bundle(),
+        )
+        assert resp.status_code == 400
+
+    async def test_bad_secrets_json_rejected(self, client):
+        resp = await client.post(
+            "/api/agents/import",
+            data={"framework": "hermes", "name": "x", "secrets": "not-json"},
+            files=_bundle(),
+        )
+        assert resp.status_code == 400
+        assert "secrets" in resp.json()["error"].lower()
+
+
+@pytest.mark.asyncio
+class TestHermesImportHappyPath:
+    async def test_import_runs_profile_import_and_reads_back_persona(
+        self, client, app, monkeypatch
+    ):
+        # Mock the deploy so no real container is created.
+        async def fake_deploy(req):
+            assert req.framework == "hermes"
+            return {
+                "success": True, "name": req.name, "ip": "10.0.0.88",
+                "llm_key": "sk-imported", "steps": ["deployment_complete"],
+                "container": f"taos-agent-{req.name}",
+            }
+        monkeypatch.setattr("tinyagentos.deployer.deploy_agent", fake_deploy)
+
+        pushed = {}
+
+        async def fake_push_file(container, src, dst):
+            pushed["container"] = container
+            pushed["dst"] = dst
+            return 0, ""
+        monkeypatch.setattr("tinyagentos.containers.push_file", fake_push_file)
+
+        calls = []
+
+        async def fake_exec(container, cmd, timeout=None):
+            calls.append(cmd)
+            # binary probe
+            if cmd[:1] == ["test"]:
+                return (0, "") if cmd[-1] == "/usr/local/bin/hermes" else (1, "")
+            # `hermes profile import <path>`
+            if "profile" in cmd and "import" in cmd:
+                return 0, "imported profile ok"
+            # persona readback: SOUL.md
+            if cmd[:1] == ["cat"] and cmd[-1].endswith("SOUL.md"):
+                return 0, "You are an imported soul."
+            # persona readback: config.yaml
+            if cmd[:1] == ["cat"] and cmd[-1].endswith("config.yaml"):
+                return 0, "default_model: nous/hermes-3\n"
+            return 1, ""
+        monkeypatch.setattr("tinyagentos.containers.exec_in_container", fake_exec)
+
+        resp = await client.post(
+            "/api/agents/import",
+            data={
+                "framework": "hermes",
+                "name": "imported-hermes",
+                "secrets": '{"OPENROUTER_API_KEY": "sk-or-xyz"}',
+            },
+            files=_bundle(),
+        )
+        assert resp.status_code == 202
+        body = resp.json()
+        assert body["status"] == "importing"
+        slug = body["name"]
+        assert slug == "imported-hermes"
+
+        # Let the background task run.
+        for _ in range(20):
+            await asyncio.sleep(0.05)
+            task = app.state.deploy_tasks.get(slug)
+            if task and task["status"] in ("success", "failed"):
+                break
+
+        task = app.state.deploy_tasks.get(slug)
+        assert task is not None, "background import task should have recorded a result"
+        assert task["status"] == "success", task
+
+        # `hermes profile import <pushed-path>` was invoked with the pushed path.
+        import_calls = [c for c in calls if "profile" in c and "import" in c]
+        assert import_calls, "hermes profile import should have run"
+        assert pushed["dst"] in import_calls[0], "import should target the pushed bundle path"
+
+        # Persona readback populated soul_md + model on the agent record.
+        detail = await client.get(f"/api/agents/{slug}")
+        agent = detail.json()
+        assert agent["status"] == "running"
+        assert agent["soul_md"] == "You are an imported soul."
+        assert agent["model"] == "nous/hermes-3"
+        assert agent["llm_key"] == "sk-imported"
+
+        # The user-supplied secret was granted to the agent (same path deploy uses).
+        granted = await app.state.secrets.get_agent_secrets(slug)
+        names = {s["name"] for s in granted}
+        assert f"{slug}-OPENROUTER_API_KEY" in names
+
+    async def test_failed_profile_import_surfaces_error(self, client, app, monkeypatch):
+        async def fake_deploy(req):
+            return {
+                "success": True, "name": req.name, "ip": "10.0.0.89",
+                "llm_key": None, "steps": ["deployment_complete"],
+                "container": f"taos-agent-{req.name}",
+            }
+        monkeypatch.setattr("tinyagentos.deployer.deploy_agent", fake_deploy)
+
+        async def fake_push_file(container, src, dst):
+            return 0, ""
+        monkeypatch.setattr("tinyagentos.containers.push_file", fake_push_file)
+
+        async def fake_exec(container, cmd, timeout=None):
+            if cmd[:1] == ["test"]:
+                return (0, "") if cmd[-1] == "/usr/local/bin/hermes" else (1, "")
+            if "profile" in cmd and "import" in cmd:
+                return 2, "boom: corrupt bundle"
+            return 1, ""
+        monkeypatch.setattr("tinyagentos.containers.exec_in_container", fake_exec)
+
+        resp = await client.post(
+            "/api/agents/import",
+            data={"framework": "hermes", "name": "broken-import"},
+            files=_bundle(),
+        )
+        assert resp.status_code == 202
+        slug = resp.json()["name"]
+
+        for _ in range(20):
+            await asyncio.sleep(0.05)
+            task = app.state.deploy_tasks.get(slug)
+            if task and task["status"] in ("success", "failed"):
+                break
+
+        task = app.state.deploy_tasks.get(slug)
+        assert task["status"] == "failed"
+        assert "profile import" in task["error"].lower()
+
+        detail = await client.get(f"/api/agents/{slug}")
+        assert detail.json()["status"] == "failed"
+
+
+@pytest.mark.asyncio
+class TestJsonImportStillWorks:
+    async def test_json_config_import_unchanged(self, client):
+        payload = {
+            "version": 1,
+            "agent": {"name": "json-imported", "host": "10.0.0.5", "color": "#fff"},
+            "channels": [],
+            "groups": [],
+        }
+        resp = await client.post("/api/agents/import", json=payload)
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "imported"

--- a/tinyagentos/routes/agent_import.py
+++ b/tinyagentos/routes/agent_import.py
@@ -1,0 +1,369 @@
+"""Hermes profile-bundle import: deploy a Hermes agent then restore its
+exported profile inside the container.
+
+The user uploads a Hermes profile EXPORT bundle (produced by
+``hermes profile export <name>``). taOS deploys a fresh Hermes-framework
+agent reusing the normal deploy path, and as a post-provision step pushes
+the bundle into the container and runs ``hermes profile import`` so the
+agent's personality (SOUL.md, config.yaml, skills, cron, mcp.json) is
+restored. Secrets/.env are excluded from the bundle by design; the user
+supplies them and taOS injects them through the same agent-secrets path
+deploy already uses.
+
+Route decorators stay in agents.py; only the business logic lives here.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+
+from fastapi import Request, UploadFile
+from fastapi.responses import JSONResponse
+
+from tinyagentos.agent_db import find_agent
+from tinyagentos.config import (
+    normalize_agent,
+    save_config_locked,
+    unique_agent_slug,
+    validate_agent_name,
+)
+
+logger = logging.getLogger(__name__)
+
+# Accept only Hermes for now; the frontend locks the framework picker to it.
+SUPPORTED_IMPORT_FRAMEWORK = "hermes"
+
+# Reject empty or oversize uploads up front. 200 MB mirrors the client-side
+# cap in the ImportWizard so the user sees the same limit on both ends.
+MAX_BUNDLE_BYTES = 200 * 1024 * 1024
+
+# Accepted bundle extensions (Hermes exports a tarball/zip).
+_ACCEPTED_EXTENSIONS = (".zip", ".tar.gz", ".tgz")
+
+# Where the bundle lands inside the container before `hermes profile import`.
+_CONTAINER_BUNDLE_PATH = "/tmp/hermes-import-bundle"
+
+# Probed binary locations for the hermes CLI inside the container, matching
+# find_hermes() in scripts/install_hermes.sh.
+_HERMES_BIN_CANDIDATES = (
+    "/root/.local/bin/hermes",
+    "/usr/local/bin/hermes",
+    "/root/.hermes/hermes-agent/.venv/bin/hermes",
+    "/root/.hermes/hermes-agent/venv/bin/hermes",
+)
+
+# Host-side bundle paths, keyed by agent slug, consumed by the push step.
+_BUNDLE_PATHS: dict[str, str] = {}
+
+
+def _has_accepted_extension(filename: str) -> bool:
+    lower = (filename or "").lower()
+    return any(lower.endswith(ext) for ext in _ACCEPTED_EXTENSIONS)
+
+
+async def import_hermes_agent(
+    request: Request,
+    framework: str,
+    bundle: UploadFile,
+    name: str,
+    model: str | None,
+    secrets: str | None,
+) -> JSONResponse:
+    """Validate the upload, deploy a Hermes agent, and schedule the profile
+    import as a post-provision step. Returns an ``importing`` status without
+    blocking on the full import, mirroring the deploy endpoint.
+    """
+    import asyncio
+
+    # --- Framework gate ---------------------------------------------------
+    if framework != SUPPORTED_IMPORT_FRAMEWORK:
+        return JSONResponse(
+            {"error": f"only {SUPPORTED_IMPORT_FRAMEWORK} import is supported yet, got '{framework}'"},
+            status_code=400,
+        )
+
+    # --- Bundle validation ------------------------------------------------
+    if bundle is None or not bundle.filename:
+        return JSONResponse({"error": "a profile bundle file is required"}, status_code=400)
+    if not _has_accepted_extension(bundle.filename):
+        return JSONResponse(
+            {"error": f"bundle must be one of {', '.join(_ACCEPTED_EXTENSIONS)}"},
+            status_code=400,
+        )
+
+    # Stream to a temp file with a hard size cap so a huge upload can't
+    # exhaust disk. The bundle is NEVER extracted on the host, it is only
+    # consumed inside the sandboxed container.
+    tmp_fd, tmp_path = tempfile.mkstemp(prefix="taos-hermes-import-", suffix=".bundle")
+    total = 0
+    try:
+        with os.fdopen(tmp_fd, "wb") as out:
+            while True:
+                chunk = await bundle.read(1024 * 1024)
+                if not chunk:
+                    break
+                total += len(chunk)
+                if total > MAX_BUNDLE_BYTES:
+                    _safe_unlink(tmp_path)
+                    return JSONResponse(
+                        {"error": f"bundle exceeds the {MAX_BUNDLE_BYTES // (1024 * 1024)} MB limit"},
+                        status_code=400,
+                    )
+                out.write(chunk)
+    except Exception:
+        _safe_unlink(tmp_path)
+        raise
+    if total == 0:
+        _safe_unlink(tmp_path)
+        return JSONResponse({"error": "bundle file is empty"}, status_code=400)
+
+    # --- Name validation + slug ------------------------------------------
+    display_name = (name or "").strip()
+    name_error = validate_agent_name(display_name)
+    if name_error:
+        _safe_unlink(tmp_path)
+        return JSONResponse({"error": name_error}, status_code=400)
+
+    config = request.app.state.config
+    try:
+        unique_slug = unique_agent_slug(config, display_name)
+    except ValueError as e:
+        _safe_unlink(tmp_path)
+        return JSONResponse({"error": str(e)}, status_code=400)
+
+    # --- Parse secrets ----------------------------------------------------
+    secrets_map: dict[str, str] = {}
+    if secrets:
+        try:
+            parsed = json.loads(secrets)
+        except (ValueError, TypeError):
+            _safe_unlink(tmp_path)
+            return JSONResponse({"error": "secrets must be a JSON object"}, status_code=400)
+        if not isinstance(parsed, dict):
+            _safe_unlink(tmp_path)
+            return JSONResponse({"error": "secrets must be a JSON object"}, status_code=400)
+        secrets_map = {str(k): str(v) for k, v in parsed.items()}
+
+    # --- Register agent + create config record ----------------------------
+    import taosmd.agents as tm_agents
+    try:
+        tm_agents.register_agent(unique_slug)
+    except tm_agents.AgentExistsError:
+        pass
+    except Exception as e:
+        logger.exception("register_agent(%s) failed", unique_slug)
+        _safe_unlink(tmp_path)
+        return JSONResponse(
+            {"error": f"Could not register agent with taosmd: {e}"}, status_code=500
+        )
+
+    new_agent = normalize_agent({
+        "name": unique_slug,
+        "display_name": display_name,
+        "host": "",
+        "status": "importing",
+        "model": model,
+        "framework": SUPPORTED_IMPORT_FRAMEWORK,
+    })
+    new_agent["migrated_to_v2_personas"] = True
+    config.agents.append(new_agent)
+    await save_config_locked(config, config.config_path)
+
+    # --- Grant user-supplied secrets to the agent (same path as deploy) ---
+    # deploy_agent reads these via secrets_store.get_agent_secrets(name) and
+    # injects them into the container env, so this is the same mechanism.
+    secrets_store = getattr(request.app.state, "secrets", None)
+    if secrets_map and secrets_store is not None:
+        for sname, sval in secrets_map.items():
+            try:
+                await secrets_store.add(
+                    name=f"{unique_slug}-{sname}",
+                    value=sval,
+                    category="agent-import",
+                    description=f"Imported secret {sname} for {unique_slug}",
+                    agents=[unique_slug],
+                )
+            except Exception:
+                logger.exception("import %s: storing secret %r failed", unique_slug, sname)
+
+    deploy_tasks = request.app.state.deploy_tasks
+    deploy_tasks[unique_slug] = {"status": "importing", "name": unique_slug}
+
+    data_dir = request.app.state.data_dir
+    llm_proxy = getattr(request.app.state, "llm_proxy", None)
+
+    # Stash the host bundle path so the background task can push it.
+    _BUNDLE_PATHS[unique_slug] = tmp_path
+
+    async def _background_import():
+        from tinyagentos.deployer import deploy_agent, DeployRequest
+        try:
+            result = await deploy_agent(DeployRequest(
+                name=unique_slug,
+                framework=SUPPORTED_IMPORT_FRAMEWORK,
+                model=model,
+                data_dir=data_dir,
+                extra_config={
+                    "llm_proxy": llm_proxy,
+                    "registry": request.app.state.registry,
+                },
+                secrets_store=secrets_store,
+            ))
+            agent = find_agent(config, unique_slug)
+            if not result.get("success"):
+                if agent is not None:
+                    agent["status"] = "failed"
+                err_msg = result.get("error", "unknown error")
+                deploy_tasks[unique_slug] = {
+                    "status": "failed", "name": unique_slug, "error": err_msg,
+                }
+                await _notify_failure(request, unique_slug, err_msg)
+                return
+
+            if agent is not None:
+                agent["host"] = result.get("ip", "")
+                agent["llm_key"] = result.get("llm_key")
+                await save_config_locked(config, config.config_path)
+
+            # Post-provision: push the bundle and run `hermes profile import`.
+            await _run_profile_import(request, unique_slug, agent)
+
+            if agent is not None:
+                agent["status"] = "running"
+            deploy_tasks[unique_slug] = {
+                "status": "success", "name": unique_slug, "result": result,
+            }
+        except Exception as exc:  # noqa: BLE001
+            agent = find_agent(config, unique_slug)
+            if agent is not None:
+                agent["status"] = "failed"
+            err_msg = str(exc)
+            deploy_tasks[unique_slug] = {
+                "status": "failed", "name": unique_slug, "error": err_msg,
+            }
+            await _notify_failure(request, unique_slug, err_msg)
+        finally:
+            _safe_unlink(_BUNDLE_PATHS.pop(unique_slug, None))
+            await save_config_locked(config, config.config_path)
+
+    asyncio.create_task(_background_import())
+
+    return JSONResponse(
+        {"status": "importing", "name": unique_slug, "display_name": display_name},
+        status_code=202,
+    )
+
+
+async def _run_profile_import(request: Request, slug: str, agent: dict | None) -> None:
+    """Push the bundle into the container and run `hermes profile import`,
+    then best-effort read back persona. Raises on import failure so the
+    background task records it; readback failures are swallowed.
+    """
+    from tinyagentos.containers import exec_in_container, push_file
+
+    container_name = f"taos-agent-{slug}"
+    host_bundle = _BUNDLE_PATHS.get(slug)
+    if not host_bundle:
+        raise RuntimeError("internal error: bundle path missing for import")
+
+    push_rc, push_out = await push_file(container_name, host_bundle, _CONTAINER_BUNDLE_PATH)
+    if push_rc != 0:
+        raise RuntimeError(f"failed to push bundle into container (rc={push_rc}): {push_out[-300:]}")
+
+    hermes_bin = await _find_hermes_bin(container_name)
+    code, output = await exec_in_container(
+        container_name,
+        [hermes_bin, "profile", "import", _CONTAINER_BUNDLE_PATH],
+        timeout=300,
+    )
+    if code != 0:
+        raise RuntimeError(f"hermes profile import failed ({code}): {output[-1000:]}")
+
+    # Best-effort persona readback so the imported personality shows in taOS.
+    if agent is not None:
+        await _readback_persona(container_name, agent)
+
+
+async def _find_hermes_bin(container_name: str) -> str:
+    """Probe for the hermes binary inside the container, matching the
+    candidate list in install_hermes.sh. Falls back to ``hermes`` on PATH.
+    """
+    from tinyagentos.containers import exec_in_container
+
+    for cand in _HERMES_BIN_CANDIDATES:
+        try:
+            code, _ = await exec_in_container(container_name, ["test", "-x", cand])
+        except Exception:
+            continue
+        if code == 0:
+            return cand
+    return "hermes"
+
+
+async def _readback_persona(container_name: str, agent: dict) -> None:
+    """Best-effort: cat SOUL.md / config.yaml from the container to populate
+    the agent record's persona and model where empty. Never raises.
+    """
+    from tinyagentos.containers import exec_in_container
+
+    try:
+        if not agent.get("soul_md"):
+            for path in ("/root/.hermes/SOUL.md", "/root/.hermes/profile/SOUL.md"):
+                code, out = await exec_in_container(container_name, ["cat", path])
+                if code == 0 and out.strip():
+                    agent["soul_md"] = out
+                    break
+    except Exception:
+        logger.exception("import readback SOUL.md failed for %s", container_name)
+
+    try:
+        if not agent.get("model"):
+            code, out = await exec_in_container(
+                container_name, ["cat", "/root/.hermes/config.yaml"]
+            )
+            if code == 0 and out.strip():
+                model = _parse_model_from_config(out)
+                if model:
+                    agent["model"] = model
+    except Exception:
+        logger.exception("import readback config.yaml failed for %s", container_name)
+
+
+def _parse_model_from_config(text: str) -> str | None:
+    """Pull a model identifier out of a Hermes config.yaml without depending
+    on the exact schema. Looks for a ``default_model:`` or ``model:`` key.
+    """
+    for line in text.splitlines():
+        stripped = line.strip()
+        for key in ("default_model:", "model:"):
+            if stripped.startswith(key):
+                value = stripped[len(key):].strip().strip('"').strip("'")
+                if value:
+                    return value
+    return None
+
+
+async def _notify_failure(request: Request, slug: str, err_msg: str) -> None:
+    notif = getattr(request.app.state, "notifications", None)
+    if notif:
+        try:
+            await notif.add(
+                title=f"Import failed: {slug}",
+                message=f"Import failed for {slug}: {err_msg}",
+                level="error",
+                source="agents.import",
+            )
+        except Exception:
+            logger.exception("import failure notification failed for %s", slug)
+
+
+def _safe_unlink(path: str | None) -> None:
+    if not path:
+        return
+    try:
+        os.unlink(path)
+    except OSError:
+        pass

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -16,6 +16,7 @@ from tinyagentos.agent_db import find_agent, get_agent_summaries
 from tinyagentos.config import save_config_locked, validate_agent_name, unique_agent_slug
 from tinyagentos.routes import agent_archive
 from tinyagentos.routes import agent_deploy
+from tinyagentos.routes import agent_import
 logger = logging.getLogger(__name__)
 
 EXPORT_VERSION = 1
@@ -825,7 +826,48 @@ class AgentImport(BaseModel):
 
 
 @router.post("/api/agents/import")
-async def import_agent(request: Request, body: AgentImport):
+async def import_agent(request: Request):
+    """Import an agent.
+
+    Two content types share this path:
+
+    * ``multipart/form-data``: a Hermes profile EXPORT bundle upload
+      (framework + bundle file + name + model + secrets JSON). Deploys a
+      Hermes agent and restores the profile inside the container. Handled
+      by ``agent_import.import_hermes_agent``.
+    * ``application/json``: the existing portable JSON config import
+      (``AgentImport`` body) used by the export/import round-trip.
+
+    Dispatch on Content-Type so both clients keep working on one route.
+    """
+    content_type = request.headers.get("content-type", "")
+    if content_type.startswith("multipart/form-data") or content_type.startswith(
+        "application/x-www-form-urlencoded"
+    ):
+        form = await request.form()
+        bundle = form.get("bundle")
+        return await agent_import.import_hermes_agent(
+            request,
+            framework=str(form.get("framework", "")),
+            bundle=bundle if hasattr(bundle, "filename") else None,
+            name=str(form.get("name", "")),
+            model=(str(form["model"]) if form.get("model") else None),
+            secrets=(str(form["secrets"]) if form.get("secrets") else None),
+        )
+
+    # JSON config import.
+    try:
+        payload = await request.json()
+    except Exception:
+        return JSONResponse({"error": "request body must be JSON or multipart/form-data"}, status_code=400)
+    try:
+        body = AgentImport(**payload)
+    except Exception as e:
+        return JSONResponse({"error": f"invalid import payload: {e}"}, status_code=400)
+    return await _import_agent_json(request, body)
+
+
+async def _import_agent_json(request: Request, body: AgentImport):
     """Import an agent from an exported JSON config."""
     config = request.app.state.config
 


### PR DESCRIPTION
## Summary

Backend slice 2 of the Import Agent feature. Implements the `POST /api/agents/import` Hermes-bundle import that the UI slice (PR #1445) already posts multipart `FormData` to. It imports an existing Hermes agent into taOS from an uploaded Hermes profile EXPORT bundle (produced by `hermes profile export <name>`) by deploying a Hermes-framework agent and running `hermes profile import` inside its container.

## What changed

- **`/api/agents/import` now dispatches on Content-Type.** `multipart/form-data` runs the new Hermes import; `application/json` keeps the existing portable JSON config import (the export/import round-trip) unchanged. The old JSON logic moved verbatim into `_import_agent_json`.
- **New module `tinyagentos/routes/agent_import.py`** (mirrors the `agent_deploy.py` / `agent_archive.py` split; route decorators stay in `agents.py`):
  - Validates `framework` (`hermes` only for now, else 400), the bundle (required, `.zip`/`.tar.gz`/`.tgz`, non-empty, 200 MB cap matching the client), the agent name (same `validate_agent_name` + `unique_agent_slug` as deploy), and an optional `secrets` JSON object.
  - Streams the upload to a temp file with a hard size cap and never extracts it on the host; it is only consumed inside the sandboxed container.
  - Reuses the existing `deployer.deploy_agent` path. The profile import is hooked into the **same background provisioning task** after the container exists and Hermes is installed, so the HTTP response returns an `importing` 202 and failures land on the agent status / deploy-task record instead of being swallowed (notification on failure, same as deploy).
  - Post-import, best-effort reads back `SOUL.md` / `config.yaml` via `exec_in_container cat` to populate the agent's persona (`soul_md`) and `model` where empty. A readback failure does not fail the import.
  - Injects user-supplied secrets through the **same** secrets path deploy uses (`secrets_store.add(..., agents=[slug])`, which `deploy_agent` reads via `get_agent_secrets`).

## Tests

`tests/test_agents_import_hermes.py`: framework!=hermes -> 400; missing/empty/bad-extension/oversize bundle -> 400; invalid name -> 400; bad secrets JSON -> 400; a mocked happy path asserting `hermes profile import` runs against the pushed bundle path and persona readback populates `soul_md` + `model`; a failed import surfacing the error on agent status + deploy task; and that the JSON config import still works.

## Verification

`PYTHONPATH=. uv run --project . pytest tests/test_agents_import_hermes.py tests/test_agent_export_import.py tests/test_routes_agents.py -q`: 73 passed. `uv.lock` / `package.json` untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The agent import endpoint now supports uploading Hermes profile bundles, along with the existing JSON import flow.
  * Imported Hermes profiles can bring in persona details and secrets during setup.

* **Bug Fixes**
  * Added stronger validation for import requests, including file type, size, name, and secret payload checks.
  * Failed Hermes imports now surface clearer task and agent failure status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->