### PR TITLE
feat(notes): member writes + self-notify loop guard (option C, slice 1)

### DIFF
--- a/tests/notes/test_notes_routes.py
+++ b/tests/notes/test_notes_routes.py
@@ -229,8 +229,31 @@ async def test_user_member_can_read_shared_doc(two_user_clients):
     # owner-only in this foundation.
     assert (await bob.get(f"/api/notes/{doc_id}")).status_code == 200
     assert (await bob.get(f"/api/notes/{doc_id}/members")).status_code == 200
-    assert (await bob.post(f"/api/notes/{doc_id}/entries", json={"text": "hi"})).status_code == 403
+    # Option C: a member can write entries; doc/member management stays owner-only.
+    assert (await bob.post(f"/api/notes/{doc_id}/entries", json={"text": "hi"})).status_code == 200
     assert (await bob.patch(f"/api/notes/{doc_id}", json={"title": "x"})).status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_member_can_edit_and_remove_entries(two_user_clients):
+    alice, bob, app = two_user_clients
+    bob_id = app.state.auth.find_user("bob")["id"]
+    doc = (await alice.post("/api/notes", json={"kind": "list", "title": "Groceries"})).json()
+    doc_id = doc["id"]
+    await alice.post(
+        f"/api/notes/{doc_id}/members",
+        json={"member_type": "user", "member_id": bob_id},
+    )
+
+    entry = (await bob.post(f"/api/notes/{doc_id}/entries", json={"text": "milk"})).json()
+    eid = entry["id"]
+    assert (await bob.patch(f"/api/notes/{doc_id}/entries/{eid}/text", json={"text": "oat milk"})).status_code == 200
+    assert (await bob.patch(f"/api/notes/{doc_id}/entries/{eid}", json={"done": True})).status_code == 200
+    assert (await bob.delete(f"/api/notes/{doc_id}/entries/{eid}")).status_code == 200
+
+    # Once unshared, the former member can no longer write.
+    await alice.delete(f"/api/notes/{doc_id}/members/user/{bob_id}")
+    assert (await bob.post(f"/api/notes/{doc_id}/entries", json={"text": "x"})).status_code == 403
 
 
 # ------------------------------------------------------------ member tests
@@ -379,3 +402,41 @@ async def test_add_entry_no_agent_members_no_send(tmp_path):
 
     assert sent == [], "no message should be sent when there are no agent members"
     await shared_docs_store.close()
+
+
+@pytest.mark.asyncio
+async def test_trigger_skips_authoring_agent(tmp_path):
+    """Loop guard: skip_agent is not notified about its own write, others are."""
+    from types import SimpleNamespace
+
+    from tinyagentos.routes.notes import _trigger_agent_notifications
+
+    config_data = _make_config(tmp_path)
+    (tmp_path / "config.yaml").write_text(yaml.dump(config_data))
+    app = create_app(data_dir=tmp_path)
+    store = SharedDocsStore(tmp_path / "shared_docs.db")
+    await store.init()
+    app.state.shared_docs_store = store
+
+    doc = await store.create_doc("owner", "note", "Ideas")
+    await store.add_member(doc["id"], "agent", "atlas", "research")
+    await store.add_member(doc["id"], "agent", "nova", "critique")
+    app.state.config.agents.append({"name": "atlas", "chat_channel_id": "ch-atlas"})
+    app.state.config.agents.append({"name": "nova", "chat_channel_id": "ch-nova"})
+
+    sent: list[str] = []
+
+    async def _fake_send(channel_id, author_id, author_type, content, **kwargs):
+        sent.append(channel_id)
+        return {}
+
+    msg = MagicMock()
+    msg.send_message = _fake_send
+    app.state.chat_messages = msg
+
+    req = SimpleNamespace(app=SimpleNamespace(state=app.state))
+    await _trigger_agent_notifications(req, doc, "a new idea", skip_agent="atlas")
+
+    assert "ch-nova" in sent
+    assert "ch-atlas" not in sent
+    await store.close()

--- a/tinyagentos/routes/notes.py
+++ b/tinyagentos/routes/notes.py
@@ -84,6 +84,16 @@ async def _check_read_access(store, doc: dict, user: CurrentUser):
     return JSONResponse({"error": "forbidden"}, status_code=403)
 
 
+async def _check_write_access(store, doc: dict, user: CurrentUser):
+    """Any member (owner, admin, or a user-type member) may write entries.
+
+    Entry writes require membership, the same bar as reading the doc; doc and
+    member management stay owner-only (see _check_owner). Agent members write
+    through an agent tool rather than this human-session API.
+    """
+    return await _check_read_access(store, doc, user)
+
+
 # ------------------------------------------------------------------ doc routes
 
 @router.get("/api/notes")
@@ -153,8 +163,14 @@ async def _trigger_agent_notifications(
     request: Request,
     doc: dict,
     entry_text: str,
+    skip_agent: str | None = None,
 ) -> None:
-    """Post a message to each agent member's DM channel. Never raises."""
+    """Post a message to each agent member's DM channel. Never raises.
+
+    skip_agent names the agent that authored this change, if any, so an agent
+    writing to a shared doc does not get notified about its own entry (the
+    self-notify loop guard).
+    """
     store = _get_store(request)
     agents = await store.agent_members(doc["id"])
     if not agents:
@@ -169,6 +185,8 @@ async def _trigger_agent_notifications(
 
     for am in agents:
         agent_name = am["agent"]
+        if skip_agent is not None and agent_name == skip_agent:
+            continue
         instruction = am["standing_instruction"]
         if instruction:
             content = f"[{doc_title}] {instruction}: {entry_text}"
@@ -203,7 +221,7 @@ async def add_entry(
     doc = await store.get_doc(doc_id)
     if doc is None:
         return JSONResponse({"error": "not found"}, status_code=404)
-    err = _check_owner(doc, user)
+    err = await _check_write_access(store, doc, user)
     if err:
         return err
     entry = await store.add_entry(doc_id, body.text, author=user.user_id)
@@ -227,7 +245,7 @@ async def patch_entry(
     doc = await store.get_doc(doc_id)
     if doc is None:
         return JSONResponse({"error": "not found"}, status_code=404)
-    err = _check_owner(doc, user)
+    err = await _check_write_access(store, doc, user)
     if err:
         return err
     await store.set_entry_done(entry_id, body.done)
@@ -245,7 +263,7 @@ async def delete_entry(
     doc = await store.get_doc(doc_id)
     if doc is None:
         return JSONResponse({"error": "not found"}, status_code=404)
-    err = _check_owner(doc, user)
+    err = await _check_write_access(store, doc, user)
     if err:
         return err
     await store.delete_entry(entry_id)
@@ -264,7 +282,7 @@ async def edit_entry_text(
     doc = await store.get_doc(doc_id)
     if doc is None:
         return JSONResponse({"error": "not found"}, status_code=404)
-    err = _check_owner(doc, user)
+    err = await _check_write_access(store, doc, user)
     if err:
         return err
     try:


### PR DESCRIPTION
Option C, slice 1: members can write entries on a shared note or list, building on the tracked-edits layer that just landed (#1471).

## What
- New `_check_write_access` (owner, admin, or a user-type member) gates the four entry-write routes: add entry, edit text, toggle done, delete. It is the same membership bar as reading the doc.
- Doc and member management (rename, archive, add/remove member) stays owner-only.
- The agent-notification trigger gains a `skip_agent` loop guard: an agent that writes to a shared doc is not notified about its own entry. This is plumbing for slice 2 (the agent write tool); no human-session caller passes it yet.

## Why
Jay chose option C (user and agent members can write). This slice delivers the human-member half. Agent writes arrive in slice 2 as an agent tool authenticated as the agent, where the loop guard activates and the agent manual is updated in the same batch.

## Tests
33 notes tests pass. Updated the member-access test (a member can now write, not just read), added a member edit/done/delete + post-unshare-403 test, and a direct loop-guard test asserting the authoring agent is skipped while other agent members are still notified. compileall clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Members with access to a shared notes document can now add and manage their own entries without needing full ownership.
  * Agent notifications now avoid sending duplicate alerts to the currently active agent.

* **Bug Fixes**
  * Tightened access behavior so document settings remain owner-only while entry editing stays available to permitted members.
  * Improved shared-document permissions so removed members can no longer create new entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->