### PR TITLE
fix(logs): rank-based client-log prune keeps MAX_ROWS across rowid gaps

### DIFF
--- a/tests/test_client_log_store.py
+++ b/tests/test_client_log_store.py
@@ -75,3 +75,29 @@ async def test_prune_and_order_use_rowid_when_timestamps_tie(store, monkeypatch)
     msgs = [i["message"] for i in await store.list_recent(limit=100)]
     assert len(msgs) == 3
     assert msgs == ["m5", "m4", "m3"]
+
+
+@pytest.mark.asyncio
+async def test_prune_keeps_full_buffer_when_rowids_have_gaps(store, monkeypatch):
+    # Regression: an out-of-band delete (per-user eviction, rolled-back insert)
+    # leaves a rowid gap. A value-threshold prune (rowid <= MAX(rowid) - MAX_ROWS)
+    # would then retain FEWER than MAX_ROWS rows; the rank-based prune must keep
+    # exactly the newest MAX_ROWS regardless of gaps.
+    monkeypatch.setattr("tinyagentos.client_log_store.MAX_ROWS", 3)
+    for i in range(5):
+        await store.create(user_id="u1", level="debug", message=f"m{i}")
+    # Steady state holds 3 rows; punch a gap in the retained window by deleting the
+    # middle retained rowid directly (simulating an out-of-band delete).
+    async with store._db.execute(
+        "SELECT rowid FROM client_logs ORDER BY rowid"
+    ) as cur:
+        rowids = [r[0] for r in await cur.fetchall()]
+    assert len(rowids) == 3
+    await store._db.execute(
+        "DELETE FROM client_logs WHERE rowid = ?", (rowids[1],))
+    await store._db.commit()
+    # One more insert triggers the prune; the buffer must refill to MAX_ROWS, not
+    # collapse to 2 because of the gap.
+    await store.create(user_id="u1", level="debug", message="m5")
+    items = await store.list_recent(limit=100)
+    assert len(items) == 3

--- a/tinyagentos/client_log_store.py
+++ b/tinyagentos/client_log_store.py
@@ -91,11 +91,16 @@ class ClientLogStore(BaseStore):
         # Ring-buffer prune: keep only the most recently inserted MAX_ROWS rows.
         # Retain by rowid (monotonic insert order), not created_at: the timestamp
         # is a coarse ISO string, so same-microsecond rows under a crash loop tie
-        # and make the prune non-deterministic. rowid is the indexed primary key,
-        # so this also avoids the per-insert full-table NOT IN scan.
+        # and make the prune non-deterministic. rowid is the indexed primary key.
+        # Keep by RANK (the newest MAX_ROWS rowids), not a value threshold of
+        # MAX(rowid) - MAX_ROWS: rowids are not contiguous once any row is deleted
+        # out of band (per-user eviction, rolled-back inserts), so a value
+        # threshold would retain FEWER than MAX_ROWS rows whenever gaps exist. The
+        # subquery is index-ordered + capped, and the table itself stays bounded
+        # near MAX_ROWS, so the NOT IN check is cheap.
         await self._db.execute(
-            "DELETE FROM client_logs WHERE rowid <= "
-            "(SELECT MAX(rowid) FROM client_logs) - ?",
+            "DELETE FROM client_logs WHERE rowid NOT IN "
+            "(SELECT rowid FROM client_logs ORDER BY rowid DESC LIMIT ?)",
             (MAX_ROWS,),
         )
         await self._db.commit()


### PR DESCRIPTION
## Problem
The client-log ring-buffer prune (`client_log_store.py`) deleted by a value threshold: `rowid <= (SELECT MAX(rowid)) - MAX_ROWS`. rowids are not contiguous once a row is deleted out of band (per-user eviction, rolled-back inserts), so that threshold retains FEWER than MAX_ROWS rows whenever a gap falls in the kept window. Flagged as a gitar Edge-Case (task #139, follow-up to #137/#1438).

## Fix
Keep the newest MAX_ROWS by RANK instead: `DELETE ... WHERE rowid NOT IN (SELECT rowid FROM client_logs ORDER BY rowid DESC LIMIT ?)`. Gap-safe, and cheap because the subquery is index-ordered + capped and the table stays bounded near MAX_ROWS. rowid is still the retention key (deterministic vs the coarse created_at).

## Tests
Added `test_prune_keeps_full_buffer_when_rowids_have_gaps` (punches a rowid gap in the retained window, asserts the buffer refills to MAX_ROWS not fewer). Full client-log suite: 13 passed. The existing rowid tie-break + cap tests still pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log cleanup so the app now keeps the most recent log entries correctly, even if some older entries were removed earlier.
  * Prevents the log buffer from dropping the wrong entries when record IDs are not连续.

* **Tests**
  * Added coverage for log pruning behavior with gaps in stored log records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->