### PR TITLE
ci(images): scheduled + change-detected base-image rebuild with manual dispatch

### DIFF
--- a/.github/workflows/build-agent-images.yml
+++ b/.github/workflows/build-agent-images.yml
@@ -9,16 +9,124 @@ on:
       - '.github/workflows/build-agent-images.yml'
   repository_dispatch:
     types: [openclaw-fork-published]
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      force:
+        description: 'Rebuild every base regardless of change detection'
+        type: boolean
+        required: false
+        default: false
   schedule:
-    # Weekly refresh for security updates - Mondays 03:00 UTC.
-    - cron: '0 3 * * 1'
+    # Weekly refresh - Mondays 04:17 UTC (off-peak, non-:00 to dodge the
+    # top-of-hour scheduler congestion that delays cron-triggered runs).
+    - cron: '17 4 * * 1'
 
 permissions:
   contents: write
 
 jobs:
+  # Change detection: decide which framework bases actually need a rebuild so a
+  # scheduled run does not burn CI on unchanged bases. The published images live
+  # under a rolling `rolling-images` tag in jaylfc/tinyagentos-images; the release
+  # job stamps a base-versions.json asset recording the upstream version baked
+  # into each base. Here we read that prior manifest and compare it against the
+  # CURRENT upstream versions. Anything that moved (or is missing from the prior
+  # manifest) gets rebuilt.
+  #
+  # Gating only applies to scheduled runs. push / repository_dispatch always
+  # rebuild everything (preserving the historical behaviour), and a manual
+  # workflow_dispatch with force=true rebuilds everything too.
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      openclaw: ${{ steps.decide.outputs.openclaw }}
+      generic: ${{ steps.decide.outputs.generic }}
+      hermes: ${{ steps.decide.outputs.hermes }}
+      cur_openclaw: ${{ steps.upstream.outputs.openclaw }}
+      cur_hermes: ${{ steps.upstream.outputs.hermes }}
+    steps:
+      - name: Resolve current upstream versions
+        id: upstream
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # openclaw: latest published npm version (the base bakes openclaw@latest).
+          OPENCLAW=$(npm view openclaw version)
+          # hermes: NousResearch hermes-agent default-branch commit (the base bakes
+          # the installer from main); the commit sha is the freshness signal.
+          HERMES=$(gh api repos/NousResearch/hermes-agent/commits/main --jq '.sha')
+          echo "openclaw=$OPENCLAW" >> "$GITHUB_OUTPUT"
+          echo "hermes=$HERMES" >> "$GITHUB_OUTPUT"
+          echo "current openclaw=$OPENCLAW hermes=$HERMES"
+
+      - name: Read previously published base versions
+        id: prev
+        env:
+          GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
+        run: |
+          set -euo pipefail
+          # Best-effort: a missing tag/asset (first run) leaves the file absent,
+          # which the decision step treats as "rebuild everything".
+          gh release download rolling-images \
+            --repo jaylfc/tinyagentos-images \
+            --pattern base-versions.json \
+            --output prev-base-versions.json --clobber || true
+          if [ -f prev-base-versions.json ]; then
+            cat prev-base-versions.json
+          else
+            echo "no prior base-versions.json (first run or never stamped)"
+          fi
+
+      - name: Decide which bases to rebuild
+        id: decide
+        env:
+          EVENT: ${{ github.event_name }}
+          FORCE: ${{ github.event.inputs.force }}
+          CUR_OPENCLAW: ${{ steps.upstream.outputs.openclaw }}
+          CUR_HERMES: ${{ steps.upstream.outputs.hermes }}
+        run: |
+          set -euo pipefail
+          prev_field() {
+            # Echo a field from the prior manifest, or empty if absent. The
+            # field name is passed via argv (sys.argv[1]) so it is never spliced
+            # into the Python source.
+            [ -f prev-base-versions.json ] || { echo ""; return; }
+            python3 -c "import json,sys; print(json.load(open('prev-base-versions.json')).get(sys.argv[1],''))" "$1" 2>/dev/null || echo ""
+          }
+
+          # Non-scheduled events keep the historical "build everything" behaviour.
+          # schedule is the only change-gated trigger; force overrides the gate.
+          if [ "$EVENT" != "schedule" ] || [ "$FORCE" = "true" ]; then
+            echo "openclaw=true" >> "$GITHUB_OUTPUT"
+            echo "generic=true"  >> "$GITHUB_OUTPUT"
+            echo "hermes=true"   >> "$GITHUB_OUTPUT"
+            echo "event=$EVENT force=$FORCE -> rebuilding all bases"
+            exit 0
+          fi
+
+          PREV_OPENCLAW=$(prev_field openclaw)
+          PREV_HERMES=$(prev_field hermes)
+
+          [ "$CUR_OPENCLAW" != "$PREV_OPENCLAW" ] && OC=true || OC=false
+          [ "$CUR_HERMES"   != "$PREV_HERMES"   ] && HM=true || HM=false
+
+          # generic = common deps only (node/python/build tools). These move
+          # rarely, so on the weekly schedule we refresh them only when forced
+          # (above) or on a monthly cadence: rebuild on the first Monday of the
+          # month so security/base-package updates still land without weekly cost.
+          DOM=$(date -u +%d)
+          if [ "$DOM" -le 07 ]; then GN=true; else GN=false; fi
+
+          echo "openclaw=$OC" >> "$GITHUB_OUTPUT"
+          echo "generic=$GN"  >> "$GITHUB_OUTPUT"
+          echo "hermes=$HM"   >> "$GITHUB_OUTPUT"
+          echo "openclaw cur=$CUR_OPENCLAW prev=$PREV_OPENCLAW -> $OC"
+          echo "hermes cur=$CUR_HERMES prev=$PREV_HERMES -> $HM"
+          echo "generic (day-of-month $DOM, monthly cadence) -> $GN"
+
   build:
+    needs: detect
     strategy:
       fail-fast: false
       matrix:
@@ -39,6 +147,13 @@ jobs:
             runner: ubuntu-24.04-arm
             debarch: arm64
     runs-on: ${{ matrix.runner }}
+    # Skip matrix legs whose base did not change (detect gates them per base).
+    # A skipped leg is not a failure, so the release job still proceeds and
+    # keeps the unchanged base's existing published asset.
+    if: >-
+      (matrix.base == 'openclaw' && needs.detect.outputs.openclaw == 'true') ||
+      (matrix.base == 'generic'  && needs.detect.outputs.generic  == 'true') ||
+      (matrix.base == 'hermes'   && needs.detect.outputs.hermes   == 'true')
     env:
       # Map the "openclaw"/"generic"/"hermes" base label to its published alias.
       ALIAS: ${{ matrix.base == 'openclaw' && 'taos-openclaw-base' || (matrix.base == 'generic' && 'taos-base' || 'taos-hermes-base') }}
@@ -183,7 +298,7 @@ jobs:
           if-no-files-found: error
 
   release:
-    needs: build
+    needs: [detect, build]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -201,6 +316,27 @@ jobs:
         run: |
           echo "ts=$(date -u +%Y%m%dT%H%M%S)" >> "$GITHUB_OUTPUT"
           echo "sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      # Stamp the upstream versions baked into this publish so the next run's
+      # detect job can tell what moved. On a partial rebuild we still record the
+      # full current set (unchanged bases keep their current upstream value),
+      # which keeps the comparison honest across runs.
+      - name: Stamp base versions manifest
+        env:
+          CUR_OPENCLAW: ${{ needs.detect.outputs.cur_openclaw }}
+          CUR_HERMES: ${{ needs.detect.outputs.cur_hermes }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json, os
+          json.dump(
+              {"openclaw": os.environ["CUR_OPENCLAW"],
+               "hermes": os.environ["CUR_HERMES"]},
+              open("base-versions.json", "w"),
+              indent=2,
+          )
+          PY
+          cat base-versions.json
 
       # Images are published to the separate jaylfc/tinyagentos-images repo so
       # the main tinyagentos Releases page stays reserved for user-facing taOS
@@ -225,6 +361,11 @@ jobs:
             - `taos-hermes-base-linux-{arm64,x64}.tar.gz` -- Hermes prerequisites
 
             Source commit: ${{ github.sha }}
+          # A scheduled change-detected run may rebuild only some bases, so not
+          # every tarball is present. action-gh-release keeps prior assets that
+          # are not re-supplied; fail_on_unmatched_files lets the missing ones
+          # pass through instead of failing the publish.
+          fail_on_unmatched_files: false
           files: |
             taos-openclaw-base-linux-arm64.tar.gz
             taos-openclaw-base-linux-x64.tar.gz
@@ -232,5 +373,6 @@ jobs:
             taos-base-linux-x64.tar.gz
             taos-hermes-base-linux-arm64.tar.gz
             taos-hermes-base-linux-x64.tar.gz
+            base-versions.json
           make_latest: true
           prerelease: false


### PR DESCRIPTION
## What

Automate freshness of the prebuilt agent base images (`taos-openclaw-base`, generic `taos-base`, `taos-hermes-base`) so they do not go stale as upstream frameworks move, without babysitting and without burning CI rebuilding bases that have not changed. Closes #145.

CI-only change. No runtime code touched; the diff is confined to `.github/workflows/build-agent-images.yml`.

## Changes

- **`workflow_dispatch` gains a `force` input** (boolean, default `false`) for an on-demand rebuild of every base.
- **Weekly cron moved to an off-peak non-:00 minute** (`17 4 * * 1`) to dodge top-of-hour scheduler congestion that delays cron runs.
- **New `detect` pre-job** does honest change detection:
  - openclaw: `npm view openclaw version` (the base bakes `openclaw@latest`).
  - hermes: `gh api repos/NousResearch/hermes-agent/commits/main` sha (the base bakes the installer from `main`).
  - generic (common deps: node/python/build tools) rarely moves, so it refreshes on a **monthly cadence** (first Monday of the month) or on `force`.
  - It reads the prior `base-versions.json` stamped on the `rolling-images` release in `jaylfc/tinyagentos-images` and compares against current upstream. Anything that moved (or is missing from the prior manifest, e.g. first run) gets rebuilt.
- **Per-base gating:** the `build` matrix legs carry an `if:` on the `detect` outputs. A scheduled run only rebuilds bases that actually changed; skipped legs are not failures so `release` still runs.
- **`release` stamps `base-versions.json`** (current upstream versions) as a `rolling-images` asset so the next run can compare, and tolerates partial asset sets via `fail_on_unmatched_files: false` (`action-gh-release` keeps prior assets it is not re-supplied).

## Behaviour preserved

`push` and `repository_dispatch` events keep their historical **build-everything** behaviour. Change-gating applies **only** to the `schedule` trigger; `force=true` overrides it.

## Honest change-detection note

This is real change detection, not a faked comparison. Because the build did not previously stamp any version on the published image, the version record is introduced here as a `base-versions.json` asset stamped at publish time and read back on the next run. The first scheduled run after merge has no prior manifest, so it rebuilds all bases once and stamps the manifest; subsequent runs are change-gated. This is the "manifest on the published image" approach rather than the unconditional-rebuild fallback.

## Safety net

The baked `taos-framework-update` self-heal script is untouched and remains the runtime safety net, so a slightly-stale base still converges on deploy.

## Verify

```
python -c "import yaml,sys; yaml.safe_load(open('.github/workflows/build-agent-images.yml'))"
```
Parses cleanly. The `detect` decision shell was dry-run locally (unchanged base -> skip, moved base -> rebuild, force -> all).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manual full-rebuild option for build agent images.
  * Added a weekly scheduled refresh that rebuilds only images with upstream changes.

* **Bug Fixes**
  * Reduced unnecessary image rebuilds by checking current upstream versions before starting scheduled builds.
  * Improved release publishing so partial rebuilds can upload only the updated image artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->