### PR TITLE
feat(secrets): materialize SSH key secrets as files on deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.13] - 2026-06-28
+
 ### Added
 - Notes and Todo: tracked edits. An entry's text is editable and every change is an immutable revision tagged with editor and timestamp, stored as a diff with a full snapshot checkpoint every 20 edits so any past state can be reconstructed (Time Machine foundation). New history and at-revision endpoints expose the log and reconstructed text.
 - Todo app: a checklist companion to Notes for `kind=list` documents, with per-task done checkboxes (completed tasks struck through), shared sharing/permission/agent-action controls, and the same tracked-edit history. Notes and Todo each show only their own document kind.
@@ -15,6 +17,8 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 - Notes "Discuss" agent action: an agent shared on a doc with the discuss action now gets a dedicated threaded topic channel (one per doc and agent, reused across entries, with the agent as a lead so it actively asks clarifying questions) instead of a DM ping, and falls back to the DM if the channel cannot be created.
 - Observatory lane framework badges: the fleet endpoint now carries each agent's framework (kilo/opencode/hermes/...), and the Observatory app shows it as a small badge next to each lane handle.
 - Coding sessions: the launch alias is editable. `PATCH /api/coding-sessions/{id}` renames a session, and the change is reflected in its agent-registry entry so the Agents/Registry app stays in sync.
+- Coding sessions: host-folder launcher. `POST /api/coding-sessions/{id}/start` runs the chosen CLI in a detached tmux session scoped to the workdir, `/transcript` returns the captured terminal output (append-only), and `/stop` kills the tmux session (a no-op on an archived session).
+- Frameworks: OpenCrabs registered as a beta agent framework (adolfousier/opencrabs, a single-binary Rust agent inspired by OpenClaw). A subprocess adapter drives `opencrabs run --format json` and maps the result onto the chat reply.
 
 ## [1.0.0-beta.12] - 2026-06-28
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.12",
+  "version": "1.0.0-beta.13",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src/apps/SecretsApp.tsx
+++ b/desktop/src/apps/SecretsApp.tsx
@@ -121,15 +121,28 @@ function AddEditDialog({
 
             <div className="space-y-1.5">
               <Label htmlFor="secret-value">Value</Label>
-              <Input
-                id="secret-value"
-                type="password"
-                value={value}
-                onChange={(e) => setValue(e.target.value)}
-                placeholder={isEdit ? "Leave blank to keep existing" : "sk-..."}
-                className="font-mono"
-                autoFocus={isEdit}
-              />
+              {category === "ssh-keys" ? (
+                <textarea
+                  id="secret-value"
+                  value={value}
+                  onChange={(e) => setValue(e.target.value)}
+                  placeholder={isEdit ? "Leave blank to keep existing" : "-----BEGIN OPENSSH PRIVATE KEY-----\n..."}
+                  className="flex w-full rounded-lg border border-white/10 bg-shell-bg-deep px-3 py-2 text-sm text-shell-text font-mono focus-visible:outline-none focus-visible:border-accent/40 focus-visible:ring-2 focus-visible:ring-accent/20 resize-y min-h-[120px]"
+                  autoFocus={isEdit}
+                  aria-label="SSH private key value"
+                  spellCheck={false}
+                />
+              ) : (
+                <Input
+                  id="secret-value"
+                  type="password"
+                  value={value}
+                  onChange={(e) => setValue(e.target.value)}
+                  placeholder={isEdit ? "Leave blank to keep existing" : "sk-..."}
+                  className="font-mono"
+                  autoFocus={isEdit}
+                />
+              )}
             </div>
 
             <div className="space-y-1.5">
@@ -144,6 +157,7 @@ function AddEditDialog({
                 <option value="credential">Credential</option>
                 <option value="token">Token</option>
                 <option value="config">Config</option>
+                <option value="ssh-keys">SSH Key</option>
               </select>
             </div>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.12"
+version = "1.0.0-beta.13"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 # Upper-capped at <3.14 because litellm (the proxy extra, the agent/model proxy

--- a/tests/test_deploy_ssh_keys.py
+++ b/tests/test_deploy_ssh_keys.py
@@ -1,0 +1,227 @@
+"""Tests for SSH key materialization during agent deploy.
+
+SSH key secrets (category == "ssh-keys") must be written to
+~/.ssh/<name> with 0600 perms and ~/.ssh with 0700. Non-ssh-keys
+secrets must not trigger file materialization.
+"""
+from pathlib import Path
+
+import pytest
+from unittest.mock import AsyncMock, patch, call
+
+from tinyagentos.deployer import deploy_agent, DeployRequest
+
+
+def _req(**overrides) -> DeployRequest:
+    defaults = dict(
+        name="test",
+        framework="smolagents",
+        model=None,
+        data_dir=Path("/tmp/taos-test-data"),
+    )
+    defaults.update(overrides)
+    return DeployRequest(**defaults)
+
+
+class FakeSecretsStore:
+    def __init__(self, secrets):
+        self._secrets = secrets
+
+    async def get_agent_secrets(self, agent_name):
+        return list(self._secrets)
+
+
+async def _run_deploy(req, tmp_path):
+    """Run deploy_agent with all container calls mocked.
+
+    Returns (push_file_calls, exec_calls) so tests can assert what
+    the deployer tried to push and what it exec'd.
+    """
+    push_calls: list = []
+    exec_calls: list = []
+
+    async def mock_push(container, src, dst):
+        # Record what was pushed (read the temp file content).
+        try:
+            with open(src) as fh:
+                content = fh.read()
+        except (FileNotFoundError, OSError):
+            content = ""
+        push_calls.append({"container": container, "src": src, "dst": dst, "content": content})
+        return (0, "")
+
+    async def mock_exec(container, cmd, **kwargs):
+        exec_calls.append({"container": container, "cmd": list(cmd)})
+        if "hostname" in cmd and "-I" in cmd:
+            return (0, "10.0.0.5")
+        return (0, "ok")
+
+    with patch("tinyagentos.deployer.create_container", new_callable=AsyncMock) as mock_create, \
+         patch("tinyagentos.deployer.exec_in_container", side_effect=mock_exec), \
+         patch("tinyagentos.deployer.push_file", side_effect=mock_push), \
+         patch("tinyagentos.deployer.add_proxy_device", new_callable=AsyncMock,
+               return_value={"success": True, "output": ""}):
+        mock_create.return_value = {"success": True, "name": "taos-agent-test"}
+        result = await deploy_agent(req)
+        return result, push_calls, exec_calls
+
+
+class TestSshKeyMaterialization:
+    @pytest.mark.asyncio
+    async def test_ssh_key_written_to_dot_ssh(self, tmp_path):
+        """An ssh-keys secret is pushed to /root/.ssh/<name> inside the container."""
+        key_value = "-----BEGIN OPENSSH PRIVATE KEY-----\nfakekey\n-----END OPENSSH PRIVATE KEY-----\n"
+        store = FakeSecretsStore([
+            {"name": "my-deploy-key", "category": "ssh-keys", "value": key_value},
+        ])
+        req = _req(data_dir=tmp_path, secrets_store=store)
+
+        result, push_calls, exec_calls = await _run_deploy(req, tmp_path)
+
+        assert result["success"] is True
+
+        # A push to /root/.ssh/my-deploy-key must have happened.
+        ssh_pushes = [p for p in push_calls if p["dst"] == "/root/.ssh/my-deploy-key"]
+        assert ssh_pushes, f"expected push to /root/.ssh/my-deploy-key; got: {[p['dst'] for p in push_calls]}"
+
+        # The content pushed must be the key value verbatim (with trailing newline).
+        assert ssh_pushes[0]["content"] == key_value
+
+    @pytest.mark.asyncio
+    async def test_ssh_key_trailing_newline_added_when_missing(self, tmp_path):
+        """If the stored value has no trailing newline, the deployer adds one."""
+        key_value = "-----BEGIN OPENSSH PRIVATE KEY-----\nfakekey\n-----END OPENSSH PRIVATE KEY-----"
+        store = FakeSecretsStore([
+            {"name": "my-key", "category": "ssh-keys", "value": key_value},
+        ])
+        req = _req(data_dir=tmp_path, secrets_store=store)
+
+        result, push_calls, _exec = await _run_deploy(req, tmp_path)
+
+        assert result["success"] is True
+        ssh_pushes = [p for p in push_calls if p["dst"] == "/root/.ssh/my-key"]
+        assert ssh_pushes
+        assert ssh_pushes[0]["content"].endswith("\n")
+
+    @pytest.mark.asyncio
+    async def test_ssh_dir_created_with_700(self, tmp_path):
+        """The deployer runs a command that creates ~/.ssh with 0700 perms."""
+        store = FakeSecretsStore([
+            {"name": "deploy-key", "category": "ssh-keys", "value": "key\n"},
+        ])
+        req = _req(data_dir=tmp_path, secrets_store=store)
+
+        _result, _push, exec_calls = await _run_deploy(req, tmp_path)
+
+        # The deployer issues a bash compound command: mkdir + chmod 700.
+        # Match on the full joined command string to support both forms.
+        ssh_dir_cmds = [
+            " ".join(e["cmd"]) for e in exec_calls
+            if "/root/.ssh" in " ".join(e["cmd"]) and "700" in " ".join(e["cmd"])
+        ]
+        assert ssh_dir_cmds, (
+            f"expected a command creating ~/.ssh with 700 perms; "
+            f"exec calls: {[e['cmd'] for e in exec_calls]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_ssh_key_chmod_600_applied(self, tmp_path):
+        """After pushing, deployer runs `chmod 600 /root/.ssh/<name>`."""
+        store = FakeSecretsStore([
+            {"name": "my-key", "category": "ssh-keys", "value": "key\n"},
+        ])
+        req = _req(data_dir=tmp_path, secrets_store=store)
+
+        _result, _push, exec_calls = await _run_deploy(req, tmp_path)
+
+        chmod_cmds = [
+            e["cmd"] for e in exec_calls
+            if e["cmd"][:2] == ["chmod", "600"]
+        ]
+        assert chmod_cmds, f"expected chmod 600; exec calls: {[e['cmd'] for e in exec_calls]}"
+        assert any("/root/.ssh/my-key" in " ".join(c) for c in chmod_cmds)
+
+    @pytest.mark.asyncio
+    async def test_non_ssh_secret_not_materialized_as_file(self, tmp_path):
+        """A secret with category != ssh-keys must not be pushed to ~/.ssh."""
+        store = FakeSecretsStore([
+            {"name": "OPENROUTER_API_KEY", "category": "api-keys", "value": "sk-xxx"},
+        ])
+        req = _req(data_dir=tmp_path, secrets_store=store)
+
+        result, push_calls, _exec = await _run_deploy(req, tmp_path)
+
+        assert result["success"] is True
+        ssh_pushes = [p for p in push_calls if ".ssh" in p["dst"]]
+        assert not ssh_pushes, f"non-ssh secret wrongly pushed to .ssh: {ssh_pushes}"
+
+    @pytest.mark.asyncio
+    async def test_mixed_secrets_only_ssh_goes_to_file(self, tmp_path):
+        """With both ssh-keys and api-keys granted, only the ssh-keys one lands in ~/.ssh."""
+        store = FakeSecretsStore([
+            {"name": "OPENROUTER_API_KEY", "category": "api-keys", "value": "sk-xxx"},
+            {"name": "github-deploy-key", "category": "ssh-keys", "value": "key\n"},
+        ])
+        req = _req(data_dir=tmp_path, secrets_store=store)
+
+        result, push_calls, _exec = await _run_deploy(req, tmp_path)
+
+        assert result["success"] is True
+        ssh_pushes = [p for p in push_calls if ".ssh" in p["dst"]]
+        assert len(ssh_pushes) == 1
+        assert ssh_pushes[0]["dst"] == "/root/.ssh/github-deploy-key"
+
+    @pytest.mark.asyncio
+    async def test_ssh_keys_step_recorded(self, tmp_path):
+        """When SSH keys are materialized, the deploy result includes the step."""
+        store = FakeSecretsStore([
+            {"name": "key1", "category": "ssh-keys", "value": "key\n"},
+        ])
+        req = _req(data_dir=tmp_path, secrets_store=store)
+
+        result, _push, _exec = await _run_deploy(req, tmp_path)
+
+        assert result["success"] is True
+        assert "ssh_keys_materialized" in result["steps"]
+
+    @pytest.mark.asyncio
+    async def test_no_ssh_keys_no_step(self, tmp_path):
+        """When no ssh-keys secrets exist, the ssh_keys_materialized step is absent."""
+        store = FakeSecretsStore([
+            {"name": "SOME_TOKEN", "category": "tokens", "value": "tok-xxx"},
+        ])
+        req = _req(data_dir=tmp_path, secrets_store=store)
+
+        result, _push, _exec = await _run_deploy(req, tmp_path)
+
+        assert result["success"] is True
+        assert "ssh_keys_materialized" not in result["steps"]
+
+    @pytest.mark.asyncio
+    async def test_no_secrets_store_no_ssh_materialization(self, tmp_path):
+        """When secrets_store is None, no ~/.ssh activity happens."""
+        req = _req(data_dir=tmp_path)  # secrets_store defaults to None
+
+        result, push_calls, _exec = await _run_deploy(req, tmp_path)
+
+        assert result["success"] is True
+        ssh_pushes = [p for p in push_calls if ".ssh" in p["dst"]]
+        assert not ssh_pushes
+
+    @pytest.mark.asyncio
+    async def test_multiple_ssh_keys_all_materialized(self, tmp_path):
+        """Multiple ssh-keys secrets each get their own file."""
+        store = FakeSecretsStore([
+            {"name": "key-github", "category": "ssh-keys", "value": "keyA\n"},
+            {"name": "key-gitlab", "category": "ssh-keys", "value": "keyB\n"},
+        ])
+        req = _req(data_dir=tmp_path, secrets_store=store)
+
+        result, push_calls, _exec = await _run_deploy(req, tmp_path)
+
+        assert result["success"] is True
+        ssh_pushes = {p["dst"]: p["content"] for p in push_calls if ".ssh" in p["dst"]}
+        assert "/root/.ssh/key-github" in ssh_pushes
+        assert "/root/.ssh/key-gitlab" in ssh_pushes
+        assert ssh_pushes["/root/.ssh/key-github"] == "keyA\n"
+        assert ssh_pushes["/root/.ssh/key-gitlab"] == "keyB\n"

--- a/tests/test_deploy_ssh_keys.py
+++ b/tests/test_deploy_ssh_keys.py
@@ -88,6 +88,29 @@ class TestSshKeyMaterialization:
         assert ssh_pushes[0]["content"] == key_value
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("bad_name", [
+        "../authorized_keys",
+        "../../etc/cron.d/evil",
+        "foo/bar",
+        "..",
+        ".",
+        "a b",
+    ])
+    async def test_ssh_key_unsafe_name_is_skipped(self, tmp_path, bad_name):
+        """A traversal/unsafe secret name must never be written outside ~/.ssh."""
+        store = FakeSecretsStore([
+            {"name": bad_name, "category": "ssh-keys", "value": "key\n"},
+        ])
+        req = _req(data_dir=tmp_path, secrets_store=store)
+
+        result, push_calls, exec_calls = await _run_deploy(req, tmp_path)
+
+        assert result["success"] is True
+        # Nothing should be pushed under /root/.ssh for an unsafe name.
+        ssh_pushes = [p for p in push_calls if "/root/.ssh/" in p["dst"]]
+        assert not ssh_pushes, f"unsafe name {bad_name!r} produced a push: {[p['dst'] for p in ssh_pushes]}"
+
+    @pytest.mark.asyncio
     async def test_ssh_key_trailing_newline_added_when_missing(self, tmp_path):
         """If the stored value has no trailing newline, the deployer adds one."""
         key_value = "-----BEGIN OPENSSH PRIVATE KEY-----\nfakekey\n-----END OPENSSH PRIVATE KEY-----"

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.12"
+__version__ = "1.0.0-beta.13"

--- a/tinyagentos/deployer.py
+++ b/tinyagentos/deployer.py
@@ -393,6 +393,16 @@ async def deploy_agent(req: DeployRequest) -> dict:
                 req.name, len(injected), ", ".join(injected),
             )
 
+    # SSH key secrets to materialize as files after container start.
+    # Collected here (before container creation) so the post-start loop has
+    # them. Secrets with category "ssh-keys" land at ~/.ssh/<name> with 0600.
+    _ssh_key_secrets: list[dict] = []
+    if req.secrets_store is not None:
+        _ssh_key_secrets = [
+            s for s in agent_secrets  # type: ignore[possibly-undefined]
+            if s.get("category") == "ssh-keys"
+        ]
+
     # Pre-built base image fast-path — see tinyagentos/agent_image.py.
     # Framework-aware selection: prefer the framework's dedicated base
     # (taos-<framework>-base), then the generic taos-base, then a cold
@@ -495,6 +505,54 @@ async def deploy_agent(req: DeployRequest) -> dict:
                 break
             await asyncio.sleep(2)
         steps.append("network_ready")
+
+        # Step 2b: Materialize SSH key secrets as ~/.ssh/<name> inside the container.
+        # Secrets with category "ssh-keys" are written verbatim to files so tools
+        # like git/ssh can use them directly. The value is written via push_file
+        # (same path used for AGENTS.md and install scripts above); perms are set
+        # with chmod/chown via exec_in_container. An SSH key stored as an env var
+        # alone would not be usable by the ssh binary.
+        if _ssh_key_secrets:
+            import tempfile
+            import os as _os
+            # Ensure ~/.ssh exists and has the right permissions.
+            code, output = await exec_in_container(
+                container_name,
+                ["bash", "-c", "mkdir -p /root/.ssh && chmod 700 /root/.ssh"],
+            )
+            if code != 0:
+                logger.warning("Deploy %s: failed to create ~/.ssh: %s", req.name, output)
+            for _sk in _ssh_key_secrets:
+                _sk_name = _sk["name"]
+                _sk_value = _sk["value"]
+                # Ensure the value ends with a newline — SSH clients require it.
+                if not _sk_value.endswith("\n"):
+                    _sk_value += "\n"
+                _dest = f"/root/.ssh/{_sk_name}"
+                with tempfile.NamedTemporaryFile("w", suffix=".key", delete=False) as _tf:
+                    _tf.write(_sk_value)
+                    _tmp_key_path = _tf.name
+                try:
+                    _push_rc, _push_out = await push_file(container_name, _tmp_key_path, _dest)
+                finally:
+                    _os.unlink(_tmp_key_path)
+                if _push_rc != 0:
+                    logger.warning(
+                        "Deploy %s: failed to push SSH key %r (rc=%s): %s",
+                        req.name, _sk_name, _push_rc, _push_out[-200:],
+                    )
+                    continue
+                code, output = await exec_in_container(
+                    container_name, ["chmod", "600", _dest]
+                )
+                if code != 0:
+                    logger.warning(
+                        "Deploy %s: failed to chmod 600 on %s: %s",
+                        req.name, _dest, output,
+                    )
+                else:
+                    logger.info("Deploy %s: materialized SSH key %r at %s", req.name, _sk_name, _dest)
+            steps.append("ssh_keys_materialized")
 
         # Step 3: Install base dependencies (framework needs these).
         # Skipped entirely when the pre-built openclaw base image is in

--- a/tinyagentos/deployer.py
+++ b/tinyagentos/deployer.py
@@ -97,6 +97,11 @@ def _secret_env_name(name: str) -> str:
 _TAOSMD_BEGIN = "<!-- taosmd:rules-begin -->"
 _TAOSMD_END = "<!-- taosmd:rules-end -->"
 
+# An SSH-key secret name becomes a filename under ~/.ssh on deploy, so it must
+# be a plain safe filename: no path separators, no "..", no traversal. Names
+# that do not match are skipped rather than written outside ~/.ssh.
+_SAFE_SSH_KEY_NAME = re.compile(r"^[A-Za-z0-9._-]+$")
+
 # Per-framework AGENTS.md path inside the agent's container.
 # Frameworks read this file on every turn to pick up agent rules
 # (per the taosmd contract — see issue #378).
@@ -525,10 +530,22 @@ async def deploy_agent(req: DeployRequest) -> dict:
             for _sk in _ssh_key_secrets:
                 _sk_name = _sk["name"]
                 _sk_value = _sk["value"]
+                # Guard against path traversal: the secret name becomes a file
+                # name under ~/.ssh, so reject anything that is not a plain safe
+                # filename (no slashes, no "..", no leading-dot escapes). A name
+                # like "../authorized_keys" must never write outside ~/.ssh.
+                if not _SAFE_SSH_KEY_NAME.match(_sk_name) or _sk_name in (".", ".."):
+                    logger.warning(
+                        "Deploy %s: skipping SSH key with unsafe name %r",
+                        req.name, _sk_name,
+                    )
+                    continue
                 # Ensure the value ends with a newline — SSH clients require it.
                 if not _sk_value.endswith("\n"):
                     _sk_value += "\n"
                 _dest = f"/root/.ssh/{_sk_name}"
+                # NamedTemporaryFile creates the host-side temp file with 0600
+                # (via mkstemp), so the plaintext key is never world-readable.
                 with tempfile.NamedTemporaryFile("w", suffix=".key", delete=False) as _tf:
                     _tf.write(_sk_value)
                     _tmp_key_path = _tf.name

--- a/tinyagentos/secrets.py
+++ b/tinyagentos/secrets.py
@@ -34,7 +34,7 @@ CREATE TABLE IF NOT EXISTS secret_categories (
 );
 """
 
-DEFAULT_CATEGORIES = ["api-keys", "tokens", "credentials", "webhooks", "general"]
+DEFAULT_CATEGORIES = ["api-keys", "tokens", "credentials", "webhooks", "general", "ssh-keys"]
 
 # Prefix written into every Fernet-encrypted value so decrypt can distinguish
 # new (Fernet) from old (XOR) ciphertext and migrate transparently.

--- a/uv.lock
+++ b/uv.lock
@@ -2893,7 +2893,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b12"
+version = "1.0.0b13"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- Secrets with `category == "ssh-keys"` are now written to `~/.ssh/<name>` (0600) inside the agent container at deploy time, making private keys directly usable by `ssh`/`git` without extra setup
- Added `"ssh-keys"` to `DEFAULT_CATEGORIES` in `secrets.py` so it is available without schema migration (uses the existing `category` column)
- `SecretsApp.tsx`: added "SSH Key" option to the category select; value field switches to a resizable `<textarea>` when category is `"ssh-keys"` so multi-line key material is not truncated on paste
- 10 new unit tests in `tests/test_deploy_ssh_keys.py` covering the full materialization path (file push, 0700 dir, 0600 file, trailing-newline normalisation, non-ssh secrets excluded, step recording)

## Mechanism

Used the existing `category` field (no schema change, no new column, no migration needed). A secret in the `"ssh-keys"` category means "materialize as `~/.ssh/<name>` with 0600". File write reuses the same `push_file` + `exec_in_container` path the deployer already uses for AGENTS.md and install scripts.

## Test plan

- [ ] `python3 -m pytest tests/ --ignore=tests/e2e -k "deploy or secret" -q` passes (213 tests)
- [ ] New `tests/test_deploy_ssh_keys.py` passes (10 tests)
- [ ] `python3 -m compileall` on changed Python files clean
- [ ] Desktop form shows textarea when category is "SSH Key"