### PR TITLE
feat(agents): base-image management API (list / import / prune / prefetch)

### DIFF
--- a/tests/test_routes_agent_images.py
+++ b/tests/test_routes_agent_images.py
@@ -1,0 +1,172 @@
+"""Route tests for the base-image management API."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+# `incus image list --format=csv -c lasu` output: alias,arch,size,uploaded.
+# Includes a non-taos image that must be filtered out of the response.
+_INCUS_LIST_CSV = (
+    "taos-openclaw-base,aarch64,412.50MiB,2026/06/01 12:00 UTC\n"
+    "taos-base,aarch64,300.00MiB,2026/06/01 12:05 UTC\n"
+    "ubuntu/jammy,aarch64,180.00MiB,2026/05/01 00:00 UTC\n"
+)
+
+
+@pytest.mark.asyncio
+class TestListAgentImages:
+    async def test_lists_only_taos_bases_with_total(self, client):
+        with patch(
+            "tinyagentos.routes.agent_images._incus_image_rows",
+            new=AsyncMock(return_value=[
+                {"alias": "taos-openclaw-base", "architecture": "aarch64",
+                 "size": "412.50MiB", "uploaded_at": "2026/06/01 12:00 UTC"},
+                {"alias": "taos-base", "architecture": "aarch64",
+                 "size": "300.00MiB", "uploaded_at": "2026/06/01 12:05 UTC"},
+                {"alias": "ubuntu/jammy", "architecture": "aarch64",
+                 "size": "180.00MiB", "uploaded_at": "2026/05/01 00:00 UTC"},
+            ]),
+        ):
+            resp = await client.get("/api/agent-images")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["incus_available"] is True
+        aliases = {img["alias"] for img in data["images"]}
+        # Only taos bases, never the unrelated ubuntu image.
+        assert aliases == {"taos-openclaw-base", "taos-base"}
+        # Framework mapping: openclaw base backs openclaw; generic base is None.
+        by_alias = {img["alias"]: img for img in data["images"]}
+        assert by_alias["taos-openclaw-base"]["framework"] == "openclaw"
+        assert by_alias["taos-base"]["framework"] is None
+        # Aggregate total = sum of the two taos base sizes in bytes.
+        expected = int(412.50 * 1024 ** 2) + int(300.00 * 1024 ** 2)
+        assert data["total_size_bytes"] == expected
+
+    async def test_parses_real_incus_csv_via_subprocess(self, client):
+        proc = AsyncMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(_INCUS_LIST_CSV.encode(), b""))
+        with patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=proc)):
+            resp = await client.get("/api/agent-images")
+        assert resp.status_code == 200
+        aliases = {img["alias"] for img in resp.json()["images"]}
+        assert aliases == {"taos-openclaw-base", "taos-base"}
+
+    async def test_incus_unavailable_returns_empty(self, client):
+        with patch(
+            "tinyagentos.routes.agent_images._incus_image_rows",
+            new=AsyncMock(return_value=None),
+        ):
+            resp = await client.get("/api/agent-images")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["images"] == []
+        assert data["total_size_bytes"] == 0
+        assert data["incus_available"] is False
+
+    async def test_unauthenticated_returns_401(self, app):
+        from httpx import ASGITransport, AsyncClient
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as c:
+            resp = await c.get("/api/agent-images")
+            assert resp.status_code in (401, 403)
+
+
+@pytest.mark.asyncio
+class TestImportAgentImage:
+    async def test_known_alias_invokes_ensure(self, client):
+        with patch(
+            "tinyagentos.routes.agent_images.ensure_image_present",
+            new=AsyncMock(return_value=True),
+        ) as mock_ensure:
+            resp = await client.post("/api/agent-images/taos-openclaw-base/import")
+        assert resp.status_code == 200
+        assert resp.json() == {"alias": "taos-openclaw-base", "present": True}
+        mock_ensure.assert_awaited_once_with("taos-openclaw-base")
+
+    async def test_unknown_alias_returns_404(self, client):
+        with patch(
+            "tinyagentos.routes.agent_images.ensure_image_present",
+            new=AsyncMock(return_value=True),
+        ) as mock_ensure:
+            resp = await client.post("/api/agent-images/not-a-taos-base/import")
+        assert resp.status_code == 404
+        mock_ensure.assert_not_called()
+
+
+@pytest.mark.asyncio
+class TestDeleteAgentImage:
+    async def test_taos_alias_invokes_delete(self, client):
+        with patch(
+            "tinyagentos.routes.agent_images._incus_image_delete",
+            new=AsyncMock(return_value=(0, "")),
+        ) as mock_del:
+            resp = await client.delete("/api/agent-images/taos-base")
+        assert resp.status_code == 200
+        assert resp.json() == {"alias": "taos-base", "deleted": True}
+        mock_del.assert_awaited_once_with("taos-base")
+
+    async def test_non_taos_alias_refused_400_without_delete(self, client):
+        with patch(
+            "tinyagentos.routes.agent_images._incus_image_delete",
+            new=AsyncMock(return_value=(0, "")),
+        ) as mock_del:
+            resp = await client.delete("/api/agent-images/ubuntu-jammy")
+        assert resp.status_code == 400
+        mock_del.assert_not_called()
+
+    async def test_incus_failure_returns_502(self, client):
+        with patch(
+            "tinyagentos.routes.agent_images._incus_image_delete",
+            new=AsyncMock(return_value=(1, "image in use")),
+        ):
+            resp = await client.delete("/api/agent-images/taos-base")
+        assert resp.status_code == 502
+
+
+@pytest.mark.asyncio
+class TestPrefetchToggle:
+    async def test_enable_persists_and_reflects(self, client, tmp_data_dir):
+        with patch(
+            "tinyagentos.routes.agent_images.is_prefetch_enabled",
+            return_value=False,
+        ):
+            resp = await client.post(
+                "/api/agent-images/prefetch", json={"enabled": True},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["stored"] is True
+        assert data["prefetch_enabled"] is True
+        # Persisted to data_dir.
+        pref = tmp_data_dir / "agent_image_prefs.json"
+        assert pref.exists()
+        assert '"prefetch_enabled": true' in pref.read_text()
+
+    async def test_disable_persists(self, client, tmp_data_dir):
+        with patch(
+            "tinyagentos.routes.agent_images.is_prefetch_enabled",
+            return_value=False,
+        ):
+            resp = await client.post(
+                "/api/agent-images/prefetch", json={"enabled": False},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["stored"] is False
+        assert data["prefetch_enabled"] is False
+
+    async def test_env_var_overrides_disabled_pref(self, client):
+        # If the env var is on, effective stays True even when storing False.
+        with patch(
+            "tinyagentos.routes.agent_images.is_prefetch_enabled",
+            return_value=True,
+        ):
+            resp = await client.post(
+                "/api/agent-images/prefetch", json={"enabled": False},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["prefetch_enabled"] is True

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -340,3 +340,6 @@ def register_all_routers(app):
 
     from tinyagentos.routes.agent_model_keys import router as agent_model_keys_router
     app.include_router(agent_model_keys_router)
+
+    from tinyagentos.routes.agent_images import router as agent_images_router
+    app.include_router(agent_images_router)

--- a/tinyagentos/routes/agent_images.py
+++ b/tinyagentos/routes/agent_images.py
@@ -1,0 +1,272 @@
+"""Base-image management API for the Agents app.
+
+Prebuilt agent base images (incus images aliased ``taos-<framework>-base``
+and the generic ``taos-base``) let fresh deploys skip the ~60-90s cold apt
+run. Today they can only be inspected or pruned with the incus CLI on the
+host, which violates the no-terminal-for-end-users principle. This router
+exposes the same operations over HTTP so the Agents app can manage them:
+
+- ``GET  /api/agent-images``                 list present taos base images
+- ``POST /api/agent-images/{alias}/import``  import a known base locally
+- ``DELETE /api/agent-images/{alias}``       prune a base to reclaim disk
+- ``POST /api/agent-images/prefetch``        toggle the prefetch preference
+
+Every incus call degrades gracefully: a missing/unstarted incus or an
+absent image returns an empty list or a clear error, never a 500 crash.
+This router does NOT trigger CI image rebuilds (that is the
+build-agent-images.yml workflow); ``import`` re-imports the already
+published tarball via :func:`ensure_image_present`.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel
+
+from tinyagentos.agent_image import (
+    FRAMEWORKS_WITH_DEDICATED_BASE,
+    GENERIC_BASE_ALIAS,
+    all_base_image_aliases,
+    base_image_alias,
+    ensure_image_present,
+    is_prefetch_enabled,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+# Pref file that persists the prefetch toggle when the env var is unset.
+# Lives beside the other data_dir state (config.yaml, installed.json, ...).
+_PREFETCH_PREF_FILE = "agent_image_prefs.json"
+
+
+def _known_base_aliases() -> set[str]:
+    """Set of valid taos base aliases (dedicated frameworks + generic).
+
+    The single source of truth for what this router may import or prune, so
+    a prune can never touch an unrelated incus image.
+    """
+    return set(all_base_image_aliases())
+
+
+def _framework_for_alias(alias: str) -> str | None:
+    """Return the framework an alias backs, or None for the generic base."""
+    if alias == GENERIC_BASE_ALIAS:
+        return None
+    for framework in sorted(FRAMEWORKS_WITH_DEDICATED_BASE):
+        if base_image_alias(framework) == alias:
+            return framework
+    return None
+
+
+async def _incus_image_rows() -> list[dict] | None:
+    """Return parsed ``incus image list`` rows, or None if incus is unavailable.
+
+    Uses ``incus image list --format=csv -c lasu`` (alias, architecture,
+    size, upload date). Returns None on any failure (incus not installed,
+    daemon down, non-zero exit) so the caller can degrade to an empty list.
+    """
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "incus", "image", "list",
+            "--format=csv", "-c", "lasu",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=30)
+    except (FileNotFoundError, asyncio.TimeoutError):
+        return None
+    except Exception:  # pragma: no cover - defensive
+        return None
+    if proc.returncode != 0:
+        return None
+
+    rows: list[dict] = []
+    import csv as _csv
+
+    text = (stdout or b"").decode()
+    for fields in _csv.reader(text.splitlines()):
+        if len(fields) < 4 or not fields[0].strip():
+            continue
+        rows.append({
+            "alias": fields[0].strip(),
+            "architecture": fields[1].strip(),
+            "size": fields[2].strip(),
+            "uploaded_at": fields[3].strip(),
+        })
+    return rows
+
+
+def _parse_size_bytes(size: str) -> int:
+    """Parse an incus size string (e.g. ``412.50MiB``) into bytes.
+
+    Best-effort: returns 0 for an unrecognised value so the aggregate total
+    never crashes on an unexpected format.
+    """
+    units = {
+        "B": 1,
+        "KIB": 1024,
+        "MIB": 1024 ** 2,
+        "GIB": 1024 ** 3,
+        "TIB": 1024 ** 4,
+        "KB": 1000,
+        "MB": 1000 ** 2,
+        "GB": 1000 ** 3,
+        "TB": 1000 ** 4,
+    }
+    s = size.strip().upper()
+    # Longest suffix first so "MIB" matches before the "B" substring.
+    for suffix in sorted(units, key=len, reverse=True):
+        factor = units[suffix]
+        if s.endswith(suffix):
+            num = s[: -len(suffix)].strip()
+            try:
+                return int(float(num) * factor)
+            except ValueError:
+                return 0
+    try:
+        return int(float(s))
+    except ValueError:
+        return 0
+
+
+async def _incus_image_delete(alias: str) -> tuple[int, str]:
+    """Run ``incus image delete <alias>``; return (returncode, output).
+
+    Returns (127, msg) when incus is not installed so the route can map it
+    to a clear error instead of crashing.
+    """
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "incus", "image", "delete", alias,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=60)
+    except FileNotFoundError:
+        return 127, "incus is not installed on this host"
+    except asyncio.TimeoutError:
+        return 124, "incus image delete timed out"
+    return proc.returncode, (stdout or b"").decode()
+
+
+@router.get("/api/agent-images")
+async def list_agent_images(request: Request):
+    """List the taos base images present on the host.
+
+    Only ``taos-*-base`` aliases are reported, never unrelated incus images.
+    Each entry carries its alias, architecture, size, upload date, the
+    framework it backs (None for the generic base); an aggregate disk-usage
+    total is returned alongside the prefetch-enabled flag.
+
+    Degrades gracefully: when incus is unavailable the image list is empty
+    (``incus_available: false``) rather than a 500.
+    """
+    known = _known_base_aliases()
+    rows = await _incus_image_rows()
+    if rows is None:
+        return {
+            "images": [],
+            "total_size_bytes": 0,
+            "prefetch_enabled": is_prefetch_enabled(),
+            "incus_available": False,
+        }
+
+    images: list[dict] = []
+    total = 0
+    for row in rows:
+        alias = row["alias"]
+        if alias not in known:
+            continue
+        size_bytes = _parse_size_bytes(row["size"])
+        total += size_bytes
+        images.append({
+            "alias": alias,
+            "architecture": row["architecture"],
+            "size": row["size"],
+            "size_bytes": size_bytes,
+            "uploaded_at": row["uploaded_at"],
+            "framework": _framework_for_alias(alias),
+        })
+
+    return {
+        "images": images,
+        "total_size_bytes": total,
+        "prefetch_enabled": is_prefetch_enabled(),
+        "incus_available": True,
+    }
+
+
+@router.post("/api/agent-images/{alias}/import")
+async def import_agent_image(alias: str):
+    """Ensure a known taos base image is present locally.
+
+    Re-imports the already-published tarball via
+    :func:`ensure_image_present` (no CI rebuild is triggered). 404 if the
+    alias is not a known taos base. Returns whether the image is now present.
+    """
+    if alias not in _known_base_aliases():
+        raise HTTPException(status_code=404, detail=f"unknown base image alias: {alias}")
+
+    ok = await ensure_image_present(alias)
+    return {"alias": alias, "present": ok}
+
+
+@router.delete("/api/agent-images/{alias}")
+async def delete_agent_image(alias: str):
+    """Prune (hard-delete) a taos base image to reclaim disk.
+
+    GUARD: only aliases in the taos base set (``taos-<framework>-base`` /
+    ``taos-base``) are permitted; anything else is refused with 400 so an
+    unrelated incus image can never be deleted through this route.
+
+    This is a real hard-delete and is SAFE for base images: they are
+    reproducible (re-importable via the import endpoint) and a container's
+    rootfs is copied at launch, so pruning never affects a running agent --
+    only future cold deploys, which fall back to the slower uncached path.
+    """
+    if alias not in _known_base_aliases():
+        raise HTTPException(
+            status_code=400,
+            detail=f"refusing to delete non-taos-base alias: {alias}",
+        )
+
+    code, output = await _incus_image_delete(alias)
+    if code != 0:
+        raise HTTPException(
+            status_code=502,
+            detail=f"incus image delete failed: {output.strip()[:300]}",
+        )
+    return {"alias": alias, "deleted": True}
+
+
+class PrefetchToggle(BaseModel):
+    enabled: bool
+
+
+@router.post("/api/agent-images/prefetch")
+async def set_prefetch(body: PrefetchToggle, request: Request):
+    """Persist the base-image prefetch preference.
+
+    ``is_prefetch_enabled`` reads the ``TAOS_PREFETCH_BASE_IMAGE`` env var,
+    which a UI cannot set. We persist the toggle to a small pref file in
+    data_dir so it survives, and the response reflects the stored value.
+
+    Note: the boot-time prefetch is gated on the env var, so a change here
+    only governs UI state until the env var is also set; the effective
+    enabled flag (env OR pref) is returned so callers see the live value.
+    """
+    data_dir = request.app.state.config_path.parent
+    pref_path = data_dir / _PREFETCH_PREF_FILE
+    try:
+        pref_path.write_text(json.dumps({"prefetch_enabled": body.enabled}))
+    except OSError as exc:
+        raise HTTPException(status_code=500, detail=f"could not persist preference: {exc}")
+
+    # Effective value: the env var still wins if it is set on.
+    effective = is_prefetch_enabled() or body.enabled
+    return {"prefetch_enabled": effective, "stored": body.enabled}


### PR DESCRIPTION
## What

Backend slice of task #146: controller endpoints so the Agents app can manage the prebuilt agent base images (incus images aliased `taos-<framework>-base` / `taos-base`) without dropping to the host shell. Today this is incus-CLI-only, which violates the no-terminal-for-end-users principle. The frontend pane is a separate later slice that will consume these.

New router `tinyagentos/routes/agent_images.py`, mounted in `routes/__init__.py` beside the other routers (does not collide with `routes/images.py`, the Images Studio generation app).

## Endpoints

- `GET /api/agent-images` -- lists the `taos-*-base` images present on the host (alias, architecture, size, upload date), plus the framework each backs, an aggregate disk-usage total, and whether prefetch is enabled. Only taos bases are reported, never unrelated incus images. Parses `incus image list --format=csv -c lasu`.
- `POST /api/agent-images/{alias}/import` -- ensures a known base is present locally via `ensure_image_present` (re-imports the already-published tarball; no CI rebuild). 404 for an unknown alias.
- `DELETE /api/agent-images/{alias}` -- prunes (`incus image delete`) to reclaim disk. Guarded to the taos base set; any other alias is refused with 400. This is a real hard-delete and is safe for base images: they are reproducible and a container's rootfs is copied at launch, so pruning only affects future cold deploys, never a running agent.
- `POST /api/agent-images/prefetch` -- persists the prefetch preference (`{enabled: bool}`).

## Prefetch persistence caveat

`is_prefetch_enabled()` reads the `TAOS_PREFETCH_BASE_IMAGE` env var, which a UI cannot set. The toggle is persisted to a small `agent_image_prefs.json` in `data_dir`, and the response returns the effective value (env OR stored). The boot-time prefetch remains gated on the env var, so the stored toggle governs UI state until the env var is also set -- a fuller wiring of the pref into boot is out of scope for this slice.

## Graceful degradation

Every incus call is wrapped: a missing/unstarted incus or an absent image returns an empty list / clear error and never 500-crashes the controller.

## Tests

`tests/test_routes_agent_images.py` covers: list parsing + taos-only filtering + aggregate total (mocked incus output and via the subprocess layer), incus-unavailable -> empty, the prune guard (non-taos -> 400 with no delete; taos -> delete invoked; incus failure -> 502), import (known vs unknown alias), and the prefetch toggle (persist + reflect, env-var override). All 46 tests in the new + existing agent-image suites pass.