### PR TITLE
feat(agents): notify_user tool for async heads-up notifications (#104)

### DIFF
--- a/tests/test_notify_tools.py
+++ b/tests/test_notify_tools.py
@@ -1,0 +1,74 @@
+"""Tests for the notify_user agent tool."""
+import types
+
+import pytest
+
+from tinyagentos.tools.notify_tools import execute_notify_user
+
+
+class FakeNotifications:
+    def __init__(self):
+        self.added = []
+
+    async def add(self, *, title, message, level="info", source="system"):
+        self.added.append({"title": title, "message": message, "level": level, "source": source})
+
+
+def _request(notifs):
+    app = types.SimpleNamespace(state=types.SimpleNamespace(notifications=notifs))
+    return types.SimpleNamespace(app=app, state=types.SimpleNamespace(user_id="user-1"))
+
+
+@pytest.mark.asyncio
+async def test_sends_notification():
+    notifs = FakeNotifications()
+    res = await execute_notify_user({"message": "Build finished"}, _request(notifs))
+    assert res["ok"] is True
+    assert len(notifs.added) == 1
+    n = notifs.added[0]
+    assert n["message"] == "Build finished"
+    assert n["title"] == "Agent update"
+    assert n["level"] == "info"
+    assert n["source"] == "agent"
+
+
+@pytest.mark.asyncio
+async def test_custom_title_and_level():
+    notifs = FakeNotifications()
+    res = await execute_notify_user(
+        {"message": "Disk almost full", "title": "Warning", "level": "warning"}, _request(notifs)
+    )
+    assert res["title"] == "Warning" and res["level"] == "warning"
+    assert notifs.added[0]["level"] == "warning"
+
+
+@pytest.mark.asyncio
+async def test_invalid_level_falls_back_to_info():
+    notifs = FakeNotifications()
+    await execute_notify_user({"message": "x", "level": "critical"}, _request(notifs))
+    assert notifs.added[0]["level"] == "info"
+
+
+@pytest.mark.asyncio
+async def test_requires_message():
+    notifs = FakeNotifications()
+    res = await execute_notify_user({"title": "no body"}, _request(notifs))
+    assert "error" in res
+    assert notifs.added == []
+
+
+@pytest.mark.asyncio
+async def test_blank_title_defaults():
+    notifs = FakeNotifications()
+    await execute_notify_user({"message": "hi", "title": "   "}, _request(notifs))
+    assert notifs.added[0]["title"] == "Agent update"
+
+
+@pytest.mark.asyncio
+async def test_missing_notifications_store_errors():
+    req = types.SimpleNamespace(
+        app=types.SimpleNamespace(state=types.SimpleNamespace(notifications=None)),
+        state=types.SimpleNamespace(user_id="user-1"),
+    )
+    res = await execute_notify_user({"message": "x"}, req)
+    assert res["error"] == "notifications are not available"

--- a/tinyagentos/routes/skill_exec.py
+++ b/tinyagentos/routes/skill_exec.py
@@ -215,6 +215,16 @@ async def _skill_request_decision(args: dict, request: Request) -> dict:
         return {"error": str(exc)}
 
 
+async def _skill_notify_user(args: dict, request: Request) -> dict:
+    """Send the user a notification in their bell (async heads-up)."""
+    try:
+        from tinyagentos.tools.notify_tools import execute_notify_user
+
+        return await execute_notify_user(args, request)
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
 async def _skill_create_project(args: dict, request: Request) -> dict:
     """Create a project the user can see."""
     try:
@@ -278,6 +288,7 @@ SKILL_IMPLEMENTATIONS = {
     "arrange_windows": _skill_arrange_windows,
     "read_layout": _skill_read_layout,
     "request_decision": _skill_request_decision,
+    "notify_user": _skill_notify_user,
     "create_project": _skill_create_project,
     "add_task": _skill_add_task,
     "canvas_add_image": _skill_canvas_add_image,

--- a/tinyagentos/skills.py
+++ b/tinyagentos/skills.py
@@ -389,6 +389,32 @@ class SkillStore(BaseStore):
                 "install_target": "tinyagentos.tools.decision_tools",
             },
             {
+                "id": "notify_user",
+                "name": "Notify User",
+                "category": "agent",
+                "description": "Send the user a short notification in their bell (async heads-up)",
+                "tool_schema": {
+                    "name": "notify_user",
+                    "description": "Send the user a brief notification that appears in their bell, for an async heads-up they should see even when not in your chat. For a question that needs an answer, use request_decision instead.",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {
+                            "message": {"type": "string", "description": "The notification body (keep it short)."},
+                            "title": {"type": "string", "description": "Optional short title; defaults to 'Agent update'."},
+                            "level": {"type": "string", "enum": ["info", "success", "warning", "error"], "description": "Severity (default info)."},
+                        },
+                        "required": ["message"],
+                    },
+                },
+                "frameworks": {
+                    "smolagents": "adapter", "openclaw": "adapter", "pocketflow": "adapter",
+                    "langroid": "adapter", "hermes": "adapter", "agent-zero": "adapter",
+                    "openai-agents-sdk": "adapter", "generic": "adapter",
+                },
+                "install_method": "builtin",
+                "install_target": "tinyagentos.tools.notify_tools",
+            },
+            {
                 "id": "canvas_add_image",
                 "name": "Add Image to Canvas",
                 "category": "projects",

--- a/tinyagentos/tools/notify_tools.py
+++ b/tinyagentos/tools/notify_tools.py
@@ -1,0 +1,59 @@
+"""Agent tool for sending the user a notification.
+
+Lets an agent surface a short, asynchronous heads-up in the user's notification
+bell (e.g. "your build finished", "I hit a snag and paused"), even when the user
+is not looking at the agent's chat. This is the FYI counterpart to
+request_decision: notify_user informs and needs no answer; request_decision asks
+and waits for one. It calls the same NotificationStore the rest of the OS uses,
+so the message lands in the bell with the existing read/archive behaviour.
+"""
+from __future__ import annotations
+
+from fastapi import Request
+
+# The bell renders these severities; anything else falls back to "info" so a
+# stray level can never break rendering.
+VALID_LEVELS = frozenset({"info", "success", "warning", "error"})
+
+NOTIFY_USER_TOOL = {
+    "name": "notify_user",
+    "description": (
+        "Send the user a short notification that appears in their notification "
+        "bell, for an asynchronous heads-up they should see even when not in your "
+        "chat (a finished long task, a blocker you paused on, a result worth "
+        "surfacing). For a question that needs an answer, use request_decision "
+        "instead. Keep it brief; this is a glanceable alert, not a conversation."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "message": {"type": "string", "description": "The notification body (keep it short)."},
+            "title": {"type": "string", "description": "Optional short title; defaults to 'Agent update'."},
+            "level": {
+                "type": "string",
+                "enum": sorted(VALID_LEVELS),
+                "description": "Severity: info (default), success, warning, or error.",
+            },
+        },
+        "required": ["message"],
+    },
+}
+
+
+async def execute_notify_user(args: dict, request: Request) -> dict:
+    args = args or {}
+    message = args.get("message")
+    if not isinstance(message, str) or not message.strip():
+        return {"error": "notify_user requires a 'message' string"}
+    title = args.get("title")
+    if not isinstance(title, str) or not title.strip():
+        title = "Agent update"
+    level = args.get("level", "info")
+    if level not in VALID_LEVELS:
+        level = "info"
+
+    notifs = getattr(request.app.state, "notifications", None)
+    if notifs is None:
+        return {"error": "notifications are not available"}
+    await notifs.add(title=title, message=message, level=level, source="agent")
+    return {"ok": True, "title": title, "level": level}


### PR DESCRIPTION
## What
Agent-native coverage (#104), FYI counterpart to the `request_decision` tool. Agents could ask the user a question (request_decision) but could not proactively **inform** them: there was no agent tool to surface a short async heads-up in the notification bell (build finished, blocker hit, result worth seeing) when the user is not in the agent's chat.

## Changes
- `tinyagentos/tools/notify_tools.py` (new): `execute_notify_user` calls the same `NotificationStore` the rest of the OS uses (so it lands in the bell with existing read/archive behaviour). Validates the message, defaults title to 'Agent update', clamps level to the bell's set (info/success/warning/error; invalid falls back to info), `source=agent`.
- Skill registration + `skill_exec` dispatch wiring.

## Surgical
Additive only (170 insertions, 0 deletions); reuses the existing notifications path. No existing behaviour changed. Same shape as `read_layout` (#18) and `request_decision` (#1455).

## Verification
- `pytest tests/test_notify_tools.py` -> 6 passed (send / custom title+level / invalid-level fallback / requires-message / blank-title default / missing-store error).
- `pytest tests/test_skills.py tests/test_routes_skill_exec.py` -> green.
- ruff clean on changed files.