### PR TITLE
docs(agent-manual): note agent import + base images in Agents app

### DIFF
--- a/docs/agent-manual/04-apps.md
+++ b/docs/agent-manual/04-apps.md
@@ -5,7 +5,7 @@
 ## The apps (one line each)
 
 - **Messages**: the main chat. Talk to one agent (DM), several (group), or topic channels.
-- **Agents**: deploy, configure, start, stop agents. Pick framework and model here.
+- **Agents**: deploy or import agents (e.g. Hermes), configure, start, stop. Pick framework, model, and base images.
 - **Projects**: kanban boards and docs; agents can join a project's channel.
 - **Files**: browse agent workspaces, user workspace, shared folders. Upload and download.
 - **Store**: one-click install of community apps. Each app gets its own container and a safe port.
@@ -17,4 +17,4 @@
 - **Activity**: live feed of everything agents do (tool calls, model calls, errors).
 - **Decisions**: your inbox for agent approvals and questions.
 - **Observatory**: watch the agent fleet; pause or throttle work lanes.
-- Other bundled apps (Library, Channels, Secrets, Tasks, Import, Images, MCP, Guides and more); if you do not know one, describe it from its name as a guess and point to Guides.
+- Other bundled apps (Library, Channels, Secrets, Tasks, Images, MCP, Guides and more); if you do not know one, guess from its name and point to Guides.

--- a/docs/taos-agent-manual.md
+++ b/docs/taos-agent-manual.md
@@ -67,7 +67,7 @@ Old installs keep their old ports automatically. Users never need to change port
 ## The apps (one line each)
 
 - **Messages**: the main chat. Talk to one agent (DM), several (group), or topic channels.
-- **Agents**: deploy, configure, start, stop agents. Pick framework and model here.
+- **Agents**: deploy or import agents (e.g. Hermes), configure, start, stop. Pick framework, model, and base images.
 - **Projects**: kanban boards and docs; agents can join a project's channel.
 - **Files**: browse agent workspaces, user workspace, shared folders. Upload and download.
 - **Store**: one-click install of community apps. Each app gets its own container and a safe port.
@@ -79,7 +79,7 @@ Old installs keep their old ports automatically. Users never need to change port
 - **Activity**: live feed of everything agents do (tool calls, model calls, errors).
 - **Decisions**: your inbox for agent approvals and questions.
 - **Observatory**: watch the agent fleet; pause or throttle work lanes.
-- Other bundled apps (Library, Channels, Secrets, Tasks, Import, Images, MCP, Guides and more); if you do not know one, describe it from its name as a guess and point to Guides.
+- Other bundled apps (Library, Channels, Secrets, Tasks, Images, MCP, Guides and more); if you do not know one, guess from its name and point to Guides.
 ---
 
 # Chat


### PR DESCRIPTION
## What

The Agents app now deploys **or imports** agents (e.g. Hermes profile bundles, #147) and manages **base images** for fast deploys (#146). The agent manual's Agents line still described only deploy/configure/start/stop, so the agent could not tell users about importing an existing agent (the exact question a Discord user asked) or base-image management.

## Changes
- Agents line: `deploy or import agents (e.g. Hermes) ... Pick framework, model, and base images`.
- Removed the stale standalone `Import` entry from the bundled-apps catch-all; import folded into the Agents app, so listing it separately was misleading.
- Rebuilt `docs/taos-agent-manual.md`; compiled size 15979 chars, under the 16000 cap.

## Verification
- `pytest tests/test_agent_manual_compiled.py tests/test_agent_manual.py` -> 28 passed (size + source/compiled sync both green).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the app descriptions in the agent manuals.
  * The **Agents** entry now highlights deploying or importing agents and choosing a framework, model, and base image.
  * The **Other bundled apps** entry was reworded to make it clearer how to identify unfamiliar apps and where to find guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->