### PR TITLE
feat(coding-sessions): editable session alias (rename)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 - Observatory fleet endpoint returns a health summary (total/working/idle/stale counts, stale handles, and an active/degraded/idle status) so the UI can show fleet status at a glance without recomputing.
 - Notes "Discuss" agent action: an agent shared on a doc with the discuss action now gets a dedicated threaded topic channel (one per doc and agent, reused across entries, with the agent as a lead so it actively asks clarifying questions) instead of a DM ping, and falls back to the DM if the channel cannot be created.
 - Observatory lane framework badges: the fleet endpoint now carries each agent's framework (kilo/opencode/hermes/...), and the Observatory app shows it as a small badge next to each lane handle.
+- Coding sessions: the launch alias is editable. `PATCH /api/coding-sessions/{id}` renames a session, and the change is reflected in its agent-registry entry so the Agents/Registry app stays in sync.
 
 ## [1.0.0-beta.12] - 2026-06-28
 

--- a/tests/coding_sessions/test_routes_coding_sessions.py
+++ b/tests/coding_sessions/test_routes_coding_sessions.py
@@ -307,3 +307,54 @@ async def test_create_succeeds_even_if_registry_unavailable(tmp_path):
         assert resp.json()["status"] == "starting"
     await app.state.coding_session_store.close()
     await app.state.metrics.close()
+
+
+@pytest.mark.asyncio
+async def test_rename_updates_alias_and_registry(tmp_path):
+    app = create_app(data_dir=tmp_path / "data")
+    uid, token = await _make_client(app)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test",
+                           cookies={"taos_session": token}) as c:
+        create_resp = await c.post("/api/coding-sessions", json=_make_body(alias="old-name"))
+        sid = create_resp.json()["id"]
+        resp = await c.patch(f"/api/coding-sessions/{sid}", json={"alias": "new-name"})
+        assert resp.status_code == 200
+        assert resp.json()["alias"] == "new-name"
+        # The registry entry (handle == session id) reflects the new alias.
+        rows = await app.state.agent_registry.list_for_user(uid)
+        match = next((r for r in rows if r.get("handle") == sid), None)
+        assert match is not None
+        assert match["display_name"] == "new-name"
+    await app.state.coding_session_store.close()
+    await app.state.agent_registry.close()
+    await app.state.metrics.close()
+
+
+@pytest.mark.asyncio
+async def test_rename_empty_alias_returns_400(tmp_path):
+    app = create_app(data_dir=tmp_path / "data")
+    uid, token = await _make_client(app)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test",
+                           cookies={"taos_session": token}) as c:
+        sid = (await c.post("/api/coding-sessions", json=_make_body())).json()["id"]
+        resp = await c.patch(f"/api/coding-sessions/{sid}", json={"alias": "   "})
+        assert resp.status_code == 400
+    await app.state.coding_session_store.close()
+    await app.state.agent_registry.close()
+    await app.state.metrics.close()
+
+
+@pytest.mark.asyncio
+async def test_rename_missing_session_returns_404(tmp_path):
+    app = create_app(data_dir=tmp_path / "data")
+    uid, token = await _make_client(app)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test",
+                           cookies={"taos_session": token}) as c:
+        resp = await c.patch("/api/coding-sessions/cs-does-not-exist", json={"alias": "x"})
+        assert resp.status_code == 404
+    await app.state.coding_session_store.close()
+    await app.state.agent_registry.close()
+    await app.state.metrics.close()

--- a/tinyagentos/routes/coding_sessions.py
+++ b/tinyagentos/routes/coding_sessions.py
@@ -36,6 +36,37 @@ class CodingSessionIn(BaseModel):
     project_id: str | None = None
 
 
+class RenameCodingSessionIn(BaseModel):
+    alias: str
+
+
+async def _sync_registry_alias(
+    request: Request, session_id: str, alias: str, user: CurrentUser
+) -> None:
+    """Reflect a renamed session alias in its agent-registry entry. Never raises.
+
+    The session registered itself with handle=session_id and
+    display_name=alias, so the rename updates the matching registry row's
+    display name to keep the Agents/Registry app in sync.
+    """
+    registry = getattr(request.app.state, "agent_registry", None)
+    if registry is None:
+        return
+    try:
+        rows = (
+            await registry.list_all()
+            if user.is_admin
+            else await registry.list_for_user(user.user_id)
+        )
+        match = next((r for r in rows if r.get("handle") == session_id), None)
+        if match and match.get("canonical_id"):
+            await registry.update(match["canonical_id"], display_name=alias)
+    except Exception:
+        logger.warning(
+            "registry alias sync failed for coding session %s", session_id, exc_info=True
+        )
+
+
 @router.post("/api/coding-sessions")
 async def create_coding_session(
     body: CodingSessionIn,
@@ -124,6 +155,26 @@ async def get_coding_session(
     if session is None or (not user.is_admin and session["created_by"] != user.user_id):
         return JSONResponse({"error": "not found"}, status_code=404)
     return session
+
+
+@router.patch("/api/coding-sessions/{session_id}")
+async def rename_coding_session(
+    session_id: str,
+    body: RenameCodingSessionIn,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    """Rename a session's alias (Jay: the launch alias is user-editable)."""
+    store = request.app.state.coding_session_store
+    session = await store.get_session(session_id)
+    if session is None or (not user.is_admin and session["created_by"] != user.user_id):
+        return JSONResponse({"error": "not found"}, status_code=404)
+    alias = body.alias.strip()
+    if not alias:
+        return JSONResponse({"error": "alias must be non-empty"}, status_code=400)
+    updated = await store.set_alias(session_id, alias)
+    await _sync_registry_alias(request, session_id, alias, user)
+    return updated
 
 
 @router.post("/api/coding-sessions/{session_id}/stop")


### PR DESCRIPTION
## What

Jay's Coding Agents spec: the launch alias is "editable (maybe a repo slug default name that is editable)". Slice 1 (#1476) set the alias on create but had no way to change it. This adds the rename.

## How

- `PATCH /api/coding-sessions/{id}` with `{"alias": "..."}` renames the session (owner or admin only; 404 otherwise, 400 on an empty alias), reusing the store's existing `set_alias`.
- The session registered itself in the agent registry with `handle = session id` and `display_name = alias`, so the rename also updates the matching registry row's display name to keep the Agents/Registry app in sync. That sync is best-effort and never fails the rename (mirrors the create-path registration).

## Verification

`compileall` clean; `test_routes_coding_sessions.py` (17) green including 3 new tests: rename updates the alias and the registry display name, an empty alias returns 400, and renaming a missing session returns 404.

## Follow-up

The Coding Agents app UI (where the user edits the alias) and the launcher (slice 2, needs a live worker) are separately tracked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for renaming a coding session through the API.
  * Session renames now stay in sync with the corresponding entry in the Agents/Registry view.

* **Bug Fixes**
  * Added validation to prevent empty or whitespace-only aliases.
  * Returns a clear not-found response when updating a missing coding session.

* **Tests**
  * Added coverage for successful rename, invalid alias input, and missing-session handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->