### PR TITLE
chore(release): 1.0.0-beta.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.12] - 2026-06-28
+
 ### Added
 - Decisions app: the human-in-the-loop inbox. Store + API backend, desktop app, notification routing, answers routed back to the asking agent on the A2A bus, L1 supersede with history lineage, per-project Decisions archive tab, and a `request_decision` agent tool.
 - Observatory app: fleet view of which agents are working on what, idle-agent surfacing, queue-control pause (global and per-lane), steer v1 (global and per-lane concurrency caps with server-rejection surfacing), and a stale-claim badge.
@@ -14,6 +16,7 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 - Projects canvas: migration onto an MIT renderer (Konva foundation, Excalidraw read-only board with CanvasElement mapping), real mermaid/flowchart diagram rendering, GitHub issue to board-card sync, and channel project tagging with filter.
 - Agent deploy: framework-aware prebuilt base image for a Hermes fast-path, Base Images management (API plus desktop pane: list/import/prune/prefetch), and an Import Agent wizard that uploads a Hermes profile bundle.
 - Cluster: deploy an agent onto a cluster worker. An explicit target_worker pin creates the agent container on that worker's nested incus, with the controller reached over the LAN or tailnet.
+- Notes and Todo: shareable notes and lists with an API (create/list docs, entries, members). A doc can be shared with agents, and a new entry notifies each agent member on its DM channel with the member's standing instruction so the agent can act.
 - App permissions: a closed capability vocabulary with manifest validation, an `app_grants` ledger feeding the capability broker, and a request-consent endpoint that raises an app-grant Decision.
 - Secrets broker: grant ledger and lifecycle (P0) plus routes and service wiring with request notifications (P1).
 - Agent-model API: owner key-management (mint/list/revoke) and a `/v1/chat/completions` consent contract.

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.11",
+  "version": "1.0.0-beta.12",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -6,11 +6,12 @@ taOS uses semver beta: `1.0.0-beta.N`, incremented on every dev->master promotio
 
 ### 1. Bump version
 
-Update the version string to the next `1.0.0-beta.N` in exactly these three files (keep them identical):
+Update the version string to the next `1.0.0-beta.N` in exactly these files (keep them identical):
 
 - `pyproject.toml` line `version = "..."`
 - `desktop/package.json` line `"version": "..."`
 - `tinyagentos/__init__.py` line `__version__ = "..."`
+- `uv.lock` -- the `tinyagentos` package entry's `version = "..."` (uv normalises `1.0.0-beta.N` to `1.0.0bN`). `test_version_lock_sync.py` fails the build if this drifts from `pyproject.toml`.
 
 ### 2. Update CHANGELOG.md
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 # Upper-capped at <3.14 because litellm (the proxy extra, the agent/model proxy

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.11"
+__version__ = "1.0.0-beta.12"

--- a/uv.lock
+++ b/uv.lock
@@ -2884,7 +2884,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b11"
+version = "1.0.0b12"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Version bump beta.11 -> beta.12 across the three version files (pyproject.toml, desktop/package.json, tinyagentos/__init__.py) and the CHANGELOG `[Unreleased]` section moved into a dated `[1.0.0-beta.12] - 2026-06-28` section.

Headline of this cycle: remote agent deploy onto cluster workers (#1467), shared Notes/Lists with agent triggers (#1469), plus the Decisions app, Observatory, agent-native tools, canvas migration, app permissions, and secrets broker from the dev delta.

Per docs/RELEASING.md: merge to dev, then a follow-up dev->master promotion PR, then tag v1.0.0-beta.12 on master.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the app/package version to **1.0.0-beta.12** across release metadata.
  * Added a new **1.0.0-beta.12** changelog entry and grouped the latest added items under it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->