### PR TITLE
feat(agents): list_store_apps tool so the agent can offer to install one (#31)

### DIFF
--- a/tests/test_store_tools.py
+++ b/tests/test_store_tools.py
@@ -1,0 +1,86 @@
+"""Tests for the list_store_apps agent tool."""
+import types
+
+import pytest
+
+from tinyagentos.tools.store_tools import execute_list_store_apps
+
+
+class _App:
+    def __init__(self, id, name, type="app", category="util", description=""):
+        self.id = id
+        self.name = name
+        self.type = type
+        self.category = category
+        self.description = description
+
+
+class _FakeRegistry:
+    def __init__(self, apps, installed=()):
+        self._apps = apps
+        self._installed = set(installed)
+
+    def list_available(self, type_filter=None):
+        if type_filter:
+            return [a for a in self._apps if a.type == type_filter]
+        return list(self._apps)
+
+    def is_installed(self, app_id):
+        return app_id in self._installed
+
+
+def _req(registry, installation=None):
+    state = types.SimpleNamespace(registry=registry, installation_state=installation)
+    return types.SimpleNamespace(app=types.SimpleNamespace(state=state), state=types.SimpleNamespace(user_id="user-1"))
+
+
+@pytest.mark.asyncio
+async def test_lists_all_with_installed_flag():
+    reg = _FakeRegistry(
+        [_App("comfyui", "ComfyUI", type="service", description="image backend"),
+         _App("notes", "Notes", type="app")],
+        installed=["comfyui"],
+    )
+    res = await execute_list_store_apps({}, _req(reg))
+    assert res["ok"] is True and res["count"] == 2
+    by_id = {a["id"]: a for a in res["apps"]}
+    assert by_id["comfyui"]["installed"] is True
+    assert by_id["notes"]["installed"] is False
+    assert by_id["comfyui"]["type"] == "service"
+
+
+@pytest.mark.asyncio
+async def test_type_filter():
+    reg = _FakeRegistry([_App("comfyui", "ComfyUI", type="service"), _App("notes", "Notes", type="app")])
+    res = await execute_list_store_apps({"type": "service"}, _req(reg))
+    assert res["count"] == 1 and res["apps"][0]["id"] == "comfyui"
+
+
+@pytest.mark.asyncio
+async def test_query_search():
+    reg = _FakeRegistry([_App("comfyui", "ComfyUI", description="image backend"), _App("notes", "Notes", description="text")])
+    res = await execute_list_store_apps({"query": "image"}, _req(reg))
+    assert res["count"] == 1 and res["apps"][0]["id"] == "comfyui"
+
+
+@pytest.mark.asyncio
+async def test_installation_state_overrides_registry():
+    class _Inst:
+        def state(self, app_id):
+            return "running" if app_id == "comfyui" else "not_installed"
+    reg = _FakeRegistry([_App("comfyui", "ComfyUI"), _App("notes", "Notes")], installed=["notes"])
+    res = await execute_list_store_apps({}, _req(reg, installation=_Inst()))
+    by_id = {a["id"]: a for a in res["apps"]}
+    # installation_state wins: comfyui running -> installed, notes not_installed -> not installed
+    assert by_id["comfyui"]["installed"] is True
+    assert by_id["notes"]["installed"] is False
+
+
+@pytest.mark.asyncio
+async def test_no_registry_errors():
+    req = types.SimpleNamespace(
+        app=types.SimpleNamespace(state=types.SimpleNamespace(registry=None)),
+        state=types.SimpleNamespace(user_id="user-1"),
+    )
+    res = await execute_list_store_apps({}, req)
+    assert res["error"] == "store registry not available"

--- a/tinyagentos/routes/skill_exec.py
+++ b/tinyagentos/routes/skill_exec.py
@@ -235,6 +235,16 @@ async def _skill_list_frameworks(args: dict, request: Request) -> dict:
         return {"error": str(exc)}
 
 
+async def _skill_list_store_apps(args: dict, request: Request) -> dict:
+    """List installable Store apps/backends so the agent can offer to install one."""
+    try:
+        from tinyagentos.tools.store_tools import execute_list_store_apps
+
+        return await execute_list_store_apps(args, request)
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
 async def _skill_list_projects(args: dict, request: Request) -> dict:
     """List the user's projects so the agent can pick one."""
     try:
@@ -310,6 +320,7 @@ SKILL_IMPLEMENTATIONS = {
     "request_decision": _skill_request_decision,
     "notify_user": _skill_notify_user,
     "list_frameworks": _skill_list_frameworks,
+    "list_store_apps": _skill_list_store_apps,
     "create_project": _skill_create_project,
     "list_projects": _skill_list_projects,
     "add_task": _skill_add_task,

--- a/tinyagentos/skills.py
+++ b/tinyagentos/skills.py
@@ -435,6 +435,30 @@ class SkillStore(BaseStore):
                 "install_target": "tinyagentos.tools.framework_tools",
             },
             {
+                "id": "list_store_apps",
+                "name": "List Store Apps",
+                "category": "agent",
+                "description": "List installable Store apps/backends so the agent can offer to install one",
+                "tool_schema": {
+                    "name": "list_store_apps",
+                    "description": "List installable things in the taOS Store (apps, models, services, backends, plugins) with whether each is installed, so you can offer to install what the user needs. Optional 'type' filter and 'query' search. Read-only; the user installs from the Store app.",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {
+                            "type": {"type": "string", "description": "Optional type filter (app, model, service, backend, plugin)."},
+                            "query": {"type": "string", "description": "Optional search over name and description."},
+                        },
+                    },
+                },
+                "frameworks": {
+                    "smolagents": "adapter", "openclaw": "adapter", "pocketflow": "adapter",
+                    "langroid": "adapter", "hermes": "adapter", "agent-zero": "adapter",
+                    "openai-agents-sdk": "adapter", "generic": "adapter",
+                },
+                "install_method": "builtin",
+                "install_target": "tinyagentos.tools.store_tools",
+            },
+            {
                 "id": "notify_user",
                 "name": "Notify User",
                 "category": "agent",

--- a/tinyagentos/tools/store_tools.py
+++ b/tinyagentos/tools/store_tools.py
@@ -1,0 +1,80 @@
+"""Agent tool for discovering installable Store apps and backends.
+
+Lets the agent see what is in the Store (apps, models, services, backends,
+plugins) and whether each is installed, so it can offer a concrete next step
+("I can install the X backend / app for you") instead of guessing. Reads the
+in-process registry (the same source /api/store/catalog serves). Read-only; the
+install itself stays a user-driven action in the Store app.
+"""
+from __future__ import annotations
+
+from fastapi import Request
+
+
+def _installed(registry, installation, app_id: str) -> bool:
+    """Mirror the Store's installed semantics: a live-probe running/installed
+    state when an InstallationState is present, else the registry cache. Stale
+    cache entries are treated as not-installed (they are installable)."""
+    if installation is not None:
+        try:
+            return installation.state(app_id) in ("running", "installed")
+        except Exception:
+            pass
+    try:
+        return bool(registry.is_installed(app_id))
+    except Exception:
+        return False
+
+
+LIST_STORE_APPS_TOOL = {
+    "name": "list_store_apps",
+    "description": (
+        "List installable things in the taOS Store (apps, models, services, "
+        "backends, plugins) with whether each is installed, so you can offer to "
+        "install what the user needs. Optional 'type' filters (e.g. app, model, "
+        "service, backend, plugin) and 'query' searches name/description. "
+        "Read-only; the user installs from the Store app."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "type": {"type": "string", "description": "Optional type filter (app, model, service, backend, plugin)."},
+            "query": {"type": "string", "description": "Optional search over name and description."},
+        },
+    },
+}
+
+
+async def execute_list_store_apps(args: dict, request: Request) -> dict:
+    args = args or {}
+    type_filter = args.get("type") or None
+    query = args.get("query")
+    query = query.lower() if isinstance(query, str) and query.strip() else None
+
+    registry = getattr(request.app.state, "registry", None)
+    if registry is None:
+        return {"error": "store registry not available"}
+    installation = getattr(request.app.state, "installation_state", None)
+
+    try:
+        apps = registry.list_available(type_filter=type_filter)
+    except TypeError:
+        # Older registries may not accept the keyword; fall back to all.
+        apps = registry.list_available()
+
+    items = []
+    for a in apps:
+        name = getattr(a, "name", "") or ""
+        description = getattr(a, "description", "") or ""
+        if query and query not in name.lower() and query not in description.lower():
+            continue
+        app_id = getattr(a, "id", None)
+        items.append({
+            "id": app_id,
+            "name": name,
+            "type": getattr(a, "type", None),
+            "category": getattr(a, "category", None),
+            "description": description,
+            "installed": _installed(registry, installation, app_id),
+        })
+    return {"ok": True, "apps": items, "count": len(items)}


### PR DESCRIPTION
## What
Second slice of #31 (agent knowledge of available frameworks/backends -> offers to install/use). After `list_frameworks` (#1458), the agent still could not see what is installable in the Store, so it could not offer to install an app/backend the user needs. Adds a read-only `list_store_apps` tool.

## Changes
- `tinyagentos/tools/store_tools.py` (new): `execute_list_store_apps` reads the in-process registry (same source `/api/store/catalog` serves), returning each app/model/service/backend/plugin (id, name, type, category, description) with an `installed` flag computed from the live `InstallationState` when present (mirroring the Store's stale-aware semantics, falling back to the registry cache). Optional `type` filter and `query` search.
- Skill registration + `skill_exec` dispatch wiring.

Scope: the install itself stays a user-driven action in the Store app. Frameworks discovery shipped in #1458; together these cover #31's discovery half.

## Surgical
Additive only (201 insertions, 0 deletions); pure read via existing registry methods. No existing behaviour changed.

## Verification
- `pytest tests/test_store_tools.py` -> 5 passed (installed flag / type filter / query / InstallationState override / no-registry error).
- `pytest tests/test_skills.py tests/test_routes_skill_exec.py` -> green.
- ruff clean.