### PR TITLE
feat(observatory): fleet health pill in the app header

### DIFF
--- a/desktop/src/apps/ObservatoryApp.tsx
+++ b/desktop/src/apps/ObservatoryApp.tsx
@@ -19,6 +19,15 @@ interface PauseState {
   lanes: Record<string, boolean>;
 }
 
+interface FleetHealth {
+  total: number;
+  working: number;
+  idle: number;
+  stale: number;
+  stale_handles: string[];
+  status: "active" | "degraded" | "idle";
+}
+
 const EMPTY_PAUSE: PauseState = { global: false, lanes: {} };
 
 // Global concurrency cap: how many cards the fleet may hold in flight at once
@@ -89,6 +98,7 @@ function CapStepper({
 
 export function ObservatoryApp({ windowId: _windowId }: { windowId: string }) {
   const [agents, setAgents] = useState<FleetAgent[]>([]);
+  const [health, setHealth] = useState<FleetHealth | null>(null);
   const [pause, setPause] = useState<PauseState>(EMPTY_PAUSE);
   const [cap, setCap] = useState<number | null>(null);
   const [laneCaps, setLaneCaps] = useState<Record<string, number>>({});
@@ -113,6 +123,12 @@ export function ObservatoryApp({ windowId: _windowId }: { windowId: string }) {
       const throttleData = throttleRes.ok ? await throttleRes.json() : null;
       if (fleetData) {
         setAgents(Array.isArray(fleetData.agents) ? fleetData.agents : []);
+        // health is optional: older controllers omit it, so degrade gracefully.
+        setHealth(
+          fleetData.health && typeof fleetData.health === "object"
+            ? fleetData.health
+            : null,
+        );
       }
       if (inFlight.current === 0) {
         if (fleetData) {
@@ -237,6 +253,25 @@ export function ObservatoryApp({ windowId: _windowId }: { windowId: string }) {
       <div className="flex items-center gap-2 border-b border-shell-border px-5 py-4">
         <Radar size={18} className="text-accent" />
         <h1 className="text-base font-semibold text-shell-text">Observatory</h1>
+        {health && health.total > 0 && (
+          <span
+            className={[
+              "flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium",
+              health.status === "degraded"
+                ? "bg-red-500/10 text-red-400"
+                : health.status === "active"
+                  ? "bg-accent/10 text-accent"
+                  : "bg-shell-surface text-shell-text-secondary",
+            ].join(" ")}
+            aria-label={`Fleet ${health.status}: ${health.working} working, ${health.idle} idle, ${health.stale} stale`}
+            title={`${health.working} working, ${health.idle} idle, ${health.stale} stale`}
+          >
+            <CircleDot size={11} className="shrink-0" />
+            {health.status === "degraded"
+              ? `${health.stale} stale`
+              : `${health.working}/${health.total} active`}
+          </span>
+        )}
         <button
           type="button"
           onClick={() => setScope("global", !pause.global)}

--- a/desktop/src/apps/__tests__/ObservatoryApp.test.tsx
+++ b/desktop/src/apps/__tests__/ObservatoryApp.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+
+vi.mock("@/components/ui", () => ({
+  Switch: ({ checked, onCheckedChange, ...rest }: {
+    checked?: boolean;
+    onCheckedChange?: (v: boolean) => void;
+  } & React.HTMLAttributes<HTMLButtonElement>) => (
+    <button role="switch" aria-checked={checked} onClick={() => onCheckedChange?.(!checked)} {...rest} />
+  ),
+}));
+
+import { ObservatoryApp } from "../ObservatoryApp";
+
+function makeFetch(health: unknown) {
+  return vi.fn(async (url: string) => {
+    const u = String(url);
+    if (u === "/api/observatory/fleet") {
+      return {
+        ok: true,
+        json: async () => ({ agents: [], paused: { global: false, lanes: {} }, health }),
+      };
+    }
+    if (u === "/api/observatory/throttle") {
+      return { ok: true, json: async () => ({ global: null, lanes: {} }) };
+    }
+    return { ok: true, json: async () => ({}) };
+  });
+}
+
+describe("ObservatoryApp fleet health pill", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.restoreAllMocks());
+
+  it("shows an active pill with working/total when fleet is active", async () => {
+    global.fetch = makeFetch({
+      total: 3, working: 2, idle: 1, stale: 0, stale_handles: [], status: "active",
+    }) as typeof fetch;
+    render(<ObservatoryApp windowId="w1" />);
+    await waitFor(() => expect(screen.getByText("2/3 active")).toBeDefined());
+  });
+
+  it("shows a degraded pill with the stale count when a lane is wedged", async () => {
+    global.fetch = makeFetch({
+      total: 2, working: 1, idle: 1, stale: 1, stale_handles: ["@lane-x"], status: "degraded",
+    }) as typeof fetch;
+    render(<ObservatoryApp windowId="w1" />);
+    await waitFor(() => expect(screen.getByText("1 stale")).toBeDefined());
+  });
+
+  it("renders no pill when the controller omits health (graceful)", async () => {
+    global.fetch = makeFetch(undefined) as typeof fetch;
+    render(<ObservatoryApp windowId="w1" />);
+    // Header still renders.
+    await waitFor(() => expect(screen.getByText("Observatory")).toBeDefined());
+    expect(screen.queryByText(/active$/)).toBeNull();
+    expect(screen.queryByText(/stale$/)).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

The UI half of the #133 health slice. The Observatory header now shows a fleet-status pill next to the title, consuming the `health` summary added by #1482:
- **active** (accent): `2/3 active` (working / total)
- **degraded** (red): `1 stale` when a lane is wedged
- hidden when the fleet is empty

## Safety / independence

Reads `fleetData.health` **optionally** and only renders the pill when present, so it degrades gracefully against a controller that does not yet return it. That means this PR has **no hard dependency on #1482** landing first: once the backend health field is on dev, the pill lights up; until then it simply does not render. No change to the existing agents/pause/throttle handling.

## Verification

`tsc --noEmit` clean; full desktop vitest suite (2188) green including 3 new ObservatoryApp tests (active pill, degraded pill, graceful no-pill when health absent). Verified in-browser via a vite preview against a mocked degraded fleet (red '1 stale' pill renders beside the title).

## Follow-up

Remaining #133 dimensions (per-session steer, capabilities) are separately tracked.