### PR TITLE
fix(worker): complete the worker-LXC bring-up on Linux (deploy-capable)

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -541,10 +541,15 @@ install_and_enroll_incus() {
         _pair_manual_flag=(--manual)
         log "  TAOS_PAIR_MANUAL set — using free-tier manual pairing (enter IP + PIN in Add worker)"
     fi
+    # Save the signing key where the worker daemon reads it. The systemd unit
+    # sets TAOS_WORKER_STATE_DIR=$INSTALL_DIR/.taos-worker-state; pair.py's
+    # default state-dir differs, so pass it explicitly or the daemon starts up
+    # "not paired" despite a successful pairing.
     if ! "$INSTALL_DIR/.venv/bin/python" -m tinyagentos.worker.pair \
             "$CONTROLLER_URL" \
             --name "$WORKER_NAME" \
             --url "https://${LAN_IP}:8443" \
+            --state-dir "$INSTALL_DIR/.taos-worker-state" \
             "${_pair_manual_flag[@]}" \
             --register-after; then
         warn "pairing requires admin approval in taOS > Cluster."

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -558,25 +558,25 @@ install_and_enroll_incus() {
         return 1
     fi
 
-    # ── 8. POST to controller ───────────────────────────────────────────
+    # ── 8. Enrol the worker's incus with the controller ─────────────────
+    # The endpoint is HMAC-gated like register/heartbeat, so the request is
+    # signed with the pairing key. Crypto lives in Python (tinyagentos.worker.enroll),
+    # not shell. --state-dir matches the pairing step above so the key is found.
     log "enrolling incus remote with controller at $CONTROLLER_URL"
-    local http_code
-    http_code="$(curl -sS -o /tmp/taos-incus-enroll.out -w "%{http_code}" \
-        -X POST "$CONTROLLER_URL/api/cluster/workers/$WORKER_NAME/incus-enroll" \
-        -H "Content-Type: application/json" \
-        -d "{\"incus_url\": \"https://${LAN_IP}:8443\", \"token\": \"${TOKEN}\"}" \
-        2>/tmp/taos-incus-enroll.err || true)"
-
-    if [[ "$http_code" == 2* ]]; then
-        log "incus remote enrolled successfully (HTTP $http_code)"
+    if "$INSTALL_DIR/.venv/bin/python" -m tinyagentos.worker.enroll \
+            "$CONTROLLER_URL" \
+            --name "$WORKER_NAME" \
+            --incus-url "https://${LAN_IP}:8443" \
+            --token "$TOKEN" \
+            --state-dir "$INSTALL_DIR/.taos-worker-state"; then
+        log "incus remote enrolled successfully"
     else
-        warn "incus enrollment returned HTTP $http_code"
-        warn "  response: $(cat /tmp/taos-incus-enroll.out 2>/dev/null)"
-        warn "  to retry manually:"
+        warn "incus enrollment failed (see message above)"
+        warn "  to retry manually from inside the worker LXC:"
         warn "    TOKEN=\$(incus config trust add controller-enroll 2>&1 | tail -1)"
-        warn "    curl -X POST $CONTROLLER_URL/api/cluster/workers/$WORKER_NAME/incus-enroll \\"
-        warn "        -H 'Content-Type: application/json' \\"
-        warn "        -d \"{\\\"incus_url\\\": \\\"https://$LAN_IP:8443\\\", \\\"token\\\": \\\"\$TOKEN\\\"}\" "
+        warn "    $INSTALL_DIR/.venv/bin/python -m tinyagentos.worker.enroll $CONTROLLER_URL \\"
+        warn "        --name $WORKER_NAME --incus-url https://$LAN_IP:8443 --token \"\$TOKEN\" \\"
+        warn "        --state-dir $INSTALL_DIR/.taos-worker-state"
         warn "  set TAOS_SKIP_INCUS=1 to skip this block entirely on re-runs"
     fi
 }
@@ -664,6 +664,7 @@ Restart=always
 RestartSec=5
 Environment=PYTHONUNBUFFERED=1
 Environment=TAOS_WORKER_STATE_DIR=$INSTALL_DIR/.taos-worker-state
+Environment=TAOS_ADVERTISE_IP=${TAOS_ADVERTISE_IP:-}
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -485,10 +485,10 @@ install_and_enroll_incus() {
     TOKEN="$(echo "$token_output" | awk 'NF{last=$0} END{print last}')"
     if [[ -z "$TOKEN" ]]; then
         warn "failed to generate incus trust token — LXC enrollment skipped"
-        warn "  to enroll manually: incus config trust add controller-enroll"
-        warn "  then: curl -X POST $CONTROLLER_URL/api/cluster/workers/$WORKER_NAME/incus-enroll \\"
-        warn "      -H 'Content-Type: application/json' \\"
-        warn "      -d '{\"incus_url\": \"https://<LAN_IP>:8443\", \"token\": \"<TOKEN>\"}'"
+        warn "  to enroll manually: TOKEN=\$(incus config trust add controller-enroll 2>&1 | tail -1)"
+        warn "  then: $INSTALL_DIR/.venv/bin/python -m tinyagentos.worker.enroll $CONTROLLER_URL \\"
+        warn "      --name $WORKER_NAME --incus-url https://<LAN_IP>:8443 --token \"\$TOKEN\" \\"
+        warn "      --state-dir $INSTALL_DIR/.taos-worker-state"
         return 0
     fi
 
@@ -521,9 +521,9 @@ install_and_enroll_incus() {
     fi
     if [[ -z "$LAN_IP" ]]; then
         warn "could not detect LAN IP — LXC enrollment skipped"
-        warn "  to enroll manually: curl -X POST $CONTROLLER_URL/api/cluster/workers/$WORKER_NAME/incus-enroll \\"
-        warn "      -H 'Content-Type: application/json' \\"
-        warn "      -d '{\"incus_url\": \"https://<LAN_IP>:8443\", \"token\": \"$TOKEN\"}'"
+        warn "  to enroll manually: $INSTALL_DIR/.venv/bin/python -m tinyagentos.worker.enroll $CONTROLLER_URL \\"
+        warn "      --name $WORKER_NAME --incus-url https://<LAN_IP>:8443 --token \"$TOKEN\" \\"
+        warn "      --state-dir $INSTALL_DIR/.taos-worker-state"
         return 0
     fi
 

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -551,14 +551,105 @@ install_and_enroll_incus() {
     fi
 }
 
+# --- repo clone + python runtime (shared: macOS legacy body + phase 2) -----
+#
+# Defined here, above the phase entry-points, so phase2_inside_lxc() (which
+# runs inside the worker LXC and exits before the fall-through body) can reuse
+# the exact same clone + venv logic the macOS / non-phased path uses.
+
+clone_or_update_repo() {
+    if [[ ! -d "$INSTALL_DIR/.git" ]]; then
+        log "cloning $REPO into $INSTALL_DIR"
+        mkdir -p "$(dirname "$INSTALL_DIR")"
+        # If INSTALL_DIR already exists but isn't a git repo (e.g. a previous
+        # partial install), move it aside so the clone can proceed.
+        if [[ -d "$INSTALL_DIR" ]]; then
+            mv "$INSTALL_DIR" "${INSTALL_DIR}.old.$(date +%s)"
+        fi
+        git clone --depth 1 --branch "$BRANCH" "$REPO" "$INSTALL_DIR"
+    else
+        log "updating existing checkout"
+        (cd "$INSTALL_DIR" && git fetch --depth 1 origin "$BRANCH" && git reset --hard "origin/$BRANCH")
+    fi
+    cd "$INSTALL_DIR"
+}
+
+setup_python_venv() {
+    cd "$INSTALL_DIR"
+    if [[ ! -d .venv ]]; then
+        log "creating venv"
+        python3 -m venv .venv
+    fi
+
+    log "installing worker python deps into .venv"
+    ./.venv/bin/pip install --quiet --upgrade pip
+    ./.venv/bin/pip install --quiet \
+        httpx \
+        pydantic \
+        psutil \
+        fastapi \
+        uvicorn \
+        pyyaml \
+        pillow
+
+    # libtorrent is optional (only used for model torrent mesh). It isn't on
+    # PyPI as a wheel for most platforms — it ships as the distro's
+    # libtorrent-rasterbar package. Try pip in case a wheel is available;
+    # silently skip if not. Worker still functions without it.
+    ./.venv/bin/pip install --quiet libtorrent 2>/dev/null || \
+        warn "libtorrent python bindings not available — torrent model mesh disabled (worker still functional)"
+}
+
+# Install the worker daemon as a system service INSIDE the worker LXC, where
+# we always run as root (so no sudo / no $USER gymnastics — unlike
+# install_linux_systemd_system which targets the bare-host legacy path).
+install_worker_service_root() {
+    local unit="/etc/systemd/system/tinyagentos-worker.service"
+
+    # Deploy helper so the controller can manage backends in the nested incus.
+    local helper_src="$INSTALL_DIR/tinyagentos/scripts/taos-deploy-helper.sh"
+    if [[ -f "$helper_src" ]]; then
+        cp "$helper_src" /usr/local/bin/taos-deploy-helper
+        chmod 755 /usr/local/bin/taos-deploy-helper
+        log "installed /usr/local/bin/taos-deploy-helper"
+    else
+        warn "deploy helper not found at $helper_src — remote backend deployment will not work"
+    fi
+
+    cat > "$unit" <<EOF
+[Unit]
+Description=TinyAgentOS Worker
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=$INSTALL_DIR
+ExecStart=$INSTALL_DIR/.venv/bin/python -m tinyagentos.worker $CONTROLLER_URL --name $WORKER_NAME
+Restart=always
+RestartSec=5
+Environment=PYTHONUNBUFFERED=1
+Environment=TAOS_WORKER_STATE_DIR=$INSTALL_DIR/.taos-worker-state
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    log "installed $unit (worker LXC system unit, runs as root)"
+    systemctl daemon-reload
+    systemctl enable --now tinyagentos-worker
+    log "worker daemon running inside LXC as system service"
+    log "logs: incus exec taos-worker -- journalctl -u tinyagentos-worker -f"
+}
+
 # --- phase 2: nested incus + bees + register (runs inside worker LXC) -----
 
 phase2_inside_lxc() {
     log "phase 2: nested incus + bees + register"
 
-    # 1. Nested incus + bees
+    # 1. Nested incus + bees + worker runtime deps (the LXC is a fresh,
+    #    minimal Ubuntu image, so python3/venv/git are not present yet).
     apt update -y
-    apt install -y incus curl
+    apt install -y incus curl python3 python3-venv python3-pip git
     # bees is not packaged in Ubuntu 24.04; install if available, otherwise
     # the bees service setup below is skipped (TAOS_NO_DEDUP behaviour).
     local bees_installed=0
@@ -619,9 +710,20 @@ BEESEOF
     fi
     export TAOS_HOST_LAN_IP="$host_lan_ip"
 
-    # 4. Register with controller (reuse existing function from the rest of
+    # 4. Clone the repo + build the python venv INSIDE the LXC. The shared
+    #    clone/venv block at the foot of this script only runs on the macOS /
+    #    non-phased path, so the worker-LXC phase needs its own runtime: both
+    #    pairing (install_and_enroll_incus, below) and the worker daemon
+    #    invoke $INSTALL_DIR/.venv/bin/python.
+    clone_or_update_repo
+    setup_python_venv
+
+    # 5. Register with controller (reuse existing function from the rest of
     #    install-worker.sh; it does POST /api/cluster/workers + /incus-enroll).
     install_and_enroll_incus
+
+    # 6. Install + start the worker daemon as a system service inside the LXC.
+    install_worker_service_root
 }
 
 # --- phase 1 entry-point --------------------------------------------------
@@ -1075,48 +1177,13 @@ EOF
 # directory to work with. install_taos_ollama then drops its bundled
 # Ollama into $INSTALL_DIR/backends/ollama inside the cloned repo.
 
-if [[ ! -d "$INSTALL_DIR/.git" ]]; then
-    log "cloning $REPO into $INSTALL_DIR"
-    mkdir -p "$(dirname "$INSTALL_DIR")"
-    # If INSTALL_DIR already exists but isn't a git repo (e.g. a previous
-    # partial install), move it aside so the clone can proceed.
-    if [[ -d "$INSTALL_DIR" ]]; then
-        mv "$INSTALL_DIR" "${INSTALL_DIR}.old.$(date +%s)"
-    fi
-    git clone --depth 1 --branch "$BRANCH" "$REPO" "$INSTALL_DIR"
-else
-    log "updating existing checkout"
-    (cd "$INSTALL_DIR" && git fetch --depth 1 origin "$BRANCH" && git reset --hard "origin/$BRANCH")
-fi
-
-cd "$INSTALL_DIR"
+clone_or_update_repo
 
 install_taos_ollama
 
 # --- python venv + worker-only deps --------------------------------------
 
-if [[ ! -d .venv ]]; then
-    log "creating venv"
-    python3 -m venv .venv
-fi
-
-log "installing worker python deps into .venv"
-./.venv/bin/pip install --quiet --upgrade pip
-./.venv/bin/pip install --quiet \
-    httpx \
-    pydantic \
-    psutil \
-    fastapi \
-    uvicorn \
-    pyyaml \
-    pillow
-
-# libtorrent is optional (only used for model torrent mesh). It isn't on
-# PyPI as a wheel for most platforms — it ships as the distro's
-# libtorrent-rasterbar package. Try pip in case a wheel is available;
-# silently skip if not. Worker still functions without it.
-./.venv/bin/pip install --quiet libtorrent 2>/dev/null || \
-    warn "libtorrent python bindings not available — torrent model mesh disabled (worker still functional)"
+setup_python_venv
 
 # --- first-boot benchmark -----------------------------------------------
 

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -324,6 +324,22 @@ setup_port_forward() {
 
 reexec_into_worker_lxc() {
     log "re-execing install-worker.sh inside taos-worker for phase 2"
+
+    # The advertised incus URL the controller enrols MUST be an address the
+    # controller can reach. Inside the LXC the only detectable source address
+    # toward the controller is the NAT'd incusbr0 IP (e.g. 10.x), which is
+    # private to this host. The reachable address is the bare host's own LAN
+    # IP — the nftables rule in setup_port_forward DNATs <host>:8443 to the
+    # LXC. That IP is only knowable here on the host, so detect it and pass it
+    # into phase 2 as TAOS_ADVERTISE_IP.
+    local advertise_ip _ctrl_host
+    _ctrl_host="$(printf '%s' "$CONTROLLER_URL" | sed 's|^[^/]*/*/||; s|[:/].*||')"
+    if [[ -n "$_ctrl_host" ]] && command -v ip >/dev/null 2>&1; then
+        advertise_ip="$(ip -4 route get "$_ctrl_host" 2>/dev/null \
+            | awk '/src/{for(i=1;i<=NF;i++) if($i=="src") print $(i+1)}')"
+    fi
+    [[ -z "$advertise_ip" ]] && advertise_ip="$(hostname -I 2>/dev/null | awk '{print $1}')"
+
     # </dev/null on `incus exec` so the inner bash doesn't pull from
     # the outer curl pipe — same root cause as the storage/launch fixes
     # in this file.
@@ -332,6 +348,8 @@ reexec_into_worker_lxc() {
         export TAOS_INSIDE_WORKER=1
         export TAOS_CONTROLLER_URL='${CONTROLLER_URL}'
         export TAOS_WORKER_NAME='${WORKER_NAME}'
+        export TAOS_BRANCH='${BRANCH}'
+        export TAOS_ADVERTISE_IP='${advertise_ip}'
         curl -sL '${REPO}/raw/${BRANCH}/scripts/install-worker.sh' | bash -s -- '${CONTROLLER_URL}'
     " </dev/null
 }
@@ -479,9 +497,16 @@ install_and_enroll_incus() {
     # controller, so we don't accidentally pick up docker0 / incusbr0 /
     # Tailscale addresses that the controller can't reach back on.
     local LAN_IP=""
+    # Inside the worker LXC, the kernel's source address toward the controller
+    # is the NAT'd incusbr0 IP, which the controller cannot reach. Phase 1
+    # passes the bare host's reachable LAN IP as TAOS_ADVERTISE_IP (DNAT'd to
+    # this LXC by setup_port_forward), so prefer it when present.
+    if [[ -n "${TAOS_ADVERTISE_IP:-}" ]]; then
+        LAN_IP="$TAOS_ADVERTISE_IP"
+    fi
     local _ctrl_host
     _ctrl_host="$(printf '%s' "$CONTROLLER_URL" | sed 's|^[^/]*/*/||; s|[:/].*||')"
-    if [[ -n "$_ctrl_host" ]] && command -v ip >/dev/null 2>&1; then
+    if [[ -z "$LAN_IP" && -n "$_ctrl_host" ]] && command -v ip >/dev/null 2>&1; then
         LAN_IP="$(ip -4 route get "$_ctrl_host" 2>/dev/null \
             | awk '/src/{for(i=1;i<=NF;i++) if($i=="src") print $(i+1)}')"
     fi

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -594,7 +594,11 @@ clone_or_update_repo() {
         git clone --depth 1 --branch "$BRANCH" "$REPO" "$INSTALL_DIR"
     else
         log "updating existing checkout"
-        (cd "$INSTALL_DIR" && git fetch --depth 1 origin "$BRANCH" && git reset --hard "origin/$BRANCH")
+        # A shallow single-branch fetch only moves FETCH_HEAD; it does not
+        # create/update an origin/<branch> ref, so reset to FETCH_HEAD (the
+        # just-fetched tip) rather than a remote-tracking name that may not
+        # exist. This is what makes a re-run ("re-run to resume") idempotent.
+        (cd "$INSTALL_DIR" && git fetch --depth 1 origin "$BRANCH" && git reset --hard FETCH_HEAD)
     fi
     cd "$INSTALL_DIR"
 }

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -636,7 +636,7 @@ install_worker_service_root() {
     local unit="/etc/systemd/system/tinyagentos-worker.service"
 
     # Deploy helper so the controller can manage backends in the nested incus.
-    local helper_src="$INSTALL_DIR/tinyagentos/scripts/taos-deploy-helper.sh"
+    local helper_src="$INSTALL_DIR/scripts/taos-deploy-helper.sh"
     if [[ -f "$helper_src" ]]; then
         cp "$helper_src" /usr/local/bin/taos-deploy-helper
         chmod 755 /usr/local/bin/taos-deploy-helper
@@ -1266,7 +1266,7 @@ install_deploy_helper() {
     local sudo_cmd=""
     if [[ "$(id -u)" != "0" ]]; then sudo_cmd="sudo"; fi
 
-    local helper_src="$INSTALL_DIR/tinyagentos/scripts/taos-deploy-helper.sh"
+    local helper_src="$INSTALL_DIR/scripts/taos-deploy-helper.sh"
     local helper_dst="/usr/local/bin/taos-deploy-helper"
 
     if [[ -f "$helper_src" ]]; then

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -671,7 +671,11 @@ WantedBy=multi-user.target
 EOF
     log "installed $unit (worker LXC system unit, runs as root)"
     systemctl daemon-reload
-    systemctl enable --now tinyagentos-worker
+    systemctl enable tinyagentos-worker
+    # restart (not just enable --now): on a re-run the service is already
+    # active, and enable --now will not reload a rewritten unit — so a changed
+    # ExecStart/Environment (e.g. TAOS_ADVERTISE_IP) would never take effect.
+    systemctl restart tinyagentos-worker
     log "worker daemon running inside LXC as system service"
     log "logs: incus exec taos-worker -- journalctl -u tinyagentos-worker -f"
 }

--- a/tests/test_routes_cluster.py
+++ b/tests/test_routes_cluster.py
@@ -325,20 +325,58 @@ async def test_kv_quant_options_mixed_cluster(client, app):
 # incus-enroll endpoint
 # ---------------------------------------------------------------------------
 
+async def _signed_enroll(client, key, name, incus_url, token):
+    """POST a HMAC-signed incus-enroll request the way the worker does."""
+    import json as _json
+    path = f"/api/cluster/workers/{name}/incus-enroll"
+    body = _json.dumps({"incus_url": incus_url, "token": token}).encode()
+    headers = {
+        **sign_worker_request(key, name, "POST", path, body),
+        "content-type": "application/json",
+    }
+    return await client.post(path, content=body, headers=headers)
+
+
 @pytest.mark.asyncio
-async def test_incus_enroll_worker_not_registered(client):
-    """404 when the worker has never registered."""
+async def test_incus_enroll_unsigned_rejected(client):
+    """No HMAC headers -> 401 before the worker is even looked up."""
     resp = await client.post(
         "/api/cluster/workers/ghost-worker/incus-enroll",
         json={"incus_url": "https://10.0.0.5:8443", "token": "abc123"},
     )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_incus_enroll_worker_not_registered(client, app):
+    """404 when the worker is paired (so the request is signable) but never registered."""
+    key = await pair_worker(client, app, "ghost-worker", "https://10.0.0.5:9000")
+    resp = await _signed_enroll(client, key, "ghost-worker", "https://10.0.0.5:8443", "abc123")
     assert resp.status_code == 404
     assert "not registered" in resp.json()["error"]
+    await app.state.cluster_pairing.close()
+
+
+@pytest.mark.asyncio
+async def test_incus_enroll_name_mismatch_rejected(client, app):
+    """A worker signing for a different worker's name -> 403."""
+    key = await pair_worker(client, app, "worker-a", "https://10.0.0.7:9000")
+    # Sign for worker-a but POST to worker-b's enroll path.
+    import json as _json
+    path = "/api/cluster/workers/worker-b/incus-enroll"
+    body = _json.dumps({"incus_url": "https://10.0.0.7:8443", "token": "t"}).encode()
+    headers = {
+        **sign_worker_request(key, "worker-a", "POST", path, body),
+        "content-type": "application/json",
+    }
+    resp = await client.post(path, content=body, headers=headers)
+    assert resp.status_code == 403
+    await app.state.cluster_pairing.close()
 
 
 @pytest.mark.asyncio
 async def test_incus_enroll_success(client, app):
-    """Happy path: worker registered then incus-enroll called with right args -> 200."""
+    """Happy path: paired + registered worker signs the enroll -> 200."""
     import json as _json
     key = await pair_worker(client, app, "pi-worker", "http://10.0.0.5:9000")
     reg_body = _json.dumps({"name": "pi-worker", "url": "http://10.0.0.5:9000"}).encode()
@@ -349,10 +387,7 @@ async def test_incus_enroll_success(client, app):
 
     mock_remote_add = AsyncMock(return_value={"success": True, "output": ""})
     with patch("tinyagentos.containers.remote_add", mock_remote_add):
-        resp = await client.post(
-            "/api/cluster/workers/pi-worker/incus-enroll",
-            json={"incus_url": "https://10.0.0.5:8443", "token": "tok-xyz"},
-        )
+        resp = await _signed_enroll(client, key, "pi-worker", "https://10.0.0.5:8443", "tok-xyz")
 
     assert resp.status_code == 200
     assert resp.json() == {"ok": True}
@@ -378,10 +413,7 @@ async def test_incus_enroll_remote_add_failure(client, app):
         "output": "certificate rejected",
     })
     with patch("tinyagentos.containers.remote_add", mock_remote_add):
-        resp = await client.post(
-            "/api/cluster/workers/flaky-worker/incus-enroll",
-            json={"incus_url": "https://10.0.0.6:8443", "token": "bad-tok"},
-        )
+        resp = await _signed_enroll(client, key, "flaky-worker", "https://10.0.0.6:8443", "bad-tok")
 
     assert resp.status_code == 500
     data = resp.json()

--- a/tests/test_routes_cluster.py
+++ b/tests/test_routes_cluster.py
@@ -392,7 +392,7 @@ async def test_incus_enroll_success(client, app):
     assert resp.status_code == 200
     assert resp.json() == {"ok": True}
     mock_remote_add.assert_awaited_once_with(
-        "pi-worker", "https://10.0.0.5:8443", "tok-xyz"
+        "pi-worker", "https://10.0.0.5:8443", token="tok-xyz"
     )
     await app.state.cluster_pairing.close()
 

--- a/tests/worker/test_advertise_ip.py
+++ b/tests/worker/test_advertise_ip.py
@@ -7,6 +7,7 @@ instead, or the controller stores an unreachable URL and the incus
 host-match (enrollment) fails.
 """
 import json
+from typing import ClassVar
 
 import pytest
 
@@ -24,7 +25,7 @@ class _CaptureResponse:
 class _CaptureClient:
     """Minimal async httpx.AsyncClient stand-in that records the POST body."""
 
-    captured = {}
+    captured: ClassVar[dict] = {}
 
     def __init__(self, *a, **k):
         pass

--- a/tests/worker/test_advertise_ip.py
+++ b/tests/worker/test_advertise_ip.py
@@ -1,0 +1,68 @@
+"""TAOS_ADVERTISE_IP overrides the worker's advertised URL + host_lan_ip.
+
+Inside a worker LXC the only locally-detectable address is the NAT'd
+incusbr0 IP, which the controller cannot reach. The installer passes the
+bare-host LAN IP as TAOS_ADVERTISE_IP; register() must advertise that
+instead, or the controller stores an unreachable URL and the incus
+host-match (enrollment) fails.
+"""
+import json
+
+import pytest
+
+
+class _CaptureResponse:
+    status_code = 200
+
+    def json(self):
+        return {"status": "registered"}
+
+    def raise_for_status(self):
+        return None
+
+
+class _CaptureClient:
+    """Minimal async httpx.AsyncClient stand-in that records the POST body."""
+
+    captured = {}
+
+    def __init__(self, *a, **k):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def post(self, url, content=None, headers=None):
+        _CaptureClient.captured = {"url": url, "body": json.loads(content)}
+        return _CaptureResponse()
+
+
+@pytest.mark.asyncio
+async def test_register_prefers_advertise_ip(monkeypatch):
+    from tinyagentos.worker import agent as agent_mod
+
+    monkeypatch.setenv("TAOS_ADVERTISE_IP", "192.168.6.108")
+    # Avoid touching disk/network for the heavy detection helpers.
+    monkeypatch.setattr(agent_mod.WorkerAgent, "detect_backends",
+                        lambda self: _aval([]))
+    monkeypatch.setattr("tinyagentos.worker.pairing.load_signing_key",
+                        lambda state_dir: b"k" * 32)
+    monkeypatch.setattr(agent_mod, "_detect_lan_ip", lambda url: "10.228.114.210")
+    monkeypatch.setattr(agent_mod.httpx, "AsyncClient", _CaptureClient)
+
+    a = agent_mod.WorkerAgent("http://192.168.6.123:6969", name="fedora-worker")
+    result = await a.register()
+
+    assert result is True
+    body = _CaptureClient.captured["body"]
+    # Both the advertised URL host and host_lan_ip must be the bare-host IP,
+    # NOT the LXC-internal 10.x that _detect_lan_ip returns.
+    assert body["url"] == "http://192.168.6.108"
+    assert body["host_lan_ip"] == "192.168.6.108"
+
+
+async def _aval(v):
+    return v

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -99,6 +99,7 @@ def _is_exempt(method: str, path: str) -> bool:
       POST /api/cluster/pairing/claim         — unauthenticated, code is proof
       GET  /api/cluster/workers               — public worker list
       POST /api/cluster/workers               — session-exempt, HMAC gate at route level
+      POST /api/cluster/workers/{n}/incus-enroll — session-exempt, HMAC gate at route level
       POST /api/cluster/heartbeat             — session-exempt, HMAC gate at route level
     """
     if path in EXEMPT_PATHS or any(path.startswith(p) for p in EXEMPT_PREFIXES):
@@ -125,6 +126,14 @@ def _is_exempt(method: str, path: str) -> bool:
     if method == "POST" and path == _CLUSTER_WORKERS:
         return True
     if method == "POST" and path == _CLUSTER_HEARTBEAT:
+        return True
+    # POST /api/cluster/workers/<name>/incus-enroll — session-exempt; the route
+    # verifies the worker's HMAC signature (see tinyagentos.worker.enroll).
+    if (
+        method == "POST"
+        and path.startswith(_CLUSTER_WORKERS + "/")
+        and path.endswith("/incus-enroll")
+    ):
         return True
     return False
 

--- a/tinyagentos/routes/cluster.py
+++ b/tinyagentos/routes/cluster.py
@@ -792,7 +792,7 @@ async def incus_enroll(request: Request, name: str, body: IncusEnrollRequest):
         return JSONResponse({"error": f"invalid incus_url: {exc}"}, status_code=400)
 
     try:
-        result = await containers.remote_add(name, body.incus_url, body.token)
+        result = await containers.remote_add(name, body.incus_url, token=body.token)
     except Exception as exc:
         return JSONResponse({"ok": False, "error": str(exc)}, status_code=500)
 

--- a/tinyagentos/routes/cluster.py
+++ b/tinyagentos/routes/cluster.py
@@ -749,7 +749,22 @@ async def incus_enroll(request: Request, name: str, body: IncusEnrollRequest):
 
     Returns ``{"ok": true}`` on success or ``{"ok": false, "error": "..."}`` on
     failure. 404 when the worker is not yet registered.
+
+    HMAC-gated like register/heartbeat: the worker signs the request with its
+    pairing key (see tinyagentos.worker.enroll), so an unauthenticated caller
+    cannot enrol an arbitrary incus remote.
     """
+    # HMAC gate — only the paired worker may enrol its own incus daemon.
+    try:
+        await require_worker_hmac(request)
+    except _HMACError as exc:
+        return exc.response
+    if getattr(request.state, "hmac_worker_name", None) != name:
+        return JSONResponse(
+            {"error": "Worker name in header does not match path"},
+            status_code=403,
+        )
+
     from urllib.parse import urlparse
     import tinyagentos.containers as containers
 

--- a/tinyagentos/worker/agent.py
+++ b/tinyagentos/worker/agent.py
@@ -405,9 +405,14 @@ class WorkerAgent:
         # (DNAT'd to the LXC), so honour it for both the advertised URL and the
         # host_lan_ip used to match the incus remote to this worker.
         adv_ip = os.environ.get("TAOS_ADVERTISE_IP", "").strip()
+        # Mirror get_worker_url's port handling: include the worker_port when set
+        # so the controller stores a reachable host:port (not a bare host).
+        adv_url = None
+        if adv_ip:
+            adv_url = f"http://{adv_ip}:{self.worker_port}" if self.worker_port else f"http://{adv_ip}"
         worker_url = (
             self.advertise_url
-            or (f"http://{adv_ip}" if adv_ip else None)
+            or adv_url
             or (backends[0]["url"] if backends else self.get_worker_url())
         )
 

--- a/tinyagentos/worker/agent.py
+++ b/tinyagentos/worker/agent.py
@@ -399,12 +399,22 @@ class WorkerAgent:
         kv_quant = self.detect_kv_quant_support(backends)
 
         # Use pinned advertise_url if provided; otherwise infer from backends or LAN IP.
-        worker_url = self.advertise_url or (backends[0]["url"] if backends else self.get_worker_url())
+        # TAOS_ADVERTISE_IP is set by the worker-LXC installer: inside the LXC the
+        # only locally-detectable address is the NAT'd incusbr0 IP, which the
+        # controller cannot reach. The reachable address is the bare host's LAN IP
+        # (DNAT'd to the LXC), so honour it for both the advertised URL and the
+        # host_lan_ip used to match the incus remote to this worker.
+        adv_ip = os.environ.get("TAOS_ADVERTISE_IP", "").strip()
+        worker_url = (
+            self.advertise_url
+            or (f"http://{adv_ip}" if adv_ip else None)
+            or (backends[0]["url"] if backends else self.get_worker_url())
+        )
 
         payload = {
             "name": self.name,
             "url": worker_url,
-            "host_lan_ip": _detect_lan_ip(self.controller_url),
+            "host_lan_ip": adv_ip or _detect_lan_ip(self.controller_url),
             "hardware": asdict(hw),
             "backends": backends,
             "capabilities": caps,

--- a/tinyagentos/worker/enroll.py
+++ b/tinyagentos/worker/enroll.py
@@ -1,0 +1,79 @@
+"""Signed incus-enrollment for a paired worker.
+
+After pairing persists the HMAC signing key, the installer enrols the
+worker's nested incus daemon with the controller so the controller can
+deploy agent containers into it. That endpoint is HMAC-gated like
+``POST /api/cluster/workers`` and ``/api/cluster/heartbeat``, so the
+request must be signed with the worker's signing key — which is why this
+lives in Python, not the installer's shell (crypto stays out of bash).
+
+Usage (called by install-worker.sh):
+    python -m tinyagentos.worker.enroll <controller_url> \\
+        --name <name> --incus-url <url> --token <trust_token> \\
+        [--state-dir DIR]
+
+Exit codes:
+    0  enrolled
+    1  enrollment error (not paired, network, controller rejection)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Enrol this worker's incus daemon with a taOS controller"
+    )
+    parser.add_argument("controller", help="Controller URL, e.g. http://192.168.1.10:6969")
+    parser.add_argument("--name", required=True, help="Worker name (must match registration)")
+    parser.add_argument("--incus-url", required=True, help="This worker's incus HTTPS URL")
+    parser.add_argument("--token", required=True, help="incus trust token for the controller")
+    parser.add_argument("--state-dir", type=Path, default=None,
+                        help="Directory holding the signing key (default: system default)")
+    args = parser.parse_args()
+
+    import httpx
+    from tinyagentos.worker.pairing import (
+        default_state_dir,
+        load_signing_key,
+        sign_request_headers,
+    )
+
+    controller = args.controller.rstrip("/")
+    state_dir = args.state_dir or default_state_dir()
+    key = load_signing_key(state_dir)
+    if key is None:
+        print(
+            f"[enroll] not paired: no signing key at {state_dir}; pair the worker first",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    path = f"/api/cluster/workers/{args.name}/incus-enroll"
+    body = json.dumps({"incus_url": args.incus_url, "token": args.token}).encode()
+    headers = sign_request_headers(key, args.name, "POST", path, body)
+    headers["content-type"] = "application/json"
+
+    try:
+        resp = httpx.post(f"{controller}{path}", content=body, headers=headers, timeout=30)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[enroll] request failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if resp.status_code // 100 == 2:
+        print(f"[enroll] worker incus enrolled with controller (HTTP {resp.status_code})")
+        sys.exit(0)
+
+    print(
+        f"[enroll] enrollment rejected (HTTP {resp.status_code}): {resp.text[:300]}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The worker-LXC install path (worker runs one privileged `taos-worker` LXC with nested incus; agent containers live inside) was never exercised end-to-end on Linux — the clone/venv/service/enroll tail only ran on the macOS/non-phased path. Adding the Fedora box as a cluster worker surfaced a chain of bugs; this branch fixes all of them so an agent can be deployed onto a worker.

## Fixes (each verified live on a Fedora x64 worker against the Pi controller)
1. **Runtime bootstrap** — phase 2 inside the LXC never cloned the repo or built the venv, yet pairing + the daemon both invoke `$INSTALL_DIR/.venv/bin/python`. Extracted `clone_or_update_repo`/`setup_python_venv` (macOS path now calls them, behaviour-preserving) and wired them + a root-context service install into `phase2_inside_lxc`.
2. **Advertise IP** — the LXC advertised its NAT'd incusbr0 IP, unreachable from the controller. Phase 1 now passes the bare-host LAN IP as `TAOS_ADVERTISE_IP`; the installer pairing/enroll and the daemon both use it.
3. **Re-clone idempotency** — `reset --hard origin/$BRANCH` after a shallow fetch aborted under `set -e`; now `FETCH_HEAD`.
4. **Deploy-helper path** — looked under `tinyagentos/scripts/` instead of `scripts/`.
5. **State-dir mismatch** — pair.py saved the signing key where the daemon didn't read it (`TAOS_WORKER_STATE_DIR`); pass `--state-dir`.
6. **incus-enroll auth** — endpoint was session-gated, so the worker's request got 401. Now HMAC-gated like register/heartbeat: middleware-exempt + `require_worker_hmac` at the route + new `tinyagentos.worker.enroll` signs the request.
7. **Daemon advertise** — register/heartbeat re-clobbered the host IP with the LXC IP every beat; `register()` now honours `TAOS_ADVERTISE_IP`.

## Tests
- `tests/test_routes_cluster.py`: incus-enroll now unsigned-reject (401), name-mismatch (403), not-registered (404, paired), success, remote-add-failure — all signed.
- `tests/worker/test_advertise_ip.py`: register prefers `TAOS_ADVERTISE_IP` for url + host_lan_ip.
- Full cluster/worker/pairing suites green (216+21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Worker registration now honors `TAOS_ADVERTISE_IP` to advertise a controller-reachable IP for enrollment payloads.
  * Added a dedicated worker enrollment command that performs a signed Incus-enroll request with optional persisted state.

* **Bug Fixes**
  * Incus-enroll requests are now HMAC-authenticated and validated against the target worker name (mismatches/invalid signatures are rejected).
  * Worker installer phase handling and state directory passing were improved for more reliable pairing/enrollment.

* **Tests**
  * Added coverage for `TAOS_ADVERTISE_IP` behavior and negative-path HMAC/enrollment scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->