### PR TITLE
feat(frameworks): add OpenCrabs as a beta agent framework

### DIFF
--- a/tests/test_frameworks.py
+++ b/tests/test_frameworks.py
@@ -367,8 +367,9 @@ def test_openclaw_dashboard_port():
 
 EXPECTED_FRAMEWORKS = {
     "openclaw", "smolagents", "generic", "pocketflow", "langroid",
-    "openai-agents-sdk", "hermes", "agent_zero", "ironclaw", "microclaw",
-    "moltis", "nanoclaw", "nullclaw", "picoclaw", "shibaclaw", "zeroclaw",
+    "openai-agents-sdk", "hermes", "opencrabs", "agent_zero", "ironclaw",
+    "microclaw", "moltis", "nanoclaw", "nullclaw", "picoclaw", "shibaclaw",
+    "zeroclaw",
 }
 
 

--- a/tests/test_opencrabs_adapter.py
+++ b/tests/test_opencrabs_adapter.py
@@ -1,0 +1,121 @@
+"""Tests for the OpenCrabs adapter (drives `opencrabs run` non-interactively).
+
+The adapter shells out via the module-level ``run_opencrabs`` callable, which
+these tests rebind to a fake so no real binary is needed.
+"""
+import json
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from tinyagentos.adapters import opencrabs_adapter as mod
+
+
+def _client():
+    return AsyncClient(transport=ASGITransport(app=mod.app), base_url="http://test")
+
+
+# --------------------------------------------------------------- build_argv
+
+def test_build_argv_is_one_shot_json_run(monkeypatch):
+    monkeypatch.setattr(mod, "OPENCRABS_BIN", "opencrabs")
+    monkeypatch.setattr(mod, "OPENCRABS_PROFILE", "")
+    assert mod.build_argv("hello there") == [
+        "opencrabs", "run", "hello there", "--format", "json", "--auto-approve",
+    ]
+
+
+def test_build_argv_includes_profile_when_set(monkeypatch):
+    monkeypatch.setattr(mod, "OPENCRABS_BIN", "/opt/opencrabs")
+    monkeypatch.setattr(mod, "OPENCRABS_PROFILE", "agent-x")
+    argv = mod.build_argv("hi")
+    assert argv[:4] == ["/opt/opencrabs", "--profile", "agent-x", "run"]
+
+
+# --------------------------------------------------------------- extract_reply
+
+@pytest.mark.parametrize("payload,expected", [
+    ({"response": "the answer"}, "the answer"),
+    ({"content": "via content"}, "via content"),
+    ({"output": "via output"}, "via output"),
+    ({"message": {"content": "nested"}}, "nested"),
+])
+def test_extract_reply_known_shapes(payload, expected):
+    assert mod.extract_reply(json.dumps(payload)) == expected
+
+
+def test_extract_reply_skips_leading_progress_line():
+    out = "\U0001f914 Processing...\n" + json.dumps({"response": "done"})
+    assert mod.extract_reply(out) == "done"
+
+
+def test_extract_reply_falls_back_to_raw_text():
+    assert mod.extract_reply("just plain text") == "just plain text"
+
+
+def test_extract_reply_empty():
+    assert mod.extract_reply("") == ""
+    assert mod.extract_reply("   \n ") == ""
+
+
+# --------------------------------------------------------------- /message
+
+@pytest.mark.asyncio
+async def test_message_returns_extracted_reply(monkeypatch):
+    captured = {}
+
+    async def fake_run(argv):
+        captured["argv"] = argv
+        return 0, json.dumps({"response": "hi from opencrabs"}), ""
+
+    monkeypatch.setattr(mod, "run_opencrabs", fake_run)
+    async with _client() as client:
+        resp = await client.post("/message", json={"text": "ping"})
+    assert resp.status_code == 200
+    assert resp.json()["content"] == "hi from opencrabs"
+    assert captured["argv"][1:4] == ["run", "ping", "--format"]
+
+
+@pytest.mark.asyncio
+async def test_message_empty_text_short_circuits(monkeypatch):
+    async def fake_run(argv):  # pragma: no cover - must not be called
+        raise AssertionError("runner should not be invoked for empty text")
+
+    monkeypatch.setattr(mod, "run_opencrabs", fake_run)
+    async with _client() as client:
+        resp = await client.post("/message", json={"text": "   "})
+    assert resp.json()["content"] == ""
+
+
+@pytest.mark.asyncio
+async def test_message_nonzero_exit_surfaces_detail(monkeypatch):
+    async def fake_run(argv):
+        return 1, "", "No provider configured. Please complete onboarding."
+
+    monkeypatch.setattr(mod, "run_opencrabs", fake_run)
+    async with _client() as client:
+        resp = await client.post("/message", json={"text": "ping"})
+    content = resp.json()["content"]
+    assert "failed" in content.lower()
+    assert "No provider configured" in content
+
+
+@pytest.mark.asyncio
+async def test_message_missing_binary_is_graceful(monkeypatch):
+    async def fake_run(argv):
+        raise FileNotFoundError("opencrabs")
+
+    monkeypatch.setattr(mod, "run_opencrabs", fake_run)
+    async with _client() as client:
+        resp = await client.post("/message", json={"text": "ping"})
+    assert "not found" in resp.json()["content"].lower()
+
+
+@pytest.mark.asyncio
+async def test_health_reports_framework(monkeypatch):
+    async with _client() as client:
+        resp = await client.get("/health")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "ok"
+    assert data["framework"] == "opencrabs"

--- a/tinyagentos/adapters/__init__.py
+++ b/tinyagentos/adapters/__init__.py
@@ -56,6 +56,12 @@ _REGISTRY: list[dict] = [
         "verification_status": "beta",
     },
     {
+        "id": "opencrabs",
+        "name": "OpenCrabs",
+        "description": "Autonomous single-binary Rust agent (OpenClaw-inspired) driven via `opencrabs run`",
+        "verification_status": "beta",
+    },
+    {
         "id": "deer-flow",
         "name": "DeerFlow",
         "description": "DeerFlow LangGraph SuperAgent harness (runs API bridge)",

--- a/tinyagentos/adapters/opencrabs_adapter.py
+++ b/tinyagentos/adapters/opencrabs_adapter.py
@@ -1,0 +1,144 @@
+"""OpenCrabs adapter - drives the opencrabs CLI non-interactively.
+
+opencrabs (adolfousier/opencrabs) is a single Rust binary autonomous agent
+inspired by OpenClaw. Unlike the HTTP-gateway frameworks, it has no long-running
+server in its released CLI; taOS drives it headlessly with
+
+    opencrabs run "<prompt>" --format json --auto-approve
+
+which executes the prompt once and prints a JSON result. The binary and a
+configured provider live inside the agent's container; this sidecar only
+translates a taOS ``/message`` into that invocation and maps the result onto the
+``{content}`` reply the chat bridge expects.
+
+The subprocess call goes through the module-level ``run_opencrabs`` callable so
+the parsing logic is unit-tested without a real binary (tests rebind it).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+
+from fastapi import FastAPI
+
+app = FastAPI()
+
+# Binary name (or absolute path) and optional taOS-managed profile. The agent's
+# container installs the binary on PATH as ``opencrabs``; an explicit path can
+# be injected for non-standard layouts.
+OPENCRABS_BIN = os.environ.get("OPENCRABS_BIN", "opencrabs")
+OPENCRABS_PROFILE = os.environ.get("OPENCRABS_PROFILE", "")
+# A single autonomous turn can run tools; give it a generous ceiling.
+_TIMEOUT = float(os.environ.get("OPENCRABS_TIMEOUT", "300"))
+
+# Keys an `opencrabs run --format json` payload may carry the reply under,
+# tried in order. opencrabs versions have varied the field name, so the parser
+# is deliberately tolerant and falls back to the raw stdout.
+_REPLY_KEYS = ("response", "content", "text", "output", "message", "result")
+
+
+def build_argv(text: str) -> list[str]:
+    """Build the argv for a one-shot ``opencrabs run`` of *text*."""
+    argv = [OPENCRABS_BIN]
+    if OPENCRABS_PROFILE:
+        argv += ["--profile", OPENCRABS_PROFILE]
+    argv += ["run", text, "--format", "json", "--auto-approve"]
+    return argv
+
+
+def extract_reply(stdout: str) -> str:
+    """Pull the assistant reply text out of ``opencrabs run --format json``.
+
+    Tolerant by design: the payload may be a bare JSON object, JSON preceded by
+    a human "Processing..." line, or (on older builds) plain text. Falls back to
+    the stripped stdout when no known reply field is found.
+    """
+    stdout = (stdout or "").strip()
+    if not stdout:
+        return ""
+
+    data = _parse_json_object(stdout)
+    if isinstance(data, dict):
+        for key in _REPLY_KEYS:
+            value = data.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        # Some shapes nest the text under message: {message: {content|text}}.
+        nested = data.get("message")
+        if isinstance(nested, dict):
+            value = nested.get("content") or nested.get("text")
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return stdout
+
+
+def _parse_json_object(stdout: str):
+    """Return the JSON object in *stdout*, or None. Tries the whole string then
+    the last ``{...}`` line (to skip a leading progress line)."""
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError:
+        pass
+    for line in reversed(stdout.splitlines()):
+        line = line.strip()
+        if line.startswith("{"):
+            try:
+                return json.loads(line)
+            except json.JSONDecodeError:
+                continue
+    return None
+
+
+async def _default_runner(argv: list[str]) -> tuple[int, str, str]:
+    """Run *argv*, returning (returncode, stdout, stderr). Enforces _TIMEOUT."""
+    proc = await asyncio.create_subprocess_exec(
+        *argv,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        out, err = await asyncio.wait_for(proc.communicate(), timeout=_TIMEOUT)
+    except asyncio.TimeoutError:
+        proc.kill()
+        raise
+    return (
+        proc.returncode,
+        out.decode("utf-8", "replace"),
+        err.decode("utf-8", "replace"),
+    )
+
+
+# Injectable for tests; defaults to the real subprocess runner.
+run_opencrabs = _default_runner
+
+
+@app.post("/message")
+async def handle_message(msg: dict):
+    text = (msg.get("text") or "").strip()
+    if not text:
+        return {"content": ""}
+    try:
+        rc, out, err = await run_opencrabs(build_argv(text))
+    except FileNotFoundError:
+        return {"content": f"OpenCrabs binary {OPENCRABS_BIN!r} not found. Is it installed in the agent container?"}
+    except asyncio.TimeoutError:
+        return {"content": "OpenCrabs timed out before producing a reply."}
+    except Exception as exc:  # noqa: BLE001 - surface any drive error as chat content
+        return {"content": f"OpenCrabs error: {exc}"}
+    if rc != 0:
+        detail = (err or out).strip() or f"exit {rc}"
+        return {"content": f"OpenCrabs run failed: {detail}"}
+    return {"content": extract_reply(out)}
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok", "framework": "opencrabs", "agent": os.environ.get("TAOS_AGENT_NAME", "")}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    port = int(os.environ.get("TAOS_ADAPTER_PORT", "9001"))
+    uvicorn.run(app, host="127.0.0.1", port=port, log_level="warning")

--- a/tinyagentos/adapters/opencrabs_adapter.py
+++ b/tinyagentos/adapters/opencrabs_adapter.py
@@ -101,6 +101,12 @@ async def _default_runner(argv: list[str]) -> tuple[int, str, str]:
         out, err = await asyncio.wait_for(proc.communicate(), timeout=_TIMEOUT)
     except asyncio.TimeoutError:
         proc.kill()
+        # Reap the killed child and drain its pipes so it does not linger as a
+        # zombie; communicate() after kill returns promptly.
+        try:
+            await proc.communicate()
+        except Exception:  # noqa: BLE001
+            pass
         raise
     return (
         proc.returncode,

--- a/tinyagentos/frameworks.py
+++ b/tinyagentos/frameworks.py
@@ -129,6 +129,29 @@ FRAMEWORKS: dict[str, dict] = {
              "icon": "diagnostic", "requires_capability": "agent.terminal"},
         ],
     },
+    "opencrabs": {
+        "id": "opencrabs",
+        "name": "OpenCrabs",
+        "description": "Autonomous single-binary Rust agent inspired by OpenClaw, driven non-interactively via `opencrabs run` (adolfousier/opencrabs)",
+        "verification_status": "beta",
+        # Distributed as a per-arch GitHub release binary and self-updates via
+        # `opencrabs evolve`, so there is no taos-framework-update release probe
+        # to track here (mirrors openclaw omitting release_source).
+        "service_name": "opencrabs",
+        "slash_commands": [
+            {"name": "help", "description": "List OpenCrabs commands"},
+        ],
+        "shortcuts": [
+            {"kind": "container-terminal", "label": "Container shell",
+             "icon": "terminal", "requires_capability": "agent.shell"},
+            {"kind": "tui", "label": "OpenCrabs TUI",
+             "command": "opencrabs chat",
+             "icon": "tui", "requires_capability": "agent.terminal"},
+            {"kind": "tui", "label": "OpenCrabs doctor",
+             "command": "opencrabs doctor",
+             "icon": "diagnostic", "requires_capability": "agent.terminal"},
+        ],
+    },
     "agent_zero": {
         "id": "agent_zero",
         "name": "Agent Zero",


### PR DESCRIPTION
## What

Registers **OpenCrabs** (adolfousier/opencrabs) as a taOS agent framework at `beta`, alongside OpenClaw and Hermes, with a working drive path.

OpenCrabs is a single-binary Rust autonomous agent inspired by OpenClaw. Its released CLI has no long-running server, so taOS drives it headlessly with `opencrabs run "<prompt>" --format json --auto-approve` (one-shot per turn).

## Changes

- **`tinyagentos/adapters/opencrabs_adapter.py`** (new) - FastAPI sidecar matching the sibling adapter shape (`/message` + `/health`). `/message` shells out to the binary and maps its result onto the `{content}` reply. The subprocess call goes through an injectable `run_opencrabs` callable so the JSON parsing is unit-tested without a real binary. The reply parser is tolerant: it handles the reply-field name variants and skips a leading "Processing..." line, falling back to raw stdout.
- **`tinyagentos/frameworks.py`** - `FRAMEWORKS["opencrabs"]` at `verification_status: beta` with container-shell / TUI (`opencrabs chat`) / doctor shortcuts. Release-tracking fields are omitted because OpenCrabs self-updates via `opencrabs evolve` (mirrors how OpenClaw omits them).
- **`tinyagentos/adapters/__init__.py`** - registry entry at `beta`.
- **`tests/test_opencrabs_adapter.py`** (new) - argv shape, reply extraction across shapes, `/message` happy-path, empty-text short-circuit, non-zero-exit detail, missing-binary grace, health.
- **`tests/test_frameworks.py`** - `opencrabs` added to `EXPECTED_FRAMEWORKS`.

## Verification

- 79 framework/adapter tests pass; `compileall` clean.
- Verified against the real **v0.3.55 macOS arm64** release binary: the adapter drives it end-to-end and correctly surfaces its output as chat content (a clean "provider not configured" message in the absence of a key, proving the full adapter to binary to parse to `{content}` chain).

## Next slice (tracked)

Container-side install (per-arch GitHub release binary fetch + an OpenAI-compatible `[providers.custom.litellm]` pointing at the agent's injected LiteLLM virtual key) and the live deploy round-trip on the Fedora worker. OpenCrabs takes a custom OpenAI-compatible provider, which is exactly what taOS injects per agent.