### PR TITLE
feat(todo): Todo app for shared lists (checkbox tasks)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ### Added
 - Notes and Todo: tracked edits. An entry's text is editable and every change is an immutable revision tagged with editor and timestamp, stored as a diff with a full snapshot checkpoint every 20 edits so any past state can be reconstructed (Time Machine foundation). New history and at-revision endpoints expose the log and reconstructed text.
+- Todo app: a checklist companion to Notes for `kind=list` documents, with per-task done checkboxes (completed tasks struck through), shared sharing/permission/agent-action controls, and the same tracked-edit history. Notes and Todo each show only their own document kind.
 
 ## [1.0.0-beta.12] - 2026-06-28
 

--- a/desktop/src/apps/NotesApp.tsx
+++ b/desktop/src/apps/NotesApp.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import {
   StickyNote,
+  ListChecks,
   Plus,
   Clock,
   Users,
@@ -10,8 +11,11 @@ import {
   Trash2,
   Check,
   X,
+  Square,
+  CheckSquare,
   AlertCircle,
   ChevronLeft,
+  type LucideIcon,
 } from "lucide-react";
 import { Button, Textarea } from "@/components/ui";
 
@@ -83,6 +87,50 @@ const ACTION_OPTIONS = [
   { value: "build", label: "Build" },
   { value: "discuss", label: "Discuss" },
 ] as const;
+
+// ---- Kind config ----
+// Notes and lists share one component, one store, and one API; they differ only
+// in copy, icon, and whether entries carry a done checkbox. A config object
+// keeps both variants in sync instead of forking ~1000 lines.
+
+interface DocKindConfig {
+  kind: "note" | "list";
+  appName: string; // header + listing aria
+  icon: LucideIcon;
+  noun: string; // doc-level aria: New {noun}, Create {noun}, Share {noun}
+  titlePlaceholder: string;
+  addPlaceholder: string;
+  emptyDocs: string;
+  emptyEntries: string;
+  selectPrompt: string;
+  showDone: boolean;
+}
+
+const NOTES_CONFIG: DocKindConfig = {
+  kind: "note",
+  appName: "Notes",
+  icon: StickyNote,
+  noun: "note",
+  titlePlaceholder: "Note title...",
+  addPlaceholder: "Add a note...",
+  emptyDocs: "No notes yet.",
+  emptyEntries: "Nothing here yet. Add your first note above.",
+  selectPrompt: "Select a note to get started.",
+  showDone: false,
+};
+
+const TODO_CONFIG: DocKindConfig = {
+  kind: "list",
+  appName: "Todo",
+  icon: ListChecks,
+  noun: "list",
+  titlePlaceholder: "List title...",
+  addPlaceholder: "Add a task...",
+  emptyDocs: "No lists yet.",
+  emptyEntries: "Nothing here yet. Add your first task above.",
+  selectPrompt: "Select a list to get started.",
+  showDone: true,
+};
 
 // ---- Sub-components ----
 
@@ -286,7 +334,7 @@ function SharePanel({ doc, onClose }: { doc: NoteDetail; onClose: () => void }) 
     <div
       className="flex flex-col gap-4 rounded-xl border border-shell-border bg-shell-bg-deep p-4"
       role="dialog"
-      aria-label="Share note"
+      aria-label={`Share ${doc.kind === "list" ? "list" : "note"}`}
     >
       <div className="flex items-center justify-between">
         <span className="flex items-center gap-1.5 text-sm font-semibold text-shell-text">
@@ -471,13 +519,17 @@ function SharePanel({ doc, onClose }: { doc: NoteDetail; onClose: () => void }) 
 function EntryRow({
   entry,
   docId,
+  showDone,
   onDelete,
   onEditSave,
+  onToggleDone,
 }: {
   entry: NoteEntry;
   docId: string;
+  showDone: boolean;
   onDelete: (id: string) => void;
   onEditSave: (id: string, text: string) => Promise<void>;
+  onToggleDone: (id: string, done: boolean) => void;
 }) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(entry.text);
@@ -546,7 +598,29 @@ function EntryRow({
           </div>
         ) : (
           <>
-            <p className="min-w-0 flex-1 whitespace-pre-wrap text-sm text-shell-text">
+            {showDone && (
+              <button
+                type="button"
+                onClick={() => onToggleDone(entry.id, !entry.done)}
+                aria-label={entry.done ? "Mark task not done" : "Mark task done"}
+                aria-pressed={entry.done}
+                className="mt-0.5 shrink-0 text-shell-text-tertiary transition-colors hover:text-accent"
+              >
+                {entry.done ? (
+                  <CheckSquare size={16} className="text-accent" />
+                ) : (
+                  <Square size={16} />
+                )}
+              </button>
+            )}
+            <p
+              className={[
+                "min-w-0 flex-1 whitespace-pre-wrap text-sm",
+                showDone && entry.done
+                  ? "text-shell-text-tertiary line-through"
+                  : "text-shell-text",
+              ].join(" ")}
+            >
               {entry.text}
             </p>
             <div className="flex shrink-0 items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
@@ -598,9 +672,11 @@ function EntryRow({
 // Detail pane for a selected note
 function NoteDetailPane({
   docId,
+  config,
   onBack,
 }: {
   docId: string;
+  config: DocKindConfig;
   onBack: () => void;
 }) {
   const [doc, setDoc] = useState<NoteDetail | null>(null);
@@ -681,6 +757,36 @@ function NoteDetailPane({
     );
   }
 
+  async function toggleDone(entryId: string, done: boolean) {
+    if (!doc) return;
+    // Optimistic: flip immediately, revert on failure.
+    setDoc((prev) =>
+      prev
+        ? { ...prev, entries: prev.entries.map((e) => (e.id === entryId ? { ...e, done } : e)) }
+        : prev,
+    );
+    try {
+      const r = await fetch(`/api/notes/${doc.id}/entries/${entryId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ done }),
+      });
+      if (!r.ok) throw new Error("Could not update task.");
+    } catch (e) {
+      setDoc((prev) =>
+        prev
+          ? {
+              ...prev,
+              entries: prev.entries.map((el) =>
+                el.id === entryId ? { ...el, done: !done } : el,
+              ),
+            }
+          : prev,
+      );
+      setError(e instanceof Error ? e.message : "Could not update task.");
+    }
+  }
+
   if (loading) {
     return (
       <div className="flex h-full items-center justify-center">
@@ -700,6 +806,7 @@ function NoteDetailPane({
   const members = doc.members ?? [];
   const hasMembers = members.length > 0;
   const hasAgentMembers = members.some((m) => m.member_type === "agent");
+  const Icon = config.icon;
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
@@ -741,7 +848,7 @@ function NoteDetailPane({
             variant="outline"
             size="sm"
             onClick={() => setShowShare((v) => !v)}
-            aria-label="Share note"
+            aria-label={`Share ${config.noun}`}
             aria-expanded={showShare}
           >
             <Users size={13} />
@@ -769,7 +876,7 @@ function NoteDetailPane({
             <Textarea
               value={newText}
               onChange={(e) => setNewText(e.target.value)}
-              placeholder="Add a note..."
+              placeholder={config.addPlaceholder}
               rows={2}
               maxLength={20000}
               aria-label="New entry text"
@@ -803,15 +910,17 @@ function NoteDetailPane({
                   key={entry.id}
                   entry={entry}
                   docId={doc.id}
+                  showDone={config.showDone}
                   onDelete={deleteEntry}
                   onEditSave={editEntry}
+                  onToggleDone={toggleDone}
                 />
               ))}
             </ul>
           ) : (
             <div className="flex flex-col items-center gap-2 py-10 text-center">
-              <StickyNote size={28} className="text-shell-text-tertiary" />
-              <p className="text-sm text-shell-text-secondary">Nothing here yet. Add your first note above.</p>
+              <Icon size={28} className="text-shell-text-tertiary" />
+              <p className="text-sm text-shell-text-secondary">{config.emptyEntries}</p>
             </div>
           )}
 
@@ -862,7 +971,8 @@ function NoteListItem({
 }
 
 // Create note modal/inline form
-function CreateNoteForm({ onCreated, onCancel }: {
+function CreateNoteForm({ config, onCreated, onCancel }: {
+  config: DocKindConfig;
   onCreated: (note: NoteDoc) => void;
   onCancel: () => void;
 }) {
@@ -883,9 +993,9 @@ function CreateNoteForm({ onCreated, onCancel }: {
       const r = await fetch("/api/notes", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ kind: "note", title: title.trim() }),
+        body: JSON.stringify({ kind: config.kind, title: title.trim() }),
       });
-      if (!r.ok) throw new Error("Could not create note.");
+      if (!r.ok) throw new Error(`Could not create ${config.noun}.`);
       const doc: NoteDoc = await r.json();
       onCreated(doc);
     } catch (e) {
@@ -901,8 +1011,8 @@ function CreateNoteForm({ onCreated, onCancel }: {
         type="text"
         value={title}
         onChange={(e) => setTitle(e.target.value)}
-        placeholder="Note title..."
-        aria-label="New note title"
+        placeholder={config.titlePlaceholder}
+        aria-label={`New ${config.noun} title`}
         maxLength={255}
         onKeyDown={(e) => {
           if (e.key === "Enter") { e.preventDefault(); void create(); }
@@ -917,7 +1027,7 @@ function CreateNoteForm({ onCreated, onCancel }: {
         <Button type="button" variant="ghost" size="sm" onClick={onCancel} disabled={creating} aria-label="Cancel">
           Cancel
         </Button>
-        <Button type="button" size="sm" onClick={create} disabled={creating || !title.trim()} aria-label="Create note">
+        <Button type="button" size="sm" onClick={create} disabled={creating || !title.trim()} aria-label={`Create ${config.noun}`}>
           {creating ? "Creating..." : "Create"}
         </Button>
       </div>
@@ -927,7 +1037,7 @@ function CreateNoteForm({ onCreated, onCancel }: {
 
 // ---- Main app ----
 
-export function NotesApp({ windowId: _windowId }: { windowId: string }) {
+function DocsApp({ config }: { config: DocKindConfig }) {
   const [notes, setNotes] = useState<NoteDoc[]>([]);
   const [loading, setLoading] = useState(true);
   const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -938,14 +1048,16 @@ export function NotesApp({ windowId: _windowId }: { windowId: string }) {
       const r = await fetch("/api/notes");
       if (r.ok) {
         const data: unknown = await r.json();
-        setNotes(Array.isArray(data) ? (data as NoteDoc[]) : []);
+        const all = Array.isArray(data) ? (data as NoteDoc[]) : [];
+        // Notes and lists share one API; each app shows only its own kind.
+        setNotes(all.filter((d) => d.kind === config.kind));
       }
     } catch {
       // Keep whatever was loaded.
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [config.kind]);
 
   useEffect(() => {
     loadNotes();
@@ -957,24 +1069,26 @@ export function NotesApp({ windowId: _windowId }: { windowId: string }) {
     setShowCreate(false);
   }
 
+  const Icon = config.icon;
+
   return (
     <div className="flex h-full overflow-hidden bg-shell-bg">
-      {/* Left pane: note list */}
+      {/* Left pane: doc list */}
       <div
         className={[
           "flex flex-col border-r border-shell-border",
-          // On mobile, hide the list pane when a note is selected
+          // On mobile, hide the list pane when a doc is selected
           selectedId ? "hidden md:flex md:w-72 lg:w-80" : "flex w-full md:w-72 lg:w-80",
         ].join(" ")}
       >
         {/* List header */}
         <div className="flex items-center gap-2 border-b border-shell-border px-4 py-4">
-          <StickyNote size={17} className="text-accent" />
-          <h1 className="flex-1 text-base font-semibold text-shell-text">Notes</h1>
+          <Icon size={17} className="text-accent" />
+          <h1 className="flex-1 text-base font-semibold text-shell-text">{config.appName}</h1>
           <button
             type="button"
             onClick={() => setShowCreate((v) => !v)}
-            aria-label="New note"
+            aria-label={`New ${config.noun}`}
             aria-expanded={showCreate}
             className={[
               "flex h-8 w-8 items-center justify-center rounded-lg border transition-colors",
@@ -991,6 +1105,7 @@ export function NotesApp({ windowId: _windowId }: { windowId: string }) {
         {showCreate && (
           <div className="border-b border-shell-border px-3 py-3">
             <CreateNoteForm
+              config={config}
               onCreated={handleCreated}
               onCancel={() => setShowCreate(false)}
             />
@@ -1003,8 +1118,8 @@ export function NotesApp({ windowId: _windowId }: { windowId: string }) {
             <p className="text-sm text-shell-text-tertiary">Loading...</p>
           ) : notes.length === 0 ? (
             <div className="flex flex-col items-center gap-2 py-16 text-center">
-              <StickyNote size={28} className="text-shell-text-tertiary" />
-              <p className="text-sm text-shell-text-secondary">No notes yet.</p>
+              <Icon size={28} className="text-shell-text-tertiary" />
+              <p className="text-sm text-shell-text-secondary">{config.emptyDocs}</p>
               <button
                 type="button"
                 onClick={() => setShowCreate(true)}
@@ -1014,7 +1129,7 @@ export function NotesApp({ windowId: _windowId }: { windowId: string }) {
               </button>
             </div>
           ) : (
-            <ul className="flex flex-col gap-2" aria-label="Notes">
+            <ul className="flex flex-col gap-2" aria-label={config.appName}>
               {notes.map((note) => (
                 <NoteListItem
                   key={note.id}
@@ -1039,15 +1154,24 @@ export function NotesApp({ windowId: _windowId }: { windowId: string }) {
           <NoteDetailPane
             key={selectedId}
             docId={selectedId}
+            config={config}
             onBack={() => setSelectedId(null)}
           />
         ) : (
           <div className="flex h-full flex-col items-center justify-center gap-2 text-center">
-            <StickyNote size={32} className="text-shell-text-tertiary" />
-            <p className="text-sm text-shell-text-secondary">Select a note to get started.</p>
+            <Icon size={32} className="text-shell-text-tertiary" />
+            <p className="text-sm text-shell-text-secondary">{config.selectPrompt}</p>
           </div>
         )}
       </div>
     </div>
   );
+}
+
+export function NotesApp({ windowId: _windowId }: { windowId: string }) {
+  return <DocsApp config={NOTES_CONFIG} />;
+}
+
+export function TodoApp({ windowId: _windowId }: { windowId: string }) {
+  return <DocsApp config={TODO_CONFIG} />;
 }

--- a/desktop/src/apps/__tests__/NotesApp.test.tsx
+++ b/desktop/src/apps/__tests__/NotesApp.test.tsx
@@ -23,7 +23,7 @@ vi.mock("@/components/ui", () => ({
   ),
 }));
 
-import { NotesApp } from "../NotesApp";
+import { NotesApp, TodoApp } from "../NotesApp";
 
 const NOTE_LIST = [
   { id: "note-1", kind: "note", title: "My First Note", updated_at: new Date().toISOString(), archived_at: null },
@@ -203,6 +203,82 @@ describe("NotesApp", () => {
       expect(body.permission).toBe("contributor");
       expect(body.action).toBe("research");
       expect(body.standing_instruction).toBe("Focus on recent papers");
+    });
+  });
+});
+
+// ---- Todo (list) variant ----
+
+const MIXED_LIST = [
+  { id: "note-1", kind: "note", title: "My First Note", updated_at: new Date().toISOString(), archived_at: null },
+  { id: "list-1", kind: "list", title: "Groceries", updated_at: new Date().toISOString(), archived_at: null },
+];
+
+const LIST_DETAIL = {
+  id: "list-1",
+  kind: "list",
+  title: "Groceries",
+  updated_at: new Date().toISOString(),
+  entries: [
+    { id: "task-1", text: "Buy milk", done: false, author: null, created_at: new Date().toISOString() },
+  ],
+  members: [],
+};
+
+function makeListFetch() {
+  return vi.fn(async (url: string, init?: RequestInit) => {
+    const u = String(url);
+    const method = (init?.method ?? "GET").toUpperCase();
+
+    if (u === "/api/notes" && method === "GET") {
+      return { ok: true, json: async () => MIXED_LIST };
+    }
+    if (u === "/api/notes/list-1" && method === "GET") {
+      return { ok: true, json: async () => LIST_DETAIL };
+    }
+    if (u.startsWith("/api/notes/list-1/entries/task-1") && method === "PATCH") {
+      return { ok: true, json: async () => ({ ok: true }) };
+    }
+    return { ok: true, json: async () => ({}) };
+  });
+}
+
+describe("TodoApp", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows the Todo header and only list-kind docs", async () => {
+    global.fetch = makeListFetch() as typeof fetch;
+    render(<TodoApp windowId="w1" />);
+
+    await waitFor(() => expect(screen.getByText("Todo")).toBeDefined());
+    // A list doc shows; a note doc is filtered out.
+    await waitFor(() => expect(screen.getByText("Groceries")).toBeDefined());
+    expect(screen.queryByText("My First Note")).toBeNull();
+    expect(screen.getByLabelText("New list")).toBeDefined();
+  });
+
+  it("toggles a task done via PATCH /entries/{id}", async () => {
+    const fetchMock = makeListFetch();
+    global.fetch = fetchMock as typeof fetch;
+    render(<TodoApp windowId="w1" />);
+
+    await waitFor(() => expect(screen.getByText("Groceries")).toBeDefined());
+    fireEvent.click(screen.getByText("Groceries"));
+
+    await waitFor(() => expect(screen.getByText("Buy milk")).toBeDefined());
+    fireEvent.click(screen.getByLabelText("Mark task done"));
+
+    await waitFor(() => {
+      const patch = (fetchMock.mock.calls as [string, RequestInit?][]).filter(
+        ([u, init]) =>
+          String(u) === "/api/notes/list-1/entries/task-1" &&
+          (init?.method ?? "GET").toUpperCase() === "PATCH",
+      );
+      expect(patch.length).toBeGreaterThan(0);
+      const body = JSON.parse(patch[0]![1]!.body as string);
+      expect(body.done).toBe(true);
     });
   });
 });

--- a/desktop/src/registry/app-registry.ts
+++ b/desktop/src/registry/app-registry.ts
@@ -63,6 +63,7 @@ const apps: AppManifest[] = [
   { id: "decisions", name: "Decisions", icon: "inbox", category: "platform", component: () => import("@/apps/DecisionsApp").then((m) => ({ default: m.DecisionsApp })), defaultSize: { w: 640, h: 620 }, minSize: { w: 420, h: 400 }, singleton: true, pinned: false, launchpadOrder: 16.6 },
   { id: "observatory", name: "Observatory", icon: "radar", category: "platform", component: () => import("@/apps/ObservatoryApp").then((m) => ({ default: m.ObservatoryApp })), defaultSize: { w: 620, h: 600 }, minSize: { w: 420, h: 400 }, singleton: true, pinned: false, launchpadOrder: 16.7 },
   { id: "notes", name: "Notes", icon: "sticky-note", category: "platform", component: () => import("@/apps/NotesApp").then((m) => ({ default: m.NotesApp })), defaultSize: { w: 860, h: 620 }, minSize: { w: 520, h: 400 }, singleton: true, pinned: false, launchpadOrder: 16.8 },
+  { id: "todo", name: "Todo", icon: "list-checks", category: "platform", component: () => import("@/apps/NotesApp").then((m) => ({ default: m.TodoApp })), defaultSize: { w: 860, h: 620 }, minSize: { w: 520, h: 400 }, singleton: true, pinned: false, launchpadOrder: 16.85 },
 
   // OS apps
   { id: "weather", name: "Weather", icon: "cloud", category: "os", component: () => import("@/apps/WeatherApp").then((m) => ({ default: m.WeatherApp })), defaultSize: { w: 800, h: 600 }, minSize: { w: 400, h: 400 }, singleton: true, pinned: false, launchpadOrder: 19 },


### PR DESCRIPTION
## What

Adds a **Todo** app as a checklist companion to Notes, built on the existing shared-docs backend (`kind=list`). No backend changes were needed: the store, API, sharing, permission levels, agent actions, and tracked-edit history already support lists.

## How

`NotesApp.tsx` is refactored into a kind-parameterized `DocsApp` core driven by a `DocKindConfig` (`NOTES_CONFIG` / `TODO_CONFIG`), with thin `NotesApp` and `TodoApp` exports. This keeps both variants in sync rather than forking ~1000 lines.

Differences for the list variant:
- Per-task **done checkbox**; completed tasks are struck through and dimmed. Toggling uses the existing `PATCH /api/notes/{doc}/entries/{entry}` (optimistic, reverts on failure).
- Copy and icon (ListChecks, "Add a task...", "New list").
- Each app shows **only its own document kind** (Notes filters to notes, Todo to lists).

Sharing (viewer/contributor/editor), agent actions (research/plan/critique/build/discuss), and tracked-edit history are inherited from Notes unchanged.

## Verification

- `tsc --noEmit` clean; full desktop vitest suite green (2185 tests) including 2 new TodoApp tests (kind filtering + done-toggle PATCH).
- Booted the real component via a vite preview harness and verified in-browser: list view filters out note docs; detail pane renders checkboxes with done tasks struck through and open tasks unchecked; correct `aria-pressed` and `text-decoration` per state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Todo app for checklist-style documents alongside Notes.
  * Tasks can now be marked done with inline completion controls and updated styling.
  * Creating and viewing documents now adapts to the selected document type, including labels and empty states.

* **Bug Fixes**
  * Document lists now correctly filter to show only the matching type in each app.
  * Task completion updates use optimistic changes with rollback if an update fails.

* **Chores**
  * Added the new Todo app to the app launcher.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->