### PR TITLE
feat(agents): list_projects tool so agents can pick a project (#104)

### DIFF
--- a/tests/test_project_tools.py
+++ b/tests/test_project_tools.py
@@ -4,6 +4,7 @@ import pytest
 
 from tinyagentos.tools.project_tools import (
     execute_create_project,
+    execute_list_projects,
     execute_add_task,
     execute_canvas_add_image,
     _slugify,
@@ -23,6 +24,18 @@ class _FakeProjectStore:
         if project_id == "missing":
             return None
         return {"id": project_id, "user_id": self._owner, "slug": "luna"}
+
+    async def list_for_user(self, user_id, status="active"):
+        self.calls.append({"list_for_user": user_id, "status": status})
+        if not user_id:
+            return []
+        rows = [
+            {"id": "proj_1", "name": "Active One", "status": "active"},
+            {"id": "proj_2", "name": "Archived One", "status": "archived"},
+        ]
+        if status is None:
+            return rows
+        return [r for r in rows if r["status"] == status]
 
 
 class _FakeTaskStore:
@@ -210,3 +223,32 @@ async def test_export_storybook_rejects_other_users_project(tmp_path):
         {"project_id": "proj_1", "title": "X", "pages": [{"text": "hi"}]}, req
     )
     assert res.get("error") == "not your project"
+
+
+@pytest.mark.asyncio
+async def test_list_projects_active_default():
+    req = _req()
+    res = await execute_list_projects({}, req)
+    assert res["ok"] is True
+    assert res["count"] == 1
+    assert res["projects"] == [{"project_id": "proj_1", "name": "Active One", "status": "active"}]
+
+
+@pytest.mark.asyncio
+async def test_list_projects_all():
+    req = _req()
+    res = await execute_list_projects({"status": "all"}, req)
+    assert res["count"] == 2
+    assert {p["project_id"] for p in res["projects"]} == {"proj_1", "proj_2"}
+
+
+@pytest.mark.asyncio
+async def test_list_projects_rejects_bad_status():
+    res = await execute_list_projects({"status": "bogus"}, _req())
+    assert "error" in res
+
+
+@pytest.mark.asyncio
+async def test_list_projects_requires_user():
+    res = await execute_list_projects({}, _req(user_id=None))
+    assert res["error"] == "no authenticated user"

--- a/tinyagentos/routes/skill_exec.py
+++ b/tinyagentos/routes/skill_exec.py
@@ -225,6 +225,16 @@ async def _skill_notify_user(args: dict, request: Request) -> dict:
         return {"error": str(exc)}
 
 
+async def _skill_list_projects(args: dict, request: Request) -> dict:
+    """List the user's projects so the agent can pick one."""
+    try:
+        from tinyagentos.tools.project_tools import execute_list_projects
+
+        return await execute_list_projects(args, request)
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
 async def _skill_create_project(args: dict, request: Request) -> dict:
     """Create a project the user can see."""
     try:
@@ -290,6 +300,7 @@ SKILL_IMPLEMENTATIONS = {
     "request_decision": _skill_request_decision,
     "notify_user": _skill_notify_user,
     "create_project": _skill_create_project,
+    "list_projects": _skill_list_projects,
     "add_task": _skill_add_task,
     "canvas_add_image": _skill_canvas_add_image,
     "describe_image_capabilities": _skill_describe_image_capabilities,

--- a/tinyagentos/skills.py
+++ b/tinyagentos/skills.py
@@ -335,6 +335,29 @@ class SkillStore(BaseStore):
                 "install_target": "tinyagentos.tools.project_tools",
             },
             {
+                "id": "list_projects",
+                "name": "List Projects",
+                "category": "projects",
+                "description": "List the user's projects so the agent can pick one",
+                "tool_schema": {
+                    "name": "list_projects",
+                    "description": "List the user's projects (id, name, status) so you can pick the right project_id before adding tasks or images. Optional status filter: active (default), archived, all.",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {
+                            "status": {"type": "string", "enum": ["active", "archived", "all"], "description": "Which projects to list (default active)."},
+                        },
+                    },
+                },
+                "frameworks": {
+                    "smolagents": "adapter", "openclaw": "adapter", "pocketflow": "adapter",
+                    "langroid": "adapter", "hermes": "adapter", "agent-zero": "adapter",
+                    "openai-agents-sdk": "adapter", "generic": "adapter",
+                },
+                "install_method": "builtin",
+                "install_target": "tinyagentos.tools.project_tools",
+            },
+            {
                 "id": "add_task",
                 "name": "Add Task",
                 "category": "projects",

--- a/tinyagentos/tools/project_tools.py
+++ b/tinyagentos/tools/project_tools.py
@@ -63,6 +63,24 @@ async def execute_create_project(args: dict, request: Request) -> dict:
     return {"ok": True, "project_id": project["id"], "name": project["name"]}
 
 
+async def execute_list_projects(args: dict, request: Request) -> dict:
+    """List the user's projects so the agent can pick one before adding tasks or
+    images, instead of guessing a project_id. Read-only; scoped to the caller."""
+    user_id = _user_id(request)
+    if not user_id:
+        return {"error": "no authenticated user"}
+    status = (args or {}).get("status", "active")
+    if status not in ("active", "archived", "all"):
+        return {"error": "status must be 'active', 'archived', or 'all'"}
+    store = request.app.state.project_store
+    rows = await store.list_for_user(user_id, status=None if status == "all" else status)
+    projects = [
+        {"project_id": p.get("id"), "name": p.get("name"), "status": p.get("status")}
+        for p in rows
+    ]
+    return {"ok": True, "projects": projects, "count": len(projects)}
+
+
 async def execute_add_task(args: dict, request: Request) -> dict:
     project_id = (args or {}).get("project_id")
     title = (args or {}).get("title")


### PR DESCRIPTION
## What
Agent-native coverage (#104), read complement to `create_project` / `add_task` / `canvas_add_image`. Agents could create and write to projects but could not **list** the user's existing projects, so they had to remember a project_id or always create a new one. Adds a read-only `list_projects` tool.

## Changes
- `tinyagentos/tools/project_tools.py`: `execute_list_projects` returns the caller's projects (project_id, name, status) via the existing `project_store.list_for_user` (user-scoped), with an optional `status` filter (active default / archived / all).
- Skill registration + `skill_exec` dispatch wiring.

## Surgical
Additive only (94 insertions, 0 deletions); reuses the existing store method. No existing behaviour changed.

## Verification
- `pytest tests/test_project_tools.py` -> green incl. 4 new list_projects tests (active default / all / bad-status / no-user).
- `pytest tests/test_skills.py tests/test_routes_skill_exec.py` -> green.
- ruff clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “List Projects” capability so authenticated users can view their projects with optional status filtering.
  * Exposed the feature through the app’s built-in skill execution flow, making it available via the existing skill API.
  * Included the new capability in the default built-in skill set for easier discovery and use.

* **Bug Fixes**
  * Improved validation for project listing requests, including handling unauthenticated access and invalid status values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->