### PR TITLE
chore(release): 1.0.0-beta.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.13] - 2026-06-28
+
 ### Added
 - Notes and Todo: tracked edits. An entry's text is editable and every change is an immutable revision tagged with editor and timestamp, stored as a diff with a full snapshot checkpoint every 20 edits so any past state can be reconstructed (Time Machine foundation). New history and at-revision endpoints expose the log and reconstructed text.
 - Todo app: a checklist companion to Notes for `kind=list` documents, with per-task done checkboxes (completed tasks struck through), shared sharing/permission/agent-action controls, and the same tracked-edit history. Notes and Todo each show only their own document kind.
@@ -15,6 +17,8 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 - Notes "Discuss" agent action: an agent shared on a doc with the discuss action now gets a dedicated threaded topic channel (one per doc and agent, reused across entries, with the agent as a lead so it actively asks clarifying questions) instead of a DM ping, and falls back to the DM if the channel cannot be created.
 - Observatory lane framework badges: the fleet endpoint now carries each agent's framework (kilo/opencode/hermes/...), and the Observatory app shows it as a small badge next to each lane handle.
 - Coding sessions: the launch alias is editable. `PATCH /api/coding-sessions/{id}` renames a session, and the change is reflected in its agent-registry entry so the Agents/Registry app stays in sync.
+- Coding sessions: host-folder launcher. `POST /api/coding-sessions/{id}/start` runs the chosen CLI in a detached tmux session scoped to the workdir, `/transcript` returns the captured terminal output (append-only), and `/stop` kills the tmux session (a no-op on an archived session).
+- Frameworks: OpenCrabs registered as a beta agent framework (adolfousier/opencrabs, a single-binary Rust agent inspired by OpenClaw). A subprocess adapter drives `opencrabs run --format json` and maps the result onto the chat reply.
 
 ## [1.0.0-beta.12] - 2026-06-28
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.12",
+  "version": "1.0.0-beta.13",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.12"
+version = "1.0.0-beta.13"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 # Upper-capped at <3.14 because litellm (the proxy extra, the agent/model proxy

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.12"
+__version__ = "1.0.0-beta.13"

--- a/uv.lock
+++ b/uv.lock
@@ -2893,7 +2893,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b12"
+version = "1.0.0b13"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Promotes the beta.13 cycle. Bumps the three version files + `uv.lock` (to `1.0.0b13`) and cuts the `[1.0.0-beta.13]` CHANGELOG section.

Headline additions since beta.12: the coding-session host-folder launcher (tmux start/transcript/stop) and editable alias, OpenCrabs registered as a beta agent framework, plus the notes/todo tracked-edit history and Observatory fleet/badge work.

After this merges to dev, a follow-up dev->master PR promotes it and the tag `v1.0.0-beta.13` lands on master per docs/RELEASING.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new coding session launcher experience that starts sessions in the chosen folder, keeps transcript output available, and lets you stop a session cleanly.
  * Added support for an additional beta agent integration, enabling responses to be surfaced directly in chat.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->