### PR TITLE
feat(agents): get_capabilities tool for hardware-aware advice (#31/#104)

### DIFF
--- a/tests/test_capability_tools.py
+++ b/tests/test_capability_tools.py
@@ -1,0 +1,59 @@
+"""Tests for the get_capabilities agent tool."""
+import types
+
+import pytest
+
+from tinyagentos.tools.capability_tools import execute_get_capabilities
+
+
+class _FakeChecker:
+    def get_all_capabilities(self):
+        return {
+            "chat-small": {"available": True, "hint": None},
+            "chat-large": {"available": False, "hint": "Add a GPU worker with 8GB+ VRAM"},
+            "embedding": {"available": True, "hint": None},
+        }
+
+
+def _req(checker):
+    return types.SimpleNamespace(
+        app=types.SimpleNamespace(state=types.SimpleNamespace(capabilities=checker)),
+        state=types.SimpleNamespace(user_id="user-1"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_lists_all_with_hints():
+    res = await execute_get_capabilities({}, _req(_FakeChecker()))
+    assert res["ok"] is True
+    assert res["count"] == 3 and res["available_count"] == 2
+    by_name = {c["capability"]: c for c in res["capabilities"]}
+    assert by_name["chat-small"]["available"] is True
+    assert "unlock_hint" not in by_name["chat-small"]
+    assert by_name["chat-large"]["available"] is False
+    assert by_name["chat-large"]["unlock_hint"] == "Add a GPU worker with 8GB+ VRAM"
+
+
+@pytest.mark.asyncio
+async def test_available_only_filters():
+    res = await execute_get_capabilities({"available_only": True}, _req(_FakeChecker()))
+    assert res["count"] == 2
+    assert all(c["available"] for c in res["capabilities"])
+    assert {c["capability"] for c in res["capabilities"]} == {"chat-small", "embedding"}
+
+
+@pytest.mark.asyncio
+async def test_no_checker_errors():
+    req = types.SimpleNamespace(
+        app=types.SimpleNamespace(state=types.SimpleNamespace(capabilities=None)),
+        state=types.SimpleNamespace(user_id="user-1"),
+    )
+    res = await execute_get_capabilities({}, req)
+    assert res["error"] == "capability checker not available"
+
+
+@pytest.mark.asyncio
+async def test_results_sorted():
+    res = await execute_get_capabilities({}, _req(_FakeChecker()))
+    names = [c["capability"] for c in res["capabilities"]]
+    assert names == sorted(names)

--- a/tinyagentos/routes/skill_exec.py
+++ b/tinyagentos/routes/skill_exec.py
@@ -245,6 +245,16 @@ async def _skill_list_store_apps(args: dict, request: Request) -> dict:
         return {"error": str(exc)}
 
 
+async def _skill_get_capabilities(args: dict, request: Request) -> dict:
+    """Report hardware-aware capabilities so the agent gives accurate advice."""
+    try:
+        from tinyagentos.tools.capability_tools import execute_get_capabilities
+
+        return await execute_get_capabilities(args, request)
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
 async def _skill_list_projects(args: dict, request: Request) -> dict:
     """List the user's projects so the agent can pick one."""
     try:
@@ -331,6 +341,7 @@ SKILL_IMPLEMENTATIONS = {
     "notify_user": _skill_notify_user,
     "list_frameworks": _skill_list_frameworks,
     "list_store_apps": _skill_list_store_apps,
+    "get_capabilities": _skill_get_capabilities,
     "create_project": _skill_create_project,
     "list_projects": _skill_list_projects,
     "list_tasks": _skill_list_tasks,

--- a/tinyagentos/skills.py
+++ b/tinyagentos/skills.py
@@ -460,6 +460,29 @@ class SkillStore(BaseStore):
                 "install_target": "tinyagentos.tools.framework_tools",
             },
             {
+                "id": "get_capabilities",
+                "name": "Get Capabilities",
+                "category": "agent",
+                "description": "Report what this taOS install can do on its hardware/cluster (with unlock hints)",
+                "tool_schema": {
+                    "name": "get_capabilities",
+                    "description": "Check what this taOS install can do on its current hardware + cluster (chat-small, chat-large, image-generation-gpu, embedding, tts, lora-training, ...) with availability + unlock hints. Use before promising a hardware-bound action. Optional available_only=true.",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {
+                            "available_only": {"type": "boolean", "description": "Only currently-available capabilities. Default false."},
+                        },
+                    },
+                },
+                "frameworks": {
+                    "smolagents": "adapter", "openclaw": "adapter", "pocketflow": "adapter",
+                    "langroid": "adapter", "hermes": "adapter", "agent-zero": "adapter",
+                    "openai-agents-sdk": "adapter", "generic": "adapter",
+                },
+                "install_method": "builtin",
+                "install_target": "tinyagentos.tools.capability_tools",
+            },
+            {
                 "id": "list_store_apps",
                 "name": "List Store Apps",
                 "category": "agent",

--- a/tinyagentos/tools/capability_tools.py
+++ b/tinyagentos/tools/capability_tools.py
@@ -1,0 +1,61 @@
+"""Agent tool for hardware-aware capability awareness.
+
+Lets the agent know what this taOS install can actually do on its current
+hardware + cluster (run a large chat model, generate images on a GPU, train a
+LoRA, etc.) and, for anything not yet available, the unlock hint. With this the
+agent gives accurate advice ("you can run this locally" vs "you would need a GPU
+worker") instead of guessing. Reads the in-process CapabilityChecker (the same
+one the cluster-capability surface uses). Read-only.
+"""
+from __future__ import annotations
+
+from fastapi import Request
+
+GET_CAPABILITIES_TOOL = {
+    "name": "get_capabilities",
+    "description": (
+        "Check what this taOS install can do on its current hardware + cluster: "
+        "each capability (chat-small, chat-large, image-generation-gpu, embedding, "
+        "tts, lora-training, ...) with whether it is available now and, if not, an "
+        "unlock hint (e.g. 'add a GPU worker'). Use before promising a "
+        "hardware-bound action so you give accurate advice instead of guessing. "
+        "Optional available_only=true returns just the usable capabilities."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "available_only": {
+                "type": "boolean",
+                "description": "If true, return only currently-available capabilities. Default false (all, with hints).",
+            },
+        },
+    },
+}
+
+
+async def execute_get_capabilities(args: dict, request: Request) -> dict:
+    checker = getattr(request.app.state, "capabilities", None)
+    if checker is None:
+        return {"error": "capability checker not available"}
+    available_only = bool((args or {}).get("available_only", False))
+    try:
+        all_caps = checker.get_all_capabilities()
+    except Exception as exc:
+        return {"error": f"capability check failed: {exc}"}
+
+    capabilities = []
+    for name, info in sorted(all_caps.items()):
+        avail = bool(info.get("available"))
+        if available_only and not avail:
+            continue
+        entry = {"capability": name, "available": avail}
+        hint = info.get("hint")
+        if hint and not avail:
+            entry["unlock_hint"] = hint
+        capabilities.append(entry)
+    return {
+        "ok": True,
+        "capabilities": capabilities,
+        "count": len(capabilities),
+        "available_count": sum(1 for c in capabilities if c["available"]),
+    }


### PR DESCRIPTION
## What
Agent-native coverage; complements the #31 discovery tools. The agent could list installable frameworks (#1458) and Store apps (#1459) but had no way to know what this install can actually RUN on its current hardware + cluster, so it could not give accurate advice (run locally vs needs a GPU worker). Adds a read-only `get_capabilities` tool.

## Changes
- `tinyagentos/tools/capability_tools.py` (new): `execute_get_capabilities` reads the in-process `CapabilityChecker` (`app.state.capabilities`, the same one the cluster-capability surface uses) and returns each capability (chat-small, chat-large, image-generation-gpu, embedding, tts, lora-training, ...) with `available` + an `unlock_hint` when unavailable; optional `available_only` filter; results sorted.
- Skill registration + `skill_exec` dispatch wiring.

## Surgical
Additive only (154 insertions, 0 deletions); pure read of the existing checker. No existing behaviour changed.

## Verification
- `pytest tests/test_capability_tools.py` -> 4 passed (all+hints / available_only / no-checker error / sorted).
- `pytest tests/test_skills.py tests/test_routes_skill_exec.py` -> green.
- ruff clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Get Capabilities” action that lets the app list available and unavailable capabilities.
  * Results can be filtered to show only available capabilities.
  * Capability entries now include counts, availability status, and hints for locked items when available.

* **Bug Fixes**
  * Added clearer error handling when capability data is unavailable.
  * Ensured capability results are returned in a consistent, deterministic order.

* **Tests**
  * Added coverage for full listing, filtering, missing capability data, and sorting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->