### PR TITLE
feat: deploy agents onto cluster workers (remote deploy, #176/#150)

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -699,11 +699,15 @@ phase2_inside_lxc() {
         warn "  to enable later: apt install bees && systemctl enable --now bees.service"
     fi
 
-    # Gate init on a storage pool existing, NOT on `incus list` succeeding:
-    # `incus list` returns 0 even on a fresh daemon with no storage pool and an
-    # empty default profile, which would skip init and leave the nested incus
-    # unable to create agent containers ("No root device could be found").
-    if incus storage list --format csv 2>/dev/null | grep -q .; then
+    # Gate init on the default storage pool existing, NOT on `incus list`
+    # succeeding: `incus list` returns 0 even on a fresh daemon with no storage
+    # pool and an empty default profile, which would skip init and leave the
+    # nested incus unable to create agent containers ("No root device could be
+    # found"). Match the pool name exactly, as create_btrfs_loopback does at the
+    # host level: `--format=csv` still emits a header row on some incus builds,
+    # so a bare `grep -q .` matches the header and wrongly skips init on a fresh
+    # daemon. `incus admin init --minimal` creates a pool named `default`.
+    if incus storage list --format=csv 2>/dev/null | awk -F',' '{print $1}' | grep -q '^default$'; then
         log "nested incus already initialised"
     else
         incus admin init --minimal < /dev/null

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -699,7 +699,11 @@ phase2_inside_lxc() {
         warn "  to enable later: apt install bees && systemctl enable --now bees.service"
     fi
 
-    if incus list >/dev/null 2>&1; then
+    # Gate init on a storage pool existing, NOT on `incus list` succeeding:
+    # `incus list` returns 0 even on a fresh daemon with no storage pool and an
+    # empty default profile, which would skip init and leave the nested incus
+    # unable to create agent containers ("No root device could be found").
+    if incus storage list --format csv 2>/dev/null | grep -q .; then
         log "nested incus already initialised"
     else
         incus admin init --minimal < /dev/null

--- a/tests/test_agent_image.py
+++ b/tests/test_agent_image.py
@@ -141,6 +141,39 @@ class TestEnsureImagePresent:
         incus_proc.communicate.assert_awaited()
 
     @pytest.mark.asyncio
+    async def test_imports_to_remote_qualifies_target_and_skips_bake(self):
+        """remote= imports onto the worker's nested incus and skips the
+        local-only script bake."""
+        curl_proc = _fake_proc(0, b"")
+        incus_proc = _fake_proc(0, b"Image imported with fingerprint abc\n")
+        launched = []
+
+        async def _launch(*args, **kwargs):
+            launched.append(args)
+            if args and args[0] == "curl":
+                return curl_proc
+            return incus_proc
+
+        baked = []
+        with patch(
+            "tinyagentos.agent_image.is_image_present", new=AsyncMock(return_value=False)
+        ), patch("asyncio.create_subprocess_exec", new=_launch), patch(
+            "tinyagentos.agent_image._bake_scripts_into_image",
+            new=AsyncMock(side_effect=lambda *a, **k: baked.append(a)),
+        ):
+            ok = await ensure_image_present(
+                alias="taos-hermes-base",
+                url="http://example.test/img.tar.gz",
+                remote="fedora-worker",
+            )
+        assert ok is True
+        incus_args = [a for a in launched if a and a[0] == "incus"][0]
+        assert "fedora-worker:" in incus_args
+        assert "--alias" in incus_args and "taos-hermes-base" in incus_args
+        # The bake is a local-incus operation; it must NOT run for a remote import.
+        assert baked == []
+
+    @pytest.mark.asyncio
     async def test_returns_false_when_incus_import_fails(self):
         curl_proc = _fake_proc(0, b"")
         incus_proc = _fake_proc(1, b"import failed")

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -82,6 +82,38 @@ class TestCreateContainer:
             result = await create_container("taos-agent-test")
             assert result["success"] is False
 
+    @pytest.mark.asyncio
+    async def test_remote_qualifies_image_and_target_and_skips_mounts(self):
+        """remote= creates on the worker: image + instance name are
+        <remote>:-qualified and host bind mounts are skipped."""
+        calls = []
+
+        async def mock_run(cmd, timeout=120):
+            calls.append(cmd)
+            return (0, "")
+
+        with patch("tinyagentos.containers._run", side_effect=mock_run):
+            result = await create_container(
+                "taos-agent-bob",
+                image="taos-hermes-base",
+                env={"FOO": "bar"},
+                mounts=[("/host/path", "/ctr/path")],
+                root_size_gib=None,
+                remote="fedora-worker",
+            )
+        assert result["success"] is True
+        assert result["remote"] == "fedora-worker"
+        # launch references the remote-qualified image + instance.
+        launch = calls[0]
+        assert launch[:2] == ["incus", "launch"]
+        assert launch[2] == "fedora-worker:taos-hermes-base"
+        assert launch[3] == "fedora-worker:taos-agent-bob"
+        # env is set against the remote-qualified target.
+        env_calls = [c for c in calls if "environment.FOO=bar" in c]
+        assert env_calls and env_calls[0][3] == "fedora-worker:taos-agent-bob"
+        # No bind-mount device was added (host paths don't exist on the worker).
+        assert not [c for c in calls if "disk" in c and "taos-mount-0" in c]
+
 
 class TestSetRootQuota:
     @pytest.mark.asyncio

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -114,6 +114,27 @@ class TestCreateContainer:
         # No bind-mount device was added (host paths don't exist on the worker).
         assert not [c for c in calls if "disk" in c and "taos-mount-0" in c]
 
+    @pytest.mark.asyncio
+    async def test_remote_does_not_double_qualify_image_server_ref(self):
+        """A remote-image-server ref (cold fallback) keeps its own remote and is
+        NOT prefixed with the worker remote, else incus rejects it."""
+        calls = []
+
+        async def mock_run(cmd, timeout=120):
+            calls.append(cmd)
+            return (0, "")
+
+        with patch("tinyagentos.containers._run", side_effect=mock_run):
+            await create_container(
+                "taos-agent-bob",
+                image="images:debian/bookworm",
+                root_size_gib=None,
+                remote="fedora-worker",
+            )
+        launch = calls[0]
+        assert launch[2] == "images:debian/bookworm"
+        assert launch[3] == "fedora-worker:taos-agent-bob"
+
 
 class TestSetRootQuota:
     @pytest.mark.asyncio

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -113,6 +113,8 @@ class TestCreateContainer:
         assert env_calls and env_calls[0][3] == "fedora-worker:taos-agent-bob"
         # No bind-mount device was added (host paths don't exist on the worker).
         assert not [c for c in calls if "disk" in c and "taos-mount-0" in c]
+        # raw.idmap (a local trace-mount concern) must NOT be set for a remote create.
+        assert not [c for c in calls if "raw.idmap" in c]
 
     @pytest.mark.asyncio
     async def test_remote_does_not_double_qualify_image_server_ref(self):

--- a/tests/test_deployer.py
+++ b/tests/test_deployer.py
@@ -47,6 +47,40 @@ class TestDeployAgent:
             assert env["TAOS_SKILLS_URL"].endswith("/api/skill-exec")
 
     @pytest.mark.asyncio
+    async def test_remote_deploy_targets_worker_and_skips_proxy(self, tmp_path):
+        """remote= creates on the worker, qualifies downstream incus ops with
+        <remote>:, skips the localhost proxy devices, and keeps the record name
+        unqualified."""
+        req = _req(data_dir=tmp_path, remote="fedora-worker", taos_host="100.78.225.80")
+        exec_names = []
+
+        async def mock_exec(name, cmd, **kwargs):
+            exec_names.append(name)
+            if "hostname -I" in " ".join(cmd):
+                return (0, "10.228.0.9")
+            return (0, "ok")
+
+        with patch("tinyagentos.deployer.create_container", new_callable=AsyncMock) as mock_create, \
+             patch("tinyagentos.deployer.exec_in_container", side_effect=mock_exec), \
+             patch("tinyagentos.deployer.push_file", new_callable=AsyncMock, return_value=(0, "")), \
+             patch("tinyagentos.deployer.add_proxy_device", new_callable=AsyncMock) as mock_proxy:
+            mock_create.return_value = {"success": True, "name": "taos-agent-test"}
+
+            result = await deploy_agent(req)
+            assert result["success"] is True
+            # Record name stays unqualified.
+            assert result["container"] == "taos-agent-test"
+            # create_container was told to target the remote.
+            assert mock_create.call_args.kwargs["remote"] == "fedora-worker"
+            # Proxy devices are localhost-only; never attached for a remote deploy.
+            mock_proxy.assert_not_awaited()
+            # Downstream incus ops are qualified with the remote.
+            assert exec_names and all(n.startswith("fedora-worker:") for n in exec_names)
+            # The agent's callback host is the controller's Tailscale IP.
+            env = mock_create.call_args.kwargs["env"]
+            assert "100.78.225.80" in env["TAOS_BRIDGE_URL"]
+
+    @pytest.mark.asyncio
     async def test_one_trace_bind_mount(self, tmp_path):
         """After deploy, create_container receives exactly one mount: the trace dir."""
         req = _req(data_dir=tmp_path)
@@ -1252,7 +1286,7 @@ class TestFrameworkAwareBaseImage:
                 return (0, "10.0.0.7")
             return (0, "ok")
 
-        async def fake_present(alias):
+        async def fake_present(alias, remote=None):
             return alias in present_aliases
 
         with patch("tinyagentos.deployer.create_container", new_callable=AsyncMock) as mock_create, \

--- a/tests/test_deployer.py
+++ b/tests/test_deployer.py
@@ -79,6 +79,10 @@ class TestDeployAgent:
             # The agent's callback host is the controller's Tailscale IP.
             env = mock_create.call_args.kwargs["env"]
             assert "100.78.225.80" in env["TAOS_BRIDGE_URL"]
+            # The LiteLLM base must target the controller over the network for a
+            # remote deploy, never the container's own loopback (no proxy device).
+            assert "100.78.225.80" in env["OPENAI_BASE_URL"]
+            assert "127.0.0.1" not in env["OPENAI_BASE_URL"]
 
     @pytest.mark.asyncio
     async def test_one_trace_bind_mount(self, tmp_path):

--- a/tests/test_routes_agent_deploy.py
+++ b/tests/test_routes_agent_deploy.py
@@ -225,8 +225,11 @@ class TestResolveDeployRouting:
         assert "worker-b" in body["available_on"]
 
     @pytest.mark.asyncio
-    async def test_model_routed_to_pinned_worker_returns_202(self, client):
-        """A model on a worker with a valid pin returns 202."""
+    async def test_pinned_worker_falls_through_to_remote_deploy(self, client):
+        """An explicit, non-conflicting pin no longer 202-stubs; it attempts a
+        remote deploy. When the pinned worker is not a registered online cluster
+        worker (as here), configure_remote_deploy returns 409 'not registered'
+        rather than the old routed-stub 202."""
         with patch(
             "tinyagentos.cluster.model_resolver.resolve_model_location",
             return_value=ModelLocation(
@@ -243,10 +246,8 @@ class TestResolveDeployRouting:
                     "target_worker": "worker-b",
                 },
             )
-        assert r.status_code == 202
-        body = r.json()
-        assert body["status"] == "routed"
-        assert body["worker"] == "worker-b"
+        assert r.status_code == 409
+        assert "not registered" in r.json()["error"]
 
     @pytest.mark.asyncio
     async def test_pinned_worker_without_model_returns_409(self, client):
@@ -401,3 +402,59 @@ class TestArchiveSmokeCheck:
             if r.status_code == 200:
                 body = r.json()
                 assert body.get("archive_smoke_ok") is False
+
+
+@pytest.mark.asyncio
+class TestConfigureRemoteDeploy:
+    """Direct unit tests for agent_deploy.configure_remote_deploy."""
+
+    @staticmethod
+    def _req(worker=None):
+        from types import SimpleNamespace
+        cm = SimpleNamespace(get_worker=lambda name: worker)
+        return SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(cluster_manager=cm)))
+
+    @staticmethod
+    def _body(**kw):
+        from types import SimpleNamespace
+        defaults = dict(target_worker=None, framework="none", name="a")
+        defaults.update(kw)
+        return SimpleNamespace(**defaults)
+
+    async def test_no_pin_is_local(self):
+        from tinyagentos.routes import agent_deploy
+        remote, host, err = await agent_deploy.configure_remote_deploy(
+            self._req(), self._body()
+        )
+        assert remote is None and host == "127.0.0.1" and err is None
+
+    async def test_unknown_worker_409(self):
+        from tinyagentos.routes import agent_deploy
+        remote, host, err = await agent_deploy.configure_remote_deploy(
+            self._req(worker=None), self._body(target_worker="ghost")
+        )
+        assert remote is None and err is not None and err.status_code == 409
+
+    async def test_offline_worker_409(self):
+        from types import SimpleNamespace
+        from tinyagentos.routes import agent_deploy
+        worker = SimpleNamespace(status="offline", hardware={"arch": "x86_64"})
+        remote, host, err = await agent_deploy.configure_remote_deploy(
+            self._req(worker=worker), self._body(target_worker="w")
+        )
+        assert remote is None and err.status_code == 409
+
+    async def test_online_worker_returns_remote_and_prefetches(self):
+        from types import SimpleNamespace
+        from tinyagentos.routes import agent_deploy
+        worker = SimpleNamespace(status="online", hardware={"arch": "x86_64"})
+        with patch.object(agent_deploy, "controller_callback_host", return_value="100.78.225.80"), \
+             patch("tinyagentos.agent_image.ensure_image_present", new=AsyncMock(return_value=True)) as mock_prefetch:
+            remote, host, err = await agent_deploy.configure_remote_deploy(
+                self._req(worker=worker), self._body(target_worker="fedora-worker", framework="hermes")
+            )
+        assert err is None
+        assert remote == "fedora-worker"
+        assert host == "100.78.225.80"
+        # The x64 base was prefetched onto the worker.
+        assert mock_prefetch.await_args.kwargs.get("remote") == "fedora-worker"

--- a/tests/test_routes_agent_deploy.py
+++ b/tests/test_routes_agent_deploy.py
@@ -485,3 +485,14 @@ class TestConfigureRemoteDeploy:
         assert mock_prefetch.await_args.kwargs.get("remote") == "fedora-worker"
         # x86_64 maps to the x64 base tarball.
         assert "x64" in mock_prefetch.await_args.kwargs.get("url", "")
+
+
+@pytest.mark.asyncio
+async def test_controller_callback_host_env_override(monkeypatch):
+    """TAOS_CONTROLLER_CALLBACK_HOST takes precedence over tailscale/LAN."""
+    from types import SimpleNamespace
+    from tinyagentos.routes import agent_deploy
+    monkeypatch.setenv("TAOS_CONTROLLER_CALLBACK_HOST", "192.168.6.123")
+    req = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace()))
+    host = await agent_deploy.controller_callback_host(req)
+    assert host == "192.168.6.123"

--- a/tests/test_routes_agent_deploy.py
+++ b/tests/test_routes_agent_deploy.py
@@ -444,17 +444,44 @@ class TestConfigureRemoteDeploy:
         )
         assert remote is None and err.status_code == 409
 
-    async def test_online_worker_returns_remote_and_prefetches(self):
+    async def test_online_worker_returns_remote_and_callback_host(self):
         from types import SimpleNamespace
         from tinyagentos.routes import agent_deploy
         worker = SimpleNamespace(status="online", hardware={"arch": "x86_64"})
-        with patch.object(agent_deploy, "controller_callback_host", return_value="100.78.225.80"), \
-             patch("tinyagentos.agent_image.ensure_image_present", new=AsyncMock(return_value=True)) as mock_prefetch:
+        with patch.object(
+            agent_deploy, "controller_callback_host",
+            new=AsyncMock(return_value="100.78.225.80"),
+        ):
             remote, host, err = await agent_deploy.configure_remote_deploy(
                 self._req(worker=worker), self._body(target_worker="fedora-worker", framework="hermes")
             )
         assert err is None
         assert remote == "fedora-worker"
         assert host == "100.78.225.80"
-        # The x64 base was prefetched onto the worker.
+
+    async def test_online_worker_no_callback_host_500(self):
+        """A remote deploy with no reachable controller address must hard-fail,
+        not silently start an unreachable agent on 127.0.0.1."""
+        from types import SimpleNamespace
+        from tinyagentos.routes import agent_deploy
+        worker = SimpleNamespace(status="online", hardware={"arch": "x86_64"})
+        with patch.object(
+            agent_deploy, "controller_callback_host", new=AsyncMock(return_value=None),
+        ):
+            remote, host, err = await agent_deploy.configure_remote_deploy(
+                self._req(worker=worker), self._body(target_worker="fedora-worker", framework="hermes")
+            )
+        assert remote is None
+        assert err is not None and err.status_code == 500
+
+    async def test_prefetch_base_onto_worker_imports_correct_arch(self):
+        from types import SimpleNamespace
+        from tinyagentos.routes import agent_deploy
+        worker = SimpleNamespace(status="online", hardware={"arch": "x86_64"})
+        with patch("tinyagentos.agent_image.ensure_image_present", new=AsyncMock(return_value=True)) as mock_prefetch:
+            await agent_deploy.prefetch_base_onto_worker(
+                self._req(worker=worker), self._body(target_worker="fedora-worker", framework="hermes")
+            )
         assert mock_prefetch.await_args.kwargs.get("remote") == "fedora-worker"
+        # x86_64 maps to the x64 base tarball.
+        assert "x64" in mock_prefetch.await_args.kwargs.get("url", "")

--- a/tests/test_routes_agents.py
+++ b/tests/test_routes_agents.py
@@ -134,7 +134,12 @@ class TestDeployRouting:
         config = app.state.config
         assert not any(a["name"] == "routed-agent" for a in config.agents)
 
-    async def test_worker_hosted_model_pinned_to_holder_routes(self, client, app):
+    async def test_worker_hosted_model_pinned_to_holder_deploys_remote(self, client, app):
+        # Pin-wins: a pin to the worker that holds the model now falls through
+        # routing and schedules a remote deploy on that worker, rather than
+        # returning a 202 routing stub. With a reachable controller callback
+        # host configured, configure_remote_deploy accepts the request.
+        app.state.controller_lan_ip = "10.0.0.5"
         _seed_worker(app, "fedora", ["qwen2.5-7b"])
         _seed_worker(app, "arch-box", ["phi3"])
         resp = await client.post("/api/agents/deploy", json={
@@ -143,9 +148,10 @@ class TestDeployRouting:
             "model": "qwen2.5-7b",
             "target_worker": "fedora",
         })
-        assert resp.status_code == 202
+        assert resp.status_code == 200
         data = resp.json()
-        assert data["worker"] == "fedora"
+        assert data["status"] == "deploying"
+        assert data["name"] == "pinned-ok"
 
     async def test_worker_hosted_model_pinned_to_wrong_worker_rejects_409(self, client, app):
         _seed_worker(app, "fedora", ["qwen2.5-7b"])

--- a/tinyagentos/agent_image.py
+++ b/tinyagentos/agent_image.py
@@ -154,19 +154,22 @@ def all_base_image_aliases() -> list[str]:
     return aliases
 
 
-async def is_image_present(alias: str = BASE_IMAGE_ALIAS) -> bool:
-    """Return True iff incus already has an image with this alias locally.
+async def is_image_present(alias: str = BASE_IMAGE_ALIAS, remote: str | None = None) -> bool:
+    """Return True iff incus already has an image with this alias.
 
-    Uses ``incus image list --format=csv -c f --filter=alias=<alias>`` and
-    checks the output has any non-empty row. Any failure (incus not
-    installed, daemon down) returns False — the caller will fall back to
-    the uncached deploy path.
+    Uses ``incus image list --format=csv -c f <alias>`` and checks the output
+    has any non-empty row. ``remote`` (e.g. ``"fedora-worker"``) checks an
+    enrolled remote's nested incus instead of the local one. Any failure
+    (incus not installed, daemon down) returns False -- the caller will fall
+    back to the uncached deploy path.
     """
+    args = ["incus", "image", "list", "--format=csv", "-c", "f"]
+    if remote:
+        args.append(f"{remote}:")
+    args.append(alias)
     try:
         proc = await asyncio.create_subprocess_exec(
-            "incus", "image", "list",
-            "--format=csv", "-c", "f",
-            alias,
+            *args,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
         )
@@ -241,6 +244,7 @@ async def _bake_scripts_into_image(alias: str) -> None:
 async def ensure_image_present(
     alias: str = BASE_IMAGE_ALIAS,
     url: str | None = None,
+    remote: str | None = None,
 ) -> bool:
     """Import the base image from ``url`` if not already present.
 
@@ -259,7 +263,7 @@ async def ensure_image_present(
     temp dir so it lands on the same filesystem as /var/tmp and can be
     imported without extra copying.
     """
-    if await is_image_present(alias):
+    if await is_image_present(alias, remote=remote):
         return True
     # Derive the URL from the alias so a non-openclaw alias never imports the
     # openclaw tarball (an explicit url still wins for tests / overrides).
@@ -298,9 +302,13 @@ async def ensure_image_present(
             _prefetch_state["status"] = "failed"
             return False
         _prefetch_state["status"] = "importing"
+        import_args = ["incus", "image", "import", tmp_path]
+        if remote:
+            import_args.append(f"{remote}:")
+        import_args += ["--alias", alias]
         try:
             incus = await asyncio.create_subprocess_exec(
-                "incus", "image", "import", tmp_path, "--alias", alias,
+                *import_args,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
             )
@@ -316,8 +324,13 @@ async def ensure_image_present(
             )
             _prefetch_state["status"] = "failed"
             return False
-        logger.info("agent_image: %s imported OK", alias)
-        await _bake_scripts_into_image(alias)
+        logger.info("agent_image: %s imported OK%s", alias, f" on {remote}" if remote else "")
+        # The bake launches a temp container on the LOCAL incus to inject the
+        # taos-framework-update helper, so it only applies to local imports.
+        # On a remote the prefetched base is used as-is (the helper is
+        # non-essential and can be baked on the worker separately if needed).
+        if not remote:
+            await _bake_scripts_into_image(alias)
         _prefetch_state["status"] = "done"
         return True
     except Exception as exc:  # pragma: no cover - defensive

--- a/tinyagentos/containers/__init__.py
+++ b/tinyagentos/containers/__init__.py
@@ -269,7 +269,12 @@ async def create_container(
     if code != 0:
         return {"success": False, "error": output}
 
-    if host_uid is not None:
+    # raw.idmap maps container-root to a host UID so the trace bind-mount is
+    # writable. It is meaningless for a remote create (the host_uid is the
+    # CONTROLLER's, not the worker's, and the bind-mount is skipped anyway); a
+    # cross-host UID with no subuid mapping on the worker stops the container
+    # from starting. Skip it for remote.
+    if host_uid is not None and not remote:
         await _run([
             "incus", "config", "set", target, "raw.idmap",
             f"both {host_uid} 0",

--- a/tinyagentos/containers/__init__.py
+++ b/tinyagentos/containers/__init__.py
@@ -254,7 +254,14 @@ async def create_container(
     # Qualify image + instance name for the target remote. The prefetched base
     # alias lives on the remote, so the image ref is also remote-qualified.
     target = f"{remote}:{name}" if remote else name
-    image_ref = f"{remote}:{image}" if remote else image
+    # A bare local alias (e.g. "taos-hermes-base", prefetched onto the remote)
+    # is remote-qualified; a remote-image-server ref (e.g.
+    # "images:debian/bookworm", the cold fallback) already names its own source
+    # and must NOT be prefixed, or incus rejects "<remote>:images:debian/...".
+    if remote and ":" not in image:
+        image_ref = f"{remote}:{image}"
+    else:
+        image_ref = image
 
     code, output = await _run(
         ["incus", "launch", image_ref, target], timeout=300,

--- a/tinyagentos/containers/__init__.py
+++ b/tinyagentos/containers/__init__.py
@@ -228,6 +228,7 @@ async def create_container(
     env: dict[str, str] | None = None,
     host_uid: int | None = None,
     root_size_gib: int | None = None,
+    remote: str | None = None,
 ) -> dict:
     """Create and start a new LXC container with mounts and env injected.
 
@@ -241,51 +242,68 @@ async def create_container(
     ``root_size_gib``: when provided, apply a rootfs disk quota via
     ``set_root_quota`` after launch. Enforced on btrfs/ZFS pools;
     accounting-only on dir-backed pools.
+
+    ``remote``: when set (e.g. ``"fedora-worker"``), the container is created
+    on that enrolled incus remote's nested incus instead of locally. The base
+    image must already exist on the remote (prefetched there); both the image
+    ref and the instance name are qualified with ``<remote>:``. Bind mounts are
+    skipped for a remote create — the host paths do not exist on the worker;
+    the agent reaches the controller over the network (Tailscale) instead.
     """
     import asyncio as _asyncio
+    # Qualify image + instance name for the target remote. The prefetched base
+    # alias lives on the remote, so the image ref is also remote-qualified.
+    target = f"{remote}:{name}" if remote else name
+    image_ref = f"{remote}:{image}" if remote else image
+
     code, output = await _run(
-        ["incus", "launch", image, name], timeout=300,
+        ["incus", "launch", image_ref, target], timeout=300,
     )
     if code != 0:
         return {"success": False, "error": output}
 
     if host_uid is not None:
         await _run([
-            "incus", "config", "set", name, "raw.idmap",
+            "incus", "config", "set", target, "raw.idmap",
             f"both {host_uid} 0",
         ])
-        await _run(["incus", "stop", name, "--force"])
-        await _run(["incus", "start", name])
+        await _run(["incus", "stop", target, "--force"])
+        await _run(["incus", "start", target])
         await _asyncio.sleep(3)
 
     # Root quota — set before mounts/env so subsequent writes are subject to limit.
     if root_size_gib is not None:
-        quota_result = await set_root_quota(name, root_size_gib)
+        quota_result = await set_root_quota(target, root_size_gib)
         if not quota_result["success"]:
             logger.warning(
                 "create_container: root quota not applied for %s: %s",
-                name, quota_result.get("note", ""),
+                target, quota_result.get("note", ""),
             )
 
     if memory_limit is not None:
-        await _run(["incus", "config", "set", name, "limits.memory", memory_limit])
+        await _run(["incus", "config", "set", target, "limits.memory", memory_limit])
     if cpu_limit is not None:
-        await _run(["incus", "config", "set", name, "limits.cpu", str(cpu_limit)])
-    for idx, (host_path, container_path) in enumerate(mounts or []):
-        device_name = f"taos-mount-{idx}"
-        mcode, mout = await _run([
-            "incus", "config", "device", "add", name, device_name, "disk",
-            f"source={host_path}", f"path={container_path}",
-        ])
-        if mcode != 0:
-            logger.error(f"incus mount {host_path}->{container_path} failed: {mout}")
+        await _run(["incus", "config", "set", target, "limits.cpu", str(cpu_limit)])
+    # Bind mounts map host paths into the container; they only make sense for a
+    # local create. A remote worker has no access to the controller's filesystem.
+    if remote and mounts:
+        logger.info("create_container: skipping %d bind mount(s) for remote %s", len(mounts), remote)
+    elif not remote:
+        for idx, (host_path, container_path) in enumerate(mounts or []):
+            device_name = f"taos-mount-{idx}"
+            mcode, mout = await _run([
+                "incus", "config", "device", "add", target, device_name, "disk",
+                f"source={host_path}", f"path={container_path}",
+            ])
+            if mcode != 0:
+                logger.error(f"incus mount {host_path}->{container_path} failed: {mout}")
     for key, value in (env or {}).items():
         ecode, eout = await _run([
-            "incus", "config", "set", name, f"environment.{key}={value}",
+            "incus", "config", "set", target, f"environment.{key}={value}",
         ])
         if ecode != 0:
             logger.error(f"incus env set {key} failed: {eout}")
-    return {"success": True, "name": name}
+    return {"success": True, "name": name, "remote": remote}
 
 
 async def exec_in_container(name: str, cmd: list[str], timeout: int = 300) -> tuple[int, str]:

--- a/tinyagentos/deployer.py
+++ b/tinyagentos/deployer.py
@@ -276,10 +276,19 @@ async def deploy_agent(req: DeployRequest) -> dict:
             env["LITELLM_API_KEY"] = llm_key
             # Compat shim — smolagents and other frameworks still expect OPENAI_API_KEY.
             env["OPENAI_API_KEY"] = llm_key
-            env["OPENAI_BASE_URL"] = f"{proxy.url}/v1"
+            # A local deploy reaches LiteLLM via the proxy device on the
+            # container's own 127.0.0.1; a remote worker has no proxy device, so
+            # it reaches the controller's LiteLLM over the network at taos_host
+            # (the controller's Tailscale IP) on the host's LiteLLM port.
+            if req.remote:
+                _llm_port = getattr(proxy, "port", None) or 7834
+                _llm_base = f"http://{req.taos_host}:{_llm_port}"
+            else:
+                _llm_base = proxy.url
+            env["OPENAI_BASE_URL"] = f"{_llm_base}/v1"
             # Host-side embedding endpoint — same LiteLLM process,
             # OpenAI-compatible /v1/embeddings. Framework-agnostic.
-            env["TAOS_EMBEDDING_URL"] = f"{proxy.url}/v1/embeddings"
+            env["TAOS_EMBEDDING_URL"] = f"{_llm_base}/v1/embeddings"
             # Stable alias the host LiteLLM routes to whichever
             # concrete embedding model the backends actually have loaded.
             env["TAOS_EMBEDDING_MODEL"] = EMBEDDING_ALIAS
@@ -326,9 +335,14 @@ async def deploy_agent(req: DeployRequest) -> dict:
     # /root/.openclaw/openclaw.json and /root/.openclaw/env inside the container
     # from these env vars. Bridge URL is how the openclaw service phones home.
     env["TAOS_BRIDGE_URL"] = f"http://{req.taos_host}:{req.taos_port}"
-    # OPENAI_BASE_URL defaults to LiteLLM proxy if no llm_proxy in config.
+    # OPENAI_BASE_URL defaults to LiteLLM proxy if no llm_proxy in config. A
+    # remote deploy must target the controller over the network, not the
+    # container's own loopback (there is no proxy device on a worker).
     if "OPENAI_BASE_URL" not in env:
-        env["OPENAI_BASE_URL"] = "http://127.0.0.1:4000/v1"
+        if req.remote:
+            env["OPENAI_BASE_URL"] = f"http://{req.taos_host}:7834/v1"
+        else:
+            env["OPENAI_BASE_URL"] = "http://127.0.0.1:4000/v1"
     if "OPENAI_API_KEY" not in env:
         env["OPENAI_API_KEY"] = ""
     if "LITELLM_API_KEY" not in env:

--- a/tinyagentos/deployer.py
+++ b/tinyagentos/deployer.py
@@ -150,6 +150,12 @@ class DeployRequest:
     # 127.0.0.1 on the host.
     taos_host: str = "127.0.0.1"
     taos_port: int = 6969
+    # When set (e.g. "fedora-worker"), the agent container is created on that
+    # enrolled incus remote's nested incus instead of locally. The caller must
+    # also set taos_host to an address the worker can reach the controller on
+    # (its Tailscale IP), since the localhost proxy devices are not used for a
+    # remote deploy.
+    remote: str | None = None
     # Per §10.10: default 40 GiB rootfs quota. Overridable per-agent at
     # deploy time. None disables quota (unlimited, e.g. for dev/test).
     root_size_gib: int = 40
@@ -391,7 +397,7 @@ async def deploy_agent(req: DeployRequest) -> dict:
             candidates.append(GENERIC_BASE_ALIAS)
         for alias in candidates:
             try:
-                present = await is_image_present(alias)
+                present = await is_image_present(alias, remote=req.remote)
             except Exception:
                 present = False
             if present:
@@ -419,10 +425,18 @@ async def deploy_agent(req: DeployRequest) -> dict:
         # this host UID so the trace bind-mount is writable by the container.
         host_uid=os.getuid(),
         root_size_gib=req.root_size_gib,
+        remote=req.remote,
     )
     if not result["success"]:
         return {"success": False, "error": _explain_container_failure(result.get("error")), "steps": steps}
     steps.append("container_created")
+
+    # Keep the bare name for the agent record, then qualify container_name with
+    # the remote so every downstream incus op (exec/push/destroy) targets the
+    # worker's nested incus. Local deploys leave it unchanged.
+    record_container = container_name
+    if req.remote:
+        container_name = f"{req.remote}:{container_name}"
 
     try:
         # Incus proxy devices: let the container reach host services via
@@ -435,25 +449,30 @@ async def deploy_agent(req: DeployRequest) -> dict:
         # The connect side tracks the live proxy port so the tunnel reaches the
         # right host process regardless of whether the operator kept the legacy
         # 4000 or migrated to 7834.
-        llm_proxy_ref = (req.extra_config or {}).get("llm_proxy")
-        litellm_host_port = getattr(llm_proxy_ref, "port", None) or 7834
-        proxy_devices = [
-            ("taos-proxy-litellm", 4000, litellm_host_port),
-            ("taos-proxy-taos", req.taos_port, req.taos_port),
-        ]
-        for dev_name, listen_port, connect_port in proxy_devices:
-            res = await add_proxy_device(
-                container_name,
-                dev_name,
-                listen=f"tcp:127.0.0.1:{listen_port}",
-                connect=f"tcp:127.0.0.1:{connect_port}",
-                bind_mode="instance",
-            )
-            if not res.get("success"):
-                raise RuntimeError(
-                    f"failed to attach proxy device {dev_name}: {res.get('output', '')}"
+        # Proxy devices map the container's 127.0.0.1 to host services. They
+        # only work for a LOCAL deploy; a remote worker reaches the controller
+        # directly over the network (taos_host is the controller's Tailscale IP
+        # for a remote deploy), so skip them.
+        if not req.remote:
+            llm_proxy_ref = (req.extra_config or {}).get("llm_proxy")
+            litellm_host_port = getattr(llm_proxy_ref, "port", None) or 7834
+            proxy_devices = [
+                ("taos-proxy-litellm", 4000, litellm_host_port),
+                ("taos-proxy-taos", req.taos_port, req.taos_port),
+            ]
+            for dev_name, listen_port, connect_port in proxy_devices:
+                res = await add_proxy_device(
+                    container_name,
+                    dev_name,
+                    listen=f"tcp:127.0.0.1:{listen_port}",
+                    connect=f"tcp:127.0.0.1:{connect_port}",
+                    bind_mode="instance",
                 )
-        steps.append("proxy_devices_attached")
+                if not res.get("success"):
+                    raise RuntimeError(
+                        f"failed to attach proxy device {dev_name}: {res.get('output', '')}"
+                    )
+            steps.append("proxy_devices_attached")
 
         # Step 2: Wait for network
         for _ in range(10):
@@ -604,7 +623,7 @@ async def deploy_agent(req: DeployRequest) -> dict:
         return {
             "success": True,
             "name": req.name,
-            "container": container_name,
+            "container": record_container,
             "ip": container_ip,
             "llm_key": llm_key,
             "steps": steps,

--- a/tinyagentos/routes/agent_deploy.py
+++ b/tinyagentos/routes/agent_deploy.py
@@ -105,8 +105,6 @@ def resolve_deploy_routing(request: Request, body: "DeployAgentRequest") -> "JSO
                     status_code=409,
                 )
 
-            # Cases 3 + 4: route to the worker that holds the model.
-            # Phase 1.5 will actually instruct the worker to launch; for
             # Explicit, non-conflicting worker pin: fall through to the deploy
             # path, which now actually creates the agent container ON that
             # worker's nested incus (see configure_remote_deploy + the deployer
@@ -140,29 +138,36 @@ def resolve_deploy_routing(request: Request, body: "DeployAgentRequest") -> "JSO
     return None
 
 
-def controller_callback_host(request: Request) -> str:
+async def controller_callback_host(request: Request) -> str | None:
     """Return the address a remote worker should use to reach this controller.
 
     Per the cluster networking model (manual Tailscale, headscale not yet
     configured for taOSgo), the agent container on a worker reaches the
-    controller over the tailnet, so prefer the controller's Tailscale IP.
-    Falls back to the host LAN IP, then 127.0.0.1 (which only works for a
-    local deploy).
+    controller over the tailnet, so prefer the controller's Tailscale IP, then
+    the configured host LAN IP. Returns None when neither is available -- a
+    remote deploy must NOT silently fall back to 127.0.0.1 (the worker's own
+    loopback, where the controller is not listening).
     """
+    import asyncio
     import subprocess
 
     try:
-        out = subprocess.run(
-            ["tailscale", "ip", "-4"], capture_output=True, text=True, timeout=5
+        # Shell out off the event loop so a cold/hanging tailscale never stalls
+        # the FastAPI worker for other requests.
+        out = await asyncio.to_thread(
+            subprocess.run,
+            ["tailscale", "ip", "-4"],
+            capture_output=True,
+            text=True,
+            timeout=5,
         )
         ip = (out.stdout or "").strip().splitlines()
         if out.returncode == 0 and ip and ip[0].strip():
             return ip[0].strip()
-    except (FileNotFoundError, subprocess.TimeoutExpired, Exception):  # noqa: BLE001
+    except Exception:  # noqa: BLE001
         pass
     # Fall back to the LAN address the controller advertises, if known.
-    lan = getattr(request.app.state, "controller_lan_ip", None)
-    return lan or "127.0.0.1"
+    return getattr(request.app.state, "controller_lan_ip", None)
 
 
 def _worker_arch_suffix(worker) -> str:
@@ -185,12 +190,13 @@ async def configure_remote_deploy(request: Request, body: "DeployAgentRequest"):
       - remote: the worker name to create the container on, or None for a
         normal controller-local deploy.
       - taos_host: the address the agent uses to call back to the controller.
-      - error_response: a JSONResponse to short-circuit on (e.g. the pinned
-        worker is unknown or offline), or None.
+      - error_response: a JSONResponse to short-circuit on (the pinned worker
+        is unknown/offline, or the controller has no address the worker could
+        reach it on), or None.
 
-    When a valid online worker is pinned, this also best-effort prefetches the
-    correct-arch base image onto that worker's nested incus so the deploy can
-    clone instead of cold-installing.
+    The base-image prefetch is NOT done here -- it would block the deploy
+    request on a ~300-500MB download. Call prefetch_base_onto_worker from the
+    background deploy task instead.
     """
     if not body.target_worker:
         return None, "127.0.0.1", None
@@ -208,29 +214,54 @@ async def configure_remote_deploy(request: Request, body: "DeployAgentRequest"):
             status_code=409,
         )
 
-    taos_host = controller_callback_host(request)
-
-    # Best-effort: prefetch the framework's base image onto the worker so the
-    # deploy clones it instead of running the slow apt path. A failure here is
-    # non-fatal -- the deployer falls back to the cold install.
-    if body.framework and body.framework != "none":
-        try:
-            from tinyagentos.agent_image import (
-                base_image_alias,
-                base_image_url_for_alias,
-                ensure_image_present,
-            )
-
-            alias = base_image_alias(body.framework)
-            url = base_image_url_for_alias(alias, _worker_arch_suffix(worker))
-            await ensure_image_present(alias, url=url, remote=body.target_worker)
-        except Exception:  # noqa: BLE001
-            logger.exception(
-                "remote prefetch of base image for %s onto %s failed (non-fatal)",
-                body.framework, body.target_worker,
-            )
+    taos_host = await controller_callback_host(request)
+    if not taos_host:
+        # A remote agent that can't reach the controller would install and then
+        # silently fail to phone home (bridge, skills, traces, memory). Refuse
+        # rather than start an unreachable agent.
+        return None, "127.0.0.1", JSONResponse(
+            {
+                "error": (
+                    "cannot derive a controller address the worker can reach "
+                    "(no Tailscale IP and no controller_lan_ip configured); "
+                    "remote deploy aborted"
+                )
+            },
+            status_code=500,
+        )
 
     return body.target_worker, taos_host, None
+
+
+async def prefetch_base_onto_worker(request: Request, body: "DeployAgentRequest") -> None:
+    """Best-effort: import the framework's correct-arch base image onto the
+    pinned worker's nested incus so the deploy clones it instead of cold-installing.
+
+    Call this from the BACKGROUND deploy task -- it can download ~300-500MB and
+    must never block the deploy HTTP request. Any failure is non-fatal: the
+    deployer falls back to the cold apt path when the alias is absent.
+    """
+    if not body.target_worker or not body.framework or body.framework == "none":
+        return
+    cm = getattr(request.app.state, "cluster_manager", None)
+    worker = cm.get_worker(body.target_worker) if cm is not None else None
+    if worker is None:
+        return
+    try:
+        from tinyagentos.agent_image import (
+            base_image_alias,
+            base_image_url_for_alias,
+            ensure_image_present,
+        )
+
+        alias = base_image_alias(body.framework)
+        url = base_image_url_for_alias(alias, _worker_arch_suffix(worker))
+        await ensure_image_present(alias, url=url, remote=body.target_worker)
+    except Exception:  # noqa: BLE001
+        logger.exception(
+            "remote prefetch of base image for %s onto %s failed (non-fatal)",
+            body.framework, body.target_worker,
+        )
 
 
 async def archive_smoke_check(request: Request, unique_slug: str, framework: str) -> bool:

--- a/tinyagentos/routes/agent_deploy.py
+++ b/tinyagentos/routes/agent_deploy.py
@@ -173,7 +173,7 @@ async def controller_callback_host(request: Request) -> str | None:
         if out.returncode == 0 and ip and ip[0].strip():
             return ip[0].strip()
     except Exception:  # noqa: BLE001
-        pass
+        logger.debug("tailscale ip lookup failed; falling back to controller_lan_ip", exc_info=True)
     # Fall back to the LAN address the controller advertises, if known.
     return getattr(request.app.state, "controller_lan_ip", None)
 

--- a/tinyagentos/routes/agent_deploy.py
+++ b/tinyagentos/routes/agent_deploy.py
@@ -107,12 +107,19 @@ def resolve_deploy_routing(request: Request, body: "DeployAgentRequest") -> "JSO
 
             # Cases 3 + 4: route to the worker that holds the model.
             # Phase 1.5 will actually instruct the worker to launch; for
-            # now we return a 202 naming the destination so the caller
-            # knows where the agent needs to land. Deliberately do NOT
-            # add a local agent entry — a ghost entry on the controller
-            # for an agent that lives on Fedora would confuse both the
-            # UI and the LXC bulk-ops endpoints.
-            chosen = body.target_worker or location.canonical_host
+            # Explicit, non-conflicting worker pin: fall through to the deploy
+            # path, which now actually creates the agent container ON that
+            # worker's nested incus (see configure_remote_deploy + the deployer
+            # remote= path). Returning None lets deploy_agent_endpoint handle it.
+            if body.target_worker:
+                return None
+
+            # No pin, worker-hosted model: auto-placement onto the worker that
+            # holds the model is not implemented yet, so return a 202 naming the
+            # destination. Deliberately do NOT add a local agent entry -- a ghost
+            # entry on the controller for an agent that lives on a worker would
+            # confuse both the UI and the LXC bulk-ops endpoints.
+            chosen = location.canonical_host
             return JSONResponse(
                 {
                     "status": "routed",
@@ -122,8 +129,8 @@ def resolve_deploy_routing(request: Request, body: "DeployAgentRequest") -> "JSO
                     "available_on": location.hosts,
                     "message": (
                         f"model '{body.model}' lives on worker '{chosen}'. "
-                        f"Routed deploy target only — remote launch lands "
-                        f"with Phase 1.5 network model placement."
+                        f"Pin a target_worker to deploy there now, or wait for "
+                        f"auto-placement."
                     ),
                 },
                 status_code=202,
@@ -131,6 +138,99 @@ def resolve_deploy_routing(request: Request, body: "DeployAgentRequest") -> "JSO
         # kind == "controller" or "cloud": fall through to the unchanged
         # controller-local deploy path below.
     return None
+
+
+def controller_callback_host(request: Request) -> str:
+    """Return the address a remote worker should use to reach this controller.
+
+    Per the cluster networking model (manual Tailscale, headscale not yet
+    configured for taOSgo), the agent container on a worker reaches the
+    controller over the tailnet, so prefer the controller's Tailscale IP.
+    Falls back to the host LAN IP, then 127.0.0.1 (which only works for a
+    local deploy).
+    """
+    import subprocess
+
+    try:
+        out = subprocess.run(
+            ["tailscale", "ip", "-4"], capture_output=True, text=True, timeout=5
+        )
+        ip = (out.stdout or "").strip().splitlines()
+        if out.returncode == 0 and ip and ip[0].strip():
+            return ip[0].strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired, Exception):  # noqa: BLE001
+        pass
+    # Fall back to the LAN address the controller advertises, if known.
+    lan = getattr(request.app.state, "controller_lan_ip", None)
+    return lan or "127.0.0.1"
+
+
+def _worker_arch_suffix(worker) -> str:
+    """Map a worker's reported hardware arch to the base-image arch suffix."""
+    hw = getattr(worker, "hardware", None) or {}
+    arch = str(hw.get("arch") or hw.get("machine") or "").lower()
+    if arch in ("x86_64", "amd64", "x64"):
+        return "x64"
+    if arch in ("aarch64", "arm64"):
+        return "arm64"
+    # Unknown: default to x64 (the common worker case); a wrong guess just
+    # means the prefetch 404s and the deploy falls back to the apt path.
+    return "x64"
+
+
+async def configure_remote_deploy(request: Request, body: "DeployAgentRequest"):
+    """Resolve an explicit target_worker pin into a remote-deploy config.
+
+    Returns ``(remote, taos_host, error_response)``:
+      - remote: the worker name to create the container on, or None for a
+        normal controller-local deploy.
+      - taos_host: the address the agent uses to call back to the controller.
+      - error_response: a JSONResponse to short-circuit on (e.g. the pinned
+        worker is unknown or offline), or None.
+
+    When a valid online worker is pinned, this also best-effort prefetches the
+    correct-arch base image onto that worker's nested incus so the deploy can
+    clone instead of cold-installing.
+    """
+    if not body.target_worker:
+        return None, "127.0.0.1", None
+
+    cm = getattr(request.app.state, "cluster_manager", None)
+    worker = cm.get_worker(body.target_worker) if cm is not None else None
+    if worker is None:
+        return None, "127.0.0.1", JSONResponse(
+            {"error": f"worker '{body.target_worker}' is not registered"},
+            status_code=409,
+        )
+    if getattr(worker, "status", "offline") != "online":
+        return None, "127.0.0.1", JSONResponse(
+            {"error": f"worker '{body.target_worker}' is not online"},
+            status_code=409,
+        )
+
+    taos_host = controller_callback_host(request)
+
+    # Best-effort: prefetch the framework's base image onto the worker so the
+    # deploy clones it instead of running the slow apt path. A failure here is
+    # non-fatal -- the deployer falls back to the cold install.
+    if body.framework and body.framework != "none":
+        try:
+            from tinyagentos.agent_image import (
+                base_image_alias,
+                base_image_url_for_alias,
+                ensure_image_present,
+            )
+
+            alias = base_image_alias(body.framework)
+            url = base_image_url_for_alias(alias, _worker_arch_suffix(worker))
+            await ensure_image_present(alias, url=url, remote=body.target_worker)
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "remote prefetch of base image for %s onto %s failed (non-fatal)",
+                body.framework, body.target_worker,
+            )
+
+    return body.target_worker, taos_host, None
 
 
 async def archive_smoke_check(request: Request, unique_slug: str, framework: str) -> bool:

--- a/tinyagentos/routes/agent_deploy.py
+++ b/tinyagentos/routes/agent_deploy.py
@@ -141,15 +141,23 @@ def resolve_deploy_routing(request: Request, body: "DeployAgentRequest") -> "JSO
 async def controller_callback_host(request: Request) -> str | None:
     """Return the address a remote worker should use to reach this controller.
 
-    Per the cluster networking model (manual Tailscale, headscale not yet
-    configured for taOSgo), the agent container on a worker reaches the
-    controller over the tailnet, so prefer the controller's Tailscale IP, then
-    the configured host LAN IP. Returns None when neither is available -- a
-    remote deploy must NOT silently fall back to 127.0.0.1 (the worker's own
-    loopback, where the controller is not listening).
+    Resolution order:
+      1. TAOS_CONTROLLER_CALLBACK_HOST -- explicit operator override. Set this
+         when the worker reaches the controller on a specific address, e.g. the
+         controller's LAN IP for a bridged worker on the same LAN.
+      2. The controller's Tailscale IP (the manual-Tailscale worker path).
+      3. The configured host LAN IP (request.app.state.controller_lan_ip).
+    Returns None when none is available -- a remote deploy must NOT silently
+    fall back to 127.0.0.1 (the worker's own loopback, where the controller is
+    not listening).
     """
     import asyncio
+    import os
     import subprocess
+
+    override = os.environ.get("TAOS_CONTROLLER_CALLBACK_HOST", "").strip()
+    if override:
+        return override
 
     try:
         # Shell out off the event loop so a cold/hanging tailscale never stalls

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -490,6 +490,15 @@ async def deploy_agent_endpoint(request: Request, body: DeployAgentRequest):
                 idempotency_cache.set(scoped_key, json.loads(routed.body))
             return routed
 
+        # Explicit target_worker pin: create the agent container ON that
+        # worker's nested incus (remote deploy) rather than locally. Resolves
+        # the controller callback host (Tailscale IP) and prefetches the base.
+        deploy_remote, deploy_taos_host, remote_err = await agent_deploy.configure_remote_deploy(request, body)
+        if remote_err is not None:
+            if scoped_key and idempotency_cache is not None:
+                idempotency_cache.set(scoped_key, json.loads(remote_err.body))
+            return remote_err
+
         # Register the agent with taosmd BEFORE mutating config so a failure
         # here aborts cleanly with no half-state.
         try:
@@ -575,6 +584,8 @@ async def deploy_agent_endpoint(request: Request, body: DeployAgentRequest):
                     },
                     can_read_user_memory=body.can_read_user_memory,
                     secrets_store=secrets_store,
+                    remote=deploy_remote,
+                    taos_host=deploy_taos_host,
                 ))
                 agent = find_agent(config, body.name)
                 if result.get("success"):

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -569,6 +569,10 @@ async def deploy_agent_endpoint(request: Request, body: DeployAgentRequest):
 
         async def _background_deploy():
             try:
+                # Prefetch the base onto the worker here (not in the request
+                # path) so a cold ~300-500MB import never blocks POST /deploy.
+                if deploy_remote:
+                    await agent_deploy.prefetch_base_onto_worker(request, body)
                 result = await deploy_agent(DeployRequest(
                     name=body.name,
                     framework=body.framework,


### PR DESCRIPTION
Completes the worker-deploy path so an agent container is created ON a cluster worker's nested incus, not just on the controller. Builds on the worker-LXC foundation (#1466).

## Slices (each tested)
1. `create_container(remote=)` creates on an enrolled remote's nested incus (qualified image + instance, host mounts skipped).
2. `ensure_image_present(remote=)` prefetches the base onto a worker (incus image import/list with a `<remote>:` positional; local-only bake skipped).
3. `deploy_agent` threads `remote`: creates on the worker, qualifies every incus op with `<remote>:`, skips the localhost proxy devices, and points the agent's callback at the controller (`taos_host`). Record name stays unqualified.
4. Routing: an explicit `target_worker` pin deploys the container on that worker (was a 202 stub). `configure_remote_deploy` resolves the pin (409 if unknown/offline), sets the controller Tailscale IP as the callback host, and best-effort prefetches the correct-arch base.

## Networking (per Jay: manual Tailscale, not headscale)
The agent reaches the controller over the tailnet (`controller_callback_host` -> `tailscale ip -4`). The live on-worker test is held pending a decision on nested-container -> tailnet routing (see pending-decisions); same-LAN workers can use the LAN IP in the meantime.

## Tests
configure_remote_deploy unit tests + routing fall-through + create_container/ensure_image_present/deploy_agent remote paths. Full deployer/containers/agent_image/agent_deploy suites green (126).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for deploying agents to a specified remote worker, including remote base-image prefetch and correct worker callback wiring.
  * Remote deployments now use networked LiteLLM endpoints and honor an optional controller callback host override.
* **Bug Fixes**
  * Remote image import/presence checks now target enrolled remotes; remote-imported images are not baked.
  * Remote container creation skips local-only mounts and related proxy/device setup, while still applying resource limits and environment on the remote target.
  * Container-related responses now consistently return the bare container name.
* **Tests**
  * Expanded coverage for remote image importing, remote container creation, remote deploy execution, and remote routing edge cases.
* **Chores**
  * Improved nested incus initialization logic during worker setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->