### PR TITLE
feat(desktop): agent layout-read API for screen-aware window management (#18)

### DIFF
--- a/desktop/src/hooks/use-desktop-command-stream.test.ts
+++ b/desktop/src/hooks/use-desktop-command-stream.test.ts
@@ -55,6 +55,25 @@ describe("useDesktopCommandStream", () => {
     expect(seen).toEqual([{ action: "arrange", preset: "tile-2" }]);
   });
 
+  it("reports the desktop layout for a layout command", async () => {
+    const layout = { screen: { width: 1920, height: 1080, ratio: 1.778 }, windows: [] };
+    const getLayout = vi.fn(() => layout);
+    (window as unknown as { taosDesktop?: unknown }).taosDesktop = { getLayout, run: vi.fn() };
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: true } as Response));
+    vi.stubGlobal("fetch", fetchMock);
+    renderHook(() => useDesktopCommandStream());
+    FakeEventSource.last!.push(JSON.stringify({ kind: "layout", payload: { request_id: "req-1" } }));
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(getLayout).toHaveBeenCalled();
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("/api/desktop/layout-result");
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      request_id: "req-1",
+      layout,
+    });
+    delete (window as unknown as { taosDesktop?: unknown }).taosDesktop;
+  });
+
   it("ignores malformed payloads without throwing", () => {
     renderHook(() => useDesktopCommandStream());
     expect(() => FakeEventSource.last!.push("not json")).not.toThrow();

--- a/desktop/src/hooks/use-desktop-command-stream.ts
+++ b/desktop/src/hooks/use-desktop-command-stream.ts
@@ -63,6 +63,33 @@ async function captureAndReport(requestId: string): Promise<void> {
   }
 }
 
+/**
+ * Read the live desktop layout (screen size + every window's bounds and state)
+ * and POST it back to resolve an agent layout request. This is the read half of
+ * the agent window-management API: the agent fetches the layout to decide
+ * placement, then drives windows via taos:window ops. getLayout is exposed by
+ * use-desktop-control on window.taosDesktop.
+ */
+async function reportLayout(requestId: string): Promise<void> {
+  let body: { request_id: string; layout?: unknown; error?: string };
+  try {
+    const layout = window.taosDesktop?.getLayout();
+    if (!layout) throw new Error("desktop control not ready");
+    body = { request_id: requestId, layout };
+  } catch (e) {
+    body = { request_id: requestId, error: e instanceof Error ? e.message : "layout read failed" };
+  }
+  try {
+    await fetch("/api/desktop/layout-result", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  } catch {
+    /* the agent side will time out and report it */
+  }
+}
+
 export function useDesktopCommandStream(): void {
   useEffect(() => {
     const es = new EventSource("/api/desktop/stream");
@@ -83,6 +110,9 @@ export function useDesktopCommandStream(): void {
       } else if (cmd.kind === "screenshot") {
         const requestId = (cmd.payload?.request_id as string) ?? "";
         if (requestId) void captureAndReport(requestId);
+      } else if (cmd.kind === "layout") {
+        const requestId = (cmd.payload?.request_id as string) ?? "";
+        if (requestId) void reportLayout(requestId);
       }
     };
     es.onerror = () => {

--- a/tests/test_desktop_control.py
+++ b/tests/test_desktop_control.py
@@ -161,3 +161,63 @@ async def test_stream_receives_emitted_command():
     evt = json.loads(lines[0][5:].strip())
     assert evt["kind"] == "open-app"
     assert evt["payload"]["app"] == "projects"
+
+
+# --------------------------------------------------------------------------- #
+# Layout read round-trip (screen-aware window-management API)                  #
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_layout_no_desktop_returns_409():
+    app = _make_app()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post("/api/desktop/layout")
+        assert r.status_code == 409
+        assert r.json()["error"] == "no desktop connected"
+
+
+@pytest.mark.asyncio
+async def test_layout_result_resolves_pending_request():
+    """The layout endpoint emits a `layout` command and returns whatever the
+    desktop reports to /api/desktop/layout-result for that request_id."""
+    app = _make_app()
+    broker = app.state.desktop_command_broker
+    # A connected desktop: subscribe so the layout command is delivered.
+    q = await broker.subscribe("system")
+    sample = {"screen": {"width": 1920, "height": 1080, "ratio": 1.778}, "windows": []}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        async def respond():
+            cmd = await asyncio.wait_for(q.get(), timeout=2.0)
+            assert cmd.kind == "layout"
+            rid = cmd.payload["request_id"]
+            r = await c.post(
+                "/api/desktop/layout-result",
+                json={"request_id": rid, "layout": sample},
+            )
+            assert r.json()["resolved"] is True
+
+        responder = asyncio.create_task(respond())
+        r = await c.post("/api/desktop/layout")
+        await responder
+    assert r.status_code == 200
+    assert r.json() == sample
+
+
+@pytest.mark.asyncio
+async def test_layout_result_error_propagates_502():
+    app = _make_app()
+    broker = app.state.desktop_command_broker
+    q = await broker.subscribe("system")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        async def respond():
+            cmd = await asyncio.wait_for(q.get(), timeout=2.0)
+            rid = cmd.payload["request_id"]
+            await c.post(
+                "/api/desktop/layout-result",
+                json={"request_id": rid, "error": "layout read failed"},
+            )
+
+        responder = asyncio.create_task(respond())
+        r = await c.post("/api/desktop/layout")
+        await responder
+    assert r.status_code == 502
+    assert r.json()["error"] == "layout read failed"

--- a/tests/test_desktop_tools.py
+++ b/tests/test_desktop_tools.py
@@ -79,3 +79,32 @@ async def test_refuses_when_no_authenticated_user():
     assert "error" in res
     with pytest.raises(asyncio.TimeoutError):
         await asyncio.wait_for(sub.get(), timeout=0.1)
+
+
+@pytest.mark.asyncio
+async def test_read_layout_no_desktop_returns_error():
+    from tinyagentos.tools.desktop_tools import execute_read_layout
+    broker = DesktopCommandBroker()
+    res = await execute_read_layout({}, _fake_request(broker))
+    assert res.get("error") == "no desktop connected"
+
+
+@pytest.mark.asyncio
+async def test_read_layout_round_trips_desktop_report():
+    import asyncio
+    from tinyagentos.tools.desktop_tools import execute_read_layout
+    broker = DesktopCommandBroker()
+    req = _fake_request(broker)
+    user_id = req.state.user_id
+    q = await broker.subscribe(user_id)
+    sample = {"screen": {"width": 1440, "height": 900, "ratio": 1.6}, "windows": []}
+
+    async def respond():
+        cmd = await asyncio.wait_for(q.get(), timeout=2.0)
+        assert cmd.kind == "layout"
+        broker.resolve_result(cmd.payload["request_id"], {"layout": sample}, user_id=user_id)
+
+    responder = asyncio.create_task(respond())
+    res = await execute_read_layout({}, req)
+    await responder
+    assert res == {"ok": True, "layout": sample}

--- a/tinyagentos/routes/desktop_control.py
+++ b/tinyagentos/routes/desktop_control.py
@@ -66,6 +66,13 @@ class ScreenshotResultIn(BaseModel):
     error: str = ""
 
 
+class LayoutResultIn(BaseModel):
+    request_id: str
+    # The desktop's window.taosDesktop.getLayout() result: {screen, windows}.
+    layout: dict[str, Any] = Field(default_factory=dict)
+    error: str = ""
+
+
 @router.post("/api/desktop/screenshot")
 async def take_screenshot(request: Request):
     """Capture the calling user's live desktop and return a PNG.
@@ -122,6 +129,57 @@ async def screenshot_result(body: ScreenshotResultIn, request: Request):
         return JSONResponse({"error": "screenshot too large"}, status_code=413)
     broker = request.app.state.desktop_command_broker
     payload = {"error": body.error} if body.error else {"image": body.image}
+    resolved = broker.resolve_result(
+        body.request_id, payload, user_id=_user_id(request),
+    )
+    return {"resolved": resolved}
+
+
+@router.post("/api/desktop/layout")
+async def get_layout(request: Request):
+    """Read the calling user's live desktop layout: screen size + every window's
+    bounds and state. This is the "screen-aware" read half of the agent window-
+    management API -- the agent fetches the layout to decide placement, then
+    drives windows via POST /api/desktop/command kind="window" (move/resize/snap/
+    arrange). Mirrors the screenshot round-trip: emit a `layout` command, the
+    first desktop to answer POSTs its getLayout() to /api/desktop/layout-result.
+    409 if no desktop is connected, 504 if none responds in time.
+    """
+    broker = request.app.state.desktop_command_broker
+    user_id = _user_id(request)
+    request_id = uuid.uuid4().hex
+    fut = broker.register_result(request_id, user_id)
+    try:
+        delivered = await broker.emit(
+            user_id,
+            DesktopCommand(kind="layout", payload={"request_id": request_id}),
+        )
+        if delivered == 0:
+            return JSONResponse({"error": "no desktop connected"}, status_code=409)
+        try:
+            result = await asyncio.wait_for(fut, timeout=10.0)
+        except asyncio.TimeoutError:
+            return JSONResponse(
+                {"error": "desktop did not respond in time"}, status_code=504,
+            )
+    finally:
+        broker.discard_result(request_id)
+
+    if isinstance(result, dict) and result.get("error"):
+        return JSONResponse({"error": result["error"]}, status_code=502)
+    layout = result.get("layout", {}) if isinstance(result, dict) else {}
+    return JSONResponse(layout)
+
+
+@router.post("/api/desktop/layout-result")
+async def layout_result(body: LayoutResultIn, request: Request):
+    """A desktop reports its getLayout() result, resolving the waiting request.
+
+    Scoped like the screenshot result: only this user's desktops receive the
+    layout command (which carries the request_id), and resolve_result re-checks
+    the calling user owns the request before resolving."""
+    broker = request.app.state.desktop_command_broker
+    payload = {"error": body.error} if body.error else {"layout": body.layout}
     resolved = broker.resolve_result(
         body.request_id, payload, user_id=_user_id(request),
     )

--- a/tinyagentos/routes/skill_exec.py
+++ b/tinyagentos/routes/skill_exec.py
@@ -195,6 +195,16 @@ async def _skill_arrange_windows(args: dict, request: Request) -> dict:
         return {"error": str(exc)}
 
 
+async def _skill_read_layout(args: dict, request: Request) -> dict:
+    """Read the user's desktop layout: screen + window bounds (agent OS control)."""
+    try:
+        from tinyagentos.tools.desktop_tools import execute_read_layout
+
+        return await execute_read_layout(args, request)
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
 async def _skill_create_project(args: dict, request: Request) -> dict:
     """Create a project the user can see."""
     try:
@@ -256,6 +266,7 @@ SKILL_IMPLEMENTATIONS = {
     "list_image_models": _skill_list_image_models,
     "open_app": _skill_open_app,
     "arrange_windows": _skill_arrange_windows,
+    "read_layout": _skill_read_layout,
     "create_project": _skill_create_project,
     "add_task": _skill_add_task,
     "canvas_add_image": _skill_canvas_add_image,

--- a/tinyagentos/skills.py
+++ b/tinyagentos/skills.py
@@ -264,6 +264,24 @@ class SkillStore(BaseStore):
                 "install_target": "tinyagentos.tools.desktop_tools",
             },
             {
+                "id": "read_layout",
+                "name": "Read Desktop Layout",
+                "category": "desktop",
+                "description": "Read the user's screen size and open-window bounds (screen-aware control)",
+                "tool_schema": {
+                    "name": "read_layout",
+                    "description": "Read the desktop layout: screen size + every open window's bounds and state.",
+                    "input_schema": {"type": "object", "properties": {}},
+                },
+                "frameworks": {
+                    "smolagents": "adapter", "openclaw": "adapter", "pocketflow": "adapter",
+                    "langroid": "adapter", "hermes": "adapter", "agent-zero": "adapter",
+                    "openai-agents-sdk": "adapter", "generic": "adapter",
+                },
+                "install_method": "builtin",
+                "install_target": "tinyagentos.tools.desktop_tools",
+            },
+            {
                 "id": "arrange_windows",
                 "name": "Arrange Windows",
                 "category": "desktop",

--- a/tinyagentos/tools/desktop_tools.py
+++ b/tinyagentos/tools/desktop_tools.py
@@ -47,6 +47,17 @@ OPEN_APP_TOOL = {
     },
 }
 
+READ_LAYOUT_TOOL = {
+    "name": "read_layout",
+    "description": (
+        "Read the user's current desktop layout: the screen size and every open "
+        "window's position, size, and state (minimized/maximized/snapped/focused). "
+        "Use this to be screen-aware before arranging or moving windows, e.g. to "
+        "see which apps are open and where, then place a new window in free space."
+    ),
+    "input_schema": {"type": "object", "properties": {}},
+}
+
 ARRANGE_WINDOWS_TOOL = {
     "name": "arrange_windows",
     "description": (
@@ -104,3 +115,35 @@ async def execute_arrange_windows(args: dict, request: Request) -> dict:
         DesktopCommand(kind="window", payload={"action": "arrange", "preset": preset}),
     )
     return {"ok": True, "preset": preset, "delivered": delivered}
+
+
+async def execute_read_layout(args: dict, request: Request) -> dict:
+    """Round-trip the user's desktop layout: emit a `layout` command and wait for
+    the desktop to report back its getLayout() (screen + window bounds). This is
+    the screen-aware READ half of the window-management API; arrange/move/etc are
+    the drive half. Returns {"error": ...} if no desktop is connected or it does
+    not answer in time, so the agent can fall back gracefully."""
+    import asyncio
+    import uuid
+
+    user_id = _user_id(request)
+    if not user_id:
+        return {"error": "no authenticated user desktop to read"}
+    broker = request.app.state.desktop_command_broker
+    request_id = uuid.uuid4().hex
+    fut = broker.register_result(request_id, user_id)
+    try:
+        delivered = await broker.emit(
+            user_id, DesktopCommand(kind="layout", payload={"request_id": request_id})
+        )
+        if delivered == 0:
+            return {"error": "no desktop connected"}
+        try:
+            result = await asyncio.wait_for(fut, timeout=10.0)
+        except asyncio.TimeoutError:
+            return {"error": "desktop did not respond in time"}
+    finally:
+        broker.discard_result(request_id)
+    if isinstance(result, dict) and result.get("error"):
+        return {"error": result["error"]}
+    return {"ok": True, "layout": result.get("layout", {}) if isinstance(result, dict) else {}}


### PR DESCRIPTION
## What
Completes #18 (agent desktop window-management, screen-aware). The agent could already DRIVE windows (open/move/resize/snap/arrange, via `taos:window` over the command broker) and `window.taosDesktop.getLayout()` already returns screen size + every window's bounds and state, but there was NO way for the agent to READ that layout over the API. So screen-aware placement (see what's open + where, then put a new window in free space) was impossible. This adds the read half.

## Changes
- `POST /api/desktop/layout` emits a `layout` command and waits for the desktop to report back (mirrors the existing screenshot round-trip on the same per-user broker). `POST /api/desktop/layout-result` resolves it, user-scoped. 409 no desktop, 504 timeout, 502 client error.
- Desktop `use-desktop-command-stream` answers a `layout` command by calling `getLayout()` and POSTing the result back.
- New `read_layout` agent tool (`execute_read_layout`) + skill registration + skill_exec dispatch, so the agent reads layout before arranging/placing.

## Surgical
Additive only (268 insertions, 0 deletions); reuses the broker's existing generic request/result machinery. No existing behaviour changed.

## Verification
- `pytest tests/test_desktop_control.py tests/test_desktop_tools.py` -> 21 passed (incl. 409 / round-trip / 502-error-propagation / tool round-trip).
- `pytest tests/test_skills.py tests/test_routes_skill_exec.py tests/test_skill_runtime.py` -> green (skill registration intact).
- Full desktop vitest suite -> 2178 passed (added a layout-dispatch test to use-desktop-command-stream.test.ts).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Read Desktop Layout” capability that lets the app request and receive the current desktop layout.
  * Desktop layout requests now return the live layout data when available.
* **Bug Fixes**
  * Added clearer handling for cases where no desktop is connected, layout requests time out, or the desktop reports an error.
  * Improved reliability of layout reporting and response matching during desktop communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->