### PR TITLE
feat(agents): list_frameworks tool so the agent can offer to deploy one (#31)

### DIFF
--- a/tests/test_framework_tools.py
+++ b/tests/test_framework_tools.py
@@ -1,0 +1,36 @@
+"""Tests for the list_frameworks agent tool."""
+import types
+
+import pytest
+
+from tinyagentos.tools.framework_tools import execute_list_frameworks
+
+
+def _req():
+    return types.SimpleNamespace(
+        app=types.SimpleNamespace(state=types.SimpleNamespace()),
+        state=types.SimpleNamespace(user_id="user-1"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_lists_all_frameworks():
+    res = await execute_list_frameworks({}, _req())
+    assert res["ok"] is True
+    assert res["count"] >= 1
+    ids = {f["id"] for f in res["frameworks"]}
+    # The adapter registry ships at least openclaw and hermes.
+    assert "openclaw" in ids and "hermes" in ids
+    for f in res["frameworks"]:
+        assert set(f.keys()) == {"id", "name", "description", "verification_status"}
+
+
+@pytest.mark.asyncio
+async def test_verified_only_returns_beta_subset():
+    all_res = await execute_list_frameworks({}, _req())
+    beta_res = await execute_list_frameworks({"verified_only": True}, _req())
+    assert beta_res["count"] <= all_res["count"]
+    assert all(f["verification_status"] == "beta" for f in beta_res["frameworks"])
+    # hermes and openclaw are beta, so verified_only must include them.
+    ids = {f["id"] for f in beta_res["frameworks"]}
+    assert "openclaw" in ids and "hermes" in ids

--- a/tinyagentos/routes/skill_exec.py
+++ b/tinyagentos/routes/skill_exec.py
@@ -225,6 +225,16 @@ async def _skill_notify_user(args: dict, request: Request) -> dict:
         return {"error": str(exc)}
 
 
+async def _skill_list_frameworks(args: dict, request: Request) -> dict:
+    """List the agent frameworks taOS can deploy (so the agent can offer one)."""
+    try:
+        from tinyagentos.tools.framework_tools import execute_list_frameworks
+
+        return await execute_list_frameworks(args, request)
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
 async def _skill_list_projects(args: dict, request: Request) -> dict:
     """List the user's projects so the agent can pick one."""
     try:
@@ -299,6 +309,7 @@ SKILL_IMPLEMENTATIONS = {
     "read_layout": _skill_read_layout,
     "request_decision": _skill_request_decision,
     "notify_user": _skill_notify_user,
+    "list_frameworks": _skill_list_frameworks,
     "create_project": _skill_create_project,
     "list_projects": _skill_list_projects,
     "add_task": _skill_add_task,

--- a/tinyagentos/skills.py
+++ b/tinyagentos/skills.py
@@ -412,6 +412,29 @@ class SkillStore(BaseStore):
                 "install_target": "tinyagentos.tools.decision_tools",
             },
             {
+                "id": "list_frameworks",
+                "name": "List Agent Frameworks",
+                "category": "agent",
+                "description": "List the agent frameworks taOS can deploy, so the agent can offer one",
+                "tool_schema": {
+                    "name": "list_frameworks",
+                    "description": "List the agent frameworks taOS can deploy (id, name, description, verification_status; beta = recommended). Use before offering to deploy/set up an agent so you name a real framework and prefer a beta one. Optional verified_only=true returns beta only.",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {
+                            "verified_only": {"type": "boolean", "description": "Only beta (recommended) frameworks. Default false."},
+                        },
+                    },
+                },
+                "frameworks": {
+                    "smolagents": "adapter", "openclaw": "adapter", "pocketflow": "adapter",
+                    "langroid": "adapter", "hermes": "adapter", "agent-zero": "adapter",
+                    "openai-agents-sdk": "adapter", "generic": "adapter",
+                },
+                "install_method": "builtin",
+                "install_target": "tinyagentos.tools.framework_tools",
+            },
+            {
                 "id": "notify_user",
                 "name": "Notify User",
                 "category": "agent",

--- a/tinyagentos/tools/framework_tools.py
+++ b/tinyagentos/tools/framework_tools.py
@@ -1,0 +1,50 @@
+"""Agent tool for discovering the agent frameworks taOS can deploy.
+
+Gives the agent the knowledge to offer the user a concrete next step ("I can
+deploy a Hermes agent for you") instead of guessing what is available. Reads the
+adapter registry in-process (the same source /api/frameworks serves), so it
+stays in sync with what the Deploy Agent wizard shows. Read-only; the deploy
+itself stays a user-driven action in the Agents app.
+"""
+from __future__ import annotations
+
+from fastapi import Request
+
+from tinyagentos.adapters import list_frameworks
+
+LIST_FRAMEWORKS_TOOL = {
+    "name": "list_frameworks",
+    "description": (
+        "List the agent frameworks taOS can deploy (id, name, description, and "
+        "verification_status: beta is recommended, alpha is experimental). Use "
+        "this before offering to deploy or set up an agent for the user, so you "
+        "name a framework that actually exists and prefer a beta one. Read-only; "
+        "the user deploys from the Agents app."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "verified_only": {
+                "type": "boolean",
+                "description": "If true, return only beta (recommended) frameworks. Default false (all).",
+            },
+        },
+    },
+}
+
+
+async def execute_list_frameworks(args: dict, request: Request) -> dict:
+    verified_only = bool((args or {}).get("verified_only", False))
+    frameworks = list_frameworks()
+    if verified_only:
+        frameworks = [f for f in frameworks if f.get("verification_status") == "beta"]
+    slim = [
+        {
+            "id": f.get("id"),
+            "name": f.get("name"),
+            "description": f.get("description"),
+            "verification_status": f.get("verification_status"),
+        }
+        for f in frameworks
+    ]
+    return {"ok": True, "frameworks": slim, "count": len(slim)}


### PR DESCRIPTION
## What
First slice of #31 (agent knowledge of available frameworks/backends -> agent offers to install/use). The agent had no way to know which agent frameworks taOS can deploy, so it could not concretely offer to set one up. Adds a read-only `list_frameworks` tool.

## Changes
- `tinyagentos/tools/framework_tools.py` (new): `execute_list_frameworks` reads the adapter registry in-process (the same source `/api/frameworks` serves, so it stays in sync with the Deploy Agent wizard), returning id, name, description, verification_status; optional `verified_only` returns beta (recommended) only.
- Skill registration + `skill_exec` dispatch wiring.

Scope: the deploy itself stays a user-driven action in the Agents app. Backends/models discovery is a follow-up slice.

## Surgical
Additive only (120 insertions, 0 deletions); pure read of existing metadata. No existing behaviour changed.

## Verification
- `pytest tests/test_framework_tools.py` -> 2 passed (lists all incl. openclaw+hermes with the expected fields; verified_only returns the beta subset).
- `pytest tests/test_skills.py tests/test_routes_skill_exec.py` -> green.
- ruff clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new framework discovery option so users can list available agent frameworks.
  * Results include key details like name, description, and verification status.
  * Added a filter to show only beta-verified frameworks.

* **Tests**
  * Added coverage for the full framework list and the beta-only filtered results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->