### PR TITLE
feat(agents): request_decision tool so agents can use the Decisions inbox (#104)

### DIFF
--- a/tests/test_decision_tools.py
+++ b/tests/test_decision_tools.py
@@ -1,0 +1,95 @@
+"""Tests for the request_decision agent tool (human-in-the-loop inbox)."""
+import types
+
+import pytest
+import pytest_asyncio
+
+from tinyagentos.decisions.decision_store import DecisionStore
+from tinyagentos.tools.decision_tools import execute_request_decision, _normalize_options
+
+
+@pytest_asyncio.fixture
+async def app_request(tmp_path):
+    store = DecisionStore(tmp_path / "decisions.db")
+    await store.init()
+    app = types.SimpleNamespace(state=types.SimpleNamespace(decision_store=store, notifications=None))
+    req = types.SimpleNamespace(app=app, state=types.SimpleNamespace(user_id="user-1", is_admin=False))
+    yield req, store
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_creates_pending_decision(app_request):
+    req, store = app_request
+    res = await execute_request_decision(
+        {"question": "Pick a colour", "type": "single_select", "options": ["Red", "Blue"]}, req
+    )
+    assert res["ok"] is True
+    did = res["decision_id"]
+    assert res["status"] == "pending"
+    saved = await store.get(did)
+    assert saved["question"] == "Pick a colour"
+    assert saved["type"] == "single_select"
+    assert [o["label"] for o in saved["options"]] == ["Red", "Blue"]
+    assert saved["user_id"] == "user-1"
+    assert saved["from_agent"] == "@agent"
+
+
+@pytest.mark.asyncio
+async def test_from_agent_is_carried(app_request):
+    req, store = app_request
+    res = await execute_request_decision(
+        {"question": "Ship it?", "type": "approve_deny", "from_agent": "@builder"}, req
+    )
+    saved = await store.get(res["decision_id"])
+    assert saved["from_agent"] == "@builder"
+
+
+@pytest.mark.asyncio
+async def test_select_type_requires_options(app_request):
+    req, _ = app_request
+    res = await execute_request_decision({"question": "Which?", "type": "multi_select"}, req)
+    assert "error" in res and "options" in res["error"]
+
+
+@pytest.mark.asyncio
+async def test_rejects_unknown_type(app_request):
+    req, _ = app_request
+    res = await execute_request_decision({"question": "Q", "type": "rank"}, req)
+    assert "error" in res
+
+
+@pytest.mark.asyncio
+async def test_requires_question(app_request):
+    req, _ = app_request
+    res = await execute_request_decision({"type": "free_text"}, req)
+    assert "error" in res
+
+
+@pytest.mark.asyncio
+async def test_free_text_needs_no_options(app_request):
+    req, store = app_request
+    res = await execute_request_decision({"question": "Name it", "type": "free_text"}, req)
+    assert res["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_no_user_refuses(tmp_path):
+    store = DecisionStore(tmp_path / "d.db")
+    await store.init()
+    app = types.SimpleNamespace(state=types.SimpleNamespace(decision_store=store, notifications=None))
+    req = types.SimpleNamespace(app=app, state=types.SimpleNamespace(user_id=None))
+    res = await execute_request_decision({"question": "Q", "type": "free_text"}, req)
+    assert res["error"] == "no authenticated user to ask"
+    await store.close()
+
+
+def test_normalize_options_dedupes_colliding_labels():
+    out = _normalize_options(["Other", "Other", "Other"])
+    assert [o["value"] for o in out] == ["Other", "Other (2)", "Other (3)"]
+    assert [o["label"] for o in out] == ["Other", "Other", "Other"]
+
+
+def test_normalize_options_accepts_dicts():
+    out = _normalize_options([{"label": "Yes", "value": "y"}, {"label": "No", "value": "n"}])
+    assert out == [{"label": "Yes", "value": "y"}, {"label": "No", "value": "n"}]

--- a/tinyagentos/routes/skill_exec.py
+++ b/tinyagentos/routes/skill_exec.py
@@ -205,6 +205,16 @@ async def _skill_read_layout(args: dict, request: Request) -> dict:
         return {"error": str(exc)}
 
 
+async def _skill_request_decision(args: dict, request: Request) -> dict:
+    """Ask the user a question via the Decisions inbox (human-in-the-loop)."""
+    try:
+        from tinyagentos.tools.decision_tools import execute_request_decision
+
+        return await execute_request_decision(args, request)
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
 async def _skill_create_project(args: dict, request: Request) -> dict:
     """Create a project the user can see."""
     try:
@@ -267,6 +277,7 @@ SKILL_IMPLEMENTATIONS = {
     "open_app": _skill_open_app,
     "arrange_windows": _skill_arrange_windows,
     "read_layout": _skill_read_layout,
+    "request_decision": _skill_request_decision,
     "create_project": _skill_create_project,
     "add_task": _skill_add_task,
     "canvas_add_image": _skill_canvas_add_image,

--- a/tinyagentos/skills.py
+++ b/tinyagentos/skills.py
@@ -360,6 +360,35 @@ class SkillStore(BaseStore):
                 "install_target": "tinyagentos.tools.project_tools",
             },
             {
+                "id": "request_decision",
+                "name": "Request Decision",
+                "category": "agent",
+                "description": "Ask the user a question via the Decisions inbox (human-in-the-loop)",
+                "tool_schema": {
+                    "name": "request_decision",
+                    "description": "Ask the user a question (single_select/multi_select need options; approve_deny; free_text) that queues in their Decisions inbox until answered. Returns a decision_id; the answer arrives later.",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {
+                            "question": {"type": "string", "description": "The question to ask."},
+                            "type": {"type": "string", "enum": ["single_select", "multi_select", "approve_deny", "free_text"], "description": "Decision type."},
+                            "options": {"type": "array", "items": {"type": "string"}, "description": "Choices (required for select types)."},
+                            "context": {"type": "string", "description": "Optional background to help the user decide."},
+                            "priority": {"type": "string", "enum": ["normal", "blocking"], "description": "'blocking' only if you cannot proceed without it."},
+                            "from_agent": {"type": "string", "description": "Your agent name, shown as the asker."},
+                        },
+                        "required": ["question", "type"],
+                    },
+                },
+                "frameworks": {
+                    "smolagents": "adapter", "openclaw": "adapter", "pocketflow": "adapter",
+                    "langroid": "adapter", "hermes": "adapter", "agent-zero": "adapter",
+                    "openai-agents-sdk": "adapter", "generic": "adapter",
+                },
+                "install_method": "builtin",
+                "install_target": "tinyagentos.tools.decision_tools",
+            },
+            {
                 "id": "canvas_add_image",
                 "name": "Add Image to Canvas",
                 "category": "projects",

--- a/tinyagentos/tools/decision_tools.py
+++ b/tinyagentos/tools/decision_tools.py
@@ -1,0 +1,130 @@
+"""Agent tool for the human-in-the-loop Decisions inbox.
+
+Lets an agent ask the user a question (single/multi select, approve/deny, or free
+text) that queues in the Decisions app until answered, so the agent can stop
+guessing and hand a real choice to the user. This is the programmatic counterpart
+to the Decisions app: it calls the same DecisionStore the REST route uses, so the
+card appears live in the inbox and fires the same notification.
+
+Answering is asynchronous (the user replies later in the app); this tool only
+RAISES the decision and returns its id so the agent can poll or move on.
+"""
+from __future__ import annotations
+
+from fastapi import Request
+
+from tinyagentos.decisions.decision_store import DECISION_TYPES, PRIORITIES
+
+REQUEST_DECISION_TOOL = {
+    "name": "request_decision",
+    "description": (
+        "Ask the user a question that queues in their Decisions inbox until they "
+        "answer, instead of guessing. Use for a real choice you cannot resolve "
+        "yourself: 'single_select' / 'multi_select' need an options list; "
+        "'approve_deny' is a yes/no; 'free_text' is an open answer. Set priority "
+        "'blocking' only when you genuinely cannot proceed without the answer. "
+        "Returns a decision_id; the answer arrives later, so poll or move on."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "question": {"type": "string", "description": "The question to ask the user."},
+            "type": {
+                "type": "string",
+                "enum": list(DECISION_TYPES),
+                "description": "single_select, multi_select, approve_deny, or free_text.",
+            },
+            "options": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Choices (required for single_select / multi_select).",
+            },
+            "context": {"type": "string", "description": "Optional background to help the user decide."},
+            "priority": {
+                "type": "string",
+                "enum": list(PRIORITIES),
+                "description": "'normal' (default) or 'blocking' (you cannot proceed without it).",
+            },
+            "from_agent": {"type": "string", "description": "Your agent name, shown as the asker."},
+        },
+        "required": ["question", "type"],
+    },
+}
+
+
+def _user_id(request: Request) -> str | None:
+    return getattr(request.state, "user_id", None) or None
+
+
+def _normalize_options(raw) -> list[dict]:
+    """Coerce options to [{label, value}] with distinct values. Accepts a list of
+    strings or of {label, value} dicts; value defaults to the label, and a later
+    collision is suffixed so the inbox (which keys on value) keeps each distinct,
+    mirroring the create_decision route's dedupe."""
+    out: list[dict] = []
+    seen: set[str] = set()
+    for item in raw or []:
+        if isinstance(item, dict):
+            label = str(item.get("label", item.get("value", "")))
+            base = str(item.get("value", label) or label)
+        else:
+            label = str(item)
+            base = label
+        value = base
+        n = 2
+        while value in seen:
+            value = f"{base} ({n})"
+            n += 1
+        seen.add(value)
+        out.append({"label": label, "value": value})
+    return out
+
+
+async def execute_request_decision(args: dict, request: Request) -> dict:
+    args = args or {}
+    question = args.get("question")
+    dtype = args.get("type")
+    if not isinstance(question, str) or not question.strip():
+        return {"error": "request_decision requires a 'question' string"}
+    if dtype not in DECISION_TYPES:
+        return {"error": f"type must be one of {DECISION_TYPES}"}
+    priority = args.get("priority", "normal")
+    if priority not in PRIORITIES:
+        return {"error": f"priority must be one of {PRIORITIES}"}
+    options = _normalize_options(args.get("options"))
+    if dtype in ("single_select", "multi_select") and not options:
+        return {"error": "select types require a non-empty 'options' list"}
+    user_id = _user_id(request)
+    if not user_id:
+        return {"error": "no authenticated user to ask"}
+
+    from_agent = args.get("from_agent")
+    if not isinstance(from_agent, str) or not from_agent.strip():
+        from_agent = "@agent"
+
+    store = request.app.state.decision_store
+    decision = await store.create(
+        from_agent=from_agent,
+        question=question,
+        type=dtype,
+        options=options,
+        context=str(args.get("context", "")),
+        priority=priority,
+        user_id=user_id,
+    )
+
+    # Best effort: surface it in the notification bell like the REST route does;
+    # a notification failure must not fail the queued decision.
+    notifs = getattr(request.app.state, "notifications", None)
+    if notifs is not None:
+        try:
+            await notifs.add(
+                title="Decision needed",
+                message=f"{from_agent} needs a decision: {question[:120]}",
+                level="warning" if priority == "blocking" else "info",
+                source="decisions",
+            )
+        except Exception:
+            pass
+
+    return {"ok": True, "decision_id": decision["id"], "status": decision["status"]}


### PR DESCRIPTION
## What
Agent-native coverage (#104) for the Decisions surface. The Decisions app (human-in-the-loop inbox) is fed by agent-created decisions, but there was no first-class agent **tool** to raise one, only the raw `POST /api/decisions` route. This adds a `request_decision` skill/tool so any framework agent (smolagents, hermes, openclaw, etc.) can ask the user a real question instead of guessing.

## Changes
- `tinyagentos/tools/decision_tools.py` (new): `execute_request_decision` calls the same `DecisionStore` the REST route uses, so the card streams live into the inbox and fires the same 'Decision needed' notification. Validates type/priority, requires options for select types, normalizes options to `{label,value}` with the same collision-suffix dedupe as the route, defaults `from_agent` to `@agent`. Returns `decision_id` (answering is asynchronous, in the app).
- Skill registration (`skills.py`) + `skill_exec` dispatch wiring.

## Surgical
Additive only (265 insertions, 0 deletions); reuses the existing store + notification path. No existing behaviour changed. Same shape as the desktop `read_layout` tool (#18).

## Verification
- `pytest tests/test_decision_tools.py` -> 9 passed (create / from_agent / select-requires-options / unknown-type / requires-question / free-text / no-user / option dedupe).
- `pytest tests/test_skills.py tests/test_routes_skill_exec.py` -> green (registry + dispatch intact).
- ruff clean on changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “request decision” workflow for sending questions to the Decisions inbox.
  * Decision requests can include a question, type, options, context, priority, and source agent.
  * The decision view now supports clearer option handling, including duplicate label cleanup.

* **Bug Fixes**
  * Added validation for missing required fields and unsupported decision types.
  * Improved behavior when no authenticated user is available.
  * Notification updates no longer block decision creation if they fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->