### PR TITLE
feat(agents): list_files tool to browse the workspace (#104)

### DIFF
--- a/tests/test_skill_runtime.py
+++ b/tests/test_skill_runtime.py
@@ -108,6 +108,41 @@ async def test_file_write_and_read(app_with_store):
 
 
 @pytest.mark.asyncio
+async def test_list_files_lists_workspace(app_with_store):
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_store), base_url="http://test"
+    ) as client:
+        await client.post(
+            "/api/skill-exec/file_write/call",
+            json={"args": {"path": "a.txt", "content": "hello"}},
+        )
+        await client.post(
+            "/api/skill-exec/file_write/call",
+            json={"args": {"path": "sub/b.txt", "content": "x"}},
+        )
+        resp = await client.post("/api/skill-exec/list_files/call", json={"args": {}})
+        assert resp.status_code == 200
+        by_name = {e["name"]: e for e in resp.json()["entries"]}
+        assert by_name["a.txt"]["type"] == "file" and by_name["a.txt"]["size"] == 5
+        assert by_name["sub"]["type"] == "dir"
+        sub = await client.post(
+            "/api/skill-exec/list_files/call", json={"args": {"path": "sub"}}
+        )
+        assert {e["name"] for e in sub.json()["entries"]} == {"b.txt"}
+
+
+@pytest.mark.asyncio
+async def test_list_files_rejects_path_outside_workspace(app_with_store):
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_store), base_url="http://test"
+    ) as client:
+        resp = await client.post(
+            "/api/skill-exec/list_files/call", json={"args": {"path": "../.."}}
+        )
+        assert resp.json().get("error") == "Path outside workspace"
+
+
+@pytest.mark.asyncio
 async def test_skill_exec_list_image_models(app_with_store):
     """list_image_models skill returns a list of models via skill-exec."""
     store = app_with_store.state.skills

--- a/tinyagentos/routes/skill_exec.py
+++ b/tinyagentos/routes/skill_exec.py
@@ -86,6 +86,30 @@ async def _skill_file_write(args: dict, request: Request) -> dict:
         return {"error": str(exc)}
 
 
+async def _skill_list_files(args: dict, request: Request) -> dict:
+    """List a directory in the calling agent's workspace (read complement to
+    file_read / file_write). Sandboxed to the workspace, same as file_read."""
+    path = args.get("path", "") or ""
+    workspace = _resolve_agent_workspace(request, args)
+    target = (workspace / path).resolve()
+    try:
+        if workspace not in target.parents and target != workspace:
+            return {"error": "Path outside workspace"}
+        if not target.is_dir():
+            return {"error": "Directory not found"}
+        entries = []
+        for child in sorted(target.iterdir(), key=lambda c: c.name):
+            is_dir = child.is_dir()
+            entries.append({
+                "name": child.name,
+                "type": "dir" if is_dir else "file",
+                "size": (child.stat().st_size if child.is_file() else None),
+            })
+        return {"entries": entries, "count": len(entries)}
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
 async def _skill_web_search(args: dict, request: Request) -> dict:
     """Search the web via SearXNG (if available)."""
     import httpx
@@ -329,6 +353,7 @@ SKILL_IMPLEMENTATIONS = {
     "memory_search": _skill_memory_search,
     "file_read": _skill_file_read,
     "file_write": _skill_file_write,
+    "list_files": _skill_list_files,
     "web_search": _skill_web_search,
     "code_exec": _skill_code_exec,
     "http_request": _skill_http_request,

--- a/tinyagentos/skills.py
+++ b/tinyagentos/skills.py
@@ -118,6 +118,29 @@ class SkillStore(BaseStore):
                 "install_target": "tinyagentos.tools.file_write",
             },
             {
+                "id": "list_files",
+                "name": "List Files",
+                "category": "files",
+                "description": "List a directory in the agent workspace",
+                "tool_schema": {
+                    "name": "list_files",
+                    "description": "List the files and folders in a workspace directory (name, type, size) so you can see what exists before reading. Optional relative path; defaults to the workspace root.",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {
+                            "path": {"type": "string", "description": "Relative directory path (default: workspace root)."},
+                        },
+                    },
+                },
+                "frameworks": {
+                    "smolagents": "adapter", "openclaw": "native", "pocketflow": "adapter",
+                    "langroid": "adapter", "openai-agents-sdk": "adapter", "hermes": "adapter",
+                    "agent-zero": "native", "generic": "adapter",
+                },
+                "install_method": "builtin",
+                "install_target": "tinyagentos.tools.file_read",
+            },
+            {
                 "id": "web_search",
                 "name": "Web Search",
                 "category": "search",


### PR DESCRIPTION
## What
Completes the files agent-surface (file_read, file_write, list_files). The agent could read and write workspace files but not discover what exists, so it had to guess filenames. Adds a read-only `list_files` skill.

## Changes
- `_skill_list_files` in `routes/skill_exec.py` (inline, like file_read/file_write) lists a workspace directory (name, type, size), sandboxed to the agent workspace with the same containment check as file_read (path-outside-workspace rejected). Optional relative `path`, defaults to the workspace root. Registered in the dispatch map.
- `skills.py` catalog entry (category files).

## Surgical
Additive only (83 insertions, 0 deletions); reuses `_resolve_agent_workspace` + the file_read containment check. No existing behaviour changed.

## Verification
- `pytest tests/test_skill_runtime.py` -> green incl. 2 new round-trip tests (write -> list, subdir listing, and path-traversal rejection).
- `pytest tests/test_skills.py tests/test_routes_skill_exec.py` -> green.
- `compileall tinyagentos/` clean (CI lint scope).