### PR TITLE
feat(coding-sessions): host-folder launcher (tmux start/stop + transcript)

### DIFF
--- a/tests/coding_sessions/test_launcher.py
+++ b/tests/coding_sessions/test_launcher.py
@@ -1,0 +1,70 @@
+"""Unit tests for the coding-session tmux launcher (no real tmux needed)."""
+import pytest
+
+from tinyagentos.coding_sessions.launcher import CodingSessionLauncher, tmux_name
+
+
+class FakeRunner:
+    """Records argv and returns a queued (rc, out, err) per call."""
+
+    def __init__(self, results=None):
+        self.calls = []
+        self._results = list(results or [])
+
+    def __call__(self, argv):
+        self.calls.append(argv)
+        return self._results.pop(0) if self._results else (0, "", "")
+
+
+def test_start_host_folder_issues_tmux_new_session(tmp_path):
+    runner = FakeRunner([(0, "", "")])
+    launcher = CodingSessionLauncher(run=runner)
+    name = launcher.start_host_folder("cs-abc", str(tmp_path), "opencode")
+    assert name == "taos-cs-cs-abc" == tmux_name("cs-abc")
+    assert runner.calls[0] == [
+        "tmux", "new-session", "-d", "-s", "taos-cs-cs-abc",
+        "-c", str(tmp_path), "opencode",
+    ]
+
+
+def test_start_unknown_cli_raises():
+    launcher = CodingSessionLauncher(run=FakeRunner())
+    with pytest.raises(ValueError):
+        launcher.start_host_folder("cs-x", "/repo", "nope")
+
+
+def test_start_missing_workdir_raises_filenotfound(tmp_path):
+    # tmux returns 0 even for a bad workdir, so the launcher validates it itself.
+    launcher = CodingSessionLauncher(run=FakeRunner([(0, "", "")]))
+    with pytest.raises(FileNotFoundError):
+        launcher.start_host_folder("cs-x", str(tmp_path / "nope"), "opencode")
+
+
+def test_start_tmux_failure_raises_runtimeerror(tmp_path):
+    runner = FakeRunner([(1, "", "tmux server error")])
+    launcher = CodingSessionLauncher(run=runner)
+    with pytest.raises(RuntimeError) as exc:
+        launcher.start_host_folder("cs-x", str(tmp_path), "opencode")
+    assert "tmux server error" in str(exc.value)
+
+
+def test_is_running_maps_has_session_returncode():
+    assert CodingSessionLauncher(run=FakeRunner([(0, "", "")])).is_running("cs-x") is True
+    assert CodingSessionLauncher(run=FakeRunner([(1, "", "")])).is_running("cs-x") is False
+
+
+def test_stop_issues_kill_session():
+    runner = FakeRunner([(0, "", "")])
+    CodingSessionLauncher(run=runner).stop("cs-abc")
+    assert runner.calls[0] == ["tmux", "kill-session", "-t", "taos-cs-cs-abc"]
+
+
+def test_capture_returns_output_or_empty():
+    assert CodingSessionLauncher(run=FakeRunner([(0, "hello\n", "")])).capture("cs-x") == "hello\n"
+    assert CodingSessionLauncher(run=FakeRunner([(1, "", "gone")])).capture("cs-x") == ""
+
+
+def test_send_input_types_and_enters():
+    runner = FakeRunner([(0, "", "")])
+    CodingSessionLauncher(run=runner).send_input("cs-abc", "yes")
+    assert runner.calls[0] == ["tmux", "send-keys", "-t", "taos-cs-cs-abc", "yes", "Enter"]

--- a/tests/coding_sessions/test_routes_coding_sessions.py
+++ b/tests/coding_sessions/test_routes_coding_sessions.py
@@ -331,6 +331,33 @@ async def test_rename_updates_alias_and_registry(tmp_path):
     await app.state.metrics.close()
 
 
+class _FakeLauncher:
+    """In-memory launcher for route tests: no real tmux."""
+
+    def __init__(self):
+        self.started = []
+        self.stopped = []
+        self._running = set()
+
+    def is_running(self, sid):
+        return sid in self._running
+
+    def start_host_folder(self, sid, workdir, cli):
+        self.started.append((sid, workdir, cli))
+        self._running.add(sid)
+        return f"taos-cs-{sid}"
+
+    def stop(self, sid):
+        self.stopped.append(sid)
+        self._running.discard(sid)
+
+    def capture(self, sid):
+        return f"output for {sid}\n"
+
+    def send_input(self, sid, text):
+        pass
+
+
 @pytest.mark.asyncio
 async def test_rename_empty_alias_returns_400(tmp_path):
     app = create_app(data_dir=tmp_path / "data")
@@ -347,6 +374,30 @@ async def test_rename_empty_alias_returns_400(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_start_host_folder_runs_and_captures(tmp_path):
+    app = create_app(data_dir=tmp_path / "data")
+    uid, token = await _make_client(app)
+    app.state.coding_launcher = _FakeLauncher()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test",
+                           cookies={"taos_session": token}) as c:
+        sid = (await c.post("/api/coding-sessions", json=_make_body())).json()["id"]
+        resp = await c.post(f"/api/coding-sessions/{sid}/start")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "running"
+        assert data["tmux_session"] == f"taos-cs-{sid}"
+        assert (sid, "/home/jay/myrepo", "claude") in app.state.coding_launcher.started
+        # The transcript captured the initial output.
+        tr = await c.get(f"/api/coding-sessions/{sid}/transcript")
+        assert tr.status_code == 200
+        assert any(f"output for {sid}" in e["text"] for e in tr.json()["entries"])
+    await app.state.coding_session_store.close()
+    await app.state.agent_registry.close()
+    await app.state.metrics.close()
+
+
+@pytest.mark.asyncio
 async def test_rename_missing_session_returns_404(tmp_path):
     app = create_app(data_dir=tmp_path / "data")
     uid, token = await _make_client(app)
@@ -354,6 +405,57 @@ async def test_rename_missing_session_returns_404(tmp_path):
     async with AsyncClient(transport=transport, base_url="http://test",
                            cookies={"taos_session": token}) as c:
         resp = await c.patch("/api/coding-sessions/cs-does-not-exist", json={"alias": "x"})
+        assert resp.status_code == 404
+    await app.state.coding_session_store.close()
+    await app.state.agent_registry.close()
+    await app.state.metrics.close()
+
+
+@pytest.mark.asyncio
+async def test_start_non_host_folder_returns_501(tmp_path):
+    app = create_app(data_dir=tmp_path / "data")
+    uid, token = await _make_client(app)
+    app.state.coding_launcher = _FakeLauncher()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test",
+                           cookies={"taos_session": token}) as c:
+        body = _make_body(launch_target="worker-lxc", worker="linstation")
+        sid = (await c.post("/api/coding-sessions", json=body)).json()["id"]
+        resp = await c.post(f"/api/coding-sessions/{sid}/start")
+        assert resp.status_code == 501
+    await app.state.coding_session_store.close()
+    await app.state.agent_registry.close()
+    await app.state.metrics.close()
+
+
+@pytest.mark.asyncio
+async def test_stop_kills_tmux_and_records_status(tmp_path):
+    app = create_app(data_dir=tmp_path / "data")
+    uid, token = await _make_client(app)
+    app.state.coding_launcher = _FakeLauncher()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test",
+                           cookies={"taos_session": token}) as c:
+        sid = (await c.post("/api/coding-sessions", json=_make_body())).json()["id"]
+        await c.post(f"/api/coding-sessions/{sid}/start")
+        resp = await c.post(f"/api/coding-sessions/{sid}/stop")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "stopped"
+        assert sid in app.state.coding_launcher.stopped
+    await app.state.coding_session_store.close()
+    await app.state.agent_registry.close()
+    await app.state.metrics.close()
+
+
+@pytest.mark.asyncio
+async def test_start_missing_session_returns_404(tmp_path):
+    app = create_app(data_dir=tmp_path / "data")
+    uid, token = await _make_client(app)
+    app.state.coding_launcher = _FakeLauncher()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test",
+                           cookies={"taos_session": token}) as c:
+        resp = await c.post("/api/coding-sessions/cs-nope/start")
         assert resp.status_code == 404
     await app.state.coding_session_store.close()
     await app.state.agent_registry.close()

--- a/tests/coding_sessions/test_routes_coding_sessions.py
+++ b/tests/coding_sessions/test_routes_coding_sessions.py
@@ -448,6 +448,25 @@ async def test_stop_kills_tmux_and_records_status(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_stop_does_not_resurrect_archived_session(tmp_path):
+    app = create_app(data_dir=tmp_path / "data")
+    uid, token = await _make_client(app)
+    app.state.coding_launcher = _FakeLauncher()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test",
+                           cookies={"taos_session": token}) as c:
+        sid = (await c.post("/api/coding-sessions", json=_make_body())).json()["id"]
+        await c.post(f"/api/coding-sessions/{sid}/archive")
+        resp = await c.post(f"/api/coding-sessions/{sid}/stop")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "archived"
+        assert sid not in app.state.coding_launcher.stopped
+    await app.state.coding_session_store.close()
+    await app.state.agent_registry.close()
+    await app.state.metrics.close()
+
+
+@pytest.mark.asyncio
 async def test_start_missing_session_returns_404(tmp_path):
     app = create_app(data_dir=tmp_path / "data")
     uid, token = await _make_client(app)

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -375,8 +375,10 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     decision_store = DecisionStore(data_dir / "decisions.db")
     from tinyagentos.notes.shared_docs_store import SharedDocsStore
     shared_docs_store = SharedDocsStore(data_dir / "shared_docs.db")
+    from tinyagentos.coding_sessions.launcher import CodingSessionLauncher
     from tinyagentos.coding_sessions.store import CodingSessionStore
     coding_session_store = CodingSessionStore(data_dir / "coding_sessions.db")
+    coding_launcher = CodingSessionLauncher()
     projects_root = data_dir / "projects"
     chat_hub = ChatHub()
     canvas_store = CanvasStore(data_dir / "canvas.db")
@@ -487,6 +489,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         app.state.shared_docs_store = shared_docs_store
         await coding_session_store.init()
         app.state.coding_session_store = coding_session_store
+        app.state.coding_launcher = coding_launcher
         projects_root.mkdir(parents=True, exist_ok=True)
         await canvas_store.init()
         await desktop_settings.init()

--- a/tinyagentos/coding_sessions/launcher.py
+++ b/tinyagentos/coding_sessions/launcher.py
@@ -28,7 +28,13 @@ CLI_COMMANDS = {
 
 
 def _subprocess_runner(argv: list[str]) -> tuple[int, str, str]:
-    proc = subprocess.run(argv, capture_output=True, text=True, timeout=30)
+    # errors="replace": capture-pane of a TUI app can emit bytes that are not
+    # valid in the locale encoding; the default errors="strict" would raise
+    # UnicodeDecodeError and crash capture(), so decode leniently instead.
+    proc = subprocess.run(
+        argv, capture_output=True, text=True, timeout=30,
+        encoding="utf-8", errors="replace",
+    )
     return proc.returncode, proc.stdout, proc.stderr
 
 

--- a/tinyagentos/coding_sessions/launcher.py
+++ b/tinyagentos/coding_sessions/launcher.py
@@ -1,0 +1,85 @@
+"""Launch and control coding-CLI sessions in tmux.
+
+Slice 2a: the ``host-folder`` target. A detached tmux session on the controller
+host, scoped to the session's workdir, running the chosen CLI. Output is read on
+demand with ``tmux capture-pane`` and appended to the append-only transcript.
+The worker-LXC target, repo cloning, and continuous streaming are later slices.
+
+The tmux calls go through an injectable ``run`` callable so the launcher logic is
+unit tested without a real tmux, and live-verified against real tmux separately.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from typing import Callable
+
+# A runner takes an argv list and returns (returncode, stdout, stderr).
+Runner = Callable[[list[str]], "tuple[int, str, str]"]
+
+# CLIs we know how to launch. opencode is wired first (the App Builder already
+# drives it); claude and codex use the same tmux path once their binaries exist.
+CLI_COMMANDS = {
+    "opencode": "opencode",
+    "claude": "claude",
+    "codex": "codex",
+}
+
+
+def _subprocess_runner(argv: list[str]) -> tuple[int, str, str]:
+    proc = subprocess.run(argv, capture_output=True, text=True, timeout=30)
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def tmux_name(session_id: str) -> str:
+    """tmux session name for a coding session. Prefixed so it never collides
+    with the owl-dispatch tmux sessions; the cs- id has no tmux-illegal chars."""
+    return f"taos-cs-{session_id}"
+
+
+class CodingSessionLauncher:
+    """Start, stop, and read a coding CLI running in a detached tmux session."""
+
+    def __init__(self, run: Runner | None = None) -> None:
+        self._run = run or _subprocess_runner
+
+    def is_running(self, session_id: str) -> bool:
+        rc, _, _ = self._run(["tmux", "has-session", "-t", tmux_name(session_id)])
+        return rc == 0
+
+    def start_host_folder(self, session_id: str, workdir: str, cli: str) -> str:
+        """Start a detached tmux session running ``cli`` in ``workdir``.
+
+        Returns the tmux session name. Raises ValueError for an unknown CLI and
+        RuntimeError if tmux refuses to start (e.g. the workdir does not exist).
+        """
+        if cli not in CLI_COMMANDS:
+            raise ValueError(f"unknown cli {cli!r}")
+        # tmux new-session returns 0 even for a missing workdir or a CLI binary
+        # that is not found (the window just exits), so validate the workdir here
+        # rather than trusting the return code.
+        if not os.path.isdir(workdir):
+            raise FileNotFoundError(f"workdir does not exist: {workdir}")
+        name = tmux_name(session_id)
+        rc, out, err = self._run(
+            ["tmux", "new-session", "-d", "-s", name, "-c", workdir, CLI_COMMANDS[cli]]
+        )
+        if rc != 0:
+            raise RuntimeError(f"tmux start failed: {(err or out).strip()}")
+        return name
+
+    def stop(self, session_id: str) -> None:
+        """Kill the session's tmux. Idempotent: a missing session is not an error."""
+        self._run(["tmux", "kill-session", "-t", tmux_name(session_id)])
+
+    def capture(self, session_id: str) -> str:
+        """Return the current terminal contents, or '' if the session is gone."""
+        rc, out, _ = self._run(
+            ["tmux", "capture-pane", "-p", "-t", tmux_name(session_id)]
+        )
+        return out if rc == 0 else ""
+
+    def send_input(self, session_id: str, text: str) -> None:
+        """Type ``text`` into the session and press Enter (steering uses this)."""
+        self._run(["tmux", "send-keys", "-t", tmux_name(session_id), text, "Enter"])

--- a/tinyagentos/coding_sessions/store.py
+++ b/tinyagentos/coding_sessions/store.py
@@ -46,6 +46,14 @@ CREATE TABLE IF NOT EXISTS coding_sessions (
 );
 CREATE INDEX IF NOT EXISTS idx_cs_created_by ON coding_sessions(created_by, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_cs_status ON coding_sessions(status, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS coding_session_transcript (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id  TEXT NOT NULL,
+    captured_at REAL NOT NULL,
+    text        TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_cst_session ON coding_session_transcript(session_id, id);
 """
 
 _JSON_FIELDS = ("repo_source",)
@@ -155,3 +163,27 @@ class CodingSessionStore(BaseStore):
         )
         await self._db.commit()
         return await self.get_session(session_id)
+
+    # ----------------------------------------------------------- transcript
+    async def append_transcript(self, session_id: str, text: str) -> None:
+        """Append a captured chunk of terminal output (append-only, never edited)."""
+        if not text:
+            return
+        await self._db.execute(
+            "INSERT INTO coding_session_transcript (session_id, captured_at, text) "
+            "VALUES (?, ?, ?)",
+            (session_id, time.time(), text),
+        )
+        await self._db.commit()
+
+    async def get_transcript(self, session_id: str, *, limit: int = 500) -> list[dict]:
+        """Return transcript chunks oldest-first (most recent ``limit`` entries)."""
+        cur = await self._db.execute(
+            "SELECT id, captured_at, text FROM ("
+            "  SELECT id, captured_at, text FROM coding_session_transcript "
+            "  WHERE session_id = ? ORDER BY id DESC LIMIT ?"
+            ") ORDER BY id ASC",
+            (session_id, limit),
+        )
+        rows = await cur.fetchall()
+        return [{"id": r[0], "captured_at": r[1], "text": r[2]} for r in rows]

--- a/tinyagentos/routes/coding_sessions.py
+++ b/tinyagentos/routes/coding_sessions.py
@@ -177,6 +177,73 @@ async def rename_coding_session(
     return updated
 
 
+def _launcher(request: Request):
+    from tinyagentos.coding_sessions.launcher import CodingSessionLauncher
+
+    return getattr(request.app.state, "coding_launcher", None) or CodingSessionLauncher()
+
+
+@router.post("/api/coding-sessions/{session_id}/start")
+async def start_coding_session(
+    session_id: str,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    """Launch the CLI in a tmux session and stream its output to the transcript.
+
+    Slice 2a supports the host-folder target only; other targets return 501
+    until their launcher path lands.
+    """
+    store = request.app.state.coding_session_store
+    session = await store.get_session(session_id)
+    if session is None or (not user.is_admin and session["created_by"] != user.user_id):
+        return JSONResponse({"error": "not found"}, status_code=404)
+    if session["launch_target"] != "host-folder":
+        return JSONResponse(
+            {"error": f"launch_target {session['launch_target']!r} not yet supported"},
+            status_code=501,
+        )
+    launcher = _launcher(request)
+    if launcher.is_running(session_id):
+        return await store.set_status(session_id, "running")
+    try:
+        name = launcher.start_host_folder(session_id, session["workdir"], session["cli"])
+    except (ValueError, FileNotFoundError) as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("coding session %s failed to start: %s", session_id, exc)
+        await store.set_status(session_id, "stopped")
+        return JSONResponse({"error": f"could not start session: {exc}"}, status_code=502)
+    await store.set_tmux_session(session_id, name)
+    updated = await store.set_status(session_id, "running")
+    # Best-effort: a transcript capture failure must not fail the start.
+    try:
+        await store.append_transcript(session_id, launcher.capture(session_id))
+    except Exception:  # noqa: BLE001
+        logger.warning("transcript capture failed for %s", session_id, exc_info=True)
+    return updated
+
+
+@router.get("/api/coding-sessions/{session_id}/transcript")
+async def get_coding_session_transcript(
+    session_id: str,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    store = request.app.state.coding_session_store
+    session = await store.get_session(session_id)
+    if session is None or (not user.is_admin and session["created_by"] != user.user_id):
+        return JSONResponse({"error": "not found"}, status_code=404)
+    # If the session is live, append a fresh capture before returning.
+    launcher = _launcher(request)
+    if launcher.is_running(session_id):
+        try:
+            await store.append_transcript(session_id, launcher.capture(session_id))
+        except Exception:  # noqa: BLE001
+            logger.warning("transcript capture failed for %s", session_id, exc_info=True)
+    return {"entries": await store.get_transcript(session_id)}
+
+
 @router.post("/api/coding-sessions/{session_id}/stop")
 async def stop_coding_session(
     session_id: str,
@@ -187,6 +254,11 @@ async def stop_coding_session(
     session = await store.get_session(session_id)
     if session is None or (not user.is_admin and session["created_by"] != user.user_id):
         return JSONResponse({"error": "not found"}, status_code=404)
+    # Best-effort: kill the tmux session, then record the stop regardless.
+    try:
+        _launcher(request).stop(session_id)
+    except Exception:  # noqa: BLE001
+        logger.warning("tmux stop failed for %s", session_id, exc_info=True)
     updated = await store.set_status(session_id, "stopped")
     return updated
 

--- a/tinyagentos/routes/coding_sessions.py
+++ b/tinyagentos/routes/coding_sessions.py
@@ -254,6 +254,9 @@ async def stop_coding_session(
     session = await store.get_session(session_id)
     if session is None or (not user.is_admin and session["created_by"] != user.user_id):
         return JSONResponse({"error": "not found"}, status_code=404)
+    # archived is terminal: never resurrect it back to stopped.
+    if session["status"] == "archived":
+        return session
     # Best-effort: kill the tmux session, then record the stop regardless.
     try:
         _launcher(request).stop(session_id)


### PR DESCRIPTION
## What

Slice 2 of the Coding Agents app (#101/#94): actually launch a coding CLI. This first cut covers the **host-folder** target (controller host, an existing local folder).

- `POST /api/coding-sessions/{id}/start` runs the CLI (opencode/claude/codex) in a **detached tmux session** scoped to the workdir, records the tmux name, and sets status `running`.
- `POST /.../stop` kills the tmux session and records `stopped`.
- `GET /.../transcript` returns the **append-only** captured terminal output (a fresh `capture-pane` is appended when the session is live).

Other launch targets (controller-lxc, worker-lxc) return **501** until their slice lands; the worker-LXC path will run the same tmux inside the worker's incus over the now-live Fedora worker.

## Design

The tmux calls go through an **injectable runner** so the launcher logic is unit-tested deterministically without a real tmux. The launcher lives in `coding_sessions/launcher.py`; a new append-only `coding_session_transcript` table backs the transcript.

## A real-tmux finding

A real-tmux smoke test confirmed start/capture/stop, and surfaced that `tmux new-session -d` returns **0 even for a missing workdir** (the window just exits). So the launcher validates the workdir itself and returns 400 rather than reporting a phantom "running" session.

## Verification

`compileall` clean; `test_launcher.py` (8) + `test_routes_coding_sessions.py` (18) green (26 total) including start/stop/transcript, the 501 for unsupported targets, the missing-workdir 400, and 404s. Real-tmux smoke verified locally.

## Follow-ups

The app UI (slice 3), worker-LXC + cloning (slice 2b), and steering (slice 4) are separately tracked. CHANGELOG line follows once #1486 (the rename, also touching CHANGELOG) lands, to avoid a concurrent edit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API support to start coding sessions, retrieve session transcripts, and stop sessions more reliably.
  * Session launches now support a host-folder workflow with live transcript capture.
* **Bug Fixes**
  * Improved error handling for invalid launch options, missing session IDs, and launch failures.
  * Transcript retrieval now includes the latest session output when a session is still running.
* **Tests**
  * Added coverage for session start, stop, transcript capture, error cases, and command handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->