### PR TITLE
chore(agent-tools): steer open_app toward Notes/Todo/Decisions/Observatory/Mail

### DIFF
--- a/docs/agent-manual/09-os-control.md
+++ b/docs/agent-manual/09-os-control.md
@@ -5,11 +5,11 @@ is easier shown than described, open the app and do it.
 
 Tools available to you:
 
-- **open_app** — open or focus an app so the user can see it. Args: `app` (one of
-  projects, images, chat, messages, agents, files, store, settings, terminal,
-  browser, memory, models), optional `props` to deep-link. Open the relevant app
-  before you act in it (e.g. open `projects` before creating a project, `images`
-  before generating artwork).
+- **open_app** — open or focus an app so the user can see it. Args: `app` (e.g.
+  projects, images, messages, mail, notes, todo, decisions, observatory, agents,
+  files, store, settings, browser, memory, models; any registered app id works),
+  optional `props` to deep-link. Open the app before you act in it (e.g.
+  `projects` before creating one).
 - **arrange_windows** — tidy the open windows. `preset`: `tile-2`, `tile-3`,
   `center`, or `cascade`.
 

--- a/docs/taos-agent-manual.md
+++ b/docs/taos-agent-manual.md
@@ -149,11 +149,11 @@ is easier shown than described, open the app and do it.
 
 Tools available to you:
 
-- **open_app** — open or focus an app so the user can see it. Args: `app` (one of
-  projects, images, chat, messages, agents, files, store, settings, terminal,
-  browser, memory, models), optional `props` to deep-link. Open the relevant app
-  before you act in it (e.g. open `projects` before creating a project, `images`
-  before generating artwork).
+- **open_app** — open or focus an app so the user can see it. Args: `app` (e.g.
+  projects, images, messages, mail, notes, todo, decisions, observatory, agents,
+  files, store, settings, browser, memory, models; any registered app id works),
+  optional `props` to deep-link. Open the app before you act in it (e.g.
+  `projects` before creating one).
 - **arrange_windows** — tidy the open windows. `preset`: `tile-2`, `tile-3`,
   `center`, or `cascade`.
 

--- a/tinyagentos/tools/desktop_tools.py
+++ b/tinyagentos/tools/desktop_tools.py
@@ -19,8 +19,9 @@ from tinyagentos.desktop_control.broker import DesktopCommand
 # Known desktop app ids the agent can open. The browser resolves aliases/names
 # too, but listing the common ones in the schema steers the model.
 KNOWN_APPS = [
-    "chat", "messages", "projects", "agents", "files", "store", "settings",
-    "images", "terminal", "browser", "memory", "models",
+    "chat", "messages", "mail", "projects", "agents", "files", "store",
+    "settings", "images", "notes", "todo", "decisions", "observatory",
+    "terminal", "browser", "memory", "models",
 ]
 
 OPEN_APP_TOOL = {


### PR DESCRIPTION
## What

The `open_app` agent tool accepts **any** registered desktop app id (it passes the id straight to the desktop broker), but the `KNOWN_APPS` schema hint and the agent manual only listed the original platform apps. So the model was never steered toward the newer first-class apps: Notes, Todo, Decisions, Observatory, and Mail.

## Change

- `KNOWN_APPS` in `desktop_tools.py`: add `mail, notes, todo, decisions, observatory`.
- Agent manual `open_app` entry: sync the list and note that any registered app id works (trimmed surrounding copy to stay under the compiled-manual 16000-char cap; recompiled to 15989).

No behaviour change: the tool already accepted these ids. This only improves the steering hint so an agent discovers and opens them.

## Verification

- `compileall` clean; `test_desktop_tools.py`, `test_skill_runtime.py`, and `test_agent_manual_compiled.py` (sync + cap) all green.