### PR TITLE
feat(notes): agent write tool for shared docs (option C, slice 2)

### DIFF
--- a/docs/agent-manual/09-os-control.md
+++ b/docs/agent-manual/09-os-control.md
@@ -30,19 +30,15 @@ update the open Projects app in real time):
   GPU model for a quality cover. The system loads/unloads and queues for you — you
   just choose the model.
 
-A typical flow: open the Projects app, create_project, add a few tasks, call
-generate_image and keep its `image_ref`, then canvas_add_image(project_id, image_ref)
-to drop it on the board. To finish a storybook, call export_storybook(project_id,
-title, pages) to produce the illustrated PDF in the project's Files.
+A typical flow: open Projects, create_project, add tasks, generate_image then
+canvas_add_image(project_id, image_ref) to place it; export_storybook(project_id,
+title, pages) writes the illustrated PDF to the project's Files.
 
-These drive the user's own desktop in their session. Use them to make your work
-visible: open the relevant app so the user can watch, then carry out the task with
-that app's own tools and your other skills.
+These drive the user's own desktop. Make your work visible: open the relevant app
+so the user can watch, then carry out the task with that app's tools. Open only
+what you need, leave their windows alone, say what you do.
 
-Keep it purposeful: open what you need, don't rearrange the user's windows without
-reason, and tell the user what you're doing as you do it.
+You can read and write shared notes and lists you belong to:
 
-You can also read and write to shared notes and lists you are a member of:
-
-- **notes_list_shared_docs** -- list the shared notes and lists you belong to (no args). Each result has id, kind, title, updated_at.
-- **notes_add_entry** -- append an entry to a shared doc you belong to. Args: `doc_id` (from notes_list_shared_docs), `text`.
+- **notes_list_shared_docs** -- the docs you belong to (id, kind, title, updated_at).
+- **notes_add_entry** -- append to a doc you belong to. Args: `doc_id`, `text`.

--- a/docs/agent-manual/09-os-control.md
+++ b/docs/agent-manual/09-os-control.md
@@ -41,3 +41,8 @@ that app's own tools and your other skills.
 
 Keep it purposeful: open what you need, don't rearrange the user's windows without
 reason, and tell the user what you're doing as you do it.
+
+You can also read and write to shared notes and lists you are a member of:
+
+- **notes_list_shared_docs** -- list the shared notes and lists you belong to (no args). Each result has id, kind, title, updated_at.
+- **notes_add_entry** -- append an entry to a shared doc you belong to. Args: `doc_id` (from notes_list_shared_docs), `text`.

--- a/docs/taos-agent-manual.md
+++ b/docs/taos-agent-manual.md
@@ -174,22 +174,18 @@ update the open Projects app in real time):
   GPU model for a quality cover. The system loads/unloads and queues for you — you
   just choose the model.
 
-A typical flow: open the Projects app, create_project, add a few tasks, call
-generate_image and keep its `image_ref`, then canvas_add_image(project_id, image_ref)
-to drop it on the board. To finish a storybook, call export_storybook(project_id,
-title, pages) to produce the illustrated PDF in the project's Files.
+A typical flow: open Projects, create_project, add tasks, generate_image then
+canvas_add_image(project_id, image_ref) to place it; export_storybook(project_id,
+title, pages) writes the illustrated PDF to the project's Files.
 
-These drive the user's own desktop in their session. Use them to make your work
-visible: open the relevant app so the user can watch, then carry out the task with
-that app's own tools and your other skills.
+These drive the user's own desktop. Make your work visible: open the relevant app
+so the user can watch, then carry out the task with that app's tools. Open only
+what you need, leave their windows alone, say what you do.
 
-Keep it purposeful: open what you need, don't rearrange the user's windows without
-reason, and tell the user what you're doing as you do it.
+You can read and write shared notes and lists you belong to:
 
-You can also read and write to shared notes and lists you are a member of:
-
-- **notes_list_shared_docs** -- list the shared notes and lists you belong to (no args). Each result has id, kind, title, updated_at.
-- **notes_add_entry** -- append an entry to a shared doc you belong to. Args: `doc_id` (from notes_list_shared_docs), `text`.
+- **notes_list_shared_docs** -- the docs you belong to (id, kind, title, updated_at).
+- **notes_add_entry** -- append to a doc you belong to. Args: `doc_id`, `text`.
 ---
 
 # Generating good images

--- a/docs/taos-agent-manual.md
+++ b/docs/taos-agent-manual.md
@@ -185,6 +185,11 @@ that app's own tools and your other skills.
 
 Keep it purposeful: open what you need, don't rearrange the user's windows without
 reason, and tell the user what you're doing as you do it.
+
+You can also read and write to shared notes and lists you are a member of:
+
+- **notes_list_shared_docs** -- list the shared notes and lists you belong to (no args). Each result has id, kind, title, updated_at.
+- **notes_add_entry** -- append an entry to a shared doc you belong to. Args: `doc_id` (from notes_list_shared_docs), `text`.
 ---
 
 # Generating good images

--- a/tests/notes/test_notes_tools.py
+++ b/tests/notes/test_notes_tools.py
@@ -1,0 +1,155 @@
+"""Tests for the notes agent tools (notes_list_shared_docs, notes_add_entry)."""
+from __future__ import annotations
+
+import types
+from unittest.mock import MagicMock
+
+import pytest
+import pytest_asyncio
+
+from tinyagentos.notes.shared_docs_store import SharedDocsStore
+from tinyagentos.tools.notes_tools import execute_notes_add_entry, execute_notes_list_shared_docs
+
+
+# --------------------------------------------------------------------- helpers
+
+def _make_request(store, config=None, msg_store=None):
+    state = types.SimpleNamespace(
+        shared_docs_store=store,
+        config=config,
+        chat_messages=msg_store,
+    )
+    app = types.SimpleNamespace(state=state)
+    return types.SimpleNamespace(app=app)
+
+
+@pytest_asyncio.fixture
+async def store(tmp_path):
+    s = SharedDocsStore(tmp_path / "test_notes_tools.db")
+    await s.init()
+    yield s
+    await s.close()
+
+
+# ------------------------------------------------------------------ list tests
+
+@pytest.mark.asyncio
+async def test_list_returns_member_docs(store):
+    doc = await store.create_doc("user-1", "note", "Shared Ideas")
+    await store.add_member(doc["id"], "agent", "atlas")
+
+    req = _make_request(store)
+    res = await execute_notes_list_shared_docs({"agent_name": "atlas"}, req)
+    assert "docs" in res
+    assert any(d["id"] == doc["id"] for d in res["docs"])
+
+
+@pytest.mark.asyncio
+async def test_list_excludes_non_member_docs(store):
+    await store.create_doc("user-1", "note", "Private Note")
+
+    req = _make_request(store)
+    res = await execute_notes_list_shared_docs({"agent_name": "atlas"}, req)
+    assert res["docs"] == []
+
+
+@pytest.mark.asyncio
+async def test_list_excludes_archived_docs(store):
+    doc = await store.create_doc("user-1", "note", "Old Note")
+    await store.add_member(doc["id"], "agent", "atlas")
+    await store.archive_doc(doc["id"])
+
+    req = _make_request(store)
+    res = await execute_notes_list_shared_docs({"agent_name": "atlas"}, req)
+    assert res["docs"] == []
+
+
+@pytest.mark.asyncio
+async def test_list_missing_agent_name_returns_error(store):
+    req = _make_request(store)
+    res = await execute_notes_list_shared_docs({}, req)
+    assert "error" in res
+
+
+# ------------------------------------------------------------------ add tests
+
+@pytest.mark.asyncio
+async def test_agent_member_can_add_entry(store):
+    doc = await store.create_doc("user-1", "list", "Grocery List")
+    await store.add_member(doc["id"], "agent", "atlas")
+
+    req = _make_request(store)
+    res = await execute_notes_add_entry(
+        {"agent_name": "atlas", "doc_id": doc["id"], "text": "Buy milk"},
+        req,
+    )
+    assert res.get("ok") is True
+    assert "entry_id" in res
+
+    entries = await store.list_entries(doc["id"])
+    assert any(e["text"] == "Buy milk" for e in entries)
+
+
+@pytest.mark.asyncio
+async def test_non_member_agent_rejected(store):
+    doc = await store.create_doc("user-1", "note", "Private")
+
+    req = _make_request(store)
+    res = await execute_notes_add_entry(
+        {"agent_name": "intruder", "doc_id": doc["id"], "text": "Hacked"},
+        req,
+    )
+    assert "error" in res
+    assert "member" in res["error"]
+
+    entries = await store.list_entries(doc["id"])
+    assert entries == []
+
+
+@pytest.mark.asyncio
+async def test_add_entry_notifies_other_agents_not_writer(store):
+    doc = await store.create_doc("user-1", "note", "Ideas")
+    await store.add_member(doc["id"], "agent", "atlas")
+    await store.add_member(doc["id"], "agent", "nova")
+
+    sent: list[dict] = []
+
+    async def _fake_send(channel_id, author_id, author_type, content, **kwargs):
+        sent.append({"channel_id": channel_id, "content": content})
+        return {}
+
+    fake_msg_store = MagicMock()
+    fake_msg_store.send_message = _fake_send
+
+    fake_config = types.SimpleNamespace(
+        agents=[
+            {"name": "atlas", "chat_channel_id": "ch-atlas"},
+            {"name": "nova", "chat_channel_id": "ch-nova"},
+        ]
+    )
+
+    req = _make_request(store, config=fake_config, msg_store=fake_msg_store)
+    res = await execute_notes_add_entry(
+        {"agent_name": "atlas", "doc_id": doc["id"], "text": "Great idea"},
+        req,
+    )
+    assert res.get("ok") is True
+
+    # nova should be notified; atlas (the writer) should not
+    channels_notified = [m["channel_id"] for m in sent]
+    assert "ch-nova" in channels_notified
+    assert "ch-atlas" not in channels_notified
+
+
+@pytest.mark.asyncio
+async def test_add_entry_missing_fields_returns_error(store):
+    req = _make_request(store)
+
+    res = await execute_notes_add_entry({"agent_name": "atlas", "doc_id": "doc-x"}, req)
+    assert "error" in res
+
+    res = await execute_notes_add_entry({"agent_name": "atlas", "text": "hi"}, req)
+    assert "error" in res
+
+    res = await execute_notes_add_entry({"doc_id": "doc-x", "text": "hi"}, req)
+    assert "error" in res

--- a/tests/notes/test_notes_tools.py
+++ b/tests/notes/test_notes_tools.py
@@ -153,3 +153,47 @@ async def test_add_entry_missing_fields_returns_error(store):
 
     res = await execute_notes_add_entry({"doc_id": "doc-x", "text": "hi"}, req)
     assert "error" in res
+
+
+@pytest.mark.asyncio
+async def test_agent_cannot_write_archived_doc(store):
+    doc = await store.create_doc("user-1", "list", "Old List")
+    await store.add_member(doc["id"], "agent", "atlas")
+    await store.archive_doc(doc["id"])
+
+    req = _make_request(store)
+    res = await execute_notes_add_entry(
+        {"agent_name": "atlas", "doc_id": doc["id"], "text": "late entry"},
+        req,
+    )
+    assert "error" in res
+    assert "archived" in res["error"]
+    assert await store.list_entries(doc["id"]) == []
+
+
+@pytest.mark.asyncio
+async def test_agent_write_attributed_to_agent(store):
+    doc = await store.create_doc("user-1", "note", "Ideas")
+    await store.add_member(doc["id"], "agent", "atlas")
+
+    req = _make_request(store)
+    res = await execute_notes_add_entry(
+        {"agent_name": "atlas", "doc_id": doc["id"], "text": "an idea"},
+        req,
+    )
+    revs = await store.list_revisions(res["entry_id"])
+    assert revs[0]["editor_type"] == "agent"
+    assert revs[0]["editor_id"] == "atlas"
+
+
+@pytest.mark.asyncio
+async def test_list_shared_docs_excludes_internal_fields(store):
+    doc = await store.create_doc("user-1", "note", "Shared")
+    await store.add_member(doc["id"], "agent", "atlas")
+
+    req = _make_request(store)
+    res = await execute_notes_list_shared_docs({"agent_name": "atlas"}, req)
+    assert res["docs"]
+    keys = set(res["docs"][0].keys())
+    assert "owner_user_id" not in keys
+    assert keys <= {"id", "kind", "title", "updated_at"}

--- a/tinyagentos/notes/shared_docs_store.py
+++ b/tinyagentos/notes/shared_docs_store.py
@@ -354,3 +354,16 @@ class SharedDocsStore(BaseStore):
         )
         rows = await cur.fetchall()
         return [{"agent": r[0], "standing_instruction": r[1]} for r in rows]
+
+    async def docs_for_agent(self, agent_name: str) -> list[dict]:
+        """Non-archived docs where the given agent is an agent-type member."""
+        cur = await self._db.execute(
+            "SELECT DISTINCT d.* FROM shared_docs d "
+            "JOIN shared_doc_members m ON m.doc_id = d.id "
+            "WHERE m.member_type = 'agent' AND m.member_id = ? "
+            "AND d.archived_at IS NULL "
+            "ORDER BY d.updated_at DESC",
+            (agent_name,),
+        )
+        rows = await cur.fetchall()
+        return [_row(cur.description, r) for r in rows]

--- a/tinyagentos/notes/shared_docs_store.py
+++ b/tinyagentos/notes/shared_docs_store.py
@@ -145,7 +145,9 @@ class SharedDocsStore(BaseStore):
         await self._db.commit()
 
     # --------------------------------------------------------------- entries
-    async def add_entry(self, doc_id: str, text: str, author: str = "") -> dict:
+    async def add_entry(
+        self, doc_id: str, text: str, author: str = "", editor_type: str = "user"
+    ) -> dict:
         entry_id = new_id("ent")
         now = time.time()
         await self._db.execute(
@@ -160,8 +162,8 @@ class SharedDocsStore(BaseStore):
         await self._db.execute(
             "INSERT INTO shared_doc_entry_revisions "
             "(id, entry_id, rev_index, editor_id, editor_type, op, diff, snapshot, created_at) "
-            "VALUES (?, ?, 0, ?, 'user', 'create', NULL, ?, ?)",
-            (rev_id, entry_id, author, text, now),
+            "VALUES (?, ?, 0, ?, ?, 'create', NULL, ?, ?)",
+            (rev_id, entry_id, author, editor_type, text, now),
         )
         await self._db.commit()
         cur = await self._db.execute("SELECT * FROM shared_doc_entries WHERE id = ?", (entry_id,))
@@ -358,7 +360,7 @@ class SharedDocsStore(BaseStore):
     async def docs_for_agent(self, agent_name: str) -> list[dict]:
         """Non-archived docs where the given agent is an agent-type member."""
         cur = await self._db.execute(
-            "SELECT DISTINCT d.* FROM shared_docs d "
+            "SELECT DISTINCT d.id, d.kind, d.title, d.updated_at FROM shared_docs d "
             "JOIN shared_doc_members m ON m.doc_id = d.id "
             "WHERE m.member_type = 'agent' AND m.member_id = ? "
             "AND d.archived_at IS NULL "

--- a/tinyagentos/routes/skill_exec.py
+++ b/tinyagentos/routes/skill_exec.py
@@ -356,6 +356,27 @@ async def _skill_export_storybook(args: dict, request: Request) -> dict:
         return {"error": str(exc)}
 
 
+
+async def _skill_notes_list_shared_docs(args: dict, request: Request) -> dict:
+    """List non-archived shared docs the calling agent is a member of."""
+    try:
+        from tinyagentos.tools.notes_tools import execute_notes_list_shared_docs
+
+        return await execute_notes_list_shared_docs(args, request)
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
+async def _skill_notes_add_entry(args: dict, request: Request) -> dict:
+    """Append an entry to a shared doc the agent is a member of."""
+    try:
+        from tinyagentos.tools.notes_tools import execute_notes_add_entry
+
+        return await execute_notes_add_entry(args, request)
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
 SKILL_IMPLEMENTATIONS = {
     "memory_search": _skill_memory_search,
     "file_read": _skill_file_read,
@@ -381,6 +402,8 @@ SKILL_IMPLEMENTATIONS = {
     "canvas_add_image": _skill_canvas_add_image,
     "describe_image_capabilities": _skill_describe_image_capabilities,
     "export_storybook": _skill_export_storybook,
+    "notes_list_shared_docs": _skill_notes_list_shared_docs,
+    "notes_add_entry": _skill_notes_add_entry,
 }
 
 

--- a/tinyagentos/skills.py
+++ b/tinyagentos/skills.py
@@ -638,6 +638,53 @@ class SkillStore(BaseStore):
                 "install_method": "builtin",
                 "install_target": "tinyagentos.tools.project_tools",
             },
+            {
+                "id": "notes_list_shared_docs",
+                "name": "List Shared Docs",
+                "category": "notes",
+                "description": "List the non-archived shared notes and lists the agent is a member of",
+                "tool_schema": {
+                    "name": "notes_list_shared_docs",
+                    "description": "List the non-archived shared notes and lists this agent is a member of. Returns id, kind, title, and updated_at for each doc.",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {},
+                    },
+                },
+                "frameworks": {
+                    "smolagents": "adapter", "openclaw": "adapter", "pocketflow": "adapter",
+                    "langroid": "adapter", "hermes": "adapter", "agent-zero": "adapter",
+                    "openai-agents-sdk": "adapter", "generic": "adapter",
+                },
+                "install_method": "builtin",
+                "install_target": "tinyagentos.tools.notes_tools",
+            },
+            {
+                "id": "notes_add_entry",
+                "name": "Add Notes Entry",
+                "category": "notes",
+                "description": "Append a new entry to a shared note or list the agent is a member of",
+                "tool_schema": {
+                    "name": "notes_add_entry",
+                    "description": "Append a new entry to a shared note or list this agent is a member of. Use notes_list_shared_docs first to get the doc_id.",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {
+                            "doc_id": {"type": "string", "description": "Id of the shared doc (from notes_list_shared_docs)."},
+                            "text": {"type": "string", "description": "The entry text to append."},
+                        },
+                        "required": ["doc_id", "text"],
+                    },
+                },
+                "frameworks": {
+                    "smolagents": "adapter", "openclaw": "adapter", "pocketflow": "adapter",
+                    "langroid": "adapter", "hermes": "adapter", "agent-zero": "adapter",
+                    "openai-agents-sdk": "adapter", "generic": "adapter",
+                },
+                "install_method": "builtin",
+                "install_target": "tinyagentos.tools.notes_tools",
+            },
+
         ]
 
         for skill in defaults:

--- a/tinyagentos/tools/notes_tools.py
+++ b/tinyagentos/tools/notes_tools.py
@@ -1,0 +1,61 @@
+"""Agent-side tools for shared notes and lists.
+
+Lets an agent list the docs it is a member of, and append a new entry to any
+doc it belongs to. The loop guard (skip_agent) prevents the writing agent from
+being notified about its own write.
+"""
+
+from __future__ import annotations
+
+from fastapi import Request
+
+
+async def execute_notes_list_shared_docs(args: dict, request: Request) -> dict:
+    """List non-archived shared docs the calling agent is a member of."""
+    args = args or {}
+    agent_name = args.get("agent_name")
+    if not agent_name or not isinstance(agent_name, str):
+        return {"error": "notes_list_shared_docs requires an 'agent_name' string"}
+    try:
+        store = request.app.state.shared_docs_store
+        docs = await store.docs_for_agent(agent_name)
+        return {"docs": docs}
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
+async def execute_notes_add_entry(args: dict, request: Request) -> dict:
+    """Append an entry to a shared doc the calling agent is a member of."""
+    args = args or {}
+    agent_name = args.get("agent_name")
+    doc_id = args.get("doc_id")
+    text = args.get("text")
+
+    if not agent_name or not isinstance(agent_name, str):
+        return {"error": "notes_add_entry requires an 'agent_name' string"}
+    if not doc_id or not isinstance(doc_id, str):
+        return {"error": "notes_add_entry requires a 'doc_id' string"}
+    if not isinstance(text, str) or not text:
+        return {"error": "notes_add_entry requires a 'text' string"}
+
+    try:
+        store = request.app.state.shared_docs_store
+
+        members = await store.agent_members(doc_id)
+        if not any(m["agent"] == agent_name for m in members):
+            return {"error": "agent is not a member of this doc"}
+
+        entry = await store.add_entry(doc_id, text, author=agent_name)
+
+        doc = await store.get_doc(doc_id)
+        if doc is not None:
+            from tinyagentos.routes.notes import _trigger_agent_notifications
+
+            try:
+                await _trigger_agent_notifications(request, doc, text, skip_agent=agent_name)
+            except Exception:
+                pass
+
+        return {"ok": True, "entry_id": entry["id"]}
+    except Exception as exc:
+        return {"error": str(exc)}

--- a/tinyagentos/tools/notes_tools.py
+++ b/tinyagentos/tools/notes_tools.py
@@ -7,7 +7,11 @@ being notified about its own write.
 
 from __future__ import annotations
 
+import logging
+
 from fastapi import Request
+
+logger = logging.getLogger(__name__)
 
 
 async def execute_notes_list_shared_docs(args: dict, request: Request) -> dict:
@@ -45,16 +49,20 @@ async def execute_notes_add_entry(args: dict, request: Request) -> dict:
         if not any(m["agent"] == agent_name for m in members):
             return {"error": "agent is not a member of this doc"}
 
-        entry = await store.add_entry(doc_id, text, author=agent_name)
-
         doc = await store.get_doc(doc_id)
-        if doc is not None:
-            from tinyagentos.routes.notes import _trigger_agent_notifications
+        if doc is None:
+            return {"error": "doc not found"}
+        if doc.get("archived_at") is not None:
+            return {"error": "doc is archived"}
 
-            try:
-                await _trigger_agent_notifications(request, doc, text, skip_agent=agent_name)
-            except Exception:
-                pass
+        entry = await store.add_entry(doc_id, text, author=agent_name, editor_type="agent")
+
+        from tinyagentos.routes.notes import _trigger_agent_notifications
+
+        try:
+            await _trigger_agent_notifications(request, doc, text, skip_agent=agent_name)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("notes_add_entry: agent trigger failed: %s", exc)
 
         return {"ok": True, "entry_id": entry["id"]}
     except Exception as exc:


### PR DESCRIPTION
Option C, slice 2: agents can write to shared notes/lists they belong to, completing the member-writes feature.

## What
- Store: `docs_for_agent(agent_name)` returns the non-archived docs where the agent is an agent-type member.
- New agent tools (`tinyagentos/tools/notes_tools.py`), dispatched in-process with the calling agent's identity injected as `agent_name` (the standard skill_exec convention):
  - `notes_list_shared_docs` -- the docs the agent is shared on, so it can discover what it may write to.
  - `notes_add_entry(doc_id, text)` -- appends an entry. Authorization is membership: the call is rejected unless the agent is an agent-member of the doc. The write is attributed to the agent, and the existing `_trigger_agent_notifications(..., skip_agent=agent_name)` notifies the OTHER agent members but never the writer (the self-notify loop guard from slice 1).
- Registered both in `SKILL_IMPLEMENTATIONS` mirroring `notify_user` / `list_projects`, with `agent_name` injected by dispatch (not model-facing).
- Agent manual: documented both tools in `docs/agent-manual/09-os-control.md`.

## Why
This is the agent half of option C (Jay: user and agent members can write). With slice 1 (human member writes) it means a user can share an "app ideas" note with an agent, the agent gets pinged on new entries, and now the agent can append its research or critique straight back into the doc without looping on its own write.

## Tests
41 notes tests pass (8 new): agent member can add an entry, non-member agent rejected, the write notifies other agents but not the writer, plus list/archived/validation cases. compileall clean.

## Follow-up
The two app UIs (Notes + Todo) to the impeccable/taste bar, live screenshot-verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for shared notes/lists so agents can view shared documents they belong to and append new entries to them.
  * Shared documents now return a simple list with recent updates first.

* **Documentation**
  * Updated the agent manual with guidance for using the new shared-notes capabilities.

* **Tests**
  * Added coverage for shared-doc access, entry creation, membership checks, and required-field validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->