### PR TITLE
feat(observatory): fleet endpoint returns a health summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 - Notes and Todo: tracked edits. An entry's text is editable and every change is an immutable revision tagged with editor and timestamp, stored as a diff with a full snapshot checkpoint every 20 edits so any past state can be reconstructed (Time Machine foundation). New history and at-revision endpoints expose the log and reconstructed text.
 - Todo app: a checklist companion to Notes for `kind=list` documents, with per-task done checkboxes (completed tasks struck through), shared sharing/permission/agent-action controls, and the same tracked-edit history. Notes and Todo each show only their own document kind.
 - Agent tool `notes_set_done`: an agent shared on a list (contributor or editor) can mark a task done or reopen it, completing the agent surface for shared todos. Membership, permission, archived-doc, and entry-belongs-to-doc are all enforced.
+- Observatory fleet endpoint returns a health summary (total/working/idle/stale counts, stale handles, and an active/degraded/idle status) so the UI can show fleet status at a glance without recomputing.
 
 ## [1.0.0-beta.12] - 2026-06-28
 

--- a/tests/test_routes_observatory.py
+++ b/tests/test_routes_observatory.py
@@ -232,3 +232,54 @@ async def test_fleet_clamps_held_seconds_under_clock_skew(app, client):
     assert len(mine) == 1
     assert mine[0]["held_seconds"] == 0
     assert mine[0]["stale"] is False
+
+
+@pytest.mark.asyncio
+async def test_fleet_health_empty_is_idle(client):
+    health = (await client.get("/api/observatory/fleet")).json()["health"]
+    assert health == {
+        "total": 0, "working": 0, "idle": 0, "stale": 0,
+        "stale_handles": [], "status": "idle",
+    }
+
+
+@pytest.mark.asyncio
+async def test_fleet_health_counts_working_and_idle(app, client):
+    pstore = app.state.project_store
+    tstore = app.state.project_task_store
+    reg = app.state.agent_registry
+    if reg._db is None:
+        await reg.init()
+    proj = await pstore.create_project(name="ObsH", slug="obs-health", created_by="admin", user_id="admin")
+    task = await tstore.create_task(proj["id"], title="A card", created_by="admin")
+    await tstore.claim_task(task["id"], "@lane-busy")
+    await reg.register(framework="opencode", display_name="Idle H",
+                       handle="@lane-free", user_id="admin")
+
+    health = (await client.get("/api/observatory/fleet")).json()["health"]
+    assert health["total"] == 2
+    assert health["working"] == 1
+    assert health["idle"] == 1
+    assert health["stale"] == 0
+    assert health["status"] == "active"
+
+
+@pytest.mark.asyncio
+async def test_fleet_health_degraded_when_stale(app, client):
+    from tinyagentos.routes.observatory import STALE_CLAIM_SECONDS
+    import time
+
+    pstore = app.state.project_store
+    tstore = app.state.project_task_store
+    proj = await pstore.create_project(name="ObsHD", slug="obs-health-degraded", created_by="admin", user_id="admin")
+    task = await tstore.create_task(proj["id"], title="Wedged", created_by="admin")
+    await tstore.claim_task(task["id"], "@lane-wedged")
+    old = time.time() - (STALE_CLAIM_SECONDS + 600)
+    await tstore._db.execute(
+        "UPDATE project_tasks SET claimed_at = ? WHERE id = ?", (old, task["id"]))
+    await tstore._db.commit()
+
+    health = (await client.get("/api/observatory/fleet")).json()["health"]
+    assert health["stale"] == 1
+    assert health["stale_handles"] == ["@lane-wedged"]
+    assert health["status"] == "degraded"

--- a/tinyagentos/routes/observatory.py
+++ b/tinyagentos/routes/observatory.py
@@ -253,4 +253,20 @@ async def get_fleet(request: Request, user: CurrentUser = Depends(current_user))
             })
 
     agents.sort(key=lambda a: a["handle"])
-    return {"agents": agents, "paused": _read_state(request)}
+
+    # Fleet health summary: a single-glance roll-up for the Observatory header so
+    # the UI does not have to recompute counts. `status` is degraded when any
+    # lane is stale (a wedged claim the pause switch would hide), else active if
+    # anything is working, else idle.
+    stale_handles = [a["handle"] for a in agents if a.get("stale")]
+    working_count = sum(1 for a in agents if a["state"] == "working")
+    idle_count = sum(1 for a in agents if a["state"] == "idle")
+    health = {
+        "total": len(agents),
+        "working": working_count,
+        "idle": idle_count,
+        "stale": len(stale_handles),
+        "stale_handles": stale_handles,
+        "status": "degraded" if stale_handles else ("active" if working_count else "idle"),
+    }
+    return {"agents": agents, "paused": _read_state(request), "health": health}


### PR DESCRIPTION
## What

A bounded, additive slice of #133 (Observatory health). `GET /api/observatory/fleet` now returns a derived `health` roll-up alongside the existing `agents` and `paused` so the Observatory header can show fleet status at a glance without recomputing client-side.

```json
"health": { "total": 2, "working": 1, "idle": 1, "stale": 0, "stale_handles": [], "status": "active" }
```

`status` is **degraded** when any lane is stale (a wedged claim the pause switch would otherwise hide), else **active** if anything is working, else **idle**.

## Safety

Purely additive: `agents` and `paused` are byte-identical, the summary is derived from the already-computed agents list (no new data sources, no new queries). No live-loop or cross-cutting change.

## Verification

`compileall` clean; `test_routes_observatory.py` (21) green including 3 new tests: empty fleet reports idle, working+idle counts, and degraded status with the stale handle listed.

## Follow-up

UI consumption (a fleet-status pill in the Observatory header) is the next slice; the remaining #133 dimensions (per-session steer, capabilities) are separately tracked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Observatory fleet view now includes an overall health summary, with total, working, idle, and stale counts.
  * Added a fleet status indicator for quick at-a-glance monitoring: active, degraded, or idle.
  * The health summary also lists any stale handles for easier identification in the UI.

* **Bug Fixes**
  * Improved endpoint responses to better reflect empty, active, and stale fleet states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->