### PR TITLE
feat(notes): notes_set_done agent tool for shared todo lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 ### Added
 - Notes and Todo: tracked edits. An entry's text is editable and every change is an immutable revision tagged with editor and timestamp, stored as a diff with a full snapshot checkpoint every 20 edits so any past state can be reconstructed (Time Machine foundation). New history and at-revision endpoints expose the log and reconstructed text.
 - Todo app: a checklist companion to Notes for `kind=list` documents, with per-task done checkboxes (completed tasks struck through), shared sharing/permission/agent-action controls, and the same tracked-edit history. Notes and Todo each show only their own document kind.
+- Agent tool `notes_set_done`: an agent shared on a list (contributor or editor) can mark a task done or reopen it, completing the agent surface for shared todos. Membership, permission, archived-doc, and entry-belongs-to-doc are all enforced.
 
 ## [1.0.0-beta.12] - 2026-06-28
 

--- a/tests/notes/test_notes_tools.py
+++ b/tests/notes/test_notes_tools.py
@@ -8,7 +8,11 @@ import pytest
 import pytest_asyncio
 
 from tinyagentos.notes.shared_docs_store import SharedDocsStore
-from tinyagentos.tools.notes_tools import execute_notes_add_entry, execute_notes_list_shared_docs
+from tinyagentos.tools.notes_tools import (
+    execute_notes_add_entry,
+    execute_notes_list_shared_docs,
+    execute_notes_set_done,
+)
 
 
 # --------------------------------------------------------------------- helpers
@@ -197,3 +201,118 @@ async def test_list_shared_docs_excludes_internal_fields(store):
     keys = set(res["docs"][0].keys())
     assert "owner_user_id" not in keys
     assert keys <= {"id", "kind", "title", "updated_at"}
+
+
+# -------------------------------------------------------------- set_done tests
+
+@pytest.mark.asyncio
+async def test_agent_member_can_mark_task_done(store):
+    doc = await store.create_doc("user-1", "list", "Build List")
+    await store.add_member(doc["id"], "agent", "atlas")
+    entry = await store.add_entry(doc["id"], "Ship the feature", author="user-1")
+
+    req = _make_request(store)
+    res = await execute_notes_set_done(
+        {"agent_name": "atlas", "doc_id": doc["id"], "entry_id": entry["id"], "done": True},
+        req,
+    )
+    assert res.get("ok") is True
+    assert res["done"] is True
+
+    entries = await store.list_entries(doc["id"])
+    target = next(e for e in entries if e["id"] == entry["id"])
+    assert target["done"] is True
+
+    # And it can be reopened.
+    res = await execute_notes_set_done(
+        {"agent_name": "atlas", "doc_id": doc["id"], "entry_id": entry["id"], "done": False},
+        req,
+    )
+    assert res.get("ok") is True
+    entries = await store.list_entries(doc["id"])
+    target = next(e for e in entries if e["id"] == entry["id"])
+    assert target["done"] is False
+
+
+@pytest.mark.asyncio
+async def test_viewer_agent_cannot_mark_done(store):
+    doc = await store.create_doc("user-1", "list", "Read Only")
+    await store.add_member(doc["id"], "agent", "atlas", permission="viewer")
+    entry = await store.add_entry(doc["id"], "A task", author="user-1")
+
+    req = _make_request(store)
+    res = await execute_notes_set_done(
+        {"agent_name": "atlas", "doc_id": doc["id"], "entry_id": entry["id"], "done": True},
+        req,
+    )
+    assert "error" in res
+    assert "permission" in res["error"]
+
+    entries = await store.list_entries(doc["id"])
+    assert entries[0]["done"] is False
+
+
+@pytest.mark.asyncio
+async def test_non_member_agent_cannot_mark_done(store):
+    doc = await store.create_doc("user-1", "list", "Private")
+    entry = await store.add_entry(doc["id"], "A task", author="user-1")
+
+    req = _make_request(store)
+    res = await execute_notes_set_done(
+        {"agent_name": "intruder", "doc_id": doc["id"], "entry_id": entry["id"], "done": True},
+        req,
+    )
+    assert "error" in res
+    assert "permission" in res["error"]
+
+
+@pytest.mark.asyncio
+async def test_set_done_rejects_entry_from_another_doc(store):
+    doc_a = await store.create_doc("user-1", "list", "List A")
+    await store.add_member(doc_a["id"], "agent", "atlas")
+    doc_b = await store.create_doc("user-1", "list", "List B")
+    foreign = await store.add_entry(doc_b["id"], "Not yours", author="user-1")
+
+    req = _make_request(store)
+    res = await execute_notes_set_done(
+        {"agent_name": "atlas", "doc_id": doc_a["id"], "entry_id": foreign["id"], "done": True},
+        req,
+    )
+    assert "error" in res
+    assert "not found" in res["error"]
+
+    entries = await store.list_entries(doc_b["id"])
+    assert entries[0]["done"] is False
+
+
+@pytest.mark.asyncio
+async def test_set_done_on_archived_doc_rejected(store):
+    doc = await store.create_doc("user-1", "list", "Old List")
+    await store.add_member(doc["id"], "agent", "atlas")
+    entry = await store.add_entry(doc["id"], "A task", author="user-1")
+    await store.archive_doc(doc["id"])
+
+    req = _make_request(store)
+    res = await execute_notes_set_done(
+        {"agent_name": "atlas", "doc_id": doc["id"], "entry_id": entry["id"], "done": True},
+        req,
+    )
+    assert "error" in res
+    assert "archived" in res["error"]
+
+
+@pytest.mark.asyncio
+async def test_set_done_missing_or_bad_fields_returns_error(store):
+    req = _make_request(store)
+
+    # missing done
+    res = await execute_notes_set_done({"agent_name": "atlas", "doc_id": "d", "entry_id": "e"}, req)
+    assert "error" in res
+    # non-boolean done
+    res = await execute_notes_set_done(
+        {"agent_name": "atlas", "doc_id": "d", "entry_id": "e", "done": "yes"}, req
+    )
+    assert "error" in res
+    # missing entry_id
+    res = await execute_notes_set_done({"agent_name": "atlas", "doc_id": "d", "done": True}, req)
+    assert "error" in res

--- a/tinyagentos/routes/skill_exec.py
+++ b/tinyagentos/routes/skill_exec.py
@@ -377,6 +377,16 @@ async def _skill_notes_add_entry(args: dict, request: Request) -> dict:
         return {"error": str(exc)}
 
 
+async def _skill_notes_set_done(args: dict, request: Request) -> dict:
+    """Mark a list task done/not-done on a shared doc the agent belongs to."""
+    try:
+        from tinyagentos.tools.notes_tools import execute_notes_set_done
+
+        return await execute_notes_set_done(args, request)
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
 SKILL_IMPLEMENTATIONS = {
     "memory_search": _skill_memory_search,
     "file_read": _skill_file_read,
@@ -404,6 +414,7 @@ SKILL_IMPLEMENTATIONS = {
     "export_storybook": _skill_export_storybook,
     "notes_list_shared_docs": _skill_notes_list_shared_docs,
     "notes_add_entry": _skill_notes_add_entry,
+    "notes_set_done": _skill_notes_set_done,
 }
 
 

--- a/tinyagentos/skills.py
+++ b/tinyagentos/skills.py
@@ -684,6 +684,32 @@ class SkillStore(BaseStore):
                 "install_method": "builtin",
                 "install_target": "tinyagentos.tools.notes_tools",
             },
+            {
+                "id": "notes_set_done",
+                "name": "Set Notes Task Done",
+                "category": "notes",
+                "description": "Mark a task done or not done on a shared list the agent is a member of",
+                "tool_schema": {
+                    "name": "notes_set_done",
+                    "description": "Mark a task on a shared list done or not done. Use notes_list_shared_docs to find the doc_id and read the entry ids. The agent needs contributor or editor permission.",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {
+                            "doc_id": {"type": "string", "description": "Id of the shared list (from notes_list_shared_docs)."},
+                            "entry_id": {"type": "string", "description": "Id of the task entry to mark."},
+                            "done": {"type": "boolean", "description": "True to mark done, false to reopen."},
+                        },
+                        "required": ["doc_id", "entry_id", "done"],
+                    },
+                },
+                "frameworks": {
+                    "smolagents": "adapter", "openclaw": "adapter", "pocketflow": "adapter",
+                    "langroid": "adapter", "hermes": "adapter", "agent-zero": "adapter",
+                    "openai-agents-sdk": "adapter", "generic": "adapter",
+                },
+                "install_method": "builtin",
+                "install_target": "tinyagentos.tools.notes_tools",
+            },
 
         ]
 

--- a/tinyagentos/tools/notes_tools.py
+++ b/tinyagentos/tools/notes_tools.py
@@ -76,3 +76,54 @@ async def execute_notes_add_entry(args: dict, request: Request) -> dict:
         return {"ok": True, "entry_id": entry["id"]}
     except Exception as exc:
         return {"error": str(exc)}
+
+
+async def execute_notes_set_done(args: dict, request: Request) -> dict:
+    """Mark a list task done (or not done) on a shared doc the agent belongs to.
+
+    Completes the Todo surface for agents: an agent told to work a shared list
+    can check tasks off as it finishes them. The agent must have 'contributor'
+    or 'editor' permission, the entry must belong to the named doc, and the doc
+    must not be archived.
+    """
+    args = args or {}
+    agent_name = args.get("agent_name")
+    doc_id = args.get("doc_id")
+    entry_id = args.get("entry_id")
+    done = args.get("done")
+
+    if not agent_name or not isinstance(agent_name, str):
+        return {"error": "notes_set_done requires an 'agent_name' string"}
+    if not doc_id or not isinstance(doc_id, str):
+        return {"error": "notes_set_done requires a 'doc_id' string"}
+    if not entry_id or not isinstance(entry_id, str):
+        return {"error": "notes_set_done requires an 'entry_id' string"}
+    if not isinstance(done, bool):
+        return {"error": "notes_set_done requires a boolean 'done'"}
+
+    try:
+        store = request.app.state.shared_docs_store
+
+        members = await store.agent_members(doc_id)
+        agent_member = next((m for m in members if m["agent"] == agent_name), None)
+        if agent_member is None:
+            return {"error": "agent does not have write permission on this doc"}
+
+        perm = agent_member.get("permission", "contributor")
+        if perm not in ("contributor", "editor"):
+            return {"error": "agent does not have write permission on this doc"}
+
+        doc = await store.get_doc(doc_id)
+        if doc is None:
+            return {"error": "doc not found"}
+        if doc.get("archived_at") is not None:
+            return {"error": "doc is archived"}
+
+        # Confine the agent to entries of the doc it actually belongs to.
+        if not any(e.get("id") == entry_id for e in doc.get("entries", [])):
+            return {"error": "entry not found in this doc"}
+
+        await store.set_entry_done(entry_id, done)
+        return {"ok": True, "entry_id": entry_id, "done": done}
+    except Exception as exc:
+        return {"error": str(exc)}


### PR DESCRIPTION
## What

Completes the agent surface for the Todo app (#1478). Agents shared on a list could already `notes_add_entry` but had no way to **check a task off**. This adds `notes_set_done` so a build-action agent can mark items done or reopen them as it works a shared list.

## Guards (mirror `notes_add_entry`)

- Agent must be a member with **contributor or editor** permission (viewer rejected).
- Doc must exist and not be archived.
- The entry must belong to the named doc, so an agent cannot toggle an entry in a doc it is not a member of.

## Wiring

- `execute_notes_set_done` in `notes_tools.py` (uses the existing `set_entry_done` store method).
- Registered in `skills.py` `_seed_defaults` + `skill_exec.py` `SKILL_IMPLEMENTATIONS`.
- 6 new tests: mark done + reopen, viewer rejected, non-member rejected, foreign-entry rejected, archived-doc rejected, bad-field validation.

## Notes

No HTTP route change (this is the agent-tool path; the human UI already toggles done via `PATCH /entries/{id}`). The agent-manual one-line mention is deferred to a tiny follow-up once #1479 lands, to avoid a conflict on the regenerated `taos-agent-manual.md`.

## Verification

`compileall` clean; `test_notes_tools.py` (17), `test_skill_runtime.py`, and the full `tests/notes/` suite (75 total) green; dispatch key present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shared notes now support marking individual tasks as done or reopening them.
  * Contributors and editors can update task status directly from the agent tools.
* **Bug Fixes**
  * Added checks to prevent changes on archived notes.
  * Prevented updates to tasks that don’t belong to the selected note.
  * Improved validation and permission handling for invalid or unauthorized requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->