### PR TITLE
fix(agents): hermes profile import must pass --name (default profile rejected)

### DIFF
--- a/tests/test_agents_import_hermes.py
+++ b/tests/test_agents_import_hermes.py
@@ -105,9 +105,14 @@ class TestHermesImportHappyPath:
             # binary probe
             if cmd[:1] == ["test"]:
                 return (0, "") if cmd[-1] == "/usr/local/bin/hermes" else (1, "")
-            # `hermes profile import <path>`
+            # `hermes profile import <path> --name <slug>`
             if "profile" in cmd and "import" in cmd:
                 return 0, "imported profile ok"
+            # `hermes profile use <slug>` + `hermes gateway restart`
+            if "profile" in cmd and "use" in cmd:
+                return 0, "switched"
+            if "gateway" in cmd and "restart" in cmd:
+                return 0, "restarted"
             # persona readback: SOUL.md
             if cmd[:1] == ["cat"] and cmd[-1].endswith("SOUL.md"):
                 return 0, "You are an imported soul."
@@ -143,10 +148,18 @@ class TestHermesImportHappyPath:
         assert task is not None, "background import task should have recorded a result"
         assert task["status"] == "success", task
 
-        # `hermes profile import <pushed-path>` was invoked with the pushed path.
+        # `hermes profile import <pushed-path> --name <slug>` was invoked: the
+        # pushed path AND an explicit --name (never the bundle's own, possibly
+        # `default`, name which hermes refuses to import).
         import_calls = [c for c in calls if "profile" in c and "import" in c]
         assert import_calls, "hermes profile import should have run"
         assert pushed["dst"] in import_calls[0], "import should target the pushed bundle path"
+        assert "--name" in import_calls[0], "import must pass --name to avoid the forbidden 'default' name"
+        assert slug in import_calls[0], "import should name the profile after the agent slug"
+        # The imported profile is made the sticky default so the agent runs it.
+        assert any("profile" in c and "use" in c and slug in c for c in calls), (
+            "import should `hermes profile use <slug>` to activate the imported profile"
+        )
 
         # Persona readback populated soul_md + model on the agent record.
         detail = await client.get(f"/api/agents/{slug}")

--- a/tests/test_agents_import_hermes.py
+++ b/tests/test_agents_import_hermes.py
@@ -174,6 +174,48 @@ class TestHermesImportHappyPath:
         names = {s["name"] for s in granted}
         assert f"{slug}-OPENROUTER_API_KEY" in names
 
+    async def test_gateway_restart_nonzero_still_succeeds(self, client, app, monkeypatch):
+        """A non-zero `hermes gateway restart` must NOT fail an otherwise good
+        import (the profile is imported + set sticky); it is logged, not fatal."""
+        async def fake_deploy(req):
+            return {"success": True, "name": req.name, "ip": "10.0.0.90",
+                    "llm_key": "sk-x", "steps": ["deployment_complete"],
+                    "container": f"taos-agent-{req.name}"}
+        monkeypatch.setattr("tinyagentos.deployer.deploy_agent", fake_deploy)
+
+        async def fake_push_file(container, src, dst):
+            return 0, ""
+        monkeypatch.setattr("tinyagentos.containers.push_file", fake_push_file)
+
+        async def fake_exec(container, cmd, timeout=None):
+            if cmd[:1] == ["test"]:
+                return (0, "") if cmd[-1] == "/usr/local/bin/hermes" else (1, "")
+            if "profile" in cmd and "import" in cmd:
+                return 0, "ok"
+            if "profile" in cmd and "use" in cmd:
+                return 0, "switched"
+            if "gateway" in cmd and "restart" in cmd:
+                return 1, "gateway restart failed"  # non-zero, but not fatal
+            if cmd[:1] == ["cat"]:
+                return 1, ""
+            return 1, ""
+        monkeypatch.setattr("tinyagentos.containers.exec_in_container", fake_exec)
+
+        resp = await client.post(
+            "/api/agents/import",
+            data={"framework": "hermes", "name": "restart-flaky"},
+            files=_bundle(),
+        )
+        assert resp.status_code == 202
+        slug = resp.json()["name"]
+        for _ in range(20):
+            await asyncio.sleep(0.05)
+            task = app.state.deploy_tasks.get(slug)
+            if task and task["status"] in ("success", "failed"):
+                break
+        task = app.state.deploy_tasks.get(slug)
+        assert task["status"] == "success", task
+
     async def test_failed_profile_import_surfaces_error(self, client, app, monkeypatch):
         async def fake_deploy(req):
             return {

--- a/tinyagentos/routes/agent_import.py
+++ b/tinyagentos/routes/agent_import.py
@@ -299,14 +299,26 @@ async def _run_profile_import(request: Request, slug: str, agent: dict | None) -
     if use_code != 0:
         raise RuntimeError(f"hermes profile use failed ({use_code}): {use_out[-500:]}")
 
-    # Restart the gateway so the now-default imported profile is the one serving
-    # (`use` sets the sticky default but does not move the already-running
-    # gateway). Best-effort: a restart hiccup must not fail an otherwise
-    # successful import; the next agent start picks up the sticky default.
+    # Restart the gateway so the now-default imported profile is the one
+    # serving. `use` sets the sticky default but does not move the already-
+    # running gateway, and the agent is already started + marked running by
+    # this task, so without an explicit restart it keeps serving the empty
+    # built-in `default`. Best-effort: a restart failure must not undo an
+    # otherwise successful import, but a non-zero exit is logged loudly (not
+    # swallowed) since exec_in_container only RAISES on transport errors -- the
+    # agent would otherwise look healthy while serving the wrong profile. The
+    # slug is already a validated agent slug (alphanumeric + dashes), a valid
+    # hermes profile name, so `use <slug>` cannot be a bad-name case.
     try:
-        await exec_in_container(
+        restart_code, restart_out = await exec_in_container(
             container_name, [hermes_bin, "gateway", "restart"], timeout=120
         )
+        if restart_code != 0:
+            logger.warning(
+                "import %s: hermes gateway restart exited %s; the agent may serve "
+                "the empty default profile until its gateway is restarted: %s",
+                slug, restart_code, (restart_out or "")[-300:],
+            )
     except Exception:
         logger.exception("import %s: hermes gateway restart after profile use failed", slug)
 

--- a/tinyagentos/routes/agent_import.py
+++ b/tinyagentos/routes/agent_import.py
@@ -274,13 +274,41 @@ async def _run_profile_import(request: Request, slug: str, agent: dict | None) -
         raise RuntimeError(f"failed to push bundle into container (rc={push_rc}): {push_out[-300:]}")
 
     hermes_bin = await _find_hermes_bin(container_name)
+    # Import under a unique per-agent profile name (the slug), never the bundle's
+    # own name. A profile exported from a user's main agent is named `default`,
+    # and `hermes profile import` REFUSES to import as `default` because that is
+    # the built-in root profile (~/.hermes): it errors with "Specify a different
+    # name". Passing --name <slug> both avoids that and prevents collisions with
+    # any existing profile in the fresh container.
     code, output = await exec_in_container(
         container_name,
-        [hermes_bin, "profile", "import", _CONTAINER_BUNDLE_PATH],
+        [hermes_bin, "profile", "import", _CONTAINER_BUNDLE_PATH, "--name", slug],
         timeout=300,
     )
     if code != 0:
         raise RuntimeError(f"hermes profile import failed ({code}): {output[-1000:]}")
+
+    # Make the imported profile the sticky default so the agent runs it rather
+    # than the empty built-in `default`. The import never overwrites `default`,
+    # so without this the agent would deploy with none of the restored persona.
+    use_code, use_out = await exec_in_container(
+        container_name,
+        [hermes_bin, "profile", "use", slug],
+        timeout=60,
+    )
+    if use_code != 0:
+        raise RuntimeError(f"hermes profile use failed ({use_code}): {use_out[-500:]}")
+
+    # Restart the gateway so the now-default imported profile is the one serving
+    # (`use` sets the sticky default but does not move the already-running
+    # gateway). Best-effort: a restart hiccup must not fail an otherwise
+    # successful import; the next agent start picks up the sticky default.
+    try:
+        await exec_in_container(
+            container_name, [hermes_bin, "gateway", "restart"], timeout=120
+        )
+    except Exception:
+        logger.exception("import %s: hermes gateway restart after profile use failed", slug)
 
     # Best-effort persona readback so the imported personality shows in taOS.
     if agent is not None:


### PR DESCRIPTION
## Bug (found in live testing on the Pi)
Importing a Hermes profile bundle exported from a user's **main** agent fails outright. `hermes profile export` names the main profile `default`, and our importer ran `hermes profile import <archive>` with no `--name`, so Hermes refused: *Cannot import as 'default' — that is the built-in root profile (~/.hermes). Specify a different name.* The agent deployed but the import step failed, leaving a failed agent.

## Fix
- Import under the agent slug: `hermes profile import <archive> --name <slug>`.
- `hermes profile use <slug>` so the restored profile becomes the sticky default (import never overwrites `default`, so without this the agent runs an empty profile).
- Best-effort `hermes gateway restart` so the running gateway serves the imported profile.

Validated the import + use sequence live in a Hermes container before patching.

## Tests
- `tests/test_agents_import_hermes.py` updated: fake_exec handles `profile use` / `gateway restart`; asserts import passes `--name <slug>` and that `use` activates it. 10 passed.

## Follow-up (flagged)
The gateway-activation step (use + restart) is the nuanced part of Hermes's per-profile gateway model; worth a live re-confirm that an imported agent serves the restored persona end to end after this lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Imported Hermes profiles now keep an agent-specific name during upload, making them easier to identify and manage.
  * After import, the newly added profile is automatically selected as the active default.

* **Bug Fixes**
  * Improved Hermes profile import flow to avoid issues caused by using a reserved default profile name.
  * The gateway now refreshes after import so the selected profile takes effect immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->