### PR TITLE
feat(observatory): lane framework badge in the fleet rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 - Agent tool `notes_set_done`: an agent shared on a list (contributor or editor) can mark a task done or reopen it, completing the agent surface for shared todos. Membership, permission, archived-doc, and entry-belongs-to-doc are all enforced.
 - Observatory fleet endpoint returns a health summary (total/working/idle/stale counts, stale handles, and an active/degraded/idle status) so the UI can show fleet status at a glance without recomputing.
 - Notes "Discuss" agent action: an agent shared on a doc with the discuss action now gets a dedicated threaded topic channel (one per doc and agent, reused across entries, with the agent as a lead so it actively asks clarifying questions) instead of a DM ping, and falls back to the DM if the channel cannot be created.
+- Observatory lane framework badges: the fleet endpoint now carries each agent's framework (kilo/opencode/hermes/...), and the Observatory app shows it as a small badge next to each lane handle.
 
 ## [1.0.0-beta.12] - 2026-06-28
 

--- a/desktop/src/apps/ObservatoryApp.tsx
+++ b/desktop/src/apps/ObservatoryApp.tsx
@@ -11,6 +11,7 @@ interface HeldCard {
 interface FleetAgent {
   handle: string;
   state: string;
+  framework?: string;
   holds: HeldCard | null;
 }
 
@@ -371,8 +372,15 @@ export function ObservatoryApp({ windowId: _windowId }: { windowId: string }) {
                     className={lanePaused ? "shrink-0 text-amber-400" : "shrink-0 text-green-400"}
                   />
                   <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-                    <span className="truncate text-sm font-medium text-shell-text">
-                      {a.handle}
+                    <span className="flex min-w-0 items-center gap-1.5">
+                      <span className="truncate text-sm font-medium text-shell-text">
+                        {a.handle}
+                      </span>
+                      {a.framework && (
+                        <span className="shrink-0 rounded bg-shell-bg-deep px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-shell-text-tertiary">
+                          {a.framework}
+                        </span>
+                      )}
                     </span>
                     {a.holds ? (
                       <span className="truncate text-xs text-shell-text-secondary">

--- a/desktop/src/apps/__tests__/ObservatoryApp.test.tsx
+++ b/desktop/src/apps/__tests__/ObservatoryApp.test.tsx
@@ -58,3 +58,40 @@ describe("ObservatoryApp fleet health pill", () => {
     expect(screen.queryByText(/stale$/)).toBeNull();
   });
 });
+
+function makeFleetFetch(agents: unknown[]) {
+  return vi.fn(async (url: string) => {
+    const u = String(url);
+    if (u === "/api/observatory/fleet") {
+      return { ok: true, json: async () => ({ agents, paused: { global: false, lanes: {} } }) };
+    }
+    if (u === "/api/observatory/throttle") {
+      return { ok: true, json: async () => ({ global: null, lanes: {} }) };
+    }
+    return { ok: true, json: async () => ({}) };
+  });
+}
+
+describe("ObservatoryApp lane framework badge", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.restoreAllMocks());
+
+  it("renders the framework badge for an agent that has one", async () => {
+    global.fetch = makeFleetFetch([
+      { handle: "@lane-kilo", state: "idle", framework: "kilo", holds: null },
+    ]) as typeof fetch;
+    render(<ObservatoryApp windowId="w1" />);
+    await waitFor(() => expect(screen.getByText("@lane-kilo")).toBeDefined());
+    expect(screen.getByText("kilo")).toBeDefined();
+  });
+
+  it("renders no badge for an agent without a framework (graceful)", async () => {
+    global.fetch = makeFleetFetch([
+      { handle: "@lane-bare", state: "idle", framework: "", holds: null },
+    ]) as typeof fetch;
+    render(<ObservatoryApp windowId="w1" />);
+    await waitFor(() => expect(screen.getByText("@lane-bare")).toBeDefined());
+    // Only the handle renders, no empty badge node next to it.
+    expect(screen.queryByText("kilo")).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

The UI completion of the #133 session-badges slice. Each agent in the Observatory fleet list now shows a small badge next to its lane handle with the agent's framework (kilo / opencode / hermes / ...), consuming the `framework` field added by #1484.

## Independence

Reads `framework` **optionally** and renders the badge only when present, so it degrades gracefully against a controller that does not return it (an empty framework shows no badge). No hard dependency on #1484 landing first; once the backend field is on dev, the badges appear.

## Verification

`tsc --noEmit` clean; full desktop vitest suite (2190) green including 2 new ObservatoryApp tests (badge renders for an agent with a framework, no badge when empty). Verified in-browser via a vite preview: KILO / OPENCODE / HERMES badges render next to their handles, and an agent with no framework shows none.