### PR TITLE
fix(agents): fail-soft archive on snapshot-restricted projects + resolve/clean orphaned containers on delete

### DIFF
--- a/tests/test_agent_orphan_reconcile.py
+++ b/tests/test_agent_orphan_reconcile.py
@@ -1,0 +1,161 @@
+"""Orphaned agent-container reconciliation (BUG B, part 2).
+
+Covers:
+  (a) find_orphaned_agent_containers returns taOS containers with no backing
+      agent (live or archived) and skips backed ones,
+  (b) non-taOS containers and backed containers are never returned,
+  (c) reconcile clean=True snapshots-then-archives an orphan (restore point),
+  (d) idempotency: a second pass finds nothing once archived.
+"""
+from __future__ import annotations
+
+import pytest
+
+from tinyagentos.agent_orphan_reconcile import (
+    find_orphaned_agent_containers,
+    reconcile_orphaned_agent_containers,
+)
+
+
+class _FakeConfig:
+    def __init__(self, agents=None, archived=None):
+        self.agents = agents or []
+        self.archived_agents = archived or []
+
+
+@pytest.mark.asyncio
+class TestFindOrphans:
+    async def test_unbacked_taos_container_is_orphan(self, monkeypatch):
+        # list_all_taos_containers already prefix-filters to taOS containers,
+        # so the fake returns only those (non-taOS filtering is covered in
+        # test_containers.TestResolveAgentContainer).
+        async def fake_list(*_a, **_k):
+            return [
+                {"name": "taos-agent-live", "project": "default"},   # backed (live)
+                {"name": "taos-agent-ghost", "project": "user-9"},   # orphan
+            ]
+        monkeypatch.setattr(
+            "tinyagentos.containers.list_all_taos_containers", fake_list
+        )
+        config = _FakeConfig(agents=[{"name": "live"}])
+        orphans = await find_orphaned_agent_containers(config)
+        names = {o["name"] for o in orphans}
+        assert names == {"taos-agent-ghost"}
+
+    async def test_legacy_named_live_agent_container_is_not_orphan(self, monkeypatch):
+        """A live agent's legacy ``taos-<slug>`` container counts as backed."""
+        async def fake_list(*_a, **_k):
+            return [{"name": "taos-live", "project": "default"}]
+        monkeypatch.setattr(
+            "tinyagentos.containers.list_all_taos_containers", fake_list
+        )
+        config = _FakeConfig(agents=[{"name": "live"}])
+        assert await find_orphaned_agent_containers(config) == []
+
+    async def test_archived_container_is_not_orphan(self, monkeypatch):
+        async def fake_list(*_a, **_k):
+            return [{"name": "taos-test", "project": "user-9"}]
+        monkeypatch.setattr(
+            "tinyagentos.containers.list_all_taos_containers", fake_list
+        )
+        config = _FakeConfig(
+            archived=[{"archived_slug": "test", "container_name": "taos-test"}]
+        )
+        assert await find_orphaned_agent_containers(config) == []
+
+
+@pytest.mark.asyncio
+class TestReconcileClean:
+    async def test_report_only_does_not_snapshot(self, client, app, monkeypatch):
+        async def fake_list(*_a, **_k):
+            return [{"name": "taos-agent-ghost", "project": "default"}]
+        monkeypatch.setattr(
+            "tinyagentos.containers.list_all_taos_containers", fake_list
+        )
+
+        async def fake_snapshot(name, snapshot_name):
+            raise AssertionError("report-only must not snapshot")
+        monkeypatch.setattr("tinyagentos.containers.snapshot_create", fake_snapshot)
+
+        resp = await client.post("/api/agents/reconcile-orphan-containers")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["count"] == 1
+        assert data["containers"][0]["action"] == "found"
+
+    async def test_clean_snapshots_then_archives(self, client, app, monkeypatch):
+        async def fake_list(*_a, **_k):
+            return [{"name": "taos-agent-ghost", "project": "default"}]
+        monkeypatch.setattr(
+            "tinyagentos.containers.list_all_taos_containers", fake_list
+        )
+
+        snap_calls = []
+
+        async def fake_stop(name, force=False):
+            return {"success": True, "output": ""}
+
+        async def fake_snapshot(name, snapshot_name):
+            snap_calls.append(name)
+            return {"success": True, "output": ""}
+
+        monkeypatch.setattr("tinyagentos.containers.stop_container", fake_stop)
+        monkeypatch.setattr("tinyagentos.containers.snapshot_create", fake_snapshot)
+
+        resp = await client.post(
+            "/api/agents/reconcile-orphan-containers?clean=true"
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["count"] == 1
+        assert data["containers"][0]["action"] == "archived"
+        # The orphan was snapshotted (restore point) before being archived.
+        assert snap_calls == ["taos-agent-ghost"]
+
+        # An archive entry now backs the former orphan, so a second pass (with
+        # the container still "present" in the fake listing) treats it as backed.
+        archived = (await client.get("/api/agents/archived")).json()
+        assert any(e.get("container_name") == "taos-agent-ghost" for e in archived)
+
+        second = await reconcile_orphaned_agent_containers(
+            _Req(app), clean=False
+        )
+        assert second == []
+
+    async def test_clean_leaves_orphan_when_snapshot_fails(
+        self, client, app, monkeypatch
+    ):
+        """No restore point -> never destroy; orphan is reported, not archived."""
+        async def fake_list(*_a, **_k):
+            return [{"name": "taos-agent-ghost", "project": "default"}]
+        monkeypatch.setattr(
+            "tinyagentos.containers.list_all_taos_containers", fake_list
+        )
+
+        async def fake_stop(name, force=False):
+            return {"success": True, "output": ""}
+
+        async def fake_snapshot(name, snapshot_name):
+            return {"success": False, "output": "Error: pool offline"}
+
+        monkeypatch.setattr("tinyagentos.containers.stop_container", fake_stop)
+        monkeypatch.setattr("tinyagentos.containers.snapshot_create", fake_snapshot)
+
+        resp = await client.post(
+            "/api/agents/reconcile-orphan-containers?clean=true"
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["containers"][0]["action"] == "snapshot_failed"
+        # No archive entry was written for a container we could not snapshot.
+        archived = (await client.get("/api/agents/archived")).json()
+        assert not any(
+            e.get("container_name") == "taos-agent-ghost" for e in archived
+        )
+
+
+class _Req:
+    """Minimal request stand-in exposing app.state for the reconcile helper."""
+
+    def __init__(self, app):
+        self.app = app

--- a/tests/test_agent_orphan_reconcile.py
+++ b/tests/test_agent_orphan_reconcile.py
@@ -122,6 +122,51 @@ class TestReconcileClean:
         )
         assert second == []
 
+    async def test_bare_prefix_container_is_ignored(self, client, app, monkeypatch):
+        """A container named exactly ``taos-`` / ``taos-agent-`` strips to an
+        empty slug -- it must be skipped (no archive row) while a normal
+        ``taos-agent-<slug>`` orphan is still archived."""
+        async def fake_list(*_a, **_k):
+            return [
+                {"name": "taos-agent-", "project": "default"},        # empty slug
+                {"name": "taos-", "project": "default"},              # empty slug
+                {"name": "taos-agent-ghost", "project": "default"},   # valid orphan
+            ]
+        monkeypatch.setattr(
+            "tinyagentos.containers.list_all_taos_containers", fake_list
+        )
+
+        snap_calls = []
+
+        async def fake_stop(name, force=False):
+            return {"success": True, "output": ""}
+
+        async def fake_snapshot(name, snapshot_name):
+            snap_calls.append(name)
+            return {"success": True, "output": ""}
+
+        monkeypatch.setattr("tinyagentos.containers.stop_container", fake_stop)
+        monkeypatch.setattr("tinyagentos.containers.snapshot_create", fake_snapshot)
+
+        resp = await client.post(
+            "/api/agents/reconcile-orphan-containers?clean=true"
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        by_name = {c["name"]: c["action"] for c in data["containers"]}
+        assert by_name["taos-agent-"] == "skipped_empty_slug"
+        assert by_name["taos-"] == "skipped_empty_slug"
+        assert by_name["taos-agent-ghost"] == "archived"
+
+        # Only the valid orphan was snapshotted/archived; the bare-prefix ones
+        # produced no archive row.
+        assert snap_calls == ["taos-agent-ghost"]
+        archived = (await client.get("/api/agents/archived")).json()
+        assert all(e.get("archived_slug") for e in archived)
+        assert not any(
+            e.get("container_name") in {"taos-agent-", "taos-"} for e in archived
+        )
+
     async def test_clean_leaves_orphan_when_snapshot_fails(
         self, client, app, monkeypatch
     ):

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -232,6 +232,105 @@ class TestContainerLifecycle:
             stop_cmd = mock_run.call_args_list[1].args[0]
             assert "--project" not in stop_cmd
 
+
+class TestSnapshotCreateSelfHeal:
+    """snapshot_create must succeed in restricted projects (BUG A)."""
+
+    @pytest.mark.asyncio
+    async def test_self_heals_project_snapshot_restriction(self):
+        from tinyagentos.containers import snapshot_create
+
+        forbidden = (
+            'Error: Failed to create instance snapshot: Project "user-999" '
+            "doesn't allow for snapshot creation"
+        )
+        calls = []
+
+        async def mock_run(cmd, timeout=120):
+            calls.append(cmd)
+            # 1) snapshot create -> forbidden
+            # 2) project set restricted.snapshots allow -> ok
+            # 3) snapshot create retry -> ok
+            if cmd[:3] == ["incus", "snapshot", "create"] and len(calls) == 1:
+                return (1, forbidden)
+            if cmd[:3] == ["incus", "project", "set"]:
+                return (0, "")
+            return (0, "")
+
+        with patch("tinyagentos.containers._run", side_effect=mock_run):
+            result = await snapshot_create("taos-agent-x", "taos-archive-1")
+
+        assert result["success"] is True
+        # The project named in the error was relaxed before the retry.
+        set_cmd = next(c for c in calls if c[:3] == ["incus", "project", "set"])
+        assert set_cmd == [
+            "incus", "project", "set", "user-999",
+            "restricted.snapshots", "allow",
+        ]
+        # Two snapshot-create attempts: original + retry.
+        snap_attempts = [c for c in calls if c[:3] == ["incus", "snapshot", "create"]]
+        assert len(snap_attempts) == 2
+
+    @pytest.mark.asyncio
+    async def test_non_restriction_failure_does_not_retry(self):
+        from tinyagentos.containers import snapshot_create
+
+        calls = []
+
+        async def mock_run(cmd, timeout=120):
+            calls.append(cmd)
+            return (1, "Error: storage pool is offline")
+
+        with patch("tinyagentos.containers._run", side_effect=mock_run):
+            result = await snapshot_create("taos-agent-x", "taos-archive-1")
+
+        assert result["success"] is False
+        # A non-restriction failure must NOT touch project config nor retry.
+        assert all(c[:3] != ["incus", "project", "set"] for c in calls)
+        assert len(calls) == 1
+
+
+class TestResolveAgentContainer:
+    """resolve_agent_container probes both naming conventions across projects."""
+
+    @pytest.mark.asyncio
+    async def test_resolves_legacy_name_across_projects(self):
+        from tinyagentos.containers import resolve_agent_container
+
+        listing = json.dumps([
+            {"name": "taos-test", "project": "user-999"},
+            {"name": "some-other-vm", "project": "default"},
+        ])
+        with patch("tinyagentos.containers._run", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = (0, listing)
+            # Derived ``taos-agent-test`` is absent; legacy ``taos-test`` is found.
+            name = await resolve_agent_container("test")
+        assert name == "taos-test"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_taos_container_matches(self):
+        from tinyagentos.containers import resolve_agent_container
+
+        listing = json.dumps([{"name": "unrelated", "project": "default"}])
+        with patch("tinyagentos.containers._run", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = (0, listing)
+            assert await resolve_agent_container("test") is None
+
+    @pytest.mark.asyncio
+    async def test_list_all_taos_containers_filters_non_taos(self):
+        from tinyagentos.containers import list_all_taos_containers
+
+        listing = json.dumps([
+            {"name": "taos-agent-a", "project": "default"},
+            {"name": "taos-b", "project": "user-1"},
+            {"name": "postgres", "project": "default"},
+        ])
+        with patch("tinyagentos.containers._run", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = (0, listing)
+            out = await list_all_taos_containers()
+        names = {c["name"] for c in out}
+        assert names == {"taos-agent-a", "taos-b"}
+
     @pytest.mark.asyncio
     async def test_destroy_targets_restricted_project(self):
         """A container living in a restricted project (user-999) must be

--- a/tests/test_routes_agents.py
+++ b/tests/test_routes_agents.py
@@ -1155,6 +1155,90 @@ class TestOrphanAgentDeletion:
 
 
 @pytest.mark.asyncio
+class TestDeleteResolvesOrphanedContainer:
+    """DELETE must not orphan a real container when the record lost its link.
+
+    Reproduces Jay's live bug: a 'test' agent whose container_name was null but
+    whose legacy ``taos-test`` container was still running. Delete must resolve
+    and archive that container instead of hard-deleting the bare row.
+    """
+
+    async def test_null_link_resolves_and_archives_legacy_container(
+        self, client, tmp_data_dir, monkeypatch
+    ):
+        # The derived ``taos-agent-test-agent`` does not exist...
+        async def _no_container(name):
+            return False
+        monkeypatch.setattr("tinyagentos.containers.container_exists", _no_container)
+
+        # ...but a legacy ``taos-test-agent`` container is live in some project.
+        async def fake_list_all(*_a, **_k):
+            return [{"name": "taos-test-agent", "project": "user-999"}]
+        monkeypatch.setattr(
+            "tinyagentos.containers.list_all_taos_containers", fake_list_all
+        )
+
+        stop_calls = []
+        snap_calls = []
+
+        async def fake_stop(name, force=False):
+            stop_calls.append(name)
+            return {"success": True, "output": ""}
+
+        async def fake_snapshot_create(name, snapshot_name):
+            snap_calls.append((name, snapshot_name))
+            return {"success": True, "output": ""}
+
+        monkeypatch.setattr("tinyagentos.containers.stop_container", fake_stop)
+        monkeypatch.setattr("tinyagentos.containers.snapshot_create", fake_snapshot_create)
+
+        resp = await client.delete("/api/agents/test-agent")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "archived"
+        # The resolved legacy container is the one snapshotted, not the derived name.
+        assert stop_calls == ["taos-test-agent"]
+        assert snap_calls and snap_calls[0][0] == "taos-test-agent"
+
+        config = load_config(tmp_data_dir / "config.yaml")
+        assert not any(a["name"] == "test-agent" for a in config.agents)
+        entry = next(
+            a for a in config.archived_agents if a.get("archived_slug") == "test-agent"
+        )
+        # container_name records the REAL (legacy) container so restore/purge act on it.
+        assert entry["container_name"] == "taos-test-agent"
+        assert entry["snapshot_name"] is not None
+
+    async def test_truly_container_less_row_still_hard_deletes(
+        self, client, tmp_data_dir, monkeypatch
+    ):
+        """When NO container exists anywhere, the bare row is hard-deleted."""
+        async def _no_container(name):
+            return False
+        monkeypatch.setattr("tinyagentos.containers.container_exists", _no_container)
+
+        async def fake_list_all(*_a, **_k):
+            return []  # nothing on the host
+        monkeypatch.setattr(
+            "tinyagentos.containers.list_all_taos_containers", fake_list_all
+        )
+
+        async def fake_snapshot_create(name, snapshot_name):
+            raise AssertionError("no container -> snapshot must not run")
+        monkeypatch.setattr("tinyagentos.containers.snapshot_create", fake_snapshot_create)
+
+        resp = await client.delete("/api/agents/test-agent")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "deleted"
+
+        config = load_config(tmp_data_dir / "config.yaml")
+        assert not any(a["name"] == "test-agent" for a in config.agents)
+        assert not any(
+            a.get("archived_slug") == "test-agent" for a in config.archived_agents
+        )
+
+
+@pytest.mark.asyncio
 class TestDeployMemoryConfig:
     """Deploy endpoint should accept and persist memory_plugin + memory_config."""
 

--- a/tinyagentos/agent_orphan_reconcile.py
+++ b/tinyagentos/agent_orphan_reconcile.py
@@ -1,0 +1,155 @@
+"""Orphaned agent-container reconciliation.
+
+A taOS agent container is named ``taos-agent-<slug>`` (legacy: ``taos-<slug>``).
+Every removal path is supposed to archive the container alongside the agent
+record, but a record can lose its container link, or a deploy can be cleaned up
+partially, leaving a real container running with NO backing agent in any list
+(live or archived). Those containers are invisible in the UI yet still consume
+RAM/disk on the host.
+
+This mirrors the channel-side :mod:`tinyagentos.chat.orphan_reconcile`: it finds
+taOS containers with no backing agent record and reports them (and optionally
+archives them through the same snapshot-then-archive path the delete flow uses,
+so they too get a restore point). It is idempotent and only ever touches
+containers whose name carries the taOS prefix -- a non-taOS container on the
+same host is never inspected or removed.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _backed_container_names(config) -> set[str]:
+    """Container names that DO belong to a known agent (live or archived).
+
+    For each live agent we accept both the current ``taos-agent-<slug>`` and
+    legacy ``taos-<slug>`` names plus any explicit ``container_name``. For each
+    archived entry we accept the recorded ``container_name`` and the derived
+    names from its slug. Anything not in this set is, by definition, unbacked.
+    """
+    from tinyagentos.containers import candidate_agent_container_names
+
+    backed: set[str] = set()
+    for agent in getattr(config, "agents", []) or []:
+        slug = agent.get("name")
+        if slug:
+            backed.update(candidate_agent_container_names(slug, agent.get("display_name")))
+        explicit = agent.get("container_name") or agent.get("container")
+        if explicit:
+            backed.add(explicit)
+    for entry in getattr(config, "archived_agents", []) or []:
+        explicit = entry.get("container_name")
+        if explicit:
+            backed.add(explicit)
+        slug = entry.get("archived_slug") or (entry.get("original") or {}).get("name")
+        if slug:
+            backed.update(candidate_agent_container_names(slug))
+    return backed
+
+
+async def find_orphaned_agent_containers(config) -> list[dict]:
+    """Return taOS containers with no backing agent record (live or archived).
+
+    Each item is ``{"name", "project"}``. Only containers carrying the taOS
+    prefix are considered; non-taOS containers are never returned.
+    """
+    from tinyagentos.containers import list_all_taos_containers
+
+    backed = _backed_container_names(config)
+    orphans: list[dict] = []
+    for c in await list_all_taos_containers():
+        if c["name"] not in backed:
+            orphans.append(c)
+    return orphans
+
+
+async def reconcile_orphaned_agent_containers(
+    request, *, clean: bool = False
+) -> list[dict]:
+    """Find (and optionally clean) taOS containers with no backing agent.
+
+    With ``clean=False`` (default) this only reports -- safe to call anywhere.
+    With ``clean=True`` each orphan is run through the same snapshot-then-archive
+    path the delete flow uses (:func:`archive_agent_fully` semantics) by way of
+    :func:`destroy_container` AFTER a snapshot, so an operator keeps a restore
+    point. The project principle is "nothing is truly deleted": we snapshot the
+    orphan, then remove the live container, recording a tombstone-style archive
+    entry so it shows in Archived and can be restored or purged.
+
+    Idempotent: once an orphan is archived its container is gone, so a second
+    pass finds nothing. Never touches non-taOS containers (the listing is
+    prefix-filtered) and never touches a container that backs a known agent.
+
+    Returns a list of ``{"name", "project", "action"}`` describing this pass.
+    """
+    from datetime import datetime, timezone
+
+    from tinyagentos.containers import (
+        snapshot_create,
+        stop_container,
+        destroy_container,
+    )
+    from tinyagentos.config import save_config_locked
+
+    config = request.app.state.config
+    orphans = await find_orphaned_agent_containers(config)
+    results: list[dict] = []
+
+    for orphan in orphans:
+        name = orphan["name"]
+        if not clean:
+            logger.info("orphan container reconcile: found unbacked container %s", name)
+            results.append({**orphan, "action": "found"})
+            continue
+
+        ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
+        snapshot_name = f"taos-archive-{ts}"
+        try:
+            await stop_container(name, force=True)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("orphan container reconcile: stop failed for %s: %s", name, exc)
+
+        snap = await snapshot_create(name, snapshot_name)
+        if not snap.get("success"):
+            # Snapshot is the restore guarantee; without it we do NOT remove the
+            # container (never destroy without a restore point). Report and skip.
+            logger.warning(
+                "orphan container reconcile: snapshot failed for %s (%s); "
+                "leaving container intact",
+                name, (snap.get("output") or "").strip(),
+            )
+            results.append({**orphan, "action": "snapshot_failed"})
+            continue
+
+        import uuid
+
+        archive_id = uuid.uuid4().hex[:12]
+        # Derive a best-effort slug from the container name for the archive row.
+        slug = name
+        for prefix in ("taos-agent-", "taos-"):
+            if slug.startswith(prefix):
+                slug = slug[len(prefix):]
+                break
+        archive_entry = {
+            "id": archive_id,
+            "archived_at": ts,
+            "archived_slug": slug,
+            "container_name": name,
+            "snapshot_name": snapshot_name,
+            "export_path": None,
+            "archive_dir": f"archive/{slug}-{ts}",
+            "original": {"name": slug},
+            "orphan_reconciled": True,
+        }
+        config.archived_agents.append(archive_entry)
+        await save_config_locked(config, config.config_path)
+        logger.info(
+            "orphan container reconcile: archived unbacked container %s as %s",
+            name, archive_id,
+        )
+        results.append({**orphan, "action": "archived", "archive_id": archive_id})
+
+    return results

--- a/tinyagentos/agent_orphan_reconcile.py
+++ b/tinyagentos/agent_orphan_reconcile.py
@@ -22,6 +22,21 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+def _slug_from_container_name(name: str) -> str:
+    """Strip the taOS container prefix to recover the agent slug.
+
+    Returns an empty string when nothing survives -- a container named exactly
+    ``taos-`` or ``taos-agent-`` is not a valid agent container and callers must
+    skip it rather than build a malformed (empty-slug) archive row.
+    """
+    slug = name
+    for prefix in ("taos-agent-", "taos-"):
+        if slug.startswith(prefix):
+            slug = slug[len(prefix):]
+            break
+    return slug.strip()
+
+
 def _backed_container_names(config) -> set[str]:
     """Container names that DO belong to a known agent (live or archived).
 
@@ -100,6 +115,19 @@ async def reconcile_orphaned_agent_containers(
 
     for orphan in orphans:
         name = orphan["name"]
+        # A container named exactly ``taos-`` / ``taos-agent-`` strips to an
+        # empty slug: it is not a valid taOS agent container, so never archive
+        # it (an empty-slug row breaks the Archived UI + restore/purge).
+        slug = _slug_from_container_name(name)
+        if not slug:
+            logger.warning(
+                "orphan container reconcile: skipping bare-prefix container %s "
+                "(no slug after stripping taOS prefix)",
+                name,
+            )
+            results.append({**orphan, "action": "skipped_empty_slug"})
+            continue
+
         if not clean:
             logger.info("orphan container reconcile: found unbacked container %s", name)
             results.append({**orphan, "action": "found"})
@@ -127,12 +155,7 @@ async def reconcile_orphaned_agent_containers(
         import uuid
 
         archive_id = uuid.uuid4().hex[:12]
-        # Derive a best-effort slug from the container name for the archive row.
-        slug = name
-        for prefix in ("taos-agent-", "taos-"):
-            if slug.startswith(prefix):
-                slug = slug[len(prefix):]
-                break
+        # ``slug`` was derived (and validated non-empty) at the top of the loop.
         archive_entry = {
             "id": archive_id,
             "archived_at": ts,

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -616,6 +616,26 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
                 )
         except Exception:
             logger.exception("orphan DM channel reconcile failed")
+
+        # Report (do NOT auto-clean) taOS containers with no backing agent
+        # record.  Cleaning destroys a live container, so startup only surfaces
+        # them; an operator cleans via POST /api/agents/reconcile-orphan-containers
+        # ?clean=true.  Idempotent; only inspects taOS-prefixed containers.
+        try:
+            from tinyagentos.agent_orphan_reconcile import (
+                find_orphaned_agent_containers,
+            )
+            _orphan_containers = await find_orphaned_agent_containers(config)
+            if _orphan_containers:
+                logger.warning(
+                    "orphan reconcile: %d taOS container(s) have no backing agent "
+                    "record: %s -- clean via POST "
+                    "/api/agents/reconcile-orphan-containers?clean=true",
+                    len(_orphan_containers),
+                    ", ".join(c["name"] for c in _orphan_containers),
+                )
+        except Exception:
+            logger.exception("orphan container reconcile (report) failed")
         # Probe installed framework versions in the BACKGROUND so the UI can
         # show whether each agent is up-to-date before any manual check is
         # triggered. Each probe does an `incus exec` into the agent container,

--- a/tinyagentos/containers/__init__.py
+++ b/tinyagentos/containers/__init__.py
@@ -74,6 +74,85 @@ async def container_exists(name: str) -> bool:
     return (await _resolve_container_project(name)) is not None
 
 
+# Prefix shared by every taOS-managed agent container. The current convention
+# is ``taos-agent-<slug>``; the legacy convention was ``taos-<slug>``. Both
+# share this prefix, which is how reconcile distinguishes taOS containers from
+# anything else on the host.
+TAOS_CONTAINER_PREFIX = "taos-"
+
+
+def candidate_agent_container_names(slug: str, display_name: str | None = None) -> list[str]:
+    """Return the container names an agent's slug could map to, newest
+    convention first.
+
+    Current deploys name containers ``taos-agent-<slug>``; legacy deploys used
+    ``taos-<slug>``. When the agent record lost its ``container_name`` link the
+    only way to find its container is to probe both conventions. A
+    ``display_name`` (if it slugifies differently from ``slug``) contributes its
+    own pair of candidates so a record whose slug drifted from the original
+    display name still resolves.
+    """
+    from tinyagentos.config import slugify_agent_name
+
+    slugs: list[str] = []
+    for s in (slug, slugify_agent_name(display_name) if display_name else None):
+        if s and s not in slugs:
+            slugs.append(s)
+    names: list[str] = []
+    for s in slugs:
+        for name in (f"taos-agent-{s}", f"taos-{s}"):
+            if name not in names:
+                names.append(name)
+    return names
+
+
+async def list_all_taos_containers() -> list[dict]:
+    """Return every taOS-managed container across ALL incus projects.
+
+    Each item is ``{"name": str, "project": str}``. Filters to names beginning
+    with :data:`TAOS_CONTAINER_PREFIX` so non-taOS containers are never
+    included. Errors (incus absent, daemon down, malformed output) return an
+    empty list.
+    """
+    try:
+        code, output = await _run(["incus", "list", "--all-projects", "-f", "json"])
+    except (FileNotFoundError, OSError):
+        # incus binary not present (dev hosts, CI). Treat as "no containers".
+        return []
+    if code != 0:
+        return []
+    try:
+        instances = json.loads(output)
+    except (json.JSONDecodeError, TypeError):
+        return []
+    results: list[dict] = []
+    for inst in instances:
+        if not isinstance(inst, dict):
+            continue
+        name = inst.get("name", "")
+        if not name.startswith(TAOS_CONTAINER_PREFIX):
+            continue
+        results.append({"name": name, "project": inst.get("project") or "default"})
+    return results
+
+
+async def resolve_agent_container(slug: str, display_name: str | None = None) -> str | None:
+    """Resolve the live container backing an agent slug, or None.
+
+    Probes both the current (``taos-agent-<slug>``) and legacy (``taos-<slug>``)
+    naming conventions, plus the display-name variants, across ALL incus
+    projects. Returns the first matching container name. Used by delete to
+    rescue a container whose agent record lost its ``container_name`` link
+    rather than orphaning a still-running container.
+    """
+    candidates = candidate_agent_container_names(slug, display_name)
+    existing = {c["name"] for c in await list_all_taos_containers()}
+    for name in candidates:
+        if name in existing:
+            return name
+    return None
+
+
 async def list_containers(prefix: str = "taos-agent-") -> list[ContainerInfo]:
     """List all agent containers."""
     code, output = await _run(["incus", "list", "-f", "json"])
@@ -322,6 +401,21 @@ async def get_container_logs(name: str, lines: int = 100) -> str:
     return output if code == 0 else f"Error getting logs: {output}"
 
 
+def _is_snapshot_forbidden(output: str) -> bool:
+    """True when an incus error means the container's project forbids snapshots.
+
+    Detects the restriction robustly by its wording rather than by a hard-coded
+    project name, so it fires for any per-user project (user-999, user-1001, …):
+    incus 6.x phrases it as ``Project "user-999" doesn't allow for snapshot
+    creation``. Matches both the curly and straight apostrophe and is
+    case-insensitive.
+    """
+    low = (output or "").lower().replace("’", "'")
+    return "snapshot creation" in low and (
+        "doesn't allow" in low or "does not allow" in low or "not allowed" in low
+    )
+
+
 async def snapshot_create(name: str, snapshot_name: str) -> dict:
     """Create a named snapshot of a container.
 
@@ -330,9 +424,43 @@ async def snapshot_create(name: str, snapshot_name: str) -> dict:
 
     Docker: ``docker commit <name> taos/<snapshot_name>:latest``.
 
+    Self-heals project snapshot restrictions: multi-user installs put agent
+    containers in a restricted incus project (e.g. user-999) provisioned
+    outside taOS, which can forbid snapshot creation. A snapshot is taOS's
+    point-in-time restore guarantee, so rather than fail the archive we set
+    ``restricted.snapshots=allow`` on the offending project (mirroring the
+    ``add_proxy_device`` self-heal for ``restricted.devices.proxy``) and retry
+    once. Only the trusted controller snapshots, never the agent inside the
+    container, so relaxing this one restriction is safe.
+
     Returns ``{"success": bool, "output": str}``.
     """
     code, output = await _run(["incus", "snapshot", "create", name, snapshot_name])
+    if code != 0 and _is_snapshot_forbidden(output):
+        # Find the project named in the error; fall back to resolving it from
+        # the container itself if the message did not quote one.
+        m = re.search(r'[Pp]roject "([^"]+)"', output or "")
+        project = m.group(1) if m else await _resolve_container_project(name)
+        if project:
+            allow_code, allow_out = await _run([
+                "incus", "project", "set", project,
+                "restricted.snapshots", "allow",
+            ])
+            if allow_code == 0:
+                logger.warning(
+                    "snapshot_create: project %r forbade snapshots; set "
+                    "restricted.snapshots=allow and retried %s/%s",
+                    project, name, snapshot_name,
+                )
+                code, output = await _run(
+                    ["incus", "snapshot", "create", name, snapshot_name]
+                )
+            else:
+                logger.warning(
+                    "snapshot_create: could not relax restricted.snapshots on "
+                    "project %r: %s",
+                    project, allow_out,
+                )
     return {"success": code == 0, "output": output}
 
 
@@ -680,6 +808,10 @@ __all__ = [
     "LXCBackend",
     "DockerBackend",
     "container_exists",
+    "TAOS_CONTAINER_PREFIX",
+    "candidate_agent_container_names",
+    "list_all_taos_containers",
+    "resolve_agent_container",
     "list_containers",
     "set_root_quota",
     "create_container",

--- a/tinyagentos/routes/agent_archive.py
+++ b/tinyagentos/routes/agent_archive.py
@@ -38,7 +38,12 @@ async def archive_agent_fully(request: Request, name: str) -> dict:
     can re-raise as JSONResponse.
     """
     import json as _json
-    from tinyagentos.containers import container_exists, stop_container, snapshot_create
+    from tinyagentos.containers import (
+        container_exists,
+        resolve_agent_container,
+        stop_container,
+        snapshot_create,
+    )
 
     config = request.app.state.config
     agent = find_agent(config, name)
@@ -64,6 +69,18 @@ async def archive_agent_fully(request: Request, name: str) -> dict:
     #    entirely and decide between hard-delete and tombstone based on
     #    whether there is any history worth preserving.
     has_container = await container_exists(container)
+
+    # 0a) Record lost its container link, or the standard name is gone: probe
+    #     the legacy ``taos-<slug>`` convention and display-name variants across
+    #     ALL projects before treating this as an orphan row. A record whose
+    #     container_name drifted (e.g. an old "test" agent backed by a live
+    #     ``taos-test`` container) must NOT be hard-deleted while its container
+    #     keeps running -- resolve it and archive it through the snapshot path.
+    if not has_container:
+        resolved = await resolve_agent_container(slug, agent.get("display_name"))
+        if resolved:
+            container = resolved
+            has_container = True
 
     if not has_container:
         # Hard-delete when the agent has no chat history and no trace dir —
@@ -253,12 +270,16 @@ async def archive_agent_fully(request: Request, name: str) -> dict:
         except Exception:
             pass
 
-    # 6) Move config entry out of agents into archived_agents.
+    # 6) Move config entry out of agents into archived_agents. Record the
+    #    actual container name (which may be the legacy ``taos-<slug>`` form when
+    #    resolved in step 0a) so restore/purge act on the real container rather
+    #    than the derived ``taos-agent-<slug>`` name.
     original_snapshot = dict(agent)
     archive_entry = {
         "id": agent_id,
         "archived_at": ts,
         "archived_slug": slug,
+        "container_name": container,
         "snapshot_name": snapshot_name,
         "export_path": export_path,
         "archive_dir": f"archive/{archive_subdir}",
@@ -304,9 +325,11 @@ async def restore_archived(request: Request, archive_id: str):
             status_code=500,
         )
 
-    # The container name is derived from the original slug (unchanged since
-    # archive; we snapshot in-place, not rename).
-    container = f"taos-agent-{desired_slug}"
+    # The container name is whatever was archived. Prefer the recorded
+    # ``container_name`` (set by the archive path, and may be the legacy
+    # ``taos-<slug>`` form); fall back to the derived name for entries written
+    # before that field existed.
+    container = entry.get("container_name") or f"taos-agent-{desired_slug}"
 
     # Resolve slug collisions with currently-live agents.
     try:
@@ -467,7 +490,9 @@ async def purge_archived(request: Request, archive_id: str):
         return JSONResponse({"error": f"Archived agent '{archive_id}' not found"}, status_code=404)
 
     archived_slug = entry.get("archived_slug") or (entry.get("original") or {}).get("name") or ""
-    container_name = f"taos-agent-{archived_slug}" if archived_slug else ""
+    container_name = entry.get("container_name") or (
+        f"taos-agent-{archived_slug}" if archived_slug else ""
+    )
     data_dir = request.app.state.data_dir
     archive_base = data_dir / entry.get("archive_dir", "")
 

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -939,6 +939,19 @@ async def reconcile_orphan_channels(request: Request):
     return {"status": "ok", "archived": archived, "count": len(archived)}
 
 
+@router.post("/api/agents/reconcile-orphan-containers")
+async def reconcile_orphan_containers(request: Request, clean: bool = False):
+    """Find taOS containers with no backing agent record (live or archived).
+
+    Report-only by default. Pass ``?clean=true`` to snapshot-then-archive each
+    orphan so it gets a restore point and shows in Archived. Idempotent; only
+    ever touches containers carrying the taOS naming prefix."""
+    from tinyagentos.agent_orphan_reconcile import reconcile_orphaned_agent_containers
+
+    results = await reconcile_orphaned_agent_containers(request, clean=clean)
+    return {"status": "ok", "containers": results, "count": len(results)}
+
+
 async def _registry_canonical_ids(state) -> list[str]:
     """Best-effort list of canonical agent ids from the registry, so the
     reconcile can recognise a former agent whose config row is gone."""


### PR DESCRIPTION
Two real delete/archive cleanup bugs Jay hit on the live Pi, durable code fixes (both were manually worked around).

## BUG A: archive aborted on snapshot-restricted projects
An agent in a per-user restricted incus project (e.g. `user-999`, provisioned outside taOS) could not be archived: the project forbids snapshot creation, so `snapshot_create` failed and the agent was left in the live list.

A snapshot is taOS's restore / Time Machine guarantee, so the fix makes the snapshot **succeed**, not skip it. `snapshot_create` now self-heals: it detects the project-forbids-snapshots error robustly (by wording, not a hard-coded project name, matching both apostrophe forms), sets `restricted.snapshots=allow` on the offending project, and retries once. This mirrors the existing `add_proxy_device` self-heal for `restricted.devices.proxy`. Only the trusted controller snapshots, never the agent, so relaxing this one restriction is safe.

Archive still **requires** a snapshot: if it genuinely fails (pool offline, etc.) the archive aborts cleanly and leaves the agent intact. There is no snapshot-free archive path.

> Allowing snapshots on restricted user projects at provisioning time is an optional separate follow-up: those projects are created outside taOS, so there is no in-repo provisioning config map to add the key to.

## BUG B: delete orphaned a real container when the record lost its link
A record whose `container_name`/`project` was null returned `orphan config row (no container); hard-deleted` but left the actual container (`taos-test`, legacy `taos-<slug>`) running.

Now, before treating a row as an orphan to hard-delete, delete resolves the container by naming convention -- both `taos-agent-<slug>` and legacy `taos-<slug>`, plus display-name variants -- across **all** incus projects (`incus list --all-projects`). A match is archived through the same snapshot-then-archive path (the real `container_name` is recorded so restore/purge act on the right container). Only a truly container-less row is hard-deleted.

Also adds an idempotent reconcile helper + route `POST /api/agents/reconcile-orphan-containers` (report-only by default, `?clean=true` to snapshot+archive) that finds taOS containers with no backing agent record and **never** touches non-taOS containers. Startup reports (does not auto-clean) any orphans, mirroring the existing orphan-channel reconcile pattern.

## Tests
- snapshot self-heal retries on the restriction error and sets `restricted.snapshots=allow`; does not retry/touch project config on other failures
- `resolve_agent_container` / `list_all_taos_containers` probe both conventions across projects and filter non-taOS
- delete resolves + archives a legacy `taos-<slug>` container (records `container_name`) vs hard-deletes a container-less row
- reconcile finds orphans, snapshots before archive, leaves non-taOS + backed containers untouched, leaves an orphan intact when its snapshot fails, and is idempotent

Scope: archive/delete area only. No incus PROJECT config changed at provisioning. `uv.lock`/`package.json` untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `POST /api/agents/reconcile-orphan-containers` to review orphaned taOS agent containers, with optional `clean=true` to stop and archive them.
  * On startup, the app now reports any orphaned taOS containers and recommends the cleanup action.
* **Bug Fixes**
  * Improved taOS container name resolution and cross-project matching (including legacy naming) so orphan handling is accurate.
  * Archive/restore/delete flows now use the correct container name for legacy/resolved cases.
  * Snapshot creation now self-heals once when blocked by project snapshot restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->