### PR TITLE
feat(notes): per-member permission levels + agent actions

### DIFF
--- a/tests/notes/test_notes_routes.py
+++ b/tests/notes/test_notes_routes.py
@@ -1,7 +1,7 @@
-"""Tests for /api/notes routes -- CRUD, ownership, and agent trigger."""
+"""Tests for /api/notes routes -- CRUD, ownership, permissions, and agent trigger."""
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 import pytest_asyncio
@@ -225,24 +225,31 @@ async def test_user_member_can_read_shared_doc(two_user_clients):
     )
     assert r.status_code == 200
 
-    # Bob can now read the doc and its members, but writes/management stay
-    # owner-only in this foundation.
+    # Bob can now read the doc and its members.
     assert (await bob.get(f"/api/notes/{doc_id}")).status_code == 200
     assert (await bob.get(f"/api/notes/{doc_id}/members")).status_code == 200
-    # Option C: a member can write entries; doc/member management stays owner-only.
+    # Default permission is 'contributor': can add entries but not edit/delete them.
     assert (await bob.post(f"/api/notes/{doc_id}/entries", json={"text": "hi"})).status_code == 200
+    # Contributor cannot edit existing entries or manage the doc.
+    entry = (await alice.post(f"/api/notes/{doc_id}/entries", json={"text": "alice entry"})).json()
+    eid = entry["id"]
+    assert (await bob.patch(f"/api/notes/{doc_id}/entries/{eid}/text", json={"text": "x"})).status_code == 403
+    assert (await bob.patch(f"/api/notes/{doc_id}/entries/{eid}", json={"done": True})).status_code == 403
+    assert (await bob.delete(f"/api/notes/{doc_id}/entries/{eid}")).status_code == 403
     assert (await bob.patch(f"/api/notes/{doc_id}", json={"title": "x"})).status_code == 403
 
 
 @pytest.mark.asyncio
-async def test_member_can_edit_and_remove_entries(two_user_clients):
+async def test_editor_member_can_edit_and_remove_entries(two_user_clients):
+    """A member shared with permission='editor' can add, edit, toggle-done, and delete."""
     alice, bob, app = two_user_clients
     bob_id = app.state.auth.find_user("bob")["id"]
     doc = (await alice.post("/api/notes", json={"kind": "list", "title": "Groceries"})).json()
     doc_id = doc["id"]
+    # Share with editor permission so bob can edit/delete.
     await alice.post(
         f"/api/notes/{doc_id}/members",
-        json={"member_type": "user", "member_id": bob_id},
+        json={"member_type": "user", "member_id": bob_id, "permission": "editor"},
     )
 
     entry = (await bob.post(f"/api/notes/{doc_id}/entries", json={"text": "milk"})).json()
@@ -292,6 +299,177 @@ async def test_invalid_member_type_returns_400(client):
         json={"member_type": "robot", "member_id": "r2d2"},
     )
     assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_invalid_permission_returns_400(client):
+    doc = (await client.post("/api/notes", json={"kind": "note", "title": "x"})).json()
+    resp = await client.post(
+        f"/api/notes/{doc['id']}/members",
+        json={"member_type": "user", "member_id": "bob", "permission": "superuser"},
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_invalid_action_returns_400(client):
+    doc = (await client.post("/api/notes", json={"kind": "note", "title": "x"})).json()
+    resp = await client.post(
+        f"/api/notes/{doc['id']}/members",
+        json={"member_type": "agent", "member_id": "atlas", "action": "sleep"},
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_viewer_cannot_add_or_edit(two_user_clients):
+    """A viewer member can read but not add, edit, or delete entries."""
+    alice, bob, app = two_user_clients
+    bob_id = app.state.auth.find_user("bob")["id"]
+    doc = (await alice.post("/api/notes", json={"kind": "list", "title": "ViewOnly"})).json()
+    doc_id = doc["id"]
+    await alice.post(
+        f"/api/notes/{doc_id}/members",
+        json={"member_type": "user", "member_id": bob_id, "permission": "viewer"},
+    )
+
+    assert (await bob.get(f"/api/notes/{doc_id}")).status_code == 200
+    assert (await bob.post(f"/api/notes/{doc_id}/entries", json={"text": "try"})).status_code == 403
+
+    entry = (await alice.post(f"/api/notes/{doc_id}/entries", json={"text": "alice entry"})).json()
+    eid = entry["id"]
+    assert (await bob.patch(f"/api/notes/{doc_id}/entries/{eid}/text", json={"text": "x"})).status_code == 403
+    assert (await bob.patch(f"/api/notes/{doc_id}/entries/{eid}", json={"done": True})).status_code == 403
+    assert (await bob.delete(f"/api/notes/{doc_id}/entries/{eid}")).status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_contributor_can_add_but_not_edit(two_user_clients):
+    """A contributor member can add new entries but cannot edit or delete existing ones."""
+    alice, bob, app = two_user_clients
+    bob_id = app.state.auth.find_user("bob")["id"]
+    doc = (await alice.post("/api/notes", json={"kind": "list", "title": "ContribOnly"})).json()
+    doc_id = doc["id"]
+    await alice.post(
+        f"/api/notes/{doc_id}/members",
+        json={"member_type": "user", "member_id": bob_id, "permission": "contributor"},
+    )
+
+    assert (await bob.post(f"/api/notes/{doc_id}/entries", json={"text": "new"})).status_code == 200
+
+    entry = (await alice.post(f"/api/notes/{doc_id}/entries", json={"text": "alice entry"})).json()
+    eid = entry["id"]
+    assert (await bob.patch(f"/api/notes/{doc_id}/entries/{eid}", json={"done": True})).status_code == 403
+    assert (await bob.delete(f"/api/notes/{doc_id}/entries/{eid}")).status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_owner_always_has_full_access(two_user_clients):
+    """The owner can add, edit, and delete regardless of any member permission rules."""
+    alice, bob, _ = two_user_clients
+    doc = (await alice.post("/api/notes", json={"kind": "list", "title": "Mine"})).json()
+    doc_id = doc["id"]
+    entry = (await alice.post(f"/api/notes/{doc_id}/entries", json={"text": "item"})).json()
+    eid = entry["id"]
+    assert (await alice.patch(f"/api/notes/{doc_id}/entries/{eid}/text", json={"text": "updated"})).status_code == 200
+    assert (await alice.patch(f"/api/notes/{doc_id}/entries/{eid}", json={"done": True})).status_code == 200
+    assert (await alice.delete(f"/api/notes/{doc_id}/entries/{eid}")).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_member_default_permission_is_contributor(client):
+    """When no permission is passed, the member gets 'contributor' by default."""
+    doc = (await client.post("/api/notes", json={"kind": "note", "title": "x"})).json()
+    doc_id = doc["id"]
+    await client.post(
+        f"/api/notes/{doc_id}/members",
+        json={"member_type": "agent", "member_id": "atlas"},
+    )
+    members = (await client.get(f"/api/notes/{doc_id}/members")).json()
+    atlas = next(m for m in members if m["member_id"] == "atlas")
+    assert atlas["permission"] == "contributor"
+    assert atlas["action"] is None
+
+
+@pytest.mark.asyncio
+async def test_add_member_stores_permission_and_action(client):
+    """The permission and action fields are persisted and returned via list_members."""
+    doc = (await client.post("/api/notes", json={"kind": "note", "title": "x"})).json()
+    doc_id = doc["id"]
+    await client.post(
+        f"/api/notes/{doc_id}/members",
+        json={"member_type": "agent", "member_id": "nova", "permission": "editor", "action": "critique"},
+    )
+    members = (await client.get(f"/api/notes/{doc_id}/members")).json()
+    nova = next(m for m in members if m["member_id"] == "nova")
+    assert nova["permission"] == "editor"
+    assert nova["action"] == "critique"
+
+
+# ------------------------------------------------- agent tool permission tests
+
+@pytest.mark.asyncio
+async def test_agent_tool_viewer_cannot_add(tmp_path):
+    """An agent with viewer permission is rejected by execute_notes_add_entry."""
+    import yaml
+    from types import SimpleNamespace
+
+    from tinyagentos.tools.notes_tools import execute_notes_add_entry
+
+    config_data = _make_config(tmp_path)
+    (tmp_path / "config.yaml").write_text(yaml.dump(config_data))
+    (tmp_path / ".setup_complete").touch()
+
+    app = create_app(data_dir=tmp_path)
+    store = SharedDocsStore(tmp_path / "shared_docs.db")
+    await store.init()
+    app.state.shared_docs_store = store
+
+    doc = await store.create_doc("owner", "note", "Ideas")
+    await store.add_member(doc["id"], "agent", "atlas", permission="viewer")
+
+    req = SimpleNamespace(
+        app=SimpleNamespace(state=app.state),
+        state=SimpleNamespace(agent_name="atlas"),
+    )
+    result = await execute_notes_add_entry(
+        {"agent_name": "atlas", "doc_id": doc["id"], "text": "hi"}, req
+    )
+    assert "error" in result
+    assert "permission" in result["error"]
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_agent_tool_contributor_can_add(tmp_path):
+    """An agent with contributor permission can append via execute_notes_add_entry."""
+    import yaml
+    from types import SimpleNamespace
+
+    from tinyagentos.tools.notes_tools import execute_notes_add_entry
+
+    config_data = _make_config(tmp_path)
+    (tmp_path / "config.yaml").write_text(yaml.dump(config_data))
+    (tmp_path / ".setup_complete").touch()
+
+    app = create_app(data_dir=tmp_path)
+    store = SharedDocsStore(tmp_path / "shared_docs.db")
+    await store.init()
+    app.state.shared_docs_store = store
+
+    doc = await store.create_doc("owner", "note", "Ideas")
+    await store.add_member(doc["id"], "agent", "atlas", permission="contributor")
+
+    req = SimpleNamespace(
+        app=SimpleNamespace(state=app.state),
+        state=SimpleNamespace(agent_name="atlas"),
+    )
+    result = await execute_notes_add_entry(
+        {"agent_name": "atlas", "doc_id": doc["id"], "text": "a new idea"}, req
+    )
+    assert result.get("ok") is True
+    assert "entry_id" in result
+    await store.close()
 
 
 # ----------------------------------------------------------- agent trigger test
@@ -402,6 +580,44 @@ async def test_add_entry_no_agent_members_no_send(tmp_path):
 
     assert sent == [], "no message should be sent when there are no agent members"
     await shared_docs_store.close()
+
+
+@pytest.mark.asyncio
+async def test_trigger_message_reflects_action(tmp_path):
+    """When an agent member has an action, the trigger message contains the directive."""
+    import yaml
+    from types import SimpleNamespace
+
+    from tinyagentos.routes.notes import _trigger_agent_notifications
+
+    config_data = _make_config(tmp_path)
+    (tmp_path / "config.yaml").write_text(yaml.dump(config_data))
+    app = create_app(data_dir=tmp_path)
+    store = SharedDocsStore(tmp_path / "shared_docs.db")
+    await store.init()
+    app.state.shared_docs_store = store
+
+    doc = await store.create_doc("owner", "note", "Plans")
+    await store.add_member(doc["id"], "agent", "atlas", action="plan")
+    app.state.config.agents.append({"name": "atlas", "chat_channel_id": "ch-atlas"})
+
+    sent: list[dict] = []
+
+    async def _fake_send(channel_id, author_id, author_type, content, **kwargs):
+        sent.append({"channel_id": channel_id, "content": content})
+        return {}
+
+    msg = MagicMock()
+    msg.send_message = _fake_send
+    app.state.chat_messages = msg
+
+    req = SimpleNamespace(app=SimpleNamespace(state=app.state))
+    await _trigger_agent_notifications(req, doc, "build a login page")
+
+    assert len(sent) == 1
+    assert "Plan this:" in sent[0]["content"]
+    assert "build a login page" in sent[0]["content"]
+    await store.close()
 
 
 @pytest.mark.asyncio

--- a/tests/notes/test_notes_tools.py
+++ b/tests/notes/test_notes_tools.py
@@ -100,7 +100,7 @@ async def test_non_member_agent_rejected(store):
         req,
     )
     assert "error" in res
-    assert "member" in res["error"]
+    assert "permission" in res["error"]
 
     entries = await store.list_entries(doc["id"])
     assert entries == []

--- a/tests/notes/test_shared_docs_store.py
+++ b/tests/notes/test_shared_docs_store.py
@@ -50,9 +50,11 @@ async def test_share_with_agent_and_standing_instruction(store):
         standing_instruction="Research each new idea and reply with feasibility.",
     )
     agents = await store.agent_members(doc["id"])
-    assert agents == [
-        {"agent": "atlas", "standing_instruction": "Research each new idea and reply with feasibility."}
-    ]
+    assert len(agents) == 1
+    assert agents[0]["agent"] == "atlas"
+    assert agents[0]["standing_instruction"] == "Research each new idea and reply with feasibility."
+    assert agents[0]["permission"] == "contributor"
+    assert agents[0]["action"] is None
     # Re-sharing updates the instruction (INSERT OR REPLACE), no duplicate.
     await store.add_member(doc["id"], "agent", "atlas", standing_instruction="Critique it.")
     agents = await store.agent_members(doc["id"])
@@ -60,6 +62,91 @@ async def test_share_with_agent_and_standing_instruction(store):
     assert agents[0]["standing_instruction"] == "Critique it."
     await store.remove_member(doc["id"], "agent", "atlas")
     assert await store.agent_members(doc["id"]) == []
+
+
+@pytest.mark.asyncio
+async def test_add_member_permission_and_action(store):
+    doc = await store.create_doc("user", "note", "x")
+    await store.add_member(doc["id"], "agent", "nova", permission="editor", action="critique")
+    agents = await store.agent_members(doc["id"])
+    nova = next(a for a in agents if a["agent"] == "nova")
+    assert nova["permission"] == "editor"
+    assert nova["action"] == "critique"
+
+
+@pytest.mark.asyncio
+async def test_add_member_invalid_permission_raises(store):
+    doc = await store.create_doc("user", "note", "x")
+    with pytest.raises(ValueError, match="invalid permission"):
+        await store.add_member(doc["id"], "user", "bob", permission="superuser")
+
+
+@pytest.mark.asyncio
+async def test_add_member_invalid_action_raises(store):
+    doc = await store.create_doc("user", "note", "x")
+    with pytest.raises(ValueError, match="invalid action"):
+        await store.add_member(doc["id"], "agent", "atlas", action="sleep")
+
+
+@pytest.mark.asyncio
+async def test_member_permission_helper(store):
+    doc = await store.create_doc("alice", "note", "x")
+    await store.add_member(doc["id"], "user", "bob", permission="viewer")
+    await store.add_member(doc["id"], "user", "carol", permission="editor")
+
+    assert await store.member_permission(doc["id"], "user", "alice", "alice") == "owner"
+    assert await store.member_permission(doc["id"], "user", "bob", "alice") == "viewer"
+    assert await store.member_permission(doc["id"], "user", "carol", "alice") == "editor"
+    assert await store.member_permission(doc["id"], "user", "eve", "alice") is None
+
+
+@pytest.mark.asyncio
+async def test_additive_columns_tolerate_existing_db(tmp_path):
+    """A DB created without permission/action columns still works after re-init."""
+    import aiosqlite
+
+    db_path = tmp_path / "shared_docs.db"
+
+    # Simulate a pre-existing DB that lacks the new columns.
+    async with aiosqlite.connect(str(db_path)) as db:
+        await db.executescript("""
+            CREATE TABLE IF NOT EXISTS shared_docs (
+                id TEXT PRIMARY KEY, owner_user_id TEXT NOT NULL,
+                kind TEXT NOT NULL, title TEXT NOT NULL DEFAULT '',
+                created_at REAL NOT NULL, updated_at REAL NOT NULL, archived_at REAL
+            );
+            CREATE TABLE IF NOT EXISTS shared_doc_entries (
+                id TEXT PRIMARY KEY, doc_id TEXT NOT NULL,
+                text TEXT NOT NULL DEFAULT '', done INTEGER NOT NULL DEFAULT 0,
+                author TEXT NOT NULL DEFAULT '', created_at REAL NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS shared_doc_members (
+                doc_id TEXT NOT NULL, member_type TEXT NOT NULL,
+                member_id TEXT NOT NULL,
+                standing_instruction TEXT NOT NULL DEFAULT '',
+                created_at REAL NOT NULL,
+                PRIMARY KEY (doc_id, member_type, member_id)
+            );
+            CREATE TABLE IF NOT EXISTS shared_doc_entry_revisions (
+                id TEXT PRIMARY KEY, entry_id TEXT NOT NULL,
+                rev_index INTEGER NOT NULL, editor_id TEXT NOT NULL DEFAULT '',
+                editor_type TEXT NOT NULL DEFAULT 'user', op TEXT NOT NULL,
+                diff TEXT, snapshot TEXT, created_at REAL NOT NULL,
+                UNIQUE (entry_id, rev_index)
+            );
+        """)
+        await db.commit()
+
+    # Opening with SharedDocsStore must not crash and must add the columns.
+    from tinyagentos.notes.shared_docs_store import SharedDocsStore as SDS
+    s = SDS(db_path)
+    await s.init()
+    doc = await s.create_doc("user", "note", "test")
+    await s.add_member(doc["id"], "agent", "atlas", permission="editor", action="plan")
+    agents = await s.agent_members(doc["id"])
+    assert agents[0]["permission"] == "editor"
+    assert agents[0]["action"] == "plan"
+    await s.close()
 
 
 @pytest.mark.asyncio

--- a/tinyagentos/notes/shared_docs_store.py
+++ b/tinyagentos/notes/shared_docs_store.py
@@ -28,6 +28,9 @@ from tinyagentos.projects.ids import new_id
 
 DOC_KINDS = ("note", "list")
 
+VALID_PERMISSIONS = ("viewer", "contributor", "editor")
+VALID_ACTIONS = ("research", "plan", "critique", "build", "discuss")
+
 CHECKPOINT_EVERY = 20
 
 SHARED_DOCS_SCHEMA = """
@@ -57,6 +60,8 @@ CREATE TABLE IF NOT EXISTS shared_doc_members (
     member_type          TEXT NOT NULL,   -- 'user' | 'agent'
     member_id            TEXT NOT NULL,
     standing_instruction TEXT NOT NULL DEFAULT '',
+    permission           TEXT NOT NULL DEFAULT 'contributor',
+    action               TEXT,
     created_at           REAL NOT NULL,
     PRIMARY KEY (doc_id, member_type, member_id)
 );
@@ -85,6 +90,22 @@ def _row(cursor_desc, row) -> dict:
 
 class SharedDocsStore(BaseStore):
     SCHEMA = SHARED_DOCS_SCHEMA
+
+    async def _post_init(self) -> None:
+        # `permission` and `action` were added after initial release. Guard with
+        # PRAGMA table_info since SQLite lacks ADD COLUMN IF NOT EXISTS pre-3.37.
+        cur = await self._db.execute("PRAGMA table_info(shared_doc_members)")
+        cols = {row[1] for row in await cur.fetchall()}
+        if "permission" not in cols:
+            await self._db.execute(
+                "ALTER TABLE shared_doc_members "
+                "ADD COLUMN permission TEXT NOT NULL DEFAULT 'contributor'"
+            )
+        if "action" not in cols:
+            await self._db.execute(
+                "ALTER TABLE shared_doc_members ADD COLUMN action TEXT"
+            )
+        await self._db.commit()
 
     # ------------------------------------------------------------------ docs
     async def create_doc(self, owner_user_id: str, kind: str, title: str = "") -> dict:
@@ -321,14 +342,24 @@ class SharedDocsStore(BaseStore):
         member_type: str,
         member_id: str,
         standing_instruction: str = "",
+        permission: str = "contributor",
+        action: str | None = None,
     ) -> None:
         if member_type not in ("user", "agent"):
             raise ValueError(f"invalid member_type {member_type!r}")
+        if permission not in VALID_PERMISSIONS:
+            raise ValueError(
+                f"invalid permission {permission!r}; expected one of {VALID_PERMISSIONS}"
+            )
+        if action is not None and action not in VALID_ACTIONS:
+            raise ValueError(
+                f"invalid action {action!r}; expected one of {VALID_ACTIONS} or null"
+            )
         await self._db.execute(
             "INSERT OR REPLACE INTO shared_doc_members "
-            "(doc_id, member_type, member_id, standing_instruction, created_at) "
-            "VALUES (?, ?, ?, ?, ?)",
-            (doc_id, member_type, member_id, standing_instruction, time.time()),
+            "(doc_id, member_type, member_id, standing_instruction, permission, action, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (doc_id, member_type, member_id, standing_instruction, permission, action, time.time()),
         )
         await self._db.commit()
 
@@ -347,15 +378,43 @@ class SharedDocsStore(BaseStore):
         return [_row(cur.description, r) for r in rows]
 
     async def agent_members(self, doc_id: str) -> list[dict]:
-        """Agent shares for a doc -- the targets to notify on a new entry,
-        each with its standing_instruction."""
+        """Agent shares for a doc -- the targets to notify on a new entry."""
         cur = await self._db.execute(
-            "SELECT member_id, standing_instruction FROM shared_doc_members "
+            "SELECT member_id, standing_instruction, permission, action "
+            "FROM shared_doc_members "
             "WHERE doc_id = ? AND member_type = 'agent'",
             (doc_id,),
         )
         rows = await cur.fetchall()
-        return [{"agent": r[0], "standing_instruction": r[1]} for r in rows]
+        return [
+            {
+                "agent": r[0],
+                "standing_instruction": r[1],
+                "permission": r[2],
+                "action": r[3],
+            }
+            for r in rows
+        ]
+
+    async def member_permission(
+        self, doc_id: str, member_type: str, member_id: str, owner_user_id: str
+    ) -> str | None:
+        """Return the effective permission level for the caller on this doc.
+
+        Returns 'owner' if the caller is the owner, the stored permission string
+        if they are a member, or None if they have no access at all.
+        """
+        if member_type == "user" and member_id == owner_user_id:
+            return "owner"
+        cur = await self._db.execute(
+            "SELECT permission FROM shared_doc_members "
+            "WHERE doc_id = ? AND member_type = ? AND member_id = ?",
+            (doc_id, member_type, member_id),
+        )
+        row = await cur.fetchone()
+        if row is None:
+            return None
+        return row[0]
 
     async def docs_for_agent(self, agent_name: str) -> list[dict]:
         """Non-archived docs where the given agent is an agent-type member."""

--- a/tinyagentos/routes/notes.py
+++ b/tinyagentos/routes/notes.py
@@ -16,10 +16,20 @@ from pydantic import BaseModel
 
 from tinyagentos.agent_db import find_agent
 from tinyagentos.auth_context import CurrentUser, current_user
+from tinyagentos.notes.shared_docs_store import VALID_ACTIONS, VALID_PERMISSIONS
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+# Action directives used in agent trigger messages.
+_ACTION_DIRECTIVE = {
+    "research": "Research this:",
+    "plan": "Plan this:",
+    "critique": "Critique this:",
+    "build": "Start building:",
+    "discuss": "Discuss this with the user, ask clarifying questions to develop it:",
+}
 
 
 # --------------------------------------------------------------------- models
@@ -50,6 +60,8 @@ class AddMemberIn(BaseModel):
     member_type: str
     member_id: str
     standing_instruction: str = ""
+    permission: str = "contributor"
+    action: str | None = None
 
 
 # -------------------------------------------------------------------- helpers
@@ -59,23 +71,14 @@ def _get_store(request: Request):
 
 
 def _check_owner(doc: dict, user: CurrentUser):
-    """Return a 403 JSONResponse if the caller does not own the doc, else None.
-
-    Used for writes and doc/member management, which stay owner-only in this
-    foundation. Member and agent writes land with the revisions work.
-    """
+    """Return a 403 JSONResponse if the caller does not own the doc, else None."""
     if not user.is_admin and doc["owner_user_id"] != user.user_id:
         return JSONResponse({"error": "forbidden"}, status_code=403)
     return None
 
 
 async def _check_read_access(store, doc: dict, user: CurrentUser):
-    """Allow the owner, an admin, or a user-type member to read the doc.
-
-    Consistent with list_docs, which surfaces a doc to the users it is shared
-    with as a user-type member; without this they would see the doc in their
-    listing and then get a 403 opening it.
-    """
+    """Allow the owner, an admin, or any user-type member to read the doc."""
     if user.is_admin or doc["owner_user_id"] == user.user_id:
         return None
     for m in await store.list_members(doc["id"]):
@@ -84,14 +87,24 @@ async def _check_read_access(store, doc: dict, user: CurrentUser):
     return JSONResponse({"error": "forbidden"}, status_code=403)
 
 
-async def _check_write_access(store, doc: dict, user: CurrentUser):
-    """Any member (owner, admin, or a user-type member) may write entries.
+async def _check_add_access(store, doc: dict, user: CurrentUser):
+    """Owner/admin can always add. User members need contributor or editor."""
+    if user.is_admin or doc["owner_user_id"] == user.user_id:
+        return None
+    perm = await store.member_permission(doc["id"], "user", user.user_id, doc["owner_user_id"])
+    if perm in ("contributor", "editor"):
+        return None
+    return JSONResponse({"error": "forbidden"}, status_code=403)
 
-    Entry writes require membership, the same bar as reading the doc; doc and
-    member management stay owner-only (see _check_owner). Agent members write
-    through an agent tool rather than this human-session API.
-    """
-    return await _check_read_access(store, doc, user)
+
+async def _check_edit_access(store, doc: dict, user: CurrentUser):
+    """Owner/admin can always edit/delete/toggle. User members need editor."""
+    if user.is_admin or doc["owner_user_id"] == user.user_id:
+        return None
+    perm = await store.member_permission(doc["id"], "user", user.user_id, doc["owner_user_id"])
+    if perm == "editor":
+        return None
+    return JSONResponse({"error": "forbidden"}, status_code=403)
 
 
 # ------------------------------------------------------------------ doc routes
@@ -168,8 +181,7 @@ async def _trigger_agent_notifications(
     """Post a message to each agent member's DM channel. Never raises.
 
     skip_agent names the agent that authored this change, if any, so an agent
-    writing to a shared doc does not get notified about its own entry (the
-    self-notify loop guard).
+    writing to a shared doc does not get notified about its own entry.
     """
     store = _get_store(request)
     agents = await store.agent_members(doc["id"])
@@ -187,8 +199,14 @@ async def _trigger_agent_notifications(
         agent_name = am["agent"]
         if skip_agent is not None and agent_name == skip_agent:
             continue
+        action = am.get("action")
         instruction = am["standing_instruction"]
-        if instruction:
+        if action:
+            directive = _ACTION_DIRECTIVE.get(action, "New entry:")
+            content = f"[{doc_title}] {directive} {entry_text}"
+            if instruction:
+                content += f" ({instruction})"
+        elif instruction:
             content = f"[{doc_title}] {instruction}: {entry_text}"
         else:
             content = f"[{doc_title}] New entry: {entry_text}"
@@ -221,7 +239,7 @@ async def add_entry(
     doc = await store.get_doc(doc_id)
     if doc is None:
         return JSONResponse({"error": "not found"}, status_code=404)
-    err = await _check_write_access(store, doc, user)
+    err = await _check_add_access(store, doc, user)
     if err:
         return err
     entry = await store.add_entry(doc_id, body.text, author=user.user_id)
@@ -245,7 +263,7 @@ async def patch_entry(
     doc = await store.get_doc(doc_id)
     if doc is None:
         return JSONResponse({"error": "not found"}, status_code=404)
-    err = await _check_write_access(store, doc, user)
+    err = await _check_edit_access(store, doc, user)
     if err:
         return err
     await store.set_entry_done(entry_id, body.done)
@@ -263,7 +281,7 @@ async def delete_entry(
     doc = await store.get_doc(doc_id)
     if doc is None:
         return JSONResponse({"error": "not found"}, status_code=404)
-    err = await _check_write_access(store, doc, user)
+    err = await _check_edit_access(store, doc, user)
     if err:
         return err
     await store.delete_entry(entry_id)
@@ -282,7 +300,7 @@ async def edit_entry_text(
     doc = await store.get_doc(doc_id)
     if doc is None:
         return JSONResponse({"error": "not found"}, status_code=404)
-    err = await _check_write_access(store, doc, user)
+    err = await _check_edit_access(store, doc, user)
     if err:
         return err
     try:
@@ -366,12 +384,24 @@ async def add_member(
     err = _check_owner(doc, user)
     if err:
         return err
+    if body.permission not in VALID_PERMISSIONS:
+        return JSONResponse(
+            {"error": f"invalid permission {body.permission!r}; expected one of {VALID_PERMISSIONS}"},
+            status_code=400,
+        )
+    if body.action is not None and body.action not in VALID_ACTIONS:
+        return JSONResponse(
+            {"error": f"invalid action {body.action!r}; expected one of {VALID_ACTIONS} or null"},
+            status_code=400,
+        )
     try:
         await store.add_member(
             doc_id,
             body.member_type,
             body.member_id,
             body.standing_instruction,
+            permission=body.permission,
+            action=body.action,
         )
     except ValueError as exc:
         return JSONResponse({"error": str(exc)}, status_code=400)

--- a/tinyagentos/tools/notes_tools.py
+++ b/tinyagentos/tools/notes_tools.py
@@ -29,7 +29,11 @@ async def execute_notes_list_shared_docs(args: dict, request: Request) -> dict:
 
 
 async def execute_notes_add_entry(args: dict, request: Request) -> dict:
-    """Append an entry to a shared doc the calling agent is a member of."""
+    """Append an entry to a shared doc the calling agent is a member of.
+
+    The agent must have 'contributor' or 'editor' permission on the doc.
+    'viewer' agents are rejected.
+    """
     args = args or {}
     agent_name = args.get("agent_name")
     doc_id = args.get("doc_id")
@@ -46,8 +50,13 @@ async def execute_notes_add_entry(args: dict, request: Request) -> dict:
         store = request.app.state.shared_docs_store
 
         members = await store.agent_members(doc_id)
-        if not any(m["agent"] == agent_name for m in members):
-            return {"error": "agent is not a member of this doc"}
+        agent_member = next((m for m in members if m["agent"] == agent_name), None)
+        if agent_member is None:
+            return {"error": "agent does not have write permission on this doc"}
+
+        perm = agent_member.get("permission", "contributor")
+        if perm not in ("contributor", "editor"):
+            return {"error": "agent does not have write permission on this doc"}
 
         doc = await store.get_doc(doc_id)
         if doc is None:


### PR DESCRIPTION
Per-member permission levels and agent actions for shared notes/lists -- the real sharing contract behind the Notes app share dialog.

## What
- Member permission: viewer (read), contributor (read + add new entries), editor (read + add + edit/toggle/delete existing). Owner/admin always full + manage membership. Default for a new member = contributor.
- Agent action (agents only, nullable): research | plan | critique | build | discuss, stored alongside the standing-instruction note.
- Enforcement matrix in the routes AND the agent write tool: add-new requires contributor+, edit/done/delete requires editor, owner/admin always pass, viewer is read-only.
- The agent-notification trigger now includes the agent member's action as a directive ("Research this:", "Plan this:", "Critique this:", "Start building:", "Discuss this with the user, ask clarifying questions to develop it:") plus the note and the entry, so the agent knows its job.
- add_member API + request model gain permission + action (400 on a bad value). Schema adds the columns; init does a PRAGMA-guarded ALTER TABLE so an existing DB without them keeps working (tested).

## Permission matrix
| Operation | viewer | contributor | editor | owner/admin |
|---|---|---|---|---|
| read | yes | yes | yes | yes |
| add new entry | no | yes | yes | yes |
| edit / done / delete | no | no | yes | yes |
| manage doc/members | no | no | no | yes |

## Tests
59 notes tests pass (15 new + a few existing updated to the explicit model: the default is now contributor, so tests that edit/delete share with editor). compileall clean. Agent manual untouched (it is at its size cap).

## Follow-up
The "Discuss" action only carries the directive for now. The richer behavior you described -- the agent spinning up a dedicated discussion channel and engaging you with questions -- is a separate slice (it needs careful channel-creation design) and will reference this action.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added role-based sharing permissions for notes, including viewer, contributor, and editor access.
  * Added support for optional agent action directives in shared documents.

* **Bug Fixes**
  * Tightened entry access so only allowed roles can add, edit, delete, or toggle entries.
  * Improved agent write checks so viewers are blocked and only write-enabled members can add entries.
  * Added compatibility for older shared-document databases during upgrade.

* **Tests**
  * Expanded coverage for permissions, member actions, and shared-document behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->