### PR TITLE
feat(agents): Base Images management pane (UI)

### DIFF
--- a/desktop/src/apps/AgentsApp.tsx
+++ b/desktop/src/apps/AgentsApp.tsx
@@ -16,6 +16,7 @@ import { DeployWizard } from "./agents/DeployWizard";
 import { ImportWizard } from "./agents/ImportWizard";
 import { ArchivedAgentsPanel } from "./agents/ArchivedAgents";
 import { RegistryPanel } from "./agents/RegistryPanel";
+import { BaseImagesPanel } from "./agents/BaseImagesPanel";
 import { fetchTaosAgentConfig } from "@/lib/taos-agent-api";
 
 /* ------------------------------------------------------------------ */
@@ -570,6 +571,7 @@ export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
               onPurge={handlePurge}
             />
             <RegistryPanel />
+            <BaseImagesPanel />
           </div>
         ) : (
           <div className="p-4">
@@ -657,6 +659,7 @@ export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
               onPurge={handlePurge}
             />
             <RegistryPanel />
+            <BaseImagesPanel />
           </div>
         )}
       </div>

--- a/desktop/src/apps/agents/BaseImagesPanel.tsx
+++ b/desktop/src/apps/agents/BaseImagesPanel.tsx
@@ -1,0 +1,303 @@
+import { useState, useEffect, useCallback } from "react";
+import {
+  ChevronRight,
+  Layers,
+  RefreshCw,
+  DownloadCloud,
+  Trash2,
+  HardDrive,
+} from "lucide-react";
+import { Button, Card, Switch, Label } from "@/components/ui";
+import {
+  parseBaseImagesResponse,
+  formatBytes,
+  frameworkLabel,
+  type BaseImageRow,
+  type BaseImagesView,
+} from "./baseImages";
+
+/* ------------------------------------------------------------------ */
+/*  Base Images management pane                                         */
+/*                                                                     */
+/*  Advanced / secondary surface (most users never need it): manage    */
+/*  the prebuilt taos base images that let fresh deploys skip the cold  */
+/*  apt run. Consumes /api/agent-images (list / import / delete /       */
+/*  prefetch). Follows the collapsible-section pattern used by the      */
+/*  Registry and Archived panels.                                      */
+/* ------------------------------------------------------------------ */
+
+const EMPTY_VIEW: BaseImagesView = {
+  images: [],
+  totalSizeBytes: 0,
+  prefetchEnabled: false,
+  incusAvailable: false,
+};
+
+function BaseImageRowItem({
+  row,
+  busy,
+  onImport,
+  onPrune,
+}: {
+  row: BaseImageRow;
+  busy: boolean;
+  onImport: (alias: string) => void;
+  onPrune: (row: BaseImageRow) => void;
+}) {
+  return (
+    <Card className="flex items-center gap-3 px-4 py-3" role="listitem">
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="font-medium text-sm truncate">{frameworkLabel(row.framework)}</span>
+          <span className="text-[11px] text-shell-text-tertiary">{row.architecture}</span>
+          <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium border bg-emerald-500/20 text-emerald-300 border-emerald-500/30">
+            present
+          </span>
+        </div>
+        <div className="flex items-center gap-3 mt-0.5 flex-wrap">
+          <code
+            className="text-[10px] text-shell-text-tertiary font-mono truncate max-w-[220px]"
+            title={row.alias}
+          >
+            {row.alias}
+          </code>
+          <span className="text-[11px] text-shell-text-tertiary">{row.size || formatBytes(row.sizeBytes)}</span>
+          {row.uploadedAt && (
+            <span className="text-[11px] text-shell-text-tertiary">built {row.uploadedAt}</span>
+          )}
+        </div>
+      </div>
+
+      <div className="flex items-center gap-1 shrink-0" role="group" aria-label="Base image actions">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 hover:bg-accent/15 hover:text-accent"
+          onClick={() => onImport(row.alias)}
+          disabled={busy}
+          aria-label={`Re-import ${frameworkLabel(row.framework)} base image`}
+          title="Re-import / refresh"
+        >
+          <DownloadCloud size={14} />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 hover:bg-red-500/15 hover:text-red-400"
+          onClick={() => onPrune(row)}
+          disabled={busy}
+          aria-label={`Prune ${frameworkLabel(row.framework)} base image`}
+          title="Prune to reclaim disk"
+        >
+          <Trash2 size={14} />
+        </Button>
+      </div>
+    </Card>
+  );
+}
+
+export function BaseImagesPanel() {
+  const [expanded, setExpanded] = useState(false);
+  const [view, setView] = useState<BaseImagesView>(EMPTY_VIEW);
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  // Alias currently running an action, so its row buttons disable.
+  const [busyAlias, setBusyAlias] = useState<string | null>(null);
+  const [prefetchBusy, setPrefetchBusy] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setErr(null);
+    try {
+      const resp = await fetch("/api/agent-images", { credentials: "include" });
+      if (!resp.ok) {
+        setErr(`Failed to load base images (${resp.status})`);
+        return;
+      }
+      setView(parseBaseImagesResponse(await resp.json()));
+    } catch (e: unknown) {
+      setErr(e instanceof Error ? e.message : "Network error");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (expanded) load();
+  }, [expanded, load]);
+
+  async function handleImport(alias: string) {
+    setBusyAlias(alias);
+    setErr(null);
+    setNotice(null);
+    try {
+      const resp = await fetch(`/api/agent-images/${encodeURIComponent(alias)}/import`, {
+        method: "POST",
+        credentials: "include",
+      });
+      if (!resp.ok) {
+        const e = await resp.json().catch(() => ({}));
+        setErr((e as { detail?: string }).detail ?? `Import failed (${resp.status})`);
+        return;
+      }
+      setNotice(`Imported ${alias}.`);
+      await load();
+    } catch (e: unknown) {
+      setErr(e instanceof Error ? e.message : "Network error");
+    } finally {
+      setBusyAlias(null);
+    }
+  }
+
+  async function handlePrune(row: BaseImageRow) {
+    const label = frameworkLabel(row.framework);
+    const confirmed = window.confirm(
+      `Prune the ${label} base image (${row.alias})?\n\n` +
+        "This is safe: base images are reproducible and a container's rootfs is " +
+        "copied at launch, so pruning never affects a running agent -- only future " +
+        "cold deploys, which fall back to the slower uncached path. You can re-import " +
+        "it any time.",
+    );
+    if (!confirmed) return;
+
+    setBusyAlias(row.alias);
+    setErr(null);
+    setNotice(null);
+    try {
+      const resp = await fetch(`/api/agent-images/${encodeURIComponent(row.alias)}`, {
+        method: "DELETE",
+        credentials: "include",
+      });
+      if (!resp.ok) {
+        const e = await resp.json().catch(() => ({}));
+        setErr((e as { detail?: string }).detail ?? `Prune failed (${resp.status})`);
+        return;
+      }
+      setNotice(`Pruned ${row.alias}.`);
+      await load();
+    } catch (e: unknown) {
+      setErr(e instanceof Error ? e.message : "Network error");
+    } finally {
+      setBusyAlias(null);
+    }
+  }
+
+  async function handlePrefetchToggle(enabled: boolean) {
+    setPrefetchBusy(true);
+    setErr(null);
+    setNotice(null);
+    // Optimistic: reflect the intent immediately, reconcile from the response.
+    setView((v) => ({ ...v, prefetchEnabled: enabled }));
+    try {
+      const resp = await fetch("/api/agent-images/prefetch", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json", Accept: "application/json" },
+        body: JSON.stringify({ enabled }),
+      });
+      if (!resp.ok) {
+        const e = await resp.json().catch(() => ({}));
+        setErr((e as { detail?: string }).detail ?? `Prefetch toggle failed (${resp.status})`);
+        setView((v) => ({ ...v, prefetchEnabled: !enabled }));
+        return;
+      }
+      const data = await resp.json();
+      setView((v) => ({ ...v, prefetchEnabled: Boolean(data.prefetch_enabled) }));
+    } catch (e: unknown) {
+      setErr(e instanceof Error ? e.message : "Network error");
+      setView((v) => ({ ...v, prefetchEnabled: !enabled }));
+    } finally {
+      setPrefetchBusy(false);
+    }
+  }
+
+  return (
+    <section className="mt-4" aria-label="Base images">
+      <button
+        onClick={() => setExpanded((v) => !v)}
+        className="flex items-center gap-2 text-xs text-shell-text-secondary hover:text-shell-text transition-colors mb-2 w-full"
+        aria-expanded={expanded}
+        aria-controls="base-images-panel"
+      >
+        <ChevronRight
+          size={14}
+          className={`transition-transform shrink-0 ${expanded ? "rotate-90" : ""}`}
+          aria-hidden
+        />
+        <Layers size={13} aria-hidden />
+        <span>Base Images</span>
+        <span className="text-shell-text-tertiary">(advanced)</span>
+      </button>
+
+      <div id="base-images-panel" className={`space-y-3 ${expanded ? "" : "hidden"}`}>
+        <p className="text-[11px] text-shell-text-tertiary">
+          Prebuilt base images let fresh deploys skip the cold setup run. Most users never
+          need to touch these.
+        </p>
+
+        {/* Aggregate disk usage + prefetch toggle */}
+        <Card className="flex items-center justify-between gap-3 px-4 py-3">
+          <div className="flex items-center gap-2 min-w-0">
+            <HardDrive size={16} className="text-accent shrink-0" aria-hidden />
+            <div className="min-w-0">
+              <div className="text-sm font-semibold">
+                {formatBytes(view.totalSizeBytes)}
+              </div>
+              <div className="text-[11px] text-shell-text-tertiary">
+                total base-image disk usage
+              </div>
+            </div>
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
+            <Label htmlFor="base-image-prefetch" className="text-[11px] text-shell-text-secondary">
+              Prefetch on boot
+            </Label>
+            <Switch
+              id="base-image-prefetch"
+              checked={view.prefetchEnabled}
+              onCheckedChange={handlePrefetchToggle}
+              disabled={prefetchBusy}
+              aria-label="Prefetch base images on boot"
+            />
+          </div>
+        </Card>
+
+        {notice && (
+          <p className="text-[11px] text-emerald-400" role="status">{notice}</p>
+        )}
+        {err && (
+          <p className="text-[11px] text-red-400" role="alert">{err}</p>
+        )}
+
+        {loading ? (
+          <div className="flex items-center gap-2 text-xs text-shell-text-tertiary py-2">
+            <RefreshCw size={12} className="animate-spin" aria-hidden />
+            Loading base images…
+          </div>
+        ) : !view.incusAvailable ? (
+          <p className="text-xs text-shell-text-tertiary py-1">
+            The container runtime is unavailable on this host, so no base images can be
+            listed or managed.
+          </p>
+        ) : view.images.length === 0 ? (
+          <p className="text-xs text-shell-text-tertiary py-1">
+            No base images present. Import one to speed up future deploys.
+          </p>
+        ) : (
+          <div className="space-y-2" role="list" aria-label="Base image list">
+            {view.images.map((row) => (
+              <BaseImageRowItem
+                key={row.alias}
+                row={row}
+                busy={busyAlias === row.alias}
+                onImport={handleImport}
+                onPrune={handlePrune}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/desktop/src/apps/agents/BaseImagesPanel.tsx
+++ b/desktop/src/apps/agents/BaseImagesPanel.tsx
@@ -7,7 +7,7 @@ import {
   Trash2,
   HardDrive,
 } from "lucide-react";
-import { Button, Card, Switch, Label } from "@/components/ui";
+import { Button, Card } from "@/components/ui";
 import {
   parseBaseImagesResponse,
   formatBytes,
@@ -250,16 +250,19 @@ export function BaseImagesPanel() {
             </div>
           </div>
           <div className="flex items-center gap-2 shrink-0">
-            <Label htmlFor="base-image-prefetch" className="text-[11px] text-shell-text-secondary">
-              Prefetch on boot
-            </Label>
-            <Switch
-              id="base-image-prefetch"
-              checked={view.prefetchEnabled}
-              onCheckedChange={handlePrefetchToggle}
-              disabled={prefetchBusy}
+            <span className="text-[11px] text-shell-text-secondary">Prefetch on boot</span>
+            <Button
+              variant="outline"
+              size="sm"
+              role="switch"
+              aria-checked={view.prefetchEnabled}
               aria-label="Prefetch base images on boot"
-            />
+              onClick={() => handlePrefetchToggle(!view.prefetchEnabled)}
+              disabled={prefetchBusy}
+              className={view.prefetchEnabled ? "border-accent/40 text-accent" : ""}
+            >
+              {view.prefetchEnabled ? "On" : "Off"}
+            </Button>
           </div>
         </Card>
 

--- a/desktop/src/apps/agents/baseImages.test.ts
+++ b/desktop/src/apps/agents/baseImages.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatBytes,
+  frameworkLabel,
+  parseBaseImagesResponse,
+} from "./baseImages";
+
+describe("formatBytes", () => {
+  it("renders 0 B for zero, negative and non-finite input", () => {
+    expect(formatBytes(0)).toBe("0 B");
+    expect(formatBytes(-5)).toBe("0 B");
+    expect(formatBytes(NaN)).toBe("0 B");
+    expect(formatBytes(Infinity)).toBe("0 B");
+  });
+
+  it("renders whole bytes without a decimal", () => {
+    expect(formatBytes(512)).toBe("512 B");
+  });
+
+  it("scales into KB, MB and GB with one decimal", () => {
+    expect(formatBytes(1536)).toBe("1.5 KB");
+    expect(formatBytes(5 * 1024 * 1024)).toBe("5.0 MB");
+    expect(formatBytes(2.25 * 1024 * 1024 * 1024)).toBe("2.3 GB");
+  });
+});
+
+describe("frameworkLabel", () => {
+  it("returns the framework name when present", () => {
+    expect(frameworkLabel("hermes")).toBe("hermes");
+  });
+
+  it("falls back to 'generic' for the generic base", () => {
+    expect(frameworkLabel(null)).toBe("generic");
+  });
+});
+
+describe("parseBaseImagesResponse", () => {
+  it("maps a well-formed response into rows and aggregates", () => {
+    const view = parseBaseImagesResponse({
+      images: [
+        {
+          alias: "taos-hermes-base",
+          architecture: "aarch64",
+          size: "412.50MiB",
+          size_bytes: 432537600,
+          uploaded_at: "2026/06/20 10:11 UTC",
+          framework: "hermes",
+        },
+        {
+          alias: "taos-base",
+          architecture: "aarch64",
+          size: "300MiB",
+          size_bytes: 314572800,
+          uploaded_at: "2026/06/19 09:00 UTC",
+          framework: null,
+        },
+      ],
+      total_size_bytes: 747110400,
+      prefetch_enabled: true,
+      incus_available: true,
+    });
+
+    expect(view.images).toHaveLength(2);
+    expect(view.images[0]).toEqual({
+      alias: "taos-hermes-base",
+      architecture: "aarch64",
+      size: "412.50MiB",
+      sizeBytes: 432537600,
+      uploadedAt: "2026/06/20 10:11 UTC",
+      framework: "hermes",
+    });
+    expect(view.images[1]!.framework).toBeNull();
+    expect(view.totalSizeBytes).toBe(747110400);
+    expect(view.prefetchEnabled).toBe(true);
+    expect(view.incusAvailable).toBe(true);
+  });
+
+  it("degrades a missing/incus-unavailable response to safe defaults", () => {
+    const view = parseBaseImagesResponse({
+      images: [],
+      total_size_bytes: 0,
+      prefetch_enabled: false,
+      incus_available: false,
+    });
+    expect(view.images).toEqual([]);
+    expect(view.totalSizeBytes).toBe(0);
+    expect(view.prefetchEnabled).toBe(false);
+    expect(view.incusAvailable).toBe(false);
+  });
+
+  it("tolerates entirely malformed input without throwing", () => {
+    expect(parseBaseImagesResponse(null).images).toEqual([]);
+    expect(parseBaseImagesResponse("nope").totalSizeBytes).toBe(0);
+    expect(parseBaseImagesResponse({}).incusAvailable).toBe(false);
+  });
+
+  it("fills defaults for partial image entries", () => {
+    const view = parseBaseImagesResponse({ images: [{ alias: "taos-base" }] });
+    expect(view.images[0]).toEqual({
+      alias: "taos-base",
+      architecture: "",
+      size: "",
+      sizeBytes: 0,
+      uploadedAt: "",
+      framework: null,
+    });
+  });
+});

--- a/desktop/src/apps/agents/baseImages.ts
+++ b/desktop/src/apps/agents/baseImages.ts
@@ -1,0 +1,79 @@
+/* ------------------------------------------------------------------ */
+/*  Base Images: pure client-side helpers                              */
+/*                                                                     */
+/*  Byte-size formatting and the GET /api/agent-images response ->     */
+/*  row mapping for the Base Images pane. Kept framework-free so they  */
+/*  are unit-testable (mirrors importBundle.ts / a2aSelection.ts).     */
+/* ------------------------------------------------------------------ */
+
+/** One base image row rendered by the pane. */
+export interface BaseImageRow {
+  alias: string;
+  architecture: string;
+  /** Raw incus size string, e.g. "412.50MiB". */
+  size: string;
+  sizeBytes: number;
+  uploadedAt: string;
+  /** Framework the alias backs, or null for the generic taos-base. */
+  framework: string | null;
+}
+
+/** Parsed shape of GET /api/agent-images. */
+export interface BaseImagesView {
+  images: BaseImageRow[];
+  totalSizeBytes: number;
+  prefetchEnabled: boolean;
+  incusAvailable: boolean;
+}
+
+/**
+ * Human-readable byte size using binary (1024) units, e.g. "1.2 GB".
+ * Best-effort: a negative or non-finite value renders as "0 B".
+ */
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let value = bytes;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  // Whole bytes need no decimal; larger units get one.
+  const text = unit === 0 ? String(Math.round(value)) : value.toFixed(1);
+  return `${text} ${units[unit]}`;
+}
+
+/** Display label for the framework an image backs (generic base has none). */
+export function frameworkLabel(framework: string | null): string {
+  return framework ?? "generic";
+}
+
+/**
+ * Map the raw GET /api/agent-images JSON into the view the pane renders.
+ * Unknown/missing fields degrade to safe defaults so a malformed entry can
+ * never crash the list.
+ */
+export function parseBaseImagesResponse(data: unknown): BaseImagesView {
+  const obj = (data && typeof data === "object" ? data : {}) as Record<string, unknown>;
+  const rawImages = Array.isArray(obj.images) ? obj.images : [];
+
+  const images: BaseImageRow[] = rawImages.map((entry) => {
+    const e = (entry && typeof entry === "object" ? entry : {}) as Record<string, unknown>;
+    return {
+      alias: String(e.alias ?? ""),
+      architecture: String(e.architecture ?? ""),
+      size: String(e.size ?? ""),
+      sizeBytes: typeof e.size_bytes === "number" ? e.size_bytes : 0,
+      uploadedAt: String(e.uploaded_at ?? ""),
+      framework: e.framework == null ? null : String(e.framework),
+    };
+  });
+
+  return {
+    images,
+    totalSizeBytes: typeof obj.total_size_bytes === "number" ? obj.total_size_bytes : 0,
+    prefetchEnabled: Boolean(obj.prefetch_enabled),
+    incusAvailable: Boolean(obj.incus_available),
+  };
+}


### PR DESCRIPTION
## What

Adds an advanced, collapsible **Base Images** pane to the Agents app (task #146, UI slice; the backend already merged on dev). It consumes the new `/api/agent-images` endpoints so a user can manage prebuilt agent base images without dropping to the host shell.

Base images are the `taos-<framework>-base` / `taos-base` incus images that let a fresh deploy skip the ~60-90s cold setup run. Previously they could only be inspected or pruned with the incus CLI, which breaks the no-terminal-for-end-users principle.

## Where

Mounted alongside the existing Registry / Archived panels in `AgentsApp`, as a secondary surface (collapsed by default, labelled "advanced") -- it is deliberately kept out of the main deploy flow since most users never need it.

## Behaviour

- Lists each present base image: backing framework, architecture, human-readable size, build/import date, present state.
- Shows the **aggregate base-image disk usage** prominently (this matters on the Pi) plus a **prefetch-on-boot** toggle wired to `POST /api/agent-images/prefetch` (optimistic, reconciled from the response).
- Per-image actions: Import/refresh (`POST /import`) and Prune (`DELETE`) behind a confirm step whose copy explains pruning is safe -- base images are reproducible and a container's rootfs is copied at launch, so pruning never affects a running agent, only future cold deploys.
- Success/error surfaced inline; the list refreshes after every action.
- Degrades cleanly when the container runtime is unavailable (`incus_available: false`).
- `onClick` handlers only (no HTML form submit); all fetches use `credentials: "include"`.

## Tests

Pure logic (byte formatting, response -> row mapping) extracted into `baseImages.ts` with vitest cases in `baseImages.test.ts`, mirroring the existing `importBundle.ts` helper+test pattern.

- `vitest run src/apps/agents/baseImages.test.ts` -- 9 passed.
- `tsc -b` -- clean (no new type errors).

## Scope

Surgical: one import + two mount points in `AgentsApp.tsx`; two new helper/test files and one new panel component. No unrelated refactors. `package.json` / lockfiles untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an expandable **Base Images (advanced)** panel to the Agents area, displayed alongside the registry in applicable states.
  * Shows base image list details, total disk usage, and whether **prefetch on boot** is enabled.
  * Added per-image actions to **re-import** or **prune**, with loading/error/success feedback and automatic refresh.
* **Tests**
  * Added Vitest coverage for byte formatting and defensive parsing of base image API responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->