### PR TITLE
feat(notes): discuss action spins up a threaded topic channel

### DIFF
--- a/tests/notes/test_notes_routes.py
+++ b/tests/notes/test_notes_routes.py
@@ -656,3 +656,100 @@ async def test_trigger_skips_authoring_agent(tmp_path):
     assert "ch-nova" in sent
     assert "ch-atlas" not in sent
     await store.close()
+
+
+@pytest.mark.asyncio
+async def test_discuss_action_creates_and_reuses_topic_channel(tmp_path):
+    """A 'discuss' agent gets a dedicated topic channel (not its DM), threaded across entries."""
+    import yaml
+    from types import SimpleNamespace
+
+    from tinyagentos.chat.channel_store import ChatChannelStore
+    from tinyagentos.routes.notes import _trigger_agent_notifications
+
+    config_data = _make_config(tmp_path)
+    (tmp_path / "config.yaml").write_text(yaml.dump(config_data))
+    app = create_app(data_dir=tmp_path)
+    store = SharedDocsStore(tmp_path / "shared_docs.db")
+    await store.init()
+    app.state.shared_docs_store = store
+
+    channels = ChatChannelStore(tmp_path / "chat.db")
+    await channels.init()
+    app.state.chat_channels = channels
+
+    doc = await store.create_doc("owner", "note", "Big Idea")
+    await store.add_member(doc["id"], "agent", "atlas", action="discuss")
+    app.state.config.agents.append({"name": "atlas", "chat_channel_id": "ch-atlas"})
+
+    sent: list[dict] = []
+
+    async def _fake_send(channel_id, author_id, author_type, content, **kwargs):
+        sent.append({"channel_id": channel_id, "content": content})
+        return {}
+
+    msg = MagicMock()
+    msg.send_message = _fake_send
+    app.state.chat_messages = msg
+
+    req = SimpleNamespace(app=SimpleNamespace(state=app.state))
+    await _trigger_agent_notifications(req, doc, "an idea to develop")
+
+    # Posted to a fresh topic channel, NOT the agent DM, with the discuss directive.
+    assert len(sent) == 1
+    ch_id = sent[0]["channel_id"]
+    assert ch_id != "ch-atlas"
+    assert "clarifying questions" in sent[0]["content"]
+
+    ch = await channels.get_channel(ch_id)
+    assert ch is not None
+    assert ch["type"] == "topic"
+    assert "atlas" in (ch.get("members") or [])
+    assert "atlas" in (ch.get("settings") or {}).get("leads", [])
+
+    # Persisted and reused on the next entry (no second channel).
+    assert await store.discuss_channel_for(doc["id"], "atlas") == ch_id
+    await _trigger_agent_notifications(req, doc, "a second idea")
+    assert sent[1]["channel_id"] == ch_id
+    all_channels = await channels.list_channels()
+    discuss = [c for c in all_channels if (c.get("settings") or {}).get("kind") == "notes-discuss"]
+    assert len(discuss) == 1
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_discuss_action_falls_back_to_dm_without_channel_store(tmp_path):
+    """If no chat-channel store is available, a discuss agent still gets its DM."""
+    import yaml
+    from types import SimpleNamespace
+
+    from tinyagentos.routes.notes import _trigger_agent_notifications
+
+    config_data = _make_config(tmp_path)
+    (tmp_path / "config.yaml").write_text(yaml.dump(config_data))
+    app = create_app(data_dir=tmp_path)
+    store = SharedDocsStore(tmp_path / "shared_docs.db")
+    await store.init()
+    app.state.shared_docs_store = store
+    app.state.chat_channels = None  # no channel store
+
+    doc = await store.create_doc("owner", "note", "Big Idea")
+    await store.add_member(doc["id"], "agent", "atlas", action="discuss")
+    app.state.config.agents.append({"name": "atlas", "chat_channel_id": "ch-atlas"})
+
+    sent: list[str] = []
+
+    async def _fake_send(channel_id, author_id, author_type, content, **kwargs):
+        sent.append(channel_id)
+        return {}
+
+    msg = MagicMock()
+    msg.send_message = _fake_send
+    app.state.chat_messages = msg
+
+    req = SimpleNamespace(app=SimpleNamespace(state=app.state))
+    await _trigger_agent_notifications(req, doc, "an idea")
+
+    # Fell back to the DM channel rather than dropping the notification.
+    assert sent == ["ch-atlas"]
+    await store.close()

--- a/tinyagentos/notes/shared_docs_store.py
+++ b/tinyagentos/notes/shared_docs_store.py
@@ -105,6 +105,13 @@ class SharedDocsStore(BaseStore):
             await self._db.execute(
                 "ALTER TABLE shared_doc_members ADD COLUMN action TEXT"
             )
+        # `discuss_channel_id` caches the topic channel an agent's "discuss"
+        # action spun up for this doc, so the discussion stays threaded across
+        # entries instead of forking a new channel each time.
+        if "discuss_channel_id" not in cols:
+            await self._db.execute(
+                "ALTER TABLE shared_doc_members ADD COLUMN discuss_channel_id TEXT"
+            )
         await self._db.commit()
 
     # ------------------------------------------------------------------ docs
@@ -415,6 +422,25 @@ class SharedDocsStore(BaseStore):
         if row is None:
             return None
         return row[0]
+
+    async def discuss_channel_for(self, doc_id: str, agent_name: str) -> str | None:
+        """Return the cached discuss-topic channel id for an agent member, if any."""
+        cur = await self._db.execute(
+            "SELECT discuss_channel_id FROM shared_doc_members "
+            "WHERE doc_id = ? AND member_type = 'agent' AND member_id = ?",
+            (doc_id, agent_name),
+        )
+        row = await cur.fetchone()
+        return row[0] if row and row[0] else None
+
+    async def set_discuss_channel(self, doc_id: str, agent_name: str, channel_id: str) -> None:
+        """Persist the topic channel an agent's discuss action created for this doc."""
+        await self._db.execute(
+            "UPDATE shared_doc_members SET discuss_channel_id = ? "
+            "WHERE doc_id = ? AND member_type = 'agent' AND member_id = ?",
+            (channel_id, doc_id, agent_name),
+        )
+        await self._db.commit()
 
     async def docs_for_agent(self, agent_name: str) -> list[dict]:
         """Non-archived docs where the given agent is an agent-type member."""

--- a/tinyagentos/routes/notes.py
+++ b/tinyagentos/routes/notes.py
@@ -172,16 +172,53 @@ async def patch_doc(
 
 # --------------------------------------------------------------- entry routes
 
+async def _ensure_discuss_channel(request: Request, doc: dict, agent_name: str) -> str | None:
+    """Create or reuse the topic channel an agent's "discuss" action threads in.
+
+    Returns the channel id, or None if the chat channel store is unavailable.
+    The discussion stays threaded per (doc, agent): repeated entries land in one
+    channel instead of forking a new one each time. The agent is set as a lead so
+    it actively asks the user clarifying questions rather than staying quiet.
+    """
+    store = _get_store(request)
+    channels = getattr(request.app.state, "chat_channels", None)
+    if channels is None:
+        return None
+    existing = await store.discuss_channel_for(doc["id"], agent_name)
+    if existing:
+        ch = await channels.get_channel(existing)
+        if ch is not None:
+            return existing
+    owner = doc.get("owner_user_id") or "system"
+    title = doc.get("title", "") or "shared doc"
+    created = await channels.create_channel(
+        name=f"Discuss: {title}",
+        type="topic",
+        created_by=owner,
+        members=sorted({owner, agent_name}),
+        description=f"Idea discussion for a shared doc with {agent_name}.",
+        settings={"kind": "notes-discuss", "leads": [agent_name], "response_mode": "lively"},
+    )
+    ch_id = created.get("id") if isinstance(created, dict) else None
+    if ch_id:
+        await store.set_discuss_channel(doc["id"], agent_name, ch_id)
+    return ch_id
+
+
 async def _trigger_agent_notifications(
     request: Request,
     doc: dict,
     entry_text: str,
     skip_agent: str | None = None,
 ) -> None:
-    """Post a message to each agent member's DM channel. Never raises.
+    """Notify each agent member on a new entry. Never raises.
 
-    skip_agent names the agent that authored this change, if any, so an agent
-    writing to a shared doc does not get notified about its own entry.
+    Most agents are pinged on their DM channel. An agent whose action is
+    "discuss" instead gets a dedicated topic channel (created or reused) so it
+    can develop the idea with the user there; if that fails it falls back to the
+    DM so the agent is never silently skipped. skip_agent names the agent that
+    authored this change, if any, so an agent does not get notified about its
+    own entry.
     """
     store = _get_store(request)
     agents = await store.agent_members(doc["id"])
@@ -210,6 +247,23 @@ async def _trigger_agent_notifications(
             content = f"[{doc_title}] {instruction}: {entry_text}"
         else:
             content = f"[{doc_title}] New entry: {entry_text}"
+        if action == "discuss":
+            try:
+                ch_id = await _ensure_discuss_channel(request, doc, agent_name)
+                if ch_id:
+                    await message_store.send_message(
+                        channel_id=ch_id,
+                        author_id="system",
+                        author_type="system",
+                        content=content,
+                    )
+                    continue
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "notes: discuss channel failed for %r, falling back to DM: %s",
+                    agent_name,
+                    exc,
+                )
         try:
             agent_cfg = find_agent(config, agent_name)
             channel_id = (agent_cfg or {}).get("chat_channel_id")


### PR DESCRIPTION
## What

Implements the notes **"Discuss"** agent action (the design recorded in pending-decisions). When a shared note/list has an agent member whose action is `discuss`, a new entry now routes to a dedicated **topic channel** instead of the agent's DM, so the agent develops the idea with the user there by asking clarifying questions.

Follows the documented default shape: **one threaded topic channel per (doc, agent)**, created lazily and reused for later entries; the agent is set as a channel **lead** so it actively responds (topic channels are otherwise quiet); routed to the channel **instead of** the DM for discuss agents.

## How

- Store: additive `discuss_channel_id` column on `shared_doc_members` (same PRAGMA-guarded migration as permission/action), plus `discuss_channel_for` / `set_discuss_channel` helpers.
- Route: `_ensure_discuss_channel` creates or reuses a `topic` channel (members = owner + agent, `leads=[agent]`, `kind=notes-discuss`) and caches its id. The trigger loop posts the existing discuss directive there and skips the DM for that agent.

## Safety

**Strictly additive and fail-soft.** Non-discuss agents are byte-identical to before. If the chat-channel store is unavailable or channel creation raises, the discuss agent **falls back to its DM** so it is never silently skipped. The live notify path for every other action is untouched.

## Verification

`compileall` clean; full `tests/notes/` suite (61) green including 2 new route tests: channel create + thread-reuse (one channel across two entries, agent is a member + lead), and DM fallback when no channel store. The agent's in-channel auto-reply is existing chat-router behaviour (lead in a lively topic channel) and is not unit-tested here.

## Follow-ups

CHANGELOG and the agent-manual mention (for this + `notes_set_done` #1480) are deferred to one consolidated docs commit once #1480 lands, to avoid concurrent edits to CHANGELOG and the regenerated manual.