### PR TITLE
fix(security): reject traversal agent_name in skill workspace resolver

### DIFF
--- a/tests/test_skill_runtime.py
+++ b/tests/test_skill_runtime.py
@@ -132,6 +132,22 @@ async def test_list_files_lists_workspace(app_with_store):
 
 
 @pytest.mark.asyncio
+async def test_agent_name_traversal_rejected(app_with_store):
+    """A traversal agent_name must not escape the workspaces base via any file
+    skill (it feeds the workspace path before the per-call path check)."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_store), base_url="http://test"
+    ) as client:
+        for skill in ("file_read", "list_files"):
+            resp = await client.post(
+                f"/api/skill-exec/{skill}/call",
+                json={"args": {"agent_name": "../../../../etc", "path": ""}},
+            )
+            body = resp.json()
+            assert "error" in body and "agent_name" in body["error"], (skill, body)
+
+
+@pytest.mark.asyncio
 async def test_list_files_rejects_path_outside_workspace(app_with_store):
     async with AsyncClient(
         transport=ASGITransport(app=app_with_store), base_url="http://test"

--- a/tests/test_skill_runtime.py
+++ b/tests/test_skill_runtime.py
@@ -159,6 +159,31 @@ async def test_list_files_rejects_path_outside_workspace(app_with_store):
 
 
 @pytest.mark.asyncio
+async def test_symlink_escape_rejected(app_with_store):
+    """A symlink inside the workspace pointing outside must not let file_read or
+    list_files escape: resolve() canonicalises the symlink and the containment
+    check then rejects the escaped target."""
+    import os
+    ws = app_with_store.state.agent_workspaces_dir / "default"
+    ws.mkdir(parents=True, exist_ok=True)
+    outside = app_with_store.state.agent_workspaces_dir.parent / "outside-secret"
+    outside.mkdir(parents=True, exist_ok=True)
+    (outside / "secret.txt").write_text("top secret")
+    os.symlink(outside, ws / "escape")
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_store), base_url="http://test"
+    ) as client:
+        r = await client.post(
+            "/api/skill-exec/list_files/call", json={"args": {"path": "escape"}}
+        )
+        assert r.json().get("error") == "Path outside workspace"
+        r2 = await client.post(
+            "/api/skill-exec/file_read/call", json={"args": {"path": "escape/secret.txt"}}
+        )
+        assert r2.json().get("error") == "Path outside workspace"
+
+
+@pytest.mark.asyncio
 async def test_skill_exec_list_image_models(app_with_store):
     """list_image_models skill returns a list of models via skill-exec."""
     store = app_with_store.state.skills

--- a/tests/test_skill_runtime.py
+++ b/tests/test_skill_runtime.py
@@ -138,7 +138,7 @@ async def test_agent_name_traversal_rejected(app_with_store):
     async with AsyncClient(
         transport=ASGITransport(app=app_with_store), base_url="http://test"
     ) as client:
-        for skill in ("file_read", "list_files"):
+        for skill in ("file_read", "file_write", "list_files"):
             resp = await client.post(
                 f"/api/skill-exec/{skill}/call",
                 json={"args": {"agent_name": "../../../../etc", "path": ""}},

--- a/tinyagentos/routes/skill_exec.py
+++ b/tinyagentos/routes/skill_exec.py
@@ -50,7 +50,14 @@ def _resolve_agent_workspace(request: Request, args: dict) -> Path:
         or request.query_params.get("agent_name")
         or "default"
     )
-    base = Path(request.app.state.agent_workspaces_dir) / agent_name
+    # agent_name feeds a filesystem path, so a value like "../../etc" would
+    # escape the workspaces base and let a caller read or enumerate arbitrary
+    # host directories through file_read / file_write / list_files. Resolve and
+    # require the result to stay within the workspaces root before creating it.
+    root = Path(request.app.state.agent_workspaces_dir).resolve()
+    base = (root / agent_name).resolve()
+    if base != root and root not in base.parents:
+        raise ValueError("invalid agent_name (escapes the workspaces directory)")
     base.mkdir(parents=True, exist_ok=True)
     return base
 
@@ -58,9 +65,9 @@ def _resolve_agent_workspace(request: Request, args: dict) -> Path:
 async def _skill_file_read(args: dict, request: Request) -> dict:
     """Read a file from the calling agent's workspace."""
     path = args.get("path", "")
-    workspace = _resolve_agent_workspace(request, args)
-    target = (workspace / path).resolve()
     try:
+        workspace = _resolve_agent_workspace(request, args)
+        target = (workspace / path).resolve()
         if workspace not in target.parents and target != workspace:
             return {"error": "Path outside workspace"}
         if not target.is_file():
@@ -74,9 +81,9 @@ async def _skill_file_write(args: dict, request: Request) -> dict:
     """Write a file to the calling agent's workspace."""
     path = args.get("path", "")
     content = args.get("content", "")
-    workspace = _resolve_agent_workspace(request, args)
-    target = (workspace / path).resolve()
     try:
+        workspace = _resolve_agent_workspace(request, args)
+        target = (workspace / path).resolve()
         if workspace not in target.parents and target != workspace:
             return {"error": "Path outside workspace"}
         target.parent.mkdir(parents=True, exist_ok=True)
@@ -90,9 +97,9 @@ async def _skill_list_files(args: dict, request: Request) -> dict:
     """List a directory in the calling agent's workspace (read complement to
     file_read / file_write). Sandboxed to the workspace, same as file_read."""
     path = args.get("path", "") or ""
-    workspace = _resolve_agent_workspace(request, args)
-    target = (workspace / path).resolve()
     try:
+        workspace = _resolve_agent_workspace(request, args)
+        target = (workspace / path).resolve()
         if workspace not in target.parents and target != workspace:
             return {"error": "Path outside workspace"}
         if not target.is_dir():


### PR DESCRIPTION
## Found in retrospective bot review
Kilo (on the merged list_files PR #1462) flagged: `agent_name` is unvalidated and feeds the workspace path, so `agent_name=../../etc` escapes the workspaces base. Shared by `file_read` / `file_write` / `list_files` via `_resolve_agent_workspace`; `list_files` amplifies it (directory enumeration). Auth-gated and single-user trust lowers the risk, but it is a real traversal gap.

## Fix
- `_resolve_agent_workspace` resolves the candidate workspace and requires it to stay within the workspaces root before `mkdir`; rejects otherwise.
- Moved the resolver call inside each file skill's try block so a rejected agent_name returns a clean `{error}` rather than a 500.

## Tests
- New: `agent_name='../../../../etc'` rejected by file_read and list_files. 12 passed.

## Notes
Kilo also flagged the list_files `install_target` as wrong, but it follows the same vestigial convention as file_read/file_write (inline builtins), so changing only list_files would introduce inconsistency: left as-is. The symlink-resolve suggestion matches the existing file_read/write pattern and is deferred.