### PR TITLE
feat(notes): tracked edits with diff + checkpoint history (Time Machine foundation)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ dependencies = [
     # http://taos.local:<port>/ on the LAN without users knowing its IP
     # (tinyagentos/services/mdns_publisher.py).
     "zeroconf>=0.150.0",
+    # Diff/patch for the notes revision log: computes and applies text diffs
+    # for the Time Machine history layer (tinyagentos/notes/shared_docs_store.py).
+    "diff-match-patch>=20230430",
 ]
 
 [project.optional-dependencies]

--- a/tests/notes/test_revisions.py
+++ b/tests/notes/test_revisions.py
@@ -1,0 +1,271 @@
+"""Tests for the notes revision / Time Machine layer."""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+import yaml
+from httpx import ASGITransport, AsyncClient
+
+from tinyagentos.app import create_app
+from tinyagentos.notes.shared_docs_store import CHECKPOINT_EVERY, SharedDocsStore
+
+
+# ------------------------------------------------------------------ fixtures
+
+@pytest_asyncio.fixture
+async def store(tmp_path):
+    s = SharedDocsStore(tmp_path / "shared_docs.db")
+    await s.init()
+    yield s
+    await s.close()
+
+
+def _make_config(tmp_path):
+    return {
+        "server": {"host": "0.0.0.0", "port": 6969},
+        "backends": [],
+        "qmd": {"url": "http://localhost:7832"},
+        "agents": [],
+        "metrics": {"poll_interval": 30, "retention_days": 30},
+    }
+
+
+@pytest_asyncio.fixture
+async def client(tmp_path):
+    config = _make_config(tmp_path)
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    (tmp_path / ".setup_complete").touch()
+    app = create_app(data_dir=tmp_path)
+    shared_docs_store = SharedDocsStore(tmp_path / "shared_docs.db")
+    await shared_docs_store.init()
+    app.state.shared_docs_store = shared_docs_store
+    auth = app.state.auth
+    auth.setup_user("admin", "Admin", "", "adminpass")
+    record = auth.find_user("admin")
+    token = auth.create_session(user_id=record["id"], long_lived=True)
+    app.state._startup_complete = True
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        cookies={"taos_session": token},
+    ) as c:
+        yield c
+    await shared_docs_store.close()
+
+
+@pytest_asyncio.fixture
+async def two_user_clients(tmp_path):
+    config = _make_config(tmp_path)
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    (tmp_path / ".setup_complete").touch()
+    app = create_app(data_dir=tmp_path)
+    shared_docs_store = SharedDocsStore(tmp_path / "shared_docs.db")
+    await shared_docs_store.init()
+    app.state.shared_docs_store = shared_docs_store
+    auth = app.state.auth
+    auth.setup_user("alice", "Alice", "", "alicepass")
+    alice_rec = auth.find_user("alice")
+    alice_token = auth.create_session(user_id=alice_rec["id"], long_lived=True)
+    bob_invite = auth.add_user_invite("bob", "alice")
+    auth.complete_invite("bob", bob_invite, "bob", "", "bobpass123")
+    bob_rec = auth.find_user("bob")
+    bob_token = auth.create_session(user_id=bob_rec["id"], long_lived=True)
+    app.state._startup_complete = True
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport, base_url="http://test",
+        cookies={"taos_session": alice_token},
+    ) as alice, AsyncClient(
+        transport=transport, base_url="http://test",
+        cookies={"taos_session": bob_token},
+    ) as bob:
+        yield alice, bob, app
+    await shared_docs_store.close()
+
+
+# ---------------------------------------------------------------- store tests
+
+@pytest.mark.asyncio
+async def test_add_entry_creates_create_revision(store):
+    doc = await store.create_doc("user1", "note", "Test")
+    entry = await store.add_entry(doc["id"], "hello", author="user1")
+    revs = await store.list_revisions(entry["id"])
+    assert len(revs) == 1
+    r = revs[0]
+    assert r["rev_index"] == 0
+    assert r["op"] == "create"
+    assert r["editor_id"] == "user1"
+    assert r["editor_type"] == "user"
+
+
+@pytest.mark.asyncio
+async def test_edit_entry_increments_rev_index(store):
+    doc = await store.create_doc("user1", "note", "Test")
+    entry = await store.add_entry(doc["id"], "v0", author="user1")
+    entry_id = entry["id"]
+
+    await store.edit_entry(entry_id, "v1", editor_id="user1")
+    await store.edit_entry(entry_id, "v2", editor_id="user1")
+
+    revs = await store.list_revisions(entry_id)
+    assert len(revs) == 3
+    assert [r["rev_index"] for r in revs] == [0, 1, 2]
+    assert revs[0]["op"] == "create"
+    assert revs[1]["op"] == "edit"
+    assert revs[2]["op"] == "edit"
+    assert revs[1]["editor_id"] == "user1"
+
+
+@pytest.mark.asyncio
+async def test_edit_entry_editor_type_agent(store):
+    doc = await store.create_doc("user1", "list", "Tasks")
+    entry = await store.add_entry(doc["id"], "do it", author="user1")
+    await store.edit_entry(entry["id"], "done!", editor_id="atlas", editor_type="agent")
+    revs = await store.list_revisions(entry["id"])
+    assert revs[1]["editor_type"] == "agent"
+    assert revs[1]["editor_id"] == "atlas"
+
+
+@pytest.mark.asyncio
+async def test_entry_text_at_simple(store):
+    doc = await store.create_doc("u", "note", "N")
+    entry = await store.add_entry(doc["id"], "original", author="u")
+    entry_id = entry["id"]
+    await store.edit_entry(entry_id, "changed", editor_id="u")
+    await store.edit_entry(entry_id, "changed again", editor_id="u")
+
+    assert await store.entry_text_at(entry_id, 0) == "original"
+    assert await store.entry_text_at(entry_id, 1) == "changed"
+    assert await store.entry_text_at(entry_id, 2) == "changed again"
+
+
+@pytest.mark.asyncio
+async def test_entry_text_at_cross_checkpoint(store):
+    """Make >CHECKPOINT_EVERY edits; verify reconstruction crosses a checkpoint."""
+    doc = await store.create_doc("u", "note", "Chk")
+    entry = await store.add_entry(doc["id"], "text-0", author="u")
+    entry_id = entry["id"]
+
+    # Keep a ground-truth list of every text state.
+    states = ["text-0"]
+    total_edits = CHECKPOINT_EVERY + 5  # 25 edits, crosses one checkpoint at rev 20
+    for i in range(1, total_edits + 1):
+        new_text = f"text-{i} with some extra words to make the diff interesting"
+        await store.edit_entry(entry_id, new_text, editor_id="u")
+        states.append(new_text)
+
+    # Spot-check a range of revisions including the create, just before the
+    # checkpoint, the checkpoint itself, and after the checkpoint.
+    revs = await store.list_revisions(entry_id)
+    assert len(revs) == total_edits + 1  # create + edits
+
+    for rev_idx in [0, CHECKPOINT_EVERY - 1, CHECKPOINT_EVERY, CHECKPOINT_EVERY + 1, total_edits]:
+        reconstructed = await store.entry_text_at(entry_id, rev_idx)
+        assert reconstructed == states[rev_idx], (
+            f"Mismatch at rev_index={rev_idx}: expected {states[rev_idx]!r}, "
+            f"got {reconstructed!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_revision_diff_returns_none_for_create(store):
+    doc = await store.create_doc("u", "note", "N")
+    entry = await store.add_entry(doc["id"], "start", author="u")
+    diff = await store.revision_diff(entry["id"], 0)
+    assert diff is None
+
+
+@pytest.mark.asyncio
+async def test_revision_diff_set_on_edit(store):
+    doc = await store.create_doc("u", "note", "N")
+    entry = await store.add_entry(doc["id"], "before", author="u")
+    await store.edit_entry(entry["id"], "after", editor_id="u")
+    diff = await store.revision_diff(entry["id"], 1)
+    assert diff is not None
+    assert len(diff) > 0
+
+
+# ----------------------------------------------------------------- route tests
+
+@pytest.mark.asyncio
+async def test_edit_text_route_returns_updated_entry(client):
+    doc = (await client.post("/api/notes", json={"kind": "note", "title": "T"})).json()
+    entry = (await client.post(f"/api/notes/{doc['id']}/entries", json={"text": "old"})).json()
+    resp = await client.patch(
+        f"/api/notes/{doc['id']}/entries/{entry['id']}/text",
+        json={"text": "new"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["text"] == "new"
+
+
+@pytest.mark.asyncio
+async def test_history_route_returns_revision_list(client):
+    doc = (await client.post("/api/notes", json={"kind": "note", "title": "T"})).json()
+    entry = (await client.post(f"/api/notes/{doc['id']}/entries", json={"text": "v0"})).json()
+    await client.patch(
+        f"/api/notes/{doc['id']}/entries/{entry['id']}/text",
+        json={"text": "v1"},
+    )
+    resp = await client.get(f"/api/notes/{doc['id']}/entries/{entry['id']}/history")
+    assert resp.status_code == 200
+    revs = resp.json()
+    assert len(revs) == 2
+    assert revs[0]["op"] == "create"
+    assert revs[1]["op"] == "edit"
+
+
+@pytest.mark.asyncio
+async def test_at_revision_route_reconstructs_text(client):
+    doc = (await client.post("/api/notes", json={"kind": "note", "title": "T"})).json()
+    entry = (await client.post(f"/api/notes/{doc['id']}/entries", json={"text": "alpha"})).json()
+    entry_id = entry["id"]
+    doc_id = doc["id"]
+
+    await client.patch(f"/api/notes/{doc_id}/entries/{entry_id}/text", json={"text": "beta"})
+    await client.patch(f"/api/notes/{doc_id}/entries/{entry_id}/text", json={"text": "gamma"})
+
+    r0 = (await client.get(f"/api/notes/{doc_id}/entries/{entry_id}/at/0")).json()
+    assert r0["text"] == "alpha"
+
+    r1 = (await client.get(f"/api/notes/{doc_id}/entries/{entry_id}/at/1")).json()
+    assert r1["text"] == "beta"
+
+    r2 = (await client.get(f"/api/notes/{doc_id}/entries/{entry_id}/at/2")).json()
+    assert r2["text"] == "gamma"
+
+
+@pytest.mark.asyncio
+async def test_edit_text_route_owner_only(two_user_clients):
+    alice, bob, _ = two_user_clients
+    doc = (await alice.post("/api/notes", json={"kind": "note", "title": "A"})).json()
+    entry = (await alice.post(f"/api/notes/{doc['id']}/entries", json={"text": "orig"})).json()
+
+    resp = await bob.patch(
+        f"/api/notes/{doc['id']}/entries/{entry['id']}/text",
+        json={"text": "hacked"},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_history_route_readable_by_shared_member(two_user_clients):
+    alice, bob, app = two_user_clients
+    bob_id = app.state.auth.find_user("bob")["id"]
+
+    doc = (await alice.post("/api/notes", json={"kind": "note", "title": "Shared"})).json()
+    entry = (await alice.post(f"/api/notes/{doc['id']}/entries", json={"text": "hi"})).json()
+
+    # Before sharing, bob gets 403.
+    assert (await bob.get(f"/api/notes/{doc['id']}/entries/{entry['id']}/history")).status_code == 403
+
+    # Alice shares with bob.
+    await alice.post(
+        f"/api/notes/{doc['id']}/members",
+        json={"member_type": "user", "member_id": bob_id},
+    )
+
+    # Now bob can read history.
+    resp = await bob.get(f"/api/notes/{doc['id']}/entries/{entry['id']}/history")
+    assert resp.status_code == 200

--- a/tinyagentos/notes/shared_docs_store.py
+++ b/tinyagentos/notes/shared_docs_store.py
@@ -10,17 +10,25 @@ notify after an entry is added.
 
 Append-only-friendly: archiving sets ``archived_at`` rather than deleting, so
 nothing is truly lost (#103).
+
+Every text change to an entry is recorded as an immutable revision row. The
+revision log stores a diff per edit plus a full-text snapshot every
+CHECKPOINT_EVERY revisions so that rewinding to any past state requires at
+most one checkpoint load plus a short diff replay.
 """
 
 from __future__ import annotations
 
-import json
 import time
+
+from diff_match_patch import diff_match_patch
 
 from tinyagentos.base_store import BaseStore
 from tinyagentos.projects.ids import new_id
 
 DOC_KINDS = ("note", "list")
+
+CHECKPOINT_EVERY = 20
 
 SHARED_DOCS_SCHEMA = """
 CREATE TABLE IF NOT EXISTS shared_docs (
@@ -54,6 +62,20 @@ CREATE TABLE IF NOT EXISTS shared_doc_members (
 );
 CREATE INDEX IF NOT EXISTS idx_shared_doc_members_doc ON shared_doc_members(doc_id);
 CREATE INDEX IF NOT EXISTS idx_shared_doc_members_agent ON shared_doc_members(member_type, member_id);
+
+CREATE TABLE IF NOT EXISTS shared_doc_entry_revisions (
+    id          TEXT PRIMARY KEY,
+    entry_id    TEXT NOT NULL,
+    rev_index   INTEGER NOT NULL,
+    editor_id   TEXT NOT NULL DEFAULT '',
+    editor_type TEXT NOT NULL DEFAULT 'user',
+    op          TEXT NOT NULL,
+    diff        TEXT,
+    snapshot    TEXT,
+    created_at  REAL NOT NULL,
+    UNIQUE (entry_id, rev_index)
+);
+CREATE INDEX IF NOT EXISTS idx_entry_revisions_entry ON shared_doc_entry_revisions(entry_id, rev_index);
 """
 
 
@@ -134,6 +156,56 @@ class SharedDocsStore(BaseStore):
         await self._db.execute(
             "UPDATE shared_docs SET updated_at = ? WHERE id = ?", (now, doc_id)
         )
+        rev_id = new_id("rev")
+        await self._db.execute(
+            "INSERT INTO shared_doc_entry_revisions "
+            "(id, entry_id, rev_index, editor_id, editor_type, op, diff, snapshot, created_at) "
+            "VALUES (?, ?, 0, ?, 'user', 'create', NULL, ?, ?)",
+            (rev_id, entry_id, author, text, now),
+        )
+        await self._db.commit()
+        cur = await self._db.execute("SELECT * FROM shared_doc_entries WHERE id = ?", (entry_id,))
+        return _row(cur.description, await cur.fetchone())
+
+    async def edit_entry(
+        self,
+        entry_id: str,
+        new_text: str,
+        editor_id: str = "",
+        editor_type: str = "user",
+    ) -> dict:
+        cur = await self._db.execute(
+            "SELECT text FROM shared_doc_entries WHERE id = ?", (entry_id,)
+        )
+        row = await cur.fetchone()
+        if row is None:
+            raise KeyError(f"entry not found: {entry_id}")
+        old_text = row[0]
+
+        dmp = diff_match_patch()
+        patches = dmp.patch_make(old_text, new_text)
+        diff_text = dmp.patch_toText(patches)
+
+        cur = await self._db.execute(
+            "SELECT MAX(rev_index) FROM shared_doc_entry_revisions WHERE entry_id = ?",
+            (entry_id,),
+        )
+        row_max = await cur.fetchone()
+        next_index = (row_max[0] or 0) + 1
+
+        snapshot = new_text if next_index % CHECKPOINT_EVERY == 0 else None
+
+        rev_id = new_id("rev")
+        now = time.time()
+        await self._db.execute(
+            "INSERT INTO shared_doc_entry_revisions "
+            "(id, entry_id, rev_index, editor_id, editor_type, op, diff, snapshot, created_at) "
+            "VALUES (?, ?, ?, ?, ?, 'edit', ?, ?, ?)",
+            (rev_id, entry_id, next_index, editor_id, editor_type, diff_text, snapshot, now),
+        )
+        await self._db.execute(
+            "UPDATE shared_doc_entries SET text = ? WHERE id = ?", (new_text, entry_id)
+        )
         await self._db.commit()
         cur = await self._db.execute("SELECT * FROM shared_doc_entries WHERE id = ?", (entry_id,))
         return _row(cur.description, await cur.fetchone())
@@ -159,6 +231,86 @@ class SharedDocsStore(BaseStore):
     async def delete_entry(self, entry_id: str) -> None:
         await self._db.execute("DELETE FROM shared_doc_entries WHERE id = ?", (entry_id,))
         await self._db.commit()
+
+    # ------------------------------------------------------------ revision reads
+
+    async def list_revisions(self, entry_id: str) -> list[dict]:
+        """Return all revisions for an entry, ascending by rev_index.
+
+        Each dict contains: rev_index, editor_id, editor_type, op, created_at.
+        The diff and snapshot columns are intentionally omitted here; use
+        revision_diff / entry_text_at for those.
+        """
+        cur = await self._db.execute(
+            "SELECT rev_index, editor_id, editor_type, op, created_at "
+            "FROM shared_doc_entry_revisions WHERE entry_id = ? ORDER BY rev_index",
+            (entry_id,),
+        )
+        rows = await cur.fetchall()
+        return [dict(zip([c[0] for c in cur.description], r)) for r in rows]
+
+    async def revision_diff(self, entry_id: str, rev_index: int) -> str | None:
+        """Return the stored diff text for the given revision (None for create rows)."""
+        cur = await self._db.execute(
+            "SELECT diff FROM shared_doc_entry_revisions WHERE entry_id = ? AND rev_index = ?",
+            (entry_id, rev_index),
+        )
+        row = await cur.fetchone()
+        if row is None:
+            raise KeyError(f"revision not found: entry={entry_id} rev={rev_index}")
+        return row[0]
+
+    async def entry_text_at(self, entry_id: str, rev_index: int) -> str:
+        """Reconstruct the entry text as it was after revision rev_index.
+
+        Strategy: find the highest revision <= rev_index whose snapshot is set,
+        then apply each subsequent revision's diff up to rev_index. Raises
+        KeyError if entry or revision is missing, ValueError if a diff fails.
+        """
+        cur = await self._db.execute(
+            "SELECT rev_index, snapshot, diff FROM shared_doc_entry_revisions "
+            "WHERE entry_id = ? AND rev_index <= ? ORDER BY rev_index",
+            (entry_id, rev_index),
+        )
+        rows = await cur.fetchall()
+        if not rows:
+            raise KeyError(f"no revisions found: entry={entry_id} rev<={rev_index}")
+
+        # Find the last checkpoint at or before rev_index.
+        base_text = None
+        base_rev = -1
+        for r in rows:
+            r_idx, r_snapshot, _ = r
+            if r_snapshot is not None:
+                base_text = r_snapshot
+                base_rev = r_idx
+
+        if base_text is None:
+            raise ValueError(
+                f"no snapshot/checkpoint found for entry={entry_id} up to rev={rev_index}; "
+                "revision log may be corrupt"
+            )
+
+        if base_rev == rev_index:
+            return base_text
+
+        # Replay diffs from base_rev+1 up to rev_index.
+        dmp = diff_match_patch()
+        text = base_text
+        for r in rows:
+            r_idx, _, r_diff = r
+            if r_idx <= base_rev:
+                continue
+            if r_diff is None:
+                continue
+            patches = dmp.patch_fromText(r_diff)
+            text, results = dmp.patch_apply(patches, text)
+            if not all(results):
+                raise ValueError(
+                    f"diff application failed at rev={r_idx} for entry={entry_id}; "
+                    "revision log may be corrupt"
+                )
+        return text
 
     # --------------------------------------------------------------- members
     async def add_member(

--- a/tinyagentos/projects/ids.py
+++ b/tinyagentos/projects/ids.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import secrets
 
-ID_PREFIXES = ("prj", "tsk", "cmt", "rel", "cve", "dec", "doc", "ent")
+ID_PREFIXES = ("prj", "tsk", "cmt", "rel", "cve", "dec", "doc", "ent", "rev")
 _ALPHABET = "abcdefghijklmnopqrstuvwxyz234567"
 
 

--- a/tinyagentos/routes/notes.py
+++ b/tinyagentos/routes/notes.py
@@ -42,6 +42,10 @@ class PatchEntryIn(BaseModel):
     done: bool
 
 
+class EditEntryTextIn(BaseModel):
+    text: str
+
+
 class AddMemberIn(BaseModel):
     member_type: str
     member_id: str
@@ -246,6 +250,70 @@ async def delete_entry(
         return err
     await store.delete_entry(entry_id)
     return JSONResponse({"ok": True})
+
+
+@router.patch("/api/notes/{doc_id}/entries/{entry_id}/text")
+async def edit_entry_text(
+    doc_id: str,
+    entry_id: str,
+    body: EditEntryTextIn,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    store = _get_store(request)
+    doc = await store.get_doc(doc_id)
+    if doc is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    err = _check_owner(doc, user)
+    if err:
+        return err
+    try:
+        entry = await store.edit_entry(entry_id, body.text, editor_id=user.user_id, editor_type="user")
+    except KeyError:
+        return JSONResponse({"error": "entry not found"}, status_code=404)
+    return entry
+
+
+@router.get("/api/notes/{doc_id}/entries/{entry_id}/history")
+async def entry_history(
+    doc_id: str,
+    entry_id: str,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    store = _get_store(request)
+    doc = await store.get_doc(doc_id)
+    if doc is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    err = await _check_read_access(store, doc, user)
+    if err:
+        return err
+    return await store.list_revisions(entry_id)
+
+
+@router.get("/api/notes/{doc_id}/entries/{entry_id}/at/{rev_index}")
+async def entry_at_revision(
+    doc_id: str,
+    entry_id: str,
+    rev_index: int,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    store = _get_store(request)
+    doc = await store.get_doc(doc_id)
+    if doc is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    err = await _check_read_access(store, doc, user)
+    if err:
+        return err
+    try:
+        text = await store.entry_text_at(entry_id, rev_index)
+        diff = await store.revision_diff(entry_id, rev_index)
+    except KeyError:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    except ValueError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=500)
+    return {"text": text, "diff": diff}
 
 
 # -------------------------------------------------------------- member routes

--- a/uv.lock
+++ b/uv.lock
@@ -514,6 +514,15 @@ wheels = [
 ]
 
 [[package]]
+name = "diff-match-patch"
+version = "20241021"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0e/ad/32e1777dd57d8e85fa31e3a243af66c538245b8d64b7265bec9a61f2ca33/diff_match_patch-20241021.tar.gz", hash = "sha256:beae57a99fa48084532935ee2968b8661db861862ec82c6f21f4acdd6d835073", size = 39962, upload-time = "2024-10-21T19:41:21.094Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/bb/2aa9b46a01197398b901e458974c20ed107935c26e44e37ad5b0e5511e44/diff_match_patch-20241021-py3-none-any.whl", hash = "sha256:93cea333fb8b2bc0d181b0de5e16df50dd344ce64828226bda07728818936782", size = 43252, upload-time = "2024-10-21T19:41:19.914Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2889,6 +2898,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
     { name = "argon2-cffi" },
+    { name = "diff-match-patch" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "jinja2" },
@@ -2936,6 +2946,7 @@ worker = [
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.20.0" },
     { name = "argon2-cffi", specifier = ">=23.1.0" },
+    { name = "diff-match-patch", specifier = ">=20230430" },
     { name = "fastapi", specifier = ">=0.115.0,<0.137" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "httpx", marker = "extra == 'dev'" },


### PR DESCRIPTION
The history layer for shared notes/lists. Entry text becomes editable, and every edit is an immutable revision tagged with who changed it and when, so the UI can show history, diffs, and rewind to any past state.

## Storage model (decided with Jay: diffs + checkpoints)
Each edit stores a diff (the event-sourced record), and a full-text snapshot checkpoint is written every 20 edits. Rewind to revision K loads the nearest checkpoint at or before K and replays only the diffs after it, so reconstruction is fast and a single corrupt diff can never orphan more than one checkpoint window. Diffs use the diff-match-patch library (patch_make / patch_apply); a failed patch hunk raises rather than returning wrong text.

## What
- Store: a shared_doc_entry_revisions table (rev_index, editor_id, editor_type, op, diff, snapshot, created_at); add_entry writes the rev-0 create row; new edit_entry, list_revisions, revision_diff, entry_text_at.
- Routes: PATCH entries/{id}/text (owner-only, records a revision), GET entries/{id}/history, GET entries/{id}/at/{rev_index} (reconstructed text + diff). Reads use the shared-member read-access check.
- Writes stay owner-only here, matching #1469. Member and agent writes (option C) plus the self-notify loop guard are the next PR, and they get tracking for free because this lands first.

## Tests
12 new (including test_entry_text_at_cross_checkpoint: 25 edits across the rev-20 checkpoint, asserting reconstruction at revs 0/19/20/21/25) plus the existing notes suite; 31 total green in the worktree, compileall clean.

## Follow-up
Option C (member and agent writes + loop guard), then the Notes and Todo app UIs to the impeccable/taste bar (live screenshot-verified).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added revision history for note entries, including the ability to view past versions and reconstruct text at a specific revision.
  * Added an endpoint to edit entry text and save changes as tracked revisions.
  * Revision IDs now support a new prefix for history entries.

* **Bug Fixes**
  * Improved access control so only permitted users can edit or view entry history.
  * Added stronger handling for missing revisions and reconstruction errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->