### PR TITLE
feat(agents): list_tasks tool to read a project board (#104)

### DIFF
--- a/tests/test_project_tools.py
+++ b/tests/test_project_tools.py
@@ -5,6 +5,7 @@ import pytest
 from tinyagentos.tools.project_tools import (
     execute_create_project,
     execute_list_projects,
+    execute_list_tasks,
     execute_add_task,
     execute_canvas_add_image,
     _slugify,
@@ -45,6 +46,15 @@ class _FakeTaskStore:
     async def create_task(self, **kw):
         self.calls.append(kw)
         return {"id": "task_1", "title": kw["title"]}
+
+    async def list_tasks(self, project_id, status=None):
+        rows = [
+            {"id": "task_1", "title": "Outline", "status": "open", "project_id": project_id},
+            {"id": "task_2", "title": "Draft", "status": "done", "project_id": project_id},
+        ]
+        if status is not None:
+            return [r for r in rows if r["status"] == status]
+        return rows
 
 
 class _FakeCanvasStore:
@@ -252,3 +262,34 @@ async def test_list_projects_rejects_bad_status():
 async def test_list_projects_requires_user():
     res = await execute_list_projects({}, _req(user_id=None))
     assert res["error"] == "no authenticated user"
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_returns_board():
+    req = _req()
+    res = await execute_list_tasks({"project_id": "proj_1"}, req)
+    assert res["ok"] is True and res["count"] == 2
+    assert res["tasks"][0] == {"task_id": "task_1", "title": "Outline", "status": "open"}
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_status_filter():
+    res = await execute_list_tasks({"project_id": "proj_1", "status": "done"}, _req())
+    assert res["count"] == 1 and res["tasks"][0]["task_id"] == "task_2"
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_requires_project_id():
+    assert "error" in await execute_list_tasks({}, _req())
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_denied_on_other_users_project():
+    res = await execute_list_tasks({"project_id": "proj_1"}, _req(user_id="attacker", owner="victim"))
+    assert res.get("error") == "not your project"
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_missing_project():
+    res = await execute_list_tasks({"project_id": "missing"}, _req())
+    assert res.get("error") == "project not found"

--- a/tinyagentos/routes/skill_exec.py
+++ b/tinyagentos/routes/skill_exec.py
@@ -255,6 +255,16 @@ async def _skill_list_projects(args: dict, request: Request) -> dict:
         return {"error": str(exc)}
 
 
+async def _skill_list_tasks(args: dict, request: Request) -> dict:
+    """List a project's tasks so the agent can review progress or pick next."""
+    try:
+        from tinyagentos.tools.project_tools import execute_list_tasks
+
+        return await execute_list_tasks(args, request)
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
 async def _skill_create_project(args: dict, request: Request) -> dict:
     """Create a project the user can see."""
     try:
@@ -323,6 +333,7 @@ SKILL_IMPLEMENTATIONS = {
     "list_store_apps": _skill_list_store_apps,
     "create_project": _skill_create_project,
     "list_projects": _skill_list_projects,
+    "list_tasks": _skill_list_tasks,
     "add_task": _skill_add_task,
     "canvas_add_image": _skill_canvas_add_image,
     "describe_image_capabilities": _skill_describe_image_capabilities,

--- a/tinyagentos/skills.py
+++ b/tinyagentos/skills.py
@@ -358,6 +358,31 @@ class SkillStore(BaseStore):
                 "install_target": "tinyagentos.tools.project_tools",
             },
             {
+                "id": "list_tasks",
+                "name": "List Tasks",
+                "category": "projects",
+                "description": "List a project's tasks so the agent can review progress or pick next",
+                "tool_schema": {
+                    "name": "list_tasks",
+                    "description": "List a project's tasks (id, title, status) so you can review progress or pick the next one. Requires project_id (from list_projects/create_project); optional status filter (e.g. open, in_progress, done).",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {
+                            "project_id": {"type": "string", "description": "Id from list_projects/create_project."},
+                            "status": {"type": "string", "description": "Optional status filter (e.g. open, in_progress, done)."},
+                        },
+                        "required": ["project_id"],
+                    },
+                },
+                "frameworks": {
+                    "smolagents": "adapter", "openclaw": "adapter", "pocketflow": "adapter",
+                    "langroid": "adapter", "hermes": "adapter", "agent-zero": "adapter",
+                    "openai-agents-sdk": "adapter", "generic": "adapter",
+                },
+                "install_method": "builtin",
+                "install_target": "tinyagentos.tools.project_tools",
+            },
+            {
                 "id": "add_task",
                 "name": "Add Task",
                 "category": "projects",

--- a/tinyagentos/tools/project_tools.py
+++ b/tinyagentos/tools/project_tools.py
@@ -81,6 +81,30 @@ async def execute_list_projects(args: dict, request: Request) -> dict:
     return {"ok": True, "projects": projects, "count": len(projects)}
 
 
+async def execute_list_tasks(args: dict, request: Request) -> dict:
+    """List a project's tasks so the agent can review progress or pick the next
+    one, instead of guessing. Read-only; scoped to a project the caller owns."""
+    project_id = (args or {}).get("project_id")
+    if not isinstance(project_id, str) or not project_id:
+        return {"error": "list_tasks requires a 'project_id' string"}
+    user_id = _user_id(request)
+    if not user_id:
+        return {"error": "no authenticated user"}
+    _, err = await _owned_project(request, project_id, user_id)
+    if err:
+        return err
+    status = (args or {}).get("status")
+    if status is not None and not isinstance(status, str):
+        return {"error": "status must be a string"}
+    store = request.app.state.project_task_store
+    rows = await store.list_tasks(project_id, status=status or None)
+    tasks = [
+        {"task_id": t.get("id"), "title": t.get("title"), "status": t.get("status")}
+        for t in rows
+    ]
+    return {"ok": True, "tasks": tasks, "count": len(tasks)}
+
+
 async def execute_add_task(args: dict, request: Request) -> dict:
     project_id = (args or {}).get("project_id")
     title = (args or {}).get("title")


### PR DESCRIPTION
## What
Completes the projects agent-surface (create_project, list_projects, add_task, list_tasks, canvas_add_image). The agent could add tasks but not read a board, so it could not review progress or pick the next task. Adds a read-only `list_tasks` tool.

## Changes
- `tinyagentos/tools/project_tools.py`: `execute_list_tasks` returns a project's tasks (task_id, title, status) via the existing `task_store.list_tasks`, scoped to a project the caller owns (reuses `_owned_project`), with an optional status filter.
- Skill registration + `skill_exec` dispatch wiring.

## Surgical
Additive only (101 insertions, 0 deletions); reuses the existing store + ownership check. No existing behaviour changed.

## Verification
- `pytest tests/test_project_tools.py` -> green incl. 5 new list_tasks tests (board / status filter / requires-project_id / not-your-project / project-not-found).
- `pytest tests/test_skills.py tests/test_routes_skill_exec.py` -> green.
- ruff clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a task-listing feature for projects, including support for filtering tasks by status.
  * Integrated the new task list action into the built-in skill set.

* **Bug Fixes**
  * Added validation for missing project information and clearer error handling when a project can’t be found.
  * Enforced project ownership checks so only authorized users can view task lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->